### PR TITLE
arch/cortex-m3: re-export interrupt mask

### DIFF
--- a/arch/cortex-m3/src/lib.rs
+++ b/arch/cortex-m3/src/lib.rs
@@ -15,6 +15,7 @@ pub mod mpu {
 }
 
 pub use cortexm::initialize_ram_jump_to_main;
+pub use cortexm::interrupt_mask;
 pub use cortexm::nvic;
 pub use cortexm::scb;
 pub use cortexm::support;

--- a/kernel/src/hil/time.rs
+++ b/kernel/src/hil/time.rs
@@ -55,7 +55,7 @@ pub trait Ticks: Clone + Copy + From<u32> + fmt::Debug + Ord + PartialOrd + Eq {
     /// Returns the half the maximum value of this type, which should be (2^width-1).
     fn half_max_value() -> Self;
 
-    /// Coverts the specified val into this type if it fits otherwise the
+    /// Converts the specified val into this type if it fits otherwise the
     /// `max_value()` is returned
     fn from_or_max(val: u64) -> Self;
 


### PR DESCRIPTION
### Pull Request Overview

Re-export for `interrupt_mask!` macro is added to `cortex-m3` crate.
Justification: my hardware needs to mask an interrupt.

As a bonus, a typo is fixed in a comment.

### Formatting

- [x] Ran `make prepush`.
