### PR TITLE
hmac test: fix set_client

### DIFF
--- a/boards/nordic/nrf52840dk/src/test/hmac_sha256_test.rs
+++ b/boards/nordic/nrf52840dk/src/test/hmac_sha256_test.rs
@@ -13,7 +13,6 @@ use capsules_extra::hmac_sha256::HmacSha256Software;
 use capsules_extra::sha256::Sha256Software;
 use capsules_extra::test::hmac_sha256::TestHmacSha256;
 use kernel::deferred_call::DeferredCallClient;
-use kernel::hil::digest::Digest;
 use kernel::static_init;
 
 pub unsafe fn run_hmacsha256() {
@@ -43,7 +42,7 @@ unsafe fn static_init_test_hmacsha256() -> &'static TestHmacSha256 {
         HmacSha256Software<'static, Sha256Software<'static>>,
         HmacSha256Software::new(sha256, sha256_hash_buf, hmacsha256_verify_buf)
     );
-    sha256.set_client(hmacsha256);
+    kernel::hil::digest::Digest::set_client(sha256, hmacsha256);
 
     let test = static_init!(
         TestHmacSha256,

--- a/capsules/extra/src/test/hmac_sha256.rs
+++ b/capsules/extra/src/test/hmac_sha256.rs
@@ -9,7 +9,7 @@ use crate::hmac_sha256::HmacSha256Software;
 use crate::sha256::Sha256Software;
 use kernel::hil::digest;
 use kernel::hil::digest::HmacSha256;
-use kernel::hil::digest::{DigestData, DigestDataHash, DigestHash};
+use kernel::hil::digest::{DigestData, DigestHash};
 use kernel::utilities::cells::TakeCell;
 use kernel::utilities::leasable_buffer::SubSlice;
 use kernel::utilities::leasable_buffer::SubSliceMut;
@@ -41,7 +41,8 @@ impl TestHmacSha256 {
     }
 
     pub fn run(&'static self) {
-        self.hmac.set_client(self);
+        kernel::hil::digest::Digest::set_client(self.hmac, self);
+
         let key = self.key.take().unwrap();
         let r = self.hmac.set_mode_hmacsha256(key);
         if r.is_err() {
@@ -79,5 +80,10 @@ impl digest::ClientHash<32> for TestHmacSha256 {
             }
         }
         kernel::debug!("HMAC-SHA256 matches!");
+    }
+}
+
+impl digest::ClientVerify<32> for TestHmacSha256 {
+    fn verification_done(&self, _result: Result<bool, ErrorCode>, _compare: &'static mut [u8; 32]) {
     }
 }


### PR DESCRIPTION


### Pull Request Overview

Have to make sure to call the Digest set client.


### Testing Strategy

Trying to run the HMAC test.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
