### PR TITLE
tickv: remove get_buffer functions

### DIFF
--- a/libraries/tickv/src/async_ops.rs
+++ b/libraries/tickv/src/async_ops.rs
@@ -277,18 +277,6 @@ impl<'a, C: FlashController<S>, const S: usize> AsyncTicKV<'a, C, S> {
         self.tickv.read_buffer.replace(Some(buf));
     }
 
-    /// Get the `value` buffer that was passed in by previous
-    /// commands.
-    pub fn get_stored_value_buffer(&self) -> Option<&'static mut [u8]> {
-        self.value.take()
-    }
-
-    /// Get the `buf` buffer that was passed in by previous
-    /// commands.
-    pub fn get_stored_buffer(&self) -> Option<&'static mut [u8]> {
-        self.buf.take()
-    }
-
     /// Continue the last operation after the async operation has completed.
     /// This should be called from a read/erase complete callback.
     /// NOTE: If called from a read callback, `set_read_buffer` should be


### PR DESCRIPTION
### Pull Request Overview

These would be hard to use correctly, if they can be used correctly, since either tickv should be using the buffers or they are passed back in callbacks.

#3489 removes the use of the get_value_buffer after I fixed that the value buffer is provided in the append done callback.






### Testing Strategy

This pull request was tested by using the kv app in libtock-c.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
