### PR TITLE
Update rust january 2024

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
     "editor.defaultFormatter": "rust-lang.rust-analyzer",
     "editor.formatOnSave": true,
     "rust-analyzer.server.extraEnv": {
-        "RUSTUP_TOOLCHAIN": "nightly-2023-07-30"
+        "RUSTUP_TOOLCHAIN": "nightly-2024-01-01"
     },
     "rust-analyzer.check.allTargets": false,
 }

--- a/boards/acd52832/src/io.rs
+++ b/boards/acd52832/src/io.rs
@@ -12,7 +12,7 @@ use nrf52832::gpio::Pin;
 #[cfg(not(test))]
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(_pi: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(_pi: &PanicInfo) -> ! {
     let led_kernel_pin = &nrf52832::gpio::GPIOPin::new(Pin::P0_22);
     let led = &mut led::LedLow::new(led_kernel_pin);
     debug::panic_blink_forever(&mut [led])

--- a/boards/apollo3/lora_things_plus/src/io.rs
+++ b/boards/apollo3/lora_things_plus/src/io.rs
@@ -37,7 +37,7 @@ impl IoWrite for Writer {
 /// Panic handler.
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(info: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     // just create a new pin reference here instead of using global
     let led_pin = &mut apollo3::gpio::GpioPin::new(
         kernel::utilities::StaticRef::new(

--- a/boards/apollo3/lora_things_plus/src/main.rs
+++ b/boards/apollo3/lora_things_plus/src/main.rs
@@ -244,27 +244,27 @@ unsafe fn setup() -> (
     pwr_ctrl.enable_iom3();
 
     // Enable PinCfg
-    let _ = &peripherals
+    peripherals
         .gpio_port
         .enable_uart(&peripherals.gpio_port[48], &peripherals.gpio_port[49]);
     // Enable SDA and SCL for I2C (exposed via Qwiic)
-    let _ = &peripherals
+    peripherals
         .gpio_port
         .enable_i2c(&peripherals.gpio_port[6], &peripherals.gpio_port[5]);
     // Enable Main SPI
-    let _ = &peripherals.gpio_port.enable_spi(
+    peripherals.gpio_port.enable_spi(
         &peripherals.gpio_port[27],
         &peripherals.gpio_port[28],
         &peripherals.gpio_port[25],
     );
     // Enable SPI for SX1262
-    let _ = &peripherals.gpio_port.enable_spi(
+    peripherals.gpio_port.enable_spi(
         &peripherals.gpio_port[42],
         &peripherals.gpio_port[38],
         &peripherals.gpio_port[43],
     );
     // Enable the radio pins
-    let _ = &peripherals.gpio_port.enable_sx1262_radio_pins();
+    peripherals.gpio_port.enable_sx1262_radio_pins();
 
     // Configure kernel debug gpios as early as possible
     kernel::debug::assign_gpios(Some(&peripherals.gpio_port[26]), None, None);
@@ -342,8 +342,8 @@ unsafe fn setup() -> (
         )
     );
 
-    let _ = &peripherals.iom0.set_master_client(i2c_master);
-    let _ = &peripherals.iom0.enable();
+    peripherals.iom0.set_master_client(i2c_master);
+    peripherals.iom0.enable();
 
     let mux_i2c = components::i2c::I2CMuxComponent::new(&peripherals.iom0, None).finalize(
         components::i2c_mux_component_static!(apollo3::iom::Iom<'static>),
@@ -429,10 +429,10 @@ unsafe fn setup() -> (
     mcu_ctrl.enable_ble();
     clkgen.enable_ble();
     pwr_ctrl.enable_ble();
-    let _ = &peripherals.ble.setup_clocks();
+    peripherals.ble.setup_clocks();
     mcu_ctrl.reset_ble();
-    let _ = &peripherals.ble.power_up();
-    let _ = &peripherals.ble.ble_initialise();
+    peripherals.ble.power_up();
+    peripherals.ble.ble_initialise();
 
     let ble_radio = components::ble::BLEComponent::new(
         board_kernel,

--- a/boards/apollo3/redboard_artemis_nano/src/io.rs
+++ b/boards/apollo3/redboard_artemis_nano/src/io.rs
@@ -37,7 +37,7 @@ impl IoWrite for Writer {
 /// Panic handler.
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(info: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     // just create a new pin reference here instead of using global
     let led_pin = &mut apollo3::gpio::GpioPin::new(
         kernel::utilities::StaticRef::new(

--- a/boards/apollo3/redboard_artemis_nano/src/main.rs
+++ b/boards/apollo3/redboard_artemis_nano/src/main.rs
@@ -206,15 +206,15 @@ unsafe fn setup() -> (
     pwr_ctrl.enable_ios();
 
     // Enable PinCfg
-    let _ = &peripherals
+    peripherals
         .gpio_port
         .enable_uart(&peripherals.gpio_port[48], &peripherals.gpio_port[49]);
     // Enable SDA and SCL for I2C2 (exposed via Qwiic)
-    let _ = &peripherals
+    peripherals
         .gpio_port
         .enable_i2c(&peripherals.gpio_port[25], &peripherals.gpio_port[27]);
     // Enable Main SPI
-    let _ = &peripherals.gpio_port.enable_spi(
+    peripherals.gpio_port.enable_spi(
         &peripherals.gpio_port[5],
         &peripherals.gpio_port[7],
         &peripherals.gpio_port[6],
@@ -304,8 +304,8 @@ unsafe fn setup() -> (
         )
     );
 
-    let _ = &peripherals.iom2.set_master_client(i2c_master);
-    let _ = &peripherals.iom2.enable();
+    peripherals.iom2.set_master_client(i2c_master);
+    peripherals.iom2.enable();
 
     let mux_i2c = components::i2c::I2CMuxComponent::new(&peripherals.iom2, None)
         .finalize(components::i2c_mux_component_static!(apollo3::iom::Iom));
@@ -357,10 +357,10 @@ unsafe fn setup() -> (
     mcu_ctrl.enable_ble();
     clkgen.enable_ble();
     pwr_ctrl.enable_ble();
-    let _ = &peripherals.ble.setup_clocks();
+    peripherals.ble.setup_clocks();
     mcu_ctrl.reset_ble();
-    let _ = &peripherals.ble.power_up();
-    let _ = &peripherals.ble.ble_initialise();
+    peripherals.ble.power_up();
+    peripherals.ble.ble_initialise();
 
     let ble_radio = components::ble::BLEComponent::new(
         board_kernel,

--- a/boards/arty_e21/src/io.rs
+++ b/boards/arty_e21/src/io.rs
@@ -39,7 +39,7 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // turn off the non panic leds, just in case
     let led_green = &sifive::gpio::GpioPin::new(
         arty_e21_chip::gpio::GPIO0_BASE,

--- a/boards/clue_nrf52840/src/io.rs
+++ b/boards/clue_nrf52840/src/io.rs
@@ -128,7 +128,7 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P1_01);
     let led = &mut led::LedHigh::new(led_kernel_pin);
     let writer = &mut WRITER;

--- a/boards/esp32-c3-devkitM-1/src/io.rs
+++ b/boards/esp32-c3-devkitM-1/src/io.rs
@@ -37,7 +37,7 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let writer = &mut WRITER;
 
     debug::panic_banner(writer, pi);
@@ -52,7 +52,7 @@ pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
 #[cfg(test)]
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let writer = &mut WRITER;
 
     debug::panic_print(

--- a/boards/hail/src/io.rs
+++ b/boards/hail/src/io.rs
@@ -59,7 +59,7 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // turn off the non panic leds, just in case
     let led_green = sam4l::gpio::GPIOPin::new(sam4l::gpio::Pin::PA14);
     led_green.enable_output();

--- a/boards/hifive1/src/io.rs
+++ b/boards/hifive1/src/io.rs
@@ -39,7 +39,7 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // turn off the non panic leds, just in case
     let led_green = sifive::gpio::GpioPin::new(
         e310_g002::gpio::GPIO0_BASE,

--- a/boards/hifive_inventor/src/io.rs
+++ b/boards/hifive_inventor/src/io.rs
@@ -38,7 +38,7 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led = sifive::gpio::GpioPin::new(
         e310_g003::gpio::GPIO0_BASE,
         sifive::gpio::pins::pin22,

--- a/boards/imix/src/imix_components/test/mod.rs
+++ b/boards/imix/src/imix_components/test/mod.rs
@@ -3,5 +3,3 @@
 // Copyright Tock Contributors 2022.
 
 pub mod mock_udp;
-
-pub use self::mock_udp::MockUDPComponent;

--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -61,7 +61,7 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_pin = sam4l::gpio::GPIOPin::new(sam4l::gpio::Pin::PC22);
     let led = &mut led::LedLow::new(&led_pin);
     let writer = &mut WRITER;

--- a/boards/imix/src/test/log_test.rs
+++ b/boards/imix/src/test/log_test.rs
@@ -300,7 +300,7 @@ impl<A: 'static + Alarm<'static>> LogTest<A> {
             .take()
             .map(
                 move |buffer| match self.log.read(buffer, buffer.len() + 1) {
-                    Ok(_) => panic!("Read with too-large max read length succeeded unexpectedly!"),
+                    Ok(()) => panic!("Read with too-large max read length succeeded unexpectedly!"),
                     Err((error, original_buffer)) => {
                         self.buffer.replace(original_buffer);
                         assert_eq!(error, ErrorCode::INVAL);
@@ -313,7 +313,7 @@ impl<A: 'static + Alarm<'static>> LogTest<A> {
         self.buffer
             .take()
             .map(move |buffer| match self.log.read(buffer, BUFFER_LEN - 1) {
-                Ok(_) => panic!("Read with too-small buffer succeeded unexpectedly!"),
+                Ok(()) => panic!("Read with too-small buffer succeeded unexpectedly!"),
                 Err((error, original_buffer)) => {
                     self.buffer.replace(original_buffer);
                     if self.read_val.get() == self.write_val.get() {
@@ -355,7 +355,7 @@ impl<A: 'static + Alarm<'static>> LogTest<A> {
         self.buffer
             .take()
             .map(move |buffer| match self.log.append(buffer, 0) {
-                Ok(_) => panic!("Appending entry of size 0 succeeded unexpectedly!"),
+                Ok(()) => panic!("Appending entry of size 0 succeeded unexpectedly!"),
                 Err((error, original_buffer)) => {
                     self.buffer.replace(original_buffer);
                     assert_eq!(error, ErrorCode::INVAL);
@@ -368,7 +368,7 @@ impl<A: 'static + Alarm<'static>> LogTest<A> {
             .take()
             .map(
                 move |buffer| match self.log.append(buffer, buffer.len() + 1) {
-                    Ok(_) => panic!("Appending with too-small buffer succeeded unexpectedly!"),
+                    Ok(()) => panic!("Appending with too-small buffer succeeded unexpectedly!"),
                     Err((error, original_buffer)) => {
                         self.buffer.replace(original_buffer);
                         assert_eq!(error, ErrorCode::INVAL);
@@ -380,7 +380,7 @@ impl<A: 'static + Alarm<'static>> LogTest<A> {
         // Ensure failure if entry is too large to fit within a single flash page.
         unsafe {
             match self.log.append(&mut DUMMY_BUFFER, DUMMY_BUFFER.len()) {
-                Ok(_) => panic!("Appending with too-small buffer succeeded unexpectedly!"),
+                Ok(()) => panic!("Appending with too-small buffer succeeded unexpectedly!"),
                 Err((ecode, _original_buffer)) => assert_eq!(ecode, ErrorCode::SIZE),
             }
         }

--- a/boards/imxrt1050-evkb/src/io.rs
+++ b/boards/imxrt1050-evkb/src/io.rs
@@ -67,7 +67,7 @@ impl IoWrite for Writer {
 /// Panic handler.
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(info: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     // User Led is connected to AdB0_09
     let pin = imxrt1050::gpio::Pin::from_pin_id(PinId::AdB0_09);
     let led = &mut led::LedLow::new(&pin);

--- a/boards/litex/arty/src/io.rs
+++ b/boards/litex/arty/src/io.rs
@@ -34,7 +34,7 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let panic_led = PANIC_REFERENCES
         .led_controller
         .and_then(|ctrl| ctrl.panic_led(0));

--- a/boards/litex/sim/src/io.rs
+++ b/boards/litex/sim/src/io.rs
@@ -34,7 +34,7 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let writer = &mut WRITER;
 
     debug::panic_print(

--- a/boards/microbit_v2/src/io.rs
+++ b/boards/microbit_v2/src/io.rs
@@ -99,7 +99,7 @@ impl led::Led for MatrixLed {
 #[cfg(not(test))]
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // MicroBit v2 has an LED matrix, use the upper left LED
     // let mut led = Led (&gpio::PORT[Pin::P0_28], );
 

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -546,7 +546,7 @@ unsafe fn start() -> (
         nrf52833::gpio::GPIOPin
     ));
 
-    let _ = &nrf52833_peripherals.gpio_port[LED_MICROPHONE_PIN].set_high_drive(true);
+    nrf52833_peripherals.gpio_port[LED_MICROPHONE_PIN].set_high_drive(true);
 
     let sound_pressure = components::sound_pressure::SoundPressureComponent::new(
         board_kernel,

--- a/boards/msp_exp432p401r/src/io.rs
+++ b/boards/msp_exp432p401r/src/io.rs
@@ -38,7 +38,7 @@ impl IoWrite for Uart {
 /// Panic handler
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(info: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     const LED1_PIN: IntPinNr = IntPinNr::P01_0;
     let gpio_pin = msp432::gpio::IntPin::new(LED1_PIN);
     let led = &mut led::LedHigh::new(&gpio_pin);

--- a/boards/nano33ble/src/io.rs
+++ b/boards/nano33ble/src/io.rs
@@ -128,7 +128,7 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut WRITER;

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -481,8 +481,8 @@ pub unsafe fn start() -> (
         nrf52840::pinmux::Pinmux::new(I2C_SDA_PIN as u32),
     );
 
-    let _ = &nrf52840_peripherals.gpio_port[I2C_PULLUP_PIN].make_output();
-    let _ = &nrf52840_peripherals.gpio_port[I2C_PULLUP_PIN].set();
+    nrf52840_peripherals.gpio_port[I2C_PULLUP_PIN].make_output();
+    nrf52840_peripherals.gpio_port[I2C_PULLUP_PIN].set();
 
     let apds9960 = components::apds9960::Apds9960Component::new(
         sensors_i2c_bus,

--- a/boards/nano33ble/src/test/linear_log_test.rs
+++ b/boards/nano33ble/src/test/linear_log_test.rs
@@ -163,7 +163,7 @@ impl<A: 'static + Alarm<'static>> LogTest<A> {
                 }
 
                 match self.log.read(buffer, buffer.len()) {
-                    Ok(_) => debug_verbose!("Dispatched asynchronous read operation."),
+                    Ok(()) => debug_verbose!("Dispatched asynchronous read operation."),
                     Err((return_code, buffer)) => {
                         self.buffer.replace(buffer);
                         match return_code {

--- a/boards/nano33ble/src/test/log_test.rs
+++ b/boards/nano33ble/src/test/log_test.rs
@@ -305,7 +305,7 @@ impl<A: 'static + Alarm<'static>> LogTest<A> {
             .take()
             .map(
                 move |buffer| match self.log.read(buffer, buffer.len() + 1) {
-                    Ok(_) => panic!("Read with too-large max read length succeeded unexpectedly!"),
+                    Ok(()) => panic!("Read with too-large max read length succeeded unexpectedly!"),
                     Err((error, original_buffer)) => {
                         self.buffer.replace(original_buffer);
                         assert_eq!(error, ErrorCode::INVAL);
@@ -318,7 +318,7 @@ impl<A: 'static + Alarm<'static>> LogTest<A> {
         self.buffer
             .take()
             .map(move |buffer| match self.log.read(buffer, BUFFER_LEN - 1) {
-                Ok(_) => panic!("Read with too-small buffer succeeded unexpectedly!"),
+                Ok(()) => panic!("Read with too-small buffer succeeded unexpectedly!"),
                 Err((error, original_buffer)) => {
                     self.buffer.replace(original_buffer);
                     if self.read_val.get() == self.write_val.get() {
@@ -360,7 +360,7 @@ impl<A: 'static + Alarm<'static>> LogTest<A> {
         self.buffer
             .take()
             .map(move |buffer| match self.log.append(buffer, 0) {
-                Ok(_) => panic!("Appending entry of size 0 succeeded unexpectedly!"),
+                Ok(()) => panic!("Appending entry of size 0 succeeded unexpectedly!"),
                 Err((error, original_buffer)) => {
                     self.buffer.replace(original_buffer);
                     assert_eq!(error, ErrorCode::INVAL);
@@ -373,7 +373,7 @@ impl<A: 'static + Alarm<'static>> LogTest<A> {
             .take()
             .map(
                 move |buffer| match self.log.append(buffer, buffer.len() + 1) {
-                    Ok(_) => panic!("Appending with too-small buffer succeeded unexpectedly!"),
+                    Ok(()) => panic!("Appending with too-small buffer succeeded unexpectedly!"),
                     Err((error, original_buffer)) => {
                         self.buffer.replace(original_buffer);
                         assert_eq!(error, ErrorCode::INVAL);
@@ -385,7 +385,7 @@ impl<A: 'static + Alarm<'static>> LogTest<A> {
         // Ensure failure if entry is too large to fit within a single flash page.
         unsafe {
             match self.log.append(&mut DUMMY_BUFFER, DUMMY_BUFFER.len()) {
-                Ok(_) => panic!("Appending with too-small buffer succeeded unexpectedly!"),
+                Ok(()) => panic!("Appending with too-small buffer succeeded unexpectedly!"),
                 Err((error, _original_buffer)) => assert_eq!(error, ErrorCode::SIZE),
             }
         }

--- a/boards/nano_rp2040_connect/src/io.rs
+++ b/boards/nano_rp2040_connect/src/io.rs
@@ -86,8 +86,8 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
-    // LED is conneted to GPIO 25
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
+    // LED is connected to GPIO 25
     let led_kernel_pin = &RPGpioPin::new(RPGpio::GPIO25);
     let led = &mut LedHigh::new(led_kernel_pin);
     let writer = &mut WRITER;

--- a/boards/nordic/nrf52840_dongle/src/io.rs
+++ b/boards/nordic/nrf52840_dongle/src/io.rs
@@ -59,7 +59,7 @@ impl IoWrite for Writer {
 #[no_mangle]
 #[panic_handler]
 /// Panic handler
-pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // The nRF52840 Dongle LEDs (see back of board)
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_06);
     let led = &mut led::LedLow::new(led_kernel_pin);

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -98,7 +98,7 @@ impl IoWrite for Writer {
 #[no_mangle]
 #[panic_handler]
 /// Panic handler
-pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // The nRF52840DK LEDs (see back of board)
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
     let led = &mut led::LedLow::new(led_kernel_pin);

--- a/boards/nordic/nrf52dk/src/io.rs
+++ b/boards/nordic/nrf52dk/src/io.rs
@@ -59,7 +59,7 @@ impl IoWrite for Writer {
 #[no_mangle]
 #[panic_handler]
 /// Panic handler
-pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // The nRF52 DK LEDs (see back of board)
     let led_kernel_pin = &nrf52832::gpio::GPIOPin::new(Pin::P0_17);
     let led = &mut led::LedLow::new(led_kernel_pin);

--- a/boards/nucleo_f429zi/src/io.rs
+++ b/boards/nucleo_f429zi/src/io.rs
@@ -70,7 +70,7 @@ impl IoWrite for Writer {
 /// Panic handler.
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(info: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     // User LD2 is connected to PB07
     // Have to reinitialize several peripherals because otherwise can't access them here.
     let rcc = stm32f429zi::rcc::Rcc::new();

--- a/boards/nucleo_f446re/src/io.rs
+++ b/boards/nucleo_f446re/src/io.rs
@@ -70,7 +70,7 @@ impl IoWrite for Writer {
 /// Panic handler.
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(info: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     // User LD2 is connected to PA05
     // Have to reinitialize several peripherals because otherwise can't access them here.
     let rcc = stm32f446re::rcc::Rcc::new();

--- a/boards/opentitan/src/io.rs
+++ b/boards/opentitan/src/io.rs
@@ -46,7 +46,7 @@ use kernel::hil::led;
 #[cfg(not(test))]
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let first_led_pin = &mut earlgrey::gpio::GpioPin::new(
         earlgrey::gpio::GPIO_BASE,
         earlgrey::pinmux::PadConfig::Output(
@@ -85,7 +85,7 @@ pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
 #[cfg(test)]
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let writer = &mut WRITER;
 
     #[cfg(feature = "sim_verilator")]

--- a/boards/particle_boron/src/io.rs
+++ b/boards/particle_boron/src/io.rs
@@ -67,7 +67,7 @@ const LED2_R_PIN: Pin = Pin::P0_13;
 #[no_mangle]
 #[panic_handler]
 /// Panic handler
-pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // The nRF52840DK LEDs (see back of board)
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(LED2_R_PIN);
     let led = &mut led::LedLow::new(led_kernel_pin);

--- a/boards/pico_explorer_base/src/io.rs
+++ b/boards/pico_explorer_base/src/io.rs
@@ -88,7 +88,7 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // LED is conneted to GPIO 25
     let led_kernel_pin = &RPGpioPin::new(RPGpio::GPIO25);
     let led = &mut LedHigh::new(led_kernel_pin);

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -429,7 +429,7 @@ pub unsafe fn main() {
     peripherals.adc.init();
 
     // Set PWM function for Buzzer.
-    let _ = &peripherals
+    peripherals
         .pins
         .get_pin(RPGpio::GPIO2)
         .set_function(GpioFunction::PWM);

--- a/boards/qemu_rv32_virt/src/io.rs
+++ b/boards/qemu_rv32_virt/src/io.rs
@@ -36,7 +36,7 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let writer = &mut WRITER;
 
     debug::panic_print::<_, _, _>(

--- a/boards/raspberry_pi_pico/src/io.rs
+++ b/boards/raspberry_pi_pico/src/io.rs
@@ -88,8 +88,8 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
-    // LED is conneted to GPIO 25
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
+    // LED is connected to GPIO 25
     let led_kernel_pin = &RPGpioPin::new(RPGpio::GPIO25);
     let led = &mut LedHigh::new(led_kernel_pin);
     let writer = &mut WRITER;

--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -452,7 +452,7 @@ pub unsafe fn main() {
     // RTC DATE TIME
 
     match peripherals.rtc.rtc_init() {
-        Ok(_) => {}
+        Ok(()) => {}
         Err(e) => {
             debug!("error starting rtc {:?}", e);
         }

--- a/boards/redboard_redv/src/io.rs
+++ b/boards/redboard_redv/src/io.rs
@@ -39,7 +39,7 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // turn off the non panic leds, just in case
     let led_green = sifive::gpio::GpioPin::new(
         e310_g002::gpio::GPIO0_BASE,

--- a/boards/sma_q3/src/io.rs
+++ b/boards/sma_q3/src/io.rs
@@ -74,7 +74,7 @@ impl IoWrite for Writer {
 #[no_mangle]
 #[panic_handler]
 /// Panic handler
-pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // The display LEDs (see back of board)
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
     let led = &mut led::LedLow::new(led_kernel_pin);

--- a/boards/stm32f3discovery/src/io.rs
+++ b/boards/stm32f3discovery/src/io.rs
@@ -68,7 +68,7 @@ impl IoWrite for Writer {
 /// Panic handler.
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(info: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     // User LD3 is connected to PE09
     // Have to reinitialize several peripherals because otherwise can't access them here.
     let rcc = stm32f303xc::rcc::Rcc::new();

--- a/boards/stm32f412gdiscovery/src/io.rs
+++ b/boards/stm32f412gdiscovery/src/io.rs
@@ -71,7 +71,7 @@ impl IoWrite for Writer {
 /// Panic handler.
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(info: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     // User LD2 is connected to PB07
     // Have to reinitialize several peripherals because otherwise can't access them here.
     let rcc = stm32f412g::rcc::Rcc::new();

--- a/boards/stm32f429idiscovery/src/io.rs
+++ b/boards/stm32f429idiscovery/src/io.rs
@@ -71,7 +71,7 @@ impl IoWrite for Writer {
 /// Panic handler.
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(info: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     // User LD4 is connected to PG14
     // Have to reinitialize several peripherals because otherwise can't access them here.
     let rcc = stm32f429zi::rcc::Rcc::new();

--- a/boards/swervolf/src/io.rs
+++ b/boards/swervolf/src/io.rs
@@ -40,7 +40,7 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let writer = &mut WRITER;
 
     debug::panic_print(

--- a/boards/weact_f401ccu6/src/io.rs
+++ b/boards/weact_f401ccu6/src/io.rs
@@ -70,7 +70,7 @@ impl IoWrite for Writer {
 /// Panic handler.
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(info: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     // On-board LED C13 is connected to PC13
     // Have to reinitialize several peripherals because otherwise can't access them here.
     let rcc = stm32f401cc::rcc::Rcc::new();

--- a/boards/wm1110dev/src/io.rs
+++ b/boards/wm1110dev/src/io.rs
@@ -72,7 +72,7 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[no_mangle]
 #[panic_handler]
-pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // Red Led
     let led_red_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_14);
     let led = &mut led::LedHigh::new(led_red_pin);

--- a/boards/wm1110dev/src/main.rs
+++ b/boards/wm1110dev/src/main.rs
@@ -319,8 +319,8 @@ pub unsafe fn start() -> (
     //--------------------------------------------------------------------------
 
     // Enable the power supply for the I2C bus and attached sensors.
-    let _ = &nrf52840_peripherals.gpio_port[I2C_PWR].make_output();
-    let _ = &nrf52840_peripherals.gpio_port[I2C_PWR].set();
+    nrf52840_peripherals.gpio_port[I2C_PWR].make_output();
+    nrf52840_peripherals.gpio_port[I2C_PWR].set();
 
     let mux_i2c = components::i2c::I2CMuxComponent::new(&base_peripherals.twi1, None)
         .finalize(components::i2c_mux_component_static!(nrf52840::i2c::TWI));

--- a/capsules/core/src/i2c_master.rs
+++ b/capsules/core/src/i2c_master.rs
@@ -94,7 +94,7 @@ impl<'a, I: i2c::I2CMaster<'a>> I2CMasterDriver<'a, I> {
                             Cmd::WriteRead => self.i2c.write_read(addr, buffer, wlen, rlen),
                         };
                         match res {
-                            Ok(_) => Ok(()),
+                            Ok(()) => Ok(()),
                             Err((error, data)) => {
                                 self.buf.put(Some(data));
                                 Err(error.into())

--- a/capsules/core/src/i2c_master_slave_driver.rs
+++ b/capsules/core/src/i2c_master_slave_driver.rs
@@ -106,7 +106,7 @@ impl<'a, I: hil::i2c::I2CMasterSlave<'a>> hil::i2c::I2CHwMasterClient
     fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), hil::i2c::Error>) {
         // Map I2C error to a number we can pass back to the application
         let status = kernel::errorcode::into_statuscode(match status {
-            Ok(_) => Ok(()),
+            Ok(()) => Ok(()),
             Err(e) => Err(e.into()),
         });
 

--- a/capsules/core/src/virtualizers/virtual_aes_ccm.rs
+++ b/capsules/core/src/virtualizers/virtual_aes_ccm.rs
@@ -300,7 +300,7 @@ impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC + AES128ECB> VirtualAES128CCM<'a,
                     SResult::Needed(_) => {
                         return Err(ErrorCode::NOMEM);
                     }
-                    SResult::Error(_) => {
+                    SResult::Error(()) => {
                         return Err(ErrorCode::FAIL);
                     }
                 };

--- a/capsules/core/src/virtualizers/virtual_i2c.rs
+++ b/capsules/core/src/virtualizers/virtual_i2c.rs
@@ -83,7 +83,7 @@ impl<'a, I: i2c::I2CMaster<'a>, S: i2c::SMBusMaster<'a>> MuxI2C<'a, I, S> {
                 node.buffer.take().map(|buf| {
                     match node.operation.get() {
                         Op::Write(len) => match self.i2c.write(node.addr, buf, len) {
-                            Ok(_) => {}
+                            Ok(()) => {}
                             Err((error, buffer)) => {
                                 node.buffer.replace(buffer);
                                 node.operation.set(Op::CommandComplete(Err(error)));
@@ -91,7 +91,7 @@ impl<'a, I: i2c::I2CMaster<'a>, S: i2c::SMBusMaster<'a>> MuxI2C<'a, I, S> {
                             }
                         },
                         Op::Read(len) => match self.i2c.read(node.addr, buf, len) {
-                            Ok(_) => {}
+                            Ok(()) => {}
                             Err((error, buffer)) => {
                                 node.buffer.replace(buffer);
                                 node.operation.set(Op::CommandComplete(Err(error)));
@@ -100,7 +100,7 @@ impl<'a, I: i2c::I2CMaster<'a>, S: i2c::SMBusMaster<'a>> MuxI2C<'a, I, S> {
                         },
                         Op::WriteRead(wlen, rlen) => {
                             match self.i2c.write_read(node.addr, buf, wlen, rlen) {
-                                Ok(_) => {}
+                                Ok(()) => {}
                                 Err((error, buffer)) => {
                                     node.buffer.replace(buffer);
                                     node.operation.set(Op::CommandComplete(Err(error)));
@@ -128,7 +128,7 @@ impl<'a, I: i2c::I2CMaster<'a>, S: i2c::SMBusMaster<'a>> MuxI2C<'a, I, S> {
                     node.buffer.take().map(|buf| match node.operation.get() {
                         Op::Write(len) => {
                             match self.smbus.unwrap().smbus_write(node.addr, buf, len) {
-                                Ok(_) => {}
+                                Ok(()) => {}
                                 Err(e) => {
                                     node.buffer.replace(e.1);
                                     node.operation.set(Op::CommandComplete(Err(e.0)));
@@ -138,7 +138,7 @@ impl<'a, I: i2c::I2CMaster<'a>, S: i2c::SMBusMaster<'a>> MuxI2C<'a, I, S> {
                         }
                         Op::Read(len) => {
                             match self.smbus.unwrap().smbus_read(node.addr, buf, len) {
-                                Ok(_) => {}
+                                Ok(()) => {}
                                 Err(e) => {
                                     node.buffer.replace(e.1);
                                     node.operation.set(Op::CommandComplete(Err(e.0)));
@@ -152,7 +152,7 @@ impl<'a, I: i2c::I2CMaster<'a>, S: i2c::SMBusMaster<'a>> MuxI2C<'a, I, S> {
                                 .unwrap()
                                 .smbus_write_read(node.addr, buf, wlen, rlen)
                             {
-                                Ok(_) => {}
+                                Ok(()) => {}
                                 Err(e) => {
                                     node.buffer.replace(e.1);
                                     node.operation.set(Op::CommandComplete(Err(e.0)));

--- a/capsules/extra/src/ble_advertising_driver.rs
+++ b/capsules/extra/src/ble_advertising_driver.rs
@@ -637,7 +637,7 @@ where
                     .map_or_else(
                         |err| CommandReturn::failure(err.into()),
                         |res| match res {
-                            Ok(_) => {
+                            Ok(()) => {
                                 // must be called outside closure passed to grant region!
                                 self.reset_active_alarm();
                                 CommandReturn::success()
@@ -705,7 +705,7 @@ where
                     .map_or_else(
                         |err| err.into(),
                         |res| match res {
-                            Ok(_) => {
+                            Ok(()) => {
                                 // must be called outside closure passed to grant region!
                                 self.reset_active_alarm();
                                 CommandReturn::success()

--- a/capsules/extra/src/can.rs
+++ b/capsules/extra/src/can.rs
@@ -175,7 +175,7 @@ impl<'a, Can: can::Can> CanCapsule<'a, Can> {
                                                 dest_buffer[i] = buffer[i].get();
                                             }
                                             match self.can.send(id, dest_buffer, length) {
-                                                Ok(_) => Ok(()),
+                                                Ok(()) => Ok(()),
                                                 Err((err, buf)) => {
                                                     self.can_tx.replace(buf);
                                                     Err(err)
@@ -225,7 +225,7 @@ impl<'a, Can: can::Can> SyscallDriver for CanCapsule<'a, Can> {
         match command_num {
             // Set the bitrate
             1 => match self.can.set_bitrate(arg1 as u32) {
-                Ok(_) => CommandReturn::success(),
+                Ok(()) => CommandReturn::success(),
                 Err(err) => CommandReturn::failure(err),
             },
 
@@ -237,20 +237,20 @@ impl<'a, Can: can::Can> SyscallDriver for CanCapsule<'a, Can> {
                     2 => can::OperationMode::Freeze,
                     _ => can::OperationMode::Normal,
                 }) {
-                    Ok(_) => CommandReturn::success(),
+                    Ok(()) => CommandReturn::success(),
                     Err(err) => CommandReturn::failure(err),
                 }
             }
 
             // Enable the peripheral
             3 => match self.can.enable() {
-                Ok(_) => CommandReturn::success(),
+                Ok(()) => CommandReturn::success(),
                 Err(err) => CommandReturn::failure(err),
             },
 
             // Disable the peripheral
             4 => match self.can.disable() {
-                Ok(_) => CommandReturn::success(),
+                Ok(()) => CommandReturn::success(),
                 Err(err) => CommandReturn::failure(err),
             },
 
@@ -261,7 +261,7 @@ impl<'a, Can: can::Can> SyscallDriver for CanCapsule<'a, Can> {
                     .map_or(
                         CommandReturn::failure(ErrorCode::BUSY),
                         |processid| match self.process_send_command(processid, id, arg2) {
-                            Ok(_) => CommandReturn::success(),
+                            Ok(()) => CommandReturn::success(),
                             Err(err) => CommandReturn::failure(err),
                         },
                     )
@@ -274,7 +274,7 @@ impl<'a, Can: can::Can> SyscallDriver for CanCapsule<'a, Can> {
                     .map_or(
                         CommandReturn::failure(ErrorCode::BUSY),
                         |processid| match self.process_send_command(processid, id, arg2) {
-                            Ok(_) => CommandReturn::success(),
+                            Ok(()) => CommandReturn::success(),
                             Err(err) => CommandReturn::failure(err),
                         },
                     )
@@ -306,8 +306,8 @@ impl<'a, Can: can::Can> SyscallDriver for CanCapsule<'a, Can> {
                                             .unwrap_or_else(|err| err.into())
                                     },
                                 ) {
-                                    Ok(_) => match self.can.start_receive_process(dest_buffer) {
-                                        Ok(_) => CommandReturn::success(),
+                                    Ok(()) => match self.can.start_receive_process(dest_buffer) {
+                                        Ok(()) => CommandReturn::success(),
                                         Err((err, _)) => CommandReturn::failure(err),
                                     },
                                     Err(err) => CommandReturn::failure(err),
@@ -319,7 +319,7 @@ impl<'a, Can: can::Can> SyscallDriver for CanCapsule<'a, Can> {
 
             // Stop receiving messages
             8 => match self.can.stop_receive() {
-                Ok(_) => CommandReturn::success(),
+                Ok(()) => CommandReturn::success(),
                 Err(err) => CommandReturn::failure(err),
             },
 
@@ -332,7 +332,7 @@ impl<'a, Can: can::Can> SyscallDriver for CanCapsule<'a, Can> {
                     sync_jump_width: ((arg1 & BYTE2_MASK) >> 8) as u32,
                     baud_rate_prescaler: (arg1 & BYTE1_MASK) as u32,
                 }) {
-                    Ok(_) => CommandReturn::success(),
+                    Ok(()) => CommandReturn::success(),
                     Err(err) => CommandReturn::failure(err),
                 }
             }
@@ -360,7 +360,7 @@ impl<'a, Can: can::Can> can::ControllerClient for CanCapsule<'a, Can> {
     // error callback.
     fn enabled(&self, status: Result<(), ErrorCode>) {
         match status {
-            Ok(_) => match self.peripheral_state.take() {
+            Ok(()) => match self.peripheral_state.take() {
                 Some(can::State::Running) => {
                     self.schedule_callback(up_calls::UPCALL_ENABLE, (0, 0, 0));
                 }
@@ -388,7 +388,7 @@ impl<'a, Can: can::Can> can::ControllerClient for CanCapsule<'a, Can> {
     // error callback.
     fn disabled(&self, status: Result<(), ErrorCode>) {
         match status {
-            Ok(_) => match self.peripheral_state.take() {
+            Ok(()) => match self.peripheral_state.take() {
                 Some(can::State::Disabled) => {
                     self.schedule_callback(up_calls::UPCALL_DISABLE, (0, 0, 0));
                 }
@@ -449,7 +449,7 @@ impl<'a, Can: can::Can> can::ReceiveClient<{ can::STANDARD_CAN_PACKET_SIZE }>
         let mut new_buffer = false;
         let mut shared_len = 0;
         match status {
-            Ok(_) => {
+            Ok(()) => {
                 match self.processid.map_or(Err(ErrorCode::NOMEM), |processid| {
                     self.processes
                         .enter(processid, |app_data, kernel_data| {
@@ -502,7 +502,7 @@ impl<'a, Can: can::Can> can::ReceiveClient<{ can::STANDARD_CAN_PACKET_SIZE }>
                         up_calls::UPCALL_TRANSMISSION_ERROR,
                         (error_upcalls::ERROR_RX, err as usize, 0),
                     ),
-                    Ok(_) => {
+                    Ok(()) => {
                         if new_buffer {
                             self.schedule_callback(
                                 up_calls::UPCALL_MESSAGE_RECEIVED,

--- a/capsules/extra/src/crc.rs
+++ b/capsules/extra/src/crc.rs
@@ -366,7 +366,7 @@ impl<'a, C: Crc<'a>> SyscallDriver for CrcDriver<'a, C> {
                         if self.current_process.is_none() {
                             self.next_request().map_or_else(
                                 |e| CommandReturn::failure(ErrorCode::into(e)),
-                                |_| CommandReturn::success(),
+                                |()| CommandReturn::success(),
                             )
                         } else {
                             // Another request is ongoing. We've enqueued this one,

--- a/capsules/extra/src/date_time.rs
+++ b/capsules/extra/src/date_time.rs
@@ -234,7 +234,7 @@ impl<'a, DateTime: date_time::DateTime<'a>> DateTimeCapsule<'a, DateTime> {
         if self.in_progress.is_none() {
             match grant_enter_res {
                 Ok(_) => match self.call_driver(command, processid) {
-                    Ok(_) => CommandReturn::success(),
+                    Ok(()) => CommandReturn::success(),
                     Err(e) => CommandReturn::failure(e),
                 },
                 Err(_e) => CommandReturn::failure(ErrorCode::FAIL),
@@ -254,7 +254,7 @@ impl<'a, DateTime: date_time::DateTime<'a>> DateTimeCapsule<'a, DateTime> {
                 app.task.map_or(None, |command| {
                     let command_return = self.call_driver(command, processid);
                     match command_return {
-                        Ok(_) => Some(()),
+                        Ok(()) => Some(()),
                         Err(e) => {
                             let upcall_status = into_statuscode(Err(e));
                             kernel.schedule_upcall(0, (upcall_status, 0, 0)).ok();

--- a/capsules/extra/src/hmac.rs
+++ b/capsules/extra/src/hmac.rs
@@ -411,7 +411,7 @@ impl<
                         });
 
                     match result {
-                        Ok(_) => kernel_data.schedule_upcall(0, (0, pointer as usize, 0)),
+                        Ok(()) => kernel_data.schedule_upcall(0, (0, pointer as usize, 0)),
                         Err(e) => kernel_data
                             .schedule_upcall(0, (into_statuscode(e.into()), pointer as usize, 0)),
                     }

--- a/capsules/extra/src/hmac_sha256.rs
+++ b/capsules/extra/src/hmac_sha256.rs
@@ -425,7 +425,7 @@ impl<'a, S: hil::digest::Sha256 + hil::digest::DigestDataHash<'a, 32>> hil::dige
                     // self.verify_client.map(|c| {
                     self.client.map(|c| {
                         // Convert to Result<bool, ErrorCode>
-                        c.verification_done(error.map(|_| false), compare);
+                        c.verification_done(error.map(|()| false), compare);
                     })
                 }
             }

--- a/capsules/extra/src/ieee802154/driver.rs
+++ b/capsules/extra/src/ieee802154/driver.rs
@@ -765,7 +765,7 @@ impl SyscallDriver for RadioDriver<'_> {
                 .unwrap_or_else(|err| CommandReturn::failure(err.into())),
 
             18 => match self.remove_neighbor(arg1) {
-                Ok(_) => CommandReturn::success(),
+                Ok(()) => CommandReturn::success(),
                 Err(e) => CommandReturn::failure(e),
             },
             19 => {
@@ -906,7 +906,7 @@ impl SyscallDriver for RadioDriver<'_> {
                     .map_or_else(
                         |err| CommandReturn::failure(err.into()),
                         |setup_tx| match setup_tx {
-                            Ok(_) => self.do_next_tx_sync(processid).into(),
+                            Ok(()) => self.do_next_tx_sync(processid).into(),
                             Err(e) => CommandReturn::failure(e),
                         },
                     )

--- a/capsules/extra/src/max17205.rs
+++ b/capsules/extra/src/max17205.rs
@@ -230,7 +230,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for MAX17205<'_, I> {
                     client.status(
                         status,
                         match error {
-                            Ok(_) => Ok(()),
+                            Ok(()) => Ok(()),
                             Err(e) => Err(e.into()),
                         },
                     )
@@ -281,7 +281,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for MAX17205<'_, I> {
                         self.soc_mah.get(),
                         full_mah,
                         match error {
-                            Ok(_) => Ok(()),
+                            Ok(()) => Ok(()),
                             Err(e) => Err(e.into()),
                         },
                     );
@@ -305,7 +305,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for MAX17205<'_, I> {
                     client.coulomb(
                         coulomb,
                         match error {
-                            Ok(_) => Ok(()),
+                            Ok(()) => Ok(()),
                             Err(e) => Err(e.into()),
                         },
                     );
@@ -352,7 +352,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for MAX17205<'_, I> {
                         self.voltage.get(),
                         current,
                         match error {
-                            Ok(_) => Ok(()),
+                            Ok(()) => Ok(()),
                             Err(e) => Err(e.into()),
                         },
                     )
@@ -380,7 +380,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for MAX17205<'_, I> {
                     client.romid(
                         rid,
                         match error {
-                            Ok(_) => Ok(()),
+                            Ok(()) => Ok(()),
                             Err(e) => Err(e.into()),
                         },
                     )

--- a/capsules/extra/src/net/sixlowpan/sixlowpan_state.rs
+++ b/capsules/extra/src/net/sixlowpan/sixlowpan_state.rs
@@ -487,7 +487,7 @@ impl<'a> TxState<'a> {
                 self.dst_mac_addr.get(),
                 &mut lowpan_packet,
             ) {
-                Err(_) => return Err((Err(ErrorCode::FAIL), frame.into_buf())),
+                Err(()) => return Err((Err(ErrorCode::FAIL), frame.into_buf())),
                 Ok(result) => result,
             }
         };
@@ -735,7 +735,7 @@ impl<'a> RxState<'a> {
                 dgram_size,
                 true,
             )
-            .map_err(|_| Err(ErrorCode::FAIL))?;
+            .map_err(|()| Err(ErrorCode::FAIL))?;
             let remaining = payload_len - consumed;
             packet[written..written + remaining]
                 .copy_from_slice(&payload[consumed..consumed + remaining]);
@@ -955,7 +955,7 @@ impl<'a, A: time::Alarm<'a>, C: ContextStore> Sixlowpan<'a, A, C> {
                     // Want dgram_size to contain decompressed size of packet
                     state.dgram_size.set((written + remaining) as u16);
                 }
-                Err(_) => {
+                Err(()) => {
                     return (None, Err(ErrorCode::FAIL));
                 }
             }

--- a/capsules/extra/src/net/thread/driver.rs
+++ b/capsules/extra/src/net/thread/driver.rs
@@ -394,7 +394,7 @@ impl<'a, A: time::Alarm<'a>> ThreadNetworkDriver<'a, A> {
             return Err((ErrorCode::FAIL, buf));
         }
 
-        let (offset, _) = encode_res.unwrap();
+        let (offset, ()) = encode_res.unwrap();
 
         // GENERAL NOTE: `self.crypto_sizelock`
         // This does not seem to be the most elegant solution. The `crypto_sizelock` arose from the fact
@@ -619,7 +619,7 @@ impl<'a, A: time::Alarm<'a>> UDPRecvClient for ThreadNetworkDriver<'a, A> {
                         );
                         self.recv_buffer.replace(SubSliceMut::new(buf));
                     },
-                    |_| (),
+                    |()| (),
                 )
             },
         );

--- a/capsules/extra/src/net/thread/tlv.rs
+++ b/capsules/extra/src/net/thread/tlv.rs
@@ -125,7 +125,7 @@ pub enum Tlv<'a> {
 
 pub fn unwrap_tlv_offset(res: SResult) -> usize {
     match res {
-        SResult::Done(val, _) => val,
+        SResult::Done(val, ()) => val,
         _ => 0,
     }
 }

--- a/capsules/extra/src/net/udp/driver.rs
+++ b/capsules/extra/src/net/udp/driver.rs
@@ -259,7 +259,7 @@ impl<'a> UDPDriver<'a> {
                                     self.driver_send_cap,
                                     self.net_cap,
                                 ) {
-                                    Ok(_) => Ok(()),
+                                    Ok(()) => Ok(()),
                                     Err(mut buf) => {
                                         buf.reset();
                                         self.kernel_buffer.replace(buf);
@@ -469,7 +469,7 @@ impl<'a> SyscallDriver for UDPDriver<'a> {
                     })
                     .unwrap_or_else(|err| Err(err.into()));
                 match res {
-                    Ok(_) => self.do_next_tx_immediate(processid).map_or_else(
+                    Ok(()) => self.do_next_tx_immediate(processid).map_or_else(
                         |err| CommandReturn::failure(err),
                         |v| CommandReturn::success_u32(v),
                     ),
@@ -544,7 +544,7 @@ impl<'a> SyscallDriver for UDPDriver<'a> {
                                             })
                                     }
                                 }
-                                Err(_) => CommandReturn::failure(ErrorCode::FAIL), //error in port table
+                                Err(()) => CommandReturn::failure(ErrorCode::FAIL), //error in port table
                             }
                         })
                     }

--- a/capsules/extra/src/net/udp/udp_port_table.rs
+++ b/capsules/extra/src/net/udp/udp_port_table.rs
@@ -274,7 +274,7 @@ impl UdpPortManager {
                             .unwrap()
                     }
                 }
-                Err(_) => Err(socket),
+                Err(()) => Err(socket),
             }
         } else {
             Err(socket)

--- a/capsules/extra/src/read_only_state.rs
+++ b/capsules/extra/src/read_only_state.rs
@@ -106,7 +106,7 @@ impl<'a, T: Time> SyscallDriver for ReadOnlyStateDriver<'a, T> {
                 core::mem::swap(&mut data.mem_region, &mut slice);
             });
             match res {
-                Ok(_) => Ok(slice),
+                Ok(()) => Ok(slice),
                 Err(e) => Err((slice, e.into())),
             }
         } else {

--- a/capsules/extra/src/sdcard.rs
+++ b/capsules/extra/src/sdcard.rs
@@ -1537,7 +1537,6 @@ impl<'a, A: hil::time::Alarm<'a>> SDCardClient for SDCardDriver<'a, A> {
                         .get_readwrite_processbuffer(rw_allow::READ)
                         .and_then(|read| {
                             read.mut_enter(|read_buffer| {
-                                let read_buffer = read_buffer;
                                 // copy bytes to user buffer
                                 // Limit to minimum length between read_buffer, data, and
                                 // len field

--- a/capsules/extra/src/sha.rs
+++ b/capsules/extra/src/sha.rs
@@ -386,7 +386,7 @@ impl<
                         });
 
                     match result {
-                        Ok(_) => kernel_data
+                        Ok(()) => kernel_data
                             .schedule_upcall(0, (0, pointer as usize, 0))
                             .ok(),
                         Err(e) => kernel_data

--- a/capsules/extra/src/sht4x.rs
+++ b/capsules/extra/src/sht4x.rs
@@ -134,7 +134,7 @@ impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> SHT4x<'a, A, I> {
 
             let _res = self.i2c.write(buffer, 1);
             match _res {
-                Ok(_) => Ok(()),
+                Ok(()) => Ok(()),
                 Err((error, data)) => {
                     self.buffer.replace(data);
                     self.state.set(State::Idle);

--- a/capsules/extra/src/st77xx.rs
+++ b/capsules/extra/src/st77xx.rs
@@ -161,7 +161,6 @@ const COLMOD: Command = Command {
 
 const MADCTL: Command = Command {
     id: 0x36,
-    /// Default Parameters:
     parameters: Some(&[0x00]),
     delay: 0,
 };
@@ -892,84 +891,73 @@ impl<'a, A: Alarm<'a>, B: Bus<'a>, P: Pin> bus::Client for ST77XX<'a, A, B, P> {
 #[allow(dead_code)]
 const GAMSET: Command = Command {
     id: 0x26,
-    /// Default parameters: Gama Set
+    // Default parameters: Gama Set
     parameters: Some(&[0]),
     delay: 0,
 };
 
 const FRMCTR1: Command = Command {
     id: 0xB1,
-    /// Default Parameters:
     parameters: Some(&[0x01, 0x2C, 0x2D]),
     delay: 0,
 };
 
 const FRMCTR2: Command = Command {
     id: 0xB2,
-    /// Default Parameters:
     parameters: Some(&[0x01, 0x2C, 0x2D]),
     delay: 0,
 };
 
 const FRMCTR3: Command = Command {
     id: 0xB3,
-    /// Default Parameters:
     parameters: Some(&[0x01, 0x2C, 0x2D, 0x01, 0x2C, 0x2D]),
     delay: 0,
 };
 
 const INVCTR: Command = Command {
     id: 0xB4,
-    /// Default Parameters:
     parameters: Some(&[0x07]),
     delay: 0,
 };
 
 const PWCTR1: Command = Command {
     id: 0xC0,
-    /// Default Parameters:
     parameters: Some(&[0xA2, 0x02, 0x84]),
     delay: 0,
 };
 
 const PWCTR2: Command = Command {
     id: 0xC1,
-    /// Default Parameters:
     parameters: Some(&[0xC5]),
     delay: 0,
 };
 
 const PWCTR3: Command = Command {
     id: 0xC2,
-    /// Default Parameters:
     parameters: Some(&[0x0A, 0x00]),
     delay: 0,
 };
 
 const PWCTR4: Command = Command {
     id: 0xC3,
-    /// Default Parameters:
     parameters: Some(&[0x8A, 0x2A]),
     delay: 0,
 };
 
 const PWCTR5: Command = Command {
     id: 0xC4,
-    /// Default Parameters:
     parameters: Some(&[0x8A, 0xEE]),
     delay: 0,
 };
 
 const VMCTR1: Command = Command {
     id: 0xC5,
-    /// Default Parameters:
     parameters: Some(&[0x0E]),
     delay: 0,
 };
 
 const GMCTRP1: Command = Command {
     id: 0xE0,
-    /// Default Parameters:
     parameters: Some(&[
         0x02, 0x1c, 0x07, 0x12, 0x37, 0x32, 0x29, 0x2d, 0x29, 0x25, 0x2B, 0x39, 0x00, 0x01, 0x03,
         0x10,
@@ -979,7 +967,6 @@ const GMCTRP1: Command = Command {
 
 const GMCTRN1: Command = Command {
     id: 0xE1,
-    /// Default Parameters:
     parameters: Some(&[
         0x03, 0x1d, 0x07, 0x06, 0x2E, 0x2C, 0x29, 0x2D, 0x2E, 0x2E, 0x37, 0x3F, 0x00, 0x00, 0x02,
         0x10,

--- a/capsules/extra/src/test/udp.rs
+++ b/capsules/extra/src/test/udp.rs
@@ -168,7 +168,7 @@ impl<'a, A: Alarm<'a>> MockUdp<'a, A> {
                     dgram,
                     self.net_cap.get(),
                 ) {
-                    Ok(_) => Ok(()),
+                    Ok(()) => Ok(()),
                     Err(mut buf) => {
                         buf.reset();
                         self.udp_dgram.replace(buf);

--- a/capsules/extra/src/usb/descriptors.rs
+++ b/capsules/extra/src/usb/descriptors.rs
@@ -30,7 +30,7 @@ pub struct Buffer64 {
 impl Default for Buffer64 {
     fn default() -> Self {
         Self {
-            buf: [(); 64].map(|_| VolatileCell::default()),
+            buf: [(); 64].map(|()| VolatileCell::default()),
         }
     }
 }

--- a/capsules/extra/src/usb_hid_driver.rs
+++ b/capsules/extra/src/usb_hid_driver.rs
@@ -239,7 +239,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> SyscallDriver for UsbHidDriver<'a, U>
                         app.can_receive.set(true);
                         if let Some(buf) = self.recv_buffer.take() {
                             match usb.receive_buffer(buf) {
-                                Ok(_) => CommandReturn::success(),
+                                Ok(()) => CommandReturn::success(),
                                 Err((err, buffer)) => {
                                     self.recv_buffer.replace(buffer);
                                     CommandReturn::failure(err)
@@ -317,7 +317,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> SyscallDriver for UsbHidDriver<'a, U>
                             app.can_receive.set(true);
                             if let Some(buf) = self.recv_buffer.take() {
                                 match usb.receive_buffer(buf) {
-                                    Ok(_) => CommandReturn::success(),
+                                    Ok(()) => CommandReturn::success(),
                                     Err((err, buffer)) => {
                                         self.recv_buffer.replace(buffer);
                                         return CommandReturn::failure(err);

--- a/chips/litex/src/litex_registers.rs
+++ b/chips/litex/src/litex_registers.rs
@@ -18,7 +18,7 @@
 //!
 //! The different register types of a specific SoC configuration are
 //! combined using a
-//! [`LiteXSoCRegisterConfiguration`](crate::litex_registers::LiteXSoCRegisterConfiguration)
+//! [`LiteXSoCRegisterConfiguration`]
 //! structure, which can be used to adapt the register interfaces of
 //! peripherals to the different configurations.
 //!

--- a/chips/litex/src/timer.rs
+++ b/chips/litex/src/timer.rs
@@ -348,7 +348,7 @@ impl<'a, R: LiteXSoCRegisterConfiguration, F: Frequency> Timer<'a> for LiteXTime
 /// LiteX does not have an [`Alarm`] compatible hardware peripheral,
 /// so an [`Alarm`] is emulated using a repeatedly set [`LiteXTimer`],
 /// comparing the current time against the [`LiteXTimerUptime`] (which
-/// is also exposed as [`Time::now`](Time::now).
+/// is also exposed as [`Time::now`].
 pub struct LiteXAlarm<'t, 'c, R: LiteXSoCRegisterConfiguration, F: Frequency> {
     uptime: &'t LiteXTimerUptime<'t, R, F>,
     timer: &'t LiteXTimer<'t, R, F>,

--- a/chips/nrf52/src/ble_radio.rs
+++ b/chips/nrf52/src/ble_radio.rs
@@ -822,7 +822,7 @@ impl ble_advertising::BleConfig for Radio<'_> {
         // Convert u8 to TxPower
         match nrf5x::constants::TxPower::try_from(tx_power) {
             // Invalid transmitting power, propogate error
-            Err(_) => Err(ErrorCode::NOSUPPORT),
+            Err(()) => Err(ErrorCode::NOSUPPORT),
             // Valid transmitting power, propogate success
             Ok(res) => {
                 self.tx_power.set(res);

--- a/chips/nrf52840/src/ieee802154_radio.rs
+++ b/chips/nrf52840/src/ieee802154_radio.rs
@@ -1303,7 +1303,7 @@ impl<'a> kernel::hil::radio::RadioConfig<'a> for Radio<'a> {
 
     fn set_channel(&self, chan: u8) -> Result<(), ErrorCode> {
         match RadioChannel::try_from(chan) {
-            Err(_) => Err(ErrorCode::NOSUPPORT),
+            Err(()) => Err(ErrorCode::NOSUPPORT),
             Ok(res) => {
                 self.channel.set(res);
                 Ok(())
@@ -1315,7 +1315,7 @@ impl<'a> kernel::hil::radio::RadioConfig<'a> for Radio<'a> {
         // Convert u8 to TxPower
         match nrf52::constants::TxPower::try_from(tx_power as u8) {
             // Invalid transmitting power, propogate error
-            Err(_) => Err(ErrorCode::NOSUPPORT),
+            Err(()) => Err(ErrorCode::NOSUPPORT),
             // Valid transmitting power, propogate success
             Ok(res) => {
                 self.tx_power.set(res);

--- a/chips/rp2040/src/pwm.rs
+++ b/chips/rp2040/src/pwm.rs
@@ -680,7 +680,7 @@ impl<'a> Pwm<'a> {
     ) -> Result<(), ErrorCode> {
         let (top, int, frac) = match self.compute_top_int_frac(frequency_hz) {
             Ok(result) => result,
-            Err(_) => return Result::from(ErrorCode::INVAL),
+            Err(()) => return Result::from(ErrorCode::INVAL),
         };
 
         let max_duty_cycle = hil::pwm::Pwm::get_maximum_duty_cycle(self);

--- a/chips/sam4l/src/pm.rs
+++ b/chips/sam4l/src/pm.rs
@@ -576,7 +576,7 @@ pub struct PowerManager {
 impl PowerManager {
     pub const fn new() -> Self {
         Self {
-            /// Set to the RCSYS by default.
+            // Set to the RCSYS by default.
             system_clock_source: Cell::new(SystemClockSource::RcsysAt115kHz),
 
             system_on_clocks: Cell::new(ClockMask::RCSYS as u32),

--- a/chips/stm32f4xx/src/can.rs
+++ b/chips/stm32f4xx/src/can.rs
@@ -758,7 +758,7 @@ impl<'a> Can<'a> {
                         .can_tir
                         .modify(CAN_TIxR::TXRQ::SET);
                 }) {
-                    Some(_) => Ok(()),
+                    Some(()) => Ok(()),
                     None => Err(kernel::ErrorCode::FAIL),
                 }
             } else {
@@ -1252,7 +1252,7 @@ impl can::Controller for Can<'_> {
                     } else {
                         // set an Enable or an EnableError deferred action
                         match r {
-                            Ok(_) => {
+                            Ok(()) => {
                                 self.deferred_action.set(AsyncAction::Enable);
                             }
                             Err(err) => {
@@ -1322,7 +1322,7 @@ impl can::Transmit<{ can::STANDARD_CAN_PACKET_SIZE }> for Can<'_> {
                 self.enable_irq(CanInterruptMode::TransmitInterrupt);
                 self.can_state.set(CanState::Normal);
                 match self.send_8byte_message(id, len, 0) {
-                    Ok(_) => Ok(()),
+                    Ok(()) => Ok(()),
                     Err(err) => Err((err, self.tx_buffer.take().unwrap())),
                 }
             }

--- a/chips/stm32f4xx/src/clocks/clocks.rs
+++ b/chips/stm32f4xx/src/clocks/clocks.rs
@@ -288,7 +288,7 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
     /// Get the current APB1 frequency
     pub fn get_apb1_frequency(&self) -> usize {
         // Every enum variant can be converted into a usize
-        let divider: usize = self.rcc.get_apb1_prescaler().try_into().unwrap();
+        let divider: usize = self.rcc.get_apb1_prescaler().into();
         self.get_ahb_frequency() / divider
     }
 
@@ -334,7 +334,7 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
     /// Get the current APB2 frequency
     pub fn get_apb2_frequency(&self) -> usize {
         // Every enum variant can be converted into a usize
-        let divider: usize = self.rcc.get_apb2_prescaler().try_into().unwrap();
+        let divider: usize = self.rcc.get_apb2_prescaler().into();
         self.get_ahb_frequency() / divider
     }
 

--- a/chips/virtio/src/queues/split_queue.rs
+++ b/chips/virtio/src/queues/split_queue.rs
@@ -88,7 +88,6 @@ fn init_constgeneric_default_array<const N: usize, T: Default>() -> [T; N] {
     // the original `[MaybeUnit<T>; N]` array, as described here:
     // https://github.com/rust-lang/rust/issues/62875#issuecomment-513834029
     let uninit_arr_ptr: *mut [core::mem::MaybeUninit<T>; N] = &mut uninit_arr as *mut _;
-    core::mem::forget(uninit_arr);
     let transmuted: [T; N] = unsafe { core::ptr::read(uninit_arr_ptr.cast::<[T; N]>()) };
 
     // With the original value forgotten and new value recreated from its

--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -77,7 +77,7 @@ of installing some of these tools, but you can also install them yourself.
 
 #### Rust (nightly)
 
-We are using `nightly-2023-07-30`. We require
+We are using `nightly-2024-01-01`. We require
 installing it with [rustup](http://www.rustup.rs) so you can manage multiple
 versions of Rust and continue using stable versions for other Rust code:
 
@@ -92,7 +92,7 @@ to your `$PATH`.
 Then install the correct nightly version of Rust:
 
 ```bash
-$ rustup install nightly-2023-07-30
+$ rustup install nightly-2024-01-01
 ```
 
 #### Tockloader

--- a/kernel/src/deferred_call.rs
+++ b/kernel/src/deferred_call.rs
@@ -5,7 +5,7 @@
 //! Hardware-independent kernel interface for deferred calls
 //!
 //! This allows any struct in the kernel which implements
-//! [DeferredCallClient](crate::deferred_call::DeferredCallClient)
+//! [DeferredCallClient]
 //! to set and receive deferred calls, Tock's version of software
 //! interrupts.
 //!
@@ -19,7 +19,7 @@
 //! -----
 //!
 //! The `DEFCALLS` array size determines how many
-//! [DeferredCall](crate::deferred_call::DeferredCall)s
+//! [DeferredCall]s
 //! may be registered. By default this is set to 32.
 //! To support more deferred calls, this file would need to be modified
 //! to use a larger variable for BITMASK (e.g. BITMASK could be a u64

--- a/kernel/src/deferred_call.rs
+++ b/kernel/src/deferred_call.rs
@@ -230,6 +230,10 @@ impl DeferredCall {
     /// that DeferredCalls will actually be delivered as expected. This function costs about 300
     /// bytes, so you can remove it if you are confident your setup will not exceed 32 deferred
     /// calls, and that all of your components register their deferred calls.
+    // Ignore the clippy warning for using `.filter(|opt| opt.is_some())` since
+    // we don't actually have an Option (we have an OptionalCell) and
+    // IntoIterator is not implemented for OptionalCell.
+    #[allow(clippy::iter_filter_is_some)]
     pub fn verify_setup() {
         // SAFETY: No accesses to CTR/DEFCALLS are via an &mut, and the Tock kernel is
         // single-threaded so all accesses will occur from this thread.

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -671,7 +671,7 @@ impl Kernel {
                             debug!("Making process {} runnable", process.get_process_name());
                         }
                         match process.enqueue_init_task(&self.init_cap) {
-                            Ok(_) => { /* All is good, do nothing. */ }
+                            Ok(()) => { /* All is good, do nothing. */ }
                             Err(e) => {
                                 if config::CONFIG.debug_load_processes {
                                     debug!(

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -644,7 +644,7 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
                 Err(Error::AddressOutOfBounds)
             } else if new_break > self.kernel_memory_break.get() {
                 Err(Error::OutOfMemory)
-            } else if let Err(_) = self.chip.mpu().update_app_memory_region(
+            } else if let Err(()) = self.chip.mpu().update_app_memory_region(
                 new_break,
                 self.kernel_memory_break.get(),
                 mpu::Permissions::ReadWriteOnly,
@@ -2018,7 +2018,7 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
         });
         match ukb_init_process {
             Ok(()) => {}
-            Err(_) => {
+            Err(()) => {
                 // We couldn't initialize the architecture-specific state for
                 // this process. This shouldn't happen since the app was able to
                 // be started before, but at this point the app is no longer
@@ -2110,7 +2110,7 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
             } else if new_break > self.kernel_memory_break.get() {
                 None
                 // Verify this is compatible with the MPU.
-            } else if let Err(_) = self.chip.mpu().update_app_memory_region(
+            } else if let Err(()) = self.chip.mpu().update_app_memory_region(
                 self.app_break.get(),
                 new_break,
                 mpu::Permissions::ReadWriteOnly,

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -272,7 +272,7 @@ pub enum SyscallReturnVariant {
 /// types
 /// (e.g. [`ReadWriteProcessBuffer`](crate::processbuffer::ReadWriteProcessBuffer)
 /// and `GrantKernelData`) or wrappers around this struct
-/// ([`CommandReturn`](crate::syscall_driver::CommandReturn)) which limit the
+/// ([`CommandReturn`]) which limit the
 /// available constructors to safely constructable variants.
 #[derive(Copy, Clone, Debug)]
 pub enum SyscallReturn {

--- a/libraries/tock-register-interface/src/fields.rs
+++ b/libraries/tock-register-interface/src/fields.rs
@@ -13,7 +13,7 @@
 //!
 //! A specific section (bitfield) in a register is described by the
 //! [`Field`] type, consisting of an unshifted bitmask over the base
-//! register [`UIntLike`](crate::UIntLike) type, and a shift
+//! register [`UIntLike`] type, and a shift
 //! parameter. It is further associated with a specific
 //! [`RegisterLongName`], which can prevent its use with incompatible
 //! registers.
@@ -27,7 +27,7 @@
 //! ## `register_bitfields` macro
 //!
 //! For defining register layouts with an associated
-//! [`RegisterLongName`](crate::RegisterLongName), along with
+//! [`RegisterLongName`], along with
 //! [`Field`]s and matching [`FieldValue`]s, a convenient macro-based
 //! interface can be used.
 //!

--- a/libraries/tock-register-interface/src/interfaces.rs
+++ b/libraries/tock-register-interface/src/interfaces.rs
@@ -11,14 +11,14 @@
 //!
 //! Each trait has two associated type parameters, namely:
 //!
-//! - `T`: [`UIntLike`](crate::UIntLike), indicating the underlying
+//! - `T`: [`UIntLike`], indicating the underlying
 //!   integer type used to represent the register's raw contents.
 //!
-//! - `R`: [`RegisterLongName`](crate::RegisterLongName), functioning
+//! - `R`: [`RegisterLongName`], functioning
 //!   as a type to identify this register's descriptive name and
 //!   semantic meaning. It is further used to impose type constraints
 //!   on values passed through the API, such as
-//!   [`FieldValue`](crate::fields::FieldValue).
+//!   [`FieldValue`].
 //!
 //! Registers can have different access levels, which are mapped to
 //! different traits respectively:
@@ -39,7 +39,7 @@
 //!   writing and receive when reading.
 //!
 //!   If a type implements both [`Readable`] and [`Writeable`], and
-//!   the associated [`RegisterLongName`](crate::RegisterLongName)
+//!   the associated [`RegisterLongName`]
 //!   type parameters are identical, it will automatically implement
 //!   [`ReadWriteable`]. In particular, for
 //!   [`Aliased`](crate::registers::Aliased) this is -- in general --

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,6 +3,6 @@
 # Copyright Tock Contributors 2023.
 
 [toolchain]
-channel = "nightly-2023-07-30"
+channel = "nightly-2024-01-01"
 components = ["miri", "llvm-tools", "rust-src", "rustfmt", "clippy"]
 targets = ["thumbv6m-none-eabi", "thumbv7em-none-eabi", "thumbv7em-none-eabihf", "riscv32imc-unknown-none-elf", "riscv32imac-unknown-none-elf"]

--- a/tools/netlify-build.sh
+++ b/tools/netlify-build.sh
@@ -17,7 +17,7 @@ set -u
 set -x
 
 # Install rust stuff that we need
-curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2023-07-30
+curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2024-01-01
 
 # And fixup path for the newly installed rust stuff
 export PATH="$PATH:$HOME/.cargo/bin"

--- a/tools/run_clippy.sh
+++ b/tools/run_clippy.sh
@@ -69,7 +69,7 @@ CLIPPY_ARGS_COMPLEXITY="
 CLIPPY_ARGS_STYLE="
 -D clippy::style
 
--A clippy::blocks-in-if-conditions
+-A clippy::blocks_in_conditions
 -A clippy::collapsible_else_if
 -A clippy::collapsible_if
 -A clippy::collapsible_match

--- a/tools/run_clippy.sh
+++ b/tools/run_clippy.sh
@@ -178,6 +178,7 @@ CLIPPY_ARGS_PEDANTIC="
 -A clippy::verbose_bit_mask
 -A clippy::large_types_passed_by_value
 -A clippy::no_mangle_with_rust_abi
+-A clippy::struct_field_names
 
 
 -A clippy::cast_lossless
@@ -196,6 +197,7 @@ CLIPPY_ARGS_PEDANTIC="
 -A clippy::match_bool
 -A clippy::redundant_closure_for_method_calls
 -A clippy::no_effect_underscore_binding
+-A clippy::iter_without_into_iter
 
 
 -A clippy::semicolon_if_nothing_returned
@@ -211,4 +213,4 @@ CLIPPY_ARGS_PEDANTIC="
 # disallowed lints.
 # FIX="--fix --allow-dirty"
 
-cargo clippy $FIX -- $CLIPPY_ARGS $CLIPPY_ARGS_COMPLEXITY $CLIPPY_ARGS_STYLE $CLIPPY_ARGS_PERF $CLIPPY_ARGS_CARGO $CLIPPY_ARGS_NURSERY $CLIPPY_ARGS_PEDANTIC
+cargo clippy $FIX -- $CLIPPY_ARGS_COMPLEXITY $CLIPPY_ARGS_STYLE $CLIPPY_ARGS_PERF $CLIPPY_ARGS_CARGO $CLIPPY_ARGS_NURSERY $CLIPPY_ARGS_PEDANTIC $CLIPPY_ARGS


### PR DESCRIPTION
### Pull Request Overview

Periodic rust update.

- Panic handler can no longer be marked as `extern c`.
- Fixed new rustdoc warnings about comments that were not being used.
- Replace `Err(_)` with `Err(())`.
- Remove unneeded `let _ = &fn()`.
- Ignore two new lints that I don't think we want.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
