### PR TITLE
clippy: -D clippy::enum_glob_use

### DIFF
--- a/capsules/core/src/process_console.rs
+++ b/capsules/core/src/process_console.rs
@@ -147,7 +147,12 @@ enum EscState {
 
 impl EscState {
     fn next_state(self, data: u8) -> Self {
-        use self::{EscKey::*, EscState::*};
+        use self::{
+            EscKey::{Delete, Down, End, Home, Left, Right, Up},
+            EscState::{
+                Bracket, Bracket3, Bypass, Complete, Started, Unrecognized, UnrecognizedDone,
+            },
+        };
         match (self, data) {
             (Bypass, ESC) | (UnrecognizedDone, ESC) | (Complete(_), ESC) => Started,
             (Bypass, _) | (UnrecognizedDone, _) | (Complete(_), _) => Bypass,

--- a/chips/imxrt10xx/src/gpio.rs
+++ b/chips/imxrt10xx/src/gpio.rs
@@ -650,7 +650,7 @@ impl<'a> Pin<'a> {
     }
 
     fn set_edge_sensitive(&self, sensitive: hil::gpio::InterruptEdge) {
-        use hil::gpio::InterruptEdge::*;
+        use hil::gpio::InterruptEdge::{EitherEdge, FallingEdge, RisingEdge};
         const RISING_EDGE_SENSITIVE: u32 = 0b10;
         const FALLING_EDGE_SENSITIVE: u32 = 0b11;
 

--- a/tools/run_clippy.sh
+++ b/tools/run_clippy.sh
@@ -252,7 +252,6 @@ CLIPPY_ARGS_PEDANTIC="
 -A clippy::ptr_cast_constness
 -A clippy::mut_mut
 -A clippy::cast_ptr_alignment
--A clippy::enum_glob_use
 -A clippy::used_underscore_binding
 -A clippy::bool_to_int_with_if
 -A clippy::inconsistent_struct_constructor


### PR DESCRIPTION


### Pull Request Overview

This pull request enables the https://rust-lang.github.io/rust-clippy/master/index.html#/enum_g lint.

This should have been enabled long ago.

### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
