### PR TITLE
Use autogenerated register constants for OpenTitan

### DIFF
--- a/chips/earlgrey/src/lib.rs
+++ b/chips/earlgrey/src/lib.rs
@@ -8,6 +8,9 @@
 #![no_std]
 #![crate_name = "earlgrey"]
 #![crate_type = "rlib"]
+// `registers/rv_plic_regs` has many register definitions in `register_structs()!`
+// and requires a deeper recursion limit than the default to fully expand.
+#![recursion_limit = "256"]
 
 pub mod chip_config;
 mod interrupts;
@@ -23,6 +26,7 @@ pub mod i2c;
 pub mod otbn;
 pub mod plic;
 pub mod pwrmgr;
+pub mod registers;
 pub mod spi_host;
 pub mod timer;
 pub mod uart;

--- a/chips/earlgrey/src/registers/README.md
+++ b/chips/earlgrey/src/registers/README.md
@@ -1,0 +1,16 @@
+# Earlgrey Register Definitions
+
+The files in this directory are auto-generated register definitions for
+Earlgrey peripherals.  These files were auto-generated from the OpenTitan
+codebase as follows:
+
+```bash
+$ cd $OPENTITAN_TREE
+$ git checkout earlgrey_es
+$ bazel build //sw/device/tock:tock_earlgrey_registers
+$ tar -C $TOCK_TREE -xvf bazel-bin/sw/device/tock/tock_earlgrey_registers.tar
+```
+
+Note: the existence of a file in this directory does not necessarily mean
+that a tock peripheral implementation exists.  These files are _only_
+the register definitions.

--- a/chips/earlgrey/src/registers/alert_handler_regs.rs
+++ b/chips/earlgrey/src/registers/alert_handler_regs.rs
@@ -1,0 +1,500 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for alert_handler.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Number of alert channels.
+pub const ALERT_HANDLER_PARAM_N_ALERTS: u32 = 65;
+/// Number of LPGs.
+pub const ALERT_HANDLER_PARAM_N_LPG: u32 = 24;
+/// Width of LPG ID.
+pub const ALERT_HANDLER_PARAM_N_LPG_WIDTH: u32 = 5;
+/// Width of the escalation timer.
+pub const ALERT_HANDLER_PARAM_ESC_CNT_DW: u32 = 32;
+/// Width of the accumulation counter.
+pub const ALERT_HANDLER_PARAM_ACCU_CNT_DW: u32 = 16;
+/// Number of classes
+pub const ALERT_HANDLER_PARAM_N_CLASSES: u32 = 4;
+/// Number of escalation severities
+pub const ALERT_HANDLER_PARAM_N_ESC_SEV: u32 = 4;
+/// Number of escalation phases
+pub const ALERT_HANDLER_PARAM_N_PHASES: u32 = 4;
+/// Number of local alerts
+pub const ALERT_HANDLER_PARAM_N_LOC_ALERT: u32 = 7;
+/// Width of ping counter
+pub const ALERT_HANDLER_PARAM_PING_CNT_DW: u32 = 16;
+/// Width of phase ID
+pub const ALERT_HANDLER_PARAM_PHASE_DW: u32 = 2;
+/// Width of class ID
+pub const ALERT_HANDLER_PARAM_CLASS_DW: u32 = 2;
+/// Local alert ID for alert ping failure.
+pub const ALERT_HANDLER_PARAM_LOCAL_ALERT_ID_ALERT_PINGFAIL: u32 = 0;
+/// Local alert ID for escalation ping failure.
+pub const ALERT_HANDLER_PARAM_LOCAL_ALERT_ID_ESC_PINGFAIL: u32 = 1;
+/// Local alert ID for alert integrity failure.
+pub const ALERT_HANDLER_PARAM_LOCAL_ALERT_ID_ALERT_INTEGFAIL: u32 = 2;
+/// Local alert ID for escalation integrity failure.
+pub const ALERT_HANDLER_PARAM_LOCAL_ALERT_ID_ESC_INTEGFAIL: u32 = 3;
+/// Local alert ID for bus integrity failure.
+pub const ALERT_HANDLER_PARAM_LOCAL_ALERT_ID_BUS_INTEGFAIL: u32 = 4;
+/// Local alert ID for shadow register update error.
+pub const ALERT_HANDLER_PARAM_LOCAL_ALERT_ID_SHADOW_REG_UPDATE_ERROR: u32 = 5;
+/// Local alert ID for shadow register storage error.
+pub const ALERT_HANDLER_PARAM_LOCAL_ALERT_ID_SHADOW_REG_STORAGE_ERROR: u32 = 6;
+/// Last local alert ID.
+pub const ALERT_HANDLER_PARAM_LOCAL_ALERT_ID_LAST: u32 = 6;
+/// Register width
+pub const ALERT_HANDLER_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub AlertHandlerRegisters {
+        /// Interrupt State Register
+        (0x0000 => pub(crate) intr_state: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Enable Register
+        (0x0004 => pub(crate) intr_enable: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Test Register
+        (0x0008 => pub(crate) intr_test: ReadWrite<u32, INTR::Register>),
+        /// Register write enable for !!PING_TIMEOUT_CYC_SHADOWED and !!PING_TIMER_EN_SHADOWED.
+        (0x000c => pub(crate) ping_timer_regwen: ReadWrite<u32, PING_TIMER_REGWEN::Register>),
+        /// Ping timeout cycle count.
+        (0x0010 => pub(crate) ping_timeout_cyc_shadowed: ReadWrite<u32, PING_TIMEOUT_CYC_SHADOWED::Register>),
+        /// Ping timer enable.
+        (0x0014 => pub(crate) ping_timer_en_shadowed: ReadWrite<u32, PING_TIMER_EN_SHADOWED::Register>),
+        /// Register write enable for alert enable bits.
+        (0x0018 => pub(crate) alert_regwen: [ReadWrite<u32, ALERT_REGWEN::Register>; 65]),
+        /// Enable register for alerts.
+        (0x011c => pub(crate) alert_en_shadowed: [ReadWrite<u32, ALERT_EN_SHADOWED::Register>; 65]),
+        /// Class assignment of alerts.
+        (0x0220 => pub(crate) alert_class_shadowed: [ReadWrite<u32, ALERT_CLASS_SHADOWED::Register>; 65]),
+        /// Alert Cause Register
+        (0x0324 => pub(crate) alert_cause: [ReadWrite<u32, ALERT_CAUSE::Register>; 65]),
+        /// Register write enable for alert enable bits.
+        (0x0428 => pub(crate) loc_alert_regwen: [ReadWrite<u32, LOC_ALERT_REGWEN::Register>; 7]),
+        /// Enable register for the local alerts
+        (0x0444 => pub(crate) loc_alert_en_shadowed: [ReadWrite<u32, LOC_ALERT_EN_SHADOWED::Register>; 7]),
+        /// Class assignment of the local alerts
+        (0x0460 => pub(crate) loc_alert_class_shadowed: [ReadWrite<u32, LOC_ALERT_CLASS_SHADOWED::Register>; 7]),
+        /// Alert Cause Register for the local alerts
+        (0x047c => pub(crate) loc_alert_cause: [ReadWrite<u32, LOC_ALERT_CAUSE::Register>; 7]),
+        /// Lock bit for Class A configuration.
+        (0x0498 => pub(crate) classa_regwen: ReadWrite<u32, CLASSA_REGWEN::Register>),
+        /// Escalation control register for alert Class A. Can not be modified if !!CLASSA_REGWEN is
+        /// false.
+        (0x049c => pub(crate) classa_ctrl_shadowed: ReadWrite<u32, CLASSA_CTRL_SHADOWED::Register>),
+        /// Clear enable for escalation protocol of Class A alerts.
+        (0x04a0 => pub(crate) classa_clr_regwen: ReadWrite<u32, CLASSA_CLR_REGWEN::Register>),
+        /// Clear for escalation protocol of Class A.
+        (0x04a4 => pub(crate) classa_clr_shadowed: ReadWrite<u32, CLASSA_CLR_SHADOWED::Register>),
+        /// Current accumulation value for alert Class A. Software can clear this register
+        (0x04a8 => pub(crate) classa_accum_cnt: ReadWrite<u32, CLASSA_ACCUM_CNT::Register>),
+        /// Accumulation threshold value for alert Class A.
+        (0x04ac => pub(crate) classa_accum_thresh_shadowed: ReadWrite<u32, CLASSA_ACCUM_THRESH_SHADOWED::Register>),
+        /// Interrupt timeout in cycles.
+        (0x04b0 => pub(crate) classa_timeout_cyc_shadowed: ReadWrite<u32, CLASSA_TIMEOUT_CYC_SHADOWED::Register>),
+        /// Crashdump trigger configuration for Class A.
+        (0x04b4 => pub(crate) classa_crashdump_trigger_shadowed: ReadWrite<u32, CLASSA_CRASHDUMP_TRIGGER_SHADOWED::Register>),
+        /// Duration of escalation phase 0 for Class A.
+        (0x04b8 => pub(crate) classa_phase0_cyc_shadowed: ReadWrite<u32, CLASSA_PHASE0_CYC_SHADOWED::Register>),
+        /// Duration of escalation phase 1 for Class A.
+        (0x04bc => pub(crate) classa_phase1_cyc_shadowed: ReadWrite<u32, CLASSA_PHASE1_CYC_SHADOWED::Register>),
+        /// Duration of escalation phase 2 for Class A.
+        (0x04c0 => pub(crate) classa_phase2_cyc_shadowed: ReadWrite<u32, CLASSA_PHASE2_CYC_SHADOWED::Register>),
+        /// Duration of escalation phase 3 for Class A.
+        (0x04c4 => pub(crate) classa_phase3_cyc_shadowed: ReadWrite<u32, CLASSA_PHASE3_CYC_SHADOWED::Register>),
+        /// Escalation counter in cycles for Class A.
+        (0x04c8 => pub(crate) classa_esc_cnt: ReadWrite<u32, CLASSA_ESC_CNT::Register>),
+        /// Current escalation state of Class A. See also !!CLASSA_ESC_CNT.
+        (0x04cc => pub(crate) classa_state: ReadWrite<u32, CLASSA_STATE::Register>),
+        /// Lock bit for Class B configuration.
+        (0x04d0 => pub(crate) classb_regwen: ReadWrite<u32, CLASSB_REGWEN::Register>),
+        /// Escalation control register for alert Class B. Can not be modified if !!CLASSB_REGWEN is
+        /// false.
+        (0x04d4 => pub(crate) classb_ctrl_shadowed: ReadWrite<u32, CLASSB_CTRL_SHADOWED::Register>),
+        /// Clear enable for escalation protocol of Class B alerts.
+        (0x04d8 => pub(crate) classb_clr_regwen: ReadWrite<u32, CLASSB_CLR_REGWEN::Register>),
+        /// Clear for escalation protocol of Class B.
+        (0x04dc => pub(crate) classb_clr_shadowed: ReadWrite<u32, CLASSB_CLR_SHADOWED::Register>),
+        /// Current accumulation value for alert Class B. Software can clear this register
+        (0x04e0 => pub(crate) classb_accum_cnt: ReadWrite<u32, CLASSB_ACCUM_CNT::Register>),
+        /// Accumulation threshold value for alert Class B.
+        (0x04e4 => pub(crate) classb_accum_thresh_shadowed: ReadWrite<u32, CLASSB_ACCUM_THRESH_SHADOWED::Register>),
+        /// Interrupt timeout in cycles.
+        (0x04e8 => pub(crate) classb_timeout_cyc_shadowed: ReadWrite<u32, CLASSB_TIMEOUT_CYC_SHADOWED::Register>),
+        /// Crashdump trigger configuration for Class B.
+        (0x04ec => pub(crate) classb_crashdump_trigger_shadowed: ReadWrite<u32, CLASSB_CRASHDUMP_TRIGGER_SHADOWED::Register>),
+        /// Duration of escalation phase 0 for Class B.
+        (0x04f0 => pub(crate) classb_phase0_cyc_shadowed: ReadWrite<u32, CLASSB_PHASE0_CYC_SHADOWED::Register>),
+        /// Duration of escalation phase 1 for Class B.
+        (0x04f4 => pub(crate) classb_phase1_cyc_shadowed: ReadWrite<u32, CLASSB_PHASE1_CYC_SHADOWED::Register>),
+        /// Duration of escalation phase 2 for Class B.
+        (0x04f8 => pub(crate) classb_phase2_cyc_shadowed: ReadWrite<u32, CLASSB_PHASE2_CYC_SHADOWED::Register>),
+        /// Duration of escalation phase 3 for Class B.
+        (0x04fc => pub(crate) classb_phase3_cyc_shadowed: ReadWrite<u32, CLASSB_PHASE3_CYC_SHADOWED::Register>),
+        /// Escalation counter in cycles for Class B.
+        (0x0500 => pub(crate) classb_esc_cnt: ReadWrite<u32, CLASSB_ESC_CNT::Register>),
+        /// Current escalation state of Class B. See also !!CLASSB_ESC_CNT.
+        (0x0504 => pub(crate) classb_state: ReadWrite<u32, CLASSB_STATE::Register>),
+        /// Lock bit for Class C configuration.
+        (0x0508 => pub(crate) classc_regwen: ReadWrite<u32, CLASSC_REGWEN::Register>),
+        /// Escalation control register for alert Class C. Can not be modified if !!CLASSC_REGWEN is
+        /// false.
+        (0x050c => pub(crate) classc_ctrl_shadowed: ReadWrite<u32, CLASSC_CTRL_SHADOWED::Register>),
+        /// Clear enable for escalation protocol of Class C alerts.
+        (0x0510 => pub(crate) classc_clr_regwen: ReadWrite<u32, CLASSC_CLR_REGWEN::Register>),
+        /// Clear for escalation protocol of Class C.
+        (0x0514 => pub(crate) classc_clr_shadowed: ReadWrite<u32, CLASSC_CLR_SHADOWED::Register>),
+        /// Current accumulation value for alert Class C. Software can clear this register
+        (0x0518 => pub(crate) classc_accum_cnt: ReadWrite<u32, CLASSC_ACCUM_CNT::Register>),
+        /// Accumulation threshold value for alert Class C.
+        (0x051c => pub(crate) classc_accum_thresh_shadowed: ReadWrite<u32, CLASSC_ACCUM_THRESH_SHADOWED::Register>),
+        /// Interrupt timeout in cycles.
+        (0x0520 => pub(crate) classc_timeout_cyc_shadowed: ReadWrite<u32, CLASSC_TIMEOUT_CYC_SHADOWED::Register>),
+        /// Crashdump trigger configuration for Class C.
+        (0x0524 => pub(crate) classc_crashdump_trigger_shadowed: ReadWrite<u32, CLASSC_CRASHDUMP_TRIGGER_SHADOWED::Register>),
+        /// Duration of escalation phase 0 for Class C.
+        (0x0528 => pub(crate) classc_phase0_cyc_shadowed: ReadWrite<u32, CLASSC_PHASE0_CYC_SHADOWED::Register>),
+        /// Duration of escalation phase 1 for Class C.
+        (0x052c => pub(crate) classc_phase1_cyc_shadowed: ReadWrite<u32, CLASSC_PHASE1_CYC_SHADOWED::Register>),
+        /// Duration of escalation phase 2 for Class C.
+        (0x0530 => pub(crate) classc_phase2_cyc_shadowed: ReadWrite<u32, CLASSC_PHASE2_CYC_SHADOWED::Register>),
+        /// Duration of escalation phase 3 for Class C.
+        (0x0534 => pub(crate) classc_phase3_cyc_shadowed: ReadWrite<u32, CLASSC_PHASE3_CYC_SHADOWED::Register>),
+        /// Escalation counter in cycles for Class C.
+        (0x0538 => pub(crate) classc_esc_cnt: ReadWrite<u32, CLASSC_ESC_CNT::Register>),
+        /// Current escalation state of Class C. See also !!CLASSC_ESC_CNT.
+        (0x053c => pub(crate) classc_state: ReadWrite<u32, CLASSC_STATE::Register>),
+        /// Lock bit for Class D configuration.
+        (0x0540 => pub(crate) classd_regwen: ReadWrite<u32, CLASSD_REGWEN::Register>),
+        /// Escalation control register for alert Class D. Can not be modified if !!CLASSD_REGWEN is
+        /// false.
+        (0x0544 => pub(crate) classd_ctrl_shadowed: ReadWrite<u32, CLASSD_CTRL_SHADOWED::Register>),
+        /// Clear enable for escalation protocol of Class D alerts.
+        (0x0548 => pub(crate) classd_clr_regwen: ReadWrite<u32, CLASSD_CLR_REGWEN::Register>),
+        /// Clear for escalation protocol of Class D.
+        (0x054c => pub(crate) classd_clr_shadowed: ReadWrite<u32, CLASSD_CLR_SHADOWED::Register>),
+        /// Current accumulation value for alert Class D. Software can clear this register
+        (0x0550 => pub(crate) classd_accum_cnt: ReadWrite<u32, CLASSD_ACCUM_CNT::Register>),
+        /// Accumulation threshold value for alert Class D.
+        (0x0554 => pub(crate) classd_accum_thresh_shadowed: ReadWrite<u32, CLASSD_ACCUM_THRESH_SHADOWED::Register>),
+        /// Interrupt timeout in cycles.
+        (0x0558 => pub(crate) classd_timeout_cyc_shadowed: ReadWrite<u32, CLASSD_TIMEOUT_CYC_SHADOWED::Register>),
+        /// Crashdump trigger configuration for Class D.
+        (0x055c => pub(crate) classd_crashdump_trigger_shadowed: ReadWrite<u32, CLASSD_CRASHDUMP_TRIGGER_SHADOWED::Register>),
+        /// Duration of escalation phase 0 for Class D.
+        (0x0560 => pub(crate) classd_phase0_cyc_shadowed: ReadWrite<u32, CLASSD_PHASE0_CYC_SHADOWED::Register>),
+        /// Duration of escalation phase 1 for Class D.
+        (0x0564 => pub(crate) classd_phase1_cyc_shadowed: ReadWrite<u32, CLASSD_PHASE1_CYC_SHADOWED::Register>),
+        /// Duration of escalation phase 2 for Class D.
+        (0x0568 => pub(crate) classd_phase2_cyc_shadowed: ReadWrite<u32, CLASSD_PHASE2_CYC_SHADOWED::Register>),
+        /// Duration of escalation phase 3 for Class D.
+        (0x056c => pub(crate) classd_phase3_cyc_shadowed: ReadWrite<u32, CLASSD_PHASE3_CYC_SHADOWED::Register>),
+        /// Escalation counter in cycles for Class D.
+        (0x0570 => pub(crate) classd_esc_cnt: ReadWrite<u32, CLASSD_ESC_CNT::Register>),
+        /// Current escalation state of Class D. See also !!CLASSD_ESC_CNT.
+        (0x0574 => pub(crate) classd_state: ReadWrite<u32, CLASSD_STATE::Register>),
+        (0x0578 => @END),
+    }
+}
+
+register_bitfields![u32,
+    /// Common Interrupt Offsets
+    pub(crate) INTR [
+        CLASSA OFFSET(0) NUMBITS(1) [],
+        CLASSB OFFSET(1) NUMBITS(1) [],
+        CLASSC OFFSET(2) NUMBITS(1) [],
+        CLASSD OFFSET(3) NUMBITS(1) [],
+    ],
+    pub(crate) PING_TIMER_REGWEN [
+        PING_TIMER_REGWEN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) PING_TIMEOUT_CYC_SHADOWED [
+        PING_TIMEOUT_CYC_SHADOWED OFFSET(0) NUMBITS(16) [],
+    ],
+    pub(crate) PING_TIMER_EN_SHADOWED [
+        PING_TIMER_EN_SHADOWED OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) ALERT_REGWEN [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) ALERT_EN_SHADOWED [
+        EN_A_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) ALERT_CLASS_SHADOWED [
+        CLASS_A_0 OFFSET(0) NUMBITS(2) [
+            CLASSA = 0,
+            CLASSB = 1,
+            CLASSC = 2,
+            CLASSD = 3,
+        ],
+    ],
+    pub(crate) ALERT_CAUSE [
+        A_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) LOC_ALERT_REGWEN [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) LOC_ALERT_EN_SHADOWED [
+        EN_LA_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) LOC_ALERT_CLASS_SHADOWED [
+        CLASS_LA_0 OFFSET(0) NUMBITS(2) [
+            CLASSA = 0,
+            CLASSB = 1,
+            CLASSC = 2,
+            CLASSD = 3,
+        ],
+    ],
+    pub(crate) LOC_ALERT_CAUSE [
+        LA_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CLASSA_REGWEN [
+        CLASSA_REGWEN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CLASSA_CTRL_SHADOWED [
+        EN OFFSET(0) NUMBITS(1) [],
+        LOCK OFFSET(1) NUMBITS(1) [],
+        EN_E0 OFFSET(2) NUMBITS(1) [],
+        EN_E1 OFFSET(3) NUMBITS(1) [],
+        EN_E2 OFFSET(4) NUMBITS(1) [],
+        EN_E3 OFFSET(5) NUMBITS(1) [],
+        MAP_E0 OFFSET(6) NUMBITS(2) [],
+        MAP_E1 OFFSET(8) NUMBITS(2) [],
+        MAP_E2 OFFSET(10) NUMBITS(2) [],
+        MAP_E3 OFFSET(12) NUMBITS(2) [],
+    ],
+    pub(crate) CLASSA_CLR_REGWEN [
+        CLASSA_CLR_REGWEN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CLASSA_CLR_SHADOWED [
+        CLASSA_CLR_SHADOWED OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CLASSA_ACCUM_CNT [
+        CLASSA_ACCUM_CNT OFFSET(0) NUMBITS(16) [],
+    ],
+    pub(crate) CLASSA_ACCUM_THRESH_SHADOWED [
+        CLASSA_ACCUM_THRESH_SHADOWED OFFSET(0) NUMBITS(16) [],
+    ],
+    pub(crate) CLASSA_TIMEOUT_CYC_SHADOWED [
+        CLASSA_TIMEOUT_CYC_SHADOWED OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) CLASSA_CRASHDUMP_TRIGGER_SHADOWED [
+        CLASSA_CRASHDUMP_TRIGGER_SHADOWED OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) CLASSA_PHASE0_CYC_SHADOWED [
+        CLASSA_PHASE0_CYC_SHADOWED OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) CLASSA_PHASE1_CYC_SHADOWED [
+        CLASSA_PHASE1_CYC_SHADOWED OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) CLASSA_PHASE2_CYC_SHADOWED [
+        CLASSA_PHASE2_CYC_SHADOWED OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) CLASSA_PHASE3_CYC_SHADOWED [
+        CLASSA_PHASE3_CYC_SHADOWED OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) CLASSA_ESC_CNT [
+        CLASSA_ESC_CNT OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) CLASSA_STATE [
+        CLASSA_STATE OFFSET(0) NUMBITS(3) [
+            IDLE = 0,
+            TIMEOUT = 1,
+            FSMERROR = 2,
+            TERMINAL = 3,
+            PHASE0 = 4,
+            PHASE1 = 5,
+            PHASE2 = 6,
+            PHASE3 = 7,
+        ],
+    ],
+    pub(crate) CLASSB_REGWEN [
+        CLASSB_REGWEN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CLASSB_CTRL_SHADOWED [
+        EN OFFSET(0) NUMBITS(1) [],
+        LOCK OFFSET(1) NUMBITS(1) [],
+        EN_E0 OFFSET(2) NUMBITS(1) [],
+        EN_E1 OFFSET(3) NUMBITS(1) [],
+        EN_E2 OFFSET(4) NUMBITS(1) [],
+        EN_E3 OFFSET(5) NUMBITS(1) [],
+        MAP_E0 OFFSET(6) NUMBITS(2) [],
+        MAP_E1 OFFSET(8) NUMBITS(2) [],
+        MAP_E2 OFFSET(10) NUMBITS(2) [],
+        MAP_E3 OFFSET(12) NUMBITS(2) [],
+    ],
+    pub(crate) CLASSB_CLR_REGWEN [
+        CLASSB_CLR_REGWEN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CLASSB_CLR_SHADOWED [
+        CLASSB_CLR_SHADOWED OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CLASSB_ACCUM_CNT [
+        CLASSB_ACCUM_CNT OFFSET(0) NUMBITS(16) [],
+    ],
+    pub(crate) CLASSB_ACCUM_THRESH_SHADOWED [
+        CLASSB_ACCUM_THRESH_SHADOWED OFFSET(0) NUMBITS(16) [],
+    ],
+    pub(crate) CLASSB_TIMEOUT_CYC_SHADOWED [
+        CLASSB_TIMEOUT_CYC_SHADOWED OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) CLASSB_CRASHDUMP_TRIGGER_SHADOWED [
+        CLASSB_CRASHDUMP_TRIGGER_SHADOWED OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) CLASSB_PHASE0_CYC_SHADOWED [
+        CLASSB_PHASE0_CYC_SHADOWED OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) CLASSB_PHASE1_CYC_SHADOWED [
+        CLASSB_PHASE1_CYC_SHADOWED OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) CLASSB_PHASE2_CYC_SHADOWED [
+        CLASSB_PHASE2_CYC_SHADOWED OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) CLASSB_PHASE3_CYC_SHADOWED [
+        CLASSB_PHASE3_CYC_SHADOWED OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) CLASSB_ESC_CNT [
+        CLASSB_ESC_CNT OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) CLASSB_STATE [
+        CLASSB_STATE OFFSET(0) NUMBITS(3) [
+            IDLE = 0,
+            TIMEOUT = 1,
+            FSMERROR = 2,
+            TERMINAL = 3,
+            PHASE0 = 4,
+            PHASE1 = 5,
+            PHASE2 = 6,
+            PHASE3 = 7,
+        ],
+    ],
+    pub(crate) CLASSC_REGWEN [
+        CLASSC_REGWEN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CLASSC_CTRL_SHADOWED [
+        EN OFFSET(0) NUMBITS(1) [],
+        LOCK OFFSET(1) NUMBITS(1) [],
+        EN_E0 OFFSET(2) NUMBITS(1) [],
+        EN_E1 OFFSET(3) NUMBITS(1) [],
+        EN_E2 OFFSET(4) NUMBITS(1) [],
+        EN_E3 OFFSET(5) NUMBITS(1) [],
+        MAP_E0 OFFSET(6) NUMBITS(2) [],
+        MAP_E1 OFFSET(8) NUMBITS(2) [],
+        MAP_E2 OFFSET(10) NUMBITS(2) [],
+        MAP_E3 OFFSET(12) NUMBITS(2) [],
+    ],
+    pub(crate) CLASSC_CLR_REGWEN [
+        CLASSC_CLR_REGWEN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CLASSC_CLR_SHADOWED [
+        CLASSC_CLR_SHADOWED OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CLASSC_ACCUM_CNT [
+        CLASSC_ACCUM_CNT OFFSET(0) NUMBITS(16) [],
+    ],
+    pub(crate) CLASSC_ACCUM_THRESH_SHADOWED [
+        CLASSC_ACCUM_THRESH_SHADOWED OFFSET(0) NUMBITS(16) [],
+    ],
+    pub(crate) CLASSC_TIMEOUT_CYC_SHADOWED [
+        CLASSC_TIMEOUT_CYC_SHADOWED OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) CLASSC_CRASHDUMP_TRIGGER_SHADOWED [
+        CLASSC_CRASHDUMP_TRIGGER_SHADOWED OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) CLASSC_PHASE0_CYC_SHADOWED [
+        CLASSC_PHASE0_CYC_SHADOWED OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) CLASSC_PHASE1_CYC_SHADOWED [
+        CLASSC_PHASE1_CYC_SHADOWED OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) CLASSC_PHASE2_CYC_SHADOWED [
+        CLASSC_PHASE2_CYC_SHADOWED OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) CLASSC_PHASE3_CYC_SHADOWED [
+        CLASSC_PHASE3_CYC_SHADOWED OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) CLASSC_ESC_CNT [
+        CLASSC_ESC_CNT OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) CLASSC_STATE [
+        CLASSC_STATE OFFSET(0) NUMBITS(3) [
+            IDLE = 0,
+            TIMEOUT = 1,
+            FSMERROR = 2,
+            TERMINAL = 3,
+            PHASE0 = 4,
+            PHASE1 = 5,
+            PHASE2 = 6,
+            PHASE3 = 7,
+        ],
+    ],
+    pub(crate) CLASSD_REGWEN [
+        CLASSD_REGWEN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CLASSD_CTRL_SHADOWED [
+        EN OFFSET(0) NUMBITS(1) [],
+        LOCK OFFSET(1) NUMBITS(1) [],
+        EN_E0 OFFSET(2) NUMBITS(1) [],
+        EN_E1 OFFSET(3) NUMBITS(1) [],
+        EN_E2 OFFSET(4) NUMBITS(1) [],
+        EN_E3 OFFSET(5) NUMBITS(1) [],
+        MAP_E0 OFFSET(6) NUMBITS(2) [],
+        MAP_E1 OFFSET(8) NUMBITS(2) [],
+        MAP_E2 OFFSET(10) NUMBITS(2) [],
+        MAP_E3 OFFSET(12) NUMBITS(2) [],
+    ],
+    pub(crate) CLASSD_CLR_REGWEN [
+        CLASSD_CLR_REGWEN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CLASSD_CLR_SHADOWED [
+        CLASSD_CLR_SHADOWED OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CLASSD_ACCUM_CNT [
+        CLASSD_ACCUM_CNT OFFSET(0) NUMBITS(16) [],
+    ],
+    pub(crate) CLASSD_ACCUM_THRESH_SHADOWED [
+        CLASSD_ACCUM_THRESH_SHADOWED OFFSET(0) NUMBITS(16) [],
+    ],
+    pub(crate) CLASSD_TIMEOUT_CYC_SHADOWED [
+        CLASSD_TIMEOUT_CYC_SHADOWED OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) CLASSD_CRASHDUMP_TRIGGER_SHADOWED [
+        CLASSD_CRASHDUMP_TRIGGER_SHADOWED OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) CLASSD_PHASE0_CYC_SHADOWED [
+        CLASSD_PHASE0_CYC_SHADOWED OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) CLASSD_PHASE1_CYC_SHADOWED [
+        CLASSD_PHASE1_CYC_SHADOWED OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) CLASSD_PHASE2_CYC_SHADOWED [
+        CLASSD_PHASE2_CYC_SHADOWED OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) CLASSD_PHASE3_CYC_SHADOWED [
+        CLASSD_PHASE3_CYC_SHADOWED OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) CLASSD_ESC_CNT [
+        CLASSD_ESC_CNT OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) CLASSD_STATE [
+        CLASSD_STATE OFFSET(0) NUMBITS(3) [
+            IDLE = 0,
+            TIMEOUT = 1,
+            FSMERROR = 2,
+            TERMINAL = 3,
+            PHASE0 = 4,
+            PHASE1 = 5,
+            PHASE2 = 6,
+            PHASE3 = 7,
+        ],
+    ],
+];
+
+// End generated register constants for alert_handler

--- a/chips/earlgrey/src/registers/ast_regs.rs
+++ b/chips/earlgrey/src/registers/ast_regs.rs
@@ -1,0 +1,231 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for ast.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/top_earlgrey/ip/ast/data/ast.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Number of registers in the Array-B
+pub const AST_PARAM_NUM_REGS_B: u32 = 5;
+/// Number of USB valid beacon pulses for clock to re-calibrate
+pub const AST_PARAM_NUM_USB_BEACON_PULSES: u32 = 8;
+/// Register width
+pub const AST_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub AstRegisters {
+        /// AST Register 0 for OTP/ROM Write Testing
+        (0x0000 => pub(crate) rega0: ReadWrite<u32, REGA0::Register>),
+        /// AST 1 Register for OTP/ROM Write Testing
+        (0x0004 => pub(crate) rega1: ReadWrite<u32, REGA1::Register>),
+        /// AST 2 Register for OTP/ROM Write Testing
+        (0x0008 => pub(crate) rega2: ReadWrite<u32, REGA2::Register>),
+        /// AST 3 Register for OTP/ROM Write Testing
+        (0x000c => pub(crate) rega3: ReadWrite<u32, REGA3::Register>),
+        /// AST 4 Register for OTP/ROM Write Testing
+        (0x0010 => pub(crate) rega4: ReadWrite<u32, REGA4::Register>),
+        /// AST 5 Register for OTP/ROM Write Testing
+        (0x0014 => pub(crate) rega5: ReadWrite<u32, REGA5::Register>),
+        /// AST 6 Register for OTP/ROM Write Testing
+        (0x0018 => pub(crate) rega6: ReadWrite<u32, REGA6::Register>),
+        /// AST 7 Register for OTP/ROM Write Testing
+        (0x001c => pub(crate) rega7: ReadWrite<u32, REGA7::Register>),
+        /// AST 8 Register for OTP/ROM Write Testing
+        (0x0020 => pub(crate) rega8: ReadWrite<u32, REGA8::Register>),
+        /// AST 9 Register for OTP/ROM Write Testing
+        (0x0024 => pub(crate) rega9: ReadWrite<u32, REGA9::Register>),
+        /// AST 10 Register for OTP/ROM Write Testing
+        (0x0028 => pub(crate) rega10: ReadWrite<u32, REGA10::Register>),
+        /// AST 11 Register for OTP/ROM Write Testing
+        (0x002c => pub(crate) rega11: ReadWrite<u32, REGA11::Register>),
+        /// AST 13 Register for OTP/ROM Write Testing
+        (0x0030 => pub(crate) rega12: ReadWrite<u32, REGA12::Register>),
+        /// AST 13 Register for OTP/ROM Write Testing
+        (0x0034 => pub(crate) rega13: ReadWrite<u32, REGA13::Register>),
+        /// AST 14 Register for OTP/ROM Write Testing
+        (0x0038 => pub(crate) rega14: ReadWrite<u32, REGA14::Register>),
+        /// AST 15 Register for OTP/ROM Write Testing
+        (0x003c => pub(crate) rega15: ReadWrite<u32, REGA15::Register>),
+        /// AST 16 Register for OTP/ROM Write Testing
+        (0x0040 => pub(crate) rega16: ReadWrite<u32, REGA16::Register>),
+        /// AST 17 Register for OTP/ROM Write Testing
+        (0x0044 => pub(crate) rega17: ReadWrite<u32, REGA17::Register>),
+        /// AST 18 Register for OTP/ROM Write Testing
+        (0x0048 => pub(crate) rega18: ReadWrite<u32, REGA18::Register>),
+        /// AST 19 Register for OTP/ROM Write Testing
+        (0x004c => pub(crate) rega19: ReadWrite<u32, REGA19::Register>),
+        /// AST 20 Register for OTP/ROM Write Testing
+        (0x0050 => pub(crate) rega20: ReadWrite<u32, REGA20::Register>),
+        /// AST 21 Register for OTP/ROM Write Testing
+        (0x0054 => pub(crate) rega21: ReadWrite<u32, REGA21::Register>),
+        /// AST 22 Register for OTP/ROM Write Testing
+        (0x0058 => pub(crate) rega22: ReadWrite<u32, REGA22::Register>),
+        /// AST 23 Register for OTP/ROM Write Testing
+        (0x005c => pub(crate) rega23: ReadWrite<u32, REGA23::Register>),
+        /// AST 24 Register for OTP/ROM Write Testing
+        (0x0060 => pub(crate) rega24: ReadWrite<u32, REGA24::Register>),
+        /// AST 25 Register for OTP/ROM Write Testing
+        (0x0064 => pub(crate) rega25: ReadWrite<u32, REGA25::Register>),
+        /// AST 26 Register for OTP/ROM Write Testing
+        (0x0068 => pub(crate) rega26: ReadWrite<u32, REGA26::Register>),
+        /// AST 27 Register for OTP/ROM Write Testing
+        (0x006c => pub(crate) rega27: ReadWrite<u32, REGA27::Register>),
+        /// AST 28 Register for OTP/ROM Write Testing
+        (0x0070 => pub(crate) rega28: ReadWrite<u32, REGA28::Register>),
+        /// AST 29 Register for OTP/ROM Write Testing
+        (0x0074 => pub(crate) rega29: ReadWrite<u32, REGA29::Register>),
+        /// AST 30 Register for OTP/ROM Write Testing
+        (0x0078 => pub(crate) rega30: ReadWrite<u32, REGA30::Register>),
+        /// AST 31 Register for OTP/ROM Write Testing
+        (0x007c => pub(crate) rega31: ReadWrite<u32, REGA31::Register>),
+        /// AST 32 Register for OTP/ROM Write Testing
+        (0x0080 => pub(crate) rega32: ReadWrite<u32, REGA32::Register>),
+        /// AST 33 Register for OTP/ROM Write Testing
+        (0x0084 => pub(crate) rega33: ReadWrite<u32, REGA33::Register>),
+        /// AST 34 Register for OTP/ROM Write Testing
+        (0x0088 => pub(crate) rega34: ReadWrite<u32, REGA34::Register>),
+        /// AST 35 Register for OTP/ROM Write Testing
+        (0x008c => pub(crate) rega35: ReadWrite<u32, REGA35::Register>),
+        /// AST 36 Register for OTP/ROM Write Testing
+        (0x0090 => pub(crate) rega36: ReadWrite<u32, REGA36::Register>),
+        /// AST 37 Register for OTP/ROM Write Testing
+        (0x0094 => pub(crate) rega37: ReadWrite<u32, REGA37::Register>),
+        /// AST Last Register for OTP/ROM Write Testing
+        (0x0098 => pub(crate) regal: ReadWrite<u32, REGAL::Register>),
+        (0x009c => _reserved1),
+        /// AST Registers Array-B to set address space size
+        (0x0200 => pub(crate) regb: [ReadWrite<u32, REGB::Register>; 5]),
+        (0x0214 => @END),
+    }
+}
+
+register_bitfields![u32,
+    pub(crate) REGA0 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA1 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA2 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA3 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA4 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA5 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA6 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA7 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA8 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA9 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA10 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA11 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA12 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA13 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA14 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA15 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA16 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA17 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA18 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA19 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA20 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA21 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA22 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA23 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA24 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA25 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA26 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA27 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA28 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA29 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA30 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA31 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA32 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA33 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA34 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA35 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA36 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGA37 [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGAL [
+        REG32 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REGB [
+        REG32_0 OFFSET(0) NUMBITS(32) [],
+    ],
+];
+
+// End generated register constants for ast

--- a/chips/earlgrey/src/registers/clkmgr_regs.rs
+++ b/chips/earlgrey/src/registers/clkmgr_regs.rs
@@ -1,0 +1,172 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for clkmgr.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Number of clock groups
+pub const CLKMGR_PARAM_NUM_GROUPS: u32 = 7;
+/// Number of SW gateable clocks
+pub const CLKMGR_PARAM_NUM_SW_GATEABLE_CLOCKS: u32 = 4;
+/// Number of hintable clocks
+pub const CLKMGR_PARAM_NUM_HINTABLE_CLOCKS: u32 = 4;
+/// Number of alerts
+pub const CLKMGR_PARAM_NUM_ALERTS: u32 = 2;
+/// Register width
+pub const CLKMGR_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub ClkmgrRegisters {
+        /// Alert Test Register
+        (0x0000 => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// External clock control write enable
+        (0x0004 => pub(crate) extclk_ctrl_regwen: ReadWrite<u32, EXTCLK_CTRL_REGWEN::Register>),
+        /// Select external clock
+        (0x0008 => pub(crate) extclk_ctrl: ReadWrite<u32, EXTCLK_CTRL::Register>),
+        /// Status of requested external clock switch
+        (0x000c => pub(crate) extclk_status: ReadWrite<u32, EXTCLK_STATUS::Register>),
+        /// Jitter write enable
+        (0x0010 => pub(crate) jitter_regwen: ReadWrite<u32, JITTER_REGWEN::Register>),
+        /// Enable jittery clock
+        (0x0014 => pub(crate) jitter_enable: ReadWrite<u32, JITTER_ENABLE::Register>),
+        /// Clock enable for software gateable clocks.
+        (0x0018 => pub(crate) clk_enables: ReadWrite<u32, CLK_ENABLES::Register>),
+        /// Clock hint for software gateable transactional clocks during active mode.
+        (0x001c => pub(crate) clk_hints: ReadWrite<u32, CLK_HINTS::Register>),
+        /// Since the final state of !!CLK_HINTS is not always determined by software,
+        (0x0020 => pub(crate) clk_hints_status: ReadWrite<u32, CLK_HINTS_STATUS::Register>),
+        /// Measurement control write enable
+        (0x0024 => pub(crate) measure_ctrl_regwen: ReadWrite<u32, MEASURE_CTRL_REGWEN::Register>),
+        /// Enable for measurement control
+        (0x0028 => pub(crate) io_meas_ctrl_en: ReadWrite<u32, IO_MEAS_CTRL_EN::Register>),
+        /// Configuration controls for io measurement.
+        (0x002c => pub(crate) io_meas_ctrl_shadowed: ReadWrite<u32, IO_MEAS_CTRL_SHADOWED::Register>),
+        /// Enable for measurement control
+        (0x0030 => pub(crate) io_div2_meas_ctrl_en: ReadWrite<u32, IO_DIV2_MEAS_CTRL_EN::Register>),
+        /// Configuration controls for io_div2 measurement.
+        (0x0034 => pub(crate) io_div2_meas_ctrl_shadowed: ReadWrite<u32, IO_DIV2_MEAS_CTRL_SHADOWED::Register>),
+        /// Enable for measurement control
+        (0x0038 => pub(crate) io_div4_meas_ctrl_en: ReadWrite<u32, IO_DIV4_MEAS_CTRL_EN::Register>),
+        /// Configuration controls for io_div4 measurement.
+        (0x003c => pub(crate) io_div4_meas_ctrl_shadowed: ReadWrite<u32, IO_DIV4_MEAS_CTRL_SHADOWED::Register>),
+        /// Enable for measurement control
+        (0x0040 => pub(crate) main_meas_ctrl_en: ReadWrite<u32, MAIN_MEAS_CTRL_EN::Register>),
+        /// Configuration controls for main measurement.
+        (0x0044 => pub(crate) main_meas_ctrl_shadowed: ReadWrite<u32, MAIN_MEAS_CTRL_SHADOWED::Register>),
+        /// Enable for measurement control
+        (0x0048 => pub(crate) usb_meas_ctrl_en: ReadWrite<u32, USB_MEAS_CTRL_EN::Register>),
+        /// Configuration controls for usb measurement.
+        (0x004c => pub(crate) usb_meas_ctrl_shadowed: ReadWrite<u32, USB_MEAS_CTRL_SHADOWED::Register>),
+        /// Recoverable Error code
+        (0x0050 => pub(crate) recov_err_code: ReadWrite<u32, RECOV_ERR_CODE::Register>),
+        /// Error code
+        (0x0054 => pub(crate) fatal_err_code: ReadWrite<u32, FATAL_ERR_CODE::Register>),
+        (0x0058 => @END),
+    }
+}
+
+register_bitfields![u32,
+    pub(crate) ALERT_TEST [
+        RECOV_FAULT OFFSET(0) NUMBITS(1) [],
+        FATAL_FAULT OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) EXTCLK_CTRL_REGWEN [
+        EN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) EXTCLK_CTRL [
+        SEL OFFSET(0) NUMBITS(4) [],
+        HI_SPEED_SEL OFFSET(4) NUMBITS(4) [],
+    ],
+    pub(crate) EXTCLK_STATUS [
+        ACK OFFSET(0) NUMBITS(4) [],
+    ],
+    pub(crate) JITTER_REGWEN [
+        EN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) JITTER_ENABLE [
+        VAL OFFSET(0) NUMBITS(4) [],
+    ],
+    pub(crate) CLK_ENABLES [
+        CLK_IO_DIV4_PERI_EN OFFSET(0) NUMBITS(1) [],
+        CLK_IO_DIV2_PERI_EN OFFSET(1) NUMBITS(1) [],
+        CLK_IO_PERI_EN OFFSET(2) NUMBITS(1) [],
+        CLK_USB_PERI_EN OFFSET(3) NUMBITS(1) [],
+    ],
+    pub(crate) CLK_HINTS [
+        CLK_MAIN_AES_HINT OFFSET(0) NUMBITS(1) [],
+        CLK_MAIN_HMAC_HINT OFFSET(1) NUMBITS(1) [],
+        CLK_MAIN_KMAC_HINT OFFSET(2) NUMBITS(1) [],
+        CLK_MAIN_OTBN_HINT OFFSET(3) NUMBITS(1) [],
+    ],
+    pub(crate) CLK_HINTS_STATUS [
+        CLK_MAIN_AES_VAL OFFSET(0) NUMBITS(1) [],
+        CLK_MAIN_HMAC_VAL OFFSET(1) NUMBITS(1) [],
+        CLK_MAIN_KMAC_VAL OFFSET(2) NUMBITS(1) [],
+        CLK_MAIN_OTBN_VAL OFFSET(3) NUMBITS(1) [],
+    ],
+    pub(crate) MEASURE_CTRL_REGWEN [
+        EN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) IO_MEAS_CTRL_EN [
+        EN OFFSET(0) NUMBITS(4) [],
+    ],
+    pub(crate) IO_MEAS_CTRL_SHADOWED [
+        HI OFFSET(0) NUMBITS(10) [],
+        LO OFFSET(10) NUMBITS(10) [],
+    ],
+    pub(crate) IO_DIV2_MEAS_CTRL_EN [
+        EN OFFSET(0) NUMBITS(4) [],
+    ],
+    pub(crate) IO_DIV2_MEAS_CTRL_SHADOWED [
+        HI OFFSET(0) NUMBITS(9) [],
+        LO OFFSET(9) NUMBITS(9) [],
+    ],
+    pub(crate) IO_DIV4_MEAS_CTRL_EN [
+        EN OFFSET(0) NUMBITS(4) [],
+    ],
+    pub(crate) IO_DIV4_MEAS_CTRL_SHADOWED [
+        HI OFFSET(0) NUMBITS(8) [],
+        LO OFFSET(8) NUMBITS(8) [],
+    ],
+    pub(crate) MAIN_MEAS_CTRL_EN [
+        EN OFFSET(0) NUMBITS(4) [],
+    ],
+    pub(crate) MAIN_MEAS_CTRL_SHADOWED [
+        HI OFFSET(0) NUMBITS(10) [],
+        LO OFFSET(10) NUMBITS(10) [],
+    ],
+    pub(crate) USB_MEAS_CTRL_EN [
+        EN OFFSET(0) NUMBITS(4) [],
+    ],
+    pub(crate) USB_MEAS_CTRL_SHADOWED [
+        HI OFFSET(0) NUMBITS(9) [],
+        LO OFFSET(9) NUMBITS(9) [],
+    ],
+    pub(crate) RECOV_ERR_CODE [
+        SHADOW_UPDATE_ERR OFFSET(0) NUMBITS(1) [],
+        IO_MEASURE_ERR OFFSET(1) NUMBITS(1) [],
+        IO_DIV2_MEASURE_ERR OFFSET(2) NUMBITS(1) [],
+        IO_DIV4_MEASURE_ERR OFFSET(3) NUMBITS(1) [],
+        MAIN_MEASURE_ERR OFFSET(4) NUMBITS(1) [],
+        USB_MEASURE_ERR OFFSET(5) NUMBITS(1) [],
+        IO_TIMEOUT_ERR OFFSET(6) NUMBITS(1) [],
+        IO_DIV2_TIMEOUT_ERR OFFSET(7) NUMBITS(1) [],
+        IO_DIV4_TIMEOUT_ERR OFFSET(8) NUMBITS(1) [],
+        MAIN_TIMEOUT_ERR OFFSET(9) NUMBITS(1) [],
+        USB_TIMEOUT_ERR OFFSET(10) NUMBITS(1) [],
+    ],
+    pub(crate) FATAL_ERR_CODE [
+        REG_INTG OFFSET(0) NUMBITS(1) [],
+        IDLE_CNT OFFSET(1) NUMBITS(1) [],
+        SHADOW_STORAGE_ERR OFFSET(2) NUMBITS(1) [],
+    ],
+];
+
+// End generated register constants for clkmgr

--- a/chips/earlgrey/src/registers/flash_ctrl_regs.rs
+++ b/chips/earlgrey/src/registers/flash_ctrl_regs.rs
@@ -1,0 +1,429 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for flash_ctrl.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+use kernel::utilities::registers::ReadOnly;
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::WriteOnly;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Number of flash banks
+pub const FLASH_CTRL_PARAM_REG_NUM_BANKS: u32 = 2;
+/// Number of pages per bank
+pub const FLASH_CTRL_PARAM_REG_PAGES_PER_BANK: u32 = 256;
+/// Program resolution window in bytes
+pub const FLASH_CTRL_PARAM_REG_BUS_PGM_RES_BYTES: u32 = 64;
+/// Number of bits needed to represent the pages within a bank
+pub const FLASH_CTRL_PARAM_REG_PAGE_WIDTH: u32 = 8;
+/// Number of bits needed to represent the number of banks
+pub const FLASH_CTRL_PARAM_REG_BANK_WIDTH: u32 = 1;
+/// Number of configurable flash regions
+pub const FLASH_CTRL_PARAM_NUM_REGIONS: u32 = 8;
+/// Number of info partition types
+pub const FLASH_CTRL_PARAM_NUM_INFO_TYPES: u32 = 3;
+/// Number of configurable flash info pages for info type 0
+pub const FLASH_CTRL_PARAM_NUM_INFOS0: u32 = 10;
+/// Number of configurable flash info pages for info type 1
+pub const FLASH_CTRL_PARAM_NUM_INFOS1: u32 = 1;
+/// Number of configurable flash info pages for info type 2
+pub const FLASH_CTRL_PARAM_NUM_INFOS2: u32 = 2;
+/// Number of words per page
+pub const FLASH_CTRL_PARAM_WORDS_PER_PAGE: u32 = 256;
+/// Number of bytes per word
+pub const FLASH_CTRL_PARAM_BYTES_PER_WORD: u32 = 8;
+/// Number of bytes per page
+pub const FLASH_CTRL_PARAM_BYTES_PER_PAGE: u32 = 2048;
+/// Number of bytes per bank
+pub const FLASH_CTRL_PARAM_BYTES_PER_BANK: u32 = 524288;
+/// Maximum depth for read / program fifos
+pub const FLASH_CTRL_PARAM_MAX_FIFO_DEPTH: u32 = 16;
+/// Maximum depth for read / program fifos
+pub const FLASH_CTRL_PARAM_MAX_FIFO_WIDTH: u32 = 5;
+/// Number of alerts
+pub const FLASH_CTRL_PARAM_NUM_ALERTS: u32 = 5;
+/// Register width
+pub const FLASH_CTRL_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub FlashCtrlRegisters {
+        /// Interrupt State Register
+        (0x0000 => pub(crate) intr_state: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Enable Register
+        (0x0004 => pub(crate) intr_enable: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Test Register
+        (0x0008 => pub(crate) intr_test: ReadWrite<u32, INTR::Register>),
+        /// Alert Test Register
+        (0x000c => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// Disable flash functionality
+        (0x0010 => pub(crate) dis: ReadWrite<u32, DIS::Register>),
+        /// Controls whether flash can be used for code execution fetches
+        (0x0014 => pub(crate) exec: ReadWrite<u32, EXEC::Register>),
+        /// Controller init register
+        (0x0018 => pub(crate) init: ReadWrite<u32, INIT::Register>),
+        /// Controls the configurability of the !!CONTROL register.
+        (0x001c => pub(crate) ctrl_regwen: ReadWrite<u32, CTRL_REGWEN::Register>),
+        /// Control register
+        (0x0020 => pub(crate) control: ReadWrite<u32, CONTROL::Register>),
+        /// Address for flash operation
+        (0x0024 => pub(crate) addr: ReadWrite<u32, ADDR::Register>),
+        /// Enable different program types
+        (0x0028 => pub(crate) prog_type_en: ReadWrite<u32, PROG_TYPE_EN::Register>),
+        /// Suspend erase
+        (0x002c => pub(crate) erase_suspend: ReadWrite<u32, ERASE_SUSPEND::Register>),
+        /// Memory region registers configuration enable.
+        (0x0030 => pub(crate) region_cfg_regwen: [ReadWrite<u32, REGION_CFG_REGWEN::Register>; 8]),
+        /// Memory property configuration for data partition
+        (0x0050 => pub(crate) mp_region_cfg: [ReadWrite<u32, MP_REGION_CFG::Register>; 8]),
+        /// Memory base and size configuration for data partition
+        (0x0070 => pub(crate) mp_region: [ReadWrite<u32, MP_REGION::Register>; 8]),
+        /// Default region properties
+        (0x0090 => pub(crate) default_region: ReadWrite<u32, DEFAULT_REGION::Register>),
+        /// Memory region registers configuration enable.
+        (0x0094 => pub(crate) bank0_info0_regwen: [ReadWrite<u32, BANK0_INFO0_REGWEN::Register>; 10]),
+        ///   Memory property configuration for info partition in bank0,
+        (0x00bc => pub(crate) bank0_info0_page_cfg: [ReadWrite<u32, BANK0_INFO0_PAGE_CFG::Register>; 10]),
+        /// Memory region registers configuration enable.
+        (0x00e4 => pub(crate) bank0_info1_regwen: [ReadWrite<u32, BANK0_INFO1_REGWEN::Register>; 1]),
+        ///   Memory property configuration for info partition in bank0,
+        (0x00e8 => pub(crate) bank0_info1_page_cfg: [ReadWrite<u32, BANK0_INFO1_PAGE_CFG::Register>; 1]),
+        /// Memory region registers configuration enable.
+        (0x00ec => pub(crate) bank0_info2_regwen: [ReadWrite<u32, BANK0_INFO2_REGWEN::Register>; 2]),
+        ///   Memory property configuration for info partition in bank0,
+        (0x00f4 => pub(crate) bank0_info2_page_cfg: [ReadWrite<u32, BANK0_INFO2_PAGE_CFG::Register>; 2]),
+        /// Memory region registers configuration enable.
+        (0x00fc => pub(crate) bank1_info0_regwen: [ReadWrite<u32, BANK1_INFO0_REGWEN::Register>; 10]),
+        ///   Memory property configuration for info partition in bank1,
+        (0x0124 => pub(crate) bank1_info0_page_cfg: [ReadWrite<u32, BANK1_INFO0_PAGE_CFG::Register>; 10]),
+        /// Memory region registers configuration enable.
+        (0x014c => pub(crate) bank1_info1_regwen: [ReadWrite<u32, BANK1_INFO1_REGWEN::Register>; 1]),
+        ///   Memory property configuration for info partition in bank1,
+        (0x0150 => pub(crate) bank1_info1_page_cfg: [ReadWrite<u32, BANK1_INFO1_PAGE_CFG::Register>; 1]),
+        /// Memory region registers configuration enable.
+        (0x0154 => pub(crate) bank1_info2_regwen: [ReadWrite<u32, BANK1_INFO2_REGWEN::Register>; 2]),
+        ///   Memory property configuration for info partition in bank1,
+        (0x015c => pub(crate) bank1_info2_page_cfg: [ReadWrite<u32, BANK1_INFO2_PAGE_CFG::Register>; 2]),
+        /// HW interface info configuration rule overrides
+        (0x0164 => pub(crate) hw_info_cfg_override: ReadWrite<u32, HW_INFO_CFG_OVERRIDE::Register>),
+        /// Bank configuration registers configuration enable.
+        (0x0168 => pub(crate) bank_cfg_regwen: ReadWrite<u32, BANK_CFG_REGWEN::Register>),
+        /// Memory properties bank configuration
+        (0x016c => pub(crate) mp_bank_cfg_shadowed: [ReadWrite<u32, MP_BANK_CFG_SHADOWED::Register>; 1]),
+        /// Flash Operation Status
+        (0x0170 => pub(crate) op_status: ReadWrite<u32, OP_STATUS::Register>),
+        /// Flash Controller Status
+        (0x0174 => pub(crate) status: ReadWrite<u32, STATUS::Register>),
+        /// Current flash fsm state
+        (0x0178 => pub(crate) debug_state: ReadWrite<u32, DEBUG_STATE::Register>),
+        /// Flash error code register.
+        (0x017c => pub(crate) err_code: ReadWrite<u32, ERR_CODE::Register>),
+        /// This register tabulates standard fault status of the flash.
+        (0x0180 => pub(crate) std_fault_status: ReadWrite<u32, STD_FAULT_STATUS::Register>),
+        /// This register tabulates customized fault status of the flash.
+        (0x0184 => pub(crate) fault_status: ReadWrite<u32, FAULT_STATUS::Register>),
+        /// Synchronous error address
+        (0x0188 => pub(crate) err_addr: ReadWrite<u32, ERR_ADDR::Register>),
+        /// Total number of single bit ECC error count
+        (0x018c => pub(crate) ecc_single_err_cnt: [ReadWrite<u32, ECC_SINGLE_ERR_CNT::Register>; 1]),
+        /// Latest address of ECC single err
+        (0x0190 => pub(crate) ecc_single_err_addr: [ReadWrite<u32, ECC_SINGLE_ERR_ADDR::Register>; 2]),
+        /// Phy alert configuration
+        (0x0198 => pub(crate) phy_alert_cfg: ReadWrite<u32, PHY_ALERT_CFG::Register>),
+        /// Flash Phy Status
+        (0x019c => pub(crate) phy_status: ReadWrite<u32, PHY_STATUS::Register>),
+        /// Flash Controller Scratch
+        (0x01a0 => pub(crate) scratch: ReadWrite<u32, SCRATCH::Register>),
+        /// Programmable depth where FIFOs should generate interrupts
+        (0x01a4 => pub(crate) fifo_lvl: ReadWrite<u32, FIFO_LVL::Register>),
+        /// Reset for flash controller FIFOs
+        (0x01a8 => pub(crate) fifo_rst: ReadWrite<u32, FIFO_RST::Register>),
+        /// Current program and read fifo depth
+        (0x01ac => pub(crate) curr_fifo_lvl: ReadWrite<u32, CURR_FIFO_LVL::Register>),
+        /// Memory area: Flash program FIFO.
+        (0x01b0 => pub(crate) prog_fifo: [WriteOnly<u32>; 1]),
+        /// Memory area: Flash read FIFO.
+        (0x01b4 => pub(crate) rd_fifo: [ReadOnly<u32>; 1]),
+        (0x01b8 => @END),
+    }
+}
+
+register_bitfields![u32,
+    /// Common Interrupt Offsets
+    pub(crate) INTR [
+        PROG_EMPTY OFFSET(0) NUMBITS(1) [],
+        PROG_LVL OFFSET(1) NUMBITS(1) [],
+        RD_FULL OFFSET(2) NUMBITS(1) [],
+        RD_LVL OFFSET(3) NUMBITS(1) [],
+        OP_DONE OFFSET(4) NUMBITS(1) [],
+        CORR_ERR OFFSET(5) NUMBITS(1) [],
+    ],
+    pub(crate) ALERT_TEST [
+        RECOV_ERR OFFSET(0) NUMBITS(1) [],
+        FATAL_STD_ERR OFFSET(1) NUMBITS(1) [],
+        FATAL_ERR OFFSET(2) NUMBITS(1) [],
+        FATAL_PRIM_FLASH_ALERT OFFSET(3) NUMBITS(1) [],
+        RECOV_PRIM_FLASH_ALERT OFFSET(4) NUMBITS(1) [],
+    ],
+    pub(crate) DIS [
+        VAL OFFSET(0) NUMBITS(4) [],
+    ],
+    pub(crate) EXEC [
+        EN OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) INIT [
+        VAL OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CTRL_REGWEN [
+        EN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CONTROL [
+        START OFFSET(0) NUMBITS(1) [],
+        OP OFFSET(4) NUMBITS(2) [
+            READ = 0,
+            PROG = 1,
+            ERASE = 2,
+        ],
+        PROG_SEL OFFSET(6) NUMBITS(1) [
+            NORMAL_PROGRAM = 0,
+            PROGRAM_REPAIR = 1,
+        ],
+        ERASE_SEL OFFSET(7) NUMBITS(1) [
+            PAGE_ERASE = 0,
+            BANK_ERASE = 1,
+        ],
+        PARTITION_SEL OFFSET(8) NUMBITS(1) [],
+        INFO_SEL OFFSET(9) NUMBITS(2) [],
+        NUM OFFSET(16) NUMBITS(12) [],
+    ],
+    pub(crate) ADDR [
+        START OFFSET(0) NUMBITS(20) [],
+    ],
+    pub(crate) PROG_TYPE_EN [
+        NORMAL OFFSET(0) NUMBITS(1) [],
+        REPAIR OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) ERASE_SUSPEND [
+        REQ OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) REGION_CFG_REGWEN [
+        REGION_0 OFFSET(0) NUMBITS(1) [
+            REGION_LOCKED = 0,
+            REGION_ENABLED = 1,
+        ],
+    ],
+    pub(crate) MP_REGION_CFG [
+        EN_0 OFFSET(0) NUMBITS(4) [],
+        RD_EN_0 OFFSET(4) NUMBITS(4) [],
+        PROG_EN_0 OFFSET(8) NUMBITS(4) [],
+        ERASE_EN_0 OFFSET(12) NUMBITS(4) [],
+        SCRAMBLE_EN_0 OFFSET(16) NUMBITS(4) [],
+        ECC_EN_0 OFFSET(20) NUMBITS(4) [],
+        HE_EN_0 OFFSET(24) NUMBITS(4) [],
+    ],
+    pub(crate) MP_REGION [
+        BASE_0 OFFSET(0) NUMBITS(9) [],
+        SIZE_0 OFFSET(9) NUMBITS(10) [],
+    ],
+    pub(crate) DEFAULT_REGION [
+        RD_EN OFFSET(0) NUMBITS(4) [],
+        PROG_EN OFFSET(4) NUMBITS(4) [],
+        ERASE_EN OFFSET(8) NUMBITS(4) [],
+        SCRAMBLE_EN OFFSET(12) NUMBITS(4) [],
+        ECC_EN OFFSET(16) NUMBITS(4) [],
+        HE_EN OFFSET(20) NUMBITS(4) [],
+    ],
+    pub(crate) BANK0_INFO0_REGWEN [
+        REGION_0 OFFSET(0) NUMBITS(1) [
+            PAGE_LOCKED = 0,
+            PAGE_ENABLED = 1,
+        ],
+    ],
+    pub(crate) BANK0_INFO0_PAGE_CFG [
+        EN_0 OFFSET(0) NUMBITS(4) [],
+        RD_EN_0 OFFSET(4) NUMBITS(4) [],
+        PROG_EN_0 OFFSET(8) NUMBITS(4) [],
+        ERASE_EN_0 OFFSET(12) NUMBITS(4) [],
+        SCRAMBLE_EN_0 OFFSET(16) NUMBITS(4) [],
+        ECC_EN_0 OFFSET(20) NUMBITS(4) [],
+        HE_EN_0 OFFSET(24) NUMBITS(4) [],
+    ],
+    pub(crate) BANK0_INFO1_REGWEN [
+        REGION_0 OFFSET(0) NUMBITS(1) [
+            PAGE_LOCKED = 0,
+            PAGE_ENABLED = 1,
+        ],
+    ],
+    pub(crate) BANK0_INFO1_PAGE_CFG [
+        EN_0 OFFSET(0) NUMBITS(4) [],
+        RD_EN_0 OFFSET(4) NUMBITS(4) [],
+        PROG_EN_0 OFFSET(8) NUMBITS(4) [],
+        ERASE_EN_0 OFFSET(12) NUMBITS(4) [],
+        SCRAMBLE_EN_0 OFFSET(16) NUMBITS(4) [],
+        ECC_EN_0 OFFSET(20) NUMBITS(4) [],
+        HE_EN_0 OFFSET(24) NUMBITS(4) [],
+    ],
+    pub(crate) BANK0_INFO2_REGWEN [
+        REGION_0 OFFSET(0) NUMBITS(1) [
+            PAGE_LOCKED = 0,
+            PAGE_ENABLED = 1,
+        ],
+    ],
+    pub(crate) BANK0_INFO2_PAGE_CFG [
+        EN_0 OFFSET(0) NUMBITS(4) [],
+        RD_EN_0 OFFSET(4) NUMBITS(4) [],
+        PROG_EN_0 OFFSET(8) NUMBITS(4) [],
+        ERASE_EN_0 OFFSET(12) NUMBITS(4) [],
+        SCRAMBLE_EN_0 OFFSET(16) NUMBITS(4) [],
+        ECC_EN_0 OFFSET(20) NUMBITS(4) [],
+        HE_EN_0 OFFSET(24) NUMBITS(4) [],
+    ],
+    pub(crate) BANK1_INFO0_REGWEN [
+        REGION_0 OFFSET(0) NUMBITS(1) [
+            PAGE_LOCKED = 0,
+            PAGE_ENABLED = 1,
+        ],
+    ],
+    pub(crate) BANK1_INFO0_PAGE_CFG [
+        EN_0 OFFSET(0) NUMBITS(4) [],
+        RD_EN_0 OFFSET(4) NUMBITS(4) [],
+        PROG_EN_0 OFFSET(8) NUMBITS(4) [],
+        ERASE_EN_0 OFFSET(12) NUMBITS(4) [],
+        SCRAMBLE_EN_0 OFFSET(16) NUMBITS(4) [],
+        ECC_EN_0 OFFSET(20) NUMBITS(4) [],
+        HE_EN_0 OFFSET(24) NUMBITS(4) [],
+    ],
+    pub(crate) BANK1_INFO1_REGWEN [
+        REGION_0 OFFSET(0) NUMBITS(1) [
+            PAGE_LOCKED = 0,
+            PAGE_ENABLED = 1,
+        ],
+    ],
+    pub(crate) BANK1_INFO1_PAGE_CFG [
+        EN_0 OFFSET(0) NUMBITS(4) [],
+        RD_EN_0 OFFSET(4) NUMBITS(4) [],
+        PROG_EN_0 OFFSET(8) NUMBITS(4) [],
+        ERASE_EN_0 OFFSET(12) NUMBITS(4) [],
+        SCRAMBLE_EN_0 OFFSET(16) NUMBITS(4) [],
+        ECC_EN_0 OFFSET(20) NUMBITS(4) [],
+        HE_EN_0 OFFSET(24) NUMBITS(4) [],
+    ],
+    pub(crate) BANK1_INFO2_REGWEN [
+        REGION_0 OFFSET(0) NUMBITS(1) [
+            PAGE_LOCKED = 0,
+            PAGE_ENABLED = 1,
+        ],
+    ],
+    pub(crate) BANK1_INFO2_PAGE_CFG [
+        EN_0 OFFSET(0) NUMBITS(4) [],
+        RD_EN_0 OFFSET(4) NUMBITS(4) [],
+        PROG_EN_0 OFFSET(8) NUMBITS(4) [],
+        ERASE_EN_0 OFFSET(12) NUMBITS(4) [],
+        SCRAMBLE_EN_0 OFFSET(16) NUMBITS(4) [],
+        ECC_EN_0 OFFSET(20) NUMBITS(4) [],
+        HE_EN_0 OFFSET(24) NUMBITS(4) [],
+    ],
+    pub(crate) HW_INFO_CFG_OVERRIDE [
+        SCRAMBLE_DIS OFFSET(0) NUMBITS(4) [],
+        ECC_DIS OFFSET(4) NUMBITS(4) [],
+    ],
+    pub(crate) BANK_CFG_REGWEN [
+        BANK OFFSET(0) NUMBITS(1) [
+            BANK_LOCKED = 0,
+            BANK_ENABLED = 1,
+        ],
+    ],
+    pub(crate) MP_BANK_CFG_SHADOWED [
+        ERASE_EN_0 OFFSET(0) NUMBITS(1) [],
+        ERASE_EN_1 OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) OP_STATUS [
+        DONE OFFSET(0) NUMBITS(1) [],
+        ERR OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) STATUS [
+        RD_FULL OFFSET(0) NUMBITS(1) [],
+        RD_EMPTY OFFSET(1) NUMBITS(1) [],
+        PROG_FULL OFFSET(2) NUMBITS(1) [],
+        PROG_EMPTY OFFSET(3) NUMBITS(1) [],
+        INIT_WIP OFFSET(4) NUMBITS(1) [],
+        INITIALIZED OFFSET(5) NUMBITS(1) [],
+    ],
+    pub(crate) DEBUG_STATE [
+        LCMGR_STATE OFFSET(0) NUMBITS(11) [],
+    ],
+    pub(crate) ERR_CODE [
+        OP_ERR OFFSET(0) NUMBITS(1) [],
+        MP_ERR OFFSET(1) NUMBITS(1) [],
+        RD_ERR OFFSET(2) NUMBITS(1) [],
+        PROG_ERR OFFSET(3) NUMBITS(1) [],
+        PROG_WIN_ERR OFFSET(4) NUMBITS(1) [],
+        PROG_TYPE_ERR OFFSET(5) NUMBITS(1) [],
+        UPDATE_ERR OFFSET(6) NUMBITS(1) [],
+        MACRO_ERR OFFSET(7) NUMBITS(1) [],
+    ],
+    pub(crate) STD_FAULT_STATUS [
+        REG_INTG_ERR OFFSET(0) NUMBITS(1) [],
+        PROG_INTG_ERR OFFSET(1) NUMBITS(1) [],
+        LCMGR_ERR OFFSET(2) NUMBITS(1) [],
+        LCMGR_INTG_ERR OFFSET(3) NUMBITS(1) [],
+        ARB_FSM_ERR OFFSET(4) NUMBITS(1) [],
+        STORAGE_ERR OFFSET(5) NUMBITS(1) [],
+        PHY_FSM_ERR OFFSET(6) NUMBITS(1) [],
+        CTRL_CNT_ERR OFFSET(7) NUMBITS(1) [],
+        FIFO_ERR OFFSET(8) NUMBITS(1) [],
+    ],
+    pub(crate) FAULT_STATUS [
+        OP_ERR OFFSET(0) NUMBITS(1) [],
+        MP_ERR OFFSET(1) NUMBITS(1) [],
+        RD_ERR OFFSET(2) NUMBITS(1) [],
+        PROG_ERR OFFSET(3) NUMBITS(1) [],
+        PROG_WIN_ERR OFFSET(4) NUMBITS(1) [],
+        PROG_TYPE_ERR OFFSET(5) NUMBITS(1) [],
+        SEED_ERR OFFSET(6) NUMBITS(1) [],
+        PHY_RELBL_ERR OFFSET(7) NUMBITS(1) [],
+        PHY_STORAGE_ERR OFFSET(8) NUMBITS(1) [],
+        SPURIOUS_ACK OFFSET(9) NUMBITS(1) [],
+        ARB_ERR OFFSET(10) NUMBITS(1) [],
+        HOST_GNT_ERR OFFSET(11) NUMBITS(1) [],
+    ],
+    pub(crate) ERR_ADDR [
+        ERR_ADDR OFFSET(0) NUMBITS(20) [],
+    ],
+    pub(crate) ECC_SINGLE_ERR_CNT [
+        ECC_SINGLE_ERR_CNT_0 OFFSET(0) NUMBITS(8) [],
+        ECC_SINGLE_ERR_CNT_1 OFFSET(8) NUMBITS(8) [],
+    ],
+    pub(crate) ECC_SINGLE_ERR_ADDR [
+        ECC_SINGLE_ERR_ADDR_0 OFFSET(0) NUMBITS(20) [],
+    ],
+    pub(crate) PHY_ALERT_CFG [
+        ALERT_ACK OFFSET(0) NUMBITS(1) [],
+        ALERT_TRIG OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) PHY_STATUS [
+        INIT_WIP OFFSET(0) NUMBITS(1) [],
+        PROG_NORMAL_AVAIL OFFSET(1) NUMBITS(1) [],
+        PROG_REPAIR_AVAIL OFFSET(2) NUMBITS(1) [],
+    ],
+    pub(crate) SCRATCH [
+        DATA OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) FIFO_LVL [
+        PROG OFFSET(0) NUMBITS(5) [],
+        RD OFFSET(8) NUMBITS(5) [],
+    ],
+    pub(crate) FIFO_RST [
+        EN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CURR_FIFO_LVL [
+        PROG OFFSET(0) NUMBITS(5) [],
+        RD OFFSET(8) NUMBITS(5) [],
+    ],
+];
+
+// End generated register constants for flash_ctrl

--- a/chips/earlgrey/src/registers/mod.rs
+++ b/chips/earlgrey/src/registers/mod.rs
@@ -1,0 +1,13 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+pub mod alert_handler_regs;
+pub mod ast_regs;
+pub mod clkmgr_regs;
+pub mod flash_ctrl_regs;
+pub mod pinmux_regs;
+pub mod pwrmgr_regs;
+pub mod rstmgr_regs;
+pub mod rv_plic_regs;
+pub mod sensor_ctrl_regs;

--- a/chips/earlgrey/src/registers/pinmux_regs.rs
+++ b/chips/earlgrey/src/registers/pinmux_regs.rs
@@ -1,0 +1,250 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for pinmux.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Pad attribute data width
+pub const PINMUX_PARAM_ATTR_DW: u32 = 13;
+/// Number of muxed peripheral inputs
+pub const PINMUX_PARAM_N_MIO_PERIPH_IN: u32 = 57;
+/// Number of muxed peripheral outputs
+pub const PINMUX_PARAM_N_MIO_PERIPH_OUT: u32 = 75;
+/// Number of muxed IO pads
+pub const PINMUX_PARAM_N_MIO_PADS: u32 = 47;
+/// Number of dedicated IO pads
+pub const PINMUX_PARAM_N_DIO_PADS: u32 = 16;
+/// Number of wakeup detectors
+pub const PINMUX_PARAM_N_WKUP_DETECT: u32 = 8;
+/// Number of wakeup counter bits
+pub const PINMUX_PARAM_WKUP_CNT_WIDTH: u32 = 8;
+/// Number of alerts
+pub const PINMUX_PARAM_NUM_ALERTS: u32 = 1;
+/// Register width
+pub const PINMUX_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub PinmuxRegisters {
+        /// Alert Test Register
+        (0x0000 => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// Register write enable for MIO peripheral input selects.
+        (0x0004 => pub(crate) mio_periph_insel_regwen: [ReadWrite<u32, MIO_PERIPH_INSEL_REGWEN::Register>; 57]),
+        /// For each peripheral input, this selects the muxable pad input.
+        (0x00e8 => pub(crate) mio_periph_insel: [ReadWrite<u32, MIO_PERIPH_INSEL::Register>; 57]),
+        /// Register write enable for MIO output selects.
+        (0x01cc => pub(crate) mio_outsel_regwen: [ReadWrite<u32, MIO_OUTSEL_REGWEN::Register>; 47]),
+        /// For each muxable pad, this selects the peripheral output.
+        (0x0288 => pub(crate) mio_outsel: [ReadWrite<u32, MIO_OUTSEL::Register>; 47]),
+        /// Register write enable for MIO PAD attributes.
+        (0x0344 => pub(crate) mio_pad_attr_regwen: [ReadWrite<u32, MIO_PAD_ATTR_REGWEN::Register>; 47]),
+        /// Muxed pad attributes.
+        (0x0400 => pub(crate) mio_pad_attr: [ReadWrite<u32, MIO_PAD_ATTR::Register>; 47]),
+        /// Register write enable for DIO PAD attributes.
+        (0x04bc => pub(crate) dio_pad_attr_regwen: [ReadWrite<u32, DIO_PAD_ATTR_REGWEN::Register>; 16]),
+        /// Dedicated pad attributes.
+        (0x04fc => pub(crate) dio_pad_attr: [ReadWrite<u32, DIO_PAD_ATTR::Register>; 16]),
+        /// Register indicating whether the corresponding pad is in sleep mode.
+        (0x053c => pub(crate) mio_pad_sleep_status: [ReadWrite<u32, MIO_PAD_SLEEP_STATUS::Register>; 2]),
+        /// Register write enable for MIO sleep value configuration.
+        (0x0544 => pub(crate) mio_pad_sleep_regwen: [ReadWrite<u32, MIO_PAD_SLEEP_REGWEN::Register>; 47]),
+        /// Enables the sleep mode of the corresponding muxed pad.
+        (0x0600 => pub(crate) mio_pad_sleep_en: [ReadWrite<u32, MIO_PAD_SLEEP_EN::Register>; 47]),
+        /// Defines sleep behavior of the corresponding muxed pad.
+        (0x06bc => pub(crate) mio_pad_sleep_mode: [ReadWrite<u32, MIO_PAD_SLEEP_MODE::Register>; 47]),
+        /// Register indicating whether the corresponding pad is in sleep mode.
+        (0x0778 => pub(crate) dio_pad_sleep_status: [ReadWrite<u32, DIO_PAD_SLEEP_STATUS::Register>; 1]),
+        /// Register write enable for DIO sleep value configuration.
+        (0x077c => pub(crate) dio_pad_sleep_regwen: [ReadWrite<u32, DIO_PAD_SLEEP_REGWEN::Register>; 16]),
+        /// Enables the sleep mode of the corresponding dedicated pad.
+        (0x07bc => pub(crate) dio_pad_sleep_en: [ReadWrite<u32, DIO_PAD_SLEEP_EN::Register>; 16]),
+        /// Defines sleep behavior of the corresponding dedicated pad.
+        (0x07fc => pub(crate) dio_pad_sleep_mode: [ReadWrite<u32, DIO_PAD_SLEEP_MODE::Register>; 16]),
+        /// Register write enable for wakeup detectors.
+        (0x083c => pub(crate) wkup_detector_regwen: [ReadWrite<u32, WKUP_DETECTOR_REGWEN::Register>; 8]),
+        /// Enables for the wakeup detectors.
+        (0x085c => pub(crate) wkup_detector_en: [ReadWrite<u32, WKUP_DETECTOR_EN::Register>; 8]),
+        /// Configuration of wakeup condition detectors.
+        (0x087c => pub(crate) wkup_detector: [ReadWrite<u32, WKUP_DETECTOR::Register>; 8]),
+        /// Counter thresholds for wakeup condition detectors.
+        (0x089c => pub(crate) wkup_detector_cnt_th: [ReadWrite<u32, WKUP_DETECTOR_CNT_TH::Register>; 8]),
+        /// Pad selects for pad wakeup condition detectors.
+        (0x08bc => pub(crate) wkup_detector_padsel: [ReadWrite<u32, WKUP_DETECTOR_PADSEL::Register>; 8]),
+        /// Cause registers for wakeup detectors.
+        (0x08dc => pub(crate) wkup_cause: [ReadWrite<u32, WKUP_CAUSE::Register>; 1]),
+        (0x08e0 => @END),
+    }
+}
+
+register_bitfields![u32,
+    pub(crate) ALERT_TEST [
+        FATAL_FAULT OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) MIO_PERIPH_INSEL_REGWEN [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) MIO_PERIPH_INSEL [
+        IN_0 OFFSET(0) NUMBITS(6) [],
+    ],
+    pub(crate) MIO_OUTSEL_REGWEN [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) MIO_OUTSEL [
+        OUT_0 OFFSET(0) NUMBITS(7) [],
+    ],
+    pub(crate) MIO_PAD_ATTR_REGWEN [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) MIO_PAD_ATTR [
+        INVERT_0 OFFSET(0) NUMBITS(1) [],
+        VIRTUAL_OD_EN_0 OFFSET(1) NUMBITS(1) [],
+        PULL_EN_0 OFFSET(2) NUMBITS(1) [],
+        PULL_SELECT_0 OFFSET(3) NUMBITS(1) [
+            PULL_DOWN = 0,
+            PULL_UP = 1,
+        ],
+        KEEPER_EN_0 OFFSET(4) NUMBITS(1) [],
+        SCHMITT_EN_0 OFFSET(5) NUMBITS(1) [],
+        OD_EN_0 OFFSET(6) NUMBITS(1) [],
+        SLEW_RATE_0 OFFSET(16) NUMBITS(2) [],
+        DRIVE_STRENGTH_0 OFFSET(20) NUMBITS(4) [],
+    ],
+    pub(crate) DIO_PAD_ATTR_REGWEN [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) DIO_PAD_ATTR [
+        INVERT_0 OFFSET(0) NUMBITS(1) [],
+        VIRTUAL_OD_EN_0 OFFSET(1) NUMBITS(1) [],
+        PULL_EN_0 OFFSET(2) NUMBITS(1) [],
+        PULL_SELECT_0 OFFSET(3) NUMBITS(1) [
+            PULL_DOWN = 0,
+            PULL_UP = 1,
+        ],
+        KEEPER_EN_0 OFFSET(4) NUMBITS(1) [],
+        SCHMITT_EN_0 OFFSET(5) NUMBITS(1) [],
+        OD_EN_0 OFFSET(6) NUMBITS(1) [],
+        SLEW_RATE_0 OFFSET(16) NUMBITS(2) [],
+        DRIVE_STRENGTH_0 OFFSET(20) NUMBITS(4) [],
+    ],
+    pub(crate) MIO_PAD_SLEEP_STATUS [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+        EN_1 OFFSET(1) NUMBITS(1) [],
+        EN_2 OFFSET(2) NUMBITS(1) [],
+        EN_3 OFFSET(3) NUMBITS(1) [],
+        EN_4 OFFSET(4) NUMBITS(1) [],
+        EN_5 OFFSET(5) NUMBITS(1) [],
+        EN_6 OFFSET(6) NUMBITS(1) [],
+        EN_7 OFFSET(7) NUMBITS(1) [],
+        EN_8 OFFSET(8) NUMBITS(1) [],
+        EN_9 OFFSET(9) NUMBITS(1) [],
+        EN_10 OFFSET(10) NUMBITS(1) [],
+        EN_11 OFFSET(11) NUMBITS(1) [],
+        EN_12 OFFSET(12) NUMBITS(1) [],
+        EN_13 OFFSET(13) NUMBITS(1) [],
+        EN_14 OFFSET(14) NUMBITS(1) [],
+        EN_15 OFFSET(15) NUMBITS(1) [],
+        EN_16 OFFSET(16) NUMBITS(1) [],
+        EN_17 OFFSET(17) NUMBITS(1) [],
+        EN_18 OFFSET(18) NUMBITS(1) [],
+        EN_19 OFFSET(19) NUMBITS(1) [],
+        EN_20 OFFSET(20) NUMBITS(1) [],
+        EN_21 OFFSET(21) NUMBITS(1) [],
+        EN_22 OFFSET(22) NUMBITS(1) [],
+        EN_23 OFFSET(23) NUMBITS(1) [],
+        EN_24 OFFSET(24) NUMBITS(1) [],
+        EN_25 OFFSET(25) NUMBITS(1) [],
+        EN_26 OFFSET(26) NUMBITS(1) [],
+        EN_27 OFFSET(27) NUMBITS(1) [],
+        EN_28 OFFSET(28) NUMBITS(1) [],
+        EN_29 OFFSET(29) NUMBITS(1) [],
+        EN_30 OFFSET(30) NUMBITS(1) [],
+        EN_31 OFFSET(31) NUMBITS(1) [],
+    ],
+    pub(crate) MIO_PAD_SLEEP_REGWEN [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) MIO_PAD_SLEEP_EN [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) MIO_PAD_SLEEP_MODE [
+        OUT_0 OFFSET(0) NUMBITS(2) [
+            TIE_LOW = 0,
+            TIE_HIGH = 1,
+            HIGH_Z = 2,
+            KEEP = 3,
+        ],
+    ],
+    pub(crate) DIO_PAD_SLEEP_STATUS [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+        EN_1 OFFSET(1) NUMBITS(1) [],
+        EN_2 OFFSET(2) NUMBITS(1) [],
+        EN_3 OFFSET(3) NUMBITS(1) [],
+        EN_4 OFFSET(4) NUMBITS(1) [],
+        EN_5 OFFSET(5) NUMBITS(1) [],
+        EN_6 OFFSET(6) NUMBITS(1) [],
+        EN_7 OFFSET(7) NUMBITS(1) [],
+        EN_8 OFFSET(8) NUMBITS(1) [],
+        EN_9 OFFSET(9) NUMBITS(1) [],
+        EN_10 OFFSET(10) NUMBITS(1) [],
+        EN_11 OFFSET(11) NUMBITS(1) [],
+        EN_12 OFFSET(12) NUMBITS(1) [],
+        EN_13 OFFSET(13) NUMBITS(1) [],
+        EN_14 OFFSET(14) NUMBITS(1) [],
+        EN_15 OFFSET(15) NUMBITS(1) [],
+    ],
+    pub(crate) DIO_PAD_SLEEP_REGWEN [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) DIO_PAD_SLEEP_EN [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) DIO_PAD_SLEEP_MODE [
+        OUT_0 OFFSET(0) NUMBITS(2) [
+            TIE_LOW = 0,
+            TIE_HIGH = 1,
+            HIGH_Z = 2,
+            KEEP = 3,
+        ],
+    ],
+    pub(crate) WKUP_DETECTOR_REGWEN [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) WKUP_DETECTOR_EN [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) WKUP_DETECTOR [
+        MODE_0 OFFSET(0) NUMBITS(3) [
+            POSEDGE = 0,
+            NEGEDGE = 1,
+            EDGE = 2,
+            TIMEDHIGH = 3,
+            TIMEDLOW = 4,
+        ],
+        FILTER_0 OFFSET(3) NUMBITS(1) [],
+        MIODIO_0 OFFSET(4) NUMBITS(1) [],
+    ],
+    pub(crate) WKUP_DETECTOR_CNT_TH [
+        TH_0 OFFSET(0) NUMBITS(8) [],
+    ],
+    pub(crate) WKUP_DETECTOR_PADSEL [
+        SEL_0 OFFSET(0) NUMBITS(6) [],
+    ],
+    pub(crate) WKUP_CAUSE [
+        CAUSE_0 OFFSET(0) NUMBITS(1) [],
+        CAUSE_1 OFFSET(1) NUMBITS(1) [],
+        CAUSE_2 OFFSET(2) NUMBITS(1) [],
+        CAUSE_3 OFFSET(3) NUMBITS(1) [],
+        CAUSE_4 OFFSET(4) NUMBITS(1) [],
+        CAUSE_5 OFFSET(5) NUMBITS(1) [],
+        CAUSE_6 OFFSET(6) NUMBITS(1) [],
+        CAUSE_7 OFFSET(7) NUMBITS(1) [],
+    ],
+];
+
+// End generated register constants for pinmux

--- a/chips/earlgrey/src/registers/pwrmgr_regs.rs
+++ b/chips/earlgrey/src/registers/pwrmgr_regs.rs
@@ -1,0 +1,173 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for pwrmgr.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Number of wakeups
+pub const PWRMGR_PARAM_NUM_WKUPS: u32 = 6;
+/// Vector index for sysrst_ctrl_aon wkup_req, applies for WAKEUP_EN, WAKE_STATUS and WAKE_INFO
+pub const PWRMGR_PARAM_SYSRST_CTRL_AON_WKUP_REQ_IDX: u32 = 0;
+/// Vector index for adc_ctrl_aon wkup_req, applies for WAKEUP_EN, WAKE_STATUS and WAKE_INFO
+pub const PWRMGR_PARAM_ADC_CTRL_AON_WKUP_REQ_IDX: u32 = 1;
+/// Vector index for pinmux_aon pin_wkup_req, applies for WAKEUP_EN, WAKE_STATUS and WAKE_INFO
+pub const PWRMGR_PARAM_PINMUX_AON_PIN_WKUP_REQ_IDX: u32 = 2;
+/// Vector index for pinmux_aon usb_wkup_req, applies for WAKEUP_EN, WAKE_STATUS and WAKE_INFO
+pub const PWRMGR_PARAM_PINMUX_AON_USB_WKUP_REQ_IDX: u32 = 3;
+/// Vector index for aon_timer_aon wkup_req, applies for WAKEUP_EN, WAKE_STATUS and WAKE_INFO
+pub const PWRMGR_PARAM_AON_TIMER_AON_WKUP_REQ_IDX: u32 = 4;
+/// Vector index for sensor_ctrl wkup_req, applies for WAKEUP_EN, WAKE_STATUS and WAKE_INFO
+pub const PWRMGR_PARAM_SENSOR_CTRL_WKUP_REQ_IDX: u32 = 5;
+/// Number of peripheral reset requets
+pub const PWRMGR_PARAM_NUM_RST_REQS: u32 = 2;
+/// Number of pwrmgr internal reset requets
+pub const PWRMGR_PARAM_NUM_INT_RST_REQS: u32 = 2;
+/// Number of debug reset requets
+pub const PWRMGR_PARAM_NUM_DEBUG_RST_REQS: u32 = 1;
+/// Reset req idx for MainPwr
+pub const PWRMGR_PARAM_RESET_MAIN_PWR_IDX: u32 = 2;
+/// Reset req idx for Esc
+pub const PWRMGR_PARAM_RESET_ESC_IDX: u32 = 3;
+/// Reset req idx for Ndm
+pub const PWRMGR_PARAM_RESET_NDM_IDX: u32 = 4;
+/// Number of alerts
+pub const PWRMGR_PARAM_NUM_ALERTS: u32 = 1;
+/// Register width
+pub const PWRMGR_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub PwrmgrRegisters {
+        /// Interrupt State Register
+        (0x0000 => pub(crate) intr_state: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Enable Register
+        (0x0004 => pub(crate) intr_enable: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Test Register
+        (0x0008 => pub(crate) intr_test: ReadWrite<u32, INTR::Register>),
+        /// Alert Test Register
+        (0x000c => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// Controls the configurability of the !!CONTROL register.
+        (0x0010 => pub(crate) ctrl_cfg_regwen: ReadWrite<u32, CTRL_CFG_REGWEN::Register>),
+        /// Control register
+        (0x0014 => pub(crate) control: ReadWrite<u32, CONTROL::Register>),
+        /// The configuration registers CONTROL, WAKEUP_EN, RESET_EN are all written in the
+        (0x0018 => pub(crate) cfg_cdc_sync: ReadWrite<u32, CFG_CDC_SYNC::Register>),
+        /// Configuration enable for wakeup_en register
+        (0x001c => pub(crate) wakeup_en_regwen: ReadWrite<u32, WAKEUP_EN_REGWEN::Register>),
+        /// Bit mask for enabled wakeups
+        (0x0020 => pub(crate) wakeup_en: [ReadWrite<u32, WAKEUP_EN::Register>; 1]),
+        /// A read only register of all current wake requests post enable mask
+        (0x0024 => pub(crate) wake_status: [ReadWrite<u32, WAKE_STATUS::Register>; 1]),
+        /// Configuration enable for reset_en register
+        (0x0028 => pub(crate) reset_en_regwen: ReadWrite<u32, RESET_EN_REGWEN::Register>),
+        /// Bit mask for enabled reset requests
+        (0x002c => pub(crate) reset_en: [ReadWrite<u32, RESET_EN::Register>; 1]),
+        /// A read only register of all current reset requests post enable mask
+        (0x0030 => pub(crate) reset_status: [ReadWrite<u32, RESET_STATUS::Register>; 1]),
+        /// A read only register of escalation reset request
+        (0x0034 => pub(crate) escalate_reset_status: ReadWrite<u32, ESCALATE_RESET_STATUS::Register>),
+        /// Indicates which functions caused the chip to wakeup
+        (0x0038 => pub(crate) wake_info_capture_dis: ReadWrite<u32, WAKE_INFO_CAPTURE_DIS::Register>),
+        /// Indicates which functions caused the chip to wakeup.
+        (0x003c => pub(crate) wake_info: ReadWrite<u32, WAKE_INFO::Register>),
+        /// A read only register that shows the existing faults
+        (0x0040 => pub(crate) fault_status: ReadWrite<u32, FAULT_STATUS::Register>),
+        (0x0044 => @END),
+    }
+}
+
+register_bitfields![u32,
+    /// Common Interrupt Offsets
+    pub(crate) INTR [
+        WAKEUP OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) ALERT_TEST [
+        FATAL_FAULT OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CTRL_CFG_REGWEN [
+        EN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CONTROL [
+        LOW_POWER_HINT OFFSET(0) NUMBITS(1) [
+            NONE = 0,
+            LOW_POWER = 1,
+        ],
+        CORE_CLK_EN OFFSET(4) NUMBITS(1) [
+            DISABLED = 0,
+            ENABLED = 1,
+        ],
+        IO_CLK_EN OFFSET(5) NUMBITS(1) [
+            DISABLED = 0,
+            ENABLED = 1,
+        ],
+        USB_CLK_EN_LP OFFSET(6) NUMBITS(1) [
+            DISABLED = 0,
+            ENABLED = 1,
+        ],
+        USB_CLK_EN_ACTIVE OFFSET(7) NUMBITS(1) [
+            DISABLED = 0,
+            ENABLED = 1,
+        ],
+        MAIN_PD_N OFFSET(8) NUMBITS(1) [
+            POWER_DOWN = 0,
+            POWER_UP = 1,
+        ],
+    ],
+    pub(crate) CFG_CDC_SYNC [
+        SYNC OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) WAKEUP_EN_REGWEN [
+        EN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) WAKEUP_EN [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+        EN_1 OFFSET(1) NUMBITS(1) [],
+        EN_2 OFFSET(2) NUMBITS(1) [],
+        EN_3 OFFSET(3) NUMBITS(1) [],
+        EN_4 OFFSET(4) NUMBITS(1) [],
+        EN_5 OFFSET(5) NUMBITS(1) [],
+    ],
+    pub(crate) WAKE_STATUS [
+        VAL_0 OFFSET(0) NUMBITS(1) [],
+        VAL_1 OFFSET(1) NUMBITS(1) [],
+        VAL_2 OFFSET(2) NUMBITS(1) [],
+        VAL_3 OFFSET(3) NUMBITS(1) [],
+        VAL_4 OFFSET(4) NUMBITS(1) [],
+        VAL_5 OFFSET(5) NUMBITS(1) [],
+    ],
+    pub(crate) RESET_EN_REGWEN [
+        EN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) RESET_EN [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+        EN_1 OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) RESET_STATUS [
+        VAL_0 OFFSET(0) NUMBITS(1) [],
+        VAL_1 OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) ESCALATE_RESET_STATUS [
+        VAL OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) WAKE_INFO_CAPTURE_DIS [
+        VAL OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) WAKE_INFO [
+        REASONS OFFSET(0) NUMBITS(6) [],
+        FALL_THROUGH OFFSET(6) NUMBITS(1) [],
+        ABORT OFFSET(7) NUMBITS(1) [],
+    ],
+    pub(crate) FAULT_STATUS [
+        REG_INTG_ERR OFFSET(0) NUMBITS(1) [],
+        ESC_TIMEOUT OFFSET(1) NUMBITS(1) [],
+        MAIN_PD_GLITCH OFFSET(2) NUMBITS(1) [],
+    ],
+];
+
+// End generated register constants for pwrmgr

--- a/chips/earlgrey/src/registers/rstmgr_regs.rs
+++ b/chips/earlgrey/src/registers/rstmgr_regs.rs
@@ -1,0 +1,116 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for rstmgr.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Read width for crash info
+pub const RSTMGR_PARAM_RD_WIDTH: u32 = 32;
+/// Index width for crash info
+pub const RSTMGR_PARAM_IDX_WIDTH: u32 = 4;
+/// Number of hardware reset requests, inclusive of debug resets and pwrmgr's internal resets
+pub const RSTMGR_PARAM_NUM_HW_RESETS: u32 = 5;
+/// Number of software resets
+pub const RSTMGR_PARAM_NUM_SW_RESETS: u32 = 8;
+/// Number of total reset requests, inclusive of hw/sw, por and low power exit
+pub const RSTMGR_PARAM_NUM_TOTAL_RESETS: u32 = 8;
+/// Number of alerts
+pub const RSTMGR_PARAM_NUM_ALERTS: u32 = 2;
+/// Register width
+pub const RSTMGR_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub RstmgrRegisters {
+        /// Alert Test Register
+        (0x0000 => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// Software requested system reset.
+        (0x0004 => pub(crate) reset_req: ReadWrite<u32, RESET_REQ::Register>),
+        /// Device reset reason.
+        (0x0008 => pub(crate) reset_info: ReadWrite<u32, RESET_INFO::Register>),
+        /// Alert write enable
+        (0x000c => pub(crate) alert_regwen: ReadWrite<u32, ALERT_REGWEN::Register>),
+        /// Alert info dump controls.
+        (0x0010 => pub(crate) alert_info_ctrl: ReadWrite<u32, ALERT_INFO_CTRL::Register>),
+        /// Alert info dump attributes.
+        (0x0014 => pub(crate) alert_info_attr: ReadWrite<u32, ALERT_INFO_ATTR::Register>),
+        ///   Alert dump information prior to last reset.
+        (0x0018 => pub(crate) alert_info: ReadWrite<u32, ALERT_INFO::Register>),
+        /// Cpu write enable
+        (0x001c => pub(crate) cpu_regwen: ReadWrite<u32, CPU_REGWEN::Register>),
+        /// Cpu info dump controls.
+        (0x0020 => pub(crate) cpu_info_ctrl: ReadWrite<u32, CPU_INFO_CTRL::Register>),
+        /// Cpu info dump attributes.
+        (0x0024 => pub(crate) cpu_info_attr: ReadWrite<u32, CPU_INFO_ATTR::Register>),
+        ///   Cpu dump information prior to last reset.
+        (0x0028 => pub(crate) cpu_info: ReadWrite<u32, CPU_INFO::Register>),
+        /// Register write enable for software controllable resets.
+        (0x002c => pub(crate) sw_rst_regwen: [ReadWrite<u32, SW_RST_REGWEN::Register>; 8]),
+        /// Software controllable resets.
+        (0x004c => pub(crate) sw_rst_ctrl_n: [ReadWrite<u32, SW_RST_CTRL_N::Register>; 8]),
+        /// A bit vector of all the errors that have occurred in reset manager
+        (0x006c => pub(crate) err_code: ReadWrite<u32, ERR_CODE::Register>),
+        (0x0070 => @END),
+    }
+}
+
+register_bitfields![u32,
+    pub(crate) ALERT_TEST [
+        FATAL_FAULT OFFSET(0) NUMBITS(1) [],
+        FATAL_CNSTY_FAULT OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) RESET_REQ [
+        VAL OFFSET(0) NUMBITS(4) [],
+    ],
+    pub(crate) RESET_INFO [
+        POR OFFSET(0) NUMBITS(1) [],
+        LOW_POWER_EXIT OFFSET(1) NUMBITS(1) [],
+        SW_RESET OFFSET(2) NUMBITS(1) [],
+        HW_REQ OFFSET(3) NUMBITS(5) [],
+    ],
+    pub(crate) ALERT_REGWEN [
+        EN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) ALERT_INFO_CTRL [
+        EN OFFSET(0) NUMBITS(1) [],
+        INDEX OFFSET(4) NUMBITS(4) [],
+    ],
+    pub(crate) ALERT_INFO_ATTR [
+        CNT_AVAIL OFFSET(0) NUMBITS(4) [],
+    ],
+    pub(crate) ALERT_INFO [
+        VALUE OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) CPU_REGWEN [
+        EN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CPU_INFO_CTRL [
+        EN OFFSET(0) NUMBITS(1) [],
+        INDEX OFFSET(4) NUMBITS(4) [],
+    ],
+    pub(crate) CPU_INFO_ATTR [
+        CNT_AVAIL OFFSET(0) NUMBITS(4) [],
+    ],
+    pub(crate) CPU_INFO [
+        VALUE OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) SW_RST_REGWEN [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) SW_RST_CTRL_N [
+        VAL_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) ERR_CODE [
+        REG_INTG_ERR OFFSET(0) NUMBITS(1) [],
+        RESET_CONSISTENCY_ERR OFFSET(1) NUMBITS(1) [],
+        FSM_ERR OFFSET(2) NUMBITS(1) [],
+    ],
+];
+
+// End generated register constants for rstmgr

--- a/chips/earlgrey/src/registers/rv_plic_regs.rs
+++ b/chips/earlgrey/src/registers/rv_plic_regs.rs
@@ -1,0 +1,1056 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for rv_plic.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/top_earlgrey/ip_autogen/rv_plic/data/rv_plic.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Number of interrupt sources
+pub const RV_PLIC_PARAM_NUM_SRC: u32 = 185;
+/// Number of Targets (Harts)
+pub const RV_PLIC_PARAM_NUM_TARGET: u32 = 1;
+/// Width of priority signals
+pub const RV_PLIC_PARAM_PRIO_WIDTH: u32 = 2;
+/// Number of alerts
+pub const RV_PLIC_PARAM_NUM_ALERTS: u32 = 1;
+/// Register width
+pub const RV_PLIC_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub RvPlicRegisters {
+        /// Interrupt Source 0 Priority
+        (0x0000 => pub(crate) prio0: ReadWrite<u32, PRIO0::Register>),
+        /// Interrupt Source 1 Priority
+        (0x0004 => pub(crate) prio1: ReadWrite<u32, PRIO1::Register>),
+        /// Interrupt Source 2 Priority
+        (0x0008 => pub(crate) prio2: ReadWrite<u32, PRIO2::Register>),
+        /// Interrupt Source 3 Priority
+        (0x000c => pub(crate) prio3: ReadWrite<u32, PRIO3::Register>),
+        /// Interrupt Source 4 Priority
+        (0x0010 => pub(crate) prio4: ReadWrite<u32, PRIO4::Register>),
+        /// Interrupt Source 5 Priority
+        (0x0014 => pub(crate) prio5: ReadWrite<u32, PRIO5::Register>),
+        /// Interrupt Source 6 Priority
+        (0x0018 => pub(crate) prio6: ReadWrite<u32, PRIO6::Register>),
+        /// Interrupt Source 7 Priority
+        (0x001c => pub(crate) prio7: ReadWrite<u32, PRIO7::Register>),
+        /// Interrupt Source 8 Priority
+        (0x0020 => pub(crate) prio8: ReadWrite<u32, PRIO8::Register>),
+        /// Interrupt Source 9 Priority
+        (0x0024 => pub(crate) prio9: ReadWrite<u32, PRIO9::Register>),
+        /// Interrupt Source 10 Priority
+        (0x0028 => pub(crate) prio10: ReadWrite<u32, PRIO10::Register>),
+        /// Interrupt Source 11 Priority
+        (0x002c => pub(crate) prio11: ReadWrite<u32, PRIO11::Register>),
+        /// Interrupt Source 12 Priority
+        (0x0030 => pub(crate) prio12: ReadWrite<u32, PRIO12::Register>),
+        /// Interrupt Source 13 Priority
+        (0x0034 => pub(crate) prio13: ReadWrite<u32, PRIO13::Register>),
+        /// Interrupt Source 14 Priority
+        (0x0038 => pub(crate) prio14: ReadWrite<u32, PRIO14::Register>),
+        /// Interrupt Source 15 Priority
+        (0x003c => pub(crate) prio15: ReadWrite<u32, PRIO15::Register>),
+        /// Interrupt Source 16 Priority
+        (0x0040 => pub(crate) prio16: ReadWrite<u32, PRIO16::Register>),
+        /// Interrupt Source 17 Priority
+        (0x0044 => pub(crate) prio17: ReadWrite<u32, PRIO17::Register>),
+        /// Interrupt Source 18 Priority
+        (0x0048 => pub(crate) prio18: ReadWrite<u32, PRIO18::Register>),
+        /// Interrupt Source 19 Priority
+        (0x004c => pub(crate) prio19: ReadWrite<u32, PRIO19::Register>),
+        /// Interrupt Source 20 Priority
+        (0x0050 => pub(crate) prio20: ReadWrite<u32, PRIO20::Register>),
+        /// Interrupt Source 21 Priority
+        (0x0054 => pub(crate) prio21: ReadWrite<u32, PRIO21::Register>),
+        /// Interrupt Source 22 Priority
+        (0x0058 => pub(crate) prio22: ReadWrite<u32, PRIO22::Register>),
+        /// Interrupt Source 23 Priority
+        (0x005c => pub(crate) prio23: ReadWrite<u32, PRIO23::Register>),
+        /// Interrupt Source 24 Priority
+        (0x0060 => pub(crate) prio24: ReadWrite<u32, PRIO24::Register>),
+        /// Interrupt Source 25 Priority
+        (0x0064 => pub(crate) prio25: ReadWrite<u32, PRIO25::Register>),
+        /// Interrupt Source 26 Priority
+        (0x0068 => pub(crate) prio26: ReadWrite<u32, PRIO26::Register>),
+        /// Interrupt Source 27 Priority
+        (0x006c => pub(crate) prio27: ReadWrite<u32, PRIO27::Register>),
+        /// Interrupt Source 28 Priority
+        (0x0070 => pub(crate) prio28: ReadWrite<u32, PRIO28::Register>),
+        /// Interrupt Source 29 Priority
+        (0x0074 => pub(crate) prio29: ReadWrite<u32, PRIO29::Register>),
+        /// Interrupt Source 30 Priority
+        (0x0078 => pub(crate) prio30: ReadWrite<u32, PRIO30::Register>),
+        /// Interrupt Source 31 Priority
+        (0x007c => pub(crate) prio31: ReadWrite<u32, PRIO31::Register>),
+        /// Interrupt Source 32 Priority
+        (0x0080 => pub(crate) prio32: ReadWrite<u32, PRIO32::Register>),
+        /// Interrupt Source 33 Priority
+        (0x0084 => pub(crate) prio33: ReadWrite<u32, PRIO33::Register>),
+        /// Interrupt Source 34 Priority
+        (0x0088 => pub(crate) prio34: ReadWrite<u32, PRIO34::Register>),
+        /// Interrupt Source 35 Priority
+        (0x008c => pub(crate) prio35: ReadWrite<u32, PRIO35::Register>),
+        /// Interrupt Source 36 Priority
+        (0x0090 => pub(crate) prio36: ReadWrite<u32, PRIO36::Register>),
+        /// Interrupt Source 37 Priority
+        (0x0094 => pub(crate) prio37: ReadWrite<u32, PRIO37::Register>),
+        /// Interrupt Source 38 Priority
+        (0x0098 => pub(crate) prio38: ReadWrite<u32, PRIO38::Register>),
+        /// Interrupt Source 39 Priority
+        (0x009c => pub(crate) prio39: ReadWrite<u32, PRIO39::Register>),
+        /// Interrupt Source 40 Priority
+        (0x00a0 => pub(crate) prio40: ReadWrite<u32, PRIO40::Register>),
+        /// Interrupt Source 41 Priority
+        (0x00a4 => pub(crate) prio41: ReadWrite<u32, PRIO41::Register>),
+        /// Interrupt Source 42 Priority
+        (0x00a8 => pub(crate) prio42: ReadWrite<u32, PRIO42::Register>),
+        /// Interrupt Source 43 Priority
+        (0x00ac => pub(crate) prio43: ReadWrite<u32, PRIO43::Register>),
+        /// Interrupt Source 44 Priority
+        (0x00b0 => pub(crate) prio44: ReadWrite<u32, PRIO44::Register>),
+        /// Interrupt Source 45 Priority
+        (0x00b4 => pub(crate) prio45: ReadWrite<u32, PRIO45::Register>),
+        /// Interrupt Source 46 Priority
+        (0x00b8 => pub(crate) prio46: ReadWrite<u32, PRIO46::Register>),
+        /// Interrupt Source 47 Priority
+        (0x00bc => pub(crate) prio47: ReadWrite<u32, PRIO47::Register>),
+        /// Interrupt Source 48 Priority
+        (0x00c0 => pub(crate) prio48: ReadWrite<u32, PRIO48::Register>),
+        /// Interrupt Source 49 Priority
+        (0x00c4 => pub(crate) prio49: ReadWrite<u32, PRIO49::Register>),
+        /// Interrupt Source 50 Priority
+        (0x00c8 => pub(crate) prio50: ReadWrite<u32, PRIO50::Register>),
+        /// Interrupt Source 51 Priority
+        (0x00cc => pub(crate) prio51: ReadWrite<u32, PRIO51::Register>),
+        /// Interrupt Source 52 Priority
+        (0x00d0 => pub(crate) prio52: ReadWrite<u32, PRIO52::Register>),
+        /// Interrupt Source 53 Priority
+        (0x00d4 => pub(crate) prio53: ReadWrite<u32, PRIO53::Register>),
+        /// Interrupt Source 54 Priority
+        (0x00d8 => pub(crate) prio54: ReadWrite<u32, PRIO54::Register>),
+        /// Interrupt Source 55 Priority
+        (0x00dc => pub(crate) prio55: ReadWrite<u32, PRIO55::Register>),
+        /// Interrupt Source 56 Priority
+        (0x00e0 => pub(crate) prio56: ReadWrite<u32, PRIO56::Register>),
+        /// Interrupt Source 57 Priority
+        (0x00e4 => pub(crate) prio57: ReadWrite<u32, PRIO57::Register>),
+        /// Interrupt Source 58 Priority
+        (0x00e8 => pub(crate) prio58: ReadWrite<u32, PRIO58::Register>),
+        /// Interrupt Source 59 Priority
+        (0x00ec => pub(crate) prio59: ReadWrite<u32, PRIO59::Register>),
+        /// Interrupt Source 60 Priority
+        (0x00f0 => pub(crate) prio60: ReadWrite<u32, PRIO60::Register>),
+        /// Interrupt Source 61 Priority
+        (0x00f4 => pub(crate) prio61: ReadWrite<u32, PRIO61::Register>),
+        /// Interrupt Source 62 Priority
+        (0x00f8 => pub(crate) prio62: ReadWrite<u32, PRIO62::Register>),
+        /// Interrupt Source 63 Priority
+        (0x00fc => pub(crate) prio63: ReadWrite<u32, PRIO63::Register>),
+        /// Interrupt Source 64 Priority
+        (0x0100 => pub(crate) prio64: ReadWrite<u32, PRIO64::Register>),
+        /// Interrupt Source 65 Priority
+        (0x0104 => pub(crate) prio65: ReadWrite<u32, PRIO65::Register>),
+        /// Interrupt Source 66 Priority
+        (0x0108 => pub(crate) prio66: ReadWrite<u32, PRIO66::Register>),
+        /// Interrupt Source 67 Priority
+        (0x010c => pub(crate) prio67: ReadWrite<u32, PRIO67::Register>),
+        /// Interrupt Source 68 Priority
+        (0x0110 => pub(crate) prio68: ReadWrite<u32, PRIO68::Register>),
+        /// Interrupt Source 69 Priority
+        (0x0114 => pub(crate) prio69: ReadWrite<u32, PRIO69::Register>),
+        /// Interrupt Source 70 Priority
+        (0x0118 => pub(crate) prio70: ReadWrite<u32, PRIO70::Register>),
+        /// Interrupt Source 71 Priority
+        (0x011c => pub(crate) prio71: ReadWrite<u32, PRIO71::Register>),
+        /// Interrupt Source 72 Priority
+        (0x0120 => pub(crate) prio72: ReadWrite<u32, PRIO72::Register>),
+        /// Interrupt Source 73 Priority
+        (0x0124 => pub(crate) prio73: ReadWrite<u32, PRIO73::Register>),
+        /// Interrupt Source 74 Priority
+        (0x0128 => pub(crate) prio74: ReadWrite<u32, PRIO74::Register>),
+        /// Interrupt Source 75 Priority
+        (0x012c => pub(crate) prio75: ReadWrite<u32, PRIO75::Register>),
+        /// Interrupt Source 76 Priority
+        (0x0130 => pub(crate) prio76: ReadWrite<u32, PRIO76::Register>),
+        /// Interrupt Source 77 Priority
+        (0x0134 => pub(crate) prio77: ReadWrite<u32, PRIO77::Register>),
+        /// Interrupt Source 78 Priority
+        (0x0138 => pub(crate) prio78: ReadWrite<u32, PRIO78::Register>),
+        /// Interrupt Source 79 Priority
+        (0x013c => pub(crate) prio79: ReadWrite<u32, PRIO79::Register>),
+        /// Interrupt Source 80 Priority
+        (0x0140 => pub(crate) prio80: ReadWrite<u32, PRIO80::Register>),
+        /// Interrupt Source 81 Priority
+        (0x0144 => pub(crate) prio81: ReadWrite<u32, PRIO81::Register>),
+        /// Interrupt Source 82 Priority
+        (0x0148 => pub(crate) prio82: ReadWrite<u32, PRIO82::Register>),
+        /// Interrupt Source 83 Priority
+        (0x014c => pub(crate) prio83: ReadWrite<u32, PRIO83::Register>),
+        /// Interrupt Source 84 Priority
+        (0x0150 => pub(crate) prio84: ReadWrite<u32, PRIO84::Register>),
+        /// Interrupt Source 85 Priority
+        (0x0154 => pub(crate) prio85: ReadWrite<u32, PRIO85::Register>),
+        /// Interrupt Source 86 Priority
+        (0x0158 => pub(crate) prio86: ReadWrite<u32, PRIO86::Register>),
+        /// Interrupt Source 87 Priority
+        (0x015c => pub(crate) prio87: ReadWrite<u32, PRIO87::Register>),
+        /// Interrupt Source 88 Priority
+        (0x0160 => pub(crate) prio88: ReadWrite<u32, PRIO88::Register>),
+        /// Interrupt Source 89 Priority
+        (0x0164 => pub(crate) prio89: ReadWrite<u32, PRIO89::Register>),
+        /// Interrupt Source 90 Priority
+        (0x0168 => pub(crate) prio90: ReadWrite<u32, PRIO90::Register>),
+        /// Interrupt Source 91 Priority
+        (0x016c => pub(crate) prio91: ReadWrite<u32, PRIO91::Register>),
+        /// Interrupt Source 92 Priority
+        (0x0170 => pub(crate) prio92: ReadWrite<u32, PRIO92::Register>),
+        /// Interrupt Source 93 Priority
+        (0x0174 => pub(crate) prio93: ReadWrite<u32, PRIO93::Register>),
+        /// Interrupt Source 94 Priority
+        (0x0178 => pub(crate) prio94: ReadWrite<u32, PRIO94::Register>),
+        /// Interrupt Source 95 Priority
+        (0x017c => pub(crate) prio95: ReadWrite<u32, PRIO95::Register>),
+        /// Interrupt Source 96 Priority
+        (0x0180 => pub(crate) prio96: ReadWrite<u32, PRIO96::Register>),
+        /// Interrupt Source 97 Priority
+        (0x0184 => pub(crate) prio97: ReadWrite<u32, PRIO97::Register>),
+        /// Interrupt Source 98 Priority
+        (0x0188 => pub(crate) prio98: ReadWrite<u32, PRIO98::Register>),
+        /// Interrupt Source 99 Priority
+        (0x018c => pub(crate) prio99: ReadWrite<u32, PRIO99::Register>),
+        /// Interrupt Source 100 Priority
+        (0x0190 => pub(crate) prio100: ReadWrite<u32, PRIO100::Register>),
+        /// Interrupt Source 101 Priority
+        (0x0194 => pub(crate) prio101: ReadWrite<u32, PRIO101::Register>),
+        /// Interrupt Source 102 Priority
+        (0x0198 => pub(crate) prio102: ReadWrite<u32, PRIO102::Register>),
+        /// Interrupt Source 103 Priority
+        (0x019c => pub(crate) prio103: ReadWrite<u32, PRIO103::Register>),
+        /// Interrupt Source 104 Priority
+        (0x01a0 => pub(crate) prio104: ReadWrite<u32, PRIO104::Register>),
+        /// Interrupt Source 105 Priority
+        (0x01a4 => pub(crate) prio105: ReadWrite<u32, PRIO105::Register>),
+        /// Interrupt Source 106 Priority
+        (0x01a8 => pub(crate) prio106: ReadWrite<u32, PRIO106::Register>),
+        /// Interrupt Source 107 Priority
+        (0x01ac => pub(crate) prio107: ReadWrite<u32, PRIO107::Register>),
+        /// Interrupt Source 108 Priority
+        (0x01b0 => pub(crate) prio108: ReadWrite<u32, PRIO108::Register>),
+        /// Interrupt Source 109 Priority
+        (0x01b4 => pub(crate) prio109: ReadWrite<u32, PRIO109::Register>),
+        /// Interrupt Source 110 Priority
+        (0x01b8 => pub(crate) prio110: ReadWrite<u32, PRIO110::Register>),
+        /// Interrupt Source 111 Priority
+        (0x01bc => pub(crate) prio111: ReadWrite<u32, PRIO111::Register>),
+        /// Interrupt Source 112 Priority
+        (0x01c0 => pub(crate) prio112: ReadWrite<u32, PRIO112::Register>),
+        /// Interrupt Source 113 Priority
+        (0x01c4 => pub(crate) prio113: ReadWrite<u32, PRIO113::Register>),
+        /// Interrupt Source 114 Priority
+        (0x01c8 => pub(crate) prio114: ReadWrite<u32, PRIO114::Register>),
+        /// Interrupt Source 115 Priority
+        (0x01cc => pub(crate) prio115: ReadWrite<u32, PRIO115::Register>),
+        /// Interrupt Source 116 Priority
+        (0x01d0 => pub(crate) prio116: ReadWrite<u32, PRIO116::Register>),
+        /// Interrupt Source 117 Priority
+        (0x01d4 => pub(crate) prio117: ReadWrite<u32, PRIO117::Register>),
+        /// Interrupt Source 118 Priority
+        (0x01d8 => pub(crate) prio118: ReadWrite<u32, PRIO118::Register>),
+        /// Interrupt Source 119 Priority
+        (0x01dc => pub(crate) prio119: ReadWrite<u32, PRIO119::Register>),
+        /// Interrupt Source 120 Priority
+        (0x01e0 => pub(crate) prio120: ReadWrite<u32, PRIO120::Register>),
+        /// Interrupt Source 121 Priority
+        (0x01e4 => pub(crate) prio121: ReadWrite<u32, PRIO121::Register>),
+        /// Interrupt Source 122 Priority
+        (0x01e8 => pub(crate) prio122: ReadWrite<u32, PRIO122::Register>),
+        /// Interrupt Source 123 Priority
+        (0x01ec => pub(crate) prio123: ReadWrite<u32, PRIO123::Register>),
+        /// Interrupt Source 124 Priority
+        (0x01f0 => pub(crate) prio124: ReadWrite<u32, PRIO124::Register>),
+        /// Interrupt Source 125 Priority
+        (0x01f4 => pub(crate) prio125: ReadWrite<u32, PRIO125::Register>),
+        /// Interrupt Source 126 Priority
+        (0x01f8 => pub(crate) prio126: ReadWrite<u32, PRIO126::Register>),
+        /// Interrupt Source 127 Priority
+        (0x01fc => pub(crate) prio127: ReadWrite<u32, PRIO127::Register>),
+        /// Interrupt Source 128 Priority
+        (0x0200 => pub(crate) prio128: ReadWrite<u32, PRIO128::Register>),
+        /// Interrupt Source 129 Priority
+        (0x0204 => pub(crate) prio129: ReadWrite<u32, PRIO129::Register>),
+        /// Interrupt Source 130 Priority
+        (0x0208 => pub(crate) prio130: ReadWrite<u32, PRIO130::Register>),
+        /// Interrupt Source 131 Priority
+        (0x020c => pub(crate) prio131: ReadWrite<u32, PRIO131::Register>),
+        /// Interrupt Source 132 Priority
+        (0x0210 => pub(crate) prio132: ReadWrite<u32, PRIO132::Register>),
+        /// Interrupt Source 133 Priority
+        (0x0214 => pub(crate) prio133: ReadWrite<u32, PRIO133::Register>),
+        /// Interrupt Source 134 Priority
+        (0x0218 => pub(crate) prio134: ReadWrite<u32, PRIO134::Register>),
+        /// Interrupt Source 135 Priority
+        (0x021c => pub(crate) prio135: ReadWrite<u32, PRIO135::Register>),
+        /// Interrupt Source 136 Priority
+        (0x0220 => pub(crate) prio136: ReadWrite<u32, PRIO136::Register>),
+        /// Interrupt Source 137 Priority
+        (0x0224 => pub(crate) prio137: ReadWrite<u32, PRIO137::Register>),
+        /// Interrupt Source 138 Priority
+        (0x0228 => pub(crate) prio138: ReadWrite<u32, PRIO138::Register>),
+        /// Interrupt Source 139 Priority
+        (0x022c => pub(crate) prio139: ReadWrite<u32, PRIO139::Register>),
+        /// Interrupt Source 140 Priority
+        (0x0230 => pub(crate) prio140: ReadWrite<u32, PRIO140::Register>),
+        /// Interrupt Source 141 Priority
+        (0x0234 => pub(crate) prio141: ReadWrite<u32, PRIO141::Register>),
+        /// Interrupt Source 142 Priority
+        (0x0238 => pub(crate) prio142: ReadWrite<u32, PRIO142::Register>),
+        /// Interrupt Source 143 Priority
+        (0x023c => pub(crate) prio143: ReadWrite<u32, PRIO143::Register>),
+        /// Interrupt Source 144 Priority
+        (0x0240 => pub(crate) prio144: ReadWrite<u32, PRIO144::Register>),
+        /// Interrupt Source 145 Priority
+        (0x0244 => pub(crate) prio145: ReadWrite<u32, PRIO145::Register>),
+        /// Interrupt Source 146 Priority
+        (0x0248 => pub(crate) prio146: ReadWrite<u32, PRIO146::Register>),
+        /// Interrupt Source 147 Priority
+        (0x024c => pub(crate) prio147: ReadWrite<u32, PRIO147::Register>),
+        /// Interrupt Source 148 Priority
+        (0x0250 => pub(crate) prio148: ReadWrite<u32, PRIO148::Register>),
+        /// Interrupt Source 149 Priority
+        (0x0254 => pub(crate) prio149: ReadWrite<u32, PRIO149::Register>),
+        /// Interrupt Source 150 Priority
+        (0x0258 => pub(crate) prio150: ReadWrite<u32, PRIO150::Register>),
+        /// Interrupt Source 151 Priority
+        (0x025c => pub(crate) prio151: ReadWrite<u32, PRIO151::Register>),
+        /// Interrupt Source 152 Priority
+        (0x0260 => pub(crate) prio152: ReadWrite<u32, PRIO152::Register>),
+        /// Interrupt Source 153 Priority
+        (0x0264 => pub(crate) prio153: ReadWrite<u32, PRIO153::Register>),
+        /// Interrupt Source 154 Priority
+        (0x0268 => pub(crate) prio154: ReadWrite<u32, PRIO154::Register>),
+        /// Interrupt Source 155 Priority
+        (0x026c => pub(crate) prio155: ReadWrite<u32, PRIO155::Register>),
+        /// Interrupt Source 156 Priority
+        (0x0270 => pub(crate) prio156: ReadWrite<u32, PRIO156::Register>),
+        /// Interrupt Source 157 Priority
+        (0x0274 => pub(crate) prio157: ReadWrite<u32, PRIO157::Register>),
+        /// Interrupt Source 158 Priority
+        (0x0278 => pub(crate) prio158: ReadWrite<u32, PRIO158::Register>),
+        /// Interrupt Source 159 Priority
+        (0x027c => pub(crate) prio159: ReadWrite<u32, PRIO159::Register>),
+        /// Interrupt Source 160 Priority
+        (0x0280 => pub(crate) prio160: ReadWrite<u32, PRIO160::Register>),
+        /// Interrupt Source 161 Priority
+        (0x0284 => pub(crate) prio161: ReadWrite<u32, PRIO161::Register>),
+        /// Interrupt Source 162 Priority
+        (0x0288 => pub(crate) prio162: ReadWrite<u32, PRIO162::Register>),
+        /// Interrupt Source 163 Priority
+        (0x028c => pub(crate) prio163: ReadWrite<u32, PRIO163::Register>),
+        /// Interrupt Source 164 Priority
+        (0x0290 => pub(crate) prio164: ReadWrite<u32, PRIO164::Register>),
+        /// Interrupt Source 165 Priority
+        (0x0294 => pub(crate) prio165: ReadWrite<u32, PRIO165::Register>),
+        /// Interrupt Source 166 Priority
+        (0x0298 => pub(crate) prio166: ReadWrite<u32, PRIO166::Register>),
+        /// Interrupt Source 167 Priority
+        (0x029c => pub(crate) prio167: ReadWrite<u32, PRIO167::Register>),
+        /// Interrupt Source 168 Priority
+        (0x02a0 => pub(crate) prio168: ReadWrite<u32, PRIO168::Register>),
+        /// Interrupt Source 169 Priority
+        (0x02a4 => pub(crate) prio169: ReadWrite<u32, PRIO169::Register>),
+        /// Interrupt Source 170 Priority
+        (0x02a8 => pub(crate) prio170: ReadWrite<u32, PRIO170::Register>),
+        /// Interrupt Source 171 Priority
+        (0x02ac => pub(crate) prio171: ReadWrite<u32, PRIO171::Register>),
+        /// Interrupt Source 172 Priority
+        (0x02b0 => pub(crate) prio172: ReadWrite<u32, PRIO172::Register>),
+        /// Interrupt Source 173 Priority
+        (0x02b4 => pub(crate) prio173: ReadWrite<u32, PRIO173::Register>),
+        /// Interrupt Source 174 Priority
+        (0x02b8 => pub(crate) prio174: ReadWrite<u32, PRIO174::Register>),
+        /// Interrupt Source 175 Priority
+        (0x02bc => pub(crate) prio175: ReadWrite<u32, PRIO175::Register>),
+        /// Interrupt Source 176 Priority
+        (0x02c0 => pub(crate) prio176: ReadWrite<u32, PRIO176::Register>),
+        /// Interrupt Source 177 Priority
+        (0x02c4 => pub(crate) prio177: ReadWrite<u32, PRIO177::Register>),
+        /// Interrupt Source 178 Priority
+        (0x02c8 => pub(crate) prio178: ReadWrite<u32, PRIO178::Register>),
+        /// Interrupt Source 179 Priority
+        (0x02cc => pub(crate) prio179: ReadWrite<u32, PRIO179::Register>),
+        /// Interrupt Source 180 Priority
+        (0x02d0 => pub(crate) prio180: ReadWrite<u32, PRIO180::Register>),
+        /// Interrupt Source 181 Priority
+        (0x02d4 => pub(crate) prio181: ReadWrite<u32, PRIO181::Register>),
+        /// Interrupt Source 182 Priority
+        (0x02d8 => pub(crate) prio182: ReadWrite<u32, PRIO182::Register>),
+        /// Interrupt Source 183 Priority
+        (0x02dc => pub(crate) prio183: ReadWrite<u32, PRIO183::Register>),
+        /// Interrupt Source 184 Priority
+        (0x02e0 => pub(crate) prio184: ReadWrite<u32, PRIO184::Register>),
+        (0x02e4 => _reserved1),
+        /// Interrupt Pending
+        (0x1000 => pub(crate) ip: [ReadWrite<u32, IP::Register>; 6]),
+        (0x1018 => _reserved2),
+        /// Interrupt Enable for Target 0
+        (0x2000 => pub(crate) ie0: [ReadWrite<u32, IE0::Register>; 6]),
+        (0x2018 => _reserved3),
+        /// Threshold of priority for Target 0
+        (0x200000 => pub(crate) threshold0: ReadWrite<u32, THRESHOLD0::Register>),
+        /// Claim interrupt by read, complete interrupt by write for Target 0.
+        (0x200004 => pub(crate) cc0: ReadWrite<u32, CC0::Register>),
+        (0x200008 => _reserved4),
+        /// msip for Hart 0.
+        (0x4000000 => pub(crate) msip0: ReadWrite<u32, MSIP0::Register>),
+        (0x4000004 => _reserved5),
+        /// Alert Test Register.
+        (0x4004000 => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        (0x4004004 => @END),
+    }
+}
+
+register_bitfields![u32,
+    pub(crate) PRIO0 [
+        PRIO0 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO1 [
+        PRIO1 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO2 [
+        PRIO2 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO3 [
+        PRIO3 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO4 [
+        PRIO4 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO5 [
+        PRIO5 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO6 [
+        PRIO6 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO7 [
+        PRIO7 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO8 [
+        PRIO8 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO9 [
+        PRIO9 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO10 [
+        PRIO10 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO11 [
+        PRIO11 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO12 [
+        PRIO12 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO13 [
+        PRIO13 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO14 [
+        PRIO14 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO15 [
+        PRIO15 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO16 [
+        PRIO16 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO17 [
+        PRIO17 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO18 [
+        PRIO18 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO19 [
+        PRIO19 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO20 [
+        PRIO20 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO21 [
+        PRIO21 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO22 [
+        PRIO22 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO23 [
+        PRIO23 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO24 [
+        PRIO24 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO25 [
+        PRIO25 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO26 [
+        PRIO26 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO27 [
+        PRIO27 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO28 [
+        PRIO28 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO29 [
+        PRIO29 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO30 [
+        PRIO30 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO31 [
+        PRIO31 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO32 [
+        PRIO32 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO33 [
+        PRIO33 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO34 [
+        PRIO34 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO35 [
+        PRIO35 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO36 [
+        PRIO36 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO37 [
+        PRIO37 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO38 [
+        PRIO38 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO39 [
+        PRIO39 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO40 [
+        PRIO40 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO41 [
+        PRIO41 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO42 [
+        PRIO42 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO43 [
+        PRIO43 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO44 [
+        PRIO44 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO45 [
+        PRIO45 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO46 [
+        PRIO46 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO47 [
+        PRIO47 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO48 [
+        PRIO48 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO49 [
+        PRIO49 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO50 [
+        PRIO50 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO51 [
+        PRIO51 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO52 [
+        PRIO52 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO53 [
+        PRIO53 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO54 [
+        PRIO54 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO55 [
+        PRIO55 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO56 [
+        PRIO56 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO57 [
+        PRIO57 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO58 [
+        PRIO58 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO59 [
+        PRIO59 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO60 [
+        PRIO60 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO61 [
+        PRIO61 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO62 [
+        PRIO62 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO63 [
+        PRIO63 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO64 [
+        PRIO64 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO65 [
+        PRIO65 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO66 [
+        PRIO66 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO67 [
+        PRIO67 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO68 [
+        PRIO68 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO69 [
+        PRIO69 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO70 [
+        PRIO70 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO71 [
+        PRIO71 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO72 [
+        PRIO72 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO73 [
+        PRIO73 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO74 [
+        PRIO74 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO75 [
+        PRIO75 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO76 [
+        PRIO76 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO77 [
+        PRIO77 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO78 [
+        PRIO78 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO79 [
+        PRIO79 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO80 [
+        PRIO80 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO81 [
+        PRIO81 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO82 [
+        PRIO82 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO83 [
+        PRIO83 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO84 [
+        PRIO84 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO85 [
+        PRIO85 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO86 [
+        PRIO86 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO87 [
+        PRIO87 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO88 [
+        PRIO88 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO89 [
+        PRIO89 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO90 [
+        PRIO90 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO91 [
+        PRIO91 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO92 [
+        PRIO92 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO93 [
+        PRIO93 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO94 [
+        PRIO94 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO95 [
+        PRIO95 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO96 [
+        PRIO96 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO97 [
+        PRIO97 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO98 [
+        PRIO98 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO99 [
+        PRIO99 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO100 [
+        PRIO100 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO101 [
+        PRIO101 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO102 [
+        PRIO102 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO103 [
+        PRIO103 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO104 [
+        PRIO104 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO105 [
+        PRIO105 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO106 [
+        PRIO106 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO107 [
+        PRIO107 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO108 [
+        PRIO108 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO109 [
+        PRIO109 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO110 [
+        PRIO110 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO111 [
+        PRIO111 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO112 [
+        PRIO112 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO113 [
+        PRIO113 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO114 [
+        PRIO114 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO115 [
+        PRIO115 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO116 [
+        PRIO116 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO117 [
+        PRIO117 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO118 [
+        PRIO118 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO119 [
+        PRIO119 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO120 [
+        PRIO120 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO121 [
+        PRIO121 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO122 [
+        PRIO122 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO123 [
+        PRIO123 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO124 [
+        PRIO124 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO125 [
+        PRIO125 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO126 [
+        PRIO126 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO127 [
+        PRIO127 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO128 [
+        PRIO128 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO129 [
+        PRIO129 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO130 [
+        PRIO130 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO131 [
+        PRIO131 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO132 [
+        PRIO132 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO133 [
+        PRIO133 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO134 [
+        PRIO134 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO135 [
+        PRIO135 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO136 [
+        PRIO136 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO137 [
+        PRIO137 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO138 [
+        PRIO138 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO139 [
+        PRIO139 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO140 [
+        PRIO140 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO141 [
+        PRIO141 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO142 [
+        PRIO142 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO143 [
+        PRIO143 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO144 [
+        PRIO144 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO145 [
+        PRIO145 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO146 [
+        PRIO146 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO147 [
+        PRIO147 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO148 [
+        PRIO148 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO149 [
+        PRIO149 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO150 [
+        PRIO150 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO151 [
+        PRIO151 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO152 [
+        PRIO152 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO153 [
+        PRIO153 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO154 [
+        PRIO154 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO155 [
+        PRIO155 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO156 [
+        PRIO156 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO157 [
+        PRIO157 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO158 [
+        PRIO158 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO159 [
+        PRIO159 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO160 [
+        PRIO160 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO161 [
+        PRIO161 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO162 [
+        PRIO162 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO163 [
+        PRIO163 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO164 [
+        PRIO164 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO165 [
+        PRIO165 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO166 [
+        PRIO166 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO167 [
+        PRIO167 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO168 [
+        PRIO168 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO169 [
+        PRIO169 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO170 [
+        PRIO170 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO171 [
+        PRIO171 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO172 [
+        PRIO172 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO173 [
+        PRIO173 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO174 [
+        PRIO174 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO175 [
+        PRIO175 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO176 [
+        PRIO176 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO177 [
+        PRIO177 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO178 [
+        PRIO178 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO179 [
+        PRIO179 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO180 [
+        PRIO180 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO181 [
+        PRIO181 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO182 [
+        PRIO182 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO183 [
+        PRIO183 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) PRIO184 [
+        PRIO184 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) IP [
+        P_0 OFFSET(0) NUMBITS(1) [],
+        P_1 OFFSET(1) NUMBITS(1) [],
+        P_2 OFFSET(2) NUMBITS(1) [],
+        P_3 OFFSET(3) NUMBITS(1) [],
+        P_4 OFFSET(4) NUMBITS(1) [],
+        P_5 OFFSET(5) NUMBITS(1) [],
+        P_6 OFFSET(6) NUMBITS(1) [],
+        P_7 OFFSET(7) NUMBITS(1) [],
+        P_8 OFFSET(8) NUMBITS(1) [],
+        P_9 OFFSET(9) NUMBITS(1) [],
+        P_10 OFFSET(10) NUMBITS(1) [],
+        P_11 OFFSET(11) NUMBITS(1) [],
+        P_12 OFFSET(12) NUMBITS(1) [],
+        P_13 OFFSET(13) NUMBITS(1) [],
+        P_14 OFFSET(14) NUMBITS(1) [],
+        P_15 OFFSET(15) NUMBITS(1) [],
+        P_16 OFFSET(16) NUMBITS(1) [],
+        P_17 OFFSET(17) NUMBITS(1) [],
+        P_18 OFFSET(18) NUMBITS(1) [],
+        P_19 OFFSET(19) NUMBITS(1) [],
+        P_20 OFFSET(20) NUMBITS(1) [],
+        P_21 OFFSET(21) NUMBITS(1) [],
+        P_22 OFFSET(22) NUMBITS(1) [],
+        P_23 OFFSET(23) NUMBITS(1) [],
+        P_24 OFFSET(24) NUMBITS(1) [],
+        P_25 OFFSET(25) NUMBITS(1) [],
+        P_26 OFFSET(26) NUMBITS(1) [],
+        P_27 OFFSET(27) NUMBITS(1) [],
+        P_28 OFFSET(28) NUMBITS(1) [],
+        P_29 OFFSET(29) NUMBITS(1) [],
+        P_30 OFFSET(30) NUMBITS(1) [],
+        P_31 OFFSET(31) NUMBITS(1) [],
+    ],
+    pub(crate) IE0 [
+        E_0 OFFSET(0) NUMBITS(1) [],
+        E_1 OFFSET(1) NUMBITS(1) [],
+        E_2 OFFSET(2) NUMBITS(1) [],
+        E_3 OFFSET(3) NUMBITS(1) [],
+        E_4 OFFSET(4) NUMBITS(1) [],
+        E_5 OFFSET(5) NUMBITS(1) [],
+        E_6 OFFSET(6) NUMBITS(1) [],
+        E_7 OFFSET(7) NUMBITS(1) [],
+        E_8 OFFSET(8) NUMBITS(1) [],
+        E_9 OFFSET(9) NUMBITS(1) [],
+        E_10 OFFSET(10) NUMBITS(1) [],
+        E_11 OFFSET(11) NUMBITS(1) [],
+        E_12 OFFSET(12) NUMBITS(1) [],
+        E_13 OFFSET(13) NUMBITS(1) [],
+        E_14 OFFSET(14) NUMBITS(1) [],
+        E_15 OFFSET(15) NUMBITS(1) [],
+        E_16 OFFSET(16) NUMBITS(1) [],
+        E_17 OFFSET(17) NUMBITS(1) [],
+        E_18 OFFSET(18) NUMBITS(1) [],
+        E_19 OFFSET(19) NUMBITS(1) [],
+        E_20 OFFSET(20) NUMBITS(1) [],
+        E_21 OFFSET(21) NUMBITS(1) [],
+        E_22 OFFSET(22) NUMBITS(1) [],
+        E_23 OFFSET(23) NUMBITS(1) [],
+        E_24 OFFSET(24) NUMBITS(1) [],
+        E_25 OFFSET(25) NUMBITS(1) [],
+        E_26 OFFSET(26) NUMBITS(1) [],
+        E_27 OFFSET(27) NUMBITS(1) [],
+        E_28 OFFSET(28) NUMBITS(1) [],
+        E_29 OFFSET(29) NUMBITS(1) [],
+        E_30 OFFSET(30) NUMBITS(1) [],
+        E_31 OFFSET(31) NUMBITS(1) [],
+    ],
+    pub(crate) THRESHOLD0 [
+        THRESHOLD0 OFFSET(0) NUMBITS(2) [],
+    ],
+    pub(crate) CC0 [
+        CC0 OFFSET(0) NUMBITS(8) [],
+    ],
+    pub(crate) MSIP0 [
+        MSIP0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) ALERT_TEST [
+        FATAL_FAULT OFFSET(0) NUMBITS(1) [],
+    ],
+];
+
+// End generated register constants for rv_plic

--- a/chips/earlgrey/src/registers/sensor_ctrl_regs.rs
+++ b/chips/earlgrey/src/registers/sensor_ctrl_regs.rs
@@ -1,0 +1,123 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for sensor_ctrl.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/top_earlgrey/ip/sensor_ctrl/data/sensor_ctrl.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Number of alert events from ast
+pub const SENSOR_CTRL_PARAM_NUM_ALERT_EVENTS: u32 = 11;
+/// Number of local events
+pub const SENSOR_CTRL_PARAM_NUM_LOCAL_EVENTS: u32 = 1;
+/// Number of alerts sent from sensor control
+pub const SENSOR_CTRL_PARAM_NUM_ALERTS: u32 = 2;
+/// Number of IO rails
+pub const SENSOR_CTRL_PARAM_NUM_IO_RAILS: u32 = 2;
+/// Register width
+pub const SENSOR_CTRL_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub SensorCtrlRegisters {
+        /// Interrupt State Register
+        (0x0000 => pub(crate) intr_state: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Enable Register
+        (0x0004 => pub(crate) intr_enable: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Test Register
+        (0x0008 => pub(crate) intr_test: ReadWrite<u32, INTR::Register>),
+        /// Alert Test Register
+        (0x000c => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// Controls the configurability of !!FATAL_ALERT_EN register.
+        (0x0010 => pub(crate) cfg_regwen: ReadWrite<u32, CFG_REGWEN::Register>),
+        /// Alert trigger test
+        (0x0014 => pub(crate) alert_trig: [ReadWrite<u32, ALERT_TRIG::Register>; 1]),
+        /// Each bit marks a corresponding alert as fatal or recoverable.
+        (0x0018 => pub(crate) fatal_alert_en: [ReadWrite<u32, FATAL_ALERT_EN::Register>; 1]),
+        /// Each bit represents a recoverable alert that has been triggered by AST.
+        (0x001c => pub(crate) recov_alert: [ReadWrite<u32, RECOV_ALERT::Register>; 1]),
+        /// Each bit represents a fatal alert that has been triggered by AST.
+        (0x0020 => pub(crate) fatal_alert: [ReadWrite<u32, FATAL_ALERT::Register>; 1]),
+        /// Status readback for ast
+        (0x0024 => pub(crate) status: ReadWrite<u32, STATUS::Register>),
+        (0x0028 => @END),
+    }
+}
+
+register_bitfields![u32,
+    /// Common Interrupt Offsets
+    pub(crate) INTR [
+        IO_STATUS_CHANGE OFFSET(0) NUMBITS(1) [],
+        INIT_STATUS_CHANGE OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) ALERT_TEST [
+        RECOV_ALERT OFFSET(0) NUMBITS(1) [],
+        FATAL_ALERT OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) CFG_REGWEN [
+        EN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) ALERT_TRIG [
+        VAL_0 OFFSET(0) NUMBITS(1) [],
+        VAL_1 OFFSET(1) NUMBITS(1) [],
+        VAL_2 OFFSET(2) NUMBITS(1) [],
+        VAL_3 OFFSET(3) NUMBITS(1) [],
+        VAL_4 OFFSET(4) NUMBITS(1) [],
+        VAL_5 OFFSET(5) NUMBITS(1) [],
+        VAL_6 OFFSET(6) NUMBITS(1) [],
+        VAL_7 OFFSET(7) NUMBITS(1) [],
+        VAL_8 OFFSET(8) NUMBITS(1) [],
+        VAL_9 OFFSET(9) NUMBITS(1) [],
+        VAL_10 OFFSET(10) NUMBITS(1) [],
+    ],
+    pub(crate) FATAL_ALERT_EN [
+        VAL_0 OFFSET(0) NUMBITS(1) [],
+        VAL_1 OFFSET(1) NUMBITS(1) [],
+        VAL_2 OFFSET(2) NUMBITS(1) [],
+        VAL_3 OFFSET(3) NUMBITS(1) [],
+        VAL_4 OFFSET(4) NUMBITS(1) [],
+        VAL_5 OFFSET(5) NUMBITS(1) [],
+        VAL_6 OFFSET(6) NUMBITS(1) [],
+        VAL_7 OFFSET(7) NUMBITS(1) [],
+        VAL_8 OFFSET(8) NUMBITS(1) [],
+        VAL_9 OFFSET(9) NUMBITS(1) [],
+        VAL_10 OFFSET(10) NUMBITS(1) [],
+    ],
+    pub(crate) RECOV_ALERT [
+        VAL_0 OFFSET(0) NUMBITS(1) [],
+        VAL_1 OFFSET(1) NUMBITS(1) [],
+        VAL_2 OFFSET(2) NUMBITS(1) [],
+        VAL_3 OFFSET(3) NUMBITS(1) [],
+        VAL_4 OFFSET(4) NUMBITS(1) [],
+        VAL_5 OFFSET(5) NUMBITS(1) [],
+        VAL_6 OFFSET(6) NUMBITS(1) [],
+        VAL_7 OFFSET(7) NUMBITS(1) [],
+        VAL_8 OFFSET(8) NUMBITS(1) [],
+        VAL_9 OFFSET(9) NUMBITS(1) [],
+        VAL_10 OFFSET(10) NUMBITS(1) [],
+    ],
+    pub(crate) FATAL_ALERT [
+        VAL_0 OFFSET(0) NUMBITS(1) [],
+        VAL_1 OFFSET(1) NUMBITS(1) [],
+        VAL_2 OFFSET(2) NUMBITS(1) [],
+        VAL_3 OFFSET(3) NUMBITS(1) [],
+        VAL_4 OFFSET(4) NUMBITS(1) [],
+        VAL_5 OFFSET(5) NUMBITS(1) [],
+        VAL_6 OFFSET(6) NUMBITS(1) [],
+        VAL_7 OFFSET(7) NUMBITS(1) [],
+        VAL_8 OFFSET(8) NUMBITS(1) [],
+        VAL_9 OFFSET(9) NUMBITS(1) [],
+        VAL_10 OFFSET(10) NUMBITS(1) [],
+        VAL_11 OFFSET(11) NUMBITS(1) [],
+    ],
+    pub(crate) STATUS [
+        AST_INIT_DONE OFFSET(0) NUMBITS(1) [],
+        IO_POK OFFSET(1) NUMBITS(2) [],
+    ],
+];
+
+// End generated register constants for sensor_ctrl

--- a/chips/earlgrey/src/uart.rs
+++ b/chips/earlgrey/src/uart.rs
@@ -3,8 +3,8 @@
 // Copyright Tock Contributors 2022.
 
 use kernel::utilities::StaticRef;
+use lowrisc::registers::uart_regs::UartRegisters;
 pub use lowrisc::uart::Uart;
-use lowrisc::uart::UartRegisters;
 
 use crate::chip_config::CONFIG;
 

--- a/chips/lowrisc/src/lib.rs
+++ b/chips/lowrisc/src/lib.rs
@@ -17,6 +17,7 @@ pub mod i2c;
 pub mod otbn;
 pub mod padctrl;
 pub mod pwrmgr;
+pub mod registers;
 pub mod rsa;
 pub mod spi_host;
 pub mod uart;

--- a/chips/lowrisc/src/registers/README.md
+++ b/chips/lowrisc/src/registers/README.md
@@ -1,0 +1,16 @@
+# lowRISC Register Definitions
+
+The files in this directory are auto-generated register definitions for
+lowRISC peripherals.  These files were auto-generated from the OpenTitan
+codebase as follows:
+
+```bash
+$ cd $OPENTITAN_TREE
+$ git checkout earlgrey_es
+$ bazel build //sw/device/tock:tock_lowrisc_registers
+$ tar -C $TOCK_TREE -xvf bazel-bin/sw/device/tock/tock_lowrisc_registers.tar
+```
+
+Note: the existence of a file in this directory does not necessarily mean
+that a tock peripheral implementation exists.  These files are _only_
+the register definitions.

--- a/chips/lowrisc/src/registers/adc_ctrl_regs.rs
+++ b/chips/lowrisc/src/registers/adc_ctrl_regs.rs
@@ -1,0 +1,120 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for adc_ctrl.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/ip/adc_ctrl/data/adc_ctrl.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Number for ADC filters
+pub const ADC_CTRL_PARAM_NUM_ADC_FILTER: u32 = 8;
+/// Number for ADC channels
+pub const ADC_CTRL_PARAM_NUM_ADC_CHANNEL: u32 = 2;
+/// Number of alerts
+pub const ADC_CTRL_PARAM_NUM_ALERTS: u32 = 1;
+/// Register width
+pub const ADC_CTRL_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub AdcCtrlRegisters {
+        /// Interrupt State Register
+        (0x0000 => pub(crate) intr_state: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Enable Register
+        (0x0004 => pub(crate) intr_enable: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Test Register
+        (0x0008 => pub(crate) intr_test: ReadWrite<u32, INTR::Register>),
+        /// Alert Test Register
+        (0x000c => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// ADC enable control register
+        (0x0010 => pub(crate) adc_en_ctl: ReadWrite<u32, ADC_EN_CTL::Register>),
+        /// ADC PowerDown(PD) control register
+        (0x0014 => pub(crate) adc_pd_ctl: ReadWrite<u32, ADC_PD_CTL::Register>),
+        /// ADC Low-Power(LP) sample control register
+        (0x0018 => pub(crate) adc_lp_sample_ctl: ReadWrite<u32, ADC_LP_SAMPLE_CTL::Register>),
+        /// ADC sample control register
+        (0x001c => pub(crate) adc_sample_ctl: ReadWrite<u32, ADC_SAMPLE_CTL::Register>),
+        /// ADC FSM reset control
+        (0x0020 => pub(crate) adc_fsm_rst: ReadWrite<u32, ADC_FSM_RST::Register>),
+        /// ADC channel0 filter range
+        (0x0024 => pub(crate) adc_chn0_filter_ctl: [ReadWrite<u32, ADC_CHN0_FILTER_CTL::Register>; 8]),
+        /// ADC channel1 filter range
+        (0x0044 => pub(crate) adc_chn1_filter_ctl: [ReadWrite<u32, ADC_CHN1_FILTER_CTL::Register>; 8]),
+        /// ADC value sampled on channel
+        (0x0064 => pub(crate) adc_chn_val: [ReadWrite<u32, ADC_CHN_VAL::Register>; 2]),
+        /// Enable filter matches as wakeups
+        (0x006c => pub(crate) adc_wakeup_ctl: ReadWrite<u32, ADC_WAKEUP_CTL::Register>),
+        /// Adc filter match status
+        (0x0070 => pub(crate) filter_status: ReadWrite<u32, FILTER_STATUS::Register>),
+        /// Interrupt enable controls.
+        (0x0074 => pub(crate) adc_intr_ctl: ReadWrite<u32, ADC_INTR_CTL::Register>),
+        /// Debug cable internal status
+        (0x0078 => pub(crate) adc_intr_status: ReadWrite<u32, ADC_INTR_STATUS::Register>),
+        (0x007c => @END),
+    }
+}
+
+register_bitfields![u32,
+    /// Common Interrupt Offsets
+    pub(crate) INTR [
+        MATCH_DONE OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) ALERT_TEST [
+        FATAL_FAULT OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) ADC_EN_CTL [
+        ADC_ENABLE OFFSET(0) NUMBITS(1) [],
+        ONESHOT_MODE OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) ADC_PD_CTL [
+        LP_MODE OFFSET(0) NUMBITS(1) [],
+        PWRUP_TIME OFFSET(4) NUMBITS(4) [],
+        WAKEUP_TIME OFFSET(8) NUMBITS(24) [],
+    ],
+    pub(crate) ADC_LP_SAMPLE_CTL [
+        LP_SAMPLE_CNT OFFSET(0) NUMBITS(8) [],
+    ],
+    pub(crate) ADC_SAMPLE_CTL [
+        NP_SAMPLE_CNT OFFSET(0) NUMBITS(16) [],
+    ],
+    pub(crate) ADC_FSM_RST [
+        RST_EN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) ADC_CHN0_FILTER_CTL [
+        MIN_V_0 OFFSET(2) NUMBITS(10) [],
+        COND_0 OFFSET(12) NUMBITS(1) [],
+        MAX_V_0 OFFSET(18) NUMBITS(10) [],
+        EN_0 OFFSET(31) NUMBITS(1) [],
+    ],
+    pub(crate) ADC_CHN1_FILTER_CTL [
+        MIN_V_0 OFFSET(2) NUMBITS(10) [],
+        COND_0 OFFSET(12) NUMBITS(1) [],
+        MAX_V_0 OFFSET(18) NUMBITS(10) [],
+        EN_0 OFFSET(31) NUMBITS(1) [],
+    ],
+    pub(crate) ADC_CHN_VAL [
+        ADC_CHN_VALUE_EXT_0 OFFSET(0) NUMBITS(2) [],
+        ADC_CHN_VALUE_0 OFFSET(2) NUMBITS(10) [],
+        ADC_CHN_VALUE_INTR_EXT_0 OFFSET(16) NUMBITS(2) [],
+        ADC_CHN_VALUE_INTR_0 OFFSET(18) NUMBITS(10) [],
+    ],
+    pub(crate) ADC_WAKEUP_CTL [
+        EN OFFSET(0) NUMBITS(8) [],
+    ],
+    pub(crate) FILTER_STATUS [
+        COND OFFSET(0) NUMBITS(8) [],
+    ],
+    pub(crate) ADC_INTR_CTL [
+        EN OFFSET(0) NUMBITS(9) [],
+    ],
+    pub(crate) ADC_INTR_STATUS [
+        FILTER_MATCH OFFSET(0) NUMBITS(8) [],
+        ONESHOT OFFSET(8) NUMBITS(1) [],
+    ],
+];
+
+// End generated register constants for adc_ctrl

--- a/chips/lowrisc/src/registers/aes_regs.rs
+++ b/chips/lowrisc/src/registers/aes_regs.rs
@@ -1,0 +1,123 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for aes.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/ip/aes/data/aes.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Number registers for key
+pub const AES_PARAM_NUM_REGS_KEY: u32 = 8;
+/// Number registers for initialization vector
+pub const AES_PARAM_NUM_REGS_IV: u32 = 4;
+/// Number registers for input and output data
+pub const AES_PARAM_NUM_REGS_DATA: u32 = 4;
+/// Number of alerts
+pub const AES_PARAM_NUM_ALERTS: u32 = 2;
+/// Register width
+pub const AES_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub AesRegisters {
+        /// Alert Test Register
+        (0x0000 => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// Initial Key Registers Share 0.
+        (0x0004 => pub(crate) key_share0: [ReadWrite<u32, KEY_SHARE0::Register>; 8]),
+        /// Initial Key Registers Share 1.
+        (0x0024 => pub(crate) key_share1: [ReadWrite<u32, KEY_SHARE1::Register>; 8]),
+        /// Initialization Vector Registers.
+        (0x0044 => pub(crate) iv: [ReadWrite<u32, IV::Register>; 4]),
+        /// Input Data Registers.
+        (0x0054 => pub(crate) data_in: [ReadWrite<u32, DATA_IN::Register>; 4]),
+        /// Output Data Register.
+        (0x0064 => pub(crate) data_out: [ReadWrite<u32, DATA_OUT::Register>; 4]),
+        /// Control Register.
+        (0x0074 => pub(crate) ctrl_shadowed: ReadWrite<u32, CTRL_SHADOWED::Register>),
+        /// Auxiliary Control Register.
+        (0x0078 => pub(crate) ctrl_aux_shadowed: ReadWrite<u32, CTRL_AUX_SHADOWED::Register>),
+        /// Lock bit for Auxiliary Control Register.
+        (0x007c => pub(crate) ctrl_aux_regwen: ReadWrite<u32, CTRL_AUX_REGWEN::Register>),
+        /// Trigger Register.
+        (0x0080 => pub(crate) trigger: ReadWrite<u32, TRIGGER::Register>),
+        /// Status Register
+        (0x0084 => pub(crate) status: ReadWrite<u32, STATUS::Register>),
+        (0x0088 => @END),
+    }
+}
+
+register_bitfields![u32,
+    pub(crate) ALERT_TEST [
+        RECOV_CTRL_UPDATE_ERR OFFSET(0) NUMBITS(1) [],
+        FATAL_FAULT OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) KEY_SHARE0 [
+        KEY_SHARE0_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) KEY_SHARE1 [
+        KEY_SHARE1_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) IV [
+        IV_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) DATA_IN [
+        DATA_IN_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) DATA_OUT [
+        DATA_OUT_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) CTRL_SHADOWED [
+        OPERATION OFFSET(0) NUMBITS(2) [
+            AES_ENC = 1,
+            AES_DEC = 2,
+        ],
+        MODE OFFSET(2) NUMBITS(6) [
+            AES_ECB = 1,
+            AES_CBC = 2,
+            AES_CFB = 4,
+            AES_OFB = 8,
+            AES_CTR = 16,
+            AES_NONE = 32,
+        ],
+        KEY_LEN OFFSET(8) NUMBITS(3) [
+            AES_128 = 1,
+            AES_192 = 2,
+            AES_256 = 4,
+        ],
+        SIDELOAD OFFSET(11) NUMBITS(1) [],
+        PRNG_RESEED_RATE OFFSET(12) NUMBITS(3) [
+            PER_1 = 1,
+            PER_64 = 2,
+            PER_8K = 4,
+        ],
+        MANUAL_OPERATION OFFSET(15) NUMBITS(1) [],
+    ],
+    pub(crate) CTRL_AUX_SHADOWED [
+        KEY_TOUCH_FORCES_RESEED OFFSET(0) NUMBITS(1) [],
+        FORCE_MASKS OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) CTRL_AUX_REGWEN [
+        CTRL_AUX_REGWEN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) TRIGGER [
+        START OFFSET(0) NUMBITS(1) [],
+        KEY_IV_DATA_IN_CLEAR OFFSET(1) NUMBITS(1) [],
+        DATA_OUT_CLEAR OFFSET(2) NUMBITS(1) [],
+        PRNG_RESEED OFFSET(3) NUMBITS(1) [],
+    ],
+    pub(crate) STATUS [
+        IDLE OFFSET(0) NUMBITS(1) [],
+        STALL OFFSET(1) NUMBITS(1) [],
+        OUTPUT_LOST OFFSET(2) NUMBITS(1) [],
+        OUTPUT_VALID OFFSET(3) NUMBITS(1) [],
+        INPUT_READY OFFSET(4) NUMBITS(1) [],
+        ALERT_RECOV_CTRL_UPDATE_ERR OFFSET(5) NUMBITS(1) [],
+        ALERT_FATAL_FAULT OFFSET(6) NUMBITS(1) [],
+    ],
+];
+
+// End generated register constants for aes

--- a/chips/lowrisc/src/registers/aon_timer_regs.rs
+++ b/chips/lowrisc/src/registers/aon_timer_regs.rs
@@ -1,0 +1,92 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for aon_timer.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/ip/aon_timer/data/aon_timer.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Number of alerts
+pub const AON_TIMER_PARAM_NUM_ALERTS: u32 = 1;
+/// Register width
+pub const AON_TIMER_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub AonTimerRegisters {
+        /// Alert Test Register
+        (0x0000 => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// Wakeup Timer Control register
+        (0x0004 => pub(crate) wkup_ctrl: ReadWrite<u32, WKUP_CTRL::Register>),
+        /// Wakeup Timer Threshold Register
+        (0x0008 => pub(crate) wkup_thold: ReadWrite<u32, WKUP_THOLD::Register>),
+        /// Wakeup Timer Count Register
+        (0x000c => pub(crate) wkup_count: ReadWrite<u32, WKUP_COUNT::Register>),
+        /// Watchdog Timer Write Enable Register
+        (0x0010 => pub(crate) wdog_regwen: ReadWrite<u32, WDOG_REGWEN::Register>),
+        /// Watchdog Timer Control register
+        (0x0014 => pub(crate) wdog_ctrl: ReadWrite<u32, WDOG_CTRL::Register>),
+        /// Watchdog Timer Bark Threshold Register
+        (0x0018 => pub(crate) wdog_bark_thold: ReadWrite<u32, WDOG_BARK_THOLD::Register>),
+        /// Watchdog Timer Bite Threshold Register
+        (0x001c => pub(crate) wdog_bite_thold: ReadWrite<u32, WDOG_BITE_THOLD::Register>),
+        /// Watchdog Timer Count Register
+        (0x0020 => pub(crate) wdog_count: ReadWrite<u32, WDOG_COUNT::Register>),
+        /// Interrupt State Register
+        (0x0024 => pub(crate) intr_state: ReadWrite<u32, INTR_STATE::Register>),
+        /// Interrupt Test Register
+        (0x0028 => pub(crate) intr_test: ReadWrite<u32, INTR_TEST::Register>),
+        /// Wakeup request status
+        (0x002c => pub(crate) wkup_cause: ReadWrite<u32, WKUP_CAUSE::Register>),
+        (0x0030 => @END),
+    }
+}
+
+register_bitfields![u32,
+    pub(crate) ALERT_TEST [
+        FATAL_FAULT OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) WKUP_CTRL [
+        ENABLE OFFSET(0) NUMBITS(1) [],
+        PRESCALER OFFSET(1) NUMBITS(12) [],
+    ],
+    pub(crate) WKUP_THOLD [
+        THRESHOLD OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) WKUP_COUNT [
+        COUNT OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) WDOG_REGWEN [
+        REGWEN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) WDOG_CTRL [
+        ENABLE OFFSET(0) NUMBITS(1) [],
+        PAUSE_IN_SLEEP OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) WDOG_BARK_THOLD [
+        THRESHOLD OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) WDOG_BITE_THOLD [
+        THRESHOLD OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) WDOG_COUNT [
+        COUNT OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) INTR_STATE [
+        WKUP_TIMER_EXPIRED OFFSET(0) NUMBITS(1) [],
+        WDOG_TIMER_BARK OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) INTR_TEST [
+        WKUP_TIMER_EXPIRED OFFSET(0) NUMBITS(1) [],
+        WDOG_TIMER_BARK OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) WKUP_CAUSE [
+        CAUSE OFFSET(0) NUMBITS(1) [],
+    ],
+];
+
+// End generated register constants for aon_timer

--- a/chips/lowrisc/src/registers/clkmgr_regs.rs
+++ b/chips/lowrisc/src/registers/clkmgr_regs.rs
@@ -1,0 +1,46 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for clkmgr.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/ip/clkmgr/data/clkmgr.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Number of clock groups
+pub const CLKMGR_PARAM_NUM_GROUPS: u32 = 7;
+/// Register width
+pub const CLKMGR_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub ClkmgrRegisters {
+        /// Clock enable for software gateable clocks.
+        (0x0000 => pub(crate) clk_enables: ReadWrite<u32, CLK_ENABLES::Register>),
+        /// Clock hint for software gateable clocks.
+        (0x0004 => pub(crate) clk_hints: ReadWrite<u32, CLK_HINTS::Register>),
+        /// Since the final state of !!CLK_HINTS is not always determined by software,
+        (0x0008 => pub(crate) clk_hints_status: ReadWrite<u32, CLK_HINTS_STATUS::Register>),
+        (0x000c => @END),
+    }
+}
+
+register_bitfields![u32,
+    pub(crate) CLK_ENABLES [
+        CLK_FIXED_PERI_EN OFFSET(0) NUMBITS(1) [],
+        CLK_USB_48MHZ_PERI_EN OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) CLK_HINTS [
+        CLK_MAIN_AES_HINT OFFSET(0) NUMBITS(1) [],
+        CLK_MAIN_HMAC_HINT OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) CLK_HINTS_STATUS [
+        CLK_MAIN_AES_VAL OFFSET(0) NUMBITS(1) [],
+        CLK_MAIN_HMAC_VAL OFFSET(1) NUMBITS(1) [],
+    ],
+];
+
+// End generated register constants for clkmgr

--- a/chips/lowrisc/src/registers/csrng_regs.rs
+++ b/chips/lowrisc/src/registers/csrng_regs.rs
@@ -1,0 +1,146 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for csrng.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/ip/csrng/data/csrng.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Number of alerts
+pub const CSRNG_PARAM_NUM_ALERTS: u32 = 2;
+/// Register width
+pub const CSRNG_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub CsrngRegisters {
+        /// Interrupt State Register
+        (0x0000 => pub(crate) intr_state: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Enable Register
+        (0x0004 => pub(crate) intr_enable: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Test Register
+        (0x0008 => pub(crate) intr_test: ReadWrite<u32, INTR::Register>),
+        /// Alert Test Register
+        (0x000c => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// Register write enable for all control registers
+        (0x0010 => pub(crate) regwen: ReadWrite<u32, REGWEN::Register>),
+        /// Control register
+        (0x0014 => pub(crate) ctrl: ReadWrite<u32, CTRL::Register>),
+        /// Command request register
+        (0x0018 => pub(crate) cmd_req: ReadWrite<u32, CMD_REQ::Register>),
+        /// Application interface command status register
+        (0x001c => pub(crate) sw_cmd_sts: ReadWrite<u32, SW_CMD_STS::Register>),
+        /// Generate bits returned valid register
+        (0x0020 => pub(crate) genbits_vld: ReadWrite<u32, GENBITS_VLD::Register>),
+        /// Generate bits returned register
+        (0x0024 => pub(crate) genbits: ReadWrite<u32, GENBITS::Register>),
+        /// Internal state number register
+        (0x0028 => pub(crate) int_state_num: ReadWrite<u32, INT_STATE_NUM::Register>),
+        /// Internal state read access register
+        (0x002c => pub(crate) int_state_val: ReadWrite<u32, INT_STATE_VAL::Register>),
+        /// Hardware instance exception status register
+        (0x0030 => pub(crate) hw_exc_sts: ReadWrite<u32, HW_EXC_STS::Register>),
+        /// Recoverable alert status register
+        (0x0034 => pub(crate) recov_alert_sts: ReadWrite<u32, RECOV_ALERT_STS::Register>),
+        /// Hardware detection of error conditions status register
+        (0x0038 => pub(crate) err_code: ReadWrite<u32, ERR_CODE::Register>),
+        /// Test error conditions register
+        (0x003c => pub(crate) err_code_test: ReadWrite<u32, ERR_CODE_TEST::Register>),
+        /// Main state machine state debug register
+        (0x0040 => pub(crate) main_sm_state: ReadWrite<u32, MAIN_SM_STATE::Register>),
+        (0x0044 => @END),
+    }
+}
+
+register_bitfields![u32,
+    /// Common Interrupt Offsets
+    pub(crate) INTR [
+        CS_CMD_REQ_DONE OFFSET(0) NUMBITS(1) [],
+        CS_ENTROPY_REQ OFFSET(1) NUMBITS(1) [],
+        CS_HW_INST_EXC OFFSET(2) NUMBITS(1) [],
+        CS_FATAL_ERR OFFSET(3) NUMBITS(1) [],
+    ],
+    pub(crate) ALERT_TEST [
+        RECOV_ALERT OFFSET(0) NUMBITS(1) [],
+        FATAL_ALERT OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) REGWEN [
+        REGWEN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CTRL [
+        ENABLE OFFSET(0) NUMBITS(4) [],
+        SW_APP_ENABLE OFFSET(4) NUMBITS(4) [],
+        READ_INT_STATE OFFSET(8) NUMBITS(4) [],
+    ],
+    pub(crate) CMD_REQ [
+        CMD_REQ OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) SW_CMD_STS [
+        CMD_RDY OFFSET(0) NUMBITS(1) [],
+        CMD_STS OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) GENBITS_VLD [
+        GENBITS_VLD OFFSET(0) NUMBITS(1) [],
+        GENBITS_FIPS OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) GENBITS [
+        GENBITS OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) INT_STATE_NUM [
+        INT_STATE_NUM OFFSET(0) NUMBITS(4) [],
+    ],
+    pub(crate) INT_STATE_VAL [
+        INT_STATE_VAL OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) HW_EXC_STS [
+        HW_EXC_STS OFFSET(0) NUMBITS(16) [],
+    ],
+    pub(crate) RECOV_ALERT_STS [
+        ENABLE_FIELD_ALERT OFFSET(0) NUMBITS(1) [],
+        SW_APP_ENABLE_FIELD_ALERT OFFSET(1) NUMBITS(1) [],
+        READ_INT_STATE_FIELD_ALERT OFFSET(2) NUMBITS(1) [],
+        ACMD_FLAG0_FIELD_ALERT OFFSET(3) NUMBITS(1) [],
+        CS_BUS_CMP_ALERT OFFSET(12) NUMBITS(1) [],
+        CS_MAIN_SM_ALERT OFFSET(13) NUMBITS(1) [],
+    ],
+    pub(crate) ERR_CODE [
+        SFIFO_CMD_ERR OFFSET(0) NUMBITS(1) [],
+        SFIFO_GENBITS_ERR OFFSET(1) NUMBITS(1) [],
+        SFIFO_CMDREQ_ERR OFFSET(2) NUMBITS(1) [],
+        SFIFO_RCSTAGE_ERR OFFSET(3) NUMBITS(1) [],
+        SFIFO_KEYVRC_ERR OFFSET(4) NUMBITS(1) [],
+        SFIFO_UPDREQ_ERR OFFSET(5) NUMBITS(1) [],
+        SFIFO_BENCREQ_ERR OFFSET(6) NUMBITS(1) [],
+        SFIFO_BENCACK_ERR OFFSET(7) NUMBITS(1) [],
+        SFIFO_PDATA_ERR OFFSET(8) NUMBITS(1) [],
+        SFIFO_FINAL_ERR OFFSET(9) NUMBITS(1) [],
+        SFIFO_GBENCACK_ERR OFFSET(10) NUMBITS(1) [],
+        SFIFO_GRCSTAGE_ERR OFFSET(11) NUMBITS(1) [],
+        SFIFO_GGENREQ_ERR OFFSET(12) NUMBITS(1) [],
+        SFIFO_GADSTAGE_ERR OFFSET(13) NUMBITS(1) [],
+        SFIFO_GGENBITS_ERR OFFSET(14) NUMBITS(1) [],
+        SFIFO_BLKENC_ERR OFFSET(15) NUMBITS(1) [],
+        CMD_STAGE_SM_ERR OFFSET(20) NUMBITS(1) [],
+        MAIN_SM_ERR OFFSET(21) NUMBITS(1) [],
+        DRBG_GEN_SM_ERR OFFSET(22) NUMBITS(1) [],
+        DRBG_UPDBE_SM_ERR OFFSET(23) NUMBITS(1) [],
+        DRBG_UPDOB_SM_ERR OFFSET(24) NUMBITS(1) [],
+        AES_CIPHER_SM_ERR OFFSET(25) NUMBITS(1) [],
+        CMD_GEN_CNT_ERR OFFSET(26) NUMBITS(1) [],
+        FIFO_WRITE_ERR OFFSET(28) NUMBITS(1) [],
+        FIFO_READ_ERR OFFSET(29) NUMBITS(1) [],
+        FIFO_STATE_ERR OFFSET(30) NUMBITS(1) [],
+    ],
+    pub(crate) ERR_CODE_TEST [
+        ERR_CODE_TEST OFFSET(0) NUMBITS(5) [],
+    ],
+    pub(crate) MAIN_SM_STATE [
+        MAIN_SM_STATE OFFSET(0) NUMBITS(8) [],
+    ],
+];
+
+// End generated register constants for csrng

--- a/chips/lowrisc/src/registers/edn_regs.rs
+++ b/chips/lowrisc/src/registers/edn_regs.rs
@@ -1,0 +1,126 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for edn.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/ip/edn/data/edn.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Number of alerts
+pub const EDN_PARAM_NUM_ALERTS: u32 = 2;
+/// Register width
+pub const EDN_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub EdnRegisters {
+        /// Interrupt State Register
+        (0x0000 => pub(crate) intr_state: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Enable Register
+        (0x0004 => pub(crate) intr_enable: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Test Register
+        (0x0008 => pub(crate) intr_test: ReadWrite<u32, INTR::Register>),
+        /// Alert Test Register
+        (0x000c => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// Register write enable for all control registers
+        (0x0010 => pub(crate) regwen: ReadWrite<u32, REGWEN::Register>),
+        /// EDN control register
+        (0x0014 => pub(crate) ctrl: ReadWrite<u32, CTRL::Register>),
+        /// EDN boot instantiate command register
+        (0x0018 => pub(crate) boot_ins_cmd: ReadWrite<u32, BOOT_INS_CMD::Register>),
+        /// EDN boot generate command register
+        (0x001c => pub(crate) boot_gen_cmd: ReadWrite<u32, BOOT_GEN_CMD::Register>),
+        /// EDN csrng app command request register
+        (0x0020 => pub(crate) sw_cmd_req: ReadWrite<u32, SW_CMD_REQ::Register>),
+        /// EDN command status register
+        (0x0024 => pub(crate) sw_cmd_sts: ReadWrite<u32, SW_CMD_STS::Register>),
+        /// EDN csrng reseed command register
+        (0x0028 => pub(crate) reseed_cmd: ReadWrite<u32, RESEED_CMD::Register>),
+        /// EDN csrng generate command register
+        (0x002c => pub(crate) generate_cmd: ReadWrite<u32, GENERATE_CMD::Register>),
+        /// EDN maximum number of requests between reseeds register
+        (0x0030 => pub(crate) max_num_reqs_between_reseeds: ReadWrite<u32, MAX_NUM_REQS_BETWEEN_RESEEDS::Register>),
+        /// Recoverable alert status register
+        (0x0034 => pub(crate) recov_alert_sts: ReadWrite<u32, RECOV_ALERT_STS::Register>),
+        /// Hardware detection of fatal error conditions status register
+        (0x0038 => pub(crate) err_code: ReadWrite<u32, ERR_CODE::Register>),
+        /// Test error conditions register
+        (0x003c => pub(crate) err_code_test: ReadWrite<u32, ERR_CODE_TEST::Register>),
+        /// Main state machine state observation register
+        (0x0040 => pub(crate) main_sm_state: ReadWrite<u32, MAIN_SM_STATE::Register>),
+        (0x0044 => @END),
+    }
+}
+
+register_bitfields![u32,
+    /// Common Interrupt Offsets
+    pub(crate) INTR [
+        EDN_CMD_REQ_DONE OFFSET(0) NUMBITS(1) [],
+        EDN_FATAL_ERR OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) ALERT_TEST [
+        RECOV_ALERT OFFSET(0) NUMBITS(1) [],
+        FATAL_ALERT OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) REGWEN [
+        REGWEN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CTRL [
+        EDN_ENABLE OFFSET(0) NUMBITS(4) [],
+        BOOT_REQ_MODE OFFSET(4) NUMBITS(4) [],
+        AUTO_REQ_MODE OFFSET(8) NUMBITS(4) [],
+        CMD_FIFO_RST OFFSET(12) NUMBITS(4) [],
+    ],
+    pub(crate) BOOT_INS_CMD [
+        BOOT_INS_CMD OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) BOOT_GEN_CMD [
+        BOOT_GEN_CMD OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) SW_CMD_REQ [
+        SW_CMD_REQ OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) SW_CMD_STS [
+        CMD_RDY OFFSET(0) NUMBITS(1) [],
+        CMD_STS OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) RESEED_CMD [
+        RESEED_CMD OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) GENERATE_CMD [
+        GENERATE_CMD OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) MAX_NUM_REQS_BETWEEN_RESEEDS [
+        MAX_NUM_REQS_BETWEEN_RESEEDS OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) RECOV_ALERT_STS [
+        EDN_ENABLE_FIELD_ALERT OFFSET(0) NUMBITS(1) [],
+        BOOT_REQ_MODE_FIELD_ALERT OFFSET(1) NUMBITS(1) [],
+        AUTO_REQ_MODE_FIELD_ALERT OFFSET(2) NUMBITS(1) [],
+        CMD_FIFO_RST_FIELD_ALERT OFFSET(3) NUMBITS(1) [],
+        EDN_BUS_CMP_ALERT OFFSET(12) NUMBITS(1) [],
+    ],
+    pub(crate) ERR_CODE [
+        SFIFO_RESCMD_ERR OFFSET(0) NUMBITS(1) [],
+        SFIFO_GENCMD_ERR OFFSET(1) NUMBITS(1) [],
+        SFIFO_OUTPUT_ERR OFFSET(2) NUMBITS(1) [],
+        EDN_ACK_SM_ERR OFFSET(20) NUMBITS(1) [],
+        EDN_MAIN_SM_ERR OFFSET(21) NUMBITS(1) [],
+        EDN_CNTR_ERR OFFSET(22) NUMBITS(1) [],
+        FIFO_WRITE_ERR OFFSET(28) NUMBITS(1) [],
+        FIFO_READ_ERR OFFSET(29) NUMBITS(1) [],
+        FIFO_STATE_ERR OFFSET(30) NUMBITS(1) [],
+    ],
+    pub(crate) ERR_CODE_TEST [
+        ERR_CODE_TEST OFFSET(0) NUMBITS(5) [],
+    ],
+    pub(crate) MAIN_SM_STATE [
+        MAIN_SM_STATE OFFSET(0) NUMBITS(9) [],
+    ],
+];
+
+// End generated register constants for edn

--- a/chips/lowrisc/src/registers/entropy_src_regs.rs
+++ b/chips/lowrisc/src/registers/entropy_src_regs.rs
@@ -1,0 +1,378 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for entropy_src.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/ip/entropy_src/data/entropy_src.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Number of alerts
+pub const ENTROPY_SRC_PARAM_NUM_ALERTS: u32 = 2;
+/// Register width
+pub const ENTROPY_SRC_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub EntropySrcRegisters {
+        /// Interrupt State Register
+        (0x0000 => pub(crate) intr_state: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Enable Register
+        (0x0004 => pub(crate) intr_enable: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Test Register
+        (0x0008 => pub(crate) intr_test: ReadWrite<u32, INTR::Register>),
+        /// Alert Test Register
+        (0x000c => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// Register write enable for module enable register
+        (0x0010 => pub(crate) me_regwen: ReadWrite<u32, ME_REGWEN::Register>),
+        /// Register write enable for control and threshold registers
+        (0x0014 => pub(crate) sw_regupd: ReadWrite<u32, SW_REGUPD::Register>),
+        /// Register write enable for all control registers
+        (0x0018 => pub(crate) regwen: ReadWrite<u32, REGWEN::Register>),
+        /// Revision register
+        (0x001c => pub(crate) rev: ReadWrite<u32, REV::Register>),
+        /// Module enable register
+        (0x0020 => pub(crate) module_enable: ReadWrite<u32, MODULE_ENABLE::Register>),
+        /// Configuration register
+        (0x0024 => pub(crate) conf: ReadWrite<u32, CONF::Register>),
+        /// Entropy control register
+        (0x0028 => pub(crate) entropy_control: ReadWrite<u32, ENTROPY_CONTROL::Register>),
+        /// Entropy data bits
+        (0x002c => pub(crate) entropy_data: ReadWrite<u32, ENTROPY_DATA::Register>),
+        /// Health test windows register
+        (0x0030 => pub(crate) health_test_windows: ReadWrite<u32, HEALTH_TEST_WINDOWS::Register>),
+        /// Repetition count test thresholds register
+        (0x0034 => pub(crate) repcnt_thresholds: ReadWrite<u32, REPCNT_THRESHOLDS::Register>),
+        /// Repetition count symbol test thresholds register
+        (0x0038 => pub(crate) repcnts_thresholds: ReadWrite<u32, REPCNTS_THRESHOLDS::Register>),
+        /// Adaptive proportion test high thresholds register
+        (0x003c => pub(crate) adaptp_hi_thresholds: ReadWrite<u32, ADAPTP_HI_THRESHOLDS::Register>),
+        /// Adaptive proportion test low thresholds register
+        (0x0040 => pub(crate) adaptp_lo_thresholds: ReadWrite<u32, ADAPTP_LO_THRESHOLDS::Register>),
+        /// Bucket test thresholds register
+        (0x0044 => pub(crate) bucket_thresholds: ReadWrite<u32, BUCKET_THRESHOLDS::Register>),
+        /// Markov test high thresholds register
+        (0x0048 => pub(crate) markov_hi_thresholds: ReadWrite<u32, MARKOV_HI_THRESHOLDS::Register>),
+        /// Markov test low thresholds register
+        (0x004c => pub(crate) markov_lo_thresholds: ReadWrite<u32, MARKOV_LO_THRESHOLDS::Register>),
+        /// External health test high thresholds register
+        (0x0050 => pub(crate) extht_hi_thresholds: ReadWrite<u32, EXTHT_HI_THRESHOLDS::Register>),
+        /// External health test low thresholds register
+        (0x0054 => pub(crate) extht_lo_thresholds: ReadWrite<u32, EXTHT_LO_THRESHOLDS::Register>),
+        /// Repetition count test high watermarks register
+        (0x0058 => pub(crate) repcnt_hi_watermarks: ReadWrite<u32, REPCNT_HI_WATERMARKS::Register>),
+        /// Repetition count symbol test high watermarks register
+        (0x005c => pub(crate) repcnts_hi_watermarks: ReadWrite<u32, REPCNTS_HI_WATERMARKS::Register>),
+        /// Adaptive proportion test high watermarks register
+        (0x0060 => pub(crate) adaptp_hi_watermarks: ReadWrite<u32, ADAPTP_HI_WATERMARKS::Register>),
+        /// Adaptive proportion test low watermarks register
+        (0x0064 => pub(crate) adaptp_lo_watermarks: ReadWrite<u32, ADAPTP_LO_WATERMARKS::Register>),
+        /// External health test high watermarks register
+        (0x0068 => pub(crate) extht_hi_watermarks: ReadWrite<u32, EXTHT_HI_WATERMARKS::Register>),
+        /// External health test low watermarks register
+        (0x006c => pub(crate) extht_lo_watermarks: ReadWrite<u32, EXTHT_LO_WATERMARKS::Register>),
+        /// Bucket test high watermarks register
+        (0x0070 => pub(crate) bucket_hi_watermarks: ReadWrite<u32, BUCKET_HI_WATERMARKS::Register>),
+        /// Markov test high watermarks register
+        (0x0074 => pub(crate) markov_hi_watermarks: ReadWrite<u32, MARKOV_HI_WATERMARKS::Register>),
+        /// Markov test low watermarks register
+        (0x0078 => pub(crate) markov_lo_watermarks: ReadWrite<u32, MARKOV_LO_WATERMARKS::Register>),
+        /// Repetition count test failure counter register
+        (0x007c => pub(crate) repcnt_total_fails: ReadWrite<u32, REPCNT_TOTAL_FAILS::Register>),
+        /// Repetition count symbol test failure counter register
+        (0x0080 => pub(crate) repcnts_total_fails: ReadWrite<u32, REPCNTS_TOTAL_FAILS::Register>),
+        /// Adaptive proportion high test failure counter register
+        (0x0084 => pub(crate) adaptp_hi_total_fails: ReadWrite<u32, ADAPTP_HI_TOTAL_FAILS::Register>),
+        /// Adaptive proportion low test failure counter register
+        (0x0088 => pub(crate) adaptp_lo_total_fails: ReadWrite<u32, ADAPTP_LO_TOTAL_FAILS::Register>),
+        /// Bucket test failure counter register
+        (0x008c => pub(crate) bucket_total_fails: ReadWrite<u32, BUCKET_TOTAL_FAILS::Register>),
+        /// Markov high test failure counter register
+        (0x0090 => pub(crate) markov_hi_total_fails: ReadWrite<u32, MARKOV_HI_TOTAL_FAILS::Register>),
+        /// Markov low test failure counter register
+        (0x0094 => pub(crate) markov_lo_total_fails: ReadWrite<u32, MARKOV_LO_TOTAL_FAILS::Register>),
+        /// External health test high threshold failure counter register
+        (0x0098 => pub(crate) extht_hi_total_fails: ReadWrite<u32, EXTHT_HI_TOTAL_FAILS::Register>),
+        /// External health test low threshold failure counter register
+        (0x009c => pub(crate) extht_lo_total_fails: ReadWrite<u32, EXTHT_LO_TOTAL_FAILS::Register>),
+        /// Alert threshold register
+        (0x00a0 => pub(crate) alert_threshold: ReadWrite<u32, ALERT_THRESHOLD::Register>),
+        /// Alert summary failure counts register
+        (0x00a4 => pub(crate) alert_summary_fail_counts: ReadWrite<u32, ALERT_SUMMARY_FAIL_COUNTS::Register>),
+        /// Alert failure counts register
+        (0x00a8 => pub(crate) alert_fail_counts: ReadWrite<u32, ALERT_FAIL_COUNTS::Register>),
+        /// External health test alert failure counts register
+        (0x00ac => pub(crate) extht_fail_counts: ReadWrite<u32, EXTHT_FAIL_COUNTS::Register>),
+        /// Firmware override control register
+        (0x00b0 => pub(crate) fw_ov_control: ReadWrite<u32, FW_OV_CONTROL::Register>),
+        /// Firmware override sha3 block start control register
+        (0x00b4 => pub(crate) fw_ov_sha3_start: ReadWrite<u32, FW_OV_SHA3_START::Register>),
+        /// Firmware override FIFO write full status register
+        (0x00b8 => pub(crate) fw_ov_wr_fifo_full: ReadWrite<u32, FW_OV_WR_FIFO_FULL::Register>),
+        /// Firmware override observe FIFO overflow status
+        (0x00bc => pub(crate) fw_ov_rd_fifo_overflow: ReadWrite<u32, FW_OV_RD_FIFO_OVERFLOW::Register>),
+        /// Firmware override observe FIFO read register
+        (0x00c0 => pub(crate) fw_ov_rd_data: ReadWrite<u32, FW_OV_RD_DATA::Register>),
+        /// Firmware override FIFO write register
+        (0x00c4 => pub(crate) fw_ov_wr_data: ReadWrite<u32, FW_OV_WR_DATA::Register>),
+        /// Observe FIFO threshold register
+        (0x00c8 => pub(crate) observe_fifo_thresh: ReadWrite<u32, OBSERVE_FIFO_THRESH::Register>),
+        /// Observe FIFO depth register
+        (0x00cc => pub(crate) observe_fifo_depth: ReadWrite<u32, OBSERVE_FIFO_DEPTH::Register>),
+        /// Debug status register
+        (0x00d0 => pub(crate) debug_status: ReadWrite<u32, DEBUG_STATUS::Register>),
+        /// Recoverable alert status register
+        (0x00d4 => pub(crate) recov_alert_sts: ReadWrite<u32, RECOV_ALERT_STS::Register>),
+        /// Hardware detection of error conditions status register
+        (0x00d8 => pub(crate) err_code: ReadWrite<u32, ERR_CODE::Register>),
+        /// Test error conditions register
+        (0x00dc => pub(crate) err_code_test: ReadWrite<u32, ERR_CODE_TEST::Register>),
+        /// Main state machine state debug register
+        (0x00e0 => pub(crate) main_sm_state: ReadWrite<u32, MAIN_SM_STATE::Register>),
+        (0x00e4 => @END),
+    }
+}
+
+register_bitfields![u32,
+    /// Common Interrupt Offsets
+    pub(crate) INTR [
+        ES_ENTROPY_VALID OFFSET(0) NUMBITS(1) [],
+        ES_HEALTH_TEST_FAILED OFFSET(1) NUMBITS(1) [],
+        ES_OBSERVE_FIFO_READY OFFSET(2) NUMBITS(1) [],
+        ES_FATAL_ERR OFFSET(3) NUMBITS(1) [],
+    ],
+    pub(crate) ALERT_TEST [
+        RECOV_ALERT OFFSET(0) NUMBITS(1) [],
+        FATAL_ALERT OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) ME_REGWEN [
+        ME_REGWEN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) SW_REGUPD [
+        SW_REGUPD OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) REGWEN [
+        REGWEN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) REV [
+        ABI_REVISION OFFSET(0) NUMBITS(8) [],
+        HW_REVISION OFFSET(8) NUMBITS(8) [],
+        CHIP_TYPE OFFSET(16) NUMBITS(8) [],
+    ],
+    pub(crate) MODULE_ENABLE [
+        MODULE_ENABLE OFFSET(0) NUMBITS(4) [],
+    ],
+    pub(crate) CONF [
+        FIPS_ENABLE OFFSET(0) NUMBITS(4) [],
+        ENTROPY_DATA_REG_ENABLE OFFSET(4) NUMBITS(4) [],
+        THRESHOLD_SCOPE OFFSET(12) NUMBITS(4) [],
+        RNG_BIT_ENABLE OFFSET(20) NUMBITS(4) [],
+        RNG_BIT_SEL OFFSET(24) NUMBITS(2) [],
+    ],
+    pub(crate) ENTROPY_CONTROL [
+        ES_ROUTE OFFSET(0) NUMBITS(4) [],
+        ES_TYPE OFFSET(4) NUMBITS(4) [],
+    ],
+    pub(crate) ENTROPY_DATA [
+        ENTROPY_DATA OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) HEALTH_TEST_WINDOWS [
+        FIPS_WINDOW OFFSET(0) NUMBITS(16) [],
+        BYPASS_WINDOW OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) REPCNT_THRESHOLDS [
+        FIPS_THRESH OFFSET(0) NUMBITS(16) [],
+        BYPASS_THRESH OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) REPCNTS_THRESHOLDS [
+        FIPS_THRESH OFFSET(0) NUMBITS(16) [],
+        BYPASS_THRESH OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) ADAPTP_HI_THRESHOLDS [
+        FIPS_THRESH OFFSET(0) NUMBITS(16) [],
+        BYPASS_THRESH OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) ADAPTP_LO_THRESHOLDS [
+        FIPS_THRESH OFFSET(0) NUMBITS(16) [],
+        BYPASS_THRESH OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) BUCKET_THRESHOLDS [
+        FIPS_THRESH OFFSET(0) NUMBITS(16) [],
+        BYPASS_THRESH OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) MARKOV_HI_THRESHOLDS [
+        FIPS_THRESH OFFSET(0) NUMBITS(16) [],
+        BYPASS_THRESH OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) MARKOV_LO_THRESHOLDS [
+        FIPS_THRESH OFFSET(0) NUMBITS(16) [],
+        BYPASS_THRESH OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) EXTHT_HI_THRESHOLDS [
+        FIPS_THRESH OFFSET(0) NUMBITS(16) [],
+        BYPASS_THRESH OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) EXTHT_LO_THRESHOLDS [
+        FIPS_THRESH OFFSET(0) NUMBITS(16) [],
+        BYPASS_THRESH OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) REPCNT_HI_WATERMARKS [
+        FIPS_WATERMARK OFFSET(0) NUMBITS(16) [],
+        BYPASS_WATERMARK OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) REPCNTS_HI_WATERMARKS [
+        FIPS_WATERMARK OFFSET(0) NUMBITS(16) [],
+        BYPASS_WATERMARK OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) ADAPTP_HI_WATERMARKS [
+        FIPS_WATERMARK OFFSET(0) NUMBITS(16) [],
+        BYPASS_WATERMARK OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) ADAPTP_LO_WATERMARKS [
+        FIPS_WATERMARK OFFSET(0) NUMBITS(16) [],
+        BYPASS_WATERMARK OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) EXTHT_HI_WATERMARKS [
+        FIPS_WATERMARK OFFSET(0) NUMBITS(16) [],
+        BYPASS_WATERMARK OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) EXTHT_LO_WATERMARKS [
+        FIPS_WATERMARK OFFSET(0) NUMBITS(16) [],
+        BYPASS_WATERMARK OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) BUCKET_HI_WATERMARKS [
+        FIPS_WATERMARK OFFSET(0) NUMBITS(16) [],
+        BYPASS_WATERMARK OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) MARKOV_HI_WATERMARKS [
+        FIPS_WATERMARK OFFSET(0) NUMBITS(16) [],
+        BYPASS_WATERMARK OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) MARKOV_LO_WATERMARKS [
+        FIPS_WATERMARK OFFSET(0) NUMBITS(16) [],
+        BYPASS_WATERMARK OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) REPCNT_TOTAL_FAILS [
+        REPCNT_TOTAL_FAILS OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) REPCNTS_TOTAL_FAILS [
+        REPCNTS_TOTAL_FAILS OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) ADAPTP_HI_TOTAL_FAILS [
+        ADAPTP_HI_TOTAL_FAILS OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) ADAPTP_LO_TOTAL_FAILS [
+        ADAPTP_LO_TOTAL_FAILS OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) BUCKET_TOTAL_FAILS [
+        BUCKET_TOTAL_FAILS OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) MARKOV_HI_TOTAL_FAILS [
+        MARKOV_HI_TOTAL_FAILS OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) MARKOV_LO_TOTAL_FAILS [
+        MARKOV_LO_TOTAL_FAILS OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) EXTHT_HI_TOTAL_FAILS [
+        EXTHT_HI_TOTAL_FAILS OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) EXTHT_LO_TOTAL_FAILS [
+        EXTHT_LO_TOTAL_FAILS OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) ALERT_THRESHOLD [
+        ALERT_THRESHOLD OFFSET(0) NUMBITS(16) [],
+        ALERT_THRESHOLD_INV OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) ALERT_SUMMARY_FAIL_COUNTS [
+        ANY_FAIL_COUNT OFFSET(0) NUMBITS(16) [],
+    ],
+    pub(crate) ALERT_FAIL_COUNTS [
+        REPCNT_FAIL_COUNT OFFSET(4) NUMBITS(4) [],
+        ADAPTP_HI_FAIL_COUNT OFFSET(8) NUMBITS(4) [],
+        ADAPTP_LO_FAIL_COUNT OFFSET(12) NUMBITS(4) [],
+        BUCKET_FAIL_COUNT OFFSET(16) NUMBITS(4) [],
+        MARKOV_HI_FAIL_COUNT OFFSET(20) NUMBITS(4) [],
+        MARKOV_LO_FAIL_COUNT OFFSET(24) NUMBITS(4) [],
+        REPCNTS_FAIL_COUNT OFFSET(28) NUMBITS(4) [],
+    ],
+    pub(crate) EXTHT_FAIL_COUNTS [
+        EXTHT_HI_FAIL_COUNT OFFSET(0) NUMBITS(4) [],
+        EXTHT_LO_FAIL_COUNT OFFSET(4) NUMBITS(4) [],
+    ],
+    pub(crate) FW_OV_CONTROL [
+        FW_OV_MODE OFFSET(0) NUMBITS(4) [],
+        FW_OV_ENTROPY_INSERT OFFSET(4) NUMBITS(4) [],
+    ],
+    pub(crate) FW_OV_SHA3_START [
+        FW_OV_INSERT_START OFFSET(0) NUMBITS(4) [],
+    ],
+    pub(crate) FW_OV_WR_FIFO_FULL [
+        FW_OV_WR_FIFO_FULL OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) FW_OV_RD_FIFO_OVERFLOW [
+        FW_OV_RD_FIFO_OVERFLOW OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) FW_OV_RD_DATA [
+        FW_OV_RD_DATA OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) FW_OV_WR_DATA [
+        FW_OV_WR_DATA OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) OBSERVE_FIFO_THRESH [
+        OBSERVE_FIFO_THRESH OFFSET(0) NUMBITS(7) [],
+    ],
+    pub(crate) OBSERVE_FIFO_DEPTH [
+        OBSERVE_FIFO_DEPTH OFFSET(0) NUMBITS(7) [],
+    ],
+    pub(crate) DEBUG_STATUS [
+        ENTROPY_FIFO_DEPTH OFFSET(0) NUMBITS(3) [],
+        SHA3_FSM OFFSET(3) NUMBITS(3) [],
+        SHA3_BLOCK_PR OFFSET(6) NUMBITS(1) [],
+        SHA3_SQUEEZING OFFSET(7) NUMBITS(1) [],
+        SHA3_ABSORBED OFFSET(8) NUMBITS(1) [],
+        SHA3_ERR OFFSET(9) NUMBITS(1) [],
+        MAIN_SM_IDLE OFFSET(16) NUMBITS(1) [],
+        MAIN_SM_BOOT_DONE OFFSET(17) NUMBITS(1) [],
+    ],
+    pub(crate) RECOV_ALERT_STS [
+        FIPS_ENABLE_FIELD_ALERT OFFSET(0) NUMBITS(1) [],
+        ENTROPY_DATA_REG_EN_FIELD_ALERT OFFSET(1) NUMBITS(1) [],
+        MODULE_ENABLE_FIELD_ALERT OFFSET(2) NUMBITS(1) [],
+        THRESHOLD_SCOPE_FIELD_ALERT OFFSET(3) NUMBITS(1) [],
+        RNG_BIT_ENABLE_FIELD_ALERT OFFSET(5) NUMBITS(1) [],
+        FW_OV_SHA3_START_FIELD_ALERT OFFSET(7) NUMBITS(1) [],
+        FW_OV_MODE_FIELD_ALERT OFFSET(8) NUMBITS(1) [],
+        FW_OV_ENTROPY_INSERT_FIELD_ALERT OFFSET(9) NUMBITS(1) [],
+        ES_ROUTE_FIELD_ALERT OFFSET(10) NUMBITS(1) [],
+        ES_TYPE_FIELD_ALERT OFFSET(11) NUMBITS(1) [],
+        ES_MAIN_SM_ALERT OFFSET(12) NUMBITS(1) [],
+        ES_BUS_CMP_ALERT OFFSET(13) NUMBITS(1) [],
+        ES_THRESH_CFG_ALERT OFFSET(14) NUMBITS(1) [],
+        ES_FW_OV_WR_ALERT OFFSET(15) NUMBITS(1) [],
+        ES_FW_OV_DISABLE_ALERT OFFSET(16) NUMBITS(1) [],
+    ],
+    pub(crate) ERR_CODE [
+        SFIFO_ESRNG_ERR OFFSET(0) NUMBITS(1) [],
+        SFIFO_OBSERVE_ERR OFFSET(1) NUMBITS(1) [],
+        SFIFO_ESFINAL_ERR OFFSET(2) NUMBITS(1) [],
+        ES_ACK_SM_ERR OFFSET(20) NUMBITS(1) [],
+        ES_MAIN_SM_ERR OFFSET(21) NUMBITS(1) [],
+        ES_CNTR_ERR OFFSET(22) NUMBITS(1) [],
+        SHA3_STATE_ERR OFFSET(23) NUMBITS(1) [],
+        SHA3_RST_STORAGE_ERR OFFSET(24) NUMBITS(1) [],
+        FIFO_WRITE_ERR OFFSET(28) NUMBITS(1) [],
+        FIFO_READ_ERR OFFSET(29) NUMBITS(1) [],
+        FIFO_STATE_ERR OFFSET(30) NUMBITS(1) [],
+    ],
+    pub(crate) ERR_CODE_TEST [
+        ERR_CODE_TEST OFFSET(0) NUMBITS(5) [],
+    ],
+    pub(crate) MAIN_SM_STATE [
+        MAIN_SM_STATE OFFSET(0) NUMBITS(9) [],
+    ],
+];
+
+// End generated register constants for entropy_src

--- a/chips/lowrisc/src/registers/flash_ctrl_regs.rs
+++ b/chips/lowrisc/src/registers/flash_ctrl_regs.rs
@@ -1,0 +1,429 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for flash_ctrl.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/ip/flash_ctrl/data/flash_ctrl.hjson
+use kernel::utilities::registers::ReadOnly;
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::WriteOnly;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Number of flash banks
+pub const FLASH_CTRL_PARAM_REG_NUM_BANKS: u32 = 2;
+/// Number of pages per bank
+pub const FLASH_CTRL_PARAM_REG_PAGES_PER_BANK: u32 = 256;
+/// Program resolution window in bytes
+pub const FLASH_CTRL_PARAM_REG_BUS_PGM_RES_BYTES: u32 = 64;
+/// Number of bits needed to represent the pages within a bank
+pub const FLASH_CTRL_PARAM_REG_PAGE_WIDTH: u32 = 8;
+/// Number of bits needed to represent the number of banks
+pub const FLASH_CTRL_PARAM_REG_BANK_WIDTH: u32 = 1;
+/// Number of configurable flash regions
+pub const FLASH_CTRL_PARAM_NUM_REGIONS: u32 = 8;
+/// Number of info partition types
+pub const FLASH_CTRL_PARAM_NUM_INFO_TYPES: u32 = 3;
+/// Number of configurable flash info pages for info type 0
+pub const FLASH_CTRL_PARAM_NUM_INFOS0: u32 = 10;
+/// Number of configurable flash info pages for info type 1
+pub const FLASH_CTRL_PARAM_NUM_INFOS1: u32 = 1;
+/// Number of configurable flash info pages for info type 2
+pub const FLASH_CTRL_PARAM_NUM_INFOS2: u32 = 2;
+/// Number of words per page
+pub const FLASH_CTRL_PARAM_WORDS_PER_PAGE: u32 = 256;
+/// Number of bytes per word
+pub const FLASH_CTRL_PARAM_BYTES_PER_WORD: u32 = 8;
+/// Number of bytes per page
+pub const FLASH_CTRL_PARAM_BYTES_PER_PAGE: u32 = 2048;
+/// Number of bytes per bank
+pub const FLASH_CTRL_PARAM_BYTES_PER_BANK: u32 = 524288;
+/// Maximum depth for read / program fifos
+pub const FLASH_CTRL_PARAM_MAX_FIFO_DEPTH: u32 = 16;
+/// Maximum depth for read / program fifos
+pub const FLASH_CTRL_PARAM_MAX_FIFO_WIDTH: u32 = 5;
+/// Number of alerts
+pub const FLASH_CTRL_PARAM_NUM_ALERTS: u32 = 5;
+/// Register width
+pub const FLASH_CTRL_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub FlashCtrlRegisters {
+        /// Interrupt State Register
+        (0x0000 => pub(crate) intr_state: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Enable Register
+        (0x0004 => pub(crate) intr_enable: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Test Register
+        (0x0008 => pub(crate) intr_test: ReadWrite<u32, INTR::Register>),
+        /// Alert Test Register
+        (0x000c => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// Disable flash functionality
+        (0x0010 => pub(crate) dis: ReadWrite<u32, DIS::Register>),
+        /// Controls whether flash can be used for code execution fetches
+        (0x0014 => pub(crate) exec: ReadWrite<u32, EXEC::Register>),
+        /// Controller init register
+        (0x0018 => pub(crate) init: ReadWrite<u32, INIT::Register>),
+        /// Controls the configurability of the !!CONTROL register.
+        (0x001c => pub(crate) ctrl_regwen: ReadWrite<u32, CTRL_REGWEN::Register>),
+        /// Control register
+        (0x0020 => pub(crate) control: ReadWrite<u32, CONTROL::Register>),
+        /// Address for flash operation
+        (0x0024 => pub(crate) addr: ReadWrite<u32, ADDR::Register>),
+        /// Enable different program types
+        (0x0028 => pub(crate) prog_type_en: ReadWrite<u32, PROG_TYPE_EN::Register>),
+        /// Suspend erase
+        (0x002c => pub(crate) erase_suspend: ReadWrite<u32, ERASE_SUSPEND::Register>),
+        /// Memory region registers configuration enable.
+        (0x0030 => pub(crate) region_cfg_regwen: [ReadWrite<u32, REGION_CFG_REGWEN::Register>; 8]),
+        /// Memory property configuration for data partition
+        (0x0050 => pub(crate) mp_region_cfg: [ReadWrite<u32, MP_REGION_CFG::Register>; 8]),
+        /// Memory base and size configuration for data partition
+        (0x0070 => pub(crate) mp_region: [ReadWrite<u32, MP_REGION::Register>; 8]),
+        /// Default region properties
+        (0x0090 => pub(crate) default_region: ReadWrite<u32, DEFAULT_REGION::Register>),
+        /// Memory region registers configuration enable.
+        (0x0094 => pub(crate) bank0_info0_regwen: [ReadWrite<u32, BANK0_INFO0_REGWEN::Register>; 10]),
+        ///   Memory property configuration for info partition in bank0,
+        (0x00bc => pub(crate) bank0_info0_page_cfg: [ReadWrite<u32, BANK0_INFO0_PAGE_CFG::Register>; 10]),
+        /// Memory region registers configuration enable.
+        (0x00e4 => pub(crate) bank0_info1_regwen: [ReadWrite<u32, BANK0_INFO1_REGWEN::Register>; 1]),
+        ///   Memory property configuration for info partition in bank0,
+        (0x00e8 => pub(crate) bank0_info1_page_cfg: [ReadWrite<u32, BANK0_INFO1_PAGE_CFG::Register>; 1]),
+        /// Memory region registers configuration enable.
+        (0x00ec => pub(crate) bank0_info2_regwen: [ReadWrite<u32, BANK0_INFO2_REGWEN::Register>; 2]),
+        ///   Memory property configuration for info partition in bank0,
+        (0x00f4 => pub(crate) bank0_info2_page_cfg: [ReadWrite<u32, BANK0_INFO2_PAGE_CFG::Register>; 2]),
+        /// Memory region registers configuration enable.
+        (0x00fc => pub(crate) bank1_info0_regwen: [ReadWrite<u32, BANK1_INFO0_REGWEN::Register>; 10]),
+        ///   Memory property configuration for info partition in bank1,
+        (0x0124 => pub(crate) bank1_info0_page_cfg: [ReadWrite<u32, BANK1_INFO0_PAGE_CFG::Register>; 10]),
+        /// Memory region registers configuration enable.
+        (0x014c => pub(crate) bank1_info1_regwen: [ReadWrite<u32, BANK1_INFO1_REGWEN::Register>; 1]),
+        ///   Memory property configuration for info partition in bank1,
+        (0x0150 => pub(crate) bank1_info1_page_cfg: [ReadWrite<u32, BANK1_INFO1_PAGE_CFG::Register>; 1]),
+        /// Memory region registers configuration enable.
+        (0x0154 => pub(crate) bank1_info2_regwen: [ReadWrite<u32, BANK1_INFO2_REGWEN::Register>; 2]),
+        ///   Memory property configuration for info partition in bank1,
+        (0x015c => pub(crate) bank1_info2_page_cfg: [ReadWrite<u32, BANK1_INFO2_PAGE_CFG::Register>; 2]),
+        /// HW interface info configuration rule overrides
+        (0x0164 => pub(crate) hw_info_cfg_override: ReadWrite<u32, HW_INFO_CFG_OVERRIDE::Register>),
+        /// Bank configuration registers configuration enable.
+        (0x0168 => pub(crate) bank_cfg_regwen: ReadWrite<u32, BANK_CFG_REGWEN::Register>),
+        /// Memory properties bank configuration
+        (0x016c => pub(crate) mp_bank_cfg_shadowed: [ReadWrite<u32, MP_BANK_CFG_SHADOWED::Register>; 1]),
+        /// Flash Operation Status
+        (0x0170 => pub(crate) op_status: ReadWrite<u32, OP_STATUS::Register>),
+        /// Flash Controller Status
+        (0x0174 => pub(crate) status: ReadWrite<u32, STATUS::Register>),
+        /// Current flash fsm state
+        (0x0178 => pub(crate) debug_state: ReadWrite<u32, DEBUG_STATE::Register>),
+        /// Flash error code register.
+        (0x017c => pub(crate) err_code: ReadWrite<u32, ERR_CODE::Register>),
+        /// This register tabulates standard fault status of the flash.
+        (0x0180 => pub(crate) std_fault_status: ReadWrite<u32, STD_FAULT_STATUS::Register>),
+        /// This register tabulates customized fault status of the flash.
+        (0x0184 => pub(crate) fault_status: ReadWrite<u32, FAULT_STATUS::Register>),
+        /// Synchronous error address
+        (0x0188 => pub(crate) err_addr: ReadWrite<u32, ERR_ADDR::Register>),
+        /// Total number of single bit ECC error count
+        (0x018c => pub(crate) ecc_single_err_cnt: [ReadWrite<u32, ECC_SINGLE_ERR_CNT::Register>; 1]),
+        /// Latest address of ECC single err
+        (0x0190 => pub(crate) ecc_single_err_addr: [ReadWrite<u32, ECC_SINGLE_ERR_ADDR::Register>; 2]),
+        /// Phy alert configuration
+        (0x0198 => pub(crate) phy_alert_cfg: ReadWrite<u32, PHY_ALERT_CFG::Register>),
+        /// Flash Phy Status
+        (0x019c => pub(crate) phy_status: ReadWrite<u32, PHY_STATUS::Register>),
+        /// Flash Controller Scratch
+        (0x01a0 => pub(crate) scratch: ReadWrite<u32, SCRATCH::Register>),
+        /// Programmable depth where FIFOs should generate interrupts
+        (0x01a4 => pub(crate) fifo_lvl: ReadWrite<u32, FIFO_LVL::Register>),
+        /// Reset for flash controller FIFOs
+        (0x01a8 => pub(crate) fifo_rst: ReadWrite<u32, FIFO_RST::Register>),
+        /// Current program and read fifo depth
+        (0x01ac => pub(crate) curr_fifo_lvl: ReadWrite<u32, CURR_FIFO_LVL::Register>),
+        /// Memory area: Flash program FIFO.
+        (0x01b0 => pub(crate) prog_fifo: [WriteOnly<u32>; 1]),
+        /// Memory area: Flash read FIFO.
+        (0x01b4 => pub(crate) rd_fifo: [ReadOnly<u32>; 1]),
+        (0x01b8 => @END),
+    }
+}
+
+register_bitfields![u32,
+    /// Common Interrupt Offsets
+    pub(crate) INTR [
+        PROG_EMPTY OFFSET(0) NUMBITS(1) [],
+        PROG_LVL OFFSET(1) NUMBITS(1) [],
+        RD_FULL OFFSET(2) NUMBITS(1) [],
+        RD_LVL OFFSET(3) NUMBITS(1) [],
+        OP_DONE OFFSET(4) NUMBITS(1) [],
+        CORR_ERR OFFSET(5) NUMBITS(1) [],
+    ],
+    pub(crate) ALERT_TEST [
+        RECOV_ERR OFFSET(0) NUMBITS(1) [],
+        FATAL_STD_ERR OFFSET(1) NUMBITS(1) [],
+        FATAL_ERR OFFSET(2) NUMBITS(1) [],
+        FATAL_PRIM_FLASH_ALERT OFFSET(3) NUMBITS(1) [],
+        RECOV_PRIM_FLASH_ALERT OFFSET(4) NUMBITS(1) [],
+    ],
+    pub(crate) DIS [
+        VAL OFFSET(0) NUMBITS(4) [],
+    ],
+    pub(crate) EXEC [
+        EN OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) INIT [
+        VAL OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CTRL_REGWEN [
+        EN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CONTROL [
+        START OFFSET(0) NUMBITS(1) [],
+        OP OFFSET(4) NUMBITS(2) [
+            READ = 0,
+            PROG = 1,
+            ERASE = 2,
+        ],
+        PROG_SEL OFFSET(6) NUMBITS(1) [
+            NORMAL_PROGRAM = 0,
+            PROGRAM_REPAIR = 1,
+        ],
+        ERASE_SEL OFFSET(7) NUMBITS(1) [
+            PAGE_ERASE = 0,
+            BANK_ERASE = 1,
+        ],
+        PARTITION_SEL OFFSET(8) NUMBITS(1) [],
+        INFO_SEL OFFSET(9) NUMBITS(2) [],
+        NUM OFFSET(16) NUMBITS(12) [],
+    ],
+    pub(crate) ADDR [
+        START OFFSET(0) NUMBITS(20) [],
+    ],
+    pub(crate) PROG_TYPE_EN [
+        NORMAL OFFSET(0) NUMBITS(1) [],
+        REPAIR OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) ERASE_SUSPEND [
+        REQ OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) REGION_CFG_REGWEN [
+        REGION_0 OFFSET(0) NUMBITS(1) [
+            REGION_LOCKED = 0,
+            REGION_ENABLED = 1,
+        ],
+    ],
+    pub(crate) MP_REGION_CFG [
+        EN_0 OFFSET(0) NUMBITS(4) [],
+        RD_EN_0 OFFSET(4) NUMBITS(4) [],
+        PROG_EN_0 OFFSET(8) NUMBITS(4) [],
+        ERASE_EN_0 OFFSET(12) NUMBITS(4) [],
+        SCRAMBLE_EN_0 OFFSET(16) NUMBITS(4) [],
+        ECC_EN_0 OFFSET(20) NUMBITS(4) [],
+        HE_EN_0 OFFSET(24) NUMBITS(4) [],
+    ],
+    pub(crate) MP_REGION [
+        BASE_0 OFFSET(0) NUMBITS(9) [],
+        SIZE_0 OFFSET(9) NUMBITS(10) [],
+    ],
+    pub(crate) DEFAULT_REGION [
+        RD_EN OFFSET(0) NUMBITS(4) [],
+        PROG_EN OFFSET(4) NUMBITS(4) [],
+        ERASE_EN OFFSET(8) NUMBITS(4) [],
+        SCRAMBLE_EN OFFSET(12) NUMBITS(4) [],
+        ECC_EN OFFSET(16) NUMBITS(4) [],
+        HE_EN OFFSET(20) NUMBITS(4) [],
+    ],
+    pub(crate) BANK0_INFO0_REGWEN [
+        REGION_0 OFFSET(0) NUMBITS(1) [
+            PAGE_LOCKED = 0,
+            PAGE_ENABLED = 1,
+        ],
+    ],
+    pub(crate) BANK0_INFO0_PAGE_CFG [
+        EN_0 OFFSET(0) NUMBITS(4) [],
+        RD_EN_0 OFFSET(4) NUMBITS(4) [],
+        PROG_EN_0 OFFSET(8) NUMBITS(4) [],
+        ERASE_EN_0 OFFSET(12) NUMBITS(4) [],
+        SCRAMBLE_EN_0 OFFSET(16) NUMBITS(4) [],
+        ECC_EN_0 OFFSET(20) NUMBITS(4) [],
+        HE_EN_0 OFFSET(24) NUMBITS(4) [],
+    ],
+    pub(crate) BANK0_INFO1_REGWEN [
+        REGION_0 OFFSET(0) NUMBITS(1) [
+            PAGE_LOCKED = 0,
+            PAGE_ENABLED = 1,
+        ],
+    ],
+    pub(crate) BANK0_INFO1_PAGE_CFG [
+        EN_0 OFFSET(0) NUMBITS(4) [],
+        RD_EN_0 OFFSET(4) NUMBITS(4) [],
+        PROG_EN_0 OFFSET(8) NUMBITS(4) [],
+        ERASE_EN_0 OFFSET(12) NUMBITS(4) [],
+        SCRAMBLE_EN_0 OFFSET(16) NUMBITS(4) [],
+        ECC_EN_0 OFFSET(20) NUMBITS(4) [],
+        HE_EN_0 OFFSET(24) NUMBITS(4) [],
+    ],
+    pub(crate) BANK0_INFO2_REGWEN [
+        REGION_0 OFFSET(0) NUMBITS(1) [
+            PAGE_LOCKED = 0,
+            PAGE_ENABLED = 1,
+        ],
+    ],
+    pub(crate) BANK0_INFO2_PAGE_CFG [
+        EN_0 OFFSET(0) NUMBITS(4) [],
+        RD_EN_0 OFFSET(4) NUMBITS(4) [],
+        PROG_EN_0 OFFSET(8) NUMBITS(4) [],
+        ERASE_EN_0 OFFSET(12) NUMBITS(4) [],
+        SCRAMBLE_EN_0 OFFSET(16) NUMBITS(4) [],
+        ECC_EN_0 OFFSET(20) NUMBITS(4) [],
+        HE_EN_0 OFFSET(24) NUMBITS(4) [],
+    ],
+    pub(crate) BANK1_INFO0_REGWEN [
+        REGION_0 OFFSET(0) NUMBITS(1) [
+            PAGE_LOCKED = 0,
+            PAGE_ENABLED = 1,
+        ],
+    ],
+    pub(crate) BANK1_INFO0_PAGE_CFG [
+        EN_0 OFFSET(0) NUMBITS(4) [],
+        RD_EN_0 OFFSET(4) NUMBITS(4) [],
+        PROG_EN_0 OFFSET(8) NUMBITS(4) [],
+        ERASE_EN_0 OFFSET(12) NUMBITS(4) [],
+        SCRAMBLE_EN_0 OFFSET(16) NUMBITS(4) [],
+        ECC_EN_0 OFFSET(20) NUMBITS(4) [],
+        HE_EN_0 OFFSET(24) NUMBITS(4) [],
+    ],
+    pub(crate) BANK1_INFO1_REGWEN [
+        REGION_0 OFFSET(0) NUMBITS(1) [
+            PAGE_LOCKED = 0,
+            PAGE_ENABLED = 1,
+        ],
+    ],
+    pub(crate) BANK1_INFO1_PAGE_CFG [
+        EN_0 OFFSET(0) NUMBITS(4) [],
+        RD_EN_0 OFFSET(4) NUMBITS(4) [],
+        PROG_EN_0 OFFSET(8) NUMBITS(4) [],
+        ERASE_EN_0 OFFSET(12) NUMBITS(4) [],
+        SCRAMBLE_EN_0 OFFSET(16) NUMBITS(4) [],
+        ECC_EN_0 OFFSET(20) NUMBITS(4) [],
+        HE_EN_0 OFFSET(24) NUMBITS(4) [],
+    ],
+    pub(crate) BANK1_INFO2_REGWEN [
+        REGION_0 OFFSET(0) NUMBITS(1) [
+            PAGE_LOCKED = 0,
+            PAGE_ENABLED = 1,
+        ],
+    ],
+    pub(crate) BANK1_INFO2_PAGE_CFG [
+        EN_0 OFFSET(0) NUMBITS(4) [],
+        RD_EN_0 OFFSET(4) NUMBITS(4) [],
+        PROG_EN_0 OFFSET(8) NUMBITS(4) [],
+        ERASE_EN_0 OFFSET(12) NUMBITS(4) [],
+        SCRAMBLE_EN_0 OFFSET(16) NUMBITS(4) [],
+        ECC_EN_0 OFFSET(20) NUMBITS(4) [],
+        HE_EN_0 OFFSET(24) NUMBITS(4) [],
+    ],
+    pub(crate) HW_INFO_CFG_OVERRIDE [
+        SCRAMBLE_DIS OFFSET(0) NUMBITS(4) [],
+        ECC_DIS OFFSET(4) NUMBITS(4) [],
+    ],
+    pub(crate) BANK_CFG_REGWEN [
+        BANK OFFSET(0) NUMBITS(1) [
+            BANK_LOCKED = 0,
+            BANK_ENABLED = 1,
+        ],
+    ],
+    pub(crate) MP_BANK_CFG_SHADOWED [
+        ERASE_EN_0 OFFSET(0) NUMBITS(1) [],
+        ERASE_EN_1 OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) OP_STATUS [
+        DONE OFFSET(0) NUMBITS(1) [],
+        ERR OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) STATUS [
+        RD_FULL OFFSET(0) NUMBITS(1) [],
+        RD_EMPTY OFFSET(1) NUMBITS(1) [],
+        PROG_FULL OFFSET(2) NUMBITS(1) [],
+        PROG_EMPTY OFFSET(3) NUMBITS(1) [],
+        INIT_WIP OFFSET(4) NUMBITS(1) [],
+        INITIALIZED OFFSET(5) NUMBITS(1) [],
+    ],
+    pub(crate) DEBUG_STATE [
+        LCMGR_STATE OFFSET(0) NUMBITS(11) [],
+    ],
+    pub(crate) ERR_CODE [
+        OP_ERR OFFSET(0) NUMBITS(1) [],
+        MP_ERR OFFSET(1) NUMBITS(1) [],
+        RD_ERR OFFSET(2) NUMBITS(1) [],
+        PROG_ERR OFFSET(3) NUMBITS(1) [],
+        PROG_WIN_ERR OFFSET(4) NUMBITS(1) [],
+        PROG_TYPE_ERR OFFSET(5) NUMBITS(1) [],
+        UPDATE_ERR OFFSET(6) NUMBITS(1) [],
+        MACRO_ERR OFFSET(7) NUMBITS(1) [],
+    ],
+    pub(crate) STD_FAULT_STATUS [
+        REG_INTG_ERR OFFSET(0) NUMBITS(1) [],
+        PROG_INTG_ERR OFFSET(1) NUMBITS(1) [],
+        LCMGR_ERR OFFSET(2) NUMBITS(1) [],
+        LCMGR_INTG_ERR OFFSET(3) NUMBITS(1) [],
+        ARB_FSM_ERR OFFSET(4) NUMBITS(1) [],
+        STORAGE_ERR OFFSET(5) NUMBITS(1) [],
+        PHY_FSM_ERR OFFSET(6) NUMBITS(1) [],
+        CTRL_CNT_ERR OFFSET(7) NUMBITS(1) [],
+        FIFO_ERR OFFSET(8) NUMBITS(1) [],
+    ],
+    pub(crate) FAULT_STATUS [
+        OP_ERR OFFSET(0) NUMBITS(1) [],
+        MP_ERR OFFSET(1) NUMBITS(1) [],
+        RD_ERR OFFSET(2) NUMBITS(1) [],
+        PROG_ERR OFFSET(3) NUMBITS(1) [],
+        PROG_WIN_ERR OFFSET(4) NUMBITS(1) [],
+        PROG_TYPE_ERR OFFSET(5) NUMBITS(1) [],
+        SEED_ERR OFFSET(6) NUMBITS(1) [],
+        PHY_RELBL_ERR OFFSET(7) NUMBITS(1) [],
+        PHY_STORAGE_ERR OFFSET(8) NUMBITS(1) [],
+        SPURIOUS_ACK OFFSET(9) NUMBITS(1) [],
+        ARB_ERR OFFSET(10) NUMBITS(1) [],
+        HOST_GNT_ERR OFFSET(11) NUMBITS(1) [],
+    ],
+    pub(crate) ERR_ADDR [
+        ERR_ADDR OFFSET(0) NUMBITS(20) [],
+    ],
+    pub(crate) ECC_SINGLE_ERR_CNT [
+        ECC_SINGLE_ERR_CNT_0 OFFSET(0) NUMBITS(8) [],
+        ECC_SINGLE_ERR_CNT_1 OFFSET(8) NUMBITS(8) [],
+    ],
+    pub(crate) ECC_SINGLE_ERR_ADDR [
+        ECC_SINGLE_ERR_ADDR_0 OFFSET(0) NUMBITS(20) [],
+    ],
+    pub(crate) PHY_ALERT_CFG [
+        ALERT_ACK OFFSET(0) NUMBITS(1) [],
+        ALERT_TRIG OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) PHY_STATUS [
+        INIT_WIP OFFSET(0) NUMBITS(1) [],
+        PROG_NORMAL_AVAIL OFFSET(1) NUMBITS(1) [],
+        PROG_REPAIR_AVAIL OFFSET(2) NUMBITS(1) [],
+    ],
+    pub(crate) SCRATCH [
+        DATA OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) FIFO_LVL [
+        PROG OFFSET(0) NUMBITS(5) [],
+        RD OFFSET(8) NUMBITS(5) [],
+    ],
+    pub(crate) FIFO_RST [
+        EN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CURR_FIFO_LVL [
+        PROG OFFSET(0) NUMBITS(5) [],
+        RD OFFSET(8) NUMBITS(5) [],
+    ],
+];
+
+// End generated register constants for flash_ctrl

--- a/chips/lowrisc/src/registers/gpio_regs.rs
+++ b/chips/lowrisc/src/registers/gpio_regs.rs
@@ -1,0 +1,157 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for gpio.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/ip/gpio/data/gpio.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Number of alerts
+pub const GPIO_PARAM_NUM_ALERTS: u32 = 1;
+/// Register width
+pub const GPIO_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub GpioRegisters {
+        /// Interrupt State Register
+        (0x0000 => pub(crate) intr_state: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Enable Register
+        (0x0004 => pub(crate) intr_enable: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Test Register
+        (0x0008 => pub(crate) intr_test: ReadWrite<u32, INTR::Register>),
+        /// Alert Test Register
+        (0x000c => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// GPIO Input data read value
+        (0x0010 => pub(crate) data_in: ReadWrite<u32, DATA_IN::Register>),
+        /// GPIO direct output data write value
+        (0x0014 => pub(crate) direct_out: ReadWrite<u32, DIRECT_OUT::Register>),
+        /// GPIO write data lower with mask.
+        (0x0018 => pub(crate) masked_out_lower: ReadWrite<u32, MASKED_OUT_LOWER::Register>),
+        /// GPIO write data upper with mask.
+        (0x001c => pub(crate) masked_out_upper: ReadWrite<u32, MASKED_OUT_UPPER::Register>),
+        /// GPIO Output Enable.
+        (0x0020 => pub(crate) direct_oe: ReadWrite<u32, DIRECT_OE::Register>),
+        /// GPIO write Output Enable lower with mask.
+        (0x0024 => pub(crate) masked_oe_lower: ReadWrite<u32, MASKED_OE_LOWER::Register>),
+        /// GPIO write Output Enable upper with mask.
+        (0x0028 => pub(crate) masked_oe_upper: ReadWrite<u32, MASKED_OE_UPPER::Register>),
+        /// GPIO interrupt enable for GPIO, rising edge.
+        (0x002c => pub(crate) intr_ctrl_en_rising: ReadWrite<u32, INTR::Register>),
+        /// GPIO interrupt enable for GPIO, falling edge.
+        (0x0030 => pub(crate) intr_ctrl_en_falling: ReadWrite<u32, INTR::Register>),
+        /// GPIO interrupt enable for GPIO, level high.
+        (0x0034 => pub(crate) intr_ctrl_en_lvlhigh: ReadWrite<u32, INTR::Register>),
+        /// GPIO interrupt enable for GPIO, level low.
+        (0x0038 => pub(crate) intr_ctrl_en_lvllow: ReadWrite<u32, INTR::Register>),
+        /// filter enable for GPIO input bits.
+        (0x003c => pub(crate) ctrl_en_input_filter: ReadWrite<u32, CTRL_EN_INPUT_FILTER::Register>),
+        (0x0040 => @END),
+    }
+}
+
+register_bitfields![u32,
+    /// Common Interrupt Offsets
+    pub(crate) INTR [
+        GPIO_0 OFFSET(0) NUMBITS(1) [],
+        GPIO_1 OFFSET(1) NUMBITS(1) [],
+        GPIO_2 OFFSET(2) NUMBITS(1) [],
+        GPIO_3 OFFSET(3) NUMBITS(1) [],
+        GPIO_4 OFFSET(4) NUMBITS(1) [],
+        GPIO_5 OFFSET(5) NUMBITS(1) [],
+        GPIO_6 OFFSET(6) NUMBITS(1) [],
+        GPIO_7 OFFSET(7) NUMBITS(1) [],
+        GPIO_8 OFFSET(8) NUMBITS(1) [],
+        GPIO_9 OFFSET(9) NUMBITS(1) [],
+        GPIO_10 OFFSET(10) NUMBITS(1) [],
+        GPIO_11 OFFSET(11) NUMBITS(1) [],
+        GPIO_12 OFFSET(12) NUMBITS(1) [],
+        GPIO_13 OFFSET(13) NUMBITS(1) [],
+        GPIO_14 OFFSET(14) NUMBITS(1) [],
+        GPIO_15 OFFSET(15) NUMBITS(1) [],
+        GPIO_16 OFFSET(16) NUMBITS(1) [],
+        GPIO_17 OFFSET(17) NUMBITS(1) [],
+        GPIO_18 OFFSET(18) NUMBITS(1) [],
+        GPIO_19 OFFSET(19) NUMBITS(1) [],
+        GPIO_20 OFFSET(20) NUMBITS(1) [],
+        GPIO_21 OFFSET(21) NUMBITS(1) [],
+        GPIO_22 OFFSET(22) NUMBITS(1) [],
+        GPIO_23 OFFSET(23) NUMBITS(1) [],
+        GPIO_24 OFFSET(24) NUMBITS(1) [],
+        GPIO_25 OFFSET(25) NUMBITS(1) [],
+        GPIO_26 OFFSET(26) NUMBITS(1) [],
+        GPIO_27 OFFSET(27) NUMBITS(1) [],
+        GPIO_28 OFFSET(28) NUMBITS(1) [],
+        GPIO_29 OFFSET(29) NUMBITS(1) [],
+        GPIO_30 OFFSET(30) NUMBITS(1) [],
+        GPIO_31 OFFSET(31) NUMBITS(1) [],
+    ],
+    pub(crate) ALERT_TEST [
+        FATAL_FAULT OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) DATA_IN [
+        DATA_IN OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) DIRECT_OUT [
+        DIRECT_OUT OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) MASKED_OUT_LOWER [
+        DATA OFFSET(0) NUMBITS(16) [],
+        MASK OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) MASKED_OUT_UPPER [
+        DATA OFFSET(0) NUMBITS(16) [],
+        MASK OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) DIRECT_OE [
+        DIRECT_OE_0 OFFSET(0) NUMBITS(1) [],
+        DIRECT_OE_1 OFFSET(1) NUMBITS(1) [],
+        DIRECT_OE_2 OFFSET(2) NUMBITS(1) [],
+        DIRECT_OE_3 OFFSET(3) NUMBITS(1) [],
+        DIRECT_OE_4 OFFSET(4) NUMBITS(1) [],
+        DIRECT_OE_5 OFFSET(5) NUMBITS(1) [],
+        DIRECT_OE_6 OFFSET(6) NUMBITS(1) [],
+        DIRECT_OE_7 OFFSET(7) NUMBITS(1) [],
+        DIRECT_OE_8 OFFSET(8) NUMBITS(1) [],
+        DIRECT_OE_9 OFFSET(9) NUMBITS(1) [],
+        DIRECT_OE_10 OFFSET(10) NUMBITS(1) [],
+        DIRECT_OE_11 OFFSET(11) NUMBITS(1) [],
+        DIRECT_OE_12 OFFSET(12) NUMBITS(1) [],
+        DIRECT_OE_13 OFFSET(13) NUMBITS(1) [],
+        DIRECT_OE_14 OFFSET(14) NUMBITS(1) [],
+        DIRECT_OE_15 OFFSET(15) NUMBITS(1) [],
+        DIRECT_OE_16 OFFSET(16) NUMBITS(1) [],
+        DIRECT_OE_17 OFFSET(17) NUMBITS(1) [],
+        DIRECT_OE_18 OFFSET(18) NUMBITS(1) [],
+        DIRECT_OE_19 OFFSET(19) NUMBITS(1) [],
+        DIRECT_OE_20 OFFSET(20) NUMBITS(1) [],
+        DIRECT_OE_21 OFFSET(21) NUMBITS(1) [],
+        DIRECT_OE_22 OFFSET(22) NUMBITS(1) [],
+        DIRECT_OE_23 OFFSET(23) NUMBITS(1) [],
+        DIRECT_OE_24 OFFSET(24) NUMBITS(1) [],
+        DIRECT_OE_25 OFFSET(25) NUMBITS(1) [],
+        DIRECT_OE_26 OFFSET(26) NUMBITS(1) [],
+        DIRECT_OE_27 OFFSET(27) NUMBITS(1) [],
+        DIRECT_OE_28 OFFSET(28) NUMBITS(1) [],
+        DIRECT_OE_29 OFFSET(29) NUMBITS(1) [],
+        DIRECT_OE_30 OFFSET(30) NUMBITS(1) [],
+        DIRECT_OE_31 OFFSET(31) NUMBITS(1) [],
+    ],
+    pub(crate) MASKED_OE_LOWER [
+        DATA OFFSET(0) NUMBITS(16) [],
+        MASK OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) MASKED_OE_UPPER [
+        DATA OFFSET(0) NUMBITS(16) [],
+        MASK OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) CTRL_EN_INPUT_FILTER [
+        CTRL_EN_INPUT_FILTER OFFSET(0) NUMBITS(32) [],
+    ],
+];
+
+// End generated register constants for gpio

--- a/chips/lowrisc/src/registers/hmac_regs.rs
+++ b/chips/lowrisc/src/registers/hmac_regs.rs
@@ -1,0 +1,104 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for hmac.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/ip/hmac/data/hmac.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::WriteOnly;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Number of words for digest/ key
+pub const HMAC_PARAM_NUM_WORDS: u32 = 8;
+/// Number of alerts
+pub const HMAC_PARAM_NUM_ALERTS: u32 = 1;
+/// Register width
+pub const HMAC_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub HmacRegisters {
+        /// Interrupt State Register
+        (0x0000 => pub(crate) intr_state: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Enable Register
+        (0x0004 => pub(crate) intr_enable: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Test Register
+        (0x0008 => pub(crate) intr_test: ReadWrite<u32, INTR::Register>),
+        /// Alert Test Register
+        (0x000c => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// HMAC Configuration register.
+        (0x0010 => pub(crate) cfg: ReadWrite<u32, CFG::Register>),
+        /// HMAC command register
+        (0x0014 => pub(crate) cmd: ReadWrite<u32, CMD::Register>),
+        /// HMAC Status register
+        (0x0018 => pub(crate) status: ReadWrite<u32, STATUS::Register>),
+        /// HMAC Error Code
+        (0x001c => pub(crate) err_code: ReadWrite<u32, ERR_CODE::Register>),
+        /// Randomize internal secret registers.
+        (0x0020 => pub(crate) wipe_secret: ReadWrite<u32, WIPE_SECRET::Register>),
+        /// HMAC Secret Key
+        (0x0024 => pub(crate) key: [ReadWrite<u32, KEY::Register>; 8]),
+        /// Digest output. If HMAC is disabled, the register shows result of SHA256
+        (0x0044 => pub(crate) digest: [ReadWrite<u32, DIGEST::Register>; 8]),
+        /// Received Message Length calculated by the HMAC in bits [31:0]
+        (0x0064 => pub(crate) msg_length_lower: ReadWrite<u32, MSG_LENGTH_LOWER::Register>),
+        /// Received Message Length calculated by the HMAC in bits [63:32]
+        (0x0068 => pub(crate) msg_length_upper: ReadWrite<u32, MSG_LENGTH_UPPER::Register>),
+        (0x006c => _reserved1),
+        /// Memory area: Message FIFO. Any write to this window will be appended to the FIFO. Only the
+        /// lower [1:0] bits of the address matter to writes within the window (for correctly dealing
+        /// with non 32-bit writes)
+        (0x0800 => pub(crate) msg_fifo: [WriteOnly<u32>; 512]),
+        (0x1000 => @END),
+    }
+}
+
+register_bitfields![u32,
+    /// Common Interrupt Offsets
+    pub(crate) INTR [
+        HMAC_DONE OFFSET(0) NUMBITS(1) [],
+        FIFO_EMPTY OFFSET(1) NUMBITS(1) [],
+        HMAC_ERR OFFSET(2) NUMBITS(1) [],
+    ],
+    pub(crate) ALERT_TEST [
+        FATAL_FAULT OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CFG [
+        HMAC_EN OFFSET(0) NUMBITS(1) [],
+        SHA_EN OFFSET(1) NUMBITS(1) [],
+        ENDIAN_SWAP OFFSET(2) NUMBITS(1) [],
+        DIGEST_SWAP OFFSET(3) NUMBITS(1) [],
+    ],
+    pub(crate) CMD [
+        HASH_START OFFSET(0) NUMBITS(1) [],
+        HASH_PROCESS OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) STATUS [
+        FIFO_EMPTY OFFSET(0) NUMBITS(1) [],
+        FIFO_FULL OFFSET(1) NUMBITS(1) [],
+        FIFO_DEPTH OFFSET(4) NUMBITS(5) [],
+    ],
+    pub(crate) ERR_CODE [
+        ERR_CODE OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) WIPE_SECRET [
+        SECRET OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) KEY [
+        KEY_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) DIGEST [
+        DIGEST_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) MSG_LENGTH_LOWER [
+        V OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) MSG_LENGTH_UPPER [
+        V OFFSET(0) NUMBITS(32) [],
+    ],
+];
+
+// End generated register constants for hmac

--- a/chips/lowrisc/src/registers/i2c_regs.rs
+++ b/chips/lowrisc/src/registers/i2c_regs.rs
@@ -1,0 +1,202 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for i2c.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/ip/i2c/data/i2c.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Depth of FMT, RX, TX, and ACQ FIFOs
+pub const I2C_PARAM_FIFO_DEPTH: u32 = 64;
+/// Number of alerts
+pub const I2C_PARAM_NUM_ALERTS: u32 = 1;
+/// Register width
+pub const I2C_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub I2cRegisters {
+        /// Interrupt State Register
+        (0x0000 => pub(crate) intr_state: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Enable Register
+        (0x0004 => pub(crate) intr_enable: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Test Register
+        (0x0008 => pub(crate) intr_test: ReadWrite<u32, INTR::Register>),
+        /// Alert Test Register
+        (0x000c => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// I2C Control Register
+        (0x0010 => pub(crate) ctrl: ReadWrite<u32, CTRL::Register>),
+        /// I2C Live Status Register
+        (0x0014 => pub(crate) status: ReadWrite<u32, STATUS::Register>),
+        /// I2C Read Data
+        (0x0018 => pub(crate) rdata: ReadWrite<u32, RDATA::Register>),
+        /// I2C Format Data
+        (0x001c => pub(crate) fdata: ReadWrite<u32, FDATA::Register>),
+        /// I2C FIFO control register
+        (0x0020 => pub(crate) fifo_ctrl: ReadWrite<u32, FIFO_CTRL::Register>),
+        /// I2C FIFO status register
+        (0x0024 => pub(crate) fifo_status: ReadWrite<u32, FIFO_STATUS::Register>),
+        /// I2C Override Control Register
+        (0x0028 => pub(crate) ovrd: ReadWrite<u32, OVRD::Register>),
+        /// Oversampled RX values
+        (0x002c => pub(crate) val: ReadWrite<u32, VAL::Register>),
+        /// Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).
+        (0x0030 => pub(crate) timing0: ReadWrite<u32, TIMING0::Register>),
+        /// Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).
+        (0x0034 => pub(crate) timing1: ReadWrite<u32, TIMING1::Register>),
+        /// Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).
+        (0x0038 => pub(crate) timing2: ReadWrite<u32, TIMING2::Register>),
+        /// Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification).
+        (0x003c => pub(crate) timing3: ReadWrite<u32, TIMING3::Register>),
+        /// Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification).
+        (0x0040 => pub(crate) timing4: ReadWrite<u32, TIMING4::Register>),
+        /// I2C clock stretching timeout control
+        (0x0044 => pub(crate) timeout_ctrl: ReadWrite<u32, TIMEOUT_CTRL::Register>),
+        /// I2C target address and mask pairs
+        (0x0048 => pub(crate) target_id: ReadWrite<u32, TARGET_ID::Register>),
+        /// I2C target acquired data
+        (0x004c => pub(crate) acqdata: ReadWrite<u32, ACQDATA::Register>),
+        /// I2C target transmit data
+        (0x0050 => pub(crate) txdata: ReadWrite<u32, TXDATA::Register>),
+        /// I2C host clock generation timeout value (in units of input clock frequency)
+        (0x0054 => pub(crate) host_timeout_ctrl: ReadWrite<u32, HOST_TIMEOUT_CTRL::Register>),
+        (0x0058 => @END),
+    }
+}
+
+register_bitfields![u32,
+    /// Common Interrupt Offsets
+    pub(crate) INTR [
+        FMT_THRESHOLD OFFSET(0) NUMBITS(1) [],
+        RX_THRESHOLD OFFSET(1) NUMBITS(1) [],
+        FMT_OVERFLOW OFFSET(2) NUMBITS(1) [],
+        RX_OVERFLOW OFFSET(3) NUMBITS(1) [],
+        NAK OFFSET(4) NUMBITS(1) [],
+        SCL_INTERFERENCE OFFSET(5) NUMBITS(1) [],
+        SDA_INTERFERENCE OFFSET(6) NUMBITS(1) [],
+        STRETCH_TIMEOUT OFFSET(7) NUMBITS(1) [],
+        SDA_UNSTABLE OFFSET(8) NUMBITS(1) [],
+        CMD_COMPLETE OFFSET(9) NUMBITS(1) [],
+        TX_STRETCH OFFSET(10) NUMBITS(1) [],
+        TX_OVERFLOW OFFSET(11) NUMBITS(1) [],
+        ACQ_FULL OFFSET(12) NUMBITS(1) [],
+        UNEXP_STOP OFFSET(13) NUMBITS(1) [],
+        HOST_TIMEOUT OFFSET(14) NUMBITS(1) [],
+    ],
+    pub(crate) ALERT_TEST [
+        FATAL_FAULT OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CTRL [
+        ENABLEHOST OFFSET(0) NUMBITS(1) [],
+        ENABLETARGET OFFSET(1) NUMBITS(1) [],
+        LLPBK OFFSET(2) NUMBITS(1) [],
+    ],
+    pub(crate) STATUS [
+        FMTFULL OFFSET(0) NUMBITS(1) [],
+        RXFULL OFFSET(1) NUMBITS(1) [],
+        FMTEMPTY OFFSET(2) NUMBITS(1) [],
+        HOSTIDLE OFFSET(3) NUMBITS(1) [],
+        TARGETIDLE OFFSET(4) NUMBITS(1) [],
+        RXEMPTY OFFSET(5) NUMBITS(1) [],
+        TXFULL OFFSET(6) NUMBITS(1) [],
+        ACQFULL OFFSET(7) NUMBITS(1) [],
+        TXEMPTY OFFSET(8) NUMBITS(1) [],
+        ACQEMPTY OFFSET(9) NUMBITS(1) [],
+    ],
+    pub(crate) RDATA [
+        RDATA OFFSET(0) NUMBITS(8) [],
+    ],
+    pub(crate) FDATA [
+        FBYTE OFFSET(0) NUMBITS(8) [],
+        START OFFSET(8) NUMBITS(1) [],
+        STOP OFFSET(9) NUMBITS(1) [],
+        READ OFFSET(10) NUMBITS(1) [],
+        RCONT OFFSET(11) NUMBITS(1) [],
+        NAKOK OFFSET(12) NUMBITS(1) [],
+    ],
+    pub(crate) FIFO_CTRL [
+        RXRST OFFSET(0) NUMBITS(1) [],
+        FMTRST OFFSET(1) NUMBITS(1) [],
+        RXILVL OFFSET(2) NUMBITS(3) [
+            RXLVL1 = 0,
+            RXLVL4 = 1,
+            RXLVL8 = 2,
+            RXLVL16 = 3,
+            RXLVL30 = 4,
+        ],
+        FMTILVL OFFSET(5) NUMBITS(2) [
+            FMTLVL1 = 0,
+            FMTLVL4 = 1,
+            FMTLVL8 = 2,
+            FMTLVL16 = 3,
+        ],
+        ACQRST OFFSET(7) NUMBITS(1) [],
+        TXRST OFFSET(8) NUMBITS(1) [],
+    ],
+    pub(crate) FIFO_STATUS [
+        FMTLVL OFFSET(0) NUMBITS(7) [],
+        TXLVL OFFSET(8) NUMBITS(7) [],
+        RXLVL OFFSET(16) NUMBITS(7) [],
+        ACQLVL OFFSET(24) NUMBITS(7) [],
+    ],
+    pub(crate) OVRD [
+        TXOVRDEN OFFSET(0) NUMBITS(1) [],
+        SCLVAL OFFSET(1) NUMBITS(1) [],
+        SDAVAL OFFSET(2) NUMBITS(1) [],
+    ],
+    pub(crate) VAL [
+        SCL_RX OFFSET(0) NUMBITS(16) [],
+        SDA_RX OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) TIMING0 [
+        THIGH OFFSET(0) NUMBITS(16) [],
+        TLOW OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) TIMING1 [
+        T_R OFFSET(0) NUMBITS(16) [],
+        T_F OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) TIMING2 [
+        TSU_STA OFFSET(0) NUMBITS(16) [],
+        THD_STA OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) TIMING3 [
+        TSU_DAT OFFSET(0) NUMBITS(16) [],
+        THD_DAT OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) TIMING4 [
+        TSU_STO OFFSET(0) NUMBITS(16) [],
+        T_BUF OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) TIMEOUT_CTRL [
+        VAL OFFSET(0) NUMBITS(31) [],
+        EN OFFSET(31) NUMBITS(1) [],
+    ],
+    pub(crate) TARGET_ID [
+        ADDRESS0 OFFSET(0) NUMBITS(7) [],
+        MASK0 OFFSET(7) NUMBITS(7) [],
+        ADDRESS1 OFFSET(14) NUMBITS(7) [],
+        MASK1 OFFSET(21) NUMBITS(7) [],
+    ],
+    pub(crate) ACQDATA [
+        ABYTE OFFSET(0) NUMBITS(8) [],
+        SIGNAL OFFSET(8) NUMBITS(2) [
+            NONE = 0,
+            START = 1,
+            STOP = 2,
+            RESTART = 3,
+        ],
+    ],
+    pub(crate) TXDATA [
+        TXDATA OFFSET(0) NUMBITS(8) [],
+    ],
+    pub(crate) HOST_TIMEOUT_CTRL [
+        HOST_TIMEOUT_CTRL OFFSET(0) NUMBITS(32) [],
+    ],
+];
+
+// End generated register constants for i2c

--- a/chips/lowrisc/src/registers/keymgr_regs.rs
+++ b/chips/lowrisc/src/registers/keymgr_regs.rs
@@ -1,0 +1,229 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for keymgr.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/ip/keymgr/data/keymgr.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Number of Registers for SW inputs (Salt)
+pub const KEYMGR_PARAM_NUM_SALT_REG: u32 = 8;
+/// Number of Registers for SW inputs (SW binding)
+pub const KEYMGR_PARAM_NUM_SW_BINDING_REG: u32 = 8;
+/// Number of Registers for SW outputs
+pub const KEYMGR_PARAM_NUM_OUT_REG: u32 = 8;
+/// Number of Registers for key version
+pub const KEYMGR_PARAM_NUM_KEY_VERSION: u32 = 1;
+/// Number of alerts
+pub const KEYMGR_PARAM_NUM_ALERTS: u32 = 2;
+/// Register width
+pub const KEYMGR_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub KeymgrRegisters {
+        /// Interrupt State Register
+        (0x0000 => pub(crate) intr_state: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Enable Register
+        (0x0004 => pub(crate) intr_enable: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Test Register
+        (0x0008 => pub(crate) intr_test: ReadWrite<u32, INTR::Register>),
+        /// Alert Test Register
+        (0x000c => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// Key manager configuration enable
+        (0x0010 => pub(crate) cfg_regwen: ReadWrite<u32, CFG_REGWEN::Register>),
+        /// Key manager operation start
+        (0x0014 => pub(crate) start: ReadWrite<u32, START::Register>),
+        /// Key manager operation controls
+        (0x0018 => pub(crate) control_shadowed: ReadWrite<u32, CONTROL_SHADOWED::Register>),
+        /// sideload key slots clear
+        (0x001c => pub(crate) sideload_clear: ReadWrite<u32, SIDELOAD_CLEAR::Register>),
+        /// regwen for reseed interval
+        (0x0020 => pub(crate) reseed_interval_regwen: ReadWrite<u32, RESEED_INTERVAL_REGWEN::Register>),
+        /// Reseed interval for key manager entropy reseed
+        (0x0024 => pub(crate) reseed_interval_shadowed: ReadWrite<u32, RESEED_INTERVAL_SHADOWED::Register>),
+        /// Register write enable for SOFTWARE_BINDING
+        (0x0028 => pub(crate) sw_binding_regwen: ReadWrite<u32, SW_BINDING_REGWEN::Register>),
+        /// Software binding input to sealing portion of the key manager.
+        (0x002c => pub(crate) sealing_sw_binding: [ReadWrite<u32, SEALING_SW_BINDING::Register>; 8]),
+        /// Software binding input to the attestation portion of the key manager.
+        (0x004c => pub(crate) attest_sw_binding: [ReadWrite<u32, ATTEST_SW_BINDING::Register>; 8]),
+        /// Salt value used as part of output generation
+        (0x006c => pub(crate) salt: [ReadWrite<u32, SALT::Register>; 8]),
+        /// Version used as part of output generation
+        (0x008c => pub(crate) key_version: [ReadWrite<u32, KEY_VERSION::Register>; 1]),
+        /// Register write enable for MAX_CREATOR_KEY_VERSION
+        (0x0090 => pub(crate) max_creator_key_ver_regwen: ReadWrite<u32, MAX_CREATOR_KEY_VER_REGWEN::Register>),
+        /// Max creator key version
+        (0x0094 => pub(crate) max_creator_key_ver_shadowed: ReadWrite<u32, MAX_CREATOR_KEY_VER_SHADOWED::Register>),
+        /// Register write enable for MAX_OWNER_INT_KEY_VERSION
+        (0x0098 => pub(crate) max_owner_int_key_ver_regwen: ReadWrite<u32, MAX_OWNER_INT_KEY_VER_REGWEN::Register>),
+        /// Max owner intermediate key version
+        (0x009c => pub(crate) max_owner_int_key_ver_shadowed: ReadWrite<u32, MAX_OWNER_INT_KEY_VER_SHADOWED::Register>),
+        /// Register write enable for MAX_OWNER_KEY_VERSION
+        (0x00a0 => pub(crate) max_owner_key_ver_regwen: ReadWrite<u32, MAX_OWNER_KEY_VER_REGWEN::Register>),
+        /// Max owner key version
+        (0x00a4 => pub(crate) max_owner_key_ver_shadowed: ReadWrite<u32, MAX_OWNER_KEY_VER_SHADOWED::Register>),
+        /// Key manager software output.
+        (0x00a8 => pub(crate) sw_share0_output: [ReadWrite<u32, SW_SHARE0_OUTPUT::Register>; 8]),
+        /// Key manager software output.
+        (0x00c8 => pub(crate) sw_share1_output: [ReadWrite<u32, SW_SHARE1_OUTPUT::Register>; 8]),
+        /// Key manager working state.
+        (0x00e8 => pub(crate) working_state: ReadWrite<u32, WORKING_STATE::Register>),
+        /// Key manager status.
+        (0x00ec => pub(crate) op_status: ReadWrite<u32, OP_STATUS::Register>),
+        /// Key manager error code.
+        (0x00f0 => pub(crate) err_code: ReadWrite<u32, ERR_CODE::Register>),
+        /// This register represents both synchronous and asynchronous fatal faults.
+        (0x00f4 => pub(crate) fault_status: ReadWrite<u32, FAULT_STATUS::Register>),
+        /// The register holds some debug information that may be convenient if keymgr
+        (0x00f8 => pub(crate) debug: ReadWrite<u32, DEBUG::Register>),
+        (0x00fc => @END),
+    }
+}
+
+register_bitfields![u32,
+    /// Common Interrupt Offsets
+    pub(crate) INTR [
+        OP_DONE OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) ALERT_TEST [
+        RECOV_OPERATION_ERR OFFSET(0) NUMBITS(1) [],
+        FATAL_FAULT_ERR OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) CFG_REGWEN [
+        EN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) START [
+        EN OFFSET(0) NUMBITS(1) [
+            VALID_STATE = 1,
+        ],
+    ],
+    pub(crate) CONTROL_SHADOWED [
+        OPERATION OFFSET(4) NUMBITS(3) [
+            ADVANCE = 0,
+            GENERATE_ID = 1,
+            GENERATE_SW_OUTPUT = 2,
+            GENERATE_HW_OUTPUT = 3,
+            DISABLE = 4,
+        ],
+        CDI_SEL OFFSET(7) NUMBITS(1) [
+            SEALING_CDI = 0,
+            ATTESTATION_CDI = 1,
+        ],
+        DEST_SEL OFFSET(12) NUMBITS(2) [
+            NONE = 0,
+            AES = 1,
+            KMAC = 2,
+            OTBN = 3,
+        ],
+    ],
+    pub(crate) SIDELOAD_CLEAR [
+        VAL OFFSET(0) NUMBITS(3) [
+            NONE = 0,
+            AES = 1,
+            KMAC = 2,
+            OTBN = 3,
+        ],
+    ],
+    pub(crate) RESEED_INTERVAL_REGWEN [
+        EN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) RESEED_INTERVAL_SHADOWED [
+        VAL OFFSET(0) NUMBITS(16) [],
+    ],
+    pub(crate) SW_BINDING_REGWEN [
+        EN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) SEALING_SW_BINDING [
+        VAL_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) ATTEST_SW_BINDING [
+        VAL_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) SALT [
+        VAL_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) KEY_VERSION [
+        VAL_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) MAX_CREATOR_KEY_VER_REGWEN [
+        EN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) MAX_CREATOR_KEY_VER_SHADOWED [
+        VAL OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) MAX_OWNER_INT_KEY_VER_REGWEN [
+        EN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) MAX_OWNER_INT_KEY_VER_SHADOWED [
+        VAL OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) MAX_OWNER_KEY_VER_REGWEN [
+        EN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) MAX_OWNER_KEY_VER_SHADOWED [
+        VAL OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) SW_SHARE0_OUTPUT [
+        VAL_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) SW_SHARE1_OUTPUT [
+        VAL_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) WORKING_STATE [
+        STATE OFFSET(0) NUMBITS(3) [
+            RESET = 0,
+            INIT = 1,
+            CREATOR_ROOT_KEY = 2,
+            OWNER_INTERMEDIATE_KEY = 3,
+            OWNER_KEY = 4,
+            DISABLED = 5,
+            INVALID = 6,
+        ],
+    ],
+    pub(crate) OP_STATUS [
+        STATUS OFFSET(0) NUMBITS(2) [
+            IDLE = 0,
+            WIP = 1,
+            DONE_SUCCESS = 2,
+            DONE_ERROR = 3,
+        ],
+    ],
+    pub(crate) ERR_CODE [
+        INVALID_OP OFFSET(0) NUMBITS(1) [],
+        INVALID_KMAC_INPUT OFFSET(1) NUMBITS(1) [],
+        INVALID_SHADOW_UPDATE OFFSET(2) NUMBITS(1) [],
+    ],
+    pub(crate) FAULT_STATUS [
+        CMD OFFSET(0) NUMBITS(1) [],
+        KMAC_FSM OFFSET(1) NUMBITS(1) [],
+        KMAC_DONE OFFSET(2) NUMBITS(1) [],
+        KMAC_OP OFFSET(3) NUMBITS(1) [],
+        KMAC_OUT OFFSET(4) NUMBITS(1) [],
+        REGFILE_INTG OFFSET(5) NUMBITS(1) [],
+        SHADOW OFFSET(6) NUMBITS(1) [],
+        CTRL_FSM_INTG OFFSET(7) NUMBITS(1) [],
+        CTRL_FSM_CHK OFFSET(8) NUMBITS(1) [],
+        CTRL_FSM_CNT OFFSET(9) NUMBITS(1) [],
+        RESEED_CNT OFFSET(10) NUMBITS(1) [],
+        SIDE_CTRL_FSM OFFSET(11) NUMBITS(1) [],
+        SIDE_CTRL_SEL OFFSET(12) NUMBITS(1) [],
+        KEY_ECC OFFSET(13) NUMBITS(1) [],
+    ],
+    pub(crate) DEBUG [
+        INVALID_CREATOR_SEED OFFSET(0) NUMBITS(1) [],
+        INVALID_OWNER_SEED OFFSET(1) NUMBITS(1) [],
+        INVALID_DEV_ID OFFSET(2) NUMBITS(1) [],
+        INVALID_HEALTH_STATE OFFSET(3) NUMBITS(1) [],
+        INVALID_KEY_VERSION OFFSET(4) NUMBITS(1) [],
+        INVALID_KEY OFFSET(5) NUMBITS(1) [],
+        INVALID_DIGEST OFFSET(6) NUMBITS(1) [],
+    ],
+];
+
+// End generated register constants for keymgr

--- a/chips/lowrisc/src/registers/kmac_regs.rs
+++ b/chips/lowrisc/src/registers/kmac_regs.rs
@@ -1,0 +1,175 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for kmac.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/ip/kmac/data/kmac.hjson
+use kernel::utilities::registers::ReadOnly;
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::WriteOnly;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Number of words for the secret key
+pub const KMAC_PARAM_NUM_WORDS_KEY: u32 = 16;
+/// Number of words for Encoded NsPrefix.
+pub const KMAC_PARAM_NUM_WORDS_PREFIX: u32 = 11;
+/// Number of entries in the message FIFO. Must match kmac_pkg::MsgFifoDepth.
+pub const KMAC_PARAM_NUM_ENTRIES_MSG_FIFO: u32 = 10;
+/// Number of bytes in a single entry of the message FIFO. Must match kmac_pkg::MsgWidth.
+pub const KMAC_PARAM_NUM_BYTES_MSG_FIFO_ENTRY: u32 = 8;
+/// Number of words for the LFSR seed used for entropy generation
+pub const KMAC_PARAM_NUM_SEEDS_ENTROPY_LFSR: u32 = 5;
+/// Number of alerts
+pub const KMAC_PARAM_NUM_ALERTS: u32 = 2;
+/// Register width
+pub const KMAC_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub KmacRegisters {
+        /// Interrupt State Register
+        (0x0000 => pub(crate) intr_state: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Enable Register
+        (0x0004 => pub(crate) intr_enable: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Test Register
+        (0x0008 => pub(crate) intr_test: ReadWrite<u32, INTR::Register>),
+        /// Alert Test Register
+        (0x000c => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// Controls the configurability of !!CFG_SHADOWED register.
+        (0x0010 => pub(crate) cfg_regwen: ReadWrite<u32, CFG_REGWEN::Register>),
+        /// KMAC Configuration register.
+        (0x0014 => pub(crate) cfg_shadowed: ReadWrite<u32, CFG_SHADOWED::Register>),
+        /// KMAC/ SHA3 command register.
+        (0x0018 => pub(crate) cmd: ReadWrite<u32, CMD::Register>),
+        /// KMAC/SHA3 Status register.
+        (0x001c => pub(crate) status: ReadWrite<u32, STATUS::Register>),
+        /// Entropy Timer Periods.
+        (0x0020 => pub(crate) entropy_period: ReadWrite<u32, ENTROPY_PERIOD::Register>),
+        /// Entropy Refresh Counter
+        (0x0024 => pub(crate) entropy_refresh_hash_cnt: ReadWrite<u32, ENTROPY_REFRESH_HASH_CNT::Register>),
+        /// Entropy Refresh Threshold
+        (0x0028 => pub(crate) entropy_refresh_threshold_shadowed: ReadWrite<u32, ENTROPY_REFRESH_THRESHOLD_SHADOWED::Register>),
+        /// Entropy Seed
+        (0x002c => pub(crate) entropy_seed: [ReadWrite<u32, ENTROPY_SEED::Register>; 5]),
+        /// KMAC Secret Key
+        (0x0040 => pub(crate) key_share0: [ReadWrite<u32, KEY_SHARE0::Register>; 16]),
+        /// KMAC Secret Key, 2nd share.
+        (0x0080 => pub(crate) key_share1: [ReadWrite<u32, KEY_SHARE1::Register>; 16]),
+        /// Secret Key length in bit.
+        (0x00c0 => pub(crate) key_len: ReadWrite<u32, KEY_LEN::Register>),
+        /// cSHAKE Prefix register.
+        (0x00c4 => pub(crate) prefix: [ReadWrite<u32, PREFIX::Register>; 11]),
+        /// KMAC/SHA3 Error Code
+        (0x00f0 => pub(crate) err_code: ReadWrite<u32, ERR_CODE::Register>),
+        (0x00f4 => _reserved1),
+        /// Memory area: Keccak State (1600 bit) memory.
+        (0x0400 => pub(crate) state: [ReadOnly<u32>; 128]),
+        (0x0600 => _reserved2),
+        /// Memory area: Message FIFO.
+        (0x0800 => pub(crate) msg_fifo: [WriteOnly<u32>; 512]),
+        (0x1000 => @END),
+    }
+}
+
+register_bitfields![u32,
+    /// Common Interrupt Offsets
+    pub(crate) INTR [
+        KMAC_DONE OFFSET(0) NUMBITS(1) [],
+        FIFO_EMPTY OFFSET(1) NUMBITS(1) [],
+        KMAC_ERR OFFSET(2) NUMBITS(1) [],
+    ],
+    pub(crate) ALERT_TEST [
+        RECOV_OPERATION_ERR OFFSET(0) NUMBITS(1) [],
+        FATAL_FAULT_ERR OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) CFG_REGWEN [
+        EN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CFG_SHADOWED [
+        KMAC_EN OFFSET(0) NUMBITS(1) [],
+        KSTRENGTH OFFSET(1) NUMBITS(3) [
+            L128 = 0,
+            L224 = 1,
+            L256 = 2,
+            L384 = 3,
+            L512 = 4,
+        ],
+        MODE OFFSET(4) NUMBITS(2) [
+            SHA3 = 0,
+            SHAKE = 2,
+            CSHAKE = 3,
+        ],
+        MSG_ENDIANNESS OFFSET(8) NUMBITS(1) [],
+        STATE_ENDIANNESS OFFSET(9) NUMBITS(1) [],
+        SIDELOAD OFFSET(12) NUMBITS(1) [],
+        ENTROPY_MODE OFFSET(16) NUMBITS(2) [
+            IDLE_MODE = 0,
+            EDN_MODE = 1,
+            SW_MODE = 2,
+        ],
+        ENTROPY_FAST_PROCESS OFFSET(19) NUMBITS(1) [],
+        MSG_MASK OFFSET(20) NUMBITS(1) [],
+        ENTROPY_READY OFFSET(24) NUMBITS(1) [],
+        ERR_PROCESSED OFFSET(25) NUMBITS(1) [],
+        EN_UNSUPPORTED_MODESTRENGTH OFFSET(26) NUMBITS(1) [],
+    ],
+    pub(crate) CMD [
+        CMD OFFSET(0) NUMBITS(6) [
+            START = 29,
+            PROCESS = 46,
+            RUN = 49,
+            DONE = 22,
+        ],
+        ENTROPY_REQ OFFSET(8) NUMBITS(1) [],
+        HASH_CNT_CLR OFFSET(9) NUMBITS(1) [],
+    ],
+    pub(crate) STATUS [
+        SHA3_IDLE OFFSET(0) NUMBITS(1) [],
+        SHA3_ABSORB OFFSET(1) NUMBITS(1) [],
+        SHA3_SQUEEZE OFFSET(2) NUMBITS(1) [],
+        FIFO_DEPTH OFFSET(8) NUMBITS(5) [],
+        FIFO_EMPTY OFFSET(14) NUMBITS(1) [],
+        FIFO_FULL OFFSET(15) NUMBITS(1) [],
+        ALERT_FATAL_FAULT OFFSET(16) NUMBITS(1) [],
+        ALERT_RECOV_CTRL_UPDATE_ERR OFFSET(17) NUMBITS(1) [],
+    ],
+    pub(crate) ENTROPY_PERIOD [
+        PRESCALER OFFSET(0) NUMBITS(10) [],
+        WAIT_TIMER OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) ENTROPY_REFRESH_HASH_CNT [
+        HASH_CNT OFFSET(0) NUMBITS(10) [],
+    ],
+    pub(crate) ENTROPY_REFRESH_THRESHOLD_SHADOWED [
+        THRESHOLD OFFSET(0) NUMBITS(10) [],
+    ],
+    pub(crate) ENTROPY_SEED [
+        SEED_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) KEY_SHARE0 [
+        KEY_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) KEY_SHARE1 [
+        KEY_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) KEY_LEN [
+        LEN OFFSET(0) NUMBITS(3) [
+            KEY128 = 0,
+            KEY192 = 1,
+            KEY256 = 2,
+            KEY384 = 3,
+            KEY512 = 4,
+        ],
+    ],
+    pub(crate) PREFIX [
+        PREFIX_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) ERR_CODE [
+        ERR_CODE OFFSET(0) NUMBITS(32) [],
+    ],
+];
+
+// End generated register constants for kmac

--- a/chips/lowrisc/src/registers/lc_ctrl_regs.rs
+++ b/chips/lowrisc/src/registers/lc_ctrl_regs.rs
@@ -1,0 +1,207 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for lc_ctrl.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/ip/lc_ctrl/data/lc_ctrl.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Width of SiliconCreatorId revision field.
+pub const LC_CTRL_PARAM_SILICON_CREATOR_ID_WIDTH: u32 = 16;
+/// Width of ProductId revision field.
+pub const LC_CTRL_PARAM_PRODUCT_ID_WIDTH: u32 = 16;
+/// Width of RevisionId revision field.
+pub const LC_CTRL_PARAM_REVISION_ID_WIDTH: u32 = 8;
+/// Number of 32bit words in a token.
+pub const LC_CTRL_PARAM_NUM_TOKEN_WORDS: u32 = 4;
+/// Number of life cycle state enum bits.
+pub const LC_CTRL_PARAM_CSR_LC_STATE_WIDTH: u32 = 30;
+/// Number of life cycle transition counter bits.
+pub const LC_CTRL_PARAM_CSR_LC_COUNT_WIDTH: u32 = 5;
+/// Number of life cycle id state enum bits.
+pub const LC_CTRL_PARAM_CSR_LC_ID_STATE_WIDTH: u32 = 32;
+/// Number of vendor/test-specific OTP control bits.
+pub const LC_CTRL_PARAM_CSR_OTP_TEST_CTRL_WIDTH: u32 = 32;
+/// Number of vendor/test-specific OTP status bits.
+pub const LC_CTRL_PARAM_CSR_OTP_TEST_STATUS_WIDTH: u32 = 32;
+/// Number of 32bit words in the Device ID.
+pub const LC_CTRL_PARAM_NUM_DEVICE_ID_WORDS: u32 = 8;
+/// Number of 32bit words in the manufacturing state.
+pub const LC_CTRL_PARAM_NUM_MANUF_STATE_WORDS: u32 = 8;
+/// Number of alerts
+pub const LC_CTRL_PARAM_NUM_ALERTS: u32 = 3;
+/// Register width
+pub const LC_CTRL_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub LcCtrlRegisters {
+        /// Alert Test Register
+        (0x0000 => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// life cycle status register. Note that all errors are terminal and require a reset cycle.
+        (0x0004 => pub(crate) status: ReadWrite<u32, STATUS::Register>),
+        /// Register write enable for the hardware mutex register.
+        (0x0008 => pub(crate) claim_transition_if_regwen: ReadWrite<u32, CLAIM_TRANSITION_IF_REGWEN::Register>),
+        /// Hardware mutex to claim exclusive access to the transition interface.
+        (0x000c => pub(crate) claim_transition_if: ReadWrite<u32, CLAIM_TRANSITION_IF::Register>),
+        /// Register write enable for all transition interface registers.
+        (0x0010 => pub(crate) transition_regwen: ReadWrite<u32, TRANSITION_REGWEN::Register>),
+        /// Command register for state transition requests.
+        (0x0014 => pub(crate) transition_cmd: ReadWrite<u32, TRANSITION_CMD::Register>),
+        /// Control register for state transition requests.
+        (0x0018 => pub(crate) transition_ctrl: ReadWrite<u32, TRANSITION_CTRL::Register>),
+        /// 128bit token for conditional transitions.
+        (0x001c => pub(crate) transition_token: [ReadWrite<u32, TRANSITION_TOKEN::Register>; 4]),
+        /// This register exposes the decoded life cycle state.
+        (0x002c => pub(crate) transition_target: ReadWrite<u32, TRANSITION_TARGET::Register>),
+        /// Test/vendor-specific settings for the OTP macro wrapper.
+        (0x0030 => pub(crate) otp_vendor_test_ctrl: ReadWrite<u32, OTP_VENDOR_TEST_CTRL::Register>),
+        /// Test/vendor-specific settings for the OTP macro wrapper.
+        (0x0034 => pub(crate) otp_vendor_test_status: ReadWrite<u32, OTP_VENDOR_TEST_STATUS::Register>),
+        /// This register exposes the decoded life cycle state.
+        (0x0038 => pub(crate) lc_state: ReadWrite<u32, LC_STATE::Register>),
+        /// This register exposes the state of the decoded life cycle transition counter.
+        (0x003c => pub(crate) lc_transition_cnt: ReadWrite<u32, LC_TRANSITION_CNT::Register>),
+        /// This register exposes the id state of the device.
+        (0x0040 => pub(crate) lc_id_state: ReadWrite<u32, LC_ID_STATE::Register>),
+        /// This register holds the SILICON_CREATOR_ID and the PRODUCT_ID.
+        (0x0044 => pub(crate) hw_revision0: ReadWrite<u32, HW_REVISION0::Register>),
+        /// This register holds the REVISION_ID.
+        (0x0048 => pub(crate) hw_revision1: ReadWrite<u32, HW_REVISION1::Register>),
+        /// This is the 256bit DEVICE_ID value that is stored in the HW_CFG partition in OTP.
+        (0x004c => pub(crate) device_id: [ReadWrite<u32, DEVICE_ID::Register>; 8]),
+        /// This is a 256bit field used for keeping track of the manufacturing state.
+        (0x006c => pub(crate) manuf_state: [ReadWrite<u32, MANUF_STATE::Register>; 8]),
+        (0x008c => @END),
+    }
+}
+
+register_bitfields![u32,
+    pub(crate) ALERT_TEST [
+        FATAL_PROG_ERROR OFFSET(0) NUMBITS(1) [],
+        FATAL_STATE_ERROR OFFSET(1) NUMBITS(1) [],
+        FATAL_BUS_INTEG_ERROR OFFSET(2) NUMBITS(1) [],
+    ],
+    pub(crate) STATUS [
+        INITIALIZED OFFSET(0) NUMBITS(1) [],
+        READY OFFSET(1) NUMBITS(1) [],
+        EXT_CLOCK_SWITCHED OFFSET(2) NUMBITS(1) [],
+        TRANSITION_SUCCESSFUL OFFSET(3) NUMBITS(1) [],
+        TRANSITION_COUNT_ERROR OFFSET(4) NUMBITS(1) [],
+        TRANSITION_ERROR OFFSET(5) NUMBITS(1) [],
+        TOKEN_ERROR OFFSET(6) NUMBITS(1) [],
+        FLASH_RMA_ERROR OFFSET(7) NUMBITS(1) [],
+        OTP_ERROR OFFSET(8) NUMBITS(1) [],
+        STATE_ERROR OFFSET(9) NUMBITS(1) [],
+        BUS_INTEG_ERROR OFFSET(10) NUMBITS(1) [],
+        OTP_PARTITION_ERROR OFFSET(11) NUMBITS(1) [],
+    ],
+    pub(crate) CLAIM_TRANSITION_IF_REGWEN [
+        CLAIM_TRANSITION_IF_REGWEN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CLAIM_TRANSITION_IF [
+        MUTEX OFFSET(0) NUMBITS(8) [],
+    ],
+    pub(crate) TRANSITION_REGWEN [
+        TRANSITION_REGWEN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) TRANSITION_CMD [
+        START OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) TRANSITION_CTRL [
+        EXT_CLOCK_EN OFFSET(0) NUMBITS(1) [],
+        VOLATILE_RAW_UNLOCK OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) TRANSITION_TOKEN [
+        TRANSITION_TOKEN_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) TRANSITION_TARGET [
+        STATE OFFSET(0) NUMBITS(30) [
+            RAW = 0,
+            TEST_UNLOCKED0 = 34636833,
+            TEST_LOCKED0 = 69273666,
+            TEST_UNLOCKED1 = 103910499,
+            TEST_LOCKED1 = 138547332,
+            TEST_UNLOCKED2 = 173184165,
+            TEST_LOCKED2 = 207820998,
+            TEST_UNLOCKED3 = 242457831,
+            TEST_LOCKED3 = 277094664,
+            TEST_UNLOCKED4 = 311731497,
+            TEST_LOCKED4 = 346368330,
+            TEST_UNLOCKED5 = 381005163,
+            TEST_LOCKED5 = 415641996,
+            TEST_UNLOCKED6 = 450278829,
+            TEST_LOCKED6 = 484915662,
+            TEST_UNLOCKED7 = 519552495,
+            DEV = 554189328,
+            PROD = 588826161,
+            PROD_END = 623462994,
+            RMA = 658099827,
+            SCRAP = 692736660,
+        ],
+    ],
+    pub(crate) OTP_VENDOR_TEST_CTRL [
+        OTP_VENDOR_TEST_CTRL OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) OTP_VENDOR_TEST_STATUS [
+        OTP_VENDOR_TEST_STATUS OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) LC_STATE [
+        STATE OFFSET(0) NUMBITS(30) [
+            RAW = 0,
+            TEST_UNLOCKED0 = 34636833,
+            TEST_LOCKED0 = 69273666,
+            TEST_UNLOCKED1 = 103910499,
+            TEST_LOCKED1 = 138547332,
+            TEST_UNLOCKED2 = 173184165,
+            TEST_LOCKED2 = 207820998,
+            TEST_UNLOCKED3 = 242457831,
+            TEST_LOCKED3 = 277094664,
+            TEST_UNLOCKED4 = 311731497,
+            TEST_LOCKED4 = 346368330,
+            TEST_UNLOCKED5 = 381005163,
+            TEST_LOCKED5 = 415641996,
+            TEST_UNLOCKED6 = 450278829,
+            TEST_LOCKED6 = 484915662,
+            TEST_UNLOCKED7 = 519552495,
+            DEV = 554189328,
+            PROD = 588826161,
+            PROD_END = 623462994,
+            RMA = 658099827,
+            SCRAP = 692736660,
+            POST_TRANSITION = 727373493,
+            ESCALATE = 762010326,
+            INVALID = 796647159,
+        ],
+    ],
+    pub(crate) LC_TRANSITION_CNT [
+        CNT OFFSET(0) NUMBITS(5) [],
+    ],
+    pub(crate) LC_ID_STATE [
+        STATE OFFSET(0) NUMBITS(32) [
+            BLANK = 0,
+            PERSONALIZED = 286331153,
+            INVALID = 572662306,
+        ],
+    ],
+    pub(crate) HW_REVISION0 [
+        PRODUCT_ID OFFSET(0) NUMBITS(16) [],
+        SILICON_CREATOR_ID OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) HW_REVISION1 [
+        REVISION_ID OFFSET(0) NUMBITS(8) [],
+        RESERVED OFFSET(8) NUMBITS(24) [],
+    ],
+    pub(crate) DEVICE_ID [
+        DEVICE_ID_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) MANUF_STATE [
+        MANUF_STATE_0 OFFSET(0) NUMBITS(32) [],
+    ],
+];
+
+// End generated register constants for lc_ctrl

--- a/chips/lowrisc/src/registers/mod.rs
+++ b/chips/lowrisc/src/registers/mod.rs
@@ -1,0 +1,32 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2023.
+
+pub mod adc_ctrl_regs;
+pub mod aes_regs;
+pub mod aon_timer_regs;
+pub mod clkmgr_regs;
+pub mod csrng_regs;
+pub mod edn_regs;
+pub mod entropy_src_regs;
+pub mod flash_ctrl_regs;
+pub mod gpio_regs;
+pub mod hmac_regs;
+pub mod i2c_regs;
+pub mod keymgr_regs;
+pub mod kmac_regs;
+pub mod lc_ctrl_regs;
+pub mod otbn_regs;
+pub mod otp_ctrl_regs;
+pub mod pattgen_regs;
+pub mod pinmux_regs;
+pub mod pwm_regs;
+pub mod rom_ctrl_regs;
+pub mod rv_core_ibex_regs;
+pub mod rv_timer_regs;
+pub mod spi_device_regs;
+pub mod spi_host_regs;
+pub mod sram_ctrl_regs;
+pub mod sysrst_ctrl_regs;
+pub mod uart_regs;
+pub mod usbdev_regs;

--- a/chips/lowrisc/src/registers/otbn_regs.rs
+++ b/chips/lowrisc/src/registers/otbn_regs.rs
@@ -1,0 +1,107 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for otbn.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/ip/otbn/data/otbn.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Number of alerts
+pub const OTBN_PARAM_NUM_ALERTS: u32 = 2;
+/// Register width
+pub const OTBN_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub OtbnRegisters {
+        /// Interrupt State Register
+        (0x0000 => pub(crate) intr_state: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Enable Register
+        (0x0004 => pub(crate) intr_enable: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Test Register
+        (0x0008 => pub(crate) intr_test: ReadWrite<u32, INTR::Register>),
+        /// Alert Test Register
+        (0x000c => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// Command Register
+        (0x0010 => pub(crate) cmd: ReadWrite<u32, CMD::Register>),
+        /// Control Register
+        (0x0014 => pub(crate) ctrl: ReadWrite<u32, CTRL::Register>),
+        /// Status Register
+        (0x0018 => pub(crate) status: ReadWrite<u32, STATUS::Register>),
+        /// Operation Result Register
+        (0x001c => pub(crate) err_bits: ReadWrite<u32, ERR_BITS::Register>),
+        /// Fatal Alert Cause Register
+        (0x0020 => pub(crate) fatal_alert_cause: ReadWrite<u32, FATAL_ALERT_CAUSE::Register>),
+        /// Instruction Count Register
+        (0x0024 => pub(crate) insn_cnt: ReadWrite<u32, INSN_CNT::Register>),
+        /// A 32-bit CRC checksum of data written to memory
+        (0x0028 => pub(crate) load_checksum: ReadWrite<u32, LOAD_CHECKSUM::Register>),
+        (0x002c => _reserved1),
+        /// Memory area: Instruction Memory Access
+        (0x4000 => pub(crate) imem: [ReadWrite<u32>; 1024]),
+        (0x5000 => _reserved2),
+        /// Memory area: Data Memory Access
+        (0x8000 => pub(crate) dmem: [ReadWrite<u32>; 768]),
+        (0x8c00 => @END),
+    }
+}
+
+register_bitfields![u32,
+    /// Common Interrupt Offsets
+    pub(crate) INTR [
+        DONE OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) ALERT_TEST [
+        FATAL OFFSET(0) NUMBITS(1) [],
+        RECOV OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) CMD [
+        CMD OFFSET(0) NUMBITS(8) [],
+    ],
+    pub(crate) CTRL [
+        SOFTWARE_ERRS_FATAL OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) STATUS [
+        STATUS OFFSET(0) NUMBITS(8) [],
+    ],
+    pub(crate) ERR_BITS [
+        BAD_DATA_ADDR OFFSET(0) NUMBITS(1) [],
+        BAD_INSN_ADDR OFFSET(1) NUMBITS(1) [],
+        CALL_STACK OFFSET(2) NUMBITS(1) [],
+        ILLEGAL_INSN OFFSET(3) NUMBITS(1) [],
+        LOOP OFFSET(4) NUMBITS(1) [],
+        KEY_INVALID OFFSET(5) NUMBITS(1) [],
+        RND_REP_CHK_FAIL OFFSET(6) NUMBITS(1) [],
+        RND_FIPS_CHK_FAIL OFFSET(7) NUMBITS(1) [],
+        IMEM_INTG_VIOLATION OFFSET(16) NUMBITS(1) [],
+        DMEM_INTG_VIOLATION OFFSET(17) NUMBITS(1) [],
+        REG_INTG_VIOLATION OFFSET(18) NUMBITS(1) [],
+        BUS_INTG_VIOLATION OFFSET(19) NUMBITS(1) [],
+        BAD_INTERNAL_STATE OFFSET(20) NUMBITS(1) [],
+        ILLEGAL_BUS_ACCESS OFFSET(21) NUMBITS(1) [],
+        LIFECYCLE_ESCALATION OFFSET(22) NUMBITS(1) [],
+        FATAL_SOFTWARE OFFSET(23) NUMBITS(1) [],
+    ],
+    pub(crate) FATAL_ALERT_CAUSE [
+        IMEM_INTG_VIOLATION OFFSET(0) NUMBITS(1) [],
+        DMEM_INTG_VIOLATION OFFSET(1) NUMBITS(1) [],
+        REG_INTG_VIOLATION OFFSET(2) NUMBITS(1) [],
+        BUS_INTG_VIOLATION OFFSET(3) NUMBITS(1) [],
+        BAD_INTERNAL_STATE OFFSET(4) NUMBITS(1) [],
+        ILLEGAL_BUS_ACCESS OFFSET(5) NUMBITS(1) [],
+        LIFECYCLE_ESCALATION OFFSET(6) NUMBITS(1) [],
+        FATAL_SOFTWARE OFFSET(7) NUMBITS(1) [],
+    ],
+    pub(crate) INSN_CNT [
+        INSN_CNT OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) LOAD_CHECKSUM [
+        CHECKSUM OFFSET(0) NUMBITS(32) [],
+    ],
+];
+
+// End generated register constants for otbn

--- a/chips/lowrisc/src/registers/otp_ctrl_regs.rs
+++ b/chips/lowrisc/src/registers/otp_ctrl_regs.rs
@@ -1,0 +1,629 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for otp_ctrl.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/ip/otp_ctrl/data/otp_ctrl.hjson
+use kernel::utilities::registers::ReadOnly;
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Number of key slots
+pub const OTP_CTRL_PARAM_NUM_SRAM_KEY_REQ_SLOTS: u32 = 3;
+/// Width of the OTP byte address.
+pub const OTP_CTRL_PARAM_OTP_BYTE_ADDR_WIDTH: u32 = 11;
+/// Number of error register entries.
+pub const OTP_CTRL_PARAM_NUM_ERROR_ENTRIES: u32 = 10;
+/// Number of 32bit words in the DAI.
+pub const OTP_CTRL_PARAM_NUM_DAI_WORDS: u32 = 2;
+/// Size of the digest fields in 32bit words.
+pub const OTP_CTRL_PARAM_NUM_DIGEST_WORDS: u32 = 2;
+/// Size of the TL-UL window in 32bit words. Note that the effective partition size is smaller
+/// than that.
+pub const OTP_CTRL_PARAM_NUM_SW_CFG_WINDOW_WORDS: u32 = 512;
+/// Number of partitions
+pub const OTP_CTRL_PARAM_NUM_PART: u32 = 8;
+/// Offset of the VENDOR_TEST partition
+pub const OTP_CTRL_PARAM_VENDOR_TEST_OFFSET: usize = 0;
+/// Size of the VENDOR_TEST partition
+pub const OTP_CTRL_PARAM_VENDOR_TEST_SIZE: u32 = 64;
+/// Offset of SCRATCH
+pub const OTP_CTRL_PARAM_SCRATCH_OFFSET: usize = 0;
+/// Size of SCRATCH
+pub const OTP_CTRL_PARAM_SCRATCH_SIZE: u32 = 56;
+/// Offset of VENDOR_TEST_DIGEST
+pub const OTP_CTRL_PARAM_VENDOR_TEST_DIGEST_OFFSET: usize = 56;
+/// Size of VENDOR_TEST_DIGEST
+pub const OTP_CTRL_PARAM_VENDOR_TEST_DIGEST_SIZE: u32 = 8;
+/// Offset of the CREATOR_SW_CFG partition
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_OFFSET: usize = 64;
+/// Size of the CREATOR_SW_CFG partition
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_SIZE: u32 = 800;
+/// Offset of CREATOR_SW_CFG_AST_CFG
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_AST_CFG_OFFSET: usize = 64;
+/// Size of CREATOR_SW_CFG_AST_CFG
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_AST_CFG_SIZE: u32 = 156;
+/// Offset of CREATOR_SW_CFG_AST_INIT_EN
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_AST_INIT_EN_OFFSET: usize = 220;
+/// Size of CREATOR_SW_CFG_AST_INIT_EN
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_AST_INIT_EN_SIZE: u32 = 4;
+/// Offset of CREATOR_SW_CFG_ROM_EXT_SKU
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_ROM_EXT_SKU_OFFSET: usize = 224;
+/// Size of CREATOR_SW_CFG_ROM_EXT_SKU
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_ROM_EXT_SKU_SIZE: u32 = 4;
+/// Offset of CREATOR_SW_CFG_SIGVERIFY_RSA_MOD_EXP_IBEX_EN
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_SIGVERIFY_RSA_MOD_EXP_IBEX_EN_OFFSET: usize = 228;
+/// Size of CREATOR_SW_CFG_SIGVERIFY_RSA_MOD_EXP_IBEX_EN
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_SIGVERIFY_RSA_MOD_EXP_IBEX_EN_SIZE: u32 = 4;
+/// Offset of CREATOR_SW_CFG_SIGVERIFY_RSA_KEY_EN
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_SIGVERIFY_RSA_KEY_EN_OFFSET: usize = 232;
+/// Size of CREATOR_SW_CFG_SIGVERIFY_RSA_KEY_EN
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_SIGVERIFY_RSA_KEY_EN_SIZE: u32 = 8;
+/// Offset of CREATOR_SW_CFG_SIGVERIFY_SPX_EN
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_SIGVERIFY_SPX_EN_OFFSET: usize = 240;
+/// Size of CREATOR_SW_CFG_SIGVERIFY_SPX_EN
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_SIGVERIFY_SPX_EN_SIZE: u32 = 4;
+/// Offset of CREATOR_SW_CFG_SIGVERIFY_SPX_KEY_EN
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_SIGVERIFY_SPX_KEY_EN_OFFSET: usize = 244;
+/// Size of CREATOR_SW_CFG_SIGVERIFY_SPX_KEY_EN
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_SIGVERIFY_SPX_KEY_EN_SIZE: u32 = 8;
+/// Offset of CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG_OFFSET: usize = 252;
+/// Size of CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG_SIZE: u32 = 4;
+/// Offset of CREATOR_SW_CFG_FLASH_INFO_BOOT_DATA_CFG
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_INFO_BOOT_DATA_CFG_OFFSET: usize = 256;
+/// Size of CREATOR_SW_CFG_FLASH_INFO_BOOT_DATA_CFG
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_INFO_BOOT_DATA_CFG_SIZE: u32 = 4;
+/// Offset of CREATOR_SW_CFG_FLASH_HW_INFO_CFG_OVERRIDE
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_HW_INFO_CFG_OVERRIDE_OFFSET: usize = 260;
+/// Size of CREATOR_SW_CFG_FLASH_HW_INFO_CFG_OVERRIDE
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_HW_INFO_CFG_OVERRIDE_SIZE: u32 = 4;
+/// Offset of CREATOR_SW_CFG_RNG_EN
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_EN_OFFSET: usize = 264;
+/// Size of CREATOR_SW_CFG_RNG_EN
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_EN_SIZE: u32 = 4;
+/// Offset of CREATOR_SW_CFG_JITTER_EN
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_JITTER_EN_OFFSET: usize = 268;
+/// Size of CREATOR_SW_CFG_JITTER_EN
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_JITTER_EN_SIZE: u32 = 4;
+/// Offset of CREATOR_SW_CFG_RET_RAM_RESET_MASK
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RET_RAM_RESET_MASK_OFFSET: usize = 272;
+/// Size of CREATOR_SW_CFG_RET_RAM_RESET_MASK
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RET_RAM_RESET_MASK_SIZE: u32 = 4;
+/// Offset of CREATOR_SW_CFG_MANUF_STATE
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_MANUF_STATE_OFFSET: usize = 276;
+/// Size of CREATOR_SW_CFG_MANUF_STATE
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_MANUF_STATE_SIZE: u32 = 4;
+/// Offset of CREATOR_SW_CFG_ROM_EXEC_EN
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_ROM_EXEC_EN_OFFSET: usize = 280;
+/// Size of CREATOR_SW_CFG_ROM_EXEC_EN
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_ROM_EXEC_EN_SIZE: u32 = 4;
+/// Offset of CREATOR_SW_CFG_CPUCTRL
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_CPUCTRL_OFFSET: usize = 284;
+/// Size of CREATOR_SW_CFG_CPUCTRL
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_CPUCTRL_SIZE: u32 = 4;
+/// Offset of CREATOR_SW_CFG_MIN_SEC_VER_ROM_EXT
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_MIN_SEC_VER_ROM_EXT_OFFSET: usize = 288;
+/// Size of CREATOR_SW_CFG_MIN_SEC_VER_ROM_EXT
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_MIN_SEC_VER_ROM_EXT_SIZE: u32 = 4;
+/// Offset of CREATOR_SW_CFG_MIN_SEC_VER_BL0
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_MIN_SEC_VER_BL0_OFFSET: usize = 292;
+/// Size of CREATOR_SW_CFG_MIN_SEC_VER_BL0
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_MIN_SEC_VER_BL0_SIZE: u32 = 4;
+/// Offset of CREATOR_SW_CFG_DEFAULT_BOOT_DATA_IN_PROD_EN
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_DEFAULT_BOOT_DATA_IN_PROD_EN_OFFSET: usize = 296;
+/// Size of CREATOR_SW_CFG_DEFAULT_BOOT_DATA_IN_PROD_EN
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_DEFAULT_BOOT_DATA_IN_PROD_EN_SIZE: u32 = 4;
+/// Offset of CREATOR_SW_CFG_RMA_SPIN_EN
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RMA_SPIN_EN_OFFSET: usize = 300;
+/// Size of CREATOR_SW_CFG_RMA_SPIN_EN
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RMA_SPIN_EN_SIZE: u32 = 4;
+/// Offset of CREATOR_SW_CFG_RMA_SPIN_CYCLES
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RMA_SPIN_CYCLES_OFFSET: usize = 304;
+/// Size of CREATOR_SW_CFG_RMA_SPIN_CYCLES
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RMA_SPIN_CYCLES_SIZE: u32 = 4;
+/// Offset of CREATOR_SW_CFG_RNG_REPCNT_THRESHOLDS
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_REPCNT_THRESHOLDS_OFFSET: usize = 308;
+/// Size of CREATOR_SW_CFG_RNG_REPCNT_THRESHOLDS
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_REPCNT_THRESHOLDS_SIZE: u32 = 4;
+/// Offset of CREATOR_SW_CFG_RNG_REPCNTS_THRESHOLDS
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_REPCNTS_THRESHOLDS_OFFSET: usize = 312;
+/// Size of CREATOR_SW_CFG_RNG_REPCNTS_THRESHOLDS
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_REPCNTS_THRESHOLDS_SIZE: u32 = 4;
+/// Offset of CREATOR_SW_CFG_RNG_ADAPTP_HI_THRESHOLDS
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_ADAPTP_HI_THRESHOLDS_OFFSET: usize = 316;
+/// Size of CREATOR_SW_CFG_RNG_ADAPTP_HI_THRESHOLDS
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_ADAPTP_HI_THRESHOLDS_SIZE: u32 = 4;
+/// Offset of CREATOR_SW_CFG_RNG_ADAPTP_LO_THRESHOLDS
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_ADAPTP_LO_THRESHOLDS_OFFSET: usize = 320;
+/// Size of CREATOR_SW_CFG_RNG_ADAPTP_LO_THRESHOLDS
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_ADAPTP_LO_THRESHOLDS_SIZE: u32 = 4;
+/// Offset of CREATOR_SW_CFG_RNG_BUCKET_THRESHOLDS
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_BUCKET_THRESHOLDS_OFFSET: usize = 324;
+/// Size of CREATOR_SW_CFG_RNG_BUCKET_THRESHOLDS
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_BUCKET_THRESHOLDS_SIZE: u32 = 4;
+/// Offset of CREATOR_SW_CFG_RNG_MARKOV_HI_THRESHOLDS
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_MARKOV_HI_THRESHOLDS_OFFSET: usize = 328;
+/// Size of CREATOR_SW_CFG_RNG_MARKOV_HI_THRESHOLDS
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_MARKOV_HI_THRESHOLDS_SIZE: u32 = 4;
+/// Offset of CREATOR_SW_CFG_RNG_MARKOV_LO_THRESHOLDS
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_MARKOV_LO_THRESHOLDS_OFFSET: usize = 332;
+/// Size of CREATOR_SW_CFG_RNG_MARKOV_LO_THRESHOLDS
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_MARKOV_LO_THRESHOLDS_SIZE: u32 = 4;
+/// Offset of CREATOR_SW_CFG_RNG_EXTHT_HI_THRESHOLDS
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_EXTHT_HI_THRESHOLDS_OFFSET: usize = 336;
+/// Size of CREATOR_SW_CFG_RNG_EXTHT_HI_THRESHOLDS
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_EXTHT_HI_THRESHOLDS_SIZE: u32 = 4;
+/// Offset of CREATOR_SW_CFG_RNG_EXTHT_LO_THRESHOLDS
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_EXTHT_LO_THRESHOLDS_OFFSET: usize = 340;
+/// Size of CREATOR_SW_CFG_RNG_EXTHT_LO_THRESHOLDS
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_EXTHT_LO_THRESHOLDS_SIZE: u32 = 4;
+/// Offset of CREATOR_SW_CFG_RNG_ALERT_THRESHOLD
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_ALERT_THRESHOLD_OFFSET: usize = 344;
+/// Size of CREATOR_SW_CFG_RNG_ALERT_THRESHOLD
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_ALERT_THRESHOLD_SIZE: u32 = 4;
+/// Offset of CREATOR_SW_CFG_RNG_HEALTH_CONFIG_DIGEST
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_HEALTH_CONFIG_DIGEST_OFFSET: usize = 348;
+/// Size of CREATOR_SW_CFG_RNG_HEALTH_CONFIG_DIGEST
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_HEALTH_CONFIG_DIGEST_SIZE: u32 = 4;
+/// Offset of CREATOR_SW_CFG_SRAM_KEY_RENEW_EN
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_SRAM_KEY_RENEW_EN_OFFSET: usize = 352;
+/// Size of CREATOR_SW_CFG_SRAM_KEY_RENEW_EN
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_SRAM_KEY_RENEW_EN_SIZE: u32 = 4;
+/// Offset of CREATOR_SW_CFG_DIGEST
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_DIGEST_OFFSET: usize = 856;
+/// Size of CREATOR_SW_CFG_DIGEST
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_DIGEST_SIZE: u32 = 8;
+/// Offset of the OWNER_SW_CFG partition
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_OFFSET: usize = 864;
+/// Size of the OWNER_SW_CFG partition
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE: u32 = 800;
+/// Offset of OWNER_SW_CFG_ROM_ERROR_REPORTING
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_ERROR_REPORTING_OFFSET: usize = 864;
+/// Size of OWNER_SW_CFG_ROM_ERROR_REPORTING
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_ERROR_REPORTING_SIZE: u32 = 4;
+/// Offset of OWNER_SW_CFG_ROM_BOOTSTRAP_DIS
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_BOOTSTRAP_DIS_OFFSET: usize = 868;
+/// Size of OWNER_SW_CFG_ROM_BOOTSTRAP_DIS
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_BOOTSTRAP_DIS_SIZE: u32 = 4;
+/// Offset of OWNER_SW_CFG_ROM_ALERT_CLASS_EN
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_ALERT_CLASS_EN_OFFSET: usize = 872;
+/// Size of OWNER_SW_CFG_ROM_ALERT_CLASS_EN
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_ALERT_CLASS_EN_SIZE: u32 = 4;
+/// Offset of OWNER_SW_CFG_ROM_ALERT_ESCALATION
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_ALERT_ESCALATION_OFFSET: usize = 876;
+/// Size of OWNER_SW_CFG_ROM_ALERT_ESCALATION
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_ALERT_ESCALATION_SIZE: u32 = 4;
+/// Offset of OWNER_SW_CFG_ROM_ALERT_CLASSIFICATION
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_ALERT_CLASSIFICATION_OFFSET: usize = 880;
+/// Size of OWNER_SW_CFG_ROM_ALERT_CLASSIFICATION
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_ALERT_CLASSIFICATION_SIZE: u32 = 320;
+/// Offset of OWNER_SW_CFG_ROM_LOCAL_ALERT_CLASSIFICATION
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_LOCAL_ALERT_CLASSIFICATION_OFFSET: usize = 1200;
+/// Size of OWNER_SW_CFG_ROM_LOCAL_ALERT_CLASSIFICATION
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_LOCAL_ALERT_CLASSIFICATION_SIZE: u32 = 64;
+/// Offset of OWNER_SW_CFG_ROM_ALERT_ACCUM_THRESH
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_ALERT_ACCUM_THRESH_OFFSET: usize = 1264;
+/// Size of OWNER_SW_CFG_ROM_ALERT_ACCUM_THRESH
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_ALERT_ACCUM_THRESH_SIZE: u32 = 16;
+/// Offset of OWNER_SW_CFG_ROM_ALERT_TIMEOUT_CYCLES
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_ALERT_TIMEOUT_CYCLES_OFFSET: usize = 1280;
+/// Size of OWNER_SW_CFG_ROM_ALERT_TIMEOUT_CYCLES
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_ALERT_TIMEOUT_CYCLES_SIZE: u32 = 16;
+/// Offset of OWNER_SW_CFG_ROM_ALERT_PHASE_CYCLES
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_ALERT_PHASE_CYCLES_OFFSET: usize = 1296;
+/// Size of OWNER_SW_CFG_ROM_ALERT_PHASE_CYCLES
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_ALERT_PHASE_CYCLES_SIZE: u32 = 64;
+/// Offset of OWNER_SW_CFG_ROM_ALERT_DIGEST_PROD
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_ALERT_DIGEST_PROD_OFFSET: usize = 1360;
+/// Size of OWNER_SW_CFG_ROM_ALERT_DIGEST_PROD
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_ALERT_DIGEST_PROD_SIZE: u32 = 4;
+/// Offset of OWNER_SW_CFG_ROM_ALERT_DIGEST_PROD_END
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_ALERT_DIGEST_PROD_END_OFFSET: usize = 1364;
+/// Size of OWNER_SW_CFG_ROM_ALERT_DIGEST_PROD_END
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_ALERT_DIGEST_PROD_END_SIZE: u32 = 4;
+/// Offset of OWNER_SW_CFG_ROM_ALERT_DIGEST_DEV
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_ALERT_DIGEST_DEV_OFFSET: usize = 1368;
+/// Size of OWNER_SW_CFG_ROM_ALERT_DIGEST_DEV
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_ALERT_DIGEST_DEV_SIZE: u32 = 4;
+/// Offset of OWNER_SW_CFG_ROM_ALERT_DIGEST_RMA
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_ALERT_DIGEST_RMA_OFFSET: usize = 1372;
+/// Size of OWNER_SW_CFG_ROM_ALERT_DIGEST_RMA
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_ALERT_DIGEST_RMA_SIZE: u32 = 4;
+/// Offset of OWNER_SW_CFG_ROM_WATCHDOG_BITE_THRESHOLD_CYCLES
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_WATCHDOG_BITE_THRESHOLD_CYCLES_OFFSET: usize = 1376;
+/// Size of OWNER_SW_CFG_ROM_WATCHDOG_BITE_THRESHOLD_CYCLES
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_WATCHDOG_BITE_THRESHOLD_CYCLES_SIZE: u32 = 4;
+/// Offset of OWNER_SW_CFG_ROM_KEYMGR_ROM_EXT_MEAS_EN
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_KEYMGR_ROM_EXT_MEAS_EN_OFFSET: usize = 1380;
+/// Size of OWNER_SW_CFG_ROM_KEYMGR_ROM_EXT_MEAS_EN
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_KEYMGR_ROM_EXT_MEAS_EN_SIZE: u32 = 4;
+/// Offset of OWNER_SW_CFG_MANUF_STATE
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_MANUF_STATE_OFFSET: usize = 1384;
+/// Size of OWNER_SW_CFG_MANUF_STATE
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_MANUF_STATE_SIZE: u32 = 4;
+/// Offset of OWNER_SW_CFG_ROM_RSTMGR_INFO_EN
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_RSTMGR_INFO_EN_OFFSET: usize = 1388;
+/// Size of OWNER_SW_CFG_ROM_RSTMGR_INFO_EN
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_RSTMGR_INFO_EN_SIZE: u32 = 4;
+/// Offset of OWNER_SW_CFG_DIGEST
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_DIGEST_OFFSET: usize = 1656;
+/// Size of OWNER_SW_CFG_DIGEST
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_DIGEST_SIZE: u32 = 8;
+/// Offset of the HW_CFG partition
+pub const OTP_CTRL_PARAM_HW_CFG_OFFSET: usize = 1664;
+/// Size of the HW_CFG partition
+pub const OTP_CTRL_PARAM_HW_CFG_SIZE: u32 = 80;
+/// Offset of DEVICE_ID
+pub const OTP_CTRL_PARAM_DEVICE_ID_OFFSET: usize = 1664;
+/// Size of DEVICE_ID
+pub const OTP_CTRL_PARAM_DEVICE_ID_SIZE: u32 = 32;
+/// Offset of MANUF_STATE
+pub const OTP_CTRL_PARAM_MANUF_STATE_OFFSET: usize = 1696;
+/// Size of MANUF_STATE
+pub const OTP_CTRL_PARAM_MANUF_STATE_SIZE: u32 = 32;
+/// Offset of EN_SRAM_IFETCH
+pub const OTP_CTRL_PARAM_EN_SRAM_IFETCH_OFFSET: usize = 1728;
+/// Size of EN_SRAM_IFETCH
+pub const OTP_CTRL_PARAM_EN_SRAM_IFETCH_SIZE: u32 = 1;
+/// Offset of EN_CSRNG_SW_APP_READ
+pub const OTP_CTRL_PARAM_EN_CSRNG_SW_APP_READ_OFFSET: usize = 1729;
+/// Size of EN_CSRNG_SW_APP_READ
+pub const OTP_CTRL_PARAM_EN_CSRNG_SW_APP_READ_SIZE: u32 = 1;
+/// Offset of EN_ENTROPY_SRC_FW_READ
+pub const OTP_CTRL_PARAM_EN_ENTROPY_SRC_FW_READ_OFFSET: usize = 1730;
+/// Size of EN_ENTROPY_SRC_FW_READ
+pub const OTP_CTRL_PARAM_EN_ENTROPY_SRC_FW_READ_SIZE: u32 = 1;
+/// Offset of EN_ENTROPY_SRC_FW_OVER
+pub const OTP_CTRL_PARAM_EN_ENTROPY_SRC_FW_OVER_OFFSET: usize = 1731;
+/// Size of EN_ENTROPY_SRC_FW_OVER
+pub const OTP_CTRL_PARAM_EN_ENTROPY_SRC_FW_OVER_SIZE: u32 = 1;
+/// Offset of HW_CFG_DIGEST
+pub const OTP_CTRL_PARAM_HW_CFG_DIGEST_OFFSET: usize = 1736;
+/// Size of HW_CFG_DIGEST
+pub const OTP_CTRL_PARAM_HW_CFG_DIGEST_SIZE: u32 = 8;
+/// Offset of the SECRET0 partition
+pub const OTP_CTRL_PARAM_SECRET0_OFFSET: usize = 1744;
+/// Size of the SECRET0 partition
+pub const OTP_CTRL_PARAM_SECRET0_SIZE: u32 = 40;
+/// Offset of TEST_UNLOCK_TOKEN
+pub const OTP_CTRL_PARAM_TEST_UNLOCK_TOKEN_OFFSET: usize = 1744;
+/// Size of TEST_UNLOCK_TOKEN
+pub const OTP_CTRL_PARAM_TEST_UNLOCK_TOKEN_SIZE: u32 = 16;
+/// Offset of TEST_EXIT_TOKEN
+pub const OTP_CTRL_PARAM_TEST_EXIT_TOKEN_OFFSET: usize = 1760;
+/// Size of TEST_EXIT_TOKEN
+pub const OTP_CTRL_PARAM_TEST_EXIT_TOKEN_SIZE: u32 = 16;
+/// Offset of SECRET0_DIGEST
+pub const OTP_CTRL_PARAM_SECRET0_DIGEST_OFFSET: usize = 1776;
+/// Size of SECRET0_DIGEST
+pub const OTP_CTRL_PARAM_SECRET0_DIGEST_SIZE: u32 = 8;
+/// Offset of the SECRET1 partition
+pub const OTP_CTRL_PARAM_SECRET1_OFFSET: usize = 1784;
+/// Size of the SECRET1 partition
+pub const OTP_CTRL_PARAM_SECRET1_SIZE: u32 = 88;
+/// Offset of FLASH_ADDR_KEY_SEED
+pub const OTP_CTRL_PARAM_FLASH_ADDR_KEY_SEED_OFFSET: usize = 1784;
+/// Size of FLASH_ADDR_KEY_SEED
+pub const OTP_CTRL_PARAM_FLASH_ADDR_KEY_SEED_SIZE: u32 = 32;
+/// Offset of FLASH_DATA_KEY_SEED
+pub const OTP_CTRL_PARAM_FLASH_DATA_KEY_SEED_OFFSET: usize = 1816;
+/// Size of FLASH_DATA_KEY_SEED
+pub const OTP_CTRL_PARAM_FLASH_DATA_KEY_SEED_SIZE: u32 = 32;
+/// Offset of SRAM_DATA_KEY_SEED
+pub const OTP_CTRL_PARAM_SRAM_DATA_KEY_SEED_OFFSET: usize = 1848;
+/// Size of SRAM_DATA_KEY_SEED
+pub const OTP_CTRL_PARAM_SRAM_DATA_KEY_SEED_SIZE: u32 = 16;
+/// Offset of SECRET1_DIGEST
+pub const OTP_CTRL_PARAM_SECRET1_DIGEST_OFFSET: usize = 1864;
+/// Size of SECRET1_DIGEST
+pub const OTP_CTRL_PARAM_SECRET1_DIGEST_SIZE: u32 = 8;
+/// Offset of the SECRET2 partition
+pub const OTP_CTRL_PARAM_SECRET2_OFFSET: usize = 1872;
+/// Size of the SECRET2 partition
+pub const OTP_CTRL_PARAM_SECRET2_SIZE: u32 = 88;
+/// Offset of RMA_TOKEN
+pub const OTP_CTRL_PARAM_RMA_TOKEN_OFFSET: usize = 1872;
+/// Size of RMA_TOKEN
+pub const OTP_CTRL_PARAM_RMA_TOKEN_SIZE: u32 = 16;
+/// Offset of CREATOR_ROOT_KEY_SHARE0
+pub const OTP_CTRL_PARAM_CREATOR_ROOT_KEY_SHARE0_OFFSET: usize = 1888;
+/// Size of CREATOR_ROOT_KEY_SHARE0
+pub const OTP_CTRL_PARAM_CREATOR_ROOT_KEY_SHARE0_SIZE: u32 = 32;
+/// Offset of CREATOR_ROOT_KEY_SHARE1
+pub const OTP_CTRL_PARAM_CREATOR_ROOT_KEY_SHARE1_OFFSET: usize = 1920;
+/// Size of CREATOR_ROOT_KEY_SHARE1
+pub const OTP_CTRL_PARAM_CREATOR_ROOT_KEY_SHARE1_SIZE: u32 = 32;
+/// Offset of SECRET2_DIGEST
+pub const OTP_CTRL_PARAM_SECRET2_DIGEST_OFFSET: usize = 1952;
+/// Size of SECRET2_DIGEST
+pub const OTP_CTRL_PARAM_SECRET2_DIGEST_SIZE: u32 = 8;
+/// Offset of the LIFE_CYCLE partition
+pub const OTP_CTRL_PARAM_LIFE_CYCLE_OFFSET: usize = 1960;
+/// Size of the LIFE_CYCLE partition
+pub const OTP_CTRL_PARAM_LIFE_CYCLE_SIZE: u32 = 88;
+/// Offset of LC_TRANSITION_CNT
+pub const OTP_CTRL_PARAM_LC_TRANSITION_CNT_OFFSET: usize = 1960;
+/// Size of LC_TRANSITION_CNT
+pub const OTP_CTRL_PARAM_LC_TRANSITION_CNT_SIZE: u32 = 48;
+/// Offset of LC_STATE
+pub const OTP_CTRL_PARAM_LC_STATE_OFFSET: usize = 2008;
+/// Size of LC_STATE
+pub const OTP_CTRL_PARAM_LC_STATE_SIZE: u32 = 40;
+/// Number of alerts
+pub const OTP_CTRL_PARAM_NUM_ALERTS: u32 = 5;
+/// Register width
+pub const OTP_CTRL_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub OtpCtrlRegisters {
+        /// Interrupt State Register
+        (0x0000 => pub(crate) intr_state: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Enable Register
+        (0x0004 => pub(crate) intr_enable: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Test Register
+        (0x0008 => pub(crate) intr_test: ReadWrite<u32, INTR::Register>),
+        /// Alert Test Register
+        (0x000c => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// OTP status register.
+        (0x0010 => pub(crate) status: ReadWrite<u32, STATUS::Register>),
+        /// This register holds information about error conditions that occurred in the agents
+        (0x0014 => pub(crate) err_code: [ReadWrite<u32, ERR_CODE::Register>; 1]),
+        /// Register write enable for all direct access interface registers.
+        (0x0018 => pub(crate) direct_access_regwen: ReadWrite<u32, DIRECT_ACCESS_REGWEN::Register>),
+        /// Command register for direct accesses.
+        (0x001c => pub(crate) direct_access_cmd: ReadWrite<u32, DIRECT_ACCESS_CMD::Register>),
+        /// Address register for direct accesses.
+        (0x0020 => pub(crate) direct_access_address: ReadWrite<u32, DIRECT_ACCESS_ADDRESS::Register>),
+        /// Write data for direct accesses.
+        (0x0024 => pub(crate) direct_access_wdata: [ReadWrite<u32, DIRECT_ACCESS_WDATA::Register>; 2]),
+        /// Read data for direct accesses.
+        (0x002c => pub(crate) direct_access_rdata: [ReadWrite<u32, DIRECT_ACCESS_RDATA::Register>; 2]),
+        /// Register write enable for !!CHECK_TRIGGER.
+        (0x0034 => pub(crate) check_trigger_regwen: ReadWrite<u32, CHECK_TRIGGER_REGWEN::Register>),
+        /// Command register for direct accesses.
+        (0x0038 => pub(crate) check_trigger: ReadWrite<u32, CHECK_TRIGGER::Register>),
+        /// Register write enable for !!INTEGRITY_CHECK_PERIOD and !!CONSISTENCY_CHECK_PERIOD.
+        (0x003c => pub(crate) check_regwen: ReadWrite<u32, CHECK_REGWEN::Register>),
+        /// Timeout value for the integrity and consistency checks.
+        (0x0040 => pub(crate) check_timeout: ReadWrite<u32, CHECK_TIMEOUT::Register>),
+        /// This value specifies the maximum period that can be generated pseudo-randomly.
+        (0x0044 => pub(crate) integrity_check_period: ReadWrite<u32, INTEGRITY_CHECK_PERIOD::Register>),
+        /// This value specifies the maximum period that can be generated pseudo-randomly.
+        (0x0048 => pub(crate) consistency_check_period: ReadWrite<u32, CONSISTENCY_CHECK_PERIOD::Register>),
+        /// Runtime read lock for the VENDOR_TEST partition.
+        (0x004c => pub(crate) vendor_test_read_lock: ReadWrite<u32, VENDOR_TEST_READ_LOCK::Register>),
+        /// Runtime read lock for the CREATOR_SW_CFG partition.
+        (0x0050 => pub(crate) creator_sw_cfg_read_lock: ReadWrite<u32, CREATOR_SW_CFG_READ_LOCK::Register>),
+        /// Runtime read lock for the OWNER_SW_CFG partition.
+        (0x0054 => pub(crate) owner_sw_cfg_read_lock: ReadWrite<u32, OWNER_SW_CFG_READ_LOCK::Register>),
+        /// Integrity digest for the VENDOR_TEST partition.
+        (0x0058 => pub(crate) vendor_test_digest: [ReadWrite<u32, VENDOR_TEST_DIGEST::Register>; 2]),
+        /// Integrity digest for the CREATOR_SW_CFG partition.
+        (0x0060 => pub(crate) creator_sw_cfg_digest: [ReadWrite<u32, CREATOR_SW_CFG_DIGEST::Register>; 2]),
+        /// Integrity digest for the OWNER_SW_CFG partition.
+        (0x0068 => pub(crate) owner_sw_cfg_digest: [ReadWrite<u32, OWNER_SW_CFG_DIGEST::Register>; 2]),
+        /// Integrity digest for the HW_CFG partition.
+        (0x0070 => pub(crate) hw_cfg_digest: [ReadWrite<u32, HW_CFG_DIGEST::Register>; 2]),
+        /// Integrity digest for the SECRET0 partition.
+        (0x0078 => pub(crate) secret0_digest: [ReadWrite<u32, SECRET0_DIGEST::Register>; 2]),
+        /// Integrity digest for the SECRET1 partition.
+        (0x0080 => pub(crate) secret1_digest: [ReadWrite<u32, SECRET1_DIGEST::Register>; 2]),
+        /// Integrity digest for the SECRET2 partition.
+        (0x0088 => pub(crate) secret2_digest: [ReadWrite<u32, SECRET2_DIGEST::Register>; 2]),
+        (0x0090 => _reserved1),
+        /// Memory area: Any read to this window directly maps to the corresponding offset in the creator
+        /// and owner software
+        (0x1000 => pub(crate) sw_cfg_window: [ReadOnly<u32>; 512]),
+        (0x1800 => @END),
+    }
+}
+
+register_bitfields![u32,
+    /// Common Interrupt Offsets
+    pub(crate) INTR [
+        OTP_OPERATION_DONE OFFSET(0) NUMBITS(1) [],
+        OTP_ERROR OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) ALERT_TEST [
+        FATAL_MACRO_ERROR OFFSET(0) NUMBITS(1) [],
+        FATAL_CHECK_ERROR OFFSET(1) NUMBITS(1) [],
+        FATAL_BUS_INTEG_ERROR OFFSET(2) NUMBITS(1) [],
+        FATAL_PRIM_OTP_ALERT OFFSET(3) NUMBITS(1) [],
+        RECOV_PRIM_OTP_ALERT OFFSET(4) NUMBITS(1) [],
+    ],
+    pub(crate) STATUS [
+        VENDOR_TEST_ERROR OFFSET(0) NUMBITS(1) [],
+        CREATOR_SW_CFG_ERROR OFFSET(1) NUMBITS(1) [],
+        OWNER_SW_CFG_ERROR OFFSET(2) NUMBITS(1) [],
+        HW_CFG_ERROR OFFSET(3) NUMBITS(1) [],
+        SECRET0_ERROR OFFSET(4) NUMBITS(1) [],
+        SECRET1_ERROR OFFSET(5) NUMBITS(1) [],
+        SECRET2_ERROR OFFSET(6) NUMBITS(1) [],
+        LIFE_CYCLE_ERROR OFFSET(7) NUMBITS(1) [],
+        DAI_ERROR OFFSET(8) NUMBITS(1) [],
+        LCI_ERROR OFFSET(9) NUMBITS(1) [],
+        TIMEOUT_ERROR OFFSET(10) NUMBITS(1) [],
+        LFSR_FSM_ERROR OFFSET(11) NUMBITS(1) [],
+        SCRAMBLING_FSM_ERROR OFFSET(12) NUMBITS(1) [],
+        KEY_DERIV_FSM_ERROR OFFSET(13) NUMBITS(1) [],
+        BUS_INTEG_ERROR OFFSET(14) NUMBITS(1) [],
+        DAI_IDLE OFFSET(15) NUMBITS(1) [],
+        CHECK_PENDING OFFSET(16) NUMBITS(1) [],
+    ],
+    pub(crate) ERR_CODE [
+        ERR_CODE_0 OFFSET(0) NUMBITS(3) [
+            NO_ERROR = 0,
+            MACRO_ERROR = 1,
+            MACRO_ECC_CORR_ERROR = 2,
+            MACRO_ECC_UNCORR_ERROR = 3,
+            MACRO_WRITE_BLANK_ERROR = 4,
+            ACCESS_ERROR = 5,
+            CHECK_FAIL_ERROR = 6,
+            FSM_STATE_ERROR = 7,
+        ],
+        ERR_CODE_1 OFFSET(3) NUMBITS(3) [
+            NO_ERROR = 0,
+            MACRO_ERROR = 1,
+            MACRO_ECC_CORR_ERROR = 2,
+            MACRO_ECC_UNCORR_ERROR = 3,
+            MACRO_WRITE_BLANK_ERROR = 4,
+            ACCESS_ERROR = 5,
+            CHECK_FAIL_ERROR = 6,
+            FSM_STATE_ERROR = 7,
+        ],
+        ERR_CODE_2 OFFSET(6) NUMBITS(3) [
+            NO_ERROR = 0,
+            MACRO_ERROR = 1,
+            MACRO_ECC_CORR_ERROR = 2,
+            MACRO_ECC_UNCORR_ERROR = 3,
+            MACRO_WRITE_BLANK_ERROR = 4,
+            ACCESS_ERROR = 5,
+            CHECK_FAIL_ERROR = 6,
+            FSM_STATE_ERROR = 7,
+        ],
+        ERR_CODE_3 OFFSET(9) NUMBITS(3) [
+            NO_ERROR = 0,
+            MACRO_ERROR = 1,
+            MACRO_ECC_CORR_ERROR = 2,
+            MACRO_ECC_UNCORR_ERROR = 3,
+            MACRO_WRITE_BLANK_ERROR = 4,
+            ACCESS_ERROR = 5,
+            CHECK_FAIL_ERROR = 6,
+            FSM_STATE_ERROR = 7,
+        ],
+        ERR_CODE_4 OFFSET(12) NUMBITS(3) [
+            NO_ERROR = 0,
+            MACRO_ERROR = 1,
+            MACRO_ECC_CORR_ERROR = 2,
+            MACRO_ECC_UNCORR_ERROR = 3,
+            MACRO_WRITE_BLANK_ERROR = 4,
+            ACCESS_ERROR = 5,
+            CHECK_FAIL_ERROR = 6,
+            FSM_STATE_ERROR = 7,
+        ],
+        ERR_CODE_5 OFFSET(15) NUMBITS(3) [
+            NO_ERROR = 0,
+            MACRO_ERROR = 1,
+            MACRO_ECC_CORR_ERROR = 2,
+            MACRO_ECC_UNCORR_ERROR = 3,
+            MACRO_WRITE_BLANK_ERROR = 4,
+            ACCESS_ERROR = 5,
+            CHECK_FAIL_ERROR = 6,
+            FSM_STATE_ERROR = 7,
+        ],
+        ERR_CODE_6 OFFSET(18) NUMBITS(3) [
+            NO_ERROR = 0,
+            MACRO_ERROR = 1,
+            MACRO_ECC_CORR_ERROR = 2,
+            MACRO_ECC_UNCORR_ERROR = 3,
+            MACRO_WRITE_BLANK_ERROR = 4,
+            ACCESS_ERROR = 5,
+            CHECK_FAIL_ERROR = 6,
+            FSM_STATE_ERROR = 7,
+        ],
+        ERR_CODE_7 OFFSET(21) NUMBITS(3) [
+            NO_ERROR = 0,
+            MACRO_ERROR = 1,
+            MACRO_ECC_CORR_ERROR = 2,
+            MACRO_ECC_UNCORR_ERROR = 3,
+            MACRO_WRITE_BLANK_ERROR = 4,
+            ACCESS_ERROR = 5,
+            CHECK_FAIL_ERROR = 6,
+            FSM_STATE_ERROR = 7,
+        ],
+        ERR_CODE_8 OFFSET(24) NUMBITS(3) [
+            NO_ERROR = 0,
+            MACRO_ERROR = 1,
+            MACRO_ECC_CORR_ERROR = 2,
+            MACRO_ECC_UNCORR_ERROR = 3,
+            MACRO_WRITE_BLANK_ERROR = 4,
+            ACCESS_ERROR = 5,
+            CHECK_FAIL_ERROR = 6,
+            FSM_STATE_ERROR = 7,
+        ],
+        ERR_CODE_9 OFFSET(27) NUMBITS(3) [
+            NO_ERROR = 0,
+            MACRO_ERROR = 1,
+            MACRO_ECC_CORR_ERROR = 2,
+            MACRO_ECC_UNCORR_ERROR = 3,
+            MACRO_WRITE_BLANK_ERROR = 4,
+            ACCESS_ERROR = 5,
+            CHECK_FAIL_ERROR = 6,
+            FSM_STATE_ERROR = 7,
+        ],
+    ],
+    pub(crate) DIRECT_ACCESS_REGWEN [
+        DIRECT_ACCESS_REGWEN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) DIRECT_ACCESS_CMD [
+        RD OFFSET(0) NUMBITS(1) [],
+        WR OFFSET(1) NUMBITS(1) [],
+        DIGEST OFFSET(2) NUMBITS(1) [],
+    ],
+    pub(crate) DIRECT_ACCESS_ADDRESS [
+        DIRECT_ACCESS_ADDRESS OFFSET(0) NUMBITS(11) [],
+    ],
+    pub(crate) DIRECT_ACCESS_WDATA [
+        DIRECT_ACCESS_WDATA_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) DIRECT_ACCESS_RDATA [
+        DIRECT_ACCESS_RDATA_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) CHECK_TRIGGER_REGWEN [
+        CHECK_TRIGGER_REGWEN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CHECK_TRIGGER [
+        INTEGRITY OFFSET(0) NUMBITS(1) [],
+        CONSISTENCY OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) CHECK_REGWEN [
+        CHECK_REGWEN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CHECK_TIMEOUT [
+        CHECK_TIMEOUT OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) INTEGRITY_CHECK_PERIOD [
+        INTEGRITY_CHECK_PERIOD OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) CONSISTENCY_CHECK_PERIOD [
+        CONSISTENCY_CHECK_PERIOD OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) VENDOR_TEST_READ_LOCK [
+        VENDOR_TEST_READ_LOCK OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CREATOR_SW_CFG_READ_LOCK [
+        CREATOR_SW_CFG_READ_LOCK OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) OWNER_SW_CFG_READ_LOCK [
+        OWNER_SW_CFG_READ_LOCK OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) VENDOR_TEST_DIGEST [
+        VENDOR_TEST_DIGEST_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) CREATOR_SW_CFG_DIGEST [
+        CREATOR_SW_CFG_DIGEST_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) OWNER_SW_CFG_DIGEST [
+        OWNER_SW_CFG_DIGEST_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) HW_CFG_DIGEST [
+        HW_CFG_DIGEST_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) SECRET0_DIGEST [
+        SECRET0_DIGEST_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) SECRET1_DIGEST [
+        SECRET1_DIGEST_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) SECRET2_DIGEST [
+        SECRET2_DIGEST_0 OFFSET(0) NUMBITS(32) [],
+    ],
+];
+
+// End generated register constants for otp_ctrl

--- a/chips/lowrisc/src/registers/pattgen_regs.rs
+++ b/chips/lowrisc/src/registers/pattgen_regs.rs
@@ -1,0 +1,82 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for pattgen.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/ip/pattgen/data/pattgen.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Number of data registers per each channel
+pub const PATTGEN_PARAM_NUM_REGS_DATA: u32 = 2;
+/// Number of alerts
+pub const PATTGEN_PARAM_NUM_ALERTS: u32 = 1;
+/// Register width
+pub const PATTGEN_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub PattgenRegisters {
+        /// Interrupt State Register
+        (0x0000 => pub(crate) intr_state: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Enable Register
+        (0x0004 => pub(crate) intr_enable: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Test Register
+        (0x0008 => pub(crate) intr_test: ReadWrite<u32, INTR::Register>),
+        /// Alert Test Register
+        (0x000c => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// PATTGEN control register
+        (0x0010 => pub(crate) ctrl: ReadWrite<u32, CTRL::Register>),
+        /// PATTGEN pre-divider register for Channel 0
+        (0x0014 => pub(crate) prediv_ch0: ReadWrite<u32, PREDIV_CH0::Register>),
+        /// PATTGEN pre-divider register for Channel 1
+        (0x0018 => pub(crate) prediv_ch1: ReadWrite<u32, PREDIV_CH1::Register>),
+        /// PATTGEN seed pattern multi-registers for Channel 0.
+        (0x001c => pub(crate) data_ch0: [ReadWrite<u32, DATA_CH0::Register>; 2]),
+        /// PATTGEN seed pattern multi-registers for Channel 1.
+        (0x0024 => pub(crate) data_ch1: [ReadWrite<u32, DATA_CH1::Register>; 2]),
+        /// PATTGEN pattern length
+        (0x002c => pub(crate) size: ReadWrite<u32, SIZE::Register>),
+        (0x0030 => @END),
+    }
+}
+
+register_bitfields![u32,
+    /// Common Interrupt Offsets
+    pub(crate) INTR [
+        DONE_CH0 OFFSET(0) NUMBITS(1) [],
+        DONE_CH1 OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) ALERT_TEST [
+        FATAL_FAULT OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CTRL [
+        ENABLE_CH0 OFFSET(0) NUMBITS(1) [],
+        ENABLE_CH1 OFFSET(1) NUMBITS(1) [],
+        POLARITY_CH0 OFFSET(2) NUMBITS(1) [],
+        POLARITY_CH1 OFFSET(3) NUMBITS(1) [],
+    ],
+    pub(crate) PREDIV_CH0 [
+        CLK_RATIO OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) PREDIV_CH1 [
+        CLK_RATIO OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) DATA_CH0 [
+        DATA_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) DATA_CH1 [
+        DATA_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) SIZE [
+        LEN_CH0 OFFSET(0) NUMBITS(6) [],
+        REPS_CH0 OFFSET(6) NUMBITS(10) [],
+        LEN_CH1 OFFSET(16) NUMBITS(6) [],
+        REPS_CH1 OFFSET(22) NUMBITS(10) [],
+    ],
+];
+
+// End generated register constants for pattgen

--- a/chips/lowrisc/src/registers/pinmux_regs.rs
+++ b/chips/lowrisc/src/registers/pinmux_regs.rs
@@ -1,0 +1,250 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for pinmux.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/ip/pinmux/data/pinmux.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Pad attribute data width
+pub const PINMUX_PARAM_ATTR_DW: u32 = 10;
+/// Number of muxed peripheral inputs
+pub const PINMUX_PARAM_N_MIO_PERIPH_IN: u32 = 33;
+/// Number of muxed peripheral outputs
+pub const PINMUX_PARAM_N_MIO_PERIPH_OUT: u32 = 32;
+/// Number of muxed IO pads
+pub const PINMUX_PARAM_N_MIO_PADS: u32 = 32;
+/// Number of dedicated IO pads
+pub const PINMUX_PARAM_N_DIO_PADS: u32 = 16;
+/// Number of wakeup detectors
+pub const PINMUX_PARAM_N_WKUP_DETECT: u32 = 8;
+/// Number of wakeup counter bits
+pub const PINMUX_PARAM_WKUP_CNT_WIDTH: u32 = 8;
+/// Number of alerts
+pub const PINMUX_PARAM_NUM_ALERTS: u32 = 1;
+/// Register width
+pub const PINMUX_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub PinmuxRegisters {
+        /// Alert Test Register
+        (0x0000 => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// Register write enable for MIO peripheral input selects.
+        (0x0004 => pub(crate) mio_periph_insel_regwen: [ReadWrite<u32, MIO_PERIPH_INSEL_REGWEN::Register>; 33]),
+        /// For each peripheral input, this selects the muxable pad input.
+        (0x0088 => pub(crate) mio_periph_insel: [ReadWrite<u32, MIO_PERIPH_INSEL::Register>; 33]),
+        /// Register write enable for MIO output selects.
+        (0x010c => pub(crate) mio_outsel_regwen: [ReadWrite<u32, MIO_OUTSEL_REGWEN::Register>; 32]),
+        /// For each muxable pad, this selects the peripheral output.
+        (0x018c => pub(crate) mio_outsel: [ReadWrite<u32, MIO_OUTSEL::Register>; 32]),
+        /// Register write enable for MIO PAD attributes.
+        (0x020c => pub(crate) mio_pad_attr_regwen: [ReadWrite<u32, MIO_PAD_ATTR_REGWEN::Register>; 32]),
+        /// Muxed pad attributes.
+        (0x028c => pub(crate) mio_pad_attr: [ReadWrite<u32, MIO_PAD_ATTR::Register>; 32]),
+        /// Register write enable for DIO PAD attributes.
+        (0x030c => pub(crate) dio_pad_attr_regwen: [ReadWrite<u32, DIO_PAD_ATTR_REGWEN::Register>; 16]),
+        /// Dedicated pad attributes.
+        (0x034c => pub(crate) dio_pad_attr: [ReadWrite<u32, DIO_PAD_ATTR::Register>; 16]),
+        /// Register indicating whether the corresponding pad is in sleep mode.
+        (0x038c => pub(crate) mio_pad_sleep_status: [ReadWrite<u32, MIO_PAD_SLEEP_STATUS::Register>; 1]),
+        /// Register write enable for MIO sleep value configuration.
+        (0x0390 => pub(crate) mio_pad_sleep_regwen: [ReadWrite<u32, MIO_PAD_SLEEP_REGWEN::Register>; 32]),
+        /// Enables the sleep mode of the corresponding muxed pad.
+        (0x0410 => pub(crate) mio_pad_sleep_en: [ReadWrite<u32, MIO_PAD_SLEEP_EN::Register>; 32]),
+        /// Defines sleep behavior of the corresponding muxed pad.
+        (0x0490 => pub(crate) mio_pad_sleep_mode: [ReadWrite<u32, MIO_PAD_SLEEP_MODE::Register>; 32]),
+        /// Register indicating whether the corresponding pad is in sleep mode.
+        (0x0510 => pub(crate) dio_pad_sleep_status: [ReadWrite<u32, DIO_PAD_SLEEP_STATUS::Register>; 1]),
+        /// Register write enable for DIO sleep value configuration.
+        (0x0514 => pub(crate) dio_pad_sleep_regwen: [ReadWrite<u32, DIO_PAD_SLEEP_REGWEN::Register>; 16]),
+        /// Enables the sleep mode of the corresponding dedicated pad.
+        (0x0554 => pub(crate) dio_pad_sleep_en: [ReadWrite<u32, DIO_PAD_SLEEP_EN::Register>; 16]),
+        /// Defines sleep behavior of the corresponding dedicated pad.
+        (0x0594 => pub(crate) dio_pad_sleep_mode: [ReadWrite<u32, DIO_PAD_SLEEP_MODE::Register>; 16]),
+        /// Register write enable for wakeup detectors.
+        (0x05d4 => pub(crate) wkup_detector_regwen: [ReadWrite<u32, WKUP_DETECTOR_REGWEN::Register>; 8]),
+        /// Enables for the wakeup detectors.
+        (0x05f4 => pub(crate) wkup_detector_en: [ReadWrite<u32, WKUP_DETECTOR_EN::Register>; 8]),
+        /// Configuration of wakeup condition detectors.
+        (0x0614 => pub(crate) wkup_detector: [ReadWrite<u32, WKUP_DETECTOR::Register>; 8]),
+        /// Counter thresholds for wakeup condition detectors.
+        (0x0634 => pub(crate) wkup_detector_cnt_th: [ReadWrite<u32, WKUP_DETECTOR_CNT_TH::Register>; 8]),
+        /// Pad selects for pad wakeup condition detectors.
+        (0x0654 => pub(crate) wkup_detector_padsel: [ReadWrite<u32, WKUP_DETECTOR_PADSEL::Register>; 8]),
+        /// Cause registers for wakeup detectors.
+        (0x0674 => pub(crate) wkup_cause: [ReadWrite<u32, WKUP_CAUSE::Register>; 1]),
+        (0x0678 => @END),
+    }
+}
+
+register_bitfields![u32,
+    pub(crate) ALERT_TEST [
+        FATAL_FAULT OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) MIO_PERIPH_INSEL_REGWEN [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) MIO_PERIPH_INSEL [
+        IN_0 OFFSET(0) NUMBITS(6) [],
+    ],
+    pub(crate) MIO_OUTSEL_REGWEN [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) MIO_OUTSEL [
+        OUT_0 OFFSET(0) NUMBITS(6) [],
+    ],
+    pub(crate) MIO_PAD_ATTR_REGWEN [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) MIO_PAD_ATTR [
+        INVERT_0 OFFSET(0) NUMBITS(1) [],
+        VIRTUAL_OD_EN_0 OFFSET(1) NUMBITS(1) [],
+        PULL_EN_0 OFFSET(2) NUMBITS(1) [],
+        PULL_SELECT_0 OFFSET(3) NUMBITS(1) [
+            PULL_DOWN = 0,
+            PULL_UP = 1,
+        ],
+        KEEPER_EN_0 OFFSET(4) NUMBITS(1) [],
+        SCHMITT_EN_0 OFFSET(5) NUMBITS(1) [],
+        OD_EN_0 OFFSET(6) NUMBITS(1) [],
+        SLEW_RATE_0 OFFSET(16) NUMBITS(2) [],
+        DRIVE_STRENGTH_0 OFFSET(20) NUMBITS(4) [],
+    ],
+    pub(crate) DIO_PAD_ATTR_REGWEN [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) DIO_PAD_ATTR [
+        INVERT_0 OFFSET(0) NUMBITS(1) [],
+        VIRTUAL_OD_EN_0 OFFSET(1) NUMBITS(1) [],
+        PULL_EN_0 OFFSET(2) NUMBITS(1) [],
+        PULL_SELECT_0 OFFSET(3) NUMBITS(1) [
+            PULL_DOWN = 0,
+            PULL_UP = 1,
+        ],
+        KEEPER_EN_0 OFFSET(4) NUMBITS(1) [],
+        SCHMITT_EN_0 OFFSET(5) NUMBITS(1) [],
+        OD_EN_0 OFFSET(6) NUMBITS(1) [],
+        SLEW_RATE_0 OFFSET(16) NUMBITS(2) [],
+        DRIVE_STRENGTH_0 OFFSET(20) NUMBITS(4) [],
+    ],
+    pub(crate) MIO_PAD_SLEEP_STATUS [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+        EN_1 OFFSET(1) NUMBITS(1) [],
+        EN_2 OFFSET(2) NUMBITS(1) [],
+        EN_3 OFFSET(3) NUMBITS(1) [],
+        EN_4 OFFSET(4) NUMBITS(1) [],
+        EN_5 OFFSET(5) NUMBITS(1) [],
+        EN_6 OFFSET(6) NUMBITS(1) [],
+        EN_7 OFFSET(7) NUMBITS(1) [],
+        EN_8 OFFSET(8) NUMBITS(1) [],
+        EN_9 OFFSET(9) NUMBITS(1) [],
+        EN_10 OFFSET(10) NUMBITS(1) [],
+        EN_11 OFFSET(11) NUMBITS(1) [],
+        EN_12 OFFSET(12) NUMBITS(1) [],
+        EN_13 OFFSET(13) NUMBITS(1) [],
+        EN_14 OFFSET(14) NUMBITS(1) [],
+        EN_15 OFFSET(15) NUMBITS(1) [],
+        EN_16 OFFSET(16) NUMBITS(1) [],
+        EN_17 OFFSET(17) NUMBITS(1) [],
+        EN_18 OFFSET(18) NUMBITS(1) [],
+        EN_19 OFFSET(19) NUMBITS(1) [],
+        EN_20 OFFSET(20) NUMBITS(1) [],
+        EN_21 OFFSET(21) NUMBITS(1) [],
+        EN_22 OFFSET(22) NUMBITS(1) [],
+        EN_23 OFFSET(23) NUMBITS(1) [],
+        EN_24 OFFSET(24) NUMBITS(1) [],
+        EN_25 OFFSET(25) NUMBITS(1) [],
+        EN_26 OFFSET(26) NUMBITS(1) [],
+        EN_27 OFFSET(27) NUMBITS(1) [],
+        EN_28 OFFSET(28) NUMBITS(1) [],
+        EN_29 OFFSET(29) NUMBITS(1) [],
+        EN_30 OFFSET(30) NUMBITS(1) [],
+        EN_31 OFFSET(31) NUMBITS(1) [],
+    ],
+    pub(crate) MIO_PAD_SLEEP_REGWEN [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) MIO_PAD_SLEEP_EN [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) MIO_PAD_SLEEP_MODE [
+        OUT_0 OFFSET(0) NUMBITS(2) [
+            TIE_LOW = 0,
+            TIE_HIGH = 1,
+            HIGH_Z = 2,
+            KEEP = 3,
+        ],
+    ],
+    pub(crate) DIO_PAD_SLEEP_STATUS [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+        EN_1 OFFSET(1) NUMBITS(1) [],
+        EN_2 OFFSET(2) NUMBITS(1) [],
+        EN_3 OFFSET(3) NUMBITS(1) [],
+        EN_4 OFFSET(4) NUMBITS(1) [],
+        EN_5 OFFSET(5) NUMBITS(1) [],
+        EN_6 OFFSET(6) NUMBITS(1) [],
+        EN_7 OFFSET(7) NUMBITS(1) [],
+        EN_8 OFFSET(8) NUMBITS(1) [],
+        EN_9 OFFSET(9) NUMBITS(1) [],
+        EN_10 OFFSET(10) NUMBITS(1) [],
+        EN_11 OFFSET(11) NUMBITS(1) [],
+        EN_12 OFFSET(12) NUMBITS(1) [],
+        EN_13 OFFSET(13) NUMBITS(1) [],
+        EN_14 OFFSET(14) NUMBITS(1) [],
+        EN_15 OFFSET(15) NUMBITS(1) [],
+    ],
+    pub(crate) DIO_PAD_SLEEP_REGWEN [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) DIO_PAD_SLEEP_EN [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) DIO_PAD_SLEEP_MODE [
+        OUT_0 OFFSET(0) NUMBITS(2) [
+            TIE_LOW = 0,
+            TIE_HIGH = 1,
+            HIGH_Z = 2,
+            KEEP = 3,
+        ],
+    ],
+    pub(crate) WKUP_DETECTOR_REGWEN [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) WKUP_DETECTOR_EN [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) WKUP_DETECTOR [
+        MODE_0 OFFSET(0) NUMBITS(3) [
+            POSEDGE = 0,
+            NEGEDGE = 1,
+            EDGE = 2,
+            TIMEDHIGH = 3,
+            TIMEDLOW = 4,
+        ],
+        FILTER_0 OFFSET(3) NUMBITS(1) [],
+        MIODIO_0 OFFSET(4) NUMBITS(1) [],
+    ],
+    pub(crate) WKUP_DETECTOR_CNT_TH [
+        TH_0 OFFSET(0) NUMBITS(8) [],
+    ],
+    pub(crate) WKUP_DETECTOR_PADSEL [
+        SEL_0 OFFSET(0) NUMBITS(6) [],
+    ],
+    pub(crate) WKUP_CAUSE [
+        CAUSE_0 OFFSET(0) NUMBITS(1) [],
+        CAUSE_1 OFFSET(1) NUMBITS(1) [],
+        CAUSE_2 OFFSET(2) NUMBITS(1) [],
+        CAUSE_3 OFFSET(3) NUMBITS(1) [],
+        CAUSE_4 OFFSET(4) NUMBITS(1) [],
+        CAUSE_5 OFFSET(5) NUMBITS(1) [],
+        CAUSE_6 OFFSET(6) NUMBITS(1) [],
+        CAUSE_7 OFFSET(7) NUMBITS(1) [],
+    ],
+];
+
+// End generated register constants for pinmux

--- a/chips/lowrisc/src/registers/pwm_regs.rs
+++ b/chips/lowrisc/src/registers/pwm_regs.rs
@@ -1,0 +1,86 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for pwm.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/ip/pwm/data/pwm.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Number of PWM outputs
+pub const PWM_PARAM_N_OUTPUTS: u32 = 6;
+/// Number of alerts
+pub const PWM_PARAM_NUM_ALERTS: u32 = 1;
+/// Register width
+pub const PWM_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub PwmRegisters {
+        /// Alert Test Register
+        (0x0000 => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// Register write enable for all control registers
+        (0x0004 => pub(crate) regwen: ReadWrite<u32, REGWEN::Register>),
+        /// Configuration register
+        (0x0008 => pub(crate) cfg: ReadWrite<u32, CFG::Register>),
+        /// Enable PWM operation for each channel
+        (0x000c => pub(crate) pwm_en: [ReadWrite<u32, PWM_EN::Register>; 1]),
+        /// Invert the PWM output for each channel
+        (0x0010 => pub(crate) invert: [ReadWrite<u32, INVERT::Register>; 1]),
+        /// Basic PWM Channel Parameters
+        (0x0014 => pub(crate) pwm_param: [ReadWrite<u32, PWM_PARAM::Register>; 6]),
+        /// Controls the duty_cycle of each channel.
+        (0x002c => pub(crate) duty_cycle: [ReadWrite<u32, DUTY_CYCLE::Register>; 6]),
+        /// Hardware controlled blink/heartbeat parameters.
+        (0x0044 => pub(crate) blink_param: [ReadWrite<u32, BLINK_PARAM::Register>; 6]),
+        (0x005c => @END),
+    }
+}
+
+register_bitfields![u32,
+    pub(crate) ALERT_TEST [
+        FATAL_FAULT OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) REGWEN [
+        REGWEN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CFG [
+        CLK_DIV OFFSET(0) NUMBITS(27) [],
+        DC_RESN OFFSET(27) NUMBITS(4) [],
+        CNTR_EN OFFSET(31) NUMBITS(1) [],
+    ],
+    pub(crate) PWM_EN [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+        EN_1 OFFSET(1) NUMBITS(1) [],
+        EN_2 OFFSET(2) NUMBITS(1) [],
+        EN_3 OFFSET(3) NUMBITS(1) [],
+        EN_4 OFFSET(4) NUMBITS(1) [],
+        EN_5 OFFSET(5) NUMBITS(1) [],
+    ],
+    pub(crate) INVERT [
+        INVERT_0 OFFSET(0) NUMBITS(1) [],
+        INVERT_1 OFFSET(1) NUMBITS(1) [],
+        INVERT_2 OFFSET(2) NUMBITS(1) [],
+        INVERT_3 OFFSET(3) NUMBITS(1) [],
+        INVERT_4 OFFSET(4) NUMBITS(1) [],
+        INVERT_5 OFFSET(5) NUMBITS(1) [],
+    ],
+    pub(crate) PWM_PARAM [
+        PHASE_DELAY_0 OFFSET(0) NUMBITS(16) [],
+        HTBT_EN_0 OFFSET(30) NUMBITS(1) [],
+        BLINK_EN_0 OFFSET(31) NUMBITS(1) [],
+    ],
+    pub(crate) DUTY_CYCLE [
+        A_0 OFFSET(0) NUMBITS(16) [],
+        B_0 OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) BLINK_PARAM [
+        X_0 OFFSET(0) NUMBITS(16) [],
+        Y_0 OFFSET(16) NUMBITS(16) [],
+    ],
+];
+
+// End generated register constants for pwm

--- a/chips/lowrisc/src/registers/rom_ctrl_regs.rs
+++ b/chips/lowrisc/src/registers/rom_ctrl_regs.rs
@@ -1,0 +1,49 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for rom_ctrl.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/ip/rom_ctrl/data/rom_ctrl.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Number of alerts
+pub const ROM_CTRL_PARAM_NUM_ALERTS: u32 = 1;
+/// Register width
+pub const ROM_CTRL_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub RomCtrlRegisters {
+        /// Alert Test Register
+        (0x0000 => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// The cause of a fatal alert.
+        (0x0004 => pub(crate) fatal_alert_cause: ReadWrite<u32, FATAL_ALERT_CAUSE::Register>),
+        /// The digest computed from the contents of ROM
+        (0x0008 => pub(crate) digest: [ReadWrite<u32, DIGEST::Register>; 8]),
+        /// The expected digest, stored in the top words of ROM
+        (0x0028 => pub(crate) exp_digest: [ReadWrite<u32, EXP_DIGEST::Register>; 8]),
+        (0x0048 => @END),
+    }
+}
+
+register_bitfields![u32,
+    pub(crate) ALERT_TEST [
+        FATAL OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) FATAL_ALERT_CAUSE [
+        CHECKER_ERROR OFFSET(0) NUMBITS(1) [],
+        INTEGRITY_ERROR OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) DIGEST [
+        DIGEST_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) EXP_DIGEST [
+        DIGEST_0 OFFSET(0) NUMBITS(32) [],
+    ],
+];
+
+// End generated register constants for rom_ctrl

--- a/chips/lowrisc/src/registers/rv_core_ibex_regs.rs
+++ b/chips/lowrisc/src/registers/rv_core_ibex_regs.rs
@@ -1,0 +1,137 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for rv_core_ibex.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Number of software triggerable alerts
+pub const RV_CORE_IBEX_PARAM_NUM_SW_ALERTS: u32 = 2;
+/// Number of translatable regions per ibex bus
+pub const RV_CORE_IBEX_PARAM_NUM_REGIONS: u32 = 2;
+/// Number of scratch words maintained.
+pub const RV_CORE_IBEX_PARAM_NUM_SCRATCH_WORDS: u32 = 8;
+/// Number of alerts
+pub const RV_CORE_IBEX_PARAM_NUM_ALERTS: u32 = 4;
+/// Register width
+pub const RV_CORE_IBEX_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub RvCoreIbexRegisters {
+        /// Alert Test Register
+        (0x0000 => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// Software recoverable error
+        (0x0004 => pub(crate) sw_recov_err: ReadWrite<u32, SW_RECOV_ERR::Register>),
+        /// Software fatal error
+        (0x0008 => pub(crate) sw_fatal_err: ReadWrite<u32, SW_FATAL_ERR::Register>),
+        /// Ibus address control regwen.
+        (0x000c => pub(crate) ibus_regwen: [ReadWrite<u32, IBUS_REGWEN::Register>; 2]),
+        ///   Enable Ibus address matching
+        (0x0014 => pub(crate) ibus_addr_en: [ReadWrite<u32, IBUS_ADDR_EN::Register>; 2]),
+        ///   Matching region programming for ibus.
+        (0x001c => pub(crate) ibus_addr_matching: [ReadWrite<u32, IBUS_ADDR_MATCHING::Register>; 2]),
+        ///   The remap address after a match has been made.
+        (0x0024 => pub(crate) ibus_remap_addr: [ReadWrite<u32, IBUS_REMAP_ADDR::Register>; 2]),
+        /// Dbus address control regwen.
+        (0x002c => pub(crate) dbus_regwen: [ReadWrite<u32, DBUS_REGWEN::Register>; 2]),
+        ///   Enable dbus address matching
+        (0x0034 => pub(crate) dbus_addr_en: [ReadWrite<u32, DBUS_ADDR_EN::Register>; 2]),
+        ///   See !!IBUS_ADDR_MATCHING_0 for detailed description.
+        (0x003c => pub(crate) dbus_addr_matching: [ReadWrite<u32, DBUS_ADDR_MATCHING::Register>; 2]),
+        ///   See !!IBUS_REMAP_ADDR_0 for a detailed description.
+        (0x0044 => pub(crate) dbus_remap_addr: [ReadWrite<u32, DBUS_REMAP_ADDR::Register>; 2]),
+        /// Enable mask for NMI.
+        (0x004c => pub(crate) nmi_enable: ReadWrite<u32, NMI_ENABLE::Register>),
+        /// Current NMI state
+        (0x0050 => pub(crate) nmi_state: ReadWrite<u32, NMI_STATE::Register>),
+        /// error status
+        (0x0054 => pub(crate) err_status: ReadWrite<u32, ERR_STATUS::Register>),
+        /// Random data from EDN
+        (0x0058 => pub(crate) rnd_data: ReadWrite<u32, RND_DATA::Register>),
+        /// Status of random data in !!RND_DATA
+        (0x005c => pub(crate) rnd_status: ReadWrite<u32, RND_STATUS::Register>),
+        /// FPGA build timestamp info.
+        (0x0060 => pub(crate) fpga_info: ReadWrite<u32, FPGA_INFO::Register>),
+        (0x0064 => _reserved1),
+        /// Memory area: Exposed tlul window for DV only purposes.
+        (0x0080 => pub(crate) dv_sim_window: [ReadWrite<u32>; 8]),
+        (0x00a0 => @END),
+    }
+}
+
+register_bitfields![u32,
+    pub(crate) ALERT_TEST [
+        FATAL_SW_ERR OFFSET(0) NUMBITS(1) [],
+        RECOV_SW_ERR OFFSET(1) NUMBITS(1) [],
+        FATAL_HW_ERR OFFSET(2) NUMBITS(1) [],
+        RECOV_HW_ERR OFFSET(3) NUMBITS(1) [],
+    ],
+    pub(crate) SW_RECOV_ERR [
+        VAL OFFSET(0) NUMBITS(4) [],
+    ],
+    pub(crate) SW_FATAL_ERR [
+        VAL OFFSET(0) NUMBITS(4) [],
+    ],
+    pub(crate) IBUS_REGWEN [
+        EN_0 OFFSET(0) NUMBITS(1) [
+            LOCKED = 0,
+            ENABLED = 1,
+        ],
+    ],
+    pub(crate) IBUS_ADDR_EN [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) IBUS_ADDR_MATCHING [
+        VAL_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) IBUS_REMAP_ADDR [
+        VAL_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) DBUS_REGWEN [
+        EN_0 OFFSET(0) NUMBITS(1) [
+            LOCKED = 0,
+            ENABLED = 1,
+        ],
+    ],
+    pub(crate) DBUS_ADDR_EN [
+        EN_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) DBUS_ADDR_MATCHING [
+        VAL_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) DBUS_REMAP_ADDR [
+        VAL_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) NMI_ENABLE [
+        ALERT_EN OFFSET(0) NUMBITS(1) [],
+        WDOG_EN OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) NMI_STATE [
+        ALERT OFFSET(0) NUMBITS(1) [],
+        WDOG OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) ERR_STATUS [
+        REG_INTG_ERR OFFSET(0) NUMBITS(1) [],
+        FATAL_INTG_ERR OFFSET(8) NUMBITS(1) [],
+        FATAL_CORE_ERR OFFSET(9) NUMBITS(1) [],
+        RECOV_CORE_ERR OFFSET(10) NUMBITS(1) [],
+    ],
+    pub(crate) RND_DATA [
+        DATA OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) RND_STATUS [
+        RND_DATA_VALID OFFSET(0) NUMBITS(1) [],
+        RND_DATA_FIPS OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) FPGA_INFO [
+        VAL OFFSET(0) NUMBITS(32) [],
+    ],
+];
+
+// End generated register constants for rv_core_ibex

--- a/chips/lowrisc/src/registers/rv_timer_regs.rs
+++ b/chips/lowrisc/src/registers/rv_timer_regs.rs
@@ -1,0 +1,84 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for rv_timer.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/ip/rv_timer/data/rv_timer.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Number of harts
+pub const RV_TIMER_PARAM_N_HARTS: u32 = 1;
+/// Number of timers per Hart
+pub const RV_TIMER_PARAM_N_TIMERS: u32 = 1;
+/// Number of alerts
+pub const RV_TIMER_PARAM_NUM_ALERTS: u32 = 1;
+/// Register width
+pub const RV_TIMER_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub RvTimerRegisters {
+        /// Alert Test Register
+        (0x0000 => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// Control register
+        (0x0004 => pub(crate) ctrl: [ReadWrite<u32, CTRL::Register>; 1]),
+        (0x0008 => _reserved1),
+        /// Interrupt Enable
+        (0x0100 => pub(crate) intr_enable0: [ReadWrite<u32, INTR_ENABLE0::Register>; 1]),
+        /// Interrupt Status
+        (0x0104 => pub(crate) intr_state0: [ReadWrite<u32, INTR_STATE0::Register>; 1]),
+        /// Interrupt test register
+        (0x0108 => pub(crate) intr_test0: [ReadWrite<u32, INTR_TEST0::Register>; 1]),
+        /// Configuration for Hart 0
+        (0x010c => pub(crate) cfg0: ReadWrite<u32, CFG0::Register>),
+        /// Timer value Lower
+        (0x0110 => pub(crate) timer_v_lower0: ReadWrite<u32, TIMER_V_LOWER0::Register>),
+        /// Timer value Upper
+        (0x0114 => pub(crate) timer_v_upper0: ReadWrite<u32, TIMER_V_UPPER0::Register>),
+        /// Timer value Lower
+        (0x0118 => pub(crate) compare_lower0_0: ReadWrite<u32, COMPARE_LOWER0_0::Register>),
+        /// Timer value Upper
+        (0x011c => pub(crate) compare_upper0_0: ReadWrite<u32, COMPARE_UPPER0_0::Register>),
+        (0x0120 => @END),
+    }
+}
+
+register_bitfields![u32,
+    pub(crate) ALERT_TEST [
+        FATAL_FAULT OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CTRL [
+        ACTIVE_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) INTR_ENABLE0 [
+        IE_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) INTR_STATE0 [
+        IS_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) INTR_TEST0 [
+        T_0 OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CFG0 [
+        PRESCALE OFFSET(0) NUMBITS(12) [],
+        STEP OFFSET(16) NUMBITS(8) [],
+    ],
+    pub(crate) TIMER_V_LOWER0 [
+        V OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) TIMER_V_UPPER0 [
+        V OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) COMPARE_LOWER0_0 [
+        V OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) COMPARE_UPPER0_0 [
+        V OFFSET(0) NUMBITS(32) [],
+    ],
+];
+
+// End generated register constants for rv_timer

--- a/chips/lowrisc/src/registers/spi_device_regs.rs
+++ b/chips/lowrisc/src/registers/spi_device_regs.rs
@@ -1,0 +1,381 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for spi_device.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/ip/spi_device/data/spi_device.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Number of alerts
+pub const SPI_DEVICE_PARAM_NUM_ALERTS: u32 = 1;
+/// Register width
+pub const SPI_DEVICE_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub SpiDeviceRegisters {
+        /// Interrupt State Register
+        (0x0000 => pub(crate) intr_state: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Enable Register
+        (0x0004 => pub(crate) intr_enable: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Test Register
+        (0x0008 => pub(crate) intr_test: ReadWrite<u32, INTR::Register>),
+        /// Alert Test Register
+        (0x000c => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// Control register
+        (0x0010 => pub(crate) control: ReadWrite<u32, CONTROL::Register>),
+        /// Configuration Register
+        (0x0014 => pub(crate) cfg: ReadWrite<u32, CFG::Register>),
+        /// RX/ TX FIFO levels.
+        (0x0018 => pub(crate) fifo_level: ReadWrite<u32, FIFO_LEVEL::Register>),
+        /// RX/ TX Async FIFO levels between main clk and spi clock
+        (0x001c => pub(crate) async_fifo_level: ReadWrite<u32, ASYNC_FIFO_LEVEL::Register>),
+        /// SPI Device status register
+        (0x0020 => pub(crate) status: ReadWrite<u32, STATUS::Register>),
+        /// Receiver FIFO (SRAM) pointers
+        (0x0024 => pub(crate) rxf_ptr: ReadWrite<u32, RXF_PTR::Register>),
+        /// Transmitter FIFO (SRAM) pointers
+        (0x0028 => pub(crate) txf_ptr: ReadWrite<u32, TXF_PTR::Register>),
+        /// Receiver FIFO (SRAM) Addresses
+        (0x002c => pub(crate) rxf_addr: ReadWrite<u32, RXF_ADDR::Register>),
+        /// Transmitter FIFO (SRAM) Addresses
+        (0x0030 => pub(crate) txf_addr: ReadWrite<u32, TXF_ADDR::Register>),
+        /// Intercept Passthrough datapath.
+        (0x0034 => pub(crate) intercept_en: ReadWrite<u32, INTERCEPT_EN::Register>),
+        /// Last Read Address
+        (0x0038 => pub(crate) last_read_addr: ReadWrite<u32, LAST_READ_ADDR::Register>),
+        /// SPI Flash Status register.
+        (0x003c => pub(crate) flash_status: ReadWrite<u32, FLASH_STATUS::Register>),
+        /// JEDEC Continuation Code configuration register.
+        (0x0040 => pub(crate) jedec_cc: ReadWrite<u32, JEDEC_CC::Register>),
+        /// JEDEC ID register.
+        (0x0044 => pub(crate) jedec_id: ReadWrite<u32, JEDEC_ID::Register>),
+        /// Read Buffer threshold register.
+        (0x0048 => pub(crate) read_threshold: ReadWrite<u32, READ_THRESHOLD::Register>),
+        /// Mailbox Base address register.
+        (0x004c => pub(crate) mailbox_addr: ReadWrite<u32, MAILBOX_ADDR::Register>),
+        /// Upload module status register.
+        (0x0050 => pub(crate) upload_status: ReadWrite<u32, UPLOAD_STATUS::Register>),
+        /// Upload module status 2 register.
+        (0x0054 => pub(crate) upload_status2: ReadWrite<u32, UPLOAD_STATUS2::Register>),
+        /// Command Fifo Read Port.
+        (0x0058 => pub(crate) upload_cmdfifo: ReadWrite<u32, UPLOAD_CMDFIFO::Register>),
+        /// Address Fifo Read Port.
+        (0x005c => pub(crate) upload_addrfifo: ReadWrite<u32, UPLOAD_ADDRFIFO::Register>),
+        /// Command Filter
+        (0x0060 => pub(crate) cmd_filter: [ReadWrite<u32, CMD_FILTER::Register>; 8]),
+        /// Address Swap Mask register.
+        (0x0080 => pub(crate) addr_swap_mask: ReadWrite<u32, ADDR_SWAP_MASK::Register>),
+        /// The address value for the address swap feature.
+        (0x0084 => pub(crate) addr_swap_data: ReadWrite<u32, ADDR_SWAP_DATA::Register>),
+        /// Write Data Swap in the passthrough mode.
+        (0x0088 => pub(crate) payload_swap_mask: ReadWrite<u32, PAYLOAD_SWAP_MASK::Register>),
+        /// Write Data Swap in the passthrough mode.
+        (0x008c => pub(crate) payload_swap_data: ReadWrite<u32, PAYLOAD_SWAP_DATA::Register>),
+        /// Command Info register.
+        (0x0090 => pub(crate) cmd_info: [ReadWrite<u32, CMD_INFO::Register>; 24]),
+        /// Opcode for EN4B.
+        (0x00f0 => pub(crate) cmd_info_en4b: ReadWrite<u32, CMD_INFO_EN4B::Register>),
+        /// Opcode for EX4B
+        (0x00f4 => pub(crate) cmd_info_ex4b: ReadWrite<u32, CMD_INFO_EX4B::Register>),
+        /// Opcode for Write Enable (WREN)
+        (0x00f8 => pub(crate) cmd_info_wren: ReadWrite<u32, CMD_INFO_WREN::Register>),
+        /// Opcode for Write Disable (WRDI)
+        (0x00fc => pub(crate) cmd_info_wrdi: ReadWrite<u32, CMD_INFO_WRDI::Register>),
+        (0x0100 => _reserved1),
+        /// TPM HWIP Capability register.
+        (0x0800 => pub(crate) tpm_cap: ReadWrite<u32, TPM_CAP::Register>),
+        /// TPM Configuration register.
+        (0x0804 => pub(crate) tpm_cfg: ReadWrite<u32, TPM_CFG::Register>),
+        /// TPM submodule state register.
+        (0x0808 => pub(crate) tpm_status: ReadWrite<u32, TPM_STATUS::Register>),
+        /// TPM_ACCESS_x register.
+        (0x080c => pub(crate) tpm_access: [ReadWrite<u32, TPM_ACCESS::Register>; 2]),
+        /// TPM_STS_x register.
+        (0x0814 => pub(crate) tpm_sts: ReadWrite<u32, TPM_STS::Register>),
+        /// TPM_INTF_CAPABILITY
+        (0x0818 => pub(crate) tpm_intf_capability: ReadWrite<u32, TPM_INTF_CAPABILITY::Register>),
+        /// TPM_INT_ENABLE
+        (0x081c => pub(crate) tpm_int_enable: ReadWrite<u32, TPM_INT_ENABLE::Register>),
+        /// TPM_INT_VECTOR
+        (0x0820 => pub(crate) tpm_int_vector: ReadWrite<u32, TPM_INT_VECTOR::Register>),
+        /// TPM_INT_STATUS
+        (0x0824 => pub(crate) tpm_int_status: ReadWrite<u32, TPM_INT_STATUS::Register>),
+        /// TPM_DID/ TPM_VID register
+        (0x0828 => pub(crate) tpm_did_vid: ReadWrite<u32, TPM_DID_VID::Register>),
+        /// TPM_RID
+        (0x082c => pub(crate) tpm_rid: ReadWrite<u32, TPM_RID::Register>),
+        /// TPM Command and Address buffer
+        (0x0830 => pub(crate) tpm_cmd_addr: ReadWrite<u32, TPM_CMD_ADDR::Register>),
+        /// TPM Read command return data FIFO.
+        (0x0834 => pub(crate) tpm_read_fifo: ReadWrite<u32, TPM_READ_FIFO::Register>),
+        /// TPM Write command received data FIFO.
+        (0x0838 => pub(crate) tpm_write_fifo: ReadWrite<u32, TPM_WRITE_FIFO::Register>),
+        (0x083c => _reserved2),
+        /// Memory area: SPI internal buffer.
+        (0x1000 => pub(crate) buffer: [ReadWrite<u32>; 1024]),
+        (0x2000 => @END),
+    }
+}
+
+register_bitfields![u32,
+    /// Common Interrupt Offsets
+    pub(crate) INTR [
+        GENERIC_RX_FULL OFFSET(0) NUMBITS(1) [],
+        GENERIC_RX_WATERMARK OFFSET(1) NUMBITS(1) [],
+        GENERIC_TX_WATERMARK OFFSET(2) NUMBITS(1) [],
+        GENERIC_RX_ERROR OFFSET(3) NUMBITS(1) [],
+        GENERIC_RX_OVERFLOW OFFSET(4) NUMBITS(1) [],
+        GENERIC_TX_UNDERFLOW OFFSET(5) NUMBITS(1) [],
+        UPLOAD_CMDFIFO_NOT_EMPTY OFFSET(6) NUMBITS(1) [],
+        UPLOAD_PAYLOAD_NOT_EMPTY OFFSET(7) NUMBITS(1) [],
+        UPLOAD_PAYLOAD_OVERFLOW OFFSET(8) NUMBITS(1) [],
+        READBUF_WATERMARK OFFSET(9) NUMBITS(1) [],
+        READBUF_FLIP OFFSET(10) NUMBITS(1) [],
+        TPM_HEADER_NOT_EMPTY OFFSET(11) NUMBITS(1) [],
+    ],
+    pub(crate) ALERT_TEST [
+        FATAL_FAULT OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CONTROL [
+        ABORT OFFSET(0) NUMBITS(1) [],
+        MODE OFFSET(4) NUMBITS(2) [
+            FWMODE = 0,
+            FLASHMODE = 1,
+            PASSTHROUGH = 2,
+        ],
+        RST_TXFIFO OFFSET(16) NUMBITS(1) [],
+        RST_RXFIFO OFFSET(17) NUMBITS(1) [],
+        SRAM_CLK_EN OFFSET(31) NUMBITS(1) [],
+    ],
+    pub(crate) CFG [
+        CPOL OFFSET(0) NUMBITS(1) [],
+        CPHA OFFSET(1) NUMBITS(1) [],
+        TX_ORDER OFFSET(2) NUMBITS(1) [],
+        RX_ORDER OFFSET(3) NUMBITS(1) [],
+        TIMER_V OFFSET(8) NUMBITS(8) [],
+        ADDR_4B_EN OFFSET(16) NUMBITS(1) [],
+        MAILBOX_EN OFFSET(24) NUMBITS(1) [],
+    ],
+    pub(crate) FIFO_LEVEL [
+        RXLVL OFFSET(0) NUMBITS(16) [],
+        TXLVL OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) ASYNC_FIFO_LEVEL [
+        RXLVL OFFSET(0) NUMBITS(8) [],
+        TXLVL OFFSET(16) NUMBITS(8) [],
+    ],
+    pub(crate) STATUS [
+        RXF_FULL OFFSET(0) NUMBITS(1) [],
+        RXF_EMPTY OFFSET(1) NUMBITS(1) [],
+        TXF_FULL OFFSET(2) NUMBITS(1) [],
+        TXF_EMPTY OFFSET(3) NUMBITS(1) [],
+        ABORT_DONE OFFSET(4) NUMBITS(1) [],
+        CSB OFFSET(5) NUMBITS(1) [],
+        TPM_CSB OFFSET(6) NUMBITS(1) [],
+    ],
+    pub(crate) RXF_PTR [
+        RPTR OFFSET(0) NUMBITS(16) [],
+        WPTR OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) TXF_PTR [
+        RPTR OFFSET(0) NUMBITS(16) [],
+        WPTR OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) RXF_ADDR [
+        BASE OFFSET(0) NUMBITS(16) [],
+        LIMIT OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) TXF_ADDR [
+        BASE OFFSET(0) NUMBITS(16) [],
+        LIMIT OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) INTERCEPT_EN [
+        STATUS OFFSET(0) NUMBITS(1) [],
+        JEDEC OFFSET(1) NUMBITS(1) [],
+        SFDP OFFSET(2) NUMBITS(1) [],
+        MBX OFFSET(3) NUMBITS(1) [],
+    ],
+    pub(crate) LAST_READ_ADDR [
+        ADDR OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) FLASH_STATUS [
+        BUSY OFFSET(0) NUMBITS(1) [],
+        STATUS OFFSET(1) NUMBITS(23) [],
+    ],
+    pub(crate) JEDEC_CC [
+        CC OFFSET(0) NUMBITS(8) [],
+        NUM_CC OFFSET(8) NUMBITS(8) [],
+    ],
+    pub(crate) JEDEC_ID [
+        ID OFFSET(0) NUMBITS(16) [],
+        MF OFFSET(16) NUMBITS(8) [],
+    ],
+    pub(crate) READ_THRESHOLD [
+        THRESHOLD OFFSET(0) NUMBITS(10) [],
+    ],
+    pub(crate) MAILBOX_ADDR [
+        ADDR OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) UPLOAD_STATUS [
+        CMDFIFO_DEPTH OFFSET(0) NUMBITS(5) [],
+        CMDFIFO_NOTEMPTY OFFSET(7) NUMBITS(1) [],
+        ADDRFIFO_DEPTH OFFSET(8) NUMBITS(5) [],
+        ADDRFIFO_NOTEMPTY OFFSET(15) NUMBITS(1) [],
+    ],
+    pub(crate) UPLOAD_STATUS2 [
+        PAYLOAD_DEPTH OFFSET(0) NUMBITS(9) [],
+        PAYLOAD_START_IDX OFFSET(16) NUMBITS(8) [],
+    ],
+    pub(crate) UPLOAD_CMDFIFO [
+        DATA OFFSET(0) NUMBITS(8) [],
+    ],
+    pub(crate) UPLOAD_ADDRFIFO [
+        DATA OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) CMD_FILTER [
+        FILTER_0 OFFSET(0) NUMBITS(1) [],
+        FILTER_1 OFFSET(1) NUMBITS(1) [],
+        FILTER_2 OFFSET(2) NUMBITS(1) [],
+        FILTER_3 OFFSET(3) NUMBITS(1) [],
+        FILTER_4 OFFSET(4) NUMBITS(1) [],
+        FILTER_5 OFFSET(5) NUMBITS(1) [],
+        FILTER_6 OFFSET(6) NUMBITS(1) [],
+        FILTER_7 OFFSET(7) NUMBITS(1) [],
+        FILTER_8 OFFSET(8) NUMBITS(1) [],
+        FILTER_9 OFFSET(9) NUMBITS(1) [],
+        FILTER_10 OFFSET(10) NUMBITS(1) [],
+        FILTER_11 OFFSET(11) NUMBITS(1) [],
+        FILTER_12 OFFSET(12) NUMBITS(1) [],
+        FILTER_13 OFFSET(13) NUMBITS(1) [],
+        FILTER_14 OFFSET(14) NUMBITS(1) [],
+        FILTER_15 OFFSET(15) NUMBITS(1) [],
+        FILTER_16 OFFSET(16) NUMBITS(1) [],
+        FILTER_17 OFFSET(17) NUMBITS(1) [],
+        FILTER_18 OFFSET(18) NUMBITS(1) [],
+        FILTER_19 OFFSET(19) NUMBITS(1) [],
+        FILTER_20 OFFSET(20) NUMBITS(1) [],
+        FILTER_21 OFFSET(21) NUMBITS(1) [],
+        FILTER_22 OFFSET(22) NUMBITS(1) [],
+        FILTER_23 OFFSET(23) NUMBITS(1) [],
+        FILTER_24 OFFSET(24) NUMBITS(1) [],
+        FILTER_25 OFFSET(25) NUMBITS(1) [],
+        FILTER_26 OFFSET(26) NUMBITS(1) [],
+        FILTER_27 OFFSET(27) NUMBITS(1) [],
+        FILTER_28 OFFSET(28) NUMBITS(1) [],
+        FILTER_29 OFFSET(29) NUMBITS(1) [],
+        FILTER_30 OFFSET(30) NUMBITS(1) [],
+        FILTER_31 OFFSET(31) NUMBITS(1) [],
+    ],
+    pub(crate) ADDR_SWAP_MASK [
+        MASK OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) ADDR_SWAP_DATA [
+        DATA OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) PAYLOAD_SWAP_MASK [
+        MASK OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) PAYLOAD_SWAP_DATA [
+        DATA OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) CMD_INFO [
+        OPCODE_0 OFFSET(0) NUMBITS(8) [],
+        ADDR_MODE_0 OFFSET(8) NUMBITS(2) [
+            ADDRDISABLED = 0,
+            ADDRCFG = 1,
+            ADDR3B = 2,
+            ADDR4B = 3,
+        ],
+        ADDR_SWAP_EN_0 OFFSET(10) NUMBITS(1) [],
+        MBYTE_EN_0 OFFSET(11) NUMBITS(1) [],
+        DUMMY_SIZE_0 OFFSET(12) NUMBITS(3) [],
+        DUMMY_EN_0 OFFSET(15) NUMBITS(1) [],
+        PAYLOAD_EN_0 OFFSET(16) NUMBITS(4) [],
+        PAYLOAD_DIR_0 OFFSET(20) NUMBITS(1) [
+            PAYLOADIN = 0,
+            PAYLOADOUT = 1,
+        ],
+        PAYLOAD_SWAP_EN_0 OFFSET(21) NUMBITS(1) [],
+        UPLOAD_0 OFFSET(24) NUMBITS(1) [],
+        BUSY_0 OFFSET(25) NUMBITS(1) [],
+        VALID_0 OFFSET(31) NUMBITS(1) [],
+    ],
+    pub(crate) CMD_INFO_EN4B [
+        OPCODE OFFSET(0) NUMBITS(8) [],
+        VALID OFFSET(31) NUMBITS(1) [],
+    ],
+    pub(crate) CMD_INFO_EX4B [
+        OPCODE OFFSET(0) NUMBITS(8) [],
+        VALID OFFSET(31) NUMBITS(1) [],
+    ],
+    pub(crate) CMD_INFO_WREN [
+        OPCODE OFFSET(0) NUMBITS(8) [],
+        VALID OFFSET(31) NUMBITS(1) [],
+    ],
+    pub(crate) CMD_INFO_WRDI [
+        OPCODE OFFSET(0) NUMBITS(8) [],
+        VALID OFFSET(31) NUMBITS(1) [],
+    ],
+    pub(crate) TPM_CAP [
+        REV OFFSET(0) NUMBITS(8) [],
+        LOCALITY OFFSET(8) NUMBITS(1) [],
+        MAX_WR_SIZE OFFSET(16) NUMBITS(3) [],
+        MAX_RD_SIZE OFFSET(20) NUMBITS(3) [],
+    ],
+    pub(crate) TPM_CFG [
+        EN OFFSET(0) NUMBITS(1) [],
+        TPM_MODE OFFSET(1) NUMBITS(1) [],
+        HW_REG_DIS OFFSET(2) NUMBITS(1) [],
+        TPM_REG_CHK_DIS OFFSET(3) NUMBITS(1) [],
+        INVALID_LOCALITY OFFSET(4) NUMBITS(1) [],
+    ],
+    pub(crate) TPM_STATUS [
+        CMDADDR_NOTEMPTY OFFSET(0) NUMBITS(1) [],
+        WRFIFO_DEPTH OFFSET(16) NUMBITS(7) [],
+    ],
+    pub(crate) TPM_ACCESS [
+        ACCESS_0 OFFSET(0) NUMBITS(8) [],
+        ACCESS_1 OFFSET(8) NUMBITS(8) [],
+        ACCESS_2 OFFSET(16) NUMBITS(8) [],
+        ACCESS_3 OFFSET(24) NUMBITS(8) [],
+    ],
+    pub(crate) TPM_STS [
+        STS OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) TPM_INTF_CAPABILITY [
+        INTF_CAPABILITY OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) TPM_INT_ENABLE [
+        INT_ENABLE OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) TPM_INT_VECTOR [
+        INT_VECTOR OFFSET(0) NUMBITS(8) [],
+    ],
+    pub(crate) TPM_INT_STATUS [
+        INT_STATUS OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) TPM_DID_VID [
+        VID OFFSET(0) NUMBITS(16) [],
+        DID OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) TPM_RID [
+        RID OFFSET(0) NUMBITS(8) [],
+    ],
+    pub(crate) TPM_CMD_ADDR [
+        ADDR OFFSET(0) NUMBITS(24) [],
+        CMD OFFSET(24) NUMBITS(8) [],
+    ],
+    pub(crate) TPM_READ_FIFO [
+        VALUE OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) TPM_WRITE_FIFO [
+        VALUE OFFSET(0) NUMBITS(8) [],
+    ],
+];
+
+// End generated register constants for spi_device

--- a/chips/lowrisc/src/registers/spi_host_regs.rs
+++ b/chips/lowrisc/src/registers/spi_host_regs.rs
@@ -1,0 +1,138 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for spi_host.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/ip/spi_host/data/spi_host.hjson
+use kernel::utilities::registers::ReadOnly;
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::WriteOnly;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// The number of active-low chip select (cs_n) lines to create.
+pub const SPI_HOST_PARAM_NUM_C_S: u32 = 1;
+/// The size of the Tx FIFO (in words)
+pub const SPI_HOST_PARAM_TX_DEPTH: u32 = 72;
+/// The size of the Rx FIFO (in words)
+pub const SPI_HOST_PARAM_RX_DEPTH: u32 = 64;
+/// The size of the Cmd FIFO (one segment descriptor per entry)
+pub const SPI_HOST_PARAM_CMD_DEPTH: u32 = 4;
+/// Number of alerts
+pub const SPI_HOST_PARAM_NUM_ALERTS: u32 = 1;
+/// Register width
+pub const SPI_HOST_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub SpiHostRegisters {
+        /// Interrupt State Register
+        (0x0000 => pub(crate) intr_state: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Enable Register
+        (0x0004 => pub(crate) intr_enable: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Test Register
+        (0x0008 => pub(crate) intr_test: ReadWrite<u32, INTR::Register>),
+        /// Alert Test Register
+        (0x000c => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// Control register
+        (0x0010 => pub(crate) control: ReadWrite<u32, CONTROL::Register>),
+        /// Status register
+        (0x0014 => pub(crate) status: ReadWrite<u32, STATUS::Register>),
+        /// Configuration options register.
+        (0x0018 => pub(crate) configopts: [ReadWrite<u32, CONFIGOPTS::Register>; 1]),
+        /// Chip-Select ID
+        (0x001c => pub(crate) csid: ReadWrite<u32, CSID::Register>),
+        /// Command Register
+        (0x0020 => pub(crate) command: ReadWrite<u32, COMMAND::Register>),
+        /// Memory area: SPI Receive Data.
+        (0x0024 => pub(crate) rxdata: [ReadOnly<u32>; 1]),
+        /// Memory area: SPI Transmit Data.
+        (0x0028 => pub(crate) txdata: [WriteOnly<u32>; 1]),
+        /// Controls which classes of errors raise an interrupt.
+        (0x002c => pub(crate) error_enable: ReadWrite<u32, ERROR_ENABLE::Register>),
+        /// Indicates that any errors that have occurred.
+        (0x0030 => pub(crate) error_status: ReadWrite<u32, ERROR_STATUS::Register>),
+        /// Controls which classes of SPI events raise an interrupt.
+        (0x0034 => pub(crate) event_enable: ReadWrite<u32, EVENT_ENABLE::Register>),
+        (0x0038 => @END),
+    }
+}
+
+register_bitfields![u32,
+    /// Common Interrupt Offsets
+    pub(crate) INTR [
+        ERROR OFFSET(0) NUMBITS(1) [],
+        SPI_EVENT OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) ALERT_TEST [
+        FATAL_FAULT OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CONTROL [
+        RX_WATERMARK OFFSET(0) NUMBITS(8) [],
+        TX_WATERMARK OFFSET(8) NUMBITS(8) [],
+        OUTPUT_EN OFFSET(29) NUMBITS(1) [],
+        SW_RST OFFSET(30) NUMBITS(1) [],
+        SPIEN OFFSET(31) NUMBITS(1) [],
+    ],
+    pub(crate) STATUS [
+        TXQD OFFSET(0) NUMBITS(8) [],
+        RXQD OFFSET(8) NUMBITS(8) [],
+        CMDQD OFFSET(16) NUMBITS(4) [],
+        RXWM OFFSET(20) NUMBITS(1) [],
+        BYTEORDER OFFSET(22) NUMBITS(1) [],
+        RXSTALL OFFSET(23) NUMBITS(1) [],
+        RXEMPTY OFFSET(24) NUMBITS(1) [],
+        RXFULL OFFSET(25) NUMBITS(1) [],
+        TXWM OFFSET(26) NUMBITS(1) [],
+        TXSTALL OFFSET(27) NUMBITS(1) [],
+        TXEMPTY OFFSET(28) NUMBITS(1) [],
+        TXFULL OFFSET(29) NUMBITS(1) [],
+        ACTIVE OFFSET(30) NUMBITS(1) [],
+        READY OFFSET(31) NUMBITS(1) [],
+    ],
+    pub(crate) CONFIGOPTS [
+        CLKDIV_0 OFFSET(0) NUMBITS(16) [],
+        CSNIDLE_0 OFFSET(16) NUMBITS(4) [],
+        CSNTRAIL_0 OFFSET(20) NUMBITS(4) [],
+        CSNLEAD_0 OFFSET(24) NUMBITS(4) [],
+        FULLCYC_0 OFFSET(29) NUMBITS(1) [],
+        CPHA_0 OFFSET(30) NUMBITS(1) [],
+        CPOL_0 OFFSET(31) NUMBITS(1) [],
+    ],
+    pub(crate) CSID [
+        CSID OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) COMMAND [
+        LEN OFFSET(0) NUMBITS(9) [],
+        CSAAT OFFSET(9) NUMBITS(1) [],
+        SPEED OFFSET(10) NUMBITS(2) [],
+        DIRECTION OFFSET(12) NUMBITS(2) [],
+    ],
+    pub(crate) ERROR_ENABLE [
+        CMDBUSY OFFSET(0) NUMBITS(1) [],
+        OVERFLOW OFFSET(1) NUMBITS(1) [],
+        UNDERFLOW OFFSET(2) NUMBITS(1) [],
+        CMDINVAL OFFSET(3) NUMBITS(1) [],
+        CSIDINVAL OFFSET(4) NUMBITS(1) [],
+    ],
+    pub(crate) ERROR_STATUS [
+        CMDBUSY OFFSET(0) NUMBITS(1) [],
+        OVERFLOW OFFSET(1) NUMBITS(1) [],
+        UNDERFLOW OFFSET(2) NUMBITS(1) [],
+        CMDINVAL OFFSET(3) NUMBITS(1) [],
+        CSIDINVAL OFFSET(4) NUMBITS(1) [],
+        ACCESSINVAL OFFSET(5) NUMBITS(1) [],
+    ],
+    pub(crate) EVENT_ENABLE [
+        RXFULL OFFSET(0) NUMBITS(1) [],
+        TXEMPTY OFFSET(1) NUMBITS(1) [],
+        RXWM OFFSET(2) NUMBITS(1) [],
+        TXWM OFFSET(3) NUMBITS(1) [],
+        READY OFFSET(4) NUMBITS(1) [],
+        IDLE OFFSET(5) NUMBITS(1) [],
+    ],
+];
+
+// End generated register constants for spi_host

--- a/chips/lowrisc/src/registers/sram_ctrl_regs.rs
+++ b/chips/lowrisc/src/registers/sram_ctrl_regs.rs
@@ -1,0 +1,64 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for sram_ctrl.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/ip/sram_ctrl/data/sram_ctrl.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Number of alerts
+pub const SRAM_CTRL_PARAM_NUM_ALERTS: u32 = 1;
+/// Register width
+pub const SRAM_CTRL_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub SramCtrlRegisters {
+        /// Alert Test Register
+        (0x0000 => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// SRAM status register.
+        (0x0004 => pub(crate) status: ReadWrite<u32, STATUS::Register>),
+        /// Lock register for execution enable register.
+        (0x0008 => pub(crate) exec_regwen: ReadWrite<u32, EXEC_REGWEN::Register>),
+        /// Sram execution enable.
+        (0x000c => pub(crate) exec: ReadWrite<u32, EXEC::Register>),
+        /// Lock register for control register.
+        (0x0010 => pub(crate) ctrl_regwen: ReadWrite<u32, CTRL_REGWEN::Register>),
+        /// SRAM ctrl register.
+        (0x0014 => pub(crate) ctrl: ReadWrite<u32, CTRL::Register>),
+        (0x0018 => @END),
+    }
+}
+
+register_bitfields![u32,
+    pub(crate) ALERT_TEST [
+        FATAL_ERROR OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) STATUS [
+        BUS_INTEG_ERROR OFFSET(0) NUMBITS(1) [],
+        INIT_ERROR OFFSET(1) NUMBITS(1) [],
+        ESCALATED OFFSET(2) NUMBITS(1) [],
+        SCR_KEY_VALID OFFSET(3) NUMBITS(1) [],
+        SCR_KEY_SEED_VALID OFFSET(4) NUMBITS(1) [],
+        INIT_DONE OFFSET(5) NUMBITS(1) [],
+    ],
+    pub(crate) EXEC_REGWEN [
+        EXEC_REGWEN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) EXEC [
+        EN OFFSET(0) NUMBITS(4) [],
+    ],
+    pub(crate) CTRL_REGWEN [
+        CTRL_REGWEN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CTRL [
+        RENEW_SCR_KEY OFFSET(0) NUMBITS(1) [],
+        INIT OFFSET(1) NUMBITS(1) [],
+    ],
+];
+
+// End generated register constants for sram_ctrl

--- a/chips/lowrisc/src/registers/sysrst_ctrl_regs.rs
+++ b/chips/lowrisc/src/registers/sysrst_ctrl_regs.rs
@@ -1,0 +1,262 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for sysrst_ctrl.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/ip/sysrst_ctrl/data/sysrst_ctrl.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Number of keyboard combos
+pub const SYSRST_CTRL_PARAM_NUM_COMBO: u32 = 4;
+/// Number of timer bits
+pub const SYSRST_CTRL_PARAM_TIMER_WIDTH: u32 = 16;
+/// Number of detection timer bits
+pub const SYSRST_CTRL_PARAM_DET_TIMER_WIDTH: u32 = 32;
+/// Number of alerts
+pub const SYSRST_CTRL_PARAM_NUM_ALERTS: u32 = 1;
+/// Register width
+pub const SYSRST_CTRL_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub SysrstCtrlRegisters {
+        /// Interrupt State Register
+        (0x0000 => pub(crate) intr_state: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Enable Register
+        (0x0004 => pub(crate) intr_enable: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Test Register
+        (0x0008 => pub(crate) intr_test: ReadWrite<u32, INTR::Register>),
+        /// Alert Test Register
+        (0x000c => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// Configuration write enable control register
+        (0x0010 => pub(crate) regwen: ReadWrite<u32, REGWEN::Register>),
+        /// EC reset control register
+        (0x0014 => pub(crate) ec_rst_ctl: ReadWrite<u32, EC_RST_CTL::Register>),
+        /// Ultra low power AC debounce control register
+        (0x0018 => pub(crate) ulp_ac_debounce_ctl: ReadWrite<u32, ULP_AC_DEBOUNCE_CTL::Register>),
+        /// Ultra low power lid debounce control register
+        (0x001c => pub(crate) ulp_lid_debounce_ctl: ReadWrite<u32, ULP_LID_DEBOUNCE_CTL::Register>),
+        /// Ultra low power pwrb debounce control register
+        (0x0020 => pub(crate) ulp_pwrb_debounce_ctl: ReadWrite<u32, ULP_PWRB_DEBOUNCE_CTL::Register>),
+        /// Ultra low power control register
+        (0x0024 => pub(crate) ulp_ctl: ReadWrite<u32, ULP_CTL::Register>),
+        /// Ultra low power status
+        (0x0028 => pub(crate) ulp_status: ReadWrite<u32, ULP_STATUS::Register>),
+        /// wakeup status
+        (0x002c => pub(crate) wkup_status: ReadWrite<u32, WKUP_STATUS::Register>),
+        /// configure key input output invert property
+        (0x0030 => pub(crate) key_invert_ctl: ReadWrite<u32, KEY_INVERT_CTL::Register>),
+        /// This register determines which override values are allowed for a given output.
+        (0x0034 => pub(crate) pin_allowed_ctl: ReadWrite<u32, PIN_ALLOWED_CTL::Register>),
+        /// Enables the override function for a specific pin.
+        (0x0038 => pub(crate) pin_out_ctl: ReadWrite<u32, PIN_OUT_CTL::Register>),
+        /// Sets the pin override value. Note that only the values
+        (0x003c => pub(crate) pin_out_value: ReadWrite<u32, PIN_OUT_VALUE::Register>),
+        /// For SW to read the sysrst_ctrl inputs like GPIO
+        (0x0040 => pub(crate) pin_in_value: ReadWrite<u32, PIN_IN_VALUE::Register>),
+        /// Define the keys or inputs that can trigger the interrupt
+        (0x0044 => pub(crate) key_intr_ctl: ReadWrite<u32, KEY_INTR_CTL::Register>),
+        /// Debounce timer control register for key-triggered interrupt
+        (0x0048 => pub(crate) key_intr_debounce_ctl: ReadWrite<u32, KEY_INTR_DEBOUNCE_CTL::Register>),
+        /// Debounce timer control register for pwrb_in H2L transition
+        (0x004c => pub(crate) auto_block_debounce_ctl: ReadWrite<u32, AUTO_BLOCK_DEBOUNCE_CTL::Register>),
+        /// configure the key outputs to auto-override and their value
+        (0x0050 => pub(crate) auto_block_out_ctl: ReadWrite<u32, AUTO_BLOCK_OUT_CTL::Register>),
+        /// To define the keys that define the pre-condition of the combo
+        (0x0054 => pub(crate) com_pre_sel_ctl: [ReadWrite<u32, COM_PRE_SEL_CTL::Register>; 4]),
+        /// To define the duration that the combo pre-condition should be pressed
+        (0x0064 => pub(crate) com_pre_det_ctl: [ReadWrite<u32, COM_PRE_DET_CTL::Register>; 4]),
+        /// To define the keys that trigger the combo
+        (0x0074 => pub(crate) com_sel_ctl: [ReadWrite<u32, COM_SEL_CTL::Register>; 4]),
+        /// To define the duration that the combo should be pressed
+        (0x0084 => pub(crate) com_det_ctl: [ReadWrite<u32, COM_DET_CTL::Register>; 4]),
+        /// To define the actions once the combo is detected
+        (0x0094 => pub(crate) com_out_ctl: [ReadWrite<u32, COM_OUT_CTL::Register>; 4]),
+        /// Combo interrupt source. These registers will only be set if the
+        (0x00a4 => pub(crate) combo_intr_status: ReadWrite<u32, COMBO_INTR_STATUS::Register>),
+        /// key interrupt source
+        (0x00a8 => pub(crate) key_intr_status: ReadWrite<u32, KEY_INTR_STATUS::Register>),
+        (0x00ac => @END),
+    }
+}
+
+register_bitfields![u32,
+    /// Common Interrupt Offsets
+    pub(crate) INTR [
+        EVENT_DETECTED OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) ALERT_TEST [
+        FATAL_FAULT OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) REGWEN [
+        WRITE_EN OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) EC_RST_CTL [
+        EC_RST_PULSE OFFSET(0) NUMBITS(16) [],
+    ],
+    pub(crate) ULP_AC_DEBOUNCE_CTL [
+        ULP_AC_DEBOUNCE_TIMER OFFSET(0) NUMBITS(16) [],
+    ],
+    pub(crate) ULP_LID_DEBOUNCE_CTL [
+        ULP_LID_DEBOUNCE_TIMER OFFSET(0) NUMBITS(16) [],
+    ],
+    pub(crate) ULP_PWRB_DEBOUNCE_CTL [
+        ULP_PWRB_DEBOUNCE_TIMER OFFSET(0) NUMBITS(16) [],
+    ],
+    pub(crate) ULP_CTL [
+        ULP_ENABLE OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) ULP_STATUS [
+        ULP_WAKEUP OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) WKUP_STATUS [
+        WAKEUP_STS OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) KEY_INVERT_CTL [
+        KEY0_IN OFFSET(0) NUMBITS(1) [],
+        KEY0_OUT OFFSET(1) NUMBITS(1) [],
+        KEY1_IN OFFSET(2) NUMBITS(1) [],
+        KEY1_OUT OFFSET(3) NUMBITS(1) [],
+        KEY2_IN OFFSET(4) NUMBITS(1) [],
+        KEY2_OUT OFFSET(5) NUMBITS(1) [],
+        PWRB_IN OFFSET(6) NUMBITS(1) [],
+        PWRB_OUT OFFSET(7) NUMBITS(1) [],
+        AC_PRESENT OFFSET(8) NUMBITS(1) [],
+        BAT_DISABLE OFFSET(9) NUMBITS(1) [],
+        LID_OPEN OFFSET(10) NUMBITS(1) [],
+        Z3_WAKEUP OFFSET(11) NUMBITS(1) [],
+    ],
+    pub(crate) PIN_ALLOWED_CTL [
+        BAT_DISABLE_0 OFFSET(0) NUMBITS(1) [],
+        EC_RST_L_0 OFFSET(1) NUMBITS(1) [],
+        PWRB_OUT_0 OFFSET(2) NUMBITS(1) [],
+        KEY0_OUT_0 OFFSET(3) NUMBITS(1) [],
+        KEY1_OUT_0 OFFSET(4) NUMBITS(1) [],
+        KEY2_OUT_0 OFFSET(5) NUMBITS(1) [],
+        Z3_WAKEUP_0 OFFSET(6) NUMBITS(1) [],
+        FLASH_WP_L_0 OFFSET(7) NUMBITS(1) [],
+        BAT_DISABLE_1 OFFSET(8) NUMBITS(1) [],
+        EC_RST_L_1 OFFSET(9) NUMBITS(1) [],
+        PWRB_OUT_1 OFFSET(10) NUMBITS(1) [],
+        KEY0_OUT_1 OFFSET(11) NUMBITS(1) [],
+        KEY1_OUT_1 OFFSET(12) NUMBITS(1) [],
+        KEY2_OUT_1 OFFSET(13) NUMBITS(1) [],
+        Z3_WAKEUP_1 OFFSET(14) NUMBITS(1) [],
+        FLASH_WP_L_1 OFFSET(15) NUMBITS(1) [],
+    ],
+    pub(crate) PIN_OUT_CTL [
+        BAT_DISABLE OFFSET(0) NUMBITS(1) [],
+        EC_RST_L OFFSET(1) NUMBITS(1) [],
+        PWRB_OUT OFFSET(2) NUMBITS(1) [],
+        KEY0_OUT OFFSET(3) NUMBITS(1) [],
+        KEY1_OUT OFFSET(4) NUMBITS(1) [],
+        KEY2_OUT OFFSET(5) NUMBITS(1) [],
+        Z3_WAKEUP OFFSET(6) NUMBITS(1) [],
+        FLASH_WP_L OFFSET(7) NUMBITS(1) [],
+    ],
+    pub(crate) PIN_OUT_VALUE [
+        BAT_DISABLE OFFSET(0) NUMBITS(1) [],
+        EC_RST_L OFFSET(1) NUMBITS(1) [],
+        PWRB_OUT OFFSET(2) NUMBITS(1) [],
+        KEY0_OUT OFFSET(3) NUMBITS(1) [],
+        KEY1_OUT OFFSET(4) NUMBITS(1) [],
+        KEY2_OUT OFFSET(5) NUMBITS(1) [],
+        Z3_WAKEUP OFFSET(6) NUMBITS(1) [],
+        FLASH_WP_L OFFSET(7) NUMBITS(1) [],
+    ],
+    pub(crate) PIN_IN_VALUE [
+        PWRB_IN OFFSET(0) NUMBITS(1) [],
+        KEY0_IN OFFSET(1) NUMBITS(1) [],
+        KEY1_IN OFFSET(2) NUMBITS(1) [],
+        KEY2_IN OFFSET(3) NUMBITS(1) [],
+        LID_OPEN OFFSET(4) NUMBITS(1) [],
+        AC_PRESENT OFFSET(5) NUMBITS(1) [],
+        EC_RST_L OFFSET(6) NUMBITS(1) [],
+        FLASH_WP_L OFFSET(7) NUMBITS(1) [],
+    ],
+    pub(crate) KEY_INTR_CTL [
+        PWRB_IN_H2L OFFSET(0) NUMBITS(1) [],
+        KEY0_IN_H2L OFFSET(1) NUMBITS(1) [],
+        KEY1_IN_H2L OFFSET(2) NUMBITS(1) [],
+        KEY2_IN_H2L OFFSET(3) NUMBITS(1) [],
+        AC_PRESENT_H2L OFFSET(4) NUMBITS(1) [],
+        EC_RST_L_H2L OFFSET(5) NUMBITS(1) [],
+        FLASH_WP_L_H2L OFFSET(6) NUMBITS(1) [],
+        PWRB_IN_L2H OFFSET(7) NUMBITS(1) [],
+        KEY0_IN_L2H OFFSET(8) NUMBITS(1) [],
+        KEY1_IN_L2H OFFSET(9) NUMBITS(1) [],
+        KEY2_IN_L2H OFFSET(10) NUMBITS(1) [],
+        AC_PRESENT_L2H OFFSET(11) NUMBITS(1) [],
+        EC_RST_L_L2H OFFSET(12) NUMBITS(1) [],
+        FLASH_WP_L_L2H OFFSET(13) NUMBITS(1) [],
+    ],
+    pub(crate) KEY_INTR_DEBOUNCE_CTL [
+        DEBOUNCE_TIMER OFFSET(0) NUMBITS(16) [],
+    ],
+    pub(crate) AUTO_BLOCK_DEBOUNCE_CTL [
+        DEBOUNCE_TIMER OFFSET(0) NUMBITS(16) [],
+        AUTO_BLOCK_ENABLE OFFSET(16) NUMBITS(1) [],
+    ],
+    pub(crate) AUTO_BLOCK_OUT_CTL [
+        KEY0_OUT_SEL OFFSET(0) NUMBITS(1) [],
+        KEY1_OUT_SEL OFFSET(1) NUMBITS(1) [],
+        KEY2_OUT_SEL OFFSET(2) NUMBITS(1) [],
+        KEY0_OUT_VALUE OFFSET(4) NUMBITS(1) [],
+        KEY1_OUT_VALUE OFFSET(5) NUMBITS(1) [],
+        KEY2_OUT_VALUE OFFSET(6) NUMBITS(1) [],
+    ],
+    pub(crate) COM_PRE_SEL_CTL [
+        KEY0_IN_SEL_0 OFFSET(0) NUMBITS(1) [],
+        KEY1_IN_SEL_0 OFFSET(1) NUMBITS(1) [],
+        KEY2_IN_SEL_0 OFFSET(2) NUMBITS(1) [],
+        PWRB_IN_SEL_0 OFFSET(3) NUMBITS(1) [],
+        AC_PRESENT_SEL_0 OFFSET(4) NUMBITS(1) [],
+    ],
+    pub(crate) COM_PRE_DET_CTL [
+        PRECONDITION_TIMER_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) COM_SEL_CTL [
+        KEY0_IN_SEL_0 OFFSET(0) NUMBITS(1) [],
+        KEY1_IN_SEL_0 OFFSET(1) NUMBITS(1) [],
+        KEY2_IN_SEL_0 OFFSET(2) NUMBITS(1) [],
+        PWRB_IN_SEL_0 OFFSET(3) NUMBITS(1) [],
+        AC_PRESENT_SEL_0 OFFSET(4) NUMBITS(1) [],
+    ],
+    pub(crate) COM_DET_CTL [
+        DETECTION_TIMER_0 OFFSET(0) NUMBITS(32) [],
+    ],
+    pub(crate) COM_OUT_CTL [
+        BAT_DISABLE_0 OFFSET(0) NUMBITS(1) [],
+        INTERRUPT_0 OFFSET(1) NUMBITS(1) [],
+        EC_RST_0 OFFSET(2) NUMBITS(1) [],
+        RST_REQ_0 OFFSET(3) NUMBITS(1) [],
+    ],
+    pub(crate) COMBO_INTR_STATUS [
+        COMBO0_H2L OFFSET(0) NUMBITS(1) [],
+        COMBO1_H2L OFFSET(1) NUMBITS(1) [],
+        COMBO2_H2L OFFSET(2) NUMBITS(1) [],
+        COMBO3_H2L OFFSET(3) NUMBITS(1) [],
+    ],
+    pub(crate) KEY_INTR_STATUS [
+        PWRB_H2L OFFSET(0) NUMBITS(1) [],
+        KEY0_IN_H2L OFFSET(1) NUMBITS(1) [],
+        KEY1_IN_H2L OFFSET(2) NUMBITS(1) [],
+        KEY2_IN_H2L OFFSET(3) NUMBITS(1) [],
+        AC_PRESENT_H2L OFFSET(4) NUMBITS(1) [],
+        EC_RST_L_H2L OFFSET(5) NUMBITS(1) [],
+        FLASH_WP_L_H2L OFFSET(6) NUMBITS(1) [],
+        PWRB_L2H OFFSET(7) NUMBITS(1) [],
+        KEY0_IN_L2H OFFSET(8) NUMBITS(1) [],
+        KEY1_IN_L2H OFFSET(9) NUMBITS(1) [],
+        KEY2_IN_L2H OFFSET(10) NUMBITS(1) [],
+        AC_PRESENT_L2H OFFSET(11) NUMBITS(1) [],
+        EC_RST_L_L2H OFFSET(12) NUMBITS(1) [],
+        FLASH_WP_L_L2H OFFSET(13) NUMBITS(1) [],
+    ],
+];
+
+// End generated register constants for sysrst_ctrl

--- a/chips/lowrisc/src/registers/uart_regs.rs
+++ b/chips/lowrisc/src/registers/uart_regs.rs
@@ -1,0 +1,136 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for uart.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/ip/uart/data/uart.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Number of alerts
+pub const UART_PARAM_NUM_ALERTS: u32 = 1;
+/// Register width
+pub const UART_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub UartRegisters {
+        /// Interrupt State Register
+        (0x0000 => pub(crate) intr_state: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Enable Register
+        (0x0004 => pub(crate) intr_enable: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Test Register
+        (0x0008 => pub(crate) intr_test: ReadWrite<u32, INTR::Register>),
+        /// Alert Test Register
+        (0x000c => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// UART control register
+        (0x0010 => pub(crate) ctrl: ReadWrite<u32, CTRL::Register>),
+        /// UART live status register
+        (0x0014 => pub(crate) status: ReadWrite<u32, STATUS::Register>),
+        /// UART read data
+        (0x0018 => pub(crate) rdata: ReadWrite<u32, RDATA::Register>),
+        /// UART write data
+        (0x001c => pub(crate) wdata: ReadWrite<u32, WDATA::Register>),
+        /// UART FIFO control register
+        (0x0020 => pub(crate) fifo_ctrl: ReadWrite<u32, FIFO_CTRL::Register>),
+        /// UART FIFO status register
+        (0x0024 => pub(crate) fifo_status: ReadWrite<u32, FIFO_STATUS::Register>),
+        /// TX pin override control. Gives direct SW control over TX pin state
+        (0x0028 => pub(crate) ovrd: ReadWrite<u32, OVRD::Register>),
+        /// UART oversampled values
+        (0x002c => pub(crate) val: ReadWrite<u32, VAL::Register>),
+        /// UART RX timeout control
+        (0x0030 => pub(crate) timeout_ctrl: ReadWrite<u32, TIMEOUT_CTRL::Register>),
+        (0x0034 => @END),
+    }
+}
+
+register_bitfields![u32,
+    /// Common Interrupt Offsets
+    pub(crate) INTR [
+        TX_WATERMARK OFFSET(0) NUMBITS(1) [],
+        RX_WATERMARK OFFSET(1) NUMBITS(1) [],
+        TX_EMPTY OFFSET(2) NUMBITS(1) [],
+        RX_OVERFLOW OFFSET(3) NUMBITS(1) [],
+        RX_FRAME_ERR OFFSET(4) NUMBITS(1) [],
+        RX_BREAK_ERR OFFSET(5) NUMBITS(1) [],
+        RX_TIMEOUT OFFSET(6) NUMBITS(1) [],
+        RX_PARITY_ERR OFFSET(7) NUMBITS(1) [],
+    ],
+    pub(crate) ALERT_TEST [
+        FATAL_FAULT OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) CTRL [
+        TX OFFSET(0) NUMBITS(1) [],
+        RX OFFSET(1) NUMBITS(1) [],
+        NF OFFSET(2) NUMBITS(1) [],
+        SLPBK OFFSET(4) NUMBITS(1) [],
+        LLPBK OFFSET(5) NUMBITS(1) [],
+        PARITY_EN OFFSET(6) NUMBITS(1) [],
+        PARITY_ODD OFFSET(7) NUMBITS(1) [],
+        RXBLVL OFFSET(8) NUMBITS(2) [
+            BREAK2 = 0,
+            BREAK4 = 1,
+            BREAK8 = 2,
+            BREAK16 = 3,
+        ],
+        NCO OFFSET(16) NUMBITS(16) [],
+    ],
+    pub(crate) STATUS [
+        TXFULL OFFSET(0) NUMBITS(1) [],
+        RXFULL OFFSET(1) NUMBITS(1) [],
+        TXEMPTY OFFSET(2) NUMBITS(1) [],
+        TXIDLE OFFSET(3) NUMBITS(1) [],
+        RXIDLE OFFSET(4) NUMBITS(1) [],
+        RXEMPTY OFFSET(5) NUMBITS(1) [],
+    ],
+    pub(crate) RDATA [
+        RDATA OFFSET(0) NUMBITS(8) [],
+    ],
+    pub(crate) WDATA [
+        WDATA OFFSET(0) NUMBITS(8) [],
+    ],
+    pub(crate) FIFO_CTRL [
+        RXRST OFFSET(0) NUMBITS(1) [],
+        TXRST OFFSET(1) NUMBITS(1) [],
+        RXILVL OFFSET(2) NUMBITS(3) [
+            RXLVL1 = 0,
+            RXLVL2 = 1,
+            RXLVL4 = 2,
+            RXLVL8 = 3,
+            RXLVL16 = 4,
+            RXLVL32 = 5,
+            RXLVL64 = 6,
+            RXLVL126 = 7,
+        ],
+        TXILVL OFFSET(5) NUMBITS(3) [
+            TXLVL1 = 0,
+            TXLVL2 = 1,
+            TXLVL4 = 2,
+            TXLVL8 = 3,
+            TXLVL16 = 4,
+            TXLVL32 = 5,
+            TXLVL64 = 6,
+        ],
+    ],
+    pub(crate) FIFO_STATUS [
+        TXLVL OFFSET(0) NUMBITS(8) [],
+        RXLVL OFFSET(16) NUMBITS(8) [],
+    ],
+    pub(crate) OVRD [
+        TXEN OFFSET(0) NUMBITS(1) [],
+        TXVAL OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) VAL [
+        RX OFFSET(0) NUMBITS(16) [],
+    ],
+    pub(crate) TIMEOUT_CTRL [
+        VAL OFFSET(0) NUMBITS(24) [],
+        EN OFFSET(31) NUMBITS(1) [],
+    ],
+];
+
+// End generated register constants for uart

--- a/chips/lowrisc/src/registers/usbdev_regs.rs
+++ b/chips/lowrisc/src/registers/usbdev_regs.rs
@@ -1,0 +1,337 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright lowRISC contributors 2023.
+
+// Generated register constants for usbdev.
+// Built for Earlgrey-M2.5.1-RC1-438-gacc67de99
+// https://github.com/lowRISC/opentitan/tree/acc67de992ee8de5f2481b1b9580679850d8b5f5
+// Tree status: clean
+// Build date: 2023-08-08T00:15:38
+
+// Original reference file: hw/ip/usbdev/data/usbdev.hjson
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::{register_bitfields, register_structs};
+/// Number of endpoints
+pub const USBDEV_PARAM_N_ENDPOINTS: u32 = 12;
+/// Number of alerts
+pub const USBDEV_PARAM_NUM_ALERTS: u32 = 1;
+/// Register width
+pub const USBDEV_PARAM_REG_WIDTH: u32 = 32;
+
+register_structs! {
+    pub UsbdevRegisters {
+        /// Interrupt State Register
+        (0x0000 => pub(crate) intr_state: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Enable Register
+        (0x0004 => pub(crate) intr_enable: ReadWrite<u32, INTR::Register>),
+        /// Interrupt Test Register
+        (0x0008 => pub(crate) intr_test: ReadWrite<u32, INTR::Register>),
+        /// Alert Test Register
+        (0x000c => pub(crate) alert_test: ReadWrite<u32, ALERT_TEST::Register>),
+        /// USB Control
+        (0x0010 => pub(crate) usbctrl: ReadWrite<u32, USBCTRL::Register>),
+        /// Enable an endpoint to respond to transactions in the downstream direction.
+        (0x0014 => pub(crate) ep_out_enable: [ReadWrite<u32, EP_OUT_ENABLE::Register>; 1]),
+        /// Enable an endpoint to respond to transactions in the upstream direction.
+        (0x0018 => pub(crate) ep_in_enable: [ReadWrite<u32, EP_IN_ENABLE::Register>; 1]),
+        /// USB Status
+        (0x001c => pub(crate) usbstat: ReadWrite<u32, USBSTAT::Register>),
+        /// Available Buffer FIFO
+        (0x0020 => pub(crate) avbuffer: ReadWrite<u32, AVBUFFER::Register>),
+        /// Received Buffer FIFO
+        (0x0024 => pub(crate) rxfifo: ReadWrite<u32, RXFIFO::Register>),
+        /// Receive SETUP transaction enable
+        (0x0028 => pub(crate) rxenable_setup: [ReadWrite<u32, RXENABLE_SETUP::Register>; 1]),
+        /// Receive OUT transaction enable
+        (0x002c => pub(crate) rxenable_out: [ReadWrite<u32, RXENABLE_OUT::Register>; 1]),
+        /// Set NAK after OUT transactions
+        (0x0030 => pub(crate) set_nak_out: [ReadWrite<u32, SET_NAK_OUT::Register>; 1]),
+        /// IN Transaction Sent
+        (0x0034 => pub(crate) in_sent: [ReadWrite<u32, IN_SENT::Register>; 1]),
+        /// OUT Endpoint STALL control
+        (0x0038 => pub(crate) out_stall: [ReadWrite<u32, OUT_STALL::Register>; 1]),
+        /// IN Endpoint STALL control
+        (0x003c => pub(crate) in_stall: [ReadWrite<u32, IN_STALL::Register>; 1]),
+        /// Configure IN Transaction
+        (0x0040 => pub(crate) configin: [ReadWrite<u32, CONFIGIN::Register>; 12]),
+        /// OUT Endpoint isochronous setting
+        (0x0070 => pub(crate) out_iso: [ReadWrite<u32, OUT_ISO::Register>; 1]),
+        /// IN Endpoint isochronous setting
+        (0x0074 => pub(crate) in_iso: [ReadWrite<u32, IN_ISO::Register>; 1]),
+        /// Clear the data toggle flag
+        (0x0078 => pub(crate) data_toggle_clear: [ReadWrite<u32, DATA_TOGGLE_CLEAR::Register>; 1]),
+        /// USB PHY pins sense.
+        (0x007c => pub(crate) phy_pins_sense: ReadWrite<u32, PHY_PINS_SENSE::Register>),
+        /// USB PHY pins drive.
+        (0x0080 => pub(crate) phy_pins_drive: ReadWrite<u32, PHY_PINS_DRIVE::Register>),
+        /// USB PHY Configuration
+        (0x0084 => pub(crate) phy_config: ReadWrite<u32, PHY_CONFIG::Register>),
+        /// USB wake module control for suspend / resume
+        (0x0088 => pub(crate) wake_control: ReadWrite<u32, WAKE_CONTROL::Register>),
+        /// USB wake module events and debug
+        (0x008c => pub(crate) wake_events: ReadWrite<u32, WAKE_EVENTS::Register>),
+        (0x0090 => _reserved1),
+        /// Memory area: 2 kB packet buffer. Divided into 32 64-byte buffers.
+        (0x0800 => pub(crate) buffer: [ReadWrite<u32>; 512]),
+        (0x1000 => @END),
+    }
+}
+
+register_bitfields![u32,
+    /// Common Interrupt Offsets
+    pub(crate) INTR [
+        PKT_RECEIVED OFFSET(0) NUMBITS(1) [],
+        PKT_SENT OFFSET(1) NUMBITS(1) [],
+        DISCONNECTED OFFSET(2) NUMBITS(1) [],
+        HOST_LOST OFFSET(3) NUMBITS(1) [],
+        LINK_RESET OFFSET(4) NUMBITS(1) [],
+        LINK_SUSPEND OFFSET(5) NUMBITS(1) [],
+        LINK_RESUME OFFSET(6) NUMBITS(1) [],
+        AV_EMPTY OFFSET(7) NUMBITS(1) [],
+        RX_FULL OFFSET(8) NUMBITS(1) [],
+        AV_OVERFLOW OFFSET(9) NUMBITS(1) [],
+        LINK_IN_ERR OFFSET(10) NUMBITS(1) [],
+        RX_CRC_ERR OFFSET(11) NUMBITS(1) [],
+        RX_PID_ERR OFFSET(12) NUMBITS(1) [],
+        RX_BITSTUFF_ERR OFFSET(13) NUMBITS(1) [],
+        FRAME OFFSET(14) NUMBITS(1) [],
+        POWERED OFFSET(15) NUMBITS(1) [],
+        LINK_OUT_ERR OFFSET(16) NUMBITS(1) [],
+    ],
+    pub(crate) ALERT_TEST [
+        FATAL_FAULT OFFSET(0) NUMBITS(1) [],
+    ],
+    pub(crate) USBCTRL [
+        ENABLE OFFSET(0) NUMBITS(1) [],
+        RESUME_LINK_ACTIVE OFFSET(1) NUMBITS(1) [],
+        DEVICE_ADDRESS OFFSET(16) NUMBITS(7) [],
+    ],
+    pub(crate) EP_OUT_ENABLE [
+        ENABLE_0 OFFSET(0) NUMBITS(1) [],
+        ENABLE_1 OFFSET(1) NUMBITS(1) [],
+        ENABLE_2 OFFSET(2) NUMBITS(1) [],
+        ENABLE_3 OFFSET(3) NUMBITS(1) [],
+        ENABLE_4 OFFSET(4) NUMBITS(1) [],
+        ENABLE_5 OFFSET(5) NUMBITS(1) [],
+        ENABLE_6 OFFSET(6) NUMBITS(1) [],
+        ENABLE_7 OFFSET(7) NUMBITS(1) [],
+        ENABLE_8 OFFSET(8) NUMBITS(1) [],
+        ENABLE_9 OFFSET(9) NUMBITS(1) [],
+        ENABLE_10 OFFSET(10) NUMBITS(1) [],
+        ENABLE_11 OFFSET(11) NUMBITS(1) [],
+    ],
+    pub(crate) EP_IN_ENABLE [
+        ENABLE_0 OFFSET(0) NUMBITS(1) [],
+        ENABLE_1 OFFSET(1) NUMBITS(1) [],
+        ENABLE_2 OFFSET(2) NUMBITS(1) [],
+        ENABLE_3 OFFSET(3) NUMBITS(1) [],
+        ENABLE_4 OFFSET(4) NUMBITS(1) [],
+        ENABLE_5 OFFSET(5) NUMBITS(1) [],
+        ENABLE_6 OFFSET(6) NUMBITS(1) [],
+        ENABLE_7 OFFSET(7) NUMBITS(1) [],
+        ENABLE_8 OFFSET(8) NUMBITS(1) [],
+        ENABLE_9 OFFSET(9) NUMBITS(1) [],
+        ENABLE_10 OFFSET(10) NUMBITS(1) [],
+        ENABLE_11 OFFSET(11) NUMBITS(1) [],
+    ],
+    pub(crate) USBSTAT [
+        FRAME OFFSET(0) NUMBITS(11) [],
+        HOST_LOST OFFSET(11) NUMBITS(1) [],
+        LINK_STATE OFFSET(12) NUMBITS(3) [
+            DISCONNECTED = 0,
+            POWERED = 1,
+            POWERED_SUSPENDED = 2,
+            ACTIVE = 3,
+            SUSPENDED = 4,
+            ACTIVE_NOSOF = 5,
+            RESUMING = 6,
+        ],
+        SENSE OFFSET(15) NUMBITS(1) [],
+        AV_DEPTH OFFSET(16) NUMBITS(4) [],
+        AV_FULL OFFSET(23) NUMBITS(1) [],
+        RX_DEPTH OFFSET(24) NUMBITS(4) [],
+        RX_EMPTY OFFSET(31) NUMBITS(1) [],
+    ],
+    pub(crate) AVBUFFER [
+        BUFFER OFFSET(0) NUMBITS(5) [],
+    ],
+    pub(crate) RXFIFO [
+        BUFFER OFFSET(0) NUMBITS(5) [],
+        SIZE OFFSET(8) NUMBITS(7) [],
+        SETUP OFFSET(19) NUMBITS(1) [],
+        EP OFFSET(20) NUMBITS(4) [],
+    ],
+    pub(crate) RXENABLE_SETUP [
+        SETUP_0 OFFSET(0) NUMBITS(1) [],
+        SETUP_1 OFFSET(1) NUMBITS(1) [],
+        SETUP_2 OFFSET(2) NUMBITS(1) [],
+        SETUP_3 OFFSET(3) NUMBITS(1) [],
+        SETUP_4 OFFSET(4) NUMBITS(1) [],
+        SETUP_5 OFFSET(5) NUMBITS(1) [],
+        SETUP_6 OFFSET(6) NUMBITS(1) [],
+        SETUP_7 OFFSET(7) NUMBITS(1) [],
+        SETUP_8 OFFSET(8) NUMBITS(1) [],
+        SETUP_9 OFFSET(9) NUMBITS(1) [],
+        SETUP_10 OFFSET(10) NUMBITS(1) [],
+        SETUP_11 OFFSET(11) NUMBITS(1) [],
+    ],
+    pub(crate) RXENABLE_OUT [
+        OUT_0 OFFSET(0) NUMBITS(1) [],
+        OUT_1 OFFSET(1) NUMBITS(1) [],
+        OUT_2 OFFSET(2) NUMBITS(1) [],
+        OUT_3 OFFSET(3) NUMBITS(1) [],
+        OUT_4 OFFSET(4) NUMBITS(1) [],
+        OUT_5 OFFSET(5) NUMBITS(1) [],
+        OUT_6 OFFSET(6) NUMBITS(1) [],
+        OUT_7 OFFSET(7) NUMBITS(1) [],
+        OUT_8 OFFSET(8) NUMBITS(1) [],
+        OUT_9 OFFSET(9) NUMBITS(1) [],
+        OUT_10 OFFSET(10) NUMBITS(1) [],
+        OUT_11 OFFSET(11) NUMBITS(1) [],
+    ],
+    pub(crate) SET_NAK_OUT [
+        ENABLE_0 OFFSET(0) NUMBITS(1) [],
+        ENABLE_1 OFFSET(1) NUMBITS(1) [],
+        ENABLE_2 OFFSET(2) NUMBITS(1) [],
+        ENABLE_3 OFFSET(3) NUMBITS(1) [],
+        ENABLE_4 OFFSET(4) NUMBITS(1) [],
+        ENABLE_5 OFFSET(5) NUMBITS(1) [],
+        ENABLE_6 OFFSET(6) NUMBITS(1) [],
+        ENABLE_7 OFFSET(7) NUMBITS(1) [],
+        ENABLE_8 OFFSET(8) NUMBITS(1) [],
+        ENABLE_9 OFFSET(9) NUMBITS(1) [],
+        ENABLE_10 OFFSET(10) NUMBITS(1) [],
+        ENABLE_11 OFFSET(11) NUMBITS(1) [],
+    ],
+    pub(crate) IN_SENT [
+        SENT_0 OFFSET(0) NUMBITS(1) [],
+        SENT_1 OFFSET(1) NUMBITS(1) [],
+        SENT_2 OFFSET(2) NUMBITS(1) [],
+        SENT_3 OFFSET(3) NUMBITS(1) [],
+        SENT_4 OFFSET(4) NUMBITS(1) [],
+        SENT_5 OFFSET(5) NUMBITS(1) [],
+        SENT_6 OFFSET(6) NUMBITS(1) [],
+        SENT_7 OFFSET(7) NUMBITS(1) [],
+        SENT_8 OFFSET(8) NUMBITS(1) [],
+        SENT_9 OFFSET(9) NUMBITS(1) [],
+        SENT_10 OFFSET(10) NUMBITS(1) [],
+        SENT_11 OFFSET(11) NUMBITS(1) [],
+    ],
+    pub(crate) OUT_STALL [
+        ENDPOINT_0 OFFSET(0) NUMBITS(1) [],
+        ENDPOINT_1 OFFSET(1) NUMBITS(1) [],
+        ENDPOINT_2 OFFSET(2) NUMBITS(1) [],
+        ENDPOINT_3 OFFSET(3) NUMBITS(1) [],
+        ENDPOINT_4 OFFSET(4) NUMBITS(1) [],
+        ENDPOINT_5 OFFSET(5) NUMBITS(1) [],
+        ENDPOINT_6 OFFSET(6) NUMBITS(1) [],
+        ENDPOINT_7 OFFSET(7) NUMBITS(1) [],
+        ENDPOINT_8 OFFSET(8) NUMBITS(1) [],
+        ENDPOINT_9 OFFSET(9) NUMBITS(1) [],
+        ENDPOINT_10 OFFSET(10) NUMBITS(1) [],
+        ENDPOINT_11 OFFSET(11) NUMBITS(1) [],
+    ],
+    pub(crate) IN_STALL [
+        ENDPOINT_0 OFFSET(0) NUMBITS(1) [],
+        ENDPOINT_1 OFFSET(1) NUMBITS(1) [],
+        ENDPOINT_2 OFFSET(2) NUMBITS(1) [],
+        ENDPOINT_3 OFFSET(3) NUMBITS(1) [],
+        ENDPOINT_4 OFFSET(4) NUMBITS(1) [],
+        ENDPOINT_5 OFFSET(5) NUMBITS(1) [],
+        ENDPOINT_6 OFFSET(6) NUMBITS(1) [],
+        ENDPOINT_7 OFFSET(7) NUMBITS(1) [],
+        ENDPOINT_8 OFFSET(8) NUMBITS(1) [],
+        ENDPOINT_9 OFFSET(9) NUMBITS(1) [],
+        ENDPOINT_10 OFFSET(10) NUMBITS(1) [],
+        ENDPOINT_11 OFFSET(11) NUMBITS(1) [],
+    ],
+    pub(crate) CONFIGIN [
+        BUFFER_0 OFFSET(0) NUMBITS(5) [],
+        SIZE_0 OFFSET(8) NUMBITS(7) [],
+        PEND_0 OFFSET(30) NUMBITS(1) [],
+        RDY_0 OFFSET(31) NUMBITS(1) [],
+    ],
+    pub(crate) OUT_ISO [
+        ISO_0 OFFSET(0) NUMBITS(1) [],
+        ISO_1 OFFSET(1) NUMBITS(1) [],
+        ISO_2 OFFSET(2) NUMBITS(1) [],
+        ISO_3 OFFSET(3) NUMBITS(1) [],
+        ISO_4 OFFSET(4) NUMBITS(1) [],
+        ISO_5 OFFSET(5) NUMBITS(1) [],
+        ISO_6 OFFSET(6) NUMBITS(1) [],
+        ISO_7 OFFSET(7) NUMBITS(1) [],
+        ISO_8 OFFSET(8) NUMBITS(1) [],
+        ISO_9 OFFSET(9) NUMBITS(1) [],
+        ISO_10 OFFSET(10) NUMBITS(1) [],
+        ISO_11 OFFSET(11) NUMBITS(1) [],
+    ],
+    pub(crate) IN_ISO [
+        ISO_0 OFFSET(0) NUMBITS(1) [],
+        ISO_1 OFFSET(1) NUMBITS(1) [],
+        ISO_2 OFFSET(2) NUMBITS(1) [],
+        ISO_3 OFFSET(3) NUMBITS(1) [],
+        ISO_4 OFFSET(4) NUMBITS(1) [],
+        ISO_5 OFFSET(5) NUMBITS(1) [],
+        ISO_6 OFFSET(6) NUMBITS(1) [],
+        ISO_7 OFFSET(7) NUMBITS(1) [],
+        ISO_8 OFFSET(8) NUMBITS(1) [],
+        ISO_9 OFFSET(9) NUMBITS(1) [],
+        ISO_10 OFFSET(10) NUMBITS(1) [],
+        ISO_11 OFFSET(11) NUMBITS(1) [],
+    ],
+    pub(crate) DATA_TOGGLE_CLEAR [
+        CLEAR_0 OFFSET(0) NUMBITS(1) [],
+        CLEAR_1 OFFSET(1) NUMBITS(1) [],
+        CLEAR_2 OFFSET(2) NUMBITS(1) [],
+        CLEAR_3 OFFSET(3) NUMBITS(1) [],
+        CLEAR_4 OFFSET(4) NUMBITS(1) [],
+        CLEAR_5 OFFSET(5) NUMBITS(1) [],
+        CLEAR_6 OFFSET(6) NUMBITS(1) [],
+        CLEAR_7 OFFSET(7) NUMBITS(1) [],
+        CLEAR_8 OFFSET(8) NUMBITS(1) [],
+        CLEAR_9 OFFSET(9) NUMBITS(1) [],
+        CLEAR_10 OFFSET(10) NUMBITS(1) [],
+        CLEAR_11 OFFSET(11) NUMBITS(1) [],
+    ],
+    pub(crate) PHY_PINS_SENSE [
+        RX_DP_I OFFSET(0) NUMBITS(1) [],
+        RX_DN_I OFFSET(1) NUMBITS(1) [],
+        RX_D_I OFFSET(2) NUMBITS(1) [],
+        TX_DP_O OFFSET(8) NUMBITS(1) [],
+        TX_DN_O OFFSET(9) NUMBITS(1) [],
+        TX_D_O OFFSET(10) NUMBITS(1) [],
+        TX_SE0_O OFFSET(11) NUMBITS(1) [],
+        TX_OE_O OFFSET(12) NUMBITS(1) [],
+        PWR_SENSE OFFSET(16) NUMBITS(1) [],
+    ],
+    pub(crate) PHY_PINS_DRIVE [
+        DP_O OFFSET(0) NUMBITS(1) [],
+        DN_O OFFSET(1) NUMBITS(1) [],
+        D_O OFFSET(2) NUMBITS(1) [],
+        SE0_O OFFSET(3) NUMBITS(1) [],
+        OE_O OFFSET(4) NUMBITS(1) [],
+        RX_ENABLE_O OFFSET(5) NUMBITS(1) [],
+        DP_PULLUP_EN_O OFFSET(6) NUMBITS(1) [],
+        DN_PULLUP_EN_O OFFSET(7) NUMBITS(1) [],
+        EN OFFSET(16) NUMBITS(1) [],
+    ],
+    pub(crate) PHY_CONFIG [
+        USE_DIFF_RCVR OFFSET(0) NUMBITS(1) [],
+        TX_USE_D_SE0 OFFSET(1) NUMBITS(1) [],
+        EOP_SINGLE_BIT OFFSET(2) NUMBITS(1) [],
+        PINFLIP OFFSET(5) NUMBITS(1) [],
+        USB_REF_DISABLE OFFSET(6) NUMBITS(1) [],
+        TX_OSC_TEST_MODE OFFSET(7) NUMBITS(1) [],
+    ],
+    pub(crate) WAKE_CONTROL [
+        SUSPEND_REQ OFFSET(0) NUMBITS(1) [],
+        WAKE_ACK OFFSET(1) NUMBITS(1) [],
+    ],
+    pub(crate) WAKE_EVENTS [
+        MODULE_ACTIVE OFFSET(0) NUMBITS(1) [],
+        DISCONNECTED OFFSET(8) NUMBITS(1) [],
+        BUS_RESET OFFSET(9) NUMBITS(1) [],
+    ],
+];
+
+// End generated register constants for usbdev

--- a/chips/lowrisc/src/uart.rs
+++ b/chips/lowrisc/src/uart.rs
@@ -12,97 +12,10 @@ use kernel::hil::uart;
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::cells::TakeCell;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
-use kernel::utilities::registers::{
-    register_bitfields, register_structs, ReadOnly, ReadWrite, WriteOnly,
-};
 use kernel::utilities::StaticRef;
 
-register_structs! {
-    pub UartRegisters {
-        (0x00 => intr_state: ReadWrite<u32, intr::Register>),
-        (0x04 => intr_enable: ReadWrite<u32, intr::Register>),
-        (0x08 => intr_test: ReadWrite<u32, intr::Register>),
-        (0x0C => alert_test: ReadWrite<u32, intr::Register>),
-        /// UART control register
-        (0x10 => ctrl: ReadWrite<u32, ctrl::Register>),
-        /// UART live status register
-        (0x14 => status: ReadOnly<u32, status::Register>),
-        /// UART read data)
-        (0x18 => rdata: ReadOnly<u32, rdata::Register>),
-        /// UART write data
-        (0x1C => wdata: WriteOnly<u32, wdata::Register>),
-        /// UART FIFO control register")
-        (0x20 => fifo_ctrl: ReadWrite<u32, fifo_ctrl::Register>),
-        /// UART FIFO status register
-        (0x24 => fifo_status: ReadWrite<u32, fifo_status::Register>),
-        /// TX pin override control. Gives direct SW control over TX pin state
-        (0x28 => ovrd: ReadWrite<u32, ovrd::Register>),
-        /// UART oversampled values
-        (0x2C => val: ReadWrite<u32, val::Register>),
-        /// UART RX timeout control
-        (0x30 => timeout_ctrl: ReadWrite<u32, timeout_ctrl::Register>),
-        (0x34 => @END),
-    }
-}
-
-register_bitfields![u32,
-    intr [
-        tx_watermark OFFSET(0) NUMBITS(1) [],
-        rx_watermark OFFSET(1) NUMBITS(1) [],
-        tx_empty OFFSET(2) NUMBITS(1) [],
-        rx_overflow OFFSET(3) NUMBITS(1) [],
-        rx_frame_err OFFSET(4) NUMBITS(1) [],
-        rx_break_err OFFSET(5) NUMBITS(1) [],
-        rx_timeout OFFSET(6) NUMBITS(1) [],
-        rx_parity_err OFFSET(7) NUMBITS(1) []
-    ],
-    ctrl [
-        tx OFFSET(0) NUMBITS(1) [],
-        rx OFFSET(1) NUMBITS(1) [],
-        nf OFFSET(2) NUMBITS(1) [],
-        slpbk OFFSET(4) NUMBITS(1) [],
-        llpbk OFFSET(5) NUMBITS(1) [],
-        parity_en OFFSET(6) NUMBITS(1) [],
-        parity_odd OFFSET(7) NUMBITS(1) [],
-        rxblvl OFFSET(8) NUMBITS(2) [],
-        nco OFFSET(16) NUMBITS(16) []
-    ],
-    status [
-        txfull OFFSET(0) NUMBITS(1) [],
-        rxfull OFFSET(1) NUMBITS(1) [],
-        txempty OFFSET(2) NUMBITS(1) [],
-        txidle OFFSET(3) NUMBITS(1) [],
-        rxidle OFFSET(4) NUMBITS(1) [],
-        rxempty OFFSET(5) NUMBITS(1) []
-    ],
-    rdata [
-        data OFFSET(0) NUMBITS(8) []
-    ],
-    wdata [
-        data OFFSET(0) NUMBITS(8) []
-    ],
-    fifo_ctrl [
-        rxrst OFFSET(0) NUMBITS(1) [],
-        txrst OFFSET(1) NUMBITS(1) [],
-        rxilvl OFFSET(2) NUMBITS(2) [],
-        txilvl OFFSET(5) NUMBITS(2) []
-    ],
-    fifo_status [
-        txlvl OFFSET(0) NUMBITS(5) [],
-        rxlvl OFFSET(16) NUMBITS(5) []
-    ],
-    ovrd [
-        txen OFFSET(0) NUMBITS(1) [],
-        txval OFFSET(1) NUMBITS(1) []
-    ],
-    val [
-        rx OFFSET(0) NUMBITS(16) []
-    ],
-    timeout_ctrl [
-        val OFFSET(0) NUMBITS(23) [],
-        en OFFSET(31) NUMBITS(1) []
-    ]
-];
+use crate::registers::uart_regs::UartRegisters;
+use crate::registers::uart_regs::{CTRL, FIFO_CTRL, INTR, STATUS, WDATA};
 
 pub struct Uart<'a> {
     registers: StaticRef<UartRegisters>,
@@ -143,43 +56,43 @@ impl<'a> Uart<'a> {
         let uart_ctrl_nco = ((baud_rate as u64) << 20) / self.clock_frequency as u64;
 
         regs.ctrl
-            .write(ctrl::nco.val((uart_ctrl_nco & 0xffff) as u32));
-        regs.ctrl.modify(ctrl::tx::SET + ctrl::rx::SET);
+            .write(CTRL::NCO.val((uart_ctrl_nco & 0xffff) as u32));
+        regs.ctrl.modify(CTRL::TX::SET + CTRL::RX::SET);
 
         regs.fifo_ctrl
-            .write(fifo_ctrl::rxrst::SET + fifo_ctrl::txrst::SET);
+            .write(FIFO_CTRL::RXRST::SET + FIFO_CTRL::TXRST::SET);
     }
 
     fn enable_tx_interrupt(&self) {
         let regs = self.registers;
 
-        regs.intr_enable.modify(intr::tx_empty::SET);
+        regs.intr_enable.modify(INTR::TX_EMPTY::SET);
     }
 
     fn disable_tx_interrupt(&self) {
         let regs = self.registers;
 
-        regs.intr_enable.modify(intr::tx_empty::CLEAR);
+        regs.intr_enable.modify(INTR::TX_EMPTY::CLEAR);
         // Clear the interrupt bit (by writing 1), if it happens to be set
-        regs.intr_state.write(intr::tx_empty::SET);
+        regs.intr_state.write(INTR::TX_EMPTY::SET);
     }
 
     fn enable_rx_interrupt(&self) {
         let regs = self.registers;
 
         // Generate an interrupt if we get any value in the RX buffer
-        regs.intr_enable.modify(intr::rx_watermark::SET);
-        regs.fifo_ctrl.write(fifo_ctrl::rxilvl.val(0 as u32));
+        regs.intr_enable.modify(INTR::RX_WATERMARK::SET);
+        regs.fifo_ctrl.write(FIFO_CTRL::RXILVL.val(0 as u32));
     }
 
     fn disable_rx_interrupt(&self) {
         let regs = self.registers;
 
         // Generate an interrupt if we get any value in the RX buffer
-        regs.intr_enable.modify(intr::rx_watermark::CLEAR);
+        regs.intr_enable.modify(INTR::RX_WATERMARK::CLEAR);
 
         // Clear the interrupt bit (by writing 1), if it happens to be set
-        regs.intr_state.write(intr::rx_watermark::SET);
+        regs.intr_state.write(INTR::RX_WATERMARK::SET);
     }
 
     fn tx_progress(&self) {
@@ -200,12 +113,11 @@ impl<'a> Uart<'a> {
                 let tx_len = len - idx;
 
                 for i in 0..tx_len {
-                    if regs.status.is_set(status::txfull) {
+                    if regs.status.is_set(STATUS::TXFULL) {
                         break;
                     }
                     let tx_idx = idx + i;
-                    let data: u32 = *tx_buf.get(tx_idx).unwrap_or(&0) as u32;
-                    regs.wdata.write(wdata::data.val(data));
+                    regs.wdata.write(WDATA::WDATA.val(tx_buf[tx_idx] as u32));
                     self.tx_index.set(tx_idx + 1)
                 }
             });
@@ -216,7 +128,7 @@ impl<'a> Uart<'a> {
         let regs = self.registers;
         let intrs = regs.intr_state.extract();
 
-        if intrs.is_set(intr::tx_empty) {
+        if intrs.is_set(INTR::TX_EMPTY) {
             self.disable_tx_interrupt();
 
             if self.tx_index.get() == self.tx_len.get() {
@@ -231,7 +143,7 @@ impl<'a> Uart<'a> {
                 // We have more to transmit, so continue in tx_progress().
                 self.tx_progress();
             }
-        } else if intrs.is_set(intr::rx_watermark) {
+        } else if intrs.is_set(INTR::RX_WATERMARK) {
             self.disable_rx_interrupt();
 
             self.rx_client.map(|client| {
@@ -243,7 +155,7 @@ impl<'a> Uart<'a> {
                         rx_buf[i] = regs.rdata.get() as u8;
                         len = i + 1;
 
-                        if regs.status.is_set(status::rxempty) {
+                        if regs.status.is_set(STATUS::RXEMPTY) {
                             /* RX is empty */
                             return_code = Err(ErrorCode::SIZE);
                             break;
@@ -259,8 +171,8 @@ impl<'a> Uart<'a> {
     pub fn transmit_sync(&self, bytes: &[u8]) {
         let regs = self.registers;
         for b in bytes.iter() {
-            while regs.status.is_set(status::txfull) {}
-            regs.wdata.write(wdata::data.val(*b as u32));
+            while regs.status.is_set(STATUS::TXFULL) {}
+            regs.wdata.write(WDATA::WDATA.val(*b as u32));
         }
     }
 }
@@ -272,7 +184,7 @@ impl hil::uart::Configure for Uart<'_> {
         self.set_baud_rate(params.baud_rate);
 
         regs.fifo_ctrl
-            .write(fifo_ctrl::rxrst::SET + fifo_ctrl::txrst::SET);
+            .write(FIFO_CTRL::RXRST::SET + FIFO_CTRL::TXRST::SET);
 
         // Disable all interrupts for now
         regs.intr_enable.set(0 as u32);


### PR DESCRIPTION
### Pull Request Overview

This pull request adds auto-generated register definitions for lowrisc/opentitan peripherals and updates the lowrisc/uart driver to use the autogenerated definitions.

### Testing Strategy

This pull request was tested by executing a tock image on the CW310 FPGA board and observing kernel initialization.


### TODO or Help Wanted

- Follow-on PRs to update other lowrisc/opentitan peripherals to use the autogenerated register definitions.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
