### PR TITLE
Arch: Cortex: Fix stack addresses for kernel hardfault debug message

### DIFF
--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -22,8 +22,6 @@ pub mod systick;
 
 // These constants are defined in the linker script.
 extern "C" {
-    static _estack: *const u32;
-    static _sstack: *const u32;
     static _szero: *const u32;
     static _ezero: *const u32;
     static _etext: *const u32;

--- a/arch/cortex-v7m/src/lib.rs
+++ b/arch/cortex-v7m/src/lib.rs
@@ -13,13 +13,8 @@ use core::arch::global_asm;
 
 // These constants are defined in the linker script.
 extern "C" {
-    static _estack: *const u32;
-    static _sstack: *const u32;
-    static _szero: *const u32;
-    static _ezero: *const u32;
-    static _etext: *const u32;
-    static _srelocate: *const u32;
-    static _erelocate: *const u32;
+    static _estack: u8;
+    static _sstack: u8;
 }
 
 #[cfg(all(target_arch = "arm", target_os = "none"))]
@@ -407,8 +402,8 @@ unsafe extern "C" fn hard_fault_handler_arm_v7m_kernel(
             exception_number,
             ipsr_isr_number_to_str(exception_number),
             faulting_stack as u32,
-            _estack as u32,
-            _sstack as u32,
+            core::ptr::addr_of!(_estack) as u32,
+            core::ptr::addr_of!(_sstack) as u32,
             shcsr,
             cfsr,
             hfsr,


### PR DESCRIPTION
### Pull Request Overview

This pull request changes how the stack addresses are created to print during kernel hardfaults. I noticed when I was getting kernel hardfaults like:

```
panicked at arch/cortex-v7m/src/lib.rs:347:9:
Kernel HardFault.
	Kernel version release-2.1-2639-ga67a57c99
	r0  0xffff00ff
	r1  0x2000866c
	r2  0x6
	r3  0x6
	r12 0x20001d50
	lr  0x20008634
	pc  0x19942
	prs 0x61000000 [ N 0 Z 1 C 1 V 0 Q 0 GE 0000 ; ICI.IT 0 T true ; Exc 0-Thread Mode ]
	sp  0x20001718
	top of stack     0x10000000
	bottom of stack  0x2a4b29ca
	SHCSR 0x0
	CFSR  0x8200
	HSFR  0x40000000
	Instruction Access Violation:       false
```

Now it is correct:

```

panicked at arch/cortex-v7m/src/lib.rs:347:9:
Kernel HardFault.
	Kernel version release-2.1-2639-ga67a57c99
	r0  0xffff00ff
	r1  0x2000866c
	r2  0x6
	r3  0x6
	r12 0x20001d50
	lr  0x20008634
	pc  0x19942
	prs 0x61000000 [ N 0 Z 1 C 1 V 0 Q 0 GE 0000 ; ICI.IT 0 T true ; Exc 0-Thread Mode ]
	sp  0x20001718
	top of stack     0x20002000
	bottom of stack  0x20000000
	SHCSR 0x0
	CFSR  0x8200
	HSFR  0x40000000
	Instruction Access Violation:       false
	Data Access Violation:              false
	Memory Management Unstacking Fault: false
```

I also removed some old externs we don't use.


### Testing Strategy

This pull request was tested by faulting on the nrf52840dk.


### TODO or Help Wanted

Is this the best fix?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
