### PR TITLE
chips/lowrisc: spi_host: Enable interrupts before operation

### DIFF
--- a/chips/lowrisc/src/spi_host.rs
+++ b/chips/lowrisc/src/spi_host.rs
@@ -370,6 +370,9 @@ impl<'a> SpiHost<'a> {
             txfifo_num_bytes
         };
 
+        self.enable_interrupts();
+        self.enable_tx_interrupt();
+
         //Flush all data in TXFIFO and assert CSAAT for all
         // but the last transfer segment.
         if self.tx_offset.get() >= self.tx_len.get() {
@@ -387,8 +390,6 @@ impl<'a> SpiHost<'a> {
                     + command::SPEED.val(SPI_HOST_CMD_STANDARD_SPI),
             );
         }
-        self.enable_interrupts();
-        self.enable_tx_interrupt();
     }
 
     /// Reset the soft internal state, should be called once


### PR DESCRIPTION
### Pull Request Overview

If we clear and enable interrupts after we start the operation we can hit race conditions where the operation has completed before we enable interrupts. So instead let's enable the interrupts before starting the operation.

### Testing Strategy

CI

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
