### PR TITLE
Doc: update boards readme with new boards and add script

### DIFF
--- a/boards/README.md
+++ b/boards/README.md
@@ -57,6 +57,7 @@ but the approximate definitions:
 | [Imix](imix/README.md)                                            | ARM Cortex-M4    | SAM4LC8CA      | Bootloader | tockloader                  | No            |
 | [Nordic nRF52840-DK](nordic/nrf52840dk/README.md)                 | ARM Cortex-M4    | nRF52840       | jLink      | tockloader                  | No            |
 | [Nano 33 BLE](nano33ble/README.md)                                | ARM Cortex-M4    | nRF52840       | Bootloader | tockloader                  | No            |
+| [Nano 33 BLE Rev2](nano33ble_rev2/README.md)                      | ARM Cortex-M4    | nRF52840       | Bootloader | tockloader                  | No            |
 | [BBC Micro:bit v2](microbit_v2/README.md)                         | ARM Cortex-M4    | nRF52833       | openocd    | tockloader                  | No            |
 | [Clue nRF52840](clue_nrf52840/README.md)                          | ARM Cortex-M4    | nRF52840       | Bootloader | tockloader                  | No            |
 
@@ -68,15 +69,20 @@ but the approximate definitions:
 | [Nordic nRF52840-Dongle](nordic/nrf52840_dongle/README.md)        | ARM Cortex-M4    | nRF52840       | jLink      | tockloader                  | No            |
 | [Particle Boron](particle_boron/README.md)                        | ARM Cortex-M4    | nRF52840       | jLink      | tockloader                  | No            |
 | [ACD52832](acd52832/README.md)                                    | ARM Cortex-M4    | nRF52832       | jLink      | tockloader                  | No            |
+| [MakePython nRF52840dk](makepython-nrf52840/README.md)            | ARM Cortex-M4    | nRF52840       | Bootloader | tockloader                  | No            |
 | [ST Nucleo F446RE](nucleo_f446re/README.md)                       | ARM Cortex-M4    | STM32F446      | openocd    | custom                      | https://github.com/tock/tock/issues/1827 |
 | [ST Nucleo F429ZI](nucleo_f429zi/README.md)                       | ARM Cortex-M4    | STM32F429      | openocd    | custom                      | https://github.com/tock/tock/issues/1827 |
 | [STM32F3Discovery kit](stm32f3discovery/README.md)                | ARM Cortex-M4    | STM32F303VCT6  | openocd    | custom                      | https://github.com/tock/tock/issues/1827 |
 | [STM32F412G Discovery kit](stm32f412gdiscovery/README.md)         | ARM Cortex-M4    | STM32F412G     | openocd    | custom                      | https://github.com/tock/tock/issues/1827 |
+| [STM32F429I Discovery kit](stm32f429idiscovery/README.md)         | ARM Cortex-M4    | STM32F429I     | openocd    | custom                      | https://github.com/tock/tock/issues/1827 |
 | [Pico Explorer Base](pico_explorer_base/README.md)                | ARM Cortex-M0+   | RP2040         | openocd    | openocd                     | No            |
 | [Nano RP2040 Connect](nano_rp2040_connect/README.md)              | ARM Cortex-M0+   | RP2040         | custom     | custom                      | No            |
 | [Raspberry Pi Pico](raspberry_pi_pico/README.md)                  | ARM Cortex-M0+   | RP2040         | openocd    | openocd                     | No            |
-| [SparkFun RedBoard Artemis Nano](apollo3/redboard_artemis_nano/README.md) | ARM Cortex-M4    | Apollo3        | custom     | custom                      | No            |
-| [SparkFun LoRa Thing Plus - expLoRaBLE](apollo3/lora_things_plus/README.md) | ARM Cortex-M4    | Apollo3        | custom     | custom                      | No            |
+| [SparkFun RedBoard Artemis Nano](apollo3/redboard_artemis_nano/README.md) | ARM Cortex-M4 | Apollo3   | custom     | custom                      | No            |
+| [SparkFun LoRa Thing Plus - expLoRaBLE](apollo3/lora_things_plus/README.md) | ARM Cortex-M4 | Apollo3 | custom     | custom                      | No            |
+| [SparkFun RedBoard Artemis ATP](apollo3/redboard_artemis_atp/README.md) | ARM Cortex-M4 | Apollo3     | custom     | custom                      | No            |
+| [SMA Q3](sma_q3/README.md)                                        | ARM Cortex-M4    | nRF52840       | openocd    | tockloader                  | No            |
+| [Wio WM1110 Development Board](wm1110dev/README.md)               | ARM Cortex-M4    | nRF52840       | Bootloader | tockloader                  | No            |
 
 ### Tier 3
 
@@ -85,11 +91,12 @@ but the approximate definitions:
 | [WeAct F401CCU6 Core Board](weact_f401ccu6/README.md)             | ARM Cortex-M4    | STM32F401CCU6  | openocd    | custom                      | No            |
 | [SparkFun RedBoard Red-V](redboard_redv/README.md)                | RISC-V           | FE310-G002     | openocd    | tockloader                  | Yes (5.1)     |
 | [SiFive HiFive1 Rev B](hifive1/README.md)                         | RISC-V           | FE310-G002     | openocd    | tockloader                  | Yes (5.1)     |
-| [BBC HiFive Inventor](hifive1/README.md)                          | RISC-V           | FE310-G003     | tockloader | tockloader                  | No            |
+| [BBC HiFive Inventor](hifive_inventor/README.md)                  | RISC-V           | FE310-G003     | tockloader | tockloader                  | No            |
 | [ESP32-C3-DevKitM-1](esp32-c3-devkitM-1/README.md)                | RISC-V-ish RV32I | ESP32-C3       | custom     | custom                      | No            |
 | [i.MX RT 1052 Evaluation Kit](imxrt1050-evkb/README.md)           | ARM Cortex-M7    | i.MX RT 1052   | custom     | custom                      | No            |
 | [Teensy 4.0](teensy40/README.md)                                  | ARM Cortex-M7    | i.MX RT 1062   | custom     | custom                      | No            |
 | [Digilent Arty A-7 100T](arty_e21/README.md)                      | RISC-V RV32IMAC  | SiFive E21     | openocd    | tockloader                  | No            |
+| [MSP432 Evaluation kit MSP432P401R](msp_exp432p401r/README.md)    | ARM Cortex-M4    | MSP432P401R    | openocd    | custom                      | No            |
 
 
 ### Other
@@ -100,13 +107,14 @@ An FPGA and Verilator implementation that is well supported and is regularly tes
 |-------------------------------------------------------------------|------------------|----------------|------------|-----------------------------|---------------|
 | [OpenTitan Earlgrey on CW310](opentitan/earlgrey-cw310/README.md) | RISC-V RV32IMC   | EarlGrey       | custom     | custom                      | Yes (5.1)     |
 
-Virtual hardware platforms that are regulary tested as part of the CI.
+Virtual hardware platforms that are regularly tested as part of the CI.
 
 | Board                                                             | Architecture     | MCU            | Interface  | App deployment              | QEMU Support? |
 |-------------------------------------------------------------------|------------------|----------------|------------|-----------------------------|---------------|
 | [QEMU RISC-V 32 bit `virt` platform](qemu_rv32_virt/README.md)    | RISC-V RV32IMAC  | QEMU           | custom     | custom                      | Yes (7.2.0)   |
 | [LiteX on Digilent Arty A-7](litex/arty/README.md)                | RISC-V RV32IMC   | LiteX+VexRiscV | custom     | tockloader (flash-file)[^1] | No            |
 | [Verilated LiteX Simulation](litex/sim/README.md)                 | RISC-V RV32IMC   | LiteX+VexRiscv | custom     | tockloader (flash-file)[^1] | No            |
+| [SweRVolf](swervolf/README.md)                                    | RISC-V RV32IMC   | swervolf-eh1   | custom     | tockloader (flash-file)[^1] | No            |
 
 [^1]: Tockloader is not able to interact with this board directly, but
       can be used to work on a flash-image of the board, which can in

--- a/tools/check_boards_readme.py
+++ b/tools/check_boards_readme.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
+"""
+Check if all of the available boards are documented in the README.
+"""
+
+import os
+import re
+import sys
+
+SKIP = ["boards/components", "boards/nordic/nrf52_components"]
+
+
+documented_boards = []
+implemented_boards = []
+
+# Find all documented capsules
+with open("boards/README.md") as f:
+    for l in f:
+        items = re.findall(r".*\((.*?/README.md)\).*", l)
+        if len(items) > 0:
+            for item in items:
+                documented_boards.append("boards/{}".format(item))
+
+
+# Find all capsule source files.
+for subdir, dirs, files in os.walk(os.fsencode("boards/")):
+    # Skip some directories we do not consider.
+    for skip in SKIP:
+        if skip in os.fsdecode(subdir):
+            break
+    else:
+        for file in files:
+            if os.fsdecode(file) == "Cargo.toml":
+                # Create the filepath to the board readme.
+                filepath = os.fsdecode(
+                    os.path.join(subdir, "README.md".encode("utf-8"))
+                )
+                implemented_boards.append(filepath)
+
+
+# Calculate what doesn't seem to be documented.
+missing = list(set(implemented_boards) - set(documented_boards))
+
+# Calculate what has been removed
+removed = list(set(documented_boards) - set(implemented_boards))
+
+
+if len(missing) > 0:
+    print("The following boards do not seem to be documented:")
+    for m in sorted(missing):
+        print(" - {}".format(m))
+
+if len(removed) > 0:
+    print("The following boards seem to have been removed:")
+    for m in sorted(removed):
+        print(" - {}".format(m))
+
+
+if len(missing) > 0:
+    print("ERROR: Boards missing documentation")
+    sys.exit(-1)
+
+if len(removed) > 0:
+    print("ERROR: Boards documented that are missing")
+    sys.exit(-1)
+
+print("Board documentation up to date.")


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the top level boards readme with new chips added somewhat recently.

This also adds a script for finding boards which are not documented.


### Testing Strategy

n/a


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
