### PR TITLE
chips: nrf52: i2c: fixup register bitfield

### DIFF
--- a/chips/nrf52/src/i2c.rs
+++ b/chips/nrf52/src/i2c.rs
@@ -629,7 +629,7 @@ register_bitfields![u32,
         MAXCNT OFFSET(0) NUMBITS(16)
     ],
     AMOUNT [
-        AMOUNT OFFSET(0) NUMBITS(7),
+        AMOUNT OFFSET(0) NUMBITS(16),
     ],
     ADDRESS [
         /// Address used in the TWI transfer


### PR DESCRIPTION
### Pull Request Overview

The `amount` bitfield is 16 bits as per nrf52 TRM. Discovered when doing transfers that exceed max value from the prior 7bits.

### Testing Strategy

Running large transfers on an i2c master/slave config across 2 devices.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
