### PR TITLE
process: print: display credential, if available

### DIFF
--- a/kernel/src/process_printer.rs
+++ b/kernel/src/process_printer.rs
@@ -151,6 +151,13 @@ impl ProcessPrinter for ProcessPrinterText {
             None => bww.write_str(" Completion Code: None\r\n"),
         };
 
+        let _ = match process.get_credentials() {
+            Some(credential) => {
+                bww.write_fmt(format_args!(" Credential: {:?}\r\n", credential.format()))
+            }
+            None => bww.write_str(" Credential: None\r\n"),
+        };
+
         let _ = bww.write_fmt(format_args!(
             "\
                  \r\n\


### PR DESCRIPTION

### Pull Request Overview

When we print process information include if there was a suitable credential that was validated when this process was loaded.


New print out looks like:

```
tock$ process crash_dummy
𝐀𝐩𝐩: crash_dummy   -   [Yielded]
 Events Queued: 0   Syscall Count: 6   Dropped Upcall Count: 0
 Restart Count: 0
 Last Syscall: Yield { which: 1, address: 0x0 }
 Completion Code: None
 Credential: None


 ╔═══════════╤══════════════════════════════════════════╗
 ║  Address  │ Region Name    Used | Allocated (bytes)  ║
 ╚0x20009000═╪══════════════════════════════════════════╝
             │ Grant Ptrs      112
             │ Upcalls         320
             │ Process         920
  0x20008AB8 ┼───────────────────────────────────────────
             │ ▼ Grant          16
  0x20008AA8 ┼───────────────────────────────────────────
             │ Unused
  0x200079F8 ┼───────────────────────────────────────────
             │ ▲ Heap            0 |   4272               S
  0x200079F8 ┼─────────────────────────────────────────── R
             │ Data            504 |    504               A
  0x20007800 ┼─────────────────────────────────────────── M
             │ ▼ Stack          88 |   2048
  0x200077A8 ┼───────────────────────────────────────────
             │ Unused
  0x20007000 ┴───────────────────────────────────────────
             .....
  0x00031000 ┬─────────────────────────────────────────── F
             │ App Flash      4016                        L
  0x00030050 ┼─────────────────────────────────────────── A
             │ Protected        80                        S
  0x00030000 ┴─────────────────────────────────────────── H
```


### Testing Strategy

Using the process console.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
