### PR TITLE
arch/cortex-m: fix typo in asm comment of switch_to_user_arm_v7m

### DIFF
--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -422,7 +422,7 @@ pub unsafe fn switch_to_user_arm_v7m(
     // r9 using r12, and then mark those as clobbered.
     mov r2, r6                        // r2 = r6
     mov r3, r7                        // r3 = r7
-    mov r12, r9                       // r12 = r8
+    mov r12, r9                       // r12 = r9
 
     // The arguments passed in are:
     // - `r0` is the bottom of the user stack


### PR DESCRIPTION
### Pull Request Overview

Just fixing my own typo...

Reported-by: 黄伟钧 (@hawav)
Fixes: https://github.com/tock/tock/issues/3737


### Testing Strategy

N/A


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
