### PR TITLE
Update nrf5x temperature calculation

### DIFF
--- a/chips/nrf5x/src/temperature.rs
+++ b/chips/nrf5x/src/temperature.rs
@@ -128,8 +128,8 @@ impl<'a> Temp<'a> {
         self.disable_interrupts();
 
         // get temperature
-        // Result of temperature measurement in °C, 2's complement format, 0.25 °C
-        let temp = (self.registers.temp.get() as i32 / 4) * 100;
+        // Result of temperature measurement in °C, 2's complement format, 0.25 °C steps
+        let temp = (self.registers.temp.get() as i32 * 100) / 4;
 
         // stop measurement
         self.registers.task_stop.write(Task::ENABLE::SET);


### PR DESCRIPTION
### Pull Request Overview

The nrf5x internal temperature sensor measures in 0.25 °C intervals. (i.e. 20 °C would have a register value of 80). 

The prior calculation converting this to an integer value divided by 4 prior to scaling by 100 and subsequently lost the 0.25 precision.

This PR updates the calculation.

### Testing Strategy

This pull request was tested on the nrf52840dk.

### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
