### PR TITLE
nrf52: remove unsafe and static mut from adc

### DIFF
--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -254,9 +254,10 @@ impl SyscallDriverLookup for Platform {
 #[inline(never)]
 unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> {
     // Initialize chip peripheral drivers
+    let adc_sample_buffer = static_init!([u8; 2], [0; 2]);
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new()
+        Nrf52840DefaultPeripherals::new(adc_sample_buffer)
     );
 
     nrf52840_peripherals

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -52,7 +52,7 @@ pub struct Nrf52DefaultPeripherals<'a> {
 }
 
 impl<'a> Nrf52DefaultPeripherals<'a> {
-    pub fn new() -> Self {
+    pub fn new(adc_sample_buf: &'static mut [u8; 2]) -> Self {
         Self {
             acomp: crate::acomp::Comparator::new(),
             ecb: crate::aes::AesECB::new(),
@@ -71,7 +71,7 @@ impl<'a> Nrf52DefaultPeripherals<'a> {
             spim1: crate::spi::SPIM::new(1),
             twi1: crate::i2c::TWI::new_twi1(),
             spim2: crate::spi::SPIM::new(2),
-            adc: crate::adc::Adc::new(),
+            adc: crate::adc::Adc::new(adc_sample_buf),
             nvmc: crate::nvmc::Nvmc::new(),
             clock: crate::clock::Clock::new(),
             pwm0: crate::pwm::Pwm::new(),

--- a/chips/nrf52840/src/interrupt_service.rs
+++ b/chips/nrf52840/src/interrupt_service.rs
@@ -16,9 +16,9 @@ pub struct Nrf52840DefaultPeripherals<'a> {
 }
 
 impl<'a> Nrf52840DefaultPeripherals<'a> {
-    pub unsafe fn new() -> Self {
+    pub unsafe fn new(adc_sample_buf: &'static mut [u8; 2]) -> Self {
         Self {
-            nrf52: Nrf52DefaultPeripherals::new(),
+            nrf52: Nrf52DefaultPeripherals::new(adc_sample_buf),
             usbd: crate::usbd::Usbd::new(),
             gpio_port: crate::gpio::nrf52840_gpio_create(),
         }


### PR DESCRIPTION
### Pull Request Overview

Since the nRF52 adc peripheral uses DMA, we were using a static mut buffer to store the ADC result. This requires `unsafe`. This PR is one attempt to remove that unsafe.

Of course, now we are doing perhaps undesirable things with buffers stored in a TakeCell.


### Testing Strategy

travis


### TODO or Help Wanted

What is better? This, or having `unsafe` in the driver?

If OK, needs to be added to each nrf board.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
