### PR TITLE
kernel/platform/mpu: don't provide default impls for methods

### DIFF
--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -100,13 +100,13 @@ pub trait MPU {
     /// MPU where possible.
     /// On some hardware it is impossible to reset the MPU after it has
     /// been locked, in this case this function wont change those regions.
-    fn clear_mpu(&self) {}
+    fn clear_mpu(&self);
 
     /// Enables the MPU for userspace apps.
     ///
     /// This function must enable the permission restrictions on the various
     /// regions protected by the MPU.
-    fn enable_app_mpu(&self) {}
+    fn enable_app_mpu(&self);
 
     /// Disables the MPU for userspace apps.
     ///
@@ -116,12 +116,10 @@ pub trait MPU {
     /// platforms the MPU rules apply to privileged code as well, and therefore
     /// some of the MPU configuration must be disabled for the kernel to effectively
     /// manage processes.
-    fn disable_app_mpu(&self) {}
+    fn disable_app_mpu(&self);
 
     /// Returns the maximum number of regions supported by the MPU.
-    fn number_total_regions(&self) -> usize {
-        0
-    }
+    fn number_total_regions(&self) -> usize;
 
     /// Allocates a new MPU region.
     ///
@@ -143,7 +141,6 @@ pub trait MPU {
     ///
     /// Returns the start and size of the allocated MPU region. If it is
     /// infeasible to allocate the MPU region, returns None.
-    #[allow(unused_variables)]
     fn allocate_region(
         &self,
         unallocated_memory_start: *const u8,
@@ -151,13 +148,7 @@ pub trait MPU {
         min_region_size: usize,
         permissions: Permissions,
         config: &mut Self::MpuConfig,
-    ) -> Option<Region> {
-        if min_region_size > unallocated_memory_size {
-            None
-        } else {
-            Some(Region::new(unallocated_memory_start, min_region_size))
-        }
-    }
+    ) -> Option<Region>;
 
     /// Removes an MPU region within app-owned memory.
     ///
@@ -174,10 +165,7 @@ pub trait MPU {
     /// # Return Value
     ///
     /// Returns an error if the specified region is not exactly mapped to the process as specified
-    #[allow(unused_variables)]
-    fn remove_memory_region(&self, region: Region, config: &mut Self::MpuConfig) -> Result<(), ()> {
-        Ok(())
-    }
+    fn remove_memory_region(&self, region: Region, config: &mut Self::MpuConfig) -> Result<(), ()>;
 
     /// Chooses the location for a process's memory, and allocates an MPU region
     /// covering the app-owned part.
@@ -217,7 +205,6 @@ pub trait MPU {
     /// chosen for the process. If it is infeasible to find a memory block or
     /// allocate the MPU region, or if the function has already been called,
     /// returns None. If None is returned no changes are made.
-    #[allow(unused_variables)]
     fn allocate_app_memory_region(
         &self,
         unallocated_memory_start: *const u8,
@@ -227,17 +214,7 @@ pub trait MPU {
         initial_kernel_memory_size: usize,
         permissions: Permissions,
         config: &mut Self::MpuConfig,
-    ) -> Option<(*const u8, usize)> {
-        let memory_size = cmp::max(
-            min_memory_size,
-            initial_app_memory_size + initial_kernel_memory_size,
-        );
-        if memory_size > unallocated_memory_size {
-            None
-        } else {
-            Some((unallocated_memory_start, memory_size))
-        }
-    }
+    ) -> Option<(*const u8, usize)>;
 
     /// Updates the MPU region for app-owned memory.
     ///
@@ -257,20 +234,13 @@ pub trait MPU {
     /// Returns an error if it is infeasible to update the MPU region, or if it
     /// was never created. If an error is returned no changes are made to the
     /// configuration.
-    #[allow(unused_variables)]
     fn update_app_memory_region(
         &self,
         app_memory_break: *const u8,
         kernel_memory_break: *const u8,
         permissions: Permissions,
         config: &mut Self::MpuConfig,
-    ) -> Result<(), ()> {
-        if (app_memory_break as usize) > (kernel_memory_break as usize) {
-            Err(())
-        } else {
-            Ok(())
-        }
-    }
+    ) -> Result<(), ()>;
 
     /// Configures the MPU with the provided region configuration.
     ///
@@ -282,13 +252,82 @@ pub trait MPU {
     ///
     /// - `config`: MPU region configuration
     /// - `processid`: ProcessId of the process that the MPU is configured for
-    #[allow(unused_variables)]
-    fn configure_mpu(&self, config: &Self::MpuConfig, processid: &ProcessId) {}
+    fn configure_mpu(&self, config: &Self::MpuConfig, processid: &ProcessId);
 }
 
 /// Implement default MPU trait for unit.
 impl MPU for () {
     type MpuConfig = MpuConfigDefault;
+
+    fn clear_mpu(&self) {}
+
+    fn enable_app_mpu(&self) {}
+
+    fn disable_app_mpu(&self) {}
+
+    fn number_total_regions(&self) -> usize {
+        0
+    }
+
+    fn allocate_region(
+        &self,
+        unallocated_memory_start: *const u8,
+        unallocated_memory_size: usize,
+        min_region_size: usize,
+        _permissions: Permissions,
+        _config: &mut Self::MpuConfig,
+    ) -> Option<Region> {
+        if min_region_size > unallocated_memory_size {
+            None
+        } else {
+            Some(Region::new(unallocated_memory_start, min_region_size))
+        }
+    }
+
+    fn remove_memory_region(
+        &self,
+        _region: Region,
+        _config: &mut Self::MpuConfig,
+    ) -> Result<(), ()> {
+        Ok(())
+    }
+
+    fn allocate_app_memory_region(
+        &self,
+        unallocated_memory_start: *const u8,
+        unallocated_memory_size: usize,
+        min_memory_size: usize,
+        initial_app_memory_size: usize,
+        initial_kernel_memory_size: usize,
+        _permissions: Permissions,
+        _config: &mut Self::MpuConfig,
+    ) -> Option<(*const u8, usize)> {
+        let memory_size = cmp::max(
+            min_memory_size,
+            initial_app_memory_size + initial_kernel_memory_size,
+        );
+        if memory_size > unallocated_memory_size {
+            None
+        } else {
+            Some((unallocated_memory_start, memory_size))
+        }
+    }
+
+    fn update_app_memory_region(
+        &self,
+        app_memory_break: *const u8,
+        kernel_memory_break: *const u8,
+        _permissions: Permissions,
+        _config: &mut Self::MpuConfig,
+    ) -> Result<(), ()> {
+        if (app_memory_break as usize) > (kernel_memory_break as usize) {
+            Err(())
+        } else {
+            Ok(())
+        }
+    }
+
+    fn configure_mpu(&self, _config: &Self::MpuConfig, _processid: &ProcessId) {}
 }
 
 /// The generic trait that particular kernel level memory protection unit


### PR DESCRIPTION
### Pull Request Overview

Providing default implementations for the various `kernel::mpu::MPU` methods makes it easy to forget a method in an implementation, and would not cause compiler errors when adding a new method that should be implemented. Default implementations should really only be used when it is legal for an implemenation to not provide a specialized method and fall back onto the default. This is not the case for any of the `MPU` trait methods.

This instead moves those method implementations to the unit type, which implements an `MPU` for boards that don't have one present.


### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [x] Ran `make prepush`.
