### PR TITLE
wm1110: add nonvolatile storage

### DIFF
--- a/boards/components/src/nonvolatile_storage.rs
+++ b/boards/components/src/nonvolatile_storage.rs
@@ -48,6 +48,8 @@ macro_rules! nonvolatile_storage_component_static {
     };};
 }
 
+pub type NonvolatileStorageComponentType = NonvolatileStorage<'static>;
+
 pub struct NonvolatileStorageComponent<
     F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, NonvolatileToPages<'static, F>>,
 > {

--- a/boards/wm1110dev/layout.ld
+++ b/boards/wm1110dev/layout.ld
@@ -2,10 +2,12 @@
 /* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
 /* Copyright Tock Contributors 2023.                                  */
 
+/* prog: leave 16KB at the end for nonvolatile storage. */
+
 MEMORY
 {
   rom (rx)  : ORIGIN = 0x00010000, LENGTH = 256K
-  prog (rx) : ORIGIN = 0x00050000, LENGTH = 704K
+  prog (rx) : ORIGIN = 0x00050000, LENGTH = 704K-16K
   ram (rwx) : ORIGIN = 0x20000000, LENGTH = 256K
 }
 


### PR DESCRIPTION
### Pull Request Overview

For the WM1110 LoRa stack, we need persistent storage to store context. This adds the nonvolatile storage driver to enable saving context in the userspace library.


### Testing Strategy

Getting the LoRa stack running.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
