### PR TITLE
usb_hid: disambiguate RESERVE/BUSY

### DIFF
--- a/capsules/extra/src/usb_hid_driver.rs
+++ b/capsules/extra/src/usb_hid_driver.rs
@@ -212,7 +212,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> SyscallDriver for UsbHidDriver<'a, U>
                             .and_then(|send| {
                                 send.enter(|data| {
                                     self.send_buffer.take().map_or(
-                                        CommandReturn::failure(ErrorCode::RESERVE),
+                                        CommandReturn::failure(ErrorCode::BUSY),
                                         |buf| {
                                             // Copy the data into the static buffer
                                             data.copy_to_slice(buf);
@@ -336,7 +336,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> SyscallDriver for UsbHidDriver<'a, U>
                                     .and_then(|send| {
                                         send.enter(|data| {
                                             self.send_buffer.take().map_or(
-                                                CommandReturn::failure(ErrorCode::RESERVE),
+                                                CommandReturn::failure(ErrorCode::BUSY),
                                                 |buf| {
                                                     // Copy the data into the static buffer
                                                     data.copy_to_slice(buf);


### PR DESCRIPTION
### Pull Request Overview

The send path has two possible failures
 1. Userspace forgot to allow a buffer to send from
 2. The driver already sending something

Previously, we returned ERESERVE in both cases, but (2) should be EBUSY instead, which this corrects.

I believe this will explain https://github.com/tock/libtock-c/pull/333


### Testing Strategy

Reading and reasoning through behavior.

### TODO or Help Wanted

I'm pretty certain this is correct, but after this goes in, @brghena can you re-test https://github.com/tock/libtock-c/pull/333 and see if you're (my guess) in the EBUSY case?

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
