### PR TITLE
IEEE802.15.4 RxClient Encrypted Receive

### DIFF
--- a/boards/components/src/ieee802154.rs
+++ b/boards/components/src/ieee802154.rs
@@ -324,6 +324,7 @@ impl<
             ));
         mac_device.set_transmit_client(mux_mac);
         mac_device.set_receive_client(mux_mac);
+        mac_device.set_receive_raw_client(mux_mac);
 
         let userspace_mac =
             static_buffer
@@ -347,6 +348,7 @@ impl<
         mac_device.set_device_procedure(radio_driver);
         userspace_mac.set_transmit_client(radio_driver);
         userspace_mac.set_receive_client(radio_driver);
+        userspace_mac.set_receive_raw_client(radio_driver);
         userspace_mac.set_pan(self.pan_id);
         userspace_mac.set_address(self.short_addr);
         userspace_mac.set_address_long(self.long_addr);

--- a/boards/components/src/ieee802154.rs
+++ b/boards/components/src/ieee802154.rs
@@ -324,7 +324,7 @@ impl<
             ));
         mac_device.set_transmit_client(mux_mac);
         mac_device.set_receive_client(mux_mac);
-        mac_device.set_receive_raw_client(mux_mac);
+        mac_device.set_receive_secured_frame_no_decrypt_client(mux_mac);
 
         let userspace_mac =
             static_buffer
@@ -348,7 +348,7 @@ impl<
         mac_device.set_device_procedure(radio_driver);
         userspace_mac.set_transmit_client(radio_driver);
         userspace_mac.set_receive_client(radio_driver);
-        userspace_mac.set_receive_raw_client(radio_driver);
+        userspace_mac.set_receive_secured_frame_no_decrypt_client(radio_driver);
         userspace_mac.set_pan(self.pan_id);
         userspace_mac.set_address(self.short_addr);
         userspace_mac.set_address_long(self.long_addr);

--- a/capsules/extra/src/ieee802154/device.rs
+++ b/capsules/extra/src/ieee802154/device.rs
@@ -24,8 +24,11 @@ pub trait MacDevice<'a> {
     fn set_transmit_client(&self, client: &'a dyn TxClient);
     /// Sets the receive client of this MAC device
     fn set_receive_client(&self, client: &'a dyn RxClient);
-    /// Sets the raw receive client of this MAC device
-    fn set_receive_raw_client(&self, client: &'a dyn SecuredFrameNoDecryptRxClient);
+    /// Sets the secure frame no decrypt receive client of this MAC device
+    fn set_receive_secured_frame_no_decrypt_client(
+        &self,
+        client: &'a dyn SecuredFrameNoDecryptRxClient,
+    );
 
     /// The short 16-bit address of the MAC device
     fn get_address(&self) -> u16;
@@ -158,7 +161,7 @@ pub trait SecuredFrameNoDecryptRxClient {
     /// `buf`, so that the payload of the frame is contained in
     /// `buf[data_offset..data_offset + data_len]`.
     /// - `data_len`: Length of the data payload
-    fn receive_raw<'a>(
+    fn receive_secured_frame<'a>(
         &self,
         buf: &'a [u8],
         header: Header<'a>,

--- a/capsules/extra/src/ieee802154/device.rs
+++ b/capsules/extra/src/ieee802154/device.rs
@@ -133,5 +133,13 @@ pub trait RxClient {
     /// `buf`, so that the payload of the frame is contained in
     /// `buf[data_offset..data_offset + data_len]`.
     /// - `data_len`: Length of the data payload
-    fn receive<'a>(&self, buf: &'a [u8], header: Header<'a>, data_offset: usize, data_len: usize);
+    /// - `encrypted`: Flag to denote if the frame held in buffer is encrypted
+    fn receive<'a>(
+        &self,
+        buf: &'a [u8],
+        header: Header<'a>,
+        data_offset: usize,
+        data_len: usize,
+        encrypted: bool,
+    );
 }

--- a/capsules/extra/src/ieee802154/device.rs
+++ b/capsules/extra/src/ieee802154/device.rs
@@ -24,7 +24,7 @@ pub trait MacDevice<'a> {
     fn set_transmit_client(&self, client: &'a dyn TxClient);
     /// Sets the receive client of this MAC device
     fn set_receive_client(&self, client: &'a dyn RxClient);
-
+    /// Sets the raw receive client of this MAC device
     fn set_receive_raw_client(&self, client: &'a dyn RawRxClient);
 
     /// The short 16-bit address of the MAC device
@@ -135,7 +135,6 @@ pub trait RxClient {
     /// `buf`, so that the payload of the frame is contained in
     /// `buf[data_offset..data_offset + data_len]`.
     /// - `data_len`: Length of the data payload
-    /// - `encrypted`: Flag to denote if the frame held in buffer is encrypted
     fn receive<'a>(&self, buf: &'a [u8], header: Header<'a>, data_offset: usize, data_len: usize);
 }
 

--- a/capsules/extra/src/ieee802154/device.rs
+++ b/capsules/extra/src/ieee802154/device.rs
@@ -25,6 +25,8 @@ pub trait MacDevice<'a> {
     /// Sets the receive client of this MAC device
     fn set_receive_client(&self, client: &'a dyn RxClient);
 
+    fn set_receive_raw_client(&self, client: &'a dyn RawRxClient);
+
     /// The short 16-bit address of the MAC device
     fn get_address(&self) -> u16;
     /// The long 64-bit address (EUI-64) of the MAC device
@@ -134,12 +136,15 @@ pub trait RxClient {
     /// `buf[data_offset..data_offset + data_len]`.
     /// - `data_len`: Length of the data payload
     /// - `encrypted`: Flag to denote if the frame held in buffer is encrypted
-    fn receive<'a>(
+    fn receive<'a>(&self, buf: &'a [u8], header: Header<'a>, data_offset: usize, data_len: usize);
+}
+
+pub trait RawRxClient {
+    fn receive_raw<'a>(
         &self,
         buf: &'a [u8],
         header: Header<'a>,
         data_offset: usize,
         data_len: usize,
-        encrypted: bool,
     );
 }

--- a/capsules/extra/src/ieee802154/device.rs
+++ b/capsules/extra/src/ieee802154/device.rs
@@ -25,7 +25,7 @@ pub trait MacDevice<'a> {
     /// Sets the receive client of this MAC device
     fn set_receive_client(&self, client: &'a dyn RxClient);
     /// Sets the raw receive client of this MAC device
-    fn set_receive_raw_client(&self, client: &'a dyn RawRxClient);
+    fn set_receive_raw_client(&self, client: &'a dyn SecuredFrameNoDecryptRxClient);
 
     /// The short 16-bit address of the MAC device
     fn get_address(&self) -> u16;
@@ -143,9 +143,10 @@ pub trait RxClient {
 /// have not been decrypted). This allows the client to perform decryption
 /// on the frame. The callback is trigger whenever a valid frame is received.
 /// In this context, raw refers to receiving frames without processing the
-/// security of the frame. The RawRxClient should not be used to pass frames
-/// to the higher layers of the network stack that expect unsecured frames.
-pub trait RawRxClient {
+/// security of the frame. The SecuredFrameNoDecryptRxClient should not be
+/// used to pass frames to the higher layers of the network stack that expect
+/// unsecured frames.
+pub trait SecuredFrameNoDecryptRxClient {
     /// When a frame is received, this callback is triggered. The client only
     /// receives an immutable borrow of the buffer. All frames, regardless of
     /// their secured state, are exposed to the client.

--- a/capsules/extra/src/ieee802154/driver.rs
+++ b/capsules/extra/src/ieee802154/driver.rs
@@ -56,6 +56,7 @@
 use crate::ieee802154::{device, framer};
 use crate::net::ieee802154::{AddressMode, Header, KeyId, MacAddress, PanID, SecurityLevel};
 use crate::net::stream::{decode_bytes, decode_u8, encode_bytes, encode_u8, SResult};
+use device::RxClient;
 
 use core::cell::Cell;
 
@@ -1081,6 +1082,21 @@ fn encode_address(addr: &Option<MacAddress>) -> usize {
         _ => 0,
     };
     ((AddressMode::from(addr) as usize) << 16) | short_addr_only
+}
+
+impl<'a, M: device::MacDevice<'a>> device::RawRxClient for RadioDriver<'a, M> {
+    fn receive_raw<'b>(
+        &self,
+        buf: &'b [u8],
+        header: Header<'b>,
+        data_offset: usize,
+        data_len: usize,
+    ) {
+        // The current 15.4 userspace receive does not differentiate between
+        // raw and standard receive. As such, we can simply call the standard
+        // receive method of the RxClient trait.
+        self.receive(buf, header, data_offset, data_len)
+    }
 }
 
 impl<'a, M: device::MacDevice<'a>> device::RxClient for RadioDriver<'a, M> {

--- a/capsules/extra/src/ieee802154/driver.rs
+++ b/capsules/extra/src/ieee802154/driver.rs
@@ -1084,7 +1084,14 @@ fn encode_address(addr: &Option<MacAddress>) -> usize {
 }
 
 impl<'a, M: device::MacDevice<'a>> device::RxClient for RadioDriver<'a, M> {
-    fn receive<'b>(&self, buf: &'b [u8], header: Header<'b>, data_offset: usize, data_len: usize) {
+    fn receive<'b>(
+        &self,
+        buf: &'b [u8],
+        header: Header<'b>,
+        data_offset: usize,
+        data_len: usize,
+        _encrypted: bool,
+    ) {
         self.apps.each(|_, _, kernel_data| {
             let read_present = kernel_data
                 .get_readwrite_processbuffer(rw_allow::READ)

--- a/capsules/extra/src/ieee802154/driver.rs
+++ b/capsules/extra/src/ieee802154/driver.rs
@@ -1085,15 +1085,15 @@ fn encode_address(addr: &Option<MacAddress>) -> usize {
 }
 
 impl<'a, M: device::MacDevice<'a>> device::SecuredFrameNoDecryptRxClient for RadioDriver<'a, M> {
-    fn receive_raw<'b>(
+    fn receive_secured_frame<'b>(
         &self,
         buf: &'b [u8],
         header: Header<'b>,
         data_offset: usize,
         data_len: usize,
     ) {
-        // The current 15.4 userspace receive does not differentiate between
-        // raw and standard receive. As such, we can simply call the standard
+        // The current 15.4 userspace receive accepts both secured and
+        // unsecured frames. As such, we can simply call the standard
         // receive method of the RxClient trait.
         self.receive(buf, header, data_offset, data_len)
     }

--- a/capsules/extra/src/ieee802154/driver.rs
+++ b/capsules/extra/src/ieee802154/driver.rs
@@ -1084,7 +1084,7 @@ fn encode_address(addr: &Option<MacAddress>) -> usize {
     ((AddressMode::from(addr) as usize) << 16) | short_addr_only
 }
 
-impl<'a, M: device::MacDevice<'a>> device::RawRxClient for RadioDriver<'a, M> {
+impl<'a, M: device::MacDevice<'a>> device::SecuredFrameNoDecryptRxClient for RadioDriver<'a, M> {
     fn receive_raw<'b>(
         &self,
         buf: &'b [u8],

--- a/capsules/extra/src/ieee802154/driver.rs
+++ b/capsules/extra/src/ieee802154/driver.rs
@@ -1084,14 +1084,7 @@ fn encode_address(addr: &Option<MacAddress>) -> usize {
 }
 
 impl<'a, M: device::MacDevice<'a>> device::RxClient for RadioDriver<'a, M> {
-    fn receive<'b>(
-        &self,
-        buf: &'b [u8],
-        header: Header<'b>,
-        data_offset: usize,
-        data_len: usize,
-        _encrypted: bool,
-    ) {
+    fn receive<'b>(&self, buf: &'b [u8], header: Header<'b>, data_offset: usize, data_len: usize) {
         self.apps.each(|_, _, kernel_data| {
             let read_present = kernel_data
                 .get_readwrite_processbuffer(rw_allow::READ)

--- a/capsules/extra/src/ieee802154/framer.rs
+++ b/capsules/extra/src/ieee802154/framer.rs
@@ -75,7 +75,7 @@
 // TODO: Channel scanning
 //
 
-use crate::ieee802154::device::{MacDevice, RawRxClient, RxClient, TxClient};
+use crate::ieee802154::device::{MacDevice, RxClient, SecuredFrameNoDecryptRxClient, TxClient};
 use crate::ieee802154::mac::Mac;
 use crate::net::ieee802154::{
     FrameType, FrameVersion, Header, KeyId, MacAddress, PanID, Security, SecurityLevel,
@@ -394,7 +394,7 @@ pub struct Framer<'a, M: Mac<'a>, A: AES128CCM<'a>> {
     /// `None`, except when transitioning between states.
     rx_state: MapCell<RxState>,
     rx_client: OptionalCell<&'a dyn RxClient>,
-    raw_rx_client: OptionalCell<&'a dyn RawRxClient>,
+    raw_rx_client: OptionalCell<&'a dyn SecuredFrameNoDecryptRxClient>,
     crypt_buf: MapCell<SubSliceMut<'static, u8>>,
 }
 
@@ -786,7 +786,7 @@ impl<'a, M: Mac<'a>, A: AES128CCM<'a>> MacDevice<'a> for Framer<'a, M, A> {
         self.rx_client.set(client);
     }
 
-    fn set_receive_raw_client(&self, client: &'a dyn super::device::RawRxClient) {
+    fn set_receive_raw_client(&self, client: &'a dyn super::device::SecuredFrameNoDecryptRxClient) {
         self.raw_rx_client.set(client);
     }
 

--- a/capsules/extra/src/ieee802154/framer.rs
+++ b/capsules/extra/src/ieee802154/framer.rs
@@ -759,6 +759,7 @@ impl<'a, M: Mac<'a>, A: AES128CCM<'a>> Framer<'a, M, A> {
                                 header,
                                 data_offset,
                                 frame_len - data_offset,
+                                false,
                             );
                         });
                         self.crypt_buf.replace(SubSliceMut::new(buf));

--- a/capsules/extra/src/ieee802154/virtual_mac.rs
+++ b/capsules/extra/src/ieee802154/virtual_mac.rs
@@ -60,9 +60,16 @@ impl<'a, M: device::MacDevice<'a>> device::TxClient for MuxMac<'a, M> {
 }
 
 impl<'a, M: device::MacDevice<'a>> device::RxClient for MuxMac<'a, M> {
-    fn receive<'b>(&self, buf: &'b [u8], header: Header<'b>, data_offset: usize, data_len: usize) {
+    fn receive<'b>(
+        &self,
+        buf: &'b [u8],
+        header: Header<'b>,
+        data_offset: usize,
+        data_len: usize,
+        encrypted: bool,
+    ) {
         for user in self.users.iter() {
-            user.receive(buf, header, data_offset, data_len);
+            user.receive(buf, header, data_offset, data_len, encrypted);
         }
     }
 }
@@ -219,10 +226,17 @@ impl<'a, M: device::MacDevice<'a>> MacUser<'a, M> {
             .map(move |client| client.send_done(spi_buf, acked, result));
     }
 
-    fn receive<'b>(&self, buf: &'b [u8], header: Header<'b>, data_offset: usize, data_len: usize) {
+    fn receive<'b>(
+        &self,
+        buf: &'b [u8],
+        header: Header<'b>,
+        data_offset: usize,
+        data_len: usize,
+        encrypted: bool,
+    ) {
         self.rx_client
             .get()
-            .map(move |client| client.receive(buf, header, data_offset, data_len));
+            .map(move |client| client.receive(buf, header, data_offset, data_len, encrypted));
     }
 }
 

--- a/capsules/extra/src/ieee802154/virtual_mac.rs
+++ b/capsules/extra/src/ieee802154/virtual_mac.rs
@@ -57,7 +57,6 @@ impl<'a, M: device::MacDevice<'a>> device::TxClient for MuxMac<'a, M> {
     }
 }
 
-// here
 impl<'a, M: device::MacDevice<'a>> device::RxClient for MuxMac<'a, M> {
     fn receive<'b>(&self, buf: &'b [u8], header: Header<'b>, data_offset: usize, data_len: usize) {
         for user in self.users.iter() {

--- a/capsules/extra/src/ieee802154/virtual_mac.rs
+++ b/capsules/extra/src/ieee802154/virtual_mac.rs
@@ -65,7 +65,7 @@ impl<'a, M: device::MacDevice<'a>> device::RxClient for MuxMac<'a, M> {
     }
 }
 
-impl<'a, M: device::MacDevice<'a>> device::RawRxClient for MuxMac<'a, M> {
+impl<'a, M: device::MacDevice<'a>> device::SecuredFrameNoDecryptRxClient for MuxMac<'a, M> {
     fn receive_raw<'b>(
         &self,
         buf: &'b [u8],
@@ -210,7 +210,7 @@ pub struct MacUser<'a, M: device::MacDevice<'a>> {
     next: ListLink<'a, MacUser<'a, M>>,
     tx_client: OptionalCell<&'a dyn device::TxClient>,
     rx_client: OptionalCell<&'a dyn device::RxClient>,
-    raw_rx_client: OptionalCell<&'a dyn device::RawRxClient>,
+    secure_frame_no_decrypt_rx_client: OptionalCell<&'a dyn device::SecuredFrameNoDecryptRxClient>,
 }
 
 impl<'a, M: device::MacDevice<'a>> MacUser<'a, M> {
@@ -221,7 +221,7 @@ impl<'a, M: device::MacDevice<'a>> MacUser<'a, M> {
             next: ListLink::empty(),
             tx_client: OptionalCell::empty(),
             rx_client: OptionalCell::empty(),
-            raw_rx_client: OptionalCell::empty(),
+            secure_frame_no_decrypt_rx_client: OptionalCell::empty(),
         }
     }
 }
@@ -246,7 +246,7 @@ impl<'a, M: device::MacDevice<'a>> MacUser<'a, M> {
         data_offset: usize,
         data_len: usize,
     ) {
-        self.raw_rx_client
+        self.secure_frame_no_decrypt_rx_client
             .get()
             .map(move |client| client.receive_raw(buf, header, data_offset, data_len));
     }
@@ -267,8 +267,8 @@ impl<'a, M: device::MacDevice<'a>> device::MacDevice<'a> for MacUser<'a, M> {
         self.rx_client.set(client);
     }
 
-    fn set_receive_raw_client(&self, client: &'a dyn device::RawRxClient) {
-        self.raw_rx_client.set(client);
+    fn set_receive_raw_client(&self, client: &'a dyn device::SecuredFrameNoDecryptRxClient) {
+        self.secure_frame_no_decrypt_rx_client.set(client);
     }
 
     fn get_address(&self) -> u16 {

--- a/capsules/extra/src/ieee802154/virtual_mac.rs
+++ b/capsules/extra/src/ieee802154/virtual_mac.rs
@@ -66,7 +66,7 @@ impl<'a, M: device::MacDevice<'a>> device::RxClient for MuxMac<'a, M> {
 }
 
 impl<'a, M: device::MacDevice<'a>> device::SecuredFrameNoDecryptRxClient for MuxMac<'a, M> {
-    fn receive_raw<'b>(
+    fn receive_secured_frame<'b>(
         &self,
         buf: &'b [u8],
         header: Header<'b>,
@@ -74,7 +74,7 @@ impl<'a, M: device::MacDevice<'a>> device::SecuredFrameNoDecryptRxClient for Mux
         data_len: usize,
     ) {
         for user in self.users.iter() {
-            user.receive_raw(buf, header, data_offset, data_len);
+            user.receive_secured_frame(buf, header, data_offset, data_len);
         }
     }
 }
@@ -239,7 +239,7 @@ impl<'a, M: device::MacDevice<'a>> MacUser<'a, M> {
             .map(move |client| client.receive(buf, header, data_offset, data_len));
     }
 
-    fn receive_raw<'b>(
+    fn receive_secured_frame<'b>(
         &self,
         buf: &'b [u8],
         header: Header<'b>,
@@ -248,7 +248,7 @@ impl<'a, M: device::MacDevice<'a>> MacUser<'a, M> {
     ) {
         self.secure_frame_no_decrypt_rx_client
             .get()
-            .map(move |client| client.receive_raw(buf, header, data_offset, data_len));
+            .map(move |client| client.receive_secured_frame(buf, header, data_offset, data_len));
     }
 }
 
@@ -267,7 +267,10 @@ impl<'a, M: device::MacDevice<'a>> device::MacDevice<'a> for MacUser<'a, M> {
         self.rx_client.set(client);
     }
 
-    fn set_receive_raw_client(&self, client: &'a dyn device::SecuredFrameNoDecryptRxClient) {
+    fn set_receive_secured_frame_no_decrypt_client(
+        &self,
+        client: &'a dyn device::SecuredFrameNoDecryptRxClient,
+    ) {
         self.secure_frame_no_decrypt_rx_client.set(client);
     }
 

--- a/capsules/extra/src/net/sixlowpan/sixlowpan_state.rs
+++ b/capsules/extra/src/net/sixlowpan/sixlowpan_state.rs
@@ -805,21 +805,7 @@ pub struct Sixlowpan<'a, A: time::Alarm<'a>, C: ContextStore> {
 
 // This function is called after receiving a frame
 impl<'a, A: time::Alarm<'a>, C: ContextStore> RxClient for Sixlowpan<'a, A, C> {
-    fn receive<'b>(
-        &self,
-        buf: &'b [u8],
-        header: Header<'b>,
-        data_offset: usize,
-        data_len: usize,
-        encrypted: bool,
-    ) {
-        // 6LoWPAN can only handle packets not possessing link layer security or packets
-        // that have been decrypted by the MAC layer. As such we drop packets that remain
-        // encrypted.
-        if encrypted {
-            return;
-        }
-
+    fn receive<'b>(&self, buf: &'b [u8], header: Header<'b>, data_offset: usize, data_len: usize) {
         // We return if retcode is not valid, as it does not make sense to issue
         // a callback for an invalid frame reception
         // TODO: Handle the case where the addresses are None/elided - they

--- a/capsules/extra/src/net/sixlowpan/sixlowpan_state.rs
+++ b/capsules/extra/src/net/sixlowpan/sixlowpan_state.rs
@@ -805,7 +805,21 @@ pub struct Sixlowpan<'a, A: time::Alarm<'a>, C: ContextStore> {
 
 // This function is called after receiving a frame
 impl<'a, A: time::Alarm<'a>, C: ContextStore> RxClient for Sixlowpan<'a, A, C> {
-    fn receive<'b>(&self, buf: &'b [u8], header: Header<'b>, data_offset: usize, data_len: usize) {
+    fn receive<'b>(
+        &self,
+        buf: &'b [u8],
+        header: Header<'b>,
+        data_offset: usize,
+        data_len: usize,
+        encrypted: bool,
+    ) {
+        // 6LoWPAN can only handle packets not possessing link layer security or packets
+        // that have been decrypted by the MAC layer. As such we drop packets that remain
+        // encrypted.
+        if encrypted {
+            return;
+        }
+
         // We return if retcode is not valid, as it does not make sense to issue
         // a callback for an invalid frame reception
         // TODO: Handle the case where the addresses are None/elided - they


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the bug described in #3923. This provides a minimal change to the `RxClient` `receive` method to allow the `RxClient` to know if a packet remains encrypted and subsequently filter the packet if needed. Additional context for these changes can be found in the linked issue.

### Testing Strategy

This pull request was tested using the libtock-c openthread implementation.

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
