### PR TITLE
make: add libraries/tickv to cargo test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -423,6 +423,7 @@ ci-job-libraries:
 	@cd libraries/riscv-csr && NOWARNINGS=true RUSTFLAGS="-D warnings" cargo test
 	@cd libraries/tock-cells && NOWARNINGS=true RUSTFLAGS="-D warnings" cargo test
 	@cd libraries/tock-register-interface && NOWARNINGS=true RUSTFLAGS="-D warnings" cargo test
+	@cd libraries/tickv && NOWARNINGS=true RUSTFLAGS="-D warnings" cargo test
 
 .PHONY: ci-job-archs
 ci-job-archs:


### PR DESCRIPTION
### Pull Request Overview

This pull request runs the tickv tests in the `make ci-job-libraries` target.

I assume this wasn't intentionally omitted.

Blocked on #3619.

### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
