### PR TITLE
clippy: Address several complexity lints

### DIFF
--- a/arch/cortex-m/src/mpu.rs
+++ b/arch/cortex-m/src/mpu.rs
@@ -361,11 +361,7 @@ impl CortexMRegion {
             None => return false,
         };
 
-        if region_start < other_end && other_start < region_end {
-            true
-        } else {
-            false
-        }
+        region_start < other_end && other_start < region_end
     }
 }
 

--- a/arch/rv32i/src/epmp.rs
+++ b/arch/rv32i/src/epmp.rs
@@ -368,11 +368,7 @@ impl PMPRegion {
 
         // PMP addresses are not inclusive on the high end, that is
         //     pmpaddr[i-i] <= y < pmpaddr[i]
-        if region_start < (other_end - 4) && other_start < (region_end - 4) {
-            true
-        } else {
-            false
-        }
+        region_start < (other_end - 4) && other_start < (region_end - 4)
     }
 }
 

--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -214,11 +214,7 @@ impl PMPRegion {
 
         // PMP addresses are not inclusive on the high end, that is
         //     pmpaddr[i-i] <= y < pmpaddr[i]
-        if region_start < (other_end - 4) && other_start < (region_end - 4) {
-            true
-        } else {
-            false
-        }
+        region_start < (other_end - 4) && other_start < (region_end - 4)
     }
 }
 

--- a/boards/components/src/fxos8700.rs
+++ b/boards/components/src/fxos8700.rs
@@ -49,7 +49,7 @@ pub struct Fxos8700Component<I: 'static + i2c::I2CMaster<'static>> {
 }
 
 impl<I: 'static + i2c::I2CMaster<'static>> Fxos8700Component<I> {
-    pub fn new<'a>(
+    pub fn new(
         i2c: &'static MuxI2C<'static, I>,
         i2c_address: u8,
         gpio: &'static dyn hil::gpio::InterruptPin<'static>,

--- a/boards/components/src/kv.rs
+++ b/boards/components/src/kv.rs
@@ -88,7 +88,7 @@ pub struct KVPermissionsMuxComponent<V: hil::kv::KVPermissions<'static> + 'stati
     kv: &'static V,
 }
 
-impl<'a, V: hil::kv::KVPermissions<'static>> KVPermissionsMuxComponent<V> {
+impl<V: hil::kv::KVPermissions<'static>> KVPermissionsMuxComponent<V> {
     pub fn new(kv: &'static V) -> KVPermissionsMuxComponent<V> {
         Self { kv }
     }
@@ -123,7 +123,7 @@ pub struct VirtualKVPermissionsComponent<V: hil::kv::KVPermissions<'static> + 's
     mux_kv: &'static MuxKVPermissions<'static, V>,
 }
 
-impl<'a, V: hil::kv::KVPermissions<'static>> VirtualKVPermissionsComponent<V> {
+impl<V: hil::kv::KVPermissions<'static>> VirtualKVPermissionsComponent<V> {
     pub fn new(mux_kv: &'static MuxKVPermissions<'static, V>) -> VirtualKVPermissionsComponent<V> {
         Self { mux_kv }
     }

--- a/boards/hail/src/test_take_map_cell.rs
+++ b/boards/hail/src/test_take_map_cell.rs
@@ -35,7 +35,7 @@ pub unsafe fn test_take_map_cell() {
 
 #[inline(never)]
 #[allow(unused_unsafe)]
-unsafe fn test_map_cell<'a, A>(tc: &MapCell<A>) {
+unsafe fn test_map_cell<A>(tc: &MapCell<A>) {
     let dwt_ctl: *mut u32 = 0xE0001000 as *mut u32;
     let dwt_cycles: *mut u32 = 0xE0001004 as *mut u32;
     let demcr: *mut u32 = 0xE000EDFC as *mut u32;

--- a/boards/imix/src/test/crc_test.rs
+++ b/boards/imix/src/test/crc_test.rs
@@ -37,7 +37,7 @@ unsafe fn static_init_crc(crc: &'static Crccu) -> &'static TestCrc<'static, Crcc
     let data = static_init!([u8; 9], [0; 9]);
 
     for i in 0..9 {
-        data[i] = i as u8 + ('1' as u8);
+        data[i] = i as u8 + b'1';
     }
     static_init!(TestCrc<'static, Crccu>, TestCrc::new(crc, data))
 }

--- a/capsules/core/src/gpio.rs
+++ b/capsules/core/src/gpio.rs
@@ -113,7 +113,7 @@ impl<'a, IP: gpio::InterruptPin<'a>> GPIO<'a, IP> {
     }
 
     fn configure_interrupt(&self, pin_num: u32, config: usize) -> CommandReturn {
-        let pins = self.pins.as_ref();
+        let pins = self.pins;
         let index = pin_num as usize;
         if let Some(pin) = pins[index] {
             match config {
@@ -143,7 +143,7 @@ impl<'a, IP: gpio::InterruptPin<'a>> GPIO<'a, IP> {
 impl<'a, IP: gpio::InterruptPin<'a>> gpio::ClientWithValue for GPIO<'a, IP> {
     fn fired(&self, pin_num: u32) {
         // read the value of the pin
-        let pins = self.pins.as_ref();
+        let pins = self.pins;
         if let Some(pin) = pins[pin_num as usize] {
             let pin_state = pin.read();
 
@@ -195,7 +195,7 @@ impl<'a, IP: gpio::InterruptPin<'a>> SyscallDriver for GPIO<'a, IP> {
         data2: usize,
         _: ProcessId,
     ) -> CommandReturn {
-        let pins = self.pins.as_ref();
+        let pins = self.pins;
         let pin_index = data1;
         match command_num {
             // number of pins

--- a/capsules/core/src/process_console.rs
+++ b/capsules/core/src/process_console.rs
@@ -46,25 +46,25 @@ const VALID_COMMANDS_STR: &[u8] =
     b"help status list stop start fault boot terminate process kernel reset panic console-start console-stop\r\n";
 
 /// Escape character for ANSI escape sequences.
-const ESC: u8 = '\x1B' as u8;
+const ESC: u8 = b'\x1B';
 
 /// End of line character.
-const EOL: u8 = '\x00' as u8;
+const EOL: u8 = b'\x00';
 
 /// Backspace ANSI character
-const BS: u8 = '\x08' as u8;
+const BS: u8 = b'\x08';
 
 /// Delete ANSI character
-const DEL: u8 = '\x7F' as u8;
+const DEL: u8 = b'\x7F';
 
 /// Space ANSI character
-const SPACE: u8 = '\x20' as u8;
+const SPACE: u8 = b'\x20';
 
 /// Carriage return ANSI character
-const CR: u8 = '\x0D' as u8;
+const CR: u8 = b'\x0D';
 
 /// Newline ANSI character
-const NLINE: u8 = '\x0A' as u8;
+const NLINE: u8 = b'\x0A';
 
 /// Upper limit for ASCII characters
 const ASCII_LIMIT: u8 = 128;
@@ -72,8 +72,9 @@ const ASCII_LIMIT: u8 = 128;
 /// States used for state machine to allow printing large strings asynchronously
 /// across multiple calls. This reduces the size of the buffer needed to print
 /// each section of the debug message.
-#[derive(PartialEq, Eq, Copy, Clone)]
+#[derive(PartialEq, Eq, Copy, Clone, Default)]
 enum WriterState {
+    #[default]
     Empty,
     KernelStart,
     KernelBss,
@@ -89,12 +90,6 @@ enum WriterState {
         index: isize,
         total: isize,
     },
-}
-
-impl Default for WriterState {
-    fn default() -> Self {
-        WriterState::Empty
-    }
 }
 
 /// Key that can be part from an escape sequence.
@@ -436,7 +431,7 @@ impl ConsoleWriter {
 impl fmt::Write for ConsoleWriter {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         let curr = (s).as_bytes().len();
-        self.buf[self.size..self.size + curr].copy_from_slice(&(s).as_bytes()[..]);
+        self.buf[self.size..self.size + curr].copy_from_slice((s).as_bytes());
         self.size += curr;
         Ok(())
     }

--- a/capsules/core/src/spi_controller.rs
+++ b/capsules/core/src/spi_controller.rs
@@ -257,7 +257,7 @@ impl<'a, S: SpiMasterDevice<'a>> SyscallDriver for Spi<'a, S> {
                 // set baud rate
                 match self.spi_master.set_rate(arg1 as u32) {
                     Ok(()) => CommandReturn::success(),
-                    Err(error) => CommandReturn::failure(error.into()),
+                    Err(error) => CommandReturn::failure(error),
                 }
             }
             6 => {
@@ -271,7 +271,7 @@ impl<'a, S: SpiMasterDevice<'a>> SyscallDriver for Spi<'a, S> {
                     _ => self.spi_master.set_phase(ClockPhase::SampleTrailing),
                 } {
                     Ok(()) => CommandReturn::success(),
-                    Err(error) => CommandReturn::failure(error.into()),
+                    Err(error) => CommandReturn::failure(error),
                 }
             }
             8 => {
@@ -285,7 +285,7 @@ impl<'a, S: SpiMasterDevice<'a>> SyscallDriver for Spi<'a, S> {
                     _ => self.spi_master.set_polarity(ClockPolarity::IdleHigh),
                 } {
                     Ok(()) => CommandReturn::success(),
-                    Err(error) => CommandReturn::failure(error.into()),
+                    Err(error) => CommandReturn::failure(error),
                 }
             }
             10 => {

--- a/capsules/core/src/spi_peripheral.rs
+++ b/capsules/core/src/spi_peripheral.rs
@@ -233,7 +233,7 @@ impl<'a, S: SpiSlaveDevice<'a>> SyscallDriver for SpiPeripheral<'a, S> {
                     _ => self.spi_slave.set_phase(ClockPhase::SampleTrailing),
                 } {
                     Ok(()) => CommandReturn::success(),
-                    Err(error) => CommandReturn::failure(error.into()),
+                    Err(error) => CommandReturn::failure(error),
                 }
             }
             4 => {
@@ -247,7 +247,7 @@ impl<'a, S: SpiSlaveDevice<'a>> SyscallDriver for SpiPeripheral<'a, S> {
                     _ => self.spi_slave.set_polarity(ClockPolarity::IdleHigh),
                 } {
                     Ok(()) => CommandReturn::success(),
-                    Err(error) => CommandReturn::failure(error.into()),
+                    Err(error) => CommandReturn::failure(error),
                 }
             }
             6 => {

--- a/capsules/extra/src/air_quality.rs
+++ b/capsules/extra/src/air_quality.rs
@@ -34,17 +34,12 @@ use kernel::{ErrorCode, ProcessId};
 use capsules_core::driver;
 pub const DRIVER_NUM: usize = driver::NUM::AirQuality as usize;
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Default)]
 enum Operation {
+    #[default]
     None,
     CO2,
     TVOC,
-}
-
-impl Default for Operation {
-    fn default() -> Self {
-        Operation::None
-    }
 }
 
 #[derive(Default)]

--- a/capsules/extra/src/app_flash_driver.rs
+++ b/capsules/extra/src/app_flash_driver.rs
@@ -104,9 +104,7 @@ impl<'a> AppFlash<'a> {
                                     .map_or(Err(ErrorCode::RESERVE), |buffer| {
                                         let length = cmp::min(buffer.len(), app_buffer.len());
                                         let d = &app_buffer[0..length];
-                                        for (i, c) in
-                                            buffer.as_mut()[0..length].iter_mut().enumerate()
-                                        {
+                                        for (i, c) in buffer[0..length].iter_mut().enumerate() {
                                             *c = d[i].get();
                                         }
 
@@ -164,9 +162,7 @@ impl hil::nonvolatile_storage::NonvolatileStorageClient for AppFlash<'_> {
                                         // Copy contents to internal buffer and write it.
                                         let length = cmp::min(buffer.len(), app_buffer.len());
                                         let d = &app_buffer[0..length];
-                                        for (i, c) in
-                                            buffer.as_mut()[0..length].iter_mut().enumerate()
-                                        {
+                                        for (i, c) in buffer[0..length].iter_mut().enumerate() {
                                             *c = d[i].get();
                                         }
 

--- a/capsules/extra/src/ble_advertising_driver.rs
+++ b/capsules/extra/src/ble_advertising_driver.rs
@@ -642,7 +642,7 @@ where
                                 self.reset_active_alarm();
                                 CommandReturn::success()
                             }
-                            Err(e) => CommandReturn::failure(e.into()),
+                            Err(e) => CommandReturn::failure(e),
                         },
                     )
             }
@@ -710,14 +710,13 @@ where
                                 self.reset_active_alarm();
                                 CommandReturn::success()
                             }
-                            Err(e) => CommandReturn::failure(e.into()),
+                            Err(e) => CommandReturn::failure(e),
                         },
                     )
             }
 
             _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
         }
-        .into()
     }
 
     fn allocate_grant(&self, processid: ProcessId) -> Result<(), kernel::process::Error> {

--- a/capsules/extra/src/bme280.rs
+++ b/capsules/extra/src/bme280.rs
@@ -53,7 +53,7 @@ enum Operation {
     Humidity,
 }
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Default)]
 struct CalibrationData {
     temp1: u16,
     temp2: u16,
@@ -75,33 +75,6 @@ struct CalibrationData {
     hum4: u16,
     hum5: u16,
     hum6: u16,
-}
-
-impl Default for CalibrationData {
-    fn default() -> Self {
-        CalibrationData {
-            temp1: 0,
-            temp2: 0,
-            temp3: 0,
-
-            press1: 0,
-            press2: 0,
-            press3: 0,
-            press4: 0,
-            press5: 0,
-            press6: 0,
-            press7: 0,
-            press8: 0,
-            press9: 0,
-
-            hum1: 0,
-            hum2: 0,
-            hum3: 0,
-            hum4: 0,
-            hum5: 0,
-            hum6: 0,
-        }
-    }
 }
 
 pub struct Bme280<'a> {

--- a/capsules/extra/src/buzzer_driver.rs
+++ b/capsules/extra/src/buzzer_driver.rs
@@ -182,16 +182,8 @@ impl<'a, B: hil::buzzer::Buzzer<'a>> Buzzer<'a, B> {
     /// to the current active_app. Otherwise, a different app is trying to
     /// use the driver while it is already in use, therefore it is not valid.
     pub fn is_valid_app(&self, processid: ProcessId) -> bool {
-        self.active_app.map_or(
-            true,
-            |owning_app| {
-                if owning_app == processid {
-                    true
-                } else {
-                    false
-                }
-            },
-        )
+        self.active_app
+            .map_or(true, |owning_app| owning_app == processid)
     }
 }
 

--- a/capsules/extra/src/can.rs
+++ b/capsules/extra/src/can.rs
@@ -113,18 +113,10 @@ pub struct CanCapsule<'a, Can: can::Can> {
     peripheral_state: OptionalCell<can::State>,
 }
 
+#[derive(Default)]
 pub struct App {
     receive_index: usize,
     lost_messages: u32,
-}
-
-impl Default for App {
-    fn default() -> Self {
-        App {
-            receive_index: 0,
-            lost_messages: 0,
-        }
-    }
 }
 
 impl<'a, Can: can::Can> CanCapsule<'a, Can> {
@@ -318,7 +310,7 @@ impl<'a, Can: can::Can> SyscallDriver for CanCapsule<'a, Can> {
                                         Ok(_) => CommandReturn::success(),
                                         Err((err, _)) => CommandReturn::failure(err),
                                     },
-                                    Err(err) => CommandReturn::failure(err.into()),
+                                    Err(err) => CommandReturn::failure(err),
                                 }
                             })
                             .unwrap_or_else(|err| err.into())

--- a/capsules/extra/src/gpio_async.rs
+++ b/capsules/extra/src/gpio_async.rs
@@ -76,7 +76,7 @@ impl<'a, Port: hil::gpio_async::Port> GPIOAsync<'a, Port> {
     }
 
     fn configure_input_pin(&self, port: usize, pin: usize, config: usize) -> Result<(), ErrorCode> {
-        let ports = self.ports.as_ref();
+        let ports = self.ports;
         let mode = match config {
             0 => hil::gpio::FloatingState::PullNone,
             1 => hil::gpio::FloatingState::PullUp,
@@ -87,7 +87,7 @@ impl<'a, Port: hil::gpio_async::Port> GPIOAsync<'a, Port> {
     }
 
     fn configure_interrupt(&self, port: usize, pin: usize, config: usize) -> Result<(), ErrorCode> {
-        let ports = self.ports.as_ref();
+        let ports = self.ports;
         let mode = match config {
             0 => hil::gpio::InterruptEdge::EitherEdge,
             1 => hil::gpio::InterruptEdge::RisingEdge,
@@ -167,7 +167,7 @@ impl<Port: hil::gpio_async::Port> SyscallDriver for GPIOAsync<'_, Port> {
     ) -> CommandReturn {
         let port = data & 0xFFFF;
         let other = (data >> 16) & 0xFFFF;
-        let ports = self.ports.as_ref();
+        let ports = self.ports;
 
         // Special case command 0; everything else results in a process-owned,
         // split-phase call.

--- a/capsules/extra/src/ieee802154/driver.rs
+++ b/capsules/extra/src/ieee802154/driver.rs
@@ -43,19 +43,10 @@ mod rw_allow {
 use capsules_core::driver;
 pub const DRIVER_NUM: usize = driver::NUM::Ieee802154 as usize;
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Default)]
 struct DeviceDescriptor {
     short_addr: u16,
     long_addr: [u8; 8],
-}
-
-impl Default for DeviceDescriptor {
-    fn default() -> Self {
-        DeviceDescriptor {
-            short_addr: 0,
-            long_addr: [0; 8],
-        }
-    }
 }
 
 /// The Key ID mode mapping expected by the userland driver
@@ -879,7 +870,7 @@ impl SyscallDriver for RadioDriver<'_> {
                         |err| CommandReturn::failure(err.into()),
                         |setup_tx| match setup_tx {
                             Ok(_) => self.do_next_tx_sync(processid).into(),
-                            Err(e) => CommandReturn::failure(e.into()),
+                            Err(e) => CommandReturn::failure(e),
                         },
                     )
             }

--- a/capsules/extra/src/kv_driver.rs
+++ b/capsules/extra/src/kv_driver.rs
@@ -349,7 +349,7 @@ impl<'a, V: kv::KVPermissions<'a>> kv::KVClient for KVStoreDriver<'a, V> {
                         upcalls
                             .schedule_upcall(
                                 upcalls::VALUE,
-                                (errorcode::into_statuscode(ret.into()), value_len, 0),
+                                (errorcode::into_statuscode(ret), value_len, 0),
                             )
                             .ok();
                     }

--- a/capsules/extra/src/l3gd20.rs
+++ b/capsules/extra/src/l3gd20.rs
@@ -379,7 +379,7 @@ impl SyscallDriver for L3gd20Spi<'_> {
             // Set High Pass Filter Mode and Divider
             5 => {
                 if self.status.get() == L3gd20Status::Idle {
-                    let enabled = if data1 == 1 { true } else { false };
+                    let enabled = data1 == 1;
                     self.enable_hpf(enabled);
                     CommandReturn::success()
                 } else {
@@ -427,11 +427,7 @@ impl spi::SpiMasterClient for L3gd20Spi<'_> {
                 self.status.set(match self.status.get() {
                     L3gd20Status::IsPresent => {
                         let present = if let Some(ref buf) = read_buffer {
-                            if buf[1] == L3GD20_WHO_AM_I {
-                                true
-                            } else {
-                                false
-                            }
+                            buf[1] == L3GD20_WHO_AM_I
                         } else {
                             false
                         };

--- a/capsules/extra/src/led_matrix.rs
+++ b/capsules/extra/src/led_matrix.rs
@@ -212,7 +212,7 @@ impl<'a, L: Pin, A: Alarm<'a>> LedMatrixDriver<'a, L, A> {
     fn off_index(&self, led_index: usize) -> Result<(), ErrorCode> {
         if led_index < self.rows.len() * self.cols.len() {
             self.buffer
-                .map(|bits| bits[led_index / 8] = bits[led_index / 8] & !(1 << led_index % 8));
+                .map(|bits| bits[led_index / 8] = bits[led_index / 8] & !(1 << (led_index % 8)));
             Ok(())
         } else {
             Err(ErrorCode::INVAL)
@@ -286,9 +286,6 @@ impl<'a, L: Pin, A: Alarm<'a>> Led for LedMatrixLed<'a, L, A> {
     }
 
     fn read(&self) -> bool {
-        match self.matrix.read(self.col, self.row) {
-            Ok(v) => v,
-            Err(_) => false,
-        }
+        self.matrix.read(self.col, self.row).unwrap_or(false)
     }
 }

--- a/capsules/extra/src/lsm303agr.rs
+++ b/capsules/extra/src/lsm303agr.rs
@@ -409,7 +409,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303agrI2C<'_, I> {
     fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
         match self.state.get() {
             State::IsPresent => {
-                let present = status == Ok(()) && buffer[0] == 60;
+                let present = status.is_ok() && buffer[0] == 60;
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(pid, |_app, upcalls| {
                         upcalls

--- a/capsules/extra/src/lsm303agr.rs
+++ b/capsules/extra/src/lsm303agr.rs
@@ -409,11 +409,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303agrI2C<'_, I> {
     fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
         match self.state.get() {
             State::IsPresent => {
-                let present = if status == Ok(()) && buffer[0] == 60 {
-                    true
-                } else {
-                    false
-                };
+                let present = status == Ok(()) && buffer[0] == 60;
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(pid, |_app, upcalls| {
                         upcalls
@@ -658,8 +654,7 @@ impl<I: i2c::I2CDevice> SyscallDriver for Lsm303agrI2C<'_, I> {
             2 => {
                 if self.state.get() == State::Idle {
                     if let Some(data_rate) = Lsm303AccelDataRate::from_usize(data1) {
-                        match self.set_power_mode(data_rate, if data2 != 0 { true } else { false })
-                        {
+                        match self.set_power_mode(data_rate, data2 != 0) {
                             Ok(()) => CommandReturn::success(),
                             Err(error) => CommandReturn::failure(error),
                         }
@@ -674,9 +669,7 @@ impl<I: i2c::I2CDevice> SyscallDriver for Lsm303agrI2C<'_, I> {
             3 => {
                 if self.state.get() == State::Idle {
                     if let Some(scale) = Lsm303Scale::from_usize(data1) {
-                        match self
-                            .set_scale_and_resolution(scale, if data2 != 0 { true } else { false })
-                        {
+                        match self.set_scale_and_resolution(scale, data2 != 0) {
                             Ok(()) => CommandReturn::success(),
                             Err(error) => CommandReturn::failure(error),
                         }

--- a/capsules/extra/src/lsm303dlhc.rs
+++ b/capsules/extra/src/lsm303dlhc.rs
@@ -402,11 +402,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303dlhcI2C<'_, I> {
     fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
         match self.state.get() {
             State::IsPresent => {
-                let present = if status == Ok(()) && buffer[0] == 60 {
-                    true
-                } else {
-                    false
-                };
+                let present = status == Ok(()) && buffer[0] == 60;
 
                 self.current_process.map(|process_id| {
                     let _ = self.apps.enter(process_id, |_grant, upcalls| {
@@ -685,8 +681,7 @@ impl<I: i2c::I2CDevice> SyscallDriver for Lsm303dlhcI2C<'_, I> {
             2 => {
                 if self.state.get() == State::Idle {
                     if let Some(data_rate) = Lsm303AccelDataRate::from_usize(data1) {
-                        match self.set_power_mode(data_rate, if data2 != 0 { true } else { false })
-                        {
+                        match self.set_power_mode(data_rate, data2 != 0) {
                             Ok(()) => CommandReturn::success(),
                             Err(error) => CommandReturn::failure(error),
                         }
@@ -701,9 +696,7 @@ impl<I: i2c::I2CDevice> SyscallDriver for Lsm303dlhcI2C<'_, I> {
             3 => {
                 if self.state.get() == State::Idle {
                     if let Some(scale) = Lsm303Scale::from_usize(data1) {
-                        match self
-                            .set_scale_and_resolution(scale, if data2 != 0 { true } else { false })
-                        {
+                        match self.set_scale_and_resolution(scale, data2 != 0) {
                             Ok(()) => CommandReturn::success(),
                             Err(error) => CommandReturn::failure(error),
                         }
@@ -718,10 +711,7 @@ impl<I: i2c::I2CDevice> SyscallDriver for Lsm303dlhcI2C<'_, I> {
             4 => {
                 if self.state.get() == State::Idle {
                     if let Some(data_rate) = Lsm303MagnetoDataRate::from_usize(data1) {
-                        match self.set_temperature_and_magneto_data_rate(
-                            if data2 != 0 { true } else { false },
-                            data_rate,
-                        ) {
+                        match self.set_temperature_and_magneto_data_rate(data2 != 0, data_rate) {
                             Ok(()) => CommandReturn::success(),
                             Err(error) => CommandReturn::failure(error),
                         }

--- a/capsules/extra/src/lsm303dlhc.rs
+++ b/capsules/extra/src/lsm303dlhc.rs
@@ -402,7 +402,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303dlhcI2C<'_, I> {
     fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
         match self.state.get() {
             State::IsPresent => {
-                let present = status == Ok(()) && buffer[0] == 60;
+                let present = status.is_ok() && buffer[0] == 60;
 
                 self.current_process.map(|process_id| {
                     let _ = self.apps.enter(process_id, |_grant, upcalls| {

--- a/capsules/extra/src/lsm6dsoxtr.rs
+++ b/capsules/extra/src/lsm6dsoxtr.rs
@@ -586,10 +586,7 @@ impl<I: i2c::I2CDevice> SyscallDriver for Lsm6dsoxtrI2C<'_, I> {
             2 => {
                 if self.state.get() == State::Idle {
                     if let Some(data_rate) = LSM6DSOXAccelDataRate::from_usize(data1) {
-                        match self.set_accelerometer_power_mode(
-                            data_rate,
-                            if data2 != 0 { true } else { false },
-                        ) {
+                        match self.set_accelerometer_power_mode(data_rate, data2 != 0) {
                             Ok(()) => {
                                 self.syscall_process.set(process_id);
                                 CommandReturn::success()
@@ -607,10 +604,7 @@ impl<I: i2c::I2CDevice> SyscallDriver for Lsm6dsoxtrI2C<'_, I> {
             3 => {
                 if self.state.get() == State::Idle {
                     if let Some(data_rate) = LSM6DSOXGyroDataRate::from_usize(data1) {
-                        match self.set_gyroscope_power_mode(
-                            data_rate,
-                            if data2 != 0 { true } else { false },
-                        ) {
+                        match self.set_gyroscope_power_mode(data_rate, data2 != 0) {
                             Ok(()) => {
                                 self.syscall_process.set(process_id);
                                 CommandReturn::success()

--- a/capsules/extra/src/max17205.rs
+++ b/capsules/extra/src/max17205.rs
@@ -373,7 +373,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for MAX17205<'_, I> {
                     .iter()
                     .take(8)
                     .enumerate()
-                    .fold(0u64, |rid, (i, b)| rid | ((*b as u64) << i * 8));
+                    .fold(0u64, |rid, (i, b)| rid | ((*b as u64) << (i * 8)));
                 self.buffer.replace(buffer);
 
                 self.client.map(|client| {

--- a/capsules/extra/src/mlx90614.rs
+++ b/capsules/extra/src/mlx90614.rs
@@ -126,7 +126,7 @@ impl<'a> i2c::I2CClient for Mlx90614SMBus<'a> {
                 self.buffer.replace(buffer);
             }
             State::IsPresent => {
-                let present = status == Ok(()) && buffer[0] == 60;
+                let present = status.is_ok() && buffer[0] == 60;
 
                 self.owning_process.map(|pid| {
                     let _ = self.apps.enter(pid, |_app, upcalls| {

--- a/capsules/extra/src/mlx90614.rs
+++ b/capsules/extra/src/mlx90614.rs
@@ -126,11 +126,7 @@ impl<'a> i2c::I2CClient for Mlx90614SMBus<'a> {
                 self.buffer.replace(buffer);
             }
             State::IsPresent => {
-                let present = if status == Ok(()) && buffer[0] == 60 {
-                    true
-                } else {
-                    false
-                };
+                let present = status == Ok(()) && buffer[0] == 60;
 
                 self.owning_process.map(|pid| {
                     let _ = self.apps.enter(pid, |_app, upcalls| {

--- a/capsules/extra/src/net/ieee802154.rs
+++ b/capsules/extra/src/net/ieee802154.rs
@@ -350,17 +350,15 @@ mod ie_control {
     pub const TYPE: u16 = 0x8000;
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Default)]
 pub enum HeaderIE<'a> {
-    Undissected { element_id: u8, content: &'a [u8] },
+    Undissected {
+        element_id: u8,
+        content: &'a [u8],
+    },
+    #[default]
     Termination1,
     Termination2,
-}
-
-impl Default for HeaderIE<'_> {
-    fn default() -> Self {
-        HeaderIE::Termination1
-    }
 }
 
 impl HeaderIE<'_> {
@@ -396,7 +394,7 @@ impl HeaderIE<'_> {
         stream_done!(off);
     }
 
-    pub fn decode<'b>(buf: &'b [u8]) -> SResult<HeaderIE<'b>> {
+    pub fn decode(buf: &[u8]) -> SResult<HeaderIE<'_>> {
         let (off, ie_ctl_be) = dec_try!(buf; decode_u16);
         let ie_ctl = u16::from_be(ie_ctl_be);
 
@@ -421,16 +419,14 @@ impl HeaderIE<'_> {
     }
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Default)]
 pub enum PayloadIE<'a> {
-    Undissected { group_id: u8, content: &'a [u8] },
+    Undissected {
+        group_id: u8,
+        content: &'a [u8],
+    },
+    #[default]
     Termination,
-}
-
-impl Default for PayloadIE<'_> {
-    fn default() -> Self {
-        PayloadIE::Termination
-    }
 }
 
 impl PayloadIE<'_> {
@@ -462,7 +458,7 @@ impl PayloadIE<'_> {
         stream_done!(off);
     }
 
-    pub fn decode<'b>(buf: &'b [u8]) -> SResult<PayloadIE<'b>> {
+    pub fn decode(buf: &[u8]) -> SResult<PayloadIE<'_>> {
         let (off, ie_ctl_be) = dec_try!(buf; decode_u16);
         let ie_ctl = u16::from_be(ie_ctl_be);
 

--- a/capsules/extra/src/net/sixlowpan/sixlowpan_state.rs
+++ b/capsules/extra/src/net/sixlowpan/sixlowpan_state.rs
@@ -254,7 +254,7 @@ const FRAG_TIMEOUT: u32 = 60;
 /// for the [Sixlowpan](struct.Sixlowpan.html) struct, and will then receive
 /// a callback once an IPv6 packet has been fully reassembled.
 pub trait SixlowpanRxClient {
-    fn receive<'a>(&self, buf: &'a [u8], len: usize, result: Result<(), ErrorCode>);
+    fn receive(&self, buf: &[u8], len: usize, result: Result<(), ErrorCode>);
 }
 
 pub mod lowpan_frag {

--- a/capsules/extra/src/net/udp/driver.rs
+++ b/capsules/extra/src/net/udp/driver.rs
@@ -454,7 +454,7 @@ impl<'a> SyscallDriver for UDPDriver<'a> {
                                             &tmp_cfg_buffer[..size_of::<UDPEndpoint>()],
                                         ),
                                     ) {
-                                        if Some(src.clone()) == app.bound_port {
+                                        if Some(src) == app.bound_port {
                                             Some([src, dst])
                                         } else {
                                             None
@@ -474,7 +474,7 @@ impl<'a> SyscallDriver for UDPDriver<'a> {
                     .unwrap_or_else(|err| Err(err.into()));
                 match res {
                     Ok(_) => self.do_next_tx_immediate(processid).map_or_else(
-                        |err| CommandReturn::failure(err.into()),
+                        |err| CommandReturn::failure(err),
                         |v| CommandReturn::success_u32(v),
                     ),
                     Err(e) => CommandReturn::failure(e),
@@ -650,7 +650,7 @@ impl<'a> PortQuery for UDPDriver<'a> {
         for app in self.apps.iter() {
             app.enter(|other_app, _| {
                 if other_app.bound_port.is_some() {
-                    let other_addr_opt = other_app.bound_port.clone();
+                    let other_addr_opt = other_app.bound_port;
                     let other_addr = other_addr_opt.unwrap(); // Unwrap fail = Missing other_addr
                     if other_addr.port == port {
                         port_bound = true;

--- a/capsules/extra/src/pca9544a.rs
+++ b/capsules/extra/src/pca9544a.rs
@@ -228,16 +228,16 @@ impl<I: i2c::I2CDevice> SyscallDriver for PCA9544A<'_, I> {
             0 => CommandReturn::success(),
 
             // Select channels.
-            1 => self.select_channels(data as u8).into(),
+            1 => self.select_channels(data as u8),
 
             // Disable all channels.
-            2 => self.select_channels(0).into(),
+            2 => self.select_channels(0),
 
             // Read the current interrupt fired mask.
-            3 => self.read_interrupts().into(),
+            3 => self.read_interrupts(),
 
             // Read the current selected channels.
-            4 => self.read_selected_channels().into(),
+            4 => self.read_selected_channels(),
 
             // default
             _ => CommandReturn::failure(ErrorCode::NOSUPPORT),

--- a/capsules/extra/src/proximity.rs
+++ b/capsules/extra/src/proximity.rs
@@ -71,17 +71,12 @@ pub struct App {
     upper_proximity: u8,
 }
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Default)]
 pub enum ProximityCommand {
     ReadProximity = 1,
     ReadProximityOnInterrupt = 2,
+    #[default]
     NoCommand = 3,
-}
-
-impl Default for ProximityCommand {
-    fn default() -> Self {
-        ProximityCommand::NoCommand
-    }
 }
 
 #[derive(Default)]

--- a/capsules/extra/src/public_key_crypto/rsa_keys.rs
+++ b/capsules/extra/src/public_key_crypto/rsa_keys.rs
@@ -23,7 +23,7 @@ struct RSAKeys<const L: usize> {
     private_key: OptionalCell<MutImutBuffer<'static, u8>>,
 }
 
-impl<'a, const L: usize> RSAKeys<L> {
+impl<const L: usize> RSAKeys<L> {
     const fn new() -> Self {
         Self {
             public_key: OptionalCell::empty(),

--- a/capsules/extra/src/symmetric_encryption/aes.rs
+++ b/capsules/extra/src/symmetric_encryption/aes.rs
@@ -55,7 +55,6 @@ pub struct AesDriver<'a, A: AES128<'a> + AES128CCM<'static> + AES128GCM<'static>
 }
 
 impl<
-        'a,
         A: AES128<'static>
             + AES128Ctr
             + AES128CBC
@@ -551,7 +550,6 @@ impl<
 }
 
 impl<
-        'a,
         A: AES128<'static>
             + AES128Ctr
             + AES128CBC
@@ -629,7 +627,6 @@ impl<
 }
 
 impl<
-        'a,
         A: AES128<'static>
             + AES128Ctr
             + AES128CBC
@@ -707,7 +704,6 @@ impl<
 }
 
 impl<
-        'a,
         A: AES128<'static>
             + AES128Ctr
             + AES128CBC

--- a/capsules/extra/src/touch.rs
+++ b/capsules/extra/src/touch.rs
@@ -113,7 +113,7 @@ impl<'a> Touch<'a> {
     fn touch_enable(&self) -> Result<(), ErrorCode> {
         let mut enabled = false;
         for app in self.apps.iter() {
-            if app.enter(|app, _| if app.touch_enable { true } else { false }) {
+            if app.enter(|app, _| app.touch_enable) {
                 enabled = true;
                 break;
             }
@@ -145,7 +145,7 @@ impl<'a> Touch<'a> {
     fn multi_touch_enable(&self) -> Result<(), ErrorCode> {
         let mut enabled = false;
         for app in self.apps.iter() {
-            if app.enter(|app, _| if app.multi_touch_enable { true } else { false }) {
+            if app.enter(|app, _| app.multi_touch_enable) {
                 enabled = true;
                 break;
             }
@@ -255,7 +255,7 @@ impl<'a> hil::touch::MultiTouchClient for Touch<'a> {
                                     };
 
                                     for event_index in 0..num {
-                                        let mut event = touch_events[event_index].clone();
+                                        let mut event = touch_events[event_index];
                                         self.update_rotation(&mut event);
                                         let event_status = touch_status_to_number(&event.status);
                                         // debug!(

--- a/capsules/extra/src/usb/descriptors.rs
+++ b/capsules/extra/src/usb/descriptors.rs
@@ -949,7 +949,7 @@ fn get_u32(b0: u8, b1: u8, b2: u8, b3: u8) -> u32 {
 }
 
 /// Write a `u16` to a buffer for transmission on the bus
-fn put_u16<'a>(buf: &'a [Cell<u8>], n: u16) {
+fn put_u16(buf: &[Cell<u8>], n: u16) {
     buf[0].set((n & 0xff) as u8);
     buf[1].set((n >> 8) as u8);
 }

--- a/capsules/extra/src/usb/usbc_client_ctrl.rs
+++ b/capsules/extra/src/usb/usbc_client_ctrl.rs
@@ -85,8 +85,9 @@ pub struct ClientCtrl<'a, 'b, U: 'a> {
 }
 
 /// States for the individual endpoints.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 enum State {
+    #[default]
     Init,
 
     /// We are doing a Control In transfer of some data in
@@ -97,12 +98,6 @@ enum State {
     CtrlOut,
 
     SetAddress,
-}
-
-impl Default for State {
-    fn default() -> Self {
-        State::Init
-    }
 }
 
 impl<'a, 'b, U: hil::usb::UsbController<'a>> ClientCtrl<'a, 'b, U> {

--- a/chips/apollo3/src/gpio.rs
+++ b/chips/apollo3/src/gpio.rs
@@ -1057,9 +1057,11 @@ impl<'a> gpio::Output for GpioPin<'a> {
         } else {
             cur_value = (regs.wtsb.get() & 1 << self.pin as usize) != 0;
             if cur_value {
-                regs.wtb.set(1 << self.pin as usize - 32 | regs.wtsb.get());
+                regs.wtb
+                    .set(1 << (self.pin as usize - 32) | regs.wtsb.get());
             } else {
-                regs.wtb.set(0 << self.pin as usize - 32 | regs.wtsb.get());
+                regs.wtb
+                    .set(0 << (self.pin as usize - 32) | regs.wtsb.get());
             }
         }
 

--- a/chips/earlgrey/src/aes.rs
+++ b/chips/earlgrey/src/aes.rs
@@ -508,7 +508,7 @@ impl kernel::hil::symmetric_encryption::AES128CBC for Aes<'_> {
     }
 }
 
-impl<'a> DeferredCallClient for Aes<'_> {
+impl DeferredCallClient for Aes<'_> {
     fn register(&'static self) {
         self.deferred_call.register(self);
     }

--- a/chips/esp32/src/rtc_cntl.rs
+++ b/chips/esp32/src/rtc_cntl.rs
@@ -105,7 +105,7 @@ pub struct RtcCntl {
     registers: StaticRef<RtcCntlRegisters>,
 }
 
-impl<'a> RtcCntl {
+impl RtcCntl {
     pub const fn new(base: StaticRef<RtcCntlRegisters>) -> RtcCntl {
         Self { registers: base }
     }

--- a/chips/imxrt10xx/src/lpi2c.rs
+++ b/chips/imxrt10xx/src/lpi2c.rs
@@ -703,9 +703,9 @@ impl<'a> Lpi2c<'a> {
 
         // setting slave address
         self.registers.mier.modify(MIER::EPIE::CLEAR);
-        self.registers
-            .mtdr
-            .write(MTDR::CMD.val(100) + MTDR::DATA.val((self.slave_address.get() << 1 + 1) as u32));
+        self.registers.mtdr.write(
+            MTDR::CMD.val(100) + MTDR::DATA.val((self.slave_address.get() << (1 + 1)) as u32),
+        );
 
         self.registers.mcfgr1.modify(MCFGR1::PINCFG::CLEAR);
         self.registers

--- a/chips/litex/src/gpio.rs
+++ b/chips/litex/src/gpio.rs
@@ -41,7 +41,7 @@ pub struct LiteXGPIORegisters<R: LiteXSoCRegisterConfiguration> {
 }
 
 impl<R: LiteXSoCRegisterConfiguration> LiteXGPIORegisters<R> {
-    fn ev<'a>(&'a self) -> LiteXGPIOEV<'a, R> {
+    fn ev(&self) -> LiteXGPIOEV<'_, R> {
         LiteXGPIOEV::<R>::new(
             &self.gpio_ev_status,
             &self.gpio_ev_pending,

--- a/chips/litex/src/led_controller.rs
+++ b/chips/litex/src/led_controller.rs
@@ -69,7 +69,7 @@ impl<R: LiteXSoCRegisterConfiguration> LiteXLedController<R> {
     /// instance for the requested LED already exists. Call
     /// [`LiteXLed::destroy`] (or drop the [`LiteXLed`]) to be create
     /// a new instance for this LED.
-    pub fn get_led<'a>(&'a self, index: usize) -> Option<LiteXLed<'a, R>> {
+    pub fn get_led(&self, index: usize) -> Option<LiteXLed<'_, R>> {
         if index < self.led_count() && (self.led_references.get() & (1 << index)) == 0 {
             self.led_references
                 .set(self.led_references.get() | (1 << index));
@@ -89,7 +89,7 @@ impl<R: LiteXSoCRegisterConfiguration> LiteXLedController<R> {
     /// This function only checks whether the requested LEDs is within
     /// the controller's range of available LEDs, but *NOT* whether
     /// there already is a different reference to the same LED.
-    pub unsafe fn panic_led<'a>(&'a self, index: usize) -> Option<LiteXLed<'a, R>> {
+    pub unsafe fn panic_led(&self, index: usize) -> Option<LiteXLed<'_, R>> {
         if index < self.led_count() {
             Some(LiteXLed::new(self, index))
         } else {

--- a/chips/litex/src/liteeth.rs
+++ b/chips/litex/src/liteeth.rs
@@ -75,11 +75,11 @@ pub struct LiteEthMacRegisters<R: LiteXSoCRegisterConfiguration> {
 }
 
 impl<R: LiteXSoCRegisterConfiguration> LiteEthMacRegisters<R> {
-    fn rx_ev<'a>(&'a self) -> LiteEthRXEV<'a, R> {
+    fn rx_ev(&self) -> LiteEthRXEV<'_, R> {
         LiteEthRXEV::<R>::new(&self.rx_ev_status, &self.rx_ev_pending, &self.rx_ev_enable)
     }
 
-    fn tx_ev<'a>(&'a self) -> LiteEthTXEV<'a, R> {
+    fn tx_ev(&self) -> LiteEthTXEV<'_, R> {
         LiteEthTXEV::<R>::new(&self.tx_ev_status, &self.tx_ev_pending, &self.tx_ev_enable)
     }
 }
@@ -159,7 +159,7 @@ impl<'a, R: LiteXSoCRegisterConfiguration> LiteEth<'a, R> {
         self.initialized.set(true);
     }
 
-    unsafe fn get_slot_buffer<'s>(&'s self, tx: bool, slot_id: usize) -> Option<&'s mut [u8]> {
+    unsafe fn get_slot_buffer(&self, tx: bool, slot_id: usize) -> Option<&mut [u8]> {
         if (tx && slot_id > self.tx_slots) || (!tx && slot_id > self.rx_slots) {
             return None;
         }

--- a/chips/litex/src/timer.rs
+++ b/chips/litex/src/timer.rs
@@ -80,7 +80,7 @@ pub struct LiteXTimerRegisters<R: LiteXSoCRegisterConfiguration> {
 }
 
 impl<R: LiteXSoCRegisterConfiguration> LiteXTimerRegisters<R> {
-    fn ev<'a>(&'a self) -> LiteXTimerEV<'a, R> {
+    fn ev(&self) -> LiteXTimerEV<'_, R> {
         LiteXTimerEV::<R>::new(&self.ev_status, &self.ev_pending, &self.ev_enable)
     }
 }

--- a/chips/litex/src/uart.rs
+++ b/chips/litex/src/uart.rs
@@ -63,7 +63,7 @@ pub struct LiteXUartRegisters<R: LiteXSoCRegisterConfiguration> {
 
 impl<R: LiteXSoCRegisterConfiguration> LiteXUartRegisters<R> {
     /// Create an event manager instance for the UART events
-    fn ev<'a>(&'a self) -> LiteXUartEV<'a, R> {
+    fn ev(&self) -> LiteXUartEV<'_, R> {
         LiteXUartEV::<R>::new(&self.ev_status, &self.ev_pending, &self.ev_enable)
     }
 }

--- a/chips/lowrisc/src/spi_host.rs
+++ b/chips/lowrisc/src/spi_host.rs
@@ -270,7 +270,7 @@ impl<'a> SpiHost<'a> {
                         if self.rx_offset.get() >= self.rx_len.get() {
                             break;
                         }
-                        val8 = ((val32 & shift_mask) >> i * 8) as u8;
+                        val8 = ((val32 & shift_mask) >> (i * 8)) as u8;
                         if let Some(ptr) = rx_buf.get_mut(self.rx_offset.get()) {
                             *ptr = val8;
                         } else {

--- a/chips/msp432/src/cs.rs
+++ b/chips/msp432/src/cs.rs
@@ -321,7 +321,7 @@ impl ClockSystem {
     }
 }
 
-impl<'a> PeripheralManagement<NoClockControl> for ClockSystem {
+impl PeripheralManagement<NoClockControl> for ClockSystem {
     type RegisterType = CsRegisters;
 
     fn get_registers(&self) -> &CsRegisters {

--- a/chips/nrf52/src/ficr.rs
+++ b/chips/nrf52/src/ficr.rs
@@ -449,10 +449,7 @@ impl Ficr {
             .deviceaddr1
             .read(DeviceAddress1::DEVICEADDRESS);
 
-        let h: [u8; 16] = [
-            b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9', b'a', b'b', b'c', b'd',
-            b'e', b'f',
-        ];
+        let h: [u8; 16] = *b"0123456789abcdef";
 
         buf[0] = h[((hi >> 12) & 0xf) as usize];
         buf[1] = h[((hi >> 8) & 0xf) as usize];

--- a/chips/nrf52/src/ficr.rs
+++ b/chips/nrf52/src/ficr.rs
@@ -450,25 +450,25 @@ impl Ficr {
             .read(DeviceAddress1::DEVICEADDRESS);
 
         let h: [u8; 16] = [
-            '0' as u8, '1' as u8, '2' as u8, '3' as u8, '4' as u8, '5' as u8, '6' as u8, '7' as u8,
-            '8' as u8, '9' as u8, 'a' as u8, 'b' as u8, 'c' as u8, 'd' as u8, 'e' as u8, 'f' as u8,
+            b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9', b'a', b'b', b'c', b'd',
+            b'e', b'f',
         ];
 
         buf[0] = h[((hi >> 12) & 0xf) as usize];
         buf[1] = h[((hi >> 8) & 0xf) as usize];
-        buf[2] = ':' as u8;
+        buf[2] = b':';
         buf[3] = h[((hi >> 4) & 0xf) as usize];
         buf[4] = h[((hi >> 0) & 0xf) as usize];
-        buf[5] = ':' as u8;
+        buf[5] = b':';
         buf[6] = h[((lo >> 28) & 0xf) as usize];
         buf[7] = h[((lo >> 24) & 0xf) as usize];
-        buf[8] = ':' as u8;
+        buf[8] = b':';
         buf[9] = h[((lo >> 20) & 0xf) as usize];
         buf[10] = h[((lo >> 16) & 0xf) as usize];
-        buf[11] = ':' as u8;
+        buf[11] = b':';
         buf[12] = h[((lo >> 12) & 0xf) as usize];
         buf[13] = h[((lo >> 8) & 0xf) as usize];
-        buf[14] = ':' as u8;
+        buf[14] = b':';
         buf[15] = h[((lo >> 4) & 0xf) as usize];
         buf[16] = h[((lo >> 0) & 0xf) as usize];
 

--- a/chips/nrf52840/src/ieee802154_radio.rs
+++ b/chips/nrf52840/src/ieee802154_radio.rs
@@ -1234,11 +1234,7 @@ impl<'a> kernel::hil::radio::RadioConfig<'a> for Radio<'a> {
         Ok(())
     }
     fn is_on(&self) -> bool {
-        if self.registers.power.is_set(Task::ENABLE) {
-            true
-        } else {
-            false
-        }
+        self.registers.power.is_set(Task::ENABLE)
     }
 
     // Previous driver implementation //

--- a/chips/nrf5x/src/trng.rs
+++ b/chips/nrf5x/src/trng.rs
@@ -141,7 +141,7 @@ impl<'a> Trng<'a> {
                 //  e = 1 -> byte 2
                 //  e = 2 -> byte 3
                 //  e = 3 -> byte 4 MSB
-                rn |= r << 8 * e;
+                rn |= r << (8 * e);
                 self.randomness.set(rn);
 
                 self.index.set(e + 1);

--- a/chips/rp2040/src/gpio.rs
+++ b/chips/rp2040/src/gpio.rs
@@ -347,13 +347,13 @@ impl<'a> RPPins<'a> {
                 let l_low_reg_no = pin * 4;
                 if (current_val & enabled_val & (1 << l_low_reg_no)) != 0 {
                     self.pins[pin + bank_no * 8].handle_interrupt();
-                } else if (current_val & enabled_val & (1 << l_low_reg_no + 1)) != 0 {
+                } else if (current_val & enabled_val & (1 << (l_low_reg_no + 1))) != 0 {
                     self.pins[pin + bank_no * 8].handle_interrupt();
-                } else if (current_val & enabled_val & (1 << l_low_reg_no + 2)) != 0 {
-                    self.gpio_registers.intr[bank_no].set(current_val & (1 << l_low_reg_no + 2));
+                } else if (current_val & enabled_val & (1 << (l_low_reg_no + 2))) != 0 {
+                    self.gpio_registers.intr[bank_no].set(current_val & (1 << (l_low_reg_no + 2)));
                     self.pins[pin + bank_no * 8].handle_interrupt();
-                } else if (current_val & enabled_val & (1 << l_low_reg_no + 3)) != 0 {
-                    self.gpio_registers.intr[bank_no].set(current_val & (1 << l_low_reg_no + 3));
+                } else if (current_val & enabled_val & (1 << (l_low_reg_no + 3))) != 0 {
+                    self.gpio_registers.intr[bank_no].set(current_val & (1 << (l_low_reg_no + 3)));
                     self.pins[pin + bank_no * 8].handle_interrupt();
                 }
             }
@@ -426,11 +426,7 @@ impl<'a> RPGpioPin<'a> {
     fn read_pin(&self) -> bool {
         //TODO - read alternate function
         let value = self.sio_registers.gpio_out.read(GPIO_OUT::OUT) & (1 << self.pin);
-        if value == 0 {
-            false
-        } else {
-            true
-        }
+        value != 0
     }
 
     pub fn set_function(&self, f: GpioFunction) {
@@ -500,17 +496,12 @@ impl<'a> hil::gpio::Interrupt<'a> for RPGpioPin<'a> {
         let interrupt_bank_no = self.pin / 8;
         let l_low_reg_no = (self.pin * 4) % 32;
         let current_val = self.gpio_registers.interrupt_proc[0].status[interrupt_bank_no].get();
-        if (current_val
+        (current_val
             & (1 << l_low_reg_no)
-            & (1 << l_low_reg_no + 1)
-            & (1 << l_low_reg_no + 2)
-            & (1 << l_low_reg_no + 3))
-            == 0
-        {
-            false
-        } else {
-            true
-        }
+            & (1 << (l_low_reg_no + 1))
+            & (1 << (l_low_reg_no + 2))
+            & (1 << (l_low_reg_no + 3)))
+            != 0
     }
 
     fn enable_interrupts(&self, mode: hil::gpio::InterruptEdge) {
@@ -653,11 +644,7 @@ impl hil::gpio::Output for RPGpioPin<'_> {
 impl hil::gpio::Input for RPGpioPin<'_> {
     fn read(&self) -> bool {
         let value = self.sio_registers.gpio_in.read(GPIO_IN::IN) & (1 << self.pin);
-        if value == 0 {
-            false
-        } else {
-            true
-        }
+        value != 0
     }
 }
 

--- a/chips/rp2040/src/uart.rs
+++ b/chips/rp2040/src/uart.rs
@@ -552,14 +552,9 @@ impl<'a> Uart<'a> {
     }
 
     pub fn is_configured(&self) -> bool {
-        if self.registers.uartcr.is_set(UARTCR::UARTEN)
+        self.registers.uartcr.is_set(UARTCR::UARTEN)
             && (self.registers.uartcr.is_set(UARTCR::RXE)
                 || self.registers.uartcr.is_set(UARTCR::TXE))
-        {
-            true
-        } else {
-            false
-        }
     }
 }
 

--- a/chips/sam4l/src/ast.rs
+++ b/chips/sam4l/src/ast.rs
@@ -354,7 +354,7 @@ impl<'a> time::Alarm<'a> for Ast<'a> {
         if !now.within_range(reference, expire) {
             // We have already passed when: just fire ASAP
             // Note this will also trigger the increment below
-            expire = Self::Ticks::from(now);
+            expire = now;
         }
 
         // Firing is too close in the future, delay it a bit

--- a/chips/sam4l/src/i2c.rs
+++ b/chips/sam4l/src/i2c.rs
@@ -600,7 +600,7 @@ type TWIMRegisterManager<'a, 'm> = PeripheralManager<'m, I2CHw<'a>, TWIMClock>;
 impl<'a> PeripheralManagement<TWISClock> for I2CHw<'a> {
     type RegisterType = TWISRegisters;
 
-    fn get_registers<'b>(&'b self) -> &'b TWISRegisters {
+    fn get_registers(&self) -> &TWISRegisters {
         &*self.slave_mmio_address.as_ref().unwrap() // Unwrap fail = Access of non-existent slave
     }
 

--- a/chips/sam4l/src/serial_num.rs
+++ b/chips/sam4l/src/serial_num.rs
@@ -48,6 +48,6 @@ impl SerialNum {
             .rev()
             .take(8)
             .enumerate()
-            .fold(0u64, |sum, (i, &val)| sum + ((val as u64) << i * 8))
+            .fold(0u64, |sum, (i, &val)| sum + ((val as u64) << (i * 8)))
     }
 }

--- a/chips/sam4l/src/usbc/mod.rs
+++ b/chips/sam4l/src/usbc/mod.rs
@@ -302,8 +302,9 @@ pub struct DeviceState {
     pub endpoint_states: [EndpointState; N_ENDPOINTS],
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 pub enum EndpointState {
+    #[default]
     Disabled,
     Ctrl(CtrlState),
     BulkIn(BulkInState),
@@ -331,12 +332,6 @@ pub enum BulkInState {
 pub enum BulkOutState {
     Init,
     Delay,
-}
-
-impl Default for EndpointState {
-    fn default() -> Self {
-        EndpointState::Disabled
-    }
 }
 
 #[derive(Copy, Clone, PartialEq, Debug)]

--- a/chips/stm32f303xc/src/gpio.rs
+++ b/chips/stm32f303xc/src/gpio.rs
@@ -1118,7 +1118,7 @@ impl<'a> hil::gpio::Interrupt<'a> for Pin<'a> {
         unsafe {
             atomic(|| {
                 self.exti_lineid.map(|lineid| {
-                    let l = lineid.clone();
+                    let l = lineid;
 
                     // disable the interrupt
                     self.exti.mask_interrupt(l);
@@ -1149,7 +1149,7 @@ impl<'a> hil::gpio::Interrupt<'a> for Pin<'a> {
         unsafe {
             atomic(|| {
                 self.exti_lineid.map(|lineid| {
-                    let l = lineid.clone();
+                    let l = lineid;
                     self.exti.mask_interrupt(l);
                     self.exti.clear_pending(l);
                 });

--- a/chips/stm32f4xx/src/can.rs
+++ b/chips/stm32f4xx/src/can.rs
@@ -1131,7 +1131,7 @@ impl ClockInterface for CanClock<'_> {
     }
 }
 
-impl<'a> can::Configure for Can<'_> {
+impl can::Configure for Can<'_> {
     const MIN_BIT_TIMINGS: can::BitTiming = can::BitTiming {
         segment1: BitSegment1::CanBtrTs1Min as u8,
         segment2: BitSegment2::CanBtrTs2Min as u8,
@@ -1232,7 +1232,7 @@ impl<'a> can::Configure for Can<'_> {
     }
 }
 
-impl<'a> can::Controller for Can<'_> {
+impl can::Controller for Can<'_> {
     fn set_client(&self, client: Option<&'static dyn can::ControllerClient>) {
         if let Some(client) = client {
             self.controller_client.replace(client);
@@ -1294,7 +1294,7 @@ impl<'a> can::Controller for Can<'_> {
     }
 }
 
-impl<'a> can::Transmit<{ can::STANDARD_CAN_PACKET_SIZE }> for Can<'_> {
+impl can::Transmit<{ can::STANDARD_CAN_PACKET_SIZE }> for Can<'_> {
     fn set_client(
         &self,
         client: Option<&'static dyn can::TransmitClient<{ can::STANDARD_CAN_PACKET_SIZE }>>,
@@ -1333,7 +1333,7 @@ impl<'a> can::Transmit<{ can::STANDARD_CAN_PACKET_SIZE }> for Can<'_> {
     }
 }
 
-impl<'a> can::Receive<{ can::STANDARD_CAN_PACKET_SIZE }> for Can<'_> {
+impl can::Receive<{ can::STANDARD_CAN_PACKET_SIZE }> for Can<'_> {
     fn set_client(
         &self,
         client: Option<&'static dyn can::ReceiveClient<{ can::STANDARD_CAN_PACKET_SIZE }>>,

--- a/chips/stm32f4xx/src/dma.rs
+++ b/chips/stm32f4xx/src/dma.rs
@@ -1417,7 +1417,7 @@ impl Dma1Peripheral {
         }
     }
 
-    pub fn get_stream_idx<'a>(&self) -> usize {
+    pub fn get_stream_idx(&self) -> usize {
         usize::from(StreamId::from(*self) as u8)
     }
 }
@@ -1593,7 +1593,7 @@ impl Dma2Peripheral {
         }
     }
 
-    pub fn get_stream_idx<'a>(&self) -> usize {
+    pub fn get_stream_idx(&self) -> usize {
         usize::from(StreamId::from(*self) as u8)
     }
 }

--- a/chips/stm32f4xx/src/gpio.rs
+++ b/chips/stm32f4xx/src/gpio.rs
@@ -1205,7 +1205,7 @@ impl<'a> hil::gpio::Interrupt<'a> for Pin<'a> {
         unsafe {
             atomic(|| {
                 self.exti_lineid.map(|lineid| {
-                    let l = lineid.clone();
+                    let l = lineid;
 
                     // disable the interrupt
                     self.exti.mask_interrupt(l);
@@ -1236,7 +1236,7 @@ impl<'a> hil::gpio::Interrupt<'a> for Pin<'a> {
         unsafe {
             atomic(|| {
                 self.exti_lineid.map(|lineid| {
-                    let l = lineid.clone();
+                    let l = lineid;
                     self.exti.mask_interrupt(l);
                     self.exti.clear_pending(l);
                 });

--- a/chips/virtio/src/queues/split_queue.rs
+++ b/chips/virtio/src/queues/split_queue.rs
@@ -735,7 +735,7 @@ impl<'a, 'b, const MAX_QUEUE_SIZE: usize> SplitVirtqueue<'a, 'b, MAX_QUEUE_SIZE>
         let mut i = 0;
         let mut next_index: Option<usize> = Some(top_descriptor_index);
 
-        while let Some(current_index) = next_index.clone() {
+        while let Some(current_index) = next_index {
             // Get a reference over the current descriptor
             let current_desc = &self.descriptors.0[current_index];
 

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -81,7 +81,7 @@ use crate::ErrorCode;
 pub trait IoWrite {
     fn write(&mut self, buf: &[u8]) -> usize;
 
-    fn write_ring_buffer<'a>(&mut self, buf: &RingBuffer<'a, u8>) -> usize {
+    fn write_ring_buffer(&mut self, buf: &RingBuffer<'_, u8>) -> usize {
         let (left, right) = buf.as_slices();
         let mut total = 0;
         if let Some(slice) = left {

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -328,7 +328,7 @@ impl<'a> EnteredGrantKernelManagedLayout<'a> {
         let allow_ro_array = upcalls_array.add(upcalls_num_val.0.into()) as *mut SavedAllowRo;
         let allow_rw_array = allow_ro_array.add(allow_ro_num_val.0.into()) as *mut SavedAllowRw;
 
-        counters_ptr.write(counter.into());
+        counters_ptr.write(counter);
         write_default_array(upcalls_array, upcalls_num_val.0.into());
         write_default_array(allow_ro_array, allow_ro_num_val.0.into());
         write_default_array(allow_rw_array, allow_rw_num_val.0.into());

--- a/kernel/src/process_checker/basic.rs
+++ b/kernel/src/process_checker/basic.rs
@@ -202,7 +202,7 @@ impl ClientData<32_usize> for AppCheckerSha256 {
     }
 }
 
-impl<'a> ClientVerify<32_usize> for AppCheckerSha256 {
+impl ClientVerify<32_usize> for AppCheckerSha256 {
     fn verification_done(
         &self,
         result: Result<bool, ErrorCode>,
@@ -235,7 +235,7 @@ impl<'a> ClientVerify<32_usize> for AppCheckerSha256 {
     }
 }
 
-impl<'a> ClientHash<32_usize> for AppCheckerSha256 {
+impl ClientHash<32_usize> for AppCheckerSha256 {
     fn hash_done(&self, _result: Result<(), ErrorCode>, _digest: &'static mut [u8; 32_usize]) {}
 }
 

--- a/kernel/src/process_loading.rs
+++ b/kernel/src/process_loading.rs
@@ -359,7 +359,7 @@ fn load_processes_from_flash<C: Chip>(
 /// by enqueueing a stack frame to run the initialization function as
 /// indicated in the TBF header.
 #[inline(always)]
-fn check_processes<'a, KR: KernelResources<C>, C: Chip>(
+fn check_processes<KR: KernelResources<C>, C: Chip>(
     kernel_resources: &KR,
     machine: &'static ProcessCheckerMachine,
 ) -> Result<(), ProcessLoadError> {

--- a/kernel/src/processbuffer.rs
+++ b/kernel/src/processbuffer.rs
@@ -680,9 +680,7 @@ pub struct ReadableProcessSlice {
     slice: [ReadableProcessByte],
 }
 
-fn cast_byte_slice_to_process_slice<'a>(
-    byte_slice: &'a [ReadableProcessByte],
-) -> &'a ReadableProcessSlice {
+fn cast_byte_slice_to_process_slice(byte_slice: &[ReadableProcessByte]) -> &ReadableProcessSlice {
     // As ReadableProcessSlice is a transparent wrapper around its inner type,
     // [ReadableProcessByte], we can safely transmute a reference to the inner
     // type as a reference to the outer type with the same lifetime.
@@ -867,7 +865,7 @@ pub struct WriteableProcessSlice {
     slice: [Cell<u8>],
 }
 
-fn cast_cell_slice_to_process_slice<'a>(cell_slice: &'a [Cell<u8>]) -> &'a WriteableProcessSlice {
+fn cast_cell_slice_to_process_slice(cell_slice: &[Cell<u8>]) -> &WriteableProcessSlice {
     // # Safety
     //
     // As WriteableProcessSlice is a transparent wrapper around its inner type,

--- a/tools/run_clippy.sh
+++ b/tools/run_clippy.sh
@@ -63,20 +63,10 @@ CLIPPY_ARGS_COMPLEXITY="
 
 
 -A clippy::unnecessary_cast
--A clippy::extra_unused_lifetimes
 -A clippy::unnecessary_unwrap
 -A clippy::needless_lifetimes
--A clippy::useless_conversion
--A clippy::precedence
--A clippy::redundant_slicing
--A clippy::derivable_impls
--A clippy::char_lit_as_u8
--A clippy::needless_bool
--A clippy::useless_asref
--A clippy::clone-on-copy
 -A clippy::explicit_auto_deref
 -A clippy::explicit_counter_loop
--A clippy::manual_unwrap_or
 -A clippy::borrow_deref_ref
 -A clippy::overflow_check_conditional
 -A clippy::needless-match


### PR DESCRIPTION
### Pull Request Overview

This pull request addresses several complexity clippy lints:

```diff
diff --git a/tools/run_clippy.sh b/tools/run_clippy.sh
index 45bc69afa..6d2337366 100755
--- a/tools/run_clippy.sh
+++ b/tools/run_clippy.sh
@@ -63,20 +63,10 @@ CLIPPY_ARGS_COMPLEXITY="


 -A clippy::unnecessary_cast
--A clippy::extra_unused_lifetimes
 -A clippy::unnecessary_unwrap
 -A clippy::needless_lifetimes
--A clippy::useless_conversion
--A clippy::precedence
--A clippy::redundant_slicing
--A clippy::derivable_impls
--A clippy::char_lit_as_u8
--A clippy::needless_bool
--A clippy::useless_asref
--A clippy::clone-on-copy
 -A clippy::explicit_auto_deref
 -A clippy::explicit_counter_loop
--A clippy::manual_unwrap_or
 -A clippy::borrow_deref_ref
 -A clippy::overflow_check_conditional
 -A clippy::needless-match
```

Most of them were done automatically but removing unnecessary lifetimes was a bit more manual.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
