### PR TITLE
Rename `LeasableBuffer` to `SubSlice`

### DIFF
--- a/boards/components/src/udp_driver.rs
+++ b/boards/components/src/udp_driver.rs
@@ -152,7 +152,7 @@ impl<A: Alarm<'static>> Component for UDPDriverComponent<A> {
             self.interface_list,
             MAX_PAYLOAD_LEN,
             self.port_table,
-            kernel::utilities::leasable_buffer::LeasableMutableBuffer::new(buffer),
+            kernel::utilities::leasable_buffer::SubSliceMut::new(buffer),
             &DRIVER_CAP,
             net_cap,
         ));

--- a/boards/imix/src/imix_components/test/mock_udp.rs
+++ b/boards/imix/src/imix_components/test/mock_udp.rs
@@ -131,7 +131,7 @@ impl Component for MockUDPComponent {
             udp_send,
             udp_recv,
             self.bound_port_table,
-            kernel::utilities::leasable_buffer::LeasableMutableBuffer::new(
+            kernel::utilities::leasable_buffer::SubSliceMut::new(
                 self.udp_payload.take().expect("missing payload"),
             ),
             self.dst_port,

--- a/boards/opentitan/src/tests/hmac.rs
+++ b/boards/opentitan/src/tests/hmac.rs
@@ -11,7 +11,7 @@ use kernel::hil::digest::{self, Digest, DigestVerify, HmacSha256};
 use kernel::static_init;
 use kernel::utilities::cells::TakeCell;
 use kernel::utilities::leasable_buffer::LeasableBuffer;
-use kernel::utilities::leasable_buffer::LeasableMutableBuffer;
+use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::{debug, ErrorCode};
 
 static KEY: [u8; 32] = [0xA1; 32];
@@ -42,11 +42,7 @@ impl<'a> HmacTestCallback {
 }
 
 impl<'a> digest::ClientData<32> for HmacTestCallback {
-    fn add_mut_data_done(
-        &self,
-        result: Result<(), ErrorCode>,
-        data: LeasableMutableBuffer<'static, u8>,
-    ) {
+    fn add_mut_data_done(&self, result: Result<(), ErrorCode>, data: SubSliceMut<'static, u8>) {
         self.add_mut_data_done.set(true);
         // Check that all of the data was accepted and the active slice is length 0
         assert_eq!(data.len(), 0);
@@ -101,7 +97,7 @@ fn hmac_check_load_binary() {
     let hmac = &perf.hmac;
 
     let callback = unsafe { static_init_test_cb!() };
-    let _buf = LeasableMutableBuffer::new(callback.input_buffer.take().unwrap());
+    let _buf = SubSliceMut::new(callback.input_buffer.take().unwrap());
 
     debug!("check hmac load binary... ");
     run_kernel_op(100);
@@ -128,7 +124,7 @@ fn hmac_check_verify() {
 
     let callback = unsafe { static_init_test_cb!() };
 
-    let _buf = LeasableMutableBuffer::new(callback.input_buffer.take().unwrap());
+    let _buf = SubSliceMut::new(callback.input_buffer.take().unwrap());
 
     debug!("check hmac check verify... ");
     run_kernel_op(100);

--- a/boards/opentitan/src/tests/sip_hash.rs
+++ b/boards/opentitan/src/tests/sip_hash.rs
@@ -8,8 +8,7 @@ use core::cell::Cell;
 use kernel::hil::hasher::{self, Hasher};
 use kernel::static_init;
 use kernel::utilities::cells::TakeCell;
-use kernel::utilities::leasable_buffer::LeasableBuffer;
-use kernel::utilities::leasable_buffer::LeasableMutableBuffer;
+use kernel::utilities::leasable_buffer::{SubSlice, SubSliceMut};
 use kernel::{debug, ErrorCode};
 
 struct SipHashTestCallback {
@@ -190,7 +189,7 @@ fn sip_hasher_2_4() {
         // Data add done should be reset per each slice
         cb.run_reset();
         assert_eq!(
-            sip_hasher.add_mut_data(LeasableMutableBuffer::new(slice.take().unwrap())),
+            sip_hasher.add_mut_data(SubSliceMut::new(slice.take().unwrap())),
             Ok(8)
         );
 
@@ -208,7 +207,7 @@ fn sip_hasher_2_4() {
         // Data add done should be reset per each slice
         cb.run_reset();
         assert_eq!(
-            sip_hasher.add_mut_data(LeasableMutableBuffer::new(slice.take().unwrap())),
+            sip_hasher.add_mut_data(SubSliceMut::new(slice.take().unwrap())),
             Ok(8)
         );
 

--- a/capsules/extra/src/crc.rs
+++ b/capsules/extra/src/crc.rs
@@ -87,7 +87,7 @@ use kernel::processbuffer::{ReadableProcessBuffer, ReadableProcessSlice};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::NumericCellExt;
 use kernel::utilities::cells::{OptionalCell, TakeCell};
-use kernel::utilities::leasable_buffer::LeasableMutableBuffer;
+use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::{ErrorCode, ProcessId};
 
 /// Syscall driver number.
@@ -156,7 +156,7 @@ impl<'a, C: Crc<'a>> CrcDriver<'a, C> {
                 kbuffer[i] = data[i].get();
             }
             if copy_len > 0 {
-                let mut leasable = LeasableMutableBuffer::new(kbuffer);
+                let mut leasable = SubSliceMut::new(kbuffer);
                 leasable.slice(0..copy_len);
                 let res = self.crc.input(leasable);
                 match res {
@@ -387,17 +387,13 @@ impl<'a, C: Crc<'a>> SyscallDriver for CrcDriver<'a, C> {
 }
 
 impl<'a, C: Crc<'a>> Client for CrcDriver<'a, C> {
-    fn input_done(
-        &self,
-        result: Result<(), ErrorCode>,
-        buffer: LeasableMutableBuffer<'static, u8>,
-    ) {
+    fn input_done(&self, result: Result<(), ErrorCode>, buffer: SubSliceMut<'static, u8>) {
         // A call to `input` has finished. This can mean that either
         // we have processed the entire buffer passed in, or it was
         // truncated by the CRC unit as it was too large. In the first
         // case, we can see whether there is more outstanding data
         // from the app, whereas in the latter we need to advance the
-        // LeasableMutableBuffer window and pass it in again.
+        // SubSliceMut window and pass it in again.
         let mut computing = false;
         // There are three outcomes to this match:
         //   - crc_buffer is not put back: input is ongoing

--- a/capsules/extra/src/net/icmpv6/icmpv6_send.rs
+++ b/capsules/extra/src/net/icmpv6/icmpv6_send.rs
@@ -18,7 +18,7 @@ use crate::net::ipv6::TransportHeader;
 use crate::net::network_capabilities::NetworkCapability;
 
 use kernel::utilities::cells::OptionalCell;
-use kernel::utilities::leasable_buffer::LeasableMutableBuffer;
+use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::ErrorCode;
 
 /// A trait for a client of an `ICMP6Sender`.
@@ -91,12 +91,8 @@ impl<'a, T: IP6Sender<'a>> ICMP6Sender<'a> for ICMP6SendStruct<'a, T> {
         let total_len = buf.len() + icmp_header.get_hdr_size();
         icmp_header.set_len(total_len as u16);
         let transport_header = TransportHeader::ICMP(icmp_header);
-        self.ip_send_struct.send_to(
-            dest,
-            transport_header,
-            &LeasableMutableBuffer::new(buf),
-            net_cap,
-        )
+        self.ip_send_struct
+            .send_to(dest, transport_header, &SubSliceMut::new(buf), net_cap)
     }
 }
 

--- a/capsules/extra/src/net/ipv6/ipv6.rs
+++ b/capsules/extra/src/net/ipv6/ipv6.rs
@@ -78,7 +78,7 @@ use crate::net::stream::{encode_bytes, encode_u16, encode_u8};
 use crate::net::tcp::TCPHeader;
 use crate::net::udp::UDPHeader;
 
-use kernel::utilities::leasable_buffer::LeasableMutableBuffer;
+use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::ErrorCode;
 
 pub const UDP_HDR_LEN: usize = 8;
@@ -356,7 +356,7 @@ impl<'a> IPPayload<'a> {
     pub fn set_payload(
         &mut self,
         transport_header: TransportHeader,
-        payload: &LeasableMutableBuffer<'static, u8>,
+        payload: &SubSliceMut<'static, u8>,
     ) -> (u8, u16) {
         for i in 0..payload.len() {
             self.payload[i] = payload[i];
@@ -382,7 +382,7 @@ impl<'a> IPPayload<'a> {
     ///
     /// # Arguments
     ///
-    /// `buf` - LeasableMutableBuffer to write the serialized `IPPayload` to
+    /// `buf` - SubSliceMut to write the serialized `IPPayload` to
     /// `offset` - Current offset into the buffer
     ///
     /// # Return Value
@@ -508,7 +508,7 @@ impl<'a> IP6Packet<'a> {
     pub fn set_payload(
         &mut self,
         transport_header: TransportHeader,
-        payload: &LeasableMutableBuffer<'static, u8>,
+        payload: &SubSliceMut<'static, u8>,
     ) {
         let (next_header, payload_len) = self.payload.set_payload(transport_header, payload);
         self.header.set_next_header(next_header);

--- a/capsules/extra/src/net/ipv6/ipv6_send.rs
+++ b/capsules/extra/src/net/ipv6/ipv6_send.rs
@@ -32,7 +32,7 @@ use core::cell::Cell;
 use kernel::debug;
 use kernel::hil::time::{self, ConvertTicks};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
-use kernel::utilities::leasable_buffer::LeasableMutableBuffer;
+use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::ErrorCode;
 
 /// This trait must be implemented by upper layers in order to receive
@@ -89,7 +89,7 @@ pub trait IP6Sender<'a> {
         &self,
         dst: IPAddr,
         transport_header: TransportHeader,
-        payload: &LeasableMutableBuffer<'static, u8>,
+        payload: &SubSliceMut<'static, u8>,
         net_cap: &'static NetworkCapability,
     ) -> Result<(), ErrorCode>;
 }
@@ -135,7 +135,7 @@ impl<'a, A: time::Alarm<'a>> IP6Sender<'a> for IP6SendStruct<'a, A> {
         &self,
         dst: IPAddr,
         transport_header: TransportHeader,
-        payload: &LeasableMutableBuffer<'static, u8>,
+        payload: &SubSliceMut<'static, u8>,
         net_cap: &'static NetworkCapability,
     ) -> Result<(), ErrorCode> {
         if !net_cap.remote_addr_valid(dst, self.ip_vis) {
@@ -183,7 +183,7 @@ impl<'a, A: time::Alarm<'a>> IP6SendStruct<'a, A> {
         &self,
         dst_addr: IPAddr,
         transport_header: TransportHeader,
-        payload: &LeasableMutableBuffer<'static, u8>,
+        payload: &SubSliceMut<'static, u8>,
     ) {
         self.ip6_packet.map_or_else(
             || {

--- a/capsules/extra/src/net/udp/udp_send.rs
+++ b/capsules/extra/src/net/udp/udp_send.rs
@@ -32,7 +32,7 @@ use kernel::capabilities::UdpDriverCapability;
 use kernel::collections::list::{List, ListLink, ListNode};
 use kernel::debug;
 use kernel::utilities::cells::{MapCell, OptionalCell};
-use kernel::utilities::leasable_buffer::LeasableMutableBuffer;
+use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::ErrorCode;
 
 pub struct MuxUdpSender<'a, T: IP6Sender<'a>> {
@@ -153,7 +153,7 @@ impl<'a, T: IP6Sender<'a>> IP6SendClient for MuxUdpSender<'a, T> {
 /// has completed sending the requested packet. Note that the
 /// `UDPSender::set_client` method must be called to set the client.
 pub trait UDPSendClient {
-    fn send_done(&self, result: Result<(), ErrorCode>, dgram: LeasableMutableBuffer<'static, u8>);
+    fn send_done(&self, result: Result<(), ErrorCode>, dgram: SubSliceMut<'static, u8>);
 }
 
 /// This trait represents the bulk of the UDP functionality. The two
@@ -187,9 +187,9 @@ pub trait UDPSender<'a> {
         dest: IPAddr,
         dst_port: u16,
         //src_port: u16,
-        buf: LeasableMutableBuffer<'static, u8>,
+        buf: SubSliceMut<'static, u8>,
         net_cap: &'static NetworkCapability,
-    ) -> Result<(), LeasableMutableBuffer<'static, u8>>;
+    ) -> Result<(), SubSliceMut<'static, u8>>;
 
     /// This function is identical to `send_to()` except that it takes in
     /// an explicit src_port instead of a binding. This allows it to be used
@@ -209,10 +209,10 @@ pub trait UDPSender<'a> {
         dest: IPAddr,
         dst_port: u16,
         src_port: u16,
-        buf: LeasableMutableBuffer<'static, u8>,
+        buf: SubSliceMut<'static, u8>,
         driver_send_cap: &dyn UdpDriverCapability,
         net_cap: &'static NetworkCapability,
-    ) -> Result<(), LeasableMutableBuffer<'static, u8>>;
+    ) -> Result<(), SubSliceMut<'static, u8>>;
 
     /// This function constructs an IP packet from the completed `UDPHeader`
     /// and buffer, and sends it to the provided IP address
@@ -229,9 +229,9 @@ pub trait UDPSender<'a> {
         &'a self,
         dest: IPAddr,
         udp_header: UDPHeader,
-        buf: LeasableMutableBuffer<'static, u8>,
+        buf: SubSliceMut<'static, u8>,
         net_cap: &'static NetworkCapability,
-    ) -> Result<(), LeasableMutableBuffer<'static, u8>>;
+    ) -> Result<(), SubSliceMut<'static, u8>>;
 
     fn get_binding(&self) -> Option<UdpPortBindingTx>;
 
@@ -247,7 +247,7 @@ pub struct UDPSendStruct<'a, T: IP6Sender<'a>> {
     udp_mux_sender: &'a MuxUdpSender<'a, T>,
     client: OptionalCell<&'a dyn UDPSendClient>,
     next: ListLink<'a, UDPSendStruct<'a, T>>,
-    tx_buffer: MapCell<LeasableMutableBuffer<'static, u8>>,
+    tx_buffer: MapCell<SubSliceMut<'static, u8>>,
     next_dest: Cell<IPAddr>,
     next_th: OptionalCell<TransportHeader>,
     binding: MapCell<UdpPortBindingTx>,
@@ -272,9 +272,9 @@ impl<'a, T: IP6Sender<'a>> UDPSender<'a> for UDPSendStruct<'a, T> {
         &'a self,
         dest: IPAddr,
         dst_port: u16,
-        buf: LeasableMutableBuffer<'static, u8>,
+        buf: SubSliceMut<'static, u8>,
         net_cap: &'static NetworkCapability,
-    ) -> Result<(), LeasableMutableBuffer<'static, u8>> {
+    ) -> Result<(), SubSliceMut<'static, u8>> {
         let mut udp_header = UDPHeader::new();
         udp_header.set_dst_port(dst_port);
         match self.binding.take() {
@@ -303,10 +303,10 @@ impl<'a, T: IP6Sender<'a>> UDPSender<'a> for UDPSendStruct<'a, T> {
         dest: IPAddr,
         dst_port: u16,
         src_port: u16,
-        buf: LeasableMutableBuffer<'static, u8>,
+        buf: SubSliceMut<'static, u8>,
         _driver_send_cap: &dyn UdpDriverCapability,
         net_cap: &'static NetworkCapability,
-    ) -> Result<(), LeasableMutableBuffer<'static, u8>> {
+    ) -> Result<(), SubSliceMut<'static, u8>> {
         let mut udp_header = UDPHeader::new();
         udp_header.set_dst_port(dst_port);
         udp_header.set_src_port(src_port);
@@ -317,9 +317,9 @@ impl<'a, T: IP6Sender<'a>> UDPSender<'a> for UDPSendStruct<'a, T> {
         &'a self,
         dest: IPAddr,
         mut udp_header: UDPHeader,
-        buf: LeasableMutableBuffer<'static, u8>,
+        buf: SubSliceMut<'static, u8>,
         net_cap: &'static NetworkCapability,
-    ) -> Result<(), LeasableMutableBuffer<'static, u8>> {
+    ) -> Result<(), SubSliceMut<'static, u8>> {
         udp_header.set_len((buf.len() + udp_header.get_hdr_size()) as u16);
         let transport_header = TransportHeader::UDP(udp_header);
         self.tx_buffer.replace(buf);

--- a/capsules/extra/src/sha.rs
+++ b/capsules/extra/src/sha.rs
@@ -55,8 +55,8 @@ use kernel::hil::digest;
 use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
-use kernel::utilities::leasable_buffer::LeasableBuffer;
-use kernel::utilities::leasable_buffer::LeasableMutableBuffer;
+use kernel::utilities::leasable_buffer::SubSlice;
+use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::{ErrorCode, ProcessId};
 
 enum ShaOperation {
@@ -149,7 +149,7 @@ impl<
                                 });
 
                                 // Add the data from the static buffer to the HMAC
-                                let mut lease_buf = LeasableMutableBuffer::new(
+                                let mut lease_buf = SubSliceMut::new(
                                     self.data_buffer.take().ok_or(ErrorCode::RESERVE)?,
                                 );
                                 lease_buf.slice(0..static_buffer_len);
@@ -233,13 +233,9 @@ impl<
 {
     // Because data needs to be copied from a userspace buffer into a kernel (RAM) one,
     // we always pass mut data; this callback should never be invoked.
-    fn add_data_done(&self, _result: Result<(), ErrorCode>, _data: LeasableBuffer<'static, u8>) {}
+    fn add_data_done(&self, _result: Result<(), ErrorCode>, _data: SubSlice<'static, u8>) {}
 
-    fn add_mut_data_done(
-        &self,
-        _result: Result<(), ErrorCode>,
-        data: LeasableMutableBuffer<'static, u8>,
-    ) {
+    fn add_mut_data_done(&self, _result: Result<(), ErrorCode>, data: SubSliceMut<'static, u8>) {
         self.processid.map(move |id| {
             self.apps
                 .enter(id, move |app, kernel_data| {
@@ -296,8 +292,7 @@ impl<
                             // Update the amount of data copied
                             self.data_copied.set(copied_data + static_buffer_len);
 
-                            let mut lease_buf =
-                                LeasableMutableBuffer::new(self.data_buffer.take().unwrap());
+                            let mut lease_buf = SubSliceMut::new(self.data_buffer.take().unwrap());
 
                             // Add the data from the static buffer to the HMAC
                             if data_len < (copied_data + static_buffer_len) {

--- a/capsules/extra/src/sha256.rs
+++ b/capsules/extra/src/sha256.rs
@@ -17,9 +17,9 @@ use kernel::hil::digest::{Client, ClientData, ClientHash, ClientVerify};
 use kernel::hil::digest::{ClientDataHash, ClientDataVerify, DigestDataHash, DigestDataVerify};
 use kernel::hil::digest::{Digest, DigestData, DigestHash, DigestVerify};
 use kernel::utilities::cells::{MapCell, OptionalCell};
-use kernel::utilities::leasable_buffer::LeasableBuffer;
-use kernel::utilities::leasable_buffer::LeasableBufferDynamic;
-use kernel::utilities::leasable_buffer::LeasableMutableBuffer;
+use kernel::utilities::leasable_buffer::SubSlice;
+use kernel::utilities::leasable_buffer::SubSliceMut;
+use kernel::utilities::leasable_buffer::SubSliceMutImmut;
 use kernel::ErrorCode;
 
 #[derive(Clone, Copy, PartialEq)]
@@ -52,7 +52,7 @@ pub struct Sha256Software<'a> {
     state: Cell<State>,
 
     client: OptionalCell<&'a dyn Client<SHA_256_OUTPUT_LEN_BYTES>>,
-    input_data: OptionalCell<LeasableBufferDynamic<'static, u8>>,
+    input_data: OptionalCell<SubSliceMutImmut<'static, u8>>,
     data_buffer: MapCell<[u8; SHA_BLOCK_LEN_BYTES]>,
     buffered_length: Cell<usize>,
     total_length: Cell<usize>,
@@ -299,14 +299,14 @@ impl<'a> Sha256Software<'a> {
 impl<'a> DigestData<'a, 32> for Sha256Software<'a> {
     fn add_data(
         &self,
-        data: LeasableBuffer<'static, u8>,
-    ) -> Result<(), (ErrorCode, LeasableBuffer<'static, u8>)> {
+        data: SubSlice<'static, u8>,
+    ) -> Result<(), (ErrorCode, SubSlice<'static, u8>)> {
         if self.busy() {
             Err((ErrorCode::BUSY, data))
         } else {
             self.state.set(State::Data);
             self.deferred_call.set();
-            self.input_data.set(LeasableBufferDynamic::Immutable(data));
+            self.input_data.set(SubSliceMutImmut::Immutable(data));
             self.compute_sha256();
             Ok(())
         }
@@ -314,14 +314,14 @@ impl<'a> DigestData<'a, 32> for Sha256Software<'a> {
 
     fn add_mut_data(
         &self,
-        data: LeasableMutableBuffer<'static, u8>,
-    ) -> Result<(), (ErrorCode, LeasableMutableBuffer<'static, u8>)> {
+        data: SubSliceMut<'static, u8>,
+    ) -> Result<(), (ErrorCode, SubSliceMut<'static, u8>)> {
         if self.busy() {
             Err((ErrorCode::BUSY, data))
         } else {
             self.state.set(State::Data);
             self.deferred_call.set();
-            self.input_data.set(LeasableBufferDynamic::Mutable(data));
+            self.input_data.set(SubSliceMutImmut::Mutable(data));
             self.compute_sha256();
             Ok(())
         }
@@ -424,12 +424,12 @@ impl<'a> DeferredCallClient for Sha256Software<'a> {
                 let data = self.input_data.take().unwrap();
                 self.state.set(State::Idle);
                 match data {
-                    LeasableBufferDynamic::Mutable(buffer) => {
+                    SubSliceMutImmut::Mutable(buffer) => {
                         self.client.map(|client| {
                             client.add_mut_data_done(Ok(()), buffer);
                         });
                     }
-                    LeasableBufferDynamic::Immutable(buffer) => {
+                    SubSliceMutImmut::Immutable(buffer) => {
                         self.client.map(|client| {
                             client.add_data_done(Ok(()), buffer);
                         });
@@ -450,12 +450,12 @@ impl<'a> DeferredCallClient for Sha256Software<'a> {
                 self.clear_data();
                 let data = self.input_data.take().unwrap();
                 match data {
-                    LeasableBufferDynamic::Mutable(buffer) => {
+                    SubSliceMutImmut::Mutable(buffer) => {
                         self.client.map(|client| {
                             client.add_mut_data_done(Err(ErrorCode::CANCEL), buffer);
                         });
                     }
-                    LeasableBufferDynamic::Immutable(buffer) => {
+                    SubSliceMutImmut::Immutable(buffer) => {
                         self.client.map(|client| {
                             client.add_data_done(Err(ErrorCode::CANCEL), buffer);
                         });

--- a/capsules/extra/src/sip_hash.rs
+++ b/capsules/extra/src/sip_hash.rs
@@ -32,9 +32,9 @@ use core::{cmp, mem};
 use kernel::deferred_call::{DeferredCall, DeferredCallClient};
 use kernel::hil::hasher::{Client, Hasher, SipHash};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
-use kernel::utilities::leasable_buffer::LeasableBuffer;
-use kernel::utilities::leasable_buffer::LeasableBufferDynamic;
-use kernel::utilities::leasable_buffer::LeasableMutableBuffer;
+use kernel::utilities::leasable_buffer::SubSlice;
+use kernel::utilities::leasable_buffer::SubSliceMut;
+use kernel::utilities::leasable_buffer::SubSliceMutImmut;
 use kernel::ErrorCode;
 
 pub struct SipHasher24<'a> {
@@ -46,7 +46,7 @@ pub struct SipHasher24<'a> {
     complete_deferred_call: Cell<bool>,
     deferred_call: DeferredCall,
 
-    data_buffer: Cell<Option<LeasableBufferDynamic<'static, u8>>>,
+    data_buffer: Cell<Option<SubSliceMutImmut<'static, u8>>>,
     out_buffer: TakeCell<'static, [u8; 8]>,
 }
 

--- a/capsules/extra/src/sip_hash.rs
+++ b/capsules/extra/src/sip_hash.rs
@@ -189,8 +189,8 @@ impl<'a> Hasher<'a, 8> for SipHasher24<'a> {
 
     fn add_data(
         &self,
-        data: LeasableBuffer<'static, u8>,
-    ) -> Result<usize, (ErrorCode, LeasableBuffer<'static, u8>)> {
+        data: SubSlice<'static, u8>,
+    ) -> Result<usize, (ErrorCode, SubSlice<'static, u8>)> {
         let length = data.len();
         let mut hasher = self.hasher.get();
 
@@ -235,7 +235,7 @@ impl<'a> Hasher<'a, 8> for SipHasher24<'a> {
 
         self.hasher.set(hasher);
         self.data_buffer
-            .set(Some(LeasableBufferDynamic::Immutable(data)));
+            .set(Some(SubSliceMutImmut::Immutable(data)));
 
         self.add_data_deferred_call.set(true);
         self.deferred_call.set();
@@ -245,8 +245,8 @@ impl<'a> Hasher<'a, 8> for SipHasher24<'a> {
 
     fn add_mut_data(
         &self,
-        mut data: LeasableMutableBuffer<'static, u8>,
-    ) -> Result<usize, (ErrorCode, LeasableMutableBuffer<'static, u8>)> {
+        mut data: SubSliceMut<'static, u8>,
+    ) -> Result<usize, (ErrorCode, SubSliceMut<'static, u8>)> {
         let length = data.len();
         let mut hasher = self.hasher.get();
 
@@ -290,8 +290,7 @@ impl<'a> Hasher<'a, 8> for SipHasher24<'a> {
         hasher.ntail = left;
 
         self.hasher.set(hasher);
-        self.data_buffer
-            .set(Some(LeasableBufferDynamic::Mutable(data)));
+        self.data_buffer.set(Some(SubSliceMutImmut::Mutable(data)));
 
         self.add_data_deferred_call.set(true);
         self.deferred_call.set();
@@ -362,8 +361,8 @@ impl<'a> DeferredCallClient for SipHasher24<'a> {
 
             self.client.map(|client| {
                 self.data_buffer.take().map(|buffer| match buffer {
-                    LeasableBufferDynamic::Immutable(b) => client.add_data_done(Ok(()), b),
-                    LeasableBufferDynamic::Mutable(b) => client.add_mut_data_done(Ok(()), b),
+                    SubSliceMutImmut::Immutable(b) => client.add_data_done(Ok(()), b),
+                    SubSliceMutImmut::Mutable(b) => client.add_mut_data_done(Ok(()), b),
                 });
             });
         }

--- a/capsules/extra/src/test/crc.rs
+++ b/capsules/extra/src/test/crc.rs
@@ -7,7 +7,7 @@
 use kernel::debug;
 use kernel::hil::crc::{Client, Crc, CrcAlgorithm, CrcOutput};
 use kernel::utilities::cells::TakeCell;
-use kernel::utilities::leasable_buffer::LeasableMutableBuffer;
+use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::ErrorCode;
 
 pub struct TestCrc<'a, C: 'a> {
@@ -29,8 +29,7 @@ impl<'a, C: Crc<'a>> TestCrc<'a, C> {
             debug!("CrcTest ERROR: failed to set algorithm to Crc32: {:?}", res);
             return;
         }
-        let leasable: LeasableMutableBuffer<'static, u8> =
-            LeasableMutableBuffer::new(self.data.take().unwrap());
+        let leasable: SubSliceMut<'static, u8> = SubSliceMut::new(self.data.take().unwrap());
 
         let res = self.crc.input(leasable);
         if let Err((error, _buffer)) = res {
@@ -47,11 +46,7 @@ impl<'a, C: Crc<'a>> TestCrc<'a, C> {
 }
 
 impl<'a, C: Crc<'a>> Client for TestCrc<'a, C> {
-    fn input_done(
-        &self,
-        result: Result<(), ErrorCode>,
-        buffer: LeasableMutableBuffer<'static, u8>,
-    ) {
+    fn input_done(&self, result: Result<(), ErrorCode>, buffer: SubSliceMut<'static, u8>) {
         if result.is_err() {
             debug!("CrcTest ERROR: failed to process input: {:?}", result);
             return;

--- a/capsules/extra/src/test/hmac_sha256.rs
+++ b/capsules/extra/src/test/hmac_sha256.rs
@@ -11,8 +11,8 @@ use kernel::hil::digest;
 use kernel::hil::digest::HmacSha256;
 use kernel::hil::digest::{DigestData, DigestDataHash, DigestHash};
 use kernel::utilities::cells::TakeCell;
-use kernel::utilities::leasable_buffer::LeasableBuffer;
-use kernel::utilities::leasable_buffer::LeasableMutableBuffer;
+use kernel::utilities::leasable_buffer::SubSlice;
+use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::ErrorCode;
 
 pub struct TestHmacSha256 {
@@ -48,7 +48,7 @@ impl TestHmacSha256 {
             panic!("HmacSha256Test: failed to set key: {:?}", r);
         }
         let data = self.data.take().unwrap();
-        let buffer = LeasableMutableBuffer::new(data);
+        let buffer = SubSliceMut::new(data);
         let r = self.hmac.add_mut_data(buffer);
         if r.is_err() {
             panic!("HmacSha256Test: failed to add data: {:?}", r);
@@ -57,15 +57,11 @@ impl TestHmacSha256 {
 }
 
 impl digest::ClientData<32> for TestHmacSha256 {
-    fn add_data_done(&self, _result: Result<(), ErrorCode>, _data: LeasableBuffer<'static, u8>) {
+    fn add_data_done(&self, _result: Result<(), ErrorCode>, _data: SubSlice<'static, u8>) {
         unimplemented!()
     }
 
-    fn add_mut_data_done(
-        &self,
-        _result: Result<(), ErrorCode>,
-        data: LeasableMutableBuffer<'static, u8>,
-    ) {
+    fn add_mut_data_done(&self, _result: Result<(), ErrorCode>, data: SubSliceMut<'static, u8>) {
         self.data.replace(data.take());
 
         let r = self.hmac.run(self.digest.take().unwrap());

--- a/capsules/extra/src/test/siphash24.rs
+++ b/capsules/extra/src/test/siphash24.rs
@@ -48,16 +48,12 @@ impl TestSipHash24 {
 }
 
 impl Client<8> for TestSipHash24 {
-    fn add_mut_data_done(
-        &self,
-        _result: Result<(), ErrorCode>,
-        data: LeasableMutableBuffer<'static, u8>,
-    ) {
+    fn add_mut_data_done(&self, _result: Result<(), ErrorCode>, data: SubSliceMut<'static, u8>) {
         self.data.replace(data.take());
         self.hasher.run(self.hash.take().unwrap()).unwrap();
     }
 
-    fn add_data_done(&self, _result: Result<(), ErrorCode>, _data: LeasableBuffer<'static, u8>) {}
+    fn add_data_done(&self, _result: Result<(), ErrorCode>, _data: SubSlice<'static, u8>) {}
 
     fn hash_done(&self, _result: Result<(), ErrorCode>, digest: &'static mut [u8; 8]) {
         debug!("hashed result:   {:?}", digest);

--- a/capsules/extra/src/test/siphash24.rs
+++ b/capsules/extra/src/test/siphash24.rs
@@ -11,8 +11,7 @@ use crate::sip_hash::SipHasher24;
 use kernel::debug;
 use kernel::hil::hasher::{Client, Hasher};
 use kernel::utilities::cells::TakeCell;
-use kernel::utilities::leasable_buffer::LeasableBuffer;
-use kernel::utilities::leasable_buffer::LeasableMutableBuffer;
+use kernel::utilities::leasable_buffer::{SubSlice, SubSliceMut};
 use kernel::ErrorCode;
 
 pub struct TestSipHash24 {
@@ -40,7 +39,7 @@ impl TestSipHash24 {
     pub fn run(&'static self) {
         self.hasher.set_client(self);
         let data = self.data.take().unwrap();
-        let buffer = LeasableMutableBuffer::new(data);
+        let buffer = SubSliceMut::new(data);
         let r = self.hasher.add_mut_data(buffer);
         if r.is_err() {
             panic!("SipHash24Test: failed to add data: {:?}", r);

--- a/capsules/extra/src/tickv.rs
+++ b/capsules/extra/src/tickv.rs
@@ -41,8 +41,7 @@ use kernel::hil::flash::{self, Flash};
 use kernel::hil::hasher::{self, Hasher};
 use kernel::hil::kv_system::{self, KVSystem};
 use kernel::utilities::cells::{MapCell, OptionalCell, TakeCell};
-use kernel::utilities::leasable_buffer::LeasableBuffer;
-use kernel::utilities::leasable_buffer::LeasableMutableBuffer;
+use kernel::utilities::leasable_buffer::{SubSlice, SubSliceMut};
 use kernel::ErrorCode;
 use tickv::{self, AsyncTicKV};
 

--- a/chips/lowrisc/src/hmac.rs
+++ b/chips/lowrisc/src/hmac.rs
@@ -9,9 +9,9 @@ use core::ops::Index;
 use kernel::hil;
 use kernel::hil::digest::{self, DigestData, DigestHash};
 use kernel::utilities::cells::OptionalCell;
-use kernel::utilities::leasable_buffer::LeasableBuffer;
-use kernel::utilities::leasable_buffer::LeasableBufferDynamic;
-use kernel::utilities::leasable_buffer::LeasableMutableBuffer;
+use kernel::utilities::leasable_buffer::SubSlice;
+use kernel::utilities::leasable_buffer::SubSliceMut;
+use kernel::utilities::leasable_buffer::SubSliceMutImmut;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{
     register_bitfields, register_structs, ReadOnly, ReadWrite, WriteOnly,
@@ -78,7 +78,7 @@ register_bitfields![u32,
 pub struct Hmac<'a> {
     registers: StaticRef<HmacRegisters>,
     client: OptionalCell<&'a dyn hil::digest::Client<32>>,
-    data: Cell<Option<LeasableBufferDynamic<'static, u8>>>,
+    data: Cell<Option<SubSliceMutImmut<'static, u8>>>,
     verify: Cell<bool>,
     digest: Cell<Option<&'static mut [u8; 32]>>,
     cancelled: Cell<bool>,
@@ -128,25 +128,25 @@ impl Hmac<'_> {
     // is completely processed.
     fn data_progress(&self) -> bool {
         self.data.take().map_or(false, |buf| match buf {
-            LeasableBufferDynamic::Immutable(mut b) => {
+            SubSliceMutImmut::Immutable(mut b) => {
                 if b.len() == 0 {
-                    self.data.set(Some(LeasableBufferDynamic::Immutable(b)));
+                    self.data.set(Some(SubSliceMutImmut::Immutable(b)));
                     false
                 } else {
                     let count = self.process(&b, b.len());
                     b.slice(count..);
-                    self.data.set(Some(LeasableBufferDynamic::Immutable(b)));
+                    self.data.set(Some(SubSliceMutImmut::Immutable(b)));
                     true
                 }
             }
-            LeasableBufferDynamic::Mutable(mut b) => {
+            SubSliceMutImmut::Mutable(mut b) => {
                 if b.len() == 0 {
-                    self.data.set(Some(LeasableBufferDynamic::Mutable(b)));
+                    self.data.set(Some(SubSliceMutImmut::Mutable(b)));
                     false
                 } else {
                     let count = self.process(&b, b.len());
                     b.slice(count..);
-                    self.data.set(Some(LeasableBufferDynamic::Mutable(b)));
+                    self.data.set(Some(SubSliceMutImmut::Mutable(b)));
                     true
                 }
             }
@@ -229,8 +229,8 @@ impl Hmac<'_> {
                 // False means we are done
                 self.client.map(move |client| {
                     self.data.take().map(|buf| match buf {
-                        LeasableBufferDynamic::Mutable(b) => client.add_mut_data_done(rval, b),
-                        LeasableBufferDynamic::Immutable(b) => client.add_data_done(rval, b),
+                        SubSliceMutImmut::Mutable(b) => client.add_mut_data_done(rval, b),
+                        SubSliceMutImmut::Immutable(b) => client.add_data_done(rval, b),
                     })
                 });
                 // Make sure we don't get any more FIFO empty interrupts
@@ -263,13 +263,13 @@ impl Hmac<'_> {
 impl<'a> hil::digest::DigestData<'a, 32> for Hmac<'a> {
     fn add_data(
         &self,
-        data: LeasableBuffer<'static, u8>,
-    ) -> Result<(), (ErrorCode, LeasableBuffer<'static, u8>)> {
+        data: SubSlice<'static, u8>,
+    ) -> Result<(), (ErrorCode, SubSlice<'static, u8>)> {
         if self.busy.get() {
             Err((ErrorCode::BUSY, data))
         } else {
             self.busy.set(true);
-            self.data.set(Some(LeasableBufferDynamic::Immutable(data)));
+            self.data.set(Some(SubSliceMutImmut::Immutable(data)));
 
             let regs = self.registers;
             regs.cmd.modify(CMD::START::SET);
@@ -289,13 +289,13 @@ impl<'a> hil::digest::DigestData<'a, 32> for Hmac<'a> {
 
     fn add_mut_data(
         &self,
-        data: LeasableMutableBuffer<'static, u8>,
-    ) -> Result<(), (ErrorCode, LeasableMutableBuffer<'static, u8>)> {
+        data: SubSliceMut<'static, u8>,
+    ) -> Result<(), (ErrorCode, SubSliceMut<'static, u8>)> {
         if self.busy.get() {
             Err((ErrorCode::BUSY, data))
         } else {
             self.busy.set(true);
-            self.data.set(Some(LeasableBufferDynamic::Mutable(data)));
+            self.data.set(Some(SubSliceMutImmut::Mutable(data)));
 
             let regs = self.registers;
             regs.cmd.modify(CMD::START::SET);

--- a/chips/sam4l/src/crccu.rs
+++ b/chips/sam4l/src/crccu.rs
@@ -57,7 +57,7 @@ use core::cell::Cell;
 use kernel::deferred_call::{DeferredCall, DeferredCallClient};
 use kernel::hil::crc::{Client, Crc, CrcAlgorithm, CrcOutput};
 use kernel::utilities::cells::OptionalCell;
-use kernel::utilities::leasable_buffer::LeasableMutableBuffer;
+use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 use kernel::utilities::registers::{
     register_bitfields, FieldValue, InMemoryRegister, ReadOnly, ReadWrite, WriteOnly,
@@ -334,7 +334,7 @@ impl Crccu<'_> {
                 // Disable the unit
                 self.registers.mr.write(Mode::ENABLE::Disabled);
 
-                // Recover the window into the LeasableMutableBuffer
+                // Recover the window into the SubSliceMut
                 let window_addr = self.descriptor.addr.get();
                 let window_len = TCR(self.descriptor.ctrl.get()).get_btsize() as usize;
 
@@ -352,7 +352,7 @@ impl Crccu<'_> {
                 // Reconstruct the leasable buffer from stored
                 // information and slice into the proper window
                 let (full_buffer_addr, full_buffer_len) = self.current_full_buffer.get();
-                let mut data = LeasableMutableBuffer::<'static, u8>::new(unsafe {
+                let mut data = SubSliceMut::<'static, u8>::new(unsafe {
                     core::slice::from_raw_parts_mut(full_buffer_addr, full_buffer_len)
                 });
 
@@ -435,8 +435,8 @@ impl<'a> Crc<'a> for Crccu<'a> {
 
     fn input(
         &self,
-        mut data: LeasableMutableBuffer<'static, u8>,
-    ) -> Result<(), (ErrorCode, LeasableMutableBuffer<'static, u8>)> {
+        mut data: SubSliceMut<'static, u8>,
+    ) -> Result<(), (ErrorCode, SubSliceMut<'static, u8>)> {
         let algorithm = if let Some(algorithm) = self.algorithm.get() {
             algorithm
         } else {
@@ -484,13 +484,13 @@ impl<'a> Crc<'a> for Crccu<'a> {
         // Configure the data transfer descriptor
         //
         // The data length is guaranteed to be <= u16::MAX by the
-        // above LeasableMutableBuffer resizing mechanism
+        // above SubSliceMut resizing mechanism
         self.descriptor.addr.set(data.as_ptr() as u32);
         self.descriptor.ctrl.set(ctrl.0);
         self.descriptor.crc.set(0); // this is the CRC compare field, not used
 
         // Prior to starting the DMA operation, drop the
-        // LeasableBuffer slice. Otherwise we violate Rust's mutable
+        // SubSlice slice. Otherwise we violate Rust's mutable
         // aliasing rules.
         let full_slice = data.take();
         let full_slice_ptr_len = (full_slice.as_mut_ptr(), full_slice.len());

--- a/doc/reference/trd-digest.md
+++ b/doc/reference/trd-digest.md
@@ -79,8 +79,8 @@ to compute a digest is a large overhead. Furthermore, the data input can
 be large (tens or hundreds of kilobytes). Therefore `DigestData` and 
 `ClientData` support both mutable and immutable inputs.
 
-Clients provide input to `DigestData` through the `LeasableBuffer`
-and `LeasableMutableBuffer` types. These allow a client to ask a
+Clients provide input to `DigestData` through the `SubSlice`
+and `SubSliceMut` types. These allow a client to ask a
 digest engine to compute a digest over a subset of their data, e.g. to
 exclude the area where the digest that will be compared against is stored. 
 These types have a source slice and maintain an active range over that slice.
@@ -90,10 +90,10 @@ entire slice.
 ```rust
 pub trait DigestData<'a, const L: usize> {
     fn set_data_client(&'a self, client: &'a dyn ClientData<'a, L>);
-    fn add_data(&self, data: LeasableBuffer<'static, u8>) 
-       -> Result<(), (ErrorCode, LeasableBuffer<'static, u8>)>;
-    fn add_mut_data(&self, data: LeasableMutableBuffer<'static, u8>)
-       -> Result<(), (ErrorCode, LeasableMutableBuffer<'static, u8>)>;
+    fn add_data(&self, data: SubSlice<'static, u8>) 
+       -> Result<(), (ErrorCode, SubSlice<'static, u8>)>;
+    fn add_mut_data(&self, data: SubSliceMut<'static, u8>)
+       -> Result<(), (ErrorCode, SubSliceMut<'static, u8>)>;
     fn clear_data(&self);
 }
 ```
@@ -112,11 +112,11 @@ until a completion callback delivered through `ClientData`.
 
 ```rust
 pub trait ClientData<'a, const L: usize> {
-    fn add_data_done(&'a self, result: Result<(), ErrorCode>, data: LeasableBuffer<'static, u8>);
+    fn add_data_done(&'a self, result: Result<(), ErrorCode>, data: SubSlice<'static, u8>);
     fn add_mut_data_done(
         &'a self,
         result: Result<(), ErrorCode>,
-        data: LeasableMutableBuffer<'static, u8>,
+        data: SubSliceMut<'static, u8>,
     );
 }
 ```

--- a/kernel/src/hil/crc.rs
+++ b/kernel/src/hil/crc.rs
@@ -4,7 +4,7 @@
 
 //! Interface for CRC computation.
 
-use crate::utilities::leasable_buffer::LeasableMutableBuffer;
+use crate::utilities::leasable_buffer::SubSliceMut;
 use crate::ErrorCode;
 
 /// Client for CRC algorithm implementations
@@ -15,7 +15,7 @@ pub trait Client {
     /// Called when the current data chunk has been processed by the
     /// CRC engine. Further data may be supplied when this callback is
     /// received.
-    fn input_done(&self, result: Result<(), ErrorCode>, buffer: LeasableMutableBuffer<'static, u8>);
+    fn input_done(&self, result: Result<(), ErrorCode>, buffer: SubSliceMut<'static, u8>);
 
     /// Called when the CRC computation is finished.
     fn crc_done(&self, result: Result<CrcOutput, ErrorCode>);
@@ -107,13 +107,13 @@ pub trait Crc<'a> {
     /// [`Client::input_done`] is called.
     ///
     /// The implementation may only read a part of the passed
-    /// [`LeasableMutableBuffer`]. It will return the bytes read and will
-    /// resize the returned [`LeasableMutableBuffer`] appropriately prior to
+    /// [`SubSliceMut`]. It will return the bytes read and will
+    /// resize the returned [`SubSliceMut`] appropriately prior to
     /// passing it back through [`Client::input_done`].
     fn input(
         &self,
-        data: LeasableMutableBuffer<'static, u8>,
-    ) -> Result<(), (ErrorCode, LeasableMutableBuffer<'static, u8>)>;
+        data: SubSliceMut<'static, u8>,
+    ) -> Result<(), (ErrorCode, SubSliceMut<'static, u8>)>;
 
     /// Request calculation of the CRC.
     ///

--- a/kernel/src/hil/hasher.rs
+++ b/kernel/src/hil/hasher.rs
@@ -18,7 +18,7 @@ pub trait Client<const L: usize> {
     /// data supplied to `add_data()`.
     /// The possible ErrorCodes are:
     ///    - SIZE: The size of the `data` buffer is invalid
-    fn add_data_done(&self, result: Result<(), ErrorCode>, data: LeasableBuffer<'static, u8>);
+    fn add_data_done(&self, result: Result<(), ErrorCode>, data: SubSlice<'static, u8>);
 
     /// This callback is called when the data has been added to the hash
     /// engine.
@@ -26,11 +26,7 @@ pub trait Client<const L: usize> {
     /// data supplied to `add_mut_data()`.
     /// The possible ErrorCodes are:
     ///    - SIZE: The size of the `data` buffer is invalid
-    fn add_mut_data_done(
-        &self,
-        result: Result<(), ErrorCode>,
-        data: LeasableMutableBuffer<'static, u8>,
-    );
+    fn add_mut_data_done(&self, result: Result<(), ErrorCode>, data: SubSliceMut<'static, u8>);
 
     /// This callback is called when a hash is computed.
     /// On error or success `hash` will contain a reference to the original

--- a/kernel/src/hil/hasher.rs
+++ b/kernel/src/hil/hasher.rs
@@ -4,8 +4,8 @@
 
 //! Interface for Hasher
 
-use crate::utilities::leasable_buffer::LeasableBuffer;
-use crate::utilities::leasable_buffer::LeasableMutableBuffer;
+use crate::utilities::leasable_buffer::SubSlice;
+use crate::utilities::leasable_buffer::SubSliceMut;
 use crate::ErrorCode;
 
 /// Implement this trait and use `set_client()` in order to receive callbacks.
@@ -63,8 +63,8 @@ pub trait Hasher<'a, const L: usize> {
     ///    - SIZE: The size of the `data` buffer is invalid
     fn add_data(
         &self,
-        data: LeasableBuffer<'static, u8>,
-    ) -> Result<usize, (ErrorCode, LeasableBuffer<'static, u8>)>;
+        data: SubSlice<'static, u8>,
+    ) -> Result<usize, (ErrorCode, SubSlice<'static, u8>)>;
 
     /// Add data to the hash block. This is the data that will be used
     /// for the hash function.
@@ -78,8 +78,8 @@ pub trait Hasher<'a, const L: usize> {
     ///    - SIZE: The size of the `data` buffer is invalid
     fn add_mut_data(
         &self,
-        data: LeasableMutableBuffer<'static, u8>,
-    ) -> Result<usize, (ErrorCode, LeasableMutableBuffer<'static, u8>)>;
+        data: SubSliceMut<'static, u8>,
+    ) -> Result<usize, (ErrorCode, SubSliceMut<'static, u8>)>;
 
     /// Request the implementation to generate a hash and stores the returned
     /// hash in the memory location specified.

--- a/kernel/src/hil/kv_system.rs
+++ b/kernel/src/hil/kv_system.rs
@@ -58,7 +58,7 @@
 //!    hil::flash
 //! ```
 
-use crate::utilities::leasable_buffer::LeasableMutableBuffer;
+use crate::utilities::leasable_buffer::SubSliceMut;
 use crate::ErrorCode;
 
 /// The type of keys, this should define the output size of the digest
@@ -77,7 +77,7 @@ pub trait Client<K: KeyType> {
     fn generate_key_complete(
         &self,
         result: Result<(), ErrorCode>,
-        unhashed_key: LeasableMutableBuffer<'static, u8>,
+        unhashed_key: SubSliceMut<'static, u8>,
         key_buf: &'static mut K,
     );
 
@@ -90,7 +90,7 @@ pub trait Client<K: KeyType> {
         &self,
         result: Result<(), ErrorCode>,
         key: &'static mut K,
-        value: LeasableMutableBuffer<'static, u8>,
+        value: SubSliceMut<'static, u8>,
     );
 
     /// This callback is called when the get_value operation completes.
@@ -102,7 +102,7 @@ pub trait Client<K: KeyType> {
         &self,
         result: Result<(), ErrorCode>,
         key: &'static mut K,
-        ret_buf: LeasableMutableBuffer<'static, u8>,
+        ret_buf: SubSliceMut<'static, u8>,
     );
 
     /// This callback is called when the invalidate_key operation completes.
@@ -133,12 +133,12 @@ pub trait KVSystem<'a> {
     /// On error the unhashed_key, key_buf and `Result<(), ErrorCode>` will be returned.
     fn generate_key(
         &self,
-        unhashed_key: LeasableMutableBuffer<'static, u8>,
+        unhashed_key: SubSliceMut<'static, u8>,
         key_buf: &'static mut Self::K,
     ) -> Result<
         (),
         (
-            LeasableMutableBuffer<'static, u8>,
+            SubSliceMut<'static, u8>,
             &'static mut Self::K,
             Result<(), ErrorCode>,
         ),
@@ -166,12 +166,12 @@ pub trait KVSystem<'a> {
     fn append_key(
         &self,
         key: &'static mut Self::K,
-        value: LeasableMutableBuffer<'static, u8>,
+        value: SubSliceMut<'static, u8>,
     ) -> Result<
         (),
         (
             &'static mut Self::K,
-            LeasableMutableBuffer<'static, u8>,
+            SubSliceMut<'static, u8>,
             Result<(), ErrorCode>,
         ),
     >;
@@ -193,12 +193,12 @@ pub trait KVSystem<'a> {
     fn get_value(
         &self,
         key: &'static mut Self::K,
-        ret_buf: LeasableMutableBuffer<'static, u8>,
+        ret_buf: SubSliceMut<'static, u8>,
     ) -> Result<
         (),
         (
             &'static mut Self::K,
-            LeasableMutableBuffer<'static, u8>,
+            SubSliceMut<'static, u8>,
             Result<(), ErrorCode>,
         ),
     >;

--- a/kernel/src/process_checker/basic.rs
+++ b/kernel/src/process_checker/basic.rs
@@ -14,7 +14,7 @@ use crate::process_checker::{AppCredentialsChecker, AppUniqueness};
 use crate::process_checker::{CheckResult, Client, Compress};
 use crate::utilities::cells::OptionalCell;
 use crate::utilities::cells::TakeCell;
-use crate::utilities::leasable_buffer::{LeasableBuffer, LeasableMutableBuffer};
+use crate::utilities::leasable_buffer::{SubSlice, SubSliceMut};
 use crate::ErrorCode;
 use tock_tbf::types::TbfFooterV2Credentials;
 use tock_tbf::types::TbfFooterV2CredentialsType;
@@ -147,7 +147,7 @@ impl AppCredentialsChecker<'static> for AppCheckerSha256 {
                     }
                 });
                 self.hasher.clear_data();
-                match self.hasher.add_data(LeasableBuffer::new(binary)) {
+                match self.hasher.add_data(SubSlice::new(binary)) {
                     Ok(()) => Ok(()),
                     Err((e, b)) => Err((e, credentials, b.take())),
                 }
@@ -185,14 +185,9 @@ impl AppUniqueness for AppCheckerSha256 {
 }
 
 impl ClientData<32_usize> for AppCheckerSha256 {
-    fn add_mut_data_done(
-        &self,
-        _result: Result<(), ErrorCode>,
-        _data: LeasableMutableBuffer<'static, u8>,
-    ) {
-    }
+    fn add_mut_data_done(&self, _result: Result<(), ErrorCode>, _data: SubSliceMut<'static, u8>) {}
 
-    fn add_data_done(&self, result: Result<(), ErrorCode>, data: LeasableBuffer<'static, u8>) {
+    fn add_data_done(&self, result: Result<(), ErrorCode>, data: SubSlice<'static, u8>) {
         match result {
             Err(e) => panic!("Internal error during application binary checking. SHA256 engine threw error in adding data: {:?}", e),
             Ok(()) => {


### PR DESCRIPTION
### Pull Request Overview

This pull request renames the `LeasableBuffer` type to ~~`Splice`~~ `SubSlice` and the `LeasableMutableBuffer` type to ~~`SpliceMut`~~ `SubSliceMut`. This is part of #3504.

#### Why rename?

`kernel::leasable_buffer::LeasableBuffer` is clunky to use, hard to type/spell, and doesn't provide enough connection to why its useful. I propose that changing its name to be a riff on "slice" makes it easier to use throughout Tock, akin to how `TakeCell` is ubiquitous in Tock despite not being a Rust core type. 

#### ~~Why "splice"?~~

~~Mostly because it sounds like slice. It's also short and maybe catchy. Also, I think a splice (say in a wire) is reminiscent of a what a leasable buffer does: let you edit within a larger object.~~

#### Why "subslice"?

Discussion seemed to suggest this name was acceptable.

#### What about "leasable buffer"?

I propose we retain the "leasable buffer" terminology to describe the general idea of a buffer that decouples the underlying buffer memory from the current view of that buffer. `SubSlice` is just one concrete implementation of a leasable buffer. Much like how Roundnet is a game, while Spikeball is one company that sells supplies for the game.

### Testing Strategy

todo


### TODO or Help Wanted

So far I've only changed the content of the leasable_buffer.rs file. I want to get a sense of if we want to go forward with this before changing the name of the file and all current uses of `LeasableBuffer`.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
