### PR TITLE
capsules: tickv: call error cb on append error

### DIFF
--- a/kernel/src/hil/kv_system.rs
+++ b/kernel/src/hil/kv_system.rs
@@ -216,6 +216,7 @@ pub trait KVSystem<'a> {
     ///    `INVAL`: An invalid parameter was passed
     ///    `NODEVICE`: No KV store was setup
     ///    `ENOSUPPORT`: The key could not be found.
+    ///    `SIZE`: The value is longer than the provided buffer.
     fn get_value(
         &self,
         key: &'static mut Self::K,


### PR DESCRIPTION
### Pull Request Overview

In the tickv capsule we need to signal a callback even if the append fails.


### Testing Strategy

Writing to an existing key.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
