### PR TITLE
clippy: now disallow everything

### DIFF
--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -91,7 +91,7 @@ const NUM_PROCS: usize = 4;
 const RADIO_CHANNEL: u8 = 26;
 const DST_MAC_ADDR: MacAddress = MacAddress::Short(49138);
 const DEFAULT_CTX_PREFIX_LEN: u8 = 8; //Length of context for 6LoWPAN compression
-const DEFAULT_CTX_PREFIX: [u8; 16] = [0x0 as u8; 16]; //Context for 6LoWPAN Compression
+const DEFAULT_CTX_PREFIX: [u8; 16] = [0x0_u8; 16]; //Context for 6LoWPAN Compression
 const PAN_ID: u16 = 0xABCD;
 
 // how should the kernel respond when a process faults

--- a/boards/imix/src/test/i2c_dummy.rs
+++ b/boards/imix/src/test/i2c_dummy.rs
@@ -99,16 +99,16 @@ impl hil::i2c::I2CHwMasterClient for AccelClient {
             AccelClientState::ReadingWhoami => {
                 debug!("WHOAMI Register 0x{:x} ({:?})", buffer[0], status);
                 debug!("Activating Sensor...");
-                buffer[0] = 0x2A as u8; // CTRL_REG1
+                buffer[0] = 0x2A_u8; // CTRL_REG1
                 buffer[1] = 1; // Bit 1 sets `active`
                 dev.write(0x1e, buffer, 2).unwrap();
                 self.state.set(AccelClientState::Activating);
             }
             AccelClientState::Activating => {
                 debug!("Sensor Activated ({:?})", status);
-                buffer[0] = 0x01 as u8; // X-MSB register
-                                        // Reading 6 bytes will increment the register pointer through
-                                        // X-MSB, X-LSB, Y-MSB, Y-LSB, Z-MSB, Z-LSB
+                buffer[0] = 0x01_u8; // X-MSB register
+                                     // Reading 6 bytes will increment the register pointer through
+                                     // X-MSB, X-LSB, Y-MSB, Y-LSB, Z-MSB, Z-LSB
                 dev.write_read(0x1e, buffer, 1, 6).unwrap();
                 self.state.set(AccelClientState::ReadingAccelData);
             }
@@ -129,16 +129,16 @@ impl hil::i2c::I2CHwMasterClient for AccelClient {
                     status
                 );
 
-                buffer[0] = 0x01 as u8; // X-MSB register
-                                        // Reading 6 bytes will increment the register pointer through
-                                        // X-MSB, X-LSB, Y-MSB, Y-LSB, Z-MSB, Z-LSB
+                buffer[0] = 0x01_u8; // X-MSB register
+                                     // Reading 6 bytes will increment the register pointer through
+                                     // X-MSB, X-LSB, Y-MSB, Y-LSB, Z-MSB, Z-LSB
                 dev.write_read(0x1e, buffer, 1, 6).unwrap();
                 self.state.set(AccelClientState::ReadingAccelData);
             }
             AccelClientState::Deactivating => {
                 debug!("Sensor deactivated ({:?})", status);
                 debug!("Reading Accel's WHOAMI...");
-                buffer[0] = 0x0D as u8; // 0x0D == WHOAMI register
+                buffer[0] = 0x0D_u8; // 0x0D == WHOAMI register
                 dev.write_read(0x1e, buffer, 1, 1).unwrap();
                 self.state.set(AccelClientState::ReadingWhoami);
             }
@@ -158,7 +158,7 @@ pub fn i2c_accel_test(i2c_master: &'static dyn I2CMaster<'static>) {
 
     let buf = unsafe { &mut DATA };
     debug!("Reading Accel's WHOAMI...");
-    buf[0] = 0x0D as u8; // 0x0D == WHOAMI register
+    buf[0] = 0x0D_u8; // 0x0D == WHOAMI register
     dev.write_read(0x1e, buf, 1, 1).unwrap();
     i2c_client.state.set(AccelClientState::ReadingWhoami);
 }
@@ -194,7 +194,7 @@ impl hil::i2c::I2CHwMasterClient for LiClient {
         match self.state.get() {
             LiClientState::Enabling => {
                 debug!("Reading luminance Registers ({:?})", status);
-                buffer[0] = 0x02 as u8;
+                buffer[0] = 0x02_u8;
                 buffer[0] = 0;
                 dev.write_read(0x44, buffer, 1, 2).unwrap();
                 self.state.set(LiClientState::ReadingLI);
@@ -206,7 +206,7 @@ impl hil::i2c::I2CHwMasterClient for LiClient {
                     (intensity * 100) >> 16,
                     status
                 );
-                buffer[0] = 0x02 as u8;
+                buffer[0] = 0x02_u8;
                 dev.write_read(0x44, buffer, 1, 2).unwrap();
                 self.state.set(LiClientState::ReadingLI);
             }

--- a/boards/imix/src/test/icmp_lowpan_test.rs
+++ b/boards/imix/src/test/icmp_lowpan_test.rs
@@ -46,7 +46,7 @@ pub const DST_ADDR: IPAddr = IPAddr([
 
 /* 6LoWPAN Constants */
 const DEFAULT_CTX_PREFIX_LEN: u8 = 8;
-static DEFAULT_CTX_PREFIX: [u8; 16] = [0x0 as u8; 16];
+static DEFAULT_CTX_PREFIX: [u8; 16] = [0x0_u8; 16];
 static mut RX_STATE_BUF: [u8; 1280] = [0x0; 1280];
 const DST_MAC_ADDR: MacAddress = MacAddress::Short(0x802);
 const SRC_MAC_ADDR: MacAddress = MacAddress::Short(0xf00f);
@@ -56,7 +56,7 @@ pub const TEST_LOOP: bool = false;
 
 static mut ICMP_PAYLOAD: [u8; 10] = [0; 10];
 
-pub static mut RF233_BUF: [u8; radio::MAX_BUF_SIZE] = [0 as u8; radio::MAX_BUF_SIZE];
+pub static mut RF233_BUF: [u8; radio::MAX_BUF_SIZE] = [0_u8; radio::MAX_BUF_SIZE];
 
 //Use a global variable option, initialize as None, then actually initialize in initialize all
 

--- a/boards/imix/src/test/ipv6_lowpan_test.rs
+++ b/boards/imix/src/test/ipv6_lowpan_test.rs
@@ -64,11 +64,11 @@ pub const DST_MAC_ADDR: MacAddress = MacAddress::Short(57326);
 pub const IP6_HDR_SIZE: usize = 40;
 pub const UDP_HDR_SIZE: usize = 8;
 pub const PAYLOAD_LEN: usize = 200;
-pub static mut RF233_BUF: [u8; radio::MAX_BUF_SIZE] = [0 as u8; radio::MAX_BUF_SIZE];
+pub static mut RF233_BUF: [u8; radio::MAX_BUF_SIZE] = [0_u8; radio::MAX_BUF_SIZE];
 
 /* 6LoWPAN Constants */
 const DEFAULT_CTX_PREFIX_LEN: u8 = 8;
-static DEFAULT_CTX_PREFIX: [u8; 16] = [0x0 as u8; 16];
+static DEFAULT_CTX_PREFIX: [u8; 16] = [0x0_u8; 16];
 static mut RX_STATE_BUF: [u8; 1280] = [0x0; 1280];
 
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -788,7 +788,7 @@ fn ipv6_prepare_packet(tf: TF, hop_limit: u8, sac: SAC, dac: DAC) {
                             ip6_header.dst_addr.0[0] = 0xff;
                             ip6_header.dst_addr.0[1] = DST_ADDR.0[1];
                             ip6_header.dst_addr.0[2] = DST_ADDR.0[2];
-                            ip6_header.dst_addr.0[3] = 64 as u8;
+                            ip6_header.dst_addr.0[3] = 64_u8;
                             ip6_header.dst_addr.0[4..12].copy_from_slice(&MLP);
                             ip6_header.dst_addr.0[12..16].copy_from_slice(&DST_ADDR.0[12..16]);
                         }

--- a/boards/imix/src/test/spi_dummy.rs
+++ b/boards/imix/src/test/spi_dummy.rs
@@ -16,10 +16,7 @@ pub struct DummyCB {
 
 impl DummyCB {
     pub fn new(spi: &'static sam4l::spi::SpiHw<'static>) -> Self {
-        Self {
-            val: 0x55 as u8,
-            spi,
-        }
+        Self { val: 0x55_u8, spi }
     }
 }
 

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -71,7 +71,7 @@ const PAN_ID: u16 = 0xABCD;
 const DST_MAC_ADDR: capsules_extra::net::ieee802154::MacAddress =
     capsules_extra::net::ieee802154::MacAddress::Short(49138);
 const DEFAULT_CTX_PREFIX_LEN: u8 = 8; //Length of context for 6LoWPAN compression
-const DEFAULT_CTX_PREFIX: [u8; 16] = [0x0 as u8; 16]; //Context for 6LoWPAN Compression
+const DEFAULT_CTX_PREFIX: [u8; 16] = [0x0_u8; 16]; //Context for 6LoWPAN Compression
 
 /// UART Writer for panic!()s.
 pub mod io;

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -128,7 +128,7 @@ const PAN_ID: u16 = 0xABCD;
 const DST_MAC_ADDR: capsules_extra::net::ieee802154::MacAddress =
     capsules_extra::net::ieee802154::MacAddress::Short(49138);
 const DEFAULT_CTX_PREFIX_LEN: u8 = 8; //Length of context for 6LoWPAN compression
-const DEFAULT_CTX_PREFIX: [u8; 16] = [0x0 as u8; 16]; //Context for 6LoWPAN Compression
+const DEFAULT_CTX_PREFIX: [u8; 16] = [0x0_u8; 16]; //Context for 6LoWPAN Compression
 
 /// Debug Writer
 pub mod io;

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -402,16 +402,16 @@ pub unsafe fn main() {
             // 1 => &peripherals.pins.get_pin(RPGpio::GPIO1),
             // Used for Buzzer.
             // 2 => &peripherals.pins.get_pin(RPGpio::GPIO2),
-            3 => &peripherals.pins.get_pin(RPGpio::GPIO3),
-            4 => &peripherals.pins.get_pin(RPGpio::GPIO4),
-            5 => &peripherals.pins.get_pin(RPGpio::GPIO5),
-            6 => &peripherals.pins.get_pin(RPGpio::GPIO6),
-            7 => &peripherals.pins.get_pin(RPGpio::GPIO7),
-            20 => &peripherals.pins.get_pin(RPGpio::GPIO20),
-            21 => &peripherals.pins.get_pin(RPGpio::GPIO21),
-            22 => &peripherals.pins.get_pin(RPGpio::GPIO22),
-            23 => &peripherals.pins.get_pin(RPGpio::GPIO23),
-            24 => &peripherals.pins.get_pin(RPGpio::GPIO24),
+            3 => peripherals.pins.get_pin(RPGpio::GPIO3),
+            4 => peripherals.pins.get_pin(RPGpio::GPIO4),
+            5 => peripherals.pins.get_pin(RPGpio::GPIO5),
+            6 => peripherals.pins.get_pin(RPGpio::GPIO6),
+            7 => peripherals.pins.get_pin(RPGpio::GPIO7),
+            20 => peripherals.pins.get_pin(RPGpio::GPIO20),
+            21 => peripherals.pins.get_pin(RPGpio::GPIO21),
+            22 => peripherals.pins.get_pin(RPGpio::GPIO22),
+            23 => peripherals.pins.get_pin(RPGpio::GPIO23),
+            24 => peripherals.pins.get_pin(RPGpio::GPIO24),
         ),
     )
     .finalize(components::gpio_component_static!(RPGpioPin<'static>));
@@ -573,7 +573,7 @@ pub unsafe fn main() {
         .finalize(components::pwm_mux_component_static!(rp2040::pwm::Pwm));
 
     let virtual_pwm_buzzer =
-        components::pwm::PwmPinUserComponent::new(&mux_pwm, rp2040::gpio::RPGpio::GPIO2)
+        components::pwm::PwmPinUserComponent::new(mux_pwm, rp2040::gpio::RPGpio::GPIO2)
             .finalize(components::pwm_pin_user_component_static!(rp2040::pwm::Pwm));
 
     let virtual_alarm_buzzer = static_init!(

--- a/boards/swervolf/src/io.rs
+++ b/boards/swervolf/src/io.rs
@@ -29,7 +29,7 @@ impl IoWrite for Writer {
         for b in buf {
             // Print to a special address for simulation output
             unsafe {
-                write_volatile(0x8000_1008 as *mut u8, *b as u8);
+                write_volatile(0x8000_1008 as *mut u8, *b);
             }
         }
         buf.len()

--- a/tools/run_clippy.sh
+++ b/tools/run_clippy.sh
@@ -21,15 +21,6 @@ CLIPPY_ARGS="
 -A clippy::restriction
 
 -A clippy::if_same_then_else
-
--D clippy::needless_return
--D clippy::unnecessary_mut_passed
--D clippy::empty_line_after_outer_attr
--D clippy::unnecessary_cast
--D clippy::default_trait_access
--D clippy::map_unwrap_or
--D clippy::wildcard_imports
--D clippy::needless_borrow
 "
 
 # Disallow all complexity lints, then re-allow each one Tock does not comply
@@ -60,7 +51,6 @@ CLIPPY_ARGS_COMPLEXITY="
 -A clippy::needless-if
 
 
--A clippy::unnecessary_cast
 -A clippy::unnecessary_unwrap
 -A clippy::needless_lifetimes
 -A clippy::explicit_auto_deref
@@ -114,9 +104,6 @@ CLIPPY_ARGS_STYLE="
 -A clippy::redundant_pattern_matching
 -A clippy::unusual-byte-groupings
 -A clippy::wrong-self-convention
-
-
--A clippy::needless_borrow
 "
 
 # Disallow all perf lints, then re-allow each one Tock does not comply with.


### PR DESCRIPTION
### Pull Request Overview
Don't need to specify specific disallows. I checked that none of these are in clippy::restriction.






### Testing Strategy

n/a


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
