### PR TITLE
Remove Redundant Imports

### DIFF
--- a/arch/cortex-m/src/mpu.rs
+++ b/arch/cortex-m/src/mpu.rs
@@ -10,7 +10,6 @@ use core::cmp;
 use core::fmt;
 use core::num::NonZeroUsize;
 
-use kernel;
 use kernel::platform::mpu;
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::math;

--- a/arch/cortex-m/src/support.rs
+++ b/arch/cortex-m/src/support.rs
@@ -3,7 +3,6 @@
 // Copyright Tock Contributors 2022.
 
 use crate::scb;
-use core::ops::FnOnce;
 
 #[cfg(all(target_arch = "arm", target_os = "none"))]
 #[inline(always)]

--- a/arch/rv32i/src/support.rs
+++ b/arch/rv32i/src/support.rs
@@ -5,7 +5,6 @@
 //! Core low-level operations.
 
 use crate::csr::{mstatus::mstatus, CSR};
-use core::ops::FnOnce;
 
 #[cfg(all(target_arch = "riscv32", target_os = "none"))]
 #[inline(always)]

--- a/arch/rv32i/src/syscall.rs
+++ b/arch/rv32i/src/syscall.rs
@@ -4,13 +4,11 @@
 
 //! Kernel-userland system call interface for RISC-V architecture.
 
-use core::convert::TryInto;
 use core::fmt::Write;
 use core::mem::size_of;
 use core::ops::Range;
 
 use crate::csr::mcause;
-use kernel;
 use kernel::errorcode::ErrorCode;
 use kernel::syscall::ContextSwitchReason;
 

--- a/boards/apollo3/lora_things_plus/src/io.rs
+++ b/boards/apollo3/lora_things_plus/src/io.rs
@@ -8,7 +8,6 @@ use core::panic::PanicInfo;
 use crate::CHIP;
 use crate::PROCESSES;
 use crate::PROCESS_PRINTER;
-use apollo3;
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;

--- a/boards/apollo3/redboard_artemis_atp/src/io.rs
+++ b/boards/apollo3/redboard_artemis_atp/src/io.rs
@@ -8,7 +8,6 @@ use core::panic::PanicInfo;
 use crate::CHIP;
 use crate::PROCESSES;
 use crate::PROCESS_PRINTER;
-use apollo3;
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;

--- a/boards/apollo3/redboard_artemis_nano/src/io.rs
+++ b/boards/apollo3/redboard_artemis_nano/src/io.rs
@@ -8,7 +8,6 @@ use core::panic::PanicInfo;
 use crate::CHIP;
 use crate::PROCESSES;
 use crate::PROCESS_PRINTER;
-use apollo3;
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;

--- a/boards/arty_e21/src/io.rs
+++ b/boards/arty_e21/src/io.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use arty_e21_chip;
 use core::fmt::Write;
 use core::panic::PanicInfo;
 use core::str;
@@ -10,8 +9,6 @@ use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::gpio;
 use kernel::hil::led;
-use rv32i;
-use sifive;
 
 use crate::CHIP;
 use crate::PROCESSES;

--- a/boards/clue_nrf52840/src/io.rs
+++ b/boards/clue_nrf52840/src/io.rs
@@ -6,7 +6,6 @@ use core::fmt::Write;
 use core::panic::PanicInfo;
 use kernel::ErrorCode;
 
-use cortexm4;
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;

--- a/boards/components/src/analog_comparator.rs
+++ b/boards/components/src/analog_comparator.rs
@@ -25,7 +25,6 @@
 
 use capsules_extra::analog_comparator::AnalogComparator;
 use core::mem::MaybeUninit;
-use kernel;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;

--- a/boards/components/src/ble.rs
+++ b/boards/components/src/ble.rs
@@ -10,7 +10,6 @@
 //! let ble_radio = BLEComponent::new(board_kernel, &nrf52::ble_radio::RADIO, mux_alarm).finalize();
 //! ```
 
-use capsules_core;
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use core::mem::MaybeUninit;
 use kernel::capabilities;

--- a/boards/components/src/thread_network.rs
+++ b/boards/components/src/thread_network.rs
@@ -26,7 +26,6 @@
 //!         ));
 //! ```
 
-use capsules_core;
 use capsules_core::virtualizers::virtual_aes_ccm::MuxAES128CCM;
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use capsules_extra::net::ipv6::ipv6_send::IP6SendStruct;
@@ -42,7 +41,6 @@ use capsules_extra::net::udp::udp_recv::MuxUdpReceiver;
 use capsules_extra::net::udp::udp_recv::UDPReceiver;
 use capsules_extra::net::udp::udp_send::{MuxUdpSender, UDPSendStruct, UDPSender};
 use core::mem::MaybeUninit;
-use kernel;
 use kernel::capabilities;
 use kernel::capabilities::NetworkCapabilityCreationCapability;
 use kernel::component::Component;

--- a/boards/components/src/udp_driver.rs
+++ b/boards/components/src/udp_driver.rs
@@ -21,7 +21,6 @@
 //!     .finalize(components::udp_driver_component_static!());
 //! ```
 
-use capsules_core;
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use capsules_extra::net::ipv6::ip_utils::IPAddr;
 use capsules_extra::net::ipv6::ipv6_send::IP6SendStruct;
@@ -33,7 +32,6 @@ use capsules_extra::net::udp::udp_recv::MuxUdpReceiver;
 use capsules_extra::net::udp::udp_recv::UDPReceiver;
 use capsules_extra::net::udp::udp_send::{MuxUdpSender, UDPSendStruct, UDPSender};
 use core::mem::MaybeUninit;
-use kernel;
 use kernel::capabilities;
 use kernel::capabilities::NetworkCapabilityCreationCapability;
 use kernel::component::Component;

--- a/boards/components/src/udp_mux.rs
+++ b/boards/components/src/udp_mux.rs
@@ -27,7 +27,6 @@
 // Author: Hudson Ayers <hayers@stanford.edu>
 // Last Modified: 5/21/2019
 
-use capsules_core;
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules_extra::ieee802154::device::MacDevice;
 use capsules_extra::net::ieee802154::MacAddress;
@@ -46,7 +45,6 @@ use capsules_extra::net::udp::udp_recv::MuxUdpReceiver;
 use capsules_extra::net::udp::udp_send::MuxUdpSender;
 use capsules_extra::net::udp::UDPHeader;
 use core::mem::MaybeUninit;
-use kernel;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;

--- a/boards/hail/src/io.rs
+++ b/boards/hail/src/io.rs
@@ -5,7 +5,6 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
 use core::str;
-use cortexm4;
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;

--- a/boards/hifive1/src/io.rs
+++ b/boards/hifive1/src/io.rs
@@ -5,12 +5,10 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
 use core::str;
-use e310_g002;
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::gpio;
 use kernel::hil::led;
-use rv32i;
 
 use crate::CHIP;
 use crate::PROCESSES;

--- a/boards/hifive_inventor/src/io.rs
+++ b/boards/hifive_inventor/src/io.rs
@@ -5,11 +5,9 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
 use core::str;
-use e310_g003;
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;
-use rv32i;
 
 use crate::CHIP;
 use crate::PROCESSES;

--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -4,12 +4,10 @@
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
-use cortexm4;
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart::{self, Configure};
-use sam4l;
 
 use crate::CHIP;
 use crate::PROCESSES;

--- a/boards/microbit_v2/src/io.rs
+++ b/boards/microbit_v2/src/io.rs
@@ -5,7 +5,6 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
 
-use cortexm4;
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;

--- a/boards/nano33ble/src/io.rs
+++ b/boards/nano33ble/src/io.rs
@@ -5,7 +5,6 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
 
-use cortexm4;
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;

--- a/boards/nordic/nrf52840_dongle/src/io.rs
+++ b/boards/nordic/nrf52840_dongle/src/io.rs
@@ -4,7 +4,6 @@
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
-use cortexm4;
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -26,7 +26,7 @@ use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{capabilities, create_capability, debug, debug_gpio, debug_verbose, static_init};
 use nrf52840::gpio::Pin;
 use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
-use nrf52_components::{self, UartChannel, UartPins};
+use nrf52_components::{UartChannel, UartPins};
 
 // The nRF52840 Dongle LEDs
 const LED1_PIN: Pin = Pin::P0_06;

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -4,7 +4,6 @@
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
-use cortexm4;
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -87,7 +87,7 @@ use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{capabilities, create_capability, debug, debug_gpio, debug_verbose, static_init};
 use nrf52840::gpio::Pin;
 use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
-use nrf52_components::{self, UartChannel, UartPins};
+use nrf52_components::{UartChannel, UartPins};
 
 #[allow(dead_code)]
 mod test;

--- a/boards/nordic/nrf52_components/src/startup.rs
+++ b/boards/nordic/nrf52_components/src/startup.rs
@@ -9,7 +9,6 @@
 
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules_extra::segger_rtt::SeggerRtt;
-use components;
 use core::mem::MaybeUninit;
 use kernel::component::Component;
 use nrf52::gpio::Pin;

--- a/boards/nordic/nrf52dk/src/io.rs
+++ b/boards/nordic/nrf52dk/src/io.rs
@@ -4,7 +4,6 @@
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
-use cortexm4;
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -82,7 +82,7 @@ use kernel::{capabilities, create_capability, debug, debug_gpio, debug_verbose, 
 use nrf52832::gpio::Pin;
 use nrf52832::interrupt_service::Nrf52832DefaultPeripherals;
 use nrf52832::rtc::Rtc;
-use nrf52_components::{self, UartChannel, UartPins};
+use nrf52_components::{UartChannel, UartPins};
 
 // The nRF52 DK LEDs (see back of board)
 const LED1_PIN: Pin = Pin::P0_17;

--- a/boards/nucleo_f429zi/src/io.rs
+++ b/boards/nucleo_f429zi/src/io.rs
@@ -5,15 +5,12 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
 
-use cortexm4;
-
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart;
 use kernel::hil::uart::Configure;
 
-use stm32f429zi;
 use stm32f429zi::gpio::PinId;
 
 use crate::CHIP;

--- a/boards/nucleo_f446re/src/io.rs
+++ b/boards/nucleo_f446re/src/io.rs
@@ -5,15 +5,12 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
 
-use cortexm4;
-
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart;
 use kernel::hil::uart::Configure;
 
-use stm32f446re;
 use stm32f446re::gpio::PinId;
 
 use crate::CHIP;

--- a/boards/particle_boron/src/io.rs
+++ b/boards/particle_boron/src/io.rs
@@ -4,7 +4,6 @@
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
-use cortexm4;
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;

--- a/boards/redboard_redv/src/io.rs
+++ b/boards/redboard_redv/src/io.rs
@@ -5,12 +5,10 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
 use core::str;
-use e310_g002;
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::gpio;
 use kernel::hil::led;
-use rv32i;
 
 use crate::CHIP;
 use crate::PROCESSES;

--- a/boards/sma_q3/src/io.rs
+++ b/boards/sma_q3/src/io.rs
@@ -4,7 +4,6 @@
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
-use cortexm4;
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;

--- a/boards/stm32f3discovery/src/io.rs
+++ b/boards/stm32f3discovery/src/io.rs
@@ -11,7 +11,6 @@ use kernel::hil::led;
 use kernel::hil::uart;
 use kernel::hil::uart::Configure;
 
-use stm32f303xc;
 use stm32f303xc::gpio::PinId;
 
 use crate::CHIP;

--- a/boards/stm32f412gdiscovery/src/io.rs
+++ b/boards/stm32f412gdiscovery/src/io.rs
@@ -5,15 +5,12 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
 
-use cortexm4;
-
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart;
 use kernel::hil::uart::Configure;
 
-use stm32f412g;
 use stm32f412g::gpio::PinId;
 
 use crate::CHIP;

--- a/boards/stm32f429idiscovery/src/io.rs
+++ b/boards/stm32f429idiscovery/src/io.rs
@@ -5,15 +5,12 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
 
-use cortexm4;
-
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart;
 use kernel::hil::uart::Configure;
 
-use stm32f429zi;
 use stm32f429zi::gpio::PinId;
 
 use crate::CHIP;

--- a/boards/weact_f401ccu6/src/io.rs
+++ b/boards/weact_f401ccu6/src/io.rs
@@ -5,15 +5,12 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
 
-use cortexm4;
-
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart;
 use kernel::hil::uart::Configure;
 
-use stm32f401cc;
 use stm32f401cc::gpio::PinId;
 
 use crate::CHIP;

--- a/boards/wm1110dev/src/io.rs
+++ b/boards/wm1110dev/src/io.rs
@@ -5,7 +5,6 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
 
-use cortexm4;
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;

--- a/capsules/core/src/adc.rs
+++ b/capsules/core/src/adc.rs
@@ -54,7 +54,6 @@
 
 use core::cell::Cell;
 use core::cmp;
-use core::convert::TryFrom;
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::hil;

--- a/capsules/extra/src/air_quality.rs
+++ b/capsules/extra/src/air_quality.rs
@@ -24,7 +24,6 @@
 //! ```
 
 use core::cell::Cell;
-use core::convert::TryFrom;
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::hil;
 use kernel::syscall::{CommandReturn, SyscallDriver};

--- a/capsules/extra/src/log.rs
+++ b/capsules/extra/src/log.rs
@@ -63,7 +63,6 @@
 //! ```
 
 use core::cell::Cell;
-use core::convert::TryFrom;
 use core::mem::size_of;
 use core::unreachable;
 

--- a/capsules/extra/src/net/sixlowpan/sixlowpan_compression.rs
+++ b/capsules/extra/src/net/sixlowpan/sixlowpan_compression.rs
@@ -11,7 +11,6 @@ use crate::net::util::{network_slice_to_u16, u16_to_network_slice};
 /// Implements the 6LoWPAN specification for sending IPv6 datagrams over
 /// 802.15.4 packets efficiently, as detailed in RFC 6282.
 use core::mem;
-use core::result::Result;
 
 /// Contains bit masks and constants related to the two-byte header of the
 /// LoWPAN_IPHC encoding format.

--- a/capsules/extra/src/net/udp/driver.rs
+++ b/capsules/extra/src/net/udp/driver.rs
@@ -21,8 +21,6 @@ use crate::net::udp::udp_send::{UDPSendClient, UDPSender};
 use crate::net::util::host_slice_to_u16;
 
 use core::cell::Cell;
-use core::convert::TryFrom;
-use core::convert::TryInto;
 use core::mem::size_of;
 use core::{cmp, mem};
 

--- a/capsules/extra/src/screen.rs
+++ b/capsules/extra/src/screen.rs
@@ -15,7 +15,6 @@
 //! ```
 
 use core::cell::Cell;
-use core::convert::From;
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::hil;

--- a/capsules/extra/src/sip_hash.rs
+++ b/capsules/extra/src/sip_hash.rs
@@ -27,7 +27,6 @@
 //! option.
 
 use core::cell::Cell;
-use core::convert::TryInto;
 use core::{cmp, mem};
 use kernel::deferred_call::{DeferredCall, DeferredCallClient};
 use kernel::hil::hasher::{Client, Hasher, SipHash};

--- a/capsules/extra/src/sound_pressure.rs
+++ b/capsules/extra/src/sound_pressure.rs
@@ -57,7 +57,6 @@
 //! ```
 
 use core::cell::Cell;
-use core::convert::TryFrom;
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::hil;
 use kernel::syscall::{CommandReturn, SyscallDriver};

--- a/capsules/extra/src/text_screen.rs
+++ b/capsules/extra/src/text_screen.rs
@@ -16,7 +16,6 @@
 //! ```
 
 use core::cmp;
-use core::convert::From;
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::hil;

--- a/capsules/extra/src/tickv.rs
+++ b/capsules/extra/src/tickv.rs
@@ -39,7 +39,7 @@ use kernel::hil::hasher::{self, Hasher};
 use kernel::utilities::cells::{MapCell, OptionalCell, TakeCell};
 use kernel::utilities::leasable_buffer::{SubSlice, SubSliceMut};
 use kernel::ErrorCode;
-use tickv::{self, AsyncTicKV};
+use tickv::AsyncTicKV;
 
 /// The type of keys, this should define the output size of the digest
 /// operations.

--- a/capsules/extra/src/usb/descriptors.rs
+++ b/capsules/extra/src/usb/descriptors.rs
@@ -8,7 +8,6 @@
 
 use core::cell::Cell;
 use core::cmp::min;
-use core::convert::From;
 use core::fmt;
 
 use kernel::hil::usb::TransferType;

--- a/chips/apollo3/src/chip.rs
+++ b/chips/apollo3/src/chip.rs
@@ -5,7 +5,7 @@
 //! Chip trait setup.
 
 use core::fmt::Write;
-use cortexm4::{self, CortexM4, CortexMVariant};
+use cortexm4::{CortexM4, CortexMVariant};
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
 

--- a/chips/arty_e21_chip/src/chip.rs
+++ b/chips/arty_e21_chip/src/chip.rs
@@ -3,12 +3,10 @@
 // Copyright Tock Contributors 2022.
 
 use core::fmt::Write;
-use kernel;
 use kernel::debug;
 use kernel::hil::time::Freq32KHz;
 use kernel::platform::chip::InterruptService;
 use kernel::utilities::registers::interfaces::Readable;
-use rv32i;
 
 use crate::clint;
 use crate::interrupts;

--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -5,11 +5,9 @@
 //! High-level setup and interrupt mapping for the chip.
 
 use core::fmt::Write;
-use kernel;
 use kernel::debug;
 use kernel::platform::chip::Chip;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
-use rv32i;
 use rv32i::csr;
 use rv32i::csr::{mcause, mie::mie, mip::mip, CSR};
 use rv32i::pmp::{simple::SimplePMP, PMPUserMPU};

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -6,7 +6,6 @@
 
 use core::fmt::{Display, Write};
 use core::marker::PhantomData;
-use kernel;
 use kernel::platform::chip::{Chip, InterruptService};
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use rv32i::csr::{mcause, mie::mie, mtvec::mtvec, CSR};

--- a/chips/earlgrey/src/registers/top_earlgrey.rs
+++ b/chips/earlgrey/src/registers/top_earlgrey.rs
@@ -24,8 +24,6 @@
 //! - Pinmux Pin/Select Names
 //! - Power Manager Wakeups
 
-use core::convert::TryFrom;
-
 /// Peripheral base address for uart0 in top earlgrey.
 ///
 /// This should be used with #mmio_region_from_addr to access the memory-mapped

--- a/chips/esp32-c3/src/chip.rs
+++ b/chips/esp32-c3/src/chip.rs
@@ -6,7 +6,6 @@
 
 use core::fmt::Write;
 
-use kernel;
 use kernel::platform::chip::{Chip, InterruptService};
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::StaticRef;

--- a/chips/imxrt10xx/src/chip.rs
+++ b/chips/imxrt10xx/src/chip.rs
@@ -5,7 +5,7 @@
 //! Chip trait setup.
 
 use core::fmt::Write;
-use cortexm7::{self, CortexM7, CortexMVariant};
+use cortexm7::{CortexM7, CortexMVariant};
 use kernel::debug;
 use kernel::platform::chip::{Chip, InterruptService};
 

--- a/chips/imxrt10xx/src/gpt.rs
+++ b/chips/imxrt10xx/src/gpt.rs
@@ -3,7 +3,6 @@
 // Copyright Tock Contributors 2022.
 
 use core::sync::atomic::{AtomicU32, Ordering};
-use cortexm7;
 use cortexm7::support::atomic;
 use kernel::hil;
 use kernel::hil::time::{Ticks, Ticks32, Time};

--- a/chips/litex_vexriscv/src/chip.rs
+++ b/chips/litex_vexriscv/src/chip.rs
@@ -5,7 +5,6 @@
 //! High-level setup and interrupt mapping for the chip.
 
 use core::fmt::Write;
-use kernel;
 use kernel::debug;
 use kernel::platform::chip::InterruptService;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};

--- a/chips/msp432/src/chip.rs
+++ b/chips/msp432/src/chip.rs
@@ -3,7 +3,7 @@
 // Copyright Tock Contributors 2022.
 
 use core::fmt::Write;
-use cortexm4::{self, CortexM4, CortexMVariant};
+use cortexm4::{CortexM4, CortexMVariant};
 use kernel::platform::chip::Chip;
 
 use crate::nvic;

--- a/chips/nrf52/src/ble_radio.rs
+++ b/chips/nrf52/src/ble_radio.rs
@@ -38,7 +38,6 @@
 //! * CRC - 3 bytes
 
 use core::cell::Cell;
-use core::convert::TryFrom;
 use kernel::hil::ble_advertising;
 use kernel::hil::ble_advertising::RadioChannel;
 use kernel::utilities::cells::OptionalCell;

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -3,7 +3,7 @@
 // Copyright Tock Contributors 2022.
 
 use core::fmt::Write;
-use cortexm4::{self, nvic, CortexM4, CortexMVariant};
+use cortexm4::{nvic, CortexM4, CortexMVariant};
 use kernel::platform::chip::InterruptService;
 
 pub struct NRF52<'a, I: InterruptService + 'a> {

--- a/chips/nrf52/src/pwm.rs
+++ b/chips/nrf52/src/pwm.rs
@@ -10,7 +10,6 @@ use kernel::utilities::registers::interfaces::Writeable;
 use kernel::utilities::registers::{register_bitfields, ReadWrite, WriteOnly};
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
-use nrf5x;
 
 #[repr(C)]
 struct PwmRegisters {

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -10,7 +10,6 @@
 //! * Author: Niklas Adolfsson <niklasadolfsson1@gmail.com>
 //! * Date: March 10 2018
 
-use core;
 use core::cell::Cell;
 use core::cmp::min;
 use kernel::hil::uart;

--- a/chips/nrf52840/src/ieee802154_radio.rs
+++ b/chips/nrf52840/src/ieee802154_radio.rs
@@ -6,8 +6,6 @@
 
 use crate::timer::TimerAlarm;
 use core::cell::Cell;
-use core::convert::TryFrom;
-use kernel;
 use kernel::hil::radio::{self, PowerClient, RadioData};
 use kernel::hil::time::{Alarm, AlarmClient, Time};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
@@ -16,7 +14,6 @@ use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite, Writ
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 
-use nrf52;
 use nrf52::constants::TxPower;
 
 // This driver implements a subset of 802.15.4 sending and receiving for the

--- a/chips/nrf5x/src/constants.rs
+++ b/chips/nrf5x/src/constants.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::convert::TryFrom;
-
 // PCNF0
 pub const RADIO_PCNF0_LFLEN_POS: u32 = 0;
 pub const RADIO_PCNF0_S0LEN_POS: u32 = 8;

--- a/chips/qemu_rv32_virt_chip/src/chip.rs
+++ b/chips/qemu_rv32_virt_chip/src/chip.rs
@@ -6,14 +6,12 @@
 
 use core::fmt::Write;
 
-use kernel;
 use kernel::debug;
 use kernel::hil::time::Freq10MHz;
 use kernel::platform::chip::{Chip, InterruptService};
 
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 
-use rv32i;
 use rv32i::csr::{mcause, mie::mie, mip::mip, CSR};
 
 use crate::plic::PLIC;

--- a/chips/rp2040/src/deferred_calls.rs
+++ b/chips/rp2040/src/deferred_calls.rs
@@ -7,9 +7,6 @@
 //! Deferred calls also peripheral drivers to register pseudo interrupts.
 //! These are the definitions of which deferred calls this chip needs.
 
-use core::convert::Into;
-use core::convert::TryFrom;
-
 /// A type of task to defer a call for
 #[derive(Copy, Clone)]
 pub enum DeferredCallTask {

--- a/chips/rp2040/src/lib.rs
+++ b/chips/rp2040/src/lib.rs
@@ -23,9 +23,7 @@ pub mod usb;
 pub mod watchdog;
 pub mod xosc;
 
-use cortexm0p::{
-    self, initialize_ram_jump_to_main, unhandled_interrupt, CortexM0P, CortexMVariant,
-};
+use cortexm0p::{initialize_ram_jump_to_main, unhandled_interrupt, CortexM0P, CortexMVariant};
 
 extern "C" {
     // _estack is not really a function, but it makes the types work

--- a/chips/rp2040/src/timer.rs
+++ b/chips/rp2040/src/timer.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use cortexm0p;
 use cortexm0p::support::atomic;
 use kernel::hil;
 use kernel::hil::time::{Alarm, Ticks, Ticks32, Time};

--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -7,7 +7,7 @@
 use crate::pm;
 
 use core::fmt::Write;
-use cortexm4::{self, CortexM4, CortexMVariant};
+use cortexm4::{CortexM4, CortexMVariant};
 use kernel::platform::chip::{Chip, InterruptService};
 
 pub struct Sam4l<I: InterruptService + 'static> {

--- a/chips/stm32f303xc/src/tim2.rs
+++ b/chips/stm32f303xc/src/tim2.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use cortexm4;
 use cortexm4::support::atomic;
 use kernel::hil::time::{
     Alarm, AlarmClient, Counter, Freq16KHz, OverflowClient, Ticks, Ticks32, Time,

--- a/chips/stm32f4xx/src/chip.rs
+++ b/chips/stm32f4xx/src/chip.rs
@@ -5,7 +5,7 @@
 //! Chip trait setup.
 
 use core::fmt::Write;
-use cortexm4::{self, CortexM4, CortexMVariant};
+use cortexm4::{CortexM4, CortexMVariant};
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
 

--- a/chips/stm32f4xx/src/gpio.rs
+++ b/chips/stm32f4xx/src/gpio.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use cortexm4;
 use cortexm4::support::atomic;
 use enum_primitive::cast::FromPrimitive;
 use enum_primitive::enum_from_primitive;

--- a/chips/stm32f4xx/src/tim2.rs
+++ b/chips/stm32f4xx/src/tim2.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use cortexm4;
 use cortexm4::support::atomic;
 use kernel::hil::time::{
     Alarm, AlarmClient, Counter, Freq16KHz, OverflowClient, Ticks, Ticks32, Time,

--- a/chips/swervolf-eh1/src/chip.rs
+++ b/chips/swervolf-eh1/src/chip.rs
@@ -5,7 +5,6 @@
 //! High-level setup and interrupt mapping for the chip.
 
 use core::fmt::Write;
-use kernel;
 use kernel::platform::chip::{Chip, InterruptService};
 use kernel::utilities::cells::VolatileCell;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};

--- a/kernel/src/errorcode.rs
+++ b/kernel/src/errorcode.rs
@@ -4,8 +4,6 @@
 
 //! Standard errors in Tock.
 
-use core::convert::TryFrom;
-
 /// Standard errors in Tock.
 ///
 /// In contrast to [`Result<(), ErrorCode>`](crate::Result<(), ErrorCode>) this

--- a/kernel/src/hil/i2c.rs
+++ b/kernel/src/hil/i2c.rs
@@ -6,7 +6,6 @@
 
 use crate::ErrorCode;
 
-use core::convert::Into;
 use core::fmt;
 use core::fmt::{Display, Formatter};
 

--- a/kernel/src/hil/spi.rs
+++ b/kernel/src/hil/spi.rs
@@ -14,7 +14,6 @@
 // Author: Amit Aryeh Levy <amit@amitlevy.com>
 
 use crate::ErrorCode;
-use core::option::Option;
 
 /// Data order defines the order of bits sent over the wire: most
 /// significant first, or least significant first.

--- a/kernel/src/hil/time.rs
+++ b/kernel/src/hil/time.rs
@@ -16,7 +16,7 @@
 //! into these more general ones.
 
 use crate::ErrorCode;
-use core::cmp::{Eq, Ord, Ordering, PartialOrd};
+use core::cmp::Ordering;
 use core::fmt;
 
 /// An integer type defining the width of a time value, which allows

--- a/kernel/src/process_loading.rs
+++ b/kernel/src/process_loading.rs
@@ -8,7 +8,6 @@
 //! checking whether they are allowed to be loaded, and if so initializing a process
 //! structure to run it.
 
-use core::convert::TryInto;
 use core::fmt;
 
 use crate::capabilities::{ProcessApprovalCapability, ProcessManagementCapability};

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -9,7 +9,6 @@
 //! - error types
 //! - interface trait for context switches
 
-use core::convert::TryFrom;
 use core::fmt::Write;
 
 use crate::errorcode::ErrorCode;

--- a/kernel/src/syscall_driver.rs
+++ b/kernel/src/syscall_driver.rs
@@ -77,8 +77,6 @@
 //! kernel (the scheduler and syscall dispatcher) is responsible for
 //! encoding these types into the Tock system call ABI specification.
 
-use core::convert::TryFrom;
-
 use crate::errorcode::ErrorCode;
 use crate::process;
 use crate::process::ProcessId;

--- a/kernel/src/utilities/math.rs
+++ b/kernel/src/utilities/math.rs
@@ -4,7 +4,6 @@
 
 //! Helper functions for common mathematical operations.
 
-use core::convert::{From, Into};
 use core::f32;
 
 /// Get closest power of two greater than the given number.

--- a/libraries/tock-cells/src/numeric_cell_ext.rs
+++ b/libraries/tock-cells/src/numeric_cell_ext.rs
@@ -17,7 +17,6 @@
 //! ```
 
 use core::cell::Cell;
-use core::marker::Copy;
 use core::ops::{Add, Sub};
 
 pub trait NumericCellExt<T>

--- a/libraries/tock-tbf/src/parse.rs
+++ b/libraries/tock-tbf/src/parse.rs
@@ -4,8 +4,6 @@
 
 //! Tock Binary Format parsing code.
 
-use core::convert::TryInto;
-use core::iter::Iterator;
 use core::{mem, str};
 
 use crate::types;

--- a/libraries/tock-tbf/src/types.rs
+++ b/libraries/tock-tbf/src/types.rs
@@ -4,7 +4,6 @@
 
 //! Types and Data Structures for TBFs.
 
-use core::convert::TryInto;
 use core::fmt;
 use core::mem::size_of;
 


### PR DESCRIPTION
Newer compiler versions warn about these.

Warnings like:

```
warning: the item `cortexm4` is imported redundantly
 --> boards/nucleo_f429zi/src/io.rs:8:5
  |
8 | use cortexm4;
  |     ^^^^^^^^ the item `cortexm4` is already defined here
  |
  = note: `#[warn(unused_imports)]` on by default
```




### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
