### PR TITLE
lowrisc: usb: change while to if

### DIFF
--- a/chips/lowrisc/src/usbdev.rs
+++ b/chips/lowrisc/src/usbdev.rs
@@ -884,7 +884,7 @@ impl<'a> Usb<'a> {
         }
 
         if irqs.is_set(INTR::PKT_RECEIVED) {
-            while !self.registers.usbstat.is_set(USBSTAT::RX_EMPTY) {
+            if !self.registers.usbstat.is_set(USBSTAT::RX_EMPTY) {
                 let rxinfo = self.registers.rxfifo.extract();
                 let buf = rxinfo.read(RXFIFO::BUFFER);
                 let size = rxinfo.read(RXFIFO::SIZE);
@@ -896,7 +896,6 @@ impl<'a> Usb<'a> {
                     0 => {
                         self.control_ep_receive(ep as usize, buf as usize, size, setup);
                         self.free_buffer(buf as usize);
-                        break;
                     }
                     1..=7 => {
                         let receive_size = match self.descriptors[ep as usize].state.get() {
@@ -908,7 +907,6 @@ impl<'a> Usb<'a> {
                         };
                         self.ep_receive(ep as usize, buf as usize, receive_size, setup);
                         self.free_buffer(buf as usize);
-                        break;
                     }
                     8 => unimplemented!("isochronous endpoint"),
                     _ => unimplemented!(),


### PR DESCRIPTION
### Pull Request Overview

This while loop can only ever execute once because there are break statements in all of the valid match arms.

This was found via a new clippy lint.

This patch makes the code match what is actually happening. I don't know if it should be a loop and the breaks are the issue, however.






### Testing Strategy

No testing, just travis.


### TODO or Help Wanted

Is this the right fix?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
