### PR TITLE
arch/rv32i: separate kernel and app trap handlers to simply assembly flow and allow foreign process implementations

### DIFF
--- a/arch/rv32i/src/lib.rs
+++ b/arch/rv32i/src/lib.rs
@@ -163,15 +163,15 @@ pub enum PermissionMode {
 pub unsafe fn configure_trap_handler(mode: PermissionMode) {
     match mode {
         PermissionMode::Machine => csr::CSR.mtvec.write(
-            csr::mtvec::mtvec::trap_addr.val(_start_trap as usize >> 2)
+            csr::mtvec::mtvec::trap_addr.val(_start_kernel_trap as usize >> 2)
                 + csr::mtvec::mtvec::mode::CLEAR,
         ),
         PermissionMode::Supervisor => csr::CSR.stvec.write(
-            csr::stvec::stvec::trap_addr.val(_start_trap as usize >> 2)
+            csr::stvec::stvec::trap_addr.val(_start_kernel_trap as usize >> 2)
                 + csr::stvec::stvec::mode::CLEAR,
         ),
         PermissionMode::User => csr::CSR.utvec.write(
-            csr::utvec::utvec::trap_addr.val(_start_trap as usize >> 2)
+            csr::utvec::utvec::trap_addr.val(_start_kernel_trap as usize >> 2)
                 + csr::utvec::utvec::mode::CLEAR,
         ),
         PermissionMode::Reserved => {
@@ -182,7 +182,7 @@ pub unsafe fn configure_trap_handler(mode: PermissionMode) {
 
 // Mock implementation for tests on Travis-CI.
 #[cfg(not(any(target_arch = "riscv32", target_os = "none")))]
-pub extern "C" fn _start_trap() {
+pub extern "C" fn _start_kernel_trap() {
     unimplemented!()
 }
 
@@ -202,47 +202,16 @@ extern "C" {
     /// need to. If the trap happens while and application was executing, we have to
     /// save the application state and then resume the `switch_to()` function to
     /// correctly return back to the kernel.
-    pub fn _start_trap();
+    pub fn _start_kernel_trap();
 }
 
 #[cfg(all(target_arch = "riscv32", target_os = "none"))]
 global_asm!(
     "
             .section .riscv.trap, \"ax\"
-            .globl _start_trap
-          _start_trap:
-
-            // The first thing we have to do is determine if we came from user
-            // mode or kernel mode, as we need to save state and proceed
-            // differently. We cannot, however, use any registers because we do
-            // not want to lose their contents. So, we rely on `mscratch`. If
-            // mscratch is 0, then we came from the kernel. If it is >0, then it
-            // contains the kernel's stack pointer and we came from an app.
-            //
-            // We use the csrrw instruction to save the current stack pointer
-            // so we can retrieve it if necessary.
-            //
-            // If we could enter this trap handler twice (for example,
-            // handling an interrupt while an exception is being
-            // handled), storing a non-zero value in mscratch
-            // temporarily could cause a race condition similar to the
-            // one of PR 2308[1].
-            // However, as indicated in section 3.1.6.1 of the RISC-V
-            // Privileged Spec[2], MIE will be set to 0 when taking a
-            // trap into machine mode. Therefore, this can only happen
-            // when causing an exception in the trap handler itself.
-            //
-            // [1] https://github.com/tock/tock/pull/2308
-            // [2] https://github.com/riscv/riscv-isa-manual/releases/download/draft-20201222-42dc13a/riscv-privileged.pdf
-            csrrw sp, 0x340, sp // CSR=0x340=mscratch
-            bnez  sp, 300f      // If sp != 0 then we must have come from an app.
-
-
-        // _from_kernel:
-            // Swap back the zero value for the stack pointer in mscratch
-            csrrw sp, 0x340, sp // CSR=0x340=mscratch
-
-            // Now, since we want to use the stack to save kernel registers, we
+            .globl _start_kernel_trap
+          _start_kernel_trap:
+            // Since we want to use the stack to save kernel registers, we
             // first need to make sure that the trap wasn't the result of a
             // stack overflow, in which case we can't use the current stack
             // pointer. We also, however, cannot modify any of the current
@@ -269,11 +238,10 @@ global_asm!(
             // top of the original stack.
             la sp, {estack}                     // sp = _estack
 
+        100: // _start_kernel_trap_continue
 
-        100: // _from_kernel_continue
-
-            // Restore t0, and make sure mscratch is set back to 0 (our flag
-            // tracking that the kernel is executing).
+            // Restore t0. We set mscratch to 0 (to aid in debugging, signalling
+            // that we're currently executing the kernel).
             csrrw t0, 0x340, zero // t0=mscratch, mscratch=0
 
             // Make room for the caller saved registers we need to restore after
@@ -327,113 +295,6 @@ global_asm!(
             // mret returns from the trap handler. The PC is set to what is in
             // mepc and execution proceeds from there. Since we did not modify
             // mepc we will return to where the exception occurred.
-            mret
-
-
-
-            // Handle entering the trap handler from an app differently.
-        300: // _from_app
-
-            // At this point all we know is that we entered the trap handler
-            // from an app. We don't know _why_ we got a trap, it could be from
-            // an interrupt, syscall, or fault (or maybe something else).
-            // Therefore we have to be very careful not to overwrite any
-            // registers before we have saved them.
-            //
-            // We ideally want to save registers in the per-process stored state
-            // struct. However, we don't have a pointer to that yet, and we need
-            // to use a temporary register to get that address. So, we save s0
-            // to the kernel stack before we can it to the proper spot.
-            sw   s0, 0*4(sp)
-
-            // Ideally it would be better to save all of the app registers once
-            // we return back to the `switch_to_process()` code. However, we
-            // also potentially need to disable an interrupt in case the app was
-            // interrupted, so it is safer to just immediately save all of the
-            // app registers.
-            //
-            // We do this by retrieving the stored state pointer from the kernel
-            // stack and storing the necessary values in it.
-            lw   s0,  1*4(sp)  // Load the stored state pointer into s0.
-            sw   x1,  0*4(s0)  // ra
-            sw   x3,  2*4(s0)  // gp
-            sw   x4,  3*4(s0)  // tp
-            sw   x5,  4*4(s0)  // t0
-            sw   x6,  5*4(s0)  // t1
-            sw   x7,  6*4(s0)  // t2
-            sw   x9,  8*4(s0)  // s1
-            sw   x10, 9*4(s0)  // a0
-            sw   x11, 10*4(s0) // a1
-            sw   x12, 11*4(s0) // a2
-            sw   x13, 12*4(s0) // a3
-            sw   x14, 13*4(s0) // a4
-            sw   x15, 14*4(s0) // a5
-            sw   x16, 15*4(s0) // a6
-            sw   x17, 16*4(s0) // a7
-            sw   x18, 17*4(s0) // s2
-            sw   x19, 18*4(s0) // s3
-            sw   x20, 19*4(s0) // s4
-            sw   x21, 20*4(s0) // s5
-            sw   x22, 21*4(s0) // s6
-            sw   x23, 22*4(s0) // s7
-            sw   x24, 23*4(s0) // s8
-            sw   x25, 24*4(s0) // s9
-            sw   x26, 25*4(s0) // s10
-            sw   x27, 26*4(s0) // s11
-            sw   x28, 27*4(s0) // t3
-            sw   x29, 28*4(s0) // t4
-            sw   x30, 29*4(s0) // t5
-            sw   x31, 30*4(s0) // t6
-            // Now retrieve the original value of s0 and save that as well.
-            lw   t0,  0*4(sp)
-            sw   t0,  7*4(s0)  // s0,fp
-
-            // We also need to store the app stack pointer, mcause, and mepc. We
-            // need to store mcause because we use that to determine why the app
-            // stopped executing and returned to the kernel. We store mepc
-            // because it is where we need to return to in the app at some
-            // point. We need to store mtval in case the app faulted and we need
-            // mtval to help with debugging.
-            csrr t0, 0x340    // CSR=0x340=mscratch
-            sw   t0, 1*4(s0)  // Save the app sp to the stored state struct
-            csrr t0, 0x341    // CSR=0x341=mepc
-            sw   t0, 31*4(s0) // Save the PC to the stored state struct
-            csrr t0, 0x343    // CSR=0x343=mtval
-            sw   t0, 33*4(s0) // Save mtval to the stored state struct
-
-            // Save mcause last, as we depend on it being loaded in t0 below
-            csrr t0, 0x342    // CSR=0x342=mcause
-            sw   t0, 32*4(s0) // Save mcause to the stored state struct, leave in t0
-
-            // Now we need to check if this was an interrupt, and if it was,
-            // then we need to disable the interrupt before returning from this
-            // trap handler so that it does not fire again. If mcause is greater
-            // than or equal to zero this was not an interrupt (i.e. the most
-            // significant bit is not 1).
-            bge  t0, zero, 200f
-            // Copy mcause into a0 and then call the interrupt disable function.
-            mv   a0, t0
-            jal  ra, _disable_interrupt_trap_rust_from_app
-
-        200: // _from_app_continue
-            // Now determine the address of _return_to_kernel and resume the
-            // context switching code. We need to load _return_to_kernel into
-            // mepc so we can use it to return to the context switch code.
-            lw   t0, 2*4(sp)  // Load _return_to_kernel into t0.
-            csrw 0x341, t0    // CSR=0x341=mepc
-
-            // Ensure that mscratch is 0. This makes sure that we know that on
-            // a future trap that we came from the kernel.
-            csrw 0x340, zero  // CSR=0x340=mscratch
-
-            // Need to set mstatus.MPP to 0b11 so that we stay in machine mode.
-            csrr t0, 0x300    // CSR=0x300=mstatus
-            li   t1, 0x1800   // Load 0b11 to the MPP bits location in t1
-            or   t0, t0, t1   // Set the MPP bits to one
-            csrw 0x300, t0    // CSR=0x300=mstatus
-
-            // Use mret to exit the trap handler and return to the context
-            // switching code.
             mret
         ",
     estack = sym _estack,


### PR DESCRIPTION
### Pull Request Overview

Tock's core kernel design permits process implementations with system call interfaces other than the ones shipped upstream in the `arch/cortex-m` and `arch/rv32i` crates. However, in practice, the `UserspaceKernelBoundary` implementation for RV32I has always been tightly coupled to the generic kernel RISC-V trap handler. This has made it difficult to build an alternative process implementation (e.g., as part of [Encapsulated Functions](https://dl.acm.org/doi/10.1145/3625275.3625397)), while reusing much of Tock's RISC-V implementation.

By separating out the app trap handler from the kernel trap handler, we get a fully "branchless" (no indirect branches and being able to read top-to-bottom), albeit longer, context switch assembly block in the `switch_to_process` implementation. Because the kernel trap handler no longer contains any application logic and expects the app to set its own trap handler, implementing a new syscall ABI becomes as simple as temporarily swapping out the trap handler.

##### In-depth Walkthrough

Currently context switches on RISC-V work as follows:

0. For traps arriving in kernel mode, the kernel trap handler does an intricate dance to compare the `mscratch` value to `0` without clobbering any registers, and then takes a `_from_kernel` branch in `_start_trap`.
1. When switching to an app we disable interrupts and then swap the current kernel stack pointer into `mscratch`, making it non-zero. We re-enable interrupts when switching into user-mode.
2. When a trap arrives during app execution we perform the same dance as in `0.`, but then branch into `_from_app`.
3. The `_from_app` branch saves all of the application state through two levels of pointer indirection:
    - reading the stack pointer from `mscratch`
    - dereferencing a pointer on said stack to a struct compatible in layout to the `Riscv32iStoredState`

   We then proceed to dump all registers into this state struct, and other core-local state (CSRs) onto known offsets from the stack pointer

    _This hard-codes many assumptions about Tock's process model, and may preclude implementations that want additional state stored, or do not want to buy into storing the whole register file (e.g., for single function invocations as with Encapsulated Functions, or cooperative userspace apps)._
4. `_from_app` proceeds to switch to Machine mode.
   
    _This may be undesirable for process models which defer interrupt handling, e.g., for cooperative apps._
6. `_from_app` returns from the interrupt handler to an address stored at a well-known offset on the stack.

As is obvious from the above, using this trap handler has a significant amount of "buy in" concerning both the process execution semantics and the layout of stack pointer and the necessary `Riscv32iStoredState`.

I propose changing the routing of traps caught while executing processes by avoiding the initial `mscratch` branch, and instead having `mscratch` decide the _effective_ trap handler branch simply swapping out the trap handler altogether. This is a minor architectural change and mirrors the semantics of our current approach, but has some advantages:

- straightforward and top-down context-switch assembly, with the following all in one block:
  1. prepare the CPU for context switch by
      a. storing clobbered registers on the stack, (importantly not the trap handler, as that could be changed in an interrupt!)
      b. disabling interrupts,
      c. storing the old trap handler, and swapping in the new one from an immediate load,
      d. storing the current kernel stack in `mscratch`
      f. switching to userspace, re-enabling interrupts
  2. on trap, jump directly below to the `_start_app_trap` entry. This stores the CPU state and register file in the `Riscv32iStoredState` and stack layout defined in the very same file / assembly block.
    a. if this trap was caused by an interrupt, disable it.
  3. return from the trap handler, by loading the `_return_to_kernel` symbol directly below via an immediate, and jumping to it via `mret`
  4. restoring clobbered registers
- no hard-coded assumptions about process semantics, stored state, stack layout, etc.
- a couple less memory loads / stored, replaced through immediate loads (`la`, expanding to `auipc` or `lui` and `addi`)
- potential for more drastic optimizations: the linear execution through the assembly allows more efficient register clobbering / reuse

In short, this change increases cohesion and reduces coupling in the `rv32i` crate, and allows foreign process implementations.

### Testing Strategy

This pull request was tested by CI and needs some careful reviews. Right now, the change-set is deliberately minimal -- it effectively moves the `_from_app` assembly to the `switch_to_kernel` method and swaps out the stack-saved `_return_to_kernel` for a stack-saved `mtvec`. I have a version with some more instructions optimized locally and would propose those in a follow-up PR.

### TODO or Help Wanted

One issue on RISC-V is the presence of trap & interrupt handlers for different modes. A RISC-V platform with supervisor- and/or user-mode will feature the `stvec` and `utvec` CSRs. These will not be consulted for disabled interrupts / trap routing, however, and many more of Tock's assumptions, at least around the `SysCall` implementation in `rv32i`, would break if these were used by enabling interrupts in the `sie` / `uie` CSRs. Thus, this only stores the `mtvec` value right now and leaves `utvec` + `stvec` untouched. I _think_ this is correct, but we should make this a more explicit assumption.

Looking forward to other's opinions on this!

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
