### PR TITLE
Add jlink to shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -14,7 +14,10 @@
 #  $ nix-shell
 #
 
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import <nixpkgs> {
+  config.allowUnfree = true;
+  config.segger-jlink.acceptLicense = true;
+} }:
 
 with builtins;
 let
@@ -95,6 +98,9 @@ in
 
       # --- CI support packages ---
       qemu
+
+      # --- Flashing tools ---
+      segger-jlink
     ];
 
     LD_LIBRARY_PATH="${stdenv.cc.cc.lib}/lib64:$LD_LIBRARY_PATH";


### PR DESCRIPTION
### Pull Request Overview

The nix shell config does not support jlink. It errors as so:
`FileNotFoundError: [Errno 2] No such file or directory: 'JLinkExe'`

I added a line users can edit to add it. 

### Testing Strategy

`make install` works. Added EULA accept as required by jlink.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
