### PR TITLE
boards: HOTP Tutorial: Enable screen

### DIFF
--- a/boards/tutorials/nrf52840dk-hotp-tutorial/Cargo.toml
+++ b/boards/tutorials/nrf52840dk-hotp-tutorial/Cargo.toml
@@ -9,6 +9,11 @@ authors.workspace = true
 build = "../../build.rs"
 edition.workspace = true
 
+[features]
+default = ["screen_ssd1306"]
+screen_ssd1306 = []
+screen_sh1106 = []
+
 [dependencies]
 kernel = { path = "../../../kernel" }
 nrf52840 = { path = "../../../chips/nrf52840" }


### PR DESCRIPTION
### Pull Request Overview

Our tutorial boards have screens on them (or at least they can) and this enables the kernel to use them

Key here is we have to use `twi1`, as `twi0` is already used by spi0 for the flash chip.


### Testing Strategy

Running all of the HOTP apps with https://github.com/tock/libtock-c/pull/445.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
