### PR TITLE
Change the I2C implementation to use generics

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -352,7 +352,7 @@ pub unsafe fn main() {
 
     // Create shared mux for the I2C bus
     let i2c_mux = static_init!(
-        capsules_core::virtualizers::virtual_i2c::MuxI2C<'static>,
+        capsules_core::virtualizers::virtual_i2c::MuxI2C<'static, nrf52832::i2c::TWI>,
         capsules_core::virtualizers::virtual_i2c::MuxI2C::new(&base_peripherals.twi0, None,)
     );
     kernel::deferred_call::DeferredCallClient::register(i2c_mux);

--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -79,7 +79,7 @@ pub struct Platform {
     >,
     gpio_async: &'static capsules_extra::gpio_async::GPIOAsync<
         'static,
-        capsules_extra::mcp230xx::MCP230xx<'static>,
+        capsules_extra::mcp230xx::MCP230xx<'static, nrf52832::i2c::TWI>,
     >,
     light: &'static capsules_extra::ambient_light::AmbientLight<'static>,
     buzzer: &'static capsules_extra::buzzer_driver::Buzzer<
@@ -378,7 +378,10 @@ pub unsafe fn main() {
         capsules_core::virtualizers::virtual_i2c::I2CDevice::new(i2c_mux, 0x40)
     );
     let mcp23017 = static_init!(
-        capsules_extra::mcp230xx::MCP230xx<'static>,
+        capsules_extra::mcp230xx::MCP230xx<
+            'static,
+            capsules::virtual_i2c::I2CDevice<'static, nrf52832::i2c::TWI>,
+        >,
         capsules_extra::mcp230xx::MCP230xx::new(
             mcp23017_i2c,
             Some(mcp_pin0),
@@ -398,12 +401,22 @@ pub unsafe fn main() {
 
     // Create an array of the GPIO extenders so we can pass them to an
     // administrative layer that provides a single interface to them all.
-    let async_gpio_ports =
-        static_init!([&'static capsules_extra::mcp230xx::MCP230xx; 1], [mcp23017]);
+    let async_gpio_ports = static_init!(
+        [&'static capsules_extra::mcp230xx::MCP230xx<
+            capsules::virtual_i2c::I2CDevice<'static, nrf52832::i2c::TWI>,
+        >; 1],
+        [mcp23017]
+    );
 
     // `gpio_async` is the object that manages all of the extenders.
     let gpio_async = static_init!(
-        capsules_extra::gpio_async::GPIOAsync<'static, capsules_extra::mcp230xx::MCP230xx<'static>>,
+        capsules_extra::gpio_async::GPIOAsync<
+            'static,
+            capsules_extra::mcp230xx::MCP230xx<
+                'static,
+                capsules::virtual_i2c::I2CDevice<'static, nrf52832::i2c::TWI>,
+            >,
+        >,
         capsules_extra::gpio_async::GPIOAsync::new(
             async_gpio_ports,
             board_kernel.create_grant(

--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -79,7 +79,10 @@ pub struct Platform {
     >,
     gpio_async: &'static capsules_extra::gpio_async::GPIOAsync<
         'static,
-        capsules_extra::mcp230xx::MCP230xx<'static, nrf52832::i2c::TWI>,
+        capsules_extra::mcp230xx::MCP230xx<
+            'static,
+            capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, nrf52832::i2c::TWI>,
+        >,
     >,
     light: &'static capsules_extra::ambient_light::AmbientLight<'static>,
     buzzer: &'static capsules_extra::buzzer_driver::Buzzer<
@@ -374,13 +377,13 @@ pub unsafe fn main() {
     )
     .finalize();
     let mcp23017_i2c = static_init!(
-        capsules_core::virtualizers::virtual_i2c::I2CDevice,
+        capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, nrf52832::i2c::TWI>,
         capsules_core::virtualizers::virtual_i2c::I2CDevice::new(i2c_mux, 0x40)
     );
     let mcp23017 = static_init!(
         capsules_extra::mcp230xx::MCP230xx<
             'static,
-            capsules::virtual_i2c::I2CDevice<'static, nrf52832::i2c::TWI>,
+            capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, nrf52832::i2c::TWI>,
         >,
         capsules_extra::mcp230xx::MCP230xx::new(
             mcp23017_i2c,
@@ -403,7 +406,7 @@ pub unsafe fn main() {
     // administrative layer that provides a single interface to them all.
     let async_gpio_ports = static_init!(
         [&'static capsules_extra::mcp230xx::MCP230xx<
-            capsules::virtual_i2c::I2CDevice<'static, nrf52832::i2c::TWI>,
+            capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, nrf52832::i2c::TWI>,
         >; 1],
         [mcp23017]
     );
@@ -414,7 +417,7 @@ pub unsafe fn main() {
             'static,
             capsules_extra::mcp230xx::MCP230xx<
                 'static,
-                capsules::virtual_i2c::I2CDevice<'static, nrf52832::i2c::TWI>,
+                capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, nrf52832::i2c::TWI>,
             >,
         >,
         capsules_extra::gpio_async::GPIOAsync::new(

--- a/boards/apollo3/lora_things_plus/src/main.rs
+++ b/boards/apollo3/lora_things_plus/src/main.rs
@@ -315,11 +315,13 @@ unsafe fn setup() -> (
     let _ = &peripherals.iom0.set_master_client(i2c_master);
     let _ = &peripherals.iom0.enable();
 
-    let mux_i2c = components::i2c::I2CMuxComponent::new(&peripherals.iom0, None)
-        .finalize(components::i2c_mux_component_static!());
+    let mux_i2c = components::i2c::I2CMuxComponent::new(&peripherals.iom0, None).finalize(
+        components::i2c_mux_component_static!(apollo3::iom::Iom<'static>),
+    );
 
-    let bme280 =
-        Bme280Component::new(mux_i2c, 0x77).finalize(components::bme280_component_static!());
+    let bme280 = Bme280Component::new(mux_i2c, 0x77).finalize(
+        components::bme280_component_static!(apollo3::iom::Iom<'static>),
+    );
     let temperature = components::temperature::TemperatureComponent::new(
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,
@@ -334,8 +336,9 @@ unsafe fn setup() -> (
     .finalize(components::humidity_component_static!());
     BME280 = Some(bme280);
 
-    let ccs811 =
-        Ccs811Component::new(mux_i2c, 0x5B).finalize(components::ccs811_component_static!());
+    let ccs811 = Ccs811Component::new(mux_i2c, 0x5B).finalize(
+        components::ccs811_component_static!(apollo3::iom::Iom<'static>),
+    );
     let air_quality = components::air_quality::AirQualityComponent::new(
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,

--- a/boards/apollo3/redboard_artemis_nano/src/main.rs
+++ b/boards/apollo3/redboard_artemis_nano/src/main.rs
@@ -284,10 +284,10 @@ unsafe fn setup() -> (
     let _ = &peripherals.iom2.enable();
 
     let mux_i2c = components::i2c::I2CMuxComponent::new(&peripherals.iom2, None)
-        .finalize(components::i2c_mux_component_static!());
+        .finalize(components::i2c_mux_component_static!(apollo3::iom::Iom));
 
-    let bme280 =
-        Bme280Component::new(mux_i2c, 0x77).finalize(components::bme280_component_static!());
+    let bme280 = Bme280Component::new(mux_i2c, 0x77)
+        .finalize(components::bme280_component_static!(apollo3::iom::Iom));
     let temperature = components::temperature::TemperatureComponent::new(
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,
@@ -302,8 +302,8 @@ unsafe fn setup() -> (
     .finalize(components::humidity_component_static!());
     BME280 = Some(bme280);
 
-    let ccs811 =
-        Ccs811Component::new(mux_i2c, 0x5B).finalize(components::ccs811_component_static!());
+    let ccs811 = Ccs811Component::new(mux_i2c, 0x5B)
+        .finalize(components::ccs811_component_static!(apollo3::iom::Iom));
     let air_quality = components::air_quality::AirQualityComponent::new(
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -585,7 +585,7 @@ pub unsafe fn main() {
     //--------------------------------------------------------------------------
 
     let sensors_i2c_bus = static_init!(
-        capsules_core::virtualizers::virtual_i2c::MuxI2C<'static>,
+        capsules_core::virtualizers::virtual_i2c::MuxI2C<'static, nrf52840::i2c::TWI>,
         capsules_core::virtualizers::virtual_i2c::MuxI2C::new(&base_peripherals.twi1, None,)
     );
     kernel::deferred_call::DeferredCallClient::register(sensors_i2c_bus);

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -600,7 +600,7 @@ pub unsafe fn main() {
         0x39,
         &nrf52840_peripherals.gpio_port[APDS9960_PIN],
     )
-    .finalize(components::apds9960_component_static!());
+    .finalize(components::apds9960_component_static!(nrf52840::i2c::TWI));
     let proximity = components::proximity::ProximityComponent::new(
         apds9960,
         board_kernel,
@@ -614,7 +614,8 @@ pub unsafe fn main() {
         mux_alarm,
     )
     .finalize(components::sht3x_component_static!(
-        nrf52::rtc::Rtc<'static>
+        nrf52::rtc::Rtc<'static>,
+        nrf52840::i2c::TWI
     ));
 
     let temperature = components::temperature::TemperatureComponent::new(

--- a/boards/components/src/apds9960.rs
+++ b/boards/components/src/apds9960.rs
@@ -12,7 +12,12 @@ macro_rules! apds9960_component_static {
     ($I:ty $(,)?) => {{
         let i2c_device =
             kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, $I>);
-        let apds9960 = kernel::static_buf!(capsules_extra::apds9960::APDS9960<'static>);
+        let apds9960 = kernel::static_buf!(
+            capsules_extra::apds9960::APDS9960<
+                'static,
+                capsules_core::virtualizers::virtual_i2c::I2CDevice<$I>,
+            >
+        );
         let buffer = kernel::static_buf!([u8; capsules_extra::apds9960::BUF_LEN]);
 
         (i2c_device, apds9960, buffer)

--- a/boards/components/src/apds9960.rs
+++ b/boards/components/src/apds9960.rs
@@ -5,12 +5,13 @@ use capsules_extra::apds9960::APDS9960;
 use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::hil::gpio;
+use kernel::hil::i2c;
 
 #[macro_export]
 macro_rules! apds9960_component_static {
-    () => {{
+    ($I:ty $(,)?) => {{
         let i2c_device =
-            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<'static>);
+            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, $I>);
         let apds9960 = kernel::static_buf!(capsules_extra::apds9960::APDS9960<'static>);
         let buffer = kernel::static_buf!([u8; capsules_extra::apds9960::BUF_LEN]);
 
@@ -18,15 +19,15 @@ macro_rules! apds9960_component_static {
     };};
 }
 
-pub struct Apds9960Component {
-    i2c_mux: &'static MuxI2C<'static>,
+pub struct Apds9960Component<I: 'static + i2c::I2CMaster> {
+    i2c_mux: &'static MuxI2C<'static, I>,
     i2c_address: u8,
     interrupt_pin: &'static dyn gpio::InterruptPin<'static>,
 }
 
-impl Apds9960Component {
+impl<I: 'static + i2c::I2CMaster> Apds9960Component<I> {
     pub fn new(
-        i2c_mux: &'static MuxI2C<'static>,
+        i2c_mux: &'static MuxI2C<'static, I>,
         i2c_address: u8,
         interrupt_pin: &'static dyn gpio::InterruptPin<'static>,
     ) -> Self {
@@ -38,9 +39,9 @@ impl Apds9960Component {
     }
 }
 
-impl Component for Apds9960Component {
+impl<I: 'static + i2c::I2CMaster> Component for Apds9960Component<I> {
     type StaticInput = (
-        &'static mut MaybeUninit<I2CDevice<'static>>,
+        &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<APDS9960<'static>>,
         &'static mut MaybeUninit<[u8; capsules_extra::apds9960::BUF_LEN]>,
     );

--- a/boards/components/src/apds9960.rs
+++ b/boards/components/src/apds9960.rs
@@ -19,14 +19,13 @@ macro_rules! apds9960_component_static {
     };};
 }
 
-pub struct Apds9960Component<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> {
+pub struct Apds9960Component<I: 'static + i2c::I2CMaster> {
     i2c_mux: &'static MuxI2C<'static, I>,
     i2c_address: u8,
     interrupt_pin: &'static dyn gpio::InterruptPin<'static>,
-    i2c_device: PhantomData<J>,
 }
 
-impl<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> Apds9960Component<I, J> {
+impl<I: 'static + i2c::I2CMaster> Apds9960Component<I> {
     pub fn new(
         i2c_mux: &'static MuxI2C<'static, I>,
         i2c_address: u8,
@@ -36,20 +35,17 @@ impl<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> Apds9960Component
             i2c_mux,
             i2c_address,
             interrupt_pin,
-            i2c_device: PhantomData,
         }
     }
 }
 
-impl<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> Component
-    for Apds9960Component<I, J>
-{
+impl<I: 'static + i2c::I2CMaster> Component for Apds9960Component<I> {
     type StaticInput = (
         &'static mut MaybeUninit<I2CDevice<'static, I>>,
-        &'static mut MaybeUninit<APDS9960<'static, J>>,
+        &'static mut MaybeUninit<APDS9960<'static, I2CDevice<'static, I>>>,
         &'static mut MaybeUninit<[u8; capsules_extra::apds9960::BUF_LEN]>,
     );
-    type Output = &'static APDS9960<'static, J>;
+    type Output = &'static APDS9960<'static, I2CDevice<'static, I>>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
         let apds9960_i2c = s.0.write(I2CDevice::new(self.i2c_mux, self.i2c_address));

--- a/boards/components/src/bme280.rs
+++ b/boards/components/src/bme280.rs
@@ -23,13 +23,14 @@ use capsules_core::virtualizers::virtual_i2c::{I2CDevice, MuxI2C};
 use capsules_extra::bme280::Bme280;
 use core::mem::MaybeUninit;
 use kernel::component::Component;
+use kernel::hil::i2c;
 
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! bme280_component_static {
-    () => {{
+    ($I:ty $(,)?) => {{
         let i2c_device =
-            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<'static>);
+            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, $I>);
         let i2c_buffer = kernel::static_buf!([u8; 26]);
         let bme280 = kernel::static_buf!(capsules_extra::bme280::Bme280<'static>);
 
@@ -37,13 +38,13 @@ macro_rules! bme280_component_static {
     };};
 }
 
-pub struct Bme280Component {
-    i2c_mux: &'static MuxI2C<'static>,
+pub struct Bme280Component<I: 'static + i2c::I2CMaster> {
+    i2c_mux: &'static MuxI2C<'static, I>,
     i2c_address: u8,
 }
 
-impl Bme280Component {
-    pub fn new(i2c: &'static MuxI2C<'static>, i2c_address: u8) -> Self {
+impl<I: 'static + i2c::I2CMaster> Bme280Component<I> {
+    pub fn new(i2c: &'static MuxI2C<'static, I>, i2c_address: u8) -> Self {
         Bme280Component {
             i2c_mux: i2c,
             i2c_address: i2c_address,
@@ -51,9 +52,9 @@ impl Bme280Component {
     }
 }
 
-impl Component for Bme280Component {
+impl<I: 'static + i2c::I2CMaster> Component for Bme280Component<I> {
     type StaticInput = (
-        &'static mut MaybeUninit<I2CDevice<'static>>,
+        &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<[u8; 26]>,
         &'static mut MaybeUninit<Bme280<'static>>,
     );

--- a/boards/components/src/bmp280.rs
+++ b/boards/components/src/bmp280.rs
@@ -44,7 +44,7 @@ macro_rules! bmp280_component_static {
             capsules_extra::bmp280::Bmp280<
                 'static,
                 VirtualMuxAlarm<'static, $A>,
-                I2CDevice<'static, $I>,
+                capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, $I>,
             >
         );
 

--- a/boards/components/src/bmp280.rs
+++ b/boards/components/src/bmp280.rs
@@ -28,13 +28,14 @@ use capsules_core::virtualizers::virtual_i2c::{I2CDevice, MuxI2C};
 use capsules_extra::bmp280::Bmp280;
 use core::mem::MaybeUninit;
 use kernel::component::Component;
+use kernel::hil::i2c;
 use kernel::hil::time::Alarm;
 
 #[macro_export]
 macro_rules! bmp280_component_static {
-    ($A:ty $(,)?) => {{
+    ($A:ty $(,)?, $I:ty) => {{
         let i2c_device =
-            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<'static>);
+            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, $I>);
         let alarm = kernel::static_buf!(
             capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, $A>
         );
@@ -47,18 +48,18 @@ macro_rules! bmp280_component_static {
     };};
 }
 
-pub struct Bmp280Component<A: 'static + Alarm<'static>> {
-    i2c_mux: &'static MuxI2C<'static>,
+pub struct Bmp280Component<A: 'static + Alarm<'static>, I: 'static + i2c::I2CMaster> {
+    i2c_mux: &'static MuxI2C<'static, I>,
     i2c_address: u8,
     alarm_mux: &'static MuxAlarm<'static, A>,
 }
 
-impl<A: 'static + Alarm<'static>> Bmp280Component<A> {
+impl<A: 'static + Alarm<'static>, I: 'static + i2c::I2CMaster> Bmp280Component<A, I> {
     pub fn new(
-        i2c_mux: &'static MuxI2C<'static>,
+        i2c_mux: &'static MuxI2C<'static, I>,
         i2c_address: u8,
         alarm_mux: &'static MuxAlarm<'static, A>,
-    ) -> Bmp280Component<A> {
+    ) -> Bmp280Component<A, I> {
         Bmp280Component {
             i2c_mux,
             i2c_address,
@@ -67,9 +68,9 @@ impl<A: 'static + Alarm<'static>> Bmp280Component<A> {
     }
 }
 
-impl<A: 'static + Alarm<'static>> Component for Bmp280Component<A> {
+impl<A: 'static + Alarm<'static>, I: 'static + i2c::I2CMaster> Component for Bmp280Component<A, I> {
     type StaticInput = (
-        &'static mut MaybeUninit<I2CDevice<'static>>,
+        &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<VirtualMuxAlarm<'static, A>>,
         &'static mut MaybeUninit<[u8; capsules_extra::bmp280::BUFFER_SIZE]>,
         &'static mut MaybeUninit<Bmp280<'static, VirtualMuxAlarm<'static, A>>>,

--- a/boards/components/src/bmp280.rs
+++ b/boards/components/src/bmp280.rs
@@ -41,7 +41,11 @@ macro_rules! bmp280_component_static {
         );
         let buffer = kernel::static_buf!([u8; capsules_extra::bmp280::BUFFER_SIZE]);
         let bmp280 = kernel::static_buf!(
-            capsules_extra::bmp280::Bmp280<'static, VirtualMuxAlarm<'static, $A>>
+            capsules_extra::bmp280::Bmp280<
+                'static,
+                VirtualMuxAlarm<'static, $A>,
+                I2CDevice<'static, $I>,
+            >
         );
 
         (i2c_device, alarm, buffer, bmp280)

--- a/boards/components/src/bmp280.rs
+++ b/boards/components/src/bmp280.rs
@@ -48,34 +48,44 @@ macro_rules! bmp280_component_static {
     };};
 }
 
-pub struct Bmp280Component<A: 'static + Alarm<'static>, I: 'static + i2c::I2CMaster> {
+pub struct Bmp280Component<
+    A: 'static + Alarm<'static>,
+    I: 'static + i2c::I2CMaster,
+    J: 'static + i2c::I2CDevice,
+> {
     i2c_mux: &'static MuxI2C<'static, I>,
     i2c_address: u8,
     alarm_mux: &'static MuxAlarm<'static, A>,
+    i2c_device: PhantomData<J>,
 }
 
-impl<A: 'static + Alarm<'static>, I: 'static + i2c::I2CMaster> Bmp280Component<A, I> {
+impl<A: 'static + Alarm<'static>, I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice>
+    Bmp280Component<A, I, J>
+{
     pub fn new(
         i2c_mux: &'static MuxI2C<'static, I>,
         i2c_address: u8,
         alarm_mux: &'static MuxAlarm<'static, A>,
-    ) -> Bmp280Component<A, I> {
+    ) -> Bmp280Component<A, I, J> {
         Bmp280Component {
             i2c_mux,
             i2c_address,
             alarm_mux,
+            i2c_device: PhantomData,
         }
     }
 }
 
-impl<A: 'static + Alarm<'static>, I: 'static + i2c::I2CMaster> Component for Bmp280Component<A, I> {
+impl<A: 'static + Alarm<'static>, I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice>
+    Component for Bmp280Component<A, I, J>
+{
     type StaticInput = (
         &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<VirtualMuxAlarm<'static, A>>,
         &'static mut MaybeUninit<[u8; capsules_extra::bmp280::BUFFER_SIZE]>,
-        &'static mut MaybeUninit<Bmp280<'static, VirtualMuxAlarm<'static, A>>>,
+        &'static mut MaybeUninit<Bmp280<'static, VirtualMuxAlarm<'static, A>, J>>,
     );
-    type Output = &'static Bmp280<'static, VirtualMuxAlarm<'static, A>>;
+    type Output = &'static Bmp280<'static, VirtualMuxAlarm<'static, A>, J>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
         let bmp280_i2c = s.0.write(I2CDevice::new(self.i2c_mux, self.i2c_address));

--- a/boards/components/src/ccs811.rs
+++ b/boards/components/src/ccs811.rs
@@ -23,6 +23,7 @@ use capsules_core::virtualizers::virtual_i2c::{I2CDevice, MuxI2C};
 use capsules_extra::ccs811::Ccs811;
 use core::mem::MaybeUninit;
 use kernel::component::Component;
+use kernel::hil::i2c;
 
 // Setup static space for the objects.
 #[macro_export]

--- a/boards/components/src/ccs811.rs
+++ b/boards/components/src/ccs811.rs
@@ -27,8 +27,9 @@ use kernel::component::Component;
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! ccs811_component_static {
-    () => {{
-        let i2c_device = kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice);
+    ($I:ty $(,)?) => {{
+        let i2c_device =
+            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<$I>);
         let buffer = kernel::static_buf!([u8; 6]);
         let ccs811 = kernel::static_buf!(capsules_extra::ccs811::Ccs811<'static>);
 
@@ -36,13 +37,13 @@ macro_rules! ccs811_component_static {
     };};
 }
 
-pub struct Ccs811Component {
-    i2c_mux: &'static MuxI2C<'static>,
+pub struct Ccs811Component<I: 'static + i2c::I2CMaster> {
+    i2c_mux: &'static MuxI2C<'static, I>,
     i2c_address: u8,
 }
 
-impl Ccs811Component {
-    pub fn new(i2c: &'static MuxI2C<'static>, i2c_address: u8) -> Self {
+impl<I: 'static + i2c::I2CMaster> Ccs811Component<I> {
+    pub fn new(i2c: &'static MuxI2C<'static, I>, i2c_address: u8) -> Self {
         Ccs811Component {
             i2c_mux: i2c,
             i2c_address,
@@ -50,9 +51,9 @@ impl Ccs811Component {
     }
 }
 
-impl Component for Ccs811Component {
+impl<I: 'static + i2c::I2CMaster> Component for Ccs811Component<I> {
     type StaticInput = (
-        &'static mut MaybeUninit<I2CDevice<'static>>,
+        &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<[u8; 6]>,
         &'static mut MaybeUninit<Ccs811<'static>>,
     );

--- a/boards/components/src/ft6x06.rs
+++ b/boards/components/src/ft6x06.rs
@@ -17,12 +17,14 @@ use capsules_extra::ft6x06::NO_TOUCH;
 use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::hil::gpio;
+use kernel::hil::i2c;
 
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! ft6x06_component_static {
-    () => {{
-        let i2c_device = kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice);
+    ($I:ty $(,)?) => {{
+        let i2c_device =
+            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<$I>);
         let buffer = kernel::static_buf!([u8; 17]);
         let events_buffer = kernel::static_buf!([kernel::hil::touch::TouchEvent; 2]);
         let ft6x06 = kernel::static_buf!(capsules_extra::ft6x06::Ft6x06<'static>);
@@ -31,18 +33,18 @@ macro_rules! ft6x06_component_static {
     };};
 }
 
-pub struct Ft6x06Component {
-    i2c_mux: &'static MuxI2C<'static>,
+pub struct Ft6x06Component<I: 'static + i2c::I2CMaster> {
+    i2c_mux: &'static MuxI2C<'static, I>,
     i2c_address: u8,
     interrupt_pin: &'static dyn gpio::InterruptPin<'static>,
 }
 
-impl Ft6x06Component {
+impl<I: 'static + i2c::I2CMaster> Ft6x06Component<I> {
     pub fn new(
-        i2c_mux: &'static MuxI2C<'static>,
+        i2c_mux: &'static MuxI2C<'static, I>,
         i2c_address: u8,
         pin: &'static dyn gpio::InterruptPin,
-    ) -> Ft6x06Component {
+    ) -> Ft6x06Component<I> {
         Ft6x06Component {
             i2c_mux,
             i2c_address,
@@ -51,9 +53,9 @@ impl Ft6x06Component {
     }
 }
 
-impl Component for Ft6x06Component {
+impl<I: 'static + i2c::I2CMaster> Component for Ft6x06Component<I> {
     type StaticInput = (
-        &'static mut MaybeUninit<I2CDevice<'static>>,
+        &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<Ft6x06<'static>>,
         &'static mut MaybeUninit<[u8; 17]>,
         &'static mut MaybeUninit<[kernel::hil::touch::TouchEvent; 2]>,

--- a/boards/components/src/ft6x06.rs
+++ b/boards/components/src/ft6x06.rs
@@ -33,34 +33,36 @@ macro_rules! ft6x06_component_static {
     };};
 }
 
-pub struct Ft6x06Component<I: 'static + i2c::I2CMaster> {
+pub struct Ft6x06Component<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> {
     i2c_mux: &'static MuxI2C<'static, I>,
     i2c_address: u8,
     interrupt_pin: &'static dyn gpio::InterruptPin<'static>,
+    i2c_device: PhantomData<J>,
 }
 
-impl<I: 'static + i2c::I2CMaster> Ft6x06Component<I> {
+impl<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> Ft6x06Component<I, J> {
     pub fn new(
         i2c_mux: &'static MuxI2C<'static, I>,
         i2c_address: u8,
         pin: &'static dyn gpio::InterruptPin,
-    ) -> Ft6x06Component<I> {
+    ) -> Ft6x06Component<I, J> {
         Ft6x06Component {
             i2c_mux,
             i2c_address,
             interrupt_pin: pin,
+            i2c_device: PhantomData,
         }
     }
 }
 
-impl<I: 'static + i2c::I2CMaster> Component for Ft6x06Component<I> {
+impl<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> Component for Ft6x06Component<I, J> {
     type StaticInput = (
         &'static mut MaybeUninit<I2CDevice<'static, I>>,
-        &'static mut MaybeUninit<Ft6x06<'static>>,
+        &'static mut MaybeUninit<Ft6x06<'static, J>>,
         &'static mut MaybeUninit<[u8; 17]>,
         &'static mut MaybeUninit<[kernel::hil::touch::TouchEvent; 2]>,
     );
-    type Output = &'static Ft6x06<'static>;
+    type Output = &'static Ft6x06<'static, J>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let ft6x06_i2c = static_buffer

--- a/boards/components/src/ft6x06.rs
+++ b/boards/components/src/ft6x06.rs
@@ -27,7 +27,12 @@ macro_rules! ft6x06_component_static {
             kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<$I>);
         let buffer = kernel::static_buf!([u8; 17]);
         let events_buffer = kernel::static_buf!([kernel::hil::touch::TouchEvent; 2]);
-        let ft6x06 = kernel::static_buf!(capsules_extra::ft6x06::Ft6x06<'static>);
+        let ft6x06 = kernel::static_buf!(
+            capsules_extra::ft6x06::Ft6x06<
+                'static,
+                capsules_core::virtualizers::virtual_i2c::I2CDevice<$I>,
+            >
+        );
 
         (i2c_device, ft6x06, buffer, events_buffer)
     };};

--- a/boards/components/src/ft6x06.rs
+++ b/boards/components/src/ft6x06.rs
@@ -33,36 +33,34 @@ macro_rules! ft6x06_component_static {
     };};
 }
 
-pub struct Ft6x06Component<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> {
+pub struct Ft6x06Component<I: 'static + i2c::I2CMaster> {
     i2c_mux: &'static MuxI2C<'static, I>,
     i2c_address: u8,
     interrupt_pin: &'static dyn gpio::InterruptPin<'static>,
-    i2c_device: PhantomData<J>,
 }
 
-impl<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> Ft6x06Component<I, J> {
+impl<I: 'static + i2c::I2CMaster> Ft6x06Component<I> {
     pub fn new(
         i2c_mux: &'static MuxI2C<'static, I>,
         i2c_address: u8,
         pin: &'static dyn gpio::InterruptPin,
-    ) -> Ft6x06Component<I, J> {
+    ) -> Ft6x06Component<I> {
         Ft6x06Component {
             i2c_mux,
             i2c_address,
             interrupt_pin: pin,
-            i2c_device: PhantomData,
         }
     }
 }
 
-impl<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> Component for Ft6x06Component<I, J> {
+impl<I: 'static + i2c::I2CMaster> Component for Ft6x06Component<I> {
     type StaticInput = (
         &'static mut MaybeUninit<I2CDevice<'static, I>>,
-        &'static mut MaybeUninit<Ft6x06<'static, J>>,
+        &'static mut MaybeUninit<Ft6x06<'static, I2CDevice<'static, I>>>,
         &'static mut MaybeUninit<[u8; 17]>,
         &'static mut MaybeUninit<[kernel::hil::touch::TouchEvent; 2]>,
     );
-    type Output = &'static Ft6x06<'static, J>;
+    type Output = &'static Ft6x06<'static, I2CDevice<'static, I>>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let ft6x06_i2c = static_buffer

--- a/boards/components/src/fxos8700.rs
+++ b/boards/components/src/fxos8700.rs
@@ -24,11 +24,13 @@ use kernel::component::Component;
 use core::mem::MaybeUninit;
 use kernel::hil;
 use kernel::hil::gpio;
+use kernel::hil::i2c;
 
 #[macro_export]
 macro_rules! fxos8700_component_static {
-    () => {{
-        let i2c_device = kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice);
+    ($I:ty $(,)?) => {{
+        let i2c_device =
+            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<$I>);
         let buffer = kernel::static_buf!([u8; capsules_extra::fxos8700cq::BUF_LEN]);
         let fxo = kernel::static_buf!(capsules_extra::fxos8700cq::Fxos8700cq<'static>);
 
@@ -36,18 +38,18 @@ macro_rules! fxos8700_component_static {
     };};
 }
 
-pub struct Fxos8700Component {
-    i2c_mux: &'static MuxI2C<'static>,
+pub struct Fxos8700Component<I: 'static + i2c::I2CMaster> {
+    i2c_mux: &'static MuxI2C<'static, I>,
     i2c_address: u8,
     gpio: &'static dyn gpio::InterruptPin<'static>,
 }
 
-impl Fxos8700Component {
+impl<I: 'static + i2c::I2CMaster> Fxos8700Component<I> {
     pub fn new<'a>(
-        i2c: &'static MuxI2C<'static>,
+        i2c: &'static MuxI2C<'static, I>,
         i2c_address: u8,
         gpio: &'static dyn hil::gpio::InterruptPin<'static>,
-    ) -> Fxos8700Component {
+    ) -> Fxos8700Component<I> {
         Fxos8700Component {
             i2c_mux: i2c,
             i2c_address,
@@ -56,9 +58,9 @@ impl Fxos8700Component {
     }
 }
 
-impl Component for Fxos8700Component {
+impl<I: 'static + i2c::I2CMaster> Component for Fxos8700Component<I> {
     type StaticInput = (
-        &'static mut MaybeUninit<I2CDevice<'static>>,
+        &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<[u8; capsules_extra::fxos8700cq::BUF_LEN]>,
         &'static mut MaybeUninit<Fxos8700cq<'static>>,
     );

--- a/boards/components/src/hts221.rs
+++ b/boards/components/src/hts221.rs
@@ -22,7 +22,12 @@ macro_rules! hts221_component_static {
         let i2c_device =
             kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<$I>);
         let buffer = kernel::static_buf!([u8; 17]);
-        let hts221 = kernel::static_buf!(capsules_extra::hts221::Hts221<'static>);
+        let hts221 = kernel::static_buf!(
+            capsules_extra::hts221::Hts221<
+                'static,
+                capsules_core::virtualizers::virtual_i2c::I2CDevice<$I>,
+            >
+        );
 
         (i2c_device, buffer, hts221)
     };};

--- a/boards/components/src/hts221.rs
+++ b/boards/components/src/hts221.rs
@@ -28,27 +28,29 @@ macro_rules! hts221_component_static {
     };};
 }
 
-pub struct Hts221Component<I: 'static + i2c::I2CMaster> {
+pub struct Hts221Component<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> {
     i2c_mux: &'static MuxI2C<'static, I>,
     i2c_address: u8,
+    i2c_device: PhantomData<J>,
 }
 
-impl<I: 'static + i2c::I2CMaster> Hts221Component<I> {
+impl<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> Hts221Component<I, J> {
     pub fn new(i2c: &'static MuxI2C<'static, I>, i2c_address: u8) -> Self {
         Hts221Component {
             i2c_mux: i2c,
             i2c_address: i2c_address,
+            i2c_device: PhantomData,
         }
     }
 }
 
-impl<I: 'static + i2c::I2CMaster> Component for Hts221Component<I> {
+impl<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> Component for Hts221Component<I, J> {
     type StaticInput = (
         &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<[u8; 17]>,
-        &'static mut MaybeUninit<Hts221<'static>>,
+        &'static mut MaybeUninit<Hts221<'static, J>>,
     );
-    type Output = &'static Hts221<'static>;
+    type Output = &'static Hts221<'static, J>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let hts221_i2c = static_buffer

--- a/boards/components/src/hts221.rs
+++ b/boards/components/src/hts221.rs
@@ -28,29 +28,27 @@ macro_rules! hts221_component_static {
     };};
 }
 
-pub struct Hts221Component<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> {
+pub struct Hts221Component<I: 'static + i2c::I2CMaster> {
     i2c_mux: &'static MuxI2C<'static, I>,
     i2c_address: u8,
-    i2c_device: PhantomData<J>,
 }
 
-impl<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> Hts221Component<I, J> {
+impl<I: 'static + i2c::I2CMaster> Hts221Component<I> {
     pub fn new(i2c: &'static MuxI2C<'static, I>, i2c_address: u8) -> Self {
         Hts221Component {
             i2c_mux: i2c,
             i2c_address: i2c_address,
-            i2c_device: PhantomData,
         }
     }
 }
 
-impl<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> Component for Hts221Component<I, J> {
+impl<I: 'static + i2c::I2CMaster> Component for Hts221Component<I> {
     type StaticInput = (
         &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<[u8; 17]>,
-        &'static mut MaybeUninit<Hts221<'static, J>>,
+        &'static mut MaybeUninit<Hts221<'static, I2CDevice<'static, I>>>,
     );
-    type Output = &'static Hts221<'static, J>;
+    type Output = &'static Hts221<'static, I2CDevice<'static, I>>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let hts221_i2c = static_buffer

--- a/boards/components/src/hts221.rs
+++ b/boards/components/src/hts221.rs
@@ -13,12 +13,14 @@ use capsules_core::virtualizers::virtual_i2c::{I2CDevice, MuxI2C};
 use capsules_extra::hts221::Hts221;
 use core::mem::MaybeUninit;
 use kernel::component::Component;
+use kernel::hil::i2c;
 
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! hts221_component_static {
-    () => {{
-        let i2c_device = kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice);
+    ($I:ty $(,)?) => {{
+        let i2c_device =
+            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<$I>);
         let buffer = kernel::static_buf!([u8; 17]);
         let hts221 = kernel::static_buf!(capsules_extra::hts221::Hts221<'static>);
 
@@ -26,13 +28,13 @@ macro_rules! hts221_component_static {
     };};
 }
 
-pub struct Hts221Component {
-    i2c_mux: &'static MuxI2C<'static>,
+pub struct Hts221Component<I: 'static + i2c::I2CMaster> {
+    i2c_mux: &'static MuxI2C<'static, I>,
     i2c_address: u8,
 }
 
-impl Hts221Component {
-    pub fn new(i2c: &'static MuxI2C<'static>, i2c_address: u8) -> Self {
+impl<I: 'static + i2c::I2CMaster> Hts221Component<I> {
+    pub fn new(i2c: &'static MuxI2C<'static, I>, i2c_address: u8) -> Self {
         Hts221Component {
             i2c_mux: i2c,
             i2c_address: i2c_address,
@@ -40,9 +42,9 @@ impl Hts221Component {
     }
 }
 
-impl Component for Hts221Component {
+impl<I: 'static + i2c::I2CMaster> Component for Hts221Component<I> {
     type StaticInput = (
-        &'static mut MaybeUninit<I2CDevice<'static>>,
+        &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<[u8; 17]>,
         &'static mut MaybeUninit<Hts221<'static>>,
     );

--- a/boards/components/src/i2c.rs
+++ b/boards/components/src/i2c.rs
@@ -28,6 +28,9 @@ macro_rules! i2c_mux_component_static {
     ($I:ty $(,)?) => {{
         kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::MuxI2C<'static, $I>)
     };};
+    ($I:ty, $S:ty $(,)?) => {{
+        kernel::static_buf!(capsules::virtual_i2c::MuxI2C<'static, $I, $S>)
+    };};
 }
 
 #[macro_export]

--- a/boards/components/src/isl29035.rs
+++ b/boards/components/src/isl29035.rs
@@ -31,17 +31,18 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
+use kernel::hil::i2c;
 use kernel::hil::time::{self, Alarm};
 
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! isl29035_component_static {
-    ($A:ty $(,)?) => {{
+    ($A:ty $(,)?, $I:ty $(,)?) => {{
         let alarm = kernel::static_buf!(
             capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, $A>
         );
         let i2c_device =
-            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<'static>);
+            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, $I>);
         let i2c_buffer = kernel::static_buf!([u8; capsules_extra::isl29035::BUF_LEN]);
         let isl29035 = kernel::static_buf!(
             capsules_extra::isl29035::Isl29035<
@@ -61,13 +62,13 @@ macro_rules! ambient_light_component_static {
     };};
 }
 
-pub struct Isl29035Component<A: 'static + time::Alarm<'static>> {
-    i2c_mux: &'static MuxI2C<'static>,
+pub struct Isl29035Component<A: 'static + time::Alarm<'static>, I: 'static + i2c::I2CMaster> {
+    i2c_mux: &'static MuxI2C<'static, I>,
     alarm_mux: &'static MuxAlarm<'static, A>,
 }
 
-impl<A: 'static + time::Alarm<'static>> Isl29035Component<A> {
-    pub fn new(i2c: &'static MuxI2C<'static>, alarm: &'static MuxAlarm<'static, A>) -> Self {
+impl<A: 'static + time::Alarm<'static>, I: 'static + i2c::I2CMaster> Isl29035Component<A, I> {
+    pub fn new(i2c: &'static MuxI2C<'static, I>, alarm: &'static MuxAlarm<'static, A>) -> Self {
         Isl29035Component {
             i2c_mux: i2c,
             alarm_mux: alarm,
@@ -75,10 +76,12 @@ impl<A: 'static + time::Alarm<'static>> Isl29035Component<A> {
     }
 }
 
-impl<A: 'static + time::Alarm<'static>> Component for Isl29035Component<A> {
+impl<A: 'static + time::Alarm<'static>, I: 'static + i2c::I2CMaster> Component
+    for Isl29035Component<A, I>
+{
     type StaticInput = (
         &'static mut MaybeUninit<VirtualMuxAlarm<'static, A>>,
-        &'static mut MaybeUninit<I2CDevice<'static>>,
+        &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<[u8; capsules_extra::isl29035::BUF_LEN]>,
         &'static mut MaybeUninit<Isl29035<'static, VirtualMuxAlarm<'static, A>>>,
     );

--- a/boards/components/src/isl29035.rs
+++ b/boards/components/src/isl29035.rs
@@ -37,7 +37,7 @@ use kernel::hil::time::{self, Alarm};
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! isl29035_component_static {
-    ($A:ty, $I:ty $(,)? $(,)?) => {{
+    ($A:ty, $I:ty $(,)?) => {{
         let alarm = kernel::static_buf!(
             capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, $A>
         );

--- a/boards/components/src/isl29035.rs
+++ b/boards/components/src/isl29035.rs
@@ -37,7 +37,7 @@ use kernel::hil::time::{self, Alarm};
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! isl29035_component_static {
-    ($A:ty $(,)?, $I:ty $(,)?) => {{
+    ($A:ty, $I:ty $(,)? $(,)?) => {{
         let alarm = kernel::static_buf!(
             capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, $A>
         );

--- a/boards/components/src/lps25hb.rs
+++ b/boards/components/src/lps25hb.rs
@@ -21,16 +21,15 @@ macro_rules! lps25hb_component_static {
     };};
 }
 
-pub struct Lps25hbComponent<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> {
+pub struct Lps25hbComponent<I: 'static + i2c::I2CMaster> {
     i2c_mux: &'static MuxI2C<'static, I>,
     i2c_address: u8,
     interrupt_pin: &'static dyn gpio::InterruptPin<'static>,
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
-    i2c_device: PhantomData<J>,
 }
 
-impl<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> Lps25hbComponent<I, J> {
+impl<I: 'static + i2c::I2CMaster> Lps25hbComponent<I> {
     pub fn new(
         i2c_mux: &'static MuxI2C<'static, I>,
         i2c_address: u8,
@@ -44,20 +43,17 @@ impl<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> Lps25hbComponent<
             interrupt_pin,
             board_kernel,
             driver_num,
-            i2c_device: PhantomData,
         }
     }
 }
 
-impl<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> Component
-    for Lps25hbComponent<I, J>
-{
+impl<I: 'static + i2c::I2CMaster> Component for Lps25hbComponent<I> {
     type StaticInput = (
         &'static mut MaybeUninit<I2CDevice<'static, I>>,
-        &'static mut MaybeUninit<LPS25HB<'static, J>>,
+        &'static mut MaybeUninit<LPS25HB<'static, I2CDevice<'static, I>>>,
         &'static mut MaybeUninit<[u8; capsules_extra::lps25hb::BUF_LEN]>,
     );
-    type Output = &'static LPS25HB<'static, J>;
+    type Output = &'static LPS25HB<'static, I2CDevice<'static, I>>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);

--- a/boards/components/src/lps25hb.rs
+++ b/boards/components/src/lps25hb.rs
@@ -21,15 +21,16 @@ macro_rules! lps25hb_component_static {
     };};
 }
 
-pub struct Lps25hbComponent<I: 'static + i2c::I2CMaster> {
+pub struct Lps25hbComponent<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> {
     i2c_mux: &'static MuxI2C<'static, I>,
     i2c_address: u8,
     interrupt_pin: &'static dyn gpio::InterruptPin<'static>,
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
+    i2c_device: PhantomData<J>,
 }
 
-impl<I: 'static + i2c::I2CMaster> Lps25hbComponent<I> {
+impl<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> Lps25hbComponent<I, J> {
     pub fn new(
         i2c_mux: &'static MuxI2C<'static, I>,
         i2c_address: u8,
@@ -43,17 +44,20 @@ impl<I: 'static + i2c::I2CMaster> Lps25hbComponent<I> {
             interrupt_pin,
             board_kernel,
             driver_num,
+            i2c_device: PhantomData,
         }
     }
 }
 
-impl<I: 'static + i2c::I2CMaster> Component for Lps25hbComponent<I> {
+impl<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> Component
+    for Lps25hbComponent<I, J>
+{
     type StaticInput = (
         &'static mut MaybeUninit<I2CDevice<'static, I>>,
-        &'static mut MaybeUninit<LPS25HB<'static>>,
+        &'static mut MaybeUninit<LPS25HB<'static, J>>,
         &'static mut MaybeUninit<[u8; capsules_extra::lps25hb::BUF_LEN]>,
     );
-    type Output = &'static LPS25HB<'static>;
+    type Output = &'static LPS25HB<'static, J>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);

--- a/boards/components/src/lps25hb.rs
+++ b/boards/components/src/lps25hb.rs
@@ -11,10 +11,15 @@ use kernel::hil::i2c;
 
 #[macro_export]
 macro_rules! lps25hb_component_static {
-    () => {{
+    ($I:ty $(,)?) => {{
         let i2c_device =
             kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<'static>);
-        let lps25hb = kernel::static_buf!(capsules_extra::lps25hb::LPS25HB<'static>);
+        let lps25hb = kernel::static_buf!(
+            capsules_extra::lps25hb::LPS25HB<
+                'static,
+                capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, $I>,
+            >
+        );
         let buffer = kernel::static_buf!([u8; capsules_extra::lps25hb::BUF_LEN]);
 
         (i2c_device, lps25hb, buffer)

--- a/boards/components/src/lps25hb.rs
+++ b/boards/components/src/lps25hb.rs
@@ -7,6 +7,7 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::gpio;
+use kernel::hil::i2c;
 
 #[macro_export]
 macro_rules! lps25hb_component_static {
@@ -20,17 +21,17 @@ macro_rules! lps25hb_component_static {
     };};
 }
 
-pub struct Lps25hbComponent {
-    i2c_mux: &'static MuxI2C<'static>,
+pub struct Lps25hbComponent<I: 'static + i2c::I2CMaster> {
+    i2c_mux: &'static MuxI2C<'static, I>,
     i2c_address: u8,
     interrupt_pin: &'static dyn gpio::InterruptPin<'static>,
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
 }
 
-impl Lps25hbComponent {
+impl<I: 'static + i2c::I2CMaster> Lps25hbComponent<I> {
     pub fn new(
-        i2c_mux: &'static MuxI2C<'static>,
+        i2c_mux: &'static MuxI2C<'static, I>,
         i2c_address: u8,
         interrupt_pin: &'static dyn gpio::InterruptPin<'static>,
         board_kernel: &'static kernel::Kernel,
@@ -46,9 +47,9 @@ impl Lps25hbComponent {
     }
 }
 
-impl Component for Lps25hbComponent {
+impl<I: 'static + i2c::I2CMaster> Component for Lps25hbComponent<I> {
     type StaticInput = (
-        &'static mut MaybeUninit<I2CDevice<'static>>,
+        &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<LPS25HB<'static>>,
         &'static mut MaybeUninit<[u8; capsules_extra::lps25hb::BUF_LEN]>,
     );

--- a/boards/components/src/lsm303agr.rs
+++ b/boards/components/src/lsm303agr.rs
@@ -43,23 +43,22 @@ macro_rules! lsm303agr_component_static {
     };};
 }
 
-pub struct Lsm303agrI2CComponent<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> {
+pub struct Lsm303agrI2CComponent<I: 'static + i2c::I2CMaster> {
     i2c_mux: &'static MuxI2C<'static, I>,
     accelerometer_i2c_address: u8,
     magnetometer_i2c_address: u8,
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
-    i2c_device: PhantomData<J>,
 }
 
-impl<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> Lsm303agrI2CComponent<I, J> {
+impl<I: 'static + i2c::I2CMaster> Lsm303agrI2CComponent<I> {
     pub fn new(
         i2c_mux: &'static MuxI2C<'static, I>,
         accelerometer_i2c_address: Option<u8>,
         magnetometer_i2c_address: Option<u8>,
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
-    ) -> Lsm303agrI2CComponent<I, J> {
+    ) -> Lsm303agrI2CComponent<I> {
         Lsm303agrI2CComponent {
             i2c_mux,
             accelerometer_i2c_address: accelerometer_i2c_address
@@ -68,21 +67,18 @@ impl<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> Lsm303agrI2CCompo
                 .unwrap_or(lsm303xx::MAGNETOMETER_BASE_ADDRESS),
             board_kernel,
             driver_num,
-            i2c_device: PhantomData,
         }
     }
 }
 
-impl<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> Component
-    for Lsm303agrI2CComponent<I, J>
-{
+impl<I: 'static + i2c::I2CMaster> Component for Lsm303agrI2CComponent<I> {
     type StaticInput = (
         &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<[u8; 8]>,
-        &'static mut MaybeUninit<Lsm303agrI2C<'static, J>>,
+        &'static mut MaybeUninit<Lsm303agrI2C<'static, I2CDevice<'static, I>>>,
     );
-    type Output = &'static Lsm303agrI2C<'static, J>;
+    type Output = &'static Lsm303agrI2C<'static, I2CDevice<'static, I>>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);

--- a/boards/components/src/lsm303agr.rs
+++ b/boards/components/src/lsm303agr.rs
@@ -34,10 +34,15 @@ macro_rules! lsm303agr_component_static {
     ($I:ty $(,)?) => {{
         let buffer = kernel::static_buf!([u8; 8]);
         let accelerometer_i2c =
-            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<I>);
+            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<$I>);
         let magnetometer_i2c =
-            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<I>);
-        let lsm303agr = kernel::static_buf!(capsules_extra::lsm303agr::Lsm303agrI2C<'static>);
+            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<$I>);
+        let lsm303agr = kernel::static_buf!(
+            capsules_extra::lsm303agr::Lsm303agrI2C<
+                'static,
+                capsules_core::virtualizers::virtual_i2c::I2CDevice<$I>,
+            >
+        );
 
         (accelerometer_i2c, magnetometer_i2c, buffer, lsm303agr)
     };};

--- a/boards/components/src/lsm303agr.rs
+++ b/boards/components/src/lsm303agr.rs
@@ -26,38 +26,39 @@ use core::mem::MaybeUninit;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
+use kernel::hil::i2c;
 
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! lsm303agr_component_static {
-    () => {{
+    ($I:ty $(,)?) => {{
         let buffer = kernel::static_buf!([u8; 8]);
         let accelerometer_i2c =
-            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice);
+            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<I>);
         let magnetometer_i2c =
-            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice);
+            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<I>);
         let lsm303agr = kernel::static_buf!(capsules_extra::lsm303agr::Lsm303agrI2C<'static>);
 
         (accelerometer_i2c, magnetometer_i2c, buffer, lsm303agr)
     };};
 }
 
-pub struct Lsm303agrI2CComponent {
-    i2c_mux: &'static MuxI2C<'static>,
+pub struct Lsm303agrI2CComponent<I: 'static + i2c::I2CMaster> {
+    i2c_mux: &'static MuxI2C<'static, I>,
     accelerometer_i2c_address: u8,
     magnetometer_i2c_address: u8,
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
 }
 
-impl Lsm303agrI2CComponent {
+impl<I: 'static + i2c::I2CMaster> Lsm303agrI2CComponent<I> {
     pub fn new(
-        i2c_mux: &'static MuxI2C<'static>,
+        i2c_mux: &'static MuxI2C<'static, I>,
         accelerometer_i2c_address: Option<u8>,
         magnetometer_i2c_address: Option<u8>,
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
-    ) -> Lsm303agrI2CComponent {
+    ) -> Lsm303agrI2CComponent<I> {
         Lsm303agrI2CComponent {
             i2c_mux,
             accelerometer_i2c_address: accelerometer_i2c_address
@@ -70,10 +71,10 @@ impl Lsm303agrI2CComponent {
     }
 }
 
-impl Component for Lsm303agrI2CComponent {
+impl<I: 'static + i2c::I2CMaster> Component for Lsm303agrI2CComponent<I> {
     type StaticInput = (
-        &'static mut MaybeUninit<I2CDevice<'static>>,
-        &'static mut MaybeUninit<I2CDevice<'static>>,
+        &'static mut MaybeUninit<I2CDevice<'static, I>>,
+        &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<[u8; 8]>,
         &'static mut MaybeUninit<Lsm303agrI2C<'static>>,
     );

--- a/boards/components/src/lsm303agr.rs
+++ b/boards/components/src/lsm303agr.rs
@@ -43,22 +43,23 @@ macro_rules! lsm303agr_component_static {
     };};
 }
 
-pub struct Lsm303agrI2CComponent<I: 'static + i2c::I2CMaster> {
+pub struct Lsm303agrI2CComponent<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> {
     i2c_mux: &'static MuxI2C<'static, I>,
     accelerometer_i2c_address: u8,
     magnetometer_i2c_address: u8,
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
+    i2c_device: PhantomData<J>,
 }
 
-impl<I: 'static + i2c::I2CMaster> Lsm303agrI2CComponent<I> {
+impl<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> Lsm303agrI2CComponent<I, J> {
     pub fn new(
         i2c_mux: &'static MuxI2C<'static, I>,
         accelerometer_i2c_address: Option<u8>,
         magnetometer_i2c_address: Option<u8>,
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
-    ) -> Lsm303agrI2CComponent<I> {
+    ) -> Lsm303agrI2CComponent<I, J> {
         Lsm303agrI2CComponent {
             i2c_mux,
             accelerometer_i2c_address: accelerometer_i2c_address
@@ -67,18 +68,21 @@ impl<I: 'static + i2c::I2CMaster> Lsm303agrI2CComponent<I> {
                 .unwrap_or(lsm303xx::MAGNETOMETER_BASE_ADDRESS),
             board_kernel,
             driver_num,
+            i2c_device: PhantomData,
         }
     }
 }
 
-impl<I: 'static + i2c::I2CMaster> Component for Lsm303agrI2CComponent<I> {
+impl<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> Component
+    for Lsm303agrI2CComponent<I, J>
+{
     type StaticInput = (
         &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<[u8; 8]>,
-        &'static mut MaybeUninit<Lsm303agrI2C<'static>>,
+        &'static mut MaybeUninit<Lsm303agrI2C<'static, J>>,
     );
-    type Output = &'static Lsm303agrI2C<'static>;
+    type Output = &'static Lsm303agrI2C<'static, J>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);

--- a/boards/components/src/lsm303dlhc.rs
+++ b/boards/components/src/lsm303dlhc.rs
@@ -31,10 +31,15 @@ macro_rules! lsm303dlhc_component_static {
     ($I:ty $(,)?) => {{
         let buffer = kernel::static_buf!([u8; 8]);
         let accelerometer_i2c =
-            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<I>);
+            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<$I>);
         let magnetometer_i2c =
-            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<I>);
-        let lsm303dlhc = kernel::static_buf!(capsules_extra::lsm303dlhc::Lsm303dlhcI2C<'static>);
+            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<$I>);
+        let lsm303dlhc = kernel::static_buf!(
+            capsules_extra::lsm303dlhc::Lsm303dlhcI2C<
+                'static,
+                capsules_core::virtualizers::virtual_i2c::I2CDevice<$I>,
+            >
+        );
 
         (accelerometer_i2c, magnetometer_i2c, buffer, lsm303dlhc)
     };};

--- a/boards/components/src/lsm303dlhc.rs
+++ b/boards/components/src/lsm303dlhc.rs
@@ -23,38 +23,39 @@ use capsules_extra::lsm303dlhc::Lsm303dlhcI2C;
 use capsules_extra::lsm303xx;
 use core::mem::MaybeUninit;
 use kernel::component::Component;
+use kernel::hil::i2c;
 
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! lsm303dlhc_component_static {
-    () => {{
+    ($I:ty $(,)?) => {{
         let buffer = kernel::static_buf!([u8; 8]);
         let accelerometer_i2c =
-            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice);
+            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<I>);
         let magnetometer_i2c =
-            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice);
+            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<I>);
         let lsm303dlhc = kernel::static_buf!(capsules_extra::lsm303dlhc::Lsm303dlhcI2C<'static>);
 
         (accelerometer_i2c, magnetometer_i2c, buffer, lsm303dlhc)
     };};
 }
 
-pub struct Lsm303dlhcI2CComponent {
-    i2c_mux: &'static MuxI2C<'static>,
+pub struct Lsm303dlhcI2CComponent<I: 'static + i2c::I2CMaster> {
+    i2c_mux: &'static MuxI2C<'static, I>,
     accelerometer_i2c_address: u8,
     magnetometer_i2c_address: u8,
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
 }
 
-impl Lsm303dlhcI2CComponent {
+impl<I: 'static + i2c::I2CMaster> Lsm303dlhcI2CComponent<I> {
     pub fn new(
-        i2c_mux: &'static MuxI2C<'static>,
+        i2c_mux: &'static MuxI2C<'static, I>,
         accelerometer_i2c_address: Option<u8>,
         magnetometer_i2c_address: Option<u8>,
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
-    ) -> Lsm303dlhcI2CComponent {
+    ) -> Lsm303dlhcI2CComponent<I> {
         Lsm303dlhcI2CComponent {
             i2c_mux,
             accelerometer_i2c_address: accelerometer_i2c_address
@@ -67,10 +68,10 @@ impl Lsm303dlhcI2CComponent {
     }
 }
 
-impl Component for Lsm303dlhcI2CComponent {
+impl<I: 'static + i2c::I2CMaster> Component for Lsm303dlhcI2CComponent<I> {
     type StaticInput = (
-        &'static mut MaybeUninit<I2CDevice<'static>>,
-        &'static mut MaybeUninit<I2CDevice<'static>>,
+        &'static mut MaybeUninit<I2CDevice<'static, I>>,
+        &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<[u8; 8]>,
         &'static mut MaybeUninit<Lsm303dlhcI2C<'static>>,
     );

--- a/boards/components/src/lsm303dlhc.rs
+++ b/boards/components/src/lsm303dlhc.rs
@@ -40,23 +40,22 @@ macro_rules! lsm303dlhc_component_static {
     };};
 }
 
-pub struct Lsm303dlhcI2CComponent<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> {
+pub struct Lsm303dlhcI2CComponent<I: 'static + i2c::I2CMaster> {
     i2c_mux: &'static MuxI2C<'static, I>,
     accelerometer_i2c_address: u8,
     magnetometer_i2c_address: u8,
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
-    i2c_device: PhantomData<J>,
 }
 
-impl<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> Lsm303dlhcI2CComponent<I, J> {
+impl<I: 'static + i2c::I2CMaster> Lsm303dlhcI2CComponent<I> {
     pub fn new(
         i2c_mux: &'static MuxI2C<'static, I>,
         accelerometer_i2c_address: Option<u8>,
         magnetometer_i2c_address: Option<u8>,
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
-    ) -> Lsm303dlhcI2CComponent<I, J> {
+    ) -> Lsm303dlhcI2CComponent<I> {
         Lsm303dlhcI2CComponent {
             i2c_mux,
             accelerometer_i2c_address: accelerometer_i2c_address
@@ -65,21 +64,18 @@ impl<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> Lsm303dlhcI2CComp
                 .unwrap_or(lsm303xx::MAGNETOMETER_BASE_ADDRESS),
             board_kernel,
             driver_num,
-            i2c_device: PhantomData,
         }
     }
 }
 
-impl<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> Component
-    for Lsm303dlhcI2CComponent<I, J>
-{
+impl<I: 'static + i2c::I2CMaster> Component for Lsm303dlhcI2CComponent<I> {
     type StaticInput = (
         &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<[u8; 8]>,
-        &'static mut MaybeUninit<Lsm303dlhcI2C<'static, J>>,
+        &'static mut MaybeUninit<Lsm303dlhcI2C<'static, I2CDevice<'static, I>>>,
     );
-    type Output = &'static Lsm303dlhcI2C<'static, J>;
+    type Output = &'static Lsm303dlhcI2C<'static, I2CDevice<'static, I>>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let grant_cap =

--- a/boards/components/src/lsm303dlhc.rs
+++ b/boards/components/src/lsm303dlhc.rs
@@ -40,22 +40,23 @@ macro_rules! lsm303dlhc_component_static {
     };};
 }
 
-pub struct Lsm303dlhcI2CComponent<I: 'static + i2c::I2CMaster> {
+pub struct Lsm303dlhcI2CComponent<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> {
     i2c_mux: &'static MuxI2C<'static, I>,
     accelerometer_i2c_address: u8,
     magnetometer_i2c_address: u8,
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
+    i2c_device: PhantomData<J>,
 }
 
-impl<I: 'static + i2c::I2CMaster> Lsm303dlhcI2CComponent<I> {
+impl<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> Lsm303dlhcI2CComponent<I, J> {
     pub fn new(
         i2c_mux: &'static MuxI2C<'static, I>,
         accelerometer_i2c_address: Option<u8>,
         magnetometer_i2c_address: Option<u8>,
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
-    ) -> Lsm303dlhcI2CComponent<I> {
+    ) -> Lsm303dlhcI2CComponent<I, J> {
         Lsm303dlhcI2CComponent {
             i2c_mux,
             accelerometer_i2c_address: accelerometer_i2c_address
@@ -64,18 +65,21 @@ impl<I: 'static + i2c::I2CMaster> Lsm303dlhcI2CComponent<I> {
                 .unwrap_or(lsm303xx::MAGNETOMETER_BASE_ADDRESS),
             board_kernel,
             driver_num,
+            i2c_device: PhantomData,
         }
     }
 }
 
-impl<I: 'static + i2c::I2CMaster> Component for Lsm303dlhcI2CComponent<I> {
+impl<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> Component
+    for Lsm303dlhcI2CComponent<I, J>
+{
     type StaticInput = (
         &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<[u8; 8]>,
-        &'static mut MaybeUninit<Lsm303dlhcI2C<'static>>,
+        &'static mut MaybeUninit<Lsm303dlhcI2C<'static, J>>,
     );
-    type Output = &'static Lsm303dlhcI2C<'static>;
+    type Output = &'static Lsm303dlhcI2C<'static, J>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let grant_cap =

--- a/boards/components/src/lsm6dsox.rs
+++ b/boards/components/src/lsm6dsox.rs
@@ -39,7 +39,12 @@ macro_rules! lsm6ds_i2c_component_static {
         let buffer = kernel::static_buf!([u8; 8]);
         let i2c_device =
             kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, $I>);
-        let lsm6dsoxtr = kernel::static_buf!(capsules_extra::lsm6dsoxtr::Lsm6dsoxtrI2C<'static>);
+        let lsm6dsoxtr = kernel::static_buf!(
+            capsules_extra::lsm6dsoxtr::Lsm6dsoxtrI2C<
+                'static,
+                capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, $I>,
+            >
+        );
 
         (i2c_device, buffer, lsm6dsoxtr)
     };};

--- a/boards/components/src/lsm6dsox.rs
+++ b/boards/components/src/lsm6dsox.rs
@@ -45,36 +45,40 @@ macro_rules! lsm6ds_i2c_component_static {
     };};
 }
 
-pub struct Lsm6dsoxtrI2CComponent<I: 'static + i2c::I2CMaster> {
+pub struct Lsm6dsoxtrI2CComponent<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> {
     i2c_mux: &'static MuxI2C<'static, I>,
     i2c_address: u8,
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
+    i2c_device: PhantomData<J>,
 }
 
-impl<I: 'static + i2c::I2CMaster> Lsm6dsoxtrI2CComponent<I> {
+impl<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> Lsm6dsoxtrI2CComponent<I, J> {
     pub fn new(
         i2c_mux: &'static MuxI2C<'static, I>,
         i2c_address: u8,
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
-    ) -> Lsm6dsoxtrI2CComponent<I> {
+    ) -> Lsm6dsoxtrI2CComponent<I, J> {
         Lsm6dsoxtrI2CComponent {
             i2c_mux,
             i2c_address,
             board_kernel,
             driver_num,
+            i2c_device: PhantomData,
         }
     }
 }
 
-impl<I: 'static + i2c::I2CMaster> Component for Lsm6dsoxtrI2CComponent<I> {
+impl<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> Component
+    for Lsm6dsoxtrI2CComponent<I, J>
+{
     type StaticInput = (
         &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<[u8; 8]>,
-        &'static mut MaybeUninit<Lsm6dsoxtrI2C<'static>>,
+        &'static mut MaybeUninit<Lsm6dsoxtrI2C<'static, J>>,
     );
-    type Output = &'static Lsm6dsoxtrI2C<'static>;
+    type Output = &'static Lsm6dsoxtrI2C<'static, J>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);

--- a/boards/components/src/lsm6dsox.rs
+++ b/boards/components/src/lsm6dsox.rs
@@ -45,40 +45,36 @@ macro_rules! lsm6ds_i2c_component_static {
     };};
 }
 
-pub struct Lsm6dsoxtrI2CComponent<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> {
+pub struct Lsm6dsoxtrI2CComponent<I: 'static + i2c::I2CMaster> {
     i2c_mux: &'static MuxI2C<'static, I>,
     i2c_address: u8,
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
-    i2c_device: PhantomData<J>,
 }
 
-impl<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> Lsm6dsoxtrI2CComponent<I, J> {
+impl<I: 'static + i2c::I2CMaster> Lsm6dsoxtrI2CComponent<I> {
     pub fn new(
         i2c_mux: &'static MuxI2C<'static, I>,
         i2c_address: u8,
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
-    ) -> Lsm6dsoxtrI2CComponent<I, J> {
+    ) -> Lsm6dsoxtrI2CComponent<I> {
         Lsm6dsoxtrI2CComponent {
             i2c_mux,
             i2c_address,
             board_kernel,
             driver_num,
-            i2c_device: PhantomData,
         }
     }
 }
 
-impl<I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice> Component
-    for Lsm6dsoxtrI2CComponent<I, J>
-{
+impl<I: 'static + i2c::I2CMaster> Component for Lsm6dsoxtrI2CComponent<I> {
     type StaticInput = (
         &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<[u8; 8]>,
-        &'static mut MaybeUninit<Lsm6dsoxtrI2C<'static, J>>,
+        &'static mut MaybeUninit<Lsm6dsoxtrI2C<'static, I2CDevice<'static, I>>>,
     );
-    type Output = &'static Lsm6dsoxtrI2C<'static, J>;
+    type Output = &'static Lsm6dsoxtrI2C<'static, I2CDevice<'static, I>>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);

--- a/boards/components/src/lsm6dsox.rs
+++ b/boards/components/src/lsm6dsox.rs
@@ -30,34 +30,35 @@ use core::mem::MaybeUninit;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
+use kernel::hil::i2c;
 
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! lsm6ds_i2c_component_static {
-    () => {{
+    ($I:ty $(,)?) => {{
         let buffer = kernel::static_buf!([u8; 8]);
         let i2c_device =
-            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<'static>);
+            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, $I>);
         let lsm6dsoxtr = kernel::static_buf!(capsules_extra::lsm6dsoxtr::Lsm6dsoxtrI2C<'static>);
 
         (i2c_device, buffer, lsm6dsoxtr)
     };};
 }
 
-pub struct Lsm6dsoxtrI2CComponent {
-    i2c_mux: &'static MuxI2C<'static>,
+pub struct Lsm6dsoxtrI2CComponent<I: 'static + i2c::I2CMaster> {
+    i2c_mux: &'static MuxI2C<'static, I>,
     i2c_address: u8,
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
 }
 
-impl Lsm6dsoxtrI2CComponent {
+impl<I: 'static + i2c::I2CMaster> Lsm6dsoxtrI2CComponent<I> {
     pub fn new(
-        i2c_mux: &'static MuxI2C<'static>,
+        i2c_mux: &'static MuxI2C<'static, I>,
         i2c_address: u8,
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
-    ) -> Lsm6dsoxtrI2CComponent {
+    ) -> Lsm6dsoxtrI2CComponent<I> {
         Lsm6dsoxtrI2CComponent {
             i2c_mux,
             i2c_address,
@@ -67,9 +68,9 @@ impl Lsm6dsoxtrI2CComponent {
     }
 }
 
-impl Component for Lsm6dsoxtrI2CComponent {
+impl<I: 'static + i2c::I2CMaster> Component for Lsm6dsoxtrI2CComponent<I> {
     type StaticInput = (
-        &'static mut MaybeUninit<I2CDevice<'static>>,
+        &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<[u8; 8]>,
         &'static mut MaybeUninit<Lsm6dsoxtrI2C<'static>>,
     );

--- a/boards/components/src/ltc294x.rs
+++ b/boards/components/src/ltc294x.rs
@@ -18,6 +18,7 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::gpio;
+use kernel::hil::i2c;
 
 #[macro_export]
 macro_rules! ltc294x_component_static {
@@ -38,15 +39,15 @@ macro_rules! ltc294x_driver_component_static {
     };};
 }
 
-pub struct Ltc294xComponent {
-    i2c_mux: &'static MuxI2C<'static>,
+pub struct Ltc294xComponent<I: 'static + i2c::I2CMaster> {
+    i2c_mux: &'static MuxI2C<'static, I>,
     i2c_address: u8,
     interrupt_pin: Option<&'static dyn gpio::InterruptPin<'static>>,
 }
 
-impl Ltc294xComponent {
+impl<I: 'static + i2c::I2CMaster> Ltc294xComponent<I> {
     pub fn new(
-        i2c_mux: &'static MuxI2C<'static>,
+        i2c_mux: &'static MuxI2C<'static, I>,
         i2c_address: u8,
         interrupt_pin: Option<&'static dyn gpio::InterruptPin<'static>>,
     ) -> Self {
@@ -58,9 +59,9 @@ impl Ltc294xComponent {
     }
 }
 
-impl Component for Ltc294xComponent {
+impl<I: 'static + i2c::I2CMaster> Component for Ltc294xComponent<I> {
     type StaticInput = (
-        &'static mut MaybeUninit<I2CDevice<'static>>,
+        &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<LTC294X<'static>>,
         &'static mut MaybeUninit<[u8; capsules_extra::ltc294x::BUF_LEN]>,
     );

--- a/boards/components/src/ltc294x.rs
+++ b/boards/components/src/ltc294x.rs
@@ -22,10 +22,15 @@ use kernel::hil::i2c;
 
 #[macro_export]
 macro_rules! ltc294x_component_static {
-    () => {{
+    ($I:ty $(,)?) => {{
         let i2c_device =
-            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<'static>);
-        let ltc294x = kernel::static_buf!(capsules_extra::ltc294x::LTC294X<'static>);
+            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, $I>);
+        let ltc294x = kernel::static_buf!(
+            capsules_extra::ltc294x::LTC294X<
+                'static,
+                capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, $I>,
+            >
+        );
         let buffer = kernel::static_buf!([u8; capsules_extra::ltc294x::BUF_LEN]);
 
         (i2c_device, ltc294x, buffer)

--- a/boards/components/src/mlx90614.rs
+++ b/boards/components/src/mlx90614.rs
@@ -20,6 +20,7 @@ use core::mem::MaybeUninit;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
+use kernel::hil::i2c;
 
 // Setup static space for the objects.
 #[macro_export]
@@ -33,16 +34,16 @@ macro_rules! mlx90614_component_static {
     };};
 }
 
-pub struct Mlx90614SMBusComponent {
-    i2c_mux: &'static MuxI2C<'static>,
+pub struct Mlx90614SMBusComponent<I: 'static + i2c::I2CMaster> {
+    i2c_mux: &'static MuxI2C<'static, I>,
     i2c_address: u8,
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
 }
 
-impl Mlx90614SMBusComponent {
+impl<I: 'static + i2c::I2CMaster> Mlx90614SMBusComponent<I> {
     pub fn new(
-        i2c: &'static MuxI2C<'static>,
+        i2c: &'static MuxI2C<'static, I>,
         i2c_address: u8,
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
@@ -56,9 +57,9 @@ impl Mlx90614SMBusComponent {
     }
 }
 
-impl Component for Mlx90614SMBusComponent {
+impl<I: 'static + i2c::I2CMaster> Component for Mlx90614SMBusComponent<I> {
     type StaticInput = (
-        &'static mut MaybeUninit<SMBusDevice<'static>>,
+        &'static mut MaybeUninit<SMBusDevice<'static, I>>,
         &'static mut MaybeUninit<[u8; 14]>,
         &'static mut MaybeUninit<Mlx90614SMBus<'static>>,
     );

--- a/boards/components/src/sht3x.rs
+++ b/boards/components/src/sht3x.rs
@@ -41,34 +41,44 @@ macro_rules! sht3x_component_static {
     };};
 }
 
-pub struct SHT3xComponent<A: 'static + Alarm<'static>, I: 'static + i2c::I2CMaster> {
+pub struct SHT3xComponent<
+    A: 'static + Alarm<'static>,
+    I: 'static + i2c::I2CMaster,
+    J: 'static + i2c::I2CDevice,
+> {
     i2c_mux: &'static MuxI2C<'static, I>,
     i2c_address: u8,
     alarm_mux: &'static MuxAlarm<'static, A>,
+    i2c_device: PhantomData<J>,
 }
 
-impl<A: 'static + Alarm<'static>, I: 'static + i2c::I2CMaster> SHT3xComponent<A, I> {
+impl<A: 'static + Alarm<'static>, I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice>
+    SHT3xComponent<A, I, J>
+{
     pub fn new(
         i2c_mux: &'static MuxI2C<'static, I>,
         i2c_address: u8,
         alarm_mux: &'static MuxAlarm<'static, A>,
-    ) -> SHT3xComponent<A, I> {
+    ) -> SHT3xComponent<A, I, J> {
         SHT3xComponent {
             i2c_mux,
             i2c_address,
             alarm_mux,
+            i2c_device: PhantomData,
         }
     }
 }
 
-impl<A: 'static + Alarm<'static>, I: 'static + i2c::I2CMaster> Component for SHT3xComponent<A, I> {
+impl<A: 'static + Alarm<'static>, I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice>
+    Component for SHT3xComponent<A, I, J>
+{
     type StaticInput = (
         &'static mut MaybeUninit<VirtualMuxAlarm<'static, A>>,
         &'static mut MaybeUninit<I2CDevice<'static, I>>,
-        &'static mut MaybeUninit<SHT3x<'static, VirtualMuxAlarm<'static, A>>>,
+        &'static mut MaybeUninit<SHT3x<'static, VirtualMuxAlarm<'static, A>, J>>,
         &'static mut MaybeUninit<[u8; 6]>,
     );
-    type Output = &'static SHT3x<'static, VirtualMuxAlarm<'static, A>>;
+    type Output = &'static SHT3x<'static, VirtualMuxAlarm<'static, A>, J>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let sht3x_i2c = static_buffer

--- a/boards/components/src/sht3x.rs
+++ b/boards/components/src/sht3x.rs
@@ -17,15 +17,16 @@ use capsules_core::virtualizers::virtual_i2c::{I2CDevice, MuxI2C};
 use capsules_extra::sht3x::SHT3x;
 use core::mem::MaybeUninit;
 use kernel::component::Component;
+use kernel::hil::i2c;
 use kernel::hil::time::Alarm;
 
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! sht3x_component_static {
-    ($A:ty $(,)?) => {{
+    ($A:ty $(,)?, $I:ty $(,)?) => {{
         let buffer = kernel::static_buf!([u8; 6]);
         let i2c_device =
-            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<'static>);
+            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, $I>);
         let sht3x_alarm = kernel::static_buf!(
             capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, $A>
         );
@@ -40,18 +41,18 @@ macro_rules! sht3x_component_static {
     };};
 }
 
-pub struct SHT3xComponent<A: 'static + Alarm<'static>> {
-    i2c_mux: &'static MuxI2C<'static>,
+pub struct SHT3xComponent<A: 'static + Alarm<'static>, I: 'static + i2c::I2CMaster> {
+    i2c_mux: &'static MuxI2C<'static, I>,
     i2c_address: u8,
     alarm_mux: &'static MuxAlarm<'static, A>,
 }
 
-impl<A: 'static + Alarm<'static>> SHT3xComponent<A> {
+impl<A: 'static + Alarm<'static>, I: 'static + i2c::I2CMaster> SHT3xComponent<A, I> {
     pub fn new(
-        i2c_mux: &'static MuxI2C<'static>,
+        i2c_mux: &'static MuxI2C<'static, I>,
         i2c_address: u8,
         alarm_mux: &'static MuxAlarm<'static, A>,
-    ) -> SHT3xComponent<A> {
+    ) -> SHT3xComponent<A, I> {
         SHT3xComponent {
             i2c_mux,
             i2c_address,
@@ -60,10 +61,10 @@ impl<A: 'static + Alarm<'static>> SHT3xComponent<A> {
     }
 }
 
-impl<A: 'static + Alarm<'static>> Component for SHT3xComponent<A> {
+impl<A: 'static + Alarm<'static>, I: 'static + i2c::I2CMaster> Component for SHT3xComponent<A, I> {
     type StaticInput = (
         &'static mut MaybeUninit<VirtualMuxAlarm<'static, A>>,
-        &'static mut MaybeUninit<I2CDevice<'static>>,
+        &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<SHT3x<'static, VirtualMuxAlarm<'static, A>>>,
         &'static mut MaybeUninit<[u8; 6]>,
     );

--- a/boards/components/src/sht3x.rs
+++ b/boards/components/src/sht3x.rs
@@ -23,7 +23,7 @@ use kernel::hil::time::Alarm;
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! sht3x_component_static {
-    ($A:ty $(,)?, $I:ty $(,)?) => {{
+    ($A:ty, $I:ty $(,)?) => {{
         let buffer = kernel::static_buf!([u8; 6]);
         let i2c_device =
             kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, $I>);
@@ -34,6 +34,7 @@ macro_rules! sht3x_component_static {
             capsules_extra::sht3x::SHT3x<
                 'static,
                 capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, $A>,
+                capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, $I>,
             >
         );
 

--- a/boards/components/src/sht3x.rs
+++ b/boards/components/src/sht3x.rs
@@ -41,44 +41,36 @@ macro_rules! sht3x_component_static {
     };};
 }
 
-pub struct SHT3xComponent<
-    A: 'static + Alarm<'static>,
-    I: 'static + i2c::I2CMaster,
-    J: 'static + i2c::I2CDevice,
-> {
+pub struct SHT3xComponent<A: 'static + Alarm<'static>, I: 'static + i2c::I2CMaster> {
     i2c_mux: &'static MuxI2C<'static, I>,
     i2c_address: u8,
     alarm_mux: &'static MuxAlarm<'static, A>,
-    i2c_device: PhantomData<J>,
 }
 
-impl<A: 'static + Alarm<'static>, I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice>
-    SHT3xComponent<A, I, J>
-{
+impl<A: 'static + Alarm<'static>, I: 'static + i2c::I2CMaster> SHT3xComponent<A, I> {
     pub fn new(
         i2c_mux: &'static MuxI2C<'static, I>,
         i2c_address: u8,
         alarm_mux: &'static MuxAlarm<'static, A>,
-    ) -> SHT3xComponent<A, I, J> {
+    ) -> SHT3xComponent<A, I> {
         SHT3xComponent {
             i2c_mux,
             i2c_address,
             alarm_mux,
-            i2c_device: PhantomData,
         }
     }
 }
 
-impl<A: 'static + Alarm<'static>, I: 'static + i2c::I2CMaster, J: 'static + i2c::I2CDevice>
-    Component for SHT3xComponent<A, I, J>
-{
+impl<A: 'static + Alarm<'static>, I: 'static + i2c::I2CMaster> Component for SHT3xComponent<A, I> {
     type StaticInput = (
         &'static mut MaybeUninit<VirtualMuxAlarm<'static, A>>,
         &'static mut MaybeUninit<I2CDevice<'static, I>>,
-        &'static mut MaybeUninit<SHT3x<'static, VirtualMuxAlarm<'static, A>, J>>,
+        &'static mut MaybeUninit<
+            SHT3x<'static, VirtualMuxAlarm<'static, A>, I2CDevice<'static, I>>,
+        >,
         &'static mut MaybeUninit<[u8; 6]>,
     );
-    type Output = &'static SHT3x<'static, VirtualMuxAlarm<'static, A>, J>;
+    type Output = &'static SHT3x<'static, VirtualMuxAlarm<'static, A>, I2CDevice<'static, I>>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let sht3x_i2c = static_buffer

--- a/boards/components/src/si7021.rs
+++ b/boards/components/src/si7021.rs
@@ -25,7 +25,7 @@ use kernel::hil::time::{self, Alarm};
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! si7021_component_static {
-    ($A:ty $(,)?, $I:ty $(,)?) => {{
+    ($A:ty, $I:ty $(,)? ) => {{
         let alarm = kernel::static_buf!(
             capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, $A>
         );
@@ -35,6 +35,7 @@ macro_rules! si7021_component_static {
             capsules_extra::si7021::SI7021<
                 'static,
                 capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, $A>,
+                capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, $I>,
             >
         );
         let buffer = kernel::static_buf!([u8; 14]);

--- a/boards/components/src/si7021.rs
+++ b/boards/components/src/si7021.rs
@@ -13,6 +13,7 @@
 // Author: Philip Levis <pal@cs.stanford.edu>
 // Last modified: 6/20/2018
 
+use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
@@ -43,13 +44,23 @@ macro_rules! si7021_component_static {
     };};
 }
 
-pub struct SI7021Component<A: 'static + time::Alarm<'static>, I: 'static + i2c::I2CMaster> {
+pub struct SI7021Component<
+    A: 'static + time::Alarm<'static>,
+    I: 'static + i2c::I2CMaster,
+    J: 'static + i2c::I2CDevice,
+> {
     i2c_mux: &'static MuxI2C<'static, I>,
     alarm_mux: &'static MuxAlarm<'static, A>,
     i2c_address: u8,
+    i2c_device: PhantomData<J>,
 }
 
-impl<A: 'static + time::Alarm<'static>, I: 'static + i2c::I2CMaster> SI7021Component<A, I> {
+impl<
+        A: 'static + time::Alarm<'static>,
+        I: 'static + i2c::I2CMaster,
+        J: 'static + i2c::I2CDevice,
+    > SI7021Component<A, I, J>
+{
     pub fn new(
         i2c: &'static MuxI2C<'static, I>,
         alarm: &'static MuxAlarm<'static, A>,
@@ -59,20 +70,24 @@ impl<A: 'static + time::Alarm<'static>, I: 'static + i2c::I2CMaster> SI7021Compo
             i2c_mux: i2c,
             alarm_mux: alarm,
             i2c_address: i2c_address,
+            i2c_device: PhantomData,
         }
     }
 }
 
-impl<A: 'static + time::Alarm<'static>, I: 'static + i2c::I2CMaster> Component
-    for SI7021Component<A, I>
+impl<
+        A: 'static + time::Alarm<'static>,
+        I: 'static + i2c::I2CMaster,
+        J: 'static + i2c::I2CDevice,
+    > Component for SI7021Component<A, I, J>
 {
     type StaticInput = (
         &'static mut MaybeUninit<VirtualMuxAlarm<'static, A>>,
         &'static mut MaybeUninit<I2CDevice<'static, I>>,
-        &'static mut MaybeUninit<SI7021<'static, VirtualMuxAlarm<'static, A>>>,
+        &'static mut MaybeUninit<SI7021<'static, VirtualMuxAlarm<'static, A>, J>>,
         &'static mut MaybeUninit<[u8; 14]>,
     );
-    type Output = &'static SI7021<'static, VirtualMuxAlarm<'static, A>>;
+    type Output = &'static SI7021<'static, VirtualMuxAlarm<'static, A>, J>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let si7021_i2c = static_buffer

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -331,7 +331,7 @@ pub unsafe fn main() {
     .finalize(components::nrf51822_component_static!());
 
     let sensors_i2c = components::i2c::I2CMuxComponent::new(&peripherals.i2c1, None)
-        .finalize(components::i2c_mux_component_static!(sam4l::i2c::I2CHws));
+        .finalize(components::i2c_mux_component_static!(sam4l::i2c::I2CHw));
 
     // SI7021 Temperature / Humidity Sensor, address: 0x40
     let si7021 = components::si7021::SI7021Component::new(sensors_i2c, mux_alarm, 0x40).finalize(

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -331,11 +331,12 @@ pub unsafe fn main() {
     .finalize(components::nrf51822_component_static!());
 
     let sensors_i2c = components::i2c::I2CMuxComponent::new(&peripherals.i2c1, None)
-        .finalize(components::i2c_mux_component_static!());
+        .finalize(components::i2c_mux_component_static!(sam4l::i2c::I2CHws));
 
     // SI7021 Temperature / Humidity Sensor, address: 0x40
-    let si7021 = components::si7021::SI7021Component::new(sensors_i2c, mux_alarm, 0x40)
-        .finalize(components::si7021_component_static!(sam4l::ast::Ast));
+    let si7021 = components::si7021::SI7021Component::new(sensors_i2c, mux_alarm, 0x40).finalize(
+        components::si7021_component_static!(sam4l::ast::Ast, sam4l::i2c::I2CHw),
+    );
     let temp = components::temperature::TemperatureComponent::new(
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,
@@ -350,8 +351,9 @@ pub unsafe fn main() {
     .finalize(components::humidity_component_static!());
 
     // Configure the ISL29035, device address 0x44
-    let isl29035 = components::isl29035::Isl29035Component::new(sensors_i2c, mux_alarm)
-        .finalize(components::isl29035_component_static!(sam4l::ast::Ast));
+    let isl29035 = components::isl29035::Isl29035Component::new(sensors_i2c, mux_alarm).finalize(
+        components::isl29035_component_static!(sam4l::ast::Ast, sam4l::i2c::I2CHw),
+    );
     let ambient_light = components::isl29035::AmbientLightComponent::new(
         board_kernel,
         capsules_extra::ambient_light::DRIVER_NUM,
@@ -370,7 +372,7 @@ pub unsafe fn main() {
     // FXOS8700CQ accelerometer, device address 0x1e
     let fxos8700 =
         components::fxos8700::Fxos8700Component::new(sensors_i2c, 0x1e, &peripherals.pa[9])
-            .finalize(components::fxos8700_component_static!());
+            .finalize(components::fxos8700_component_static!(sam4l::i2c::I2CHw));
 
     let ninedof = components::ninedof::NineDofComponent::new(
         board_kernel,

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -428,12 +428,16 @@ pub unsafe fn main() {
     .finalize(components::nrf51822_component_static!());
 
     // # I2C and I2C Sensors
-    let mux_i2c = static_init!(MuxI2C<'static>, MuxI2C::new(&peripherals.i2c2, None));
+    let mux_i2c = static_init!(
+        MuxI2C<'static, sam4l::i2c::I2CHw>,
+        MuxI2C::new(&peripherals.i2c2, None)
+    );
     kernel::deferred_call::DeferredCallClient::register(mux_i2c);
     peripherals.i2c2.set_master_client(mux_i2c);
 
-    let isl29035 = Isl29035Component::new(mux_i2c, mux_alarm)
-        .finalize(components::isl29035_component_static!(sam4l::ast::Ast));
+    let isl29035 = Isl29035Component::new(mux_i2c, mux_alarm).finalize(
+        components::isl29035_component_static!(sam4l::ast::Ast, sam4l::i2c::I2CHw),
+    );
     let ambient_light = AmbientLightComponent::new(
         board_kernel,
         capsules_extra::ambient_light::DRIVER_NUM,
@@ -441,8 +445,9 @@ pub unsafe fn main() {
     )
     .finalize(components::ambient_light_component_static!());
 
-    let si7021 = SI7021Component::new(mux_i2c, mux_alarm, 0x40)
-        .finalize(components::si7021_component_static!(sam4l::ast::Ast));
+    let si7021 = SI7021Component::new(mux_i2c, mux_alarm, 0x40).finalize(
+        components::si7021_component_static!(sam4l::ast::Ast, sam4l::i2c::I2CHw),
+    );
     let temp = components::temperature::TemperatureComponent::new(
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,
@@ -457,7 +462,7 @@ pub unsafe fn main() {
     .finalize(components::humidity_component_static!());
 
     let fxos8700 = components::fxos8700::Fxos8700Component::new(mux_i2c, 0x1e, &peripherals.pc[13])
-        .finalize(components::fxos8700_component_static!());
+        .finalize(components::fxos8700_component_static!(sam4l::i2c::I2CHw));
 
     let ninedof = components::ninedof::NineDofComponent::new(
         board_kernel,

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -431,8 +431,9 @@ pub unsafe fn main() {
         .set_speed(imxrt1050::lpi2c::Lpi2cSpeed::Speed100k, 8);
 
     use imxrt1050::gpio::PinId;
-    let mux_i2c = components::i2c::I2CMuxComponent::new(&peripherals.lpi2c1, None)
-        .finalize(components::i2c_mux_component_static!());
+    let mux_i2c = components::i2c::I2CMuxComponent::new(&peripherals.lpi2c1, None).finalize(
+        components::i2c_mux_component_static!(imxrt1050::lpi2c::Lpi2c),
+    );
 
     // Fxos8700 sensor
     let fxos8700 = components::fxos8700::Fxos8700Component::new(
@@ -440,7 +441,9 @@ pub unsafe fn main() {
         0x1f,
         peripherals.ports.pin(PinId::AdB1_00),
     )
-    .finalize(components::fxos8700_component_static!());
+    .finalize(components::fxos8700_component_static!(
+        imxrt1050::lpi2c::Lpi2c
+    ));
 
     // Ninedof
     let ninedof = components::ninedof::NineDofComponent::new(

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -116,7 +116,7 @@ pub struct MicroBit {
     ninedof: &'static capsules_extra::ninedof::NineDof<'static>,
     lsm303agr: &'static capsules_extra::lsm303agr::Lsm303agrI2C<
         'static,
-        capsules_core::virtualizers::virtual_i2c::I2CDevice<nrf52833::i2c::TWI>,
+        capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, nrf52833::i2c::TWI>,
     >,
     temperature: &'static capsules_extra::temperature::TemperatureSensor<'static>,
     ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -453,7 +453,7 @@ pub unsafe fn main() {
     );
 
     let sensors_i2c_bus = components::i2c::I2CMuxComponent::new(&base_peripherals.twi0, None)
-        .finalize(components::i2c_mux_component_static!());
+        .finalize(components::i2c_mux_component_static!(nrf52833::i2c::TWI));
 
     // LSM303AGR
 
@@ -464,7 +464,7 @@ pub unsafe fn main() {
         board_kernel,
         capsules_extra::lsm303agr::DRIVER_NUM,
     )
-    .finalize(components::lsm303agr_component_static!());
+    .finalize(components::lsm303agr_component_static!(nrf52833::i2c::TWI));
 
     if let Err(error) = lsm303agr.configure(
         capsules_extra::lsm303xx::Lsm303AccelDataRate::DataRate25Hz,

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -114,7 +114,10 @@ pub struct MicroBit {
     button: &'static capsules_core::button::Button<'static, nrf52::gpio::GPIOPin<'static>>,
     rng: &'static capsules_core::rng::RngDriver<'static>,
     ninedof: &'static capsules_extra::ninedof::NineDof<'static>,
-    lsm303agr: &'static capsules_extra::lsm303agr::Lsm303agrI2C<'static, nrf52::i2c::TWI>,
+    lsm303agr: &'static capsules_extra::lsm303agr::Lsm303agrI2C<
+        'static,
+        capsules_core::virtualizers::virtual_i2c::I2CDevice<nrf52833::i2c::TWI>,
+    >,
     temperature: &'static capsules_extra::temperature::TemperatureSensor<'static>,
     ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     adc: &'static capsules_core::adc::AdcVirtualized<'static>,
@@ -464,7 +467,7 @@ pub unsafe fn main() {
         board_kernel,
         capsules_extra::lsm303agr::DRIVER_NUM,
     )
-    .finalize(components::lsm303agr_component_static!(nrf52833::lsm303agr));
+    .finalize(components::lsm303agr_component_static!(nrf52833::i2c::TWI));
 
     if let Err(error) = lsm303agr.configure(
         capsules_extra::lsm303xx::Lsm303AccelDataRate::DataRate25Hz,

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -114,7 +114,7 @@ pub struct MicroBit {
     button: &'static capsules_core::button::Button<'static, nrf52::gpio::GPIOPin<'static>>,
     rng: &'static capsules_core::rng::RngDriver<'static>,
     ninedof: &'static capsules_extra::ninedof::NineDof<'static>,
-    lsm303agr: &'static capsules_extra::lsm303agr::Lsm303agrI2C<'static>,
+    lsm303agr: &'static capsules_extra::lsm303agr::Lsm303agrI2C<'static, nrf52::i2c::TWI>,
     temperature: &'static capsules_extra::temperature::TemperatureSensor<'static>,
     ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     adc: &'static capsules_core::adc::AdcVirtualized<'static>,
@@ -464,7 +464,7 @@ pub unsafe fn main() {
         board_kernel,
         capsules_extra::lsm303agr::DRIVER_NUM,
     )
-    .finalize(components::lsm303agr_component_static!(nrf52833::i2c::TWI));
+    .finalize(components::lsm303agr_component_static!(nrf52833::lsm303agr));
 
     if let Err(error) = lsm303agr.configure(
         capsules_extra::lsm303xx::Lsm303AccelDataRate::DataRate25Hz,

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -476,7 +476,7 @@ pub unsafe fn main() {
     //--------------------------------------------------------------------------
 
     let sensors_i2c_bus = components::i2c::I2CMuxComponent::new(&base_peripherals.twi0, None)
-        .finalize(components::i2c_mux_component_static!());
+        .finalize(components::i2c_mux_component_static!(nrf52840::i2c::TWI));
     base_peripherals.twi0.configure(
         nrf52840::pinmux::Pinmux::new(I2C_SCL_PIN as u32),
         nrf52840::pinmux::Pinmux::new(I2C_SDA_PIN as u32),
@@ -490,7 +490,7 @@ pub unsafe fn main() {
         0x39,
         &nrf52840_peripherals.gpio_port[APDS9960_PIN],
     )
-    .finalize(components::apds9960_component_static!());
+    .finalize(components::apds9960_component_static!(nrf52840::i2c::TWI));
     let proximity = components::proximity::ProximityComponent::new(
         apds9960,
         board_kernel,
@@ -499,7 +499,7 @@ pub unsafe fn main() {
     .finalize(components::proximity_component_static!());
 
     let hts221 = components::hts221::Hts221Component::new(sensors_i2c_bus, 0x5f)
-        .finalize(components::hts221_component_static!());
+        .finalize(components::hts221_component_static!(nrf52840::i2c::TWI));
     let temperature = components::temperature::TemperatureComponent::new(
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -86,8 +86,10 @@ pub struct NanoRP2040Connect {
     adc: &'static capsules_core::adc::AdcVirtualized<'static>,
     temperature: &'static capsules_extra::temperature::TemperatureSensor<'static>,
     ninedof: &'static capsules_extra::ninedof::NineDof<'static>,
-    lsm6dsoxtr:
-        &'static capsules_extra::lsm6dsoxtr::Lsm6dsoxtrI2C<'static, rp2040::i2c::I2c<'static>>,
+    lsm6dsoxtr: &'static capsules_extra::lsm6dsoxtr::Lsm6dsoxtrI2C<
+        'static,
+        capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, rp2040::i2c::I2c<'static>>,
+    >,
 
     scheduler: &'static RoundRobinSched<'static>,
     systick: cortexm0p::systick::SysTick,

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -86,7 +86,8 @@ pub struct NanoRP2040Connect {
     adc: &'static capsules_core::adc::AdcVirtualized<'static>,
     temperature: &'static capsules_extra::temperature::TemperatureSensor<'static>,
     ninedof: &'static capsules_extra::ninedof::NineDof<'static>,
-    lsm6dsoxtr: &'static capsules_extra::lsm6dsoxtr::Lsm6dsoxtrI2C<'static, rp2040::i2c::I2c>,
+    lsm6dsoxtr:
+        &'static capsules_extra::lsm6dsoxtr::Lsm6dsoxtrI2C<'static, rp2040::i2c::I2c<'static>>,
 
     scheduler: &'static RoundRobinSched<'static>,
     systick: cortexm0p::systick::SysTick,

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -86,7 +86,7 @@ pub struct NanoRP2040Connect {
     adc: &'static capsules_core::adc::AdcVirtualized<'static>,
     temperature: &'static capsules_extra::temperature::TemperatureSensor<'static>,
     ninedof: &'static capsules_extra::ninedof::NineDof<'static>,
-    lsm6dsoxtr: &'static capsules_extra::lsm6dsoxtr::Lsm6dsoxtrI2C<'static>,
+    lsm6dsoxtr: &'static capsules_extra::lsm6dsoxtr::Lsm6dsoxtrI2C<'static, rp2040::i2c::I2c>,
 
     scheduler: &'static RoundRobinSched<'static>,
     systick: cortexm0p::systick::SysTick,
@@ -450,7 +450,7 @@ pub unsafe fn main() {
     gpio_sda.set_function(GpioFunction::I2C);
     gpio_scl.set_function(GpioFunction::I2C);
     let mux_i2c = components::i2c::I2CMuxComponent::new(&peripherals.i2c0, None)
-        .finalize(components::i2c_mux_component_static!());
+        .finalize(components::i2c_mux_component_static!(rp2040::i2c::I2c));
 
     let lsm6dsoxtr = components::lsm6dsox::Lsm6dsoxtrI2CComponent::new(
         mux_i2c,
@@ -458,7 +458,7 @@ pub unsafe fn main() {
         board_kernel,
         capsules_extra::lsm6dsoxtr::DRIVER_NUM,
     )
-    .finalize(components::lsm6ds_i2c_component_static!());
+    .finalize(components::lsm6ds_i2c_component_static!(rp2040::i2c::I2c));
 
     let ninedof = components::ninedof::NineDofComponent::new(
         board_kernel,

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -205,7 +205,7 @@ pub struct Platform {
     udp_driver: &'static capsules_extra::net::udp::UDPDriver<'static>,
     i2c_master_slave: &'static capsules_core::i2c_master_slave_driver::I2CMasterSlaveDriver<
         'static,
-        nrf52840::i2c,
+        nrf52840::i2c::TWI,
     >,
     spi_controller: &'static capsules_core::spi_controller::Spi<
         'static,
@@ -612,7 +612,7 @@ pub unsafe fn main() {
     let i2c_slave_buffer2 = static_init!([u8; 32], [0; 32]);
 
     let i2c_master_slave = static_init!(
-        I2CMasterSlaveDriver,
+        I2CMasterSlaveDriver<nrf52840::i2c::TWI>,
         I2CMasterSlaveDriver::new(
             &base_peripherals.twi1,
             i2c_master_buffer,

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -203,8 +203,10 @@ pub struct Platform {
     nonvolatile_storage:
         &'static capsules_extra::nonvolatile_storage_driver::NonvolatileStorage<'static>,
     udp_driver: &'static capsules_extra::net::udp::UDPDriver<'static>,
-    i2c_master_slave:
-        &'static capsules_core::i2c_master_slave_driver::I2CMasterSlaveDriver<'static>,
+    i2c_master_slave: &'static capsules_core::i2c_master_slave_driver::I2CMasterSlaveDriver<
+        'static,
+        nrf52840::i2c,
+    >,
     spi_controller: &'static capsules_core::spi_controller::Spi<
         'static,
         capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -548,7 +548,7 @@ pub unsafe fn main() {
     let i2c_slave_buffer2 = static_init!([u8; 32], [0; 32]);
 
     let i2c_master_slave = static_init!(
-        I2CMasterSlaveDriver,
+        I2CMasterSlaveDriver<nrf52840::i2c::TWI>,
         I2CMasterSlaveDriver::new(
             &base_peripherals.twi1,
             i2c_master_buffer,

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -127,8 +127,10 @@ pub struct Platform {
     rng: &'static capsules_core::rng::RngDriver<'static>,
     temp: &'static capsules_extra::temperature::TemperatureSensor<'static>,
     ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
-    i2c_master_slave:
-        &'static capsules_core::i2c_master_slave_driver::I2CMasterSlaveDriver<'static>,
+    i2c_master_slave: &'static capsules_core::i2c_master_slave_driver::I2CMasterSlaveDriver<
+        'static,
+        nrf52840::i2c::TWI,
+    >,
     alarm: &'static capsules_core::alarm::AlarmDriver<
         'static,
         capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -363,7 +363,7 @@ pub unsafe fn main() {
     .finalize(components::temperature_component_static!());
 
     let sensors_i2c_bus = static_init!(
-        capsules_core::virtualizers::virtual_i2c::MuxI2C<'static>,
+        capsules_core::virtualizers::virtual_i2c::MuxI2C<'static, nrf52840::i2c::TWI>,
         capsules_core::virtualizers::virtual_i2c::MuxI2C::new(&base_peripherals.twi1, None,)
     );
     sensors_i2c_bus.register();
@@ -380,7 +380,8 @@ pub unsafe fn main() {
         mux_alarm,
     )
     .finalize(components::bmp280_component_static!(
-        nrf52840::rtc::Rtc<'static>
+        nrf52840::rtc::Rtc<'static>,
+        nrf52840::i2c::TWI
     ));
 
     let temperature = components::temperature::TemperatureComponent::new(

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -74,7 +74,13 @@ struct STM32F3Discovery {
     button: &'static capsules_core::button::Button<'static, stm32f303xc::gpio::Pin<'static>>,
     ninedof: &'static capsules_extra::ninedof::NineDof<'static>,
     l3gd20: &'static capsules_extra::l3gd20::L3gd20Spi<'static>,
-    lsm303dlhc: &'static capsules_extra::lsm303dlhc::Lsm303dlhcI2C<'static>,
+    lsm303dlhc: &'static capsules_extra::lsm303dlhc::Lsm303dlhcI2C<
+        'static,
+        capsules_core::virtualizers::virtual_i2c::I2CDevice<
+            'static,
+            stm32f303xc::i2c::I2C<'static>,
+        >,
+    >,
     temp: &'static capsules_extra::temperature::TemperatureSensor<'static>,
     alarm: &'static capsules_core::alarm::AlarmDriver<
         'static,

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -668,7 +668,7 @@ pub unsafe fn main() {
     // LSM303DLHC
 
     let mux_i2c = components::i2c::I2CMuxComponent::new(&peripherals.i2c1, None)
-        .finalize(components::i2c_mux_component_static!());
+        .finalize(components::i2c_mux_component_static!(stm32f303xc::i2c::I2C));
 
     let lsm303dlhc = components::lsm303dlhc::Lsm303dlhcI2CComponent::new(
         mux_i2c,
@@ -677,7 +677,9 @@ pub unsafe fn main() {
         board_kernel,
         capsules_extra::lsm303dlhc::DRIVER_NUM,
     )
-    .finalize(components::lsm303dlhc_component_static!());
+    .finalize(components::lsm303dlhc_component_static!(
+        stm32f303xc::i2c::I2C
+    ));
 
     if let Err(error) = lsm303dlhc.configure(
         lsm303xx::Lsm303AccelDataRate::DataRate25Hz,

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -613,7 +613,7 @@ pub unsafe fn main() {
     // FT6206
 
     let mux_i2c = components::i2c::I2CMuxComponent::new(&base_peripherals.i2c1, None)
-        .finalize(components::i2c_mux_component_static!());
+        .finalize(components::i2c_mux_component_static!(stm32f412g::i2c::I2C));
 
     let ft6x06 = components::ft6x06::Ft6x06Component::new(
         mux_i2c,
@@ -623,7 +623,7 @@ pub unsafe fn main() {
             .get_pin(stm32f412g::gpio::PinId::PG05)
             .unwrap(),
     )
-    .finalize(components::ft6x06_component_static!());
+    .finalize(components::ft6x06_component_static!(stm32f412g::i2c::I2C));
 
     let bus = components::bus::Bus8080BusComponent::new(&base_peripherals.fsmc).finalize(
         components::bus8080_bus_component_static!(stm32f412g::fsmc::Fsmc,),

--- a/capsules/core/src/i2c_master_slave_driver.rs
+++ b/capsules/core/src/i2c_master_slave_driver.rs
@@ -56,8 +56,8 @@ enum MasterAction {
     WriteRead(u8),
 }
 
-pub struct I2CMasterSlaveDriver<'a> {
-    i2c: &'a dyn hil::i2c::I2CMasterSlave,
+pub struct I2CMasterSlaveDriver<'a, I: hil::i2c::I2CMasterSlave> {
+    i2c: &'a I,
     listening: Cell<bool>,
     master_action: Cell<MasterAction>, // Whether we issued a write or read as master
     master_buffer: TakeCell<'static, [u8]>,
@@ -72,9 +72,9 @@ pub struct I2CMasterSlaveDriver<'a> {
     >,
 }
 
-impl<'a> I2CMasterSlaveDriver<'a> {
+impl<'a, I: hil::i2c::I2CMasterSlave> I2CMasterSlaveDriver<'a, I> {
     pub fn new(
-        i2c: &'a dyn hil::i2c::I2CMasterSlave,
+        i2c: &'a I,
         master_buffer: &'static mut [u8],
         slave_buffer1: &'static mut [u8],
         slave_buffer2: &'static mut [u8],
@@ -84,7 +84,7 @@ impl<'a> I2CMasterSlaveDriver<'a> {
             AllowRoCount<{ ro_allow::COUNT }>,
             AllowRwCount<{ rw_allow::COUNT }>,
         >,
-    ) -> I2CMasterSlaveDriver<'a> {
+    ) -> I2CMasterSlaveDriver<'a, I> {
         I2CMasterSlaveDriver {
             i2c,
             listening: Cell::new(false),
@@ -98,7 +98,7 @@ impl<'a> I2CMasterSlaveDriver<'a> {
     }
 }
 
-impl hil::i2c::I2CHwMasterClient for I2CMasterSlaveDriver<'_> {
+impl<I: hil::i2c::I2CMasterSlave> hil::i2c::I2CHwMasterClient for I2CMasterSlaveDriver<'_, I> {
     fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), hil::i2c::Error>) {
         // Map I2C error to a number we can pass back to the application
         let status = kernel::errorcode::into_statuscode(match status {
@@ -185,7 +185,7 @@ impl hil::i2c::I2CHwMasterClient for I2CMasterSlaveDriver<'_> {
     }
 }
 
-impl hil::i2c::I2CHwSlaveClient for I2CMasterSlaveDriver<'_> {
+impl<I: hil::i2c::I2CMasterSlave> hil::i2c::I2CHwSlaveClient for I2CMasterSlaveDriver<'_, I> {
     fn command_complete(
         &self,
         buffer: &'static mut [u8],
@@ -269,7 +269,7 @@ impl hil::i2c::I2CHwSlaveClient for I2CMasterSlaveDriver<'_> {
     }
 }
 
-impl SyscallDriver for I2CMasterSlaveDriver<'_> {
+impl<I: hil::i2c::I2CMasterSlave> SyscallDriver for I2CMasterSlaveDriver<'_, I> {
     fn command(
         &self,
         command_num: usize,

--- a/capsules/core/src/virtualizers/virtual_i2c.rs
+++ b/capsules/core/src/virtualizers/virtual_i2c.rs
@@ -9,7 +9,7 @@ use kernel::collections::list::{List, ListLink, ListNode};
 use kernel::deferred_call::{DeferredCall, DeferredCallClient};
 use kernel::hil::i2c::{self, Error, I2CClient, I2CHwMasterClient, NoSMBus};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
-
+// `NoSMBus` provides a placeholder for `SMBusMaster` in case the board doesn't have a SMBus
 pub struct MuxI2C<'a, I: i2c::I2CMaster, S: i2c::SMBusMaster = NoSMBus> {
     i2c: &'a I,
     smbus: Option<&'a S>,

--- a/capsules/extra/src/apds9960.rs
+++ b/capsules/extra/src/apds9960.rs
@@ -106,20 +106,20 @@ enum State {
     Done,      // Final state for take_measurement() state sequence
 }
 
-pub struct APDS9960<'a> {
-    i2c: &'a dyn i2c::I2CDevice,
+pub struct APDS9960<'a, I: i2c::I2CDevice> {
+    i2c: &'a I,
     interrupt_pin: &'a dyn gpio::InterruptPin<'a>,
     prox_callback: OptionalCell<&'a dyn kernel::hil::sensors::ProximityClient>,
     state: Cell<State>,
     buffer: TakeCell<'static, [u8]>,
 }
 
-impl<'a> APDS9960<'a> {
+impl<'a, I: i2c::I2CDevice> APDS9960<'a, I> {
     pub fn new(
-        i2c: &'a dyn i2c::I2CDevice,
+        i2c: &'a I,
         interrupt_pin: &'a dyn gpio::InterruptPin<'a>,
         buffer: &'static mut [u8],
-    ) -> APDS9960<'a> {
+    ) -> APDS9960<'a, I> {
         // setup and return struct
         APDS9960 {
             i2c: i2c,
@@ -291,7 +291,7 @@ impl<'a> APDS9960<'a> {
     }
 }
 
-impl i2c::I2CClient for APDS9960<'_> {
+impl<I: i2c::I2CDevice> i2c::I2CClient for APDS9960<'_, I> {
     fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), i2c::Error>) {
         match self.state.get() {
             State::ReadId => {
@@ -528,7 +528,7 @@ impl i2c::I2CClient for APDS9960<'_> {
 }
 
 /// Interrupt Service Routine
-impl gpio::Client for APDS9960<'_> {
+impl<I: i2c::I2CDevice> gpio::Client for APDS9960<'_, I> {
     fn fired(&self) {
         self.buffer.take().map(|buffer| {
             // Read value in PDATA reg
@@ -550,7 +550,7 @@ impl gpio::Client for APDS9960<'_> {
 }
 
 /// Proximity Driver Trait Implementation
-impl<'a> kernel::hil::sensors::ProximityDriver<'a> for APDS9960<'a> {
+impl<'a, I: i2c::I2CDevice> kernel::hil::sensors::ProximityDriver<'a> for APDS9960<'a, I> {
     fn read_proximity(&self) -> Result<(), ErrorCode> {
         self.take_measurement()
     }

--- a/capsules/extra/src/bmp280.rs
+++ b/capsules/extra/src/bmp280.rs
@@ -136,11 +136,11 @@ impl State {
 }
 
 /// Complies with the reading and writing protocol used by the sensor.
-struct I2cWrapper<'a> {
-    i2c: &'a dyn i2c::I2CDevice,
+struct I2cWrapper<'a, I: i2c::I2CDevice> {
+    i2c: &'a I,
 }
 
-impl<'a> I2cWrapper<'a> {
+impl<'a, I: i2c::I2CDevice> I2cWrapper<'a, I> {
     fn write<const COUNT: usize>(
         &self,
         buffer: &'static mut [u8],
@@ -175,8 +175,8 @@ impl<'a> I2cWrapper<'a> {
     }
 }
 
-pub struct Bmp280<'a, A: Alarm<'a>> {
-    i2c: I2cWrapper<'a>,
+pub struct Bmp280<'a, A: Alarm<'a>, I: i2c::I2CDevice> {
+    i2c: I2cWrapper<'a, I>,
     temperature_client: OptionalCell<&'a dyn hil::sensors::TemperatureClient>,
     // This might be better as a `RefCell`,
     // because `State` is multiple bytes due to the `CalibrationData`.
@@ -191,8 +191,8 @@ pub struct Bmp280<'a, A: Alarm<'a>> {
     alarm: &'a A,
 }
 
-impl<'a, A: Alarm<'a>> Bmp280<'a, A> {
-    pub fn new(i2c: &'a dyn i2c::I2CDevice, buffer: &'static mut [u8], alarm: &'a A) -> Self {
+impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> Bmp280<'a, A, I> {
+    pub fn new(i2c: &'a I, buffer: &'static mut [u8], alarm: &'a A) -> Self {
         Self {
             i2c: I2cWrapper { i2c },
             temperature_client: OptionalCell::empty(),
@@ -325,7 +325,7 @@ impl I2cOperation {
     }
 }
 
-impl<'a, A: Alarm<'a>> i2c::I2CClient for Bmp280<'a, A> {
+impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> i2c::I2CClient for Bmp280<'a, A, I> {
     fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
         let mut temp_readout = None;
         let mut i2c_op = I2cOperation::Disable;
@@ -333,7 +333,7 @@ impl<'a, A: Alarm<'a>> i2c::I2CClient for Bmp280<'a, A> {
         let new_state = match status {
             Ok(()) => match self.state.get() {
                 State::InitId => {
-                    let id = I2cWrapper::parse_read(buffer, 1);
+                    let id = I2cWrapper::<I>::parse_read(buffer, 1);
                     if id[0] == 0x58 {
                         i2c_op = I2cOperation::Write {
                             addr: Register::RESET,
@@ -350,7 +350,7 @@ impl<'a, A: Alarm<'a>> i2c::I2CClient for Bmp280<'a, A> {
                     State::InitWaitingReady
                 }
                 State::InitWaitingReady => {
-                    let waiting = I2cWrapper::parse_read(buffer, 1)[0];
+                    let waiting = I2cWrapper::<I>::parse_read(buffer, 1)[0];
                     if waiting & 0b1 == 0 {
                         // finished init
                         i2c_op = I2cOperation::Read {
@@ -365,7 +365,7 @@ impl<'a, A: Alarm<'a>> i2c::I2CClient for Bmp280<'a, A> {
                     }
                 }
                 State::InitReadingCalibration => {
-                    let data = I2cWrapper::parse_read(buffer, 6);
+                    let data = I2cWrapper::<I>::parse_read(buffer, 6);
                     let calibration = CalibrationData::new(data);
                     State::Idle(calibration)
                 }
@@ -375,7 +375,7 @@ impl<'a, A: Alarm<'a>> i2c::I2CClient for Bmp280<'a, A> {
                     State::WaitingForAlarm(calibration)
                 }
                 State::Waiting(calibration) => {
-                    let waiting_value = I2cWrapper::parse_read(buffer, 1);
+                    let waiting_value = I2cWrapper::<I>::parse_read(buffer, 1);
                     // not waiting
                     if waiting_value[0] & 0b1000 == 0 {
                         i2c_op = I2cOperation::Read {
@@ -390,7 +390,7 @@ impl<'a, A: Alarm<'a>> i2c::I2CClient for Bmp280<'a, A> {
                     }
                 }
                 State::Reading(calibration) => {
-                    let readout = I2cWrapper::parse_read(buffer, 3);
+                    let readout = I2cWrapper::<I>::parse_read(buffer, 3);
                     let msb = readout[0] as u32;
                     let lsb = readout[1] as u32;
                     let xlsb = readout[2] as u32;
@@ -465,7 +465,7 @@ impl<'a, A: Alarm<'a>> i2c::I2CClient for Bmp280<'a, A> {
     }
 }
 
-impl<'a, A: Alarm<'a>> hil::sensors::TemperatureDriver<'a> for Bmp280<'a, A> {
+impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> hil::sensors::TemperatureDriver<'a> for Bmp280<'a, A, I> {
     fn set_client(&self, client: &'a dyn hil::sensors::TemperatureClient) {
         self.temperature_client.set(client)
     }
@@ -475,7 +475,7 @@ impl<'a, A: Alarm<'a>> hil::sensors::TemperatureDriver<'a> for Bmp280<'a, A> {
     }
 }
 
-impl<'a, A: hil::time::Alarm<'a>> hil::time::AlarmClient for Bmp280<'a, A> {
+impl<'a, A: hil::time::Alarm<'a>, I: i2c::I2CDevice> hil::time::AlarmClient for Bmp280<'a, A, I> {
     fn alarm(&self) {
         self.handle_alarm()
     }

--- a/capsules/extra/src/ft6x06.rs
+++ b/capsules/extra/src/ft6x06.rs
@@ -46,8 +46,8 @@ enum_from_primitive! {
     }
 }
 
-pub struct Ft6x06<'a> {
-    i2c: &'a dyn i2c::I2CDevice,
+pub struct Ft6x06<'a, I: i2c::I2CDevice> {
+    i2c: &'a I,
     interrupt_pin: &'a dyn gpio::InterruptPin<'a>,
     touch_client: OptionalCell<&'a dyn touch::TouchClient>,
     gesture_client: OptionalCell<&'a dyn touch::GestureClient>,
@@ -57,13 +57,13 @@ pub struct Ft6x06<'a> {
     events: TakeCell<'static, [TouchEvent]>,
 }
 
-impl<'a> Ft6x06<'a> {
+impl<'a, I: i2c::I2CDevice> Ft6x06<'a, I> {
     pub fn new(
-        i2c: &'a dyn i2c::I2CDevice,
+        i2c: &'a I,
         interrupt_pin: &'a dyn gpio::InterruptPin<'a>,
         buffer: &'static mut [u8],
         events: &'static mut [TouchEvent],
-    ) -> Ft6x06<'a> {
+    ) -> Ft6x06<'a, I> {
         // setup and return struct
         interrupt_pin.enable_interrupts(gpio::InterruptEdge::FallingEdge);
         Ft6x06 {
@@ -79,7 +79,7 @@ impl<'a> Ft6x06<'a> {
     }
 }
 
-impl<'a> i2c::I2CClient for Ft6x06<'a> {
+impl<'a, I: i2c::I2CDevice> i2c::I2CClient for Ft6x06<'a, I> {
     fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), i2c::Error>) {
         self.num_touches.set((buffer[1] & 0x0F) as usize);
         self.touch_client.map(|client| {
@@ -164,7 +164,7 @@ impl<'a> i2c::I2CClient for Ft6x06<'a> {
     }
 }
 
-impl<'a> gpio::Client for Ft6x06<'a> {
+impl<'a, I: i2c::I2CDevice> gpio::Client for Ft6x06<'a, I> {
     fn fired(&self) {
         self.buffer.take().map(|buffer| {
             self.interrupt_pin.disable_interrupts();
@@ -183,7 +183,7 @@ impl<'a> gpio::Client for Ft6x06<'a> {
     }
 }
 
-impl<'a> touch::Touch<'a> for Ft6x06<'a> {
+impl<'a, I: i2c::I2CDevice> touch::Touch<'a> for Ft6x06<'a, I> {
     fn enable(&self) -> Result<(), ErrorCode> {
         Ok(())
     }
@@ -197,13 +197,13 @@ impl<'a> touch::Touch<'a> for Ft6x06<'a> {
     }
 }
 
-impl<'a> touch::Gesture<'a> for Ft6x06<'a> {
+impl<'a, I: i2c::I2CDevice> touch::Gesture<'a> for Ft6x06<'a, I> {
     fn set_client(&self, client: &'a dyn touch::GestureClient) {
         self.gesture_client.replace(client);
     }
 }
 
-impl<'a> touch::MultiTouch<'a> for Ft6x06<'a> {
+impl<'a, I: i2c::I2CDevice> touch::MultiTouch<'a> for Ft6x06<'a, I> {
     fn enable(&self) -> Result<(), ErrorCode> {
         Ok(())
     }

--- a/capsules/extra/src/hts221.rs
+++ b/capsules/extra/src/hts221.rs
@@ -84,9 +84,9 @@ struct CalibrationData {
     humidity_intercept: f32,
 }
 
-pub struct Hts221<'a> {
+pub struct Hts221<'a, I: I2CDevice> {
     buffer: TakeCell<'static, [u8]>,
-    i2c: &'a dyn I2CDevice,
+    i2c: &'a I,
     temperature_client: OptionalCell<&'a dyn TemperatureClient>,
     humidity_client: OptionalCell<&'a dyn HumidityClient>,
     state: Cell<State>,
@@ -94,8 +94,8 @@ pub struct Hts221<'a> {
     pending_humidity: Cell<bool>,
 }
 
-impl<'a> Hts221<'a> {
-    pub fn new(i2c: &'a dyn I2CDevice, buffer: &'static mut [u8]) -> Self {
+impl<'a, I: I2CDevice> Hts221<'a, I> {
+    pub fn new(i2c: &'a I, buffer: &'static mut [u8]) -> Self {
         Hts221 {
             buffer: TakeCell::new(buffer),
             i2c,
@@ -148,7 +148,7 @@ impl<'a> Hts221<'a> {
     }
 }
 
-impl<'a> TemperatureDriver<'a> for Hts221<'a> {
+impl<'a, I: I2CDevice> TemperatureDriver<'a> for Hts221<'a, I> {
     fn set_client(&self, client: &'a dyn TemperatureClient) {
         self.temperature_client.set(client);
     }
@@ -163,7 +163,7 @@ impl<'a> TemperatureDriver<'a> for Hts221<'a> {
     }
 }
 
-impl<'a> HumidityDriver<'a> for Hts221<'a> {
+impl<'a, I: I2CDevice> HumidityDriver<'a> for Hts221<'a, I> {
     fn set_client(&self, client: &'a dyn HumidityClient) {
         self.humidity_client.set(client);
     }
@@ -188,7 +188,7 @@ enum State {
     Idle(CalibrationData, i32, usize),
 }
 
-impl<'a> I2CClient for Hts221<'a> {
+impl<'a, I: I2CDevice> I2CClient for Hts221<'a, I> {
     fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
         if let Err(i2c_err) = status {
             self.state.set(State::Idle(

--- a/capsules/extra/src/lps25hb.rs
+++ b/capsules/extra/src/lps25hb.rs
@@ -99,8 +99,8 @@ enum State {
 #[derive(Default)]
 pub struct App {}
 
-pub struct LPS25HB<'a> {
-    i2c: &'a dyn i2c::I2CDevice,
+pub struct LPS25HB<'a, I: i2c::I2CDevice> {
+    i2c: &'a I,
     interrupt_pin: &'a dyn gpio::InterruptPin<'a>,
     state: Cell<State>,
     buffer: TakeCell<'static, [u8]>,
@@ -108,9 +108,9 @@ pub struct LPS25HB<'a> {
     owning_process: OptionalCell<ProcessId>,
 }
 
-impl<'a> LPS25HB<'a> {
+impl<'a, I: i2c::I2CDevice> LPS25HB<'a, I> {
     pub fn new(
-        i2c: &'a dyn i2c::I2CDevice,
+        i2c: &'a I,
         interrupt_pin: &'a dyn gpio::InterruptPin<'a>,
         buffer: &'static mut [u8],
         apps: Grant<App, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
@@ -171,7 +171,7 @@ impl<'a> LPS25HB<'a> {
     }
 }
 
-impl i2c::I2CClient for LPS25HB<'_> {
+impl<I: i2c::I2CDevice> i2c::I2CClient for LPS25HB<'_, I> {
     fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
         if status != Ok(()) {
             self.state.set(State::Idle);
@@ -306,7 +306,7 @@ impl i2c::I2CClient for LPS25HB<'_> {
     }
 }
 
-impl gpio::Client for LPS25HB<'_> {
+impl<I: i2c::I2CDevice> gpio::Client for LPS25HB<'_, I> {
     fn fired(&self) {
         self.buffer.take().map(|buf| {
             // turn on i2c to send commands
@@ -325,7 +325,7 @@ impl gpio::Client for LPS25HB<'_> {
     }
 }
 
-impl SyscallDriver for LPS25HB<'_> {
+impl<I: i2c::I2CDevice> SyscallDriver for LPS25HB<'_, I> {
     fn command(
         &self,
         command_num: usize,

--- a/capsules/extra/src/lsm6dsoxtr.rs
+++ b/capsules/extra/src/lsm6dsoxtr.rs
@@ -165,8 +165,8 @@ enum State {
 #[derive(Default)]
 pub struct App {}
 
-pub struct Lsm6dsoxtrI2C<'a> {
-    i2c: &'a dyn i2c::I2CDevice,
+pub struct Lsm6dsoxtrI2C<'a, I: i2c::I2CDevice> {
+    i2c: &'a I,
     state: Cell<State>,
     config_in_progress: Cell<bool>,
     gyro_data_rate: Cell<LSM6DSOXGyroDataRate>,
@@ -183,12 +183,12 @@ pub struct Lsm6dsoxtrI2C<'a> {
     syscall_process: OptionalCell<ProcessId>,
 }
 
-impl<'a> Lsm6dsoxtrI2C<'a> {
+impl<'a, I: i2c::I2CDevice> Lsm6dsoxtrI2C<'a, I> {
     pub fn new(
-        i2c: &'a dyn i2c::I2CDevice,
+        i2c: &'a I,
         buffer: &'static mut [u8],
         grant: Grant<App, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
-    ) -> Lsm6dsoxtrI2C<'a> {
+    ) -> Lsm6dsoxtrI2C<'a, I> {
         Lsm6dsoxtrI2C {
             i2c: i2c,
             state: Cell::new(State::Idle),
@@ -376,7 +376,7 @@ impl<'a> Lsm6dsoxtrI2C<'a> {
     }
 }
 
-impl i2c::I2CClient for Lsm6dsoxtrI2C<'_> {
+impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm6dsoxtrI2C<'_, I> {
     fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
         match self.state.get() {
             State::IsPresent => {
@@ -549,7 +549,7 @@ impl i2c::I2CClient for Lsm6dsoxtrI2C<'_> {
     }
 }
 
-impl SyscallDriver for Lsm6dsoxtrI2C<'_> {
+impl<I: i2c::I2CDevice> SyscallDriver for Lsm6dsoxtrI2C<'_, I> {
     fn command(
         &self,
         command_num: usize,
@@ -629,7 +629,7 @@ impl SyscallDriver for Lsm6dsoxtrI2C<'_> {
     }
 }
 
-impl<'a> NineDof<'a> for Lsm6dsoxtrI2C<'a> {
+impl<'a, I: i2c::I2CDevice> NineDof<'a> for Lsm6dsoxtrI2C<'a, I> {
     fn set_client(&self, nine_dof_client: &'a dyn NineDofClient) {
         self.nine_dof_client.replace(nine_dof_client);
     }
@@ -643,7 +643,7 @@ impl<'a> NineDof<'a> for Lsm6dsoxtrI2C<'a> {
     }
 }
 
-impl<'a> sensors::TemperatureDriver<'a> for Lsm6dsoxtrI2C<'a> {
+impl<'a, I: i2c::I2CDevice> sensors::TemperatureDriver<'a> for Lsm6dsoxtrI2C<'a, I> {
     fn set_client(&self, temperature_client: &'a dyn sensors::TemperatureClient) {
         self.temperature_client.replace(temperature_client);
     }

--- a/capsules/extra/src/max17205.rs
+++ b/capsules/extra/src/max17205.rs
@@ -104,9 +104,9 @@ pub trait MAX17205Client {
     fn romid(&self, rid: u64, error: Result<(), ErrorCode>);
 }
 
-pub struct MAX17205<'a> {
-    i2c_lower: &'a dyn i2c::I2CDevice,
-    i2c_upper: &'a dyn i2c::I2CDevice,
+pub struct MAX17205<'a, I: i2c::I2CDevice> {
+    i2c_lower: &'a I,
+    i2c_upper: &'a I,
     state: Cell<State>,
     soc: Cell<u16>,
     soc_mah: Cell<u16>,
@@ -115,12 +115,8 @@ pub struct MAX17205<'a> {
     client: OptionalCell<&'static dyn MAX17205Client>,
 }
 
-impl<'a> MAX17205<'a> {
-    pub fn new(
-        i2c_lower: &'a dyn i2c::I2CDevice,
-        i2c_upper: &'a dyn i2c::I2CDevice,
-        buffer: &'static mut [u8],
-    ) -> MAX17205<'a> {
+impl<'a, I: i2c::I2CDevice> MAX17205<'a, I> {
+    pub fn new(i2c_lower: &'a I, i2c_upper: &'a I, buffer: &'static mut [u8]) -> MAX17205<'a, I> {
         MAX17205 {
             i2c_lower: i2c_lower,
             i2c_upper: i2c_upper,
@@ -212,7 +208,7 @@ impl<'a> MAX17205<'a> {
     }
 }
 
-impl i2c::I2CClient for MAX17205<'_> {
+impl<I: i2c::I2CDevice> i2c::I2CClient for MAX17205<'_, I> {
     fn command_complete(&self, buffer: &'static mut [u8], error: Result<(), i2c::Error>) {
         match self.state.get() {
             State::SetupReadStatus => {
@@ -395,15 +391,15 @@ impl i2c::I2CClient for MAX17205<'_> {
 #[derive(Default)]
 pub struct App {}
 
-pub struct MAX17205Driver<'a> {
-    max17205: &'a MAX17205<'a>,
+pub struct MAX17205Driver<'a, I: i2c::I2CDevice> {
+    max17205: &'a MAX17205<'a, I>,
     owning_process: OptionalCell<ProcessId>,
     apps: Grant<App, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
 }
 
-impl<'a> MAX17205Driver<'a> {
+impl<'a, I: i2c::I2CDevice> MAX17205Driver<'a, I> {
     pub fn new(
-        max: &'a MAX17205,
+        max: &'a MAX17205<I>,
         grant: Grant<App, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
     ) -> Self {
         Self {
@@ -414,7 +410,7 @@ impl<'a> MAX17205Driver<'a> {
     }
 }
 
-impl MAX17205Client for MAX17205Driver<'_> {
+impl<I: i2c::I2CDevice> MAX17205Client for MAX17205Driver<'_, I> {
     fn status(&self, status: u16, error: Result<(), ErrorCode>) {
         self.owning_process.map(|pid| {
             let _ = self.apps.enter(*pid, |_app, upcalls| {
@@ -507,7 +503,7 @@ impl MAX17205Client for MAX17205Driver<'_> {
     }
 }
 
-impl SyscallDriver for MAX17205Driver<'_> {
+impl<I: i2c::I2CDevice> SyscallDriver for MAX17205Driver<'_, I> {
     // Setup callback.
     //
     // ### `subscribe_num`

--- a/capsules/extra/src/mcp230xx.rs
+++ b/capsules/extra/src/mcp230xx.rs
@@ -127,8 +127,8 @@ enum PinState {
     Low = 0x00,
 }
 
-pub struct MCP230xx<'a> {
-    i2c: &'a dyn hil::i2c::I2CDevice,
+pub struct MCP230xx<'a, I: hil::i2c::I2CDevice> {
+    i2c: &'a I,
     state: Cell<State>,
     bank_size: u8,       // How many GPIO pins per bank (likely 8)
     number_of_banks: u8, // How many GPIO banks this extender has (likely 1 or 2)
@@ -140,15 +140,15 @@ pub struct MCP230xx<'a> {
     client: OptionalCell<&'static dyn gpio_async::Client>,
 }
 
-impl<'a> MCP230xx<'a> {
+impl<'a, I: hil::i2c::I2CDevice> MCP230xx<'a, I> {
     pub fn new(
-        i2c: &'a dyn hil::i2c::I2CDevice,
+        i2c: &'a I,
         interrupt_pin_a: Option<&'a dyn gpio::InterruptValuePin<'a>>,
         interrupt_pin_b: Option<&'a dyn gpio::InterruptValuePin<'a>>,
         buffer: &'static mut [u8],
         bank_size: u8,
         number_of_banks: u8,
-    ) -> MCP230xx<'a> {
+    ) -> MCP230xx<'a, I> {
         MCP230xx {
             i2c: i2c,
             state: Cell::new(State::Idle),
@@ -388,7 +388,7 @@ impl<'a> MCP230xx<'a> {
     }
 }
 
-impl hil::i2c::I2CClient for MCP230xx<'_> {
+impl<I: hil::i2c::I2CDevice> hil::i2c::I2CClient for MCP230xx<'_, I> {
     fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), hil::i2c::Error>) {
         match self.state.get() {
             State::SelectIoDir(pin_number, direction) => {
@@ -550,7 +550,7 @@ impl hil::i2c::I2CClient for MCP230xx<'_> {
     }
 }
 
-impl gpio::ClientWithValue for MCP230xx<'_> {
+impl<I: hil::i2c::I2CDevice> gpio::ClientWithValue for MCP230xx<'_, I> {
     fn fired(&self, value: u32) {
         if value < 2 {
             return; // Error, value specifies which pin A=0, B=1
@@ -570,7 +570,7 @@ impl gpio::ClientWithValue for MCP230xx<'_> {
     }
 }
 
-impl gpio_async::Port for MCP230xx<'_> {
+impl<I: hil::i2c::I2CDevice> gpio_async::Port for MCP230xx<'_, I> {
     fn disable(&self, pin: usize) -> Result<(), ErrorCode> {
         // Best we can do is make this an input.
         self.set_direction(pin as u8, Direction::Input)

--- a/capsules/extra/src/pca9544a.rs
+++ b/capsules/extra/src/pca9544a.rs
@@ -61,17 +61,17 @@ enum ControlField {
 #[derive(Default)]
 pub struct App {}
 
-pub struct PCA9544A<'a> {
-    i2c: &'a dyn i2c::I2CDevice,
+pub struct PCA9544A<'a, I: i2c::I2CDevice> {
+    i2c: &'a I,
     state: Cell<State>,
     buffer: TakeCell<'static, [u8]>,
     apps: Grant<App, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
     owning_process: OptionalCell<ProcessId>,
 }
 
-impl<'a> PCA9544A<'a> {
+impl<'a, I: i2c::I2CDevice> PCA9544A<'a, I> {
     pub fn new(
-        i2c: &'a dyn i2c::I2CDevice,
+        i2c: &'a I,
         buffer: &'static mut [u8],
         grant: Grant<App, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
     ) -> Self {
@@ -138,7 +138,7 @@ impl<'a> PCA9544A<'a> {
     }
 }
 
-impl i2c::I2CClient for PCA9544A<'_> {
+impl<I: i2c::I2CDevice> i2c::I2CClient for PCA9544A<'_, I> {
     fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), i2c::Error>) {
         match self.state.get() {
             State::ReadControl(field) => {
@@ -175,7 +175,7 @@ impl i2c::I2CClient for PCA9544A<'_> {
     }
 }
 
-impl SyscallDriver for PCA9544A<'_> {
+impl<I: i2c::I2CDevice> SyscallDriver for PCA9544A<'_, I> {
     // Setup callback for event done.
     //
     // ### `subscribe_num`

--- a/capsules/extra/src/sht3x.rs
+++ b/capsules/extra/src/sht3x.rs
@@ -67,8 +67,8 @@ fn crc8(data: &[u8]) -> u8 {
     crc
 }
 
-pub struct SHT3x<'a, A: Alarm<'a>> {
-    i2c: &'a dyn i2c::I2CDevice,
+pub struct SHT3x<'a, A: Alarm<'a>, I: i2c::I2CDevice> {
+    i2c: &'a I,
     humidity_client: OptionalCell<&'a dyn kernel::hil::sensors::HumidityClient>,
     temperature_client: OptionalCell<&'a dyn kernel::hil::sensors::TemperatureClient>,
     state: Cell<State>,
@@ -78,12 +78,8 @@ pub struct SHT3x<'a, A: Alarm<'a>> {
     alarm: &'a A,
 }
 
-impl<'a, A: Alarm<'a>> SHT3x<'a, A> {
-    pub fn new(
-        i2c: &'a dyn i2c::I2CDevice,
-        buffer: &'static mut [u8],
-        alarm: &'a A,
-    ) -> SHT3x<'a, A> {
+impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> SHT3x<'a, A, I> {
+    pub fn new(i2c: &'a I, buffer: &'static mut [u8], alarm: &'a A) -> SHT3x<'a, A, I> {
         SHT3x {
             i2c: i2c,
             humidity_client: OptionalCell::empty(),
@@ -143,7 +139,7 @@ impl<'a, A: Alarm<'a>> SHT3x<'a, A> {
     }
 }
 
-impl<'a, A: Alarm<'a>> time::AlarmClient for SHT3x<'a, A> {
+impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> time::AlarmClient for SHT3x<'a, A, I> {
     fn alarm(&self) {
         let state = self.state.get();
         match state {
@@ -164,7 +160,7 @@ impl<'a, A: Alarm<'a>> time::AlarmClient for SHT3x<'a, A> {
     }
 }
 
-impl<'a, A: Alarm<'a>> i2c::I2CClient for SHT3x<'a, A> {
+impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> i2c::I2CClient for SHT3x<'a, A, I> {
     fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
         match status {
             Ok(()) => {
@@ -225,7 +221,9 @@ impl<'a, A: Alarm<'a>> i2c::I2CClient for SHT3x<'a, A> {
     }
 }
 
-impl<'a, A: Alarm<'a>> kernel::hil::sensors::HumidityDriver<'a> for SHT3x<'a, A> {
+impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> kernel::hil::sensors::HumidityDriver<'a>
+    for SHT3x<'a, A, I>
+{
     fn set_client(&self, client: &'a dyn kernel::hil::sensors::HumidityClient) {
         self.humidity_client.set(client);
     }
@@ -235,7 +233,9 @@ impl<'a, A: Alarm<'a>> kernel::hil::sensors::HumidityDriver<'a> for SHT3x<'a, A>
     }
 }
 
-impl<'a, A: Alarm<'a>> kernel::hil::sensors::TemperatureDriver<'a> for SHT3x<'a, A> {
+impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> kernel::hil::sensors::TemperatureDriver<'a>
+    for SHT3x<'a, A, I>
+{
     fn set_client(&self, client: &'a dyn kernel::hil::sensors::TemperatureClient) {
         self.temperature_client.set(client);
     }

--- a/capsules/extra/src/si7021.rs
+++ b/capsules/extra/src/si7021.rs
@@ -93,8 +93,8 @@ enum OnDeck {
     Humidity,
 }
 
-pub struct SI7021<'a, A: time::Alarm<'a>> {
-    i2c: &'a dyn i2c::I2CDevice,
+pub struct SI7021<'a, A: time::Alarm<'a>, I: i2c::I2CDevice> {
+    i2c: &'a I,
     alarm: &'a A,
     temp_callback: OptionalCell<&'a dyn kernel::hil::sensors::TemperatureClient>,
     humidity_callback: OptionalCell<&'a dyn kernel::hil::sensors::HumidityClient>,
@@ -103,12 +103,8 @@ pub struct SI7021<'a, A: time::Alarm<'a>> {
     buffer: TakeCell<'static, [u8]>,
 }
 
-impl<'a, A: time::Alarm<'a>> SI7021<'a, A> {
-    pub fn new(
-        i2c: &'a dyn i2c::I2CDevice,
-        alarm: &'a A,
-        buffer: &'static mut [u8],
-    ) -> SI7021<'a, A> {
+impl<'a, A: time::Alarm<'a>, I: i2c::I2CDevice> SI7021<'a, A, I> {
+    pub fn new(i2c: &'a I, alarm: &'a A, buffer: &'static mut [u8]) -> SI7021<'a, A, I> {
         // setup and return struct
         SI7021 {
             i2c: i2c,
@@ -150,7 +146,7 @@ impl<'a, A: time::Alarm<'a>> SI7021<'a, A> {
     }
 }
 
-impl<'a, A: time::Alarm<'a>> i2c::I2CClient for SI7021<'a, A> {
+impl<'a, A: time::Alarm<'a>, I: i2c::I2CDevice> i2c::I2CClient for SI7021<'a, A, I> {
     fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), i2c::Error>) {
         match self.state.get() {
             State::SelectElectronicId1 => {
@@ -244,7 +240,9 @@ impl<'a, A: time::Alarm<'a>> i2c::I2CClient for SI7021<'a, A> {
     }
 }
 
-impl<'a, A: time::Alarm<'a>> kernel::hil::sensors::TemperatureDriver<'a> for SI7021<'a, A> {
+impl<'a, A: time::Alarm<'a>, I: i2c::I2CDevice> kernel::hil::sensors::TemperatureDriver<'a>
+    for SI7021<'a, A, I>
+{
     fn read_temperature(&self) -> Result<(), ErrorCode> {
         // This chip handles both humidity and temperature measurements. We can
         // only start a new measurement if the chip is idle. If it isn't then we
@@ -277,7 +275,9 @@ impl<'a, A: time::Alarm<'a>> kernel::hil::sensors::TemperatureDriver<'a> for SI7
     }
 }
 
-impl<'a, A: time::Alarm<'a>> kernel::hil::sensors::HumidityDriver<'a> for SI7021<'a, A> {
+impl<'a, A: time::Alarm<'a>, I: i2c::I2CDevice> kernel::hil::sensors::HumidityDriver<'a>
+    for SI7021<'a, A, I>
+{
     fn read_humidity(&self) -> Result<(), ErrorCode> {
         // This chip handles both humidity and temperature measurements. We can
         // only start a new measurement if the chip is idle. If it isn't then we
@@ -311,7 +311,7 @@ impl<'a, A: time::Alarm<'a>> kernel::hil::sensors::HumidityDriver<'a> for SI7021
     }
 }
 
-impl<'a, A: time::Alarm<'a>> time::AlarmClient for SI7021<'a, A> {
+impl<'a, A: time::Alarm<'a>, I: i2c::I2CDevice> time::AlarmClient for SI7021<'a, A, I> {
     fn alarm(&self) {
         self.buffer.take().map(|buffer| {
             // turn on i2c to send commands

--- a/chips/nrf52/src/i2c.rs
+++ b/chips/nrf52/src/i2c.rs
@@ -361,6 +361,8 @@ impl hil::i2c::I2CSlave for TWI {
     }
 }
 
+impl hil::i2c::I2CMasterSlave for TWI {}
+
 // The SPI0_TWI0 and SPI1_TWI1 interrupts are dispatched to the
 // correct handler by the service_pending_interrupts() routine in
 // chip.rs based on which peripheral is enabled.

--- a/kernel/src/hil/i2c.rs
+++ b/kernel/src/hil/i2c.rs
@@ -177,7 +177,7 @@ pub trait I2CSlave {
 /// Master and Slave modes.
 pub trait I2CMasterSlave: I2CMaster + I2CSlave {}
 // Provide blanket implementations for trait group
-impl<T: I2CMaster + I2CSlave> I2CMasterSlave for T {}
+// impl<T: I2CMaster + I2CSlave> I2CMasterSlave for T {}
 
 /// Client interface for capsules that use I2CMaster devices.
 pub trait I2CHwMasterClient {

--- a/kernel/src/hil/i2c.rs
+++ b/kernel/src/hil/i2c.rs
@@ -288,3 +288,66 @@ pub trait I2CClient {
     /// successfully or if an error occured.
     fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), Error>);
 }
+
+pub struct NoSMBus;
+
+impl I2CMaster for NoSMBus {
+    fn set_master_client(&self, _master_client: &'static dyn I2CHwMasterClient) {}
+    fn enable(&self) {}
+    fn disable(&self) {}
+    fn write_read(
+        &self,
+        _addr: u8,
+        data: &'static mut [u8],
+        _write_len: usize,
+        _read_len: usize,
+    ) -> Result<(), (Error, &'static mut [u8])> {
+        Err((Error::NotSupported, data))
+    }
+    fn write(
+        &self,
+        _addr: u8,
+        data: &'static mut [u8],
+        _len: usize,
+    ) -> Result<(), (Error, &'static mut [u8])> {
+        Err((Error::NotSupported, data))
+    }
+    fn read(
+        &self,
+        _addr: u8,
+        buffer: &'static mut [u8],
+        _len: usize,
+    ) -> Result<(), (Error, &'static mut [u8])> {
+        Err((Error::NotSupported, buffer))
+    }
+}
+
+impl SMBusMaster for NoSMBus {
+    fn smbus_write_read(
+        &self,
+        _addr: u8,
+        data: &'static mut [u8],
+        _write_len: usize,
+        _read_len: usize,
+    ) -> Result<(), (Error, &'static mut [u8])> {
+        Err((Error::NotSupported, data))
+    }
+
+    fn smbus_write(
+        &self,
+        _addr: u8,
+        data: &'static mut [u8],
+        _len: usize,
+    ) -> Result<(), (Error, &'static mut [u8])> {
+        Err((Error::NotSupported, data))
+    }
+
+    fn smbus_read(
+        &self,
+        _addr: u8,
+        buffer: &'static mut [u8],
+        _len: usize,
+    ) -> Result<(), (Error, &'static mut [u8])> {
+        Err((Error::NotSupported, buffer))
+    }
+}


### PR DESCRIPTION
### Pull Request Overview

This pull request modifies the I2C HIL and capsules to use generics.

Code sizes:

Old imix:
`   text    data     bss     dec     hex ` 
` 175092       0   28568  203660   31b8c `
New imix:
`   text    data     bss     dec     hex `
` 174836       0   28556  203392   31a80 `

Old microbit:
`   text    data     bss     dec     hex `
` 106500       0   15788  122288   1ddb0 `
New microbit:
`   text    data     bss     dec     hex `
` 106500       0   15772  122272   1dda0 `

Old stm32f3discovery:
`   text    data     bss     dec     hex ` 
` 100356       0   16632  116988   1c8fc `
New stm32f3discovery:
`   text    data     bss     dec     hex `
` 100356       0   16616  116972   1c8ec `

Old hifive:
`   text    data     bss     dec     hex `
`  77388      12    7320   84720   14af0 `
New hifive:
`   text    data     bss     dec     hex `
`  75276      12    6932   82220   1412c `

Pros
- this allows the compiler to perform better optimization and function inlining;
- smaller code size.

Cons
- writing I2C drivers is more verbose as data types are longer;
- `SMBus` was optional, this uses an "empty" implementation.


### TODO or Help Wanted

Feedback would be highly appreciated.


### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
