### PR TITLE
kernel: process standard: stop in YieldedFor

### DIFF
--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -697,11 +697,7 @@ impl Kernel {
                     // This is a potential security flaw: panic.
                     panic!("Attempted to schedule an unrunnable process");
                 }
-                process::State::StoppedRunning => {
-                    return_reason = process::StoppedExecutingReason::Stopped;
-                    break;
-                }
-                process::State::StoppedYielded => {
+                process::State::Stopped(_) => {
                     return_reason = process::StoppedExecutingReason::Stopped;
                     break;
                 }


### PR DESCRIPTION
### Pull Request Overview

Using `_` in a match burned us here. We wouldn't be able to stop a process while it is in the yield_for state.

This refactors the states to make this cleaner, and removes the _ match so future state changes will lead to errors unless those states are handled.

Also updated some comments in process.rs that had fallen slightly out of date.





### Testing Strategy

I don't have an easy long-running yieldwaitfor to use to test this with, but it would be easy to test if we did.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
