### PR TITLE
Screen: update HIL to simplify, format, and use SubSlice

### DIFF
--- a/boards/components/src/screen.rs
+++ b/boards/components/src/screen.rs
@@ -46,6 +46,8 @@ macro_rules! screen_component_static {
     };};
 }
 
+pub type ScreenComponentType = capsules_extra::screen::Screen<'static>;
+
 pub struct ScreenComponent<const SCREEN_BUF_LEN: usize> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,

--- a/boards/components/src/screen.rs
+++ b/boards/components/src/screen.rs
@@ -89,9 +89,9 @@ impl<const SCREEN_BUF_LEN: usize> Component for ScreenComponent<SCREEN_BUF_LEN> 
             grant_screen,
         ));
 
-        kernel::hil::screen::Screen::set_client(self.screen, Some(screen));
+        kernel::hil::screen::Screen::set_client(self.screen, screen);
         if let Some(screen_setup) = self.screen_setup {
-            kernel::hil::screen::ScreenSetup::set_client(screen_setup, Some(screen));
+            kernel::hil::screen::ScreenSetup::set_client(screen_setup, screen);
         }
 
         screen

--- a/capsules/extra/src/lpm013m126.rs
+++ b/capsules/extra/src/lpm013m126.rs
@@ -21,6 +21,7 @@ use kernel::hil::screen::{Screen, ScreenClient, ScreenPixelFormat, ScreenRotatio
 use kernel::hil::spi::{SpiMasterClient, SpiMasterDevice};
 use kernel::hil::time::{Alarm, AlarmClient, ConvertTicks};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::ErrorCode;
 
 /// Monochrome frame buffer bytes.
@@ -347,9 +348,10 @@ where
     fn handle_write_complete_callback(&self) {
         self.client.map(|client| {
             self.write_complete_pending_call.map(|pend| {
-                self.buffer
-                    .take()
-                    .map(|buffer| client.write_complete(buffer, pend));
+                self.buffer.take().map(|buffer| {
+                    let data = SubSliceMut::new(buffer);
+                    client.write_complete(data, pend)
+                });
             });
             self.write_complete_pending_call.take();
         });
@@ -422,7 +424,10 @@ where
         ret
     }
 
-    fn write(&self, buffer: &'static mut [u8], len: usize) -> Result<(), ErrorCode> {
+    fn write(&self, data: SubSliceMut<'static, u8>) -> Result<(), ErrorCode> {
+        let len = data.len();
+        let buffer = data.take();
+
         let ret = match self.state.get() {
             State::Uninitialized | State::Off => Err(ErrorCode::OFF),
             State::InitializingPixelMemory | State::InitializingRest => Err(ErrorCode::BUSY),
@@ -464,21 +469,8 @@ where
         ret
     }
 
-    fn write_continue(&self, buffer: &'static mut [u8], len: usize) -> Result<(), ErrorCode> {
-        // Not TODO: this can be avoided entirely
-        // at the cost of a minor layering violation.
-        // https://github.com/tock/tock/pull/3011#issuecomment-1087766745
-        self.write(buffer, len)?;
-        // TODO: move position
-        Ok(())
-    }
-
-    fn set_client(&self, client: Option<&'a dyn ScreenClient>) {
-        if let Some(client) = client {
-            self.client.set(client);
-        } else {
-            self.client.clear();
-        }
+    fn set_client(&self, client: &'a dyn ScreenClient) {
+        self.client.set(client);
     }
 
     fn set_power(&self, enable: bool) -> Result<(), ErrorCode> {
@@ -498,7 +490,7 @@ where
         }
     }
 
-    fn set_brightness(&self, _brightness: usize) -> Result<(), ErrorCode> {
+    fn set_brightness(&self, _brightness: u16) -> Result<(), ErrorCode> {
         // TODO: add LED PWM
         Err(ErrorCode::NOSUPPORT)
     }
@@ -597,9 +589,10 @@ impl<'a, A: Alarm<'a>, P: Pin, S: SpiMasterDevice<'a>> SpiMasterClient for Lpm01
 
         // Device frame buffer is now up to date, return pixel buffer to client.
         self.client.map(|client| {
-            self.buffer
-                .take()
-                .map(|buf| client.write_complete(buf, status))
+            self.buffer.take().map(|buf| {
+                let data = SubSliceMut::new(buf);
+                client.write_complete(data, status)
+            })
         });
     }
 }

--- a/capsules/extra/src/screen.rs
+++ b/capsules/extra/src/screen.rs
@@ -23,6 +23,7 @@ use kernel::hil::screen::{ScreenPixelFormat, ScreenRotation};
 use kernel::processbuffer::ReadableProcessBuffer;
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::{ErrorCode, ProcessId};
 
 /// Syscall driver number.
@@ -60,7 +61,7 @@ fn screen_pixel_format_from(screen_pixel_format: usize) -> Option<ScreenPixelFor
 #[derive(Clone, Copy, PartialEq)]
 enum ScreenCommand {
     Nop,
-    SetBrightness(usize),
+    SetBrightness(u16),
     SetPower(bool),
     SetInvert(bool),
     SetRotation(ScreenRotation),
@@ -201,73 +202,81 @@ impl<'a> Screen<'a> {
                     Err(ErrorCode::NOSUPPORT)
                 }
             }
-            ScreenCommand::Fill => match self
-                .apps
-                .enter(process_id, |app, kernel_data| {
-                    let len = kernel_data
-                        .get_readonly_processbuffer(ro_allow::SHARED)
-                        .map_or(0, |shared| shared.len());
-                    // Ensure we have a buffer that is the correct size
-                    if len == 0 {
-                        Err(ErrorCode::NOMEM)
-                    } else if !self.is_len_multiple_color_depth(len) {
-                        Err(ErrorCode::INVAL)
-                    } else {
-                        app.write_position = 0;
-                        app.write_len = pixels_in_bytes(
-                            app.width * app.height,
-                            self.pixel_format.get().get_bits_per_pixel(),
-                        );
-                        Ok(())
-                    }
-                })
-                .unwrap_or_else(|err| err.into())
-            {
-                Err(e) => Err(e),
-                Ok(()) => self.buffer.take().map_or(Err(ErrorCode::NOMEM), |buffer| {
-                    let len = self.fill_next_buffer_for_write(buffer);
-                    if len > 0 {
-                        self.screen.write(buffer, len)
-                    } else {
-                        self.buffer.replace(buffer);
-                        self.run_next_command(kernel::errorcode::into_statuscode(Ok(())), 0, 0);
-                        Ok(())
-                    }
-                }),
-            },
+            ScreenCommand::Fill => {
+                match self
+                    .apps
+                    .enter(process_id, |app, kernel_data| {
+                        let len = kernel_data
+                            .get_readonly_processbuffer(ro_allow::SHARED)
+                            .map_or(0, |shared| shared.len());
+                        // Ensure we have a buffer that is the correct size
+                        if len == 0 {
+                            Err(ErrorCode::NOMEM)
+                        } else if !self.is_len_multiple_color_depth(len) {
+                            Err(ErrorCode::INVAL)
+                        } else {
+                            app.write_position = 0;
+                            app.write_len = pixels_in_bytes(
+                                app.width * app.height,
+                                self.pixel_format.get().get_bits_per_pixel(),
+                            );
+                            Ok(())
+                        }
+                    })
+                    .unwrap_or_else(|err| err.into())
+                {
+                    Err(e) => Err(e),
+                    Ok(()) => self.buffer.take().map_or(Err(ErrorCode::NOMEM), |buffer| {
+                        let len = self.fill_next_buffer_for_write(buffer);
+                        if len > 0 {
+                            let mut data = SubSliceMut::new(buffer);
+                            data.slice(..len);
+                            self.screen.write(data)
+                        } else {
+                            self.buffer.replace(buffer);
+                            self.run_next_command(kernel::errorcode::into_statuscode(Ok(())), 0, 0);
+                            Ok(())
+                        }
+                    }),
+                }
+            }
 
-            ScreenCommand::Write(data_len) => match self
-                .apps
-                .enter(process_id, |app, kernel_data| {
-                    let len = kernel_data
-                        .get_readonly_processbuffer(ro_allow::SHARED)
-                        .map_or(0, |shared| shared.len())
-                        .min(data_len);
-                    // Ensure we have a buffer that is the correct size
-                    if len == 0 {
-                        Err(ErrorCode::NOMEM)
-                    } else if !self.is_len_multiple_color_depth(len) {
-                        Err(ErrorCode::INVAL)
-                    } else {
-                        app.write_position = 0;
-                        app.write_len = len;
-                        Ok(())
-                    }
-                })
-                .unwrap_or_else(|err| err.into())
-            {
-                Ok(()) => self.buffer.take().map_or(Err(ErrorCode::FAIL), |buffer| {
-                    let len = self.fill_next_buffer_for_write(buffer);
-                    if len > 0 {
-                        self.screen.write(buffer, len)
-                    } else {
-                        self.buffer.replace(buffer);
-                        self.run_next_command(kernel::errorcode::into_statuscode(Ok(())), 0, 0);
-                        Ok(())
-                    }
-                }),
-                Err(e) => Err(e),
-            },
+            ScreenCommand::Write(data_len) => {
+                match self
+                    .apps
+                    .enter(process_id, |app, kernel_data| {
+                        let len = kernel_data
+                            .get_readonly_processbuffer(ro_allow::SHARED)
+                            .map_or(0, |shared| shared.len())
+                            .min(data_len);
+                        // Ensure we have a buffer that is the correct size
+                        if len == 0 {
+                            Err(ErrorCode::NOMEM)
+                        } else if !self.is_len_multiple_color_depth(len) {
+                            Err(ErrorCode::INVAL)
+                        } else {
+                            app.write_position = 0;
+                            app.write_len = len;
+                            Ok(())
+                        }
+                    })
+                    .unwrap_or_else(|err| err.into())
+                {
+                    Ok(()) => self.buffer.take().map_or(Err(ErrorCode::FAIL), |buffer| {
+                        let len = self.fill_next_buffer_for_write(buffer);
+                        if len > 0 {
+                            let mut data = SubSliceMut::new(buffer);
+                            data.slice(..len);
+                            self.screen.write(data)
+                        } else {
+                            self.buffer.replace(buffer);
+                            self.run_next_command(kernel::errorcode::into_statuscode(Ok(())), 0, 0);
+                            Ok(())
+                        }
+                    }),
+                    Err(e) => Err(e),
+                }
+            }
             ScreenCommand::SetWriteFrame {
                 x,
                 y,
@@ -418,11 +427,14 @@ impl<'a> hil::screen::ScreenClient for Screen<'a> {
         self.run_next_command(kernel::errorcode::into_statuscode(r), 0, 0);
     }
 
-    fn write_complete(&self, buffer: &'static mut [u8], r: Result<(), ErrorCode>) {
+    fn write_complete(&self, data: SubSliceMut<'static, u8>, r: Result<(), ErrorCode>) {
+        let buffer = data.take();
         let len = self.fill_next_buffer_for_write(buffer);
 
         if r == Ok(()) && len > 0 {
-            let _ = self.screen.write_continue(buffer, len);
+            let mut data = SubSliceMut::new(buffer);
+            data.slice(..len);
+            let _ = self.screen.write(data);
         } else {
             self.buffer.replace(buffer);
             self.run_next_command(kernel::errorcode::into_statuscode(r), 0, 0);
@@ -456,7 +468,7 @@ impl<'a> SyscallDriver for Screen<'a> {
             // Set power
             2 => self.enqueue_command(ScreenCommand::SetPower(data1 != 0), process_id),
             // Set Brightness
-            3 => self.enqueue_command(ScreenCommand::SetBrightness(data1), process_id),
+            3 => self.enqueue_command(ScreenCommand::SetBrightness(data1 as u16), process_id),
             // Invert on (deprecated)
             4 => self.enqueue_command(ScreenCommand::SetInvert(true), process_id),
             // Invert off (deprecated)

--- a/kernel/src/hil/screen.rs
+++ b/kernel/src/hil/screen.rs
@@ -2,41 +2,38 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-/*! Interface for screens and displays.
+//! Interface for screens and displays.
+//!
+//! The interfaces exposed here cover both configurable (`ScreenSetup`), and
+//! less configurable hardware (only `Screen`).
+//!
+//! It's composed of 4 main kinds of requests:
+//! - set power,
+//! - read configuration (e.g. `get_resolution`),
+//! - configure (e.g. `set_invert`),
+//! - write buffer.
+//!
+//! All requests, except for `Screen::set_power`, can return `OFF` under some
+//! circumstances.
+//!
+//! For buffer writes, it's when the display is powered off.
+//!
+//! While the display is not powered on, the user could try to configure it. In
+//! that case, the driver MUST either cache the value, or return `OFF`. This is
+//! to let the user power the display in the desired configuration.
+//!
+//! Configuration reads shall return the actual state of the display. In
+//! situations where a parameter cannot be configured (e.g. fixed resolution),
+//! they return value may be hardcoded. Otherwise, the driver should query the
+//! hardware directly, and return OFF if it's not powered.
+//!
+//! Configuration sets cause a `command_complete` callback unless noted
+//! otherwise.
 
-The interfaces exposed here cover both configurable (`ScreenSetup`),
-and less configurable hardware (only `Screen`).
-
-It's composed of 4 main kinds of requests:
-- set power,
-- read configuration (e.g. `get_resolution`),
-- configure (e.g. `set_invert`),
-- write buffer.
-
-All requests, except for `Screen::set_power`, can return `OFF`
-under some circumstances.
-
-For buffer writes, it's when the display is powered off.
-
-While the display is not powered on, the user could try to configure it.
-In that case, the driver MUST either cache the value, or return `OFF`.
-This is to let the user power the display in the desired configuration.
-
-Configuration reads shall return the actual state of the display.
-In situations where a parameter cannot be configured
-(e.g. fixed resolution), they return value may be hardcoded.
-Otherwise, the driver should query the hardware directly,
-and return OFF if it's not powered.
-
-Configuration sets cause a `command_complete` callback
-unless noted otherwise.
-*/
-
+use crate::utilities::leasable_buffer::SubSliceMut;
 use crate::ErrorCode;
 use core::ops::Add;
 use core::ops::Sub;
-
-pub const MAX_BRIGHTNESS: usize = 65536;
 
 #[derive(Copy, Clone, PartialEq)]
 pub enum ScreenRotation {
@@ -94,19 +91,24 @@ impl Sub for ScreenRotation {
     }
 }
 
+/// How pixels are encoded for the screen.
 #[derive(Copy, Clone, PartialEq)]
 #[repr(usize)]
 #[allow(non_camel_case_types)]
 pub enum ScreenPixelFormat {
-    /// Pixels encoded as 1-bit, used for monochromatic displays
+    /// Pixels encoded as 1-bit, used for monochromatic displays.
     Mono,
-    /// Pixels encoded as 2-bit red channel, 3-bit green channel, 3-bit blue channel.
+    /// Pixels encoded as 2-bit red channel, 3-bit green channel, 3-bit blue
+    /// channel.
     RGB_233,
-    /// Pixels encoded as 5-bit red channel, 6-bit green channel, 5-bit blue channel.
+    /// Pixels encoded as 5-bit red channel, 6-bit green channel, 5-bit blue
+    /// channel.
     RGB_565,
-    /// Pixels encoded as 8-bit red channel, 8-bit green channel, 8-bit blue channel.
+    /// Pixels encoded as 8-bit red channel, 8-bit green channel, 8-bit blue
+    /// channel.
     RGB_888,
-    /// Pixels encoded as 8-bit alpha channel, 8-bit red channel, 8-bit green channel, 8-bit blue channel.
+    /// Pixels encoded as 8-bit alpha channel, 8-bit red channel, 8-bit green
+    /// channel, 8-bit blue channel.
     ARGB_8888,
     // other pixel formats may be defined.
 }
@@ -123,89 +125,109 @@ impl ScreenPixelFormat {
     }
 }
 
+/// Interface to configure the screen.
 pub trait ScreenSetup<'a> {
-    fn set_client(&self, client: Option<&'a dyn ScreenSetupClient>);
+    fn set_client(&self, client: &'a dyn ScreenSetupClient);
 
-    /// Sets the screen resolution (in pixels). Returns ENOSUPPORT if the resolution is
-    /// not supported. The function should return Ok(()) if the request is registered
-    /// and will be sent to the screen.
-    /// Upon Ok(()), the caller has to wait for the `command_complete` callback function
-    /// that will return the actual Result<(), ErrorCode> after setting the resolution.
+    /// Set the screen resolution in pixels with `(X, Y)`.
+    ///
+    /// Returns `Ok(())` if the request is registered and will be sent to the
+    /// screen. A `command_complete` callback function will be triggered when
+    /// the resolution change is finished and will provide a `Result<(),
+    /// ErrorCode>` to indicate if the resolution change was successful.
+    ///
+    /// Returns `Err(NOSUPPORT)` if the resolution is not supported. No callback will
+    /// be triggered.
     fn set_resolution(&self, resolution: (usize, usize)) -> Result<(), ErrorCode>;
 
-    /// Sets the pixel format. Returns ENOSUPPORT if the pixel format is
-    /// not supported. The function should return Ok(()) if the request is registered
-    /// and will be sent to the screen.
-    /// Upon Ok(()), the caller has to wait for the `command_complete` callback function
-    /// that will return the actual Result<(), ErrorCode> after setting the pixel format.
-    fn set_pixel_format(&self, depth: ScreenPixelFormat) -> Result<(), ErrorCode>;
-
-    /// Sets the rotation of the display.
-    /// The function should return Ok(()) if the request is registered
-    /// and will be sent to the screen.
-    /// Upon Ok(()), the caller has to wait for the `command_complete` callback function
-    /// that will return the actual Result<(), ErrorCode> after setting the rotation.
+    /// Set the pixel format.
     ///
-    /// Note that in the case of `Rotated90` or `Rotated270`, this will swap the width and height.
+    /// Returns `Ok(())` if the request is registered and will be sent to the
+    /// screen. A `command_complete` callback function will be triggered when
+    /// the pixel format change is finished and will provide a `Result<(),
+    /// ErrorCode>` to indicate if the pixel format change was successful.
+    ///
+    /// Returns `Err(NOSUPPORT)` if the pixel format is not supported.
+    fn set_pixel_format(&self, format: ScreenPixelFormat) -> Result<(), ErrorCode>;
+
+    /// Set the rotation of the display.
+    ///
+    /// Returns `Ok(())` if the request is registered and will be sent to the
+    /// screen. A `command_complete` callback function will be triggered when
+    /// the rotation update is finished and will provide a `Result<(),
+    /// ErrorCode>` to indicate if the rotation change was successful.
+    ///
+    /// Note that `Rotated90` or `Rotated270` will swap the width and height.
     fn set_rotation(&self, rotation: ScreenRotation) -> Result<(), ErrorCode>;
 
-    /// Returns the number of the resolutions supported.
-    /// should return at least one (the current resolution)
-    /// This function is synchronous as the driver should know this value without
-    /// requesting it from the screen (most screens do not support such a request,
-    /// resolutions are described in the data sheet).
+    /// Get the number of supported resolutions.
     ///
-    /// If the screen supports such a feature, the driver should request this information
-    /// from the screen upfront.
+    /// This must return at least one (the current resolution).
+    ///
+    /// This function is synchronous as the driver should know this value
+    /// without requesting it from the screen (most screens do not support such
+    /// a request, resolutions are described in the data sheet).
     fn get_num_supported_resolutions(&self) -> usize;
 
-    /// Can be called with an index from 0 .. count-1 and will
-    /// a tuple (width, height) with the current resolution (in pixels).
-    /// note that width and height may change due to rotation
+    /// Get the resolution specified by the given index.
     ///
-    /// This function is synchronous as the driver should know this value without
-    /// requesting it from the screen.
+    /// `index` is from `0..get_num_supported_resolutions()-1` and this returns
+    /// a tuple `(width, height)` of the associated resolution (in pixels). Note
+    /// that width and height may change due to rotation. Returns `None` if
+    /// `index` is invalid.
+    ///
+    /// This function is synchronous as the driver should know this value
+    /// without requesting it from the screen.
     fn get_supported_resolution(&self, index: usize) -> Option<(usize, usize)>;
 
-    /// Returns the number of the pixel formats supported.
-    /// This function is synchronous as the driver should know this value without
-    /// requesting it from the screen (most screens do not support such a request,
-    /// pixel formats are described in the data sheet).
+    /// Get the number of the pixel formats supported.
     ///
-    /// If the screen supports such a feature, the driver should request this information
-    /// from the screen upfront.
+    /// This function is synchronous as the driver should know this value
+    /// without requesting it from the screen (most screens do not support such
+    /// a request, pixel formats are described in the data sheet).
     fn get_num_supported_pixel_formats(&self) -> usize;
 
-    /// Can be called with index 0 .. count-1 and will return
-    /// the value of each pixel format mode.
+    /// Get the pixel format specified by the given index.
     ///
-    /// This function is synchronous as the driver should know this value without
-    /// requesting it from the screen.
+    /// `index` is from `0..get_num_supported_pixel_formats()-1` and this
+    /// returns the associated pixel format. Returns `None` if `index` is
+    /// invalid.
+    ///
+    /// This function is synchronous as the driver should know this value
+    /// without requesting it from the screen.
     fn get_supported_pixel_format(&self, index: usize) -> Option<ScreenPixelFormat>;
 }
 
-/// The basic trait for screens
+/// Basic interface for screens.
 pub trait Screen<'a> {
-    /// Returns a tuple (width, height) with the current resolution (in pixels)
-    /// This function is synchronous as the driver should know this value without
-    /// requesting it from the screen.
+    /// Set the object to receive the asynchronous command callbacks.
+    fn set_client(&self, client: &'a dyn ScreenClient);
+
+    /// Get a tuple `(width, height)` with the current resolution (in pixels).
+    ///
+    /// This function is synchronous as the driver should know this value
+    /// without requesting it from the screen.
     ///
     /// Note that width and height may change due to rotation.
     fn get_resolution(&self) -> (usize, usize);
 
-    /// Returns the current pixel format
-    /// This function is synchronous as the driver should know this value without
-    /// requesting it from the screen.
+    /// Get the current pixel format.
+    ///
+    /// This function is synchronous as the driver should know this value
+    /// without requesting it from the screen.
     fn get_pixel_format(&self) -> ScreenPixelFormat;
 
-    /// Returns the current rotation.
-    /// This function is synchronous as the driver should know this value without
-    /// requesting it from the screen.
+    /// Get the current rotation.
+    ///
+    /// This function is synchronous as the driver should know this value
+    /// without requesting it from the screen.
     fn get_rotation(&self) -> ScreenRotation;
 
-    /// Sets the video memory frame.
-    /// This function has to be called before the first call to the write function.
-    /// This will generate a `command_complete()` callback when finished.
+    /// Sets the write frame.
+    ///
+    /// This function has to be called before the first call to the write
+    /// function. This will generate a `command_complete()` callback when
+    /// finished.
     ///
     /// Return values:
     /// - `Ok(())`: The write frame is valid.
@@ -219,74 +241,63 @@ pub trait Screen<'a> {
         height: usize,
     ) -> Result<(), ErrorCode>;
 
-    /// Sends a write command to write data in the selected video memory frame.
+    /// Write data from `buffer` to the selected write frame.
+    ///
     /// When finished, the driver will call the `write_complete()` callback.
+    ///
+    /// This function can be called multiple times if the write frame is larger
+    /// than the size of the available buffer. The write frame is only reset
+    /// when `set_write_frame()` is called.
     ///
     /// Return values:
     /// - `Ok(())`: Write is valid and will be sent to the screen.
-    /// - `INVAL`: Write is invalid or length is wrong.
+    /// - `SIZE`: The buffer is too long for the selected write frame.
     /// - `BUSY`: Another write is in progress.
-    fn write(&self, buffer: &'static mut [u8], len: usize) -> Result<(), ErrorCode>;
+    fn write(&self, buffer: SubSliceMut<'static, u8>) -> Result<(), ErrorCode>;
 
-    /// Sends a write command to write data in the selected video memory frame
-    /// without resetting the video memory frame position. It "continues" the
-    /// write from the previous position.
-    /// This allows using buffers that are smaller than the video mameory frame.
-    /// When finished, the driver will call the `write_complete()` callback.
-    ///
-    /// Return values:
-    /// - `Ok(())`: Write is valid and will be sent to the screen.
-    /// - `INVAL`: Write is invalid or length is wrong.
-    /// - `BUSY`: Another write is in progress.
-    fn write_continue(&self, buffer: &'static mut [u8], len: usize) -> Result<(), ErrorCode>;
-
-    /// Set the object to receive the asynchronous command callbacks.
-    fn set_client(&self, client: Option<&'a dyn ScreenClient>);
-
-    /// Sets the display brightness value
+    /// Set the display brightness value.
     ///
     /// Depending on the display, this may not cause any actual changes
     /// until and unless power is enabled (see `set_power`).
     ///
     /// The following values must be supported:
-    /// - 0 - completely no light emitted
-    /// - 1..MAX_BRIGHTNESS - on, set brightness to the given level
+    /// - 0: completely no light emitted
+    /// - 1..65536: set brightness to the given level
     ///
-    /// The display should interpret the brightness value as *lightness*
-    /// (each increment should change perceived brightness the same).
-    /// 1 shall be the minimum supported brightness,
-    /// `MAX_BRIGHTNESS` and greater represent the maximum.
-    /// Values in between should approximate the intermediate values;
-    /// minimum and maximum included (e.g. when there is only 1 level).
-    fn set_brightness(&self, brightness: usize) -> Result<(), ErrorCode>;
+    /// The display should interpret the brightness value as *lightness* (each
+    /// increment should change perceived brightness the same). 1 shall be the
+    /// minimum supported brightness, 65536 is the maximum brightness. Values in
+    /// between should approximate the intermediate values; minimum and maximum
+    /// included (e.g. when there is only 1 level).
+    fn set_brightness(&self, brightness: u16) -> Result<(), ErrorCode>;
 
     /// Controls the screen power supply.
     ///
     /// Use it to initialize the display device.
     ///
-    /// For screens where display needs nonzero brightness (e.g. LED),
-    /// this shall set brightness to a default value
-    /// if `set_brightness` was not called first.
+    /// For screens where display needs nonzero brightness (e.g. LED), this
+    /// shall set brightness to a default value if `set_brightness` was not
+    /// called first.
     ///
-    /// The device may implement power independently from brightness,
-    /// so call `set_brightness` to turn on/off the module completely.
+    /// The device may implement power independently from brightness, so call
+    /// `set_brightness` to turn on/off the module completely.
     ///
-    /// To allow starting in the correct configuration,
-    /// the driver is allowed to cache values like brightness or invert mode
-    /// and apply them together when power is enabled.
-    /// If the display cannot use selected configuration, this call returns `INVAL`.
+    /// To allow starting in the correct configuration, the driver is allowed to
+    /// cache values like brightness or invert mode and apply them together when
+    /// power is enabled. If the display cannot use selected configuration, this
+    /// call returns `INVAL`.
     ///
-    /// When finished, calls `ScreenClient::screen_is_ready`,
-    /// both when power was enabled and disabled.
+    /// When finished, calls `ScreenClient::screen_is_ready`, both when power
+    /// is enabled and disabled.
     fn set_power(&self, enabled: bool) -> Result<(), ErrorCode>;
 
     /// Controls the color inversion mode.
     ///
-    /// Pixels already in the frame buffer, as well as newly submitted,
-    /// will be inverted. What that means depends on the current pixel format.
-    /// May get disabled when switching to another pixel format.
-    /// Returns ENOSUPPORT if the device does not accelerate color inversion.
-    /// Returns EINVAL if the current pixel format does not support color inversion.
+    /// Pixels already in the frame buffer, as well as newly submitted, will be
+    /// inverted. What that means depends on the current pixel format. May get
+    /// disabled when switching to another pixel format. Returns `NOSUPPORT` if
+    /// the device does not accelerate color inversion. Returns `INVAL` if the
+    /// current pixel format does not support color inversion.
     fn set_invert(&self, enabled: bool) -> Result<(), ErrorCode>;
 }
 
@@ -300,13 +311,16 @@ pub trait ScreenSetupClient {
 }
 
 pub trait ScreenClient {
-    /// The screen will call this function to notify that a command (except write) has finished.
-    fn command_complete(&self, r: Result<(), ErrorCode>);
+    /// The screen will call this function to notify that a command (except
+    /// write) has finished.
+    fn command_complete(&self, result: Result<(), ErrorCode>);
 
-    /// The screen will call this function to notify that the write command has finished.
-    /// This is different from `command_complete` as it has to pass back the write buffer
-    fn write_complete(&self, buffer: &'static mut [u8], r: Result<(), ErrorCode>);
+    /// The screen will call this function to notify that the write command has
+    /// finished. This is different from `command_complete` as it has to pass
+    /// back the write buffer
+    fn write_complete(&self, buffer: SubSliceMut<'static, u8>, result: Result<(), ErrorCode>);
 
-    /// Some screens need some time to start, this function is called when the screen is ready.
+    /// Some screens need some time to start, this function is called when the
+    /// screen is ready.
     fn screen_is_ready(&self);
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the screen HIL and the capsules that use. The major changes are:

- Remove `write_continue()` which was redundant with `write()`.
- Make brightness a `u16` to match the docs.
- Use `SubSliceMut` instead of buffers and len.
- Format the markdown comments.

Related to #3504.

### Testing Strategy

Implementing the ssd1306 driver.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
