### PR TITLE
Capsules: AES test: make decryption optional

### DIFF
--- a/boards/imix/src/test/aes_test.rs
+++ b/boards/imix/src/test/aes_test.rs
@@ -53,7 +53,7 @@ unsafe fn static_init_test_ctr(aes: &'static Aes) -> &'static TestAes128Ctr<'sta
 
     static_init!(
         TestAes128Ctr<'static, Aes>,
-        TestAes128Ctr::new(aes, key, iv, source, data)
+        TestAes128Ctr::new(aes, key, iv, source, data, true)
     )
 }
 
@@ -65,6 +65,6 @@ unsafe fn static_init_test_cbc(aes: &'static Aes) -> &'static TestAes128Cbc<'sta
 
     static_init!(
         TestAes128Cbc<'static, Aes>,
-        TestAes128Cbc::new(aes, key, iv, source, data)
+        TestAes128Cbc::new(aes, key, iv, source, data, true)
     )
 }

--- a/boards/nordic/nrf52840dk/src/test/aes_test.rs
+++ b/boards/nordic/nrf52840dk/src/test/aes_test.rs
@@ -63,7 +63,7 @@ unsafe fn static_init_test_ctr(
 
     static_init!(
         TestAes128Ctr<'static, AesECB>,
-        TestAes128Ctr::new(aes, key, iv, source, data)
+        TestAes128Ctr::new(aes, key, iv, source, data, true)
     )
 }
 
@@ -77,7 +77,7 @@ unsafe fn static_init_test_cbc(
 
     static_init!(
         TestAes128Cbc<'static, AesECB>,
-        TestAes128Cbc::new(aes, key, iv, source, data)
+        TestAes128Cbc::new(aes, key, iv, source, data, false)
     )
 }
 
@@ -90,6 +90,6 @@ unsafe fn static_init_test_ecb(
 
     static_init!(
         TestAes128Ecb<'static, AesECB>,
-        TestAes128Ecb::new(aes, key, source, data)
+        TestAes128Ecb::new(aes, key, source, data, false)
     )
 }

--- a/boards/nordic/nrf52dk/src/tests/aes.rs
+++ b/boards/nordic/nrf52dk/src/tests/aes.rs
@@ -30,6 +30,6 @@ unsafe fn static_init_test(
 
     static_init!(
         TestAes128Ctr<'static, AesECB>,
-        TestAes128Ctr::new(aesecb, key, iv, source, data)
+        TestAes128Ctr::new(aesecb, key, iv, source, data, true)
     )
 }

--- a/boards/opentitan/src/tests/aes_test.rs
+++ b/boards/opentitan/src/tests/aes_test.rs
@@ -126,7 +126,7 @@ unsafe fn static_init_test_ecb(aes: &'static Aes) -> &'static TestAes128Ecb<'sta
 
     static_init!(
         TestAes128Ecb<'static, Aes>,
-        TestAes128Ecb::new(aes, key, source, data)
+        TestAes128Ecb::new(aes, key, source, data, true)
     )
 }
 
@@ -160,7 +160,7 @@ unsafe fn static_init_test_cbc(aes: &'static Aes) -> &'static TestAes128Cbc<'sta
 
     static_init!(
         TestAes128Cbc<'static, Aes>,
-        TestAes128Cbc::new(aes, key, iv, source, data)
+        TestAes128Cbc::new(aes, key, iv, source, data, true)
     )
 }
 
@@ -194,6 +194,6 @@ unsafe fn static_init_test_ctr(aes: &'static Aes) -> &'static TestAes128Ctr<'sta
 
     static_init!(
         TestAes128Ctr<'static, Aes>,
-        TestAes128Ctr::new(aes, key, iv, source, data)
+        TestAes128Ctr::new(aes, key, iv, source, data, true)
     )
 }

--- a/capsules/extra/src/test/aes.rs
+++ b/capsules/extra/src/test/aes.rs
@@ -19,6 +19,7 @@ pub struct TestAes128Ctr<'a, A: 'a> {
     iv: TakeCell<'a, [u8]>,
     source: TakeCell<'static, [u8]>,
     data: TakeCell<'static, [u8]>,
+    test_decrypt: bool,
 
     encrypting: Cell<bool>,
     use_source: Cell<bool>,
@@ -31,6 +32,7 @@ pub struct TestAes128Cbc<'a, A: 'a> {
     iv: TakeCell<'a, [u8]>,
     source: TakeCell<'static, [u8]>,
     data: TakeCell<'static, [u8]>,
+    test_decrypt: bool,
 
     encrypting: Cell<bool>,
     use_source: Cell<bool>,
@@ -42,6 +44,7 @@ pub struct TestAes128Ecb<'a, A: 'a> {
     key: TakeCell<'a, [u8]>,
     source: TakeCell<'static, [u8]>,
     data: TakeCell<'static, [u8]>,
+    test_decrypt: bool,
 
     encrypting: Cell<bool>,
     use_source: Cell<bool>,
@@ -56,6 +59,7 @@ impl<'a, A: AES128<'a> + AES128ECB> TestAes128Ecb<'a, A> {
         key: &'a mut [u8],
         source: &'static mut [u8],
         data: &'static mut [u8],
+        test_decrypt: bool,
     ) -> Self {
         TestAes128Ecb {
             aes: aes,
@@ -63,6 +67,7 @@ impl<'a, A: AES128<'a> + AES128ECB> TestAes128Ecb<'a, A> {
             key: TakeCell::new(key),
             source: TakeCell::new(source),
             data: TakeCell::new(data),
+            test_decrypt,
 
             encrypting: Cell::new(true),
             use_source: Cell::new(true),
@@ -146,6 +151,7 @@ impl<'a, A: AES128<'a> + AES128Ctr> TestAes128Ctr<'a, A> {
         iv: &'a mut [u8],
         source: &'static mut [u8],
         data: &'static mut [u8],
+        test_decrypt: bool,
     ) -> Self {
         TestAes128Ctr {
             aes: aes,
@@ -154,6 +160,7 @@ impl<'a, A: AES128<'a> + AES128Ctr> TestAes128Ctr<'a, A> {
             iv: TakeCell::new(iv),
             source: TakeCell::new(source),
             data: TakeCell::new(data),
+            test_decrypt,
 
             encrypting: Cell::new(true),
             use_source: Cell::new(true),
@@ -288,7 +295,7 @@ impl<'a, A: AES128<'a> + AES128Ctr> hil::symmetric_encryption::Client<'a> for Te
             self.use_source.set(false);
             self.run();
         } else {
-            if self.encrypting.get() {
+            if self.encrypting.get() && self.test_decrypt {
                 self.encrypting.set(false);
                 self.use_source.set(true);
                 self.run();
@@ -304,6 +311,7 @@ impl<'a, A: AES128<'a> + AES128CBC> TestAes128Cbc<'a, A> {
         iv: &'a mut [u8],
         source: &'static mut [u8],
         data: &'static mut [u8],
+        test_decrypt: bool,
     ) -> Self {
         TestAes128Cbc {
             aes: aes,
@@ -312,6 +320,7 @@ impl<'a, A: AES128<'a> + AES128CBC> TestAes128Cbc<'a, A> {
             iv: TakeCell::new(iv),
             source: TakeCell::new(source),
             data: TakeCell::new(data),
+            test_decrypt,
 
             encrypting: Cell::new(true),
             use_source: Cell::new(true),
@@ -445,7 +454,7 @@ impl<'a, A: AES128<'a> + AES128CBC> hil::symmetric_encryption::Client<'a> for Te
             self.use_source.set(false);
             self.run();
         } else {
-            if self.encrypting.get() {
+            if self.encrypting.get() && self.test_decrypt {
                 self.encrypting.set(false);
                 self.use_source.set(true);
                 self.run();
@@ -500,7 +509,7 @@ impl<'a, A: AES128<'a> + AES128ECB> hil::symmetric_encryption::Client<'a> for Te
             self.use_source.set(false);
             self.run();
         } else {
-            if self.encrypting.get() {
+            if self.encrypting.get() && self.test_decrypt {
                 self.encrypting.set(false);
                 self.use_source.set(true);
                 self.run();


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the AES test to allow testers to opt out of decryption. This is helpful because the nRF52 AES implementation does not support decryption in `TestAes128Cbc` or `TestAes128Ecb`.


### Testing Strategy

Running the test on the nrf52840dk.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
