### PR TITLE
kernel: add RestartWithDebugFaultPolicy

### DIFF
--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -29,8 +29,9 @@ pub use crate::process_loading::ProcessLoadError;
 pub use crate::process_loading::SequentialProcessLoaderMachine;
 pub use crate::process_loading::{ProcessLoadingAsync, ProcessLoadingAsyncClient};
 pub use crate::process_policies::{
-    PanicFaultPolicy, ProcessFaultPolicy, RestartFaultPolicy, StopFaultPolicy,
-    StopWithDebugFaultPolicy, ThresholdRestartFaultPolicy, ThresholdRestartThenPanicFaultPolicy,
+    PanicFaultPolicy, ProcessFaultPolicy, RestartFaultPolicy, RestartWithDebugFaultPolicy,
+    StopFaultPolicy, StopWithDebugFaultPolicy, ThresholdRestartFaultPolicy,
+    ThresholdRestartThenPanicFaultPolicy,
 };
 pub use crate::process_printer::{ProcessPrinter, ProcessPrinterContext, ProcessPrinterText};
 pub use crate::process_standard::ProcessStandard;

--- a/kernel/src/process_policies.rs
+++ b/kernel/src/process_policies.rs
@@ -63,6 +63,19 @@ impl ProcessFaultPolicy for RestartFaultPolicy {
     }
 }
 
+/// Always restart the process if it faults, but print a debug message:
+pub struct RestartWithDebugFaultPolicy {}
+
+impl ProcessFaultPolicy for RestartWithDebugFaultPolicy {
+    fn action(&self, process: &dyn Process) -> process::FaultAction {
+        crate::debug!(
+            "Process {} faulted and will be restarted.",
+            process.get_process_name()
+        );
+        process::FaultAction::Restart
+    }
+}
+
 /// Implementation of `ProcessFaultPolicy` that uses a threshold to decide
 /// whether to restart a process when it faults. If the process has been
 /// restarted more times than the threshold then the process will be stopped


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a `RestartWithDebug` fault policy, which is slightly less opaque compared to just the `RestartFaultPolicy` when we use it as part of educational material. It actually shows that Tock restarts processes and doesn't simply mask faults. :)


### Testing Strategy

This pull request was tested by faulting an app and seeing it print the message.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
