### PR TITLE
kernel: leasablebuffer: add APIs

### DIFF
--- a/kernel/src/utilities/leasable_buffer.rs
+++ b/kernel/src/utilities/leasable_buffer.rs
@@ -179,25 +179,6 @@ impl<'a, T> LeasableMutableBuffer<'a, T> {
             end: new_end,
         };
     }
-
-    /// Increase the range of the LeasableBuffer that is accessible to the left
-    /// of the starting point of the currently available range.
-    ///
-    /// This is particularly useful to insert a header before the current
-    /// contents of the buffer.
-    ///
-    /// This returns `Ok(())` if there is room to increase the range the
-    /// requested number of elements to the left. This returns `Err(())` if
-    /// there is not enough room, and the accessible range remains unchanged.
-    pub fn unslice_left(&mut self, left: usize) -> Result<(), ()> {
-        let new_start = self.active_range.start.checked_sub(left).ok_or(())?;
-
-        self.active_range = Range {
-            start: new_start,
-            end: self.active_range.end,
-        };
-        Ok(())
-    }
 }
 
 impl<'a, T, I> Index<I> for LeasableMutableBuffer<'a, T>
@@ -298,25 +279,6 @@ impl<'a, T> LeasableBuffer<'a, T> {
             start: new_start,
             end: new_end,
         };
-    }
-
-    /// Increase the range of the LeasableBuffer that is accessible to the left
-    /// of the starting point of the currently available range.
-    ///
-    /// This is particularly useful to insert a header before the current
-    /// contents of the buffer.
-    ///
-    /// This returns `Ok(())` if there is room to increase the range the
-    /// requested number of elements to the left. This returns `Err(())` if
-    /// there is not enough room, and the accessible range remains unchanged.
-    pub fn unslice_left(&mut self, left: usize) -> Result<(), ()> {
-        let new_start = self.active_range.start.checked_sub(left).ok_or(())?;
-
-        self.active_range = Range {
-            start: new_start,
-            end: self.active_range.end,
-        };
-        Ok(())
     }
 }
 


### PR DESCRIPTION
### Pull Request Overview

This pull request updates `LeasableBuffer` to add:

- `as_slice()`: gets a slice
- `is_sliced()`: whether .slice has been called
- ~~`unslice_left()`: open up room to the left~~



### Testing Strategy

Updating k-v stack.


### TODO or Help Wanted

This doesn't have to be the last PR that adds APIs, but I would like to not stall on this because these are the changes needed to update the K-V stack.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
