### PR TITLE
doc/reference/trd104: bump draft version and date modified

### DIFF
--- a/doc/reference/trd104-syscalls.md
+++ b/doc/reference/trd104-syscalls.md
@@ -7,8 +7,8 @@ System Calls
 **Status:** Draft <br/>
 **Author:** Hudson Ayers, Guillaume Endignoux, Jon Flatley, Philip Levis, Amit Levy, Pat Pannuto, Leon Schuermann, Johnathan Van Why, dcz <br/>
 **Draft-Created:** August 31, 2020<br/>
-**Draft-Modified:** September 8, 2023<br/>
-**Draft-Version:** 8<br/>
+**Draft-Modified:** June 14, 2024<br/>
+**Draft-Version:** 9<br/>
 **Draft-Discuss:** tock-dev@googlegroups.com</br>
 
 Abstract


### PR DESCRIPTION
### Pull Request Overview

Merging the YieldFor PR has changed the TRD, but did not update its draft version or date modified attribute: "Merge pull request #3577 from tock/yeild-for" (db6b98242ada)


### Testing Strategy

N/A


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
