### PR TITLE
Disconnect debug-related pins from GPIO by default in OpenTitan

### DIFF
--- a/boards/opentitan/src/pinmux_layout.rs
+++ b/boards/opentitan/src/pinmux_layout.rs
@@ -113,10 +113,10 @@ impl EarlGreyPinmuxConfig for BoardPinmuxLayout {
         Out::GpioGpio12,    // Ioc2
         Out::ConstantHighZ, // Ioc3 UART3_RX
         Out::Uart0Tx,       // Ioc4 UART3_TX
-        Out::GpioGpio13,    // Ioc5
+        Out::ConstantHighZ, // Ioc5 (TAP STRAP 1)
         Out::GpioGpio14,    // Ioc6
         Out::GpioGpio15,    // Ioc7
-        Out::GpioGpio16,    // Ioc8
+        Out::ConstantHighZ, // Ioc8 (TAP STRAP 0)
         Out::GpioGpio17,    // Ioc9
         Out::GpioGpio18,    // Ioc10
         Out::GpioGpio19,    // Ioc11


### PR DESCRIPTION
### Pull Request Overview

This PR changes the default pinmux configuration of the TAP strap pins in OpenTitan Earl Grey.

The two TAP straps are used to select which JTAG TAP (test access point) is connected to the JTAG pins. This is commonly used to select either the RISC-V debug module or the OpenTitan lifecycle controller.

Most OpenTitan lifecycle states will sample these pins once on boot and use that TAP until reset. The RMA lifecycle state samples these pins continuously. Connecting them to GPIO prevents connecting a debugger as the TAP straps are changed once the pinmux is configured.

### Testing Strategy

I tested this by connecting OpenOCD to an Earl Grey bitstream in RMA mode running Tock.

Before this change, trying to connect would give this error message:

```
Open On-Chip Debugger 0.12.0
Licensed under GNU GPL v2
For bug reports, read
    http://openocd.org/doc/doxygen/bugs.html
trst_only separate trst_push_pull

Info : Hardware thread awareness created
force hard breakpoints
Info : Listening on port 6666 for tcl connections
Info : Listening on port 4444 for telnet connections
Info : clock speed 500 kHz
Error: JTAG scan chain interrogation failed: all ones
Error: Check JTAG interface, timings, target power, etc.
Error: Trying to use configured scan chain anyway...
Error: riscv.tap: IR capture error; saw 0x1f not 0x01
Warn : Bypassing JTAG setup events due to errors
Error: Unsupported DTM version: 15
Warn : target riscv.tap.0 examination failed
Info : starting gdb server for riscv.tap.0 on 3333
Info : Listening on port 3333 for gdb connections
```

We could only connect pre-pinmux configuration. With this change applied, we can connect after the pinmux connection. There is a separate issue that breaks debugging at another stage, but I'm still working that one out.

### TODO or Help Wanted

Is floating these pins the right fallback? They can still be pinmuxed to GPIO pins manually if you want to use them for that I believe.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
