### PR TITLE
Stopgap changes to treatment of `static mut` to get around compiler warnings.

### DIFF
--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -9,7 +9,7 @@ use core::fmt::Write;
 use core::marker::PhantomData;
 use core::mem::{self, size_of};
 use core::ops::Range;
-use core::ptr::{self, read_volatile, write_volatile};
+use core::ptr::{self, addr_of, addr_of_mut, read_volatile, write_volatile};
 use kernel::errorcode::ErrorCode;
 
 use crate::CortexMVariant;
@@ -264,13 +264,13 @@ impl<A: CortexMVariant> kernel::syscall::UserspaceKernelBoundary for SysCall<A> 
 
         // Check to see if the fault handler was called while the process was
         // running.
-        let app_fault = read_volatile(&APP_HARD_FAULT);
-        write_volatile(&mut APP_HARD_FAULT, 0);
+        let app_fault = read_volatile(&*addr_of!(APP_HARD_FAULT));
+        write_volatile(&mut *addr_of_mut!(APP_HARD_FAULT), 0);
 
         // Check to see if the svc_handler was called and the process called a
         // syscall.
-        let syscall_fired = read_volatile(&SYSCALL_FIRED);
-        write_volatile(&mut SYSCALL_FIRED, 0);
+        let syscall_fired = read_volatile(&*addr_of!(SYSCALL_FIRED));
+        write_volatile(&mut *addr_of_mut!(SYSCALL_FIRED), 0);
 
         // Now decide the reason based on which flags were set.
         let switch_reason = if app_fault == 1 || invalid_stack_pointer {

--- a/boards/apollo3/lora_things_plus/src/io.rs
+++ b/boards/apollo3/lora_things_plus/src/io.rs
@@ -4,6 +4,8 @@
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
+use core::ptr::addr_of;
+use core::ptr::addr_of_mut;
 
 use crate::CHIP;
 use crate::PROCESSES;
@@ -45,15 +47,15 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
         apollo3::gpio::Pin::Pin26,
     );
     let led = &mut led::LedLow::new(led_pin);
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
 
     debug::panic(
         &mut [led],
         writer,
         info,
         &cortexm4::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/apollo3/lora_things_plus/src/main.rs
+++ b/boards/apollo3/lora_things_plus/src/main.rs
@@ -39,6 +39,9 @@
 #![test_runner(test_runner)]
 #![reexport_test_harness_main = "test_main"]
 
+use core::ptr::addr_of;
+use core::ptr::addr_of_mut;
+
 use apollo3::chip::Apollo3DefaultPeripherals;
 use capsules_core::virtualizers::virtual_alarm::MuxAlarm;
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
@@ -232,7 +235,7 @@ unsafe fn setup() -> (
     let process_mgmt_cap = create_capability!(capabilities::ProcessManagementCapability);
     let memory_allocation_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
 
     // Power up components
     pwr_ctrl.enable_uart0();
@@ -458,7 +461,7 @@ unsafe fn setup() -> (
         static _eappmem: u8;
     }
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let systick = cortexm4::systick::SysTick::new_with_calibration(48_000_000);
@@ -500,7 +503,7 @@ unsafe fn setup() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut PROCESSES,
+        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_mgmt_cap,
     )

--- a/boards/apollo3/redboard_artemis_atp/src/io.rs
+++ b/boards/apollo3/redboard_artemis_atp/src/io.rs
@@ -4,6 +4,8 @@
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
+use core::ptr::addr_of;
+use core::ptr::addr_of_mut;
 
 use crate::CHIP;
 use crate::PROCESSES;
@@ -45,15 +47,15 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
         apollo3::gpio::Pin::Pin19,
     );
     let led = &mut led::LedLow::new(led_pin);
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
 
     debug::panic(
         &mut [led],
         writer,
         info,
         &cortexm4::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/apollo3/redboard_artemis_atp/src/main.rs
+++ b/boards/apollo3/redboard_artemis_atp/src/main.rs
@@ -15,6 +15,9 @@
 #![test_runner(test_runner)]
 #![reexport_test_harness_main = "test_main"]
 
+use core::ptr::addr_of;
+use core::ptr::addr_of_mut;
+
 use apollo3::chip::Apollo3DefaultPeripherals;
 use capsules_core::i2c_master_slave_driver::I2CMasterSlaveDriver;
 use capsules_core::virtualizers::virtual_alarm::MuxAlarm;
@@ -172,7 +175,7 @@ unsafe fn setup() -> (
     let process_mgmt_cap = create_capability!(capabilities::ProcessManagementCapability);
     let memory_allocation_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
 
     // Power up components
     pwr_ctrl.enable_uart0();
@@ -333,7 +336,7 @@ unsafe fn setup() -> (
         static _eappmem: u8;
     }
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let systick = cortexm4::systick::SysTick::new_with_calibration(48_000_000);
@@ -369,7 +372,7 @@ unsafe fn setup() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut PROCESSES,
+        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_mgmt_cap,
     )

--- a/boards/apollo3/redboard_artemis_nano/src/io.rs
+++ b/boards/apollo3/redboard_artemis_nano/src/io.rs
@@ -4,6 +4,8 @@
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
+use core::ptr::addr_of;
+use core::ptr::addr_of_mut;
 
 use crate::CHIP;
 use crate::PROCESSES;
@@ -45,15 +47,15 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
         apollo3::gpio::Pin::Pin19,
     );
     let led = &mut led::LedLow::new(led_pin);
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
 
     debug::panic(
         &mut [led],
         writer,
         info,
         &cortexm4::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/apollo3/redboard_artemis_nano/src/main.rs
+++ b/boards/apollo3/redboard_artemis_nano/src/main.rs
@@ -15,6 +15,9 @@
 #![test_runner(test_runner)]
 #![reexport_test_harness_main = "test_main"]
 
+use core::ptr::addr_of;
+use core::ptr::addr_of_mut;
+
 use apollo3::chip::Apollo3DefaultPeripherals;
 use capsules_core::virtualizers::virtual_alarm::MuxAlarm;
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
@@ -194,7 +197,7 @@ unsafe fn setup() -> (
     let process_mgmt_cap = create_capability!(capabilities::ProcessManagementCapability);
     let memory_allocation_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
 
     // Power up components
     pwr_ctrl.enable_uart0();
@@ -386,7 +389,7 @@ unsafe fn setup() -> (
         static _eappmem: u8;
     }
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let systick = cortexm4::systick::SysTick::new_with_calibration(48_000_000);
@@ -426,7 +429,7 @@ unsafe fn setup() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut PROCESSES,
+        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_mgmt_cap,
     )

--- a/boards/arty_e21/src/io.rs
+++ b/boards/arty_e21/src/io.rs
@@ -4,6 +4,8 @@
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
+use core::ptr::addr_of;
+use core::ptr::addr_of_mut;
 use core::str;
 use kernel::debug;
 use kernel::debug::IoWrite;
@@ -64,14 +66,14 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     );
 
     let led_red = &mut led::LedHigh::new(led_red_pin);
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
     debug::panic(
         &mut [led_red],
         writer,
         pi,
         &rv32i::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/arty_e21/src/main.rs
+++ b/boards/arty_e21/src/main.rs
@@ -9,6 +9,8 @@
 // https://github.com/rust-lang/rust/issues/62184.
 #![cfg_attr(not(doc), no_main)]
 
+use core::ptr::{addr_of, addr_of_mut};
+
 use arty_e21_chip::chip::ArtyExxDefaultPeripherals;
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 
@@ -139,7 +141,7 @@ unsafe fn start() -> (
 
     let process_mgmt_cap = create_capability!(capabilities::ProcessManagementCapability);
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
 
     // Configure kernel debug gpios as early as possible
     kernel::debug::assign_gpios(
@@ -285,7 +287,7 @@ unsafe fn start() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut PROCESSES,
+        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_mgmt_cap,
     )

--- a/boards/clue_nrf52840/src/io.rs
+++ b/boards/clue_nrf52840/src/io.rs
@@ -4,6 +4,8 @@
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
+use core::ptr::addr_of;
+use core::ptr::addr_of_mut;
 use kernel::ErrorCode;
 
 use kernel::debug;
@@ -96,8 +98,8 @@ impl IoWrite for Writer {
                 //   mutate it.
                 let usb = &mut cdc.controller();
                 STATIC_PANIC_BUF[..max].copy_from_slice(&buf[..max]);
-                let static_buf = &mut STATIC_PANIC_BUF;
-                cdc.set_transmit_client(&DUMMY);
+                let static_buf = &mut *addr_of_mut!(STATIC_PANIC_BUF);
+                cdc.set_transmit_client(&*addr_of!(DUMMY));
                 let _ = cdc.transmit_buffer(static_buf, max);
                 loop {
                     if let Some(interrupt) = cortexm4::nvic::next_pending() {
@@ -130,14 +132,14 @@ impl IoWrite for Writer {
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P1_01);
     let led = &mut led::LedHigh::new(led_kernel_pin);
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
     debug::panic(
         &mut [led],
         writer,
         pi,
         &cortexm4::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -12,6 +12,9 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::ptr::addr_of;
+use core::ptr::addr_of_mut;
+
 use capsules_core::virtualizers::virtual_aes_ccm::MuxAES128CCM;
 
 use kernel::capabilities;
@@ -288,7 +291,7 @@ unsafe fn start() -> (
     // bootloader.
     NRF52_POWER = Some(&base_peripherals.pwr_clk);
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
 
     //--------------------------------------------------------------------------
     // CAPABILITIES
@@ -751,7 +754,7 @@ unsafe fn start() -> (
     // approach than this.
     nrf52_components::NrfClockComponent::new(&base_peripherals.clock).finalize(());
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let platform = Platform {
@@ -820,7 +823,7 @@ unsafe fn start() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut PROCESSES,
+        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/io.rs
@@ -100,16 +100,18 @@ impl IoWrite for Writer {
 /// Panic handler
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // The nRF52840DK LEDs (see back of board)
+
+    use core::ptr::{addr_of, addr_of_mut};
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
     let led = &mut led::LedLow::new(led_kernel_pin);
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
     debug::panic(
         &mut [led],
         writer,
         pi,
         &cortexm4::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/main.rs
@@ -12,6 +12,7 @@
 
 use capsules_core::test::capsule_test::{CapsuleTestClient, CapsuleTestError};
 use core::cell::Cell;
+use core::ptr::addr_of;
 use kernel::component::Component;
 use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
@@ -175,7 +176,7 @@ pub unsafe fn main() {
     let base_peripherals = &nrf52840_peripherals.nrf52;
 
     // Setup space to store the core kernel data structure.
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
 
     // Create (and save for panic debugging) a chip object to setup low-level
     // resources (e.g. MPU, systick).
@@ -243,7 +244,7 @@ pub unsafe fn main() {
     // PLATFORM AND SCHEDULER
     //--------------------------------------------------------------------------
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let platform = Platform {

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/test/hmac_sha256_test.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/test/hmac_sha256_test.rs
@@ -4,6 +4,8 @@
 
 //! This tests a software HMAC-SHA256 implementation.
 
+use core::ptr::{addr_of, addr_of_mut};
+
 use capsules_core::test::capsule_test::{CapsuleTest, CapsuleTestClient};
 use capsules_extra::hmac_sha256::HmacSha256Software;
 use capsules_extra::sha256::Sha256Software;
@@ -46,10 +48,10 @@ unsafe fn static_init_test_hmacsha256(
         TestHmacSha256,
         TestHmacSha256::new(
             hmacsha256,
-            &mut WIKI_KEY,
-            &mut WIKI_STR,
-            &mut DIGEST_DATA,
-            &WIKI_HMAC
+            &mut *addr_of_mut!(WIKI_KEY),
+            &mut *addr_of_mut!(WIKI_STR),
+            &mut *addr_of_mut!(DIGEST_DATA),
+            &*addr_of!(WIKI_HMAC)
         )
     );
     test.set_client(client);

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/test/sha256_test.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/test/sha256_test.rs
@@ -57,7 +57,12 @@ unsafe fn static_init_test_sha256(client: &'static dyn CapsuleTestClient) -> &'s
     // We expect LSTRING to hash to LHASH, so final argument is true
     let test = static_init!(
         TestSha256,
-        TestSha256::new(sha, &mut *addr_of_mut!(LSTRING), &mut *addr_of_mut!(LHASH), true)
+        TestSha256::new(
+            sha,
+            &mut *addr_of_mut!(LSTRING),
+            &mut *addr_of_mut!(LHASH),
+            true
+        )
     );
     test.set_client(client);
 

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/test/sha256_test.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/test/sha256_test.rs
@@ -17,6 +17,8 @@
 //! 72 bytes long. As SHA uses 64-byte/512 bit blocks, this verifies
 //! that multi-block hashes work correctly.
 
+use core::ptr::addr_of_mut;
+
 use capsules_core::test::capsule_test::{CapsuleTest, CapsuleTestClient};
 use capsules_extra::sha256::Sha256Software;
 use capsules_extra::test::sha256::TestSha256;
@@ -55,7 +57,7 @@ unsafe fn static_init_test_sha256(client: &'static dyn CapsuleTestClient) -> &'s
     // We expect LSTRING to hash to LHASH, so final argument is true
     let test = static_init!(
         TestSha256,
-        TestSha256::new(sha, &mut LSTRING, &mut LHASH, true)
+        TestSha256::new(sha, &mut *addr_of_mut!(LSTRING), &mut *addr_of_mut!(LHASH), true)
     );
     test.set_client(client);
 

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/test/siphash24_test.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/test/siphash24_test.rs
@@ -8,6 +8,8 @@
 //! test::siphash24_test::run_siphash24();
 //! ```
 
+use core::ptr::addr_of_mut;
+
 use capsules_core::test::capsule_test::{CapsuleTest, CapsuleTestClient};
 use capsules_extra::sip_hash::SipHasher24;
 use capsules_extra::test::siphash24::TestSipHash24;
@@ -36,7 +38,7 @@ unsafe fn static_init_test_siphash24(
     }
     let test = static_init!(
         TestSipHash24,
-        TestSipHash24::new(sha, &mut HBUF, &mut HHASH, &mut CHASH)
+        TestSipHash24::new(sha, &mut *addr_of_mut!(HBUF), &mut *addr_of_mut!(HHASH), &mut *addr_of_mut!(CHASH))
     );
 
     test.set_client(client);

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/test/siphash24_test.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/test/siphash24_test.rs
@@ -38,7 +38,12 @@ unsafe fn static_init_test_siphash24(
     }
     let test = static_init!(
         TestSipHash24,
-        TestSipHash24::new(sha, &mut *addr_of_mut!(HBUF), &mut *addr_of_mut!(HHASH), &mut *addr_of_mut!(CHASH))
+        TestSipHash24::new(
+            sha,
+            &mut *addr_of_mut!(HBUF),
+            &mut *addr_of_mut!(HHASH),
+            &mut *addr_of_mut!(CHASH)
+        )
     );
 
     test.set_client(client);

--- a/boards/esp32-c3-devkitM-1/src/io.rs
+++ b/boards/esp32-c3-devkitM-1/src/io.rs
@@ -4,6 +4,7 @@
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
+use core::ptr::addr_of;
 use core::str;
 use kernel::debug;
 use kernel::debug::IoWrite;
@@ -38,11 +39,13 @@ impl IoWrite for Writer {
 #[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    let writer = &mut WRITER;
+    use core::ptr::addr_of_mut;
+
+    let writer = &mut *addr_of_mut!(WRITER);
 
     debug::panic_banner(writer, pi);
-    debug::panic_cpu_state(&CHIP, writer);
-    debug::panic_process_info(&PROCESSES, &PROCESS_PRINTER, writer);
+    debug::panic_cpu_state(&*addr_of!(CHIP), writer);
+    debug::panic_process_info(&*addr_of!(PROCESSES), &*addr_of!(PROCESS_PRINTER), writer);
 
     loop {
         rv32i::support::nop();
@@ -53,15 +56,17 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
 #[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    let writer = &mut WRITER;
+    use core::ptr::addr_of_mut;
+
+    let writer = &mut *addr_of_mut!(WRITER);
 
     debug::panic_print(
         writer,
         pi,
         &rv32i::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     );
 
     let _ = writeln!(writer, "{}", pi);

--- a/boards/esp32-c3-devkitM-1/src/main.rs
+++ b/boards/esp32-c3-devkitM-1/src/main.rs
@@ -13,6 +13,8 @@
 #![test_runner(test_runner)]
 #![reexport_test_harness_main = "test_main"]
 
+use core::ptr::{addr_of, addr_of_mut};
+
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use esp32_c3::chip::Esp32C3DefaultPeripherals;
 use kernel::capabilities;
@@ -161,7 +163,7 @@ unsafe fn setup() -> (
     let process_mgmt_cap = create_capability!(capabilities::ProcessManagementCapability);
     let memory_allocation_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
 
     // Configure kernel debug gpios as early as possible
     kernel::debug::assign_gpios(None, None, None);
@@ -311,7 +313,7 @@ unsafe fn setup() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut PROCESSES,
+        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_mgmt_cap,
     )

--- a/boards/hail/rust-toolchain.toml
+++ b/boards/hail/rust-toolchain.toml
@@ -3,6 +3,6 @@
 # Copyright Tock Contributors 2023.
 
 [toolchain]
-channel = "1.76.0"
+channel = "stable"
 components = ["llvm-tools", "rust-src", "rustfmt", "clippy"]
 targets = ["thumbv6m-none-eabi", "thumbv7em-none-eabi", "thumbv7em-none-eabihf", "riscv32imc-unknown-none-elf", "riscv32imac-unknown-none-elf"]

--- a/boards/hail/src/io.rs
+++ b/boards/hail/src/io.rs
@@ -60,6 +60,8 @@ impl IoWrite for Writer {
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // turn off the non panic leds, just in case
+
+    use core::ptr::{addr_of, addr_of_mut};
     let led_green = sam4l::gpio::GPIOPin::new(sam4l::gpio::Pin::PA14);
     led_green.enable_output();
     led_green.set();
@@ -69,14 +71,14 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
 
     let red_pin = sam4l::gpio::GPIOPin::new(sam4l::gpio::Pin::PA13);
     let led_red = &mut led::LedLow::new(&red_pin);
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
     debug::panic(
         &mut [led_red],
         writer,
         pi,
         &cortexm4::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -13,6 +13,8 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::ptr::{addr_of, addr_of_mut};
+
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::hil;
@@ -267,7 +269,7 @@ unsafe fn start() -> (
         Some(&peripherals.pa[14]),
     );
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
 
     let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
         .finalize(components::process_printer_text_component_static!());
@@ -486,7 +488,7 @@ unsafe fn start() -> (
         kernel::process::ThresholdRestartThenPanicFaultPolicy::new(4)
     );
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let hail = Hail {
@@ -547,7 +549,7 @@ unsafe fn start() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut PROCESSES,
+        &mut *addr_of_mut!(PROCESSES),
         fault_policy,
         &process_management_capability,
     )

--- a/boards/hail/src/test_take_map_cell.rs
+++ b/boards/hail/src/test_take_map_cell.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
+use core::ptr::addr_of;
+
 use kernel::debug;
 use kernel::utilities::cells::MapCell;
 
@@ -9,28 +11,28 @@ pub unsafe fn test_take_map_cell() {
     static FOO: u32 = 1234;
 
     static mut MC_REF: MapCell<&'static u32> = MapCell::new(&FOO);
-    test_map_cell(&MC_REF);
+    test_map_cell(&*addr_of!(MC_REF));
 
     static mut MC1: MapCell<[[u8; 256]; 1]> = MapCell::new([[125; 256]; 1]);
-    test_map_cell(&MC1);
+    test_map_cell(&*addr_of!(MC1));
 
     static mut MC2: MapCell<[[u8; 256]; 2]> = MapCell::new([[125; 256]; 2]);
-    test_map_cell(&MC2);
+    test_map_cell(&*addr_of!(MC2));
 
     static mut MC3: MapCell<[[u8; 256]; 3]> = MapCell::new([[125; 256]; 3]);
-    test_map_cell(&MC3);
+    test_map_cell(&*addr_of!(MC3));
 
     static mut MC4: MapCell<[[u8; 256]; 4]> = MapCell::new([[125; 256]; 4]);
-    test_map_cell(&MC4);
+    test_map_cell(&*addr_of!(MC4));
 
     static mut MC5: MapCell<[[u8; 256]; 5]> = MapCell::new([[125; 256]; 5]);
-    test_map_cell(&MC5);
+    test_map_cell(&*addr_of!(MC5));
 
     static mut MC6: MapCell<[[u8; 256]; 6]> = MapCell::new([[125; 256]; 6]);
-    test_map_cell(&MC6);
+    test_map_cell(&*addr_of!(MC6));
 
     static mut MC7: MapCell<[[u8; 256]; 7]> = MapCell::new([[125; 256]; 7]);
-    test_map_cell(&MC7);
+    test_map_cell(&*addr_of!(MC7));
 }
 
 #[inline(never)]

--- a/boards/hifive1/src/io.rs
+++ b/boards/hifive1/src/io.rs
@@ -4,6 +4,8 @@
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
+use core::ptr::addr_of;
+use core::ptr::addr_of_mut;
 use core::str;
 use kernel::debug;
 use kernel::debug::IoWrite;
@@ -64,15 +66,15 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         sifive::gpio::pins::pin22::CLEAR,
     );
     let led_red = &mut led::LedLow::new(&led_red_pin);
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
 
     debug::panic(
         &mut [led_red],
         writer,
         pi,
         &rv32i::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -325,8 +325,9 @@ unsafe fn start() -> (
     debug!("HiFive1 initialization complete.");
     debug!("Entering main loop.");
 
-    let scheduler = components::sched::cooperative::CooperativeComponent::new(&*addr_of!(PROCESSES))
-        .finalize(components::cooperative_component_static!(NUM_PROCS));
+    let scheduler =
+        components::sched::cooperative::CooperativeComponent::new(&*addr_of!(PROCESSES))
+            .finalize(components::cooperative_component_static!(NUM_PROCS));
 
     let scheduler_timer = static_init!(
         VirtualSchedulerTimer<VirtualMuxAlarm<'static, e310_g002::chip::E310xClint<'static>>>,

--- a/boards/hifive_inventor/src/io.rs
+++ b/boards/hifive_inventor/src/io.rs
@@ -37,6 +37,8 @@ impl IoWrite for Writer {
 #[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
+    use core::ptr::{addr_of, addr_of_mut};
+
     let led = sifive::gpio::GpioPin::new(
         e310_g003::gpio::GPIO0_BASE,
         sifive::gpio::pins::pin22,
@@ -44,15 +46,15 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         sifive::gpio::pins::pin22::CLEAR,
     );
     let led = &mut led::LedLow::new(&led);
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
 
     debug::panic(
         &mut [led],
         writer,
         pi,
         &rv32i::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -60,16 +60,18 @@ impl IoWrite for Writer {
 #[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
+    use core::ptr::{addr_of, addr_of_mut};
+
     let led_pin = sam4l::gpio::GPIOPin::new(sam4l::gpio::Pin::PC22);
     let led = &mut led::LedLow::new(&led_pin);
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
     debug::panic(
         &mut [led],
         writer,
         pi,
         &cortexm4::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -624,7 +624,11 @@ pub unsafe fn main() {
     peripherals.aes.set_client(aes_mux);
 
     // Can this initialize be pushed earlier, or into component? -pal
-    let _ = rf233.initialize(&mut *addr_of_mut!(RF233_BUF), &mut *addr_of_mut!(RF233_REG_WRITE), &mut *addr_of_mut!(RF233_REG_READ));
+    let _ = rf233.initialize(
+        &mut *addr_of_mut!(RF233_BUF),
+        &mut *addr_of_mut!(RF233_REG_WRITE),
+        &mut *addr_of_mut!(RF233_REG_READ),
+    );
     let (_, mux_mac) = components::ieee802154::Ieee802154Component::new(
         board_kernel,
         capsules_extra::ieee802154::DRIVER_NUM,

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -14,6 +14,8 @@
 #![deny(missing_docs)]
 
 mod imix_components;
+use core::ptr::{addr_of, addr_of_mut};
+
 use capsules_core::alarm::AlarmDriver;
 use capsules_core::console_ordered::ConsoleOrdered;
 use capsules_core::virtualizers::virtual_aes_ccm::MuxAES128CCM;
@@ -374,7 +376,7 @@ pub unsafe fn main() {
         },
     );
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
 
     let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
         .finalize(components::process_printer_text_component_static!());
@@ -622,7 +624,7 @@ pub unsafe fn main() {
     peripherals.aes.set_client(aes_mux);
 
     // Can this initialize be pushed earlier, or into component? -pal
-    let _ = rf233.initialize(&mut RF233_BUF, &mut RF233_REG_WRITE, &mut RF233_REG_READ);
+    let _ = rf233.initialize(&mut *addr_of_mut!(RF233_BUF), &mut *addr_of_mut!(RF233_REG_WRITE), &mut *addr_of_mut!(RF233_REG_READ));
     let (_, mux_mac) = components::ieee802154::Ieee802154Component::new(
         board_kernel,
         capsules_extra::ieee802154::DRIVER_NUM,
@@ -709,7 +711,7 @@ pub unsafe fn main() {
     )
     .finalize(components::udp_driver_component_static!(sam4l::ast::Ast));
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     // Create the software-based SHA engine.
@@ -751,7 +753,7 @@ pub unsafe fn main() {
         >,
         kernel::process::SequentialProcessLoaderMachine::new(
             checker,
-            &mut PROCESSES,
+            &mut *addr_of_mut!(PROCESSES),
             process_binary_array,
             board_kernel,
             chip,

--- a/boards/imix/src/test/i2c_dummy.rs
+++ b/boards/imix/src/test/i2c_dummy.rs
@@ -5,6 +5,7 @@
 //! A dummy I2C client
 
 use core::cell::Cell;
+use core::ptr::addr_of_mut;
 use kernel::debug;
 use kernel::hil;
 use kernel::hil::i2c::{Error, I2CMaster};
@@ -61,7 +62,7 @@ pub fn i2c_scan_slaves(i2c_master: &'static dyn I2CMaster<'static>) {
     dev.enable();
 
     debug!("Scanning for I2C devices...");
-    dev.write(i2c_client.dev_id.get(), unsafe { &mut DATA }, 2)
+    dev.write(i2c_client.dev_id.get(), unsafe { &mut *addr_of_mut!(DATA) }, 2)
         .unwrap();
 }
 
@@ -156,7 +157,7 @@ pub fn i2c_accel_test(i2c_master: &'static dyn I2CMaster<'static>) {
     dev.set_master_client(i2c_client);
     dev.enable();
 
-    let buf = unsafe { &mut DATA };
+    let buf = unsafe { &mut *addr_of_mut!(DATA) };
     debug!("Reading Accel's WHOAMI...");
     buf[0] = 0x0D_u8; // 0x0D == WHOAMI register
     dev.write_read(0x1e, buf, 1, 1).unwrap();
@@ -228,7 +229,7 @@ pub fn i2c_li_test(i2c_master: &'static dyn I2CMaster<'static>) {
     dev.set_master_client(i2c_client);
     dev.enable();
 
-    let buf = unsafe { &mut DATA };
+    let buf = unsafe { &mut *addr_of_mut!(DATA) };
     debug!("Enabling LI...");
     buf[0] = 0;
     buf[1] = 0b10100000;

--- a/boards/imix/src/test/i2c_dummy.rs
+++ b/boards/imix/src/test/i2c_dummy.rs
@@ -62,8 +62,12 @@ pub fn i2c_scan_slaves(i2c_master: &'static dyn I2CMaster<'static>) {
     dev.enable();
 
     debug!("Scanning for I2C devices...");
-    dev.write(i2c_client.dev_id.get(), unsafe { &mut *addr_of_mut!(DATA) }, 2)
-        .unwrap();
+    dev.write(
+        i2c_client.dev_id.get(),
+        unsafe { &mut *addr_of_mut!(DATA) },
+        2,
+    )
+    .unwrap();
 }
 
 // ===========================================

--- a/boards/imix/src/test/icmp_lowpan_test.rs
+++ b/boards/imix/src/test/icmp_lowpan_test.rs
@@ -254,8 +254,12 @@ impl<'a, A: time::Alarm<'a>> LowpanICMPTest<'a, A> {
     fn send_next(&self) {
         let icmp_hdr = ICMP6Header::new(ICMP6Type::Type128); // Echo Request
         let _ = unsafe {
-            self.icmp_sender
-                .send(DST_ADDR, icmp_hdr, &mut *addr_of_mut!(ICMP_PAYLOAD), self.net_cap)
+            self.icmp_sender.send(
+                DST_ADDR,
+                icmp_hdr,
+                &mut *addr_of_mut!(ICMP_PAYLOAD),
+                self.net_cap,
+            )
         };
     }
 }

--- a/boards/imix/src/test/icmp_lowpan_test.rs
+++ b/boards/imix/src/test/icmp_lowpan_test.rs
@@ -30,6 +30,7 @@ use kernel::ErrorCode;
 
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use core::cell::Cell;
+use core::ptr::addr_of_mut;
 use kernel::capabilities::NetworkCapabilityCreationCapability;
 use kernel::create_capability;
 use kernel::debug;
@@ -125,7 +126,7 @@ pub unsafe fn run(
 
     let ip_pyld: IPPayload = IPPayload {
         header: TransportHeader::ICMP(icmp_hdr),
-        payload: &mut ICMP_PAYLOAD,
+        payload: &mut *addr_of_mut!(ICMP_PAYLOAD),
     };
 
     let ip6_dg = static_init!(IP6Packet<'static>, IP6Packet::new(ip_pyld));
@@ -135,7 +136,7 @@ pub unsafe fn run(
         IP6SendStruct::new(
             ip6_dg,
             ipsender_virtual_alarm,
-            &mut RF233_BUF,
+            &mut *addr_of_mut!(RF233_BUF),
             sixlowpan_tx,
             radio_mac,
             DST_MAC_ADDR,
@@ -254,7 +255,7 @@ impl<'a, A: time::Alarm<'a>> LowpanICMPTest<'a, A> {
         let icmp_hdr = ICMP6Header::new(ICMP6Type::Type128); // Echo Request
         let _ = unsafe {
             self.icmp_sender
-                .send(DST_ADDR, icmp_hdr, &mut ICMP_PAYLOAD, self.net_cap)
+                .send(DST_ADDR, icmp_hdr, &mut *addr_of_mut!(ICMP_PAYLOAD), self.net_cap)
         };
     }
 }

--- a/boards/imix/src/test/ipv6_lowpan_test.rs
+++ b/boards/imix/src/test/ipv6_lowpan_test.rs
@@ -43,6 +43,7 @@ use capsules_extra::net::sixlowpan::sixlowpan_state::{
 };
 use capsules_extra::net::udp::UDPHeader;
 use core::cell::Cell;
+use core::ptr::addr_of_mut;
 use kernel::debug;
 use kernel::hil::radio;
 use kernel::hil::time::{self, Alarm, ConvertTicks};
@@ -148,7 +149,7 @@ pub unsafe fn initialize_all(
         capsules_extra::ieee802154::virtual_mac::MacUser::new(mux_mac)
     );
     mux_mac.add_user(radio_mac);
-    let default_rx_state = static_init!(RxState<'static>, RxState::new(&mut RX_STATE_BUF));
+    let default_rx_state = static_init!(RxState<'static>, RxState::new(&mut *addr_of_mut!(RX_STATE_BUF)));
 
     let sixlo_alarm = static_init!(
         VirtualMuxAlarm<sam4l::ast::Ast>,
@@ -212,7 +213,7 @@ pub unsafe fn initialize_all(
 
     let ip_pyld: IPPayload = IPPayload {
         header: tr_hdr,
-        payload: &mut UDP_DGRAM,
+        payload: &mut *addr_of_mut!(UDP_DGRAM),
     };
 
     let mut ip6_dg: IP6Packet = IP6Packet {
@@ -418,7 +419,7 @@ impl<'a, A: time::Alarm<'a>> LowpanTest<'a, A> {
     }
 
     unsafe fn send_ipv6_packet(&self, _: &[u8]) {
-        self.send_next(&mut RF233_BUF);
+        self.send_next(&mut *addr_of_mut!(RF233_BUF));
     }
 
     fn send_next(&self, tx_buf: &'static mut [u8]) {

--- a/boards/imix/src/test/ipv6_lowpan_test.rs
+++ b/boards/imix/src/test/ipv6_lowpan_test.rs
@@ -149,7 +149,10 @@ pub unsafe fn initialize_all(
         capsules_extra::ieee802154::virtual_mac::MacUser::new(mux_mac)
     );
     mux_mac.add_user(radio_mac);
-    let default_rx_state = static_init!(RxState<'static>, RxState::new(&mut *addr_of_mut!(RX_STATE_BUF)));
+    let default_rx_state = static_init!(
+        RxState<'static>,
+        RxState::new(&mut *addr_of_mut!(RX_STATE_BUF))
+    );
 
     let sixlo_alarm = static_init!(
         VirtualMuxAlarm<sam4l::ast::Ast>,

--- a/boards/imix/src/test/linear_log_test.rs
+++ b/boards/imix/src/test/linear_log_test.rs
@@ -20,6 +20,7 @@
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules_extra::log;
 use core::cell::Cell;
+use core::ptr::addr_of_mut;
 use kernel::debug;
 use kernel::hil::flash;
 use kernel::hil::log::{LogRead, LogReadClient, LogWrite, LogWriteClient};
@@ -59,7 +60,7 @@ pub unsafe fn run(
     // Create and run test for log storage.
     let test = static_init!(
         LogTest<VirtualMuxAlarm<'static, Ast>>,
-        LogTest::new(log, &mut BUFFER, alarm, &TEST_OPS)
+        LogTest::new(log, &mut *addr_of_mut!(BUFFER), alarm, &TEST_OPS)
     );
     log.set_read_client(test);
     log.set_append_client(test);

--- a/boards/imix/src/test/log_test.rs
+++ b/boards/imix/src/test/log_test.rs
@@ -32,6 +32,7 @@
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules_extra::log;
 use core::cell::Cell;
+use core::ptr::addr_of_mut;
 use kernel::debug;
 use kernel::hil::flash;
 use kernel::hil::gpio::{self, Interrupt};
@@ -72,7 +73,7 @@ pub unsafe fn run(
     // Create and run test for log storage.
     let test = static_init!(
         LogTest<VirtualMuxAlarm<'static, Ast>>,
-        LogTest::new(log, &mut BUFFER, alarm, &TEST_OPS)
+        LogTest::new(log, &mut *addr_of_mut!(BUFFER), alarm, &TEST_OPS)
     );
     log.set_read_client(test);
     log.set_append_client(test);
@@ -379,7 +380,10 @@ impl<A: 'static + Alarm<'static>> LogTest<A> {
 
         // Ensure failure if entry is too large to fit within a single flash page.
         unsafe {
-            match self.log.append(&mut DUMMY_BUFFER, DUMMY_BUFFER.len()) {
+            match self
+                .log
+                .append(&mut *addr_of_mut!(DUMMY_BUFFER), DUMMY_BUFFER.len())
+            {
                 Ok(()) => panic!("Appending with too-small buffer succeeded unexpectedly!"),
                 Err((ecode, _original_buffer)) => assert_eq!(ecode, ErrorCode::SIZE),
             }

--- a/boards/imix/src/test/sha256_test.rs
+++ b/boards/imix/src/test/sha256_test.rs
@@ -59,7 +59,12 @@ unsafe fn static_init_test_sha256() -> &'static TestSha256 {
     // We expect LSTRING to hash to LHASH, so final argument is true
     let test = static_init!(
         TestSha256,
-        TestSha256::new(sha, &mut *addr_of_mut!(LSTRING), &mut *addr_of_mut!(LHASH), true)
+        TestSha256::new(
+            sha,
+            &mut *addr_of_mut!(LSTRING),
+            &mut *addr_of_mut!(LHASH),
+            true
+        )
     );
 
     test

--- a/boards/imix/src/test/sha256_test.rs
+++ b/boards/imix/src/test/sha256_test.rs
@@ -20,6 +20,8 @@
 //! 72 bytes long. As SHA uses 64-byte/512 bit blocks, this verifies
 //! that multi-block hashes work correctly.
 
+use core::ptr::addr_of_mut;
+
 use capsules_extra::sha256::Sha256Software;
 use capsules_extra::test::sha256::TestSha256;
 use kernel::static_init;
@@ -57,7 +59,7 @@ unsafe fn static_init_test_sha256() -> &'static TestSha256 {
     // We expect LSTRING to hash to LHASH, so final argument is true
     let test = static_init!(
         TestSha256,
-        TestSha256::new(sha, &mut LSTRING, &mut LHASH, true)
+        TestSha256::new(sha, &mut *addr_of_mut!(LSTRING), &mut *addr_of_mut!(LHASH), true)
     );
 
     test

--- a/boards/imix/src/test/spi_dummy.rs
+++ b/boards/imix/src/test/spi_dummy.rs
@@ -4,6 +4,8 @@
 
 //! A dummy SPI client to test the SPI implementation
 
+use core::ptr::addr_of_mut;
+
 use kernel::hil::gpio::Configure;
 use kernel::hil::spi::{self, SpiMaster};
 use kernel::ErrorCode;
@@ -37,7 +39,7 @@ impl spi::SpiMasterClient for DummyCB {
         unsafe {
             // do actual stuff
             // TODO verify SPI return value
-            let _ = self.spi.read_write_bytes(&mut A5, None, A5.len());
+            let _ = self.spi.read_write_bytes(&mut *addr_of_mut!(A5), None, A5.len());
 
             // FLOP = !FLOP;
             // let len: usize = BUF1.len();
@@ -83,7 +85,7 @@ pub unsafe fn spi_dummy_test(spi: &'static sam4l::spi::SpiHw<'static>) {
     spi.set_baud_rate(200000);
 
     let len = BUF2.len();
-    if spi.read_write_bytes(&mut BUF2, Some(&mut BUF1), len) != Ok(()) {
+    if spi.read_write_bytes(&mut *addr_of_mut!(BUF2), Some(&mut *addr_of_mut!(BUF1)), len) != Ok(()) {
         loop {
             spi.write_byte(0xA5).unwrap();
         }

--- a/boards/imix/src/test/spi_dummy.rs
+++ b/boards/imix/src/test/spi_dummy.rs
@@ -39,7 +39,9 @@ impl spi::SpiMasterClient for DummyCB {
         unsafe {
             // do actual stuff
             // TODO verify SPI return value
-            let _ = self.spi.read_write_bytes(&mut *addr_of_mut!(A5), None, A5.len());
+            let _ = self
+                .spi
+                .read_write_bytes(&mut *addr_of_mut!(A5), None, A5.len());
 
             // FLOP = !FLOP;
             // let len: usize = BUF1.len();
@@ -85,7 +87,12 @@ pub unsafe fn spi_dummy_test(spi: &'static sam4l::spi::SpiHw<'static>) {
     spi.set_baud_rate(200000);
 
     let len = BUF2.len();
-    if spi.read_write_bytes(&mut *addr_of_mut!(BUF2), Some(&mut *addr_of_mut!(BUF1)), len) != Ok(()) {
+    if spi.read_write_bytes(
+        &mut *addr_of_mut!(BUF2),
+        Some(&mut *addr_of_mut!(BUF1)),
+        len,
+    ) != Ok(())
+    {
         loop {
             spi.write_byte(0xA5).unwrap();
         }

--- a/boards/imix/src/test/spi_loopback.rs
+++ b/boards/imix/src/test/spi_loopback.rs
@@ -97,7 +97,11 @@ pub unsafe fn spi_loopback_test(
         .expect("Failed to set SPI speed in SPI loopback test.");
 
     let len = WBUF.len();
-    if let Err((e, _, _)) = spi.read_write_bytes(&mut *addr_of_mut!(WBUF), Some(&mut *addr_of_mut!(RBUF)), len) {
+    if let Err((e, _, _)) = spi.read_write_bytes(
+        &mut *addr_of_mut!(WBUF),
+        Some(&mut *addr_of_mut!(RBUF)),
+        len,
+    ) {
         panic!(
             "Could not start SPI test, error on read_write_bytes is {:?}",
             e
@@ -125,7 +129,11 @@ pub unsafe fn spi_two_loopback_test(mux: &'static MuxSpiMaster<'static, sam4l::s
     spi_slow.set_client(spicb_slow);
 
     let len = WBUF.len();
-    if let Err((e, _, _)) = spi_fast.read_write_bytes(&mut *addr_of_mut!(WBUF), Some(&mut *addr_of_mut!(RBUF)), len) {
+    if let Err((e, _, _)) = spi_fast.read_write_bytes(
+        &mut *addr_of_mut!(WBUF),
+        Some(&mut *addr_of_mut!(RBUF)),
+        len,
+    ) {
         panic!(
             "Could not start SPI test, error on read_write_bytes is {:?}",
             e
@@ -133,7 +141,11 @@ pub unsafe fn spi_two_loopback_test(mux: &'static MuxSpiMaster<'static, sam4l::s
     }
 
     let len = WBUF2.len();
-    if let Err((e, _, _)) = spi_slow.read_write_bytes(&mut *addr_of_mut!(WBUF2), Some(&mut *addr_of_mut!(RBUF2)), len) {
+    if let Err((e, _, _)) = spi_slow.read_write_bytes(
+        &mut *addr_of_mut!(WBUF2),
+        Some(&mut *addr_of_mut!(RBUF2)),
+        len,
+    ) {
         panic!(
             "Could not start SPI test, error on read_write_bytes is {:?}",
             e

--- a/boards/imix/src/test/spi_loopback.rs
+++ b/boards/imix/src/test/spi_loopback.rs
@@ -17,6 +17,7 @@
 use capsules_core::virtualizers::virtual_spi::MuxSpiMaster;
 use components::spi::SpiComponent;
 use core::cell::Cell;
+use core::ptr::addr_of_mut;
 use kernel::component::Component;
 use kernel::debug;
 use kernel::hil::spi::{self, SpiMasterDevice};
@@ -96,7 +97,7 @@ pub unsafe fn spi_loopback_test(
         .expect("Failed to set SPI speed in SPI loopback test.");
 
     let len = WBUF.len();
-    if let Err((e, _, _)) = spi.read_write_bytes(&mut WBUF, Some(&mut RBUF), len) {
+    if let Err((e, _, _)) = spi.read_write_bytes(&mut *addr_of_mut!(WBUF), Some(&mut *addr_of_mut!(RBUF)), len) {
         panic!(
             "Could not start SPI test, error on read_write_bytes is {:?}",
             e
@@ -124,7 +125,7 @@ pub unsafe fn spi_two_loopback_test(mux: &'static MuxSpiMaster<'static, sam4l::s
     spi_slow.set_client(spicb_slow);
 
     let len = WBUF.len();
-    if let Err((e, _, _)) = spi_fast.read_write_bytes(&mut WBUF, Some(&mut RBUF), len) {
+    if let Err((e, _, _)) = spi_fast.read_write_bytes(&mut *addr_of_mut!(WBUF), Some(&mut *addr_of_mut!(RBUF)), len) {
         panic!(
             "Could not start SPI test, error on read_write_bytes is {:?}",
             e
@@ -132,7 +133,7 @@ pub unsafe fn spi_two_loopback_test(mux: &'static MuxSpiMaster<'static, sam4l::s
     }
 
     let len = WBUF2.len();
-    if let Err((e, _, _)) = spi_slow.read_write_bytes(&mut WBUF2, Some(&mut RBUF2), len) {
+    if let Err((e, _, _)) = spi_slow.read_write_bytes(&mut *addr_of_mut!(WBUF2), Some(&mut *addr_of_mut!(RBUF2)), len) {
         panic!(
             "Could not start SPI test, error on read_write_bytes is {:?}",
             e

--- a/boards/imix/src/test/udp_lowpan_test.rs
+++ b/boards/imix/src/test/udp_lowpan_test.rs
@@ -132,6 +132,7 @@ use capsules_extra::net::udp::udp_recv::MuxUdpReceiver;
 use capsules_extra::net::udp::udp_send::MuxUdpSender;
 use capsules_extra::test::udp::MockUdp;
 use core::cell::Cell;
+use core::ptr::addr_of_mut;
 use kernel::capabilities::NetworkCapabilityCreationCapability;
 use kernel::component::Component;
 use kernel::create_capability;
@@ -192,7 +193,7 @@ pub unsafe fn initialize_all(
         udp_recv_mux,
         port_table,
         mux_alarm,
-        &mut UDP_PAYLOAD1,
+        &mut *addr_of_mut!(UDP_PAYLOAD1),
         1, //id
         3, //dst_port
         net_cap,
@@ -205,7 +206,7 @@ pub unsafe fn initialize_all(
         udp_recv_mux,
         port_table,
         mux_alarm,
-        &mut UDP_PAYLOAD2,
+        &mut *addr_of_mut!(UDP_PAYLOAD2),
         2, //id
         4, //dst_port
         net_cap,

--- a/boards/imix/src/test/virtual_uart_rx_test.rs
+++ b/boards/imix/src/test/virtual_uart_rx_test.rs
@@ -72,8 +72,8 @@ unsafe fn static_init_test_receive_small(
     device.setup();
     let test = static_init!(
         TestVirtualUartReceive,
-        TestVirtualUartReceive::new(device, &mut *addr_of_mut!(SMALL)
-    ));
+        TestVirtualUartReceive::new(device, &mut *addr_of_mut!(SMALL))
+    );
     device.set_receive_client(test);
     test
 }

--- a/boards/imix/src/test/virtual_uart_rx_test.rs
+++ b/boards/imix/src/test/virtual_uart_rx_test.rs
@@ -48,6 +48,8 @@
 //! 61
 //! ```
 
+use core::ptr::addr_of_mut;
+
 use capsules_core::test::virtual_uart::TestVirtualUartReceive;
 use capsules_core::virtualizers::virtual_uart::{MuxUart, UartDevice};
 use kernel::debug;
@@ -70,8 +72,8 @@ unsafe fn static_init_test_receive_small(
     device.setup();
     let test = static_init!(
         TestVirtualUartReceive,
-        TestVirtualUartReceive::new(device, &mut SMALL)
-    );
+        TestVirtualUartReceive::new(device, &mut *addr_of_mut!(SMALL)
+    ));
     device.set_receive_client(test);
     test
 }
@@ -84,7 +86,7 @@ unsafe fn static_init_test_receive_large(
     device.setup();
     let test = static_init!(
         TestVirtualUartReceive,
-        TestVirtualUartReceive::new(device, &mut BUFFER)
+        TestVirtualUartReceive::new(device, &mut *addr_of_mut!(BUFFER))
     );
     device.set_receive_client(test);
     test

--- a/boards/imxrt1050-evkb/src/io.rs
+++ b/boards/imxrt1050-evkb/src/io.rs
@@ -4,6 +4,8 @@
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
+use core::ptr::addr_of;
+use core::ptr::addr_of_mut;
 
 use kernel::debug;
 use kernel::debug::IoWrite;
@@ -71,15 +73,15 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     // User Led is connected to AdB0_09
     let pin = imxrt1050::gpio::Pin::from_pin_id(PinId::AdB0_09);
     let led = &mut led::LedLow::new(&pin);
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
 
     debug::panic(
         &mut [led],
         writer,
         info,
         &cortexm7::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -10,6 +10,8 @@
 #![no_main]
 #![deny(missing_docs)]
 
+use core::ptr::{addr_of, addr_of_mut};
+
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
 use kernel::capabilities;
@@ -253,7 +255,7 @@ pub unsafe fn main() {
 
     setup_peripherals(peripherals);
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
 
     let chip = static_init!(Chip, Chip::new(peripherals));
     CHIP = Some(chip);
@@ -452,7 +454,7 @@ pub unsafe fn main() {
     )
     .finalize(components::ninedof_component_static!(fxos8700));
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let imxrt1050 = Imxrt1050EVKB {
@@ -524,7 +526,7 @@ pub unsafe fn main() {
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut PROCESSES,
+        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/litex/arty/src/io.rs
+++ b/boards/litex/arty/src/io.rs
@@ -35,19 +35,21 @@ impl IoWrite for Writer {
 #[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
+    use core::ptr::{addr_of, addr_of_mut};
+
     let panic_led = PANIC_REFERENCES
         .led_controller
         .and_then(|ctrl| ctrl.panic_led(0));
 
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
 
     debug::panic(
         &mut [&mut panic_led.unwrap()],
         writer,
         pi,
         &rv32i::support::nop,
-        &PROCESSES,
-        &PANIC_REFERENCES.chip,
-        &PANIC_REFERENCES.process_printer,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(PANIC_REFERENCES.chip),
+        &*addr_of!(PANIC_REFERENCES.process_printer),
     )
 }

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -10,6 +10,8 @@
 // https://github.com/rust-lang/rust/issues/62184.
 #![cfg_attr(not(doc), no_main)]
 
+use core::ptr::{addr_of, addr_of_mut};
+
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 
 use kernel::capabilities;
@@ -300,7 +302,7 @@ pub unsafe fn main() {
     let memory_allocation_cap = create_capability!(capabilities::MemoryAllocationCapability);
     let main_loop_cap = create_capability!(capabilities::MainLoopCapability);
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
 
     // ---------- LED CONTROLLER HARDWARE ----------
 
@@ -574,7 +576,7 @@ pub unsafe fn main() {
     )
     .finalize(components::low_level_debug_component_static!());
 
-    let scheduler = components::sched::cooperative::CooperativeComponent::new(&PROCESSES)
+    let scheduler = components::sched::cooperative::CooperativeComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::cooperative_component_static!(NUM_PROCS));
 
     let litex_arty = LiteXArty {
@@ -606,7 +608,7 @@ pub unsafe fn main() {
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut PROCESSES,
+        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_mgmt_cap,
     )

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -576,8 +576,9 @@ pub unsafe fn main() {
     )
     .finalize(components::low_level_debug_component_static!());
 
-    let scheduler = components::sched::cooperative::CooperativeComponent::new(&*addr_of!(PROCESSES))
-        .finalize(components::cooperative_component_static!(NUM_PROCS));
+    let scheduler =
+        components::sched::cooperative::CooperativeComponent::new(&*addr_of!(PROCESSES))
+            .finalize(components::cooperative_component_static!(NUM_PROCS));
 
     let litex_arty = LiteXArty {
         console,

--- a/boards/litex/sim/src/io.rs
+++ b/boards/litex/sim/src/io.rs
@@ -35,15 +35,17 @@ impl IoWrite for Writer {
 #[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    let writer = &mut WRITER;
+    use core::ptr::{addr_of, addr_of_mut};
+
+    let writer = &mut *addr_of_mut!(WRITER);
 
     debug::panic_print(
         writer,
         pi,
         &rv32i::support::nop,
-        &PROCESSES,
-        &PANIC_REFERENCES.chip,
-        &PANIC_REFERENCES.process_printer,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(PANIC_REFERENCES.chip),
+        &*addr_of!(PANIC_REFERENCES.process_printer),
     );
 
     // The system is no longer in a well-defined state; loop forever

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -651,8 +651,9 @@ pub unsafe fn main() {
 
     debug!("Verilated LiteX+VexRiscv: initialization complete, entering main loop.");
 
-    let scheduler = components::sched::cooperative::CooperativeComponent::new(&*addr_of!(PROCESSES))
-        .finalize(components::cooperative_component_static!(NUM_PROCS));
+    let scheduler =
+        components::sched::cooperative::CooperativeComponent::new(&*addr_of!(PROCESSES))
+            .finalize(components::cooperative_component_static!(NUM_PROCS));
 
     let litex_sim = LiteXSim {
         gpio_driver: gpio_driver,

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -9,6 +9,8 @@
 // https://github.com/rust-lang/rust/issues/62184.
 #![cfg_attr(not(doc), no_main)]
 
+use core::ptr::{addr_of, addr_of_mut};
+
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use kernel::capabilities;
 use kernel::component::Component;
@@ -299,7 +301,7 @@ pub unsafe fn main() {
     let memory_allocation_cap = create_capability!(capabilities::MemoryAllocationCapability);
     let main_loop_cap = create_capability!(capabilities::MainLoopCapability);
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
 
     // --------- TIMER & UPTIME CORE; ALARM INITIALIZATION ----------
 
@@ -649,7 +651,7 @@ pub unsafe fn main() {
 
     debug!("Verilated LiteX+VexRiscv: initialization complete, entering main loop.");
 
-    let scheduler = components::sched::cooperative::CooperativeComponent::new(&PROCESSES)
+    let scheduler = components::sched::cooperative::CooperativeComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::cooperative_component_static!(NUM_PROCS));
 
     let litex_sim = LiteXSim {
@@ -679,7 +681,7 @@ pub unsafe fn main() {
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut PROCESSES,
+        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_mgmt_cap,
     )

--- a/boards/makepython-nrf52840/src/io.rs
+++ b/boards/makepython-nrf52840/src/io.rs
@@ -127,8 +127,6 @@ impl IoWrite for Writer {
 #[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    use core::ptr::{addr_of, addr_of_mut};
-
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P1_10);
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);

--- a/boards/makepython-nrf52840/src/io.rs
+++ b/boards/makepython-nrf52840/src/io.rs
@@ -4,8 +4,8 @@
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
+use core::ptr::{addr_of, addr_of_mut};
 
-use cortexm4;
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;
@@ -97,8 +97,8 @@ impl IoWrite for Writer {
                 //   mutate it.
                 let usb = &mut cdc.controller();
                 STATIC_PANIC_BUF[..max].copy_from_slice(&buf[..max]);
-                let static_buf = &mut STATIC_PANIC_BUF;
-                cdc.set_transmit_client(&DUMMY);
+                let static_buf = &mut *addr_of_mut!(STATIC_PANIC_BUF);
+                cdc.set_transmit_client(&*addr_of!(DUMMY));
                 let _ = cdc.transmit_buffer(static_buf, max);
                 loop {
                     if let Some(interrupt) = cortexm4::nvic::next_pending() {
@@ -127,16 +127,18 @@ impl IoWrite for Writer {
 #[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
+    use core::ptr::{addr_of, addr_of_mut};
+
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P1_10);
     let led = &mut led::LedLow::new(led_kernel_pin);
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
     debug::panic(
         &mut [led],
         writer,
         pi,
         &cortexm4::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/microbit_v2/src/io.rs
+++ b/boards/microbit_v2/src/io.rs
@@ -103,17 +103,19 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // let mut led = Led (&gpio::PORT[Pin::P0_28], );
 
     // MicroBit v2 has a microphone LED, use it for panic
+
+    use core::ptr::{addr_of, addr_of_mut};
     let led_kernel_pin = &nrf52833::gpio::GPIOPin::new(Pin::P0_20);
     let led = &mut led::LedLow::new(led_kernel_pin);
     // MatrixLed(&gpio::PORT[Pin::P0_28], &gpio::PORT[Pin::P0_21]);
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
     debug::panic(
         &mut [led],
         writer,
         pi,
         &cortexm4::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -12,6 +12,8 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::ptr::{addr_of, addr_of_mut};
+
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::hil::time::Counter;
@@ -227,7 +229,7 @@ unsafe fn start() -> (
 
     let base_peripherals = &nrf52833_peripherals.nrf52;
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
 
     //--------------------------------------------------------------------------
     // CAPABILITIES
@@ -703,7 +705,7 @@ unsafe fn start() -> (
     while !base_peripherals.clock.low_started() {}
     while !base_peripherals.clock.high_started() {}
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let microbit = MicroBit {
@@ -767,7 +769,7 @@ unsafe fn start() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut PROCESSES,
+        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/msp_exp432p401r/src/io.rs
+++ b/boards/msp_exp432p401r/src/io.rs
@@ -8,6 +8,8 @@ use crate::PROCESS_PRINTER;
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
+use core::ptr::addr_of;
+use core::ptr::addr_of_mut;
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;
@@ -42,7 +44,7 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     const LED1_PIN: IntPinNr = IntPinNr::P01_0;
     let gpio_pin = msp432::gpio::IntPin::new(LED1_PIN);
     let led = &mut led::LedHigh::new(&gpio_pin);
-    let writer = &mut UART;
+    let writer = &mut *addr_of_mut!(UART);
     let wdt = Wdt::new();
 
     wdt.disable();
@@ -51,8 +53,8 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
         writer,
         info,
         &cortexm4::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -12,6 +12,8 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::ptr::{addr_of, addr_of_mut};
+
 use components::gpio::GpioComponent;
 use kernel::capabilities;
 use kernel::component::Component;
@@ -233,7 +235,7 @@ pub unsafe fn main() {
     peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P01_2 as usize].enable_primary_function();
     peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P01_3 as usize].enable_primary_function();
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
     let chip = static_init!(
         msp432::chip::Msp432<msp432::chip::Msp432DefaultPeripherals>,
         msp432::chip::Msp432::new(peripherals)
@@ -406,7 +408,7 @@ pub unsafe fn main() {
     // Enable the internal temperature sensor on ADC Channel 22
     peripherals.adc_ref.enable_temp_sensor(true);
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
@@ -455,7 +457,7 @@ pub unsafe fn main() {
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut PROCESSES,
+        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/nano33ble/src/io.rs
+++ b/boards/nano33ble/src/io.rs
@@ -4,6 +4,7 @@
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
+use core::ptr::{addr_of, addr_of_mut};
 
 use kernel::debug;
 use kernel::debug::IoWrite;
@@ -96,8 +97,8 @@ impl IoWrite for Writer {
                 //   mutate it.
                 let usb = &mut cdc.controller();
                 STATIC_PANIC_BUF[..max].copy_from_slice(&buf[..max]);
-                let static_buf = &mut STATIC_PANIC_BUF;
-                cdc.set_transmit_client(&DUMMY);
+                let static_buf = &mut *addr_of_mut!(STATIC_PANIC_BUF);
+                cdc.set_transmit_client(& *addr_of!(DUMMY));
                 let _ = cdc.transmit_buffer(static_buf, max);
                 loop {
                     if let Some(interrupt) = cortexm4::nvic::next_pending() {
@@ -130,14 +131,14 @@ impl IoWrite for Writer {
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
     let led = &mut led::LedLow::new(led_kernel_pin);
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
     debug::panic(
         &mut [led],
         writer,
         pi,
         &cortexm4::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/nano33ble/src/io.rs
+++ b/boards/nano33ble/src/io.rs
@@ -98,7 +98,7 @@ impl IoWrite for Writer {
                 let usb = &mut cdc.controller();
                 STATIC_PANIC_BUF[..max].copy_from_slice(&buf[..max]);
                 let static_buf = &mut *addr_of_mut!(STATIC_PANIC_BUF);
-                cdc.set_transmit_client(& *addr_of!(DUMMY));
+                cdc.set_transmit_client(&*addr_of!(DUMMY));
                 let _ = cdc.transmit_buffer(static_buf, max);
                 loop {
                     if let Some(interrupt) = cortexm4::nvic::next_pending() {

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -12,6 +12,9 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::ptr::addr_of;
+use core::ptr::addr_of_mut;
+
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::hil::gpio::Configure;
@@ -262,7 +265,7 @@ pub unsafe fn start() -> (
     // bootloader.
     NRF52_POWER = Some(&base_peripherals.pwr_clk);
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
 
     //--------------------------------------------------------------------------
     // CAPABILITIES
@@ -606,7 +609,7 @@ pub unsafe fn start() -> (
     // approach than this.
     nrf52_components::NrfClockComponent::new(&base_peripherals.clock).finalize(());
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let platform = Platform {
@@ -687,7 +690,7 @@ pub unsafe fn start() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut PROCESSES,
+        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/nano33ble/src/test/linear_log_test.rs
+++ b/boards/nano33ble/src/test/linear_log_test.rs
@@ -25,6 +25,7 @@
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules_extra::log;
 use core::cell::Cell;
+use core::ptr::addr_of_mut;
 use kernel::debug_verbose;
 use kernel::hil::flash;
 use kernel::hil::log::{LogRead, LogReadClient, LogWrite, LogWriteClient};
@@ -64,7 +65,7 @@ pub unsafe fn run(mux_alarm: &'static MuxAlarm<'static, Rtc>, flash_controller: 
     // Create and run test for log storage.
     let test = static_init!(
         LogTest<VirtualMuxAlarm<'static, Rtc>>,
-        LogTest::new(log, &mut BUFFER, alarm, &TEST_OPS)
+        LogTest::new(log, &mut *addr_of_mut!(BUFFER), alarm, &TEST_OPS)
     );
     log.set_read_client(test);
     log.set_append_client(test);

--- a/boards/nano33ble/src/test/log_test.rs
+++ b/boards/nano33ble/src/test/log_test.rs
@@ -35,6 +35,7 @@
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules_extra::log;
 use core::cell::Cell;
+use core::ptr::addr_of_mut;
 use kernel::debug;
 use kernel::hil::flash;
 use kernel::hil::gpio::{self, Interrupt, InterruptEdge};
@@ -76,7 +77,7 @@ pub unsafe fn run(mux_alarm: &'static MuxAlarm<'static, Rtc>, flash_controller: 
     // Create and run test for log storage.
     let test = static_init!(
         LogTest<VirtualMuxAlarm<'static, Rtc>>,
-        LogTest::new(log, &mut BUFFER, alarm, &TEST_OPS)
+        LogTest::new(log, &mut *addr_of_mut!(BUFFER), alarm, &TEST_OPS)
     );
     log.set_read_client(test);
     log.set_append_client(test);
@@ -384,7 +385,7 @@ impl<A: 'static + Alarm<'static>> LogTest<A> {
 
         // Ensure failure if entry is too large to fit within a single flash page.
         unsafe {
-            match self.log.append(&mut DUMMY_BUFFER, DUMMY_BUFFER.len()) {
+            match self.log.append(&mut *addr_of_mut!(DUMMY_BUFFER), DUMMY_BUFFER.len()) {
                 Ok(()) => panic!("Appending with too-small buffer succeeded unexpectedly!"),
                 Err((error, _original_buffer)) => assert_eq!(error, ErrorCode::SIZE),
             }

--- a/boards/nano33ble/src/test/log_test.rs
+++ b/boards/nano33ble/src/test/log_test.rs
@@ -385,7 +385,10 @@ impl<A: 'static + Alarm<'static>> LogTest<A> {
 
         // Ensure failure if entry is too large to fit within a single flash page.
         unsafe {
-            match self.log.append(&mut *addr_of_mut!(DUMMY_BUFFER), DUMMY_BUFFER.len()) {
+            match self
+                .log
+                .append(&mut *addr_of_mut!(DUMMY_BUFFER), DUMMY_BUFFER.len())
+            {
                 Ok(()) => panic!("Appending with too-small buffer succeeded unexpectedly!"),
                 Err((error, _original_buffer)) => assert_eq!(error, ErrorCode::SIZE),
             }

--- a/boards/nano33ble_rev2/src/io.rs
+++ b/boards/nano33ble_rev2/src/io.rs
@@ -4,6 +4,7 @@
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
+use core::ptr::{addr_of, addr_of_mut};
 
 use cortexm4;
 use kernel::debug;
@@ -97,8 +98,8 @@ impl IoWrite for Writer {
                 //   mutate it.
                 let usb = &mut cdc.controller();
                 STATIC_PANIC_BUF[..max].copy_from_slice(&buf[..max]);
-                let static_buf = &mut STATIC_PANIC_BUF;
-                cdc.set_transmit_client(&DUMMY);
+                let static_buf = &mut *addr_of_mut!(STATIC_PANIC_BUF);
+                cdc.set_transmit_client(&*addr_of!(DUMMY));
                 let _ = cdc.transmit_buffer(static_buf, max);
                 loop {
                     if let Some(interrupt) = cortexm4::nvic::next_pending() {
@@ -129,16 +130,18 @@ impl IoWrite for Writer {
 #[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
+    use core::ptr::{addr_of, addr_of_mut};
+
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
     let led = &mut led::LedLow::new(led_kernel_pin);
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
     debug::panic(
         &mut [led],
         writer,
         pi,
         &cortexm4::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/nano33ble_rev2/src/io.rs
+++ b/boards/nano33ble_rev2/src/io.rs
@@ -130,8 +130,6 @@ impl IoWrite for Writer {
 #[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    use core::ptr::{addr_of, addr_of_mut};
-
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);

--- a/boards/nano33ble_rev2/src/main.rs
+++ b/boards/nano33ble_rev2/src/main.rs
@@ -12,6 +12,9 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::ptr::addr_of;
+use core::ptr::addr_of_mut;
+
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::hil::gpio::Configure;
@@ -270,7 +273,7 @@ pub unsafe fn start() -> (
     // bootloader.
     NRF52_POWER = Some(&base_peripherals.pwr_clk);
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
 
     //--------------------------------------------------------------------------
     // CAPABILITIES
@@ -628,7 +631,7 @@ pub unsafe fn start() -> (
     // approach than this.
     nrf52_components::NrfClockComponent::new(&base_peripherals.clock).finalize(());
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let platform = Platform {
@@ -707,10 +710,10 @@ pub unsafe fn start() -> (
             &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
         ),
         core::slice::from_raw_parts_mut(
-            &mut _sappmem as *mut u8,
-            &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
+            addr_of_mut!(_sappmem),
+            addr_of!(_eappmem) as usize - addr_of!(_sappmem) as usize,
         ),
-        &mut PROCESSES,
+        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/nano_rp2040_connect/src/io.rs
+++ b/boards/nano_rp2040_connect/src/io.rs
@@ -88,17 +88,19 @@ impl IoWrite for Writer {
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // LED is connected to GPIO 25
+
+    use core::ptr::{addr_of, addr_of_mut};
     let led_kernel_pin = &RPGpioPin::new(RPGpio::GPIO25);
     let led = &mut LedHigh::new(led_kernel_pin);
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
 
     debug::panic(
         &mut [led],
         writer,
         pi,
         &cortexm0p::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -12,6 +12,8 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::ptr::{addr_of, addr_of_mut};
+
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
 use components::led::LedsComponent;
@@ -312,7 +314,7 @@ pub unsafe fn start() -> (
 
     CHIP = Some(chip);
 
-    let board_kernel = static_init!(Kernel, Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(Kernel, Kernel::new(&*addr_of!(PROCESSES)));
 
     let process_management_capability =
         create_capability!(capabilities::ProcessManagementCapability);
@@ -539,7 +541,7 @@ pub unsafe fn start() -> (
     .finalize(components::process_console_component_static!(RPTimer));
     let _ = process_console.start();
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let nano_rp2040_connect = NanoRP2040Connect {
@@ -597,7 +599,7 @@ pub unsafe fn start() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut PROCESSES,
+        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/nordic/nrf52840_dongle/src/io.rs
+++ b/boards/nordic/nrf52840_dongle/src/io.rs
@@ -60,16 +60,18 @@ impl IoWrite for Writer {
 /// Panic handler
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // The nRF52840 Dongle LEDs (see back of board)
+
+    use core::ptr::{addr_of, addr_of_mut};
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_06);
     let led = &mut led::LedLow::new(led_kernel_pin);
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
     debug::panic(
         &mut [led],
         writer,
         pi,
         &cortexm4::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -13,6 +13,8 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::ptr::{addr_of, addr_of_mut};
+
 use capsules_core::virtualizers::virtual_aes_ccm::MuxAES128CCM;
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use kernel::component::Component;
@@ -207,7 +209,7 @@ pub unsafe fn start() -> (
     nrf52840_peripherals.init();
     let base_peripherals = &nrf52840_peripherals.nrf52;
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
 
     // GPIOs
     let gpio = components::gpio::GpioComponent::new(
@@ -403,7 +405,7 @@ pub unsafe fn start() -> (
         &base_peripherals.acomp,
         components::analog_comparator_component_helper!(
             nrf52840::acomp::Channel,
-            &nrf52840::acomp::CHANNEL_AC0
+            &*addr_of!(nrf52840::acomp::CHANNEL_AC0)
         ),
         board_kernel,
         capsules_extra::analog_comparator::DRIVER_NUM,
@@ -414,7 +416,7 @@ pub unsafe fn start() -> (
 
     nrf52_components::NrfClockComponent::new(&base_peripherals.clock).finalize(());
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let platform = Platform {
@@ -440,7 +442,7 @@ pub unsafe fn start() -> (
 
     let _ = platform.pconsole.start();
     debug!("Initialization complete. Entering main loop\r");
-    debug!("{}", &nrf52840::ficr::FICR_INSTANCE);
+    debug!("{}", &*addr_of!(nrf52840::ficr::FICR_INSTANCE));
 
     // These symbols are defined in the linker script.
     extern "C" {
@@ -465,7 +467,7 @@ pub unsafe fn start() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut PROCESSES,
+        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -4,6 +4,8 @@
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
+use core::ptr::addr_of;
+use core::ptr::addr_of_mut;
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;
@@ -101,14 +103,14 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // The nRF52840DK LEDs (see back of board)
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
     let led = &mut led::LedLow::new(led_kernel_pin);
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
     debug::panic(
         &mut [led],
         writer,
         pi,
         &cortexm4::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/nordic/nrf52dk/src/io.rs
+++ b/boards/nordic/nrf52dk/src/io.rs
@@ -60,16 +60,18 @@ impl IoWrite for Writer {
 /// Panic handler
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // The nRF52 DK LEDs (see back of board)
+
+    use core::ptr::{addr_of, addr_of_mut};
     let led_kernel_pin = &nrf52832::gpio::GPIOPin::new(Pin::P0_17);
     let led = &mut led::LedLow::new(led_kernel_pin);
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
     debug::panic(
         &mut [led],
         writer,
         pi,
         &cortexm4::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -71,6 +71,8 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::ptr::{addr_of, addr_of_mut};
+
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use kernel::component::Component;
 use kernel::hil::led::LedLow;
@@ -252,7 +254,7 @@ pub unsafe fn start() -> (
     nrf52832_peripherals.init();
     let base_peripherals = &nrf52832_peripherals.nrf52;
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
 
     let gpio = components::gpio::GpioComponent::new(
         board_kernel,
@@ -426,7 +428,7 @@ pub unsafe fn start() -> (
         &base_peripherals.acomp,
         components::analog_comparator_component_helper!(
             nrf52832::acomp::Channel,
-            &nrf52832::acomp::CHANNEL_AC0
+            &*addr_of!(nrf52832::acomp::CHANNEL_AC0)
         ),
         board_kernel,
         capsules_extra::analog_comparator::DRIVER_NUM,
@@ -437,7 +439,7 @@ pub unsafe fn start() -> (
 
     nrf52_components::NrfClockComponent::new(&base_peripherals.clock).finalize(());
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let platform = Platform {
@@ -462,7 +464,7 @@ pub unsafe fn start() -> (
 
     let _ = platform.pconsole.start();
     debug!("Initialization complete. Entering main loop\r");
-    debug!("{}", &nrf52832::ficr::FICR_INSTANCE);
+    debug!("{}", &*addr_of!(nrf52832::ficr::FICR_INSTANCE));
 
     // These symbols are defined in the linker script.
     extern "C" {
@@ -487,7 +489,7 @@ pub unsafe fn start() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut PROCESSES,
+        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/nucleo_f429zi/src/io.rs
+++ b/boards/nucleo_f429zi/src/io.rs
@@ -4,6 +4,8 @@
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
+use core::ptr::addr_of;
+use core::ptr::addr_of_mut;
 
 use kernel::debug;
 use kernel::debug::IoWrite;
@@ -78,15 +80,15 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     pin.set_ports_ref(&gpio_ports);
     let led = &mut led::LedHigh::new(&pin);
 
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
 
     debug::panic(
         &mut [led],
         writer,
         info,
         &cortexm4::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -12,6 +12,8 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::ptr::{addr_of, addr_of_mut};
+
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
 use kernel::capabilities;
@@ -350,7 +352,7 @@ unsafe fn start() -> (
         &base_peripherals.usart3,
     );
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
 
     let chip = static_init!(
         stm32f429zi::chip::Stm32f4xx<Stm32f429ziDefaultPeripherals>,
@@ -634,7 +636,7 @@ unsafe fn start() -> (
     ));
     let _ = process_console.start();
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let nucleo_f429zi = NucleoF429ZI {
@@ -689,7 +691,7 @@ unsafe fn start() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut PROCESSES,
+        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/nucleo_f446re/src/io.rs
+++ b/boards/nucleo_f446re/src/io.rs
@@ -4,6 +4,7 @@
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
+use core::ptr::{addr_of, addr_of_mut};
 
 use kernel::debug;
 use kernel::debug::IoWrite;
@@ -78,15 +79,15 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     pin.set_ports_ref(&gpio_ports);
     let led = &mut led::LedHigh::new(&pin);
 
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
 
     debug::panic(
         &mut [led],
         writer,
         info,
         &cortexm4::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -12,6 +12,8 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::ptr::{addr_of, addr_of_mut};
+
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
 use kernel::capabilities;
@@ -294,7 +296,7 @@ unsafe fn start() -> (
         &base_peripherals.usart2,
     );
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
 
     let chip = static_init!(
         stm32f446re::chip::Stm32f4xx<Stm32f446reDefaultPeripherals>,
@@ -478,7 +480,7 @@ unsafe fn start() -> (
     ));
     let _ = process_console.start();
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let nucleo_f446re = NucleoF446RE {
@@ -530,7 +532,7 @@ unsafe fn start() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut PROCESSES,
+        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/nucleo_f446re/src/virtual_uart_rx_test.rs
+++ b/boards/nucleo_f446re/src/virtual_uart_rx_test.rs
@@ -48,6 +48,8 @@
 //! 61
 //! ```
 
+use core::ptr::addr_of_mut;
+
 use capsules_core::test::virtual_uart::TestVirtualUartReceive;
 use capsules_core::virtualizers::virtual_uart::{MuxUart, UartDevice};
 use kernel::debug;
@@ -70,7 +72,7 @@ unsafe fn static_init_test_receive_small(
     device.setup();
     let test = static_init!(
         TestVirtualUartReceive,
-        TestVirtualUartReceive::new(device, &mut SMALL)
+        TestVirtualUartReceive::new(device, &mut *addr_of_mut!(SMALL))
     );
     device.set_receive_client(test);
     test
@@ -84,7 +86,7 @@ unsafe fn static_init_test_receive_large(
     device.setup();
     let test = static_init!(
         TestVirtualUartReceive,
-        TestVirtualUartReceive::new(device, &mut BUFFER)
+        TestVirtualUartReceive::new(device, &mut *addr_of_mut!(BUFFER))
     );
     device.set_receive_client(test);
     test

--- a/boards/opentitan/src/io.rs
+++ b/boards/opentitan/src/io.rs
@@ -47,6 +47,7 @@ use kernel::hil::led;
 #[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
+    use core::ptr::{addr_of, addr_of_mut};
     let first_led_pin = &mut earlgrey::gpio::GpioPin::new(
         earlgrey::gpio::GPIO_BASE,
         earlgrey::pinmux::PadConfig::Output(
@@ -57,7 +58,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     );
     first_led_pin.make_output();
     let first_led = &mut led::LedLow::new(first_led_pin);
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
 
     #[cfg(feature = "sim_verilator")]
     debug::panic(
@@ -65,9 +66,9 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         writer,
         pi,
         &|| {},
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     );
 
     #[cfg(not(feature = "sim_verilator"))]
@@ -76,9 +77,9 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         writer,
         pi,
         &rv32i::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     );
 }
 

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -14,6 +14,7 @@
 #![test_runner(test_runner)]
 #![reexport_test_harness_main = "test_main"]
 
+use core::ptr::{addr_of, addr_of_mut};
 use crate::hil::symmetric_encryption::AES128_BLOCK_SIZE;
 use crate::otbn::OtbnComponent;
 use crate::pinmux_layout::BoardPinmuxLayout;
@@ -381,7 +382,7 @@ unsafe fn setup() -> (
     let process_mgmt_cap = create_capability!(capabilities::ProcessManagementCapability);
     let memory_allocation_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
 
     let peripherals = static_init!(
         EarlGreyDefaultPeripherals<ChipConfig, BoardPinmuxLayout>,
@@ -868,7 +869,7 @@ unsafe fn setup() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut PROCESSES,
+        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_mgmt_cap,
     )

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -14,13 +14,13 @@
 #![test_runner(test_runner)]
 #![reexport_test_harness_main = "test_main"]
 
-use core::ptr::{addr_of, addr_of_mut};
 use crate::hil::symmetric_encryption::AES128_BLOCK_SIZE;
 use crate::otbn::OtbnComponent;
 use crate::pinmux_layout::BoardPinmuxLayout;
 use capsules_aes_gcm::aes_gcm;
 use capsules_core::virtualizers::virtual_aes_ccm;
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use core::ptr::{addr_of, addr_of_mut};
 use earlgrey::chip::EarlGreyDefaultPeripherals;
 use earlgrey::chip_config::EarlGreyConfig;
 use earlgrey::pinmux_config::EarlGreyPinmuxConfig;

--- a/boards/particle_boron/src/io.rs
+++ b/boards/particle_boron/src/io.rs
@@ -68,16 +68,18 @@ const LED2_R_PIN: Pin = Pin::P0_13;
 /// Panic handler
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // The nRF52840DK LEDs (see back of board)
+
+    use core::ptr::{addr_of, addr_of_mut};
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(LED2_R_PIN);
     let led = &mut led::LedLow::new(led_kernel_pin);
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
     debug::panic(
         &mut [led],
         writer,
         pi,
         &cortexm4::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -13,6 +13,9 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::ptr::addr_of;
+use core::ptr::addr_of_mut;
+
 use capsules_core::i2c_master_slave_driver::I2CMasterSlaveDriver;
 use capsules_core::virtualizers::virtual_aes_ccm::MuxAES128CCM;
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
@@ -228,7 +231,7 @@ pub unsafe fn start_particle_boron() -> (
     // bootloader.
     NRF52_POWER = Some(&base_peripherals.pwr_clk);
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
 
     //--------------------------------------------------------------------------
     // CAPABILITIES
@@ -549,7 +552,7 @@ pub unsafe fn start_particle_boron() -> (
 
     nrf52_components::NrfClockComponent::new(&base_peripherals.clock).finalize(());
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let platform = Platform {
@@ -608,7 +611,7 @@ pub unsafe fn start_particle_boron() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut PROCESSES,
+        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/pico_explorer_base/src/io.rs
+++ b/boards/pico_explorer_base/src/io.rs
@@ -90,17 +90,19 @@ impl IoWrite for Writer {
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // LED is conneted to GPIO 25
+
+    use core::ptr::{addr_of, addr_of_mut};
     let led_kernel_pin = &RPGpioPin::new(RPGpio::GPIO25);
     let led = &mut LedHigh::new(led_kernel_pin);
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
 
     debug::panic(
         &mut [led],
         writer,
         pi,
         &cortexm0p::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -12,6 +12,8 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::ptr::{addr_of, addr_of_mut};
+
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
 use components::led::LedsComponent;
@@ -325,7 +327,7 @@ pub unsafe fn start() -> (
 
     CHIP = Some(chip);
 
-    let board_kernel = static_init!(Kernel, Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(Kernel, Kernel::new(&*addr_of!(PROCESSES)));
 
     let process_management_capability =
         create_capability!(capabilities::ProcessManagementCapability);
@@ -559,7 +561,7 @@ pub unsafe fn start() -> (
     .finalize(components::process_console_component_static!(RPTimer));
     let _ = process_console.start();
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     //--------------------------------------------------------------------------
@@ -681,7 +683,7 @@ pub unsafe fn start() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut PROCESSES,
+        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/qemu_rv32_virt/src/io.rs
+++ b/boards/qemu_rv32_virt/src/io.rs
@@ -37,15 +37,17 @@ impl IoWrite for Writer {
 #[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    let writer = &mut WRITER;
+    use core::ptr::{addr_of, addr_of_mut};
+
+    let writer = &mut *addr_of_mut!(WRITER);
 
     debug::panic_print::<_, _, _>(
         writer,
         pi,
         &rv32i::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     );
 
     // The system is no longer in a well-defined state. Use

--- a/boards/qemu_rv32_virt/src/main.rs
+++ b/boards/qemu_rv32_virt/src/main.rs
@@ -502,8 +502,9 @@ pub unsafe fn main() {
     )
     .finalize(components::low_level_debug_component_static!());
 
-    let scheduler = components::sched::cooperative::CooperativeComponent::new(&*addr_of!(PROCESSES))
-        .finalize(components::cooperative_component_static!(NUM_PROCS));
+    let scheduler =
+        components::sched::cooperative::CooperativeComponent::new(&*addr_of!(PROCESSES))
+            .finalize(components::cooperative_component_static!(NUM_PROCS));
 
     let scheduler_timer = static_init!(
         VirtualSchedulerTimer<

--- a/boards/qemu_rv32_virt/src/main.rs
+++ b/boards/qemu_rv32_virt/src/main.rs
@@ -9,6 +9,9 @@
 // https://github.com/rust-lang/rust/issues/62184.
 #![cfg_attr(not(doc), no_main)]
 
+use core::ptr::addr_of;
+use core::ptr::addr_of_mut;
+
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use kernel::capabilities;
 use kernel::component::Component;
@@ -219,7 +222,7 @@ pub unsafe fn main() {
     let main_loop_cap = create_capability!(capabilities::MainLoopCapability);
 
     // Create a board kernel instance
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
 
     // ---------- QEMU-SYSTEM-RISCV32 "virt" MACHINE PERIPHERALS ----------
 
@@ -499,7 +502,7 @@ pub unsafe fn main() {
     )
     .finalize(components::low_level_debug_component_static!());
 
-    let scheduler = components::sched::cooperative::CooperativeComponent::new(&PROCESSES)
+    let scheduler = components::sched::cooperative::CooperativeComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::cooperative_component_static!(NUM_PROCS));
 
     let scheduler_timer = static_init!(
@@ -543,7 +546,7 @@ pub unsafe fn main() {
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut PROCESSES,
+        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_mgmt_cap,
     )

--- a/boards/raspberry_pi_pico/src/io.rs
+++ b/boards/raspberry_pi_pico/src/io.rs
@@ -90,17 +90,19 @@ impl IoWrite for Writer {
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // LED is connected to GPIO 25
+
+    use core::ptr::{addr_of, addr_of_mut};
     let led_kernel_pin = &RPGpioPin::new(RPGpio::GPIO25);
     let led = &mut LedHigh::new(led_kernel_pin);
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
 
     debug::panic(
         &mut [led],
         writer,
         pi,
         &cortexm0p::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -12,6 +12,8 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::ptr::{addr_of, addr_of_mut};
+
 use capsules_core::i2c_master::I2CMasterDriver;
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::date_time_component_static;
@@ -313,7 +315,7 @@ pub unsafe fn start() -> (
 
     CHIP = Some(chip);
 
-    let board_kernel = static_init!(Kernel, Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(Kernel, Kernel::new(&*addr_of!(PROCESSES)));
 
     let process_management_capability =
         create_capability!(capabilities::ProcessManagementCapability);
@@ -532,7 +534,7 @@ pub unsafe fn start() -> (
     i2c0.init(10 * 1000);
     i2c0.set_master_client(i2c);
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let raspberry_pi_pico = RaspberryPiPico {
@@ -590,7 +592,7 @@ pub unsafe fn start() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut PROCESSES,
+        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/redboard_redv/src/io.rs
+++ b/boards/redboard_redv/src/io.rs
@@ -39,6 +39,8 @@ impl IoWrite for Writer {
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // turn off the non panic leds, just in case
+
+    use core::ptr::{addr_of, addr_of_mut};
     let led_green = sifive::gpio::GpioPin::new(
         e310_g002::gpio::GPIO0_BASE,
         sifive::gpio::pins::pin19,
@@ -64,15 +66,15 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         sifive::gpio::pins::pin22::CLEAR,
     );
     let led_red = &mut led::LedLow::new(&led_red_pin);
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
 
     debug::panic(
         &mut [led_red],
         writer,
         pi,
         &rv32i::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/redboard_redv/src/main.rs
+++ b/boards/redboard_redv/src/main.rs
@@ -288,8 +288,9 @@ pub unsafe fn main() {
         static _eappmem: u8;
     }
 
-    let scheduler = components::sched::cooperative::CooperativeComponent::new(&*addr_of!(PROCESSES))
-        .finalize(components::cooperative_component_static!(NUM_PROCS));
+    let scheduler =
+        components::sched::cooperative::CooperativeComponent::new(&*addr_of!(PROCESSES))
+            .finalize(components::cooperative_component_static!(NUM_PROCS));
 
     let scheduler_timer = static_init!(
         VirtualSchedulerTimer<VirtualMuxAlarm<'static, e310_g002::chip::E310xClint<'static>>>,

--- a/boards/sma_q3/src/io.rs
+++ b/boards/sma_q3/src/io.rs
@@ -75,16 +75,18 @@ impl IoWrite for Writer {
 /// Panic handler
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // The display LEDs (see back of board)
+
+    use core::ptr::{addr_of, addr_of_mut};
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
     let led = &mut led::LedLow::new(led_kernel_pin);
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
     debug::panic(
         &mut [led],
         writer,
         pi,
         &cortexm4::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -16,6 +16,8 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::ptr::{addr_of, addr_of_mut};
+
 use capsules_core::virtualizers::virtual_aes_ccm::MuxAES128CCM;
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use kernel::component::Component;
@@ -210,7 +212,7 @@ pub unsafe fn main() {
     nrf52840_peripherals.init();
     let base_peripherals = &nrf52840_peripherals.nrf52;
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
 
     // GPIOs
     let gpio = components::gpio::GpioComponent::new(
@@ -414,7 +416,7 @@ pub unsafe fn main() {
         &base_peripherals.acomp,
         components::analog_comparator_component_helper!(
             nrf52840::acomp::Channel,
-            &nrf52840::acomp::CHANNEL_AC0
+            &*addr_of!(nrf52840::acomp::CHANNEL_AC0)
         ),
         board_kernel,
         capsules_extra::analog_comparator::DRIVER_NUM,
@@ -425,7 +427,7 @@ pub unsafe fn main() {
 
     nrf52_components::NrfClockComponent::new(&base_peripherals.clock).finalize(());
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let periodic_virtual_alarm = static_init!(
@@ -483,7 +485,7 @@ pub unsafe fn main() {
                     core::ptr::addr_of_mut!(_sappmem),
                     core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
                 ),
-                &mut PROCESSES,
+                &mut *addr_of_mut!(PROCESSES),
                 &FAULT_RESPONSE,
                 &process_management_capability,
             )
@@ -496,7 +498,7 @@ pub unsafe fn main() {
 
     let _ = platform.pconsole.start();
     debug!("Initialization complete. Entering main loop\r");
-    debug!("{}", &nrf52840::ficr::FICR_INSTANCE);
+    debug!("{}", &*addr_of!(nrf52840::ficr::FICR_INSTANCE));
 
     load_processes(board_kernel, chip);
     // These symbols are defined in the linker script.

--- a/boards/stm32f3discovery/src/io.rs
+++ b/boards/stm32f3discovery/src/io.rs
@@ -4,6 +4,8 @@
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
+use core::ptr::addr_of;
+use core::ptr::addr_of_mut;
 
 use kernel::debug;
 use kernel::debug::IoWrite;
@@ -77,15 +79,15 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     let gpio_ports = stm32f303xc::gpio::GpioPorts::new(&rcc, &exti);
     pin.set_ports_ref(&gpio_ports);
     let led = &mut led::LedHigh::new(&pin);
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
 
     debug::panic(
         &mut [led],
         writer,
         info,
         &cortexm4::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -12,6 +12,9 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::ptr::addr_of;
+use core::ptr::addr_of_mut;
+
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use capsules_extra::lsm303xx;
 use components::gpio::GpioComponent;
@@ -408,7 +411,7 @@ pub unsafe fn main() {
 
     setup_peripherals(&peripherals.tim2);
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
 
     let chip = static_init!(
         stm32f303xc::chip::Stm32f3xx<Stm32f3xxDefaultPeripherals>,
@@ -790,7 +793,7 @@ pub unsafe fn main() {
     ));
     let _ = process_console.start();
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let stm32f3discovery = STM32F3Discovery {
@@ -846,7 +849,7 @@ pub unsafe fn main() {
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut PROCESSES,
+        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/stm32f3discovery/src/virtual_uart_rx_test.rs
+++ b/boards/stm32f3discovery/src/virtual_uart_rx_test.rs
@@ -48,6 +48,8 @@
 //! 61
 //! ```
 
+use core::ptr::addr_of_mut;
+
 use capsules_core::test::virtual_uart::TestVirtualUartReceive;
 use capsules_core::virtualizers::virtual_uart::{MuxUart, UartDevice};
 use kernel::debug;
@@ -70,7 +72,7 @@ unsafe fn static_init_test_receive_small(
     device.setup();
     let test = static_init!(
         TestVirtualUartReceive,
-        TestVirtualUartReceive::new(device, &mut SMALL)
+        TestVirtualUartReceive::new(device, &mut *addr_of_mut!(SMALL))
     );
     device.set_receive_client(test);
     test
@@ -84,7 +86,7 @@ unsafe fn static_init_test_receive_large(
     device.setup();
     let test = static_init!(
         TestVirtualUartReceive,
-        TestVirtualUartReceive::new(device, &mut BUFFER)
+        TestVirtualUartReceive::new(device, &mut *addr_of_mut!(BUFFER))
     );
     device.set_receive_client(test);
     test

--- a/boards/stm32f412gdiscovery/src/io.rs
+++ b/boards/stm32f412gdiscovery/src/io.rs
@@ -4,6 +4,8 @@
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
+use core::ptr::addr_of;
+use core::ptr::addr_of_mut;
 
 use kernel::debug;
 use kernel::debug::IoWrite;
@@ -78,15 +80,15 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     let gpio_ports = stm32f412g::gpio::GpioPorts::new(&rcc, &exti);
     pin.set_ports_ref(&gpio_ports);
     let led = &mut led::LedHigh::new(&pin);
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
 
     debug::panic(
         &mut [led],
         writer,
         info,
         &cortexm4::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -11,6 +11,8 @@
 // https://github.com/rust-lang/rust/issues/62184.
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
+use core::ptr::{addr_of, addr_of_mut};
+
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
 use components::rng::RngComponent;
@@ -427,7 +429,7 @@ pub unsafe fn main() {
         &base_peripherals.usart2,
     );
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
 
     let chip = static_init!(
         stm32f412g::chip::Stm32f4xx<Stm32f412gDefaultPeripherals>,
@@ -744,7 +746,7 @@ pub unsafe fn main() {
     ));
     let _ = process_console.start();
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let stm32f412g = STM32F412GDiscovery {
@@ -810,7 +812,7 @@ pub unsafe fn main() {
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut PROCESSES,
+        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/stm32f429idiscovery/src/io.rs
+++ b/boards/stm32f429idiscovery/src/io.rs
@@ -4,6 +4,8 @@
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
+use core::ptr::addr_of;
+use core::ptr::addr_of_mut;
 
 use kernel::debug;
 use kernel::debug::IoWrite;
@@ -79,15 +81,15 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     pin.set_ports_ref(&gpio_ports);
     let led = &mut led::LedHigh::new(&pin);
 
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
 
     debug::panic(
         &mut [led],
         writer,
         info,
         &cortexm4::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/stm32f429idiscovery/src/main.rs
+++ b/boards/stm32f429idiscovery/src/main.rs
@@ -12,6 +12,8 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::ptr::{addr_of, addr_of_mut};
+
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
 use kernel::capabilities;
@@ -313,7 +315,7 @@ pub unsafe fn main() {
         &base_peripherals.usart1,
     );
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
 
     let chip = static_init!(
         stm32f429zi::chip::Stm32f4xx<Stm32f429ziDefaultPeripherals>,
@@ -573,7 +575,7 @@ pub unsafe fn main() {
     ));
     let _ = process_console.start();
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let stm32f429i_discovery = STM32F429IDiscovery {
@@ -624,7 +626,7 @@ pub unsafe fn main() {
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut PROCESSES,
+        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/swervolf/src/io.rs
+++ b/boards/swervolf/src/io.rs
@@ -41,15 +41,17 @@ impl IoWrite for Writer {
 #[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    let writer = &mut WRITER;
+    use core::ptr::{addr_of, addr_of_mut};
+
+    let writer = &mut *addr_of_mut!(WRITER);
 
     debug::panic_print(
         writer,
         pi,
         &rv32i::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     );
 
     // By writing to address 0x80001009 we can exit the simulation.

--- a/boards/swervolf/src/main.rs
+++ b/boards/swervolf/src/main.rs
@@ -12,6 +12,8 @@
 // https://github.com/rust-lang/rust/issues/62184.
 #![cfg_attr(not(doc), no_main)]
 
+use core::ptr::{addr_of, addr_of_mut};
+
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use kernel::capabilities;
 use kernel::component::Component;
@@ -122,7 +124,7 @@ pub unsafe fn main() {
 
     let main_loop_cap = create_capability!(capabilities::MainLoopCapability);
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
 
     // Configure kernel debug gpios as early as possible
     kernel::debug::assign_gpios(None, None, None);
@@ -215,7 +217,7 @@ pub unsafe fn main() {
         static _eappmem: u8;
     }
 
-    let scheduler = components::sched::cooperative::CooperativeComponent::new(&PROCESSES)
+    let scheduler = components::sched::cooperative::CooperativeComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::cooperative_component_static!(NUM_PROCS));
 
     let swervolf = SweRVolf {
@@ -236,7 +238,7 @@ pub unsafe fn main() {
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut PROCESSES,
+        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_mgmt_cap,
     )

--- a/boards/swervolf/src/main.rs
+++ b/boards/swervolf/src/main.rs
@@ -217,8 +217,9 @@ pub unsafe fn main() {
         static _eappmem: u8;
     }
 
-    let scheduler = components::sched::cooperative::CooperativeComponent::new(&*addr_of!(PROCESSES))
-        .finalize(components::cooperative_component_static!(NUM_PROCS));
+    let scheduler =
+        components::sched::cooperative::CooperativeComponent::new(&*addr_of!(PROCESSES))
+            .finalize(components::cooperative_component_static!(NUM_PROCS));
 
     let swervolf = SweRVolf {
         console,

--- a/boards/teensy40/src/io.rs
+++ b/boards/teensy40/src/io.rs
@@ -3,6 +3,7 @@
 // Copyright Tock Contributors 2022.
 
 use core::fmt::{self, Write};
+use core::ptr::addr_of;
 
 use kernel::debug::{self, IoWrite};
 use kernel::hil::{
@@ -62,8 +63,8 @@ unsafe fn panic_handler(panic_info: &core::panic::PanicInfo) -> ! {
         &mut writer,
         panic_info,
         &cortexm7::support::nop,
-        &crate::PROCESSES,
-        &crate::CHIP,
-        &crate::PROCESS_PRINTER,
+        &*addr_of!(crate::PROCESSES),
+        &*addr_of!(crate::CHIP),
+        &*addr_of!(crate::PROCESS_PRINTER),
     )
 }

--- a/boards/teensy40/src/main.rs
+++ b/boards/teensy40/src/main.rs
@@ -14,6 +14,8 @@
 mod fcb;
 mod io;
 
+use core::ptr::{addr_of, addr_of_mut};
+
 use imxrt1060::gpio::PinId;
 use imxrt1060::iomuxc::{MuxMode, PadId, Sion};
 use imxrt10xx as imxrt1060;
@@ -254,7 +256,7 @@ pub unsafe fn main() {
     CHIP = Some(chip);
 
     // Start loading the kernel
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
     // TODO how many of these should there be...?
 
     let uart_mux = components::console::UartMuxComponent::new(&peripherals.lpuart2, 115_200)
@@ -306,7 +308,7 @@ pub unsafe fn main() {
         .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     //
@@ -351,7 +353,7 @@ pub unsafe fn main() {
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut PROCESSES,
+        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/weact_f401ccu6/src/io.rs
+++ b/boards/weact_f401ccu6/src/io.rs
@@ -4,6 +4,8 @@
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
+use core::ptr::addr_of;
+use core::ptr::addr_of_mut;
 
 use kernel::debug;
 use kernel::debug::IoWrite;
@@ -78,15 +80,15 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     pin.set_ports_ref(&gpio_ports);
     let led = &mut led::LedLow::new(&pin);
 
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
 
     debug::panic(
         &mut [led],
         writer,
         info,
         &cortexm4::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -12,6 +12,8 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::ptr::{addr_of, addr_of_mut};
+
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
 use kernel::capabilities;
@@ -259,7 +261,7 @@ pub unsafe fn main() {
         &base_peripherals.usart2,
     );
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
 
     let chip = static_init!(
         stm32f401cc::chip::Stm32f4xx<Stm32f401ccDefaultPeripherals>,
@@ -432,7 +434,7 @@ pub unsafe fn main() {
     ));
     let _ = process_console.start();
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let weact_f401cc = WeactF401CC {
@@ -476,7 +478,7 @@ pub unsafe fn main() {
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut PROCESSES,
+        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/wm1110dev/src/io.rs
+++ b/boards/wm1110dev/src/io.rs
@@ -73,16 +73,18 @@ impl IoWrite for Writer {
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // Red Led
+
+    use core::ptr::{addr_of, addr_of_mut};
     let led_red_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_14);
     let led = &mut led::LedHigh::new(led_red_pin);
-    let writer = &mut WRITER;
+    let writer = &mut *addr_of_mut!(WRITER);
     debug::panic(
         &mut [led],
         writer,
         pi,
         &cortexm4::support::nop,
-        &PROCESSES,
-        &CHIP,
-        &PROCESS_PRINTER,
+        &*addr_of!(PROCESSES),
+        &*addr_of!(CHIP),
+        &*addr_of!(PROCESS_PRINTER),
     )
 }

--- a/boards/wm1110dev/src/main.rs
+++ b/boards/wm1110dev/src/main.rs
@@ -12,6 +12,9 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::ptr::addr_of;
+use core::ptr::addr_of_mut;
+
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::hil::gpio::Configure;
@@ -213,7 +216,7 @@ pub unsafe fn start() -> (
     nrf52840_peripherals.init();
     let base_peripherals = &nrf52840_peripherals.nrf52;
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
 
     nrf52_components::startup::NrfStartupComponent::new(
         false,
@@ -454,7 +457,7 @@ pub unsafe fn start() -> (
     // approach than this.
     nrf52_components::NrfClockComponent::new(&base_peripherals.clock).finalize(());
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let platform = Platform {
@@ -521,7 +524,7 @@ pub unsafe fn start() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut PROCESSES,
+        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/chips/apollo3/src/ble.rs
+++ b/chips/apollo3/src/ble.rs
@@ -5,6 +5,7 @@
 //! BLE driver.
 
 use core::cell::Cell;
+use core::ptr::addr_of_mut;
 use kernel::hil::ble_advertising;
 use kernel::hil::ble_advertising::RadioChannel;
 use kernel::utilities::cells::OptionalCell;
@@ -420,7 +421,7 @@ impl<'a> Ble<'a> {
                         i += 4;
                     }
 
-                    client.receive_event(&mut PAYLOAD, 10, Ok(()));
+                    client.receive_event(&mut *addr_of_mut!(PAYLOAD), 10, Ok(()));
                 }
             });
         }

--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -5,6 +5,7 @@
 //! High-level setup and interrupt mapping for the chip.
 
 use core::fmt::Write;
+use core::ptr::addr_of;
 use kernel::debug;
 use kernel::platform::chip::Chip;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
@@ -72,7 +73,7 @@ impl<'a, I: InterruptService + 'a> E310x<'a, I> {
         Self {
             userspace_kernel_boundary: rv32i::syscall::SysCall::new(),
             pmp: PMPUserMPU::new(SimplePMP::new().unwrap()),
-            plic: &PLIC,
+            plic: &*addr_of!(PLIC),
             timer,
             plic_interrupt_service,
         }

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -6,6 +6,7 @@
 
 use core::fmt::{Display, Write};
 use core::marker::PhantomData;
+use core::ptr::addr_of;
 use kernel::platform::chip::{Chip, InterruptService};
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use rv32i::csr::{mcause, mie::mie, mtvec::mtvec, CSR};
@@ -153,7 +154,7 @@ impl<
         Self {
             userspace_kernel_boundary: SysCall::new(),
             mpu: PMPUserMPU::new(pmp),
-            plic: &PLIC,
+            plic: &*addr_of!(PLIC),
             pwrmgr: lowrisc::pwrmgr::PwrMgr::new(crate::pwrmgr::PWRMGR_BASE),
             timer,
             plic_interrupt_service,

--- a/chips/esp32-c3/src/chip.rs
+++ b/chips/esp32-c3/src/chip.rs
@@ -5,6 +5,7 @@
 //! High-level setup and interrupt mapping for the chip.
 
 use core::fmt::Write;
+use core::ptr::addr_of;
 
 use kernel::platform::chip::{Chip, InterruptService};
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
@@ -81,7 +82,7 @@ impl<'a, I: InterruptService + 'a> Esp32C3<'a, I> {
         Self {
             userspace_kernel_boundary: SysCall::new(),
             pmp: PMPUserMPU::new(SimplePMP::new().unwrap()),
-            intc: &INTC,
+            intc: &*addr_of!(INTC),
             pic_interrupt_service,
         }
     }

--- a/chips/litex_vexriscv/src/chip.rs
+++ b/chips/litex_vexriscv/src/chip.rs
@@ -5,6 +5,7 @@
 //! High-level setup and interrupt mapping for the chip.
 
 use core::fmt::Write;
+use core::ptr::addr_of;
 use kernel::debug;
 use kernel::platform::chip::InterruptService;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
@@ -38,7 +39,7 @@ impl<I: 'static + InterruptService> LiteXVexRiscv<I> {
         Self {
             soc_identifier,
             userspace_kernel_boundary: SysCall::new(),
-            interrupt_controller: &INTERRUPT_CONTROLLER,
+            interrupt_controller: &*addr_of!(INTERRUPT_CONTROLLER),
             pmp_mpu: PMPUserMPU::new(pmp),
             interrupt_service,
         }

--- a/chips/nrf52/src/ble_radio.rs
+++ b/chips/nrf52/src/ble_radio.rs
@@ -38,6 +38,7 @@
 //! * CRC - 3 bytes
 
 use core::cell::Cell;
+use core::ptr::addr_of_mut;
 use kernel::hil::ble_advertising;
 use kernel::hil::ble_advertising::RadioChannel;
 use kernel::utilities::cells::OptionalCell;
@@ -644,7 +645,11 @@ impl<'a> Radio<'a> {
                             // Length is: S0 (1 Byte) + Length (1 Byte) + S1 (0 Bytes) + Payload
                             // And because the length field is directly read from the packet
                             // We need to add 2 to length to get the total length
-                            client.receive_event(&mut PAYLOAD, PAYLOAD[1] + 2, result)
+                            client.receive_event(
+                                &mut *addr_of_mut!(PAYLOAD),
+                                PAYLOAD[1] + 2,
+                                result,
+                            )
                         });
                     }
                 }

--- a/chips/qemu_rv32_virt_chip/src/chip.rs
+++ b/chips/qemu_rv32_virt_chip/src/chip.rs
@@ -5,6 +5,7 @@
 //! High-level setup and interrupt mapping for the chip.
 
 use core::fmt::Write;
+use core::ptr::addr_of;
 
 use kernel::debug;
 use kernel::hil::time::Freq10MHz;
@@ -86,7 +87,7 @@ impl<'a, I: InterruptService + 'a> QemuRv32VirtChip<'a, I> {
         Self {
             userspace_kernel_boundary: rv32i::syscall::SysCall::new(),
             pmp: rv32i::pmp::PMPUserMPU::new(pmp),
-            plic: &PLIC,
+            plic: &*addr_of!(PLIC),
             timer,
             plic_interrupt_service,
         }

--- a/chips/swervolf-eh1/src/chip.rs
+++ b/chips/swervolf-eh1/src/chip.rs
@@ -5,6 +5,7 @@
 //! High-level setup and interrupt mapping for the chip.
 
 use core::fmt::Write;
+use core::ptr::addr_of;
 use kernel::platform::chip::{Chip, InterruptService};
 use kernel::utilities::cells::VolatileCell;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
@@ -72,7 +73,7 @@ impl<'a, I: InterruptService + 'a> SweRVolf<'a, I> {
     ) -> Self {
         Self {
             userspace_kernel_boundary: SysCall::new(),
-            pic: &PIC,
+            pic: &*addr_of!(PIC),
             scheduler_timer: swerv::eh1_timer::Timer::new(swerv::eh1_timer::TimerNumber::ZERO),
             mtimer,
             pic_interrupt_service,

--- a/kernel/src/deferred_call.rs
+++ b/kernel/src/deferred_call.rs
@@ -62,6 +62,7 @@ use crate::utilities::cells::OptionalCell;
 use core::cell::Cell;
 use core::marker::Copy;
 use core::marker::PhantomData;
+use core::ptr::addr_of;
 
 // This trait is not intended to be used as a trait object;
 // e.g. you should not create a `&dyn DeferredCallClient`.
@@ -142,7 +143,7 @@ impl DeferredCall {
     pub fn new() -> Self {
         // SAFETY: No accesses to CTR are via an &mut, and the Tock kernel is
         // single-threaded so all accesses will occur from this thread.
-        let ctr = unsafe { &CTR };
+        let ctr = unsafe { &*addr_of!(CTR) };
         let idx = ctr.get() + 1;
         ctr.set(idx);
         DeferredCall { idx }
@@ -154,7 +155,7 @@ impl DeferredCall {
     fn register_internal_non_generic(&self, handler: DynDefCallRef<'static>) {
         // SAFETY: No accesses to DEFCALLS are via an &mut, and the Tock kernel is
         // single-threaded so all accesses will occur from this thread.
-        let defcalls = unsafe { &DEFCALLS };
+        let defcalls = unsafe { &*addr_of!(DEFCALLS) };
         if self.idx >= defcalls.len() {
             // This error will be caught by the scheduler at the beginning of the kernel loop,
             // which is much better than panicking here, before the debug writer is setup.
@@ -177,7 +178,7 @@ impl DeferredCall {
     pub fn set(&self) {
         // SAFETY: No accesses to BITMASK are via an &mut, and the Tock kernel is
         // single-threaded so all accesses will occur from this thread.
-        let bitmask = unsafe { &BITMASK };
+        let bitmask = unsafe { &*addr_of!(BITMASK) };
         bitmask.set(bitmask.get() | (1 << self.idx));
     }
 
@@ -185,7 +186,7 @@ impl DeferredCall {
     pub fn is_pending(&self) -> bool {
         // SAFETY: No accesses to BITMASK are via an &mut, and the Tock kernel is
         // single-threaded so all accesses will occur from this thread.
-        let bitmask = unsafe { &BITMASK };
+        let bitmask = unsafe { &*addr_of!(BITMASK) };
         bitmask.get() & (1 << self.idx) == 1
     }
 
@@ -194,8 +195,8 @@ impl DeferredCall {
     pub fn service_next_pending() -> Option<usize> {
         // SAFETY: No accesses to BITMASK/DEFCALLS are via an &mut, and the Tock kernel is
         // single-threaded so all accesses will occur from this thread.
-        let bitmask = unsafe { &BITMASK };
-        let defcalls = unsafe { &DEFCALLS };
+        let bitmask = unsafe { &*addr_of!(BITMASK) };
+        let defcalls = unsafe { &*addr_of!(DEFCALLS) };
         let val = bitmask.get();
         if val == 0 {
             None
@@ -215,7 +216,7 @@ impl DeferredCall {
     pub fn has_tasks() -> bool {
         // SAFETY: No accesses to BITMASK are via an &mut, and the Tock kernel is
         // single-threaded so all accesses will occur from this thread.
-        let bitmask = unsafe { &BITMASK };
+        let bitmask = unsafe { &*addr_of!(BITMASK) };
         bitmask.get() != 0
     }
 
@@ -237,8 +238,8 @@ impl DeferredCall {
     pub fn verify_setup() {
         // SAFETY: No accesses to CTR/DEFCALLS are via an &mut, and the Tock kernel is
         // single-threaded so all accesses will occur from this thread.
-        let ctr = unsafe { &CTR };
-        let defcalls = unsafe { &DEFCALLS };
+        let ctr = unsafe { &*addr_of!(CTR) };
+        let defcalls = unsafe { &*addr_of!(DEFCALLS) };
         let num_deferred_calls = ctr.get();
         let num_registered_calls = defcalls.iter().filter(|opt| opt.is_some()).count();
         if num_deferred_calls >= defcalls.len() || num_registered_calls != num_deferred_calls {


### PR DESCRIPTION
### Pull Request Overview

This change is a *_stopgap*_ pending a permanent, safe solution, sketched in #3945.

We can't currently update Rust compiler versions due deprecation of creating references from `&'static mut`s. This workaround simply replaces those with uses of the `addr_of{_mut}!` macros as recommended by Rust. This should have no semantic affect on compiled artifacts.

### Testing Strategy

Compile tested all boards with a recent nightly

### Formatting

- [X] Ran `make prepush`.
