### PR TITLE
Extend feature support for lowrisc UART

### DIFF
--- a/chips/lowrisc/src/uart.rs
+++ b/chips/lowrisc/src/uart.rs
@@ -51,9 +51,11 @@ impl<'a> Uart<'a> {
         }
     }
 
-    fn set_baud_rate(&self, baud_rate: u32) {
+    fn set_baud_rate(&self, baud_rate: u32) -> Result<(), ErrorCode> {
+        const NCO_BITS: u32 = u32::count_ones(CTRL::NCO.mask);
         let regs = self.registers;
-        let uart_ctrl_nco = ((baud_rate as u64) << 20) / self.clock_frequency as u64;
+
+        let uart_ctrl_nco = ((baud_rate as u64) << (NCO_BITS + 4)) / self.clock_frequency as u64;
 
         regs.ctrl
             .write(CTRL::NCO.val((uart_ctrl_nco & 0xffff) as u32));
@@ -61,6 +63,8 @@ impl<'a> Uart<'a> {
 
         regs.fifo_ctrl
             .write(FIFO_CTRL::RXRST::SET + FIFO_CTRL::TXRST::SET);
+
+        Ok(())
     }
 
     fn enable_tx_interrupt(&self) {

--- a/chips/lowrisc/src/uart.rs
+++ b/chips/lowrisc/src/uart.rs
@@ -36,6 +36,7 @@ pub struct Uart<'a> {
 #[derive(Copy, Clone)]
 pub struct UartParams {
     pub baud_rate: u32,
+    pub parity: uart::Parity,
 }
 
 /// Compute a / b, rounding such that the result is within 2.5% error of the floating point result.
@@ -313,6 +314,18 @@ impl hil::uart::Configure for Uart<'_> {
         let regs = self.registers;
         // We can set the baud rate.
         self.set_baud_rate(params.baud_rate)?;
+
+        match params.parity {
+            uart::Parity::Even => regs
+                .ctrl
+                .modify(CTRL::PARITY_EN::SET + CTRL::PARITY_ODD::CLEAR),
+            uart::Parity::Odd => regs
+                .ctrl
+                .modify(CTRL::PARITY_EN::SET + CTRL::PARITY_ODD::SET),
+            uart::Parity::None => regs
+                .ctrl
+                .modify(CTRL::PARITY_EN::CLEAR + CTRL::PARITY_ODD::CLEAR),
+        }
 
         regs.fifo_ctrl
             .write(FIFO_CTRL::RXRST::SET + FIFO_CTRL::TXRST::SET);

--- a/chips/lowrisc/src/uart.rs
+++ b/chips/lowrisc/src/uart.rs
@@ -15,7 +15,7 @@ use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeabl
 use kernel::utilities::StaticRef;
 
 use crate::registers::uart_regs::UartRegisters;
-use crate::registers::uart_regs::{CTRL, FIFO_CTRL, INTR, STATUS, WDATA};
+use crate::registers::uart_regs::{CTRL, FIFO_CTRL, INTR, STATUS, TIMEOUT_CTRL, WDATA};
 
 pub struct Uart<'a> {
     registers: StaticRef<UartRegisters>,
@@ -29,6 +29,8 @@ pub struct Uart<'a> {
 
     rx_buffer: TakeCell<'static, [u8]>,
     rx_len: Cell<usize>,
+    rx_index: Cell<usize>,
+    rx_timeout: Cell<u8>,
 }
 
 #[derive(Copy, Clone)]
@@ -61,6 +63,8 @@ impl<'a> Uart<'a> {
             tx_index: Cell::new(0),
             rx_buffer: TakeCell::empty(),
             rx_len: Cell::new(0),
+            rx_index: Cell::new(0),
+            rx_timeout: Cell::new(0),
         }
     }
 
@@ -114,6 +118,33 @@ impl<'a> Uart<'a> {
         regs.intr_state.write(INTR::RX_WATERMARK::SET);
     }
 
+    fn enable_rx_timeout(&self, interbyte_timeout: u8) {
+        let regs = self.registers;
+
+        // Program the timeout value
+        regs.timeout_ctrl
+            .write(TIMEOUT_CTRL::VAL.val(interbyte_timeout as u32));
+
+        // Enable RX timeout feature
+        regs.timeout_ctrl.write(TIMEOUT_CTRL::EN::SET);
+
+        // Enable RX timeout interrupt
+        regs.intr_enable.write(INTR::RX_TIMEOUT::SET);
+    }
+
+    fn disable_rx_timeout(&self) {
+        let regs = self.registers;
+
+        // Disable RX timeout feature
+        regs.timeout_ctrl.modify(TIMEOUT_CTRL::EN::CLEAR);
+
+        // Disable RX timeout interrupt
+        regs.intr_enable.modify(INTR::RX_TIMEOUT::CLEAR);
+
+        // Clear the interrupt bit (by writing 1), if it happens to be set
+        regs.intr_state.write(INTR::RX_TIMEOUT::SET);
+    }
+
     fn tx_progress(&self) {
         let regs = self.registers;
         let idx = self.tx_index.get();
@@ -143,6 +174,41 @@ impl<'a> Uart<'a> {
         }
     }
 
+    fn consume_rx(&self) {
+        let regs = self.registers;
+
+        self.rx_client.map(|client| {
+            self.rx_buffer.take().map(|rx_buf| {
+                let mut len = 0;
+                let mut return_code = Ok(());
+
+                for i in self.rx_index.get()..self.rx_len.get() {
+                    rx_buf[i] = regs.rdata.get() as u8;
+                    len = i + 1;
+
+                    if regs.status.is_set(STATUS::RXEMPTY) {
+                        /* RX is empty */
+
+                        // If this was kicked off by `receive_automatic()` then we can reenable
+                        // interupts and wait for either the rest of the data or for the timeout.
+                        let rx_timeout = self.rx_timeout.get();
+                        if rx_timeout > 0 {
+                            self.rx_index.set(i);
+                            self.enable_rx_timeout(rx_timeout);
+                            self.enable_rx_interrupt();
+                            return;
+                        } else {
+                            return_code = Err(ErrorCode::SIZE);
+                            break;
+                        }
+                    }
+                }
+
+                client.received_buffer(rx_buf, len, return_code, uart::Error::None);
+            });
+        });
+    }
+
     pub fn handle_interrupt(&self) {
         let regs = self.registers;
         let intrs = regs.intr_state.extract();
@@ -164,53 +230,71 @@ impl<'a> Uart<'a> {
             }
         } else if intrs.is_set(INTR::RX_WATERMARK) {
             self.disable_rx_interrupt();
+            self.consume_rx();
+        } else if intrs.is_set(INTR::RX_TIMEOUT) {
+            self.disable_rx_interrupt();
+            self.disable_rx_timeout();
 
+            // On timeout return whatever is in the buffer to the client.
             self.rx_client.map(|client| {
                 self.rx_buffer.take().map(|rx_buf| {
-                    let mut len = 0;
-                    let mut return_code = Ok(());
-
-                    for i in 0..self.rx_len.get() {
-                        if regs.status.is_set(STATUS::RXEMPTY) {
-                            /* RX is empty */
-                            return_code = Err(ErrorCode::SIZE);
-                            break;
-                        }
-
-                        rx_buf[i] = regs.rdata.get() as u8;
-                        len = i + 1;
-                    }
-
-                    client.received_buffer(rx_buf, len, return_code, uart::Error::None);
-                });
+                    client.received_buffer(
+                        rx_buf,
+                        self.rx_index.get() + 1,
+                        Err(kernel::ErrorCode::SIZE),
+                        uart::Error::None,
+                    );
+                })
             });
         } else if intrs.is_set(INTR::TX_WATERMARK) {
             // TODO: Additional logic or notification related to the watermark.
         } else if intrs.is_set(INTR::RX_OVERFLOW) {
-            // Buffer has overflowed; notify the client or handle as needed.
+            self.disable_rx_interrupt();
             self.rx_client.map(|client| {
-                client.error(uart::Error::OverrunError);
+                self.rx_buffer.take().map(|rx_buf| {
+                    client.received_buffer(
+                        rx_buf,
+                        self.rx_index.get(),
+                        Err(kernel::ErrorCode::FAIL),
+                        uart::Error::OverrunError,
+                    );
+                });
             });
         } else if intrs.is_set(INTR::RX_FRAME_ERR) {
-            // There was a framing error during reception.
+            self.disable_rx_interrupt();
             self.rx_client.map(|client| {
-                client.error(uart::Error::FramingError);
+                self.rx_buffer.take().map(|rx_buf| {
+                    client.received_buffer(
+                        rx_buf,
+                        self.rx_index.get(),
+                        Err(kernel::ErrorCode::FAIL),
+                        uart::Error::FramingError,
+                    );
+                });
             });
         } else if intrs.is_set(INTR::RX_BREAK_ERR) {
-            // A break condition was detected.
-            // TODO: Handle as required, perhaps reset or notify client.
+            self.disable_rx_interrupt();
             self.rx_client.map(|client| {
-                client.error(uart::Error::BreakError);
-            });
-        } else if intrs.is_set(INTR::RX_TIMEOUT) {
-            // RX has timed out.
-            self.rx_client.map(|client| {
-                client.error(uart::Error::TimeoutError);
+                self.rx_buffer.take().map(|rx_buf| {
+                    client.received_buffer(
+                        rx_buf,
+                        self.rx_index.get(),
+                        Err(kernel::ErrorCode::FAIL),
+                        uart::Error::BreakError,
+                    );
+                });
             });
         } else if intrs.is_set(INTR::RX_PARITY_ERR) {
-            // Parity error in the received data.
+            self.disable_rx_interrupt();
             self.rx_client.map(|client| {
-                client.error(uart::Error::ParityError);
+                self.rx_buffer.take().map(|rx_buf| {
+                    client.received_buffer(
+                        rx_buf,
+                        self.rx_index.get(),
+                        Err(kernel::ErrorCode::FAIL),
+                        uart::Error::ParityError,
+                    );
+                });
             });
         }
     }
@@ -228,7 +312,7 @@ impl hil::uart::Configure for Uart<'_> {
     fn configure(&self, params: hil::uart::Parameters) -> Result<(), ErrorCode> {
         let regs = self.registers;
         // We can set the baud rate.
-        self.set_baud_rate(params.baud_rate);
+        self.set_baud_rate(params.baud_rate)?;
 
         regs.fifo_ctrl
             .write(FIFO_CTRL::RXRST::SET + FIFO_CTRL::TXRST::SET);
@@ -293,6 +377,8 @@ impl<'a> hil::uart::Receive<'a> for Uart<'a> {
 
         self.rx_buffer.replace(rx_buffer);
         self.rx_len.set(rx_len);
+        self.rx_timeout.set(0);
+        self.rx_index.set(0);
 
         Ok(())
     }
@@ -306,6 +392,25 @@ impl<'a> hil::uart::Receive<'a> for Uart<'a> {
     }
 }
 
+impl<'a> hil::uart::ReceiveAdvanced<'a> for Uart<'a> {
+    fn receive_automatic(
+        &self,
+        rx_buffer: &'static mut [u8],
+        rx_len: usize,
+        interbyte_timeout: u8,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+        if rx_len == 0 || rx_len > rx_buffer.len() {
+            return Err((ErrorCode::SIZE, rx_buffer));
+        }
+
+        self.rx_buffer.replace(rx_buffer);
+        self.rx_len.set(rx_len);
+        self.rx_timeout.set(interbyte_timeout);
+        self.rx_index.set(0);
+
+        Ok(())
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/kernel/src/hil/uart.rs
+++ b/kernel/src/hil/uart.rs
@@ -58,6 +58,9 @@ pub enum Error {
     /// UART hardware was reset
     ResetError,
 
+    /// UART hardware was disconnected
+    BreakError,
+
     /// Read or write was aborted early
     Aborted,
 }


### PR DESCRIPTION
### Pull Request Overview

This PR adds the following to the lowrisc UART implementation

- Parameter validation for baud rate configuration
- Support for different parity modes
- An implementation of `ReceiveAdvanced::receive_automatic()` using the UART's built in `rx_timeout`
- Adds support for a few interrupt driven errors and adds `BreakError` to the UART HIL


### Testing Strategy

This pull request was tested by...


### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
