### PR TITLE
print-tock-memory-usage.py: fix regex warnings

### DIFF
--- a/tools/print_tock_memory_usage.py
+++ b/tools/print_tock_memory_usage.py
@@ -122,7 +122,7 @@ def process_section_line(line):
     """Parses a line from the Sections: header of an ELF objdump,
     inserting it into a data structure keeping track of the sections."""
     # pylint: disable=anomalous-backslash-in-string,line-too-long
-    match = re.search("^\S+\s+\.(text|relocate|sram|stack|app_memory)\s+(\S+).+", line)
+    match = re.search(r"^\S+\s+\.(text|relocate|sram|stack|app_memory)\s+(\S+).+", line)
     if match != None:
         sections[match.group(1)] = int(match.group(2), 16)
 
@@ -244,7 +244,7 @@ def process_symbol_line(line):
     global kernel_initialized
     global kernel_uninitialized
     match = re.search(
-        "^(\S+)\s+(\w*)\s+(\w*)\s+\.(text|relocate|sram|stack|app_memory)\s+(\S+)\s+(.+)",
+        r"^(\S+)\s+(\w*)\s+(\w*)\s+\.(text|relocate|sram|stack|app_memory)\s+(\S+)\s+(.+)",
         line,
     )
     if match != None:
@@ -278,7 +278,7 @@ def process_symbol_line(line):
 
         # Code and embedded data.
         elif segment == "text":
-            match = re.search("\$(((\w+\.\.)+)(\w+))\$", name)
+            match = re.search(r"\$(((\w+\.\.)+)(\w+))\$", name)
             # It's a function
             if is_private_symbol(name):
                 # Skip this symbol
@@ -659,7 +659,7 @@ if __name__ == "__main__":
 
     for hline in header_lines:
         # pylint: disable=anomalous-backslash-in-string
-        hmatch = re.search("file format (\S+)", hline)
+        hmatch = re.search(r"file format (\S+)", hline)
         if hmatch != None:
             arch = hmatch.group(1)
 


### PR DESCRIPTION
### Pull Request Overview

This pull request should fix https://github.com/tock/tock/issues/3874 . The issue is that you need to pass a raw string when constructing a regex using regex-specific escape sequences.

I did not see the warning when compiling locally so going to look at the CI output to see if this fix works.


### Testing Strategy

This pull request was tested by...


### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
