### PR TITLE
802.15.4: Add 15.4 Stack Readme

### DIFF
--- a/capsules/extra/src/ieee802154/README.md
+++ b/capsules/extra/src/ieee802154/README.md
@@ -3,9 +3,8 @@ IEEE 802.15.4 Stack
 
 Tock supports two different implementations of an IEEE 802.15.4 stack in the
 kernel. The first version implements packet framing and a MAC layer, virtualizes
-the 15.4 interface, and provides a userspace interface. The second version
-provides a much more raw version and only provides userspace with direct access
-to the 15.4 radio.
+the 15.4 interface, and provides a multi-programmable userspace interface. The second version
+provides userspace with the ability to send/receive raw 802.15.4 frames as well as directly control the radio, and is appropriate for access by one process at a time.
 
 In-Kernel Stack
 ---------------

--- a/capsules/extra/src/ieee802154/README.md
+++ b/capsules/extra/src/ieee802154/README.md
@@ -1,0 +1,53 @@
+IEEE 802.15.4 Stack
+===================
+
+Tock supports two different implementations of an IEEE 802.15.4 stack in the
+kernel. The first version implements packet framing and a MAC layer, virtualizes
+the 15.4 interface, and provides a userspace interface. The second version
+provides a much more raw version and only provides userspace with direct access
+to the 15.4 radio.
+
+In-Kernel Stack
+---------------
+
+Stack overview:
+
+```text
+┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄ Syscall Interface
+┌──────────────────────┐
+│     RadioDriver      │
+└──────────────────────┘
+┄┄ ieee802154::device::MacDevice ┄┄
+┌──────────────────────┐
+│      VirtualMac      │
+└──────────────────────┘
+┄┄ ieee802154::device::MacDevice ┄┄
+┌──────────────────────┐
+│        Framer        │
+└──────────────────────┘
+┄┄ ieee802154::mac::Mac ┄┄
+┌──────────────────────┐
+│  MAC (ex: AwakeMac)  │
+└──────────────────────┘
+┄┄ hil::radio::Radio ┄┄
+┌──────────────────────┐
+│    802.15.4 Radio    │
+└──────────────────────┘
+```
+
+
+Raw Stack
+---------
+
+Stack overview:
+
+```text
+┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄ Syscall Interface
+┌─────────────────────────┐
+│ phy_driver::RadioDriver │
+└─────────────────────────┘
+┄┄ hil::radio::Radio ┄┄
+┌─────────────────────────┐
+│     802.15.4 Radio      │
+└─────────────────────────┘
+```


### PR DESCRIPTION
### Pull Request Overview

Add a simple diagram showing the layers of the 15.4 stack and the two syscall drivers.


### Testing Strategy

Documentation


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
