### PR TITLE
Avoid building PRs twice through the push and merge_group triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,11 @@ env:
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
 on:
-  push: # Run CI for all branches
+  push: # Run CI for all branches except GitHub merge queue tmp branches
+    branches-ignore:
+    - "gh-readonly-queue/**"
   pull_request: # Run CI for PRs on any branch
-  merge_group:
+  merge_group: # Run CI for the GitHub merge queue
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 # If you add additional jobs, remember to add them to bors.toml

--- a/.github/workflows/litex_sim.yml
+++ b/.github/workflows/litex_sim.yml
@@ -13,9 +13,11 @@ env:
 # Controls when the action will run. Triggers the workflow on push or pull
 # request events but only for the master branch
 on:
-  push: # Run CI for all branches
+  push: # Run CI for all branches except GitHub merge queue tmp branches
+    branches-ignore:
+    - "gh-readonly-queue/**"
   pull_request: # Run CI for PRs on any branch
-  merge_group:
+  merge_group: # Run CI for the GitHub merge queue
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 # If you add additional jobs, remember to add them to bors.toml


### PR DESCRIPTION
### Pull Request Overview

GitHub issues its own `merge_group` event when building a PR as part of its merge queue (pushing to a `github-readonly-queue/*` branch). However, we also unconditionally build all pushed branches through the `push` trigger. We can avoid uncessarily building PRs in the merge-queue twice by excluding those special GitHub-created branches in the `push` trigger.

### Testing Strategy

This pull request was tested by merging a PR with this workflow config on a fork.


### TODO or Help Wanted

N/A


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
