### PR TITLE
Pin labeler action to v4.3.0

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -16,6 +16,6 @@ jobs:
       pull-requests: write  # for actions/labeler to add labels to PRs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@main
+    - uses: actions/labeler@v4.3.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
### Pull Request Overview

This pull fix the GitHub "labeler" action by fixing the version to v4.3.0. See changes to v5.0 [here](https://github.com/actions/labeler/releases/tag/v5.0.0) which break our YAML configuration.


### Testing Strategy

Testing by opening this pull request


### TODO or Help Wanted

- Might be better to update our YAML file to match 5.0


