### PR TITLE
bump Rust nightly to nightly-2024-05-23 and set optimize_for_size

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
     "editor.defaultFormatter": "rust-lang.rust-analyzer",
     "editor.formatOnSave": true,
     "rust-analyzer.server.extraEnv": {
-        "RUSTUP_TOOLCHAIN": "nightly-2024-04-19"
+        "RUSTUP_TOOLCHAIN": "nightly-2024-05-26"
     },
     "rust-analyzer.check.allTargets": false,
 }

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -247,11 +247,15 @@ RUSTDOC_FLAGS_TOCK ?= -D warnings
 #   sizes, and makes debugging easier since debug information for the core
 #   library is included in the resulting .elf file. See
 #   https://github.com/tock/tock/pull/2847 for more details.
+# - `optimize_for_size`: Sets a feature flag in the core library that aims to
+#   produce smaller implementations for certain algorithms. See
+#   https://github.com/rust-lang/rust/pull/125011 for more details.
 # - `--document-hidden-items`: Document internal interfaces when building
 #   rustdoc API documentation.
 ifneq ($(USE_STABLE_RUST),1)
   CARGO_FLAGS_TOCK += \
-    -Z build-std=core,compiler_builtins
+    -Z build-std=core,compiler_builtins \
+    -Z build-std-features="core/optimize_for_size"
   RUSTDOC_FLAGS_TOCK += -Z unstable-options --document-hidden-items
 endif
 
@@ -277,7 +281,10 @@ PTMU_ARGS ?=
 
 # `cargo bloat` does not support `-Z build-std`, so we must remove it from cargo
 # flags. See https://github.com/RazrFalcon/cargo-bloat/issues/62.
+# As we aren't building the library we also remove the
+# `-Z build-std-features="core/optimize_for_size"` argument.
 CARGO_FLAGS_TOCK_NO_BUILD_STD := $(filter-out -Z build-std=core,$(CARGO_FLAGS_TOCK))
+CARGO_FLAGS_TOCK_NO_BUILD_STD := $(filter-out -Z build-std-features="core/optimize_for_size",$(CARGO_FLAGS_TOCK))
 
 # Check whether the system already has a sha256sum or shasum application
 # present. If not, use the custom shipped one.

--- a/boards/arty_e21/src/timer_test.rs
+++ b/boards/arty_e21/src/timer_test.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-#![allow(dead_code)]
-
 use kernel::debug;
 use kernel::hil::time::{self, Alarm, Ticks};
 

--- a/capsules/core/src/spi_controller.rs
+++ b/capsules/core/src/spi_controller.rs
@@ -98,7 +98,7 @@ impl<'a, S: SpiMasterDevice<'a>> Spi<'a, S> {
         }
     }
 
-    pub fn config_buffers(&mut self, read: &'static mut [u8], write: &'static mut [u8]) {
+    pub fn config_buffers(&self, read: &'static mut [u8], write: &'static mut [u8]) {
         let len = cmp::min(read.len(), write.len());
         self.kernel_len.set(len);
         self.kernel_read.replace(read);

--- a/capsules/core/src/spi_peripheral.rs
+++ b/capsules/core/src/spi_peripheral.rs
@@ -84,7 +84,7 @@ impl<'a, S: SpiSlaveDevice<'a>> SpiPeripheral<'a, S> {
         }
     }
 
-    pub fn config_buffers(&mut self, read: &'static mut [u8], write: &'static mut [u8]) {
+    pub fn config_buffers(&self, read: &'static mut [u8], write: &'static mut [u8]) {
         let len = cmp::min(read.len(), write.len());
         self.kernel_len.set(len);
         self.kernel_read.replace(read);

--- a/capsules/system/src/process_checker/basic.rs
+++ b/capsules/system/src/process_checker/basic.rs
@@ -191,10 +191,7 @@ impl ClientData<32_usize> for AppCheckerSha256 {
             Ok(()) => {
                 self.binary.set(data.take());
                 let hash: &'static mut [u8; 32_usize] = self.hash.take().unwrap();
-                match self.hasher.verify(hash) {
-                    Err((e, _)) => panic!("Failed invoke hash verification in process credential checking: {:?}", e),
-                    Ok(()) => {},
-                }
+                if let Err((e, _)) = self.hasher.verify(hash) { panic!("Failed invoke hash verification in process credential checking: {:?}", e) }
             }
         }
     }

--- a/capsules/system/src/process_checker/signature.rs
+++ b/capsules/system/src/process_checker/signature.rs
@@ -90,15 +90,14 @@ impl<
                 });
             }
             Ok(()) => {
-                self.hash.take().map(|h| match self.hasher.run(h) {
-                    Err((e, _)) => {
+                self.hash.take().map(|h| {
+                    if let Err((e, _)) = self.hasher.run(h) {
                         self.client.map(|c| {
                             let binary = self.binary.take().unwrap();
                             let cred = self.credentials.take().unwrap();
                             c.check_done(Err(e), cred, binary)
                         });
                     }
-                    Ok(()) => {}
                 });
             }
         }
@@ -124,8 +123,8 @@ impl<
                 });
             }
             Ok(()) => match self.signature.take() {
-                Some(sig) => match self.verifier.verify(digest, sig) {
-                    Err((e, d, s)) => {
+                Some(sig) => {
+                    if let Err((e, d, s)) = self.verifier.verify(digest, sig) {
                         self.hash.replace(d);
                         self.signature.replace(s);
                         self.client.map(|c| {
@@ -134,8 +133,7 @@ impl<
                             c.check_done(Err(e), cred, binary)
                         });
                     }
-                    Ok(()) => {}
-                },
+                }
                 None => {
                     self.hash.replace(digest);
                     self.client.map(|c| {

--- a/chips/stm32f4xx/Cargo.toml
+++ b/chips/stm32f4xx/Cargo.toml
@@ -22,3 +22,9 @@ stm32f401 = []
 stm32f412 = []
 stm32f429 = []
 stm32f446 = []
+
+# These are unused and unsupported
+stm32f410 = []
+stm32f411 = []
+stm32f413 = []
+stm32f423 = []

--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -72,7 +72,7 @@ of installing some of these tools, but you can also install them yourself.
 
 #### Rust (nightly)
 
-We are using `nightly-2024-04-19`. We require
+We are using `nightly-2024-05-26`. We require
 installing it with [rustup](http://www.rustup.rs) so you can manage multiple
 versions of Rust and continue using stable versions for other Rust code:
 
@@ -87,7 +87,7 @@ to your `$PATH`.
 Then install the correct nightly version of Rust:
 
 ```bash
-$ rustup install nightly-2024-04-19
+$ rustup install nightly-2024-05-26
 ```
 
 ### Compiling the Kernel

--- a/kernel/src/collections/ring_buffer.rs
+++ b/kernel/src/collections/ring_buffer.rs
@@ -17,7 +17,7 @@ impl<'a, T: Copy> RingBuffer<'a, T> {
         RingBuffer {
             head: 0,
             tail: 0,
-            ring: ring,
+            ring,
         }
     }
 

--- a/kernel/src/hil/can.rs
+++ b/kernel/src/hil/can.rs
@@ -111,15 +111,15 @@ pub enum Error {
     SetBySoftware,
 }
 
-impl Into<ErrorCode> for Error {
-    fn into(self) -> ErrorCode {
-        match self {
-            Self::ArbitrationLost => ErrorCode::RESERVE,
-            Self::BusOff => ErrorCode::OFF,
-            Self::Form => ErrorCode::INVAL,
-            Self::BitRecessive | Self::BitDominant => ErrorCode::BUSY,
-            Self::Ack | Self::Transmission => ErrorCode::NOACK,
-            Self::Crc | Self::SetBySoftware | Self::Warning | Self::Passive | Self::Stuff => {
+impl From<Error> for ErrorCode {
+    fn from(val: Error) -> Self {
+        match val {
+            Error::ArbitrationLost => ErrorCode::RESERVE,
+            Error::BusOff => ErrorCode::OFF,
+            Error::Form => ErrorCode::INVAL,
+            Error::BitRecessive | Error::BitDominant => ErrorCode::BUSY,
+            Error::Ack | Error::Transmission => ErrorCode::NOACK,
+            Error::Crc | Error::SetBySoftware | Error::Warning | Error::Passive | Error::Stuff => {
                 ErrorCode::FAIL
             }
         }

--- a/kernel/src/hil/i2c.rs
+++ b/kernel/src/hil/i2c.rs
@@ -35,14 +35,14 @@ pub enum Error {
     Busy,
 }
 
-impl Into<ErrorCode> for Error {
-    fn into(self) -> ErrorCode {
-        match self {
-            Self::AddressNak | Self::DataNak => ErrorCode::NOACK,
-            Self::ArbitrationLost => ErrorCode::RESERVE,
-            Self::Overrun => ErrorCode::SIZE,
-            Self::NotSupported => ErrorCode::NOSUPPORT,
-            Self::Busy => ErrorCode::BUSY,
+impl From<Error> for ErrorCode {
+    fn from(val: Error) -> Self {
+        match val {
+            Error::AddressNak | Error::DataNak => ErrorCode::NOACK,
+            Error::ArbitrationLost => ErrorCode::RESERVE,
+            Error::Overrun => ErrorCode::SIZE,
+            Error::NotSupported => ErrorCode::NOSUPPORT,
+            Error::Busy => ErrorCode::BUSY,
         }
     }
 }

--- a/kernel/src/introspection.rs
+++ b/kernel/src/introspection.rs
@@ -29,7 +29,7 @@ pub struct KernelInfo {
 
 impl KernelInfo {
     pub fn new(kernel: &'static Kernel) -> KernelInfo {
-        KernelInfo { kernel: kernel }
+        KernelInfo { kernel }
     }
 
     /// Returns how many processes have been loaded on this platform. This is

--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -37,8 +37,8 @@ impl Region {
     /// Create a new MPU region with a given starting point and length in bytes.
     pub fn new(start_address: *const u8, size: usize) -> Region {
         Region {
-            start_address: start_address,
-            size: size,
+            start_address,
+            size,
         }
     }
 

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -125,9 +125,9 @@ impl ProcessId {
     /// index in the processes array.
     pub(crate) fn new(kernel: &'static Kernel, identifier: usize, index: usize) -> ProcessId {
         ProcessId {
-            kernel: kernel,
-            identifier: identifier,
-            index: index,
+            kernel,
+            index,
+            identifier,
         }
     }
 
@@ -143,9 +143,9 @@ impl ProcessId {
         _capability: &dyn capabilities::ExternalProcessCapability,
     ) -> ProcessId {
         ProcessId {
-            kernel: kernel,
-            identifier: identifier,
-            index: index,
+            kernel,
+            index,
+            identifier,
         }
     }
 

--- a/kernel/src/process_binary.rs
+++ b/kernel/src/process_binary.rs
@@ -144,14 +144,12 @@ impl ProcessBinary {
         // If this isn't an app (i.e. it is padding) then we can skip it and do
         // not create a `ProcessBinary` object.
         if !tbf_header.is_app() {
-            if config::CONFIG.debug_load_processes {
-                if !tbf_header.is_app() {
-                    debug!(
-                        "Padding in flash={:#010X}-{:#010X}",
-                        app_flash.as_ptr() as usize,
-                        app_flash.as_ptr() as usize + app_flash.len() - 1
-                    );
-                }
+            if config::CONFIG.debug_load_processes && !tbf_header.is_app() {
+                debug!(
+                    "Padding in flash={:#010X}-{:#010X}",
+                    app_flash.as_ptr() as usize,
+                    app_flash.as_ptr() as usize + app_flash.len() - 1
+                );
             }
             // Return no process and the full memory slice we were given.
             return Err(ProcessBinaryError::Padding);
@@ -197,20 +195,18 @@ impl ProcessBinary {
                     version: Some((major, minor)),
                 });
             }
-        } else {
-            if require_kernel_version {
-                // If enforcing the kernel version is requested, and the
-                // `KernelVersion` header is not present, we prevent the process
-                // from loading.
-                if config::CONFIG.debug_load_processes {
-                    debug!(
-                        "WARN process {} has no kernel version header",
-                        tbf_header.get_package_name().unwrap_or("")
-                    );
-                    debug!("Please upgrade to elf2tab >= 0.8.0");
-                }
-                return Err(ProcessBinaryError::IncompatibleKernelVersion { version: None });
+        } else if require_kernel_version {
+            // If enforcing the kernel version is requested, and the
+            // `KernelVersion` header is not present, we prevent the process
+            // from loading.
+            if config::CONFIG.debug_load_processes {
+                debug!(
+                    "WARN process {} has no kernel version header",
+                    tbf_header.get_package_name().unwrap_or("")
+                );
+                debug!("Please upgrade to elf2tab >= 0.8.0");
             }
+            return Err(ProcessBinaryError::IncompatibleKernelVersion { version: None });
         }
 
         let binary_end = tbf_header.get_binary_end() as usize;

--- a/kernel/src/process_checker.rs
+++ b/kernel/src/process_checker.rs
@@ -421,7 +421,9 @@ impl AppCredentialsPolicyClient<'static> for ProcessCheckerMachine {
         let cont = match result {
             Ok(CheckResult::Accept) => {
                 self.client.map(|client| {
-                    self.process_binary.take().map(|pb| client.done(pb, Ok(())));
+                    if let Some(pb) = self.process_binary.take() {
+                        client.done(pb, Ok(()))
+                    }
                 });
                 false
             }
@@ -432,14 +434,14 @@ impl AppCredentialsPolicyClient<'static> for ProcessCheckerMachine {
             }
             Ok(CheckResult::Reject) => {
                 self.client.map(|client| {
-                    self.process_binary.take().map(|pb| {
+                    if let Some(pb) = self.process_binary.take() {
                         client.done(
                             pb,
                             Err(ProcessCheckError::CredentialsRejected(
                                 self.footer_index.get() as u32,
                             )),
                         )
-                    });
+                    }
                 });
                 false
             }

--- a/kernel/src/process_loading.rs
+++ b/kernel/src/process_loading.rs
@@ -223,15 +223,18 @@ fn load_processes_from_flash<C: Chip>(
                 match load_result {
                     Ok((new_mem, proc)) => {
                         remaining_memory = new_mem;
-                        if proc.is_some() {
-                            if config::CONFIG.debug_load_processes {
-                                proc.map(|p| debug!("Loaded process {}", p.get_process_name()));
+                        match proc {
+                            Some(p) => {
+                                if config::CONFIG.debug_load_processes {
+                                    debug!("Loaded process {}", p.get_process_name())
+                                }
+                                procs[index] = proc;
+                                index += 1;
                             }
-                            procs[index] = proc;
-                            index += 1;
-                        } else {
-                            if config::CONFIG.debug_load_processes {
-                                debug!("No process loaded.");
+                            None => {
+                                if config::CONFIG.debug_load_processes {
+                                    debug!("No process loaded.");
+                                }
                             }
                         }
                     }
@@ -648,21 +651,43 @@ impl<'a, C: Chip> SequentialProcessLoaderMachine<'a, C> {
         for i in 0..proc_binaries_len {
             // We are either going to load this process binary or discard it, so
             // we can use `take()` here.
-            match proc_binaries[i].take() {
-                Some(process_binary) => {
-                    // We assume the process can be loaded. This is not the case
-                    // if there is a conflicting process.
-                    let mut ok_to_load = true;
+            if let Some(process_binary) = proc_binaries[i].take() {
+                // We assume the process can be loaded. This is not the case
+                // if there is a conflicting process.
+                let mut ok_to_load = true;
 
-                    // Start by iterating all other process binaries and seeing
-                    // if any are in conflict (same AppID with newer version).
-                    for j in 0..proc_binaries_len {
-                        match &proc_binaries[j] {
-                            Some(other_process_binary) => {
-                                let blocked = self.is_blocked_from_loading_by(
-                                    &process_binary,
-                                    other_process_binary,
-                                );
+                // Start by iterating all other process binaries and seeing
+                // if any are in conflict (same AppID with newer version).
+                for j in 0..proc_binaries_len {
+                    match &proc_binaries[j] {
+                        Some(other_process_binary) => {
+                            let blocked = self
+                                .is_blocked_from_loading_by(&process_binary, other_process_binary);
+
+                            if blocked {
+                                ok_to_load = false;
+                                break;
+                            }
+                        }
+                        None => {}
+                    }
+                }
+
+                // Go to next ProcessBinary if we cannot load this process.
+                if !ok_to_load {
+                    continue;
+                }
+
+                // Now scan the already loaded processes and make sure this
+                // doesn't conflict with any of those. Since those processes
+                // are already loaded, we just need to check if this process
+                // binary has the same AppID as an already loaded process.
+                self.procs.map(|procs| {
+                    for proc in procs.iter() {
+                        match proc {
+                            Some(p) => {
+                                let blocked =
+                                    self.is_blocked_from_loading_by_process(&process_binary, *p);
 
                                 if blocked {
                                     ok_to_load = false;
@@ -672,67 +697,40 @@ impl<'a, C: Chip> SequentialProcessLoaderMachine<'a, C> {
                             None => {}
                         }
                     }
+                });
 
-                    // Go to next ProcessBinary if we cannot load this process.
-                    if !ok_to_load {
-                        continue;
-                    }
+                if !ok_to_load {
+                    continue;
+                }
 
-                    // Now scan the already loaded processes and make sure this
-                    // doesn't conflict with any of those. Since those processes
-                    // are already loaded, we just need to check if this process
-                    // binary has the same AppID as an already loaded process.
-                    self.procs.map(|procs| {
-                        for proc in procs.iter() {
-                            match proc {
-                                Some(p) => {
-                                    let blocked = self
-                                        .is_blocked_from_loading_by_process(&process_binary, *p);
+                // If we get here it is ok to load the process.
+                match self.find_open_process_slot() {
+                    Some(index) => {
+                        // Calculate the ShortId for this new process.
+                        let short_app_id = self.policy.map_or(ShortId::LocallyUnique, |policy| {
+                            policy.to_short_id(&process_binary)
+                        });
 
-                                    if blocked {
-                                        ok_to_load = false;
-                                        break;
-                                    }
-                                }
-                                None => {}
-                            }
-                        }
-                    });
-
-                    if !ok_to_load {
-                        continue;
-                    }
-
-                    // If we get here it is ok to load the process.
-                    match self.find_open_process_slot() {
-                        Some(index) => {
-                            // Calculate the ShortId for this new process.
-                            let short_app_id =
-                                self.policy.map_or(ShortId::LocallyUnique, |policy| {
-                                    policy.to_short_id(&process_binary)
-                                });
-
-                            // Try to create a `Process` object.
-                            let load_result = load_process(
-                                self.kernel,
-                                self.chip,
-                                process_binary,
-                                self.app_memory.take(),
-                                short_app_id,
-                                index,
-                                self.fault_policy,
-                            );
-                            match load_result {
-                                Ok((new_mem, proc)) => {
-                                    self.app_memory.set(new_mem);
-                                    if proc.is_some() {
+                        // Try to create a `Process` object.
+                        let load_result = load_process(
+                            self.kernel,
+                            self.chip,
+                            process_binary,
+                            self.app_memory.take(),
+                            short_app_id,
+                            index,
+                            self.fault_policy,
+                        );
+                        match load_result {
+                            Ok((new_mem, proc)) => {
+                                self.app_memory.set(new_mem);
+                                match proc {
+                                    Some(p) => {
                                         if config::CONFIG.debug_load_processes {
-                                            proc.map(|p| {
-                                                debug!(
-                                                    "Loading: Loaded process {}",
-                                                    p.get_process_name()
-                                                )
-                                            });
+                                            debug!(
+                                                "Loading: Loaded process {}",
+                                                p.get_process_name()
+                                            )
                                         }
 
                                         // Store the `ProcessStandard` object in the `PROCESSES`
@@ -745,33 +743,33 @@ impl<'a, C: Chip> SequentialProcessLoaderMachine<'a, C> {
                                         self.client.map(|client| {
                                             client.process_loaded(Ok(()));
                                         });
-                                    } else {
+                                    }
+                                    None => {
                                         if config::CONFIG.debug_load_processes {
                                             debug!("No process loaded.");
                                         }
                                     }
                                 }
-                                Err((new_mem, err)) => {
-                                    self.app_memory.set(new_mem);
-                                    if config::CONFIG.debug_load_processes {
-                                        debug!("Could not load process: {:?}.", err);
-                                    }
-
-                                    self.client.map(|client| {
-                                        client.process_loaded(Err(err));
-                                    });
+                            }
+                            Err((new_mem, err)) => {
+                                self.app_memory.set(new_mem);
+                                if config::CONFIG.debug_load_processes {
+                                    debug!("Could not load process: {:?}.", err);
                                 }
+
+                                self.client.map(|client| {
+                                    client.process_loaded(Err(err));
+                                });
                             }
                         }
-                        None => {
-                            // Nowhere to store the process.
-                            self.client.map(|client| {
-                                client.process_loaded(Err(ProcessLoadError::NoProcessSlot));
-                            });
-                        }
+                    }
+                    None => {
+                        // Nowhere to store the process.
+                        self.client.map(|client| {
+                            client.process_loaded(Err(ProcessLoadError::NoProcessSlot));
+                        });
                     }
                 }
-                None => {}
             }
         }
         self.proc_binaries.put(proc_binaries);

--- a/kernel/src/scheduler/mlfq.rs
+++ b/kernel/src/scheduler/mlfq.rs
@@ -115,17 +115,14 @@ impl<'a, A: 'static + time::Alarm<'static>> MLFQSched<'a, A> {
                 // pop procs to back until we get to match
                 loop {
                     let cur = queue.pop_head();
-                    match cur {
-                        Some(node) => {
-                            if core::ptr::eq(node, next.unwrap()) {
-                                queue.push_head(node);
-                                // match! Put back on front
-                                return (next, idx);
-                            } else {
-                                queue.push_tail(node);
-                            }
+                    if let Some(node) = cur {
+                        if core::ptr::eq(node, next.unwrap()) {
+                            queue.push_head(node);
+                            // match! Put back on front
+                            return (next, idx);
+                        } else {
+                            queue.push_tail(node);
                         }
-                        None => {}
                     }
                 }
             }

--- a/kernel/src/scheduler/priority.rs
+++ b/kernel/src/scheduler/priority.rs
@@ -46,7 +46,7 @@ impl<C: Chip> Scheduler<C> for PrioritySched {
             .kernel
             .get_process_iter()
             .find(|&proc| proc.ready())
-            .map_or(None, |proc| Some(proc.processid()));
+            .map(|proc| proc.processid());
         self.running.insert(next);
 
         next.map_or(SchedulingDecision::TrySleep, |next| {

--- a/kernel/src/storage_permissions.rs
+++ b/kernel/src/storage_permissions.rs
@@ -123,7 +123,7 @@ impl StoragePermissions {
             // If kerneluser, write_id is 0 unless specifically set.
             Some(self.write_id.map_or(0, |wid| wid.get()))
         } else {
-            self.write_id.map_or(None, |wid| Some(wid.get()))
+            self.write_id.map(|wid| wid.get())
         }
     }
 }

--- a/kernel/src/upcall.rs
+++ b/kernel/src/upcall.rs
@@ -123,7 +123,7 @@ impl Upcall {
     /// case we could have `process` be an Option and just do the search with
     /// the stored process_id.
     pub(crate) fn schedule(
-        &mut self,
+        &self,
         process: &dyn process::Process,
         r0: usize,
         r1: usize,

--- a/libraries/enum_primitive/src/cast.rs
+++ b/libraries/enum_primitive/src/cast.rs
@@ -102,8 +102,6 @@ macro_rules! impl_to_primitive_int {
                 fn to_i16 -> i16;
                 fn to_i32 -> i32;
                 fn to_i64 -> i64;
-                #[cfg(has_i128)]
-                fn to_i128 -> i128;
             }
 
             impl_to_primitive_int_to_uint! { $T:
@@ -112,8 +110,6 @@ macro_rules! impl_to_primitive_int {
                 fn to_u16 -> u16;
                 fn to_u32 -> u32;
                 fn to_u64 -> u64;
-                #[cfg(has_i128)]
-                fn to_u128 -> u128;
             }
         }
     };

--- a/libraries/tickv/src/crc32.rs
+++ b/libraries/tickv/src/crc32.rs
@@ -382,7 +382,7 @@ impl Crc32 {
     }
 
     /// Update the CRC based on the data in `bytes`
-    pub fn update(&mut self, bytes: &[u8]) {
+    pub fn update(&self, bytes: &[u8]) {
         self.value.set(self.crc.update(self.value.get(), bytes));
     }
 

--- a/libraries/tickv/src/tickv.rs
+++ b/libraries/tickv/src/tickv.rs
@@ -392,7 +392,7 @@ impl<'a, C: FlashController<S>, const S: usize> TicKV<'a, C, S> {
     /// On error a `ErrorCode` will be returned.
     pub fn append_key(&self, hash: u64, value: &[u8]) -> Result<SuccessCode, ErrorCode> {
         let region = self.get_region(hash);
-        let mut check_sum = crc32::Crc32::new();
+        let check_sum = crc32::Crc32::new();
 
         // Length not including check sum
         let package_length = HEADER_LENGTH + value.len();
@@ -670,7 +670,7 @@ impl<'a, C: FlashController<S>, const S: usize> TicKV<'a, C, S> {
         let mut region_offset: isize = 0;
 
         loop {
-            let mut check_sum = crc32::Crc32::new();
+            let check_sum = crc32::Crc32::new();
             let new_region = match self.state.get() {
                 State::None => (region as isize + region_offset) as usize,
                 State::Init(state) => {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,6 +3,6 @@
 # Copyright Tock Contributors 2023.
 
 [toolchain]
-channel = "nightly-2024-04-19"
+channel = "nightly-2024-05-26"
 components = ["miri", "llvm-tools", "rust-src", "rustfmt", "clippy"]
 targets = ["thumbv6m-none-eabi", "thumbv7em-none-eabi", "thumbv7em-none-eabihf", "riscv32imc-unknown-none-elf", "riscv32imac-unknown-none-elf"]

--- a/tools/netlify-build.sh
+++ b/tools/netlify-build.sh
@@ -17,7 +17,7 @@ set -u
 set -x
 
 # Install rust stuff that we need
-curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2024-04-19
+curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2024-05-26
 
 # And fixup path for the newly installed rust stuff
 export PATH="$PATH:$HOME/.cargo/bin"

--- a/tools/run_clippy.sh
+++ b/tools/run_clippy.sh
@@ -104,6 +104,7 @@ CLIPPY_ARGS_STYLE="
 -A clippy::redundant_pattern_matching
 -A clippy::unusual-byte-groupings
 -A clippy::wrong-self-convention
+-A clippy::doc_lazy_continuation
 "
 
 # Disallow all perf lints, then re-allow each one Tock does not comply with.


### PR DESCRIPTION
### Pull Request Overview

bump Rust nightly to nightly-2024-05-23

Bump to nightly-2024-05-23 of Rust. This includes:
 - a few clippy fixes
 - Removing mut from &mut self that don't need it
 - Removing dead code hidden behind non-existant cfg

Also set a feature flag in the core library that aims to produce smaller implementations for certain algorithms. See https://github.com/rust-lang/rust/pull/125011 for more details.

### Testing Strategy

CI

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
