### PR TITLE
chips/earlgrey/chip_config: increase CW310 FPGA clock frequencies

### DIFF
--- a/chips/earlgrey/src/chip_config.rs
+++ b/chips/earlgrey/src/chip_config.rs
@@ -34,8 +34,9 @@ pub struct Config<'a> {
 #[cfg(any(feature = "config_fpga_cw310", not(feature = "config_disable_default")))]
 pub const CONFIG: Config = Config {
     name: "fpga_cw310",
-    cpu_freq: 10_000_000,
-    peripheral_freq: 2_500_000,
+    // Clock frequencies as of https://github.com/lowRISC/opentitan/pull/19368
+    cpu_freq: 24_000_000,
+    peripheral_freq: 6_000_000,
     aon_timer_freq: 250_000,
     uart_baudrate: 115200,
 };


### PR DESCRIPTION
### Pull Request Overview

This is in accordance with an upstream change [1]. While the register set and other chip attributes are frozen for EarlGrey, the clock frequencies are not. This change will also be backported to the lowRISC/opentitan `earlgrey_es` branch [2].

[1]: https://github.com/lowRISC/opentitan/pull/19368
[2]: https://github.com/lowRISC/opentitan/pull/19479

### Testing Strategy

This pull request was tested by running Tock on latest OpenTitan master on a CW310 FPGA.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [x] Ran `make prepush`.
