### PR TITLE
Add stm32f4xx HSE (high-speed external) clock support

### DIFF
--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -47,7 +47,7 @@ const FAULT_RESPONSE: kernel::process::PanicFaultPolicy = kernel::process::Panic
 pub static mut STACK_MEMORY: [u8; 0x2000] = [0; 0x2000];
 
 /// Nucleo F429ZI HSE frequency in MHz
-pub const HSE_FREQUENCY_MHZ: usize = 8;
+pub const NUCLEO_F429ZI_HSE_FREQUENCY_MHZ: usize = 8;
 
 /// A structure representing this platform that holds references to all
 /// capsules for this platform.
@@ -310,7 +310,6 @@ unsafe fn create_peripherals() -> (
 ) {
     // We use the default HSI 16Mhz clock
     let rcc = static_init!(stm32f429zi::rcc::Rcc, stm32f429zi::rcc::Rcc::new());
-    rcc.set_hse_frequency(HSE_FREQUENCY_MHZ);
 
     let syscfg = static_init!(
         stm32f429zi::syscfg::Syscfg,
@@ -340,6 +339,9 @@ pub unsafe fn main() {
     let (peripherals, syscfg, dma1) = create_peripherals();
     peripherals.init();
     let base_peripherals = &peripherals.stm32f4;
+
+    let pll = &peripherals.stm32f4.clocks.pll;
+    pll.hse.set_frequency(NUCLEO_F429ZI_HSE_FREQUENCY_MHZ);
 
     setup_peripherals(
         &base_peripherals.tim2,

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -340,9 +340,6 @@ pub unsafe fn main() {
     peripherals.init();
     let base_peripherals = &peripherals.stm32f4;
 
-    let pll = &peripherals.stm32f4.clocks.pll;
-    pll.hse.set_frequency(NUCLEO_F429ZI_HSE_FREQUENCY_MHZ);
-
     setup_peripherals(
         &base_peripherals.tim2,
         &peripherals.trng,

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -46,6 +46,9 @@ const FAULT_RESPONSE: kernel::process::PanicFaultPolicy = kernel::process::Panic
 #[link_section = ".stack_buffer"]
 pub static mut STACK_MEMORY: [u8; 0x2000] = [0; 0x2000];
 
+/// Nucleo F429ZI HSE frequency in MHz
+pub const HSE_FREQUENCY_MHZ: usize = 8;
+
 /// A structure representing this platform that holds references to all
 /// capsules for this platform.
 struct NucleoF429ZI {
@@ -307,6 +310,7 @@ unsafe fn create_peripherals() -> (
 ) {
     // We use the default HSI 16Mhz clock
     let rcc = static_init!(stm32f429zi::rcc::Rcc, stm32f429zi::rcc::Rcc::new());
+    rcc.set_hse_frequency(HSE_FREQUENCY_MHZ);
 
     let syscfg = static_init!(
         stm32f429zi::syscfg::Syscfg,

--- a/chips/stm32f4xx/src/clocks/clocks.rs
+++ b/chips/stm32f4xx/src/clocks/clocks.rs
@@ -102,6 +102,7 @@
 //!
 //! Then, configure its frequency and enable it
 //! ```rust,ignore
+//! clocks.set_sys_clock_source(stm32f429zi::rcc::SysClockSource::HSI);
 //! pll.set_frequency(50);
 //! pll.enable();
 //! ```
@@ -155,6 +156,7 @@
 //! [^usage_note]: For the purpose of brevity, any error checking has been removed.
 
 use crate::chip_specific::ChipSpecs as ChipSpecsTrait;
+use crate::clocks::hse::Hse;
 use crate::clocks::hsi::Hsi;
 use crate::clocks::hsi::HSI_FREQUENCY_MHZ;
 use crate::clocks::pll::Pll;
@@ -176,6 +178,8 @@ pub struct Clocks<'a, ChipSpecs> {
     flash: OptionalCell<&'a Flash<ChipSpecs>>,
     /// High speed internal clock
     pub hsi: Hsi<'a>,
+    /// High speed external clock
+    pub hse: Hse<'a>,
     /// Main phase loop-lock clock
     pub pll: Pll<'a, ChipSpecs>,
 }
@@ -187,6 +191,7 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
             rcc,
             flash: OptionalCell::empty(),
             hsi: Hsi::new(rcc),
+            hse: Hse::new(rcc),
             pll: Pll::new(rcc),
         }
     }
@@ -351,6 +356,7 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
         // Ensure the source is enabled before configuring it as the system clock source
         if let false = match source {
             SysClockSource::HSI => self.hsi.is_enabled(),
+            SysClockSource::HSE => self.hse.is_enabled(),
             SysClockSource::PLL => self.pll.is_enabled(),
         } {
             return Err(ErrorCode::FAIL);
@@ -362,6 +368,7 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
         let alternate_frequency = match source {
             // The unwrap can't fail because the source clock status was checked before
             SysClockSource::HSI => self.hsi.get_frequency().unwrap(),
+            SysClockSource::HSE => self.hse.get_frequency().unwrap(),
             SysClockSource::PLL => self.pll.get_frequency().unwrap(),
         };
 
@@ -420,6 +427,7 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
             // enabled. Also, Hsi and Pll structs ensure that the clocks can't be disabled when
             // they are configured as the system clock
             SysClockSource::HSI => self.hsi.get_frequency().unwrap(),
+            SysClockSource::HSE => self.hse.get_frequency().unwrap(),
             SysClockSource::PLL => self.pll.get_frequency().unwrap(),
         }
     }
@@ -431,8 +439,13 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
     /// + [Err]\([ErrorCode::FAIL]\) if the source apart from HSI is already enabled.
     pub fn set_mco1_clock_source(&self, source: MCO1Source) -> Result<(), ErrorCode> {
         match source {
+            MCO1Source::HSE => {
+                if !self.hse.is_enabled() {
+                    return Err(ErrorCode::FAIL);
+                }
+            }
             MCO1Source::PLL => {
-                if self.pll.is_enabled() {
+                if !self.pll.is_enabled() {
                     return Err(ErrorCode::FAIL);
                 }
             }
@@ -462,6 +475,7 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
                 }
             }
             MCO1Source::HSI => (),
+            MCO1Source::HSE => (),
         }
 
         self.rcc.set_mco1_clock_divider(divider);

--- a/chips/stm32f4xx/src/clocks/hse.rs
+++ b/chips/stm32f4xx/src/clocks/hse.rs
@@ -1,0 +1,204 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! HSE (high-speed external) clock driver for the STM32F4xx family. [^doc_ref]
+//!
+//! # Usage
+//!
+//! For the purposes of brevity, any error checking has been removed. In real applications, always
+//! check the return values of the [Hse] methods.
+//!
+//! First, get a reference to the [Hse] struct:
+//! ```rust,ignore
+//! let hse = &base_peripherals.clocks.hse;
+//! ```
+//!
+//! ## Start the clock
+//!
+//! ```rust,ignore
+//! hse.enable(stm32f429zi::rcc::HseMode::BYPASS);
+//! ```
+//!
+//! ## Set the clock frequency
+//! ```rust,ignore
+//! hse.set_frequency(8);
+//! ```
+//!
+//! ## Stop the clock
+//!
+//! ```rust,ignore
+//! hse.disable();
+//! ```
+//!
+//! ## Check if the clock is enabled
+//! ```rust,ignore
+//! if hse.is_enabled() {
+//!     /* Do something */
+//! } else {
+//!     /* Do something */
+//! }
+//! ```
+//!
+//! ## Get the frequency of the clock
+//! ```rust,ignore
+//! let hse_frequency_mhz = hse.get_frequency().unwrap();
+//! ```
+//!
+//! [^doc_ref]: See 6.2.1 in the documentation.
+
+use crate::rcc::HseMode;
+use crate::rcc::Rcc;
+
+use kernel::debug;
+use kernel::ErrorCode;
+
+/// Main HSE clock structure
+pub struct Hse<'a> {
+    rcc: &'a Rcc,
+}
+
+impl<'a> Hse<'a> {
+    /// Create a new instance of the HSE clock.
+    ///
+    /// # Parameters
+    ///
+    /// + rcc: an instance of [crate::rcc]
+    ///
+    /// # Returns
+    ///
+    /// An instance of the HSE clock.
+    pub(in crate::clocks) fn new(rcc: &'a Rcc) -> Self {
+        Self { rcc }
+    }
+
+    /// Start the HSE clock.
+    ///
+    /// # Errors
+    ///
+    /// + [Err]\([ErrorCode::BUSY]\): disabling the HSE clock took to long. Retry to ensure it is
+    pub fn enable(&self, source: HseMode) -> Result<(), ErrorCode> {
+        if source == HseMode::BYPASS {
+            self.rcc.enable_hse_clock_bypass();
+        }
+
+        self.rcc.enable_hse_clock();
+
+        for _ in 0..100 {
+            if self.rcc.is_ready_hse_clock() {
+                return Ok(());
+            }
+        }
+
+        Err(ErrorCode::BUSY)
+    }
+
+    /// Stop the HSE clock.
+    ///
+    /// # Errors
+    ///
+    /// + [Err]\([ErrorCode::FAIL]\): if the HSE clock is configured as the system clock.
+    /// + [Err]\([ErrorCode::BUSY]\): disabling the HSE clock took to long. Retry to ensure it is
+    /// not running.
+    pub fn disable(&self) -> Result<(), ErrorCode> {
+        if self.rcc.is_hse_clock_system_clock() {
+            return Err(ErrorCode::FAIL);
+        }
+
+        self.rcc.disable_hse_clock();
+
+        for _ in 0..10 {
+            if !self.rcc.is_ready_hse_clock() {
+                return Ok(());
+            }
+        }
+
+        Err(ErrorCode::BUSY)
+    }
+
+    /// Check whether the HSE clock is enabled or not.
+    ///
+    /// # Returns
+    ///
+    /// + [false]: the HSE clock is not enabled
+    /// + [true]: the HSE clock is enabled
+    pub fn is_enabled(&self) -> bool {
+        self.rcc.is_enabled_hse_clock()
+    }
+
+    /// Get the frequency in MHz of the HSE clock.
+    ///
+    /// # Returns
+    ///
+    /// + [Some]\(frequency_mhz\): if the HSE clock is enabled.
+    /// + [None]: if the HSE clock is disabled.
+    pub fn get_frequency(&self) -> Option<usize> {
+        if self.is_enabled() {
+            self.rcc.get_hse_frequency()
+        } else {
+            None
+        }
+    }
+}
+
+/// Tests for the HSE clock
+///
+/// This module ensures that the HSE clock works as expected. If changes are brought to the HSE
+/// clock, ensure to run all the tests to see if anything is broken.
+///
+/// # Usage
+///
+/// First, import the [crate::clocks::hse] module in the desired board main file:
+///
+/// ```rust,ignore
+/// use stm32f429zi::clocks::hse;
+/// ```
+///
+/// Then, to run the tests, put the following line before [kernel::process::load_processes]:
+///
+/// ```rust,ignore
+/// hse::tests::run(&peripherals.stm32f4.clocks.hse);
+/// ```
+///
+/// If everything works as expected, the following message should be printed on the kernel console:
+///
+/// ```text
+/// ===============================================
+/// Testing HSE...
+/// Finished testing HSE. Everything is alright!
+/// ===============================================
+/// ```
+///
+/// **NOTE:** All these tests assume default boot configuration.
+pub mod tests {
+    use super::*;
+
+    /// Run the entire test suite.
+    pub fn run(hse: &Hse) {
+        debug!("");
+        debug!("===============================================");
+        debug!("Testing HSE...");
+
+        // By default, the HSE clock is disabled
+        assert!(!hse.is_enabled());
+
+        // HSE frequency is None
+        assert_eq!(None, hse.get_frequency());
+
+        // HSE should be enabled
+        assert_eq!(Ok(()), hse.enable(HseMode::BYPASS));
+
+        // HSE frequency is 8MHz
+        assert_eq!(Some(8), hse.get_frequency());
+
+        // Nothing should happen if the HSE clock is being enabled when already running
+        assert_eq!(Ok(()), hse.enable(HseMode::BYPASS));
+
+        // It is possible to disable the HSE clock since it is not the system clock source
+        assert_eq!(Ok(()), hse.disable());
+
+        debug!("Finished testing HSE. Everything is alright!");
+        debug!("===============================================");
+        debug!("");
+    }
+}

--- a/chips/stm32f4xx/src/clocks/hsi.rs
+++ b/chips/stm32f4xx/src/clocks/hsi.rs
@@ -147,13 +147,13 @@ impl<'a> Hsi<'a> {
 /// First, import the [crate::clocks::hsi] module in the desired board main file:
 ///
 /// ```rust,ignore
-/// use stm32f429zi::hsi;
+/// use stm32f429zi::clocks::hsi;
 /// ```
 ///
 /// Then, to run the tests, put the following line before [kernel::process::load_processes]:
 ///
 /// ```rust,ignore
-/// hsi::tests::run_all(&peripherals.stm32f4.clocks.hsi);
+/// hsi::tests::run(&peripherals.stm32f4.clocks.hsi);
 /// ```
 ///
 /// If everything works as expected, the following message should be printed on the kernel console:

--- a/chips/stm32f4xx/src/clocks/mod.rs
+++ b/chips/stm32f4xx/src/clocks/mod.rs
@@ -5,6 +5,7 @@
 // Author: Ioan-Cristian CÎRSTEA <ioan.cirstea@oxidos.io>
 
 pub mod clocks;
+pub mod hse;
 pub mod hsi;
 pub mod pll;
 

--- a/chips/stm32f4xx/src/clocks/pll.rs
+++ b/chips/stm32f4xx/src/clocks/pll.rs
@@ -305,7 +305,7 @@ impl<'a, PllConstants: clock_constants::PllConstants> Pll<'a, PllConstants> {
     /// + [Err]\([ErrorCode::INVAL]\): if the desired frequency can't be achieved
     /// + [Err]\([ErrorCode::FAIL]\): if the PLL clock is already enabled. It must be disabled before
     /// configuring it.
-    pub fn set_frequency(
+    pub(super) fn set_frequency(
         &self,
         pll_source: PllSource,
         source_frequency: usize,

--- a/chips/stm32f4xx/src/clocks/pll.rs
+++ b/chips/stm32f4xx/src/clocks/pll.rs
@@ -233,7 +233,7 @@ impl<'a, PllConstants: clock_constants::PllConstants> Pll<'a, PllConstants> {
             } else {
                 self.rcc.set_pll_clocks_source(PllSource::HSE);
             }
-            return Ok(());
+            Ok(())
         }
     }
 

--- a/chips/stm32f4xx/src/rcc.rs
+++ b/chips/stm32f4xx/src/rcc.rs
@@ -1369,11 +1369,6 @@ impl Rcc {
     }
 }
 
-pub(crate) enum PllSource {
-    HSI = 0b0,
-    HSE = 0b1,
-}
-
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub(crate) enum PLLP {
     DivideBy2 = 0b00,
@@ -1417,6 +1412,11 @@ pub enum SysClockSource {
     PLL = 0b10,
     // NOTE: not all STM32F4xx boards support this source.
     //PPLLR = 0b11, Uncomment this when support for PPLLR is added
+}
+
+pub enum PllSource {
+    HSI = 0b0,
+    HSE = 0b1,
 }
 
 pub enum MCO1Source {

--- a/chips/stm32f4xx/src/rcc.rs
+++ b/chips/stm32f4xx/src/rcc.rs
@@ -3,6 +3,7 @@
 // Copyright Tock Contributors 2022.
 
 use kernel::platform::chip::ClockInterface;
+use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 use kernel::utilities::registers::{register_bitfields, ReadWrite};
 use kernel::utilities::StaticRef;
@@ -733,6 +734,7 @@ pub(crate) const DEFAULT_PLLQ_VALUE: PLLQ = match DEFAULT_PLLM_VALUE {
 
 pub struct Rcc {
     registers: StaticRef<RccRegisters>,
+    hse_frequency: OptionalCell<usize>,
 }
 
 pub enum RtcClockSource {
@@ -745,6 +747,7 @@ impl Rcc {
     pub fn new() -> Self {
         let rcc = Self {
             registers: RCC_BASE,
+            hse_frequency: OptionalCell::empty(),
         };
         rcc.init();
         rcc
@@ -778,7 +781,7 @@ impl Rcc {
     pub(crate) fn get_sys_clock_source(&self) -> SysClockSource {
         match self.registers.cfgr.read(CFGR::SWS) {
             0b00 => SysClockSource::HSI,
-            //0b01 => SysClockSource::HSE, Uncomment this when HSE support is added
+            0b01 => SysClockSource::HSE,
             _ => SysClockSource::PLL,
             // Uncomment this when PPLLR support is added. Also change the above match arm to
             // 0b10 => SysClockSource::PLL,
@@ -800,6 +803,13 @@ impl Rcc {
                 && self.registers.pllcfgr.read(PLLCFGR::PLLSRC) == PllSource::HSI as u32
     }
 
+    pub(crate) fn is_hse_clock_system_clock(&self) -> bool {
+        let system_clock_source = self.get_sys_clock_source();
+        system_clock_source == SysClockSource::HSE
+            || system_clock_source == SysClockSource::PLL
+                && self.registers.pllcfgr.read(PLLCFGR::PLLSRC) == PllSource::HSE as u32
+    }
+
     /* HSI clock */
     // The HSI clock must not be configured as the system clock, either directly or indirectly.
     pub(crate) fn disable_hsi_clock(&self) {
@@ -817,6 +827,37 @@ impl Rcc {
     // Indicates whether the HSI oscillator is stable
     pub(crate) fn is_ready_hsi_clock(&self) -> bool {
         self.registers.cr.is_set(CR::HSIRDY)
+    }
+
+    /* HSE clock */
+    pub fn set_hse_frequency(&self, frequency: usize) {
+        self.hse_frequency.set(frequency);
+    }
+
+    pub fn get_hse_frequency(&self) -> Option<usize> {
+        self.hse_frequency.get()
+    }
+
+    pub(crate) fn disable_hse_clock(&self) {
+        self.registers.cr.modify(CR::HSEON::CLEAR);
+        self.registers.cr.modify(CR::HSEBYP::CLEAR);
+    }
+
+    pub(crate) fn enable_hse_clock_bypass(&self) {
+        self.registers.cr.modify(CR::HSEBYP::SET);
+    }
+
+    pub(crate) fn enable_hse_clock(&self) {
+        self.registers.cr.modify(CR::HSEON::SET);
+    }
+
+    pub(crate) fn is_enabled_hse_clock(&self) -> bool {
+        self.registers.cr.is_set(CR::HSEON)
+    }
+
+    // Indicates whether the HSE oscillator is stable
+    pub(crate) fn is_ready_hse_clock(&self) -> bool {
+        self.registers.cr.is_set(CR::HSERDY)
     }
 
     /* Main PLL clock*/
@@ -933,7 +974,7 @@ impl Rcc {
             0b00 => MCO1Source::HSI,
             // When LSE or HSE are added, uncomment the following lines
             //0b01 => MCO1Source::LSE,
-            //0b10 => MCO1Source::HSE,
+            0b10 => MCO1Source::HSE,
             // 0b11 corresponds to MCO1Source::PLL
             _ => MCO1Source::PLL,
         }
@@ -1339,10 +1380,9 @@ impl Rcc {
     }
 }
 
-// NOTE: HSE is not yet supported as source clock.
 pub(crate) enum PllSource {
     HSI = 0b0,
-    //HSE = 0b1,
+    HSE = 0b1,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -1384,7 +1424,7 @@ pub(crate) enum PLLQ {
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum SysClockSource {
     HSI = 0b00,
-    //HSE = 0b01, Uncomment this when support for HSE is added
+    HSE = 0b01,
     PLL = 0b10,
     // NOTE: not all STM32F4xx boards support this source.
     //PPLLR = 0b11, Uncomment this when support for PPLLR is added
@@ -1393,7 +1433,7 @@ pub enum SysClockSource {
 pub enum MCO1Source {
     HSI = 0b00,
     //LSE = 0b01, // When support for LSE is added, uncomment this
-    //HSE = 0b10, // When support for HSE is added, uncomment this
+    HSE = 0b10,
     PLL = 0b11,
 }
 
@@ -1403,6 +1443,13 @@ pub enum MCO1Divider {
     DivideBy3 = 0b101,
     DivideBy4 = 0b110,
     DivideBy5 = 0b111,
+}
+
+/// HSE Mode
+#[derive(PartialEq)]
+pub enum HseMode {
+    BYPASS,
+    CRYSTAL,
 }
 
 #[derive(Clone, Copy, PartialEq, Debug)]

--- a/chips/stm32f4xx/src/rcc.rs
+++ b/chips/stm32f4xx/src/rcc.rs
@@ -3,7 +3,6 @@
 // Copyright Tock Contributors 2022.
 
 use kernel::platform::chip::ClockInterface;
-use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 use kernel::utilities::registers::{register_bitfields, ReadWrite};
 use kernel::utilities::StaticRef;
@@ -734,7 +733,6 @@ pub(crate) const DEFAULT_PLLQ_VALUE: PLLQ = match DEFAULT_PLLM_VALUE {
 
 pub struct Rcc {
     registers: StaticRef<RccRegisters>,
-    hse_frequency: OptionalCell<usize>,
 }
 
 pub enum RtcClockSource {
@@ -747,7 +745,6 @@ impl Rcc {
     pub fn new() -> Self {
         let rcc = Self {
             registers: RCC_BASE,
-            hse_frequency: OptionalCell::empty(),
         };
         rcc.init();
         rcc
@@ -830,14 +827,6 @@ impl Rcc {
     }
 
     /* HSE clock */
-    pub fn set_hse_frequency(&self, frequency: usize) {
-        self.hse_frequency.set(frequency);
-    }
-
-    pub fn get_hse_frequency(&self) -> Option<usize> {
-        self.hse_frequency.get()
-    }
-
     pub(crate) fn disable_hse_clock(&self) {
         self.registers.cr.modify(CR::HSEON::CLEAR);
         self.registers.cr.modify(CR::HSEBYP::CLEAR);


### PR DESCRIPTION
### Pull Request Overview

- Add stm32f4xx HSE (high-speed external) clock support.

- Update `pll.rs` to support both `HSI` and `HSE` sources.

- Add `hse_frequency` member to `Rcc`. Each board should configure this value manually since there is no way of knowing the HSE frequency value from the firmware (range of 1-50 MHz). As per my understanding this is the proper place for this value, due to the hierarchy of `rcc.rs`, `clocks.rs`, `pll.rs` and `hse.rs`.

### Testing Strategy

- Enable HSE. Route it to `MCO1` pin and validate that the clock is enabled.
- Enable PLL with HSE as source (tested 96 MHz). Route it to `MCO1` pin and validate the frequency.
- Run `hse.rs`, `hsi.rs` and `pll.rs` tests on `nucleo_f429zi`


### Documentation Updated

Minor documentation updates in `hsi.rs` and `pll.rs`.

### Formatting

- [ x] Ran `make prepush`.
