### PR TITLE
capsules: tickv: not ready cases need flash loop

### DIFF
--- a/capsules/extra/src/tickv.rs
+++ b/capsules/extra/src/tickv.rs
@@ -504,6 +504,11 @@ impl<'a, F: Flash, H: Hasher<'a, 8>, const PAGE_SIZE: usize> flash::Client<F>
                         self.operation.set(Operation::None);
                     }
                     Ok(tickv::success_codes::SuccessCode::Queued) => {}
+                    Err(tickv::error_codes::ErrorCode::ReadNotReady(_))
+                    | Err(tickv::error_codes::ErrorCode::WriteNotReady(_))
+                    | Err(tickv::error_codes::ErrorCode::EraseNotReady(_)) => {
+                        // Need to do another flash operation.
+                    }
                     Err(e) => {
                         self.operation.set(Operation::None);
 


### PR DESCRIPTION
### Pull Request Overview

For TicKV, these append "errors" just mean we need to let the next flash operation complete before doing anything.



### Testing Strategy

Found this using the `kv` test app.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
