### PR TITLE
boards: microbitv2: use helper function in main

### DIFF
--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -220,7 +220,11 @@ impl KernelResources<nrf52833::chip::NRF52<'static, Nrf52833DefaultPeripherals<'
 /// removed when this function returns. Otherwise, the stack space used for
 /// these static_inits is wasted.
 #[inline(never)]
-unsafe fn start() -> (&'static kernel::Kernel, MicroBit) {
+unsafe fn start() -> (
+    &'static kernel::Kernel,
+    MicroBit,
+    &'static nrf52833::chip::NRF52<'static, Nrf52833DefaultPeripherals<'static>>,
+) {
     nrf52833::init();
 
     let nrf52833_peripherals = static_init!(
@@ -780,7 +784,7 @@ unsafe fn start() -> (&'static kernel::Kernel, MicroBit) {
         debug!("{:?}", err);
     });
 
-    (board_kernel, microbit)
+    (board_kernel, microbit, chip)
 }
 
 /// Main function called after RAM initialized.
@@ -788,11 +792,6 @@ unsafe fn start() -> (&'static kernel::Kernel, MicroBit) {
 pub unsafe fn main() {
     let main_loop_capability = create_capability!(capabilities::MainLoopCapability);
 
-    let (board_kernel, microbit) = start();
-    board_kernel.kernel_loop(
-        &microbit,
-        CHIP.unwrap(),
-        Some(&microbit.ipc),
-        &main_loop_capability,
-    );
+    let (board_kernel, board, chip) = start();
+    board_kernel.kernel_loop(&board, chip, Some(&board.ipc), &main_loop_capability);
 }


### PR DESCRIPTION
### Pull Request Overview

By outsourcing all of `main()` to a separate function (in this case `start()` other than running the kernel, we can minimize the stack frame size of main. This is important because the main stack frame is never popped since main does not return.

This is an alternative to doing this piecemeal for individual functions.

This PR is an alternative to #3499.







### Testing Strategy

travis


### TODO or Help Wanted

I only did this for one board. Thoughts? Naming? Is using `Chip.unwrap()` ok / is there a better option?


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
