### PR TITLE
nrf52: support new access port protection mechanism on new nRF52 chips

### DIFF
--- a/boards/nordic/nrf52_components/src/startup.rs
+++ b/boards/nordic/nrf52_components/src/startup.rs
@@ -42,6 +42,12 @@ impl<'a> Component for NrfStartupComponent<'a> {
     type StaticInput = ();
     type Output = ();
     fn finalize(self, _s: Self::StaticInput) -> Self::Output {
+        // Disable APPROTECT in software. This is required as of newer nRF52
+        // hardware revisions. See
+        // https://devzone.nordicsemi.com/nordic/nordic-blog/b/blog/posts/working-with-the-nrf52-series-improved-approtect.
+        let approtect = nrf52::approtect::Approtect::new();
+        approtect.sw_disable_approtect();
+
         // Make non-volatile memory writable and activate the reset button
         let uicr = nrf52::uicr::Uicr::new();
 

--- a/boards/nordic/nrf52_components/src/startup.rs
+++ b/boards/nordic/nrf52_components/src/startup.rs
@@ -45,6 +45,7 @@ impl<'a> Component for NrfStartupComponent<'a> {
         // Disable APPROTECT in software. This is required as of newer nRF52
         // hardware revisions. See
         // https://devzone.nordicsemi.com/nordic/nordic-blog/b/blog/posts/working-with-the-nrf52-series-improved-approtect.
+        // If run on older HW revisions this function will do nothing.
         let approtect = nrf52::approtect::Approtect::new();
         approtect.sw_disable_approtect();
 
@@ -63,6 +64,12 @@ impl<'a> Component for NrfStartupComponent<'a> {
         // Only enabling the NFC pin protection requires an erase.
         if self.nfc_as_gpios {
             erase_uicr |= !uicr.is_nfc_pins_protection_enabled();
+        }
+
+        // On new nRF52 variants we need to ensure that the APPROTECT field in UICR is
+        // set to `HwDisable`.
+        if uicr.is_ap_protect_enabled() {
+            erase_uicr = true;
         }
 
         if erase_uicr {
@@ -102,6 +109,13 @@ impl<'a> Component for NrfStartupComponent<'a> {
         // Check if we need to free the NFC pins for GPIO
         if self.nfc_as_gpios {
             uicr.set_nfc_pins_protection(true);
+            while !self.nvmc.is_ready() {}
+            needs_soft_reset = true;
+        }
+
+        // If APPROTECT was not already disabled, ensure it is set to disabled.
+        if uicr.is_ap_protect_enabled() {
+            uicr.disable_ap_protect();
             while !self.nvmc.is_ready() {}
             needs_soft_reset = true;
         }

--- a/chips/nrf52/src/approtect.rs
+++ b/chips/nrf52/src/approtect.rs
@@ -4,7 +4,7 @@
 
 //! Access port protection
 //!
-//! https://infocenter.nordicsemi.com/index.jsp?topic=%2Fps_nrf52840%2Fdif.html&cp=5_0_0_3_7_1&anchor=register.DISABLE
+//! <https://infocenter.nordicsemi.com/index.jsp?topic=%2Fps_nrf52840%2Fdif.html&cp=5_0_0_3_7_1&anchor=register.DISABLE>
 //!
 //! The logic around APPROTECT was changed in newer revisions of the nRF52
 //! series chips (Oct 2021) and later which requires more careful disabling of
@@ -67,8 +67,8 @@ impl Approtect {
     /// disabled both in the UICR register (hardware) and in this register
     /// (software). For older variants this is just a no-op.
     ///
-    /// - https://devzone.nordicsemi.com/f/nordic-q-a/96590/how-to-disable-approtect-permanently-dfu-is-needed
-    /// - https://devzone.nordicsemi.com/nordic/nordic-blog/b/blog/posts/working-with-the-nrf52-series-improved-approtect
+    /// - <https://devzone.nordicsemi.com/f/nordic-q-a/96590/how-to-disable-approtect-permanently-dfu-is-needed>
+    /// - <https://devzone.nordicsemi.com/nordic/nordic-blog/b/blog/posts/working-with-the-nrf52-series-improved-approtect>
     pub fn sw_disable_approtect(&self) {
         let factory_config = ficr::Ficr::new();
         match factory_config.variant() {

--- a/chips/nrf52/src/approtect.rs
+++ b/chips/nrf52/src/approtect.rs
@@ -79,7 +79,27 @@ impl Approtect {
                 // updated to recognize it.
                 self.registers.disable.write(Disable::DISABLE::SWDISABLE);
             }
-            _ => {
+
+            // Exhaustively list variants here to produce compiler error on
+            // adding a new variant, which would otherwise not match the above
+            // condition.
+            ficr::Variant::AAA0
+            | ficr::Variant::AAAA
+            | ficr::Variant::AAAB
+            | ficr::Variant::AAB0
+            | ficr::Variant::AABA
+            | ficr::Variant::AABB
+            | ficr::Variant::AAC0
+            | ficr::Variant::AACA
+            | ficr::Variant::AACB
+            | ficr::Variant::AAD0
+            | ficr::Variant::AAD1
+            | ficr::Variant::AADA
+            | ficr::Variant::AAE0
+            | ficr::Variant::AAEA
+            | ficr::Variant::ABBA
+            | ficr::Variant::BAAA
+            | ficr::Variant::CAAA => {
                 // All other revisions don't need this.
             }
         }

--- a/chips/nrf52/src/approtect.rs
+++ b/chips/nrf52/src/approtect.rs
@@ -13,7 +13,7 @@
 //!
 //! Example code to disable the APPROTECT protection in software:
 //!
-//! ```rust
+//! ```rust,ignore
 //! let approtect = nrf52::approtect::Approtect::new();
 //! approtect.sw_disable_approtect();
 //! ```

--- a/chips/nrf52/src/approtect.rs
+++ b/chips/nrf52/src/approtect.rs
@@ -1,0 +1,87 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2023.
+
+//! Access port protection
+//!
+//! https://infocenter.nordicsemi.com/index.jsp?topic=%2Fps_nrf52840%2Fdif.html&cp=5_0_0_3_7_1&anchor=register.DISABLE
+//!
+//! The logic around APPROTECT was changed in newer revisions of the nRF52
+//! series chips (Oct 2021) and later which requires more careful disabling of
+//! the access port (JTAG), both in the UICR register and in a software written
+//! register. This module enables the kernel to disable the protection on boot.
+//!
+//! Example code to disable the APPROTECT protection in software:
+//!
+//! ```rust
+//! let approtect = nrf52::approtect::Approtect::new();
+//! approtect.sw_disable_approtect();
+//! ```
+
+use crate::ficr;
+use kernel::utilities::registers::interfaces::Writeable;
+use kernel::utilities::registers::{register_bitfields, register_structs, ReadWrite};
+use kernel::utilities::StaticRef;
+
+const APPROTECT_BASE: StaticRef<ApprotectRegisters> =
+    unsafe { StaticRef::new(0x40000000 as *const ApprotectRegisters) };
+
+register_structs! {
+    ApprotectRegisters {
+        (0x000 => _reserved0),
+        (0x550 => forceprotect: ReadWrite<u32, Forceprotect::Register>),
+        (0x554 => _reserved1),
+        (0x558 => disable: ReadWrite<u32, Disable::Register>),
+        (0x55c => @END),
+    }
+}
+
+register_bitfields! [u32,
+    Forceprotect [
+        FORCEPROTECT OFFSET(0) NUMBITS(8) [
+            FORCE = 0
+        ]
+    ],
+    /// Access port protection
+    Disable [
+        DISABLE OFFSET(0) NUMBITS(8) [
+            SWDISABLE = 0x5a
+        ]
+    ]
+];
+
+pub struct Approtect {
+    registers: StaticRef<ApprotectRegisters>,
+}
+
+impl Approtect {
+    pub const fn new() -> Approtect {
+        Approtect {
+            registers: APPROTECT_BASE,
+        }
+    }
+
+    /// Software disable the Access Port Protection mechanism.
+    ///
+    /// On newer variants of the nRF52, to enable JTAG, APPROTECT must be
+    /// disabled both in the UICR register (hardware) and in this register
+    /// (software). For older variants this is just a no-op.
+    ///
+    /// - https://devzone.nordicsemi.com/f/nordic-q-a/96590/how-to-disable-approtect-permanently-dfu-is-needed
+    /// - https://devzone.nordicsemi.com/nordic/nordic-blog/b/blog/posts/working-with-the-nrf52-series-improved-approtect
+    pub fn sw_disable_approtect(&self) {
+        let factory_config = ficr::Ficr::new();
+        match factory_config.variant() {
+            ficr::Variant::AAF0 | ficr::Variant::Unspecified => {
+                // Newer revisions of the chip require setting the APPROTECT
+                // software register to `SwDisable`. We assume that an unspecified
+                // version means that it is new and the FICR module hasn't been
+                // updated to recognize it.
+                self.registers.disable.write(Disable::DISABLE::SWDISABLE);
+            }
+            _ => {
+                // All other revisions don't need this.
+            }
+        }
+    }
+}

--- a/chips/nrf52/src/ficr.rs
+++ b/chips/nrf52/src/ficr.rs
@@ -338,6 +338,8 @@ impl Ficr {
     }
 
     pub(crate) fn variant(&self) -> Variant {
+        // If you update this, make sure to update
+        // `has_updated_approtect_logic()` as well.
         match self.registers.info_variant.get() {
             0x41414130 => Variant::AAA0,
             0x41414141 => Variant::AAAA,
@@ -358,6 +360,21 @@ impl Ficr {
             0x42414141 => Variant::BAAA,
             0x43414141 => Variant::CAAA,
             _ => Variant::Unspecified,
+        }
+    }
+
+    /// Returns if this variant of the nRF52 has the updated APPROTECT logic.
+    /// This changed occurred towards the end of 2021 with chips becoming widely
+    /// available/used in 2023.
+    ///
+    /// See https://devzone.nordicsemi.com/nordic/nordic-blog/b/blog/posts/working-with-the-nrf52-series-improved-approtect
+    /// for more information.
+    pub(crate) fn has_updated_approtect_logic(&self) -> bool {
+        // We assume that an unspecified version means that it is new and this
+        // module hasn't been updated to recognize it.
+        match self.variant() {
+            Variant::AAF0 | Variant::Unspecified => true,
+            _ => false,
         }
     }
 

--- a/chips/nrf52/src/ficr.rs
+++ b/chips/nrf52/src/ficr.rs
@@ -171,8 +171,16 @@ register_bitfields! [u32,
             ABBA = 0x41424241,
             /// AAD0
             AAD0 = 0x41414430,
+            /// AAD1
+            AAD1 = 0x41414431,
+            /// AADA
+            AADA = 0x41414441,
             /// AAE0
             AAE0 = 0x41414530,
+            /// AAEA
+            AAEA = 0x41414541,
+            /// AAF0
+            AAF0 = 0x41414630,
             /// BAAA
             BAAA = 0x42414141,
             /// CAAA
@@ -248,9 +256,13 @@ enum Variant {
     AAC0 = 0x41414330,
     AACA = 0x41414341,
     AACB = 0x41414342,
-    ABBA = 0x41424241,
     AAD0 = 0x41414430,
+    AAD1 = 0x41414431,
+    AADA = 0x41414441,
     AAE0 = 0x41414530,
+    AAEA = 0x41414541,
+    AAF0 = 0x41414630,
+    ABBA = 0x41424241,
     BAAA = 0x42414141,
     CAAA = 0x43414141,
     Unspecified = 0xffffffff,
@@ -338,7 +350,11 @@ impl Ficr {
             0x41414342 => Variant::AACB,
             0x41424241 => Variant::ABBA,
             0x41414430 => Variant::AAD0,
+            0x41414431 => Variant::AAD1,
+            0x41414441 => Variant::AADA,
             0x41414530 => Variant::AAE0,
+            0x41414541 => Variant::AAEA,
+            0x41414630 => Variant::AAF0,
             0x42414141 => Variant::BAAA,
             0x43414141 => Variant::CAAA,
             _ => Variant::Unspecified,

--- a/chips/nrf52/src/ficr.rs
+++ b/chips/nrf52/src/ficr.rs
@@ -246,7 +246,7 @@ register_bitfields! [u32,
 /// Variant describes part variant, hardware version, and production configuration.
 #[derive(PartialEq, Debug)]
 #[repr(u32)]
-enum Variant {
+pub(crate) enum Variant {
     AAA0 = 0x41414130,
     AAAA = 0x41414141,
     AAAB = 0x41414142,
@@ -322,7 +322,7 @@ pub struct Ficr {
 }
 
 impl Ficr {
-    const fn new() -> Ficr {
+    pub(crate) const fn new() -> Ficr {
         Ficr {
             registers: FICR_BASE,
         }
@@ -337,7 +337,7 @@ impl Ficr {
         }
     }
 
-    fn variant(&self) -> Variant {
+    pub(crate) fn variant(&self) -> Variant {
         match self.registers.info_variant.get() {
             0x41414130 => Variant::AAA0,
             0x41414141 => Variant::AAAA,

--- a/chips/nrf52/src/lib.rs
+++ b/chips/nrf52/src/lib.rs
@@ -8,6 +8,7 @@
 
 pub mod acomp;
 pub mod adc;
+pub mod approtect;
 pub mod ble_radio;
 pub mod chip;
 pub mod clock;

--- a/chips/nrf52/src/uicr.rs
+++ b/chips/nrf52/src/uicr.rs
@@ -185,9 +185,10 @@ impl Uicr {
         // implement this function. Newer versions use a different value to
         // indicate disabled.
         let factory_config = ficr::Ficr::new();
-        let disabled_val = match factory_config.variant() {
-            ficr::Variant::AAF0 | ficr::Variant::Unspecified => ApProtect::PALL::HWDISABLE,
-            _ => ApProtect::PALL::DISABLED,
+        let disabled_val = if factory_config.has_updated_approtect_logic() {
+            ApProtect::PALL::HWDISABLE
+        } else {
+            ApProtect::PALL::DISABLED
         };
 
         // Here we compare to the correct DISABLED value because any other value
@@ -206,18 +207,13 @@ impl Uicr {
         // We need to understand the variant of this nRF52 chip to correctly
         // implement this function.
         let factory_config = ficr::Ficr::new();
-        match factory_config.variant() {
-            ficr::Variant::AAF0 | ficr::Variant::Unspecified => {
-                // Newer revisions of the chip require setting the APPROTECT
-                // register to `HwDisable`. We assume that an unspecified
-                // version means that it is new and the FICR module hasn't been
-                // updated to recognize it.
-                self.registers.approtect.write(ApProtect::PALL::HWDISABLE);
-            }
-            _ => {
-                // All other revisions just use normal disable.
-                self.registers.approtect.write(ApProtect::PALL::DISABLED);
-            }
+        if factory_config.has_updated_approtect_logic() {
+            // Newer revisions of the chip require setting the APPROTECT
+            // register to `HwDisable`.
+            self.registers.approtect.write(ApProtect::PALL::HWDISABLE);
+        } else {
+            // All other revisions just use normal disable.
+            self.registers.approtect.write(ApProtect::PALL::DISABLED);
         }
     }
 }


### PR DESCRIPTION
### Pull Request Overview

It seems like recently nordic got bad press for having a vulnerability in how they disable jtag access, so newer versions of the nrf52840 change how they restrict jtag access, which essentially restricts jtag by default. This PR adds support to disable the protection so we can use and reprogram newer nRFs without re-flashing every time.

This requires setting both a "HW" register (aka in flash), and a "SW" register (aka in RAM) to 0x5a. The HW register can just be done once. The SW register needs to be done on every boot. Note, this is only for the new versions. So this code checks the variant and only includes it on the new variant.


### Testing Strategy

Running tock on a new nrf52840dk board.


### TODO or Help Wanted

~~Still need to set the UICR, or for now running `nrfjprog --recover` works.~~


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
