### PR TITLE
TicKV: Use const parameter rather than assume 2048 byte pages

### DIFF
--- a/boards/components/src/tickv.rs
+++ b/boards/components/src/tickv.rs
@@ -23,7 +23,15 @@
 //!        components::flash_user_component_static!(lowrisc::flash_ctrl::FlashCtrl),
 //!    );
 //!
-//!    let kvstore = components::tickv::TicKVComponent::new(
+//!    // SipHash
+//!    let sip_hash = static_init!(
+//!        capsules_extra::sip_hash::SipHasher24,
+//!        capsules_extra::sip_hash::SipHasher24::new()
+//!    );
+//!    sip_hash.register();
+//!
+//!    let tickv = components::tickv::TicKVComponent::new(
+//!        sip_hash,
 //!        &mux_flash,
 //!        0x20040000 / lowrisc::flash_ctrl::PAGE_SIZE,
 //!        0x40000,
@@ -31,7 +39,8 @@
 //!        page_buffer,
 //!    )
 //!    .finalize(components::tickv_component_static!(
-//!        lowrisc::flash_ctrl::FlashCtrl
+//!        lowrisc::flash_ctrl::FlashCtrl,
+//!        capsules_extra::sip_hash::SipHasher24
 //!    ));
 //!    hil::flash::HasClient::set_client(&peripherals.flash_ctrl, mux_flash);
 //! ```
@@ -50,7 +59,7 @@ use kernel::hil::hasher::Hasher;
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! tickv_component_static {
-    ($F:ty, $H:ty) => {{
+    ($F:ty, $H:ty, $PAGE_SIZE:expr $(,)?) => {{
         let flash =
             kernel::static_buf!(capsules_core::virtualizers::virtual_flash::FlashUser<'static, $F>);
         let tickv = kernel::static_buf!(
@@ -58,6 +67,7 @@ macro_rules! tickv_component_static {
                 'static,
                 capsules_core::virtualizers::virtual_flash::FlashUser<'static, $F>,
                 $H,
+                $PAGE_SIZE,
             >
         );
 
@@ -65,29 +75,42 @@ macro_rules! tickv_component_static {
     };};
 }
 
+#[macro_export]
+macro_rules! tickv_dedicated_flash_component_static {
+    ($F:ty, $H:ty, $PAGE_SIZE:expr $(,)?) => {{
+        let tickfs_read_buffer = kernel::static_buf!([u8; $PAGE_SIZE]);
+        let tickv =
+            kernel::static_buf!(capsules_extra::tickv::TicKVStore<'static, $F, $H, $PAGE_SIZE>);
+
+        (tickv, tickfs_read_buffer)
+    };};
+}
+
 pub struct TicKVComponent<
     F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, MuxFlash<'static, F>>,
     H: 'static + Hasher<'static, 8>,
+    const PAGE_SIZE: usize,
 > {
     mux_flash: &'static MuxFlash<'static, F>,
     hasher: &'static H,
     region_offset: usize,
     flash_size: usize,
-    tickfs_read_buf: &'static mut [u8; 2048],
+    tickfs_read_buf: &'static mut [u8; PAGE_SIZE],
     flash_read_buffer: &'static mut F::Page,
 }
 
 impl<
         F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, MuxFlash<'static, F>>,
         H: Hasher<'static, 8>,
-    > TicKVComponent<F, H>
+        const PAGE_SIZE: usize,
+    > TicKVComponent<F, H, PAGE_SIZE>
 {
     pub fn new(
         hasher: &'static H,
         mux_flash: &'static MuxFlash<'static, F>,
         region_offset: usize,
         flash_size: usize,
-        tickfs_read_buf: &'static mut [u8; 2048],
+        tickfs_read_buf: &'static mut [u8; PAGE_SIZE],
         flash_read_buffer: &'static mut F::Page,
     ) -> Self {
         Self {
@@ -104,13 +127,14 @@ impl<
 impl<
         F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, MuxFlash<'static, F>>,
         H: 'static + Hasher<'static, 8>,
-    > Component for TicKVComponent<F, H>
+        const PAGE_SIZE: usize,
+    > Component for TicKVComponent<F, H, PAGE_SIZE>
 {
     type StaticInput = (
         &'static mut MaybeUninit<FlashUser<'static, F>>,
-        &'static mut MaybeUninit<TicKVStore<'static, FlashUser<'static, F>, H>>,
+        &'static mut MaybeUninit<TicKVStore<'static, FlashUser<'static, F>, H, PAGE_SIZE>>,
     );
-    type Output = &'static TicKVStore<'static, FlashUser<'static, F>, H>;
+    type Output = &'static TicKVStore<'static, FlashUser<'static, F>, H, PAGE_SIZE>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let _grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
@@ -128,5 +152,78 @@ impl<
         virtual_flash.set_client(driver);
         driver.initialise();
         driver
+    }
+}
+
+pub struct TicKVDedicatedFlashComponent<
+    F: 'static
+        + hil::flash::Flash
+        + hil::flash::HasClient<'static, TicKVStore<'static, F, H, PAGE_SIZE>>,
+    H: 'static + Hasher<'static, 8>,
+    const PAGE_SIZE: usize,
+> {
+    flash: &'static F,
+    hasher: &'static H,
+    region_offset: usize,
+    flash_size: usize,
+    flash_read_buffer: &'static mut F::Page,
+}
+
+impl<
+        F: 'static
+            + hil::flash::Flash
+            + hil::flash::HasClient<'static, TicKVStore<'static, F, H, PAGE_SIZE>>,
+        H: Hasher<'static, 8>,
+        const PAGE_SIZE: usize,
+    > TicKVDedicatedFlashComponent<F, H, PAGE_SIZE>
+{
+    pub fn new(
+        hasher: &'static H,
+        flash: &'static F,
+        region_offset: usize,
+        flash_size: usize,
+        flash_read_buffer: &'static mut F::Page,
+    ) -> Self {
+        Self {
+            hasher,
+            flash,
+            region_offset,
+            flash_size,
+            flash_read_buffer,
+        }
+    }
+}
+
+impl<
+        F: 'static
+            + hil::flash::Flash
+            + hil::flash::HasClient<'static, TicKVStore<'static, F, H, PAGE_SIZE>>,
+        H: 'static + Hasher<'static, 8>,
+        const PAGE_SIZE: usize,
+    > Component for TicKVDedicatedFlashComponent<F, H, PAGE_SIZE>
+{
+    type StaticInput = (
+        &'static mut MaybeUninit<TicKVStore<'static, F, H, PAGE_SIZE>>,
+        &'static mut MaybeUninit<[u8; PAGE_SIZE]>,
+    );
+    type Output = &'static TicKVStore<'static, F, H, PAGE_SIZE>;
+
+    fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
+        let _grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+
+        let tickfs_read_buf = static_buffer.1.write([0; PAGE_SIZE]);
+
+        let tickv = static_buffer.0.write(TicKVStore::new(
+            self.flash,
+            self.hasher,
+            tickfs_read_buf,
+            self.flash_read_buffer,
+            self.region_offset,
+            self.flash_size,
+        ));
+        self.flash.set_client(tickv);
+        self.hasher.set_client(tickv);
+        tickv.initialise();
+        tickv
     }
 }

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -77,6 +77,7 @@ static mut TICKV: Option<
             lowrisc::flash_ctrl::FlashCtrl<'static>,
         >,
         capsules_extra::sip_hash::SipHasher24<'static>,
+        2048,
     >,
 > = None;
 // Test access to AES CCM
@@ -169,6 +170,7 @@ struct EarlGrey {
                 lowrisc::flash_ctrl::FlashCtrl<'static>,
             >,
             capsules_extra::sip_hash::SipHasher24<'static>,
+            2048,
         >,
         [u8; 8],
     >,
@@ -534,7 +536,8 @@ unsafe fn setup() -> (
     )
     .finalize(components::tickv_component_static!(
         lowrisc::flash_ctrl::FlashCtrl,
-        capsules_extra::sip_hash::SipHasher24
+        capsules_extra::sip_hash::SipHasher24,
+        2048
     ));
     hil::flash::HasClient::set_client(&peripherals.flash_ctrl, mux_flash);
     sip_hash.set_client(tickv);
@@ -547,6 +550,7 @@ unsafe fn setup() -> (
                     lowrisc::flash_ctrl::FlashCtrl,
                 >,
                 capsules_extra::sip_hash::SipHasher24<'static>,
+                2048,
             >,
             capsules_extra::tickv::TicKVKeyType,
         ),
@@ -559,6 +563,7 @@ unsafe fn setup() -> (
                     lowrisc::flash_ctrl::FlashCtrl,
                 >,
                 capsules_extra::sip_hash::SipHasher24<'static>,
+                2048,
             >,
             capsules_extra::tickv::TicKVKeyType,
         ),
@@ -574,6 +579,7 @@ unsafe fn setup() -> (
         capsules_extra::tickv::TicKVStore<
             capsules_core::virtualizers::virtual_flash::FlashUser<lowrisc::flash_ctrl::FlashCtrl>,
             capsules_extra::sip_hash::SipHasher24<'static>,
+            2048,
         >,
         capsules_extra::tickv::TicKVKeyType,
     ));

--- a/boards/opentitan/src/tests/tickv_test.rs
+++ b/boards/opentitan/src/tests/tickv_test.rs
@@ -40,6 +40,7 @@ fn tickv_append_key() {
                     'static,
                     FlashUser<'static, lowrisc::flash_ctrl::FlashCtrl<'static>>,
                     capsules_extra::sip_hash::SipHasher24,
+                    2048,
                 >,
                 TicKVKeyType,
             >,


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the tickv stack to:

1. Add a component for using a dedicated flash interface instead of a mux on top of flash.
2. Add a const param instead of assuming 2048 byte pages.


### Testing Strategy

Using tickv on nrf52840


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
