### PR TITLE
components/console: use snake case for variables

### DIFF
--- a/boards/components/src/console.rs
+++ b/boards/components/src/console.rs
@@ -54,9 +54,9 @@ macro_rules! uart_mux_component_static {
     ($rx_buffer_len: expr) => {{
         use capsules_core::virtualizers::virtual_uart::MuxUart;
         use kernel::static_buf;
-        let UART_MUX = static_buf!(MuxUart<'static>);
-        let RX_BUF = static_buf!([u8; $rx_buffer_len]);
-        (UART_MUX, RX_BUF)
+        let uart_mux = static_buf!(MuxUart<'static>);
+        let rx_buf = static_buf!([u8; $rx_buffer_len]);
+        (uart_mux, rx_buf)
     }};
     () => {
         $crate::uart_mux_component_static!(capsules_core::virtualizers::virtual_uart::RX_BUF_LEN);


### PR DESCRIPTION
### Pull Request Overview

A code path hasn't probably been tested. Entering it would lead to a warning about variables not following snake_case convention. The case is now fixed.


### Testing Strategy

This pull request was tested by passing an argument to the macro, which would trigger warnings before the changes.

### Formatting

- [x] Ran `make prepush`.
