### PR TITLE
stm32f4xx: expose clock frequency to peripherals

### DIFF
--- a/chips/stm32f4xx/src/tim2.rs
+++ b/chips/stm32f4xx/src/tim2.rs
@@ -4,7 +4,7 @@
 
 use cortexm4::support::atomic;
 use kernel::hil::time::{
-    Alarm, AlarmClient, Counter, Freq16KHz, OverflowClient, Ticks, Ticks32, Time,
+    Alarm, AlarmClient, Counter, Freq16KHz, Frequency, OverflowClient, Ticks, Ticks32, Time,
 };
 use kernel::platform::chip::ClockInterface;
 use kernel::utilities::cells::OptionalCell;
@@ -351,14 +351,23 @@ impl<'a> Tim2<'a> {
 
     // starts the timer
     pub fn start(&self) {
-        // TIM2 uses PCLK1. By default PCLK1 uses HSI running at 16Mhz.
         // Before calling set_alarm, we assume clock to TIM2 has been
         // enabled.
 
         self.registers.arr.set(0xFFFF_FFFF - 1);
-        // Prescale 16Mhz to 16Khz, by dividing it by 1000. We need set EGR.UG
-        // in order for the prescale value to become active.
-        self.registers.psc.set((999 - 1) as u32);
+
+        let clk_freq = self.clock.0.get_frequency();
+
+        // TIM2 uses PCLK1. Set the prescaler to the current PCLK1 frequency divided by the wanted
+        // frequency (16KHz).
+        // WARNING: When PCLK1 is not a multiple of 16KHz (e.g. PCLK1 == 25MHz), the prescaler is
+        // the truncated division result, which would cause loss of timer precision
+        // TODO: We could use a 1KHz or 1MHz frequency instead of 16KHz to cover most clock frequencies
+        // or use a parametric frequency (generic/argument)
+        let psc = clk_freq / Freq16KHz::frequency();
+        self.registers.psc.set(psc - 1);
+
+        // We need set EGR.UG in order for the prescale value to become active.
         self.registers.egr.write(EGR::UG::SET);
         self.registers.cr1.modify(CR1::CEN::SET);
     }


### PR DESCRIPTION
### Pull Request Overview

This pull request extends the kernel clock interface with a `get_frequency()` method to let peripherals use their current clock frequency.
Currently, all peripheral drivers assume the system clock is set to the HW default of 16MHz, however the system clock can be changed through the clocks module. In this case the peripheral should be able to access their respective clock frequency. For instance the usart needs it to accordingly set a parametric baud rate and the tim2 to accordingly set its prescaler. Such two use cases are also implemented by this PR.

Notes:
USARTDIV calculation to set the usart baud rate is based on stm32-rs stm32f4xx-hal:
https://github.com/stm32-rs/stm32f4xx-hal/blob/v0.20.0/src/serial/uart_impls.rs#L145
I tested (see below) and checked it carefully. It looks sound to me.

### Testing Strategy

Tested with a nucleo-f439zi and a few clock configurations:
#### Default clock config: 
HSI sysclock source, APB prescalers set to 1: 16MHz resulting sysclock frequency.
This is the default configuration applied by the rcc init function.

#### Clock config 1
```rust
impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
       ...
    pub fn test_config1(&self) {
        self.pll.set_frequency(PllSource::HSI, HSI_FREQUENCY_MHZ, 96).unwrap();
        self.pll.enable().unwrap();
        self.set_apb1_prescaler(APBPrescaler::DivideBy4).unwrap();
        self.set_apb2_prescaler(APBPrescaler::DivideBy2).unwrap();
        self.set_sys_clock_source(SysClockSource::PLL).unwrap();
    }
 ```

#### Clock config 2
```rust
    pub fn test_config2(&self) {
        self.pll.set_frequency(PllSource::HSI, HSI_FREQUENCY_MHZ, 25).unwrap();
        self.pll.enable().unwrap();
        self.set_apb1_prescaler(APBPrescaler::DivideBy1).unwrap();
        self.set_apb2_prescaler(APBPrescaler::DivideBy1).unwrap();
        self.set_sys_clock_source(SysClockSource::PLL).unwrap();
    }
```

#### Clock config 3
```rust
    pub fn test_config3(&self) {
        self.pll.set_frequency(PllSource::HSI, HSI_FREQUENCY_MHZ, 50).unwrap();
        self.pll.enable().unwrap();
        self.set_apb1_prescaler(APBPrescaler::DivideBy2).unwrap();
        self.set_apb2_prescaler(APBPrescaler::DivideBy1).unwrap();
        self.set_sys_clock_source(SysClockSource::PLL).unwrap();
    }
```

#### Clock config 4
```rust
    pub fn test_config4(&self) {
        self.pll.set_frequency(PllSource::HSI, HSI_FREQUENCY_MHZ, 24).unwrap();
        self.pll.enable().unwrap();
        self.set_apb1_prescaler(APBPrescaler::DivideBy2).unwrap();
        self.set_apb2_prescaler(APBPrescaler::DivideBy1).unwrap();
        self.set_sys_clock_source(SysClockSource::PLL).unwrap();
    }
```

#### Usart test

For all clock configurations I could be able to use the process console at different baud rates: 9600, 115200, 921600.

#### Timer test
For all clock configurations, I tested the timer with a simple application that toggles a gpio every second:
``` rust
fn main() {
    let mut pin = Gpio::get_pin(0).unwrap();
    let mut out_pin = pin.make_output().unwrap();

    loop {
        Alarm::sleep_for(Milliseconds(1000)).unwrap();
        let _ = out_pin.toggle();
    }
}
```
The gpio is getting toggled every about 1005ms for the default configuration (HSI sysclock source) and about 992ms for the other configurations (PLL sysclock source). Note that with the default configuration there is the same ~5ms delta even without my modifications. This is likely due to the HSI clock error of 1%. In fact retesting it with the HSE as sysclock source (on the nucleo board HSE is MCO from ST-LINK), the gpio is being toggled every 1002ms (0.2% error).

### TODO or Help Wanted

- Sysclock frequency calculation should probably be moved into the clocks.rs module, which however cannot be currently accessed by the peripherals. I think it would be ideal if the peripheral would be able to access the Clocks instance instead of the Rcc instance. Since this would require an extensive refactoring and some considerations to address, I would leave it out of the scope of this PR and open a related issue in case this will be merged.
- Support for other peripherals (e.g. SPI) and clock types (RTC, PWR). I would also leave this for future developments.

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
