### PR TITLE
Fix MapCell safety 2.0

### DIFF
--- a/libraries/tock-cells/src/map_cell.rs
+++ b/libraries/tock-cells/src/map_cell.rs
@@ -2,61 +2,179 @@
 
 use core::cell::{Cell, UnsafeCell};
 use core::mem::MaybeUninit;
-use core::ptr;
+use core::ptr::drop_in_place;
 
-/// A mutable memory location that enforces borrow rules at runtime without
-/// possible panics.
+#[derive(Clone, Copy, PartialEq)]
+enum MapCellState {
+    Uninit,
+    Init,
+    Borrowed,
+}
+
+#[inline(never)]
+#[cold]
+fn access_panic() {
+    panic!("`MapCell` accessed while borrowed");
+}
+
+macro_rules! debug_assert_not_borrowed {
+    ($slf:ident) => {
+        if cfg!(debug_assertions) && $slf.occupied.get() == MapCellState::Borrowed {
+            access_panic();
+        }
+    };
+}
+
+/// A mutable, possibly unset, memory location that provides checked `&mut` access
+/// to its contents via a closure.
 ///
-/// A `MapCell` is a potential reference to mutable memory. Borrow rules are
-/// enforced by forcing clients to either move the memory out of the cell or
-/// operate on a borrow within a closure. You can think of a `MapCell` as an
-/// `Option` wrapped in a `RefCell` --- attempts to take the value from inside a
-/// `MapCell` may fail by returning `None`.
+/// A `MapCell` provides checked shared access to its mutable memory. Borrow
+/// rules are enforced by forcing clients to either move the memory out of the
+/// cell or operate on a `&mut` within a closure. You can think of a `MapCell`
+/// as a `Cell<Option<T>>` with an extra "in-use" state to prevent `map` from invoking
+/// undefined behavior when called re-entrantly.
+///
+/// # Examples
+/// ```
+/// # use tock_cells::map_cell::MapCell;
+/// let cell: MapCell<i64> = MapCell::empty();
+///
+/// assert!(cell.is_none());
+/// cell.map(|_| unreachable!("The cell is empty; map does not call the closure"));
+/// assert_eq!(cell.take(), None);
+/// cell.put(10);
+/// assert_eq!(cell.take(), Some(10));
+/// assert_eq!(cell.replace(20), None);
+/// assert_eq!(cell.get(), Some(20));
+///
+/// cell.map(|x| {
+///     assert_eq!(x, &mut 20);
+///     // `map` provides a `&mut` to the contents inside the closure
+///     *x = 30;
+/// });
+/// assert_eq!(cell.replace(60), Some(30));
+/// ```
 pub struct MapCell<T> {
     // Since val is potentially uninitialized memory, we must be sure to check
     // `.occupied` before calling `.val.get()` or `.val.assume_init()`. See
     // [mem::MaybeUninit](https://doc.rust-lang.org/core/mem/union.MaybeUninit.html).
     val: UnsafeCell<MaybeUninit<T>>,
-    occupied: Cell<bool>,
+
+    // Safety invariants:
+    // - The contents of `val` must be initialized if this is `Init` or `InsideMap`.
+    // - It must be sound to mutate `val` behind a shared reference if this is `Uninit` or `Init`.
+    //   No outside mutation can occur while a `&mut` to the contents of `val` exist.
+    occupied: Cell<MapCellState>,
+}
+
+impl<T> Drop for MapCell<T> {
+    fn drop(&mut self) {
+        let state = self.occupied.get();
+        debug_assert_not_borrowed!(self); // This should be impossible
+        if state == MapCellState::Init {
+            unsafe {
+                // SAFETY:
+                // - `occupied` is `Init`; `val` is initialized as an invariant.
+                // - Even though this violates the `occupied` invariant, by causing `val`
+                //   to be no longer valid, `self` is immediately dropped.
+                drop_in_place(self.val.get_mut().as_mut_ptr())
+            }
+        }
+    }
+}
+
+impl<T: Copy> MapCell<T> {
+    /// Gets the contents of the cell, if any.
+    ///
+    /// Returns `None` if the cell is empty.
+    ///
+    /// This requires the held type be `Copy` for the same reason [`Cell::get`] does:
+    /// it leaves the contents of `self` intact and so it can't have drop glue.
+    ///
+    /// This returns `None` in release mode if the `MapCell`'s contents are already borrowed.
+    ///
+    /// # Examples
+    /// ```
+    /// # use tock_cells::map_cell::MapCell;
+    /// let cell: MapCell<u32> = MapCell::empty();
+    /// assert_eq!(cell.get(), None);
+    ///
+    /// cell.put(20);
+    /// assert_eq!(cell.get(), Some(20));
+    /// ```
+    ///
+    /// # Panics
+    /// If debug assertions are enabled, this panics if the `MapCell`'s contents are already borrowed.
+    pub fn get(&self) -> Option<T> {
+        debug_assert_not_borrowed!(self);
+        // SAFETY:
+        // - `Init` means that `val` is initialized and can be read
+        // - `T: Copy` so there is no drop glue
+        (self.occupied.get() == MapCellState::Init)
+            .then(|| unsafe { self.val.get().read().assume_init() })
+    }
 }
 
 impl<T> MapCell<T> {
-    /// Creates an empty `MapCell`
+    /// Creates an empty `MapCell`.
     pub const fn empty() -> MapCell<T> {
         MapCell {
             val: UnsafeCell::new(MaybeUninit::uninit()),
-            occupied: Cell::new(false),
+            occupied: Cell::new(MapCellState::Uninit),
         }
     }
 
-    /// Creates a new `MapCell` containing `value`
+    /// Creates a new `MapCell` containing `value`.
     pub const fn new(value: T) -> MapCell<T> {
         MapCell {
-            val: UnsafeCell::new(MaybeUninit::<T>::new(value)),
-            occupied: Cell::new(true),
+            val: UnsafeCell::new(MaybeUninit::new(value)),
+            occupied: Cell::new(MapCellState::Init),
         }
     }
 
-    /// Returns a boolean which indicates if the MapCell is unoccupied.
+    /// Returns `true` if the `MapCell` contains no value.
+    ///
+    /// # Examples
+    /// ```
+    /// # use tock_cells::map_cell::MapCell;
+    /// let x: MapCell<i32> = MapCell::empty();
+    /// assert!(x.is_none());
+    ///
+    /// x.put(10);
+    /// x.map(|_| assert!(!x.is_none()));
+    /// assert!(!x.is_none());
+    /// ```
     pub fn is_none(&self) -> bool {
         !self.is_some()
     }
 
-    /// Returns a boolean which indicates if the MapCell is occupied.
+    /// Returns `true` if the `MapCell` contains a value.
+    ///
+    /// # Examples
+    /// ```
+    /// # use tock_cells::map_cell::MapCell;
+    /// let x: MapCell<i32> = MapCell::new(10);
+    /// assert!(x.is_some());
+    /// x.map(|_| assert!(x.is_some()));
+    ///
+    /// x.take();
+    /// assert!(!x.is_some());
+    /// ```
     pub fn is_some(&self) -> bool {
-        self.occupied.get()
+        self.occupied.get() != MapCellState::Uninit
     }
 
-    /// Takes the value out of the `MapCell` leaving it empty. If
-    /// the value has already been taken elsewhere (and not `replace`ed), the
-    /// returned `Option` will be `None`.
+    /// Takes the value out of the `MapCell`, leaving it empty.
+    ///
+    /// Returns `None` if the cell is empty.
+    ///
+    /// To save size, this has no effect and returns `None` in release mode
+    /// if the `MapCell`'s contents are already borrowed.
     ///
     /// # Examples
     ///
     /// ```
-    /// extern crate tock_cells;
-    /// use tock_cells::map_cell::MapCell;
-    ///
+    /// # use tock_cells::map_cell::MapCell;
     /// let cell = MapCell::new(1234);
     /// let x = &cell;
     /// let y = &cell;
@@ -64,53 +182,74 @@ impl<T> MapCell<T> {
     /// assert_eq!(x.take(), Some(1234));
     /// assert_eq!(y.take(), None);
     /// ```
+    ///
+    /// # Panics
+    /// If debug assertions are enabled, this panics if the `MapCell`'s contents are already borrowed.
     pub fn take(&self) -> Option<T> {
-        if self.is_none() {
-            None
-        } else {
-            self.occupied.set(false);
+        debug_assert_not_borrowed!(self);
+        (self.occupied.get() == MapCellState::Init).then(|| {
+            // SAFETY: Since `occupied` is `Init`, `val` is initialized and can be mutated
+            //         behind a shared reference. `result` is therefore initialized.
             unsafe {
-                let result: MaybeUninit<T> =
-                    ptr::replace(self.val.get(), MaybeUninit::<T>::uninit());
-                // `result` is _initialized_ and now `self.val` is now a new uninitialized value
-                Some(result.assume_init())
+                let result: MaybeUninit<T> = self.val.get().replace(MaybeUninit::uninit());
+                self.occupied.set(MapCellState::Uninit);
+                result.assume_init()
             }
-        }
+        })
     }
 
-    /// Puts a value into the `MapCell`.
+    /// Puts a value into the `MapCell` without returning the old value.
+    ///
+    /// To save size, this has no effect in release mode if `map` is invoking
+    /// a closure for this cell.
+    ///
+    /// # Panics
+    /// If debug assertions are enabled, this panics if the `MapCell`'s contents are already borrowed.
     pub fn put(&self, val: T) {
-        self.occupied.set(true);
-        unsafe {
-            ptr::write(self.val.get(), MaybeUninit::<T>::new(val));
-        }
+        debug_assert_not_borrowed!(self);
+        // This will ensure the value as dropped
+        self.replace(val);
     }
 
-    /// Replaces the contents of the `MapCell` with `val`. If the cell was not
-    /// empty, the previous value is returned, otherwise `None` is returned.
+    /// Replaces the contents of the `MapCell`, returning the old value if available.
+    ///
+    /// To save size, this has no effect and returns `None` in release mode
+    /// if the `MapCell`'s contents are already borrowed.
+    ///
+    /// # Panics
+    /// If debug assertions are enabled, this panics if the `MapCell`'s contents are already borrowed.
     pub fn replace(&self, val: T) -> Option<T> {
-        if self.is_none() {
-            self.put(val);
-            None
-        } else {
-            unsafe {
-                let result: MaybeUninit<T> = ptr::replace(self.val.get(), MaybeUninit::new(val));
-                // `result` is _initialized_ and now `self.val` is now a new uninitialized value
-                Some(result.assume_init())
-            }
+        let occupied = self.occupied.get();
+        debug_assert_not_borrowed!(self);
+        if occupied == MapCellState::Borrowed {
+            return None;
         }
+        self.occupied.set(MapCellState::Init);
+
+        // SAFETY:
+        // - Since `occupied` is `Init` or `Uninit`, no `&mut` to the `val` exists, meaning it
+        //   is safe to mutate the `get` pointer.
+        // - If occupied is `Init`, `maybe_uninit_val` must be initialized.
+        let maybe_uninit_val = unsafe { self.val.get().replace(MaybeUninit::new(val)) };
+        (occupied == MapCellState::Init).then(|| unsafe { maybe_uninit_val.assume_init() })
     }
 
-    /// Allows `closure` to borrow the contents of the `MapCell` if-and-only-if
-    /// it is not `take`n already. The state of the `MapCell` is unchanged
-    /// after the closure completes.
+    /// Calls `closure` with a `&mut` of the contents of the `MapCell`, if available.
+    ///
+    /// The closure is only called if the `MapCell` has a value.
+    /// The state of the `MapCell` is unchanged after the closure completes.
+    ///
+    /// # Re-entrancy
+    ///
+    /// This borrows the contents of the cell while the closure is executing.
+    /// Be careful about calling methods on `&self` inside of that closure!
+    /// To save size, this has no effect in release mode, but if debug assertions
+    /// are enabled, this panics to indicate a likely bug.
     ///
     /// # Examples
     ///
     /// ```
-    /// extern crate tock_cells;
-    /// use tock_cells::map_cell::MapCell;
-    ///
+    /// # use tock_cells::map_cell::MapCell;
     /// let cell = MapCell::new(1234);
     /// let x = &cell;
     /// let y = &cell;
@@ -124,22 +263,33 @@ impl<T> MapCell<T> {
     /// // but potentially changed.
     /// assert_eq!(y.take(), Some(1235));
     /// ```
+    ///
+    /// # Panics
+    /// If debug assertions are enabled, this panics if the `MapCell`'s contents are already borrowed.
+    #[inline(always)]
     pub fn map<F, R>(&self, closure: F) -> Option<R>
     where
         F: FnOnce(&mut T) -> R,
     {
-        if self.is_some() {
-            self.occupied.set(false);
-            let valref = unsafe { &mut *self.val.get() };
-            // TODO: change to valref.get_mut() once stabilized [#53491](https://github.com/rust-lang/rust/issues/53491)
-            let res = closure(unsafe { &mut *valref.as_mut_ptr() });
-            self.occupied.set(true);
-            Some(res)
-        } else {
-            None
-        }
+        debug_assert_not_borrowed!(self);
+        (self.occupied.get() == MapCellState::Init).then(move || {
+            self.occupied.set(MapCellState::Borrowed);
+            // `occupied` is reset to initialized at the end of scope,
+            // even if a panic occurs in `closure`.
+            struct ResetToInit<'a>(&'a Cell<MapCellState>);
+            impl Drop for ResetToInit<'_> {
+                #[inline(always)]
+                fn drop(&mut self) {
+                    self.0.set(MapCellState::Init);
+                }
+            }
+            let _reset_to_init = ResetToInit(&self.occupied);
+            unsafe { closure(&mut *self.val.get().cast::<T>()) }
+        })
     }
 
+    /// Behaves like `map`, but returns `default` if there is no value present.
+    #[inline(always)]
     pub fn map_or<F, R>(&self, default: R, closure: F) -> R
     where
         F: FnOnce(&mut T) -> R,
@@ -149,22 +299,17 @@ impl<T> MapCell<T> {
 
     /// Behaves the same as `map`, except the closure is allowed to return
     /// an `Option`.
+    #[inline(always)]
     pub fn and_then<F, R>(&self, closure: F) -> Option<R>
     where
         F: FnOnce(&mut T) -> Option<R>,
     {
-        if self.is_some() {
-            self.occupied.set(false);
-            let valref = unsafe { &mut *self.val.get() };
-            // TODO: change to valref.get_mut() once stabilized [#53491](https://github.com/rust-lang/rust/issues/53491)
-            let res = closure(unsafe { &mut *valref.as_mut_ptr() });
-            self.occupied.set(true);
-            res
-        } else {
-            None
-        }
+        self.map(closure).flatten()
     }
 
+    /// If a value is present `modify` is called with a borrow.
+    /// Otherwise, the value is set with `G`.
+    #[inline(always)]
     pub fn modify_or_replace<F, G>(&self, modify: F, mkval: G)
     where
         F: FnOnce(&mut T),
@@ -173,5 +318,83 @@ impl<T> MapCell<T> {
         if self.map(modify).is_none() {
             self.put(mkval());
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use map_cell::MapCell;
+
+    struct DropCheck<'a> {
+        flag: &'a mut bool,
+    }
+    impl<'a> Drop for DropCheck<'a> {
+        fn drop(&mut self) {
+            *self.flag = true;
+        }
+    }
+
+    #[test]
+    fn test_drop() {
+        let mut dropped_after_drop = false;
+        let mut dropped_after_put = false;
+        {
+            let cell = MapCell::new(DropCheck {
+                flag: &mut dropped_after_put,
+            });
+            cell.put(DropCheck {
+                flag: &mut dropped_after_drop,
+            });
+        }
+        assert!(dropped_after_drop);
+        assert!(dropped_after_put);
+    }
+
+    #[test]
+    fn test_replace() {
+        let a_cell = MapCell::new(1);
+        let old = a_cell.replace(2);
+        assert_eq!(old, Some(1));
+        assert_eq!(a_cell.take(), Some(2));
+        assert_eq!(a_cell.take(), None);
+    }
+
+    #[test]
+    #[should_panic = "`MapCell` accessed while borrowed"]
+    fn test_map_in_borrow() {
+        let cell = MapCell::new(1);
+        let borrow1 = &cell;
+        let borrow2 = &cell;
+        borrow1.map(|_| borrow2.map(|_| ()));
+    }
+
+    #[test]
+    #[should_panic = "`MapCell` accessed while borrowed"]
+    fn test_replace_in_borrow() {
+        let my_cell = MapCell::new(55);
+        my_cell.map(|_ref1: &mut i32| {
+            // Should fail
+            my_cell.replace(56);
+        });
+    }
+
+    #[test]
+    #[should_panic = "`MapCell` accessed while borrowed"]
+    fn test_put_in_borrow() {
+        let my_cell = MapCell::new(55);
+        my_cell.map(|_ref1: &mut i32| {
+            // Should fail
+            my_cell.put(56);
+        });
+    }
+
+    #[test]
+    #[should_panic = "`MapCell` accessed while borrowed"]
+    fn test_get_in_borrow() {
+        let my_cell = MapCell::new(55);
+        my_cell.map(|_ref1: &mut i32| {
+            // Should fail
+            my_cell.get();
+        });
     }
 }


### PR DESCRIPTION
### Pull Request Overview

MapCell is unsound if mutated inside of `map`, since it invalidates the `&mut T` in the closure.
It also fails to drop its contents if put is called.

This fixes the soundness hole by making these re-entrant mutations silently do nothing, while panicking with debug assertions to inform unit tests of a bug.

More rustdoc has also been added. This replaces pull #3325 - see that for further context.

`MapCell` is like a `Cell<Option<T>>` with an extra state and check to allow `map` to be sound against re-entrancy.

- `map` marks the cell as borrowed while the closure is running, in order to detect re-entrancy.
- `map` does not call its closure if currently inside `map`, like it does for the empty state.
- `take` returns `None` and does not mutate if currently inside `map`, unlike the empty state.
- `put` drops its input and does not mutate if currently inside `map`, unlike the empty state.
- `replace` drops its input, does not mutate, and returns `None` if currently inside map, unlike the empty state.
- A `get` function has been added that returns `Option<T>` and returns `None` if currently inside `map`, like it does for the empty state.


### Testing Strategy

I have not tested this on hardware. This PR will be primarily tested by CI unless someone chips in.


### TODO or Help Wanted

The /docs for `MapCell` could use some updating - [what it says about comparing to `TakeCell` is confusing](https://github.com/tock/tock/blob/master/doc/Mutable_References.md#mapcell).

A way to test the release behavior of mutating inside of a `map` while inside of a unit test would be helpful - right now it's solely `should_panic` tests.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] ~Ran `make prepush`.~ Ran `cargo fmt` and `cargo clippy`
