### PR TITLE
boards/opentitan: bump opentitan commit sha

### DIFF
--- a/boards/opentitan/README.md
+++ b/boards/opentitan/README.md
@@ -130,9 +130,6 @@ $ ./bazelisk.sh build //hw/ip/otp_ctrl/...
 
 # To build FuseSOC
 $ ./bazelisk.sh build //hw:verilator
-
-# To build OTBN Binary (optional for testing rsa/otbn)
-$ ./bazelisk.sh build //sw/device/tests:otbn_rsa_test
 ```
 
 ### Test Verilator
@@ -359,8 +356,14 @@ $ make test
 
 in the specific board directory.
 
-To run the test on hardware use these commands to build the OTBN binary and run it on hardware:
+To run the test on hardware use the following steps to build the OTBN binary and run it on hardware:
 
+**Note: You will need to have **Vivado 2020.2 Lab Edition** installed to be able to build `rsa.elf`. See here for an [installation guide](https://docs.opentitan.org/doc/getting_started/install_vivado/) from the OpenTitan docs. Once installed source the settings.sh file. Can be done with:**
+
+```shell
+source <path_to_installation>/Xilinx/Vivado_Lab/2020.2/settings64.sh
+```
+We can now build the `rsa.elf` with:
 ```shell
 $ cd ${OPENTITAN_TREE}
 # Build OTBN Binary

--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -10,7 +10,7 @@ QEMU ?= ../../../tools/qemu/build/qemu-system-riscv32
 # ORIGIN(rom) + size_manifest = 0x20000000 + 0x400
 QEMU_ENTRY_POINT=0x20000400
 # Latest supported commmit of OpenTitan
-OPENTITAN_SUPPORTED_SHA := 565e4af39760a123c59a184aa2f5812a961fde47
+OPENTITAN_SUPPORTED_SHA := 8a3159dbeb743a64c6898e1e8ecac4f18808c00c
 # Enable virtual function elimination
 VFUNC_ELIM=1
 

--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -105,10 +105,10 @@ test-hardware: ot-check
 	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
-	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" OBJCOPY=${OBJCOPY} TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} TARGET=${TARGET} $(CARGO) test $(CARGO_FLAGS_TOCK) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests
+	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" OBJCOPY=$(RISC_PREFIX)-objcopy TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} TARGET=${TARGET} $(CARGO) test $(CARGO_FLAGS_TOCK) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests
 
 test-verilator: ot-check
 	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
-	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" VERILATOR="yes" OBJCOPY=${OBJCOPY} TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} TARGET=${TARGET} $(CARGO) test $(CARGO_FLAGS_TOCK) $(NO_RUN) --bin $(PLATFORM) --release --no-default-features --features=hardware_tests,sim_verilator
+	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" VERILATOR="yes" OBJCOPY=$(RISC_PREFIX)-objcopy TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} TARGET=${TARGET} $(CARGO) test $(CARGO_FLAGS_TOCK) $(NO_RUN) --bin $(PLATFORM) --release --no-default-features --features=hardware_tests,sim_verilator

--- a/boards/opentitan/earlgrey-cw310/run.sh
+++ b/boards/opentitan/earlgrey-cw310/run.sh
@@ -27,7 +27,7 @@ if [[ "${VERILATOR}" == "yes" ]]; then
 		--binary --offset 0 --byte-swap 8 --fill 0xff \
 		-within "$BUILD_DIR"/earlgrey-cw310-tests.bin\
 		-binary -range-pad 8 --output "$BUILD_DIR"/binary.64.vmem --vmem 64
-	${OPENTITAN_TREE}/bazel-out/k8-fastbuild/bin/hw/build.verilator_real/sim-verilator/Vchip_sim_tb \
+	${OPENTITAN_TREE}/bazel-bin/hw/build.verilator_real/sim-verilator/Vchip_sim_tb \
 		--meminit=rom,${OPENTITAN_TREE}/bazel-out/k8-fastbuild-ST-2cc462681f62/bin/sw/device/lib/testing/test_rom/test_rom_sim_verilator.39.scr.vmem \
 		--meminit=flash,./"$BUILD_DIR"/binary.64.vmem \
 		--meminit=otp,${OPENTITAN_TREE}/bazel-out/k8-fastbuild/bin/hw/ip/otp_ctrl/data/img_rma.24.vmem

--- a/boards/opentitan/earlgrey-cw310/run.sh
+++ b/boards/opentitan/earlgrey-cw310/run.sh
@@ -18,7 +18,7 @@ if [[ "${VERILATOR}" == "yes" ]]; then
 	${OBJCOPY} ${1} "$BUILD_DIR"/earlgrey-cw310-tests.elf
 	if [[ "${APP}" != "" ]]; then
 		# An app was specified, copy it in
-		printf "[CW-130: Verilator Tests]: Linking APP...\n\n"
+		printf "[CW-130: Verilator Tests]: Linking APP\n\n"
 		${OBJCOPY} --update-section .apps=${APP} "$BUILD_DIR"/earlgrey-cw310-tests.elf "$BUILD_DIR"/earlgrey-cw310-tests.elf
 	fi
 	${OBJCOPY} --output-target=binary "$BUILD_DIR"/earlgrey-cw310-tests.elf "$BUILD_DIR"/earlgrey-cw310-tests.bin

--- a/chips/lowrisc/src/otbn.rs
+++ b/chips/lowrisc/src/otbn.rs
@@ -167,6 +167,10 @@ impl<'a> Otbn<'a> {
             // OTBN is performing an operation, we can't make any changes
             return Err(ErrorCode::BUSY);
         }
+        // Instruction memory is too large to fit
+        if (input.len() / 4) > self.registers.imem.len() {
+            return Err(ErrorCode::SIZE);
+        }
 
         for i in 0..(input.len() / 4) {
             let idx = i * 4;


### PR DESCRIPTION
### Pull Request Overview

Bumps the opentitan commit sha to match the latest RTL version as of this commit <lowrisc/opentitan@8a3159dbeb743a64c6898e1e8ecac4f18808c00c>. 

~Notes:  I've not gotten the `rsa.elf` to build, thus OTBN needs testing.~ **Vivado 2020.2 LabEdition** is required now for this, build process uses `updatemem` for some splicing. I've updated the README in this PR to reflect.

### Testing Strategy

By running the unit tests on Verilator. ( This took ~8hrs 😢 )

```
I00000 test_rom.c:136] Version: earlgrey_silver_release_v5-9863-g8a3159dbe, Build Date: 2023-03-02 10:57:51
I00001 test_rom.c:238] Test ROM complete, jumping to flash (addr: 20000400)!
OpenTitan initialisation complete. Entering main loop
check run AES128 CCM... 
AES CCM* encryption/decryption tests
aes_ccm_test passed: (current_test=0, encrypting=true, tag_is_valid=true)
aes_ccm_test passed: (current_test=0, encrypting=false, tag_is_valid=true)
aes_ccm_test passed: (current_test=1, encrypting=true, tag_is_valid=true)
aes_ccm_test passed: (current_test=1, encrypting=false, tag_is_valid=true)
aes_ccm_test passed: (current_test=2, encrypting=true, tag_is_valid=true)
aes_ccm_test passed: (current_test=2, encrypting=false, tag_is_valid=true)
    [ok]
check run AES128 ECB... 
aes_test passed (ECB Enc Src/Dst)
aes_test passed (ECB Dec Src/Dst)
aes_test passed (ECB Enc In-place)
aes_test passed (ECB Dec In-place)
    [ok]
check run AES128 CBC... 
aes_test passed (CBC Enc Src/Dst)
aes_test passed (CBC Dec Src/Dst)
aes_test passed (CBC Enc In-place)
aes_test passed (CBC Dec In-place)
    [ok]
check run AES128 CTR... 
aes_test CTR passed: (CTR Enc Ctr Src/Dst)
aes_test CTR passed: (CTR Dec Ctr Src/Dst)
    [ok]
check run CSRNG Entropy 32... 
Entropy32 test: first get Ok(())
Entropy test: obtained all 8 values. They are:
[00]: 735b27a0
[01]: 497b246f
[02]: 9a8f9420
[03]: 91618fe9
[04]: e07e680b
[05]: 01aec0b9
[06]: 3ca6b2a0
[07]: 19078a9d
    [ok]
check hmac load binary... 
    [ok]
check hmac check verify... 
    [ok]
start multi alarm test...
    [ok]
check otbn run binary...
check otbn run rsa binary...
    [ok]
check rsa exponent... 
    [ok]
check rsa exponent one... 
    [ok]
check rsa key import... 
    [ok]
check rsa 4096 bit key import... 
    [ok]
check rsa 4096 exponent... 
    [ok]
start SHA256 verify test
Sha256Test: Setting slice to 12..24
Sha256Test: Setting slice to 24..36
Sha256Test: Setting slice to 36..48
Sha256Test: Setting slice to 48..60
Sha256Test: Setting slice to 60..72
Sha256Test: Verification result: Ok(true)
    [ok]
check SipHash 2-4... 
    [ok]
[SPI] Setup spi_host0 partial_transfer... 
    [ok]
[SPI] Setup spi_host0 transfers... 
    [ok]
[SPI] Setup spi_host0 transfer...x2 
    [ok]
start TicKV append key test...
---Starting TicKV Tests---
Generated key: [61, 245, 130, 62, 163, 73, 69, 239]
Now appending the key
Key: [61, 245, 130, 62, 163, 73, 69, 239] with value [16, 32, 48] was added
Now retrieving the key
Key: [61, 245, 130, 62, 163, 73, 69, 239] with value [16, 32, 48, 0] was retrieved
Removed Key: [61, 245, 130, 62, 163, 73, 69, 239]
Try to read removed key: [61, 245, 130, 62, 163, 73, 69, 239]
Unable to find key: [61, 245, 130, 62, 163, 73, 69, 239]
Let's start a garbage collection
Finished garbage collection
---Finished TicKV Tests---
    [ok]
[FLASH_CTRL] Test page read/write....
    [ok]
[FLASH_CTRL] Test page erase....
    [ok]
[FLASH_CTRL] Test memory protection api....
    [ok]
[FLASH_CTRL] Test memory protection functionality....
    [ok]
trivial assertion... 
    [ok]
```

### TODO or Help Wanted
- HW Testing
- ~Test using rsa.elf~

Should we provide the `rsa.tbf`? So people don't need to Vivado?

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
