### PR TITLE
hil: dac: remove init

### DIFF
--- a/capsules/extra/src/dac.rs
+++ b/capsules/extra/src/dac.rs
@@ -45,8 +45,8 @@ impl SyscallDriver for Dac<'_> {
         match command_num {
             0 /* check if present */ => CommandReturn::success(),
 
-            // enable the dac
-            1 => CommandReturn::from(self.dac.initialize()),
+            // enable the dac. no-op as using the dac will enable it.
+            1 => CommandReturn::success(),
 
             // set the dac output
             2 => CommandReturn::from(self.dac.set_value(data)),

--- a/kernel/src/hil/dac.rs
+++ b/kernel/src/hil/dac.rs
@@ -8,9 +8,6 @@ use crate::ErrorCode;
 
 /// Simple interface for using the DAC.
 pub trait DacChannel {
-    /// Initialize and enable the DAC.
-    fn initialize(&self) -> Result<(), ErrorCode>;
-
     /// Set the DAC output value.
     fn set_value(&self, value: usize) -> Result<(), ErrorCode>;
 }


### PR DESCRIPTION
### Pull Request Overview
As part of #1035, this removes the initialize function from the DAC HIL.


### Testing Strategy

It just calls self.initialize() instead of returning an error.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
