### PR TITLE
Boards: wm1110dev updates: remove build.rs, update readme

### DIFF
--- a/boards/wm1110dev/Cargo.toml
+++ b/boards/wm1110dev/Cargo.toml
@@ -6,7 +6,7 @@
 name = "wm1110dev"
 version.workspace = true
 authors.workspace = true
-build = "build.rs"
+build = "../build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/wm1110dev/README.md
+++ b/boards/wm1110dev/README.md
@@ -47,6 +47,10 @@ Pin mappings:
 Make sure _both_ the nRF52840dk board and the WM1110-dev board are attached to
 your computer via two USB connections.
 
+> Tip: If you only have one USB cable, plug it into the nRF52840dk. Then, jumper
+> `3V3 (wm1110dev) <-> VDD (nrf)` and `SWD SEL (nrf) <-> VDD (nrf)`. The other
+> jumpers remain the same.
+
 Then:
 
 ```

--- a/boards/wm1110dev/build.rs
+++ b/boards/wm1110dev/build.rs
@@ -1,8 +1,0 @@
-// Licensed under the Apache License, Version 2.0 or the MIT License.
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2023.
-
-fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=../kernel_layout.ld");
-}


### PR DESCRIPTION
### Pull Request Overview

Use shared build.rs.

We also ran into an issue where it was tricky to have two USB cables plugged in at the same time. It is possible to flash the board with one cable, so document that.


### Testing Strategy

n/a


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
