### PR TITLE
arch/cortex-m3: re-export `unhandled_interrupt()`

### DIFF
--- a/arch/cortex-m3/src/lib.rs
+++ b/arch/cortex-m3/src/lib.rs
@@ -18,6 +18,7 @@ pub use cortexm::nvic;
 pub use cortexm::scb;
 pub use cortexm::support;
 pub use cortexm::systick;
+pub use cortexm::unhandled_interrupt;
 pub use cortexm::CortexMVariant;
 
 // Enum with no variants to ensure that this type is not instantiable. It is


### PR DESCRIPTION
I don't see a reason for `unhandled_interrupt()` being valid for `cortex-m4` and yet invalid for `cortex-m3`. I claim that since it's re-exported by `cortex-m4`, it should be re-exported as well by `cortex-m3`.

### Pull Request Overview

`unhandled_interrupt()` is now re-exported by `cortex-m3` crate.


### TODO or Help Wanted

Please confirm that such re-export is valid for `cortex-m3`.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
