### PR TITLE
UDPHeader Visibility

### DIFF
--- a/boards/imix/src/test/ipv6_lowpan_test.rs
+++ b/boards/imix/src/test/ipv6_lowpan_test.rs
@@ -186,12 +186,7 @@ pub unsafe fn initialize_all(
     radio_mac.set_receive_client(sixlowpan);
 
     // Following code initializes an IP6Packet using the global UDP_DGRAM buffer as the payload
-    let mut udp_hdr: UDPHeader = UDPHeader {
-        src_port: 0,
-        dst_port: 0,
-        len: 0,
-        cksum: 0,
-    };
+    let mut udp_hdr: UDPHeader = UDPHeader::new();
     udp_hdr.set_src_port(12345);
     udp_hdr.set_dst_port(54321);
     udp_hdr.set_len(PAYLOAD_LEN as u16);

--- a/capsules/extra/src/net/udp/udp.rs
+++ b/capsules/extra/src/net/udp/udp.rs
@@ -18,10 +18,10 @@ use crate::net::stream::SResult;
 /// for the various fields of the header, to avoid confusion with endian-ness.
 #[derive(Copy, Clone, Debug)]
 pub struct UDPHeader {
-    pub src_port: u16,
-    pub dst_port: u16,
-    pub len: u16,
-    pub cksum: u16,
+    src_port: u16,
+    dst_port: u16,
+    len: u16,
+    cksum: u16,
 }
 
 impl Default for UDPHeader {


### PR DESCRIPTION
### Pull Request Overview

The fields of the UDPHeader struct are all currently public. These fields all possess getters/setters to insure correct endianness. To enforce the use of these getters/setters, the fields of this struct should be private.


### Testing Strategy

This is a minor visibility change and should not require testing beyond compile time checks.


### TODO or Help Wanted

N/A 


### Documentation Updated

- [ x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ x] Ran `make prepush`.
