### PR TITLE
Remove `#![feature(naked_functions)]` and compile Cortex-M on stable!

### DIFF
--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -6,10 +6,12 @@
 
 #![crate_name = "cortexm"]
 #![crate_type = "rlib"]
-#![feature(naked_functions)]
 #![no_std]
 
 use core::fmt::Write;
+
+#[cfg(all(target_arch = "arm", target_os = "none"))]
+use core::arch::global_asm;
 
 pub mod mpu;
 pub mod nvic;
@@ -131,18 +133,24 @@ pub unsafe extern "C" fn unhandled_interrupt() {
     panic!("Unhandled Interrupt. ISR {} is active.", interrupt_number);
 }
 
-/// Assembly function to initialize the .bss and .data sections in RAM.
-///
-/// We need to (unfortunately) do these operations in assembly because it is
-/// not valid to run Rust code without RAM initialized.
-///
-/// See https://github.com/tock/tock/issues/2222 for more information.
 #[cfg(all(target_arch = "arm", target_os = "none"))]
-#[naked]
-pub unsafe extern "C" fn initialize_ram_jump_to_main() {
-    use core::arch::asm;
-    asm!(
-        "
+extern "C" {
+    /// Assembly function to initialize the .bss and .data sections in RAM.
+    ///
+    /// We need to (unfortunately) do these operations in assembly because it is
+    /// not valid to run Rust code without RAM initialized.
+    ///
+    /// See https://github.com/tock/tock/issues/2222 for more information.
+    pub fn initialize_ram_jump_to_main();
+}
+
+#[cfg(all(target_arch = "arm", target_os = "none"))]
+global_asm!(
+"
+    .section .initialize_ram_jump_to_main, \"ax\"
+    .global initialize_ram_jump_to_main
+    .thumb_func
+  initialize_ram_jump_to_main:
     // Start by initializing .bss memory. The Tock linker script defines
     // `_szero` and `_ezero` to mark the .bss segment.
     ldr r0, ={sbss}     // r0 = first address of .bss
@@ -184,14 +192,12 @@ pub unsafe extern "C" fn initialize_ram_jump_to_main() {
     // board initialization takes place and Rust code starts.
     bl main
     ",
-        sbss = sym _szero,
-        ebss = sym _ezero,
-        sdata = sym _srelocate,
-        edata = sym _erelocate,
-        etext = sym _etext,
-        options(noreturn)
-    );
-}
+    sbss = sym _szero,
+    ebss = sym _ezero,
+    sdata = sym _srelocate,
+    edata = sym _erelocate,
+    etext = sym _etext,
+);
 
 pub unsafe fn print_cortexm_state(writer: &mut dyn Write) {
     let _ccr = syscall::SCB_REGISTERS[0];

--- a/arch/cortex-m0/src/lib.rs
+++ b/arch/cortex-m0/src/lib.rs
@@ -292,13 +292,16 @@ global_asm!(
 
 200: // _hardfault_exit
 
-    // If the hard-fault occured while executing the kernel (r1 != 0),
+    // If the hard-fault occurred while executing the kernel (r1 != 0),
     // jump to the non-naked kernel hard fault handler. This handler
     // MUST NOT return. The faulting stack is passed as the first argument
     // (r0).
-    cmp r1, #0
-    bne {kernel_hard_fault_handler}    // Branch to the non-naked fault handler.
+    cmp r1, #0                           // Check if app (r1==0) or kernel (r1==1) fault.
+    beq 400f                             // If app fault, skip to app handling.
+    ldr r2, ={kernel_hard_fault_handler} // Load address of fault handler.
+    bx r2                                // Branch to the non-naked fault handler.
 
+400: // _hardfault_app
     // Otherwise, store that a hardfault occurred in an app, store some CPU
     // state and finally return to the kernel stack:
     ldr r0, =APP_HARD_FAULT

--- a/arch/rv32i/src/lib.rs
+++ b/arch/rv32i/src/lib.rs
@@ -6,10 +6,12 @@
 
 #![crate_name = "rv32i"]
 #![crate_type = "rlib"]
-#![feature(naked_functions)]
 #![no_std]
 
 use core::fmt::Write;
+
+#[cfg(all(target_arch = "riscv32", target_os = "none"))]
+use core::arch::global_asm;
 
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 
@@ -45,24 +47,27 @@ extern "C" {
     static __global_pointer: usize;
 }
 
-/// Entry point of all programs (`_start`).
-///
-/// This assembly does three functions:
-///
-/// 1. It initializes the stack pointer, the frame pointer (needed for closures
-///    to work in start_rust) and the global pointer.
-/// 2. It initializes the .bss and .data RAM segments. This must be done before
-///    any Rust code runs. See https://github.com/tock/tock/issues/2222 for more
-///    information.
-/// 3. Finally it calls `main()`, the main entry point for Tock boards.
 #[cfg(all(target_arch = "riscv32", target_os = "none"))]
-#[link_section = ".riscv.start"]
-#[export_name = "_start"]
-#[naked]
-pub extern "C" fn _start() {
-    use core::arch::asm;
-    unsafe {
-        asm! ("
+extern "C" {
+    // Entry point of all programs (`_start`).
+    ///
+    /// This assembly does three functions:
+    ///
+    /// 1. It initializes the stack pointer, the frame pointer (needed for closures
+    ///    to work in start_rust) and the global pointer.
+    /// 2. It initializes the .bss and .data RAM segments. This must be done before
+    ///    any Rust code runs. See https://github.com/tock/tock/issues/2222 for more
+    ///    information.
+    /// 3. Finally it calls `main()`, the main entry point for Tock boards.
+    pub fn _start();
+}
+
+#[cfg(all(target_arch = "riscv32", target_os = "none"))]
+global_asm! ("
+            .section .riscv.start, \"ax\"
+            .globl _start
+          _start:
+
             // Set the global pointer register using the variable defined in the
             // linker script. This register is only set once. The global pointer
             // is a method for sharing state between the linker and the CPU so
@@ -132,17 +137,14 @@ pub extern "C" fn _start() {
             // code, likely defined in a board's main.rs.
             j main
         ",
-        gp = sym __global_pointer,
-        estack = sym _estack,
-        sbss = sym _szero,
-        ebss = sym _ezero,
-        sdata = sym _srelocate,
-        edata = sym _erelocate,
-        etext = sym _etext,
-        options(noreturn)
-        );
-    }
-}
+gp = sym __global_pointer,
+estack = sym _estack,
+sbss = sym _szero,
+ebss = sym _ezero,
+sdata = sym _srelocate,
+edata = sym _erelocate,
+etext = sym _etext,
+);
 
 /// The various privilege levels in RISC-V.
 pub enum PermissionMode {
@@ -184,29 +186,32 @@ pub extern "C" fn _start_trap() {
     unimplemented!()
 }
 
-/// This is the trap handler function. This code is called on all traps,
-/// including interrupts, exceptions, and system calls from applications.
-///
-/// Tock uses only the single trap handler, and does not use any vectored
-/// interrupts or other exception handling. The trap handler has to determine
-/// why the trap handler was called, and respond accordingly. Generally, there
-/// are two reasons the trap handler gets called: an interrupt occurred or an
-/// application called a syscall.
-///
-/// In the case of an interrupt while the kernel was executing we only need to
-/// save the kernel registers and then run whatever interrupt handling code we
-/// need to. If the trap happens while and application was executing, we have to
-/// save the application state and then resume the `switch_to()` function to
-/// correctly return back to the kernel.
 #[cfg(all(target_arch = "riscv32", target_os = "none"))]
-#[link_section = ".riscv.trap"]
-#[export_name = "_start_trap"]
-#[naked]
-pub extern "C" fn _start_trap() {
-    use core::arch::asm;
-    unsafe {
-        asm!(
-            "
+extern "C" {
+    /// This is the trap handler function. This code is called on all traps,
+    /// including interrupts, exceptions, and system calls from applications.
+    ///
+    /// Tock uses only the single trap handler, and does not use any vectored
+    /// interrupts or other exception handling. The trap handler has to determine
+    /// why the trap handler was called, and respond accordingly. Generally, there
+    /// are two reasons the trap handler gets called: an interrupt occurred or an
+    /// application called a syscall.
+    ///
+    /// In the case of an interrupt while the kernel was executing we only need to
+    /// save the kernel registers and then run whatever interrupt handling code we
+    /// need to. If the trap happens while and application was executing, we have to
+    /// save the application state and then resume the `switch_to()` function to
+    /// correctly return back to the kernel.
+    pub fn _start_trap();
+}
+
+#[cfg(all(target_arch = "riscv32", target_os = "none"))]
+global_asm!(
+    "
+            .section .riscv.trap, \"ax\"
+            .globl _start_trap
+          _start_trap:
+
             // The first thing we have to do is determine if we came from user
             // mode or kernel mode, as we need to save state and proceed
             // differently. We cannot, however, use any registers because we do
@@ -431,12 +436,9 @@ pub extern "C" fn _start_trap() {
             // switching code.
             mret
         ",
-            estack = sym _estack,
-            sstack = sym _sstack,
-            options(noreturn)
-        );
-    }
-}
+    estack = sym _estack,
+    sstack = sym _sstack,
+);
 
 /// RISC-V semihosting needs three exact instructions in uncompressed form.
 ///

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -233,6 +233,9 @@ CARGO_FLAGS_TOCK ?= \
   --package $(PLATFORM) \
   --target-dir=$(TARGET_DIRECTORY) $(CARGO_FLAGS)
 
+# Add default flags to rustdoc.
+RUSTDOC_FLAGS_TOCK ?= -D warnings
+
 # Add flags if we are compiling on nightly. If we are on stable, disallow
 # features.
 #
@@ -241,9 +244,12 @@ CARGO_FLAGS_TOCK ?= \
 #   sizes, and makes debugging easier since debug information for the core
 #   library is included in the resulting .elf file. See
 #   https://github.com/tock/tock/pull/2847 for more details.
+# - `--document-hidden-items`: Document internal interfaces when building
+#   rustdoc API documentation.
 ifneq ($(USE_STABLE_RUST),1)
   CARGO_FLAGS_TOCK += \
     -Zbuild-std=core,compiler_builtins
+  RUSTDOC_FLAGS_TOCK += -Z unstable-options --document-hidden-items
 endif
 
 # Set the default flags we need for objdump to get a .lst file.
@@ -365,7 +371,7 @@ debug-lst:  $(TARGET_PATH)/debug/$(PLATFORM).lst
 doc: | target
 	@# This mess is all to work around rustdoc giving no way to return an
 	@# error if there are warnings. This effectively simulates that.
-	$(Q)RUSTDOCFLAGS='-Z unstable-options --document-hidden-items -D warnings' $(CARGO) --color=always doc $(VERBOSE_FLAGS) --release --package $(PLATFORM) --target-dir=$(TARGET_DIRECTORY) 2>&1 | grep -C 9999 warning && (echo "Warnings detected during doc build" && if [[ $$NOWARNINGS == "true" ]]; then echo "Erroring due to CI context" && exit 33; fi) || if [ $$? -eq 33 ]; then exit 1; fi
+	$(Q)RUSTDOCFLAGS='$(RUSTDOC_FLAGS_TOCK)' $(CARGO) --color=always doc $(VERBOSE_FLAGS) --release --package $(PLATFORM) --target-dir=$(TARGET_DIRECTORY) 2>&1 | grep -C 9999 warning && (echo "Warnings detected during doc build" && if [[ $$NOWARNINGS == "true" ]]; then echo "Erroring due to CI context" && exit 33; fi) || if [ $$? -eq 33 ]; then exit 1; fi
 
 
 .PHONY: lst

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -227,18 +227,24 @@ CARGO_FLAGS ?=
 
 # Add default flags to cargo. Boards can add additional options in
 # `CARGO_FLAGS`.
+CARGO_FLAGS_TOCK ?= \
+  $(VERBOSE_FLAGS) \
+  --target=$(TARGET) \
+  --package $(PLATFORM) \
+  --target-dir=$(TARGET_DIRECTORY) $(CARGO_FLAGS)
+
+# Add flags if we are compiling on nightly. If we are on stable, disallow
+# features.
 #
 # - `-Z build-std=core,compiler_builtins`: Build the std library from source
 #   using our optimization settings. This leads to significantly smaller binary
 #   sizes, and makes debugging easier since debug information for the core
 #   library is included in the resulting .elf file. See
 #   https://github.com/tock/tock/pull/2847 for more details.
-CARGO_FLAGS_TOCK ?= \
-  $(VERBOSE_FLAGS) \
-  -Z build-std=core,compiler_builtins \
-  --target=$(TARGET) \
-  --package $(PLATFORM) \
-  --target-dir=$(TARGET_DIRECTORY) $(CARGO_FLAGS)
+ifneq ($(USE_STABLE_RUST),1)
+  CARGO_FLAGS_TOCK += \
+    -Zbuild-std=core,compiler_builtins
+endif
 
 # Set the default flags we need for objdump to get a .lst file.
 OBJDUMP_FLAGS ?= --disassemble-all --source --section-headers --demangle

--- a/boards/hail/Makefile
+++ b/boards/hail/Makefile
@@ -6,6 +6,7 @@
 
 TARGET=thumbv7em-none-eabi
 PLATFORM=hail
+USE_STABLE_RUST=1
 
 include ../Makefile.common
 

--- a/boards/hail/rust-toolchain.toml
+++ b/boards/hail/rust-toolchain.toml
@@ -1,0 +1,8 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2023.
+
+[toolchain]
+channel = "stable"
+components = ["llvm-tools", "rust-src", "rustfmt", "clippy"]
+targets = ["thumbv6m-none-eabi", "thumbv7em-none-eabi", "thumbv7em-none-eabihf", "riscv32imc-unknown-none-elf", "riscv32imac-unknown-none-elf"]

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -11,9 +11,8 @@
 // https://github.com/rust-lang/rust/issues/62184.
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
-#![feature(naked_functions)]
 
-use core::arch::asm;
+use core::arch::global_asm;
 
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
@@ -152,31 +151,35 @@ impl KernelResources<Rp2040<'static, Rp2040DefaultPeripherals<'static>>> for Nan
     }
 }
 
-/// Entry point used for debuger
-///
-/// When loaded using gdb, the Arduino Nano RP2040 Connect is not reset
-/// by default. Without this function, gdb sets the PC to the
-/// beginning of the flash. This is not correct, as the RP2040
-/// has a more complex boot process.
-///
-/// This function is set to be the entry point for gdb and is used
-/// to send the RP2040 back in the bootloader so that all the boot
-/// sqeuence is performed.
-#[no_mangle]
-#[naked]
-pub unsafe extern "C" fn jump_to_bootloader() {
-    asm!(
-        "
+#[allow(dead_code)]
+extern "C" {
+    /// Entry point used for debugger
+    ///
+    /// When loaded using gdb, the Arduino Nano RP2040 Connect is not reset
+    /// by default. Without this function, gdb sets the PC to the
+    /// beginning of the flash. This is not correct, as the RP2040
+    /// has a more complex boot process.
+    ///
+    /// This function is set to be the entry point for gdb and is used
+    /// to send the RP2040 back in the bootloader so that all the boot
+    /// sequence is performed.
+    fn jump_to_bootloader();
+}
+
+global_asm!(
+    "
+    .section .jump_to_bootloader, \"ax\"
+    .global jump_to_bootloader
+    .thumb_func
+  jump_to_bootloader:
     movs r0, #0
     ldr r1, =(0xe0000000 + 0x0000ed08)
     str r0, [r1]
     ldmia r0!, {{r1, r2}}
     msr msp, r1
     bx r2
-    ",
-        options(noreturn)
-    );
-}
+    "
+);
 
 fn init_clocks(peripherals: &Rp2040DefaultPeripherals) {
     // Start tick in watchdog

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -11,9 +11,8 @@
 // https://github.com/rust-lang/rust/issues/62184.
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
-#![feature(naked_functions)]
 
-use core::arch::asm;
+use core::arch::global_asm;
 
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
@@ -162,31 +161,35 @@ impl KernelResources<Rp2040<'static, Rp2040DefaultPeripherals<'static>>> for Pic
     }
 }
 
-/// Entry point used for debuger
-///
-/// When loaded using gdb, the Raspberry Pi Pico is not reset
-/// by default. Without this function, gdb sets the PC to the
-/// beginning of the flash. This is not correct, as the RP2040
-/// has a more complex boot process.
-///
-/// This function is set to be the entry point for gdb and is used
-/// to send the RP2040 back in the bootloader so that all the boot
-/// sqeuence is performed.
-#[no_mangle]
-#[naked]
-pub unsafe extern "C" fn jump_to_bootloader() {
-    asm!(
-        "
+#[allow(dead_code)]
+extern "C" {
+    /// Entry point used for debugger
+    ///
+    /// When loaded using gdb, the Raspberry Pi Pico is not reset
+    /// by default. Without this function, gdb sets the PC to the
+    /// beginning of the flash. This is not correct, as the RP2040
+    /// has a more complex boot process.
+    ///
+    /// This function is set to be the entry point for gdb and is used
+    /// to send the RP2040 back in the bootloader so that all the boot
+    /// sequence is performed.
+    fn jump_to_bootloader();
+}
+
+global_asm!(
+    "
+    .section .jump_to_bootloader, \"ax\"
+    .global jump_to_bootloader
+    .thumb_func
+  jump_to_bootloader:
     movs r0, #0
     ldr r1, =(0xe0000000 + 0x0000ed08)
     str r0, [r1]
     ldmia r0!, {{r1, r2}}
     msr msp, r1
     bx r2
-    ",
-        options(noreturn)
-    );
-}
+    "
+);
 
 fn init_clocks(peripherals: &Rp2040DefaultPeripherals) {
     // Start tick in watchdog

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -445,55 +445,55 @@ pub extern "C" fn _start_trap_vectored() {
 }
 
 #[cfg(all(target_arch = "riscv32", target_os = "none"))]
-#[link_section = ".riscv.trap_vectored"]
-#[export_name = "_start_trap_vectored"]
-#[naked]
-pub extern "C" fn _start_trap_vectored() -> ! {
-    use core::arch::asm;
-    unsafe {
-        // According to the Ibex user manual:
-        // [NMI] has interrupt ID 31, i.e., it has the highest priority of all
-        // interrupts and the core jumps to the trap-handler base address (in
-        // mtvec) plus 0x7C to handle the NMI.
-        //
-        // Below are 32 (non-compressed) jumps to cover the entire possible
-        // range of vectored traps.
-        asm!(
-            "
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-        ",
-            options(noreturn)
-        );
-    }
+extern "C" {
+    pub fn _start_trap_vectored();
 }
+
+#[cfg(all(target_arch = "riscv32", target_os = "none"))]
+// According to the Ibex user manual:
+// [NMI] has interrupt ID 31, i.e., it has the highest priority of all
+// interrupts and the core jumps to the trap-handler base address (in
+// mtvec) plus 0x7C to handle the NMI.
+//
+// Below are 32 (non-compressed) jumps to cover the entire possible
+// range of vectored traps.
+core::arch::global_asm!(
+    "
+            .section .riscv.trap_vectored, \"ax\"
+            .globl _start_trap_vectored
+          _start_trap_vectored:
+
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+        "
+);

--- a/chips/earlgrey/src/lib.rs
+++ b/chips/earlgrey/src/lib.rs
@@ -4,7 +4,6 @@
 
 //! Drivers and chip support for EarlGrey.
 
-#![feature(naked_functions)]
 #![no_std]
 #![crate_name = "earlgrey"]
 #![crate_type = "rlib"]

--- a/chips/esp32-c3/src/chip.rs
+++ b/chips/esp32-c3/src/chip.rs
@@ -297,49 +297,48 @@ pub extern "C" fn _start_trap_vectored() {
 }
 
 #[cfg(all(target_arch = "riscv32", target_os = "none"))]
-#[link_section = ".riscv.trap_vectored"]
-#[export_name = "_start_trap_vectored"]
-#[naked]
-pub extern "C" fn _start_trap_vectored() -> ! {
-    use core::arch::asm;
-    unsafe {
-        // Below are 32 (non-compressed) jumps to cover the entire possible
-        // range of vectored traps.
-        asm!(
-            "
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-        ",
-            options(noreturn)
-        );
-    }
+extern "C" {
+    pub fn _start_trap_vectored();
 }
+
+#[cfg(all(target_arch = "riscv32", target_os = "none"))]
+// Below are 32 (non-compressed) jumps to cover the entire possible
+// range of vectored traps.
+core::arch::global_asm!(
+    "
+            .section .riscv.trap_vectored, \"ax\"
+            .globl _start_trap_vectored
+          _start_trap_vectored:
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+            j _start_trap
+        "
+);

--- a/chips/esp32-c3/src/lib.rs
+++ b/chips/esp32-c3/src/lib.rs
@@ -4,7 +4,6 @@
 
 //! Drivers and chip support for ESP32-C3.
 
-#![feature(naked_functions)]
 #![no_std]
 #![crate_name = "esp32_c3"]
 #![crate_type = "rlib"]

--- a/chips/swervolf-eh1/src/lib.rs
+++ b/chips/swervolf-eh1/src/lib.rs
@@ -4,7 +4,6 @@
 
 //! Drivers and chip support for SweRVolf.
 
-#![feature(naked_functions)]
 #![no_std]
 #![crate_name = "swervolf_eh1"]
 #![crate_type = "rlib"]


### PR DESCRIPTION
### Pull Request Overview

This is a realization of the long-desired #1654 (at least for arm). Switches `#[naked]` to `global_asm!()`.

It seems like no one cares to stabilize naked_functions. There was momentum 1.5 years ago, but that was derailed and it seems like projects looking to use stable are just using `global_asm!()`.

I somewhat arbitrarily decided to switch hail to use stable as an example.


### Testing Strategy

Running on nrf52840dk. 


### TODO or Help Wanted

One odd thing came up:

```
#[cfg(all(
    target_arch = "arm",
    target_feature = "v7",
    target_feature = "thumb-mode",
    target_os = "none"
))]
```

Doesn't seem to work the same way on stable. With that, even when building for a board the cfg doesn't match and the function/variable is removed. It's the `target_feature` part which doesn't seem to work the same way.



### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
