### PR TITLE
rustup: need version 1.23.0

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -175,7 +175,7 @@ ifneq ($(RUSTUP_ERROR),0)
 endif
 
 # Validate that rustup is new enough.
-MINIMUM_RUSTUP_VERSION := 1.11.0
+MINIMUM_RUSTUP_VERSION := 1.23.0
 RUSTUP_VERSION := $(strip $(word 2, $(shell $(RUSTUP) --version 2> /dev/null)))
 ifeq ($(shell $(TOCK_ROOT_DIRECTORY)tools/semver.sh $(RUSTUP_VERSION) \< $(MINIMUM_RUSTUP_VERSION)), true)
   $(warning Required tool `$(RUSTUP)` is out-of-date.)

--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -29,7 +29,7 @@ developing Tock.
 ## Requirements
 
 1. [Rust](http://www.rust-lang.org/)
-2. [rustup](https://rustup.rs/) to install Rust (version >= 1.11.0)
+2. [rustup](https://rustup.rs/) (version >= 1.23.0) to install Rust
 3. Host toolchain (gcc, glibc)
 4. Command line utilities: make, find
 5. A supported board or QEMU configuration.


### PR DESCRIPTION
### Pull Request Overview

#3593 needs a newer version of rustup.


https://github.com/rust-lang/rustup/blob/bcfac6278c7c2f16a41294f7533aeee2f7f88d07/CHANGELOG.md?plain=1#L579






### Testing Strategy

n/a


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
