### PR TITLE
Full KV stack update PR

### DIFF
--- a/boards/components/src/kv_system.rs
+++ b/boards/components/src/kv_system.rs
@@ -39,7 +39,7 @@
 //!    ));
 //! ```
 
-use capsules_extra::kv_driver::KVSystemDriver;
+use capsules_extra::kv_driver::KVStoreDriver;
 use capsules_extra::kv_store::{KVStore, MuxKVStore};
 use core::mem::MaybeUninit;
 use kernel::capabilities;
@@ -135,7 +135,7 @@ impl<K: 'static + KVSystem<'static, K = T>, T: 'static + KeyType> Component
 #[macro_export]
 macro_rules! kv_driver_component_static {
     ($K:ty, $T:ty $(,)?) => {{
-        let kv = kernel::static_buf!(capsules_extra::kv_driver::KVSystemDriver<'static, $K, $T>);
+        let kv = kernel::static_buf!(capsules_extra::kv_driver::KVStoreDriver<'static, $K, $T>);
         let data_buffer = kernel::static_buf!([u8; 32]);
         let dest_buffer = kernel::static_buf!([u8; 48]);
 
@@ -167,11 +167,11 @@ impl<K: 'static + KVSystem<'static, K = T>, T: 'static + KeyType> Component
     for KVDriverComponent<K, T>
 {
     type StaticInput = (
-        &'static mut MaybeUninit<KVSystemDriver<'static, K, T>>,
+        &'static mut MaybeUninit<KVStoreDriver<'static, K, T>>,
         &'static mut MaybeUninit<[u8; 32]>,
         &'static mut MaybeUninit<[u8; 48]>,
     );
-    type Output = &'static KVSystemDriver<'static, K, T>;
+    type Output = &'static KVStoreDriver<'static, K, T>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
@@ -179,7 +179,7 @@ impl<K: 'static + KVSystem<'static, K = T>, T: 'static + KeyType> Component
         let data_buffer = static_buffer.1.write([0; 32]);
         let dest_buffer = static_buffer.2.write([0; 48]);
 
-        let driver = static_buffer.0.write(KVSystemDriver::new(
+        let driver = static_buffer.0.write(KVStoreDriver::new(
             self.kv,
             data_buffer,
             dest_buffer,

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -140,7 +140,7 @@ struct EarlGrey {
             virtual_aes_ccm::VirtualAES128CCM<'static, earlgrey::aes::Aes<'static>>,
         >,
     >,
-    kv_driver: &'static capsules_extra::kv_driver::KVSystemDriver<
+    kv_driver: &'static capsules_extra::kv_driver::KVStoreDriver<
         'static,
         capsules_extra::tickv::TicKVStore<
             'static,

--- a/boards/opentitan/src/tests/sip_hash.rs
+++ b/boards/opentitan/src/tests/sip_hash.rs
@@ -8,6 +8,7 @@ use core::cell::Cell;
 use kernel::hil::hasher::{self, Hasher};
 use kernel::static_init;
 use kernel::utilities::cells::TakeCell;
+use kernel::utilities::leasable_buffer::LeasableBuffer;
 use kernel::utilities::leasable_buffer::LeasableMutableBuffer;
 use kernel::{debug, ErrorCode};
 
@@ -47,11 +48,15 @@ impl<'a> SipHashTestCallback {
 }
 
 impl<'a> hasher::Client<8> for SipHashTestCallback {
-    fn add_data_done(&self, _result: Result<(), ErrorCode>, _data: &'static [u8]) {
+    fn add_data_done(&self, _result: Result<(), ErrorCode>, _data: LeasableBuffer<'static, u8>) {
         unimplemented!()
     }
 
-    fn add_mut_data_done(&self, result: Result<(), ErrorCode>, data: &'static mut [u8]) {
+    fn add_mut_data_done(
+        &self,
+        result: Result<(), ErrorCode>,
+        mut data: LeasableMutableBuffer<'static, u8>,
+    ) {
         assert_eq!(result, Ok(()));
         self.data_add_done.set(true);
 
@@ -59,7 +64,7 @@ impl<'a> hasher::Client<8> for SipHashTestCallback {
         assert_eq!(self.cb_count.get() < 20, true);
 
         // Replace the input buffer with all of cb data
-        self.input_buf[self.cb_count.get()].replace(data.try_into().unwrap());
+        self.input_buf[self.cb_count.get()].replace(data.take().try_into().unwrap());
 
         self.cb_count.set(self.cb_count.get() + 1);
     }

--- a/boards/opentitan/src/tests/tickv_test.rs
+++ b/boards/opentitan/src/tests/tickv_test.rs
@@ -13,6 +13,7 @@ use kernel::debug;
 use kernel::hil::hasher::Hasher;
 use kernel::hil::kv_system::KVSystem;
 use kernel::static_init;
+use kernel::utilities::leasable_buffer::LeasableMutableBuffer;
 
 #[test_case]
 fn tickv_append_key() {
@@ -44,14 +45,16 @@ fn tickv_append_key() {
                 >,
                 TicKVKeyType,
             >,
-            KVSystemTest::new(tickv, value, ret)
+            KVSystemTest::new(tickv, LeasableMutableBuffer::new(value), ret)
         );
 
         sip_hasher.set_client(tickv);
         tickv.set_client(test);
 
         // Kick start the tests by generating a key
-        tickv.generate_key(key_input, key).unwrap();
+        tickv
+            .generate_key(LeasableMutableBuffer::new(key_input), key)
+            .unwrap();
     }
     run_kernel_op(100000);
 

--- a/capsules/extra/src/kv_driver.rs
+++ b/capsules/extra/src/kv_driver.rs
@@ -190,9 +190,12 @@ impl<'a, K: kv_system::KVSystem<'a, K = T>, T: kv_system::KeyType> KVStoreDriver
                                     let mut unhashed_key = LeasableMutableBuffer::new(data_buffer);
                                     unhashed_key.slice(..unhashed_key_len);
 
+                                    // Make sure we provide a value buffer with
+                                    // space for the tock kv header at the
+                                    // front.
                                     let header_size = self.kv.header_size();
                                     let mut value = LeasableMutableBuffer::new(dest_buffer);
-                                    value.slice(header_size..(value_len + header_size));
+                                    value.slice(..(value_len + header_size));
 
                                     if let Err((data, dest, e)) =
                                         self.kv.set(unhashed_key, value, perms)

--- a/capsules/extra/src/kv_driver.rs
+++ b/capsules/extra/src/kv_driver.rs
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-//! KV Driver
+//! KV Store Userspace Driver.
 //!
+//! Provides userspace access to key-value store. Access is restricted based on
+//! `StoragePermissions` so processes must have the required permissions in
+//! their TBF headers to use this interface.
 
 use capsules_core::driver;
 /// Syscall driver number.
@@ -11,7 +14,8 @@ pub const DRIVER_NUM: usize = driver::NUM::KVSystem as usize;
 
 use crate::kv_store;
 use crate::kv_store::KVStore;
-use core::cell::Cell;
+use core::cmp;
+use kernel::errorcode;
 use kernel::grant::Grant;
 use kernel::grant::{AllowRoCount, AllowRwCount, UpcallCount};
 use kernel::hil::kv_system;
@@ -45,28 +49,43 @@ mod upcalls {
     pub const COUNT: u8 = 1;
 }
 
-pub struct KVSystemDriver<
+#[derive(Copy, Clone, PartialEq)]
+enum UserSpaceOp {
+    Get,
+    Set,
+    Delete,
+}
+
+/// Contents of the grant for each app.
+#[derive(Default)]
+pub struct App {
+    op: OptionalCell<UserSpaceOp>,
+}
+
+/// Capsule that provides userspace access to a key-value store.
+pub struct KVStoreDriver<
     'a,
     K: kv_system::KVSystem<'a> + kv_system::KVSystem<'a, K = T>,
     T: 'static + kv_system::KeyType,
 > {
+    /// Underlying k-v store implementation.
     kv: &'a KVStore<'a, K, T>,
-
-    active: Cell<bool>,
-
+    /// Grant storage for each app.
     apps: Grant<
         App,
         UpcallCount<{ upcalls::COUNT }>,
         AllowRoCount<{ ro_allow::COUNT }>,
         AllowRwCount<{ rw_allow::COUNT }>,
     >,
+    /// App that is actively using the k-v store.
     processid: OptionalCell<ProcessId>,
-
+    /// Key buffer.
     data_buffer: TakeCell<'static, [u8]>,
+    /// Value buffer.
     dest_buffer: TakeCell<'static, [u8]>,
 }
 
-impl<'a, K: kv_system::KVSystem<'a, K = T>, T: kv_system::KeyType> KVSystemDriver<'a, K, T> {
+impl<'a, K: kv_system::KVSystem<'a, K = T>, T: kv_system::KeyType> KVStoreDriver<'a, K, T> {
     pub fn new(
         kv: &'a KVStore<'a, K, T>,
         data_buffer: &'static mut [u8],
@@ -77,10 +96,9 @@ impl<'a, K: kv_system::KVSystem<'a, K = T>, T: kv_system::KeyType> KVSystemDrive
             AllowRoCount<{ ro_allow::COUNT }>,
             AllowRwCount<{ rw_allow::COUNT }>,
         >,
-    ) -> KVSystemDriver<'a, K, T> {
-        KVSystemDriver {
+    ) -> KVStoreDriver<'a, K, T> {
+        KVStoreDriver {
             kv,
-            active: Cell::new(false),
             apps: grant,
             processid: OptionalCell::empty(),
             data_buffer: TakeCell::new(data_buffer),
@@ -92,146 +110,33 @@ impl<'a, K: kv_system::KVSystem<'a, K = T>, T: kv_system::KeyType> KVSystemDrive
         self.processid.map_or(Err(ErrorCode::RESERVE), |processid| {
             self.apps
                 .enter(processid, |app, kernel_data| {
-                    if let Some(operation) = app.op.get() {
-                        match operation {
-                            UserSpaceOp::Get => {
-                                let unhashed_key_len = kernel_data
-                                    .get_readonly_processbuffer(ro_allow::UNHASHED_KEY)
-                                    .and_then(|buffer| {
-                                        buffer.enter(|unhashed_key| {
-                                            self.data_buffer.map_or(Err(ErrorCode::NOMEM), |buf| {
-                                                // Determine the size of the
-                                                // static buffer we have and
-                                                // copy the contents.
-                                                let static_buffer_len =
-                                                    buf.len().min(unhashed_key.len());
-                                                unhashed_key[..static_buffer_len]
-                                                    .copy_to_slice(&mut buf[..static_buffer_len]);
+                    let unhashed_key_len = if app.op.is_some() {
+                        // For all operations we need to copy in the unhashed
+                        // key.
+                        kernel_data
+                            .get_readonly_processbuffer(ro_allow::UNHASHED_KEY)
+                            .and_then(|buffer| {
+                                buffer.enter(|unhashed_key| {
+                                    self.data_buffer.map_or(Err(ErrorCode::NOMEM), |buf| {
+                                        // Determine the size of the static
+                                        // buffer we have and copy the contents.
+                                        let static_buffer_len = buf.len().min(unhashed_key.len());
+                                        unhashed_key[..static_buffer_len]
+                                            .copy_to_slice(&mut buf[..static_buffer_len]);
 
-                                                Ok(static_buffer_len)
-                                            })
-                                        })
+                                        Ok(static_buffer_len)
                                     })
-                                    .unwrap_or(Err(ErrorCode::RESERVE))?;
+                                })
+                            })
+                            .unwrap_or(Err(ErrorCode::RESERVE))?
+                    } else {
+                        0
+                    };
 
-                                if let Some(Some(Err(e))) =
-                                    self.data_buffer.take().map(|data_buffer| {
-                                        self.dest_buffer.take().map(|dest_buffer| {
-                                            let perms = processid
-                                                .get_storage_permissions()
-                                                .ok_or(ErrorCode::INVAL)?;
-
-                                            let mut unhashed_key =
-                                                LeasableMutableBuffer::new(data_buffer);
-                                            unhashed_key.slice(..unhashed_key_len);
-
-                                            let value = LeasableMutableBuffer::new(dest_buffer);
-
-                                            if let Err((data, dest, e)) =
-                                                self.kv.get(unhashed_key, value, perms)
-                                            {
-                                                self.data_buffer.replace(data.take());
-                                                self.dest_buffer.replace(dest.take());
-                                                return Err(e);
-                                            }
-                                            Ok(())
-                                        })
-                                    })
-                                {
-                                    return e;
-                                }
-                            }
-                            UserSpaceOp::Set => {
-                                let unhashed_key_len = kernel_data
-                                    .get_readonly_processbuffer(ro_allow::UNHASHED_KEY)
-                                    .and_then(|buffer| {
-                                        buffer.enter(|unhashed_key| {
-                                            self.data_buffer.map_or(Err(ErrorCode::NOMEM), |buf| {
-                                                // Determine the size of the
-                                                // static buffer we have and
-                                                // copy the contents.
-                                                let static_buffer_len =
-                                                    buf.len().min(unhashed_key.len());
-                                                unhashed_key[..static_buffer_len]
-                                                    .copy_to_slice(&mut buf[..static_buffer_len]);
-
-                                                Ok(static_buffer_len)
-                                            })
-                                        })
-                                    })
-                                    .unwrap_or(Err(ErrorCode::RESERVE))?;
-
-                                let value_len = kernel_data
-                                    .get_readonly_processbuffer(ro_allow::VALUE)
-                                    .and_then(|buffer| {
-                                        buffer.enter(|value| {
-                                            self.dest_buffer.map_or(Err(ErrorCode::NOMEM), |buf| {
-                                                // Determine the size of the
-                                                // static buffer we have for the
-                                                // value and copy the contents.
-                                                let header_size = self.kv.header_size();
-                                                let copy_len =
-                                                    (buf.len() - header_size).min(value.len());
-                                                value[..copy_len].copy_to_slice(
-                                                    &mut buf[header_size..(copy_len + header_size)],
-                                                );
-
-                                                Ok(copy_len)
-                                            })
-                                        })
-                                    })
-                                    .unwrap_or(Err(ErrorCode::RESERVE))?;
-
-                                if let Some(Some(Err(e))) =
-                                    self.data_buffer.take().map(|data_buffer| {
-                                        self.dest_buffer.take().map(|dest_buffer| {
-                                            let perms = processid
-                                                .get_storage_permissions()
-                                                .ok_or(ErrorCode::INVAL)?;
-
-                                            let mut unhashed_key =
-                                                LeasableMutableBuffer::new(data_buffer);
-                                            unhashed_key.slice(..unhashed_key_len);
-
-                                            let header_size = self.kv.header_size();
-                                            let mut value = LeasableMutableBuffer::new(dest_buffer);
-                                            value.slice(header_size..(value_len + header_size));
-
-                                            if let Err((data, dest, e)) =
-                                                self.kv.set(unhashed_key, value, perms)
-                                            {
-                                                self.data_buffer.replace(data.take());
-                                                self.dest_buffer.replace(dest.take());
-                                                return Err(e);
-                                            }
-                                            Ok(())
-                                        })
-                                    })
-                                {
-                                    return e;
-                                }
-                            }
-                            UserSpaceOp::Delete => {
-                                let unhashed_key_len = kernel_data
-                                    .get_readonly_processbuffer(ro_allow::UNHASHED_KEY)
-                                    .and_then(|buffer| {
-                                        buffer.enter(|unhashed_key| {
-                                            self.data_buffer.map_or(Err(ErrorCode::NOMEM), |buf| {
-                                                // Determine the size of the
-                                                // static buffer we have and
-                                                // copy the contents.
-                                                let static_buffer_len =
-                                                    buf.len().min(unhashed_key.len());
-                                                unhashed_key[..static_buffer_len]
-                                                    .copy_to_slice(&mut buf[..static_buffer_len]);
-
-                                                Ok(static_buffer_len)
-                                            })
-                                        })
-                                    })
-                                    .unwrap_or(Err(ErrorCode::RESERVE))?;
-
-                                if let Some(Err(e)) = self.data_buffer.take().map(|data_buffer| {
+                    match app.op.extract() {
+                        Some(UserSpaceOp::Get) => {
+                            if let Some(Some(Err(e))) = self.data_buffer.take().map(|data_buffer| {
+                                self.dest_buffer.take().map(|dest_buffer| {
                                     let perms = processid
                                         .get_storage_permissions()
                                         .ok_or(ErrorCode::INVAL)?;
@@ -239,16 +144,88 @@ impl<'a, K: kv_system::KVSystem<'a, K = T>, T: kv_system::KeyType> KVSystemDrive
                                     let mut unhashed_key = LeasableMutableBuffer::new(data_buffer);
                                     unhashed_key.slice(..unhashed_key_len);
 
-                                    if let Err((data, e)) = self.kv.delete(unhashed_key, perms) {
+                                    let value = LeasableMutableBuffer::new(dest_buffer);
+
+                                    if let Err((data, dest, e)) =
+                                        self.kv.get(unhashed_key, value, perms)
+                                    {
                                         self.data_buffer.replace(data.take());
+                                        self.dest_buffer.replace(dest.take());
                                         return Err(e);
                                     }
                                     Ok(())
-                                }) {
-                                    return e;
-                                }
+                                })
+                            }) {
+                                return e;
                             }
                         }
+                        Some(UserSpaceOp::Set) => {
+                            let value_len = kernel_data
+                                .get_readonly_processbuffer(ro_allow::VALUE)
+                                .and_then(|buffer| {
+                                    buffer.enter(|value| {
+                                        self.dest_buffer.map_or(Err(ErrorCode::NOMEM), |buf| {
+                                            // Determine the size of the static
+                                            // buffer we have for the value and
+                                            // copy the contents.
+                                            let header_size = self.kv.header_size();
+                                            let copy_len =
+                                                (buf.len() - header_size).min(value.len());
+                                            value[..copy_len].copy_to_slice(
+                                                &mut buf[header_size..(copy_len + header_size)],
+                                            );
+
+                                            Ok(copy_len)
+                                        })
+                                    })
+                                })
+                                .unwrap_or(Err(ErrorCode::RESERVE))?;
+
+                            if let Some(Some(Err(e))) = self.data_buffer.take().map(|data_buffer| {
+                                self.dest_buffer.take().map(|dest_buffer| {
+                                    let perms = processid
+                                        .get_storage_permissions()
+                                        .ok_or(ErrorCode::INVAL)?;
+
+                                    let mut unhashed_key = LeasableMutableBuffer::new(data_buffer);
+                                    unhashed_key.slice(..unhashed_key_len);
+
+                                    let header_size = self.kv.header_size();
+                                    let mut value = LeasableMutableBuffer::new(dest_buffer);
+                                    value.slice(header_size..(value_len + header_size));
+
+                                    if let Err((data, dest, e)) =
+                                        self.kv.set(unhashed_key, value, perms)
+                                    {
+                                        self.data_buffer.replace(data.take());
+                                        self.dest_buffer.replace(dest.take());
+                                        return Err(e);
+                                    }
+                                    Ok(())
+                                })
+                            }) {
+                                return e;
+                            }
+                        }
+                        Some(UserSpaceOp::Delete) => {
+                            if let Some(Err(e)) = self.data_buffer.take().map(|data_buffer| {
+                                let perms = processid
+                                    .get_storage_permissions()
+                                    .ok_or(ErrorCode::INVAL)?;
+
+                                let mut unhashed_key = LeasableMutableBuffer::new(data_buffer);
+                                unhashed_key.slice(..unhashed_key_len);
+
+                                if let Err((data, e)) = self.kv.delete(unhashed_key, perms) {
+                                    self.data_buffer.replace(data.take());
+                                    return Err(e);
+                                }
+                                Ok(())
+                            }) {
+                                return e;
+                            }
+                        }
+                        _ => {}
                     }
 
                     Ok(())
@@ -258,87 +235,90 @@ impl<'a, K: kv_system::KVSystem<'a, K = T>, T: kv_system::KeyType> KVSystemDrive
     }
 
     fn check_queue(&self) {
-        for appiter in self.apps.iter() {
-            let started_command = appiter.enter(|app, _| {
-                // If an app is already running let it complete
-                if self.processid.is_some() {
-                    return true;
-                }
+        // If an app is already running let it complete.
+        if self.processid.is_some() {
+            return;
+        }
 
+        for appiter in self.apps.iter() {
+            let processid = appiter.processid();
+            let started_command = appiter.enter(|app, _| {
                 // If this app has a pending command let's use it.
-                app.pending_run_app.take().map_or(false, |processid| {
+                if app.op.is_some() {
                     // Mark this driver as being in use.
                     self.processid.set(processid);
-                    // Actually make the buzz happen.
                     self.run() == Ok(())
-                })
+                } else {
+                    false
+                }
             });
             if started_command {
                 break;
+            } else {
+                self.processid.clear();
             }
         }
     }
 }
 
 impl<'a, K: kv_system::KVSystem<'a, K = T>, T: kv_system::KeyType> kv_store::StoreClient<T>
-    for KVSystemDriver<'a, K, T>
+    for KVStoreDriver<'a, K, T>
 {
     fn get_complete(
         &self,
         result: Result<(), ErrorCode>,
         key: LeasableMutableBuffer<'static, u8>,
-        ret_buf: LeasableMutableBuffer<'static, u8>,
+        value: LeasableMutableBuffer<'static, u8>,
     ) {
         self.data_buffer.replace(key.take());
-        self.dest_buffer.replace(ret_buf.take());
 
         self.processid.map(move |id| {
             self.apps.enter(id, move |app, upcalls| {
-                if app.op.get().map(|op| op == UserSpaceOp::Get).is_some() {
+                if app.op.contains(&UserSpaceOp::Get) {
+                    app.op.clear();
+
                     if let Err(e) = result {
                         upcalls
                             .schedule_upcall(
                                 upcalls::VALUE,
-                                (kernel::errorcode::into_statuscode(e.into()), 0, 0),
+                                (errorcode::into_statuscode(e.into()), 0, 0),
                             )
                             .ok();
                     } else {
-                        self.dest_buffer.map(|buf| {
-                            let ret = upcalls
-                                .get_readwrite_processbuffer(rw_allow::VALUE)
-                                .and_then(|buffer| {
-                                    buffer.mut_enter(|data| {
-                                        // Determine the size of the static buffer we have
-                                        let static_buffer_len = buf.len();
-                                        let data_len = data.len();
-
-                                        if data_len < static_buffer_len {
-                                            data.copy_from_slice(&buf[..data_len]);
-                                        } else {
-                                            data[..static_buffer_len].copy_from_slice(&buf);
-                                        }
-                                        Ok(())
-                                    })
+                        let value_len = value.len();
+                        let ret = upcalls
+                            .get_readwrite_processbuffer(rw_allow::VALUE)
+                            .and_then(|buffer| {
+                                buffer.mut_enter(|appslice| {
+                                    let copy_len = cmp::min(value_len, appslice.len());
+                                    appslice[..copy_len].copy_from_slice(&value[..copy_len]);
+                                    Ok(())
                                 })
-                                .unwrap_or(Err(ErrorCode::RESERVE));
+                            })
+                            .unwrap_or(Err(ErrorCode::RESERVE));
 
-                            if ret == Err(ErrorCode::RESERVE) {
-                                upcalls
-                                    .schedule_upcall(
-                                        upcalls::VALUE,
-                                        (kernel::errorcode::into_statuscode(ret.into()), 0, 0),
-                                    )
-                                    .ok();
-                            } else {
-                                upcalls.schedule_upcall(upcalls::VALUE, (0, 0, 0)).ok();
-                            }
-                        });
-
-                        self.processid.clear();
+                        // Signal the upcall, and return the length of the
+                        // value. Userspace should be careful to check for an
+                        // error and only read the portion that would fit in the
+                        // buffer if the value was larger than the provided
+                        // processbuffer.
+                        upcalls
+                            .schedule_upcall(
+                                upcalls::VALUE,
+                                (errorcode::into_statuscode(ret.into()), value_len, 0),
+                            )
+                            .ok();
                     }
                 }
+
+                self.dest_buffer.replace(value.take());
             })
         });
+
+        // We have completed the operation so see if there is a queued operation
+        // to run next.
+        self.processid.clear();
+        self.check_queue();
     }
 
     fn set_complete(
@@ -350,24 +330,23 @@ impl<'a, K: kv_system::KVSystem<'a, K = T>, T: kv_system::KeyType> kv_store::Sto
         self.data_buffer.replace(key.take());
         self.dest_buffer.replace(value.take());
 
+        // Signal the upcall and clear the requested op. We have to do a lot of
+        // checking for robustness, but there is no reason this should fail.
         self.processid.map(move |id| {
             self.apps.enter(id, move |app, upcalls| {
-                if app.op.get().map(|op| op == UserSpaceOp::Set).is_some() {
-                    if let Err(e) = result {
-                        upcalls
-                            .schedule_upcall(
-                                upcalls::VALUE,
-                                (kernel::errorcode::into_statuscode(e.into()), 0, 0),
-                            )
-                            .ok();
-                    } else {
-                        upcalls.schedule_upcall(upcalls::VALUE, (0, 0, 0)).ok();
-
-                        self.processid.clear();
-                    }
+                if app.op.contains(&UserSpaceOp::Set) {
+                    app.op.clear();
+                    upcalls
+                        .schedule_upcall(upcalls::VALUE, (errorcode::into_statuscode(result), 0, 0))
+                        .ok();
                 }
             })
         });
+
+        // We have completed the operation so see if there is a queued operation
+        // to run next.
+        self.processid.clear();
+        self.check_queue();
     }
 
     fn delete_complete(
@@ -379,27 +358,24 @@ impl<'a, K: kv_system::KVSystem<'a, K = T>, T: kv_system::KeyType> kv_store::Sto
 
         self.processid.map(move |id| {
             self.apps.enter(id, move |app, upcalls| {
-                if app.op.get().map(|op| op == UserSpaceOp::Delete).is_some() {
-                    if let Err(e) = result {
-                        upcalls
-                            .schedule_upcall(
-                                upcalls::VALUE,
-                                (kernel::errorcode::into_statuscode(e.into()), 0, 0),
-                            )
-                            .ok();
-                    } else {
-                        upcalls.schedule_upcall(upcalls::VALUE, (0, 0, 0)).ok();
-
-                        self.processid.clear();
-                    }
+                if app.op.contains(&UserSpaceOp::Delete) {
+                    app.op.clear();
+                    upcalls
+                        .schedule_upcall(upcalls::VALUE, (errorcode::into_statuscode(result), 0, 0))
+                        .ok();
                 }
             })
         });
+
+        // We have completed the operation so see if there is a queued operation
+        // to run next.
+        self.processid.clear();
+        self.check_queue();
     }
 }
 
 impl<'a, K: kv_system::KVSystem<'a, K = T>, T: kv_system::KeyType> SyscallDriver
-    for KVSystemDriver<'a, K, T>
+    for KVStoreDriver<'a, K, T>
 {
     fn command(
         &self,
@@ -408,42 +384,20 @@ impl<'a, K: kv_system::KVSystem<'a, K = T>, T: kv_system::KeyType> SyscallDriver
         _data2: usize,
         processid: ProcessId,
     ) -> CommandReturn {
-        let match_or_empty_or_nonexistant = self.processid.map_or(true, |owning_app| {
-            // We have recorded that an app has ownership of the KV Store.
-
-            // If the KV Store is still active, then we need to wait for the operation
-            // to finish and the app, whether it exists or not (it may have crashed),
-            // still owns this capsule. If the KV Store is not active, then
-            // we need to verify that that application still exists, and remove
-            // it as owner if not.
-            if self.active.get() {
-                owning_app == processid
-            } else {
-                // Check the app still exists.
-                //
-                // If the `.enter()` succeeds, then the app is still valid, and
-                // we can check if the owning app matches the one that called
-                // the command. If the `.enter()` fails, then the owning app no
-                // longer exists and we return `true` to signify the
-                // "or_nonexistant" case.
-                self.apps
-                    .enter(owning_app, |_, _| owning_app == processid)
-                    .unwrap_or(true)
-            }
-        });
-
         match command_num {
             // check if present
             0 => CommandReturn::success(),
 
             // get, set, delete
             1 | 2 | 3 => {
-                if match_or_empty_or_nonexistant {
+                if self.processid.is_none() {
+                    // Nothing is using the KV store, so we can handle this
+                    // request.
                     self.processid.set(processid);
                     let _ = self.apps.enter(processid, |app, _| match command_num {
-                        1 => app.op.set(Some(UserSpaceOp::Get)),
-                        2 => app.op.set(Some(UserSpaceOp::Set)),
-                        3 => app.op.set(Some(UserSpaceOp::Delete)),
+                        1 => app.op.set(UserSpaceOp::Get),
+                        2 => app.op.set(UserSpaceOp::Set),
+                        3 => app.op.set(UserSpaceOp::Delete),
                         _ => {}
                     });
                     let ret = self.run();
@@ -456,21 +410,21 @@ impl<'a, K: kv_system::KVSystem<'a, K = T>, T: kv_system::KeyType> SyscallDriver
                         CommandReturn::success()
                     }
                 } else {
-                    // There is an active app, so queue this request (if possible).
+                    // There is an active app, so queue this request (if
+                    // possible).
                     self.apps
                         .enter(processid, |app, _| {
-                            // Some app is using the storage, we must wait.
-                            if app.pending_run_app.is_some() {
-                                // No more room in the queue, nowhere to store this
-                                // request.
+                            if app.op.is_some() {
+                                // No more room in the queue, nowhere to store
+                                // this request.
                                 CommandReturn::failure(ErrorCode::NOMEM)
                             } else {
-                                // We can store this, so lets do it.
-                                app.pending_run_app = Some(processid);
+                                // This app has not already queued a command so
+                                // we can store this.
                                 match command_num {
-                                    1 => app.op.set(Some(UserSpaceOp::Get)),
-                                    2 => app.op.set(Some(UserSpaceOp::Set)),
-                                    3 => app.op.set(Some(UserSpaceOp::Delete)),
+                                    1 => app.op.set(UserSpaceOp::Get),
+                                    2 => app.op.set(UserSpaceOp::Set),
+                                    3 => app.op.set(UserSpaceOp::Delete),
                                     _ => {}
                                 }
                                 CommandReturn::success()
@@ -488,17 +442,4 @@ impl<'a, K: kv_system::KVSystem<'a, K = T>, T: kv_system::KeyType> SyscallDriver
     fn allocate_grant(&self, processid: ProcessId) -> Result<(), kernel::process::Error> {
         self.apps.enter(processid, |_, _| {})
     }
-}
-
-#[derive(Copy, Clone, PartialEq)]
-enum UserSpaceOp {
-    Get,
-    Set,
-    Delete,
-}
-
-#[derive(Default)]
-pub struct App {
-    pending_run_app: Option<ProcessId>,
-    op: Cell<Option<UserSpaceOp>>,
 }

--- a/capsules/extra/src/kv_driver.rs
+++ b/capsules/extra/src/kv_driver.rs
@@ -133,7 +133,7 @@ impl<'a, K: kv_system::KVSystem<'a, K = T>, T: kv_system::KeyType> KVStoreDriver
                         0
                     };
 
-                    match app.op.extract() {
+                    match app.op.get() {
                         Some(UserSpaceOp::Get) => {
                             if let Some(Some(Err(e))) = self.data_buffer.take().map(|data_buffer| {
                                 self.dest_buffer.take().map(|dest_buffer| {

--- a/capsules/extra/src/kv_store.rs
+++ b/capsules/extra/src/kv_store.rs
@@ -548,10 +548,9 @@ impl<'a, K: KVSystem<'a, K = T>, T: kv_system::KeyType> kv_system::Client<T>
                                 });
 
                                 if read_allowed {
-                                    ret_buf.as_slice().copy_within(
-                                        HEADER_LENGTH..(HEADER_LENGTH + header.length as usize),
-                                        0,
-                                    );
+                                    // Remove the header from the accessible
+                                    // portion of the buffer.
+                                    ret_buf.slice(HEADER_LENGTH..);
                                 }
                             }
                         }

--- a/capsules/extra/src/sip_hash.rs
+++ b/capsules/extra/src/sip_hash.rs
@@ -149,8 +149,11 @@ macro_rules! compress {
 }
 
 fn read_le_u64(input: &[u8]) -> u64 {
-    let (int_bytes, _rest) = input.split_at(mem::size_of::<u64>());
-    u64::from_le_bytes(int_bytes.try_into().unwrap())
+    let mut eight_buf: [u8; 8] = [0; 8];
+    for i in 0..8 {
+        eight_buf[i] = *input.get(i).unwrap_or(&0);
+    }
+    u64::from_le_bytes(eight_buf)
 }
 
 fn read_le_u16(input: &[u8]) -> u16 {

--- a/capsules/extra/src/test/kv_system.rs
+++ b/capsules/extra/src/test/kv_system.rs
@@ -56,7 +56,8 @@ use core::cell::Cell;
 use core::marker::PhantomData;
 use kernel::debug;
 use kernel::hil::kv_system::{self, KVSystem, KeyType};
-use kernel::utilities::cells::TakeCell;
+use kernel::utilities::cells::{MapCell, TakeCell};
+use kernel::utilities::leasable_buffer::LeasableMutableBuffer;
 use kernel::ErrorCode;
 
 #[derive(Clone, Copy, PartialEq)]
@@ -68,7 +69,7 @@ enum CurrentState {
 pub struct KVSystemTest<'a, S: KVSystem<'static>, T: KeyType> {
     kv_system: &'a S,
     phantom: PhantomData<&'a T>,
-    value: TakeCell<'static, [u8]>,
+    value: MapCell<LeasableMutableBuffer<'static, u8>>,
     ret_buffer: TakeCell<'static, [u8]>,
     state: Cell<CurrentState>,
 }
@@ -76,7 +77,7 @@ pub struct KVSystemTest<'a, S: KVSystem<'static>, T: KeyType> {
 impl<'a, S: KVSystem<'static>, T: KeyType> KVSystemTest<'a, S, T> {
     pub fn new(
         kv_system: &'a S,
-        value: &'static mut [u8],
+        value: LeasableMutableBuffer<'static, u8>,
         static_buf: &'static mut [u8; 4],
     ) -> KVSystemTest<'a, S, T> {
         debug!("---Starting TicKV Tests---");
@@ -84,7 +85,7 @@ impl<'a, S: KVSystem<'static>, T: KeyType> KVSystemTest<'a, S, T> {
         Self {
             kv_system: kv_system,
             phantom: PhantomData,
-            value: TakeCell::new(value),
+            value: MapCell::new(value),
             ret_buffer: TakeCell::new(static_buf),
             state: Cell::new(CurrentState::Normal),
         }
@@ -97,7 +98,7 @@ impl<'a, S: KVSystem<'static, K = T>, T: KeyType + core::fmt::Debug> kv_system::
     fn generate_key_complete(
         &self,
         result: Result<(), ErrorCode>,
-        _unhashed_key: &'static mut [u8],
+        _unhashed_key: LeasableMutableBuffer<'static, u8>,
         key_buf: &'static mut T,
     ) {
         match result {
@@ -118,14 +119,17 @@ impl<'a, S: KVSystem<'static, K = T>, T: KeyType + core::fmt::Debug> kv_system::
         &self,
         result: Result<(), ErrorCode>,
         key: &'static mut T,
-        value: &'static mut [u8],
+        value: LeasableMutableBuffer<'static, u8>,
     ) {
         match result {
             Ok(()) => {
                 debug!("Key: {:?} with value {:?} was added", key, value);
                 debug!("Now retrieving the key");
                 self.kv_system
-                    .get_value(key, self.ret_buffer.take().unwrap())
+                    .get_value(
+                        key,
+                        LeasableMutableBuffer::new(self.ret_buffer.take().unwrap()),
+                    )
                     .unwrap();
             }
             Err(e) => {
@@ -138,12 +142,12 @@ impl<'a, S: KVSystem<'static, K = T>, T: KeyType + core::fmt::Debug> kv_system::
         &self,
         result: Result<(), ErrorCode>,
         key: &'static mut T,
-        ret_buf: &'static mut [u8],
+        ret_buf: LeasableMutableBuffer<'static, u8>,
     ) {
         match result {
             Ok(()) => {
                 debug!("Key: {:?} with value {:?} was retrieved", key, ret_buf);
-                self.ret_buffer.replace(ret_buf);
+                self.ret_buffer.replace(ret_buf.take());
                 self.kv_system.invalidate_key(key).unwrap();
             }
             Err(e) => {
@@ -169,7 +173,10 @@ impl<'a, S: KVSystem<'static, K = T>, T: KeyType + core::fmt::Debug> kv_system::
                 debug!("Try to read removed key: {:?}", key);
                 self.state.set(CurrentState::ExpectGetValueFail);
                 self.kv_system
-                    .get_value(key, self.ret_buffer.take().unwrap())
+                    .get_value(
+                        key,
+                        LeasableMutableBuffer::new(self.ret_buffer.take().unwrap()),
+                    )
                     .unwrap();
             }
             Err(e) => {

--- a/capsules/extra/src/test/siphash24.rs
+++ b/capsules/extra/src/test/siphash24.rs
@@ -11,6 +11,7 @@ use crate::sip_hash::SipHasher24;
 use kernel::debug;
 use kernel::hil::hasher::{Client, Hasher};
 use kernel::utilities::cells::TakeCell;
+use kernel::utilities::leasable_buffer::LeasableBuffer;
 use kernel::utilities::leasable_buffer::LeasableMutableBuffer;
 use kernel::ErrorCode;
 
@@ -48,12 +49,16 @@ impl TestSipHash24 {
 }
 
 impl Client<8> for TestSipHash24 {
-    fn add_mut_data_done(&self, _result: Result<(), ErrorCode>, data: &'static mut [u8]) {
-        self.data.replace(data);
+    fn add_mut_data_done(
+        &self,
+        _result: Result<(), ErrorCode>,
+        data: LeasableMutableBuffer<'static, u8>,
+    ) {
+        self.data.replace(data.take());
         self.hasher.run(self.hash.take().unwrap()).unwrap();
     }
 
-    fn add_data_done(&self, _result: Result<(), ErrorCode>, _data: &'static [u8]) {}
+    fn add_data_done(&self, _result: Result<(), ErrorCode>, _data: LeasableBuffer<'static, u8>) {}
 
     fn hash_done(&self, _result: Result<(), ErrorCode>, digest: &'static mut [u8; 8]) {
         debug!("hashed result:   {:?}", digest);

--- a/kernel/src/hil/hasher.rs
+++ b/kernel/src/hil/hasher.rs
@@ -18,7 +18,7 @@ pub trait Client<const L: usize> {
     /// data supplied to `add_data()`.
     /// The possible ErrorCodes are:
     ///    - SIZE: The size of the `data` buffer is invalid
-    fn add_data_done(&self, result: Result<(), ErrorCode>, data: &'static [u8]);
+    fn add_data_done(&self, result: Result<(), ErrorCode>, data: LeasableBuffer<'static, u8>);
 
     /// This callback is called when the data has been added to the hash
     /// engine.
@@ -26,7 +26,11 @@ pub trait Client<const L: usize> {
     /// data supplied to `add_mut_data()`.
     /// The possible ErrorCodes are:
     ///    - SIZE: The size of the `data` buffer is invalid
-    fn add_mut_data_done(&self, result: Result<(), ErrorCode>, data: &'static mut [u8]);
+    fn add_mut_data_done(
+        &self,
+        result: Result<(), ErrorCode>,
+        data: LeasableMutableBuffer<'static, u8>,
+    );
 
     /// This callback is called when a hash is computed.
     /// On error or success `hash` will contain a reference to the original
@@ -60,7 +64,7 @@ pub trait Hasher<'a, const L: usize> {
     fn add_data(
         &self,
         data: LeasableBuffer<'static, u8>,
-    ) -> Result<usize, (ErrorCode, &'static [u8])>;
+    ) -> Result<usize, (ErrorCode, LeasableBuffer<'static, u8>)>;
 
     /// Add data to the hash block. This is the data that will be used
     /// for the hash function.
@@ -75,7 +79,7 @@ pub trait Hasher<'a, const L: usize> {
     fn add_mut_data(
         &self,
         data: LeasableMutableBuffer<'static, u8>,
-    ) -> Result<usize, (ErrorCode, &'static mut [u8])>;
+    ) -> Result<usize, (ErrorCode, LeasableMutableBuffer<'static, u8>)>;
 
     /// Request the implementation to generate a hash and stores the returned
     /// hash in the memory location specified.

--- a/kernel/src/hil/kv_system.rs
+++ b/kernel/src/hil/kv_system.rs
@@ -58,6 +58,7 @@
 //!    hil::flash
 //! ```
 
+use crate::utilities::leasable_buffer::LeasableMutableBuffer;
 use crate::ErrorCode;
 
 /// The type of keys, this should define the output size of the digest
@@ -109,7 +110,7 @@ pub trait Client<K: KeyType> {
     fn generate_key_complete(
         &self,
         result: Result<(), ErrorCode>,
-        unhashed_key: &'static mut [u8],
+        unhashed_key: LeasableMutableBuffer<'static, u8>,
         key_buf: &'static mut K,
     );
 
@@ -165,12 +166,12 @@ pub trait KVSystem<'a> {
     /// On error the unhashed_key, key_buf and `Result<(), ErrorCode>` will be returned.
     fn generate_key(
         &self,
-        unhashed_key: &'static mut [u8],
+        unhashed_key: LeasableMutableBuffer<'static, u8>,
         key_buf: &'static mut Self::K,
     ) -> Result<
         (),
         (
-            &'static mut [u8],
+            LeasableMutableBuffer<'static, u8>,
             &'static mut Self::K,
             Result<(), ErrorCode>,
         ),

--- a/kernel/src/hil/kv_system.rs
+++ b/kernel/src/hil/kv_system.rs
@@ -6,33 +6,33 @@
 //!
 //! The KV store implementation in Tock has three levels, described below.
 //!
-//! 1 - Hardware Level:
-//! This level is the interface that writes a buffer to the hardware. This will
-//! generally be writing to flash, although in theory it would be possible to
-//! write to other mediums.
+//! 1. **Hardware Level**: This level is the interface that writes a buffer to the
+//!    hardware. This will generally be writing to flash, although in theory it
+//!    would be possible to write to other mediums.
 //!
-//! An example of the HIL used here is the Tock Flash HIL.
+//!    An example of the HIL used here is the Tock Flash HIL.
 //!
-//! 2 - KV System Level:
-//! This level can be thought of like a file system. It is responsible for
-//! taking save/load operations and generating a buffer to pass to level 1
-//! This level is also in charge of generating hashes and checksums.
+//! 2. **KV System Level**: This level can be thought of like a file system. It
+//!    is responsible for taking save/load operations and generating a buffer to
+//!    pass to level 1. This level is also in charge of generating hashes and
+//!    checksums.
 //!
-//! This level allows generating a key hash but otherwise operates on
-//! hashed keys. This level is not responsible for permission checks.
+//!    This level allows generating a key hash but otherwise operates on hashed
+//!    keys. This level is not responsible for permission checks.
 //!
-//! This file describes the HIL for this level.
+//!    This file describes the HIL for this level.
 //!
-//! 3 - KV Store:
-//! This is a user friendly high level API. This API is used inside the kernel
-//! and exposed to applications to allow KV operations. The API from this level
-//! should be high level, for example set/get/delete on unhashed keys.
-//! This level is in charge of enforcing permissions.
+//! 3. **KV Store**: This is a user friendly high level API. This API is used
+//!    inside the kernel and exposed to applications to allow KV operations. The
+//!    API from this level should be high level, for example set/get/delete on
+//!    unhashed keys. This level is in charge of enforcing permissions.
 //!
-//! This level is also in charge of generating the key hash by calling into
-//! level 2.
+//!    This level is also in charge of generating the key hash by calling into
+//!    level 2.
 //!
 //! The expected setup inside Tock will look like this:
+//!
+//! ```text
 //! +-----------------------+
 //! |                       |
 //! |  Capsule using K-V    |
@@ -56,6 +56,7 @@
 //! +-----------------------+
 //!
 //!    hil::flash
+//! ```
 
 use crate::ErrorCode;
 
@@ -67,11 +68,11 @@ impl KeyType for [u8; 8] {}
 
 /// Implement this trait and use `set_client()` in order to receive callbacks.
 pub trait StoreClient<K: KeyType> {
-    /// This callback is called when the get operation completes
+    /// This callback is called when the get operation completes.
     ///
-    /// `result`: Nothing on success, 'ErrorCode' on error
-    /// `key`: The key buffer
-    /// `ret_buf`: The ret_buf buffer
+    /// - `result`: Nothing on success, 'ErrorCode' on error
+    /// - `key`: The key buffer
+    /// - `ret_buf`: The ret_buf buffer
     fn get_complete(
         &self,
         result: Result<(), ErrorCode>,
@@ -79,11 +80,11 @@ pub trait StoreClient<K: KeyType> {
         ret_buf: &'static mut [u8],
     );
 
-    /// This callback is called when the set operation completes
+    /// This callback is called when the set operation completes.
     ///
-    /// `result`: Nothing on success, 'ErrorCode' on error
-    /// `key`: The key buffer
-    /// `value`: The value buffer
+    /// - `result`: Nothing on success, 'ErrorCode' on error
+    /// - `key`: The key buffer
+    /// - `value`: The value buffer
     fn set_complete(
         &self,
         result: Result<(), ErrorCode>,
@@ -91,20 +92,20 @@ pub trait StoreClient<K: KeyType> {
         value: &'static mut [u8],
     );
 
-    /// This callback is called when the delete operation completes
+    /// This callback is called when the delete operation completes.
     ///
-    /// `result`: Nothing on success, 'ErrorCode' on error
-    /// `key`: The key buffer
+    /// - `result`: Nothing on success, 'ErrorCode' on error
+    /// - `key`: The key buffer
     fn delete_complete(&self, result: Result<(), ErrorCode>, key: &'static mut [u8]);
 }
 
 /// Implement this trait and use `set_client()` in order to receive callbacks.
 pub trait Client<K: KeyType> {
-    /// This callback is called when the append_key operation completes
+    /// This callback is called when the append_key operation completes.
     ///
-    /// `result`: Nothing on success, 'ErrorCode' on error
-    /// `unhashed_key`: The unhashed_key buffer
-    /// `key_buf`: The key_buf buffer
+    /// - `result`: Nothing on success, 'ErrorCode' on error
+    /// - `unhashed_key`: The unhashed_key buffer
+    /// - `key_buf`: The key_buf buffer
     fn generate_key_complete(
         &self,
         result: Result<(), ErrorCode>,
@@ -112,11 +113,11 @@ pub trait Client<K: KeyType> {
         key_buf: &'static mut K,
     );
 
-    /// This callback is called when the append_key operation completes
+    /// This callback is called when the append_key operation completes.
     ///
-    /// `result`: Nothing on success, 'ErrorCode' on error
-    /// `key`: The key buffer
-    /// `value`: The value buffer
+    /// - `result`: Nothing on success, 'ErrorCode' on error
+    /// - `key`: The key buffer
+    /// - `value`: The value buffer
     fn append_key_complete(
         &self,
         result: Result<(), ErrorCode>,
@@ -124,11 +125,11 @@ pub trait Client<K: KeyType> {
         value: &'static mut [u8],
     );
 
-    /// This callback is called when the get_value operation completes
+    /// This callback is called when the get_value operation completes.
     ///
-    /// `result`: Nothing on success, 'ErrorCode' on error
-    /// `key`: The key buffer
-    /// `ret_buf`: The ret_buf buffer
+    /// - `result`: Nothing on success, 'ErrorCode' on error
+    /// - `key`: The key buffer
+    /// - `ret_buf`: The ret_buf buffer
     fn get_value_complete(
         &self,
         result: Result<(), ErrorCode>,
@@ -136,29 +137,29 @@ pub trait Client<K: KeyType> {
         ret_buf: &'static mut [u8],
     );
 
-    /// This callback is called when the invalidate_key operation completes
+    /// This callback is called when the invalidate_key operation completes.
     ///
-    /// `result`: Nothing on success, 'ErrorCode' on error
-    /// `key`: The key buffer
+    /// - `result`: Nothing on success, 'ErrorCode' on error
+    /// - `key`: The key buffer
     fn invalidate_key_complete(&self, result: Result<(), ErrorCode>, key: &'static mut K);
 
-    /// This callback is called when the garbage_collect operation completes
+    /// This callback is called when the garbage_collect operation completes.
     ///
-    /// `result`: Nothing on success, 'ErrorCode' on error
+    /// - `result`: Nothing on success, 'ErrorCode' on error
     fn garbage_collect_complete(&self, result: Result<(), ErrorCode>);
 }
 
 pub trait KVSystem<'a> {
-    /// The type of the hashed key. For example '[u8; 8]'.
+    /// The type of the hashed key. For example `[u8; 8]`.
     type K: KeyType;
 
-    /// Set the client
+    /// Set the client.
     fn set_client(&self, client: &'a dyn Client<Self::K>);
 
-    /// Generate key
+    /// Generate key.
     ///
-    /// `unhashed_key`: A unhashed key that should be hashed.
-    /// `key_buf`: A buffer to store the hashed key output.
+    /// - `unhashed_key`: A unhashed key that should be hashed.
+    /// - `key_buf`: A buffer to store the hashed key output.
     ///
     /// On success returns nothing.
     /// On error the unhashed_key, key_buf and `Result<(), ErrorCode>` will be returned.
@@ -181,19 +182,19 @@ pub trait KVSystem<'a> {
     /// the append operation will fail. To update an existing key to a new value
     /// the key must first be invalidated.
     ///
-    /// `key`: A hashed key. This key will be used in future to retrieve
-    ///        or remove the `value`.
-    /// `value`: A buffer containing the data to be stored to flash.
+    /// - `key`: A hashed key. This key will be used in future to retrieve
+    ///          or remove the `value`.
+    /// - `value`: A buffer containing the data to be stored to flash.
     ///
     /// On success nothing will be returned.
     /// On error the key, value and a `Result<(), ErrorCode>` will be returned.
     ///
     /// The possible `Result<(), ErrorCode>`s are:
-    ///    `BUSY`: An operation is already in progress
-    ///    `INVAL`: An invalid parameter was passed
-    ///    `NODEVICE`: No KV store was setup
-    ///    `NOSUPPORT`: The key could not be added due to a collision.
-    ///    `NOMEM`: The key could not be added due to no more space.
+    /// - `BUSY`: An operation is already in progress
+    /// - `INVAL`: An invalid parameter was passed
+    /// - `NODEVICE`: No KV store was setup
+    /// - `NOSUPPORT`: The key could not be added due to a collision.
+    /// - `NOMEM`: The key could not be added due to no more space.
     fn append_key(
         &self,
         key: &'static mut Self::K,
@@ -209,18 +210,18 @@ pub trait KVSystem<'a> {
 
     /// Retrieves the value from a specified key.
     ///
-    /// `key`: A hashed key. This key will be used to retrieve the `value`.
-    /// `ret_buf`: A buffer to store the value to.
+    /// - `key`: A hashed key. This key will be used to retrieve the `value`.
+    /// - `ret_buf`: A buffer to store the value to.
     ///
     /// On success nothing will be returned.
     /// On error the key, ret_buf and a `Result<(), ErrorCode>` will be returned.
     ///
     /// The possible `Result<(), ErrorCode>`s are:
-    ///    `BUSY`: An operation is already in progress
-    ///    `INVAL`: An invalid parameter was passed
-    ///    `NODEVICE`: No KV store was setup
-    ///    `ENOSUPPORT`: The key could not be found.
-    ///    `SIZE`: The value is longer than the provided buffer.
+    /// - `BUSY`: An operation is already in progress
+    /// - `INVAL`: An invalid parameter was passed
+    /// - `NODEVICE`: No KV store was setup
+    /// - `ENOSUPPORT`: The key could not be found.
+    /// - `SIZE`: The value is longer than the provided buffer.
     fn get_value(
         &self,
         key: &'static mut Self::K,
@@ -234,34 +235,34 @@ pub trait KVSystem<'a> {
         ),
     >;
 
-    /// Invalidates the key in flash storage
+    /// Invalidates the key in flash storage.
     ///
-    /// `key`: A hashed key. This key will be used to remove the `value`.
+    /// - `key`: A hashed key. This key will be used to remove the `value`.
     ///
     /// On success nothing will be returned.
     /// On error the key and a `Result<(), ErrorCode>` will be returned.
     ///
     /// The possible `Result<(), ErrorCode>`s are:
-    ///    `BUSY`: An operation is already in progress
-    ///    `INVAL`: An invalid parameter was passed
-    ///    `NODEVICE`: No KV store was setup
-    ///    `ENOSUPPORT`: The key could not be found.
+    /// - `BUSY`: An operation is already in progress
+    /// - `INVAL`: An invalid parameter was passed
+    /// - `NODEVICE`: No KV store was setup
+    /// - `ENOSUPPORT`: The key could not be found.
     fn invalidate_key(
         &self,
         key: &'static mut Self::K,
     ) -> Result<(), (&'static mut Self::K, Result<(), ErrorCode>)>;
 
-    /// Perform a garbage collection on the KV Store
+    /// Perform a garbage collection on the KV Store.
     ///
-    /// For implementations that don't require garbage collecting
-    /// this can just be a NOP that returns 'Ok(0)'.
+    /// For implementations that don't require garbage collecting this can just
+    /// be a NOP that returns `Ok(0)`.
     ///
     /// On success the number of bytes freed will be returned.
     /// On error a `Result<(), ErrorCode>` will be returned.
     ///
     /// The possible `Result<(), ErrorCode>`s are:
-    ///    `BUSY`: An operation is already in progress
-    ///    `INVAL`: An invalid parameter was passed
-    ///    `NODEVICE`: No KV store was setup
+    /// - `BUSY`: An operation is already in progress
+    /// - `INVAL`: An invalid parameter was passed
+    /// - `NODEVICE`: No KV store was setup
     fn garbage_collect(&self) -> Result<usize, Result<(), ErrorCode>>;
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request is the full update to the KV stack so far, including unmerged PRs.

In addition to previous PRs, this changes the KV stack to use leasable buffers to address #3495.

This also updates the syscall driver to report value length to userspace.

#### KV Stack Major Fixes:

- Implement virtualization for kv_store interface.
- Support getting the value length on a `get()` operation.
- Allow siphash to hash buffers other than 64 bytes.
- Support multiple apps using kv_driver.
- Move `StoreClient` out of the  KV system HIL..
- Update expected async calls to use Ok.



### Testing Strategy

todo


### TODO or Help Wanted

I needed to sort out all of the changes and various commits, but now that this code is largely in place I can work on running all of the tests I've been using so far.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
