### PR TITLE
make: check for semver and support mac and linux

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -177,11 +177,14 @@ endif
 # Validate that rustup is new enough.
 MINIMUM_RUSTUP_VERSION := 1.23.0
 RUSTUP_VERSION := $(strip $(word 2, $(shell $(RUSTUP) --version 2> /dev/null)))
+# Check that the semver script exists.
+ifneq (,$(wildcard $(TOCK_ROOT_DIRECTORY)tools/semver.sh))
 ifeq ($(shell $(TOCK_ROOT_DIRECTORY)tools/semver.sh $(RUSTUP_VERSION) \< $(MINIMUM_RUSTUP_VERSION)), true)
   $(warning Required tool `$(RUSTUP)` is out-of-date.)
   $(warning Running `$(RUSTUP) update` in 3 seconds (ctrl-c to cancel))
-  $(shell sleep 3s)
+  $(shell sleep 3)
   DUMMY := $(shell $(RUSTUP) update)
+endif
 endif
 
 # Verify that various required Rust components are installed. All of these steps


### PR DESCRIPTION

### Pull Request Overview

- Check for semver script before checking for rustup version. This helps out-of-tree builds like the tock-bootloader.
- The mac `sleep` command does not accept the "s" specifier. Linux defaults to seconds.





### Testing Strategy

Working on the soil moisture example project.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
