### PR TITLE
kernel: utilities: add simple hash function (re: app checker and AppID)

### DIFF
--- a/kernel/src/utilities/helpers.rs
+++ b/kernel/src/utilities/helpers.rs
@@ -42,3 +42,17 @@ macro_rules! count_expressions {
     ($head:expr $(,)?) => (1usize);
     ($head:expr, $($tail:expr),* $(,)?) => (1usize + count_expressions!($($tail),*));
 }
+
+/// A very simple hashing algorithm "AddHash".
+///
+/// This just adds the ASCII character values from a string to create a 32 bit
+/// hash value. To make different orders of the same characters more likely to
+/// hash to different values, the characters are shifted left incrementally
+/// before summing.
+pub fn addhash_str(s: &'static str) -> u32 {
+    let mut sum = 0_u32;
+    for (i, c) in s.chars().enumerate() {
+        sum += ((c as u8) as u32) << (i % 25);
+    }
+    sum
+}


### PR DESCRIPTION
### Pull Request Overview

The AppID TRD references being able to assign `ShortID`s to applications (and therefore running processes) based on the app name. To do this, we need a function with signature `fn create_short_id(s: &'static str) -> u32`.

I just made this one up since it is simple to implement, doesn't require a dependency, and will probably work for the type of basic use cases that we want to be able to experiment with. For example, I've used this to assign specific applications by name to specific regions on a screen. We could also assign apps to LEDs or any other resource. What is nice is this "just works" without having to add new TBF headers, and we as humans have an easy time understanding the app name.


### Testing Strategy

Work on screens.


### TODO or Help Wanted

If there is something in the core library that would be better.

If there is a more well known simple hash-like function that does this that might be better. I'm opening this PR because I think we need something like this, but I'm not exactly sure what.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
