### PR TITLE
Update pinned Tockloader rev to v1.12.0

### DIFF
--- a/.github/workflows/litex_sim.yml
+++ b/.github/workflows/litex_sim.yml
@@ -57,7 +57,7 @@ jobs:
       # applications.
       - name: Install tockloader
         run: |
-          pip3 install tockloader==1.11.0
+          pip3 install tockloader==1.12.0
 
       # Clone tock-litex support repository under ./tock-litex, check out the
       # targeted release.

--- a/shell.nix
+++ b/shell.nix
@@ -20,12 +20,12 @@ with builtins;
 let
   inherit (pkgs) stdenv lib;
 
-  # Tockloader v1.11.0
+  # Tockloader v1.12.0
   tockloader = import (pkgs.fetchFromGitHub {
     owner = "tock";
     repo = "tockloader";
-    rev = "v1.11.0";
-    sha256 = "sha256-bPEfpfOZOjOiazqRgn1cnqe4ohLPvocuENKoZx/Qw80=";
+    rev = "v1.12.0";
+    sha256 = "sha256-VgbAKDY/7ZVINDkqSHF7C0zRzVgtk8YG6O/ZmUpsh/g=";
   }) { inherit pkgs withUnfreePkgs; };
 
   rust_overlay = import "${pkgs.fetchFromGitHub {
@@ -63,7 +63,7 @@ in
 
       # --- CI support packages ---
       qemu
-      
+
       # --- Flashing tools ---
       # If your board requires J-Link to flash and you are on NixOS,
       # add these lines to your system wide configuration.


### PR DESCRIPTION
### Pull Request Overview

This pull request updates pinned Tockloader revisions to `v1.12.0`, including fixes for the nRF52840 accessible flash range.


### Testing Strategy

Entering nix-shell and CI.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
