### PR TITLE
kernel_layout: remove eh_frame_hdr

### DIFF
--- a/boards/kernel_layout.ld
+++ b/boards/kernel_layout.ld
@@ -341,7 +341,7 @@ SECTIONS
        so it is not needed. */
     /DISCARD/ :
     {
-      *(.eh_frame);
+      *(.eh_frame*);
     }
 }
 


### PR DESCRIPTION
### Pull Request Overview

The current kernel_layout does not remove all sections related to the eh_frame. This PR removes all eh_frame related sections.

I was observing a section called eh_frame_hdr within my own project. Removing this section had a 15% decrease to the size of my project. While I did not observe this section on the qemu "board", it could potentially be present on other projects and is worth removing. 


### Testing Strategy

This pull request was tested by compiling and running the kernel for the qemu_rv32_virt board, as well as 2 other custom boards.


### TODO or Help Wanted

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
