### PR TITLE
stm32f4xx: clocks rework

### DIFF
--- a/boards/nucleo_f429zi/src/io.rs
+++ b/boards/nucleo_f429zi/src/io.rs
@@ -13,6 +13,7 @@ use kernel::hil::led;
 use kernel::hil::uart;
 use kernel::hil::uart::Configure;
 
+use stm32f429zi::chip_specs::Stm32f429Specs;
 use stm32f429zi::gpio::PinId;
 
 use crate::CHIP;
@@ -45,7 +46,9 @@ impl Write for Writer {
 impl IoWrite for Writer {
     fn write(&mut self, buf: &[u8]) -> usize {
         let rcc = stm32f429zi::rcc::Rcc::new();
-        let uart = stm32f429zi::usart::Usart::new_usart3(&rcc);
+        let clocks: stm32f429zi::clocks::Clocks<Stm32f429Specs> =
+            stm32f429zi::clocks::Clocks::new(&rcc);
+        let uart = stm32f429zi::usart::Usart::new_usart3(&clocks);
 
         if !self.initialized {
             self.initialized = true;
@@ -73,10 +76,12 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     // User LD2 is connected to PB07
     // Have to reinitialize several peripherals because otherwise can't access them here.
     let rcc = stm32f429zi::rcc::Rcc::new();
-    let syscfg = stm32f429zi::syscfg::Syscfg::new(&rcc);
+    let clocks: stm32f429zi::clocks::Clocks<Stm32f429Specs> =
+        stm32f429zi::clocks::Clocks::new(&rcc);
+    let syscfg = stm32f429zi::syscfg::Syscfg::new(&clocks);
     let exti = stm32f429zi::exti::Exti::new(&syscfg);
     let pin = stm32f429zi::gpio::Pin::new(PinId::PB07, &exti);
-    let gpio_ports = stm32f429zi::gpio::GpioPorts::new(&rcc, &exti);
+    let gpio_ports = stm32f429zi::gpio::GpioPorts::new(&clocks, &exti);
     pin.set_ports_ref(&gpio_ports);
     let led = &mut led::LedHigh::new(&pin);
 

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -23,6 +23,7 @@ use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
 
+use stm32f429zi::chip_specs::Stm32f429Specs;
 use stm32f429zi::gpio::{AlternateFunction, Mode, PinId, PortId};
 use stm32f429zi::interrupt_service::Stm32f429ziDefaultPeripherals;
 
@@ -320,21 +321,25 @@ unsafe fn start() -> (
 
     // We use the default HSI 16Mhz clock
     let rcc = static_init!(stm32f429zi::rcc::Rcc, stm32f429zi::rcc::Rcc::new());
+    let clocks = static_init!(
+        stm32f429zi::clocks::Clocks<Stm32f429Specs>,
+        stm32f429zi::clocks::Clocks::new(rcc)
+    );
 
     let syscfg = static_init!(
         stm32f429zi::syscfg::Syscfg,
-        stm32f429zi::syscfg::Syscfg::new(rcc)
+        stm32f429zi::syscfg::Syscfg::new(clocks)
     );
     let exti = static_init!(
         stm32f429zi::exti::Exti,
         stm32f429zi::exti::Exti::new(syscfg)
     );
-    let dma1 = static_init!(stm32f429zi::dma::Dma1, stm32f429zi::dma::Dma1::new(rcc));
-    let dma2 = static_init!(stm32f429zi::dma::Dma2, stm32f429zi::dma::Dma2::new(rcc));
+    let dma1 = static_init!(stm32f429zi::dma::Dma1, stm32f429zi::dma::Dma1::new(clocks));
+    let dma2 = static_init!(stm32f429zi::dma::Dma2, stm32f429zi::dma::Dma2::new(clocks));
 
     let peripherals = static_init!(
         Stm32f429ziDefaultPeripherals,
-        Stm32f429ziDefaultPeripherals::new(rcc, exti, dma1, dma2)
+        Stm32f429ziDefaultPeripherals::new(clocks, exti, dma1, dma2)
     );
     peripherals.init();
     let base_peripherals = &peripherals.stm32f4;

--- a/boards/nucleo_f446re/src/io.rs
+++ b/boards/nucleo_f446re/src/io.rs
@@ -12,6 +12,7 @@ use kernel::hil::led;
 use kernel::hil::uart;
 use kernel::hil::uart::Configure;
 
+use stm32f446re::chip_specs::Stm32f446Specs;
 use stm32f446re::gpio::PinId;
 
 use crate::CHIP;
@@ -44,7 +45,9 @@ impl Write for Writer {
 impl IoWrite for Writer {
     fn write(&mut self, buf: &[u8]) -> usize {
         let rcc = stm32f446re::rcc::Rcc::new();
-        let uart = stm32f446re::usart::Usart::new_usart2(&rcc);
+        let clocks: stm32f446re::clocks::Clocks<Stm32f446Specs> =
+            stm32f446re::clocks::Clocks::new(&rcc);
+        let uart = stm32f446re::usart::Usart::new_usart2(&clocks);
 
         if !self.initialized {
             self.initialized = true;
@@ -72,10 +75,12 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     // User LD2 is connected to PA05
     // Have to reinitialize several peripherals because otherwise can't access them here.
     let rcc = stm32f446re::rcc::Rcc::new();
-    let syscfg = stm32f446re::syscfg::Syscfg::new(&rcc);
+    let clocks: stm32f446re::clocks::Clocks<Stm32f446Specs> =
+        stm32f446re::clocks::Clocks::new(&rcc);
+    let syscfg = stm32f446re::syscfg::Syscfg::new(&clocks);
     let exti = stm32f446re::exti::Exti::new(&syscfg);
     let pin = stm32f446re::gpio::Pin::new(PinId::PA05, &exti);
-    let gpio_ports = stm32f446re::gpio::GpioPorts::new(&rcc, &exti);
+    let gpio_ports = stm32f446re::gpio::GpioPorts::new(&clocks, &exti);
     pin.set_ports_ref(&gpio_ports);
     let led = &mut led::LedHigh::new(&pin);
 

--- a/boards/stm32f429idiscovery/src/io.rs
+++ b/boards/stm32f429idiscovery/src/io.rs
@@ -13,6 +13,7 @@ use kernel::hil::led;
 use kernel::hil::uart;
 use kernel::hil::uart::Configure;
 
+use stm32f429zi::chip_specs::Stm32f429Specs;
 use stm32f429zi::gpio::PinId;
 
 use crate::CHIP;
@@ -45,7 +46,9 @@ impl Write for Writer {
 impl IoWrite for Writer {
     fn write(&mut self, buf: &[u8]) -> usize {
         let rcc = stm32f429zi::rcc::Rcc::new();
-        let uart = stm32f429zi::usart::Usart::new_usart1(&rcc);
+        let clocks: stm32f429zi::clocks::Clocks<Stm32f429Specs> =
+            stm32f429zi::clocks::Clocks::new(&rcc);
+        let uart = stm32f429zi::usart::Usart::new_usart1(&clocks);
 
         if !self.initialized {
             self.initialized = true;
@@ -74,10 +77,12 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     // User LD4 is connected to PG14
     // Have to reinitialize several peripherals because otherwise can't access them here.
     let rcc = stm32f429zi::rcc::Rcc::new();
-    let syscfg = stm32f429zi::syscfg::Syscfg::new(&rcc);
+    let clocks: stm32f429zi::clocks::Clocks<Stm32f429Specs> =
+        stm32f429zi::clocks::Clocks::new(&rcc);
+    let syscfg = stm32f429zi::syscfg::Syscfg::new(&clocks);
     let exti = stm32f429zi::exti::Exti::new(&syscfg);
     let pin = stm32f429zi::gpio::Pin::new(PinId::PG14, &exti);
-    let gpio_ports = stm32f429zi::gpio::GpioPorts::new(&rcc, &exti);
+    let gpio_ports = stm32f429zi::gpio::GpioPorts::new(&clocks, &exti);
     pin.set_ports_ref(&gpio_ports);
     let led = &mut led::LedHigh::new(&pin);
 

--- a/boards/stm32f429idiscovery/src/main.rs
+++ b/boards/stm32f429idiscovery/src/main.rs
@@ -23,6 +23,7 @@ use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
 
+use stm32f429zi::chip_specs::Stm32f429Specs;
 use stm32f429zi::gpio::{AlternateFunction, Mode, PinId, PortId};
 use stm32f429zi::interrupt_service::Stm32f429ziDefaultPeripherals;
 
@@ -279,19 +280,23 @@ unsafe fn create_peripherals() -> (
 ) {
     // We use the default HSI 16Mhz clock
     let rcc = static_init!(stm32f429zi::rcc::Rcc, stm32f429zi::rcc::Rcc::new());
+    let clocks = static_init!(
+        stm32f429zi::clocks::Clocks<Stm32f429Specs>,
+        stm32f429zi::clocks::Clocks::new(rcc)
+    );
     let syscfg = static_init!(
         stm32f429zi::syscfg::Syscfg,
-        stm32f429zi::syscfg::Syscfg::new(rcc)
+        stm32f429zi::syscfg::Syscfg::new(clocks)
     );
     let exti = static_init!(
         stm32f429zi::exti::Exti,
         stm32f429zi::exti::Exti::new(syscfg)
     );
-    let dma1 = static_init!(stm32f429zi::dma::Dma1, stm32f429zi::dma::Dma1::new(rcc));
-    let dma2 = static_init!(stm32f429zi::dma::Dma2, stm32f429zi::dma::Dma2::new(rcc));
+    let dma1 = static_init!(stm32f429zi::dma::Dma1, stm32f429zi::dma::Dma1::new(clocks));
+    let dma2 = static_init!(stm32f429zi::dma::Dma2, stm32f429zi::dma::Dma2::new(clocks));
     let peripherals = static_init!(
         Stm32f429ziDefaultPeripherals,
-        Stm32f429ziDefaultPeripherals::new(rcc, exti, dma1, dma2)
+        Stm32f429ziDefaultPeripherals::new(clocks, exti, dma1, dma2)
     );
     (peripherals, syscfg, dma2)
 }

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -23,6 +23,7 @@ use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
 
+use stm32f401cc::chip_specs::Stm32f401Specs;
 use stm32f401cc::interrupt_service::Stm32f401ccDefaultPeripherals;
 
 /// Support routines for debugging I/O.
@@ -224,20 +225,24 @@ unsafe fn create_peripherals() -> (
 ) {
     // We use the default HSI 16Mhz clock
     let rcc = static_init!(stm32f401cc::rcc::Rcc, stm32f401cc::rcc::Rcc::new());
+    let clocks = static_init!(
+        stm32f401cc::clocks::Clocks<Stm32f401Specs>,
+        stm32f401cc::clocks::Clocks::new(rcc)
+    );
     let syscfg = static_init!(
         stm32f401cc::syscfg::Syscfg,
-        stm32f401cc::syscfg::Syscfg::new(rcc)
+        stm32f401cc::syscfg::Syscfg::new(clocks)
     );
     let exti = static_init!(
         stm32f401cc::exti::Exti,
         stm32f401cc::exti::Exti::new(syscfg)
     );
-    let dma1 = static_init!(stm32f401cc::dma::Dma1, stm32f401cc::dma::Dma1::new(rcc));
-    let dma2 = static_init!(stm32f401cc::dma::Dma2, stm32f401cc::dma::Dma2::new(rcc));
+    let dma1 = static_init!(stm32f401cc::dma::Dma1, stm32f401cc::dma::Dma1::new(clocks));
+    let dma2 = static_init!(stm32f401cc::dma::Dma2, stm32f401cc::dma::Dma2::new(clocks));
 
     let peripherals = static_init!(
         Stm32f401ccDefaultPeripherals,
-        Stm32f401ccDefaultPeripherals::new(rcc, exti, dma1, dma2)
+        Stm32f401ccDefaultPeripherals::new(clocks, exti, dma1, dma2)
     );
     (peripherals, syscfg, dma1)
 }

--- a/chips/stm32f401cc/src/interrupt_service.rs
+++ b/chips/stm32f401cc/src/interrupt_service.rs
@@ -12,13 +12,13 @@ pub struct Stm32f401ccDefaultPeripherals<'a> {
 
 impl<'a> Stm32f401ccDefaultPeripherals<'a> {
     pub unsafe fn new(
-        rcc: &'a crate::rcc::Rcc,
+        clocks: &'a crate::clocks::Clocks<'a, Stm32f401Specs>,
         exti: &'a crate::exti::Exti<'a>,
         dma1: &'a crate::dma::Dma1<'a>,
         dma2: &'a crate::dma::Dma2<'a>,
     ) -> Self {
         Self {
-            stm32f4: Stm32f4xxDefaultPeripherals::new(rcc, exti, dma1, dma2),
+            stm32f4: Stm32f4xxDefaultPeripherals::new(clocks, exti, dma1, dma2),
         }
     }
 

--- a/chips/stm32f412g/src/interrupt_service.rs
+++ b/chips/stm32f412g/src/interrupt_service.rs
@@ -15,14 +15,14 @@ pub struct Stm32f412gDefaultPeripherals<'a> {
 
 impl<'a> Stm32f412gDefaultPeripherals<'a> {
     pub unsafe fn new(
-        rcc: &'a crate::rcc::Rcc,
+        clocks: &'a crate::clocks::Clocks<'a, Stm32f412Specs>,
         exti: &'a crate::exti::Exti<'a>,
         dma1: &'a crate::dma::Dma1<'a>,
         dma2: &'a crate::dma::Dma2<'a>,
     ) -> Self {
         Self {
-            stm32f4: Stm32f4xxDefaultPeripherals::new(rcc, exti, dma1, dma2),
-            trng: stm32f4xx::trng::Trng::new(trng_registers::RNG_BASE, rcc),
+            stm32f4: Stm32f4xxDefaultPeripherals::new(clocks, exti, dma1, dma2),
+            trng: stm32f4xx::trng::Trng::new(trng_registers::RNG_BASE, clocks),
         }
     }
     // Necessary for setting up circular dependencies & registering deferred calls

--- a/chips/stm32f429zi/src/interrupt_service.rs
+++ b/chips/stm32f429zi/src/interrupt_service.rs
@@ -17,16 +17,16 @@ pub struct Stm32f429ziDefaultPeripherals<'a> {
 
 impl<'a> Stm32f429ziDefaultPeripherals<'a> {
     pub unsafe fn new(
-        rcc: &'a crate::rcc::Rcc,
+        clocks: &'a crate::clocks::Clocks<'a, Stm32f429Specs>,
         exti: &'a crate::exti::Exti<'a>,
         dma1: &'a crate::dma::Dma1<'a>,
         dma2: &'a crate::dma::Dma2<'a>,
     ) -> Self {
         Self {
-            stm32f4: Stm32f4xxDefaultPeripherals::new(rcc, exti, dma1, dma2),
-            trng: stm32f4xx::trng::Trng::new(trng_registers::RNG_BASE, rcc),
-            can1: stm32f4xx::can::Can::new(rcc, can_registers::CAN1_BASE),
-            rtc: crate::rtc::Rtc::new(rcc),
+            stm32f4: Stm32f4xxDefaultPeripherals::new(clocks, exti, dma1, dma2),
+            trng: stm32f4xx::trng::Trng::new(trng_registers::RNG_BASE, clocks),
+            can1: stm32f4xx::can::Can::new(clocks, can_registers::CAN1_BASE),
+            rtc: crate::rtc::Rtc::new(clocks),
         }
     }
     // Necessary for setting up circular dependencies and registering deferred calls

--- a/chips/stm32f429zi/src/rtc.rs
+++ b/chips/stm32f429zi/src/rtc.rs
@@ -25,8 +25,7 @@ use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 use kernel::utilities::registers::{register_bitfields, ReadWrite};
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
-use stm32f4xx::clocks::Stm32f4Clocks;
-use stm32f4xx::rcc;
+use stm32f4xx::clocks::{phclk, Stm32f4Clocks};
 
 /// Register block to control RTC
 #[repr(C)]
@@ -366,8 +365,8 @@ RTC_BKPXR[
 pub struct Rtc<'a> {
     registers: StaticRef<RtcRegisters>,
     client: OptionalCell<&'a dyn date_time::DateTimeClient>,
-    pub clock: rcc::PeripheralClock<'a>,
-    pub pwr_clock: rcc::PeripheralClock<'a>,
+    pub clock: phclk::PeripheralClock<'a>,
+    pub pwr_clock: phclk::PeripheralClock<'a>,
     time: Cell<DateTimeValues>,
 
     deferred_call: DeferredCall,
@@ -402,8 +401,8 @@ impl<'a> Rtc<'a> {
         Rtc {
             registers: RTC_BASE,
             client: OptionalCell::empty(),
-            clock: rcc::PeripheralClock::new(rcc::PeripheralClockType::RTC, clocks),
-            pwr_clock: rcc::PeripheralClock::new(rcc::PeripheralClockType::PWR, clocks),
+            clock: phclk::PeripheralClock::new(phclk::PeripheralClockType::RTC, clocks),
+            pwr_clock: phclk::PeripheralClock::new(phclk::PeripheralClockType::PWR, clocks),
             time: Cell::new(DateTimeValues {
                 year: 0,
                 month: Month::January,

--- a/chips/stm32f429zi/src/rtc.rs
+++ b/chips/stm32f429zi/src/rtc.rs
@@ -25,6 +25,7 @@ use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 use kernel::utilities::registers::{register_bitfields, ReadWrite};
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
+use stm32f4xx::clocks::Stm32f4Clocks;
 use stm32f4xx::rcc;
 
 /// Register block to control RTC
@@ -397,12 +398,12 @@ const RTC_BASE: StaticRef<RtcRegisters> =
     unsafe { StaticRef::new(0x40002800 as *const RtcRegisters) };
 
 impl<'a> Rtc<'a> {
-    pub fn new(rcc: &'a rcc::Rcc) -> Rtc<'a> {
+    pub fn new(clocks: &'a dyn Stm32f4Clocks) -> Rtc<'a> {
         Rtc {
             registers: RTC_BASE,
             client: OptionalCell::empty(),
-            clock: rcc::PeripheralClock::new(rcc::PeripheralClockType::RTC, rcc),
-            pwr_clock: rcc::PeripheralClock::new(rcc::PeripheralClockType::PWR, rcc),
+            clock: rcc::PeripheralClock::new(rcc::PeripheralClockType::RTC, clocks),
+            pwr_clock: rcc::PeripheralClock::new(rcc::PeripheralClockType::PWR, clocks),
             time: Cell::new(DateTimeValues {
                 year: 0,
                 month: Month::January,

--- a/chips/stm32f446re/src/interrupt_service.rs
+++ b/chips/stm32f446re/src/interrupt_service.rs
@@ -12,13 +12,13 @@ pub struct Stm32f446reDefaultPeripherals<'a> {
 
 impl<'a> Stm32f446reDefaultPeripherals<'a> {
     pub unsafe fn new(
-        rcc: &'a crate::rcc::Rcc,
+        clocks: &'a crate::clocks::Clocks<'a, Stm32f446Specs>,
         exti: &'a crate::exti::Exti<'a>,
         dma1: &'a crate::dma::Dma1<'a>,
         dma2: &'a crate::dma::Dma2<'a>,
     ) -> Self {
         Self {
-            stm32f4: Stm32f4xxDefaultPeripherals::new(rcc, exti, dma1, dma2),
+            stm32f4: Stm32f4xxDefaultPeripherals::new(clocks, exti, dma1, dma2),
         }
     }
     // Necessary for setting up circular dependencies & registering deferred

--- a/chips/stm32f4xx/src/adc.rs
+++ b/chips/stm32f4xx/src/adc.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
+use crate::clocks::clocks::Stm32f4Clocks;
 use crate::rcc;
 use core::cell::Cell;
 use kernel::hil;
@@ -314,13 +315,13 @@ pub struct Adc<'a> {
 }
 
 impl<'a> Adc<'a> {
-    pub const fn new(rcc: &'a rcc::Rcc) -> Adc {
+    pub const fn new(clocks: &'a dyn Stm32f4Clocks) -> Adc {
         Adc {
             registers: ADC1_BASE,
             common_registers: ADC_COMMON_BASE,
             clock: AdcClock(rcc::PeripheralClock::new(
                 rcc::PeripheralClockType::APB2(rcc::PCLK2::ADC1),
-                rcc,
+                clocks,
             )),
             status: Cell::new(ADCStatus::Off),
             client: OptionalCell::empty(),

--- a/chips/stm32f4xx/src/adc.rs
+++ b/chips/stm32f4xx/src/adc.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use crate::clocks::clocks::Stm32f4Clocks;
-use crate::rcc;
+use crate::clocks::{phclk, Stm32f4Clocks};
 use core::cell::Cell;
 use kernel::hil;
 use kernel::platform::chip::ClockInterface;
@@ -319,8 +318,8 @@ impl<'a> Adc<'a> {
         Adc {
             registers: ADC1_BASE,
             common_registers: ADC_COMMON_BASE,
-            clock: AdcClock(rcc::PeripheralClock::new(
-                rcc::PeripheralClockType::APB2(rcc::PCLK2::ADC1),
+            clock: AdcClock(phclk::PeripheralClock::new(
+                phclk::PeripheralClockType::APB2(phclk::PCLK2::ADC1),
                 clocks,
             )),
             status: Cell::new(ADCStatus::Off),
@@ -370,7 +369,7 @@ impl<'a> Adc<'a> {
     }
 }
 
-struct AdcClock<'a>(rcc::PeripheralClock<'a>);
+struct AdcClock<'a>(phclk::PeripheralClock<'a>);
 
 impl ClockInterface for AdcClock<'_> {
     fn is_enabled(&self) -> bool {

--- a/chips/stm32f4xx/src/can.rs
+++ b/chips/stm32f4xx/src/can.rs
@@ -8,6 +8,7 @@
 //! Low-level CAN driver for STM32F4XX chips
 //!
 
+use crate::clocks::Stm32f4Clocks;
 use crate::rcc;
 use core::cell::Cell;
 use kernel::deferred_call::{DeferredCall, DeferredCallClient};
@@ -472,12 +473,12 @@ pub struct Can<'a> {
 }
 
 impl<'a> Can<'a> {
-    pub fn new(rcc: &'a rcc::Rcc, registers: StaticRef<Registers>) -> Can<'a> {
+    pub fn new(clocks: &'a dyn Stm32f4Clocks, registers: StaticRef<Registers>) -> Can<'a> {
         Can {
             registers: registers,
             clock: CanClock(rcc::PeripheralClock::new(
                 rcc::PeripheralClockType::APB1(rcc::PCLK1::CAN1),
-                rcc,
+                clocks,
             )),
             can_state: Cell::new(CanState::Sleep),
             error_interrupt_counter: Cell::new(0),

--- a/chips/stm32f4xx/src/can.rs
+++ b/chips/stm32f4xx/src/can.rs
@@ -8,8 +8,7 @@
 //! Low-level CAN driver for STM32F4XX chips
 //!
 
-use crate::clocks::Stm32f4Clocks;
-use crate::rcc;
+use crate::clocks::{phclk, Stm32f4Clocks};
 use core::cell::Cell;
 use kernel::deferred_call::{DeferredCall, DeferredCallClient};
 use kernel::hil::can::{self, StandardBitTiming};
@@ -476,8 +475,8 @@ impl<'a> Can<'a> {
     pub fn new(clocks: &'a dyn Stm32f4Clocks, registers: StaticRef<Registers>) -> Can<'a> {
         Can {
             registers: registers,
-            clock: CanClock(rcc::PeripheralClock::new(
-                rcc::PeripheralClockType::APB1(rcc::PCLK1::CAN1),
+            clock: CanClock(phclk::PeripheralClock::new(
+                phclk::PeripheralClockType::APB1(phclk::PCLK1::CAN1),
                 clocks,
             )),
             can_state: Cell::new(CanState::Sleep),
@@ -1114,7 +1113,7 @@ impl DeferredCallClient for Can<'_> {
     }
 }
 
-struct CanClock<'a>(rcc::PeripheralClock<'a>);
+struct CanClock<'a>(phclk::PeripheralClock<'a>);
 
 impl ClockInterface for CanClock<'_> {
     fn is_enabled(&self) -> bool {

--- a/chips/stm32f4xx/src/chip.rs
+++ b/chips/stm32f4xx/src/chip.rs
@@ -66,8 +66,10 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Stm32f4xxDefaultPeripherals<'a, ChipSpecs> {
             i2c1: crate::i2c::I2C::new(clocks),
             spi3: crate::spi::Spi::new(
                 crate::spi::SPI3_BASE,
-                crate::spi::SpiClock(crate::rcc::PeripheralClock::new(
-                    crate::rcc::PeripheralClockType::APB1(crate::rcc::PCLK1::SPI3),
+                crate::spi::SpiClock(crate::clocks::phclk::PeripheralClock::new(
+                    crate::clocks::phclk::PeripheralClockType::APB1(
+                        crate::clocks::phclk::PCLK1::SPI3,
+                    ),
                     clocks,
                 )),
                 dma::Dma1Peripheral::SPI3_TX,

--- a/chips/stm32f4xx/src/chip.rs
+++ b/chips/stm32f4xx/src/chip.rs
@@ -30,7 +30,7 @@ pub struct Stm32f4xxDefaultPeripherals<'a, ChipSpecs> {
     pub fsmc: crate::fsmc::Fsmc<'a>,
     pub gpio_ports: crate::gpio::GpioPorts<'a>,
     pub i2c1: crate::i2c::I2C<'a>,
-    pub clocks: crate::clocks::Clocks<'a, ChipSpecs>,
+    pub clocks: &'a crate::clocks::Clocks<'a, ChipSpecs>,
     pub spi3: crate::spi::Spi<'a>,
     pub tim2: crate::tim2::Tim2<'a>,
     pub usart1: crate::usart::Usart<'a, dma::Dma2<'a>>,
@@ -40,15 +40,15 @@ pub struct Stm32f4xxDefaultPeripherals<'a, ChipSpecs> {
 
 impl<'a, ChipSpecs: ChipSpecsTrait> Stm32f4xxDefaultPeripherals<'a, ChipSpecs> {
     pub fn new(
-        rcc: &'a crate::rcc::Rcc,
+        clocks: &'a crate::clocks::Clocks<'a, ChipSpecs>,
         exti: &'a crate::exti::Exti<'a>,
         dma1: &'a dma::Dma1<'a>,
         dma2: &'a dma::Dma2<'a>,
     ) -> Self {
         Self {
-            adc1: crate::adc::Adc::new(rcc),
-            clocks: crate::clocks::Clocks::new(rcc),
-            dac: crate::dac::Dac::new(rcc),
+            adc1: crate::adc::Adc::new(clocks),
+            clocks,
+            dac: crate::dac::Dac::new(clocks),
             dma1_streams: dma::new_dma1_stream(dma1),
             dma2_streams: dma::new_dma2_stream(dma2),
             exti,
@@ -60,23 +60,23 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Stm32f4xxDefaultPeripherals<'a, ChipSpecs> {
                     Some(crate::fsmc::FSMC_BANK3),
                     None,
                 ],
-                rcc,
+                clocks,
             ),
-            gpio_ports: crate::gpio::GpioPorts::new(rcc, exti),
-            i2c1: crate::i2c::I2C::new(rcc),
+            gpio_ports: crate::gpio::GpioPorts::new(clocks, exti),
+            i2c1: crate::i2c::I2C::new(clocks),
             spi3: crate::spi::Spi::new(
                 crate::spi::SPI3_BASE,
                 crate::spi::SpiClock(crate::rcc::PeripheralClock::new(
                     crate::rcc::PeripheralClockType::APB1(crate::rcc::PCLK1::SPI3),
-                    rcc,
+                    clocks,
                 )),
                 dma::Dma1Peripheral::SPI3_TX,
                 dma::Dma1Peripheral::SPI3_RX,
             ),
-            tim2: crate::tim2::Tim2::new(rcc),
-            usart1: crate::usart::Usart::new_usart1(rcc),
-            usart2: crate::usart::Usart::new_usart2(rcc),
-            usart3: crate::usart::Usart::new_usart3(rcc),
+            tim2: crate::tim2::Tim2::new(clocks),
+            usart1: crate::usart::Usart::new_usart1(clocks),
+            usart2: crate::usart::Usart::new_usart2(clocks),
+            usart3: crate::usart::Usart::new_usart3(clocks),
         }
     }
 

--- a/chips/stm32f4xx/src/clocks/clocks.rs
+++ b/chips/stm32f4xx/src/clocks/clocks.rs
@@ -43,7 +43,7 @@
 //! ## Retrieve the AHB frequency:
 //!
 //! ```rust,ignore
-//! let ahb_frequency = clocks.get_ahb_frequency();
+//! let ahb_frequency = clocks.get_ahb_frequency_mhz();
 //! debug!("Current AHB frequency is {}MHz", ahb_frequency);
 //! ```
 //!
@@ -78,7 +78,7 @@
 //! ## Retrieve the system clock frequency:
 //!
 //! ```rust,ignore
-//! let sys_frequency = clocks.get_sys_clock_frequency();
+//! let sys_frequency = clocks.get_sys_clock_frequency_mhz();
 //! debug!("Current system clock frequency is {}MHz", sys_frequency);
 //! ```
 //!
@@ -102,7 +102,7 @@
 //!
 //! Then, configure its frequency and enable it
 //! ```rust,ignore
-//! pll.set_frequency(50);
+//! pll.set_frequency_mhz(50);
 //! pll.enable();
 //! ```
 //!
@@ -126,7 +126,7 @@
 //! As before, Pll clock is configured and enabled.
 //!
 //! ```rust,ignore
-//! pll.set_frequency(100);
+//! pll.set_frequency_mhz(100);
 //! pll.enable();
 //! ```
 //!
@@ -215,7 +215,7 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
         // Changing the AHB prescaler affects the APB frequencies. A check must be done to ensure
         // that the constraints are still valid
         let divider: usize = prescaler.into();
-        let new_ahb_frequency = self.get_sys_clock_frequency() / divider;
+        let new_ahb_frequency = self.get_sys_clock_frequency_mhz() / divider;
         if !self.check_apb1_frequency_limit(new_ahb_frequency)
             || !self.check_apb2_frequency_limit(new_ahb_frequency)
         {
@@ -239,9 +239,9 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
     }
 
     /// Get the frequency of the AHB
-    pub fn get_ahb_frequency(&self) -> usize {
+    pub fn get_ahb_frequency_mhz(&self) -> usize {
         let ahb_divider: usize = self.get_ahb_prescaler().into();
-        self.get_sys_clock_frequency() / ahb_divider
+        self.get_sys_clock_frequency_mhz() / ahb_divider
     }
 
     // APB1 frequency must not be higher than the maximum allowable frequency. This method is
@@ -263,7 +263,7 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
     /// + [Err]\([ErrorCode::FAIL]\) if the desired prescaler would break the APB1 frequency limit
     /// + [Err]\([ErrorCode::BUSY]\) if setting the prescaler took too long. Retry.
     pub fn set_apb1_prescaler(&self, prescaler: APBPrescaler) -> Result<(), ErrorCode> {
-        let ahb_frequency = self.get_ahb_frequency();
+        let ahb_frequency = self.get_ahb_frequency_mhz();
         let divider: usize = prescaler.into();
         if ahb_frequency / divider > ChipSpecs::APB1_FREQUENCY_LIMIT_MHZ {
             return Err(ErrorCode::FAIL);
@@ -286,10 +286,10 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
     }
 
     /// Get the current APB1 frequency
-    pub fn get_apb1_frequency(&self) -> usize {
+    pub fn get_apb1_frequency_mhz(&self) -> usize {
         // Every enum variant can be converted into a usize
         let divider: usize = self.rcc.get_apb1_prescaler().into();
-        self.get_ahb_frequency() / divider
+        self.get_ahb_frequency_mhz() / divider
     }
 
     // Same as for APB1, APB2 has a frequency limit that must be enforced by software
@@ -309,7 +309,7 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
     /// + [Err]\([ErrorCode::FAIL]\) if the desired prescaler would break the APB2 frequency limit
     /// + [Err]\([ErrorCode::BUSY]\) if setting the prescaler took too long. Retry.
     pub fn set_apb2_prescaler(&self, prescaler: APBPrescaler) -> Result<(), ErrorCode> {
-        let current_ahb_frequency = self.get_ahb_frequency();
+        let current_ahb_frequency = self.get_ahb_frequency_mhz();
         let divider: usize = prescaler.into();
         if current_ahb_frequency / divider > ChipSpecs::APB2_FREQUENCY_LIMIT_MHZ {
             return Err(ErrorCode::FAIL);
@@ -332,10 +332,10 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
     }
 
     /// Get the current APB2 frequency
-    pub fn get_apb2_frequency(&self) -> usize {
+    pub fn get_apb2_frequency_mhz(&self) -> usize {
         // Every enum variant can be converted into a usize
         let divider: usize = self.rcc.get_apb2_prescaler().into();
-        self.get_ahb_frequency() / divider
+        self.get_ahb_frequency_mhz() / divider
     }
 
     /// Set the system clock source
@@ -362,14 +362,14 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
             return Err(ErrorCode::FAIL);
         }
 
-        let current_frequency = self.get_sys_clock_frequency();
+        let current_frequency = self.get_sys_clock_frequency_mhz();
 
         // Get the frequency of the source to be configured
         let alternate_frequency = match source {
             // The unwrap can't fail because the source clock status was checked before
-            SysClockSource::HSI => self.hsi.get_frequency().unwrap(),
-            SysClockSource::HSE => self.hse.get_frequency().unwrap(),
-            SysClockSource::PLL => self.pll.get_frequency().unwrap(),
+            SysClockSource::HSI => self.hsi.get_frequency_mhz().unwrap(),
+            SysClockSource::HSE => self.hse.get_frequency_mhz().unwrap(),
+            SysClockSource::PLL => self.pll.get_frequency_mhz().unwrap(),
         };
 
         // Check the alternate frequency is not higher than the system clock limit
@@ -420,15 +420,15 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
         self.rcc.get_sys_clock_source()
     }
 
-    /// Get the current system clock frequency
-    pub fn get_sys_clock_frequency(&self) -> usize {
+    /// Get the current system clock frequency in MHz
+    pub fn get_sys_clock_frequency_mhz(&self) -> usize {
         match self.get_sys_clock_source() {
             // These unwraps can't panic because set_sys_clock_frequency ensures that the source is
             // enabled. Also, Hsi and Pll structs ensure that the clocks can't be disabled when
             // they are configured as the system clock
-            SysClockSource::HSI => self.hsi.get_frequency().unwrap(),
-            SysClockSource::HSE => self.hse.get_frequency().unwrap(),
-            SysClockSource::PLL => self.pll.get_frequency().unwrap(),
+            SysClockSource::HSI => self.hsi.get_frequency_mhz().unwrap(),
+            SysClockSource::HSE => self.hse.get_frequency_mhz().unwrap(),
+            SysClockSource::PLL => self.pll.get_frequency_mhz().unwrap(),
         }
     }
 
@@ -445,17 +445,17 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
     ///
     /// + [Err]\([ErrorCode::INVAL]\): if the desired frequency can't be achieved
     /// + [Err]\([ErrorCode::FAIL]\): if the PLL clock is already enabled. It must be disabled before
-    pub fn set_pll_frequency(
+    pub fn set_pll_frequency_mhz(
         &self,
         pll_source: PllSource,
         desired_frequency_mhz: usize,
     ) -> Result<(), ErrorCode> {
         let source_frequency = match pll_source {
             PllSource::HSI => HSI_FREQUENCY_MHZ,
-            PllSource::HSE => self.hse.get_frequency().unwrap(),
+            PllSource::HSE => self.hse.get_frequency_mhz().unwrap(),
         };
         self.pll
-            .set_frequency(pll_source, source_frequency, desired_frequency_mhz)
+            .set_frequency_mhz(pll_source, source_frequency, desired_frequency_mhz)
     }
 
     /// Set the clock source for the microcontroller clock output 1 (MCO1)
@@ -622,9 +622,9 @@ pub mod tests {
         assert_eq!(Ok(()), clocks.set_ahb_prescaler(AHBPrescaler::DivideBy1));
         assert_eq!(Ok(()), clocks.set_apb1_prescaler(APBPrescaler::DivideBy1));
         assert_eq!(Ok(()), clocks.set_apb2_prescaler(APBPrescaler::DivideBy1));
-        assert_eq!(HSI_FREQUENCY_MHZ, clocks.get_sys_clock_frequency());
-        assert_eq!(HSI_FREQUENCY_MHZ, clocks.get_apb1_frequency());
-        assert_eq!(HSI_FREQUENCY_MHZ, clocks.get_apb2_frequency());
+        assert_eq!(HSI_FREQUENCY_MHZ, clocks.get_sys_clock_frequency_mhz());
+        assert_eq!(HSI_FREQUENCY_MHZ, clocks.get_apb1_frequency_mhz());
+        assert_eq!(HSI_FREQUENCY_MHZ, clocks.get_apb2_frequency_mhz());
     }
 
     // This macro ensure that the system clock frequency goes back to the default value to prevent
@@ -664,7 +664,7 @@ pub mod tests {
             Ok(()),
             clocks
                 .pll
-                .set_frequency(PllSource::HSI, HSI_FREQUENCY_MHZ, HIGH_FREQUENCY),
+                .set_frequency_mhz(PllSource::HSI, HSI_FREQUENCY_MHZ, HIGH_FREQUENCY),
             clocks
         );
         check_and_panic!(Ok(()), clocks.pll.enable(), clocks);
@@ -764,19 +764,23 @@ pub mod tests {
         check_and_panic!(SysClockSource::HSI, clocks.get_sys_clock_source(), clocks);
 
         // HSI frequency is 16MHz
-        check_and_panic!(HSI_FREQUENCY_MHZ, clocks.get_sys_clock_frequency(), clocks);
+        check_and_panic!(
+            HSI_FREQUENCY_MHZ,
+            clocks.get_sys_clock_frequency_mhz(),
+            clocks
+        );
 
         // APB1 default prescaler is 1
         check_and_panic!(APBPrescaler::DivideBy1, clocks.get_apb1_prescaler(), clocks);
 
         // APB1 default frequency is 16MHz
-        check_and_panic!(HSI_FREQUENCY_MHZ, clocks.get_apb1_frequency(), clocks);
+        check_and_panic!(HSI_FREQUENCY_MHZ, clocks.get_apb1_frequency_mhz(), clocks);
 
         // APB2 default prescaler is 1
         check_and_panic!(APBPrescaler::DivideBy1, clocks.get_apb1_prescaler(), clocks);
 
         // APB2 default frequency is 16MHz
-        check_and_panic!(HSI_FREQUENCY_MHZ, clocks.get_apb2_frequency(), clocks);
+        check_and_panic!(HSI_FREQUENCY_MHZ, clocks.get_apb2_frequency_mhz(), clocks);
 
         // Attempting to change the system clock source with a disabled source
         check_and_panic!(
@@ -798,7 +802,7 @@ pub mod tests {
             Ok(()),
             clocks
                 .pll
-                .set_frequency(PllSource::HSI, HSI_FREQUENCY_MHZ, LOW_FREQUENCY),
+                .set_frequency_mhz(PllSource::HSI, HSI_FREQUENCY_MHZ, LOW_FREQUENCY),
             clocks
         );
         check_and_panic!(Ok(()), clocks.pll.enable(), clocks);
@@ -810,11 +814,11 @@ pub mod tests {
         check_and_panic!(SysClockSource::PLL, clocks.get_sys_clock_source(), clocks);
 
         // Now the system clock frequency is equal to 25MHz
-        check_and_panic!(LOW_FREQUENCY, clocks.get_sys_clock_frequency(), clocks);
+        check_and_panic!(LOW_FREQUENCY, clocks.get_sys_clock_frequency_mhz(), clocks);
 
         // APB1 and APB2 frequencies must also be 25MHz
-        check_and_panic!(LOW_FREQUENCY, clocks.get_apb1_frequency(), clocks);
-        check_and_panic!(LOW_FREQUENCY, clocks.get_apb2_frequency(), clocks);
+        check_and_panic!(LOW_FREQUENCY, clocks.get_apb1_frequency_mhz(), clocks);
+        check_and_panic!(LOW_FREQUENCY, clocks.get_apb2_frequency_mhz(), clocks);
 
         // Attempting to disable PLL when it is configured as the system clock must fail
         check_and_panic!(Err(ErrorCode::FAIL), clocks.pll.disable(), clocks);
@@ -832,7 +836,7 @@ pub mod tests {
             Ok(()),
             clocks
                 .pll
-                .set_frequency(PllSource::HSI, HSI_FREQUENCY_MHZ, HIGH_FREQUENCY),
+                .set_frequency_mhz(PllSource::HSI, HSI_FREQUENCY_MHZ, HIGH_FREQUENCY),
             clocks
         );
         check_and_panic!(Ok(()), clocks.pll.enable(), clocks);
@@ -896,8 +900,8 @@ pub mod tests {
             clocks.set_sys_clock_source(SysClockSource::PLL),
             clocks
         );
-        check_and_panic!(HIGH_FREQUENCY / 4, clocks.get_apb1_frequency(), clocks);
-        check_and_panic!(HIGH_FREQUENCY / 2, clocks.get_apb2_frequency(), clocks);
+        check_and_panic!(HIGH_FREQUENCY / 4, clocks.get_apb1_frequency_mhz(), clocks);
+        check_and_panic!(HIGH_FREQUENCY / 2, clocks.get_apb2_frequency_mhz(), clocks);
 
         // Revert to default system clock configuration
         set_default_configuration(clocks);
@@ -914,9 +918,9 @@ pub mod tests {
             clocks.set_sys_clock_source(SysClockSource::PLL),
             clocks
         );
-        check_and_panic!(HIGH_FREQUENCY / 4, clocks.get_ahb_frequency(), clocks);
-        check_and_panic!(HIGH_FREQUENCY / 4, clocks.get_apb1_frequency(), clocks);
-        check_and_panic!(HIGH_FREQUENCY / 4, clocks.get_apb2_frequency(), clocks);
+        check_and_panic!(HIGH_FREQUENCY / 4, clocks.get_ahb_frequency_mhz(), clocks);
+        check_and_panic!(HIGH_FREQUENCY / 4, clocks.get_apb1_frequency_mhz(), clocks);
+        check_and_panic!(HIGH_FREQUENCY / 4, clocks.get_apb2_frequency_mhz(), clocks);
 
         // Revert to default configuration
         set_default_configuration(clocks);

--- a/chips/stm32f4xx/src/clocks/clocks.rs
+++ b/chips/stm32f4xx/src/clocks/clocks.rs
@@ -186,7 +186,7 @@ pub struct Clocks<'a, ChipSpecs> {
 
 impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
     // The constructor must be called when the default peripherals are created
-    pub(crate) fn new(rcc: &'a Rcc) -> Self {
+    pub fn new(rcc: &'a Rcc) -> Self {
         Self {
             rcc,
             flash: OptionalCell::empty(),
@@ -512,6 +512,23 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
     /// Get MCO1 divider
     pub fn get_mco1_clock_divider(&self) -> MCO1Divider {
         self.rcc.get_mco1_clock_divider()
+    }
+}
+
+/// Stm32f4Clocks trait
+///
+/// This can be used to control clocks without the need to keep a reference of the chip specific
+/// Clocks struct, for instance by peripherals
+pub trait Stm32f4Clocks {
+    /// Get RCC instance
+    fn get_rcc(&self) -> &Rcc;
+
+    // Extend this to expose additional clock resources
+}
+
+impl<'a, ChipSpecs: ChipSpecsTrait> Stm32f4Clocks for Clocks<'a, ChipSpecs> {
+    fn get_rcc(&self) -> &'a Rcc {
+        self.rcc
     }
 }
 

--- a/chips/stm32f4xx/src/clocks/hse.rs
+++ b/chips/stm32f4xx/src/clocks/hse.rs
@@ -22,7 +22,7 @@
 //!
 //! ## Set the clock frequency
 //! ```rust,ignore
-//! hse.set_frequency(8);
+//! hse.set_frequency_mhz(8);
 //! ```
 //!
 //! ## Stop the clock
@@ -42,7 +42,7 @@
 //!
 //! ## Get the frequency of the clock
 //! ```rust,ignore
-//! let hse_frequency_mhz = hse.get_frequency().unwrap();
+//! let hse_frequency_mhz = hse.get_frequency_mhz().unwrap();
 //! ```
 //!
 //! [^doc_ref]: See 6.2.1 in the documentation.
@@ -57,7 +57,7 @@ use kernel::ErrorCode;
 /// Main HSE clock structure
 pub struct Hse<'a> {
     rcc: &'a Rcc,
-    hse_frequency: OptionalCell<usize>,
+    hse_frequency_mhz: OptionalCell<usize>,
 }
 
 impl<'a> Hse<'a> {
@@ -73,7 +73,7 @@ impl<'a> Hse<'a> {
     pub(in crate::clocks) fn new(rcc: &'a Rcc) -> Self {
         Self {
             rcc,
-            hse_frequency: OptionalCell::empty(),
+            hse_frequency_mhz: OptionalCell::empty(),
         }
     }
 
@@ -137,9 +137,9 @@ impl<'a> Hse<'a> {
     ///
     /// + [Some]\(frequency_mhz\): if the HSE clock is enabled.
     /// + [None]: if the HSE clock is disabled.
-    pub fn get_frequency(&self) -> Option<usize> {
+    pub fn get_frequency_mhz(&self) -> Option<usize> {
         if self.is_enabled() {
-            self.hse_frequency.get()
+            self.hse_frequency_mhz.get()
         } else {
             None
         }
@@ -150,8 +150,8 @@ impl<'a> Hse<'a> {
     /// # Parameters
     ///
     /// + frequency: HSE frequency in MHz
-    pub fn set_frequency(&self, frequency: usize) {
-        self.hse_frequency.set(frequency);
+    pub fn set_frequency_mhz(&self, frequency: usize) {
+        self.hse_frequency_mhz.set(frequency);
     }
 }
 
@@ -197,13 +197,13 @@ pub mod tests {
         assert!(!hse.is_enabled());
 
         // HSE frequency is None
-        assert_eq!(None, hse.get_frequency());
+        assert_eq!(None, hse.get_frequency_mhz());
 
         // HSE should be enabled
         assert_eq!(Ok(()), hse.enable(HseMode::BYPASS));
 
         // HSE frequency is 8MHz
-        assert_eq!(Some(8), hse.get_frequency());
+        assert_eq!(Some(8), hse.get_frequency_mhz());
 
         // Nothing should happen if the HSE clock is being enabled when already running
         assert_eq!(Ok(()), hse.enable(HseMode::BYPASS));

--- a/chips/stm32f4xx/src/clocks/hsi.rs
+++ b/chips/stm32f4xx/src/clocks/hsi.rs
@@ -128,7 +128,7 @@ impl<'a> Hsi<'a> {
     ///
     /// + [Some]\(frequency_mhz\): if the HSI clock is enabled.
     /// + [None]: if the HSI clock is disabled.
-    pub fn get_frequency(&self) -> Option<usize> {
+    pub fn get_frequency_mhz(&self) -> Option<usize> {
         if self.is_enabled() {
             Some(HSI_FREQUENCY_MHZ)
         } else {
@@ -179,7 +179,7 @@ pub mod tests {
         assert!(hsi.is_enabled());
 
         // HSI frequency is 16MHz
-        assert_eq!(Some(HSI_FREQUENCY_MHZ), hsi.get_frequency());
+        assert_eq!(Some(HSI_FREQUENCY_MHZ), hsi.get_frequency_mhz());
 
         // Nothing should happen if the HSI clock is being enabled when already running
         assert_eq!(Ok(()), hsi.enable());

--- a/chips/stm32f4xx/src/clocks/mod.rs
+++ b/chips/stm32f4xx/src/clocks/mod.rs
@@ -10,4 +10,4 @@ pub mod hsi;
 pub mod pll;
 
 pub use crate::clocks::clocks::tests;
-pub use crate::clocks::clocks::Clocks;
+pub use crate::clocks::clocks::{Clocks, Stm32f4Clocks};

--- a/chips/stm32f4xx/src/clocks/mod.rs
+++ b/chips/stm32f4xx/src/clocks/mod.rs
@@ -7,6 +7,7 @@
 pub mod clocks;
 pub mod hse;
 pub mod hsi;
+pub mod phclk;
 pub mod pll;
 
 pub use crate::clocks::clocks::tests;

--- a/chips/stm32f4xx/src/clocks/phclk.rs
+++ b/chips/stm32f4xx/src/clocks/phclk.rs
@@ -1,0 +1,334 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+use crate::clocks::Stm32f4Clocks;
+use crate::rcc::{APBPrescaler, Rcc, RtcClockSource};
+use kernel::platform::chip::ClockInterface;
+
+pub struct PeripheralClock<'a> {
+    pub clock: PeripheralClockType,
+    clocks: &'a dyn Stm32f4Clocks,
+}
+
+/// Bus + Clock name for the peripherals
+pub enum PeripheralClockType {
+    AHB1(HCLK1),
+    AHB2(HCLK2),
+    AHB3(HCLK3),
+    APB1(PCLK1),
+    APB2(PCLK2),
+    RTC,
+    PWR,
+}
+
+/// Peripherals clocked by HCLK1
+pub enum HCLK1 {
+    DMA1,
+    DMA2,
+    GPIOH,
+    GPIOG,
+    GPIOF,
+    GPIOE,
+    GPIOD,
+    GPIOC,
+    GPIOB,
+    GPIOA,
+}
+
+/// Peripherals clocked by HCLK3
+pub enum HCLK3 {
+    FMC,
+}
+
+/// Peripherals clocked by HCLK2
+pub enum HCLK2 {
+    RNG,
+    OTGFS,
+}
+
+/// Peripherals clocked by PCLK1
+pub enum PCLK1 {
+    TIM2,
+    USART2,
+    USART3,
+    SPI3,
+    I2C1,
+    CAN1,
+    DAC,
+}
+
+/// Peripherals clocked by PCLK2
+pub enum PCLK2 {
+    USART1,
+    ADC1,
+    SYSCFG,
+}
+
+impl<'a> PeripheralClock<'a> {
+    pub const fn new(clock: PeripheralClockType, clocks: &'a dyn Stm32f4Clocks) -> Self {
+        Self { clock, clocks }
+    }
+
+    pub fn configure_rng_clock(&self) {
+        self.clocks.get_rcc().configure_rng_clock();
+    }
+
+    pub fn get_frequency(&self) -> u32 {
+        #[inline(always)]
+        fn tim_freq(rcc: &Rcc, hclk_freq: usize, prescaler: APBPrescaler) -> usize {
+            // Reference Manual RM0090 section 6.2
+            // When TIMPRE bit of the RCC_DCKCFGR register is reset, if APBx prescaler is 1, then
+            // TIMxCLK = PCLKx, otherwise TIMxCLK = 2x PCLKx.
+            // When TIMPRE bit in the RCC_DCKCFGR register is set, if APBx prescaler is 1,2 or 4,
+            // then TIMxCLK = HCLK, otherwise TIMxCLK = 4x PCLKx.
+            if !rcc.is_enabled_tim_pre() {
+                match prescaler {
+                    APBPrescaler::DivideBy1 | APBPrescaler::DivideBy2 => hclk_freq,
+                    _ => hclk_freq / usize::from(prescaler) * 2,
+                }
+            } else {
+                match prescaler {
+                    APBPrescaler::DivideBy1 | APBPrescaler::DivideBy2 | APBPrescaler::DivideBy4 => {
+                        hclk_freq
+                    }
+                    _ => hclk_freq / usize::from(prescaler) * 4,
+                }
+            }
+        }
+        let rcc = self.clocks.get_rcc();
+        let hclk_freq = rcc.get_sys_clock_frequency();
+        match self.clock {
+            PeripheralClockType::AHB1(_)
+            | PeripheralClockType::AHB2(_)
+            | PeripheralClockType::AHB3(_) => hclk_freq as u32,
+            PeripheralClockType::APB1(ref v) => {
+                let prescaler = rcc.get_apb1_prescaler();
+                match v {
+                    PCLK1::TIM2 => tim_freq(rcc, hclk_freq, prescaler) as u32,
+                    _ => (hclk_freq / usize::from(prescaler)) as u32,
+                }
+            }
+            PeripheralClockType::APB2(_) => {
+                let prescaler = rcc.get_apb2_prescaler();
+                (hclk_freq / usize::from(prescaler)) as u32
+            }
+            //TODO: implement clock frequency retrieval for RTC and PWR peripherals
+            PeripheralClockType::RTC => todo!(),
+            PeripheralClockType::PWR => todo!(),
+        }
+    }
+}
+
+impl<'a> ClockInterface for PeripheralClock<'a> {
+    fn is_enabled(&self) -> bool {
+        let rcc = self.clocks.get_rcc();
+        match self.clock {
+            PeripheralClockType::AHB1(ref v) => match v {
+                HCLK1::DMA1 => rcc.is_enabled_dma1_clock(),
+                HCLK1::DMA2 => rcc.is_enabled_dma2_clock(),
+                HCLK1::GPIOH => rcc.is_enabled_gpioh_clock(),
+                HCLK1::GPIOG => rcc.is_enabled_gpiog_clock(),
+                HCLK1::GPIOF => rcc.is_enabled_gpiof_clock(),
+                HCLK1::GPIOE => rcc.is_enabled_gpioe_clock(),
+                HCLK1::GPIOD => rcc.is_enabled_gpiod_clock(),
+                HCLK1::GPIOC => rcc.is_enabled_gpioc_clock(),
+                HCLK1::GPIOB => rcc.is_enabled_gpiob_clock(),
+                HCLK1::GPIOA => rcc.is_enabled_gpioa_clock(),
+            },
+            PeripheralClockType::AHB2(ref v) => match v {
+                HCLK2::RNG => rcc.is_enabled_rng_clock(),
+                HCLK2::OTGFS => rcc.is_enabled_otgfs_clock(),
+            },
+            PeripheralClockType::AHB3(ref v) => match v {
+                HCLK3::FMC => rcc.is_enabled_fmc_clock(),
+            },
+            PeripheralClockType::APB1(ref v) => match v {
+                PCLK1::TIM2 => rcc.is_enabled_tim2_clock(),
+                PCLK1::USART2 => rcc.is_enabled_usart2_clock(),
+                PCLK1::USART3 => rcc.is_enabled_usart3_clock(),
+                PCLK1::I2C1 => rcc.is_enabled_i2c1_clock(),
+                PCLK1::SPI3 => rcc.is_enabled_spi3_clock(),
+                PCLK1::CAN1 => rcc.is_enabled_can1_clock(),
+                PCLK1::DAC => rcc.is_enabled_dac_clock(),
+            },
+            PeripheralClockType::APB2(ref v) => match v {
+                PCLK2::USART1 => rcc.is_enabled_usart1_clock(),
+                PCLK2::ADC1 => rcc.is_enabled_adc1_clock(),
+                PCLK2::SYSCFG => rcc.is_enabled_syscfg_clock(),
+            },
+            PeripheralClockType::RTC => rcc.is_enabled_rtc_clock(),
+            PeripheralClockType::PWR => rcc.is_enabled_pwr_clock(),
+        }
+    }
+
+    fn enable(&self) {
+        let rcc = self.clocks.get_rcc();
+        match self.clock {
+            PeripheralClockType::AHB1(ref v) => match v {
+                HCLK1::DMA1 => {
+                    rcc.enable_dma1_clock();
+                }
+                HCLK1::DMA2 => {
+                    rcc.enable_dma2_clock();
+                }
+                HCLK1::GPIOH => {
+                    rcc.enable_gpioh_clock();
+                }
+                HCLK1::GPIOG => {
+                    rcc.enable_gpiog_clock();
+                }
+                HCLK1::GPIOF => {
+                    rcc.enable_gpiof_clock();
+                }
+                HCLK1::GPIOE => {
+                    rcc.enable_gpioe_clock();
+                }
+                HCLK1::GPIOD => {
+                    rcc.enable_gpiod_clock();
+                }
+                HCLK1::GPIOC => {
+                    rcc.enable_gpioc_clock();
+                }
+                HCLK1::GPIOB => {
+                    rcc.enable_gpiob_clock();
+                }
+                HCLK1::GPIOA => {
+                    rcc.enable_gpioa_clock();
+                }
+            },
+            PeripheralClockType::AHB2(ref v) => match v {
+                HCLK2::RNG => {
+                    rcc.enable_rng_clock();
+                }
+                HCLK2::OTGFS => {
+                    rcc.enable_otgfs_clock();
+                }
+            },
+            PeripheralClockType::AHB3(ref v) => match v {
+                HCLK3::FMC => rcc.enable_fmc_clock(),
+            },
+            PeripheralClockType::APB1(ref v) => match v {
+                PCLK1::TIM2 => {
+                    rcc.enable_tim2_clock();
+                }
+                PCLK1::USART2 => {
+                    rcc.enable_usart2_clock();
+                }
+                PCLK1::USART3 => {
+                    rcc.enable_usart3_clock();
+                }
+                PCLK1::I2C1 => {
+                    rcc.enable_i2c1_clock();
+                }
+                PCLK1::SPI3 => {
+                    rcc.enable_spi3_clock();
+                }
+                PCLK1::CAN1 => {
+                    rcc.enable_can1_clock();
+                }
+                PCLK1::DAC => {
+                    rcc.enable_dac_clock();
+                }
+            },
+            PeripheralClockType::APB2(ref v) => match v {
+                PCLK2::USART1 => {
+                    rcc.enable_usart1_clock();
+                }
+                PCLK2::ADC1 => {
+                    rcc.enable_adc1_clock();
+                }
+                PCLK2::SYSCFG => {
+                    rcc.enable_syscfg_clock();
+                }
+            },
+            PeripheralClockType::RTC => rcc.enable_rtc_clock(RtcClockSource::LSI),
+            PeripheralClockType::PWR => rcc.enable_pwr_clock(),
+        }
+    }
+
+    fn disable(&self) {
+        let rcc = self.clocks.get_rcc();
+        match self.clock {
+            PeripheralClockType::AHB1(ref v) => match v {
+                HCLK1::DMA1 => {
+                    rcc.disable_dma1_clock();
+                }
+                HCLK1::DMA2 => {
+                    rcc.disable_dma2_clock();
+                }
+                HCLK1::GPIOH => {
+                    rcc.disable_gpioh_clock();
+                }
+                HCLK1::GPIOG => {
+                    rcc.disable_gpiog_clock();
+                }
+                HCLK1::GPIOF => {
+                    rcc.disable_gpiof_clock();
+                }
+                HCLK1::GPIOE => {
+                    rcc.disable_gpioe_clock();
+                }
+                HCLK1::GPIOD => {
+                    rcc.disable_gpiod_clock();
+                }
+                HCLK1::GPIOC => {
+                    rcc.disable_gpioc_clock();
+                }
+                HCLK1::GPIOB => {
+                    rcc.disable_gpiob_clock();
+                }
+                HCLK1::GPIOA => {
+                    rcc.disable_gpioa_clock();
+                }
+            },
+            PeripheralClockType::AHB2(ref v) => match v {
+                HCLK2::RNG => {
+                    rcc.disable_rng_clock();
+                }
+                HCLK2::OTGFS => {
+                    rcc.disable_otgfs_clock();
+                }
+            },
+            PeripheralClockType::AHB3(ref v) => match v {
+                HCLK3::FMC => rcc.disable_fmc_clock(),
+            },
+            PeripheralClockType::APB1(ref v) => match v {
+                PCLK1::TIM2 => {
+                    rcc.disable_tim2_clock();
+                }
+                PCLK1::USART2 => {
+                    rcc.disable_usart2_clock();
+                }
+                PCLK1::USART3 => {
+                    rcc.disable_usart3_clock();
+                }
+                PCLK1::I2C1 => {
+                    rcc.disable_i2c1_clock();
+                }
+                PCLK1::SPI3 => {
+                    rcc.disable_spi3_clock();
+                }
+                PCLK1::CAN1 => {
+                    rcc.disable_can1_clock();
+                }
+                PCLK1::DAC => {
+                    rcc.disable_dac_clock();
+                }
+            },
+            PeripheralClockType::APB2(ref v) => match v {
+                PCLK2::USART1 => {
+                    rcc.disable_usart1_clock();
+                }
+                PCLK2::ADC1 => {
+                    rcc.disable_adc1_clock();
+                }
+                PCLK2::SYSCFG => {
+                    rcc.disable_syscfg_clock();
+                }
+            },
+            PeripheralClockType::RTC => rcc.disable_rtc_clock(),
+            PeripheralClockType::PWR => rcc.disable_pwr_clock(),
+        }
+    }
+}

--- a/chips/stm32f4xx/src/clocks/phclk.rs
+++ b/chips/stm32f4xx/src/clocks/phclk.rs
@@ -97,7 +97,7 @@ impl<'a> PeripheralClock<'a> {
             }
         }
         let rcc = self.clocks.get_rcc();
-        let hclk_freq = rcc.get_sys_clock_frequency();
+        let hclk_freq = self.clocks.get_ahb_frequency();
         match self.clock {
             PeripheralClockType::AHB1(_)
             | PeripheralClockType::AHB2(_)

--- a/chips/stm32f4xx/src/clocks/pll.rs
+++ b/chips/stm32f4xx/src/clocks/pll.rs
@@ -372,6 +372,24 @@ impl<'a, PllConstants: clock_constants::PllConstants> Pll<'a, PllConstants> {
         }
     }
 
+    /// Get the frequency in MHz of the PLL clock from RCC registers instead of using the cached
+    /// value.
+    ///
+    /// # Returns
+    ///
+    /// + [Some]\(frequency_mhz\): if the PLL clock is enabled.
+    /// + [None]: if the PLL clock is disabled.
+    pub fn get_frequency_mhz_no_cache(&self, source_frequency: usize) -> Option<usize> {
+        if self.is_enabled() {
+            let pllm = self.rcc.get_pll_clocks_m_divider() as usize;
+            let plln = self.rcc.get_pll_clock_n_multiplier();
+            let pllp: usize = self.rcc.get_pll_clock_p_divider().into();
+            Some(source_frequency / pllm * plln / pllp)
+        } else {
+            None
+        }
+    }
+
     /// Get the frequency in MHz of the PLL48 clock.
     ///
     /// **NOTE:** If the PLL clock was not configured with a frequency multiple of 48MHz, the

--- a/chips/stm32f4xx/src/clocks/pll.rs
+++ b/chips/stm32f4xx/src/clocks/pll.rs
@@ -41,7 +41,7 @@
 //! ## Start the clock with a given frequency
 //!
 //! ```rust,ignore
-//! pll.set_frequency(PllSource::HSI, HSI_FREQUENCY_MHZ, 100); // 100MHz
+//! pll.set_frequency_mhz(PllSource::HSI, HSI_FREQUENCY_MHZ, 100); // 100MHz
 //! pll.enable();
 //! ```
 //!
@@ -63,7 +63,7 @@
 //! ## Check the clock frequency
 //!
 //! ```rust,ignore
-//! let optional_pll_frequency = pll.get_frequency();
+//! let optional_pll_frequency = pll.get_frequency_mhz();
 //! if let None = optional_pll_frequency {
 //!     /* Clock stopped */
 //! }
@@ -75,7 +75,7 @@
 //!
 //! ```rust,ignore
 //! pll.disable(); // The PLL clock can't be configured while running
-//! pll.set_frequency(PllSource::HSI, HSI_FREQUENCY_MHZ, 50); // 50MHz
+//! pll.set_frequency_mhz(PllSource::HSI, HSI_FREQUENCY_MHZ, 50); // 50MHz
 //! pll.enable();
 //! ```
 //!
@@ -83,7 +83,7 @@
 //! ```rust,ignore
 //! // The frequency of the PLL clock must be 1, 1.5, 2, 2.5, 3, 3.5 or 4 x 48MHz in order to get
 //! // 48MHz output. Otherwise, the driver will attempt to get the closest frequency lower than 48MHz
-//! pll.set_frequency(PllSource::HSI, HSI_FREQUENCY_MHZ, 72); // 72MHz = 48MHz * 1.5
+//! pll.set_frequency_mhz(PllSource::HSI, HSI_FREQUENCY_MHZ, 72); // 72MHz = 48MHz * 1.5
 //! pll.enable();
 //! ```
 //!
@@ -97,7 +97,7 @@
 //! ## Get the frequency of the PLL48CLK output
 //!
 //! ```rust,ignore
-//! let optional_pll48_frequency = pll.get_frequency();
+//! let optional_pll48_frequency = pll.get_frequency_mhz();
 //! if let None = optional_pll48_frequency {
 //!     /* Clock stopped */
 //! }
@@ -123,8 +123,8 @@ use core::marker::PhantomData;
 /// Main PLL clock structure.
 pub struct Pll<'a, PllConstants> {
     rcc: &'a Rcc,
-    frequency: OptionalCell<usize>,
-    pll48_frequency: OptionalCell<usize>,
+    frequency_mhz: OptionalCell<usize>,
+    pll48_frequency_mhz: OptionalCell<usize>,
     pll48_calibrated: Cell<bool>,
     _marker: PhantomData<PllConstants>,
 }
@@ -153,8 +153,8 @@ impl<'a, PllConstants: clock_constants::PllConstants> Pll<'a, PllConstants> {
         const PLLQ: usize = DEFAULT_PLLQ_VALUE as usize;
         Self {
             rcc,
-            frequency: OptionalCell::new(HSI_FREQUENCY_MHZ / PLLM * DEFAULT_PLLN_VALUE / PLLP),
-            pll48_frequency: OptionalCell::new(
+            frequency_mhz: OptionalCell::new(HSI_FREQUENCY_MHZ / PLLM * DEFAULT_PLLN_VALUE / PLLP),
+            pll48_frequency_mhz: OptionalCell::new(
                 HSI_FREQUENCY_MHZ / PLLM * DEFAULT_PLLN_VALUE / PLLQ,
             ),
             pll48_calibrated: Cell::new(true),
@@ -305,7 +305,7 @@ impl<'a, PllConstants: clock_constants::PllConstants> Pll<'a, PllConstants> {
     /// + [Err]\([ErrorCode::INVAL]\): if the desired frequency can't be achieved
     /// + [Err]\([ErrorCode::FAIL]\): if the PLL clock is already enabled. It must be disabled before
     /// configuring it.
-    pub(super) fn set_frequency(
+    pub(super) fn set_frequency_mhz(
         &self,
         pll_source: PllSource,
         source_frequency: usize,
@@ -352,8 +352,8 @@ impl<'a, PllConstants: clock_constants::PllConstants> Pll<'a, PllConstants> {
             .set(pll48_frequency == 48 && vco_output_frequency % pllq as usize == 0);
 
         // Cache the frequency so it is not computed every time a get method is called
-        self.frequency.set(desired_frequency_mhz);
-        self.pll48_frequency.set(pll48_frequency);
+        self.frequency_mhz.set(desired_frequency_mhz);
+        self.pll48_frequency_mhz.set(pll48_frequency);
 
         Ok(())
     }
@@ -364,9 +364,9 @@ impl<'a, PllConstants: clock_constants::PllConstants> Pll<'a, PllConstants> {
     ///
     /// + [Some]\(frequency_mhz\): if the PLL clock is enabled.
     /// + [None]: if the PLL clock is disabled.
-    pub fn get_frequency(&self) -> Option<usize> {
+    pub fn get_frequency_mhz(&self) -> Option<usize> {
         if self.is_enabled() {
-            self.frequency.get()
+            self.frequency_mhz.get()
         } else {
             None
         }
@@ -381,9 +381,9 @@ impl<'a, PllConstants: clock_constants::PllConstants> Pll<'a, PllConstants> {
     ///
     /// + [Some]\(frequency_mhz\): if the PLL clock is enabled.
     /// + [None]: if the PLL clock is disabled.
-    pub fn get_frequency_pll48(&self) -> Option<usize> {
+    pub fn get_frequency_mhz_pll48(&self) -> Option<usize> {
         if self.is_enabled() {
-            self.pll48_frequency.get()
+            self.pll48_frequency_mhz.get()
         } else {
             None
         }
@@ -617,11 +617,11 @@ pub mod tests {
         // Attempting to configure the PLL with either too high or too low frequency
         assert_eq!(
             Err(ErrorCode::INVAL),
-            pll.set_frequency(PllSource::HSI, HSI_FREQUENCY_MHZ, 12)
+            pll.set_frequency_mhz(PllSource::HSI, HSI_FREQUENCY_MHZ, 12)
         );
         assert_eq!(
             Err(ErrorCode::INVAL),
-            pll.set_frequency(PllSource::HSI, HSI_FREQUENCY_MHZ, 217)
+            pll.set_frequency_mhz(PllSource::HSI, HSI_FREQUENCY_MHZ, 217)
         );
 
         // Start the PLL with the default configuration.
@@ -631,7 +631,7 @@ pub mod tests {
         assert!(pll.is_enabled());
 
         // By default, the PLL clock is set to 96MHz
-        assert_eq!(Some(96), pll.get_frequency());
+        assert_eq!(Some(96), pll.get_frequency_mhz());
 
         // By default, the PLL48 clock is correctly calibrated
         assert!(pll.is_pll48_calibrated());
@@ -639,7 +639,7 @@ pub mod tests {
         // Impossible to configure the PLL clock once it is enabled.
         assert_eq!(
             Err(ErrorCode::FAIL),
-            pll.set_frequency(PllSource::HSI, HSI_FREQUENCY_MHZ, 50)
+            pll.set_frequency_mhz(PllSource::HSI, HSI_FREQUENCY_MHZ, 50)
         );
 
         // Stop the PLL in order to reconfigure it.
@@ -648,68 +648,68 @@ pub mod tests {
         // Configure the PLL clock to run at 25MHz
         assert_eq!(
             Ok(()),
-            pll.set_frequency(PllSource::HSI, HSI_FREQUENCY_MHZ, 25)
+            pll.set_frequency_mhz(PllSource::HSI, HSI_FREQUENCY_MHZ, 25)
         );
 
         // Start the PLL with the new configuration
         assert_eq!(Ok(()), pll.enable());
 
         // get_frequency() method should reflect the new change
-        assert_eq!(Some(25), pll.get_frequency());
+        assert_eq!(Some(25), pll.get_frequency_mhz());
 
         // Since 25 is not a multiple of 48, the PLL48 clock is not correctly calibrated
         assert!(!pll.is_pll48_calibrated());
 
         // The expected PLL48 clock value in this case should be approximately 40 MHz.
         // It is actually exactly 40MHz in this particular case.
-        assert_eq!(Some(40), pll.get_frequency_pll48());
+        assert_eq!(Some(40), pll.get_frequency_mhz_pll48());
 
         // Stop the PLL clock
         assert_eq!(Ok(()), pll.disable());
 
         // Attempting to get the frequency of the PLL clock when it is disabled should return None.
-        assert_eq!(None, pll.get_frequency());
+        assert_eq!(None, pll.get_frequency_mhz());
         // Same for PLL48 clock
-        assert_eq!(None, pll.get_frequency_pll48());
+        assert_eq!(None, pll.get_frequency_mhz_pll48());
 
         // Attempting to configure the PLL clock with a frequency multiple of 48MHz
         assert_eq!(
             Ok(()),
-            pll.set_frequency(PllSource::HSI, HSI_FREQUENCY_MHZ, 144)
+            pll.set_frequency_mhz(PllSource::HSI, HSI_FREQUENCY_MHZ, 144)
         );
         assert_eq!(Ok(()), pll.enable());
-        assert_eq!(Some(144), pll.get_frequency());
+        assert_eq!(Some(144), pll.get_frequency_mhz());
 
         // PLL48 clock output should be correctly calibrated
         assert!(pll.is_pll48_calibrated());
-        assert_eq!(Some(48), pll.get_frequency_pll48());
+        assert_eq!(Some(48), pll.get_frequency_mhz_pll48());
 
         // Reconfigure the clock for 100MHz
         assert_eq!(Ok(()), pll.disable());
         assert_eq!(
             Ok(()),
-            pll.set_frequency(PllSource::HSI, HSI_FREQUENCY_MHZ, 100)
+            pll.set_frequency_mhz(PllSource::HSI, HSI_FREQUENCY_MHZ, 100)
         );
         assert_eq!(Ok(()), pll.enable());
-        assert_eq!(Some(100), pll.get_frequency());
+        assert_eq!(Some(100), pll.get_frequency_mhz());
 
         // In this case, the PLL48 clock is not correctly calibrated. Its frequency is
         // approximately 44MHz.
         assert!(!pll.is_pll48_calibrated());
-        assert_eq!(Some(44), pll.get_frequency_pll48());
+        assert_eq!(Some(44), pll.get_frequency_mhz_pll48());
 
         // Configure the clock to 72MHz = 48MHz * 1.5
         assert_eq!(Ok(()), pll.disable());
         assert_eq!(
             Ok(()),
-            pll.set_frequency(PllSource::HSI, HSI_FREQUENCY_MHZ, 72)
+            pll.set_frequency_mhz(PllSource::HSI, HSI_FREQUENCY_MHZ, 72)
         );
         assert_eq!(Ok(()), pll.enable());
-        assert_eq!(Some(72), pll.get_frequency());
+        assert_eq!(Some(72), pll.get_frequency_mhz());
 
         // In this case, the PLL48 clock is correctly calibrated
         assert!(pll.is_pll48_calibrated());
-        assert_eq!(Some(48), pll.get_frequency_pll48());
+        assert_eq!(Some(48), pll.get_frequency_mhz_pll48());
 
         // Turn off the PLL clock
         assert_eq!(Ok(()), pll.disable());

--- a/chips/stm32f4xx/src/dac.rs
+++ b/chips/stm32f4xx/src/dac.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use crate::clocks::clocks::Stm32f4Clocks;
-use crate::rcc;
+use crate::clocks::{phclk, Stm32f4Clocks};
 use core::cell::Cell;
 use kernel::hil;
 use kernel::platform::chip::ClockInterface;
@@ -151,8 +150,8 @@ impl<'a> Dac<'a> {
     pub const fn new(clocks: &'a dyn Stm32f4Clocks) -> Self {
         Self {
             registers: DAC_BASE,
-            clock: DacClock(rcc::PeripheralClock::new(
-                rcc::PeripheralClockType::APB1(rcc::PCLK1::DAC),
+            clock: DacClock(phclk::PeripheralClock::new(
+                phclk::PeripheralClockType::APB1(phclk::PCLK1::DAC),
                 clocks,
             )),
             initialized: Cell::new(false),
@@ -193,7 +192,7 @@ impl<'a> Dac<'a> {
     }
 }
 
-struct DacClock<'a>(rcc::PeripheralClock<'a>);
+struct DacClock<'a>(phclk::PeripheralClock<'a>);
 
 impl ClockInterface for DacClock<'_> {
     fn is_enabled(&self) -> bool {

--- a/chips/stm32f4xx/src/dac.rs
+++ b/chips/stm32f4xx/src/dac.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
+use crate::clocks::clocks::Stm32f4Clocks;
 use crate::rcc;
 use core::cell::Cell;
 use kernel::hil;
@@ -147,12 +148,12 @@ pub struct Dac<'a> {
 }
 
 impl<'a> Dac<'a> {
-    pub const fn new(rcc: &'a rcc::Rcc) -> Self {
+    pub const fn new(clocks: &'a dyn Stm32f4Clocks) -> Self {
         Self {
             registers: DAC_BASE,
             clock: DacClock(rcc::PeripheralClock::new(
                 rcc::PeripheralClockType::APB1(rcc::PCLK1::DAC),
-                rcc,
+                clocks,
             )),
             initialized: Cell::new(false),
             enabled: Cell::new(false),

--- a/chips/stm32f4xx/src/dma.rs
+++ b/chips/stm32f4xx/src/dma.rs
@@ -10,6 +10,7 @@ use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeabl
 use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite};
 use kernel::utilities::StaticRef;
 
+use crate::clocks::Stm32f4Clocks;
 use crate::nvic;
 use crate::rcc;
 use crate::spi;
@@ -1542,12 +1543,12 @@ pub struct Dma1<'a> {
 }
 
 impl<'a> Dma1<'a> {
-    pub const fn new(rcc: &'a rcc::Rcc) -> Dma1 {
+    pub const fn new(clocks: &'a dyn Stm32f4Clocks) -> Dma1 {
         Dma1 {
             registers: DMA1_BASE,
             clock: DmaClock(rcc::PeripheralClock::new(
                 rcc::PeripheralClockType::AHB1(rcc::HCLK1::DMA1),
-                rcc,
+                clocks,
             )),
         }
     }
@@ -1663,12 +1664,12 @@ pub struct Dma2<'a> {
 }
 
 impl<'a> Dma2<'a> {
-    pub const fn new(rcc: &'a rcc::Rcc) -> Dma2 {
+    pub const fn new(clocks: &'a dyn Stm32f4Clocks) -> Dma2 {
         Dma2 {
             registers: DMA2_BASE,
             clock: DmaClock(rcc::PeripheralClock::new(
                 rcc::PeripheralClockType::AHB1(rcc::HCLK1::DMA2),
-                rcc,
+                clocks,
             )),
         }
     }

--- a/chips/stm32f4xx/src/dma.rs
+++ b/chips/stm32f4xx/src/dma.rs
@@ -10,9 +10,8 @@ use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeabl
 use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite};
 use kernel::utilities::StaticRef;
 
-use crate::clocks::Stm32f4Clocks;
+use crate::clocks::{phclk, Stm32f4Clocks};
 use crate::nvic;
-use crate::rcc;
 use crate::spi;
 use crate::usart;
 
@@ -1374,7 +1373,7 @@ pub trait StreamClient<'a, DMA: StreamServer<'a>> {
     fn transfer_done(&self, pid: DMA::Peripheral);
 }
 
-struct DmaClock<'a>(rcc::PeripheralClock<'a>);
+struct DmaClock<'a>(phclk::PeripheralClock<'a>);
 
 impl ClockInterface for DmaClock<'_> {
     fn is_enabled(&self) -> bool {
@@ -1546,8 +1545,8 @@ impl<'a> Dma1<'a> {
     pub const fn new(clocks: &'a dyn Stm32f4Clocks) -> Dma1 {
         Dma1 {
             registers: DMA1_BASE,
-            clock: DmaClock(rcc::PeripheralClock::new(
-                rcc::PeripheralClockType::AHB1(rcc::HCLK1::DMA1),
+            clock: DmaClock(phclk::PeripheralClock::new(
+                phclk::PeripheralClockType::AHB1(phclk::HCLK1::DMA1),
                 clocks,
             )),
         }
@@ -1667,8 +1666,8 @@ impl<'a> Dma2<'a> {
     pub const fn new(clocks: &'a dyn Stm32f4Clocks) -> Dma2 {
         Dma2 {
             registers: DMA2_BASE,
-            clock: DmaClock(rcc::PeripheralClock::new(
-                rcc::PeripheralClockType::AHB1(rcc::HCLK1::DMA2),
+            clock: DmaClock(phclk::PeripheralClock::new(
+                phclk::PeripheralClockType::AHB1(phclk::HCLK1::DMA2),
                 clocks,
             )),
         }

--- a/chips/stm32f4xx/src/fsmc.rs
+++ b/chips/stm32f4xx/src/fsmc.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use crate::clocks::clocks::Stm32f4Clocks;
-use crate::rcc;
+use crate::clocks::{phclk, Stm32f4Clocks};
 use core::cell::Cell;
 use kernel::deferred_call::{DeferredCall, DeferredCallClient};
 use kernel::hil::bus8080::{Bus8080, BusWidth, Client};
@@ -177,8 +176,8 @@ impl<'a> Fsmc<'a> {
         Self {
             registers: FSMC_BASE,
             bank: bank_addr,
-            clock: FsmcClock(rcc::PeripheralClock::new(
-                rcc::PeripheralClockType::AHB3(rcc::HCLK3::FMC),
+            clock: FsmcClock(phclk::PeripheralClock::new(
+                phclk::PeripheralClockType::AHB3(phclk::HCLK3::FMC),
                 clocks,
             )),
             client: OptionalCell::empty(),
@@ -299,7 +298,7 @@ impl DeferredCallClient for Fsmc<'_> {
     }
 }
 
-struct FsmcClock<'a>(rcc::PeripheralClock<'a>);
+struct FsmcClock<'a>(phclk::PeripheralClock<'a>);
 
 impl ClockInterface for FsmcClock<'_> {
     fn is_enabled(&self) -> bool {

--- a/chips/stm32f4xx/src/fsmc.rs
+++ b/chips/stm32f4xx/src/fsmc.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
+use crate::clocks::clocks::Stm32f4Clocks;
 use crate::rcc;
 use core::cell::Cell;
 use kernel::deferred_call::{DeferredCall, DeferredCallClient};
@@ -172,13 +173,13 @@ pub struct Fsmc<'a> {
 }
 
 impl<'a> Fsmc<'a> {
-    pub fn new(bank_addr: [Option<StaticRef<FsmcBank>>; 4], rcc: &'a rcc::Rcc) -> Self {
+    pub fn new(bank_addr: [Option<StaticRef<FsmcBank>>; 4], clocks: &'a dyn Stm32f4Clocks) -> Self {
         Self {
             registers: FSMC_BASE,
             bank: bank_addr,
             clock: FsmcClock(rcc::PeripheralClock::new(
                 rcc::PeripheralClockType::AHB3(rcc::HCLK3::FMC),
-                rcc,
+                clocks,
             )),
             client: OptionalCell::empty(),
 

--- a/chips/stm32f4xx/src/gpio.rs
+++ b/chips/stm32f4xx/src/gpio.rs
@@ -12,9 +12,8 @@ use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeabl
 use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::utilities::StaticRef;
 
-use crate::clocks::Stm32f4Clocks;
+use crate::clocks::{phclk, Stm32f4Clocks};
 use crate::exti::{self, LineId};
-use crate::rcc;
 
 /// General-purpose I/Os
 #[repr(C)]
@@ -614,57 +613,57 @@ impl<'a> GpioPorts<'a> {
             ports: [
                 Port {
                     registers: GPIOA_BASE,
-                    clock: PortClock(rcc::PeripheralClock::new(
-                        rcc::PeripheralClockType::AHB1(rcc::HCLK1::GPIOA),
+                    clock: PortClock(phclk::PeripheralClock::new(
+                        phclk::PeripheralClockType::AHB1(phclk::HCLK1::GPIOA),
                         clocks,
                     )),
                 },
                 Port {
                     registers: GPIOB_BASE,
-                    clock: PortClock(rcc::PeripheralClock::new(
-                        rcc::PeripheralClockType::AHB1(rcc::HCLK1::GPIOB),
+                    clock: PortClock(phclk::PeripheralClock::new(
+                        phclk::PeripheralClockType::AHB1(phclk::HCLK1::GPIOB),
                         clocks,
                     )),
                 },
                 Port {
                     registers: GPIOC_BASE,
-                    clock: PortClock(rcc::PeripheralClock::new(
-                        rcc::PeripheralClockType::AHB1(rcc::HCLK1::GPIOC),
+                    clock: PortClock(phclk::PeripheralClock::new(
+                        phclk::PeripheralClockType::AHB1(phclk::HCLK1::GPIOC),
                         clocks,
                     )),
                 },
                 Port {
                     registers: GPIOD_BASE,
-                    clock: PortClock(rcc::PeripheralClock::new(
-                        rcc::PeripheralClockType::AHB1(rcc::HCLK1::GPIOD),
+                    clock: PortClock(phclk::PeripheralClock::new(
+                        phclk::PeripheralClockType::AHB1(phclk::HCLK1::GPIOD),
                         clocks,
                     )),
                 },
                 Port {
                     registers: GPIOE_BASE,
-                    clock: PortClock(rcc::PeripheralClock::new(
-                        rcc::PeripheralClockType::AHB1(rcc::HCLK1::GPIOE),
+                    clock: PortClock(phclk::PeripheralClock::new(
+                        phclk::PeripheralClockType::AHB1(phclk::HCLK1::GPIOE),
                         clocks,
                     )),
                 },
                 Port {
                     registers: GPIOF_BASE,
-                    clock: PortClock(rcc::PeripheralClock::new(
-                        rcc::PeripheralClockType::AHB1(rcc::HCLK1::GPIOF),
+                    clock: PortClock(phclk::PeripheralClock::new(
+                        phclk::PeripheralClockType::AHB1(phclk::HCLK1::GPIOF),
                         clocks,
                     )),
                 },
                 Port {
                     registers: GPIOG_BASE,
-                    clock: PortClock(rcc::PeripheralClock::new(
-                        rcc::PeripheralClockType::AHB1(rcc::HCLK1::GPIOG),
+                    clock: PortClock(phclk::PeripheralClock::new(
+                        phclk::PeripheralClockType::AHB1(phclk::HCLK1::GPIOG),
                         clocks,
                     )),
                 },
                 Port {
                     registers: GPIOH_BASE,
-                    clock: PortClock(rcc::PeripheralClock::new(
-                        rcc::PeripheralClockType::AHB1(rcc::HCLK1::GPIOH),
+                    clock: PortClock(phclk::PeripheralClock::new(
+                        phclk::PeripheralClockType::AHB1(phclk::HCLK1::GPIOH),
                         clocks,
                     )),
                 },
@@ -743,7 +742,7 @@ impl Port<'_> {
     }
 }
 
-struct PortClock<'a>(rcc::PeripheralClock<'a>);
+struct PortClock<'a>(phclk::PeripheralClock<'a>);
 
 impl ClockInterface for PortClock<'_> {
     fn is_enabled(&self) -> bool {

--- a/chips/stm32f4xx/src/gpio.rs
+++ b/chips/stm32f4xx/src/gpio.rs
@@ -12,6 +12,7 @@ use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeabl
 use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::utilities::StaticRef;
 
+use crate::clocks::Stm32f4Clocks;
 use crate::exti::{self, LineId};
 use crate::rcc;
 
@@ -608,63 +609,63 @@ pub struct GpioPorts<'a> {
 }
 
 impl<'a> GpioPorts<'a> {
-    pub fn new(rcc: &'a rcc::Rcc, exti: &'a exti::Exti<'a>) -> Self {
+    pub fn new(clocks: &'a dyn Stm32f4Clocks, exti: &'a exti::Exti<'a>) -> Self {
         Self {
             ports: [
                 Port {
                     registers: GPIOA_BASE,
                     clock: PortClock(rcc::PeripheralClock::new(
                         rcc::PeripheralClockType::AHB1(rcc::HCLK1::GPIOA),
-                        rcc,
+                        clocks,
                     )),
                 },
                 Port {
                     registers: GPIOB_BASE,
                     clock: PortClock(rcc::PeripheralClock::new(
                         rcc::PeripheralClockType::AHB1(rcc::HCLK1::GPIOB),
-                        rcc,
+                        clocks,
                     )),
                 },
                 Port {
                     registers: GPIOC_BASE,
                     clock: PortClock(rcc::PeripheralClock::new(
                         rcc::PeripheralClockType::AHB1(rcc::HCLK1::GPIOC),
-                        rcc,
+                        clocks,
                     )),
                 },
                 Port {
                     registers: GPIOD_BASE,
                     clock: PortClock(rcc::PeripheralClock::new(
                         rcc::PeripheralClockType::AHB1(rcc::HCLK1::GPIOD),
-                        rcc,
+                        clocks,
                     )),
                 },
                 Port {
                     registers: GPIOE_BASE,
                     clock: PortClock(rcc::PeripheralClock::new(
                         rcc::PeripheralClockType::AHB1(rcc::HCLK1::GPIOE),
-                        rcc,
+                        clocks,
                     )),
                 },
                 Port {
                     registers: GPIOF_BASE,
                     clock: PortClock(rcc::PeripheralClock::new(
                         rcc::PeripheralClockType::AHB1(rcc::HCLK1::GPIOF),
-                        rcc,
+                        clocks,
                     )),
                 },
                 Port {
                     registers: GPIOG_BASE,
                     clock: PortClock(rcc::PeripheralClock::new(
                         rcc::PeripheralClockType::AHB1(rcc::HCLK1::GPIOG),
-                        rcc,
+                        clocks,
                     )),
                 },
                 Port {
                     registers: GPIOH_BASE,
                     clock: PortClock(rcc::PeripheralClock::new(
                         rcc::PeripheralClockType::AHB1(rcc::HCLK1::GPIOH),
-                        rcc,
+                        clocks,
                     )),
                 },
             ],

--- a/chips/stm32f4xx/src/i2c.rs
+++ b/chips/stm32f4xx/src/i2c.rs
@@ -12,6 +12,7 @@ use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeabl
 use kernel::utilities::registers::{register_bitfields, ReadWrite};
 use kernel::utilities::StaticRef;
 
+use crate::clocks::Stm32f4Clocks;
 use crate::rcc;
 
 pub enum I2CSpeed {
@@ -210,12 +211,12 @@ enum I2CStatus {
 }
 
 impl<'a> I2C<'a> {
-    pub fn new(rcc: &'a rcc::Rcc) -> Self {
+    pub fn new(clocks: &'a dyn Stm32f4Clocks) -> Self {
         Self {
             registers: I2C1_BASE,
             clock: I2CClock(rcc::PeripheralClock::new(
                 rcc::PeripheralClockType::APB1(rcc::PCLK1::I2C1),
-                rcc,
+                clocks,
             )),
 
             master_client: OptionalCell::empty(),

--- a/chips/stm32f4xx/src/i2c.rs
+++ b/chips/stm32f4xx/src/i2c.rs
@@ -12,8 +12,7 @@ use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeabl
 use kernel::utilities::registers::{register_bitfields, ReadWrite};
 use kernel::utilities::StaticRef;
 
-use crate::clocks::Stm32f4Clocks;
-use crate::rcc;
+use crate::clocks::{phclk, Stm32f4Clocks};
 
 pub enum I2CSpeed {
     Speed100k,
@@ -214,8 +213,8 @@ impl<'a> I2C<'a> {
     pub fn new(clocks: &'a dyn Stm32f4Clocks) -> Self {
         Self {
             registers: I2C1_BASE,
-            clock: I2CClock(rcc::PeripheralClock::new(
-                rcc::PeripheralClockType::APB1(rcc::PCLK1::I2C1),
+            clock: I2CClock(phclk::PeripheralClock::new(
+                phclk::PeripheralClockType::APB1(phclk::PCLK1::I2C1),
                 clocks,
             )),
 
@@ -473,7 +472,7 @@ impl<'a> i2c::I2CMaster<'a> for I2C<'a> {
     }
 }
 
-struct I2CClock<'a>(rcc::PeripheralClock<'a>);
+struct I2CClock<'a>(phclk::PeripheralClock<'a>);
 
 impl ClockInterface for I2CClock<'_> {
     fn is_enabled(&self) -> bool {

--- a/chips/stm32f4xx/src/rcc.rs
+++ b/chips/stm32f4xx/src/rcc.rs
@@ -911,7 +911,7 @@ impl Rcc {
         self.registers.pllcfgr.modify(PLLCFGR::PLLM.val(m as u32));
     }
 
-    pub(crate) fn get_pll_clocks_n_multiplier(&self) -> usize {
+    pub(crate) fn get_pll_clock_n_multiplier(&self) -> usize {
         self.registers.pllcfgr.read(PLLCFGR::PLLN) as usize
     }
 
@@ -920,7 +920,7 @@ impl Rcc {
         self.registers.pllcfgr.modify(PLLCFGR::PLLN.val(n as u32));
     }
 
-    pub(crate) fn get_pll_clocks_p_divider(&self) -> PLLP {
+    pub(crate) fn get_pll_clock_p_divider(&self) -> PLLP {
         match self.registers.pllcfgr.read(PLLCFGR::PLLP) {
             0b00 => PLLP::DivideBy2,
             0b01 => PLLP::DivideBy4,
@@ -934,7 +934,7 @@ impl Rcc {
         self.registers.pllcfgr.modify(PLLCFGR::PLLP.val(p as u32));
     }
 
-    pub(crate) fn _get_pll_clocks_q_divider(&self) -> PLLQ {
+    pub(crate) fn _get_pll_clock_q_divider(&self) -> PLLQ {
         match self.registers.pllcfgr.read(PLLCFGR::PLLQ) {
             3 => PLLQ::DivideBy3,
             4 => PLLQ::DivideBy4,
@@ -959,8 +959,8 @@ impl Rcc {
             PllSource::HSE => todo!(),
         };
         let pllm = self.get_pll_clocks_m_divider() as usize;
-        let plln = self.get_pll_clocks_n_multiplier();
-        let pllp: usize = self.get_pll_clocks_p_divider().into();
+        let plln = self.get_pll_clock_n_multiplier();
+        let pllp: usize = self.get_pll_clock_p_divider().into();
         src_freq / pllm * plln / pllp
     }
 

--- a/chips/stm32f4xx/src/rcc.rs
+++ b/chips/stm32f4xx/src/rcc.rs
@@ -1560,9 +1560,11 @@ impl From<APBPrescaler> for usize {
     }
 }
 
+use crate::clocks::clocks::Stm32f4Clocks;
+
 pub struct PeripheralClock<'a> {
     pub clock: PeripheralClockType,
-    rcc: &'a Rcc,
+    clocks: &'a dyn Stm32f4Clocks,
 }
 
 /// Bus + Clock name for the peripherals
@@ -1620,12 +1622,12 @@ pub enum PCLK2 {
 }
 
 impl<'a> PeripheralClock<'a> {
-    pub const fn new(clock: PeripheralClockType, rcc: &'a Rcc) -> Self {
-        Self { clock, rcc }
+    pub const fn new(clock: PeripheralClockType, clocks: &'a dyn Stm32f4Clocks) -> Self {
+        Self { clock, clocks }
     }
 
     pub fn configure_rng_clock(&self) {
-        self.rcc.configure_rng_clock();
+        self.clocks.get_rcc().configure_rng_clock();
     }
 
     pub fn get_frequency(&self) -> u32 {
@@ -1650,20 +1652,21 @@ impl<'a> PeripheralClock<'a> {
                 }
             }
         }
-        let hclk_freq = self.rcc.get_sys_clock_frequency();
+        let rcc = self.clocks.get_rcc();
+        let hclk_freq = rcc.get_sys_clock_frequency();
         match self.clock {
             PeripheralClockType::AHB1(_)
             | PeripheralClockType::AHB2(_)
             | PeripheralClockType::AHB3(_) => hclk_freq as u32,
             PeripheralClockType::APB1(ref v) => {
-                let prescaler = self.rcc.get_apb1_prescaler();
+                let prescaler = rcc.get_apb1_prescaler();
                 match v {
-                    PCLK1::TIM2 => tim_freq(self.rcc, hclk_freq, prescaler) as u32,
+                    PCLK1::TIM2 => tim_freq(rcc, hclk_freq, prescaler) as u32,
                     _ => (hclk_freq / usize::from(prescaler)) as u32,
                 }
             }
             PeripheralClockType::APB2(_) => {
-                let prescaler = self.rcc.get_apb2_prescaler();
+                let prescaler = rcc.get_apb2_prescaler();
                 (hclk_freq / usize::from(prescaler)) as u32
             }
             //TODO: implement clock frequency retrieval for RTC and PWR peripherals
@@ -1675,210 +1678,213 @@ impl<'a> PeripheralClock<'a> {
 
 impl<'a> ClockInterface for PeripheralClock<'a> {
     fn is_enabled(&self) -> bool {
+        let rcc = self.clocks.get_rcc();
         match self.clock {
             PeripheralClockType::AHB1(ref v) => match v {
-                HCLK1::DMA1 => self.rcc.is_enabled_dma1_clock(),
-                HCLK1::DMA2 => self.rcc.is_enabled_dma2_clock(),
-                HCLK1::GPIOH => self.rcc.is_enabled_gpioh_clock(),
-                HCLK1::GPIOG => self.rcc.is_enabled_gpiog_clock(),
-                HCLK1::GPIOF => self.rcc.is_enabled_gpiof_clock(),
-                HCLK1::GPIOE => self.rcc.is_enabled_gpioe_clock(),
-                HCLK1::GPIOD => self.rcc.is_enabled_gpiod_clock(),
-                HCLK1::GPIOC => self.rcc.is_enabled_gpioc_clock(),
-                HCLK1::GPIOB => self.rcc.is_enabled_gpiob_clock(),
-                HCLK1::GPIOA => self.rcc.is_enabled_gpioa_clock(),
+                HCLK1::DMA1 => rcc.is_enabled_dma1_clock(),
+                HCLK1::DMA2 => rcc.is_enabled_dma2_clock(),
+                HCLK1::GPIOH => rcc.is_enabled_gpioh_clock(),
+                HCLK1::GPIOG => rcc.is_enabled_gpiog_clock(),
+                HCLK1::GPIOF => rcc.is_enabled_gpiof_clock(),
+                HCLK1::GPIOE => rcc.is_enabled_gpioe_clock(),
+                HCLK1::GPIOD => rcc.is_enabled_gpiod_clock(),
+                HCLK1::GPIOC => rcc.is_enabled_gpioc_clock(),
+                HCLK1::GPIOB => rcc.is_enabled_gpiob_clock(),
+                HCLK1::GPIOA => rcc.is_enabled_gpioa_clock(),
             },
             PeripheralClockType::AHB2(ref v) => match v {
-                HCLK2::RNG => self.rcc.is_enabled_rng_clock(),
-                HCLK2::OTGFS => self.rcc.is_enabled_otgfs_clock(),
+                HCLK2::RNG => rcc.is_enabled_rng_clock(),
+                HCLK2::OTGFS => rcc.is_enabled_otgfs_clock(),
             },
             PeripheralClockType::AHB3(ref v) => match v {
-                HCLK3::FMC => self.rcc.is_enabled_fmc_clock(),
+                HCLK3::FMC => rcc.is_enabled_fmc_clock(),
             },
             PeripheralClockType::APB1(ref v) => match v {
-                PCLK1::TIM2 => self.rcc.is_enabled_tim2_clock(),
-                PCLK1::USART2 => self.rcc.is_enabled_usart2_clock(),
-                PCLK1::USART3 => self.rcc.is_enabled_usart3_clock(),
-                PCLK1::I2C1 => self.rcc.is_enabled_i2c1_clock(),
-                PCLK1::SPI3 => self.rcc.is_enabled_spi3_clock(),
-                PCLK1::CAN1 => self.rcc.is_enabled_can1_clock(),
-                PCLK1::DAC => self.rcc.is_enabled_dac_clock(),
+                PCLK1::TIM2 => rcc.is_enabled_tim2_clock(),
+                PCLK1::USART2 => rcc.is_enabled_usart2_clock(),
+                PCLK1::USART3 => rcc.is_enabled_usart3_clock(),
+                PCLK1::I2C1 => rcc.is_enabled_i2c1_clock(),
+                PCLK1::SPI3 => rcc.is_enabled_spi3_clock(),
+                PCLK1::CAN1 => rcc.is_enabled_can1_clock(),
+                PCLK1::DAC => rcc.is_enabled_dac_clock(),
             },
             PeripheralClockType::APB2(ref v) => match v {
-                PCLK2::USART1 => self.rcc.is_enabled_usart1_clock(),
-                PCLK2::ADC1 => self.rcc.is_enabled_adc1_clock(),
-                PCLK2::SYSCFG => self.rcc.is_enabled_syscfg_clock(),
+                PCLK2::USART1 => rcc.is_enabled_usart1_clock(),
+                PCLK2::ADC1 => rcc.is_enabled_adc1_clock(),
+                PCLK2::SYSCFG => rcc.is_enabled_syscfg_clock(),
             },
-            PeripheralClockType::RTC => self.rcc.is_enabled_rtc_clock(),
-            PeripheralClockType::PWR => self.rcc.is_enabled_pwr_clock(),
+            PeripheralClockType::RTC => rcc.is_enabled_rtc_clock(),
+            PeripheralClockType::PWR => rcc.is_enabled_pwr_clock(),
         }
     }
 
     fn enable(&self) {
+        let rcc = self.clocks.get_rcc();
         match self.clock {
             PeripheralClockType::AHB1(ref v) => match v {
                 HCLK1::DMA1 => {
-                    self.rcc.enable_dma1_clock();
+                    rcc.enable_dma1_clock();
                 }
                 HCLK1::DMA2 => {
-                    self.rcc.enable_dma2_clock();
+                    rcc.enable_dma2_clock();
                 }
                 HCLK1::GPIOH => {
-                    self.rcc.enable_gpioh_clock();
+                    rcc.enable_gpioh_clock();
                 }
                 HCLK1::GPIOG => {
-                    self.rcc.enable_gpiog_clock();
+                    rcc.enable_gpiog_clock();
                 }
                 HCLK1::GPIOF => {
-                    self.rcc.enable_gpiof_clock();
+                    rcc.enable_gpiof_clock();
                 }
                 HCLK1::GPIOE => {
-                    self.rcc.enable_gpioe_clock();
+                    rcc.enable_gpioe_clock();
                 }
                 HCLK1::GPIOD => {
-                    self.rcc.enable_gpiod_clock();
+                    rcc.enable_gpiod_clock();
                 }
                 HCLK1::GPIOC => {
-                    self.rcc.enable_gpioc_clock();
+                    rcc.enable_gpioc_clock();
                 }
                 HCLK1::GPIOB => {
-                    self.rcc.enable_gpiob_clock();
+                    rcc.enable_gpiob_clock();
                 }
                 HCLK1::GPIOA => {
-                    self.rcc.enable_gpioa_clock();
+                    rcc.enable_gpioa_clock();
                 }
             },
             PeripheralClockType::AHB2(ref v) => match v {
                 HCLK2::RNG => {
-                    self.rcc.enable_rng_clock();
+                    rcc.enable_rng_clock();
                 }
                 HCLK2::OTGFS => {
-                    self.rcc.enable_otgfs_clock();
+                    rcc.enable_otgfs_clock();
                 }
             },
             PeripheralClockType::AHB3(ref v) => match v {
-                HCLK3::FMC => self.rcc.enable_fmc_clock(),
+                HCLK3::FMC => rcc.enable_fmc_clock(),
             },
             PeripheralClockType::APB1(ref v) => match v {
                 PCLK1::TIM2 => {
-                    self.rcc.enable_tim2_clock();
+                    rcc.enable_tim2_clock();
                 }
                 PCLK1::USART2 => {
-                    self.rcc.enable_usart2_clock();
+                    rcc.enable_usart2_clock();
                 }
                 PCLK1::USART3 => {
-                    self.rcc.enable_usart3_clock();
+                    rcc.enable_usart3_clock();
                 }
                 PCLK1::I2C1 => {
-                    self.rcc.enable_i2c1_clock();
+                    rcc.enable_i2c1_clock();
                 }
                 PCLK1::SPI3 => {
-                    self.rcc.enable_spi3_clock();
+                    rcc.enable_spi3_clock();
                 }
                 PCLK1::CAN1 => {
-                    self.rcc.enable_can1_clock();
+                    rcc.enable_can1_clock();
                 }
                 PCLK1::DAC => {
-                    self.rcc.enable_dac_clock();
+                    rcc.enable_dac_clock();
                 }
             },
             PeripheralClockType::APB2(ref v) => match v {
                 PCLK2::USART1 => {
-                    self.rcc.enable_usart1_clock();
+                    rcc.enable_usart1_clock();
                 }
                 PCLK2::ADC1 => {
-                    self.rcc.enable_adc1_clock();
+                    rcc.enable_adc1_clock();
                 }
                 PCLK2::SYSCFG => {
-                    self.rcc.enable_syscfg_clock();
+                    rcc.enable_syscfg_clock();
                 }
             },
-            PeripheralClockType::RTC => self.rcc.enable_rtc_clock(RtcClockSource::LSI),
-            PeripheralClockType::PWR => self.rcc.enable_pwr_clock(),
+            PeripheralClockType::RTC => rcc.enable_rtc_clock(RtcClockSource::LSI),
+            PeripheralClockType::PWR => rcc.enable_pwr_clock(),
         }
     }
 
     fn disable(&self) {
+        let rcc = self.clocks.get_rcc();
         match self.clock {
             PeripheralClockType::AHB1(ref v) => match v {
                 HCLK1::DMA1 => {
-                    self.rcc.disable_dma1_clock();
+                    rcc.disable_dma1_clock();
                 }
                 HCLK1::DMA2 => {
-                    self.rcc.disable_dma2_clock();
+                    rcc.disable_dma2_clock();
                 }
                 HCLK1::GPIOH => {
-                    self.rcc.disable_gpioh_clock();
+                    rcc.disable_gpioh_clock();
                 }
                 HCLK1::GPIOG => {
-                    self.rcc.disable_gpiog_clock();
+                    rcc.disable_gpiog_clock();
                 }
                 HCLK1::GPIOF => {
-                    self.rcc.disable_gpiof_clock();
+                    rcc.disable_gpiof_clock();
                 }
                 HCLK1::GPIOE => {
-                    self.rcc.disable_gpioe_clock();
+                    rcc.disable_gpioe_clock();
                 }
                 HCLK1::GPIOD => {
-                    self.rcc.disable_gpiod_clock();
+                    rcc.disable_gpiod_clock();
                 }
                 HCLK1::GPIOC => {
-                    self.rcc.disable_gpioc_clock();
+                    rcc.disable_gpioc_clock();
                 }
                 HCLK1::GPIOB => {
-                    self.rcc.disable_gpiob_clock();
+                    rcc.disable_gpiob_clock();
                 }
                 HCLK1::GPIOA => {
-                    self.rcc.disable_gpioa_clock();
+                    rcc.disable_gpioa_clock();
                 }
             },
             PeripheralClockType::AHB2(ref v) => match v {
                 HCLK2::RNG => {
-                    self.rcc.disable_rng_clock();
+                    rcc.disable_rng_clock();
                 }
                 HCLK2::OTGFS => {
-                    self.rcc.disable_otgfs_clock();
+                    rcc.disable_otgfs_clock();
                 }
             },
             PeripheralClockType::AHB3(ref v) => match v {
-                HCLK3::FMC => self.rcc.disable_fmc_clock(),
+                HCLK3::FMC => rcc.disable_fmc_clock(),
             },
             PeripheralClockType::APB1(ref v) => match v {
                 PCLK1::TIM2 => {
-                    self.rcc.disable_tim2_clock();
+                    rcc.disable_tim2_clock();
                 }
                 PCLK1::USART2 => {
-                    self.rcc.disable_usart2_clock();
+                    rcc.disable_usart2_clock();
                 }
                 PCLK1::USART3 => {
-                    self.rcc.disable_usart3_clock();
+                    rcc.disable_usart3_clock();
                 }
                 PCLK1::I2C1 => {
-                    self.rcc.disable_i2c1_clock();
+                    rcc.disable_i2c1_clock();
                 }
                 PCLK1::SPI3 => {
-                    self.rcc.disable_spi3_clock();
+                    rcc.disable_spi3_clock();
                 }
                 PCLK1::CAN1 => {
-                    self.rcc.disable_can1_clock();
+                    rcc.disable_can1_clock();
                 }
                 PCLK1::DAC => {
-                    self.rcc.disable_dac_clock();
+                    rcc.disable_dac_clock();
                 }
             },
             PeripheralClockType::APB2(ref v) => match v {
                 PCLK2::USART1 => {
-                    self.rcc.disable_usart1_clock();
+                    rcc.disable_usart1_clock();
                 }
                 PCLK2::ADC1 => {
-                    self.rcc.disable_adc1_clock();
+                    rcc.disable_adc1_clock();
                 }
                 PCLK2::SYSCFG => {
-                    self.rcc.disable_syscfg_clock();
+                    rcc.disable_syscfg_clock();
                 }
             },
-            PeripheralClockType::RTC => self.rcc.disable_rtc_clock(),
-            PeripheralClockType::PWR => self.rcc.disable_pwr_clock(),
+            PeripheralClockType::RTC => rcc.disable_rtc_clock(),
+            PeripheralClockType::PWR => rcc.disable_pwr_clock(),
         }
     }
 }

--- a/chips/stm32f4xx/src/rcc.rs
+++ b/chips/stm32f4xx/src/rcc.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use kernel::platform::chip::ClockInterface;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 use kernel::utilities::registers::{register_bitfields, ReadWrite};
 use kernel::utilities::StaticRef;
@@ -1054,337 +1053,340 @@ impl Rcc {
         }
     }
 
-    fn configure_rng_clock(&self) {
+    pub(crate) fn configure_rng_clock(&self) {
         self.registers.pllcfgr.modify(PLLCFGR::PLLQ.val(2));
         self.registers.cr.modify(CR::PLLON::SET);
     }
 
     // I2C1 clock
 
-    fn is_enabled_i2c1_clock(&self) -> bool {
+    pub(crate) fn is_enabled_i2c1_clock(&self) -> bool {
         self.registers.apb1enr.is_set(APB1ENR::I2C1EN)
     }
 
-    fn enable_i2c1_clock(&self) {
+    pub(crate) fn enable_i2c1_clock(&self) {
         self.registers.apb1enr.modify(APB1ENR::I2C1EN::SET);
         self.registers.apb1rstr.modify(APB1RSTR::I2C1RST::SET);
         self.registers.apb1rstr.modify(APB1RSTR::I2C1RST::CLEAR);
     }
 
-    fn disable_i2c1_clock(&self) {
+    pub(crate) fn disable_i2c1_clock(&self) {
         self.registers.apb1enr.modify(APB1ENR::I2C1EN::CLEAR)
     }
 
     // SPI3 clock
 
-    fn is_enabled_spi3_clock(&self) -> bool {
+    pub(crate) fn is_enabled_spi3_clock(&self) -> bool {
         self.registers.apb1enr.is_set(APB1ENR::SPI3EN)
     }
 
-    fn enable_spi3_clock(&self) {
+    pub(crate) fn enable_spi3_clock(&self) {
         self.registers.apb1enr.modify(APB1ENR::SPI3EN::SET)
     }
 
-    fn disable_spi3_clock(&self) {
+    pub(crate) fn disable_spi3_clock(&self) {
         self.registers.apb1enr.modify(APB1ENR::SPI3EN::CLEAR)
     }
 
     // TIM2 clock
+    pub(crate) fn is_enabled_tim_pre(&self) -> bool {
+        self.registers.dckcfgr.is_set(DCKCFGR::TIMPRE)
+    }
 
-    fn is_enabled_tim2_clock(&self) -> bool {
+    pub(crate) fn is_enabled_tim2_clock(&self) -> bool {
         self.registers.apb1enr.is_set(APB1ENR::TIM2EN)
     }
 
-    fn enable_tim2_clock(&self) {
+    pub(crate) fn enable_tim2_clock(&self) {
         self.registers.apb1enr.modify(APB1ENR::TIM2EN::SET)
     }
 
-    fn disable_tim2_clock(&self) {
+    pub(crate) fn disable_tim2_clock(&self) {
         self.registers.apb1enr.modify(APB1ENR::TIM2EN::CLEAR)
     }
 
     // SYSCFG clock
 
-    fn is_enabled_syscfg_clock(&self) -> bool {
+    pub(crate) fn is_enabled_syscfg_clock(&self) -> bool {
         self.registers.apb2enr.is_set(APB2ENR::SYSCFGEN)
     }
 
-    fn enable_syscfg_clock(&self) {
+    pub(crate) fn enable_syscfg_clock(&self) {
         self.registers.apb2enr.modify(APB2ENR::SYSCFGEN::SET)
     }
 
-    fn disable_syscfg_clock(&self) {
+    pub(crate) fn disable_syscfg_clock(&self) {
         self.registers.apb2enr.modify(APB2ENR::SYSCFGEN::CLEAR)
     }
 
     // DMA1 clock
 
-    fn is_enabled_dma1_clock(&self) -> bool {
+    pub(crate) fn is_enabled_dma1_clock(&self) -> bool {
         self.registers.ahb1enr.is_set(AHB1ENR::DMA1EN)
     }
 
-    fn enable_dma1_clock(&self) {
+    pub(crate) fn enable_dma1_clock(&self) {
         self.registers.ahb1enr.modify(AHB1ENR::DMA1EN::SET)
     }
 
-    fn disable_dma1_clock(&self) {
+    pub(crate) fn disable_dma1_clock(&self) {
         self.registers.ahb1enr.modify(AHB1ENR::DMA1EN::CLEAR)
     }
 
     // DMA2 clock
-    fn is_enabled_dma2_clock(&self) -> bool {
+    pub(crate) fn is_enabled_dma2_clock(&self) -> bool {
         self.registers.ahb1enr.is_set(AHB1ENR::DMA2EN)
     }
 
-    fn enable_dma2_clock(&self) {
+    pub(crate) fn enable_dma2_clock(&self) {
         self.registers.ahb1enr.modify(AHB1ENR::DMA2EN::SET)
     }
 
-    fn disable_dma2_clock(&self) {
+    pub(crate) fn disable_dma2_clock(&self) {
         self.registers.ahb1enr.modify(AHB1ENR::DMA2EN::CLEAR)
     }
 
     // GPIOH clock
 
-    fn is_enabled_gpioh_clock(&self) -> bool {
+    pub(crate) fn is_enabled_gpioh_clock(&self) -> bool {
         self.registers.ahb1enr.is_set(AHB1ENR::GPIOHEN)
     }
 
-    fn enable_gpioh_clock(&self) {
+    pub(crate) fn enable_gpioh_clock(&self) {
         self.registers.ahb1enr.modify(AHB1ENR::GPIOHEN::SET)
     }
 
-    fn disable_gpioh_clock(&self) {
+    pub(crate) fn disable_gpioh_clock(&self) {
         self.registers.ahb1enr.modify(AHB1ENR::GPIOHEN::CLEAR)
     }
 
     // GPIOG clock
 
-    fn is_enabled_gpiog_clock(&self) -> bool {
+    pub(crate) fn is_enabled_gpiog_clock(&self) -> bool {
         self.registers.ahb1enr.is_set(AHB1ENR::GPIOGEN)
     }
 
-    fn enable_gpiog_clock(&self) {
+    pub(crate) fn enable_gpiog_clock(&self) {
         self.registers.ahb1enr.modify(AHB1ENR::GPIOGEN::SET)
     }
 
-    fn disable_gpiog_clock(&self) {
+    pub(crate) fn disable_gpiog_clock(&self) {
         self.registers.ahb1enr.modify(AHB1ENR::GPIOGEN::CLEAR)
     }
 
     // GPIOF clock
 
-    fn is_enabled_gpiof_clock(&self) -> bool {
+    pub(crate) fn is_enabled_gpiof_clock(&self) -> bool {
         self.registers.ahb1enr.is_set(AHB1ENR::GPIOFEN)
     }
 
-    fn enable_gpiof_clock(&self) {
+    pub(crate) fn enable_gpiof_clock(&self) {
         self.registers.ahb1enr.modify(AHB1ENR::GPIOFEN::SET)
     }
 
-    fn disable_gpiof_clock(&self) {
+    pub(crate) fn disable_gpiof_clock(&self) {
         self.registers.ahb1enr.modify(AHB1ENR::GPIOFEN::CLEAR)
     }
 
     // GPIOE clock
 
-    fn is_enabled_gpioe_clock(&self) -> bool {
+    pub(crate) fn is_enabled_gpioe_clock(&self) -> bool {
         self.registers.ahb1enr.is_set(AHB1ENR::GPIOEEN)
     }
 
-    fn enable_gpioe_clock(&self) {
+    pub(crate) fn enable_gpioe_clock(&self) {
         self.registers.ahb1enr.modify(AHB1ENR::GPIOEEN::SET)
     }
 
-    fn disable_gpioe_clock(&self) {
+    pub(crate) fn disable_gpioe_clock(&self) {
         self.registers.ahb1enr.modify(AHB1ENR::GPIOEEN::CLEAR)
     }
 
     // GPIOD clock
 
-    fn is_enabled_gpiod_clock(&self) -> bool {
+    pub(crate) fn is_enabled_gpiod_clock(&self) -> bool {
         self.registers.ahb1enr.is_set(AHB1ENR::GPIODEN)
     }
 
-    fn enable_gpiod_clock(&self) {
+    pub(crate) fn enable_gpiod_clock(&self) {
         self.registers.ahb1enr.modify(AHB1ENR::GPIODEN::SET)
     }
 
-    fn disable_gpiod_clock(&self) {
+    pub(crate) fn disable_gpiod_clock(&self) {
         self.registers.ahb1enr.modify(AHB1ENR::GPIODEN::CLEAR)
     }
 
     // GPIOC clock
 
-    fn is_enabled_gpioc_clock(&self) -> bool {
+    pub(crate) fn is_enabled_gpioc_clock(&self) -> bool {
         self.registers.ahb1enr.is_set(AHB1ENR::GPIOCEN)
     }
 
-    fn enable_gpioc_clock(&self) {
+    pub(crate) fn enable_gpioc_clock(&self) {
         self.registers.ahb1enr.modify(AHB1ENR::GPIOCEN::SET)
     }
 
-    fn disable_gpioc_clock(&self) {
+    pub(crate) fn disable_gpioc_clock(&self) {
         self.registers.ahb1enr.modify(AHB1ENR::GPIOCEN::CLEAR)
     }
 
     // GPIOB clock
 
-    fn is_enabled_gpiob_clock(&self) -> bool {
+    pub(crate) fn is_enabled_gpiob_clock(&self) -> bool {
         self.registers.ahb1enr.is_set(AHB1ENR::GPIOBEN)
     }
 
-    fn enable_gpiob_clock(&self) {
+    pub(crate) fn enable_gpiob_clock(&self) {
         self.registers.ahb1enr.modify(AHB1ENR::GPIOBEN::SET)
     }
 
-    fn disable_gpiob_clock(&self) {
+    pub(crate) fn disable_gpiob_clock(&self) {
         self.registers.ahb1enr.modify(AHB1ENR::GPIOBEN::CLEAR)
     }
 
     // GPIOA clock
 
-    fn is_enabled_gpioa_clock(&self) -> bool {
+    pub(crate) fn is_enabled_gpioa_clock(&self) -> bool {
         self.registers.ahb1enr.is_set(AHB1ENR::GPIOAEN)
     }
 
-    fn enable_gpioa_clock(&self) {
+    pub(crate) fn enable_gpioa_clock(&self) {
         self.registers.ahb1enr.modify(AHB1ENR::GPIOAEN::SET)
     }
 
-    fn disable_gpioa_clock(&self) {
+    pub(crate) fn disable_gpioa_clock(&self) {
         self.registers.ahb1enr.modify(AHB1ENR::GPIOAEN::CLEAR)
     }
 
     // FMC
 
-    fn is_enabled_fmc_clock(&self) -> bool {
+    pub(crate) fn is_enabled_fmc_clock(&self) -> bool {
         self.registers.ahb3enr.is_set(AHB3ENR::FMCEN)
     }
 
-    fn enable_fmc_clock(&self) {
+    pub(crate) fn enable_fmc_clock(&self) {
         self.registers.ahb3enr.modify(AHB3ENR::FMCEN::SET)
     }
 
-    fn disable_fmc_clock(&self) {
+    pub(crate) fn disable_fmc_clock(&self) {
         self.registers.ahb3enr.modify(AHB3ENR::FMCEN::CLEAR)
     }
 
     // USART1 clock
-    fn is_enabled_usart1_clock(&self) -> bool {
+    pub(crate) fn is_enabled_usart1_clock(&self) -> bool {
         self.registers.apb2enr.is_set(APB2ENR::USART1EN)
     }
 
-    fn enable_usart1_clock(&self) {
+    pub(crate) fn enable_usart1_clock(&self) {
         self.registers.apb2enr.modify(APB2ENR::USART1EN::SET)
     }
 
-    fn disable_usart1_clock(&self) {
+    pub(crate) fn disable_usart1_clock(&self) {
         self.registers.apb2enr.modify(APB2ENR::USART1EN::CLEAR)
     }
 
     // USART2 clock
 
-    fn is_enabled_usart2_clock(&self) -> bool {
+    pub(crate) fn is_enabled_usart2_clock(&self) -> bool {
         self.registers.apb1enr.is_set(APB1ENR::USART2EN)
     }
 
-    fn enable_usart2_clock(&self) {
+    pub(crate) fn enable_usart2_clock(&self) {
         self.registers.apb1enr.modify(APB1ENR::USART2EN::SET)
     }
 
-    fn disable_usart2_clock(&self) {
+    pub(crate) fn disable_usart2_clock(&self) {
         self.registers.apb1enr.modify(APB1ENR::USART2EN::CLEAR)
     }
 
     // USART3 clock
 
-    fn is_enabled_usart3_clock(&self) -> bool {
+    pub(crate) fn is_enabled_usart3_clock(&self) -> bool {
         self.registers.apb1enr.is_set(APB1ENR::USART3EN)
     }
 
-    fn enable_usart3_clock(&self) {
+    pub(crate) fn enable_usart3_clock(&self) {
         self.registers.apb1enr.modify(APB1ENR::USART3EN::SET)
     }
 
-    fn disable_usart3_clock(&self) {
+    pub(crate) fn disable_usart3_clock(&self) {
         self.registers.apb1enr.modify(APB1ENR::USART3EN::CLEAR)
     }
 
     // ADC1 clock
 
-    fn is_enabled_adc1_clock(&self) -> bool {
+    pub(crate) fn is_enabled_adc1_clock(&self) -> bool {
         self.registers.apb2enr.is_set(APB2ENR::ADC1EN)
     }
 
-    fn enable_adc1_clock(&self) {
+    pub(crate) fn enable_adc1_clock(&self) {
         self.registers.apb2enr.modify(APB2ENR::ADC1EN::SET)
     }
 
-    fn disable_adc1_clock(&self) {
+    pub(crate) fn disable_adc1_clock(&self) {
         self.registers.apb2enr.modify(APB2ENR::ADC1EN::CLEAR)
     }
 
     // DAC clock
 
-    fn is_enabled_dac_clock(&self) -> bool {
+    pub(crate) fn is_enabled_dac_clock(&self) -> bool {
         self.registers.apb1enr.is_set(APB1ENR::DACEN)
     }
 
-    fn enable_dac_clock(&self) {
+    pub(crate) fn enable_dac_clock(&self) {
         self.registers.apb1enr.modify(APB1ENR::DACEN::SET)
     }
 
-    fn disable_dac_clock(&self) {
+    pub(crate) fn disable_dac_clock(&self) {
         self.registers.apb1enr.modify(APB1ENR::DACEN::CLEAR)
     }
 
     // RNG clock
 
-    fn is_enabled_rng_clock(&self) -> bool {
+    pub(crate) fn is_enabled_rng_clock(&self) -> bool {
         self.registers.ahb2enr.is_set(AHB2ENR::RNGEN)
     }
 
-    fn enable_rng_clock(&self) {
+    pub(crate) fn enable_rng_clock(&self) {
         self.registers.ahb2enr.modify(AHB2ENR::RNGEN::SET);
     }
 
-    fn disable_rng_clock(&self) {
+    pub(crate) fn disable_rng_clock(&self) {
         self.registers.ahb2enr.modify(AHB2ENR::RNGEN::CLEAR);
     }
 
     // OTGFS clock
 
-    fn is_enabled_otgfs_clock(&self) -> bool {
+    pub(crate) fn is_enabled_otgfs_clock(&self) -> bool {
         self.registers.ahb2enr.is_set(AHB2ENR::OTGFSEN)
     }
 
-    fn enable_otgfs_clock(&self) {
+    pub(crate) fn enable_otgfs_clock(&self) {
         self.registers.ahb2enr.modify(AHB2ENR::OTGFSEN::SET);
     }
 
-    fn disable_otgfs_clock(&self) {
+    pub(crate) fn disable_otgfs_clock(&self) {
         self.registers.ahb2enr.modify(AHB2ENR::OTGFSEN::CLEAR);
     }
 
     // CAN1 clock
 
-    fn is_enabled_can1_clock(&self) -> bool {
+    pub(crate) fn is_enabled_can1_clock(&self) -> bool {
         self.registers.apb1enr.is_set(APB1ENR::CAN1EN)
     }
 
-    fn enable_can1_clock(&self) {
+    pub(crate) fn enable_can1_clock(&self) {
         self.registers.apb1rstr.modify(APB1RSTR::CAN1RST::SET);
         self.registers.apb1rstr.modify(APB1RSTR::CAN1RST::CLEAR);
         self.registers.apb1enr.modify(APB1ENR::CAN1EN::SET);
     }
 
-    fn disable_can1_clock(&self) {
+    pub(crate) fn disable_can1_clock(&self) {
         self.registers.apb1enr.modify(APB1ENR::CAN1EN::CLEAR);
     }
 
     // RTC clock
-    fn source_into_u32(source: RtcClockSource) -> u32 {
+    pub(crate) fn source_into_u32(source: RtcClockSource) -> u32 {
         match source {
             RtcClockSource::LSE => 1,
             RtcClockSource::LSI => 2,
@@ -1392,28 +1394,28 @@ impl Rcc {
         }
     }
 
-    fn enable_lsi_clock(&self) {
+    pub(crate) fn enable_lsi_clock(&self) {
         self.registers.csr.modify(CSR::LSION::SET);
     }
 
-    fn is_enabled_pwr_clock(&self) -> bool {
+    pub(crate) fn is_enabled_pwr_clock(&self) -> bool {
         self.registers.apb1enr.is_set(APB1ENR::PWREN)
     }
 
-    fn enable_pwr_clock(&self) {
+    pub(crate) fn enable_pwr_clock(&self) {
         // Enable the power interface clock
         self.registers.apb1enr.modify(APB1ENR::PWREN::SET);
     }
 
-    fn disable_pwr_clock(&self) {
+    pub(crate) fn disable_pwr_clock(&self) {
         self.registers.apb1enr.modify(APB1ENR::PWREN::CLEAR);
     }
 
-    fn is_enabled_rtc_clock(&self) -> bool {
+    pub(crate) fn is_enabled_rtc_clock(&self) -> bool {
         self.registers.bdcr.is_set(BDCR::RTCEN)
     }
 
-    fn enable_rtc_clock(&self, source: RtcClockSource) {
+    pub(crate) fn enable_rtc_clock(&self, source: RtcClockSource) {
         // Enable LSI
         self.enable_lsi_clock();
         let mut counter = 1_000;
@@ -1432,7 +1434,7 @@ impl Rcc {
         self.registers.bdcr.modify(BDCR::RTCEN::SET);
     }
 
-    fn disable_rtc_clock(&self) {
+    pub(crate) fn disable_rtc_clock(&self) {
         self.registers.bdcr.modify(BDCR::RTCEN.val(1));
         self.registers.bdcr.modify(BDCR::RTCSEL.val(0));
     }
@@ -1556,335 +1558,6 @@ impl From<APBPrescaler> for usize {
             APBPrescaler::DivideBy4 => 4,
             APBPrescaler::DivideBy8 => 8,
             APBPrescaler::DivideBy16 => 16,
-        }
-    }
-}
-
-use crate::clocks::clocks::Stm32f4Clocks;
-
-pub struct PeripheralClock<'a> {
-    pub clock: PeripheralClockType,
-    clocks: &'a dyn Stm32f4Clocks,
-}
-
-/// Bus + Clock name for the peripherals
-pub enum PeripheralClockType {
-    AHB1(HCLK1),
-    AHB2(HCLK2),
-    AHB3(HCLK3),
-    APB1(PCLK1),
-    APB2(PCLK2),
-    RTC,
-    PWR,
-}
-
-/// Peripherals clocked by HCLK1
-pub enum HCLK1 {
-    DMA1,
-    DMA2,
-    GPIOH,
-    GPIOG,
-    GPIOF,
-    GPIOE,
-    GPIOD,
-    GPIOC,
-    GPIOB,
-    GPIOA,
-}
-
-/// Peripherals clocked by HCLK3
-pub enum HCLK3 {
-    FMC,
-}
-
-/// Peripherals clocked by HCLK2
-pub enum HCLK2 {
-    RNG,
-    OTGFS,
-}
-
-/// Peripherals clocked by PCLK1
-pub enum PCLK1 {
-    TIM2,
-    USART2,
-    USART3,
-    SPI3,
-    I2C1,
-    CAN1,
-    DAC,
-}
-
-/// Peripherals clocked by PCLK2
-pub enum PCLK2 {
-    USART1,
-    ADC1,
-    SYSCFG,
-}
-
-impl<'a> PeripheralClock<'a> {
-    pub const fn new(clock: PeripheralClockType, clocks: &'a dyn Stm32f4Clocks) -> Self {
-        Self { clock, clocks }
-    }
-
-    pub fn configure_rng_clock(&self) {
-        self.clocks.get_rcc().configure_rng_clock();
-    }
-
-    pub fn get_frequency(&self) -> u32 {
-        #[inline(always)]
-        fn tim_freq(rcc: &Rcc, hclk_freq: usize, prescaler: APBPrescaler) -> usize {
-            // Reference Manual RM0090 section 6.2
-            // When TIMPRE bit of the RCC_DCKCFGR register is reset, if APBx prescaler is 1, then
-            // TIMxCLK = PCLKx, otherwise TIMxCLK = 2x PCLKx.
-            // When TIMPRE bit in the RCC_DCKCFGR register is set, if APBx prescaler is 1,2 or 4,
-            // then TIMxCLK = HCLK, otherwise TIMxCLK = 4x PCLKx.
-            if !rcc.registers.dckcfgr.is_set(DCKCFGR::TIMPRE) {
-                match prescaler {
-                    APBPrescaler::DivideBy1 | APBPrescaler::DivideBy2 => hclk_freq,
-                    _ => hclk_freq / usize::from(prescaler) * 2,
-                }
-            } else {
-                match prescaler {
-                    APBPrescaler::DivideBy1 | APBPrescaler::DivideBy2 | APBPrescaler::DivideBy4 => {
-                        hclk_freq
-                    }
-                    _ => hclk_freq / usize::from(prescaler) * 4,
-                }
-            }
-        }
-        let rcc = self.clocks.get_rcc();
-        let hclk_freq = rcc.get_sys_clock_frequency();
-        match self.clock {
-            PeripheralClockType::AHB1(_)
-            | PeripheralClockType::AHB2(_)
-            | PeripheralClockType::AHB3(_) => hclk_freq as u32,
-            PeripheralClockType::APB1(ref v) => {
-                let prescaler = rcc.get_apb1_prescaler();
-                match v {
-                    PCLK1::TIM2 => tim_freq(rcc, hclk_freq, prescaler) as u32,
-                    _ => (hclk_freq / usize::from(prescaler)) as u32,
-                }
-            }
-            PeripheralClockType::APB2(_) => {
-                let prescaler = rcc.get_apb2_prescaler();
-                (hclk_freq / usize::from(prescaler)) as u32
-            }
-            //TODO: implement clock frequency retrieval for RTC and PWR peripherals
-            PeripheralClockType::RTC => todo!(),
-            PeripheralClockType::PWR => todo!(),
-        }
-    }
-}
-
-impl<'a> ClockInterface for PeripheralClock<'a> {
-    fn is_enabled(&self) -> bool {
-        let rcc = self.clocks.get_rcc();
-        match self.clock {
-            PeripheralClockType::AHB1(ref v) => match v {
-                HCLK1::DMA1 => rcc.is_enabled_dma1_clock(),
-                HCLK1::DMA2 => rcc.is_enabled_dma2_clock(),
-                HCLK1::GPIOH => rcc.is_enabled_gpioh_clock(),
-                HCLK1::GPIOG => rcc.is_enabled_gpiog_clock(),
-                HCLK1::GPIOF => rcc.is_enabled_gpiof_clock(),
-                HCLK1::GPIOE => rcc.is_enabled_gpioe_clock(),
-                HCLK1::GPIOD => rcc.is_enabled_gpiod_clock(),
-                HCLK1::GPIOC => rcc.is_enabled_gpioc_clock(),
-                HCLK1::GPIOB => rcc.is_enabled_gpiob_clock(),
-                HCLK1::GPIOA => rcc.is_enabled_gpioa_clock(),
-            },
-            PeripheralClockType::AHB2(ref v) => match v {
-                HCLK2::RNG => rcc.is_enabled_rng_clock(),
-                HCLK2::OTGFS => rcc.is_enabled_otgfs_clock(),
-            },
-            PeripheralClockType::AHB3(ref v) => match v {
-                HCLK3::FMC => rcc.is_enabled_fmc_clock(),
-            },
-            PeripheralClockType::APB1(ref v) => match v {
-                PCLK1::TIM2 => rcc.is_enabled_tim2_clock(),
-                PCLK1::USART2 => rcc.is_enabled_usart2_clock(),
-                PCLK1::USART3 => rcc.is_enabled_usart3_clock(),
-                PCLK1::I2C1 => rcc.is_enabled_i2c1_clock(),
-                PCLK1::SPI3 => rcc.is_enabled_spi3_clock(),
-                PCLK1::CAN1 => rcc.is_enabled_can1_clock(),
-                PCLK1::DAC => rcc.is_enabled_dac_clock(),
-            },
-            PeripheralClockType::APB2(ref v) => match v {
-                PCLK2::USART1 => rcc.is_enabled_usart1_clock(),
-                PCLK2::ADC1 => rcc.is_enabled_adc1_clock(),
-                PCLK2::SYSCFG => rcc.is_enabled_syscfg_clock(),
-            },
-            PeripheralClockType::RTC => rcc.is_enabled_rtc_clock(),
-            PeripheralClockType::PWR => rcc.is_enabled_pwr_clock(),
-        }
-    }
-
-    fn enable(&self) {
-        let rcc = self.clocks.get_rcc();
-        match self.clock {
-            PeripheralClockType::AHB1(ref v) => match v {
-                HCLK1::DMA1 => {
-                    rcc.enable_dma1_clock();
-                }
-                HCLK1::DMA2 => {
-                    rcc.enable_dma2_clock();
-                }
-                HCLK1::GPIOH => {
-                    rcc.enable_gpioh_clock();
-                }
-                HCLK1::GPIOG => {
-                    rcc.enable_gpiog_clock();
-                }
-                HCLK1::GPIOF => {
-                    rcc.enable_gpiof_clock();
-                }
-                HCLK1::GPIOE => {
-                    rcc.enable_gpioe_clock();
-                }
-                HCLK1::GPIOD => {
-                    rcc.enable_gpiod_clock();
-                }
-                HCLK1::GPIOC => {
-                    rcc.enable_gpioc_clock();
-                }
-                HCLK1::GPIOB => {
-                    rcc.enable_gpiob_clock();
-                }
-                HCLK1::GPIOA => {
-                    rcc.enable_gpioa_clock();
-                }
-            },
-            PeripheralClockType::AHB2(ref v) => match v {
-                HCLK2::RNG => {
-                    rcc.enable_rng_clock();
-                }
-                HCLK2::OTGFS => {
-                    rcc.enable_otgfs_clock();
-                }
-            },
-            PeripheralClockType::AHB3(ref v) => match v {
-                HCLK3::FMC => rcc.enable_fmc_clock(),
-            },
-            PeripheralClockType::APB1(ref v) => match v {
-                PCLK1::TIM2 => {
-                    rcc.enable_tim2_clock();
-                }
-                PCLK1::USART2 => {
-                    rcc.enable_usart2_clock();
-                }
-                PCLK1::USART3 => {
-                    rcc.enable_usart3_clock();
-                }
-                PCLK1::I2C1 => {
-                    rcc.enable_i2c1_clock();
-                }
-                PCLK1::SPI3 => {
-                    rcc.enable_spi3_clock();
-                }
-                PCLK1::CAN1 => {
-                    rcc.enable_can1_clock();
-                }
-                PCLK1::DAC => {
-                    rcc.enable_dac_clock();
-                }
-            },
-            PeripheralClockType::APB2(ref v) => match v {
-                PCLK2::USART1 => {
-                    rcc.enable_usart1_clock();
-                }
-                PCLK2::ADC1 => {
-                    rcc.enable_adc1_clock();
-                }
-                PCLK2::SYSCFG => {
-                    rcc.enable_syscfg_clock();
-                }
-            },
-            PeripheralClockType::RTC => rcc.enable_rtc_clock(RtcClockSource::LSI),
-            PeripheralClockType::PWR => rcc.enable_pwr_clock(),
-        }
-    }
-
-    fn disable(&self) {
-        let rcc = self.clocks.get_rcc();
-        match self.clock {
-            PeripheralClockType::AHB1(ref v) => match v {
-                HCLK1::DMA1 => {
-                    rcc.disable_dma1_clock();
-                }
-                HCLK1::DMA2 => {
-                    rcc.disable_dma2_clock();
-                }
-                HCLK1::GPIOH => {
-                    rcc.disable_gpioh_clock();
-                }
-                HCLK1::GPIOG => {
-                    rcc.disable_gpiog_clock();
-                }
-                HCLK1::GPIOF => {
-                    rcc.disable_gpiof_clock();
-                }
-                HCLK1::GPIOE => {
-                    rcc.disable_gpioe_clock();
-                }
-                HCLK1::GPIOD => {
-                    rcc.disable_gpiod_clock();
-                }
-                HCLK1::GPIOC => {
-                    rcc.disable_gpioc_clock();
-                }
-                HCLK1::GPIOB => {
-                    rcc.disable_gpiob_clock();
-                }
-                HCLK1::GPIOA => {
-                    rcc.disable_gpioa_clock();
-                }
-            },
-            PeripheralClockType::AHB2(ref v) => match v {
-                HCLK2::RNG => {
-                    rcc.disable_rng_clock();
-                }
-                HCLK2::OTGFS => {
-                    rcc.disable_otgfs_clock();
-                }
-            },
-            PeripheralClockType::AHB3(ref v) => match v {
-                HCLK3::FMC => rcc.disable_fmc_clock(),
-            },
-            PeripheralClockType::APB1(ref v) => match v {
-                PCLK1::TIM2 => {
-                    rcc.disable_tim2_clock();
-                }
-                PCLK1::USART2 => {
-                    rcc.disable_usart2_clock();
-                }
-                PCLK1::USART3 => {
-                    rcc.disable_usart3_clock();
-                }
-                PCLK1::I2C1 => {
-                    rcc.disable_i2c1_clock();
-                }
-                PCLK1::SPI3 => {
-                    rcc.disable_spi3_clock();
-                }
-                PCLK1::CAN1 => {
-                    rcc.disable_can1_clock();
-                }
-                PCLK1::DAC => {
-                    rcc.disable_dac_clock();
-                }
-            },
-            PeripheralClockType::APB2(ref v) => match v {
-                PCLK2::USART1 => {
-                    rcc.disable_usart1_clock();
-                }
-                PCLK2::ADC1 => {
-                    rcc.disable_adc1_clock();
-                }
-                PCLK2::SYSCFG => {
-                    rcc.disable_syscfg_clock();
-                }
-            },
-            PeripheralClockType::RTC => rcc.disable_rtc_clock(),
-            PeripheralClockType::PWR => rcc.disable_pwr_clock(),
         }
     }
 }

--- a/chips/stm32f4xx/src/spi.rs
+++ b/chips/stm32f4xx/src/spi.rs
@@ -15,9 +15,9 @@ use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite};
 use kernel::utilities::StaticRef;
 
+use crate::clocks::phclk;
 use crate::dma;
 use crate::dma::{Dma1, Dma1Peripheral};
-use crate::rcc;
 
 /// Serial peripheral interface
 #[repr(C)]
@@ -510,7 +510,7 @@ impl<'a> dma::StreamClient<'a, Dma1<'a>> for Spi<'a> {
     }
 }
 
-pub struct SpiClock<'a>(pub rcc::PeripheralClock<'a>);
+pub struct SpiClock<'a>(pub phclk::PeripheralClock<'a>);
 
 impl ClockInterface for SpiClock<'_> {
     fn is_enabled(&self) -> bool {

--- a/chips/stm32f4xx/src/syscfg.rs
+++ b/chips/stm32f4xx/src/syscfg.rs
@@ -9,9 +9,8 @@ use kernel::utilities::registers::interfaces::ReadWriteable;
 use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite};
 use kernel::utilities::StaticRef;
 
-use crate::clocks::Stm32f4Clocks;
+use crate::clocks::{phclk, Stm32f4Clocks};
 use crate::gpio;
-use crate::rcc;
 
 /// System configuration controller
 #[repr(C)]
@@ -129,8 +128,8 @@ impl<'a> Syscfg<'a> {
     pub const fn new(clocks: &'a dyn Stm32f4Clocks) -> Self {
         Self {
             registers: SYSCFG_BASE,
-            clock: SyscfgClock(rcc::PeripheralClock::new(
-                rcc::PeripheralClockType::APB2(rcc::PCLK2::SYSCFG),
+            clock: SyscfgClock(phclk::PeripheralClock::new(
+                phclk::PeripheralClockType::APB2(phclk::PCLK2::SYSCFG),
                 clocks,
             )),
         }
@@ -231,7 +230,7 @@ impl<'a> Syscfg<'a> {
     }
 }
 
-struct SyscfgClock<'a>(rcc::PeripheralClock<'a>);
+struct SyscfgClock<'a>(phclk::PeripheralClock<'a>);
 
 impl ClockInterface for SyscfgClock<'_> {
     fn is_enabled(&self) -> bool {

--- a/chips/stm32f4xx/src/syscfg.rs
+++ b/chips/stm32f4xx/src/syscfg.rs
@@ -9,6 +9,7 @@ use kernel::utilities::registers::interfaces::ReadWriteable;
 use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite};
 use kernel::utilities::StaticRef;
 
+use crate::clocks::Stm32f4Clocks;
 use crate::gpio;
 use crate::rcc;
 
@@ -125,12 +126,12 @@ pub struct Syscfg<'a> {
 }
 
 impl<'a> Syscfg<'a> {
-    pub const fn new(rcc: &'a rcc::Rcc) -> Self {
+    pub const fn new(clocks: &'a dyn Stm32f4Clocks) -> Self {
         Self {
             registers: SYSCFG_BASE,
             clock: SyscfgClock(rcc::PeripheralClock::new(
                 rcc::PeripheralClockType::APB2(rcc::PCLK2::SYSCFG),
-                rcc,
+                clocks,
             )),
         }
     }

--- a/chips/stm32f4xx/src/tim2.rs
+++ b/chips/stm32f4xx/src/tim2.rs
@@ -13,9 +13,8 @@ use kernel::utilities::registers::{register_bitfields, ReadWrite, WriteOnly};
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 
-use crate::clocks::Stm32f4Clocks;
+use crate::clocks::{phclk, Stm32f4Clocks};
 use crate::nvic;
-use crate::rcc;
 
 /// General purpose timers
 #[repr(C)]
@@ -323,8 +322,8 @@ impl<'a> Tim2<'a> {
     pub const fn new(clocks: &'a dyn Stm32f4Clocks) -> Self {
         Self {
             registers: TIM2_BASE,
-            clock: Tim2Clock(rcc::PeripheralClock::new(
-                rcc::PeripheralClockType::APB1(rcc::PCLK1::TIM2),
+            clock: Tim2Clock(phclk::PeripheralClock::new(
+                phclk::PeripheralClockType::APB1(phclk::PCLK1::TIM2),
                 clocks,
             )),
             client: OptionalCell::empty(),
@@ -454,7 +453,7 @@ impl<'a> Alarm<'a> for Tim2<'a> {
     }
 }
 
-struct Tim2Clock<'a>(rcc::PeripheralClock<'a>);
+struct Tim2Clock<'a>(phclk::PeripheralClock<'a>);
 
 impl ClockInterface for Tim2Clock<'_> {
     fn is_enabled(&self) -> bool {

--- a/chips/stm32f4xx/src/tim2.rs
+++ b/chips/stm32f4xx/src/tim2.rs
@@ -13,6 +13,7 @@ use kernel::utilities::registers::{register_bitfields, ReadWrite, WriteOnly};
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 
+use crate::clocks::Stm32f4Clocks;
 use crate::nvic;
 use crate::rcc;
 
@@ -319,12 +320,12 @@ pub struct Tim2<'a> {
 }
 
 impl<'a> Tim2<'a> {
-    pub const fn new(rcc: &'a rcc::Rcc) -> Self {
+    pub const fn new(clocks: &'a dyn Stm32f4Clocks) -> Self {
         Self {
             registers: TIM2_BASE,
             clock: Tim2Clock(rcc::PeripheralClock::new(
                 rcc::PeripheralClockType::APB1(rcc::PCLK1::TIM2),
-                rcc,
+                clocks,
             )),
             client: OptionalCell::empty(),
             irqn: nvic::TIM2,

--- a/chips/stm32f4xx/src/trng.rs
+++ b/chips/stm32f4xx/src/trng.rs
@@ -4,6 +4,7 @@
 
 //! True random number generator
 
+use crate::clocks::Stm32f4Clocks;
 use crate::rcc;
 use kernel::hil;
 use kernel::hil::entropy::Continue;
@@ -58,12 +59,15 @@ pub struct Trng<'a> {
 }
 
 impl<'a> Trng<'a> {
-    pub const fn new(registers: StaticRef<RngRegisters>, rcc: &'a rcc::Rcc) -> Trng<'a> {
+    pub const fn new(
+        registers: StaticRef<RngRegisters>,
+        clocks: &'a dyn Stm32f4Clocks,
+    ) -> Trng<'a> {
         Trng {
             registers: registers,
             clock: RngClock(rcc::PeripheralClock::new(
                 rcc::PeripheralClockType::AHB2(rcc::HCLK2::RNG),
-                rcc,
+                clocks,
             )),
             client: OptionalCell::empty(),
         }

--- a/chips/stm32f4xx/src/trng.rs
+++ b/chips/stm32f4xx/src/trng.rs
@@ -4,8 +4,7 @@
 
 //! True random number generator
 
-use crate::clocks::Stm32f4Clocks;
-use crate::rcc;
+use crate::clocks::{phclk, Stm32f4Clocks};
 use kernel::hil;
 use kernel::hil::entropy::Continue;
 use kernel::platform::chip::ClockInterface;
@@ -65,8 +64,8 @@ impl<'a> Trng<'a> {
     ) -> Trng<'a> {
         Trng {
             registers: registers,
-            clock: RngClock(rcc::PeripheralClock::new(
-                rcc::PeripheralClockType::AHB2(rcc::HCLK2::RNG),
+            clock: RngClock(phclk::PeripheralClock::new(
+                phclk::PeripheralClockType::AHB2(phclk::HCLK2::RNG),
                 clocks,
             )),
             client: OptionalCell::empty(),
@@ -112,7 +111,7 @@ impl<'a> Trng<'a> {
     }
 }
 
-struct RngClock<'a>(rcc::PeripheralClock<'a>);
+struct RngClock<'a>(phclk::PeripheralClock<'a>);
 
 impl ClockInterface for RngClock<'_> {
     fn is_enabled(&self) -> bool {

--- a/chips/stm32f4xx/src/usart.rs
+++ b/chips/stm32f4xx/src/usart.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
+use crate::clocks::Stm32f4Clocks;
 use core::cell::Cell;
 use kernel::deferred_call::{DeferredCall, DeferredCallClient};
 use kernel::hil;
@@ -212,24 +213,24 @@ pub struct TxDMA<'a, DMA: dma::StreamServer<'a>>(pub &'a dma::Stream<'a, DMA>);
 pub struct RxDMA<'a, DMA: dma::StreamServer<'a>>(pub &'a dma::Stream<'a, DMA>);
 
 impl<'a> Usart<'a, dma::Dma1<'a>> {
-    pub fn new_usart2(rcc: &'a rcc::Rcc) -> Self {
+    pub fn new_usart2(clocks: &'a dyn Stm32f4Clocks) -> Self {
         Self::new(
             USART2_BASE,
             UsartClock(rcc::PeripheralClock::new(
                 rcc::PeripheralClockType::APB1(rcc::PCLK1::USART2),
-                rcc,
+                clocks,
             )),
             dma::Dma1Peripheral::USART2_TX,
             dma::Dma1Peripheral::USART2_RX,
         )
     }
 
-    pub fn new_usart3(rcc: &'a rcc::Rcc) -> Self {
+    pub fn new_usart3(clocks: &'a dyn Stm32f4Clocks) -> Self {
         Self::new(
             USART3_BASE,
             UsartClock(rcc::PeripheralClock::new(
                 rcc::PeripheralClockType::APB1(rcc::PCLK1::USART3),
-                rcc,
+                clocks,
             )),
             dma::Dma1Peripheral::USART3_TX,
             dma::Dma1Peripheral::USART3_RX,
@@ -238,12 +239,12 @@ impl<'a> Usart<'a, dma::Dma1<'a>> {
 }
 
 impl<'a> Usart<'a, dma::Dma2<'a>> {
-    pub fn new_usart1(rcc: &'a rcc::Rcc) -> Self {
+    pub fn new_usart1(clocks: &'a dyn Stm32f4Clocks) -> Self {
         Self::new(
             USART1_BASE,
             UsartClock(rcc::PeripheralClock::new(
                 rcc::PeripheralClockType::APB2(rcc::PCLK2::USART1),
-                rcc,
+                clocks,
             )),
             dma::Dma2Peripheral::USART1_TX,
             dma::Dma2Peripheral::USART1_RX,

--- a/chips/stm32f4xx/src/usart.rs
+++ b/chips/stm32f4xx/src/usart.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use crate::clocks::Stm32f4Clocks;
 use core::cell::Cell;
 use kernel::deferred_call::{DeferredCall, DeferredCallClient};
 use kernel::hil;
@@ -13,8 +12,8 @@ use kernel::utilities::registers::{register_bitfields, ReadWrite};
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 
+use crate::clocks::{phclk, Stm32f4Clocks};
 use crate::dma;
-use crate::rcc;
 
 /// Universal synchronous asynchronous receiver transmitter
 #[repr(C)]
@@ -216,8 +215,8 @@ impl<'a> Usart<'a, dma::Dma1<'a>> {
     pub fn new_usart2(clocks: &'a dyn Stm32f4Clocks) -> Self {
         Self::new(
             USART2_BASE,
-            UsartClock(rcc::PeripheralClock::new(
-                rcc::PeripheralClockType::APB1(rcc::PCLK1::USART2),
+            UsartClock(phclk::PeripheralClock::new(
+                phclk::PeripheralClockType::APB1(phclk::PCLK1::USART2),
                 clocks,
             )),
             dma::Dma1Peripheral::USART2_TX,
@@ -228,8 +227,8 @@ impl<'a> Usart<'a, dma::Dma1<'a>> {
     pub fn new_usart3(clocks: &'a dyn Stm32f4Clocks) -> Self {
         Self::new(
             USART3_BASE,
-            UsartClock(rcc::PeripheralClock::new(
-                rcc::PeripheralClockType::APB1(rcc::PCLK1::USART3),
+            UsartClock(phclk::PeripheralClock::new(
+                phclk::PeripheralClockType::APB1(phclk::PCLK1::USART3),
                 clocks,
             )),
             dma::Dma1Peripheral::USART3_TX,
@@ -242,8 +241,8 @@ impl<'a> Usart<'a, dma::Dma2<'a>> {
     pub fn new_usart1(clocks: &'a dyn Stm32f4Clocks) -> Self {
         Self::new(
             USART1_BASE,
-            UsartClock(rcc::PeripheralClock::new(
-                rcc::PeripheralClockType::APB2(rcc::PCLK2::USART1),
+            UsartClock(phclk::PeripheralClock::new(
+                phclk::PeripheralClockType::APB2(phclk::PCLK2::USART1),
                 clocks,
             )),
             dma::Dma2Peripheral::USART1_TX,
@@ -722,7 +721,7 @@ impl<'a> dma::StreamClient<'a, dma::Dma2<'a>> for Usart<'a, dma::Dma2<'a>> {
     }
 }
 
-struct UsartClock<'a>(rcc::PeripheralClock<'a>);
+struct UsartClock<'a>(phclk::PeripheralClock<'a>);
 
 impl ClockInterface for UsartClock<'_> {
     fn is_enabled(&self) -> bool {


### PR DESCRIPTION
### Pull Request Overview

This PR is a continuation of PR #3888. It is mostly a refactoring to allow peripheral clocks to access the clocks module features. The main motivation is to allow peripherals to get their clock frequency also when the HSE clock is used as PLL source or SYSCLK source, that was not possible before this PR because the HSE clock is controlled by the clocks module but peripheral clocks were only able to access the rcc module. Also, this would also help to extend the peripherals implementation in future: other peripherals might need to access some other clock info from the clocks module (e.g. PLLI2S or PLL48CK). To let peripheral access the clocks module, a `ClocksCtrl` trait object is passed to the peripherals. Even if a new trait seems unnecessary here, it avoids the peripherals to become chip specific: they would had required the `ChipSpecific` trait bound generic instead. At first, I tried to just pass a `Clocks` struct reference to peripherals but they became far more verbose and most of the implementation became bound to the `ChipSpecific` trait. There were also lifetime conflicts between the `ChipSpecific` generic and gpio pins. [Here](https://github.com/mattmart3/tock/commit/07f13e607d50769adf21b8573a3d7748b397bcd3) a non working example. Thus I think that using the `ClocksCtrl` trait is the less intrusive approach for now and might be reconsidered in future.
This PR also comes with some other minor refactoring and cleanup for rcc and clocks modules.

### Testing Strategy

The tests listed in #3888 have been re-run on a nucleo_f39zi board with the following additional configurations:

#### Clock Config 5
```rust
pub fn test_config5<ChipSpecs: ChipSpecsTrait>(clocks: &Clocks<ChipSpecs>) {
    clocks
        .pll
        .set_frequency_mhz(PllSource::HSI, HSI_FREQUENCY_MHZ, 112)
        .unwrap();
    clocks.pll.enable().unwrap();
    clocks.set_apb1_prescaler(APBPrescaler::DivideBy2).unwrap();
    clocks.set_apb2_prescaler(APBPrescaler::DivideBy2).unwrap();
    clocks.set_ahb_prescaler(AHBPrescaler::DivideBy4).unwrap();
    clocks.set_sys_clock_source(SysClockSource::PLL).unwrap();
}
```

#### Clock Config 6
```rust
  pub fn test_config6<ChipSpecs: ChipSpecsTrait>(clocks: &Clocks<ChipSpecs>) {
      clocks.hse.set_frequency_mhz(8);
      clocks.hse.enable(crate::rcc::HseMode::BYPASS).unwrap();
      clocks.set_sys_clock_source(SysClockSource::HSE).unwrap();
  }
```

#### Clock Config 7
```rust
    pub fn test_config7<ChipSpecs: ChipSpecsTrait>(clocks: &Clocks<ChipSpecs>) {
     clocks.hse.set_frequency_mhz(8);
     clocks.hse.enable(crate::rcc::HseMode::BYPASS).unwrap();
     clocks
         .pll
         .set_frequency_mhz(PllSource::HSE, clocks.hse.get_frequency_mhz().unwrap(), 80)
         .unwrap();
     clocks.pll.enable().unwrap();
     clocks.set_apb1_prescaler(APBPrescaler::DivideBy2).unwrap();
     clocks.set_apb2_prescaler(APBPrescaler::DivideBy1).unwrap();
     clocks.set_ahb_prescaler(AHBPrescaler::DivideBy2).unwrap();
     clocks.set_sys_clock_source(SysClockSource::PLL).unwrap();
 }
```
I also had to increase the enable wait cycles for PLL and HSE clocks due to #4004 :

```diff
diff --git a/chips/stm32f4xx/src/clocks/hse.rs b/chips/stm32f4xx/src/clocks/hse.rs
index 22bdd4069..edc0245c9 100644
--- a/chips/stm32f4xx/src/clocks/hse.rs
+++ b/chips/stm32f4xx/src/clocks/hse.rs
@@ -89,7 +89,7 @@ impl<'a> Hse<'a> {

         self.rcc.enable_hse_clock();

-        for _ in 0..100 {
+        for _ in 0..500 {
             if self.rcc.is_ready_hse_clock() {
                 return Ok(());
             }
diff --git a/chips/stm32f4xx/src/clocks/pll.rs b/chips/stm32f4xx/src/clocks/pll.rs
index 741401459..18ae80366 100644
--- a/chips/stm32f4xx/src/clocks/pll.rs
+++ b/chips/stm32f4xx/src/clocks/pll.rs
@@ -228,7 +228,7 @@ impl<'a, PllConstants: clock_constants::PllConstants> Pll<'a, PllConstants> {

         // Wait until the PLL clock is locked.
         // 200 was obtained by running tests in release mode
-        for _ in 0..200 {
+        for _ in 0..500 {
             if self.rcc.is_locked_pll_clock() {
                 return Ok(());
             }
```

With all configurations (1 to 7) I repeated the usart tests (process console at different baud rates 9600, 115200, 921600) and the timer test (simple application toggling a gpio every second).

All tests succeeded without issues except for config 6 with usart at baudrate 921600, but this is likely due to the baud error being too high at that configuration, no issue with baudrate 460800.

### TODO or Help Wanted

This PR affects all the stm32f4 boards, but I could only test the nucleo_f439zi board. 

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
