### PR TITLE
Ensure Rust code generated is eligible for linker relaxation

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -74,6 +74,9 @@ ifneq ($(findstring riscv32i, $(TARGET)),)
   # benefit is almost exclusively for RISC-V, we only apply it for those
   # targets.
   RUSTC_FLAGS += -C force-frame-pointers=no
+  # Ensure relocations generated is eligible for linker relaxtion.
+  # This provide huge space savings.
+  RUSTC_FLAGS += -C target-feature=+relax
 endif
 
 # RUSTC_FLAGS_TOCK by default extends RUSTC_FLAGS with options that are global


### PR DESCRIPTION
By default, Rust does not enable `relax` target feature, and therefore no `R_RISCV_RELAX` will not be generated, causing no relaxation to be performed. This causes `auipc + jalr` far jump pair to be not optimised to near `jr` jump.

Taking earlgrey-cw310 as example, this change shaves a lot off the binary:

Size before this commit:
```
   text    data     bss     dec     hex
 141304      28   18976  160308   27234
```

Size after this commit:
```
   text    data     bss     dec     hex
 131272      28   18976  150276   24b04
```

This is 7% space saving in the .text!

### Testing Strategy

`make -C boards/opentitan/earlgrey-cw310 test` and manual assembly inspection

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
