### PR TITLE
kernel: utilities: add crc32_posix

### DIFF
--- a/kernel/src/utilities/helpers.rs
+++ b/kernel/src/utilities/helpers.rs
@@ -42,3 +42,23 @@ macro_rules! count_expressions {
     ($head:expr $(,)?) => (1usize);
     ($head:expr, $($tail:expr),* $(,)?) => (1usize + count_expressions!($($tail),*));
 }
+
+/// Compute a POSIX-style CRC32 checksum of a slice.
+///
+/// Online calculator: <https://crccalc.com/>
+pub fn crc32_posix(b: &[u8]) -> u32 {
+    let mut crc: u32 = 0;
+
+    for c in b {
+        crc ^= (*c as u32) << 24;
+
+        for _i in 0..8 {
+            if crc & (0b1 << 31) > 0 {
+                crc = (crc << 1) ^ 0x04c11db7;
+            } else {
+                crc <<= 1;
+            }
+        }
+    }
+    !crc
+}


### PR DESCRIPTION
### Pull Request Overview

This is for computing short IDs from process names. Follow up to #3825.

More information here: #3825

This CRC matches the CRC TicKV uses.


### Testing Strategy

The online calculator compared to tickv.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
