### PR TITLE
capsules/extra/tutorials/encryption_oracle: add DRIVER_NUM

### DIFF
--- a/capsules/extra/src/tutorials/encryption_oracle_chkpt2.rs
+++ b/capsules/extra/src/tutorials/encryption_oracle_chkpt2.rs
@@ -8,6 +8,8 @@ use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::ErrorCode;
 use kernel::ProcessId;
 
+pub const DRIVER_NUM: usize = 0x99999;
+
 pub static KEY: &'static [u8; kernel::hil::symmetric_encryption::AES128_KEY_SIZE] =
     b"InsecureAESKey12";
 

--- a/capsules/extra/src/tutorials/encryption_oracle_chkpt3.rs
+++ b/capsules/extra/src/tutorials/encryption_oracle_chkpt3.rs
@@ -9,6 +9,8 @@ use kernel::utilities::cells::OptionalCell;
 use kernel::ErrorCode;
 use kernel::ProcessId;
 
+pub const DRIVER_NUM: usize = 0x99999;
+
 pub static KEY: &'static [u8; kernel::hil::symmetric_encryption::AES128_KEY_SIZE] =
     b"InsecureAESKey12";
 

--- a/capsules/extra/src/tutorials/encryption_oracle_chkpt4.rs
+++ b/capsules/extra/src/tutorials/encryption_oracle_chkpt4.rs
@@ -12,6 +12,8 @@ use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::ErrorCode;
 use kernel::ProcessId;
 
+pub const DRIVER_NUM: usize = 0x99999;
+
 pub static KEY: &'static [u8; kernel::hil::symmetric_encryption::AES128_KEY_SIZE] =
     b"InsecureAESKey12";
 

--- a/capsules/extra/src/tutorials/encryption_oracle_chkpt5.rs
+++ b/capsules/extra/src/tutorials/encryption_oracle_chkpt5.rs
@@ -12,6 +12,8 @@ use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::ErrorCode;
 use kernel::ProcessId;
 
+pub const DRIVER_NUM: usize = 0x99999;
+
 pub static KEY: &'static [u8; kernel::hil::symmetric_encryption::AES128_KEY_SIZE] =
     b"InsecureAESKey12";
 


### PR DESCRIPTION
### Pull Request Overview

As added to the guide in the Tock book.

This doesn't add this number to the `capsules/core/src/driver.rs`, as presumably we don't want to pollute that with tutorial capsules.

### Testing Strategy

N/A


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [x] Ran `make prepush`.
