### PR TITLE
doc: CodeReview.md: Clarify cfg usage

### DIFF
--- a/chips/lowrisc/Cargo.toml
+++ b/chips/lowrisc/Cargo.toml
@@ -11,3 +11,7 @@ edition.workspace = true
 [dependencies]
 rv32i = { path = "../../arch/rv32i" }
 kernel = { path = "../../kernel" }
+
+[lints.rust]
+# These are unused and unsupported
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(aon_wkup_timer)'] }

--- a/doc/CodeReview.md
+++ b/doc/CodeReview.md
@@ -344,6 +344,15 @@ Generally, this means `cfg` directives should be an explicit list of chips or'd
 together. Rarely, if ever, is a `cfg(not ...)` the correct approach for anything
 outside of unit tests.
 
+Rust `cfg` features can also be used to disable code that isn't used in upstream
+Tock but might be used in private or public forks. Rust custom configs can also
+be used, but generally require changes to the lint configuration. See
+https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html#check-cfg-in-lintsrust-table
+for more details on getting the Rust lints to pass.
+
+It would be better to use Cargo feature flags then `cfg`s and avoinding compile
+time configuration at all would be best.
+
 #### Boards
 
 Changes to boards are generally left to the maintainer or original contributor


### PR DESCRIPTION
### Pull Request Overview

As part of the [latest Rust update](https://github.com/tock/tock/pull/4002), Clippy is now complaining when there are Rust `cfg`s or Cargo features that cannot be enabled.

I want to remove the dead code, but @alevy [has requested](https://github.com/tock/tock/pull/4002#issuecomment-2141129145) that we keep these configs as it is possible that the code is being used outside the repository (although the configs in questions can't be enabled without code changes and the functions are not public).

In order to update to the latest Rust nightly we need to expose the configs to keep the Rust lints happy.  I don't want to sneak in a practice that clearly goes against the current Tock coding style. So I would like to update the docs to clarify Tock's position first.

I personally think this is a really bad idea. I don't think we should allow unused `cfg`s in mainline Tock. In [this case](https://github.com/tock/tock/blob/master/chips/lowrisc/src/aon_timer.rs#L146) the functions aren't public and the config isn't exposed, so code changes are required to use it anyway (although there [appear to be no users](https://github.com/search?q=org%3AlowRISC+aon_wkup_timer&type=code)).

### Testing Strategy

N/A

### TODO or Help Wanted

N/A

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
