### PR TITLE
kernel: hil: Various spelling fixes

### DIFF
--- a/kernel/src/hil/buzzer.rs
+++ b/kernel/src/hil/buzzer.rs
@@ -19,7 +19,7 @@ pub trait Buzzer<'a> {
     /// Once the buzzer finishes buzzing, the `buzzer_done()` callback
     /// is called.
     /// If it is called while the buzzer is playing, the buzzer command will be
-    /// overriden with the new frequency and duration values.
+    /// overridden with the new frequency and duration values.
     ///
     /// Return values:
     ///
@@ -27,7 +27,7 @@ pub trait Buzzer<'a> {
     /// - `FAIL`: Cannot start the buzzer.
     fn buzz(&self, frequency_hz: usize, duration_ms: usize) -> Result<(), ErrorCode>;
 
-    /// Stop the sound currenty playing.
+    /// Stop the sound currently playing.
     /// After the buzzer is successfully stopped, the `buzzer_done()`
     /// callback is called.
     ///

--- a/kernel/src/hil/can.rs
+++ b/kernel/src/hil/can.rs
@@ -186,7 +186,7 @@ pub struct BitTiming {
     pub propagation: u8,
 
     /// A value that represents the maximum time by which
-    /// the bit sampling period may lenghten or shorten
+    /// the bit sampling period may lengthen or shorten
     /// each cycle to perform the resynchronization. It is
     /// measured in time quanta.
     pub sync_jump_width: u32,
@@ -365,9 +365,9 @@ pub trait Configure {
     const SYNC_SEG: u8 = 1;
 
     /// Configures the CAN peripheral at the given bitrate. This function is
-    /// supposed to be caled before the `enable` function. This function is
+    /// supposed to be called before the `enable` function. This function is
     /// synchronous as the driver should only calculate the timing parameters
-    /// based on the bitrate and the frequenct of the board and store them.
+    /// based on the bitrate and the frequency of the board and store them.
     /// This function does not configure the hardware.
     ///
     /// # Arguments:
@@ -387,7 +387,7 @@ pub trait Configure {
     /// configure the hardware.
     ///
     /// # Arguments:
-    ///  
+    ///
     /// * `bit_timing` - A BitTiming structure to define the bit timing
     ///                  settings for the peripheral
     ///
@@ -509,7 +509,7 @@ pub trait ConfigureFd: Configure {
     /// configure the hardware.
     ///
     /// # Arguments:
-    ///  
+    ///
     /// * `payload_bit_timing` - A BitTiming structure to define the bit timing
     ///                         settings for the frame payload
     ///
@@ -663,7 +663,7 @@ pub trait Transmit<const PACKET_SIZE: usize> {
     /// * `Err(ErrorCode, &'static mut [u8])` - a tuple with the error that occurred
     ///                                         during the transmission request and
     ///                                         the buffer that was provided as an
-    ///                                         argument to the function                     
+    ///                                         argument to the function
     fn send(
         &self,
         id: Id,
@@ -707,7 +707,7 @@ pub trait Receive<const PACKET_SIZE: usize> {
 
     /// Asks the driver to stop receiving messages. This function should
     /// be called only after a call to the `start_receive_process` function.
-    ///     
+    ///
     /// # Return values:
     ///
     /// * `Ok()` - The request was successful an the caller waits for the
@@ -793,12 +793,12 @@ pub trait ReceiveClient<const PACKET_SIZE: usize> {
         status: Result<(), Error>,
     );
 
-    /// The driver calls this function when the reception of messages has been stopeed.
+    /// The driver calls this function when the reception of messages has been stopped.
     ///
     /// # Arguments:
     ///
     /// * `buffer` - The buffer that was given as an argument to the
-    ///               `start_receive_process` function  
+    ///               `start_receive_process` function
     fn stopped(&self, buffer: &'static mut [u8; PACKET_SIZE]);
 }
 

--- a/kernel/src/hil/eic.rs
+++ b/kernel/src/hil/eic.rs
@@ -29,7 +29,7 @@ pub trait ExternalInterruptController {
     type Line;
 
     /// Enables external interrupt on the given 'line'
-    /// In asychronous mode, all edge interrupts will be
+    /// In asynchronous mode, all edge interrupts will be
     /// interpreted as level interrupts and the filter is disabled.
     fn line_enable(&self, line: &Self::Line, interrupt_mode: InterruptMode);
 

--- a/kernel/src/hil/entropy.rs
+++ b/kernel/src/hil/entropy.rs
@@ -105,7 +105,7 @@ pub enum Continue {
 /// Implementors should assume the client implements the
 /// [Client](trait.Client32.html) trait.
 pub trait Entropy32<'a> {
-    /// Initiate the aquisition of entropy.
+    /// Initiate the acquisition of entropy.
     ///
     /// There are three valid return values:
     ///   - Ok(()): a `entropy_available` callback will be called in

--- a/kernel/src/hil/screen.rs
+++ b/kernel/src/hil/screen.rs
@@ -253,7 +253,7 @@ pub trait Screen<'a> {
     /// - 1..MAX_BRIGHTNESS - on, set brightness to the given level
     ///
     /// The display should interpret the brightness value as *lightness*
-    /// (each increment should change preceived brightness the same).
+    /// (each increment should change perceived brightness the same).
     /// 1 shall be the minimum supported brightness,
     /// `MAX_BRIGHTNESS` and greater represent the maximum.
     /// Values in between should approximate the intermediate values;
@@ -282,7 +282,7 @@ pub trait Screen<'a> {
 
     /// Controls the color inversion mode.
     ///
-    /// Pixels already in the frame buffer, as well as newly submited,
+    /// Pixels already in the frame buffer, as well as newly submitted,
     /// will be inverted. What that means depends on the current pixel format.
     /// May get disabled when switching to another pixel format.
     /// Returns ENOSUPPORT if the device does not accelerate color inversion.

--- a/kernel/src/hil/time.rs
+++ b/kernel/src/hil/time.rs
@@ -6,7 +6,7 @@
 //! kernel.
 //!
 //! These traits are designed to be able encompass the wide
-//! variety of hardare counters in a general yet efficient way. They
+//! variety of hardware counters in a general yet efficient way. They
 //! abstract the frequency of a counter through the `Frequency` trait
 //! and the width of a time value through the `Ticks`
 //! trait. Higher-level software abstractions should generally rely on
@@ -173,7 +173,7 @@ pub trait Counter<'a>: Time {
     ///   - `Err(ErrorCode::OFF)`: underlying clocks or other hardware resources
     ///   are not on, such that the counter cannot start.
     ///   - `Err(ErrorCode::FAIL)`: unidentified failure, counter is not running.
-    /// After a successful call to `start`, `is_running` MUST return true.    
+    /// After a successful call to `start`, `is_running` MUST return true.
     fn start(&self) -> Result<(), ErrorCode>;
 
     /// Stops the free-running hardware counter. Valid `Result<(), ErrorCode>` values are:
@@ -182,7 +182,7 @@ pub trait Counter<'a>: Time {
     ///   - `Err(ErrorCode::BUSY)`: the counter is in use in a way that means it
     ///   cannot be stopped and is busy.
     ///   - `Err(ErrorCode::FAIL)`: unidentified failure, counter is running.
-    /// After a successful call to `stop`, `is_running` MUST return false.        
+    /// After a successful call to `stop`, `is_running` MUST return false.
     fn stop(&self) -> Result<(), ErrorCode>;
 
     /// Resets the counter to 0. This may introduce jitter on the counter.
@@ -191,7 +191,7 @@ pub trait Counter<'a>: Time {
     /// call `stop` before `reset`.
     /// Valid `Result<(), ErrorCode>` values are:
     ///    - `Ok(())`: the counter was reset to 0.
-    ///    - `Err(ErrorCode::FAIL)`: the counter was not reset to 0.    
+    ///    - `Err(ErrorCode::FAIL)`: the counter was not reset to 0.
     fn reset(&self) -> Result<(), ErrorCode>;
 
     /// Returns whether the counter is currently running.
@@ -239,9 +239,9 @@ pub trait Alarm<'a>: Time {
     /// Disable the alarm and stop it from firing in the future.
     /// Valid `Result<(), ErrorCode>` codes are:
     ///   - `Ok(())` the alarm has been disarmed and will not invoke
-    ///   the callback in the future    
+    ///   the callback in the future
     ///   - `Err(ErrorCode::FAIL)` the alarm could not be disarmed and will invoke
-    ///   the callback in the future    
+    ///   the callback in the future
     fn disarm(&self) -> Result<(), ErrorCode>;
 
     /// Returns whether the alarm is currently armed. Note that this
@@ -270,7 +270,7 @@ pub trait TimerClient {
 /// precisely timed callbacks should use the `Alarm` trait instead.
 pub trait Timer<'a>: Time {
     /// Specify the callback to invoke when the timer interval expires.
-    /// If there was a previously installed callback this call replaces it.    
+    /// If there was a previously installed callback this call replaces it.
     fn set_timer_client(&self, client: &'a dyn TimerClient);
 
     /// Start a one-shot timer that will invoke the callback at least
@@ -300,7 +300,7 @@ pub trait Timer<'a>: Time {
 
     /// Return how many ticks are remaining until the next callback,
     /// or None if the timer is disabled.  This call is useful because
-    /// there may be non-neglible delays between when a timer was
+    /// there may be non-negligible delays between when a timer was
     /// requested and it was actually scheduled. Therefore, since a
     /// timer's start might be delayed slightly, the time remaining
     /// might be slightly higher than one would expect if one


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes some spelling. I don't claim this to be exhaustive.


### Testing Strategy

n/a


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
