### PR TITLE
kernel/collections/queue: rename `remove_first` to `remove_first_matching`

### DIFF
--- a/kernel/src/collections/queue.rs
+++ b/kernel/src/collections/queue.rs
@@ -25,7 +25,7 @@ pub trait Queue<T> {
     fn dequeue(&mut self) -> Option<T>;
 
     /// Remove and return one (the first) element that matches the predicate.
-    fn remove_first<F>(&mut self, f: F) -> Option<T>
+    fn remove_first_matching<F>(&mut self, f: F) -> Option<T>
     where
         F: Fn(&T) -> bool;
 

--- a/kernel/src/collections/ring_buffer.rs
+++ b/kernel/src/collections/ring_buffer.rs
@@ -111,7 +111,14 @@ impl<T: Copy> queue::Queue<T> for RingBuffer<'_, T> {
         }
     }
 
-    fn remove_first<F>(&mut self, f: F) -> Option<T>
+    /// Removes the first element for which the provided closure returns `true`.
+    ///
+    /// This walks the ring buffer and, upon finding a matching element, removes
+    /// it. It then shifts all subsequent elements forward (filling the hole
+    /// created by removing the element).
+    ///
+    /// If an element was removed, this function returns it as `Some(elem)`.
+    fn remove_first_matching<F>(&mut self, f: F) -> Option<T>
     where
         F: Fn(&T) -> bool,
     {

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -461,7 +461,7 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
 
     fn remove_upcall(&self, upcall_id: UpcallId) -> Option<Task> {
         self.tasks.map_or(None, |tasks| {
-            tasks.remove_first(|task| match task {
+            tasks.remove_first_matching(|task| match task {
                 Task::FunctionCall(fc) => match fc.source {
                     FunctionCallSource::Driver(upid) => upid == upcall_id,
                     _ => false,


### PR DESCRIPTION
### Pull Request Overview

`Queue`'s `dequeue_specific` was renamed to `remove_first` in ab293c54c36a ("Rename dequeue_specific to remove_first").

While I don't disagree with the fact that `dequeue_specific` is an oxymoron and a bad name, arguably `remove_first` carries its own baggage. We're talking about collections where "first" has meaning, often used interchangably with "head". Looking over the code in #3577 I was quite surprised with the complexity of this method's implementation in `RingBuffer`, for what I thought would just be a `dequeue` operation---removing the _first_ / _head_ element.

This is an effort to clear up that confusion. This is not a hill worth dying on for me, so if anyone has strong feelings otherwise, feel free to close this.

### Testing Strategy

N/A


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [x] Ran `make prepush`.
