### PR TITLE
kernel: appchecker: compress: pass &Process

### DIFF
--- a/doc/reference/trd-appid.md
+++ b/doc/reference/trd-appid.md
@@ -929,7 +929,7 @@ impl PartialEq for ShortID {
 impl Eq for ShortID {}
 
 pub trait Compress {
-    fn to_short_id(process: &dyn Process) -> ShortID;
+    fn to_short_id(process: &dyn Process, credentials: &TbfFooterV2Credentials) -> ShortID;
 }
 ```
 

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -1609,7 +1609,7 @@ impl process_checker::Client<'static> for ProcessCheckerMachine {
             Ok(process_checker::CheckResult::Accept) => {
                 self.processes[self.process.get()].map(|p| {
                     let short_id = self.policy.map_or(ShortID::LocallyUnique, |policy| {
-                        policy.to_short_id(&credentials)
+                        policy.to_short_id(p, &credentials)
                     });
                     let _r =
                         p.mark_credentials_pass(Some(credentials), short_id, &self.approve_cap);

--- a/kernel/src/process_checker.rs
+++ b/kernel/src/process_checker.rs
@@ -172,11 +172,15 @@ impl AppUniqueness for () {
 
 /// Transforms Application Credentials into a corresponding ShortID.
 pub trait Compress {
-    fn to_short_id(&self, _credentials: &TbfFooterV2Credentials) -> ShortID;
+    fn to_short_id(&self, process: &dyn Process, credentials: &TbfFooterV2Credentials) -> ShortID;
 }
 
 impl Compress for () {
-    fn to_short_id(&self, _credentials: &TbfFooterV2Credentials) -> ShortID {
+    fn to_short_id(
+        &self,
+        _process: &dyn Process,
+        _credentials: &TbfFooterV2Credentials,
+    ) -> ShortID {
         ShortID::LocallyUnique
     }
 }

--- a/kernel/src/process_checker/basic.rs
+++ b/kernel/src/process_checker/basic.rs
@@ -93,7 +93,11 @@ impl AppUniqueness for AppCheckerSimulated<'_> {
 }
 
 impl Compress for AppCheckerSimulated<'_> {
-    fn to_short_id(&self, _credentials: &TbfFooterV2Credentials) -> ShortID {
+    fn to_short_id(
+        &self,
+        _process: &dyn Process,
+        _credentials: &TbfFooterV2Credentials,
+    ) -> ShortID {
         ShortID::LocallyUnique
     }
 }
@@ -242,7 +246,7 @@ impl Compress for AppCheckerSha256 {
     // hash and sets the first bit to be 1 to ensure it is non-zero.
     // Note that since these identifiers are only 31 bits, they do not
     // provide sufficient collision resistance to verify a unique identity.
-    fn to_short_id(&self, credentials: &TbfFooterV2Credentials) -> ShortID {
+    fn to_short_id(&self, _process: &dyn Process, credentials: &TbfFooterV2Credentials) -> ShortID {
         let id: u32 = 0x8000000_u32
             | (credentials.data()[0] as u32) << 24
             | (credentials.data()[1] as u32) << 16
@@ -365,7 +369,7 @@ impl AppUniqueness for AppCheckerRsaSimulated<'_> {
 }
 
 impl Compress for AppCheckerRsaSimulated<'_> {
-    fn to_short_id(&self, credentials: &TbfFooterV2Credentials) -> ShortID {
+    fn to_short_id(&self, _process: &dyn Process, credentials: &TbfFooterV2Credentials) -> ShortID {
         // Should never trigger, as we only approve RSA3072 and RSA4096 credentials.
         let data = credentials.data();
         if data.len() < 4 {


### PR DESCRIPTION


### Pull Request Overview
This changes the `Compress` trait to:

```rust
pub trait Compress {
    fn to_short_id(process: &dyn Process, credentials: &TbfFooterV2Credentials) -> ShortID;
}
```

The TRD mentions that short IDs can be based on things like process names, but the `to_short_id()` function didn't have access to any process information.


### Testing Strategy

Working on a new capsule.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
