### PR TITLE
nrf52840 802.15.4 LQI

### DIFF
--- a/capsules/extra/src/ieee802154/device.rs
+++ b/capsules/extra/src/ieee802154/device.rs
@@ -134,11 +134,19 @@ pub trait RxClient {
     /// - `header`: A fully-parsed representation of the MAC header, with the
     /// caveat that the auxiliary security header is still included if the frame
     /// was previously secured.
+    /// - `lqi`: The link quality indicator of the received frame.
     /// - `data_offset`: Offset of the data payload relative to
     /// `buf`, so that the payload of the frame is contained in
     /// `buf[data_offset..data_offset + data_len]`.
     /// - `data_len`: Length of the data payload
-    fn receive<'a>(&self, buf: &'a [u8], header: Header<'a>, data_offset: usize, data_len: usize);
+    fn receive<'a>(
+        &self,
+        buf: &'a [u8],
+        header: Header<'a>,
+        lqi: u8,
+        data_offset: usize,
+        data_len: usize,
+    );
 }
 
 /// Trait to be implemented by users of the IEEE 802.15.4 device that wish to
@@ -157,6 +165,7 @@ pub trait SecuredFrameNoDecryptRxClient {
     /// - `buf`: The entire buffer containing the frame, potentially also
     /// including extra bytes in front used for the physical layer.
     /// - `header`: A fully-parsed representation of the MAC header.
+    /// - `lqi`: The link quality indicator of the received frame.
     /// - `data_offset`: Offset of the data payload relative to
     /// `buf`, so that the payload of the frame is contained in
     /// `buf[data_offset..data_offset + data_len]`.
@@ -165,6 +174,7 @@ pub trait SecuredFrameNoDecryptRxClient {
         &self,
         buf: &'a [u8],
         header: Header<'a>,
+        lqi: u8,
         data_offset: usize,
         data_len: usize,
     );

--- a/capsules/extra/src/ieee802154/driver.rs
+++ b/capsules/extra/src/ieee802154/driver.rs
@@ -54,7 +54,7 @@
 //! provided to the capsule.
 
 use crate::ieee802154::{device, framer};
-use crate::net::ieee802154::{AddressMode, Header, KeyId, MacAddress, PanID, SecurityLevel};
+use crate::net::ieee802154::{Header, KeyId, MacAddress, SecurityLevel};
 use crate::net::stream::{decode_bytes, decode_u8, encode_bytes, encode_u8, SResult};
 use device::RxClient;
 
@@ -1066,24 +1066,6 @@ impl<'a, M: device::MacDevice<'a>> device::TxClient for RadioDriver<'a, M> {
         });
         self.do_next_tx_async();
     }
-}
-
-/// Encode two PAN IDs into a single usize.
-#[inline]
-#[allow(dead_code)]
-fn encode_pans(dst_pan: &Option<PanID>, src_pan: &Option<PanID>) -> usize {
-    ((dst_pan.unwrap_or(0) as usize) << 16) | (src_pan.unwrap_or(0) as usize)
-}
-
-/// Encodes as much as possible about an address into a single usize.
-#[inline]
-#[allow(dead_code)]
-fn encode_address(addr: &Option<MacAddress>) -> usize {
-    let short_addr_only = match *addr {
-        Some(MacAddress::Short(addr)) => addr as usize,
-        _ => 0,
-    };
-    ((AddressMode::from(addr) as usize) << 16) | short_addr_only
 }
 
 impl<'a, M: device::MacDevice<'a>> device::SecuredFrameNoDecryptRxClient for RadioDriver<'a, M> {

--- a/capsules/extra/src/ieee802154/driver.rs
+++ b/capsules/extra/src/ieee802154/driver.rs
@@ -1110,9 +1110,6 @@ impl<'a, M: device::MacDevice<'a>> device::RxClient for RadioDriver<'a, M> {
         data_offset: usize,
         data_len: usize,
     ) {
-        kernel::debug!("LQI: {}", lqi);
-        // kernel::debug!("RECV BUF {:02x?}", buf);
-        kernel::debug!("RECV BUF LEN {}", buf.len());
         self.apps.each(|_, _, kernel_data| {
             let read_present = kernel_data
                 .get_readwrite_processbuffer(rw_allow::READ)
@@ -1172,7 +1169,6 @@ impl<'a, M: device::MacDevice<'a>> device::RxClient for RadioDriver<'a, M> {
                         rbuf[offset + 1].set(data_len as u8);
                         rbuf[offset + 2].set(mic_len as u8);
 
-                        // kernel::debug!("RECV BUF APP {:02x?}", &buf[..frame_len]);
                         // Prepare the ring buffer for the next write. The current design favors newness;
                         // newly received packets will begin to overwrite the oldest data in the event
                         // of the buffer becoming full. The read index must always point to the "oldest"

--- a/capsules/extra/src/ieee802154/driver.rs
+++ b/capsules/extra/src/ieee802154/driver.rs
@@ -1077,6 +1077,7 @@ fn encode_pans(dst_pan: &Option<PanID>, src_pan: &Option<PanID>) -> usize {
 
 /// Encodes as much as possible about an address into a single usize.
 #[inline]
+#[allow(dead_code)]
 fn encode_address(addr: &Option<MacAddress>) -> usize {
     let short_addr_only = match *addr {
         Some(MacAddress::Short(addr)) => addr as usize,
@@ -1189,11 +1190,9 @@ impl<'a, M: device::MacDevice<'a>> device::RxClient for RadioDriver<'a, M> {
                 })
                 .unwrap_or(false);
             if read_present {
-                // Encode lqi and useful parts of the header in 3 usizes
-                let dst_addr = encode_address(&header.dst_addr);
-                let src_addr = encode_address(&header.src_addr);
+                // Place lqi as argument to be included in upcall.
                 kernel_data
-                    .schedule_upcall(upcall::FRAME_RECEIVED, (lqi as usize, dst_addr, src_addr))
+                    .schedule_upcall(upcall::FRAME_RECEIVED, (lqi as usize, 0, 0))
                     .ok();
             }
         });

--- a/capsules/extra/src/ieee802154/mac.rs
+++ b/capsules/extra/src/ieee802154/mac.rs
@@ -176,6 +176,7 @@ impl<'a, R: radio::Radio<'a>> radio::RxClient for AwakeMac<'a, R> {
         &self,
         buf: &'static mut [u8],
         frame_len: usize,
+        lqi: u8,
         crc_valid: bool,
         result: Result<(), ErrorCode>,
     ) {
@@ -195,7 +196,7 @@ impl<'a, R: radio::Radio<'a>> radio::RxClient for AwakeMac<'a, R> {
         if addr_match {
             // debug!("[AwakeMAC] Rcvd a 15.4 frame addressed to this device");
             self.rx_client.map(move |c| {
-                c.receive(buf, frame_len, crc_valid, result);
+                c.receive(buf, frame_len, lqi, crc_valid, result);
             });
         } else {
             // debug!("[AwakeMAC] Received a packet, but not addressed to us");

--- a/capsules/extra/src/ieee802154/xmac.rs
+++ b/capsules/extra/src/ieee802154/xmac.rs
@@ -307,6 +307,7 @@ impl<'a, R: radio::Radio<'a>, A: Alarm<'a>> XMac<'a, R, A> {
         &self,
         buf: &'static mut [u8],
         len: usize,
+        lqi: u8,
         crc_valid: bool,
         result: Result<(), ErrorCode>,
     ) {
@@ -314,7 +315,7 @@ impl<'a, R: radio::Radio<'a>, A: Alarm<'a>> XMac<'a, R, A> {
         self.sleep();
 
         self.rx_client.map(move |c| {
-            c.receive(buf, len, crc_valid, result);
+            c.receive(buf, len, lqi, crc_valid, result);
         });
     }
 }
@@ -573,6 +574,7 @@ impl<'a, R: radio::Radio<'a>, A: Alarm<'a>> radio::RxClient for XMac<'a, R, A> {
         &self,
         buf: &'static mut [u8],
         frame_len: usize,
+        lqi: u8,
         crc_valid: bool,
         result: Result<(), ErrorCode>,
     ) {
@@ -634,7 +636,7 @@ impl<'a, R: radio::Radio<'a>, A: Alarm<'a>> radio::RxClient for XMac<'a, R, A> {
 
         if data_received {
             self.rx_pending.set(false);
-            self.call_rx_client(buf, frame_len, crc_valid, result);
+            self.call_rx_client(buf, frame_len, lqi, crc_valid, result);
         } else {
             self.radio.set_receive_buffer(buf);
         }

--- a/capsules/extra/src/net/sixlowpan/sixlowpan_state.rs
+++ b/capsules/extra/src/net/sixlowpan/sixlowpan_state.rs
@@ -805,7 +805,14 @@ pub struct Sixlowpan<'a, A: time::Alarm<'a>, C: ContextStore> {
 
 // This function is called after receiving a frame
 impl<'a, A: time::Alarm<'a>, C: ContextStore> RxClient for Sixlowpan<'a, A, C> {
-    fn receive<'b>(&self, buf: &'b [u8], header: Header<'b>, data_offset: usize, data_len: usize) {
+    fn receive<'b>(
+        &self,
+        buf: &'b [u8],
+        header: Header<'b>,
+        _lqi: u8,
+        data_offset: usize,
+        data_len: usize,
+    ) {
         // We return if retcode is not valid, as it does not make sense to issue
         // a callback for an invalid frame reception
         // TODO: Handle the case where the addresses are None/elided - they

--- a/capsules/extra/src/rf233.rs
+++ b/capsules/extra/src/rf233.rs
@@ -913,16 +913,10 @@ impl<'a, S: spi::SpiMasterDevice<'a>> spi::SpiMasterClient for RF233<'a, S> {
                 }
                 self.rx_client.map(|client| {
                     let rbuf = self.rx_buf.take().unwrap();
+                    let frame_len = rbuf[1] as usize - radio::MFR_SIZE;
 
-                    // data buffer format: | PSDU OFFSET | FRAME | LQI |
-                    // length of received data transferred to buffer (including PSDU)
-                    let data_len = rbuf[1] as usize;
-
-                    // LQI value is byte following the data
-                    let lqi: u8 = rbuf[data_len];
-
-                    let frame_len = data_len - radio::MFR_SIZE;
-                    client.receive(rbuf, frame_len, lqi, self.crc_valid.get(), Ok(()));
+                    // lqi is currently unimplemented for rf233 and is subsequently hardcoded to zero
+                    client.receive(rbuf, frame_len, 0, self.crc_valid.get(), Ok(()));
                 });
             }
 

--- a/capsules/extra/src/rf233.rs
+++ b/capsules/extra/src/rf233.rs
@@ -913,8 +913,16 @@ impl<'a, S: spi::SpiMasterDevice<'a>> spi::SpiMasterClient for RF233<'a, S> {
                 }
                 self.rx_client.map(|client| {
                     let rbuf = self.rx_buf.take().unwrap();
-                    let frame_len = rbuf[1] as usize - radio::MFR_SIZE;
-                    client.receive(rbuf, frame_len, self.crc_valid.get(), Ok(()));
+
+                    // data buffer format: | PSDU OFFSET | FRAME | LQI |
+                    // length of received data transferred to buffer (including PSDU)
+                    let data_len = rbuf[1] as usize;
+
+                    // LQI value is byte following the data
+                    let lqi: u8 = rbuf[data_len];
+
+                    let frame_len = data_len - radio::MFR_SIZE;
+                    client.receive(rbuf, frame_len, lqi, self.crc_valid.get(), Ok(()));
                 });
             }
 

--- a/kernel/src/hil/radio.rs
+++ b/kernel/src/hil/radio.rs
@@ -22,6 +22,7 @@ pub trait RxClient {
         &self,
         buf: &'static mut [u8],
         frame_len: usize,
+        lqi: u8,
         crc_valid: bool,
         result: Result<(), ErrorCode>,
     );
@@ -63,7 +64,8 @@ pub const MIN_FRAME_SIZE: usize = MIN_MHR_SIZE + MFR_SIZE;
 pub const MAX_FRAME_SIZE: usize = MAX_MTU;
 
 pub const PSDU_OFFSET: usize = 2;
-pub const MAX_BUF_SIZE: usize = PSDU_OFFSET + MAX_MTU;
+pub const LQI_SIZE: usize = 1;
+pub const MAX_BUF_SIZE: usize = PSDU_OFFSET + MAX_MTU + LQI_SIZE;
 pub const MIN_PAYLOAD_OFFSET: usize = PSDU_OFFSET + MIN_MHR_SIZE;
 
 pub trait Radio<'a>: RadioConfig<'a> + RadioData<'a> {}


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the 15.4 network stack to pass the LQI value up the stack. This updates the `receive()` method to accept LQI as an argument. In both the nrf52840 and rf233 radios, the LQI value is found in the receive buffer following the last byte of data received. This implementation implements the LQI for the nrf52840 and not for the rf233 radio. For now, the rf233 LQI value is set to zero. 

This PR also updates the arguments passed to the userprocess. Previously, the pan, src address, and dest address were passed to the userprocess in the three available registers. The pan field has now been replaced by the lqi value as the pan field can be obtained in userland by re parsing the header. 

### Testing Strategy

This pull request was tested on the nrf52840. 

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
