### PR TITLE
Fix global pointer setup code

### DIFF
--- a/arch/rv32i/src/lib.rs
+++ b/arch/rv32i/src/lib.rs
@@ -41,6 +41,7 @@ extern "C" {
     static mut _erelocate: usize;
 
     // The global pointer, value set in the linker script
+    #[link_name = "__global_pointer$"]
     static __global_pointer: usize;
 }
 
@@ -72,8 +73,16 @@ pub extern "C" fn _start() {
             // https://groups.google.com/a/groups.riscv.org/forum/#!msg/sw-dev/60IdaZj27dY/5MydPLnHAQAJ
             // https://www.sifive.com/blog/2017/08/28/all-aboard-part-3-linker-relaxation-in-riscv-toolchain/
             //
-            lui  gp, %hi({gp}$)     // Set the global pointer.
-            addi gp, gp, %lo({gp}$) // Value set in linker script.
+            // Disable linker relaxation for code that sets up GP so that this doesn't
+            // get turned into `mv gp, gp`.
+            .option push
+            .option norelax
+
+            lui  gp, %hi({gp})     // Set the global pointer.
+            addi gp, gp, %lo({gp}) // Value set in linker script.
+
+            // Re-enable linker relaxations.
+            .option pop
 
             // Initialize the stack pointer register. This comes directly from
             // the linker script.


### PR DESCRIPTION
The current code is broken when linker relaxation of GP is enabled. The problem has not manifested yet because upstream LLD does not yet support relaxation of GP.

Plus, change the way `__global_pointer$` is referenced to `__global_pointer` plus a manual `$` in asm to properly use `link_name`. The current approach is confusing because there's no symbol named `__global_pointer`.

### Testing Strategy

`make -C boards/opentitan/earlgrey-cw310 test` and manual assembly inspection

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
