### PR TITLE
Add makepython-nrf52840 board, SSD1306 OLED driver, and SharedScreen SyscallDriver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "boards/msp_exp432p401r",
     "boards/microbit_v2",
     "boards/wm1110dev",
+    "boards/makepython-nrf52840",
     "boards/nordic/nrf52840dk",
     "boards/nordic/nrf52840_dongle",
     "boards/nordic/nrf52dk",

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -77,6 +77,7 @@ pub mod si7021;
 pub mod siphash;
 pub mod sound_pressure;
 pub mod spi;
+pub mod ssd1306;
 pub mod st77xx;
 pub mod temperature;
 pub mod temperature_rp2040;

--- a/boards/components/src/ssd1306.rs
+++ b/boards/components/src/ssd1306.rs
@@ -1,0 +1,89 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2024.
+
+//! Components for the SSD1306 OLED screen.
+//!
+//! Usage
+//! -----
+//! ```rust
+//!
+//! let ssd1306_i2c = components::i2c::I2CComponent::new(i2c_bus, 0x3c)
+//!     .finalize(components::i2c_component_static!(nrf52840::i2c::TWI));
+//!
+//! let ssd1306 = components::ssd1306::Ssd1306Component::new(ssd1306_i2c, true)
+//!     .finalize(components::ssd1306_component_static!(nrf52840::i2c::TWI));
+//! ```
+
+use core::mem::MaybeUninit;
+use kernel::component::Component;
+use kernel::hil;
+
+// Setup static space for the objects.
+#[macro_export]
+macro_rules! ssd1306_component_static {
+    ($I: ty $(,)?) => {{
+        let buffer = kernel::static_buf!([u8; capsules_extra::ssd1306::BUFFER_SIZE]);
+        let ssd1306 = kernel::static_buf!(
+            capsules_extra::ssd1306::Ssd1306<
+                'static,
+                capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, $I>,
+            >
+        );
+
+        (buffer, ssd1306)
+    };};
+}
+
+pub type Ssd1306ComponentType<I> = capsules_extra::ssd1306::Ssd1306<
+    'static,
+    capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, I>,
+>;
+
+pub struct Ssd1306Component<I: hil::i2c::I2CMaster<'static> + 'static> {
+    i2c_device: &'static capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, I>,
+    use_charge_pump: bool,
+}
+
+impl<I: hil::i2c::I2CMaster<'static> + 'static> Ssd1306Component<I> {
+    pub fn new(
+        i2c_device: &'static capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, I>,
+        use_charge_pump: bool,
+    ) -> Ssd1306Component<I> {
+        Ssd1306Component {
+            i2c_device,
+            use_charge_pump,
+        }
+    }
+}
+
+impl<I: hil::i2c::I2CMaster<'static> + 'static> Component for Ssd1306Component<I> {
+    type StaticInput = (
+        &'static mut MaybeUninit<[u8; capsules_extra::ssd1306::BUFFER_SIZE]>,
+        &'static mut MaybeUninit<
+            capsules_extra::ssd1306::Ssd1306<
+                'static,
+                capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, I>,
+            >,
+        >,
+    );
+    type Output = &'static capsules_extra::ssd1306::Ssd1306<
+        'static,
+        capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, I>,
+    >;
+
+    fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
+        let buffer = static_buffer
+            .0
+            .write([0; capsules_extra::ssd1306::BUFFER_SIZE]);
+
+        let ssd1306 = static_buffer.1.write(capsules_extra::ssd1306::Ssd1306::new(
+            self.i2c_device,
+            buffer,
+            self.use_charge_pump,
+        ));
+        self.i2c_device.set_client(ssd1306);
+
+        ssd1306
+    }
+}

--- a/boards/makepython-nrf52840/Cargo.toml
+++ b/boards/makepython-nrf52840/Cargo.toml
@@ -1,0 +1,21 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2022.
+
+[package]
+name = "makepython-nrf52840"
+version.workspace = true
+authors.workspace = true
+build = "../build.rs"
+edition.workspace = true
+
+[dependencies]
+cortexm4 = { path = "../../arch/cortex-m4" }
+kernel = { path = "../../kernel" }
+nrf52 = { path = "../../chips/nrf52" }
+nrf52840 = { path = "../../chips/nrf52840" }
+components = { path = "../components" }
+nrf52_components = { path = "../nordic/nrf52_components" }
+
+capsules-core = { path = "../../capsules/core" }
+capsules-extra = { path = "../../capsules/extra" }

--- a/boards/makepython-nrf52840/Makefile
+++ b/boards/makepython-nrf52840/Makefile
@@ -1,0 +1,30 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2022.
+
+# Makefile for building the tock kernel for the Arduino Nano 33 BLE board.
+
+TOCK_ARCH=cortex-m4
+TARGET=thumbv7em-none-eabi
+PLATFORM=makepython-nrf52840
+
+include ../Makefile.common
+
+ifdef PORT
+  FLAGS += --port $(PORT)
+endif
+
+# Default target for installing the kernel.
+.PHONY: install
+install: program
+
+# Upload the kernel using tockloader and the tock bootloader
+.PHONY: program
+program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+	tockloader $(FLAGS) flash --address 0x10000 $<
+
+.PHONY: flash-bootloader
+flash-bootloader:
+	curl -L --output /tmp/makepython-nrf52840-bootloader_v1.1.3.bin https://github.com/tock/tock-bootloader/releases/download/v1.1.3/makepython-nrf52840-bootloader_v1.1.3.bin
+	tockloader flash --address 0 /tmp/makepython-nrf52840-bootloader_v1.1.3.bin
+	rm /tmp/makepython-nrf52840-bootloader_v1.1.3.bin

--- a/boards/makepython-nrf52840/README.md
+++ b/boards/makepython-nrf52840/README.md
@@ -1,0 +1,52 @@
+MakePython nRF52840
+===================
+
+<img src="https://www.makerfabs.com/image/cache/makerfabs/MakePython%20nRF52840/MakePython%20nRF52840-1-1000x750.jpg" width="35%">
+
+The [MakePython nRF52840](https://www.makerfabs.com/makepython-nrf52840.html) is
+a development board with the Nordic nRF52840 SoC and a 128 x 64 pixel OLED
+display.
+
+
+## Getting Started
+
+First, follow the [Tock Getting Started guide](../../doc/Getting_Started.md).
+
+The MakePython nRF52840 is designed to be programmed using an external JLink
+programmer. We would like to avoid this requirement, so we use the [Tock
+Bootloader](https://github.com/tock/tock-bootloader) which allows us to program
+the board over the UART connection. However, we still require the programmer one
+time to flash the bootloader.
+
+To flash the bootloader we must connect a JLink programmer. The easiest way is
+to use an nRF52840dk board.
+
+### Connect the nRF52840dk to the MakePython-nRF52840
+
+First we jumper the board as shown with the following pin mappings
+
+| nRF52840dk | MakePython-nRF52840 |
+|------------|---------------------|
+| GND        | GND                 |
+| SWD SEL    | +3V3                |
+| SWD CLK    | SWDCLK              |
+| SWD IO     | SWDDIO              |
+
+Make sure _both_ the nRF52840dk board and the MakePython-nRF52840 board are
+attached to your computer via two USB connections.
+
+Then:
+
+```
+make flash-bootloader
+```
+
+This will use JLinkExe to flash the bootloader using the nRF52840dk's onboard
+jtag hardware.
+
+### Using the Bootloader
+
+The bootloader activates when the reset button is pressed twice in quick
+succession. The green LED will stay on when the bootloader is active.
+
+Once the bootloader is installed tockloader will work as expected.

--- a/boards/makepython-nrf52840/README.md
+++ b/boards/makepython-nrf52840/README.md
@@ -1,7 +1,7 @@
 MakePython nRF52840
 ===================
 
-<img src="https://www.makerfabs.com/image/cache/makerfabs/MakePython%20nRF52840/MakePython%20nRF52840-1-1000x750.jpg" width="35%">
+<img src="https://www.makerfabs.com/media/catalog/product/cache/5082619e83af502b1cf28572733576a0/m/a/makepython_nrf52840-2.jpg" width="35%">
 
 The [MakePython nRF52840](https://www.makerfabs.com/makepython-nrf52840.html) is
 a development board with the Nordic nRF52840 SoC and a 128 x 64 pixel OLED

--- a/boards/makepython-nrf52840/layout.ld
+++ b/boards/makepython-nrf52840/layout.ld
@@ -1,0 +1,14 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
+MEMORY
+{
+  rom (rx)  : ORIGIN = 0x00010000, LENGTH = 256K
+  prog (rx) : ORIGIN = 0x00050000, LENGTH = 704K
+  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 256K
+}
+
+PAGE_SIZE = 4K;
+
+INCLUDE ../kernel_layout.ld

--- a/boards/makepython-nrf52840/src/io.rs
+++ b/boards/makepython-nrf52840/src/io.rs
@@ -122,8 +122,6 @@ impl IoWrite for Writer {
     }
 }
 
-/// Default panic handler for the Nano 33 Board.
-///
 /// We just use the standard default provided by the debug module in the kernel.
 #[cfg(not(test))]
 #[no_mangle]

--- a/boards/makepython-nrf52840/src/io.rs
+++ b/boards/makepython-nrf52840/src/io.rs
@@ -1,0 +1,144 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+use core::fmt::Write;
+use core::panic::PanicInfo;
+
+use cortexm4;
+use kernel::debug;
+use kernel::debug::IoWrite;
+use kernel::hil::led;
+use kernel::hil::uart::{self};
+use kernel::ErrorCode;
+use nrf52840::gpio::Pin;
+
+use crate::CHIP;
+use crate::PROCESSES;
+use crate::PROCESS_PRINTER;
+use kernel::hil::uart::Transmit;
+use kernel::utilities::cells::VolatileCell;
+
+struct Writer {
+    initialized: bool,
+}
+
+static mut WRITER: Writer = Writer { initialized: false };
+
+impl Write for Writer {
+    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+const BUF_LEN: usize = 512;
+static mut STATIC_PANIC_BUF: [u8; BUF_LEN] = [0; BUF_LEN];
+
+static mut DUMMY: DummyUsbClient = DummyUsbClient {
+    fired: VolatileCell::new(false),
+};
+
+struct DummyUsbClient {
+    fired: VolatileCell<bool>,
+}
+
+impl uart::TransmitClient for DummyUsbClient {
+    fn transmitted_buffer(&self, _: &'static mut [u8], _: usize, _: Result<(), ErrorCode>) {
+        self.fired.set(true);
+    }
+}
+
+impl IoWrite for Writer {
+    fn write(&mut self, buf: &[u8]) -> usize {
+        if !self.initialized {
+            self.initialized = true;
+        }
+        // Here we mimic a synchronous UART output by calling transmit_buffer
+        // on the CDC stack and then spinning on USB interrupts until the transaction
+        // is complete. If the USB or CDC stack panicked, this may fail. It will also
+        // fail if the panic occurred prior to the USB connection being initialized.
+        // In the latter case, the LEDs should still blink in the panic pattern.
+
+        // spin so that if any USB DMA is ongoing it will finish
+        // we should only need this on the first call to write()
+        let mut i = 0;
+        loop {
+            i += 1;
+            cortexm4::support::nop();
+            if i > 10000 {
+                break;
+            }
+        }
+
+        // copy_from_slice() requires equal length slices
+        // This will truncate any writes longer than BUF_LEN, but simplifies the
+        // code. In practice, BUF_LEN=512 always seems sufficient for the size of
+        // individual calls to write made by the panic handler.
+        let mut max = BUF_LEN;
+        if buf.len() < BUF_LEN {
+            max = buf.len();
+        }
+
+        unsafe {
+            // If CDC_REF_FOR_PANIC is not yet set we panicked very early,
+            // and not much we can do. Don't want to double fault,
+            // so just return.
+            super::CDC_REF_FOR_PANIC.map(|cdc| {
+                // Lots of unsafe dereferencing of global static mut objects here.
+                // However, this should be okay, because it all happens within
+                // a single thread, and:
+                // - This is the only place the global CDC_REF_FOR_PANIC is used, the logic is the same
+                //   as applies for the global CHIP variable used in the panic handler.
+                // - We do create multiple mutable references to the STATIC_PANIC_BUF, but we never
+                //   access the STATIC_PANIC_BUF after a slice of it is passed to transmit_buffer
+                //   until the slice has been returned in the uart callback.
+                // - Similarly, only this function uses the global DUMMY variable, and we do not
+                //   mutate it.
+                let usb = &mut cdc.controller();
+                STATIC_PANIC_BUF[..max].copy_from_slice(&buf[..max]);
+                let static_buf = &mut STATIC_PANIC_BUF;
+                cdc.set_transmit_client(&DUMMY);
+                let _ = cdc.transmit_buffer(static_buf, max);
+                loop {
+                    if let Some(interrupt) = cortexm4::nvic::next_pending() {
+                        if interrupt == 39 {
+                            usb.handle_interrupt();
+                        }
+                        let n = cortexm4::nvic::Nvic::new(interrupt);
+                        n.clear_pending();
+                        n.enable();
+                    }
+                    if DUMMY.fired.get() {
+                        // buffer finished transmitting, return so we can output additional
+                        // messages when requested by the panic handler.
+                        break;
+                    }
+                }
+                DUMMY.fired.set(false);
+            });
+        }
+        buf.len()
+    }
+}
+
+/// Default panic handler for the Nano 33 Board.
+///
+/// We just use the standard default provided by the debug module in the kernel.
+#[cfg(not(test))]
+#[no_mangle]
+#[panic_handler]
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P1_10);
+    let led = &mut led::LedLow::new(led_kernel_pin);
+    let writer = &mut WRITER;
+    debug::panic(
+        &mut [led],
+        writer,
+        pi,
+        &cortexm4::support::nop,
+        &PROCESSES,
+        &CHIP,
+        &PROCESS_PRINTER,
+    )
+}

--- a/boards/makepython-nrf52840/src/main.rs
+++ b/boards/makepython-nrf52840/src/main.rs
@@ -1,0 +1,739 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! Tock kernel for the MakePython nRF52840.
+//!
+//! It is based on nRF52840 SoC.
+
+#![no_std]
+// Disable this attribute when documenting, as a workaround for
+// https://github.com/rust-lang/rust/issues/62184.
+#![cfg_attr(not(doc), no_main)]
+#![deny(missing_docs)]
+
+use kernel::capabilities;
+use kernel::component::Component;
+use kernel::hil::led::LedLow;
+use kernel::hil::time::Counter;
+use kernel::hil::usb::Client;
+use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::scheduler::round_robin::RoundRobinSched;
+#[allow(unused_imports)]
+use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
+
+use nrf52840::gpio::Pin;
+use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
+
+// The datasheet and website and everything say this is connected to P1.10, but
+// actually looking at the hardware files (and what actually works) is that the
+// LED is connected to P1.11 (as of a board I received in September 2023).
+//
+// https://github.com/Makerfabs/NRF52840/issues/1
+const LED_PIN: Pin = Pin::P1_11;
+
+const BUTTON_RST_PIN: Pin = Pin::P0_18;
+const BUTTON_PIN: Pin = Pin::P1_15;
+
+const GPIO_D0: Pin = Pin::P0_23;
+const GPIO_D1: Pin = Pin::P0_12;
+const GPIO_D2: Pin = Pin::P0_09;
+const GPIO_D3: Pin = Pin::P0_07;
+
+const _UART_TX_PIN: Pin = Pin::P0_06;
+const _UART_RX_PIN: Pin = Pin::P0_08;
+
+/// I2C pins for all of the sensors.
+const I2C_SDA_PIN: Pin = Pin::P0_26;
+const I2C_SCL_PIN: Pin = Pin::P0_27;
+
+// Constants related to the configuration of the 15.4 network stack
+/// Personal Area Network ID for the IEEE 802.15.4 radio
+const PAN_ID: u16 = 0xABCD;
+/// Gateway (or next hop) MAC Address
+const DST_MAC_ADDR: capsules_extra::net::ieee802154::MacAddress =
+    capsules_extra::net::ieee802154::MacAddress::Short(49138);
+const DEFAULT_CTX_PREFIX_LEN: u8 = 8; //Length of context for 6LoWPAN compression
+const DEFAULT_CTX_PREFIX: [u8; 16] = [0x0_u8; 16]; //Context for 6LoWPAN Compression
+
+/// UART Writer for panic!()s.
+pub mod io;
+
+// How should the kernel respond when a process faults. For this board we choose
+// to stop the app and print a notice, but not immediately panic. This allows
+// users to debug their apps, but avoids issues with using the USB/CDC stack
+// synchronously for panic! too early after the board boots.
+const FAULT_RESPONSE: kernel::process::StopWithDebugFaultPolicy =
+    kernel::process::StopWithDebugFaultPolicy {};
+
+// Number of concurrent processes this platform supports.
+const NUM_PROCS: usize = 8;
+
+// State for loading and holding applications.
+static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS] =
+    [None; NUM_PROCS];
+
+static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;
+static mut PROCESS_PRINTER: Option<&'static kernel::process::ProcessPrinterText> = None;
+static mut CDC_REF_FOR_PANIC: Option<
+    &'static capsules_extra::usb::cdc::CdcAcm<
+        'static,
+        nrf52::usbd::Usbd,
+        capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, nrf52::rtc::Rtc>,
+    >,
+> = None;
+static mut NRF52_POWER: Option<&'static nrf52840::power::Power> = None;
+
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
+
+// Function for the CDC/USB stack to use to enter the bootloader.
+fn baud_rate_reset_bootloader_enter() {
+    unsafe {
+        // 0x90 is the magic value the bootloader expects
+        NRF52_POWER.unwrap().set_gpregret(0x90);
+        cortexm4::scb::reset();
+    }
+}
+
+fn crc(s: &'static str) -> u32 {
+    kernel::utilities::helpers::crc32_posix(s.as_bytes())
+}
+
+//------------------------------------------------------------------------------
+// SYSCALL DRIVER TYPE DEFINITIONS
+//------------------------------------------------------------------------------
+
+type AlarmDriver = components::alarm::AlarmDriverComponentType<nrf52840::rtc::Rtc<'static>>;
+
+type Screen = components::ssd1306::Ssd1306ComponentType<nrf52840::i2c::TWI<'static>>;
+type ScreenDriver = components::screen::ScreenSharedComponentType<Screen>;
+
+type Checker = kernel::process_checker::basic::AppCheckerNames<'static, fn(&'static str) -> u32>;
+
+/// Supported drivers by the platform
+pub struct Platform {
+    ble_radio: &'static capsules_extra::ble_advertising_driver::BLE<
+        'static,
+        nrf52::ble_radio::Radio<'static>,
+        capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<
+            'static,
+            nrf52::rtc::Rtc<'static>,
+        >,
+    >,
+    ieee802154_radio: &'static capsules_extra::ieee802154::RadioDriver<'static>,
+    console: &'static capsules_core::console::Console<'static>,
+    pconsole: &'static capsules_core::process_console::ProcessConsole<
+        'static,
+        { capsules_core::process_console::DEFAULT_COMMAND_HISTORY_LEN },
+        capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<
+            'static,
+            nrf52::rtc::Rtc<'static>,
+        >,
+        components::process_console::Capability,
+    >,
+    gpio: &'static capsules_core::gpio::GPIO<'static, nrf52::gpio::GPIOPin<'static>>,
+    led: &'static capsules_core::led::LedDriver<
+        'static,
+        LedLow<'static, nrf52::gpio::GPIOPin<'static>>,
+        1,
+    >,
+    adc: &'static capsules_core::adc::AdcVirtualized<'static>,
+    rng: &'static capsules_core::rng::RngDriver<'static>,
+    ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
+    alarm: &'static AlarmDriver,
+    button: &'static capsules_core::button::Button<'static, nrf52840::gpio::GPIOPin<'static>>,
+    screen: &'static ScreenDriver,
+    udp_driver: &'static capsules_extra::net::udp::UDPDriver<'static>,
+    scheduler: &'static RoundRobinSched<'static>,
+    checker: &'static Checker,
+    systick: cortexm4::systick::SysTick,
+}
+
+impl SyscallDriverLookup for Platform {
+    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    where
+        F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
+    {
+        match driver_num {
+            capsules_core::console::DRIVER_NUM => f(Some(self.console)),
+            capsules_core::gpio::DRIVER_NUM => f(Some(self.gpio)),
+            capsules_core::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules_core::led::DRIVER_NUM => f(Some(self.led)),
+            capsules_core::button::DRIVER_NUM => f(Some(self.button)),
+            capsules_core::adc::DRIVER_NUM => f(Some(self.adc)),
+            capsules_core::rng::DRIVER_NUM => f(Some(self.rng)),
+            capsules_extra::screen::DRIVER_NUM => f(Some(self.screen)),
+            capsules_extra::ble_advertising_driver::DRIVER_NUM => f(Some(self.ble_radio)),
+            capsules_extra::ieee802154::DRIVER_NUM => f(Some(self.ieee802154_radio)),
+            capsules_extra::net::udp::DRIVER_NUM => f(Some(self.udp_driver)),
+            kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
+            _ => f(None),
+        }
+    }
+}
+
+impl KernelResources<nrf52::chip::NRF52<'static, Nrf52840DefaultPeripherals<'static>>>
+    for Platform
+{
+    type SyscallDriverLookup = Self;
+    type SyscallFilter = ();
+    type ProcessFault = ();
+    type CredentialsCheckingPolicy = Checker;
+    type Scheduler = RoundRobinSched<'static>;
+    type SchedulerTimer = cortexm4::systick::SysTick;
+    type WatchDog = ();
+    type ContextSwitchCallback = ();
+
+    fn syscall_driver_lookup(&self) -> &Self::SyscallDriverLookup {
+        self
+    }
+    fn syscall_filter(&self) -> &Self::SyscallFilter {
+        &()
+    }
+    fn process_fault(&self) -> &Self::ProcessFault {
+        &()
+    }
+    fn credentials_checking_policy(&self) -> &'static Self::CredentialsCheckingPolicy {
+        self.checker
+    }
+    fn scheduler(&self) -> &Self::Scheduler {
+        self.scheduler
+    }
+    fn scheduler_timer(&self) -> &Self::SchedulerTimer {
+        &self.systick
+    }
+    fn watchdog(&self) -> &Self::WatchDog {
+        &()
+    }
+    fn context_switch_callback(&self) -> &Self::ContextSwitchCallback {
+        &()
+    }
+}
+
+/// This is in a separate, inline(never) function so that its stack frame is
+/// removed when this function returns. Otherwise, the stack space used for
+/// these static_inits is wasted.
+#[inline(never)]
+pub unsafe fn start() -> (
+    &'static kernel::Kernel,
+    Platform,
+    &'static nrf52840::chip::NRF52<'static, Nrf52840DefaultPeripherals<'static>>,
+) {
+    nrf52840::init();
+
+    let ieee802154_ack_buf = static_init!(
+        [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
+        [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
+    );
+
+    // Initialize chip peripheral drivers
+    let nrf52840_peripherals = static_init!(
+        Nrf52840DefaultPeripherals,
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf)
+    );
+
+    // set up circular peripheral dependencies
+    nrf52840_peripherals.init();
+    let base_peripherals = &nrf52840_peripherals.nrf52;
+
+    // Save a reference to the power module for resetting the board into the
+    // bootloader.
+    NRF52_POWER = Some(&base_peripherals.pwr_clk);
+
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+
+    // Do nRF configuration and setup. This is shared code with other nRF-based
+    // platforms.
+    nrf52_components::startup::NrfStartupComponent::new(
+        false,
+        BUTTON_RST_PIN,
+        nrf52840::uicr::Regulator0Output::DEFAULT,
+        &base_peripherals.nvmc,
+    )
+    .finalize(());
+
+    //--------------------------------------------------------------------------
+    // CAPABILITIES
+    //--------------------------------------------------------------------------
+
+    // Create capabilities that the board needs to call certain protected kernel
+    // functions.
+    let process_management_capability =
+        create_capability!(capabilities::ProcessManagementCapability);
+    let memory_allocation_capability = create_capability!(capabilities::MemoryAllocationCapability);
+
+    //--------------------------------------------------------------------------
+    // DEBUG GPIO
+    //--------------------------------------------------------------------------
+
+    // Configure kernel debug GPIOs as early as possible. These are used by the
+    // `debug_gpio!(0, toggle)` macro. We configure these early so that the
+    // macro is available during most of the setup code and kernel execution.
+    kernel::debug::assign_gpios(Some(&nrf52840_peripherals.gpio_port[LED_PIN]), None, None);
+
+    //--------------------------------------------------------------------------
+    // GPIO
+    //--------------------------------------------------------------------------
+
+    let gpio = components::gpio::GpioComponent::new(
+        board_kernel,
+        capsules_core::gpio::DRIVER_NUM,
+        components::gpio_component_helper!(
+            nrf52840::gpio::GPIOPin,
+            0 => &nrf52840_peripherals.gpio_port[GPIO_D0],
+            1 => &nrf52840_peripherals.gpio_port[GPIO_D1],
+            2 => &nrf52840_peripherals.gpio_port[GPIO_D2],
+            3 => &nrf52840_peripherals.gpio_port[GPIO_D3],
+        ),
+    )
+    .finalize(components::gpio_component_static!(nrf52840::gpio::GPIOPin));
+
+    //--------------------------------------------------------------------------
+    // LEDs
+    //--------------------------------------------------------------------------
+
+    let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
+        LedLow<'static, nrf52840::gpio::GPIOPin>,
+        LedLow::new(&nrf52840_peripherals.gpio_port[LED_PIN]),
+    ));
+
+    //--------------------------------------------------------------------------
+    // BUTTONS
+    //--------------------------------------------------------------------------
+
+    let button = components::button::ButtonComponent::new(
+        board_kernel,
+        capsules_core::button::DRIVER_NUM,
+        components::button_component_helper!(
+            nrf52840::gpio::GPIOPin,
+            (
+                &nrf52840_peripherals.gpio_port[BUTTON_PIN],
+                kernel::hil::gpio::ActivationMode::ActiveLow,
+                kernel::hil::gpio::FloatingState::PullUp
+            )
+        ),
+    )
+    .finalize(components::button_component_static!(
+        nrf52840::gpio::GPIOPin
+    ));
+
+    //--------------------------------------------------------------------------
+    // ALARM & TIMER
+    //--------------------------------------------------------------------------
+
+    let rtc = &base_peripherals.rtc;
+    let _ = rtc.start();
+
+    let mux_alarm = components::alarm::AlarmMuxComponent::new(rtc)
+        .finalize(components::alarm_mux_component_static!(nrf52::rtc::Rtc));
+    let alarm = components::alarm::AlarmDriverComponent::new(
+        board_kernel,
+        capsules_core::alarm::DRIVER_NUM,
+        mux_alarm,
+    )
+    .finalize(components::alarm_component_static!(nrf52::rtc::Rtc));
+
+    //--------------------------------------------------------------------------
+    // UART & CONSOLE & DEBUG
+    //--------------------------------------------------------------------------
+
+    // Setup the CDC-ACM over USB driver that we will use for UART.
+    // We use the Arduino Vendor ID and Product ID since the device is the same.
+
+    // Create the strings we include in the USB descriptor. We use the hardcoded
+    // DEVICEADDR register on the nRF52 to set the serial number.
+    let serial_number_buf = static_init!([u8; 17], [0; 17]);
+    let serial_number_string: &'static str =
+        nrf52::ficr::FICR_INSTANCE.address_str(serial_number_buf);
+    let strings = static_init!(
+        [&str; 3],
+        [
+            "MakePython",         // Manufacturer
+            "NRF52840 - TockOS",  // Product
+            serial_number_string, // Serial number
+        ]
+    );
+
+    let cdc = components::cdc::CdcAcmComponent::new(
+        &nrf52840_peripherals.usbd,
+        capsules_extra::usb::cdc::MAX_CTRL_PACKET_SIZE_NRF52840,
+        0x2341,
+        0x005a,
+        strings,
+        mux_alarm,
+        Some(&baud_rate_reset_bootloader_enter),
+    )
+    .finalize(components::cdc_acm_component_static!(
+        nrf52::usbd::Usbd,
+        nrf52::rtc::Rtc
+    ));
+    CDC_REF_FOR_PANIC = Some(cdc); //for use by panic handler
+
+    // Process Printer for displaying process information.
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
+    PROCESS_PRINTER = Some(process_printer);
+
+    // Create a shared UART channel for the console and for kernel debug.
+    let uart_mux = components::console::UartMuxComponent::new(cdc, 115200)
+        .finalize(components::uart_mux_component_static!());
+
+    let pconsole = components::process_console::ProcessConsoleComponent::new(
+        board_kernel,
+        uart_mux,
+        mux_alarm,
+        process_printer,
+        Some(cortexm4::support::reset),
+    )
+    .finalize(components::process_console_component_static!(
+        nrf52::rtc::Rtc<'static>
+    ));
+
+    // Setup the console.
+    let console = components::console::ConsoleComponent::new(
+        board_kernel,
+        capsules_core::console::DRIVER_NUM,
+        uart_mux,
+    )
+    .finalize(components::console_component_static!());
+    // Create the debugger object that handles calls to `debug!()`.
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
+
+    //--------------------------------------------------------------------------
+    // RANDOM NUMBERS
+    //--------------------------------------------------------------------------
+
+    let rng = components::rng::RngComponent::new(
+        board_kernel,
+        capsules_core::rng::DRIVER_NUM,
+        &base_peripherals.trng,
+    )
+    .finalize(components::rng_component_static!());
+
+    //--------------------------------------------------------------------------
+    // ADC
+    //--------------------------------------------------------------------------
+    base_peripherals.adc.calibrate();
+
+    let adc_mux = components::adc::AdcMuxComponent::new(&base_peripherals.adc)
+        .finalize(components::adc_mux_component_static!(nrf52840::adc::Adc));
+
+    let adc_syscall =
+        components::adc::AdcVirtualComponent::new(board_kernel, capsules_core::adc::DRIVER_NUM)
+            .finalize(components::adc_syscall_component_helper!(
+                // A0
+                components::adc::AdcComponent::new(
+                    adc_mux,
+                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput2)
+                )
+                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+                // A1
+                components::adc::AdcComponent::new(
+                    adc_mux,
+                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput3)
+                )
+                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+                // A2
+                components::adc::AdcComponent::new(
+                    adc_mux,
+                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput6)
+                )
+                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+                // A3
+                components::adc::AdcComponent::new(
+                    adc_mux,
+                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput5)
+                )
+                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+                // A4
+                components::adc::AdcComponent::new(
+                    adc_mux,
+                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput7)
+                )
+                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+                // A5
+                components::adc::AdcComponent::new(
+                    adc_mux,
+                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput0)
+                )
+                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+                // A6
+                components::adc::AdcComponent::new(
+                    adc_mux,
+                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput4)
+                )
+                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+                // A7
+                components::adc::AdcComponent::new(
+                    adc_mux,
+                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput1)
+                )
+                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+            ));
+
+    //--------------------------------------------------------------------------
+    // SCREEN
+    //--------------------------------------------------------------------------
+
+    let i2c_bus = components::i2c::I2CMuxComponent::new(&base_peripherals.twi0, None)
+        .finalize(components::i2c_mux_component_static!(nrf52840::i2c::TWI));
+    base_peripherals.twi0.configure(
+        nrf52840::pinmux::Pinmux::new(I2C_SCL_PIN as u32),
+        nrf52840::pinmux::Pinmux::new(I2C_SDA_PIN as u32),
+    );
+
+    // I2C address is b011110X, and on this board D/C̅ is GND.
+    let ssd1306_i2c = components::i2c::I2CComponent::new(i2c_bus, 0x3c)
+        .finalize(components::i2c_component_static!(nrf52840::i2c::TWI));
+
+    // Create the ssd1306 object for the actual screen driver.
+    let ssd1306 = components::ssd1306::Ssd1306Component::new(ssd1306_i2c, true)
+        .finalize(components::ssd1306_component_static!(nrf52840::i2c::TWI));
+
+    // Create a Driver for userspace access to the screen.
+    // let screen = components::screen::ScreenComponent::new(
+    //     board_kernel,
+    //     capsules_extra::screen::DRIVER_NUM,
+    //     ssd1306,
+    //     Some(ssd1306),
+    // )
+    // .finalize(components::screen_component_static!(1032));
+
+    let apps_regions = static_init!(
+        [capsules_extra::screen_shared::AppScreenRegion; 3],
+        [
+            capsules_extra::screen_shared::AppScreenRegion::new(
+                kernel::process::ShortID::Fixed(core::num::NonZeroU32::new(crc("circle")).unwrap()),
+                0,     // x
+                0,     // y
+                8 * 8, // width
+                8 * 8  // height
+            ),
+            capsules_extra::screen_shared::AppScreenRegion::new(
+                kernel::process::ShortID::Fixed(core::num::NonZeroU32::new(crc("count")).unwrap()),
+                8 * 8, // x
+                0,     // y
+                8 * 8, // width
+                4 * 8  // height
+            ),
+            capsules_extra::screen_shared::AppScreenRegion::new(
+                kernel::process::ShortID::Fixed(
+                    core::num::NonZeroU32::new(crc("tock-scroll")).unwrap()
+                ),
+                8 * 8, // x
+                4 * 8, // y
+                8 * 8, // width
+                4 * 8  // height
+            )
+        ]
+    );
+
+    let screen = components::screen::ScreenSharedComponent::new(
+        board_kernel,
+        capsules_extra::screen::DRIVER_NUM,
+        ssd1306,
+        apps_regions,
+    )
+    .finalize(components::screen_shared_component_static!(1032, Screen));
+
+    //--------------------------------------------------------------------------
+    // WIRELESS
+    //--------------------------------------------------------------------------
+
+    let ble_radio = components::ble::BLEComponent::new(
+        board_kernel,
+        capsules_extra::ble_advertising_driver::DRIVER_NUM,
+        &base_peripherals.ble_radio,
+        mux_alarm,
+    )
+    .finalize(components::ble_component_static!(
+        nrf52840::rtc::Rtc,
+        nrf52840::ble_radio::Radio
+    ));
+
+    use capsules_extra::net::ieee802154::MacAddress;
+
+    let aes_mux = components::ieee802154::MuxAes128ccmComponent::new(&base_peripherals.ecb)
+        .finalize(components::mux_aes128ccm_component_static!(
+            nrf52840::aes::AesECB
+        ));
+
+    let device_id = nrf52840::ficr::FICR_INSTANCE.id();
+    let device_id_bottom_16 = u16::from_le_bytes([device_id[0], device_id[1]]);
+    let (ieee802154_radio, mux_mac) = components::ieee802154::Ieee802154Component::new(
+        board_kernel,
+        capsules_extra::ieee802154::DRIVER_NUM,
+        &nrf52840_peripherals.ieee802154_radio,
+        aes_mux,
+        PAN_ID,
+        device_id_bottom_16,
+        device_id,
+    )
+    .finalize(components::ieee802154_component_static!(
+        nrf52840::ieee802154_radio::Radio,
+        nrf52840::aes::AesECB<'static>
+    ));
+    use capsules_extra::net::ipv6::ip_utils::IPAddr;
+
+    let local_ip_ifaces = static_init!(
+        [IPAddr; 3],
+        [
+            IPAddr([
+                0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
+                0x0e, 0x0f,
+            ]),
+            IPAddr([
+                0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d,
+                0x1e, 0x1f,
+            ]),
+            IPAddr::generate_from_mac(capsules_extra::net::ieee802154::MacAddress::Short(
+                device_id_bottom_16
+            )),
+        ]
+    );
+
+    let (udp_send_mux, udp_recv_mux, udp_port_table) = components::udp_mux::UDPMuxComponent::new(
+        mux_mac,
+        DEFAULT_CTX_PREFIX_LEN,
+        DEFAULT_CTX_PREFIX,
+        DST_MAC_ADDR,
+        MacAddress::Short(device_id_bottom_16),
+        local_ip_ifaces,
+        mux_alarm,
+    )
+    .finalize(components::udp_mux_component_static!(nrf52840::rtc::Rtc));
+
+    // UDP driver initialization happens here
+    let udp_driver = components::udp_driver::UDPDriverComponent::new(
+        board_kernel,
+        capsules_extra::net::udp::DRIVER_NUM,
+        udp_send_mux,
+        udp_recv_mux,
+        udp_port_table,
+        local_ip_ifaces,
+    )
+    .finalize(components::udp_driver_component_static!(nrf52840::rtc::Rtc));
+
+    //--------------------------------------------------------------------------
+    // APP ID CHECKING
+    //--------------------------------------------------------------------------
+
+    let checker = static_init!(
+        kernel::process_checker::basic::AppCheckerNames<fn(&'static str) -> u32>,
+        kernel::process_checker::basic::AppCheckerNames::new(&(crc as fn(&'static str) -> u32))
+    );
+    kernel::deferred_call::DeferredCallClient::register(checker);
+
+    //--------------------------------------------------------------------------
+    // FINAL SETUP AND BOARD BOOT
+    //--------------------------------------------------------------------------
+
+    // Start all of the clocks. Low power operation will require a better
+    // approach than this.
+    nrf52_components::NrfClockComponent::new(&base_peripherals.clock).finalize(());
+
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+        .finalize(components::round_robin_component_static!(NUM_PROCS));
+
+    let platform = Platform {
+        ble_radio,
+        ieee802154_radio,
+        console,
+        pconsole,
+        adc: adc_syscall,
+        led,
+        button,
+        gpio,
+        rng,
+        screen,
+        alarm,
+        udp_driver,
+        ipc: kernel::ipc::IPC::new(
+            board_kernel,
+            kernel::ipc::DRIVER_NUM,
+            &memory_allocation_capability,
+        ),
+        scheduler,
+        checker,
+        systick: cortexm4::systick::SysTick::new_with_calibration(64000000),
+    };
+
+    let chip = static_init!(
+        nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
+        nrf52840::chip::NRF52::new(nrf52840_peripherals)
+    );
+    CHIP = Some(chip);
+
+    // Configure the USB stack to enable a serial port over CDC-ACM.
+    cdc.enable();
+    cdc.attach();
+
+    //--------------------------------------------------------------------------
+    // TESTS
+    //--------------------------------------------------------------------------
+    // test::linear_log_test::run(
+    //     mux_alarm,
+    //     &nrf52840_peripherals.nrf52.nvmc,
+    // );
+    // test::log_test::run(
+    //     mux_alarm,
+    //     &nrf52840_peripherals.nrf52.nvmc,
+    // );
+
+    debug!("Initialization complete. Entering main loop.");
+    let _ = platform.pconsole.start();
+
+    ssd1306.init_screen();
+
+    //--------------------------------------------------------------------------
+    // PROCESSES AND MAIN LOOP
+    //--------------------------------------------------------------------------
+
+    // These symbols are defined in the linker script.
+    extern "C" {
+        /// Beginning of the ROM region containing app images.
+        static _sapps: u8;
+        /// End of the ROM region containing app images.
+        static _eapps: u8;
+        /// Beginning of the RAM region for app memory.
+        static mut _sappmem: u8;
+        /// End of the RAM region for app memory.
+        static _eappmem: u8;
+    }
+
+    kernel::process::load_and_check_processes(
+        board_kernel,
+        &platform,
+        chip,
+        core::slice::from_raw_parts(
+            &_sapps as *const u8,
+            &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
+        ),
+        core::slice::from_raw_parts_mut(
+            &mut _sappmem as *mut u8,
+            &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
+        ),
+        &mut PROCESSES,
+        &FAULT_RESPONSE,
+        &process_management_capability,
+    )
+    .unwrap_or_else(|err| {
+        debug!("Error loading processes!");
+        debug!("{:?}", err);
+    });
+
+    (board_kernel, platform, chip)
+}
+
+/// Main function called after RAM initialized.
+#[no_mangle]
+pub unsafe fn main() {
+    let main_loop_capability = create_capability!(capabilities::MainLoopCapability);
+
+    let (board_kernel, platform, chip) = start();
+    board_kernel.kernel_loop(&platform, chip, Some(&platform.ipc), &main_loop_capability);
+}

--- a/capsules/extra/src/lib.rs
+++ b/capsules/extra/src/lib.rs
@@ -85,6 +85,7 @@ pub mod sht4x;
 pub mod si7021;
 pub mod sip_hash;
 pub mod sound_pressure;
+pub mod ssd1306;
 pub mod st77xx;
 pub mod symmetric_encryption;
 pub mod temperature;

--- a/capsules/extra/src/lib.rs
+++ b/capsules/extra/src/lib.rs
@@ -75,6 +75,7 @@ pub mod read_only_state;
 pub mod rf233;
 pub mod rf233_const;
 pub mod screen;
+pub mod screen_shared;
 pub mod sdcard;
 pub mod segger_rtt;
 pub mod seven_segment;

--- a/capsules/extra/src/screen_shared.rs
+++ b/capsules/extra/src/screen_shared.rs
@@ -1,0 +1,459 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2024.
+
+//! Shares a screen among multiple userspace processes.
+//!
+//! The screen can be split into multiple regions, and regions are assigned to
+//! processes by AppID.
+//!
+//! Boards should create an array of `AppScreenRegion` objects that assign apps
+//! to specific regions (frames) within the screen.
+//!
+//! ```
+//! AppScreenRegion {
+//!     app_id: kernel::process:ShortID::new(id),
+//!     frame: Frame {
+//!         x: 0,
+//!         y: 0,
+//!         width: 8,
+//!         height: 16,
+//!     }
+//! }
+//! ```
+//!
+//! This driver uses a subset of the API from `Screen`. It does not support any
+//! screen config settings (brightness, invert) as those operations affect the
+//! entire screen.
+
+use core::convert::From;
+
+use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
+use kernel::hil;
+use kernel::processbuffer::ReadableProcessBuffer;
+use kernel::syscall::{CommandReturn, SyscallDriver};
+use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::utilities::leasable_buffer::SubSliceMut;
+use kernel::{ErrorCode, ProcessId};
+
+/// Syscall driver number.
+use capsules_core::driver;
+pub const DRIVER_NUM: usize = driver::NUM::Screen as usize;
+
+/// Ids for read-only allow buffers
+mod ro_allow {
+    pub const SHARED: usize = 0;
+    /// The number of allow buffers the kernel stores for this grant
+    pub const COUNT: u8 = 1;
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum ScreenCommand {
+    WriteSetFrame,
+    WriteBuffer,
+}
+
+fn pixels_in_bytes(pixels: usize, bits_per_pixel: usize) -> usize {
+    let bytes = pixels * bits_per_pixel / 8;
+    if pixels * bits_per_pixel % 8 != 0 {
+        bytes + 1
+    } else {
+        bytes
+    }
+}
+
+/// Rectangular region of a screen.
+#[derive(Default, Clone, Copy, PartialEq)]
+pub struct Frame {
+    /// X coordinate of the upper left corner of the frame.
+    x: usize,
+    /// Y coordinate of the upper left corner of the frame.
+    y: usize,
+    /// Width of the frame.
+    width: usize,
+    /// Height of the frame.
+    height: usize,
+}
+
+pub struct AppScreenRegion {
+    app_id: kernel::process::ShortID,
+    frame: Frame,
+}
+
+impl AppScreenRegion {
+    pub fn new(
+        app_id: kernel::process::ShortID,
+        x: usize,
+        y: usize,
+        width: usize,
+        height: usize,
+    ) -> Self {
+        Self {
+            app_id,
+            frame: Frame {
+                x,
+                y,
+                width,
+                height,
+            },
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct App {
+    /// The app has requested some screen operation, or `None()` if idle.
+    command: Option<ScreenCommand>,
+    /// The current frame the app is using.
+    frame: Frame,
+}
+
+/// A userspace driver that allows multiple apps to use the same screen.
+///
+/// Each app is given a pre-set rectangular region of the screen to use.
+pub struct ScreenShared<'a, S: hil::screen::Screen<'a>> {
+    /// Underlying screen driver to use.
+    screen: &'a S,
+
+    /// Grant region for apps using the screen.
+    apps: Grant<App, UpcallCount<1>, AllowRoCount<{ ro_allow::COUNT }>, AllowRwCount<0>>,
+
+    /// Static allocations of screen regions for each app.
+    apps_regions: &'a [AppScreenRegion],
+
+    /// The process currently executing a command on the screen.
+    current_process: OptionalCell<ProcessId>,
+
+    /// Internal buffer for write commands.
+    buffer: TakeCell<'static, [u8]>,
+}
+
+impl<'a, S: hil::screen::Screen<'a>> ScreenShared<'a, S> {
+    pub fn new(
+        screen: &'a S,
+        grant: Grant<App, UpcallCount<1>, AllowRoCount<{ ro_allow::COUNT }>, AllowRwCount<0>>,
+        buffer: &'static mut [u8],
+        apps_regions: &'a [AppScreenRegion],
+    ) -> ScreenShared<'a, S> {
+        ScreenShared {
+            screen: screen,
+            apps: grant,
+            current_process: OptionalCell::empty(),
+            buffer: TakeCell::new(buffer),
+            apps_regions,
+        }
+    }
+
+    // Enqueue a command for the given app.
+    fn enqueue_command(&self, command: ScreenCommand, process_id: ProcessId) -> CommandReturn {
+        let ret = self
+            .apps
+            .enter(process_id, |app, _| {
+                if app.command.is_some() {
+                    Err(ErrorCode::BUSY)
+                } else {
+                    app.command = Some(command);
+                    Ok(())
+                }
+            })
+            .map_err(ErrorCode::from)
+            .and_then(|r| r)
+            .into();
+
+        if self.current_process.is_none() {
+            self.run_next_command();
+        }
+
+        ret
+    }
+
+    /// Calculate the frame within the entire screen that the app is currently
+    /// trying to use. This is the `app_frame` within the app's allocated
+    /// `app_screen_region`.
+    fn calculate_absolute_frame(&self, app_screen_region_frame: Frame, app_frame: Frame) -> Frame {
+        // x and y are sums
+        let mut absolute_x = app_screen_region_frame.x + app_frame.x;
+        let mut absolute_y = app_screen_region_frame.y + app_frame.y;
+        // width and height are simply the app_frame width and height.
+        let mut absolute_w = app_frame.width;
+        let mut absolute_h = app_frame.height;
+
+        // Make sure that the calculate frame is within the allocated region.
+        absolute_x = core::cmp::min(
+            app_screen_region_frame.x + app_screen_region_frame.width,
+            absolute_x,
+        );
+        absolute_y = core::cmp::min(
+            app_screen_region_frame.y + app_screen_region_frame.height,
+            absolute_y,
+        );
+        absolute_w = core::cmp::min(
+            app_screen_region_frame.x + app_screen_region_frame.width - absolute_x,
+            absolute_w,
+        );
+        absolute_h = core::cmp::min(
+            app_screen_region_frame.y + app_screen_region_frame.height - absolute_y,
+            absolute_h,
+        );
+
+        Frame {
+            x: absolute_x,
+            y: absolute_y,
+            width: absolute_w,
+            height: absolute_h,
+        }
+    }
+
+    fn call_screen(
+        &self,
+        process_id: ProcessId,
+        app_screen_region_frame: Frame,
+    ) -> Result<(), ErrorCode> {
+        self.apps
+            .enter(process_id, |app, kernel_data| {
+                match app.command {
+                    Some(ScreenCommand::WriteSetFrame) => {
+                        let absolute_frame =
+                            self.calculate_absolute_frame(app_screen_region_frame, app.frame);
+
+                        app.command = Some(ScreenCommand::WriteBuffer);
+                        self.screen
+                            .set_write_frame(
+                                absolute_frame.x,
+                                absolute_frame.y,
+                                absolute_frame.width,
+                                absolute_frame.height,
+                            )
+                            .map_err(|e| {
+                                app.command = None;
+                                e
+                            })
+                    }
+                    Some(ScreenCommand::WriteBuffer) => {
+                        app.command = None;
+                        kernel_data
+                            .get_readonly_processbuffer(ro_allow::SHARED)
+                            .map(|allow_buf| {
+                                let len = allow_buf.len();
+
+                                if len == 0 {
+                                    Err(ErrorCode::NOMEM)
+                                } else if !self.is_len_multiple_color_depth(len) {
+                                    Err(ErrorCode::INVAL)
+                                } else {
+                                    // All good, copy buffer.
+
+                                    self.buffer.take().map_or(Err(ErrorCode::FAIL), |buffer| {
+                                        let copy_len =
+                                            core::cmp::min(buffer.len(), allow_buf.len());
+                                        allow_buf.enter(|ab| {
+                                            // buffer[..copy_len].copy_from_slice(ab[..copy_len]);
+                                            ab[..copy_len].copy_to_slice(&mut buffer[..copy_len])
+                                        })?;
+
+                                        // Send to screen.
+                                        let mut data = SubSliceMut::new(buffer);
+                                        data.slice(..copy_len);
+                                        self.screen.write(data, false)
+                                    })
+                                }
+                            })
+                            .map_err(ErrorCode::from)
+                            .and_then(|r| r)
+                    }
+                    _ => Err(ErrorCode::NOSUPPORT),
+                }
+            })
+            .map_err(ErrorCode::from)
+            .and_then(|r| r)
+    }
+
+    fn schedule_callback(&self, process_id: ProcessId, data1: usize, data2: usize, data3: usize) {
+        let _ = self.apps.enter(process_id, |_app, kernel_data| {
+            kernel_data.schedule_upcall(0, (data1, data2, data3)).ok();
+        });
+    }
+
+    fn get_app_screen_region_frame(&self, process_id: ProcessId) -> Option<Frame> {
+        let short_id = process_id.short_app_id();
+
+        for app_screen_region in self.apps_regions {
+            if short_id == app_screen_region.app_id {
+                return Some(app_screen_region.frame);
+            }
+        }
+        None
+    }
+
+    fn run_next_command(&self) {
+        let ran_cmd = self.current_process.map_or(false, |process_id| {
+            let app_region_frame = self.get_app_screen_region_frame(process_id);
+
+            app_region_frame.map_or(false, |frame| {
+                let r = self.call_screen(process_id, frame);
+                if r.is_err() {
+                    // We were unable to run the screen operation meaning we
+                    // will not get a callback and we need to report the error.
+                    self.current_process.take().map(|process_id| {
+                        self.schedule_callback(
+                            process_id,
+                            kernel::errorcode::into_statuscode(r),
+                            0,
+                            0,
+                        );
+                    });
+                    false
+                } else {
+                    true
+                }
+            })
+        });
+
+        if !ran_cmd {
+            // Check if there are any pending events.
+            for app in self.apps.iter() {
+                let process_id = app.processid();
+
+                // Check if this process has both a pending command and is
+                // allocated a region on the screen.
+                let frame_maybe = app.enter(|app, _| {
+                    if app.command.is_some() {
+                        self.get_app_screen_region_frame(process_id)
+                    } else {
+                        None
+                    }
+                });
+
+                // If we have a candidate, try to execute the screen operation.
+                if frame_maybe.is_some() {
+                    match frame_maybe {
+                        Some(frame) => {
+                            // Reserve the screen for this process and execute
+                            // the operation.
+                            self.current_process.set(process_id);
+                            match self.call_screen(process_id, frame) {
+                                Ok(()) => {
+                                    // Everything is good, stop looking for apps
+                                    // to execute.
+                                    break;
+                                }
+                                Err(err) => {
+                                    // Could not run the screen command.
+                                    // Un-reserve the screen and do an upcall
+                                    // with the bad news.
+                                    self.current_process.clear();
+                                    self.schedule_callback(
+                                        process_id,
+                                        kernel::errorcode::into_statuscode(Err(err)),
+                                        0,
+                                        0,
+                                    );
+                                }
+                            }
+                        }
+                        None => {}
+                    }
+                }
+            }
+        }
+    }
+
+    fn is_len_multiple_color_depth(&self, len: usize) -> bool {
+        let depth = pixels_in_bytes(1, self.screen.get_pixel_format().get_bits_per_pixel());
+        (len % depth) == 0
+    }
+}
+
+impl<'a, S: hil::screen::Screen<'a>> hil::screen::ScreenClient for ScreenShared<'a, S> {
+    fn command_complete(&self, r: Result<(), ErrorCode>) {
+        if r.is_err() {
+            self.current_process.take().map(|process_id| {
+                self.schedule_callback(process_id, kernel::errorcode::into_statuscode(r), 0, 0);
+            });
+        }
+
+        self.run_next_command();
+    }
+
+    fn write_complete(&self, data: SubSliceMut<'static, u8>, r: Result<(), ErrorCode>) {
+        self.buffer.replace(data.take());
+
+        // Notify that the write is finished.
+        self.current_process.take().map(|process_id| {
+            self.schedule_callback(process_id, kernel::errorcode::into_statuscode(r), 0, 0);
+        });
+
+        self.run_next_command();
+    }
+
+    fn screen_is_ready(&self) {
+        self.run_next_command();
+    }
+}
+
+impl<'a, S: hil::screen::Screen<'a>> SyscallDriver for ScreenShared<'a, S> {
+    fn command(
+        &self,
+        command_num: usize,
+        data1: usize,
+        data2: usize,
+        process_id: ProcessId,
+    ) -> CommandReturn {
+        match command_num {
+            // Driver existence check
+            0 => CommandReturn::success(),
+
+            // Get Rotation
+            21 => CommandReturn::success_u32(self.screen.get_rotation() as u32),
+
+            // Get Resolution
+            23 => match self.get_app_screen_region_frame(process_id) {
+                Some(frame) => {
+                    CommandReturn::success_u32_u32(frame.width as u32, frame.height as u32)
+                }
+                None => CommandReturn::failure(ErrorCode::NOSUPPORT),
+            },
+
+            // Get pixel format
+            25 => CommandReturn::success_u32(self.screen.get_pixel_format() as u32),
+
+            // Set Write Frame
+            100 => {
+                let frame = Frame {
+                    x: (data1 >> 16) & 0xFFFF,
+                    y: data1 & 0xFFFF,
+                    width: (data2 >> 16) & 0xFFFF,
+                    height: data2 & 0xFFFF,
+                };
+
+                self.apps
+                    .enter(process_id, |app, kernel_data| {
+                        app.frame = frame;
+
+                        // Just issue upcall.
+                        let _ = kernel_data
+                            .schedule_upcall(0, (kernel::errorcode::into_statuscode(Ok(())), 0, 0));
+                    })
+                    .map_err(ErrorCode::from)
+                    .into()
+            }
+
+            // Write
+            200 => {
+                // First check if this app has any screen real estate allocated.
+                // If not, return error.
+                if self.get_app_screen_region_frame(process_id).is_none() {
+                    CommandReturn::failure(ErrorCode::NOSUPPORT)
+                } else {
+                    self.enqueue_command(ScreenCommand::WriteSetFrame, process_id)
+                }
+            }
+
+            _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
+        }
+    }
+
+    fn allocate_grant(&self, processid: ProcessId) -> Result<(), kernel::process::Error> {
+        self.apps.enter(processid, |_, _| {})
+    }
+}

--- a/capsules/extra/src/ssd1306.rs
+++ b/capsules/extra/src/ssd1306.rs
@@ -1,0 +1,564 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2023.
+
+//! SSD1306/SSD1315 OLED Screen
+
+use core::cell::Cell;
+use kernel::hil;
+use kernel::utilities::cells::{MapCell, OptionalCell, TakeCell};
+use kernel::utilities::leasable_buffer::SubSliceMut;
+use kernel::ErrorCode;
+
+pub const BUFFER_SIZE: usize = 1032;
+
+const WIDTH: usize = 128;
+const HEIGHT: usize = 64;
+
+#[derive(Copy, Clone, PartialEq)]
+#[repr(usize)]
+pub enum Command {
+    // Charge Pump Commands
+    /// Charge Pump Setting.
+    SetChargePump { enable: bool },
+
+    // Fundamental Commands
+    /// SetContrastControl. Double byte command to select 1 out of 256 contrast
+    /// steps. Contrast increases as the value increases.
+    SetContrast { contrast: u8 },
+    /// Entire Display On.
+    EntireDisplayOn { ignore_ram: bool },
+    /// Set Normal Display.
+    SetDisplayInvert { inverse: bool },
+    /// Set Display Off.
+    SetDisplayOnOff { on: bool },
+
+    // Scrolling Commands
+    /// Continuous Horizontal Scroll. Right or Left Horizontal Scroll.
+    ContinuousHorizontalScroll {
+        left: bool,
+        page_start: u8,
+        interval: u8,
+        page_end: u8,
+    },
+    /// Continuous Vertical and Horizontal Scroll. Vertical and Right Horizontal
+    /// Scroll.
+    ContinuousVerticalHorizontalScroll {
+        left: bool,
+        page_start: u8,
+        interval: u8,
+        page_end: u8,
+        vertical_offset: u8,
+    },
+    /// Deactivate Scroll. Stop scrolling that is configured by scroll commands.
+    DeactivateScroll = 0x2e,
+    /// Activate Scroll. Start scrolling that is configured by scroll commands.
+    ActivateScroll = 0x2f,
+    /// Set Vertical Scroll Area. Set number of rows in top fixed area. The
+    /// number of rows in top fixed area is referenced to the top of the GDDRAM
+    /// (i.e. row 0).
+    SetVerticalScrollArea { rows_fixed: u8, rows_scroll: u8 },
+
+    // Addressing Setting Commands
+    /// Set Lower Column Start Address for Page Addressing Mode.
+    ///
+    /// Set the lower nibble of the column start address register for Page
+    /// Addressing Mode using `X[3:0]` as data bits. The initial display line
+    /// register is reset to 0000b after RESET.
+    SetLowerColumnStartAddress { address: u8 },
+    /// Set Higher Column Start Address for Page Addressing Mode.
+    ///
+    /// Set the higher nibble of the column start address register for Page
+    /// Addressing Mode using `X[3:0]` as data bits. The initial display line
+    /// register is reset to 0000b after RESET.
+    SetHigherColumnStartAddress { address: u8 },
+    /// Set Memory Addressing Mode.
+    SetMemoryAddressingMode { mode: u8 },
+    /// Set Column Address. Setup column start and end address.
+    SetColumnAddress { column_start: u8, column_end: u8 },
+    /// Set Page Address. Setup page start and end address.
+    SetPageAddress { page_start: u8, page_end: u8 },
+    /// Set Page Start Address for Page Addressing Mode. Set GDDRAM Page Start
+    /// Address (PAGE0~PAGE7) for Page Addressing Mode using `X[2:0]`.
+    SetPageStartAddress { address: u8 },
+
+    // Hardware Configuration Commands
+    /// Set Display Start Line. Set display RAM display start line register from
+    /// 0-63 using `X[5:0]`.
+    SetDisplayStartLine { line: u8 },
+    /// Set Segment Remap.
+    SetSegmentRemap { reverse: bool },
+    /// Set Multiplex Ratio.
+    SetMultiplexRatio { ratio: u8 },
+    /// Set COM Output Scan Direction.
+    SetComScanDirection { decrement: bool },
+    /// Set Display Offset. Set vertical shift by COM from 0-63.
+    SetDisplayOffset { vertical_shift: u8 } = 0xd3,
+    /// Set COM Pins Hardware Configuration
+    SetComPins { alternative: bool, enable_com: bool },
+
+    // Timing & Driving Scheme Setting Commands.
+    /// Set Display Clock Divide Ratio/Oscillator Frequency.
+    SetDisplayClockDivide {
+        divide_ratio: u8,
+        oscillator_frequency: u8,
+    },
+    /// Set Pre-charge Period.
+    SetPrechargePeriod { phase1: u8, phase2: u8 },
+    /// Set VCOMH Deselect Level.
+    SetVcomDeselect { level: u8 },
+}
+
+impl Command {
+    fn encode(self, buffer: &mut SubSliceMut<'static, u8>) {
+        let take = match self {
+            Self::SetChargePump { enable } => {
+                buffer[0] = 0x8D;
+                buffer[1] = 0x10 | ((enable as u8) << 2);
+                2
+            }
+            Self::SetContrast { contrast } => {
+                buffer[0] = 0x81;
+                buffer[1] = contrast;
+                2
+            }
+            Self::EntireDisplayOn { ignore_ram } => {
+                buffer[0] = 0xa4 | (ignore_ram as u8);
+                1
+            }
+            Self::SetDisplayInvert { inverse } => {
+                buffer[0] = 0xa6 | (inverse as u8);
+                1
+            }
+            Self::SetDisplayOnOff { on } => {
+                buffer[0] = 0xae | (on as u8);
+                1
+            }
+            Self::ContinuousHorizontalScroll {
+                left,
+                page_start,
+                interval,
+                page_end,
+            } => {
+                buffer[0] = 0x26 | (left as u8);
+                buffer[1] = 0;
+                buffer[2] = page_start;
+                buffer[3] = interval;
+                buffer[4] = page_end;
+                buffer[5] = 0;
+                buffer[6] = 0xff;
+                7
+            }
+            Self::ContinuousVerticalHorizontalScroll {
+                left,
+                page_start,
+                interval,
+                page_end,
+                vertical_offset,
+            } => {
+                buffer[0] = 0x29 | (left as u8);
+                buffer[1] = 0;
+                buffer[2] = page_start;
+                buffer[3] = interval;
+                buffer[4] = page_end;
+                buffer[5] = vertical_offset;
+                6
+            }
+            Self::DeactivateScroll => {
+                buffer[0] = 0x2e;
+                1
+            }
+            Self::ActivateScroll => {
+                buffer[0] = 0x2f;
+                1
+            }
+            Self::SetVerticalScrollArea {
+                rows_fixed,
+                rows_scroll,
+            } => {
+                buffer[0] = 0xa3;
+                buffer[1] = rows_fixed;
+                buffer[2] = rows_scroll;
+                3
+            }
+            Self::SetLowerColumnStartAddress { address } => {
+                buffer[0] = 0x00 | (address & 0xF);
+                1
+            }
+            Self::SetHigherColumnStartAddress { address } => {
+                buffer[0] = 0x10 | (address & 0xF);
+                1
+            }
+            Self::SetMemoryAddressingMode { mode } => {
+                buffer[0] = 0x20;
+                buffer[1] = mode;
+                2
+            }
+            Self::SetColumnAddress {
+                column_start,
+                column_end,
+            } => {
+                buffer[0] = 0x21;
+                buffer[1] = column_start;
+                buffer[2] = column_end;
+                3
+            }
+            Self::SetPageAddress {
+                page_start,
+                page_end,
+            } => {
+                buffer[0] = 0x22;
+                buffer[1] = page_start;
+                buffer[2] = page_end;
+                3
+            }
+            Self::SetPageStartAddress { address } => {
+                buffer[0] = 0xb0 | (address & 0x7);
+                1
+            }
+            Self::SetDisplayStartLine { line } => {
+                buffer[0] = 0x40 | (line & 0x3F);
+                1
+            }
+            Self::SetSegmentRemap { reverse } => {
+                buffer[0] = 0xa0 | (reverse as u8);
+                1
+            }
+            Self::SetMultiplexRatio { ratio } => {
+                buffer[0] = 0xa8;
+                buffer[1] = ratio;
+                2
+            }
+            Self::SetComScanDirection { decrement } => {
+                buffer[0] = 0xc0 | ((decrement as u8) << 3);
+                1
+            }
+            Self::SetDisplayOffset { vertical_shift } => {
+                buffer[0] = 0xd3;
+                buffer[1] = vertical_shift;
+                2
+            }
+            Self::SetComPins {
+                alternative,
+                enable_com,
+            } => {
+                buffer[0] = 0xda;
+                buffer[1] = ((alternative as u8) << 4) | ((enable_com as u8) << 5) | 0x2;
+                2
+            }
+            Self::SetDisplayClockDivide {
+                divide_ratio,
+                oscillator_frequency,
+            } => {
+                buffer[0] = 0xd5;
+                buffer[1] = ((oscillator_frequency & 0xF) << 4) | (divide_ratio & 0xf);
+                2
+            }
+            Self::SetPrechargePeriod { phase1, phase2 } => {
+                buffer[0] = 0xd9;
+                buffer[1] = ((phase2 & 0xF) << 4) | (phase1 & 0xf);
+                2
+            }
+            Self::SetVcomDeselect { level } => {
+                buffer[0] = 0xdb;
+                buffer[1] = (level & 0xF) << 4;
+                2
+            }
+        };
+
+        // Move the available region of the buffer to what is remaining after
+        // this command was encoded.
+        buffer.slice(take..);
+    }
+}
+
+// #[derive(Copy, Clone, PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
+enum State {
+    Idle,
+    Init,
+    SimpleCommand,
+    Write,
+}
+
+pub struct Ssd1306<'a, I: hil::i2c::I2CDevice> {
+    i2c: &'a I,
+    state: Cell<State>,
+    client: OptionalCell<&'a dyn hil::screen::ScreenClient>,
+    setup_client: OptionalCell<&'a dyn hil::screen::ScreenSetupClient>,
+    buffer: TakeCell<'static, [u8]>,
+    write_buffer: MapCell<SubSliceMut<'static, u8>>,
+    enable_charge_pump: bool,
+}
+
+impl<'a, I: hil::i2c::I2CDevice> Ssd1306<'a, I> {
+    pub fn new(i2c: &'a I, buffer: &'static mut [u8], enable_charge_pump: bool) -> Ssd1306<'a, I> {
+        Ssd1306 {
+            i2c,
+            state: Cell::new(State::Idle),
+            client: OptionalCell::empty(),
+            setup_client: OptionalCell::empty(),
+            buffer: TakeCell::new(buffer),
+            write_buffer: MapCell::empty(),
+            enable_charge_pump,
+        }
+    }
+
+    pub fn init_screen(&self) {
+        let commands = [
+            Command::SetDisplayOnOff { on: false },
+            Command::SetDisplayClockDivide {
+                divide_ratio: 0,
+                oscillator_frequency: 0x8,
+            },
+            Command::SetMultiplexRatio {
+                ratio: HEIGHT as u8 - 1,
+            },
+            Command::SetDisplayOffset { vertical_shift: 0 },
+            Command::SetDisplayStartLine { line: 0 },
+            Command::SetChargePump {
+                enable: self.enable_charge_pump,
+            },
+            Command::SetMemoryAddressingMode { mode: 0 }, //horizontal
+            Command::SetSegmentRemap { reverse: true },
+            Command::SetComScanDirection { decrement: true },
+            Command::SetComPins {
+                alternative: true,
+                enable_com: false,
+            },
+            Command::SetContrast { contrast: 0xcf },
+            Command::SetPrechargePeriod {
+                phase1: 0x1,
+                phase2: 0xf,
+            },
+            Command::SetVcomDeselect { level: 2 },
+            Command::EntireDisplayOn { ignore_ram: false },
+            Command::SetDisplayInvert { inverse: false },
+            Command::DeactivateScroll,
+            Command::SetDisplayOnOff { on: true },
+        ];
+
+        match self.send_sequence(&commands) {
+            Ok(()) => {
+                self.state.set(State::Init);
+            }
+            Err(_e) => {}
+        }
+    }
+
+    fn send_sequence(&self, sequence: &[Command]) -> Result<(), ErrorCode> {
+        if self.state.get() == State::Idle {
+            self.buffer.take().map_or(Err(ErrorCode::NOMEM), |buffer| {
+                let mut buf_slice = SubSliceMut::new(buffer);
+
+                // Specify this is a series of command bytes.
+                buf_slice[0] = 0; // Co = 0, D/C̅ = 0
+
+                // Move the window of the subslice after the command byte header.
+                buf_slice.slice(1..);
+
+                for cmd in sequence.iter() {
+                    cmd.encode(&mut buf_slice);
+                }
+
+                // We need the amount of data that has been sliced away
+                // at the start of the subslice.
+                let remaining_len = buf_slice.len();
+                buf_slice.reset();
+                let tx_len = buf_slice.len() - remaining_len;
+
+                self.i2c.enable();
+                match self.i2c.write(buf_slice.take(), tx_len) {
+                    Ok(()) => Ok(()),
+                    Err((_e, buf)) => {
+                        self.buffer.replace(buf);
+                        self.i2c.disable();
+                        Err(ErrorCode::INVAL)
+                    }
+                }
+            })
+        } else {
+            Err(ErrorCode::BUSY)
+        }
+    }
+}
+
+impl<'a, I: hil::i2c::I2CDevice> hil::screen::ScreenSetup<'a> for Ssd1306<'a, I> {
+    fn set_client(&self, client: &'a dyn hil::screen::ScreenSetupClient) {
+        self.setup_client.set(client);
+    }
+
+    fn set_resolution(&self, _resolution: (usize, usize)) -> Result<(), ErrorCode> {
+        Err(ErrorCode::NOSUPPORT)
+    }
+
+    fn set_pixel_format(&self, _depth: hil::screen::ScreenPixelFormat) -> Result<(), ErrorCode> {
+        Err(ErrorCode::NOSUPPORT)
+    }
+
+    fn set_rotation(&self, _rotation: hil::screen::ScreenRotation) -> Result<(), ErrorCode> {
+        Err(ErrorCode::NOSUPPORT)
+    }
+
+    fn get_num_supported_resolutions(&self) -> usize {
+        1
+    }
+
+    fn get_supported_resolution(&self, index: usize) -> Option<(usize, usize)> {
+        match index {
+            0 => Some((WIDTH, HEIGHT)),
+            _ => None,
+        }
+    }
+
+    fn get_num_supported_pixel_formats(&self) -> usize {
+        1
+    }
+
+    fn get_supported_pixel_format(&self, index: usize) -> Option<hil::screen::ScreenPixelFormat> {
+        match index {
+            0 => Some(hil::screen::ScreenPixelFormat::Mono),
+            _ => None,
+        }
+    }
+}
+
+impl<'a, I: hil::i2c::I2CDevice> hil::screen::Screen<'a> for Ssd1306<'a, I> {
+    fn set_client(&self, client: &'a dyn hil::screen::ScreenClient) {
+        self.client.set(client);
+    }
+
+    fn get_resolution(&self) -> (usize, usize) {
+        (WIDTH, HEIGHT)
+    }
+
+    fn get_pixel_format(&self) -> hil::screen::ScreenPixelFormat {
+        hil::screen::ScreenPixelFormat::Mono
+    }
+
+    fn get_rotation(&self) -> hil::screen::ScreenRotation {
+        hil::screen::ScreenRotation::Normal
+    }
+
+    fn set_write_frame(
+        &self,
+        x: usize,
+        y: usize,
+        width: usize,
+        height: usize,
+    ) -> Result<(), ErrorCode> {
+        let commands = [
+            Command::SetPageAddress {
+                page_start: (y / 8) as u8,
+                page_end: ((y / 8) + (height / 8) - 1) as u8,
+            },
+            Command::SetColumnAddress {
+                column_start: x as u8,
+                column_end: (x + width - 1) as u8,
+            },
+        ];
+        match self.send_sequence(&commands) {
+            Ok(()) => {
+                self.state.set(State::SimpleCommand);
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    fn write(&self, data: SubSliceMut<'static, u8>, _continue: bool) -> Result<(), ErrorCode> {
+        self.buffer.take().map_or(Err(ErrorCode::NOMEM), |buffer| {
+            let mut buf_slice = SubSliceMut::new(buffer);
+
+            // Specify this is data.
+            buf_slice[0] = 0x40; // Co = 0, D/C̅ = 1
+
+            // Move the window of the subslice after the command byte header.
+            buf_slice.slice(1..);
+
+            // Figure out how much we can send.
+            let copy_len = core::cmp::min(buf_slice.len(), data.len());
+
+            for i in 0..copy_len {
+                buf_slice[i] = data[i];
+            }
+
+            let tx_len = copy_len + 1;
+
+            self.i2c.enable();
+            match self.i2c.write(buf_slice.take(), tx_len) {
+                Ok(()) => {
+                    self.state.set(State::Write);
+                    self.write_buffer.replace(data);
+                    Ok(())
+                }
+                Err((_e, buf)) => {
+                    self.buffer.replace(buf);
+                    Err(ErrorCode::INVAL)
+                }
+            }
+        })
+    }
+
+    fn set_brightness(&self, brightness: u16) -> Result<(), ErrorCode> {
+        let commands = [Command::SetContrast {
+            contrast: (brightness >> 8) as u8,
+        }];
+        match self.send_sequence(&commands) {
+            Ok(()) => {
+                self.state.set(State::SimpleCommand);
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    fn set_power(&self, enabled: bool) -> Result<(), ErrorCode> {
+        let commands = [Command::SetDisplayOnOff { on: enabled }];
+        match self.send_sequence(&commands) {
+            Ok(()) => {
+                self.state.set(State::SimpleCommand);
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    fn set_invert(&self, enabled: bool) -> Result<(), ErrorCode> {
+        let commands = [Command::SetDisplayInvert { inverse: enabled }];
+        match self.send_sequence(&commands) {
+            Ok(()) => {
+                self.state.set(State::SimpleCommand);
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
+impl<'a, I: hil::i2c::I2CDevice> hil::i2c::I2CClient for Ssd1306<'a, I> {
+    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), hil::i2c::Error>) {
+        self.buffer.replace(buffer);
+        self.i2c.disable();
+
+        match self.state.get() {
+            State::Init => {
+                self.state.set(State::Idle);
+                self.client.map(|client| client.screen_is_ready());
+            }
+
+            State::SimpleCommand => {
+                self.state.set(State::Idle);
+                self.client.map(|client| client.command_complete(Ok(())));
+            }
+
+            State::Write => {
+                self.state.set(State::Idle);
+                self.write_buffer.take().map(|buf| {
+                    self.client.map(|client| client.write_complete(buf, Ok(())));
+                });
+            }
+            _ => {}
+        }
+    }
+}


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a nRF52840-based board that has an OLED monochromatic display. I implemented the SSD1306 driver to support the display. Otherwise the board is just a normal nRF52840.

This also adds a new screen SyscallDriver, called `ScreenShared`, which allows a board to partition a screen into multiple rectangles, and assign rectangles to _specific_ apps. The assignments are persistent as they use AppID and not ProcessId.


https://github.com/tock/tock/assets/1467890/055736ac-6f0b-43d4-ada4-d2c1e6823ff8



This works by having the capsule configured with an `[AppScreenRegion]` which ties a rectangular frame to a ShortID.

```rust
pub struct AppScreenRegion {
    app_id: kernel::process::ShortID,
    frame: Frame,
}

pub struct Frame {
    x: usize,
    y: usize,
    width: usize,
    height: usize,
}
```


### Testing Strategy

Well, see the video. Uses the u8g2 library in userspace.


### TODO or Help Wanted

To merge as is we need some more AppID infrastructure which is/will be in other PRs.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
