### PR TITLE
libraries: tock-tbf: fix footer parse error

### DIFF
--- a/libraries/tock-tbf/src/parse.rs
+++ b/libraries/tock-tbf/src/parse.rs
@@ -315,7 +315,10 @@ pub fn parse_tbf_footer(
     footers: &'static [u8],
 ) -> Result<(types::TbfFooterV2Credentials, u32), types::TbfParseError> {
     let mut remaining = footers;
-    let tlv_header: types::TbfTlv = remaining.try_into()?;
+    let tlv_header: types::TbfTlv = remaining
+        .get(0..4)
+        .ok_or(types::TbfParseError::NotEnoughFlash)?
+        .try_into()?;
     remaining = remaining
         .get(4..)
         .ok_or(types::TbfParseError::NotEnoughFlash)?;


### PR DESCRIPTION
### Pull Request Overview

If there isn't enough room for footer TLV, that is a `NotEnoughFlash` error, not internal error.






### Testing Strategy

New async process loader.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
