### PR TITLE
siphash24: add test

### DIFF
--- a/boards/nordic/nrf52840dk/src/test/mod.rs
+++ b/boards/nordic/nrf52840dk/src/test/mod.rs
@@ -2,11 +2,4 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2023.
 
-pub mod aes;
-pub mod aes_ccm;
-pub mod aes_gcm;
-pub mod crc;
-pub mod kv_system;
-pub mod sha256;
-pub mod siphash24;
-pub mod udp;
+pub(crate) mod siphash24_test;

--- a/boards/nordic/nrf52840dk/src/test/siphash24_test.rs
+++ b/boards/nordic/nrf52840dk/src/test/siphash24_test.rs
@@ -1,0 +1,40 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2023.
+
+//! This tests a software SipHash24 implementation. To run this test,
+//! add this line to the boot sequence:
+//! ```
+//! test::siphash24_test::run_siphash24();
+//! ```
+
+use capsules_extra::sip_hash::SipHasher24;
+use capsules_extra::test::siphash24::TestSipHash24;
+use kernel::static_init;
+
+pub unsafe fn run_siphash24() {
+    let t = static_init_test_siphash24();
+    t.run();
+}
+
+pub static mut HSTRING: [u8; 15] = *b"tickv-super-key";
+pub static mut HBUF: [u8; 64] = [0; 64];
+
+pub static mut HHASH: [u8; 8] = [0; 8];
+pub static mut CHASH: [u8; 8] = [0xd1, 0xdc, 0x3b, 0x92, 0xc2, 0x5a, 0x1b, 0x30];
+
+unsafe fn static_init_test_siphash24() -> &'static TestSipHash24 {
+    let sha = static_init!(SipHasher24<'static>, SipHasher24::new());
+    kernel::deferred_call::DeferredCallClient::register(sha);
+
+    // Copy to the 64 byte buffer because we always hash 64 bytes.
+    for i in 0..15 {
+        HBUF[i] = HSTRING[i];
+    }
+    let test = static_init!(
+        TestSipHash24,
+        TestSipHash24::new(sha, &mut HBUF, &mut HHASH, &mut CHASH)
+    );
+
+    test
+}

--- a/capsules/extra/src/test/siphash24.rs
+++ b/capsules/extra/src/test/siphash24.rs
@@ -1,0 +1,65 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! Test the software implementation of SipHash24 by performing a hash
+//! and checking it against the expected hash value. It uses
+//! DigestData::add_date and DigestVerify::verify through the
+//! Digest trait.
+
+use crate::sip_hash::SipHasher24;
+use kernel::debug;
+use kernel::hil::hasher::{Client, Hasher};
+use kernel::utilities::cells::TakeCell;
+use kernel::utilities::leasable_buffer::LeasableMutableBuffer;
+use kernel::ErrorCode;
+
+pub struct TestSipHash24 {
+    hasher: &'static SipHasher24<'static>,
+    data: TakeCell<'static, [u8]>,            // The data to hash
+    hash: TakeCell<'static, [u8; 8]>,         // The supplied hash
+    correct_hash: TakeCell<'static, [u8; 8]>, // The correct hash
+}
+
+impl TestSipHash24 {
+    pub fn new(
+        hasher: &'static SipHasher24<'static>,
+        data: &'static mut [u8],
+        hash: &'static mut [u8; 8],
+        correct_hash: &'static mut [u8; 8],
+    ) -> Self {
+        TestSipHash24 {
+            hasher,
+            data: TakeCell::new(data),
+            hash: TakeCell::new(hash),
+            correct_hash: TakeCell::new(correct_hash),
+        }
+    }
+
+    pub fn run(&'static self) {
+        self.hasher.set_client(self);
+        let data = self.data.take().unwrap();
+        let buffer = LeasableMutableBuffer::new(data);
+        let r = self.hasher.add_mut_data(buffer);
+        if r.is_err() {
+            panic!("SipHash24Test: failed to add data: {:?}", r);
+        }
+    }
+}
+
+impl Client<8> for TestSipHash24 {
+    fn add_mut_data_done(&self, _result: Result<(), ErrorCode>, data: &'static mut [u8]) {
+        self.data.replace(data);
+        self.hasher.run(self.hash.take().unwrap()).unwrap();
+    }
+
+    fn add_data_done(&self, _result: Result<(), ErrorCode>, _data: &'static [u8]) {}
+
+    fn hash_done(&self, _result: Result<(), ErrorCode>, digest: &'static mut [u8; 8]) {
+        debug!("hashed result:   {:?}", digest);
+        debug!("expected result: {:?}", self.correct_hash.take().unwrap());
+
+        self.hash.replace(digest);
+        self.hasher.clear_data();
+    }
+}


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a simple test for the SipHash24 software hash capsule.


### Testing Strategy

Running the test on the nrf52840dk.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
