### PR TITLE
kernel: LeasableBuffer: fix double slice end value

### DIFF
--- a/kernel/src/utilities/leasable_buffer.rs
+++ b/kernel/src/utilities/leasable_buffer.rs
@@ -152,7 +152,7 @@ impl<'a, T> LeasableMutableBuffer<'a, T> {
         let end = match range.end_bound() {
             Bound::Included(e) => *e + 1,
             Bound::Excluded(e) => *e,
-            Bound::Unbounded => self.internal.len(),
+            Bound::Unbounded => self.active_range.end,
         };
 
         let new_start = self.active_range.start + start;
@@ -237,7 +237,7 @@ impl<'a, T> LeasableBuffer<'a, T> {
         let end = match range.end_bound() {
             Bound::Included(e) => *e + 1,
             Bound::Excluded(e) => *e,
-            Bound::Unbounded => self.internal.len(),
+            Bound::Unbounded => self.active_range.end,
         };
 
         let new_start = self.active_range.start + start;


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the `slice()` operation in LeasableBuffer when .slice() is called twice. In the second .slice(), if the end was `..` (ie `mybuf.slice(4..)`), the buffer would go back to its full length rather than just the part originally visible.

The fix is just to use the saved end as the default (which is set in `new()` so it works for the first slice as well).

### Testing Strategy

KV stack work.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
