### PR TITLE
rust: suppress static warnings on stable compiler

### DIFF
--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -7,6 +7,9 @@
 #![crate_name = "cortexm"]
 #![crate_type = "rlib"]
 #![no_std]
+// Suppress warnings until we have a principled solution.
+// See: https://github.com/tock/tock/issues/3841
+#![allow(static_mut_refs)]
 
 use core::fmt::Write;
 

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -12,6 +12,9 @@
 // https://github.com/rust-lang/rust/issues/62184.
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
+// Suppress warnings until we have a principled solution.
+// See: https://github.com/tock/tock/issues/3841
+#![allow(static_mut_refs)]
 
 use kernel::capabilities;
 use kernel::component::Component;

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -91,6 +91,9 @@
 
 #![warn(unreachable_pub)]
 #![no_std]
+// Suppress warnings until we have a principled solution.
+// See: https://github.com/tock/tock/issues/3841
+#![allow(static_mut_refs)]
 
 /// Kernel major version.
 ///


### PR DESCRIPTION
### Pull Request Overview

This is a stop-gap measure to allow the hail board compile without warnings with the latest stable compiler.

We will revert this soon when we have a better design.






### Testing Strategy

running make and travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
