### PR TITLE
Labeler updates

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -32,6 +32,7 @@ WG-OpenTitan:
   - boards/opentitan/**/*
   - chips/earlgrey/**/*
   - chips/lowrisc/**/*
+  - doc/wg/opentitan/**/*
 
 # add kernel label unless already covered by hil label
 kernel:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -34,6 +34,25 @@ WG-OpenTitan:
   - chips/lowrisc/**/*
   - doc/wg/opentitan/**/*
 
+WG-Network
+  - capsules/extra/src/ble_advertising_driver.rs
+  - capsules/extra/src/can.rs
+  - capsules/extra/src/ieee802154/**/*
+  - capsules/extra/src/net/**/*
+  - capsules/extra/src/rf233.rs
+  - capsules/extra/src/rf233_const.rs
+  - chips/apollo3/src/ble.rs
+  - chips/litex/src/liteeth.rs
+  - chips/nrf52/src/ble_radio.rs
+  - chips/nrf52840/src/ieee802154_radio.rs
+  - chips/stm32f429zi/src/can_registers.rs
+  - chips/stm32f4xx/src/can.rs
+  - chips/virtio/src/devices/virtio_net.rs
+  - doc/wg/network/**/*
+  - kernel/src/hil/ble_advertising.rs
+  - kernel/src/hil/can.rs
+  - kernel/src/hil/radio.rs
+
 # add kernel label unless already covered by hil label
 kernel:
   - any: ['kernel/**/*', '!kernel/src/hil/*']


### PR DESCRIPTION
### Pull Request Overview

This pull request changes auto-labeling GitHub action to apply WG-Network to relevant files. Since the Network WG isn't entirely contained in certain directories, I've added individual files in many places.

Also adds the WG-OpenTitan label to their documentation directory.


### TODO or Help Wanted

Can @lschuermann and @alexandruradovici take a brief skim to make sure I haven't missed obvious files?

Can @bradjc or @jrvanwhy confirm the WG-OpenTitan change? I'll remove it if you don't want it.

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [N/A] Ran `make prepush`.
