### PR TITLE
rv32i/{pmp,epmp}: invalidate unused regions on config switch

### DIFF
--- a/arch/rv32i/src/epmp.rs
+++ b/arch/rv32i/src/epmp.rs
@@ -787,7 +787,19 @@ impl<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> kernel::platform::mpu::MPU
                             (cfg_val << 8) << region_shift | (csr::CSR.pmpconfig_get(x / 2)),
                         );
                     }
-                    None => {}
+                    None => {
+                        // Invalidate other regions not used in this PMPConfig.
+                        match x % 2 {
+                            0 => {
+                                csr::CSR.pmpconfig_modify(x / 2, csr::pmpconfig::pmpcfg::a1::OFF);
+                            }
+                            1 => {
+                                csr::CSR.pmpconfig_modify(x / 2, csr::pmpconfig::pmpcfg::a3::OFF);
+                            }
+                            // unreachable, but don't insert a panic
+                            _ => (),
+                        };
+                    }
                 };
             }
         } else {
@@ -802,7 +814,8 @@ impl<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> kernel::platform::mpu::MPU
                             1 => {
                                 csr::CSR.pmpconfig_modify(x / 2, csr::pmpconfig::pmpcfg::a3::TOR);
                             }
-                            _ => break,
+                            // unreachable, but don't insert a panic
+                            _ => (),
                         };
                     }
                     None => {}


### PR DESCRIPTION
### Pull Request Overview

This change ensures that the RISC-V PMP actually invalidates regions that are not used as part of the current PMP configuration. Without this change, applications will have access to all PMP regions which were previously allocated and not overwritten by their current configuration. This is a major safety and security issue.

This patch simply turns all other regions which are unconfigured in the current configuration off in the PMP. However, it is unclear how this fix interacts with the PMP if used as a kernel memory protection unit, given the current implementation does not have a clear separation of concerns here.

Furthermore, this causes the PMP configuration to be much less efficient and issue 417 instructions on a RV32IMC chip (LiteX sim), compared to 238 previously.

I assume that a major rearchitecture of this codebase can help make the interactions between the KernelMPU and MPU implementations significantly simpler and more comprehensible, preventing these types of bugs. We should further be able to optimize this code by pre-computing the PMPCFG register values and copying them into the appropriate CSRs using CSRRS/CSRRC instructions, which may remove some of the overhead introduced by this.

I am working on an aforementioned re-architecture to address the problems of the current codebase. Meanwhile, this fix should be sufficient to ensure that PMP memory protection is actually working as intended.

### Testing Strategy

This pull request was tested by trying to invalidate the PMP configuration by removing all allocations, and seeing that an app indeed experiences a fault on the LiteX sim platform.

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [x] Ran `make prepush`.
