### PR TITLE
New approach for kernel attributes

### DIFF
--- a/boards/kernel_layout.ld
+++ b/boards/kernel_layout.ld
@@ -351,11 +351,8 @@ SECTIONS
      *
      * `Length` specifies the size of the value (i.e. not include the header).
      */
-    .attributes :
+    .attributes : AT (ORIGIN(rom) + LENGTH(rom) - SIZEOF(.attributes))
     {
-        . = ABSOLUTE(ORIGIN(rom) + LENGTH(rom) - 16);
-        _sattributes = .;
-
         /* TLV: App Memory
          * This indicates the start address and size of RAM available for
          * userspace apps.
@@ -369,7 +366,6 @@ SECTIONS
         BYTE(79) /* O */
         BYTE(67) /* C */
         BYTE(75) /* K */
-        _eattributes = .;
     }  > rom
 
 
@@ -381,6 +377,30 @@ SECTIONS
     }
 }
 
+/* LOADADDR: Return the absolute load address of the named section. This is
+ * normally the same as ADDR, but it may be different if the AT keyword is used
+ * in the section definition. */
+_sattributes = LOADADDR(.attributes);
+_eattributes = LOADADDR(.attributes) + SIZEOF(.attributes);
+_erom = ORIGIN(rom) + LENGTH(rom);
+
+/* This.. this is a dirty, not-fully-understood, hack. In some way, linking is
+ * a multi-pass process. i.e., if you were to ASSERT(0, "how many links")
+ * you'll get three assertions printed for one invocation of rust-lld.
+ *
+ * Emprically, in the first pass, _eattributes ends up at
+ *     _erom + SIZEOF(.attributes)
+ * So, we need to allow that case.
+ *
+ * That's really not the dream, since we can't identify passes. We really only
+ * want to let the wrong location through on the first pass. Thus, the _best_
+ * solution would be to extract the _erom and _eattributes symbols with readelf
+ * or similar and verify they're equal, but that would be yet-one-more-tool.
+ * Maybe something we can do in CI at some point, and remove this assert.
+ */
+ASSERT((_eattributes == _erom) || (_eattributes == _erom + SIZEOF(.attributes)), "Kernel attributes are not at the end of ROM.")
+
+/* This assert works out becuase even though some of the relative positions are
+ * off, the sizes are sane in each pass. */
 ASSERT((_etext - _stext) + (_erelocate - _srelocate) + (_eattributes - _sattributes) < LENGTH(rom),
 "Text plus relocations plus attributes exceeds the available ROM space.");
-ASSERT(_eattributes == ORIGIN(rom) + LENGTH(rom), "Kernel attributes are not at the end of ROM.")

--- a/boards/kernel_layout.ld
+++ b/boards/kernel_layout.ld
@@ -354,6 +354,7 @@ SECTIONS
     .attributes :
     {
         . = ABSOLUTE(ORIGIN(rom) + LENGTH(rom) - 16);
+        _sattributes = .;
 
         /* TLV: App Memory
          * This indicates the start address and size of RAM available for
@@ -368,6 +369,7 @@ SECTIONS
         BYTE(79) /* O */
         BYTE(67) /* C */
         BYTE(75) /* K */
+        _eattributes = .;
     }  > rom
 
 
@@ -379,5 +381,6 @@ SECTIONS
     }
 }
 
-ASSERT((_etext - _stext) + (_erelocate - _srelocate) < LENGTH(rom), "
-Text plus relocations exceeds the available ROM space.");
+ASSERT((_etext - _stext) + (_erelocate - _srelocate) + (_eattributes - _sattributes) < LENGTH(rom),
+"Text plus relocations plus attributes exceeds the available ROM space.");
+ASSERT(_eattributes == ORIGIN(rom) + LENGTH(rom), "Kernel attributes are not at the end of ROM.")

--- a/boards/kernel_layout.ld
+++ b/boards/kernel_layout.ld
@@ -343,13 +343,14 @@ SECTIONS
      *
      * Attributes are stored as TLVs, but going backwards in flash.
      *
-     *                           2 byte   2 byte   4 byte
-     * -----------+------------+--------+--------+------------+
-     *            | Value...   | Type   | Length | TOCK       | Start of `prog`
-     * -----------+------------+--------+--------+------------+
-     * <-TLVs...-> <-----TLV--------------------> <-Sentinel->
+     *                           2 byte   2 byte   3 byte     1 byte    4 byte
+     * -----------+------------+--------+--------+----------+---------+---------+ Start
+     *            | Value...   | Type   | Length | Reserved | Version | TOCK    | of
+     * -----------+------------+--------+--------+----------+---------+---------+ `prog`
+     * <-TLVs...-> <-----TLV--------------------> <----Header--------> <-Sentl->
      *
-     * `Length` specifies the size of the value (i.e. not include the header).
+     * The TLV `Length` specifies the size of the TLV value (i.e. not including
+     * the TLV header).
      */
     .attributes : AT (ORIGIN(rom) + LENGTH(rom) - SIZEOF(.attributes))
     {
@@ -362,6 +363,15 @@ SECTIONS
         SHORT(0x0101) /* Type = App RAM Region = 0x0101 */
         SHORT(8)      /* Length = 8 bytes */
 
+        /* Version and Reserved. Current version is 0x01.
+         */
+        BYTE(0) /* Reserved */
+        BYTE(0) /* Reserved */
+        BYTE(0) /* Reserved */
+        BYTE(1) /* Version = 0x01 */
+
+        /* Sentinel.
+         */
         BYTE(84) /* T */
         BYTE(79) /* O */
         BYTE(67) /* C */

--- a/boards/kernel_layout.ld
+++ b/boards/kernel_layout.ld
@@ -354,6 +354,15 @@ SECTIONS
      */
     .attributes : AT (ORIGIN(rom) + LENGTH(rom) - SIZEOF(.attributes))
     {
+        /* TLV: Kernel Flash
+         * This indicates the start address of the kernel flash and the size of
+         * the kernel binary.
+         */
+        LONG(ORIGIN(rom)) /* Address of start of kernel binary. */
+        LONG((LOADADDR(.relocate) + (_erelocate-_srelocate)) - ORIGIN(rom)) /* Length of kernel binary. */
+        SHORT(0x0102) /* Type = Kernel Flash = 0x0102 */
+        SHORT(8)      /* Length = 8 bytes */
+
         /* TLV: App Memory
          * This indicates the start address and size of RAM available for
          * userspace apps.

--- a/boards/kernel_layout.ld
+++ b/boards/kernel_layout.ld
@@ -337,6 +337,40 @@ SECTIONS
     } > ram
     _eappmem = ORIGIN(ram) + LENGTH(ram);
 
+
+    /* Place attributes at the end of the kernel ROM region. These will be used
+     * for host-side tools to learn about the installed kernel.
+     *
+     * Attributes are stored as TLVs, but going backwards in flash.
+     *
+     *                           2 byte   2 byte   4 byte
+     * -----------+------------+--------+--------+------------+
+     *            | Value...   | Type   | Length | TOCK       | Start of `prog`
+     * -----------+------------+--------+--------+------------+
+     * <-TLVs...-> <-----TLV--------------------> <-Sentinel->
+     *
+     * `Length` specifies the size of the value (i.e. not include the header).
+     */
+    .attributes :
+    {
+        . = ABSOLUTE(ORIGIN(rom) + LENGTH(rom) - 16);
+
+        /* TLV: App Memory
+         * This indicates the start address and size of RAM available for
+         * userspace apps.
+         */
+        LONG(_sappmem) /* Address of start of app memory. */
+        LONG(_eappmem - _sappmem) /* Length of app memory. */
+        SHORT(0x0101) /* Type = App RAM Region = 0x0101 */
+        SHORT(8)      /* Length = 8 bytes */
+
+        BYTE(84) /* T */
+        BYTE(79) /* O */
+        BYTE(67) /* C */
+        BYTE(75) /* K */
+    }  > rom
+
+
     /* Discard RISC-V relevant .eh_frame, we are not doing unwind on panic
        so it is not needed. */
     /DISCARD/ :

--- a/boards/kernel_layout.ld
+++ b/boards/kernel_layout.ld
@@ -388,7 +388,7 @@ _erom = ORIGIN(rom) + LENGTH(rom);
  * a multi-pass process. i.e., if you were to ASSERT(0, "how many links")
  * you'll get three assertions printed for one invocation of rust-lld.
  *
- * Emprically, in the first pass, _eattributes ends up at
+ * Empirically, in the first pass, _eattributes ends up at
  *     _erom + SIZEOF(.attributes)
  * So, we need to allow that case.
  *
@@ -400,7 +400,7 @@ _erom = ORIGIN(rom) + LENGTH(rom);
  */
 ASSERT((_eattributes == _erom) || (_eattributes == _erom + SIZEOF(.attributes)), "Kernel attributes are not at the end of ROM.")
 
-/* This assert works out becuase even though some of the relative positions are
+/* This assert works out because even though some of the relative positions are
  * off, the sizes are sane in each pass. */
 ASSERT((_etext - _stext) + (_erelocate - _srelocate) + (_eattributes - _sattributes) < LENGTH(rom),
 "Text plus relocations plus attributes exceeds the available ROM space.");

--- a/boards/kernel_layout.ld
+++ b/boards/kernel_layout.ld
@@ -359,7 +359,7 @@ SECTIONS
          * the kernel binary.
          */
         LONG(ORIGIN(rom)) /* Address of start of kernel binary. */
-        LONG((LOADADDR(.relocate) + (_erelocate-_srelocate)) - ORIGIN(rom)) /* Length of kernel binary. */
+        LONG((LOADADDR(.relocate) + (_erelocate - _srelocate)) - ORIGIN(rom)) /* Length of kernel binary. */
         SHORT(0x0102) /* Type = Kernel Flash = 0x0102 */
         SHORT(8)      /* Length = 8 bytes */
 

--- a/doc/Kernel_Attributes.md
+++ b/doc/Kernel_Attributes.md
@@ -1,0 +1,117 @@
+Kernel Attributes
+=================
+
+Kernel attributes are stored in a data structure at the end of the kernel's
+allocated flash region. These attributes describe properties of the flashed
+kernel on a particular hardware board. External tools can read these attributes
+to learn about the kernel installed on the board.
+
+<!-- npm i -g markdown-toc; markdown-toc -i Kernel_Attributes.md -->
+
+<!-- toc -->
+
+- [Format](#format)
+  * [Header Format](#header-format)
+  * [TLV Format](#tlv-format)
+- [TLVs](#tlvs)
+  * [App Memory (0x0101)](#app-memory-0x0101)
+  * [Kernel Binary (0x0102)](#kernel-binary-0x0102)
+- [Kernel Attributes Location](#kernel-attributes-location)
+
+<!-- tocstop -->
+
+## Format
+
+Kernel attributes are stored in a descending TLV (type-length-value) structure.
+That means they start at the highest address in flash, and are appended in
+descending flash addresses.
+
+The first four bytes are a sentinel that spells "TOCK" (in ASCII). This sentinel
+allows external tools to check if kernel attributes are present. Note, "first"
+in this context means the four bytes with the largest address since this
+structure is stored at the _end_ of flash.
+
+The next byte is a version byte. This allows for future changes to the
+structure.
+
+The next three bytes are reserved.
+
+After the header are zero or more TLV structures that hold the kernel
+attributes.
+
+### Header Format
+
+```text
+0          1          2          3          4 (bytes)
++----------+----------+----------+----------+
+|                            TLVs...        |
++----------+----------+----------+----------+
+| Reserved | Reserved | Reserved | Version  |
++----------+----------+----------+----------+
+| T (0x54) | O (0x4F) | C (0x43) | K (0x4B) |
++----------+----------+----------+----------+
+                                            ^
+                        end of flash region─┘
+```
+
+### TLV Format
+
+```text
+0          1          2          3          4 (bytes)
++----------+----------+----------+----------+
+|                           Value...        |
++----------+----------+----------+----------+
+| Type                | Length              |
++----------+----------+----------+----------+
+```
+
+- Type: Indicates which TLV this is. Little endian.
+- Length: The length of the value. Little endian.
+- Value: Length bytes corresponding to the TLV.
+
+## TLVs
+
+### App Memory (0x0101)
+
+Specifies the region of memory the kernel will use for applications.
+
+```text
+0          1          2          3          4 (bytes)
++----------+----------+----------+----------+
+| Start Address                             |
++----------+----------+----------+----------+
+| App Memory Length                         |
++----------+----------+----------+----------+
+| Type = 0x0101       | Length = 8          |
++----------+----------+----------+----------+
+```
+
+- Start Address: The address in RAM the kernel will use to start allocation
+  memory for apps. Little endian.
+- App Memory Length: The number of bytes in the region of memory for apps.
+  Little endian.
+
+
+### Kernel Binary (0x0102)
+
+Specifies where the kernel binary is and its size.
+
+```text
+0          1          2          3          4 (bytes)
++----------+----------+----------+----------+
+| Start Address                             |
++----------+----------+----------+----------+
+| Binary Length                             |
++----------+----------+----------+----------+
+| Type = 0x0102       | Length = 8          |
++----------+----------+----------+----------+
+```
+
+- Start Address: The address in flash the kernel binary starts at. Little
+  endian.
+- Binary Length: The number of bytes in the kernel binary. Little endian.
+
+## Kernel Attributes Location
+
+Kernel attributes are stored at the end of the kernel's flash region and
+immediately before the start of flash for TBFs.

--- a/doc/Kernel_Attributes.md
+++ b/doc/Kernel_Attributes.md
@@ -71,6 +71,11 @@ attributes.
 
 ## TLVs
 
+The TLV types used for kernel attributes are unrelated to the TLV types used for
+the [Tock Binary Format](./doc/TockBinaryFormat.md#tlv-types). However, to
+minimize possible confusion, type values for each should not use the same
+numbers.
+
 ### App Memory (0x0101)
 
 Specifies the region of memory the kernel will use for applications.


### PR DESCRIPTION


### Pull Request Overview

This is the spiritual successor to #367 and part of #695.

This PR modifies the linker script to insert kernel attributes at the end of the kernel's ROM region. These can be used to store metadata about the kernel that is loaded on the board.

The location at the end of ROM makes them easy to find since they are right before the app flash start address which tockloader already knows about.


#### First use case

The motivation for these is to specify the app RAM region in a way that tockloader can find. Tockloader can then use knowledge about the ram available to processes to choose which version of an app to load onto the board.

#### Downsides

- Every kernel image is now always the full size of the available ROM. This makes loading kernels take longer.

#### Comparison to #367

- This PR puts the attributes at the end of the flash region rather than the beginning. That avoids issues with different boards needing different amounts of data at the start of flash, and makes it easier for tockloader to find (since it already needs to know where to put apps).
- Back when we created the previous PR, kernel attributes were more of a "nice to have" rather than a "must have". That meant we never really wanted to deal with the overhead of creating and maintaining attributes. Now, however, since PIC is _still_ not a thing in LLVM and riscv-gcc, and libtock-rs has no PIC whatsoever, writing interesting apps and using multiple apps with libtock-rs is very difficult. Even when building TBFs for different plausible addresses, loading the correct ones is challenging since we need fixed flash _and_ RAM addresses. I think this means today's need is much more pressing than before.
- We've done a lot with TLVs, and they work for us. We use them in TBF headers and footers. The risk of committing to something now and keeping it stable is low since we've been able to do it with TBFs.
- The changes are entirely contained in the linker script.


### Testing Strategy

Using this with tockloader to load console libtock-rs app.


### TODO or Help Wanted

RFC


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
