### PR TITLE
boards/pico_explorer_base: add buzzer driver

### DIFF
--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -80,7 +80,20 @@ pub struct PicoExplorerBase {
     led: &'static capsules_core::led::LedDriver<'static, LedHigh<'static, RPGpioPin<'static>>, 1>,
     adc: &'static capsules_core::adc::AdcVirtualized<'static>,
     temperature: &'static capsules_extra::temperature::TemperatureSensor<'static>,
-
+    buzzer_driver: &'static capsules_extra::buzzer_driver::Buzzer<
+        'static,
+        capsules_extra::buzzer_pwm::PwmBuzzer<
+            'static,
+            capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<
+                'static,
+                rp2040::timer::RPTimer<'static>,
+            >,
+            capsules_core::virtualizers::virtual_pwm::PwmPinUser<
+                'static,
+                rp2040::pwm::Pwm<'static>,
+            >,
+        >,
+    >,
     button: &'static capsules_core::button::Button<'static, RPGpioPin<'static>>,
     screen: &'static capsules_extra::screen::Screen<'static>,
 
@@ -101,10 +114,9 @@ impl SyscallDriverLookup for PicoExplorerBase {
             kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
             capsules_core::adc::DRIVER_NUM => f(Some(self.adc)),
             capsules_extra::temperature::DRIVER_NUM => f(Some(self.temperature)),
-
+            capsules_extra::buzzer_driver::DRIVER_NUM => f(Some(self.buzzer_driver)),
             capsules_core::button::DRIVER_NUM => f(Some(self.button)),
             capsules_extra::screen::DRIVER_NUM => f(Some(self.screen)),
-
             _ => f(None),
         }
     }
@@ -387,19 +399,20 @@ pub unsafe fn main() {
         components::gpio_component_helper!(
             RPGpioPin,
             // Used for serial communication. Comment them in if you don't use serial.
-            // 0 => peripherals.pins.get_pin(RPGpio::GPIO0),
-            // 1 => peripherals.pins.get_pin(RPGpio::GPIO1),
-            2 => peripherals.pins.get_pin(RPGpio::GPIO2),
-            3 => peripherals.pins.get_pin(RPGpio::GPIO3),
-            4 => peripherals.pins.get_pin(RPGpio::GPIO4),
-            5 => peripherals.pins.get_pin(RPGpio::GPIO5),
-            6 => peripherals.pins.get_pin(RPGpio::GPIO6),
-            7 => peripherals.pins.get_pin(RPGpio::GPIO7),
-            20 => peripherals.pins.get_pin(RPGpio::GPIO20),
-            21 => peripherals.pins.get_pin(RPGpio::GPIO21),
-            22 => peripherals.pins.get_pin(RPGpio::GPIO22),
-            23 => peripherals.pins.get_pin(RPGpio::GPIO23),
-            24 => peripherals.pins.get_pin(RPGpio::GPIO24),
+            // 0 => &peripherals.pins.get_pin(RPGpio::GPIO0),
+            // 1 => &peripherals.pins.get_pin(RPGpio::GPIO1),
+            // Used for Buzzer.
+            // 2 => &peripherals.pins.get_pin(RPGpio::GPIO2),
+            3 => &peripherals.pins.get_pin(RPGpio::GPIO3),
+            4 => &peripherals.pins.get_pin(RPGpio::GPIO4),
+            5 => &peripherals.pins.get_pin(RPGpio::GPIO5),
+            6 => &peripherals.pins.get_pin(RPGpio::GPIO6),
+            7 => &peripherals.pins.get_pin(RPGpio::GPIO7),
+            20 => &peripherals.pins.get_pin(RPGpio::GPIO20),
+            21 => &peripherals.pins.get_pin(RPGpio::GPIO21),
+            22 => &peripherals.pins.get_pin(RPGpio::GPIO22),
+            23 => &peripherals.pins.get_pin(RPGpio::GPIO23),
+            24 => &peripherals.pins.get_pin(RPGpio::GPIO24),
         ),
     )
     .finalize(components::gpio_component_static!(RPGpioPin<'static>));
@@ -410,6 +423,12 @@ pub unsafe fn main() {
     ));
 
     peripherals.adc.init();
+
+    // Set PWM function for Buzzer.
+    let _ = &peripherals
+        .pins
+        .get_pin(RPGpio::GPIO2)
+        .set_function(GpioFunction::PWM);
 
     let adc_mux = components::adc::AdcMuxComponent::new(&peripherals.adc)
         .finalize(components::adc_mux_component_static!(Adc));
@@ -527,10 +546,10 @@ pub unsafe fn main() {
                 adc_channel_1,
                 adc_channel_2,
             ));
+
     let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
         .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
-
     // PROCESS CONSOLE
     let process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
@@ -545,6 +564,71 @@ pub unsafe fn main() {
     let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
+    //--------------------------------------------------------------------------
+    // BUZZER
+    //--------------------------------------------------------------------------
+    use kernel::hil::buzzer::Buzzer;
+    use kernel::hil::time::Alarm;
+
+    let mux_pwm = components::pwm::PwmMuxComponent::new(&peripherals.pwm)
+        .finalize(components::pwm_mux_component_static!(rp2040::pwm::Pwm));
+
+    let virtual_pwm_buzzer =
+        components::pwm::PwmPinUserComponent::new(&mux_pwm, rp2040::gpio::RPGpio::GPIO2)
+            .finalize(components::pwm_pin_user_component_static!(rp2040::pwm::Pwm));
+
+    let virtual_alarm_buzzer = static_init!(
+        capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<
+            'static,
+            rp2040::timer::RPTimer,
+        >,
+        capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm::new(mux_alarm)
+    );
+
+    virtual_alarm_buzzer.setup();
+
+    let pwm_buzzer = static_init!(
+        capsules_extra::buzzer_pwm::PwmBuzzer<
+            'static,
+            capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<
+                'static,
+                rp2040::timer::RPTimer,
+            >,
+            capsules_core::virtualizers::virtual_pwm::PwmPinUser<'static, rp2040::pwm::Pwm>,
+        >,
+        capsules_extra::buzzer_pwm::PwmBuzzer::new(
+            virtual_pwm_buzzer,
+            virtual_alarm_buzzer,
+            capsules_extra::buzzer_pwm::DEFAULT_MAX_BUZZ_TIME_MS,
+        )
+    );
+
+    let buzzer_driver = static_init!(
+        capsules_extra::buzzer_driver::Buzzer<
+            'static,
+            capsules_extra::buzzer_pwm::PwmBuzzer<
+                'static,
+                capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<
+                    'static,
+                    rp2040::timer::RPTimer,
+                >,
+                capsules_core::virtualizers::virtual_pwm::PwmPinUser<'static, rp2040::pwm::Pwm>,
+            >,
+        >,
+        capsules_extra::buzzer_driver::Buzzer::new(
+            pwm_buzzer,
+            capsules_extra::buzzer_driver::DEFAULT_MAX_BUZZ_TIME_MS,
+            board_kernel.create_grant(
+                capsules_extra::buzzer_driver::DRIVER_NUM,
+                &memory_allocation_capability
+            )
+        )
+    );
+
+    pwm_buzzer.set_client(buzzer_driver);
+
+    virtual_alarm_buzzer.set_alarm_client(pwm_buzzer);
+
     let pico_explorer_base = PicoExplorerBase {
         ipc: kernel::ipc::IPC::new(
             board_kernel,
@@ -557,10 +641,9 @@ pub unsafe fn main() {
         console,
         adc: adc_syscall,
         temperature: temp,
-
+        buzzer_driver,
         button,
         screen,
-
         scheduler,
         systick: cortexm0p::systick::SysTick::new_with_calibration(125_000_000),
     };


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a `buzzer` driver for the Pico Explorer board.


### Testing Strategy

This pull request was tested by using the `libtock-c` buzzer API on a Pico Explorer board.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
