### PR TITLE
Remove dead code

### DIFF
--- a/chips/lowrisc/src/aon_timer.rs
+++ b/chips/lowrisc/src/aon_timer.rs
@@ -142,35 +142,6 @@ impl AonTimer {
         ms.saturating_mul(self.aon_clk_freq).saturating_div(1000)
     }
 
-    /// Start the wake up counter
-    #[cfg(aon_wkup_timer)]
-    fn wkup_start_count(&self) {
-        self.registers.wkup_ctrl.write(WKUP_CTRL::ENABLE::SET);
-    }
-
-    /// Set wake-up prescaler, NOTE: Independant of the watchdog timer
-    /// A count starts at 0 and slowly ticks upwards
-    /// (one tick every N + 1 clock cycles, where N is the pre-scaler value)
-    #[cfg(aon_wkup_timer)]
-    fn set_wkup_prescaler(&self) {
-        // Ex: AON VerilatorClock ~125kHZ, (2^12)/125_000Hz ~= 32ms (per tick)
-        // NOTE: Arbitrarily chosen, update as necessary.
-        let prescaler = 0x1000; // 2^12
-        self.registers
-            .wkup_ctrl
-            .write(WKUP_CTRL::PRESCALER.val(prescaler));
-    }
-
-    /// Set threshold ticks for the wake-up interrupt,
-    /// Note: the timing here depends on the prescaler set in
-    /// `set_wkup_prescaler()`
-    #[cfg(aon_wkup_timer)]
-    fn set_wkup_thresh(&self) {
-        let regs = self.registers;
-        // 0xFF arbitrarily chosen.
-        regs.wkup_thold.write(THRESHOLD::THRESHOLD.val(0xFF));
-    }
-
     fn reset_wkup_count(&self) {
         self.registers.wkup_count.set(0x00);
     }

--- a/chips/sam4l/src/flashcalw.rs
+++ b/chips/sam4l/src/flashcalw.rs
@@ -422,16 +422,6 @@ pub struct FLASHCALW {
 // Few constants relating to module configuration.
 const PAGE_SIZE: u32 = 512;
 
-#[cfg(CONFIG_FLASH_READ_MODE_HIGH_SPEED_DISABLE)]
-const FREQ_PS1_FWS_1_FWU_MAX_FREQ: u32 = 12000000;
-#[cfg(CONFIG_FLASH_READ_MODE_HIGH_SPEED_DISABLE)]
-const FREQ_PS0_FWS_0_MAX_FREQ: u32 = 18000000;
-#[cfg(CONFIG_FLASH_READ_MODE_HIGH_SPEED_DISABLE)]
-const FREQ_PS0_FWS_1_MAX_FREQ: u32 = 36000000;
-#[cfg(CONFIG_FLASH_READ_MODE_HIGH_SPEED_DISABLE)]
-const FREQ_PS1_FWS_0_MAX_FREQ: u32 = 8000000;
-
-#[cfg(not(CONFIG_FLASH_READ_MODE_HIGH_SPEED_DISABLE))]
 const FREQ_PS2_FWS_0_MAX_FREQ: u32 = 24000000;
 
 impl FLASHCALW {
@@ -597,7 +587,6 @@ impl FLASHCALW {
 
     //  By default, we are going with High Speed Enable (based on our device running
     //  in PS2).
-    #[cfg(not(CONFIG_FLASH_READ_MODE_HIGH_SPEED_DISABLE))]
     fn set_flash_waitstate_and_readmode(&self, cpu_freq: u32, _ps_val: u32, _is_fwu_enabled: bool) {
         // ps_val and is_fwu_enabled not used in this implementation.
         if cpu_freq > FREQ_PS2_FWS_0_MAX_FREQ {
@@ -607,41 +596,6 @@ impl FLASHCALW {
         }
 
         self.issue_command(FlashCMD::HSEN, -1);
-    }
-
-    #[cfg(CONFIG_FLASH_READ_MODE_HIGH_SPEED_DISABLE)]
-    fn set_flash_waitstate_and_readmode(
-        &mut self,
-        cpu_freq: u32,
-        ps_val: u32,
-        is_fwu_enabled: bool,
-    ) {
-        if ps_val == 0 {
-            if cpu_freq > FREQ_PS0_FWS_0_MAX_FREQ {
-                self.set_wait_state(1);
-                if cpu_freq <= FREQ_PS0_FWS_1_MAX_FREQ {
-                    self.issue_command(FlashCMD::HSDIS, -1);
-                } else {
-                    self.issue_command(FlashCMD::HSEN, -1);
-                }
-            } else {
-                if is_fwu_enabled && cpu_freq <= FREQ_PS1_FWS_1_FWU_MAX_FREQ {
-                    self.set_wait_state(1);
-                    self.issue_command(FlashCMD::HSDIS, -1);
-                } else {
-                    self.set_wait_state(0);
-                    self.issue_command(FlashCMD::HSDIS, -1);
-                }
-            }
-        } else {
-            // ps_val == 1
-            if cpu_freq > FREQ_PS1_FWS_0_MAX_FREQ {
-                self.set_wait_state(1);
-            } else {
-                self.set_wait_state(0);
-            }
-            self.issue_command(FlashCMD::HSDIS, -1);
-        }
     }
 
     /// Configure high-speed flash mode. This is taken from the ASF code


### PR DESCRIPTION
### Pull Request Overview

This code is not compiled so let's remove it

The lowRISC wakeup timer code was originally added via https://github.com/tock/tock/pull/3208. It's unused and there is no current plan to use the wakeup timer. The code hasn't been tested or update along with other OpenTitan updates or test, so we don't know if it even works. Let's remove it. If wakeup timer support is added in the future the code can easily be reverted.

### Testing Strategy

N/A

### TODO or Help Wanted

N/A

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
