### PR TITLE
capsules: tickv: hashed keys big endian

### DIFF
--- a/capsules/extra/src/tickv.rs
+++ b/capsules/extra/src/tickv.rs
@@ -424,7 +424,7 @@ impl<'a, F: Flash, H: Hasher<'a, 8>> KVSystem<'a> for TicKVStore<'a, F, H> {
             Operation::None => {
                 self.operation.set(Operation::AppendKey);
 
-                match self.tickv.append_key(u64::from_le_bytes(*key), value) {
+                match self.tickv.append_key(u64::from_be_bytes(*key), value) {
                     Ok(_ret) => {
                         self.key_buffer.replace(key);
                         Ok(())
@@ -470,7 +470,7 @@ impl<'a, F: Flash, H: Hasher<'a, 8>> KVSystem<'a> for TicKVStore<'a, F, H> {
             Operation::None => {
                 self.operation.set(Operation::GetKey);
 
-                match self.tickv.get_key(u64::from_le_bytes(*key), ret_buf) {
+                match self.tickv.get_key(u64::from_be_bytes(*key), ret_buf) {
                     Ok(_ret) => {
                         self.key_buffer.replace(key);
                         Ok(())
@@ -508,7 +508,7 @@ impl<'a, F: Flash, H: Hasher<'a, 8>> KVSystem<'a> for TicKVStore<'a, F, H> {
             Operation::None => {
                 self.operation.set(Operation::InvalidateKey);
 
-                match self.tickv.invalidate_key(u64::from_le_bytes(*key)) {
+                match self.tickv.invalidate_key(u64::from_be_bytes(*key)) {
                     Ok(_ret) => {
                         self.key_buffer.replace(key);
                         Ok(())


### PR DESCRIPTION


### Pull Request Overview

This pull request changes how we pass hashed keys to the tickv library. Since the library stores hashed keys as big endian:


https://github.com/tock/tock/blob/f5bd104ce5ef1e603d2cb8e6180369ece836cfcd/libraries/tickv/src/tickv.rs#L575-L598

we should pass the keys in as big endian.


### Testing Strategy

I found this when trying to write a tockloader library to parse tickv databases.

After this change the stored hash and my computed hash are in the same byte order.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
