### PR TITLE
tock-cells/OptionalCell: rename extract-method to get

### DIFF
--- a/chips/sam4l/src/crccu.rs
+++ b/chips/sam4l/src/crccu.rs
@@ -437,7 +437,7 @@ impl<'a> Crc<'a> for Crccu<'a> {
         &self,
         mut data: LeasableMutableBuffer<'static, u8>,
     ) -> Result<(), (ErrorCode, LeasableMutableBuffer<'static, u8>)> {
-        let algorithm = if let Some(algorithm) = self.algorithm.extract() {
+        let algorithm = if let Some(algorithm) = self.algorithm.get() {
             algorithm
         } else {
             return Err((ErrorCode::RESERVE, data));

--- a/chips/stm32f4xx/src/can.rs
+++ b/chips/stm32f4xx/src/can.rs
@@ -558,7 +558,7 @@ impl<'a> Can<'a> {
             false => self.registers.can_mcr.modify(CAN_MCR::NART::SET),
         }
 
-        if let Some(operating_mode_settings) = self.operating_mode.extract() {
+        if let Some(operating_mode_settings) = self.operating_mode.get() {
             match operating_mode_settings {
                 can::OperationMode::Loopback => self.registers.can_btr.modify(CAN_BTR::LBKM::SET),
                 can::OperationMode::Monitoring => self.registers.can_btr.modify(CAN_BTR::SILM::SET),
@@ -568,7 +568,7 @@ impl<'a> Can<'a> {
         }
 
         // set bit timing mode
-        if let Some(bit_timing_settings) = self.bit_timing.extract() {
+        if let Some(bit_timing_settings) = self.bit_timing.get() {
             self.registers
                 .can_btr
                 .modify(CAN_BTR::TS1.val(bit_timing_settings.segment1 as u32));
@@ -1180,7 +1180,7 @@ impl<'a> can::Configure for Can<'_> {
     }
 
     fn get_bit_timing(&self) -> Result<can::BitTiming, kernel::ErrorCode> {
-        if let Some(bit_timing) = self.bit_timing.extract() {
+        if let Some(bit_timing) = self.bit_timing.get() {
             Ok(bit_timing)
         } else {
             Err(kernel::ErrorCode::INVAL)
@@ -1188,7 +1188,7 @@ impl<'a> can::Configure for Can<'_> {
     }
 
     fn get_operation_mode(&self) -> Result<can::OperationMode, kernel::ErrorCode> {
-        if let Some(operation_mode) = self.operating_mode.extract() {
+        if let Some(operation_mode) = self.operating_mode.get() {
             Ok(operation_mode)
         } else {
             Err(kernel::ErrorCode::INVAL)

--- a/chips/virtio/src/transports/mmio.rs
+++ b/chips/virtio/src/transports/mmio.rs
@@ -402,7 +402,7 @@ impl VirtIOTransport for VirtIOMMIODevice {
             queue_id
                 < self
                     .queues
-                    .extract()
+                    .get()
                     .expect("VirtIO transport not initialized")
                     .len() as u32
         );

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -1042,7 +1042,7 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
     }
 
     fn get_completion_code(&self) -> Option<Option<u32>> {
-        self.completion_code.extract()
+        self.completion_code.get()
     }
 
     fn set_syscall_return_value(&self, return_value: SyscallReturn) {

--- a/libraries/tock-cells/src/optional_cell.rs
+++ b/libraries/tock-cells/src/optional_cell.rs
@@ -154,8 +154,8 @@ impl<T> OptionalCell<T> {
 }
 
 impl<T: Copy> OptionalCell<T> {
-    /// Returns a copy of the contained [`Option`].
-    pub fn extract(&self) -> Option<T> {
+    /// Returns a copy the contained [`Option`].
+    pub fn get(&self) -> Option<T> {
         self.value.get()
     }
 

--- a/libraries/tock-cells/src/optional_cell.rs
+++ b/libraries/tock-cells/src/optional_cell.rs
@@ -154,7 +154,35 @@ impl<T> OptionalCell<T> {
 }
 
 impl<T: Copy> OptionalCell<T> {
-    /// Returns a copy the contained [`Option`].
+    /// Returns a copy of the contained [`Option`].
+    //
+    // This was originally introduced in PR #2531 [1], then renamed to `extract`
+    // in PR #2533 [2], and finally renamed back in PR #3536 [3].
+    //
+    // The rationale for including a `get` method is to allow developers to
+    // treat an `OptionalCell<T>` as what it is underneath: a `Cell<Option<T>>`.
+    // This is useful to be interoperable with APIs that take an `Option<T>`, or
+    // to use an *if-let* or *match* expression to perform case-analysis on the
+    // `OptionalCell`'s state: this avoids using a closure and can thus allow
+    // Rust to deduce that only a single branch will ever be entered (either the
+    // `Some(_)` or `None`) branch, avoiding lifetime & move restrictions.
+    //
+    // However, there was pushback for that name, as an `OptionalCell`'s `get`
+    // method might indicate that it should directly return a `T` -- given that
+    // `OptionalCell<T>` presents itself as to be a wrapper around
+    // `T`. Furthermore, adding `.get()` might have developers use
+    // `.get().map(...)` instead, which defeats the purpose of having the
+    // `OptionalCell` convenience wrapper in the first place. For these reasons,
+    // `get` was renamed to `extract`.
+    //
+    // Unfortunately, `extract` turned out to be a confusing name, as it is not
+    // an idiomatic method name as found on Rust's standard library types, and
+    // further suggests that it actually removes a value from the `OptionalCell`
+    // (as the `take` method does). Thus, it has been renamed back to `get`.
+    //
+    // [1]: https://github.com/tock/tock/pull/2531
+    // [2]: https://github.com/tock/tock/pull/2533
+    // [3]: https://github.com/tock/tock/pull/3536
     pub fn get(&self) -> Option<T> {
         self.value.get()
     }


### PR DESCRIPTION
### Pull Request Overview

In response to https://github.com/tock/tock/pull/2531#issuecomment-1625703637, this renames `OptionalCell::extract` to `OptionalCell::get`. Hence this reverts commit 3136f00a77173708625256011be54ee24778364f.

I agree that `extract` is extremely confusing in this context -- we're operating on a cell, and `extract` could reasonably suggest that it removes the value from the `OptionalCell`. This is amplified by the fact that `take` (the natural method name for a "destructive get" in `TakeCell`) implies move-semantics, which we don't have in `OptionalCell<T>`, as it requires that `T: Copy`. Even though I originally made the `get -> extract` change, I still get this wrong.

Now, do I want to open this can of worms again? I don't know. I still believe we need a method on `OptionalCell` whose signature is `fn somename(&self) -> Option<T>`. Is `get` the right name? At least some evidence (in @kupiakos) seems to suggest that it's not entirely atypical for a `get` method to return an `Option<T>`, and it is the only interpretation of `get` that makes sense given `OptionalCell`'s semantics. On the other hand, I think the concerns over this name as raised on the initial PR (#2531) are fair.

### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

This pull request still needs bike-shedding of the method name.


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`, or~ no updates are required.

### Formatting

- [x] Ran `make prepush`.
