### PR TITLE
capsules: rename KVSystem to Kv

### DIFF
--- a/capsules/core/src/driver.rs
+++ b/capsules/core/src/driver.rs
@@ -54,7 +54,7 @@ pub enum NUM {
     AppFlash              = 0x50000,
     NvmStorage            = 0x50001,
     SdCard                = 0x50002,
-    KVSystem              = 0x50003,
+    Kv                    = 0x50003,
 
     // Sensors
     Temperature           = 0x60000,

--- a/capsules/extra/src/kv_driver.rs
+++ b/capsules/extra/src/kv_driver.rs
@@ -42,7 +42,7 @@
 
 use capsules_core::driver;
 /// Syscall driver number.
-pub const DRIVER_NUM: usize = driver::NUM::KVSystem as usize;
+pub const DRIVER_NUM: usize = driver::NUM::Kv as usize;
 
 use core::cmp;
 use kernel::errorcode;


### PR DESCRIPTION
### Pull Request Overview

Keep the same driver number, just renamed since we now export a KV interface to userspace.







### Testing Strategy

CI


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
