### PR TITLE
RFC: Add a <component>_type!() macro in components

### DIFF
--- a/boards/components/src/alarm.rs
+++ b/boards/components/src/alarm.rs
@@ -31,6 +31,19 @@ use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::time::{self, Alarm};
 
+#[macro_export]
+macro_rules! alarm_component_type {
+    ($A:ty $(,)?) => {
+        capsules_core::alarm::AlarmDriver<
+                'static,
+                capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<
+                    'static,
+                    $A,
+                >,
+            >
+        };
+}
+
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! alarm_mux_component_static {

--- a/boards/components/src/alarm.rs
+++ b/boards/components/src/alarm.rs
@@ -70,6 +70,35 @@ macro_rules! alarm_component_static {
     };};
 }
 
+// Setup static space for the objects.
+#[macro_export]
+macro_rules! alarm_component_static_and_type {
+    ($A:ty $(,)?) => {
+        /// Static definition for the Alarm Component.
+        pub mod alarm {
+            use core::mem::MaybeUninit;
+
+            use capsules_core::alarm::AlarmDriver;
+            use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+
+            /// Type definition for the Alarm syscall driver.
+            pub type ttype = AlarmDriver<'static, VirtualMuxAlarm<'static, $A>>;
+
+            /// Static data for the Alarm syscall driver.
+            pub unsafe fn static_data() -> (
+                &'static mut MaybeUninit<VirtualMuxAlarm<'static, $A>>,
+                &'static mut MaybeUninit<AlarmDriver<'static, VirtualMuxAlarm<'static, $A>>>,
+            ) {
+                let mux_alarm = kernel::static_buf!(VirtualMuxAlarm<'static, $A>);
+                let alarm_driver =
+                    kernel::static_buf!(AlarmDriver<'static, VirtualMuxAlarm<'static, $A>>);
+
+                (mux_alarm, alarm_driver)
+            }
+        }
+    };
+}
+
 pub struct AlarmMuxComponent<A: 'static + time::Alarm<'static>> {
     alarm: &'static A,
 }

--- a/boards/components/src/analog_comparator.rs
+++ b/boards/components/src/analog_comparator.rs
@@ -53,6 +53,9 @@ macro_rules! analog_comparator_component_static {
     };};
 }
 
+pub type AnalogComparatorComponentType<AC> =
+    capsules_extra::analog_comparator::AnalogComparator<'static, AC>;
+
 pub struct AnalogComparatorComponent<
     AC: 'static + kernel::hil::analog_comparator::AnalogComparator<'static>,
 > {

--- a/boards/components/src/mx25r6435f.rs
+++ b/boards/components/src/mx25r6435f.rs
@@ -30,6 +30,21 @@ use kernel::hil;
 use kernel::hil::spi::SpiMasterDevice;
 use kernel::hil::time::Alarm;
 
+#[macro_export]
+macro_rules! mx25r6435f_component_type {
+    ($S:ty, $P:ty, $A:ty $(,)?) => {
+        capsules_extra::mx25r6435f::MX25R6435F<
+            'static,
+            capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<
+                'static,
+                $S,
+            >,
+            $P,
+            VirtualMuxAlarm<'static, $A>,
+        >
+    };
+}
+
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! mx25r6435f_component_static {

--- a/boards/components/src/mx25r6435f.rs
+++ b/boards/components/src/mx25r6435f.rs
@@ -71,6 +71,66 @@ macro_rules! mx25r6435f_component_static {
     };};
 }
 
+// Setup static space for the objects.
+#[macro_export]
+macro_rules! mx25r6435f_component_static_and_type {
+    ($S:ty, $P:ty, $A:ty $(,)?) => {
+        pub mod mx25r6435f {
+            pub type ttype = capsules_extra::mx25r6435f::MX25R6435F<
+                'static,
+                capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<'static, $S>,
+                $P,
+                capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, $A>,
+            >;
+
+            pub unsafe fn static_data() -> (
+                &'static mut core::mem::MaybeUninit<
+                    capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<'static, $S>,
+                >,
+                &'static mut core::mem::MaybeUninit<
+                    capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, $A>,
+                >,
+                &'static mut core::mem::MaybeUninit<
+                    capsules_extra::mx25r6435f::MX25R6435F<
+                        'static,
+                        capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<
+                            'static,
+                            $S,
+                        >,
+                        $P,
+                        capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, $A>,
+                    >,
+                >,
+                &'static mut core::mem::MaybeUninit<[u8; capsules_extra::mx25r6435f::TX_BUF_LEN]>,
+                &'static mut core::mem::MaybeUninit<[u8; capsules_extra::mx25r6435f::RX_BUF_LEN]>,
+            ) {
+                let spi_device = kernel::static_buf!(
+                    capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<'static, $S>
+                );
+                let alarm = kernel::static_buf!(
+                    capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, $A>
+                );
+                let mx25r6435f = kernel::static_buf!(
+                    capsules_extra::mx25r6435f::MX25R6435F<
+                        'static,
+                        capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<
+                            'static,
+                            $S,
+                        >,
+                        $P,
+                        capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, $A>,
+                    >
+                );
+
+                let tx_buf = kernel::static_buf!([u8; capsules_extra::mx25r6435f::TX_BUF_LEN]);
+                let rx_buf = kernel::static_buf!([u8; capsules_extra::mx25r6435f::RX_BUF_LEN]);
+
+                (spi_device, alarm, mx25r6435f, tx_buf, rx_buf)
+            }
+        }
+    };
+}
+
 pub struct Mx25r6435fComponent<
     S: 'static + hil::spi::SpiMaster<'static>,
     P: 'static + hil::gpio::Pin,

--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -29,6 +29,21 @@ use kernel::hil::time::Alarm;
 use kernel::process::ProcessPrinter;
 
 #[macro_export]
+macro_rules! process_console_component_type {
+    ($A: ty, $COMMAND_HISTORY_LEN: expr $(,)?) => {
+        capsules_core::process_console::ProcessConsole<
+            'static,
+            $COMMAND_HISTORY_LEN,
+            VirtualMuxAlarm<'static, $A>,
+            components::process_console::Capability,
+        >
+    };
+    ($A: ty $(,)?) => {
+        $crate::process_console_component_type!($A, { capsules_core::process_console::DEFAULT_COMMAND_HISTORY_LEN })
+    };
+}
+
+#[macro_export]
 macro_rules! process_console_component_static {
     ($A: ty, $COMMAND_HISTORY_LEN: expr $(,)?) => {{
         let alarm = kernel::static_buf!(capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, $A>);

--- a/boards/components/src/spi.rs
+++ b/boards/components/src/spi.rs
@@ -40,6 +40,19 @@ use kernel::create_capability;
 use kernel::hil::spi;
 use kernel::hil::spi::{SpiMasterDevice, SpiSlaveDevice};
 
+#[macro_export]
+macro_rules! spi_syscall_component_type {
+    ($S:ty $(,)?) => {
+        capsules_core::spi_controller::Spi<
+                'static,
+                capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<
+                    'static,
+                    $S,
+                >,
+            >
+    };
+}
+
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! spi_mux_component_static {

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -678,15 +678,11 @@ pub unsafe fn main() {
         0x60000,   // Length of kernel region
     )
     .finalize(components::nonvolatile_storage_component_static!(
-        capsules_extra::mx25r6435f::MX25R6435F<
-            'static,
-            capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<
-                'static,
-                nrf52840::spi::SPIM,
-            >,
+        components::mx25r6435f_component_type!(
+            nrf52840::spi::SPIM,
             nrf52840::gpio::GPIOPin,
-            VirtualMuxAlarm<'static, nrf52840::rtc::Rtc>,
-        >
+            nrf52840::rtc::Rtc
+        )
     ));
 
     //--------------------------------------------------------------------------

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -181,13 +181,7 @@ pub struct Platform {
         'static,
         nrf52840::acomp::Comparator<'static>,
     >,
-    alarm: &'static capsules_core::alarm::AlarmDriver<
-        'static,
-        capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<
-            'static,
-            nrf52840::rtc::Rtc<'static>,
-        >,
-    >,
+    alarm: &'static components::alarm_component_type!(nrf52840::rtc::Rtc<'static>),
     nonvolatile_storage:
         &'static capsules_extra::nonvolatile_storage_driver::NonvolatileStorage<'static>,
     udp_driver: &'static capsules_extra::net::udp::UDPDriver<'static>,

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -177,8 +177,7 @@ pub struct Platform {
     adc: &'static capsules_core::adc::AdcDedicated<'static, nrf52840::adc::Adc<'static>>,
     temp: &'static capsules_extra::temperature::TemperatureSensor<'static>,
     ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
-    analog_comparator: &'static capsules_extra::analog_comparator::AnalogComparator<
-        'static,
+    analog_comparator: &'static components::analog_comparator::AnalogComparatorComponentType<
         nrf52840::acomp::Comparator<'static>,
     >,
     alarm: &'static components::alarm_component_type!(nrf52840::rtc::Rtc<'static>),

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -647,6 +647,12 @@ pub unsafe fn main() {
     // ONBOARD EXTERNAL FLASH
     //--------------------------------------------------------------------------
 
+    components::mx25r6435f_component_static_and_type!(
+        nrf52840::spi::SPIM<'static>,
+        nrf52840::gpio::GPIOPin<'static>,
+        nrf52840::rtc::Rtc<'static>
+    );
+
     let mx25r6435f = components::mx25r6435f::Mx25r6435fComponent::new(
         Some(&gpio_port[SPI_MX25R6435F_WRITE_PROTECT_PIN]),
         Some(&gpio_port[SPI_MX25R6435F_HOLD_PIN]),
@@ -654,11 +660,7 @@ pub unsafe fn main() {
         mux_alarm,
         mux_spi,
     )
-    .finalize(components::mx25r6435f_component_static!(
-        nrf52840::spi::SPIM,
-        nrf52840::gpio::GPIOPin,
-        nrf52840::rtc::Rtc
-    ));
+    .finalize(mx25r6435f::static_data());
 
     // API for accessing nonvolatile storage for both the kernel and userspace.
     let nonvolatile_storage = components::nonvolatile_storage::NonvolatileStorageComponent::new(
@@ -671,11 +673,7 @@ pub unsafe fn main() {
         0x60000,   // Length of kernel region
     )
     .finalize(components::nonvolatile_storage_component_static!(
-        components::mx25r6435f_component_type!(
-            nrf52840::spi::SPIM,
-            nrf52840::gpio::GPIOPin,
-            nrf52840::rtc::Rtc
-        )
+        mx25r6435f::ttype
     ));
 
     //--------------------------------------------------------------------------

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -165,12 +165,7 @@ pub struct Platform {
     >,
     ieee802154_radio: &'static capsules_extra::ieee802154::RadioDriver<'static>,
     button: &'static capsules_core::button::Button<'static, nrf52840::gpio::GPIOPin<'static>>,
-    pconsole: &'static capsules_core::process_console::ProcessConsole<
-        'static,
-        { capsules_core::process_console::DEFAULT_COMMAND_HISTORY_LEN },
-        VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
-        components::process_console::Capability,
-    >,
+    pconsole: &'static components::process_console_component_type!(nrf52840::rtc::Rtc<'static>),
     console: &'static capsules_core::console::Console<'static>,
     gpio: &'static capsules_core::gpio::GPIO<'static, nrf52840::gpio::GPIOPin<'static>>,
     led: &'static capsules_core::led::LedDriver<
@@ -200,13 +195,7 @@ pub struct Platform {
         'static,
         nrf52840::i2c::TWI<'static>,
     >,
-    spi_controller: &'static capsules_core::spi_controller::Spi<
-        'static,
-        capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<
-            'static,
-            nrf52840::spi::SPIM<'static>,
-        >,
-    >,
+    spi_controller: &'static components::spi_syscall_component_type!(nrf52840::spi::SPIM<'static>),
     scheduler: &'static RoundRobinSched<'static>,
     systick: cortexm4::systick::SysTick,
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a couple ideas for how to make the `Platform` struct perhaps easier to write. Or maybe copy board-to-board.

Components help with making static_init easy to port from board to board. But editing the Platform struct is always manual.

This PR tries out adding a new macro to components: `component_type!()`, like:

```rust
#[macro_export]
macro_rules! alarm_component_type {
    ($A:ty $(,)?) => {
        capsules_core::alarm::AlarmDriver<
                'static,
                capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<
                    'static,
                    $A,
                >,
            >
        };
}
```

That can then be used to create the platform struct:

```rust
pub struct Platform {
    ...
    alarm: &'static components::alarm_component_type!(nrf52840::rtc::Rtc<'static>),
    ...
}
```

The savings aren't _huge_ in general, but with complex stacks (e.g. tickv), the savings would be pretty substantial.

I'm not normally a fan of macros, but in for a penny in for a pound?


### Testing Strategy

travis


### TODO or Help Wanted

RFC

Obviously I didn't do all components, just some as an example.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
