### PR TITLE
clippy: -D ptr_eq

### DIFF
--- a/capsules/core/src/virtualizers/virtual_rng.rs
+++ b/capsules/core/src/virtualizers/virtual_rng.rs
@@ -121,7 +121,7 @@ impl<'a> VirtualRngMasterDevice<'a> {
 impl<'a> PartialEq<VirtualRngMasterDevice<'a>> for VirtualRngMasterDevice<'a> {
     fn eq(&self, other: &VirtualRngMasterDevice<'a>) -> bool {
         // Check whether two rng devices point to the same device
-        self as *const VirtualRngMasterDevice<'a> == other as *const VirtualRngMasterDevice<'a>
+        core::ptr::eq(self, other)
     }
 }
 

--- a/capsules/extra/src/ieee802154/virtual_mac.rs
+++ b/capsules/extra/src/ieee802154/virtual_mac.rs
@@ -165,7 +165,7 @@ impl<'a> MuxMac<'a> {
         new_node: &MacUser<'a>,
     ) -> Option<Result<(), (ErrorCode, &'static mut [u8])>> {
         self.get_next_op_if_idle().and_then(|(node, op)| {
-            if node as *const _ == new_node as *const _ {
+            if core::ptr::eq(node, new_node) {
                 // The new node's operation is the one being scheduled, so the
                 // operation is synchronous
                 self.perform_op_sync(node, op)

--- a/kernel/src/scheduler/mlfq.rs
+++ b/kernel/src/scheduler/mlfq.rs
@@ -117,7 +117,7 @@ impl<'a, A: 'static + time::Alarm<'static>> MLFQSched<'a, A> {
                     let cur = queue.pop_head();
                     match cur {
                         Some(node) => {
-                            if node as *const _ == next.unwrap() as *const _ {
+                            if core::ptr::eq(node, next.unwrap()) {
                                 queue.push_head(node);
                                 // match! Put back on front
                                 return (next, idx);

--- a/tools/run_clippy.sh
+++ b/tools/run_clippy.sh
@@ -31,6 +31,7 @@ CLIPPY_ARGS="
 -D clippy::empty_line_after_outer_attr
 -D clippy::default_trait_access
 -D clippy::map_unwrap_or
+-D clippy::ptr_eq
 -D clippy::wildcard_imports
 "
 


### PR DESCRIPTION
### Pull Request Overview

This pull request changes code to use `core::ptr::eq()` instead of `==`. I guess this is better?

https://rust-lang.github.io/rust-clippy/master/index.html#/ptr_eq

### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
