### PR TITLE
boards: make: document objcopy flag

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -216,11 +216,13 @@ OBJDUMP ?= $(TOOLCHAIN)-objdump
 # Set additional flags to produce binary from .elf.
 #
 # - `--strip-sections`: Prevents enormous binaries when SRAM is below flash.
+# - `--strip-all`: Remove non-allocated sections outside segments.
+#   `.gnu.warning*` and `.ARM.attribute` sections are not removed.
 # - `--remove-section .apps`: Prevents the .apps section from being included in
 #   the kernel binary file. This section is a placeholder for optionally
 #   including application binaries, and only needs to exist in the .elf. By
 #   removing it, we prevent the kernel binary from overwriting applications.
-OBJCOPY_FLAGS ?= --strip-sections -S --remove-section .apps
+OBJCOPY_FLAGS ?= --strip-sections --strip-all --remove-section .apps
 
 # This make variable allows board-specific Makefiles to pass down options to
 # the Cargo build command. For example, in boards/<custom_board>/Makefile:


### PR DESCRIPTION
### Pull Request Overview

There is a small `-S` flag in our objcopy flags which isn't documented. According to the objcopy docs:

```
./llvm-objcopy --help
OVERVIEW: llvm-objcopy tool
...
  --split-dwo=dwo-file    Equivalent to extract-dwo on the input file to <dwo-file>, then strip-dwo on the input file
  --strip-all-gnu         Compatible with GNU's --strip-all
  --strip-all             Remove non-allocated sections outside segments. .gnu.warning* and .ARM.attribute sections are not removed
  --strip-debug           Remove all debug sections
  --strip-dwo             Remove all DWARF .dwo sections from file
  --strip-non-alloc       Remove all non-allocated sections outside segments
  --strip-sections        Remove all section headers and all sections not in segments
  --strip-symbol=symbol   Strip <symbol>
  --strip-symbols=filename
                          Reads a list of symbols from <filename> and removes them.
  --strip-unneeded-symbol=symbol
                          Remove symbol <symbol> if it is not needed by relocations
  --strip-unneeded-symbols=filename
                          Reads a list of symbols from <filename> and removes them if they are not needed by relocations
  --strip-unneeded        Remove all symbols not needed by relocations
  --subsystem=name[:version]
                          Set PE subsystem and version
  -S                      Alias for --strip-all
...
```

`-S` is the same as `--strip-all`, so I changed to the more descriptive form and included the docs.

### Testing Strategy

travis


### TODO or Help Wanted

Anyone want to speculate we should just remove this flag?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
