### PR TITLE
Update EOL GitHub Actions dependencies

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -24,12 +24,12 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1 # pulls version from rust-toolchain file
         with:
           components: rustfmt, clippy
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,11 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1 # pulls version from rust-toolchain file
-      - uses: actions/setup-node@v1
         with:
           components: rustfmt
+      - uses: actions/setup-node@v3
       - name: ci-job-format
         run:  make ci-job-format
       - name: ci-markdown-toc
@@ -51,7 +51,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1 # pulls version from rust-toolchain file
         with:
           components: clippy
@@ -65,7 +65,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
 
       - name: ci-job-syntax
@@ -78,7 +78,7 @@ jobs:
       - name: ci-job-collect-artifacts
         run: make ci-job-collect-artifacts
       - name: upload-build-artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifacts
           path: tools/ci-artifacts
@@ -102,7 +102,7 @@ jobs:
         run: |
           brew install zeromq
         if: matrix.os == 'macos-latest'
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
       - name: ci-job-libraries
         run: make ci-job-libraries
@@ -126,7 +126,7 @@ jobs:
         continue-on-error: true
         run: |
           sudo apt install meson
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
       - name: ci-job-qemu
         run: make ci-job-qemu

--- a/.github/workflows/litex_sim.yml
+++ b/.github/workflows/litex_sim.yml
@@ -39,7 +39,7 @@ jobs:
       # that other steps (such as the Rust toolchain) depend on files
       # in this repo.
       - name: Checkout the current repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Install basic packages required for the GitHub actions workflow
       - name: Update packages and install dependencies
@@ -79,7 +79,7 @@ jobs:
       # Clone tock-litex support repository under ./tock-litex, check out the
       # targeted release.
       - name: Checkout the tock-litex repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: lschuermann/tock-litex
           # The pinned revision is different from the targeted release as
@@ -114,7 +114,7 @@ jobs:
       # Revision to checkout defined in the main tock repository in
       # .libtock_c_ci_rev
       - name: Checkout libtock-c CI revision
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: tock/libtock-c
           # Pins a libtock-c revision for LiteX CI tests. In case of


### PR DESCRIPTION
### Pull Request Overview

This pull request updates GitHub Actions dependencies which use Node v12 and will stop working soon to Node v16.

GitHub [will remove Node v12](https://github.blog/changelog/2023-07-17-github-actions-removal-of-node12-from-the-actions-runner/) from the action runners on the 14th of August.

### Testing Strategy

All the updated workflows run `on: pull_request`, so if this PR passes then the CI still works.

I checked the major-version release notes of the updated actions and didn't see any breaking changes apart from updating Node v12 to Node v16.

I see that [one workflow is using actions/setup-node](https://github.com/tock/tock/blob/master/.github/workflows/ci.yml#L37) so there could be breakage here.

### TODO or Help Wanted

There is one action left that hasn't been updated to Node v16: [actions-rs/toolchain](https://github.com/actions-rs/toolchain/pull/220) which doesn't seem to be maintained any more. It's used in most workflows.

There's a replacement action called [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain/blob/master/action.yml) but I'm not sure it supports using the toolchain specified in `rust-toolchain`.

I think GitHub's container comes with `rustup`, so I think you could drop this action if the repo had a `rust-toolchain.toml` which [specified the required components](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file), but [the update script](https://github.com/tock/tock/blob/08ff147363d1351ed278d3eff5fcbc6c3b402dfc/tools/update_rust_version.sh#L34) currently depends on this being a plaintext file.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.