### PR TITLE
Use a fallback syntect syntax rather than a custom Rust parser in the license checker.

### DIFF
--- a/tools/license-checker/Cargo.toml
+++ b/tools/license-checker/Cargo.toml
@@ -16,5 +16,5 @@ thiserror = "1.0.37"
 
 [dependencies.syntect]
 default-features = false
-features = ["default-syntaxes", "regex-onig"]
+features = ["default-syntaxes", "regex-onig", "yaml-load"]
 version = "5.0.0"

--- a/tools/license-checker/src/fallback_syntax.yaml
+++ b/tools/license-checker/src/fallback_syntax.yaml
@@ -1,0 +1,58 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2023.
+# Copyright Google LLC 2023.
+
+# This syntax definition is used by the license checker to parse files that
+# syntect does not recognize. It contains generic support for a handful of
+# common comment types.
+
+scope: source.fallback
+
+contexts:
+  # The main context looks for the first not-entirely-whitespace line, and uses
+  # it to detect what type of comment the header uses. Once detected, it
+  # switches to one of the has_*_comments contexts, and that context will remain
+  # for the remainder of the file.
+  main:
+    # When checking for number sign comments, allow either the first line of a
+    # comment or a shebang line.
+    - match: ^#(!| )
+      scope: punctuation.definition.comment.fallback
+      push: [has_number_comments, number_comment]
+
+    - match: "^// "
+      scope: punctuation.definition.comment.fallback
+      push: [has_slashes_comments, slashes_comment]
+
+    # If none of the above matchers match, and this line is not entirely
+    # whitespace, then assume the filetype does not support comments.
+    - match: "\\S"
+      push: has_no_comments
+
+  has_number_comments:
+    - match: "^# "
+      scope: punctuation.definition.comment.fallback
+      push: number_comment
+
+  number_comment:
+    - meta_scope: comment.line.number-sign.fallback
+    - match: $\n?
+      pop: true
+
+  has_slashes_comments:
+    - match: "^// "
+      scope: punctuation.definition.comment.fallback
+      push: slashes_comment
+
+  slashes_comment:
+    - meta_scope: comment.line.double-slash.fallback
+    - match: $\n?
+      pop: true
+
+  # Context used for files that do not have comments, e.g. plain text files. For
+  # these, we consider every line to be a comment.
+  has_no_comments:
+    # TODO: This should probably be changed to comment.block.fallback once the
+    # license checker supports block comments.
+    - meta_scope: comment.line.fallback

--- a/tools/license-checker/testdata/number_signs.fallback
+++ b/tools/license-checker/testdata/number_signs.fallback
@@ -1,0 +1,8 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2023.
+# Copyright Google LLC 2023.
+
+syntect should not recognize this file type. Instead, the license checker
+// should use the fallback parser, which should identify that this file uses
+/* number signs for its comments. */

--- a/tools/license-checker/testdata/plain_text
+++ b/tools/license-checker/testdata/plain_text
@@ -1,0 +1,7 @@
+Licensed under the Apache License, Version 2.0 or the MIT License.
+SPDX-License-Identifier: Apache-2.0 OR MIT
+Copyright Tock Contributors 2023.
+Copyright Google LLC 2023.
+
+This is a plain text file; the license checker should recognize that it does
+# not use a common comment syntax.

--- a/tools/license-checker/testdata/shebang.fallback
+++ b/tools/license-checker/testdata/shebang.fallback
@@ -1,0 +1,10 @@
+#!Shebang line here
+
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2023.
+# Copyright Google LLC 2023.
+
+syntect should not recognize this file type. Instead, the license checker
+// should use the fallback parser, which should identify that this file has a
+/* shebang line and uses number signs for its comments. */

--- a/tools/license-checker/testdata/slashes.fallback
+++ b/tools/license-checker/testdata/slashes.fallback
@@ -1,0 +1,8 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2023.
+// Copyright Google LLC 2023.
+
+syntect should not recognize this file type. Instead, the license checker
+# should use the fallback parser, which should identify that this file uses
+/* double slashes for its comments. */

--- a/tools/license-checker/testdata/source.unknown_file_type
+++ b/tools/license-checker/testdata/source.unknown_file_type
@@ -1,7 +1,0 @@
-Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-# Copyright Tock Contributors 2022.
-# Copyright Google LLC 2022.
-
-Syntect should not be able to recognize this file's type.
-Parser should adapt and automatically strip // and # comment prefixes.


### PR DESCRIPTION
The license checker uses the `syntect` crate to parse files wherever possible. `syntect` provides a number of syntax definitions for common language types. However, we have some files that `syntect` does not recognize. Currently, the license checker falls back to a hand-coded parser if it encounters a file type that `syntect` does not recognize. This PR removes that hand-coded parser, and replaces it with a fallback `syntect` syntax. This removes the duplicate parsing logic, replacing it with an easier-to-extend Sublime syntax definition file.

This will make it easier to resolve #3417, as one of the file types that `syntect` does not recognize does not support line comments (linker scripts), and parsing block comments is harder than parsing line comments.