### PR TITLE
Add TicKV to nrf52840dk

### DIFF
--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -68,6 +68,7 @@ pub mod segger_rtt;
 pub mod sha;
 pub mod sht3x;
 pub mod si7021;
+pub mod siphash;
 pub mod sound_pressure;
 pub mod spi;
 pub mod st77xx;

--- a/boards/components/src/siphash.rs
+++ b/boards/components/src/siphash.rs
@@ -1,0 +1,36 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2023.
+
+//! Components for SipHash hasher.
+
+use core::mem::MaybeUninit;
+use kernel::component::Component;
+use kernel::deferred_call::DeferredCallClient;
+
+// Setup static space for the objects.
+#[macro_export]
+macro_rules! siphasher24_component_static {
+    ($(,)?) => {{
+        kernel::static_buf!(capsules_extra::sip_hash::SipHasher24)
+    };};
+}
+
+pub struct Siphasher24Component {}
+
+impl Siphasher24Component {
+    pub fn new() -> Siphasher24Component {
+        Siphasher24Component {}
+    }
+}
+
+impl Component for Siphasher24Component {
+    type StaticInput = &'static mut MaybeUninit<capsules_extra::sip_hash::SipHasher24<'static>>;
+    type Output = &'static capsules_extra::sip_hash::SipHasher24<'static>;
+
+    fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        let sip_hash = s.write(capsules_extra::sip_hash::SipHasher24::new());
+        sip_hash.register();
+        sip_hash
+    }
+}

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -207,21 +207,24 @@ pub struct Platform {
     >,
     kv_driver: &'static capsules_extra::kv_driver::KVStoreDriver<
         'static,
-        capsules_extra::tickv::TicKVStore<
+        capsules_extra::kv_store::KVStore<
             'static,
-            capsules_extra::mx25r6435f::MX25R6435F<
+            capsules_extra::tickv::TicKVStore<
                 'static,
-                capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<
+                capsules_extra::mx25r6435f::MX25R6435F<
                     'static,
-                    nrf52840::spi::SPIM<'static>,
+                    capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<
+                        'static,
+                        nrf52840::spi::SPIM<'static>,
+                    >,
+                    nrf52840::gpio::GPIOPin<'static>,
+                    VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
                 >,
-                nrf52840::gpio::GPIOPin<'static>,
-                VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
+                capsules_extra::sip_hash::SipHasher24<'static>,
+                { capsules_extra::mx25r6435f::SECTOR_SIZE as usize },
             >,
-            capsules_extra::sip_hash::SipHasher24<'static>,
-            { capsules_extra::mx25r6435f::SECTOR_SIZE as usize },
+            [u8; 8],
         >,
-        [u8; 8],
     >,
     scheduler: &'static RoundRobinSched<'static>,
     systick: cortexm4::systick::SysTick,
@@ -797,19 +800,21 @@ pub unsafe fn main() {
         capsules_extra::kv_driver::DRIVER_NUM,
     )
     .finalize(components::kv_driver_component_static!(
-        capsules_extra::tickv::TicKVStore<
-            capsules_extra::mx25r6435f::MX25R6435F<
-                capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<
-                    'static,
-                    nrf52840::spi::SPIM,
+        capsules_extra::kv_store::KVStore<
+            capsules_extra::tickv::TicKVStore<
+                capsules_extra::mx25r6435f::MX25R6435F<
+                    capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<
+                        'static,
+                        nrf52840::spi::SPIM,
+                    >,
+                    nrf52840::gpio::GPIOPin,
+                    VirtualMuxAlarm<'static, nrf52840::rtc::Rtc>,
                 >,
-                nrf52840::gpio::GPIOPin,
-                VirtualMuxAlarm<'static, nrf52840::rtc::Rtc>,
+                capsules_extra::sip_hash::SipHasher24<'static>,
+                TICKV_PAGE_SIZE,
             >,
-            capsules_extra::sip_hash::SipHasher24<'static>,
-            TICKV_PAGE_SIZE,
-        >,
-        capsules_extra::tickv::TicKVKeyType,
+            capsules_extra::tickv::TicKVKeyType,
+        >
     ));
 
     //--------------------------------------------------------------------------

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -211,9 +211,9 @@ pub struct Platform {
             'static,
             capsules_extra::kv_store_permissions::KVStorePermissions<
                 'static,
-                capsules_extra::kv_store::KVStore<
+                capsules_extra::tickv_kv_store::TicKVKVStore<
                     'static,
-                    capsules_extra::tickv::TicKVStore<
+                    capsules_extra::tickv::TicKVSystem<
                         'static,
                         capsules_extra::mx25r6435f::MX25R6435F<
                             'static,
@@ -761,10 +761,10 @@ pub unsafe fn main() {
         TICKV_PAGE_SIZE,
     ));
 
-    // Tock-specific interface to KV (built on TicKV).
-    let kv_store = components::kv_system::KVStoreComponent::new(tickv).finalize(
-        components::kv_store_component_static!(
-            capsules_extra::tickv::TicKVStore<
+    // KVSystem interface to KV (built on TicKV).
+    let tickv_kv_store = components::kv::TicKVKVStoreComponent::new(tickv).finalize(
+        components::tickv_kv_store_component_static!(
+            capsules_extra::tickv::TicKVSystem<
                 capsules_extra::mx25r6435f::MX25R6435F<
                     capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<
                         'static,
@@ -780,10 +780,10 @@ pub unsafe fn main() {
         ),
     );
 
-    let kv_store_permissions = components::kv_system::KVStorePermissionsComponent::new(kv_store)
+    let kv_store_permissions = components::kv::KVStorePermissionsComponent::new(tickv_kv_store)
         .finalize(components::kv_store_permissions_component_static!(
-            capsules_extra::kv_store::KVStore<
-                capsules_extra::tickv::TicKVStore<
+            capsules_extra::tickv_kv_store::TicKVKVStore<
+                capsules_extra::tickv::TicKVSystem<
                     capsules_extra::mx25r6435f::MX25R6435F<
                         capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<
                             'static,
@@ -800,11 +800,11 @@ pub unsafe fn main() {
         ));
 
     // Share the KV stack with a mux.
-    let mux_kv = components::kv_system::KVPermissionsMuxComponent::new(kv_store_permissions)
-        .finalize(components::kv_permissions_mux_component_static!(
+    let mux_kv = components::kv::KVPermissionsMuxComponent::new(kv_store_permissions).finalize(
+        components::kv_permissions_mux_component_static!(
             capsules_extra::kv_store_permissions::KVStorePermissions<
-                capsules_extra::kv_store::KVStore<
-                    capsules_extra::tickv::TicKVStore<
+                capsules_extra::tickv_kv_store::TicKVKVStore<
+                    capsules_extra::tickv::TicKVSystem<
                         capsules_extra::mx25r6435f::MX25R6435F<
                             capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<
                                 'static,
@@ -819,14 +819,15 @@ pub unsafe fn main() {
                     capsules_extra::tickv::TicKVKeyType,
                 >,
             >
-        ));
+        ),
+    );
 
     // Create a virtual component for the userspace driver.
-    let virtual_kv_driver = components::kv_system::VirtualKVPermissionsComponent::new(mux_kv)
-        .finalize(components::virtual_kv_permissions_component_static!(
+    let virtual_kv_driver = components::kv::VirtualKVPermissionsComponent::new(mux_kv).finalize(
+        components::virtual_kv_permissions_component_static!(
             capsules_extra::kv_store_permissions::KVStorePermissions<
-                capsules_extra::kv_store::KVStore<
-                    capsules_extra::tickv::TicKVStore<
+                capsules_extra::tickv_kv_store::TicKVKVStore<
+                    capsules_extra::tickv::TicKVSystem<
                         capsules_extra::mx25r6435f::MX25R6435F<
                             capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<
                                 'static,
@@ -841,10 +842,11 @@ pub unsafe fn main() {
                     capsules_extra::tickv::TicKVKeyType,
                 >,
             >
-        ));
+        ),
+    );
 
     // Userspace driver for KV.
-    let kv_driver = components::kv_system::KVDriverComponent::new(
+    let kv_driver = components::kv::KVDriverComponent::new(
         virtual_kv_driver,
         board_kernel,
         capsules_extra::kv_driver::DRIVER_NUM,
@@ -852,8 +854,8 @@ pub unsafe fn main() {
     .finalize(components::kv_driver_component_static!(
         capsules_extra::virtual_kv::VirtualKVPermissions<
             capsules_extra::kv_store_permissions::KVStorePermissions<
-                capsules_extra::kv_store::KVStore<
-                    capsules_extra::tickv::TicKVStore<
+                capsules_extra::tickv_kv_store::TicKVKVStore<
+                    capsules_extra::tickv::TicKVSystem<
                         capsules_extra::mx25r6435f::MX25R6435F<
                             capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<
                                 'static,

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -244,9 +244,6 @@ impl SyscallDriverLookup for Platform {
             capsules_extra::ieee802154::DRIVER_NUM => f(Some(self.ieee802154_radio)),
             capsules_extra::temperature::DRIVER_NUM => f(Some(self.temp)),
             capsules_extra::analog_comparator::DRIVER_NUM => f(Some(self.analog_comparator)),
-            // capsules_extra::nonvolatile_storage_driver::DRIVER_NUM => {
-            //     f(Some(self.nonvolatile_storage))
-            // }
             capsules_extra::net::udp::DRIVER_NUM => f(Some(self.udp_driver)),
             kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
             capsules_core::i2c_master_slave_driver::DRIVER_NUM => f(Some(self.i2c_master_slave)),

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -219,7 +219,7 @@ pub struct Platform {
                 VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
             >,
             capsules_extra::sip_hash::SipHasher24<'static>,
-            4096,
+            { capsules_extra::mx25r6435f::SECTOR_SIZE as usize },
         >,
         [u8; 8],
     >,
@@ -735,8 +735,8 @@ pub unsafe fn main() {
     let tickv = components::tickv::TicKVDedicatedFlashComponent::new(
         sip_hash,
         mx25r6435f,
-        0,         // start at the beginning of the flash chip
-        4096 * 32, // arbitrary size of 32 pages
+        0, // start at the beginning of the flash chip
+        (capsules_extra::mx25r6435f::SECTOR_SIZE as usize) * 32, // arbitrary size of 32 pages
         page_buffer,
     )
     .finalize(components::tickv_dedicated_flash_component_static!(

--- a/capsules/extra/src/mx25r6435f.rs
+++ b/capsules/extra/src/mx25r6435f.rs
@@ -67,8 +67,8 @@ pub const TX_BUF_LEN: usize = PAGE_SIZE as usize + 4;
 pub const RX_BUF_LEN: usize = PAGE_SIZE as usize + 4;
 
 const SPI_SPEED: u32 = 8000000;
-const SECTOR_SIZE: u32 = 4096;
-const PAGE_SIZE: u32 = 256;
+pub const SECTOR_SIZE: u32 = 4096;
+pub const PAGE_SIZE: u32 = 256;
 
 /// This is a wrapper around a u8 array that is sized to a single page for the
 /// MX25R6435F. The page size is 4k because that is the smallest size that can


### PR DESCRIPTION
### Pull Request Overview

The nRF52840dk has an external flash chip which is a great target for hosting a TicKV interface.

Use KV instead of the generic (and hard to use) nonvolatile storage interface.


### Testing Strategy

This is how I've been developing the TicKV updates.


### TODO or Help Wanted

Needs #3508.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
