### PR TITLE
kernel: process: add get_short_id() to ProcessId

### DIFF
--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -180,6 +180,21 @@ impl ProcessId {
         self.identifier
     }
 
+    /// Get the `ShortID` for this application this process is an execution of.
+    ///
+    /// The `ShortID` is an identifier for the _application_, not the particular
+    /// execution (i.e. the currently running process). This makes `ShortID`
+    /// distinct from `ProcessId`.
+    ///
+    /// This function is a helper function as capsules typically use `ProcessId`
+    /// as a handle to the running process and corresponding app.
+    pub fn short_app_id(&self) -> ShortID {
+        self.kernel
+            .process_map_or(ShortID::LocallyUnique, *self, |process| {
+                process.short_app_id()
+            })
+    }
+
     /// Returns the full address of the start and end of the flash region that
     /// the app owns and can write to. This includes the app's code and data and
     /// any padding at the end of the app. It does not include the TBF header,


### PR DESCRIPTION


### Pull Request Overview

This allows capsules to access the short ID to determine which app a process is and to act accordingly.



### Testing Strategy

Writing a new capsule.


### TODO or Help Wanted

I'm not missing anything am I? I don't otherwise think there is a way to actually use ShortID to do anything within a capsule.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
