### PR TITLE
kernel: process_std: easy copy `make debug`

### DIFF
--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -1312,8 +1312,9 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
 
                 let _ = writer.write_fmt(format_args!(
                     "\
-                    \r\nTo debug libtock-c apps, run `make debug RAM_START={:#x}`\
-                    \r\nFLASH_INIT={:#x} in the app's folder and open the .lst file.\r\n\r\n",
+                    \r\nTo debug libtock-c apps, run\
+                    \r\n`make debug RAM_START={:#x} FLASH_INIT={:#x}`\
+                    \r\nin the app's folder and open the .lst file.\r\n\r\n",
                     sram_start, flash_init_fn
                 ));
             }


### PR DESCRIPTION
### Pull Request Overview

It seems like this got changed somewhere along the way. The "`" ended up in the middle of the command. This makes it much easier to copy and paste when debugging.


### Testing Strategy

n/a


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
