### PR TITLE
Storage Permissions: Implement to match TRD

### DIFF
--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -83,6 +83,7 @@ pub mod sound_pressure;
 pub mod spi;
 pub mod ssd1306;
 pub mod st77xx;
+pub mod storage_permissions;
 pub mod temperature;
 pub mod temperature_rp2040;
 pub mod temperature_stm;

--- a/boards/components/src/loader/sequential.rs
+++ b/boards/components/src/loader/sequential.rs
@@ -38,6 +38,7 @@ pub struct ProcessLoaderSequentialComponent<C: Chip + 'static, const NUM_PROCS: 
     chip: &'static C,
     fault_policy: &'static dyn kernel::process::ProcessFaultPolicy,
     appid_policy: &'static dyn kernel::process_checker::AppIdPolicy,
+    storage_policy: &'static dyn kernel::process::ProcessStandardStoragePermissionsPolicy<C>,
 }
 
 impl<C: Chip, const NUM_PROCS: usize> ProcessLoaderSequentialComponent<C, NUM_PROCS> {
@@ -48,6 +49,7 @@ impl<C: Chip, const NUM_PROCS: usize> ProcessLoaderSequentialComponent<C, NUM_PR
         chip: &'static C,
         fault_policy: &'static dyn kernel::process::ProcessFaultPolicy,
         appid_policy: &'static dyn kernel::process_checker::AppIdPolicy,
+        storage_policy: &'static dyn kernel::process::ProcessStandardStoragePermissionsPolicy<C>,
     ) -> Self {
         Self {
             checker,
@@ -56,6 +58,7 @@ impl<C: Chip, const NUM_PROCS: usize> ProcessLoaderSequentialComponent<C, NUM_PR
             chip,
             fault_policy,
             appid_policy,
+            storage_policy,
         }
     }
 }
@@ -103,6 +106,7 @@ impl<C: Chip, const NUM_PROCS: usize> Component for ProcessLoaderSequentialCompo
                     core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
                 ),
                 self.fault_policy,
+                self.storage_policy,
                 self.appid_policy,
                 &proc_manage_cap,
             ))

--- a/boards/components/src/storage_permissions/individual.rs
+++ b/boards/components/src/storage_permissions/individual.rs
@@ -14,6 +14,7 @@
 //! ```
 
 use core::mem::MaybeUninit;
+use kernel::capabilities;
 use kernel::component::Component;
 use kernel::platform::chip::Chip;
 
@@ -21,13 +22,22 @@ use kernel::platform::chip::Chip;
 macro_rules! storage_permissions_individual_component_static {
     ($C:ty $(,)?) => {{
         kernel::static_buf!(
-            capsules_system::storage_permissions::individual::IndividualStoragePermissions<$C>
+            capsules_system::storage_permissions::individual::IndividualStoragePermissions<
+                $C,
+                components::storage_permissions::individual::AppStoreCapability
+            >
         )
     };};
 }
 
+pub struct AppStoreCapability;
+unsafe impl capabilities::ApplicationStorageCapability for AppStoreCapability {}
+
 pub type StoragePermissionsIndividualComponentType<C> =
-    capsules_system::storage_permissions::individual::IndividualStoragePermissions<C>;
+    capsules_system::storage_permissions::individual::IndividualStoragePermissions<
+        C,
+        AppStoreCapability,
+    >;
 
 pub struct StoragePermissionsIndividualComponent<C: Chip> {
     _chip: core::marker::PhantomData<C>,
@@ -43,14 +53,22 @@ impl<C: Chip> StoragePermissionsIndividualComponent<C> {
 
 impl<C: Chip + 'static> Component for StoragePermissionsIndividualComponent<C> {
     type StaticInput = &'static mut MaybeUninit<
-        capsules_system::storage_permissions::individual::IndividualStoragePermissions<C>,
+        capsules_system::storage_permissions::individual::IndividualStoragePermissions<
+            C,
+            AppStoreCapability,
+        >,
     >;
     type Output =
-        &'static capsules_system::storage_permissions::individual::IndividualStoragePermissions<C>;
+        &'static capsules_system::storage_permissions::individual::IndividualStoragePermissions<
+            C,
+            AppStoreCapability,
+        >;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
         s.write(
-            capsules_system::storage_permissions::individual::IndividualStoragePermissions::new(),
+            capsules_system::storage_permissions::individual::IndividualStoragePermissions::new(
+                AppStoreCapability,
+            ),
         )
     }
 }

--- a/boards/components/src/storage_permissions/individual.rs
+++ b/boards/components/src/storage_permissions/individual.rs
@@ -1,0 +1,56 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2024.
+
+//! Component for creating a storage permissions policy that grants applications
+//! access to their own stored state.
+//!
+//! ```rust
+//! let storage_permissions_policy =
+//!     components::storage_permissions::individual::StoragePermissionsIndividualComponent::new()
+//!         .finalize(
+//!             components::storage_permissions_individual_component_static!(nrf52840dk_lib::Chip),
+//!         );
+//! ```
+
+use core::mem::MaybeUninit;
+use kernel::component::Component;
+use kernel::platform::chip::Chip;
+
+#[macro_export]
+macro_rules! storage_permissions_individual_component_static {
+    ($C:ty $(,)?) => {{
+        kernel::static_buf!(
+            capsules_system::storage_permissions::individual::IndividualStoragePermissions<$C>
+        )
+    };};
+}
+
+pub type StoragePermissionsIndividualComponentType<C> =
+    capsules_system::storage_permissions::individual::IndividualStoragePermissions<C>;
+
+pub struct StoragePermissionsIndividualComponent<C: Chip> {
+    _chip: core::marker::PhantomData<C>,
+}
+
+impl<C: Chip> StoragePermissionsIndividualComponent<C> {
+    pub fn new() -> Self {
+        Self {
+            _chip: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<C: Chip + 'static> Component for StoragePermissionsIndividualComponent<C> {
+    type StaticInput = &'static mut MaybeUninit<
+        capsules_system::storage_permissions::individual::IndividualStoragePermissions<C>,
+    >;
+    type Output =
+        &'static capsules_system::storage_permissions::individual::IndividualStoragePermissions<C>;
+
+    fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        s.write(
+            capsules_system::storage_permissions::individual::IndividualStoragePermissions::new(),
+        )
+    }
+}

--- a/boards/components/src/storage_permissions/mod.rs
+++ b/boards/components/src/storage_permissions/mod.rs
@@ -1,0 +1,7 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2024.
+
+pub mod individual;
+pub mod null;
+pub mod tbf_header;

--- a/boards/components/src/storage_permissions/null.rs
+++ b/boards/components/src/storage_permissions/null.rs
@@ -1,0 +1,43 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2024.
+
+//! Component for creating a storage permissions policy that provides no storage
+//! permissions.
+
+use core::mem::MaybeUninit;
+use kernel::component::Component;
+use kernel::platform::chip::Chip;
+
+#[macro_export]
+macro_rules! storage_permissions_null_component_static {
+    ($C:ty $(,)?) => {{
+        kernel::static_buf!(capsules_system::storage_permissions::null::NullStoragePermissions<$C>)
+    };};
+}
+
+pub type StoragePermissionsNullComponentType<C> =
+    capsules_system::storage_permissions::null::NullStoragePermissions<C>;
+
+pub struct StoragePermissionsNullComponent<C: Chip> {
+    _chip: core::marker::PhantomData<C>,
+}
+
+impl<C: Chip> StoragePermissionsNullComponent<C> {
+    pub fn new() -> Self {
+        Self {
+            _chip: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<C: Chip + 'static> Component for StoragePermissionsNullComponent<C> {
+    type StaticInput = &'static mut MaybeUninit<
+        capsules_system::storage_permissions::null::NullStoragePermissions<C>,
+    >;
+    type Output = &'static capsules_system::storage_permissions::null::NullStoragePermissions<C>;
+
+    fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        s.write(capsules_system::storage_permissions::null::NullStoragePermissions::new())
+    }
+}

--- a/boards/components/src/storage_permissions/tbf_header.rs
+++ b/boards/components/src/storage_permissions/tbf_header.rs
@@ -13,13 +13,22 @@ use kernel::platform::chip::Chip;
 macro_rules! storage_permissions_tbf_header_component_static {
     ($C:ty $(,)?) => {{
         kernel::static_buf!(
-            capsules_system::storage_permissions::tbf_header::TbfHeaderStoragePermissions<$C>
+            capsules_system::storage_permissions::tbf_header::TbfHeaderStoragePermissions<
+                $C,
+                components::storage_permissions::tbf_header::AppStoreCapability
+            >
         )
     };};
 }
 
+pub struct AppStoreCapability;
+unsafe impl kernel::capabilities::ApplicationStorageCapability for AppStoreCapability {}
+
 pub type StoragePermissionsTbfHeaderComponentType<C> =
-    capsules_system::storage_permissions::tbf_header::TbfHeaderStoragePermissions<C>;
+    capsules_system::storage_permissions::tbf_header::TbfHeaderStoragePermissions<
+        C,
+        AppStoreCapability,
+    >;
 
 pub struct StoragePermissionsTbfHeaderComponent<C: Chip> {
     _chip: core::marker::PhantomData<C>,
@@ -35,14 +44,22 @@ impl<C: Chip> StoragePermissionsTbfHeaderComponent<C> {
 
 impl<C: Chip + 'static> Component for StoragePermissionsTbfHeaderComponent<C> {
     type StaticInput = &'static mut MaybeUninit<
-        capsules_system::storage_permissions::tbf_header::TbfHeaderStoragePermissions<C>,
+        capsules_system::storage_permissions::tbf_header::TbfHeaderStoragePermissions<
+            C,
+            AppStoreCapability,
+        >,
     >;
     type Output =
-        &'static capsules_system::storage_permissions::tbf_header::TbfHeaderStoragePermissions<C>;
+        &'static capsules_system::storage_permissions::tbf_header::TbfHeaderStoragePermissions<
+            C,
+            AppStoreCapability,
+        >;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
         s.write(
-            capsules_system::storage_permissions::tbf_header::TbfHeaderStoragePermissions::new(),
+            capsules_system::storage_permissions::tbf_header::TbfHeaderStoragePermissions::new(
+                AppStoreCapability,
+            ),
         )
     }
 }

--- a/boards/components/src/storage_permissions/tbf_header.rs
+++ b/boards/components/src/storage_permissions/tbf_header.rs
@@ -1,0 +1,48 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2024.
+
+//! Component for creating a storage permissions policy that grants applications
+//! storage permissions based on TBF headers.
+
+use core::mem::MaybeUninit;
+use kernel::component::Component;
+use kernel::platform::chip::Chip;
+
+#[macro_export]
+macro_rules! storage_permissions_tbf_header_component_static {
+    ($C:ty $(,)?) => {{
+        kernel::static_buf!(
+            capsules_system::storage_permissions::tbf_header::TbfHeaderStoragePermissions<$C>
+        )
+    };};
+}
+
+pub type StoragePermissionsTbfHeaderComponentType<C> =
+    capsules_system::storage_permissions::tbf_header::TbfHeaderStoragePermissions<C>;
+
+pub struct StoragePermissionsTbfHeaderComponent<C: Chip> {
+    _chip: core::marker::PhantomData<C>,
+}
+
+impl<C: Chip> StoragePermissionsTbfHeaderComponent<C> {
+    pub fn new() -> Self {
+        Self {
+            _chip: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<C: Chip + 'static> Component for StoragePermissionsTbfHeaderComponent<C> {
+    type StaticInput = &'static mut MaybeUninit<
+        capsules_system::storage_permissions::tbf_header::TbfHeaderStoragePermissions<C>,
+    >;
+    type Output =
+        &'static capsules_system::storage_permissions::tbf_header::TbfHeaderStoragePermissions<C>;
+
+    fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        s.write(
+            capsules_system::storage_permissions::tbf_header::TbfHeaderStoragePermissions::new(),
+        )
+    }
+}

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-sha256/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-sha256/src/main.rs
@@ -271,6 +271,21 @@ pub unsafe fn main() {
     let checker = components::appid::checker::ProcessCheckerMachineComponent::new(checking_policy)
         .finalize(components::process_checker_machine_component_static!());
 
+    //--------------------------------------------------------------------------
+    // STORAGE PERMISSIONS
+    //--------------------------------------------------------------------------
+
+    let storage_permissions_policy =
+        components::storage_permissions::null::StoragePermissionsNullComponent::new().finalize(
+            components::storage_permissions_null_component_static!(
+                nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>
+            ),
+        );
+
+    //--------------------------------------------------------------------------
+    // PROCESS LOADING
+    //--------------------------------------------------------------------------
+
     // Create and start the asynchronous process loader.
     let _loader = components::loader::sequential::ProcessLoaderSequentialComponent::new(
         checker,
@@ -279,6 +294,7 @@ pub unsafe fn main() {
         chip,
         &FAULT_RESPONSE,
         assigner,
+        storage_permissions_policy,
     )
     .finalize(components::process_loader_sequential_component_static!(
         nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/main.rs
@@ -306,6 +306,21 @@ pub unsafe fn main() {
     let checker = components::appid::checker::ProcessCheckerMachineComponent::new(checking_policy)
         .finalize(components::process_checker_machine_component_static!());
 
+    //--------------------------------------------------------------------------
+    // STORAGE PERMISSIONS
+    //--------------------------------------------------------------------------
+
+    let storage_permissions_policy =
+        components::storage_permissions::null::StoragePermissionsNullComponent::new().finalize(
+            components::storage_permissions_null_component_static!(
+                nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>
+            ),
+        );
+
+    //--------------------------------------------------------------------------
+    // PROCESS LOADING
+    //--------------------------------------------------------------------------
+
     // Create and start the asynchronous process loader.
     let loader = components::loader::sequential::ProcessLoaderSequentialComponent::new(
         checker,
@@ -314,6 +329,7 @@ pub unsafe fn main() {
         chip,
         &FAULT_RESPONSE,
         assigner,
+        storage_permissions_policy,
     )
     .finalize(components::process_loader_sequential_component_static!(
         nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -715,6 +715,22 @@ pub unsafe fn main() {
     let checker = components::appid::checker::ProcessCheckerMachineComponent::new(checking_policy)
         .finalize(components::process_checker_machine_component_static!());
 
+    //--------------------------------------------------------------------------
+    // STORAGE PERMISSIONS
+    //--------------------------------------------------------------------------
+
+    let storage_permissions_policy =
+        components::storage_permissions::individual::StoragePermissionsIndividualComponent::new()
+            .finalize(
+                components::storage_permissions_individual_component_static!(
+                    sam4l::chip::Sam4l<Sam4lDefaultPeripherals>
+                ),
+            );
+
+    //--------------------------------------------------------------------------
+    // PROCESS LOADING
+    //--------------------------------------------------------------------------
+
     // Create and start the asynchronous process loader.
     let _loader = components::loader::sequential::ProcessLoaderSequentialComponent::new(
         checker,
@@ -723,6 +739,7 @@ pub unsafe fn main() {
         chip,
         &FAULT_RESPONSE,
         assigner,
+        storage_permissions_policy,
     )
     .finalize(components::process_loader_sequential_component_static!(
         sam4l::chip::Sam4l<Sam4lDefaultPeripherals>,

--- a/boards/makepython-nrf52840/src/main.rs
+++ b/boards/makepython-nrf52840/src/main.rs
@@ -651,6 +651,22 @@ pub unsafe fn start() -> (
     let checker = components::appid::checker::ProcessCheckerMachineComponent::new(checking_policy)
         .finalize(components::process_checker_machine_component_static!());
 
+    //--------------------------------------------------------------------------
+    // STORAGE PERMISSIONS
+    //--------------------------------------------------------------------------
+
+    let storage_permissions_policy =
+        components::storage_permissions::individual::StoragePermissionsIndividualComponent::new()
+            .finalize(
+                components::storage_permissions_individual_component_static!(
+                    nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>
+                ),
+            );
+
+    //--------------------------------------------------------------------------
+    // PROCESS LOADING
+    //--------------------------------------------------------------------------
+
     // Create and start the asynchronous process loader.
     let _loader = components::loader::sequential::ProcessLoaderSequentialComponent::new(
         checker,
@@ -659,6 +675,7 @@ pub unsafe fn start() -> (
         chip,
         &FAULT_RESPONSE,
         assigner,
+        storage_permissions_policy,
     )
     .finalize(components::process_loader_sequential_component_static!(
         nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,

--- a/capsules/extra/src/kv_store_permissions.rs
+++ b/capsules/extra/src/kv_store_permissions.rs
@@ -311,7 +311,7 @@ impl<'a, K: kv::KV<'a>> kv::KVClient for KVStorePermissions<'a, K> {
 
                         if header.version == HEADER_VERSION {
                             self.valid_ids.map(|perms| {
-                                access_allowed = perms.check_write_permission(header.write_id);
+                                access_allowed = perms.check_modify_permission(header.write_id);
                             });
                         }
                     } else if result.err() == Some(ErrorCode::NOSUPPORT) {
@@ -352,7 +352,7 @@ impl<'a, K: kv::KV<'a>> kv::KVClient for KVStorePermissions<'a, K> {
 
                         if header.version == HEADER_VERSION {
                             self.valid_ids.map(|perms| {
-                                access_allowed = perms.check_write_permission(header.write_id);
+                                access_allowed = perms.check_modify_permission(header.write_id);
                             });
                         }
                     }
@@ -394,7 +394,7 @@ impl<'a, K: kv::KV<'a>> kv::KVClient for KVStorePermissions<'a, K> {
 
                         if header.version == HEADER_VERSION {
                             self.valid_ids.map(|perms| {
-                                access_allowed = perms.check_write_permission(header.write_id);
+                                access_allowed = perms.check_modify_permission(header.write_id);
                             });
                         }
                     }

--- a/capsules/system/src/storage_permissions/individual.rs
+++ b/capsules/system/src/storage_permissions/individual.rs
@@ -1,0 +1,35 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2024.
+
+use kernel::platform::chip::Chip;
+use kernel::process::Process;
+use kernel::process::ShortId;
+use kernel::storage_permissions::StoragePermissions;
+
+/// Assign storage permissions that grant applications access to their own
+/// state.
+pub struct IndividualStoragePermissions<C: Chip> {
+    _chip: core::marker::PhantomData<C>,
+}
+
+impl<C: Chip> IndividualStoragePermissions<C> {
+    pub fn new() -> Self {
+        Self {
+            _chip: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<C: Chip> kernel::process::ProcessStandardStoragePermissionsPolicy<C>
+    for IndividualStoragePermissions<C>
+{
+    fn get_permissions(&self, process: &kernel::process::ProcessStandard<C>) -> StoragePermissions {
+        // If we have a fixed ShortId then this process can have storage
+        // permissions. Otherwise we get null permissions.
+        match process.short_app_id() {
+            ShortId::Fixed(id) => StoragePermissions::new_self_only(id),
+            ShortId::LocallyUnique => StoragePermissions::new_null(),
+        }
+    }
+}

--- a/capsules/system/src/storage_permissions/individual.rs
+++ b/capsules/system/src/storage_permissions/individual.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2024.
 
+use kernel::capabilities::ApplicationStorageCapability;
 use kernel::platform::chip::Chip;
 use kernel::process::Process;
 use kernel::process::ShortId;
@@ -9,26 +10,29 @@ use kernel::storage_permissions::StoragePermissions;
 
 /// Assign storage permissions that grant applications access to their own
 /// state.
-pub struct IndividualStoragePermissions<C: Chip> {
+pub struct IndividualStoragePermissions<C: Chip, CAP: ApplicationStorageCapability> {
+    cap: CAP,
     _chip: core::marker::PhantomData<C>,
 }
 
-impl<C: Chip> IndividualStoragePermissions<C> {
-    pub fn new() -> Self {
+impl<C: Chip, CAP: ApplicationStorageCapability> IndividualStoragePermissions<C, CAP> {
+    pub fn new(cap: CAP) -> Self {
         Self {
+            cap,
             _chip: core::marker::PhantomData,
         }
     }
 }
 
-impl<C: Chip> kernel::process::ProcessStandardStoragePermissionsPolicy<C>
-    for IndividualStoragePermissions<C>
+impl<C: Chip, CAP: ApplicationStorageCapability>
+    kernel::process::ProcessStandardStoragePermissionsPolicy<C>
+    for IndividualStoragePermissions<C, CAP>
 {
     fn get_permissions(&self, process: &kernel::process::ProcessStandard<C>) -> StoragePermissions {
         // If we have a fixed ShortId then this process can have storage
         // permissions. Otherwise we get null permissions.
         match process.short_app_id() {
-            ShortId::Fixed(id) => StoragePermissions::new_self_only(id),
+            ShortId::Fixed(id) => StoragePermissions::new_self_only(id, &self.cap),
             ShortId::LocallyUnique => StoragePermissions::new_null(),
         }
     }

--- a/capsules/system/src/storage_permissions/mod.rs
+++ b/capsules/system/src/storage_permissions/mod.rs
@@ -2,10 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2024.
 
-#![forbid(unsafe_code)]
-#![no_std]
-
-pub mod process_checker;
-pub mod process_policies;
-pub mod process_printer;
-pub mod storage_permissions;
+pub mod individual;
+pub mod null;
+pub mod tbf_header;

--- a/capsules/system/src/storage_permissions/null.rs
+++ b/capsules/system/src/storage_permissions/null.rs
@@ -1,0 +1,30 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2024.
+
+use kernel::platform::chip::Chip;
+use kernel::storage_permissions::StoragePermissions;
+
+/// Always assign no storage permissions.
+pub struct NullStoragePermissions<C: Chip> {
+    _chip: core::marker::PhantomData<C>,
+}
+
+impl<C: Chip> NullStoragePermissions<C> {
+    pub fn new() -> Self {
+        Self {
+            _chip: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<C: Chip> kernel::process::ProcessStandardStoragePermissionsPolicy<C>
+    for NullStoragePermissions<C>
+{
+    fn get_permissions(
+        &self,
+        _process: &kernel::process::ProcessStandard<C>,
+    ) -> StoragePermissions {
+        StoragePermissions::new_null()
+    }
+}

--- a/capsules/system/src/storage_permissions/tbf_header.rs
+++ b/capsules/system/src/storage_permissions/tbf_header.rs
@@ -1,0 +1,61 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2024.
+
+use core::cmp;
+use kernel::platform::chip::Chip;
+use kernel::process::Process;
+use kernel::process::ShortId;
+use kernel::storage_permissions::StoragePermissions;
+
+/// Assign storage permissions based on the fields in the application's TBF
+/// header.
+///
+/// If the process does not have a fixed ShortId then it cannot have storage
+/// permissions and will get null permissions.
+///
+/// If the header is _not_ present, then the process will be assigned null
+/// permissions.
+pub struct TbfHeaderStoragePermissions<C: Chip> {
+    _chip: core::marker::PhantomData<C>,
+}
+
+impl<C: Chip> TbfHeaderStoragePermissions<C> {
+    pub fn new() -> Self {
+        Self {
+            _chip: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<C: Chip> kernel::process::ProcessStandardStoragePermissionsPolicy<C>
+    for TbfHeaderStoragePermissions<C>
+{
+    fn get_permissions(&self, process: &kernel::process::ProcessStandard<C>) -> StoragePermissions {
+        // If we have a fixed ShortId then this process can have storage
+        // permissions. Otherwise we get null permissions.
+        match process.short_app_id() {
+            ShortId::Fixed(id) => {
+                if let Some((write_allowed, read_count, read_ids, modify_count, modify_ids)) =
+                    process.get_tbf_storage_permissions()
+                {
+                    let read_count_capped = cmp::min(read_count, 8);
+                    let modify_count_capped = cmp::min(modify_count, 8);
+
+                    StoragePermissions::new_fixed_size(
+                        id,
+                        write_allowed,
+                        false,
+                        read_count_capped,
+                        read_ids,
+                        modify_count_capped,
+                        modify_ids,
+                    )
+                } else {
+                    StoragePermissions::new_null()
+                }
+            }
+            ShortId::LocallyUnique => StoragePermissions::new_null(),
+        }
+    }
+}

--- a/doc/reference/trd-storage-permissions.md
+++ b/doc/reference/trd-storage-permissions.md
@@ -248,7 +248,9 @@ The `StoragePermissions` type is capable of holding storage permissions in
 different formats. In general, the type looks like:
 
 ```rust
-pub enum StoragePermissions {
+pub struct StoragePermissions(StoragePermissionsPrivate);
+
+enum StoragePermissionsPrivate {
     SelfOnly(core::num::NonZeroU32),
     FixedSize(FixedSizePermissions),
     Listed(ListedPermissions),
@@ -261,8 +263,10 @@ Each variant is a different method for representing and storing storage
 permissions. For example, `FixedSize` contains fixed size lists of permissions,
 where as `Null` grants no storage permissions.
 
-The `StoragePermissions` type includes multiple constructors for instantiating
-storage permissions.
+The `StoragePermissions` struct includes multiple constructors for instantiating
+storage permissions. The struct wraps the enum to ensure that permissions can
+only be created with those constructors. The constructors require a capability
+to use so only trusted code can create storage permissions.
 
 
 7 Specifying Permissions

--- a/doc/reference/trd-storage-permissions.md
+++ b/doc/reference/trd-storage-permissions.md
@@ -148,8 +148,8 @@ pub fn check_modify_permission(&self, stored_id: u32) -> bool;
 pub fn get_write_id(&self) -> Option<u32>;
 ```
 
-This API is implemented for the `StoragePermissions` object (which is an
-`enum`). The `StoragePermissions` type can be stored per-process and passed in
+This API is implemented for the `StoragePermissions` object.
+The `StoragePermissions` type can be stored per-process and passed in
 storage APIs to express the storage permissions of the caller of any storage
 operations.
 
@@ -164,8 +164,8 @@ a record name might have an (asynchronous) API like this:
 
 ```rust
 pub trait FilingCabinet {
-    fn read(&self, record: &str, permissions: &dyn StoragePermissions) -> Result<(), ErrorCode>;
-    fn write(&self, record: &str, data: &[u8], permissions: &dyn StoragePermissions) -> Result<(), ErrorCode>;
+    fn read(&self, record: &str, permissions: StoragePermissions) -> Result<(), ErrorCode>;
+    fn write(&self, record: &str, data: &[u8], permissions: StoragePermissions) -> Result<(), ErrorCode>;
 }
 ```
 
@@ -198,7 +198,7 @@ For example, with the filing cabinet example:
 
 ```rust
 pub trait FilingCabinet {
-    fn read(&self, record: &str, permissions: &dyn StoragePermissions) -> Result<[u8], ErrorCode> {
+    fn read(&self, record: &str, permissions: StoragePermissions) -> Result<[u8], ErrorCode> {
         let obj = self.cabinet.read(record);
         match obj {
             Some(r) => {
@@ -212,7 +212,7 @@ pub trait FilingCabinet {
         }
     }
 
-    fn write(&self, record: &str, data: &[u8], permissions: &dyn StoragePermissions) -> Result<(), ErrorCode> {
+    fn write(&self, record: &str, data: &[u8], permissions: StoragePermissions) -> Result<(), ErrorCode> {
         let obj = self.cabinet.read(record);
         match obj {
             Some(r) => {

--- a/kernel/src/capabilities.rs
+++ b/kernel/src/capabilities.rs
@@ -83,6 +83,11 @@ pub unsafe trait ExternalProcessCapability {}
 /// permissions to access kernel-only stored values on the system.
 pub unsafe trait KerneluserStorageCapability {}
 
+/// The `ApplicationStorageCapability` capability allows the holder to create
+/// permissions to allow applications to have access to stored state on the
+/// system.
+pub unsafe trait ApplicationStorageCapability {}
+
 /// The `UdpDriverCapability` capability allows the holder to use two functions
 /// only allowed by the UDP driver. The first is the `driver_send_to()` function
 /// in udp_send.rs, which does not require being bound to a single port, since

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -28,7 +28,7 @@ pub use crate::process_loading::load_processes;
 pub use crate::process_loading::ProcessLoadError;
 pub use crate::process_loading::SequentialProcessLoaderMachine;
 pub use crate::process_loading::{ProcessLoadingAsync, ProcessLoadingAsyncClient};
-pub use crate::process_policies::ProcessFaultPolicy;
+pub use crate::process_policies::{ProcessFaultPolicy, ProcessStandardStoragePermissionsPolicy};
 pub use crate::process_printer::{ProcessPrinter, ProcessPrinterContext};
 pub use crate::process_standard::ProcessStandard;
 
@@ -211,8 +211,9 @@ impl ProcessId {
     /// what the process is allowed to read and write. Returns `None` if the
     /// process has no storage permissions.
     pub fn get_storage_permissions(&self) -> Option<storage_permissions::StoragePermissions> {
-        self.kernel
-            .process_map_or(None, *self, |process| process.get_storage_permissions())
+        self.kernel.process_map_or(None, *self, |process| {
+            Some(process.get_storage_permissions())
+        })
     }
 }
 
@@ -587,7 +588,7 @@ pub trait Process {
     /// Get the storage permissions for the process.
     ///
     /// Returns `None` if the process has no storage permissions.
-    fn get_storage_permissions(&self) -> Option<storage_permissions::StoragePermissions>;
+    fn get_storage_permissions(&self) -> storage_permissions::StoragePermissions;
 
     // mpu
 

--- a/kernel/src/process_loading.rs
+++ b/kernel/src/process_loading.rs
@@ -220,7 +220,7 @@ fn load_processes_from_flash<C: Chip>(
                     ShortId::LocallyUnique,
                     index,
                     fault_policy,
-                    None,
+                    &(),
                 );
                 match load_result {
                     Ok((new_mem, proc)) => {
@@ -354,7 +354,7 @@ fn load_process<C: Chip>(
     app_id: ShortId,
     index: usize,
     fault_policy: &'static dyn ProcessFaultPolicy,
-    storage_policy: Option<&'static dyn ProcessStandardStoragePermissionsPolicy<C>>,
+    storage_policy: &'static dyn ProcessStandardStoragePermissionsPolicy<C>,
 ) -> Result<(&'static mut [u8], Option<&'static dyn Process>), (&'static mut [u8], ProcessLoadError)>
 {
     if config::CONFIG.debug_load_processes {
@@ -728,7 +728,7 @@ impl<'a, C: Chip> SequentialProcessLoaderMachine<'a, C> {
                             short_app_id,
                             index,
                             self.fault_policy,
-                            Some(self.storage_policy),
+                            self.storage_policy,
                         );
                         match load_result {
                             Ok((new_mem, proc)) => {

--- a/kernel/src/process_policies.rs
+++ b/kernel/src/process_policies.rs
@@ -8,8 +8,11 @@
 //! managing processes. For example, these policies control decisions such as
 //! whether a specific process should be restarted.
 
+use crate::platform::chip::Chip;
 use crate::process;
 use crate::process::Process;
+use crate::process_standard::ProcessStandard;
+use crate::storage_permissions::StoragePermissions;
 
 /// Generic trait for implementing a policy on what to do when a process faults.
 ///
@@ -19,4 +22,11 @@ pub trait ProcessFaultPolicy {
     /// Decide which action the kernel should take in response to `process`
     /// faulting.
     fn action(&self, process: &dyn Process) -> process::FaultAction;
+}
+
+/// Generic trait for implementing a policy on how applications should be
+/// assigned storage permissions.
+pub trait ProcessStandardStoragePermissionsPolicy<C: Chip> {
+    /// Return the storage permissions for the specified `process`.
+    fn get_permissions(&self, process: &ProcessStandard<C>) -> StoragePermissions;
 }

--- a/kernel/src/process_policies.rs
+++ b/kernel/src/process_policies.rs
@@ -30,3 +30,12 @@ pub trait ProcessStandardStoragePermissionsPolicy<C: Chip> {
     /// Return the storage permissions for the specified `process`.
     fn get_permissions(&self, process: &ProcessStandard<C>) -> StoragePermissions;
 }
+
+// Any platforms that do not issue storage permissions can use `&()` as the
+// [`ProcessStandardStoragePermissionsPolicy`]. This will only provide null
+// permissions (that is, no permission to access persistent storage).
+impl<C: Chip> ProcessStandardStoragePermissionsPolicy<C> for () {
+    fn get_permissions(&self, _process: &ProcessStandard<C>) -> StoragePermissions {
+        StoragePermissions::new_null()
+    }
+}

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -2038,6 +2038,33 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
         process_memory_end - identifier.offset
     }
 
+    /// Return the app's read and modify storage permissions from the TBF header
+    /// if it exists.
+    ///
+    /// If the header does not exist then return `None`. If the header does
+    /// exist, this returns a 5-tuple with:
+    ///
+    /// - `write_allowed`: bool. If this process should have write permissions.
+    /// - `read_count`: usize. How many read IDs are valid.
+    /// - `read_ids`: [u32]. The read IDs.
+    /// - `modify_count`: usze. How many modify IDs are valid.
+    /// - `modify_ids`: [u32]. The modify IDs.
+    pub fn get_tbf_storage_permissions(&self) -> Option<(bool, usize, [u32; 8], usize, [u32; 8])> {
+        let read_perms = self.header.get_storage_read_ids();
+        let modify_perms = self.header.get_storage_modify_ids();
+
+        match (read_perms, modify_perms) {
+            (Some((read_count, read_ids)), Some((modify_count, modify_ids))) => Some((
+                self.header.get_storage_write_id().is_some(),
+                read_count,
+                read_ids,
+                modify_count,
+                modify_ids,
+            )),
+            _ => None,
+        }
+    }
+
     /// The start address of allocated RAM for this process.
     fn mem_start(&self) -> *const u8 {
         self.memory_start

--- a/kernel/src/storage_permissions.rs
+++ b/kernel/src/storage_permissions.rs
@@ -7,25 +7,65 @@
 //! These permissions are intended for userspace applications so the kernel can
 //! restrict which stored elements the apps have access to.
 
-use core::cmp;
-use core::num::NonZeroU32;
-
-use crate::capabilities;
-
-/// List of storage permissions for a storage user.
+/// Permissions for accessing persistent storage.
 ///
-/// These identifiers signify what permissions a storage user has. The storage
-/// mechanism defines how the identifiers are assigned and how they relate to
-/// stored objects.
+/// This is a general type capable of representing permissions in different
+/// ways. Users of storage permissions do not need to understand the different
+/// ways permissions are stored internally. Instead, layers that need to enforce
+/// permissions only use the following API:
+///
+/// ```rust,ignore
+/// fn StoragePermissions::check_read_permission(&self, stored_id: u32) -> bool;
+/// fn StoragePermissions::check_modify_permission(&self, stored_id: u32) -> bool;
+/// fn StoragePermissions::get_write_id(&self) -> Option<u32>;
+/// ```
+#[derive(Clone, Copy)]
+pub enum StoragePermissions {
+    /// This permission grants an application full access to its own stored
+    /// state. The application may write state, and read and modify anything it
+    /// has written.
+    ///
+    /// The `NonZeroU32` is the `ShortId::Fixed` of the application.
+    SelfOnly(core::num::NonZeroU32),
+
+    /// This permission supports setting whether an application can write and
+    /// supports setting up to eight storage identifiers the application can
+    /// read and eight storage identifiers the application can modify. This
+    /// permission also includes a flag allowing an application to read and
+    /// modify its own state.
+    FixedSize(FixedSizePermissions),
+
+    /// This permission supports setting whether an application can write and
+    /// supports storing references to static buffers that contain an arbitrary
+    /// list of storage identifiers the application can read and modify. This
+    /// permission also includes a flag allowing an application to read and
+    /// modify its own state.
+    Listed(ListedPermissions),
+
+    /// This permission is designed for only the kernel use, and allows the
+    /// kernel to store and read/modify its own state. Note, this permission
+    /// does not give the kernel access to application state.
+    Kernel,
+
+    /// This permission grants an application no access to any persistent
+    /// storage.
+    Null,
+}
+
+/// `StoragePermissions` with a fixed size number of read and modify
+/// permissions.
 ///
 /// For simplicity, a we store to eight read and eight write permissions. The
-/// first `count` `u32` values in `permissions` are valid.
-///
-/// Mar, 2022: This interface is considered experimental and for initial
-/// prototyping. As we learn more about how these permissions are set and used
-/// we may want to revamp this interface.
+/// first `X_count` `u32` values in `X_permissions` are valid.
 #[derive(Clone, Copy)]
-pub struct StoragePermissions {
+pub struct FixedSizePermissions {
+    /// The `ShortId::Fixed` of the application these permissions belong to.
+    app_id: core::num::NonZeroU32,
+    /// Whether this permission grants write access.
+    write_permission: bool,
+    /// If true, these permissions grant read and modify access to any stored
+    /// state where this AppId matches the storage identifier.
+    read_modify_self: bool,
     /// How many entries in the `read_permissions` slice are valid, starting at
     /// index 0.
     read_count: usize,
@@ -38,92 +78,127 @@ pub struct StoragePermissions {
     /// Up to eight 32 bit identifiers of storage items the process has modify
     /// (update) access to.
     modify_permissions: [u32; 8],
-    /// The identifier for this storage user when creating new objects. If
-    /// `None` there is no `write_id` for these permissions.
-    write_id: Option<NonZeroU32>,
-    /// If `kerneluser` is true, this permission grants access to all objects
-    /// stored stored with `write_id` 0. New items created with `kerneluser ==
-    /// true` will use the specified ID if `write_id.is_some()`, otherwise new
-    /// items will be created with the reserved ID (i.e., 0).
-    kerneluser: bool,
+}
+
+/// `StoragePermissions` with arbitrary static arrays holding read and modify
+/// permissions.
+#[derive(Clone, Copy)]
+pub struct ListedPermissions {
+    /// The `ShortId::Fixed` of the application these permissions belong to.
+    app_id: core::num::NonZeroU32,
+    /// Whether this permission grants write access.
+    write_permission: bool,
+    /// If true, these permissions grant read and modify access to any stored
+    /// state where this AppId matches the storage identifier.
+    read_modify_self: bool,
+    /// The 32 bit identifiers of storage items the process can read.
+    read_permissions: &'static [u32],
+    /// The 32 bit identifiers of storage items the process can modify
+    modify_permissions: &'static [u32],
 }
 
 impl StoragePermissions {
-    pub(crate) fn new(
+    pub fn new_self_only(short_id_fixed: core::num::NonZeroU32) -> Self {
+        Self::SelfOnly(short_id_fixed)
+    }
+
+    pub fn new_fixed_size(
+        app_id: core::num::NonZeroU32,
+        write_permission: bool,
+        read_modify_self: bool,
         read_count: usize,
         read_permissions: [u32; 8],
         modify_count: usize,
         modify_permissions: [u32; 8],
-        write_id: Option<NonZeroU32>,
     ) -> Self {
-        let read_count_capped = cmp::min(read_count, 8);
-        let modify_count_capped = cmp::min(modify_count, 8);
-        StoragePermissions {
-            read_count: read_count_capped,
+        Self::FixedSize(FixedSizePermissions {
+            app_id,
+            write_permission,
+            read_modify_self,
+            read_count,
             read_permissions,
-            modify_count: modify_count_capped,
+            modify_count,
             modify_permissions,
-            write_id,
-            kerneluser: false,
-        }
+        })
     }
 
-    /// Create superuser permissions suitable for the kernel. This allows the
-    /// kernel to read/update any stored item, and allows the kernel to write
-    /// items that will not be accessible to any clients without superuser
-    /// permissions.
-    pub fn new_kernel_permissions(_cap: &dyn capabilities::KerneluserStorageCapability) -> Self {
-        let read_permissions: [u32; 8] = [0; 8];
-        let modify_permissions: [u32; 8] = [0; 8];
-        StoragePermissions {
-            read_count: 0,
+    pub fn new_listed(
+        app_id: core::num::NonZeroU32,
+        write_permission: bool,
+        read_modify_self: bool,
+        read_permissions: &'static [u32],
+        modify_permissions: &'static [u32],
+    ) -> Self {
+        Self::Listed(ListedPermissions {
+            app_id,
+            write_permission,
+            read_modify_self,
             read_permissions,
-            modify_count: 0,
             modify_permissions,
-            write_id: None,
-            kerneluser: true,
+        })
+    }
+
+    pub fn new_kernel() -> Self {
+        Self::Kernel
+    }
+
+    pub fn new_null() -> Self {
+        Self::Null
+    }
+
+    /// Check if these storage permissions grant read access to the stored state
+    /// marked with identifier `stored_id`.
+    pub fn check_read_permission(&self, stored_id: u32) -> bool {
+        match *self {
+            StoragePermissions::SelfOnly(id) => stored_id == id.into(),
+            StoragePermissions::FixedSize(p) => {
+                (stored_id == p.app_id.into() && p.read_modify_self)
+                    || (stored_id != 0
+                        && p.read_permissions
+                            .get(0..p.read_count)
+                            .unwrap_or(&[])
+                            .contains(&stored_id))
+            }
+            StoragePermissions::Listed(p) => {
+                (stored_id == p.app_id.into() && p.read_modify_self)
+                    || (stored_id != 0 && p.read_permissions.contains(&stored_id))
+            }
+            StoragePermissions::Kernel => stored_id == 0,
+            StoragePermissions::Null => false,
         }
     }
 
-    /// Check if this permission object grants read access to the specified
-    /// `storage_id`. Returns `true` if access is permitted, `false` otherwise.
-    pub fn check_read_permission(&self, storage_id: u32) -> bool {
-        if storage_id == 0 {
-            // Only kerneluser can read ID 0.
-            self.kerneluser
-        } else {
-            // Otherwise check if given storage_id is in read permissions
-            // array.
-            self.read_permissions
-                .get(0..self.read_count)
-                .unwrap_or(&[])
-                .contains(&storage_id)
+    /// Check if these storage permissions grant modify access to the stored
+    /// state marked with identifier `stored_id`.
+    pub fn check_modify_permission(&self, stored_id: u32) -> bool {
+        match *self {
+            StoragePermissions::SelfOnly(id) => stored_id == id.into(),
+            StoragePermissions::FixedSize(p) => {
+                (stored_id == p.app_id.into() && p.read_modify_self)
+                    || (stored_id != 0
+                        && p.modify_permissions
+                            .get(0..p.modify_count)
+                            .unwrap_or(&[])
+                            .contains(&stored_id))
+            }
+            StoragePermissions::Listed(p) => {
+                (stored_id == p.app_id.into() && p.read_modify_self)
+                    || (stored_id != 0 && p.modify_permissions.contains(&stored_id))
+            }
+            StoragePermissions::Kernel => stored_id == 0,
+            StoragePermissions::Null => false,
         }
     }
 
-    /// Check if this permission object grants modify access to the specified
-    /// `storage_id`. Returns `true` if access is permitted, `false` otherwise.
-    pub fn check_write_permission(&self, storage_id: u32) -> bool {
-        if storage_id == 0 {
-            // Only kerneluser can access ID 0.
-            self.kerneluser
-        } else {
-            // Otherwise check if given storage_id is in read permissions
-            // array.
-            self.modify_permissions
-                .get(0..self.modify_count)
-                .unwrap_or(&[])
-                .contains(&storage_id)
-        }
-    }
-
-    /// Get the `write_id` for saving items to the storage.
+    /// Retrieve the identifier to use when storing state, if the application
+    /// has permission to write. Returns `None` if the application cannot write.
     pub fn get_write_id(&self) -> Option<u32> {
-        if self.kerneluser {
-            // If kerneluser, write_id is 0 unless specifically set.
-            Some(self.write_id.map_or(0, |wid| wid.get()))
-        } else {
-            self.write_id.map(|wid| wid.get())
+        match *self {
+            StoragePermissions::SelfOnly(id) => Some(id.into()),
+            StoragePermissions::FixedSize(p) => p.write_permission.then_some(p.app_id.into()),
+            StoragePermissions::Listed(p) => p.write_permission.then_some(p.app_id.into()),
+            StoragePermissions::Kernel => Some(0),
+            StoragePermissions::Null => None,
         }
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request adds an implementation to match the [storage permissions TRD](https://github.com/tock/tock/blob/master/doc/reference/trd-storage-permissions.md).

The core is the `StoragePermissions` enum:

```rust
pub enum StoragePermissionsPrivate {
    SelfOnly(core::num::NonZeroU32),
    FixedSize(FixedSizePermissions),
    Listed(ListedPermissions),
    Kernel,
    Null,
}
```

Policies then create a storage permissions variant based on how they want to assign applications storage permissions.

To merge the general storage permissions framework with the storage permissions TBF header, the write_id field is just used as a boolean: if the field is 0 the app has no write permissions, otherwise it does.

I also added some components to help with instantiating storage permissions policies.


### Testing Strategy

This pull request was tested by...


### TODO or Help Wanted

Need to figure out how this works with the HOTP tutorial. Non credentialed apps don't have storage permissions anymore.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
