### PR TITLE
802.15.4: Revert raw/encrypted receive

### DIFF
--- a/boards/components/src/ieee802154.rs
+++ b/boards/components/src/ieee802154.rs
@@ -325,7 +325,6 @@ impl<
             ));
         mac_device.set_transmit_client(mux_mac);
         mac_device.set_receive_client(mux_mac);
-        mac_device.set_receive_secured_frame_no_decrypt_client(mux_mac);
 
         let userspace_mac =
             static_buffer
@@ -349,7 +348,6 @@ impl<
         mac_device.set_device_procedure(radio_driver);
         userspace_mac.set_transmit_client(radio_driver);
         userspace_mac.set_receive_client(radio_driver);
-        userspace_mac.set_receive_secured_frame_no_decrypt_client(radio_driver);
         userspace_mac.set_pan(self.pan_id);
         userspace_mac.set_address(self.short_addr);
         userspace_mac.set_address_long(self.long_addr);

--- a/capsules/extra/src/ieee802154/device.rs
+++ b/capsules/extra/src/ieee802154/device.rs
@@ -24,11 +24,6 @@ pub trait MacDevice<'a> {
     fn set_transmit_client(&self, client: &'a dyn TxClient);
     /// Sets the receive client of this MAC device
     fn set_receive_client(&self, client: &'a dyn RxClient);
-    /// Sets the secure frame no decrypt receive client of this MAC device
-    fn set_receive_secured_frame_no_decrypt_client(
-        &self,
-        client: &'a dyn SecuredFrameNoDecryptRxClient,
-    );
 
     /// The short 16-bit address of the MAC device
     fn get_address(&self) -> u16;
@@ -129,8 +124,8 @@ pub trait RxClient {
     /// unsecured frames that have passed the incoming security procedure are
     /// exposed to the client.
     ///
-    /// - `buf`: The entire buffer containing the frame, potentially also
-    /// including extra bytes in front used for the physical layer.
+    /// - `buf`: The entire buffer containing the frame, including extra bytes
+    /// in front used for the physical layer.
     /// - `header`: A fully-parsed representation of the MAC header, with the
     /// caveat that the auxiliary security header is still included if the frame
     /// was previously secured.
@@ -140,37 +135,6 @@ pub trait RxClient {
     /// `buf[data_offset..data_offset + data_len]`.
     /// - `data_len`: Length of the data payload
     fn receive<'a>(
-        &self,
-        buf: &'a [u8],
-        header: Header<'a>,
-        lqi: u8,
-        data_offset: usize,
-        data_len: usize,
-    );
-}
-
-/// Trait to be implemented by users of the IEEE 802.15.4 device that wish to
-/// receive frames possessing link layer security that remain secured (i.e.
-/// have not been decrypted). This allows the client to perform decryption
-/// on the frame. The callback is trigger whenever a valid frame is received.
-/// In this context, raw refers to receiving frames without processing the
-/// security of the frame. The SecuredFrameNoDecryptRxClient should not be
-/// used to pass frames to the higher layers of the network stack that expect
-/// unsecured frames.
-pub trait SecuredFrameNoDecryptRxClient {
-    /// When a frame is received, this callback is triggered. The client only
-    /// receives an immutable borrow of the buffer. All frames, regardless of
-    /// their secured state, are exposed to the client.
-    ///
-    /// - `buf`: The entire buffer containing the frame, potentially also
-    /// including extra bytes in front used for the physical layer.
-    /// - `header`: A fully-parsed representation of the MAC header.
-    /// - `lqi`: The link quality indicator of the received frame.
-    /// - `data_offset`: Offset of the data payload relative to
-    /// `buf`, so that the payload of the frame is contained in
-    /// `buf[data_offset..data_offset + data_len]`.
-    /// - `data_len`: Length of the data payload
-    fn receive_secured_frame<'a>(
         &self,
         buf: &'a [u8],
         header: Header<'a>,

--- a/capsules/extra/src/ieee802154/driver.rs
+++ b/capsules/extra/src/ieee802154/driver.rs
@@ -56,7 +56,6 @@
 use crate::ieee802154::{device, framer};
 use crate::net::ieee802154::{Header, KeyId, MacAddress, SecurityLevel};
 use crate::net::stream::{decode_bytes, decode_u8, encode_bytes, encode_u8, SResult};
-use device::RxClient;
 
 use core::cell::Cell;
 
@@ -1065,22 +1064,6 @@ impl<'a, M: device::MacDevice<'a>> device::TxClient for RadioDriver<'a, M> {
             });
         });
         self.do_next_tx_async();
-    }
-}
-
-impl<'a, M: device::MacDevice<'a>> device::SecuredFrameNoDecryptRxClient for RadioDriver<'a, M> {
-    fn receive_secured_frame<'b>(
-        &self,
-        buf: &'b [u8],
-        header: Header<'b>,
-        lqi: u8,
-        data_offset: usize,
-        data_len: usize,
-    ) {
-        // The current 15.4 userspace receive accepts both secured and
-        // unsecured frames. As such, we can simply call the standard
-        // receive method of the RxClient trait.
-        self.receive(buf, header, lqi, data_offset, data_len)
     }
 }
 

--- a/capsules/extra/src/ieee802154/framer.rs
+++ b/capsules/extra/src/ieee802154/framer.rs
@@ -75,7 +75,7 @@
 // TODO: Channel scanning
 //
 
-use crate::ieee802154::device::{MacDevice, RxClient, SecuredFrameNoDecryptRxClient, TxClient};
+use crate::ieee802154::device::{MacDevice, RxClient, TxClient};
 use crate::ieee802154::mac::Mac;
 use crate::net::ieee802154::{
     FrameType, FrameVersion, Header, KeyId, MacAddress, PanID, Security, SecurityLevel,
@@ -396,7 +396,6 @@ pub struct Framer<'a, M: Mac<'a>, A: AES128CCM<'a>> {
     /// `None`, except when transitioning between states.
     rx_state: MapCell<RxState>,
     rx_client: OptionalCell<&'a dyn RxClient>,
-    secured_frame_no_decrypt_rx_client: OptionalCell<&'a dyn SecuredFrameNoDecryptRxClient>,
     crypt_buf: MapCell<SubSliceMut<'static, u8>>,
 }
 
@@ -416,7 +415,6 @@ impl<'a, M: Mac<'a>, A: AES128CCM<'a>> Framer<'a, M, A> {
             tx_client: OptionalCell::empty(),
             rx_state: MapCell::new(RxState::Idle),
             rx_client: OptionalCell::empty(),
-            secured_frame_no_decrypt_rx_client: OptionalCell::empty(),
             crypt_buf: MapCell::new(crypt_buf),
         }
     }
@@ -512,8 +510,8 @@ impl<'a, M: Mac<'a>, A: AES128CCM<'a>> Framer<'a, M, A> {
                             Some(key) => key,
                             None => {
                                 // Key not found -- pass raw encrypted packet to client
-                                self.secured_frame_no_decrypt_rx_client.map(|client| {
-                                    client.receive_secured_frame(frame_buffer, header, lqi, data_offset, data_len);
+                                self.rx_client.map(|client| {
+                                    client.receive(frame_buffer, header, lqi, data_offset, data_len);
                                 });
                                 return None;
                             }
@@ -805,13 +803,6 @@ impl<'a, M: Mac<'a>, A: AES128CCM<'a>> MacDevice<'a> for Framer<'a, M, A> {
 
     fn set_receive_client(&self, client: &'a dyn RxClient) {
         self.rx_client.set(client);
-    }
-
-    fn set_receive_secured_frame_no_decrypt_client(
-        &self,
-        client: &'a dyn super::device::SecuredFrameNoDecryptRxClient,
-    ) {
-        self.secured_frame_no_decrypt_rx_client.set(client);
     }
 
     fn get_address(&self) -> u16 {

--- a/capsules/extra/src/ieee802154/framer.rs
+++ b/capsules/extra/src/ieee802154/framer.rs
@@ -509,10 +509,6 @@ impl<'a, M: Mac<'a>, A: AES128CCM<'a>> Framer<'a, M, A> {
                         let key = match self.lookup_key(security.level, security.key_id) {
                             Some(key) => key,
                             None => {
-                                // Key not found -- pass raw encrypted packet to client
-                                self.rx_client.map(|client| {
-                                    client.receive(frame_buffer, header, lqi, data_offset, data_len);
-                                });
                                 return None;
                             }
                         };

--- a/capsules/extra/src/ieee802154/virtual_mac.rs
+++ b/capsules/extra/src/ieee802154/virtual_mac.rs
@@ -72,21 +72,6 @@ impl<'a, M: device::MacDevice<'a>> device::RxClient for MuxMac<'a, M> {
     }
 }
 
-impl<'a, M: device::MacDevice<'a>> device::SecuredFrameNoDecryptRxClient for MuxMac<'a, M> {
-    fn receive_secured_frame<'b>(
-        &self,
-        buf: &'b [u8],
-        header: Header<'b>,
-        lqi: u8,
-        data_offset: usize,
-        data_len: usize,
-    ) {
-        for user in self.users.iter() {
-            user.receive_secured_frame(buf, header, lqi, data_offset, data_len);
-        }
-    }
-}
-
 impl<'a, M: device::MacDevice<'a>> MuxMac<'a, M> {
     pub const fn new(mac: &'a M) -> MuxMac<'a, M> {
         MuxMac {
@@ -218,7 +203,6 @@ pub struct MacUser<'a, M: device::MacDevice<'a>> {
     next: ListLink<'a, MacUser<'a, M>>,
     tx_client: OptionalCell<&'a dyn device::TxClient>,
     rx_client: OptionalCell<&'a dyn device::RxClient>,
-    secure_frame_no_decrypt_rx_client: OptionalCell<&'a dyn device::SecuredFrameNoDecryptRxClient>,
 }
 
 impl<'a, M: device::MacDevice<'a>> MacUser<'a, M> {
@@ -229,7 +213,6 @@ impl<'a, M: device::MacDevice<'a>> MacUser<'a, M> {
             next: ListLink::empty(),
             tx_client: OptionalCell::empty(),
             rx_client: OptionalCell::empty(),
-            secure_frame_no_decrypt_rx_client: OptionalCell::empty(),
         }
     }
 }
@@ -253,21 +236,6 @@ impl<'a, M: device::MacDevice<'a>> MacUser<'a, M> {
             .get()
             .map(move |client| client.receive(buf, header, lqi, data_offset, data_len));
     }
-
-    fn receive_secured_frame<'b>(
-        &self,
-        buf: &'b [u8],
-        header: Header<'b>,
-        lqi: u8,
-        data_offset: usize,
-        data_len: usize,
-    ) {
-        self.secure_frame_no_decrypt_rx_client
-            .get()
-            .map(move |client| {
-                client.receive_secured_frame(buf, header, lqi, data_offset, data_len)
-            });
-    }
 }
 
 impl<'a, M: device::MacDevice<'a>> ListNode<'a, MacUser<'a, M>> for MacUser<'a, M> {
@@ -283,13 +251,6 @@ impl<'a, M: device::MacDevice<'a>> device::MacDevice<'a> for MacUser<'a, M> {
 
     fn set_receive_client(&self, client: &'a dyn device::RxClient) {
         self.rx_client.set(client);
-    }
-
-    fn set_receive_secured_frame_no_decrypt_client(
-        &self,
-        client: &'a dyn device::SecuredFrameNoDecryptRxClient,
-    ) {
-        self.secure_frame_no_decrypt_rx_client.set(client);
     }
 
     fn get_address(&self) -> u16 {


### PR DESCRIPTION
### Pull Request Overview
In the lead up to the Thread tutorial we needed to sidestep the in-kernel 15.4 stack when receiving. Our new approach is to implement the userspace driver with the radio HIL directly and not use the 15.4 stack. So we no longer need this.


### Testing Strategy

Testing is a work in progress, and only really makes sense with all 15.4 changes.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
