### PR TITLE
boards: esp32-c3: fix test

### DIFF
--- a/boards/esp32-c3-devkitM-1/src/main.rs
+++ b/boards/esp32-c3-devkitM-1/src/main.rs
@@ -360,8 +360,10 @@ fn test_runner(tests: &[&dyn Fn()]) {
         BOARD = Some(board_kernel);
         PLATFORM = Some(&esp32_c3_board);
         PERIPHERALS = Some(peripherals);
-        SCHEDULER =
-            Some(components::sched::priority::PriorityComponent::new(board_kernel).finalize(()));
+        SCHEDULER = Some(
+            components::sched::priority::PriorityComponent::new(board_kernel)
+                .finalize(components::priority_component_static!()),
+        );
         MAIN_CAP = Some(&create_capability!(capabilities::MainLoopCapability));
 
         PLATFORM.map(|p| {

--- a/boards/esp32-c3-devkitM-1/src/tests/mod.rs
+++ b/boards/esp32-c3-devkitM-1/src/tests/mod.rs
@@ -5,7 +5,6 @@
 use crate::BOARD;
 use crate::CHIP;
 use crate::MAIN_CAP;
-use crate::NUM_PROCS;
 use crate::PLATFORM;
 use kernel::debug;
 


### PR DESCRIPTION
### Pull Request Overview

The priority scheduler needs the static macro.


This will be checked in #3948.


### Testing Strategy

Running `make ci-job-cargo-test-build` 


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
