### PR TITLE
rust: update nightly April 2024

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
     "editor.defaultFormatter": "rust-lang.rust-analyzer",
     "editor.formatOnSave": true,
     "rust-analyzer.server.extraEnv": {
-        "RUSTUP_TOOLCHAIN": "nightly-2024-01-01"
+        "RUSTUP_TOOLCHAIN": "nightly-2024-04-19"
     },
     "rust-analyzer.check.allTargets": false,
 }

--- a/arch/cortex-m/src/mpu.rs
+++ b/arch/cortex-m/src/mpu.rs
@@ -318,7 +318,7 @@ impl CortexMRegion {
         // To compute the mask, we start with all subregions disabled and enable
         // the ones in the inclusive range [min_subregion, max_subregion].
         if let Some((min_subregion, max_subregion)) = subregions {
-            let mask = (min_subregion..=max_subregion).fold(u8::max_value(), |res, i| {
+            let mask = (min_subregion..=max_subregion).fold(u8::MAX, |res, i| {
                 // Enable subregions bit by bit (1 ^ 1 == 0)
                 res ^ (1 << i)
             });

--- a/boards/components/src/segger_rtt.rs
+++ b/boards/components/src/segger_rtt.rs
@@ -66,7 +66,7 @@ pub struct SeggerRttMemoryRefs<'a> {
 
 impl<'a> SeggerRttMemoryRefs<'a> {
     pub unsafe fn get_rtt_memory_ptr(&mut self) -> *mut SeggerRttMemory<'a> {
-        self.rtt_memory as *mut _
+        core::ptr::from_mut(self.rtt_memory)
     }
 }
 

--- a/boards/imix/src/test/log_test.rs
+++ b/boards/imix/src/test/log_test.rs
@@ -115,7 +115,7 @@ static TEST_OPS: [TestOp; 24] = [
     // Try bad seeks, should fail and not change read entry ID.
     TestOp::Write,
     TestOp::BadSeek(0),
-    TestOp::BadSeek(core::usize::MAX),
+    TestOp::BadSeek(usize::MAX),
     TestOp::Read,
     // Try bad write, nothing should change.
     TestOp::BadWrite,

--- a/boards/makepython-nrf52840/src/main.rs
+++ b/boards/makepython-nrf52840/src/main.rs
@@ -681,12 +681,12 @@ pub unsafe fn start() -> (
             board_kernel,
             chip,
             core::slice::from_raw_parts(
-                &_sapps as *const u8,
-                &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
+                core::ptr::addr_of!(_sapps),
+                core::ptr::addr_of!(_eapps) as usize - core::ptr::addr_of!(_sapps) as usize,
             ),
             core::slice::from_raw_parts_mut(
-                addr_of_mut!(_sappmem),
-                &_eappmem as *const u8 as usize - addr_of!(_sappmem) as usize,
+                core::ptr::addr_of_mut!(_sappmem),
+                core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
             ),
             &FAULT_RESPONSE,
             assigner,

--- a/boards/microbit_v2/src/io.rs
+++ b/boards/microbit_v2/src/io.rs
@@ -9,10 +9,8 @@ use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart;
-use nrf52833::gpio::{self, Pin};
+use nrf52833::gpio::Pin;
 use nrf52833::uart::{Uarte, UARTE0_BASE};
-
-use kernel::hil::gpio::{Configure, Input, Output};
 
 use crate::CHIP;
 use crate::PROCESSES;
@@ -67,31 +65,6 @@ impl IoWrite for Writer {
     }
 }
 
-struct MatrixLed(
-    &'static gpio::GPIOPin<'static>,
-    &'static gpio::GPIOPin<'static>,
-);
-
-impl led::Led for MatrixLed {
-    fn init(&self) {
-        self.0.make_output();
-        self.1.make_output();
-        self.1.clear();
-    }
-    fn on(&self) {
-        self.1.set();
-    }
-    fn off(&self) {
-        self.1.clear();
-    }
-    fn toggle(&self) {
-        self.1.toggle();
-    }
-    fn read(&self) -> bool {
-        self.1.read()
-    }
-}
-
 /// Default panic handler for the microbit board.
 ///
 /// We just use the standard default provided by the debug module in the kernel.
@@ -107,7 +80,6 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     use core::ptr::{addr_of, addr_of_mut};
     let led_kernel_pin = &nrf52833::gpio::GPIOPin::new(Pin::P0_20);
     let led = &mut led::LedLow::new(led_kernel_pin);
-    // MatrixLed(&gpio::PORT[Pin::P0_28], &gpio::PORT[Pin::P0_21]);
     let writer = &mut *addr_of_mut!(WRITER);
     debug::panic(
         &mut [led],

--- a/boards/nano33ble/src/test/log_test.rs
+++ b/boards/nano33ble/src/test/log_test.rs
@@ -119,7 +119,7 @@ static TEST_OPS: [TestOp; 24] = [
     // Try bad seeks, should fail and not change read entry ID.
     TestOp::Write,
     TestOp::BadSeek(0),
-    TestOp::BadSeek(core::usize::MAX),
+    TestOp::BadSeek(usize::MAX),
     TestOp::Read,
     // Try bad write, nothing should change.
     TestOp::BadWrite,

--- a/boards/nano33ble_rev2/src/main.rs
+++ b/boards/nano33ble_rev2/src/main.rs
@@ -706,12 +706,12 @@ pub unsafe fn start() -> (
         board_kernel,
         chip,
         core::slice::from_raw_parts(
-            &_sapps as *const u8,
-            &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
+            core::ptr::addr_of!(_sapps),
+            core::ptr::addr_of!(_eapps) as usize - core::ptr::addr_of!(_sapps) as usize,
         ),
         core::slice::from_raw_parts_mut(
-            addr_of_mut!(_sappmem),
-            addr_of!(_eappmem) as usize - addr_of!(_sappmem) as usize,
+            core::ptr::addr_of_mut!(_sappmem),
+            core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
         &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,

--- a/capsules/extra/src/ble_advertising_driver.rs
+++ b/capsules/extra/src/ble_advertising_driver.rs
@@ -377,9 +377,9 @@ where
     // likely be chosen.
     fn reset_active_alarm(&self) {
         let now = self.alarm.now();
-        let mut next_ref = u32::max_value();
-        let mut next_dt = u32::max_value();
-        let mut next_dist = u32::max_value();
+        let mut next_ref = u32::MAX;
+        let mut next_dt = u32::MAX;
+        let mut next_dist = u32::MAX;
         for app in self.app.iter() {
             app.enter(|app, _| match app.alarm_data.expiration {
                 Expiration::Enabled(reference, dt) => {
@@ -394,7 +394,7 @@ where
                 Expiration::Disabled => {}
             });
         }
-        if next_ref != u32::max_value() {
+        if next_ref != u32::MAX {
             self.alarm
                 .set_alarm(A::Ticks::from(next_ref), A::Ticks::from(next_dt));
         }

--- a/capsules/extra/src/log.rs
+++ b/capsules/extra/src/log.rs
@@ -217,7 +217,7 @@ impl<'a, F: Flash + 'static> Log<'a, F> {
     /// Reconstructs a log from flash.
     fn reconstruct(&self) {
         // Read page headers, get IDs of oldest and newest pages.
-        let mut oldest_page_id: EntryID = core::usize::MAX;
+        let mut oldest_page_id: EntryID = usize::MAX;
         let mut newest_page_id: EntryID = 0;
         for header_pos in (0..self.volume.len()).step_by(self.page_size) {
             let page_id = {
@@ -240,7 +240,7 @@ impl<'a, F: Flash + 'static> Log<'a, F> {
 
         // Reconstruct log if at least one valid page was found (meaning oldest page ID was set to
         // something not usize::MAX).
-        if oldest_page_id != core::usize::MAX {
+        if oldest_page_id != usize::MAX {
             // Walk entries in last (newest) page to calculate last page length.
             let mut last_page_len = PAGE_HEADER_SIZE;
             loop {

--- a/chips/msp432/src/adc.rs
+++ b/chips/msp432/src/adc.rs
@@ -940,7 +940,8 @@ impl<'a> hil::adc::AdcHighSpeed<'a> for Adc<'a> {
         );
 
         let adc_reg =
-            (&self.registers.mem[*channel as usize] as *const ReadWrite<u32>).cast::<()>();
+            (core::ptr::from_ref::<ReadWrite<u32>>(&self.registers.mem[*channel as usize]))
+                .cast::<()>();
 
         // Convert the [u16] into an [u8] since the DMA works only with [u8]
         let buf1 = unsafe { buf_u16_to_buf_u8(buffer1) };

--- a/chips/msp432/src/adc.rs
+++ b/chips/msp432/src/adc.rs
@@ -625,8 +625,8 @@ impl<'a> Adc<'a> {
         self.registers.ie0.set(0);
 
         // Clear all pending interrupts
-        self.registers.clrifg0.set(core::u32::MAX);
-        self.registers.clrifg1.set(core::u32::MAX);
+        self.registers.clrifg0.set(u32::MAX);
+        self.registers.clrifg1.set(u32::MAX);
     }
 
     fn setup(&self) {

--- a/chips/msp432/src/dma.rs
+++ b/chips/msp432/src/dma.rs
@@ -687,7 +687,7 @@ impl<'a> DmaChannel<'a> {
 
         // Set the pointer to the configuration-memory
         // Since the config needs exactly 256 bytes, mask out the lower 256 bytes
-        let addr = (&DMA_CONFIG.0[0] as *const DmaChannelControl as u32) & (!0xFFu32);
+        let addr = (core::ptr::from_ref::<DmaChannelControl>(&DMA_CONFIG.0[0]) as u32) & (!0xFFu32);
         self.registers.ctlbase.set(addr);
     }
 
@@ -940,8 +940,8 @@ impl<'a> DmaChannel<'a> {
 
         // The pointers must point to the end of the buffer, for detailed calculation see
         // datasheet p. 646, section 11.2.4.4.
-        let src_end_ptr = (&src_buf[0] as *const u8 as u32) + ((len as u32) - 1);
-        let dst_end_ptr = (&dst_buf[0] as *const u8 as u32) + ((len as u32) - 1);
+        let src_end_ptr = (core::ptr::from_ref::<u8>(&src_buf[0]) as u32) + ((len as u32) - 1);
+        let dst_end_ptr = (core::ptr::from_ref::<u8>(&dst_buf[0]) as u32) + ((len as u32) - 1);
 
         // Setup the DMA configuration
         self.set_dma_mode(DmaMode::Basic);
@@ -981,7 +981,7 @@ impl<'a> DmaChannel<'a> {
         // The pointers must point to the end of the buffer, for detailed calculation see
         // datasheet p. 646, section 11.2.4.4.
         let src_end_ptr = src_reg as u32;
-        let dst_end_ptr = (&buf[0] as *const u8 as u32) + ((len as u32) - 1);
+        let dst_end_ptr = (core::ptr::from_ref::<u8>(&buf[0]) as u32) + ((len as u32) - 1);
 
         // Setup the DMA configuration
         self.set_dma_mode(DmaMode::Basic);
@@ -1004,7 +1004,7 @@ impl<'a> DmaChannel<'a> {
     pub fn transfer_mem_to_periph(&self, dst_reg: *const (), buf: &'static mut [u8], len: usize) {
         // The pointers must point to the end of the buffer, for detailed calculation see
         // datasheet p. 646, section 11.2.4.4.
-        let src_end_ptr = (&buf[0] as *const u8 as u32) + ((len as u32) - 1);
+        let src_end_ptr = (core::ptr::from_ref::<u8>(&buf[0]) as u32) + ((len as u32) - 1);
         let dst_end_ptr = dst_reg as u32;
 
         // Setup the DMA configuration
@@ -1037,8 +1037,8 @@ impl<'a> DmaChannel<'a> {
         // datasheet p. 646, section 11.2.4.4.
 
         let src_end_ptr = src_reg as u32;
-        let dst_end_ptr1 = (&buf1[0] as *const u8 as u32) + ((len1 as u32) - 1);
-        let dst_end_ptr2 = (&buf2[0] as *const u8 as u32) + ((len2 as u32) - 1);
+        let dst_end_ptr1 = (core::ptr::from_ref::<u8>(&buf1[0]) as u32) + ((len1 as u32) - 1);
+        let dst_end_ptr2 = (core::ptr::from_ref::<u8>(&buf2[0]) as u32) + ((len2 as u32) - 1);
 
         // Setup the DMA configuration
         self.set_dma_mode(DmaMode::PingPong);
@@ -1063,7 +1063,7 @@ impl<'a> DmaChannel<'a> {
 
     /// Provide a new buffer for a ping-pong transfer
     pub fn provide_new_buffer(&self, buf: &'static mut [u8], len: usize) {
-        let buf_end_ptr = (&buf[0] as *const u8 as u32) + ((len as u32) - 1);
+        let buf_end_ptr = (core::ptr::from_ref::<u8>(&buf[0]) as u32) + ((len as u32) - 1);
 
         if self.transfer_type.get() == DmaTransferType::PeripheralToMemoryPingPong {
             if self.active_buf.get() == ActiveBuffer::Primary {

--- a/chips/nrf52/src/ficr.rs
+++ b/chips/nrf52/src/ficr.rs
@@ -479,7 +479,7 @@ impl Ficr {
         buf[16] = h[((lo >> 0) & 0xf) as usize];
 
         // Safe because we use only ascii characters in this buffer.
-        unsafe { &*(buf as *const [u8] as *const str) }
+        unsafe { &*(core::ptr::from_ref::<[u8]>(buf) as *const str) }
     }
 }
 

--- a/chips/nrf5x/src/trng.rs
+++ b/chips/nrf5x/src/trng.rs
@@ -44,23 +44,23 @@ pub struct RngRegisters {
     /// Address: 0x004 - 0x008
     pub task_stop: WriteOnly<u32, Task::Register>,
     /// Reserved
-    pub _reserved1: [u32; 62],
+    _reserved1: [u32; 62],
     /// Event being generated for every new random number written to the VALUE register
     /// Address: 0x100 - 0x104
     pub event_valrdy: ReadWrite<u32, Event::Register>,
     /// Reserved
-    pub _reserved2: [u32; 63],
+    _reserved2: [u32; 63],
     /// Shortcut register
     /// Address: 0x200 - 0x204
     pub shorts: ReadWrite<u32, Shorts::Register>,
-    pub _reserved3: [u32; 64],
+    _reserved3: [u32; 64],
     /// Enable interrupt
     /// Address: 0x304 - 0x308
     pub intenset: ReadWrite<u32, Intenset::Register>,
     /// Disable interrupt
     /// Address: 0x308 - 0x30c
     pub intenclr: ReadWrite<u32, Intenclr::Register>,
-    pub _reserved4: [u32; 126],
+    _reserved4: [u32; 126],
     /// Configuration register
     /// Address: 0x504 - 0x508
     pub config: ReadWrite<u32, Config::Register>,

--- a/chips/sam4l/src/dma.rs
+++ b/chips/sam4l/src/dma.rs
@@ -282,7 +282,7 @@ impl DMAChannel {
         self.registers.psr.set(pid);
         self.registers
             .marr
-            .write(MemoryAddressReload::MARV.val(&buf[0] as *const u8 as u32));
+            .write(MemoryAddressReload::MARV.val(core::ptr::from_ref::<u8>(&buf[0]) as u32));
         self.registers
             .tcrr
             .write(TransferCounter::TCV.val(len as u32));

--- a/chips/stm32f4xx/src/dma.rs
+++ b/chips/stm32f4xx/src/dma.rs
@@ -854,7 +854,7 @@ impl<'a, DMA: StreamServer<'a>> Stream<'a, DMA> {
         // 2
         self.set_peripheral_address();
         // 3
-        self.set_memory_address(&buf[0] as *const u8 as u32);
+        self.set_memory_address(core::ptr::from_ref::<u8>(&buf[0]) as u32);
         // 4
         self.set_data_items(len as u32);
         // 5

--- a/chips/virtio/src/queues/split_queue.rs
+++ b/chips/virtio/src/queues/split_queue.rs
@@ -472,9 +472,9 @@ impl<'a, 'b, const MAX_QUEUE_SIZE: usize> SplitVirtqueue<'a, 'b, MAX_QUEUE_SIZE>
         available_ring: &'a mut VirtqueueAvailableRing<MAX_QUEUE_SIZE>,
         used_ring: &'a mut VirtqueueUsedRing<MAX_QUEUE_SIZE>,
     ) -> Self {
-        assert!(descriptors as *const _ as usize % DESCRIPTOR_ALIGNMENT == 0);
-        assert!(available_ring as *const _ as usize % AVAILABLE_RING_ALIGNMENT == 0);
-        assert!(used_ring as *const _ as usize % USED_RING_ALIGNMENT == 0);
+        assert!(core::ptr::from_ref(descriptors) as usize % DESCRIPTOR_ALIGNMENT == 0);
+        assert!(core::ptr::from_ref(available_ring) as usize % AVAILABLE_RING_ALIGNMENT == 0);
+        assert!(core::ptr::from_ref(used_ring) as usize % USED_RING_ALIGNMENT == 0);
 
         SplitVirtqueue {
             descriptors,
@@ -878,9 +878,9 @@ impl<'a, 'b, const MAX_QUEUE_SIZE: usize> Virtqueue for SplitVirtqueue<'a, 'b, M
 
     fn physical_addresses(&self) -> VirtqueueAddresses {
         VirtqueueAddresses {
-            descriptor_area: self.descriptors as *const _ as u64,
-            driver_area: self.available_ring as *const _ as u64,
-            device_area: self.used_ring as *const _ as u64,
+            descriptor_area: core::ptr::from_ref(self.descriptors) as u64,
+            driver_area: core::ptr::from_ref(self.available_ring) as u64,
+            device_area: core::ptr::from_ref(self.used_ring) as u64,
         }
     }
 

--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -77,7 +77,7 @@ of installing some of these tools, but you can also install them yourself.
 
 #### Rust (nightly)
 
-We are using `nightly-2024-01-01`. We require
+We are using `nightly-2024-04-19`. We require
 installing it with [rustup](http://www.rustup.rs) so you can manage multiple
 versions of Rust and continue using stable versions for other Rust code:
 
@@ -92,7 +92,7 @@ to your `$PATH`.
 Then install the correct nightly version of Rust:
 
 ```bash
-$ rustup install nightly-2024-01-01
+$ rustup install nightly-2024-04-19
 ```
 
 #### Tockloader

--- a/kernel/src/deferred_call.rs
+++ b/kernel/src/deferred_call.rs
@@ -96,7 +96,7 @@ impl<'a> DynDefCallRef<'a> {
     // convention for any type.
     fn new<T: DeferredCallClient>(x: &'a T) -> Self {
         Self {
-            data: x as *const _ as *const (),
+            data: core::ptr::from_ref(x) as *const (),
             callback: |p| unsafe { T::handle_deferred_call(&*p.cast()) },
             _lifetime: PhantomData,
         }

--- a/kernel/src/hil/can.rs
+++ b/kernel/src/hil/can.rs
@@ -241,7 +241,7 @@ impl<T: Configure> StandardBitTiming for T {
             875
         };
         let mut sample_point_err;
-        let mut sample_point_err_min = core::u16::MAX;
+        let mut sample_point_err_min = u16::MAX;
         let mut ts: u32 = (Self::MAX_BIT_TIMINGS.propagation
             + Self::MAX_BIT_TIMINGS.segment1
             + Self::MAX_BIT_TIMINGS.segment2

--- a/libraries/tickv/src/async_ops.rs
+++ b/libraries/tickv/src/async_ops.rs
@@ -398,6 +398,7 @@ mod tests {
         use crate::success_codes::SuccessCode;
         use crate::tickv::{HASH_OFFSET, LEN_OFFSET, MAIN_KEY, VERSION, VERSION_OFFSET};
         use core::hash::{Hash, Hasher};
+        use core::ptr::addr_of_mut;
         use std::cell::Cell;
         use std::cell::RefCell;
         use std::collections::hash_map::DefaultHasher;
@@ -641,7 +642,8 @@ mod tests {
 
             println!("HASHED KEY {:?}", get_hashed_key(b"ONE"));
 
-            let ret = unsafe { tickv.append_key(get_hashed_key(b"ONE"), &mut VALUE, 32) };
+            let ret =
+                unsafe { tickv.append_key(get_hashed_key(b"ONE"), &mut *addr_of_mut!(VALUE), 32) };
             match ret {
                 Ok(SuccessCode::Queued) => {
                     // There is no actual delay in the test, just continue now
@@ -652,7 +654,8 @@ mod tests {
                 _ => unreachable!(),
             }
 
-            let ret = unsafe { tickv.append_key(get_hashed_key(b"TWO"), &mut VALUE, 32) };
+            let ret =
+                unsafe { tickv.append_key(get_hashed_key(b"TWO"), &mut *addr_of_mut!(VALUE), 32) };
             match ret {
                 Ok(SuccessCode::Queued) => {
                     // There is no actual delay in the test, just continue now
@@ -689,7 +692,8 @@ mod tests {
             static mut BUF: [u8; 32] = [0; 32];
 
             println!("Add key ONE");
-            let ret = unsafe { tickv.append_key(get_hashed_key(b"ONE"), &mut VALUE, 32) };
+            let ret =
+                unsafe { tickv.append_key(get_hashed_key(b"ONE"), &mut *addr_of_mut!(VALUE), 32) };
             match ret {
                 Ok(SuccessCode::Queued) => {
                     // There is no actual delay in the test, just continue now
@@ -702,7 +706,7 @@ mod tests {
 
             println!("Get key ONE");
 
-            let ret = unsafe { tickv.get_key(get_hashed_key(b"ONE"), &mut BUF) };
+            let ret = unsafe { tickv.get_key(get_hashed_key(b"ONE"), &mut *addr_of_mut!(BUF)) };
             match ret {
                 Ok(SuccessCode::Queued) => {
                     flash_ctrl_callback(&tickv);
@@ -713,7 +717,7 @@ mod tests {
             }
 
             println!("Get non-existent key TWO");
-            let ret = unsafe { tickv.get_key(get_hashed_key(b"TWO"), &mut BUF) };
+            let ret = unsafe { tickv.get_key(get_hashed_key(b"TWO"), &mut *addr_of_mut!(BUF)) };
             match ret {
                 Ok(SuccessCode::Queued) => {
                     // There is no actual delay in the test, just continue now
@@ -725,7 +729,8 @@ mod tests {
             }
 
             println!("Add key ONE again");
-            let ret = unsafe { tickv.append_key(get_hashed_key(b"ONE"), &mut VALUE, 32) };
+            let ret =
+                unsafe { tickv.append_key(get_hashed_key(b"ONE"), &mut *addr_of_mut!(VALUE), 32) };
             match ret {
                 Ok(SuccessCode::Queued) => {
                     // There is no actual delay in the test, just continue now
@@ -740,7 +745,8 @@ mod tests {
             }
 
             println!("Add key TWO");
-            let ret = unsafe { tickv.append_key(get_hashed_key(b"TWO"), &mut VALUE, 32) };
+            let ret =
+                unsafe { tickv.append_key(get_hashed_key(b"TWO"), &mut *addr_of_mut!(VALUE), 32) };
             match ret {
                 Ok(SuccessCode::Queued) => {
                     // There is no actual delay in the test, just continue now
@@ -752,7 +758,7 @@ mod tests {
             }
 
             println!("Get key ONE");
-            let ret = unsafe { tickv.get_key(get_hashed_key(b"ONE"), &mut BUF) };
+            let ret = unsafe { tickv.get_key(get_hashed_key(b"ONE"), &mut *addr_of_mut!(BUF)) };
             match ret {
                 Ok(SuccessCode::Queued) => {
                     // There is no actual delay in the test, just continue now
@@ -764,7 +770,7 @@ mod tests {
             }
 
             println!("Get key TWO");
-            let ret = unsafe { tickv.get_key(get_hashed_key(b"TWO"), &mut BUF) };
+            let ret = unsafe { tickv.get_key(get_hashed_key(b"TWO"), &mut *addr_of_mut!(BUF)) };
             match ret {
                 Ok(SuccessCode::Queued) => {
                     // There is no actual delay in the test, just continue now
@@ -776,7 +782,7 @@ mod tests {
             }
 
             println!("Get non-existent key THREE");
-            let ret = unsafe { tickv.get_key(get_hashed_key(b"THREE"), &mut BUF) };
+            let ret = unsafe { tickv.get_key(get_hashed_key(b"THREE"), &mut *addr_of_mut!(BUF)) };
             match ret {
                 Ok(SuccessCode::Queued) => {
                     // There is no actual delay in the test, just continue now
@@ -786,7 +792,7 @@ mod tests {
                 _ => unreachable!(),
             }
 
-            let ret = unsafe { tickv.get_key(get_hashed_key(b"THREE"), &mut BUF) };
+            let ret = unsafe { tickv.get_key(get_hashed_key(b"THREE"), &mut *addr_of_mut!(BUF)) };
             match ret {
                 Ok(SuccessCode::Queued) => {
                     flash_ctrl_callback(&tickv);
@@ -822,7 +828,7 @@ mod tests {
             static mut BUF: [u8; 32] = [0; 32];
 
             println!("Add key 0x1000");
-            let ret = unsafe { tickv.append_key(0x1000, &mut VALUE, 32) };
+            let ret = unsafe { tickv.append_key(0x1000, &mut *addr_of_mut!(VALUE), 32) };
             match ret {
                 Ok(SuccessCode::Queued) => {
                     // There is no actual delay in the test, just continue now
@@ -834,7 +840,7 @@ mod tests {
             }
 
             println!("Add key 0x2000");
-            let ret = unsafe { tickv.append_key(0x2000, &mut VALUE, 32) };
+            let ret = unsafe { tickv.append_key(0x2000, &mut *addr_of_mut!(VALUE), 32) };
             match ret {
                 Ok(SuccessCode::Queued) => {
                     // There is no actual delay in the test, just continue now
@@ -853,7 +859,7 @@ mod tests {
             }
 
             println!("Add key 0x3000");
-            let ret = unsafe { tickv.append_key(0x3000, &mut VALUE, 32) };
+            let ret = unsafe { tickv.append_key(0x3000, &mut *addr_of_mut!(VALUE), 32) };
             match ret {
                 Ok(SuccessCode::Queued) => {
                     // There is no actual delay in the test, just continue now
@@ -876,7 +882,7 @@ mod tests {
             }
 
             println!("Get key 0x1000");
-            let ret = unsafe { tickv.get_key(0x1000, &mut BUF) };
+            let ret = unsafe { tickv.get_key(0x1000, &mut *addr_of_mut!(BUF)) };
             match ret {
                 Ok(SuccessCode::Queued) => {
                     // There is no actual delay in the test, just continue now
@@ -898,7 +904,7 @@ mod tests {
             }
 
             println!("Get key 0x3000");
-            let ret = unsafe { tickv.get_key(0x3000, &mut BUF) };
+            let ret = unsafe { tickv.get_key(0x3000, &mut *addr_of_mut!(BUF)) };
             match ret {
                 Ok(_) => flash_ctrl_callback(&tickv),
                 Err(_) => unreachable!(),
@@ -942,7 +948,8 @@ mod tests {
             static mut BUF: [u8; 32] = [0; 32];
 
             println!("Add key ONE");
-            let ret = unsafe { tickv.append_key(get_hashed_key(b"ONE"), &mut VALUE, 32) };
+            let ret =
+                unsafe { tickv.append_key(get_hashed_key(b"ONE"), &mut *addr_of_mut!(VALUE), 32) };
             match ret {
                 Ok(SuccessCode::Queued) => {
                     // There is no actual delay in the test, just continue now
@@ -954,7 +961,7 @@ mod tests {
             }
 
             println!("Get key ONE");
-            let ret = unsafe { tickv.get_key(get_hashed_key(b"ONE"), &mut BUF) };
+            let ret = unsafe { tickv.get_key(get_hashed_key(b"ONE"), &mut *addr_of_mut!(BUF)) };
             match ret {
                 Ok(SuccessCode::Queued) => {
                     // There is no actual delay in the test, just continue now
@@ -978,7 +985,7 @@ mod tests {
 
             println!("Get non-existent key ONE");
             unsafe {
-                match tickv.get_key(get_hashed_key(b"ONE"), &mut BUF) {
+                match tickv.get_key(get_hashed_key(b"ONE"), &mut *addr_of_mut!(BUF)) {
                     Ok(SuccessCode::Queued) => {
                         flash_ctrl_callback(&tickv);
 
@@ -1103,7 +1110,8 @@ mod tests {
             }
 
             println!("Add key ONE");
-            let ret = unsafe { tickv.append_key(get_hashed_key(b"ONE"), &mut VALUE, 32) };
+            let ret =
+                unsafe { tickv.append_key(get_hashed_key(b"ONE"), &mut *addr_of_mut!(VALUE), 32) };
             match ret {
                 Ok(SuccessCode::Queued) => {
                     // There is no actual delay in the test, just continue now
@@ -1156,7 +1164,7 @@ mod tests {
             }
 
             println!("Get non-existent key ONE");
-            match unsafe { tickv.get_key(get_hashed_key(b"ONE"), &mut BUF) } {
+            match unsafe { tickv.get_key(get_hashed_key(b"ONE"), &mut *addr_of_mut!(BUF)) } {
                 Ok(SuccessCode::Queued) => {
                     flash_ctrl_callback(&tickv);
                     assert_eq!(
@@ -1170,7 +1178,8 @@ mod tests {
             }
 
             println!("Add Key ONE");
-            let ret = unsafe { tickv.append_key(get_hashed_key(b"ONE"), &mut VALUE, 32) };
+            let ret =
+                unsafe { tickv.append_key(get_hashed_key(b"ONE"), &mut *addr_of_mut!(VALUE), 32) };
             match ret {
                 Ok(SuccessCode::Queued) => {
                     // There is no actual delay in the test, just continue now

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,6 +3,6 @@
 # Copyright Tock Contributors 2023.
 
 [toolchain]
-channel = "nightly-2024-01-01"
+channel = "nightly-2024-04-19"
 components = ["miri", "llvm-tools", "rust-src", "rustfmt", "clippy"]
 targets = ["thumbv6m-none-eabi", "thumbv7em-none-eabi", "thumbv7em-none-eabihf", "riscv32imc-unknown-none-elf", "riscv32imac-unknown-none-elf"]

--- a/tools/netlify-build.sh
+++ b/tools/netlify-build.sh
@@ -17,7 +17,7 @@ set -u
 set -x
 
 # Install rust stuff that we need
-curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2024-01-01
+curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2024-04-19
 
 # And fixup path for the newly installed rust stuff
 export PATH="$PATH:$HOME/.cargo/bin"

--- a/tools/run_clippy.sh
+++ b/tools/run_clippy.sh
@@ -17,10 +17,13 @@
 #
 # - `clippy::if_same_then_else`: There are often good reasons to enumerate
 #   different states that have the same effect.
+# - `clippy::manual_unwrap_or_default`: As of Apr 2024, this lint has many false
+#   positives.
 CLIPPY_ARGS="
 -A clippy::restriction
 
 -A clippy::if_same_then_else
+-A clippy::manual_unwrap_or_default
 "
 
 # Disallow all complexity lints, then re-allow each one Tock does not comply


### PR DESCRIPTION
### Pull Request Overview

This pull request updates rust to force the new warning mentioned in #3841.

We need to fix these warnings before we can merge this, but this serves as a way to check if we have fixed them.


### Testing Strategy

travis


### TODO or Help Wanted

Fix warnings


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
