### PR TITLE
CI: synchronize with makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2023.
 
-# This workflow contains all tock-ci, seperated into jobs
+# This workflow contains all tock-ci, separated into jobs
 
 name: tock-ci
 env:
@@ -34,10 +34,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
-      - name: ci-job-format
+      - name:      ci-job-format
         run:  make ci-job-format
-      - name: ci-markdown-toc
-        run: make ci-job-markdown-toc
+      - name:      ci-job-markdown-toc
+        run:  make ci-job-markdown-toc
+      - name:      ci-job-readme-check
+        run:  make ci-job-readme-check
 
   ci-clippy:
     strategy:
@@ -49,7 +51,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - uses: actions/checkout@v3
-      - name: ci-job-clippy
+      - name:      ci-job-clippy
         run:  make ci-job-clippy
 
   ci-build:
@@ -60,16 +62,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
-      - name: ci-job-syntax
-        run: make ci-job-syntax
-      - name: ci-job-compilation
-        run: make ci-job-compilation
-      - name: ci-job-debug-support-targets
-        run: make ci-job-debug-support-targets
-
-      - name: ci-job-collect-artifacts
-        run: make ci-job-collect-artifacts
+      - name:      ci-job-syntax
+        run:  make ci-job-syntax
+      - name:      ci-job-compilation
+        run:  make ci-job-compilation
+      - name:      ci-job-debug-support-targets
+        run:  make ci-job-debug-support-targets
+      - name:      ci-job-collect-artifacts
+        run:  make ci-job-collect-artifacts
       - name: upload-build-artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -92,19 +92,26 @@ jobs:
           sudo apt install libudev-dev libzmq3-dev
         if: matrix.os == 'ubuntu-latest'
       - uses: actions/checkout@v3
-      - name: ci-job-libraries
-        run: make ci-job-libraries
-      - name: ci-job-archs
-        run: make ci-job-archs
-      - name: ci-job-kernel
-        run: make ci-job-kernel
-      - name: ci-job-chips
-        run: make ci-job-chips
-      - name: ci-job-tools
-        run: make ci-job-tools
+      - name:      ci-job-libraries
+        run:  make ci-job-libraries
+      - name:      ci-job-archs
+        run:  make ci-job-archs
+      - name:      ci-job-kernel
+        run:  make ci-job-kernel
+      - name:      ci-job-capsules
+        run:  make ci-job-capsules
+      - name:      ci-job-chips
+        run:  make ci-job-chips
+      - name:      ci-job-tools
+        run:  make ci-job-tools
+      - name:      ci-job-cargo-test-build
+        run:  make ci-job-cargo-test-build
 
   ci-qemu:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Update package repositories
@@ -115,5 +122,5 @@ jobs:
         run: |
           sudo apt install meson
       - uses: actions/checkout@v3
-      - name: ci-job-qemu
-        run: make ci-job-qemu
+      - name:      ci-job-qemu
+        run:  make ci-job-qemu


### PR DESCRIPTION
### Pull Request Overview

This updates the ci.yml workflow to match the Makefile. Some jobs were in different places in each file. This also adds a note that the CI rules do not use the ci-runner* targets.

I didn't realize in my earlier PR that just changing the makefile actually doesn't update the CI. This resolves this to (hopefully) actually run the readme checkers.

Also adds `make ci-job-capsules`. We just weren't doing that?






### Testing Strategy

CI


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
