### PR TITLE
kernel: StoragePermissions: add "kerneluser" storage access

### DIFF
--- a/kernel/src/capabilities.rs
+++ b/kernel/src/capabilities.rs
@@ -84,6 +84,10 @@ pub unsafe trait MemoryAllocationCapability {}
 /// restricted.
 pub unsafe trait ExternalProcessCapability {}
 
+/// The `SuperuserStorageCapability` capability allows the holder to create
+/// permissions to access any stored values on the system.
+pub unsafe trait SuperuserStorageCapability {}
+
 /// The `UdpDriverCapability` capability allows the holder to use two functions
 /// only allowed by the UDP driver. The first is the `driver_send_to()` function
 /// in udp_send.rs, which does not require being bound to a single port, since

--- a/kernel/src/capabilities.rs
+++ b/kernel/src/capabilities.rs
@@ -84,9 +84,9 @@ pub unsafe trait MemoryAllocationCapability {}
 /// restricted.
 pub unsafe trait ExternalProcessCapability {}
 
-/// The `SuperuserStorageCapability` capability allows the holder to create
-/// permissions to access any stored values on the system.
-pub unsafe trait SuperuserStorageCapability {}
+/// The KernelruserStorageCapability` capability allows the holder to create
+/// permissions to access kernel-only stored values on the system.
+pub unsafe trait KerneluserStorageCapability {}
 
 /// The `UdpDriverCapability` capability allows the holder to use two functions
 /// only allowed by the UDP driver. The first is the `driver_send_to()` function

--- a/kernel/src/storage_permissions.rs
+++ b/kernel/src/storage_permissions.rs
@@ -5,6 +5,9 @@
 //! Mechanism for managing storage read & write permissions.
 
 use core::cmp;
+use core::num::NonZeroU32;
+
+use crate::capabilities;
 
 /// List of storage permissions for a storage user.
 ///
@@ -20,21 +23,26 @@ use core::cmp;
 /// we may want to revamp this interface.
 #[derive(Clone, Copy)]
 pub struct StoragePermissions {
-    // How many entries in the `read_permissions` slice are valid, starting at
-    // index 0.
+    /// How many entries in the `read_permissions` slice are valid, starting at
+    /// index 0.
     read_count: usize,
-    // Up to eight 32 bit identifiers of storage items the process has read
-    // access to.
+    /// Up to eight 32 bit identifiers of storage items the process has read
+    /// access to.
     read_permissions: [u32; 8],
-    // How many entries in the `write_permissions` slice are valid, starting at
-    // index 0.
+    /// How many entries in the `write_permissions` slice are valid, starting at
+    /// index 0.
     write_count: usize,
-    // Up to eight 32 bit identifiers of storage items the process has write
-    // (update) access to.
+    /// Up to eight 32 bit identifiers of storage items the process has write
+    /// (update) access to.
     write_permissions: [u32; 8],
-    // The identifier for this storage user when creating new objects. If `None`
-    // there is no `write_id` for these permissions.
-    write_id: Option<u32>,
+    /// The identifier for this storage user when creating new objects. If
+    /// `None` there is no `write_id` for these permissions.
+    write_id: Option<NonZeroU32>,
+    /// If `superuser` is true, this permission grants full access to all stored
+    /// items. New items created with `superuser == true` will use the specified
+    /// ID if  `write_id.is_some()`, otherwise new items will be created with
+    /// the reserved ID (i.e., 0).
+    superuser: bool,
 }
 
 impl StoragePermissions {
@@ -43,7 +51,7 @@ impl StoragePermissions {
         read_permissions: [u32; 8],
         write_count: usize,
         write_permissions: [u32; 8],
-        write_id: Option<u32>,
+        write_id: Option<NonZeroU32>,
     ) -> Self {
         let read_count_capped = cmp::min(read_count, 8);
         let write_count_capped = cmp::min(write_count, 8);
@@ -53,29 +61,76 @@ impl StoragePermissions {
             write_count: write_count_capped,
             write_permissions,
             write_id,
+            superuser: false,
+        }
+    }
+
+    /// Create superuser permissions suitable for the kernel. This allows the
+    /// kernel to read/update any stored item, and allows the kernel to write
+    /// items that will not be accessible to any clients without superuser
+    /// permissions.
+    pub fn new_kernel_permissions(_cap: &dyn capabilities::SuperuserStorageCapability) -> Self {
+        let read_permissions: [u32; 8] = [0; 8];
+        let write_permissions: [u32; 8] = [0; 8];
+        StoragePermissions {
+            read_count: 0,
+            read_permissions,
+            write_count: 0,
+            write_permissions,
+            write_id: None,
+            superuser: true,
         }
     }
 
     /// Check if this permission object grants read access to the specified
     /// `storage_id`. Returns `true` if access is permitted, `false` otherwise.
     pub fn check_read_permission(&self, storage_id: u32) -> bool {
-        self.read_permissions
-            .get(0..self.read_count)
-            .unwrap_or(&[])
-            .contains(&storage_id)
+        if self.superuser {
+            // Superuser grants all permissions.
+            true
+        } else {
+            if storage_id == 0 {
+                // Only superuser can read ID 0.
+                false
+            } else {
+                // Otherwise check if given storage_id is in read permissions
+                // array.
+                self.read_permissions
+                    .get(0..self.read_count)
+                    .unwrap_or(&[])
+                    .contains(&storage_id)
+            }
+        }
     }
 
     /// Check if this permission object grants write access to the specified
     /// `storage_id`. Returns `true` if access is permitted, `false` otherwise.
     pub fn check_write_permission(&self, storage_id: u32) -> bool {
-        self.write_permissions
-            .get(0..self.write_count)
-            .unwrap_or(&[])
-            .contains(&storage_id)
+        if self.superuser {
+            // Superuser grants all permissions.
+            true
+        } else {
+            if storage_id == 0 {
+                // Only superuser can access ID 0.
+                false
+            } else {
+                // Otherwise check if given storage_id is in read permissions
+                // array.
+                self.write_permissions
+                    .get(0..self.write_count)
+                    .unwrap_or(&[])
+                    .contains(&storage_id)
+            }
+        }
     }
 
     /// Get the `write_id` for saving items to the storage.
     pub fn get_write_id(&self) -> Option<u32> {
-        self.write_id
+        if self.superuser {
+            // If superuser, write_id is 0 unless specifically set.
+            Some(self.write_id.map_or(0, |wid| wid.get()))
+        } else {
+            self.write_id.map_or(None, |wid| Some(wid.get()))
+        }
     }
 }

--- a/libraries/tock-tbf/src/types.rs
+++ b/libraries/tock-tbf/src/types.rs
@@ -227,7 +227,7 @@ pub struct TbfHeaderV2Permissions<const L: usize> {
 /// A list of persistent access permissions
 #[derive(Clone, Copy, Debug)]
 pub struct TbfHeaderV2PersistentAcl<const L: usize> {
-    write_id: u32,
+    write_id: Option<core::num::NonZeroU32>,
     read_length: u16,
     read_ids: [u32; L],
     access_length: u16,
@@ -518,11 +518,11 @@ impl<const L: usize> core::convert::TryFrom<&[u8]> for TbfHeaderV2PersistentAcl<
     fn try_from(b: &[u8]) -> Result<TbfHeaderV2PersistentAcl<L>, Self::Error> {
         let mut read_end = 6;
 
-        let write_id = u32::from_le_bytes(
+        let write_id = core::num::NonZeroU32::new(u32::from_le_bytes(
             b.get(0..4)
                 .ok_or(TbfParseError::NotEnoughFlash)?
                 .try_into()?,
-        );
+        ));
 
         let read_length = u16::from_le_bytes(
             b.get(4..6)
@@ -877,10 +877,10 @@ impl TbfHeader {
 
     /// Get the process `write_id`.
     /// Returns `None` if a `write_id` is not included.
-    pub fn get_persistent_acl_write_id(&self) -> Option<u32> {
+    pub fn get_persistent_acl_write_id(&self) -> Option<core::num::NonZeroU32> {
         match self {
             TbfHeader::TbfHeaderV2(hd) => match hd.persistent_acls {
-                Some(persistent_acls) => Some(persistent_acls.write_id),
+                Some(persistent_acls) => persistent_acls.write_id,
                 _ => None,
             },
             _ => None,


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a mechanism for the kernel to have special access to its items on a board, _and_ to use a storage platform shared with processes while keeping keys reserved for itself. This should allow us to use TicKV in the kernel.

Since the TBF definition already effectively reserved write_id 0 to mean "this process cannot write items" this PR uses write_id 0 for the kernel. This also formalizes that 0 means no writing by saving `write_id` as an `Option<NonZeroU32>`.

To give the kernel access I added a `kerneluser` flag to the `StoragePermission`. It allows the kernel to access items with write_id 0.

To create a kernel level `StoragePermission` I added a capability (`KerneluserStorageCapability`) and then made the constructor protected on that capability.


### Testing Strategy

This pull request was tested by compiling. The changes are largely mechanical.


### TODO or Help Wanted

Thoughts on reserving 0 for the kernel?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

The TBF doc already reserves the write id 0, so I didn't need to update anything.

### Formatting

- [x] Ran `make prepush`.
