### PR TITLE
KV: set operation now overwrites existing key

### DIFF
--- a/capsules/extra/src/kv_store.rs
+++ b/capsules/extra/src/kv_store.rs
@@ -540,6 +540,8 @@ impl<'a, K: KVSystem<'a, K = T>, T: kv_system::KeyType> kv_system::Client<T>
                             }
                         }
 
+                        self.header_value.replace(ret_buf.take());
+
                         if access_allowed {
                             match self.kv.invalidate_key(key) {
                                 Ok(()) => {

--- a/libraries/tickv/src/async_ops.rs
+++ b/libraries/tickv/src/async_ops.rs
@@ -324,7 +324,7 @@ impl<'a, C: FlashController<S>, const S: usize> AsyncTicKV<'a, C, S> {
                     .tickv
                     .append_key(self.key.get().unwrap(), &value[0..value_length]);
                 self.value.replace(Some(value));
-                (ret, 0)
+                (ret, value_length)
             }
             State::GetKey(_) => {
                 let buf = self.value.take().unwrap();
@@ -356,7 +356,7 @@ impl<'a, C: FlashController<S>, const S: usize> AsyncTicKV<'a, C, S> {
                 }
                 _ => {
                     self.tickv.state.set(State::None);
-                    (ret, self.value.take(), 0)
+                    (ret, self.value.take(), length)
                 }
             },
         }


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the KVStore interface to enable set to overwrite an existing key, assuming the caller has permission to do so.

Before set with an existing key would fail, and the user would have to call delete then set again.

This also makes a small fix to tickv to return the length of the value buffer so we can reconstruct the leasable buffer when the value buffer is passed back.

This is part of #3524.


### Testing Strategy

Using the interactive kv app.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
