### PR TITLE
Update Syscalls.md documentation

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -23,6 +23,7 @@ Tock Guides
 - **[Memory Isolation](Memory_Isolation.md)** - How memory is isolated in Tock.
 - **[Registers](../libraries/tock-register-interface/README.md)** - How memory-mapped registers are handled in Tock.
 - **[Startup](Startup.md)** - What happens when Tock boots.
+- **[Scheduling](Scheduling.md)** - How the Tock scheduler works.
 - **[Syscalls](Syscalls.md)** - Kernel/Userland abstraction.
 - **[Userland](Userland.md)** - Description of userland applications.
 - **[Networking Stack](Networking_Stack.md)** - Design of the networking stack in Tock.

--- a/doc/Scheduling.md
+++ b/doc/Scheduling.md
@@ -1,0 +1,76 @@
+Scheduling
+==========
+
+This describes how processes are scheduled by the Tock kernel.
+
+<!-- npm i -g markdown-toc; markdown-toc -i Scheduling.md -->
+
+<!-- toc -->
+
+- [Tock Scheduling](#tock-scheduling)
+- [Process State](#process-state)
+
+<!-- tocstop -->
+
+## Tock Scheduling
+
+The kernel defines a `Scheduler` trait that the main kernel loop uses to
+determine which process to execute next. Here is a simplified view of that
+trait:
+
+```rust
+pub trait Scheduler {
+    /// Decide which process to run next.
+    fn next(&self) -> SchedulingDecision;
+
+    /// Inform the scheduler of why the last process stopped executing, and how
+    /// long it executed for.
+    fn result(&self, result: StoppedExecutingReason, execution_time_us: Option<u32>);
+
+    /// Tell the scheduler to execute kernel work such as interrupt bottom
+    /// halves and dynamic deferred calls. Most schedulers will use the default
+    /// implementation.
+    unsafe fn execute_kernel_work(&self, chip: &C) {...}
+
+    /// Ask the scheduler whether to take a break from executing userspace
+    /// processes to handle kernel tasks.
+    unsafe fn do_kernel_work_now(&self, chip: &C) -> bool {...}
+
+    /// Ask the scheduler whether to continue trying to execute a process.
+    /// Most schedulers will use this default implementation.
+    unsafe fn continue_process(&self, _id: ProcessId, chip: &C) -> bool {...}
+}
+```
+
+Individual boards can choose which scheduler to use, and implementing new
+schedulers just requires implementing this trait.
+
+## Process State
+
+In Tock, a process can be in one of seven states:
+
+- **Running**: Normal operation. A Running process is eligible to be scheduled
+  for execution, although is subject to being paused by Tock to allow interrupt
+  handlers or other processes to run. During normal operation, a process remains
+  in the Running state until it explicitly yields. Upcalls from other kernel
+  operations are not delivered to Running processes (i.e. upcalls do not
+  interrupt processes), rather they are enqueued until the process yields.
+- **Yielded**: Suspended operation. A Yielded process will not be scheduled by
+  Tock. Processes often yield while they are waiting for I/O or other operations
+  to complete and have no immediately useful work to do. Whenever the kernel
+  issues an upcall to a Yielded process, the process is transitioned to the
+  Running state.
+- **Fault**: Erroneous operation. A Fault-ed process will not be scheduled by
+  Tock. Processes enter the Fault state by performing an illegal operation, such
+  as accessing memory outside of their address space.
+- **Terminated**: The process ended itself by calling the `Exit` system call and
+  the kernel has not restarted it.
+- **Unstarted**: The process has not yet started; this state is typically very
+  short-lived, between process loading and it started. However, in cases when
+  processes might be loaded for a long time without running, this state might be
+  long-lived.
+- **StoppedRunning**, **StoppedYielded**: These states correspond to a process
+  that was in either the Running or Yielded state but was then explicitly
+  stopped by the kernel (e.g., by the process console). A process in these
+  states will not be made runnable until it is restarted, at which point it will
+  continue execution where it was stopped.

--- a/doc/Syscalls.md
+++ b/doc/Syscalls.md
@@ -8,21 +8,30 @@ contains the more formal specification of the system call API and ABI for 32-bit
 systems. This document describes the considerations behind the system call
 design.
 
+<!-- npm i -g markdown-toc; markdown-toc -i Syscalls.md -->
+
 <!-- toc -->
 
 - [Overview of System Calls in Tock](#overview-of-system-calls-in-tock)
-- [Process State](#process-state)
-- [Startup](#startup)
-- [System Call Invocation](#system-call-invocation)
-- [The Context Switch](#the-context-switch)
+- [Tock System Call Types](#tock-system-call-types)
+  * [System Call Descriptions](#system-call-descriptions)
+- [Data Movement Between Userspace and Kernel](#data-movement-between-userspace-and-kernel)
+  * [Userspace → Kernel](#userspace-%E2%86%92-kernel)
+  * [Kernel → Userspace](#kernel-%E2%86%92-userspace)
+- [System Call Implementations](#system-call-implementations)
   * [Context Switch Interface](#context-switch-interface)
   * [Cortex-M Architecture Details](#cortex-m-architecture-details)
   * [RISC-V Architecture Details](#risc-v-architecture-details)
-- [How System Calls Connect to Drivers](#how-system-calls-connect-to-drivers)
-- [Error and Return Types](#error-and-return-types)
+- [Upcalls](#upcalls)
+  * [Process Startup](#process-startup)
+- [How System Calls Connect to Capsules (Drivers)](#how-system-calls-connect-to-capsules-drivers)
+- [Identifying Syscalls](#identifying-syscalls)
+  * [Syscall Class](#syscall-class)
+  * [Driver Numbers](#driver-numbers)
+  * [Syscall-Specific Numbers](#syscall-specific-numbers)
+- [Identifying Error and Return Types](#identifying-error-and-return-types)
   * [Naming Conventions](#naming-conventions)
   * [Type Descriptions](#type-descriptions)
-- [Allocated Driver Numbers](#allocated-driver-numbers)
 
 <!-- tocstop -->
 
@@ -30,23 +39,9 @@ design.
 
 System calls are the method used to send information from applications to the
 kernel. Rather than directly calling a function in the kernel, applications
-trigger a service call (`svc`) interrupt which causes a context switch to the
-kernel. The kernel then uses the values in registers and the stack at the time
-of the interrupt call to determine how to route the system call and which driver
-function to call with which data values.
-
-The system calls in Tock fall into 7 classes, described in detail in the
-[TRD104](reference/trd104-syscalls.md):
-
-| Syscall Class    | Syscall Class Number |
-|------------------|----------------------|
-| Yield            |           0          |
-| Subscribe        |           1          |
-| Command          |           2          |
-| Read-Write Allow |           3          |
-| Read-Only Allow  |           4          |
-| Memop            |           5          |
-| Exit             |           6          |
+trigger a context switch to the kernel. The kernel then uses the values in
+registers and the stack at the time of the interrupt call to determine how to
+route the system call and which driver function to call with which data values.
 
 Using system calls has three advantages. First, the act of triggering a service
 call interrupt can be used to change the processor state. Rather than being in
@@ -54,7 +49,6 @@ unprivileged mode (as applications are run) and limited by the Memory Protection
 Unit (MPU), after the service call the kernel switches to privileged mode where
 it has full control of system resources (more detail on ARM [processor
 modes](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0553a/CHDIGFCA.html)).
-
 
 Second, context switching to the kernel allows it to do other resource handling
 before returning to the application. This could include running other
@@ -68,57 +62,163 @@ separated from the kernel, no longer need to be loaded at the same time as the
 kernel. They could be uploaded at a later time, modified, and then have a new
 version uploaded, all without modifying the kernel running on a platform.
 
-## Process State
+## Tock System Call Types
 
-In Tock, a process can be in one of seven states:
+Tock has 7 general types (i.e. "classes") of system calls:
 
-- **Running**: Normal operation. A Running process is eligible to be scheduled
-  for execution, although is subject to being paused by Tock to allow interrupt
-  handlers or other processes to run. During normal operation, a process remains
-  in the Running state until it explicitly yields. Upcalls from other kernel
-  operations are not delivered to Running processes (i.e. upcalls do not
-  interrupt processes), rather they are enqueued until the process yields.
-- **Yielded**: Suspended operation. A Yielded process will not be scheduled by
-  Tock. Processes often yield while they are waiting for I/O or other operations
-  to complete and have no immediately useful work to do. Whenever the kernel
-  issues an upcall to a Yielded process, the process is transitioned to the
-  Running state.
-- **Fault**: Erroneous operation. A Fault-ed process will not be scheduled by
-  Tock. Processes enter the Fault state by performing an illegal operation, such
-  as accessing memory outside of their address space.
-- **Terminated** The process ended itself by calling the `Exit` system call and
-  the kernel has not restarted it.
-- **Unstarted** The process has not yet started; this state is typically very
-  short-lived, between process loading and it started. However, in cases when
-  processes might be loaded for a long time without running, this state might be
-  long-lived.
-- **StoppedRunning**, **StoppedYielded** These states correspond to a process
-  that was in either the Running or Yielded state but was then explicitly
-  stopped by the kernel (e.g., by the process console). A process in these
-  states will not be made runnable until it is restarted, at which point it will
-  continue execution where it was stopped.
+| Syscall Class    |
+|------------------|
+| Yield            |
+| Subscribe        |
+| Command          |
+| Read-Write Allow |
+| Read-Only Allow  |
+| Memop            |
+| Exit             |
 
-## Startup
+All communication and interaction between applications and the kernel uses only
+these system calls.
 
-Upon process initialization, a single function call task is added to its upcall
-queue. The function is determined by the ENTRY point in the process TBF header
-(typically the `_start` symbol) and is passed the following arguments in
-registers `r0` - `r3`:
+Within these system calls, there are two general groups of syscalls:
+administrative and capsule-specific.
 
-  * r0: the base address of the process code
-  * r1: the base address of the processes allocated memory region
-  * r2: the total amount of memory in its region
-  * r3: the current process memory break
+1. **Administrative Syscalls**: These adjust the execution or resources of the
+   running process, and are handled entirely by the core kernel. These calls
+   always behave the same way no matter which kernel resources are exposed to
+   userspace. This group includes:
+   - `Yield`
+   - `Memop`
+   - `Exit`
 
-## System Call Invocation
+2. **Capsule-Specific Syscalls**: These interact with specific capsules (i.e.
+   kernel modules). While the general semantics are the same no matter the
+   underlying capsule or resource being accessed, the actual behavior of the
+   syscall depends on which capsule is being accessed. For example, a command to
+   a timer capsule might start a timer, whereas a command to a temperature
+   sensor capsule might start a temperature measurement. This group includes:
+   - `Subscribe`
+   - `Command`
+   - `Read-Write Allow`
+   - `Read-Only Allow`
 
-A process invokes a system call by triggering a software interrupt that
-transitions the microcontroller to supervisor/kernel mode. The exact mechanism
-for this is architecture-specific. [TRD104](reference/trd104-syscalls.md)
-specifies how userspace and the kernel pass values to each other for CortexM and
-RISCV32I platforms.
+All Tock system calls are synchronous, which means they immediately return to
+the application. Capsules must not implement long-running operations by blocking
+on a command system call, as this prevents other applications or kernel routines
+from running – kernel code is never preempted.
 
-## The Context Switch
+### System Call Descriptions
+
+This provides an introduction to each type of Tock system call. These are
+described in much more detail in [TRD104](reference/trd104-syscalls.md).
+
+- `Yield`: An application yields its execution back to the kernel. The kernel
+  will only trigger an upcall for a process after it has called yield.
+
+- `Memop`: This group of "memory operations" allows a process to adjust its
+  memory break (i.e. request more memory be available for the process to use),
+  learn about its memory allocations, and provide debug information.
+
+- `Exit`: An application can call exit to inform the kernel it no longer needs
+  to execute and its resources can be freed. This also lets the process request
+  a restart.
+
+- `Subscribe`: An application can issue a subscribe system call to register
+  upcalls, which are functions being invoked in response to certain events.
+  These upcalls are similar in concept to UNIX signal handlers. A driver can
+  request an application-provided upcall to be invoked. Every system call driver
+  can provide multiple "subscribe slots", each of which the application can
+  register a upcall to.
+
+- `Command`: Applications can use command-type system calls to signal arbitrary
+  events or send requests to the userspace driver. A common use-case for
+  command-style systems calls is, for instance, to request that a driver start
+  some long-running operation.
+
+- `Read-only Allow`: An application may expose some data for drivers to read.
+  Tock provides the read-only allow system call for this purpose: an application
+  invokes this system call passing a buffer, the contents of which are then made
+  accessible to the requested driver. Every driver can have multiple "allow
+  slots", each of which the application can place a buffer in.
+
+- `Read-write Allow`: Works similarly to read-only allow, but enables drivers to
+  also mutate the application-provided buffer.
+
+## Data Movement Between Userspace and Kernel
+
+All data movement and communication between userspace and the kernel happens
+through syscalls. This section describes the general mechanisms for data
+movement that syscalls enable. In this case, we use "data" to be very general
+and describe any form of information transfer.
+
+### Userspace → Kernel
+
+Moving data from a userspace application to the kernel happens in two forms.
+
+1. Instruction with simple options. Applications often want to instruct the
+   kernel to take some action (e.g. play a sound, turn on an LED, or take a
+   sensor reading). Some of these may require small amounts of configuration
+   (e.g. which LED, or the resolution of the sensor reading). This data transfer
+   is possible with the `Command` syscall.
+
+   There are two important considerations for `Command`. First, the amount of
+   data that can be transferred for configuration is on the order of 32 bits.
+   Second, `Command` is non-blocking, meaning the `Command` syscall will finish
+   before the requested operation completes.
+
+2. Arbitrary buffers of data. Applications often need to pass data to the kernel
+   for the kernel to use it for some action (e.g. audio samples to play, data
+   packets to transmit, or data buffers to encrypt). This data transfer is
+   possible with the "allow" family of syscalls, specifically the `Read-only
+   allow`.
+
+   Once an application shares a buffer with the kernel via allow, the process
+   should not use that buffer until it has "un-shared" the buffer with the
+   kernel.
+
+### Kernel → Userspace
+
+Moving data from the kernel to a userspace application to the kernel happens in
+three ways.
+
+1. Small data that is synchronously available. The kernel may have status
+   information or fixed values it can send to an application (e.g. how many
+   packets have been sent, or the maximum resolution of an ADC). This can be
+   shared via the return value to a `Command` syscall. An application must call
+   the `Command` syscall, and the return value must be immediately available,
+   but the kernel can provide about 12 bytes of data back to the application via
+   the return value to the command syscall.
+
+2. Arbitrary buffers of data. The kernel may have more data to send to
+   application (e.g. an incoming data packet, or ADC readings). This data can be
+   shared with the application by filling in a buffer the application has
+   already shared with the kernel via an allow syscall. For the kernel to be
+   able to modify the buffer, the application must have called the `Read-write
+   allow` syscall.
+
+3. Events with small amounts of data. The kernel may need to notify an
+   application about a recent event or provide small amounts of new data (e.g. a
+   button was pressed, a sensor reading is newly available, or a incoming packet
+   has arrived). This is accomplished by the kernel issuing an "upcall" to the
+   application. You can think of an upcall as a callback, where when the process
+   resumes running it executes a particular function provided with particular
+   arguments.
+
+   For the kernel to be able to trigger an upcall, the process must have first
+   called `Subscribe` to pass the address of the function the upcall will
+   execute.
+
+   The kernel can pass a few arguments (roughly 12 bytes) with the upcall. This
+   is useful for providing small amounts of data, like a reading sensor reading.
+
+## System Call Implementations
+
+All system calls are implemented via context switches. A couple values are
+passed along with the context switch to indicate the type and manor of the
+syscall. A process invokes a system call by triggering context switch via a
+software interrupt that transitions the microcontroller to supervisor/kernel
+mode. The exact mechanism for this is architecture-specific.
+[TRD104](reference/trd104-syscalls.md) specifies how userspace and the kernel
+pass values to each other for Cortex-M and RV32I platforms.
 
 Handling a context switch is one of the few pieces of architecture-specific Tock
 code. The code is located in `lib.rs` within the `arch/` folder under the
@@ -212,31 +312,53 @@ registers except for this return value register (`a0`). However, the `yield()`
 system call results in a upcall executing in the process. This can clobber all
 caller saved registers, as well as the return address (`ra`) register.
 
-## How System Calls Connect to Drivers
+## Upcalls
+
+The kernel can signal events to userspace via upcalls. Upcalls run a function in
+userspace after a context switch. The kernel, as part of the upcall, provides
+four 32 bit arguments. The address of the function to run is provided via the
+`Subscribe` syscall.
+
+### Process Startup
+
+Upon process initialization, the kernel starts executing a process by running an
+upcall to the process's entry point. A single function call task is added to the
+process's upcall queue. The function is determined by the ENTRY point in the
+process TBF header (typically the `_start` symbol) and is passed the following
+arguments in registers `r0` - `r3`:
+
+- `r0`: the base address of the process code
+- `r1`: the base address of the processes allocated memory region
+- `r2`: the total amount of memory in its region
+- `r3`: the current process memory break
+
+
+## How System Calls Connect to Capsules (Drivers)
 
 After a system call is made, the call is handled and routed by the Tock kernel
 in [`sched.rs`](../kernel/src/kernel.rs) through a series of steps.
 
-1. For Command, Subscribe, Allow Read-Write, and Allow Read-Only system call
-   classes, the kernel calls a platform-defined system call filter function.
-   This function determines if the kernel should handle the system call or not.
-   Yield, Exit, and Memop system calls are not filtered. This filter function
-   allows the kernel to impose security policies that limit which system calls a
-   process might invoke. The filter function takes the system call and which
-   process issued the system call to return a `Result<(), ErrorCode>` to signal
-   if the system call should be handled or if an error should be returned to the
-   process. If the filter function disallows the system call it returns
-   `Err(ErrorCode)` and the `ErrorCode` is provided to the process as the return
-   code for the system call. Otherwise, the system call proceeds. _The filter
-   interface is unstable and may be changed in the future._
+1. For `Command`, `Subscribe`, `Read-Write Allow`, and `Read-Only Allow` system
+   calls, the kernel calls a platform-defined system call filter function. This
+   function determines if the kernel should handle the system call or not.
+   `Yield`, `Exit`, and `Memop` system calls are not filtered. This filter
+   function allows the kernel to impose security policies that limit which
+   system calls a process might invoke. The filter function takes the system
+   call and which process issued the system call to return a `Result<(),
+   ErrorCode>` to signal if the system call should be handled or if an error
+   should be returned to the process. If the filter function disallows the
+   system call it returns `Err(ErrorCode)` and the `ErrorCode` is provided to
+   the process as the return code for the system call. Otherwise, the system
+   call proceeds. _The filter interface is unstable and may be changed in the
+   future._
 
-2. The kernel scheduler loop handles the Exit and Yield system call classes.
+2. The kernel scheduler loop handles the `Exit` and `Yield` system calls.
 
-3. To handle Memop system calls, the scheduler loop invokes the `memop` module,
-   which implements the Memop class.
+3. To handle `Memop` system calls, the scheduler loop invokes the `memop`
+   module, which implements the Memop class.
 
-4. Allow Read-Write, Allow Read-Only, Subscribe, and Command follow a more
-   complex execution path because are implemented by drivers.  To route these
+4. `Command`, `Subscribe`, `Read-Write Allow`, and `Read-Only Allow` follow a more
+   complex execution path because are implemented by drivers. To route these
    system calls, the scheduler loop calls a struct that implements the
    `SyscallDriverLookup` trait. This trait has a `with_driver()` function that
    the driver number as an argument and returns either a reference to the
@@ -244,36 +366,86 @@ in [`sched.rs`](../kernel/src/kernel.rs) through a series of steps.
    returned reference to call the appropriate system call function on that
    driver with the remaining system call arguments.
 
-An example board that implements the `SyscallDriverLookup` trait looks something
-like this:
+   An example board that implements the `SyscallDriverLookup` trait looks
+   something like this:
 
-```rust
-struct TestBoard {
-    console: &'static Console<'static, usart::USART>,
-}
+   ```rust
+   struct TestBoard {
+       console: &'static Console<'static, usart::USART>,
+   }
 
-impl SyscallDriverLookup for TestBoard {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
-        where F: FnOnce(Option<&kernel::syscall::SyscallDriver>) -> R
-    {
+   impl SyscallDriverLookup for TestBoard {
+       fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+           where F: FnOnce(Option<&kernel::syscall::SyscallDriver>) -> R
+       {
 
-        match driver_num {
-            0 => f(Some(self.console)), // use capsules::console::DRIVER_NUM rather than 0 in real code
-            _ => f(None),
-        }
-    }
-}
-```
+           match driver_num {
+               0 => f(Some(self.console)), // use capsules::console::DRIVER_NUM rather than 0 in real code
+               _ => f(None),
+           }
+       }
+   }
+   ```
 
-`TestBoard` then supports one driver, the UART console, and maps it to driver
-number 0. Any `command`, `subscribe`, and `allow` sycalls to driver number 0
-will get routed to the console, and all other driver numbers will return
-`Err(ErrorCode::NODEVICE)`.
+   `TestBoard` then supports one driver, the UART console, and maps it to driver
+   number 0. Any `command`, `subscribe`, and `allow` sycalls to driver number 0
+   will get routed to the console, and all other driver numbers will return
+   `Err(ErrorCode::NODEVICE)`.
 
-## Error and Return Types
+## Identifying Syscalls
+
+A series of numbers and conventions identify syscalls as they pass via a context
+switch.
+
+### Syscall Class
+
+The first identifier specifies which syscall it is. The values are specified as
+in the table and are fixed by convention.
+
+| Syscall Class    | Syscall Class Number |
+|------------------|----------------------|
+| Yield            |           0          |
+| Subscribe        |           1          |
+| Command          |           2          |
+| Read-Write Allow |           3          |
+| Read-Only Allow  |           4          |
+| Memop            |           5          |
+| Exit             |           6          |
+
+### Driver Numbers
+
+For capsule-specific syscalls, the syscall must be directed to the correct
+capsule (driver). The `with_driver()` function takes an argument `driver_num` to
+identify the driver.
+
+To enable the kernel and userspace to agree, we maintain a
+[list](https://github.com/tock/tock/blob/master/capsules/core/src/driver.rs) of
+known driver numbers.
+
+To support custom capsules and driver, a `driver_num` whose highest bit is set
+is private and can be used by out-of-tree drivers.
+
+### Syscall-Specific Numbers
+
+For each capsule/driver, the driver can support more than one of each syscall
+(e.g. it can support multiple commands). Another number included in the context
+switch indicates which of the syscall the call refers to.
+
+For the `Command` syscall, the `command_num` 0 is reserved as an existence
+check: userspace can call a command for a driver with `command_num` 0 to check
+if the driver is installed on the board. Otherwise, the numbers are entirely
+driver-specific.
+
+For `Subscribe`, `Read-only allow`, and `Read-write allow`, the numbers start at
+0 and increment for each defined use of the various syscalls. There cannot be a
+gap between valid subscribe or allow numbers. The actual meaning of each
+subscribe or allow number is driver-specific.
+
+## Identifying Error and Return Types
 
 Tock includes some defined types and conventions for errors and return values
-between the kernel and userspace.
+between the kernel and userspace. These allow the kernel to indicate success and
+failure to userspace.
 
 ### Naming Conventions
 
@@ -306,11 +478,3 @@ between the kernel and userspace.
   - `SyscallReturn`: The return type for a syscall. Includes whether the syscall
     succeeded or failed, optionally additional data values, and in the case of
     failure an `ErrorCode`.
-
-## Allocated Driver Numbers
-
-All documented drivers are in the [doc/syscalls](syscalls/README.md) folder.
-
-The `with_driver()` function takes an argument `driver_num` to identify the
-driver. `driver_num` whose highest bit is set is private and can be used by
-out-of-tree drivers.


### PR DESCRIPTION
### Pull Request Overview

Leon wrote some nice text for the encryption oracle tutorial that I thought would be better in the main tock documentation. That prompted me to update the syscalls doc. I added more basic overview of syscalls that we didn't have. I also reorganized the document.

Heads up, the first commit is a formatting commit so the delta might be easier to look at on a per-commit basis.

There was a section on process states which doesn't have much to do with syscalls so I moved that to a new document on scheduling.


### Testing Strategy

doc


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
