### PR TITLE
capsules: remove lingering pub static mut

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -384,6 +384,10 @@ pub unsafe fn main() {
         capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, nrf52832::i2c::TWI>,
         capsules_core::virtualizers::virtual_i2c::I2CDevice::new(i2c_mux, 0x40)
     );
+    let mcp230xx_buffer = static_init!(
+        [u8; capsules_extra::mcp230xx::BUFFER_LENGTH],
+        [0; capsules_extra::mcp230xx::BUFFER_LENGTH]
+    );
     let mcp23017 = static_init!(
         capsules_extra::mcp230xx::MCP230xx<
             'static,
@@ -393,7 +397,7 @@ pub unsafe fn main() {
             mcp23017_i2c,
             Some(mcp_pin0),
             Some(mcp_pin1),
-            &mut capsules_extra::mcp230xx::BUFFER,
+            mcp230xx_buffer,
             8,
             2
         )

--- a/boards/apollo3/lora_things_plus/src/main.rs
+++ b/boards/apollo3/lora_things_plus/src/main.rs
@@ -315,11 +315,15 @@ unsafe fn setup() -> (
     PROCESS_PRINTER = Some(process_printer);
 
     // Init the I2C device attached via Qwiic
+    let i2c_master_buffer = static_init!(
+        [u8; capsules_core::i2c_master::BUFFER_LENGTH],
+        [0; capsules_core::i2c_master::BUFFER_LENGTH]
+    );
     let i2c_master = static_init!(
         capsules_core::i2c_master::I2CMasterDriver<'static, apollo3::iom::Iom<'static>>,
         capsules_core::i2c_master::I2CMasterDriver::new(
             &peripherals.iom0,
-            &mut capsules_core::i2c_master::BUF,
+            i2c_master_buffer,
             board_kernel.create_grant(
                 capsules_core::i2c_master::DRIVER_NUM,
                 &memory_allocation_cap

--- a/boards/apollo3/redboard_artemis_nano/src/main.rs
+++ b/boards/apollo3/redboard_artemis_nano/src/main.rs
@@ -272,11 +272,15 @@ unsafe fn setup() -> (
     PROCESS_PRINTER = Some(process_printer);
 
     // Init the I2C device attached via Qwiic
+    let i2c_master_buffer = static_init!(
+        [u8; capsules_core::i2c_master::BUFFER_LENGTH],
+        [0; capsules_core::i2c_master::BUFFER_LENGTH]
+    );
     let i2c_master = static_init!(
         capsules_core::i2c_master::I2CMasterDriver<'static, apollo3::iom::Iom<'static>>,
         capsules_core::i2c_master::I2CMasterDriver::new(
             &peripherals.iom2,
-            &mut capsules_core::i2c_master::BUF,
+            i2c_master_buffer,
             board_kernel.create_grant(
                 capsules_core::i2c_master::DRIVER_NUM,
                 &memory_allocation_cap

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -424,11 +424,15 @@ unsafe fn setup() -> (
 
     digest.set_sha_client(sha);
 
+    let i2c_master_buffer = static_init!(
+        [u8; capsules_core::i2c_master::BUFFER_LENGTH],
+        [0; capsules_core::i2c_master::BUFFER_LENGTH]
+    );
     let i2c_master = static_init!(
         capsules_core::i2c_master::I2CMasterDriver<'static, lowrisc::i2c::I2c<'static>>,
         capsules_core::i2c_master::I2CMasterDriver::new(
             &peripherals.i2c0,
-            &mut capsules_core::i2c_master::BUF,
+            i2c_master_buffer,
             board_kernel.create_grant(
                 capsules_core::i2c_master::DRIVER_NUM,
                 &memory_allocation_cap

--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -505,12 +505,16 @@ pub unsafe fn main() {
     sda_pin.set_floating_state(FloatingState::PullUp);
     scl_pin.set_floating_state(FloatingState::PullUp);
 
+    let i2c_master_buffer = static_init!(
+        [u8; capsules_core::i2c_master::BUFFER_LENGTH],
+        [0; capsules_core::i2c_master::BUFFER_LENGTH]
+    );
     let i2c0 = &peripherals.i2c0;
     let i2c = static_init!(
         I2CMasterDriver<I2c>,
         I2CMasterDriver::new(
             i2c0,
-            &mut capsules_core::i2c_master::BUF,
+            i2c_master_buffer,
             board_kernel.create_grant(
                 capsules_core::i2c_master::DRIVER_NUM,
                 &memory_allocation_capability

--- a/capsules/core/src/i2c_master.rs
+++ b/capsules/core/src/i2c_master.rs
@@ -27,7 +27,7 @@ mod rw_allow {
 #[derive(Default)]
 pub struct App;
 
-pub static mut BUF: [u8; 64] = [0; 64];
+pub const BUFFER_LENGTH: usize = 64;
 
 struct Transaction {
     /// The buffer containing the bytes to transmit as it should be returned to

--- a/capsules/core/src/i2c_master_slave_driver.rs
+++ b/capsules/core/src/i2c_master_slave_driver.rs
@@ -26,9 +26,7 @@ use kernel::{ErrorCode, ProcessId};
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 
-pub static mut BUFFER1: [u8; 256] = [0; 256];
-pub static mut BUFFER2: [u8; 256] = [0; 256];
-pub static mut BUFFER3: [u8; 256] = [0; 256];
+pub const BUFFER_LENGTH: usize = 256;
 
 /// Syscall driver number.
 use crate::driver;

--- a/capsules/extra/src/app_flash_driver.rs
+++ b/capsules/extra/src/app_flash_driver.rs
@@ -19,11 +19,11 @@
 //! ```
 //! # use kernel::static_init;
 //!
-//! pub static mut APP_FLASH_BUFFER: [u8; 512] = [0; 512];
+//! let app_flash_buffer = static_init!([u8; 512], [0; 512]);
 //! let app_flash = static_init!(
 //!     capsules::app_flash_driver::AppFlash<'static>,
 //!     capsules::app_flash_driver::AppFlash::new(nv_to_page,
-//!         board_kernel.create_grant(&grant_cap), &mut APP_FLASH_BUFFER));
+//!         board_kernel.create_grant(&grant_cap), app_flash_buffer));
 //! ```
 
 use core::cmp;

--- a/capsules/extra/src/max17205.rs
+++ b/capsules/extra/src/max17205.rs
@@ -28,10 +28,12 @@
 //! let max17205_i2c_upper = static_init!(
 //!     capsules::virtual_i2c::I2CDevice,
 //!     capsules::virtual_i2c::I2CDevice::new(i2c_bus, 0x0B));
+//! let max17205_buffer = static_init!([u8; capsules::max17205::BUFFER_LENGTH],
+//!                                    [0; capsules::max17205::BUFFER_LENGTH]);
 //! let max17205 = static_init!(
 //!     capsules::max17205::MAX17205<'static>,
 //!     capsules::max17205::MAX17205::new(max17205_i2c_lower, max17205_i2c_upper,
-//!                                       &mut capsules::max17205::BUFFER));
+//!                                       max17205_buffer));
 //! max17205_i2c.set_client(max17205);
 //!
 //! // For userspace.
@@ -53,7 +55,7 @@ use kernel::{ErrorCode, ProcessId};
 use capsules_core::driver;
 pub const DRIVER_NUM: usize = driver::NUM::Max17205 as usize;
 
-pub static mut BUFFER: [u8; 8] = [0; 8];
+pub const BUFFER_LENGTH: usize = 8;
 
 // Addresses 0x000 - 0x0FF, 0x180 - 0x1FF can be written as blocks
 // Addresses 0x100 - 0x17F must be written by word

--- a/capsules/extra/src/mcp230xx.rs
+++ b/capsules/extra/src/mcp230xx.rs
@@ -36,12 +36,14 @@
 //! let mcp230xx_i2c = static_init!(
 //!     capsules::virtual_i2c::I2CDevice,
 //!     capsules::virtual_i2c::I2CDevice::new(i2c_mux, 0x20));
+//! let mcp230xx_buffer = static_init!([u8; capsules::mcp230xx::BUFFER_LENGTH],
+//!                                    [0; capsules::mcp230xx::BUFFER_LENGTH]);
 //! let mcp230xx = static_init!(
 //!     capsules::mcp230xx::MCP230xx<'static>,
 //!     capsules::mcp230xx::MCP230xx::new(mcp230xx_i2c,
 //!                                       Some(&sam4l::gpio::PA[04]),
 //!                                       None,
-//!                                       &mut capsules::mcp230xx::BUFFER,
+//!                                       mcp230xx_buffer,
 //!                                       8, // How many pins in a bank
 //!                                       1, // How many pin banks on the chip
 //!                                       ));
@@ -75,7 +77,7 @@ use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::ErrorCode;
 
 // Buffer to use for I2C messages
-pub static mut BUFFER: [u8; 7] = [0; 7];
+pub const BUFFER_LENGTH: usize = 7;
 
 #[allow(dead_code)]
 #[derive(Debug)]

--- a/capsules/extra/src/nonvolatile_to_pages.rs
+++ b/capsules/extra/src/nonvolatile_to_pages.rs
@@ -26,14 +26,17 @@
 //!
 //! ```rust
 //! # use kernel::{hil, static_init};
-//!
+
 //! sam4l::flashcalw::FLASH_CONTROLLER.configure();
-//! pub static mut PAGEBUFFER: sam4l::flashcalw::Sam4lPage = sam4l::flashcalw::Sam4lPage::new();
+//! let page_buffer = static_init!(
+//!     sam4l::flashcalw::Sam4lPage,
+//!     sam4l::flashcalw::Sam4lPage::default()
+//! );
 //! let nv_to_page = static_init!(
 //!     capsules::nonvolatile_to_pages::NonvolatileToPages<'static, sam4l::flashcalw::FLASHCALW>,
 //!     capsules::nonvolatile_to_pages::NonvolatileToPages::new(
 //!         &mut sam4l::flashcalw::FLASH_CONTROLLER,
-//!         &mut PAGEBUFFER));
+//!         page_buffer));
 //! hil::flash::HasClient::set_client(&sam4l::flashcalw::FLASH_CONTROLLER, nv_to_page);
 //! ```
 

--- a/capsules/extra/src/pca9544a.rs
+++ b/capsules/extra/src/pca9544a.rs
@@ -26,9 +26,11 @@
 //! let pca9544a_i2c = static_init!(
 //!     capsules::virtual_i2c::I2CDevice,
 //!     capsules::virtual_i2c::I2CDevice::new(i2c_bus, 0x70));
+//! let pca9544a_buffer = static_init!([u8; capsules::pca9544a::BUFFER_LENGTH],
+//!                                    [0; capsules::pca9544a::BUFFER_LENGTH]);
 //! let pca9544a = static_init!(
 //!     capsules::pca9544a::PCA9544A<'static>,
-//!     capsules::pca9544a::PCA9544A::new(pca9544a_i2c, &mut capsules::pca9544a::BUFFER));
+//!     capsules::pca9544a::PCA9544A::new(pca9544a_i2c, pca9544a_buffer));
 //! pca9544a_i2c.set_client(pca9544a);
 //! ```
 
@@ -44,7 +46,7 @@ use kernel::{ErrorCode, ProcessId};
 use capsules_core::driver;
 pub const DRIVER_NUM: usize = driver::NUM::Pca9544a as usize;
 
-pub static mut BUFFER: [u8; 5] = [0; 5];
+pub const BUFFER_LENGTH: usize = 5;
 
 #[derive(Clone, Copy, PartialEq)]
 enum State {

--- a/capsules/extra/src/sdcard.rs
+++ b/capsules/extra/src/sdcard.rs
@@ -34,6 +34,11 @@
 //!      capsules::virtual_alarm::VirtualMuxAlarm::new(mux_alarm));
 //! sdcard_virtual_alarm.setup();
 //!
+//! let sdcard_tx_buffer = static_init!([u8; capsules::sdcard::TXRX_BUFFER_LENGTH],
+//!                                     [0; capsules::sdcard::TXRX_BUFFER_LENGTH]);
+//! let sdcard_rx_buffer = static_init!([u8; capsules::sdcard::TXRX_BUFFER_LENGTH],
+//!                                     [0; capsules::sdcard::TXRX_BUFFER_LENGTH]);
+//!
 //! let sdcard = static_init!(
 //!     capsules::sdcard::SDCard<
 //!         'static,
@@ -41,11 +46,14 @@
 //!     capsules::sdcard::SDCard::new(sdcard_spi,
 //!                                   sdcard_virtual_alarm,
 //!                                   Some(&SD_DETECT_PIN),
-//!                                   &mut capsules::sdcard::TXBUFFER,
-//!                                   &mut capsules::sdcard::RXBUFFER));
+//!                                   sdcard_tx_buffer,
+//!                                   sdcard_rx_buffer));
 //! sdcard_spi.set_client(sdcard);
 //! sdcard_virtual_alarm.set_alarm_client(sdcard);
 //! SD_DETECT_PIN.set_client(sdcard);
+//!
+//! let sdcard_kernel_buffer = static_init!([u8; capsules::sdcard::KERNEL_BUFFER_LENGTH],
+//!                                         [0; capsules::sdcard::KERNEL_BUFFER_LENGTH]);
 //!
 //! let sdcard_driver = static_init!(
 //!     capsules::sdcard::SDCardDriver<
@@ -53,7 +61,7 @@
 //!         capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf52833::rtc::Rtc>>,
 //!     capsules::sdcard::SDCardDriver::new(
 //!         sdcard,
-//!         &mut capsules::sdcard::KERNEL_BUFFER,
+//!         sdcard_kernel_buffer,
 //!         board_kernel.create_grant(
 //!             capsules::sdcard::DRIVER_NUM,
 //!             &memory_allocation_capability)));
@@ -100,8 +108,7 @@ mod rw_allow {
 ///
 ///  * RXBUFFER must be greater than or equal to TXBUFFER in length
 ///  * Both RXBUFFER and TXBUFFER must be longer  than the SD card's block size
-pub static mut TXBUFFER: [u8; 515] = [0; 515];
-pub static mut RXBUFFER: [u8; 515] = [0; 515];
+pub const TXRX_BUFFER_LENGTH: usize = 515;
 
 /// SD Card capsule, capable of being built on top of by other kernel capsules
 pub struct SDCard<'a, A: hil::time::Alarm<'a>> {
@@ -1467,7 +1474,7 @@ pub struct SDCardDriver<'a, A: hil::time::Alarm<'a>> {
 pub struct App;
 
 /// Buffer for SD card driver, assigned in board `main.rs` files
-pub static mut KERNEL_BUFFER: [u8; 512] = [0; 512];
+pub const KERNEL_BUFFER_LENGTH: usize = 512;
 
 /// Functions for SDCardDriver
 impl<'a, A: hil::time::Alarm<'a>> SDCardDriver<'a, A> {

--- a/capsules/extra/src/tsl2561.rs
+++ b/capsules/extra/src/tsl2561.rs
@@ -31,7 +31,7 @@ use capsules_core::driver;
 pub const DRIVER_NUM: usize = driver::NUM::Tsl2561 as usize;
 
 // Buffer to use for I2C messages
-pub static mut BUFFER: [u8; 4] = [0; 4];
+pub const BUFFER_LENGTH: usize = 4;
 
 /// Command register defines
 const COMMAND_REG: u8 = 0x80;


### PR DESCRIPTION
### Pull Request Overview

This includes some comments as well as a few remaining static mut buffers used by boards.


Fixes #1545.







### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
