### PR TITLE
6LoWPAN Packet Filtering

### DIFF
--- a/capsules/extra/src/net/sixlowpan/sixlowpan_state.rs
+++ b/capsules/extra/src/net/sixlowpan/sixlowpan_state.rs
@@ -955,7 +955,7 @@ impl<'a, A: time::Alarm<'a>, C: ContextStore> Sixlowpan<'a, A, C> {
                     }
                 }
             } else {
-                packet[0..payload_len].copy_from_slice(&payload[0..payload_len]);
+                return (None, Ok(()));
             }
             state.packet.replace(packet);
             (Some(state), Ok(()))

--- a/capsules/extra/src/net/sixlowpan/sixlowpan_state.rs
+++ b/capsules/extra/src/net/sixlowpan/sixlowpan_state.rs
@@ -932,31 +932,34 @@ impl<'a, A: time::Alarm<'a>, C: ContextStore> Sixlowpan<'a, A, C> {
             // since this state is not busy, it must have the packet buffer.
             // Otherwise, we are in an inconsistent state and can fail.
             let packet = state.packet.take().unwrap();
-            if is_lowpan(payload) {
-                let decompressed = sixlowpan_compression::decompress(
-                    &self.ctx_store,
-                    &payload[0..payload_len],
-                    src_mac_addr,
-                    dst_mac_addr,
-                    packet,
-                    0,
-                    false,
-                );
-                match decompressed {
-                    Ok((consumed, written)) => {
-                        let remaining = payload_len - consumed;
-                        packet[written..written + remaining]
-                            .copy_from_slice(&payload[consumed..consumed + remaining]);
-                        // Want dgram_size to contain decompressed size of packet
-                        state.dgram_size.set((written + remaining) as u16);
-                    }
-                    Err(_) => {
-                        return (None, Err(ErrorCode::FAIL));
-                    }
-                }
-            } else {
+
+            // Filter non 6LoWPAN packets and return
+            if !is_lowpan(payload) {
                 return (None, Ok(()));
             }
+
+            let decompressed = sixlowpan_compression::decompress(
+                &self.ctx_store,
+                &payload[0..payload_len],
+                src_mac_addr,
+                dst_mac_addr,
+                packet,
+                0,
+                false,
+            );
+            match decompressed {
+                Ok((consumed, written)) => {
+                    let remaining = payload_len - consumed;
+                    packet[written..written + remaining]
+                        .copy_from_slice(&payload[consumed..consumed + remaining]);
+                    // Want dgram_size to contain decompressed size of packet
+                    state.dgram_size.set((written + remaining) as u16);
+                }
+                Err(_) => {
+                    return (None, Err(ErrorCode::FAIL));
+                }
+            }
+
             state.packet.replace(packet);
             (Some(state), Ok(()))
         })


### PR DESCRIPTION
### Pull Request Overview

A received 15.4 packet is passed to both the radio driver and 6LoWPAN RxClient. This is in accordance with the networking stack documentation stating: 

> Any received packet is passed to ALL MacUsers, which are expected to filter packets themselves accordingly.

The current 6LoWPAN module checks if the packet is in fact a 6LoWPAN packet, but incorrectly copies the packet/passes the packet along to the higher network layers when the packet is not 6LoWPAN (i.e. simply a generic 15.4 packet containing data). This is incorrect behavior. This PR resolves this issue with a minor change.

### Testing Strategy

This pull request was tested by running the 15.4 rx/tx (both encrypted and non encrypted) libtock-c example tests. 

### TODO or Help Wanted

N/A

### Documentation Updated

- [ x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ x] Ran `make prepush`.
