### PR TITLE
Resolve "unused import: `core::arch::global_asm`" warnings.

### DIFF
--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -12,8 +12,6 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
-use core::arch::global_asm;
-
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
 use components::led::LedsComponent;
@@ -167,7 +165,7 @@ extern "C" {
 }
 
 #[cfg(all(target_arch = "arm", target_os = "none"))]
-global_asm!(
+core::arch::global_asm!(
     "
     .section .jump_to_bootloader, \"ax\"
     .global jump_to_bootloader

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -12,8 +12,6 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
-use core::arch::global_asm;
-
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
 use components::led::LedsComponent;
@@ -177,7 +175,7 @@ extern "C" {
 }
 
 #[cfg(all(target_arch = "arm", target_os = "none"))]
-global_asm!(
+core::arch::global_asm!(
     "
     .section .jump_to_bootloader, \"ax\"
     .global jump_to_bootloader

--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -12,8 +12,6 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
-use core::arch::global_asm;
-
 use capsules_core::i2c_master::I2CMasterDriver;
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::date_time_component_static;
@@ -168,7 +166,7 @@ extern "C" {
 }
 
 #[cfg(all(target_arch = "arm", target_os = "none"))]
-global_asm!(
+core::arch::global_asm!(
     "
     .section .jump_to_bootloader, \"ax\"
     .global jump_to_bootloader


### PR DESCRIPTION
A few of the board main files have `global_asm!` statements that are `#[cfg(...)]`-ed to disappear when built on non-embedded targets. This results in "unused import" warnings when `cargo check` and `cargo clippy` are run by `make prepush`.

Because writing `core::arch::global_asm` does not noticeably affect readability, I'm just removing the use statements rather than than adding `#[allow(unused_imports)]`.