### PR TITLE
Update thiserror to 1.0.44.

### DIFF
--- a/tools/license-checker/Cargo.toml
+++ b/tools/license-checker/Cargo.toml
@@ -13,7 +13,7 @@ edition.workspace = true
 clap = { features = ["derive"], version = "4.0.29" }
 colored = "2.0.1"
 ignore = "0.4"
-thiserror = "1.0.37"
+thiserror = "1.0.44"
 
 [dependencies.syntect]
 default-features = false


### PR DESCRIPTION
thiserror 1.0.37 depends on proc-macro2 `1.0`. Older versions of proc-macro2 do not compiler on newer nightly compilers. This dependency bump requires proc-macro2 1.0.63, which works on our current nightly toolchain.