### PR TITLE
virtual_alarm: Do not disarm when setting client.

### DIFF
--- a/capsules/core/src/virtualizers/virtual_alarm.rs
+++ b/capsules/core/src/virtualizers/virtual_alarm.rs
@@ -89,10 +89,6 @@ impl<'a, A: Alarm<'a>> Time for VirtualMuxAlarm<'a, A> {
 
 impl<'a, A: Alarm<'a>> Alarm<'a> for VirtualMuxAlarm<'a, A> {
     fn set_alarm_client(&self, client: &'a dyn time::AlarmClient) {
-        // Reset the alarm state: should it do this? Does not seem
-        // to be semantically correct. What if you just wanted to
-        // change the callback. Keeping it but skeptical. -pal
-        self.armed.set(false);
         self.client.set(client);
     }
 


### PR DESCRIPTION
### Pull Request Overview

When using the Component::finalize paradigm, it is useful to only put static initialization and client connections in the finalize method. All business logic should move outside of the finalize method. This makes the business logic easier to unit test.

It is possible that the business logic needs to start an alarm when the object is created (e.g. to debounce some value). The constructor of the actual capsule is a good place to put the business logic if that capsule must always run the business logic when the capsule is created.

Here lies the issue: if the constructor of the capsule starts an alarm, there is no client yet, but the Component::finalize method will hook up the alarm_client relationship after the capsule object has been created. If the set_alarm_client method disarms the alarm, then the alarm that was set in the constructor is canceled.

Wait, isn't there a race condition or something weird going to happen if one sets an alarm before setting a client? Generally no, since TockOS is single threaded and all the alarm callbacks are meant to be handled in the main kernel loop.

An alternative would be for the capsule to create an init method that must always be called by the Component::finalize after the finalize method hooks up all of the client callback relationship. This allows a capsule object to be created in a half initialize state, which developer may want to prevent.

Lastly, the virtual_timer doesn't disarm anything when updating the client; only virtual_alarm does. Let's make things more consistent as well.



### Documentation Updated

- None

### Formatting

- [x] Ran `make prepush`.
