### PR TITLE
AppID/TBF: Add `ShortId` header

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ members = [
     "boards/swervolf",
     "boards/weact_f401ccu6/",
     "boards/configurations/nrf52840dk/nrf52840dk-test-appid-sha256",
+    "boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf",
     "boards/configurations/nrf52840dk/nrf52840dk-test-kernel",
     "boards/tutorials/nrf52840dk-thread-tutorial",
     "capsules/aes_gcm",

--- a/boards/components/src/appid/assigner_tbf.rs
+++ b/boards/components/src/appid/assigner_tbf.rs
@@ -1,0 +1,34 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2024.
+
+//! Components for AppID assigners based on TBF headers.
+
+use core::mem::MaybeUninit;
+use kernel::component::Component;
+
+#[macro_export]
+macro_rules! appid_assigner_tbf_header_component_static {
+    () => {{
+        kernel::static_buf!(capsules_system::process_checker::tbf::AppIdAssignerTbfHeader)
+    };};
+}
+
+pub struct AppIdAssignerTbfHeaderComponent {}
+
+impl AppIdAssignerTbfHeaderComponent {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Component for AppIdAssignerTbfHeaderComponent {
+    type StaticInput =
+        &'static mut MaybeUninit<capsules_system::process_checker::tbf::AppIdAssignerTbfHeader>;
+
+    type Output = &'static capsules_system::process_checker::tbf::AppIdAssignerTbfHeader;
+
+    fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        s.write(capsules_system::process_checker::tbf::AppIdAssignerTbfHeader {})
+    }
+}

--- a/boards/components/src/appid/checker_null.rs
+++ b/boards/components/src/appid/checker_null.rs
@@ -11,7 +11,7 @@ use kernel::component::Component;
 #[macro_export]
 macro_rules! app_checker_null_component_static {
     () => {{
-        kernel::static_buf!(capsules_system::process_checker::basic::AppCheckerNull);
+        kernel::static_buf!(capsules_system::process_checker::basic::AppCheckerNull)
     };};
 }
 

--- a/boards/components/src/appid/mod.rs
+++ b/boards/components/src/appid/mod.rs
@@ -3,6 +3,7 @@
 // Copyright Tock Contributors 2024.
 
 pub mod assigner_name;
+pub mod assigner_tbf;
 pub mod checker;
 pub mod checker_null;
 pub mod checker_sha;

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/Cargo.toml
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/Cargo.toml
@@ -1,0 +1,21 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
+[package]
+name = "nrf52840dk-test-appid-tbf"
+version.workspace = true
+authors.workspace = true
+build = "../../../build.rs"
+edition.workspace = true
+
+[dependencies]
+components = { path = "../../../components" }
+cortexm4 = { path = "../../../../arch/cortex-m4" }
+kernel = { path = "../../../../kernel" }
+nrf52840 = { path = "../../../../chips/nrf52840" }
+nrf52_components = { path = "../../../nordic/nrf52_components" }
+
+capsules-core = { path = "../../../../capsules/core" }
+capsules-extra = { path = "../../../../capsules/extra" }
+capsules-system = { path = "../../../../capsules/system" }

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/Makefile
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/Makefile
@@ -1,0 +1,9 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
+TARGET=thumbv7em-none-eabi
+PLATFORM=nrf52840dk-test-appid-tbf
+
+include ../../../Makefile.common
+include ../nrf52840dk.mk

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/README.md
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/README.md
@@ -1,0 +1,4 @@
+nRF52840-DK TBF AppID Test Board
+================================
+
+This is a minimal kernel for testing with setting `ShortId`s from TBF headers.

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/layout.ld
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/layout.ld
@@ -1,0 +1,6 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
+INCLUDE ../../../nordic/nrf52840_chip_layout.ld
+INCLUDE ../../../kernel_layout.ld

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/io.rs
@@ -1,0 +1,17 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2024.
+
+use core::panic::PanicInfo;
+use nrf52840::gpio::Pin;
+
+#[cfg(not(test))]
+#[no_mangle]
+#[panic_handler]
+/// Panic handler
+pub unsafe fn panic_fmt(_pi: &PanicInfo) -> ! {
+    // The nRF52840DK LEDs (see back of board)
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
+    let led = &mut kernel::hil::led::LedLow::new(led_kernel_pin);
+    kernel::debug::panic_blink_forever(&mut [led])
+}

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/main.rs
@@ -1,0 +1,385 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! Tock kernel for the Nordic Semiconductor nRF52840 development kit (DK).
+
+#![no_std]
+// Disable this attribute when documenting, as a workaround for
+// https://github.com/rust-lang/rust/issues/62184.
+#![cfg_attr(not(doc), no_main)]
+#![deny(missing_docs)]
+
+use core::ptr::{addr_of, addr_of_mut};
+
+use kernel::component::Component;
+use kernel::deferred_call::DeferredCallClient;
+use kernel::hil::led::LedLow;
+use kernel::hil::time::Counter;
+use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::process::ProcessLoadingAsync;
+use kernel::scheduler::round_robin::RoundRobinSched;
+use kernel::{capabilities, create_capability, static_init};
+use nrf52840::gpio::Pin;
+use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
+use nrf52_components::{UartChannel, UartPins};
+
+// The nRF52840DK LEDs (see back of board)
+const LED1_PIN: Pin = Pin::P0_13;
+const LED2_PIN: Pin = Pin::P0_14;
+const LED3_PIN: Pin = Pin::P0_15;
+const LED4_PIN: Pin = Pin::P0_16;
+
+const BUTTON_RST_PIN: Pin = Pin::P0_18;
+
+const UART_RTS: Option<Pin> = Some(Pin::P0_05);
+const UART_TXD: Pin = Pin::P0_06;
+const UART_CTS: Option<Pin> = Some(Pin::P0_07);
+const UART_RXD: Pin = Pin::P0_08;
+
+/// Debug Writer
+pub mod io;
+
+// State for loading and holding applications.
+// How should the kernel respond when a process faults.
+const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
+    capsules_system::process_policies::PanicFaultPolicy {};
+
+// Number of concurrent processes this platform supports.
+const NUM_PROCS: usize = 8;
+
+static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS] =
+    [None; NUM_PROCS];
+
+static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;
+
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x2000] = [0; 0x2000];
+
+//------------------------------------------------------------------------------
+// SYSCALL DRIVER TYPE DEFINITIONS
+//------------------------------------------------------------------------------
+
+type AlarmDriver = components::alarm::AlarmDriverComponentType<nrf52840::rtc::Rtc<'static>>;
+
+/// Supported drivers by the platform
+pub struct Platform {
+    console: &'static capsules_core::console::Console<'static>,
+    led: &'static capsules_core::led::LedDriver<
+        'static,
+        kernel::hil::led::LedLow<'static, nrf52840::gpio::GPIOPin<'static>>,
+        4,
+    >,
+    alarm: &'static AlarmDriver,
+    scheduler: &'static RoundRobinSched<'static>,
+    systick: cortexm4::systick::SysTick,
+}
+
+impl SyscallDriverLookup for Platform {
+    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    where
+        F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
+    {
+        match driver_num {
+            capsules_core::console::DRIVER_NUM => f(Some(self.console)),
+            capsules_core::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules_core::led::DRIVER_NUM => f(Some(self.led)),
+            _ => f(None),
+        }
+    }
+}
+
+/// This is in a separate, inline(never) function so that its stack frame is
+/// removed when this function returns. Otherwise, the stack space used for
+/// these static_inits is wasted.
+#[inline(never)]
+unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> {
+    let ieee802154_ack_buf = static_init!(
+        [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
+        [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
+    );
+    // Initialize chip peripheral drivers
+    let nrf52840_peripherals = static_init!(
+        Nrf52840DefaultPeripherals,
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf)
+    );
+
+    nrf52840_peripherals
+}
+
+impl KernelResources<nrf52840::chip::NRF52<'static, Nrf52840DefaultPeripherals<'static>>>
+    for Platform
+{
+    type SyscallDriverLookup = Self;
+    type SyscallFilter = ();
+    type ProcessFault = ();
+    type Scheduler = RoundRobinSched<'static>;
+    type SchedulerTimer = cortexm4::systick::SysTick;
+    type WatchDog = ();
+    type ContextSwitchCallback = ();
+
+    fn syscall_driver_lookup(&self) -> &Self::SyscallDriverLookup {
+        self
+    }
+    fn syscall_filter(&self) -> &Self::SyscallFilter {
+        &()
+    }
+    fn process_fault(&self) -> &Self::ProcessFault {
+        &()
+    }
+    fn scheduler(&self) -> &Self::Scheduler {
+        self.scheduler
+    }
+    fn scheduler_timer(&self) -> &Self::SchedulerTimer {
+        &self.systick
+    }
+    fn watchdog(&self) -> &Self::WatchDog {
+        &()
+    }
+    fn context_switch_callback(&self) -> &Self::ContextSwitchCallback {
+        &()
+    }
+}
+
+impl kernel::process::ProcessLoadingAsyncClient for Platform {
+    fn process_loaded(&self, _result: Result<(), kernel::process::ProcessLoadError>) {}
+
+    fn process_loading_finished(&self) {
+        kernel::debug!("Processes Loaded:");
+
+        unsafe {
+            for (i, proc) in PROCESSES.iter().enumerate() {
+                proc.map(|p| {
+                    kernel::debug!("[{}] {}", i, p.get_process_name());
+                    kernel::debug!("    ShortId: {}", p.short_app_id());
+                });
+            }
+        }
+    }
+}
+
+/// Main function called after RAM initialized.
+#[no_mangle]
+pub unsafe fn main() {
+    //--------------------------------------------------------------------------
+    // INITIAL SETUP
+    //--------------------------------------------------------------------------
+
+    // Apply errata fixes and enable interrupts.
+    nrf52840::init();
+
+    // Set up peripheral drivers. Called in separate function to reduce stack
+    // usage.
+    let nrf52840_peripherals = create_peripherals();
+
+    // Set up circular peripheral dependencies.
+    nrf52840_peripherals.init();
+    let base_peripherals = &nrf52840_peripherals.nrf52;
+
+    // Choose the channel for serial output. This board can be configured to use
+    // either the Segger RTT channel or via UART with traditional TX/RX GPIO
+    // pins.
+    let uart_channel = UartChannel::Pins(UartPins::new(UART_RTS, UART_TXD, UART_CTS, UART_RXD));
+
+    // Setup space to store the core kernel data structure.
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
+
+    // Create (and save for panic debugging) a chip object to setup low-level
+    // resources (e.g. MPU, systick).
+    let chip = static_init!(
+        nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
+        nrf52840::chip::NRF52::new(nrf52840_peripherals)
+    );
+    CHIP = Some(chip);
+
+    // Do nRF configuration and setup. This is shared code with other nRF-based
+    // platforms.
+    nrf52_components::startup::NrfStartupComponent::new(
+        false,
+        BUTTON_RST_PIN,
+        nrf52840::uicr::Regulator0Output::DEFAULT,
+        &base_peripherals.nvmc,
+    )
+    .finalize(());
+
+    //--------------------------------------------------------------------------
+    // CAPABILITIES
+    //--------------------------------------------------------------------------
+
+    // Create capabilities that the board needs to call certain protected kernel
+    // functions.
+    let process_management_capability =
+        create_capability!(capabilities::ProcessManagementCapability);
+    let main_loop_capability = create_capability!(capabilities::MainLoopCapability);
+
+    //--------------------------------------------------------------------------
+    // LEDs
+    //--------------------------------------------------------------------------
+
+    let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
+        LedLow<'static, nrf52840::gpio::GPIOPin>,
+        LedLow::new(&nrf52840_peripherals.gpio_port[LED1_PIN]),
+        LedLow::new(&nrf52840_peripherals.gpio_port[LED2_PIN]),
+        LedLow::new(&nrf52840_peripherals.gpio_port[LED3_PIN]),
+        LedLow::new(&nrf52840_peripherals.gpio_port[LED4_PIN]),
+    ));
+
+    //--------------------------------------------------------------------------
+    // TIMER
+    //--------------------------------------------------------------------------
+
+    let rtc = &base_peripherals.rtc;
+    let _ = rtc.start();
+    let mux_alarm = components::alarm::AlarmMuxComponent::new(rtc)
+        .finalize(components::alarm_mux_component_static!(nrf52840::rtc::Rtc));
+    let alarm = components::alarm::AlarmDriverComponent::new(
+        board_kernel,
+        capsules_core::alarm::DRIVER_NUM,
+        mux_alarm,
+    )
+    .finalize(components::alarm_component_static!(nrf52840::rtc::Rtc));
+
+    //--------------------------------------------------------------------------
+    // UART & CONSOLE & DEBUG
+    //--------------------------------------------------------------------------
+
+    let uart_channel = nrf52_components::UartChannelComponent::new(
+        uart_channel,
+        mux_alarm,
+        &base_peripherals.uarte0,
+    )
+    .finalize(nrf52_components::uart_channel_component_static!(
+        nrf52840::rtc::Rtc
+    ));
+
+    // Virtualize the UART channel for the console and for kernel debug.
+    let uart_mux = components::console::UartMuxComponent::new(uart_channel, 115200)
+        .finalize(components::uart_mux_component_static!());
+
+    // Setup the serial console for userspace.
+    let console = components::console::ConsoleComponent::new(
+        board_kernel,
+        capsules_core::console::DRIVER_NUM,
+        uart_mux,
+    )
+    .finalize(components::console_component_static!());
+
+    // Tool for displaying information about processes.
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
+
+    // Create the process console, an interactive terminal for managing
+    // processes.
+    let pconsole = components::process_console::ProcessConsoleComponent::new(
+        board_kernel,
+        uart_mux,
+        mux_alarm,
+        process_printer,
+        Some(cortexm4::support::reset),
+    )
+    .finalize(components::process_console_component_static!(
+        nrf52840::rtc::Rtc<'static>
+    ));
+
+    // Create the debugger object that handles calls to `debug!()`.
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
+
+    //--------------------------------------------------------------------------
+    // NRF CLOCK SETUP
+    //--------------------------------------------------------------------------
+
+    nrf52_components::NrfClockComponent::new(&base_peripherals.clock).finalize(());
+
+    //--------------------------------------------------------------------------
+    // Credential Checking
+    //--------------------------------------------------------------------------
+
+    // Create the credential checker.
+    let checking_policy = components::appid::checker_null::AppCheckerNullComponent::new()
+        .finalize(components::app_checker_null_component_static!());
+
+    // Create the AppID assigner.
+    let assigner = components::appid::assigner_tbf::AppIdAssignerTbfHeaderComponent::new()
+        .finalize(components::appid_assigner_tbf_header_component_static!());
+
+    // Create the process checking machine.
+    let checker = components::appid::checker::ProcessCheckerMachineComponent::new(checking_policy)
+        .finalize(components::process_checker_machine_component_static!());
+
+    // These symbols are defined in the linker script.
+    extern "C" {
+        /// Beginning of the ROM region containing app images.
+        static _sapps: u8;
+        /// End of the ROM region containing app images.
+        static _eapps: u8;
+        /// Beginning of the RAM region for app memory.
+        static mut _sappmem: u8;
+        /// End of the RAM region for app memory.
+        static _eappmem: u8;
+    }
+
+    let process_binary_array = static_init!(
+        [Option<kernel::process::ProcessBinary>; NUM_PROCS],
+        [None, None, None, None, None, None, None, None]
+    );
+
+    let loader = static_init!(
+        kernel::process::SequentialProcessLoaderMachine<
+            nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
+        >,
+        kernel::process::SequentialProcessLoaderMachine::new(
+            checker,
+            &mut *addr_of_mut!(PROCESSES),
+            process_binary_array,
+            board_kernel,
+            chip,
+            core::slice::from_raw_parts(
+                core::ptr::addr_of!(_sapps),
+                core::ptr::addr_of!(_eapps) as usize - core::ptr::addr_of!(_sapps) as usize,
+            ),
+            core::slice::from_raw_parts_mut(
+                core::ptr::addr_of_mut!(_sappmem),
+                core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
+            ),
+            &FAULT_RESPONSE,
+            assigner,
+            &process_management_capability
+        )
+    );
+
+    checker.set_client(loader);
+
+    //--------------------------------------------------------------------------
+    // PLATFORM SETUP, SCHEDULER, AND START KERNEL LOOP
+    //--------------------------------------------------------------------------
+
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
+        .finalize(components::round_robin_component_static!(NUM_PROCS));
+
+    let platform = static_init!(
+        Platform,
+        Platform {
+            console,
+            led,
+            alarm,
+            scheduler,
+            systick: cortexm4::systick::SysTick::new_with_calibration(64000000),
+        }
+    );
+
+    loader.set_client(platform);
+    loader.register();
+    loader.start();
+
+    let _ = pconsole.start();
+
+    board_kernel.kernel_loop(
+        platform,
+        chip,
+        None::<&kernel::ipc::IPC<0>>,
+        &main_loop_capability,
+    );
+}

--- a/capsules/system/src/process_checker/mod.rs
+++ b/capsules/system/src/process_checker/mod.rs
@@ -4,3 +4,4 @@
 
 pub mod basic;
 pub mod signature;
+pub mod tbf;

--- a/capsules/system/src/process_checker/tbf.rs
+++ b/capsules/system/src/process_checker/tbf.rs
@@ -1,0 +1,46 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2024.
+
+//! AppID mechanisms based on TBF headers.
+
+use kernel::process::{Process, ProcessBinary, ShortId};
+use kernel::process_checker::{AppUniqueness, Compress};
+
+/// Assign AppIDs based on fields in the app's TBF header.
+///
+/// This uses the ShortId TBF header to assign short IDs to applications. If the
+/// header is not present the application will be assigned a
+/// `ShortID::LocallyUnique` ID.
+///
+/// This assigner uses ShortIds as the AppID, so the built-in check for ShortId
+/// uniqueness is sufficient.
+pub struct AppIdAssignerTbfHeader {}
+
+impl AppUniqueness for AppIdAssignerTbfHeader {
+    fn different_identifier(&self, _process_a: &ProcessBinary, _process_b: &ProcessBinary) -> bool {
+        true
+    }
+
+    fn different_identifier_process(
+        &self,
+        _process_binary: &ProcessBinary,
+        _process: &dyn Process,
+    ) -> bool {
+        true
+    }
+
+    fn different_identifier_processes(
+        &self,
+        _process_a: &dyn Process,
+        _process_b: &dyn Process,
+    ) -> bool {
+        true
+    }
+}
+
+impl Compress for AppIdAssignerTbfHeader {
+    fn to_short_id(&self, process: &ProcessBinary) -> ShortId {
+        process.header.get_fixed_short_id().into()
+    }
+}

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -261,6 +261,15 @@ impl PartialEq for ShortId {
 }
 impl Eq for ShortId {}
 
+impl core::convert::From<Option<core::num::NonZeroU32>> for ShortId {
+    fn from(id: Option<core::num::NonZeroU32>) -> ShortId {
+        match id {
+            Some(fixed) => ShortId::Fixed(fixed),
+            None => ShortId::LocallyUnique,
+        }
+    }
+}
+
 /// Enum used to inform scheduler why a process stopped executing (aka why
 /// `do_process()` returned).
 ///

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -270,6 +270,19 @@ impl core::convert::From<Option<core::num::NonZeroU32>> for ShortId {
     }
 }
 
+impl core::fmt::Display for ShortId {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter) -> fmt::Result {
+        match *self {
+            ShortId::LocallyUnique => {
+                write!(fmt, "Unique")
+            }
+            ShortId::Fixed(id) => {
+                write!(fmt, "0x{:<8x} ", id)
+            }
+        }
+    }
+}
+
 /// Enum used to inform scheduler why a process stopped executing (aka why
 /// `do_process()` returned).
 ///

--- a/libraries/tock-tbf/src/parse.rs
+++ b/libraries/tock-tbf/src/parse.rs
@@ -128,6 +128,7 @@ pub fn parse_tbf_header(
                 let mut permissions_pointer: Option<&'static [u8]> = None;
                 let mut storage_permissions_pointer: Option<&'static [u8]> = None;
                 let mut kernel_version: Option<types::TbfHeaderV2KernelVersion> = None;
+                let mut short_id: Option<types::TbfHeaderV2ShortId> = None;
 
                 // Iterate the remainder of the header looking for TLV entries.
                 while remaining.len() > 0 {
@@ -256,6 +257,22 @@ pub fn parse_tbf_header(
                             }
                         }
 
+                        types::TbfHeaderTypes::TbfHeaderShortId => {
+                            let entry_len = mem::size_of::<types::TbfHeaderV2ShortId>();
+                            if tlv_header.length as usize == entry_len {
+                                short_id = Some(
+                                    remaining
+                                        .get(0..entry_len)
+                                        .ok_or(types::TbfParseError::NotEnoughFlash)?
+                                        .try_into()?,
+                                );
+                            } else {
+                                return Err(types::TbfParseError::BadTlvEntry(
+                                    tlv_header.tipe as usize,
+                                ));
+                            }
+                        }
+
                         _ => {}
                     }
 
@@ -279,6 +296,7 @@ pub fn parse_tbf_header(
                     permissions: permissions_pointer,
                     storage_permissions: storage_permissions_pointer,
                     kernel_version: kernel_version,
+                    short_id: short_id,
                 };
 
                 Ok(types::TbfHeader::TbfHeaderV2(tbf_header))

--- a/libraries/tock-tbf/src/types.rs
+++ b/libraries/tock-tbf/src/types.rs
@@ -130,6 +130,7 @@ pub enum TbfHeaderTypes {
     TbfHeaderStoragePermissions = 7,
     TbfHeaderKernelVersion = 8,
     TbfHeaderProgram = 9,
+    TbfHeaderShortId = 10,
     TbfFooterCredentials = 128,
 
     /// Some field in the header that we do not understand. Since the TLV format
@@ -241,6 +242,14 @@ pub struct TbfHeaderV2KernelVersion {
     minor: u16,
 }
 
+/// The v2 ShortId for apps.
+///
+/// Header to specify a fixed ShortID for an app.
+#[derive(Clone, Copy, Debug)]
+pub struct TbfHeaderV2ShortId {
+    short_id: Option<core::num::NonZeroU32>,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum TbfFooterV2CredentialsType {
     Reserved = 0,
@@ -319,6 +328,7 @@ impl core::convert::TryFrom<u16> for TbfHeaderTypes {
             7 => Ok(TbfHeaderTypes::TbfHeaderStoragePermissions),
             8 => Ok(TbfHeaderTypes::TbfHeaderKernelVersion),
             9 => Ok(TbfHeaderTypes::TbfHeaderProgram),
+            10 => Ok(TbfHeaderTypes::TbfHeaderShortId),
             128 => Ok(TbfHeaderTypes::TbfFooterCredentials),
             _ => Ok(TbfHeaderTypes::Unknown),
         }
@@ -563,6 +573,20 @@ impl core::convert::TryFrom<&[u8]> for TbfHeaderV2KernelVersion {
     }
 }
 
+impl core::convert::TryFrom<&[u8]> for TbfHeaderV2ShortId {
+    type Error = TbfParseError;
+
+    fn try_from(b: &[u8]) -> Result<TbfHeaderV2ShortId, Self::Error> {
+        Ok(TbfHeaderV2ShortId {
+            short_id: core::num::NonZeroU32::new(u32::from_le_bytes(
+                b.get(0..4)
+                    .ok_or(TbfParseError::InternalError)?
+                    .try_into()?,
+            )),
+        })
+    }
+}
+
 impl core::convert::TryFrom<&'static [u8]> for TbfFooterV2Credentials {
     type Error = TbfParseError;
 
@@ -633,6 +657,7 @@ pub struct TbfHeaderV2 {
     pub(crate) permissions: Option<&'static [u8]>,
     pub(crate) storage_permissions: Option<&'static [u8]>,
     pub(crate) kernel_version: Option<TbfHeaderV2KernelVersion>,
+    pub(crate) short_id: Option<TbfHeaderV2ShortId>,
 }
 
 /// Type that represents the fields of the Tock Binary Format header.
@@ -983,6 +1008,15 @@ impl TbfHeader {
         match self {
             TbfHeader::TbfHeaderV2(hd) => hd.program.map_or(0, |p| p.version),
             _ => 0,
+        }
+    }
+
+    /// Return the fixed ShortId of the application if it was specified in the
+    /// TBF header.
+    pub fn get_fixed_short_id(&self) -> Option<core::num::NonZeroU32> {
+        match self {
+            TbfHeader::TbfHeaderV2(hd) => hd.short_id.map_or(None, |si| si.short_id),
+            _ => None,
         }
     }
 }


### PR DESCRIPTION
### Pull Request Overview

Tock's process loading mechanism can assign AppIds and ShortIds to processes. Since there are only ~2^32 ShortIds, Tock kernels need some (at least partially manual) method to assign ShortIds to avoid the issue where two different applications are assigned the same ShortId.

Right now we really only have one upstream method: using a CRC of the process's name to create a ShortId.

This would add a second: allowing the developer to set the ShortId in the TBF header of the process. An implementation of the `Compress` trait can then use this header to set the ShortId (and this PR includes an example of that). This is the successor to a version that was in the original AppId PR where the id would be stored in the footer. That was removed because the footer is not included in the integrity region. This moves it to the header which is checked.

A kernel that is concerned about trusted apps should be careful to only use this header if the app was correctly signed by a trusted party.

The header itself is simple and is just a u32 with the fixed ShortId.

This PR also includes a config board to help with testing this feature.

I have corresponding changes to the book and Tockloader.


### Testing Strategy

Running the config board and displaying the ShortId as set by the TBF header.

```
❯ tockloader inspect-tab
[INFO   ] No TABs passed to tockloader.
[STATUS ] Searching for TABs in subdirectories.
[INFO   ] Using: ['./build/blink.tab']
[STATUS ] Inspecting TABs...
TAB: blink
  build-date: 2024-06-06 18:58:13+00:00
  minimum-tock-kernel-version: 2.0
  tab-version: 1
  included architectures: cortex-m0, cortex-m3, cortex-m4, cortex-m7, rv32imac, rv32imc

 Which TBF to inspect further? cortex-m4

cortex-m4:
  version               : 2                       [0x0  ]
  header_size           :         76         0x4c
  total_size            :       8192       0x2000
  checksum              :              0x6e3c4860
  flags                 :          1          0x1
    enabled             : Yes
    sticky              : No
  TLV: Main (1)                                   [0x10 ]
    init_fn_offset      :         49         0x31
    protected_size      :          8          0x8
    minimum_ram_size    :       4916       0x1334
  TLV: Program (9)                                [0x20 ]
    init_fn_offset      :         49         0x31
    protected_size      :          8          0x8
    minimum_ram_size    :       4916       0x1334
    binary_end_offset   :       1612        0x64c
    app_version         :          0          0x0
  TLV: Package Name (3)                           [0x38 ]
    package_name        : blink
  TLV: ShortID (10)                               [0x44 ]
    short_id            : 551

TBF Footers
  Footer
    footer_size         :       6580       0x19b4
  Footer TLV: Credentials (128)                   [0x0  ]
    Type: Reserved (0)
    Length: 6572
```


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
