### PR TITLE
kernel/process_standard: ensure kernel_memory_break align & cleanup

### DIFF
--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -1658,6 +1658,33 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
             }
         }
 
+        // With our MPU allocation, we can begin to divide up the
+        // `remaining_memory` slice into individual regions for the process and
+        // kernel, as follows:
+        //
+        //
+        //  +-----------------------------------------------------------------
+        //  | remaining_memory
+        //  +----------------------------------------------------+------------
+        //  v                                                    v
+        //  +----------------------------------------------------+
+        //  | allocated_padded_memory                            |
+        //  +--+-------------------------------------------------+
+        //     v                                                 v
+        //     +-------------------------------------------------+
+        //     | allocated_memory                                |
+        //     +-------------------------------------------------+
+        //     v                                                 v
+        //     +-----------------------+-------------------------+
+        //     | app_accessible_memory | allocated_kernel_memory |
+        //     +-----------------------+-------------------+-----+
+        //                                                 v
+        //                               kernel memory break
+        //                                                  \---+/
+        //                                                      v
+        //                                        optional padding
+        //
+        //
         // First split the `remaining_memory` into two slices:
         //
         // - `allocated_padded_memory`: the allocated memory region, containing


### PR DESCRIPTION
### Pull Request Overview

This commit addresses issue tock/tock#1739 by ensuring that the kernel memory break is always well-aligned to a word-boundary, regardless of the MPU's internal alignment constraints.

It further cleans up the memory allocation code. Tracing the previous slices and pointers through the previous code was rather difficult. In an effort to simply this logic, the returned memory is now continuously sub-sliced until all individual memory sub-sections have been isolated into their own slices. This avoids indexing into larger slices, encompassing multiple logically-distinct memory allocations.

It further renames the allocation returned by `allocate_app_memory_region` to no longer have "app" in its name, as this can be mistaken for app-accessible memory. Instead, it simply calls it `allocated_memory`, which is then sub-sliced into `app_accessible_memory` and `allocated_kernel_memory` slices.

Visually, the memory is now sliced as follows:

    +-----------------------------------------------------------------
    | remaining_memory
    +----------------------------------------------------+------------
    v                                                    v
    +----------------------------------------------------+
    | allocated_padded_memory                            |
    +--+-------------------------------------------------+
       v                                                 v
       +-------------------------------------------------+
       | allocated_memory                                |
       +-------------------------------------------------+
       v                                                 v
       +-----------------------+-------------------------+
       | app_accessible_memory | allocated_kernel_memory |
       +-----------------------+-------------------+-----+
                                                   v
                                 kernel memory break
                                                    \---+/
                                                        v
                                          optional padding

### Testing Strategy

Needs testing. How to best test this? Deliberately have the dummy MPU (`()`) return a non word-aligned kernel break?

### TODO or Help Wanted

N/A


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [x] Ran `make prepush`.
