### PR TITLE
tickv: handle additional read

### DIFF
--- a/capsules/extra/src/tickv.rs
+++ b/capsules/extra/src/tickv.rs
@@ -474,6 +474,9 @@ impl<'a, F: Flash, H: Hasher<'a, 8>, const PAGE_SIZE: usize> flash::Client<F>
                     }
                     Err(tickv::error_codes::ErrorCode::ReadNotReady(_)) => {
                         // Need to do another flash read.
+                        //
+                        // `self.operation` will still be `GetKey`, so this will automatically
+                        // be retried by the primary state machine.
                     }
                     Err(tickv::error_codes::ErrorCode::EraseNotReady(_)) | Ok(_) => {}
                     Err(e) => {

--- a/capsules/extra/src/tickv.rs
+++ b/capsules/extra/src/tickv.rs
@@ -472,6 +472,9 @@ impl<'a, F: Flash, H: Hasher<'a, 8>, const PAGE_SIZE: usize> flash::Client<F>
                             );
                         });
                     }
+                    Err(tickv::error_codes::ErrorCode::ReadNotReady(_)) => {
+                        // Need to do another flash read.
+                    }
                     Err(tickv::error_codes::ErrorCode::EraseNotReady(_)) | Ok(_) => {}
                     Err(e) => {
                         let get_tock_err = match e {


### PR DESCRIPTION
### Pull Request Overview

If the first read does not find a key we may need to do an additional read.

This wasn't handled before because the search feature wasn't working.


### Testing Strategy

Porting HTOP to kv.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
