### PR TITLE
Pin hail stable to 1.76 until static mut fixed

### DIFF
--- a/boards/hail/rust-toolchain.toml
+++ b/boards/hail/rust-toolchain.toml
@@ -3,6 +3,6 @@
 # Copyright Tock Contributors 2023.
 
 [toolchain]
-channel = "stable"
+channel = "1.76.0"
 components = ["llvm-tools", "rust-src", "rustfmt", "clippy"]
 targets = ["thumbv6m-none-eabi", "thumbv7em-none-eabi", "thumbv7em-none-eabihf", "riscv32imc-unknown-none-elf", "riscv32imac-unknown-none-elf"]


### PR DESCRIPTION
### Pull Request Overview

This pull request pins Hail's rust stable to 1.76 until the static mut issue is fixed. Current stable (as of 1.77) warns of use of static muts and therefore we can't successfully build in the CI.

This will be reverted along with the PR to avoid static muts.

### Testing Strategy

`cd boards/hail; make`

### TODO or Help Wanted

N/A
