### PR TITLE
Fix single APP panic in kernel scheduler

### DIFF
--- a/kernel/src/scheduler/cooperative.rs
+++ b/kernel/src/scheduler/cooperative.rs
@@ -60,9 +60,9 @@ impl<'a, C: Chip> Scheduler<C> for CooperativeSched<'a> {
         let mut first_head = None;
         let mut next = None;
 
-        // Find next ready process. Place any *empty* process slots, or not-ready
-        // processes, at the back of the queue.
-        for node in self.processes.iter() {
+        // Find the first ready process in the queue. Place any *empty* process slots,
+        // or not-ready processes, at the back of the queue.
+        while let Some(node) = self.processes.head() {
             // Ensure we do not loop forever if all processes are not not ready
             match first_head {
                 None => first_head = Some(node),

--- a/kernel/src/scheduler/round_robin.rs
+++ b/kernel/src/scheduler/round_robin.rs
@@ -72,9 +72,9 @@ impl<'a, C: Chip> Scheduler<C> for RoundRobinSched<'a> {
         let mut first_head = None;
         let mut next = None;
 
-        // Find next ready process. Place any *empty* process slots, or not-ready
-        // processes, at the back of the queue.
-        for node in self.processes.iter() {
+        // Find the first ready process in the queue. Place any *empty* process slots,
+        // or not-ready processes, at the back of the queue.
+        while let Some(node) = self.processes.head() {
             // Ensure we do not loop forever if all processes are not ready
             match first_head {
                 None => first_head = Some(node),


### PR DESCRIPTION
### Pull Request Overview

This pull request fixed a bug that the kernel will crash if we only have one APP and that APP is not ready.

In that kind of case, the scheduler will panic when doing `next.unwrap()`:

### Testing Strategy

This pull request was tested by running a few combos of apps / and single app test cases on our platform(ti50).

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
