### PR TITLE
arch/cortex-m3: re-export `initialize_ram_jump_to_main`

### DIFF
--- a/arch/cortex-m3/src/lib.rs
+++ b/arch/cortex-m3/src/lib.rs
@@ -14,6 +14,7 @@ pub mod mpu {
     pub type MPU = cortexm::mpu::MPU<8, 32>;
 }
 
+pub use cortexm::initialize_ram_jump_to_main;
 pub use cortexm::nvic;
 pub use cortexm::scb;
 pub use cortexm::support;


### PR DESCRIPTION
I don't see a reason for `initialize_ram_jump_to_main()` being valid for `cortex-m4` and invalid for `cortex-m3`. I claim that since it's re-exported by `cortex-m4`, it should be re-exported as well by `cortex-m3`.

### Pull Request Overview

`initialize_ram_jump_to_main()` is now re-exported by `cortex-m3` crate.

### TODO or Help Wanted

Please confirm that such re-export is valid for cortex-m3.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
