### PR TITLE
capsules: tickv: do operation after init on already init

### DIFF
--- a/capsules/extra/src/tickv.rs
+++ b/capsules/extra/src/tickv.rs
@@ -260,7 +260,7 @@ impl<'a, F: Flash, H: Hasher<'a, 8>> flash::Client<F> for TicKVStore<'a, F, H> {
             Operation::Init => match ret {
                 Ok(tickv::success_codes::SuccessCode::Complete)
                 | Ok(tickv::success_codes::SuccessCode::Written) => {
-                    self.operation.set(Operation::None)
+                    self.complete_init();
                 }
                 _ => {}
             },


### PR DESCRIPTION
### Pull Request Overview

With tickv, if the KV store is already initialized, and a board runs an operation right away, the operation would get queued waiting on the init to finish, but if the init finishes without having to do anything (already inited), the queued operation would never run. This fixes that.


### Testing Strategy

testing out tickv on nrf52840dk


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
