### PR TITLE
Clippy: -D question_mark

### DIFF
--- a/arch/rv32i/src/epmp.rs
+++ b/arch/rv32i/src/epmp.rs
@@ -612,9 +612,7 @@ impl<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> kernel::platform::mpu::MPU
 
         let region = PMPRegion::new_app(start as *const u8, size, permissions);
 
-        if region.is_none() {
-            return None;
-        }
+        region?;
 
         config.regions[region_num] = region;
         config.is_dirty.set(true);
@@ -706,9 +704,7 @@ impl<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> kernel::platform::mpu::MPU
             permissions,
         );
 
-        if region.is_none() {
-            return None;
-        }
+        region?;
 
         config.regions[region_num] = region;
 
@@ -962,9 +958,7 @@ impl<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> kernel::platform::mpu::KernelM
 
         let region = PMPRegion::new_kernel(start as *const u8, size, permissions);
 
-        if region.is_none() {
-            return None;
-        }
+        region?;
 
         config.regions[region_num] = region;
 

--- a/capsules/extra/src/hmac.rs
+++ b/capsules/extra/src/hmac.rs
@@ -147,9 +147,7 @@ impl<
                             })
                         })
                         .unwrap_or(Err(ErrorCode::RESERVE));
-                    if ret.is_err() {
-                        return ret;
-                    }
+                    ret?;
 
                     kernel_data
                         .get_readonly_processbuffer(ro_allow::DATA)

--- a/capsules/extra/src/hmac.rs
+++ b/capsules/extra/src/hmac.rs
@@ -120,7 +120,7 @@ impl<
         self.processid.map_or(Err(ErrorCode::RESERVE), |processid| {
             self.apps
                 .enter(processid, |app, kernel_data| {
-                    let ret = kernel_data
+                    kernel_data
                         .get_readonly_processbuffer(ro_allow::KEY)
                         .and_then(|key| {
                             key.enter(|k| {
@@ -146,8 +146,7 @@ impl<
                                 }
                             })
                         })
-                        .unwrap_or(Err(ErrorCode::RESERVE));
-                    ret?;
+                        .unwrap_or(Err(ErrorCode::RESERVE))?;
 
                     kernel_data
                         .get_readonly_processbuffer(ro_allow::DATA)

--- a/capsules/extra/src/sha.rs
+++ b/capsules/extra/src/sha.rs
@@ -115,16 +115,12 @@ impl<
         self.processid.map_or(Err(ErrorCode::RESERVE), |processid| {
             self.apps
                 .enter(processid, |app, kernel_data| {
-                    let ret = if let Some(op) = &app.sha_operation {
-                        match op {
-                            ShaOperation::Sha256 => self.sha.set_mode_sha256(),
-                            ShaOperation::Sha384 => self.sha.set_mode_sha384(),
-                            ShaOperation::Sha512 => self.sha.set_mode_sha512(),
-                        }
-                    } else {
-                        Err(ErrorCode::INVAL)
-                    };
-                    ret?;
+                    match app.sha_operation {
+                        Some(ShaOperation::Sha256) => self.sha.set_mode_sha256()?,
+                        Some(ShaOperation::Sha384) => self.sha.set_mode_sha384()?,
+                        Some(ShaOperation::Sha512) => self.sha.set_mode_sha512()?,
+                        _ => return Err(ErrorCode::INVAL),
+                    }
 
                     kernel_data
                         .get_readonly_processbuffer(ro_allow::DATA)

--- a/capsules/extra/src/sha.rs
+++ b/capsules/extra/src/sha.rs
@@ -124,9 +124,7 @@ impl<
                     } else {
                         Err(ErrorCode::INVAL)
                     };
-                    if ret.is_err() {
-                        return ret;
-                    }
+                    ret?;
 
                     kernel_data
                         .get_readonly_processbuffer(ro_allow::DATA)

--- a/capsules/extra/src/symmetric_encryption/aes.rs
+++ b/capsules/extra/src/symmetric_encryption/aes.rs
@@ -91,24 +91,20 @@ impl<
             self.apps
                 .enter(processid, |app, kernel_data| {
                     self.aes.enable();
-                    let ret = if let Some(op) = &app.aes_operation {
-                        match op {
-                            AesOperation::AES128Ctr(encrypt) => {
-                                self.aes.set_mode_aes128ctr(*encrypt)
-                            }
-                            AesOperation::AES128CBC(encrypt) => {
-                                self.aes.set_mode_aes128cbc(*encrypt)
-                            }
-                            AesOperation::AES128ECB(encrypt) => {
-                                self.aes.set_mode_aes128ecb(*encrypt)
-                            }
-                            AesOperation::AES128CCM(_encrypt) => Ok(()),
-                            AesOperation::AES128GCM(_encrypt) => Ok(()),
+                    match app.aes_operation {
+                        Some(AesOperation::AES128Ctr(encrypt)) => {
+                            self.aes.set_mode_aes128ctr(encrypt)?
                         }
-                    } else {
-                        Err(ErrorCode::INVAL)
-                    };
-                    ret?;
+                        Some(AesOperation::AES128CBC(encrypt)) => {
+                            self.aes.set_mode_aes128cbc(encrypt)?
+                        }
+                        Some(AesOperation::AES128ECB(encrypt)) => {
+                            self.aes.set_mode_aes128ecb(encrypt)?
+                        }
+                        Some(AesOperation::AES128CCM(_encrypt)) => {}
+                        Some(AesOperation::AES128GCM(_encrypt)) => {}
+                        _ => return Err(ErrorCode::INVAL),
+                    }
 
                     kernel_data
                         .get_readonly_processbuffer(ro_allow::KEY)

--- a/capsules/extra/src/symmetric_encryption/aes.rs
+++ b/capsules/extra/src/symmetric_encryption/aes.rs
@@ -108,9 +108,7 @@ impl<
                     } else {
                         Err(ErrorCode::INVAL)
                     };
-                    if ret.is_err() {
-                        return ret;
-                    }
+                    ret?;
 
                     kernel_data
                         .get_readonly_processbuffer(ro_allow::KEY)
@@ -134,21 +132,15 @@ impl<
                                             AesOperation::AES128Ctr(_)
                                             | AesOperation::AES128CBC(_)
                                             | AesOperation::AES128ECB(_) => {
-                                                if let Err(e) = AES128::set_key(self.aes, buf) {
-                                                    return Err(e);
-                                                }
+                                                AES128::set_key(self.aes, buf)?;
                                                 Ok(())
                                             }
                                             AesOperation::AES128CCM(_) => {
-                                                if let Err(e) = AES128CCM::set_key(self.aes, buf) {
-                                                    return Err(e);
-                                                }
+                                                AES128CCM::set_key(self.aes, buf)?;
                                                 Ok(())
                                             }
                                             AesOperation::AES128GCM(_) => {
-                                                if let Err(e) = AES128GCM::set_key(self.aes, buf) {
-                                                    return Err(e);
-                                                }
+                                                AES128GCM::set_key(self.aes, buf)?;
                                                 Ok(())
                                             }
                                         }
@@ -182,25 +174,15 @@ impl<
                                             AesOperation::AES128Ctr(_)
                                             | AesOperation::AES128CBC(_)
                                             | AesOperation::AES128ECB(_) => {
-                                                if let Err(e) = AES128::set_iv(self.aes, buf) {
-                                                    return Err(e);
-                                                }
+                                                AES128::set_iv(self.aes, buf)?;
                                                 Ok(())
                                             }
                                             AesOperation::AES128CCM(_) => {
-                                                if let Err(e) =
-                                                    AES128CCM::set_nonce(self.aes, &buf[0..13])
-                                                {
-                                                    return Err(e);
-                                                }
+                                                AES128CCM::set_nonce(self.aes, &buf[0..13])?;
                                                 Ok(())
                                             }
                                             AesOperation::AES128GCM(_) => {
-                                                if let Err(e) =
-                                                    AES128GCM::set_iv(self.aes, &buf[0..13])
-                                                {
-                                                    return Err(e);
-                                                }
+                                                AES128GCM::set_iv(self.aes, &buf[0..13])?;
                                                 Ok(())
                                             }
                                         }
@@ -290,16 +272,14 @@ impl<
                                         }
                                     }
 
-                                    if let Err(e) = self.calculate_output(
+                                    self.calculate_output(
                                         op,
                                         app.aoff.get(),
                                         app.moff.get(),
                                         app.mlen.get(),
                                         app.mic_len.get(),
                                         app.confidential.get(),
-                                    ) {
-                                        return Err(e);
-                                    }
+                                    )?;
                                     Ok(())
                                 } else {
                                     Err(ErrorCode::FAIL)
@@ -891,16 +871,14 @@ impl<
                                         )?;
 
                                         if let Some(op) = app.aes_operation.as_ref() {
-                                            if let Err(e) = self.calculate_output(
+                                            self.calculate_output(
                                                 op,
                                                 app.aoff.get(),
                                                 app.moff.get(),
                                                 app.mlen.get(),
                                                 app.mic_len.get(),
                                                 app.confidential.get(),
-                                            ) {
-                                                return Err(e);
-                                            }
+                                            )?;
                                             Ok(())
                                         } else {
                                             Err(ErrorCode::FAIL)

--- a/chips/lowrisc/src/flash_ctrl.rs
+++ b/chips/lowrisc/src/flash_ctrl.rs
@@ -1102,16 +1102,12 @@ impl hil::flash::Flash for FlashCtrl<'_> {
 
         if !self.data_configured.get() {
             // If we aren't configured yet, configure now
-            if let Err(e) = self.configure_data_partition(self.region_num) {
-                return Err(e);
-            }
+            self.configure_data_partition(self.region_num)?;
         }
 
         if !self.info_configured.get() {
             // If we aren't configured yet, configure now
-            if let Err(e) = self.configure_info_partition(FlashBank::BANK1, self.region_num) {
-                return Err(e);
-            }
+            self.configure_info_partition(FlashBank::BANK1, self.region_num)?;
         }
 
         // Check control status before we commit

--- a/chips/rp2040/src/spi.rs
+++ b/chips/rp2040/src/spi.rs
@@ -552,9 +552,7 @@ impl<'a> SpiMaster<'a> for Spi<'a> {
 
     fn read_write_byte(&self, val: u8) -> Result<u8, ErrorCode> {
         if !self.is_busy() {
-            if let Err(error) = self.write_byte(val) {
-                return Err(error);
-            }
+            self.write_byte(val)?;
 
             while !self.registers.sspsr.is_set(SSPSR::RNE) {}
 

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -578,14 +578,12 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
                 min_region_size,
                 mpu::Permissions::ReadWriteOnly,
                 &mut config,
-            );
-
-            new_region?;
+            )?;
 
             for region in self.mpu_regions.iter() {
                 if region.get().is_none() {
-                    region.set(new_region);
-                    return new_region;
+                    region.set(Some(new_region));
+                    return Some(new_region);
                 }
             }
 

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -580,9 +580,7 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
                 &mut config,
             );
 
-            if new_region.is_none() {
-                return None;
-            }
+            new_region?;
 
             for region in self.mpu_regions.iter() {
                 if region.get().is_none() {

--- a/tools/run_clippy.sh
+++ b/tools/run_clippy.sh
@@ -123,7 +123,6 @@ CLIPPY_ARGS_STYLE="
 -A clippy::needless-range-loop
 -A clippy::needless_late_init
 -A clippy::option_map_or_none
--A clippy::question-mark
 -A clippy::redundant_field_names
 -A clippy::redundant_pattern_matching
 -A clippy::unusual-byte-groupings


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the question mark clippy lint that says to use `?` instead of checking the error and then returning it.

This makes some changes to make the ? use more natural.

Skips the epmp because it is changing anyway.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
