### PR TITLE
Remove 'static from ADC HIL client

### DIFF
--- a/boards/components/src/adc.rs
+++ b/boards/components/src/adc.rs
@@ -57,17 +57,17 @@ macro_rules! adc_dedicated_component_static {
     };};
 }
 
-pub struct AdcMuxComponent<A: 'static + adc::Adc> {
+pub struct AdcMuxComponent<A: 'static + adc::Adc<'static>> {
     adc: &'static A,
 }
 
-impl<A: 'static + adc::Adc> AdcMuxComponent<A> {
+impl<A: 'static + adc::Adc<'static>> AdcMuxComponent<A> {
     pub fn new(adc: &'static A) -> Self {
         AdcMuxComponent { adc: adc }
     }
 }
 
-impl<A: 'static + adc::Adc> Component for AdcMuxComponent<A> {
+impl<A: 'static + adc::Adc<'static>> Component for AdcMuxComponent<A> {
     type StaticInput = &'static mut MaybeUninit<MuxAdc<'static, A>>;
     type Output = &'static MuxAdc<'static, A>;
 
@@ -80,12 +80,12 @@ impl<A: 'static + adc::Adc> Component for AdcMuxComponent<A> {
     }
 }
 
-pub struct AdcComponent<A: 'static + adc::Adc> {
+pub struct AdcComponent<A: 'static + adc::Adc<'static>> {
     adc_mux: &'static MuxAdc<'static, A>,
     channel: A::Channel,
 }
 
-impl<A: 'static + adc::Adc> AdcComponent<A> {
+impl<A: 'static + adc::Adc<'static>> AdcComponent<A> {
     pub fn new(mux: &'static MuxAdc<'static, A>, channel: A::Channel) -> Self {
         AdcComponent {
             adc_mux: mux,
@@ -94,7 +94,7 @@ impl<A: 'static + adc::Adc> AdcComponent<A> {
     }
 }
 
-impl<A: 'static + adc::Adc> Component for AdcComponent<A> {
+impl<A: 'static + adc::Adc<'static>> Component for AdcComponent<A> {
     type StaticInput = &'static mut MaybeUninit<AdcDevice<'static, A>>;
     type Output = &'static AdcDevice<'static, A>;
 
@@ -124,7 +124,7 @@ impl AdcVirtualComponent {
 impl Component for AdcVirtualComponent {
     type StaticInput = (
         &'static mut MaybeUninit<AdcVirtualized<'static>>,
-        &'static [&'static dyn kernel::hil::adc::AdcChannel],
+        &'static [&'static dyn kernel::hil::adc::AdcChannel<'static>],
     );
     type Output = &'static capsules_core::adc::AdcVirtualized<'static>;
 
@@ -148,7 +148,7 @@ impl Component for AdcVirtualComponent {
 }
 
 pub struct AdcDedicatedComponent<
-    A: kernel::hil::adc::Adc + kernel::hil::adc::AdcHighSpeed + 'static,
+    A: kernel::hil::adc::Adc<'static> + kernel::hil::adc::AdcHighSpeed<'static> + 'static,
 > {
     adc: &'static A,
     channels: &'static [A::Channel],
@@ -156,7 +156,9 @@ pub struct AdcDedicatedComponent<
     driver_num: usize,
 }
 
-impl<A: kernel::hil::adc::Adc + kernel::hil::adc::AdcHighSpeed + 'static> AdcDedicatedComponent<A> {
+impl<A: kernel::hil::adc::Adc<'static> + kernel::hil::adc::AdcHighSpeed<'static> + 'static>
+    AdcDedicatedComponent<A>
+{
     pub fn new(
         adc: &'static A,
         channels: &'static [A::Channel],
@@ -172,8 +174,8 @@ impl<A: kernel::hil::adc::Adc + kernel::hil::adc::AdcHighSpeed + 'static> AdcDed
     }
 }
 
-impl<A: kernel::hil::adc::Adc + kernel::hil::adc::AdcHighSpeed + 'static> Component
-    for AdcDedicatedComponent<A>
+impl<A: kernel::hil::adc::Adc<'static> + kernel::hil::adc::AdcHighSpeed<'static> + 'static>
+    Component for AdcDedicatedComponent<A>
 {
     type StaticInput = (
         &'static mut MaybeUninit<AdcDedicated<'static, A>>,

--- a/boards/components/src/adc_microphone.rs
+++ b/boards/components/src/adc_microphone.rs
@@ -50,7 +50,7 @@ macro_rules! adc_microphone_component_static {
 }
 
 pub struct AdcMicrophoneComponent<
-    A: 'static + adc::Adc,
+    A: 'static + adc::Adc<'static>,
     P: 'static + gpio::Pin,
     const BUF_LEN: usize,
 > {
@@ -59,7 +59,7 @@ pub struct AdcMicrophoneComponent<
     pin: Option<&'static P>,
 }
 
-impl<A: 'static + adc::Adc, P: 'static + gpio::Pin, const BUF_LEN: usize>
+impl<A: 'static + adc::Adc<'static>, P: 'static + gpio::Pin, const BUF_LEN: usize>
     AdcMicrophoneComponent<A, P, BUF_LEN>
 {
     pub fn new(
@@ -75,7 +75,7 @@ impl<A: 'static + adc::Adc, P: 'static + gpio::Pin, const BUF_LEN: usize>
     }
 }
 
-impl<A: 'static + adc::Adc, P: 'static + gpio::Pin, const BUF_LEN: usize> Component
+impl<A: 'static + adc::Adc<'static>, P: 'static + gpio::Pin, const BUF_LEN: usize> Component
     for AdcMicrophoneComponent<A, P, BUF_LEN>
 {
     type StaticInput = (

--- a/boards/components/src/temperature_rp2040.rs
+++ b/boards/components/src/temperature_rp2040.rs
@@ -22,14 +22,14 @@ macro_rules! temperature_rp2040_adc_component_static {
     };};
 }
 
-pub struct TemperatureRp2040Component<A: 'static + adc::Adc> {
+pub struct TemperatureRp2040Component<A: 'static + adc::Adc<'static>> {
     adc_mux: &'static capsules_core::virtualizers::virtual_adc::MuxAdc<'static, A>,
     adc_channel: A::Channel,
     slope: f32,
     v_27: f32,
 }
 
-impl<A: 'static + adc::Adc> TemperatureRp2040Component<A> {
+impl<A: 'static + adc::Adc<'static>> TemperatureRp2040Component<A> {
     pub fn new(
         adc_mux: &'static capsules_core::virtualizers::virtual_adc::MuxAdc<'static, A>,
         adc_channel: A::Channel,
@@ -45,7 +45,7 @@ impl<A: 'static + adc::Adc> TemperatureRp2040Component<A> {
     }
 }
 
-impl<A: 'static + adc::Adc> Component for TemperatureRp2040Component<A> {
+impl<A: 'static + adc::Adc<'static>> Component for TemperatureRp2040Component<A> {
     type StaticInput = (
         &'static mut MaybeUninit<AdcDevice<'static, A>>,
         &'static mut MaybeUninit<TemperatureRp2040<'static>>,

--- a/boards/components/src/temperature_stm.rs
+++ b/boards/components/src/temperature_stm.rs
@@ -22,14 +22,14 @@ macro_rules! temperature_stm_adc_component_static {
     };};
 }
 
-pub struct TemperatureSTMComponent<A: 'static + adc::Adc> {
+pub struct TemperatureSTMComponent<A: 'static + adc::Adc<'static>> {
     adc_mux: &'static capsules_core::virtualizers::virtual_adc::MuxAdc<'static, A>,
     adc_channel: A::Channel,
     slope: f32,
     v_25: f32,
 }
 
-impl<A: 'static + adc::Adc> TemperatureSTMComponent<A> {
+impl<A: 'static + adc::Adc<'static>> TemperatureSTMComponent<A> {
     pub fn new(
         adc_mux: &'static capsules_core::virtualizers::virtual_adc::MuxAdc<'static, A>,
         adc_channel: A::Channel,
@@ -45,7 +45,7 @@ impl<A: 'static + adc::Adc> TemperatureSTMComponent<A> {
     }
 }
 
-impl<A: 'static + adc::Adc> Component for TemperatureSTMComponent<A> {
+impl<A: 'static + adc::Adc<'static>> Component for TemperatureSTMComponent<A> {
     type StaticInput = (
         &'static mut MaybeUninit<AdcDevice<'static, A>>,
         &'static mut MaybeUninit<TemperatureSTM<'static>>,

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -82,7 +82,7 @@ struct Hail {
         >,
     >,
     nrf51822: &'static capsules_extra::nrf51822_serialization::Nrf51822Serialization<'static>,
-    adc: &'static capsules_core::adc::AdcDedicated<'static, sam4l::adc::Adc>,
+    adc: &'static capsules_core::adc::AdcDedicated<'static, sam4l::adc::Adc<'static>>,
     led: &'static capsules_core::led::LedDriver<
         'static,
         LedLow<'static, sam4l::gpio::GPIOPin<'static>>,

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -138,7 +138,7 @@ struct Imix {
     temp: &'static capsules_extra::temperature::TemperatureSensor<'static>,
     humidity: &'static capsules_extra::humidity::HumiditySensor<'static>,
     ambient_light: &'static capsules_extra::ambient_light::AmbientLight<'static>,
-    adc: &'static capsules_core::adc::AdcDedicated<'static, sam4l::adc::Adc>,
+    adc: &'static capsules_core::adc::AdcDedicated<'static, sam4l::adc::Adc<'static>>,
     led: &'static capsules_core::led::LedDriver<
         'static,
         LedHigh<'static, sam4l::gpio::GPIOPin<'static>>,

--- a/capsules/extra/src/adc_microphone.rs
+++ b/capsules/extra/src/adc_microphone.rs
@@ -18,7 +18,7 @@ enum State {
 }
 
 pub struct AdcMicrophone<'a, P: gpio::Pin> {
-    adc: &'a dyn adc::AdcChannel,
+    adc: &'a dyn adc::AdcChannel<'a>,
     enable_pin: Option<&'a P>,
     spl_client: OptionalCell<&'a dyn SoundPressureClient>,
     spl_buffer: TakeCell<'a, [u16]>,
@@ -28,7 +28,7 @@ pub struct AdcMicrophone<'a, P: gpio::Pin> {
 
 impl<'a, P: gpio::Pin> AdcMicrophone<'a, P> {
     pub fn new(
-        adc: &'a dyn adc::AdcChannel,
+        adc: &'a dyn adc::AdcChannel<'a>,
         enable_pin: Option<&'a P>,
         spl_buffer: &'a mut [u16],
     ) -> AdcMicrophone<'a, P> {

--- a/capsules/extra/src/analog_sensor.rs
+++ b/capsules/extra/src/analog_sensor.rs
@@ -19,17 +19,17 @@ pub enum AnalogLightSensorType {
     LightDependentResistor,
 }
 
-pub struct AnalogLightSensor<'a, A: hil::adc::Adc> {
+pub struct AnalogLightSensor<'a, A: hil::adc::Adc<'a>> {
     adc: &'a A,
-    channel: &'a <A as hil::adc::Adc>::Channel,
+    channel: &'a <A as hil::adc::Adc<'a>>::Channel,
     sensor_type: AnalogLightSensorType,
     client: OptionalCell<&'a dyn hil::sensors::AmbientLightClient>,
 }
 
-impl<'a, A: hil::adc::Adc> AnalogLightSensor<'a, A> {
+impl<'a, A: hil::adc::Adc<'a>> AnalogLightSensor<'a, A> {
     pub fn new(
         adc: &'a A,
-        channel: &'a <A as hil::adc::Adc>::Channel,
+        channel: &'a <A as kernel::hil::adc::Adc<'a>>::Channel,
         sensor_type: AnalogLightSensorType,
     ) -> AnalogLightSensor<'a, A> {
         AnalogLightSensor {
@@ -42,7 +42,7 @@ impl<'a, A: hil::adc::Adc> AnalogLightSensor<'a, A> {
 }
 
 /// Callbacks from the ADC driver
-impl<A: hil::adc::Adc> hil::adc::Client for AnalogLightSensor<'_, A> {
+impl<'a, A: hil::adc::Adc<'a>> hil::adc::Client for AnalogLightSensor<'a, A> {
     fn sample_ready(&self, sample: u16) {
         // TODO: calculate the actual light reading.
         let measurement: usize = match self.sensor_type {
@@ -55,7 +55,7 @@ impl<A: hil::adc::Adc> hil::adc::Client for AnalogLightSensor<'_, A> {
     }
 }
 
-impl<'a, A: hil::adc::Adc> hil::sensors::AmbientLight<'a> for AnalogLightSensor<'a, A> {
+impl<'a, A: hil::adc::Adc<'a>> hil::sensors::AmbientLight<'a> for AnalogLightSensor<'a, A> {
     fn set_client(&self, client: &'a dyn hil::sensors::AmbientLightClient) {
         self.client.set(client);
     }
@@ -71,17 +71,17 @@ pub enum AnalogTemperatureSensorType {
     MicrochipMcp9700,
 }
 
-pub struct AnalogTemperatureSensor<'a, A: hil::adc::Adc> {
+pub struct AnalogTemperatureSensor<'a, A: hil::adc::Adc<'a>> {
     adc: &'a A,
-    channel: &'a <A as hil::adc::Adc>::Channel,
+    channel: &'a <A as hil::adc::Adc<'a>>::Channel,
     sensor_type: AnalogTemperatureSensorType,
     client: OptionalCell<&'a dyn hil::sensors::TemperatureClient>,
 }
 
-impl<'a, A: hil::adc::Adc> AnalogTemperatureSensor<'a, A> {
+impl<'a, A: hil::adc::Adc<'a>> AnalogTemperatureSensor<'a, A> {
     pub fn new(
         adc: &'a A,
-        channel: &'a <A as hil::adc::Adc>::Channel,
+        channel: &'a <A as kernel::hil::adc::Adc<'a>>::Channel,
         sensor_type: AnalogLightSensorType,
     ) -> AnalogLightSensor<'a, A> {
         AnalogLightSensor {
@@ -94,7 +94,7 @@ impl<'a, A: hil::adc::Adc> AnalogTemperatureSensor<'a, A> {
 }
 
 /// Callbacks from the ADC driver
-impl<A: hil::adc::Adc> hil::adc::Client for AnalogTemperatureSensor<'_, A> {
+impl<'a, A: hil::adc::Adc<'a>> hil::adc::Client for AnalogTemperatureSensor<'a, A> {
     fn sample_ready(&self, sample: u16) {
         // TODO: calculate the actual temperature reading.
         let measurement = match self.sensor_type {
@@ -114,7 +114,9 @@ impl<A: hil::adc::Adc> hil::adc::Client for AnalogTemperatureSensor<'_, A> {
     }
 }
 
-impl<'a, A: hil::adc::Adc> hil::sensors::TemperatureDriver<'a> for AnalogTemperatureSensor<'a, A> {
+impl<'a, A: hil::adc::Adc<'a>> hil::sensors::TemperatureDriver<'a>
+    for AnalogTemperatureSensor<'a, A>
+{
     fn set_client(&self, client: &'a dyn hil::sensors::TemperatureClient) {
         self.client.set(client);
     }

--- a/capsules/extra/src/temperature_rp2040.rs
+++ b/capsules/extra/src/temperature_rp2040.rs
@@ -20,7 +20,7 @@ pub enum Status {
 }
 
 pub struct TemperatureRp2040<'a> {
-    adc: &'a dyn adc::AdcChannel,
+    adc: &'a dyn adc::AdcChannel<'a>,
     slope: f32,
     v_27: f32,
     temperature_client: OptionalCell<&'a dyn sensors::TemperatureClient>,
@@ -30,7 +30,7 @@ pub struct TemperatureRp2040<'a> {
 impl<'a> TemperatureRp2040<'a> {
     /// slope - device specific slope found in datasheet
     /// v_27 - voltage at 27 degrees Celsius found in datasheet
-    pub fn new(adc: &'a dyn adc::AdcChannel, slope: f32, v_27: f32) -> TemperatureRp2040<'a> {
+    pub fn new(adc: &'a dyn adc::AdcChannel<'a>, slope: f32, v_27: f32) -> TemperatureRp2040<'a> {
         TemperatureRp2040 {
             adc: adc,
             slope: slope,

--- a/capsules/extra/src/temperature_stm.rs
+++ b/capsules/extra/src/temperature_stm.rs
@@ -20,7 +20,7 @@ pub enum Status {
 }
 
 pub struct TemperatureSTM<'a> {
-    adc: &'a dyn adc::AdcChannel,
+    adc: &'a dyn adc::AdcChannel<'a>,
     slope: f32,
     v_25: f32,
     temperature_client: OptionalCell<&'a dyn sensors::TemperatureClient>,
@@ -30,7 +30,7 @@ pub struct TemperatureSTM<'a> {
 impl<'a> TemperatureSTM<'a> {
     /// slope - device specific slope found in datasheet
     /// v_25 - voltage at 25 degrees Celsius found in datasheet
-    pub fn new(adc: &'a dyn adc::AdcChannel, slope: f32, v_25: f32) -> TemperatureSTM<'a> {
+    pub fn new(adc: &'a dyn adc::AdcChannel<'a>, slope: f32, v_25: f32) -> TemperatureSTM<'a> {
         TemperatureSTM {
             adc: adc,
             slope: slope,

--- a/chips/msp432/src/adc.rs
+++ b/chips/msp432/src/adc.rs
@@ -502,8 +502,8 @@ pub struct Adc<'a> {
     dma_src: u8,
     buffer1: TakeCell<'static, [u16]>,
     buffer2: TakeCell<'static, [u16]>,
-    client: OptionalCell<&'static dyn hil::adc::Client>,
-    highspeed_client: OptionalCell<&'static dyn hil::adc::HighSpeedClient>,
+    client: OptionalCell<&'a dyn hil::adc::Client>,
+    highspeed_client: OptionalCell<&'a dyn hil::adc::HighSpeedClient>,
 }
 
 impl Adc<'_> {
@@ -742,7 +742,7 @@ impl<'a> Adc<'a> {
     }
 }
 
-impl dma::DmaClient for Adc<'_> {
+impl<'a> dma::DmaClient for Adc<'a> {
     fn transfer_done(
         &self,
         _tx_buf: Option<&'static mut [u8]>,
@@ -767,7 +767,7 @@ impl dma::DmaClient for Adc<'_> {
     }
 }
 
-impl hil::adc::Adc for Adc<'_> {
+impl<'a> hil::adc::Adc<'a> for Adc<'a> {
     type Channel = Channel;
 
     fn sample(&self, channel: &Self::Channel) -> Result<(), ErrorCode> {
@@ -892,12 +892,12 @@ impl hil::adc::Adc for Adc<'_> {
         self.ref_module.map(|ref_mod| ref_mod.ref_voltage_mv())
     }
 
-    fn set_client(&self, client: &'static dyn hil::adc::Client) {
+    fn set_client(&self, client: &'a dyn hil::adc::Client) {
         self.client.set(client);
     }
 }
 
-impl hil::adc::AdcHighSpeed for Adc<'_> {
+impl<'a> hil::adc::AdcHighSpeed<'a> for Adc<'a> {
     fn sample_highspeed(
         &self,
         channel: &Self::Channel,
@@ -994,7 +994,7 @@ impl hil::adc::AdcHighSpeed for Adc<'_> {
         }
     }
 
-    fn set_highspeed_client(&self, client: &'static dyn hil::adc::HighSpeedClient) {
+    fn set_highspeed_client(&self, client: &'a dyn hil::adc::HighSpeedClient) {
         self.highspeed_client.set(client);
     }
 }

--- a/chips/nrf52/src/adc.rs
+++ b/chips/nrf52/src/adc.rs
@@ -324,12 +324,12 @@ impl AdcChannelSetup {
     }
 }
 
-pub struct Adc {
+pub struct Adc<'a> {
     registers: StaticRef<AdcRegisters>,
-    client: OptionalCell<&'static dyn hil::adc::Client>,
+    client: OptionalCell<&'a dyn hil::adc::Client>,
 }
 
-impl Adc {
+impl<'a> Adc<'a> {
     pub const fn new() -> Self {
         Self {
             registers: SAADC_BASE,
@@ -374,7 +374,7 @@ impl Adc {
 }
 
 /// Implements an ADC capable reading ADC samples on any channel.
-impl hil::adc::Adc for Adc {
+impl<'a> hil::adc::Adc<'a> for Adc<'a> {
     type Channel = AdcChannelSetup;
 
     fn sample(&self, channel: &Self::Channel) -> Result<(), ErrorCode> {
@@ -443,7 +443,7 @@ impl hil::adc::Adc for Adc {
         Some(3300)
     }
 
-    fn set_client(&self, client: &'static dyn hil::adc::Client) {
+    fn set_client(&self, client: &'a dyn hil::adc::Client) {
         self.client.set(client);
     }
 }

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -45,7 +45,7 @@ pub struct Nrf52DefaultPeripherals<'a> {
     pub spim1: crate::spi::SPIM,
     pub twi1: crate::i2c::TWI,
     pub spim2: crate::spi::SPIM,
-    pub adc: crate::adc::Adc,
+    pub adc: crate::adc::Adc<'a>,
     pub nvmc: crate::nvmc::Nvmc,
     pub clock: crate::clock::Clock,
     pub pwm0: crate::pwm::Pwm,

--- a/chips/rp2040/src/adc.rs
+++ b/chips/rp2040/src/adc.rs
@@ -141,14 +141,14 @@ enum ADCStatus {
     OneSample,
 }
 
-pub struct Adc {
+pub struct Adc<'a> {
     registers: StaticRef<AdcRegisters>,
     status: Cell<ADCStatus>,
     channel: Cell<Channel>,
-    client: OptionalCell<&'static dyn hil::adc::Client>,
+    client: OptionalCell<&'a dyn hil::adc::Client>,
 }
 
-impl Adc {
+impl<'a> Adc<'a> {
     pub const fn new() -> Self {
         Self {
             registers: ADC_BASE,
@@ -192,7 +192,7 @@ impl Adc {
     }
 }
 
-impl hil::adc::Adc for Adc {
+impl<'a> hil::adc::Adc<'a> for Adc<'a> {
     type Channel = Channel;
 
     fn sample(&self, channel: &Self::Channel) -> Result<(), ErrorCode> {
@@ -234,7 +234,7 @@ impl hil::adc::Adc for Adc {
         Some(3300)
     }
 
-    fn set_client(&self, client: &'static dyn hil::adc::Client) {
+    fn set_client(&self, client: &'a dyn hil::adc::Client) {
         self.client.set(client);
     }
 }

--- a/chips/rp2040/src/chip.rs
+++ b/chips/rp2040/src/chip.rs
@@ -118,7 +118,7 @@ impl<'a, I: InterruptService> Chip for Rp2040<'a, I> {
 }
 
 pub struct Rp2040DefaultPeripherals<'a> {
-    pub adc: adc::Adc,
+    pub adc: adc::Adc<'a>,
     pub clocks: Clocks,
     pub i2c0: i2c::I2c<'a>,
     pub pins: RPPins<'a>,

--- a/chips/sam4l/src/adc.rs
+++ b/chips/sam4l/src/adc.rs
@@ -81,7 +81,7 @@ impl AdcChannel {
 }
 
 /// ADC driver code for the SAM4L.
-pub struct Adc {
+pub struct Adc<'a> {
     registers: StaticRef<AdcRegisters>,
 
     // state tracking for the ADC
@@ -105,8 +105,8 @@ pub struct Adc {
     stopped_buffer: TakeCell<'static, [u16]>,
 
     // ADC client to send sample complete notifications to
-    client: OptionalCell<&'static dyn hil::adc::Client>,
-    highspeed_client: OptionalCell<&'static dyn hil::adc::HighSpeedClient>,
+    client: OptionalCell<&'a dyn hil::adc::Client>,
+    highspeed_client: OptionalCell<&'a dyn hil::adc::HighSpeedClient>,
     pm: &'static pm::PowerManager,
 }
 
@@ -322,7 +322,7 @@ const BASE_ADDRESS: StaticRef<AdcRegisters> =
     unsafe { StaticRef::new(0x40038000 as *const AdcRegisters) };
 
 /// Functions for initializing the ADC.
-impl Adc {
+impl<'a> Adc<'a> {
     /// Create a new ADC driver.
     ///
     /// - `rx_dma_peripheral`: type used for DMA transactions
@@ -596,7 +596,7 @@ impl Adc {
 }
 
 /// Implements an ADC capable reading ADC samples on any channel.
-impl hil::adc::Adc for Adc {
+impl<'a> hil::adc::Adc<'a> for Adc<'a> {
     type Channel = AdcChannel;
 
     /// Capture a single analog sample, calling the client when complete.
@@ -809,13 +809,13 @@ impl hil::adc::Adc for Adc {
     /// Sets the client for this driver.
     ///
     /// - `client`: reference to capsule which handles responses
-    fn set_client(&self, client: &'static dyn hil::adc::Client) {
+    fn set_client(&self, client: &'a dyn hil::adc::Client) {
         self.client.set(client);
     }
 }
 
 /// Implements an ADC capable of continuous sampling
-impl hil::adc::AdcHighSpeed for Adc {
+impl<'a> hil::adc::AdcHighSpeed<'a> for Adc<'a> {
     /// Capture buffered samples from the ADC continuously at a given
     /// frequency, calling the client whenever a buffer fills up. The client is
     /// then expected to either stop sampling or provide an additional buffer
@@ -969,13 +969,13 @@ impl hil::adc::AdcHighSpeed for Adc {
         }
     }
 
-    fn set_highspeed_client(&self, client: &'static dyn hil::adc::HighSpeedClient) {
+    fn set_highspeed_client(&self, client: &'a dyn hil::adc::HighSpeedClient) {
         self.highspeed_client.set(client);
     }
 }
 
 /// Implements a client of a DMA.
-impl dma::DMAClient for Adc {
+impl<'a> dma::DMAClient for Adc<'a> {
     /// Handler for DMA transfer completion.
     ///
     /// - `pid`: the DMA peripheral that is complete

--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -34,7 +34,7 @@ impl<I: InterruptService + 'static> Sam4l<I> {
 /// constructed manually in main.rs.
 pub struct Sam4lDefaultPeripherals {
     pub acifc: crate::acifc::Acifc<'static>,
-    pub adc: crate::adc::Adc,
+    pub adc: crate::adc::Adc<'static>,
     pub aes: crate::aes::Aes<'static>,
     pub ast: crate::ast::Ast<'static>,
     pub crccu: crate::crccu::Crccu<'static>,

--- a/chips/stm32f303xc/src/adc.rs
+++ b/chips/stm32f303xc/src/adc.rs
@@ -504,7 +504,7 @@ pub struct Adc<'a> {
     common_registers: StaticRef<AdcCommonRegisters>,
     clock: AdcClock<'a>,
     status: Cell<ADCStatus>,
-    client: OptionalCell<&'static dyn hil::adc::Client>,
+    client: OptionalCell<&'a dyn hil::adc::Client>,
     requested: Cell<ADCStatus>,
     requested_channel: Cell<u32>,
     sc_enabled: Cell<bool>,
@@ -680,7 +680,7 @@ impl ClockInterface for AdcClock<'_> {
     }
 }
 
-impl hil::adc::Adc for Adc<'_> {
+impl<'a> hil::adc::Adc<'a> for Adc<'a> {
     type Channel = Channel;
 
     fn sample(&self, channel: &Self::Channel) -> Result<(), ErrorCode> {
@@ -723,13 +723,13 @@ impl hil::adc::Adc for Adc<'_> {
         Some(3300)
     }
 
-    fn set_client(&self, client: &'static dyn hil::adc::Client) {
+    fn set_client(&self, client: &'a dyn hil::adc::Client) {
         self.client.set(client);
     }
 }
 
 /// Not yet supported
-impl hil::adc::AdcHighSpeed for Adc<'_> {
+impl<'a> hil::adc::AdcHighSpeed<'a> for Adc<'a> {
     /// Capture buffered samples from the ADC continuously at a given
     /// frequency, calling the client whenever a buffer fills up. The client is
     /// then expected to either stop sampling or provide an additional buffer
@@ -776,5 +776,5 @@ impl hil::adc::AdcHighSpeed for Adc<'_> {
         Err(ErrorCode::NOSUPPORT)
     }
 
-    fn set_highspeed_client(&self, _client: &'static dyn hil::adc::HighSpeedClient) {}
+    fn set_highspeed_client(&self, _client: &'a dyn hil::adc::HighSpeedClient) {}
 }

--- a/chips/stm32f4xx/src/adc.rs
+++ b/chips/stm32f4xx/src/adc.rs
@@ -310,7 +310,7 @@ pub struct Adc<'a> {
     common_registers: StaticRef<AdcCommonRegisters>,
     clock: AdcClock<'a>,
     status: Cell<ADCStatus>,
-    client: OptionalCell<&'static dyn hil::adc::Client>,
+    client: OptionalCell<&'a dyn hil::adc::Client>,
 }
 
 impl<'a> Adc<'a> {
@@ -385,7 +385,7 @@ impl ClockInterface for AdcClock<'_> {
     }
 }
 
-impl hil::adc::Adc for Adc<'_> {
+impl<'a> hil::adc::Adc<'a> for Adc<'a> {
     type Channel = Channel;
 
     fn sample(&self, channel: &Self::Channel) -> Result<(), ErrorCode> {
@@ -427,13 +427,13 @@ impl hil::adc::Adc for Adc<'_> {
         Some(3300)
     }
 
-    fn set_client(&self, client: &'static dyn hil::adc::Client) {
+    fn set_client(&self, client: &'a dyn hil::adc::Client) {
         self.client.set(client);
     }
 }
 
 /// Not yet supported
-impl hil::adc::AdcHighSpeed for Adc<'_> {
+impl<'a> hil::adc::AdcHighSpeed<'a> for Adc<'a> {
     /// Capture buffered samples from the ADC continuously at a given
     /// frequency, calling the client whenever a buffer fills up. The client is
     /// then expected to either stop sampling or provide an additional buffer
@@ -480,5 +480,5 @@ impl hil::adc::AdcHighSpeed for Adc<'_> {
         Err(ErrorCode::NOSUPPORT)
     }
 
-    fn set_highspeed_client(&self, _client: &'static dyn hil::adc::HighSpeedClient) {}
+    fn set_highspeed_client(&self, _client: &'a dyn hil::adc::HighSpeedClient) {}
 }

--- a/kernel/src/hil/adc.rs
+++ b/kernel/src/hil/adc.rs
@@ -9,7 +9,7 @@ use crate::ErrorCode;
 // *** Interfaces for low-speed, single-sample ADCs ***
 
 /// Simple interface for reading an ADC sample on any channel.
-pub trait Adc {
+pub trait Adc<'a> {
     /// The chip-dependent type of an ADC channel.
     type Channel: PartialEq;
 
@@ -42,7 +42,7 @@ pub trait Adc {
     /// The returned reference voltage is in millivolts, or `None` if unknown.
     fn get_voltage_reference_mv(&self) -> Option<usize>;
 
-    fn set_client(&self, client: &'static dyn Client);
+    fn set_client(&self, client: &'a dyn Client);
 }
 
 /// Trait for handling callbacks from simple ADC calls.
@@ -55,7 +55,7 @@ pub trait Client {
 
 /// Interface for continuously sampling at a given frequency on a channel.
 /// Requires the AdcSimple interface to have been implemented as well.
-pub trait AdcHighSpeed: Adc {
+pub trait AdcHighSpeed<'a>: Adc<'a> {
     /// Start sampling continuously into buffers.
     /// Samples are double-buffered, going first into `buffer1` and then into
     /// `buffer2`. A callback is performed to the client whenever either buffer
@@ -102,7 +102,7 @@ pub trait AdcHighSpeed: Adc {
         &self,
     ) -> Result<(Option<&'static mut [u16]>, Option<&'static mut [u16]>), ErrorCode>;
 
-    fn set_highspeed_client(&self, client: &'static dyn HighSpeedClient);
+    fn set_highspeed_client(&self, client: &'a dyn HighSpeedClient);
 }
 
 /// Trait for handling callbacks from high-speed ADC calls.
@@ -114,7 +114,7 @@ pub trait HighSpeedClient {
     fn samples_ready(&self, buf: &'static mut [u16], length: usize);
 }
 
-pub trait AdcChannel {
+pub trait AdcChannel<'a> {
     /// Request a single ADC sample on a particular channel.
     /// Used for individual samples that have no timing requirements.
     /// All ADC samples will be the raw ADC value left-justified in the u16.
@@ -144,5 +144,5 @@ pub trait AdcChannel {
     /// The returned reference voltage is in millivolts, or `None` if unknown.
     fn get_voltage_reference_mv(&self) -> Option<usize>;
 
-    fn set_client(&self, client: &'static dyn Client);
+    fn set_client(&self, client: &'a dyn Client);
 }


### PR DESCRIPTION
### Pull Request Overview

Part of #1074.

Removes the 'static from the ADC set client calls.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
