### PR TITLE
[RFC] `tock-registers` macro rewrite try 2

### DIFF
--- a/doc/RegistersPeripheralDesign.md
+++ b/doc/RegistersPeripheralDesign.md
@@ -1,0 +1,68 @@
+`tock_registers::peripheral!` Macro and Trait Interface Design
+==============================================================
+
+## An oversimplified explanation
+
+`peripheral!` turns a register definition like:
+
+```rust
+peripheral! {
+    pub foo {
+        0x00 => ctrl: u32 { read + write }
+        0x04 => received: u8 { read }
+    }
+}
+```
+
+into a module, which contains an `Accessor` trait and a `Registers` struct:
+
+```rust
+pub mod foo {
+    trait Accessor: /* To be explained */ {}
+
+    struct Registers<A: Accessor> {
+        pub ctrl: tock_registers::Register<0x00, Self, A>,
+        pub received: tock_registers::Register<0x04, Self, A>,
+    }
+
+    /* Plus trait impls that I will explain later */
+}
+```
+
+## What is this `Accessor` trait?
+
+`Accessor` exists to facilitate unit testing. An `Accessor` provides access to a
+peripheral: either the real peripheral (e.g. via MMIO access) or a mock/fake
+version. Operations performed on the members of `foo::Registers` forward to the
+accessor; if you call `foo.ctrl.get()`, it will invoke a method on an instance
+of `A`.
+
+## Where is this `A` instance?
+
+Each `tock_registers::Register` instance needs access to an instance of `A`, so
+they must contain it:
+
+```rust
+// In tock_registers
+pub struct Registers<const REL_ADDR: usize, Peripheral, Accessor> {
+    pub accessor: A,
+    /* ... */
+}
+```
+
+Now the implementation of `foo.ctrl.get()` can call the accessor:
+
+```rust
+impl<Peripheral, A: ...> /*Mystery trait*/ for Register<..., Peripheral, A> {
+    fn get(&self) -> ... {
+        self.accessor.get::<...>()
+    }
+}
+```
+
+## What is this mystery trait?
+
+`Register` is defined inside `tock_registers`, but some of the operations are
+not. For example, RISC-V CSR traits are defined in the `riscv-csr` crate, which
+depends on `tock_registers`. Therefore, the methods on `Register` cannot be
+inherent impls. Instead, the 

--- a/libraries/tock-register-interface/Cargo.toml
+++ b/libraries/tock-register-interface/Cargo.toml
@@ -14,6 +14,9 @@ edition = "2021"
 [badges]
 travis-ci = { repository = "tock/tock", branch = "master" }
 
+[dependencies]
+tock-registers-derive = { path = "derive" }
+
 [features]
 default = [ "register_types" ]
 

--- a/libraries/tock-register-interface/derive/Cargo.toml
+++ b/libraries/tock-register-interface/derive/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "tock-registers-derive"
+version = "0.8.1"
+authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+description = "Procedural macros for tock-registers"
+homepage = "https://www.tockos.org/"
+repository = "https://github.com/tock/tock/tree/master/libraries/tock-register-interface"
+readme = "README.md"
+keywords = ["tock", "embedded", "registers", "mmio", "bare-metal"]
+categories = ["data-structures", "embedded", "no-std"]
+license = "MIT/Apache-2.0"
+edition = "2021"
+
+[dependencies]
+proc-macro2 = "1.0.47"
+quote = "1.0.23"
+syn = "1.0.105"
+
+[lib]
+proc-macro = true

--- a/libraries/tock-register-interface/derive/Cargo.toml
+++ b/libraries/tock-register-interface/derive/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 [dependencies]
 proc-macro2 = "1.0.47"
 quote = "1.0.23"
-syn = "1.0.105"
+syn = { features = ["extra-traits"], version = "1.0.105" }
 
 [lib]
 proc-macro = true

--- a/libraries/tock-register-interface/derive/src/lib.rs
+++ b/libraries/tock-register-interface/derive/src/lib.rs
@@ -1,0 +1,85 @@
+extern crate proc_macro;
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{AngleBracketedGenericArguments, braced, Ident, LitInt, parse2, Token, TypePath};
+use syn::parse::{self, Parse, ParseStream};
+use syn::punctuated::Punctuated;
+
+struct Operation {
+    op_trait: TypePath,
+    generics: Option<AngleBracketedGenericArguments>,
+}
+
+impl Parse for Operation {
+    fn parse(input: ParseStream) -> parse::Result<Self> {
+        Ok(Self {
+            op_trait: input.parse()?,
+            generics: match input.peek(Token![<]) {
+                false => None,
+                true => Some(input.parse()?),
+            },
+        })
+    }
+}
+
+struct Register {
+    offset: LitInt,
+    name: Ident,
+    reg_type: TypePath,
+    operations: Punctuated<Operation, Token![+]>,
+}
+
+impl Parse for Register {
+    fn parse(input: ParseStream) -> parse::Result<Self> {
+        let offset = input.parse()?;
+        let _: Token![=>] = input.parse()?;
+        let name = input.parse()?;
+        let _: Token![:] = input.parse()?;
+        let reg_type = input.parse()?;
+        let operations;
+        braced!(operations in input);
+        Ok(Self {
+            offset,
+            name,
+            reg_type,
+            operations: Punctuated::parse_terminated(&operations)?,
+        })
+    }
+}
+
+struct Peripheral {
+    name: Ident,
+    registers: Punctuated<Register, Token![,]>,
+}
+
+impl Parse for Peripheral {
+    fn parse(input: ParseStream) -> parse::Result<Self> {
+        let name = input.parse()?;
+        let registers;
+        braced!(registers in input);
+        Ok(Self {
+            name,
+            registers: Punctuated::parse_terminated(&registers)?,
+        })
+    }
+}
+
+fn peripheral_impl(input: TokenStream) -> TokenStream {
+    let peripheral: Peripheral = match parse2(input) {
+        Err(error) => return error.into_compile_error(),
+        Ok(peripheral) => peripheral,
+    };
+    let peripheral_name = peripheral.name;
+    let register_names: Vec<_> = peripheral.registers.iter().map(|r| r.name).collect();
+    quote! {
+        struct #peripheral_name {
+            #(#register_names: ),*
+        }
+    }
+}
+
+#[proc_macro]
+pub fn peripheral(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    peripheral_impl(input.into()).into()
+}

--- a/libraries/tock-register-interface/examples/peripheral.rs
+++ b/libraries/tock-register-interface/examples/peripheral.rs
@@ -1,7 +1,7 @@
 use tock_registers::{peripheral, read};
 
 peripheral! {
-    Foo {
+    foo {
         0x00 => ctrl: u32 { read<> }
     }
 }

--- a/libraries/tock-register-interface/examples/peripheral.rs
+++ b/libraries/tock-register-interface/examples/peripheral.rs
@@ -1,0 +1,9 @@
+use tock_registers::{peripheral, read};
+
+peripheral! {
+    Foo {
+        0x00 => ctrl: u32 { read<> }
+    }
+}
+
+fn main() {}

--- a/libraries/tock-register-interface/examples/peripheral.rs
+++ b/libraries/tock-register-interface/examples/peripheral.rs
@@ -2,7 +2,8 @@ use tock_registers::{peripheral, read};
 
 peripheral! {
     foo {
-        0x00 => ctrl: u32 { read<> }
+        0x00 => ctrl: u32 { read + write }
+        0x04 => received: u8 { read }
     }
 }
 

--- a/libraries/tock-register-interface/src/lib.rs
+++ b/libraries/tock-register-interface/src/lib.rs
@@ -58,6 +58,10 @@
 // code in this crate
 #![cfg_attr(not(feature = "register_types"), forbid(unsafe_code))]
 
+mod new;
+pub use new::*;
+pub use tock_registers_derive::peripheral;
+
 pub mod fields;
 pub mod interfaces;
 pub mod macros;

--- a/libraries/tock-register-interface/src/lib.rs
+++ b/libraries/tock-register-interface/src/lib.rs
@@ -60,7 +60,6 @@
 
 mod new;
 pub use new::*;
-pub use tock_registers_derive::peripheral;
 
 pub mod fields;
 pub mod interfaces;

--- a/libraries/tock-register-interface/src/new.rs
+++ b/libraries/tock-register-interface/src/new.rs
@@ -1,3 +1,5 @@
+use core::marker::PhantomData;
+
 #[macro_export]
 macro_rules! peripheral {
     {$($tokens:tt)*} => {
@@ -13,8 +15,9 @@ pub mod read {
     }
 }
 
-pub struct Register<const REL_ADDR: usize, Accessor> {
+pub struct Register<const REL_ADDR: usize, Peripheral, Accessor> {
     pub accessor: Accessor,
+    _phantom: PhantomData<Peripheral>,
 }
 
 pub trait ValueAt<const REL_ADDR: usize> {

--- a/libraries/tock-register-interface/src/new.rs
+++ b/libraries/tock-register-interface/src/new.rs
@@ -9,7 +9,7 @@ macro_rules! peripheral {
 
 pub mod read {
     use crate::*;
-    pub trait Access<const REL_ADDR: usize>: ValueAt<REL_ADDR> {
+    pub trait At<const REL_ADDR: usize>: ValueAt<REL_ADDR> {
     }
     pub trait Has<const REL_ADDR: usize>: ValueAt<REL_ADDR> {
     }

--- a/libraries/tock-register-interface/src/new.rs
+++ b/libraries/tock-register-interface/src/new.rs
@@ -9,6 +9,8 @@ pub mod read {
     use crate::*;
     pub trait Access<const REL_ADDR: usize>: ValueAt<REL_ADDR> {
     }
+    pub trait Has<const REL_ADDR: usize>: ValueAt<REL_ADDR> {
+    }
 }
 
 pub struct Register<const REL_ADDR: usize, Accessor> {

--- a/libraries/tock-register-interface/src/new.rs
+++ b/libraries/tock-register-interface/src/new.rs
@@ -1,0 +1,13 @@
+pub mod read {
+    use crate::*;
+    pub trait Access<const REL_ADDR: usize>: ValueAt<REL_ADDR> {
+    }
+}
+
+pub struct Register<const REL_ADDR: usize, Accessor> {
+    pub accessor: Accessor,
+}
+
+pub trait ValueAt<const REL_ADDR: usize> {
+    type Value;
+}

--- a/libraries/tock-register-interface/src/new.rs
+++ b/libraries/tock-register-interface/src/new.rs
@@ -1,3 +1,10 @@
+#[macro_export]
+macro_rules! peripheral {
+    {$($tokens:tt)*} => {
+        tock_registers_derive::peripheral!{$crate $($tokens)*}
+    }
+}
+
 pub mod read {
     use crate::*;
     pub trait Access<const REL_ADDR: usize>: ValueAt<REL_ADDR> {

--- a/libraries/tock-register-interface/src/new.rs
+++ b/libraries/tock-register-interface/src/new.rs
@@ -9,10 +9,8 @@ macro_rules! peripheral {
 
 pub mod read {
     use crate::*;
-    pub trait At<const REL_ADDR: usize>: ValueAt<REL_ADDR> {
-    }
-    pub trait Has<const REL_ADDR: usize>: ValueAt<REL_ADDR> {
-    }
+    pub trait At<const REL_ADDR: usize>: ValueAt<REL_ADDR> {}
+    pub trait Has<const REL_ADDR: usize>: ValueAt<REL_ADDR> {}
 }
 
 pub struct Register<const REL_ADDR: usize, Peripheral, Accessor> {


### PR DESCRIPTION
This is a request for comments on a possible redesign of the `register_structs!` macro in `tock-registers`. Note: the code is not ready for review -- it is incomplete, and I've implemented the most difficult parts without writing any comments.

Instead, read the [Design document](https://github.com/jrvanwhy/tock/blob/registers-proc-macro/doc/RegistersPeripheralDesign.md) and see if you can make sense of it.

1. Allows unit testing -- a driver test can implement a fake version of the hardware and use that to test the driver's functionality.
2. Resolves the unsoundness with pointers pointing into MMIO memory. The constructed registers type is zero-sized, so references to it do not reference any bytes, so the compiler cannot insert arbitrary reads.
3. Operations can be defined outside `tock_registers`. This design allows the `riscv-csr` crate to define its operations and retain the full functionality of `tock_registers` (including unit test functionality).
4. Hideously complex and hard to explain.

Note: I realize the design document may be incomprehensible -- please don't waste too much time trying to comprehend it. Instead, ask questions and I will respond (and improve the document if possible). I tried to explain the *why* behind the design but it got way too verbose to be useful, so instead I'm dumping the finished design in the doc without explaining the reasoning behind it.