### PR TITLE
cortex-m: Add initial dwt and dcb support, take 2

### DIFF
--- a/arch/cortex-m/src/dcb.rs
+++ b/arch/cortex-m/src/dcb.rs
@@ -1,0 +1,100 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! ARM Debug Control Block
+//!
+//! <https://developer.arm.com/documentation/ddi0403/latest>
+//! Implementation matches `ARM DDI 0403E.e`
+
+use kernel::utilities::registers::interfaces::ReadWriteable;
+use kernel::utilities::registers::{register_bitfields, register_structs, ReadWrite, WriteOnly};
+use kernel::utilities::StaticRef;
+
+register_structs! {
+    DcbRegisters {
+        /// Debug Halting Control and Status Register
+        (0x00 => dhcsr: ReadWrite<u32, DebugHaltingControlAndStatus::Register>),
+
+        /// Debug Core Register Selector Register
+        (0x04 => dcrsr: WriteOnly<u32, DebugCoreRegisterSelector::Register>),
+
+        /// Debug Core Register Data Register
+        (0x08 => dcrdr: ReadWrite<u32, DebugCoreRegisterData::Register>),
+
+        /// Debug Exception and Monitor Control Register
+        (0xC => demcr: ReadWrite<u32, DebugExceptionAndMonitorControl::Register>),
+
+        (0x10 => @END),
+    }
+}
+
+register_bitfields![u32,
+    DebugHaltingControlAndStatus [
+        /// Debug key. 0xA05F must be written to enable write access to bits 15 through 0.
+        /// WO.
+        DBGKEY          OFFSET(16)  NUMBITS(16),
+
+        /// Is 1 if at least one reset happend since last read of this register. Is cleared to 0 on
+        /// read.
+        /// RO.
+        S_RESET_ST      OFFSET(25)  NUMBITS(1),
+
+        /// Is 1 if at least one instruction was retired since last read of this register.
+        /// It is cleared to 0 after a read of this register.
+        /// RO.
+        S_RETIRE_ST     OFFSET(24)  NUMBITS(1),
+
+        /// Is 1 when the processor is locked up doe tu an unrecoverable instruction.
+        /// RO.
+        S_LOCKUP        OFFSET(20)  NUMBITS(4),
+
+        /// Is 1 if processor is in debug state.
+        /// RO.
+        S_SLEEP         OFFSET(18)  NUMBITS(1),
+
+        /// Is used as a handshake flag for transfers through DCRDR. Writing to DCRSR clears this
+        /// bit to 0. Is 0 if there is a transfer that has not completed and 1 on completion of the DCRSR transfer.
+        ///
+        /// RW.
+        S_REGREADY      OFFSET(16)  NUMBITS(1),
+    ],
+    DebugCoreRegisterSelector [
+        DBGTMP          OFFSET(0)   NUMBITS(32)
+    ],
+    DebugCoreRegisterData [
+        DBGTMP          OFFSET(0)   NUMBITS(32)
+    ],
+    DebugExceptionAndMonitorControl [
+        /// Write 1 to globally enable all DWT and ITM features.
+        TRCENA          OFFSET(24)  NUMBITS(1),
+
+        /// Debug monitor semaphore bit.
+        /// Monitor software defined.
+        MON_REQ         OFFSET(19)  NUMBITS(1),
+
+        /// Write 1 to make step request pending.
+        MON_STEP        OFFSET(18)  NUMBITS(1),
+        /// Write 0 to clear the pending state of the DebugMonitor exception.
+        /// Writing 1 pends the exception.
+        MON_PEND        OFFSET(17)  NUMBITS(1),
+
+        /// Write 1 to enable DebugMonitor exception.
+        MON_EN        OFFSET(16)  NUMBITS(1),
+    ],
+];
+
+const DCB: StaticRef<DcbRegisters> = unsafe { StaticRef::new(0xE000EDF0 as *const DcbRegisters) };
+
+/// Enable the Debug and Trace unit `DWT`
+/// This has to be enabled before using any feature of the `DWT`
+pub fn enable_debug_and_trace() {
+    DCB.demcr
+        .modify(DebugExceptionAndMonitorControl::TRCENA::SET);
+}
+
+/// Disable the Debug and Trace unit `DWT`
+pub fn disable_debug_and_trace() {
+    DCB.demcr
+        .modify(DebugExceptionAndMonitorControl::TRCENA::CLEAR);
+}

--- a/arch/cortex-m/src/dwt.rs
+++ b/arch/cortex-m/src/dwt.rs
@@ -1,0 +1,479 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! ARM Data Watchpoint and Trace Unit
+//!
+//! <https://developer.arm.com/documentation/100166/0001/Data-Watchpoint-and-Trace-Unit/DWT-Programmers--model?lang=en>
+
+use super::dcb;
+use kernel::hil;
+use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
+use kernel::utilities::registers::{register_bitfields, register_structs, ReadOnly, ReadWrite};
+use kernel::utilities::StaticRef;
+
+register_structs! {
+    /// In an ARMv7-M processor, a System Control Block (SCB) in the SCS
+    /// provides key status information and control features for the processor.
+    DwtRegisters {
+        // Control Register
+        (0x00 => ctrl: ReadWrite<u32, Control::Register>),
+
+        // Cycle Count Register
+        (0x04 => cyccnt: ReadWrite<u32, CycleCount::Register>),
+
+        // CPI Count Register
+        (0x08 => cpicnt: ReadWrite<u32, CpiCount::Register>),
+
+        // Exception Overhead Register
+        (0x0C => exccnt: ReadWrite<u32, ExceptionOverheadCount::Register>),
+
+        // Sleep Count Register
+        (0x10 => sleepcnt: ReadWrite<u32, SleepCount::Register>),
+
+        // LSU Count Register
+        (0x14 => lsucnt: ReadWrite<u32, LsuCount::Register>),
+
+        // Folder-Instruction Count Register
+        (0x18 => foldcnt: ReadWrite<u32, FoldedInstructionCount::Register>),
+
+        // Program Count Sample Register
+        (0x1C => pcsr: ReadOnly<u32, ProgramCounterSample::Register>),
+
+        // Comparator Register0
+        (0x20 => comp0: ReadWrite<u32, Comparator0::Register>),
+
+        // Mask Regsiter0
+        // The maximum mask size is 32KB
+        (0x24 => mask0: ReadWrite<u32, Comparator0Mask::Register>),
+
+        // Function Register0
+        (0x28 => function0: ReadWrite<u32, Comparator0Function::Register>),
+
+        (0x2c => _reserved0),
+
+        // Comparator Register1
+        (0x30 => comp1: ReadWrite<u32, Comparator1::Register>),
+
+        // Mask Regsiter1
+        // The maximum mask size is 32KB
+        (0x34 => mask1: ReadWrite<u32, Comparator1Mask::Register>),
+
+        // Function Register1
+        (0x38 => function1: ReadWrite<u32, Comparator1Function::Register>),
+
+        (0x3c => _reserved1),
+
+        // Comparator Register2
+        (0x40 => comp2: ReadWrite<u32, Comparator2::Register>),
+
+        // Mask Regsiter2
+        // The maximum mask size is 32KB
+        (0x44 => mask2: ReadWrite<u32, Comparator2Mask::Register>),
+
+        // Function Register2
+        (0x48 => function2: ReadWrite<u32, Comparator2Function::Register>),
+
+        (0x4c => _reserved2),
+
+        // Comparator Register3
+        (0x50 => comp3: ReadWrite<u32, Comparator3::Register>),
+
+        // Mask Regsiter3
+        // The maximum mask size is 33KB
+        (0x54 => mask3: ReadWrite<u32, Comparator3Mask::Register>),
+
+        // Function Register3
+        (0x58 => function3: ReadWrite<u32, Comparator3Function::Register>),
+
+        (0x5c => @END),
+    }
+}
+
+register_bitfields![u32,
+    Control [
+        /// Number of Camparators implemented.
+        /// RO.
+        NUMCOMP         OFFSET(28)  NUMBITS(4),
+
+        /// Shows if trace sampling and exception tracing is implemented
+        /// Is 0 if supported, is 1 if it is not.
+        /// RO
+        NOTRCPKT        OFFSET(27)  NUMBITS(1),
+
+        /// Shows if external match signals ([`CMPMATCH`]) are implemented
+        /// Is 0 if supported, is 1 if it is not.
+        /// RO
+        NOEXITTRIG      OFFSET(26)  NUMBITS(1),
+
+        /// Shows if the cycle counter is implemented
+        /// Is 0 if supported, is 1 if it is not.
+        /// RO
+        NOCYCCNT        OFFSET(25)  NUMBITS(1),
+
+        /// Shows if profiling counters are supported.
+        /// Is 0 if supported, is 1 if it is not.
+        /// RO
+        NOPERFCNT       OFFSET(24)  NUMBITS(1),
+
+        /// Writing 1 enables event counter packets generation if [`PCSAMPLENA`] is set to 0.
+        /// Defaults to 0b0 on reset.
+        /// WARN: This bit is UNKNOWN if `NOTPRCPKT` or `NOCYCCNT` is read as one.
+        /// RW
+        CYCEVTENA       OFFSET(22)  NUMBITS(1),
+
+        /// Writing 1 enables generation of folded instruction counter overflow event. Defaults to
+        /// 0b0 on reset.
+        /// WARN: This bit is UNKNOWN if `NOPERFCNT` reads as one.
+        /// RW
+        FOLDEVTENA      OFFSET(21)  NUMBITS(1),
+
+        /// Writing 1 enables generation of LSU counter overflow event.
+        /// Defaults to 0b0 on reset.
+        /// WARN: This bit is UNKNOWN if `NOPERFCNT` reads as one.
+        /// RW
+        LSUEVTENA       OFFSET(20)  NUMBITS(1),
+
+        /// Writing 1 enables generation of sleep counter overflow event.
+        /// Defaults to 0b0 on reset.
+        /// WARN: This bit is UNKNOWN if `NOPERFCNT` reads as one.
+        /// RW
+        SLEEPEVTENA     OFFSET(19)  NUMBITS(1),
+
+        /// Writing 1 enables generation of exception overhead counter overflow event.
+        /// Defaults to 0b0 on reset.
+        /// WARN: This bit is UNKNOWN if `NOPERFCNT` reads as one.
+        /// RW
+        EXCEVTENA       OFFSET(18)  NUMBITS(1),
+
+        /// Writing 1 enables generation of the CPI counter overlow event.
+        /// Defaults to 0b0 on reset.
+        /// WARN: This bit is UNKNOWN if `NOPERFCNT` reads as one.
+        /// RW
+        CPIEVTENA       OFFSET(17)  NUMBITS(1),
+
+        /// Writing 1 enables generation of exception trace.
+        /// Defaults to 0b0 on reset.
+        /// WARN: This bit is UNKNOWN if `NOTRCPKT` reads as one.
+        /// RW
+        EXCTRCENA       OFFSET(16)  NUMBITS(1),
+
+        /// Writing 1 enables use of [`POSTCNT`] counter as a timer for Periodic PC sample packet
+        /// generation.
+        /// Defaults to 0b0 on reset.
+        /// WARN: This bit is UNKNOWN if `NOTRCPKT` or `NOCYCCNT` read as one.
+        /// RW
+        PCSAMPLENA      OFFSET(12)  NUMBITS(1),
+
+        /// Determines the position of synchronisation packet counter tap on the `CYCCNT` counter
+        /// and thus the synchronisation packet rate.
+        /// Defaults to UNKNOWN on reset.
+        /// WARN: This bit is UNKNOWN if `NOCYCCNT` reads as one.
+        /// RW
+        SYNCTAP         OFFSET(10)  NUMBITS(2),
+
+        /// Determines the position of the `POSTCNT` tap on the `CYCCNT` counter.
+        /// Defaults to UNKNOWN on reset.
+        /// WARN: This bit is UNKNOWN if `NOCYCCNT` reads as one.
+        /// RW
+        CYCTAP          OFFSET(9)  NUMBITS(1),
+
+        /// Initial value for the `POSTCNT` counter.
+        /// Defaults to UNKNOWN on reset.
+        /// WARN: This bit is UNKNOWN if `NOCYCCNT` reads as one.
+        /// RW
+        POSTINIT        OFFSET(8)  NUMBITS(4),
+
+        /// Reload value for the `POSTCNT` counter.
+        /// Defaults to UNKNOWN on reset.
+        /// WARN: This bit is UNKNOWN if `NOCYCCNT` reads as one.
+        /// RW
+        POSTPRESET      OFFSET(1)  NUMBITS(4),
+
+        /// Writing 1 enables `CYCCNT`.
+        /// Defaults to 0b0 on reset.
+        /// WARN: This bit is UNKNOWN if `NOCYCCNT` reads as one.
+        /// RW
+        CYCNTENA       OFFSET(0)  NUMBITS(1),
+    ],
+
+    CycleCount[
+        /// When enabled, increases on each processor clock cycle when Control::CYCNTENA and
+        /// DEMCRL::TRCENA read as one.
+        /// Wraps to zero on overflow.
+        CYCCNT          OFFSET(0)   NUMBITS(32),
+    ],
+
+    CpiCount[
+        /// Base instruction overhead counter.
+        CPICNT          OFFSET(0)   NUMBITS(8),
+    ],
+
+    ExceptionOverheadCount[
+        /// Counts cycles spent in exception processing.
+        EXCCNT          OFFSET(0)   NUMBITS(8),
+    ],
+
+    SleepCount[
+        /// Counts each cycle the processor is sleeping.
+        SLEEPCNT        OFFSET(0)   NUMBITS(8),
+    ],
+
+    LsuCount[
+        /// Counts additional cycles required to excecute all load store instructions
+        LSUCNT          OFFSET(0)   NUMBITS(8),
+    ],
+
+    FoldedInstructionCount[
+        /// Increments by one for each instruction that takes 0 cycles to excecute.
+        FOLDCNT          OFFSET(0)   NUMBITS(8),
+    ],
+
+    ProgramCounterSample[
+        /// Samples current value of the program counter
+        /// RO.
+        EIASAMPLE       OFFSET(0)   NUMBITS(32),
+    ],
+
+    Comparator0[
+        /// Reference value for comparator 0.
+        COMP       OFFSET(0)   NUMBITS(32),
+    ],
+
+    Comparator0Mask[
+        /// Size of ignore mask aplied to the access address for address range matching by comparator 0.
+        /// WARN: Maximum Mask size is IMPLEMENTATION DEFINED.
+        MASK       OFFSET(0)   NUMBITS(5),
+    ],
+
+    Comparator0Function[
+        /// Is one if comparator matches. Reading the register clears it to 0.
+        /// RO.
+        MATCHED     OFFSET(24)   NUMBITS(1),
+
+        /// Second comparator number for linked address comparison.
+        /// Works, when `DATAVMATCH` and `LNK1ENA` read as one.
+        /// RW.
+        DATAVADDR1  OFFSET(16)   NUMBITS(4),
+
+        /// Comparator number for linked address comparison.
+        /// Works, when `DATAVMATCH` reads as one.
+        /// RW.
+        DATAVADDR0  OFFSET(12)   NUMBITS(4),
+
+        /// Size of data comparision (Byte, Halfword, Word).
+        /// RW.
+        DATAVSIZE   OFFSET(10)   NUMBITS(2),
+
+        /// Reads as one if a second linked comparator is supported.
+        LNK1ENA     OFFSET(9)    NUMBITS(1),
+
+        /// Enables data value comparison
+        /// When 0: Perform address comparison, when 1: data value comparison.
+        /// RW.
+        DATAVMATCH  OFFSET(8)    NUMBITS(1),
+
+        /// Enable cycle count comparision for comparator 0.
+        /// WARN: Only supported by FUNCTION0
+        /// RW.
+        CYCMATCH    OFFSET(7)    NUMBITS(1),
+
+        /// Write 1 to enable generation of data trace address packets.
+        /// WARN: If `Control::NOTRCPKT` reads as zero, this bit is UNKNOWN.
+        /// RW.
+        EMITRANGE   OFFSET(5)    NUMBITS(1),
+
+        /// Selects action taken on comparator match.
+        /// Resets to 0b0000.
+        /// RW.
+        FUNCTION    OFFSET(0)    NUMBITS(4),
+    ],
+
+    Comparator1[
+        /// Reference value for comparator 0.
+        COMP       OFFSET(0)   NUMBITS(32),
+    ],
+
+    Comparator1Mask[
+        /// Size of ignore mask aplied to the access address for address range matching by comparator 0.
+        /// WARN: Maximum Mask size is IMPLEMENTATION DEFINED.
+        MASK       OFFSET(0)   NUMBITS(5),
+    ],
+
+    Comparator1Function[
+        /// Is one if comparator matches. Reading the register clears it to 0.
+        /// RO.
+        MATCHED     OFFSET(24)   NUMBITS(1),
+
+        /// Second comparator number for linked address comparison.
+        /// Works, when `DATAVMATCH` and `LNK1ENA` read as one.
+        /// RW.
+        DATAVADDR1  OFFSET(16)   NUMBITS(4),
+
+        /// Comparator number for linked address comparison.
+        /// Works, when `DATAVMATCH` reads as one.
+        /// RW.
+        DATAVADDR0  OFFSET(12)   NUMBITS(4),
+
+        /// Size of data comparision (Byte, Halfword, Word).
+        /// RW.
+        DATAVSIZE   OFFSET(10)   NUMBITS(2),
+
+        /// Reads as one if a second linked comparator is supported.
+        LNK1ENA     OFFSET(9)    NUMBITS(1),
+
+        /// Enables data value comparison
+        /// When 0: Perform address comparison, when 1: data value comparison.
+        /// RW.
+        DATAVMATCH  OFFSET(8)    NUMBITS(1),
+
+        /// Write 1 to enable generation of data trace address packets.
+        /// WARN: If `Control::NOTRCPKT` reads as zero, this bit is UNKNOWN.
+        /// RW.
+        EMITRANGE   OFFSET(5)    NUMBITS(1),
+
+        /// Selects action taken on comparator match.
+        /// Resets to 0b0000.
+        /// RW.
+        FUNCTION    OFFSET(0)    NUMBITS(4),
+    ],
+
+    Comparator2[
+        /// Reference value for comparator 0.
+        COMP       OFFSET(0)   NUMBITS(32),
+    ],
+
+    Comparator2Mask[
+        /// Size of ignore mask aplied to the access address for address range matching by comparator 0.
+        /// WARN: Maximum Mask size is IMPLEMENTATION DEFINED.
+        MASK       OFFSET(0)   NUMBITS(5),
+    ],
+
+    Comparator2Function[
+        /// Is one if comparator matches. Reading the register clears it to 0.
+        /// RO.
+        MATCHED     OFFSET(24)   NUMBITS(1),
+
+        /// Second comparator number for linked address comparison.
+        /// Works, when `DATAVMATCH` and `LNK1ENA` read as one.
+        /// RW.
+        DATAVADDR1  OFFSET(16)   NUMBITS(4),
+
+        /// Comparator number for linked address comparison.
+        /// Works, when `DATAVMATCH` reads as one.
+        /// RW.
+        DATAVADDR0  OFFSET(12)   NUMBITS(4),
+
+        /// Size of data comparision (Byte, Halfword, Word).
+        /// RW.
+        DATAVSIZE   OFFSET(10)   NUMBITS(2),
+
+        /// Reads as one if a second linked comparator is supported.
+        LNK1ENA     OFFSET(9)    NUMBITS(1),
+
+        /// Enables data value comparison
+        /// When 0: Perform address comparison, when 1: data value comparison.
+        /// RW.
+        DATAVMATCH  OFFSET(8)    NUMBITS(1),
+
+        /// Write 1 to enable generation of data trace address packets.
+        /// WARN: If `Control::NOTRCPKT` reads as zero, this bit is UNKNOWN.
+        /// RW.
+        EMITRANGE   OFFSET(5)    NUMBITS(1),
+
+        /// Selects action taken on comparator match.
+        /// Resets to 0b0000.
+        /// RW.
+        FUNCTION    OFFSET(0)    NUMBITS(4),
+    ],
+
+    Comparator3[
+        /// Reference value for comparator 0.
+        COMP       OFFSET(0)   NUMBITS(32),
+    ],
+
+    Comparator3Mask[
+        /// Size of ignore mask aplied to the access address for address range matching by comparator 0.
+        /// WARN: Maximum Mask size is IMPLEMENTATION DEFINED.
+        MASK       OFFSET(0)   NUMBITS(5),
+    ],
+
+    Comparator3Function[
+        /// Is one if comparator matches. Reading the register clears it to 0.
+        /// RO.
+        MATCHED     OFFSET(24)   NUMBITS(1),
+
+        /// Second comparator number for linked address comparison.
+        /// Works, when `DATAVMATCH` and `LNK1ENA` read as one.
+        /// RW.
+        DATAVADDR1  OFFSET(16)   NUMBITS(4),
+
+        /// Comparator number for linked address comparison.
+        /// Works, when `DATAVMATCH` reads as one.
+        /// RW.
+        DATAVADDR0  OFFSET(12)   NUMBITS(4),
+
+        /// Size of data comparision (Byte, Halfword, Word).
+        /// RW.
+        DATAVSIZE   OFFSET(10)   NUMBITS(2),
+
+        /// Reads as one if a second linked comparator is supported.
+        LNK1ENA     OFFSET(9)    NUMBITS(1),
+
+        /// Enables data value comparison
+        /// When 0: Perform address comparison, when 1: data value comparison.
+        /// RW.
+        DATAVMATCH  OFFSET(8)    NUMBITS(1),
+
+        /// Write 1 to enable generation of data trace address packets.
+        /// WARN: If `Control::NOTRCPKT` reads as zero, this bit is UNKNOWN.
+        /// RW.
+        EMITRANGE   OFFSET(5)    NUMBITS(1),
+
+        /// Selects action taken on comparator match.
+        /// Resets to 0b0000.
+        /// RW.
+        FUNCTION    OFFSET(0)    NUMBITS(4),
+    ],
+
+];
+
+const DWT: StaticRef<DwtRegisters> = unsafe { StaticRef::new(0xE0001000 as *const DwtRegisters) };
+
+pub struct Dwt {
+    registers: StaticRef<DwtRegisters>,
+}
+
+impl Dwt {
+    pub const fn new() -> Self {
+        Self { registers: DWT }
+    }
+
+    /// Returns wether a cycle counter is present on the chip.
+    pub fn is_cycle_counter_present(&self) -> bool {
+        DWT.ctrl.read(Control::NOCYCCNT) == 0
+    }
+}
+
+impl hil::hw_debug::CycleCounter for Dwt {
+    fn start(&self) {
+        if self.is_cycle_counter_present() {
+            // The cycle counter has to be enabled in the DCB block
+            dcb::enable_debug_and_trace();
+            self.registers.ctrl.modify(Control::CYCNTENA::SET);
+        }
+    }
+
+    fn stop(&self) {
+        self.registers.ctrl.modify(Control::CYCNTENA::CLEAR);
+    }
+
+    fn count(&self) -> u64 {
+        self.registers.cyccnt.read(CycleCount::CYCCNT) as u64
+    }
+
+    fn reset(&self) {
+        self.registers.ctrl.modify(Control::CYCNTENA::CLEAR); // disable the counter
+        self.registers.cyccnt.set(0); // reset the counter
+    }
+}

--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -13,6 +13,8 @@ use core::fmt::Write;
 #[cfg(all(target_arch = "arm", target_os = "none"))]
 use core::arch::global_asm;
 
+pub mod dcb;
+pub mod dwt;
 pub mod mpu;
 pub mod nvic;
 pub mod scb;

--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -14,6 +14,7 @@ pub mod mpu {
     pub type MPU = cortexm::mpu::MPU<8, 32>;
 }
 
+pub use cortexm::dwt;
 pub use cortexm::initialize_ram_jump_to_main;
 pub use cortexm::nvic;
 pub use cortexm::scb;

--- a/capsules/core/src/driver.rs
+++ b/capsules/core/src/driver.rs
@@ -92,5 +92,6 @@ pub enum NUM {
     SevenSegment          = 0x90004,
     KeyboardHid           = 0x90005,
     DateTime              = 0x90007,
+    CycleCount            = 0x90008,
 }
 }

--- a/capsules/extra/README.md
+++ b/capsules/extra/README.md
@@ -176,6 +176,8 @@ Debugging Capsules
 These are selectively included on a board to help with testing and debugging
 various elements of Tock.
 
+- **[Cycle Counter](src/cycle_count.rs)**: Start, stop, reset, and read a hardware cycle
+  counter from userspace.
 - **[Debug Process Restart](src/debug_process_restart.rs)**: Force all processes
   to enter a fault state when a button is pressed.
 - **[Panic Button](src/panic_button.rs)**: Use a button to force a `panic!()`.

--- a/capsules/extra/src/cycle_count.rs
+++ b/capsules/extra/src/cycle_count.rs
@@ -1,0 +1,113 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! Provides a cycle counter interface for userspace.
+//!
+//! Usage
+//! -----
+//!
+//! This capsule is intended for debug purposes. However, to ensure that use
+//! by multiple apps does not lead to innacurate results, basic virtualization
+//! is implemented: only the first app to start the cycle counter can start or
+//! stop or reset the counter. Other apps are restricted to reading the counter
+//! (which can be useful for debugging the time required by cross-process routines).
+
+/// Syscall driver number.
+use capsules_core::driver;
+pub const DRIVER_NUM: usize = driver::NUM::CycleCount as usize;
+
+use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
+use kernel::syscall::{CommandReturn, SyscallDriver};
+use kernel::utilities::cells::OptionalCell;
+use kernel::{hil, ErrorCode, ProcessId};
+
+#[derive(Default)]
+pub struct App;
+
+pub struct CycleCount<'a, P: hil::hw_debug::CycleCounter> {
+    counters: &'a P,
+    apps: Grant<App, UpcallCount<0>, AllowRoCount<0>, AllowRwCount<0>>,
+    controlling_app: OptionalCell<ProcessId>,
+}
+
+impl<'a, P: hil::hw_debug::CycleCounter> CycleCount<'a, P> {
+    pub fn new(
+        counters: &'a P,
+        grant: Grant<App, UpcallCount<0>, AllowRoCount<0>, AllowRwCount<0>>,
+    ) -> Self {
+        Self {
+            counters,
+            apps: grant,
+            controlling_app: OptionalCell::empty(),
+        }
+    }
+}
+
+impl<'a, P: hil::hw_debug::CycleCounter> SyscallDriver for CycleCount<'a, P> {
+    /// Control the CycleCount system.
+    ///
+    /// ### `command_num`
+    ///
+    /// - `0`: Driver check.
+    /// - `1`: Start the cycle counter.
+    /// - `2`: Get current cycle count.
+    /// - `3`: Reset and stop the cycle counter.
+    /// - `4`: Stop the cycle counter.
+    fn command(
+        &self,
+        command_num: usize,
+        _data: usize,
+        _: usize,
+        processid: ProcessId,
+    ) -> CommandReturn {
+        let try_claim_driver = || {
+            let match_or_empty_or_nonexistant =
+                self.controlling_app.map_or(true, |controlling_app| {
+                    self.apps
+                        .enter(controlling_app, |_, _| controlling_app == processid)
+                        .unwrap_or(true)
+                });
+            if match_or_empty_or_nonexistant {
+                self.controlling_app.set(processid);
+                true
+            } else {
+                false
+            }
+        };
+        match command_num {
+            0 => CommandReturn::success(),
+
+            1 => {
+                if try_claim_driver() {
+                    self.counters.start();
+                    CommandReturn::success()
+                } else {
+                    CommandReturn::failure(ErrorCode::RESERVE)
+                }
+            }
+            2 => CommandReturn::success_u64(self.counters.count()),
+            3 => {
+                if try_claim_driver() {
+                    self.counters.reset();
+                    CommandReturn::success()
+                } else {
+                    CommandReturn::failure(ErrorCode::RESERVE)
+                }
+            }
+            4 => {
+                if try_claim_driver() {
+                    self.counters.stop();
+                    CommandReturn::success()
+                } else {
+                    CommandReturn::failure(ErrorCode::RESERVE)
+                }
+            }
+            _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
+        }
+    }
+
+    fn allocate_grant(&self, processid: ProcessId) -> Result<(), kernel::process::Error> {
+        self.apps.enter(processid, |_, _| {})
+    }
+}

--- a/capsules/extra/src/lib.rs
+++ b/capsules/extra/src/lib.rs
@@ -29,6 +29,7 @@ pub mod buzzer_pwm;
 pub mod can;
 pub mod ccs811;
 pub mod crc;
+pub mod cycle_count;
 pub mod dac;
 pub mod date_time;
 pub mod debug_process_restart;

--- a/kernel/src/hil/hw_debug.rs
+++ b/kernel/src/hil/hw_debug.rs
@@ -1,0 +1,33 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! Interfaces for interacting with debug hardware integrated in various SoCs.
+//! Currently allows reading the cycle counter.
+
+pub trait CycleCounter {
+    /// Enable and start the cycle counter.
+    /// Depending on the underlying hardware, it may be necessary to call reset
+    /// before starting the cycle counter for the first time to get accurate results.
+    fn start(&self);
+
+    /// Stop the cycle counter.
+    /// Does nothing if the cycle counter is not present.
+    fn stop(&self);
+
+    /// Return the current value of the cycle counter.
+    fn count(&self) -> u64;
+
+    /// Reset the counter to zero and stop the cycle counter.
+    fn reset(&self);
+
+    /// Benchmark the number of cycles to run a passed closure.
+    /// This function is intended for use debugging in-kernel routines.
+    fn profile_closure<F: FnOnce()>(&self, f: F) -> u64 {
+        self.reset();
+        self.start();
+        f();
+        self.stop();
+        self.count()
+    }
+}

--- a/kernel/src/hil/mod.rs
+++ b/kernel/src/hil/mod.rs
@@ -20,6 +20,7 @@ pub mod flash;
 pub mod gpio;
 pub mod gpio_async;
 pub mod hasher;
+pub mod hw_debug;
 pub mod i2c;
 pub mod kv;
 pub mod led;


### PR DESCRIPTION
### Pull Request Overview

This PR rebases the contents of https://github.com/tock/tock/pull/3246 and applies all of the changes that were requested on that PR. The commit structure on that PR was challenging because the design changed over time, so I just squashed all the commits.

I fleshed out the remaining DCB register_structs() and register_bitfields() and added some helper functions that I have found useful for benchmarking in the past. 

It still needs docs describing the new HIL and syscall driver, and probably some other cleanup.

libtock-c PR: https://github.com/tock/libtock-c/pull/386

### Testing Strategy

This pull request has been tested on an nrf52840dk by benchmarking load_processes (401 cycles!).


### TODO or Help Wanted

future work: risc-v implementation, global macro.

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
