### PR TITLE
Small licence checker enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ allstack stack stack-analysis:
 
 .PHONY: licensecheck
 licensecheck:
-	$(call banner,Licence checker)
+	$(call banner,License checker)
 	@cargo run --manifest-path=tools/license-checker/Cargo.toml --release
 
 ## Commands

--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,7 @@ allstack stack stack-analysis:
 
 .PHONY: licensecheck
 licensecheck:
+	$(call banner,Licence checker)
 	@cargo run --manifest-path=tools/license-checker/Cargo.toml --release
 
 ## Commands

--- a/tools/license-checker/Cargo.toml
+++ b/tools/license-checker/Cargo.toml
@@ -11,9 +11,9 @@ edition.workspace = true
 
 [dependencies]
 clap = { features = ["derive"], version = "4.0.29" }
+colored = "2.0.1"
 ignore = "0.4"
 thiserror = "1.0.37"
-colored = "2.0.1"
 
 [dependencies.syntect]
 default-features = false

--- a/tools/license-checker/Cargo.toml
+++ b/tools/license-checker/Cargo.toml
@@ -13,6 +13,7 @@ edition.workspace = true
 clap = { features = ["derive"], version = "4.0.29" }
 ignore = "0.4"
 thiserror = "1.0.37"
+colored = "2.0.1"
 
 [dependencies.syntect]
 default-features = false

--- a/tools/license-checker/src/main.rs
+++ b/tools/license-checker/src/main.rs
@@ -87,11 +87,11 @@
 
 #![allow(rustdoc::invalid_rust_codeblocks)]
 
+use colored::ColoredString;
+use colored::Colorize;
 use ignore::WalkBuilder;
 use std::path::{Path, PathBuf};
 use std::process::exit;
-
-use colored::Colorize;
 
 mod parser;
 use parser::{Cache, LineContents, ParseError, Parser};
@@ -117,32 +117,28 @@ struct Args {
     verbose: bool,
 }
 
-const ERROR_MESSAGE: &str = "error:";
-
-macro_rules! bright_red_and_bold_error_message {
-    () => {
-        ERROR_MESSAGE.bright_red().bold()
-    };
+fn error_prefix() -> ColoredString {
+    "error:".bright_red().bold()
 }
 
 #[derive(Debug, thiserror::Error, PartialEq)]
 enum LicenseError {
-    #[error("{} {}", bright_red_and_bold_error_message!(), "license header missing")]
+    #[error("{} {}", error_prefix(), "license header missing")]
     Missing,
 
-    #[error("{} {}", bright_red_and_bold_error_message!(), "missing blank line after header")]
+    #[error("{} {}", error_prefix(), "missing blank line after header")]
     MissingBlank,
 
-    #[error("{} {}", bright_red_and_bold_error_message!(), "missing copyright line")]
+    #[error("{} {}", error_prefix(), "missing copyright line")]
     MissingCopyright,
 
-    #[error("{} {}", bright_red_and_bold_error_message!(), "missing SPDX line")]
+    #[error("{} {}", error_prefix(), "missing SPDX line")]
     MissingSpdx,
 
-    #[error("{} {}", bright_red_and_bold_error_message!(), "incorrect first line")]
+    #[error("{} {}", error_prefix(), "incorrect first line")]
     WrongFirst,
 
-    #[error("{} {}", bright_red_and_bold_error_message!(), "wrong SPDX line")]
+    #[error("{} {}", error_prefix(), "wrong SPDX line")]
     WrongSpdx,
 }
 

--- a/tools/license-checker/src/main.rs
+++ b/tools/license-checker/src/main.rs
@@ -91,6 +91,8 @@ use ignore::WalkBuilder;
 use std::path::{Path, PathBuf};
 use std::process::exit;
 
+use colored::Colorize;
+
 mod parser;
 use parser::{Cache, LineContents, ParseError, Parser};
 
@@ -115,24 +117,26 @@ struct Args {
     verbose: bool,
 }
 
+const ERROR_MESSAGE: &str = "error:";
+
 #[derive(Debug, thiserror::Error, PartialEq)]
 enum LicenseError {
-    #[error("license header missing")]
+    #[error("{} {}", ERROR_MESSAGE.bright_red().bold(), "license header missing")]
     Missing,
 
-    #[error("missing blank line after header")]
+    #[error("{} {}", ERROR_MESSAGE.bright_red().bold(), "missing blank line after header")]
     MissingBlank,
 
-    #[error("missing copyright line")]
+    #[error("{} {}", ERROR_MESSAGE.bright_red().bold(), "missing copyright line")]
     MissingCopyright,
 
-    #[error("missing SPDX line")]
+    #[error("{} {}", ERROR_MESSAGE.bright_red().bold(), "missing SPDX line")]
     MissingSpdx,
 
-    #[error("incorrect first line")]
+    #[error("{} {}", ERROR_MESSAGE.bright_red().bold(), "incorrect first line")]
     WrongFirst,
 
-    #[error("wrong SPDX line")]
+    #[error("{} {}", ERROR_MESSAGE.bright_red().bold(), "wrong SPDX line")]
     WrongSpdx,
 }
 

--- a/tools/license-checker/src/main.rs
+++ b/tools/license-checker/src/main.rs
@@ -119,24 +119,30 @@ struct Args {
 
 const ERROR_MESSAGE: &str = "error:";
 
+macro_rules! bright_red_and_bold_error_message {
+    () => {
+        ERROR_MESSAGE.bright_red().bold()
+    };
+}
+
 #[derive(Debug, thiserror::Error, PartialEq)]
 enum LicenseError {
-    #[error("{} {}", ERROR_MESSAGE.bright_red().bold(), "license header missing")]
+    #[error("{} {}", bright_red_and_bold_error_message!(), "license header missing")]
     Missing,
 
-    #[error("{} {}", ERROR_MESSAGE.bright_red().bold(), "missing blank line after header")]
+    #[error("{} {}", bright_red_and_bold_error_message!(), "missing blank line after header")]
     MissingBlank,
 
-    #[error("{} {}", ERROR_MESSAGE.bright_red().bold(), "missing copyright line")]
+    #[error("{} {}", bright_red_and_bold_error_message!(), "missing copyright line")]
     MissingCopyright,
 
-    #[error("{} {}", ERROR_MESSAGE.bright_red().bold(), "missing SPDX line")]
+    #[error("{} {}", bright_red_and_bold_error_message!(), "missing SPDX line")]
     MissingSpdx,
 
-    #[error("{} {}", ERROR_MESSAGE.bright_red().bold(), "incorrect first line")]
+    #[error("{} {}", bright_red_and_bold_error_message!(), "incorrect first line")]
     WrongFirst,
 
-    #[error("{} {}", ERROR_MESSAGE.bright_red().bold(), "wrong SPDX line")]
+    #[error("{} {}", bright_red_and_bold_error_message!(), "wrong SPDX line")]
     WrongSpdx,
 }
 


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a red error message when errors are encountered. This
way, it's more obvious whether the licence checker failed or not. Additionally,
a banner is printed every time the test is launched.


### Testing Strategy

This pull request was manually tested.


### TODO or Help Wanted

No help wanted.


### Documentation Updated

- No updates are required.

### Formatting

- [x] Ran `make prepush`.
