### PR TITLE
802.15.4 HIL updates; nRF52840 IEEE 802.15.4 Driver Updates

### DIFF
--- a/chips/nrf52840/src/ieee802154_radio.rs
+++ b/chips/nrf52840/src/ieee802154_radio.rs
@@ -763,6 +763,8 @@ impl<'a> Radio<'a> {
     }
 
     fn radio_off(&self) {
+        self.state.set(RadioState::OFF);
+
         self.registers.power.write(Task::ENABLE::CLEAR);
     }
 
@@ -1206,7 +1208,6 @@ impl<'a> kernel::hil::radio::RadioConfig<'a> for Radio<'a> {
 
     fn stop(&self) -> Result<(), ErrorCode> {
         self.radio_off();
-        self.state.set(RadioState::OFF);
 
         // Configure deferred call to trigger callback.
         self.deferred_call_operation

--- a/chips/nrf52840/src/ieee802154_radio.rs
+++ b/chips/nrf52840/src/ieee802154_radio.rs
@@ -3,6 +3,65 @@
 // Copyright Tock Contributors 2022.
 
 //! IEEE 802.15.4 radio driver for nRF52
+//!
+//! This driver implements a subset of 802.15.4 sending and receiving for the
+//! nRF52840 chip per the nRF52840_PS_v1.0 spec. Upon calling the initialization
+//! function, the chip is powered on and configured to the fields of the Radio
+//! struct. This driver maintains a state machine between receiving,
+//! transmitting, and sending acknowledgements. Because the nRF52840 15.4 radio
+//! chip does not possess hardware support for ACK, this driver implements
+//! software support for sending ACK when a received packet requests to be
+//! acknowledged. The driver currently lacks support to listen for requested ACK
+//! on packets the radio has sent. As of 8/14/23, the driver is able to send and
+//! receive 15.4 packets as used in the basic 15.4 libtock-c apps.
+//!
+//! ## Driver State Machine
+//!
+//! To aid in future implementations, this describes a simplified and concise
+//! version of the nrf52840 radio state machine specification and the state
+//! machine this driver separately maintains.
+//!
+//! To interact with the radio, tasks are issued to the radio which in turn
+//! trigger interrupt events. To receive, the radio must first "ramp up". The
+//! RXRU state is entered by issuing a RXEN task. Once the radio has ramped up
+//! successfully, it is now in the RXIDLE state and triggers a READY interrupt
+//! event. To optimize the radio's operation, this driver enables hardware
+//! shortcuts such that upon receiving the READY event, the radio chip
+//! immediately triggers a START task. The START task notifies the radio to begin
+//! officially "listening for packets" (RX state). Upon completing receiving the
+//! packet, the radio issues an END event. The driver then determines if the
+//! received packet has requested to be acknowledged (bit flag) and sends an ACK
+//! accordingly. Finally, the received packet buffer and accompanying fields are
+//! passed to the registered radio client. This marks the end of a receive cycle
+//! and a new READY event is issued to once again begin listening for packets.
+//!
+//! When a registered radio client wishes to send a packet. The transmit(...)
+//! method is called. To transmit a packet, the radio must first ramp up for
+//! receiving and then perform a clear channel assessment by listening for a
+//! specified period of time to determine if there is "traffic". If traffic is
+//! detected, the radio sets an alarm and waits to perform another CCA after this
+//! backoff. If the channel is determined to be clear, the radio then begins a TX
+//! ramp up, enters a TX state and then sends the packet. To progress through
+//! these states, hardware shortcuts are once again enabled in this driver. The
+//! driver first issues a DISABLE task. A hardware shortcut is enabled so that
+//! upon receipt of the disable task, the radio automatically issues a RXEN task
+//! to enter the RXRU state. Additionally, a shortcut is enabled such that when
+//! the RXREADY event is received, the radio automatically issues a CCA_START
+//! task. Finally, a shortcut is also enabled such that upon receiving a CCAIDLE
+//! event the radio automatically issues a TXEN event to ramp up the radio. The
+//! driver then handles receiving the READY interrupt event and triggers the
+//! START task to begin sending the packet. Upon completing the sending of the
+//! packet, the radio issues an END event, to which the driver then returns the
+//! radio to a receiving mode as described above. (For a more complete
+//! explanation of the radio's operation, refer to nRF52840_PS_v1.0)
+//!
+//! This radio state machine provides nine possible states the radio can exist
+//! in. For ease of implementation and clarity, this driver also maintains a
+//! simplified state machine. These states consist of the radio being off (OFF),
+//! receiving (RX), transmitting (TX), or acknowledging (ACK).
+
+// Author: Tyler Potyondy
+// 8/21/23
 
 use crate::timer::TimerAlarm;
 use core::cell::Cell;
@@ -15,56 +74,6 @@ use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 
 use nrf52::constants::TxPower;
-
-// This driver implements a subset of 802.15.4 sending and receiving for the
-// nRF52840 chip per the nRF52840_PS_v1.0 spec. Upon calling the initialization
-// function, the chip is powered on and configured to the fields of the Radio
-// struct. This driver maintains a state machine between receiving, transmitting,
-// and sending acknowledgements. Because the nRF52840 15.4 radio chip does not
-// possess hardware support for ACK, this driver implements software support
-// for sending ACK when a received packet requests to be acknowledged. The driver
-// currently lacks support to listen for requested ACK on packets the radio has sent.
-// As of 8/14/23, the driver is able to send and receive 15.4 packets as used in the
-// basic 15.4 libtock-c apps.
-//
-// To aid in future implementations, a simplified and concise version of the nrf52840 radio
-// state machine specification is described. Additionally, the state machine this driver separately
-// maintains is also described.
-//
-// To interact with the radio, tasks are issued to the radio which in turn trigger interrupt events.
-// To receive, the radio must first "ramp up". The RXRU state is entered by issuing a RXEN task.
-// Once the radio has ramped up successfully, it is now in the RXIDLE state and triggers a READY
-// interrupt event. To optimize the radio's operation, this driver enables hardware shortcuts such
-// that upon receiving the READY event, the radio chip immediately triggers a START task. The
-// START task notifies the radio to begin officially "listening for packets" (RX state). Upon
-// completing receiving the packet, the radio issues an END event. The driver then determines
-// if the received packet has requested to be acknowledged (bit flag) and sends an ACK accordingly.
-// Finally, the received packet buffer and accompanying fields are passed to the registered radio
-// client. This marks the end of a receive cycle and a new READY event is issued to once again
-// begin listening for packets.
-//
-// When a registered radio client wishes to send a packet. The transmit(...) method is called.
-// To transmit a packet, the radio must first ramp up for receiving and then perform a clear channel assessment
-// by listening for a specified period of time to determine if there is "traffic". If traffic is
-// detected, the radio sets an alarm and waits to perform another CCA after this backoff. If the
-// channel is determined to be clear, the radio then begins a TX ramp up, enters a TX state and then sends
-// the packet. To progress through these states, hardware shortcuts are once again enabled in this driver.
-// The driver first issues a DISABLE task. A hardware shortcut is enabled so that upon receipt of the disable
-// task, the radio automatically issues a RXEN task to enter the RXRU state. Additionally, a shortcut is enabled such that
-// when the RXREADY event is received, the radio automatically issues a CCA_START task. Finally, a shortcut is also
-// enabled such that upon receiving a CCAIDLE event the radio automatically issues a TXEN event to ramp up the
-// radio. The driver then handles receiving the READY interrupt event and triggers the START task to begin
-// sending the packet. Upon completing the sending of the packet, the radio issues an END event, to which
-// the driver then returns the radio to a receiving mode as described above.
-// (For a more complete explanation of the radio's operation, refer to nRF52840_PS_v1.0)
-//
-// This radio state machine provides nine possible states the radio can exist in. For ease of
-// implementation and clarity, this driver also maintains a simplified state machine. These
-// states consist of the radio being off (OFF), receiving (RX), transmitting (TX),
-// or acknowledging (ACK).
-
-// Author: Tyler Potyondy
-// 8/21/23
 
 const RADIO_BASE: StaticRef<RadioRegisters> =
     unsafe { StaticRef::new(0x40001000 as *const RadioRegisters) };

--- a/chips/nrf52840/src/ieee802154_radio.rs
+++ b/chips/nrf52840/src/ieee802154_radio.rs
@@ -1348,7 +1348,7 @@ impl<'a> kernel::hil::radio::RadioData<'a> for Radio<'a> {
         } else if self.busy() {
             return Err((ErrorCode::BUSY, buf));
         } else if buf.len() < radio::PSDU_OFFSET + frame_len + radio::MFR_SIZE {
-            // Not enough room for CRC
+            // Not enough room for CRC or PHR or reserved byte
             return Err((ErrorCode::SIZE, buf));
         }
 

--- a/chips/nrf52840/src/ieee802154_radio.rs
+++ b/chips/nrf52840/src/ieee802154_radio.rs
@@ -1263,9 +1263,9 @@ impl<'a> kernel::hil::radio::RadioConfig<'a> for Radio<'a> {
     fn set_tx_power(&self, tx_power: i8) -> Result<(), ErrorCode> {
         // Convert u8 to TxPower
         match nrf52::constants::TxPower::try_from(tx_power as u8) {
-            // Invalid transmitting power, propogate error
+            // Invalid transmitting power, propagate error
             Err(()) => Err(ErrorCode::NOSUPPORT),
-            // Valid transmitting power, propogate success
+            // Valid transmitting power, propagate success
             Ok(res) => {
                 self.tx_power.set(res);
                 Ok(())
@@ -1294,9 +1294,9 @@ impl<'a> kernel::hil::radio::RadioData<'a> for Radio<'a> {
     ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         if self.tx_buf.is_some() {
             // tx_buf TakeCell is only occupied when a transmission is underway. This
-            // check insures we do not interrupt an ungoing transmission
+            // check insures we do not interrupt an ongoing transmission.
             return Err((ErrorCode::BUSY, buf));
-        } else if radio::PSDU_OFFSET + frame_len >= buf.len() {
+        } else if radio::MFR_SIZE + frame_len >= buf.len() {
             // Not enough room for CRC
             return Err((ErrorCode::SIZE, buf));
         }

--- a/chips/nrf52840/src/ieee802154_radio.rs
+++ b/chips/nrf52840/src/ieee802154_radio.rs
@@ -1181,7 +1181,6 @@ impl<'a> Radio<'a> {
 
 impl<'a> kernel::hil::radio::RadioConfig<'a> for Radio<'a> {
     fn initialize(&self) -> Result<(), ErrorCode> {
-        self.radio_initialize();
         Ok(())
     }
 

--- a/chips/nrf52840/src/ieee802154_radio.rs
+++ b/chips/nrf52840/src/ieee802154_radio.rs
@@ -66,7 +66,7 @@
 use crate::timer::TimerAlarm;
 use core::cell::Cell;
 use kernel::deferred_call::{DeferredCall, DeferredCallClient};
-use kernel::hil::radio::{self, PowerClient, RadioChannel, RadioData};
+use kernel::hil::radio::{self, PowerClient, RadioChannel, RadioConfig, RadioData};
 use kernel::hil::time::{Alarm, AlarmClient, Time};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
@@ -1345,9 +1345,7 @@ impl<'a> kernel::hil::radio::RadioData<'a> for Radio<'a> {
     ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         if self.state.get() == RadioState::OFF {
             return Err((ErrorCode::OFF, buf));
-        } else if self.tx_buf.is_some() {
-            // tx_buf is only occupied when a transmission is underway. This
-            // check insures we do not interrupt an ongoing transmission.
+        } else if self.busy() {
             return Err((ErrorCode::BUSY, buf));
         } else if buf.len() < radio::PSDU_OFFSET + frame_len + radio::MFR_SIZE {
             // Not enough room for CRC

--- a/chips/nrf52840/src/interrupt_service.rs
+++ b/chips/nrf52840/src/interrupt_service.rs
@@ -34,6 +34,7 @@ impl<'a> Nrf52840DefaultPeripherals<'a> {
         self.nrf52.timer0.set_alarm_client(&self.ieee802154_radio);
         self.nrf52.pwr_clk.set_usb_client(&self.usbd);
         self.usbd.set_power_ref(&self.nrf52.pwr_clk);
+        kernel::deferred_call::DeferredCallClient::register(&self.ieee802154_radio);
         self.nrf52.init();
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request is a pass over the nRF52840 15.4 driver. The changes are fairly well encapsulated in commits, but listed here:

- Implement the config and power callbacks with a deferred call.
- Do not enter RX mode on init. RX mode is entered on start(). Otherwise the radio is always on, even if nothing is using it.
- Change constants to defines in the HIL. 
- Remove setting RX and TX addresses as these functions were not doing anything and this support does not exist in the hardware.
- Change the catch for a "too long" packet to just set the 8th bit of the length to 0. This avoids both dropping the packet and any buffer index errors.
- Pass the ACK transmission error to the callback instead of the CRC result. Also rename the CRC variable. Also we know the CRC passed if we sent an ACK, so no need to check in the second RX case.
- Return `OFF` error if try to TX when radio is off.
- Format comments

This required some changes to the constants in the HIL.

- Add `PHR_SIZE` and `PHR_OFFSET`.
- Remove `MIN_MHR_SIZE` as it is incorrect (should be 7, as the minimum PHR is 9, and the MFR is 2, so that leaves 7).
- Add comments.



### Testing Strategy

Need to do this.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
