### PR TITLE
capsules: ensure driver existence check

### DIFF
--- a/capsules/core/src/adc.rs
+++ b/capsules/core/src/adc.rs
@@ -1186,10 +1186,10 @@ impl<'a, A: hil::adc::Adc<'a> + hil::adc::AdcHighSpeed<'a>> SyscallDriver for Ad
             return CommandReturn::failure(ErrorCode::NOMEM);
         }
         match command_num {
-            // check if present
+            // Driver existence check
             // TODO(Tock 3.0): TRD104 specifies that Command 0 should return Success, not SuccessU32,
             // but this driver is unchanged since it has been stabilized. It will be brought into
-            // compliance as part of the next major release of Tock.
+            // compliance as part of the next major release of Tock. See #3375.
             0 => CommandReturn::success_u32(self.channels.len() as u32),
 
             // Single sample on channel

--- a/capsules/core/src/alarm.rs
+++ b/capsules/core/src/alarm.rs
@@ -159,7 +159,7 @@ impl<'a, A: Alarm<'a>> SyscallDriver for AlarmDriver<'a, A> {
     ///
     /// ### `command_num`
     ///
-    /// - `0`: Driver check.
+    /// - `0`: Driver existence check.
     /// - `1`: Return the clock frequency in Hz.
     /// - `2`: Read the the current clock value
     /// - `3`: Stop the alarm if it is outstanding

--- a/capsules/core/src/button.rs
+++ b/capsules/core/src/button.rs
@@ -36,7 +36,7 @@
 //!
 //! #### `command_num`
 //!
-//! - `0`: Driver check and get number of buttons on the board.
+//! - `0`: Driver existence check and get number of buttons on the board.
 //! - `1`: Enable interrupts for a given button. This will enable both press
 //!   and depress events.
 //! - `2`: Disable interrupts for a button. No affect or reliance on
@@ -138,7 +138,7 @@ impl<'a, P: gpio::InterruptPin<'a>> SyscallDriver for Button<'a, P> {
     ///
     /// ### `command_num`
     ///
-    /// - `0`: Driver check and get number of buttons on the board.
+    /// - `0`: Driver existence check and get number of buttons on the board.
     /// - `1`: Enable interrupts for a given button. This will enable both press
     ///   and depress events.
     /// - `2`: Disable interrupts for a button. No affect or reliance on
@@ -156,7 +156,7 @@ impl<'a, P: gpio::InterruptPin<'a>> SyscallDriver for Button<'a, P> {
             // return button count
             // TODO(Tock 3.0): TRD104 specifies that Command 0 should return Success, not SuccessU32,
             // but this driver is unchanged since it has been stabilized. It will be brought into
-            // compliance as part of the next major release of Tock.
+            // compliance as part of the next major release of Tock. See #3375.
             0 => CommandReturn::success_u32(pins.len() as u32),
 
             // enable interrupts for a button

--- a/capsules/core/src/console.rs
+++ b/capsules/core/src/console.rs
@@ -254,7 +254,7 @@ impl SyscallDriver for Console<'_> {
     ///
     /// ### `command_num`
     ///
-    /// - `0`: Driver check.
+    /// - `0`: Driver existence check.
     /// - `1`: Transmits a buffer passed via `allow`, up to the length
     ///        passed in `arg1`
     /// - `2`: Receives into a buffer passed via `allow`, up to the length

--- a/capsules/core/src/console_ordered.rs
+++ b/capsules/core/src/console_ordered.rs
@@ -411,7 +411,7 @@ impl<'a, A: Alarm<'a>> SyscallDriver for ConsoleOrdered<'a, A> {
     ///
     /// ### `command_num`
     ///
-    /// - `0`: Driver check.
+    /// - `0`: Driver existence check.
     /// - `1`: Transmits a buffer passed via `allow`, up to the length
     ///        passed in `arg1`
     fn command(&self, cmd_num: usize, arg1: usize, _: usize, appid: ProcessId) -> CommandReturn {

--- a/capsules/core/src/gpio.rs
+++ b/capsules/core/src/gpio.rs
@@ -178,7 +178,7 @@ impl<'a, IP: gpio::InterruptPin<'a>> SyscallDriver for GPIO<'a, IP> {
     ///
     /// ### `command_num`
     ///
-    /// - `0`: Number of pins.
+    /// - `0`: Driver existence check.
     /// - `1`: Enable output on `pin`.
     /// - `2`: Set `pin`.
     /// - `3`: Clear `pin`.
@@ -188,6 +188,7 @@ impl<'a, IP: gpio::InterruptPin<'a>> SyscallDriver for GPIO<'a, IP> {
     /// - `7`: Configure interrupt on `pin` with `irq_config` in 0x00XX00000
     /// - `8`: Disable interrupt on `pin`.
     /// - `9`: Disable `pin`.
+    /// - `10`: Get number of GPIO ports supported.
     fn command(
         &self,
         command_num: usize,
@@ -198,8 +199,8 @@ impl<'a, IP: gpio::InterruptPin<'a>> SyscallDriver for GPIO<'a, IP> {
         let pins = self.pins;
         let pin_index = data1;
         match command_num {
-            // number of pins
-            0 => CommandReturn::success_u32(pins.len() as u32),
+            // Check existence.
+            0 => CommandReturn::success(),
 
             // enable output
             1 => {
@@ -330,6 +331,9 @@ impl<'a, IP: gpio::InterruptPin<'a>> SyscallDriver for GPIO<'a, IP> {
                     }
                 }
             }
+
+            // number of pins
+            10 => CommandReturn::success_u32(pins.len() as u32),
 
             // default
             _ => CommandReturn::failure(ErrorCode::NOSUPPORT),

--- a/capsules/core/src/i2c_master_slave_driver.rs
+++ b/capsules/core/src/i2c_master_slave_driver.rs
@@ -284,8 +284,7 @@ impl<'a, I: hil::i2c::I2CMasterSlave<'a>> SyscallDriver for I2CMasterSlaveDriver
         process_id: ProcessId,
     ) -> CommandReturn {
         if command_num == 0 {
-            // Handle this first as it should be returned
-            // unconditionally
+            // Handle unconditional driver existence check.
             return CommandReturn::success();
         }
         // Check if this non-virtualized driver is already in use by

--- a/capsules/core/src/led.rs
+++ b/capsules/core/src/led.rs
@@ -98,7 +98,7 @@ impl<L: led::Led, const NUM_LEDS: usize> SyscallDriver for LedDriver<'_, L, NUM_
             // get number of LEDs
             // TODO(Tock 3.0): TRD104 specifies that Command 0 should return Success, not SuccessU32,
             // but this driver is unchanged since it has been stabilized. It will be brought into
-            // compliance as part of the next major release of Tock.
+            // compliance as part of the next major release of Tock. See #3375.
             0 => CommandReturn::success_u32(NUM_LEDS as u32),
 
             // on

--- a/capsules/core/src/rng.rs
+++ b/capsules/core/src/rng.rs
@@ -180,7 +180,7 @@ impl<'a> SyscallDriver for RngDriver<'a> {
         processid: ProcessId,
     ) -> CommandReturn {
         match command_num {
-            // Check if exists
+            // Driver existence check
             0 => CommandReturn::success(),
 
             // Ask for a given number of random bytes

--- a/capsules/core/src/spi_controller.rs
+++ b/capsules/core/src/spi_controller.rs
@@ -140,6 +140,7 @@ impl<'a, S: SpiMasterDevice<'a>> Spi<'a, S> {
 }
 
 impl<'a, S: SpiMasterDevice<'a>> SyscallDriver for Spi<'a, S> {
+    // 0: driver existence check
     // 2: read/write buffers
     //   - requires write buffer registered with allow
     //   - read buffer optional
@@ -184,7 +185,7 @@ impl<'a, S: SpiMasterDevice<'a>> SyscallDriver for Spi<'a, S> {
         process_id: ProcessId,
     ) -> CommandReturn {
         if command_num == 0 {
-            // Handle this first as it should be returned unconditionally.
+            // Handle unconditional driver existence check.
             return CommandReturn::success();
         }
 

--- a/capsules/core/src/spi_peripheral.rs
+++ b/capsules/core/src/spi_peripheral.rs
@@ -132,7 +132,7 @@ impl<'a, S: SpiSlaveDevice<'a>> SyscallDriver for SpiPeripheral<'a, S> {
     ///
     /// - allow_num 0: Provides a buffer to transmit
 
-    /// - 0: check if present
+    /// - 0: driver existence check
     /// - 1: read/write buffers
     ///   - read and write buffers optional
     ///   - fails if arg1 (bytes to write) >
@@ -170,7 +170,7 @@ impl<'a, S: SpiSlaveDevice<'a>> SyscallDriver for SpiPeripheral<'a, S> {
         process_id: ProcessId,
     ) -> CommandReturn {
         if command_num == 0 {
-            // Handle this first as it should be returned unconditionally.
+            // Handle unconditional driver existence check.
             return CommandReturn::success();
         }
 

--- a/capsules/extra/src/analog_comparator.rs
+++ b/capsules/extra/src/analog_comparator.rs
@@ -118,7 +118,7 @@ impl<'a, A: hil::analog_comparator::AnalogComparator<'a>> SyscallDriver
     ///
     /// ### `command_num`
     ///
-    /// - `0`: Driver check.
+    /// - `0`: Driver existence check.
     /// - `1`: Perform a simple comparison.
     ///        Input x chooses the desired comparator ACx (e.g. 0 or 1 for
     ///        hail, 0-3 for imix)
@@ -128,6 +128,7 @@ impl<'a, A: hil::analog_comparator::AnalogComparator<'a>> SyscallDriver
     /// - `3`: Stop interrupt-based comparisons.
     ///        Input x chooses the desired comparator ACx (e.g. 0 or 1 for
     ///        hail, 0-3 for imix)
+    /// - `4`: Get number of channels.
     fn command(
         &self,
         command_num: usize,
@@ -136,8 +137,8 @@ impl<'a, A: hil::analog_comparator::AnalogComparator<'a>> SyscallDriver
         processid: ProcessId,
     ) -> CommandReturn {
         if command_num == 0 {
-            // Handle this first as it should be returned unconditionally.
-            return CommandReturn::success_u32(self.channels.len() as u32);
+            // Handle unconditional driver existence check.
+            return CommandReturn::success();
         }
 
         // Check if this driver is free, or already dedicated to this process.
@@ -163,6 +164,8 @@ impl<'a, A: hil::analog_comparator::AnalogComparator<'a>> SyscallDriver
             2 => self.start_comparing(channel).into(),
 
             3 => self.stop_comparing(channel).into(),
+
+            4 => CommandReturn::success_u32(self.channels.len() as u32),
 
             _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
         }

--- a/capsules/extra/src/app_flash_driver.rs
+++ b/capsules/extra/src/app_flash_driver.rs
@@ -213,7 +213,7 @@ impl SyscallDriver for AppFlash<'_> {
     ///
     /// ### `command_num`
     ///
-    /// - `0`: Driver check.
+    /// - `0`: Driver existence check.
     /// - `1`: Write the memory from the `allow` buffer to the address in flash.
     fn command(
         &self,

--- a/capsules/extra/src/dac.rs
+++ b/capsules/extra/src/dac.rs
@@ -38,7 +38,7 @@ impl SyscallDriver for Dac<'_> {
     ///
     /// ### `command_num`
     ///
-    /// - `0`: Driver check.
+    /// - `0`: Driver existence check.
     /// - `1`: Initialize and enable the DAC.
     /// - `2`: Set the output to `data1`, a scaled output value.
     fn command(&self, command_num: usize, data: usize, _: usize, _: ProcessId) -> CommandReturn {

--- a/capsules/extra/src/gpio_async.rs
+++ b/capsules/extra/src/gpio_async.rs
@@ -143,7 +143,7 @@ impl<Port: hil::gpio_async::Port> SyscallDriver for GPIOAsync<'_, Port> {
     ///
     /// ### `command_num`
     ///
-    /// - `0`: Driver check and get number of GPIO ports supported.
+    /// - `0`: Driver existence check.
     /// - `1`: Set a pin as an output.
     /// - `2`: Set a pin high by setting it to 1.
     /// - `3`: Clear a pin by setting it to 0.
@@ -158,6 +158,7 @@ impl<Port: hil::gpio_async::Port> SyscallDriver for GPIOAsync<'_, Port> {
     ///   interrupt, and 2 for a falling edge interrupt.
     /// - `8`: Disable an interrupt on a pin.
     /// - `9`: Disable a GPIO pin.
+    /// - `10`: Get number of GPIO ports supported.
     fn command(
         &self,
         command_number: usize,
@@ -169,9 +170,14 @@ impl<Port: hil::gpio_async::Port> SyscallDriver for GPIOAsync<'_, Port> {
         let other = (data >> 16) & 0xFFFF;
         let ports = self.ports;
 
-        // Special case command 0; everything else results in a process-owned,
-        // split-phase call.
+        // Driver existence check.
         if command_number == 0 {
+            CommandReturn::success();
+        }
+
+        // Special case command 10; everything else results in a process-owned,
+        // split-phase call.
+        if command_number == 10 {
             // How many ports
             return CommandReturn::success_u32(ports.len() as u32);
         }

--- a/capsules/extra/src/humidity.rs
+++ b/capsules/extra/src/humidity.rs
@@ -25,7 +25,7 @@
 //! The `command` system call support one argument `cmd` which is used to specify the specific
 //! operation, currently the following cmd's are supported:
 //!
-//! * `0`: check whether the driver exists
+//! * `0`: driver existence check
 //! * `1`: read humidity
 //!
 //!
@@ -143,7 +143,7 @@ impl SyscallDriver for HumiditySensor<'_> {
         processid: ProcessId,
     ) -> CommandReturn {
         match command_num {
-            // check whether the driver exist!!
+            // driver existence check
             0 => CommandReturn::success(),
 
             // single humidity measurement

--- a/capsules/extra/src/ieee802154/driver.rs
+++ b/capsules/extra/src/ieee802154/driver.rs
@@ -544,7 +544,7 @@ impl SyscallDriver for RadioDriver<'_> {
     ///
     /// ### `command_num`
     ///
-    /// - `0`: Driver check.
+    /// - `0`: Driver existence check.
     /// - `1`: Return radio status. Ok(())/OFF = on/off.
     /// - `2`: Set short MAC address.
     /// - `3`: Set long MAC address.

--- a/capsules/extra/src/ltc294x.rs
+++ b/capsules/extra/src/ltc294x.rs
@@ -542,7 +542,7 @@ impl<I: i2c::I2CDevice> SyscallDriver for LTC294XDriver<'_, I> {
     ///
     /// ### `command_num`
     ///
-    /// - `0`: Driver check.
+    /// - `0`: Driver existence check.
     /// - `1`: Get status of the chip.
     /// - `2`: Configure settings of the chip.
     /// - `3`: Reset accumulated charge measurement to zero.

--- a/capsules/extra/src/max17205.rs
+++ b/capsules/extra/src/max17205.rs
@@ -522,7 +522,7 @@ impl<I: i2c::I2CDevice> SyscallDriver for MAX17205Driver<'_, I> {
     ///
     /// ### `command_num`
     ///
-    /// - `0`: Driver check.
+    /// - `0`: Driver existence check.
     /// - `1`: Read the current status of the MAX17205.
     /// - `2`: Read the current state of charge percent.
     /// - `3`: Read the current voltage and current draw.

--- a/capsules/extra/src/net/udp/driver.rs
+++ b/capsules/extra/src/net/udp/driver.rs
@@ -337,7 +337,7 @@ impl<'a> SyscallDriver for UDPDriver<'a> {
     ///
     /// ### `command_num`
     ///
-    /// - `0`: Driver check.
+    /// - `0`: Driver existence check.
     /// - `1`: Get the interface list
     ///        app_cfg (out): 16 * `n` bytes: the list of interface IPv6 addresses, length
     ///                       limited by `app_cfg` length.

--- a/capsules/extra/src/nrf51822_serialization.rs
+++ b/capsules/extra/src/nrf51822_serialization.rs
@@ -142,7 +142,7 @@ impl SyscallDriver for Nrf51822Serialization<'_> {
     ///
     /// ### `command_type`
     ///
-    /// - `0`: Driver check.
+    /// - `0`: Driver existence check.
     /// - `1`: Send the allowed buffer to the nRF.
     /// - `2`: Received from the nRF into the allowed buffer.
     /// - `3`: Reset the nRF51822.

--- a/capsules/extra/src/pca9544a.rs
+++ b/capsules/extra/src/pca9544a.rs
@@ -200,7 +200,7 @@ impl<I: i2c::I2CDevice> SyscallDriver for PCA9544A<'_, I> {
     ///
     /// ### `command_num`
     ///
-    /// - `0`: Driver check.
+    /// - `0`: Driver existence check.
     /// - `1`: Choose which channels are active.
     /// - `2`: Disable all channels.
     /// - `3`: Read the list of fired interrupts.

--- a/capsules/extra/src/proximity.rs
+++ b/capsules/extra/src/proximity.rs
@@ -23,7 +23,7 @@
 //! The `command` system call support one argument `cmd` which is used to specify the specific
 //! operation, currently the following cmd's are supported:
 //!
-//! * `0`: check whether the driver exist
+//! * `0`: driver existence check
 //! * `1`: read proximity
 //! * `2`: read proximity on interrupt
 //!
@@ -296,7 +296,7 @@ impl SyscallDriver for ProximitySensor<'_> {
         processid: ProcessId,
     ) -> CommandReturn {
         match command_num {
-            // check whether the driver exist!!
+            // Driver existence check
             0 => CommandReturn::success(),
 
             // Instantaneous proximity measurement

--- a/capsules/extra/src/pwm.rs
+++ b/capsules/extra/src/pwm.rs
@@ -66,13 +66,14 @@ impl<'a, const NUM_PINS: usize> SyscallDriver for Pwm<'a, NUM_PINS> {
     ///
     /// ### `command_num`
     ///
-    /// - `0`: Return number of PWM pins if this driver is included on the platform.
+    /// - `0`: Driver existence check.
     /// - `1`: Start the PWM pin output. First 16 bits of `data1` are used for the duty cycle, as a
     ///     percentage with 2 decimals, and the last 16 bits of `data1` are used for the PWM channel
     ///     to be controlled. `data2` is used for the frequency in hertz. For the duty cycle, 100% is
     ///     the max duty cycle for this pin.
     /// - `2`: Stop the PWM output.
     /// - `3`: Return the maximum possible frequency for this pin.
+    /// - `4`: Return number of PWM pins if this driver is included on the platform.
     fn command(
         &self,
         command_num: usize,
@@ -81,8 +82,8 @@ impl<'a, const NUM_PINS: usize> SyscallDriver for Pwm<'a, NUM_PINS> {
         processid: ProcessId,
     ) -> CommandReturn {
         match command_num {
-            // Return number of usable PWM pins.
-            0 => CommandReturn::success_u32(NUM_PINS as u32),
+            // Check existence.
+            0 => CommandReturn::success(),
 
             // Start the pwm output.
 
@@ -151,6 +152,9 @@ impl<'a, const NUM_PINS: usize> SyscallDriver for Pwm<'a, NUM_PINS> {
                     CommandReturn::success_u32(self.pwm_pins[pin].get_maximum_frequency_hz() as u32)
                 }
             }
+
+            // Return number of usable PWM pins.
+            4 => CommandReturn::success_u32(NUM_PINS as u32),
 
             _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
         }

--- a/capsules/extra/src/read_only_state.rs
+++ b/capsules/extra/src/read_only_state.rs
@@ -118,7 +118,8 @@ impl<'a, T: Time> SyscallDriver for ReadOnlyStateDriver<'a, T> {
     ///
     /// ### `command_num`
     ///
-    /// - `0`: get version
+    /// - `0`: Driver existence check.
+    /// - `1`: Get version.
     fn command(
         &self,
         command_number: usize,
@@ -127,8 +128,11 @@ impl<'a, T: Time> SyscallDriver for ReadOnlyStateDriver<'a, T> {
         _processid: ProcessId,
     ) -> CommandReturn {
         match command_number {
-            // get version
-            0 => CommandReturn::success_u32(VERSION),
+            // Check existence
+            0 => CommandReturn::success(),
+
+            // Get version
+            1 => CommandReturn::success_u32(VERSION),
 
             // default
             _ => CommandReturn::failure(ErrorCode::NOSUPPORT),

--- a/capsules/extra/src/screen.rs
+++ b/capsules/extra/src/screen.rs
@@ -449,11 +449,8 @@ impl<'a> SyscallDriver for Screen<'a> {
         process_id: ProcessId,
     ) -> CommandReturn {
         match command_num {
-            0 =>
-            // This driver exists.
-            {
-                CommandReturn::success()
-            }
+            // Driver existence check
+            0 => CommandReturn::success(),
             // Does it have the screen setup
             1 => CommandReturn::success_u32(self.screen_setup.is_some() as u32),
             // Set power

--- a/capsules/extra/src/sdcard.rs
+++ b/capsules/extra/src/sdcard.rs
@@ -1590,7 +1590,7 @@ impl<'a, A: hil::time::Alarm<'a>> SyscallDriver for SDCardDriver<'a, A> {
         process_id: ProcessId,
     ) -> CommandReturn {
         if command_num == 0 {
-            // Handle this first as it should be returned unconditionally.
+            // Handle unconditional driver existence check.
             return CommandReturn::success();
         }
 

--- a/capsules/extra/src/seven_segment.rs
+++ b/capsules/extra/src/seven_segment.rs
@@ -126,7 +126,7 @@
 //!
 //! #### `command_num`
 //!
-//! - `0`: Return the number of digits on the display being used.
+//! - `0`: Driver Check.
 //!   - `data1`: Unused.
 //!   - `data2`: Unused.
 //!   - Return: Number of digits.
@@ -144,6 +144,9 @@
 //!   - `data1`: The position of the digit. Starts at 1.
 //!   - `data2`: The custom pattern to be represented.
 //!   - Return: `Ok(())` if the index was valid, `INVAL` otherwise.
+//! - `5`: Return the number of digits on the display being used.
+//!   - `data1`: Unused.
+//!   - `data2`: Unused.
 
 use core::cell::Cell;
 
@@ -358,8 +361,7 @@ impl<'a, P: Pin, A: Alarm<'a>, const NUM_DIGITS: usize> SyscallDriver
     ///
     /// ### `command_num`
     ///
-    /// - `0`: Returns the number of digits on the display. This will always be 0 or
-    ///        greater, and therefore also allows for checking for this driver.
+    /// - `0`: Driver existence check.
     /// - `1`: Prints one digit at the requested position. Returns `INVAL` if the
     ///        position is not valid.
     /// - `2`: Clears all digits currently being displayed.
@@ -367,6 +369,8 @@ impl<'a, P: Pin, A: Alarm<'a>, const NUM_DIGITS: usize> SyscallDriver
     ///        `INVAL` if the position is not valid.
     /// - `4`: Print a custom pattern for a certain digit. Returns
     ///        `INVAL` if the position is not valid.
+    /// - `5`: Returns the number of digits on the display. This will always be 0 or
+    ///        greater, and therefore also allows for checking for this driver.
     fn command(
         &self,
         command_num: usize,
@@ -375,8 +379,8 @@ impl<'a, P: Pin, A: Alarm<'a>, const NUM_DIGITS: usize> SyscallDriver
         _: ProcessId,
     ) -> CommandReturn {
         match command_num {
-            // Return number of digits
-            0 => CommandReturn::success_u32(self.digits.len() as u32),
+            // Check existence
+            0 => CommandReturn::success(),
 
             // Print one digit
             1 => CommandReturn::from(self.print_digit(data1, data2)),
@@ -389,6 +393,9 @@ impl<'a, P: Pin, A: Alarm<'a>, const NUM_DIGITS: usize> SyscallDriver
 
             // Print a custom pattern
             4 => CommandReturn::from(self.print(data1, data2 as u8)),
+
+            // Return number of digits
+            5 => CommandReturn::success_u32(self.digits.len() as u32),
 
             // default
             _ => CommandReturn::failure(ErrorCode::NOSUPPORT),

--- a/capsules/extra/src/temperature.rs
+++ b/capsules/extra/src/temperature.rs
@@ -143,7 +143,7 @@ impl SyscallDriver for TemperatureSensor<'_> {
         processid: ProcessId,
     ) -> CommandReturn {
         match command_num {
-            // check whether the driver exists!!
+            // driver existence check
             0 => CommandReturn::success(),
 
             // read temperature

--- a/capsules/extra/src/touch.rs
+++ b/capsules/extra/src/touch.rs
@@ -339,11 +339,8 @@ impl<'a> SyscallDriver for Touch<'a> {
         processid: ProcessId,
     ) -> CommandReturn {
         match command_num {
-            0 =>
-            // This driver exists.
-            {
-                CommandReturn::success()
-            }
+            // driver existence check
+            0 => CommandReturn::success(),
 
             // touch enable
             1 => {

--- a/doc/syscalls/00000_alarm.md
+++ b/doc/syscalls/00000_alarm.md
@@ -22,7 +22,7 @@ The alarm's frequency is platform-specific, but must be _at least_ 1kHz.
 
     **Argument 2**: unused
 
-    **Returns**: Ok(()) if the driver exists, otherwise NODEVICE.
+    **Returns**: Success if the driver exists, otherwise NODEVICE.
 
   * ### Command number: `1`
 
@@ -53,7 +53,7 @@ The alarm's frequency is platform-specific, but must be _at least_ 1kHz.
     **Argument 2**: unused
 
     **Returns**: INVAL if the notification identifier is invalid, ALREADY if
-    the notification is already disabled, or Ok(()).
+    the notification is already disabled, or success.
 
   * ### Command number: `5`
 

--- a/doc/syscalls/00004_gpio.md
+++ b/doc/syscalls/00004_gpio.md
@@ -22,17 +22,13 @@ actual hardware pins. This mapping is currently subject to change.
 
   * ### Command number: `0`
 
-    **Description**: Whether GPIO pins are exported by this board.
+    **Description**: Does the driver exist?
 
     **Argument 1**: unused
 
     **Argument 2**: unused
 
-    **Returns**: _Unstable:_ Most boards return the number of GPIO pins
-    available, however users should consult their board for details of
-    this return value.
-    `NODEVICE` if this driver is not present on the board.
-
+    **Returns**: Success if it exists, otherwise `NODEVICE`
 
   * ### Command number: `1`
 
@@ -44,7 +40,7 @@ actual hardware pins. This mapping is currently subject to change.
 
     **Argument 2**: unused
 
-    **Returns**: Ok(()) if the command was successful, and `INVAL` if the
+    **Returns**: `Ok(())` if the command was successful, and `INVAL` if the
     argument refers to a non-existent pin.
 
   * ### Command number: `2`
@@ -124,6 +120,18 @@ actual hardware pins. This mapping is currently subject to change.
     invalid, and `ENOSUPPORT` if an invalid interrupt mode is passed in the
     configuration field of the argument. If any error is returned, no state
     will be changed.
+
+  * ### Command number: `10`
+
+    **Description**: Whether GPIO pins are exported by this board.
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: _Unstable:_ Most boards return the number of GPIO pins
+    available, however users should consult their board for details of
+    this return value.
 
 ## Subscribe
 

--- a/doc/syscalls/00007_analog_comparator.md
+++ b/doc/syscalls/00007_analog_comparator.md
@@ -55,7 +55,7 @@ the index of the last AC module.
 
     **Returns**: `Ok(())` if starting interrupts was succesful.
 
-* ### Command number: `4`
+* ### Command number: `3`
 
     **Description**: Stop interrupts on an analog comparator. 
 
@@ -65,3 +65,13 @@ the index of the last AC module.
     **Argument 2**: unused
 
     **Returns**: `Ok(())` if stopping interrupts was succesful.
+
+  * ### Command number: `4`
+
+    **Description**: Get number of channels
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: Number of channels

--- a/doc/syscalls/00009_ros.md
+++ b/doc/syscalls/00009_ros.md
@@ -83,9 +83,17 @@ valid userspace readable buffer.
 
 ## Command
 
-  * Description: command() is used to query the version:
+  * ### Command number: `0`
 
-  * ### Command Number: 0
+    **Description**: Existence check.
+
+    **Argument 1**: Unused
+
+    **Argument 2**: Unused
+
+    **Returns**: Success, or `NODEVICE` if this driver is not present on the board.
+
+  * ### Command Number: 1
 
     **Description**: Get Version.
 

--- a/doc/syscalls/00010_pwm.md
+++ b/doc/syscalls/00010_pwm.md
@@ -14,13 +14,13 @@ The PWM pins are indexed in the array starting at 0. The order of the pins and t
 
   * ### Command number: `0`
 
-    **Description**: How many PWM pins are supported on this board, if the driver exists.
+    **Description**: Existence check.
 
-    **Argument 1**: unused
+    **Argument 1**: Unused
 
-    **Argument 2**: unused
+    **Argument 2**: Unused
 
-    **Returns**: The number of PWM pins on this board.
+    **Returns**: Success, or `NODEVICE` if this driver is not present on the board.
 
   * ### Command number: `1`
 
@@ -51,6 +51,16 @@ The PWM pins are indexed in the array starting at 0. The order of the pins and t
     **Argument 2**: unused
 
     **Returns**: The maximum frequency of the pin, `INVAL` if the pin is invalid.
+
+  * ### Command number: `4`
+
+    **Description**: How many PWM pins are supported on this board.
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: The number of PWM pins on this board.
 
 ## Subscribe
 

--- a/doc/syscalls/20007_can.md
+++ b/doc/syscalls/20007_can.md
@@ -26,7 +26,7 @@ using a read-write buffer.
 
 	  **Argument 2**: unused
 
-	  **Returns**: Ok(()) if it exists, otherwise NODEVICE
+	  **Returns**: Success if it exists, otherwise NODEVICE
 
   * ### Command number: `1`
 

--- a/doc/syscalls/60000_ambient_temperature.md
+++ b/doc/syscalls/60000_ambient_temperature.md
@@ -20,7 +20,7 @@ hundredths of degrees
 
     **Argument 2**: unused
 
-    **Returns**: Ok(()) if it exists, otherwise NODEVICE
+    **Returns**: Success if it exists, otherwise NODEVICE
 
   * ### Command number: `1`
 

--- a/doc/syscalls/60001_humidity.md
+++ b/doc/syscalls/60001_humidity.md
@@ -20,7 +20,7 @@ hundredths of a percent.
 
     **Argument 2**: unused
 
-    **Returns**: Ok(()) if it exists, otherwise NODEVICE
+    **Returns**: Success if it exists, otherwise NODEVICE
 
   * ### Command number: `1`
 

--- a/doc/syscalls/60002_luminance.md
+++ b/doc/syscalls/60002_luminance.md
@@ -19,7 +19,7 @@ from a sensor. Luminance is reported in lux (lx).
 
     **Argument 2**: unused
 
-    **Returns**: Ok(()) if it exists, otherwise NODEVICE
+    **Returns**: Success if it exists, otherwise NODEVICE
 
   * ### Command number: `1`
 

--- a/doc/syscalls/70005_l3gd20.md
+++ b/doc/syscalls/70005_l3gd20.md
@@ -14,7 +14,7 @@ Three axis gyroscope and temperature sensor.
 
   * ### Command number: `0`
 
-    **Description**: Returns Ok(())
+    **Description**: Existence check.
 
     **Argument 1**: unused
 

--- a/doc/syscalls/70006_lsm303dlhc.md
+++ b/doc/syscalls/70006_lsm303dlhc.md
@@ -14,7 +14,7 @@ Three axis accelerometer, magnetometer and temperature sensor.
 
   * ### Command number: `0`
 
-    **Description**: Returns Ok(())
+    **Description**: Existence check.
 
     **Argument 1**: unused
 

--- a/doc/syscalls/90001_screen.md
+++ b/doc/syscalls/90001_screen.md
@@ -29,7 +29,7 @@ may return OFF when power is not enabled (see screen HIL for details).
 
     **Argument 2**: unused
 
-    **Returns**: Ok(()) if it exists, otherwise NODEVICE
+    **Returns**: Success if it exists, otherwise NODEVICE
 
   * ### Command number: `1`
 

--- a/doc/syscalls/90002_touch.md
+++ b/doc/syscalls/90002_touch.md
@@ -18,7 +18,7 @@ The touch driver allows the process to interract with a touch panel.
 
     **Argument 2**: unused
 
-    **Returns**: Ok(()) if it exists, otherwise NODEVICE
+    **Returns**: Success if it exists, otherwise NODEVICE
 
   * ### Command number: `1`
 

--- a/doc/syscalls/90003_text_screen.md
+++ b/doc/syscalls/90003_text_screen.md
@@ -19,7 +19,7 @@ screen like an LCD display.
 
     **Argument 2**: unused
 
-    **Returns**: Ok(()) if it exists, otherwise NODEVICE
+    **Returns**: Success if it exists, otherwise NODEVICE
 
   * ### Command number: `1` 
 

--- a/doc/syscalls/README.md
+++ b/doc/syscalls/README.md
@@ -52,6 +52,7 @@ stabilized or not (a "✓" indicates stability) in the Tock 2.0 release.
 |   | 0x00007       | [AnalogComparator](00007_analog_comparator.md) | Analog Comparator       |
 |   | 0x00008       | [Low-Level Debug](00008_low_level_debug.md) | Low-level debugging tools  |
 |   | 0x00009       | [ROS](00009_ros.md)         | Read Only State, access system information |
+|   | 0x00010       | [PWM](00010_pwm.md)         | Control PWM pins                           |
 
 ### Kernel
 

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -115,7 +115,7 @@ impl<const NUM_PROCS: u8> SyscallDriver for IPC<NUM_PROCS> {
     ///
     /// ### `command_num`
     ///
-    /// - `0`: Driver check, always returns Ok(())
+    /// - `0`: Driver existence check, always returns Ok(())
     /// - `1`: Perform discovery on the package name passed to `allow_readonly`. Returns the
     ///        service descriptor if the service is found, otherwise returns an error.
     /// - `2`: Notify a service previously discovered to have the service descriptor in


### PR DESCRIPTION
### Pull Request Overview

The driver liveliness check is defined in TRD104 4.3.1. I have updated all drivers in advance of Tock v3 (#3375). Make code comments and documentation consistent with regards to "driver existence check" terminology -- change as per #2908. "Driver check" falsely implies some sort of functionality checking.


### Testing Strategy

Unsure how to test. These are breaking changes.


### TODO or Help Wanted

There seems to be an established convention that command code 0 should return the number of things the driver is controlling. I moved those commands to the next available command code. Should these syscalls have some standardized code number?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
