### PR TITLE
`clippy::unnecessary-cast` lint fixes

### DIFF
--- a/arch/rv32i/src/epmp.rs
+++ b/arch/rv32i/src/epmp.rs
@@ -677,7 +677,7 @@ impl<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> kernel::platform::mpu::MPU
         let mut region_size = cmp::max(
             min_memory_size,
             initial_app_memory_size + initial_kernel_memory_size,
-        ) as usize;
+        );
 
         // Region size always has to align to 4 bytes
         if region_size % 4 != 0 {

--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -448,7 +448,7 @@ impl<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> kernel::platform::mpu::MPU
         let mut region_size = cmp::max(
             min_memory_size,
             initial_app_memory_size + initial_kernel_memory_size,
-        ) as usize;
+        );
 
         // Region size always has to align to 4 bytes
         if region_size % 4 != 0 {

--- a/capsules/extra/src/nonvolatile_storage_driver.rs
+++ b/capsules/extra/src/nonvolatile_storage_driver.rs
@@ -457,7 +457,7 @@ impl hil::nonvolatile_storage::NonvolatileStorageClient for NonvolatileStorage<'
                                 read.mut_enter(|app_buffer| {
                                     let read_len = cmp::min(app_buffer.len(), length);
 
-                                    let d = &app_buffer[0..(read_len as usize)];
+                                    let d = &app_buffer[0..read_len];
                                     for (i, c) in buffer[0..read_len].iter().enumerate() {
                                         d[i].set(*c);
                                     }

--- a/chips/lowrisc/src/spi_host.rs
+++ b/chips/lowrisc/src/spi_host.rs
@@ -630,8 +630,7 @@ impl<'a> hil::spi::SpiMaster<'a> for SpiHost<'a> {
         //Hold rx_buf for later
 
         rx_buf.map(|rx_buf_t| {
-            self.rx_len
-                .set(cmp::min(self.tx_len.get(), rx_buf_t.len()) as usize);
+            self.rx_len.set(cmp::min(self.tx_len.get(), rx_buf_t.len()));
             self.rx_buf.replace(rx_buf_t);
         });
 


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes a couple of clippy warnings which occur on my local machine, but not in CI. Why that is, I have no idea. They persist across a full reinstall of the Rust toolchain for me. They seem to be valid lints though.

### Testing Strategy

Clippy.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`, or~ no updates are required.

### Formatting

- [x] Ran `make prepush`.
