### PR TITLE
Temperature Stack: Use templated capsules

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -59,6 +59,9 @@ static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS]
 #[link_section = ".stack_buffer"]
 pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
 
+type TemperatureDriver =
+    components::temperature::TemperatureComponentType<nrf52832::temperature::Temp<'static>>;
+
 /// Supported drivers by the platform
 pub struct Platform {
     ble_radio: &'static capsules_extra::ble_advertising_driver::BLE<
@@ -75,10 +78,7 @@ pub struct Platform {
         4,
     >,
     rng: &'static capsules_core::rng::RngDriver<'static>,
-    temp: &'static capsules_extra::temperature::TemperatureSensor<
-        'static,
-        nrf52832::temperature::Temp<'static>,
-    >,
+    temp: &'static TemperatureDriver,
     ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     alarm: &'static capsules_core::alarm::AlarmDriver<
         'static,

--- a/boards/apollo3/lora_things_plus/src/main.rs
+++ b/boards/apollo3/lora_things_plus/src/main.rs
@@ -105,6 +105,11 @@ pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
 const LORA_SPI_DRIVER_NUM: usize = capsules_core::driver::NUM::LoRaPhySPI as usize;
 const LORA_GPIO_DRIVER_NUM: usize = capsules_core::driver::NUM::LoRaPhyGPIO as usize;
 
+type BME280Sensor = components::bme280::Bme280ComponentType<
+    capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, apollo3::iom::Iom<'static>>,
+>;
+type TemperatureDriver = components::temperature::TemperatureComponentType<BME280Sensor>;
+
 /// A structure representing this platform that holds references to all
 /// capsules for this platform.
 struct LoRaThingsPlus {
@@ -141,16 +146,7 @@ struct LoRaThingsPlus {
         apollo3::ble::Ble<'static>,
         VirtualMuxAlarm<'static, apollo3::stimer::STimer<'static>>,
     >,
-    temperature: &'static capsules_extra::temperature::TemperatureSensor<
-        'static,
-        capsules_extra::bme280::Bme280<
-            'static,
-            capsules_core::virtualizers::virtual_i2c::I2CDevice<
-                'static,
-                apollo3::iom::Iom<'static>,
-            >,
-        >,
-    >,
+    temperature: &'static TemperatureDriver,
     humidity: &'static capsules_extra::humidity::HumiditySensor<'static>,
     air_quality: &'static capsules_extra::air_quality::AirQualitySensor<'static>,
     scheduler: &'static RoundRobinSched<'static>,
@@ -361,12 +357,7 @@ unsafe fn setup() -> (
         capsules_extra::temperature::DRIVER_NUM,
         bme280,
     )
-    .finalize(components::temperature_component_static!(
-        capsules_extra::bme280::Bme280<
-            'static,
-            capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, apollo3::iom::Iom>,
-        >
-    ));
+    .finalize(components::temperature_component_static!(BME280Sensor));
     let humidity = components::humidity::HumidityComponent::new(
         board_kernel,
         capsules_extra::humidity::DRIVER_NUM,

--- a/boards/apollo3/lora_things_plus/src/main.rs
+++ b/boards/apollo3/lora_things_plus/src/main.rs
@@ -89,7 +89,12 @@ static mut MAIN_CAP: Option<&dyn kernel::capabilities::MainLoopCapability> = Non
 // Test access to alarm
 static mut ALARM: Option<&'static MuxAlarm<'static, apollo3::stimer::STimer<'static>>> = None;
 // Test access to sensors
-static mut BME280: Option<&'static capsules_extra::bme280::Bme280<'static>> = None;
+static mut BME280: Option<
+    &'static capsules_extra::bme280::Bme280<
+        'static,
+        capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, apollo3::iom::Iom<'static>>,
+    >,
+> = None;
 static mut CCS811: Option<&'static capsules_extra::ccs811::Ccs811<'static>> = None;
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
@@ -136,7 +141,16 @@ struct LoRaThingsPlus {
         apollo3::ble::Ble<'static>,
         VirtualMuxAlarm<'static, apollo3::stimer::STimer<'static>>,
     >,
-    temperature: &'static capsules_extra::temperature::TemperatureSensor<'static>,
+    temperature: &'static capsules_extra::temperature::TemperatureSensor<
+        'static,
+        capsules_extra::bme280::Bme280<
+            'static,
+            capsules_core::virtualizers::virtual_i2c::I2CDevice<
+                'static,
+                apollo3::iom::Iom<'static>,
+            >,
+        >,
+    >,
     humidity: &'static capsules_extra::humidity::HumiditySensor<'static>,
     air_quality: &'static capsules_extra::air_quality::AirQualitySensor<'static>,
     scheduler: &'static RoundRobinSched<'static>,
@@ -347,7 +361,12 @@ unsafe fn setup() -> (
         capsules_extra::temperature::DRIVER_NUM,
         bme280,
     )
-    .finalize(components::temperature_component_static!());
+    .finalize(components::temperature_component_static!(
+        capsules_extra::bme280::Bme280<
+            'static,
+            capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, apollo3::iom::Iom>,
+        >
+    ));
     let humidity = components::humidity::HumidityComponent::new(
         board_kernel,
         capsules_extra::humidity::DRIVER_NUM,

--- a/boards/apollo3/redboard_artemis_nano/src/main.rs
+++ b/boards/apollo3/redboard_artemis_nano/src/main.rs
@@ -64,7 +64,12 @@ static mut MAIN_CAP: Option<&dyn kernel::capabilities::MainLoopCapability> = Non
 // Test access to alarm
 static mut ALARM: Option<&'static MuxAlarm<'static, apollo3::stimer::STimer<'static>>> = None;
 // Test access to sensors
-static mut BME280: Option<&'static capsules_extra::bme280::Bme280<'static>> = None;
+static mut BME280: Option<
+    &'static capsules_extra::bme280::Bme280<
+        'static,
+        capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, apollo3::iom::Iom<'static>>,
+    >,
+> = None;
 static mut CCS811: Option<&'static capsules_extra::ccs811::Ccs811<'static>> = None;
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
@@ -100,7 +105,16 @@ struct RedboardArtemisNano {
         apollo3::ble::Ble<'static>,
         VirtualMuxAlarm<'static, apollo3::stimer::STimer<'static>>,
     >,
-    temperature: &'static capsules_extra::temperature::TemperatureSensor<'static>,
+    temperature: &'static capsules_extra::temperature::TemperatureSensor<
+        'static,
+        capsules_extra::bme280::Bme280<
+            'static,
+            capsules_core::virtualizers::virtual_i2c::I2CDevice<
+                'static,
+                apollo3::iom::Iom<'static>,
+            >,
+        >,
+    >,
     humidity: &'static capsules_extra::humidity::HumiditySensor<'static>,
     air_quality: &'static capsules_extra::air_quality::AirQualitySensor<'static>,
     scheduler: &'static RoundRobinSched<'static>,
@@ -302,7 +316,12 @@ unsafe fn setup() -> (
         capsules_extra::temperature::DRIVER_NUM,
         bme280,
     )
-    .finalize(components::temperature_component_static!());
+    .finalize(components::temperature_component_static!(
+        capsules_extra::bme280::Bme280<
+            'static,
+            capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, apollo3::iom::Iom>,
+        >
+    ));
     let humidity = components::humidity::HumidityComponent::new(
         board_kernel,
         capsules_extra::humidity::DRIVER_NUM,

--- a/boards/apollo3/redboard_artemis_nano/src/main.rs
+++ b/boards/apollo3/redboard_artemis_nano/src/main.rs
@@ -77,6 +77,11 @@ static mut CCS811: Option<&'static capsules_extra::ccs811::Ccs811<'static>> = No
 #[link_section = ".stack_buffer"]
 pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
 
+type BME280Sensor = components::bme280::Bme280ComponentType<
+    capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, apollo3::iom::Iom<'static>>,
+>;
+type TemperatureDriver = components::temperature::TemperatureComponentType<BME280Sensor>;
+
 /// A structure representing this platform that holds references to all
 /// capsules for this platform.
 struct RedboardArtemisNano {
@@ -105,16 +110,7 @@ struct RedboardArtemisNano {
         apollo3::ble::Ble<'static>,
         VirtualMuxAlarm<'static, apollo3::stimer::STimer<'static>>,
     >,
-    temperature: &'static capsules_extra::temperature::TemperatureSensor<
-        'static,
-        capsules_extra::bme280::Bme280<
-            'static,
-            capsules_core::virtualizers::virtual_i2c::I2CDevice<
-                'static,
-                apollo3::iom::Iom<'static>,
-            >,
-        >,
-    >,
+    temperature: &'static TemperatureDriver,
     humidity: &'static capsules_extra::humidity::HumiditySensor<'static>,
     air_quality: &'static capsules_extra::air_quality::AirQualitySensor<'static>,
     scheduler: &'static RoundRobinSched<'static>,
@@ -316,12 +312,7 @@ unsafe fn setup() -> (
         capsules_extra::temperature::DRIVER_NUM,
         bme280,
     )
-    .finalize(components::temperature_component_static!(
-        capsules_extra::bme280::Bme280<
-            'static,
-            capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, apollo3::iom::Iom>,
-        >
-    ));
+    .finalize(components::temperature_component_static!(BME280Sensor));
     let humidity = components::humidity::HumidityComponent::new(
         board_kernel,
         capsules_extra::humidity::DRIVER_NUM,

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -180,7 +180,20 @@ pub struct Platform {
         >,
     >,
     adc: &'static capsules_core::adc::AdcVirtualized<'static>,
-    temperature: &'static capsules_extra::temperature::TemperatureSensor<'static>,
+    temperature: &'static capsules_extra::temperature::TemperatureSensor<
+        'static,
+        capsules_extra::sht3x::SHT3x<
+            'static,
+            capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<
+                'static,
+                nrf52::rtc::Rtc<'static>,
+            >,
+            capsules_core::virtualizers::virtual_i2c::I2CDevice<
+                'static,
+                nrf52840::i2c::TWI<'static>,
+            >,
+        >,
+    >,
     humidity: &'static capsules_extra::humidity::HumiditySensor<'static>,
     scheduler: &'static RoundRobinSched<'static>,
     systick: cortexm4::systick::SysTick,
@@ -621,7 +634,13 @@ pub unsafe fn main() {
         capsules_extra::temperature::DRIVER_NUM,
         sht3x,
     )
-    .finalize(components::temperature_component_static!());
+    .finalize(components::temperature_component_static!(
+        capsules_extra::sht3x::SHT3x<
+            'static,
+            capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, nrf52::rtc::Rtc>,
+            capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, nrf52840::i2c::TWI>,
+        >
+    ));
 
     let humidity = components::humidity::HumidityComponent::new(
         board_kernel,

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -138,6 +138,12 @@ fn baud_rate_reset_bootloader_enter() {
     }
 }
 
+type SHT3xSensor = components::sht3x::SHT3xComponentType<
+    capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, nrf52::rtc::Rtc<'static>>,
+    capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, nrf52840::i2c::TWI<'static>>,
+>;
+type TemperatureDriver = components::temperature::TemperatureComponentType<SHT3xSensor>;
+
 /// Supported drivers by the platform
 pub struct Platform {
     ble_radio: &'static capsules_extra::ble_advertising_driver::BLE<
@@ -180,20 +186,7 @@ pub struct Platform {
         >,
     >,
     adc: &'static capsules_core::adc::AdcVirtualized<'static>,
-    temperature: &'static capsules_extra::temperature::TemperatureSensor<
-        'static,
-        capsules_extra::sht3x::SHT3x<
-            'static,
-            capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<
-                'static,
-                nrf52::rtc::Rtc<'static>,
-            >,
-            capsules_core::virtualizers::virtual_i2c::I2CDevice<
-                'static,
-                nrf52840::i2c::TWI<'static>,
-            >,
-        >,
-    >,
+    temperature: &'static TemperatureDriver,
     humidity: &'static capsules_extra::humidity::HumiditySensor<'static>,
     scheduler: &'static RoundRobinSched<'static>,
     systick: cortexm4::systick::SysTick,
@@ -634,13 +627,7 @@ pub unsafe fn main() {
         capsules_extra::temperature::DRIVER_NUM,
         sht3x,
     )
-    .finalize(components::temperature_component_static!(
-        capsules_extra::sht3x::SHT3x<
-            'static,
-            capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, nrf52::rtc::Rtc>,
-            capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, nrf52840::i2c::TWI>,
-        >
-    ));
+    .finalize(components::temperature_component_static!(SHT3xSensor));
 
     let humidity = components::humidity::HumidityComponent::new(
         board_kernel,

--- a/boards/components/src/bme280.rs
+++ b/boards/components/src/bme280.rs
@@ -47,6 +47,8 @@ macro_rules! bme280_component_static {
     };};
 }
 
+pub type Bme280ComponentType<I> = capsules_extra::bme280::Bme280<'static, I>;
+
 pub struct Bme280Component<I: 'static + i2c::I2CMaster<'static>> {
     i2c_mux: &'static MuxI2C<'static, I>,
     i2c_address: u8,

--- a/boards/components/src/bme280.rs
+++ b/boards/components/src/bme280.rs
@@ -36,7 +36,12 @@ macro_rules! bme280_component_static {
         let i2c_device =
             kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, $I>);
         let i2c_buffer = kernel::static_buf!([u8; 26]);
-        let bme280 = kernel::static_buf!(capsules_extra::bme280::Bme280<'static>);
+        let bme280 = kernel::static_buf!(
+            capsules_extra::bme280::Bme280<
+                'static,
+                capsules_core::virtualizers::virtual_i2c::I2CDevice<$I>,
+            >
+        );
 
         (i2c_device, i2c_buffer, bme280)
     };};
@@ -60,9 +65,9 @@ impl<I: 'static + i2c::I2CMaster<'static>> Component for Bme280Component<I> {
     type StaticInput = (
         &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<[u8; 26]>,
-        &'static mut MaybeUninit<Bme280<'static>>,
+        &'static mut MaybeUninit<Bme280<'static, I2CDevice<'static, I>>>,
     );
-    type Output = &'static Bme280<'static>;
+    type Output = &'static Bme280<'static, I2CDevice<'static, I>>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
         let bme280_i2c = s.0.write(I2CDevice::new(self.i2c_mux, self.i2c_address));

--- a/boards/components/src/bmp280.rs
+++ b/boards/components/src/bmp280.rs
@@ -37,7 +37,7 @@ use kernel::hil::time::Alarm;
 
 #[macro_export]
 macro_rules! bmp280_component_static {
-    ($A:ty $(,)?, $I:ty) => {{
+    ($A:ty, $I:ty $(,)?) => {{
         let i2c_device =
             kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, $I>);
         let alarm = kernel::static_buf!(

--- a/boards/components/src/bmp280.rs
+++ b/boards/components/src/bmp280.rs
@@ -56,6 +56,8 @@ macro_rules! bmp280_component_static {
     };};
 }
 
+pub type Bmp280ComponentType<A, I> = capsules_extra::bmp280::Bmp280<'static, A, I>;
+
 pub struct Bmp280Component<A: 'static + Alarm<'static>, I: 'static + i2c::I2CMaster<'static>> {
     i2c_mux: &'static MuxI2C<'static, I>,
     i2c_address: u8,

--- a/boards/components/src/hts221.rs
+++ b/boards/components/src/hts221.rs
@@ -37,6 +37,8 @@ macro_rules! hts221_component_static {
     };};
 }
 
+pub type Hts221ComponentType<I> = capsules_extra::hts221::Hts221<'static, I>;
+
 pub struct Hts221Component<I: 'static + i2c::I2CMaster<'static>> {
     i2c_mux: &'static MuxI2C<'static, I>,
     i2c_address: u8,

--- a/boards/components/src/l3gd20.rs
+++ b/boards/components/src/l3gd20.rs
@@ -43,6 +43,8 @@ macro_rules! l3gd20_component_static {
     };};
 }
 
+pub type L3gd20ComponentType<S> = capsules_extra::l3gd20::L3gd20Spi<'static, S>;
+
 pub struct L3gd20Component<S: 'static + spi::SpiMaster<'static>> {
     spi_mux: &'static MuxSpiMaster<'static, S>,
     chip_select: S::ChipSelect,

--- a/boards/components/src/l3gd20.rs
+++ b/boards/components/src/l3gd20.rs
@@ -25,14 +25,19 @@ use kernel::hil::spi::SpiMasterDevice;
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! l3gd20_component_static {
-    ($A:ty $(,)?) => {{
+    ($S:ty $(,)?) => {{
         let txbuffer = kernel::static_buf!([u8; capsules_extra::l3gd20::TX_BUF_LEN]);
         let rxbuffer = kernel::static_buf!([u8; capsules_extra::l3gd20::RX_BUF_LEN]);
 
         let spi = kernel::static_buf!(
-            capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<'static, $A>
+            capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<'static, $S>
         );
-        let l3gd20spi = kernel::static_buf!(capsules_extra::l3gd20::L3gd20Spi<'static>);
+        let l3gd20spi = kernel::static_buf!(
+            capsules_extra::l3gd20::L3gd20Spi<
+                'static,
+                capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<'static, $S>,
+            >
+        );
 
         (spi, l3gd20spi, txbuffer, rxbuffer)
     };};
@@ -64,11 +69,11 @@ impl<S: 'static + spi::SpiMaster<'static>> L3gd20Component<S> {
 impl<S: 'static + spi::SpiMaster<'static>> Component for L3gd20Component<S> {
     type StaticInput = (
         &'static mut MaybeUninit<VirtualSpiMasterDevice<'static, S>>,
-        &'static mut MaybeUninit<L3gd20Spi<'static>>,
+        &'static mut MaybeUninit<L3gd20Spi<'static, VirtualSpiMasterDevice<'static, S>>>,
         &'static mut MaybeUninit<[u8; capsules_extra::l3gd20::TX_BUF_LEN]>,
         &'static mut MaybeUninit<[u8; capsules_extra::l3gd20::RX_BUF_LEN]>,
     );
-    type Output = &'static L3gd20Spi<'static>;
+    type Output = &'static L3gd20Spi<'static, VirtualSpiMasterDevice<'static, S>>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);

--- a/boards/components/src/mlx90614.rs
+++ b/boards/components/src/mlx90614.rs
@@ -72,9 +72,9 @@ impl<I: 'static + i2c::I2CMaster<'static>, S: 'static + i2c::SMBusMaster<'static
     type StaticInput = (
         &'static mut MaybeUninit<SMBusDevice<'static, I, S>>,
         &'static mut MaybeUninit<[u8; 14]>,
-        &'static mut MaybeUninit<Mlx90614SMBus<'static>>,
+        &'static mut MaybeUninit<Mlx90614SMBus<'static, SMBusDevice<'static, I, S>>>,
     );
-    type Output = &'static Mlx90614SMBus<'static>;
+    type Output = &'static Mlx90614SMBus<'static, SMBusDevice<'static, I, S>>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let mlx90614_smbus = static_buffer

--- a/boards/components/src/sht3x.rs
+++ b/boards/components/src/sht3x.rs
@@ -46,6 +46,8 @@ macro_rules! sht3x_component_static {
     };};
 }
 
+pub type SHT3xComponentType<A, I> = capsules_extra::sht3x::SHT3x<'static, A, I>;
+
 pub struct SHT3xComponent<A: 'static + Alarm<'static>, I: 'static + i2c::I2CMaster<'static>> {
     i2c_mux: &'static MuxI2C<'static, I>,
     i2c_address: u8,

--- a/boards/components/src/si7021.rs
+++ b/boards/components/src/si7021.rs
@@ -48,6 +48,8 @@ macro_rules! si7021_component_static {
     };};
 }
 
+pub type SI7021ComponentType<A, I> = capsules_extra::si7021::SI7021<'static, A, I>;
+
 pub struct SI7021Component<A: 'static + time::Alarm<'static>, I: 'static + i2c::I2CMaster<'static>>
 {
     i2c_mux: &'static MuxI2C<'static, I>,

--- a/boards/components/src/temperature.rs
+++ b/boards/components/src/temperature.rs
@@ -20,8 +20,8 @@ use kernel::hil;
 
 #[macro_export]
 macro_rules! temperature_component_static {
-    () => {{
-        kernel::static_buf!(capsules_extra::temperature::TemperatureSensor<'static>)
+    ($T:ty $(,)?) => {{
+        kernel::static_buf!(capsules_extra::temperature::TemperatureSensor<'static, $T>)
     };};
 }
 
@@ -46,8 +46,8 @@ impl<T: 'static + hil::sensors::TemperatureDriver<'static>> TemperatureComponent
 }
 
 impl<T: 'static + hil::sensors::TemperatureDriver<'static>> Component for TemperatureComponent<T> {
-    type StaticInput = &'static mut MaybeUninit<TemperatureSensor<'static>>;
-    type Output = &'static TemperatureSensor<'static>;
+    type StaticInput = &'static mut MaybeUninit<TemperatureSensor<'static, T>>;
+    type Output = &'static TemperatureSensor<'static, T>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);

--- a/boards/components/src/temperature.rs
+++ b/boards/components/src/temperature.rs
@@ -25,6 +25,8 @@ macro_rules! temperature_component_static {
     };};
 }
 
+pub type TemperatureComponentType<T> = capsules_extra::temperature::TemperatureSensor<'static, T>;
+
 pub struct TemperatureComponent<T: 'static + hil::sensors::TemperatureDriver<'static>> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,

--- a/boards/components/src/temperature_rp2040.rs
+++ b/boards/components/src/temperature_rp2040.rs
@@ -26,6 +26,9 @@ macro_rules! temperature_rp2040_adc_component_static {
     };};
 }
 
+pub type TemperatureRp2040ComponentType<A> =
+    capsules_extra::temperature_rp2040::TemperatureRp2040<'static, A>;
+
 pub struct TemperatureRp2040Component<A: 'static + adc::Adc<'static>> {
     adc_mux: &'static capsules_core::virtualizers::virtual_adc::MuxAdc<'static, A>,
     adc_channel: A::Channel,

--- a/boards/components/src/temperature_rp2040.rs
+++ b/boards/components/src/temperature_rp2040.rs
@@ -15,8 +15,12 @@ use kernel::hil::adc::AdcChannel;
 macro_rules! temperature_rp2040_adc_component_static {
     ($A:ty $(,)?) => {{
         let adc_device = components::adc_component_static!($A);
-        let temperature_rp2040 =
-            kernel::static_buf!(capsules_extra::temperature_rp2040::TemperatureRp2040<'static>);
+        let temperature_rp2040 = kernel::static_buf!(
+            capsules_extra::temperature_rp2040::TemperatureRp2040<
+                'static,
+                capsules_core::virtualizers::virtual_adc::AdcDevice<'static, $A>,
+            >
+        );
 
         (adc_device, temperature_rp2040)
     };};
@@ -48,9 +52,9 @@ impl<A: 'static + adc::Adc<'static>> TemperatureRp2040Component<A> {
 impl<A: 'static + adc::Adc<'static>> Component for TemperatureRp2040Component<A> {
     type StaticInput = (
         &'static mut MaybeUninit<AdcDevice<'static, A>>,
-        &'static mut MaybeUninit<TemperatureRp2040<'static>>,
+        &'static mut MaybeUninit<TemperatureRp2040<'static, AdcDevice<'static, A>>>,
     );
-    type Output = &'static TemperatureRp2040<'static>;
+    type Output = &'static TemperatureRp2040<'static, AdcDevice<'static, A>>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
         let adc_device =

--- a/boards/components/src/temperature_stm.rs
+++ b/boards/components/src/temperature_stm.rs
@@ -15,8 +15,12 @@ use kernel::hil::adc::AdcChannel;
 macro_rules! temperature_stm_adc_component_static {
     ($A:ty $(,)?) => {{
         let adc_device = components::adc_component_static!($A);
-        let temperature_stm =
-            kernel::static_buf!(capsules_extra::temperature_stm::TemperatureSTM<'static>);
+        let temperature_stm = kernel::static_buf!(
+            capsules_extra::temperature_stm::TemperatureSTM<
+                'static,
+                capsules_core::virtualizers::virtual_adc::AdcDevice<'static, $A>,
+            >
+        );
 
         (adc_device, temperature_stm)
     };};
@@ -48,9 +52,9 @@ impl<A: 'static + adc::Adc<'static>> TemperatureSTMComponent<A> {
 impl<A: 'static + adc::Adc<'static>> Component for TemperatureSTMComponent<A> {
     type StaticInput = (
         &'static mut MaybeUninit<AdcDevice<'static, A>>,
-        &'static mut MaybeUninit<TemperatureSTM<'static>>,
+        &'static mut MaybeUninit<TemperatureSTM<'static, AdcDevice<'static, A>>>,
     );
-    type Output = &'static TemperatureSTM<'static>;
+    type Output = &'static TemperatureSTM<'static, AdcDevice<'static, A>>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
         let adc_device =

--- a/boards/components/src/temperature_stm.rs
+++ b/boards/components/src/temperature_stm.rs
@@ -26,6 +26,9 @@ macro_rules! temperature_stm_adc_component_static {
     };};
 }
 
+pub type TemperatureSTMComponentType<A> =
+    capsules_extra::temperature_stm::TemperatureSTM<'static, A>;
+
 pub struct TemperatureSTMComponent<A: 'static + adc::Adc<'static>> {
     adc_mux: &'static capsules_core::virtualizers::virtual_adc::MuxAdc<'static, A>,
     adc_channel: A::Channel,

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -48,6 +48,12 @@ static mut PROCESS_PRINTER: Option<&'static kernel::process::ProcessPrinterText>
 #[link_section = ".stack_buffer"]
 pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
 
+type SI7021Sensor = components::si7021::SI7021ComponentType<
+    capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>,
+    capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, sam4l::i2c::I2CHw<'static>>,
+>;
+type TemperatureDriver = components::temperature::TemperatureComponentType<SI7021Sensor>;
+
 /// A structure representing this platform that holds references to all
 /// capsules for this platform.
 struct Hail {
@@ -61,20 +67,7 @@ struct Hail {
         >,
     >,
     ambient_light: &'static capsules_extra::ambient_light::AmbientLight<'static>,
-    temp: &'static capsules_extra::temperature::TemperatureSensor<
-        'static,
-        capsules_extra::si7021::SI7021<
-            'static,
-            capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<
-                'static,
-                sam4l::ast::Ast<'static>,
-            >,
-            capsules_core::virtualizers::virtual_i2c::I2CDevice<
-                'static,
-                sam4l::i2c::I2CHw<'static>,
-            >,
-        >,
-    >,
+    temp: &'static TemperatureDriver,
     ninedof: &'static capsules_extra::ninedof::NineDof<'static>,
     humidity: &'static capsules_extra::humidity::HumiditySensor<'static>,
     spi: &'static capsules_core::spi_controller::Spi<
@@ -341,16 +334,7 @@ unsafe fn start() -> (
         capsules_extra::temperature::DRIVER_NUM,
         si7021,
     )
-    .finalize(components::temperature_component_static!(
-        capsules_extra::si7021::SI7021<
-            'static,
-            capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, sam4l::ast::Ast>,
-            capsules_core::virtualizers::virtual_i2c::I2CDevice<
-                'static,
-                sam4l::i2c::I2CHw<'static>,
-            >,
-        >
-    ));
+    .finalize(components::temperature_component_static!(SI7021Sensor));
     let humidity = components::humidity::HumidityComponent::new(
         board_kernel,
         capsules_extra::humidity::DRIVER_NUM,

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -61,7 +61,20 @@ struct Hail {
         >,
     >,
     ambient_light: &'static capsules_extra::ambient_light::AmbientLight<'static>,
-    temp: &'static capsules_extra::temperature::TemperatureSensor<'static>,
+    temp: &'static capsules_extra::temperature::TemperatureSensor<
+        'static,
+        capsules_extra::si7021::SI7021<
+            'static,
+            capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<
+                'static,
+                sam4l::ast::Ast<'static>,
+            >,
+            capsules_core::virtualizers::virtual_i2c::I2CDevice<
+                'static,
+                sam4l::i2c::I2CHw<'static>,
+            >,
+        >,
+    >,
     ninedof: &'static capsules_extra::ninedof::NineDof<'static>,
     humidity: &'static capsules_extra::humidity::HumiditySensor<'static>,
     spi: &'static capsules_core::spi_controller::Spi<
@@ -328,7 +341,16 @@ unsafe fn start() -> (
         capsules_extra::temperature::DRIVER_NUM,
         si7021,
     )
-    .finalize(components::temperature_component_static!());
+    .finalize(components::temperature_component_static!(
+        capsules_extra::si7021::SI7021<
+            'static,
+            capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, sam4l::ast::Ast>,
+            capsules_core::virtualizers::virtual_i2c::I2CDevice<
+                'static,
+                sam4l::i2c::I2CHw<'static>,
+            >,
+        >
+    ));
     let humidity = components::humidity::HumidityComponent::new(
         board_kernel,
         capsules_extra::humidity::DRIVER_NUM,

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -124,7 +124,17 @@ struct Imix {
     >,
     gpio: &'static capsules_core::gpio::GPIO<'static, sam4l::gpio::GPIOPin<'static>>,
     alarm: &'static AlarmDriver<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
-    temp: &'static capsules_extra::temperature::TemperatureSensor<'static>,
+    temp: &'static capsules_extra::temperature::TemperatureSensor<
+        'static,
+        capsules_extra::si7021::SI7021<
+            'static,
+            VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>,
+            capsules_core::virtualizers::virtual_i2c::I2CDevice<
+                'static,
+                sam4l::i2c::I2CHw<'static>,
+            >,
+        >,
+    >,
     humidity: &'static capsules_extra::humidity::HumiditySensor<'static>,
     ambient_light: &'static capsules_extra::ambient_light::AmbientLight<'static>,
     adc: &'static capsules_core::adc::AdcDedicated<'static, sam4l::adc::Adc<'static>>,
@@ -461,7 +471,16 @@ pub unsafe fn main() {
         capsules_extra::temperature::DRIVER_NUM,
         si7021,
     )
-    .finalize(components::temperature_component_static!());
+    .finalize(components::temperature_component_static!(
+        capsules_extra::si7021::SI7021<
+            'static,
+            VirtualMuxAlarm<'static, sam4l::ast::Ast>,
+            capsules_core::virtualizers::virtual_i2c::I2CDevice<
+                'static,
+                sam4l::i2c::I2CHw<'static>,
+            >,
+        >
+    ));
     let humidity = components::humidity::HumidityComponent::new(
         board_kernel,
         capsules_extra::humidity::DRIVER_NUM,

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -108,6 +108,12 @@ static mut PROCESS_PRINTER: Option<&'static kernel::process::ProcessPrinterText>
 #[link_section = ".stack_buffer"]
 pub static mut STACK_MEMORY: [u8; 0x2000] = [0; 0x2000];
 
+type SI7021Sensor = components::si7021::SI7021ComponentType<
+    capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>,
+    capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, sam4l::i2c::I2CHw<'static>>,
+>;
+type TemperatureDriver = components::temperature::TemperatureComponentType<SI7021Sensor>;
+
 struct Imix {
     pconsole: &'static capsules_core::process_console::ProcessConsole<
         'static,
@@ -124,17 +130,7 @@ struct Imix {
     >,
     gpio: &'static capsules_core::gpio::GPIO<'static, sam4l::gpio::GPIOPin<'static>>,
     alarm: &'static AlarmDriver<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
-    temp: &'static capsules_extra::temperature::TemperatureSensor<
-        'static,
-        capsules_extra::si7021::SI7021<
-            'static,
-            VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>,
-            capsules_core::virtualizers::virtual_i2c::I2CDevice<
-                'static,
-                sam4l::i2c::I2CHw<'static>,
-            >,
-        >,
-    >,
+    temp: &'static TemperatureDriver,
     humidity: &'static capsules_extra::humidity::HumiditySensor<'static>,
     ambient_light: &'static capsules_extra::ambient_light::AmbientLight<'static>,
     adc: &'static capsules_core::adc::AdcDedicated<'static, sam4l::adc::Adc<'static>>,
@@ -471,16 +467,7 @@ pub unsafe fn main() {
         capsules_extra::temperature::DRIVER_NUM,
         si7021,
     )
-    .finalize(components::temperature_component_static!(
-        capsules_extra::si7021::SI7021<
-            'static,
-            VirtualMuxAlarm<'static, sam4l::ast::Ast>,
-            capsules_core::virtualizers::virtual_i2c::I2CDevice<
-                'static,
-                sam4l::i2c::I2CHw<'static>,
-            >,
-        >
-    ));
+    .finalize(components::temperature_component_static!(SI7021Sensor));
     let humidity = components::humidity::HumidityComponent::new(
         board_kernel,
         capsules_extra::humidity::DRIVER_NUM,

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -81,6 +81,9 @@ pub static mut STACK_MEMORY: [u8; 0x2000] = [0; 0x2000];
 // debug mode requires more stack space
 // pub static mut STACK_MEMORY: [u8; 0x2000] = [0; 0x2000];
 
+type TemperatureDriver =
+    components::temperature::TemperatureComponentType<nrf52::temperature::Temp<'static>>;
+
 /// Supported drivers by the platform
 pub struct MicroBit {
     ble_radio: &'static capsules_extra::ble_advertising_driver::BLE<
@@ -112,10 +115,7 @@ pub struct MicroBit {
         'static,
         capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, nrf52833::i2c::TWI<'static>>,
     >,
-    temperature: &'static capsules_extra::temperature::TemperatureSensor<
-        'static,
-        nrf52833::temperature::Temp<'static>,
-    >,
+    temperature: &'static TemperatureDriver,
     ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     adc: &'static capsules_core::adc::AdcVirtualized<'static>,
     alarm: &'static capsules_core::alarm::AlarmDriver<

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -112,7 +112,10 @@ pub struct MicroBit {
         'static,
         capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, nrf52833::i2c::TWI<'static>>,
     >,
-    temperature: &'static capsules_extra::temperature::TemperatureSensor<'static>,
+    temperature: &'static capsules_extra::temperature::TemperatureSensor<
+        'static,
+        nrf52833::temperature::Temp<'static>,
+    >,
     ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     adc: &'static capsules_core::adc::AdcVirtualized<'static>,
     alarm: &'static capsules_core::alarm::AlarmDriver<
@@ -485,7 +488,9 @@ unsafe fn start() -> (
         capsules_extra::temperature::DRIVER_NUM,
         &base_peripherals.temp,
     )
-    .finalize(components::temperature_component_static!());
+    .finalize(components::temperature_component_static!(
+        nrf52833::temperature::Temp
+    ));
 
     //--------------------------------------------------------------------------
     // ADC

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -137,7 +137,16 @@ pub struct Platform {
         components::process_console::Capability,
     >,
     proximity: &'static capsules_extra::proximity::ProximitySensor<'static>,
-    temperature: &'static capsules_extra::temperature::TemperatureSensor<'static>,
+    temperature: &'static capsules_extra::temperature::TemperatureSensor<
+        'static,
+        capsules_extra::hts221::Hts221<
+            'static,
+            capsules_core::virtualizers::virtual_i2c::I2CDevice<
+                'static,
+                nrf52840::i2c::TWI<'static>,
+            >,
+        >,
+    >,
     humidity: &'static capsules_extra::humidity::HumiditySensor<'static>,
     gpio: &'static capsules_core::gpio::GPIO<'static, nrf52::gpio::GPIOPin<'static>>,
     led: &'static capsules_core::led::LedDriver<
@@ -499,7 +508,12 @@ pub unsafe fn start() -> (
         capsules_extra::temperature::DRIVER_NUM,
         hts221,
     )
-    .finalize(components::temperature_component_static!());
+    .finalize(components::temperature_component_static!(
+        capsules_extra::hts221::Hts221<
+            'static,
+            capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, nrf52840::i2c::TWI>,
+        >
+    ));
     let humidity = components::humidity::HumidityComponent::new(
         board_kernel,
         capsules_extra::humidity::DRIVER_NUM,

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -115,6 +115,11 @@ fn baud_rate_reset_bootloader_enter() {
     }
 }
 
+type HTS221Sensor = components::hts221::Hts221ComponentType<
+    capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, nrf52840::i2c::TWI<'static>>,
+>;
+type TemperatureDriver = components::temperature::TemperatureComponentType<HTS221Sensor>;
+
 /// Supported drivers by the platform
 pub struct Platform {
     ble_radio: &'static capsules_extra::ble_advertising_driver::BLE<
@@ -137,16 +142,7 @@ pub struct Platform {
         components::process_console::Capability,
     >,
     proximity: &'static capsules_extra::proximity::ProximitySensor<'static>,
-    temperature: &'static capsules_extra::temperature::TemperatureSensor<
-        'static,
-        capsules_extra::hts221::Hts221<
-            'static,
-            capsules_core::virtualizers::virtual_i2c::I2CDevice<
-                'static,
-                nrf52840::i2c::TWI<'static>,
-            >,
-        >,
-    >,
+    temperature: &'static TemperatureDriver,
     humidity: &'static capsules_extra::humidity::HumiditySensor<'static>,
     gpio: &'static capsules_core::gpio::GPIO<'static, nrf52::gpio::GPIOPin<'static>>,
     led: &'static capsules_core::led::LedDriver<
@@ -508,12 +504,7 @@ pub unsafe fn start() -> (
         capsules_extra::temperature::DRIVER_NUM,
         hts221,
     )
-    .finalize(components::temperature_component_static!(
-        capsules_extra::hts221::Hts221<
-            'static,
-            capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, nrf52840::i2c::TWI>,
-        >
-    ));
+    .finalize(components::temperature_component_static!(HTS221Sensor));
     let humidity = components::humidity::HumidityComponent::new(
         board_kernel,
         capsules_extra::humidity::DRIVER_NUM,

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -100,7 +100,10 @@ pub struct Platform {
         4,
     >,
     rng: &'static capsules_core::rng::RngDriver<'static>,
-    temp: &'static capsules_extra::temperature::TemperatureSensor<'static>,
+    temp: &'static capsules_extra::temperature::TemperatureSensor<
+        'static,
+        nrf52840::temperature::Temp<'static>,
+    >,
     ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     analog_comparator: &'static capsules_extra::analog_comparator::AnalogComparator<
         'static,
@@ -386,7 +389,9 @@ pub unsafe fn main() {
         capsules_extra::temperature::DRIVER_NUM,
         &base_peripherals.temp,
     )
-    .finalize(components::temperature_component_static!());
+    .finalize(components::temperature_component_static!(
+        nrf52840::temperature::Temp
+    ));
 
     let rng = components::rng::RngComponent::new(
         board_kernel,

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -77,6 +77,9 @@ static mut PROCESS_PRINTER: Option<&'static kernel::process::ProcessPrinterText>
 #[link_section = ".stack_buffer"]
 pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
 
+type TemperatureDriver =
+    components::temperature::TemperatureComponentType<nrf52840::temperature::Temp<'static>>;
+
 /// Supported drivers by the platform
 pub struct Platform {
     ble_radio: &'static capsules_extra::ble_advertising_driver::BLE<
@@ -100,10 +103,7 @@ pub struct Platform {
         4,
     >,
     rng: &'static capsules_core::rng::RngDriver<'static>,
-    temp: &'static capsules_extra::temperature::TemperatureSensor<
-        'static,
-        nrf52840::temperature::Temp<'static>,
-    >,
+    temp: &'static TemperatureDriver,
     ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     analog_comparator: &'static capsules_extra::analog_comparator::AnalogComparator<
         'static,

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -181,6 +181,10 @@ type KVStorePermissions = components::kv::KVStorePermissionsComponentType<TicKVK
 type VirtualKVPermissions = components::kv::VirtualKVPermissionsComponentType<KVStorePermissions>;
 type KVDriver = components::kv::KVDriverComponentType<VirtualKVPermissions>;
 
+// Temperature
+type TemperatureDriver =
+    components::temperature::TemperatureComponentType<nrf52840::temperature::Temp<'static>>;
+
 /// Supported drivers by the platform
 pub struct Platform {
     ble_radio: &'static capsules_extra::ble_advertising_driver::BLE<
@@ -205,10 +209,7 @@ pub struct Platform {
     >,
     rng: &'static capsules_core::rng::RngDriver<'static>,
     adc: &'static capsules_core::adc::AdcDedicated<'static, nrf52840::adc::Adc<'static>>,
-    temp: &'static capsules_extra::temperature::TemperatureSensor<
-        'static,
-        nrf52840::temperature::Temp<'static>,
-    >,
+    temp: &'static TemperatureDriver,
     ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     analog_comparator: &'static capsules_extra::analog_comparator::AnalogComparator<
         'static,

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -205,7 +205,10 @@ pub struct Platform {
     >,
     rng: &'static capsules_core::rng::RngDriver<'static>,
     adc: &'static capsules_core::adc::AdcDedicated<'static, nrf52840::adc::Adc<'static>>,
-    temp: &'static capsules_extra::temperature::TemperatureSensor<'static>,
+    temp: &'static capsules_extra::temperature::TemperatureSensor<
+        'static,
+        nrf52840::temperature::Temp<'static>,
+    >,
     ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     analog_comparator: &'static capsules_extra::analog_comparator::AnalogComparator<
         'static,
@@ -639,7 +642,9 @@ pub unsafe fn main() {
         capsules_extra::temperature::DRIVER_NUM,
         &base_peripherals.temp,
     )
-    .finalize(components::temperature_component_static!());
+    .finalize(components::temperature_component_static!(
+        nrf52840::temperature::Temp
+    ));
 
     //--------------------------------------------------------------------------
     // RANDOM NUMBER GENERATOR

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -156,7 +156,10 @@ pub struct Platform {
         4,
     >,
     rng: &'static capsules_core::rng::RngDriver<'static>,
-    temp: &'static capsules_extra::temperature::TemperatureSensor<'static>,
+    temp: &'static capsules_extra::temperature::TemperatureSensor<
+        'static,
+        nrf52832::temperature::Temp<'static>,
+    >,
     ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     analog_comparator: &'static capsules_extra::analog_comparator::AnalogComparator<
         'static,
@@ -415,7 +418,9 @@ pub unsafe fn main() {
         capsules_extra::temperature::DRIVER_NUM,
         &base_peripherals.temp,
     )
-    .finalize(components::temperature_component_static!());
+    .finalize(components::temperature_component_static!(
+        nrf52832::temperature::Temp
+    ));
 
     let rng = components::rng::RngComponent::new(
         board_kernel,

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -134,6 +134,9 @@ static mut PROCESS_PRINTER: Option<&'static kernel::process::ProcessPrinterText>
 #[link_section = ".stack_buffer"]
 pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
 
+type TemperatureDriver =
+    components::temperature::TemperatureComponentType<nrf52832::temperature::Temp<'static>>;
+
 /// Supported drivers by the platform
 pub struct Platform {
     ble_radio: &'static capsules_extra::ble_advertising_driver::BLE<
@@ -156,10 +159,7 @@ pub struct Platform {
         4,
     >,
     rng: &'static capsules_core::rng::RngDriver<'static>,
-    temp: &'static capsules_extra::temperature::TemperatureSensor<
-        'static,
-        nrf52832::temperature::Temp<'static>,
-    >,
+    temp: &'static TemperatureDriver,
     ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     analog_comparator: &'static capsules_extra::analog_comparator::AnalogComparator<
         'static,

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -69,7 +69,16 @@ struct NucleoF446RE {
         VirtualMuxAlarm<'static, stm32f446re::tim2::Tim2<'static>>,
     >,
 
-    temperature: &'static capsules_extra::temperature::TemperatureSensor<'static>,
+    temperature: &'static capsules_extra::temperature::TemperatureSensor<
+        'static,
+        capsules_extra::temperature_stm::TemperatureSTM<
+            'static,
+            capsules_core::virtualizers::virtual_adc::AdcDevice<
+                'static,
+                stm32f446re::adc::Adc<'static>,
+            >,
+        >,
+    >,
     gpio: &'static capsules_core::gpio::GPIO<'static, stm32f446re::gpio::Pin<'static>>,
 
     scheduler: &'static RoundRobinSched<'static>,
@@ -391,15 +400,18 @@ pub unsafe fn main() {
     .finalize(components::temperature_stm_adc_component_static!(
         stm32f446re::adc::Adc
     ));
-    let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-    let grant_temperature =
-        board_kernel.create_grant(capsules_extra::temperature::DRIVER_NUM, &grant_cap);
 
-    let temp = static_init!(
-        capsules_extra::temperature::TemperatureSensor<'static>,
-        capsules_extra::temperature::TemperatureSensor::new(temp_sensor, grant_temperature)
-    );
-    kernel::hil::sensors::TemperatureDriver::set_client(temp_sensor, temp);
+    let temp = components::temperature::TemperatureComponent::new(
+        board_kernel,
+        capsules_extra::temperature::DRIVER_NUM,
+        temp_sensor,
+    )
+    .finalize(components::temperature_component_static!(
+        capsules_extra::temperature_stm::TemperatureSTM<
+            'static,
+            capsules_core::virtualizers::virtual_adc::AdcDevice<'static, stm32f446re::adc::Adc>,
+        >
+    ));
 
     let adc_channel_0 =
         components::adc::AdcComponent::new(adc_mux, stm32f446re::adc::Channel::Channel0)

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -110,7 +110,10 @@ pub struct Platform {
     >,
     adc: &'static capsules_core::adc::AdcVirtualized<'static>,
     rng: &'static capsules_core::rng::RngDriver<'static>,
-    temp: &'static capsules_extra::temperature::TemperatureSensor<'static>,
+    temp: &'static capsules_extra::temperature::TemperatureSensor<
+        'static,
+        nrf52840::temperature::Temp<'static>,
+    >,
     ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     i2c_master_slave: &'static capsules_core::i2c_master_slave_driver::I2CMasterSlaveDriver<
         'static,
@@ -450,7 +453,9 @@ pub unsafe fn start_particle_boron() -> (
         capsules_extra::temperature::DRIVER_NUM,
         &base_peripherals.temp,
     )
-    .finalize(components::temperature_component_static!());
+    .finalize(components::temperature_component_static!(
+        nrf52840::temperature::Temp
+    ));
 
     //--------------------------------------------------------------------------
     // RANDOM NUMBERS

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -86,6 +86,9 @@ static mut NRF52_POWER: Option<&'static nrf52840::power::Power> = None;
 #[link_section = ".stack_buffer"]
 pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
 
+type TemperatureDriver =
+    components::temperature::TemperatureComponentType<nrf52840::temperature::Temp<'static>>;
+
 /// Supported drivers by the platform
 pub struct Platform {
     ble_radio: &'static capsules_extra::ble_advertising_driver::BLE<
@@ -110,10 +113,7 @@ pub struct Platform {
     >,
     adc: &'static capsules_core::adc::AdcVirtualized<'static>,
     rng: &'static capsules_core::rng::RngDriver<'static>,
-    temp: &'static capsules_extra::temperature::TemperatureSensor<
-        'static,
-        nrf52840::temperature::Temp<'static>,
-    >,
+    temp: &'static TemperatureDriver,
     ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     i2c_master_slave: &'static capsules_core::i2c_master_slave_driver::I2CMasterSlaveDriver<
         'static,

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -67,6 +67,11 @@ static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS]
 static mut CHIP: Option<&'static Rp2040<Rp2040DefaultPeripherals>> = None;
 static mut PROCESS_PRINTER: Option<&'static kernel::process::ProcessPrinterText> = None;
 
+type TemperatureRp2040Sensor = components::temperature_rp2040::TemperatureRp2040ComponentType<
+    capsules_core::virtualizers::virtual_adc::AdcDevice<'static, rp2040::adc::Adc<'static>>,
+>;
+type TemperatureDriver = components::temperature::TemperatureComponentType<TemperatureRp2040Sensor>;
+
 /// Supported drivers by the platform
 pub struct PicoExplorerBase {
     ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
@@ -78,13 +83,7 @@ pub struct PicoExplorerBase {
     gpio: &'static capsules_core::gpio::GPIO<'static, RPGpioPin<'static>>,
     led: &'static capsules_core::led::LedDriver<'static, LedHigh<'static, RPGpioPin<'static>>, 1>,
     adc: &'static capsules_core::adc::AdcVirtualized<'static>,
-    temperature: &'static capsules_extra::temperature::TemperatureSensor<
-        'static,
-        capsules_extra::temperature_rp2040::TemperatureRp2040<
-            'static,
-            capsules_core::virtualizers::virtual_adc::AdcDevice<'static, rp2040::adc::Adc<'static>>,
-        >,
-    >,
+    temperature: &'static TemperatureDriver,
     buzzer_driver: &'static capsules_extra::buzzer_driver::Buzzer<
         'static,
         capsules_extra::buzzer_pwm::PwmBuzzer<
@@ -454,10 +453,7 @@ pub unsafe fn main() {
         temp_sensor,
     )
     .finalize(components::temperature_component_static!(
-        capsules_extra::temperature_rp2040::TemperatureRp2040<
-            'static,
-            capsules_core::virtualizers::virtual_adc::AdcDevice<'static, rp2040::adc::Adc>,
-        >
+        TemperatureRp2040Sensor
     ));
 
     //set CLK, MOSI and CS pins in SPI mode

--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -83,7 +83,13 @@ pub struct RaspberryPiPico {
     gpio: &'static capsules_core::gpio::GPIO<'static, RPGpioPin<'static>>,
     led: &'static capsules_core::led::LedDriver<'static, LedHigh<'static, RPGpioPin<'static>>, 1>,
     adc: &'static capsules_core::adc::AdcVirtualized<'static>,
-    temperature: &'static capsules_extra::temperature::TemperatureSensor<'static>,
+    temperature: &'static capsules_extra::temperature::TemperatureSensor<
+        'static,
+        capsules_extra::temperature_rp2040::TemperatureRp2040<
+            'static,
+            capsules_core::virtualizers::virtual_adc::AdcDevice<'static, rp2040::adc::Adc<'static>>,
+        >,
+    >,
     i2c: &'static capsules_core::i2c_master::I2CMasterDriver<'static, I2c<'static, 'static>>,
 
     date_time:
@@ -460,15 +466,17 @@ pub unsafe fn main() {
     )
     .finalize(date_time_component_static!(rp2040::rtc::Rtc<'static>));
 
-    let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-    let grant_temperature =
-        board_kernel.create_grant(capsules_extra::temperature::DRIVER_NUM, &grant_cap);
-
-    let temp = static_init!(
-        capsules_extra::temperature::TemperatureSensor<'static>,
-        capsules_extra::temperature::TemperatureSensor::new(temp_sensor, grant_temperature)
-    );
-    kernel::hil::sensors::TemperatureDriver::set_client(temp_sensor, temp);
+    let temp = components::temperature::TemperatureComponent::new(
+        board_kernel,
+        capsules_extra::temperature::DRIVER_NUM,
+        temp_sensor,
+    )
+    .finalize(components::temperature_component_static!(
+        capsules_extra::temperature_rp2040::TemperatureRp2040<
+            'static,
+            capsules_core::virtualizers::virtual_adc::AdcDevice<'static, rp2040::adc::Adc>,
+        >
+    ));
 
     let adc_channel_0 = components::adc::AdcComponent::new(adc_mux, Channel::Channel0)
         .finalize(components::adc_component_static!(Adc));

--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -72,6 +72,11 @@ static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS]
 static mut CHIP: Option<&'static Rp2040<Rp2040DefaultPeripherals>> = None;
 static mut PROCESS_PRINTER: Option<&'static kernel::process::ProcessPrinterText> = None;
 
+type TemperatureRp2040Sensor = components::temperature_rp2040::TemperatureRp2040ComponentType<
+    capsules_core::virtualizers::virtual_adc::AdcDevice<'static, rp2040::adc::Adc<'static>>,
+>;
+type TemperatureDriver = components::temperature::TemperatureComponentType<TemperatureRp2040Sensor>;
+
 /// Supported drivers by the platform
 pub struct RaspberryPiPico {
     ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
@@ -83,13 +88,7 @@ pub struct RaspberryPiPico {
     gpio: &'static capsules_core::gpio::GPIO<'static, RPGpioPin<'static>>,
     led: &'static capsules_core::led::LedDriver<'static, LedHigh<'static, RPGpioPin<'static>>, 1>,
     adc: &'static capsules_core::adc::AdcVirtualized<'static>,
-    temperature: &'static capsules_extra::temperature::TemperatureSensor<
-        'static,
-        capsules_extra::temperature_rp2040::TemperatureRp2040<
-            'static,
-            capsules_core::virtualizers::virtual_adc::AdcDevice<'static, rp2040::adc::Adc<'static>>,
-        >,
-    >,
+    temperature: &'static TemperatureDriver,
     i2c: &'static capsules_core::i2c_master::I2CMasterDriver<'static, I2c<'static, 'static>>,
 
     date_time:
@@ -472,10 +471,7 @@ pub unsafe fn main() {
         temp_sensor,
     )
     .finalize(components::temperature_component_static!(
-        capsules_extra::temperature_rp2040::TemperatureRp2040<
-            'static,
-            capsules_core::virtualizers::virtual_adc::AdcDevice<'static, rp2040::adc::Adc>,
-        >
+        TemperatureRp2040Sensor
     ));
 
     let adc_channel_0 = components::adc::AdcComponent::new(adc_mux, Channel::Channel0)

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -75,13 +75,7 @@ struct STM32F3Discovery {
     >,
     button: &'static capsules_core::button::Button<'static, stm32f303xc::gpio::Pin<'static>>,
     ninedof: &'static capsules_extra::ninedof::NineDof<'static>,
-    l3gd20: &'static capsules_extra::l3gd20::L3gd20Spi<
-        'static,
-        capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<
-            'static,
-            stm32f303xc::spi::Spi<'static>,
-        >,
-    >,
+    l3gd20: &'static L3GD20Sensor,
     lsm303dlhc: &'static capsules_extra::lsm303dlhc::Lsm303dlhcI2C<
         'static,
         capsules_core::virtualizers::virtual_i2c::I2CDevice<

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -54,6 +54,14 @@ const FAULT_RESPONSE: kernel::process::PanicFaultPolicy = kernel::process::Panic
 #[link_section = ".stack_buffer"]
 pub static mut STACK_MEMORY: [u8; 0x1700] = [0; 0x1700];
 
+type L3GD20Sensor = components::l3gd20::L3gd20ComponentType<
+    capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<
+        'static,
+        stm32f303xc::spi::Spi<'static>,
+    >,
+>;
+type TemperatureDriver = components::temperature::TemperatureComponentType<L3GD20Sensor>;
+
 /// A structure representing this platform that holds references to all
 /// capsules for this platform.
 struct STM32F3Discovery {
@@ -81,16 +89,7 @@ struct STM32F3Discovery {
             stm32f303xc::i2c::I2C<'static>,
         >,
     >,
-    temp: &'static capsules_extra::temperature::TemperatureSensor<
-        'static,
-        capsules_extra::l3gd20::L3gd20Spi<
-            'static,
-            capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<
-                'static,
-                stm32f303xc::spi::Spi<'static>,
-            >,
-        >,
-    >,
+    temp: &'static TemperatureDriver,
     alarm: &'static capsules_core::alarm::AlarmDriver<
         'static,
         VirtualMuxAlarm<'static, stm32f303xc::tim2::Tim2<'static>>,
@@ -675,15 +674,7 @@ pub unsafe fn main() {
         capsules_extra::temperature::DRIVER_NUM,
         l3gd20,
     )
-    .finalize(components::temperature_component_static!(
-        capsules_extra::l3gd20::L3gd20Spi<
-            'static,
-            capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<
-                'static,
-                stm32f303xc::spi::Spi,
-            >,
-        >
-    ));
+    .finalize(components::temperature_component_static!(L3GD20Sensor));
 
     // LSM303DLHC
 

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -64,7 +64,16 @@ struct STM32F412GDiscovery {
     adc: &'static capsules_core::adc::AdcVirtualized<'static>,
     touch: &'static capsules_extra::touch::Touch<'static>,
     screen: &'static capsules_extra::screen::Screen<'static>,
-    temperature: &'static capsules_extra::temperature::TemperatureSensor<'static>,
+    temperature: &'static capsules_extra::temperature::TemperatureSensor<
+        'static,
+        capsules_extra::temperature_stm::TemperatureSTM<
+            'static,
+            capsules_core::virtualizers::virtual_adc::AdcDevice<
+                'static,
+                stm32f412g::adc::Adc<'static>,
+            >,
+        >,
+    >,
     rng: &'static capsules_core::rng::RngDriver<'static>,
 
     scheduler: &'static RoundRobinSched<'static>,
@@ -680,15 +689,18 @@ pub unsafe fn main() {
     .finalize(components::temperature_stm_adc_component_static!(
         stm32f412g::adc::Adc
     ));
-    let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-    let grant_temperature =
-        board_kernel.create_grant(capsules_extra::temperature::DRIVER_NUM, &grant_cap);
 
-    let temp = static_init!(
-        capsules_extra::temperature::TemperatureSensor<'static>,
-        capsules_extra::temperature::TemperatureSensor::new(temp_sensor, grant_temperature)
-    );
-    kernel::hil::sensors::TemperatureDriver::set_client(temp_sensor, temp);
+    let temp = components::temperature::TemperatureComponent::new(
+        board_kernel,
+        capsules_extra::temperature::DRIVER_NUM,
+        temp_sensor,
+    )
+    .finalize(components::temperature_component_static!(
+        capsules_extra::temperature_stm::TemperatureSTM<
+            'static,
+            capsules_core::virtualizers::virtual_adc::AdcDevice<'static, stm32f412g::adc::Adc>,
+        >
+    ));
 
     let adc_channel_0 =
         components::adc::AdcComponent::new(adc_mux, stm32f412g::adc::Channel::Channel1)

--- a/boards/stm32f429idiscovery/src/main.rs
+++ b/boards/stm32f429idiscovery/src/main.rs
@@ -62,7 +62,16 @@ struct STM32F429IDiscovery {
         'static,
         VirtualMuxAlarm<'static, stm32f429zi::tim2::Tim2<'static>>,
     >,
-    temperature: &'static capsules_extra::temperature::TemperatureSensor<'static>,
+    temperature: &'static capsules_extra::temperature::TemperatureSensor<
+        'static,
+        capsules_extra::temperature_stm::TemperatureSTM<
+            'static,
+            capsules_core::virtualizers::virtual_adc::AdcDevice<
+                'static,
+                stm32f429zi::adc::Adc<'static>,
+            >,
+        >,
+    >,
     gpio: &'static capsules_core::gpio::GPIO<'static, stm32f429zi::gpio::Pin<'static>>,
 
     scheduler: &'static RoundRobinSched<'static>,
@@ -510,15 +519,18 @@ pub unsafe fn main() {
     .finalize(components::temperature_stm_adc_component_static!(
         stm32f429zi::adc::Adc
     ));
-    let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-    let grant_temperature =
-        board_kernel.create_grant(capsules_extra::temperature::DRIVER_NUM, &grant_cap);
 
-    let temp = static_init!(
-        capsules_extra::temperature::TemperatureSensor<'static>,
-        capsules_extra::temperature::TemperatureSensor::new(temp_sensor, grant_temperature)
-    );
-    kernel::hil::sensors::TemperatureDriver::set_client(temp_sensor, temp);
+    let temp = components::temperature::TemperatureComponent::new(
+        board_kernel,
+        capsules_extra::temperature::DRIVER_NUM,
+        temp_sensor,
+    )
+    .finalize(components::temperature_component_static!(
+        capsules_extra::temperature_stm::TemperatureSTM<
+            'static,
+            capsules_core::virtualizers::virtual_adc::AdcDevice<'static, stm32f429zi::adc::Adc>,
+        >
+    ));
 
     let adc_channel_0 =
         components::adc::AdcComponent::new(adc_mux, stm32f429zi::adc::Channel::Channel3)

--- a/boards/stm32f429idiscovery/src/main.rs
+++ b/boards/stm32f429idiscovery/src/main.rs
@@ -46,6 +46,11 @@ const FAULT_RESPONSE: kernel::process::PanicFaultPolicy = kernel::process::Panic
 #[link_section = ".stack_buffer"]
 pub static mut STACK_MEMORY: [u8; 0x2000] = [0; 0x2000];
 
+type TemperatureSTMSensor = components::temperature_stm::TemperatureSTMComponentType<
+    capsules_core::virtualizers::virtual_adc::AdcDevice<'static, stm32f429zi::adc::Adc<'static>>,
+>;
+type TemperatureDriver = components::temperature::TemperatureComponentType<TemperatureSTMSensor>;
+
 /// A structure representing this platform that holds references to all
 /// capsules for this platform.
 struct STM32F429IDiscovery {
@@ -62,16 +67,7 @@ struct STM32F429IDiscovery {
         'static,
         VirtualMuxAlarm<'static, stm32f429zi::tim2::Tim2<'static>>,
     >,
-    temperature: &'static capsules_extra::temperature::TemperatureSensor<
-        'static,
-        capsules_extra::temperature_stm::TemperatureSTM<
-            'static,
-            capsules_core::virtualizers::virtual_adc::AdcDevice<
-                'static,
-                stm32f429zi::adc::Adc<'static>,
-            >,
-        >,
-    >,
+    temperature: &'static TemperatureDriver,
     gpio: &'static capsules_core::gpio::GPIO<'static, stm32f429zi::gpio::Pin<'static>>,
 
     scheduler: &'static RoundRobinSched<'static>,
@@ -526,10 +522,7 @@ pub unsafe fn main() {
         temp_sensor,
     )
     .finalize(components::temperature_component_static!(
-        capsules_extra::temperature_stm::TemperatureSTM<
-            'static,
-            capsules_core::virtualizers::virtual_adc::AdcDevice<'static, stm32f429zi::adc::Adc>,
-        >
+        TemperatureSTMSensor
     ));
 
     let adc_channel_0 =

--- a/capsules/extra/src/bme280.rs
+++ b/capsules/extra/src/bme280.rs
@@ -77,9 +77,9 @@ struct CalibrationData {
     hum6: u16,
 }
 
-pub struct Bme280<'a> {
+pub struct Bme280<'a, I: I2CDevice> {
     buffer: TakeCell<'static, [u8]>,
-    i2c: &'a dyn I2CDevice,
+    i2c: &'a I,
     calibration: Cell<CalibrationData>,
     temperature_client: OptionalCell<&'a dyn TemperatureClient>,
     humidity_client: OptionalCell<&'a dyn HumidityClient>,
@@ -88,8 +88,8 @@ pub struct Bme280<'a> {
     t_fine: Cell<usize>,
 }
 
-impl<'a> Bme280<'a> {
-    pub fn new(i2c: &'a dyn I2CDevice, buffer: &'static mut [u8]) -> Self {
+impl<'a, I: I2CDevice> Bme280<'a, I> {
+    pub fn new(i2c: &'a I, buffer: &'static mut [u8]) -> Self {
         Bme280 {
             buffer: TakeCell::new(buffer),
             i2c,
@@ -113,7 +113,7 @@ impl<'a> Bme280<'a> {
     }
 }
 
-impl<'a> TemperatureDriver<'a> for Bme280<'a> {
+impl<'a, I: I2CDevice> TemperatureDriver<'a> for Bme280<'a, I> {
     fn set_client(&self, client: &'a dyn TemperatureClient) {
         self.temperature_client.set(client);
     }
@@ -138,7 +138,7 @@ impl<'a> TemperatureDriver<'a> for Bme280<'a> {
     }
 }
 
-impl<'a> HumidityDriver<'a> for Bme280<'a> {
+impl<'a, I: I2CDevice> HumidityDriver<'a> for Bme280<'a, I> {
     fn set_client(&self, client: &'a dyn HumidityClient) {
         self.humidity_client.set(client);
     }
@@ -163,7 +163,7 @@ impl<'a> HumidityDriver<'a> for Bme280<'a> {
     }
 }
 
-impl<'a> I2CClient for Bme280<'a> {
+impl<'a, I: I2CDevice> I2CClient for Bme280<'a, I> {
     fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
         if let Err(i2c_err) = status {
             // We have no way to report an error, so just return a bogus value

--- a/capsules/extra/src/mlx90614.rs
+++ b/capsules/extra/src/mlx90614.rs
@@ -68,8 +68,8 @@ enum_from_primitive! {
 #[derive(Default)]
 pub struct App {}
 
-pub struct Mlx90614SMBus<'a> {
-    smbus_temp: &'a dyn i2c::SMBusDevice,
+pub struct Mlx90614SMBus<'a, S: i2c::SMBusDevice> {
+    smbus_temp: &'a S,
     temperature_client: OptionalCell<&'a dyn sensors::TemperatureClient>,
     buffer: TakeCell<'static, [u8]>,
     state: Cell<State>,
@@ -77,12 +77,12 @@ pub struct Mlx90614SMBus<'a> {
     owning_process: OptionalCell<ProcessId>,
 }
 
-impl<'a> Mlx90614SMBus<'_> {
+impl<'a, S: i2c::SMBusDevice> Mlx90614SMBus<'a, S> {
     pub fn new(
-        smbus_temp: &'a dyn i2c::SMBusDevice,
+        smbus_temp: &'a S,
         buffer: &'static mut [u8],
         grant: Grant<App, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
-    ) -> Mlx90614SMBus<'a> {
+    ) -> Mlx90614SMBus<'a, S> {
         Mlx90614SMBus {
             smbus_temp,
             temperature_client: OptionalCell::empty(),
@@ -119,7 +119,7 @@ impl<'a> Mlx90614SMBus<'_> {
     }
 }
 
-impl<'a> i2c::I2CClient for Mlx90614SMBus<'a> {
+impl<'a, S: i2c::SMBusDevice> i2c::I2CClient for Mlx90614SMBus<'a, S> {
     fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
         match self.state.get() {
             State::Idle => {
@@ -170,7 +170,7 @@ impl<'a> i2c::I2CClient for Mlx90614SMBus<'a> {
     }
 }
 
-impl<'a> SyscallDriver for Mlx90614SMBus<'a> {
+impl<'a, S: i2c::SMBusDevice> SyscallDriver for Mlx90614SMBus<'a, S> {
     fn command(
         &self,
         command_num: usize,
@@ -235,7 +235,7 @@ impl<'a> SyscallDriver for Mlx90614SMBus<'a> {
     }
 }
 
-impl<'a> sensors::TemperatureDriver<'a> for Mlx90614SMBus<'a> {
+impl<'a, S: i2c::SMBusDevice> sensors::TemperatureDriver<'a> for Mlx90614SMBus<'a, S> {
     fn set_client(&self, temperature_client: &'a dyn sensors::TemperatureClient) {
         self.temperature_client.replace(temperature_client);
     }

--- a/capsules/extra/src/temperature.rs
+++ b/capsules/extra/src/temperature.rs
@@ -71,17 +71,17 @@ pub struct App {
     subscribed: bool,
 }
 
-pub struct TemperatureSensor<'a> {
-    driver: &'a dyn hil::sensors::TemperatureDriver<'a>,
+pub struct TemperatureSensor<'a, T: hil::sensors::TemperatureDriver<'a>> {
+    driver: &'a T,
     apps: Grant<App, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
     busy: Cell<bool>,
 }
 
-impl<'a> TemperatureSensor<'a> {
+impl<'a, T: hil::sensors::TemperatureDriver<'a>> TemperatureSensor<'a, T> {
     pub fn new(
-        driver: &'a dyn hil::sensors::TemperatureDriver<'a>,
+        driver: &'a T,
         grant: Grant<App, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
-    ) -> TemperatureSensor<'a> {
+    ) -> TemperatureSensor<'a, T> {
         TemperatureSensor {
             driver: driver,
             apps: grant,
@@ -113,7 +113,9 @@ impl<'a> TemperatureSensor<'a> {
     }
 }
 
-impl hil::sensors::TemperatureClient for TemperatureSensor<'_> {
+impl<'a, T: hil::sensors::TemperatureDriver<'a>> hil::sensors::TemperatureClient
+    for TemperatureSensor<'a, T>
+{
     fn callback(&self, temp_val: Result<i32, ErrorCode>) {
         // We completed the operation so we clear the busy flag in case we get
         // another measurement request.
@@ -134,7 +136,7 @@ impl hil::sensors::TemperatureClient for TemperatureSensor<'_> {
     }
 }
 
-impl SyscallDriver for TemperatureSensor<'_> {
+impl<'a, T: hil::sensors::TemperatureDriver<'a>> SyscallDriver for TemperatureSensor<'a, T> {
     fn command(
         &self,
         command_num: usize,

--- a/capsules/extra/src/temperature_rp2040.rs
+++ b/capsules/extra/src/temperature_rp2040.rs
@@ -19,18 +19,18 @@ pub enum Status {
     Idle,
 }
 
-pub struct TemperatureRp2040<'a> {
-    adc: &'a dyn adc::AdcChannel<'a>,
+pub struct TemperatureRp2040<'a, A: adc::AdcChannel<'a>> {
+    adc: &'a A,
     slope: f32,
     v_27: f32,
     temperature_client: OptionalCell<&'a dyn sensors::TemperatureClient>,
     status: Cell<Status>,
 }
 
-impl<'a> TemperatureRp2040<'a> {
+impl<'a, A: adc::AdcChannel<'a>> TemperatureRp2040<'a, A> {
     /// slope - device specific slope found in datasheet
     /// v_27 - voltage at 27 degrees Celsius found in datasheet
-    pub fn new(adc: &'a dyn adc::AdcChannel<'a>, slope: f32, v_27: f32) -> TemperatureRp2040<'a> {
+    pub fn new(adc: &'a A, slope: f32, v_27: f32) -> TemperatureRp2040<'a, A> {
         TemperatureRp2040 {
             adc: adc,
             slope: slope,
@@ -41,7 +41,7 @@ impl<'a> TemperatureRp2040<'a> {
     }
 }
 
-impl<'a> adc::Client for TemperatureRp2040<'a> {
+impl<'a, A: adc::AdcChannel<'a>> adc::Client for TemperatureRp2040<'a, A> {
     fn sample_ready(&self, sample: u16) {
         self.status.set(Status::Idle);
         self.temperature_client.map(|client| {
@@ -52,7 +52,7 @@ impl<'a> adc::Client for TemperatureRp2040<'a> {
     }
 }
 
-impl<'a> sensors::TemperatureDriver<'a> for TemperatureRp2040<'a> {
+impl<'a, A: adc::AdcChannel<'a>> sensors::TemperatureDriver<'a> for TemperatureRp2040<'a, A> {
     fn set_client(&self, temperature_client: &'a dyn sensors::TemperatureClient) {
         self.temperature_client.replace(temperature_client);
     }

--- a/capsules/extra/src/temperature_stm.rs
+++ b/capsules/extra/src/temperature_stm.rs
@@ -19,18 +19,18 @@ pub enum Status {
     Idle,
 }
 
-pub struct TemperatureSTM<'a> {
-    adc: &'a dyn adc::AdcChannel<'a>,
+pub struct TemperatureSTM<'a, A: adc::AdcChannel<'a>> {
+    adc: &'a A,
     slope: f32,
     v_25: f32,
     temperature_client: OptionalCell<&'a dyn sensors::TemperatureClient>,
     status: Cell<Status>,
 }
 
-impl<'a> TemperatureSTM<'a> {
+impl<'a, A: adc::AdcChannel<'a>> TemperatureSTM<'a, A> {
     /// slope - device specific slope found in datasheet
     /// v_25 - voltage at 25 degrees Celsius found in datasheet
-    pub fn new(adc: &'a dyn adc::AdcChannel<'a>, slope: f32, v_25: f32) -> TemperatureSTM<'a> {
+    pub fn new(adc: &'a A, slope: f32, v_25: f32) -> TemperatureSTM<'a, A> {
         TemperatureSTM {
             adc: adc,
             slope: slope,
@@ -41,7 +41,7 @@ impl<'a> TemperatureSTM<'a> {
     }
 }
 
-impl<'a> adc::Client for TemperatureSTM<'a> {
+impl<'a, A: adc::AdcChannel<'a>> adc::Client for TemperatureSTM<'a, A> {
     fn sample_ready(&self, sample: u16) {
         self.status.set(Status::Idle);
         self.temperature_client.map(|client| {
@@ -53,7 +53,7 @@ impl<'a> adc::Client for TemperatureSTM<'a> {
     }
 }
 
-impl<'a> sensors::TemperatureDriver<'a> for TemperatureSTM<'a> {
+impl<'a, A: adc::AdcChannel<'a>> sensors::TemperatureDriver<'a> for TemperatureSTM<'a, A> {
     fn set_client(&self, temperature_client: &'a dyn sensors::TemperatureClient) {
         self.temperature_client.replace(temperature_client);
     }


### PR DESCRIPTION
### Pull Request Overview

Remove `i2c: &'a dyn I2CDevice` in favor of `i2c: &'a I` throughout the temperature sensor stack.

I think this pull request is a net improvement (#1761), but my real goal is to further motivate #3657. My argument in #3657 is that one major impediment to using templated types and not dynamic dispatch is that main.rs files get even _more_ unwieldy. 

For example, some nrf boards now look like:

```diff
diff --git a/boards/clue_nrf52840/src/main.rs b/boards/clue_nrf52840/src/main.rs
index 1badea619..00e81152b 100644
--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -180,7 +180,20 @@ pub struct Platform {
         >,
     >,
     adc: &'static capsules_core::adc::AdcVirtualized<'static>,
-    temperature: &'static capsules_extra::temperature::TemperatureSensor<'static>,
+    temperature: &'static capsules_extra::temperature::TemperatureSensor<
+        'static,
+        capsules_extra::sht3x::SHT3x<
+            'static,
+            capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<
+                'static,
+                nrf52::rtc::Rtc<'static>,
+            >,
+            capsules_core::virtualizers::virtual_i2c::I2CDevice<
+                'static,
+                nrf52840::i2c::TWI<'static>,
+            >,
+        >,
+    >,
     humidity: &'static capsules_extra::humidity::HumiditySensor<'static>,
```

### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
