### PR TITLE
IEEE802.15.4: Remove dyn, change to template

### DIFF
--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -144,6 +144,11 @@ type SHT3xSensor = components::sht3x::SHT3xComponentType<
 type TemperatureDriver = components::temperature::TemperatureComponentType<SHT3xSensor>;
 type HumidityDriver = components::humidity::HumidityComponentType<SHT3xSensor>;
 
+type Ieee802154Driver = components::ieee802154::Ieee802154ComponentType<
+    nrf52840::ieee802154_radio::Radio<'static>,
+    nrf52840::aes::AesECB<'static>,
+>;
+
 /// Supported drivers by the platform
 pub struct Platform {
     ble_radio: &'static capsules_extra::ble_advertising_driver::BLE<
@@ -154,7 +159,7 @@ pub struct Platform {
             nrf52::rtc::Rtc<'static>,
         >,
     >,
-    ieee802154_radio: &'static capsules_extra::ieee802154::RadioDriver<'static>,
+    ieee802154_radio: &'static Ieee802154Driver,
     console: &'static capsules_core::console::Console<'static>,
     proximity: &'static capsules_extra::proximity::ProximitySensor<'static>,
     gpio: &'static capsules_core::gpio::GPIO<'static, nrf52::gpio::GPIOPin<'static>>,

--- a/boards/components/src/ieee802154.rs
+++ b/boards/components/src/ieee802154.rs
@@ -54,6 +54,8 @@ macro_rules! mux_aes128ccm_component_static {
     };};
 }
 
+pub type MuxAes128ccmComponentType<A> = MuxAES128CCM<'static, A>;
+
 pub struct MuxAes128ccmComponent<A: 'static + AES128<'static> + AES128Ctr + AES128CBC + AES128ECB> {
     aes: &'static A,
 }
@@ -95,10 +97,39 @@ macro_rules! ieee802154_component_static {
             >
         );
 
-        let mux_mac = kernel::static_buf!(capsules_extra::ieee802154::virtual_mac::MuxMac<'static>);
-        let mac_user =
-            kernel::static_buf!(capsules_extra::ieee802154::virtual_mac::MacUser<'static>);
-        let radio_driver = kernel::static_buf!(capsules_extra::ieee802154::RadioDriver<'static>);
+        let mux_mac = kernel::static_buf!(
+            capsules_extra::ieee802154::virtual_mac::MuxMac<
+                'static,
+                capsules_extra::ieee802154::framer::Framer<
+                    'static,
+                    capsules_extra::ieee802154::mac::AwakeMac<'static, $R>,
+                    capsules_core::virtualizers::virtual_aes_ccm::VirtualAES128CCM<'static, $A>,
+                >,
+            >
+        );
+        let mac_user = kernel::static_buf!(
+            capsules_extra::ieee802154::virtual_mac::MacUser<
+                'static,
+                capsules_extra::ieee802154::framer::Framer<
+                    'static,
+                    capsules_extra::ieee802154::mac::AwakeMac<'static, $R>,
+                    capsules_core::virtualizers::virtual_aes_ccm::VirtualAES128CCM<'static, $A>,
+                >,
+            >
+        );
+        let radio_driver = kernel::static_buf!(
+            capsules_extra::ieee802154::RadioDriver<
+                'static,
+                capsules_extra::ieee802154::virtual_mac::MacUser<
+                    'static,
+                    capsules_extra::ieee802154::framer::Framer<
+                        'static,
+                        capsules_extra::ieee802154::mac::AwakeMac<'static, $R>,
+                        capsules_core::virtualizers::virtual_aes_ccm::VirtualAES128CCM<'static, $A>,
+                    >,
+                >,
+            >
+        );
 
         let radio_buf = kernel::static_buf!([u8; kernel::hil::radio::MAX_BUF_SIZE]);
         let radio_rx_buf = kernel::static_buf!([u8; kernel::hil::radio::MAX_BUF_SIZE]);
@@ -119,6 +150,24 @@ macro_rules! ieee802154_component_static {
         )
     };};
 }
+
+pub type Ieee802154ComponentType<R, A> = capsules_extra::ieee802154::RadioDriver<
+    'static,
+    capsules_extra::ieee802154::virtual_mac::MacUser<
+        'static,
+        capsules_extra::ieee802154::framer::Framer<
+            'static,
+            capsules_extra::ieee802154::mac::AwakeMac<'static, R>,
+            capsules_core::virtualizers::virtual_aes_ccm::VirtualAES128CCM<'static, A>,
+        >,
+    >,
+>;
+
+pub type Ieee802154ComponentMacDeviceType<R, A> = capsules_extra::ieee802154::framer::Framer<
+    'static,
+    capsules_extra::ieee802154::mac::AwakeMac<'static, R>,
+    capsules_core::virtualizers::virtual_aes_ccm::VirtualAES128CCM<'static, A>,
+>;
 
 pub struct Ieee802154Component<
     R: 'static + kernel::hil::radio::Radio<'static>,
@@ -176,17 +225,64 @@ impl<
                 capsules_core::virtualizers::virtual_aes_ccm::VirtualAES128CCM<'static, A>,
             >,
         >,
-        &'static mut MaybeUninit<capsules_extra::ieee802154::virtual_mac::MuxMac<'static>>,
-        &'static mut MaybeUninit<capsules_extra::ieee802154::virtual_mac::MacUser<'static>>,
-        &'static mut MaybeUninit<capsules_extra::ieee802154::RadioDriver<'static>>,
+        &'static mut MaybeUninit<
+            capsules_extra::ieee802154::virtual_mac::MuxMac<
+                'static,
+                capsules_extra::ieee802154::framer::Framer<
+                    'static,
+                    AwakeMac<'static, R>,
+                    capsules_core::virtualizers::virtual_aes_ccm::VirtualAES128CCM<'static, A>,
+                >,
+            >,
+        >,
+        &'static mut MaybeUninit<
+            capsules_extra::ieee802154::virtual_mac::MacUser<
+                'static,
+                capsules_extra::ieee802154::framer::Framer<
+                    'static,
+                    AwakeMac<'static, R>,
+                    capsules_core::virtualizers::virtual_aes_ccm::VirtualAES128CCM<'static, A>,
+                >,
+            >,
+        >,
+        &'static mut MaybeUninit<
+            capsules_extra::ieee802154::RadioDriver<
+                'static,
+                capsules_extra::ieee802154::virtual_mac::MacUser<
+                    'static,
+                    capsules_extra::ieee802154::framer::Framer<
+                        'static,
+                        AwakeMac<'static, R>,
+                        capsules_core::virtualizers::virtual_aes_ccm::VirtualAES128CCM<'static, A>,
+                    >,
+                >,
+            >,
+        >,
         &'static mut MaybeUninit<[u8; radio::MAX_BUF_SIZE]>,
         &'static mut MaybeUninit<[u8; radio::MAX_BUF_SIZE]>,
         &'static mut MaybeUninit<[u8; CRYPT_SIZE]>,
         &'static mut MaybeUninit<[u8; radio::MAX_BUF_SIZE]>,
     );
     type Output = (
-        &'static capsules_extra::ieee802154::RadioDriver<'static>,
-        &'static capsules_extra::ieee802154::virtual_mac::MuxMac<'static>,
+        &'static capsules_extra::ieee802154::RadioDriver<
+            'static,
+            capsules_extra::ieee802154::virtual_mac::MacUser<
+                'static,
+                capsules_extra::ieee802154::framer::Framer<
+                    'static,
+                    AwakeMac<'static, R>,
+                    capsules_core::virtualizers::virtual_aes_ccm::VirtualAES128CCM<'static, A>,
+                >,
+            >,
+        >,
+        &'static capsules_extra::ieee802154::virtual_mac::MuxMac<
+            'static,
+            capsules_extra::ieee802154::framer::Framer<
+                'static,
+                AwakeMac<'static, R>,
+                capsules_core::virtualizers::virtual_aes_ccm::VirtualAES128CCM<'static, A>,
+            >,
+        >,
     );
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -115,6 +115,13 @@ type SI7021Sensor = components::si7021::SI7021ComponentType<
 type TemperatureDriver = components::temperature::TemperatureComponentType<SI7021Sensor>;
 type HumidityDriver = components::humidity::HumidityComponentType<SI7021Sensor>;
 
+type Rf233 = capsules_extra::rf233::RF233<
+    'static,
+    VirtualSpiMasterDevice<'static, sam4l::spi::SpiHw<'static>>,
+>;
+type Ieee802154MacDevice =
+    components::ieee802154::Ieee802154ComponentMacDeviceType<Rf233, sam4l::aes::Aes<'static>>;
+
 struct Imix {
     pconsole: &'static capsules_core::process_console::ProcessConsole<
         'static,
@@ -705,7 +712,10 @@ pub unsafe fn main() {
         local_ip_ifaces,
         mux_alarm,
     )
-    .finalize(components::udp_mux_component_static!(sam4l::ast::Ast));
+    .finalize(components::udp_mux_component_static!(
+        sam4l::ast::Ast,
+        Ieee802154MacDevice
+    ));
 
     // UDP driver initialization happens here
     let udp_driver = components::udp_driver::UDPDriverComponent::new(

--- a/boards/imix/src/test/icmp_lowpan_test.rs
+++ b/boards/imix/src/test/icmp_lowpan_test.rs
@@ -67,8 +67,18 @@ pub struct LowpanICMPTest<'a, A: time::Alarm<'a>> {
     net_cap: &'static NetworkCapability,
 }
 
+type Rf233 = capsules_extra::rf233::RF233<
+    'static,
+    capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<
+        'static,
+        sam4l::spi::SpiHw<'static>,
+    >,
+>;
+type Ieee802154MacDevice =
+    components::ieee802154::Ieee802154ComponentMacDeviceType<Rf233, sam4l::aes::Aes<'static>>;
+
 pub unsafe fn run(
-    mux_mac: &'static capsules_extra::ieee802154::virtual_mac::MuxMac<'static>,
+    mux_mac: &'static capsules_extra::ieee802154::virtual_mac::MuxMac<'static, Ieee802154MacDevice>,
     mux_alarm: &'static MuxAlarm<'static, sam4l::ast::Ast>,
 ) {
     let create_cap = create_capability!(NetworkCapabilityCreationCapability);
@@ -81,7 +91,7 @@ pub unsafe fn run(
         IpVisibilityCapability::new(&create_cap)
     );
     let radio_mac = static_init!(
-        capsules_extra::ieee802154::virtual_mac::MacUser<'static>,
+        capsules_extra::ieee802154::virtual_mac::MacUser<'static, Ieee802154MacDevice>,
         capsules_extra::ieee802154::virtual_mac::MacUser::new(mux_mac)
     );
     mux_mac.add_user(radio_mac);

--- a/boards/makepython-nrf52840/src/main.rs
+++ b/boards/makepython-nrf52840/src/main.rs
@@ -113,6 +113,15 @@ type ScreenDriver = components::screen::ScreenSharedComponentType<Screen>;
 
 type Checker = kernel::process_checker::basic::AppCheckerNames<'static, fn(&'static str) -> u32>;
 
+type Ieee802154MacDevice = components::ieee802154::Ieee802154ComponentMacDeviceType<
+    nrf52840::ieee802154_radio::Radio<'static>,
+    nrf52840::aes::AesECB<'static>,
+>;
+type Ieee802154Driver = components::ieee802154::Ieee802154ComponentType<
+    nrf52840::ieee802154_radio::Radio<'static>,
+    nrf52840::aes::AesECB<'static>,
+>;
+
 /// Supported drivers by the platform
 pub struct Platform {
     ble_radio: &'static capsules_extra::ble_advertising_driver::BLE<
@@ -123,7 +132,7 @@ pub struct Platform {
             nrf52::rtc::Rtc<'static>,
         >,
     >,
-    ieee802154_radio: &'static capsules_extra::ieee802154::RadioDriver<'static>,
+    ieee802154_radio: &'static Ieee802154Driver,
     console: &'static capsules_core::console::Console<'static>,
     pconsole: &'static capsules_core::process_console::ProcessConsole<
         'static,
@@ -605,7 +614,10 @@ pub unsafe fn start() -> (
         local_ip_ifaces,
         mux_alarm,
     )
-    .finalize(components::udp_mux_component_static!(nrf52840::rtc::Rtc));
+    .finalize(components::udp_mux_component_static!(
+        nrf52840::rtc::Rtc,
+        Ieee802154MacDevice
+    ));
 
     // UDP driver initialization happens here
     let udp_driver = components::udp_driver::UDPDriverComponent::new(

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -119,6 +119,14 @@ type HTS221Sensor = components::hts221::Hts221ComponentType<
 >;
 type TemperatureDriver = components::temperature::TemperatureComponentType<HTS221Sensor>;
 type HumidityDriver = components::humidity::HumidityComponentType<HTS221Sensor>;
+type Ieee802154MacDevice = components::ieee802154::Ieee802154ComponentMacDeviceType<
+    nrf52840::ieee802154_radio::Radio<'static>,
+    nrf52840::aes::AesECB<'static>,
+>;
+type Ieee802154Driver = components::ieee802154::Ieee802154ComponentType<
+    nrf52840::ieee802154_radio::Radio<'static>,
+    nrf52840::aes::AesECB<'static>,
+>;
 
 /// Supported drivers by the platform
 pub struct Platform {
@@ -130,7 +138,7 @@ pub struct Platform {
             nrf52::rtc::Rtc<'static>,
         >,
     >,
-    ieee802154_radio: &'static capsules_extra::ieee802154::RadioDriver<'static>,
+    ieee802154_radio: &'static Ieee802154Driver,
     console: &'static capsules_core::console::Console<'static>,
     pconsole: &'static capsules_core::process_console::ProcessConsole<
         'static,
@@ -577,7 +585,10 @@ pub unsafe fn start() -> (
         local_ip_ifaces,
         mux_alarm,
     )
-    .finalize(components::udp_mux_component_static!(nrf52840::rtc::Rtc));
+    .finalize(components::udp_mux_component_static!(
+        nrf52840::rtc::Rtc,
+        Ieee802154MacDevice
+    ));
 
     // UDP driver initialization happens here
     let udp_driver = components::udp_driver::UDPDriverComponent::new(

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -80,6 +80,11 @@ pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
 type TemperatureDriver =
     components::temperature::TemperatureComponentType<nrf52840::temperature::Temp<'static>>;
 
+type Ieee802154Driver = components::ieee802154::Ieee802154ComponentType<
+    nrf52840::ieee802154_radio::Radio<'static>,
+    nrf52840::aes::AesECB<'static>,
+>;
+
 /// Supported drivers by the platform
 pub struct Platform {
     ble_radio: &'static capsules_extra::ble_advertising_driver::BLE<
@@ -87,7 +92,7 @@ pub struct Platform {
         nrf52840::ble_radio::Radio<'static>,
         VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
     >,
-    ieee802154_radio: &'static capsules_extra::ieee802154::RadioDriver<'static>,
+    ieee802154_radio: &'static Ieee802154Driver,
     button: &'static capsules_core::button::Button<'static, nrf52840::gpio::GPIOPin<'static>>,
     pconsole: &'static capsules_core::process_console::ProcessConsole<
         'static,

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -185,6 +185,15 @@ type KVDriver = components::kv::KVDriverComponentType<VirtualKVPermissions>;
 type TemperatureDriver =
     components::temperature::TemperatureComponentType<nrf52840::temperature::Temp<'static>>;
 
+type Ieee802154MacDevice = components::ieee802154::Ieee802154ComponentMacDeviceType<
+    nrf52840::ieee802154_radio::Radio<'static>,
+    nrf52840::aes::AesECB<'static>,
+>;
+type Ieee802154Driver = components::ieee802154::Ieee802154ComponentType<
+    nrf52840::ieee802154_radio::Radio<'static>,
+    nrf52840::aes::AesECB<'static>,
+>;
+
 /// Supported drivers by the platform
 pub struct Platform {
     ble_radio: &'static capsules_extra::ble_advertising_driver::BLE<
@@ -192,7 +201,7 @@ pub struct Platform {
         nrf52840::ble_radio::Radio<'static>,
         VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
     >,
-    ieee802154_radio: &'static capsules_extra::ieee802154::RadioDriver<'static>,
+    ieee802154_radio: &'static Ieee802154Driver,
     button: &'static capsules_core::button::Button<'static, nrf52840::gpio::GPIOPin<'static>>,
     pconsole: &'static capsules_core::process_console::ProcessConsole<
         'static,
@@ -598,7 +607,10 @@ pub unsafe fn start() -> (
         local_ip_ifaces,
         mux_alarm,
     )
-    .finalize(components::udp_mux_component_static!(nrf52840::rtc::Rtc));
+    .finalize(components::udp_mux_component_static!(
+        nrf52840::rtc::Rtc,
+        Ieee802154MacDevice
+    ));
 
     // UDP driver initialization happens here
     let udp_driver = components::udp_driver::UDPDriverComponent::new(

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -91,6 +91,11 @@ pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
 type TemperatureDriver =
     components::temperature::TemperatureComponentType<nrf52840::temperature::Temp<'static>>;
 
+type Ieee802154Driver = components::ieee802154::Ieee802154ComponentType<
+    nrf52840::ieee802154_radio::Radio<'static>,
+    nrf52840::aes::AesECB<'static>,
+>;
+
 /// Supported drivers by the platform
 pub struct Platform {
     ble_radio: &'static capsules_extra::ble_advertising_driver::BLE<
@@ -98,7 +103,7 @@ pub struct Platform {
         nrf52840::ble_radio::Radio<'static>,
         VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
     >,
-    ieee802154_radio: &'static capsules_extra::ieee802154::RadioDriver<'static>,
+    ieee802154_radio: &'static Ieee802154Driver,
     button: &'static capsules_core::button::Button<'static, nrf52840::gpio::GPIOPin<'static>>,
     console: &'static capsules_core::console::Console<'static>,
     gpio: &'static capsules_core::gpio::GPIO<'static, nrf52840::gpio::GPIOPin<'static>>,

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -79,6 +79,11 @@ type Bmp280Sensor = components::bmp280::Bmp280ComponentType<
 >;
 type TemperatureDriver = components::temperature::TemperatureComponentType<Bmp280Sensor>;
 
+type Ieee802154Driver = components::ieee802154::Ieee802154ComponentType<
+    nrf52840::ieee802154_radio::Radio<'static>,
+    nrf52840::aes::AesECB<'static>,
+>;
+
 /// Supported drivers by the platform
 pub struct Platform {
     temperature: &'static TemperatureDriver,
@@ -87,7 +92,7 @@ pub struct Platform {
         nrf52840::ble_radio::Radio<'static>,
         VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
     >,
-    ieee802154_radio: &'static capsules_extra::ieee802154::RadioDriver<'static>,
+    ieee802154_radio: &'static Ieee802154Driver,
     button: &'static capsules_core::button::Button<'static, nrf52840::gpio::GPIOPin<'static>>,
     pconsole: &'static capsules_core::process_console::ProcessConsole<
         'static,

--- a/capsules/extra/src/ieee802154/virtual_mac.rs
+++ b/capsules/extra/src/ieee802154/virtual_mac.rs
@@ -44,13 +44,13 @@ use kernel::ErrorCode;
 /// IEE 802.15.4 MAC device muxer that keeps a list of MAC users and sequences
 /// any pending transmission requests. Any received frames from the underlying
 /// MAC device are sent to all users.
-pub struct MuxMac<'a> {
-    mac: &'a dyn device::MacDevice<'a>,
-    users: List<'a, MacUser<'a>>,
-    inflight: OptionalCell<&'a MacUser<'a>>,
+pub struct MuxMac<'a, M: device::MacDevice<'a>> {
+    mac: &'a M,
+    users: List<'a, MacUser<'a, M>>,
+    inflight: OptionalCell<&'a MacUser<'a, M>>,
 }
 
-impl device::TxClient for MuxMac<'_> {
+impl<'a, M: device::MacDevice<'a>> device::TxClient for MuxMac<'a, M> {
     fn send_done(&self, spi_buf: &'static mut [u8], acked: bool, result: Result<(), ErrorCode>) {
         self.inflight.take().map(move |user| {
             user.send_done(spi_buf, acked, result);
@@ -59,7 +59,7 @@ impl device::TxClient for MuxMac<'_> {
     }
 }
 
-impl device::RxClient for MuxMac<'_> {
+impl<'a, M: device::MacDevice<'a>> device::RxClient for MuxMac<'a, M> {
     fn receive<'b>(&self, buf: &'b [u8], header: Header<'b>, data_offset: usize, data_len: usize) {
         for user in self.users.iter() {
             user.receive(buf, header, data_offset, data_len);
@@ -67,8 +67,8 @@ impl device::RxClient for MuxMac<'_> {
     }
 }
 
-impl<'a> MuxMac<'a> {
-    pub const fn new(mac: &'a dyn device::MacDevice<'a>) -> MuxMac<'a> {
+impl<'a, M: device::MacDevice<'a>> MuxMac<'a, M> {
+    pub const fn new(mac: &'a M) -> MuxMac<'a, M> {
         MuxMac {
             mac: mac,
             users: List::new(),
@@ -78,13 +78,13 @@ impl<'a> MuxMac<'a> {
 
     /// Registers a MAC user with this MAC mux device. Each MAC user should only
     /// be registered once.
-    pub fn add_user(&self, user: &'a MacUser<'a>) {
+    pub fn add_user(&self, user: &'a MacUser<'a, M>) {
         self.users.push_head(user);
     }
 
     /// Gets the next `MacUser` and operation to perform if an operation is not
     /// already underway.
-    fn get_next_op_if_idle(&self) -> Option<(&'a MacUser<'a>, Op)> {
+    fn get_next_op_if_idle(&self) -> Option<(&'a MacUser<'a, M>, Op)> {
         if self.inflight.is_some() {
             return None;
         }
@@ -107,7 +107,7 @@ impl<'a> MuxMac<'a> {
     /// Performs a non-idle operation on a `MacUser` asynchronously: that is, if the
     /// transmission operation results in immediate failure, then return the
     /// buffer to the `MacUser` via its transmit client.
-    fn perform_op_async(&self, node: &'a MacUser<'a>, op: Op) {
+    fn perform_op_async(&self, node: &'a MacUser<'a, M>, op: Op) {
         if let Op::Transmit(frame) = op {
             match self.mac.transmit(frame) {
                 // If Err, the transmission failed,
@@ -126,7 +126,7 @@ impl<'a> MuxMac<'a> {
     /// the error code and the buffer immediately.
     fn perform_op_sync(
         &self,
-        node: &'a MacUser<'a>,
+        node: &'a MacUser<'a, M>,
         op: Op,
     ) -> Option<Result<(), (ErrorCode, &'static mut [u8])>> {
         if let Op::Transmit(frame) = op {
@@ -162,7 +162,7 @@ impl<'a> MuxMac<'a> {
     /// device but fails immediately, return the buffer synchronously.
     fn do_next_op_sync(
         &self,
-        new_node: &MacUser<'a>,
+        new_node: &MacUser<'a, M>,
     ) -> Option<Result<(), (ErrorCode, &'static mut [u8])>> {
         self.get_next_op_if_idle().and_then(|(node, op)| {
             if core::ptr::eq(node, new_node) {
@@ -192,17 +192,17 @@ enum Op {
 /// all MacUsers because there is only one MAC device. For example, the MAC
 /// device address is shared, so calling `set_address` on one `MacUser` sets the
 /// MAC address for all `MacUser`s.
-pub struct MacUser<'a> {
-    mux: &'a MuxMac<'a>,
+pub struct MacUser<'a, M: device::MacDevice<'a>> {
+    mux: &'a MuxMac<'a, M>,
     operation: MapCell<Op>,
-    next: ListLink<'a, MacUser<'a>>,
+    next: ListLink<'a, MacUser<'a, M>>,
     tx_client: Cell<Option<&'a dyn device::TxClient>>,
     rx_client: Cell<Option<&'a dyn device::RxClient>>,
 }
 
-impl<'a> MacUser<'a> {
-    pub const fn new(mux: &'a MuxMac<'a>) -> MacUser<'a> {
-        MacUser {
+impl<'a, M: device::MacDevice<'a>> MacUser<'a, M> {
+    pub const fn new(mux: &'a MuxMac<'a, M>) -> Self {
+        Self {
             mux: mux,
             operation: MapCell::new(Op::Idle),
             next: ListLink::empty(),
@@ -212,7 +212,7 @@ impl<'a> MacUser<'a> {
     }
 }
 
-impl MacUser<'_> {
+impl<'a, M: device::MacDevice<'a>> MacUser<'a, M> {
     fn send_done(&self, spi_buf: &'static mut [u8], acked: bool, result: Result<(), ErrorCode>) {
         self.tx_client
             .get()
@@ -226,13 +226,13 @@ impl MacUser<'_> {
     }
 }
 
-impl<'a> ListNode<'a, MacUser<'a>> for MacUser<'a> {
-    fn next(&'a self) -> &'a ListLink<'a, MacUser<'a>> {
+impl<'a, M: device::MacDevice<'a>> ListNode<'a, MacUser<'a, M>> for MacUser<'a, M> {
+    fn next(&'a self) -> &'a ListLink<'a, MacUser<'a, M>> {
         &self.next
     }
 }
 
-impl<'a> device::MacDevice<'a> for MacUser<'a> {
+impl<'a, M: device::MacDevice<'a>> device::MacDevice<'a> for MacUser<'a, M> {
     fn set_transmit_client(&self, client: &'a dyn device::TxClient) {
         self.tx_client.set(Some(client));
     }


### PR DESCRIPTION
### Pull Request Overview

Remove `dyn` from RadioDriver.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
