### PR TITLE
Fix conditional compilation #[cfg( matches for arch & target_os

### DIFF
--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -384,12 +384,12 @@ pub unsafe fn print_cortexm_state(writer: &mut dyn Write) {
 // ARM assembly since it will not compile.
 ///////////////////////////////////////////////////////////////////
 
-#[cfg(not(any(target_arch = "arm", target_os = "none")))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 pub unsafe extern "C" fn unhandled_interrupt() {
     unimplemented!()
 }
 
-#[cfg(not(any(target_arch = "arm", target_os = "none")))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 pub unsafe extern "C" fn initialize_ram_jump_to_main() {
     unimplemented!()
 }

--- a/arch/cortex-m/src/scb.rs
+++ b/arch/cortex-m/src/scb.rs
@@ -316,7 +316,7 @@ pub unsafe fn disable_fpca() {
 }
 
 // Mock implementation for tests on Travis-CI.
-#[cfg(not(any(target_arch = "arm", target_os = "none")))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 pub unsafe fn disable_fpca() {
     // Dummy read register, to satisfy the `Readable` trait import on
     // non-ARM platforms.

--- a/arch/cortex-m/src/support.rs
+++ b/arch/cortex-m/src/support.rs
@@ -40,19 +40,19 @@ where
 }
 
 // Mock implementations for tests on Travis-CI.
-#[cfg(not(any(target_arch = "arm", target_os = "none")))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 /// NOP instruction (mock)
 pub fn nop() {
     unimplemented!()
 }
 
-#[cfg(not(any(target_arch = "arm", target_os = "none")))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 /// WFI instruction (mock)
 pub unsafe fn wfi() {
     unimplemented!()
 }
 
-#[cfg(not(any(target_arch = "arm", target_os = "none")))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 pub unsafe fn atomic<F, R>(_f: F) -> R
 where
     F: FnOnce() -> R,

--- a/arch/cortex-m0/src/lib.rs
+++ b/arch/cortex-m0/src/lib.rs
@@ -72,7 +72,7 @@ unsafe extern "C" fn hard_fault_handler_kernel(faulting_stack: *mut u32) -> ! {
 }
 
 // Mock implementation for tests on Travis-CI.
-#[cfg(not(any(target_arch = "arm", target_os = "none")))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 unsafe extern "C" fn generic_isr() {
     unimplemented!()
 }
@@ -167,7 +167,7 @@ global_asm!(
 );
 
 // Mock implementation for tests on Travis-CI.
-#[cfg(not(any(target_arch = "arm", target_os = "none")))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 unsafe extern "C" fn systick_handler_m0() {
     unimplemented!()
 }
@@ -210,7 +210,7 @@ global_asm!(
 );
 
 // Mock implementation for tests on Travis-CI.
-#[cfg(not(any(target_arch = "arm", target_os = "none")))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 unsafe extern "C" fn svc_handler() {
     unimplemented!()
 }
@@ -249,7 +249,7 @@ svc_handler:
 );
 
 // Mock implementation for tests on Travis-CI.
-#[cfg(not(any(target_arch = "arm", target_os = "none")))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 unsafe extern "C" fn hard_fault_handler() {
     unimplemented!()
 }
@@ -365,7 +365,7 @@ impl cortexm::CortexMVariant for CortexM0 {
     const HARD_FAULT_HANDLER: unsafe extern "C" fn() = hard_fault_handler;
 
     // Mock implementation for tests on Travis-CI.
-    #[cfg(not(any(target_arch = "arm", target_os = "none")))]
+    #[cfg(not(all(target_arch = "arm", target_os = "none")))]
     unsafe fn switch_to_user(
         _user_stack: *const usize,
         _process_regs: &mut [usize; 8],

--- a/arch/cortex-m0p/src/lib.rs
+++ b/arch/cortex-m0p/src/lib.rs
@@ -31,7 +31,7 @@ pub use cortexm::CortexMVariant;
 use cortexm0::CortexM0;
 
 // Mock implementation for tests on Travis-CI.
-#[cfg(not(any(target_arch = "arm", target_os = "none")))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 pub unsafe extern "C" fn svc_handler_m0p() {
     unimplemented!()
 }
@@ -96,7 +96,7 @@ impl cortexm::CortexMVariant for CortexM0P {
         CortexM0::switch_to_user(user_stack, process_regs)
     }
 
-    #[cfg(not(any(target_arch = "arm", target_os = "none")))]
+    #[cfg(not(all(target_arch = "arm", target_os = "none")))]
     unsafe fn switch_to_user(
         _user_stack: *const usize,
         _process_regs: &mut [usize; 8],

--- a/arch/cortex-m3/src/lib.rs
+++ b/arch/cortex-m3/src/lib.rs
@@ -39,7 +39,7 @@ impl cortexm::CortexMVariant for CortexM3 {
         cortexv7m::switch_to_user_arm_v7m(user_stack, process_regs)
     }
 
-    #[cfg(not(any(target_arch = "arm", target_os = "none")))]
+    #[cfg(not(all(target_arch = "arm", target_os = "none")))]
     unsafe fn switch_to_user(
         _user_stack: *const usize,
         _process_regs: &mut [usize; 8],

--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -41,7 +41,7 @@ impl cortexm::CortexMVariant for CortexM4 {
         cortexv7m::switch_to_user_arm_v7m(user_stack, process_regs)
     }
 
-    #[cfg(not(any(target_arch = "arm", target_os = "none")))]
+    #[cfg(not(all(target_arch = "arm", target_os = "none")))]
     unsafe fn switch_to_user(
         _user_stack: *const usize,
         _process_regs: &mut [usize; 8],

--- a/arch/cortex-m7/src/lib.rs
+++ b/arch/cortex-m7/src/lib.rs
@@ -41,7 +41,7 @@ impl cortexm::CortexMVariant for CortexM7 {
         cortexv7m::switch_to_user_arm_v7m(user_stack, process_regs)
     }
 
-    #[cfg(not(any(target_arch = "arm", target_os = "none")))]
+    #[cfg(not(all(target_arch = "arm", target_os = "none")))]
     unsafe fn switch_to_user(
         _user_stack: *const usize,
         _process_regs: &mut [usize; 8],

--- a/arch/cortex-v7m/src/lib.rs
+++ b/arch/cortex-v7m/src/lib.rs
@@ -561,22 +561,22 @@ pub fn ipsr_isr_number_to_str(isr_number: usize) -> &'static str {
 // ARM assembly since it will not compile.
 ///////////////////////////////////////////////////////////////////
 
-#[cfg(not(any(target_arch = "arm", target_os = "none")))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 pub unsafe extern "C" fn systick_handler_arm_v7m() {
     unimplemented!()
 }
 
-#[cfg(not(any(target_arch = "arm", target_os = "none")))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 pub unsafe extern "C" fn svc_handler_arm_v7m() {
     unimplemented!()
 }
 
-#[cfg(not(any(target_arch = "arm", target_os = "none")))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 pub unsafe extern "C" fn generic_isr_arm_v7m() {
     unimplemented!()
 }
 
-#[cfg(not(any(target_arch = "arm", target_os = "none")))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 pub unsafe extern "C" fn switch_to_user_arm_v7m(
     _user_stack: *const u8,
     _process_regs: &mut [usize; 8],
@@ -584,7 +584,7 @@ pub unsafe extern "C" fn switch_to_user_arm_v7m(
     unimplemented!()
 }
 
-#[cfg(not(any(target_arch = "arm", target_os = "none")))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 pub unsafe extern "C" fn hard_fault_handler_arm_v7m() {
     unimplemented!()
 }

--- a/arch/riscv/src/csr/mcycle.rs
+++ b/arch/riscv/src/csr/mcycle.rs
@@ -13,7 +13,7 @@ register_bitfields![usize,
 
 // `mcycleh` is the higher XLEN bits of the number of elapsed cycles.
 // It does not exist on riscv64.
-#[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+#[cfg(not(target_arch = "riscv64"))]
 register_bitfields![usize,
     pub mcycleh [
         mcycleh OFFSET(0) NUMBITS(crate::XLEN) []

--- a/arch/riscv/src/csr/minstret.rs
+++ b/arch/riscv/src/csr/minstret.rs
@@ -13,7 +13,7 @@ register_bitfields![usize,
 
 // `minstreth` is the higher XLEN bits of the number of elapsed instructions.
 // It does not exist on riscv64.
-#[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+#[cfg(not(target_arch = "riscv64"))]
 register_bitfields![usize,
     pub minstreth [
         minstreth OFFSET(0) NUMBITS(crate::XLEN) []

--- a/arch/riscv/src/csr/mod.rs
+++ b/arch/riscv/src/csr/mod.rs
@@ -43,38 +43,38 @@ pub mod utvec;
 // something (as it would be if compiled for a host OS).
 
 pub struct CSR {
-    #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+    #[cfg(not(target_arch = "riscv64"))]
     pub minstreth: ReadWriteRiscvCsr<usize, minstret::minstreth::Register, MINSTRETH>,
     pub minstret: ReadWriteRiscvCsr<usize, minstret::minstret::Register, MINSTRET>,
 
-    #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+    #[cfg(not(target_arch = "riscv64"))]
     pub mcycleh: ReadWriteRiscvCsr<usize, mcycle::mcycleh::Register, MCYCLEH>,
     pub mcycle: ReadWriteRiscvCsr<usize, mcycle::mcycle::Register, MCYCLE>,
 
-    #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+    #[cfg(not(target_arch = "riscv64"))]
     pub pmpcfg0: ReadWriteRiscvCsr<usize, pmpconfig::pmpcfg::Register, PMPCFG0>,
-    #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+    #[cfg(not(target_arch = "riscv64"))]
     pub pmpcfg1: ReadWriteRiscvCsr<usize, pmpconfig::pmpcfg::Register, PMPCFG1>,
     pub pmpcfg2: ReadWriteRiscvCsr<usize, pmpconfig::pmpcfg::Register, PMPCFG2>,
-    #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+    #[cfg(not(target_arch = "riscv64"))]
     pub pmpcfg3: ReadWriteRiscvCsr<usize, pmpconfig::pmpcfg::Register, PMPCFG3>,
     pub pmpcfg4: ReadWriteRiscvCsr<usize, pmpconfig::pmpcfg::Register, PMPCFG4>,
-    #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+    #[cfg(not(target_arch = "riscv64"))]
     pub pmpcfg5: ReadWriteRiscvCsr<usize, pmpconfig::pmpcfg::Register, PMPCFG5>,
     pub pmpcfg6: ReadWriteRiscvCsr<usize, pmpconfig::pmpcfg::Register, PMPCFG6>,
-    #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+    #[cfg(not(target_arch = "riscv64"))]
     pub pmpcfg7: ReadWriteRiscvCsr<usize, pmpconfig::pmpcfg::Register, PMPCFG7>,
     pub pmpcfg8: ReadWriteRiscvCsr<usize, pmpconfig::pmpcfg::Register, PMPCFG8>,
-    #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+    #[cfg(not(target_arch = "riscv64"))]
     pub pmpcfg9: ReadWriteRiscvCsr<usize, pmpconfig::pmpcfg::Register, PMPCFG9>,
     pub pmpcfg10: ReadWriteRiscvCsr<usize, pmpconfig::pmpcfg::Register, PMPCFG10>,
-    #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+    #[cfg(not(target_arch = "riscv64"))]
     pub pmpcfg11: ReadWriteRiscvCsr<usize, pmpconfig::pmpcfg::Register, PMPCFG11>,
     pub pmpcfg12: ReadWriteRiscvCsr<usize, pmpconfig::pmpcfg::Register, PMPCFG12>,
-    #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+    #[cfg(not(target_arch = "riscv64"))]
     pub pmpcfg13: ReadWriteRiscvCsr<usize, pmpconfig::pmpcfg::Register, PMPCFG13>,
     pub pmpcfg14: ReadWriteRiscvCsr<usize, pmpconfig::pmpcfg::Register, PMPCFG14>,
-    #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+    #[cfg(not(target_arch = "riscv64"))]
     pub pmpcfg15: ReadWriteRiscvCsr<usize, pmpconfig::pmpcfg::Register, PMPCFG15>,
 
     pub pmpaddr0: ReadWriteRiscvCsr<usize, pmpaddr::pmpaddr::Register, PMPADDR0>,
@@ -152,7 +152,7 @@ pub struct CSR {
     pub mstatus: ReadWriteRiscvCsr<usize, mstatus::mstatus::Register, MSTATUS>,
 
     pub mseccfg: ReadWriteRiscvCsr<usize, mseccfg::mseccfg::Register, MSECCFG>,
-    #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+    #[cfg(not(target_arch = "riscv64"))]
     pub mseccfgh: ReadWriteRiscvCsr<usize, mseccfg::mseccfgh::Register, MSECCFGH>,
 
     pub utvec: ReadWriteRiscvCsr<usize, utvec::utvec::Register, UTVEC>,
@@ -161,37 +161,37 @@ pub struct CSR {
 
 // Define the "addresses" of each CSR register.
 pub const CSR: &CSR = &CSR {
-    #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+    #[cfg(not(target_arch = "riscv64"))]
     minstreth: ReadWriteRiscvCsr::new(),
     minstret: ReadWriteRiscvCsr::new(),
 
-    #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+    #[cfg(not(target_arch = "riscv64"))]
     mcycleh: ReadWriteRiscvCsr::new(),
     mcycle: ReadWriteRiscvCsr::new(),
 
     pmpcfg0: ReadWriteRiscvCsr::new(),
-    #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+    #[cfg(not(target_arch = "riscv64"))]
     pmpcfg1: ReadWriteRiscvCsr::new(),
     pmpcfg2: ReadWriteRiscvCsr::new(),
-    #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+    #[cfg(not(target_arch = "riscv64"))]
     pmpcfg3: ReadWriteRiscvCsr::new(),
     pmpcfg4: ReadWriteRiscvCsr::new(),
-    #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+    #[cfg(not(target_arch = "riscv64"))]
     pmpcfg5: ReadWriteRiscvCsr::new(),
     pmpcfg6: ReadWriteRiscvCsr::new(),
-    #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+    #[cfg(not(target_arch = "riscv64"))]
     pmpcfg7: ReadWriteRiscvCsr::new(),
     pmpcfg8: ReadWriteRiscvCsr::new(),
-    #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+    #[cfg(not(target_arch = "riscv64"))]
     pmpcfg9: ReadWriteRiscvCsr::new(),
     pmpcfg10: ReadWriteRiscvCsr::new(),
-    #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+    #[cfg(not(target_arch = "riscv64"))]
     pmpcfg11: ReadWriteRiscvCsr::new(),
     pmpcfg12: ReadWriteRiscvCsr::new(),
-    #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+    #[cfg(not(target_arch = "riscv64"))]
     pmpcfg13: ReadWriteRiscvCsr::new(),
     pmpcfg14: ReadWriteRiscvCsr::new(),
-    #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+    #[cfg(not(target_arch = "riscv64"))]
     pmpcfg15: ReadWriteRiscvCsr::new(),
 
     pmpaddr0: ReadWriteRiscvCsr::new(),
@@ -269,7 +269,7 @@ pub const CSR: &CSR = &CSR {
     mstatus: ReadWriteRiscvCsr::new(),
 
     mseccfg: ReadWriteRiscvCsr::new(),
-    #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+    #[cfg(not(target_arch = "riscv64"))]
     mseccfgh: ReadWriteRiscvCsr::new(),
 
     utvec: ReadWriteRiscvCsr::new(),
@@ -278,7 +278,7 @@ pub const CSR: &CSR = &CSR {
 
 impl CSR {
     // resets the cycle counter to 0
-    #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+    #[cfg(not(target_arch = "riscv64"))]
     pub fn reset_cycle_counter(&self) {
         // Write lower first so that we don't overflow before writing the upper
         CSR.mcycle.write(mcycle::mcycle::mcycle.val(0));
@@ -292,7 +292,7 @@ impl CSR {
     }
 
     // reads the cycle counter
-    #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+    #[cfg(not(target_arch = "riscv64"))]
     pub fn read_cycle_counter(&self) -> u64 {
         let (mut top, mut bot): (usize, usize);
 
@@ -319,28 +319,28 @@ impl CSR {
     pub fn pmpconfig_get(&self, index: usize) -> usize {
         match index {
             0 => self.pmpcfg0.get(),
-            #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+            #[cfg(not(target_arch = "riscv64"))]
             1 => self.pmpcfg1.get(),
             2 => self.pmpcfg2.get(),
-            #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+            #[cfg(not(target_arch = "riscv64"))]
             3 => self.pmpcfg3.get(),
             4 => self.pmpcfg4.get(),
-            #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+            #[cfg(not(target_arch = "riscv64"))]
             5 => self.pmpcfg5.get(),
             6 => self.pmpcfg6.get(),
-            #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+            #[cfg(not(target_arch = "riscv64"))]
             7 => self.pmpcfg7.get(),
             8 => self.pmpcfg8.get(),
-            #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+            #[cfg(not(target_arch = "riscv64"))]
             9 => self.pmpcfg9.get(),
             10 => self.pmpcfg10.get(),
-            #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+            #[cfg(not(target_arch = "riscv64"))]
             11 => self.pmpcfg11.get(),
             12 => self.pmpcfg12.get(),
-            #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+            #[cfg(not(target_arch = "riscv64"))]
             13 => self.pmpcfg13.get(),
             14 => self.pmpcfg14.get(),
-            #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+            #[cfg(not(target_arch = "riscv64"))]
             15 => self.pmpcfg15.get(),
             _ => unreachable!(),
         }
@@ -349,28 +349,28 @@ impl CSR {
     pub fn pmpconfig_set(&self, index: usize, value: usize) {
         match index {
             0 => self.pmpcfg0.set(value),
-            #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+            #[cfg(not(target_arch = "riscv64"))]
             1 => self.pmpcfg1.set(value),
             2 => self.pmpcfg2.set(value),
-            #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+            #[cfg(not(target_arch = "riscv64"))]
             3 => self.pmpcfg3.set(value),
             4 => self.pmpcfg4.set(value),
-            #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+            #[cfg(not(target_arch = "riscv64"))]
             5 => self.pmpcfg5.set(value),
             6 => self.pmpcfg6.set(value),
-            #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+            #[cfg(not(target_arch = "riscv64"))]
             7 => self.pmpcfg7.set(value),
             8 => self.pmpcfg8.set(value),
-            #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+            #[cfg(not(target_arch = "riscv64"))]
             9 => self.pmpcfg9.set(value),
             10 => self.pmpcfg10.set(value),
-            #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+            #[cfg(not(target_arch = "riscv64"))]
             11 => self.pmpcfg11.set(value),
             12 => self.pmpcfg12.set(value),
-            #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+            #[cfg(not(target_arch = "riscv64"))]
             13 => self.pmpcfg13.set(value),
             14 => self.pmpcfg14.set(value),
-            #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+            #[cfg(not(target_arch = "riscv64"))]
             15 => self.pmpcfg15.set(value),
             _ => unreachable!(),
         }
@@ -383,28 +383,28 @@ impl CSR {
     ) {
         match index {
             0 => self.pmpcfg0.modify(field),
-            #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+            #[cfg(not(target_arch = "riscv64"))]
             1 => self.pmpcfg1.modify(field),
             2 => self.pmpcfg2.modify(field),
-            #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+            #[cfg(not(target_arch = "riscv64"))]
             3 => self.pmpcfg3.modify(field),
             4 => self.pmpcfg4.modify(field),
-            #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+            #[cfg(not(target_arch = "riscv64"))]
             5 => self.pmpcfg5.modify(field),
             6 => self.pmpcfg6.modify(field),
-            #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+            #[cfg(not(target_arch = "riscv64"))]
             7 => self.pmpcfg7.modify(field),
             8 => self.pmpcfg8.modify(field),
-            #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+            #[cfg(not(target_arch = "riscv64"))]
             9 => self.pmpcfg9.modify(field),
             10 => self.pmpcfg10.modify(field),
-            #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+            #[cfg(not(target_arch = "riscv64"))]
             11 => self.pmpcfg11.modify(field),
             12 => self.pmpcfg12.modify(field),
-            #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+            #[cfg(not(target_arch = "riscv64"))]
             13 => self.pmpcfg13.modify(field),
             14 => self.pmpcfg14.modify(field),
-            #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+            #[cfg(not(target_arch = "riscv64"))]
             15 => self.pmpcfg15.modify(field),
             _ => unreachable!(),
         }

--- a/arch/riscv/src/csr/mseccfg.rs
+++ b/arch/riscv/src/csr/mseccfg.rs
@@ -5,7 +5,7 @@
 use kernel::utilities::registers::register_bitfields;
 
 // Default to 32 bit if compiling for debug/testing.
-#[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+#[cfg(not(target_arch = "riscv64"))]
 register_bitfields![usize,
     pub mseccfg [
         mml OFFSET(0) NUMBITS(1) [],
@@ -14,7 +14,7 @@ register_bitfields![usize,
     ]
 ];
 
-#[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+#[cfg(not(target_arch = "riscv64"))]
 register_bitfields![usize,
     pub mseccfgh [
         // This isn't a real entry, it just avoids compilation errors

--- a/arch/riscv/src/csr/pmpaddr.rs
+++ b/arch/riscv/src/csr/pmpaddr.rs
@@ -5,7 +5,7 @@
 use kernel::utilities::registers::register_bitfields;
 
 // Default to 32 bit if compiling for debug/testing.
-#[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+#[cfg(not(target_arch = "riscv64"))]
 register_bitfields![usize,
     pub pmpaddr [
         addr OFFSET(0) NUMBITS(crate::XLEN) []

--- a/arch/riscv/src/csr/pmpconfig.rs
+++ b/arch/riscv/src/csr/pmpconfig.rs
@@ -5,7 +5,10 @@
 use kernel::utilities::registers::register_bitfields;
 
 // Default to 32 bit if compiling for debug/testing.
-#[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
+#[cfg(any(
+    target_arch = "riscv32",
+    all(not(target_arch = "riscv32"), not(target_arch = "riscv64"))
+))]
 register_bitfields![usize,
     pub pmpcfg [
         r0 OFFSET(0) NUMBITS(1) [],

--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -17,5 +17,8 @@ pub const XLEN: usize = 64;
 
 // Default to 32 bit if no architecture is specified of if this is being
 // compiled for testing on a different architecture.
-#[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64", target_os = "none")))]
+#[cfg(not(all(
+    any(target_arch = "riscv32", target_arch = "riscv64"),
+    target_os = "none"
+)))]
 pub const XLEN: usize = 32;

--- a/arch/rv32i/src/lib.rs
+++ b/arch/rv32i/src/lib.rs
@@ -181,7 +181,7 @@ pub unsafe fn configure_trap_handler(mode: PermissionMode) {
 }
 
 // Mock implementation for tests on Travis-CI.
-#[cfg(not(any(target_arch = "riscv32", target_os = "none")))]
+#[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
 pub extern "C" fn _start_trap() {
     unimplemented!()
 }
@@ -475,7 +475,7 @@ pub unsafe fn semihost_command(command: usize, arg0: usize, arg1: usize) -> usiz
 }
 
 // Mock implementation for tests on Travis-CI.
-#[cfg(not(any(target_arch = "riscv32", target_os = "none")))]
+#[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
 pub unsafe fn semihost_command(_command: usize, _arg0: usize, _arg1: usize) -> usize {
     unimplemented!()
 }

--- a/arch/rv32i/src/support.rs
+++ b/arch/rv32i/src/support.rs
@@ -51,13 +51,13 @@ where
 }
 
 // Mock implementations for tests on Travis-CI.
-#[cfg(not(any(target_arch = "riscv32", target_os = "none")))]
+#[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
 /// NOP instruction (mock)
 pub fn nop() {
     unimplemented!()
 }
 
-#[cfg(not(any(target_arch = "riscv32", target_os = "none")))]
+#[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
 /// WFI instruction (mock)
 pub unsafe fn wfi() {
     unimplemented!()

--- a/arch/rv32i/src/syscall.rs
+++ b/arch/rv32i/src/syscall.rs
@@ -214,7 +214,7 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
     }
 
     // Mock implementation for tests on Travis-CI.
-    #[cfg(not(any(target_arch = "riscv32", target_os = "none")))]
+    #[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
     unsafe fn switch_to_process(
         &self,
         _accessible_memory_start: *const u8,

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -166,6 +166,7 @@ extern "C" {
     fn jump_to_bootloader();
 }
 
+#[cfg(all(target_arch = "arm", target_os = "none"))]
 global_asm!(
     "
     .section .jump_to_bootloader, \"ax\"

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -176,6 +176,7 @@ extern "C" {
     fn jump_to_bootloader();
 }
 
+#[cfg(all(target_arch = "arm", target_os = "none"))]
 global_asm!(
     "
     .section .jump_to_bootloader, \"ax\"

--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -167,6 +167,7 @@ extern "C" {
     fn jump_to_bootloader();
 }
 
+#[cfg(all(target_arch = "arm", target_os = "none"))]
 global_asm!(
     "
     .section .jump_to_bootloader, \"ax\"

--- a/chips/apollo3/src/lib.rs
+++ b/chips/apollo3/src/lib.rs
@@ -104,7 +104,7 @@ pub unsafe fn init() {
 }
 
 // Mock implementation for tests
-#[cfg(not(any(target_arch = "arm", target_os = "none")))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 pub unsafe fn init() {
     // Prevent unused code warning.
     scb::disable_fpca();

--- a/chips/arty_e21_chip/src/chip.rs
+++ b/chips/arty_e21_chip/src/chip.rs
@@ -134,7 +134,7 @@ impl<'a, I: InterruptService + 'a> ArtyExx<'a, I> {
     }
 
     // Mock implementation for tests on Travis-CI.
-    #[cfg(not(any(target_arch = "riscv32", target_os = "none")))]
+    #[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
     pub unsafe fn configure_trap_handler(&self) {
         unimplemented!()
     }

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -436,7 +436,7 @@ pub unsafe fn configure_trap_handler() {
 // Mock implementation for crate tests that does not include the section
 // specifier, as the test will not use our linker script, and the host
 // compilation environment may not allow the section name.
-#[cfg(not(any(target_arch = "riscv32", target_os = "none")))]
+#[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
 pub extern "C" fn _start_trap_vectored() {
     use core::hint::unreachable_unchecked;
     unsafe {

--- a/chips/esp32-c3/src/chip.rs
+++ b/chips/esp32-c3/src/chip.rs
@@ -288,7 +288,7 @@ pub unsafe fn configure_trap_handler() {
 // Mock implementation for crate tests that does not include the section
 // specifier, as the test will not use our linker script, and the host
 // compilation environment may not allow the section name.
-#[cfg(not(any(target_arch = "riscv32", target_os = "none")))]
+#[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
 pub extern "C" fn _start_trap_vectored() {
     use core::hint::unreachable_unchecked;
     unsafe {

--- a/chips/litex_vexriscv/src/interrupt_controller.rs
+++ b/chips/litex_vexriscv/src/interrupt_controller.rs
@@ -102,7 +102,7 @@ mod vexriscv_irq_raw {
     /// defined in litex/soc/cores/cpu/vexriscv/csr-defs.h
     const CSR_IRQ_PENDING: usize = 0xFC0;
 
-    #[cfg(not(any(target_arch = "riscv32", target_os = "none")))]
+    #[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
     pub unsafe fn irq_getmask() -> usize {
         0
     }
@@ -117,7 +117,7 @@ mod vexriscv_irq_raw {
         mask
     }
 
-    #[cfg(not(any(target_arch = "riscv32", target_os = "none")))]
+    #[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
     pub unsafe fn irq_setmask(_mask: usize) {}
 
     #[cfg(all(target_arch = "riscv32", target_os = "none"))]
@@ -128,7 +128,7 @@ mod vexriscv_irq_raw {
         asm!("csrw 0xBC0, {mask}", mask = in(reg) mask);
     }
 
-    #[cfg(not(any(target_arch = "riscv32", target_os = "none")))]
+    #[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
     pub unsafe fn irq_pending() -> usize {
         0
     }

--- a/chips/nrf5x/src/gpio.rs
+++ b/chips/nrf5x/src/gpio.rs
@@ -24,7 +24,7 @@ const NUM_GPIOTE: usize = 4;
 const NUM_GPIOTE: usize = 8;
 // Dummy value for testing on Travis-CI.
 #[cfg(all(
-    not(any(target_arch = "arm", target_os = "none")),
+    not(all(target_arch = "arm", target_os = "none")),
     not(feature = "nrf51"),
     not(feature = "nrf52"),
 ))]

--- a/chips/rp2040/src/clocks.rs
+++ b/chips/rp2040/src/clocks.rs
@@ -1059,7 +1059,7 @@ impl Clocks {
         }
     }
 
-    #[cfg(not(any(target_arch = "arm", target_os = "none")))]
+    #[cfg(not(all(target_arch = "arm", target_os = "none")))]
     fn loop_3_cycles(&self, _clock: Clock) {
         unimplemented!()
     }

--- a/chips/stm32f4xx/src/fsmc.rs
+++ b/chips/stm32f4xx/src/fsmc.rs
@@ -266,12 +266,12 @@ impl<'a> Fsmc<'a> {
         }
     }
 
-    #[cfg(not(any(target_arch = "arm", target_os = "none")))]
+    #[cfg(not(all(target_arch = "arm", target_os = "none")))]
     fn write_reg(&self, _bank: FsmcBanks, _addr: u16) {
         unimplemented!()
     }
 
-    #[cfg(not(any(target_arch = "arm", target_os = "none")))]
+    #[cfg(not(all(target_arch = "arm", target_os = "none")))]
     fn write_data(&self, _bank: FsmcBanks, _data: u16) {
         unimplemented!()
     }

--- a/libraries/riscv-csr/src/csr.rs
+++ b/libraries/riscv-csr/src/csr.rs
@@ -171,7 +171,10 @@ impl<R: RegisterLongName, const V: usize> ReadWriteRiscvCsr<usize, R, V> {
     /// instruction where `rs1 = in(reg) value_to_set` and `rd =
     /// out(reg) <return value>`.
     // Mock implementations for tests on Travis-CI.
-    #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64", target_os = "none")))]
+    #[cfg(not(all(
+        any(target_arch = "riscv32", target_arch = "riscv64"),
+        target_os = "none"
+    )))]
     pub fn atomic_replace(&self, _value_to_set: usize) -> usize {
         unimplemented!("RISC-V CSR {} Atomic Read/Write", V)
     }
@@ -204,7 +207,10 @@ impl<R: RegisterLongName, const V: usize> ReadWriteRiscvCsr<usize, R, V> {
     /// instruction where `rs1 = in(reg) bitmask` and `rd = out(reg)
     /// <return value>`.
     // Mock implementations for tests on Travis-CI.
-    #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64", target_os = "none")))]
+    #[cfg(not(all(
+        any(target_arch = "riscv32", target_arch = "riscv64"),
+        target_os = "none"
+    )))]
     pub fn read_and_set_bits(&self, bitmask: usize) -> usize {
         unimplemented!(
             "RISC-V CSR {} Atomic Read and Set Bits, bitmask {:04x}",
@@ -241,7 +247,10 @@ impl<R: RegisterLongName, const V: usize> ReadWriteRiscvCsr<usize, R, V> {
     /// instruction where `rs1 = in(reg) bitmask` and `rd = out(reg)
     /// <return value>`.
     // Mock implementations for tests on Travis-CI.
-    #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64", target_os = "none")))]
+    #[cfg(not(all(
+        any(target_arch = "riscv32", target_arch = "riscv64"),
+        target_os = "none"
+    )))]
     pub fn read_and_clear_bits(&self, bitmask: usize) -> usize {
         unimplemented!(
             "RISC-V CSR {} Atomic Read and Clear Bits, bitmask {:04x}",
@@ -294,7 +303,10 @@ impl<R: RegisterLongName, const V: usize> Readable for ReadWriteRiscvCsr<usize, 
     }
 
     // Mock implementations for tests on Travis-CI.
-    #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64", target_os = "none")))]
+    #[cfg(not(all(
+        any(target_arch = "riscv32", target_arch = "riscv64"),
+        target_os = "none"
+    )))]
     fn get(&self) -> usize {
         unimplemented!("reading RISC-V CSR {}", V)
     }
@@ -316,7 +328,10 @@ impl<R: RegisterLongName, const V: usize> Writeable for ReadWriteRiscvCsr<usize,
         }
     }
 
-    #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64", target_os = "none")))]
+    #[cfg(not(all(
+        any(target_arch = "riscv32", target_arch = "riscv64"),
+        target_os = "none"
+    )))]
     fn set(&self, _val_to_set: usize) {
         unimplemented!("writing RISC-V CSR {}", V)
     }


### PR DESCRIPTION
### Pull Request Overview

Platform-specific code in Tock is commonly placed behind a conditional compilation #[cfg( attribute that specifies that

- the target needs to be of a certain architecture (e.g., riscv32), and
- the target must not be compiled for a known OS (target_os = "none").

This can look like the following:

    #[cfg(all(target_arch = "arm", target_os = "none"))]

For CI, we provide alternative dummy implementations of these respective code snippets, which should be used whenever the above conditions don't hold (so as to not generate code with, e.g, missing function definitions, or conflicting definitions). However, up until now we have mostly relied on matches such as:

    #[cfg(not(any(target_arch = "arm", target_os = "none")))]

This means that the conditional compilation will only generate the respective "dummy" code when both `target_arch` is not "arm", and `target_os` is not "none".

However, when we, for instance, compile the `cortex-m` crate for `riscv32imac-unknown-none-elf`, `target_os` will still be "none". The first `#[cfg(` for `cortex-m` does not match (correct), but we also don't generate the stubs for foreign architectures. The result is a compilation error.

This commit updates all of the CI-specific conditional compilation flags in Tock to negate their actual architecture specific counter parts, such that we generate CI stubs if and only if we're not compiling for the intended target.

This is useful in practice. I'm developing an out of tree crate that pulls in both `cortex-m` and `rv32i` crates. We're fine calling out to stubs for any architecture other than the one we're compiling for, and hide all platform-specific assembly behind `#[cfg(` flags ourselves. This way we get typechecks for all architectures, regardless of our target.

### Testing Strategy

This pull request was tested by compiling. It shouldn't break anything, as we're not touching the actual target cfgs. In the worst case, this should generate duplicate code / function definitions and break during compilation.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`, or~ no updates are required.

### Formatting

- [ ] Ran `make prepush`.
