### PR TITLE
ieee802154: Remove buffers from `initialize()` functions

### DIFF
--- a/boards/components/src/rf233.rs
+++ b/boards/components/src/rf233.rs
@@ -25,6 +25,7 @@ use capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice;
 use capsules_extra::rf233::RF233;
 use core::mem::MaybeUninit;
 use kernel::component::Component;
+use kernel::hil::radio::RadioConfig;
 use kernel::hil::spi::{SpiMaster, SpiMasterDevice};
 use kernel::hil::{self, radio};
 
@@ -32,12 +33,25 @@ use kernel::hil::{self, radio};
 #[macro_export]
 macro_rules! rf233_component_static {
     ($S:ty $(,)?) => {{
-        kernel::static_buf!(
+        let spi_device = kernel::static_buf!(
             capsules_extra::rf233::RF233<
                 'static,
                 capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<'static, $S>,
             >
-        )
+        );
+        // The RF233 radio stack requires our buffers for its SPI operations:
+        //
+        //   1. buf: a packet-sized buffer for SPI operations, which is
+        //      used as the read buffer when it writes a packet passed to it and the write
+        //      buffer when it reads a packet into a buffer passed to it.
+        //   2. rx_buf: buffer to receive packets into
+        //   3 + 4: two small buffers for performing registers
+        //      operations (one read, one write).
+        let rf233_buf = kernel::static_buf!([u8; kernel::hil::radio::MAX_BUF_SIZE]);
+        let rf233_reg_write = kernel::static_buf!([u8; 2]);
+        let rf233_reg_read = kernel::static_buf!([u8; 2]);
+
+        (spi_device, rf233_buf, rf233_reg_write, rf233_reg_read)
     };};
 }
 
@@ -71,12 +85,23 @@ impl<S: SpiMaster<'static> + 'static> RF233Component<S> {
 }
 
 impl<S: SpiMaster<'static> + 'static> Component for RF233Component<S> {
-    type StaticInput = &'static mut MaybeUninit<RF233<'static, VirtualSpiMasterDevice<'static, S>>>;
+    type StaticInput = (
+        &'static mut MaybeUninit<RF233<'static, VirtualSpiMasterDevice<'static, S>>>,
+        &'static mut MaybeUninit<[u8; hil::radio::MAX_BUF_SIZE]>,
+        &'static mut MaybeUninit<[u8; 2]>,
+        &'static mut MaybeUninit<[u8; 2]>,
+    );
     type Output = &'static RF233<'static, VirtualSpiMasterDevice<'static, S>>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let rf233 = s.write(RF233::new(
+        let rf233_buf = s.1.write([0; hil::radio::MAX_BUF_SIZE]);
+        let rf233_reg_write = s.2.write([0; 2]);
+        let rf233_reg_read = s.3.write([0; 2]);
+        let rf233 = s.0.write(RF233::new(
             self.spi,
+            rf233_buf,
+            rf233_reg_write,
+            rf233_reg_read,
             self.reset,
             self.sleep,
             self.irq,
@@ -84,6 +109,7 @@ impl<S: SpiMaster<'static> + 'static> Component for RF233Component<S> {
         ));
         self.ctl.set_client(rf233);
         self.spi.set_client(rf233);
+        let _ = rf233.initialize();
         rf233
     }
 }

--- a/capsules/extra/src/ieee802154/mac.rs
+++ b/capsules/extra/src/ieee802154/mac.rs
@@ -19,9 +19,8 @@ use kernel::utilities::cells::OptionalCell;
 use kernel::ErrorCode;
 
 pub trait Mac<'a> {
-    /// Initializes the layer; may require a buffer to temporarily retaining frames to be
-    /// transmitted
-    fn initialize(&self, mac_buf: &'static mut [u8]) -> Result<(), ErrorCode>;
+    /// Initializes the layer.
+    fn initialize(&self) -> Result<(), ErrorCode>;
 
     /// Sets the notified client for configuration changes
     fn set_config_client(&self, client: &'a dyn radio::ConfigClient);
@@ -88,7 +87,7 @@ impl<'a, R: radio::Radio<'a>> AwakeMac<'a, R> {
 }
 
 impl<'a, R: radio::Radio<'a>> Mac<'a> for AwakeMac<'a, R> {
-    fn initialize(&self, _mac_buf: &'static mut [u8]) -> Result<(), ErrorCode> {
+    fn initialize(&self) -> Result<(), ErrorCode> {
         // do nothing, extra buffer unnecessary
         Ok(())
     }

--- a/capsules/extra/src/rf233.rs
+++ b/capsules/extra/src/rf233.rs
@@ -189,6 +189,8 @@ enum InternalState {
 // and waits for the interrupt specifying the entire packet has been
 // received.
 
+pub const SPI_REGISTER_TRANSACTION_LENGTH: usize = 2;
+
 pub struct RF233<'a, S: spi::SpiMasterDevice<'a>> {
     spi: &'a S,
     radio_on: Cell<bool>,
@@ -1034,8 +1036,8 @@ impl<'a, S: spi::SpiMasterDevice<'a>> RF233<'a, S> {
     pub fn new(
         spi: &'a S,
         spi_buf: &'static mut [u8],
-        reg_write: &'static mut [u8; 2],
-        reg_read: &'static mut [u8; 2],
+        reg_write: &'static mut [u8; SPI_REGISTER_TRANSACTION_LENGTH],
+        reg_read: &'static mut [u8; SPI_REGISTER_TRANSACTION_LENGTH],
         reset: &'a dyn gpio::Pin,
         sleep: &'a dyn gpio::Pin,
         irq: &'a dyn gpio::InterruptPin<'a>,

--- a/capsules/extra/src/rf233.rs
+++ b/capsules/extra/src/rf233.rs
@@ -164,7 +164,7 @@ enum InternalState {
 // packet-length buffers.  Since the SPI callback does not distinguish
 // which buffers are being used, the read_write_done callback checks
 // which state the stack is in and places the buffers back
-// accodingly. A bug here would mean a memory leak and later panic
+// accordingly. A bug here would mean a memory leak and later panic
 // when a buffer that should be present has been lost.
 //
 // The finite state machine is tricky for two reasons. First, the
@@ -1033,6 +1033,9 @@ impl<'a, S: spi::SpiMasterDevice<'a>> gpio::Client for RF233<'a, S> {
 impl<'a, S: spi::SpiMasterDevice<'a>> RF233<'a, S> {
     pub fn new(
         spi: &'a S,
+        spi_buf: &'static mut [u8],
+        reg_write: &'static mut [u8; 2],
+        reg_read: &'static mut [u8; 2],
         reset: &'a dyn gpio::Pin,
         sleep: &'a dyn gpio::Pin,
         irq: &'a dyn gpio::InterruptPin<'a>,
@@ -1067,9 +1070,9 @@ impl<'a, S: spi::SpiMasterDevice<'a>> RF233<'a, S> {
             pan: Cell::new(0),
             tx_power: Cell::new(setting_to_power(PHY_TX_PWR)),
             channel: Cell::new(channel),
-            spi_rx: TakeCell::empty(),
-            spi_tx: TakeCell::empty(),
-            spi_buf: TakeCell::empty(),
+            spi_rx: TakeCell::new(reg_read),
+            spi_tx: TakeCell::new(reg_write),
+            spi_buf: TakeCell::new(spi_buf),
         }
     }
 
@@ -1174,18 +1177,7 @@ impl<'a, S: spi::SpiMasterDevice<'a>> RF233<'a, S> {
 }
 
 impl<'a, S: spi::SpiMasterDevice<'a>> radio::RadioConfig<'a> for RF233<'a, S> {
-    fn initialize(
-        &self,
-        buf: &'static mut [u8],
-        reg_write: &'static mut [u8],
-        reg_read: &'static mut [u8],
-    ) -> Result<(), ErrorCode> {
-        if (buf.len() < radio::MAX_BUF_SIZE || reg_read.len() != 2 || reg_write.len() != 2) {
-            return Err(ErrorCode::SIZE);
-        }
-        self.spi_buf.replace(buf);
-        self.spi_rx.replace(reg_read);
-        self.spi_tx.replace(reg_write);
+    fn initialize(&self) -> Result<(), ErrorCode> {
         Ok(())
     }
 

--- a/chips/nrf52840/src/ieee802154_radio.rs
+++ b/chips/nrf52840/src/ieee802154_radio.rs
@@ -28,7 +28,7 @@ use nrf52::constants::TxPower;
 // basic 15.4 libtock-c apps.
 //
 // To aid in future implementations, a simplified and concise version of the nrf52840 radio
-// state machine specification is described. Additionally, the state machine this driver seperately
+// state machine specification is described. Additionally, the state machine this driver separately
 // maintains is also described.
 //
 // To interact with the radio, tasks are issued to the radio which in turn trigger interrupt events.
@@ -1166,12 +1166,7 @@ impl<'a> Radio<'a> {
 }
 
 impl<'a> kernel::hil::radio::RadioConfig<'a> for Radio<'a> {
-    fn initialize(
-        &self,
-        _spi_buf: &'static mut [u8],
-        _reg_write: &'static mut [u8],
-        _reg_read: &'static mut [u8],
-    ) -> Result<(), ErrorCode> {
+    fn initialize(&self) -> Result<(), ErrorCode> {
         self.radio_initialize();
         Ok(())
     }

--- a/kernel/src/hil/radio.rs
+++ b/kernel/src/hil/radio.rs
@@ -74,14 +74,7 @@ impl<'a, T: RadioConfig<'a> + RadioData<'a>> Radio<'a> for T {}
 
 /// Configure the 802.15.4 radio.
 pub trait RadioConfig<'a> {
-    /// buf must be at least MAX_BUF_SIZE in length, and
-    /// reg_read and reg_write must be 2 bytes.
-    fn initialize(
-        &self,
-        spi_buf: &'static mut [u8],
-        reg_write: &'static mut [u8],
-        reg_read: &'static mut [u8],
-    ) -> Result<(), ErrorCode>;
+    fn initialize(&self) -> Result<(), ErrorCode>;
     fn reset(&self) -> Result<(), ErrorCode>;
     fn start(&self) -> Result<(), ErrorCode>;
     fn stop(&self) -> Result<(), ErrorCode>;


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the `hil::radio:Radio` interface and the `mac` interface to not pass buffers to capsules via the `initialize()` function and instead use the conventional method of passing them in the `new()` constructor.

I think this is just an artifact of not knowing exactly which approach would work best at the time.

This also enables some improvements to the rf233 component and initialization in the imix board.

### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
