### PR TITLE
kernel: HIL: digest: add set_client() for `ClientDataHash` and `ClientDataVerify`

### DIFF
--- a/capsules/core/src/virtualizers/virtual_digest.rs
+++ b/capsules/core/src/virtualizers/virtual_digest.rs
@@ -148,6 +148,8 @@ impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestData<'a, L>
             self.mux.digest.clear_data()
         }
     }
+
+    fn set_data_client(&'a self, _client: &'a (dyn digest::ClientData<L> + 'a)) {}
 }
 
 impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestHash<'a, L>
@@ -175,6 +177,8 @@ impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestHash<'a, L>
             }
         }
     }
+
+    fn set_hash_client(&'a self, _client: &'a (dyn digest::ClientHash<L> + 'a)) {}
 }
 
 impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestVerify<'a, L>
@@ -200,6 +204,8 @@ impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestVerify<'a, L>
             }
         }
     }
+
+    fn set_verify_client(&'a self, _client: &'a (dyn digest::ClientVerify<L> + 'a)) {}
 }
 
 impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::Digest<'a, L>

--- a/capsules/core/src/virtualizers/virtual_digest.rs
+++ b/capsules/core/src/virtualizers/virtual_digest.rs
@@ -149,7 +149,9 @@ impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestData<'a, L>
         }
     }
 
-    fn set_data_client(&'a self, _client: &'a (dyn digest::ClientData<L> + 'a)) {}
+    fn set_data_client(&'a self, _client: &'a (dyn digest::ClientData<L> + 'a)) {
+        unimplemented!()
+    }
 }
 
 impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestHash<'a, L>
@@ -178,7 +180,9 @@ impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestHash<'a, L>
         }
     }
 
-    fn set_hash_client(&'a self, _client: &'a (dyn digest::ClientHash<L> + 'a)) {}
+    fn set_hash_client(&'a self, _client: &'a (dyn digest::ClientHash<L> + 'a)) {
+        unimplemented!()
+    }
 }
 
 impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestVerify<'a, L>
@@ -205,7 +209,9 @@ impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestVerify<'a, L>
         }
     }
 
-    fn set_verify_client(&'a self, _client: &'a (dyn digest::ClientVerify<L> + 'a)) {}
+    fn set_verify_client(&'a self, _client: &'a (dyn digest::ClientVerify<L> + 'a)) {
+        unimplemented!()
+    }
 }
 
 impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::Digest<'a, L>

--- a/capsules/core/src/virtualizers/virtual_hmac.rs
+++ b/capsules/core/src/virtualizers/virtual_hmac.rs
@@ -116,6 +116,8 @@ impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestData<'a, L>
             self.mux.hmac.clear_data()
         }
     }
+
+    fn set_data_client(&'a self, _client: &'a (dyn digest::ClientData<L> + 'a)) {}
 }
 
 impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestHash<'a, L>
@@ -142,6 +144,8 @@ impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestHash<'a, L>
             }
         }
     }
+
+    fn set_hash_client(&'a self, _client: &'a (dyn digest::ClientHash<L> + 'a)) {}
 }
 
 impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestVerify<'a, L>
@@ -166,6 +170,8 @@ impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestVerify<'a, L>
             }
         }
     }
+
+    fn set_verify_client(&'a self, _client: &'a (dyn digest::ClientVerify<L> + 'a)) {}
 }
 
 impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::Digest<'a, L>

--- a/capsules/core/src/virtualizers/virtual_hmac.rs
+++ b/capsules/core/src/virtualizers/virtual_hmac.rs
@@ -117,7 +117,9 @@ impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestData<'a, L>
         }
     }
 
-    fn set_data_client(&'a self, _client: &'a (dyn digest::ClientData<L> + 'a)) {}
+    fn set_data_client(&'a self, _client: &'a (dyn digest::ClientData<L> + 'a)) {
+        unimplemented!()
+    }
 }
 
 impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestHash<'a, L>
@@ -145,7 +147,9 @@ impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestHash<'a, L>
         }
     }
 
-    fn set_hash_client(&'a self, _client: &'a (dyn digest::ClientHash<L> + 'a)) {}
+    fn set_hash_client(&'a self, _client: &'a (dyn digest::ClientHash<L> + 'a)) {
+        unimplemented!()
+    }
 }
 
 impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestVerify<'a, L>
@@ -171,7 +175,9 @@ impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestVerify<'a, L>
         }
     }
 
-    fn set_verify_client(&'a self, _client: &'a (dyn digest::ClientVerify<L> + 'a)) {}
+    fn set_verify_client(&'a self, _client: &'a (dyn digest::ClientVerify<L> + 'a)) {
+        unimplemented!()
+    }
 }
 
 impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::Digest<'a, L>

--- a/capsules/core/src/virtualizers/virtual_sha.rs
+++ b/capsules/core/src/virtualizers/virtual_sha.rs
@@ -117,6 +117,8 @@ impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestData<'a, L>
             self.mux.sha.clear_data()
         }
     }
+
+    fn set_data_client(&'a self, _client: &'a (dyn digest::ClientData<L> + 'a)) {}
 }
 
 impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestHash<'a, L>
@@ -143,6 +145,8 @@ impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestHash<'a, L>
             }
         }
     }
+
+    fn set_hash_client(&'a self, _client: &'a (dyn digest::ClientHash<L> + 'a)) {}
 }
 
 impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestVerify<'a, L>
@@ -167,6 +171,8 @@ impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestVerify<'a, L>
             }
         }
     }
+
+    fn set_verify_client(&'a self, _client: &'a (dyn digest::ClientVerify<L> + 'a)) {}
 }
 
 impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::Digest<'a, L>

--- a/capsules/core/src/virtualizers/virtual_sha.rs
+++ b/capsules/core/src/virtualizers/virtual_sha.rs
@@ -118,7 +118,9 @@ impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestData<'a, L>
         }
     }
 
-    fn set_data_client(&'a self, _client: &'a (dyn digest::ClientData<L> + 'a)) {}
+    fn set_data_client(&'a self, _client: &'a (dyn digest::ClientData<L> + 'a)) {
+        unimplemented!()
+    }
 }
 
 impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestHash<'a, L>
@@ -146,7 +148,9 @@ impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestHash<'a, L>
         }
     }
 
-    fn set_hash_client(&'a self, _client: &'a (dyn digest::ClientHash<L> + 'a)) {}
+    fn set_hash_client(&'a self, _client: &'a (dyn digest::ClientHash<L> + 'a)) {
+        unimplemented!()
+    }
 }
 
 impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestVerify<'a, L>
@@ -172,7 +176,9 @@ impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestVerify<'a, L>
         }
     }
 
-    fn set_verify_client(&'a self, _client: &'a (dyn digest::ClientVerify<L> + 'a)) {}
+    fn set_verify_client(&'a self, _client: &'a (dyn digest::ClientVerify<L> + 'a)) {
+        unimplemented!()
+    }
 }
 
 impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::Digest<'a, L>

--- a/capsules/extra/src/sha256.rs
+++ b/capsules/extra/src/sha256.rs
@@ -14,6 +14,7 @@ use kernel::deferred_call::{DeferredCall, DeferredCallClient};
 
 use kernel::hil::digest::Client;
 use kernel::hil::digest::Sha256;
+use kernel::hil::digest::{ClientDataHash, ClientDataVerify, DigestDataHash, DigestDataVerify};
 use kernel::hil::digest::{Digest, DigestData, DigestHash, DigestVerify};
 use kernel::utilities::cells::{MapCell, OptionalCell};
 use kernel::utilities::leasable_buffer::LeasableBuffer;
@@ -478,4 +479,12 @@ impl Sha256 for Sha256Software<'_> {
     fn set_mode_sha256(&self) -> Result<(), ErrorCode> {
         Ok(())
     }
+}
+
+impl<'a> DigestDataHash<'a, 32> for Sha256Software<'a> {
+    fn set_client(&'a self, _client: &'a dyn ClientDataHash<32>) {}
+}
+
+impl<'a> DigestDataVerify<'a, 32> for Sha256Software<'a> {
+    fn set_client(&'a self, _client: &'a dyn ClientDataVerify<32>) {}
 }

--- a/capsules/extra/src/sha256.rs
+++ b/capsules/extra/src/sha256.rs
@@ -12,8 +12,8 @@
 use core::cell::Cell;
 use kernel::deferred_call::{DeferredCall, DeferredCallClient};
 
-use kernel::hil::digest::Client;
 use kernel::hil::digest::Sha256;
+use kernel::hil::digest::{Client, ClientData, ClientHash, ClientVerify};
 use kernel::hil::digest::{ClientDataHash, ClientDataVerify, DigestDataHash, DigestDataVerify};
 use kernel::hil::digest::{Digest, DigestData, DigestHash, DigestVerify};
 use kernel::utilities::cells::{MapCell, OptionalCell};
@@ -330,6 +330,8 @@ impl<'a> DigestData<'a, 32> for Sha256Software<'a> {
     fn clear_data(&self) {
         self.initialize();
     }
+
+    fn set_data_client(&'a self, _client: &'a (dyn ClientData<32> + 'a)) {}
 }
 
 impl<'a> DigestHash<'a, 32> for Sha256Software<'a> {
@@ -354,6 +356,8 @@ impl<'a> DigestHash<'a, 32> for Sha256Software<'a> {
             Ok(())
         }
     }
+
+    fn set_hash_client(&'a self, _client: &'a (dyn ClientHash<32> + 'a)) {}
 }
 
 impl<'a> DigestVerify<'a, 32> for Sha256Software<'a> {
@@ -371,6 +375,8 @@ impl<'a> DigestVerify<'a, 32> for Sha256Software<'a> {
             Ok(())
         }
     }
+
+    fn set_verify_client(&'a self, _client: &'a (dyn ClientVerify<32> + 'a)) {}
 }
 
 impl<'a> Digest<'a, 32> for Sha256Software<'a> {

--- a/capsules/extra/src/sha256.rs
+++ b/capsules/extra/src/sha256.rs
@@ -331,7 +331,9 @@ impl<'a> DigestData<'a, 32> for Sha256Software<'a> {
         self.initialize();
     }
 
-    fn set_data_client(&'a self, _client: &'a (dyn ClientData<32> + 'a)) {}
+    fn set_data_client(&'a self, _client: &'a (dyn ClientData<32> + 'a)) {
+        unimplemented!()
+    }
 }
 
 impl<'a> DigestHash<'a, 32> for Sha256Software<'a> {
@@ -357,7 +359,9 @@ impl<'a> DigestHash<'a, 32> for Sha256Software<'a> {
         }
     }
 
-    fn set_hash_client(&'a self, _client: &'a (dyn ClientHash<32> + 'a)) {}
+    fn set_hash_client(&'a self, _client: &'a (dyn ClientHash<32> + 'a)) {
+        unimplemented!()
+    }
 }
 
 impl<'a> DigestVerify<'a, 32> for Sha256Software<'a> {
@@ -376,7 +380,9 @@ impl<'a> DigestVerify<'a, 32> for Sha256Software<'a> {
         }
     }
 
-    fn set_verify_client(&'a self, _client: &'a (dyn ClientVerify<32> + 'a)) {}
+    fn set_verify_client(&'a self, _client: &'a (dyn ClientVerify<32> + 'a)) {
+        unimplemented!()
+    }
 }
 
 impl<'a> Digest<'a, 32> for Sha256Software<'a> {
@@ -488,9 +494,13 @@ impl Sha256 for Sha256Software<'_> {
 }
 
 impl<'a> DigestDataHash<'a, 32> for Sha256Software<'a> {
-    fn set_client(&'a self, _client: &'a dyn ClientDataHash<32>) {}
+    fn set_client(&'a self, _client: &'a dyn ClientDataHash<32>) {
+        unimplemented!()
+    }
 }
 
 impl<'a> DigestDataVerify<'a, 32> for Sha256Software<'a> {
-    fn set_client(&'a self, _client: &'a dyn ClientDataVerify<32>) {}
+    fn set_client(&'a self, _client: &'a dyn ClientDataVerify<32>) {
+        unimplemented!()
+    }
 }

--- a/chips/lowrisc/src/hmac.rs
+++ b/chips/lowrisc/src/hmac.rs
@@ -319,6 +319,8 @@ impl<'a> hil::digest::DigestData<'a, 32> for Hmac<'a> {
         regs.wipe_secret.set(1 as u32);
         self.cancelled.set(true);
     }
+
+    fn set_data_client(&'a self, _client: &'a (dyn digest::ClientData<32> + 'a)) {}
 }
 
 impl<'a> hil::digest::DigestHash<'a, 32> for Hmac<'a> {
@@ -341,6 +343,8 @@ impl<'a> hil::digest::DigestHash<'a, 32> for Hmac<'a> {
 
         Ok(())
     }
+
+    fn set_hash_client(&'a self, _client: &'a (dyn digest::ClientHash<32> + 'a)) {}
 }
 
 impl<'a> hil::digest::DigestVerify<'a, 32> for Hmac<'a> {
@@ -352,6 +356,8 @@ impl<'a> hil::digest::DigestVerify<'a, 32> for Hmac<'a> {
 
         self.run(compare)
     }
+
+    fn set_verify_client(&'a self, _client: &'a (dyn digest::ClientVerify<32> + 'a)) {}
 }
 
 impl<'a> hil::digest::Digest<'a, 32> for Hmac<'a> {

--- a/chips/lowrisc/src/hmac.rs
+++ b/chips/lowrisc/src/hmac.rs
@@ -320,7 +320,9 @@ impl<'a> hil::digest::DigestData<'a, 32> for Hmac<'a> {
         self.cancelled.set(true);
     }
 
-    fn set_data_client(&'a self, _client: &'a (dyn digest::ClientData<32> + 'a)) {}
+    fn set_data_client(&'a self, _client: &'a (dyn digest::ClientData<32> + 'a)) {
+        unimplemented!()
+    }
 }
 
 impl<'a> hil::digest::DigestHash<'a, 32> for Hmac<'a> {
@@ -344,7 +346,9 @@ impl<'a> hil::digest::DigestHash<'a, 32> for Hmac<'a> {
         Ok(())
     }
 
-    fn set_hash_client(&'a self, _client: &'a (dyn digest::ClientHash<32> + 'a)) {}
+    fn set_hash_client(&'a self, _client: &'a (dyn digest::ClientHash<32> + 'a)) {
+        unimplemented!()
+    }
 }
 
 impl<'a> hil::digest::DigestVerify<'a, 32> for Hmac<'a> {
@@ -357,7 +361,9 @@ impl<'a> hil::digest::DigestVerify<'a, 32> for Hmac<'a> {
         self.run(compare)
     }
 
-    fn set_verify_client(&'a self, _client: &'a (dyn digest::ClientVerify<32> + 'a)) {}
+    fn set_verify_client(&'a self, _client: &'a (dyn digest::ClientVerify<32> + 'a)) {
+        unimplemented!()
+    }
 }
 
 impl<'a> hil::digest::Digest<'a, 32> for Hmac<'a> {

--- a/kernel/src/hil/digest.rs
+++ b/kernel/src/hil/digest.rs
@@ -246,14 +246,20 @@ pub trait Digest<'a, const L: usize>:
 /// Computes a digest (cryptographic hash) over data.
 ///
 /// 'L' is the length of the 'u8' array to store the digest output.
-pub trait DigestDataHash<'a, const L: usize>: DigestData<'a, L> + DigestHash<'a, L> {}
-impl<'a, T: DigestData<'a, L> + DigestHash<'a, L>, const L: usize> DigestDataHash<'a, L> for T {}
+pub trait DigestDataHash<'a, const L: usize>: DigestData<'a, L> + DigestHash<'a, L> {
+    /// Set the client instance which will receive `hash_done()` and
+    /// `add_data_done()` callbacks.
+    fn set_client(&'a self, client: &'a dyn ClientDataHash<L>);
+}
 
-/// Verify a digest over data.
+/// Verify a digest (cryptographic hash) over data.
 ///
 /// 'L' is the length of the 'u8' array to store the digest output.
-pub trait DigestDataVerify<'a, const L: usize>: DigestData<'a, L> + DigestVerify<'a, L> {}
-impl<'a, T: DigestData<'a, L> + DigestVerify<'a, L>, const L: usize> DigestDataVerify<'a, L> for T {}
+pub trait DigestDataVerify<'a, const L: usize>: DigestData<'a, L> + DigestVerify<'a, L> {
+    /// Set the client instance which will receive `verify_done()` and
+    /// `add_data_done()` callbacks.
+    fn set_client(&'a self, client: &'a dyn ClientDataVerify<L>);
+}
 
 pub trait Sha224 {
     /// Call before adding data to perform Sha224

--- a/kernel/src/hil/digest.rs
+++ b/kernel/src/hil/digest.rs
@@ -111,10 +111,8 @@ impl<T: ClientData<L> + ClientVerify<L>, const L: usize> ClientDataVerify<L> for
 /// 'L' is the length of the 'u8' array to store the digest output.
 pub trait DigestData<'a, const L: usize> {
     /// Set the client instance which will handle the `add_data_done`
-    /// and `add_mut_data_done` callbacks.  This is not required if
-    /// using the `set_client()` fuction from the `Digest` trait.
-    #[allow(unused_variables)]
-    fn set_data_client(&'a self, client: &'a dyn ClientData<L>) {}
+    /// and `add_mut_data_done` callbacks.
+    fn set_data_client(&'a self, client: &'a dyn ClientData<L>);
 
     /// Add data to the input of the hash function/digest. `Ok`
     /// indicates all of the active bytes in `data` will be added.
@@ -166,10 +164,7 @@ pub trait DigestData<'a, const L: usize> {
 pub trait DigestHash<'a, const L: usize> {
     /// Set the client instance which will receive the `hash_done()`
     /// callback.
-    /// This is not required if using the `set_client()` fuction from the
-    /// `Digest` trait.
-    #[allow(unused_variables)]
-    fn set_hash_client(&'a self, client: &'a dyn ClientHash<L>) {}
+    fn set_hash_client(&'a self, client: &'a dyn ClientHash<L>);
 
     /// Compute a digest of all of the data added with `add_data` and
     /// `add_data_mut`, storing the computed value in `digest`.  The
@@ -201,10 +196,7 @@ pub trait DigestHash<'a, const L: usize> {
 pub trait DigestVerify<'a, const L: usize> {
     /// Set the client instance which will receive the `verification_done()`
     /// callback.
-    /// This is not required if using the `set_client()` fuction from the
-    /// `Digest` trait.
-    #[allow(unused_variables)]
-    fn set_verify_client(&'a self, client: &'a dyn ClientVerify<L>) {}
+    fn set_verify_client(&'a self, client: &'a dyn ClientVerify<L>);
 
     /// Compute a digest of all of the data added with `add_data` and
     /// `add_data_mut` then compare it with value in `compare`.  The


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the digest HIL to add `set_client()` methods for two client types which were defined but could not be set in a capsule using the HIL. This makes it possible to implement a digest module which does 2 of the 3 operations (data, hash, verify).

But, like `Digest`, we can no longer apply these traits automatically. So, we have to explicitly add them (as in the sha256 capsule).


### Testing Strategy

Creating an HMAC-SHA256 capsule.


### TODO or Help Wanted

Is this the right way to go? I might be missing something. 


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
