### PR TITLE
kernel: deferred call: better error panic

### DIFF
--- a/kernel/src/deferred_call.rs
+++ b/kernel/src/deferred_call.rs
@@ -240,11 +240,11 @@ impl DeferredCall {
         let ctr = unsafe { &CTR };
         let defcalls = unsafe { &DEFCALLS };
         let num_deferred_calls = ctr.get();
-        if num_deferred_calls >= defcalls.len()
-            || defcalls.iter().filter(|opt| opt.is_some()).count() != num_deferred_calls
-        {
+        let num_registered_calls = defcalls.iter().filter(|opt| opt.is_some()).count();
+        if num_deferred_calls >= defcalls.len() || num_registered_calls != num_deferred_calls {
             panic!(
-                "ERROR: > 32 deferred calls, or a component forgot to register a deferred call."
+                "ERROR: {} deferred calls, {} registered. A component may have forgotten to register a deferred call.",
+                num_deferred_calls, num_registered_calls
             );
         }
     }


### PR DESCRIPTION
### Pull Request Overview
Update the panic message to provide at least a bit of information.

Debugging this panic is incredibly difficult as it is, at least this tells you how many bad deferred calls you have to track down.


### Testing Strategy

well, you know...


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
