### PR TITLE
Remove Thread Capsule Debug Statements

### DIFF
--- a/capsules/extra/src/net/thread/driver.rs
+++ b/capsules/extra/src/net/thread/driver.rs
@@ -206,9 +206,11 @@ impl<'a, A: time::Alarm<'a>> ThreadNetworkDriver<'a, A> {
                         // Thread send failed sending parent req so we terminate and return
                         // to a detached state.
                         self.state.replace(ThreadState::Detached);
-                        kernel::debug!(
-                            "[Thread] Failed sending MLE parent request - crypto operation error."
-                        );
+
+                        // UNCOMMENT TO DEBUG THREAD //
+                        // kernel::debug!(
+                        //     "[Thread] Failed sending MLE parent request - crypto operation error."
+                        // );
                         self.terminate_child_join(Err(code));
                     });
             }
@@ -334,7 +336,8 @@ impl<'a, A: time::Alarm<'a>> ThreadNetworkDriver<'a, A> {
         // Obtain and unwrap frame counter
         let frame_counter = security.frame_counter;
         if frame_counter.is_none() {
-            kernel::debug!("[Thread] Malformed auxiliary security header");
+            // UNCOMMENT TO DEBUG THREAD //
+            // kernel::debug!("[Thread] Malformed auxiliary security header");
             return Err((ErrorCode::INVAL, buf));
         }
 
@@ -351,12 +354,14 @@ impl<'a, A: time::Alarm<'a>> ThreadNetworkDriver<'a, A> {
                 if self.aes_crypto.set_key(&netkey.mle_key).is_err()
                     || self.aes_crypto.set_nonce(&nonce).is_err()
                 {
-                    kernel::debug!("[Thread] Failure setting networkkey and/or nonce.");
+                    // UNCOMMENT TO DEBUG THREAD //
+                    // kernel::debug!("[Thread] Failure setting networkkey and/or nonce.");
                     return Err((ErrorCode::FAIL, buf));
                 }
             }
             None => {
-                kernel::debug!("[Thread] Attempt to access networkkey when no networkkey set.");
+                // UNCOMMENT TO DEBUG THREAD //
+                // kernel::debug!("[Thread] Attempt to access networkkey when no networkkey set.");
                 return Err((ErrorCode::NOSUPPORT, buf));
             }
         }
@@ -390,7 +395,8 @@ impl<'a, A: time::Alarm<'a>> ThreadNetworkDriver<'a, A> {
 
         // Error check on result from encoding, failure likely means buf was not large enough
         if encode_res.is_none() {
-            kernel::debug!("[Thread] Error encoding cryptographic data into buffer");
+            // UNCOMMENT TO DEBUG THREAD //
+            // kernel::debug!("[Thread] Error encoding cryptographic data into buffer");
             return Err((ErrorCode::FAIL, buf));
         }
 
@@ -413,9 +419,10 @@ impl<'a, A: time::Alarm<'a>> ThreadNetworkDriver<'a, A> {
         // The sizelock is empty except when a crypto operation
         // is underway. If the sizelock is not empty, return error
         if self.crypto_sizelock.is_some() {
-            kernel::debug!(
-                "[Thread] Error - cryptographic resources in use; crypto_sizelock occupied"
-            );
+            // UNCOMMENT TO DEBUG THREAD //
+            // kernel::debug!(
+            //     "[Thread] Error - cryptographic resources in use; crypto_sizelock occupied"
+            // );
             return Err((ErrorCode::BUSY, buf));
         }
 
@@ -580,7 +587,8 @@ impl<'a, A: time::Alarm<'a>> UDPRecvClient for ThreadNetworkDriver<'a, A> {
             // Tock's current implementation of Thread ignores all messages that do not possess MLE encryption. This
             // is due to the Thread spec stating "Except for when specifically indicated, incoming
             // messages that are not secured with either MLE or link-layer security SHOULD be ignored." (v.1.3.0 sect 4.10)
-            kernel::debug!("[Thread] DROPPED PACKET - Received unencrypted MLE packet.");
+            // UNCOMMENT TO DEBUG THREAD //
+            // kernel::debug!("[Thread] DROPPED PACKET - Received unencrypted MLE packet.");
         }
 
         // decode aux security header from packet into Security data type
@@ -588,7 +596,8 @@ impl<'a, A: time::Alarm<'a>> UDPRecvClient for ThreadNetworkDriver<'a, A> {
 
         // Guard statement for improperly formated aux sec header
         if sec_res.is_none() {
-            kernel::debug!("[Thread] DROPPED PACKET - Malformed auxiliary security header.");
+            // UNCOMMENT TO DEBUG THREAD //
+            // kernel::debug!("[Thread] DROPPED PACKET - Malformed auxiliary security header.");
             return;
         }
 
@@ -598,7 +607,10 @@ impl<'a, A: time::Alarm<'a>> UDPRecvClient for ThreadNetworkDriver<'a, A> {
         // initiates encoding all relevant auth data, setting crypto engine and initiating the
         // crypto operation.
         self.recv_buffer.take().map_or_else(
-            || kernel::debug!("[Thread] DROPPED PACKET - Receive buffer not available"),
+            || {
+                // UNCOMMENT TO DEBUG THREAD //
+                // kernel::debug!("[Thread] DROPPED PACKET - Receive buffer not available")
+            },
             |recv_buf| {
                 self.perform_crypt_op(
                     src_addr,
@@ -612,11 +624,12 @@ impl<'a, A: time::Alarm<'a>> UDPRecvClient for ThreadNetworkDriver<'a, A> {
                     // Error check on crypto operation. If the crypto operation
                     // fails, we log the error and replace the receive buffer for
                     // future receptions
-                    |(code, buf)| {
-                        kernel::debug!(
-                            "[Thread] DROPPED PACKET - Crypto Operation Error *{:?}",
-                            code
-                        );
+                    |(_code, buf)| {
+                        // UNCOMMENT TO DEBUG THREAD alter _code to code//
+                        // kernel::debug!(
+                        //     "[Thread] DROPPED PACKET - Crypto Operation Error *{:?}",
+                        //     code
+                        // );
                         self.recv_buffer.replace(SubSliceMut::new(buf));
                     },
                     |()| (),


### PR DESCRIPTION
### Pull Request Overview

This pull request comments out the Thread capsule debug statements. We discussed in the original Thread capsule PR that having debug statements may be problematic, but determined the best course forward was to comment out the debug statements. This is done elsewhere in the 15.4 network stack and allows these statements to be uncommented for debugging purposes. Long term, a more elegant solution would be to have a custom log level macro, but this works for now. 

These debug statements are particularly annoying in the context of the OpenThread app as they are triggered by the radio traffic passed through the stack to the app. In the original PR, a number of success case debug statements were commented out, but it appears the failure cases were left. From the perspective of the capsule, the Thread packets receive fails when using the OpenThread app. This is due to the capsule not being allocated the needed buffers etc. In turn, this results in these debug error statements to be triggered in the capsule. (in case this is not clear, this is entirely orthogonal to the OpenThread app as the Thread capsule and OpenThread app share no overlap)

### Testing Strategy

This pull request was tested by compile testing.


### TODO or Help Wanted

I am not sure what the best route forward is, but it seems we may wish to leave the Thread capsule for now, but remove the `main.rs` initialization. I'm curious if others agree with this.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
