### PR TITLE
Common build script

### DIFF
--- a/boards/acd52832/Cargo.toml
+++ b/boards/acd52832/Cargo.toml
@@ -6,7 +6,7 @@
 name = "acd52832"
 version.workspace = true
 authors.workspace = true
-build = "build.rs"
+build = "../build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/acd52832/build.rs
+++ b/boards/acd52832/build.rs
@@ -1,8 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=../kernel_layout.ld");
-}

--- a/boards/apollo3/lora_things_plus/Cargo.toml
+++ b/boards/apollo3/lora_things_plus/Cargo.toml
@@ -7,7 +7,7 @@ name = "lora_things_plus"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-build = "build.rs"
+build = "../../build.rs"
 
 
 [dependencies]

--- a/boards/apollo3/lora_things_plus/build.rs
+++ b/boards/apollo3/lora_things_plus/build.rs
@@ -1,8 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=../layout.ld");
-    println!("cargo:rerun-if-changed=../../kernel_layout.ld");
-}

--- a/boards/apollo3/redboard_artemis_nano/Cargo.toml
+++ b/boards/apollo3/redboard_artemis_nano/Cargo.toml
@@ -7,7 +7,7 @@ name = "redboard_artemis_nano"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-build = "build.rs"
+build = "../../build.rs"
 
 [dependencies]
 components = { path = "../../components" }

--- a/boards/apollo3/redboard_artemis_nano/build.rs
+++ b/boards/apollo3/redboard_artemis_nano/build.rs
@@ -1,8 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=../kernel_layout.ld");
-}

--- a/boards/arty_e21/Cargo.toml
+++ b/boards/arty_e21/Cargo.toml
@@ -6,7 +6,7 @@
 name = "arty_e21"
 version.workspace = true
 authors.workspace = true
-build = "build.rs"
+build = "../build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/arty_e21/build.rs
+++ b/boards/arty_e21/build.rs
@@ -1,8 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=../kernel_layout.ld");
-}

--- a/boards/build.rs
+++ b/boards/build.rs
@@ -1,0 +1,49 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2024.
+
+//! This build script can be used by Tock board crates to ensure that they are
+//! rebuilt when there are any changes to the `layout.ld` linker script or any
+//! of its `INCLUDE`s.
+//!
+//! Board crates can use this script from their `Cargo.toml` files:
+//!
+//! ```toml
+//! [package]
+//! # ...
+//! build = "../path/to/build.rs"
+//! ```
+
+use std::fs;
+use std::path::Path;
+
+const LINKER_SCRIPT: &str = "layout.ld";
+
+fn main() {
+    if !Path::new(LINKER_SCRIPT).exists() {
+        panic!("Boards must provide a `layout.ld` link script file");
+    }
+
+    track_linker_script(LINKER_SCRIPT);
+}
+
+/// Track the given linker script and all of its `INCLUDE`s so that the build
+/// is rerun when any of them change.
+fn track_linker_script<P: AsRef<Path>>(path: P) {
+    let path = path.as_ref();
+
+    assert!(path.is_file(), "expected path {path:?} to be a file");
+
+    println!("cargo:rerun-if-changed={}", path.display());
+
+    // Find all the `INCLUDE <relative path>` lines in the linker script.
+    let link_script = fs::read_to_string(path).expect("failed to read {path:?}");
+    let includes = link_script
+        .lines()
+        .filter_map(|line| line.strip_prefix("INCLUDE").map(str::trim));
+
+    // Recursively track included linker scripts.
+    for include in includes {
+        track_linker_script(include);
+    }
+}

--- a/boards/clue_nrf52840/Cargo.toml
+++ b/boards/clue_nrf52840/Cargo.toml
@@ -6,7 +6,7 @@
 name = "clue_nrf52840"
 version.workspace = true
 authors.workspace = true
-build = "build.rs"
+build = "../build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/clue_nrf52840/build.rs
+++ b/boards/clue_nrf52840/build.rs
@@ -1,8 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=../kernel_layout.ld");
-}

--- a/boards/esp32-c3-devkitM-1/Cargo.toml
+++ b/boards/esp32-c3-devkitM-1/Cargo.toml
@@ -6,7 +6,7 @@
 name = "esp32-c3-board"
 version.workspace = true
 authors.workspace = true
-build = "build.rs"
+build = "../build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/esp32-c3-devkitM-1/build.rs
+++ b/boards/esp32-c3-devkitM-1/build.rs
@@ -1,8 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=../kernel_layout.ld");
-}

--- a/boards/hail/Cargo.toml
+++ b/boards/hail/Cargo.toml
@@ -6,7 +6,7 @@
 name = "hail"
 version.workspace = true
 authors.workspace = true
-build = "build.rs"
+build = "../build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/hail/build.rs
+++ b/boards/hail/build.rs
@@ -1,9 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=chip_layout.ld");
-    println!("cargo:rerun-if-changed=../kernel_layout.ld");
-}

--- a/boards/hifive1/Cargo.toml
+++ b/boards/hifive1/Cargo.toml
@@ -6,7 +6,7 @@
 name = "hifive1"
 version.workspace = true
 authors.workspace = true
-build = "build.rs"
+build = "../build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/hifive1/build.rs
+++ b/boards/hifive1/build.rs
@@ -1,8 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=../kernel_layout.ld");
-}

--- a/boards/hifive_inventor/Cargo.toml
+++ b/boards/hifive_inventor/Cargo.toml
@@ -6,7 +6,7 @@
 name = "hifive_inventor"
 version.workspace = true
 authors.workspace = true
-build = "build.rs"
+build = "../build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/hifive_inventor/build.rs
+++ b/boards/hifive_inventor/build.rs
@@ -1,8 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=../kernel_layout.ld");
-}

--- a/boards/imix/Cargo.toml
+++ b/boards/imix/Cargo.toml
@@ -6,7 +6,7 @@
 name = "imix"
 version.workspace = true
 authors.workspace = true
-build = "build.rs"
+build = "../build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/imix/build.rs
+++ b/boards/imix/build.rs
@@ -1,8 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=../kernel_layout.ld");
-}

--- a/boards/imxrt1050-evkb/Cargo.toml
+++ b/boards/imxrt1050-evkb/Cargo.toml
@@ -6,7 +6,7 @@
 name = "imxrt1050-evkb"
 version.workspace = true
 authors.workspace = true
-build = "build.rs"
+build = "../build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/imxrt1050-evkb/build.rs
+++ b/boards/imxrt1050-evkb/build.rs
@@ -1,9 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=chip_layout.ld");
-    println!("cargo:rerun-if-changed=../kernel_layout.ld");
-}

--- a/boards/imxrt1050-evkb/build.rs
+++ b/boards/imxrt1050-evkb/build.rs
@@ -6,7 +6,4 @@ fn main() {
     println!("cargo:rerun-if-changed=layout.ld");
     println!("cargo:rerun-if-changed=chip_layout.ld");
     println!("cargo:rerun-if-changed=../kernel_layout.ld");
-
-    // rebuild if `asm.s` changed
-    println!("cargo:rerun-if-changed=hdr.s"); // <- NEW!
 }

--- a/boards/imxrt1050-evkb/hdr.s
+++ b/boards/imxrt1050-evkb/hdr.s
@@ -1,6 +1,0 @@
-# Licensed under the Apache License, Version 2.0 or the MIT License.
-# SPDX-License-Identifier: Apache-2.0 OR MIT
-# Copyright Tock Contributors 2022.
-
-.section .boot_hdr, "ax"
-.incbin "boot_header"

--- a/boards/litex/arty/Cargo.toml
+++ b/boards/litex/arty/Cargo.toml
@@ -6,7 +6,7 @@
 name = "litex_arty"
 version.workspace = true
 authors.workspace = true
-build = "build.rs"
+build = "../../build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/litex/arty/build.rs
+++ b/boards/litex/arty/build.rs
@@ -1,8 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=../../kernel_layout.ld");
-}

--- a/boards/litex/sim/Cargo.toml
+++ b/boards/litex/sim/Cargo.toml
@@ -6,7 +6,7 @@
 name = "litex_sim"
 version.workspace = true
 authors.workspace = true
-build = "build.rs"
+build = "../../build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/litex/sim/build.rs
+++ b/boards/litex/sim/build.rs
@@ -1,8 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=../../kernel_layout.ld");
-}

--- a/boards/microbit_v2/Cargo.toml
+++ b/boards/microbit_v2/Cargo.toml
@@ -6,7 +6,7 @@
 name = "microbit_v2"
 version.workspace = true
 authors.workspace = true
-build = "build.rs"
+build = "../build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/microbit_v2/build.rs
+++ b/boards/microbit_v2/build.rs
@@ -1,8 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=../kernel_layout.ld");
-}

--- a/boards/msp_exp432p401r/Cargo.toml
+++ b/boards/msp_exp432p401r/Cargo.toml
@@ -6,7 +6,7 @@
 name = "msp-exp432p401r"
 version.workspace = true
 authors.workspace = true
-build = "build.rs"
+build = "../build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/msp_exp432p401r/build.rs
+++ b/boards/msp_exp432p401r/build.rs
@@ -1,9 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=chip_layout.ld");
-    println!("cargo:rerun-if-changed=../kernel_layout.ld");
-}

--- a/boards/nano33ble/Cargo.toml
+++ b/boards/nano33ble/Cargo.toml
@@ -6,7 +6,7 @@
 name = "nano33ble"
 version.workspace = true
 authors.workspace = true
-build = "build.rs"
+build = "../build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/nano33ble/build.rs
+++ b/boards/nano33ble/build.rs
@@ -1,8 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=../kernel_layout.ld");
-}

--- a/boards/nano_rp2040_connect/Cargo.toml
+++ b/boards/nano_rp2040_connect/Cargo.toml
@@ -6,7 +6,7 @@
 name = "nano_rp2040_connect"
 version.workspace = true
 authors.workspace = true
-build = "build.rs"
+build = "../build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/nano_rp2040_connect/build.rs
+++ b/boards/nano_rp2040_connect/build.rs
@@ -1,8 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=../kernel_layout.ld");
-}

--- a/boards/nordic/nrf52840_dongle/Cargo.toml
+++ b/boards/nordic/nrf52840_dongle/Cargo.toml
@@ -6,7 +6,7 @@
 name = "nrf52840_dongle"
 version.workspace = true
 authors.workspace = true
-build = "build.rs"
+build = "../../build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/nordic/nrf52840_dongle/build.rs
+++ b/boards/nordic/nrf52840_dongle/build.rs
@@ -1,8 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=../../kernel_layout.ld");
-}

--- a/boards/nordic/nrf52840dk/Cargo.toml
+++ b/boards/nordic/nrf52840dk/Cargo.toml
@@ -6,7 +6,7 @@
 name = "nrf52840dk"
 version.workspace = true
 authors.workspace = true
-build = "build.rs"
+build = "../../build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/nordic/nrf52840dk/build.rs
+++ b/boards/nordic/nrf52840dk/build.rs
@@ -1,9 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=../../kernel_layout.ld");
-    println!("cargo:rerun-if-changed=../nrf52840_chip_layout.ld");
-}

--- a/boards/nordic/nrf52dk/Cargo.toml
+++ b/boards/nordic/nrf52dk/Cargo.toml
@@ -6,7 +6,7 @@
 name = "nrf52dk"
 version.workspace = true
 authors.workspace = true
-build = "build.rs"
+build = "../../build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/nordic/nrf52dk/build.rs
+++ b/boards/nordic/nrf52dk/build.rs
@@ -1,8 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=../../kernel_layout.ld");
-}

--- a/boards/nucleo_f429zi/Cargo.toml
+++ b/boards/nucleo_f429zi/Cargo.toml
@@ -6,7 +6,7 @@
 name = "nucleo_f429zi"
 version.workspace = true
 authors.workspace = true
-build = "build.rs"
+build = "../build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/nucleo_f429zi/build.rs
+++ b/boards/nucleo_f429zi/build.rs
@@ -1,9 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=chip_layout.ld");
-    println!("cargo:rerun-if-changed=../kernel_layout.ld");
-}

--- a/boards/nucleo_f446re/Cargo.toml
+++ b/boards/nucleo_f446re/Cargo.toml
@@ -6,7 +6,7 @@
 name = "nucleo_f446re"
 version.workspace = true
 authors.workspace = true
-build = "build.rs"
+build = "../build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/nucleo_f446re/build.rs
+++ b/boards/nucleo_f446re/build.rs
@@ -1,9 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=chip_layout.ld");
-    println!("cargo:rerun-if-changed=../kernel_layout.ld");
-}

--- a/boards/opentitan/earlgrey-cw310/Cargo.toml
+++ b/boards/opentitan/earlgrey-cw310/Cargo.toml
@@ -6,7 +6,7 @@
 name = "earlgrey-cw310"
 version.workspace = true
 authors.workspace = true
-build = "build.rs"
+build = "../../build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/opentitan/earlgrey-cw310/build.rs
+++ b/boards/opentitan/earlgrey-cw310/build.rs
@@ -1,8 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=../../kernel_layout.ld");
-}

--- a/boards/particle_boron/Cargo.toml
+++ b/boards/particle_boron/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
     "Tock Project Developers <tock-dev@googlegroups.com>",
     "Wilfred Mallawa <vindulawilfred@gmail.com>"
     ]
-build = "build.rs"
+build = "../build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/particle_boron/build.rs
+++ b/boards/particle_boron/build.rs
@@ -1,8 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=../../kernel_layout.ld");
-}

--- a/boards/pico_explorer_base/Cargo.toml
+++ b/boards/pico_explorer_base/Cargo.toml
@@ -6,7 +6,7 @@
 name = "pico_explorer_base"
 version.workspace = true
 authors.workspace = true
-build = "build.rs"
+build = "../build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/pico_explorer_base/build.rs
+++ b/boards/pico_explorer_base/build.rs
@@ -1,8 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=../kernel_layout.ld");
-}

--- a/boards/qemu_rv32_virt/Cargo.toml
+++ b/boards/qemu_rv32_virt/Cargo.toml
@@ -7,7 +7,7 @@ name = "qemu_rv32_virt"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-build = "build.rs"
+build = "../build.rs"
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/qemu_rv32_virt/build.rs
+++ b/boards/qemu_rv32_virt/build.rs
@@ -1,8 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=../kernel_layout.ld");
-}

--- a/boards/raspberry_pi_pico/Cargo.toml
+++ b/boards/raspberry_pi_pico/Cargo.toml
@@ -6,7 +6,7 @@
 name = "raspberry_pi_pico"
 version.workspace = true
 authors.workspace = true
-build = "build.rs"
+build = "../build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/raspberry_pi_pico/build.rs
+++ b/boards/raspberry_pi_pico/build.rs
@@ -1,8 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=../kernel_layout.ld");
-}

--- a/boards/redboard_redv/Cargo.toml
+++ b/boards/redboard_redv/Cargo.toml
@@ -7,7 +7,7 @@ name = "redboard_redv"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-build = "build.rs"
+build = "../build.rs"
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/redboard_redv/build.rs
+++ b/boards/redboard_redv/build.rs
@@ -1,8 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=../kernel_layout.ld");
-}

--- a/boards/sma_q3/Cargo.toml
+++ b/boards/sma_q3/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
     "Tock Project Developers <tock-dev@googlegroups.com>",
     "Dorota <gihu.dcz@porcupinefactory.org>"
 ]
-build = "build.rs"
+build = "../build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/sma_q3/build.rs
+++ b/boards/sma_q3/build.rs
@@ -1,8 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=../../kernel_layout.ld");
-}

--- a/boards/stm32f3discovery/Cargo.toml
+++ b/boards/stm32f3discovery/Cargo.toml
@@ -6,7 +6,7 @@
 name = "stm32f3discovery"
 version.workspace = true
 authors.workspace = true
-build = "build.rs"
+build = "../build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/stm32f3discovery/build.rs
+++ b/boards/stm32f3discovery/build.rs
@@ -1,9 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=chip_layout.ld");
-    println!("cargo:rerun-if-changed=../kernel_layout.ld");
-}

--- a/boards/stm32f412gdiscovery/Cargo.toml
+++ b/boards/stm32f412gdiscovery/Cargo.toml
@@ -6,7 +6,7 @@
 name = "stm32f412gdiscovery"
 version.workspace = true
 authors.workspace = true
-build = "build.rs"
+build = "../build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/stm32f412gdiscovery/build.rs
+++ b/boards/stm32f412gdiscovery/build.rs
@@ -1,9 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=chip_layout.ld");
-    println!("cargo:rerun-if-changed=../kernel_layout.ld");
-}

--- a/boards/stm32f429idiscovery/Cargo.toml
+++ b/boards/stm32f429idiscovery/Cargo.toml
@@ -7,7 +7,7 @@ name = "stm32f429idiscovery"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-build = "build.rs"
+build = "../build.rs"
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/stm32f429idiscovery/build.rs
+++ b/boards/stm32f429idiscovery/build.rs
@@ -1,9 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=chip_layout.ld");
-    println!("cargo:rerun-if-changed=../kernel_layout.ld");
-}

--- a/boards/swervolf/Cargo.toml
+++ b/boards/swervolf/Cargo.toml
@@ -6,7 +6,7 @@
 name = "swervolf"
 version.workspace = true
 authors.workspace = true
-build = "build.rs"
+build = "../build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/swervolf/build.rs
+++ b/boards/swervolf/build.rs
@@ -1,8 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=../kernel_layout.ld");
-}

--- a/boards/teensy40/Cargo.toml
+++ b/boards/teensy40/Cargo.toml
@@ -6,7 +6,7 @@
 name = "teensy40"
 version.workspace = true
 authors.workspace = true
-build = "build.rs"
+build = "../build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/teensy40/build.rs
+++ b/boards/teensy40/build.rs
@@ -1,8 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=../kernel_layout.ld");
-}

--- a/boards/weact_f401ccu6/Cargo.toml
+++ b/boards/weact_f401ccu6/Cargo.toml
@@ -6,7 +6,7 @@
 name = "weact-f401ccu6"
 version.workspace = true
 authors.workspace = true
-build = "build.rs"
+build = "../build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/weact_f401ccu6/build.rs
+++ b/boards/weact_f401ccu6/build.rs
@@ -1,8 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=../kernel_layout.ld");
-}

--- a/doc/Compilation.md
+++ b/doc/Compilation.md
@@ -94,11 +94,11 @@ commands.
 
 #### Platform Build Scripts
 
-Cargo supports [build
-scripts](https://doc.rust-lang.org/cargo/reference/build-scripts.html) when
-compiling crates, and each Tock platform crate includes a `build.rs` build
-script. In Tock, these build scripts are primarily used to instruct cargo to
-rebuild the kernel if a linker script changes.
+Cargo supports
+[build scripts](https://doc.rust-lang.org/cargo/reference/build-scripts.html)
+when compiling crates, and Tock provides the `boards/build.rs` build script. In
+Tock, these build scripts are primarily used to instruct cargo to rebuild the
+kernel if a linker script changes.
 
 Cargo's `build.rs` scripts are small Rust programs that must be compiled as part
 of the kernel build process. Since these scripts execute on the host machine,

--- a/doc/OutOfTree.md
+++ b/doc/OutOfTree.md
@@ -53,6 +53,7 @@ something like:
     │   └── my_board
     │       ├── Cargo.toml
     │       ├── Makefile
+    │       ├── layout.ld
     │       └── src
     │           └── main.rs
     ├── my_drivers
@@ -96,6 +97,7 @@ to elements of Tock.
   name = "my_board"
   version = "0.1.0"
   authors = ["Example Developer <developer@example.com>"]
+  build = "../../tock/boards/build.rs"
 
   [profile.dev]
   panic = "abort"
@@ -115,7 +117,9 @@ to elements of Tock.
   my_drivers = { path = "../../my_drivers" }
   ```
 
-
+If using a linker script named `layout.ld`, your board crate can make use of the
+Tock submodule's `build.rs` script to ensure it rebuilds when any linker scripts
+change.
 
 Everything Else
 ---------------

--- a/doc/Porting.md
+++ b/doc/Porting.md
@@ -352,9 +352,11 @@ file named `io.rs` adjacent to the board's `main.rs` file.
 
 Every board crate must author a top-level manifest, `Cargo.toml`. In general,
 you can probably simply copy this from another board, modifying the board name
-and author(s) as appropriate. Note that Tock also includes a build script,
-`build.rs`, that you should also copy. The build script simply adds a dependency
-on the kernel layout.
+and author(s) as appropriate.
+
+Note that Tock also provides a build script, `boards/build.rs`, that you should
+add to your `Cargo.toml` manifest. The build script simply adds a dependency
+on any link scripts to ensure the board is rebuilt when any changes.
 
 ##### Board Makefile
 


### PR DESCRIPTION
### Pull Request Overview

This pull request consolidates all board `build.rs` scripts into a common `boards/build.rs`.

Currently, all build scripts are used to print `cargo:rerun-if-changed=...` lines for the link scripts that they use. Some are missing these lines for scripts that are included in `layout.ld`.

One build script (imxrt1050-evkb) was also tracking a `hdr.s` file, but as far as I can tell this file is not used so I have removed it.

The motivation for this change is to simplify the repo and make `build.rs` scripts less error prone (e.g. fixing the ones that miss `rerun-if-changed` lines). I also hope that having only one `build.rs` script will open Tock up to moving some configuration out of `Makefile`s to Cargo such that `cargo build` works (but `make` would likely still be used).

Apologies for another PR that touches loads of files :)

### Testing Strategy

1. Run `make boards` to make sure they all compile.
2. Re-run `make` for a board to ensure it does not recompile.
3. Touch the board's `layout.ld` and run `make` to check that it _does_ recompile / relink.
4. Touch `kernel_layout.ld` and run `make` to check that included files trigger recompilation too.

### TODO or Help Wanted

If, in the future, boards need something else in their `build.rs` script, they will not be able to use this shared script. I think in that case the `track_link_script` function could be put in a tiny `build-utils` crate or similar and used by individual build scripts as a `[build-dependency]` in their custom `build.rs` scripts to avoid duplicating the code. Does that sound acceptable?

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

I only found `build.rs` references in `doc/Compilation.md` and doc/Porting.md`.

### Formatting

- [x] Ran `make prepush`.
