### PR TITLE
capsules: tickv: invalidate may need another read

### DIFF
--- a/capsules/extra/src/tickv.rs
+++ b/capsules/extra/src/tickv.rs
@@ -535,6 +535,11 @@ impl<'a, F: Flash, H: Hasher<'a, 8>, const PAGE_SIZE: usize> flash::Client<F>
                     self.operation.set(Operation::None);
                 }
                 Ok(tickv::success_codes::SuccessCode::Queued) => {}
+                Err(tickv::error_codes::ErrorCode::ReadNotReady(_))
+                | Err(tickv::error_codes::ErrorCode::WriteNotReady(_))
+                | Err(tickv::error_codes::ErrorCode::EraseNotReady(_)) => {
+                    // Need to do another flash operation.
+                }
                 Err(e) => {
                     self.operation.set(Operation::None);
 


### PR DESCRIPTION

### Pull Request Overview

Typically, the flow for set(k, v) is:
1. Try to append (k, v).
2. That fails, because k exists.
3. Try to invalidate key k.
4. Since we read the flash to find the key already existed, we don't need to read again.
5. Invalidate k.

However, if k has rolled to a new page, then we will need a new read. We just need to handle that case by ignoring read not ready even for invalidate.





### Testing Strategy

This pull request was tested by working on the HOTP apps.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
