### PR TITLE
workflows/litex_sim: add mirror for the pre-compiled RISC-V toolchain

### DIFF
--- a/.github/workflows/litex_sim.yml
+++ b/.github/workflows/litex_sim.yml
@@ -52,10 +52,23 @@ jobs:
       # follows the libtock-c GitHub actions definition.
       - name: Setup RISC-V GCC toolchain
         run: |
+          RISCV_TOOLCHAIN_MIRRORS=(\
+            "http://cs.virginia.edu/~bjc8c/archive/gcc-riscv64-unknown-elf-8.3.0-ubuntu.zip" \
+            "https://alpha.mirror.svc.schuermann.io/files/2023-08-17_gcc-riscv64-unknown-elf-8.3.0-ubuntu.zip"\
+          )
           pushd $HOME
-          wget -q http://cs.virginia.edu/~bjc8c/archive/gcc-riscv64-unknown-elf-8.3.0-ubuntu.zip
-          echo "2c82a8f3ac77bf2b24d66abff3aa5e873750c76de24c77e12dae91b9d2f4da27 gcc-riscv64-unknown-elf-8.3.0-ubuntu.zip" | sha256sum -c
-          unzip gcc-riscv64-unknown-elf-8.3.0-ubuntu.zip
+          for MIRROR in ${RISCV_TOOLCHAIN_MIRRORS[@]}; do
+            echo "Fetching RISC-V toolchain from ${MIRROR}..."
+            wget -Oriscv-toolchain.zip -q "$MIRROR" &&\
+              (echo "2c82a8f3ac77bf2b24d66abff3aa5e873750c76de24c77e12dae91b9d2f4da27 riscv-toolchain.zip" |\
+                sha256sum -c)
+            if [ $? -ne 0 ]; then
+              echo "WARNING: Fetching RISC-V from mirror $MIRROR failed!" >&2
+            else
+              break
+            fi
+          done
+          unzip riscv-toolchain.zip
           echo "$HOME/gcc-riscv64-unknown-elf-8.3.0-ubuntu/bin" >> $GITHUB_PATH
           popd
 


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the LiteX sim CI workflow by adding another mirror to fetch the pre-compiled toolchain from. UVA seems to have some network issues right now, and luckily I still had a version of this toolchain in my local archives. I won't make any promises on the availability of my mirror, but we're still preferring UVA and performing checksumming on the downloaded file, so I think this should be relatively low risk.


### Testing Strategy

This pull request was tested by CI.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
