### PR TITLE
boards: particle_boron: collection of improvements

### DIFF
--- a/boards/particle_boron/README.md
+++ b/boards/particle_boron/README.md
@@ -25,6 +25,7 @@ Required:
 
 * Segger JLink 
 * USB Cable for power & Debugging
+* FDTI/Serial UART converter (Optional for debugging/Console)
 
 Ensure JLink is connected and the Particle Boron is powered using either mUSB cable or a Li-Po battery. 
 
@@ -58,15 +59,30 @@ A reset on the baord can be performed by the **_RESET** push button, to reboot t
 
 ## Console output
 
-Console is interfaced using `USB cdc_acm`, so additional hardware is not required. Once the kernel is flashed, simply open up a serial port
+Console is interfaced with UART. On the left side of the Particle Boron, you can see the marked UART RX/TX pins. Connect a serial converter to the appropriate pins (`UART1_RX->CONVERTER_TX` & `UART1_TX->CONVERTER_RX`), see the figure above for the pin-out.
+
+If you are on a linux machine, it's a good idea to monitor the kernel message buffer with `dmesg -w` when plugging the serial converter in. This can quickly tell us which USB device to open.
 
 ```bash
-$ screen /dev/ttyACM0 115200 
+$ dmesg -w
+
+[26244.142183] usb 3-4: new full-speed USB device number 50 using xhci_hcd
+[26244.295996] usb 3-4: New USB device found, idVendor=0403, idProduct=6001, bcdDevice= 6.00
+[26244.296001] usb 3-4: New USB device strings: Mfr=1, Product=2, SerialNumber=3
+[26244.296004] usb 3-4: Product: FT232R USB UART
+[26244.296006] usb 3-4: Manufacturer: FTDI
+[26244.296007] usb 3-4: SerialNumber: A50285BI
+[26244.302027] ftdi_sio 3-4:1.0: FTDI USB Serial Device converter detected
+[26244.302055] usb 3-4: Detected FT232R
+[26244.309214] usb 3-4: FTDI USB Serial Device converter now attached to ttyUSB0
+```
+Based on the last kernel message, we are mapped to `ttyUSB0`, now, we can access the console with:
+```bash
+$ screen /dev/ttyUSB0 115200
 .
-.
-.
-> tock$ help
-> Valid commands are: help status list stop start fault process kernel
+..
+Particle Boron: Initialization complete. Entering main loop
+tock$
 ```
 
 OR

--- a/boards/particle_boron/src/io.rs
+++ b/boards/particle_boron/src/io.rs
@@ -4,26 +4,25 @@
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
-use kernel::ErrorCode;
-
 use cortexm4;
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;
-use kernel::hil::uart::Transmit;
-use kernel::hil::uart::{self};
-use kernel::utilities::cells::VolatileCell;
+use kernel::hil::uart;
+use kernel::hil::uart::Configure;
 use nrf52840::gpio::Pin;
+use nrf52840::uart::{Uarte, UARTE0_BASE};
 
 use crate::CHIP;
 use crate::PROCESSES;
 use crate::PROCESS_PRINTER;
 
-struct Writer {
-    initialized: bool,
+// Expand here with more writing methods as required (rtt/cdc etc...)
+enum Writer {
+    WriterUart(/* initialized */ bool),
 }
 
-static mut WRITER: Writer = Writer { initialized: false };
+static mut WRITER: Writer = Writer::WriterUart(false);
 
 impl Write for Writer {
     fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
@@ -32,105 +31,44 @@ impl Write for Writer {
     }
 }
 
-const BUF_LEN: usize = 512;
-static mut STATIC_PANIC_BUF: [u8; BUF_LEN] = [0; BUF_LEN];
-
-static mut DUMMY: DummyUsbClient = DummyUsbClient {
-    fired: VolatileCell::new(false),
-};
-
-struct DummyUsbClient {
-    fired: VolatileCell<bool>,
-}
-
-impl uart::TransmitClient for DummyUsbClient {
-    fn transmitted_buffer(&self, _: &'static mut [u8], _: usize, _: Result<(), ErrorCode>) {
-        self.fired.set(true);
-    }
-}
-
 impl IoWrite for Writer {
     fn write(&mut self, buf: &[u8]) -> usize {
-        if !self.initialized {
-            self.initialized = true;
-        }
-        // Here we mimic a synchronous UART output by calling transmit_buffer
-        // on the CDC stack and then spinning on USB interrupts until the transaction
-        // is complete. If the USB or CDC stack panicked, this may fail. It will also
-        // fail if the panic occurred prior to the USB connection being initialized.
-        // In the latter case, the LEDs should still blink in the panic pattern.
-
-        // spin so that if any USB DMA is ongoing it will finish
-        // we should only need this on the first call to write()
-        let mut i = 0;
-        loop {
-            i += 1;
-            cortexm4::support::nop();
-            if i > 10000 {
-                break;
-            }
-        }
-
-        // copy_from_slice() requires equal length slices
-        // This will truncate any writes longer than BUF_LEN, but simplifies the
-        // code. In practice, BUF_LEN=512 always seems sufficient for the size of
-        // individual calls to write made by the panic handler.
-        let mut max = BUF_LEN;
-        if buf.len() < BUF_LEN {
-            max = buf.len();
-        }
-
-        unsafe {
-            // If CDC_REF_FOR_PANIC is not yet set we panicked very early,
-            // and not much we can do. Don't want to double fault,
-            // so just return.
-            super::CDC_REF_FOR_PANIC.map(|cdc| {
-                // Lots of unsafe dereferencing of global static mut objects here.
-                // However, this should be okay, because it all happens within
-                // a single thread, and:
-                // - This is the only place the global CDC_REF_FOR_PANIC is used, the logic is the same
-                //   as applies for the global CHIP variable used in the panic handler.
-                // - We do create multiple mutable references to the STATIC_PANIC_BUF, but we never
-                //   access the STATIC_PANIC_BUF after a slice of it is passed to transmit_buffer
-                //   until the slice has been returned in the uart callback.
-                // - Similarly, only this function uses the global DUMMY variable, and we do not
-                //   mutate it.
-                let usb = &mut cdc.controller();
-                STATIC_PANIC_BUF[..max].copy_from_slice(&buf[..max]);
-                let static_buf = &mut STATIC_PANIC_BUF;
-                cdc.set_transmit_client(&DUMMY);
-                let _ = cdc.transmit_buffer(static_buf, max);
-                loop {
-                    if let Some(interrupt) = cortexm4::nvic::next_pending() {
-                        if interrupt == 39 {
-                            usb.handle_interrupt();
-                        }
-                        let n = cortexm4::nvic::Nvic::new(interrupt);
-                        n.clear_pending();
-                        n.enable();
-                    }
-                    if DUMMY.fired.get() {
-                        // buffer finished transmitting, return so we can output additional
-                        // messages when requested by the panic handler.
-                        break;
-                    }
+        match self {
+            Writer::WriterUart(ref mut initialized) => {
+                // Here, we create a second instance of the Uarte struct.
+                // This is okay because we only call this during a panic, and
+                // we will never actually process the interrupts
+                let uart = Uarte::new(UARTE0_BASE);
+                if !*initialized {
+                    *initialized = true;
+                    let _ = uart.configure(uart::Parameters {
+                        baud_rate: 115200,
+                        stop_bits: uart::StopBits::One,
+                        parity: uart::Parity::None,
+                        hw_flow_control: false,
+                        width: uart::Width::Eight,
+                    });
                 }
-                DUMMY.fired.set(false);
-            });
-        }
+                for &c in buf {
+                    unsafe {
+                        uart.send_byte(c);
+                    }
+                    while !uart.tx_ready() {}
+                }
+            }
+        };
         buf.len()
     }
 }
 
 const LED2_R_PIN: Pin = Pin::P0_13;
 
-/// Default panic handler for the Particle Boron.
-///
-/// We just use the standard default provided by the debug module in the kernel.
 #[cfg(not(test))]
 #[no_mangle]
 #[panic_handler]
+/// Panic handler
 pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+    // The nRF52840DK LEDs (see back of board)
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(LED2_R_PIN);
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut WRITER;

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -22,7 +22,6 @@ use kernel::hil::i2c::{I2CMaster, I2CSlave};
 use kernel::hil::led::LedLow;
 use kernel::hil::symmetric_encryption::AES128;
 use kernel::hil::time::Counter;
-use kernel::hil::usb::Client;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 #[allow(unused_imports)]
@@ -42,11 +41,11 @@ const LED2_B_PIN: Pin = Pin::P0_15;
 const BUTTON_PIN: Pin = Pin::P0_11;
 const BUTTON_RST_PIN: Pin = Pin::P0_18;
 
-// UART Pins
+// UART Pins (CTS/RTS Unused)
 const _UART_RTS: Option<Pin> = Some(Pin::P0_30);
-const _UART_TXD: Pin = Pin::P0_06;
 const _UART_CTS: Option<Pin> = Some(Pin::P0_31);
-const _UART_RXD: Pin = Pin::P0_08;
+const UART_TXD: Pin = Pin::P0_06;
+const UART_RXD: Pin = Pin::P0_08;
 
 // SPI pins not currently in use, but left here for convenience
 const _SPI_MOSI: Pin = Pin::P1_13;
@@ -66,12 +65,9 @@ const DEFAULT_EXT_SRC_MAC: [u8; 8] = [0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 
 /// UART Writer
 pub mod io;
 
-// How should the kernel respond when a process faults. For this board we choose
-// to stop the app and print a notice, but not immediately panic. This allows
-// users to debug their apps, but avoids issues with using the USB/CDC stack
-// synchronously for panic! too early after the board boots.
-const FAULT_RESPONSE: kernel::process::StopWithDebugFaultPolicy =
-    kernel::process::StopWithDebugFaultPolicy {};
+// State for loading and holding applications.
+// How should the kernel respond when a process faults.
+const FAULT_RESPONSE: kernel::process::PanicFaultPolicy = kernel::process::PanicFaultPolicy {};
 
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 8;
@@ -83,13 +79,6 @@ static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS]
 static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;
 // Static reference to process printer for panic dumps
 static mut PROCESS_PRINTER: Option<&'static kernel::process::ProcessPrinterText> = None;
-static mut CDC_REF_FOR_PANIC: Option<
-    &'static capsules_extra::usb::cdc::CdcAcm<
-        'static,
-        nrf52::usbd::Usbd,
-        capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, nrf52::rtc::Rtc>,
-    >,
-> = None;
 static mut NRF52_POWER: Option<&'static nrf52840::power::Power> = None;
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
@@ -255,6 +244,8 @@ pub unsafe fn main() {
     // macro is available during most of the setup code and kernel execution.
     kernel::debug::assign_gpios(Some(&gpio_port[LED2_R_PIN]), None, None);
 
+    let uart_channel = UartChannel::Pins(UartPins::new(None, UART_TXD, None, UART_RXD));
+
     //--------------------------------------------------------------------------
     // GPIO
     //--------------------------------------------------------------------------
@@ -369,37 +360,14 @@ pub unsafe fn main() {
     // UART & CONSOLE & DEBUG
     //--------------------------------------------------------------------------
 
-    // Setup the CDC-ACM over USB driver that we will use for UART.
-    // We use the Arduino Vendor ID and Product ID since the device is the same.
-
-    // Create the strings we include in the USB descriptor. We use the hardcoded
-    // DEVICEADDR register on the nRF52 to set the serial number.
-    let serial_number_buf = static_init!([u8; 17], [0; 17]);
-    let serial_number_string: &'static str =
-        nrf52::ficr::FICR_INSTANCE.address_str(serial_number_buf);
-    let strings = static_init!(
-        [&str; 3],
-        [
-            "Particle",           // Manufacturer
-            "Boron - TockOS",     // Product
-            serial_number_string, // Serial number
-        ]
-    );
-
-    let cdc = components::cdc::CdcAcmComponent::new(
-        &nrf52840_peripherals.usbd,
-        capsules_extra::usb::cdc::MAX_CTRL_PACKET_SIZE_NRF52840,
-        0x0101, // Custom
-        0x0202, // Custom
-        strings,
+    let uart_channel = nrf52_components::UartChannelComponent::new(
+        uart_channel,
         mux_alarm,
-        None,
+        &base_peripherals.uarte0,
     )
-    .finalize(components::cdc_acm_component_static!(
-        nrf52::usbd::Usbd,
-        nrf52::rtc::Rtc
+    .finalize(nrf52_components::uart_channel_component_static!(
+        nrf52840::rtc::Rtc
     ));
-    CDC_REF_FOR_PANIC = Some(cdc); //for use by panic handler
 
     // Process Printer for displaying process information.
     let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
@@ -407,7 +375,7 @@ pub unsafe fn main() {
     PROCESS_PRINTER = Some(process_printer);
 
     // Create a shared UART channel for the console and for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(cdc, 115200)
+    let uart_mux = components::console::UartMuxComponent::new(uart_channel, 115200)
         .finalize(components::uart_mux_component_static!());
 
     let pconsole = components::process_console::ProcessConsoleComponent::new(
@@ -418,7 +386,7 @@ pub unsafe fn main() {
         Some(cortexm4::support::reset),
     )
     .finalize(components::process_console_component_static!(
-        nrf52::rtc::Rtc<'static>
+        nrf52840::rtc::Rtc<'static>
     ));
 
     // Setup the console.
@@ -605,10 +573,6 @@ pub unsafe fn main() {
         nrf52840::chip::NRF52::new(nrf52840_peripherals)
     );
     CHIP = Some(chip);
-
-    // Configure the USB stack to enable a serial port over CDC-ACM.
-    cdc.enable();
-    cdc.attach();
 
     debug!("Particle Boron: Initialization complete. Entering main loop\r");
     let _ = platform.pconsole.start();


### PR DESCRIPTION
### Pull Request Overview

1. Switch from USB-CDC based console to UART
       - Missing panic handler information when using USB. Switch to UART for now, with USB in mind to add later as a configurable option.

2. Update README to reflect changes in 1

3. ~~Increase stack size~~
      - ~~Reproducible kernel panic due to a stack overflow when the `kernel` command was issued to the process console. Increase the stack size to accommodate.~~

3. Add a `inline(never)` start function that offloads the functionality of the `main()` function. The associated stack frame will be popped when this function returns allowing us to use less stack overall. This also fixes the stack overflow observed with the pconsole `kernel` command.


### Testing Strategy

Flashing the kernel to the board. The stack overflow was fix was tested by running the `kernel` cmd in the pconsole (which is what initially caused it). It now works as expected.

```
tock$ kernel
Kernel version: 2.1 (build release-2.1-2171-gb439edec9)

 ╔═══════════╤══════════════════════════════╗
 ║  Address  │ Region Name    Used (bytes)  ║
 ╚0x200034A0═╪══════════════════════════════╝
             │   BSS          9376
  0x20001000 ┼─────────────────────────────── S
             │   Relocate        0            R
  0x20001000 ┼─────────────────────────────── A
             │ ▼ Stack        4096            M
  0x20000000 ┼───────────────────────────────
             .....
  0x0001F000 ┼─────────────────────────────── F
             │   RoData      26170            L
  0x000189C6 ┼─────────────────────────────── A
             │   Code       100806            S
  0x00000000 ┼─────────────────────────────── H
```

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
