### PR TITLE
kernel: export `StoppedExecutingReason`

### DIFF
--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -72,31 +72,6 @@ pub struct Kernel {
     checker: ProcessCheckerMachine,
 }
 
-/// Enum used to inform scheduler why a process stopped executing (aka why
-/// `do_process()` returned).
-#[derive(PartialEq, Eq)]
-pub enum StoppedExecutingReason {
-    /// The process returned because it is no longer ready to run.
-    NoWorkLeft,
-
-    /// The process faulted, and the board restart policy was configured such
-    /// that it was not restarted and there was not a kernel panic.
-    StoppedFaulted,
-
-    /// The kernel stopped the process.
-    Stopped,
-
-    /// The process was preempted because its timeslice expired.
-    TimesliceExpired,
-
-    /// The process returned because it was preempted by the kernel. This can
-    /// mean that kernel work became ready (most likely because an interrupt
-    /// fired and the kernel thread needs to execute the bottom half of the
-    /// interrupt), or because the scheduler no longer wants to execute that
-    /// process.
-    KernelPreemption,
-}
-
 /// Represents the different outcomes when trying to allocate a grant region
 enum AllocResult {
     NoAllocation,
@@ -523,7 +498,7 @@ impl Kernel {
         process: &dyn process::Process,
         ipc: Option<&crate::ipc::IPC<NUM_PROCS>>,
         timeslice_us: Option<u32>,
-    ) -> (StoppedExecutingReason, Option<u32>) {
+    ) -> (process::StoppedExecutingReason, Option<u32>) {
         // We must use a dummy scheduler timer if the process should be executed
         // without any timeslice restrictions. Note, a chip may not provide a
         // real scheduler timer implementation even if a timeslice is requested.
@@ -542,7 +517,7 @@ impl Kernel {
 
         // Need to track why the process is no longer executing so that we can
         // inform the scheduler.
-        let mut return_reason = StoppedExecutingReason::NoWorkLeft;
+        let mut return_reason = process::StoppedExecutingReason::NoWorkLeft;
 
         // Since the timeslice counts both the process's execution time and the
         // time spent in the kernel on behalf of the process (setting it up and
@@ -558,7 +533,7 @@ impl Kernel {
             if stop_running {
                 // Process ran out of time while the kernel was executing.
                 process.debug_timeslice_expired();
-                return_reason = StoppedExecutingReason::TimesliceExpired;
+                return_reason = process::StoppedExecutingReason::TimesliceExpired;
                 break;
             }
 
@@ -569,7 +544,7 @@ impl Kernel {
                     .continue_process(process.processid(), chip)
             };
             if !continue_process {
-                return_reason = StoppedExecutingReason::KernelPreemption;
+                return_reason = process::StoppedExecutingReason::KernelPreemption;
                 break;
             }
 
@@ -577,7 +552,7 @@ impl Kernel {
             // try to run it. This case can happen if a process faults and is
             // stopped, for example.
             if !process.ready() {
-                return_reason = StoppedExecutingReason::NoWorkLeft;
+                return_reason = process::StoppedExecutingReason::NoWorkLeft;
                 break;
             }
 
@@ -620,7 +595,7 @@ impl Kernel {
                             if scheduler_timer.get_remaining_us().is_none() {
                                 // This interrupt was a timeslice expiration.
                                 process.debug_timeslice_expired();
-                                return_reason = StoppedExecutingReason::TimesliceExpired;
+                                return_reason = process::StoppedExecutingReason::TimesliceExpired;
                                 break;
                             }
                             // Go to the beginning of loop to determine whether
@@ -729,11 +704,11 @@ impl Kernel {
                     panic!("Attempted to schedule an unrunnable process");
                 }
                 process::State::StoppedRunning => {
-                    return_reason = StoppedExecutingReason::Stopped;
+                    return_reason = process::StoppedExecutingReason::Stopped;
                     break;
                 }
                 process::State::StoppedYielded => {
-                    return_reason = StoppedExecutingReason::Stopped;
+                    return_reason = process::StoppedExecutingReason::Stopped;
                     break;
                 }
             }
@@ -744,7 +719,7 @@ impl Kernel {
         let time_executed_us = timeslice_us.map_or(None, |timeslice| {
             // Note, we cannot call `.get_remaining_us()` again if it has previously
             // returned `None`, so we _must_ check the return reason first.
-            if return_reason == StoppedExecutingReason::TimesliceExpired {
+            if return_reason == process::StoppedExecutingReason::TimesliceExpired {
                 // used the whole timeslice
                 Some(timeslice)
             } else {

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -244,6 +244,34 @@ impl PartialEq for ShortID {
 }
 impl Eq for ShortID {}
 
+/// Enum used to inform scheduler why a process stopped executing (aka why
+/// `do_process()` returned).
+///
+/// This is publicly exported to allow for schedulers implemented outside of the
+/// kernel crate.
+#[derive(PartialEq, Eq)]
+pub enum StoppedExecutingReason {
+    /// The process returned because it is no longer ready to run.
+    NoWorkLeft,
+
+    /// The process faulted, and the board restart policy was configured such
+    /// that it was not restarted and there was not a kernel panic.
+    StoppedFaulted,
+
+    /// The kernel stopped the process.
+    Stopped,
+
+    /// The process was preempted because its timeslice expired.
+    TimesliceExpired,
+
+    /// The process returned because it was preempted by the kernel. This can
+    /// mean that kernel work became ready (most likely because an interrupt
+    /// fired and the kernel thread needs to execute the bottom half of the
+    /// interrupt), or because the scheduler no longer wants to execute that
+    /// process.
+    KernelPreemption,
+}
+
 /// This trait represents a generic process that the Tock scheduler can
 /// schedule.
 pub trait Process {

--- a/kernel/src/scheduler.rs
+++ b/kernel/src/scheduler.rs
@@ -10,9 +10,9 @@ pub mod priority;
 pub mod round_robin;
 
 use crate::deferred_call::DeferredCall;
-use crate::kernel::StoppedExecutingReason;
 use crate::platform::chip::Chip;
 use crate::process::ProcessId;
+use crate::process::StoppedExecutingReason;
 
 /// Trait which any scheduler must implement.
 pub trait Scheduler<C: Chip> {

--- a/kernel/src/scheduler/cooperative.rs
+++ b/kernel/src/scheduler/cooperative.rs
@@ -16,9 +16,9 @@
 //! that was executing.
 
 use crate::collections::list::{List, ListLink, ListNode};
-use crate::kernel::StoppedExecutingReason;
 use crate::platform::chip::Chip;
 use crate::process::Process;
+use crate::process::StoppedExecutingReason;
 use crate::scheduler::{Scheduler, SchedulingDecision};
 
 /// A node in the linked list the scheduler uses to track processes

--- a/kernel/src/scheduler/mlfq.rs
+++ b/kernel/src/scheduler/mlfq.rs
@@ -25,10 +25,10 @@ use core::cell::Cell;
 
 use crate::collections::list::{List, ListLink, ListNode};
 use crate::hil::time::{self, ConvertTicks, Ticks};
-use crate::kernel::StoppedExecutingReason;
 use crate::platform::chip::Chip;
 use crate::process::Process;
 use crate::process::ProcessId;
+use crate::process::StoppedExecutingReason;
 use crate::scheduler::{Scheduler, SchedulingDecision};
 
 #[derive(Default)]

--- a/kernel/src/scheduler/priority.rs
+++ b/kernel/src/scheduler/priority.rs
@@ -15,9 +15,10 @@
 //! for an interrupt to occur, which will cause the process to stop running.
 
 use crate::deferred_call::DeferredCall;
-use crate::kernel::{Kernel, StoppedExecutingReason};
+use crate::kernel::Kernel;
 use crate::platform::chip::Chip;
 use crate::process::ProcessId;
+use crate::process::StoppedExecutingReason;
 use crate::scheduler::{Scheduler, SchedulingDecision};
 use crate::utilities::cells::OptionalCell;
 

--- a/kernel/src/scheduler/round_robin.rs
+++ b/kernel/src/scheduler/round_robin.rs
@@ -21,9 +21,9 @@
 use core::cell::Cell;
 
 use crate::collections::list::{List, ListLink, ListNode};
-use crate::kernel::StoppedExecutingReason;
 use crate::platform::chip::Chip;
 use crate::process::Process;
+use crate::process::StoppedExecutingReason;
 use crate::scheduler::{Scheduler, SchedulingDecision};
 
 /// A node in the linked list the scheduler uses to track processes


### PR DESCRIPTION

### Pull Request Overview

Export `kernel::process::StoppedExecutingReason`. This enables out-of-crate schedulers.

Currently this is public in the kernel.rs module, but not exported out of the crate.

I need this to update the bootloader.





### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
