### PR TITLE
kernel: sched: round-robin: handle empty process array

### DIFF
--- a/kernel/src/scheduler/round_robin.rs
+++ b/kernel/src/scheduler/round_robin.rs
@@ -104,6 +104,15 @@ impl<'a, C: Chip> Scheduler<C> for RoundRobinSched<'a> {
                 }
             }
         }
+
+        let next = match next {
+            Some(p) => p,
+            None => {
+                // No processes on the system
+                return SchedulingDecision::TrySleep;
+            }
+        };
+
         let timeslice = if self.last_rescheduled.get() {
             self.time_remaining.get()
         } else {
@@ -113,9 +122,7 @@ impl<'a, C: Chip> Scheduler<C> for RoundRobinSched<'a> {
         };
         assert!(timeslice != 0);
 
-        // next will not be None, because if we make a full iteration and nothing
-        // is ready we return early
-        SchedulingDecision::RunProcess((next.unwrap(), Some(timeslice)))
+        SchedulingDecision::RunProcess((next, Some(timeslice)))
     }
 
     fn result(&self, result: StoppedExecutingReason, execution_time_us: Option<u32>) {


### PR DESCRIPTION
### Pull Request Overview

If there are no processes, next does NOT get set and we get a panic!

Unwrap is bad!






### Testing Strategy

Trying a board with no processes.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
