### PR TITLE
15.4 Receive Ring Buffer

### DIFF
--- a/capsules/extra/src/ieee802154/driver.rs
+++ b/capsules/extra/src/ieee802154/driver.rs
@@ -1138,6 +1138,13 @@ impl<'a, M: device::MacDevice<'a>> device::RxClient for RadioDriver<'a, M> {
 
                         let max_pending_rx =
                             (rbuf.len() - RING_BUF_METADATA_SIZE) / USER_FRAME_MAX_SIZE;
+
+                        // confirm user modifiable metadata is valid (i.e. within bounds of the provided buffer)
+                        if read_index > max_pending_rx || write_index > max_pending_rx {
+                            // kernel::debug!("[15.4 driver] Invalid read or write index");
+                            return false;
+                        }
+
                         let offset = RING_BUF_METADATA_SIZE + (write_index * USER_FRAME_MAX_SIZE);
 
                         // Copy the entire frame over to userland, preceded by three metadata bytes:

--- a/capsules/extra/src/ieee802154/driver.rs
+++ b/capsules/extra/src/ieee802154/driver.rs
@@ -1140,7 +1140,7 @@ impl<'a, M: device::MacDevice<'a>> device::RxClient for RadioDriver<'a, M> {
                             (rbuf.len() - RING_BUF_METADATA_SIZE) / USER_FRAME_MAX_SIZE;
 
                         // confirm user modifiable metadata is valid (i.e. within bounds of the provided buffer)
-                        if read_index > max_pending_rx || write_index > max_pending_rx {
+                        if read_index >= max_pending_rx || write_index >= max_pending_rx {
                             // kernel::debug!("[15.4 driver] Invalid read or write index");
                             return false;
                         }
@@ -1163,7 +1163,8 @@ impl<'a, M: device::MacDevice<'a>> device::RxClient for RadioDriver<'a, M> {
                             // kernel::debug!("[15.4 driver] Provided RX buffer is full");
                         }
 
-                        rbuf[0].set(read_index as u8);
+                        // update write index metadata (we do not modify the read index
+                        // in the recv functionality so we do not need to update this metadata)
                         rbuf[1].set(write_index as u8);
                         true
                     })

--- a/capsules/extra/src/ieee802154/driver.rs
+++ b/capsules/extra/src/ieee802154/driver.rs
@@ -1104,8 +1104,11 @@ impl<'a, M: device::MacDevice<'a>> device::RxClient for RadioDriver<'a, M> {
                         // of the userprocess not allocating a readwrite buffer. We must also
                         // confirm that the userprocess correctly formatted the buffer to be of length
                         // 2 + n * USER_FRAME_MAX_SIZE, where n is the number of user frames that the
-                        // buffer can store.
-                        if rbuf.len() == 0
+                        // buffer can store. We combine checking the buffer's non-zero length and the
+                        // case of the buffer being shorter than the `RING_BUF_METADATA_SIZE` as an
+                        // invalid buffer (e.g. of length 1) may otherwise errantly pass the second
+                        // conditional check (due to unsigned integer arithmetic).
+                        if rbuf.len() <= RING_BUF_METADATA_SIZE
                             || (rbuf.len() - RING_BUF_METADATA_SIZE) % USER_FRAME_MAX_SIZE != 0
                         {
                             // kernel::debug!("[15.4 Driver] Error - improperly formatted readwrite buffer provided");


### PR DESCRIPTION
### Pull Request Overview

#### Current Design / Issue
The 15.4 driver receive provides a buffer for one packet. Upon receipt of a packet, an upcall is scheduled. The kernel maintains possession of this buffer until the upcall is handled by the userprocess. As such, if packets are received in rapid succession (and the userprocess does not handle the upcall between packets), the second packet will overwrite the first. 

#### Proposed Solution
This PR adds support for the userprocess to pass a ring buffer to the 15.4 driver capsule. The userprocess determines the size of the buffer and the capsule begins filling the buffer. I will not go into the specifics of the design here as I attempted to detail this in depth at the top of the `driver.rs` file. 

With this ring buffer, the capsule possess a mechanism for handling the receipt of multiple packets in quick succession (or with a userprocess being slow to yield and handle upcalls). This design allows flexibility as the userprocess can stipulate the necessary size of the ring buffer.

#### Minor Changes
As part of the ongoing openthread port, the MIC len is useful / needed information. This minor change to the frame metadata passed to the userprocess was lumped in with this PR.


### Testing Strategy

This pull request was tested by successfully joining and remaining attached to an OpenThread network. The libtock-c 15.4 tests will need to be updated once this is upstreamed.


### TODO or Help Wanted
#### Design Choices Worth Further Discussion
I chose to have the ring buffer overwrite the oldest data upon the buffer being depleted. I believe this to be reasonable as the newest data is likely the most pertinent. This also seemed preferable to the alternative of dropping packets. If this assumption is faulty or others disagree, this can be altered.

#### TODO
In a separate PR, I am hoping to add functionality for compilation specified debug logging. As a place holder, I am leaving two helpful debug statements commented out. 

### Documentation Updated

I updated and added comments on this design within the file, but the 15.4 networking documentation will be in need of a revamp in light of the many changes. I believe the 15.4 stack will continue to see additional changes in the coming months so it likely makes sense to hold off on updating until we reach a stable point. 

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
