### PR TITLE
Tock registers v0.9

### DIFF
--- a/libraries/tock-register-interface/CHANGELOG.md
+++ b/libraries/tock-register-interface/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## master
 
+## v0.9
+
+There is a small breaking change, described below, which addresses semantic
+confusion around `matches_any()`. The interface has changed, so this should
+result in compile-time awareness rather than any silent behavioral changes.
+
+### **Breaking Changes**
+
+https://github.com/tock/tock/pull/3336
+480ee65139f1e51c149236a1b3e47cd61832ac80
+Rename matches_any() to any_matching_bits_set(), implement matches_any()
+
+> The current implementation of matches_any() does not implement the
+> functionality the name implies. This commit renames the existing
+> implementation to a name which better describes its functionality,
+> and introduces a new matches_any() function (with a different interface)
+> that actually correctly implements the functionality suggested by the
+> name. This commit also adds several tests to the tock-registers test
+> suite to verify the new version works as expected, and removes a feature
+> gate on a feature that no longer exists for the crate which was
+> preventing some of the tock-registers teste suite from being run as part
+> of `cargo test`.
+
+### Other changes:
+
+ - #3687: derive `Debug` on `Value`
+ - #3582: Update rust-toolchain to nightly of 2023-07-30
+
 ## v0.8.1
 
 A point release to allow multiple invocations of `register_fields!` in

--- a/libraries/tock-register-interface/Cargo.toml
+++ b/libraries/tock-register-interface/Cargo.toml
@@ -15,9 +15,6 @@ categories = ["data-structures", "embedded", "no-std"]
 license = "MIT/Apache-2.0"
 edition = "2021"
 
-[badges]
-travis-ci = { repository = "tock/tock", branch = "master" }
-
 [features]
 default = [ "register_types" ]
 

--- a/libraries/tock-register-interface/Cargo.toml
+++ b/libraries/tock-register-interface/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "tock-registers"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 description = "Memory-Mapped I/O and register interface developed for Tock."
 homepage = "https://www.tockos.org/"


### PR DESCRIPTION
### Pull Request Overview

This pull request tags v0.9 for release for `tock-registers`.

We haven't made a release in around a year. Creating a release now is motivated by [downstream desire for the new Derive](https://github.com/tock/tock/discussions/3691). In the last year, we've really only had two changes of substance—the Derive just now, and Hudson's `matches_any` fix from last winter.

This is probably evidence of a need for a 1.0 (though, `matches_any` was a major version breaking change). Perhaps we release 1.0 more or less as-is, and that will allow for the safety/correctness refactor long-burn project to be a 2.0?

### Testing Strategy

N/A

### TODO or Help Wanted

N/A

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
