### PR TITLE
tools: run_cargo_fmt.sh: Don't run format on QEMU Rust code

### DIFF
--- a/tools/run_cargo_fmt.sh
+++ b/tools/run_cargo_fmt.sh
@@ -70,6 +70,9 @@ for f in $(find . | grep Cargo.toml); do
 		if grep -q '"'$dir'"' xx00; then
 			continue
 		fi
+		if [[ $dir == tools/qemu* ]]; then
+			continue
+		fi
 
 		printf "\rFormatting %-$((39))s" $dir
 	fi


### PR DESCRIPTION
### Pull Request Overview

This fixes errors like this when running the Rust formatter

```shell
Formatting tools/qemu/subprojects/keycodemapdb/tests/rust-test`cargo metadata` exited with an error: error: current package believes it's in a workspace when it's not:
current:   /var/mnt/scratch/alistair/software/tock/tock/tools/qemu/subprojects/keycodemapdb/tests/rust-test/Cargo.toml
workspace: /var/mnt/scratch/alistair/software/tock/tock/tools/Cargo.toml

this may be fixable by adding `qemu/subprojects/keycodemapdb/tests/rust-test` to the `workspace.members` array of the manifest located at: /var/mnt/scratch/alistair/software/tock/tock/tools/Cargo.toml
```

### Testing Strategy

`make fmt` with QEMU cloned locally

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
