### PR TITLE
kernel: processstd: remove unsafe in version

### DIFF
--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -246,13 +246,10 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
     }
 
     fn binary_version(&self) -> Option<BinaryVersion> {
-        match self.header.get_binary_version() {
-            0 => None,
-            // Safety: because of the previous arm, version != 0, so the call to
-            // NonZeroU32::new_unchecked() is safe
-            version => Some(BinaryVersion::new(unsafe {
-                NonZeroU32::new_unchecked(version)
-            })),
+        let version = self.header.get_binary_version();
+        match NonZeroU32::new(version) {
+            Some(version_nonzero) => Some(BinaryVersion::new(version_nonzero)),
+            None => None,
         }
     }
 


### PR DESCRIPTION


### Pull Request Overview

Remove an `unsafe` from the kernel by just trying to create the nonzero first.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
