### PR TITLE
humidity: Match temperature and use templated sensor

### DIFF
--- a/boards/apollo3/lora_things_plus/src/main.rs
+++ b/boards/apollo3/lora_things_plus/src/main.rs
@@ -109,6 +109,7 @@ type BME280Sensor = components::bme280::Bme280ComponentType<
     capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, apollo3::iom::Iom<'static>>,
 >;
 type TemperatureDriver = components::temperature::TemperatureComponentType<BME280Sensor>;
+type HumidityDriver = components::humidity::HumidityComponentType<BME280Sensor>;
 
 /// A structure representing this platform that holds references to all
 /// capsules for this platform.
@@ -147,7 +148,7 @@ struct LoRaThingsPlus {
         VirtualMuxAlarm<'static, apollo3::stimer::STimer<'static>>,
     >,
     temperature: &'static TemperatureDriver,
-    humidity: &'static capsules_extra::humidity::HumiditySensor<'static>,
+    humidity: &'static HumidityDriver,
     air_quality: &'static capsules_extra::air_quality::AirQualitySensor<'static>,
     scheduler: &'static RoundRobinSched<'static>,
     systick: cortexm4::systick::SysTick,
@@ -363,7 +364,7 @@ unsafe fn setup() -> (
         capsules_extra::humidity::DRIVER_NUM,
         bme280,
     )
-    .finalize(components::humidity_component_static!());
+    .finalize(components::humidity_component_static!(BME280Sensor));
     BME280 = Some(bme280);
 
     let ccs811 = Ccs811Component::new(mux_i2c, 0x5B).finalize(

--- a/boards/apollo3/redboard_artemis_nano/src/main.rs
+++ b/boards/apollo3/redboard_artemis_nano/src/main.rs
@@ -81,6 +81,7 @@ type BME280Sensor = components::bme280::Bme280ComponentType<
     capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, apollo3::iom::Iom<'static>>,
 >;
 type TemperatureDriver = components::temperature::TemperatureComponentType<BME280Sensor>;
+type HumidityDriver = components::humidity::HumidityComponentType<BME280Sensor>;
 
 /// A structure representing this platform that holds references to all
 /// capsules for this platform.
@@ -111,7 +112,7 @@ struct RedboardArtemisNano {
         VirtualMuxAlarm<'static, apollo3::stimer::STimer<'static>>,
     >,
     temperature: &'static TemperatureDriver,
-    humidity: &'static capsules_extra::humidity::HumiditySensor<'static>,
+    humidity: &'static HumidityDriver,
     air_quality: &'static capsules_extra::air_quality::AirQualitySensor<'static>,
     scheduler: &'static RoundRobinSched<'static>,
     systick: cortexm4::systick::SysTick,
@@ -323,7 +324,7 @@ unsafe fn setup() -> (
         capsules_extra::humidity::DRIVER_NUM,
         bme280,
     )
-    .finalize(components::humidity_component_static!());
+    .finalize(components::humidity_component_static!(BME280Sensor));
     BME280 = Some(bme280);
 
     let ccs811 = Ccs811Component::new(mux_i2c, 0x5B)

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -143,6 +143,7 @@ type SHT3xSensor = components::sht3x::SHT3xComponentType<
     capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, nrf52840::i2c::TWI<'static>>,
 >;
 type TemperatureDriver = components::temperature::TemperatureComponentType<SHT3xSensor>;
+type HumidityDriver = components::humidity::HumidityComponentType<SHT3xSensor>;
 
 /// Supported drivers by the platform
 pub struct Platform {
@@ -187,7 +188,7 @@ pub struct Platform {
     >,
     adc: &'static capsules_core::adc::AdcVirtualized<'static>,
     temperature: &'static TemperatureDriver,
-    humidity: &'static capsules_extra::humidity::HumiditySensor<'static>,
+    humidity: &'static HumidityDriver,
     scheduler: &'static RoundRobinSched<'static>,
     systick: cortexm4::systick::SysTick,
 }
@@ -629,7 +630,7 @@ unsafe fn start() -> (
         capsules_extra::humidity::DRIVER_NUM,
         sht3x,
     )
-    .finalize(components::humidity_component_static!());
+    .finalize(components::humidity_component_static!(SHT3xSensor));
 
     //--------------------------------------------------------------------------
     // TFT

--- a/boards/components/src/humidity.rs
+++ b/boards/components/src/humidity.rs
@@ -20,10 +20,12 @@ use kernel::hil;
 
 #[macro_export]
 macro_rules! humidity_component_static {
-    () => {{
-        kernel::static_buf!(capsules_extra::humidity::HumiditySensor<'static>)
+    ($H: ty $(,)?) => {{
+        kernel::static_buf!(capsules_extra::humidity::HumiditySensor<'static, $H>)
     };};
 }
+
+pub type HumidityComponentType<H> = capsules_extra::humidity::HumiditySensor<'static, H>;
 
 pub struct HumidityComponent<T: 'static + hil::sensors::HumidityDriver<'static>> {
     board_kernel: &'static kernel::Kernel,
@@ -46,8 +48,8 @@ impl<T: 'static + hil::sensors::HumidityDriver<'static>> HumidityComponent<T> {
 }
 
 impl<T: 'static + hil::sensors::HumidityDriver<'static>> Component for HumidityComponent<T> {
-    type StaticInput = &'static mut MaybeUninit<HumiditySensor<'static>>;
-    type Output = &'static HumiditySensor<'static>;
+    type StaticInput = &'static mut MaybeUninit<HumiditySensor<'static, T>>;
+    type Output = &'static HumiditySensor<'static, T>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -53,6 +53,7 @@ type SI7021Sensor = components::si7021::SI7021ComponentType<
     capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, sam4l::i2c::I2CHw<'static>>,
 >;
 type TemperatureDriver = components::temperature::TemperatureComponentType<SI7021Sensor>;
+type HumidityDriver = components::humidity::HumidityComponentType<SI7021Sensor>;
 
 /// A structure representing this platform that holds references to all
 /// capsules for this platform.
@@ -69,7 +70,7 @@ struct Hail {
     ambient_light: &'static capsules_extra::ambient_light::AmbientLight<'static>,
     temp: &'static TemperatureDriver,
     ninedof: &'static capsules_extra::ninedof::NineDof<'static>,
-    humidity: &'static capsules_extra::humidity::HumiditySensor<'static>,
+    humidity: &'static HumidityDriver,
     spi: &'static capsules_core::spi_controller::Spi<
         'static,
         capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<
@@ -340,7 +341,7 @@ unsafe fn start() -> (
         capsules_extra::humidity::DRIVER_NUM,
         si7021,
     )
-    .finalize(components::humidity_component_static!());
+    .finalize(components::humidity_component_static!(SI7021Sensor));
 
     // Configure the ISL29035, device address 0x44
     let isl29035 = components::isl29035::Isl29035Component::new(sensors_i2c, mux_alarm).finalize(

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -113,6 +113,7 @@ type SI7021Sensor = components::si7021::SI7021ComponentType<
     capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, sam4l::i2c::I2CHw<'static>>,
 >;
 type TemperatureDriver = components::temperature::TemperatureComponentType<SI7021Sensor>;
+type HumidityDriver = components::humidity::HumidityComponentType<SI7021Sensor>;
 
 struct Imix {
     pconsole: &'static capsules_core::process_console::ProcessConsole<
@@ -131,7 +132,7 @@ struct Imix {
     gpio: &'static capsules_core::gpio::GPIO<'static, sam4l::gpio::GPIOPin<'static>>,
     alarm: &'static AlarmDriver<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
     temp: &'static TemperatureDriver,
-    humidity: &'static capsules_extra::humidity::HumiditySensor<'static>,
+    humidity: &'static HumidityDriver,
     ambient_light: &'static capsules_extra::ambient_light::AmbientLight<'static>,
     adc: &'static capsules_core::adc::AdcDedicated<'static, sam4l::adc::Adc<'static>>,
     led: &'static capsules_core::led::LedDriver<
@@ -473,7 +474,7 @@ pub unsafe fn main() {
         capsules_extra::humidity::DRIVER_NUM,
         si7021,
     )
-    .finalize(components::humidity_component_static!());
+    .finalize(components::humidity_component_static!(SI7021Sensor));
 
     let fxos8700 = components::fxos8700::Fxos8700Component::new(mux_i2c, 0x1e, &peripherals.pc[13])
         .finalize(components::fxos8700_component_static!(

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -119,6 +119,7 @@ type HTS221Sensor = components::hts221::Hts221ComponentType<
     capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, nrf52840::i2c::TWI<'static>>,
 >;
 type TemperatureDriver = components::temperature::TemperatureComponentType<HTS221Sensor>;
+type HumidityDriver = components::humidity::HumidityComponentType<HTS221Sensor>;
 
 /// Supported drivers by the platform
 pub struct Platform {
@@ -143,7 +144,7 @@ pub struct Platform {
     >,
     proximity: &'static capsules_extra::proximity::ProximitySensor<'static>,
     temperature: &'static TemperatureDriver,
-    humidity: &'static capsules_extra::humidity::HumiditySensor<'static>,
+    humidity: &'static HumidityDriver,
     gpio: &'static capsules_core::gpio::GPIO<'static, nrf52::gpio::GPIOPin<'static>>,
     led: &'static capsules_core::led::LedDriver<
         'static,
@@ -510,7 +511,7 @@ pub unsafe fn start() -> (
         capsules_extra::humidity::DRIVER_NUM,
         hts221,
     )
-    .finalize(components::humidity_component_static!());
+    .finalize(components::humidity_component_static!(HTS221Sensor));
 
     //--------------------------------------------------------------------------
     // WIRELESS

--- a/boards/wm1110dev/src/main.rs
+++ b/boards/wm1110dev/src/main.rs
@@ -91,6 +91,7 @@ type SHT4xSensor = components::sht4x::SHT4xComponentType<
     capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, nrf52840::i2c::TWI<'static>>,
 >;
 type TemperatureDriver = components::temperature::TemperatureComponentType<SHT4xSensor>;
+type HumidityDriver = components::humidity::HumidityComponentType<SHT4xSensor>;
 
 /// Supported drivers by the platform
 pub struct Platform {
@@ -111,7 +112,7 @@ pub struct Platform {
         >,
     >,
     temperature: &'static TemperatureDriver,
-    humidity: &'static capsules_extra::humidity::HumiditySensor<'static>,
+    humidity: &'static HumidityDriver,
     lr1110_gpio: &'static capsules_core::gpio::GPIO<'static, nrf52840::gpio::GPIOPin<'static>>,
     lr1110_spi: &'static capsules_core::spi_controller::Spi<
         'static,
@@ -351,7 +352,7 @@ pub unsafe fn start() -> (
         capsules_extra::humidity::DRIVER_NUM,
         sht4x,
     )
-    .finalize(components::humidity_component_static!());
+    .finalize(components::humidity_component_static!(SHT4xSensor));
 
     //--------------------------------------------------------------------------
     // LoRa (SPI + GPIO)


### PR DESCRIPTION
### Pull Request Overview

Use
```rust
pub struct HumiditySensor<'a, H: hil::sensors::HumidityDriver<'a>> {
    driver: &'a H,
    apps: Grant<App, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
    busy: Cell<bool>,
}
```
in the humidity capsule rather than `driver: &'a dyn hil::sensors::HumidityDriver<'a>`.

Then also update the component to make this ergonomic.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
