### PR TITLE
15.4 link layer security - encryption/decryption

### DIFF
--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -706,9 +706,9 @@ pub unsafe fn main() {
     kernel::deferred_call::DeferredCallClient::register(aes_mux);
     base_peripherals.ecb.set_client(aes_mux);
 
-    let serial_num = nrf52840::ficr::FICR_INSTANCE.address();
+    let device_id = nrf52840::ficr::FICR_INSTANCE.address();
 
-    let serial_num_bottom_16 = u16::from_le_bytes([serial_num[0], serial_num[1]]);
+    let device_id_bottom_16 = u16::from_le_bytes([device_id[0], device_id[1]]);
 
     let (ieee802154_radio, _mux_mac) = components::ieee802154::Ieee802154Component::new(
         board_kernel,
@@ -716,8 +716,8 @@ pub unsafe fn main() {
         &nrf52840_peripherals.ieee802154_radio,
         aes_mux,
         PAN_ID,
-        serial_num_bottom_16,
-        serial_num,
+        device_id_bottom_16,
+        device_id,
     )
     .finalize(components::ieee802154_component_static!(
         nrf52840::ieee802154_radio::Radio,

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -717,6 +717,7 @@ pub unsafe fn main() {
         aes_mux,
         PAN_ID,
         serial_num_bottom_16,
+        serial_num,
     )
     .finalize(components::ieee802154_component_static!(
         nrf52840::ieee802154_radio::Radio,

--- a/boards/components/src/ieee802154.rs
+++ b/boards/components/src/ieee802154.rs
@@ -40,7 +40,7 @@ use core::mem::MaybeUninit;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
-use kernel::hil::radio;
+use kernel::hil::radio::{self, MAX_BUF_SIZE};
 use kernel::hil::symmetric_encryption::{self, AES128Ctr, AES128, AES128CBC, AES128CCM, AES128ECB};
 
 // This buffer is used as an intermediate buffer for AES CCM encryption. An
@@ -103,6 +103,7 @@ macro_rules! ieee802154_component_static {
         let radio_buf = kernel::static_buf!([u8; kernel::hil::radio::MAX_BUF_SIZE]);
         let radio_rx_buf = kernel::static_buf!([u8; kernel::hil::radio::MAX_BUF_SIZE]);
         let crypt_buf = kernel::static_buf!([u8; components::ieee802154::CRYPT_SIZE]);
+        let radio_rx_crypt_buf = kernel::static_buf!([u8; kernel::hil::radio::MAX_BUF_SIZE]);
 
         (
             virtual_aes,
@@ -114,6 +115,7 @@ macro_rules! ieee802154_component_static {
             radio_buf,
             radio_rx_buf,
             crypt_buf,
+            radio_rx_crypt_buf,
         )
     };};
 }
@@ -128,6 +130,7 @@ pub struct Ieee802154Component<
     aes_mux: &'static MuxAES128CCM<'static, A>,
     pan_id: capsules_extra::net::ieee802154::PanID,
     short_addr: u16,
+    long_addr: [u8; 8],
 }
 
 impl<
@@ -142,6 +145,7 @@ impl<
         aes_mux: &'static MuxAES128CCM<'static, A>,
         pan_id: capsules_extra::net::ieee802154::PanID,
         short_addr: u16,
+        long_addr: [u8; 8],
     ) -> Self {
         Self {
             board_kernel,
@@ -150,6 +154,7 @@ impl<
             aes_mux,
             pan_id,
             short_addr,
+            long_addr,
         }
     }
 }
@@ -177,6 +182,7 @@ impl<
         &'static mut MaybeUninit<[u8; radio::MAX_BUF_SIZE]>,
         &'static mut MaybeUninit<[u8; radio::MAX_BUF_SIZE]>,
         &'static mut MaybeUninit<[u8; CRYPT_SIZE]>,
+        &'static mut MaybeUninit<[u8; radio::MAX_BUF_SIZE]>,
     );
     type Output = (
         &'static capsules_extra::ieee802154::RadioDriver<'static>,
@@ -201,10 +207,14 @@ impl<
         self.radio.set_transmit_client(awake_mac);
         self.radio.set_receive_client(awake_mac, radio_rx_buf);
 
+        let radio_rx_crypt_buf = static_buffer.9.write([0; MAX_BUF_SIZE]);
+
         let mac_device = static_buffer
             .2
             .write(capsules_extra::ieee802154::framer::Framer::new(
-                awake_mac, aes_ccm,
+                awake_mac,
+                aes_ccm,
+                kernel::utilities::leasable_buffer::SubSliceMut::new(radio_rx_crypt_buf),
             ));
         AES128CCM::set_client(aes_ccm, mac_device);
         awake_mac.set_transmit_client(mac_device);
@@ -242,7 +252,8 @@ impl<
         userspace_mac.set_transmit_client(radio_driver);
         userspace_mac.set_receive_client(radio_driver);
         userspace_mac.set_pan(self.pan_id);
-        userspace_mac.set_address(self.short_addr);
+        userspace_mac.set_address(self.short_addr); // should we assign this here?
+        userspace_mac.set_address_long(self.long_addr); //this must be assigned here
 
         (radio_driver, mux_mac)
     }

--- a/boards/components/src/ieee802154.rs
+++ b/boards/components/src/ieee802154.rs
@@ -252,8 +252,8 @@ impl<
         userspace_mac.set_transmit_client(radio_driver);
         userspace_mac.set_receive_client(radio_driver);
         userspace_mac.set_pan(self.pan_id);
-        userspace_mac.set_address(self.short_addr); // should we assign this here?
-        userspace_mac.set_address_long(self.long_addr); //this must be assigned here
+        userspace_mac.set_address(self.short_addr);
+        userspace_mac.set_address_long(self.long_addr);
 
         (radio_driver, mux_mac)
     }

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -613,11 +613,12 @@ pub unsafe fn main() {
     // For now, assign the 802.15.4 MAC address on the device as
     // simply a 16-bit short address which represents the last 16 bits
     // of the serial number of the sam4l for this device.  In the
-    // future, we could generate the MAC address by hashing the full
+    // future, we could generate the DEFAULT_EXT_SRC_MAC address by hashing the full
     // 120-bit serial number
     let serial_num: sam4l::serial_num::SerialNum = sam4l::serial_num::SerialNum::new();
     let serial_num_bottom_16 = (serial_num.get_lower_64() & 0x0000_0000_0000_ffff) as u16;
     let src_mac_from_serial_num: MacAddress = MacAddress::Short(serial_num_bottom_16);
+    const DEFAULT_EXT_SRC_MAC: [u8; 8] = [0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77];
 
     let aes_mux = static_init!(
         MuxAES128CCM<'static, sam4l::aes::Aes>,
@@ -635,6 +636,7 @@ pub unsafe fn main() {
         aes_mux,
         PAN_ID,
         serial_num_bottom_16,
+        DEFAULT_EXT_SRC_MAC,
     )
     .finalize(components::ieee802154_component_static!(
         capsules_extra::rf233::RF233<

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -539,6 +539,7 @@ pub unsafe fn start() -> (
         aes_mux,
         PAN_ID,
         serial_num_bottom_16,
+        serial_num,
     )
     .finalize(components::ieee802154_component_static!(
         nrf52840::ieee802154_radio::Radio,

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -529,17 +529,17 @@ pub unsafe fn start() -> (
             nrf52840::aes::AesECB
         ));
 
-    let serial_num = nrf52840::ficr::FICR_INSTANCE.address();
-    let serial_num_bottom_16 = u16::from_le_bytes([serial_num[0], serial_num[1]]);
-    let src_mac_from_serial_num: MacAddress = MacAddress::Short(serial_num_bottom_16);
+    let device_id = nrf52840::ficr::FICR_INSTANCE.address();
+    let device_id_bottom_16 = u16::from_le_bytes([device_id[0], device_id[1]]);
+    let short_src_mac: MacAddress = MacAddress::Short(device_id_bottom_16);
     let (ieee802154_radio, mux_mac) = components::ieee802154::Ieee802154Component::new(
         board_kernel,
         capsules_extra::ieee802154::DRIVER_NUM,
         &nrf52840_peripherals.ieee802154_radio,
         aes_mux,
         PAN_ID,
-        serial_num_bottom_16,
-        serial_num,
+        device_id_bottom_16,
+        device_id,
     )
     .finalize(components::ieee802154_component_static!(
         nrf52840::ieee802154_radio::Radio,
@@ -559,7 +559,7 @@ pub unsafe fn start() -> (
                 0x1e, 0x1f,
             ]),
             IPAddr::generate_from_mac(capsules_extra::net::ieee802154::MacAddress::Short(
-                serial_num_bottom_16
+                device_id_bottom_16
             )),
         ]
     );
@@ -569,7 +569,7 @@ pub unsafe fn start() -> (
         DEFAULT_CTX_PREFIX_LEN,
         DEFAULT_CTX_PREFIX,
         DST_MAC_ADDR,
-        src_mac_from_serial_num,
+        short_src_mac,
         local_ip_ifaces,
         mux_alarm,
     )

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -48,9 +48,11 @@ const _SPI_MOSI: Pin = Pin::P1_01;
 const _SPI_MISO: Pin = Pin::P1_02;
 const _SPI_CLK: Pin = Pin::P1_04;
 
-// Constants related to the configuration of the 15.4 network stack
+// Constants related to the configuration of the 15.4 network stack; DEFAULT_EXT_SRC_MAC
+// should be replaced by an extended src address generated from device serial number
 const SRC_MAC: u16 = 0xf00f;
 const PAN_ID: u16 = 0xABCD;
+const DEFAULT_EXT_SRC_MAC: [u8; 8] = [0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77];
 
 /// UART Writer
 pub mod io;
@@ -372,6 +374,7 @@ pub unsafe fn main() {
         aes_mux,
         PAN_ID,
         SRC_MAC,
+        DEFAULT_EXT_SRC_MAC,
     )
     .finalize(components::ieee802154_component_static!(
         nrf52840::ieee802154_radio::Radio,

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -562,17 +562,18 @@ pub unsafe fn main() {
     // IEEE 802.15.4 and UDP
     //--------------------------------------------------------------------------
 
-    let serial_num = nrf52840::ficr::FICR_INSTANCE.address();
-    let serial_num_bottom_16 = serial_num[0] as u16 + ((serial_num[1] as u16) << 8);
-    let src_mac_from_serial_num: MacAddress = MacAddress::Short(serial_num_bottom_16);
+    let device_id = nrf52840::ficr::FICR_INSTANCE.address();
+
+    let device_id_bottom_16: u16 = device_id[0] as u16 + ((device_id[1] as u16) << 8);
+    let short_mac_addr: MacAddress = MacAddress::Short(device_id_bottom_16);
     let (ieee802154_radio, mux_mac) = components::ieee802154::Ieee802154Component::new(
         board_kernel,
         capsules_extra::ieee802154::DRIVER_NUM,
         &nrf52840_peripherals.ieee802154_radio,
         aes_mux,
         PAN_ID,
-        serial_num_bottom_16,
-        serial_num,
+        device_id_bottom_16,
+        device_id,
     )
     .finalize(components::ieee802154_component_static!(
         nrf52840::ieee802154_radio::Radio,
@@ -591,7 +592,7 @@ pub unsafe fn main() {
                 0x1e, 0x1f,
             ]),
             IPAddr::generate_from_mac(capsules_extra::net::ieee802154::MacAddress::Short(
-                serial_num_bottom_16
+                device_id_bottom_16
             )),
         ]
     );
@@ -601,7 +602,7 @@ pub unsafe fn main() {
         DEFAULT_CTX_PREFIX_LEN,
         DEFAULT_CTX_PREFIX,
         DST_MAC_ADDR,
-        src_mac_from_serial_num,
+        short_mac_addr,
         local_ip_ifaces,
         mux_alarm,
     )

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -572,6 +572,7 @@ pub unsafe fn main() {
         aes_mux,
         PAN_ID,
         serial_num_bottom_16,
+        serial_num,
     )
     .finalize(components::ieee802154_component_static!(
         nrf52840::ieee802154_radio::Radio,

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -57,9 +57,11 @@ const _SPI_CLK: Pin = Pin::P1_15;
 const I2C_SDA_PIN: Pin = Pin::P0_26;
 const I2C_SCL_PIN: Pin = Pin::P0_27;
 
-// Constants related to the configuration of the 15.4 network stack
+// Constants related to the configuration of the 15.4 network stack; DEFAULT_EXT_SRC_MAC
+// should be replaced by an extended src address generated from device serial number
 const SRC_MAC: u16 = 0xf00f;
 const PAN_ID: u16 = 0xABCD;
+const DEFAULT_EXT_SRC_MAC: [u8; 8] = [0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77];
 
 /// UART Writer
 pub mod io;
@@ -459,6 +461,7 @@ pub unsafe fn main() {
         aes_mux,
         PAN_ID,
         SRC_MAC,
+        DEFAULT_EXT_SRC_MAC,
     )
     .finalize(components::ieee802154_component_static!(
         nrf52840::ieee802154_radio::Radio,

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -45,9 +45,11 @@ const BUTTON_PIN: Pin = Pin::P0_17;
 const I2C_TEMP_SDA_PIN: Pin = Pin::P1_15;
 const I2C_TEMP_SCL_PIN: Pin = Pin::P0_02;
 
-// Constants related to the configuration of the 15.4 network stack
+// Constants related to the configuration of the 15.4 network stack; DEFAULT_EXT_SRC_MAC
+// should be replaced by an extended src address generated from device serial number
 const SRC_MAC: u16 = 0xf00f;
 const PAN_ID: u16 = 0xABCD;
+const DEFAULT_EXT_SRC_MAC: [u8; 8] = [0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77];
 
 /// UART Writer
 pub mod io;
@@ -345,6 +347,7 @@ pub unsafe fn main() {
         aes_mux,
         PAN_ID,
         SRC_MAC,
+        DEFAULT_EXT_SRC_MAC,
     )
     .finalize(components::ieee802154_component_static!(
         nrf52840::ieee802154_radio::Radio,

--- a/capsules/extra/src/ieee802154/framer.rs
+++ b/capsules/extra/src/ieee802154/framer.rs
@@ -731,12 +731,16 @@ impl<'a, M: Mac<'a>, A: AES128CCM<'a>> MacDevice<'a> for Framer<'a, M, A> {
         // TODO: For Thread, in the case of `KeyIdMode::Source4Index`, the source
         // address should instead be some constant defined in their
         // specification.
+        let mut src_addr = src_addr; // NOT SURE IF THIS IS OPTIMAL
         let src_addr_long = self.get_address_long();
         let security_desc = security_needed.and_then(|(level, key_id)| {
             self.lookup_key(level, key_id).map(|key| {
                 // TODO: lookup frame counter for device
                 let frame_counter = 0;
                 let nonce = get_ccm_nonce(&src_addr_long, frame_counter, level);
+                if level != SecurityLevel::None {
+                    src_addr = MacAddress::Long(src_addr_long);
+                }
                 (
                     Security {
                         level: level,
@@ -769,7 +773,7 @@ impl<'a, M: Mac<'a>, A: AES128CCM<'a>> MacDevice<'a> for Framer<'a, M, A> {
             dst_pan: Some(dst_pan),
             dst_addr: Some(dst_addr),
             src_pan: Some(src_pan),
-            src_addr: Some(src_addr),
+            src_addr: Some(src_addr), //Not entirely sure what to do here?
             security: security,
             header_ies: Default::default(),
             header_ies_len: 0,

--- a/capsules/extra/src/net/ieee802154.rs
+++ b/capsules/extra/src/net/ieee802154.rs
@@ -311,7 +311,8 @@ impl Security {
         let asn_in_nonce = (scf & security_control::ASN_IN_NONCE) != 0;
 
         // Frame counter field
-        let frame_counter_present = (scf & security_control::FRAME_COUNTER_SUPPRESSION) != 0;
+        // if frame counter suppresion is enabled, the frame counter field will not be in the header
+        let frame_counter_present = (scf & security_control::FRAME_COUNTER_SUPPRESSION) == 0;
         let (off, frame_counter) = if frame_counter_present {
             let (off, frame_counter_be) = dec_try!(buf, off; decode_u32);
             (off, Some(u32::from_be(frame_counter_be)))

--- a/capsules/extra/src/net/ipv6/ipv6_recv.rs
+++ b/capsules/extra/src/net/ipv6/ipv6_recv.rs
@@ -71,7 +71,8 @@ impl<'a> SixlowpanRxClient for IP6RecvStruct<'a> {
         }
         match IP6Header::decode(buf).done() {
             Some((offset, ip6_header)) => {
-                let checksum_result = ip6_header.check_transport_checksum(&buf[offset..len]);
+                let checksum_result =
+                    ip6_header.check_transport_checksum(&buf[offset..offset + len]);
                 if checksum_result == Err(ErrorCode::FAIL) {
                     debug!("cksum fail!: {:?}", checksum_result);
                     return; //Dropped.
@@ -80,7 +81,7 @@ impl<'a> SixlowpanRxClient for IP6RecvStruct<'a> {
                 // are automatically assumed as fine, rather than dropped
 
                 self.client
-                    .map(|client| client.receive(ip6_header, &buf[offset..len]));
+                    .map(|client| client.receive(ip6_header, &buf[offset..offset + len]));
             }
             None => {
                 debug!("failed to decode ipv6 header");

--- a/chips/nrf52/src/ficr.rs
+++ b/chips/nrf52/src/ficr.rs
@@ -412,14 +412,8 @@ impl Ficr {
     }
 
     pub fn address(&self) -> [u8; 8] {
-        let lo = self
-            .registers
-            .deviceaddr0
-            .read(DeviceAddress0::DEVICEADDRESS);
-        let hi = self
-            .registers
-            .deviceaddr1
-            .read(DeviceAddress1::DEVICEADDRESS);
+        let lo = self.registers.deviceid0.read(DeviceId0::DEVICEID);
+        let hi = self.registers.deviceid1.read(DeviceId1::DEVICEID);
         let mut addr = [0; 8];
         addr[..4].copy_from_slice(&lo.to_le_bytes());
         addr[4..].copy_from_slice(&hi.to_le_bytes());

--- a/chips/nrf52/src/ficr.rs
+++ b/chips/nrf52/src/ficr.rs
@@ -411,7 +411,7 @@ impl Ficr {
         }
     }
 
-    pub fn address(&self) -> [u8; 6] {
+    pub fn address(&self) -> [u8; 8] {
         let lo = self
             .registers
             .deviceaddr0
@@ -419,8 +419,8 @@ impl Ficr {
         let hi = self
             .registers
             .deviceaddr1
-            .read(DeviceAddress1::DEVICEADDRESS) as u16;
-        let mut addr = [0; 6];
+            .read(DeviceAddress1::DEVICEADDRESS);
+        let mut addr = [0; 8];
         addr[..4].copy_from_slice(&lo.to_le_bytes());
         addr[4..].copy_from_slice(&hi.to_le_bytes());
         addr


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the 15.4 framer's encryption/decryption of 15.4 packets secured with the 15.4 link layer security. The existing 15.4 driver exposes functionality to add network keys, specifies the level of encryption required when sending a 15.4 packet, and decrypts received packets using the added keys. However, in testing this functionality, Tock either crashed or sent/received errant values (tested on the nrf52840dk).

A majority of these errors were initially due to parsing/offset issues that have now been resolved. After resolving these more minor errors, a larger issue appeared that led the entire kernel to crash. For context, the nrf52840dk 15.4 radio driver performs an error check that panics if the radio driver's receive buffer is empty when beginning a receive operation. The driver is written such that this buffer will only be empty if the `client.receive(...)` function fails to set the radio's receive buffer prior to returning. The current state machine for the 15.4 framer fails to set the radio's buffer prior to returning from the receive function.

The original framer would not set the buffer until after the crypto operation had completed. However, it would return from `receive(...)` prior to the crypto operation completing. This creates a challenge as the crypto operation must hold the buffer until completing the operation. This leads to either solving the issue by: (1) delaying the return from the framer until after the crypto operation completes, or (2) creating a separate buffer to copy the packet into. Solution (1) creates an obvious issue as the radio will not receive any new packets while waiting for the crypto operation to complete. This led to the adoption of solution (2). This involved adding a static buffer to the framer so that when receiving an encrypted packet, the packet could be copied from the radio's buffer to the framer's buffer. This allows for the radio's recv buffer to be set prior to returning. Although solution (2) possess the obvious setback of greater memory usage, this seems superior to simply dropping packets while waiting for a crypto operation to complete. 

The original 15.4 capsule does not send the extended address by default. Although this does not necessarily violate the 15.4 spec or impair the capsule's operation, this creates a challenge in monitoring encrypted packets in wireshark as wireshark cannot decrypt the packet without the extended source address. Moreover, the framer requires the extended source address when creating the nonce for transmitting encrypted packets. The 15.4 spec states that the extended MacAddress should be an EUI-64. This address is now passed as an argument when creating the 15.4 radio driver component in `main.rs`. This creates a challenge as not all board families have an existing function to access the device's EUI-64. For these boards, I added a default extended source address.

As a minor note, the nrf52840dk device ID should be used instead of the serial number for generating the MacAddress. The device ID is a 64 bit unique device identifier, while the serial number is only 48 bit. I updated the address function to read this register instead.

### Testing Strategy

This pull request was tested by running:
-the libtock-c 15.4 rx/tx apps to test standard 15.4 unsecured operation
-new libtock-c 15.4 rx/tx encrypted apps to test encrypted operation (will submit PR to libtock-c for these new apps)
-UDP send/rx to test higher layers use of the 15.4 functionality 


### TODO or Help Wanted

With the change of requiring the extended MacAddress when creating a 15.4 component, all boards operating with 15.4 must implement a method for generating a EUI64. The nrf52840dk has been updated accordingly, but support for this must still be added to imix, nrf52840 dongle, particle boron, sma q3. For now, these boards have a default extended mac address that is hard coded.

To determine the length of the m data, the previous implementation computed a bitwise or as seen in line 217 of the unmodified framer.rs. This led to the wrong value being computed. I revised this value to be computed as the difference. I do not see a reason for a bitwise or to compute this length, but I wanted to draw attention to this in case I am overlooking something here.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
