### PR TITLE
Code updates from new nightly

### DIFF
--- a/arch/riscv/src/csr/mtvec.rs
+++ b/arch/riscv/src/csr/mtvec.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use kernel::utilities::registers::{register_bitfields, LocalRegisterCopy};
+use kernel::utilities::registers::register_bitfields;
 
 // mtvec contains the address(es) of the trap handler
 register_bitfields![usize,
@@ -14,13 +14,3 @@ register_bitfields![usize,
         ]
     ]
 ];
-
-trait MtvecHelpers {
-    fn get_trap_address(&self) -> usize;
-}
-
-impl MtvecHelpers for LocalRegisterCopy<usize, mtvec::Register> {
-    fn get_trap_address(&self) -> usize {
-        self.read(mtvec::trap_addr) << 2
-    }
-}

--- a/arch/riscv/src/csr/stvec.rs
+++ b/arch/riscv/src/csr/stvec.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use kernel::utilities::registers::{register_bitfields, LocalRegisterCopy};
+use kernel::utilities::registers::register_bitfields;
 
 // stvec contains the address(es) of the trap handler
 register_bitfields![usize,
@@ -14,13 +14,3 @@ register_bitfields![usize,
         ]
     ]
 ];
-
-trait StvecHelpers {
-    fn get_trap_address(&self) -> usize;
-}
-
-impl StvecHelpers for LocalRegisterCopy<usize, stvec::Register> {
-    fn get_trap_address(&self) -> usize {
-        self.read(stvec::trap_addr) << 2
-    }
-}

--- a/arch/riscv/src/csr/utvec.rs
+++ b/arch/riscv/src/csr/utvec.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use kernel::utilities::registers::{register_bitfields, LocalRegisterCopy};
+use kernel::utilities::registers::register_bitfields;
 
 // utvec contains the address(es) of the trap handler
 register_bitfields![usize,
@@ -14,13 +14,3 @@ register_bitfields![usize,
         ]
     ]
 ];
-
-trait UtvecHelpers {
-    fn get_trap_address(&self) -> usize;
-}
-
-impl UtvecHelpers for LocalRegisterCopy<usize, utvec::Register> {
-    fn get_trap_address(&self) -> usize {
-        self.read(utvec::trap_addr) << 2
-    }
-}

--- a/capsules/extra/src/screen_shared.rs
+++ b/capsules/extra/src/screen_shared.rs
@@ -26,8 +26,6 @@
 //! screen config settings (brightness, invert) as those operations affect the
 //! entire screen.
 
-use core::convert::From;
-
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::hil;
 use kernel::processbuffer::ReadableProcessBuffer;

--- a/chips/nrf52840/src/ieee802154_radio.rs
+++ b/chips/nrf52840/src/ieee802154_radio.rs
@@ -6,8 +6,6 @@
 
 use crate::timer::TimerAlarm;
 use core::cell::Cell;
-use core::convert::TryFrom;
-use kernel;
 use kernel::hil::radio::{self, PowerClient, RadioChannel, RadioData};
 use kernel::hil::time::{Alarm, AlarmClient, Time};
 use kernel::utilities::cells::{OptionalCell, TakeCell};


### PR DESCRIPTION
### Pull Request Overview

The new nightly has new warnings. Some lingering duplicate imports, and some unused code in riscv CSRs.


### Testing Strategy

`make check`


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
