### PR TITLE
capsules: ssd1306: fix column command fmt

### DIFF
--- a/capsules/extra/src/ssd1306.rs
+++ b/capsules/extra/src/ssd1306.rs
@@ -186,7 +186,7 @@ impl Command {
                 1
             }
             Self::SetHigherColumnStartAddress { address } => {
-                buffer[0] = 0x10 | (address & 0xF);
+                buffer[0] = 0x10 | ((address >> 4) & 0xF);
                 1
             }
             Self::SetMemoryAddressingMode { mode } => {


### PR DESCRIPTION
### Pull Request Overview

Setting the upper and lower bits are two separate commands, and there should be a shift as the upper bits are set in the lower four bits of the command.

We aren't using this command in the current driver, so I didn't notice this issue.




### Testing Strategy

Travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
