### PR TITLE
capsules: BUGFIX: backspace/delete would send an extra EOL char

### DIFF
--- a/tools/check_process_console.py
+++ b/tools/check_process_console.py
@@ -96,7 +96,15 @@ class SerialPort:
         The function will evaluate just Backspace and Left
         escape sequences
         '''
+
+        # delete previous character
         encoded = encoded.replace("\x08 \x08", "@")
+        
+        # deletes leftover character from previous message.
+        # As such we can ignore it
+        # ! This check must go after the '@' replacement !
+        encoded = encoded.replace(" \x08", "")
+
         decoded = ""
         count = 0
 

--- a/tools/check_process_console.py
+++ b/tools/check_process_console.py
@@ -46,6 +46,7 @@ commands = {
     "home": 		"\x1B[H",
     "end": 			"\x1B[F",
     "delete": 		"\x1B[3~",
+    "delete-ascii": "\x7F",
     "backspace": 	"\x08 \x08",
     "up": 			"\x1B[A",
     "down": 		"\x1B[B",
@@ -340,37 +341,45 @@ def test_inserting(port: SerialPort):
 
 
 def test_deleting(port: SerialPort):
-    ''' Performs a serios of deletions from different places of the command '''
+    ''' Performs a series of deletions from different places of the command '''
     print_title("Deleting from a command using backspace and delete:")
     fail_test("deleting")
+    
+    def test_deleting_with(delete_char: str):
+        print("Typing 'DummyFooDummyBarDummy'")
+        port.send_input("DummyFooDummyBarDummy")
 
-    print("Typing 'DummyFooDummyBarDummy'")
-    port.send_input("DummyFooDummyBarDummy")
+        print("Moving to the start of the command")
+        port.send_input(commands["home"])
 
-    print("Moving to the start of the command")
-    port.send_input(commands["home"])
+        print("Delete first 'Dummy'")
+        port.send_input(delete_char * 5)
 
-    print("Delete first 'Dummy'")
-    port.send_input(commands["delete"] * 5)
+        print("Moving to the end of the command")
+        port.send_input(commands["end"])
 
-    print("Moving to the end of the command")
-    port.send_input(commands["end"])
+        print("Delete last 'Dummy'")
+        port.send_input(commands["backspace"] * 5)
 
-    print("Delete last 'Dummy'")
-    port.send_input(commands["backspace"] * 5)
+        print("Moving to the begining of the middle 'Dummy'")
+        port.send_input(commands["left"] * 8)
 
-    print("Moving to the begining of the middle 'Dummy'")
-    port.send_input(commands["left"] * 8)
+        print("Delete middle 'Dummy'")
+        port.send_input(delete_char * 5)
 
-    print("Delete middle 'Dummy'")
-    port.send_input(commands["delete"] * 5)
+        out = port.recv_output()
+        port.send_input("\r\n")
+        exit_if_condition(out != "FooBar",
+                        "[ERROR] Command does not match")
 
-    out = port.recv_output()
-    port.send_input("\r\n")
-    exit_if_condition(out != "FooBar",
-                      "[ERROR] Command does not match")
-
+    print("Testing with ANSI Escpae Sequence...")
+    test_deleting_with(commands["delete"])
     port.clear_input()
+
+    print("Testing with ASCII character...")
+    test_deleting_with(commands["delete-ascii"])
+    port.clear_input()
+
     pass_test("deleting")
 
 


### PR DESCRIPTION
### Pull Request Overview

Whilst working on [tockloader-rs/listen-prototype](https://github.com/tock/tockloader-rs/pull/2) I've noticed a few peculiarities with the handling of backspace & delete. To cut a very long story short - every time backspace/delete/ANSI Delete is pressed in the process-console, an additional "null"/"end of line" byte is send. Python tockloader does not have an issue with this because its terminal emulator automatically converts it into a unicode character. The issue comes when developing for tockloader-rs where there isn't (or I haven't found) a fully-functional terminal emulator. As such, all bytes are treated as-is.

This also means null is a by out-of-place. Tock sends <null><backspace><space><backspace>, which in effect should just delete the last byte. For the Unicode Null this works. For run-of-the-mill null, this doesn't work, and in fact it deletes the byte behind the <null>. I don't know why this happens, but the same effect can be had by just sending <space><backspace>.

Moreover, delete (ascii) was handled the same as backspace, which is confusing. ANSI Escape Sequence Delete is being handled properly (minus the null shenanigans). I've just made a logical short-circuit to make the code believe it is dealing with the escape sequence rather than a del byte.

### Testing Strategy

I tested this using [this branch](https://github.com/george-cosma/tockloader-rs/tree/no-magic) of tockloader-rs, without the fixes implemented in the aforementioned pull request.

`cargo run -- listen`

Board: microbit v2

### TODO or Help Wanted

The short-circuit condition to make a "DEL" char be treated the same as the escape sequence is a bit wonky. It works, but it I'd like a second opinion if we can leave it as-is or maybe extract the handling of "delete" (either) into a function or something else.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
