### PR TITLE
Fix errors when running QEMU tests for OpenTitan

### DIFF
--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -32,7 +32,9 @@ endif
 CARGO_FLAGS += -Zpanic-abort-tests
 
 .PHONY: ot-check
-OPENTITAN_ACTUAL_SHA := $(shell cd $(OPENTITAN_TREE); git show --pretty=format:"%H" --no-patch)
+ifneq ($(OPENTITAN_TREE),)
+    OPENTITAN_ACTUAL_SHA := $(shell cd $(OPENTITAN_TREE); git show --pretty=format:"%H" --no-patch)
+endif
 # TODO: Theres mix and match of tab/space indenting in the block below,
 # should be changed to using `RECIPEPREFIX` make syntax when CI supports
 # make version > 3.81 (macos)
@@ -101,9 +103,7 @@ endif
 	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
-	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" QEMU_ENTRY_POINT=${QEMU_ENTRY_POINT} $(CARGO) test $(CARGO_FLAGS_TOCK) $(NO_RUN) --bin $(PLATFORM) --release
-# 	Test layout should be removed so that following apps (non-test) load the correct layout.
-	$(Q)rm $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
+	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} QEMU_ENTRY_POINT=${QEMU_ENTRY_POINT} TARGET=${TARGET} $(CARGO) test $(CARGO_FLAGS_TOCK) $(NO_RUN) --bin $(PLATFORM) --release
 
 test-hardware: ot-check
 	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/


### PR DESCRIPTION
### Pull Request Overview

Fix two (non-fatal) errors when running QEMU tests with OpenTitan boards.

The assignment in Makefile is unconditional (and will run regardless if ot-check target is needed), so git will complain that $HOME is not a git repo if `OPENTITAN_TREE` is not set.

`cargo test` runs `run.sh` which needs `TOCK_ROOT_DIRECTORY`. This is set for `test-hardware` and `test-verilator` but is not currently set for `test` target.

### Testing Strategy

`make -C boards/opentitan/earlgrey-cw310/ test`

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
