### PR TITLE
nrf52: adc: Add highspeed implementation.

### DIFF
--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -844,6 +844,7 @@ pub unsafe fn main() {
     };
 
     let _ = platform.pconsole.start();
+    base_peripherals.adc.calibrate();
 
     // test::aes_test::run_aes128_ctr(&base_peripherals.ecb);
     // test::aes_test::run_aes128_cbc(&base_peripherals.ecb);

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -189,6 +189,7 @@ pub struct Platform {
         4,
     >,
     rng: &'static capsules_core::rng::RngDriver<'static>,
+    adc: &'static capsules_core::adc::AdcDedicated<'static, nrf52840::adc::Adc<'static>>,
     temp: &'static capsules_extra::temperature::TemperatureSensor<'static>,
     ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     analog_comparator: &'static capsules_extra::analog_comparator::AnalogComparator<
@@ -232,6 +233,7 @@ impl SyscallDriverLookup for Platform {
             capsules_core::led::DRIVER_NUM => f(Some(self.led)),
             capsules_core::button::DRIVER_NUM => f(Some(self.button)),
             capsules_core::rng::DRIVER_NUM => f(Some(self.rng)),
+            capsules_core::adc::DRIVER_NUM => f(Some(self.adc)),
             capsules_extra::ble_advertising_driver::DRIVER_NUM => f(Some(self.ble_radio)),
             capsules_extra::ieee802154::DRIVER_NUM => f(Some(self.ieee802154_radio)),
             capsules_extra::temperature::DRIVER_NUM => f(Some(self.temp)),
@@ -621,6 +623,31 @@ pub unsafe fn main() {
     .finalize(components::rng_component_static!());
 
     //--------------------------------------------------------------------------
+    // ADC
+    //--------------------------------------------------------------------------
+
+    let adc_channels = static_init!(
+        [nrf52840::adc::AdcChannelSetup; 6],
+        [
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput1),
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput2),
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput4),
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput5),
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput6),
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput7),
+        ]
+    );
+    let adc = components::adc::AdcDedicatedComponent::new(
+        &base_peripherals.adc,
+        adc_channels,
+        board_kernel,
+        capsules_core::adc::DRIVER_NUM,
+    )
+    .finalize(components::adc_dedicated_component_static!(
+        nrf52840::adc::Adc
+    ));
+
+    //--------------------------------------------------------------------------
     // SPI
     //--------------------------------------------------------------------------
 
@@ -799,6 +826,7 @@ pub unsafe fn main() {
         led,
         gpio,
         rng,
+        adc,
         temp,
         alarm,
         analog_comparator,

--- a/chips/nrf52/src/adc.rs
+++ b/chips/nrf52/src/adc.rs
@@ -499,24 +499,8 @@ impl<'a> hil::adc::Adc<'a> for Adc<'a> {
     type Channel = AdcChannelSetup;
 
     fn sample(&self, channel: &Self::Channel) -> Result<(), ErrorCode> {
-        // Positive goes to the channel passed in, negative not connected.
-        self.registers.ch[0]
-            .pselp
-            .write(PSEL::PSEL.val(channel.channel as u32));
-        self.registers.ch[0].pseln.write(PSEL::PSEL::NotConnected);
-
-        // Configure the ADC for a single read.
-        self.registers.ch[0].config.write(
-            CONFIG::GAIN.val(channel.gain as u32)
-                + CONFIG::REFSEL::VDD1_4
-                + CONFIG::TACQ.val(channel.sampling_time as u32)
-                + CONFIG::RESP.val(channel.resp as u32)
-                + CONFIG::RESN.val(channel.resn as u32)
-                + CONFIG::MODE::SE,
-        );
-
-        // Set max resolution (with oversampling).
-        self.registers.resolution.write(RESOLUTION::VAL::bit12);
+        self.setup_channel(channel);
+        self.setup_resolution();
 
         // Do one measurement.
         self.registers

--- a/chips/nrf52/src/adc.rs
+++ b/chips/nrf52/src/adc.rs
@@ -348,11 +348,10 @@ pub struct Adc<'a> {
 }
 
 impl<'a> Adc<'a> {
-    pub fn new() -> Self {
+    pub fn new(voltage_reference_in_mv: usize) -> Self {
         Self {
             registers: SAADC_BASE,
-            // Default to 3.3 V VDD reference.
-            reference: Cell::new(3300),
+            reference: Cell::new(voltage_reference_in_mv),
             mode: Cell::new(AdcMode::Idle),
             client: OptionalCell::empty(),
             highspeed_client: OptionalCell::empty(),

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -23,7 +23,8 @@ impl<'a, I: InterruptService + 'a> NRF52<'a, I> {
     }
 }
 
-/// This struct, when initialized, instantiates all peripheral drivers for the apollo3.
+/// This struct, when initialized, instantiates all peripheral drivers for the nrf52.
+///
 /// If a board wishes to use only a subset of these peripherals, this
 /// should not be used or imported, and a modified version should be
 /// constructed manually in main.rs.

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -72,7 +72,8 @@ impl<'a> Nrf52DefaultPeripherals<'a> {
             spim1: crate::spi::SPIM::new(1),
             twi1: crate::i2c::TWI::new_twi1(),
             spim2: crate::spi::SPIM::new(2),
-            adc: crate::adc::Adc::new(),
+            // Default to 3.3 V VDD reference.
+            adc: crate::adc::Adc::new(3300),
             nvmc: crate::nvmc::Nvmc::new(),
             clock: crate::clock::Clock::new(),
             pwm0: crate::pwm::Pwm::new(),


### PR DESCRIPTION
### Pull Request Overview

This pull request adds an implementation of `hil::adc::AdcHighSpeed` for the nRF52.

The main issue is that the internal clock divider for the SAADC only allows dividing a 16 MHz clock by a value in the range 80 to 2047 (so 8 kHz to 200 kHz sampling). So there is a limited range of possible frequencies. This is also why it's hard to implement continuous sampling.

This also adds VDD detection to the calibrate step, since the nRF52840dk uses a 3V reference and I couldn't figure out why my ADC readings were wrong.

### Testing Strategy

Using the libtock-c adc app.


### TODO or Help Wanted

How good of a driver do we need?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
