### PR TITLE
appid: add null checker

### DIFF
--- a/boards/components/src/appid/checker.rs
+++ b/boards/components/src/appid/checker.rs
@@ -14,8 +14,7 @@ macro_rules! process_checker_machine_component_static {
     };};
 }
 
-pub type ProcessCheckerMachineComponentType =
-    capsules_system::process_checker::basic::AppCheckerSha256;
+pub type ProcessCheckerMachineComponentType = kernel::process::ProcessCheckerMachine;
 
 pub struct ProcessCheckerMachineComponent {
     policy: &'static dyn kernel::process_checker::AppCredentialsPolicy<'static>,

--- a/boards/components/src/appid/checker_null.rs
+++ b/boards/components/src/appid/checker_null.rs
@@ -1,0 +1,36 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2024.
+
+//! Component for creating a NULL process checking machine that approves all
+//! processes.
+
+use core::mem::MaybeUninit;
+use kernel::component::Component;
+
+#[macro_export]
+macro_rules! app_checker_null_component_static {
+    () => {{
+        kernel::static_buf!(capsules_system::process_checker::basic::AppCheckerNull);
+    };};
+}
+
+pub type AppCheckerNullComponentType = capsules_system::process_checker::basic::AppCheckerNull;
+
+pub struct AppCheckerNullComponent {}
+
+impl AppCheckerNullComponent {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Component for AppCheckerNullComponent {
+    type StaticInput =
+        &'static mut MaybeUninit<capsules_system::process_checker::basic::AppCheckerNull>;
+    type Output = &'static capsules_system::process_checker::basic::AppCheckerNull;
+
+    fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        s.write(capsules_system::process_checker::basic::AppCheckerNull::new())
+    }
+}

--- a/boards/components/src/appid/mod.rs
+++ b/boards/components/src/appid/mod.rs
@@ -4,4 +4,5 @@
 
 pub mod assigner_name;
 pub mod checker;
+pub mod checker_null;
 pub mod checker_sha;


### PR DESCRIPTION
### Pull Request Overview

Now that async process loading is coupled with credential checking, it is valuable for testing to have a credential checker which approves every app. The existing implementation is much more complicated than needed. This also adds a component for using the checker.

I'm using this in the soil moisture sensor example.


### Testing Strategy

Part of soil moisture sensor example.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
