### PR TITLE
process_console: display completion code as isize

### DIFF
--- a/kernel/src/process_printer.rs
+++ b/kernel/src/process_printer.rs
@@ -145,7 +145,7 @@ impl ProcessPrinter for ProcessPrinterText {
 
         let _ = match process.get_completion_code() {
             Some(opt_cc) => match opt_cc {
-                Some(cc) => bww.write_fmt(format_args!(" Completion Code: {}\r\n", cc)),
+                Some(cc) => bww.write_fmt(format_args!(" Completion Code: {}\r\n", cc as isize)),
                 None => bww.write_str(" Completion Code: Faulted\r\n"),
             },
             None => bww.write_str(" Completion Code: None\r\n"),


### PR DESCRIPTION
### Pull Request Overview

Typically errors are negative, so having the pconsole display completion codes as `isize` makes them easier to read.


### Testing Strategy

Easier to do now that libtock-c apps exist when main returns.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
