### PR TITLE
make: llvm-tools no longer preview

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -23,12 +23,12 @@ RUSTC_SYSROOT := "$(shell rustc --print sysroot)"
 
 # Common defaults that specific boards can override, but likely do not need to.
 #
-# The TOOLCHAIN parameter is set to the magic value "llvm-tools-preview", which
-# will cause the Makefile to resolve the llvm toolchain installed as part of the
-# rustup component "llvm-tools-preview". In case a system toolchain shall be
-# used, this can be overridden to specify the toolchain prefix, e.g. "llvm" for
+# The TOOLCHAIN parameter is set to the magic value "llvm-tools", which will
+# cause the Makefile to resolve the llvm toolchain installed as part of the
+# rustup component "llvm-tools". In case a system toolchain shall be used, this
+# can be overridden to specify the toolchain prefix, e.g. "llvm" for
 # llvm-{objdump,objcopy,...} or "arm-none-eabi".
-TOOLCHAIN ?= llvm-tools-preview
+TOOLCHAIN ?= llvm-tools
 CARGO     ?= cargo
 
 # Not all platforms support the rustup tool. Those that do not can pass
@@ -180,9 +180,9 @@ endif
 # Verify that various required Rust components are installed. All of these steps
 # only have to be done once per Rust version, but will take some time when
 # compiling for the first time.
-LLVM_TOOLS_INSTALLED := $(shell $(RUSTUP) component list | grep 'llvm-tools-preview.*(installed)' > /dev/null; echo $$?)
+LLVM_TOOLS_INSTALLED := $(shell $(RUSTUP) component list | grep 'llvm-tools.*(installed)' > /dev/null; echo $$?)
 ifeq ($(LLVM_TOOLS_INSTALLED),1)
-  $(shell $(RUSTUP) component add llvm-tools-preview)
+  $(shell $(RUSTUP) component add llvm-tools)
 endif
 ifneq ($(shell $(RUSTUP) component list | grep rust-src),rust-src (installed))
   $(shell $(RUSTUP) component add rust-src)
@@ -192,11 +192,11 @@ ifneq ($(shell $(RUSTUP) target list | grep "$(TARGET) (installed)"),$(TARGET) (
 endif
 endif # $(NO_RUSTUP)
 
-# If the user is using the standard toolchain provided as part of the
-# llvm-tools-preview rustup component we need to get the full path. rustup
-# should take care of this for us by putting in a proxy in .cargo/bin, but until
-# that is setup we workaround it.
-ifeq ($(TOOLCHAIN),llvm-tools-preview)
+# If the user is using the standard toolchain provided as part of the llvm-tools
+# rustup component we need to get the full path. rustup should take care of this
+# for us by putting in a proxy in .cargo/bin, but until that is setup we
+# workaround it.
+ifeq ($(TOOLCHAIN),llvm-tools)
   TOOLCHAIN = "$(shell dirname $(shell find $(RUSTC_SYSROOT) -name llvm-size))/llvm"
 endif
 

--- a/tools/update_rust_version.sh
+++ b/tools/update_rust_version.sh
@@ -7,7 +7,7 @@
 # Ask rustup to pick the latest version that will work.
 # This requires rustup >= 1.20.0.
 echo "Updating rustc to latest compatible version..."
-rustup toolchain install nightly --allow-downgrade --component cargo --component clippy --component llvm-tools-preview --component miri --component rust-analysis --component rust-docs --component rust-src --component rust-std --component rustc --component rustfmt
+rustup toolchain install nightly --allow-downgrade --component cargo --component clippy --component llvm-tools --component miri --component rust-analysis --component rust-docs --component rust-src --component rust-std --component rustc --component rustfmt
 
 # # Rerun the command so that it prints out the version it installed. We then have
 # # to extract that from the output. If there is a better way to do this then we


### PR DESCRIPTION
### Pull Request Overview

Without this change I was getting:

```
$ make
info: component 'llvm-tools' for target 'x86_64-apple-darwin' is up to date
```
on every build. It seems llvm-tools is now a real thing, and no longer a preview.


### Testing Strategy

running make


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
