### PR TITLE
tickv: return value buffer on append fail

### DIFF
--- a/libraries/tickv/src/async_ops.rs
+++ b/libraries/tickv/src/async_ops.rs
@@ -339,8 +339,13 @@ impl<'a, C: FlashController<S>, const S: usize> AsyncTicKV<'a, C, S> {
                     (ret, None)
                 }
                 _ => {
+                    let ret_buf = match self.tickv.state.get() {
+                        State::AppendKey(_) => self.value.take(),
+                        State::GetKey(_) => self.buf.take(),
+                        _ => None,
+                    };
                     self.tickv.state.set(State::None);
-                    (ret, self.buf.take())
+                    (ret, ret_buf)
                 }
             },
         }

--- a/libraries/tickv/src/async_ops.rs
+++ b/libraries/tickv/src/async_ops.rs
@@ -329,8 +329,13 @@ impl<'a, C: FlashController<S>, const S: usize> AsyncTicKV<'a, C, S> {
 
         match ret {
             Ok(_) => {
+                let ret_buf = match self.tickv.state.get() {
+                    State::AppendKey(_) => self.value.take(),
+                    State::GetKey(_) => self.buf.take(),
+                    _ => None,
+                };
                 self.tickv.state.set(State::None);
-                (ret, self.buf.take())
+                (ret, ret_buf)
             }
             Err(e) => match e {
                 ErrorCode::ReadNotReady(_) | ErrorCode::EraseNotReady(_) => (ret, None),


### PR DESCRIPTION
### Pull Request Overview
Without this tickv would not return the value buffer on a failed append.


### Testing Strategy

Writing to the same key as is already in the db.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
