### PR TITLE
EUI-64 Capsule

### DIFF
--- a/boards/components/src/eui64.rs
+++ b/boards/components/src/eui64.rs
@@ -1,0 +1,63 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2024.
+
+//! Component for EUI-64 (Extended Unique Identifier).
+//!
+//! Usage
+//! -----
+//! ```rust
+//! let eui64 = components::eui64::Eui64Component::new(
+//!     board_kernel,
+//!     capsules_extra::eui64::DRIVER_NUM,
+//!     device_id)
+//! .finalize(components::eui64_component_static!());
+//! ```
+
+use capsules_extra::eui64::{Eui64, EUI64_BUF_SIZE};
+use core::mem::MaybeUninit;
+use kernel::component::Component;
+use kernel::{capabilities, create_capability};
+
+#[macro_export]
+macro_rules! eui64_component_static {
+    () => {{
+        let eui64 = kernel::static_buf!(capsules_extra::eui64::Eui64);
+        let eui64_buf = kernel::static_buf!([u8; capsules_extra::eui64::EUI64_BUF_SIZE]);
+        (eui64, eui64_buf)
+    };};
+}
+
+pub type Eui64ComponentType = capsules_extra::eui64::Eui64;
+
+pub struct Eui64Component {
+    board_kernel: &'static kernel::Kernel,
+    driver_num: usize,
+    eui64: [u8; 8],
+}
+
+impl Eui64Component {
+    pub fn new(board_kernel: &'static kernel::Kernel, driver_num: usize, eui64: [u8; 8]) -> Self {
+        Self {
+            board_kernel,
+            driver_num,
+            eui64,
+        }
+    }
+}
+
+impl Component for Eui64Component {
+    type StaticInput = (
+        &'static mut MaybeUninit<Eui64>,
+        &'static mut MaybeUninit<[u8; EUI64_BUF_SIZE]>,
+    );
+    type Output = &'static Eui64;
+
+    fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+        let grant = self.board_kernel.create_grant(self.driver_num, &grant_cap);
+        let eui64_buf = s.1.write(self.eui64) as &[u8; EUI64_BUF_SIZE];
+
+        s.0.write(Eui64::new(eui64_buf, grant))
+    }
+}

--- a/boards/components/src/eui64.rs
+++ b/boards/components/src/eui64.rs
@@ -18,9 +18,7 @@ use kernel::component::Component;
 #[macro_export]
 macro_rules! eui64_component_static {
     () => {{
-        let eui64_driver = kernel::static_buf!(capsules_extra::eui64::Eui64);
-        let eui64_val = kernel::static_buf!(u64);
-        (eui64_driver, eui64_val)
+        kernel::static_buf!(capsules_extra::eui64::Eui64)
     };};
 }
 
@@ -37,14 +35,10 @@ impl Eui64Component {
 }
 
 impl Component for Eui64Component {
-    type StaticInput = (
-        &'static mut MaybeUninit<Eui64>,
-        &'static mut MaybeUninit<u64>,
-    );
+    type StaticInput = &'static mut MaybeUninit<Eui64>;
     type Output = &'static Eui64;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let eui64_val = s.1.write(self.eui64);
-        s.0.write(Eui64::new(eui64_val))
+        s.write(Eui64::new(self.eui64))
     }
 }

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -29,6 +29,7 @@ pub mod dac;
 pub mod date_time;
 pub mod debug_queue;
 pub mod debug_writer;
+pub mod eui64;
 pub mod flash;
 pub mod fm25cl;
 pub mod ft6x06;

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -571,12 +571,8 @@ pub unsafe fn start() -> (
     let device_id = nrf52840::ficr::FICR_INSTANCE.id();
     let device_id_bottom_16: u16 = u16::from_le_bytes([device_id[0], device_id[1]]);
 
-    let eui64 = components::eui64::Eui64Component::new(
-        board_kernel,
-        capsules_extra::eui64::DRIVER_NUM,
-        device_id,
-    )
-    .finalize(components::eui64_component_static!());
+    let eui64 = components::eui64::Eui64Component::new(u64::from_le_bytes(device_id))
+        .finalize(components::eui64_component_static!());
 
     let (ieee802154_radio, mux_mac) = components::ieee802154::Ieee802154Component::new(
         board_kernel,

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -183,6 +183,7 @@ type KVDriver = components::kv::KVDriverComponentType<VirtualKVPermissions>;
 type TemperatureDriver =
     components::temperature::TemperatureComponentType<nrf52840::temperature::Temp<'static>>;
 
+// IEEE 802.15.4
 type Ieee802154MacDevice = components::ieee802154::Ieee802154ComponentMacDeviceType<
     nrf52840::ieee802154_radio::Radio<'static>,
     nrf52840::aes::AesECB<'static>,
@@ -192,6 +193,9 @@ type Ieee802154Driver = components::ieee802154::Ieee802154ComponentType<
     nrf52840::aes::AesECB<'static>,
 >;
 
+// EUI64
+type Eui64Driver = components::eui64::Eui64ComponentType;
+
 /// Supported drivers by the platform
 pub struct Platform {
     ble_radio: &'static capsules_extra::ble_advertising_driver::BLE<
@@ -200,6 +204,7 @@ pub struct Platform {
         VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
     >,
     ieee802154_radio: &'static Ieee802154Driver,
+    eui64: &'static Eui64Driver,
     button: &'static capsules_core::button::Button<'static, nrf52840::gpio::GPIOPin<'static>>,
     pconsole: &'static capsules_core::process_console::ProcessConsole<
         'static,
@@ -259,6 +264,7 @@ impl SyscallDriverLookup for Platform {
             capsules_core::adc::DRIVER_NUM => f(Some(self.adc)),
             capsules_extra::ble_advertising_driver::DRIVER_NUM => f(Some(self.ble_radio)),
             capsules_extra::ieee802154::DRIVER_NUM => f(Some(self.ieee802154_radio)),
+            capsules_extra::eui64::DRIVER_NUM => f(Some(self.eui64)),
             capsules_extra::temperature::DRIVER_NUM => f(Some(self.temp)),
             capsules_extra::analog_comparator::DRIVER_NUM => f(Some(self.analog_comparator)),
             capsules_extra::net::udp::DRIVER_NUM => f(Some(self.udp_driver)),
@@ -564,6 +570,14 @@ pub unsafe fn start() -> (
 
     let device_id = nrf52840::ficr::FICR_INSTANCE.id();
     let device_id_bottom_16: u16 = u16::from_le_bytes([device_id[0], device_id[1]]);
+
+    let eui64 = components::eui64::Eui64Component::new(
+        board_kernel,
+        capsules_extra::eui64::DRIVER_NUM,
+        device_id,
+    )
+    .finalize(components::eui64_component_static!());
+
     let (ieee802154_radio, mux_mac) = components::ieee802154::Ieee802154Component::new(
         board_kernel,
         capsules_extra::ieee802154::DRIVER_NUM,
@@ -888,6 +902,7 @@ pub unsafe fn start() -> (
         button,
         ble_radio,
         ieee802154_radio,
+        eui64,
         pconsole,
         console,
         led,

--- a/capsules/core/src/driver.rs
+++ b/capsules/core/src/driver.rs
@@ -42,6 +42,7 @@ pub enum NUM {
     LoRaPhySPI            = 0x30003,
     LoRaPhyGPIO           = 0x30004,
     Thread                = 0x30005,
+    Eui64                 = 0x30006,
 
     // Cryptography
     Rng                   = 0x40001,

--- a/capsules/extra/src/eui64.rs
+++ b/capsules/extra/src/eui64.rs
@@ -6,58 +6,17 @@
 
 use capsules_core::driver;
 pub const DRIVER_NUM: usize = driver::NUM::Eui64 as usize;
-pub const EUI64_BUF_SIZE: usize = 8;
 
-use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::processbuffer::WriteableProcessBuffer;
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::{ErrorCode, ProcessId};
 
-/// Ids for read-write allow buffers
-mod rw_allow {
-    /// Buffer to hold and pass the EUI-64 value.
-    pub const EUI64: usize = 0;
-    /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: u8 = 1;
-}
-
-mod ro_allow {
-    /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: u8 = 0;
-}
-
-/// IDs for subscribed upcalls.
-mod upcall {
-    /// Number of upcalls.
-    pub const COUNT: u8 = 0;
-}
-
-#[derive(Default)]
-pub struct App {}
 pub struct Eui64 {
-    eui64: &'static [u8; EUI64_BUF_SIZE],
-    app: Grant<
-        App,
-        UpcallCount<{ upcall::COUNT }>,
-        AllowRoCount<{ ro_allow::COUNT }>,
-        AllowRwCount<{ rw_allow::COUNT }>,
-    >,
+    eui64: &'static u64,
 }
 
 impl Eui64 {
-    pub fn new(
-        eui64: &'static [u8; EUI64_BUF_SIZE],
-        grant: Grant<
-            App,
-            UpcallCount<{ upcall::COUNT }>,
-            AllowRoCount<{ ro_allow::COUNT }>,
-            AllowRwCount<{ rw_allow::COUNT }>,
-        >,
-    ) -> Eui64 {
-        Eui64 {
-            eui64: eui64,
-            app: grant,
-        }
+    pub fn new(eui64: &'static u64) -> Eui64 {
+        Eui64 { eui64: eui64 }
     }
 }
 
@@ -67,36 +26,16 @@ impl SyscallDriver for Eui64 {
     /// ### `command_num`
     ///
     /// - `0`: Driver existence check.
-    /// - `1`: Obtain EUI64 - placing the EUI64 in a previously allowed read/write buffer.
-    fn command(&self, command_num: usize, _: usize, _: usize, pid: ProcessId) -> CommandReturn {
+    /// - `1`: Obtain EUI64 - providing the value within a u64 returncode.
+    fn command(&self, command_num: usize, _: usize, _: usize, _: ProcessId) -> CommandReturn {
         match command_num {
             0 => CommandReturn::success(),
-            1 => self
-                .app
-                .enter(pid, |_, grant_data| {
-                    grant_data
-                        .get_readwrite_processbuffer(rw_allow::EUI64)
-                        .and_then(|read| {
-                            read.mut_enter(|buf| {
-                                // Confirm that a read write buffer has been allowed (i.e. check
-                                // that the buffer len is not 0) and that the allowed buffer
-                                // is large enough for the EUI64.
-                                if buf.len() < EUI64_BUF_SIZE {
-                                    return CommandReturn::failure(ErrorCode::INVAL);
-                                }
-                                buf[0..EUI64_BUF_SIZE].copy_from_slice(self.eui64);
-                                CommandReturn::success()
-                            })
-                        })
-                        .unwrap_or(CommandReturn::failure(ErrorCode::NOMEM))
-                })
-                .unwrap_or_else(|err| CommandReturn::failure(err.into())),
-
+            1 => CommandReturn::success_u64(*self.eui64),
             _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
         }
     }
 
-    fn allocate_grant(&self, processid: ProcessId) -> Result<(), kernel::process::Error> {
-        self.app.enter(processid, |_, _| {})
+    fn allocate_grant(&self, _: ProcessId) -> Result<(), kernel::process::Error> {
+        Ok(())
     }
 }

--- a/capsules/extra/src/eui64.rs
+++ b/capsules/extra/src/eui64.rs
@@ -1,0 +1,102 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2024.
+
+//! Provides an EUI-64 (Extended Unique Identifier) interface for userspace.
+
+use capsules_core::driver;
+pub const DRIVER_NUM: usize = driver::NUM::Eui64 as usize;
+pub const EUI64_BUF_SIZE: usize = 8;
+
+use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
+use kernel::processbuffer::WriteableProcessBuffer;
+use kernel::syscall::{CommandReturn, SyscallDriver};
+use kernel::{ErrorCode, ProcessId};
+
+/// Ids for read-write allow buffers
+mod rw_allow {
+    /// Buffer to hold and pass the EUI-64 value.
+    pub const EUI64: usize = 0;
+    /// The number of allow buffers the kernel stores for this grant
+    pub const COUNT: u8 = 1;
+}
+
+mod ro_allow {
+    /// The number of allow buffers the kernel stores for this grant
+    pub const COUNT: u8 = 0;
+}
+
+/// IDs for subscribed upcalls.
+mod upcall {
+    /// Number of upcalls.
+    pub const COUNT: u8 = 0;
+}
+
+#[derive(Default)]
+pub struct App {}
+pub struct Eui64 {
+    eui64: &'static [u8; EUI64_BUF_SIZE],
+    app: Grant<
+        App,
+        UpcallCount<{ upcall::COUNT }>,
+        AllowRoCount<{ ro_allow::COUNT }>,
+        AllowRwCount<{ rw_allow::COUNT }>,
+    >,
+}
+
+impl Eui64 {
+    pub fn new(
+        eui64: &'static [u8; EUI64_BUF_SIZE],
+        grant: Grant<
+            App,
+            UpcallCount<{ upcall::COUNT }>,
+            AllowRoCount<{ ro_allow::COUNT }>,
+            AllowRwCount<{ rw_allow::COUNT }>,
+        >,
+    ) -> Eui64 {
+        Eui64 {
+            eui64: eui64,
+            app: grant,
+        }
+    }
+}
+
+impl SyscallDriver for Eui64 {
+    /// Control the Eui64.
+    ///
+    /// ### `command_num`
+    ///
+    /// - `0`: Driver existence check.
+    /// - `1`: Obtain EUI64 - placing the EUI64 in a previously allowed read/write buffer.
+    fn command(&self, command_num: usize, _: usize, _: usize, pid: ProcessId) -> CommandReturn {
+        match command_num {
+            0 => CommandReturn::success(),
+            1 => self
+                .app
+                .enter(pid, |_, grant_data| {
+                    grant_data
+                        .get_readwrite_processbuffer(rw_allow::EUI64)
+                        .and_then(|read| {
+                            read.mut_enter(|buf| {
+                                // Confirm that a read write buffer has been allowed (i.e. check
+                                // that the buffer len is not 0) and that the allowed buffer
+                                // is large enough for the EUI64.
+                                if buf.len() < EUI64_BUF_SIZE {
+                                    return CommandReturn::failure(ErrorCode::INVAL);
+                                }
+                                buf[0..EUI64_BUF_SIZE].copy_from_slice(self.eui64);
+                                CommandReturn::success()
+                            })
+                        })
+                        .unwrap_or(CommandReturn::failure(ErrorCode::NOMEM))
+                })
+                .unwrap_or_else(|err| CommandReturn::failure(err.into())),
+
+            _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
+        }
+    }
+
+    fn allocate_grant(&self, processid: ProcessId) -> Result<(), kernel::process::Error> {
+        self.app.enter(processid, |_, _| {})
+    }
+}

--- a/capsules/extra/src/eui64.rs
+++ b/capsules/extra/src/eui64.rs
@@ -11,11 +11,11 @@ use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::{ErrorCode, ProcessId};
 
 pub struct Eui64 {
-    eui64: &'static u64,
+    eui64: u64,
 }
 
 impl Eui64 {
-    pub fn new(eui64: &'static u64) -> Eui64 {
+    pub fn new(eui64: u64) -> Eui64 {
         Eui64 { eui64: eui64 }
     }
 }
@@ -30,7 +30,7 @@ impl SyscallDriver for Eui64 {
     fn command(&self, command_num: usize, _: usize, _: usize, _: ProcessId) -> CommandReturn {
         match command_num {
             0 => CommandReturn::success(),
-            1 => CommandReturn::success_u64(*self.eui64),
+            1 => CommandReturn::success_u64(self.eui64),
             _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
         }
     }

--- a/capsules/extra/src/lib.rs
+++ b/capsules/extra/src/lib.rs
@@ -32,6 +32,7 @@ pub mod crc;
 pub mod dac;
 pub mod date_time;
 pub mod debug_process_restart;
+pub mod eui64;
 pub mod fm25cl;
 pub mod ft6x06;
 pub mod fxos8700cq;


### PR DESCRIPTION
### Pull Request Overview

This pull request adds support for an EUI-64 capsule. An EUI-64 is needed by networking technologies (such as OpenThread) to generate a Mac or IPv6 address. Userspace apps require a syscall to retrieve this value.

### Testing Strategy

This pull request was tested using a libtock-c app to retrieve the EUI-64 of multiple nrf52840dk.

### TODO or Help Wanted

I would appreciate reviewers paying attention to confirm the EUI-64 value is not mutable by the capsule. Since this value is a board specific and unique value that does not change, a capsule should not be able to mutate this. I believe the value is immutable as implemented, but confirmation would be appreciated.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
