### PR TITLE
Add license headers to `.ld` files.

### DIFF
--- a/.lcignore
+++ b/.lcignore
@@ -34,7 +34,5 @@
 
 # File types that the license checker does not support but should support (see
 # issue #3417)
-*.ld
-!/tools/license-checker/testdata/block_comments.ld
 *.xml
 !/tools/license-checker/testdata/block_comments.xml

--- a/boards/acd52832/layout.ld
+++ b/boards/acd52832/layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 /* Memory Space Definitions, 512K flash, 64K ram */
 MEMORY
 {

--- a/boards/apollo3/lora_things_plus/layout.ld
+++ b/boards/apollo3/lora_things_plus/layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 MEMORY
 {
   rom (rx)  : ORIGIN = 0x0000C000, LENGTH = 0x00030000

--- a/boards/apollo3/redboard_artemis_nano/layout.ld
+++ b/boards/apollo3/redboard_artemis_nano/layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 MEMORY
 {
   rom (rx)  : ORIGIN = 0x0000C000, LENGTH = 0x00030000

--- a/boards/arty_e21/layout.ld
+++ b/boards/arty_e21/layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 MEMORY
 {
   rom (rx)  : ORIGIN = 0x40400000, LENGTH = 0x00030000

--- a/boards/clue_nrf52840/layout.ld
+++ b/boards/clue_nrf52840/layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 MEMORY
 {
   # Make space for the UF2 bootloader (152K)

--- a/boards/esp32-c3-devkitM-1/layout.ld
+++ b/boards/esp32-c3-devkitM-1/layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 MEMORY
 {
   rom (rx)  : ORIGIN = 0x40380000, LENGTH = 0x30000

--- a/boards/hail/chip_layout.ld
+++ b/boards/hail/chip_layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 /* Memory Spaces Definitions, 448K flash, 64K ram */
 /* Bootloader is at address 0x00000000 */
 MEMORY

--- a/boards/hail/layout.ld
+++ b/boards/hail/layout.ld
@@ -1,2 +1,6 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 INCLUDE ./chip_layout.ld
 INCLUDE ../kernel_layout.ld

--- a/boards/hifive1/layout.ld
+++ b/boards/hifive1/layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 /* The HiFive1a board has 512 MB of flash. The first 0x400000 is reserved for
  * the default bootloader provided by SiFive. We also reserve room for apps to
  * make all of the linker files work, but don't really support them on this

--- a/boards/hifive_inventor/layout.ld
+++ b/boards/hifive_inventor/layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 /* The HiFive inventor board has 512 MiB of flash and 64 KiB of RAM.
  */
 

--- a/boards/imix/chip_layout.ld
+++ b/boards/imix/chip_layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 /* Memory Spaces Definitions, 448K flash, 64K ram */
 /* Use bootloader starting at 0x0000 */
 MEMORY

--- a/boards/imix/layout.ld
+++ b/boards/imix/layout.ld
@@ -1,2 +1,6 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 INCLUDE ./chip_layout.ld
 INCLUDE ../kernel_layout.ld

--- a/boards/imxrt1050-evkb/chip_layout.ld
+++ b/boards/imxrt1050-evkb/chip_layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 /* Memory layout for the i.MX RT 1050 EVKB
  * rom = 2MB (LENGTH = 0x02000000)
  * kernel = 256KB

--- a/boards/imxrt1050-evkb/layout.ld
+++ b/boards/imxrt1050-evkb/layout.ld
@@ -1,2 +1,6 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 INCLUDE ./chip_layout.ld
 INCLUDE ../kernel_layout.ld

--- a/boards/kernel_layout.ld
+++ b/boards/kernel_layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 /*
  * This is the generic linker script for Tock. For most developers, it should
  * be sufficient to define {ROM/PROG/RAM}_{ORIGIN/LENGTH} (6 variables, the

--- a/boards/litex/arty/layout.ld
+++ b/boards/litex/arty/layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 /* The entire memory is actually placed into DRAM by the bootloader */
 
 MEMORY

--- a/boards/litex/sim/layout.ld
+++ b/boards/litex/sim/layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 /* RAM starts at 0x40000000, the binary is loaded into ROM at 0x0 */
 
 MEMORY

--- a/boards/microbit_v2/layout.ld
+++ b/boards/microbit_v2/layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 MEMORY
 {
   # with bootloader

--- a/boards/msp_exp432p401r/chip_layout.ld
+++ b/boards/msp_exp432p401r/chip_layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 /* Memory Space Definitions, 256K flash, 64K ram */
 MEMORY
 {

--- a/boards/msp_exp432p401r/layout.ld
+++ b/boards/msp_exp432p401r/layout.ld
@@ -1,2 +1,6 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 INCLUDE ./chip_layout.ld
 INCLUDE ../kernel_layout.ld

--- a/boards/nano33ble/layout.ld
+++ b/boards/nano33ble/layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 MEMORY
 {
   rom (rx)  : ORIGIN = 0x00010000, LENGTH = 256K

--- a/boards/nano_rp2040_connect/layout.ld
+++ b/boards/nano_rp2040_connect/layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 MEMORY
 {
   /* uncomment this to boot from RAM */

--- a/boards/nordic/nrf52832_chip_layout.ld
+++ b/boards/nordic/nrf52832_chip_layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 /* Memory Space Definitions, 512K flash, 64K ram */
 MEMORY
 {

--- a/boards/nordic/nrf52840_chip_layout.ld
+++ b/boards/nordic/nrf52840_chip_layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 /* Memory Space Definitions, 1M flash, 256K ram */
 MEMORY
 {

--- a/boards/nordic/nrf52840_dongle/layout.ld
+++ b/boards/nordic/nrf52840_dongle/layout.ld
@@ -1,2 +1,6 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 INCLUDE ../nrf52840_chip_layout.ld
 INCLUDE ../../kernel_layout.ld

--- a/boards/nordic/nrf52840dk/layout.ld
+++ b/boards/nordic/nrf52840dk/layout.ld
@@ -1,2 +1,6 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 INCLUDE ../nrf52840_chip_layout.ld
 INCLUDE ../../kernel_layout.ld

--- a/boards/nordic/nrf52dk/layout.ld
+++ b/boards/nordic/nrf52dk/layout.ld
@@ -1,2 +1,6 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 INCLUDE ../nrf52832_chip_layout.ld
 INCLUDE ../../kernel_layout.ld

--- a/boards/nucleo_f429zi/chip_layout.ld
+++ b/boards/nucleo_f429zi/chip_layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 /* Memory layout for the STM32F446RE
  * rom = 2MB (LENGTH = 0x02000000)
  * kernel = 256KB

--- a/boards/nucleo_f429zi/layout.ld
+++ b/boards/nucleo_f429zi/layout.ld
@@ -1,2 +1,6 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 INCLUDE ./chip_layout.ld
 INCLUDE ../kernel_layout.ld

--- a/boards/nucleo_f446re/chip_layout.ld
+++ b/boards/nucleo_f446re/chip_layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 /* Memory layout for the STM32F446RE
  * rom = 512KB (LENGTH = 0x00080000)
  * kernel = 256KB

--- a/boards/nucleo_f446re/layout.ld
+++ b/boards/nucleo_f446re/layout.ld
@@ -1,2 +1,6 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 INCLUDE ./chip_layout.ld
 INCLUDE ../kernel_layout.ld

--- a/boards/opentitan/earlgrey-cw310/layout.ld
+++ b/boards/opentitan/earlgrey-cw310/layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 MEMORY
 {
   rom   (rx)  : ORIGIN = 0x20000000, LENGTH = 0x30000

--- a/boards/opentitan/earlgrey-cw310/test_layout.ld
+++ b/boards/opentitan/earlgrey-cw310/test_layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 /*
  * This is used when building test binaries with `make test`.
  * It reduces the size for apps, as we don't use apps with the test

--- a/boards/particle_boron/layout.ld
+++ b/boards/particle_boron/layout.ld
@@ -1,2 +1,6 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 INCLUDE ../nordic/nrf52840_chip_layout.ld
 INCLUDE ../kernel_layout.ld

--- a/boards/pico_explorer_base/layout.ld
+++ b/boards/pico_explorer_base/layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 MEMORY
 {
   /* uncomment this to boot from RAM */

--- a/boards/qemu_rv32_virt/layout.ld
+++ b/boards/qemu_rv32_virt/layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 /**
  * QEMU emulated DRAM region. Tock is currently designed to be placed
  * at the start of DRAM, using the `-bios` option in qemu-system-riscv32.

--- a/boards/raspberry_pi_pico/layout.ld
+++ b/boards/raspberry_pi_pico/layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 MEMORY
 {
   /* uncomment this to boot from RAM */

--- a/boards/redboard_redv/layout.ld
+++ b/boards/redboard_redv/layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 /* The RedV board has 4 MB of flash. The first 0x10000 is reserved for
  * the default bootloader provided by SiFive. We also reserve room for apps to
  * make all of the linker files work.

--- a/boards/sma_q3/layout.ld
+++ b/boards/sma_q3/layout.ld
@@ -1,2 +1,6 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 INCLUDE ../nordic/nrf52840_chip_layout.ld
 INCLUDE ../kernel_layout.ld

--- a/boards/stm32f3discovery/chip_layout.ld
+++ b/boards/stm32f3discovery/chip_layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 /* Memory layout for the STM32F303VCT6
  * rom = 256KB (LENGTH = 0x00040000)
  * kernel = 128KB

--- a/boards/stm32f3discovery/layout.ld
+++ b/boards/stm32f3discovery/layout.ld
@@ -1,2 +1,6 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 INCLUDE ./chip_layout.ld
 INCLUDE ../kernel_layout.ld

--- a/boards/stm32f412gdiscovery/chip_layout.ld
+++ b/boards/stm32f412gdiscovery/chip_layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 /* Memory layout for the STM32F412G
  * rom = 1MB (LENGTH = 0x01000000)
  * kernel = 256KB

--- a/boards/stm32f412gdiscovery/layout.ld
+++ b/boards/stm32f412gdiscovery/layout.ld
@@ -1,2 +1,6 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 INCLUDE ./chip_layout.ld
 INCLUDE ../kernel_layout.ld

--- a/boards/stm32f429idiscovery/chip_layout.ld
+++ b/boards/stm32f429idiscovery/chip_layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 /* Memory layout for the STM32F446RE
  * rom = 2MB (LENGTH = 0x02000000)
  * kernel = 256KB

--- a/boards/stm32f429idiscovery/layout.ld
+++ b/boards/stm32f429idiscovery/layout.ld
@@ -1,2 +1,6 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 INCLUDE ./chip_layout.ld
 INCLUDE ../kernel_layout.ld

--- a/boards/swervolf/layout.ld
+++ b/boards/swervolf/layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 MEMORY
 {
   rom (rx)  : ORIGIN = 0x00000000, LENGTH = 0x30000

--- a/boards/teensy40/layout.ld
+++ b/boards/teensy40/layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 /*
  * Teensy 4 Linker Script
  *

--- a/boards/weact_f401ccu6/layout.ld
+++ b/boards/weact_f401ccu6/layout.ld
@@ -1,3 +1,7 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
 /* Memory layout for the STM32F401CCU6
  * rom = 256KB (LENGTH = 0x00040000)
  * kernel = 128KB


### PR DESCRIPTION
I don't have time to dig through the history of all the linker scripts, so I followed the practice from #3317 and used `Copyright 2023`.