### PR TITLE
[opentitan] Fix spurious `0` byte reads on the LowRISC UART driver.

### DIFF
--- a/chips/lowrisc/src/uart.rs
+++ b/chips/lowrisc/src/uart.rs
@@ -194,9 +194,6 @@ impl<'a> Uart<'a> {
                 let mut return_code = Ok(());
 
                 for i in self.rx_index.get()..self.rx_len.get() {
-                    rx_buf[i] = regs.rdata.get() as u8;
-                    len = i + 1;
-
                     if regs.status.is_set(STATUS::RXEMPTY) {
                         /* RX is empty */
 
@@ -213,6 +210,9 @@ impl<'a> Uart<'a> {
                             break;
                         }
                     }
+
+                    rx_buf[i] = regs.rdata.get() as u8;
+                    len = i + 1;
                 }
 
                 client.received_buffer(rx_buf, len, return_code, uart::Error::None);


### PR DESCRIPTION
This bug appears to have been previously fixed (#3641), then mistakenly un-fixed during a refactoring (#3729), probably due to merge skew. I'm reapplying the fix from #3641.

This PR was tested by running a UART test that I'm developing 100 times, and seeing no errors.