### PR TITLE
Refactoring of Earlgrey GPIO driver

### DIFF
--- a/boards/opentitan/src/io.rs
+++ b/boards/opentitan/src/io.rs
@@ -50,8 +50,8 @@ pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     let first_led_pin = &mut earlgrey::gpio::GpioPin::new(
         earlgrey::gpio::GPIO_BASE,
         earlgrey::pinmux::PadConfig::Output(
-            earlgrey::registers::top_earlgrey::MuxedPads::Ioa0,
-            earlgrey::registers::top_earlgrey::PinmuxOutsel::GpioGpio0,
+            earlgrey::registers::top_earlgrey::MuxedPads::Ioa6,
+            earlgrey::registers::top_earlgrey::PinmuxOutsel::GpioGpio7,
         ),
         earlgrey::gpio::pins::pin7,
     );

--- a/boards/opentitan/src/io.rs
+++ b/boards/opentitan/src/io.rs
@@ -48,8 +48,11 @@ use kernel::hil::led;
 #[panic_handler]
 pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     let first_led_pin = &mut earlgrey::gpio::GpioPin::new(
-        earlgrey::gpio::GPIO0_BASE,
-        earlgrey::gpio::PADCTRL_BASE,
+        earlgrey::gpio::GPIO_BASE,
+        earlgrey::pinmux::PadConfig::Output(
+            earlgrey::registers::top_earlgrey::MuxedPads::Ioa0,
+            earlgrey::registers::top_earlgrey::PinmuxOutsel::GpioGpio0,
+        ),
         earlgrey::gpio::pins::pin7,
     );
     first_led_pin.make_output();

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -16,11 +16,13 @@
 
 use crate::hil::symmetric_encryption::AES128_BLOCK_SIZE;
 use crate::otbn::OtbnComponent;
+use crate::pinmux_layout::BoardPinmuxLayout;
 use capsules_aes_gcm::aes_gcm;
 use capsules_core::virtualizers::virtual_aes_ccm;
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use earlgrey::chip::EarlGreyDefaultPeripherals;
 use earlgrey::chip_config::EarlGreyConfig;
+use earlgrey::pinmux_config::EarlGreyPinmuxConfig;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::hil;
@@ -42,6 +44,7 @@ use rv32i::csr;
 
 pub mod io;
 mod otbn;
+pub mod pinmux_layout;
 #[cfg(test)]
 mod tests;
 
@@ -84,7 +87,8 @@ static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; 4] = [None
 
 // Test access to the peripherals
 #[cfg(test)]
-static mut PERIPHERALS: Option<&'static EarlGreyDefaultPeripherals<ChipConfig>> = None;
+static mut PERIPHERALS: Option<&'static EarlGreyDefaultPeripherals<ChipConfig, BoardPinmuxLayout>> =
+    None;
 // Test access to board
 #[cfg(test)]
 static mut BOARD: Option<&'static kernel::Kernel> = None;
@@ -127,7 +131,11 @@ static mut RSA_HARDWARE: Option<&lowrisc::rsa::OtbnRsa<'static>> = None;
 static mut SHA256SOFT: Option<&capsules_extra::sha256::Sha256Software<'static>> = None;
 
 static mut CHIP: Option<
-    &'static earlgrey::chip::EarlGrey<EarlGreyDefaultPeripherals<ChipConfig>, ChipConfig>,
+    &'static earlgrey::chip::EarlGrey<
+        EarlGreyDefaultPeripherals<ChipConfig, BoardPinmuxLayout>,
+        ChipConfig,
+        BoardPinmuxLayout,
+    >,
 > = None;
 static mut PROCESS_PRINTER: Option<&'static kernel::process::ProcessPrinterText> = None;
 
@@ -235,8 +243,9 @@ impl
     KernelResources<
         earlgrey::chip::EarlGrey<
             'static,
-            EarlGreyDefaultPeripherals<'static, ChipConfig>,
+            EarlGreyDefaultPeripherals<'static, ChipConfig, BoardPinmuxLayout>,
             ChipConfig,
+            BoardPinmuxLayout,
         >,
     > for EarlGrey
 {
@@ -282,13 +291,17 @@ unsafe fn setup() -> (
     &'static EarlGrey,
     &'static earlgrey::chip::EarlGrey<
         'static,
-        EarlGreyDefaultPeripherals<'static, ChipConfig>,
+        EarlGreyDefaultPeripherals<'static, ChipConfig, BoardPinmuxLayout>,
         ChipConfig,
+        BoardPinmuxLayout,
     >,
-    &'static EarlGreyDefaultPeripherals<'static, ChipConfig>,
+    &'static EarlGreyDefaultPeripherals<'static, ChipConfig, BoardPinmuxLayout>,
 ) {
     // Ibex-specific handler
     earlgrey::chip::configure_trap_handler();
+
+    // Configure board layout in pinmux
+    BoardPinmuxLayout::setup();
 
     // initialize capabilities
     let process_mgmt_cap = create_capability!(capabilities::ProcessManagementCapability);
@@ -297,7 +310,7 @@ unsafe fn setup() -> (
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
 
     let peripherals = static_init!(
-        EarlGreyDefaultPeripherals<ChipConfig>,
+        EarlGreyDefaultPeripherals<ChipConfig, BoardPinmuxLayout>,
         EarlGreyDefaultPeripherals::new()
     );
     peripherals.init();
@@ -396,7 +409,11 @@ unsafe fn setup() -> (
     );
 
     let chip = static_init!(
-        earlgrey::chip::EarlGrey<EarlGreyDefaultPeripherals<ChipConfig>, ChipConfig>,
+        earlgrey::chip::EarlGrey<
+            EarlGreyDefaultPeripherals<ChipConfig, BoardPinmuxLayout>,
+            ChipConfig,
+            BoardPinmuxLayout,
+        >,
         earlgrey::chip::EarlGrey::new(peripherals, hardware_alarm)
     );
     CHIP = Some(chip);

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -144,10 +144,13 @@ pub static mut STACK_MEMORY: [u8; 0x1400] = [0; 0x1400];
 struct EarlGrey {
     led: &'static capsules_core::led::LedDriver<
         'static,
-        LedHigh<'static, earlgrey::gpio::GpioPin<'static>>,
+        LedHigh<'static, earlgrey::gpio::GpioPin<'static, earlgrey::pinmux::PadConfig>>,
         8,
     >,
-    gpio: &'static capsules_core::gpio::GPIO<'static, earlgrey::gpio::GpioPin<'static>>,
+    gpio: &'static capsules_core::gpio::GPIO<
+        'static,
+        earlgrey::gpio::GpioPin<'static, earlgrey::pinmux::PadConfig>,
+    >,
     console: &'static capsules_core::console::Console<'static>,
     alarm: &'static capsules_core::alarm::AlarmDriver<
         'static,
@@ -314,7 +317,7 @@ unsafe fn setup() -> (
     // LEDs
     // Start with half on and half off
     let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
-        LedHigh<'static, earlgrey::gpio::GpioPin>,
+        LedHigh<'static, earlgrey::gpio::GpioPin<earlgrey::pinmux::PadConfig>>,
         LedHigh::new(&peripherals.gpio_port[8]),
         LedHigh::new(&peripherals.gpio_port[9]),
         LedHigh::new(&peripherals.gpio_port[10]),
@@ -329,7 +332,7 @@ unsafe fn setup() -> (
         board_kernel,
         capsules_core::gpio::DRIVER_NUM,
         components::gpio_component_helper!(
-            earlgrey::gpio::GpioPin,
+            earlgrey::gpio::GpioPin<earlgrey::pinmux::PadConfig>,
             0 => &peripherals.gpio_port[0],
             1 => &peripherals.gpio_port[1],
             2 => &peripherals.gpio_port[2],
@@ -340,7 +343,9 @@ unsafe fn setup() -> (
             7 => &peripherals.gpio_port[15]
         ),
     )
-    .finalize(components::gpio_component_static!(earlgrey::gpio::GpioPin));
+    .finalize(components::gpio_component_static!(
+        earlgrey::gpio::GpioPin<earlgrey::pinmux::PadConfig>
+    ));
 
     let hardware_alarm = static_init!(
         earlgrey::timer::RvTimer<ChipConfig>,

--- a/boards/opentitan/src/pinmux_layout.rs
+++ b/boards/opentitan/src/pinmux_layout.rs
@@ -1,0 +1,140 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2023.
+
+use earlgrey::pinmux_config::{EarlGreyPinmuxConfig, INPUT_NUM, OUTPUT_NUM};
+use earlgrey::registers::top_earlgrey::{PinmuxInsel, PinmuxOutsel};
+
+type In = PinmuxInsel;
+type Out = PinmuxOutsel;
+
+pub enum BoardPinmuxLayout {}
+
+/// Implementations of Pinmux initial board configurations.
+/// Defined Pinmux layout is designed for CW310 FPGA board
+/// and is compatible with Hyperdebug test board IO layout.
+/// In feature we should add layouts compatible with other
+/// OpenTitan boards.
+/// Source of true:
+/// <OPENTITAN_TREE/hw/top_earlgrey/data/pins_cw310_hyperdebug.xdc>
+impl EarlGreyPinmuxConfig for BoardPinmuxLayout {
+    /// Array of input selector initial configurations
+    #[rustfmt::skip]
+    const INPUT: &'static [PinmuxInsel; INPUT_NUM] = &[
+        In::Ioa2,         // GpioGpio0
+        In::Ioa3,         // GpioGpio1
+        In::Ioa6,         // GpioGpio2
+        In::Iob0,         // GpioGpio3
+        In::Iob1,         // GpioGpio4
+        In::Iob2,         // GpioGpio5
+        In::Iob3,         // GpioGpio6
+        In::Iob6,         // GpioGpio7
+        In::Iob7,         // GpioGpio8
+        In::Iob8,         // GpioGpio9
+        In::Ioc0,         // GpioGpio10
+        In::Ioc1,         // GpioGpio11
+        In::Ioc2,         // GpioGpio12
+        In::Ioc5,         // GpioGpio13
+        In::Ioc6,         // GpioGpio14
+        In::Ioc7,         // GpioGpio15
+        In::Ioc8,         // GpioGpio16
+        In::Ioc9,         // GpioGpio17
+        In::Ioc10,        // GpioGpio18
+        In::Ioc11,        // GpioGpio19
+        In::Ioc12,        // GpioGpio20
+        In::Ior0,         // GpioGpio21
+        In::Ior1,         // GpioGpio22
+        In::Ior2,         // GpioGpio23
+        In::Ior3,         // GpioGpio24
+        In::Ior4,         // GpioGpio25
+        In::Ior5,         // GpioGpio26
+        In::Ior6,         // GpioGpio27
+        In::Ior7,         // GpioGpio28
+        In::Ior10,        // GpioGpio29
+        In::Ior11,        // GpioGpio30
+        In::Ior12,        // GpioGpio31
+        In::Ioa7,         // I2c0Sda
+        In::Ioa8,         // I2c0Scl
+        In::Iob10,        // I2c1Sda
+        In::Iob9,         // I2c1Scl
+        In::Iob11,        // I2c2Sda
+        In::Iob12,        // I2c2Scl
+        In::ConstantZero, // SpiHost1Sd0
+        In::ConstantZero, // SpiHost1Sd1
+        In::ConstantZero, // SpiHost1Sd2
+        In::ConstantZero, // SpiHost1Sd3
+        In::Ioa0,         // Uart0Rx
+        In::Ioa4,         // Uart1Rx
+        In::Iob4,         // Uart2Rx
+        In::Ioc3,         // Uart3Rx
+        In::ConstantZero, // SpiDeviceTpmCsb
+        In::ConstantZero, // FlashCtrlTck
+        In::ConstantZero, // FlashCtrlTms
+        In::ConstantZero, // FlashCtrlTdi
+        In::ConstantZero, // SysrstCtrlAonAcPresent
+        In::ConstantZero, // SysrstCtrlAonKey0In
+        In::ConstantZero, // SysrstCtrlAonKey1In
+        In::ConstantZero, // SysrstCtrlAonKey2In
+        In::ConstantZero, // SysrstCtrlAonPwrbIn
+        In::ConstantZero, // SysrstCtrlAonLidOpen
+        In::ConstantZero, // UsbdevSense
+    ];
+
+    /// Array representing configgurations of pinmux output selector
+    #[rustfmt::skip]
+    const OUTPUT: &'static [PinmuxOutsel; OUTPUT_NUM] = &[
+        // __________  BANK IOA __________
+        Out::ConstantHighZ, // Ioa0 (CW310Hyp Uart_RX / CW310 SAM3X)
+        Out::Uart0Tx,       // Ioa1 (CW310Hyp Uart_Tx / CW310 SAM3x)
+        Out::GpioGpio0,     // Ioa2
+        Out::GpioGpio1,     // Ioa3
+        Out::ConstantHighZ, // Ioa4
+        Out::Uart1Tx,       // Ioa5
+        Out::GpioGpio2,     // Ioa6
+        Out::I2c0Sda,       // Ioa7 I2C0_TPM_SDA
+        Out::I2c0Scl,       // Ioa8 I2C0_TPM_SCL
+        // __________ BANK IOB __________
+        Out::GpioGpio3,     // Iob0 SPI_HOST_CS
+        Out::GpioGpio4,     // Iob1 SPI_HOST_DI
+        Out::GpioGpio5,     // Iob2 SPI_HOST_DO
+        Out::GpioGpio6,     // Iob3 SPI_HOST_CLK
+        Out::ConstantHighZ, // Iob4 UART2_RX
+        Out::Uart2Tx,       // Iob5 UART2_TX
+        Out::GpioGpio7,     // Iob6
+        Out::GpioGpio8,     // Iob7
+        Out::GpioGpio9,     // Iob8
+        Out::I2c1Scl,       // Iob9  I2C1_SCL
+        Out::I2c1Sda,       // Iob10 I2C1_SDA
+        Out::I2c2Sda,       // Iob11 I2C2_SDA
+        Out::I2c2Scl,       // Iob12 I2C2_SCL
+        // __________ BANK IOC __________
+        Out::GpioGpio10,    // Ioc0
+        Out::GpioGpio11,    // Ioc1
+        Out::GpioGpio12,    // Ioc2
+        Out::ConstantHighZ, // Ioc3 UART3_RX
+        Out::Uart3Tx,       // Ioc4 UART3_TX
+        Out::GpioGpio13,    // Ioc5
+        Out::GpioGpio14,    // Ioc6
+        Out::GpioGpio15,    // Ioc7
+        Out::GpioGpio16,    // Ioc8
+        Out::GpioGpio17,    // Ioc9
+        Out::GpioGpio18,    // Ioc10
+        Out::GpioGpio19,    // Ioc11
+        Out::GpioGpio20,    // Ioc12
+        // __________ BANK IOR __________
+        Out::GpioGpio21,    // Ior0
+        Out::GpioGpio22,    // Ior1
+        Out::GpioGpio23,    // Ior2
+        Out::GpioGpio24,    // Ior3
+        Out::GpioGpio25,    // Ior4
+        Out::GpioGpio26,    // Ior5
+        Out::GpioGpio27,    // Ior6
+        Out::GpioGpio28,    // Ior7
+        // DIO CW310_hyp       Ior8
+        // DIO CW310_hyp       Ior9
+        Out::GpioGpio29,    // Ior10
+        Out::GpioGpio30,    // Ior11
+        Out::GpioGpio31,    // Ior12
+        Out::ConstantHighZ, // Ior13
+    ];
+}

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -15,10 +15,16 @@ use rv32i::syscall::SysCall;
 
 use crate::chip_config::EarlGreyConfig;
 use crate::interrupts;
+use crate::pinmux_config::EarlGreyPinmuxConfig;
 use crate::plic::Plic;
 use crate::plic::PLIC;
 
-pub struct EarlGrey<'a, I: InterruptService + 'a, CFG: EarlGreyConfig + 'static> {
+pub struct EarlGrey<
+    'a,
+    I: InterruptService + 'a,
+    CFG: EarlGreyConfig + 'static,
+    PINMUX: EarlGreyPinmuxConfig,
+> {
     userspace_kernel_boundary: SysCall,
     pub pmp: PMP<8>,
     plic: &'a Plic,
@@ -26,9 +32,10 @@ pub struct EarlGrey<'a, I: InterruptService + 'a, CFG: EarlGreyConfig + 'static>
     pwrmgr: lowrisc::pwrmgr::PwrMgr,
     plic_interrupt_service: &'a I,
     _cfg: PhantomData<CFG>,
+    _pinmux: PhantomData<PINMUX>,
 }
 
-pub struct EarlGreyDefaultPeripherals<'a, CFG: EarlGreyConfig> {
+pub struct EarlGreyDefaultPeripherals<'a, CFG: EarlGreyConfig, PINMUX: EarlGreyPinmuxConfig> {
     pub aes: crate::aes::Aes<'a>,
     pub hmac: lowrisc::hmac::Hmac<'a>,
     pub usb: lowrisc::usbdev::Usb<'a>,
@@ -42,9 +49,12 @@ pub struct EarlGreyDefaultPeripherals<'a, CFG: EarlGreyConfig> {
     pub rng: lowrisc::csrng::CsRng<'a>,
     pub watchdog: lowrisc::aon_timer::AonTimer,
     _cfg: PhantomData<CFG>,
+    _pinmux: PhantomData<PINMUX>,
 }
 
-impl<'a, CFG: EarlGreyConfig> EarlGreyDefaultPeripherals<'a, CFG> {
+impl<'a, CFG: EarlGreyConfig, PINMUX: EarlGreyPinmuxConfig>
+    EarlGreyDefaultPeripherals<'a, CFG, PINMUX>
+{
     pub fn new() -> Self {
         Self {
             aes: crate::aes::Aes::new(),
@@ -52,7 +62,7 @@ impl<'a, CFG: EarlGreyConfig> EarlGreyDefaultPeripherals<'a, CFG> {
             usb: lowrisc::usbdev::Usb::new(crate::usbdev::USB0_BASE),
             uart0: lowrisc::uart::Uart::new(crate::uart::UART0_BASE, CFG::PERIPHERAL_FREQ),
             otbn: lowrisc::otbn::Otbn::new(crate::otbn::OTBN_BASE),
-            gpio_port: crate::gpio::Port::new(),
+            gpio_port: crate::gpio::Port::new::<PINMUX>(),
             i2c0: lowrisc::i2c::I2c::new(crate::i2c::I2C0_BASE, (1 / CFG::CPU_FREQ) * 1000 * 1000),
             spi_host0: lowrisc::spi_host::SpiHost::new(
                 crate::spi_host::SPIHOST0_BASE,
@@ -73,6 +83,7 @@ impl<'a, CFG: EarlGreyConfig> EarlGreyDefaultPeripherals<'a, CFG> {
                 CFG::CPU_FREQ,
             ),
             _cfg: PhantomData,
+            _pinmux: PhantomData,
         }
     }
 
@@ -81,7 +92,9 @@ impl<'a, CFG: EarlGreyConfig> EarlGreyDefaultPeripherals<'a, CFG> {
     }
 }
 
-impl<'a, CFG: EarlGreyConfig> InterruptService for EarlGreyDefaultPeripherals<'a, CFG> {
+impl<'a, CFG: EarlGreyConfig, PINMUX: EarlGreyPinmuxConfig> InterruptService
+    for EarlGreyDefaultPeripherals<'a, CFG, PINMUX>
+{
     unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
             interrupts::UART0_TX_WATERMARK..=interrupts::UART0_RX_PARITYERR => {
@@ -121,7 +134,9 @@ impl<'a, CFG: EarlGreyConfig> InterruptService for EarlGreyDefaultPeripherals<'a
     }
 }
 
-impl<'a, I: InterruptService + 'a, CFG: EarlGreyConfig> EarlGrey<'a, I, CFG> {
+impl<'a, I: InterruptService + 'a, CFG: EarlGreyConfig, PINMUX: EarlGreyPinmuxConfig>
+    EarlGrey<'a, I, CFG, PINMUX>
+{
     pub unsafe fn new(
         plic_interrupt_service: &'a I,
         timer: &'static crate::timer::RvTimer<'_, CFG>,
@@ -134,6 +149,7 @@ impl<'a, I: InterruptService + 'a, CFG: EarlGreyConfig> EarlGrey<'a, I, CFG> {
             timer,
             plic_interrupt_service,
             _cfg: PhantomData,
+            _pinmux: PhantomData,
         }
     }
 
@@ -227,8 +243,8 @@ impl<'a, I: InterruptService + 'a, CFG: EarlGreyConfig> EarlGrey<'a, I, CFG> {
     }
 }
 
-impl<'a, I: InterruptService + 'a, CFG: EarlGreyConfig> kernel::platform::chip::Chip
-    for EarlGrey<'a, I, CFG>
+impl<'a, I: InterruptService + 'a, CFG: EarlGreyConfig, PINMUX: EarlGreyPinmuxConfig>
+    kernel::platform::chip::Chip for EarlGrey<'a, I, CFG, PINMUX>
 {
     type MPU = PMP<8>;
     type UserspaceKernelBoundary = SysCall;

--- a/chips/earlgrey/src/gpio.rs
+++ b/chips/earlgrey/src/gpio.rs
@@ -6,74 +6,98 @@
 
 use core::ops::{Index, IndexMut};
 
-use crate::registers::top_earlgrey::{GPIO_BASE_ADDR, PINMUX_AON_BASE_ADDR};
-
 use kernel::utilities::StaticRef;
 use lowrisc::gpio::GpioRegisters;
-pub use lowrisc::gpio::{pins, GpioPin};
-use lowrisc::padctrl::PadCtrlRegisters;
+pub use lowrisc::gpio::{pins, GpioBitfield, GpioPin};
 
-pub const PADCTRL_BASE: StaticRef<PadCtrlRegisters> =
-    unsafe { StaticRef::new(PINMUX_AON_BASE_ADDR as *const PadCtrlRegisters) };
+use crate::pinmux::PadConfig;
+use crate::registers::top_earlgrey::GPIO_BASE_ADDR;
+use crate::registers::top_earlgrey::{
+    MuxedPads, PinmuxOutsel, PinmuxPeripheralIn, PINMUX_PERIPH_OUTSEL_IDX_OFFSET,
+};
 
-pub const GPIO0_BASE: StaticRef<GpioRegisters> =
+pub const GPIO_BASE: StaticRef<GpioRegisters> =
     unsafe { StaticRef::new(GPIO_BASE_ADDR as *const GpioRegisters) };
 
 pub struct Port<'a> {
-    pins: [GpioPin<'a>; 32],
+    pins: [GpioPin<'a, PadConfig>; 32],
 }
 
+impl From<GpioBitfield> for PinmuxPeripheralIn {
+    fn from(pin: GpioBitfield) -> PinmuxPeripheralIn {
+        // We used fact that first 0-31 values are directly maped to GPIO
+        Self::try_from(pin.shift as u32).unwrap()
+    }
+}
+
+impl From<GpioBitfield> for PinmuxOutsel {
+    fn from(pin: GpioBitfield) -> Self {
+        // We skip first 3 constans to convert value to output selector
+        match Self::try_from(pin.shift as u32 + PINMUX_PERIPH_OUTSEL_IDX_OFFSET as u32) {
+            Ok(outsel) => outsel,
+            Err(_) => PinmuxOutsel::ConstantHighZ,
+        }
+    }
+}
+
+pub fn gpio_pad_config(pad: MuxedPads, pin: GpioBitfield) -> PadConfig {
+    PadConfig::InOut(pad, PinmuxPeripheralIn::from(pin), PinmuxOutsel::from(pin))
+}
+
+// Configuring first 32 pad as GPIO
 impl<'a> Port<'a> {
     pub const fn new() -> Self {
         Self {
+            // Intentionally prevent splitting GpioPin to multi line definition
+            #[rustfmt::skip]
             pins: [
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin0),
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin1),
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin2),
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin3),
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin4),
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin5),
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin6),
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin7),
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin8),
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin9),
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin10),
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin11),
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin12),
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin13),
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin14),
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin15),
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin16),
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin17),
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin18),
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin19),
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin20),
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin21),
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin22),
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin23),
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin24),
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin25),
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin26),
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin27),
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin28),
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin29),
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin30),
-                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin31),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioa0, PinmuxPeripheralIn::GpioGpio0, PinmuxOutsel::GpioGpio0), pins::pin0),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioa1, PinmuxPeripheralIn::GpioGpio1, PinmuxOutsel::GpioGpio1), pins::pin1),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioa2, PinmuxPeripheralIn::GpioGpio2, PinmuxOutsel::GpioGpio2), pins::pin2),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioa3, PinmuxPeripheralIn::GpioGpio3, PinmuxOutsel::GpioGpio3), pins::pin3),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioa4, PinmuxPeripheralIn::GpioGpio4, PinmuxOutsel::GpioGpio4), pins::pin4),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioa5, PinmuxPeripheralIn::GpioGpio5, PinmuxOutsel::GpioGpio5), pins::pin5),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioa6, PinmuxPeripheralIn::GpioGpio6, PinmuxOutsel::GpioGpio6), pins::pin6),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioa7, PinmuxPeripheralIn::GpioGpio7, PinmuxOutsel::GpioGpio7), pins::pin7),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioa8, PinmuxPeripheralIn::GpioGpio8, PinmuxOutsel::GpioGpio8), pins::pin8),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Iob0, PinmuxPeripheralIn::GpioGpio9, PinmuxOutsel::GpioGpio9), pins::pin9),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Iob1, PinmuxPeripheralIn::GpioGpio10, PinmuxOutsel::GpioGpio10), pins::pin10),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Iob2, PinmuxPeripheralIn::GpioGpio11, PinmuxOutsel::GpioGpio11), pins::pin11),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Iob3, PinmuxPeripheralIn::GpioGpio12, PinmuxOutsel::GpioGpio12), pins::pin12),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Iob4, PinmuxPeripheralIn::GpioGpio13, PinmuxOutsel::GpioGpio13), pins::pin13),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Iob5, PinmuxPeripheralIn::GpioGpio14, PinmuxOutsel::GpioGpio14), pins::pin14),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Iob6, PinmuxPeripheralIn::GpioGpio15, PinmuxOutsel::GpioGpio15), pins::pin15),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Iob7, PinmuxPeripheralIn::GpioGpio16, PinmuxOutsel::GpioGpio16), pins::pin16),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Iob8, PinmuxPeripheralIn::GpioGpio17, PinmuxOutsel::GpioGpio17), pins::pin17),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Iob9, PinmuxPeripheralIn::GpioGpio18, PinmuxOutsel::GpioGpio18), pins::pin18),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Iob10, PinmuxPeripheralIn::GpioGpio19, PinmuxOutsel::GpioGpio19), pins::pin19),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Iob11, PinmuxPeripheralIn::GpioGpio20, PinmuxOutsel::GpioGpio20), pins::pin20),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Iob12, PinmuxPeripheralIn::GpioGpio21, PinmuxOutsel::GpioGpio21), pins::pin21),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioc0, PinmuxPeripheralIn::GpioGpio22, PinmuxOutsel::GpioGpio22), pins::pin22),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioc1, PinmuxPeripheralIn::GpioGpio23, PinmuxOutsel::GpioGpio23), pins::pin23),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioc2, PinmuxPeripheralIn::GpioGpio24, PinmuxOutsel::GpioGpio24), pins::pin24),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioc3, PinmuxPeripheralIn::GpioGpio25, PinmuxOutsel::GpioGpio25), pins::pin25),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioc4, PinmuxPeripheralIn::GpioGpio26, PinmuxOutsel::GpioGpio26), pins::pin26),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioc5, PinmuxPeripheralIn::GpioGpio27, PinmuxOutsel::GpioGpio27), pins::pin27),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioc6, PinmuxPeripheralIn::GpioGpio28, PinmuxOutsel::GpioGpio28), pins::pin28),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioc7, PinmuxPeripheralIn::GpioGpio29, PinmuxOutsel::GpioGpio29), pins::pin29),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioc8, PinmuxPeripheralIn::GpioGpio30, PinmuxOutsel::GpioGpio30), pins::pin30),
+                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioc9, PinmuxPeripheralIn::GpioGpio31, PinmuxOutsel::GpioGpio31), pins::pin31),
             ],
         }
     }
 }
 
 impl<'a> Index<usize> for Port<'a> {
-    type Output = GpioPin<'a>;
+    type Output = GpioPin<'a, PadConfig>;
 
-    fn index(&self, index: usize) -> &GpioPin<'a> {
+    fn index(&self, index: usize) -> &GpioPin<'a, PadConfig> {
         &self.pins[index]
     }
 }
 
 impl<'a> IndexMut<usize> for Port<'a> {
-    fn index_mut(&mut self, index: usize) -> &mut GpioPin<'a> {
+    fn index_mut(&mut self, index: usize) -> &mut GpioPin<'a, PadConfig> {
         &mut self.pins[index]
     }
 }

--- a/chips/earlgrey/src/gpio.rs
+++ b/chips/earlgrey/src/gpio.rs
@@ -11,9 +11,11 @@ use lowrisc::gpio::GpioRegisters;
 pub use lowrisc::gpio::{pins, GpioBitfield, GpioPin};
 
 use crate::pinmux::PadConfig;
+use crate::pinmux_config::EarlGreyPinmuxConfig;
 use crate::registers::top_earlgrey::GPIO_BASE_ADDR;
 use crate::registers::top_earlgrey::{
-    MuxedPads, PinmuxOutsel, PinmuxPeripheralIn, PINMUX_PERIPH_OUTSEL_IDX_OFFSET,
+    MuxedPads, PinmuxInsel, PinmuxOutsel, PinmuxPeripheralIn, PINMUX_MIO_PERIPH_INSEL_IDX_OFFSET,
+    PINMUX_PERIPH_OUTSEL_IDX_OFFSET,
 };
 
 pub const GPIO_BASE: StaticRef<GpioRegisters> =
@@ -40,49 +42,71 @@ impl From<GpioBitfield> for PinmuxOutsel {
     }
 }
 
-pub fn gpio_pad_config(pad: MuxedPads, pin: GpioBitfield) -> PadConfig {
-    PadConfig::InOut(pad, PinmuxPeripheralIn::from(pin), PinmuxOutsel::from(pin))
+// This function use extract GPIO mapping from initial pinmux configurations
+pub fn gpio_pad_config<Layout: EarlGreyPinmuxConfig>(pin: GpioBitfield) -> PadConfig {
+    let inp: PinmuxPeripheralIn = PinmuxPeripheralIn::from(pin);
+    match Layout::INPUT[inp as usize] {
+        // Current implementation don't support Output only GPIO
+        PinmuxInsel::ConstantZero | PinmuxInsel::ConstantOne => PadConfig::Unconnected,
+        input_selector => {
+            if let Ok(pad) = MuxedPads::try_from(
+                input_selector as u32 - PINMUX_MIO_PERIPH_INSEL_IDX_OFFSET as u32,
+            ) {
+                let out: PinmuxOutsel = Layout::OUTPUT[pad as usize];
+                // Checking for bi-directional I/O
+                if out == PinmuxOutsel::from(pin) {
+                    PadConfig::InOut(pad, inp, out)
+                } else {
+                    PadConfig::Input(pad, inp)
+                }
+            } else {
+                // Upper match checked for unconnected pad so in this
+                // place we probably have some invalid value in INPUT array.
+                PadConfig::Unconnected
+            }
+        }
+    }
 }
 
-// Configuring first 32 pad as GPIO
+// Configuring first all GPIO based on board layout
 impl<'a> Port<'a> {
-    pub const fn new() -> Self {
+    pub fn new<Layout: EarlGreyPinmuxConfig>() -> Self {
         Self {
-            // Intentionally prevent splitting GpioPin to multi line definition
+            // Intentionally prevent splitting GpioPin to multiple line
             #[rustfmt::skip]
             pins: [
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioa0, PinmuxPeripheralIn::GpioGpio0, PinmuxOutsel::GpioGpio0), pins::pin0),
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioa1, PinmuxPeripheralIn::GpioGpio1, PinmuxOutsel::GpioGpio1), pins::pin1),
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioa2, PinmuxPeripheralIn::GpioGpio2, PinmuxOutsel::GpioGpio2), pins::pin2),
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioa3, PinmuxPeripheralIn::GpioGpio3, PinmuxOutsel::GpioGpio3), pins::pin3),
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioa4, PinmuxPeripheralIn::GpioGpio4, PinmuxOutsel::GpioGpio4), pins::pin4),
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioa5, PinmuxPeripheralIn::GpioGpio5, PinmuxOutsel::GpioGpio5), pins::pin5),
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioa6, PinmuxPeripheralIn::GpioGpio6, PinmuxOutsel::GpioGpio6), pins::pin6),
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioa7, PinmuxPeripheralIn::GpioGpio7, PinmuxOutsel::GpioGpio7), pins::pin7),
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioa8, PinmuxPeripheralIn::GpioGpio8, PinmuxOutsel::GpioGpio8), pins::pin8),
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Iob0, PinmuxPeripheralIn::GpioGpio9, PinmuxOutsel::GpioGpio9), pins::pin9),
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Iob1, PinmuxPeripheralIn::GpioGpio10, PinmuxOutsel::GpioGpio10), pins::pin10),
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Iob2, PinmuxPeripheralIn::GpioGpio11, PinmuxOutsel::GpioGpio11), pins::pin11),
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Iob3, PinmuxPeripheralIn::GpioGpio12, PinmuxOutsel::GpioGpio12), pins::pin12),
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Iob4, PinmuxPeripheralIn::GpioGpio13, PinmuxOutsel::GpioGpio13), pins::pin13),
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Iob5, PinmuxPeripheralIn::GpioGpio14, PinmuxOutsel::GpioGpio14), pins::pin14),
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Iob6, PinmuxPeripheralIn::GpioGpio15, PinmuxOutsel::GpioGpio15), pins::pin15),
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Iob7, PinmuxPeripheralIn::GpioGpio16, PinmuxOutsel::GpioGpio16), pins::pin16),
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Iob8, PinmuxPeripheralIn::GpioGpio17, PinmuxOutsel::GpioGpio17), pins::pin17),
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Iob9, PinmuxPeripheralIn::GpioGpio18, PinmuxOutsel::GpioGpio18), pins::pin18),
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Iob10, PinmuxPeripheralIn::GpioGpio19, PinmuxOutsel::GpioGpio19), pins::pin19),
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Iob11, PinmuxPeripheralIn::GpioGpio20, PinmuxOutsel::GpioGpio20), pins::pin20),
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Iob12, PinmuxPeripheralIn::GpioGpio21, PinmuxOutsel::GpioGpio21), pins::pin21),
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioc0, PinmuxPeripheralIn::GpioGpio22, PinmuxOutsel::GpioGpio22), pins::pin22),
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioc1, PinmuxPeripheralIn::GpioGpio23, PinmuxOutsel::GpioGpio23), pins::pin23),
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioc2, PinmuxPeripheralIn::GpioGpio24, PinmuxOutsel::GpioGpio24), pins::pin24),
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioc3, PinmuxPeripheralIn::GpioGpio25, PinmuxOutsel::GpioGpio25), pins::pin25),
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioc4, PinmuxPeripheralIn::GpioGpio26, PinmuxOutsel::GpioGpio26), pins::pin26),
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioc5, PinmuxPeripheralIn::GpioGpio27, PinmuxOutsel::GpioGpio27), pins::pin27),
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioc6, PinmuxPeripheralIn::GpioGpio28, PinmuxOutsel::GpioGpio28), pins::pin28),
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioc7, PinmuxPeripheralIn::GpioGpio29, PinmuxOutsel::GpioGpio29), pins::pin29),
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioc8, PinmuxPeripheralIn::GpioGpio30, PinmuxOutsel::GpioGpio30), pins::pin30),
-                GpioPin::new(GPIO_BASE, PadConfig::InOut(MuxedPads::Ioc9, PinmuxPeripheralIn::GpioGpio31, PinmuxOutsel::GpioGpio31), pins::pin31),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin0), pins::pin0),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin1), pins::pin1),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin2), pins::pin2),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin3), pins::pin3),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin4), pins::pin4),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin5), pins::pin5),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin6), pins::pin6),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin7), pins::pin7),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin8), pins::pin8),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin9), pins::pin9),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin10), pins::pin10),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin11), pins::pin11),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin12), pins::pin12),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin13), pins::pin13),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin14), pins::pin14),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin15), pins::pin15),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin16), pins::pin16),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin17), pins::pin17),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin18), pins::pin18),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin19), pins::pin19),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin20), pins::pin20),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin21), pins::pin21),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin22), pins::pin22),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin23), pins::pin23),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin24), pins::pin24),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin25), pins::pin25),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin26), pins::pin26),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin27), pins::pin27),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin28), pins::pin28),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin29), pins::pin29),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin30), pins::pin30),
+                GpioPin::new(GPIO_BASE, gpio_pad_config::<Layout>(pins::pin31), pins::pin31),
             ],
         }
     }

--- a/chips/earlgrey/src/lib.rs
+++ b/chips/earlgrey/src/lib.rs
@@ -13,6 +13,8 @@
 #![recursion_limit = "256"]
 
 pub mod chip_config;
+pub mod pinmux_config;
+
 mod interrupts;
 
 pub mod aes;

--- a/chips/earlgrey/src/pinmux.rs
+++ b/chips/earlgrey/src/pinmux.rs
@@ -5,6 +5,7 @@
 //! Mux'ing between physical pads and GPIO or other peripherals.
 
 use kernel::hil::gpio;
+use kernel::hil::gpio::{Configuration, Configure, FloatingState};
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 use kernel::utilities::registers::{register_bitfields, FieldValue, LocalRegisterCopy};
 use kernel::utilities::StaticRef;
@@ -15,6 +16,7 @@ use crate::registers::pinmux_regs::{
 };
 use crate::registers::top_earlgrey::{
     DirectPads, MuxedPads, PinmuxInsel, PinmuxOutsel, PinmuxPeripheralIn, PINMUX_AON_BASE_ADDR,
+    PINMUX_MIO_PERIPH_INSEL_IDX_OFFSET,
 };
 
 pub const PINMUX_BASE: StaticRef<PinmuxRegisters> =
@@ -120,7 +122,7 @@ impl Pad {
 // OpenTitan Documentation reference:
 // https://opentitan.org/book/hw/ip/pinmux/doc/programmers_guide.html#pinmux-configuration
 
-trait SelectOutput {
+pub trait SelectOutput {
     /// Connect particular pad to internal peripheral
     fn connect_output(self, output: PinmuxOutsel);
 
@@ -136,8 +138,12 @@ trait SelectOutput {
 
     /// Lock selection of output for particular pad
     fn lock(self);
+
+    /// Get value of current output selection
+    fn get_selector(self) -> PinmuxOutsel;
 }
 
+// We make a implicit conversion between PinmuxMioOut and MuxedPad
 impl SelectOutput for MuxedPads {
     fn connect_output(self, output: PinmuxOutsel) {
         PINMUX_BASE.mio_outsel[self as usize].set(output as u32)
@@ -158,9 +164,18 @@ impl SelectOutput for MuxedPads {
     fn lock(self) {
         PINMUX_BASE.mio_outsel_regwen[self as usize].write(MIO_OUTSEL_REGWEN::EN_0::CLEAR);
     }
+
+    fn get_selector(self) -> PinmuxOutsel {
+        match PinmuxOutsel::try_from(PINMUX_BASE.mio_outsel[self as usize].get()) {
+            Ok(sel) => sel,
+            // When this panic happend it mean we have some glitch in registers
+            // or a incorect version definition of registers.
+            Err(val) => panic!("PINMUX: Invalid register value: {}", val),
+        }
+    }
 }
 
-trait SelectInput {
+pub trait SelectInput {
     /// Connect internal peripheral input to particular pad
     fn connect_input(self, input: PinmuxInsel);
 
@@ -172,6 +187,9 @@ trait SelectInput {
 
     /// Lock input configurations
     fn lock(self);
+
+    /// Get value of current input selection
+    fn get_selector(self) -> PinmuxInsel;
 }
 
 /// MuxedPads names and values overlap with PinmuxInsel,
@@ -181,7 +199,7 @@ trait SelectInput {
 impl From<MuxedPads> for PinmuxInsel {
     fn from(pad: MuxedPads) -> Self {
         // Add 2 to skip constant ConstantZero and ConstantOne.
-        match PinmuxInsel::try_from(pad as u32 + 2) {
+        match PinmuxInsel::try_from(pad as u32 + PINMUX_MIO_PERIPH_INSEL_IDX_OFFSET as u32) {
             Ok(select) => select,
             Err(_) => PinmuxInsel::ConstantZero,
         }
@@ -204,5 +222,176 @@ impl SelectInput for PinmuxPeripheralIn {
     fn lock(self) {
         PINMUX_BASE.mio_periph_insel_regwen[self as usize]
             .write(MIO_PERIPH_INSEL_REGWEN::EN_0::CLEAR);
+    }
+
+    fn get_selector(self) -> PinmuxInsel {
+        match PinmuxInsel::try_from(PINMUX_BASE.mio_periph_insel[self as usize].get()) {
+            Ok(sel) => sel,
+            //
+            Err(val) => panic!("PINMUX: Invalid insel register value {}", val),
+        }
+    }
+}
+
+// diagram bellow help with interpreting meaning of input/output in enum bellow
+// <https://opentitan.org/book/hw/ip/pinmux/doc/theory_of_operation.html#muxing-matrix>
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum PadConfig {
+    // Allow to pass signal from pad to peripheral
+    // [PAD]------>[PeripherapInput]
+    Input(MuxedPads, PinmuxPeripheralIn),
+    // Allow to pass signal form peripheral to pad
+    // [PAD]<------[PeripheralOut]
+    Output(MuxedPads, PinmuxOutsel),
+    // Allow to pass signal form pad to peripheral in bouth directions
+    // [PAD]------>[PeripherapInput]
+    // [PAD]<------[PeripheralOut]
+    InOut(MuxedPads, PinmuxPeripheralIn, PinmuxOutsel),
+}
+
+impl PadConfig {
+    /// Connect Pad to internal peripheral I/O using pinmux multiplexers
+    pub fn connect(&self) {
+        match *self {
+            PadConfig::Input(pad, peripheral_in) => {
+                peripheral_in.connect_input(PinmuxInsel::from(pad));
+                // default out selector is 0x2 (Hi-Z)
+                // pad.connect_output(peripheral_out);
+            }
+            PadConfig::Output(pad, peripheral_out) => {
+                // default input selector is 0x0 (Zero)
+                // peripheral_in.connect_input(PinmuxInsel::from(pad));
+                pad.connect_output(peripheral_out);
+            }
+            PadConfig::InOut(pad, peripheral_in, peripheral_out) => {
+                peripheral_in.connect_input(PinmuxInsel::from(pad));
+                pad.connect_output(peripheral_out);
+            }
+        }
+    }
+
+    /// Disconnect pad from internal input and connect to always Low signal
+    pub fn disconnect_input(&self) {
+        match *self {
+            PadConfig::Input(_pad, peripheral_in) => peripheral_in.connect_low(),
+            PadConfig::Output(_pad, _peripheral_out) => {}
+            PadConfig::InOut(_pad, peripheral_in, _peripheral_out) => {
+                peripheral_in.connect_low();
+            }
+        };
+    }
+
+    // Disconnect pad from internal output and connect to Hi-Z
+    pub fn disconnect_output(&self) {
+        match *self {
+            PadConfig::Input(_pad, _peripheral_in) => {}
+            PadConfig::Output(pad, _peripheral_out) => pad.connect_high_z(),
+            PadConfig::InOut(pad, _peripheral_in, _peripheral_out) => {
+                pad.connect_high_z();
+            }
+        };
+    }
+
+    /// Disconnect input and output from peripheral/pad
+    /// and connect to internal Hi-Z/Low signal
+    pub fn disconnect(&self) {
+        match *self {
+            PadConfig::Input(_pad, peripheral_in) => {
+                peripheral_in.connect_low();
+            }
+            PadConfig::Output(pad, _peripheral_out) => {
+                pad.connect_high_z();
+            }
+            PadConfig::InOut(pad, peripheral_in, _peripheral_out) => {
+                peripheral_in.connect_low();
+                pad.connect_high_z();
+            }
+        }
+    }
+
+    /// Return copy of `enum` representing MIO pad
+    /// associated with this connection
+    pub fn get_pad(&self) -> Pad {
+        Pad::Mio(match *self {
+            PadConfig::Input(pad, _) => pad,
+            PadConfig::Output(pad, _) => pad,
+            PadConfig::InOut(pad, _, _) => pad,
+        })
+    }
+}
+
+impl From<PadConfig> for Configuration {
+    fn from(pad: PadConfig) -> Configuration {
+        match pad {
+            PadConfig::Input(_pad, peripheral_in) => match peripheral_in.get_selector() {
+                PinmuxInsel::ConstantZero => Configuration::LowPower,
+                PinmuxInsel::ConstantOne => Configuration::Function,
+                _ => Configuration::Input,
+            },
+            PadConfig::Output(pad, _peripheral_out) => match pad.get_selector() {
+                PinmuxOutsel::ConstantZero => Configuration::Function,
+                PinmuxOutsel::ConstantOne => Configuration::Function,
+                PinmuxOutsel::ConstantHighZ => Configuration::LowPower,
+                _ => Configuration::Output,
+            },
+            PadConfig::InOut(pad, peripheral_in, _peripheral_out) => {
+                let input_selector = peripheral_in.get_selector();
+                let output_selector = pad.get_selector();
+                match (input_selector, output_selector) {
+                    (PinmuxInsel::ConstantZero, PinmuxOutsel::ConstantHighZ) => {
+                        Configuration::LowPower
+                    }
+                    (
+                        PinmuxInsel::ConstantOne | PinmuxInsel::ConstantZero,
+                        PinmuxOutsel::ConstantZero | PinmuxOutsel::ConstantOne,
+                    ) => Configuration::Function,
+                    (_, _) => Configuration::InputOutput,
+                }
+            }
+        }
+    }
+}
+
+impl Configure for PadConfig {
+    fn configuration(&self) -> Configuration {
+        Configuration::from(*self)
+    }
+
+    fn make_output(&self) -> Configuration {
+        match self.configuration() {
+            Configuration::LowPower => self.connect(),
+            _ => {}
+        };
+        self.configuration()
+    }
+
+    fn disable_output(&self) -> Configuration {
+        self.disconnect_output();
+        self.configuration()
+    }
+
+    fn make_input(&self) -> Configuration {
+        match self.configuration() {
+            Configuration::LowPower => self.connect(),
+            _ => {}
+        };
+        self.configuration()
+    }
+
+    fn disable_input(&self) -> Configuration {
+        self.disconnect_input();
+        self.configuration()
+    }
+
+    fn deactivate_to_low_power(&self) {
+        self.disconnect();
+    }
+
+    fn set_floating_state(&self, state: FloatingState) {
+        self.get_pad().set_floating_state(state);
+    }
+
+    fn floating_state(&self) -> FloatingState {
+        self.get_pad().floating_state()
     }
 }

--- a/chips/earlgrey/src/pinmux_config.rs
+++ b/chips/earlgrey/src/pinmux_config.rs
@@ -1,0 +1,40 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! Chip sepcific pinmux Configurations
+
+use crate::pinmux::{SelectInput, SelectOutput};
+use crate::registers::top_earlgrey::{
+    MuxedPads, PinmuxInsel, PinmuxOutsel, PinmuxPeripheralIn, NUM_MIO_PADS,
+};
+
+/// Number of input selector entry (Last input + 1)
+pub const INPUT_NUM: usize = PinmuxPeripheralIn::UsbdevSense as usize + 1;
+/// Number of output selctor entry
+pub const OUTPUT_NUM: usize = NUM_MIO_PADS;
+
+/// Representations of Earlgrey pinmux configuration on targeted board
+pub trait EarlGreyPinmuxConfig {
+    /// Array representing configuration of pinmux input selctor
+    const INPUT: &'static [PinmuxInsel; INPUT_NUM];
+
+    /// Array representing configurations of pinmux output selecto
+    const OUTPUT: &'static [PinmuxOutsel; OUTPUT_NUM];
+
+    /// Setup pinmux configurations for all multiplexed pads
+    fn setup() {
+        // setup pinmux input
+        for index in 0..INPUT_NUM {
+            if let Ok(peripheral) = PinmuxPeripheralIn::try_from(index as u32) {
+                peripheral.connect_input(Self::INPUT[index]);
+            }
+        }
+        // setup pinmux output
+        for index in 0..OUTPUT_NUM {
+            if let Ok(pad) = MuxedPads::try_from(index as u32) {
+                pad.connect_output(Self::OUTPUT[index]);
+            }
+        }
+    }
+}

--- a/chips/lowrisc/src/gpio.rs
+++ b/chips/lowrisc/src/gpio.rs
@@ -4,7 +4,6 @@
 
 //! General Purpose Input/Output driver.
 
-use crate::padctrl;
 use kernel::hil::gpio;
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
@@ -76,22 +75,24 @@ register_bitfields![u32,
     ]
 ];
 
-pub struct GpioPin<'a> {
+pub type GpioBitfield = Field<u32, pins::Register>;
+
+pub struct GpioPin<'a, PAD> {
     gpio_registers: StaticRef<GpioRegisters>,
-    padctrl_registers: StaticRef<padctrl::PadCtrlRegisters>,
+    padctl: PAD,
     pin: Field<u32, pins::Register>,
     client: OptionalCell<&'a dyn gpio::Client>,
 }
 
-impl<'a> GpioPin<'a> {
+impl<'a, PAD> GpioPin<'a, PAD> {
     pub const fn new(
         gpio_base: StaticRef<GpioRegisters>,
-        padctrl_base: StaticRef<padctrl::PadCtrlRegisters>,
+        padctl: PAD,
         pin: Field<u32, pins::Register>,
-    ) -> GpioPin<'a> {
+    ) -> GpioPin<'a, PAD> {
         GpioPin {
             gpio_registers: gpio_base,
-            padctrl_registers: padctrl_base,
+            padctl: padctl,
             pin: pin,
             client: OptionalCell::empty(),
         }
@@ -128,89 +129,65 @@ impl<'a> GpioPin<'a> {
     }
 }
 
-impl gpio::Configure for GpioPin<'_> {
+impl<PAD: gpio::Configure> gpio::Configure for GpioPin<'_, PAD> {
     fn configuration(&self) -> gpio::Configuration {
-        match self.gpio_registers.direct_oe.is_set(self.pin) {
-            true => gpio::Configuration::InputOutput,
-            false => gpio::Configuration::Input,
+        match (
+            self.padctl.configuration(),
+            self.gpio_registers.direct_oe.is_set(self.pin),
+        ) {
+            (gpio::Configuration::InputOutput, true) => gpio::Configuration::InputOutput,
+            (gpio::Configuration::InputOutput, false) => gpio::Configuration::Input,
+            (gpio::Configuration::Input, false) => gpio::Configuration::Input,
+            // This is configuration error we can't enable ouput
+            // for GPIO pin connect to input only pad.
+            (gpio::Configuration::Input, true) => gpio::Configuration::Function,
+            // We curently dont support output only GPIO
+            // OT register have only output_enable flag.
+            (gpio::Configuration::Output, _) => gpio::Configuration::Function,
+            (conf, _) => conf,
         }
     }
 
     fn set_floating_state(&self, mode: gpio::FloatingState) {
-        // There is unfortunately no documentation about how these
-        // registers map to the actual GPIOs, so just write all of them.
-        match mode {
-            gpio::FloatingState::PullUp => {
-                self.padctrl_registers.dio_pads.write(
-                    padctrl::DIO_PADS::ATTR0_PULL_UP::SET
-                        + padctrl::DIO_PADS::ATTR1_PULL_UP::SET
-                        + padctrl::DIO_PADS::ATTR2_PULL_UP::SET
-                        + padctrl::DIO_PADS::ATTR3_PULL_UP::SET,
-                );
-            }
-            gpio::FloatingState::PullDown => {
-                self.padctrl_registers.dio_pads.write(
-                    padctrl::DIO_PADS::ATTR0_PULL_DOWN::SET
-                        + padctrl::DIO_PADS::ATTR1_PULL_DOWN::SET
-                        + padctrl::DIO_PADS::ATTR2_PULL_DOWN::SET
-                        + padctrl::DIO_PADS::ATTR3_PULL_DOWN::SET,
-                );
-            }
-            gpio::FloatingState::PullNone => {
-                self.padctrl_registers.dio_pads.write(
-                    padctrl::DIO_PADS::ATTR0_OPEN_DRAIN::SET
-                        + padctrl::DIO_PADS::ATTR1_OPEN_DRAIN::SET
-                        + padctrl::DIO_PADS::ATTR2_OPEN_DRAIN::SET
-                        + padctrl::DIO_PADS::ATTR3_OPEN_DRAIN::SET,
-                );
-            }
-        }
+        self.padctl.set_floating_state(mode);
     }
 
     fn floating_state(&self) -> gpio::FloatingState {
-        if self
-            .padctrl_registers
-            .dio_pads
-            .is_set(padctrl::DIO_PADS::ATTR0_PULL_UP)
-        {
-            gpio::FloatingState::PullUp
-        } else if self
-            .padctrl_registers
-            .dio_pads
-            .is_set(padctrl::DIO_PADS::ATTR0_PULL_DOWN)
-        {
-            gpio::FloatingState::PullDown
-        } else {
-            gpio::FloatingState::PullNone
-        }
+        self.padctl.floating_state()
     }
 
     fn deactivate_to_low_power(&self) {
         self.disable_input();
         self.disable_output();
+        self.padctl.deactivate_to_low_power();
     }
 
     fn make_output(&self) -> gpio::Configuration {
-        GpioPin::half_set(
-            true,
-            self.pin,
-            &self.gpio_registers.masked_oe_lower,
-            &self.gpio_registers.masked_oe_upper,
-        );
-        gpio::Configuration::InputOutput
+        // Re-connect in case we make output after switching from LowPower state.
+        if let gpio::Configuration::InputOutput = self.padctl.make_output() {
+            Self::half_set(
+                true,
+                self.pin,
+                &self.gpio_registers.masked_oe_lower,
+                &self.gpio_registers.masked_oe_upper,
+            );
+        }
+        self.configuration()
     }
 
     fn disable_output(&self) -> gpio::Configuration {
-        GpioPin::half_set(
+        Self::half_set(
             false,
             self.pin,
             &self.gpio_registers.masked_oe_lower,
             &self.gpio_registers.masked_oe_upper,
         );
-        gpio::Configuration::Input
+        self.configuration()
     }
 
     fn make_input(&self) -> gpio::Configuration {
+        // Re-connect in case we make input after switching from LowPower state.
+        self.padctl.make_input();
         self.configuration()
     }
 
@@ -219,18 +196,18 @@ impl gpio::Configure for GpioPin<'_> {
     }
 }
 
-impl gpio::Input for GpioPin<'_> {
+impl<PAD> gpio::Input for GpioPin<'_, PAD> {
     fn read(&self) -> bool {
         self.gpio_registers.data_in.is_set(self.pin)
     }
 }
 
-impl gpio::Output for GpioPin<'_> {
+impl<PAD> gpio::Output for GpioPin<'_, PAD> {
     fn toggle(&self) -> bool {
         let pin = self.pin;
         let new_state = !self.gpio_registers.direct_out.is_set(pin);
 
-        GpioPin::half_set(
+        Self::half_set(
             new_state,
             self.pin,
             &self.gpio_registers.masked_out_lower,
@@ -240,7 +217,7 @@ impl gpio::Output for GpioPin<'_> {
     }
 
     fn set(&self) {
-        GpioPin::half_set(
+        Self::half_set(
             true,
             self.pin,
             &self.gpio_registers.masked_out_lower,
@@ -249,7 +226,7 @@ impl gpio::Output for GpioPin<'_> {
     }
 
     fn clear(&self) {
-        GpioPin::half_set(
+        Self::half_set(
             false,
             self.pin,
             &self.gpio_registers.masked_out_lower,
@@ -258,7 +235,7 @@ impl gpio::Output for GpioPin<'_> {
     }
 }
 
-impl<'a> gpio::Interrupt<'a> for GpioPin<'a> {
+impl<'a, PAD> gpio::Interrupt<'a> for GpioPin<'a, PAD> {
     fn set_client(&self, client: &'a dyn gpio::Client) {
         self.client.set(client);
     }


### PR DESCRIPTION
### Pull Request Overview

- [x] Add implementation of PadConfig
- [x] Replace `padctl` with `PadConfig` in lowrisc GPIO
- [x] Add trait for supporting board I/O layout configuration
- [x] Pinmux configuration for CW310 board

Depend on changes form: (Merged) https://github.com/tock/tock/pull/3707

### Testing Strategy

Manual test using `CW310` as DUT and `Hyperdebug` with `opentitan` tool
as test bench for generating stimulus. 

### TODO

- [x] rebase on top of master after merging PINMUX
- [ ] Use auto-generated registers for lowrisc GPIO
- [ ] GPIO input filtering support
- [ ] GPIO wakeup/sleep feature

### Documentation Updated

N/A

### Formatting

- [x] Ran `make prepush`.
