### PR TITLE
Enable SHT4x Sensor on wm1110 Board

### DIFF
--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -68,6 +68,7 @@ pub mod screen;
 pub mod segger_rtt;
 pub mod sha;
 pub mod sht3x;
+pub mod sht4x;
 pub mod si7021;
 pub mod siphash;
 pub mod sound_pressure;

--- a/boards/components/src/sht4x.rs
+++ b/boards/components/src/sht4x.rs
@@ -1,0 +1,100 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2023.
+
+//! Component for the SHT4x sensor.
+//!
+//! I2C Interface
+//!
+//! Usage
+//! -----
+//!
+//! ```rust
+//! let sht4x = components::sht4x::SHT4xComponent::new(sensors_i2c_bus, capsules_extra::sht4x::BASE_ADDR, mux_alarm).finalize(
+//!         components::sht4x_component_static!(nrf52::rtc::Rtc<'static>),
+//!     );
+//! sht4x.reset();
+//! ```
+
+use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use capsules_core::virtualizers::virtual_i2c::{I2CDevice, MuxI2C};
+use capsules_extra::sht4x::SHT4x;
+use core::mem::MaybeUninit;
+use kernel::component::Component;
+use kernel::hil::i2c;
+use kernel::hil::time::Alarm;
+
+// Setup static space for the objects.
+#[macro_export]
+macro_rules! sht4x_component_static {
+    ($A:ty, $I:ty $(,)?) => {{
+        let buffer = kernel::static_buf!([u8; 6]);
+        let i2c_device =
+            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, $I>);
+        let sht4x_alarm = kernel::static_buf!(
+            capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, $A>
+        );
+        let sht4x = kernel::static_buf!(
+            capsules_extra::sht4x::SHT4x<
+                'static,
+                capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, $A>,
+                capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, $I>,
+            >
+        );
+
+        (sht4x_alarm, i2c_device, sht4x, buffer)
+    };};
+}
+
+pub struct SHT4xComponent<A: 'static + Alarm<'static>, I: 'static + i2c::I2CMaster<'static>> {
+    i2c_mux: &'static MuxI2C<'static, I>,
+    i2c_address: u8,
+    alarm_mux: &'static MuxAlarm<'static, A>,
+}
+
+impl<A: 'static + Alarm<'static>, I: 'static + i2c::I2CMaster<'static>> SHT4xComponent<A, I> {
+    pub fn new(
+        i2c_mux: &'static MuxI2C<'static, I>,
+        i2c_address: u8,
+        alarm_mux: &'static MuxAlarm<'static, A>,
+    ) -> SHT4xComponent<A, I> {
+        SHT4xComponent {
+            i2c_mux,
+            i2c_address,
+            alarm_mux,
+        }
+    }
+}
+
+impl<A: 'static + Alarm<'static>, I: 'static + i2c::I2CMaster<'static>> Component
+    for SHT4xComponent<A, I>
+{
+    type StaticInput = (
+        &'static mut MaybeUninit<VirtualMuxAlarm<'static, A>>,
+        &'static mut MaybeUninit<I2CDevice<'static, I>>,
+        &'static mut MaybeUninit<
+            SHT4x<'static, VirtualMuxAlarm<'static, A>, I2CDevice<'static, I>>,
+        >,
+        &'static mut MaybeUninit<[u8; 6]>,
+    );
+    type Output = &'static SHT4x<'static, VirtualMuxAlarm<'static, A>, I2CDevice<'static, I>>;
+
+    fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
+        let sht4x_i2c = static_buffer
+            .1
+            .write(I2CDevice::new(self.i2c_mux, self.i2c_address));
+
+        let buffer = static_buffer.3.write([0; 6]);
+
+        let sht4x_alarm = static_buffer.0.write(VirtualMuxAlarm::new(self.alarm_mux));
+        sht4x_alarm.setup();
+
+        let sht4x = static_buffer
+            .2
+            .write(SHT4x::new(sht4x_i2c, buffer, sht4x_alarm));
+        sht4x_i2c.set_client(sht4x);
+        sht4x_alarm.set_alarm_client(sht4x);
+
+        sht4x
+    }
+}

--- a/boards/wm1110dev/src/main.rs
+++ b/boards/wm1110dev/src/main.rs
@@ -297,7 +297,7 @@ pub unsafe fn start() -> (
     let _ = &nrf52840_peripherals.gpio_port[I2C_PWR].set();
 
     let mux_i2c = components::i2c::I2CMuxComponent::new(&base_peripherals.twi1, None)
-    .finalize(components::i2c_mux_component_static!(nrf52840::i2c::TWI));
+        .finalize(components::i2c_mux_component_static!(nrf52840::i2c::TWI));
     base_peripherals.twi1.configure(
         nrf52840::pinmux::Pinmux::new(I2C_SCL_PIN as u32),
         nrf52840::pinmux::Pinmux::new(I2C_SDA_PIN as u32),

--- a/capsules/extra/src/lib.rs
+++ b/capsules/extra/src/lib.rs
@@ -77,6 +77,7 @@ pub mod seven_segment;
 pub mod sha;
 pub mod sha256;
 pub mod sht3x;
+pub mod sht4x;
 pub mod si7021;
 pub mod sip_hash;
 pub mod sound_pressure;

--- a/capsules/extra/src/sht4x.rs
+++ b/capsules/extra/src/sht4x.rs
@@ -1,0 +1,268 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2023.
+
+//! Driver for SHT4x Temperature and Humidity Sensor
+
+use core::cell::Cell;
+use enum_primitive::cast::FromPrimitive;
+use enum_primitive::enum_from_primitive;
+use kernel::hil::i2c;
+use kernel::hil::time::{self, Alarm, ConvertTicks};
+use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::ErrorCode;
+
+pub static BASE_ADDR: u8 = 0x44;
+
+enum_from_primitive! {
+    enum Registers {
+        /// sht4x has no Clock Stretching
+        /// Measurement High Repeatability
+        MEASHIGHREP = 0xFD,
+        /// Measurement Medium Repeatability
+        MEASMEDREP = 0xF6,
+        /// Measurement Low Repeatability
+        MEASLOWREP = 0xE0,
+        /// Read Serial Number
+        READSERIALNUM = 0x89,
+        /// Soft Reset
+        SOFTRESET = 0x94,
+        /// Activate heater with 200mW for 1s
+        HEATER200MW1S = 0x39,
+        /// Activate heater with 200mW for 0.1s
+        HEATER200MW01S = 0x32,
+        /// Activate heater with 110mW for 1s
+        HEATER110MW1S = 0x2F,
+        /// Activate heater with 110mW for 0.1s
+        HEATER110MW01S = 0x24,
+        /// Activate heater with 20mW for 1s
+        HEATER20MW1S = 0x1E,
+        /// Activate heater with 20mW for 0.1s
+        HEATER20MW01S = 0x15,
+    }
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum State {
+    Idle,
+    Read,
+    ReadData,
+}
+
+fn crc8(data: &[u8]) -> u8 {
+    let polynomial = 0x31;
+    let mut crc = 0xff;
+
+    for x in 0..data.len() {
+        crc ^= data[x];
+        for _i in 0..8 {
+            if (crc & 0x80) != 0 {
+                crc = crc << 1 ^ polynomial;
+            } else {
+                crc = crc << 1;
+            }
+        }
+    }
+    crc
+}
+
+pub struct SHT4x<'a, A: Alarm<'a>, I: i2c::I2CDevice> {
+    i2c: &'a I,
+    humidity_client: OptionalCell<&'a dyn kernel::hil::sensors::HumidityClient>,
+    temperature_client: OptionalCell<&'a dyn kernel::hil::sensors::TemperatureClient>,
+    state: Cell<State>,
+    buffer: TakeCell<'static, [u8]>,
+    read_temp: Cell<bool>,
+    read_hum: Cell<bool>,
+    alarm: &'a A,
+}
+
+impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> SHT4x<'a, A, I> {
+    pub fn new(i2c: &'a I, buffer: &'static mut [u8], alarm: &'a A) -> SHT4x<'a, A, I> {
+        SHT4x {
+            i2c: i2c,
+            humidity_client: OptionalCell::empty(),
+            temperature_client: OptionalCell::empty(),
+            state: Cell::new(State::Idle),
+            buffer: TakeCell::new(buffer),
+            read_temp: Cell::new(false),
+            read_hum: Cell::new(false),
+            alarm: alarm,
+        }
+    }
+
+    fn read_humidity(&self) -> Result<(), ErrorCode> {
+        if self.read_hum.get() == true {
+            Err(ErrorCode::BUSY)
+        } else {
+            if self.state.get() == State::Idle {
+                let result = self.read_temp_hum();
+                if result.is_ok() {
+                    self.read_hum.set(true);
+                }
+                result
+            } else {
+                self.read_hum.set(true);
+                Ok(())
+            }
+        }
+    }
+
+    fn read_temperature(&self) -> Result<(), ErrorCode> {
+        if self.read_temp.get() == true {
+            Err(ErrorCode::BUSY)
+        } else {
+            if self.state.get() == State::Idle {
+                let result = self.read_temp_hum();
+                if result.is_ok() {
+                    self.read_temp.set(true);
+                }
+                result
+            } else {
+                self.read_temp.set(true);
+                Ok(())
+            }
+        }
+    }
+
+    fn read_temp_hum(&self) -> Result<(), ErrorCode> {
+        self.buffer.take().map_or(Err(ErrorCode::NOMEM),
+            |buffer| {
+                self.state.set(State::Read);
+                self.i2c.enable();
+
+                buffer[0] = Registers::MEASHIGHREP as u8;
+
+                let _res = self.i2c.write(buffer, 1);
+                match _res {
+                    Ok(_) => Ok(()),
+                    Err((error, data)) => {
+                        self.buffer.replace(data);
+                        self.state.set(State::Idle);
+                        self.i2c.disable();
+                        Err(error.into())
+                    }
+                }
+            },
+        )
+    }
+}
+
+impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> time::AlarmClient for SHT4x<'a, A, I> {
+    fn alarm(&self) {
+        let state = self.state.get();
+        match state {
+            State::Read => {
+                self.state.set(State::ReadData);
+                self.buffer.take().map(
+                    |buffer| {
+                        let _res = self.i2c.read(buffer, 6);
+                    },
+                );
+            }
+            _ => {
+                // This should never happen
+                panic!("SHT4x Invalid alarm!");
+            }
+        }
+    }
+}
+
+impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> i2c::I2CClient for SHT4x<'a, A, I> {
+    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
+        match status {
+            Ok(()) => {
+                let state = self.state.get();
+
+                match state {
+                    State::ReadData => {
+                    let read_temp_res = if self.read_temp.get() {
+                        self.read_temp.set(false);
+                        if crc8(&buffer[0..2]) == buffer[2] {
+                            let mut stemp = buffer[0] as u32;
+                            stemp = stemp << 8;
+                            stemp = stemp | buffer[1] as u32;
+                            let stemp = ((4375 * stemp) >> 14) as i32 - 4500;
+                            Some(Ok(stemp))
+                        } else {
+                            Some(Err(ErrorCode::FAIL))
+                        }
+                    } else {
+                        None
+                    };
+
+                    let read_hum_res = if self.read_hum.get() {
+                        self.read_hum.set(false);
+                        if crc8(&buffer[3..5]) == buffer[5] {
+                            let mut shum = buffer[3] as u32;
+                            shum = shum << 8;
+                            shum = shum | buffer[4] as u32;
+                            shum = (625 * shum) >> 12;
+                            Some(shum as usize)
+                        } else {
+                            Some(usize::MAX)
+                        }
+                    } else {
+                        None
+                    };
+
+                    self.buffer.replace(buffer);
+                    self.state.set(State::Idle);
+
+                    read_temp_res.map(|res| {
+                        self.temperature_client.map(|cb| cb.callback(res));
+                    });
+                    
+                    read_hum_res.map(|res| {
+                        self.humidity_client.map(|cb| cb.callback(res));
+                    });
+                }
+                    State::Read => {
+                        self.buffer.replace(buffer);
+                        let interval = self.alarm.ticks_from_ms(20);
+                        self.alarm.set_alarm(self.alarm.now(), interval);
+                    }
+                    _ => {}
+                }
+            }
+            Err(i2c_err) => {
+                self.buffer.replace(buffer);
+                self.i2c.disable();
+                self.state.set(State::Idle);
+                if self.read_temp.get() == true {
+                    self.read_temp.set(false);
+                    self.temperature_client
+                        .map(|cb| cb.callback(Err(i2c_err.into())));
+                }
+                if self.read_hum.get() == true {
+                    self.read_hum.set(false);
+                    self.humidity_client.map(|cb| cb.callback(usize::MAX));
+                }
+            }
+        }
+    }
+}
+
+impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> kernel::hil::sensors::HumidityDriver<'a>
+    for SHT4x<'a, A, I>
+{
+    fn set_client(&self, client: &'a dyn kernel::hil::sensors::HumidityClient) {
+        self.humidity_client.set(client);
+    }
+
+    fn read_humidity(&self) -> Result<(), ErrorCode> {
+        self.read_humidity()
+    }
+}
+
+impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> kernel::hil::sensors::TemperatureDriver<'a>
+    for SHT4x<'a, A, I>
+{
+    fn set_client(&self, client: &'a dyn kernel::hil::sensors::TemperatureClient) {
+        self.temperature_client.set(client);
+    }
+
+    fn read_temperature(&self) -> Result<(), ErrorCode> {
+        self.read_temperature()
+    }
+}


### PR DESCRIPTION
### Pull Request Overview

This pull request implements the SHT4x driver and adds the driver to main.rs, so the board can successfully use sensors to read temperature and humidity after installing the sensors app. 


### Testing Strategy

This pull request was tested by examining whether the temperature and humidity reading is successful after flashing the updated kernel code and installing the sensor app into wm1110 board


### TODO or Help Wanted

Should be good for the sensor functionality


### Documentation Updated

- [ ] Have not updated documentation for this PR

### Formatting

- [ N/A ] Ran `make prepush`.


