### PR TITLE
capsules/alarm: left-justify 32 bit ticks, re-architect alarm, add unit tests

### DIFF
--- a/capsules/core/src/alarm.rs
+++ b/capsules/core/src/alarm.rs
@@ -5,10 +5,8 @@
 //! Tock syscall driver capsule for Alarms, which issue callbacks when
 //! a point in time has been reached.
 
-use core::cell::Cell;
-
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::hil::time::{self, Alarm, Ticks, Ticks32};
+use kernel::hil::time::{self, Alarm, Ticks};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::{ErrorCode, ProcessId};
 
@@ -17,140 +15,345 @@ use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::Alarm as usize;
 
 #[derive(Copy, Clone, Debug)]
-enum Expiration {
-    Disabled,
-    Enabled { reference: u32, dt: u32 },
+struct Expiration<T: Ticks> {
+    reference: T,
+    dt: T,
 }
 
 #[derive(Copy, Clone)]
-pub struct AlarmData {
-    expiration: Expiration,
+pub struct AlarmData<T: Ticks> {
+    expiration: Option<Expiration<T>>,
 }
 
 const ALARM_CALLBACK_NUM: usize = 0;
 const NUM_UPCALLS: u8 = 1;
 
-impl Default for AlarmData {
-    fn default() -> AlarmData {
-        AlarmData {
-            expiration: Expiration::Disabled,
-        }
+impl<T: Ticks> Default for AlarmData<T> {
+    fn default() -> AlarmData<T> {
+        AlarmData { expiration: None }
     }
 }
 
 pub struct AlarmDriver<'a, A: Alarm<'a>> {
     alarm: &'a A,
-    num_armed: Cell<usize>,
-    app_alarms: Grant<AlarmData, UpcallCount<NUM_UPCALLS>, AllowRoCount<0>, AllowRwCount<0>>,
-    next_alarm: Cell<Expiration>,
+    app_alarms:
+        Grant<AlarmData<A::Ticks>, UpcallCount<NUM_UPCALLS>, AllowRoCount<0>, AllowRwCount<0>>,
 }
 
 impl<'a, A: Alarm<'a>> AlarmDriver<'a, A> {
     pub const fn new(
         alarm: &'a A,
-        grant: Grant<AlarmData, UpcallCount<NUM_UPCALLS>, AllowRoCount<0>, AllowRwCount<0>>,
+        grant: Grant<
+            AlarmData<A::Ticks>,
+            UpcallCount<NUM_UPCALLS>,
+            AllowRoCount<0>,
+            AllowRwCount<0>,
+        >,
     ) -> AlarmDriver<'a, A> {
         AlarmDriver {
             alarm: alarm,
-            num_armed: Cell::new(0),
             app_alarms: grant,
-            next_alarm: Cell::new(Expiration::Disabled),
         }
     }
 
-    // This logic is tricky because it needs to handle the case when the
-    // underlying alarm is wider than 32 bits.
-    fn reset_active_alarm(&self) {
-        let mut earliest_alarm = Expiration::Disabled;
-        let mut earliest_end: A::Ticks = A::Ticks::from(0);
-        // Scale now down to a u32 since that is the width of the alarm;
-        // otherwise for larger widths (e.g., u64) now can be outside of
-        // the range of what an alarm can be set to.
-        let now = self.alarm.now();
-        let now_lower_bits = A::Ticks::from(now.into_u32());
-        // Find the first alarm to fire and store it in earliest_alarm,
-        // its counter value at earliest_end. In the case that there
-        // are multiple alarms in the past, just store one of them
-        // and resolve ordering later, when we fire.
-        for alarm in self.app_alarms.iter() {
-            alarm.enter(|alarm, _upcalls| match alarm.expiration {
-                Expiration::Enabled { reference, dt } => {
-                    // Do this because `reference` shadowed below
-                    let current_reference = reference;
-                    let current_reference_ticks = A::Ticks::from(current_reference);
-                    let current_dt = dt;
-                    let current_dt_ticks = A::Ticks::from(current_dt);
-                    let current_end_ticks = current_reference_ticks.wrapping_add(current_dt_ticks);
+    /// Find the earliest [`Expiration`] from an iterator of expirations.
+    ///
+    /// Each [`Expiration`] value is provided as a tuple, with
+    /// - `UD`: an additional user-data argument returned together with the
+    ///   [`Expiration`], should it be the earliest, and
+    /// - `F`: a call-back function invoked when the [`Expiration`] has already
+    ///   expired. The callback is porivded the expiration value and a reference
+    ///   to its user-data.
+    ///
+    /// Whether an [`Expiration`] has expired or not is determined with respect
+    /// to `now`. If `now` is in `[exp.reference; exp.reference + exp.dt)`, it
+    /// the [`Expiration`] has not yet expired.
+    ///
+    /// An expired [`Expiration`] is not a candidate for "earliest" expiration.
+    /// This means that this function will return `Ok(None)` if it receives an
+    /// empty iterator, or all [`Expiration`]s have expired.
+    ///
+    /// To stop iteration on any expired [`Expiration`], its callback can return
+    /// `Some(R)`. Then this function will return `Err(Expiration, UD, R)`.
+    /// This avoids consuming the entire iterator.
+    fn earliest_alarm<UD, R, F: FnOnce(Expiration<A::Ticks>, &UD) -> Option<R>>(
+        now: A::Ticks,
+        expirations: impl Iterator<Item = (Expiration<A::Ticks>, UD, F)>,
+    ) -> Result<Option<(Expiration<A::Ticks>, UD)>, (Expiration<A::Ticks>, UD, R)> {
+        let mut earliest: Option<(Expiration<A::Ticks>, UD)> = None;
 
-                    earliest_alarm = match earliest_alarm {
-                        Expiration::Disabled => {
-                            earliest_end = current_end_ticks;
-                            alarm.expiration
-                        }
-                        Expiration::Enabled { reference, dt } => {
-                            // There are two cases when current might be
-                            // an earlier alarm.  The first is if it
-                            // fires inside the interval (reference,
-                            // reference+dt) of the existing earliest.
-                            // The second is if now is not within the
-                            // interval: this means that it has
-                            // passed. It could be the earliest has passed
-                            // too, but at this point we don't need to track
-                            // which is earlier: the key point is that
-                            // the alarm must fire immediately, and then when
-                            // we handle the alarm callback the userspace
-                            // callbacks will all be pushed onto processes.
-                            // Because there is at most a single callback per
-                            // process and they must go through the scheduler
-                            // we don't care about the order in which we push
-                            // their callbacks, as their order of execution is
-                            // determined by the scheduler not push order. -pal
-                            let temp_earliest_reference = A::Ticks::from(reference);
-                            let temp_earliest_dt = A::Ticks::from(dt);
-                            let temp_earliest_end =
-                                temp_earliest_reference.wrapping_add(temp_earliest_dt);
+        for (exp, ud, expired_handler) in expirations {
+            let Expiration {
+                reference: exp_ref,
+                dt: exp_dt,
+            } = exp;
 
-                            if current_end_ticks
-                                .within_range(temp_earliest_reference, temp_earliest_end)
-                            {
-                                earliest_end = current_end_ticks;
-                                alarm.expiration
-                            } else if !now_lower_bits
-                                .within_range(temp_earliest_reference, temp_earliest_end)
-                            {
-                                earliest_end = temp_earliest_end;
-                                alarm.expiration
-                            } else {
-                                earliest_alarm
-                            }
-                        }
+            // Pre-compute the absolute "end" time of this expiration (the
+            // point at which it should fire):
+            let exp_end = exp_ref.wrapping_add(exp_dt);
+
+            // If `now` is not within `[reference, reference + dt)`, this
+            // alarm has expired. Call the expired handler. If it returns
+            // false, stop here.
+            if !now.within_range(exp_ref, exp_end) {
+                let expired_handler_res = expired_handler(exp, &ud);
+                if let Some(retval) = expired_handler_res {
+                    return Err((exp, ud, retval));
+                }
+            }
+
+            // `exp` has not yet expired. At this point we can assume that
+            // `now` is within `[exp_ref, exp_end)`. Check whether it will
+            // expire earlier than the current `earliest`:
+            match &earliest {
+                None => {
+                    // Do not have an earliest expiration yet, set this
+                    // expriation as earliest:
+                    earliest = Some((exp, ud));
+                }
+
+                Some((
+                    Expiration {
+                        reference: earliest_ref,
+                        dt: earliest_dt,
+                    },
+                    _,
+                )) => {
+                    // As `now` is within `[ref, end)` for both timers, we
+                    // can check which end time is closer to `now`. We thus
+                    // first compute the end time for the current earliest
+                    // alarm as well ...
+                    let earliest_end = earliest_ref.wrapping_add(*earliest_dt);
+
+                    // ... and then perform a wrapping_sub against `now` for
+                    // both, checking which is smaller:
+                    let exp_remain = exp_end.wrapping_sub(now);
+                    let earliest_remain = earliest_end.wrapping_sub(now);
+                    if exp_remain < earliest_remain {
+                        // Our current exp expires earlier than earliest,
+                        // replace it:
+                        earliest = Some((exp, ud));
                     }
                 }
-                Expiration::Disabled => {}
-            });
+            }
         }
-        self.next_alarm.set(earliest_alarm);
-        match earliest_alarm {
-            Expiration::Disabled => {
+
+        // We have computed earliest by iterating over all alarms, but have not
+        // found one that has already expired. As such return `false`:
+        Ok(earliest)
+    }
+
+    /// Re-arm the timer. This must be called in response to the underlying
+    /// timer firing, or the set of [`Expiration`]s changing. This will iterate
+    /// over all [`Expiration`]s and
+    ///
+    /// - invoke upcalls for all expired app alarms, resetting them afterwards,
+    /// - re-arming the alarm for the next earliest [`Expiration`], or
+    /// - disarming the alarm if no unexpired [`Expiration`] is found.
+    fn process_rearm_or_callback(&self) {
+        // Ask the clock about a current reference once. This can incur a
+        // volatile read, and this may not be optimized if done in a loop:
+        let now = self.alarm.now();
+
+        let expired_handler = |expired: Expiration<A::Ticks>, process_id: &ProcessId| {
+            // This closure is run on every expired alarm, _after_ the `enter()`
+            // closure on the Grant iterator has returned. We are thus not
+            // risking reentrancy here.
+
+            // Enter the app's grant again:
+            let _ = self.app_alarms.enter(*process_id, |alarm_state, upcalls| {
+                // Reset this app's alarm:
+                alarm_state.expiration = None;
+
+                // Deliver the upcall:
+                upcalls
+                    .schedule_upcall(
+                        ALARM_CALLBACK_NUM,
+                        (
+                            now.into_u32_left_justified() as usize,
+                            expired.reference.wrapping_add(expired.dt).into_usize(),
+                            0,
+                        ),
+                    )
+                    .ok();
+            });
+
+            // Proceed iteration across expirations:
+            None::<()>
+        };
+
+        // Compute the earliest alarm, and invoke the `expired_handler` for
+        // every expired alarm. This will issue a callback and reset the alarms
+        // respectively.
+        let res = Self::earliest_alarm(
+            now,
+            // Pass an interator of all non-None expirations:
+            self.app_alarms.iter().filter_map(|app| {
+                let process_id = app.processid();
+                app.enter(|alarm_state, _upcalls| {
+                    if let Some(exp) = alarm_state.expiration {
+                        Some((exp, process_id, expired_handler))
+                    } else {
+                        None
+                    }
+                })
+            }),
+        );
+
+        // Arm or disarm the alarm accordingly:
+        match res {
+            // No pending alarm, disarm:
+            Ok(None) => {
                 let _ = self.alarm.disarm();
             }
-            Expiration::Enabled { reference, dt } => {
-                // This logic handles when the underlying Alarm is wider than
-                // 32 bits; it sets the reference to include the high bits of now
-                let mut high_bits = now.wrapping_sub(now_lower_bits);
-                // If lower bits have wrapped around from reference, this means the
-                // reference's high bits are actually one less; if we don't subtract
-                // one then the alarm will incorrectly be set 1<<32 higher than it should.
-                // This uses the invariant that reference <= now.
-                if now_lower_bits.into_u32() < reference {
-                    // Build 1<<32 in a way that just overflows to 0 if we are 32 bits
-                    let bit33 = A::Ticks::from(0xffffffff).wrapping_add(A::Ticks::from(0x1));
-                    high_bits = high_bits.wrapping_sub(bit33);
-                }
-                let real_reference = high_bits.wrapping_add(A::Ticks::from(reference));
-                self.alarm.set_alarm(real_reference, A::Ticks::from(dt));
+
+            // A future, non-expired alarm should fire:
+            Ok(Some((Expiration { reference, dt }, _))) => {
+                self.alarm.set_alarm(reference, dt);
+            }
+
+            // The expired closure has requested to stop iteration. This should
+            // be unreachable, and hence we panic:
+            Err((_, _, ())) => {
+                unreachable!();
             }
         }
+    }
+
+    fn rearm_u32_left_justified_expiration(
+        now: A::Ticks,
+        reference_u32: Option<u32>,
+        dt_u32: u32,
+        expiration: &mut Option<Expiration<A::Ticks>>,
+    ) -> u32 {
+        // If the underlying timer is less than 32-bit wide, userspace is able
+        // to provide a finer `reference` and `dt` resolution than we can
+        // possibly represent in the kernel.
+        //
+        // We do not want to switch back to userspace *before* the timer
+        // fires. As such, when userspace gives us reference and ticks values
+        // with a precision unrepresentible using our Ticks object, we round
+        // `reference` down, and `dt` up (ensuring that the timer cannot fire
+        // earlier than requested).
+        let reference_unshifted = reference_u32.map(|ref_u32| ref_u32 >> A::Ticks::u32_padding());
+
+        // Round dt up:
+        let dt_unshifted = if dt_u32 & ((1 << A::Ticks::u32_padding()) - 1) != 0 {
+            // By right-shifting, we would decrease the requested dt value,
+            // firing _before_ the time requested by userspace. Add one to
+            // compensate this:
+            (dt_u32 >> A::Ticks::u32_padding()) + 1
+        } else {
+            // dt does not need to be shifted *or* contains no lower bits
+            // unrepresentable in the kernel:
+            dt_u32 >> A::Ticks::u32_padding()
+        };
+
+        // For timers less than 32-bit wide, we do not have to handle a
+        // `reference + dt` overflow specially. This is because those timers are
+        // conveyed to us left-justified, and as such userspace would already
+        // have to take care of such overflow.
+        //
+        // However, we *may* need to handle overflow when the timer is *wider*
+        // than 32 bit. In this case, if `reference + dt` were to overflow, we
+        // need to rebase our reference on the full-width `now` time.
+        //
+        // If userspace didn't give us a reference, we can skip all of this and
+        // simply set the unshifted dt.
+        let new_exp = match (reference_unshifted, A::Ticks::width() > 32) {
+            (Some(userspace_reference_unshifted), true) => {
+                // We have a userspace reference and timer is wider than 32 bit.
+                //
+                // In this case, we need to check whether the lower 32 bits of the
+                // timer `reference` have already wrapped, compared to the reference
+                // provided by userspace:
+                if now.into_u32() < userspace_reference_unshifted {
+                    // The lower 32-bit of reference are smaller than the userspace
+                    // reference. This means that the full-width timer has had an
+                    // increment in the upper bits. We thus set the full-width
+                    // reference to the combination of the current upper timer bits
+                    // *minus 1*, concatenated to the user-space provided bits.
+                    //
+                    // Because we don't know the integer type of the Ticks object
+                    // (just that it's larger than a u32), we:
+                    //
+                    // 1. subtract a full `u32::MAX + 1` to incur a downward wrap,
+                    //    effectively subtracting `1` from the upper part,
+                    // 2. subtract the lower `u32` bits from this value, setting
+                    //    those bits to zero,
+                    // 3. adding back the userspace-provided reference.
+
+                    // Build 1 << 32:
+                    let bit33 = A::Ticks::from(0xffffffff).wrapping_add(A::Ticks::from(0x1));
+
+                    // Perform step 1, subtracting 1 << 32:
+                    let sub_1_upper = now.wrapping_sub(bit33);
+
+                    // Perform step 2, setting first 32 bit to zero:
+                    let sub_lower =
+                        sub_1_upper.wrapping_sub(A::Ticks::from(sub_1_upper.into_u32()));
+
+                    // Perform step 3, add back the userspace-provided reference:
+                    let rebased_reference =
+                        sub_lower.wrapping_add(A::Ticks::from(userspace_reference_unshifted));
+
+                    // Finally, return the new expiration. We don't have to do
+                    // anything special for `dt`, as it's relative:
+                    Expiration {
+                        reference: rebased_reference,
+                        dt: A::Ticks::from(dt_unshifted),
+                    }
+                } else {
+                    // The lower 32-bit of reference are equal to or larger than the
+                    // userspace reference. Thus we can rebase the reference,
+                    // touching only the lower 32 bit, by:
+                    //
+                    // 1. subtract the lower `u32` bits from this value, setting
+                    //    those bits to zero,
+                    // 2. adding back the userspace-provided reference.
+
+                    // Perform step 1, setting first 32 bit to zero:
+                    let sub_lower = now.wrapping_sub(A::Ticks::from(now.into_u32()));
+
+                    // Perform step 2, add back the userspace-provided reference:
+                    let rebased_reference =
+                        sub_lower.wrapping_add(A::Ticks::from(userspace_reference_unshifted));
+
+                    // Finally, return the new expiration. We don't have to do
+                    // anything special for `dt`, as it's relative:
+                    Expiration {
+                        reference: rebased_reference,
+                        dt: A::Ticks::from(dt_unshifted),
+                    }
+                }
+            }
+
+            (Some(userspace_reference_unshifted), false) => {
+                // We have a userspace reference and timer is (less than) 32
+                // bit. Simply set to unshifted values:
+                Expiration {
+                    reference: A::Ticks::from(userspace_reference_unshifted),
+                    dt: A::Ticks::from(dt_unshifted),
+                }
+            }
+
+            (None, _) => {
+                // We have no userspace reference. Use `now` as a reference:
+                Expiration {
+                    reference: now,
+                    dt: A::Ticks::from(dt_unshifted),
+                }
+            }
+        };
+
+        // Store the new expiration. We already adjusted the armed count above:
+        *expiration = Some(new_exp);
+
+        // Return the time left-justified time at which the alarm will fire:
+        new_exp
+            .reference
+            .wrapping_add(new_exp.dt)
+            .into_u32_left_justified()
     }
 }
 
@@ -181,29 +384,22 @@ impl<'a, A: Alarm<'a>> SyscallDriver for AlarmDriver<'a, A> {
         //   - on an error (i.e. no change to the alarms).
         self.app_alarms
             .enter(caller_id, |td, _upcalls| {
-                // helper function to rearm alarm
-                let mut rearm = |reference: usize, dt: usize| {
-                    if let Expiration::Disabled = td.expiration {
-                        self.num_armed.set(self.num_armed.get() + 1);
-                    }
-
-                    td.expiration = Expiration::Enabled {
-                        reference: reference as u32,
-                        dt: dt as u32,
-                    };
-
-                    reference.wrapping_add(dt) as u32
-                };
-
                 let now = self.alarm.now();
+
                 match cmd_type {
+                    // Driver check:
+                    //
+                    // Don't re-arm the timer:
                     0 => (CommandReturn::success(), false),
+
                     1 => {
                         // Get clock frequency. We return a frequency scaled by
                         // the amount of padding we add to the `ticks` value
                         // returned in command 2 ("capture time"), such that
                         // userspace knows when the timer will wrap and can
                         // accurately determine the duration of a single tick.
+                        //
+                        // Don't re-arm the timer:
                         let scaled_freq =
                             <A::Ticks>::u32_left_justified_scale_freq::<A::Frequency>();
                         (CommandReturn::success_u32(scaled_freq), false)
@@ -213,6 +409,8 @@ impl<'a, A: Alarm<'a>> SyscallDriver for AlarmDriver<'a, A> {
                         // wrap at exactly `(2 ** 32) - 1`. This predictable
                         // wrapping value allows userspace to build long running
                         // timers beyond `2 ** now.width()` ticks.
+                        //
+                        // Don't re-arm the timer:
                         (
                             CommandReturn::success_u32(now.into_u32_left_justified()),
                             false,
@@ -221,91 +419,94 @@ impl<'a, A: Alarm<'a>> SyscallDriver for AlarmDriver<'a, A> {
                     3 => {
                         // Stop
                         match td.expiration {
-                            Expiration::Disabled => {
-                                // Request to stop when already stopped
+                            None => {
+                                // Request to stop when already stopped. Don't
+                                // re-arm the timer:
                                 (CommandReturn::failure(ErrorCode::ALREADY), false)
                             }
-                            _ => {
-                                td.expiration = Expiration::Disabled;
-                                let new_num_armed = self.num_armed.get() - 1;
-                                self.num_armed.set(new_num_armed);
+                            Some(_old_expiraton) => {
+                                // Clear the expiration:
+                                td.expiration = None;
+
+                                // Ask for the timer to be re-armed. We can't do
+                                // this here, as it would re-enter the grant
+                                // region:
                                 (CommandReturn::success(), true)
                             }
                         }
                     }
                     4 => {
                         // Deprecated in 2.0, used to be: set absolute expiration
+                        //
+                        // Don't re-arm the timer:
                         (CommandReturn::failure(ErrorCode::NOSUPPORT), false)
                     }
                     5 => {
-                        // Set relative expiration.  We provided userspace a
-                        // potentially padded version of our in-kernel Ticks
-                        // object, and as such we have to invert that operation
-                        // here.
-                        let reference = now.into_u32() as usize;
+                        // Set relative expiration.
+                        //
+                        // We provided userspace a potentially padded version of
+                        // our in-kernel Ticks object, and as such we have to
+                        // invert that operation through a right shift.
+                        //
+                        // Also, we need to keep track of the currently armed
+                        // timers.
+                        //
+                        // All of this is done in the following helper method:
+                        let new_exp_left_justified = Self::rearm_u32_left_justified_expiration(
+                            // Current time:
+                            now,
+                            // No userspace-provided reference:
+                            None,
+                            // Left-justified `dt` value:
+                            data as u32,
+                            // Reference to the `Option<Expiration>`, also used
+                            // to update the counter of armed alarms:
+                            &mut td.expiration,
+                        );
 
-                        // We do not want to switch back to userspace *before*
-                        // the timer fires. As such, when userspace gives us
-                        // reference and ticks values with a precision
-                        // unrepresentible using our Ticks object, we round up:
-                        let dt = if data & ((1 << A::Ticks::u32_padding()) - 1) != 0 {
-                            // By right-shifting, we would decrease the
-                            // requested dt value. Add one to compensate:
-                            (data >> A::Ticks::u32_padding()) + 1
-                        } else {
-                            // dt does not need to be shifted or contains no
-                            // unrepresentable precision:
-                            data >> A::Ticks::u32_padding()
-                        };
-
-                        // if previously unarmed, but now will become armed
-                        (
-                            CommandReturn::success_u32(
-                                rearm(reference, dt) << A::Ticks::u32_padding(),
-                            ),
-                            true,
-                        )
+                        // Report success, with the left-justified time at which
+                        // the alarm will fire. Also ask for the timer to be
+                        // re-armed. We can't do this here, as it would re-enter
+                        // the grant region:
+                        (CommandReturn::success_u32(new_exp_left_justified), true)
                     }
                     6 => {
-                        // Set absolute expiration with reference point. We
-                        // provided userspace a potentially padded version of
-                        // our in-kernel Ticks object, and as such we have to
-                        // invert that operation here.
+                        // Also, we need to keep track of the currently armed
+                        // timers.
                         //
-                        // We do not want to switch back to userspace *before*
-                        // the timer fires. As such, when userspace gives us
-                        // reference and ticks values with a precision
-                        // unrepresentible using our Ticks object, we round
-                        // `reference` down, and `dt` up (ensuring that the
-                        // timer cannot fire earlier than requested).
-                        let reference = data >> A::Ticks::u32_padding();
-                        let dt = if data2 & ((1 << A::Ticks::u32_padding()) - 1) != 0 {
-                            // By right-shifting, we would decrease the
-                            // requested dt value. Add one to compensate:
-                            (data2 >> A::Ticks::u32_padding()) + 1
-                        } else {
-                            // dt does not need to be shifted or contains no
-                            // unrepresentable precision:
-                            data2 >> A::Ticks::u32_padding()
-                        };
+                        // All of this is done in the following helper method:
+                        let new_exp_left_justified = Self::rearm_u32_left_justified_expiration(
+                            // Current time:
+                            now,
+                            // Left-justified userspace-provided reference:
+                            Some(data as u32),
+                            // Left-justified `dt` value:
+                            data2 as u32,
+                            // Reference to the `Option<Expiration>`, also used
+                            // to update the counter of armed alarms:
+                            &mut td.expiration,
+                        );
 
-                        (
-                            CommandReturn::success_u32(
-                                rearm(reference, dt) << A::Ticks::u32_padding(),
-                            ),
-                            true,
-                        )
+                        // Report success, with the left-justified time at which
+                        // the alarm will fire. Also ask for the timer to be
+                        // re-armed. We can't do this here, as it would re-enter
+                        // the grant region:
+                        (CommandReturn::success_u32(new_exp_left_justified), true)
                     }
+
+                    // Unknown command:
+                    //
+                    // Don't re-arm the timer:
                     _ => (CommandReturn::failure(ErrorCode::NOSUPPORT), false),
                 }
             })
             .map_or_else(
                 |err| CommandReturn::failure(err.into()),
-                |(result, reset)| {
-                    if reset {
-                        self.reset_active_alarm();
+                |(retval, rearm_timer)| {
+                    if rearm_timer {
+                        self.process_rearm_or_callback();
                     }
-                    result
+                    retval
                 },
             )
     }
@@ -317,38 +518,595 @@ impl<'a, A: Alarm<'a>> SyscallDriver for AlarmDriver<'a, A> {
 
 impl<'a, A: Alarm<'a>> time::AlarmClient for AlarmDriver<'a, A> {
     fn alarm(&self) {
-        let now: Ticks32 = Ticks32::from(self.alarm.now().into_u32_left_justified());
-        self.app_alarms.each(|_processid, alarm, upcalls| {
-            if let Expiration::Enabled { reference, dt } = alarm.expiration {
-                // Now is not within reference, reference + ticks; this timer
-                // as passed (since reference must be in the past)
-                if !now.within_range(
-                    Ticks32::from(reference),
-                    Ticks32::from(reference.wrapping_add(dt)),
-                ) {
-                    alarm.expiration = Expiration::Disabled;
-                    self.num_armed.set(self.num_armed.get() - 1);
-                    upcalls
-                        .schedule_upcall(
-                            ALARM_CALLBACK_NUM,
-                            (
-                                now.into_u32_left_justified() as usize,
-                                reference.wrapping_add(dt) as usize,
-                                0,
-                            ),
-                        )
-                        .ok();
-                }
-            }
-        });
+        self.process_rearm_or_callback();
+    }
+}
 
-        // If there are no armed alarms left, skip checking and just disable.
-        // Otherwise, check all the alarms and find the next one, rescheduling
-        // the underlying alarm.
-        if self.num_armed.get() == 0 {
-            let _ = self.alarm.disarm();
-        } else {
-            self.reset_active_alarm();
+#[cfg(test)]
+mod test {
+    use core::cell::Cell;
+    use core::marker::PhantomData;
+
+    use kernel::hil::time::{
+        Alarm, AlarmClient, Freq10MHz, Frequency, Ticks, Ticks24, Ticks32, Ticks64, Time,
+    };
+    use kernel::utilities::cells::OptionalCell;
+    use kernel::ErrorCode;
+
+    use super::{AlarmDriver, Expiration};
+
+    struct MockAlarm<'a, T: Ticks, F: Frequency> {
+        current_ticks: Cell<T>,
+        client: OptionalCell<&'a dyn AlarmClient>,
+        _frequency: PhantomData<F>,
+    }
+
+    impl<'a, T: Ticks, F: Frequency> Time for MockAlarm<'a, T, F> {
+        type Frequency = F;
+        type Ticks = T;
+
+        fn now(&self) -> Self::Ticks {
+            self.current_ticks.get()
         }
+    }
+
+    impl<'a, T: Ticks, F: Frequency> Alarm<'a> for MockAlarm<'a, T, F> {
+        fn set_alarm_client(&self, client: &'a dyn AlarmClient) {
+            self.client.set(client);
+        }
+
+        fn set_alarm(&self, _reference: Self::Ticks, _dt: Self::Ticks) {
+            unimplemented!()
+        }
+
+        fn get_alarm(&self) -> Self::Ticks {
+            unimplemented!()
+        }
+
+        fn disarm(&self) -> Result<(), ErrorCode> {
+            unimplemented!()
+        }
+
+        fn is_armed(&self) -> bool {
+            unimplemented!()
+        }
+
+        fn minimum_dt(&self) -> Self::Ticks {
+            unimplemented!()
+        }
+    }
+
+    #[test]
+    fn test_earliest_alarm_no_alarms() {
+        assert!(
+            AlarmDriver::<MockAlarm<Ticks32, Freq10MHz>>::earliest_alarm(
+                // Now:
+                Ticks32::from(42_u32),
+                // Expirations:
+                <[(
+                    Expiration<kernel::hil::time::Ticks32>,
+                    (),
+                    fn(_, &()) -> Option<()>
+                ); 0] as IntoIterator>::into_iter([])
+            )
+            .unwrap()
+            .is_none()
+        )
+    }
+
+    #[test]
+    fn test_earliest_alarm_multiple_unexpired() {
+        // Should never be called:
+        let exp_handler = |exp, id: &usize| -> Option<()> {
+            panic!("Alarm should not be expired: {:?}, id: {}", exp, id)
+        };
+
+        let (earliest, id) = AlarmDriver::<MockAlarm<Ticks32, Freq10MHz>>::earliest_alarm(
+            // Now:
+            42_u32.into(),
+            // Expirations:
+            [
+                (
+                    // Will expire at 52:
+                    Expiration {
+                        reference: 42_u32.into(),
+                        dt: 10_u32.into(),
+                    },
+                    0,
+                    exp_handler,
+                ),
+                (
+                    // Will expire at exactly 43:
+                    Expiration {
+                        reference: u32::MAX.into(),
+                        dt: 44_u32.into(),
+                    },
+                    1,
+                    exp_handler,
+                ),
+                (
+                    // Will expire at 44:
+                    Expiration {
+                        reference: 10_u32.into(),
+                        dt: 34_u32.into(),
+                    },
+                    2,
+                    exp_handler,
+                ),
+            ]
+            .into_iter(),
+        )
+        .unwrap()
+        .unwrap();
+
+        assert!(earliest.reference.into_u32() == u32::MAX);
+        assert!(earliest.dt.into_u32() == 44);
+        assert!(id == 1);
+    }
+
+    #[test]
+    fn test_earliest_alarm_multiple_expired() {
+        let exp_list: [Cell<bool>; 7] = Default::default();
+
+        let exp_handler = |_exp, id: &usize| -> Option<()> {
+            exp_list[*id].set(true);
+
+            // Don't stop iterating on the first expired alarm:
+            None
+        };
+
+        let (earliest, id) = AlarmDriver::<MockAlarm<Ticks32, Freq10MHz>>::earliest_alarm(
+            // Now:
+            42_u32.into(),
+            // Expirations:
+            [
+                (
+                    // Has expired at 42 (current cycle), should fire!
+                    Expiration {
+                        reference: 41_u32.into(),
+                        dt: 1_u32.into(),
+                    },
+                    0,
+                    &exp_handler,
+                ),
+                (
+                    // Will expire at 52, should not fire.
+                    Expiration {
+                        reference: 42_u32.into(),
+                        dt: 10_u32.into(),
+                    },
+                    1,
+                    &exp_handler,
+                ),
+                (
+                    // Will expire at exactly 43, should not fire.
+                    Expiration {
+                        reference: u32::MAX.into(),
+                        dt: 44_u32.into(),
+                    },
+                    2,
+                    &exp_handler,
+                ),
+                (
+                    // Reference is current time, expiration in the future,
+                    // should not fire:
+                    Expiration {
+                        reference: 42_u32.into(),
+                        dt: 1_u32.into(),
+                    },
+                    3,
+                    &exp_handler,
+                ),
+                (
+                    // Reference is 43 (current time + 1), interpreted as "in
+                    // the past", should fire:
+                    Expiration {
+                        reference: 43_u32.into(),
+                        dt: 1_u32.into(),
+                    },
+                    4,
+                    &exp_handler,
+                ),
+                (
+                    // Reference is 0, end is at 1, in the past, should fire:
+                    Expiration {
+                        reference: 0_u32.into(),
+                        dt: 1_u32.into(),
+                    },
+                    5,
+                    &exp_handler,
+                ),
+                (
+                    // Reference is u32::MAX, end is at 0, in the past, should fire:
+                    Expiration {
+                        reference: u32::MAX.into(),
+                        dt: 1_u32.into(),
+                    },
+                    6,
+                    &exp_handler,
+                ),
+            ]
+            .into_iter(),
+        )
+        .unwrap()
+        .unwrap();
+
+        assert!(earliest.reference.into_u32() == 41);
+        assert!(earliest.dt.into_u32() == 1);
+        assert!(id == 0);
+
+        let mut bool_exp_list: [bool; 7] = [false; 7];
+        exp_list
+            .into_iter()
+            .zip(bool_exp_list.iter_mut())
+            .for_each(|(src, dst)| *dst = src.get());
+
+        assert!(bool_exp_list == [true, false, false, false, true, true, true]);
+    }
+
+    #[test]
+    fn test_earliest_alarm_expired_stop() {
+        let exp_list: [Cell<bool>; 4] = Default::default();
+
+        let exp_handler = |_exp, id: &usize| -> Option<&'static str> {
+            exp_list[*id].set(true);
+
+            // Stop iterating on id == 3
+            if *id == 3 {
+                Some("stopped")
+            } else {
+                None
+            }
+        };
+
+        let (expired, id, expired_ret) =
+            AlarmDriver::<MockAlarm<Ticks32, Freq10MHz>>::earliest_alarm(
+                // Now:
+                42_u32.into(),
+                // Expirations:
+                [
+                    (
+                        // Will expire at 52, should not fire.
+                        Expiration {
+                            reference: 42_u32.into(),
+                            dt: 10_u32.into(),
+                        },
+                        0,
+                        &exp_handler,
+                    ),
+                    (
+                        // Has expired at 42 (current cycle), should fire!
+                        Expiration {
+                            reference: 41_u32.into(),
+                            dt: 1_u32.into(),
+                        },
+                        1,
+                        &exp_handler,
+                    ),
+                    (
+                        // Will expire at exactly 43, should not fire.
+                        Expiration {
+                            reference: u32::MAX.into(),
+                            dt: 44_u32.into(),
+                        },
+                        2,
+                        &exp_handler,
+                    ),
+                    (
+                        // Reference is 0, end is at 1, in the past, should fire:
+                        Expiration {
+                            reference: 0_u32.into(),
+                            dt: 1_u32.into(),
+                        },
+                        3,
+                        &exp_handler,
+                    ),
+                ]
+                .into_iter(),
+            )
+            .err()
+            .unwrap();
+
+        assert!(expired.reference.into_u32() == 0);
+        assert!(expired.dt.into_u32() == 1);
+        assert!(id == 3);
+        assert!(expired_ret == "stopped");
+
+        let mut bool_exp_list: [bool; 4] = [false; 4];
+        exp_list
+            .into_iter()
+            .zip(bool_exp_list.iter_mut())
+            .for_each(|(src, dst)| *dst = src.get());
+
+        assert!(bool_exp_list == [false, true, false, true,]);
+    }
+
+    #[test]
+    fn test_rearm_24bit_left_justified_noref_basic() {
+        let mut expiration = None;
+        let armed_counter = Cell::new(0);
+
+        assert!(Ticks24::u32_padding() == 8);
+
+        let armed_time =
+            AlarmDriver::<MockAlarm<Ticks24, Freq10MHz>>::rearm_u32_left_justified_expiration(
+                // Current time:
+                Ticks24::from(1337_u32),
+                // No userspace-provided reference:
+                None,
+                // Left-justified `dt` value:
+                1234_u32 << Ticks24::u32_padding(),
+                // Reference to the `Option<Expiration>`, also used
+                // to update the counter of armed alarms:
+                &mut expiration,
+                // Reference to the count of currently armed alarms:
+                &armed_counter,
+            );
+
+        let expiration = expiration.unwrap();
+
+        assert_eq!(armed_time, (1337 + 1234) << Ticks24::u32_padding());
+        assert_eq!(armed_counter.get(), 1);
+        assert_eq!(expiration.reference.into_u32(), 1337);
+        assert_eq!(expiration.dt.into_u32(), 1234);
+    }
+
+    #[test]
+    fn test_rearm_24bit_left_justified_noref_wrapping() {
+        let mut expiration = None;
+        let armed_counter = Cell::new(0);
+
+        let armed_time =
+            AlarmDriver::<MockAlarm<Ticks24, Freq10MHz>>::rearm_u32_left_justified_expiration(
+                // Current time:
+                Ticks24::from(1337_u32),
+                // No userspace-provided reference:
+                None,
+                // Left-justified `dt` value (in this case, with some
+                // irrepresentable precision)
+                u32::MAX - (42 << Ticks24::u32_padding()),
+                // Reference to the `Option<Expiration>`, also used
+                // to update the counter of armed alarms:
+                &mut expiration,
+                // Reference to the count of currently armed alarms:
+                &armed_counter,
+            );
+
+        let expiration = expiration.unwrap();
+
+        // (1337 + ((0xffffffff - (42 << 8)) >> 8) + 1) % 0x01000000 = 1295
+        assert_eq!(armed_time, 1295 << Ticks24::u32_padding());
+        assert_eq!(armed_counter.get(), 1);
+        assert_eq!(expiration.reference.into_u32(), 1337);
+        assert_eq!(
+            expiration.dt.into_u32(),
+            // dt is rounded up to the next representable tick:
+            ((u32::MAX - (42 << Ticks24::u32_padding())) >> Ticks24::u32_padding()) + 1
+        );
+    }
+
+    #[test]
+    fn test_rearm_32bit_left_justified_noref_basic() {
+        let mut expiration = Some(Expiration {
+            reference: 0_u32.into(),
+            dt: 1_u32.into(),
+        });
+        let armed_counter = Cell::new(111);
+
+        assert!(Ticks32::u32_padding() == 0);
+
+        let armed_time =
+            AlarmDriver::<MockAlarm<Ticks32, Freq10MHz>>::rearm_u32_left_justified_expiration(
+                // Current time:
+                Ticks32::from(1337_u32),
+                // No userspace-provided reference:
+                None,
+                // Left-justified `dt` value, unshifted for 32 bit:
+                1234_u32,
+                // Reference to the `Option<Expiration>`, also used
+                // to update the counter of armed alarms:
+                &mut expiration,
+                // Reference to the count of currently armed alarms:
+                &armed_counter,
+            );
+
+        let expiration = expiration.unwrap();
+
+        assert_eq!(armed_time, 1337 + 1234);
+        // counter must not be increased when the alarm was previously armed
+        assert_eq!(armed_counter.get(), 111);
+        assert_eq!(expiration.reference.into_u32(), 1337);
+        assert_eq!(expiration.dt.into_u32(), 1234);
+    }
+
+    #[test]
+    fn test_rearm_32bit_left_justified_noref_wrapping() {
+        let mut expiration = None;
+        let armed_counter = Cell::new(0);
+
+        let armed_time =
+            AlarmDriver::<MockAlarm<Ticks32, Freq10MHz>>::rearm_u32_left_justified_expiration(
+                // Current time:
+                Ticks32::from(1337_u32),
+                // No userspace-provided reference:
+                None,
+                // Left-justified `dt` value (in this case, with some
+                // irrepresentable precision)
+                u32::MAX - 42,
+                // Reference to the `Option<Expiration>`, also used
+                // to update the counter of armed alarms:
+                &mut expiration,
+                // Reference to the count of currently armed alarms:
+                &armed_counter,
+            );
+
+        let expiration = expiration.unwrap();
+
+        // (1337 + (0xffffffff - 42)) % 0x100000000 = 1294
+        assert_eq!(armed_time, 1294);
+        assert_eq!(armed_counter.get(), 1);
+        assert_eq!(expiration.reference.into_u32(), 1337);
+        assert_eq!(expiration.dt.into_u32(), u32::MAX - 42);
+    }
+
+    #[test]
+    fn test_rearm_64bit_left_justified_noref_wrapping() {
+        let mut expiration = Some(Expiration {
+            reference: 0_u32.into(),
+            dt: 1_u32.into(),
+        });
+        let armed_counter = Cell::new(111);
+
+        assert!(Ticks64::u32_padding() == 0);
+
+        let armed_time =
+            AlarmDriver::<MockAlarm<Ticks64, Freq10MHz>>::rearm_u32_left_justified_expiration(
+                // Current time:
+                Ticks64::from(0xDEADBEEFCAFE_u64),
+                // No userspace-provided reference:
+                None,
+                // Left-justified `dt` value, unshifted for 32 bit:
+                0xDEADC0DE_u32,
+                // Reference to the `Option<Expiration>`, also used
+                // to update the counter of armed alarms:
+                &mut expiration,
+                // Reference to the count of currently armed alarms:
+                &armed_counter,
+            );
+
+        let expiration = expiration.unwrap();
+
+        assert_eq!(armed_time, 0x9D9D8BDC_u32);
+        // counter must not be increased when the alarm was previously armed
+        assert_eq!(armed_counter.get(), 111);
+        assert_eq!(expiration.reference.into_u64(), 0xDEADBEEFCAFE_u64);
+        assert_eq!(expiration.dt.into_u64(), 0xDEADC0DE_u64);
+    }
+
+    #[test]
+    fn test_rearm_64bit_left_justified_refnowrap_dtnorwap() {
+        let mut expiration = None;
+        let armed_counter = Cell::new(9999);
+
+        // reference smaller than now & 0xffffffff, reference + dt don't wrap:
+        let armed_time =
+            AlarmDriver::<MockAlarm<Ticks64, Freq10MHz>>::rearm_u32_left_justified_expiration(
+                // Current time:
+                Ticks64::from(0xDEADBEEFCAFE_u64),
+                // Userspace-provided reference, smaller than now and dt
+                Some(0xBEEFC0DE_u32),
+                // Left-justified `dt` value, unshifted for 32 bit:
+                0x1BADB002_u32,
+                // Reference to the `Option<Expiration>`, also used
+                // to update the counter of armed alarms:
+                &mut expiration,
+                // Reference to the count of currently armed alarms:
+                &armed_counter,
+            );
+
+        let expiration = expiration.unwrap();
+
+        assert_eq!(armed_time, 0xDA9D70E0_u32); // remains at 0xDEAD
+                                                // counter must not be increased when the alarm was previously armed
+        assert_eq!(armed_counter.get(), 10000);
+        assert_eq!(expiration.reference.into_u64(), 0xDEADBEEFC0DE_u64);
+        assert_eq!(expiration.dt.into_u64(), 0x1BADB002_u64);
+    }
+
+    #[test]
+    fn test_rearm_64bit_left_justified_refnowrwap_dtwrap() {
+        let mut expiration = Some(Expiration {
+            reference: 0_u32.into(),
+            dt: 1_u32.into(),
+        });
+        let armed_counter = Cell::new(111);
+
+        // reference smaller than now & 0xffffffff, reference + dt wrap:
+        let armed_time =
+            AlarmDriver::<MockAlarm<Ticks64, Freq10MHz>>::rearm_u32_left_justified_expiration(
+                // Current time:
+                Ticks64::from(0xDEADBEEFCAFE_u64),
+                // Userspace-provided reference, smaller than lower 32-bit of now
+                Some(0x8BADF00D_u32),
+                // Left-justified `dt` value, unshifted for 32 bit:
+                0xFEEDC0DE_u32,
+                // Reference to the `Option<Expiration>`, also used
+                // to update the counter of armed alarms:
+                &mut expiration,
+                // Reference to the count of currently armed alarms:
+                &armed_counter,
+            );
+
+        let expiration = expiration.unwrap();
+
+        assert_eq!(armed_time, 0x8A9BB0EB_u32); // wraps t0 0x0xDEAE
+                                                // counter must not be increased when the alarm was previously armed
+        assert_eq!(armed_counter.get(), 111);
+        assert_eq!(expiration.reference.into_u64(), 0xDEAD8BADF00D_u64);
+        assert_eq!(expiration.dt.into_u64(), 0xFEEDC0DE_u64);
+    }
+
+    #[test]
+    fn test_rearm_64bit_left_justified_refwrap_dtwrap() {
+        let mut expiration = None;
+        let armed_counter = Cell::new(111);
+
+        // reference larger than now & 0xffffffff, reference + dt wrap:
+        let armed_time =
+            AlarmDriver::<MockAlarm<Ticks64, Freq10MHz>>::rearm_u32_left_justified_expiration(
+                // Current time:
+                Ticks64::from(0xDEADBEEFCAFE_u64),
+                // Userspace-provided reference, larger than lower 32-bit of
+                // now, meaning that it's already past:
+                Some(0xCAFEB0BA_u32),
+                // Left-justified `dt` value, unshifted for 32 bit:
+                0xFEEDC0DE_u32,
+                // Reference to the `Option<Expiration>`, also used
+                // to update the counter of armed alarms:
+                &mut expiration,
+                // Reference to the count of currently armed alarms:
+                &armed_counter,
+            );
+
+        let expiration = expiration.unwrap();
+
+        assert_eq!(armed_time, 0xC9EC7198_u32); // wraps to 0xDEAE
+                                                // counter must not be increased when the alarm was previously armed
+        assert_eq!(armed_counter.get(), 112);
+        assert_eq!(expiration.reference.into_u64(), 0xDEACCAFEB0BA_u64);
+        assert_eq!(expiration.dt.into_u64(), 0xFEEDC0DE_u64);
+    }
+
+    #[test]
+    fn test_rearm_64bit_left_justified_refwrap_dtnowrap() {
+        let mut expiration = Some(Expiration {
+            reference: 0_u32.into(),
+            dt: 1_u32.into(),
+        });
+        let armed_counter = Cell::new(111);
+
+        // reference larger than now & 0xffffffff, reference + dt don't wrap
+        let armed_time =
+            AlarmDriver::<MockAlarm<Ticks64, Freq10MHz>>::rearm_u32_left_justified_expiration(
+                // Current time:
+                Ticks64::from(0xDEADBEEFCAFE_u64),
+                // Userspace-provided reference, larger than lower 32-bit of now
+                Some(0xCAFEB0BA_u32),
+                // Left-justified `dt` value, unshifted for 32 bit:
+                0x1BADB002_u32,
+                // Reference to the `Option<Expiration>`, also used
+                // to update the counter of armed alarms:
+                &mut expiration,
+                // Reference to the count of currently armed alarms:
+                &armed_counter,
+            );
+
+        let expiration = expiration.unwrap();
+
+        assert_eq!(armed_time, 0xE6AC60BC_u32); // remains at 0xDEAD
+                                                // counter must not be increased when the alarm was previously armed
+        assert_eq!(armed_counter.get(), 111);
+        assert_eq!(expiration.reference.into_u64(), 0xDEACCAFEB0BA_u64);
+        assert_eq!(expiration.dt.into_u64(), 0x1BADB002_u64);
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request is a second revision of #3973, with a full rewrite of the alarm driver. See below for why I deem this the best strategy forward.

##### Original Motivation

This change introduces new APIs on the `Ticks` trait of `kernel/src/hil/time.rs` which allow consumers of this type to know the underlying timer's actual ticks width (may be less than 32 bit), and to right-pad Ticks values for it to wrap at exactly `(2 ** 32) - 1` ticks.

By exposing this shifted Ticks value and an appropriately scaled tick frequency to userspace, Tock finally conforms to assumptions made in `libtock-c` long ago:

     The client should not assume anything about the underlying clock
     used by an implementation other than that it is running at
     sufficient frequency to deliver at least millisecond granularity
     and that it is a 32-bit clock (i.e. it will wrap at 2^32 clock
     ticks).

This predictable timer interface can allow userspace to build timer infrastructure that can schedule alarms or sleep for longer than `2 ** Timer Width` ticks.

Apart from now conforming to libtock-c's expectations, by scaling both timer and frequency this change should not break any existing userspace applications (apart from triggering an otherwise unrelated bug in libtock-c's virtual alarms). It does modify code for which a relevant TRD (105) exists, but that TRD is still in draft state.

##### Alarm Driver Rewrite

The wrapping logic in the alarm driver was likely still broken in #3973 with > 32 bit timers. This is because the alarm driver used to deal only with 32-bit values internally. However, it would not record whether those values were potentially stemming from a timer of a smaller timer. This then causes issues when it will set a new alarm in its wrapping logic.

Apart from that, the fact that it first converted to 32 bit, and then back again to the underlying timer width, up- and down-scaling as necessary, is very confusing. The code interleaves iterating over timers, computing wrapping, and controlling the hardware in a way that makes it hard to reason about, and virtually impossible to unit-test.

I refactored the driver to clearly separate out this logic:
- `Expiration` now always refers to a set alarm. `Option<Expiration>` refers to an alarm that can be disabled. Distinguishing between these on a type level (versus one single `enum Expiration` for both) allows us to get rid of a many checks.
- `earliest_alarm` iterates over a list of alarms, invoking a callback on each expired one, and returns the earliest non-expired one. This is very easily unit-testable and allows us to combine callback- and re-arm operations into a single handler.
- `process_rearm_or_callback` is this handler. It is a thin wrapper around the above, and controls the hardware (this part is not easily testable).
- `rearm_u32_left_justified_expiration` does all the magic wrapping / shifting logic. It is not clobbered with any details about the underlying alarm, but instead just converts a 32-bit left-justified ticks value into any underlying A::Ticks, regardless of width. It does appropriate wrapping for smaller and larger timers. This is extensively unit-tested.

The logic in the `Driver` implementation is simplified as well.

I'm not happy with the fact that this is a full re-write, but I am much more confident that the implementation is correct and has less edge-cases than with the old architecture. I hope others find the new code structure equally readable.

### Testing Strategy

LiteX Sim CI and unit tests introduced in this PR:

```
    Finished test [optimized + debuginfo] target(s) in 0.52s
     Running unittests src/lib.rs (/home/leons/develop/tock/tock/target/debug/deps/capsules_core-d4d0469fae668189)

running 17 tests
test alarm::test::test_earliest_alarm_expired_stop ... ok
test alarm::test::test_earliest_alarm_no_alarms ... ok
test alarm::test::test_earliest_alarm_multiple_expired ... ok
test alarm::test::test_earliest_alarm_multiple_unexpired ... ok
test alarm::test::test_rearm_24bit_left_justified_noref_basic ... ok
test alarm::test::test_rearm_24bit_left_justified_noref_wrapping ... ok
test alarm::test::test_rearm_32bit_left_justified_noref_basic ... ok
test alarm::test::test_rearm_32bit_left_justified_noref_wrapping ... ok
test alarm::test::test_rearm_64bit_left_justified_noref_wrapping ... ok
test alarm::test::test_rearm_64bit_left_justified_refnowrap_dtnorwap ... ok
test alarm::test::test_rearm_64bit_left_justified_refnowrwap_dtwrap ... ok
test alarm::test::test_rearm_64bit_left_justified_refwrap_dtnowrap ... ok
```


### TODO or Help Wanted

Updates to the TRD.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
