### PR TITLE
Add DateTime HIL, and implement for RPi Pico and STM32f429ZI

### DIFF
--- a/boards/components/src/date_time.rs
+++ b/boards/components/src/date_time.rs
@@ -1,0 +1,74 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! Component for Date and Time initialisation.
+//!
+//! Authors: Irina Bradu <irinabradu.a@gmail.com>
+//!          Remus Rughinis <remus.rughinis.007@gmail.com>
+//!
+//! Usage
+//! -----
+//!
+//! '''rust
+//!     let date_time = components::date_time::DateTimeComponent::new(
+//!         board_kernel,
+//!         capsules_extra::date_time::DRIVER_NUM,
+//!         &peripherals.rtc,
+//!     )
+//!     .finalize(rtc_component_static!(stm32f429zi::rtc::Rtc<'static>));
+//! '''
+
+use core::mem::MaybeUninit;
+
+use capsules_extra::date_time::DateTimeCapsule;
+use kernel::capabilities;
+use kernel::component::Component;
+use kernel::create_capability;
+use kernel::hil::date_time;
+
+#[macro_export]
+macro_rules! date_time_component_static {
+    ($R:ty $(,)?) => {{
+        let rtc = kernel::static_buf!(capsules_extra::date_time::DateTimeCapsule<'static, $R>);
+        (rtc)
+    };};
+}
+
+pub struct DateTimeComponent<D: 'static + date_time::DateTime<'static>> {
+    board_kernel: &'static kernel::Kernel,
+    driver_num: usize,
+    rtc: &'static D,
+}
+
+impl<D: 'static + date_time::DateTime<'static>> DateTimeComponent<D> {
+    pub fn new(
+        board_kernel: &'static kernel::Kernel,
+        driver_num: usize,
+        rtc: &'static D,
+    ) -> DateTimeComponent<D> {
+        DateTimeComponent {
+            board_kernel,
+            driver_num,
+            rtc,
+        }
+    }
+}
+
+impl<D: 'static + date_time::DateTime<'static> + kernel::deferred_call::DeferredCallClient>
+    Component for DateTimeComponent<D>
+{
+    type StaticInput = &'static mut MaybeUninit<DateTimeCapsule<'static, D>>;
+
+    type Output = &'static DateTimeCapsule<'static, D>;
+
+    fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        let grant_dt = create_capability!(capabilities::MemoryAllocationCapability);
+        let grant_date_time = self.board_kernel.create_grant(self.driver_num, &grant_dt);
+
+        let date_time = s.write(DateTimeCapsule::new(self.rtc, grant_date_time));
+        kernel::deferred_call::DeferredCallClient::register(self.rtc);
+        date_time::DateTime::set_client(self.rtc, date_time);
+        date_time
+    }
+}

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -23,6 +23,7 @@ pub mod console;
 pub mod crc;
 pub mod ctap;
 pub mod dac;
+pub mod date_time;
 pub mod debug_queue;
 pub mod debug_writer;
 pub mod digest;

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -79,6 +79,10 @@ struct NucleoF429ZI {
     scheduler: &'static RoundRobinSched<'static>,
     systick: cortexm4::systick::SysTick,
     can: &'static capsules_extra::can::CanCapsule<'static, stm32f429zi::can::Can<'static>>,
+    date_time: &'static capsules_extra::date_time::DateTimeCapsule<
+        'static,
+        stm32f429zi::rtc::Rtc<'static>,
+    >,
 }
 
 /// Mapping of integer syscalls to objects that implement syscalls.
@@ -98,6 +102,7 @@ impl SyscallDriverLookup for NucleoF429ZI {
             capsules_core::gpio::DRIVER_NUM => f(Some(self.gpio)),
             capsules_core::rng::DRIVER_NUM => f(Some(self.rng)),
             capsules_extra::can::DRIVER_NUM => f(Some(self.can)),
+            capsules_extra::date_time::DRIVER_NUM => f(Some(self.date_time)),
             _ => f(None),
         }
     }
@@ -272,6 +277,7 @@ unsafe fn setup_peripherals(
     tim2: &stm32f429zi::tim2::Tim2,
     trng: &stm32f429zi::trng::Trng,
     can1: &'static stm32f429zi::can::Can,
+    rtc: &'static stm32f429zi::rtc::Rtc,
 ) {
     // USART3 IRQn is 39
     cortexm4::nvic::Nvic::new(stm32f429zi::nvic::USART3).enable();
@@ -286,6 +292,9 @@ unsafe fn setup_peripherals(
 
     // CAN
     can1.enable_clock();
+
+    // RTC
+    rtc.enable_clock();
 }
 
 /// Statically initialize the core peripherals for the chip.
@@ -330,7 +339,12 @@ pub unsafe fn main() {
     peripherals.init();
     let base_peripherals = &peripherals.stm32f4;
 
-    setup_peripherals(&base_peripherals.tim2, &peripherals.trng, &peripherals.can1);
+    setup_peripherals(
+        &base_peripherals.tim2,
+        &peripherals.trng,
+        &peripherals.can1,
+        &peripherals.rtc,
+    );
 
     set_pin_primary_functions(syscfg, &base_peripherals.gpio_ports);
 
@@ -593,6 +607,21 @@ pub unsafe fn main() {
         stm32f429zi::can::Can<'static>
     ));
 
+    // RTC DATE TIME
+    match peripherals.rtc.rtc_init() {
+        Err(e) => debug!("{:?}", e),
+        _ => (),
+    };
+
+    let date_time = components::date_time::DateTimeComponent::new(
+        board_kernel,
+        capsules_extra::date_time::DRIVER_NUM,
+        &peripherals.rtc,
+    )
+    .finalize(components::date_time_component_static!(
+        stm32f429zi::rtc::Rtc<'static>
+    ));
+
     // PROCESS CONSOLE
     let process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
@@ -627,6 +656,7 @@ pub unsafe fn main() {
         scheduler,
         systick: cortexm4::systick::SysTick::new(),
         can: can,
+        date_time,
     };
 
     // // Optional kernel tests

--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -17,6 +17,7 @@ use core::arch::asm;
 
 use capsules_core::i2c_master::I2CMasterDriver;
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
+use components::date_time_component_static;
 use components::gpio::GpioComponent;
 use components::led::LedsComponent;
 use enum_primitive::cast::FromPrimitive;
@@ -96,6 +97,8 @@ pub struct RaspberryPiPico {
     temperature: &'static capsules_extra::temperature::TemperatureSensor<'static>,
     i2c: &'static capsules_core::i2c_master::I2CMasterDriver<'static, I2c<'static, 'static>>,
 
+    date_time:
+        &'static capsules_extra::date_time::DateTimeCapsule<'static, rp2040::rtc::Rtc<'static>>,
     scheduler: &'static RoundRobinSched<'static>,
     systick: cortexm0p::systick::SysTick,
 }
@@ -114,6 +117,7 @@ impl SyscallDriverLookup for RaspberryPiPico {
             capsules_core::adc::DRIVER_NUM => f(Some(self.adc)),
             capsules_extra::temperature::DRIVER_NUM => f(Some(self.temperature)),
             capsules_core::i2c_master::DRIVER_NUM => f(Some(self.i2c)),
+            capsules_extra::date_time::DRIVER_NUM => f(Some(self.date_time)),
             _ => f(None),
         }
     }
@@ -451,6 +455,22 @@ pub unsafe fn main() {
         rp2040::adc::Adc
     ));
 
+    // RTC DATE TIME
+
+    match peripherals.rtc.rtc_init() {
+        Ok(_) => {}
+        Err(e) => {
+            debug!("error starting rtc {:?}", e);
+        }
+    };
+
+    let date_time = components::date_time::DateTimeComponent::new(
+        board_kernel,
+        capsules_extra::date_time::DRIVER_NUM,
+        &peripherals.rtc,
+    )
+    .finalize(date_time_component_static!(rp2040::rtc::Rtc<'static>));
+
     let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
     let grant_temperature =
         board_kernel.create_grant(capsules_extra::temperature::DRIVER_NUM, &grant_cap);
@@ -540,6 +560,7 @@ pub unsafe fn main() {
         adc: adc_syscall,
         temperature: temp,
         i2c,
+        date_time,
 
         scheduler,
         systick: cortexm0p::systick::SysTick::new_with_calibration(125_000_000),

--- a/capsules/core/src/driver.rs
+++ b/capsules/core/src/driver.rs
@@ -88,5 +88,6 @@ pub enum NUM {
     TextScreen            = 0x90003,
     SevenSegment          = 0x90004,
     KeyboardHid           = 0x90005,
+    DateTime              = 0x90007,
 }
 }

--- a/capsules/extra/src/date_time.rs
+++ b/capsules/extra/src/date_time.rs
@@ -1,0 +1,352 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! Real Time Clock driver
+//!
+//! Allows handling of the current date and time
+//!
+//! Authors: Irina Bradu <irinabradu.a@gmail.com>
+//!          Remus Rughinis <remus.rughinis.007@gmail.com>
+//!
+//! Usage
+//! -----
+//!
+//! ```rust
+//!  let grant_dt = create_capability!(capabilities::MemoryAllocationCapability);
+//!  let grant_date_time = board_kernel.create_grant(capsules::date_time::DRIVER_NUM, &grant_dt);
+//!
+//!  let date_time = static_init!(
+//!     capsules::date_time::DateTime<'static>,
+//!     capsules::date_time::DateTime::new(&peripherals.rtc, grant_date_time)
+//!  );
+//!  kernel::hil::date_time::DateTime::set_client(&peripherals.rtc, date_time);
+//! ```
+//!
+//! A DateTimeValues structure can be transformed to and from a u32 tuple in the following way:
+//!         first number (year, month, day_of_the_month):
+//!                 -last 5 bits store the day_of_the_month
+//!                 -previous 4 bits store the month
+//!                 -previous 12 bits store the year
+//!         second number (day_of_the_week, hour, minute, seconds):
+//!                 -last 6 bits store the seconds
+//!                 -previous 6 store the minute
+//!                 -previous 5 store the hour
+//!                 -previous 3 store the day_of_the_week
+
+use capsules_core::driver::NUM;
+use core::cell::Cell;
+use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
+use kernel::hil::date_time;
+
+use kernel::errorcode::into_statuscode;
+use kernel::syscall::{CommandReturn, SyscallDriver};
+use kernel::{ErrorCode, ProcessId};
+
+pub const DRIVER_NUM: usize = NUM::DateTime as usize;
+
+pub enum DateTimeCommand {
+    ReadDateTime,
+    SetDateTime,
+}
+
+#[derive(Default, Clone, Copy)]
+pub struct AppData {
+    subscribed: bool,
+}
+
+pub struct DateTimeCapsule<'a, DateTime: date_time::DateTime<'a>> {
+    date_time: &'a DateTime,
+    apps: Grant<AppData, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
+    in_progress: Cell<bool>,
+}
+
+impl<'a, DateTime: date_time::DateTime<'a>> DateTimeCapsule<'a, DateTime> {
+    pub fn new(
+        date_time: &'a DateTime,
+        grant: Grant<AppData, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
+    ) -> DateTimeCapsule<'a, DateTime> {
+        DateTimeCapsule {
+            date_time,
+            apps: grant,
+            in_progress: Cell::new(false),
+        }
+    }
+
+    fn month_as_u32(&self, month: date_time::Month) -> u32 {
+        match month {
+            date_time::Month::January => 1,
+            date_time::Month::February => 2,
+            date_time::Month::March => 3,
+            date_time::Month::April => 4,
+            date_time::Month::May => 5,
+            date_time::Month::June => 6,
+            date_time::Month::July => 7,
+            date_time::Month::August => 8,
+            date_time::Month::September => 9,
+            date_time::Month::October => 10,
+            date_time::Month::November => 11,
+            date_time::Month::December => 12,
+        }
+    }
+
+    fn u32_as_month(&self, month_num: u32) -> Result<date_time::Month, ErrorCode> {
+        match month_num {
+            1 => Ok(date_time::Month::January),
+            2 => Ok(date_time::Month::February),
+            3 => Ok(date_time::Month::March),
+            4 => Ok(date_time::Month::April),
+            5 => Ok(date_time::Month::May),
+            6 => Ok(date_time::Month::June),
+            7 => Ok(date_time::Month::July),
+            8 => Ok(date_time::Month::August),
+            9 => Ok(date_time::Month::September),
+            10 => Ok(date_time::Month::October),
+            11 => Ok(date_time::Month::November),
+            12 => Ok(date_time::Month::December),
+            _ => Err(ErrorCode::INVAL),
+        }
+    }
+
+    fn dotw_as_u32(&self, dotw: date_time::DayOfWeek) -> u32 {
+        match dotw {
+            date_time::DayOfWeek::Sunday => 0,
+            date_time::DayOfWeek::Monday => 1,
+            date_time::DayOfWeek::Tuesday => 2,
+            date_time::DayOfWeek::Wednesday => 3,
+            date_time::DayOfWeek::Thursday => 4,
+            date_time::DayOfWeek::Friday => 5,
+            date_time::DayOfWeek::Saturday => 6,
+        }
+    }
+
+    fn u32_as_dotw(&self, dotw_num: u32) -> Result<date_time::DayOfWeek, ErrorCode> {
+        match dotw_num {
+            0 => Ok(date_time::DayOfWeek::Sunday),
+            1 => Ok(date_time::DayOfWeek::Monday),
+            2 => Ok(date_time::DayOfWeek::Tuesday),
+            3 => Ok(date_time::DayOfWeek::Wednesday),
+            4 => Ok(date_time::DayOfWeek::Thursday),
+            5 => Ok(date_time::DayOfWeek::Friday),
+            6 => Ok(date_time::DayOfWeek::Saturday),
+            _ => Err(ErrorCode::INVAL),
+        }
+    }
+
+    /// Transforms two u32 numbers into a DateTimeValues structure (year, month, dotm, dotw, hour, minute, seconds)
+    /// Check file documentation for details on how the u32 tuple stores data
+    fn date_from_u32_tuple(
+        &self,
+        date: u32,
+        time: u32,
+    ) -> Result<date_time::DateTimeValues, ErrorCode> {
+        let month_num = date % (1 << 9) / (1 << 5);
+        let month_name = self.u32_as_month(month_num)?;
+
+        let dotw_num = time % (1 << 20) / (1 << 17);
+        let dotw_name = self.u32_as_dotw(dotw_num)?;
+
+        let date_result = date_time::DateTimeValues {
+            year: (date % (1 << 21) / (1 << 9)) as u16,
+            month: month_name,
+            day: (date % (1 << 5)) as u8,
+
+            day_of_week: dotw_name,
+            hour: (time % (1 << 17) / (1 << 12)) as u8,
+            minute: (time % (1 << 12) / (1 << 6)) as u8,
+            seconds: (time % (1 << 6)) as u8,
+        };
+
+        if !(date_result.day <= 31) {
+            return Err(ErrorCode::INVAL);
+        }
+        if !(date_result.hour <= 24) {
+            return Err(ErrorCode::INVAL);
+        }
+        if !(date_result.minute <= 60) {
+            return Err(ErrorCode::INVAL);
+        }
+        if !(date_result.seconds <= 60) {
+            return Err(ErrorCode::INVAL);
+        }
+
+        Ok(date_result)
+    }
+
+    /// Transforms DateTimeValues structure (year, month, dotm, dotw, hour, minute, seconds) into two u32 numbers
+    /// Check file documentation for details on how the u32 numbers stores data
+    /// The two u32 numbers are returned as a tuple
+    fn date_as_u32_tuple(
+        &self,
+        set_date: date_time::DateTimeValues,
+    ) -> Result<(u32, u32), ErrorCode> {
+        let month = self.month_as_u32(set_date.month);
+        let dotw = self.dotw_as_u32(set_date.day_of_week);
+
+        let date = set_date.year as u32 * (1 << 9) as u32
+            + month as u32 * (1 << 5) as u32
+            + set_date.day as u32;
+        let time = dotw as u32 * (1 << 17) as u32
+            + set_date.hour as u32 * (1 << 12) as u32
+            + set_date.minute as u32 * (1 << 6) as u32
+            + set_date.seconds as u32;
+
+        Ok((date as u32, time as u32))
+    }
+
+    fn call_driver(&self, command: DateTimeCommand, r2: usize, r3: usize) -> CommandReturn {
+        match command {
+            DateTimeCommand::ReadDateTime => {
+                let date_result = self.date_time.get_date_time();
+                match date_result {
+                    Result::Ok(()) => {
+                        self.in_progress.set(true);
+                        CommandReturn::success()
+                    }
+                    Result::Err(e) => CommandReturn::failure(e),
+                }
+            }
+            DateTimeCommand::SetDateTime => {
+                let date;
+
+                match self.date_from_u32_tuple(r2 as u32, r3 as u32) {
+                    Result::Ok(d) => date = d,
+                    Result::Err(e) => {
+                        return CommandReturn::failure(e);
+                    }
+                };
+
+                let get_date_result = self.date_time.set_date_time(date);
+
+                match get_date_result {
+                    Result::Ok(()) => {
+                        self.in_progress.set(true);
+                        CommandReturn::success()
+                    }
+                    Result::Err(e) => CommandReturn::failure(e),
+                }
+            }
+        }
+    }
+
+    fn enqueue_command(
+        &self,
+        command: DateTimeCommand,
+        year_month_dotm: u32,
+        dotw_hour_min_sec: u32,
+        appid: ProcessId,
+    ) -> CommandReturn {
+        if !self.in_progress.get() {
+            let grant_enter_res = self.apps.enter(appid, |app, _| {
+                app.subscribed = true;
+            });
+            match grant_enter_res {
+                Ok(()) => self
+                    .call_driver(
+                        command,
+                        year_month_dotm as usize,
+                        dotw_hour_min_sec as usize,
+                    )
+                    .into(),
+                Err(_e) => CommandReturn::failure(ErrorCode::FAIL),
+            }
+        } else {
+            let grant_enter_res = self.apps.enter(appid, |app, _| {
+                app.subscribed = true;
+            });
+
+            match grant_enter_res {
+                Ok(()) => CommandReturn::success(),
+                Err(_e) => CommandReturn::failure(ErrorCode::FAIL),
+            }
+        }
+    }
+}
+
+impl<'a, DateTime: date_time::DateTime<'a>> date_time::DateTimeClient
+    for DateTimeCapsule<'a, DateTime>
+{
+    fn get_date_time_done(&self, datetime: Result<date_time::DateTimeValues, ErrorCode>) {
+        self.in_progress.set(false);
+        let mut upcall_status: usize = into_statuscode(Ok(()));
+        let mut upcall_r1: usize = 0;
+        let mut upcall_r2: usize = 0;
+
+        for cntr in self.apps.iter() {
+            cntr.enter(|app, upcalls| {
+                if app.subscribed {
+                    app.subscribed = false;
+                    match datetime {
+                        Result::Ok(date) => {
+                            let (year_month_dotm, dotw_hour_min_sec) =
+                                match self.date_as_u32_tuple(date) {
+                                    Result::Ok(t) => t,
+                                    Result::Err(e) => {
+                                        upcall_status = into_statuscode(Result::Err(e));
+                                        (0, 0)
+                                    }
+                                };
+
+                            upcall_r1 = year_month_dotm as usize;
+                            upcall_r2 = dotw_hour_min_sec as usize;
+                        }
+                        Result::Err(e) => {
+                            upcall_status = into_statuscode(Result::Err(e));
+                        }
+                    }
+
+                    upcalls
+                        .schedule_upcall(0, (upcall_status, upcall_r1, upcall_r2))
+                        .ok();
+                }
+            });
+        }
+    }
+
+    fn set_date_time_done(&self, result: Result<(), ErrorCode>) {
+        self.in_progress.set(false);
+
+        for cntr in self.apps.iter() {
+            cntr.enter(|app, upcalls| {
+                if app.subscribed {
+                    app.subscribed = false;
+
+                    upcalls
+                        .schedule_upcall(0, (into_statuscode(result) as usize, 0, 0))
+                        .ok();
+                }
+            });
+        }
+    }
+}
+
+impl<'a, DateTime: date_time::DateTime<'a>> SyscallDriver for DateTimeCapsule<'a, DateTime> {
+    fn command(
+        &self,
+        command_number: usize,
+        r2: usize,
+        r3: usize,
+        process_id: ProcessId,
+    ) -> CommandReturn {
+        match command_number {
+            0 => CommandReturn::success(),
+            1 => self.enqueue_command(
+                DateTimeCommand::ReadDateTime,
+                r2 as u32,
+                r3 as u32,
+                process_id,
+            ),
+            2 => self.enqueue_command(
+                DateTimeCommand::SetDateTime,
+                r2 as u32,
+                r3 as u32,
+                process_id,
+            ),
+            _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
+        }
+    }
+
+    fn allocate_grant(&self, processid: ProcessId) -> Result<(), kernel::process::Error> {
+        self.apps.enter(processid, |_, _| {})
+    }
+}

--- a/capsules/extra/src/date_time.rs
+++ b/capsules/extra/src/date_time.rs
@@ -165,10 +165,9 @@ fn date_as_u32_tuple(set_date: date_time::DateTimeValues) -> Result<(u32, u32), 
     let month = month_as_u32(set_date.month);
     let dotw = dotw_as_u32(set_date.day_of_week);
 
-    let date = set_date.year as u32 * (1 << 9) as u32
-        + month * (1 << 5) as u32
-        + set_date.day as u32;
-    let time = dotw  * (1 << 17) as u32
+    let date =
+        set_date.year as u32 * (1 << 9) as u32 + month * (1 << 5) as u32 + set_date.day as u32;
+    let time = dotw * (1 << 17) as u32
         + set_date.hour as u32 * (1 << 12) as u32
         + set_date.minute as u32 * (1 << 6) as u32
         + set_date.seconds as u32;

--- a/capsules/extra/src/date_time.rs
+++ b/capsules/extra/src/date_time.rs
@@ -45,7 +45,7 @@ use kernel::utilities::cells::OptionalCell;
 
 pub const DRIVER_NUM: usize = NUM::DateTime as usize;
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub enum DateTimeCommand {
     ReadDateTime,
     SetDateTime(u32, u32),
@@ -234,7 +234,7 @@ impl<'a, DateTime: date_time::DateTime<'a>> DateTimeCapsule<'a, DateTime> {
         processid: ProcessId,
     ) -> CommandReturn {
         let grant_enter_res = self.apps.enter(processid, |app, _| {
-            if app.task.is_none() {
+            if !(app.task == None) {
                 CommandReturn::failure(ErrorCode::BUSY)
             } else{
                 app.task = Some(command);

--- a/capsules/extra/src/lib.rs
+++ b/capsules/extra/src/lib.rs
@@ -27,6 +27,7 @@ pub mod can;
 pub mod ccs811;
 pub mod crc;
 pub mod dac;
+pub mod date_time;
 pub mod debug_process_restart;
 pub mod fm25cl;
 pub mod ft6x06;

--- a/chips/rp2040/src/chip.rs
+++ b/chips/rp2040/src/chip.rs
@@ -15,6 +15,7 @@ use crate::i2c;
 use crate::interrupts;
 use crate::pwm;
 use crate::resets::Resets;
+use crate::rtc;
 use crate::spi;
 use crate::sysinfo;
 use crate::timer::RPTimer;
@@ -133,6 +134,7 @@ pub struct Rp2040DefaultPeripherals<'a> {
     pub usb: usb::UsbCtrl<'a>,
     pub watchdog: Watchdog<'a>,
     pub xosc: Xosc,
+    pub rtc: rtc::Rtc<'a>,
 }
 
 impl<'a> Rp2040DefaultPeripherals<'a> {
@@ -153,6 +155,7 @@ impl<'a> Rp2040DefaultPeripherals<'a> {
             usb: usb::UsbCtrl::new(),
             watchdog: Watchdog::new(),
             xosc: Xosc::new(),
+            rtc: rtc::Rtc::new(),
         }
     }
 
@@ -165,6 +168,7 @@ impl<'a> Rp2040DefaultPeripherals<'a> {
         kernel::deferred_call::DeferredCallClient::register(&self.uart1);
         self.i2c0.resolve_dependencies(&self.clocks, &self.resets);
         self.usb.set_gpio(self.pins.get_pin(RPGpio::GPIO15));
+        self.rtc.set_clocks(&self.clocks);
     }
 }
 
@@ -203,6 +207,7 @@ impl InterruptService for Rp2040DefaultPeripherals<'_> {
                 self.pins.handle_interrupt();
                 true
             }
+
             interrupts::I2C0_IRQ => {
                 self.i2c0.handle_interrupt();
                 true

--- a/chips/rp2040/src/deferred_calls.rs
+++ b/chips/rp2040/src/deferred_calls.rs
@@ -1,0 +1,36 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! Definition of Deferred Call tasks.
+//!
+//! Deferred calls also peripheral drivers to register pseudo interrupts.
+//! These are the definitions of which deferred calls this chip needs.
+
+use core::convert::Into;
+use core::convert::TryFrom;
+
+/// A type of task to defer a call for
+#[derive(Copy, Clone)]
+pub enum DeferredCallTask {
+    DateTimeGet = 0,
+    DateTimeSet = 1,
+}
+
+impl TryFrom<usize> for DeferredCallTask {
+    type Error = ();
+
+    fn try_from(value: usize) -> Result<DeferredCallTask, ()> {
+        match value {
+            0 => Ok(DeferredCallTask::DateTimeGet),
+            1 => Ok(DeferredCallTask::DateTimeSet),
+            _ => Err(()),
+        }
+    }
+}
+
+impl Into<usize> for DeferredCallTask {
+    fn into(self) -> usize {
+        self as usize
+    }
+}

--- a/chips/rp2040/src/lib.rs
+++ b/chips/rp2040/src/lib.rs
@@ -7,11 +7,13 @@
 pub mod adc;
 pub mod chip;
 pub mod clocks;
+mod deferred_calls;
 pub mod gpio;
 pub mod i2c;
 pub mod interrupts;
 pub mod pwm;
 pub mod resets;
+pub mod rtc;
 pub mod spi;
 pub mod sysinfo;
 pub mod test;

--- a/chips/rp2040/src/rtc.rs
+++ b/chips/rp2040/src/rtc.rs
@@ -1,0 +1,446 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! Real Time Clock (RTC) driver for RP2040.
+//!
+//! Author: Irina Bradu <irinabradu.a@gmail.com>
+//!         Remus Rughinis <remus.rughinis.007@gmail.com>
+//!
+//! # Hardware Interface Layer (HIL)
+//!
+//! The driver implements Date_Time HIL. The following features are available when using
+//! the driver through HIL:
+//!
+//! + Set time from which real time clock should start counting
+//! + Read current time from the RTC registers
+//!
+
+use crate::clocks;
+use core::cell::Cell;
+use kernel::deferred_call::{DeferredCall, DeferredCallClient};
+use kernel::hil::date_time;
+use kernel::hil::date_time::{DateTimeClient, DateTimeValues, DayOfWeek, Month};
+use kernel::utilities::cells::OptionalCell;
+use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
+use kernel::utilities::registers::{register_bitfields, register_structs, ReadWrite};
+use kernel::utilities::StaticRef;
+use kernel::ErrorCode;
+
+register_structs! {
+    /// Register block to control RTC
+    RtcRegisters {
+        /// Divider minus 1 for the 1 second counter. Safe to change the value when RTC is n
+        (0x000 => clkdiv_m1: ReadWrite<u32, CLKDIV_M1::Register>),
+        /// RTC setup register 0
+        (0x004 => setup_0: ReadWrite<u32, SETUP_0::Register>),
+        /// RTC setup register 1
+        (0x008 => setup_1: ReadWrite<u32, SETUP_1::Register>),
+        /// RTC Control and status
+        (0x00C => ctrl: ReadWrite<u32, CTRL::Register>),
+        /// Interrupt setup register 0
+        (0x010 => irq_setup_0: ReadWrite<u32, IRQ_SETUP_0::Register>),
+        /// Interrupt setup register 1
+        (0x014 => irq_setup_1: ReadWrite<u32, IRQ_SETUP_1::Register>),
+        /// RTC register 1.
+        (0x018 => rtc_1: ReadWrite<u32, RTC_1::Register>),
+        /// RTC register 0\n
+        /// Read this before RTC 1!
+        (0x01C => rtc_0: ReadWrite<u32, RTC_0::Register>),
+        /// Raw Interrupts
+        (0x020 => intr: ReadWrite<u32>),
+        /// Interrupt Enable
+        (0x024 => inte: ReadWrite<u32, INTE::Register>),
+        /// Interrupt Force
+        (0x028 => intf: ReadWrite<u32, INTF::Register>),
+        /// Interrupt status after masking & forcing
+        (0x02C => ints: ReadWrite<u32>),
+        (0x030 => @END),
+    }
+}
+register_bitfields![u32,
+CLKDIV_M1 [
+    CLKDIV_M OFFSET(0) NUMBITS(16) []
+],
+SETUP_0 [
+    /// Year
+    YEAR OFFSET(12) NUMBITS(12) [],
+    /// Month (1..12)
+    MONTH OFFSET(8) NUMBITS(4) [],
+    /// Day of the month (1..31)
+    DAY OFFSET(0) NUMBITS(5) []
+],
+SETUP_1 [
+    /// Day of the week: 1-Monday...0-Sunday ISO 8601 mod 7
+    DOTW OFFSET(24) NUMBITS(3) [],
+    /// Hours
+    HOUR OFFSET(16) NUMBITS(5) [],
+    /// Minutes
+    MIN OFFSET(8) NUMBITS(6) [],
+    /// Seconds
+    SEC OFFSET(0) NUMBITS(6) []
+],
+CTRL [
+    /// If set, leapyear is forced off.\n
+    /// Useful for years divisible by 100 but not by 400
+    FORCE_NOTLEAPYEAR OFFSET(8) NUMBITS(1) [],
+    /// Load RTC
+    LOAD OFFSET(4) NUMBITS(1) [],
+    /// RTC enabled (running)
+    RTC_ACTIVE OFFSET(1) NUMBITS(1) [],
+    /// Enable RTC
+    RTC_ENABLE OFFSET(0) NUMBITS(1) []
+],
+IRQ_SETUP_0 [
+    MATCH_ACTIVE OFFSET(29) NUMBITS(1) [],
+    /// Global match enable. Don't change any other value while this one is enabled
+    MATCH_ENA OFFSET(28) NUMBITS(1) [],
+    /// Enable year matching
+    YEAR_ENA OFFSET(26) NUMBITS(1) [],
+    /// Enable month matching
+    MONTH_ENA OFFSET(25) NUMBITS(1) [],
+    /// Enable day matching
+    DAY_ENA OFFSET(24) NUMBITS(1) [],
+    /// Year
+    YEAR OFFSET(12) NUMBITS(12) [],
+    /// Month (1..12)
+    MONTH OFFSET(8) NUMBITS(4) [],
+    /// Day of the month (1..31)
+    DAY OFFSET(0) NUMBITS(5) []
+],
+IRQ_SETUP_1 [
+    /// Enable day of the week matching
+    DOTW_ENA OFFSET(31) NUMBITS(1) [],
+    /// Enable hour matching
+    HOUR_ENA OFFSET(30) NUMBITS(1) [],
+    /// Enable minute matching
+    MIN_ENA OFFSET(29) NUMBITS(1) [],
+    /// Enable second matching
+    SEC_ENA OFFSET(28) NUMBITS(1) [],
+    /// Day of the week
+    DOTW OFFSET(24) NUMBITS(3) [],
+    /// Hours
+    HOUR OFFSET(16) NUMBITS(5) [],
+    /// Minutes
+    MIN OFFSET(8) NUMBITS(6) [],
+    /// Seconds
+    SEC OFFSET(0) NUMBITS(6) []
+],
+RTC_1 [
+    /// Year
+    YEAR OFFSET(12) NUMBITS(12) [],
+    /// Month (1..12)
+    MONTH OFFSET(8) NUMBITS(4) [],
+    /// Day of the month (1..31)
+    DAY OFFSET(0) NUMBITS(5) []
+],
+RTC_0 [
+    /// Day of the week
+    DOTW OFFSET(24) NUMBITS(3) [],
+    /// Hours
+    HOUR OFFSET(16) NUMBITS(5) [],
+    /// Minutes
+    MIN OFFSET(8) NUMBITS(6) [],
+    /// Seconds
+    SEC OFFSET(0) NUMBITS(6) []
+],
+INTR [
+
+    RTC OFFSET(0) NUMBITS(1) []
+],
+INTE [
+
+    RTC OFFSET(0) NUMBITS(1) []
+],
+INTF [
+
+    RTC OFFSET(0) NUMBITS(1) []
+],
+INTS [
+
+    RTC OFFSET(0) NUMBITS(1) []
+]
+];
+
+const RTC_BASE: StaticRef<RtcRegisters> =
+    unsafe { StaticRef::new(0x4005C000 as *const RtcRegisters) };
+
+pub struct Rtc<'a> {
+    registers: StaticRef<RtcRegisters>,
+    client: OptionalCell<&'a dyn date_time::DateTimeClient>,
+    clocks: OptionalCell<&'a clocks::Clocks>,
+    time: Cell<DateTimeValues>,
+
+    deferred_call: DeferredCall,
+    deferred_call_task: OptionalCell<DeferredCallTask>,
+}
+
+#[derive(Clone, Copy)]
+enum DeferredCallTask {
+    Get,
+    Set,
+}
+
+impl<'a> DeferredCallClient for Rtc<'a> {
+    fn handle_deferred_call(&self) {
+        self.deferred_call_task.take().map(|value| match value {
+            DeferredCallTask::Get => self
+                .client
+                .map(|client| client.get_date_time_done(Ok(self.time.get()))),
+            DeferredCallTask::Set => self.client.map(|client| client.set_date_time_done(Ok(()))),
+        });
+    }
+    fn register(&'static self) {
+        self.deferred_call.register(self);
+    }
+}
+
+impl<'a> Rtc<'a> {
+    pub fn new() -> Rtc<'a> {
+        Rtc {
+            registers: RTC_BASE,
+            client: OptionalCell::empty(),
+            clocks: OptionalCell::empty(),
+            time: Cell::new(DateTimeValues {
+                year: 0,
+                month: Month::January,
+                day: 1,
+                day_of_week: DayOfWeek::Sunday,
+                hour: 0,
+                minute: 0,
+                seconds: 0,
+            }),
+
+            deferred_call: DeferredCall::new(),
+            deferred_call_task: OptionalCell::empty(),
+        }
+    }
+
+    fn dotw_try_from_u32(&self, dotw: u32) -> Result<DayOfWeek, ErrorCode> {
+        match dotw {
+            0 => Ok(DayOfWeek::Sunday),
+            1 => Ok(DayOfWeek::Monday),
+            2 => Ok(DayOfWeek::Tuesday),
+            3 => Ok(DayOfWeek::Wednesday),
+            4 => Ok(DayOfWeek::Thursday),
+            5 => Ok(DayOfWeek::Friday),
+            6 => Ok(DayOfWeek::Saturday),
+            _ => Err(ErrorCode::INVAL),
+        }
+    }
+
+    fn dotw_into_u32(&self, dotw: DayOfWeek) -> u32 {
+        match dotw {
+            DayOfWeek::Sunday => 0,
+            DayOfWeek::Monday => 1,
+            DayOfWeek::Tuesday => 2,
+            DayOfWeek::Wednesday => 3,
+            DayOfWeek::Thursday => 4,
+            DayOfWeek::Friday => 5,
+            DayOfWeek::Saturday => 6,
+        }
+    }
+
+    fn month_try_from_u32(&self, month_num: u32) -> Result<Month, ErrorCode> {
+        match month_num {
+            1 => Ok(Month::January),
+            2 => Ok(Month::February),
+            3 => Ok(Month::March),
+            4 => Ok(Month::April),
+            5 => Ok(Month::May),
+            6 => Ok(Month::June),
+            7 => Ok(Month::July),
+            8 => Ok(Month::August),
+            9 => Ok(Month::September),
+            10 => Ok(Month::October),
+            11 => Ok(Month::November),
+            12 => Ok(Month::December),
+            _ => Err(ErrorCode::INVAL),
+        }
+    }
+
+    fn month_into_u32(&self, month: Month) -> u32 {
+        match month {
+            Month::January => 1,
+            Month::February => 2,
+            Month::March => 3,
+            Month::April => 4,
+            Month::May => 5,
+            Month::June => 6,
+            Month::July => 7,
+            Month::August => 8,
+            Month::September => 9,
+            Month::October => 10,
+            Month::November => 11,
+            Month::December => 12,
+        }
+    }
+
+    pub fn handle_set_interrupt(&self) {
+        self.client.map(|client| client.set_date_time_done(Ok(())));
+    }
+
+    pub fn handle_get_interrupt(&self) {
+        self.client
+            .map(|client| client.get_date_time_done(Ok(self.time.get())));
+    }
+
+    pub fn set_clocks(&self, clocks: &'a clocks::Clocks) {
+        self.clocks.replace(clocks);
+    }
+
+    fn date_time_setup(&self, datetime: date_time::DateTimeValues) -> Result<(), ErrorCode> {
+        let month_val: u32 = self.month_into_u32(datetime.month);
+        let day_val: u32 = self.dotw_into_u32(datetime.day_of_week);
+
+        if !(datetime.year <= 4095) {
+            return Err(ErrorCode::INVAL);
+        }
+
+        if !(datetime.day >= 1 && datetime.day <= 31) {
+            return Err(ErrorCode::INVAL);
+        }
+
+        if !(datetime.hour <= 23) {
+            return Err(ErrorCode::INVAL);
+        }
+        if !(datetime.minute <= 59) {
+            return Err(ErrorCode::INVAL);
+        }
+        if !(datetime.seconds <= 59) {
+            return Err(ErrorCode::INVAL);
+        }
+
+        self.registers
+            .setup_0
+            .modify(SETUP_0::YEAR.val(datetime.year as u32));
+        self.registers
+            .setup_0
+            .modify(SETUP_0::MONTH.val(month_val as u32));
+        self.registers
+            .setup_0
+            .modify(SETUP_0::DAY.val(datetime.day as u32));
+
+        self.registers
+            .setup_1
+            .modify(SETUP_1::DOTW.val(day_val as u32));
+        self.registers
+            .setup_1
+            .modify(SETUP_1::HOUR.val(datetime.hour as u32));
+        self.registers
+            .setup_1
+            .modify(SETUP_1::MIN.val(datetime.minute as u32));
+        self.registers
+            .setup_1
+            .modify(SETUP_1::SEC.val(datetime.seconds as u32));
+
+        self.registers.ctrl.modify(CTRL::LOAD::SET);
+
+        Ok(())
+    }
+
+    fn set_initial(&self) -> Result<(), ErrorCode> {
+        let mut hw_ctrl: u32;
+
+        self.registers.ctrl.modify(CTRL::RTC_ENABLE.val(0));
+        hw_ctrl = self.registers.ctrl.read(CTRL::RTC_ENABLE);
+
+        while hw_ctrl & self.registers.ctrl.read(CTRL::RTC_ACTIVE) > 0 {}
+
+        let datetime = date_time::DateTimeValues {
+            year: 1970,
+            month: Month::January,
+            day: 1,
+            day_of_week: DayOfWeek::Sunday,
+            hour: 0,
+            minute: 0,
+            seconds: 0,
+        };
+
+        self.date_time_setup(datetime)?;
+        self.registers.ctrl.modify(CTRL::LOAD::SET);
+        self.registers.ctrl.modify(CTRL::RTC_ENABLE.val(1));
+        hw_ctrl = self.registers.ctrl.read(CTRL::RTC_ENABLE);
+
+        while !((hw_ctrl & self.registers.ctrl.read(CTRL::RTC_ACTIVE)) > 0) {
+            // wait until rtc starts
+        }
+
+        Ok(())
+    }
+
+    pub fn rtc_init(&self) -> Result<(), ErrorCode> {
+        let mut rtc_freq = self
+            .clocks
+            .map_or(46875, |clocks| clocks.get_frequency(clocks::Clock::Rtc));
+
+        rtc_freq = rtc_freq - 1;
+
+        self.registers
+            .clkdiv_m1
+            .modify(CLKDIV_M1::CLKDIV_M.val(rtc_freq));
+
+        self.set_initial()
+    }
+}
+
+impl<'a> date_time::DateTime<'a> for Rtc<'a> {
+    fn get_date_time(&self) -> Result<(), ErrorCode> {
+        match self.deferred_call_task.extract() {
+            Some(DeferredCallTask::Set) => return Err(ErrorCode::BUSY),
+            Some(DeferredCallTask::Get) => return Err(ErrorCode::ALREADY),
+            _ => (),
+        }
+
+        let month_num: u32 = self.registers.setup_0.read(SETUP_0::MONTH);
+        let month_name: Month = match self.month_try_from_u32(month_num) {
+            Result::Ok(t) => t,
+            Result::Err(e) => {
+                return Err(e);
+            }
+        };
+        let dotw_num = self.registers.setup_1.read(SETUP_1::DOTW);
+        let dotw = match self.dotw_try_from_u32(dotw_num) {
+            Result::Ok(t) => t,
+            Result::Err(e) => {
+                return Err(e);
+            }
+        };
+
+        let datetime = date_time::DateTimeValues {
+            hour: self.registers.rtc_0.read(RTC_0::HOUR) as u8,
+            minute: self.registers.rtc_0.read(RTC_0::MIN) as u8,
+            seconds: self.registers.rtc_0.read(RTC_0::SEC) as u8,
+
+            year: self.registers.rtc_1.read(RTC_1::YEAR) as u16,
+            month: month_name,
+            day: self.registers.rtc_1.read(RTC_1::DAY) as u8,
+            day_of_week: dotw,
+        };
+
+        self.time.replace(datetime);
+
+        self.deferred_call_task.insert(Some(DeferredCallTask::Get));
+        self.deferred_call.set();
+
+        Ok(())
+    }
+
+    fn set_date_time(&self, date_time: date_time::DateTimeValues) -> Result<(), ErrorCode> {
+        match self.deferred_call_task.extract() {
+            Some(DeferredCallTask::Set) => return Err(ErrorCode::ALREADY),
+            Some(DeferredCallTask::Get) => return Err(ErrorCode::BUSY),
+            _ => (),
+        }
+
+        self.date_time_setup(date_time)?;
+
+        self.deferred_call_task.insert(Some(DeferredCallTask::Set));
+        self.deferred_call.set();
+        Ok(())
+    }
+
+    fn set_client(&self, client: &'a dyn DateTimeClient) {
+        self.client.set(client);
+    }
+}

--- a/chips/rp2040/src/rtc.rs
+++ b/chips/rp2040/src/rtc.rs
@@ -386,9 +386,15 @@ impl<'a> Rtc<'a> {
 
 impl<'a> date_time::DateTime<'a> for Rtc<'a> {
     fn get_date_time(&self) -> Result<(), ErrorCode> {
-        match self.deferred_call_task.extract() {
-            Some(DeferredCallTask::Set) => return Err(ErrorCode::BUSY),
-            Some(DeferredCallTask::Get) => return Err(ErrorCode::ALREADY),
+        match self.deferred_call_task.take() {
+            Some(DeferredCallTask::Set) => {
+                self.deferred_call_task.insert(Some(DeferredCallTask::Set));
+                return Err(ErrorCode::BUSY)
+            },
+            Some(DeferredCallTask::Get) => {
+                self.deferred_call_task.insert(Some(DeferredCallTask::Get));
+                return Err(ErrorCode::ALREADY)
+            },
             _ => (),
         }
 
@@ -427,9 +433,15 @@ impl<'a> date_time::DateTime<'a> for Rtc<'a> {
     }
 
     fn set_date_time(&self, date_time: date_time::DateTimeValues) -> Result<(), ErrorCode> {
-        match self.deferred_call_task.extract() {
-            Some(DeferredCallTask::Set) => return Err(ErrorCode::ALREADY),
-            Some(DeferredCallTask::Get) => return Err(ErrorCode::BUSY),
+        match self.deferred_call_task.take() {
+            Some(DeferredCallTask::Set) => {
+                self.deferred_call_task.insert(Some(DeferredCallTask::Set));
+                return Err(ErrorCode::ALREADY)
+            },
+            Some(DeferredCallTask::Get) => {
+                self.deferred_call_task.insert(Some(DeferredCallTask::Get));
+                return Err(ErrorCode::BUSY)
+            },
             _ => (),
         }
 

--- a/chips/rp2040/src/rtc.rs
+++ b/chips/rp2040/src/rtc.rs
@@ -314,16 +314,12 @@ impl<'a> Rtc<'a> {
         self.registers
             .setup_0
             .modify(SETUP_0::YEAR.val(datetime.year as u32));
-        self.registers
-            .setup_0
-            .modify(SETUP_0::MONTH.val(month_val as u32));
+        self.registers.setup_0.modify(SETUP_0::MONTH.val(month_val));
         self.registers
             .setup_0
             .modify(SETUP_0::DAY.val(datetime.day as u32));
 
-        self.registers
-            .setup_1
-            .modify(SETUP_1::DOTW.val(day_val as u32));
+        self.registers.setup_1.modify(SETUP_1::DOTW.val(day_val));
         self.registers
             .setup_1
             .modify(SETUP_1::HOUR.val(datetime.hour as u32));
@@ -374,7 +370,7 @@ impl<'a> Rtc<'a> {
             .clocks
             .map_or(46875, |clocks| clocks.get_frequency(clocks::Clock::Rtc));
 
-        rtc_freq = rtc_freq - 1;
+        rtc_freq -= rtc_freq;
 
         self.registers
             .clkdiv_m1
@@ -389,12 +385,12 @@ impl<'a> date_time::DateTime<'a> for Rtc<'a> {
         match self.deferred_call_task.take() {
             Some(DeferredCallTask::Set) => {
                 self.deferred_call_task.insert(Some(DeferredCallTask::Set));
-                return Err(ErrorCode::BUSY)
-            },
+                return Err(ErrorCode::BUSY);
+            }
             Some(DeferredCallTask::Get) => {
                 self.deferred_call_task.insert(Some(DeferredCallTask::Get));
-                return Err(ErrorCode::ALREADY)
-            },
+                return Err(ErrorCode::ALREADY);
+            }
             _ => (),
         }
 
@@ -436,12 +432,12 @@ impl<'a> date_time::DateTime<'a> for Rtc<'a> {
         match self.deferred_call_task.take() {
             Some(DeferredCallTask::Set) => {
                 self.deferred_call_task.insert(Some(DeferredCallTask::Set));
-                return Err(ErrorCode::ALREADY)
-            },
+                return Err(ErrorCode::ALREADY);
+            }
             Some(DeferredCallTask::Get) => {
                 self.deferred_call_task.insert(Some(DeferredCallTask::Get));
-                return Err(ErrorCode::BUSY)
-            },
+                return Err(ErrorCode::BUSY);
+            }
             _ => (),
         }
 

--- a/chips/stm32f429zi/src/interrupt_service.rs
+++ b/chips/stm32f429zi/src/interrupt_service.rs
@@ -11,6 +11,7 @@ pub struct Stm32f429ziDefaultPeripherals<'a> {
     // Once implemented, place Stm32f429zi specific peripherals here
     pub trng: stm32f4xx::trng::Trng<'a>,
     pub can1: stm32f4xx::can::Can<'a>,
+    pub rtc: crate::rtc::Rtc<'a>,
 }
 
 impl<'a> Stm32f429ziDefaultPeripherals<'a> {
@@ -24,6 +25,7 @@ impl<'a> Stm32f429ziDefaultPeripherals<'a> {
             stm32f4: Stm32f4xxDefaultPeripherals::new(rcc, exti, dma1, dma2),
             trng: stm32f4xx::trng::Trng::new(trng_registers::RNG_BASE, rcc),
             can1: stm32f4xx::can::Can::new(rcc, can_registers::CAN1_BASE),
+            rtc: crate::rtc::Rtc::new(rcc),
         }
     }
     // Necessary for setting up circular dependencies and registering deferred calls

--- a/chips/stm32f429zi/src/lib.rs
+++ b/chips/stm32f429zi/src/lib.rs
@@ -15,6 +15,9 @@ pub mod interrupt_service;
 pub mod stm32f429zi_nvic;
 pub mod trng_registers;
 
+pub mod pwr;
+pub mod rtc;
+
 // STM32F42xxx and STM32F43xxx has total of 91 interrupts
 #[cfg_attr(all(target_arch = "arm", target_os = "none"), link_section = ".irqs")]
 // `used` ensures that the symbol is kept until the final binary. However, as of

--- a/chips/stm32f429zi/src/pwr.rs
+++ b/chips/stm32f429zi/src/pwr.rs
@@ -1,0 +1,97 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+use kernel::utilities::registers::interfaces::ReadWriteable;
+use kernel::utilities::registers::{register_bitfields, register_structs, ReadWrite};
+use kernel::utilities::StaticRef;
+use kernel::ErrorCode;
+
+register_structs! {
+    /// Power control
+    PwrRegisters {
+        /// power control register
+        (0x000 => cr: ReadWrite<u32, CR::Register>),
+        /// power control/status register
+        (0x004 => csr: ReadWrite<u32, CSR::Register>),
+        (0x008 => @END),
+    }
+}
+register_bitfields![u32,
+CR [
+    /// Low-power deep sleep
+    LPDS OFFSET(0) NUMBITS(1) [],
+    /// Power down deepsleep
+    PDDS OFFSET(1) NUMBITS(1) [],
+    /// Clear wakeup flag
+    CWUF OFFSET(2) NUMBITS(1) [],
+    /// Clear standby flag
+    CSBF OFFSET(3) NUMBITS(1) [],
+    /// Power voltage detector
+    /// enable
+    PVDE OFFSET(4) NUMBITS(1) [],
+    /// PVD level selection
+    PLS OFFSET(5) NUMBITS(3) [],
+    /// Disable backup domain write
+    /// protection
+    DBP OFFSET(8) NUMBITS(1) [],
+    /// Flash power down in Stop
+    /// mode
+    FPDS OFFSET(9) NUMBITS(1) [],
+    /// Low-Power Regulator Low Voltage in
+    /// deepsleep
+    LPLUDS OFFSET(10) NUMBITS(1) [],
+    /// Main regulator low voltage in deepsleep
+    /// mode
+    MRUDS OFFSET(11) NUMBITS(1) [],
+
+    ADCDC1 OFFSET(13) NUMBITS(1) [],
+    /// Regulator voltage scaling output
+    /// selection
+    VOS OFFSET(14) NUMBITS(2) [
+        Scale3 = 0b01,
+        Scale2 = 0b10,
+        Scale1 = 0b11,
+    ],
+    /// Over-drive enable
+    ODEN OFFSET(16) NUMBITS(1) [],
+    /// Over-drive switching
+    /// enabled
+    ODSWEN OFFSET(17) NUMBITS(1) [],
+    /// Under-drive enable in stop
+    /// mode
+    UDEN OFFSET(18) NUMBITS(2) []
+],
+CSR [
+    /// Wakeup flag
+    WUF OFFSET(0) NUMBITS(1) [],
+    /// Standby flag
+    SBF OFFSET(1) NUMBITS(1) [],
+    /// PVD output
+    PVDO OFFSET(2) NUMBITS(1) [],
+    /// Backup regulator ready
+    BRR OFFSET(3) NUMBITS(1) [],
+    /// Enable WKUP pin
+    EWUP OFFSET(8) NUMBITS(1) [],
+    /// Backup regulator enable
+    BRE OFFSET(9) NUMBITS(1) [],
+    /// Regulator voltage scaling output
+    /// selection ready bit
+    VOSRDY OFFSET(14) NUMBITS(1) [],
+    /// Over-drive mode ready
+    ODRDY OFFSET(16) NUMBITS(1) [],
+    /// Over-drive mode switching
+    /// ready
+    ODSWRDY OFFSET(17) NUMBITS(1) [],
+    /// Under-drive ready flag
+    UDRDY OFFSET(18) NUMBITS(2) []
+]
+];
+const PWR_BASE: StaticRef<PwrRegisters> =
+    unsafe { StaticRef::new(0x40007000 as *const PwrRegisters) };
+
+#[inline(never)]
+pub fn enable_backup_access() -> Result<(), ErrorCode> {
+    PWR_BASE.cr.modify(CR::DBP::SET);
+    Ok(())
+}

--- a/chips/stm32f429zi/src/rtc.rs
+++ b/chips/stm32f429zi/src/rtc.rs
@@ -605,9 +605,15 @@ impl<'a> Rtc<'a> {
 
 impl<'a> date_time::DateTime<'a> for Rtc<'a> {
     fn get_date_time(&self) -> Result<(), ErrorCode> {
-        match self.deferred_call_task.extract() {
-            Some(DeferredCallTask::Set) => return Err(ErrorCode::BUSY),
-            Some(DeferredCallTask::Get) => return Err(ErrorCode::ALREADY),
+        match self.deferred_call_task.take() {
+            Some(DeferredCallTask::Set) => {
+                self.deferred_call_task.insert(Some(DeferredCallTask::Set));
+                return Err(ErrorCode::BUSY);
+            }
+            Some(DeferredCallTask::Get) => {
+                self.deferred_call_task.insert(Some(DeferredCallTask::Get));
+                return Err(ErrorCode::ALREADY);
+            }
             _ => (),
         }
 
@@ -643,9 +649,15 @@ impl<'a> date_time::DateTime<'a> for Rtc<'a> {
     }
 
     fn set_date_time(&self, date_time: date_time::DateTimeValues) -> Result<(), ErrorCode> {
-        match self.deferred_call_task.extract() {
-            Some(DeferredCallTask::Set) => return Err(ErrorCode::ALREADY),
-            Some(DeferredCallTask::Get) => return Err(ErrorCode::BUSY),
+        match self.deferred_call_task.take() {
+            Some(DeferredCallTask::Set) => {
+                self.deferred_call_task.insert(Some(DeferredCallTask::Set));
+                return Err(ErrorCode::ALREADY);
+            }
+            Some(DeferredCallTask::Get) => {
+                self.deferred_call_task.insert(Some(DeferredCallTask::Get));
+                return Err(ErrorCode::BUSY);
+            }
             _ => (),
         }
 

--- a/chips/stm32f429zi/src/rtc.rs
+++ b/chips/stm32f429zi/src/rtc.rs
@@ -1,0 +1,664 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! Real Time Clock (RTC) driver for STM32f429zi.
+//!
+//! Author: Remus Rughinis <remus.rughinis.007@gmail.com>
+//!
+//! # Hardware Interface Layer (HIL)
+//!
+//! The driver implements Date_Time HIL. The following features are available when using
+//! the driver through HIL:
+//!
+//! + Set time from which real time clock should start counting
+//! + Read current time from the RTC registers
+//!
+
+use core::cell::Cell;
+use kernel::deferred_call::{DeferredCall, DeferredCallClient};
+use kernel::hil::date_time;
+use kernel::hil::date_time::{DateTimeClient, DateTimeValues, DayOfWeek, Month};
+use kernel::platform::chip::ClockInterface;
+use kernel::utilities::cells::OptionalCell;
+use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
+use kernel::utilities::registers::{register_bitfields, ReadWrite};
+use kernel::utilities::StaticRef;
+use kernel::ErrorCode;
+use stm32f4xx::rcc;
+
+/// Register block to control RTC
+#[repr(C)]
+pub struct RtcRegisters {
+    /// The RTC_TR is the calendar time shadow register. This register must be written in initialization mode only.
+    rtc_tr: ReadWrite<u32, RTC_TR::Register>,
+    /// The RTC_DR is the calendar date shadow register. This register must be written in initialization mode only.
+    rtc_dr: ReadWrite<u32, RTC_DR::Register>,
+    /// RTC control register
+    rtc_cr: ReadWrite<u32, RTC_CR::Register>,
+    /// RTC initialization and status register
+    rtc_isr: ReadWrite<u32, RTC_ISR::Register>,
+    /// RTC prescaler register
+    rtc_prer: ReadWrite<u32, RTC_PRER::Register>,
+    /// RTC wakeup timer register
+    rtc_wutr: ReadWrite<u32, RTC_WUTR::Register>,
+    /// RTC calibration register
+    rtc_calibr: ReadWrite<u32, RTC_CALIBR::Register>,
+    /// RTC alarm A register
+    rtc_alrmar: ReadWrite<u32, RTC_ALRMAR::Register>,
+    /// RTC alarm B register
+    rtc_alrmbr: ReadWrite<u32, RTC_ALRMBR::Register>,
+    /// RTC write protection register
+    rtc_wpr: ReadWrite<u32, RTC_WPR::Register>,
+    /// RTC sub second register
+    rtc_ssr: ReadWrite<u32, RTC_SSR::Register>,
+    /// RTC shift control register
+    rtc_shiftr: ReadWrite<u32, RTC_SHIFTR::Register>,
+    /// RTC time stamp time register
+    rtc_tstr: ReadWrite<u32, RTC_TSTR::Register>,
+    /// RTC time stamp date register
+    rtc_tsdr: ReadWrite<u32, RTC_TSDR::Register>,
+    /// RTC time stamp sub second register
+    rtc_tsssr: ReadWrite<u32, RTC_TSSSR::Register>,
+    /// RTC calibration register
+    rtc_calr: ReadWrite<u32, RTC_CALR::Register>,
+    /// RTC tamper and alternate function configuration register
+    rtc_tafcr: ReadWrite<u32, RTC_TAFCR::Register>,
+    /// RTC alarm A sub second register
+    rtc_alrmassr: ReadWrite<u32, RTC_ALRMASSR::Register>,
+    /// RTC alarm B sub second register
+    rtc_alrmbssr: ReadWrite<u32, RTC_ALRMBSSR::Register>,
+
+    /// The application can write or read data to and from these registers
+    rtc_bkpxr: [ReadWrite<u32, RTC_BKPXR::Register>; 19],
+}
+
+register_bitfields![u32,
+RTC_TR[
+    /// AM/PM notation. 0: AM or 24-hour format, 1: PM
+    PM OFFSET(22) NUMBITS(1) [],
+    /// Hour tens in BCD format
+    HT OFFSET(20) NUMBITS(2) [],
+    /// Hour units in BCD format
+    HU OFFSET(16) NUMBITS(4) [],
+    /// Minute tens in BCD format
+    MNT OFFSET(12) NUMBITS(3) [],
+    /// Minute units in BCD format
+    MNU OFFSET(8) NUMBITS(4) [],
+    /// Second tens in BCD format
+    ST OFFSET(4) NUMBITS(3) [],
+    /// Second units in BCD format
+    SU OFFSET(0) NUMBITS(4) [],
+],
+RTC_DR[
+    /// Year tens in BCD format
+    YT OFFSET(20) NUMBITS(4) [],
+    /// Year units in BCD format
+    YU OFFSET(16) NUMBITS(4) [],
+    /// Week day units. 000: forbidden, 001: Monday ... 111: Sunday
+    WDU OFFSET(13) NUMBITS(3) [],
+    ///Month tens in BCD format
+    MT OFFSET(12) NUMBITS(1) [],
+    /// Month units in BCD format
+    MU OFFSET(8) NUMBITS(4) [],
+    /// Date tens in BCD format
+    DT OFFSET(4) NUMBITS(2) [],
+    /// Date units in BCD format
+    DU OFFSET(0) NUMBITS(4) [],
+],
+RTC_CR[
+    /// Calibration output enable, enables the RTC_CALIB output
+    COE OFFSET(23) NUMBITS(1) [],
+    /// Output selection, used to select the flag to be routed to RTC_ALARM output
+    OSEL OFFSET(21) NUMBITS(2) [],
+    /// Output polarity, used to configure the polarity of RTC_ALARM output
+    POL OFFSET(20) NUMBITS(1) [],
+    /// Calibration output selection
+    COSEL OFFSET(19) NUMBITS(1) [],
+    /// Backup, memorizes whether daylight saving time change has been performed or not
+    BKP OFFSET(18) NUMBITS(1) [],
+    /// Subtract 1 hour (winter time change)
+    SUB1H OFFSET(17) NUMBITS(1) [],
+    /// Add 1 hour (summer time change)
+    ADD1H OFFSET(16) NUMBITS(1) [],
+    /// Timestamp interrupt enable
+    TSIE OFFSET(15) NUMBITS(1) [],
+    /// Wakeup timer interrupt enable
+    WUTIE OFFSET(14) NUMBITS(1) [],
+    /// Alarm B interrupt enable
+    ALRBIE OFFSET(13) NUMBITS(1) [],
+    /// Alarm A interrupt enable
+    ALRAIE OFFSET(12) NUMBITS(1) [],
+    /// Time stamp enable
+    TSE OFFSET(11) NUMBITS(1) [],
+    /// Wakeup timer enable
+    WUTE OFFSET(10) NUMBITS(1) [],
+    /// Alarm B enable
+    ALRBE OFFSET(9) NUMBITS(1) [],
+    /// Alarm A enable
+    ALRAE OFFSET(8) NUMBITS(1) [],
+    /// Coarse digital calibration enable
+    DCE OFFSET(7) NUMBITS(1) [],
+    /// Hour format
+    FMT OFFSET(6) NUMBITS(1) [],
+    /// Bypass the shadow registers
+    BYPSHAD OFFSET(5) NUMBITS(1) [],
+    /// Reference clock detection enable (50 or 60 Hz)
+    REFCKON OFFSET(4) NUMBITS(1) [],
+    /// Timestamp event active edge
+    TSEDGE OFFSET(3) NUMBITS(1) [],
+    /// Wakeup clock selection
+    WUCKSEL OFFSET(0) NUMBITS(3) [],
+],
+RTC_ISR[
+    /// Recalibration Pending Flag
+    RECALPF OFFSET(16) NUMBITS(1) [],
+    /// TAMPER2 detection flag
+    TAMP2F OFFSET(14) NUMBITS(1) [],
+    /// TAMPER detection flag
+    TAMP1F OFFSET(13) NUMBITS(1) [],
+    /// Timestamp overflow flag
+    TSOVF OFFSET(12) NUMBITS(1) [],
+    /// Timestamp flag
+    TSF OFFSET(11) NUMBITS(1) [],
+    /// Wakeup timer flag
+    WUTF OFFSET(10) NUMBITS(1) [],
+    /// Alarm B flag
+    ALRBF OFFSET(9) NUMBITS(1) [],
+    /// Alarm A flag
+    ALRAF OFFSET(8) NUMBITS(1) [],
+    /// Initialization mode
+    INIT OFFSET(7) NUMBITS(1) [],
+    /// Initialization flag
+    INITF OFFSET(6) NUMBITS(1) [],
+    /// Registers synchronization flag
+    RSF OFFSET(5) NUMBITS(1) [],
+    /// Initialization status flag
+    INITS OFFSET(4) NUMBITS(1) [],
+    /// Shift operation pending
+    SHPF OFFSET(3) NUMBITS(1) [],
+    /// Wakeup timer write flag
+    WUTWF OFFSET(2) NUMBITS(1) [],
+    /// Alarm B write flag
+    ALRBWF OFFSET(1) NUMBITS(1) [],
+    /// Alarm A write flag
+    ALRAWF OFFSET(0) NUMBITS(1) [],
+],
+RTC_PRER[
+    /// Asynchronous precaler factor
+    PREDIV_A OFFSET(16) NUMBITS(7) [],
+    /// Synchronous prescaler factor
+    PREDIV_S OFFSET(0) NUMBITS(15) [],
+],
+RTC_WUTR[
+    /// Wakeup auto-reload value bits
+    WUT OFFSET(0) NUMBITS(16) [],
+],
+RTC_CALIBR[
+    /// Digital calibration sign
+    DCS OFFSET(7) NUMBITS(1) [],
+    /// Digital calibration
+    DC OFFSET(0) NUMBITS(5) [],
+],
+RTC_ALRMAR[
+    /// Alarm A date mask
+    MSK4 OFFSET(31) NUMBITS(1) [],
+    /// Week day selection
+    WDSEL OFFSET(30) NUMBITS(1) [],
+    /// Date tens in BCD format
+    DT OFFSET(28) NUMBITS(2) [],
+    /// Date units in BCD format
+    DU OFFSET(24) NUMBITS(4) [],
+    /// Alarm A hours mask
+    MSK3 OFFSET(23) NUMBITS(1) [],
+    /// AM/PM notation
+    PM OFFSET(22) NUMBITS(1) [],
+    /// Hour tens in BCD format
+    HT OFFSET(20) NUMBITS(2) [],
+    /// Hour units in BCD format
+    HU OFFSET(16) NUMBITS(4) [],
+    /// Alarm A minutes mask
+    MSK2 OFFSET(15) NUMBITS(1) [],
+    /// Minute tens in BCD format
+    MNT OFFSET(12) NUMBITS(3) [],
+    /// Minute units in BCD format
+    MNU OFFSET(8) NUMBITS(4) [],
+    /// Alarm A seconds mask
+    MSK1 OFFSET(7) NUMBITS(1) [],
+    /// Second tens in BCD format
+    ST OFFSET(4) NUMBITS(3) [],
+    /// Second units in BCD format
+    SU OFFSET(0) NUMBITS(4) [],
+],
+RTC_ALRMBR[
+    /// Alarm B date mask
+    MSK4 OFFSET(31) NUMBITS(1) [],
+    /// Week day selection
+    WDSEL OFFSET(30) NUMBITS(1) [],
+    /// Date tens in BCD format
+    DT OFFSET(28) NUMBITS(2) [],
+    /// Date units in BCD format
+    DU OFFSET(24) NUMBITS(4) [],
+    /// Alarm B hours mask
+    MSK3 OFFSET(23) NUMBITS(1) [],
+    /// AM/PM notation
+    PM OFFSET(22) NUMBITS(1) [],
+    /// Hour tens in BCD format
+    HT OFFSET(20) NUMBITS(2) [],
+    /// Hour units in BCD format
+    HU OFFSET(16) NUMBITS(4) [],
+    /// Alarm B minutes mask
+    MSK2 OFFSET(15) NUMBITS(1) [],
+    /// Minute tens in BCD format
+    MNT OFFSET(12) NUMBITS(3) [],
+    /// Minute units in BCD format
+    MNU OFFSET(8) NUMBITS(4) [],
+    /// Alarm B seconds mask
+    MSK1 OFFSET(7) NUMBITS(1) [],
+    /// Second tens in BCD format
+    ST OFFSET(4) NUMBITS(3) [],
+    /// Second units in BCD format
+    SU OFFSET(0) NUMBITS(4) [],
+],
+RTC_WPR[
+    /// Write protection key
+    KEY OFFSET(0) NUMBITS(8) [],
+],
+RTC_SSR[
+    /// Sub second value
+    SS OFFSET(0) NUMBITS(16) [],
+],
+RTC_SHIFTR[
+    /// Add one second
+    ADD1S OFFSET(31) NUMBITS(1) [],
+    /// Subtract a fraction of a second
+    SUBFS OFFSET(0) NUMBITS(15) [],
+],
+RTC_TSTR[
+    /// AM/PM notation
+    PM OFFSET(22) NUMBITS(1) [],
+    /// Hour tens in BCD format
+    HT OFFSET(20) NUMBITS(2) [],
+    /// Hour units in BCD format
+    HU OFFSET(16) NUMBITS(4) [],
+    /// Minute tens in BCD format
+    MNT OFFSET(12) NUMBITS(3) [],
+    /// Minute units in BCD format
+    MNU OFFSET(8) NUMBITS(4) [],
+    /// Second tens in BCD format
+    ST OFFSET(4) NUMBITS(3) [],
+    /// Second units in BCD format
+    STU OFFSET(0) NUMBITS(4) [],
+],
+RTC_TSDR[
+    /// Week day units. 000: forbidden, 001: Monday ... 111: Sunday
+    WDU OFFSET(13) NUMBITS(3) [],
+    ///Month tens in BCD format
+    MT OFFSET(12) NUMBITS(1) [],
+    /// Month units in BCD format
+    MU OFFSET(8) NUMBITS(4) [],
+    /// Date tens in BCD format
+    DT OFFSET(4) NUMBITS(2) [],
+    /// Date units in BCD format
+    DU OFFSET(0) NUMBITS(4) [],
+],
+RTC_TSSSR[
+    /// Sub second value
+    SS OFFSET(0) NUMBITS(16) [],
+],
+RTC_CALR[
+    /// Increase frequency of RTC by 488.0 ppm
+    CALP OFFSET(15) NUMBITS(1) [],
+    /// Use an 8-second calibration cycle period
+    CALW8 OFFSET(14) NUMBITS(1) [],
+    /// Use a 16-second calibration cycle period
+    CALW16 OFFSET(13) NUMBITS(1) [],
+    /// Calibration minus
+    CALM OFFSET(0) NUMBITS(9) [],
+],
+RTC_TAFCR[
+    /// RTC_ALARM output type
+    ALARMOUTTYPE OFFSET(18) NUMBITS(1) [],
+    /// TIMESTAMP mapping
+    TSINSEL OFFSET(17) NUMBITS(1) [],
+    /// TAMPER1 mapping
+    TAMP1INSEL OFFSET(16) NUMBITS(1) [],
+    /// TAMPER pull-up disable
+    TAMPPUDIS OFFSET(15) NUMBITS(1) [],
+    /// Tamper prechange duration
+    TAMPPRCH OFFSET(13) NUMBITS(2) [],
+    /// Tamper filter count
+    TAMPFLT OFFSET(11) NUMBITS(2) [],
+    /// Tamper sampling frequency
+    TAMPFREQ OFFSET(8) NUMBITS(3) [],
+    /// Activate timestamp on tamper detection event
+    TAMPTS OFFSET(7) NUMBITS(1) [],
+    /// Active level for tamper 2
+    TAMP2TRG OFFSET(4) NUMBITS(1) [],
+    /// Tamper 2 detection enable
+    TAMP2E OFFSET(3) NUMBITS(1) [],
+    /// Tamper interrupt enable
+    TAMPIE OFFSET(2) NUMBITS(1) [],
+    /// Active level for tamper 1
+    TAMP1TRG OFFSET(1) NUMBITS(1) [],
+    /// Tamper 1 detection enable
+    TAMP1E OFFSET(0) NUMBITS(1) [],
+],
+RTC_ALRMASSR[
+    /// Mask the most-significant bits starting at this bit
+    MASKSS OFFSET(24) NUMBITS(4) [],
+    /// Sub seconds value
+    SS OFFSET(0) NUMBITS(15) [],
+],
+RTC_ALRMBSSR[
+    /// Mask the most-significant bits starting at this bit
+    MASKSS OFFSET(24) NUMBITS(4) [],
+    /// Sub seconds value
+    SS OFFSET(0) NUMBITS(15) [],
+],
+RTC_BKPXR[
+    /// The application can write or read data to and from these registers
+    BKP OFFSET(0) NUMBITS(32) [],
+],
+];
+
+pub struct Rtc<'a> {
+    registers: StaticRef<RtcRegisters>,
+    client: OptionalCell<&'a dyn date_time::DateTimeClient>,
+    pub clock: rcc::PeripheralClock<'a>,
+    pub pwr_clock: rcc::PeripheralClock<'a>,
+    time: Cell<DateTimeValues>,
+
+    deferred_call: DeferredCall,
+    deferred_call_task: OptionalCell<DeferredCallTask>,
+}
+
+#[derive(Clone, Copy)]
+enum DeferredCallTask {
+    Get,
+    Set,
+}
+
+impl<'a> DeferredCallClient for Rtc<'a> {
+    fn handle_deferred_call(&self) {
+        self.deferred_call_task.take().map(|value| match value {
+            DeferredCallTask::Get => self
+                .client
+                .map(|client| client.get_date_time_done(Ok(self.time.get()))),
+            DeferredCallTask::Set => self.client.map(|client| client.set_date_time_done(Ok(()))),
+        });
+    }
+    fn register(&'static self) {
+        self.deferred_call.register(self);
+    }
+}
+
+const RTC_BASE: StaticRef<RtcRegisters> =
+    unsafe { StaticRef::new(0x40002800 as *const RtcRegisters) };
+
+impl<'a> Rtc<'a> {
+    pub fn new(rcc: &'a rcc::Rcc) -> Rtc<'a> {
+        Rtc {
+            registers: RTC_BASE,
+            client: OptionalCell::empty(),
+            clock: rcc::PeripheralClock::new(rcc::PeripheralClockType::RTC, rcc),
+            pwr_clock: rcc::PeripheralClock::new(rcc::PeripheralClockType::PWR, rcc),
+            time: Cell::new(DateTimeValues {
+                year: 0,
+                month: Month::January,
+                day: 1,
+                day_of_week: DayOfWeek::Sunday,
+                hour: 0,
+                minute: 0,
+                seconds: 0,
+            }),
+            deferred_call: DeferredCall::new(),
+            deferred_call_task: OptionalCell::empty(),
+        }
+    }
+
+    fn dotw_try_from_u32(dotw: u32) -> Result<DayOfWeek, ErrorCode> {
+        match dotw {
+            1 => Ok(DayOfWeek::Monday),
+            2 => Ok(DayOfWeek::Tuesday),
+            3 => Ok(DayOfWeek::Wednesday),
+            4 => Ok(DayOfWeek::Thursday),
+            5 => Ok(DayOfWeek::Friday),
+            6 => Ok(DayOfWeek::Saturday),
+            7 => Ok(DayOfWeek::Sunday),
+            _ => Err(ErrorCode::INVAL),
+        }
+    }
+
+    fn dotw_into_u32(dotw: DayOfWeek) -> u32 {
+        match dotw {
+            DayOfWeek::Monday => 1,
+            DayOfWeek::Tuesday => 2,
+            DayOfWeek::Wednesday => 3,
+            DayOfWeek::Thursday => 4,
+            DayOfWeek::Friday => 5,
+            DayOfWeek::Saturday => 6,
+            DayOfWeek::Sunday => 7,
+        }
+    }
+
+    fn month_try_from_u32(month_num: u32) -> Result<Month, ErrorCode> {
+        match month_num {
+            1 => Ok(Month::January),
+            2 => Ok(Month::February),
+            3 => Ok(Month::March),
+            4 => Ok(Month::April),
+            5 => Ok(Month::May),
+            6 => Ok(Month::June),
+            7 => Ok(Month::July),
+            8 => Ok(Month::August),
+            9 => Ok(Month::September),
+            10 => Ok(Month::October),
+            11 => Ok(Month::November),
+            12 => Ok(Month::December),
+            _ => Err(ErrorCode::INVAL),
+        }
+    }
+
+    fn month_into_u32(month: Month) -> u32 {
+        match month {
+            Month::January => 1,
+            Month::February => 2,
+            Month::March => 3,
+            Month::April => 4,
+            Month::May => 5,
+            Month::June => 6,
+            Month::July => 7,
+            Month::August => 8,
+            Month::September => 9,
+            Month::October => 10,
+            Month::November => 11,
+            Month::December => 12,
+        }
+    }
+
+    #[inline(never)]
+    // This function is marked as #[inline(never)] in order to aid with the debugging process when
+    // disabling board memory protection
+    /// Bypass write protection
+    fn bypass_write_protection(&self) {
+        self.registers.rtc_wpr.modify(RTC_WPR::KEY.val(0xCA)); // Equivalent to 0xCA
+        self.registers.rtc_wpr.modify(RTC_WPR::KEY.val(0x53)); // Equivalent to 0x53
+    }
+
+    #[inline(never)]
+    // This function is marked as #[inline(never)] in order to aid with the debugging process when
+    // enabling board memory protection
+    /// Reactivate write protection
+    fn enable_write_protection(&self) {
+        self.registers.rtc_wpr.modify(RTC_WPR::KEY.val(0x42)); // Equivalent to 0x42
+    }
+
+    fn date_time_setup(&self, datetime: date_time::DateTimeValues) -> Result<(), ErrorCode> {
+        let month_num = Rtc::month_into_u32(datetime.month);
+        let dotw_num = Rtc::dotw_into_u32(datetime.day_of_week);
+
+        if !(datetime.day >= 1 && datetime.day <= 31) {
+            return Err(ErrorCode::INVAL);
+        }
+        if !(datetime.hour <= 23) {
+            return Err(ErrorCode::INVAL);
+        }
+        if !(datetime.minute <= 59) {
+            return Err(ErrorCode::INVAL);
+        }
+        if !(datetime.seconds <= 59) {
+            return Err(ErrorCode::INVAL);
+        }
+
+        self.registers.rtc_dr.modify(
+            RTC_DR::YT.val((datetime.year % 100) as u32 / 10)
+                + RTC_DR::YU.val((datetime.year % 100) as u32 % 10)
+                + RTC_DR::MT.val(month_num / 10)
+                + RTC_DR::MU.val(month_num % 10)
+                + RTC_DR::DT.val(datetime.day as u32 / 10)
+                + RTC_DR::DU.val(datetime.day as u32 % 10)
+                + RTC_DR::WDU.val(dotw_num),
+        );
+
+        self.registers.rtc_tr.modify(
+            RTC_TR::HT.val(datetime.hour as u32 / 10)
+                + RTC_TR::HU.val(datetime.hour as u32 % 10)
+                + RTC_TR::MNT.val(datetime.minute as u32 / 10)
+                + RTC_TR::MNU.val(datetime.minute as u32 % 10)
+                + RTC_TR::ST.val(datetime.seconds as u32 / 10)
+                + RTC_TR::SU.val(datetime.seconds as u32 % 10),
+        );
+
+        Ok(())
+    }
+
+    pub fn enter_init_mode(&self) -> Result<(), ErrorCode> {
+        self.bypass_write_protection();
+        self.registers.rtc_isr.modify(RTC_ISR::INIT::SET);
+
+        let mut cycle_counter = 100000;
+        while cycle_counter > 0 && !self.registers.rtc_isr.is_set(RTC_ISR::INITF) {
+            cycle_counter -= 1;
+            // wait until initialization phase mode is entered
+        }
+        if cycle_counter <= 0 {
+            return Err(ErrorCode::FAIL);
+        }
+        Ok(())
+    }
+    pub fn exit_init_mode(&self) -> Result<(), ErrorCode> {
+        self.registers.rtc_isr.modify(RTC_ISR::INIT::CLEAR);
+        let mut cycle_counter = 100000;
+        while cycle_counter > 0 && !self.registers.rtc_isr.is_set(RTC_ISR::RSF) {
+            cycle_counter -= 1;
+        }
+        if cycle_counter <= 0 {
+            return Err(ErrorCode::FAIL);
+        }
+
+        self.enable_write_protection();
+        Ok(())
+    }
+
+    pub fn rtc_init(&self) -> Result<(), ErrorCode> {
+        self.enter_init_mode()?;
+
+        self.registers
+            .rtc_prer
+            .modify(RTC_PRER::PREDIV_A.val(128 - 1));
+        self.registers
+            .rtc_prer
+            .modify(RTC_PRER::PREDIV_S.val(256 - 1));
+
+        // 0: 24-hour format, 1: AM/PM format
+        self.registers.rtc_cr.modify(RTC_CR::FMT.val(0));
+
+        let datetime = date_time::DateTimeValues {
+            year: 0,
+            month: Month::January,
+            day: 1,
+            day_of_week: DayOfWeek::Monday,
+
+            hour: 0,
+            minute: 0,
+            seconds: 0,
+        };
+        self.date_time_setup(datetime)?;
+
+        self.exit_init_mode()?;
+        Ok(())
+    }
+
+    pub fn enable_clock(&self) {
+        self.pwr_clock.enable();
+
+        // Enable access to the backup domain
+        match crate::pwr::enable_backup_access() {
+            Err(e) => panic!("{:?}", e),
+            _ => (),
+        }
+
+        self.clock.enable();
+    }
+}
+
+impl<'a> date_time::DateTime<'a> for Rtc<'a> {
+    fn get_date_time(&self) -> Result<(), ErrorCode> {
+        match self.deferred_call_task.extract() {
+            Some(DeferredCallTask::Set) => return Err(ErrorCode::BUSY),
+            Some(DeferredCallTask::Get) => return Err(ErrorCode::ALREADY),
+            _ => (),
+        }
+
+        let month_num =
+            self.registers.rtc_dr.read(RTC_DR::MT) * 10 + self.registers.rtc_dr.read(RTC_DR::MU);
+        let month_name = Rtc::month_try_from_u32(month_num)?;
+
+        let dotw_num = self.registers.rtc_dr.read(RTC_DR::WDU);
+        let dotw_name = Rtc::dotw_try_from_u32(dotw_num)?;
+
+        let datetime = date_time::DateTimeValues {
+            hour: (self.registers.rtc_tr.read(RTC_TR::HT) * 10
+                + self.registers.rtc_tr.read(RTC_TR::HU)) as u8,
+            minute: (self.registers.rtc_tr.read(RTC_TR::MNT) * 10
+                + self.registers.rtc_tr.read(RTC_TR::MNU)) as u8,
+            seconds: (self.registers.rtc_tr.read(RTC_TR::ST) * 10
+                + self.registers.rtc_tr.read(RTC_TR::SU)) as u8,
+
+            year: (self.registers.rtc_dr.read(RTC_DR::YT) * 10
+                + self.registers.rtc_dr.read(RTC_DR::YU)) as u16,
+            month: month_name,
+            day: (self.registers.rtc_dr.read(RTC_DR::DT) * 10
+                + self.registers.rtc_dr.read(RTC_DR::DU)) as u8,
+            day_of_week: dotw_name,
+        };
+
+        self.time.replace(datetime);
+
+        self.deferred_call_task.insert(Some(DeferredCallTask::Get));
+        self.deferred_call.set();
+
+        Ok(())
+    }
+
+    fn set_date_time(&self, date_time: date_time::DateTimeValues) -> Result<(), ErrorCode> {
+        match self.deferred_call_task.extract() {
+            Some(DeferredCallTask::Set) => return Err(ErrorCode::ALREADY),
+            Some(DeferredCallTask::Get) => return Err(ErrorCode::BUSY),
+            _ => (),
+        }
+
+        self.enter_init_mode()?;
+        self.date_time_setup(date_time)?;
+        self.exit_init_mode()?;
+
+        self.deferred_call_task.insert(Some(DeferredCallTask::Set));
+        self.deferred_call.set();
+        Ok(())
+    }
+
+    fn set_client(&self, client: &'a dyn DateTimeClient) {
+        self.client.set(client);
+    }
+}

--- a/chips/stm32f4xx/src/rcc.rs
+++ b/chips/stm32f4xx/src/rcc.rs
@@ -731,6 +731,12 @@ pub struct Rcc {
     registers: StaticRef<RccRegisters>,
 }
 
+pub enum RtcClockSource {
+    LSI,
+    LSE,
+    HSERTC,
+}
+
 impl Rcc {
     pub const fn new() -> Rcc {
         Rcc {
@@ -1052,6 +1058,60 @@ impl Rcc {
     fn disable_can1_clock(&self) {
         self.registers.apb1enr.modify(APB1ENR::CAN1EN::CLEAR);
     }
+
+    // RTC clock
+    fn source_into_u32(source: RtcClockSource) -> u32 {
+        match source {
+            RtcClockSource::LSE => 1,
+            RtcClockSource::LSI => 2,
+            RtcClockSource::HSERTC => 3,
+        }
+    }
+
+    fn enable_lsi_clock(&self) {
+        self.registers.csr.modify(CSR::LSION::SET);
+    }
+
+    fn is_enabled_pwr_clock(&self) -> bool {
+        self.registers.apb1enr.is_set(APB1ENR::PWREN)
+    }
+
+    fn enable_pwr_clock(&self) {
+        // Enable the power interface clock
+        self.registers.apb1enr.modify(APB1ENR::PWREN::SET);
+    }
+
+    fn disable_pwr_clock(&self) {
+        self.registers.apb1enr.modify(APB1ENR::PWREN::CLEAR);
+    }
+
+    fn is_enabled_rtc_clock(&self) -> bool {
+        self.registers.bdcr.is_set(BDCR::RTCEN)
+    }
+
+    fn enable_rtc_clock(&self, source: RtcClockSource) {
+        // Enable LSI
+        self.enable_lsi_clock();
+        let mut counter = 1_000;
+        while counter > 0 && !self.registers.csr.is_set(CSR::LSION) {
+            counter -= 1;
+        }
+        if counter == 0 {
+            panic!("Unable to activate lsi clock");
+        }
+
+        // Select RTC clock source
+        let source_num = Rcc::source_into_u32(source);
+        self.registers.bdcr.modify(BDCR::RTCSEL.val(source_num));
+
+        // Enable RTC clock
+        self.registers.bdcr.modify(BDCR::RTCEN::SET);
+    }
+
+    fn disable_rtc_clock(&self) {
+        self.registers.bdcr.modify(BDCR::RTCEN.val(1));
+        self.registers.bdcr.modify(BDCR::RTCSEL.val(0));
+    }
 }
 
 /// Clock sources for CPU
@@ -1074,6 +1134,8 @@ pub enum PeripheralClockType {
     AHB3(HCLK3),
     APB1(PCLK1),
     APB2(PCLK2),
+    RTC,
+    PWR,
 }
 
 /// Peripherals clocked by HCLK1
@@ -1163,6 +1225,8 @@ impl<'a> ClockInterface for PeripheralClock<'a> {
                 PCLK2::ADC1 => self.rcc.is_enabled_adc1_clock(),
                 PCLK2::SYSCFG => self.rcc.is_enabled_syscfg_clock(),
             },
+            PeripheralClockType::RTC => self.rcc.is_enabled_rtc_clock(),
+            PeripheralClockType::PWR => self.rcc.is_enabled_pwr_clock(),
         }
     }
 
@@ -1242,6 +1306,8 @@ impl<'a> ClockInterface for PeripheralClock<'a> {
                     self.rcc.enable_syscfg_clock();
                 }
             },
+            PeripheralClockType::RTC => self.rcc.enable_rtc_clock(RtcClockSource::LSI),
+            PeripheralClockType::PWR => self.rcc.enable_pwr_clock(),
         }
     }
 
@@ -1321,6 +1387,8 @@ impl<'a> ClockInterface for PeripheralClock<'a> {
                     self.rcc.disable_syscfg_clock();
                 }
             },
+            PeripheralClockType::RTC => self.rcc.disable_rtc_clock(),
+            PeripheralClockType::PWR => self.rcc.disable_pwr_clock(),
         }
     }
 }

--- a/kernel/src/hil/date_time.rs
+++ b/kernel/src/hil/date_time.rs
@@ -1,0 +1,77 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! HIL for Date Time interface
+
+use crate::ErrorCode;
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum DayOfWeek {
+    Sunday,
+    Monday,
+    Tuesday,
+    Wednesday,
+    Thursday,
+    Friday,
+    Saturday,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Month {
+    January,
+    February,
+    March,
+    April,
+    May,
+    June,
+    July,
+    August,
+    September,
+    October,
+    November,
+    December,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct DateTimeValues {
+    pub year: u16,
+    pub month: Month,
+    pub day: u8,
+    pub day_of_week: DayOfWeek,
+    pub hour: u8,
+    pub minute: u8,
+    pub seconds: u8,
+}
+
+/// Interface for reading and setting the current time
+pub trait DateTime<'a> {
+    /// Request driver to return date and time
+    ///
+    /// When successful, this function will be followed by the callback
+    /// `callback_get_date` which provides the actual date and time
+    /// or an error.
+    fn get_date_time(&self) -> Result<(), ErrorCode>;
+
+    /// Sets the current date and time
+    ///
+    /// When successful this function call must be followed by a call
+    /// to `callback_set_date`.
+    fn set_date_time(&self, date_time: DateTimeValues) -> Result<(), ErrorCode>;
+
+    /// Sets a client that calls the callback function when date and time is requested
+    fn set_client(&self, client: &'a dyn DateTimeClient);
+}
+
+/// Callback handler for when current date is read or set.
+pub trait DateTimeClient {
+    /// Called when a date time reading has completed.
+    /// Takes `Ok(DateTime)` of current date and passes it when scheduling an upcall.
+    /// If an error is encountered it takes an `Err(ErrorCode)`
+    fn get_date_time_done(&self, datetime: Result<DateTimeValues, ErrorCode>);
+
+    /// Called when a date is set
+    /// Takes `Ok(())` if time is set correctly.
+    /// Takes  `Err(ErrorCode)` in case of an error
+    fn set_date_time_done(&self, result: Result<(), ErrorCode>);
+}

--- a/kernel/src/hil/mod.rs
+++ b/kernel/src/hil/mod.rs
@@ -12,6 +12,7 @@ pub mod buzzer;
 pub mod can;
 pub mod crc;
 pub mod dac;
+pub mod date_time;
 pub mod digest;
 pub mod eic;
 pub mod entropy;


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a Date and Time HIL, driver and component. This includes low level drivers for Real Time Clock for nucleo-stm32f429zi and raspberry pi pico boards. The Real Time Clock for raspberry pi pico board was rebased for an older commit written for tock 1.0 (https://github.com/tock/tock/pull/2760). The code compiles with other changes made to the libtock-c project, including an example project to test Real Time Clock intended usage (https://github.com/tock/libtock-c/pull/334).

### Testing Strategy

This pull request was tested by running the implemented commands both in the board/main.src for the nucleo board, and also by running a program from the libtock-c userspace (setting and then printing current time each second).


### TODO or Help Wanted

The Real Time Clock works for the two boards, RTC support for more boards might be added using the component, hil and capsule provided.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
- [x] Ran `make format`.
