### PR TITLE
doc: minor TRD102 fixes

### DIFF
--- a/doc/reference/trd102-adc.md
+++ b/doc/reference/trd102-adc.md
@@ -147,7 +147,7 @@ The AdcHighSpeed trait is used for sampling data at high frequencies such that
 receiving individual samples would be untenable. Instead, it provides an
 interface that returns buffers filled with samples. This trait relies on the
 Adc trait being implemented as well in order to provide primitives like
-`intialize` and `stop_sampling` which are used for ADCs in this mode as well.
+`initialize` and `stop_sampling` which are used for ADCs in this mode as well.
 While we expect many chips to support the Adc trait, we expect the AdcHighSpeed
 trait to be implemented due to a high-speed sampling need on a platform. The
 trait has three functions:

--- a/doc/reference/trd102-adc.md
+++ b/doc/reference/trd102-adc.md
@@ -49,7 +49,7 @@ either one-shot or repeatedly. It is implemented by chip drivers to provide ADC
 functionality. Data is provided through the Client trait. It has four functions
 and one associated type:
 
-```
+```rust
 /// Simple interface for reading an ADC sample on any channel.
 pub trait Adc {
     /// The chip-dependent type of an ADC channel.
@@ -124,7 +124,7 @@ from by userland applications.
 The Client trait handles responses from Adc trait sampling commands. It is
 implemented by capsules to receive chip driver responses. It has one function:
 
-```
+```rust
 /// Trait for handling callbacks from simple ADC calls.
 pub trait Client {
     /// Called when a sample is ready.
@@ -152,7 +152,7 @@ While we expect many chips to support the Adc trait, we expect the AdcHighSpeed
 trait to be implemented due to a high-speed sampling need on a platform. The
 trait has three functions:
 
-```
+```rust
 /// Interface for continuously sampling at a given frequency on a channel.
 /// Requires the AdcSimple interface to have been implemented as well.
 pub trait AdcHighSpeed: Adc {
@@ -240,7 +240,7 @@ The HighSpeedClient trait is used to receive samples from a call to
 `sample_highspeed`. It is implemented by a capsule to receive chip driver
 responses. It has one function:
 
-```
+```rust
 /// Trait for handling callbacks from high-speed ADC calls.
 pub trait HighSpeedClient {
     /// Called when a buffer is full.
@@ -283,7 +283,7 @@ SAM4L implementation creates an AdcChannel struct which contains and enum
 defining its value. Each possible ADC channel is then statically created. Other
 chips may want to consider a similar system.
 
-```
+```rust
 /// Representation of an ADC channel on the SAM4L.
 pub struct AdcChannel {
     chan_num: u32,
@@ -328,7 +328,7 @@ As ADC functionality is split between two traits, there are two callback traits.
 ADC driver implementations that use both `Adc` and `AdcHighSpeed` need two
 clients, which must both be set:
 
-```
+```rust
 hil::adc::Adc::set_client(&peripherals.adc, adc);
 hil::adc::AdcHighSpeed::set_client(&peripherals.adc, adc);
 ```


### PR DESCRIPTION
### Pull Request Overview

This pull adds syntax highlight for the code blocks and fixes a misspelling of "initialize".


### Testing Strategy

n/a


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
