### PR TITLE
boards/apollo3: redboard_artemis_atp: Initial commit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
     "boards/particle_boron",
     "boards/pico_explorer_base",
     "boards/raspberry_pi_pico",
+    "boards/apollo3/redboard_artemis_atp",
     "boards/apollo3/redboard_artemis_nano",
     "boards/apollo3/lora_things_plus",
     "boards/redboard_redv",

--- a/boards/apollo3/README.md
+++ b/boards/apollo3/README.md
@@ -4,5 +4,33 @@ Apollo3 Boards
 This directory contains all of the Apollo3 boards supported by Tock
 
  * ambiq - Generic tools for flashing binaries
+ * redboard_artemis_atp [SparkFun RedBoard Artemis ATP](https://www.sparkfun.com/products/15442)
  * redboard_artemis_nano [SparkFun RedBoard Artemis Nano](https://www.sparkfun.com/products/15443)
  * lora_things_plus [SparkFun LoRa Thing Plus - expLoRaBLE](https://www.sparkfun.com/products/17506)
+
+## Hardware differences
+
+All of the boards use the same SoC, so the Tock board files are overall very
+similar and can actually be used interchangably for basic operations.
+
+The main difference between them is what is broken out via the boards. For
+example the Redboard Artemis ATP uses IOM4 for the Qwiic connector while
+the Redboard Artemis Nano uses IOM2.
+
+The GPIO breakouts are also a little different.
+
+The LoRa Thing Plus also sets up the SX1262 radio, which the other boards
+don't have.
+
+## Configuration differences
+
+The other difference is Tock configurations. The boards are configured
+slightly differently to show a range of different options.
+
+### I2C
+
+The Redboard Artemis ATP doesn't setup a `MuxI2C`, like the other boards,
+instead it creates a `I2CMasterSlaveDriver`.
+
+A `I2CMasterSlaveDriver` can also be setup on the Redboard Artemis Nano
+instead of a `MuxI2C` as it exposes the correct pins, but it isn't by default.

--- a/boards/apollo3/redboard_artemis_atp/.cargo/config
+++ b/boards/apollo3/redboard_artemis_atp/.cargo/config
@@ -1,0 +1,6 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2022.
+
+[target.'cfg(target_arch = "arm")']
+runner = "./run.sh"

--- a/boards/apollo3/redboard_artemis_atp/Cargo.toml
+++ b/boards/apollo3/redboard_artemis_atp/Cargo.toml
@@ -1,0 +1,19 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2022.
+
+[package]
+name = "redboard_artemis_atp"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+build = "../../build.rs"
+
+[dependencies]
+components = { path = "../../components" }
+cortexm4 = { path = "../../../arch/cortex-m4" }
+kernel = { path = "../../../kernel" }
+apollo3 = { path = "../../../chips/apollo3" }
+
+capsules-core = { path = "../../../capsules/core" }
+capsules-extra = { path = "../../../capsules/extra" }

--- a/boards/apollo3/redboard_artemis_atp/Makefile
+++ b/boards/apollo3/redboard_artemis_atp/Makefile
@@ -1,0 +1,37 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2022.
+
+# Makefile for building the tock kernel for the RedBoard Artemis ATP platform
+#
+TARGET=thumbv7em-none-eabi
+PLATFORM=redboard_artemis_atp
+
+include ../../Makefile.common
+
+ifndef PORT
+  PORT="/dev/ttyUSB0"
+endif
+
+# Default target for installing the kernel.
+.PHONY: install
+install: flash
+
+.PHONY: flash
+flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+	python ../ambiq/ambiq_bin2board.py --bin $< --load-address-blob 0x40000 -b 115200 -port $(PORT) -r 2 -v --magic-num 0xCB --version 0x0 --load-address-wired 0xc000 -i 6 --options 0x1
+
+.PHONY: flash-debug
+flash-debug: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).bin
+	python ../ambiq/ambiq_bin2board.py --bin $< --load-address-blob 0x40000 -b 115200 -port $(PORT) -r 2 -v --magic-num 0xCB --version 0x0 --load-address-wired 0xc000 -i 6 --options 0x1
+
+.PHONY: flash-app
+flash-app:
+	python ../ambiq/ambiq_bin2board.py --bin $(APP) --load-address-blob 0x60000 -b 115200 -port $(PORT) -r 2 -v --magic-num 0xCB --version 0x0 --load-address-wired 0x40000 -i 6 --options 0x1
+
+.PHONY: test
+test:
+	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
+	$(Q)cp layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
+	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
+	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" OBJCOPY=${OBJCOPY} PORT=$(PORT) $(CARGO) test $(CARGO_FLAGS_TOCK_NO_BUILD_STD) $(NO_RUN) --bin $(PLATFORM) --release

--- a/boards/apollo3/redboard_artemis_atp/README.md
+++ b/boards/apollo3/redboard_artemis_atp/README.md
@@ -1,0 +1,84 @@
+SparkFun RedBoard Artemis ATP
+=============================
+
+The RedBoard Artemis ATP is affectionately called 'All the Pins!' at SparkFun.
+The Artemis module has 48 GPIO and this board breaks out absolutely every one
+of them in a familiar Mega like form factor.
+
+## Board features
+
+ - 17 GPIO - all interrupt capable
+ - 8 ADC channels with 14-bit precision
+ - 17 PWM channels
+ - 2 UARTs
+ - 4 I2C buses
+ - 2 SPI buses
+ - PDM Digital Microphone
+ - Qwiic Connector
+
+For more details [visit the SparkFun
+website](https://www.sparkfun.com/products/15442).
+
+## Flashing the kernel
+
+The kernel can be programmed using the Ambiq python scrips. `cd` into `boards/apollo3/sparkfun_redboard_artemis_atp`
+directory and run:
+
+```shell
+$ make flash
+
+(or)
+
+$ make flash-debug # To flash the debug build
+```
+
+This will flash Tock onto the board via the /dev/ttyUSB0 port. If you would like to use a different port you can specify it from the `PORT` variable.
+
+```bash
+$ PORT=/dev/ttyUSB2 make flash
+```
+
+This will flash Tock over the SparkFun Variable Loader (SVL) using the Ambiq loader.
+The SVL can always be re-flashed if you want to.
+
+## I2C Master/Slave support
+
+To use I2C master/slave support the pins need to manually be wired together. This
+is because the IOS uses GPIO 0 and 1, while the IOM uses GPIO 40 and 39 (exposed)
+via the Qwiic connector.
+
+To do this use a [Qwiic connector breakout](https://www.sparkfun.com/products/14425).
+
+The yellow cable of the connector should be connected to GPIO 0. This is the
+SCL line, which can then be connected to other devices.
+
+The blue cable of the connector should be connected to GPIO 1. This is the
+SDA line, which can then be connected to other devices.
+
+## Debugging the board
+
+The RedBoard Artemis ATP exposes JTAG via the header in the middle of
+the board. See the [SparkFun hookup guide](https://learn.sparkfun.com/tutorials/hookup-guide-for-the-sparkfun-redboard-artemis-atp) for a picture of this.
+
+SparkFun sell accessories you can use to connecting to this. It appears
+something like the J-Link BASE will work, but that hasn't been tested by Tock.
+
+Instead, Tock has tested debugging with the [Black Magic Probe](https://black-magic.org/).
+The Black Magic Probe (BMP) is an easy to use, mostly plug and play, JTAG/SWD debugger
+for embedded microcontrollers.
+
+In order to debug with the BMP, first connect the 2x5 SWD cable to the RedBoard
+and the BMP. The ribbon on the RedBoard should face towards the USB
+connection and on the BMP away from the USB connection.
+
+Then power on both boards.
+
+Fire up an ARM GDB instance and attach to the BMP with:
+
+```
+target extended-remote /dev/ttyACM0
+monitor swdp_scan
+attach 1
+```
+
+You can then use GDB to debug the RedBoard

--- a/boards/apollo3/redboard_artemis_atp/layout.ld
+++ b/boards/apollo3/redboard_artemis_atp/layout.ld
@@ -1,0 +1,14 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
+MEMORY
+{
+  rom (rx)  : ORIGIN = 0x0000C000, LENGTH = 0x00030000
+  prog (rx) : ORIGIN = 0x00040000, LENGTH = 0x08000000 - 0x00030000
+  ram (rwx) : ORIGIN = 0x10000000, LENGTH = 0x60000
+}
+
+PAGE_SIZE = 8K;
+
+INCLUDE ../../kernel_layout.ld

--- a/boards/apollo3/redboard_artemis_atp/run.sh
+++ b/boards/apollo3/redboard_artemis_atp/run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2023.
+
+set -ex
+
+${OBJCOPY} --output-target=binary ${OBJCOPY_FLAGS} ${1} redboard-artemis-atp-tests.bin
+python ../ambiq/ambiq_bin2board.py --bin redboard-artemis-atp-tests.bin --load-address-blob 0x40000 -b 115200 -port ${PORT} -r 2 -v --magic-num 0xCB --version 0x0 --load-address-wired 0xc000 -i 6 --options 0x1
+
+# If we connect too quickly the UART doesn't work, so add a small delay
+sleep 1
+screen ${PORT} 115200

--- a/boards/apollo3/redboard_artemis_atp/src/io.rs
+++ b/boards/apollo3/redboard_artemis_atp/src/io.rs
@@ -1,0 +1,60 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+use core::fmt::Write;
+use core::panic::PanicInfo;
+
+use crate::CHIP;
+use crate::PROCESSES;
+use crate::PROCESS_PRINTER;
+use apollo3;
+use kernel::debug;
+use kernel::debug::IoWrite;
+use kernel::hil::led;
+
+/// Writer is used by kernel::debug to panic message to the serial port.
+pub struct Writer {}
+
+/// Global static for debug writer
+pub static mut WRITER: Writer = Writer {};
+
+impl Write for Writer {
+    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+impl IoWrite for Writer {
+    fn write(&mut self, buf: &[u8]) -> usize {
+        let uart = apollo3::uart::Uart::new_uart_0(); // Aliases memory for uart0. Okay bc we are panicking.
+        uart.transmit_sync(buf);
+        buf.len()
+    }
+}
+
+/// Panic handler.
+#[no_mangle]
+#[panic_handler]
+pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
+    // just create a new pin reference here instead of using global
+    let led_pin = &mut apollo3::gpio::GpioPin::new(
+        kernel::utilities::StaticRef::new(
+            apollo3::gpio::GPIO_BASE_RAW as *const apollo3::gpio::GpioRegisters,
+        ),
+        apollo3::gpio::Pin::Pin19,
+    );
+    let led = &mut led::LedLow::new(led_pin);
+    let writer = &mut WRITER;
+
+    debug::panic(
+        &mut [led],
+        writer,
+        info,
+        &cortexm4::support::nop,
+        &PROCESSES,
+        &CHIP,
+        &PROCESS_PRINTER,
+    )
+}

--- a/boards/apollo3/redboard_artemis_atp/src/main.rs
+++ b/boards/apollo3/redboard_artemis_atp/src/main.rs
@@ -1,0 +1,437 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! Board file for SparkFun Redboard Artemis ATP
+//!
+//! - <https://www.sparkfun.com/products/15442>
+
+#![no_std]
+// Disable this attribute when documenting, as a workaround for
+// https://github.com/rust-lang/rust/issues/62184.
+#![cfg_attr(not(doc), no_main)]
+#![deny(missing_docs)]
+#![feature(custom_test_frameworks)]
+#![test_runner(test_runner)]
+#![reexport_test_harness_main = "test_main"]
+
+use apollo3::chip::Apollo3DefaultPeripherals;
+use capsules_core::i2c_master_slave_driver::I2CMasterSlaveDriver;
+use capsules_core::virtualizers::virtual_alarm::MuxAlarm;
+use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
+use kernel::capabilities;
+use kernel::component::Component;
+use kernel::hil::i2c::I2CMaster;
+use kernel::hil::i2c::I2CSlave;
+use kernel::hil::led::LedHigh;
+use kernel::hil::time::Counter;
+use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::scheduler::round_robin::RoundRobinSched;
+use kernel::{create_capability, debug, static_init};
+
+/// Support routines for debugging I/O.
+pub mod io;
+
+#[cfg(test)]
+mod tests;
+
+// Number of concurrent processes this platform supports.
+const NUM_PROCS: usize = 4;
+
+// Actual memory for holding the active process structures.
+static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS] = [None; 4];
+
+// Static reference to chip for panic dumps.
+static mut CHIP: Option<&'static apollo3::chip::Apollo3<Apollo3DefaultPeripherals>> = None;
+// Static reference to process printer for panic dumps.
+static mut PROCESS_PRINTER: Option<&'static kernel::process::ProcessPrinterText> = None;
+
+// How should the kernel respond when a process faults.
+const FAULT_RESPONSE: kernel::process::PanicFaultPolicy = kernel::process::PanicFaultPolicy {};
+
+// Test access to the peripherals
+#[cfg(test)]
+static mut PERIPHERALS: Option<&'static Apollo3DefaultPeripherals> = None;
+// Test access to board
+#[cfg(test)]
+static mut BOARD: Option<&'static kernel::Kernel> = None;
+// Test access to platform
+#[cfg(test)]
+static mut PLATFORM: Option<&'static RedboardArtemisAtp> = None;
+// Test access to main loop capability
+#[cfg(test)]
+static mut MAIN_CAP: Option<&dyn kernel::capabilities::MainLoopCapability> = None;
+// Test access to alarm
+static mut ALARM: Option<&'static MuxAlarm<'static, apollo3::stimer::STimer<'static>>> = None;
+
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
+
+/// A structure representing this platform that holds references to all
+/// capsules for this platform.
+struct RedboardArtemisAtp {
+    alarm: &'static capsules_core::alarm::AlarmDriver<
+        'static,
+        VirtualMuxAlarm<'static, apollo3::stimer::STimer<'static>>,
+    >,
+    led: &'static capsules_core::led::LedDriver<
+        'static,
+        LedHigh<'static, apollo3::gpio::GpioPin<'static>>,
+        1,
+    >,
+    gpio: &'static capsules_core::gpio::GPIO<'static, apollo3::gpio::GpioPin<'static>>,
+    console: &'static capsules_core::console::Console<'static>,
+    i2c_master_slave: &'static capsules_core::i2c_master_slave_driver::I2CMasterSlaveDriver<
+        'static,
+        capsules_core::i2c_master_slave_combo::I2CMasterSlaveCombo<
+            'static,
+            apollo3::iom::Iom<'static>,
+            apollo3::ios::Ios<'static>,
+        >,
+    >,
+    ble_radio: &'static capsules_extra::ble_advertising_driver::BLE<
+        'static,
+        apollo3::ble::Ble<'static>,
+        VirtualMuxAlarm<'static, apollo3::stimer::STimer<'static>>,
+    >,
+    scheduler: &'static RoundRobinSched<'static>,
+    systick: cortexm4::systick::SysTick,
+}
+
+/// Mapping of integer syscalls to objects that implement syscalls.
+impl SyscallDriverLookup for RedboardArtemisAtp {
+    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    where
+        F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
+    {
+        match driver_num {
+            capsules_core::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules_core::led::DRIVER_NUM => f(Some(self.led)),
+            capsules_core::gpio::DRIVER_NUM => f(Some(self.gpio)),
+            capsules_core::console::DRIVER_NUM => f(Some(self.console)),
+            capsules_core::i2c_master_slave_driver::DRIVER_NUM => f(Some(self.i2c_master_slave)),
+            capsules_extra::ble_advertising_driver::DRIVER_NUM => f(Some(self.ble_radio)),
+            _ => f(None),
+        }
+    }
+}
+
+impl KernelResources<apollo3::chip::Apollo3<Apollo3DefaultPeripherals>> for RedboardArtemisAtp {
+    type SyscallDriverLookup = Self;
+    type SyscallFilter = ();
+    type ProcessFault = ();
+    type CredentialsCheckingPolicy = ();
+    type Scheduler = RoundRobinSched<'static>;
+    type SchedulerTimer = cortexm4::systick::SysTick;
+    type WatchDog = ();
+    type ContextSwitchCallback = ();
+
+    fn syscall_driver_lookup(&self) -> &Self::SyscallDriverLookup {
+        self
+    }
+    fn syscall_filter(&self) -> &Self::SyscallFilter {
+        &()
+    }
+    fn process_fault(&self) -> &Self::ProcessFault {
+        &()
+    }
+    fn credentials_checking_policy(&self) -> &'static Self::CredentialsCheckingPolicy {
+        &()
+    }
+    fn scheduler(&self) -> &Self::Scheduler {
+        self.scheduler
+    }
+    fn scheduler_timer(&self) -> &Self::SchedulerTimer {
+        &self.systick
+    }
+    fn watchdog(&self) -> &Self::WatchDog {
+        &()
+    }
+    fn context_switch_callback(&self) -> &Self::ContextSwitchCallback {
+        &()
+    }
+}
+
+// Ensure that `setup()` is never inlined
+// This helps reduce the stack frame, see https://github.com/tock/tock/issues/3518
+#[inline(never)]
+unsafe fn setup() -> (
+    &'static kernel::Kernel,
+    &'static RedboardArtemisAtp,
+    &'static apollo3::chip::Apollo3<Apollo3DefaultPeripherals>,
+    &'static Apollo3DefaultPeripherals,
+) {
+    let peripherals = static_init!(Apollo3DefaultPeripherals, Apollo3DefaultPeripherals::new());
+
+    // No need to statically allocate mcu/pwr/clk_ctrl because they are only used in main!
+    let mcu_ctrl = apollo3::mcuctrl::McuCtrl::new();
+    let pwr_ctrl = apollo3::pwrctrl::PwrCtrl::new();
+    let clkgen = apollo3::clkgen::ClkGen::new();
+
+    clkgen.set_clock_frequency(apollo3::clkgen::ClockFrequency::Freq48MHz);
+
+    // initialize capabilities
+    let process_mgmt_cap = create_capability!(capabilities::ProcessManagementCapability);
+    let memory_allocation_cap = create_capability!(capabilities::MemoryAllocationCapability);
+
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+
+    // Power up components
+    pwr_ctrl.enable_uart0();
+    pwr_ctrl.enable_iom0();
+    pwr_ctrl.enable_iom4();
+    pwr_ctrl.enable_ios();
+
+    // Enable PinCfg
+    peripherals
+        .gpio_port
+        .enable_uart(&peripherals.gpio_port[48], &peripherals.gpio_port[49]);
+    // Enable SDA and SCL for I2C4 (exposed via Qwiic)
+    peripherals
+        .gpio_port
+        .enable_i2c(&peripherals.gpio_port[40], &peripherals.gpio_port[39]);
+    // Enable I2C slave device
+    peripherals
+        .gpio_port
+        .enable_i2c_slave(&peripherals.gpio_port[1], &peripherals.gpio_port[0]);
+
+    // Configure kernel debug gpios as early as possible
+    kernel::debug::assign_gpios(
+        Some(&peripherals.gpio_port[19]), // Blue LED
+        None,
+        None,
+    );
+
+    // Create a shared UART channel for the console and for kernel debug.
+    let uart_mux = components::console::UartMuxComponent::new(&peripherals.uart0, 115200)
+        .finalize(components::uart_mux_component_static!());
+
+    // Setup the console.
+    let console = components::console::ConsoleComponent::new(
+        board_kernel,
+        capsules_core::console::DRIVER_NUM,
+        uart_mux,
+    )
+    .finalize(components::console_component_static!());
+    // Create the debugger object that handles calls to `debug!()`.
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
+
+    // LEDs
+    let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
+        LedHigh<'static, apollo3::gpio::GpioPin>,
+        LedHigh::new(&peripherals.gpio_port[19]),
+    ));
+
+    // GPIOs
+    // These are also ADC channels, but let's expose them as GPIOs
+    let gpio = components::gpio::GpioComponent::new(
+        board_kernel,
+        capsules_core::gpio::DRIVER_NUM,
+        components::gpio_component_helper!(
+            apollo3::gpio::GpioPin,
+            0 => &peripherals.gpio_port[13],  // A0
+            1 => &peripherals.gpio_port[33],  // A1
+            2 => &peripherals.gpio_port[11],  // A2
+            3 => &peripherals.gpio_port[29],  // A3
+            5 => &peripherals.gpio_port[31]  // A5
+        ),
+    )
+    .finalize(components::gpio_component_static!(apollo3::gpio::GpioPin));
+
+    // Create a shared virtualisation mux layer on top of a single hardware
+    // alarm.
+    let _ = peripherals.stimer.start();
+    let mux_alarm = components::alarm::AlarmMuxComponent::new(&peripherals.stimer).finalize(
+        components::alarm_mux_component_static!(apollo3::stimer::STimer),
+    );
+    let alarm = components::alarm::AlarmDriverComponent::new(
+        board_kernel,
+        capsules_core::alarm::DRIVER_NUM,
+        mux_alarm,
+    )
+    .finalize(components::alarm_component_static!(apollo3::stimer::STimer));
+    ALARM = Some(mux_alarm);
+
+    // Create a process printer for panic.
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
+    PROCESS_PRINTER = Some(process_printer);
+
+    let i2c_master_slave_combo = static_init!(
+        capsules_core::i2c_master_slave_combo::I2CMasterSlaveCombo<
+            'static,
+            apollo3::iom::Iom<'static>,
+            apollo3::ios::Ios<'static>,
+        >,
+        capsules_core::i2c_master_slave_combo::I2CMasterSlaveCombo::new(
+            &peripherals.iom4,
+            &peripherals.ios
+        )
+    );
+
+    let i2c_master_buffer = static_init!([u8; 32], [0; 32]);
+    let i2c_slave_buffer1 = static_init!([u8; 32], [0; 32]);
+    let i2c_slave_buffer2 = static_init!([u8; 32], [0; 32]);
+
+    let i2c_master_slave = static_init!(
+        I2CMasterSlaveDriver<
+            capsules_core::i2c_master_slave_combo::I2CMasterSlaveCombo<
+                'static,
+                apollo3::iom::Iom<'static>,
+                apollo3::ios::Ios<'static>,
+            >,
+        >,
+        I2CMasterSlaveDriver::new(
+            i2c_master_slave_combo,
+            i2c_master_buffer,
+            i2c_slave_buffer1,
+            i2c_slave_buffer2,
+            board_kernel.create_grant(
+                capsules_core::i2c_master_slave_driver::DRIVER_NUM,
+                &memory_allocation_cap
+            ),
+        )
+    );
+
+    i2c_master_slave_combo.set_master_client(i2c_master_slave);
+    i2c_master_slave_combo.set_slave_client(i2c_master_slave);
+
+    peripherals.iom4.enable();
+
+    // Setup BLE
+    mcu_ctrl.enable_ble();
+    clkgen.enable_ble();
+    pwr_ctrl.enable_ble();
+    peripherals.ble.setup_clocks();
+    mcu_ctrl.reset_ble();
+    peripherals.ble.power_up();
+    peripherals.ble.ble_initialise();
+
+    let ble_radio = components::ble::BLEComponent::new(
+        board_kernel,
+        capsules_extra::ble_advertising_driver::DRIVER_NUM,
+        &peripherals.ble,
+        mux_alarm,
+    )
+    .finalize(components::ble_component_static!(
+        apollo3::stimer::STimer,
+        apollo3::ble::Ble,
+    ));
+
+    mcu_ctrl.print_chip_revision();
+
+    debug!("Initialization complete. Entering main loop");
+
+    // These symbols are defined in the linker script.
+    extern "C" {
+        /// Beginning of the ROM region containing app images.
+        static _sapps: u8;
+        /// End of the ROM region containing app images.
+        static _eapps: u8;
+        /// Beginning of the RAM region for app memory.
+        static mut _sappmem: u8;
+        /// End of the RAM region for app memory.
+        static _eappmem: u8;
+    }
+
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+        .finalize(components::round_robin_component_static!(NUM_PROCS));
+
+    let systick = cortexm4::systick::SysTick::new_with_calibration(48_000_000);
+
+    let artemis_atp = static_init!(
+        RedboardArtemisAtp,
+        RedboardArtemisAtp {
+            alarm,
+            led,
+            gpio,
+            console,
+            i2c_master_slave,
+            ble_radio,
+            scheduler,
+            systick,
+        }
+    );
+
+    let chip = static_init!(
+        apollo3::chip::Apollo3<Apollo3DefaultPeripherals>,
+        apollo3::chip::Apollo3::new(peripherals)
+    );
+    CHIP = Some(chip);
+
+    kernel::process::load_processes(
+        board_kernel,
+        chip,
+        core::slice::from_raw_parts(
+            &_sapps as *const u8,
+            &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
+        ),
+        core::slice::from_raw_parts_mut(
+            &mut _sappmem as *mut u8,
+            &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
+        ),
+        &mut PROCESSES,
+        &FAULT_RESPONSE,
+        &process_mgmt_cap,
+    )
+    .unwrap_or_else(|err| {
+        debug!("Error loading processes!");
+        debug!("{:?}", err);
+    });
+
+    (board_kernel, artemis_atp, chip, peripherals)
+}
+
+/// Main function.
+///
+/// This function is called from the arch crate after some very basic RISC-V
+/// setup and RAM initialization.
+#[no_mangle]
+pub unsafe fn main() {
+    apollo3::init();
+
+    #[cfg(test)]
+    test_main();
+
+    #[cfg(not(test))]
+    {
+        let (board_kernel, esp32_c3_board, chip, _peripherals) = setup();
+
+        let main_loop_cap = create_capability!(capabilities::MainLoopCapability);
+
+        board_kernel.kernel_loop(
+            esp32_c3_board,
+            chip,
+            None::<&kernel::ipc::IPC<{ NUM_PROCS as u8 }>>,
+            &main_loop_cap,
+        );
+    }
+}
+
+#[cfg(test)]
+use kernel::platform::watchdog::WatchDog;
+
+#[cfg(test)]
+fn test_runner(tests: &[&dyn Fn()]) {
+    unsafe {
+        let (board_kernel, esp32_c3_board, _chip, peripherals) = setup();
+
+        BOARD = Some(board_kernel);
+        PLATFORM = Some(&esp32_c3_board);
+        PERIPHERALS = Some(peripherals);
+        MAIN_CAP = Some(&create_capability!(capabilities::MainLoopCapability));
+
+        PLATFORM.map(|p| {
+            p.watchdog().setup();
+        });
+
+        for test in tests {
+            test();
+        }
+    }
+
+    loop {}
+}

--- a/boards/apollo3/redboard_artemis_atp/src/tests/i2c_slave.rs
+++ b/boards/apollo3/redboard_artemis_atp/src/tests/i2c_slave.rs
@@ -1,0 +1,121 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+use crate::tests::run_kernel_op;
+use crate::PERIPHERALS;
+use core::cell::Cell;
+use kernel::debug;
+use kernel::hil::i2c::I2CHwSlaveClient;
+use kernel::hil::i2c::I2CSlave;
+use kernel::hil::i2c::SlaveTransmissionType;
+use kernel::static_init;
+use kernel::utilities::cells::TakeCell;
+
+struct I2CSlaveCallback {
+    master_write_done: Cell<bool>,
+    send_data: TakeCell<'static, [u8]>,
+    master_read_done: Cell<bool>,
+    received_data: TakeCell<'static, [u8]>,
+}
+
+impl<'a> I2CSlaveCallback {
+    fn new(send_data: &'static mut [u8], received_data: &'static mut [u8]) -> Self {
+        I2CSlaveCallback {
+            master_write_done: Cell::new(false),
+            send_data: TakeCell::new(send_data),
+            master_read_done: Cell::new(false),
+            received_data: TakeCell::new(received_data),
+        }
+    }
+
+    fn reset(&self) {
+        self.master_write_done.set(false);
+        self.master_read_done.set(false);
+    }
+}
+
+impl<'a> I2CHwSlaveClient for I2CSlaveCallback {
+    fn command_complete(
+        &self,
+        buffer: &'static mut [u8],
+        length: usize,
+        transmission_type: SlaveTransmissionType,
+    ) {
+        match transmission_type {
+            SlaveTransmissionType::Write => {
+                self.master_write_done.set(true);
+                debug!("Was Sent: {buffer:x?}");
+            }
+            SlaveTransmissionType::Read => {
+                self.master_read_done.set(true);
+            }
+        }
+    }
+
+    fn read_expected(&self) {
+        unimplemented!()
+    }
+
+    fn write_expected(&self) {
+        unimplemented!()
+    }
+}
+
+unsafe fn static_init_test_cb() -> &'static I2CSlaveCallback {
+    let received_data = static_init!([u8; 8], [0xdc, 0x55, 0x51, 0x5e, 0x30, 0xac, 0x50, 0xc7]);
+    let send_data = static_init!([u8; 8], [0xdc, 0x55, 0x51, 0x5e, 0x30, 0xac, 0x50, 0xc7]);
+
+    static_init!(
+        I2CSlaveCallback,
+        I2CSlaveCallback::new(send_data, received_data)
+    )
+}
+
+#[test_case]
+fn i2c_slave_receive() {
+    let perf = unsafe { PERIPHERALS.unwrap() };
+    let i2c_slave = &perf.ios;
+    let cb = unsafe { static_init_test_cb() };
+    let received_data = cb.received_data.take().unwrap();
+    let send_data = cb.send_data.take().unwrap();
+
+    debug!("[I2C] Setup ios to receive... ");
+    run_kernel_op(100);
+
+    i2c_slave.set_slave_client(cb);
+    cb.reset();
+
+    debug!("    [I2C] Enable... ");
+    i2c_slave.enable();
+    run_kernel_op(100);
+
+    debug!("    [I2C] Set address... ");
+    assert_eq!(i2c_slave.set_address(0x41), Ok(()));
+    run_kernel_op(100);
+
+    debug!("    [I2C] read_send... ");
+    i2c_slave.read_send(send_data, send_data.len()).unwrap();
+    run_kernel_op(100);
+
+    debug!("    [I2C] Starting listen... ");
+    i2c_slave.listen();
+    run_kernel_op(100);
+
+    debug!("    [I2C] Run... ");
+    run_kernel_op(5000);
+
+    debug!("    [I2C] write_receive... ");
+    i2c_slave
+        .write_receive(received_data, received_data.len())
+        .unwrap();
+    run_kernel_op(5000_00);
+
+    // If there is an I2C master device you can uncomment this to
+    // ensure we recieve the data.
+    // assert_eq!(cb.master_write_done.get(), true);
+
+    run_kernel_op(100);
+    debug!("    [ok]");
+    run_kernel_op(100);
+}

--- a/boards/apollo3/redboard_artemis_atp/src/tests/mod.rs
+++ b/boards/apollo3/redboard_artemis_atp/src/tests/mod.rs
@@ -1,0 +1,38 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+use crate::BOARD;
+use crate::CHIP;
+use crate::MAIN_CAP;
+use crate::NUM_PROCS;
+use crate::PLATFORM;
+use kernel::debug;
+
+fn run_kernel_op(loops: usize) {
+    unsafe {
+        for _i in 0..loops {
+            BOARD.unwrap().kernel_loop_operation(
+                PLATFORM.unwrap(),
+                CHIP.unwrap(),
+                None::<&kernel::ipc::IPC<{ NUM_PROCS as u8 }>>,
+                true,
+                MAIN_CAP.unwrap(),
+            );
+        }
+    }
+}
+
+#[test_case]
+fn trivial_assertion() {
+    debug!("trivial assertion... ");
+    run_kernel_op(10000);
+
+    assert_eq!(1, 1);
+
+    debug!("    [ok]");
+    run_kernel_op(10000);
+}
+
+mod i2c_slave;
+mod multi_alarm;

--- a/boards/apollo3/redboard_artemis_atp/src/tests/multi_alarm.rs
+++ b/boards/apollo3/redboard_artemis_atp/src/tests/multi_alarm.rs
@@ -1,0 +1,92 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! Test the behavior of a single alarm.
+//! To add this test, include the line
+//! ```
+//!    multi_alarm_test::run_alarm(alarm_mux);
+//! ```
+//! to the OpenTitan boot sequence, where `alarm_mux` is a
+//! `capsules_core::virtualizers::virtual_alarm::MuxAlarm`. The test sets up 3
+//! different virtualized alarms of random durations and prints
+//! out when they fire. The durations are uniformly random with
+//! one caveat, that 1 in 11 is of duration 0; this is to test
+//! that alarms whose expiration was in the past due to the
+//! latency of software work correctly.
+
+use crate::tests::run_kernel_op;
+use crate::ALARM;
+use apollo3::stimer::STimer;
+use capsules_core::test::random_alarm::TestRandomAlarm;
+use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use kernel::debug;
+use kernel::hil::time::Alarm;
+use kernel::static_init;
+
+static mut TESTS: Option<
+    [&'static TestRandomAlarm<'static, VirtualMuxAlarm<'static, STimer<'static>>>; 3],
+> = None;
+
+#[test_case]
+pub fn run_multi_alarm() {
+    debug!("start multi alarm test...");
+    unsafe {
+        TESTS = Some(static_init_multi_alarm_test(ALARM.unwrap()));
+        TESTS.unwrap()[0].run();
+        TESTS.unwrap()[1].run();
+        TESTS.unwrap()[2].run();
+    }
+
+    run_kernel_op(10000);
+
+    unsafe {
+        assert!(TESTS.unwrap()[0].counter.get() > 15);
+        assert!(TESTS.unwrap()[1].counter.get() > 30);
+        assert!(TESTS.unwrap()[2].counter.get() > 80);
+    }
+
+    debug!("    [ok]");
+    run_kernel_op(10000);
+}
+
+unsafe fn static_init_multi_alarm_test(
+    mux: &'static MuxAlarm<'static, STimer<'static>>,
+) -> [&'static TestRandomAlarm<'static, VirtualMuxAlarm<'static, STimer<'static>>>; 3] {
+    let virtual_alarm1 = static_init!(
+        VirtualMuxAlarm<'static, STimer<'static>>,
+        VirtualMuxAlarm::new(mux)
+    );
+    virtual_alarm1.setup();
+
+    let test1 = static_init!(
+        TestRandomAlarm<'static, VirtualMuxAlarm<'static, STimer<'static>>>,
+        TestRandomAlarm::new(virtual_alarm1, 19, 'A', false)
+    );
+    virtual_alarm1.set_alarm_client(test1);
+
+    let virtual_alarm2 = static_init!(
+        VirtualMuxAlarm<'static, STimer<'static>>,
+        VirtualMuxAlarm::new(mux)
+    );
+    virtual_alarm2.setup();
+
+    let test2 = static_init!(
+        TestRandomAlarm<'static, VirtualMuxAlarm<'static, STimer<'static>>>,
+        TestRandomAlarm::new(virtual_alarm2, 37, 'B', false)
+    );
+    virtual_alarm2.set_alarm_client(test2);
+
+    let virtual_alarm3 = static_init!(
+        VirtualMuxAlarm<'static, STimer<'static>>,
+        VirtualMuxAlarm::new(mux)
+    );
+    virtual_alarm3.setup();
+
+    let test3 = static_init!(
+        TestRandomAlarm<'static, VirtualMuxAlarm<'static, STimer<'static>>>,
+        TestRandomAlarm::new(virtual_alarm3, 89, 'C', false)
+    );
+    virtual_alarm3.set_alarm_client(test3);
+    [&*test1, &*test2, &*test3]
+}

--- a/chips/apollo3/src/gpio.rs
+++ b/chips/apollo3/src/gpio.rs
@@ -259,6 +259,20 @@ impl Port<'_> {
         let regs = GPIO_BASE;
 
         match sda.pin as usize {
+            40 => {
+                regs.padkey.set(115);
+                regs.padreg[10].modify(
+                    PADREG::PAD0PULL::SET
+                        + PADREG::PAD0INPEN::SET
+                        + PADREG::PAD0STRING::SET
+                        + PADREG::PAD0FNCSEL.val(0x4)
+                        + PADREG::PAD0RSEL.val(0x00),
+                );
+                regs.cfg[5].modify(CFG::GPIO0INCFG.val(0x00) + CFG::GPIO0OUTCFG.val(0x02));
+                regs.altpadcfgk
+                    .modify(ALTPADCFG::PAD0_DS1::SET + ALTPADCFG::PAD0_DS1::CLEAR);
+                regs.padkey.set(0x00);
+            }
             25 => {
                 regs.padkey.set(115);
                 regs.padreg[6].modify(
@@ -291,6 +305,20 @@ impl Port<'_> {
         }
 
         match scl.pin as usize {
+            39 => {
+                regs.padkey.set(115);
+                regs.padreg[9].modify(
+                    PADREG::PAD3PULL::SET
+                        + PADREG::PAD3INPEN::SET
+                        + PADREG::PAD3STRNG::SET
+                        + PADREG::PAD3FNCSEL.val(0x4)
+                        + PADREG::PAD3RSEL.val(0x00),
+                );
+                regs.cfg[4].modify(CFG::GPIO7INTD.val(0x00) + CFG::GPIO7OUTCFG.val(0x02));
+                regs.altpadcfgj
+                    .modify(ALTPADCFG::PAD3_DS1::SET + ALTPADCFG::PAD3_SR::CLEAR);
+                regs.padkey.set(0x00);
+            }
             27 => {
                 regs.padkey.set(115);
                 regs.padreg[6].modify(

--- a/chips/apollo3/src/pwrctrl.rs
+++ b/chips/apollo3/src/pwrctrl.rs
@@ -117,6 +117,12 @@ impl PwrCtrl {
         regs.devpwren.modify(DEVPWREN::PWRIOM3::SET);
     }
 
+    pub fn enable_iom4(&self) {
+        let regs = self.registers;
+
+        regs.devpwren.modify(DEVPWREN::PWRIOM4::SET);
+    }
+
     pub fn enable_ble(&self) {
         let regs = self.registers;
 


### PR DESCRIPTION
### Pull Request Overview

The RedBoard Artemis ATP is affectionately called 'All the Pins!' at SparkFun.
The Artemis module has 48 GPIO and this board breaks out absolutely every one
of them in a familiar Mega like form factor.

This adds support for the board to Tock

### Testing Strategy

Running I2C applications on the board

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
