### PR TITLE
AppID: Restore `AppIdPolicy` implementations' ability to use the accepted credential, and allow credential checkers to pass data with accepted credentials

### DIFF
--- a/capsules/system/src/process_checker/basic.rs
+++ b/capsules/system/src/process_checker/basic.rs
@@ -170,7 +170,7 @@ impl ClientVerify<32_usize> for AppCheckerSha256 {
             Ok(true) => {
                 self.client.map(|c| {
                     c.check_done(
-                        Ok(CheckResult::Accept),
+                        Ok(CheckResult::Accept(None)),
                         self.credentials.take().unwrap(),
                         self.binary.take().unwrap(),
                     );
@@ -294,7 +294,7 @@ impl<'a> DeferredCallClient for AppCheckerRsaSimulated<'a> {
             let result = if cred.format() == TbfFooterV2CredentialsType::Rsa3072Key
                 || cred.format() == TbfFooterV2CredentialsType::Rsa4096Key
             {
-                Ok(CheckResult::Accept)
+                Ok(CheckResult::Accept(None))
             } else {
                 Ok(CheckResult::Pass)
             };

--- a/capsules/system/src/process_checker/signature.rs
+++ b/capsules/system/src/process_checker/signature.rs
@@ -183,7 +183,7 @@ impl<
             let binary = self.binary.take().unwrap();
             let cred = self.credentials.take().unwrap();
             let check_result = if result.unwrap_or(false) {
-                Ok(CheckResult::Accept)
+                Ok(CheckResult::Accept(None))
             } else {
                 Ok(CheckResult::Pass)
             };

--- a/doc/reference/trd-appid.md
+++ b/doc/reference/trd-appid.md
@@ -549,7 +549,7 @@ which credentials, are acceptable and which are rejected.
 
 ```rust
 pub enum CheckResult {
-    Accept,
+    Accept(Option<core::num::NonZeroUsize>),
     Pass,
     Reject
 }
@@ -581,6 +581,13 @@ each `TbfFooterV2Credentials` footer it encounters, the kernel calls
 `check_credentials` on the provided `AppCredentialsPolicy`. If
 `check_credentials` returns `CheckResult::Accept`, the kernel stops processing
 credentials and stores the process binary in the process binaries array.
+When an `AppCredentialsPolicy` accepts a credential it may include an opaque
+nonzero `usize` value. This will be stored along with the accepted credential
+and allows the `AppCredentialsPolicy` to share information about the accepted
+credential. For example, if `AppCredentialsPolicy` is checking signatures, the
+opaque value may communicate the owner of the private key that validated the
+signature. This information may be useful when assigning `ShortId`s.
+
 If the
 `AppCredentialsPolicy` returns `CheckResult::Reject`, the kernel stops processing
 credentials and does not load the process binary.

--- a/doc/reference/trd-appid.md
+++ b/doc/reference/trd-appid.md
@@ -549,7 +549,7 @@ which credentials, are acceptable and which are rejected.
 
 ```rust
 pub enum CheckResult {
-    Accept(Option<core::num::NonZeroUsize>),
+    Accept(Option<usize>),
     Pass,
     Reject
 }
@@ -582,7 +582,7 @@ each `TbfFooterV2Credentials` footer it encounters, the kernel calls
 `check_credentials` returns `CheckResult::Accept`, the kernel stops processing
 credentials and stores the process binary in the process binaries array.
 When an `AppCredentialsPolicy` accepts a credential it may include an opaque
-nonzero `usize` value. This will be stored along with the accepted credential
+`usize` value. This will be stored along with the accepted credential
 and allows the `AppCredentialsPolicy` to share information about the accepted
 credential. For example, if `AppCredentialsPolicy` is checking signatures, the
 opaque value may communicate the owner of the private key that validated the

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -20,10 +20,10 @@ use crate::storage_permissions;
 use crate::syscall::{self, Syscall, SyscallReturn};
 use crate::upcall::UpcallId;
 use tock_tbf::types::CommandPermissions;
-use tock_tbf::types::TbfFooterV2Credentials;
 
 // Export all process related types via `kernel::process::`.
 pub use crate::process_binary::ProcessBinary;
+pub use crate::process_checker::AcceptedCredential;
 pub use crate::process_checker::{ProcessCheckerMachine, ProcessCheckerMachineClient};
 pub use crate::process_loading::load_processes;
 pub use crate::process_loading::ProcessLoadError;
@@ -340,7 +340,7 @@ pub trait Process {
     /// Return the credential which the credential checker approved if the
     /// credential checker approved a credential. If the process was allowed to
     /// run without credentials, return `None`.
-    fn get_credential(&self) -> Option<(TbfFooterV2Credentials, Option<core::num::NonZeroUsize>)>;
+    fn get_credential(&self) -> Option<AcceptedCredential>;
 
     /// Returns how many times this process has been restarted.
     fn get_restart_count(&self) -> usize;

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -340,7 +340,7 @@ pub trait Process {
     /// Return the credential which the credential checker approved if the
     /// credential checker approved a credential. If the process was allowed to
     /// run without credentials, return `None`.
-    fn get_credential(&self) -> Option<TbfFooterV2Credentials>;
+    fn get_credential(&self) -> Option<(TbfFooterV2Credentials, Option<core::num::NonZeroUsize>)>;
 
     /// Returns how many times this process has been restarted.
     fn get_restart_count(&self) -> usize;

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -20,6 +20,7 @@ use crate::storage_permissions;
 use crate::syscall::{self, Syscall, SyscallReturn};
 use crate::upcall::UpcallId;
 use tock_tbf::types::CommandPermissions;
+use tock_tbf::types::TbfFooterV2Credentials;
 
 // Export all process related types via `kernel::process::`.
 pub use crate::process_binary::ProcessBinary;
@@ -335,6 +336,11 @@ pub trait Process {
     /// Returns the version number of the binary in this process, as specified
     /// in a TBF Program Header; if the binary has no version assigned, return [None]
     fn binary_version(&self) -> Option<BinaryVersion>;
+
+    /// Return the credential which the credential checker approved if the
+    /// credential checker approved a credential. If the process was allowed to
+    /// run without credentials, return `None`.
+    fn get_credential(&self) -> Option<TbfFooterV2Credentials>;
 
     /// Returns how many times this process has been restarted.
     fn get_restart_count(&self) -> usize;

--- a/kernel/src/process_binary.rs
+++ b/kernel/src/process_binary.rs
@@ -11,8 +11,8 @@ use core::fmt;
 
 use crate::config;
 use crate::debug;
+use crate::process_checker::AcceptedCredential;
 use crate::utilities::cells::OptionalCell;
-use tock_tbf::types::TbfFooterV2Credentials;
 
 /// Errors resulting from trying to load a process binary structure from flash.
 pub enum ProcessBinaryError {
@@ -129,7 +129,7 @@ pub struct ProcessBinary {
     /// Optional credential that was used to approve this application. This is
     /// set if the process is checked by a credential checker and a specific
     /// credential was used to approve this process. Otherwise this is `None`.
-    pub credential: OptionalCell<(TbfFooterV2Credentials, Option<core::num::NonZeroUsize>)>,
+    pub credential: OptionalCell<AcceptedCredential>,
 }
 
 impl ProcessBinary {
@@ -249,9 +249,7 @@ impl ProcessBinary {
         })
     }
 
-    pub fn get_credential(
-        &self,
-    ) -> Option<(TbfFooterV2Credentials, Option<core::num::NonZeroUsize>)> {
+    pub fn get_credential(&self) -> Option<AcceptedCredential> {
         self.credential.get()
     }
 

--- a/kernel/src/process_binary.rs
+++ b/kernel/src/process_binary.rs
@@ -129,7 +129,7 @@ pub struct ProcessBinary {
     /// Optional credential that was used to approve this application. This is
     /// set if the process is checked by a credential checker and a specific
     /// credential was used to approve this process. Otherwise this is `None`.
-    pub credential: OptionalCell<TbfFooterV2Credentials>,
+    pub credential: OptionalCell<(TbfFooterV2Credentials, Option<core::num::NonZeroUsize>)>,
 }
 
 impl ProcessBinary {
@@ -249,7 +249,9 @@ impl ProcessBinary {
         })
     }
 
-    pub fn get_credential(&self) -> Option<TbfFooterV2Credentials> {
+    pub fn get_credential(
+        &self,
+    ) -> Option<(TbfFooterV2Credentials, Option<core::num::NonZeroUsize>)> {
         self.credential.get()
     }
 

--- a/kernel/src/process_binary.rs
+++ b/kernel/src/process_binary.rs
@@ -11,6 +11,8 @@ use core::fmt;
 
 use crate::config;
 use crate::debug;
+use crate::utilities::cells::OptionalCell;
+use tock_tbf::types::TbfFooterV2Credentials;
 
 /// Errors resulting from trying to load a process binary structure from flash.
 pub enum ProcessBinaryError {
@@ -123,6 +125,11 @@ pub struct ProcessBinary {
 
     /// Collection of pointers to the TBF header in flash.
     pub header: tock_tbf::types::TbfHeader,
+
+    /// Optional credential that was used to approve this application. This is
+    /// set if the process is checked by a credential checker and a specific
+    /// credential was used to approve this process. Otherwise this is `None`.
+    pub credential: OptionalCell<TbfFooterV2Credentials>,
 }
 
 impl ProcessBinary {
@@ -238,6 +245,7 @@ impl ProcessBinary {
             header: tbf_header,
             footers: footer_region,
             flash: app_flash,
+            credential: OptionalCell::empty(),
         })
     }
 

--- a/kernel/src/process_binary.rs
+++ b/kernel/src/process_binary.rs
@@ -249,6 +249,10 @@ impl ProcessBinary {
         })
     }
 
+    pub fn get_credential(&self) -> Option<TbfFooterV2Credentials> {
+        self.credential.get()
+    }
+
     pub(crate) fn get_integrity_region_slice(&self) -> &'static [u8] {
         unsafe {
             core::slice::from_raw_parts(self.flash.as_ptr(), self.header.get_binary_end() as usize)

--- a/kernel/src/process_checker.rs
+++ b/kernel/src/process_checker.rs
@@ -60,7 +60,7 @@ impl fmt::Debug for ProcessCheckError {
 pub enum CheckResult {
     /// Accept the credential and run the binary.
     ///
-    /// The associated value is an optional opaque nonzero usize the credential
+    /// The associated value is an optional opaque usize the credential
     /// checker can return to communication some information about the accepted
     /// credential.
     Accept(Option<CheckResultAcceptMetadata>),

--- a/kernel/src/process_checker.rs
+++ b/kernel/src/process_checker.rs
@@ -63,12 +63,27 @@ pub enum CheckResult {
     /// The associated value is an optional opaque nonzero usize the credential
     /// checker can return to communication some information about the accepted
     /// credential.
-    Accept(Option<core::num::NonZeroUsize>),
+    Accept(Option<CheckResultAcceptMetadata>),
     /// Go to the next credential or in the case of the last one fall
     /// back to the default policy.
     Pass,
     /// Reject the credential and do not run the binary.
     Reject,
+}
+
+/// Optional metadata the credential checker can attach to an accepted
+/// credential.
+///
+/// This metadata can be used to provide context for why or how the accepted
+/// credential was accepted. For example, this could be set to the index of a
+/// public key that was used to verify a cryptographic signature. This value can
+/// then be used by the AppId assigner to assign the correct AppId and
+/// [`ShortId`].
+#[derive(Debug, Copy, Clone)]
+pub struct CheckResultAcceptMetadata {
+    /// The metadata stored with the accepted credential is a usize that has an
+    /// application-specific meaning.
+    pub metadata: usize,
 }
 
 /// Receives callbacks on whether a credential was accepted or not.
@@ -99,7 +114,7 @@ pub struct AcceptedCredential {
     pub credential: TbfFooterV2Credentials,
     /// An optional opaque value set by the credential checker to store metadata
     /// about the accepted credential. This is credential checker specific.
-    pub metadata: Option<core::num::NonZeroUsize>,
+    pub metadata: Option<CheckResultAcceptMetadata>,
 }
 
 /// Implements a Credentials Checking Policy.

--- a/kernel/src/process_checker.rs
+++ b/kernel/src/process_checker.rs
@@ -154,6 +154,10 @@ impl AppUniqueness for () {
 /// Transforms Application Credentials into a corresponding ShortId.
 pub trait Compress {
     /// Create a `ShortId` for `process`.
+    ///
+    /// If the process was approved to run because of a specific credential, the
+    /// `ProcessBinary will have its `credential` filed set to `Some()` with
+    /// that credential.
     fn to_short_id(&self, process: &ProcessBinary) -> ShortId;
 }
 

--- a/kernel/src/process_loading.rs
+++ b/kernel/src/process_loading.rs
@@ -23,11 +23,11 @@ use crate::kernel::Kernel;
 use crate::platform::chip::Chip;
 use crate::process::{Process, ShortId};
 use crate::process_binary::{ProcessBinary, ProcessBinaryError};
+use crate::process_checker::AcceptedCredential;
 use crate::process_checker::{AppIdPolicy, ProcessCheckError, ProcessCheckerMachine};
 use crate::process_policies::ProcessFaultPolicy;
 use crate::process_standard::ProcessStandard;
 use crate::utilities::cells::{MapCell, OptionalCell};
-use tock_tbf::types::TbfFooterV2Credentials;
 
 /// Errors that can occur when trying to load and create processes.
 pub enum ProcessLoadError {
@@ -906,10 +906,7 @@ impl<'a, C: Chip> crate::process_checker::ProcessCheckerMachineClient
     fn done(
         &self,
         process_binary: ProcessBinary,
-        result: Result<
-            Option<(TbfFooterV2Credentials, Option<core::num::NonZeroUsize>)>,
-            crate::process_checker::ProcessCheckError,
-        >,
+        result: Result<Option<AcceptedCredential>, crate::process_checker::ProcessCheckError>,
     ) {
         // Check if this process was approved by the checker.
         match result {

--- a/kernel/src/process_loading.rs
+++ b/kernel/src/process_loading.rs
@@ -906,7 +906,10 @@ impl<'a, C: Chip> crate::process_checker::ProcessCheckerMachineClient
     fn done(
         &self,
         process_binary: ProcessBinary,
-        result: Result<Option<TbfFooterV2Credentials>, crate::process_checker::ProcessCheckError>,
+        result: Result<
+            Option<(TbfFooterV2Credentials, Option<core::num::NonZeroUsize>)>,
+            crate::process_checker::ProcessCheckError,
+        >,
     ) {
         // Check if this process was approved by the checker.
         match result {

--- a/kernel/src/process_loading.rs
+++ b/kernel/src/process_loading.rs
@@ -27,6 +27,7 @@ use crate::process_checker::{AppIdPolicy, ProcessCheckError, ProcessCheckerMachi
 use crate::process_policies::ProcessFaultPolicy;
 use crate::process_standard::ProcessStandard;
 use crate::utilities::cells::{MapCell, OptionalCell};
+use tock_tbf::types::TbfFooterV2Credentials;
 
 /// Errors that can occur when trying to load and create processes.
 pub enum ProcessLoadError {
@@ -905,11 +906,11 @@ impl<'a, C: Chip> crate::process_checker::ProcessCheckerMachineClient
     fn done(
         &self,
         process_binary: ProcessBinary,
-        result: Result<(), crate::process_checker::ProcessCheckError>,
+        result: Result<Option<TbfFooterV2Credentials>, crate::process_checker::ProcessCheckError>,
     ) {
         // Check if this process was approved by the checker.
         match result {
-            Ok(()) => {
+            Ok(optional_credential) => {
                 if config::CONFIG.debug_load_processes {
                     debug!(
                         "Loading: Check succeeded for process {}",

--- a/kernel/src/process_loading.rs
+++ b/kernel/src/process_loading.rs
@@ -921,6 +921,7 @@ impl<'a, C: Chip> crate::process_checker::ProcessCheckerMachineClient
                 match self.find_open_process_binary_slot() {
                     Some(index) => {
                         self.proc_binaries.map(|proc_binaries| {
+                            process_binary.credential.insert(optional_credential);
                             proc_binaries[index] = Some(process_binary);
                         });
                     }

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -37,6 +37,7 @@ use crate::upcall::UpcallId;
 use crate::utilities::cells::{MapCell, NumericCellExt, OptionalCell};
 
 use tock_tbf::types::CommandPermissions;
+use tock_tbf::types::TbfFooterV2Credentials;
 
 /// State for helping with debugging apps.
 ///
@@ -186,6 +187,10 @@ pub struct ProcessStandard<'a, C: 'static + Chip> {
     /// Collection of pointers to the TBF header in flash.
     header: tock_tbf::types::TbfHeader,
 
+    /// Credential that was approved for this process, or `None` if the
+    /// credential was permitted to run without an accepted credential.
+    credential: Option<TbfFooterV2Credentials>,
+
     /// State saved on behalf of the process each time the app switches to the
     /// kernel.
     stored_state:
@@ -252,6 +257,10 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
             Some(version_nonzero) => Some(BinaryVersion::new(version_nonzero)),
             None => None,
         }
+    }
+
+    fn get_credential(&self) -> Option<TbfFooterV2Credentials> {
+        self.credential
     }
 
     fn enqueue_task(&self, task: Task) -> Result<(), ErrorCode> {
@@ -1671,6 +1680,7 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
         process.app_break = Cell::new(initial_app_brk);
         process.grant_pointers = MapCell::new(grant_pointers);
 
+        process.credential = pb.credential.get();
         process.footers = pb.footers;
         process.flash = pb.flash;
 

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -189,7 +189,7 @@ pub struct ProcessStandard<'a, C: 'static + Chip> {
 
     /// Credential that was approved for this process, or `None` if the
     /// credential was permitted to run without an accepted credential.
-    credential: Option<TbfFooterV2Credentials>,
+    credential: Option<(TbfFooterV2Credentials, Option<core::num::NonZeroUsize>)>,
 
     /// State saved on behalf of the process each time the app switches to the
     /// kernel.
@@ -259,7 +259,7 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
         }
     }
 
-    fn get_credential(&self) -> Option<TbfFooterV2Credentials> {
+    fn get_credential(&self) -> Option<(TbfFooterV2Credentials, Option<core::num::NonZeroUsize>)> {
         self.credential
     }
 

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -28,6 +28,7 @@ use crate::process::{Error, FunctionCall, FunctionCallSource, Process, Task};
 use crate::process::{FaultAction, ProcessCustomGrantIdentifier, ProcessId};
 use crate::process::{ProcessAddresses, ProcessSizes, ShortId};
 use crate::process::{State, StoppedState};
+use crate::process_checker::AcceptedCredential;
 use crate::process_loading::ProcessLoadError;
 use crate::process_policies::ProcessFaultPolicy;
 use crate::processbuffer::{ReadOnlyProcessBuffer, ReadWriteProcessBuffer};
@@ -37,7 +38,6 @@ use crate::upcall::UpcallId;
 use crate::utilities::cells::{MapCell, NumericCellExt, OptionalCell};
 
 use tock_tbf::types::CommandPermissions;
-use tock_tbf::types::TbfFooterV2Credentials;
 
 /// State for helping with debugging apps.
 ///
@@ -189,7 +189,7 @@ pub struct ProcessStandard<'a, C: 'static + Chip> {
 
     /// Credential that was approved for this process, or `None` if the
     /// credential was permitted to run without an accepted credential.
-    credential: Option<(TbfFooterV2Credentials, Option<core::num::NonZeroUsize>)>,
+    credential: Option<AcceptedCredential>,
 
     /// State saved on behalf of the process each time the app switches to the
     /// kernel.
@@ -259,7 +259,7 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
         }
     }
 
-    fn get_credential(&self) -> Option<(TbfFooterV2Credentials, Option<core::num::NonZeroUsize>)> {
+    fn get_credential(&self) -> Option<AcceptedCredential> {
         self.credential
     }
 


### PR DESCRIPTION
### Pull Request Overview

This PR enables two features for AppID:

1. Allows an AppID assignment policy to use the accepted credential when assigning IDs. This is important if the AppId is the public key used to verify a signature, for example. (This functionality used to exist and I removed it previously because of how process loading changed. Turns out we still need it.)
2. Helps developers use the accepted credential correctly when assigning an AppID. There are two issues/pitfalls that can arise when trying to use an accepted credential to assign an AppID.
    1. The checker, while verifying the credential, has some state about the verification process that is necessary for assigning the AppID. Some examples:
        - The checker maintains a list of valid public keys that can verify signatures. The checker knows which public key was used to verify the signature.
        - The checker knows if the app was signed by the kernel developer or a third party (or both).
        - The checker has multiple public keys per organization, and knows which one signed the app.
    2. TBF footers are not checked for integrity, and developers must not store any values in the footer that cannot be verified by the checker. Very little can be verified by the checker. If a public key is in the credential, the checker can validate that that public key matches the signature. But any other data cannot be verified and could be modified before the app is loaded on a board.
    
    To help with these issues, this PR also includes a `usize` that the checker can store with the accepted credential to provide information about the accepted credential that the AppID assignment policy can use.

    For issue 1: this would allow the process checker to keep track of some metadata about why it accepted the credential. For example it might store the index of the public key that verified the signature. Or it might store the upper 16 bits of the ShortId for the organization that signed the app. The value is opaque, and different policies/implementations can use it differently. The `Compress` trait (ie assigning ShortId) is not asynchronous. So from a software engineering viewpoint, whatever state the AppId assignment policy needs must be fetched in advance, and the policy can not re-run any verification steps. Therefore, the checker needs some way to communicate with the AppId assigner if the assigner is going to use any outcome of the verification process in its AppId assignment.

    For issue 2: this gives developers some way to attach state to an accepted credential without including that state in the credential itself. This isn't providing a correctness guarantee, but it is providing an alternative to what seems intuitively valid: just include it in the credential. Otherwise, developers that want to use different credentials to assign different AppIds can't (or have to build some sort of workaround). 

#### PART 1

First 4 commits.

As part of the refactor in #3849, I removed the ability to retrieve the accepted credential when comparing AppIds and setting ShortIds. This was a byproduct of not actually creating a full-fledged `ProcessStandard` object before performing those operations. We no longer needed to mark the process as having valid credentials.

Unfortunately, that change made it impossible to 1) assign ShortIds based on the accepted credential, 2) define an AppId based on an accepted credential, and 3) assign fixed ShortIds to credentialed processes and locally unique ShortIds to non-credentialed processes.

This PR restores that functionality.

#### PART 2

While thinking through if supporting `get_credential()` is even a good idea, I'm concerned it has a potential issue. The issue is: credentials are stored outside of the integrity region, so using them to make any decisions about an application must be done _very carefully_. While I think ultimately we do want the API to expose credentials to the appid assigner (and other modules), some care is required.

For example, say I want to assign ShortIds based on which company signed an app. The credential checker can validate the signature and decide whether to accept the signature or not. But then it is up to the appid assigner to actually create a ShortId. How does the AppId assigner know which company created the approved signature, and therefore which ShortId to assign? Right now I think there are two ways:

1. The credential itself includes some company identifier. When the assigner assigns the ShortId it checks the company listed in the credential and uses that to determine the correct ShortId.
4. The checker stores some state (somehow) that maps the signature to a company (for each application).

I don't think 2 is realistic. That would be _possible_, but would be a lot of overhead for a conceptually simple operation.

Option 1 does work, but has two drawbacks. First is the potential issue I mentioned about. The system must be very careful to not trust what is in the credential (ie in the TBF footer). For example, an attacker could use one company's signature for an app but change the metadata about which company signed it. The credential checker must check for this and reject the credential, but this would be easy to miss. The second issue is it requires some sort of registry at signing time that all signers agree to use to identify themselves. 

Given these two options and their drawbacks, the second half of this PR allows a credential checker to return an opaque usize with any accepted credential. This usize can then convey information between the credential checker and the app id assigner on an application-by-application basis. This would simplify allowing the kernel to maintain some sort of key library where the accepted signature is matched to a pub/pri key pair and identified by some value. Or even the usize could be used to communication the intended ShortId directly.


### Testing Strategy
Only compile tested, but the code is pretty straightforward.


### TODO or Help Wanted

1. I'm not _in love_ with this implementation for part 1. It turns out to be _very_ easy to implement this by adding an `OptionalCell` to `ProcessBinary` which holds the credential if one was accepted. In practice, everywhere the credential is needed (ie creating a shortid, creating a ProcessStandard, etc.) we are already passing a `ProcessBinary`. But, does a `ProcessBinary` logically have an optional approved credential? Maybe? `ProcessBinary` was really intended to represent static state stored in flash.

    Separating the two is certainly possible, but it adds a bunch of boilerplate code (ie creating a new type that holds both a `ProcessBinary` and an `Option<Credential>`, and passing that around instead) to get to virtually the same exact place. Is that worth it? I'm not convinced. I don't think the current implementation is _wrong_, and it saves a bit of extra overhead in terms of code maintenance.

    Status: this implementation might be ok.

4. Change the optionalcell in process binary to contain a struct.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
