### PR TITLE
Add support for block comments to the license checker.

### DIFF
--- a/.lcignore
+++ b/.lcignore
@@ -35,5 +35,7 @@
 # File types that the license checker does not support but should support (see
 # issue #3417)
 *.ld
+!/tools/license-checker/testdata/block_comments.ld
 *.jlink
 *.xml
+!/tools/license-checker/testdata/block_comments.xml

--- a/tools/license-checker/src/fallback_syntax.yaml
+++ b/tools/license-checker/src/fallback_syntax.yaml
@@ -25,6 +25,10 @@ contexts:
       scope: punctuation.definition.comment.fallback
       push: [has_slashes_comments, slashes_comment]
 
+    - match: "^/\\*"
+      scope: punctuation.definition.comment.fallback
+      push: [has_slashstar_comments, slashstar_comment]
+
     # If none of the above matchers match, and this line is not entirely
     # whitespace, then assume the filetype does not support comments.
     - match: "\\S"
@@ -50,9 +54,19 @@ contexts:
     - match: $\n?
       pop: true
 
+  # /* */ -style comments. This does not allow for nested comments.
+  has_slashstar_comments:
+    - match: "^/\\*"
+      scope: punctuation.definition.comment.fallback
+      push: slashstar_comment
+
+  slashstar_comment:
+    - meta_scope: comment.block.fallback
+    - match: "\\*/"
+      scope: punctuation.definition.comment.fallback
+      pop: true
+
   # Context used for files that do not have comments, e.g. plain text files. For
   # these, we consider every line to be a comment.
   has_no_comments:
-    # TODO: This should probably be changed to comment.block.fallback once the
-    # license checker supports block comments.
-    - meta_scope: comment.line.fallback
+    - meta_scope: comment.block.fallback

--- a/tools/license-checker/testdata/block_comments.ld
+++ b/tools/license-checker/testdata/block_comments.ld
@@ -1,0 +1,8 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+/* Copyright Google LLC 2023.                                         */
+
+/*
+This file contains two styles of block comment.
+*/

--- a/tools/license-checker/testdata/block_comments.xml
+++ b/tools/license-checker/testdata/block_comments.xml
@@ -1,0 +1,8 @@
+<!-- Licensed under the Apache License, Version 2.0 or the MIT License. -->
+<!-- SPDX-License-Identifier: Apache-2.0 OR MIT                         -->
+<!-- Copyright Tock Contributors 2023.                                  -->
+<!-- Copyright Google LLC 2023.                                         -->
+
+<!--
+This file contains two styles of block comment.
+-->


### PR DESCRIPTION
As noted in #3417, there are two file types in the Tock repository that do not support line comments: XML, and linker scripts. This PR allows the license checker to operate on those files.

I will add license headers to XML files and linker scripts in a follow-up PR.

**Limitation**

This PR does not support the following comment format:

```rust
/* Licensed under ...
 * SPDX-License-Identifier: ...
 * Copyright ...
 */
```

because the license checker decodes the comment body as:

```
Licensed under ...
* SPDX-License-Identifier: ...
* Copyright ...
```

and errors on the leading `*`'s. I don't see an easy and reliable way to identify that comment style and filter out the leading `*`'s. Because block comments are rare in Tock's codebase, I don't feel that we should add complexity to handle them. Instead, use the following format:

```rust
/* Licensed under ...           */
/* SPDX-License-Identifier: ... */
/* Copyright ...                */
```

When I write documentation for the license checker (tracked in #3419), I will document this clearly.