### PR TITLE
usb: keyboard: do not retry send on ctrl finish

### DIFF
--- a/capsules/extra/src/usb/keyboard_hid.rs
+++ b/capsules/extra/src/usb/keyboard_hid.rs
@@ -253,10 +253,6 @@ impl<'a, U: hil::usb::UsbController<'a>> hil::usb::Client<'a> for KeyboardHid<'a
 
     /// Handle the completion of a Control transfer
     fn ctrl_status_complete(&'a self, endpoint: usize) {
-        if self.send_buffer.is_some() {
-            self.controller().endpoint_resume_in(ENDPOINT_NUM);
-        }
-
         self.client_ctrl.ctrl_status_complete(endpoint)
     }
 


### PR DESCRIPTION


### Pull Request Overview

This pull request removes trying to start a transmission from the ctrl status complete callback in the usb keyboard hid capsule. With this code the nrf52 usb driver crashes because it attempts to re-send a message we have already sent. This only happens if the send occurs while the usb device is being connected.

This is the panic I was getting:

```
panicked at 'assertion failed: `(left == right)`
  left: `Some(InData)`,
 right: `Some(Init)`', chips/nrf52/src/usbd.rs:1819:13
	Kernel version release-2.1-1294-g8ac0fc427

---| No debug queue found. You can set it with the DebugQueue component.

---| Cortex-M Fault Status |---
No Cortex-M faults detected.
```



### Testing Strategy

Sending USB keyboard data immediately when an app boots.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
