### PR TITLE
Add license headers to the `.jlink` files.

### DIFF
--- a/.lcignore
+++ b/.lcignore
@@ -36,6 +36,5 @@
 # issue #3417)
 *.ld
 !/tools/license-checker/testdata/block_comments.ld
-*.jlink
 *.xml
 !/tools/license-checker/testdata/block_comments.xml

--- a/boards/nordic/nrf52840_dongle/jtag/gdbinit_pca10040.jlink
+++ b/boards/nordic/nrf52840_dongle/jtag/gdbinit_pca10040.jlink
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2019.
+# Copyright Google LLC 2019.
 #
 #
 #

--- a/boards/nordic/nrf52840dk/jtag/gdbinit_pca10040.jlink
+++ b/boards/nordic/nrf52840dk/jtag/gdbinit_pca10040.jlink
@@ -1,3 +1,6 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2018.
 #
 #
 #

--- a/boards/nordic/nrf52dk/jtag/flash-full.jlink
+++ b/boards/nordic/nrf52dk/jtag/flash-full.jlink
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2017.
+
 eoe 1
 r
 loadfile ../../../target/thumbv7em-none-eabi/release/nrf52dk-blink.hex

--- a/boards/nordic/nrf52dk/jtag/flash-kernel.jlink
+++ b/boards/nordic/nrf52dk/jtag/flash-kernel.jlink
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2017.
+
 eoe 1
 r
 loadfile ../../../target/thumbv7em-none-eabi/release/nrf52dk.hex

--- a/boards/nordic/nrf52dk/jtag/gdbinit_pca10040.jlink
+++ b/boards/nordic/nrf52dk/jtag/gdbinit_pca10040.jlink
@@ -1,3 +1,6 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2018.
 #
 #
 #

--- a/tools/license-checker/src/fallback_syntax.yaml
+++ b/tools/license-checker/src/fallback_syntax.yaml
@@ -35,7 +35,7 @@ contexts:
       push: has_no_comments
 
   has_number_comments:
-    - match: "^# "
+    - match: "^#"
       scope: punctuation.definition.comment.fallback
       push: number_comment
 

--- a/tools/license-checker/src/parser.rs
+++ b/tools/license-checker/src/parser.rs
@@ -300,6 +300,7 @@ mod tests {
             Other,
             Other,
             Other,
+            Comment("Lines starting with a '#' without a space are comments too."),
         ];
         let path = Path::new("testdata/number_signs.fallback");
         assert_produces(Parser::new(&Cache::default(), path), EXPECTED);

--- a/tools/license-checker/testdata/number_signs.fallback
+++ b/tools/license-checker/testdata/number_signs.fallback
@@ -6,3 +6,4 @@
 syntect should not recognize this file type. Instead, the license checker
 // should use the fallback parser, which should identify that this file uses
 /* number signs for its comments. */
+#Lines starting with a '#' without a space are comments too.


### PR DESCRIPTION
I tweaked the license checker's fallback parser so it accepts comments that start with `#` rather than `# `, which allows for a `#\n` line at the end of the header (as we allow for other file types).