### PR TITLE
doc: remove dangling reference to IRC

### DIFF
--- a/doc/OutOfTree.md
+++ b/doc/OutOfTree.md
@@ -34,7 +34,7 @@ abreast of Tock development:
     wait at least one week to merge to allow for feedback.
 
 Finally, please don't hesitate to
-[ask for help](https://kiwiirc.com/client/irc.freenode.net/tock).
+[ask for help](https://github.com/tock/tock/#keep-up-to-date).
 
 
 Structure


### PR DESCRIPTION
### Pull Request Overview

This pull request removes a lingering reference to the old IRC channel.

### Testing Strategy

N/A

### TODO or Help Wanted

N/A

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
