### PR TITLE
make TakeCell::empty() const, and make nrf52840 GPIO pin initialization a const fn

### DIFF
--- a/chips/nrf52/src/adc.rs
+++ b/chips/nrf52/src/adc.rs
@@ -348,7 +348,7 @@ pub struct Adc<'a> {
 }
 
 impl<'a> Adc<'a> {
-    pub fn new(voltage_reference_in_mv: usize) -> Self {
+    pub const fn new(voltage_reference_in_mv: usize) -> Self {
         Self {
             registers: SAADC_BASE,
             reference: Cell::new(voltage_reference_in_mv),

--- a/chips/nrf52/src/ble_radio.rs
+++ b/chips/nrf52/src/ble_radio.rs
@@ -542,7 +542,7 @@ pub struct Radio<'a> {
 }
 
 impl<'a> Radio<'a> {
-    pub fn new() -> Radio<'a> {
+    pub const fn new() -> Radio<'a> {
         Radio {
             registers: RADIO_BASE,
             tx_power: Cell::new(TxPower::ZerodBm),

--- a/chips/nrf52/src/i2c.rs
+++ b/chips/nrf52/src/i2c.rs
@@ -45,7 +45,7 @@ pub enum Speed {
 }
 
 impl<'a> TWI<'a> {
-    fn new(registers: StaticRef<TwiRegisters>) -> Self {
+    const fn new(registers: StaticRef<TwiRegisters>) -> Self {
         Self {
             registers,
             client: OptionalCell::empty(),
@@ -55,11 +55,11 @@ impl<'a> TWI<'a> {
         }
     }
 
-    pub fn new_twi0() -> Self {
+    pub const fn new_twi0() -> Self {
         TWI::new(INSTANCES[0])
     }
 
-    pub fn new_twi1() -> Self {
+    pub const fn new_twi1() -> Self {
         TWI::new(INSTANCES[1])
     }
 

--- a/chips/nrf52/src/spi.rs
+++ b/chips/nrf52/src/spi.rs
@@ -248,7 +248,7 @@ pub struct SPIM<'a> {
 }
 
 impl<'a> SPIM<'a> {
-    pub fn new(instance: usize) -> SPIM<'a> {
+    pub const fn new(instance: usize) -> SPIM<'a> {
         SPIM {
             registers: INSTANCES[instance],
             client: OptionalCell::empty(),

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -183,7 +183,7 @@ pub struct UARTParams {
 impl<'a> Uarte<'a> {
     /// Constructor
     // This should only be constructed once
-    pub fn new(regs: StaticRef<UarteRegisters>) -> Uarte<'a> {
+    pub const fn new(regs: StaticRef<UarteRegisters>) -> Uarte<'a> {
         Uarte {
             registers: regs,
             tx_client: OptionalCell::empty(),

--- a/chips/nrf52840/src/gpio.rs
+++ b/chips/nrf52840/src/gpio.rs
@@ -6,7 +6,7 @@ pub use nrf52::gpio::{GPIOPin, Pin, Port};
 
 pub const NUM_PINS: usize = 48;
 
-pub fn nrf52840_gpio_create<'a>() -> Port<'a, NUM_PINS> {
+pub const fn nrf52840_gpio_create<'a>() -> Port<'a, NUM_PINS> {
     Port::new([
         GPIOPin::new(Pin::P0_00),
         GPIOPin::new(Pin::P0_01),

--- a/chips/nrf5x/src/aes.rs
+++ b/chips/nrf5x/src/aes.rs
@@ -144,7 +144,7 @@ pub struct AesECB<'a> {
 }
 
 impl<'a> AesECB<'a> {
-    pub fn new() -> AesECB<'a> {
+    pub const fn new() -> AesECB<'a> {
         AesECB {
             registers: AESECB_BASE,
             mode: Cell::new(AESMode::CTR),

--- a/chips/nrf5x/src/gpio.rs
+++ b/chips/nrf5x/src/gpio.rs
@@ -578,7 +578,7 @@ impl<'a, const N: usize> IndexMut<Pin> for Port<'a, N> {
 }
 
 impl<'a, const N: usize> Port<'a, N> {
-    pub fn new(pins: [GPIOPin<'a>; N]) -> Self {
+    pub const fn new(pins: [GPIOPin<'a>; N]) -> Self {
         Self { pins }
     }
 

--- a/libraries/tock-cells/src/take_cell.rs
+++ b/libraries/tock-cells/src/take_cell.rs
@@ -20,10 +20,12 @@ pub struct TakeCell<'a, T: 'a + ?Sized> {
 }
 
 impl<'a, T: ?Sized> TakeCell<'a, T> {
-    pub fn empty() -> TakeCell<'a, T> {
-        TakeCell {
-            val: Cell::new(None),
-        }
+    const EMPTY: Self = Self {
+        val: Cell::new(None),
+    };
+
+    pub const fn empty() -> TakeCell<'a, T> {
+        Self::EMPTY
     }
 
     /// Creates a new `TakeCell` containing `value`


### PR DESCRIPTION

### Pull Request Overview

This pull request makes the `TakeCell::new` function const. This requires an associated constant: moving the constant into `fn new` does not work, not using an explicit constant also does not work.

That function being const can then be used to initialize the gpio pins for the ntrf52840 in a `const fn`. It can't happen in an actual const because the final type contains a (non-static) lifetime. 

There are many more functions that can now become a `const fn`: I can add some to this PR but those are scattered all around the codebase.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
