### PR TITLE
802.15.4 Send Raw Syscall

### DIFF
--- a/capsules/extra/src/ieee802154/device.rs
+++ b/capsules/extra/src/ieee802154/device.rs
@@ -73,7 +73,24 @@ pub trait MacDevice<'a> {
         security_needed: Option<(SecurityLevel, KeyId)>,
     ) -> Result<Frame, &'static mut [u8]>;
 
-    fn buf_to_frame(&self, buf: &'static mut [u8], len: usize) -> Frame;
+    /// Creates an IEEE 802.15.4 Frame object that is compatible with the
+    /// MAC transit and append payload methods. This serves to provide
+    /// functionality for sending packets fully formed by the userprocess
+    /// and that the 15.4 capsule does not modify. The len field may be less
+    /// than the length of the buffer as the len field is the length of
+    /// the current frame while the buffer is the maximum 15.4 frame size.
+    ///
+    /// - `buf`: The buffer to be used for the frame
+    /// - `len`: The length of the frame
+    ///
+    /// Returns a Result:
+    ///     - on success a Frame object that can be used to.
+    ///     - on failure an error returning the buffer.
+    fn buf_to_frame(
+        &self,
+        buf: &'static mut [u8],
+        len: usize,
+    ) -> Result<Frame, (ErrorCode, &'static mut [u8])>;
 
     /// Transmits a frame that has been prepared by the above process. If the
     /// transmission process fails, the buffer inside the frame is returned so

--- a/capsules/extra/src/ieee802154/device.rs
+++ b/capsules/extra/src/ieee802154/device.rs
@@ -73,6 +73,8 @@ pub trait MacDevice<'a> {
         security_needed: Option<(SecurityLevel, KeyId)>,
     ) -> Result<Frame, &'static mut [u8]>;
 
+    fn buf_to_frame(&self, buf: &'static mut [u8]) -> Frame;
+
     /// Transmits a frame that has been prepared by the above process. If the
     /// transmission process fails, the buffer inside the frame is returned so
     /// that it can be re-used.

--- a/capsules/extra/src/ieee802154/device.rs
+++ b/capsules/extra/src/ieee802154/device.rs
@@ -74,7 +74,7 @@ pub trait MacDevice<'a> {
     ) -> Result<Frame, &'static mut [u8]>;
 
     /// Creates an IEEE 802.15.4 Frame object that is compatible with the
-    /// MAC transit and append payload methods. This serves to provide
+    /// MAC transmit and append payload methods. This serves to provide
     /// functionality for sending packets fully formed by the userprocess
     /// and that the 15.4 capsule does not modify. The len field may be less
     /// than the length of the buffer as the len field is the length of
@@ -84,7 +84,7 @@ pub trait MacDevice<'a> {
     /// - `len`: The length of the frame
     ///
     /// Returns a Result:
-    ///     - on success a Frame object that can be used to.
+    ///     - on success a Frame object.
     ///     - on failure an error returning the buffer.
     fn buf_to_frame(
         &self,

--- a/capsules/extra/src/ieee802154/device.rs
+++ b/capsules/extra/src/ieee802154/device.rs
@@ -73,7 +73,7 @@ pub trait MacDevice<'a> {
         security_needed: Option<(SecurityLevel, KeyId)>,
     ) -> Result<Frame, &'static mut [u8]>;
 
-    fn buf_to_frame(&self, buf: &'static mut [u8]) -> Frame;
+    fn buf_to_frame(&self, buf: &'static mut [u8], len: usize) -> Frame;
 
     /// Transmits a frame that has been prepared by the above process. If the
     /// transmission process fails, the buffer inside the frame is returned so

--- a/capsules/extra/src/ieee802154/driver.rs
+++ b/capsules/extra/src/ieee802154/driver.rs
@@ -205,11 +205,7 @@ impl PendingTX {
 
     /// Take the pending transmission, replacing it with `Empty` and return the current PendingTx
     fn take(&mut self) -> PendingTX {
-        match core::mem::replace(self, PendingTX::Empty) {
-            PendingTX::Parse(addr, sec) => PendingTX::Parse(addr, sec),
-            PendingTX::Direct => PendingTX::Direct,
-            PendingTX::Empty => PendingTX::Empty,
-        }
+        core::mem::replace(self, PendingTX::Empty)
     }
 }
 
@@ -680,6 +676,10 @@ impl SyscallDriver for RadioDriver<'_> {
     ///                      9 bytes: the key ID (might not use all bytes) +
     ///                      16 bytes: the key.
     /// - `25`: Remove the key at an index.
+    /// - `26`: Transmit a frame (parse required). Take the provided payload and
+    ///        parameters to encrypt, form headers, and transmit the frame.
+    /// - `27`: Transmit a frame (direct). Transmit preformed 15.4 frame (i.e.
+    ///        headers and security etc completed by userprocess).
     fn command(
         &self,
         command_number: usize,

--- a/capsules/extra/src/ieee802154/driver.rs
+++ b/capsules/extra/src/ieee802154/driver.rs
@@ -195,11 +195,11 @@ impl Default for PendingTX {
 }
 
 impl PendingTX {
-    /// Returns true if the PendingTX is not `Empty`
-    fn is_some(&self) -> bool {
+    /// Returns true if the PendingTX state is `Empty`
+    fn is_empty(&self) -> bool {
         match self {
-            PendingTX::Empty => false,
-            _ => true,
+            PendingTX::Empty => true,
+            _ => false,
         }
     }
 
@@ -415,7 +415,7 @@ impl<'a> RadioDriver<'a> {
         for app in self.apps.iter() {
             let processid = app.processid();
             app.enter(|app, _| {
-                if app.pending_tx.is_some() {
+                if !app.pending_tx.is_empty() {
                     pending_app = Some(processid);
                 }
             });
@@ -919,7 +919,7 @@ impl SyscallDriver for RadioDriver<'_> {
             26 => {
                 self.apps
                     .enter(processid, |app, kernel_data| {
-                        if app.pending_tx.is_some() {
+                        if !app.pending_tx.is_empty() {
                             // Cannot support more than one pending tx per process.
                             return Err(ErrorCode::BUSY);
                         }
@@ -977,7 +977,7 @@ impl SyscallDriver for RadioDriver<'_> {
             27 => {
                 self.apps
                     .enter(processid, |app, _| {
-                        if app.pending_tx.is_some() {
+                        if !app.pending_tx.is_empty() {
                             // Cannot support more than one pending tx per process.
                             return Err(ErrorCode::BUSY);
                         }

--- a/capsules/extra/src/ieee802154/framer.rs
+++ b/capsules/extra/src/ieee802154/framer.rs
@@ -133,7 +133,7 @@ impl FrameInfoWrap {
 
     /// Fetcher of the FrameInfo struct for Parse sending. Panics if
     /// called for Raw sending.
-    pub fn expect(&self) -> FrameInfo {
+    pub fn get_info(&self) -> FrameInfo {
         match self {
             FrameInfoWrap::Raw(_) => {
                 // This should never be called for a Raw send. The Framer should never
@@ -578,14 +578,14 @@ impl<'a, M: Mac<'a>, A: AES128CCM<'a>> Framer<'a, M, A> {
                 let (next_state, result) = match state {
                     TxState::Idle => (TxState::Idle, Ok(())),
                     TxState::ReadyToEncrypt(info, buf) => {
-                        match info.expect().security_params {
+                        match info.get_info().security_params {
                             None => {
                                 // `ReadyToEncrypt` should only be entered when
                                 // `security_params` is not `None`.
                                 (TxState::Idle, Err((ErrorCode::FAIL, buf)))
                             }
                             Some((level, key, nonce)) => {
-                                let (m_off, m_len) = info.expect().ccm_encrypt_ranges();
+                                let (m_off, m_len) = info.get_info().ccm_encrypt_ranges();
                                 let (a_off, m_off) =
                                     (radio::PSDU_OFFSET, radio::PSDU_OFFSET + m_off);
 
@@ -600,7 +600,7 @@ impl<'a, M: Mac<'a>, A: AES128CCM<'a>> Framer<'a, M, A> {
                                         a_off,
                                         m_off,
                                         m_len,
-                                        info.expect().mic_len,
+                                        info.get_info().mic_len,
                                         level.encryption_needed(),
                                         true,
                                     );
@@ -646,14 +646,14 @@ impl<'a, M: Mac<'a>, A: AES128CCM<'a>> Framer<'a, M, A> {
             let next_state = match state {
                 RxState::Idle => RxState::Idle,
                 RxState::ReadyToDecrypt(info, buf) => {
-                    match info.expect().security_params {
+                    match info.get_info().security_params {
                         None => {
                             // `ReadyToDecrypt` should only be entered when
                             // `security_params` is not `None`.
                             RxState::Idle
                         }
                         Some((level, key, nonce)) => {
-                            let (m_off, m_len) = info.expect().ccm_encrypt_ranges();
+                            let (m_off, m_len) = info.get_info().ccm_encrypt_ranges();
                             let (a_off, m_off) = (radio::PSDU_OFFSET, radio::PSDU_OFFSET + m_off);
 
                             // Crypto setup failed; fail receiving packet and return to idle
@@ -684,7 +684,7 @@ impl<'a, M: Mac<'a>, A: AES128CCM<'a>> Framer<'a, M, A> {
                                         a_off,
                                         m_off,
                                         m_len,
-                                        info.expect().mic_len,
+                                        info.get_info().mic_len,
                                         level.encryption_needed(),
                                         true,
                                     )

--- a/capsules/extra/src/ieee802154/framer.rs
+++ b/capsules/extra/src/ieee802154/framer.rs
@@ -126,7 +126,7 @@ impl FrameInfoWrap {
     /// Obtain unsecured_length of the Frame
     pub fn unsecured_length(&self) -> usize {
         match self {
-            FrameInfoWrap::Parse(info) => info.secured_length(),
+            FrameInfoWrap::Parse(info) => info.unsecured_length(),
             FrameInfoWrap::Raw(len) => *len,
         }
     }

--- a/capsules/extra/src/ieee802154/virtual_mac.rs
+++ b/capsules/extra/src/ieee802154/virtual_mac.rs
@@ -287,6 +287,10 @@ impl<'a> device::MacDevice<'a> for MacUser<'a> {
             .prepare_data_frame(buf, dst_pan, dst_addr, src_pan, src_addr, security_needed)
     }
 
+    fn buf_to_frame(&self, buf: &'static mut [u8]) -> framer::Frame {
+        self.mux.mac.buf_to_frame(buf)
+    }
+
     fn transmit(&self, frame: framer::Frame) -> Result<(), (ErrorCode, &'static mut [u8])> {
         // If the muxer is idle, immediately transmit the frame, otherwise
         // attempt to queue the transmission request. However, each MAC user can

--- a/capsules/extra/src/ieee802154/virtual_mac.rs
+++ b/capsules/extra/src/ieee802154/virtual_mac.rs
@@ -287,7 +287,11 @@ impl<'a> device::MacDevice<'a> for MacUser<'a> {
             .prepare_data_frame(buf, dst_pan, dst_addr, src_pan, src_addr, security_needed)
     }
 
-    fn buf_to_frame(&self, buf: &'static mut [u8], len: usize) -> framer::Frame {
+    fn buf_to_frame(
+        &self,
+        buf: &'static mut [u8],
+        len: usize,
+    ) -> Result<framer::Frame, (ErrorCode, &'static mut [u8])> {
         self.mux.mac.buf_to_frame(buf, len)
     }
 

--- a/capsules/extra/src/ieee802154/virtual_mac.rs
+++ b/capsules/extra/src/ieee802154/virtual_mac.rs
@@ -287,8 +287,8 @@ impl<'a> device::MacDevice<'a> for MacUser<'a> {
             .prepare_data_frame(buf, dst_pan, dst_addr, src_pan, src_addr, security_needed)
     }
 
-    fn buf_to_frame(&self, buf: &'static mut [u8]) -> framer::Frame {
-        self.mux.mac.buf_to_frame(buf)
+    fn buf_to_frame(&self, buf: &'static mut [u8], len: usize) -> framer::Frame {
+        self.mux.mac.buf_to_frame(buf, len)
     }
 
     fn transmit(&self, frame: framer::Frame) -> Result<(), (ErrorCode, &'static mut [u8])> {


### PR DESCRIPTION
### Pull Request Overview

Tock currently provides a syscall to support forming, securing, and sending 15.4 packets. This syscall allows user processes to provide the security level, destination address, key_id, etc and a payload. From this information, the 15.4 capsule then encrypts the payload (if necessary) and then forms the proper headers. Although this is helpful in most generic cases, it does not allow for user processes to fully form / encrypt 15.4 packets in userspace. 

In OpenThread's platform abstraction layer, OpenThread passes a fully formed 15.4 packet to the PAL function interfacing with the radio. This creates a challenge within libtock-c as there does not exist a syscall command for sending preformed packets. The current implementation would require the PAL libtock-c function deconstruct the fully formed 15.4 packet to retrieve and pass the fields into `ieee802154_send(..)`.

This PR adds a syscall command for direct sending (i.e. sending a packet fully formed by the user process). This is primarily accomplished through a wrapper `enum` `PendingTX` that abstracts the `pending_tx` as either `Direct` `Parse` or `Empty`. This allows the 15.4 capsule to differentiate between fully formed packets and packets requiring additional processing.

The direct send syscall also required modification to the `Frame` struct as `FrameInfo`  is not relevant to a `Direct` frame (beyond the length field). These nuances and explanations should be fully documented in the accompanying comments.

### Testing Strategy

This pull request was tested using the 15.4 test suite. This implementation does not break the existing 15.4 send syscall (that frames / forms the 15.4 packet). Moreover, a new 15.4 `radio_tx_direct` test was implemented.

Both test cases exhibited the expected behavior when observed in Wireshark (both in sending and edge cases of attempting to send a buffer greater than the 15.4 max buffer size).

### TODO or Help Wanted

When refactoring this, I had a comment / question regarding the  `perform_tx_sync` function. This function checks for the case when the pending_tx is Empty. In this case, the function returns without an error. I preserved this behavior in this PR, but wanted to draw attention to this. In my opinion, this seems to be the correct behavior, as not having a pending_tx does not imply that an error occurred when sending. I'm curious if others agree or think this should be handled differently.

### Documentation Updated

To my knowledge, there is not documentation on the 15.4 specific syscalls. Please let me know if there is somewhere I should update this documentation.

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
