### PR TITLE
Fixes RNG capsule re-enter

### DIFF
--- a/capsules/core/src/rng.rs
+++ b/capsules/core/src/rng.rs
@@ -180,30 +180,29 @@ impl<'a> SyscallDriver for RngDriver<'a> {
         processid: ProcessId,
     ) -> CommandReturn {
         match command_num {
-            0 /* Check if exists */ =>
-            {
-                CommandReturn::success()
-            }
+            // Check if exists
+            0 => CommandReturn::success(),
 
-            1 /* Ask for a given number of random bytes */ => {
+            // Ask for a given number of random bytes
+            1 => {
                 let mut needs_get = false;
                 let result = self
-                .apps
-                .enter(processid, |app, _| {
-                    app.remaining = data;
-                    app.idx = 0;
+                    .apps
+                    .enter(processid, |app, _| {
+                        app.remaining = data;
+                        app.idx = 0;
 
-                    // Assume that the process has a callback & slice
-                    // set. It might die or revoke them before the
-                    // result arrives anyways
-                    if !self.getting_randomness.get() {
-                        self.getting_randomness.set(true);
-                        needs_get = true;
-                    }
+                        // Assume that the process has a callback & slice
+                        // set. It might die or revoke them before the
+                        // result arrives anyways
+                        if !self.getting_randomness.get() {
+                            self.getting_randomness.set(true);
+                            needs_get = true;
+                        }
 
-                    CommandReturn::success()
-                })
-                .unwrap_or_else(|err| CommandReturn::failure(err.into()));
+                        CommandReturn::success()
+                    })
+                    .unwrap_or_else(|err| CommandReturn::failure(err.into()));
                 if needs_get {
                     let _ = self.rng.get();
                 }


### PR DESCRIPTION
Prevents "Attempted to re-enter a grant region." to be triggered by some rng client implementations.

Calling the client's `self.rng.get()` can lead to the client calling `randomness_available` immediately, which iterates all apps while the command has already one.

### Pull Request Overview

This pull request fixes the RNG capsule

### Testing Strategy

This pull request was tested on a board that is not part of mainstream Tock. Please verify it on other boards to make sure it doesn't break anything.

### TODO or Help Wanted

See above for testing.

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`. ~~Warning: Your formatter doesn't work. If I change the formatting to something outrageous and wrong, and then run `make format`, nothing happens. But this is outside the scope of this PR.~~
