### PR TITLE
TBF Header: Store slices instead of parsed objects

### DIFF
--- a/libraries/tock-tbf/src/parse.rs
+++ b/libraries/tock-tbf/src/parse.rs
@@ -131,7 +131,7 @@ pub fn parse_tbf_header(
                 let mut program_pointer: Option<types::TbfHeaderV2Program> = None;
                 let mut wfr_pointer: Option<&'static [u8]> = None;
                 let mut app_name_str = "";
-                let mut fixed_address_pointer: Option<types::TbfHeaderV2FixedAddresses> = None;
+                let mut fixed_address_pointer: Option<&'static [u8]> = None;
                 let mut permissions_pointer: Option<types::TbfHeaderV2Permissions<8>> = None;
                 let mut storage_permissions_pointer: Option<
                     types::TbfHeaderV2StoragePermissions<8>,
@@ -224,8 +224,7 @@ pub fn parse_tbf_header(
                                 fixed_address_pointer = Some(
                                     remaining
                                         .get(0..entry_len)
-                                        .ok_or(types::TbfParseError::NotEnoughFlash)?
-                                        .try_into()?,
+                                        .ok_or(types::TbfParseError::NotEnoughFlash)?,
                                 );
                             } else {
                                 return Err(types::TbfParseError::BadTlvEntry(

--- a/libraries/tock-tbf/src/parse.rs
+++ b/libraries/tock-tbf/src/parse.rs
@@ -133,9 +133,7 @@ pub fn parse_tbf_header(
                 let mut app_name_str = "";
                 let mut fixed_address_pointer: Option<&'static [u8]> = None;
                 let mut permissions_pointer: Option<&'static [u8]> = None;
-                let mut storage_permissions_pointer: Option<
-                    types::TbfHeaderV2StoragePermissions<8>,
-                > = None;
+                let mut storage_permissions_pointer: Option<&'static [u8]> = None;
                 let mut kernel_version: Option<types::TbfHeaderV2KernelVersion> = None;
 
                 // Iterate the remainder of the header looking for TLV entries.
@@ -242,7 +240,11 @@ pub fn parse_tbf_header(
                         }
 
                         types::TbfHeaderTypes::TbfHeaderStoragePermissions => {
-                            storage_permissions_pointer = Some(remaining.try_into()?);
+                            storage_permissions_pointer = Some(
+                                remaining
+                                    .get(0..tlv_header.length as usize)
+                                    .ok_or(types::TbfParseError::NotEnoughFlash)?,
+                            );
                         }
 
                         types::TbfHeaderTypes::TbfHeaderKernelVersion => {

--- a/libraries/tock-tbf/src/parse.rs
+++ b/libraries/tock-tbf/src/parse.rs
@@ -132,7 +132,7 @@ pub fn parse_tbf_header(
                 let mut wfr_pointer: Option<&'static [u8]> = None;
                 let mut app_name_str = "";
                 let mut fixed_address_pointer: Option<&'static [u8]> = None;
-                let mut permissions_pointer: Option<types::TbfHeaderV2Permissions<8>> = None;
+                let mut permissions_pointer: Option<&'static [u8]> = None;
                 let mut storage_permissions_pointer: Option<
                     types::TbfHeaderV2StoragePermissions<8>,
                 > = None;
@@ -234,7 +234,11 @@ pub fn parse_tbf_header(
                         }
 
                         types::TbfHeaderTypes::TbfHeaderPermissions => {
-                            permissions_pointer = Some(remaining.try_into()?);
+                            permissions_pointer = Some(
+                                remaining
+                                    .get(0..tlv_header.length as usize)
+                                    .ok_or(types::TbfParseError::NotEnoughFlash)?,
+                            );
                         }
 
                         types::TbfHeaderTypes::TbfHeaderStoragePermissions => {

--- a/libraries/tock-tbf/src/parse.rs
+++ b/libraries/tock-tbf/src/parse.rs
@@ -129,8 +129,7 @@ pub fn parse_tbf_header(
                 // options.
                 let mut main_pointer: Option<types::TbfHeaderV2Main> = None;
                 let mut program_pointer: Option<types::TbfHeaderV2Program> = None;
-                let mut wfr_pointer: [Option<types::TbfHeaderV2WriteableFlashRegion>; 4] =
-                    Default::default();
+                let mut wfr_pointer: Option<&'static [u8]> = None;
                 let mut app_name_str = "";
                 let mut fixed_address_pointer: Option<types::TbfHeaderV2FixedAddresses> = None;
                 let mut permissions_pointer: Option<types::TbfHeaderV2Permissions<8>> = None;
@@ -194,32 +193,12 @@ pub fn parse_tbf_header(
                                 % mem::size_of::<types::TbfHeaderV2WriteableFlashRegion>()
                                 == 0
                             {
-                                // Calculate how many writeable flash regions
-                                // there are specified in this header.
-                                let wfr_len =
-                                    mem::size_of::<types::TbfHeaderV2WriteableFlashRegion>();
-                                let mut number_regions = tlv_header.length as usize / wfr_len;
-
                                 // Capture a slice with just the wfr information.
                                 let wfr_slice = remaining
                                     .get(0..tlv_header.length as usize)
                                     .ok_or(types::TbfParseError::NotEnoughFlash)?;
 
-                                // To enable a static buffer, we only support up
-                                // to four writeable flash regions.
-                                if number_regions > 4 {
-                                    number_regions = 4;
-                                }
-
-                                // Convert and store each wfr.
-                                for i in 0..number_regions {
-                                    wfr_pointer[i] = Some(
-                                        wfr_slice
-                                            .get(i * wfr_len..(i + 1) * wfr_len)
-                                            .ok_or(types::TbfParseError::NotEnoughFlash)?
-                                            .try_into()?,
-                                    );
-                                }
+                                wfr_pointer = Some(wfr_slice);
                             } else {
                                 return Err(types::TbfParseError::BadTlvEntry(
                                     tlv_header.tipe as usize,
@@ -295,7 +274,7 @@ pub fn parse_tbf_header(
                     main: main_pointer,
                     program: program_pointer,
                     package_name: Some(app_name_str),
-                    writeable_regions: Some(wfr_pointer),
+                    writeable_regions: wfr_pointer,
                     fixed_addresses: fixed_address_pointer,
                     permissions: permissions_pointer,
                     storage_permissions: storage_permissions_pointer,

--- a/libraries/tock-tbf/src/types.rs
+++ b/libraries/tock-tbf/src/types.rs
@@ -666,7 +666,7 @@ pub struct TbfHeaderV2 {
     pub(crate) program: Option<TbfHeaderV2Program>,
     pub(crate) package_name: Option<&'static str>,
     pub(crate) writeable_regions: Option<&'static [u8]>,
-    pub(crate) fixed_addresses: Option<TbfHeaderV2FixedAddresses>,
+    pub(crate) fixed_addresses: Option<&'static [u8]>,
     pub(crate) permissions: Option<TbfHeaderV2Permissions<8>>,
     pub(crate) storage_permissions: Option<TbfHeaderV2StoragePermissions<NUM_STORAGE_PERMISSIONS>>,
     pub(crate) kernel_version: Option<TbfHeaderV2KernelVersion>,
@@ -836,7 +836,8 @@ impl TbfHeader {
             TbfHeader::TbfHeaderV2(hd) => hd,
             _ => return None,
         };
-        match hd.fixed_addresses.as_ref()?.start_process_ram {
+        let fixed_addresses: TbfHeaderV2FixedAddresses = hd.fixed_addresses?.try_into().ok()?;
+        match fixed_addresses.start_process_ram {
             0xFFFFFFFF => None,
             start => Some(start),
         }
@@ -849,7 +850,8 @@ impl TbfHeader {
             TbfHeader::TbfHeaderV2(hd) => hd,
             _ => return None,
         };
-        match hd.fixed_addresses.as_ref()?.start_process_flash {
+        let fixed_addresses: TbfHeaderV2FixedAddresses = hd.fixed_addresses?.try_into().ok()?;
+        match fixed_addresses.start_process_flash {
             0xFFFFFFFF => None,
             start => Some(start),
         }


### PR DESCRIPTION
### Pull Request Overview

Currently the `TbfHeader` struct is 368 bytes, even if the app doesn't have many of the TBF fields. This might not be desirable for two reasons:

1. Passing a `TbfHeader` on the stack takes a fair bit of stack memory.
2. Every `ProcessStandard` object stores a `TbfHeader` in the process memory.

With this PR, the size of `TbfHeader` drops to 120 bytes.

Instead of parsing the entire TBF header into objects when the process is loaded, this only parses the key fields (base/program/main). The other fields are stored as static arrays. When something wants to read the TBF header, the static arrays are parsed. This trades some execution time for memory savings.

This change has one other benefit: we don't have to limit TBF TLVs which are arrays by nature to a fixed length. For example, right now if a TBF has more than 8 driver permissions we just ignore the permissions after 8. Now we can iterate over all of them.

### Testing Strategy

Not extensively. Just enough to verify the hifive1b board doesn't overflow its stack.


### TODO or Help Wanted

Thoughts?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
