### PR TITLE
litex_sim CI: fix RISC-V precompiled GCC toolchain URL

### DIFF
--- a/.github/workflows/litex_sim.yml
+++ b/.github/workflows/litex_sim.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup RISC-V GCC toolchain
         run: |
           RISCV_TOOLCHAIN_MIRRORS=(\
-            "http://cs.virginia.edu/~bjc8c/archive/gcc-riscv64-unknown-elf-8.3.0-ubuntu.zip" \
+            "http://www.cs.virginia.edu/~bjc8c/archive/gcc-riscv64-unknown-elf-8.3.0-ubuntu.zip" \
             "https://alpha.mirror.svc.schuermann.io/files/2023-08-17_gcc-riscv64-unknown-elf-8.3.0-ubuntu.zip"\
           )
           pushd $HOME


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the virginia.edu mirror URL to our precompiled RISC-V gcc toolchain to include `www.`, as per https://github.com/tock/tock/pull/3621#issuecomment-1683215173.


### Testing Strategy

This pull request was tested by CI.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
