### PR TITLE
Add `pub type` to components

### DIFF
--- a/boards/components/src/alarm.rs
+++ b/boards/components/src/alarm.rs
@@ -57,6 +57,11 @@ macro_rules! alarm_component_static {
     };};
 }
 
+pub type AlarmDriverComponentType<A> = capsules_core::alarm::AlarmDriver<
+    'static,
+    capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, A>,
+>;
+
 pub struct AlarmMuxComponent<A: 'static + time::Alarm<'static>> {
     alarm: &'static A,
 }

--- a/boards/components/src/kv.rs
+++ b/boards/components/src/kv.rs
@@ -30,6 +30,8 @@ macro_rules! kv_driver_component_static {
     };};
 }
 
+pub type KVDriverComponentType<V> = capsules_extra::kv_driver::KVStoreDriver<'static, V>;
+
 pub struct KVDriverComponent<V: hil::kv::KVPermissions<'static> + 'static> {
     kv: &'static V,
     board_kernel: &'static kernel::Kernel,
@@ -84,6 +86,9 @@ macro_rules! kv_permissions_mux_component_static {
     };};
 }
 
+pub type KVPermissionsMuxComponentType<V> =
+    capsules_extra::kv_store_permissions::KVStorePermissions<'static, V>;
+
 pub struct KVPermissionsMuxComponent<V: hil::kv::KVPermissions<'static> + 'static> {
     kv: &'static V,
 }
@@ -118,6 +123,9 @@ macro_rules! virtual_kv_permissions_component_static {
         virtual_kv
     };};
 }
+
+pub type VirtualKVPermissionsComponentType<V> =
+    capsules_extra::virtual_kv::VirtualKVPermissions<'static, V>;
 
 pub struct VirtualKVPermissionsComponent<V: hil::kv::KVPermissions<'static> + 'static> {
     mux_kv: &'static MuxKVPermissions<'static, V>,
@@ -155,6 +163,9 @@ macro_rules! kv_store_permissions_component_static {
         (kv_store, buffer)
     };};
 }
+
+pub type KVStorePermissionsComponentType<V> =
+    capsules_extra::kv_store_permissions::KVStorePermissions<'static, V>;
 
 pub struct KVStorePermissionsComponent<V: hil::kv::KV<'static> + 'static> {
     kv: &'static V,
@@ -202,6 +213,9 @@ macro_rules! tickv_kv_store_component_static {
         (kv_store, key)
     };};
 }
+
+pub type TicKVKVStoreComponentType<K, T> =
+    capsules_extra::tickv_kv_store::TicKVKVStore<'static, K, T>;
 
 pub struct TicKVKVStoreComponent<K: 'static + KVSystem<'static, K = T>, T: 'static + KeyType> {
     kv_system: &'static K,

--- a/boards/components/src/mx25r6435f.rs
+++ b/boards/components/src/mx25r6435f.rs
@@ -56,6 +56,13 @@ macro_rules! mx25r6435f_component_static {
     };};
 }
 
+pub type Mx25r6435fComponentType<S, P, A> = capsules_extra::mx25r6435f::MX25R6435F<
+    'static,
+    capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<'static, S>,
+    P,
+    VirtualMuxAlarm<'static, A>,
+>;
+
 pub struct Mx25r6435fComponent<
     S: 'static + hil::spi::SpiMaster<'static>,
     P: 'static + hil::gpio::Pin,

--- a/boards/components/src/siphash.rs
+++ b/boards/components/src/siphash.rs
@@ -16,6 +16,8 @@ macro_rules! siphasher24_component_static {
     };};
 }
 
+pub type Siphasher24ComponentType = capsules_extra::sip_hash::SipHasher24<'static>;
+
 pub struct Siphasher24Component {}
 
 impl Siphasher24Component {

--- a/boards/components/src/tickv.rs
+++ b/boards/components/src/tickv.rs
@@ -155,6 +155,9 @@ impl<
     }
 }
 
+pub type TicKVDedicatedFlashComponentType<F, H, const PAGE: usize> =
+    capsules_extra::tickv::TicKVSystem<'static, F, H, PAGE>;
+
 pub struct TicKVDedicatedFlashComponent<
     F: 'static
         + hil::flash::Flash


### PR DESCRIPTION
### Pull Request Overview

This is an alternative to #3589 

The motivation remains the same: types for structs in main.rs get unwieldy and repetitive. Our current approach of using `dyn` traits is probably not what we want. If components can help with types, and make it easier to add resources to a board that is an improvement.

The major change for this version is that components provide templated types, and boards create the specific version for their use at the top of the main.rs. Then boards can use those types in both the `Platform` struct and when creating other components.

The downside is that the approach is somewhat brute force. We have to use the `type` keyword a fair bit. There is still redundancy, although much less. Some of the "magic" with macros is lost. In particular, there is embedded redundancy when defining both a new `type` and the macro to finalize.

The advantage is this doesn't add more macros and there's less "convention" that component authors need to follow to create easy to understand and reuse components.


### Testing Strategy

A few changes to nrf52840dk board as a test.


### TODO or Help Wanted

Is this a step forward? In the worst case (kv stack) it saves hundreds of lines in redundant type signatures. It won't have nearly as much of an impact with other components. That is sometimes because some components encapsulate several steps (ie creating a virtual device) and also because we use `dyn` quite a bit.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
