### PR TITLE
tock-tbf: fix footer parsing error type

### DIFF
--- a/libraries/tock-tbf/src/types.rs
+++ b/libraries/tock-tbf/src/types.rs
@@ -618,7 +618,9 @@ impl core::convert::TryFrom<&'static [u8]> for TbfFooterV2Credentials {
             4 => TbfFooterV2CredentialsType::SHA384,
             5 => TbfFooterV2CredentialsType::SHA512,
             _ => {
-                return Err(TbfParseError::InternalError);
+                return Err(TbfParseError::BadTlvEntry(
+                    TbfHeaderTypes::TbfFooterCredentials as usize,
+                ));
             }
         };
         let length = match ftype {


### PR DESCRIPTION


### Pull Request Overview

If the credential type doesn't match one that we don't know about, then it isn't an internal error, it's an error with the TBF.

Now, it's _possible_ that an app is using a valid credential type with an old kernel. However, that is unlikely, and better handled by the kernel version checking. More likely is the app is incorrect, and reporting an internal error is wrong.


### Testing Strategy

Writing a new app checker and getting the error.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
