### PR TITLE
TicKV: Fix garabage collect for async and update tests

### DIFF
--- a/capsules/extra/src/tickv.rs
+++ b/capsules/extra/src/tickv.rs
@@ -755,7 +755,10 @@ impl<'a, F: Flash, H: Hasher<'a, 8>, const PAGE_SIZE: usize> KVSystem<'a>
         match self.operation.get() {
             Operation::None => {
                 self.operation.set(Operation::GarbageCollect);
-                self.tickv.garbage_collect().or(Err(ErrorCode::FAIL))
+                self.tickv
+                    .garbage_collect()
+                    .and(Ok(()))
+                    .or(Err(ErrorCode::FAIL))
             }
             Operation::Init => {
                 // The init process is still occurring.

--- a/libraries/tickv/src/async_ops.rs
+++ b/libraries/tickv/src/async_ops.rs
@@ -570,15 +570,26 @@ mod tests {
             }
         }
 
+        /// This function implements what would happen in the callback function
+        /// triggered by the underlying flash hardware. In effect, it is the
+        /// callback handler, but since we don't actually have an async flash
+        /// implementation, this is just called by each test after starting the
+        /// flash operation.
         fn flash_ctrl_callback(tickv: &AsyncTicKV<FlashCtrl, 1024>) {
             match tickv.tickv.controller.get_waiting_action() {
                 FlashCtrlAction::Read => {
+                    // This mimics a read is complete, and we provide the buffer
+                    // with the newly read data to the tickv layer.
                     tickv.set_read_buffer(
                         &tickv.tickv.controller.buf.borrow()
                             [tickv.tickv.controller.async_read_region.get()],
                     );
                 }
-                _ => {}
+                _ => {
+                    // For write an erase all of the operation already occurred
+                    // in the original operation, and nothing needs to be done
+                    // in the simulated callback.
+                }
             }
         }
 

--- a/libraries/tickv/src/async_ops.rs
+++ b/libraries/tickv/src/async_ops.rs
@@ -280,12 +280,12 @@ impl<'a, C: FlashController<S>, const S: usize> AsyncTicKV<'a, C, S> {
 
     /// Perform a garbage collection on TicKV
     ///
-    /// On success nothing is returned.
+    /// On success a `SuccessCode` will be returned.
     /// On error a `ErrorCode` will be returned.
-    pub fn garbage_collect(&self) -> Result<(), ErrorCode> {
+    pub fn garbage_collect(&self) -> Result<SuccessCode, ErrorCode> {
         match self.tickv.garbage_collect() {
             Ok(_code) => Err(ErrorCode::EraseFail),
-            Err(_e) => Ok(()),
+            Err(_e) => Ok(SuccessCode::Queued),
         }
     }
 
@@ -339,7 +339,7 @@ impl<'a, C: FlashController<S>, const S: usize> AsyncTicKV<'a, C, S> {
             }
             State::InvalidateKey(_) => (self.tickv.invalidate_key(self.key.get().unwrap()), 0),
             State::GarbageCollect(_) => match self.tickv.garbage_collect() {
-                Ok(_) => (Ok(SuccessCode::Complete), 0),
+                Ok(bytes_freed) => (Ok(SuccessCode::Complete), bytes_freed),
                 Err(e) => (Err(e), 0),
             },
             _ => unreachable!(),


### PR DESCRIPTION
### Pull Request Overview

This pull request updates tickv to properly track the number of bytes freed on a garbage collect.

It also updates the async tests to use a more realistic async flash layer.


### Testing Strategy

`cargo test`:

```
cargo test
   Compiling tickv v1.0.0 (/Users/bradjc/git/tock/libraries/tickv)
    Finished test [optimized + debuginfo] target(s) in 1.58s
     Running unittests src/lib.rs (/Users/bradjc/git/tock/target/debug/deps/tickv-a394fef075a31e21)

running 11 tests
test tests::simple_flash_ctrl::test_init ... ok
test tests::no_check_store_flast_ctrl::test_region_full ... ok
test tests::single_erase_flash_ctrl::test_double_init ... ok
test async_ops::tests::store_flast_ctrl::test_simple_append ... ok
test async_ops::tests::store_flast_ctrl::test_append_and_delete ... ok
test async_ops::tests::store_flast_ctrl::test_double_append ... ok
test async_ops::tests::store_flast_ctrl::test_garbage_collect ... ok
test tests::store_flast_ctrl::test_append_and_delete ... ok
test tests::store_flast_ctrl::test_double_append ... ok
test tests::store_flast_ctrl::test_simple_append ... ok
test tests::store_flast_ctrl::test_garbage_collect ... ok

test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests tickv

running 3 tests
test libraries/tickv/src/flash_controller.rs - flash_controller::FlashController (line 29) ... ok
test libraries/tickv/src/async_ops.rs - async_ops (line 12) ... ok
test libraries/tickv/src/lib.rs - (line 96) ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.63s
```


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
