### PR TITLE
Replace `static mut`s with new `CoreLocal` construct

### DIFF
--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -264,13 +264,13 @@ impl<A: CortexMVariant> kernel::syscall::UserspaceKernelBoundary for SysCall<A> 
 
         // Check to see if the fault handler was called while the process was
         // running.
-        let app_fault = read_volatile(&*addr_of!(APP_HARD_FAULT));
-        write_volatile(&mut *addr_of_mut!(APP_HARD_FAULT), 0);
+        let app_fault = read_volatile(addr_of!(APP_HARD_FAULT));
+        write_volatile(addr_of_mut!(APP_HARD_FAULT), 0);
 
         // Check to see if the svc_handler was called and the process called a
         // syscall.
-        let syscall_fired = read_volatile(&*addr_of!(SYSCALL_FIRED));
-        write_volatile(&mut *addr_of_mut!(SYSCALL_FIRED), 0);
+        let syscall_fired = read_volatile(addr_of!(SYSCALL_FIRED));
+        write_volatile(addr_of_mut!(SYSCALL_FIRED), 0);
 
         // Now decide the reason based on which flags were set.
         let switch_reason = if app_fault == 1 || invalid_stack_pointer {

--- a/boards/components/src/sched/mod.rs
+++ b/boards/components/src/sched/mod.rs
@@ -4,5 +4,5 @@
 
 pub mod cooperative;
 pub mod mlfq;
-//pub mod priority;
+pub mod priority;
 pub mod round_robin;

--- a/boards/components/src/sched/mod.rs
+++ b/boards/components/src/sched/mod.rs
@@ -4,5 +4,5 @@
 
 pub mod cooperative;
 pub mod mlfq;
-pub mod priority;
+//pub mod priority;
 pub mod round_robin;

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -334,7 +334,7 @@ pub unsafe fn ieee802154_udp(
     // 802.15.4
     //--------------------------------------------------------------------------
 
-    let device_id = nrf52840::ficr::FICR_INSTANCE.id();
+    let device_id = nrf52840::ficr::FICR_INSTANCE.with(|fi| fi.id());
     let device_id_bottom_16: u16 = u16::from_le_bytes([device_id[0], device_id[1]]);
 
     let eui64_driver = components::eui64::Eui64Component::new(u64::from_le_bytes(device_id))
@@ -930,7 +930,7 @@ pub unsafe fn start() -> (
     base_peripherals.adc.calibrate();
 
     debug!("Initialization complete. Entering main loop\r");
-    debug!("{}", nrf52840::ficr::FICR_INSTANCE);
+    nrf52840::ficr::FICR_INSTANCE.with(|fi| debug!("{}", fi));
 
     DEBUG_INFO.with(|debug_info| {
         debug_info.put(DebugInfo {

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -10,12 +10,10 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
-use core::ptr::addr_of_mut;
-
 use kernel::debug;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::{capabilities, create_capability};
-use nrf52840dk_lib::{self, PROCESSES};
+use nrf52840dk_lib;
 
 // State for loading and holding applications.
 // How should the kernel respond when a process faults.
@@ -81,7 +79,7 @@ impl KernelResources<Chip> for Platform {
 /// Main function called after RAM initialized.
 #[no_mangle]
 pub unsafe fn main() {
-    let (board_kernel, base_platform, chip, default_peripherals, mux_alarm) =
+    let (board_kernel, base_platform, chip, processes, default_peripherals, mux_alarm) =
         nrf52840dk_lib::start();
 
     //--------------------------------------------------------------------------
@@ -123,7 +121,7 @@ pub unsafe fn main() {
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut *addr_of_mut!(PROCESSES),
+        processes,
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -110,24 +110,28 @@ pub unsafe fn main() {
 
     let process_management_capability =
         create_capability!(capabilities::ProcessManagementCapability);
-    kernel::process::load_processes(
-        board_kernel,
-        chip,
-        core::slice::from_raw_parts(
-            core::ptr::addr_of!(_sapps),
-            core::ptr::addr_of!(_eapps) as usize - core::ptr::addr_of!(_sapps) as usize,
-        ),
-        core::slice::from_raw_parts_mut(
-            core::ptr::addr_of_mut!(_sappmem),
-            core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
-        ),
-        processes,
-        &FAULT_RESPONSE,
-        &process_management_capability,
-    )
-    .unwrap_or_else(|err| {
-        debug!("Error loading processes!");
-        debug!("{:?}", err);
+    processes.with(|procs| {
+        procs.map(|procs| {
+            kernel::process::load_processes(
+                board_kernel,
+                chip,
+                core::slice::from_raw_parts(
+                    core::ptr::addr_of!(_sapps),
+                    core::ptr::addr_of!(_eapps) as usize - core::ptr::addr_of!(_sapps) as usize,
+                ),
+                core::slice::from_raw_parts_mut(
+                    core::ptr::addr_of_mut!(_sappmem),
+                    core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
+                ),
+                procs,
+                &FAULT_RESPONSE,
+                &process_management_capability,
+            )
+            .unwrap_or_else(|err| {
+                debug!("Error loading processes!");
+                debug!("{:?}", err);
+            })
+        })
     });
 
     let main_loop_capability = create_capability!(capabilities::MainLoopCapability);

--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -588,24 +588,28 @@ pub unsafe fn start() -> (
         static _eappmem: u8;
     }
 
-    kernel::process::load_processes(
-        board_kernel,
-        chip,
-        core::slice::from_raw_parts(
-            core::ptr::addr_of!(_sapps),
-            core::ptr::addr_of!(_eapps) as usize - core::ptr::addr_of!(_sapps) as usize,
-        ),
-        core::slice::from_raw_parts_mut(
-            core::ptr::addr_of_mut!(_sappmem),
-            core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
-        ),
-        processes,
-        &FAULT_RESPONSE,
-        &process_management_capability,
-    )
-    .unwrap_or_else(|err| {
-        debug!("Error loading processes!");
-        debug!("{:?}", err);
+    processes.with(|procs| {
+        procs.map(|procs| {
+            kernel::process::load_processes(
+                board_kernel,
+                chip,
+                core::slice::from_raw_parts(
+                    core::ptr::addr_of!(_sapps),
+                    core::ptr::addr_of!(_eapps) as usize - core::ptr::addr_of!(_sapps) as usize,
+                ),
+                core::slice::from_raw_parts_mut(
+                    core::ptr::addr_of_mut!(_sappmem),
+                    core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
+                ),
+                procs,
+                &FAULT_RESPONSE,
+                &process_management_capability,
+            )
+            .unwrap_or_else(|err| {
+                debug!("Error loading processes!");
+                debug!("{:?}", err);
+            })
+        })
     });
 
     (board_kernel, raspberry_pi_pico, chip)

--- a/boards/stm32f429idiscovery/src/main.rs
+++ b/boards/stm32f429idiscovery/src/main.rs
@@ -618,24 +618,28 @@ unsafe fn start() -> (
         static _eappmem: u8;
     }
 
-    kernel::process::load_processes(
-        board_kernel,
-        chip,
-        core::slice::from_raw_parts(
-            core::ptr::addr_of!(_sapps),
-            core::ptr::addr_of!(_eapps) as usize - core::ptr::addr_of!(_sapps) as usize,
-        ),
-        core::slice::from_raw_parts_mut(
-            core::ptr::addr_of_mut!(_sappmem),
-            core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
-        ),
-        processes,
-        &FAULT_RESPONSE,
-        &process_management_capability,
-    )
-    .unwrap_or_else(|err| {
-        debug!("Error loading processes!");
-        debug!("{:?}", err);
+    processes.with(|procs| {
+        procs.map(|procs| {
+            kernel::process::load_processes(
+                board_kernel,
+                chip,
+                core::slice::from_raw_parts(
+                    core::ptr::addr_of!(_sapps),
+                    core::ptr::addr_of!(_eapps) as usize - core::ptr::addr_of!(_sapps) as usize,
+                ),
+                core::slice::from_raw_parts_mut(
+                    core::ptr::addr_of_mut!(_sappmem),
+                    core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
+                ),
+                procs,
+                &FAULT_RESPONSE,
+                &process_management_capability,
+            )
+            .unwrap_or_else(|err| {
+                debug!("Error loading processes!");
+                debug!("{:?}", err);
+            })
+        })
     });
 
     //Uncomment to run multi alarm test

--- a/capsules/extra/src/ble_advertising_driver.rs
+++ b/capsules/extra/src/ble_advertising_driver.rs
@@ -460,8 +460,12 @@ where
                                 Some(BLEState::Scanning(RadioChannel::AdvertisingChannel37));
                             self.receiving_app.set(processid);
                             let _ = self.radio.set_tx_power(app.tx_power);
-                            self.radio
-                                .receive_advertisement(RadioChannel::AdvertisingChannel37);
+                            if let Some(buf) = self.kernel_tx.take() {
+                                self.kernel_tx.replace(self.radio.receive_advertisement(
+                                    RadioChannel::AdvertisingChannel37,
+                                    buf,
+                                ));
+                            }
                         }
                         _ => debug!(
                             "app: {:?} \t invalid state {:?}",
@@ -524,14 +528,14 @@ where
                         self.receiving_app.set(processid);
                         let _ = self.radio.set_tx_power(app.tx_power);
                         self.radio
-                            .receive_advertisement(RadioChannel::AdvertisingChannel38);
+                            .receive_advertisement(RadioChannel::AdvertisingChannel38, buf);
                     }
                     Some(BLEState::Scanning(RadioChannel::AdvertisingChannel38)) => {
                         app.process_status =
                             Some(BLEState::Scanning(RadioChannel::AdvertisingChannel39));
                         self.receiving_app.set(processid);
                         self.radio
-                            .receive_advertisement(RadioChannel::AdvertisingChannel39);
+                            .receive_advertisement(RadioChannel::AdvertisingChannel39, buf);
                     }
                     Some(BLEState::Scanning(RadioChannel::AdvertisingChannel39)) => {
                         self.busy.set(false);

--- a/chips/apollo3/src/ble.rs
+++ b/chips/apollo3/src/ble.rs
@@ -469,8 +469,12 @@ impl<'a> ble_advertising::BleAdvertisementDriver<'a> for Ble<'a> {
         }
     }
 
-    fn receive_advertisement(&self, _channel: RadioChannel) {
-        unimplemented!();
+    fn receive_advertisement(
+        &self,
+        _channel: RadioChannel,
+        _buffer: &'static mut [u8],
+    ) -> &'static mut [u8] {
+        unimplemented!()
     }
 
     fn set_receive_client(&self, client: &'a dyn ble_advertising::RxClient) {

--- a/chips/nrf52/src/acomp.rs
+++ b/chips/nrf52/src/acomp.rs
@@ -62,7 +62,7 @@ impl Channel {
 }
 
 /// Uses only comparator, with VIN+=AIN5 and VIN-=AIN0
-pub const CHANNEL_AC0: Channel = Channel::new(ChannelNumber::AC0);
+pub static CHANNEL_AC0: Channel = Channel::new(ChannelNumber::AC0);
 
 register_structs! {
     CompRegisters {

--- a/chips/nrf52/src/acomp.rs
+++ b/chips/nrf52/src/acomp.rs
@@ -45,7 +45,7 @@ pub struct Channel {
 /// Only one channel
 #[derive(Copy, Clone, Debug)]
 #[repr(u8)]
-enum ChannelNumber {
+pub enum ChannelNumber {
     AC0 = 0x00,
 }
 
@@ -54,7 +54,7 @@ impl Channel {
     /// Create a new AC channel.
     ///
     /// - `channel`: Channel enum representing the channel number
-    const fn new(channel: ChannelNumber) -> Channel {
+    pub const fn new(channel: ChannelNumber) -> Channel {
         Channel {
             _chan_num: (channel as u32) & 0x0F,
         }
@@ -62,7 +62,7 @@ impl Channel {
 }
 
 /// Uses only comparator, with VIN+=AIN5 and VIN-=AIN0
-pub static mut CHANNEL_AC0: Channel = Channel::new(ChannelNumber::AC0);
+pub const CHANNEL_AC0: Channel = Channel::new(ChannelNumber::AC0);
 
 register_structs! {
     CompRegisters {

--- a/chips/nrf52/src/ficr.rs
+++ b/chips/nrf52/src/ficr.rs
@@ -12,6 +12,7 @@
 //! - Date: November 27, 2017
 
 use core::fmt;
+use kernel::core_local::CoreLocal;
 use kernel::utilities::registers::interfaces::Readable;
 use kernel::utilities::registers::{register_bitfields, ReadOnly};
 use kernel::utilities::StaticRef;
@@ -498,4 +499,4 @@ impl fmt::Display for Ficr {
 }
 
 /// Static instance for the board. Only one (read-only) set of factory registers.
-pub const FICR_INSTANCE: Ficr = Ficr::new();
+pub static FICR_INSTANCE: CoreLocal<Ficr> = unsafe { CoreLocal::new_single_core(Ficr::new()) };

--- a/chips/nrf52/src/ficr.rs
+++ b/chips/nrf52/src/ficr.rs
@@ -498,4 +498,4 @@ impl fmt::Display for Ficr {
 }
 
 /// Static instance for the board. Only one (read-only) set of factory registers.
-pub static mut FICR_INSTANCE: Ficr = Ficr::new();
+pub const FICR_INSTANCE: Ficr = Ficr::new();

--- a/kernel/src/core_local.rs
+++ b/kernel/src/core_local.rs
@@ -62,14 +62,17 @@ impl<T> CoreLocal<T> {
     /// scopes that are inaccessible to ISRs or signal handler,
     /// e.g. in module-private or function-local scopes.
     pub const unsafe fn new_single_core(val: T) -> Self {
-	CoreLocal(UnsafeCell::new(val))
+        CoreLocal(UnsafeCell::new(val))
     }
 }
 
 impl<T> CoreLocal<T> {
     /// Aquires a reference to value in [`CoreLocal`].
-    pub fn with<F, R>(&self, f: F) -> R where F: FnOnce(&T) -> R {
-	f(unsafe { &*self.0.get() })
+    pub fn with<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&T) -> R,
+    {
+        f(unsafe { &*self.0.get() })
     }
 }
 

--- a/kernel/src/core_local.rs
+++ b/kernel/src/core_local.rs
@@ -1,14 +1,73 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2024.
+
+//! Core local storage
+
 use core::cell::UnsafeCell;
 
+/// A core-local store that owns its contents.
+///
+/// This type wraps a core-specific value of type `T`. It precludes
+/// access to the same value from different cores/threads, but allows
+/// multiple _shared_ (`&`) references from the same core/thread.
+///
+/// It is [`Sync`] and thus appropriate for static allocations of values
+/// that are not themselves [`Sync`].
+///
+/// # Example
+///
+/// ```
+/// static FOO: CoreLocal<Cell<usize>> = unsafe { CoreLocal::new_single_core(Cell::new(123)) };
+///
+/// fn main() {
+///   FOO.with(|foo| foo.set(foo.get() + 1));
+/// }
+/// ```
+///
+/// # Single-thread synchronization
+///
+/// Though there is no potential for races across cores, it is
+/// possible for code on the same core to get multiple, shared,
+/// references. As a result, users must use other synchronization
+/// primitives (e.g. [`Cell`](core::cell::Cell),
+/// [`MapCell`](tock_cells::map_cell::MapCell),
+/// [`TakeCell`](tock_cells::take_cell::TakeCell) to allow obtaining
+/// exclusive mutable access.
+///
+/// # Safety
+///
+/// Creators of a [`CoreLocal`] must ensure that they are only
+/// accessible from contexts that meet the requirements of the
+/// [`CoreLocal`] implementation used. See constructors (`new_*`
+/// functions) for details on safety requirements.
 pub struct CoreLocal<T>(UnsafeCell<T>);
 
 impl<T> CoreLocal<T> {
+    /// Create a [`CoreLocal`] on a single-core system.
+    ///
+    /// # Safety
+    ///
+    /// A [`CoreLocal`] must only be created with this constructor on
+    /// systems where a single-core has exclusive access to the
+    /// declared value and without preemtive threads.
+    ///
+    /// Even on single-core systems with no thread runtime, there may
+    /// be additional threads of execution, such as Interrupt Service
+    /// Routines (ISRs) or signal handlers, that could race with the
+    /// main thread if sharing a [`CoreLocal`]. It is safety-critical
+    /// that such contexts do not access [`CoreLocal`]s.
+    ///
+    /// By convetion, users should declare [`CoreLocal`] variables in
+    /// scopes that are inaccessible to ISRs or signal handler,
+    /// e.g. in module-private or function-local scopes.
     pub const unsafe fn new_single_core(val: T) -> Self {
 	CoreLocal(UnsafeCell::new(val))
     }
 }
 
 impl<T> CoreLocal<T> {
+    /// Aquires a reference to value in [`CoreLocal`].
     pub fn with<F, R>(&self, f: F) -> R where F: FnOnce(&T) -> R {
 	f(unsafe { &*self.0.get() })
     }

--- a/kernel/src/core_local.rs
+++ b/kernel/src/core_local.rs
@@ -1,0 +1,17 @@
+use core::cell::UnsafeCell;
+
+pub struct CoreLocal<T>(UnsafeCell<T>);
+
+impl<T> CoreLocal<T> {
+    pub const unsafe fn new_single_core(val: T) -> Self {
+	CoreLocal(UnsafeCell::new(val))
+    }
+}
+
+impl<T> CoreLocal<T> {
+    pub fn with<F, R>(&self, f: F) -> R where F: FnOnce(&T) -> R {
+	f(unsafe { &*self.0.get() })
+    }
+}
+
+unsafe impl<T> Sync for CoreLocal<T> {}

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -133,7 +133,10 @@ use core::ops::{Deref, DerefMut};
 use core::ptr::{write, NonNull};
 use core::slice;
 
-use crate::kernel::Kernel;
+use tock_cells::map_cell::MapCell;
+
+use crate::core_local::CoreLocal;
+use crate::kernel::{Kernel, StaticSlice};
 use crate::process::{Error, Process, ProcessCustomGrantIdentifier, ProcessId};
 use crate::processbuffer::{ReadOnlyProcessBuffer, ReadWriteProcessBuffer};
 use crate::processbuffer::{ReadOnlyProcessBufferRef, ReadWriteProcessBufferRef};
@@ -1767,7 +1770,8 @@ impl<T: Default, Upcalls: UpcallSize, AllowROs: AllowRoSize, AllowRWs: AllowRwSi
     pub fn iter(&self) -> Iter<T, Upcalls, AllowROs, AllowRWs> {
         Iter {
             grant: self,
-            subiter: self.kernel.get_process_iter(),
+            processes: self.kernel.processes,
+            iterator: 0,
         }
     }
 }
@@ -1783,11 +1787,8 @@ pub struct Iter<
     /// The grant type to use.
     grant: &'a Grant<T, Upcalls, AllowROs, AllowRWs>,
 
-    /// Iterator over valid processes.
-    subiter: core::iter::FilterMap<
-        core::slice::Iter<'a, Option<&'static dyn Process>>,
-        fn(&Option<&'static dyn Process>) -> Option<&'static dyn Process>,
-    >,
+    processes: &'a CoreLocal<MapCell<StaticSlice<Option<&'static dyn Process>>>>,
+    iterator: usize,
 }
 
 impl<'a, T: Default, Upcalls: UpcallSize, AllowROs: AllowRoSize, AllowRWs: AllowRwSize> Iterator
@@ -1800,7 +1801,17 @@ impl<'a, T: Default, Upcalls: UpcallSize, AllowROs: AllowRoSize, AllowRWs: Allow
         // Get the next `ProcessId` from the kernel processes array that is
         // setup to use this grant. Since the iterator itself is saved calling
         // this function again will start where we left off.
-        self.subiter
-            .find_map(|process| ProcessGrant::new_if_allocated(grant, process))
+        self.processes.with(|ps| {
+            ps.and_then(|ps| {
+                while self.iterator < ps.len() {
+                    let i = self.iterator;
+                    self.iterator += 1;
+                    if let Some(process) = ps[i] {
+                        return ProcessGrant::new_if_allocated(grant, process);
+                    }
+                }
+                None
+            })
+        })
     }
 }

--- a/kernel/src/hil/ble_advertising.rs
+++ b/kernel/src/hil/ble_advertising.rs
@@ -54,8 +54,17 @@
 use crate::ErrorCode;
 
 pub trait BleAdvertisementDriver<'a> {
-    fn transmit_advertisement(&self, buf: &'static mut [u8], len: usize, channel: RadioChannel);
-    fn receive_advertisement(&self, channel: RadioChannel);
+    fn transmit_advertisement(
+        &self,
+        buf: &'static mut [u8],
+        len: usize,
+        channel: RadioChannel,
+    ) -> &'static mut [u8];
+    fn receive_advertisement(
+        &self,
+        channel: RadioChannel,
+        buffer: &'static mut [u8],
+    ) -> &'static mut [u8];
     fn set_receive_client(&self, client: &'a dyn RxClient);
     fn set_transmit_client(&self, client: &'a dyn TxClient);
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -107,6 +107,7 @@ pub const KERNEL_MINOR_VERSION: u16 = 1;
 pub mod capabilities;
 pub mod collections;
 pub mod component;
+pub mod core_local;
 pub mod debug;
 pub mod deferred_call;
 pub mod errorcode;
@@ -136,6 +137,6 @@ mod syscall_driver;
 
 // Core resources exposed as `kernel::Type`.
 pub use crate::errorcode::ErrorCode;
-pub use crate::kernel::Kernel;
+pub use crate::kernel::{Kernel, StaticSlice};
 pub use crate::process::ProcessId;
 pub use crate::scheduler::Scheduler;

--- a/kernel/src/process_loading.rs
+++ b/kernel/src/process_loading.rs
@@ -16,7 +16,7 @@ use core::cell::Cell;
 use core::fmt;
 
 use crate::capabilities::ProcessManagementCapability;
-use crate::config;
+use crate::core_local::CoreLocal;
 use crate::debug;
 use crate::deferred_call::{DeferredCall, DeferredCallClient};
 use crate::kernel::Kernel;
@@ -30,6 +30,7 @@ use crate::process_policies::ProcessStandardStoragePermissionsPolicy;
 use crate::process_standard::ProcessStandard;
 use crate::process_standard::{ProcessStandardDebug, ProcessStandardDebugFull};
 use crate::utilities::cells::{MapCell, OptionalCell};
+use crate::{config, StaticSlice};
 
 /// Errors that can occur when trying to load and create processes.
 pub enum ProcessLoadError {
@@ -139,7 +140,7 @@ pub fn load_processes<C: Chip>(
     chip: &'static C,
     app_flash: &'static [u8],
     app_memory: &'static mut [u8],
-    mut procs: &'static mut [Option<&'static dyn Process>],
+    procs: &CoreLocal<MapCell<StaticSlice<Option<&'static dyn Process>>>>,
     fault_policy: &'static dyn ProcessFaultPolicy,
     _capability_management: &dyn ProcessManagementCapability,
 ) -> Result<(), ProcessLoadError> {
@@ -148,20 +149,24 @@ pub fn load_processes<C: Chip>(
         chip,
         app_flash,
         app_memory,
-        &mut procs,
+        procs,
         fault_policy,
     )?;
 
     if config::CONFIG.debug_process_credentials {
         debug!("Checking: no checking, load and run all processes");
     }
-    for proc in procs.iter() {
-        proc.map(|p| {
-            if config::CONFIG.debug_process_credentials {
-                debug!("Running {}", p.get_process_name());
+    procs.with(|procs| {
+        procs.map(|procs| {
+            for proc in procs.iter() {
+                proc.map(|p| {
+                    if config::CONFIG.debug_process_credentials {
+                        debug!("Running {}", p.get_process_name());
+                    }
+                });
             }
-        });
-    }
+        })
+    });
     Ok(())
 }
 
@@ -189,94 +194,99 @@ fn load_processes_from_flash<C: Chip, D: ProcessStandardDebug + 'static>(
     chip: &'static C,
     app_flash: &'static [u8],
     app_memory: &'static mut [u8],
-    procs: &mut &'static mut [Option<&'static dyn Process>],
+    procs: &CoreLocal<MapCell<StaticSlice<Option<&'static dyn Process>>>>,
     fault_policy: &'static dyn ProcessFaultPolicy,
 ) -> Result<(), ProcessLoadError> {
-    if config::CONFIG.debug_load_processes {
-        debug!(
-            "Loading processes from flash={:#010X}-{:#010X} into sram={:#010X}-{:#010X}",
-            app_flash.as_ptr() as usize,
-            app_flash.as_ptr() as usize + app_flash.len() - 1,
-            app_memory.as_ptr() as usize,
-            app_memory.as_ptr() as usize + app_memory.len() - 1
-        );
-    }
-
-    let mut remaining_flash = app_flash;
-    let mut remaining_memory = app_memory;
-    // Try to discover up to `procs.len()` processes in flash.
-    let mut index = 0;
-    let num_procs = procs.len();
-    while index < num_procs {
-        let load_binary_result = discover_process_binary(remaining_flash);
-
-        match load_binary_result {
-            Ok((new_flash, process_binary)) => {
-                remaining_flash = new_flash;
-
-                let load_result = load_process::<C, D>(
-                    kernel,
-                    chip,
-                    process_binary,
-                    remaining_memory,
-                    ShortId::LocallyUnique,
-                    index,
-                    fault_policy,
-                    &(),
+    procs.with(|procs| {
+        procs.map(|procs| {
+            if config::CONFIG.debug_load_processes {
+                debug!(
+                    "Loading processes from flash={:#010X}-{:#010X} into sram={:#010X}-{:#010X}",
+                    app_flash.as_ptr() as usize,
+                    app_flash.as_ptr() as usize + app_flash.len() - 1,
+                    app_memory.as_ptr() as usize,
+                    app_memory.as_ptr() as usize + app_memory.len() - 1
                 );
-                match load_result {
-                    Ok((new_mem, proc)) => {
-                        remaining_memory = new_mem;
-                        match proc {
-                            Some(p) => {
-                                if config::CONFIG.debug_load_processes {
-                                    debug!("Loaded process {}", p.get_process_name())
+            }
+
+            let mut remaining_flash = app_flash;
+            let mut remaining_memory = app_memory;
+            // Try to discover up to `procs.len()` processes in flash.
+            let mut index = 0;
+            let num_procs = procs.len();
+            while index < num_procs {
+                let load_binary_result = discover_process_binary(remaining_flash);
+
+                match load_binary_result {
+                    Ok((new_flash, process_binary)) => {
+                        remaining_flash = new_flash;
+
+                        let load_result = load_process::<C, D>(
+                            kernel,
+                            chip,
+                            process_binary,
+                            remaining_memory,
+                            ShortId::LocallyUnique,
+                            index,
+                            fault_policy,
+                            &(),
+                        );
+                        match load_result {
+                            Ok((new_mem, proc)) => {
+                                remaining_memory = new_mem;
+                                match proc {
+                                    Some(p) => {
+                                        if config::CONFIG.debug_load_processes {
+                                            debug!("Loaded process {}", p.get_process_name())
+                                        }
+                                        procs[index] = proc;
+                                        index += 1;
+                                    }
+                                    None => {
+                                        if config::CONFIG.debug_load_processes {
+                                            debug!("No process loaded.");
+                                        }
+                                    }
                                 }
-                                procs[index] = proc;
-                                index += 1;
                             }
-                            None => {
+                            Err((new_mem, err)) => {
+                                remaining_memory = new_mem;
                                 if config::CONFIG.debug_load_processes {
-                                    debug!("No process loaded.");
+                                    debug!("Processes load error: {:?}.", err);
                                 }
                             }
                         }
                     }
-                    Err((new_mem, err)) => {
-                        remaining_memory = new_mem;
-                        if config::CONFIG.debug_load_processes {
-                            debug!("Processes load error: {:?}.", err);
+                    Err((new_flash, err)) => {
+                        remaining_flash = new_flash;
+                        match err {
+                            ProcessBinaryError::NotEnoughFlash
+                            | ProcessBinaryError::TbfHeaderNotFound => {
+                                if config::CONFIG.debug_load_processes {
+                                    debug!("No more processes to load: {:?}.", err);
+                                }
+                                // No more processes to load.
+                                break;
+                            }
+
+                            ProcessBinaryError::TbfHeaderParseFailure(_)
+                            | ProcessBinaryError::IncompatibleKernelVersion { .. }
+                            | ProcessBinaryError::IncorrectFlashAddress { .. }
+                            | ProcessBinaryError::NotEnabledProcess
+                            | ProcessBinaryError::Padding => {
+                                if config::CONFIG.debug_load_processes {
+                                    debug!("Unable to use process binary: {:?}.", err);
+                                }
+
+                                // Skip this binary and move to the next one.
+                                continue;
+                            }
                         }
                     }
                 }
             }
-            Err((new_flash, err)) => {
-                remaining_flash = new_flash;
-                match err {
-                    ProcessBinaryError::NotEnoughFlash | ProcessBinaryError::TbfHeaderNotFound => {
-                        if config::CONFIG.debug_load_processes {
-                            debug!("No more processes to load: {:?}.", err);
-                        }
-                        // No more processes to load.
-                        break;
-                    }
-
-                    ProcessBinaryError::TbfHeaderParseFailure(_)
-                    | ProcessBinaryError::IncompatibleKernelVersion { .. }
-                    | ProcessBinaryError::IncorrectFlashAddress { .. }
-                    | ProcessBinaryError::NotEnabledProcess
-                    | ProcessBinaryError::Padding => {
-                        if config::CONFIG.debug_load_processes {
-                            debug!("Unable to use process binary: {:?}.", err);
-                        }
-
-                        // Skip this binary and move to the next one.
-                        continue;
-                    }
-                }
-            }
-        }
-    }
+        })
+    });
     Ok(())
 }
 

--- a/kernel/src/scheduler.rs
+++ b/kernel/src/scheduler.rs
@@ -6,7 +6,7 @@
 
 pub mod cooperative;
 pub mod mlfq;
-pub mod priority;
+//pub mod priority;
 pub mod round_robin;
 
 use crate::deferred_call::DeferredCall;

--- a/kernel/src/scheduler.rs
+++ b/kernel/src/scheduler.rs
@@ -6,7 +6,7 @@
 
 pub mod cooperative;
 pub mod mlfq;
-//pub mod priority;
+pub mod priority;
 pub mod round_robin;
 
 use crate::deferred_call::DeferredCall;

--- a/kernel/src/scheduler/round_robin.rs
+++ b/kernel/src/scheduler/round_robin.rs
@@ -29,12 +29,12 @@ use crate::scheduler::{Scheduler, SchedulingDecision};
 /// A node in the linked list the scheduler uses to track processes
 /// Each node holds a pointer to a slot in the processes array
 pub struct RoundRobinProcessNode<'a> {
-    proc: &'static Option<&'static dyn Process>,
+    proc: Option<&'static dyn Process>,
     next: ListLink<'a, RoundRobinProcessNode<'a>>,
 }
 
 impl<'a> RoundRobinProcessNode<'a> {
-    pub fn new(proc: &'static Option<&'static dyn Process>) -> RoundRobinProcessNode<'a> {
+    pub fn new(proc: Option<&'static dyn Process>) -> RoundRobinProcessNode<'a> {
         RoundRobinProcessNode {
             proc,
             next: ListLink::empty(),


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes #3841 by replacing most global `static mut` throughout the kernel, chips, capsules, and board crates with a new construct called `CoreLocal`.

`CoreLocal` is similar in principle to Rust `std`'s `LocalKey` (obtained from the `thread_local!` macro). It allows access to its internally stored data within a closure passed to `with`, which obtains a temporary shared reference. It is marked `Sync`, under the assumption that it is accessed in a thread-safe way---e.g. one copy per CPU core, as the name implies---allowing it to be stored in a global (non-mut) static.

This implementation only includes support for single-core, single-threaded, platforms (as all of Tock for the moment) via the unsafe `new_single_core` constructor, though extending to multiple cores should be relatively simple.

In order to support mutation (which is ostensibly the purpose of `static mut` in many cases), users should use some form of single-threaded mutual exclusion, such as a `MapCell`, `TakeCell`, `Cell`, etc.

This PR converts most uses of `static mut` to use this new construct, thus avoiding various annoying warnings and _probably_ some real unsoundness. This comes at virtually no cost to code size, but some minor cost to memory (around 100 bytes on the platforms I looked at).

### Testing Strategy

Still need to test. This changes some subtle parts of the kernel (deferred calls, the schedulers, process implementation) in ways that, if I didn't take enough care to be precise about the logic, could likely result in bugs (though probably not safety bugs).

### TODO or Help Wanted

- [ ] Finish porting other boards. I _think_ this is just menial and straight forward, but tbd
- [ ] Port some chip-specific drivers that have more subtle uses of static mut

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
