### PR TITLE
Capsules: SipHash respect leasable buffers and handle arbitrary buffer sizes

### DIFF
--- a/capsules/extra/src/sip_hash.rs
+++ b/capsules/extra/src/sip_hash.rs
@@ -149,8 +149,11 @@ macro_rules! compress {
 }
 
 fn read_le_u64(input: &[u8]) -> u64 {
-    let (int_bytes, _rest) = input.split_at(mem::size_of::<u64>());
-    u64::from_le_bytes(int_bytes.try_into().unwrap())
+    let mut eight_buf: [u8; 8] = [0; 8];
+    for i in 0..8 {
+        eight_buf[i] = *input.get(i).unwrap_or(&0);
+    }
+    u64::from_le_bytes(eight_buf)
 }
 
 fn read_le_u16(input: &[u8]) -> u16 {

--- a/capsules/extra/src/test/siphash24.rs
+++ b/capsules/extra/src/test/siphash24.rs
@@ -11,6 +11,7 @@ use crate::sip_hash::SipHasher24;
 use kernel::debug;
 use kernel::hil::hasher::{Client, Hasher};
 use kernel::utilities::cells::TakeCell;
+use kernel::utilities::leasable_buffer::LeasableBuffer;
 use kernel::utilities::leasable_buffer::LeasableMutableBuffer;
 use kernel::ErrorCode;
 
@@ -48,12 +49,16 @@ impl TestSipHash24 {
 }
 
 impl Client<8> for TestSipHash24 {
-    fn add_mut_data_done(&self, _result: Result<(), ErrorCode>, data: &'static mut [u8]) {
-        self.data.replace(data);
+    fn add_mut_data_done(
+        &self,
+        _result: Result<(), ErrorCode>,
+        data: LeasableMutableBuffer<'static, u8>,
+    ) {
+        self.data.replace(data.take());
         self.hasher.run(self.hash.take().unwrap()).unwrap();
     }
 
-    fn add_data_done(&self, _result: Result<(), ErrorCode>, _data: &'static [u8]) {}
+    fn add_data_done(&self, _result: Result<(), ErrorCode>, _data: LeasableBuffer<'static, u8>) {}
 
     fn hash_done(&self, _result: Result<(), ErrorCode>, digest: &'static mut [u8; 8]) {
         debug!("hashed result:   {:?}", digest);

--- a/kernel/src/hil/hasher.rs
+++ b/kernel/src/hil/hasher.rs
@@ -18,7 +18,7 @@ pub trait Client<const L: usize> {
     /// data supplied to `add_data()`.
     /// The possible ErrorCodes are:
     ///    - SIZE: The size of the `data` buffer is invalid
-    fn add_data_done(&self, result: Result<(), ErrorCode>, data: &'static [u8]);
+    fn add_data_done(&self, result: Result<(), ErrorCode>, data: LeasableBuffer<'static, u8>);
 
     /// This callback is called when the data has been added to the hash
     /// engine.
@@ -26,7 +26,11 @@ pub trait Client<const L: usize> {
     /// data supplied to `add_mut_data()`.
     /// The possible ErrorCodes are:
     ///    - SIZE: The size of the `data` buffer is invalid
-    fn add_mut_data_done(&self, result: Result<(), ErrorCode>, data: &'static mut [u8]);
+    fn add_mut_data_done(
+        &self,
+        result: Result<(), ErrorCode>,
+        data: LeasableMutableBuffer<'static, u8>,
+    );
 
     /// This callback is called when a hash is computed.
     /// On error or success `hash` will contain a reference to the original
@@ -60,7 +64,7 @@ pub trait Hasher<'a, const L: usize> {
     fn add_data(
         &self,
         data: LeasableBuffer<'static, u8>,
-    ) -> Result<usize, (ErrorCode, &'static [u8])>;
+    ) -> Result<usize, (ErrorCode, LeasableBuffer<'static, u8>)>;
 
     /// Add data to the hash block. This is the data that will be used
     /// for the hash function.
@@ -75,7 +79,7 @@ pub trait Hasher<'a, const L: usize> {
     fn add_mut_data(
         &self,
         data: LeasableMutableBuffer<'static, u8>,
-    ) -> Result<usize, (ErrorCode, &'static mut [u8])>;
+    ) -> Result<usize, (ErrorCode, LeasableMutableBuffer<'static, u8>)>;
 
     /// Request the implementation to generate a hash and stores the returned
     /// hash in the memory location specified.


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the siphash capsule to correctly use leasable buffers and to accept data in units not a multiple of 8 bytes.


### Testing Strategy

Updating the k-v stack and comparing hashes to an online calculator.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
