### PR TITLE
Fix RX race condition in lowrisc UART

### DIFF
--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -78,6 +78,7 @@ impl<'a, CFG: EarlGreyConfig> EarlGreyDefaultPeripherals<'a, CFG> {
 
     pub fn init(&'static self) {
         kernel::deferred_call::DeferredCallClient::register(&self.aes);
+        kernel::deferred_call::DeferredCallClient::register(&self.uart0);
     }
 }
 


### PR DESCRIPTION
Sometimes when reading data over the UART, there is already data in the RX FIFO before calling `receive_buffer()`. Since the UART driver depends on an edge-triggered watermark to consume the FIFO data, this race prevents the driver from ever reading the data.

To fix, schedule a deferred call in cases where there is already RX data pending when going to enable RX interrupts.

### Pull Request Overview

This pull request adds/changes/fixes...


### Testing Strategy

This pull request was tested by...


### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
