### PR TITLE
nrf5x: gpio: add i2c pin config | particle_boron: fixup i2c pin cfg

### DIFF
--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -18,6 +18,8 @@ use capsules_core::virtualizers::virtual_aes_ccm::MuxAES128CCM;
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use kernel::component::Component;
 use kernel::deferred_call::DeferredCallClient;
+use kernel::hil::gpio::Configure;
+use kernel::hil::gpio::FloatingState;
 use kernel::hil::i2c::{I2CMaster, I2CSlave};
 use kernel::hil::led::LedLow;
 use kernel::hil::symmetric_encryption::AES128;
@@ -540,7 +542,16 @@ pub unsafe fn start_particle_boron() -> (
     );
     base_peripherals.twi1.set_master_client(i2c_master_slave);
     base_peripherals.twi1.set_slave_client(i2c_master_slave);
-    base_peripherals.twi1.set_speed(nrf52840::i2c::Speed::K400);
+    // Note: strongly suggested to use external pull-ups for higher speeds
+    //       to maintain signal integrity.
+    base_peripherals.twi1.set_speed(nrf52840::i2c::Speed::K100);
+
+    // I2C pin cfg for target
+    nrf52840_peripherals.gpio_port[I2C_SDA_PIN].set_i2c_pin_cfg();
+    nrf52840_peripherals.gpio_port[I2C_SCL_PIN].set_i2c_pin_cfg();
+    // Enable internal pull-ups
+    nrf52840_peripherals.gpio_port[I2C_SDA_PIN].set_floating_state(FloatingState::PullUp);
+    nrf52840_peripherals.gpio_port[I2C_SCL_PIN].set_floating_state(FloatingState::PullUp);
 
     //--------------------------------------------------------------------------
     // FINAL SETUP AND BOARD BOOT

--- a/chips/nrf52/src/i2c.rs
+++ b/chips/nrf52/src/i2c.rs
@@ -75,18 +75,43 @@ impl<'a> TWI<'a> {
         self.registers.frequency.set(speed as u32);
     }
 
+    /// Clear all pending events
+    /// This is useful when switching between a master and slave mode to ensure
+    /// we start from a clean state.
+    pub fn clear_events(&self) {
+        self.registers.events_stopped.write(EVENT::EVENT::CLEAR);
+        self.registers.events_error.write(EVENT::EVENT::CLEAR);
+        self.registers.events_rxstarted.write(EVENT::EVENT::CLEAR);
+        self.registers.events_txstarted.write(EVENT::EVENT::CLEAR);
+        self.registers.events_write.write(EVENT::EVENT::CLEAR);
+        self.registers.events_read.write(EVENT::EVENT::CLEAR);
+        self.registers.events_suspended.write(EVENT::EVENT::CLEAR);
+        self.registers.events_lastrx.write(EVENT::EVENT::CLEAR);
+        self.registers.events_lasttx.write(EVENT::EVENT::CLEAR);
+    }
+
+    pub fn disable_interrupts(&self) {
+        // Disable all interrupts
+        self.registers.inten.set(0x00);
+        self.registers.intenclr.set(0xFFFF_FFFF);
+    }
+
     /// Enables hardware TWIM peripheral.
     fn enable_master(&self) {
+        self.clear_events();
         self.registers.enable.write(ENABLE::ENABLE::EnableMaster);
     }
 
     /// Enables hardware TWIS peripheral.
     fn enable_slave(&self) {
+        self.clear_events();
         self.registers.enable.write(ENABLE::ENABLE::EnableSlave);
     }
 
     /// Disables hardware TWIM/TWIS peripheral.
     fn disable(&self) {
+        self.clear_events();
+        self.disable_interrupts();
         self.registers.enable.write(ENABLE::ENABLE::Disable);
     }
 
@@ -98,6 +123,7 @@ impl<'a> TWI<'a> {
                 self.client.map(|client| match self.buf.take() {
                     None => (),
                     Some(buf) => {
+                        self.clear_events();
                         client.command_complete(buf, Ok(()));
                     }
                 });
@@ -119,6 +145,7 @@ impl<'a> TWI<'a> {
                         } else {
                             Ok(())
                         };
+                        self.clear_events();
                         client.command_complete(buf, status);
                     }
                 });
@@ -155,6 +182,7 @@ impl<'a> TWI<'a> {
                 self.slave_client.map(|client| match self.buf.take() {
                     None => (),
                     Some(buf) => {
+                        self.clear_events();
                         client.command_complete(
                             buf,
                             length,
@@ -171,6 +199,7 @@ impl<'a> TWI<'a> {
                     .map(|client| match self.slave_read_buf.take() {
                         None => (),
                         Some(buf) => {
+                            self.clear_events();
                             client.command_complete(
                                 buf,
                                 length,

--- a/chips/nrf5x/src/gpio.rs
+++ b/chips/nrf5x/src/gpio.rs
@@ -389,6 +389,16 @@ impl<'a> GPIOPin<'a> {
             PinConfig::DRIVE::S0S1
         });
     }
+
+    // This sets the specified pin cfg as per the TRM for i2c pin usage.
+    pub fn set_i2c_pin_cfg(&self) {
+        self.gpio_registers.pin_cnf[self.pin as usize].modify(
+            PinConfig::DIR::Input
+                + PinConfig::INPUT::Disconnect
+                + PinConfig::DRIVE::S0D1
+                + PinConfig::SENSE::Disabled,
+        );
+    }
 }
 
 impl hil::gpio::Configure for GPIOPin<'_> {


### PR DESCRIPTION
### Pull Request Overview

Fix-up I2C pin configuration for the particle boron to address intermittent bus integrity issues.

### Testing Strategy

I2C Master/Slave transferring data on the Particle Boron.

### TODO or Help Wanted

Is the change to the gpio driver acceptable? I only did it this way as the config is very specific and it would bloat the board `main.rs` to call multiple different gpio functions to configure the pins for I2C. If this is not okay, I can split it out into separate functions.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
