### PR TITLE
Fix linker script calculations

### DIFF
--- a/boards/kernel_layout.ld
+++ b/boards/kernel_layout.ld
@@ -345,5 +345,5 @@ SECTIONS
     }
 }
 
-ASSERT((_etext-_stext) + (_erelocate-_srelocate) < LENGTH(rom), "
+ASSERT((_etext - _stext) + (_erelocate - _srelocate) < LENGTH(rom), "
 Text plus relocations exceeds the available ROM space.");

--- a/boards/teensy40/layout.ld
+++ b/boards/teensy40/layout.ld
@@ -61,7 +61,7 @@ SECTIONS
     _boot_data = .;
     LONG(ORIGIN(rom));          /* Start of image */
     /* Size of the program image (assuming that we also need the boot section) */
-    LONG((_etext-_stext) + (_erelocate-_srelocate) + SIZEOF(.boot));
+    LONG((_etext - _stext) + (_erelocate - _srelocate) + SIZEOF(.boot));
     LONG(0x00000000);           /* Plugin flag (unused) */
     /* End of iMXRT10xx magic
      *


### PR DESCRIPTION
It appears that GNU ld is unable to parse some expressions without appropriate spacing around the identifiers.

### Pull Request Overview

This pull request fixes linker scripts to work with GNU ld.  It seems that GNU ld chokes on expressions without spacing around the symbol names:

- Breaks: `_etext-_stext` -> undefined symbol `_etext-_stext' referenced in expression
- Works: `_etext - _stext`.

### Testing Strategy

This pull request was tested by building the codebase.


### TODO or Help Wanted

I _think_ I found all of the expressions without spaces.  Please check if I've missed any.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
