### PR TITLE
storage permissions: clarify naming

### DIFF
--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -515,23 +515,18 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
     }
 
     fn get_storage_permissions(&self) -> Option<storage_permissions::StoragePermissions> {
-        let (read_count, read_storage_ids) = self
-            .header
-            .get_persistent_acl_read_ids()
-            .unwrap_or((0, [0; 8]));
+        let (read_count, read_ids) = self.header.get_storage_read_ids().unwrap_or((0, [0; 8]));
 
-        let (access_count, access_storage_ids) = self
-            .header
-            .get_persistent_acl_access_ids()
-            .unwrap_or((0, [0; 8]));
+        let (modify_count, modify_ids) =
+            self.header.get_storage_modify_ids().unwrap_or((0, [0; 8]));
 
-        let write_id = self.header.get_persistent_acl_write_id();
+        let write_id = self.header.get_storage_write_id();
 
         Some(storage_permissions::StoragePermissions::new(
             read_count,
-            read_storage_ids,
-            access_count,
-            access_storage_ids,
+            read_ids,
+            modify_count,
+            modify_ids,
             write_id,
         ))
     }

--- a/libraries/tock-tbf/src/parse.rs
+++ b/libraries/tock-tbf/src/parse.rs
@@ -136,7 +136,9 @@ pub fn parse_tbf_header(
                 let mut app_name_str = "";
                 let mut fixed_address_pointer: Option<types::TbfHeaderV2FixedAddresses> = None;
                 let mut permissions_pointer: Option<types::TbfHeaderV2Permissions<8>> = None;
-                let mut persistent_acls_pointer: Option<types::TbfHeaderV2PersistentAcl<8>> = None;
+                let mut storage_permissions_pointer: Option<
+                    types::TbfHeaderV2StoragePermissions<8>,
+                > = None;
                 let mut kernel_version: Option<types::TbfHeaderV2KernelVersion> = None;
 
                 // Iterate the remainder of the header looking for TLV entries.
@@ -259,8 +261,8 @@ pub fn parse_tbf_header(
                             permissions_pointer = Some(remaining.try_into()?);
                         }
 
-                        types::TbfHeaderTypes::TbfHeaderPersistentAcl => {
-                            persistent_acls_pointer = Some(remaining.try_into()?);
+                        types::TbfHeaderTypes::TbfHeaderStoragePermissions => {
+                            storage_permissions_pointer = Some(remaining.try_into()?);
                         }
 
                         types::TbfHeaderTypes::TbfHeaderKernelVersion => {
@@ -298,7 +300,7 @@ pub fn parse_tbf_header(
                     writeable_regions: Some(wfr_pointer),
                     fixed_addresses: fixed_address_pointer,
                     permissions: permissions_pointer,
-                    persistent_acls: persistent_acls_pointer,
+                    storage_permissions: storage_permissions_pointer,
                     kernel_version: kernel_version,
                 };
 

--- a/libraries/tock-tbf/src/types.rs
+++ b/libraries/tock-tbf/src/types.rs
@@ -8,7 +8,9 @@ use core::convert::TryInto;
 use core::fmt;
 use core::mem::size_of;
 
-const NUM_PERSISTENT_ACLS: usize = 8;
+/// We only support up to a fixed number of storage permissions for each of read
+/// and modify. This simplification enables us to use fixed sized buffers.
+const NUM_STORAGE_PERMISSIONS: usize = 8;
 
 /// Error when parsing just the beginning of the TBF header. This is only used
 /// when establishing the linked list structure of apps installed in flash.
@@ -126,7 +128,7 @@ pub enum TbfHeaderTypes {
     TbfHeaderPackageName = 3,
     TbfHeaderFixedAddresses = 5,
     TbfHeaderPermissions = 6,
-    TbfHeaderPersistentAcl = 7,
+    TbfHeaderStoragePermissions = 7,
     TbfHeaderKernelVersion = 8,
     TbfHeaderProgram = 9,
     TbfFooterCredentials = 128,
@@ -224,14 +226,14 @@ pub struct TbfHeaderV2Permissions<const L: usize> {
     perms: [TbfHeaderDriverPermission; L],
 }
 
-/// A list of persistent access permissions
+/// A list of storage (read/write/modify) permissions for this app.
 #[derive(Clone, Copy, Debug)]
-pub struct TbfHeaderV2PersistentAcl<const L: usize> {
+pub struct TbfHeaderV2StoragePermissions<const L: usize> {
     write_id: Option<core::num::NonZeroU32>,
     read_length: u16,
     read_ids: [u32; L],
-    access_length: u16,
-    access_ids: [u32; L],
+    modify_length: u16,
+    modify_ids: [u32; L],
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -315,7 +317,7 @@ impl core::convert::TryFrom<u16> for TbfHeaderTypes {
             3 => Ok(TbfHeaderTypes::TbfHeaderPackageName),
             5 => Ok(TbfHeaderTypes::TbfHeaderFixedAddresses),
             6 => Ok(TbfHeaderTypes::TbfHeaderPermissions),
-            7 => Ok(TbfHeaderTypes::TbfHeaderPersistentAcl),
+            7 => Ok(TbfHeaderTypes::TbfHeaderStoragePermissions),
             8 => Ok(TbfHeaderTypes::TbfHeaderKernelVersion),
             9 => Ok(TbfHeaderTypes::TbfHeaderProgram),
             128 => Ok(TbfHeaderTypes::TbfFooterCredentials),
@@ -512,10 +514,10 @@ impl<const L: usize> core::convert::TryFrom<&[u8]> for TbfHeaderV2Permissions<L>
     }
 }
 
-impl<const L: usize> core::convert::TryFrom<&[u8]> for TbfHeaderV2PersistentAcl<L> {
+impl<const L: usize> core::convert::TryFrom<&[u8]> for TbfHeaderV2StoragePermissions<L> {
     type Error = TbfParseError;
 
-    fn try_from(b: &[u8]) -> Result<TbfHeaderV2PersistentAcl<L>, Self::Error> {
+    fn try_from(b: &[u8]) -> Result<TbfHeaderV2StoragePermissions<L>, Self::Error> {
         let mut read_end = 6;
 
         let write_id = core::num::NonZeroU32::new(u32::from_le_bytes(
@@ -542,40 +544,40 @@ impl<const L: usize> core::convert::TryFrom<&[u8]> for TbfHeaderV2PersistentAcl<
                 );
             } else {
                 return Err(TbfParseError::BadTlvEntry(
-                    TbfHeaderTypes::TbfHeaderPersistentAcl as usize,
+                    TbfHeaderTypes::TbfHeaderStoragePermissions as usize,
                 ));
             }
         }
 
-        let access_length = u16::from_le_bytes(
+        let modify_length = u16::from_le_bytes(
             b.get(read_end..(read_end + 2))
                 .ok_or(TbfParseError::NotEnoughFlash)?
                 .try_into()?,
         );
 
-        let mut access_ids: [u32; L] = [0; L];
-        for i in 0..access_length as usize {
+        let mut modify_ids: [u32; L] = [0; L];
+        for i in 0..modify_length as usize {
             let start = read_end + 2 + (i * size_of::<u32>());
-            let access_end = start + size_of::<u32>();
-            if let Some(access_id) = access_ids.get_mut(i) {
-                *access_id = u32::from_le_bytes(
-                    b.get(start..access_end as usize)
+            let modify_end = start + size_of::<u32>();
+            if let Some(modify_id) = modify_ids.get_mut(i) {
+                *modify_id = u32::from_le_bytes(
+                    b.get(start..modify_end as usize)
                         .ok_or(TbfParseError::NotEnoughFlash)?
                         .try_into()?,
                 );
             } else {
                 return Err(TbfParseError::BadTlvEntry(
-                    TbfHeaderTypes::TbfHeaderPersistentAcl as usize,
+                    TbfHeaderTypes::TbfHeaderStoragePermissions as usize,
                 ));
             }
         }
 
-        Ok(TbfHeaderV2PersistentAcl {
+        Ok(TbfHeaderV2StoragePermissions {
             write_id,
             read_length,
             read_ids,
-            access_length,
-            access_ids,
+            modify_length,
+            modify_ids,
         })
     }
 }
@@ -665,7 +667,7 @@ pub struct TbfHeaderV2 {
     pub(crate) writeable_regions: Option<[Option<TbfHeaderV2WriteableFlashRegion>; 4]>,
     pub(crate) fixed_addresses: Option<TbfHeaderV2FixedAddresses>,
     pub(crate) permissions: Option<TbfHeaderV2Permissions<8>>,
-    pub(crate) persistent_acls: Option<TbfHeaderV2PersistentAcl<NUM_PERSISTENT_ACLS>>,
+    pub(crate) storage_permissions: Option<TbfHeaderV2StoragePermissions<NUM_STORAGE_PERMISSIONS>>,
     pub(crate) kernel_version: Option<TbfHeaderV2KernelVersion>,
 }
 
@@ -878,11 +880,13 @@ impl TbfHeader {
     }
 
     /// Get the process `write_id`.
-    /// Returns `None` if a `write_id` is not included.
-    pub fn get_persistent_acl_write_id(&self) -> Option<core::num::NonZeroU32> {
+    ///
+    /// Returns `None` if a `write_id` is not included. This indicates the TBF
+    /// does not have the ability to store new items.
+    pub fn get_storage_write_id(&self) -> Option<core::num::NonZeroU32> {
         match self {
-            TbfHeader::TbfHeaderV2(hd) => match hd.persistent_acls {
-                Some(persistent_acls) => persistent_acls.write_id,
+            TbfHeader::TbfHeaderV2(hd) => match hd.storage_permissions {
+                Some(permissions) => permissions.write_id,
                 _ => None,
             },
             _ => None,
@@ -891,12 +895,10 @@ impl TbfHeader {
 
     /// Get the number of valid `read_ids` and the `read_ids`.
     /// Returns `None` if a `read_ids` is not included.
-    pub fn get_persistent_acl_read_ids(&self) -> Option<(usize, [u32; NUM_PERSISTENT_ACLS])> {
+    pub fn get_storage_read_ids(&self) -> Option<(usize, [u32; NUM_STORAGE_PERMISSIONS])> {
         match self {
-            TbfHeader::TbfHeaderV2(hd) => match hd.persistent_acls {
-                Some(persistent_acls) => {
-                    Some((persistent_acls.read_length.into(), persistent_acls.read_ids))
-                }
+            TbfHeader::TbfHeaderV2(hd) => match hd.storage_permissions {
+                Some(permissions) => Some((permissions.read_length.into(), permissions.read_ids)),
                 _ => None,
             },
             _ => None,
@@ -905,13 +907,12 @@ impl TbfHeader {
 
     /// Get the number of valid `access_ids` and the `access_ids`.
     /// Returns `None` if a `access_ids` is not included.
-    pub fn get_persistent_acl_access_ids(&self) -> Option<(usize, [u32; NUM_PERSISTENT_ACLS])> {
+    pub fn get_storage_modify_ids(&self) -> Option<(usize, [u32; NUM_STORAGE_PERMISSIONS])> {
         match self {
-            TbfHeader::TbfHeaderV2(hd) => match hd.persistent_acls {
-                Some(persistent_acls) => Some((
-                    persistent_acls.access_length.into(),
-                    persistent_acls.access_ids,
-                )),
+            TbfHeader::TbfHeaderV2(hd) => match hd.storage_permissions {
+                Some(permissions) => {
+                    Some((permissions.modify_length.into(), permissions.modify_ids))
+                }
                 _ => None,
             },
             _ => None,


### PR DESCRIPTION
### Pull Request Overview

Tock has a notion of storage permissions that traces from the TBF header to a type in the kernel crate. The naming changes from module-to-module, and this PR attempts to make it consistent.

- Remove the "persistent acl" terminology. Replace with "storage permissions". This is more clear that it relates to storage and not something else that is persistent.
- Remove "access id" and replace with "modify id". I think this is more clear, as access and read are similar, but really having an access id gives the app modify permissions.
- Make the StoragePermissions object in the kernel consistent. Before it had two write ids, the app's write id and a list of write ids the app could modify. That list is now modify ids.





### Testing Strategy

This is only a cosmetic change and so verified by the compiler.


### TODO or Help Wanted

n/a

If this is good I will update elf2tab and tockloader to match.


### Documentation Updated

- [x] Updated doc/tbf.md

### Formatting

- [x] Ran `make prepush`.
