### PR TITLE
components: add SW SHA256 and HMAC-SHA256

### DIFF
--- a/boards/components/src/sha.rs
+++ b/boards/components/src/sha.rs
@@ -98,3 +98,32 @@ impl<
         sha
     }
 }
+
+#[macro_export]
+macro_rules! sha_software_256_component_static {
+    ($(,)?) => {{
+        kernel::static_buf!(capsules_extra::sha256::Sha256Software<'static>)
+    };};
+}
+
+pub struct ShaSoftware256Component {}
+
+impl ShaSoftware256Component {
+    pub fn new() -> ShaSoftware256Component {
+        ShaSoftware256Component {}
+    }
+}
+
+impl Component for ShaSoftware256Component {
+    type StaticInput = &'static mut MaybeUninit<capsules_extra::sha256::Sha256Software<'static>>;
+
+    type Output = &'static capsules_extra::sha256::Sha256Software<'static>;
+
+    fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        let sha_256_sw = s.write(capsules_extra::sha256::Sha256Software::new());
+
+        kernel::deferred_call::DeferredCallClient::register(sha_256_sw);
+
+        sha_256_sw
+    }
+}


### PR DESCRIPTION
### Pull Request Overview

This pull request adds two components for resources used in the HOTP example.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
