### PR TITLE
opentitan: Rearrange UARTs and I2Cs.

### DIFF
--- a/boards/opentitan/src/pinmux_layout.rs
+++ b/boards/opentitan/src/pinmux_layout.rs
@@ -8,17 +8,15 @@ use earlgrey::registers::top_earlgrey::{PinmuxInsel, PinmuxOutsel};
 type In = PinmuxInsel;
 type Out = PinmuxOutsel;
 
+/// Pinmux configuration for hyperdebug with cw310. The primary reference for
+/// this config is:
+/// <OPENTITAN_TREE>/hw/top_earlgrey/data/pins_cw310_hyperdebug.xdc
+/// pins_cw310_hyperdebug.xdc sometimes underspecifies the layout (e.g. it
+/// doesn't indicate UART numbering); we resolve the ambiguity by using
+/// <OPENTITAN_TREE>/hw/top_earlgrey/data/pins_cw310.xdc
 pub enum BoardPinmuxLayout {}
 
-/// Implementations of Pinmux initial board configurations.
-/// Defined Pinmux layout is designed for CW310 FPGA board
-/// and is compatible with Hyperdebug test board IO layout.
-/// In feature we should add layouts compatible with other
-/// OpenTitan boards.
-/// Source of true:
-/// <OPENTITAN_TREE/hw/top_earlgrey/data/pins_cw310_hyperdebug.xdc>
 impl EarlGreyPinmuxConfig for BoardPinmuxLayout {
-    /// Array of input selector initial configurations
     #[rustfmt::skip]
     const INPUT: &'static [PinmuxInsel; INPUT_NUM] = &[
         In::Ioa2,         // GpioGpio0
@@ -53,20 +51,20 @@ impl EarlGreyPinmuxConfig for BoardPinmuxLayout {
         In::Ior10,        // GpioGpio29
         In::Ior11,        // GpioGpio30
         In::Ior12,        // GpioGpio31
-        In::Ioa7,         // I2c0Sda
-        In::Ioa8,         // I2c0Scl
-        In::Iob10,        // I2c1Sda
-        In::Iob9,         // I2c1Scl
-        In::Iob11,        // I2c2Sda
-        In::Iob12,        // I2c2Scl
+        In::Iob12,        // I2c0Sda
+        In::Iob11,        // I2c0Scl
+        In::Ioa7,         // I2c1Sda
+        In::Ioa8,         // I2c1Scl
+        In::Iob9,         // I2c2Sda
+        In::Iob10,        // I2c2Scl
         In::ConstantZero, // SpiHost1Sd0
         In::ConstantZero, // SpiHost1Sd1
         In::ConstantZero, // SpiHost1Sd2
         In::ConstantZero, // SpiHost1Sd3
-        In::Ioa0,         // Uart0Rx
-        In::Ioa4,         // Uart1Rx
-        In::Iob4,         // Uart2Rx
-        In::Ioc3,         // Uart3Rx
+        In::Ioc3,         // Uart0Rx
+        In::Iob4,         // Uart1Rx
+        In::Ioa0,         // Uart2Rx
+        In::Ioa4,         // Uart3Rx
         In::ConstantZero, // SpiDeviceTpmCsb
         In::ConstantZero, // FlashCtrlTck
         In::ConstantZero, // FlashCtrlTms
@@ -80,39 +78,38 @@ impl EarlGreyPinmuxConfig for BoardPinmuxLayout {
         In::ConstantZero, // UsbdevSense
     ];
 
-    /// Array representing configgurations of pinmux output selector
     #[rustfmt::skip]
     const OUTPUT: &'static [PinmuxOutsel; OUTPUT_NUM] = &[
         // __________  BANK IOA __________
-        Out::ConstantHighZ, // Ioa0 (CW310Hyp Uart_RX / CW310 SAM3X)
-        Out::Uart3Tx,       // Ioa1 (CW310Hyp Uart_Tx / CW310 SAM3x)
+        Out::ConstantHighZ, // Ioa0 UART2_RX
+        Out::Uart2Tx,       // Ioa1 UART2_TX
         Out::GpioGpio0,     // Ioa2
         Out::GpioGpio1,     // Ioa3
-        Out::ConstantHighZ, // Ioa4
-        Out::Uart1Tx,       // Ioa5
+        Out::ConstantHighZ, // Ioa4 UART3_RX
+        Out::Uart3Tx,       // Ioa5 UART3_TX
         Out::GpioGpio2,     // Ioa6
-        Out::I2c0Sda,       // Ioa7 I2C0_TPM_SDA
-        Out::I2c0Scl,       // Ioa8 I2C0_TPM_SCL
+        Out::I2c1Sda,       // Ioa7 I2C1_SDA
+        Out::I2c1Scl,       // Ioa8 I2C1_SCL
         // __________ BANK IOB __________
         Out::GpioGpio3,     // Iob0 SPI_HOST_CS
         Out::GpioGpio4,     // Iob1 SPI_HOST_DI
         Out::GpioGpio5,     // Iob2 SPI_HOST_DO
         Out::GpioGpio6,     // Iob3 SPI_HOST_CLK
-        Out::ConstantHighZ, // Iob4 UART2_RX
-        Out::Uart2Tx,       // Iob5 UART2_TX
+        Out::ConstantHighZ, // Iob4 UART1_RX
+        Out::Uart1Tx,       // Iob5 UART1_TX
         Out::GpioGpio7,     // Iob6
         Out::GpioGpio8,     // Iob7
         Out::GpioGpio9,     // Iob8
-        Out::I2c1Scl,       // Iob9  I2C1_SCL
-        Out::I2c1Sda,       // Iob10 I2C1_SDA
-        Out::I2c2Sda,       // Iob11 I2C2_SDA
-        Out::I2c2Scl,       // Iob12 I2C2_SCL
+        Out::I2c2Sda,       // Iob9  I2C2_SDA
+        Out::I2c2Scl,       // Iob10 I2C2_SCL
+        Out::I2c0Scl,       // Iob11 I2C0_SCL
+        Out::I2c0Sda,       // Iob12 I2C0_SDA
         // __________ BANK IOC __________
         Out::GpioGpio10,    // Ioc0
         Out::GpioGpio11,    // Ioc1
         Out::GpioGpio12,    // Ioc2
-        Out::ConstantHighZ, // Ioc3 UART3_RX
-        Out::Uart0Tx,       // Ioc4 UART3_TX
+        Out::ConstantHighZ, // Ioc3 UART0_RX
+        Out::Uart0Tx,       // Ioc4 UART0_TX
         Out::ConstantHighZ, // Ioc5 (TAP STRAP 1)
         Out::GpioGpio14,    // Ioc6
         Out::GpioGpio15,    // Ioc7
@@ -130,8 +127,8 @@ impl EarlGreyPinmuxConfig for BoardPinmuxLayout {
         Out::GpioGpio26,    // Ior5
         Out::GpioGpio27,    // Ior6
         Out::GpioGpio28,    // Ior7
-        // DIO CW310_hyp       Ior8
-        // DIO CW310_hyp       Ior9
+        // DIO CW310_hyp    // Ior8
+        // DIO CW310_hyp    // Ior9
         Out::GpioGpio29,    // Ior10
         Out::GpioGpio30,    // Ior11
         Out::GpioGpio31,    // Ior12


### PR DESCRIPTION
OpenTitan has a convention for which UARTs and I2C peripherals are mapped to which pins. This PR updates the pinmux layout to match that convention.

With this change, both the RX and TX pins of UART0 are mapped to the SAM3X chip on the cw310, allowing us to interact with the Tock console over USB without extra hardware.

This PR was tested by using tests in the OpenTitan project.