### PR TITLE
Add openocd to shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -84,6 +84,7 @@ in
     buildInputs = with pkgs; [
       # --- Toolchains ---
       rustBuild
+      openocd
 
       # --- Convenience and support packages ---
       python3Full


### PR DESCRIPTION
### Pull Request Overview

This PR adds `openocd` as a dependency in `shell.nix`, which works for flashing at least the NRF52 boards over SWD without JLink (using `make flash-openocd`)


### Testing Strategy

Flashing a kernel to the nrf52840dk


### TODO or Help Wanted

N/A

### Documentation Updated

- ~~Updated the relevant files in `/docs`, or no updates are required.~~

### Formatting

- [X] Ran `make prepush`.
