### PR TITLE
capsules: kv driver: need to clear buffers

### DIFF
--- a/capsules/extra/src/kv_driver.rs
+++ b/capsules/extra/src/kv_driver.rs
@@ -102,7 +102,9 @@ impl<'a, K: kv_system::KVSystem<'a, K = T>, T: kv_system::KeyType> KVSystemDrive
                                                 let static_buffer_len =
                                                     buf.len().min(unhashed_key.len());
 
-                                                // Copy the data into the static buffer
+                                                // Copy the data into the
+                                                // cleared static buffer.
+                                                buf.fill(0);
                                                 unhashed_key[..static_buffer_len]
                                                     .copy_to_slice(&mut buf[..static_buffer_len]);
 
@@ -142,7 +144,9 @@ impl<'a, K: kv_system::KVSystem<'a, K = T>, T: kv_system::KeyType> KVSystemDrive
                                                 let static_buffer_len =
                                                     buf.len().min(unhashed_key.len());
 
-                                                // Copy the data into the static buffer
+                                                // Copy the data into the
+                                                // cleared static buffer.
+                                                buf.fill(0);
                                                 unhashed_key[..static_buffer_len]
                                                     .copy_to_slice(&mut buf[..static_buffer_len]);
 
@@ -162,7 +166,9 @@ impl<'a, K: kv_system::KVSystem<'a, K = T>, T: kv_system::KeyType> KVSystemDrive
                                                 // Determine the size of the static buffer we have
                                                 static_buffer_len = buf.len().min(value.len());
 
-                                                // Copy the data into the static buffer
+                                                // Copy the data into the
+                                                // cleared static buffer.
+                                                buf.fill(0);
                                                 value[..static_buffer_len]
                                                     .copy_to_slice(&mut buf[..static_buffer_len]);
 
@@ -205,7 +211,9 @@ impl<'a, K: kv_system::KVSystem<'a, K = T>, T: kv_system::KeyType> KVSystemDrive
                                                 let static_buffer_len =
                                                     buf.len().min(unhashed_key.len());
 
-                                                // Copy the data into the static buffer
+                                                // Copy the data into the
+                                                // cleared static buffer.
+                                                buf.fill(0);
                                                 unhashed_key[..static_buffer_len]
                                                     .copy_to_slice(&mut buf[..static_buffer_len]);
 


### PR DESCRIPTION


### Pull Request Overview

Because the entire buffer is used we need to make sure we clear it since it could have values in it from previous operations.


### Testing Strategy

Running an interactive key get/set/delete userspace app.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
