### PR TITLE
Notes from Core working group call: April 19, 2024

### DIFF
--- a/doc/wg/core/notes/core-notes-2024-04-19.md
+++ b/doc/wg/core/notes/core-notes-2024-04-19.md
@@ -1,0 +1,21 @@
+# Tock Meeting Notes 2024-04-19
+
+## Attendees
+- Branden Ghena
+- Brad Campbell
+- Pat Pannuto
+- Johnathan Van Why
+- Viswajith
+- Alyssa Haroldsen
+
+
+## Updates
+* Chatted about Makefile syntax and debugging for a bit
+* Brad: Working on updating the nightly https://github.com/tock/tock/pull/3842 Still some build errors. Failing in the tests, which only run on CI. It looks like the stopgap PR didn't quite cover everything
+
+## Libtock-C Rewrite
+* Brad: I'm going to try to rebase the libtock-c rewrite PR. We should then have a better sense of how close it is to compiling
+* Branden: That's multiple Makefile updates lately, right
+* Brad: Yes, everything for the split of libtock and libtock-sync. The others are for openthread
+
+


### PR DESCRIPTION
### Pull Request Overview

This pull request adds notes from the Core working group call on April 19, 2024. It was a short meeting as several people were unavailable.

[Rendered](https://github.com/tock/tock/blob/233cd8729b44c6efe42f1ee028dc79b540713cd1/doc/wg/core/notes/core-notes-2024-04-19.md)

### Testing Strategy

Documentation


### TODO or Help Wanted

Good to go


### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [N/A] Ran `make prepush`.
