### PR TITLE
Console: notify app if transmit fails

### DIFF
--- a/capsules/core/src/virtualizers/virtual_uart.rs
+++ b/capsules/core/src/virtualizers/virtual_uart.rs
@@ -413,7 +413,9 @@ impl<'a> uart::Transmit<'a> for UartDevice<'a> {
         tx_data: &'static mut [u8],
         tx_len: usize,
     ) -> Result<(), (ErrorCode, &'static mut [u8])> {
-        if self.transmitting.get() {
+        if tx_len == 0 {
+            Err((ErrorCode::SIZE, tx_data))
+        } else if self.transmitting.get() {
             Err((ErrorCode::BUSY, tx_data))
         } else {
             self.tx_buffer.replace(tx_data);


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes #3433. It corrects the virtual uart to return an error on 0 length tx, and handles that error in console.

The tricky part is ensuring that the console continues after an error. There are two cases:

1. A command happened and console called `send()`. It is ok if this does not trigger a interrupt (buf_txd) because if the command was able to immediately send, then nothing was pending and there is no other work to do.
2. A buf_txd interrupt happened, found work to do, called send, which errored. This _does_ need to check if there was other work to do. The easy fix is to check the tx_in_progress flag rather than assuming send actually sent a buffer which will cause a callback.


### Testing Strategy

Running temperature and console libtock-rs apps.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
