### PR TITLE
TicKV: Zeroizing a key to remove data

### DIFF
--- a/libraries/tickv/README.md
+++ b/libraries/tickv/README.md
@@ -94,9 +94,9 @@ committed. This is the durability guarantee as part of the ACID semantics.
 The only data that can be lost in the event of a power loss is
 the data which hasn't been write to flash yet.
 
-If a power loss occurs after calling `append_key()` or `invalidate_key()`
-before it has completed then the operation probably did not complete and
-that data is lost.
+If a power loss occurs after calling `append_key()`, `invalidate_key()` or
+`zeroize_key()` before it has completed then the operation probably did not
+complete and that data is lost.
 
 ### Security
 

--- a/libraries/tickv/src/async_ops.rs
+++ b/libraries/tickv/src/async_ops.rs
@@ -278,6 +278,26 @@ impl<'a, C: FlashController<S>, const S: usize> AsyncTicKV<'a, C, S> {
         }
     }
 
+    /// Zeroizes the key in flash storage
+    ///
+    /// `hash`: A hashed key.
+    /// `key`: A unhashed key. This will be hashed internally.
+    ///
+    /// On success a `SuccessCode` will be returned.
+    /// On error a `ErrorCode` will be returned.
+    ///
+    /// If a power loss occurs before success is returned the data is
+    /// assumed to be lost.
+    pub fn zeroize_key(&self, hash: u64) -> Result<SuccessCode, ErrorCode> {
+        match self.tickv.zeroize_key(hash) {
+            Ok(_code) => Err(ErrorCode::WriteFail),
+            Err(_e) => {
+                self.key.replace(Some(hash));
+                Ok(SuccessCode::Queued)
+            }
+        }
+    }
+
     /// Perform a garbage collection on TicKV
     ///
     /// On success a `SuccessCode` will be returned.
@@ -338,6 +358,7 @@ impl<'a, C: FlashController<S>, const S: usize> AsyncTicKV<'a, C, S> {
                 }
             }
             State::InvalidateKey(_) => (self.tickv.invalidate_key(self.key.get().unwrap()), 0),
+            State::ZeroizeKey(_) => (self.tickv.zeroize_key(self.key.get().unwrap()), 0),
             State::GarbageCollect(_) => match self.tickv.garbage_collect() {
                 Ok(bytes_freed) => (Ok(SuccessCode::Complete), bytes_freed),
                 Err(e) => (Err(e), 0),

--- a/libraries/tickv/src/tickv.rs
+++ b/libraries/tickv/src/tickv.rs
@@ -51,6 +51,8 @@ pub(crate) enum State {
     GetKey(KeyState),
     /// Invalidating a key
     InvalidateKey(KeyState),
+    /// Zeroizing a key
+    ZeroizeKey(KeyState),
     /// Running garbage collection
     GarbageCollect(RubbishState),
 }
@@ -835,6 +837,98 @@ impl<'a, C: FlashController<S>, const S: usize> TicKV<'a, C, S> {
                     *region_data
                         .get_mut(offset + LEN_OFFSET)
                         .ok_or(ErrorCode::CorruptData)? &= !0x80;
+
+                    if let Err(e) = self.controller.write(
+                        S * new_region + offset + LEN_OFFSET,
+                        region_data
+                            .get(offset + LEN_OFFSET..offset + LEN_OFFSET + 1)
+                            .ok_or(ErrorCode::ObjectTooLarge)?,
+                    ) {
+                        self.read_buffer.replace(Some(region_data));
+                        match e {
+                            ErrorCode::WriteNotReady(_) => return Ok(SuccessCode::Queued),
+                            _ => return Err(e),
+                        }
+                    }
+
+                    self.read_buffer.replace(Some(region_data));
+                    return Ok(SuccessCode::Written);
+                }
+                Err((cont, e)) => {
+                    self.read_buffer.replace(Some(region_data));
+
+                    if cont {
+                        region_offset = new_region as isize - region as isize;
+                        match self.increment_region_offset(region, region_offset) {
+                            Some(o) => {
+                                region_offset = o;
+                                self.state.set(State::None);
+                            }
+                            None => {
+                                return Err(e);
+                            }
+                        }
+                    } else {
+                        return Err(e);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Zeroizes the key in flash storage
+    ///
+    /// `hash`: A hashed key.
+    ///
+    /// On success nothing will be returned.
+    /// On error a `ErrorCode` will be returned.
+    ///
+    /// If a power loss occurs before success is returned the data is
+    /// assumed to be lost.
+    /// Changes valid bit in addition to zeroizing the entry
+    pub fn zeroize_key(&self, hash: u64) -> Result<SuccessCode, ErrorCode> {
+        let region = self.get_region(hash);
+
+        let mut region_offset: isize = 0;
+
+        loop {
+            // Get the data from that region
+            let new_region = match self.state.get() {
+                State::None => (region as isize + region_offset) as usize,
+                State::ZeroizeKey(key_state) => match key_state {
+                    KeyState::ReadRegion(reg) => reg,
+                },
+                _ => unreachable!(),
+            };
+
+            // Get the data from that region
+            let region_data = self.read_buffer.take().unwrap();
+            if self.state.get() != State::ZeroizeKey(KeyState::ReadRegion(new_region)) {
+                match self.controller.read_region(new_region, 0, region_data) {
+                    Ok(()) => {}
+                    Err(e) => {
+                        self.read_buffer.replace(Some(region_data));
+                        if let ErrorCode::ReadNotReady(reg) = e {
+                            self.state.set(State::ZeroizeKey(KeyState::ReadRegion(reg)));
+                        }
+                        return Err(e);
+                    }
+                };
+            }
+
+            match self.find_key_offset(hash, region_data) {
+                Ok((offset, data_len)) => {
+                    // We found a key, let's delete it
+                    *region_data
+                        .get_mut(offset + LEN_OFFSET)
+                        .ok_or(ErrorCode::CorruptData)? &= !0x80;
+
+                    // Replace Value with 0s
+                    for i in HEADER_LENGTH..data_len as usize {
+                        *region_data
+                            .get_mut(offset + i)
+                            .ok_or(ErrorCode::RegionFull)? = 0;
+                    }
 
                     if let Err(e) = self.controller.write(
                         S * new_region + offset + LEN_OFFSET,


### PR DESCRIPTION
In the documentation of TicKV:

    This is done because changing a 1 to a 0 in flash can be done with
    a write to a single byte (where only 1 bit changes). While changing
    a 0 to a 1 requires an erase of the entire region.

This change will Zeroize a key without erasing by utilizing the ability to change a bit from a 1 to a 0 through a write as used in the invalidate_key function. This logic is applied throughout the value of the key without modifying the header. This is done to improve security without degrading the flash device with erase. Additionally, the valid bit will be flipped, allowing for the garbage collector to function as normal.

### Pull Request Overview

This pull request adds a function to TicKV to zeroize a key.


### Testing Strategy

This pull request was tested by adding tests and ensuring functionality is similar to invalidate_key(). Tested to ensure zeroize removes only the data desired


### TODO or Help Wanted

Discuss whether zeroize_key should outright replace invalidate_key as functionally they preform the same task. See discussion https://github.com/tock/tock/discussions/3709. Current pull request is using both invalidate and zeroize.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
