### PR TITLE
capsules: virtual_uart: ensure inflight is None on error

### DIFF
--- a/capsules/core/src/virtualizers/virtual_uart.rs
+++ b/capsules/core/src/virtualizers/virtual_uart.rs
@@ -217,18 +217,18 @@ impl<'a> MuxUart<'a> {
             let mnode = self.devices.iter().find(|node| node.operation.is_some());
             mnode.map(|node| {
                 node.tx_buffer.take().map(|buf| {
-                    node.operation.map(move |op| match op {
-                        Operation::Transmit { len } => {
-                            let _ =
-                                self.uart
-                                    .transmit_buffer(buf, len)
-                                    .map_err(move |(ecode, buf)| {
-                                        node.tx_client.map(move |client| {
-                                            node.transmitting.set(false);
-                                            client.transmitted_buffer(buf, 0, Err(ecode));
-                                        });
-                                    });
-                        }
+                    node.operation.take().map(move |op| match op {
+                        Operation::Transmit { len } => match self.uart.transmit_buffer(buf, len) {
+                            Ok(()) => {
+                                self.inflight.set(node);
+                            }
+                            Err((ecode, buf)) => {
+                                node.tx_client.map(move |client| {
+                                    node.transmitting.set(false);
+                                    client.transmitted_buffer(buf, 0, Err(ecode));
+                                });
+                            }
+                        },
                         Operation::TransmitWord { word } => {
                             let rcode = self.uart.transmit_word(word);
                             if rcode != Ok(()) {
@@ -240,8 +240,6 @@ impl<'a> MuxUart<'a> {
                         }
                     });
                 });
-                node.operation.clear();
-                self.inflight.set(node);
             });
         }
     }


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the uart virtualizer to correctly set the state variables when an error occurs during transmission. In particular, we do not want inflight set if there is an error.

This happens to fix #3433, but isn't the "right" fix for that issue (this is still a bug that needs to be corrected). For that issue, the virtualizer should reject the 0 len write from the beginning.


### Testing Strategy

The temperature example in libtock-rs.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
