### PR TITLE
arch/rv32i: separate kernel and app trap handlers

### DIFF
--- a/arch/rv32i/src/syscall.rs
+++ b/arch/rv32i/src/syscall.rs
@@ -247,8 +247,8 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
           // Before switching to the app we need to save some kernel registers
           // to the kernel stack, specifically ones which we can't mark as
           // clobbered in the asm!() block. We then save the stack pointer in
-          // the mscratch CSR (0x340) so we can retrieve it after returning to
-          // the kernel from the app.
+          // the mscratch CSR so we can retrieve it after returning to the
+          // kernel from the app.
           //
           // A few values get saved to the kernel stack, including an app
           // register temporarily after entering the trap handler. Here is a
@@ -257,13 +257,14 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
           // ```
           //  8*4(sp):          <- original stack pointer
           //  7*4(sp):
-          //  6*4(sp): x9
-          //  5*4(sp): x8
-          //  4*4(sp): x4
-          //  3*4(sp): x3
-          //  2*4(sp): _return_to_kernel (100) (address to resume after trap)
-          //  1*4(sp): *state   (Per-process StoredState struct)
-          //  0*4(sp): app s0   <- new stack pointer
+          //  6*4(sp): x9  / s1
+          //  5*4(sp): x8  / s0 / fp
+          //  4*4(sp): x4  / tp
+          //  3*4(sp): x3  / gp
+          //  2*4(sp): x10 / a0 (*state, Per-process StoredState struct)
+          //  1*4(sp): custom trap handler address
+          //  0*4(sp): scratch space, having s1 written to by the trap handler
+          //                    <- new stack pointer
           // ```
 
           addi sp, sp, -8*4  // Move the stack pointer down to make room.
@@ -272,141 +273,345 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
           // by an asm!() block. These are mostly registers which have a
           // designated purpose (e.g. stack pointer) or are used internally
           // by LLVM.
-          //   x2             // sp -> saved in mscratch CSR below
-          sw   x3,  3*4(sp)   // gp (can't be clobbered / used as an operand)
-          sw   x4,  4*4(sp)   // tp (can't be clobbered / used as an operand)
-          sw   x8,  5*4(sp)   // fp (can't be clobbered / used as an operand)
           sw   x9,  6*4(sp)   // s1 (used internally by LLVM)
+          sw   x8,  5*4(sp)   // fp (can't be clobbered / used as an operand)
+          sw   x4,  4*4(sp)   // tp (can't be clobbered / used as an operand)
+          sw   x3,  3*4(sp)   // gp (can't be clobbered / used as an operand)
 
-          sw   a0, 1*4(sp)    // Store process state pointer on stack as well.
-                              // We need to have this available for after the app
-                              // returns to the kernel so we can store its
+          sw   x10, 2*4(sp)   // Store process state pointer on stack as well.
+                              // We need to have this available for after the
+                              // app returns to the kernel so we can store its
                               // registers.
 
-          // From here on we can't allow the CPU to take interrupts
-          // anymore, as that might result in the trap handler
-          // believing that a context switch to userspace already
-          // occurred (as mscratch is non-zero). Restore the userspace
-          // state fully prior to enabling interrupts again
-          // (implicitly using mret).
+          // Load the address of `_start_app_trap` into `1*4(sp)`. We swap our
+          // stack pointer into the mscratch CSR and the trap handler will load
+          // and jump to the address at this offset.
+          la    t0, 100f      // t0 = _start_app_trap
+          sw    t0, 1*4(sp)   // 1*4(sp) = t0
+
+          // sw x0, 0*4(sp)   // Reserved as scratch space for the trap handler
+
+          // -----> All required registers saved to the stack.
+          //        sp holds the updated stack pointer, a0 the per-process state
+
+          // From here on we can't allow the CPU to take interrupts anymore, as
+          // we re-route traps to `_start_app_trap` below (by writing our stack
+          // pointer into the mscratch CSR), and we rely on certain CSRs to not
+          // be modified or used in their intermediate states (e.g., mepc).
           //
-          // If this is executed _after_ setting mscratch, this result
-          // in the race condition of [PR
-          // 2308](https://github.com/tock/tock/pull/2308)
+          // We atomically switch to user-mode and re-enable interrupts using
+          // the `mret` instruction below.
+          //
+          // If interrupts are disabled _after_ setting mscratch, this result in
+          // the race condition of [PR 2308](https://github.com/tock/tock/pull/2308)
 
           // Therefore, clear the following bits in mstatus first:
           //   0x00000008 -> bit 3 -> MIE (disabling interrupts here)
           // + 0x00001800 -> bits 11,12 -> MPP (switch to usermode on mret)
-          li t0, 0x00001808
-          csrrc x0, 0x300, t0      // clear bits in mstatus, don't care about read
+          li    t0, 0x00001808
+          csrc  mstatus, t0         // clear bits in mstatus
 
           // Afterwards, set the following bits in mstatus:
           //   0x00000080 -> bit 7 -> MPIE (enable interrupts on mret)
-          li t0, 0x00000080
-          csrrs x0, 0x300, t0      // set bits in mstatus, don't care about read
+          li    t0, 0x00000080
+          csrs  mstatus, t0         // set bits in mstatus
 
-
-          // Store the address to jump back to on the stack so that the trap
-          // handler knows where to return to after the app stops executing.
+          // Execute `_start_app_trap` on a trap by setting the mscratch trap
+          // handler address to our current stack pointer. This stack pointer,
+          // at `1*4(sp)`, holds the address of `_start_app_trap`.
           //
-          // In asm!() we can't use the shorthand `li` pseudo-instruction, as it
-          // complains about _return_to_kernel (100) not being a constant in the
-          // required range.
-          lui  t0, %hi(100f)
-          addi t0, t0, %lo(100f)
-          sw   t0, 2*4(sp)
-
-          csrw 0x340, sp      // Save stack pointer in mscratch. This allows
-                              // us to find it when the app returns back to
-                              // the kernel.
+          // Upon a trap, the global trap handler (_start_trap) will swap `s0`
+          // with the `mscratch` CSR and, if it contains a non-zero address,
+          // jump to the address that is now at `1*4(s0)`. This allows us to
+          // hook a custom trap handler that saves all userspace state:
+          //
+          csrw  mscratch, sp        // Store `sp` in mscratch CSR. Discard the
+                                    // prior value, must have been set to zero.
 
           // We have to set the mepc CSR with the PC we want the app to start
           // executing at. This has been saved in Riscv32iStoredState for us
           // (either when the app returned back to the kernel or in the
           // `set_process_function()` function).
-          lw   t0, 31*4(a0)   // Retrieve the PC from Riscv32iStoredState
-          csrw 0x341, t0      // Set mepc CSR. This is the PC we want to go to.
+          lw    t0, 31*4(a0)        // Retrieve the PC from Riscv32iStoredState
+          csrw  mepc, t0            // Set mepc CSR to the app's PC.
 
           // Restore all of the app registers from what we saved. If this is the
           // first time running the app then most of these values are
           // irrelevant, However we do need to set the four arguments to the
-          // `_start_ function in the app. If the app has been executing then this
-          // allows the app to correctly resume.
-          mv   t0,  a0       // Save the state pointer to a specific register.
-          lw   x1,  0*4(t0)  // ra
-          lw   x2,  1*4(t0)  // sp
-          lw   x3,  2*4(t0)  // gp
-          lw   x4,  3*4(t0)  // tp
-          lw   x6,  5*4(t0)  // t1
-          lw   x7,  6*4(t0)  // t2
-          lw   x8,  7*4(t0)  // s0,fp
-          lw   x9,  8*4(t0)  // s1
-          lw   x10, 9*4(t0)  // a0
-          lw   x11, 10*4(t0) // a1
-          lw   x12, 11*4(t0) // a2
-          lw   x13, 12*4(t0) // a3
-          lw   x14, 13*4(t0) // a4
-          lw   x15, 14*4(t0) // a5
-          lw   x16, 15*4(t0) // a6
-          lw   x17, 16*4(t0) // a7
-          lw   x18, 17*4(t0) // s2
-          lw   x19, 18*4(t0) // s3
-          lw   x20, 19*4(t0) // s4
-          lw   x21, 20*4(t0) // s5
-          lw   x22, 21*4(t0) // s6
-          lw   x23, 22*4(t0) // s7
-          lw   x24, 23*4(t0) // s8
-          lw   x25, 24*4(t0) // s9
-          lw   x26, 25*4(t0) // s10
-          lw   x27, 26*4(t0) // s11
-          lw   x28, 27*4(t0) // t3
-          lw   x29, 28*4(t0) // t4
-          lw   x30, 29*4(t0) // t5
-          lw   x31, 30*4(t0) // t6
-          lw   x5,  4*4(t0)  // t0. Do last since we overwrite our pointer.
+          // `_start_ function in the app. If the app has been executing then
+          // this allows the app to correctly resume.
+
+          // We do a little switcheroo here, and place the per-process stored
+          // state pointer into the `sp` register instead of `a0`. Doing so
+          // allows us to use compressed instructions for all of these loads:
+          mv    sp,  a0             // sp <- a0 (per-process stored state)
+
+          lw    x1,  0*4(sp)        // ra
+          // ------------------------> sp, do last since we overwrite our pointer
+          lw    x3,  2*4(sp)        // gp
+          lw    x4,  3*4(sp)        // tp
+          lw    x5,  4*4(sp)        // t0
+          lw    x6,  5*4(sp)        // t1
+          lw    x7,  6*4(sp)        // t2
+          lw    x8,  7*4(sp)        // s0,fp
+          lw    x9,  8*4(sp)        // s1
+          lw   x10,  9*4(sp)        // a0
+          lw   x11, 10*4(sp)        // a1
+          lw   x12, 11*4(sp)        // a2
+          lw   x13, 12*4(sp)        // a3
+          lw   x14, 13*4(sp)        // a4
+          lw   x15, 14*4(sp)        // a5
+          lw   x16, 15*4(sp)        // a6
+          lw   x17, 16*4(sp)        // a7
+          lw   x18, 17*4(sp)        // s2
+          lw   x19, 18*4(sp)        // s3
+          lw   x20, 19*4(sp)        // s4
+          lw   x21, 20*4(sp)        // s5
+          lw   x22, 21*4(sp)        // s6
+          lw   x23, 22*4(sp)        // s7
+          lw   x24, 23*4(sp)        // s8
+          lw   x25, 24*4(sp)        // s9
+          lw   x26, 25*4(sp)        // s10
+          lw   x27, 26*4(sp)        // s11
+          lw   x28, 27*4(sp)        // t3
+          lw   x29, 28*4(sp)        // t4
+          lw   x30, 29*4(sp)        // t5
+          lw   x31, 30*4(sp)        // t6
+          lw    x2,  1*4(sp)        // sp, overwriting our pointer
 
           // Call mret to jump to where mepc points, switch to user mode, and
           // start running the app.
           mret
 
+          // The global trap handler will jump to this address when catching a
+          // trap while the app is executing (address loaded into the mscratch
+          // CSR).
+          //
+          // This custom trap handler is responsible for saving application
+          // state, clearing the custom trap handler (mscratch = 0), and
+          // restoring the kernel context.
+        100: // _start_app_trap
 
+          // At this point all we know is that we entered the trap handler from
+          // an app. We don't know _why_ we got a trap, it could be from an
+          // interrupt, syscall, or fault (or maybe something else). Therefore
+          // we have to be very careful not to overwrite any registers before we
+          // have saved them.
+          //
+          // The global trap handler has swapped the app's `s0` into the
+          // mscratch CSR, which now contains the address of our stack pointer.
+          // The global trap handler further clobbered `s1`, which now contains
+          // the address of `_start_app_trap`. The app's `s1` is saved at
+          // `0*4(s0)`.
+          //
+          // Thus we can clobber `s1` and load the address of the per-process
+          // stored state:
+          //
+          lw   s1, 2*4(s0)
 
+          // With the per-process stored state address in `t1`, save all
+          // non-clobbered registers. Save the `sp` first, then do the same
+          // switcheroo as above, moving the per-process stored state pointer
+          // into `sp`. This allows us to use compressed instructions for all
+          // these stores:
+          sw    x2,  1*4(s1)        // Save app's sp
+          mv    sp,  s1             // sp <- s1 (per-process stored state)
+
+          // Now, store relative to `sp` (per-process stored state) with
+          // compressed instructions:
+          sw    x1,  0*4(sp)        // ra
+          // ------------------------> sp, saved above
+          sw    x3,  2*4(sp)        // gp
+          sw    x4,  3*4(sp)        // tp
+          sw    x5,  4*4(sp)        // t0
+          sw    x6,  5*4(sp)        // t1
+          sw    x7,  6*4(sp)        // t2
+          // ------------------------> s0, in mscratch right now
+          // ------------------------> s1, stored at 0*4(s0) right now
+          sw   x10,  9*4(sp)        // a0
+          sw   x11, 10*4(sp)        // a1
+          sw   x12, 11*4(sp)        // a2
+          sw   x13, 12*4(sp)        // a3
+          sw   x14, 13*4(sp)        // a4
+          sw   x15, 14*4(sp)        // a5
+          sw   x16, 15*4(sp)        // a6
+          sw   x17, 16*4(sp)        // a7
+          sw   x18, 17*4(sp)        // s2
+          sw   x19, 18*4(sp)        // s3
+          sw   x20, 19*4(sp)        // s4
+          sw   x21, 20*4(sp)        // s5
+          sw   x22, 21*4(sp)        // s6
+          sw   x23, 22*4(sp)        // s7
+          sw   x24, 23*4(sp)        // s8
+          sw   x25, 24*4(sp)        // s9
+          sw   x26, 25*4(sp)        // s10
+          sw   x27, 26*4(sp)        // s11
+          sw   x28, 27*4(sp)        // t3
+          sw   x29, 28*4(sp)        // t4
+          sw   x30, 29*4(sp)        // t5
+          sw   x31, 30*4(sp)        // t6
+
+          // At this point, we can restore s0 into our stack pointer:
+          mv   sp, s0
+
+          // Now retrieve the original value of s1 and save that as well. We
+          // must not clobber s1, our per-process stored state pointer.
+          lw   s0,  0*4(sp)         // s0 = app s1 (from trap handler scratch space)
+          sw   s0,  8*4(s1)         // Save app s1 to per-process state
+
+          // Retrieve the original value of s0 from the mscratch CSR, save it.
+          //
+          // This will also restore the kernel trap handler by writing zero to
+          // the CSR. `csrrw` allows us to read and write the CSR in a single
+          // instruction:
+          csrrw s0, mscratch, zero  // s0 <- mscratch[app s0] <- zero
+          sw    s0, 7*4(s1)         // Save app s0 to per-process state
+
+          // -------------------------------------------------------------------
+          // At this point, the entire app register file is saved. We also
+          // restored the kernel trap handler. We have restored the following
+          // kernel registers:
+          //
+          // - sp: kernel stack pointer
+          // - s1: per-process stored state pointer
+          //
+          // We avoid clobbering those registers from this point onward.
+          // -------------------------------------------------------------------
+
+          // We also need to store some other information about the trap reason,
+          // present in CSRs:
+          //
+          // - the app's PC (mepc),
+          // - the trap reason (mcause),
+          // - the trap 'value' (mtval, e.g., faulting address).
+          //
+          // We need to store mcause because we use that to determine why the
+          // app stopped executing and returned to the kernel. We store mepc
+          // because it is where we need to return to in the app at some
+          // point. We need to store mtval in case the app faulted and we need
+          // mtval to help with debugging.
+          //
+          // We use `s0` as a scratch register, as it fits into the 3-bit
+          // register argument of RISC-V compressed loads / stores:
+
+          // Save the PC to the stored state struct. We also load the address
+          // of _return_to_kernel into it, as this will be where we jump on
+          // the mret instruction, which leaves the trap handler.
+          la    s0, 300f            // Load _return_to_kernel into t0.
+          csrrw s0, mepc, s0        // s0 <- mepc[app pc] <- _return_to_kernel
+          sw    s0, 31*4(s1)        // Store app's pc in stored state struct.
+
+          // Save mtval to the stored state struct
+          csrr  s0, mtval
+          sw    s0, 33*4(s1)
+
+          // Save mcause and leave it loaded into a0, as we call a function
+          // with it below:
+          csrr  a0, mcause
+          sw    a0, 32*4(s1)
+
+          // Depending on the value of a0, we might be calling into a function
+          // while still in the trap handler. The callee may rely on the `gp`,
+          // `tp`, and `fp` (s0) registers to be set correctly. Thus we restore
+          // them here, as we need to do anyways. They are saved registers,
+          // and so we avoid clobbering them beyond this point.
+          //
+          // We do not restore `s1`, as we need to move it back into `a0`
+          // _after_ potentially invoking the _disable_interrupt_... function.
+          // LLVM relies on it to not be clobbered internally, but it is not
+          // part of the RISC-V C ABI, which we need to follow here.
+          //
+          lw    x8, 5*4(sp)         // fp/s0: Restore the frame pointer
+          lw    x4, 4*4(sp)         // tp: Restore the thread pointer
+          lw    x3, 3*4(sp)         // gp: Restore the global pointer
+
+          // --------------------------------------------------------------------
+          // From this point onward, avoid clobbering the following registers:
+          //
+          // - x2 / sp: kernel stack pointer
+          // - x3 / gp: kernel global pointer
+          // - x4 / tp: kernel thread pointer
+          // - x8 / s0 / fp: kernel frame pointer
+          // - x9 / s1: per-process stored state pointer
+          //
+          // --------------------------------------------------------------------
+
+          // Now we need to check if this was an interrupt, and if it was,
+          // then we need to disable the interrupt before returning from this
+          // trap handler so that it does not fire again.
+          //
+          // If mcause is greater than or equal to zero this was not an
+          // interrupt (i.e. the most significant bit is not 1). In this case,
+          // jump to _start_app_trap_continue.
+          bge   a0, zero, 200f
+
+          // This was an interrupt. Call the interrupt disable function, with
+          // mcause already loaded in a0.
+          //
+          // This may clobber all caller-saved registers. However, at this
+          // stage, we only restored `sp`, `s1`, and the registers above, all of
+          // which are saved. Thus we don't have to worry about the function
+          // call clobbering these registers.
+          //
+          jal  ra, _disable_interrupt_trap_rust_from_app
+
+        200: // _start_app_trap_continue
+
+          // Need to set mstatus.MPP to 0b11 so that we stay in machine mode.
+          //
+          // We use `a0` as a scratch register, as we are allowed to clobber it
+          // here, and it fits into a compressed load instruction. We must avoid
+          // using restored saved registers like `s0`, etc.
+          //
+          li    a0, 0x1800          // Load 0b11 to the MPP bits location in a0
+          csrs  mstatus, a0         // mstatus |= a0
+
+          // Use mret to exit the trap handler and return to the context
+          // switching code. We loaded the address of _return_to_kernel
+          // into mepc above.
+          mret
 
           // This is where the trap handler jumps back to after the app stops
           // executing.
-        100: // _return_to_kernel
+        300: // _return_to_kernel
 
           // We have already stored the app registers in the trap handler. We
-          // can restore the kernel registers before resuming kernel code.
-          //   x2            // sp -> loaded from mscratch by the trap handler
-          lw   x3,  3*4(sp)  // gp (can't be clobbered / used as an operand)
-          lw   x4,  4*4(sp)  // tp (can't be clobbered / used as an operand)
-          lw   x8,  5*4(sp)  // fp (can't be clobbered / used as an operand)
-          lw   x9,  6*4(sp)  // s1 (used internally by LLVM)
+          // have further restored `gp`, `tp`, `fp`/`s0` and the stack pointer.
+          //
+          // The only other non-clobbered registers are `s1` and `a0`, where
+          // `a0` needs to hold the per-process state pointer currently stored
+          // in `s1`, and the original value of `s1` is saved on the stack.
+          // Restore them:
+          //
+          mv    a0, s1              // a0 = per-process stored state
+          lw    s1, 6*4(sp)         // restore s1 (used by LLVM internally)
 
-          lw   a0,  1*4(sp)  // Restore the the process state pointer such that
-                             // we don't need to mark it as clobbered.
-                             // Otherwise, this would cause Rust to stack a
-                             // register which we already manually save.
+          // We need thus need to mark all registers as clobbered, except:
+          //
+          // - x2  (sp)
+          // - x3  (gp)
+          // - x4  (tp)
+          // - x8  (fp)
+          // - x9  (s1)
+          // - x10 (a0)
 
           addi sp, sp, 8*4   // Reset kernel stack pointer
-          ",
+        ",
 
-          // The register to put the state struct pointer in is not
-          // particularly relevant, however we must avoid using t0
-          // as that is overwritten prior to being accessed
-          // (although stored and later restored) in the assembly
-          in("a0") state as *mut Riscv32iStoredState,
+            // We pass the per-process state struct in a register we are allowed
+            // to clobber (not s0 or s1), but still fits into 3-bit register
+            // arguments of compressed load- & store-instructions.
+            in("x10") state as *mut Riscv32iStoredState,
 
-          // Clobber all registers which can be marked as clobbered, except
-          // for `a0` / `x10`. By making it retain the value of `&mut state`,
-          // which we need to stack manually anyway, we can avoid Rust/LLVM
-          // stacking it redundantly for us.
-          out("x1") _, out("x5") _, out("x6") _, out("x7") _, out("x11") _,
-          out("x12") _, out("x13") _, out("x14") _, out("x15") _, out("x16") _,
-          out("x17") _, out("x18") _, out("x19") _, out("x20") _, out("x21") _,
-          out("x22") _, out("x23") _, out("x24") _, out("x25") _, out("x26") _,
-          out("x27") _, out("x28") _, out("x29") _, out("x30") _, out("x31") _,
+            // Clobber all registers which can be marked as clobbered, except
+            // for `a0` / `x10`. By making it retain the value of `&mut state`,
+            // which we need to stack manually anyway, we can avoid Rust/LLVM
+            // stacking it redundantly for us.
+            out("x1") _, out("x5") _, out("x6") _, out("x7") _, out("x11") _,
+            out("x12") _, out("x13") _, out("x14") _, out("x15") _, out("x16") _,
+            out("x17") _, out("x18") _, out("x19") _, out("x20") _, out("x21") _,
+            out("x22") _, out("x23") _, out("x24") _, out("x25") _, out("x26") _,
+            out("x27") _, out("x28") _, out("x29") _, out("x30") _, out("x31") _,
         );
 
         let ret = match mcause::Trap::from(state.mcause as usize) {
@@ -421,7 +626,7 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
                     mcause::Exception::UserEnvCall | mcause::Exception::MachineEnvCall => {
                         // Need to increment the PC so when we return we start at the correct
                         // instruction. The hardware does not do this for us.
-                        state.pc += 4;
+                        state.pc = state.pc.wrapping_add(4);
 
                         let syscall = kernel::syscall::Syscall::from_register_arguments(
                             state.regs[R_A4] as u8,

--- a/boards/esp32-c3-devkitM-1/src/main.rs
+++ b/boards/esp32-c3-devkitM-1/src/main.rs
@@ -146,7 +146,7 @@ unsafe fn setup() -> (
     use esp32_c3::sysreg::{CpuFrequency, PllFrequency};
 
     // only machine mode
-    rv32i::configure_trap_handler(rv32i::PermissionMode::Machine);
+    rv32i::configure_trap_handler();
 
     let peripherals = static_init!(Esp32C3DefaultPeripherals, Esp32C3DefaultPeripherals::new());
 

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -185,7 +185,7 @@ unsafe fn start() -> (
     &'static e310_g002::chip::E310x<'static, E310G002DefaultPeripherals<'static>>,
 ) {
     // only machine mode
-    rv32i::configure_trap_handler(rv32i::PermissionMode::Machine);
+    rv32i::configure_trap_handler();
 
     let peripherals = static_init!(
         E310G002DefaultPeripherals,

--- a/boards/hifive_inventor/src/main.rs
+++ b/boards/hifive_inventor/src/main.rs
@@ -127,7 +127,7 @@ unsafe fn start() -> (
     &'static e310_g003::chip::E310x<'static, E310G003DefaultPeripherals<'static>>,
 ) {
     // only machine mode
-    rv32i::configure_trap_handler(rv32i::PermissionMode::Machine);
+    rv32i::configure_trap_handler();
 
     let peripherals = static_init!(
         E310G003DefaultPeripherals,

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -261,7 +261,7 @@ pub unsafe fn main() {
     // ---------- BASIC INITIALIZATION ----------
 
     // Basic setup of the riscv platform.
-    rv32i::configure_trap_handler(rv32i::PermissionMode::Machine);
+    rv32i::configure_trap_handler();
 
     // Set up memory protection immediately after setting the trap handler, to
     // ensure that much of the board initialization routine runs with PMP kernel

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -260,7 +260,7 @@ pub unsafe fn main() {
     // ---------- BASIC INITIALIZATION ----------
 
     // Basic setup of the riscv platform.
-    rv32i::configure_trap_handler(rv32i::PermissionMode::Machine);
+    rv32i::configure_trap_handler();
 
     // Set up memory protection immediately after setting the trap handler, to
     // ensure that much of the board initialization routine runs with PMP kernel

--- a/boards/qemu_rv32_virt/src/main.rs
+++ b/boards/qemu_rv32_virt/src/main.rs
@@ -181,7 +181,7 @@ pub unsafe fn main() {
     // ---------- BASIC INITIALIZATION -----------
 
     // Basic setup of the RISC-V IMAC platform
-    rv32i::configure_trap_handler(rv32i::PermissionMode::Machine);
+    rv32i::configure_trap_handler();
 
     // Set up memory protection immediately after setting the trap handler, to
     // ensure that much of the board initialization routine runs with ePMP

--- a/boards/redboard_redv/src/main.rs
+++ b/boards/redboard_redv/src/main.rs
@@ -133,7 +133,7 @@ impl KernelResources<e310_g002::chip::E310x<'static, E310G002DefaultPeripherals<
 #[no_mangle]
 pub unsafe fn main() {
     // only machine mode
-    rv32i::configure_trap_handler(rv32i::PermissionMode::Machine);
+    rv32i::configure_trap_handler();
 
     let peripherals = static_init!(
         E310G002DefaultPeripherals,

--- a/boards/swervolf/src/main.rs
+++ b/boards/swervolf/src/main.rs
@@ -113,7 +113,7 @@ impl KernelResources<swervolf_eh1::chip::SweRVolf<'static, SweRVolfDefaultPeriph
 #[no_mangle]
 pub unsafe fn main() {
     // only machine mode
-    rv32i::configure_trap_handler(rv32i::PermissionMode::Machine);
+    rv32i::configure_trap_handler();
 
     let peripherals = static_init!(
         SweRVolfDefaultPeripherals,

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -428,16 +428,22 @@ pub unsafe extern "C" fn disable_interrupt_trap_handler(mcause_val: u32) {
 }
 
 pub unsafe fn configure_trap_handler() {
+    // The common _start_trap handler uses mscratch to determine
+    // whether we are executing kernel or process code. Set to `0` to
+    // indicate we're in the kernel right now.
+    CSR.mscratch.set(0);
+
     // The Ibex CPU does not support non-vectored trap entries.
-    CSR.mtvec
-        .write(mtvec::trap_addr.val(_start_trap_vectored as usize >> 2) + mtvec::mode::Vectored)
+    CSR.mtvec.write(
+        mtvec::trap_addr.val(_earlgrey_start_trap_vectored as usize >> 2) + mtvec::mode::Vectored,
+    );
 }
 
 // Mock implementation for crate tests that does not include the section
 // specifier, as the test will not use our linker script, and the host
 // compilation environment may not allow the section name.
 #[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
-pub extern "C" fn _start_trap_vectored() {
+pub extern "C" fn _earlgrey_start_trap_vectored() {
     use core::hint::unreachable_unchecked;
     unsafe {
         unreachable_unchecked();
@@ -446,7 +452,7 @@ pub extern "C" fn _start_trap_vectored() {
 
 #[cfg(all(target_arch = "riscv32", target_os = "none"))]
 extern "C" {
-    pub fn _start_trap_vectored();
+    pub fn _earlgrey_start_trap_vectored();
 }
 
 #[cfg(all(target_arch = "riscv32", target_os = "none"))]
@@ -461,39 +467,40 @@ core::arch::global_asm!(
     "
             .section .riscv.trap_vectored, \"ax\"
             .globl _start_trap_vectored
-          _start_trap_vectored:
+          _earlgrey_start_trap_vectored:
 
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-        "
+            j {start_trap}
+            j {start_trap}
+            j {start_trap}
+            j {start_trap}
+            j {start_trap}
+            j {start_trap}
+            j {start_trap}
+            j {start_trap}
+            j {start_trap}
+            j {start_trap}
+            j {start_trap}
+            j {start_trap}
+            j {start_trap}
+            j {start_trap}
+            j {start_trap}
+            j {start_trap}
+            j {start_trap}
+            j {start_trap}
+            j {start_trap}
+            j {start_trap}
+            j {start_trap}
+            j {start_trap}
+            j {start_trap}
+            j {start_trap}
+            j {start_trap}
+            j {start_trap}
+            j {start_trap}
+            j {start_trap}
+            j {start_trap}
+            j {start_trap}
+            j {start_trap}
+            j {start_trap}
+    ",
+    start_trap = sym rv32i::_start_trap,
 );


### PR DESCRIPTION
### Pull Request Overview

This commit re-architects Tock's RV32I trap handler, to cleanly separate the kernel- and process-handlers. It defines an "interface" for custom trap handlers of custom process implementations.

This is a third attempt at separating out the kernel- and app-trap handlers on RV32I, and a follow-up to #3847 and #3864. The motivation is much the same, however this attempt is subtly different in concept, and not so subtly in implementation, and as such warrants its own PR.

Tock's core kernel design permits process implementations with system call interfaces other than the ones shipped upstream in the arch/cortex-m and arch/rv32i crates. However, in practice, the UserspaceKernelBoundary implementation for RV32I has always been tightly coupled to the generic kernel RISC-V trap handler. This has made it difficult to build an alternative process
implementation (e.g., as part of Encapsulated Functions), while reusing much of Tock's RISC-V implementation.

By defining an "interface" that the global trap handler exposes (i.e., specifying how a custom trap handler can be registered, and which registers get clobbered), we allow foreign process implementations to hook into the rv32i arch crate's assembly, and can move all process-specific assembly into SysCall::switch_to_process. All process-specific logic is now contained in one assembly block that can be read top-to-bottom. The global trap handler no longer relies on the stack layout of that function, or other data structures in syscall.rs.

Because the kernel trap handler no longer contains any application logic and expects the app to set its own trap handler, implementing a new syscall ABI becomes as simple as temporarily swapping out the trap handler.

The precise interface is documented on the `_start_trap` symbol in `arch/rv32i/src/lib.rs`.


### Testing Strategy

This pull request was tested by using it with [Encapsulated Functions](https://dl.acm.org/doi/abs/10.1145/3625275.3625397), running regular Tock processes, and the LiteX Sim CI.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
