### PR TITLE
kernel: SubSlice: fix slice calculation

### DIFF
--- a/kernel/src/utilities/leasable_buffer.rs
+++ b/kernel/src/utilities/leasable_buffer.rs
@@ -325,7 +325,7 @@ impl<'a, T> SubSliceMut<'a, T> {
         let end = match range.end_bound() {
             Bound::Included(e) => *e + 1,
             Bound::Excluded(e) => *e,
-            Bound::Unbounded => self.active_range.end,
+            Bound::Unbounded => self.active_range.end - self.active_range.start,
         };
 
         let new_start = self.active_range.start + start;
@@ -445,7 +445,7 @@ impl<'a, T> SubSlice<'a, T> {
         let end = match range.end_bound() {
             Bound::Included(e) => *e + 1,
             Bound::Excluded(e) => *e,
-            Bound::Unbounded => self.active_range.end,
+            Bound::Unbounded => self.active_range.end - self.active_range.start,
         };
 
         let new_start = self.active_range.start + start;


### PR DESCRIPTION
### Pull Request Overview

Since end is calculated relative to start, if start moves up but end doesn't, we need to compensate by only including the size of the starting buffer.


### Testing Strategy

Working on a screen driver for the ssd1306 oled.


### TODO or Help Wanted

This fix got my other code working. Is there a better way to write this logic entirely? This is now the second issue.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
