### PR TITLE
kernel: utilities: add crc32b implementation

### DIFF
--- a/kernel/src/utilities/helpers.rs
+++ b/kernel/src/utilities/helpers.rs
@@ -42,3 +42,25 @@ macro_rules! count_expressions {
     ($head:expr $(,)?) => (1usize);
     ($head:expr, $($tail:expr),* $(,)?) => (1usize + count_expressions!($($tail),*));
 }
+
+/// Compute the CRC-32B checksum of a string.
+///
+/// Implementation based on https://lxp32.github.io/docs/a-simple-example-crc32-calculation/.
+/// Online calculator here: https://md5calc.com/hash/crc32b
+pub fn crc32b_str(s: &'static str) -> u32 {
+    let mut crc: u32 = 0xFFFFFFFF;
+
+    for c in s.chars() {
+        let mut c: u8 = c as u8;
+
+        for _i in 0..8 {
+            let b: u32 = ((c as u32) ^ crc) & 0x1;
+            crc >>= 1;
+            if b != 0 {
+                crc ^= 0xEDB88320;
+            }
+            c >>= 1;
+        }
+    }
+    !crc
+}

--- a/kernel/src/utilities/helpers.rs
+++ b/kernel/src/utilities/helpers.rs
@@ -45,8 +45,8 @@ macro_rules! count_expressions {
 
 /// Compute the CRC-32B checksum of a string.
 ///
-/// Implementation based on https://lxp32.github.io/docs/a-simple-example-crc32-calculation/.
-/// Online calculator here: https://md5calc.com/hash/crc32b
+/// Implementation based on <https://lxp32.github.io/docs/a-simple-example-crc32-calculation/>.
+/// Online calculator here: <https://md5calc.com/hash/crc32b>.
 pub fn crc32b_str(s: &'static str) -> u32 {
     let mut crc: u32 = 0xFFFFFFFF;
 

--- a/kernel/src/utilities/helpers.rs
+++ b/kernel/src/utilities/helpers.rs
@@ -43,15 +43,15 @@ macro_rules! count_expressions {
     ($head:expr, $($tail:expr),* $(,)?) => (1usize + count_expressions!($($tail),*));
 }
 
-/// Compute the CRC-32B checksum of a string.
+/// Compute the CRC-32B checksum of a slice.
 ///
 /// Implementation based on <https://lxp32.github.io/docs/a-simple-example-crc32-calculation/>.
 /// Online calculator here: <https://md5calc.com/hash/crc32b>.
-pub fn crc32b_str(s: &'static str) -> u32 {
+pub fn crc32b_str(b: &[u8]) -> u32 {
     let mut crc: u32 = 0xFFFFFFFF;
 
-    for c in s.chars() {
-        let mut c: u8 = c as u8;
+    for c in b {
+        let mut c = *c;
 
         for _i in 0..8 {
             let b: u32 = ((c as u32) ^ crc) & 0x1;


### PR DESCRIPTION
### Pull Request Overview

Alternative to #3808.

This is helpful for, for one example, computing ShortIDs from process names.

The `Compress` trait has one function:

```rust
fn to_short_id(&self, process: &dyn Process, credentials: &TbfFooterV2Credentials) -> ShortID;
```

I want to add a function with the signature `fn (&'static str) -> u32)` so I can implement `Compress` and assign ShortIDs based on process names. 

This complements #3818, which is an app checker that looks like:

```rust
pub struct AppCheckerNames<'a, F: Fn(&'static str) -> u32> {
    hasher: &'a F,
    ...
}
```

For my purposes (and for most simple use cases where apps are identified by their name), it's not important _what_ the hash function is, as long as it is reasonably ok at generating different short IDs for different strings.

Now, I've been convinced to change the signature of the function in this PR to `fn (&[u8]) -> u32`. That makes this a little more general. For my use case then I will create a small wrapper function in the board main.rs, or do something like `&|s| crc32b(s.as_bytes())`.

The other reason I want _any_ simple function like `fn (&'static str) -> u32)` is it makes actually using AppID in board files fairly ergonomic. So If I have a capsule and I want to give some resource to a specific app, I can do something like:

```rust
my_capsule::new(
  // Identify the app that is allowed to use this capsule
  ShortID::Fixed(NonZeroU32::new(kernel::utilities::helpers::crc("circle")).unwrap())
  // Other resources the capsule needs
  i2c, ...
)
```

I guess now I have to do:

```
fn my_hash(s: &'static str) -> u32 {
  kernel::utilities::helpers::crc(s.as_bytes())
}

my_capsule::new(
  // Identify the app that is allowed to use this capsule
  ShortID::Fixed(NonZeroU32::new(my_hash("circle")).unwrap())
  // Other resources the capsule needs
  i2c, ...
)
```

but you get the point.

What makes this nice is that it's easy for someone to know the ShortID for an app since we already use process names. Changing which app gets a resource is just updating the human readable string.

If we want to make AppID usable, having ways to generate ShortIDs that is intuitive is very helpful.



### Testing Strategy

Comparing to online calculator.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
