### PR TITLE
kernel: hil: radio: use standard rx client

### DIFF
--- a/boards/components/src/ieee802154.rs
+++ b/boards/components/src/ieee802154.rs
@@ -301,7 +301,8 @@ impl<
         let radio_rx_buf = static_buffer.7.write([0; radio::MAX_BUF_SIZE]);
         let awake_mac = static_buffer.1.write(AwakeMac::new(self.radio));
         self.radio.set_transmit_client(awake_mac);
-        self.radio.set_receive_client(awake_mac, radio_rx_buf);
+        self.radio.set_receive_client(awake_mac);
+        self.radio.set_receive_buffer(radio_rx_buf);
 
         let radio_rx_crypt_buf = static_buffer.9.write([0; MAX_BUF_SIZE]);
 

--- a/capsules/extra/src/rf233.rs
+++ b/capsules/extra/src/rf233.rs
@@ -1338,9 +1338,8 @@ impl<'a, S: spi::SpiMasterDevice<'a>> radio::RadioData<'a> for RF233<'a, S> {
         self.tx_client.set(client);
     }
 
-    fn set_receive_client(&self, client: &'a dyn radio::RxClient, buffer: &'static mut [u8]) {
+    fn set_receive_client(&self, client: &'a dyn radio::RxClient) {
         self.rx_client.set(client);
-        self.rx_buf.replace(buffer);
     }
 
     fn set_receive_buffer(&self, buffer: &'static mut [u8]) {

--- a/chips/nrf52840/src/ieee802154_radio.rs
+++ b/chips/nrf52840/src/ieee802154_radio.rs
@@ -1280,9 +1280,8 @@ impl<'a> kernel::hil::radio::RadioConfig<'a> for Radio<'a> {
 }
 
 impl<'a> kernel::hil::radio::RadioData<'a> for Radio<'a> {
-    fn set_receive_client(&self, client: &'a dyn radio::RxClient, buffer: &'static mut [u8]) {
+    fn set_receive_client(&self, client: &'a dyn radio::RxClient) {
         self.rx_client.set(client);
-        self.rx_buf.replace(buffer);
     }
 
     fn set_receive_buffer(&self, buffer: &'static mut [u8]) {

--- a/kernel/src/hil/radio.rs
+++ b/kernel/src/hil/radio.rs
@@ -111,7 +111,8 @@ pub trait RadioConfig<'a> {
 
 pub trait RadioData<'a> {
     fn set_transmit_client(&self, client: &'a dyn TxClient);
-    fn set_receive_client(&self, client: &'a dyn RxClient, receive_buffer: &'static mut [u8]);
+    fn set_receive_client(&self, client: &'a dyn RxClient);
+
     fn set_receive_buffer(&self, receive_buffer: &'static mut [u8]);
 
     fn transmit(


### PR DESCRIPTION


### Pull Request Overview

Update the 15.4 HIL to use a RX client that is standard with other HILs. The RX buffer can be set separately.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
