### PR TITLE
kernel: process: do not inline load_*processes() functions

### DIFF
--- a/kernel/src/process_loading.rs
+++ b/kernel/src/process_loading.rs
@@ -172,7 +172,7 @@ impl fmt::Debug for ProcessLoadError {
 /// footers in the TBF for cryptographic credentials for binary
 /// integrity, passing them to the checker to decide whether the
 /// process has sufficient credentials to run.
-#[inline(always)]
+#[inline(never)]
 pub fn load_and_check_processes<KR: KernelResources<C>, C: Chip>(
     kernel: &'static Kernel,
     kernel_resources: &KR,
@@ -207,7 +207,7 @@ where
 /// credentials can call this method instead of `load_and_check_processes`
 /// because it results in a smaller kernel, as it does not invoke
 /// the credential checking state machine.
-#[inline(always)]
+#[inline(never)]
 pub fn load_processes<C: Chip>(
     kernel: &'static Kernel,
     chip: &'static C,


### PR DESCRIPTION
### Pull Request Overview

This causes the stack size of the main function to be quite large, and since main does not return its stack frame is not recovered.

Related to #2425.



With this patch:

```
❯ make allstack
hifive_inventor
----------------------
   main stack frame:
         1408     main

   5 largest stack frames:
         1648     _ZN6kernel15process_loading14load_processes17h4086cff94706f9b2E
         1568     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$18print_full_process17he131d7be106924b4E
         1408     main
          976     _ZN13capsules_core15process_console31ProcessConsole$LT$_$C$A$C$C$GT$11write_state17hbf87fa67f6d6c55cE
          960     _ZN6kernel5debug11panic_print17h54911765252f592eE

nrf52dk
----------------------
   main stack frame:
          128     main

   5 largest stack frames:
         2408     _ZN7cortexm24kernel_hardfault_arm_v7m17h88793f49ade3c395E
         1728     _ZN6kernel15process_loading14load_processes17h6134321b823806bbE
          960     _ZN13capsules_core15process_console31ProcessConsole$LT$_$C$A$C$C$GT$11write_state17h12a38ccfec0ca229E
          832     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$18print_full_process17had5cd228b8bd15a2E
          672     _ZN117_$LT$capsules_core..process_console..ProcessConsole$LT$_$C$A$C$C$GT$$u20$as$u20$kernel..hil..uart..TransmitClient$GT$18transmitted_buffer17h5706731d0f1a1db8E

nrf52840_dongle
----------------------
   main stack frame:
          160     main

   5 largest stack frames:
         2408     _ZN7cortexm24kernel_hardfault_arm_v7m17h88793f49ade3c395E
         1728     _ZN6kernel15process_loading14load_processes17hb5eabb632f44b429E
          960     _ZN13capsules_core15process_console31ProcessConsole$LT$_$C$A$C$C$GT$11write_state17h00e75e951ec52fb3E
          832     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$18print_full_process17h0eb0f6766ab104a8E
          672     _ZN117_$LT$capsules_core..process_console..ProcessConsole$LT$_$C$A$C$C$GT$$u20$as$u20$kernel..hil..uart..TransmitClient$GT$18transmitted_buffer17had9f0933c82c1ff4E

nrf52840dk
----------------------
   main stack frame:
          216     main

   5 largest stack frames:
         2408     _ZN7cortexm24kernel_hardfault_arm_v7m17h88793f49ade3c395E
         1728     _ZN6kernel15process_loading14load_processes17h4e8fa86364e49198E
          960     _ZN13capsules_core15process_console31ProcessConsole$LT$_$C$A$C$C$GT$11write_state17he6ea68c9e143ae96E
          832     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$18print_full_process17hf2f8846d8a7cbe1eE
          672     _ZN117_$LT$capsules_core..process_console..ProcessConsole$LT$_$C$A$C$C$GT$$u20$as$u20$kernel..hil..uart..TransmitClient$GT$18transmitted_buffer17h30706ad8e2f36510E

fatal: not a git repository (or any of the parent directories): .git
earlgrey-cw310
----------------------
   main stack frame:
           32     main

   5 largest stack frames:
         1568     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$18print_full_process17hf283a9c397c3b630E
         1232     _ZN6kernel15process_loading14load_processes17hd79e454a42bcbc9eE
         1168     _ZN6kernel5debug11panic_print17hec130056d49fc7eeE
         1040     _ZN14earlgrey_cw3105setup17h97f354014a6e3d24E
          736     _ZN6kernel6kernel6Kernel11kernel_loop17hd25114638c562921E

stm32f3discovery
----------------------
   main stack frame:
          448     main

   5 largest stack frames:
         2464     _ZN16stm32f3discovery18create_peripherals17hfb5465750c99df48E
         2408     _ZN7cortexm24kernel_hardfault_arm_v7m17h88793f49ade3c395E
         2120     rust_begin_unwind
         1728     _ZN6kernel15process_loading14load_processes17h2e86363a7e5d4a82E
          960     _ZN13capsules_core15process_console31ProcessConsole$LT$_$C$A$C$C$GT$11write_state17h952b54d62ed76570E

redboard_artemis_nano
----------------------
   main stack frame:
           24     main

   5 largest stack frames:
         2408     _ZN7cortexm24kernel_hardfault_arm_v7m17h88793f49ade3c395E
         1728     _ZN6kernel15process_loading14load_processes17h55cdcc392e93c972E
          832     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$18print_full_process17h414b19f7beecc6daE
          600     _ZN6kernel5debug11panic_print17h8216f8af5bc7dc74E
          520     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$11try_restart17hfa8a62b9de019830E

lora_things_plus
----------------------
   main stack frame:
           24     main

   5 largest stack frames:
         2408     _ZN7cortexm24kernel_hardfault_arm_v7m17h88793f49ade3c395E
         1736     _ZN6kernel15process_loading14load_processes17h4945d8124335e3c6E
          832     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$18print_full_process17hd2851a4b78b89a34E
          600     _ZN6kernel5debug11panic_print17hf573d43131026b23E
          520     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$11try_restart17h699970668029a181E

nano33ble
----------------------
   main stack frame:
          200     main

   5 largest stack frames:
         2408     _ZN7cortexm24kernel_hardfault_arm_v7m17h88793f49ade3c395E
         1728     _ZN6kernel15process_loading14load_processes17h9a1326945e3fb364E
          960     _ZN13capsules_core15process_console31ProcessConsole$LT$_$C$A$C$C$GT$11write_state17h885dc5c42a4d5b45E
          832     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$18print_full_process17h626b5ab1c4d86d8cE
          672     _ZN117_$LT$capsules_core..process_console..ProcessConsole$LT$_$C$A$C$C$GT$$u20$as$u20$kernel..hil..uart..TransmitClient$GT$18transmitted_buffer17h67574b1c1c03fa95E

hifive1
----------------------
   main stack frame:
          144     main

   5 largest stack frames:
         1648     _ZN6kernel15process_loading14load_processes17h5dd8d8523ce082b7E
         1568     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$18print_full_process17h65323dc0db0296f1E
          976     _ZN13capsules_core15process_console31ProcessConsole$LT$_$C$A$C$C$GT$11write_state17he9eb5b8a30f7b10dE
          960     _ZN6kernel5debug11panic_print17h06e09a58c4e05c10E
          672     _ZN117_$LT$capsules_core..process_console..ProcessConsole$LT$_$C$A$C$C$GT$$u20$as$u20$kernel..hil..uart..TransmitClient$GT$18transmitted_buffer17hc7e489618acb4292E

pico_explorer_base
----------------------
   main stack frame:
          896     main

   5 largest stack frames:
         1792     _ZN6kernel15process_loading14load_processes17h334d10e3822c7677E
         1000     _ZN13capsules_core15process_console31ProcessConsole$LT$_$C$A$C$C$GT$11write_state17hd77d00528a4ab3f9E
          928     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$18print_full_process17h5ec72e16ce6fa71fE
          896     main
          688     _ZN117_$LT$capsules_core..process_console..ProcessConsole$LT$_$C$A$C$C$GT$$u20$as$u20$kernel..hil..uart..TransmitClient$GT$18transmitted_buffer17hac193a1df918075eE

esp32-c3-board
----------------------
   main stack frame:
           32     main

   5 largest stack frames:
         1664     _ZN6kernel15process_loading14load_processes17h626ee9caf82aefc0E
         1568     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$18print_full_process17h845fbf66ee4cb760E
          976     _ZN13capsules_core15process_console31ProcessConsole$LT$_$C$A$C$C$GT$11write_state17hd9ac43541f2602aeE
          672     _ZN117_$LT$capsules_core..process_console..ProcessConsole$LT$_$C$A$C$C$GT$$u20$as$u20$kernel..hil..uart..TransmitClient$GT$18transmitted_buffer17hdd0719157c0dc079E
          544     _ZN103_$LT$kernel..process_printer..ProcessPrinterText$u20$as$u20$kernel..process_printer..ProcessPrinter$GT$14print_overview17h8e52e9f465ab2e4bE

raspberry_pi_pico
----------------------
   main stack frame:
          784     main

   5 largest stack frames:
         1792     _ZN6kernel15process_loading14load_processes17ha9bb9c0ed7744247E
         1000     _ZN13capsules_core15process_console31ProcessConsole$LT$_$C$A$C$C$GT$11write_state17h0388a0c67be9ae97E
          928     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$18print_full_process17h85dc33a640bb1b91E
          784     main
          688     _ZN117_$LT$capsules_core..process_console..ProcessConsole$LT$_$C$A$C$C$GT$$u20$as$u20$kernel..hil..uart..TransmitClient$GT$18transmitted_buffer17h130fa61956cd62afE

teensy40
----------------------
   main stack frame:
           64     main

   5 largest stack frames:
         3200     _ZN8teensy4018create_peripherals17h31d38b30677317e5E
         2408     _ZN7cortexm24kernel_hardfault_arm_v7m17h88793f49ade3c395E
         1952     _ZN6kernel15process_loading14load_processes17h887f652ccafdd567E
          968     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$11try_restart17h5f364d4d36d0c645E
          832     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$18print_full_process17hae9f7dc3e26cb91aE

weact-f401ccu6
----------------------
   main stack frame:
          240     main

   5 largest stack frames:
         5536     _ZN14weact_f401ccu618create_peripherals17he99496fd0dfeb86fE
         2784     rust_begin_unwind
         2408     _ZN7cortexm24kernel_hardfault_arm_v7m17hd20cfee6809596c6E
         1728     _ZN6kernel15process_loading14load_processes17h18d16c9cfbeb04a7E
          960     _ZN13capsules_core15process_console31ProcessConsole$LT$_$C$A$C$C$GT$11write_state17h43508b958dc1356aE

stm32f412gdiscovery
----------------------
   main stack frame:
          120     main

   5 largest stack frames:
         5536     _ZN19stm32f412gdiscovery18create_peripherals17hdecc1caaeeccd8b8E
         2784     rust_begin_unwind
         2408     _ZN7cortexm24kernel_hardfault_arm_v7m17h88793f49ade3c395E
         1728     _ZN6kernel15process_loading14load_processes17h1325ae92e7a948f7E
          960     _ZN13capsules_core15process_console31ProcessConsole$LT$_$C$A$C$C$GT$11write_state17h500e3c1f0ead78e6E

hail
----------------------
   main stack frame:
          416     main

   5 largest stack frames:
         2408     _ZN7cortexm24kernel_hardfault_arm_v7m17h88793f49ade3c395E
         1736     _ZN6kernel15process_loading14load_processes17h9c099dd7efaa7de5E
         1216     _ZN4hail18create_peripherals17h7d7d4beb44e8d070E
          960     _ZN13capsules_core15process_console31ProcessConsole$LT$_$C$A$C$C$GT$11write_state17h2c417244b3b4fa60E
          832     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$18print_full_process17h786795ca15f47a4fE

nano_rp2040_connect
----------------------
   main stack frame:
          768     main

   5 largest stack frames:
         1792     _ZN6kernel15process_loading14load_processes17h16eb3f9bc3459374E
         1000     _ZN13capsules_core15process_console31ProcessConsole$LT$_$C$A$C$C$GT$11write_state17h127745d00dad978aE
          928     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$18print_full_process17hf98ebe7efbde1425E
          768     main
          688     _ZN117_$LT$capsules_core..process_console..ProcessConsole$LT$_$C$A$C$C$GT$$u20$as$u20$kernel..hil..uart..TransmitClient$GT$18transmitted_buffer17h34a4b480d93f68b1E

particle_boron
----------------------
   main stack frame:
          136     main

   5 largest stack frames:
         2408     _ZN7cortexm24kernel_hardfault_arm_v7m17h88793f49ade3c395E
         1728     _ZN6kernel15process_loading14load_processes17hd6835ed0d604f74dE
          960     _ZN13capsules_core15process_console31ProcessConsole$LT$_$C$A$C$C$GT$11write_state17h3bdb75f40af65114E
          832     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$18print_full_process17hfed5a706dc9e1e3eE
          672     _ZN117_$LT$capsules_core..process_console..ProcessConsole$LT$_$C$A$C$C$GT$$u20$as$u20$kernel..hil..uart..TransmitClient$GT$18transmitted_buffer17h071fe72a3300d810E

stm32f429idiscovery
----------------------
   main stack frame:
          352     main

   5 largest stack frames:
         5472     _ZN19stm32f429idiscovery18create_peripherals17h945586db1d9797e1E
         2784     rust_begin_unwind
         2408     _ZN7cortexm24kernel_hardfault_arm_v7m17h88793f49ade3c395E
         1728     _ZN6kernel15process_loading14load_processes17hd1f899512582b552E
          960     _ZN13capsules_core15process_console31ProcessConsole$LT$_$C$A$C$C$GT$11write_state17h2d351a5f6f7087eaE

arty_e21
----------------------
   main stack frame:
          112     main

   5 largest stack frames:
         1648     _ZN6kernel15process_loading14load_processes17hdf744cda1f67fe28E
         1568     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$18print_full_process17h8823acb0e7f64e72E
         1168     _ZN6kernel5debug11panic_print17hd3335fd3988a8297E
          432     _ZN6kernel6kernel6Kernel14handle_syscall28_$u7b$$u7b$closure$u7d$$u7d$17h7995bc99e038b2d7E
          304     _ZN44_$LT$$RF$T$u20$as$u20$core..fmt..Display$GT$3fmt17h4adeddc207eb6bedE

nucleo_f429zi
----------------------
   main stack frame:
          384     main

   5 largest stack frames:
         5568     _ZN13nucleo_f429zi18create_peripherals17h540643fe4407919eE
         2784     rust_begin_unwind
         2408     _ZN7cortexm24kernel_hardfault_arm_v7m17h88793f49ade3c395E
         1728     _ZN6kernel15process_loading14load_processes17h411450b17051498fE
          960     _ZN13capsules_core15process_console31ProcessConsole$LT$_$C$A$C$C$GT$11write_state17h61ccc44886fe5d26E

microbit_v2
----------------------
   main stack frame:
          480     main

   5 largest stack frames:
         2408     _ZN7cortexm24kernel_hardfault_arm_v7m17h88793f49ade3c395E
         1736     _ZN6kernel15process_loading14load_processes17h84981a9d5afa5d39E
          960     _ZN13capsules_core15process_console31ProcessConsole$LT$_$C$A$C$C$GT$11write_state17hf1a8799619718071E
          832     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$18print_full_process17haf8c56e314683244E
          672     _ZN117_$LT$capsules_core..process_console..ProcessConsole$LT$_$C$A$C$C$GT$$u20$as$u20$kernel..hil..uart..TransmitClient$GT$18transmitted_buffer17hb97c69890c491033E

imxrt1050-evkb
----------------------
   main stack frame:
          128     main

   5 largest stack frames:
         3200     _ZN14imxrt1050_evkb18create_peripherals17h640c74f823134498E
         2408     _ZN7cortexm24kernel_hardfault_arm_v7m17h88793f49ade3c395E
         1952     _ZN6kernel15process_loading14load_processes17h39de607cb5ce105bE
          968     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$11try_restart17h76ffafd9b4e91ee2E
          960     _ZN13capsules_core15process_console31ProcessConsole$LT$_$C$A$C$C$GT$11write_state17h4e5cbd8b56673567E

acd52832
----------------------
   main stack frame:
          128     main

   5 largest stack frames:
         1736     _ZN6kernel15process_loading14load_processes17h55018ae53e16df33E
          832     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$18print_full_process17h4b46fc88517bcc28E
          520     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$11try_restart17h3a809b9a0608b6e9E
          424     _ZN6kernel6kernel6Kernel11kernel_loop17had312a2e8f14cea1E
          392     _ZN6kernel6kernel6Kernel14handle_syscall28_$u7b$$u7b$closure$u7d$$u7d$17h0dc8e27faa23f70eE

imix
----------------------
   main stack frame:
          544     main

   5 largest stack frames:
         2408     _ZN7cortexm24kernel_hardfault_arm_v7m17h88793f49ade3c395E
         1752     _ZN6kernel15process_loading24load_and_check_processes17h2fd15173a1e374c1E
         1152     _ZN4imix18create_peripherals17h1e7a26615ca7fe62E
          960     _ZN13capsules_core15process_console31ProcessConsole$LT$_$C$A$C$C$GT$11write_state17h5295c44f02a4dc69E
          832     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$18print_full_process17he4c3e526b603ab97E

nucleo_f446re
----------------------
   main stack frame:
          120     main

   5 largest stack frames:
         5536     _ZN13nucleo_f446re18create_peripherals17h2b75372c01420156E
         2784     rust_begin_unwind
         2408     _ZN7cortexm24kernel_hardfault_arm_v7m17h88793f49ade3c395E
         1728     _ZN6kernel15process_loading14load_processes17h7a9015ef00a6e361E
          960     _ZN13capsules_core15process_console31ProcessConsole$LT$_$C$A$C$C$GT$11write_state17h6ba1d350bf57c851E

litex_arty
----------------------
   main stack frame:
          144     main

   5 largest stack frames:
         1664     _ZN6kernel15process_loading14load_processes17h958eb6ec6aa87415E
         1568     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$18print_full_process17h4c4d64c06576437eE
          976     _ZN13capsules_core15process_console31ProcessConsole$LT$_$C$A$C$C$GT$11write_state17ha31d34b9c1808419E
          960     _ZN6kernel5debug11panic_print17h0022b41829ee3694E
          672     _ZN117_$LT$capsules_core..process_console..ProcessConsole$LT$_$C$A$C$C$GT$$u20$as$u20$kernel..hil..uart..TransmitClient$GT$18transmitted_buffer17h2b6d1cfe4753b4f8E

litex_sim
----------------------
  1 kernel: process: do not inline load_*processes()
   main stack frame:
          352     main

   5 largest stack frames:
         1664     _ZN6kernel15process_loading14load_processes17hf6cff1df13eaf61aE
         1568     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$18print_full_process17h804d3d60860cc1fcE
         1168     rust_begin_unwind
          480     _ZN6kernel6kernel6Kernel11kernel_loop17h0b5f23dbd387712dE
          432     _ZN6kernel6kernel6Kernel14handle_syscall28_$u7b$$u7b$closure$u7d$$u7d$17hd0e75772bde47861E

swervolf
----------------------
   main stack frame:
           80     main

   5 largest stack frames:
         1648     _ZN6kernel15process_loading14load_processes17h0e24abfcbb2a1b17E
         1568     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$18print_full_process17h85ec88eb5a8e89f3E
         1168     _ZN6kernel5debug11panic_print17ha507383630f2cd26E
          432     _ZN6kernel6kernel6Kernel14handle_syscall28_$u7b$$u7b$closure$u7d$$u7d$17h4bb6906d9656ee97E
          288     _ZN6kernel6kernel6Kernel11kernel_loop17h509d27ca3f126c7aE

clue_nrf52840
----------------------
   main stack frame:
          152     main

   5 largest stack frames:
         2408     _ZN7cortexm24kernel_hardfault_arm_v7m17h88793f49ade3c395E
         1728     _ZN6kernel15process_loading14load_processes17hcb90d9d2068cee44E
          960     _ZN13capsules_core15process_console31ProcessConsole$LT$_$C$A$C$C$GT$11write_state17hd7dea068e1964990E
          832     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$18print_full_process17h00400454ee03f188E
          672     _ZN117_$LT$capsules_core..process_console..ProcessConsole$LT$_$C$A$C$C$GT$$u20$as$u20$kernel..hil..uart..TransmitClient$GT$18transmitted_buffer17h24fa4cb027b4a71dE

msp-exp432p401r
----------------------
   main stack frame:
          184     main

   5 largest stack frames:
         2408     _ZN7cortexm24kernel_hardfault_arm_v7m17h88793f49ade3c395E
         1728     _ZN6kernel15process_loading14load_processes17h515d7e0483ab615fE
          832     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$18print_full_process17h88e81b50580a6225E
          600     _ZN6kernel5debug11panic_print17h01838c8466582229E
          520     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$11try_restart17h03b6083dd8f7ededE

redboard_redv
----------------------
   main stack frame:
         1408     main

   5 largest stack frames:
         1648     _ZN6kernel15process_loading14load_processes17h4a443836c2ca5a17E
         1568     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$18print_full_process17h805fd7ddf074def8E
         1408     main
          976     _ZN13capsules_core15process_console31ProcessConsole$LT$_$C$A$C$C$GT$11write_state17h9356b51a26c09751E
          960     _ZN6kernel5debug11panic_print17h96db057fd37b1bd7E

sma_q3
----------------------
   main stack frame:
          136     main

   5 largest stack frames:
         2408     _ZN7cortexm24kernel_hardfault_arm_v7m17h88793f49ade3c395E
         1728     _ZN6kernel15process_loading14load_processes17hcfdbeb1b63fec244E
          960     _ZN13capsules_core15process_console31ProcessConsole$LT$_$C$A$C$C$GT$11write_state17h344189c4df45acb1E
          832     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$18print_full_process17h40eff728a73b13aeE
          672     _ZN117_$LT$capsules_core..process_console..ProcessConsole$LT$_$C$A$C$C$GT$$u20$as$u20$kernel..hil..uart..TransmitClient$GT$18transmitted_buffer17hdace8eacb25f075bE

qemu_rv32_virt
----------------------
   main stack frame:
          144     main

   5 largest stack frames:
         1664     _ZN6kernel15process_loading14load_processes17hbc1e4635738d77a8E
         1568     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$18print_full_process17hbb49eda1a0fd8b09E
          976     _ZN13capsules_core15process_console31ProcessConsole$LT$_$C$A$C$C$GT$11write_state17h958190b779aeb205E
          960     rust_begin_unwind
          672     _ZN117_$LT$capsules_core..process_console..ProcessConsole$LT$_$C$A$C$C$GT$$u20$as$u20$kernel..hil..uart..TransmitClient$GT$18transmitted_buffer17h3f31924f8fc41033E

```



### Testing Strategy

travis


### TODO or Help Wanted

Presumably these functions are marked inline always for a reason. What are the competing concerns here? I will add to the comments.

Also, is it better to just not have directives on inlining for these?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
