### PR TITLE
nRF52 AES Improvements

### DIFF
--- a/boards/components/src/aes.rs
+++ b/boards/components/src/aes.rs
@@ -1,0 +1,160 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! Components for various AES utilities.
+//!
+//! Usage
+//! -----
+//! ```rust
+//! let aes_driver_device = components::aes::AesVirtualComponent::new(aes_mux).finalize(
+//!     components::aes_virtual_component_static!(nrf52840::aes::AesECB<'static>),
+//! );
+//!
+//! let aes = components::aes::AesDriverComponent::new(
+//!     board_kernel,
+//!     capsules_extra::symmetric_encryption::aes::DRIVER_NUM,
+//!     aes_driver_device,
+//! )
+//! .finalize(components::aes_driver_component_static!(
+//!     capsules_core::virtualizers::virtual_aes_ccm::VirtualAES128CCM<
+//!         'static,
+//!         nrf52840::aes::AesECB<'static>,
+//!     >
+//! ));
+//! ```
+
+use core::mem::MaybeUninit;
+use kernel::capabilities;
+use kernel::component::Component;
+use kernel::create_capability;
+use kernel::hil;
+use kernel::hil::symmetric_encryption::{
+    AES128Ctr, AES128, AES128CBC, AES128CCM, AES128ECB, AES128GCM,
+};
+
+const CRYPT_SIZE: usize = 7 * hil::symmetric_encryption::AES128_BLOCK_SIZE;
+
+#[macro_export]
+macro_rules! aes_virtual_component_static {
+    ($A:ty $(,)?) => {{
+        const CRYPT_SIZE: usize = 7 * kernel::hil::symmetric_encryption::AES128_BLOCK_SIZE;
+        let virtual_aes = kernel::static_buf!(
+            capsules_core::virtualizers::virtual_aes_ccm::VirtualAES128CCM<'static, $A>
+        );
+        let crypt_buf = kernel::static_buf!([u8; CRYPT_SIZE]);
+
+        (virtual_aes, crypt_buf)
+    };};
+}
+
+#[macro_export]
+macro_rules! aes_driver_component_static {
+    ($A:ty $(,)?) => {{
+        const CRYPT_SIZE: usize = 7 * kernel::hil::symmetric_encryption::AES128_BLOCK_SIZE;
+        let aes_src_buffer = kernel::static_buf!([u8; 16]);
+        let aes_dst_buffer = kernel::static_buf!([u8; CRYPT_SIZE]);
+        let aes_driver =
+            kernel::static_buf!(capsules_extra::symmetric_encryption::aes::AesDriver<'static, $A>);
+
+        (aes_driver, aes_src_buffer, aes_dst_buffer)
+    };};
+}
+
+pub struct AesVirtualComponent<A: 'static + AES128<'static> + AES128Ctr + AES128CBC + AES128ECB> {
+    aes_mux: &'static capsules_core::virtualizers::virtual_aes_ccm::MuxAES128CCM<'static, A>,
+}
+
+impl<A: 'static + AES128<'static> + AES128Ctr + AES128CBC + AES128ECB> AesVirtualComponent<A> {
+    pub fn new(
+        aes_mux: &'static capsules_core::virtualizers::virtual_aes_ccm::MuxAES128CCM<'static, A>,
+    ) -> Self {
+        Self { aes_mux }
+    }
+}
+
+impl<A: 'static + AES128<'static> + AES128Ctr + AES128CBC + AES128ECB> Component
+    for AesVirtualComponent<A>
+{
+    type StaticInput = (
+        &'static mut MaybeUninit<
+            capsules_core::virtualizers::virtual_aes_ccm::VirtualAES128CCM<'static, A>,
+        >,
+        &'static mut MaybeUninit<[u8; CRYPT_SIZE]>,
+    );
+    type Output =
+        &'static capsules_core::virtualizers::virtual_aes_ccm::VirtualAES128CCM<'static, A>;
+
+    fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
+        let crypt_buf = static_buffer.1.write([0; CRYPT_SIZE]);
+        let aes_ccm = static_buffer.0.write(
+            capsules_core::virtualizers::virtual_aes_ccm::VirtualAES128CCM::new(
+                self.aes_mux,
+                crypt_buf,
+            ),
+        );
+        aes_ccm.setup();
+
+        aes_ccm
+    }
+}
+
+pub struct AesDriverComponent<A: AES128<'static> + AES128CCM<'static> + 'static> {
+    board_kernel: &'static kernel::Kernel,
+    driver_num: usize,
+    aes: &'static A,
+}
+
+impl<A: AES128<'static> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'static>>
+    AesDriverComponent<A>
+{
+    pub fn new(
+        board_kernel: &'static kernel::Kernel,
+        driver_num: usize,
+        aes: &'static A,
+    ) -> AesDriverComponent<A> {
+        AesDriverComponent {
+            board_kernel,
+            driver_num,
+            aes,
+        }
+    }
+}
+
+impl<
+        A: AES128<'static>
+            + AES128Ctr
+            + AES128CBC
+            + AES128ECB
+            + AES128CCM<'static>
+            + AES128GCM<'static>,
+    > Component for AesDriverComponent<A>
+{
+    type StaticInput = (
+        &'static mut MaybeUninit<capsules_extra::symmetric_encryption::aes::AesDriver<'static, A>>,
+        &'static mut MaybeUninit<[u8; 16]>,
+        &'static mut MaybeUninit<[u8; CRYPT_SIZE]>,
+    );
+    type Output = &'static capsules_extra::symmetric_encryption::aes::AesDriver<'static, A>;
+
+    fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
+        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+        let aes_src_buf = static_buffer.1.write([0; 16]);
+        let aes_dst_buf = static_buffer.2.write([0; CRYPT_SIZE]);
+
+        let aes_driver =
+            static_buffer
+                .0
+                .write(capsules_extra::symmetric_encryption::aes::AesDriver::new(
+                    self.aes,
+                    aes_src_buf,
+                    aes_dst_buf,
+                    self.board_kernel.create_grant(self.driver_num, &grant_cap),
+                ));
+
+        hil::symmetric_encryption::AES128CCM::set_client(self.aes, aes_driver);
+        hil::symmetric_encryption::AES128::set_client(self.aes, aes_driver);
+
+        aes_driver
+    }
+}

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod adc;
 pub mod adc_microphone;
+pub mod aes;
 pub mod air_quality;
 pub mod alarm;
 pub mod analog_comparator;

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -89,6 +89,9 @@ use nrf52840::gpio::Pin;
 use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
 use nrf52_components::{self, UartChannel, UartPins};
 
+#[allow(dead_code)]
+mod test;
+
 // The nRF52840DK LEDs (see back of board)
 const LED1_PIN: Pin = Pin::P0_13;
 const LED2_PIN: Pin = Pin::P0_14;
@@ -813,6 +816,11 @@ pub unsafe fn main() {
     };
 
     let _ = platform.pconsole.start();
+
+    // test::aes_test::run_aes128_ctr(&base_peripherals.ecb);
+    // test::aes_test::run_aes128_cbc(&base_peripherals.ecb);
+    // test::aes_test::run_aes128_ecb(&base_peripherals.ecb);
+
     debug!("Initialization complete. Entering main loop\r");
     debug!("{}", &nrf52840::ficr::FICR_INSTANCE);
 

--- a/boards/nordic/nrf52840dk/src/test/aes_test.rs
+++ b/boards/nordic/nrf52840dk/src/test/aes_test.rs
@@ -1,0 +1,95 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! Test that AES (either CTR or CBC mode) is working properly.
+//!
+//! To test CBC mode, add the following line to the imix boot sequence:
+//! ```
+//!     test::aes_test::run_aes128_cbc();
+//! ```
+//! You should see the following output:
+//! ```
+//!     aes_test passed (CBC Enc Src/Dst)
+//!     aes_test passed (CBC Dec Src/Dst)
+//!     aes_test passed (CBC Enc In-place)
+//!     aes_test passed (CBC Dec In-place)
+//! ```
+//! To test CTR mode, add the following line to the imix boot sequence:
+//! ```
+//!     test::aes_test::run_aes128_ctr();
+//! ```
+//! You should see the following output:
+//! ```
+//!     aes_test CTR passed: (CTR Enc Ctr Src/Dst)
+//!     aes_test CTR passed: (CTR Dec Ctr Src/Dst)
+//! ```
+
+use capsules_extra::test::aes::TestAes128Cbc;
+use capsules_extra::test::aes::TestAes128Ctr;
+use capsules_extra::test::aes::TestAes128Ecb;
+use kernel::hil::symmetric_encryption::{AES128, AES128_BLOCK_SIZE, AES128_KEY_SIZE};
+use kernel::static_init;
+use nrf52840::aes::AesECB;
+
+pub unsafe fn run_aes128_ctr(aes: &'static AesECB) {
+    let t = static_init_test_ctr(aes);
+    aes.set_client(t);
+
+    t.run();
+}
+
+pub unsafe fn run_aes128_cbc(aes: &'static AesECB) {
+    let t = static_init_test_cbc(aes);
+    aes.set_client(t);
+
+    t.run();
+}
+
+pub unsafe fn run_aes128_ecb(aes: &'static AesECB) {
+    let t = static_init_test_ecb(aes);
+    aes.set_client(t);
+
+    t.run();
+}
+
+unsafe fn static_init_test_ctr(
+    aes: &'static AesECB,
+) -> &'static TestAes128Ctr<'static, AesECB<'static>> {
+    let source = static_init!([u8; 4 * AES128_BLOCK_SIZE], [0; 4 * AES128_BLOCK_SIZE]);
+    let data = static_init!([u8; 6 * AES128_BLOCK_SIZE], [0; 6 * AES128_BLOCK_SIZE]);
+    let key = static_init!([u8; AES128_KEY_SIZE], [0; AES128_KEY_SIZE]);
+    let iv = static_init!([u8; AES128_BLOCK_SIZE], [0; AES128_BLOCK_SIZE]);
+
+    static_init!(
+        TestAes128Ctr<'static, AesECB>,
+        TestAes128Ctr::new(&aes, key, iv, source, data)
+    )
+}
+
+unsafe fn static_init_test_cbc(
+    aes: &'static AesECB,
+) -> &'static TestAes128Cbc<'static, AesECB<'static>> {
+    let source = static_init!([u8; 4 * AES128_BLOCK_SIZE], [0; 4 * AES128_BLOCK_SIZE]);
+    let data = static_init!([u8; 6 * AES128_BLOCK_SIZE], [0; 6 * AES128_BLOCK_SIZE]);
+    let key = static_init!([u8; AES128_KEY_SIZE], [0; AES128_KEY_SIZE]);
+    let iv = static_init!([u8; AES128_BLOCK_SIZE], [0; AES128_BLOCK_SIZE]);
+
+    static_init!(
+        TestAes128Cbc<'static, AesECB>,
+        TestAes128Cbc::new(&aes, key, iv, source, data)
+    )
+}
+
+unsafe fn static_init_test_ecb(
+    aes: &'static AesECB,
+) -> &'static TestAes128Ecb<'static, AesECB<'static>> {
+    let source = static_init!([u8; 4 * AES128_BLOCK_SIZE], [0; 4 * AES128_BLOCK_SIZE]);
+    let data = static_init!([u8; 6 * AES128_BLOCK_SIZE], [0; 6 * AES128_BLOCK_SIZE]);
+    let key = static_init!([u8; AES128_KEY_SIZE], [0; AES128_KEY_SIZE]);
+
+    static_init!(
+        TestAes128Ecb<'static, AesECB>,
+        TestAes128Ecb::new(&aes, key, source, data)
+    )
+}

--- a/boards/nordic/nrf52840dk/src/test/mod.rs
+++ b/boards/nordic/nrf52840dk/src/test/mod.rs
@@ -2,4 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2023.
 
+pub(crate) mod aes_test;
 pub(crate) mod siphash24_test;

--- a/capsules/extra/src/test/aes.rs
+++ b/capsules/extra/src/test/aes.rs
@@ -284,9 +284,15 @@ impl<'a, A: AES128<'a> + AES128Ctr> hil::symmetric_encryption::Client<'a> for Te
         self.aes.disable();
 
         // Continue testing with other configurations
-        if self.encrypting.get() {
-            self.encrypting.set(false);
+        if self.use_source.get() {
+            self.use_source.set(false);
             self.run();
+        } else {
+            if self.encrypting.get() {
+                self.encrypting.set(false);
+                self.use_source.set(true);
+                self.run();
+            }
         }
     }
 }
@@ -435,13 +441,13 @@ impl<'a, A: AES128<'a> + AES128CBC> hil::symmetric_encryption::Client<'a> for Te
         self.aes.disable();
 
         // Continue testing with other configurations
-        if self.encrypting.get() {
-            self.encrypting.set(false);
+        if self.use_source.get() {
+            self.use_source.set(false);
             self.run();
         } else {
-            if self.use_source.get() {
-                self.use_source.set(false);
-                self.encrypting.set(true);
+            if self.encrypting.get() {
+                self.encrypting.set(false);
+                self.use_source.set(true);
                 self.run();
             }
         }
@@ -490,13 +496,13 @@ impl<'a, A: AES128<'a> + AES128ECB> hil::symmetric_encryption::Client<'a> for Te
         self.aes.disable();
 
         // Continue testing with other configurations
-        if self.encrypting.get() {
-            self.encrypting.set(false);
+        if self.use_source.get() {
+            self.use_source.set(false);
             self.run();
         } else {
-            if self.use_source.get() {
-                self.use_source.set(false);
-                self.encrypting.set(true);
+            if self.encrypting.get() {
+                self.encrypting.set(false);
+                self.use_source.set(true);
                 self.run();
             }
         }

--- a/chips/nrf5x/src/aes.rs
+++ b/chips/nrf5x/src/aes.rs
@@ -4,10 +4,11 @@
 
 //! AES128 driver, nRF5X-family
 //!
-//! Provides a simple driverto encrypt and decrypt
-//! messages using aes128-ctr mode on top of aes128-ecb.
+//! Provides a simple driver to encrypt and decrypt messages using aes128-ctr
+//! mode on top of aes128-ecb, as well as encrypt with aes128-ecb and
+//! aes128-cbc.
 //!
-//! Roughly, the module three buffers with the following content:
+//! Roughly, the module uses three buffers with the following content:
 //!
 //! * Key
 //! * Initial counter
@@ -124,8 +125,16 @@ register_bitfields! [u32,
     ]
 ];
 
+#[derive(Copy, Clone, Debug)]
+enum AESMode {
+    ECB,
+    CTR,
+    CBC,
+}
+
 pub struct AesECB<'a> {
     registers: StaticRef<AesEcbRegisters>,
+    mode: Cell<AESMode>,
     client: OptionalCell<&'a dyn kernel::hil::symmetric_encryption::Client<'a>>,
     /// Input either plaintext or ciphertext to be encrypted or decrypted.
     input: TakeCell<'static, [u8]>,
@@ -141,6 +150,7 @@ impl<'a> AesECB<'a> {
     pub fn new() -> AesECB<'a> {
         AesECB {
             registers: AESECB_BASE,
+            mode: Cell::new(AESMode::CTR),
             client: OptionalCell::empty(),
             input: TakeCell::empty(),
             output: TakeCell::empty(),
@@ -157,6 +167,45 @@ impl<'a> AesECB<'a> {
         }
     }
 
+    /// Verify that the provided start and stop indices work with the given
+    /// buffers.
+    fn try_set_indices(&self, start_index: usize, stop_index: usize) -> bool {
+        stop_index.checked_sub(start_index).map_or(false, |sublen| {
+            sublen % symmetric_encryption::AES128_BLOCK_SIZE == 0 && {
+                self.input.map_or_else(
+                    || {
+                        // The destination buffer is also the input
+                        if self.output.map_or(false, |dest| stop_index <= dest.len()) {
+                            self.current_idx.set(0);
+                            self.start_idx.set(start_index);
+                            self.end_idx.set(stop_index);
+                            true
+                        } else {
+                            false
+                        }
+                    },
+                    |source| {
+                        if sublen == source.len()
+                            && self.output.map_or(false, |dest| stop_index <= dest.len())
+                        {
+                            // We will start writing to the AES from the
+                            // beginning of `source`, and end at its end
+                            self.current_idx.set(0);
+
+                            // We will start reading from the AES into `dest` at
+                            // `start_index`, and continue until `stop_index`
+                            self.start_idx.set(start_index);
+                            self.end_idx.set(stop_index);
+                            true
+                        } else {
+                            false
+                        }
+                    },
+                )
+            }
+        })
+    }
+
     // FIXME: should this be performed in constant time i.e. skip the break part
     // and always loop 16 times?
     fn update_ctr(&self) {
@@ -170,7 +219,100 @@ impl<'a> AesECB<'a> {
         }
     }
 
+    /// Get the relevant positions of our input data whether we are using a
+    /// source buffer or overwriting the destination buffer.
+    fn get_start_end_take(&self) -> (usize, usize, usize) {
+        let current_idx = self.current_idx.get();
+
+        // Location in the appropriate source buffer we are currently working
+        // on.
+        let start = current_idx + self.input.map_or(self.start_idx.get(), |_| 0);
+        // Last index in the appropriate source buffer we need to work on.
+        let end = self.end_idx.get() - self.input.map_or(0, |_| self.start_idx.get());
+
+        // Get the number of bytes that were used in the keystream/block.
+        let take = match end.checked_sub(start) {
+            Some(v) if v > symmetric_encryption::AES128_BLOCK_SIZE => {
+                symmetric_encryption::AES128_BLOCK_SIZE
+            }
+            Some(v) => v,
+            None => 0,
+        };
+
+        (start, end, take)
+    }
+
+    fn copy_plaintext(&self) {
+        let (start, _end, take) = self.get_start_end_take();
+
+        // Copy the plaintext either from the source if it exists or from the
+        // destination buffer.
+        if take > 0 {
+            match self.mode.get() {
+                AESMode::ECB => {
+                    self.input.map_or_else(
+                        || {
+                            self.output.map(|output| {
+                                for i in 0..take {
+                                    unsafe {
+                                        ECB_DATA[i + PLAINTEXT_START] = output[i + start];
+                                    }
+                                }
+                            });
+                        },
+                        |input| {
+                            for i in 0..take {
+                                unsafe {
+                                    ECB_DATA[i + PLAINTEXT_START] = input[i + start];
+                                }
+                            }
+                        },
+                    );
+                }
+
+                AESMode::CBC => {
+                    self.input.map_or_else(
+                        || {
+                            self.output.map(|output| {
+                                for i in 0..take {
+                                    let ecb_idx = i + PLAINTEXT_START;
+
+                                    unsafe {
+                                        ECB_DATA[ecb_idx] = ECB_DATA[ecb_idx] ^ output[i + start];
+                                    }
+                                }
+                            });
+                        },
+                        |input| {
+                            for i in 0..take {
+                                let ecb_idx = i + PLAINTEXT_START;
+                                unsafe {
+                                    ECB_DATA[ecb_idx] = ECB_DATA[ecb_idx] ^ input[i + start];
+                                }
+                            }
+                        },
+                    );
+                }
+
+                AESMode::CTR => {
+                    // no copying plaintext in ctr mode
+                }
+            }
+        }
+    }
+
     fn crypt(&self) {
+        match self.mode.get() {
+            AESMode::CTR => {}
+            AESMode::ECB => {
+                // Need to copy the plaintext to the ECB buffer.
+                self.copy_plaintext();
+            }
+            AESMode::CBC => {
+                self.copy_plaintext();
+            }
+        }
+
         self.registers.event_endecb.write(Event::READY::CLEAR);
         self.registers.task_startecb.set(1);
 
@@ -183,57 +325,136 @@ impl<'a> AesECB<'a> {
         self.disable_interrupts();
 
         if self.registers.event_endecb.get() == 1 {
-            let current_idx = self.current_idx.get();
-            let end_idx = self.end_idx.get();
+            match self.mode.get() {
+                AESMode::CTR => {
+                    let current_idx = self.current_idx.get();
 
-            // Get the number of bytes to be used in the keystream/block
-            let take = match end_idx.checked_sub(current_idx) {
-                Some(v) if v > symmetric_encryption::AES128_BLOCK_SIZE => {
-                    symmetric_encryption::AES128_BLOCK_SIZE
-                }
-                Some(v) => v,
-                None => 0,
-            };
+                    let (start, end, take) = self.get_start_end_take();
 
-            let mut ks = self.keystream.get();
+                    let mut ks = self.keystream.get();
 
-            // Append keystream to the KEYSTREAM array
-            if take > 0 {
-                for i in current_idx..current_idx + take {
-                    ks[i] = unsafe { ECB_DATA[i - current_idx + PLAINTEXT_END] }
-                }
-                self.current_idx.set(current_idx + take);
-                self.update_ctr();
-            }
-
-            // More bytes to encrypt!!!
-            if self.current_idx.get() < self.end_idx.get() {
-                self.crypt();
-            }
-            // Entire keystream generated we are done!
-            // XOR keystream the input
-            else if self.input.is_some() && self.output.is_some() {
-                self.input.take().map(|slice| {
-                    self.output.take().map(|buf| {
-                        let start = self.start_idx.get();
-                        let end = self.end_idx.get();
-                        let len = end - start;
-
-                        for ((i, out), inp) in buf.as_mut()[start..end]
-                            .iter_mut()
-                            .enumerate()
-                            .zip(slice.as_ref()[0..len].iter())
-                        {
-                            *out = ks[i] ^ *inp;
+                    // Append keystream to the KEYSTREAM array
+                    if take > 0 {
+                        for i in 0..take {
+                            ks[current_idx + i] = unsafe { ECB_DATA[i + PLAINTEXT_END] }
                         }
+                        self.current_idx.set(current_idx + take);
+                        self.update_ctr();
+                    }
 
-                        self.client
-                            .map(move |client| client.crypt_done(Some(slice), buf));
-                    });
-                });
+                    // More bytes to encrypt!!!
+                    if start + take < end {
+                        self.crypt();
+                    } else {
+                        // Entire keystream generated we are done!
+                        // XOR keystream the input.
+                        self.input.take().map_or_else(
+                            || {
+                                self.output.take().map(|output| {
+                                    let start = self.start_idx.get();
+                                    let end = self.end_idx.get();
+
+                                    for (i, out) in
+                                        output.as_mut()[start..end].iter_mut().enumerate()
+                                    {
+                                        *out = ks[i] ^ *out;
+                                    }
+
+                                    self.client
+                                        .map(move |client| client.crypt_done(None, output));
+                                });
+                            },
+                            |input| {
+                                self.output.take().map(|output| {
+                                    let start = self.start_idx.get();
+                                    let end = self.end_idx.get();
+                                    let len = end - start;
+
+                                    for ((i, out), inp) in output.as_mut()[start..end]
+                                        .iter_mut()
+                                        .enumerate()
+                                        .zip(input.as_ref()[0..len].iter())
+                                    {
+                                        *out = ks[i] ^ *inp;
+                                    }
+
+                                    self.client
+                                        .map(move |client| client.crypt_done(Some(input), output));
+                                });
+                            },
+                        );
+                    }
+
+                    self.keystream.set(ks);
+                }
+
+                AESMode::ECB => {
+                    let start_idx = self.start_idx.get();
+                    let current_idx = self.current_idx.get();
+                    let (start, end, take) = self.get_start_end_take();
+
+                    // Copy ciphertext to output.
+                    if take > 0 {
+                        self.output.map(|output| {
+                            for i in 0..take {
+                                // We write to the buffer starting at the
+                                // originally provided start index, plus our
+                                // offset at current_idx.
+                                let dest_idx = start_idx + current_idx + i;
+                                unsafe {
+                                    output[dest_idx] = ECB_DATA[i + PLAINTEXT_END];
+                                }
+                            }
+                        });
+                    }
+
+                    self.current_idx.set(current_idx + take);
+
+                    if start + take < end {
+                        // More to do.
+                        self.crypt();
+                    } else {
+                        self.output.take().map(|output| {
+                            self.client
+                                .map(move |client| client.crypt_done(self.input.take(), output));
+                        });
+                    }
+                }
+                AESMode::CBC => {
+                    let start_idx = self.start_idx.get();
+                    let current_idx = self.current_idx.get();
+                    let (start, end, take) = self.get_start_end_take();
+
+                    // Copy ciphertext to both output AND the ECB payload to use
+                    // on the next iteration.
+                    if take > 0 {
+                        self.output.map(|output| {
+                            for i in 0..take {
+                                // We write to the buffer starting at the
+                                // originally provided start index, plus our
+                                // offset at current_idx.
+                                let dest_idx = start_idx + current_idx + i;
+                                unsafe {
+                                    output[dest_idx] = ECB_DATA[i + PLAINTEXT_END];
+                                    ECB_DATA[i + PLAINTEXT_START] = ECB_DATA[i + PLAINTEXT_END];
+                                }
+                            }
+                        });
+                    }
+
+                    self.current_idx.set(current_idx + take);
+
+                    if start + take < end {
+                        // More to do.
+                        self.crypt();
+                    } else {
+                        self.output.take().map(|output| {
+                            self.client
+                                .map(move |client| client.crypt_done(self.input.take(), output));
+                        });
+                    }
+                }
             }
-
-            self.keystream.set(ks);
         }
     }
 
@@ -295,8 +516,6 @@ impl<'a> kernel::hil::symmetric_encryption::AES128<'a> for AesECB<'a> {
         ()
     }
 
-    // start_index and stop_index not used!!!
-    // assuming that
     fn crypt(
         &self,
         source: Option<&'static mut [u8]>,
@@ -308,49 +527,52 @@ impl<'a> kernel::hil::symmetric_encryption::AES128<'a> for AesECB<'a> {
         Option<&'static mut [u8]>,
         &'static mut [u8],
     )> {
-        match source {
-            None => Some((Err(ErrorCode::INVAL), source, dest)),
-            Some(src) => {
-                if stop_index - start_index <= MAX_LENGTH {
-                    // replace buffers
-                    self.input.replace(src);
-                    self.output.replace(dest);
-
-                    // configure buffer offsets
-                    self.current_idx.set(0);
-                    self.start_idx.set(start_index);
-                    self.end_idx.set(stop_index);
-
-                    // start crypt
-                    self.crypt();
-                    None
-                } else {
-                    Some((Err(ErrorCode::SIZE), Some(src), dest))
-                }
-            }
+        self.input.put(source);
+        self.output.replace(dest);
+        if self.try_set_indices(start_index, stop_index) {
+            self.crypt();
+            None
+        } else {
+            Some((
+                Err(ErrorCode::INVAL),
+                self.input.take(),
+                self.output.take().unwrap(),
+            ))
         }
     }
 }
 
 impl kernel::hil::symmetric_encryption::AES128ECB for AesECB<'_> {
     // not needed by NRF5x (the configuration is the same for encryption and decryption)
-    fn set_mode_aes128ecb(&self, _encrypting: bool) -> Result<(), ErrorCode> {
-        Ok(())
+    fn set_mode_aes128ecb(&self, encrypting: bool) -> Result<(), ErrorCode> {
+        if encrypting {
+            self.mode.set(AESMode::ECB);
+            Ok(())
+        } else {
+            Err(ErrorCode::INVAL)
+        }
     }
 }
 
 impl kernel::hil::symmetric_encryption::AES128Ctr for AesECB<'_> {
     // not needed by NRF5x (the configuration is the same for encryption and decryption)
     fn set_mode_aes128ctr(&self, _encrypting: bool) -> Result<(), ErrorCode> {
+        self.mode.set(AESMode::CTR);
         Ok(())
     }
 }
 
 impl kernel::hil::symmetric_encryption::AES128CBC for AesECB<'_> {
-    fn set_mode_aes128cbc(&self, _encrypting: bool) -> Result<(), ErrorCode> {
-        Ok(())
+    fn set_mode_aes128cbc(&self, encrypting: bool) -> Result<(), ErrorCode> {
+        if encrypting {
+            self.mode.set(AESMode::CBC);
+            Ok(())
+        } else {
+            Err(ErrorCode::INVAL)
+        }
     }
 }
+
 //TODO: replace this placeholder with a proper implementation of the AES system
 impl<'a> kernel::hil::symmetric_encryption::AES128CCM<'a> for AesECB<'a> {
     /// Set the client instance which will receive `crypt_done()` callbacks

--- a/chips/nrf5x/src/aes.rs
+++ b/chips/nrf5x/src/aes.rs
@@ -250,6 +250,7 @@ impl<'a> AesECB<'a> {
                         || {
                             self.output.map(|output| {
                                 for i in 0..take {
+                                    // Copy into static mut DMA buffer
                                     unsafe {
                                         ECB_DATA[i + PLAINTEXT_START] = output[i + start];
                                     }
@@ -258,6 +259,7 @@ impl<'a> AesECB<'a> {
                         },
                         |input| {
                             for i in 0..take {
+                                // Copy into static mut DMA buffer
                                 unsafe {
                                     ECB_DATA[i + PLAINTEXT_START] = input[i + start];
                                 }
@@ -273,6 +275,7 @@ impl<'a> AesECB<'a> {
                                 for i in 0..take {
                                     let ecb_idx = i + PLAINTEXT_START;
 
+                                    // Copy into static mut DMA buffer
                                     unsafe {
                                         ECB_DATA[ecb_idx] = ECB_DATA[ecb_idx] ^ output[i + start];
                                     }
@@ -282,6 +285,7 @@ impl<'a> AesECB<'a> {
                         |input| {
                             for i in 0..take {
                                 let ecb_idx = i + PLAINTEXT_START;
+                                // Copy into static mut DMA buffer
                                 unsafe {
                                     ECB_DATA[ecb_idx] = ECB_DATA[ecb_idx] ^ input[i + start];
                                 }
@@ -370,6 +374,7 @@ impl<'a> AesECB<'a> {
                                 // originally provided start index, plus our
                                 // offset at current_idx.
                                 let dest_idx = start_idx + current_idx + i;
+                                // Copy out of static mut DMA buffer
                                 unsafe {
                                     output[dest_idx] = ECB_DATA[i + PLAINTEXT_END];
                                 }
@@ -387,6 +392,7 @@ impl<'a> AesECB<'a> {
                                 // originally provided start index, plus our
                                 // offset at current_idx.
                                 let dest_idx = start_idx + current_idx + i;
+                                // Copy out of static mut DMA buffer
                                 unsafe {
                                     output[dest_idx] = ECB_DATA[i + PLAINTEXT_END];
                                     ECB_DATA[i + PLAINTEXT_START] = ECB_DATA[i + PLAINTEXT_END];


### PR DESCRIPTION
### Pull Request Overview

This pull request:

- Updates the nRF52 AES driver to support ECB and CBC, as well as in-place operations for ECB, CBC, and CTR.
- Adds an AES component.
- ~~Adds the userspace AES driver to the nRF52840dk board.~~
- Adds the AES tests to the nRF52840dk board.
- Updates the AES tests to run all configurations (encryption first, both diff buffers and in place, then decryption).

Note, the nRF52 ECB module does not support decryption, so the ECB and CBC decryption tests fail.


This pull request is me getting familiar with the AES support on the nRF52 in hopes of using it for the Tock Tutorial.

### Testing Strategy

Running the kernel AES tests.


### TODO or Help Wanted

When I run the libtock-c/aes test app, I get:

```
[TEST] AES CTR Example Test
Loading in the key...
   done
Loading in the IV buf...
   done
Loading in the first half of the source buf...
   done
Setting up the first half of the dest buf...
   done
Setting up the callback...
   done
Starting the initial run...
   done
Loading in second half of the source buf...
   done
Running AES twice...
   done
Finish AES operation...
   done
Encrypted text: '���␒�␇	ѕ�6␐��ΓSY␕R'
Loading in the decryption source buf...
   done
Setting up the decryption dest buf...
   done
Running decryption...
   done
Finish AES operation...
   done
Original text: 'A language empowering everyone to build reliable and efficient software.'
[TEST] AES CCM Example Test
Loading in the key...
   done
Loading in the nonce buf...
   done
Loading in the source buf...
tock$    done
Setting up the dest buf...
   done
Setting up the callback...
   done
Starting the initial run...
   done
Finish AES operation...
   done
Comparison failure at 0
Expected value: 0x4a
 But got value: 0x2
```

~~So the AES CTR works, but the CCM does not. I did not change any of the CCM code. Do we know if that test is supposed to work? I believe the userland test app uses a different size IV than the in-kernel CCM test.~~

Nevermind, since we don't have GCM we cannot use the userspace driver.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
