### PR TITLE
boards: apollo3: Use helper function in main

### DIFF
--- a/boards/apollo3/lora_things_plus/src/main.rs
+++ b/boards/apollo3/lora_things_plus/src/main.rs
@@ -203,14 +203,15 @@ impl KernelResources<apollo3::chip::Apollo3<Apollo3DefaultPeripherals>> for LoRa
     }
 }
 
+// Ensure that `setup()` is never inlined
+// This helps reduce the stack frame, see https://github.com/tock/tock/issues/3518
+#[inline(never)]
 unsafe fn setup() -> (
     &'static kernel::Kernel,
     &'static LoRaThingsPlus,
     &'static apollo3::chip::Apollo3<Apollo3DefaultPeripherals>,
     &'static Apollo3DefaultPeripherals,
 ) {
-    apollo3::init();
-
     let peripherals = static_init!(Apollo3DefaultPeripherals, Apollo3DefaultPeripherals::new());
 
     // No need to statically allocate mcu/pwr/clk_ctrl because they are only used in main!
@@ -510,6 +511,8 @@ unsafe fn setup() -> (
 /// setup and RAM initialization.
 #[no_mangle]
 pub unsafe fn main() {
+    apollo3::init();
+
     #[cfg(test)]
     test_main();
 

--- a/boards/apollo3/redboard_artemis_nano/src/main.rs
+++ b/boards/apollo3/redboard_artemis_nano/src/main.rs
@@ -165,14 +165,15 @@ impl KernelResources<apollo3::chip::Apollo3<Apollo3DefaultPeripherals>> for Redb
     }
 }
 
+// Ensure that `setup()` is never inlined
+// This helps reduce the stack frame, see https://github.com/tock/tock/issues/3518
+#[inline(never)]
 unsafe fn setup() -> (
     &'static kernel::Kernel,
     &'static RedboardArtemisNano,
     &'static apollo3::chip::Apollo3<Apollo3DefaultPeripherals>,
     &'static Apollo3DefaultPeripherals,
 ) {
-    apollo3::init();
-
     let peripherals = static_init!(Apollo3DefaultPeripherals, Apollo3DefaultPeripherals::new());
 
     // No need to statically allocate mcu/pwr/clk_ctrl because they are only used in main!
@@ -431,6 +432,8 @@ unsafe fn setup() -> (
 /// setup and RAM initialization.
 #[no_mangle]
 pub unsafe fn main() {
+    apollo3::init();
+
     #[cfg(test)]
     test_main();
 

--- a/chips/apollo3/src/lib.rs
+++ b/chips/apollo3/src/lib.rs
@@ -74,7 +74,10 @@ pub static IRQS: [unsafe extern "C" fn(); 32] = [CortexM4::GENERIC_ISR; 32];
 #[cfg_attr(all(target_arch = "arm", target_os = "none"), used)]
 pub static PATCH: [unsafe extern "C" fn(); 16] = [unhandled_interrupt; 16];
 
+// The SVC call in this function means that we need to ensure it's inlined in
+// `main()` otherwise we end up with a clobbered stack.
 #[cfg(all(target_arch = "arm", target_os = "none"))]
+#[inline(always)]
 pub unsafe fn init() {
     use core::arch::asm;
     let cache_ctrl = crate::cachectrl::CacheCtrl::new();


### PR DESCRIPTION
### Pull Request Overview

Update to use a helper function in main to reduce the stack usage. This is to address the stack usage issue as described in https://github.com/tock/tock/issues/3518.

### Testing Strategy

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
