### PR TITLE
lora_things_plus: Remove external sensors by default

### DIFF
--- a/boards/apollo3/lora_things_plus/src/tests/mod.rs
+++ b/boards/apollo3/lora_things_plus/src/tests/mod.rs
@@ -34,6 +34,7 @@ fn trivial_assertion() {
     run_kernel_op(10000);
 }
 
-mod environmental_sensors;
+// Disabled unless the sensors are connected
+// mod environmental_sensors;
 mod multi_alarm;
 mod spi_controller;


### PR DESCRIPTION
### Pull Request Overview

Remove the external sensor from the default board configuration as they aren't part of this board, but can easily be connected.

### Testing Strategy

Tock unit tests

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
