### PR TITLE
arch/rv32i: separate kernel and app trap handlers; specify trap handler "interface"

### DIFF
--- a/arch/rv32i/src/lib.rs
+++ b/arch/rv32i/src/lib.rs
@@ -160,24 +160,12 @@ pub enum PermissionMode {
 /// some platforms have added more bits to the `mtvec` register.
 ///
 /// The trap handler is called on exceptions and for interrupts.
-pub unsafe fn configure_trap_handler(mode: PermissionMode) {
-    match mode {
-        PermissionMode::Machine => csr::CSR.mtvec.write(
-            csr::mtvec::mtvec::trap_addr.val(_start_trap as usize >> 2)
-                + csr::mtvec::mtvec::mode::CLEAR,
-        ),
-        PermissionMode::Supervisor => csr::CSR.stvec.write(
-            csr::stvec::stvec::trap_addr.val(_start_trap as usize >> 2)
-                + csr::stvec::stvec::mode::CLEAR,
-        ),
-        PermissionMode::User => csr::CSR.utvec.write(
-            csr::utvec::utvec::trap_addr.val(_start_trap as usize >> 2)
-                + csr::utvec::utvec::mode::CLEAR,
-        ),
-        PermissionMode::Reserved => {
-            // TODO some sort of error handling?
-        }
-    }
+pub unsafe fn configure_trap_handler() {
+    csr::CSR.mtvec.write(
+        csr::mtvec::mtvec::trap_addr.val(_start_trap as usize >> 2)
+            + csr::mtvec::mtvec::mode::CLEAR,
+    );
+    csr::CSR.mscratch.set(0);
 }
 
 // Mock implementation for tests on Travis-CI.
@@ -188,20 +176,7 @@ pub extern "C" fn _start_trap() {
 
 #[cfg(all(target_arch = "riscv32", target_os = "none"))]
 extern "C" {
-    /// This is the trap handler function. This code is called on all traps,
-    /// including interrupts, exceptions, and system calls from applications.
-    ///
-    /// Tock uses only the single trap handler, and does not use any vectored
-    /// interrupts or other exception handling. The trap handler has to determine
-    /// why the trap handler was called, and respond accordingly. Generally, there
-    /// are two reasons the trap handler gets called: an interrupt occurred or an
-    /// application called a syscall.
-    ///
-    /// In the case of an interrupt while the kernel was executing we only need to
-    /// save the kernel registers and then run whatever interrupt handling code we
-    /// need to. If the trap happens while and application was executing, we have to
-    /// save the application state and then resume the `switch_to()` function to
-    /// correctly return back to the kernel.
+    /// TODO
     pub fn _start_trap();
 }
 
@@ -210,48 +185,74 @@ global_asm!(
     "
             .section .riscv.trap, \"ax\"
             .globl _start_trap
+            .globl _start_kernel_trap
           _start_trap:
-
-            // The first thing we have to do is determine if we came from user
-            // mode or kernel mode, as we need to save state and proceed
-            // differently. We cannot, however, use any registers because we do
-            // not want to lose their contents. So, we rely on `mscratch`. If
-            // mscratch is 0, then we came from the kernel. If it is >0, then it
-            // contains the kernel's stack pointer and we came from an app.
+            // This is the global trap handler. By default, Tock expects this
+            // trap handler to be registered at all times, and that all traps
+            // and interrupts occurring in all modes of execution (M-, S-, and
+            // U-mode) will cause this trap handler to be executed.
             //
-            // We use the csrrw instruction to save the current stack pointer
-            // so we can retrieve it if necessary.
+            // Its behavior is well defined. It will:
             //
-            // If we could enter this trap handler twice (for example,
-            // handling an interrupt while an exception is being
-            // handled), storing a non-zero value in mscratch
-            // temporarily could cause a race condition similar to the
-            // one of PR 2308[1].
-            // However, as indicated in section 3.1.6.1 of the RISC-V
-            // Privileged Spec[2], MIE will be set to 0 when taking a
-            // trap into machine mode. Therefore, this can only happen
-            // when causing an exception in the trap handler itself.
+            // 1. atomically swap t0 and the mscratch CSR,
+            // 2. execute the default kernel trap handler if t0 now contains `0`
+            //    (meaning that the mscratch CSR contained `0` before entering
+            //    this trap handler),
+            // 3. otherwise, jump to the address loaded into t0.
             //
-            // [1] https://github.com/tock/tock/pull/2308
-            // [2] https://github.com/riscv/riscv-isa-manual/releases/download/draft-20201222-42dc13a/riscv-privileged.pdf
-            csrrw sp, 0x340, sp // CSR=0x340=mscratch
-            bnez  sp, 300f      // If sp != 0 then we must have come from an app.
+            // No registers other than t0 and the mscratch CSR are to be
+            // clobberd before contiuing execution at the address loaded into
+            // the mscratch CSR or the _start_kernel_trap kernel trap handler.
+            // Execution with these second-stage trap handlers must continue
+            // in the same trap handler context as originally invoked by the
+            // trap (e.g., the global trap handler will not execute an mret
+            // instruction). It will not modify CSRs that contain information
+            // on the trap source or the system state prior to entering the
+            // trap handler.
+            //
+            // When a custom trap handler is registered in `mscratch`, the
+            // custom handler is responsible for restoring the kernel trap
+            // handler (by setting mscratch=0) before returning to kernel
+            // execution from the trap handler context.
+            //
+            // If a board or chip must, for whichever reason, use a different
+            // global trap handler, it should abide to the above contract and
+            // emulate its behavior for all traps and interrupts that are
+            // required to be handled by the respective kernel or other trap
+            // handler as registered in mscratch.
+            //
+            // For instance, a chip that does not support non-vectored trap
+            // handlers can register a vectored trap handler that routes each
+            // trap source to this global trap handler.
+            //
+            // Alternatively, a board can be allowed to ignore certain traps or
+            // interrupts, some or all of the time, provided they are not vital
+            // to Tock's execution. These boards may choose to register an
+            // alternative handler for some or all trap sources. When this
+            // alternative handler is invoked, it may, for instance, choose to
+            // ignore a certain trap, access global state (subject to
+            // synchronization), etc. It must still abide to the contract as
+            // stated above.
 
+            // Atomically swap t0 and mscratch:
+            csrrw t0, mscratch, t0
 
-        // _from_kernel:
-            // Swap back the zero value for the stack pointer in mscratch
-            csrrw sp, 0x340, sp // CSR=0x340=mscratch
+            // If mscratch contained 0, invoke the kernel trap handler.
+            beq   t0, x0, _start_kernel_trap
 
-            // Now, since we want to use the stack to save kernel registers, we
+            // Else, invoke the trap handler at the address that was loaded in
+            // the mscratch CSR.
+            jr    t0
+
+          _start_kernel_trap:
+
+            // The global trap handler has swapped t0 into mscratch. We can thus
+            // freely clobber t0 without losing any information.
+            //
+            // Since we want to use the stack to save kernel registers, we
             // first need to make sure that the trap wasn't the result of a
             // stack overflow, in which case we can't use the current stack
-            // pointer. We also, however, cannot modify any of the current
-            // registers until we save them, and we cannot save them to the
-            // stack until we know the stack is valid. So, we use the mscratch
-            // trick again to get one register we can use.
-
-            // Save t0's contents to mscratch
-            csrw 0x340, t0                      // CSR=0x340=mscratch
+            // pointer. Use t0 as a scratch register:
 
             // Load the address of the bottom of the stack (`_sstack`) into our
             // newly freed-up t0 register.
@@ -260,7 +261,7 @@ global_asm!(
             // Compare the kernel stack pointer to the bottom of the stack. If
             // the stack pointer is above the bottom of the stack, then continue
             // handling the fault as normal.
-            bgtu sp, t0, 100f                   // branch if sp > t0
+            bgtu sp, t0, 200f                   // branch if sp > t0
 
             // If we get here, then we did encounter a stack overflow. We are
             // going to panic at this point, but for that to work we need a
@@ -269,12 +270,10 @@ global_asm!(
             // top of the original stack.
             la sp, {estack}                     // sp = _estack
 
+        200: // _start_kernel_trap_continue
 
-        100: // _from_kernel_continue
-
-            // Restore t0, and make sure mscratch is set back to 0 (our flag
-            // tracking that the kernel is executing).
-            csrrw t0, 0x340, zero // t0=mscratch, mscratch=0
+            // Restore t0. We reset mscratch to 0 (kernel trap handler mode)
+            csrrw t0, mscratch, 0
 
             // Make room for the caller saved registers we need to restore after
             // running any trap handler code.
@@ -328,114 +327,7 @@ global_asm!(
             // mepc and execution proceeds from there. Since we did not modify
             // mepc we will return to where the exception occurred.
             mret
-
-
-
-            // Handle entering the trap handler from an app differently.
-        300: // _from_app
-
-            // At this point all we know is that we entered the trap handler
-            // from an app. We don't know _why_ we got a trap, it could be from
-            // an interrupt, syscall, or fault (or maybe something else).
-            // Therefore we have to be very careful not to overwrite any
-            // registers before we have saved them.
-            //
-            // We ideally want to save registers in the per-process stored state
-            // struct. However, we don't have a pointer to that yet, and we need
-            // to use a temporary register to get that address. So, we save s0
-            // to the kernel stack before we can it to the proper spot.
-            sw   s0, 0*4(sp)
-
-            // Ideally it would be better to save all of the app registers once
-            // we return back to the `switch_to_process()` code. However, we
-            // also potentially need to disable an interrupt in case the app was
-            // interrupted, so it is safer to just immediately save all of the
-            // app registers.
-            //
-            // We do this by retrieving the stored state pointer from the kernel
-            // stack and storing the necessary values in it.
-            lw   s0,  1*4(sp)  // Load the stored state pointer into s0.
-            sw   x1,  0*4(s0)  // ra
-            sw   x3,  2*4(s0)  // gp
-            sw   x4,  3*4(s0)  // tp
-            sw   x5,  4*4(s0)  // t0
-            sw   x6,  5*4(s0)  // t1
-            sw   x7,  6*4(s0)  // t2
-            sw   x9,  8*4(s0)  // s1
-            sw   x10, 9*4(s0)  // a0
-            sw   x11, 10*4(s0) // a1
-            sw   x12, 11*4(s0) // a2
-            sw   x13, 12*4(s0) // a3
-            sw   x14, 13*4(s0) // a4
-            sw   x15, 14*4(s0) // a5
-            sw   x16, 15*4(s0) // a6
-            sw   x17, 16*4(s0) // a7
-            sw   x18, 17*4(s0) // s2
-            sw   x19, 18*4(s0) // s3
-            sw   x20, 19*4(s0) // s4
-            sw   x21, 20*4(s0) // s5
-            sw   x22, 21*4(s0) // s6
-            sw   x23, 22*4(s0) // s7
-            sw   x24, 23*4(s0) // s8
-            sw   x25, 24*4(s0) // s9
-            sw   x26, 25*4(s0) // s10
-            sw   x27, 26*4(s0) // s11
-            sw   x28, 27*4(s0) // t3
-            sw   x29, 28*4(s0) // t4
-            sw   x30, 29*4(s0) // t5
-            sw   x31, 30*4(s0) // t6
-            // Now retrieve the original value of s0 and save that as well.
-            lw   t0,  0*4(sp)
-            sw   t0,  7*4(s0)  // s0,fp
-
-            // We also need to store the app stack pointer, mcause, and mepc. We
-            // need to store mcause because we use that to determine why the app
-            // stopped executing and returned to the kernel. We store mepc
-            // because it is where we need to return to in the app at some
-            // point. We need to store mtval in case the app faulted and we need
-            // mtval to help with debugging.
-            csrr t0, 0x340    // CSR=0x340=mscratch
-            sw   t0, 1*4(s0)  // Save the app sp to the stored state struct
-            csrr t0, 0x341    // CSR=0x341=mepc
-            sw   t0, 31*4(s0) // Save the PC to the stored state struct
-            csrr t0, 0x343    // CSR=0x343=mtval
-            sw   t0, 33*4(s0) // Save mtval to the stored state struct
-
-            // Save mcause last, as we depend on it being loaded in t0 below
-            csrr t0, 0x342    // CSR=0x342=mcause
-            sw   t0, 32*4(s0) // Save mcause to the stored state struct, leave in t0
-
-            // Now we need to check if this was an interrupt, and if it was,
-            // then we need to disable the interrupt before returning from this
-            // trap handler so that it does not fire again. If mcause is greater
-            // than or equal to zero this was not an interrupt (i.e. the most
-            // significant bit is not 1).
-            bge  t0, zero, 200f
-            // Copy mcause into a0 and then call the interrupt disable function.
-            mv   a0, t0
-            jal  ra, _disable_interrupt_trap_rust_from_app
-
-        200: // _from_app_continue
-            // Now determine the address of _return_to_kernel and resume the
-            // context switching code. We need to load _return_to_kernel into
-            // mepc so we can use it to return to the context switch code.
-            lw   t0, 2*4(sp)  // Load _return_to_kernel into t0.
-            csrw 0x341, t0    // CSR=0x341=mepc
-
-            // Ensure that mscratch is 0. This makes sure that we know that on
-            // a future trap that we came from the kernel.
-            csrw 0x340, zero  // CSR=0x340=mscratch
-
-            // Need to set mstatus.MPP to 0b11 so that we stay in machine mode.
-            csrr t0, 0x300    // CSR=0x300=mstatus
-            li   t1, 0x1800   // Load 0b11 to the MPP bits location in t1
-            or   t0, t0, t1   // Set the MPP bits to one
-            csrw 0x300, t0    // CSR=0x300=mstatus
-
-            // Use mret to exit the trap handler and return to the context
-            // switching code.
-            mret
-        ",
+    ",
     estack = sym _estack,
     sstack = sym _sstack,
 );

--- a/boards/esp32-c3-devkitM-1/src/main.rs
+++ b/boards/esp32-c3-devkitM-1/src/main.rs
@@ -144,7 +144,7 @@ unsafe fn setup() -> (
     use esp32_c3::sysreg::{CpuFrequency, PllFrequency};
 
     // only machine mode
-    rv32i::configure_trap_handler(rv32i::PermissionMode::Machine);
+    rv32i::configure_trap_handler();
 
     let peripherals = static_init!(Esp32C3DefaultPeripherals, Esp32C3DefaultPeripherals::new());
 

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -185,7 +185,7 @@ unsafe fn start() -> (
     &'static e310_g002::chip::E310x<'static, E310G002DefaultPeripherals<'static>>,
 ) {
     // only machine mode
-    rv32i::configure_trap_handler(rv32i::PermissionMode::Machine);
+    rv32i::configure_trap_handler();
 
     let peripherals = static_init!(
         E310G002DefaultPeripherals,

--- a/boards/hifive_inventor/src/main.rs
+++ b/boards/hifive_inventor/src/main.rs
@@ -129,7 +129,7 @@ unsafe fn start() -> (
     &'static e310_g003::chip::E310x<'static, E310G003DefaultPeripherals<'static>>,
 ) {
     // only machine mode
-    rv32i::configure_trap_handler(rv32i::PermissionMode::Machine);
+    rv32i::configure_trap_handler();
 
     let peripherals = static_init!(
         E310G003DefaultPeripherals,

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -262,7 +262,7 @@ pub unsafe fn main() {
     // ---------- BASIC INITIALIZATION ----------
 
     // Basic setup of the riscv platform.
-    rv32i::configure_trap_handler(rv32i::PermissionMode::Machine);
+    rv32i::configure_trap_handler();
 
     // Set up memory protection immediately after setting the trap handler, to
     // ensure that much of the board initialization routine runs with PMP kernel

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -261,7 +261,7 @@ pub unsafe fn main() {
     // ---------- BASIC INITIALIZATION ----------
 
     // Basic setup of the riscv platform.
-    rv32i::configure_trap_handler(rv32i::PermissionMode::Machine);
+    rv32i::configure_trap_handler();
 
     // Set up memory protection immediately after setting the trap handler, to
     // ensure that much of the board initialization routine runs with PMP kernel

--- a/boards/qemu_rv32_virt/src/main.rs
+++ b/boards/qemu_rv32_virt/src/main.rs
@@ -175,7 +175,7 @@ pub unsafe fn main() {
     // ---------- BASIC INITIALIZATION -----------
 
     // Basic setup of the RISC-V IMAC platform
-    rv32i::configure_trap_handler(rv32i::PermissionMode::Machine);
+    rv32i::configure_trap_handler();
 
     // Set up memory protection immediately after setting the trap handler, to
     // ensure that much of the board initialization routine runs with ePMP

--- a/boards/redboard_redv/src/main.rs
+++ b/boards/redboard_redv/src/main.rs
@@ -133,7 +133,7 @@ impl KernelResources<e310_g002::chip::E310x<'static, E310G002DefaultPeripherals<
 #[no_mangle]
 pub unsafe fn main() {
     // only machine mode
-    rv32i::configure_trap_handler(rv32i::PermissionMode::Machine);
+    rv32i::configure_trap_handler();
 
     let peripherals = static_init!(
         E310G002DefaultPeripherals,

--- a/boards/swervolf/src/main.rs
+++ b/boards/swervolf/src/main.rs
@@ -113,7 +113,7 @@ impl KernelResources<swervolf_eh1::chip::SweRVolf<'static, SweRVolfDefaultPeriph
 #[no_mangle]
 pub unsafe fn main() {
     // only machine mode
-    rv32i::configure_trap_handler(rv32i::PermissionMode::Machine);
+    rv32i::configure_trap_handler();
 
     let peripherals = static_init!(
         SweRVolfDefaultPeripherals,

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -430,7 +430,8 @@ pub unsafe extern "C" fn disable_interrupt_trap_handler(mcause_val: u32) {
 pub unsafe fn configure_trap_handler() {
     // The Ibex CPU does not support non-vectored trap entries.
     CSR.mtvec
-        .write(mtvec::trap_addr.val(_start_trap_vectored as usize >> 2) + mtvec::mode::Vectored)
+        .write(mtvec::trap_addr.val(_start_trap_vectored as usize >> 2) + mtvec::mode::Vectored);
+    CSR.mscratch.set(0);
 }
 
 // Mock implementation for crate tests that does not include the section


### PR DESCRIPTION
### Pull Request Overview

This is a second, slightly less elegant but working(?) stab at #3847.

Tock's core kernel design permits process implementations with system call interfaces other than the ones shipped upstream in the `arch/cortex-m` and `arch/rv32i` crates. However, in practice, the `UserspaceKernelBoundary` implementation for RV32I has always been tightly coupled to the generic kernel RISC-V trap handler. This has made it difficult to build an alternative process implementation (e.g., as part of [Encapsulated Functions](https://dl.acm.org/doi/10.1145/3625275.3625397)), while reusing much of Tock's RISC-V implementation.

By defining an "interface" that the global trap handler exposes (i.e., specifying how a custom trap handler can be registered, and which registers get clobbered), we allow foreign process implementations to hook into the `rv32i` arch crate's assembly, and can move all process-specific assembly into `SysCall::switch_to_process`. All process-specific logic is now contained in one assembly block that can be read top-to-bottom. The global trap handler no longer relies on the stack layout of that function, or other data structures in `syscall.rs`.

Because the kernel trap handler no longer contains any application logic and expects the app to set its own trap handler, implementing a new syscall ABI becomes as simple as temporarily swapping out the trap handler.

<details>
  <summary>In-depth Walkthrough</summary>

Currently context switches on RISC-V work as follows:

0. For traps arriving in kernel mode, the kernel trap handler does an intricate dance to compare the `mscratch` value to `0` without clobbering any registers, and then takes a `_from_kernel` branch in `_start_trap`.
1. When switching to an app we disable interrupts and then swap the current kernel stack pointer into `mscratch`, making it non-zero. We re-enable interrupts when switching into user-mode.
2. When a trap arrives during app execution we perform the same dance as in `0.`, but then branch into `_from_app`.
3. The `_from_app` branch saves all of the application state through two levels of pointer indirection:
    - reading the stack pointer from `mscratch`
    - dereferencing a pointer on said stack to a struct compatible in layout to the `Riscv32iStoredState`

   We then proceed to dump all registers into this state struct, and other core-local state (CSRs) onto known offsets from the stack pointer

    _This hard-codes many assumptions about Tock's process model, and may preclude implementations that want additional state stored, or do not want to buy into storing the whole register file (e.g., for single function invocations as with Encapsulated Functions, or cooperative userspace apps)._
4. `_from_app` proceeds to switch to Machine mode.
   
    _This may be undesirable for process models which defer interrupt handling, e.g., for cooperative apps._
6. `_from_app` returns from the interrupt handler to an address stored at a well-known offset on the stack.

As is obvious from the above, using this trap handler has a significant amount of "buy in" concerning both the process execution semantics and the layout of stack pointer and the necessary `Riscv32iStoredState`.

I propose changing the routing of traps caught while executing processes by using `mscratch` not to branch between "kernel" and "app" trap handlers, but between "kernel" and "custom" trap handlers. If `mscratch != 0`, the global trap handler simply jumps to the address contained in this CSR. This is a minor architectural change and mirrors the semantics of our current approach, but has some advantages:

- straightforward and top-down context-switch assembly, with everything except 2. in one block:
  1. prepare the CPU for context switch by
      a. storing clobbered registers on the stack,
      b. storing the stack pointer in a static variable,
      b. disabling interrupts,
      d. registering the app trap handler in `mscratch`
      f. switching to userspace, re-enabling interrupts
  2. on trap,
      a. swap mscratch and `t0`,
      b. check if `t0 == 0`, in that case execute the kernel trap handler,
      c. if not, jump to the address in `t0` (`_start_app_trap`) entry.
  3. `_start_app_trap` stores the CPU state and register file in the `Riscv32iStoredState` and stack layout defined in the very same file / assembly block.
    a. if this trap was caused by an interrupt, disable it.
  4. return from the trap handler, by loading the `_return_to_kernel` symbol directly below via an immediate, and jumping to it via `mret`
  5. restoring clobbered registers
- no hard-coded assumptions about process semantics, stored state, stack layout, etc.
- a couple less memory loads / stored, replaced through immediate loads (`la`, expanding to `auipc` or `lui` and `addi`)
- potential for more optimizations: the linear execution through the assembly allows more efficient register clobbering / reuse

Drawbacks:
- we can no longer keep the kernel stack pointer in `mscratch` and need to save it to a static variable. This does not change the net load/stores requires, at previously we'd store and load the address for continuing the `switch_to_process` assembly after the trap handler on the stack.

</details>

In short, this change increases cohesion and reduces coupling in the `rv32i` crate, and allows foreign process implementations.

### Testing Strategy

This pull request was tested by CI and needs some careful reviews.

This change-set modifies more parts about the `switch_to_process` assembly than I'd initially hoped for. For instance, it changes the registers that some assembly arguments are loaded in, to reduce the number of clobbers and/or moves that we have. I tried picking these changes apart into multiple, individually working commits, but that turned out to be very tricky.

I performed an initial, very unscientific analysis of how the old assembly compares to the new one in terms of instruction count. This is going through an end-to-end context switch, starting and ending with the inline assembly in `switch_to_process`, excluding all user-mode instructions:
- new:
  - Integer / CSR / always skipped branch instructions: 26
  - Loads / Stores: 79
  - Branching behavior:
    1. Jump to userspace `mepc` as part of `mret`
    2. Jump to global trap handler on trap
    3. Jump to `_start_app_trap` handler
    4. Either branch if trap not caused by interrupt, or jump to interrupt disable routine
    5. Jump back to `switch_to_process` when exiting trap handler with `mret`
- current:
  - Integer / CSR / always skipped branch instructions: 25
  - Loads / Stores: 81
  - Branching behavior:
    1. Jump to userspace `mepc` as part of `mret`
    2. Jump to global trap handler on trap
    3. Branch to app-part of global trap handler
    4. Either branch if trap not caused by interrupt, or jump to interrupt disable routine
    5. Jump back to `switch_to_process` when exiting trap handler with `mret`

### TODO or Help Wanted

One issue on RISC-V is the presence of trap & interrupt handlers for different modes. A RISC-V platform with supervisor- and/or user-mode will feature the `stvec` and `utvec` CSRs. These will not be consulted for disabled interrupts / trap routing, however, and many more of Tock's assumptions, at least around the `SysCall` implementation in `rv32i`, would break if these were used by enabling interrupts in the `sie` / `uie` CSRs.

Because we have unclear semantics around them, I documented that right now, we expect all traps to be routed to the global trap handler. I removed the `PermissionMode` argument for `rv32i::configure_trap_handler`, as only the `Machine` branch was ever used.

Looking forward to other's opinions on this!

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
