### PR TITLE
Tockbot improvements

### DIFF
--- a/tools/tockbot/maint_nightly.yaml
+++ b/tools/tockbot/maint_nightly.yaml
@@ -27,7 +27,8 @@ repo:
   name: tock
 
 # Ignore all PRs and issues that have the tockbot-ignore label:
-ignored_label: tockbot-ignore
+ignored_labels:
+  - tockbot-ignore
 
 tasks:
   - type: stale_pr_assign
@@ -44,3 +45,10 @@ tasks:
     assignee_cnt: 1
     assignee_candidates: *active_reviewers
 
+    # Ignore PRs that are marked as "blocked" or "blocked-upstream". Those
+    # should not necessarily be assigned a reviewer, but be staged for
+    # "check-in" in a core-WG call after being stale for some time (e.g., a
+    # month).
+    ignored_labels:
+      - blocked
+      - blocked-upstream

--- a/tools/tockbot/shell.nix
+++ b/tools/tockbot/shell.nix
@@ -8,7 +8,7 @@ mkShell {
   name = "mirrorcheck-shell";
   buildInputs = [
     (python3.withPackages (pypkgs: with pypkgs; [
-      pygithub pyyaml
+      requests-cache pygithub pyyaml
     ]))
   ];
 }

--- a/tools/tockbot/tockbot.py
+++ b/tools/tockbot/tockbot.py
@@ -22,14 +22,36 @@ install_cache(
     },
 )
 
+class CallbackFilter:
+    def __init__(self, function, filtered_cb, sequence):
+        self.function = function
+        self.sequence = sequence
+        self.filtered_cb = filtered_cb
 
-def ignore_prs_filter(config, prs):
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        # Let any StopIteration exception bubble up the call stack
+        while True:
+            item = next(self.sequence)
+            if self.function(item):
+                return item
+            else:
+                self.filtered_cb(item)
+
+def ignore_prs_filter(config, prs, logger):
     if "ignored_label" in config:
-        return filter(
+        ignored_label = config["ignored_label"]
+        return CallbackFilter(
             lambda pr: not any(map(
-                lambda l: l.name == config["ignored_label"],
+                lambda l: l.name == ignored_label,
                 pr.get_labels()
             )),
+            lambda ignored: logger.debug(
+                f"-> Filtered #{filtered.number}, is ignored by label "
+                + f"\"{ignored_label}\"."
+            ),
             prs
         )
     else:
@@ -48,17 +70,22 @@ def task_stale_pr_assign(config, task_config, gh, repo, rand, log, dry_run):
     prs = verbose_pr_stream(repo.get_pulls(state="open"), log)
 
     # Filter out PRs that are marked as ignored by this tool:
-    prs = ignore_prs_filter(config, prs)
+    prs = ignore_prs_filter(config, prs, log)
 
     # Filter out PRs that are assigned to one or more users:
-    prs = filter(lambda pr: len(pr.assignees) == 0, prs)
+    prs = CallbackFilter(
+        lambda pr: len(pr.assignees) == 0,
+        lambda filtered: log.debug(
+            f"-> Filtered #{filtered.number}, has assignees."),
+        prs,
+    )
 
     # Filter out PRs which have received reviews that are not dismissed
     # (optionally filted by a designated group of people, if the config is not
     # an empty list):
     no_reviews_cond = task_config.get("no_reviews_by", None)
     if no_reviews_cond is not None:
-        prs = filter(
+        prs = CallbackFilter(
             lambda pr: not any(map(
                 lambda review: (
                     # Only keep PRs that do not have any review where the
@@ -71,6 +98,8 @@ def task_stale_pr_assign(config, task_config, gh, repo, rand, log, dry_run):
                 ),
                 pr.get_reviews(),
             )),
+            lambda filtered: log.debug(
+                f"-> Filtered #{filtered.number}, has current reviews."),
             prs
         )
 
@@ -80,7 +109,7 @@ def task_stale_pr_assign(config, task_config, gh, repo, rand, log, dry_run):
         comments_since = datetime.now(timezone.utc) \
             - timedelta(seconds=task_config["staleness_time"])
 
-        prs = filter(
+        prs = CallbackFilter(
             lambda pr: (
                 (
                     # Keep PRs that do _not_ have at least one review comment or
@@ -92,6 +121,8 @@ def task_stale_pr_assign(config, task_config, gh, repo, rand, log, dry_run):
                     pr.created_at < comments_since
                 )
             ),
+            lambda filtered: log.debug(
+                f"-> Filtered #{filtered.number}, not stale."),
             prs
         )
 

--- a/tools/tockbot/tockbot.py
+++ b/tools/tockbot/tockbot.py
@@ -69,6 +69,14 @@ def task_stale_pr_assign(config, task_config, gh, repo, rand, log, dry_run):
     # Get the list of open PRs:
     prs = verbose_pr_stream(repo.get_pulls(state="open"), log)
 
+    # Ignore all draft PRs:
+    prs = CallbackFilter(
+        lambda pr: pr.draft == False,
+        lambda filtered: log.debug(
+            f"-> Filtered #{filtered.number}, is a draft PR."),
+        prs,
+    )
+
     # Filter out PRs that are marked as ignored by this tool:
     prs = ignore_prs_filter(config, prs, log)
 


### PR DESCRIPTION
### Pull Request Overview

Some quick Tockbot improvements around the "stale_pr_assign" tasks:
- Log why a PR was not staged to be assigned a reviewer. This helps debug the bots behavior.
- Ignore draft PRs.
- Ignore PRs that have the "blocked" or "blocked-upstream" labels.

The last point could be problematic. It might cause blocked PRs to linger for a long time, as we don't have a great way to correlate this "block" with its blocking dependency (internal Tock PR, upstream PR, something entirely different).

One solution could be to collect such PRs that have been blocked for a long time (e.g., a month) for brief manual review, either by assigning a reviewer or putting an item on the core WG call agenda.

### Testing Strategy

Running locally in dry-run mode.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
