### PR TITLE
Raw Receive

### DIFF
--- a/capsules/extra/src/ieee802154/framer.rs
+++ b/capsules/extra/src/ieee802154/framer.rs
@@ -497,6 +497,10 @@ impl<'a, M: Mac<'a>, A: AES128CCM<'a>> Framer<'a, M, A> {
                         let key = match self.lookup_key(security.level, security.key_id) {
                             Some(key) => key,
                             None => {
+                                // Key not found -- pass raw encrypted packet to client
+                                self.rx_client.map(|client| {
+                                    client.receive(buf, header, radio::PSDU_OFFSET + data_offset, data_len);
+                                });
                                 return None;
                             }
                         };


### PR DESCRIPTION
### Pull Request Overview

This pull request addresses the challenge addressed in #3903. This implementation elects to naively pass the encrypted packet to userland. The primary drawback of this implementation is that encrypted and decrypted packets are passed to userland in the same manner and the userprocess must infer if the packet remains encrypted. In actuality, this is less of a concern as the userprocess may assume the packet is decrypted if it registered a network key and encrypted if it did not register a key with the 15.4 capsule.

### Testing Strategy

This pull request was tested as part of the OpenThread port.


### TODO or Help Wanted

This pull request needs comments on the design choice to naively pass packets. The alternative is to add additional metadata to the passed packet (as proposed in the #3903).

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
