### PR TITLE
test_fields!: stringify offset and size in error messages

### DIFF
--- a/libraries/tock-register-interface/src/macros.rs
+++ b/libraries/tock-register-interface/src/macros.rs
@@ -220,7 +220,7 @@ macro_rules! test_fields {
                     "Invalid size for struct ",
                     stringify!($struct),
                     " (expected ",
-                    $size,
+                    stringify!($size),
                     ", actual struct size differs)",
                 ),
             );
@@ -261,7 +261,7 @@ macro_rules! test_fields {
                         "Invalid start offset for field ",
                         stringify!($field),
                         " (expected ",
-                        $offset_start,
+                        stringify!($offset_start),
                         " but actual value differs)",
                     ),
                 );
@@ -296,7 +296,7 @@ macro_rules! test_fields {
                         "Invalid end offset for field ",
                         stringify!($field),
                         " (expected ",
-                        $offset_end,
+                        stringify!($offset_end),
                         " but actual value differs)",
                     ),
                 );
@@ -345,7 +345,7 @@ macro_rules! test_fields {
                         "Invalid start offset for padding ",
                         stringify!($padding),
                         " (expected ",
-                        $offset_start,
+                        stringify!($offset_start),
                         " but actual value differs)",
                     ),
                 );


### PR DESCRIPTION
Offsets and register file size could be defined as a constant expression like `(AUX_OFFSET + 0x20)`.

`test_fields!` macro will fail for such structs as offsets go directly to `concat!` macro which accepts only literals.

To avoid this failure, stringify the offset and size first.

Example:
```
const BAR_OFFSET: usize = 256;
register_structs! {
    UartRegisters {
        (0x00 => foo: ReadWrite<u32>),
        (0x04 => _reserved),
        ((BAR_OFFSET) => bar: ReadWrite<u32>),
        ((BAR_OFFSET+0x04) => @END),
    }
}
```

********************************************************************************
* Pre-Push checks all passed!                                                  
********************************************************************************


