### PR TITLE
arch/cortex-m: hard_fault_handler: fix incorrect return to PSP stack

### DIFF
--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -473,56 +473,65 @@ pub unsafe fn switch_to_user_arm_v7m(
     target_feature = "thumb-mode",
     target_os = "none"
 ))]
-#[inline(never)]
-unsafe fn kernel_hardfault_arm_v7m(faulting_stack: *mut u32) -> ! {
-    let stacked_r0: u32 = *faulting_stack.offset(0);
-    let stacked_r1: u32 = *faulting_stack.offset(1);
-    let stacked_r2: u32 = *faulting_stack.offset(2);
-    let stacked_r3: u32 = *faulting_stack.offset(3);
-    let stacked_r12: u32 = *faulting_stack.offset(4);
-    let stacked_lr: u32 = *faulting_stack.offset(5);
-    let stacked_pc: u32 = *faulting_stack.offset(6);
-    let stacked_xpsr: u32 = *faulting_stack.offset(7);
+/// Continue the hardfault handler for all hard-faults that occurred
+/// during kernel execution. This function must never return.
+unsafe extern "C" fn hard_fault_handler_arm_v7m_kernel(
+    faulting_stack: *mut u32,
+    stack_overflow: u32,
+) -> ! {
+    if stack_overflow != 0 {
+        // Panic to show the correct error.
+        panic!("kernel stack overflow");
+    } else {
+        // Show the normal kernel hardfault message.
+        let stacked_r0: u32 = *faulting_stack.offset(0);
+        let stacked_r1: u32 = *faulting_stack.offset(1);
+        let stacked_r2: u32 = *faulting_stack.offset(2);
+        let stacked_r3: u32 = *faulting_stack.offset(3);
+        let stacked_r12: u32 = *faulting_stack.offset(4);
+        let stacked_lr: u32 = *faulting_stack.offset(5);
+        let stacked_pc: u32 = *faulting_stack.offset(6);
+        let stacked_xpsr: u32 = *faulting_stack.offset(7);
 
-    let mode_str = "Kernel";
+        let mode_str = "Kernel";
 
-    let shcsr: u32 = core::ptr::read_volatile(0xE000ED24 as *const u32);
-    let cfsr: u32 = core::ptr::read_volatile(0xE000ED28 as *const u32);
-    let hfsr: u32 = core::ptr::read_volatile(0xE000ED2C as *const u32);
-    let mmfar: u32 = core::ptr::read_volatile(0xE000ED34 as *const u32);
-    let bfar: u32 = core::ptr::read_volatile(0xE000ED38 as *const u32);
+        let shcsr: u32 = core::ptr::read_volatile(0xE000ED24 as *const u32);
+        let cfsr: u32 = core::ptr::read_volatile(0xE000ED28 as *const u32);
+        let hfsr: u32 = core::ptr::read_volatile(0xE000ED2C as *const u32);
+        let mmfar: u32 = core::ptr::read_volatile(0xE000ED34 as *const u32);
+        let bfar: u32 = core::ptr::read_volatile(0xE000ED38 as *const u32);
 
-    let iaccviol = (cfsr & 0x01) == 0x01;
-    let daccviol = (cfsr & 0x02) == 0x02;
-    let munstkerr = (cfsr & 0x08) == 0x08;
-    let mstkerr = (cfsr & 0x10) == 0x10;
-    let mlsperr = (cfsr & 0x20) == 0x20;
-    let mmfarvalid = (cfsr & 0x80) == 0x80;
+        let iaccviol = (cfsr & 0x01) == 0x01;
+        let daccviol = (cfsr & 0x02) == 0x02;
+        let munstkerr = (cfsr & 0x08) == 0x08;
+        let mstkerr = (cfsr & 0x10) == 0x10;
+        let mlsperr = (cfsr & 0x20) == 0x20;
+        let mmfarvalid = (cfsr & 0x80) == 0x80;
 
-    let ibuserr = ((cfsr >> 8) & 0x01) == 0x01;
-    let preciserr = ((cfsr >> 8) & 0x02) == 0x02;
-    let impreciserr = ((cfsr >> 8) & 0x04) == 0x04;
-    let unstkerr = ((cfsr >> 8) & 0x08) == 0x08;
-    let stkerr = ((cfsr >> 8) & 0x10) == 0x10;
-    let lsperr = ((cfsr >> 8) & 0x20) == 0x20;
-    let bfarvalid = ((cfsr >> 8) & 0x80) == 0x80;
+        let ibuserr = ((cfsr >> 8) & 0x01) == 0x01;
+        let preciserr = ((cfsr >> 8) & 0x02) == 0x02;
+        let impreciserr = ((cfsr >> 8) & 0x04) == 0x04;
+        let unstkerr = ((cfsr >> 8) & 0x08) == 0x08;
+        let stkerr = ((cfsr >> 8) & 0x10) == 0x10;
+        let lsperr = ((cfsr >> 8) & 0x20) == 0x20;
+        let bfarvalid = ((cfsr >> 8) & 0x80) == 0x80;
 
-    let undefinstr = ((cfsr >> 16) & 0x01) == 0x01;
-    let invstate = ((cfsr >> 16) & 0x02) == 0x02;
-    let invpc = ((cfsr >> 16) & 0x04) == 0x04;
-    let nocp = ((cfsr >> 16) & 0x08) == 0x08;
-    let unaligned = ((cfsr >> 16) & 0x100) == 0x100;
-    let divbysero = ((cfsr >> 16) & 0x200) == 0x200;
+        let undefinstr = ((cfsr >> 16) & 0x01) == 0x01;
+        let invstate = ((cfsr >> 16) & 0x02) == 0x02;
+        let invpc = ((cfsr >> 16) & 0x04) == 0x04;
+        let nocp = ((cfsr >> 16) & 0x08) == 0x08;
+        let unaligned = ((cfsr >> 16) & 0x100) == 0x100;
+        let divbysero = ((cfsr >> 16) & 0x200) == 0x200;
 
-    let vecttbl = (hfsr & 0x02) == 0x02;
-    let forced = (hfsr & 0x40000000) == 0x40000000;
+        let vecttbl = (hfsr & 0x02) == 0x02;
+        let forced = (hfsr & 0x40000000) == 0x40000000;
 
-    let ici_it = (((stacked_xpsr >> 25) & 0x3) << 6) | ((stacked_xpsr >> 10) & 0x3f);
-    let thumb_bit = ((stacked_xpsr >> 24) & 0x1) == 1;
-    let exception_number = (stacked_xpsr & 0x1ff) as usize;
+        let ici_it = (((stacked_xpsr >> 25) & 0x3) << 6) | ((stacked_xpsr >> 10) & 0x3f);
+        let thumb_bit = ((stacked_xpsr >> 24) & 0x1) == 1;
+        let exception_number = (stacked_xpsr & 0x1ff) as usize;
 
-    panic!(
-        "{} HardFault.\r\n\
+        panic!(
+            "{} HardFault.\r\n\
          \tKernel version {}\r\n\
          \tr0  0x{:x}\r\n\
          \tr1  0x{:x}\r\n\
@@ -560,117 +569,58 @@ unsafe fn kernel_hardfault_arm_v7m(faulting_stack: *mut u32) -> ! {
          \tFaulting Memory Address: (valid: {}) {:#010X}\r\n\
          \tBus Fault Address:       (valid: {}) {:#010X}\r\n\
          ",
-        mode_str,
-        option_env!("TOCK_KERNEL_VERSION").unwrap_or("unknown"),
-        stacked_r0,
-        stacked_r1,
-        stacked_r2,
-        stacked_r3,
-        stacked_r12,
-        stacked_lr,
-        stacked_pc,
-        stacked_xpsr,
-        (stacked_xpsr >> 31) & 0x1,
-        (stacked_xpsr >> 30) & 0x1,
-        (stacked_xpsr >> 29) & 0x1,
-        (stacked_xpsr >> 28) & 0x1,
-        (stacked_xpsr >> 27) & 0x1,
-        (stacked_xpsr >> 19) & 0x1,
-        (stacked_xpsr >> 18) & 0x1,
-        (stacked_xpsr >> 17) & 0x1,
-        (stacked_xpsr >> 16) & 0x1,
-        ici_it,
-        thumb_bit,
-        exception_number,
-        ipsr_isr_number_to_str(exception_number),
-        faulting_stack as u32,
-        _estack as u32,
-        _sstack as u32,
-        shcsr,
-        cfsr,
-        hfsr,
-        iaccviol,
-        daccviol,
-        munstkerr,
-        mstkerr,
-        mlsperr,
-        ibuserr,
-        preciserr,
-        impreciserr,
-        unstkerr,
-        stkerr,
-        lsperr,
-        undefinstr,
-        invstate,
-        invpc,
-        nocp,
-        unaligned,
-        divbysero,
-        vecttbl,
-        forced,
-        mmfarvalid,
-        mmfar,
-        bfarvalid,
-        bfar
-    );
-}
-
-#[cfg(all(
-    target_arch = "arm",
-    target_feature = "v7",
-    target_feature = "thumb-mode",
-    target_os = "none"
-))]
-/// Continue the hardfault handler. This function is not `#[naked]`, meaning we can mix
-/// `asm!()` and Rust. We separate this logic to not have to write the entire fault
-/// handler entirely in assembly.
-unsafe extern "C" fn hard_fault_handler_arm_v7m_continued(
-    faulting_stack: *mut u32,
-    kernel_stack: u32,
-    stack_overflow: u32,
-) {
-    use core::arch::asm;
-    if kernel_stack != 0 {
-        if stack_overflow != 0 {
-            // Panic to show the correct error.
-            panic!("kernel stack overflow");
-        } else {
-            // Show the normal kernel hardfault message.
-            kernel_hardfault_arm_v7m(faulting_stack);
-        }
-    } else {
-        // Hard fault occurred in an app, not the kernel. The app should be
-        // marked as in an error state and handled by the kernel.
-        asm!(
-            "
-        /* Read the relevant SCB registers. */
-        ldr r0, =SCB_REGISTERS  /* Global variable address */
-        ldr r1, =0xE000ED14     /* SCB CCR register address */
-        ldr r2, [r1, #0]        /* CCR */
-        str r2, [r0, #0]
-        ldr r2, [r1, #20]       /* CFSR */
-        str r2, [r0, #4]
-        ldr r2, [r1, #24]       /* HFSR */
-        str r2, [r0, #8]
-        ldr r2, [r1, #32]       /* MMFAR */
-        str r2, [r0, #12]
-        ldr r2, [r1, #36]       /* BFAR */
-        str r2, [r0, #16]
-
-        ldr r0, =APP_HARD_FAULT /* Global variable address */
-        mov r1, #1              /* r1 = 1 */
-        str r1, [r0, #0]        /* APP_HARD_FAULT = 1 */
-
-        /* Set thread mode to privileged */
-        mov r0, #0
-        msr CONTROL, r0
-        /* CONTROL writes must be followed by ISB */
-        /* http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dai0321a/BIHFJCAC.html */
-        isb",
-            out("r1") _,
-            out("r0") _,
-            out("r2") _,
-            options(nostack),
+            mode_str,
+            option_env!("TOCK_KERNEL_VERSION").unwrap_or("unknown"),
+            stacked_r0,
+            stacked_r1,
+            stacked_r2,
+            stacked_r3,
+            stacked_r12,
+            stacked_lr,
+            stacked_pc,
+            stacked_xpsr,
+            (stacked_xpsr >> 31) & 0x1,
+            (stacked_xpsr >> 30) & 0x1,
+            (stacked_xpsr >> 29) & 0x1,
+            (stacked_xpsr >> 28) & 0x1,
+            (stacked_xpsr >> 27) & 0x1,
+            (stacked_xpsr >> 19) & 0x1,
+            (stacked_xpsr >> 18) & 0x1,
+            (stacked_xpsr >> 17) & 0x1,
+            (stacked_xpsr >> 16) & 0x1,
+            ici_it,
+            thumb_bit,
+            exception_number,
+            ipsr_isr_number_to_str(exception_number),
+            faulting_stack as u32,
+            _estack as u32,
+            _sstack as u32,
+            shcsr,
+            cfsr,
+            hfsr,
+            iaccviol,
+            daccviol,
+            munstkerr,
+            mstkerr,
+            mlsperr,
+            ibuserr,
+            preciserr,
+            impreciserr,
+            unstkerr,
+            stkerr,
+            lsperr,
+            undefinstr,
+            invstate,
+            invpc,
+            nocp,
+            unaligned,
+            divbysero,
+            vecttbl,
+            forced,
+            mmfarvalid,
+            mmfar,
+            bfarvalid,
+            bfar
         );
     }
 }
@@ -695,11 +645,11 @@ pub unsafe extern "C" fn hard_fault_handler_arm_v7m() {
     // stack overflow and adjust the stack pointer before we branch
 
     asm!(
-        "mov    r1, 0     /* r1 = 0 */",
+        "mov    r2, 0     /* r2 = 0 */",
         "tst    lr, #4    /* bitwise AND link register to 0b100 */",
         "itte   eq        /* if lr==4, run next two instructions, else, run 3rd instruction. */",
         "mrseq  r0, msp   /* r0 = kernel stack pointer */",
-        "addeq  r1, 1     /* r1 = 1, kernel was executing */",
+        "addeq  r2, 1     /* r2 = 1, kernel was executing */",
         "mrsne  r0, psp   /* r0 = userland stack pointer */",
         // Need to determine if we had a stack overflow before we push anything
         // on to the stack. We check this by looking at the BusFault Status
@@ -711,10 +661,10 @@ pub unsafe extern "C" fn hard_fault_handler_arm_v7m() {
         "ldrb  r3, [r3]         /* r3 = BFSR */",
         "tst   r3, #0x30        /* r3 = BFSR & 0b00110000; LSPERR & STKERR bits */",
         "ite   ne               /* check if the result of that bitwise AND was not 0 */",
-        "movne r2, #1           /* BFSR & 0b00110000 != 0; r2 = 1 */",
-        "moveq r2, #0           /* BFSR & 0b00110000 == 0; r2 = 0 */",
-        "and r5, r1, r2         /* bitwise and r2 and r1, store in r5 */ ",
-        "cmp  r5, #1            /*  update condition codes to reflect if r2 == 1 && r1 == 1 */",
+        "movne r1, #1           /* BFSR & 0b00110000 != 0; r1 = 1 */",
+        "moveq r1, #0           /* BFSR & 0b00110000 == 0; r1 = 0 */",
+        "and r5, r2, r1         /* bitwise and r1 and r2, store in r5 */ ",
+        "cmp  r5, #1            /*  update condition codes to reflect if r1 == 1 && r2 == 1 */",
         "itt  eq                /* if r5==1 run the next 2 instructions, else skip to branch */",
         // if true, The hardware couldn't use the stack, so we have no saved data and
         // we cannot use the kernel stack as is. We just want to report that
@@ -725,19 +675,46 @@ pub unsafe extern "C" fn hard_fault_handler_arm_v7m() {
         // kernel's original stack. This should in theory leave the bottom
         // of the stack where the problem occurred untouched should one want
         // to further debug.
-        "ldreq  r4, ={}       /* load _estack into r4 */",
+        "ldreq  r4, ={estack} /* load _estack into r4 */",
         "moveq  sp, r4        /* Set the stack pointer to _estack */",
-        // finally, branch to non-naked handler
-        // per ARM calling convention, faulting stack is passed in r0, kernel_stack in r1,
-        // and whether there was a stack overflow in r2,
-        // we don't need to retain our original LR register
-        "bl {}", // branch to function
-        // if this function returns, then the hard fault occurred in
-        // userspace. In this case, switch to the kernel (MSP) stack:
+        // finally, if the fault occurred in privileged mode (r2 == 1), branch
+        // to non-naked handler.
+        "cmp r2, #0",
+        // Per ARM calling convention, faulting stack is passed in r0, whether
+        // there was a stack overflow in r1. This function must never return.
+        "bne {kernel_hard_fault_handler}", // branch to kernel hard fault handler
+        // Otherwise, the hard fault occurred in userspace. In this case, read
+        // the relevant SCB registers:
+        "ldr r0, =SCB_REGISTERS    /* Global variable address */",
+        "ldr r1, =0xE000ED14       /* SCB CCR register address */",
+        "ldr r2, [r1, #0]          /* CCR */",
+        "str r2, [r0, #0]",
+        "ldr r2, [r1, #20]         /* CFSR */",
+        "str r2, [r0, #4]",
+        "ldr r2, [r1, #24]         /* HFSR */",
+        "str r2, [r0, #8]",
+        "ldr r2, [r1, #32]         /* MMFAR */",
+        "str r2, [r0, #12]",
+        "ldr r2, [r1, #36]         /* BFAR */",
+        "str r2, [r0, #16]",
+
+        "ldr r0, =APP_HARD_FAULT  /* Global variable address */",
+        "mov r1, #1               /* r1 = 1 */",
+        "str r1, [r0, #0]         /* APP_HARD_FAULT = 1 */",
+
+        // Set thread mode to privileged
+        "mov r0, #0",
+        "msr CONTROL, r0",
+        // CONTROL writes must be followed by ISB
+        // http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dai0321a/BIHFJCAC.html
+        "isb",
+
+        // Switch to the kernel (MSP) stack:
         "movw lr, #0xFFF9",
         "movt lr, #0xFFFF",
         "bx lr",
-        sym _estack, sym hard_fault_handler_arm_v7m_continued,
+        estack = sym _estack,
+        kernel_hard_fault_handler = sym hard_fault_handler_arm_v7m_kernel,
         options(noreturn), // asm block never returns, so no need to mark clobbers
     );
 }


### PR DESCRIPTION
### Pull Request Overview

This fixes a critical bug in the ARMv7m hard-fault handler. Prior to this fix, it is possible (depending on the compiler) that the hard-fault handler may return to an application's context (the PSP stack), but *in privileged handler mode*. This effectively and trivially allows an application to execute arbitrary code at kernel privileges.

Tock's Cortex-M hard-fault handlers are split into a base handler (implemented through a `#[naked]` function that does not generate a function prologue / epilogue), and a non-naked `_continued` function which can contain arbitrary Rust code. Once the base handler has done sufficient preparations (make stack space for the subsequent handler, in case of a kernel stack overflow), the handler jumps to the `_continued` function. This function is expected to only return if the hard-fault has been caused by unprivileged user-mode code. In this case, the CONTROL register is set to switch to privileged thread mode, and the link register (LR) is set to `0xFFFFFFF9` (return to Thread mode, restoring state from the main stack pointer MSP). Finally, upon return, the naked handler is supposed to branch to this LR address:

    00020e4c <_RNvCsiXETrHxse8y_7cortexm26hard_fault_handler_arm_v7m>:
       20e4c:       f04f 0100       mov.w   r1, #0
       20e50:       f01e 0f04       tst.w   lr, #4
       [...]
       20e78:       46a5            moveq   sp, r4
       20e7a:       f000 b807       b.w     20e8c <_RNvCsiXETrHxse8y_7cortexm36hard_fault_handler_arm_v7m_continued>
       20e7e:       4770            bx      lr

However, because the `_continued` function is a non-naked function, the Rust compiler / LLVM may generate an arbitrary function epilogue. This epilogue may overwrite the LR register upon return.

```rust
unsafe extern "C" fn hard_fault_handler_arm_v7m_continued(
    faulting_stack: *mut u32,
    kernel_stack: u32,
    stack_overflow: u32,
) {
    use core::arch::asm;
    if kernel_stack != 0 {
        [...] // This branch never returns
    } else {
        asm!(
            [...]
            "movw LR, #0xFFF9",
            "movt LR, #0xFFFF",
            options(nostack),
         );
    }
}
```

The above code can, for instance, generate the following assembly:

    00020e8c <_RNvCsiXETrHxse8y_7cortexm36hard_fault_handler_arm_v7m_continued>:
       20e8c:       b5fe            push    {r1, r2, r3, r4, r5, r6, r7, lr}
       20e8e:       af06            add     r7, sp, #24
       [...]
       20ebc:       f3bf 8f6f       isb     sy
       20ec0:       f64f 7ef9       movw    lr, #65529      @ 0xfff9
       20ec4:       f6cf 7eff       movt    lr, #65535      @ 0xffff
       20ec8:       b006            add     sp, #24
       20eca:       bd80            pop     {r7, pc}
       [...]

In this case, the `pop {r7, pc}` instruction returns from the function, but to the stacked `lr` instead of the newly written return address. This stacked `lr` value is the faulting address in case of an instruction access fault by userspace. Thus, userspace can execute arbitrary code in the privileged handler mode.

This commit fixes this issue by calling the `_continued` function with a proper branch and link instruction, and unconditionally jumping to the `EXC_RETURN` code upon function return.

### Testing Strategy

This pull request was tested by running this code on an nRF52840DK while developing ARM Encapsulated Functions support, detecting the bug and verifying correct operation with instruction stepping in GDB.

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [x] Ran `make prepush`.
