### PR TITLE
boards/apoloo3: Update the flash layout

### DIFF
--- a/boards/apollo3/lora_things_plus/Makefile
+++ b/boards/apollo3/lora_things_plus/Makefile
@@ -19,15 +19,30 @@ install: flash
 
 .PHONY: flash
 flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
-	python ../ambiq/ambiq_bin2board.py --bin $< --load-address-blob 0x40000 -b 115200 -port $(PORT) -r 2 -v --magic-num 0xCB --version 0x0 --load-address-wired 0xc000 -i 6 --options 0x1
+	python ../ambiq/ambiq_bin2board.py --bin $< \
+		--load-address-blob 0xE000 \
+		-b 115200 -port $(PORT) -r 2 -v \
+		--magic-num 0xCB --version 0x0 \
+		--load-address-wired 0xC000 \
+		-i 6 --options 0x1
 
 .PHONY: flash-debug
 flash-debug: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).bin
-	python ../ambiq/ambiq_bin2board.py --bin $< --load-address-blob 0x40000 -b 115200 -port $(PORT) -r 2 -v --magic-num 0xCB --version 0x0 --load-address-wired 0xc000 -i 6 --options 0x1
+	python ../ambiq/ambiq_bin2board.py --bin $< \
+		--load-address-blob 0xE000 \
+		-b 115200 -port $(PORT) -r 2 -v \
+		--magic-num 0xCB --version 0x0 \
+		--load-address-wired 0xC000 \
+		-i 6 --options 0x1
 
 .PHONY: flash-app
 flash-app:
-	python ../ambiq/ambiq_bin2board.py --bin $(APP) --load-address-blob 0x60000 -b 115200 -port $(PORT) -r 2 -v --magic-num 0xCB --version 0x0 --load-address-wired 0x40000 -i 6 --options 0x1
+	python ../ambiq/ambiq_bin2board.py --bin $(APP) \
+		--load-address-blob 0x42000 \
+		-b 115200 -port $(PORT) -r 2 -v \
+		--magic-num 0xCB --version 0x0 \
+		--load-address-wired 0x40000 \
+		-i 6 --options 0x1
 
 .PHONY: test
 test:

--- a/boards/apollo3/lora_things_plus/layout.ld
+++ b/boards/apollo3/lora_things_plus/layout.ld
@@ -2,10 +2,14 @@
 /* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
 /* Copyright Tock Contributors 2023.                                  */
 
+/* We have to reduce all flash lengths by 0x2000 as that is the offset
+ * we use when writing data to flash with ambiq_bin2board.py.
+ */
+
 MEMORY
 {
-  rom (rx)  : ORIGIN = 0x0000C000, LENGTH = 0x00030000
-  prog (rx) : ORIGIN = 0x00040000, LENGTH = 0x08000000 - 0x00030000
+  rom (rx)  : ORIGIN = 0x0000C000, LENGTH = 0x034000 - 0x2000
+  prog (rx) : ORIGIN = 0x00040000, LENGTH = 0x100000 - 0x040000 - 0x2000
   ram (rwx) : ORIGIN = 0x10000000, LENGTH = 0x60000
 }
 

--- a/boards/apollo3/redboard_artemis_atp/Makefile
+++ b/boards/apollo3/redboard_artemis_atp/Makefile
@@ -19,15 +19,30 @@ install: flash
 
 .PHONY: flash
 flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
-	python ../ambiq/ambiq_bin2board.py --bin $< --load-address-blob 0x40000 -b 115200 -port $(PORT) -r 2 -v --magic-num 0xCB --version 0x0 --load-address-wired 0xc000 -i 6 --options 0x1
+	python ../ambiq/ambiq_bin2board.py --bin $< \
+		--load-address-blob 0xE000 \
+		-b 115200 -port $(PORT) -r 2 -v \
+		--magic-num 0xCB --version 0x0 \
+		--load-address-wired 0xC000 \
+		-i 6 --options 0x1
 
 .PHONY: flash-debug
 flash-debug: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).bin
-	python ../ambiq/ambiq_bin2board.py --bin $< --load-address-blob 0x40000 -b 115200 -port $(PORT) -r 2 -v --magic-num 0xCB --version 0x0 --load-address-wired 0xc000 -i 6 --options 0x1
+	python ../ambiq/ambiq_bin2board.py --bin $< \
+		--load-address-blob 0xE000 \
+		-b 115200 -port $(PORT) -r 2 -v \
+		--magic-num 0xCB --version 0x0 \
+		--load-address-wired 0xC000 \
+		-i 6 --options 0x1
 
 .PHONY: flash-app
 flash-app:
-	python ../ambiq/ambiq_bin2board.py --bin $(APP) --load-address-blob 0x60000 -b 115200 -port $(PORT) -r 2 -v --magic-num 0xCB --version 0x0 --load-address-wired 0x40000 -i 6 --options 0x1
+	python ../ambiq/ambiq_bin2board.py --bin $(APP) \
+		--load-address-blob 0x42000 \
+		-b 115200 -port $(PORT) -r 2 -v \
+		--magic-num 0xCB --version 0x0 \
+		--load-address-wired 0x40000 \
+		-i 6 --options 0x1
 
 .PHONY: test
 test:

--- a/boards/apollo3/redboard_artemis_atp/layout.ld
+++ b/boards/apollo3/redboard_artemis_atp/layout.ld
@@ -2,10 +2,14 @@
 /* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
 /* Copyright Tock Contributors 2023.                                  */
 
+/* We have to reduce all flash lengths by 0x2000 as that is the offset
+ * we use when writing data to flash with ambiq_bin2board.py.
+ */
+
 MEMORY
 {
-  rom (rx)  : ORIGIN = 0x0000C000, LENGTH = 0x00030000
-  prog (rx) : ORIGIN = 0x00040000, LENGTH = 0x08000000 - 0x00030000
+  rom (rx)  : ORIGIN = 0x0000C000, LENGTH = 0x034000 - 0x2000
+  prog (rx) : ORIGIN = 0x00040000, LENGTH = 0x100000 - 0x040000 - 0x2000
   ram (rwx) : ORIGIN = 0x10000000, LENGTH = 0x60000
 }
 

--- a/boards/apollo3/redboard_artemis_nano/Makefile
+++ b/boards/apollo3/redboard_artemis_nano/Makefile
@@ -19,15 +19,30 @@ install: flash
 
 .PHONY: flash
 flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
-	python ../ambiq/ambiq_bin2board.py --bin $< --load-address-blob 0x40000 -b 115200 -port $(PORT) -r 2 -v --magic-num 0xCB --version 0x0 --load-address-wired 0xc000 -i 6 --options 0x1
+	python ../ambiq/ambiq_bin2board.py --bin $< \
+		--load-address-blob 0xE000 \
+		-b 115200 -port $(PORT) -r 2 -v \
+		--magic-num 0xCB --version 0x0 \
+		--load-address-wired 0xC000 \
+		-i 6 --options 0x1
 
 .PHONY: flash-debug
 flash-debug: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).bin
-	python ../ambiq/ambiq_bin2board.py --bin $< --load-address-blob 0x40000 -b 115200 -port $(PORT) -r 2 -v --magic-num 0xCB --version 0x0 --load-address-wired 0xc000 -i 6 --options 0x1
+	python ../ambiq/ambiq_bin2board.py --bin $< \
+		--load-address-blob 0xE000 \
+		-b 115200 -port $(PORT) -r 2 -v \
+		--magic-num 0xCB --version 0x0 \
+		--load-address-wired 0xC000 \
+		-i 6 --options 0x1
 
 .PHONY: flash-app
 flash-app:
-	python ../ambiq/ambiq_bin2board.py --bin $(APP) --load-address-blob 0x60000 -b 115200 -port $(PORT) -r 2 -v --magic-num 0xCB --version 0x0 --load-address-wired 0x40000 -i 6 --options 0x1
+	python ../ambiq/ambiq_bin2board.py --bin $(APP) \
+		--load-address-blob 0x42000 \
+		-b 115200 -port $(PORT) -r 2 -v \
+		--magic-num 0xCB --version 0x0 \
+		--load-address-wired 0x40000 \
+		-i 6 --options 0x1
 
 .PHONY: test
 test:

--- a/boards/apollo3/redboard_artemis_nano/layout.ld
+++ b/boards/apollo3/redboard_artemis_nano/layout.ld
@@ -2,10 +2,14 @@
 /* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
 /* Copyright Tock Contributors 2023.                                  */
 
+/* We have to reduce all flash lengths by 0x2000 as that is the offset
+ * we use when writing data to flash with ambiq_bin2board.py.
+ */
+
 MEMORY
 {
-  rom (rx)  : ORIGIN = 0x0000C000, LENGTH = 0x00030000
-  prog (rx) : ORIGIN = 0x00040000, LENGTH = 0x08000000 - 0x00030000
+  rom (rx)  : ORIGIN = 0x0000C000, LENGTH = 0x034000 - 0x2000
+  prog (rx) : ORIGIN = 0x00040000, LENGTH = 0x100000 - 0x040000 - 0x2000
   ram (rwx) : ORIGIN = 0x10000000, LENGTH = 0x60000
 }
 


### PR DESCRIPTION
### Pull Request Overview

Update the flash layout for the kernel and userspace and the application loading scripts to squeeze a little more flash space for storing applications.

### Testing Strategy

https://github.com/tock/libtock-rs/pull/549 and running Slint

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
