### PR TITLE
tock-registers: Fix a `cargo miri test` memory leak error.

### DIFF
--- a/libraries/tock-register-interface/src/interfaces.rs
+++ b/libraries/tock-register-interface/src/interfaces.rs
@@ -54,8 +54,9 @@
 //!           DUMMY OFFSET(0) NUMBITS(1) [],
 //!       ],
 //!   ];
+//!   let mut register_memory: u8 = 0;
 //!   let read_write_reg: &ReadWrite<u8, A::Register> = unsafe {
-//!       core::mem::transmute(Box::leak(Box::new(0_u8)))
+//!       core::mem::transmute(&mut register_memory)
 //!   };
 //!   ReadWriteable::modify(read_write_reg, A::DUMMY::SET);
 //!   ```


### PR DESCRIPTION
Manually tested.

Note that we don't seem to be running Miri tests in CI, and currently `make ci-job-miri` fails for reasons unrelated to tock-registers.