### PR TITLE
stm32f429zi: rtc deferred call

### DIFF
--- a/chips/stm32f429zi/src/interrupt_service.rs
+++ b/chips/stm32f429zi/src/interrupt_service.rs
@@ -33,6 +33,7 @@ impl<'a> Stm32f429ziDefaultPeripherals<'a> {
     pub fn init(&'static self) {
         self.stm32f4.setup_circular_deps();
         kernel::deferred_call::DeferredCallClient::register(&self.can1);
+        kernel::deferred_call::DeferredCallClient::register(&self.rtc);
     }
 }
 impl<'a> kernel::platform::chip::InterruptService for Stm32f429ziDefaultPeripherals<'a> {


### PR DESCRIPTION
### Pull Request Overview

Need to register the deferred call for stm32f429zi RTC.


### Testing Strategy

Running tock. The kernel crashes without this.

```
---| No debug queue found. You can set it with the DebugQueue component.

panicked at kernel/src/deferred_call.rs:249:13:
ERROR: 7 deferred calls, 6 registered
	Kernel version release-2.1-2674-g67acd8f7a

---| Cortex-M Fault Status |---
No Cortex-M faults detected.

---| App Status |---
```

### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
