### PR TITLE
opentitan: tests: fix test order for flash/aes

### DIFF
--- a/boards/opentitan/src/tests/aes_test.rs
+++ b/boards/opentitan/src/tests/aes_test.rs
@@ -16,8 +16,19 @@ use kernel::debug;
 use kernel::hil::symmetric_encryption::{AES128, AES128_BLOCK_SIZE, AES128_KEY_SIZE};
 use kernel::static_init;
 
+/// The only 'test_case' for aes_test as directly invoked by the test runner,
+/// this calls all the other tests, preserving the order in which they must
+/// be ran.
 #[test_case]
-fn run000_aes128_ccm() {
+fn aes_tester() {
+    run_aes128_ccm();
+    run_aes128_gcm();
+    run_aes128_ecb();
+    run_aes128_cbc();
+    run_aes128_ctr();
+}
+
+fn run_aes128_ccm() {
     debug!("check run AES128 CCM... ");
     run_kernel_op(100);
 
@@ -51,8 +62,7 @@ unsafe fn static_init_test_ccm(
     )
 }
 
-#[test_case]
-fn run001_aes128_gcm() {
+fn run_aes128_gcm() {
     debug!("check run AES128 GCM... ");
     run_kernel_op(100);
 
@@ -87,8 +97,7 @@ unsafe fn static_init_test_gcm(
     )
 }
 
-#[test_case]
-fn run002_aes128_ecb() {
+fn run_aes128_ecb() {
     debug!("check run AES128 ECB... ");
     run_kernel_op(100);
 
@@ -121,8 +130,7 @@ unsafe fn static_init_test_ecb(aes: &'static Aes) -> &'static TestAes128Ecb<'sta
     )
 }
 
-#[test_case]
-fn run003_aes128_cbc() {
+fn run_aes128_cbc() {
     debug!("check run AES128 CBC... ");
     run_kernel_op(100);
 
@@ -156,8 +164,7 @@ unsafe fn static_init_test_cbc(aes: &'static Aes) -> &'static TestAes128Cbc<'sta
     )
 }
 
-#[test_case]
-fn run004_aes128_ctr() {
+fn run_aes128_ctr() {
     debug!("check run AES128 CTR... ");
     run_kernel_op(100);
 

--- a/boards/opentitan/src/tests/flash_ctrl.rs
+++ b/boards/opentitan/src/tests/flash_ctrl.rs
@@ -119,6 +119,17 @@ macro_rules! static_init_test {
     }};
 }
 
+/// The only 'test_case' for flash_ctrl as directly invoked by the test runner,
+/// this calls all the other tests, preserving the order in which they must
+/// be ran.
+#[test_case]
+fn flash_ctrl_tester() {
+    flash_ctrl_read_write_page();
+    flash_ctrl_erase_page();
+    flash_ctrl_mp_basic();
+    flash_ctrl_mp_functionality();
+}
+
 // Note: the tests below need to run in a particular order, hence the a, b, c...
 // function name prefix (test runner seems to invoke them alphabetically).
 
@@ -126,8 +137,7 @@ macro_rules! static_init_test {
 ///
 /// Compare the data we wrote is stored in flash with a
 /// successive read.
-#[test_case]
-fn a_flash_ctrl_read_write_page() {
+fn flash_ctrl_read_write_page() {
     let perf = unsafe { PERIPHERALS.unwrap() };
     let flash_ctl = &perf.flash_ctrl;
 
@@ -186,8 +196,7 @@ fn a_flash_ctrl_read_write_page() {
 /// A page erased should set all bits to `1`s or all bytes in page to
 /// `0xFF`. Assert this is true after writing data to a page and erasing
 /// the page.
-#[test_case]
-fn b_flash_ctrl_erase_page() {
+fn flash_ctrl_erase_page() {
     let perf = unsafe { PERIPHERALS.unwrap() };
     let flash_ctl = &perf.flash_ctrl;
 
@@ -241,9 +250,8 @@ fn b_flash_ctrl_erase_page() {
     run_kernel_op(100);
 }
 
-#[test_case]
 /// Tests: The basic api functionality and error handling of invalid arguments.
-fn c_flash_ctrl_mp_basic() {
+fn flash_ctrl_mp_basic() {
     debug!("[FLASH_CTRL] Test memory protection api....");
 
     #[cfg(feature = "hardware_tests")]
@@ -327,10 +335,9 @@ fn c_flash_ctrl_mp_basic() {
     run_kernel_op(100);
 }
 
-#[test_case]
 /// Tests the memory protection functionality of the flash_ctrl
 /// Test: Setup memory protection -> Do bad OP/cause an MP Fault -> Expect fail/assert Err(FlashMPFault)
-fn d_flash_ctrl_mp_functionality() {
+fn flash_ctrl_mp_functionality() {
     debug!("[FLASH_CTRL] Test memory protection functionality....");
 
     #[cfg(feature = "hardware_tests")]


### PR DESCRIPTION
### Pull Request Overview

To ensure  we don't rely on the test runner to organize the tests in a particular way. Let's fix the order. Implemented by adding a single test case (invoked by test runner), in which we call the individual tests in the order required. @alistair23 


### Testing Strategy

running all of tests through verilator

```
I00000 test_rom.c:160] kChipInfo: scm_revision=61abdf5c
I00001 test_rom.c:243] Test ROM complete, jumping to flash (addr: 20000400)!
Unable to find otbn-rsa, disabling RSA support
OpenTitan initialisation complete. Entering main loop
check run AES128 CCM... 
AES CCM* encryption/decryption tests
    [ok]
check run AES128 GCM... 
AES GCM* encryption/decryption tests
aes_gcm_test passed: (current_test=0, encrypting=true, tag_is_valid=true)
aes_gcm_test passed: (current_test=0, encrypting=false, tag_is_valid=true)
aes_gcm_test passed: (current_test=1, encrypting=true, tag_is_valid=true)
aes_gcm_test passed: (current_test=1, encrypting=false, tag_is_valid=true)
    [ok]
check run AES128 ECB... 
aes_test passed (ECB Enc Src/Dst)
aes_test passed (ECB Enc In-place)
aes_test passed (ECB Dec Src/Dst)
aes_test passed (ECB Dec In-place)
    [ok]
check run AES128 CBC... 
aes_test passed (CBC Enc Src/Dst)
aes_test passed (CBC Enc In-place)
aes_test passed (CBC Dec Src/Dst)
aes_test passed (CBC Dec In-place)
    [ok]
check run AES128 CTR... 
aes_test CTR passed: (CTR Enc Ctr Src/Dst)
aes_test CTR passed: (CTR Enc Ctr In-place)
aes_test CTR passed: (CTR Dec Ctr Src/Dst)
aes_test CTR passed: (CTR Dec Ctr In-place)
    [ok]
check run CSRNG Entropy 32... 
Entropy32 test: first get Ok(())
Entropy test: obtained all 8 values. They are:
[00]: 735b27a0
[01]: 497b246f
[02]: 9a8f9420
[03]: 91618fe9
[04]: e07e680b
[05]: 01aec0b9
[06]: 3ca6b2a0
[07]: 19078a9d
    [ok]
[FLASH_CTRL] Test page read/write....
    [ok]
[FLASH_CTRL] Test page erase....
    [ok]
[FLASH_CTRL] Test memory protection api....
    [ok]
[FLASH_CTRL] Test memory protection functionality....
    [ok]
check hmac load binary... 
    [ok]
check hmac check verify... 
    [ok]
start multi alarm test...
    [ok]
check otbn run binary...
    [FAIL] No OTBN binary
Not running RSA tests
Not running RSA tests
check rsa key import... 
    [ok]
Not running RSA tests
check rsa 4096 bit key import... 
    [ok]
start SHA256 verify test
Sha256Test: Setting slice to 12..24
Sha256Test: Setting slice to 24..36
Sha256Test: Setting slice to 36..48
Sha256Test: Setting slice to 48..60
Sha256Test: Setting slice to 60..72
Sha256Test: Verification result: Ok(true)
    [ok]
check SipHash 2-4... 
    [ok]
[SPI] Setup spi_host0 partial_transfer... 
    [ok]
[SPI] Setup spi_host0 transfers... 
    [ok]
[SPI] Setup spi_host0 transfer...x2 
    [ok]
start TicKV append key test...
---Starting TicKV Tests---
Generated key: [61, 245, 130, 62, 163, 73, 69, 239]
Now appending the key
    [ok]
trivial assertion... 
    [ok]
```


### TODO or Help Wanted

Thought on this? The main reason for this change is, so that we don't rely on the order set by the test-runner as that maybe subject to change...potentially.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
