### PR TITLE
doc: add notes from short-lived repo

### DIFF
--- a/doc/wg/README.md
+++ b/doc/wg/README.md
@@ -9,3 +9,9 @@ Existing Working Groups
 
 - [Core](core/README.md)
 - [OpenTitan](opentitan/README.md)
+
+
+Retired Working Groups
+----------------------
+
+- [Legacy](legacy/README.md)

--- a/doc/wg/legacy/2018-11-20.md
+++ b/doc/wg/legacy/2018-11-20.md
@@ -1,0 +1,30 @@
+Attending: Amit, Brad, Phil, Branden
+  * Updates: 10m
+    * Amit: external app library
+    * Phil:
+      * Tock updated on H1B to 1.2, Cortex-M3 MPU. USB transport
+      * New cut for the UART HIL has PR up
+    * Brad: getting things ready for 1.3 release. tracking down two userland bugs. Student interested in resurecting RISC-V port for Tock: E21 core running with Tock on FPGA, minus interrupt controller.
+  * Agreement on test coverage for release (see https://github.com/tock/tock/issues/1201): 10m
+    * Are any test cases missing from tracking issue?
+      * "lua-hello"? yes. different big app, maybe, for next time
+      * Tutorial tests? Starting in 1.4.
+      * Add tests for kernel for imix:
+        * virtual uart, aes, aes_ccm, rng: Phil will do
+  * Board testing assignment: 10m
+    * Hail: Brad, Branden
+    * imix: Hudson, Phil, Holly
+    * nrf52: Amit
+    * cc26x6: Amit
+    * Release by Decemeber 1, barring unexpected big bugs
+  * Milestones for 1.4
+    * Unified tutorial: having 5-7 tutorial "units", each one page, can combine into courses, etc.
+      * Courses are just tutorials with hands-on help
+    * Redesigned UART, GPIO, and Alarm HILs
+    * Virtualize all system calls across processes
+      * SPI, ADC, AES,  Ambient light, Button, Console, CRC, DAC, GPIO, GPIO Async, Humidity, I2C master/slave, i2C Master
+    * Process fault handling and management:
+      * Allow processes to fault without crashing kernel
+      * Restart processes correctly on fault
+      * Restart processes correctly while currently running
+      * Add flag to TBF for process to request particular behavior

--- a/doc/wg/legacy/2018-12-04.md
+++ b/doc/wg/legacy/2018-12-04.md
@@ -1,0 +1,25 @@
+Attending: Amit, Brad, Phil, Holly, Hudson, Johnathan, Brande, Pat, Jean-Luc
+
+  * Updates: 10m
+    * 1.3 release!
+    * Brad: Has been working on ESP wifi chip working, picking back up again. Slow but steady process.
+	    * Phil: Turns out Steve Clark put together a board with the ESP + SAM4D
+    * Phil:
+	    * Just synced Tock on Titan to 1.3. So Titan is up to speed with 1.3
+			* UART HIL: Niklas gave a whole bunch of detailed comments on programming style, will look over carefully, probably tomorrow
+		* Amit: Daniel Deluci has a port of 802.15.4 to the nRF52840
+	* Issues for 1.4
+		* Current list: https://github.com/tock/tock/issues?q=is%3Aopen+is%3Aissue+label%3Arelease-blocker.
+	* Testing for 1.4
+		* Re-giggering our tests so they are more consistent. E.g. make them more consistent so it's easier to figure out what should happen with each
+		* New tool! https://github.com/tock/tock-ci
+			* Can flash apps for you
+			* Then checks serial connections for particular string match
+			* Current goal is to help with manual testing process
+		* Johnathan:
+			* Google have been putting together their own test suite to run
+			* Don't have a public solution, but an internal solution that images hardware based on pub-sub of binary images
+			* Phil: trade-offs between pub-sub vs. compiling on test machine?
+				* Johnathan:
+					* basically the test machine is ultimately fairly hand-designed, rather than a travis-CI type general hardware
+					* Can a developer use this? E.g. I, as a developer, can run tests remotely without direct access to test hardware

--- a/doc/wg/legacy/2018-12-11.md
+++ b/doc/wg/legacy/2018-12-11.md
@@ -1,0 +1,28 @@
+Attending: Amit, Brad, Phil, Johnathan, Holly, Hudson, ?
+
+	* Updates: 10m
+		* Brad: WiFi working on ESP32---connecting + HTTP requests, logic is mostly in userspace, but works none-the-less
+		* Phil: Huawei agreed to fund network security that Hudson + Phil working on
+		* Amit: board admin in the repo
+		* Pat: would be good to have a list of boards with support table for each
+			* Maybe in the wiki
+			* Would avoid having pointers to non-master boards lost forever
+	* Generalizing the Radio HIL
+		* Resources:
+			* HIL: https://github.com/tock/tock/blob/master/kernel/src/hil/radio.
+			* PR that raised the issue:
+		* Brief summary:
+			* A bunch of RF233 specific details in the HIL. Totally needs to be cleaned up.
+				* E.g. SPI message for RF233 structure is basically part of the HIL
+				* Hudson: Daniel responded recently that he's been able to hack together a port with the existing HIL
+			* Other substantive change, that's  not as good:
+				* removes buffer management
+				* rather than passing in buffers in board initialization, global buffers are referenced unsafely
+				* but initialization indeed should be radio-specific, not in the HIL
+			* Hudson: still need a HIL for multi-protocol radios
+	* Driver logic ISRs: the good, the bad, and  the ugly
+		* Mailing list thread: https://groups.google.com/d/msgid/tock-dev/CACW1YzsUHhBD4GLXSXD4PFSLPZto1NFFQRozR0vhfkUgt5a61g%40mail.gmail.com
+		* Relevant PR discussion: https://github.com/tock/tock/pull/1220#issuecomment-445122564
+		* Summary: https://mailman.stanford.edu/pipermail/helena-project/Week-of-Mon-20181210/000715.html
+	* Motivation for 1.4 items
+		* Phil: on board for Time, GPIO HILs

--- a/doc/wg/legacy/README.md
+++ b/doc/wg/legacy/README.md
@@ -1,0 +1,6 @@
+# Legacy Notes
+
+Prior to the creation of the working group structure, several of the major
+developers held regular calls. Newer notes were converted to [core](../core/),
+but a handful of older notes from this less organized time survived. Those
+are archived here.


### PR DESCRIPTION
### Pull Request Overview

Once upon a time, https://github.com/tock/meeting-notes existed. There wasn't much there, but this captures those notes.

I'm cleaning up some of the tock org, and will probably delete that repo once this is in the main repo here.

### Testing Strategy

N/A

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
