### PR TITLE
`make stack-analysis`: demangle names

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -388,7 +388,7 @@ cargobloatnoinline:
 stack-analysis:
 	@$ echo $(PLATFORM)
 	@$ echo ----------------------
-	$(Q)$(MAKE) release RUSTC_FLAGS="$(RUSTC_FLAGS) -Z emit-stack-sizes" $(DEVNULL) 2>&1
+	$(Q)$(MAKE) release RUSTC_FLAGS="$(RUSTC_FLAGS) -C symbol-mangling-version=v0 -Z emit-stack-sizes" $(DEVNULL) 2>&1
 	$(Q)$(TOCK_ROOT_DIRECTORY)/tools/stack_analysis.sh $(TARGET_PATH)/release/$(PLATFORM).elf
 
 # Run the `print_tock_memory_usage.py` script for this board.

--- a/tools/stack_analysis.sh
+++ b/tools/stack_analysis.sh
@@ -12,7 +12,7 @@ bold=$(tput bold)
 normal=$(tput sgr0)
 
 # Get a list of all stack frames and their sizes.
-frames=`$(find $(rustc --print sysroot) -name llvm-readobj) --elf-output-style GNU --stack-sizes $1`
+frames=`$(find $(rustc --print sysroot) -name llvm-readobj) --demangle --elf-output-style GNU --stack-sizes $1`
 
 # Print the stack frame size of `main`
 printf "   main stack frame: \n"


### PR DESCRIPTION
### Pull Request Overview

This pull request makes it easier to read the function names when using `make stack-analysis`.

Before:

```
❯ make stack-analysis
microbit_v2
----------------------
   main stack frame:
         1784     main

   5 largest stack frames:
         2408     _ZN7cortexm24kernel_hardfault_arm_v7m17h88793f49ade3c395E
         1784     main
          896     _ZN13capsules_core15process_console31ProcessConsole$LT$_$C$A$C$C$GT$19create_state_buffer4llll17h0554a6e14ac86a27E
          832     _ZN95_$LT$kernel..process_standard..ProcessStandard$LT$C$GT$$u20$as$u20$kernel..process..Process$GT$18print_full_process17haf8c56e314683244E
          736     _ZN13capsules_core15process_console31ProcessConsole$LT$_$C$A$C$C$GT$11write_state17hf1a8799619718071E
```

After:

```
❯ make stack-analysis
microbit_v2
----------------------
   main stack frame:
         1784     main

   5 largest stack frames:
         2408     cortexm::kernel_hardfault_arm_v7m
         1784     main
          832     <kernel::process_standard::ProcessStandard<nrf52::chip::NRF52<nrf52833::interrupt_service::Nrf52833DefaultPeripherals>> as kernel::process::Process>::print_full_process
          736     <capsules_core::process_console::ProcessConsole<10, capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<nrf5x::rtc::Rtc>, components::process_console::Capability>>::write_state
          672     <capsules_core::process_console::ProcessConsole<10, capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<nrf5x::rtc::Rtc>, components::process_console::Capability> as kernel::hil::uart::TransmitClient>::transmitted_buffer
```


### Testing Strategy

Running make


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
