### PR TITLE
chips/lowrisc/uart: fix spurious RX buffer underrun error condition

### DIFF
--- a/chips/lowrisc/src/uart.rs
+++ b/chips/lowrisc/src/uart.rs
@@ -152,14 +152,14 @@ impl<'a> Uart<'a> {
                     let mut return_code = Ok(());
 
                     for i in 0..self.rx_len.get() {
-                        rx_buf[i] = regs.rdata.get() as u8;
-                        len = i + 1;
-
                         if regs.status.is_set(STATUS::RXEMPTY) {
                             /* RX is empty */
                             return_code = Err(ErrorCode::SIZE);
                             break;
                         }
+
+                        rx_buf[i] = regs.rdata.get() as u8;
+                        len = i + 1;
                     }
 
                     client.received_buffer(rx_buf, len, return_code, uart::Error::None);


### PR DESCRIPTION
### Pull Request Overview

The lowRISC UART driver currently generates spurious RX buffer underrun errors on asynchronous receive operations. By checking the `STATUS:RXEMPTY` register _after_ reading an octet from the UART FIFO, it can set asychronous return code flag of the `received_buffer` callback to `ErrorCode::SIZE`, even if a receive buffer underrun has not actually occured. This reliably happens when the last available character in the FIFO coincides with the end of the receive buffer.

Instead, the driver should loop over the receive buffer and first check whether no more data is available, before then attempting to read a given octet.

### Testing Strategy

This pull request was tested by using the OpenTitan EarlGrey chip on a CW310 board and reading characters one octet at a time from a libtock-rs app.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [x] Ran `make prepush`.
