### PR TITLE
Network Working Group call notes February 05 2024

### DIFF
--- a/doc/wg/network/notes/network-notes-2024-02-05.md
+++ b/doc/wg/network/notes/network-notes-2024-02-05.md
@@ -1,0 +1,20 @@
+# Tock Network WG Meeting Notes
+
+- **Date:** February 05, 2024
+- **Participants:**
+    - Branden Ghena
+    - Leon Schuermann
+- **Agenda**
+    1. Quick check-in on status
+- **References:**
+    - [3833](https://github.com/tock/tock/issues/3833)
+
+
+## OpenThread
+- Branden: Tyler posted https://github.com/tock/tock/issues/3833 about OpenThread progress
+- Leon: Yes. I think the libtock-c route is the major thrust at this point. Likely to work faster. Still working on encapsulated functions from a research prospective, but it's going to take a while
+- Leon: As a backup, we could just link the C code directly into the kernel if timing stuff really didn't work.
+
+## Buffer Management
+- Leon: I pushed buffer management stuff and need to get in contact with Alex's student. Next steps really need a prototype example.
+


### PR DESCRIPTION
### Pull Request Overview

Adds Network Working Group call notes from February 5th, 2024. This was just a short check-in meeting.

[Rendered](https://github.com/tock/tock/blob/d51d9c5de95a556fcc7bf2e1c77c70a0eb6d80ca/doc/wg/network/notes/network-notes-2024-02-05.md)


### Testing Strategy

It's like three sentences.


### TODO or Help Wanted

Good to go


### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [N/A] Ran `make prepush`.
