### PR TITLE
boards: config: nrf52840dk kernel test: fix import

### DIFF
--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/main.rs
@@ -21,7 +21,7 @@ use kernel::{capabilities, create_capability, static_init};
 use nrf52840::chip::Nrf52DefaultPeripherals;
 use nrf52840::gpio::Pin;
 use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
-use nrf52_components::{self, UartChannel, UartPins};
+use nrf52_components::{UartChannel, UartPins};
 
 mod test;
 


### PR DESCRIPTION
### Pull Request Overview

Do not need nrf52_components::self






### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
