### PR TITLE
Make UART registers for Nrf52840 configurable

### DIFF
--- a/boards/microbit_v2/src/io.rs
+++ b/boards/microbit_v2/src/io.rs
@@ -11,6 +11,7 @@ use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart;
 use nrf52833::gpio::{self, Pin};
+use nrf52833::uart::{Uarte, UARTE0_BASE};
 
 use kernel::hil::gpio::{Configure, Input, Output};
 
@@ -42,7 +43,7 @@ impl Write for Writer {
 
 impl IoWrite for Writer {
     fn write(&mut self, buf: &[u8]) -> usize {
-        let uart = nrf52833::uart::Uarte::new();
+        let uart = Uarte::new(UARTE0_BASE);
 
         use kernel::hil::uart::Configure;
 

--- a/boards/nordic/nrf52840_dongle/src/io.rs
+++ b/boards/nordic/nrf52840_dongle/src/io.rs
@@ -10,6 +10,7 @@ use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart::{self, Configure};
 use nrf52840::gpio::Pin;
+use nrf52840::uart::{Uarte, UARTE0_BASE};
 
 use crate::CHIP;
 use crate::PROCESSES;
@@ -33,7 +34,7 @@ impl IoWrite for Writer {
         // Here, we create a second instance of the Uarte struct.
         // This is okay because we only call this during a panic, and
         // we will never actually process the interrupts
-        let uart = nrf52840::uart::Uarte::new();
+        let uart = Uarte::new(UARTE0_BASE);
         if !self.initialized {
             self.initialized = true;
             let _ = uart.configure(uart::Parameters {

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -11,7 +11,7 @@ use kernel::hil::led;
 use kernel::hil::uart;
 use kernel::hil::uart::Configure;
 use nrf52840::gpio::Pin;
-use nrf52840::uart::UARTE0_BASE;
+use nrf52840::uart::{Uarte, UARTE0_BASE};
 
 use crate::CHIP;
 use crate::PROCESSES;
@@ -52,7 +52,7 @@ impl IoWrite for Writer {
                 // Here, we create a second instance of the Uarte struct.
                 // This is okay because we only call this during a panic, and
                 // we will never actually process the interrupts
-                let uart = nrf52840::uart::Uarte::new(UARTE0_BASE);
+                let uart = Uarte::new(UARTE0_BASE);
                 if !*initialized {
                     *initialized = true;
                     let _ = uart.configure(uart::Parameters {

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -11,6 +11,7 @@ use kernel::hil::led;
 use kernel::hil::uart;
 use kernel::hil::uart::Configure;
 use nrf52840::gpio::Pin;
+use nrf52840::uart::UARTE0_BASE;
 
 use crate::CHIP;
 use crate::PROCESSES;
@@ -51,7 +52,7 @@ impl IoWrite for Writer {
                 // Here, we create a second instance of the Uarte struct.
                 // This is okay because we only call this during a panic, and
                 // we will never actually process the interrupts
-                let uart = nrf52840::uart::Uarte::new();
+                let uart = nrf52840::uart::Uarte::new(UARTE0_BASE);
                 if !*initialized {
                     *initialized = true;
                     let _ = uart.configure(uart::Parameters {

--- a/boards/nordic/nrf52dk/src/io.rs
+++ b/boards/nordic/nrf52dk/src/io.rs
@@ -10,6 +10,7 @@ use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart::{self, Configure};
 use nrf52832::gpio::Pin;
+use nrf52832::uart::{Uarte, UARTE0_BASE};
 
 use crate::CHIP;
 use crate::PROCESSES;
@@ -33,7 +34,7 @@ impl IoWrite for Writer {
         // Here, we create a second instance of the Uarte struct.
         // This is okay because we only call this during a panic, and
         // we will never actually process the interrupts
-        let uart = nrf52832::uart::Uarte::new();
+        let uart = Uarte::new(UARTE0_BASE);
         if !self.initialized {
             self.initialized = true;
             let _ = uart.configure(uart::Parameters {

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -63,7 +63,7 @@ impl<'a> Nrf52DefaultPeripherals<'a> {
             timer0: crate::timer::TimerAlarm::new(0),
             timer1: crate::timer::TimerAlarm::new(1),
             timer2: crate::timer::Timer::new(2),
-            uarte0: crate::uart::Uarte::new(),
+            uarte0: crate::uart::Uarte::new(crate::uart::UARTE0_BASE),
             spim0: crate::spi::SPIM::new(0),
             twi0: crate::i2c::TWI::new_twi0(),
             spim1: crate::spi::SPIM::new(1),

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -25,11 +25,11 @@ const UARTE_MAX_BUFFER_SIZE: u32 = 0xff;
 
 static mut BYTE: u8 = 0;
 
-const UARTE_BASE: StaticRef<UarteRegisters> =
+pub const UARTE0_BASE: StaticRef<UarteRegisters> =
     unsafe { StaticRef::new(0x40002000 as *const UarteRegisters) };
 
 #[repr(C)]
-struct UarteRegisters {
+pub struct UarteRegisters {
     task_startrx: WriteOnly<u32, Task::Register>,
     task_stoprx: WriteOnly<u32, Task::Register>,
     task_starttx: WriteOnly<u32, Task::Register>,
@@ -184,9 +184,9 @@ pub struct UARTParams {
 impl<'a> Uarte<'a> {
     /// Constructor
     // This should only be constructed once
-    pub fn new() -> Uarte<'a> {
+    pub fn new(regs: StaticRef<UarteRegisters>) -> Uarte<'a> {
         Uarte {
-            registers: UARTE_BASE,
+            registers: regs,
             tx_client: OptionalCell::empty(),
             tx_buffer: kernel::utilities::cells::TakeCell::empty(),
             tx_len: Cell::new(0),


### PR DESCRIPTION
### Pull Request Overview

This PR makes the registers of the UART implementation for the Nrf52840 configurable by passing them into the constructor. This allows boards to re-configure the UART or to support additional UARTs.
Also see the related issue #3720 

### Testing Strategy

Only changes that can be tested by compilation.


### TODO or Help Wanted

No help required.

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
