### PR TITLE
Update pinned tock-litex release to 2024011101

### DIFF
--- a/.github/workflows/litex_sim.yml
+++ b/.github/workflows/litex_sim.yml
@@ -92,7 +92,7 @@ jobs:
           # The pinned revision is different from the targeted release as
           # documented in the LiteX boards, as the CI requires special patches
           # to LiteX for interacting with the simulation:
-          ref: 2022081701-tock-ci-0
+          ref: 2024011101-tock-ci-1
           path: tock-litex
 
       # Install all of the required Python packages from the tock-litex'

--- a/boards/litex/arty/README.md
+++ b/boards/litex/arty/README.md
@@ -11,9 +11,9 @@ differ significantly depending on the LiteX release and configuration
 options used. This board definition currently targets and has been
 tested with
 - [the LiteX SoC generator, revision
-  c4e635ea5c91ca](https://github.com/enjoy-digital/litex/tree/c4e635ea5c91ca)
+  a6d9955c9d3065](https://github.com/enjoy-digital/litex/tree/a6d9955c9d3065)
 - using the companion [target
-  file](https://github.com/litex-hub/litex-boards/blob/bf458e388efea4/litex_boards/targets/digilent_arty.py)
+  file](https://github.com/litex-hub/litex-boards/blob/52f9f0f1079085/litex_boards/targets/digilent_arty.py)
   from `litex-boards`
 - built around a VexRiscv-CPU with PMP, hardware multiplication and
   compressed instruction support (named `TockSecureIMC`)
@@ -24,7 +24,12 @@ tested with
   --cpu-variant=tock+secure+imc
   --csr-data-width=32
   --timer-uptime
+  --integrated-rom-size=0xb000
   --with-ethernet
+  --with-buttons
+  --with-xadc
+  --with-dna
+  --with-spi-flash
   ```
 
 The `tock+secure+imc` is a custom VexRiscv CPU variant, based on the
@@ -39,7 +44,7 @@ Verilog files and a patched LiteX version to support them) can be
 obtained from the [Tock on LiteX companion repository
 releases](https://github.com/lschuermann/tock-litex/releases/). The
 current board definition has been verified to work with [release
-2022081701](https://github.com/lschuermann/tock-litex/releases/tag/2022081701).
+2024011101](https://github.com/lschuermann/tock-litex/releases/tag/2024011101).
 The bitstream for this board is located in `digilent_arty_a7-35t.zip`
 or `digilent_arty_a7-100t.zip` under `gateware/digilent_arty.bit`.
 
@@ -59,18 +64,24 @@ and cores are supported:
 - [X] UART output via USB-FTDI
 - [X] Green onboard LEDs
 - [X] 100MBit/s Ethernet MAC
+- [X] GPIO Interface
+- [X] Buttons and Switches
 
 The following components and cores require porting:
-- [ ] GPIO Interface
-- [ ] Buttons and Switches
 - [ ] RGB LEDs
+- [ ] XADC Core
+- [ ] FPGA DNA Core
+- [ ] SPI Flash
 
 
 Building the SoC / Programming the FPGA
 ---------------------------------------
 
-Please refer to the [LiteX
-documentation](https://github.com/enjoy-digital/litex/wiki/) for
+The [Tock on LiteX companion
+repository](https://github.com/lschuermann/tock-litex) contains instructions for
+how to build the specific FPGA bitstream as targeted with this board
+definition. Please refer to the [LiteX
+documentation](https://github.com/enjoy-digital/litex/wiki/) for general
 instructions on how to install and use the LiteX SoC generator.
 
 Once LiteX and Xilinx Vivado is installed, building a bitstream should

--- a/boards/litex/arty/src/litex_generated_constants.rs
+++ b/boards/litex/arty/src/litex_generated_constants.rs
@@ -49,9 +49,10 @@ pub const CSR_ETHPHY_BASE: usize = CSR_BASE + 0x2800;
 pub const CSR_IDENTIFIER_MEM_BASE: usize = CSR_BASE + 0x3000;
 pub const CSR_LEDS_BASE: usize = CSR_BASE + 0x3800;
 pub const CSR_SDRAM_BASE: usize = CSR_BASE + 0x4000;
-pub const CSR_TIMER0_BASE: usize = CSR_BASE + 0x4800;
-pub const CSR_UART_BASE: usize = CSR_BASE + 0x5000;
-pub const CSR_XADC_BASE: usize = CSR_BASE + 0x5800;
+pub const CSR_SPIFLASH_CORE_BASE: usize = CSR_BASE + 0x4800;
+pub const CSR_TIMER0_BASE: usize = CSR_BASE + 0x5000;
+pub const CSR_UART_BASE: usize = CSR_BASE + 0x5800;
+pub const CSR_XADC_BASE: usize = CSR_BASE + 0x6000;
 
 // constants defined in `generated/mem.h`
 pub const MEM_ETHMAC_BASE: usize = 0x80000000;

--- a/boards/litex/sim/README.md
+++ b/boards/litex/sim/README.md
@@ -9,9 +9,9 @@ Since LiteX is a SoC builder, the individual generated SoCs can differ
 significantly depending on the release and configuration options
 used. This board definition currently targets and has been tested with
 - [the LiteX SoC generator, revision
-  c4e635ea5c91ca](https://github.com/enjoy-digital/litex/tree/c4e635ea5c91ca)
+  a6d9955c9d3065](https://github.com/enjoy-digital/litex/tree/a6d9955c9d3065)
 - using the included
-  [`litex_sim`](https://github.com/enjoy-digital/litex/blob/c4e635ea5c91ca/litex/tools/litex_sim.py)
+  [`litex_sim`](https://github.com/enjoy-digital/litex/blob/a6d9955c9d3065/litex/tools/litex_sim.py)
 - built around a VexRiscv-CPU with PMP, hardware multiplication and
   compressed instruction support (named `TockSecureIMC`)
 - featuring a TIMER0 with 64-bit wide hardware uptime
@@ -51,7 +51,7 @@ CSR locations in memory. The companion repository
 [tock-litex](https://github.com/lschuermann/tock-litex) provides
 access to an environment with the required LiteX Python packages in
 their targeted versions. This board currently targets the release
-[2022081701](https://github.com/lschuermann/tock-litex/releases/tag/2022081701)
+[2024011101](https://github.com/lschuermann/tock-litex/releases/tag/2024011101)
 of `tock-litex`.
 
 


### PR DESCRIPTION
### Pull Request Overview

This includes a fix to the VexRiscv CPU's PMP implementation, which previously has incorrectly handled NAPOT regions that include the most significant bit set. This update is required to support the PMP changes in tock/tock#3597.

### Testing Strategy

This pull request was tested by running the kernel on the Arty A7-35T board and the CI kernel/userspace integration tests on the LiteX sim target.

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] ~Updated the relevant files in `/docs`, or~ no updates are required.

### Formatting

- [x] Ran `make prepush`.
