### PR TITLE
Update OpenTitan to `Earlgrey-M2.5.2-RC0`

### DIFF
--- a/boards/opentitan/README.md
+++ b/boards/opentitan/README.md
@@ -11,10 +11,19 @@ Tock currently supports OpenTitan on the ChipWhisperer
 CW310 FPGA board. For more details on the boards see:
 https://docs.opentitan.org/doc/ug/fpga_boards/
 
-You can get started with OpenTitan using either the, ChipWhisperer CW310
+You can get started with OpenTitan using either the ChipWhisperer CW310
 board or a simulation. See the OpenTitan
-[getting started](https://docs.opentitan.org/doc/ug/getting_started/index.html)
+[getting started guide](https://opentitan.org/guides/getting_started/index.html)
 for more details.
+
+Supported version
+-----------------
+
+The OpenTitan project is producing its first chip, _Earlgrey_, from release
+[`Earlgrey-M2.5.2-RC0`](https://github.com/lowRISC/opentitan/releases/tag/Earlgrey-M2.5.2-RC0).
+You should use either an FPGA
+[bitstream](https://storage.googleapis.com/opentitan-bitstreams/master/bitstream-21ce4e9761abdf5c919b46e5ae64a5a8e24992f7.tar.gz)
+or simulator built from that version of the OpenTitan codebase.
 
 Programming
 -----------

--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -13,8 +13,9 @@ QEMU ?= ../../../tools/qemu/build/qemu-system-riscv32
 # This offset is calculated (from the linker file) as:
 # ORIGIN(rom) + size_manifest = 0x20000000 + 0x400
 QEMU_ENTRY_POINT=0x20000400
-# Latest supported commmit of OpenTitan
-OPENTITAN_SUPPORTED_SHA := 8a3159dbeb743a64c6898e1e8ecac4f18808c00c
+# OpenTitan commit 21ce4e9761abdf5c919b46e5ae64a5a8e24992f7 is Earlgrey-M2.5.2-RC0.
+# This commit is what is being taped out in the first Earlgrey chip.
+OPENTITAN_SUPPORTED_SHA := 21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 # Enable virtual function elimination
 VFUNC_ELIM=1
 

--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -94,7 +94,7 @@ endif
 		-binary -range-pad 8 --output binary.64.vmem --vmem 64
 	$(OPENTITAN_TREE)/bazel-out/k8-fastbuild/bin/hw/build.verilator_real/sim-verilator/Vchip_sim_tb \
 		--meminit=rom,$(OPENTITAN_TREE)/bazel-out/k8-fastbuild-ST-2cc462681f62/bin/sw/device/lib/testing/test_rom/test_rom_sim_verilator.39.scr.vmem \
-		--meminit=flash,./binary.64.vmem \
+		--meminit=flash0,./binary.64.vmem \
 		--meminit=otp,$(OPENTITAN_TREE)/bazel-out/k8-fastbuild/bin/hw/ip/otp_ctrl/data/img_rma.24.vmem
 
 test:
@@ -116,4 +116,4 @@ test-verilator: ot-check
 	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
-	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" VERILATOR="yes" OBJCOPY=$(RISC_PREFIX)-objcopy TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} TARGET=${TARGET} $(CARGO) test $(CARGO_FLAGS_TOCK) $(NO_RUN) --bin $(PLATFORM) --release --no-default-features --features=hardware_tests,sim_verilator
+	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" VERILATOR="yes" OBJCOPY=$(RISC_PREFIX)-objcopy TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} TARGET=${TARGET} $(CARGO) test $(CARGO_FLAGS_TOCK) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests,sim_verilator

--- a/boards/opentitan/earlgrey-cw310/layout.ld
+++ b/boards/opentitan/earlgrey-cw310/layout.ld
@@ -14,35 +14,40 @@ MEMORY
    * See https://github.com/lowRISC/opentitan/blob/master/sw/device/silicon_creator/lib/base/static_critical.ld
    * for details
    */
-  ram   (!rx) : ORIGIN = 0x10000650, LENGTH = 0x10000 - 0x650
+  ram   (!rx) : ORIGIN = 0x10000650, LENGTH = 0x20000 - 0x650
 }
 
 SECTIONS {
     .manifest ORIGIN(rom):
     {
-      _manifest = .;
-      /* sw/device/silicon_creator/lib/manifest.h */
-      . += 384; /* signature */
-      . += 4;   /* usage_constraints.selector_bits */
-      . += 32;  /* usage_constraints.device_id */
-      . += 4;   /* usage_constraints.manuf_state_creator */
-      . += 4;   /* usage_constraints.manuf_state_owner */
-      . += 4;   /* usage_constraints.life_cycle_state */
-      . += 384; /* modulus */
-      . += 4;   /* address_translation */
-      . += 4;   /* identifier */
-      . += 4;   /* length */
-      . += 4;   /* version_major */
-      . += 4;   /* version_minor */
-      . += 4;   /* security_version */
-      . += 8;   /* timestamp */
-      . += 32;  /* binding_value */
-      . += 4;   /* max_key_version */
-      . += 4;   /* code_start */
-      . += 4;   /* code_end */
-      LONG(_stext - ORIGIN(rom)); /* . = . + 4; entry_point */
-      . += 128; /* padding */
-      /* size = 1024 bytes */
+        _manifest = .;
+        /* see: sw/device/silicon_creator/lib/manifest.h */
+        . += 384; /* rsa_signature */
+        . += 4;   /* usage_constraints.selector_bits */
+        . += 32;  /* usage_constraints.device_id */
+        . += 4;   /* usage_constraints.manuf_state_creator */
+        . += 4;   /* usage_constraints.manuf_state_owner */
+        . += 4;   /* usage_constraints.life_cycle_state */
+        . += 384; /* rsa_modulus */
+        . += 4;   /* address_translation */
+        . += 4;   /* identifier */
+        . += 4;   /* manifest_version */
+        . += 4;   /* signed_region_end */
+        . += 4;   /* length */
+        . += 4;   /* version_major */
+        . += 4;   /* version_minor */
+        . += 4;   /* security_version */
+        . += 8;   /* timestamp */
+        . += 32;  /* binding_value */
+        . += 4;   /* max_key_version */
+        . += 4;   /* code_start */
+        . += 4;   /* code_end */
+        LONG(_stext - ORIGIN(rom)); /* . = . + 4; entry_point */
+        /* manifest extension table */
+        /* see: sw/device/silicon_creator/lib/base/chip.h */
+        /* CHIP_MANIFEST_EXT_TABLE_COUNT = 15 */
+        /* sizeof(manifest_ext_table_entry) = 8 */
+        . += 120; /* manifest_ext_table */
     } > rom
 }
 ASSERT (((_etext - _manifest) > 0), "Error: PMP and Flash protection setup assumes _etext follows _manifest");

--- a/boards/opentitan/earlgrey-cw310/run.sh
+++ b/boards/opentitan/earlgrey-cw310/run.sh
@@ -33,7 +33,7 @@ if [[ "${VERILATOR}" == "yes" ]]; then
 		-binary -range-pad 8 --output "$BUILD_DIR"/binary.64.vmem --vmem 64
 	${OPENTITAN_TREE}/bazel-bin/hw/build.verilator_real/sim-verilator/Vchip_sim_tb \
 		--meminit=rom,${OPENTITAN_TREE}/bazel-out/k8-fastbuild-ST-2cc462681f62/bin/sw/device/lib/testing/test_rom/test_rom_sim_verilator.39.scr.vmem \
-		--meminit=flash,./"$BUILD_DIR"/binary.64.vmem \
+		--meminit=flash0,./"$BUILD_DIR"/binary.64.vmem \
 		--meminit=otp,${OPENTITAN_TREE}/bazel-out/k8-fastbuild/bin/hw/ip/otp_ctrl/data/img_rma.24.vmem
 elif [[ "${OPENTITAN_TREE}" != "" ]]; then
 	${OBJCOPY} --update-section .apps=${APP} ${1} bundle.elf

--- a/boards/opentitan/earlgrey-cw310/test_layout.ld
+++ b/boards/opentitan/earlgrey-cw310/test_layout.ld
@@ -20,35 +20,40 @@ MEMORY
    * See https://github.com/lowRISC/opentitan/blob/master/sw/device/silicon_creator/lib/base/static_critical.ld
    * for details
    */
-  ram   (!rx) : ORIGIN = 0x10000650, LENGTH = 0x10000 - 0x650
+  ram   (!rx) : ORIGIN = 0x10000650, LENGTH = 0x20000 - 0x650
 }
 
 SECTIONS {
     .manifest ORIGIN(rom):
     {
-      _manifest = .;
-      /* sw/device/silicon_creator/lib/manifest.h */
-      . += 384; /* signature */
-      . += 4;   /* usage_constraints.selector_bits */
-      . += 32;  /* usage_constraints.device_id */
-      . += 4;   /* usage_constraints.manuf_state_creator */
-      . += 4;   /* usage_constraints.manuf_state_owner */
-      . += 4;   /* usage_constraints.life_cycle_state */
-      . += 384; /* modulus */
-      . += 4;   /* address_translation */
-      . += 4;   /* identifier */
-      . += 4;   /* length */
-      . += 4;   /* version_major */
-      . += 4;   /* version_minor */
-      . += 4;   /* security_version */
-      . += 8;   /* timestamp */
-      . += 32;  /* binding_value */
-      . += 4;   /* max_key_version */
-      . += 4;   /* code_start */
-      . += 4;   /* code_end */
-      LONG(_stext - ORIGIN(rom)); /* . = . + 4; entry_point */
-      . += 128; /* padding */
-      /* size = 1024 bytes */
+        _manifest = .;
+        /* see: sw/device/silicon_creator/lib/manifest.h */
+        . += 384; /* rsa_signature */
+        . += 4;   /* usage_constraints.selector_bits */
+        . += 32;  /* usage_constraints.device_id */
+        . += 4;   /* usage_constraints.manuf_state_creator */
+        . += 4;   /* usage_constraints.manuf_state_owner */
+        . += 4;   /* usage_constraints.life_cycle_state */
+        . += 384; /* rsa_modulus */
+        . += 4;   /* address_translation */
+        . += 4;   /* identifier */
+        . += 4;   /* manifest_version */
+        . += 4;   /* signed_region_end */
+        . += 4;   /* length */
+        . += 4;   /* version_major */
+        . += 4;   /* version_minor */
+        . += 4;   /* security_version */
+        . += 8;   /* timestamp */
+        . += 32;  /* binding_value */
+        . += 4;   /* max_key_version */
+        . += 4;   /* code_start */
+        . += 4;   /* code_end */
+        LONG(_stext - ORIGIN(rom)); /* . = . + 4; entry_point */
+        /* manifest extension table */
+        /* see: sw/device/silicon_creator/lib/base/chip.h */
+        /* CHIP_MANIFEST_EXT_TABLE_COUNT = 15 */
+        /* sizeof(manifest_ext_table_entry) = 8 */
+        . += 120; /* manifest_ext_table */
     } > rom
 }
 ASSERT (((_etext - _manifest) > 0), "Error: PMP and Flash protection setup assumes _etext follows _manifest");

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -102,7 +102,7 @@ const FAULT_RESPONSE: kernel::process::PanicFaultPolicy = kernel::process::Panic
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
 #[link_section = ".stack_buffer"]
-pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
+pub static mut STACK_MEMORY: [u8; 0x1400] = [0; 0x1400];
 
 /// A structure representing this platform that holds references to all
 /// capsules for this platform. We've included an alarm and console.

--- a/boards/opentitan/src/tests/aes_test.rs
+++ b/boards/opentitan/src/tests/aes_test.rs
@@ -17,7 +17,7 @@ use kernel::hil::symmetric_encryption::{AES128, AES128_BLOCK_SIZE, AES128_KEY_SI
 use kernel::static_init;
 
 #[test_case]
-fn run_aes128_ccm() {
+fn run000_aes128_ccm() {
     debug!("check run AES128 CCM... ");
     run_kernel_op(100);
 
@@ -52,7 +52,7 @@ unsafe fn static_init_test_ccm(
 }
 
 #[test_case]
-fn run_aes128_gcm() {
+fn run001_aes128_gcm() {
     debug!("check run AES128 GCM... ");
     run_kernel_op(100);
 
@@ -88,7 +88,7 @@ unsafe fn static_init_test_gcm(
 }
 
 #[test_case]
-fn run_aes128_ecb() {
+fn run002_aes128_ecb() {
     debug!("check run AES128 ECB... ");
     run_kernel_op(100);
 
@@ -122,7 +122,7 @@ unsafe fn static_init_test_ecb(aes: &'static Aes) -> &'static TestAes128Ecb<'sta
 }
 
 #[test_case]
-fn run_aes128_cbc() {
+fn run003_aes128_cbc() {
     debug!("check run AES128 CBC... ");
     run_kernel_op(100);
 
@@ -157,7 +157,7 @@ unsafe fn static_init_test_cbc(aes: &'static Aes) -> &'static TestAes128Cbc<'sta
 }
 
 #[test_case]
-fn run_aes128_ctr() {
+fn run004_aes128_ctr() {
     debug!("check run AES128 CTR... ");
     run_kernel_op(100);
 

--- a/boards/opentitan/src/tests/flash_ctrl.rs
+++ b/boards/opentitan/src/tests/flash_ctrl.rs
@@ -13,15 +13,15 @@ use kernel::errorcode::ErrorCode;
 use kernel::hil;
 #[allow(unused_imports)]
 use kernel::hil::flash::Flash;
-#[allow(unused_imports)]
-use lowrisc::flash_ctrl::FlashMPConfig;
 use kernel::hil::flash::HasClient;
 use kernel::static_init;
 use kernel::utilities::cells::TakeCell;
 #[allow(unused_imports)]
-use lowrisc::flash_ctrl::PAGE_SIZE;
+use lowrisc::flash_ctrl::FlashMPConfig;
 #[allow(unused_imports)]
 use lowrisc::flash_ctrl::FLASH_ADDR_OFFSET;
+#[allow(unused_imports)]
+use lowrisc::flash_ctrl::PAGE_SIZE;
 #[allow(dead_code)]
 struct FlashCtlCallBack {
     read_pending: Cell<bool>,
@@ -119,12 +119,15 @@ macro_rules! static_init_test {
     }};
 }
 
+// Note: the tests below need to run in a particular order, hence the a, b, c...
+// function name prefix (test runner seems to invoke them alphabetically).
+
 /// Tests: Erase Page -> Write Page -> Read Page
 ///
 /// Compare the data we wrote is stored in flash with a
 /// successive read.
 #[test_case]
-fn flash_ctrl_read_write_page() {
+fn a_flash_ctrl_read_write_page() {
     let perf = unsafe { PERIPHERALS.unwrap() };
     let flash_ctl = &perf.flash_ctrl;
 
@@ -184,7 +187,7 @@ fn flash_ctrl_read_write_page() {
 /// `0xFF`. Assert this is true after writing data to a page and erasing
 /// the page.
 #[test_case]
-fn flash_ctrl_erase_page() {
+fn b_flash_ctrl_erase_page() {
     let perf = unsafe { PERIPHERALS.unwrap() };
     let flash_ctl = &perf.flash_ctrl;
 
@@ -240,7 +243,7 @@ fn flash_ctrl_erase_page() {
 
 #[test_case]
 /// Tests: The basic api functionality and error handling of invalid arguments.
-fn flash_ctrl_mp_basic() {
+fn c_flash_ctrl_mp_basic() {
     debug!("[FLASH_CTRL] Test memory protection api....");
 
     #[cfg(feature = "hardware_tests")]
@@ -274,7 +277,12 @@ fn flash_ctrl_mp_basic() {
         };
         // Expect Fail
         assert_eq!(
-            flash_ctl.mp_set_region_perms(base_page_addr, invalid_page_addr, valid_region, &cfg_set),
+            flash_ctl.mp_set_region_perms(
+                base_page_addr,
+                invalid_page_addr,
+                valid_region,
+                &cfg_set
+            ),
             Err(ErrorCode::NOSUPPORT)
         );
         assert_eq!(
@@ -287,12 +295,22 @@ fn flash_ctrl_mp_basic() {
             Err(ErrorCode::NOSUPPORT)
         );
         assert_eq!(
-            flash_ctl.mp_set_region_perms(base_page_addr, base_page_addr.saturating_add(valid_num_pages * PAGE_SIZE), invalid_region, &cfg_set),
+            flash_ctl.mp_set_region_perms(
+                base_page_addr,
+                base_page_addr.saturating_add(valid_num_pages * PAGE_SIZE),
+                invalid_region,
+                &cfg_set
+            ),
             Err(ErrorCode::NOSUPPORT)
         );
         // Set Perms
         assert!(flash_ctl
-            .mp_set_region_perms(base_page_addr, base_page_addr.saturating_add(valid_num_pages * PAGE_SIZE), valid_region, &cfg_set)
+            .mp_set_region_perms(
+                base_page_addr,
+                base_page_addr.saturating_add(valid_num_pages * PAGE_SIZE),
+                valid_region,
+                &cfg_set
+            )
             .is_ok());
         // Check Perms
         assert_eq!(
@@ -312,7 +330,7 @@ fn flash_ctrl_mp_basic() {
 #[test_case]
 /// Tests the memory protection functionality of the flash_ctrl
 /// Test: Setup memory protection -> Do bad OP/cause an MP Fault -> Expect fail/assert Err(FlashMPFault)
-fn flash_ctrl_mp_functionality() {
+fn d_flash_ctrl_mp_functionality() {
     debug!("[FLASH_CTRL] Test memory protection functionality....");
 
     #[cfg(feature = "hardware_tests")]
@@ -348,7 +366,12 @@ fn flash_ctrl_mp_functionality() {
         };
         // Set Perms
         assert!(flash_ctl
-            .mp_set_region_perms(base_page_addr, base_page_addr.saturating_add(num_pages * PAGE_SIZE), region, &cfg_set)
+            .mp_set_region_perms(
+                base_page_addr,
+                base_page_addr.saturating_add(num_pages * PAGE_SIZE),
+                region,
+                &cfg_set
+            )
             .is_ok());
         // Check Perms
         assert_eq!(flash_ctl.mp_read_region_perms(region).unwrap(), cfg_set);


### PR DESCRIPTION
### Pull Request Overview

This pull request updates OpenTitan to refer to `Earlgrey-M2.5.2-RC0`.  This tag represents the version of the OpenTitan codebase that will go into the first OpenTitan chip.

### Testing Strategy

This pull request was tested by booting the tock kernel on a CW310 FPGA board with the `Earlgrey-M2.5.2-RC0` bitstream.


### TODO or Help Wanted

### Documentation Updated

- This PR deletes most of `boards/opentitan/README.md` and leaves TODOs to write new documentation.

### Formatting

- [x] Ran `make prepush`.
