### PR TITLE
chips/earlgrey: convert CONFIG to trait, make board-configurable

### DIFF
--- a/boards/opentitan/earlgrey-cw310/Cargo.toml
+++ b/boards/opentitan/earlgrey-cw310/Cargo.toml
@@ -37,8 +37,8 @@ default = ["fpga_cw310"]
 #
 #    - sim_verilator:
 #      OpenTitan SoC design simulated in Verilator.
-fpga_cw310 = ["earlgrey/config_fpga_cw310"]
-sim_verilator = ["earlgrey/config_sim_verilator"]
+fpga_cw310 = []
+sim_verilator = []
 # This is used to indicate that we should include tests that only pass on
 # hardware.
 hardware_tests = []

--- a/boards/opentitan/src/io.rs
+++ b/boards/opentitan/src/io.rs
@@ -5,6 +5,7 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
 use core::str;
+use earlgrey::chip_config::EarlGreyConfig;
 use kernel::debug;
 use kernel::debug::IoWrite;
 
@@ -29,7 +30,7 @@ impl IoWrite for Writer {
         // during panic.
         earlgrey::uart::Uart::new(
             earlgrey::uart::UART0_BASE,
-            earlgrey::chip_config::CONFIG.peripheral_freq,
+            crate::ChipConfig::PERIPHERAL_FREQ,
         )
         .transmit_sync(buf);
         buf.len()

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -20,6 +20,7 @@ use capsules_aes_gcm::aes_gcm;
 use capsules_core::virtualizers::virtual_aes_ccm;
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use earlgrey::chip::EarlGreyDefaultPeripherals;
+use earlgrey::chip_config::EarlGreyConfig;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::hil;
@@ -44,6 +45,36 @@ mod otbn;
 #[cfg(test)]
 mod tests;
 
+/// The `earlgrey` chip crate supports multiple targets with slightly different
+/// configurations, which are encoded through implementations of the
+/// `earlgrey::chip_config::EarlGreyConfig` trait. This type provides different
+/// implementations of the `EarlGreyConfig` trait, depending on Cargo's
+/// conditional compilation feature flags. If no feature is selected,
+/// compilation will error.
+pub enum ChipConfig {}
+
+#[cfg(feature = "fpga_cw310")]
+impl EarlGreyConfig for ChipConfig {
+    const NAME: &'static str = "fpga_cw310";
+
+    // Clock frequencies as of https://github.com/lowRISC/opentitan/pull/19368
+    const CPU_FREQ: u32 = 10_000_000;
+    const PERIPHERAL_FREQ: u32 = 2_500_000;
+    const AON_TIMER_FREQ: u32 = 250_000;
+    const UART_BAUDRATE: u32 = 115200;
+}
+
+#[cfg(feature = "sim_verilator")]
+impl EarlGreyConfig for ChipConfig {
+    const NAME: &'static str = "sim_verilator";
+
+    // Clock frequencies as of https://github.com/lowRISC/opentitan/pull/19368
+    const CPU_FREQ: u32 = 500_000;
+    const PERIPHERAL_FREQ: u32 = 125_000;
+    const AON_TIMER_FREQ: u32 = 125_000;
+    const UART_BAUDRATE: u32 = 7200;
+}
+
 const NUM_PROCS: usize = 4;
 
 //
@@ -53,7 +84,7 @@ static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; 4] = [None
 
 // Test access to the peripherals
 #[cfg(test)]
-static mut PERIPHERALS: Option<&'static EarlGreyDefaultPeripherals> = None;
+static mut PERIPHERALS: Option<&'static EarlGreyDefaultPeripherals<ChipConfig>> = None;
 // Test access to board
 #[cfg(test)]
 static mut BOARD: Option<&'static kernel::Kernel> = None;
@@ -64,7 +95,9 @@ static mut PLATFORM: Option<&'static EarlGrey> = None;
 #[cfg(test)]
 static mut MAIN_CAP: Option<&dyn kernel::capabilities::MainLoopCapability> = None;
 // Test access to alarm
-static mut ALARM: Option<&'static MuxAlarm<'static, earlgrey::timer::RvTimer<'static>>> = None;
+static mut ALARM: Option<
+    &'static MuxAlarm<'static, earlgrey::timer::RvTimer<'static, ChipConfig>>,
+> = None;
 // Test access to TicKV
 static mut TICKV: Option<
     &capsules_extra::tickv::TicKVSystem<
@@ -93,7 +126,9 @@ static mut RSA_HARDWARE: Option<&lowrisc::rsa::OtbnRsa<'static>> = None;
 #[cfg(test)]
 static mut SHA256SOFT: Option<&capsules_extra::sha256::Sha256Software<'static>> = None;
 
-static mut CHIP: Option<&'static earlgrey::chip::EarlGrey<EarlGreyDefaultPeripherals>> = None;
+static mut CHIP: Option<
+    &'static earlgrey::chip::EarlGrey<EarlGreyDefaultPeripherals<ChipConfig>, ChipConfig>,
+> = None;
 static mut PROCESS_PRINTER: Option<&'static kernel::process::ProcessPrinterText> = None;
 
 // How should the kernel respond when a process faults.
@@ -116,7 +151,7 @@ struct EarlGrey {
     console: &'static capsules_core::console::Console<'static>,
     alarm: &'static capsules_core::alarm::AlarmDriver<
         'static,
-        VirtualMuxAlarm<'static, earlgrey::timer::RvTimer<'static>>,
+        VirtualMuxAlarm<'static, earlgrey::timer::RvTimer<'static, ChipConfig>>,
     >,
     hmac: &'static capsules_extra::hmac::HmacDriver<'static, lowrisc::hmac::Hmac<'static>, 32>,
     lldb: &'static capsules_core::low_level_debug::LowLevelDebug<
@@ -164,8 +199,9 @@ struct EarlGrey {
     >,
     syscall_filter: &'static TbfHeaderFilterDefaultAllow,
     scheduler: &'static PrioritySched,
-    scheduler_timer:
-        &'static VirtualSchedulerTimer<VirtualMuxAlarm<'static, earlgrey::timer::RvTimer<'static>>>,
+    scheduler_timer: &'static VirtualSchedulerTimer<
+        VirtualMuxAlarm<'static, earlgrey::timer::RvTimer<'static, ChipConfig>>,
+    >,
     watchdog: &'static lowrisc::aon_timer::AonTimer,
 }
 
@@ -192,16 +228,23 @@ impl SyscallDriverLookup for EarlGrey {
     }
 }
 
-impl KernelResources<earlgrey::chip::EarlGrey<'static, EarlGreyDefaultPeripherals<'static>>>
-    for EarlGrey
+impl
+    KernelResources<
+        earlgrey::chip::EarlGrey<
+            'static,
+            EarlGreyDefaultPeripherals<'static, ChipConfig>,
+            ChipConfig,
+        >,
+    > for EarlGrey
 {
     type SyscallDriverLookup = Self;
     type SyscallFilter = TbfHeaderFilterDefaultAllow;
     type ProcessFault = ();
     type CredentialsCheckingPolicy = ();
     type Scheduler = PrioritySched;
-    type SchedulerTimer =
-        VirtualSchedulerTimer<VirtualMuxAlarm<'static, earlgrey::timer::RvTimer<'static>>>;
+    type SchedulerTimer = VirtualSchedulerTimer<
+        VirtualMuxAlarm<'static, earlgrey::timer::RvTimer<'static, ChipConfig>>,
+    >;
     type WatchDog = lowrisc::aon_timer::AonTimer;
     type ContextSwitchCallback = ();
 
@@ -234,8 +277,12 @@ impl KernelResources<earlgrey::chip::EarlGrey<'static, EarlGreyDefaultPeripheral
 unsafe fn setup() -> (
     &'static kernel::Kernel,
     &'static EarlGrey,
-    &'static earlgrey::chip::EarlGrey<'static, EarlGreyDefaultPeripherals<'static>>,
-    &'static EarlGreyDefaultPeripherals<'static>,
+    &'static earlgrey::chip::EarlGrey<
+        'static,
+        EarlGreyDefaultPeripherals<'static, ChipConfig>,
+        ChipConfig,
+    >,
+    &'static EarlGreyDefaultPeripherals<'static, ChipConfig>,
 ) {
     // Ibex-specific handler
     earlgrey::chip::configure_trap_handler();
@@ -247,7 +294,7 @@ unsafe fn setup() -> (
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
 
     let peripherals = static_init!(
-        EarlGreyDefaultPeripherals,
+        EarlGreyDefaultPeripherals<ChipConfig>,
         EarlGreyDefaultPeripherals::new()
     );
     peripherals.init();
@@ -260,11 +307,9 @@ unsafe fn setup() -> (
     );
 
     // Create a shared UART channel for the console and for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(
-        &peripherals.uart0,
-        earlgrey::uart::UART0_BAUDRATE,
-    )
-    .finalize(components::uart_mux_component_static!());
+    let uart_mux =
+        components::console::UartMuxComponent::new(&peripherals.uart0, ChipConfig::UART_BAUDRATE)
+            .finalize(components::uart_mux_component_static!());
 
     // LEDs
     // Start with half on and half off
@@ -297,13 +342,16 @@ unsafe fn setup() -> (
     )
     .finalize(components::gpio_component_static!(earlgrey::gpio::GpioPin));
 
-    let hardware_alarm = static_init!(earlgrey::timer::RvTimer, earlgrey::timer::RvTimer::new());
+    let hardware_alarm = static_init!(
+        earlgrey::timer::RvTimer<ChipConfig>,
+        earlgrey::timer::RvTimer::new()
+    );
     hardware_alarm.setup();
 
     // Create a shared virtualization mux layer on top of a single hardware
     // alarm.
     let mux_alarm = static_init!(
-        MuxAlarm<'static, earlgrey::timer::RvTimer>,
+        MuxAlarm<'static, earlgrey::timer::RvTimer<ChipConfig>>,
         MuxAlarm::new(hardware_alarm)
     );
     hil::time::Alarm::set_alarm_client(hardware_alarm, mux_alarm);
@@ -312,13 +360,13 @@ unsafe fn setup() -> (
 
     // Alarm
     let virtual_alarm_user = static_init!(
-        VirtualMuxAlarm<'static, earlgrey::timer::RvTimer>,
+        VirtualMuxAlarm<'static, earlgrey::timer::RvTimer<ChipConfig>>,
         VirtualMuxAlarm::new(mux_alarm)
     );
     virtual_alarm_user.setup();
 
     let scheduler_timer_virtual_alarm = static_init!(
-        VirtualMuxAlarm<'static, earlgrey::timer::RvTimer>,
+        VirtualMuxAlarm<'static, earlgrey::timer::RvTimer<ChipConfig>>,
         VirtualMuxAlarm::new(mux_alarm)
     );
     scheduler_timer_virtual_alarm.setup();
@@ -326,7 +374,7 @@ unsafe fn setup() -> (
     let alarm = static_init!(
         capsules_core::alarm::AlarmDriver<
             'static,
-            VirtualMuxAlarm<'static, earlgrey::timer::RvTimer>,
+            VirtualMuxAlarm<'static, earlgrey::timer::RvTimer<ChipConfig>>,
         >,
         capsules_core::alarm::AlarmDriver::new(
             virtual_alarm_user,
@@ -336,14 +384,14 @@ unsafe fn setup() -> (
     hil::time::Alarm::set_alarm_client(virtual_alarm_user, alarm);
 
     let scheduler_timer = static_init!(
-        VirtualSchedulerTimer<VirtualMuxAlarm<'static, earlgrey::timer::RvTimer<'static>>>,
+        VirtualSchedulerTimer<
+            VirtualMuxAlarm<'static, earlgrey::timer::RvTimer<'static, ChipConfig>>,
+        >,
         VirtualSchedulerTimer::new(scheduler_timer_virtual_alarm)
     );
 
     let chip = static_init!(
-        earlgrey::chip::EarlGrey<
-            EarlGreyDefaultPeripherals,
-        >,
+        earlgrey::chip::EarlGrey<EarlGreyDefaultPeripherals<ChipConfig>, ChipConfig>,
         earlgrey::chip::EarlGrey::new(peripherals, hardware_alarm)
     );
     CHIP = Some(chip);

--- a/boards/opentitan/src/tests/multi_alarm.rs
+++ b/boards/opentitan/src/tests/multi_alarm.rs
@@ -19,13 +19,17 @@ use crate::tests::run_kernel_op;
 use crate::ALARM;
 use capsules_core::test::random_alarm::TestRandomAlarm;
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use earlgrey::chip_config::EarlGreyConfig;
 use earlgrey::timer::RvTimer;
 use kernel::debug;
 use kernel::hil::time::Alarm;
 use kernel::static_init;
 
 static mut TESTS: Option<
-    [&'static TestRandomAlarm<'static, VirtualMuxAlarm<'static, RvTimer<'static>>>; 3],
+    [&'static TestRandomAlarm<
+        'static,
+        VirtualMuxAlarm<'static, RvTimer<'static, crate::ChipConfig>>,
+    >; 3],
 > = None;
 
 #[test_case]
@@ -51,40 +55,43 @@ pub fn run_multi_alarm() {
 }
 
 unsafe fn static_init_multi_alarm_test(
-    mux: &'static MuxAlarm<'static, RvTimer<'static>>,
-) -> [&'static TestRandomAlarm<'static, VirtualMuxAlarm<'static, RvTimer<'static>>>; 3] {
+    mux: &'static MuxAlarm<'static, RvTimer<'static, crate::ChipConfig>>,
+) -> [&'static TestRandomAlarm<
+    'static,
+    VirtualMuxAlarm<'static, RvTimer<'static, crate::ChipConfig>>,
+>; 3] {
     let virtual_alarm1 = static_init!(
-        VirtualMuxAlarm<'static, RvTimer<'static>>,
+        VirtualMuxAlarm<'static, RvTimer<'static, crate::ChipConfig>>,
         VirtualMuxAlarm::new(mux)
     );
     virtual_alarm1.setup();
 
     let test1 = static_init!(
-        TestRandomAlarm<'static, VirtualMuxAlarm<'static, RvTimer<'static>>>,
+        TestRandomAlarm<'static, VirtualMuxAlarm<'static, RvTimer<'static, crate::ChipConfig>>>,
         TestRandomAlarm::new(virtual_alarm1, 19, 'A', false)
     );
     virtual_alarm1.set_alarm_client(test1);
 
     let virtual_alarm2 = static_init!(
-        VirtualMuxAlarm<'static, RvTimer<'static>>,
+        VirtualMuxAlarm<'static, RvTimer<'static, crate::ChipConfig>>,
         VirtualMuxAlarm::new(mux)
     );
     virtual_alarm2.setup();
 
     let test2 = static_init!(
-        TestRandomAlarm<'static, VirtualMuxAlarm<'static, RvTimer<'static>>>,
+        TestRandomAlarm<'static, VirtualMuxAlarm<'static, RvTimer<'static, crate::ChipConfig>>>,
         TestRandomAlarm::new(virtual_alarm2, 37, 'B', false)
     );
     virtual_alarm2.set_alarm_client(test2);
 
     let virtual_alarm3 = static_init!(
-        VirtualMuxAlarm<'static, RvTimer<'static>>,
+        VirtualMuxAlarm<'static, RvTimer<'static, crate::ChipConfig>>,
         VirtualMuxAlarm::new(mux)
     );
     virtual_alarm3.setup();
 
     let test3 = static_init!(
-        TestRandomAlarm<'static, VirtualMuxAlarm<'static, RvTimer<'static>>>,
+        TestRandomAlarm<'static, VirtualMuxAlarm<'static, RvTimer<'static, crate::ChipConfig>>>,
         TestRandomAlarm::new(virtual_alarm3, 89, 'C', false)
     );
     virtual_alarm3.set_alarm_client(test3);

--- a/chips/earlgrey/Cargo.toml
+++ b/chips/earlgrey/Cargo.toml
@@ -8,13 +8,6 @@ version.workspace = true
 authors.workspace = true
 edition.workspace = true
 
-[features]
-# Compiling this crate requires enabling one of these features, otherwise
-# the default will be chosen.
-config_fpga_cw310 = ["config_disable_default"]
-config_sim_verilator = ["config_disable_default"]
-config_disable_default = []
-
 [dependencies]
 lowrisc = { path = "../lowrisc" }
 rv32i = { path = "../../arch/rv32i" }

--- a/chips/earlgrey/src/chip_config.rs
+++ b/chips/earlgrey/src/chip_config.rs
@@ -4,48 +4,30 @@
 
 //! Chip specific configuration.
 //!
-//! This file includes configuration values for different implementations and
-//! uses of the same earlgrey chip. For example, running the chip on an FPGA
-//! requires different parameters from running it in a verilog simulator.
-//! Additionally, chips on different platforms can be used differently, so this
-//! also permits changing values like the UART baud rate to enable better
-//! debugging on platforms that can support it.
-//!
-//! The configuration used is selected via Cargo features specified when the
-//! board is compiled.
+//! This file includes a common configuration trait and pre-defined constants
+//! values for different implementations and uses of the same earlgrey chip. For
+//! example, running the chip on an FPGA requires different parameters from
+//! running it in a verilog simulator.  Additionally, chips on different
+//! platforms can be used differently, so this also permits changing values like
+//! the UART baud rate to enable better debugging on platforms that can support
+//! it.
 
 /// Earlgrey configuration based on the target device.
-pub struct Config<'a> {
+pub trait EarlGreyConfig {
     /// Identifier for the platform. This is useful for debugging to confirm the
     /// correct configuration of the chip is being used.
-    pub name: &'a str,
+    const NAME: &'static str;
+
     /// The clock speed of the CPU in Hz.
-    pub cpu_freq: u32,
+    const CPU_FREQ: u32;
+
     /// The clock speed of the peripherals in Hz.
-    pub peripheral_freq: u32,
+    const PERIPHERAL_FREQ: u32;
+
     /// The clock of the AON Timer
-    pub aon_timer_freq: u32,
+    const AON_TIMER_FREQ: u32;
+
     /// The baud rate for UART. This allows for a version of the chip that can
     /// support a faster baud rate to use it to help with debugging.
-    pub uart_baudrate: u32,
+    const UART_BAUDRATE: u32;
 }
-
-/// Config for running EarlGrey on the CW310 FPGA
-#[cfg(any(feature = "config_fpga_cw310", not(feature = "config_disable_default")))]
-pub const CONFIG: Config = Config {
-    name: "fpga_cw310",
-    cpu_freq: 10_000_000,
-    peripheral_freq: 2_500_000,
-    aon_timer_freq: 250_000,
-    uart_baudrate: 115200,
-};
-
-/// Config for running EarlGrey in a verilog simulator.
-#[cfg(feature = "config_sim_verilator")]
-pub const CONFIG: Config = Config {
-    name: "sim_verilator",
-    cpu_freq: 500_000,
-    peripheral_freq: 125_000,
-    aon_timer_freq: 125_000,
-    uart_baudrate: 7200,
-};

--- a/chips/earlgrey/src/uart.rs
+++ b/chips/earlgrey/src/uart.rs
@@ -6,10 +6,7 @@ use kernel::utilities::StaticRef;
 use lowrisc::registers::uart_regs::UartRegisters;
 pub use lowrisc::uart::Uart;
 
-use crate::chip_config::CONFIG;
 use crate::registers::top_earlgrey::TOP_EARLGREY_UART0_BASE_ADDR;
-
-pub const UART0_BAUDRATE: u32 = CONFIG.uart_baudrate;
 
 pub const UART0_BASE: StaticRef<UartRegisters> =
     unsafe { StaticRef::new(TOP_EARLGREY_UART0_BASE_ADDR as *const UartRegisters) };


### PR DESCRIPTION
### Pull Request Overview

The EarlGrey chip exists in multiple variants, such as the CW310 FPGA instantiation, the Verilator simulation, or eventually the taped out chip. While the "silicon" will be idential in those chips, they can still have slightly different configurations for attributes such as clock speeds.

To drive these configuration flags, instead of using Cargo feature flags and passing them down to the `earlgrey` chip crate, this changes the chip crate to accept a generic `EarlGreyConfig` argument wherever necessary. This is a trait containing a number of constants. By implementing this trait on variant-less enums, it is guaranteed to not generate any runtime code.

This change is in the spirit of reducing Tock's reliance on conditional compilation: by plugging in a type-parameter implementing a given trait, all code is always type-checked to adhere to this trait's constraints, regardless of the actual configuration used during the build. Conditional compilation is solely used to switch between two type-aliases which expose implementations of the aforementioned trait.

In practical terms, this allows downstream users to build a customized board crate (where the board logically is also responsible for driving clocks, etc.), without maintaining patches for the chip crate. The chip crate is reduced to code related to the actual silicon. We can use this to work around issues like that of #3639, where [a downstream board definition](https://github.com/lowRISC/opentitan/pull/19477) can change its clock speed configuration to be internally consistent, while waiting on a public bitstream to be available for Tock to use.


### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [x] Ran `make prepush`.

Ping @cfrantz 