### PR TITLE
Earlgrey: Update cw310 FPGA clock frequencies

### DIFF
--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -13,9 +13,10 @@ QEMU ?= ../../../tools/qemu/build/qemu-system-riscv32
 # This offset is calculated (from the linker file) as:
 # ORIGIN(rom) + size_manifest = 0x20000000 + 0x400
 QEMU_ENTRY_POINT=0x20000400
-# OpenTitan commit 21ce4e9761abdf5c919b46e5ae64a5a8e24992f7 is Earlgrey-M2.5.2-RC0.
-# This commit is what is being taped out in the first Earlgrey chip.
-OPENTITAN_SUPPORTED_SHA := 21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
+# OpenTitan commit 7df72d61f536e9babb343219232783e5e49f7ceb is on the
+# earlgrey_es branch. earlgrey_es is what is being taped out in the first
+# Earlgrey chip.
+OPENTITAN_SUPPORTED_SHA := 7df72d61f536e9babb343219232783e5e49f7ceb
 # Enable virtual function elimination
 VFUNC_ELIM=1
 

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -57,9 +57,9 @@ pub enum ChipConfig {}
 impl EarlGreyConfig for ChipConfig {
     const NAME: &'static str = "fpga_cw310";
 
-    // Clock frequencies as of https://github.com/lowRISC/opentitan/pull/19368
-    const CPU_FREQ: u32 = 10_000_000;
-    const PERIPHERAL_FREQ: u32 = 2_500_000;
+    // Clock frequencies as of https://github.com/lowRISC/opentitan/pull/19479
+    const CPU_FREQ: u32 = 24_000_000;
+    const PERIPHERAL_FREQ: u32 = 6_000_000;
     const AON_TIMER_FREQ: u32 = 250_000;
     const UART_BAUDRATE: u32 = 115200;
 }


### PR DESCRIPTION
### Pull Request Overview

OpenTitan increased some of Earlgrey's clock frequencies on cw310: https://github.com/lowRISC/opentitan/pull/19479. This PR adjusts Tock's Earlgrey config on cw310 to match the new values.

Replaces #3639

### Testing Strategy

This pull request was tested using OpenTitan's `//sw/device/silicon_owner/tock/tests/basic:basic_test` with https://github.com/lowRISC/opentitan/pull/19895 applied.

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
