### PR TITLE
capsules: remove doc leftovers on `SyscallDriver` impls

### DIFF
--- a/capsules/core/src/console.rs
+++ b/capsules/core/src/console.rs
@@ -235,25 +235,6 @@ impl<'a> Console<'a> {
 }
 
 impl SyscallDriver for Console<'_> {
-    /// Setup shared buffers.
-    ///
-    /// ### `allow_num`
-    ///
-    /// - `1`: Writeable buffer for read buffer
-
-    /// Setup shared buffers.
-    ///
-    /// ### `allow_num`
-    ///
-    /// - `1`: Readonly buffer for write buffer
-
-    // Setup callbacks.
-    //
-    // ### `subscribe_num`
-    //
-    // - `1`: Write buffer completed callback
-    // - `2`: Read buffer completed callback
-
     /// Initiate serial transfers
     ///
     /// ### `command_num`

--- a/capsules/core/src/console.rs
+++ b/capsules/core/src/console.rs
@@ -56,8 +56,21 @@ pub const DRIVER_NUM: usize = driver::NUM::Console as usize;
 /// Boards may pass different-size buffers if needed.
 pub const DEFAULT_BUF_SIZE: usize = 64;
 
+/// IDs for subscribed upcalls.
+mod upcall {
+    /// Write buffer completed callback
+    pub const WRITE_DONE: usize = 1;
+    /// Read buffer completed callback
+    pub const READ_DONE: usize = 2;
+    /// Number of upcalls. Even though we only use two, indexing starts at 0 so
+    /// to be able to use indices 1 and 2 we need to specify three upcalls.
+    pub const COUNT: u8 = 3;
+}
+
 /// Ids for read-only allow buffers
 mod ro_allow {
+    /// Readonly buffer for write buffer
+    ///
     /// Before the allow syscall was handled by the kernel,
     /// console used allow number "1", so to preserve compatibility
     /// we still use allow number 1 now.
@@ -68,6 +81,8 @@ mod ro_allow {
 
 /// Ids for read-write allow buffers
 mod rw_allow {
+    /// Writeable buffer for read buffer
+    ///
     /// Before the allow syscall was handled by the kernel,
     /// console used allow number "1", so to preserve compatibility
     /// we still use allow number 1 now.
@@ -88,7 +103,7 @@ pub struct Console<'a> {
     uart: &'a dyn uart::UartData<'a>,
     apps: Grant<
         App,
-        UpcallCount<3>,
+        UpcallCount<{ upcall::COUNT }>,
         AllowRoCount<{ ro_allow::COUNT }>,
         AllowRwCount<{ rw_allow::COUNT }>,
     >,
@@ -105,7 +120,7 @@ impl<'a> Console<'a> {
         rx_buffer: &'static mut [u8],
         grant: Grant<
             App,
-            UpcallCount<3>,
+            UpcallCount<{ upcall::COUNT }>,
             AllowRoCount<{ ro_allow::COUNT }>,
             AllowRwCount<{ rw_allow::COUNT }>,
         >,
@@ -309,7 +324,9 @@ impl uart::TransmitClient for Console<'_> {
                         // Go ahead and signal the application
                         let written = app.write_len;
                         app.write_len = 0;
-                        kernel_data.schedule_upcall(1, (written, 0, 0)).ok();
+                        kernel_data
+                            .schedule_upcall(upcall::WRITE_DONE, (written, 0, 0))
+                            .ok();
                     }
                 }
             })
@@ -407,7 +424,7 @@ impl uart::ReceiveClient for Console<'_> {
 
                                 kernel_data
                                     .schedule_upcall(
-                                        2,
+                                        upcall::READ_DONE,
                                         (
                                             kernel::errorcode::into_statuscode(ret),
                                             received_length,
@@ -420,7 +437,7 @@ impl uart::ReceiveClient for Console<'_> {
                                 // Some UART error occurred
                                 kernel_data
                                     .schedule_upcall(
-                                        2,
+                                        upcall::READ_DONE,
                                         (
                                             kernel::errorcode::into_statuscode(Err(
                                                 ErrorCode::FAIL,

--- a/capsules/extra/src/ambient_light.rs
+++ b/capsules/extra/src/ambient_light.rs
@@ -27,6 +27,17 @@ use kernel::{ErrorCode, ProcessId};
 use capsules_core::driver;
 pub const DRIVER_NUM: usize = driver::NUM::AmbientLight as usize;
 
+/// IDs for subscribed upcalls.
+mod upcall {
+    /// Subscribe to light intensity readings.
+    ///
+    /// The callback signature is `fn(lux: usize)`, where `lux` is the light
+    /// intensity in lux (lx).
+    pub const LIGHT_INTENSITY: usize = 0;
+    /// Number of upcalls.
+    pub const COUNT: u8 = 1;
+}
+
 /// Per-process metadata
 #[derive(Default)]
 pub struct App {
@@ -36,13 +47,13 @@ pub struct App {
 pub struct AmbientLight<'a> {
     sensor: &'a dyn hil::sensors::AmbientLight<'a>,
     command_pending: Cell<bool>,
-    apps: Grant<App, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
+    apps: Grant<App, UpcallCount<{ upcall::COUNT }>, AllowRoCount<0>, AllowRwCount<0>>,
 }
 
 impl<'a> AmbientLight<'a> {
     pub fn new(
         sensor: &'a dyn hil::sensors::AmbientLight<'a>,
-        grant: Grant<App, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
+        grant: Grant<App, UpcallCount<{ upcall::COUNT }>, AllowRoCount<0>, AllowRwCount<0>>,
     ) -> AmbientLight {
         AmbientLight {
             sensor: sensor,
@@ -109,7 +120,9 @@ impl hil::sensors::AmbientLightClient for AmbientLight<'_> {
         self.apps.each(|_, app, upcalls| {
             if app.pending {
                 app.pending = false;
-                upcalls.schedule_upcall(0, (lux, 0, 0)).ok();
+                upcalls
+                    .schedule_upcall(upcall::LIGHT_INTENSITY, (lux, 0, 0))
+                    .ok();
             }
         });
     }

--- a/capsules/extra/src/ambient_light.rs
+++ b/capsules/extra/src/ambient_light.rs
@@ -70,13 +70,6 @@ impl<'a> AmbientLight<'a> {
 }
 
 impl SyscallDriver for AmbientLight<'_> {
-    // Subscribe to light intensity readings
-    //
-    // ### `subscribe`
-    //
-    // - `0`: Subscribe to light intensity readings. The callback signature is
-    // `fn(lux: usize)`, where `lux` is the light intensity in lux (lx).
-
     /// Initiate light intensity readings
     ///
     /// Sensor readings are coalesced if processes request them concurrently. If

--- a/capsules/extra/src/app_flash_driver.rs
+++ b/capsules/extra/src/app_flash_driver.rs
@@ -39,8 +39,17 @@ use kernel::{ErrorCode, ProcessId};
 use capsules_core::driver;
 pub const DRIVER_NUM: usize = driver::NUM::AppFlash as usize;
 
+/// IDs for subscribed upcalls.
+mod upcall {
+    /// `write_done` callback.
+    pub const WRITE_DONE: usize = 0;
+    /// Number of upcalls.
+    pub const COUNT: u8 = 1;
+}
+
 /// Ids for read-only allow buffers
 mod ro_allow {
+    /// Set write buffer. This entire buffer will be written to flash.
     pub const BUFFER: usize = 0;
     /// The number of allow buffers the kernel stores for this grant
     pub const COUNT: u8 = 1;
@@ -54,7 +63,12 @@ pub struct App {
 
 pub struct AppFlash<'a> {
     driver: &'a dyn hil::nonvolatile_storage::NonvolatileStorage<'a>,
-    apps: Grant<App, UpcallCount<1>, AllowRoCount<{ ro_allow::COUNT }>, AllowRwCount<0>>,
+    apps: Grant<
+        App,
+        UpcallCount<{ upcall::COUNT }>,
+        AllowRoCount<{ ro_allow::COUNT }>,
+        AllowRwCount<0>,
+    >,
     current_app: OptionalCell<ProcessId>,
     buffer: TakeCell<'static, [u8]>,
 }
@@ -62,7 +76,12 @@ pub struct AppFlash<'a> {
 impl<'a> AppFlash<'a> {
     pub fn new(
         driver: &'a dyn hil::nonvolatile_storage::NonvolatileStorage<'a>,
-        grant: Grant<App, UpcallCount<1>, AllowRoCount<{ ro_allow::COUNT }>, AllowRwCount<0>>,
+        grant: Grant<
+            App,
+            UpcallCount<{ upcall::COUNT }>,
+            AllowRoCount<{ ro_allow::COUNT }>,
+            AllowRwCount<0>,
+        >,
         buffer: &'static mut [u8],
     ) -> AppFlash<'a> {
         AppFlash {
@@ -140,7 +159,7 @@ impl hil::nonvolatile_storage::NonvolatileStorageClient for AppFlash<'_> {
         // Notify the current application that the command finished.
         self.current_app.take().map(|processid| {
             let _ = self.apps.enter(processid, |_app, upcalls| {
-                upcalls.schedule_upcall(0, (0, 0, 0)).ok();
+                upcalls.schedule_upcall(upcall::WRITE_DONE, (0, 0, 0)).ok();
             });
         });
 

--- a/capsules/extra/src/app_flash_driver.rs
+++ b/capsules/extra/src/app_flash_driver.rs
@@ -194,18 +194,6 @@ impl hil::nonvolatile_storage::NonvolatileStorageClient for AppFlash<'_> {
 }
 
 impl SyscallDriver for AppFlash<'_> {
-    /// Setup buffer to write from.
-    ///
-    /// ### `allow_num`
-    ///
-    /// - `0`: Set write buffer. This entire buffer will be written to flash.
-
-    // Setup callbacks.
-    //
-    // ### `subscribe_num`
-    //
-    // - `0`: Set a write_done callback.
-
     /// App flash control.
     ///
     /// ### `command_num`

--- a/capsules/extra/src/ieee802154/driver.rs
+++ b/capsules/extra/src/ieee802154/driver.rs
@@ -25,8 +25,19 @@ use kernel::{ErrorCode, ProcessId};
 const MAX_NEIGHBORS: usize = 4;
 const MAX_KEYS: usize = 4;
 
+/// IDs for subscribed upcalls.
+mod upcall {
+    /// Frame is received
+    pub const FRAME_RECEIVED: usize = 0;
+    /// Frame is transmitted
+    pub const FRAME_TRANSMITTED: usize = 1;
+    /// Number of upcalls.
+    pub const COUNT: u8 = 2;
+}
+
 /// Ids for read-only allow buffers
 mod ro_allow {
+    /// Write buffer. Contains the frame payload to be transmitted.
     pub const WRITE: usize = 0;
     /// The number of allow buffers the kernel stores for this grant
     pub const COUNT: u8 = 1;
@@ -34,7 +45,13 @@ mod ro_allow {
 
 /// Ids for read-write allow buffers
 mod rw_allow {
+    /// Read buffer. Will contain the received frame.
     pub const READ: usize = 0;
+    /// Config buffer.
+    ///
+    /// Used to contain miscellaneous data associated with some commands because
+    /// the system call parameters / return codes are not enough to convey the
+    /// desired information.
     pub const CFG: usize = 1;
     /// The number of allow buffers the kernel stores for this grant
     pub const COUNT: u8 = 2;
@@ -193,7 +210,7 @@ pub struct RadioDriver<'a> {
     /// Grant of apps that use this radio driver.
     apps: Grant<
         App,
-        UpcallCount<2>,
+        UpcallCount<{ upcall::COUNT }>,
         AllowRoCount<{ ro_allow::COUNT }>,
         AllowRwCount<{ rw_allow::COUNT }>,
     >,
@@ -218,7 +235,7 @@ impl<'a> RadioDriver<'a> {
         mac: &'a dyn device::MacDevice<'a>,
         grant: Grant<
             App,
-            UpcallCount<2>,
+            UpcallCount<{ upcall::COUNT }>,
             AllowRoCount<{ ro_allow::COUNT }>,
             AllowRwCount<{ rw_allow::COUNT }>,
         >,
@@ -475,7 +492,7 @@ impl DeferredCallClient for RadioDriver<'static> {
                 // Unwrap fail = missing processid
                 upcalls
                     .schedule_upcall(
-                        1,
+                        upcall::FRAME_TRANSMITTED,
                         (
                             kernel::errorcode::into_statuscode(
                                 self.saved_result.unwrap_or_panic(), // Unwrap fail = missing result
@@ -877,7 +894,7 @@ impl device::TxClient for RadioDriver<'_> {
             let _ = self.apps.enter(processid, |_app, upcalls| {
                 upcalls
                     .schedule_upcall(
-                        1,
+                        upcall::FRAME_TRANSMITTED,
                         (
                             kernel::errorcode::into_statuscode(result),
                             acked as usize,
@@ -930,7 +947,7 @@ impl device::RxClient for RadioDriver<'_> {
                 let dst_addr = encode_address(&header.dst_addr);
                 let src_addr = encode_address(&header.src_addr);
                 kernel_data
-                    .schedule_upcall(0, (pans, dst_addr, src_addr))
+                    .schedule_upcall(upcall::FRAME_RECEIVED, (pans, dst_addr, src_addr))
                     .ok();
             }
         });

--- a/capsules/extra/src/ieee802154/driver.rs
+++ b/capsules/extra/src/ieee802154/driver.rs
@@ -524,28 +524,6 @@ impl framer::KeyProcedure for RadioDriver<'_> {
 }
 
 impl SyscallDriver for RadioDriver<'_> {
-    /// Setup buffers to read/write from.
-    ///
-    /// ### `allow_num`
-    ///
-    /// - `0`: Read buffer. Will contain the received frame.
-    /// - `1`: Config buffer. Used to contain miscellaneous data associated with
-    ///        some commands because the system call parameters / return codes are
-    ///        not enough to convey the desired information.
-
-    /// Setup shared buffers.
-    ///
-    /// ### `allow_num`
-    ///
-    /// - `0`: Write buffer. Contains the frame payload to be transmitted.
-
-    // Setup callbacks.
-    //
-    // ### `subscribe_num`
-    //
-    // - `0`: Setup callback for when frame is received.
-    // - `1`: Setup callback for when frame is transmitted.
-
     /// IEEE 802.15.4 MAC device control.
     ///
     /// For some of the below commands, one 32-bit argument is not enough to

--- a/capsules/extra/src/ltc294x.rs
+++ b/capsules/extra/src/ltc294x.rs
@@ -423,18 +423,34 @@ impl<I: i2c::I2CDevice> gpio::Client for LTC294X<'_, I> {
     }
 }
 
+/// IDs for subscribed upcalls.
+mod upcall {
+    /// The callback that that is triggered when events finish and when readings
+    /// are ready. The first argument represents which callback was triggered.
+    ///
+    /// - `0`: Interrupt occurred from the LTC294X.
+    /// - `1`: Got the status.
+    /// - `2`: Read the charge used.
+    /// - `3`: `done()` was called.
+    /// - `4`: Read the voltage.
+    /// - `5`: Read the current.
+    pub const EVENT_FINISHED: usize = 0;
+    /// Number of upcalls.
+    pub const COUNT: u8 = 1;
+}
+
 /// Default implementation of the LTC2941 driver that provides a Driver
 /// interface for providing access to applications.
 pub struct LTC294XDriver<'a, I: i2c::I2CDevice> {
     ltc294x: &'a LTC294X<'a, I>,
-    grants: Grant<App, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
+    grants: Grant<App, UpcallCount<{ upcall::COUNT }>, AllowRoCount<0>, AllowRwCount<0>>,
     owning_process: OptionalCell<ProcessId>,
 }
 
 impl<'a, I: i2c::I2CDevice> LTC294XDriver<'a, I> {
     pub fn new(
         ltc: &'a LTC294X<'a, I>,
-        grants: Grant<App, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
+        grants: Grant<App, UpcallCount<{ upcall::COUNT }>, AllowRoCount<0>, AllowRwCount<0>>,
     ) -> LTC294XDriver<'a, I> {
         LTC294XDriver {
             ltc294x: ltc,
@@ -448,7 +464,9 @@ impl<I: i2c::I2CDevice> LTC294XClient for LTC294XDriver<'_, I> {
     fn interrupt(&self) {
         self.owning_process.map(|pid| {
             let _res = self.grants.enter(pid, |_app, upcalls| {
-                upcalls.schedule_upcall(0, (0, 0, 0)).ok();
+                upcalls
+                    .schedule_upcall(upcall::EVENT_FINISHED, (0, 0, 0))
+                    .ok();
             });
         });
     }
@@ -469,7 +487,10 @@ impl<I: i2c::I2CDevice> LTC294XClient for LTC294XDriver<'_, I> {
         self.owning_process.map(|pid| {
             let _res = self.grants.enter(pid, |_app, upcalls| {
                 upcalls
-                    .schedule_upcall(0, (1, ret, self.ltc294x.model.get() as usize))
+                    .schedule_upcall(
+                        upcall::EVENT_FINISHED,
+                        (1, ret, self.ltc294x.model.get() as usize),
+                    )
                     .ok();
             });
         });
@@ -478,7 +499,9 @@ impl<I: i2c::I2CDevice> LTC294XClient for LTC294XDriver<'_, I> {
     fn charge(&self, charge: u16) {
         self.owning_process.map(|pid| {
             let _res = self.grants.enter(pid, |_app, upcalls| {
-                upcalls.schedule_upcall(0, (2, charge as usize, 0)).ok();
+                upcalls
+                    .schedule_upcall(upcall::EVENT_FINISHED, (2, charge as usize, 0))
+                    .ok();
             });
         });
     }
@@ -486,7 +509,9 @@ impl<I: i2c::I2CDevice> LTC294XClient for LTC294XDriver<'_, I> {
     fn done(&self) {
         self.owning_process.map(|pid| {
             let _res = self.grants.enter(pid, |_app, upcalls| {
-                upcalls.schedule_upcall(0, (3, 0, 0)).ok();
+                upcalls
+                    .schedule_upcall(upcall::EVENT_FINISHED, (3, 0, 0))
+                    .ok();
             });
         });
     }
@@ -494,7 +519,9 @@ impl<I: i2c::I2CDevice> LTC294XClient for LTC294XDriver<'_, I> {
     fn voltage(&self, voltage: u16) {
         self.owning_process.map(|pid| {
             let _res = self.grants.enter(pid, |_app, upcalls| {
-                upcalls.schedule_upcall(0, (4, voltage as usize, 0)).ok();
+                upcalls
+                    .schedule_upcall(upcall::EVENT_FINISHED, (4, voltage as usize, 0))
+                    .ok();
             });
         });
     }
@@ -502,7 +529,9 @@ impl<I: i2c::I2CDevice> LTC294XClient for LTC294XDriver<'_, I> {
     fn current(&self, current: u16) {
         self.owning_process.map(|pid| {
             let _res = self.grants.enter(pid, |_app, upcalls| {
-                upcalls.schedule_upcall(0, (5, current as usize, 0)).ok();
+                upcalls
+                    .schedule_upcall(upcall::EVENT_FINISHED, (5, current as usize, 0))
+                    .ok();
             });
         });
     }

--- a/capsules/extra/src/ltc294x.rs
+++ b/capsules/extra/src/ltc294x.rs
@@ -509,20 +509,6 @@ impl<I: i2c::I2CDevice> LTC294XClient for LTC294XDriver<'_, I> {
 }
 
 impl<I: i2c::I2CDevice> SyscallDriver for LTC294XDriver<'_, I> {
-    // Setup callbacks.
-    //
-    // ### `subscribe_num`
-    //
-    // - `0`: Set the callback that that is triggered when events finish and
-    //   when readings are ready. The first argument represents which callback
-    //   was triggered.
-    //   - `0`: Interrupt occurred from the LTC294X.
-    //   - `1`: Got the status.
-    //   - `2`: Read the charge used.
-    //   - `3`: `done()` was called.
-    //   - `4`: Read the voltage.
-    //   - `5`: Read the current.
-
     /// Request operations for the LTC294X chip.
     ///
     /// ### `command_num`

--- a/capsules/extra/src/max17205.rs
+++ b/capsules/extra/src/max17205.rs
@@ -394,19 +394,27 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for MAX17205<'_, I> {
     }
 }
 
+/// IDs for subscribed upcalls.
+mod upcall {
+    /// Callback for when all events complete or data is ready.
+    pub const EVENT_COMPLETE: usize = 0;
+    /// Number of upcalls.
+    pub const COUNT: u8 = 1;
+}
+
 #[derive(Default)]
 pub struct App {}
 
 pub struct MAX17205Driver<'a, I: i2c::I2CDevice> {
     max17205: &'a MAX17205<'a, I>,
     owning_process: OptionalCell<ProcessId>,
-    apps: Grant<App, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
+    apps: Grant<App, UpcallCount<{ upcall::COUNT }>, AllowRoCount<0>, AllowRwCount<0>>,
 }
 
 impl<'a, I: i2c::I2CDevice> MAX17205Driver<'a, I> {
     pub fn new(
         max: &'a MAX17205<I>,
-        grant: Grant<App, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
+        grant: Grant<App, UpcallCount<{ upcall::COUNT }>, AllowRoCount<0>, AllowRwCount<0>>,
     ) -> Self {
         Self {
             max17205: max,
@@ -422,7 +430,7 @@ impl<I: i2c::I2CDevice> MAX17205Client for MAX17205Driver<'_, I> {
             let _ = self.apps.enter(pid, |_app, upcalls| {
                 upcalls
                     .schedule_upcall(
-                        0,
+                        upcall::EVENT_COMPLETE,
                         (
                             kernel::errorcode::into_statuscode(error),
                             status as usize,
@@ -445,7 +453,7 @@ impl<I: i2c::I2CDevice> MAX17205Client for MAX17205Driver<'_, I> {
             let _ = self.apps.enter(pid, |_app, upcalls| {
                 upcalls
                     .schedule_upcall(
-                        0,
+                        upcall::EVENT_COMPLETE,
                         (
                             kernel::errorcode::into_statuscode(error),
                             percent as usize,
@@ -462,7 +470,7 @@ impl<I: i2c::I2CDevice> MAX17205Client for MAX17205Driver<'_, I> {
             let _ = self.apps.enter(pid, |_app, upcalls| {
                 upcalls
                     .schedule_upcall(
-                        0,
+                        upcall::EVENT_COMPLETE,
                         (
                             kernel::errorcode::into_statuscode(error),
                             voltage as usize,
@@ -479,7 +487,7 @@ impl<I: i2c::I2CDevice> MAX17205Client for MAX17205Driver<'_, I> {
             let _ = self.apps.enter(pid, |_app, upcalls| {
                 upcalls
                     .schedule_upcall(
-                        0,
+                        upcall::EVENT_COMPLETE,
                         (
                             kernel::errorcode::into_statuscode(error),
                             coulomb as usize,
@@ -496,7 +504,7 @@ impl<I: i2c::I2CDevice> MAX17205Client for MAX17205Driver<'_, I> {
             let _ = self.apps.enter(pid, |_app, upcalls| {
                 upcalls
                     .schedule_upcall(
-                        0,
+                        upcall::EVENT_COMPLETE,
                         (
                             kernel::errorcode::into_statuscode(error),
                             (rid & 0xffffffff) as usize,

--- a/capsules/extra/src/max17205.rs
+++ b/capsules/extra/src/max17205.rs
@@ -510,12 +510,6 @@ impl<I: i2c::I2CDevice> MAX17205Client for MAX17205Driver<'_, I> {
 }
 
 impl<I: i2c::I2CDevice> SyscallDriver for MAX17205Driver<'_, I> {
-    // Setup callback.
-    //
-    // ### `subscribe_num`
-    //
-    // - `0`: Setup a callback for when all events complete or data is ready.
-
     /// Setup and read the MAX17205.
     ///
     /// ### `command_num`

--- a/capsules/extra/src/net/udp/driver.rs
+++ b/capsules/extra/src/net/udp/driver.rs
@@ -38,8 +38,26 @@ use kernel::{ErrorCode, ProcessId};
 use capsules_core::driver;
 pub const DRIVER_NUM: usize = driver::NUM::Udp as usize;
 
+/// IDs for subscribed upcalls.
+mod upcall {
+    /// Callback for when packet is received. If no port has been bound, return
+    /// `RESERVE` to indicate that port binding is is a prerequisite to
+    /// reception.
+    pub const PACKET_RECEIVED: usize = 0;
+    /// Callback for when packet is transmitted. Notably, this callback receives
+    /// the result of the send_done callback from udp_send.rs, which does not
+    /// currently pass information regarding whether packets were acked at the
+    /// link layer.
+    pub const PACKET_TRANSMITTED: usize = 1;
+    /// Number of upcalls.
+    pub const COUNT: u8 = 2;
+}
+
 /// Ids for read-only allow buffers
 mod ro_allow {
+    /// Write buffer. Contains the UDP payload to be transmitted. Returns SIZE
+    /// if the passed buffer is too long, and NOSUPPORT if an invalid
+    /// `allow_num` is passed.
     pub const WRITE: usize = 0;
     /// The number of allow buffers the kernel stores for this grant
     pub const COUNT: u8 = 1;
@@ -47,8 +65,14 @@ mod ro_allow {
 
 /// Ids for read-write allow buffers
 mod rw_allow {
+    /// Read buffer. Will contain the received payload.
     pub const READ: usize = 0;
+    /// Config buffer. Used to contain miscellaneous data associated with some
+    /// commands, namely source/destination addresses and ports.
     pub const CFG: usize = 1;
+    /// Rx config buffer. Used to contain source/destination addresses and ports
+    /// for receives (separate from `2` because receives may be waiting for an
+    /// incoming packet asynchronously).
     pub const RX_CFG: usize = 2;
     /// The number of allow buffers the kernel stores for this grant
     pub const COUNT: u8 = 3;
@@ -103,7 +127,7 @@ pub struct UDPDriver<'a> {
     /// Grant of apps that use this radio driver.
     apps: Grant<
         App,
-        UpcallCount<2>,
+        UpcallCount<{ upcall::COUNT }>,
         AllowRoCount<{ ro_allow::COUNT }>,
         AllowRwCount<{ rw_allow::COUNT }>,
     >,
@@ -131,7 +155,7 @@ impl<'a> UDPDriver<'a> {
         sender: &'a dyn UDPSender<'a>,
         grant: Grant<
             App,
-            UpcallCount<2>,
+            UpcallCount<{ upcall::COUNT }>,
             AllowRoCount<{ ro_allow::COUNT }>,
             AllowRwCount<{ rw_allow::COUNT }>,
         >,
@@ -187,7 +211,10 @@ impl<'a> UDPDriver<'a> {
         if result != Ok(()) {
             let _ = self.apps.enter(processid, |_app, upcalls| {
                 upcalls
-                    .schedule_upcall(1, (kernel::errorcode::into_statuscode(result), 0, 0))
+                    .schedule_upcall(
+                        upcall::PACKET_TRANSMITTED,
+                        (kernel::errorcode::into_statuscode(result), 0, 0),
+                    )
                     .ok();
             });
         }
@@ -542,7 +569,10 @@ impl<'a> UDPSendClient for UDPDriver<'a> {
         self.current_app.get().map(|processid| {
             let _ = self.apps.enter(processid, |_app, upcalls| {
                 upcalls
-                    .schedule_upcall(1, (kernel::errorcode::into_statuscode(result), 0, 0))
+                    .schedule_upcall(
+                        upcall::PACKET_TRANSMITTED,
+                        (kernel::errorcode::into_statuscode(result), 0, 0),
+                    )
                     .ok();
             });
         });
@@ -589,7 +619,9 @@ impl<'a> UDPRecvClient for UDPDriver<'a> {
                             addr: src_addr,
                             port: src_port,
                         };
-                        kernel_data.schedule_upcall(0, (len, 0, 0)).ok();
+                        kernel_data
+                            .schedule_upcall(upcall::PACKET_RECEIVED, (len, 0, 0))
+                            .ok();
                         const CFG_LEN: usize = 2 * size_of::<UDPEndpoint>();
                         let _ = kernel_data
                             .get_readwrite_processbuffer(rw_allow::RX_CFG)

--- a/capsules/extra/src/net/udp/driver.rs
+++ b/capsules/extra/src/net/udp/driver.rs
@@ -306,37 +306,6 @@ impl<'a> UDPDriver<'a> {
 }
 
 impl<'a> SyscallDriver for UDPDriver<'a> {
-    /// Setup buffers to read/write from.
-    ///
-    /// ### `allow_num`
-    ///
-    /// - `0`: Read buffer. Will contain the received payload.
-    /// - `1`: Config buffer. Used to contain miscellaneous data associated with
-    ///        some commands, namely source/destination addresses and ports.
-    /// - `2`: Rx config buffer. Used to contain source/destination addresses
-    ///        and ports for receives (separate from `2` because receives may
-    ///        be waiting for an incoming packet asynchronously).
-
-    /// Setup shared buffers.
-    ///
-    /// ### `allow_num`
-    ///
-    /// - `0`: Write buffer. Contains the UDP payload to be transmitted.
-    ///        Returns SIZE if the passed buffer is too long, and NOSUPPORT
-    ///        if an invalid `allow_num` is passed.
-
-    // Setup callbacks.
-    //
-    // ### `subscribe_num`
-    //
-    // - `0`: Setup callback for when packet is received. If no port has
-    //        been bound, return RESERVE to indicate that port binding is
-    //        is a prerequisite to reception.
-    // - `1`: Setup callback for when packet is transmitted. Notably,
-    //        this callback receives the result of the send_done callback
-    //        from udp_send.rs, which does not currently pass information
-    //        regarding whether packets were acked at the link layer.
-
     /// UDP control
     ///
     /// ### `command_num`

--- a/capsules/extra/src/nonvolatile_storage_driver.rs
+++ b/capsules/extra/src/nonvolatile_storage_driver.rs
@@ -519,25 +519,6 @@ impl<'a> hil::nonvolatile_storage::NonvolatileStorage<'a> for NonvolatileStorage
 
 /// Provide an interface for userland.
 impl SyscallDriver for NonvolatileStorage<'_> {
-    /// Setup shared kernel-writable buffers.
-    ///
-    /// ### `allow_num`
-    ///
-    /// - `0`: Setup a buffer to read from the nonvolatile storage into.
-
-    /// Setup shared kernel-readable buffers.
-    ///
-    /// ### `allow_num`
-    ///
-    /// - `0`: Setup a buffer to write bytes to the nonvolatile storage.
-
-    // Setup callbacks.
-    //
-    // ### `subscribe_num`
-    //
-    // - `0`: Setup a read done callback.
-    // - `1`: Setup a write done callback.
-
     /// Command interface.
     ///
     /// Commands are selected by the lowest 8 bits of the first argument.

--- a/capsules/extra/src/nonvolatile_storage_driver.rs
+++ b/capsules/extra/src/nonvolatile_storage_driver.rs
@@ -72,8 +72,19 @@ use kernel::{ErrorCode, ProcessId};
 use capsules_core::driver;
 pub const DRIVER_NUM: usize = driver::NUM::NvmStorage as usize;
 
+/// IDs for subscribed upcalls.
+mod upcall {
+    /// Read done callback.
+    pub const READ_DONE: usize = 0;
+    /// Write done callback.
+    pub const WRITE_DONE: usize = 1;
+    /// Number of upcalls.
+    pub const COUNT: u8 = 2;
+}
+
 /// Ids for read-only allow buffers
 mod ro_allow {
+    /// Setup a buffer to write bytes to the nonvolatile storage.
     pub const WRITE: usize = 0;
     /// The number of allow buffers the kernel stores for this grant
     pub const COUNT: u8 = 1;
@@ -81,6 +92,7 @@ mod ro_allow {
 
 /// Ids for read-write allow buffers
 mod rw_allow {
+    /// Setup a buffer to read from the nonvolatile storage into.
     pub const READ: usize = 0;
     /// The number of allow buffers the kernel stores for this grant
     pub const COUNT: u8 = 1;
@@ -126,7 +138,7 @@ pub struct NonvolatileStorage<'a> {
     // Per-app state.
     apps: Grant<
         App,
-        UpcallCount<2>,
+        UpcallCount<{ upcall::COUNT }>,
         AllowRoCount<{ ro_allow::COUNT }>,
         AllowRwCount<{ rw_allow::COUNT }>,
     >,
@@ -165,7 +177,7 @@ impl<'a> NonvolatileStorage<'a> {
         driver: &'a dyn hil::nonvolatile_storage::NonvolatileStorage<'a>,
         grant: Grant<
             App,
-            UpcallCount<2>,
+            UpcallCount<{ upcall::COUNT }>,
             AllowRoCount<{ ro_allow::COUNT }>,
             AllowRwCount<{ rw_allow::COUNT }>,
         >,
@@ -456,7 +468,9 @@ impl hil::nonvolatile_storage::NonvolatileStorageClient for NonvolatileStorage<'
                         self.buffer.replace(buffer);
 
                         // And then signal the app.
-                        kernel_data.schedule_upcall(0, (length, 0, 0)).ok();
+                        kernel_data
+                            .schedule_upcall(upcall::READ_DONE, (length, 0, 0))
+                            .ok();
                     });
                 }
             }
@@ -480,7 +494,9 @@ impl hil::nonvolatile_storage::NonvolatileStorageClient for NonvolatileStorage<'
                         self.buffer.replace(buffer);
 
                         // And then signal the app.
-                        kernel_data.schedule_upcall(1, (length, 0, 0)).ok();
+                        kernel_data
+                            .schedule_upcall(upcall::WRITE_DONE, (length, 0, 0))
+                            .ok();
                     });
                 }
             }

--- a/capsules/extra/src/nrf51822_serialization.rs
+++ b/capsules/extra/src/nrf51822_serialization.rs
@@ -38,8 +38,21 @@ use kernel::{ErrorCode, ProcessId};
 use capsules_core::driver;
 pub const DRIVER_NUM: usize = driver::NUM::Nrf51822Serialization as usize;
 
+/// IDs for subscribed upcalls.
+mod upcall {
+    /// Callback will be called when a TX finishes and when RX data is
+    /// available.
+    pub const TX_DONE_RX_READY: usize = 0;
+    /// Number of upcalls.
+    pub const COUNT: u8 = 1;
+}
+
 /// Ids for read-only allow buffers
 mod ro_allow {
+    /// TX buffer.
+    ///
+    /// This also sets which app is currently using this driver. Only one app
+    /// can control the nRF51 serialization driver.
     pub const TX: usize = 0;
     /// The number of allow buffers the kernel stores for this grant
     pub const COUNT: u8 = 1;
@@ -47,6 +60,10 @@ mod ro_allow {
 
 /// Ids for read-write allow buffers
 mod rw_allow {
+    /// RX buffer.
+    ///
+    /// This also sets which app is currently using this driver. Only one app
+    /// can control the nRF51 serialization driver.
     pub const RX: usize = 0;
     /// The number of allow buffers the kernel stores for this grant
     pub const COUNT: u8 = 1;
@@ -67,7 +84,7 @@ pub struct Nrf51822Serialization<'a> {
     reset_pin: &'a dyn hil::gpio::Pin,
     apps: Grant<
         App,
-        UpcallCount<1>,
+        UpcallCount<{ upcall::COUNT }>,
         AllowRoCount<{ ro_allow::COUNT }>,
         AllowRwCount<{ rw_allow::COUNT }>,
     >,
@@ -81,7 +98,7 @@ impl<'a> Nrf51822Serialization<'a> {
         uart: &'a dyn uart::UartAdvanced<'a>,
         grant: Grant<
             App,
-            UpcallCount<1>,
+            UpcallCount<{ upcall::COUNT }>,
             AllowRoCount<{ ro_allow::COUNT }>,
             AllowRwCount<{ rw_allow::COUNT }>,
         >,
@@ -263,7 +280,9 @@ impl uart::TransmitClient for Nrf51822Serialization<'_> {
         self.active_app.map(|processid| {
             let _ = self.apps.enter(processid, |_app, kernel_data| {
                 // Call the callback after TX has finished
-                kernel_data.schedule_upcall(0, (1, 0, 0)).ok();
+                kernel_data
+                    .schedule_upcall(upcall::TX_DONE_RX_READY, (1, 0, 0))
+                    .ok();
             });
         });
     }
@@ -312,7 +331,9 @@ impl uart::ReceiveClient for Nrf51822Serialization<'_> {
                 // Note: This indicates how many bytes were received by
                 // hardware, regardless of how much space (if any) was
                 // available in the buffer provided by the app.
-                kernel_data.schedule_upcall(0, (4, rx_len, len)).ok();
+                kernel_data
+                    .schedule_upcall(upcall::TX_DONE_RX_READY, (4, rx_len, len))
+                    .ok();
             }) {
                 // The app we had as active no longer exists. Clear that and
                 // stop receiving. This puts us back in an idle state. A new app

--- a/capsules/extra/src/nrf51822_serialization.rs
+++ b/capsules/extra/src/nrf51822_serialization.rs
@@ -121,33 +121,6 @@ impl<'a> Nrf51822Serialization<'a> {
 }
 
 impl SyscallDriver for Nrf51822Serialization<'_> {
-    /// Pass application space memory to this driver.
-    ///
-    /// This also sets which app is currently using this driver. Only one app
-    /// can control the nRF51 serialization driver.
-    ///
-    /// ### `allow_num`
-    ///
-    /// - `0`: Provide a RX buffer.
-
-    /// Pass application space memory to this driver.
-    ///
-    /// This also sets which app is currently using this driver. Only one app
-    /// can control the nRF51 serialization driver.
-    ///
-    /// ### `allow_num`
-    ///
-    /// - `0`: Provide a TX buffer.
-
-    // Register a callback to the Nrf51822Serialization driver.
-    //
-    // The callback will be called when a TX finishes and when
-    // RX data is available.
-    //
-    // ### `subscribe_num`
-    //
-    // - `0`: Set callback.
-
     /// Issue a command to the Nrf51822Serialization driver.
     ///
     /// ### `command_type`

--- a/capsules/extra/src/pca9544a.rs
+++ b/capsules/extra/src/pca9544a.rs
@@ -182,13 +182,6 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for PCA9544A<'_, I> {
 }
 
 impl<I: i2c::I2CDevice> SyscallDriver for PCA9544A<'_, I> {
-    // Setup callback for event done.
-    //
-    // ### `subscribe_num`
-    //
-    // - `0`: Upcall is triggered when a channel is finished being selected
-    //   or when the current channel setup is returned.
-
     /// Control the I2C selector.
     ///
     /// ### `command_num`

--- a/capsules/extra/src/pca9544a.rs
+++ b/capsules/extra/src/pca9544a.rs
@@ -64,6 +64,15 @@ enum ControlField {
     SelectedChannels,
 }
 
+/// IDs for subscribed upcalls.
+mod upcall {
+    /// Triggered when a channel is finished being selected or when the current
+    /// channel setup is returned.
+    pub const CHANNEL_DONE: usize = 0;
+    /// Number of upcalls.
+    pub const COUNT: u8 = 1;
+}
+
 #[derive(Default)]
 pub struct App {}
 
@@ -71,7 +80,7 @@ pub struct PCA9544A<'a, I: i2c::I2CDevice> {
     i2c: &'a I,
     state: Cell<State>,
     buffer: TakeCell<'static, [u8]>,
-    apps: Grant<App, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
+    apps: Grant<App, UpcallCount<{ upcall::COUNT }>, AllowRoCount<0>, AllowRwCount<0>>,
     owning_process: OptionalCell<ProcessId>,
 }
 
@@ -79,7 +88,7 @@ impl<'a, I: i2c::I2CDevice> PCA9544A<'a, I> {
     pub fn new(
         i2c: &'a I,
         buffer: &'static mut [u8],
-        grant: Grant<App, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
+        grant: Grant<App, UpcallCount<{ upcall::COUNT }>, AllowRoCount<0>, AllowRwCount<0>>,
     ) -> Self {
         Self {
             i2c,
@@ -156,7 +165,10 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for PCA9544A<'_, I> {
                 self.owning_process.map(|pid| {
                     let _ = self.apps.enter(pid, |_app, upcalls| {
                         upcalls
-                            .schedule_upcall(0, (field as usize + 1, ret as usize, 0))
+                            .schedule_upcall(
+                                upcall::CHANNEL_DONE,
+                                (field as usize + 1, ret as usize, 0),
+                            )
                             .ok();
                     });
                 });
@@ -168,7 +180,9 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for PCA9544A<'_, I> {
             State::Done => {
                 self.owning_process.map(|pid| {
                     let _ = self.apps.enter(pid, |_app, upcalls| {
-                        upcalls.schedule_upcall(0, (0, 0, 0)).ok();
+                        upcalls
+                            .schedule_upcall(upcall::CHANNEL_DONE, (0, 0, 0))
+                            .ok();
                     });
                 });
 


### PR DESCRIPTION
### Pull Request Overview

In #2639 `subscribe` was remove from the `SyscallDriver` trait, and in #2906 also `allow_readwrite` and `allow_readonly` were removed.
Both PRs however left some of the code docs related to the removed functions. I am not sure if that was intentional, but it confused me quite a bit when I was looking into the code.

This PR proposes to remove these old docs. But I am quite new to tock, so maybe I am missing something and there was a reason for keeping them?

### Testing Strategy

_Not relevant.__


### TODO or Help Wanted

Open Questions:
- Is any information lost by removing the docs? 
- Are there any other related docs that should be updated?

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
<details><summary>Fails due to an unrelated error in `kernel/src/process_standard.rs:535:13` </summary>

```sh

error[E0308]: mismatched types
   --> kernel/src/process_standard.rs:535:13
    |
530 |         Some(storage_permissions::StoragePermissions::new(
    |              -------------------------------------------- arguments to this function are incorrect
...
535 |             write_id,
    |             ^^^^^^^^ expected `Option<NonZeroU32>`, found `Option<u32>`
    |
    = note: expected enum `Option<NonZeroU32>`
               found enum `Option<u32>`
note: associated function defined here
   --> kernel/src/storage_permissions.rs:49:19
    |
49  |     pub(crate) fn new(
    |                   ^^^
...
54  |         write_id: Option<NonZeroU32>,
    |         ----------------------------

```
 </details>
  
