### PR TITLE
tock-cells: change `OptionalCell::map` to pass a copy into the closure

### DIFF
--- a/capsules/core/src/i2c_master_slave_driver.rs
+++ b/capsules/core/src/i2c_master_slave_driver.rs
@@ -117,7 +117,7 @@ impl<'a, I: hil::i2c::I2CMasterSlave<'a>> hil::i2c::I2CHwMasterClient
                 self.master_buffer.replace(buffer);
 
                 self.app.map(|app| {
-                    let _ = self.apps.enter(*app, |_, kernel_data| {
+                    let _ = self.apps.enter(app, |_, kernel_data| {
                         kernel_data.schedule_upcall(0, (0, status, 0)).ok();
                     });
                 });
@@ -125,7 +125,7 @@ impl<'a, I: hil::i2c::I2CMasterSlave<'a>> hil::i2c::I2CHwMasterClient
 
             MasterAction::Read(read_len) => {
                 self.app.map(|app| {
-                    let _ = self.apps.enter(*app, |_, kernel_data| {
+                    let _ = self.apps.enter(app, |_, kernel_data| {
                         // Because this (somewhat incorrectly) doesn't report
                         // back how many bytes were read, the result of mut_enter
                         // is ignored. Note that this requires userspace to keep
@@ -155,7 +155,7 @@ impl<'a, I: hil::i2c::I2CMasterSlave<'a>> hil::i2c::I2CHwMasterClient
 
             MasterAction::WriteRead(read_len) => {
                 self.app.map(|app| {
-                    let _ = self.apps.enter(*app, |_, kernel_data| {
+                    let _ = self.apps.enter(app, |_, kernel_data| {
                         // Because this (somewhat incorrectly) doesn't report
                         // back how many bytes were read, the result of mut_enter
                         // is ignored. Note that this requires userspace to keep
@@ -206,7 +206,7 @@ impl<'a, I: hil::i2c::I2CMasterSlave<'a>> hil::i2c::I2CHwSlaveClient
         match transmission_type {
             hil::i2c::SlaveTransmissionType::Write => {
                 self.app.map(|app| {
-                    let _ = self.apps.enter(*app, |_, kernel_data| {
+                    let _ = self.apps.enter(app, |_, kernel_data| {
                         kernel_data
                             .get_readwrite_processbuffer(rw_allow::SLAVE_RX)
                             .and_then(|slave_rx| {
@@ -242,7 +242,7 @@ impl<'a, I: hil::i2c::I2CMasterSlave<'a>> hil::i2c::I2CHwSlaveClient
 
                 // Notify the app that the read finished
                 self.app.map(|app| {
-                    let _ = self.apps.enter(*app, |_, kernel_data| {
+                    let _ = self.apps.enter(app, |_, kernel_data| {
                         kernel_data.schedule_upcall(0, (4, length as usize, 0)).ok();
                     });
                 });
@@ -254,7 +254,7 @@ impl<'a, I: hil::i2c::I2CMasterSlave<'a>> hil::i2c::I2CHwSlaveClient
         // Pass this up to the client. Not much we can do until the application
         // has setup a buffer to read from.
         self.app.map(|app| {
-            let _ = self.apps.enter(*app, |_, kernel_data| {
+            let _ = self.apps.enter(app, |_, kernel_data| {
                 // Ask the app to setup a read buffer. The app must call
                 // command 3 after it has setup the shared read buffer with
                 // the correct bytes.
@@ -292,7 +292,7 @@ impl<'a, I: hil::i2c::I2CMasterSlave<'a>> SyscallDriver for I2CMasterSlaveDriver
         // some (alive) process
         let match_or_empty_or_nonexistant = self.app.map_or(true, |current_process| {
             self.apps
-                .enter(*current_process, |_, _| current_process == &process_id)
+                .enter(current_process, |_, _| current_process == process_id)
                 .unwrap_or(true)
         });
         if match_or_empty_or_nonexistant {

--- a/capsules/core/src/spi_controller.rs
+++ b/capsules/core/src/spi_controller.rs
@@ -191,7 +191,7 @@ impl<'a, S: SpiMasterDevice<'a>> SyscallDriver for Spi<'a, S> {
         // Check if this driver is free, or already dedicated to this process.
         let match_or_empty_or_nonexistant = self.current_process.map_or(true, |current_process| {
             self.grants
-                .enter(*current_process, |_, _| current_process == &process_id)
+                .enter(current_process, |_, _| current_process == process_id)
                 .unwrap_or(true)
         });
         if match_or_empty_or_nonexistant {
@@ -310,7 +310,7 @@ impl<'a, S: SpiMasterDevice<'a>> SpiMasterClient for Spi<'a, S> {
         _status: Result<(), ErrorCode>,
     ) {
         self.current_process.map(|process_id| {
-            let _ = self.grants.enter(*process_id, move |app, kernel_data| {
+            let _ = self.grants.enter(process_id, move |app, kernel_data| {
                 let rbuf = readbuf.map(|src| {
                     let index = app.index;
                     let _ = kernel_data

--- a/capsules/core/src/spi_peripheral.rs
+++ b/capsules/core/src/spi_peripheral.rs
@@ -177,7 +177,7 @@ impl<'a, S: SpiSlaveDevice<'a>> SyscallDriver for SpiPeripheral<'a, S> {
         // Check if this driver is free, or already dedicated to this process.
         let match_or_empty_or_nonexistant = self.current_process.map_or(true, |current_process| {
             self.grants
-                .enter(*current_process, |_, _| current_process == &process_id)
+                .enter(current_process, |_, _| current_process == process_id)
                 .unwrap_or(true)
         });
         if match_or_empty_or_nonexistant {
@@ -272,7 +272,7 @@ impl<'a, S: SpiSlaveDevice<'a>> SpiSlaveClient for SpiPeripheral<'a, S> {
         _status: Result<(), ErrorCode>,
     ) {
         self.current_process.map(|process_id| {
-            let _ = self.grants.enter(*process_id, move |app, kernel_data| {
+            let _ = self.grants.enter(process_id, move |app, kernel_data| {
                 let rbuf = readbuf.map(|src| {
                     let index = app.index;
                     let _ = kernel_data
@@ -325,7 +325,7 @@ impl<'a, S: SpiSlaveDevice<'a>> SpiSlaveClient for SpiPeripheral<'a, S> {
     // Simple callback for when chip has been selected
     fn chip_selected(&self) {
         self.current_process.map(|process_id| {
-            let _ = self.grants.enter(*process_id, move |app, kernel_data| {
+            let _ = self.grants.enter(process_id, move |app, kernel_data| {
                 let len = app.len;
                 kernel_data.schedule_upcall(1, (len, 0, 0)).ok();
             });

--- a/capsules/core/src/virtualizers/virtual_rng.rs
+++ b/capsules/core/src/virtualizers/virtual_rng.rs
@@ -142,7 +142,7 @@ impl<'a> Rng<'a> for VirtualRngMasterDevice<'a> {
             },
             |current_node| {
                 // Find if current device is the one in flight or not
-                if *current_node == self {
+                if current_node == self {
                     self.mux.rng.cancel()
                 } else {
                     Ok(())

--- a/capsules/core/src/virtualizers/virtual_uart.rs
+++ b/capsules/core/src/virtualizers/virtual_uart.rs
@@ -219,17 +219,18 @@ impl<'a> MuxUart<'a> {
                 node.tx_buffer.take().map(|buf| {
                     node.operation.map(move |op| match op {
                         Operation::Transmit { len } => {
-                            let _ = self.uart.transmit_buffer(buf, *len).map_err(
-                                move |(ecode, buf)| {
-                                    node.tx_client.map(move |client| {
-                                        node.transmitting.set(false);
-                                        client.transmitted_buffer(buf, 0, Err(ecode));
+                            let _ =
+                                self.uart
+                                    .transmit_buffer(buf, len)
+                                    .map_err(move |(ecode, buf)| {
+                                        node.tx_client.map(move |client| {
+                                            node.transmitting.set(false);
+                                            client.transmitted_buffer(buf, 0, Err(ecode));
+                                        });
                                     });
-                                },
-                            );
                         }
                         Operation::TransmitWord { word } => {
-                            let rcode = self.uart.transmit_word(*word);
+                            let rcode = self.uart.transmit_word(word);
                             if rcode != Ok(()) {
                                 node.tx_client.map(|client| {
                                     node.transmitting.set(false);

--- a/capsules/extra/src/analog_comparator.rs
+++ b/capsules/extra/src/analog_comparator.rs
@@ -143,7 +143,7 @@ impl<'a, A: hil::analog_comparator::AnalogComparator<'a>> SyscallDriver
         // Check if this driver is free, or already dedicated to this process.
         let match_or_empty_or_nonexistant = self.current_process.map_or(true, |current_process| {
             self.grants
-                .enter(*current_process, |_, _| current_process == &processid)
+                .enter(current_process, |_, _| current_process == processid)
                 .unwrap_or(true)
         });
         if match_or_empty_or_nonexistant {
@@ -179,7 +179,7 @@ impl<'a, A: hil::analog_comparator::AnalogComparator<'a>> hil::analog_comparator
     /// Upcall to userland, signaling the application
     fn fired(&self, channel: usize) {
         self.current_process.map(|processid| {
-            let _ = self.grants.enter(*processid, |_app, upcalls| {
+            let _ = self.grants.enter(processid, |_app, upcalls| {
                 upcalls.schedule_upcall(0, (channel, 0, 0)).ok();
             });
         });

--- a/capsules/extra/src/ble_advertising_driver.rs
+++ b/capsules/extra/src/ble_advertising_driver.rs
@@ -483,7 +483,7 @@ where
 {
     fn receive_event(&self, buf: &'static mut [u8], len: u8, result: Result<(), ErrorCode>) {
         self.receiving_app.map(|processid| {
-            let _ = self.app.enter(*processid, |app, kernel_data| {
+            let _ = self.app.enter(processid, |app, kernel_data| {
                 // Validate the received data, because ordinary BLE packets can be bigger than 39
                 // bytes. Thus, we need to check for that!
                 // Moreover, we use the packet header to find size but the radio reads maximum
@@ -521,7 +521,7 @@ where
                     Some(BLEState::Scanning(RadioChannel::AdvertisingChannel37)) => {
                         app.process_status =
                             Some(BLEState::Scanning(RadioChannel::AdvertisingChannel38));
-                        self.receiving_app.set(*processid);
+                        self.receiving_app.set(processid);
                         let _ = self.radio.set_tx_power(app.tx_power);
                         self.radio
                             .receive_advertisement(RadioChannel::AdvertisingChannel38);
@@ -529,7 +529,7 @@ where
                     Some(BLEState::Scanning(RadioChannel::AdvertisingChannel38)) => {
                         app.process_status =
                             Some(BLEState::Scanning(RadioChannel::AdvertisingChannel39));
-                        self.receiving_app.set(*processid);
+                        self.receiving_app.set(processid);
                         self.radio
                             .receive_advertisement(RadioChannel::AdvertisingChannel39);
                     }
@@ -558,15 +558,15 @@ where
     fn transmit_event(&self, buf: &'static mut [u8], _crc_ok: Result<(), ErrorCode>) {
         self.kernel_tx.replace(buf);
         self.sending_app.map(|processid| {
-            let _ = self.app.enter(*processid, |app, kernel_data| {
+            let _ = self.app.enter(processid, |app, kernel_data| {
                 match app.process_status {
                     Some(BLEState::Advertising(RadioChannel::AdvertisingChannel37)) => {
                         app.process_status =
                             Some(BLEState::Advertising(RadioChannel::AdvertisingChannel38));
-                        self.sending_app.set(*processid);
+                        self.sending_app.set(processid);
                         let _ = self.radio.set_tx_power(app.tx_power);
                         let _ = app.send_advertisement(
-                            *processid,
+                            processid,
                             kernel_data,
                             &self,
                             RadioChannel::AdvertisingChannel38,
@@ -576,9 +576,9 @@ where
                     Some(BLEState::Advertising(RadioChannel::AdvertisingChannel38)) => {
                         app.process_status =
                             Some(BLEState::Advertising(RadioChannel::AdvertisingChannel39));
-                        self.sending_app.set(*processid);
+                        self.sending_app.set(processid);
                         let _ = app.send_advertisement(
-                            *processid,
+                            processid,
                             kernel_data,
                             &self,
                             RadioChannel::AdvertisingChannel39,

--- a/capsules/extra/src/buzzer_driver.rs
+++ b/capsules/extra/src/buzzer_driver.rs
@@ -182,13 +182,16 @@ impl<'a, B: hil::buzzer::Buzzer<'a>> Buzzer<'a, B> {
     /// to the current active_app. Otherwise, a different app is trying to
     /// use the driver while it is already in use, therefore it is not valid.
     pub fn is_valid_app(&self, processid: ProcessId) -> bool {
-        self.active_app.map_or(true, |owning_app| {
-            if owning_app == &processid {
-                true
-            } else {
-                false
-            }
-        })
+        self.active_app.map_or(
+            true,
+            |owning_app| {
+                if owning_app == processid {
+                    true
+                } else {
+                    false
+                }
+            },
+        )
     }
 }
 

--- a/capsules/extra/src/crc.rs
+++ b/capsules/extra/src/crc.rs
@@ -410,7 +410,7 @@ impl<'a, C: Crc<'a>> Client for CrcDriver<'a, C> {
                     // Put the kernel buffer back
                     self.crc_buffer.replace(buffer.take());
                     self.current_process.map(|pid| {
-                        let _res = self.grant.enter(*pid, |grant, kernel_data| {
+                        let _res = self.grant.enter(pid, |grant, kernel_data| {
                             // This shouldn't happen unless there's a way to clear out a request
                             // through a system call: regardless, the request is gone, so cancel
                             // the CRC.
@@ -505,7 +505,7 @@ impl<'a, C: Crc<'a>> Client for CrcDriver<'a, C> {
                         Err((e, returned_buffer)) => {
                             self.crc_buffer.replace(returned_buffer.take());
                             self.current_process.map(|pid| {
-                                let _res = self.grant.enter(*pid, |grant, kernel_data| {
+                                let _res = self.grant.enter(pid, |grant, kernel_data| {
                                     grant.request = None;
                                     kernel_data
                                         .schedule_upcall(
@@ -523,7 +523,7 @@ impl<'a, C: Crc<'a>> Client for CrcDriver<'a, C> {
                 // The callback returned an error, pass it back to userspace
                 self.crc_buffer.replace(buffer.take());
                 self.current_process.map(|pid| {
-                    let _res = self.grant.enter(*pid, |grant, kernel_data| {
+                    let _res = self.grant.enter(pid, |grant, kernel_data| {
                         grant.request = None;
                         kernel_data
                             .schedule_upcall(0, (kernel::errorcode::into_statuscode(Err(e)), 0, 0))

--- a/capsules/extra/src/gpio_async.rs
+++ b/capsules/extra/src/gpio_async.rs
@@ -109,7 +109,7 @@ impl<Port: hil::gpio_async::Port> hil::gpio_async::Client for GPIOAsync<'_, Port
     fn done(&self, value: usize) {
         // alert currently configuring app
         self.configuring_process.map(|pid| {
-            let _ = self.grants.enter(*pid, |_app, upcalls| {
+            let _ = self.grants.enter(pid, |_app, upcalls| {
                 upcalls.schedule_upcall(0, (0, value, 0)).ok();
             });
         });

--- a/capsules/extra/src/hmac.rs
+++ b/capsules/extra/src/hmac.rs
@@ -119,7 +119,7 @@ impl<
     fn run(&self) -> Result<(), ErrorCode> {
         self.processid.map_or(Err(ErrorCode::RESERVE), |processid| {
             self.apps
-                .enter(*processid, |app, kernel_data| {
+                .enter(processid, |app, kernel_data| {
                     let ret = kernel_data
                         .get_readonly_processbuffer(ro_allow::KEY)
                         .and_then(|key| {
@@ -265,7 +265,7 @@ impl<
     ) {
         self.processid.map(move |id| {
             self.apps
-                .enter(*id, move |app, kernel_data| {
+                .enter(id, move |app, kernel_data| {
                     let mut data_len = 0;
                     let mut exit = false;
                     let mut static_buffer_len = 0;
@@ -399,7 +399,7 @@ impl<
     fn hash_done(&self, result: Result<(), ErrorCode>, digest: &'static mut [u8; L]) {
         self.processid.map(|id| {
             self.apps
-                .enter(*id, |_, kernel_data| {
+                .enter(id, |_, kernel_data| {
                     self.hmac.clear_data();
 
                     let pointer = digest[0] as *mut u8;
@@ -451,7 +451,7 @@ impl<
     fn verification_done(&self, result: Result<bool, ErrorCode>, compare: &'static mut [u8; L]) {
         self.processid.map(|id| {
             self.apps
-                .enter(*id, |_app, kernel_data| {
+                .enter(id, |_app, kernel_data| {
                     self.hmac.clear_data();
 
                     match result {
@@ -542,7 +542,7 @@ impl<
             // we need to verify that that application still exists, and remove
             // it as owner if not.
             if self.active.get() {
-                owning_app == &processid
+                owning_app == processid
             } else {
                 // Check the app still exists.
                 //
@@ -552,7 +552,7 @@ impl<
                 // longer exists and we return `true` to signify the
                 // "or_nonexistant" case.
                 self.apps
-                    .enter(*owning_app, |_, _| owning_app == &processid)
+                    .enter(owning_app, |_, _| owning_app == processid)
                     .unwrap_or(true)
             }
         });
@@ -566,7 +566,7 @@ impl<
             // we need to verify that that application still exists, and remove
             // it as owner if not.
             if self.active.get() {
-                owning_app == &processid
+                owning_app == processid
             } else {
                 // Check the app still exists.
                 //
@@ -576,7 +576,7 @@ impl<
                 // longer exists and we return `true` to signify the
                 // "or_nonexistant" case.
                 self.apps
-                    .enter(*owning_app, |_, _| owning_app == &processid)
+                    .enter(owning_app, |_, _| owning_app == processid)
                     .unwrap_or(true)
             }
         });

--- a/capsules/extra/src/l3gd20.rs
+++ b/capsules/extra/src/l3gd20.rs
@@ -326,7 +326,7 @@ impl SyscallDriver for L3gd20Spi<'_> {
 
         let match_or_empty_or_nonexistent = self.current_process.map_or(true, |current_process| {
             self.grants
-                .enter(*current_process, |_, _| current_process == &process_id)
+                .enter(current_process, |_, _| current_process == process_id)
                 .unwrap_or(true)
         });
 
@@ -423,7 +423,7 @@ impl spi::SpiMasterClient for L3gd20Spi<'_> {
         _status: Result<(), ErrorCode>,
     ) {
         self.current_process.map(|proc_id| {
-            let _result = self.grants.enter(*proc_id, |_app, upcalls| {
+            let _result = self.grants.enter(proc_id, |_app, upcalls| {
                 self.status.set(match self.status.get() {
                     L3gd20Status::IsPresent => {
                         let present = if let Some(ref buf) = read_buffer {

--- a/capsules/extra/src/lpm013m126.rs
+++ b/capsules/extra/src/lpm013m126.rs
@@ -349,7 +349,7 @@ where
             self.write_complete_pending_call.map(|pend| {
                 self.buffer
                     .take()
-                    .map(|buffer| client.write_complete(buffer, *pend));
+                    .map(|buffer| client.write_complete(buffer, pend));
             });
             self.write_complete_pending_call.take();
         });

--- a/capsules/extra/src/lps25hb.rs
+++ b/capsules/extra/src/lps25hb.rs
@@ -181,7 +181,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for LPS25HB<'_, I> {
             self.state.set(State::Idle);
             self.buffer.replace(buffer);
             self.owning_process.map(|pid| {
-                let _ = self.apps.enter(*pid, |_app, upcalls| {
+                let _ = self.apps.enter(pid, |_app, upcalls| {
                     upcalls.schedule_upcall(0, (0, 0, 0)).ok();
                 });
             });
@@ -207,7 +207,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for LPS25HB<'_, I> {
                     self.state.set(State::Idle);
                     self.buffer.replace(buffer);
                     self.owning_process.map(|pid| {
-                        let _ = self.apps.enter(*pid, |_app, upcalls| {
+                        let _ = self.apps.enter(pid, |_app, upcalls| {
                             upcalls
                                 .schedule_upcall(0, (into_statuscode(Err(error.into())), 0, 0))
                                 .ok();
@@ -222,7 +222,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for LPS25HB<'_, I> {
                     self.state.set(State::Idle);
                     self.buffer.replace(buffer);
                     self.owning_process.map(|pid| {
-                        let _ = self.apps.enter(*pid, |_app, upcalls| {
+                        let _ = self.apps.enter(pid, |_app, upcalls| {
                             upcalls
                                 .schedule_upcall(0, (into_statuscode(Err(error.into())), 0, 0))
                                 .ok();
@@ -241,7 +241,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for LPS25HB<'_, I> {
                     self.state.set(State::Idle);
                     self.buffer.replace(buffer);
                     self.owning_process.map(|pid| {
-                        let _ = self.apps.enter(*pid, |_app, upcalls| {
+                        let _ = self.apps.enter(pid, |_app, upcalls| {
                             upcalls
                                 .schedule_upcall(0, (into_statuscode(Err(error.into())), 0, 0))
                                 .ok();
@@ -256,7 +256,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for LPS25HB<'_, I> {
                     self.state.set(State::Idle);
                     self.buffer.replace(buffer);
                     self.owning_process.map(|pid| {
-                        let _ = self.apps.enter(*pid, |_app, upcalls| {
+                        let _ = self.apps.enter(pid, |_app, upcalls| {
                             upcalls
                                 .schedule_upcall(0, (into_statuscode(Err(error.into())), 0, 0))
                                 .ok();
@@ -275,7 +275,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for LPS25HB<'_, I> {
                 let pressure_ubar = (pressure * 1000) / 4096;
 
                 self.owning_process.map(|pid| {
-                    let _ = self.apps.enter(*pid, |_app, upcalls| {
+                    let _ = self.apps.enter(pid, |_app, upcalls| {
                         upcalls
                             .schedule_upcall(0, (pressure_ubar as usize, 0, 0))
                             .ok();
@@ -289,7 +289,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for LPS25HB<'_, I> {
                     self.state.set(State::Idle);
                     self.buffer.replace(buffer);
                     self.owning_process.map(|pid| {
-                        let _ = self.apps.enter(*pid, |_app, upcalls| {
+                        let _ = self.apps.enter(pid, |_app, upcalls| {
                             upcalls
                                 .schedule_upcall(0, (into_statuscode(Err(error.into())), 0, 0))
                                 .ok();
@@ -346,7 +346,7 @@ impl<I: i2c::I2CDevice> SyscallDriver for LPS25HB<'_, I> {
         // some (alive) process
         let match_or_empty_or_nonexistant = self.owning_process.map_or(true, |current_process| {
             self.apps
-                .enter(*current_process, |_, _| current_process == &process_id)
+                .enter(current_process, |_, _| current_process == process_id)
                 .unwrap_or(true)
         });
         if match_or_empty_or_nonexistant {

--- a/capsules/extra/src/lsm303agr.rs
+++ b/capsules/extra/src/lsm303agr.rs
@@ -415,7 +415,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303agrI2C<'_, I> {
                     false
                 };
                 self.owning_process.map(|pid| {
-                    let _res = self.apps.enter(*pid, |_app, upcalls| {
+                    let _res = self.apps.enter(pid, |_app, upcalls| {
                         upcalls
                             .schedule_upcall(0, (if present { 1 } else { 0 }, 0, 0))
                             .ok();
@@ -428,7 +428,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303agrI2C<'_, I> {
             State::SetPowerMode => {
                 let set_power = status == Ok(());
                 self.owning_process.map(|pid| {
-                    let _res = self.apps.enter(*pid, |_app, upcalls| {
+                    let _res = self.apps.enter(pid, |_app, upcalls| {
                         upcalls
                             .schedule_upcall(0, (if set_power { 1 } else { 0 }, 0, 0))
                             .ok();
@@ -449,7 +449,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303agrI2C<'_, I> {
             State::SetScaleAndResolution => {
                 let set_scale_and_resolution = status == Ok(());
                 self.owning_process.map(|pid| {
-                    let _res = self.apps.enter(*pid, |_app, upcalls| {
+                    let _res = self.apps.enter(pid, |_app, upcalls| {
                         upcalls
                             .schedule_upcall(
                                 0,
@@ -501,7 +501,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303agrI2C<'_, I> {
                     false
                 };
                 self.owning_process.map(|pid| {
-                    let _res = self.apps.enter(*pid, |_app, upcalls| {
+                    let _res = self.apps.enter(pid, |_app, upcalls| {
                         if values {
                             upcalls.schedule_upcall(0, (x, y, z)).ok();
                         } else {
@@ -516,7 +516,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303agrI2C<'_, I> {
             State::SetDataRate => {
                 let set_magneto_data_rate = status == Ok(());
                 self.owning_process.map(|pid| {
-                    let _res = self.apps.enter(*pid, |_app, upcalls| {
+                    let _res = self.apps.enter(pid, |_app, upcalls| {
                         upcalls
                             .schedule_upcall(0, (if set_magneto_data_rate { 1 } else { 0 }, 0, 0))
                             .ok();
@@ -534,7 +534,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303agrI2C<'_, I> {
             State::SetRange => {
                 let set_range = status == Ok(());
                 self.owning_process.map(|pid| {
-                    let _res = self.apps.enter(*pid, |_app, upcalls| {
+                    let _res = self.apps.enter(pid, |_app, upcalls| {
                         upcalls
                             .schedule_upcall(0, (if set_range { 1 } else { 0 }, 0, 0))
                             .ok();
@@ -556,7 +556,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303agrI2C<'_, I> {
                     client.callback(values);
                 });
                 self.owning_process.map(|pid| {
-                    let _res = self.apps.enter(*pid, |_app, upcalls| {
+                    let _res = self.apps.enter(pid, |_app, upcalls| {
                         if let Ok(temp) = values {
                             upcalls.schedule_upcall(0, (temp as usize, 0, 0)).ok();
                         } else {
@@ -596,7 +596,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303agrI2C<'_, I> {
                     false
                 };
                 self.owning_process.map(|pid| {
-                    let _res = self.apps.enter(*pid, |_app, upcalls| {
+                    let _res = self.apps.enter(pid, |_app, upcalls| {
                         if values {
                             upcalls.schedule_upcall(0, (x, y, z)).ok();
                         } else {
@@ -633,7 +633,7 @@ impl<I: i2c::I2CDevice> SyscallDriver for Lsm303agrI2C<'_, I> {
 
         let match_or_empty_or_nonexistant = self.owning_process.map_or(true, |current_process| {
             self.apps
-                .enter(*current_process, |_, _| current_process == &process_id)
+                .enter(current_process, |_, _| current_process == process_id)
                 .unwrap_or(true)
         });
         if match_or_empty_or_nonexistant {

--- a/capsules/extra/src/lsm303dlhc.rs
+++ b/capsules/extra/src/lsm303dlhc.rs
@@ -409,7 +409,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303dlhcI2C<'_, I> {
                 };
 
                 self.current_process.map(|process_id| {
-                    let _ = self.apps.enter(*process_id, |_grant, upcalls| {
+                    let _ = self.apps.enter(process_id, |_grant, upcalls| {
                         upcalls
                             .schedule_upcall(0, (if present { 1 } else { 0 }, 0, 0))
                             .ok();
@@ -424,7 +424,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303dlhcI2C<'_, I> {
                 let set_power = status == Ok(());
 
                 self.current_process.map(|process_id| {
-                    let _ = self.apps.enter(*process_id, |_grant, upcalls| {
+                    let _ = self.apps.enter(process_id, |_grant, upcalls| {
                         upcalls
                             .schedule_upcall(0, (if set_power { 1 } else { 0 }, 0, 0))
                             .ok();
@@ -445,7 +445,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303dlhcI2C<'_, I> {
                 let set_scale_and_resolution = status == Ok(());
 
                 self.current_process.map(|process_id| {
-                    let _ = self.apps.enter(*process_id, |_grant, upcalls| {
+                    let _ = self.apps.enter(process_id, |_grant, upcalls| {
                         upcalls
                             .schedule_upcall(
                                 0,
@@ -502,7 +502,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303dlhcI2C<'_, I> {
                 };
 
                 self.current_process.map(|process_id| {
-                    let _ = self.apps.enter(*process_id, |_grant, upcalls| {
+                    let _ = self.apps.enter(process_id, |_grant, upcalls| {
                         if values {
                             upcalls.schedule_upcall(0, (x, y, z)).ok();
                         } else {
@@ -519,7 +519,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303dlhcI2C<'_, I> {
                 let set_temperature_and_magneto_data_rate = status == Ok(());
 
                 self.current_process.map(|process_id| {
-                    let _ = self.apps.enter(*process_id, |_grant, upcalls| {
+                    let _ = self.apps.enter(process_id, |_grant, upcalls| {
                         upcalls
                             .schedule_upcall(
                                 0,
@@ -550,7 +550,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303dlhcI2C<'_, I> {
                 let set_range = status == Ok(());
 
                 self.current_process.map(|process_id| {
-                    let _ = self.apps.enter(*process_id, |_grant, upcalls| {
+                    let _ = self.apps.enter(process_id, |_grant, upcalls| {
                         upcalls
                             .schedule_upcall(0, (if set_range { 1 } else { 0 }, 0, 0))
                             .ok();
@@ -577,7 +577,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303dlhcI2C<'_, I> {
                 });
 
                 self.current_process.map(|process_id| {
-                    let _ = self.apps.enter(*process_id, |_grant, upcalls| {
+                    let _ = self.apps.enter(process_id, |_grant, upcalls| {
                         if let Ok(temp) = values {
                             upcalls.schedule_upcall(0, (temp as usize, 0, 0)).ok();
                         } else {
@@ -619,7 +619,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303dlhcI2C<'_, I> {
                 };
 
                 self.current_process.map(|process_id| {
-                    let _ = self.apps.enter(*process_id, |_grant, upcalls| {
+                    let _ = self.apps.enter(process_id, |_grant, upcalls| {
                         if values {
                             upcalls.schedule_upcall(0, (x, y, z)).ok();
                         } else {
@@ -659,7 +659,7 @@ impl<I: i2c::I2CDevice> SyscallDriver for Lsm303dlhcI2C<'_, I> {
         // some (alive) process
         let match_or_empty_or_nonexistant = self.current_process.map_or(true, |current_process| {
             self.apps
-                .enter(*current_process, |_, _| current_process == &process_id)
+                .enter(current_process, |_, _| current_process == process_id)
                 .unwrap_or(true)
         });
 

--- a/capsules/extra/src/ltc294x.rs
+++ b/capsules/extra/src/ltc294x.rs
@@ -447,7 +447,7 @@ impl<'a, I: i2c::I2CDevice> LTC294XDriver<'a, I> {
 impl<I: i2c::I2CDevice> LTC294XClient for LTC294XDriver<'_, I> {
     fn interrupt(&self) {
         self.owning_process.map(|pid| {
-            let _res = self.grants.enter(*pid, |_app, upcalls| {
+            let _res = self.grants.enter(pid, |_app, upcalls| {
                 upcalls.schedule_upcall(0, (0, 0, 0)).ok();
             });
         });
@@ -467,7 +467,7 @@ impl<I: i2c::I2CDevice> LTC294XClient for LTC294XDriver<'_, I> {
             | ((charge_alert_high as usize) << 3)
             | ((accumulated_charge_overflow as usize) << 4);
         self.owning_process.map(|pid| {
-            let _res = self.grants.enter(*pid, |_app, upcalls| {
+            let _res = self.grants.enter(pid, |_app, upcalls| {
                 upcalls
                     .schedule_upcall(0, (1, ret, self.ltc294x.model.get() as usize))
                     .ok();
@@ -477,7 +477,7 @@ impl<I: i2c::I2CDevice> LTC294XClient for LTC294XDriver<'_, I> {
 
     fn charge(&self, charge: u16) {
         self.owning_process.map(|pid| {
-            let _res = self.grants.enter(*pid, |_app, upcalls| {
+            let _res = self.grants.enter(pid, |_app, upcalls| {
                 upcalls.schedule_upcall(0, (2, charge as usize, 0)).ok();
             });
         });
@@ -485,7 +485,7 @@ impl<I: i2c::I2CDevice> LTC294XClient for LTC294XDriver<'_, I> {
 
     fn done(&self) {
         self.owning_process.map(|pid| {
-            let _res = self.grants.enter(*pid, |_app, upcalls| {
+            let _res = self.grants.enter(pid, |_app, upcalls| {
                 upcalls.schedule_upcall(0, (3, 0, 0)).ok();
             });
         });
@@ -493,7 +493,7 @@ impl<I: i2c::I2CDevice> LTC294XClient for LTC294XDriver<'_, I> {
 
     fn voltage(&self, voltage: u16) {
         self.owning_process.map(|pid| {
-            let _res = self.grants.enter(*pid, |_app, upcalls| {
+            let _res = self.grants.enter(pid, |_app, upcalls| {
                 upcalls.schedule_upcall(0, (4, voltage as usize, 0)).ok();
             });
         });
@@ -501,7 +501,7 @@ impl<I: i2c::I2CDevice> LTC294XClient for LTC294XDriver<'_, I> {
 
     fn current(&self, current: u16) {
         self.owning_process.map(|pid| {
-            let _res = self.grants.enter(*pid, |_app, upcalls| {
+            let _res = self.grants.enter(pid, |_app, upcalls| {
                 upcalls.schedule_upcall(0, (5, current as usize, 0)).ok();
             });
         });
@@ -555,7 +555,7 @@ impl<I: i2c::I2CDevice> SyscallDriver for LTC294XDriver<'_, I> {
 
         let match_or_empty_or_nonexistant = self.owning_process.map_or(true, |current_process| {
             self.grants
-                .enter(*current_process, |_, _| current_process == &process_id)
+                .enter(current_process, |_, _| current_process == process_id)
                 .unwrap_or(true)
         });
         if match_or_empty_or_nonexistant {

--- a/capsules/extra/src/max17205.rs
+++ b/capsules/extra/src/max17205.rs
@@ -419,7 +419,7 @@ impl<'a, I: i2c::I2CDevice> MAX17205Driver<'a, I> {
 impl<I: i2c::I2CDevice> MAX17205Client for MAX17205Driver<'_, I> {
     fn status(&self, status: u16, error: Result<(), ErrorCode>) {
         self.owning_process.map(|pid| {
-            let _ = self.apps.enter(*pid, |_app, upcalls| {
+            let _ = self.apps.enter(pid, |_app, upcalls| {
                 upcalls
                     .schedule_upcall(
                         0,
@@ -442,7 +442,7 @@ impl<I: i2c::I2CDevice> MAX17205Client for MAX17205Driver<'_, I> {
         error: Result<(), ErrorCode>,
     ) {
         self.owning_process.map(|pid| {
-            let _ = self.apps.enter(*pid, |_app, upcalls| {
+            let _ = self.apps.enter(pid, |_app, upcalls| {
                 upcalls
                     .schedule_upcall(
                         0,
@@ -459,7 +459,7 @@ impl<I: i2c::I2CDevice> MAX17205Client for MAX17205Driver<'_, I> {
 
     fn voltage_current(&self, voltage: u16, current: u16, error: Result<(), ErrorCode>) {
         self.owning_process.map(|pid| {
-            let _ = self.apps.enter(*pid, |_app, upcalls| {
+            let _ = self.apps.enter(pid, |_app, upcalls| {
                 upcalls
                     .schedule_upcall(
                         0,
@@ -476,7 +476,7 @@ impl<I: i2c::I2CDevice> MAX17205Client for MAX17205Driver<'_, I> {
 
     fn coulomb(&self, coulomb: u16, error: Result<(), ErrorCode>) {
         self.owning_process.map(|pid| {
-            let _ = self.apps.enter(*pid, |_app, upcalls| {
+            let _ = self.apps.enter(pid, |_app, upcalls| {
                 upcalls
                     .schedule_upcall(
                         0,
@@ -493,7 +493,7 @@ impl<I: i2c::I2CDevice> MAX17205Client for MAX17205Driver<'_, I> {
 
     fn romid(&self, rid: u64, error: Result<(), ErrorCode>) {
         self.owning_process.map(|pid| {
-            let _ = self.apps.enter(*pid, |_app, upcalls| {
+            let _ = self.apps.enter(pid, |_app, upcalls| {
                 upcalls
                     .schedule_upcall(
                         0,
@@ -542,7 +542,7 @@ impl<I: i2c::I2CDevice> SyscallDriver for MAX17205Driver<'_, I> {
         // some (alive) process
         let match_or_empty_or_nonexistant = self.owning_process.map_or(true, |current_process| {
             self.apps
-                .enter(*current_process, |_, _| current_process == &process_id)
+                .enter(current_process, |_, _| current_process == process_id)
                 .unwrap_or(true)
         });
         if match_or_empty_or_nonexistant {

--- a/capsules/extra/src/mlx90614.rs
+++ b/capsules/extra/src/mlx90614.rs
@@ -133,7 +133,7 @@ impl<'a> i2c::I2CClient for Mlx90614SMBus<'a> {
                 };
 
                 self.owning_process.map(|pid| {
-                    let _ = self.apps.enter(*pid, |_app, upcalls| {
+                    let _ = self.apps.enter(pid, |_app, upcalls| {
                         upcalls
                             .schedule_upcall(0, (if present { 1 } else { 0 }, 0, 0))
                             .ok();
@@ -156,13 +156,13 @@ impl<'a> i2c::I2CClient for Mlx90614SMBus<'a> {
                 });
                 if let Ok(temp) = values {
                     self.owning_process.map(|pid| {
-                        let _ = self.apps.enter(*pid, |_app, upcalls| {
+                        let _ = self.apps.enter(pid, |_app, upcalls| {
                             upcalls.schedule_upcall(0, (temp as usize, 0, 0)).ok();
                         });
                     });
                 } else {
                     self.owning_process.map(|pid| {
-                        let _ = self.apps.enter(*pid, |_app, upcalls| {
+                        let _ = self.apps.enter(pid, |_app, upcalls| {
                             upcalls.schedule_upcall(0, (0, 0, 0)).ok();
                         });
                     });
@@ -191,7 +191,7 @@ impl<'a> SyscallDriver for Mlx90614SMBus<'a> {
         // some (alive) process
         let match_or_empty_or_nonexistant = self.owning_process.map_or(true, |current_process| {
             self.apps
-                .enter(*current_process, |_, _| current_process == &process_id)
+                .enter(current_process, |_, _| current_process == process_id)
                 .unwrap_or(true)
         });
         if match_or_empty_or_nonexistant {

--- a/capsules/extra/src/pca9544a.rs
+++ b/capsules/extra/src/pca9544a.rs
@@ -154,7 +154,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for PCA9544A<'_, I> {
                 };
 
                 self.owning_process.map(|pid| {
-                    let _ = self.apps.enter(*pid, |_app, upcalls| {
+                    let _ = self.apps.enter(pid, |_app, upcalls| {
                         upcalls
                             .schedule_upcall(0, (field as usize + 1, ret as usize, 0))
                             .ok();
@@ -167,7 +167,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for PCA9544A<'_, I> {
             }
             State::Done => {
                 self.owning_process.map(|pid| {
-                    let _ = self.apps.enter(*pid, |_app, upcalls| {
+                    let _ = self.apps.enter(pid, |_app, upcalls| {
                         upcalls.schedule_upcall(0, (0, 0, 0)).ok();
                     });
                 });
@@ -214,7 +214,7 @@ impl<I: i2c::I2CDevice> SyscallDriver for PCA9544A<'_, I> {
         // some (alive) process
         let match_or_empty_or_nonexistant = self.owning_process.map_or(true, |current_process| {
             self.apps
-                .enter(*current_process, |_, _| current_process == &process_id)
+                .enter(current_process, |_, _| current_process == process_id)
                 .unwrap_or(true)
         });
         if match_or_empty_or_nonexistant {

--- a/capsules/extra/src/pwm.rs
+++ b/capsules/extra/src/pwm.rs
@@ -44,7 +44,7 @@ impl<'a, const NUM_PINS: usize> Pwm<'a, NUM_PINS> {
         self.active_process[pin].map_or(true, |id| {
             // If the app is empty, that means that there is no app currently using this pin,
             // therefore the pin could be usable by the new app
-            if id == &processid {
+            if id == processid {
                 // The same app is trying to access the pin it has access to, valid
                 true
             } else {

--- a/capsules/extra/src/screen.rs
+++ b/capsules/extra/src/screen.rs
@@ -333,7 +333,7 @@ impl<'a> Screen<'a> {
             || 0,
             |process_id| {
                 self.apps
-                    .enter(*process_id, |app, kernel_data| {
+                    .enter(process_id, |app, kernel_data| {
                         let position = app.write_position;
                         let mut len = app.write_len;
                         if position < len {

--- a/capsules/extra/src/sha.rs
+++ b/capsules/extra/src/sha.rs
@@ -114,7 +114,7 @@ impl<
     fn run(&self) -> Result<(), ErrorCode> {
         self.processid.map_or(Err(ErrorCode::RESERVE), |processid| {
             self.apps
-                .enter(*processid, |app, kernel_data| {
+                .enter(processid, |app, kernel_data| {
                     let ret = if let Some(op) = &app.sha_operation {
                         match op {
                             ShaOperation::Sha256 => self.sha.set_mode_sha256(),
@@ -242,7 +242,7 @@ impl<
     ) {
         self.processid.map(move |id| {
             self.apps
-                .enter(*id, move |app, kernel_data| {
+                .enter(id, move |app, kernel_data| {
                     let mut data_len = 0;
                     let mut exit = false;
                     let mut static_buffer_len = 0;
@@ -377,7 +377,7 @@ impl<
     fn hash_done(&self, result: Result<(), ErrorCode>, digest: &'static mut [u8; L]) {
         self.processid.map(|id| {
             self.apps
-                .enter(*id, |_, kernel_data| {
+                .enter(id, |_, kernel_data| {
                     self.sha.clear_data();
 
                     let pointer = digest.as_ref()[0] as *mut u8;
@@ -431,7 +431,7 @@ impl<
     fn verification_done(&self, result: Result<bool, ErrorCode>, compare: &'static mut [u8; L]) {
         self.processid.map(|id| {
             self.apps
-                .enter(*id, |_app, kernel_data| {
+                .enter(id, |_app, kernel_data| {
                     self.sha.clear_data();
 
                     match result {
@@ -500,7 +500,7 @@ impl<
             // we need to verify that that application still exists, and remove
             // it as owner if not.
             if self.active.get() {
-                owning_app == &processid
+                owning_app == processid
             } else {
                 // Check the app still exists.
                 //
@@ -510,7 +510,7 @@ impl<
                 // longer exists and we return `true` to signify the
                 // "or_nonexistant" case.
                 self.apps
-                    .enter(*owning_app, |_, _| owning_app == &processid)
+                    .enter(owning_app, |_, _| owning_app == processid)
                     .unwrap_or(true)
             }
         });
@@ -524,7 +524,7 @@ impl<
             // we need to verify that that application still exists, and remove
             // it as owner if not.
             if self.active.get() {
-                owning_app == &processid
+                owning_app == processid
             } else {
                 // Check the app still exists.
                 //
@@ -534,7 +534,7 @@ impl<
                 // longer exists and we return `true` to signify the
                 // "or_nonexistant" case.
                 self.apps
-                    .enter(*owning_app, |_, _| owning_app == &processid)
+                    .enter(owning_app, |_, _| owning_app == processid)
                     .unwrap_or(true)
             }
         });

--- a/capsules/extra/src/symmetric_encryption/aes.rs
+++ b/capsules/extra/src/symmetric_encryption/aes.rs
@@ -89,7 +89,7 @@ impl<
     fn run(&self) -> Result<(), ErrorCode> {
         self.processid.map_or(Err(ErrorCode::RESERVE), |processid| {
             self.apps
-                .enter(*processid, |app, kernel_data| {
+                .enter(processid, |app, kernel_data| {
                     self.aes.enable();
                     let ret = if let Some(op) = &app.aes_operation {
                         match op {
@@ -434,7 +434,7 @@ impl<
 
         self.processid.map(|id| {
             self.apps
-                .enter(*id, |app, kernel_data| {
+                .enter(id, |app, kernel_data| {
                     let mut data_len = 0;
                     let mut exit = false;
                     let mut static_buffer_len = 0;
@@ -589,7 +589,7 @@ impl<
 
         self.processid.map(|id| {
             self.apps
-                .enter(*id, |_, kernel_data| {
+                .enter(id, |_, kernel_data| {
                     let mut exit = false;
 
                     if let Err(e) = res {
@@ -667,7 +667,7 @@ impl<
 
         self.processid.map(|id| {
             self.apps
-                .enter(*id, |_, kernel_data| {
+                .enter(id, |_, kernel_data| {
                     let mut exit = false;
 
                     if let Err(e) = res {
@@ -756,7 +756,7 @@ impl<
             // we need to verify that that application still exists, and remove
             // it as owner if not.
             if self.active.get() {
-                owning_app == &processid
+                owning_app == processid
             } else {
                 // Check the app still exists.
                 //
@@ -766,7 +766,7 @@ impl<
                 // longer exists and we return `true` to signify the
                 // "or_nonexistant" case.
                 self.apps
-                    .enter(*owning_app, |_, _| owning_app == &processid)
+                    .enter(owning_app, |_, _| owning_app == processid)
                     .unwrap_or(true)
             }
         });
@@ -780,7 +780,7 @@ impl<
             // we need to verify that that application still exists, and remove
             // it as owner if not.
             if self.active.get() {
-                owning_app == &processid
+                owning_app == processid
             } else {
                 // Check the app still exists.
                 //
@@ -790,7 +790,7 @@ impl<
                 // longer exists and we return `true` to signify the
                 // "or_nonexistant" case.
                 self.apps
-                    .enter(*owning_app, |_, _| owning_app == &processid)
+                    .enter(owning_app, |_, _| owning_app == processid)
                     .unwrap_or(true)
             }
         });

--- a/capsules/extra/src/text_screen.rs
+++ b/capsules/extra/src/text_screen.rs
@@ -148,7 +148,7 @@ impl<'a> TextScreen<'a> {
         let mut run_next = false;
         let res = self.current_app.map_or(Err(ErrorCode::FAIL), |app| {
             self.apps
-                .enter(*app, |app, kernel_data| match app.command {
+                .enter(app, |app, kernel_data| match app.command {
                     TextScreenCommand::GetResolution => {
                         let (x, y) = self.text_screen.get_size();
                         app.pending_command = false;

--- a/capsules/extra/src/tsl2561.rs
+++ b/capsules/extra/src/tsl2561.rs
@@ -428,7 +428,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for TSL2561<'_, I> {
                 let lux = self.calculate_lux(chan0, chan1);
 
                 self.owning_process.map(|pid| {
-                    let _ = self.apps.enter(*pid, |_, upcalls| {
+                    let _ = self.apps.enter(pid, |_, upcalls| {
                         upcalls.schedule_upcall(0, (0, lux, 0)).ok();
                     });
                 });
@@ -482,7 +482,7 @@ impl<I: i2c::I2CDevice> SyscallDriver for TSL2561<'_, I> {
         // some (alive) process
         let match_or_empty_or_nonexistant = self.owning_process.map_or(true, |current_process| {
             self.apps
-                .enter(*current_process, |_, _| current_process == &process_id)
+                .enter(current_process, |_, _| current_process == process_id)
                 .unwrap_or(true)
         });
         if match_or_empty_or_nonexistant {

--- a/capsules/extra/src/usb_hid_driver.rs
+++ b/capsules/extra/src/usb_hid_driver.rs
@@ -113,7 +113,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> usb_hid::Client<'a, [u8; 64]> for Usb
     ) {
         self.processid.map(|id| {
             self.app
-                .enter(*id, |app, kernel_data| {
+                .enter(id, |app, kernel_data| {
                     let _ = kernel_data
                         .get_readwrite_processbuffer(rw_allow::RECV)
                         .and_then(|recv| {
@@ -143,7 +143,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> usb_hid::Client<'a, [u8; 64]> for Usb
     ) {
         self.processid.map(|id| {
             self.app
-                .enter(*id, |_app, kernel_data| {
+                .enter(id, |_app, kernel_data| {
                     kernel_data.schedule_upcall(0, (1, 0, 0)).ok();
                 })
                 .map_err(|err| {
@@ -161,7 +161,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> usb_hid::Client<'a, [u8; 64]> for Usb
         self.processid
             .map(|id| {
                 self.app
-                    .enter(*id, |app, _| app.can_receive.get())
+                    .enter(id, |app, _| app.can_receive.get())
                     .unwrap_or(false)
             })
             .unwrap_or(false)
@@ -186,7 +186,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> SyscallDriver for UsbHidDriver<'a, U>
         processid: ProcessId,
     ) -> CommandReturn {
         let can_access = self.processid.map_or(true, |owning_app| {
-            if owning_app == &processid {
+            if owning_app == processid {
                 // We own the HID device
                 true
             } else {

--- a/chips/stm32f303xc/src/gpio.rs
+++ b/chips/stm32f303xc/src/gpio.rs
@@ -1163,6 +1163,6 @@ impl<'a> hil::gpio::Interrupt<'a> for Pin<'a> {
 
     fn is_pending(&self) -> bool {
         self.exti_lineid
-            .map_or(false, |&mut lineid| self.exti.is_pending(lineid))
+            .map_or(false, |lineid| self.exti.is_pending(lineid))
     }
 }

--- a/chips/stm32f4xx/src/dma.rs
+++ b/chips/stm32f4xx/src/dma.rs
@@ -807,7 +807,7 @@ impl<'a, DMA: StreamServer<'a>> Stream<'a, DMA> {
 
         self.client.map(|client| {
             self.peripheral.map(|pid| {
-                client.transfer_done(*pid);
+                client.transfer_done(pid);
             });
         });
     }

--- a/chips/stm32f4xx/src/gpio.rs
+++ b/chips/stm32f4xx/src/gpio.rs
@@ -1250,6 +1250,6 @@ impl<'a> hil::gpio::Interrupt<'a> for Pin<'a> {
 
     fn is_pending(&self) -> bool {
         self.exti_lineid
-            .map_or(false, |&mut lineid| self.exti.is_pending(lineid))
+            .map_or(false, |lineid| self.exti.is_pending(lineid))
     }
 }

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -1446,7 +1446,7 @@ impl ProcessCheckerMachine {
             // Try to check the next footer.
             let check_result = self.policy.map_or(FooterCheckResult::Error, |c| {
                 self.processes[proc_index].map_or(FooterCheckResult::NoProcess, |p| {
-                    check_footer(p, *c, footer_index)
+                    check_footer(p, c, footer_index)
                 })
             });
 

--- a/libraries/tock-cells/src/optional_cell.rs
+++ b/libraries/tock-cells/src/optional_cell.rs
@@ -185,20 +185,18 @@ impl<T: Copy> OptionalCell<T> {
     /// Call a closure on the value if the value exists.
     pub fn map<F, R>(&self, closure: F) -> Option<R>
     where
-        F: FnOnce(&mut T) -> R,
+        F: FnOnce(T) -> R,
     {
-        self.value.get().map(|mut val| closure(&mut val))
+        self.value.get().map(|val| closure(val))
     }
 
     /// Call a closure on the value if the value exists, or return the
     /// default if the value is `None`.
     pub fn map_or<F, R>(&self, default: R, closure: F) -> R
     where
-        F: FnOnce(&mut T) -> R,
+        F: FnOnce(T) -> R,
     {
-        self.value
-            .get()
-            .map_or(default, |mut val| closure(&mut val))
+        self.value.get().map_or(default, |val| closure(val))
     }
 
     /// If the cell contains a value, call a closure supplied with the
@@ -207,11 +205,9 @@ impl<T: Copy> OptionalCell<T> {
     pub fn map_or_else<U, D, F>(&self, default: D, closure: F) -> U
     where
         D: FnOnce() -> U,
-        F: FnOnce(&mut T) -> U,
+        F: FnOnce(T) -> U,
     {
-        self.value
-            .get()
-            .map_or_else(default, |mut val| closure(&mut val))
+        self.value.get().map_or_else(default, |val| closure(val))
     }
 
     /// If the cell is empty, return `None`. Otherwise, call a closure


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the semantics of `OptionalCell::map` to move a copy of the internal `Option`'s value into the provided closure. Proving a mutable reference to a copy that is then immediately discarded is very confusing.

An alternative design would remove the `map` APIs and add a `get()` method, which returns an `Option<T>`. Then we can use the `map*` methods on that returned type.


### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

This pull request still needs porting of the rest of the kernel to this new interface. This should be mostly mechanical changes.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
