### PR TITLE
Fix panic printing

### DIFF
--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -117,9 +117,9 @@ pub unsafe fn panic_print<W: Write + IoWrite, C: Chip, PP: ProcessPrinter>(
     process_printer: &'static Option<&'static PP>,
 ) {
     panic_begin(nop);
-    panic_banner(writer, panic_info);
     // Flush debug buffer if needed
     flush(writer);
+    panic_banner(writer, panic_info);
     panic_cpu_state(chip, writer);
 
     // Some systems may enforce memory protection regions for the


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes panic printing. Previously to this pull request, if a panic occurred, first the panic banner was printed, then the content of the debug queue. This has two issues:

1. It's confusing because temporally (logically) the content of the debug queue precedes panic banner (write event is before panic event)
2. If you get a panic, you see the panic status along with the CPU state, but the panic banner is separated  by the debug queue content. This is especially annoying in case of long debug queues when you have to pipe the output to the `head` command to get the panic message, file and line.

### Testing Strategy

This pull request was tested by manually panicking.


### TODO or Help Wanted

No help needed.


### Documentation Updated

No updates are required.

### Formatting

- [x] Ran `make prepush`.
