### PR TITLE
nrf52: Expose SPI0 and TWI1 (and not TWI0 and SPI1)

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -358,14 +358,14 @@ unsafe fn start() -> (
     // Create shared mux for the I2C bus
     let i2c_mux = static_init!(
         capsules_core::virtualizers::virtual_i2c::MuxI2C<'static, nrf52832::i2c::TWI<'static>>,
-        capsules_core::virtualizers::virtual_i2c::MuxI2C::new(&base_peripherals.twi0, None,)
+        capsules_core::virtualizers::virtual_i2c::MuxI2C::new(&base_peripherals.twi1, None,)
     );
     kernel::deferred_call::DeferredCallClient::register(i2c_mux);
-    base_peripherals.twi0.configure(
+    base_peripherals.twi1.configure(
         nrf52832::pinmux::Pinmux::new(21),
         nrf52832::pinmux::Pinmux::new(20),
     );
-    base_peripherals.twi0.set_master_client(i2c_mux);
+    base_peripherals.twi1.set_master_client(i2c_mux);
 
     // Configure the MCP23017. Device address 0x20.
     let mcp_pin0 = static_init!(

--- a/boards/makepython-nrf52840/src/main.rs
+++ b/boards/makepython-nrf52840/src/main.rs
@@ -489,9 +489,9 @@ pub unsafe fn start() -> (
     // SCREEN
     //--------------------------------------------------------------------------
 
-    let i2c_bus = components::i2c::I2CMuxComponent::new(&base_peripherals.twi0, None)
+    let i2c_bus = components::i2c::I2CMuxComponent::new(&base_peripherals.twi1, None)
         .finalize(components::i2c_mux_component_static!(nrf52840::i2c::TWI));
-    base_peripherals.twi0.configure(
+    base_peripherals.twi1.configure(
         nrf52840::pinmux::Pinmux::new(I2C_SCL_PIN as u32),
         nrf52840::pinmux::Pinmux::new(I2C_SDA_PIN as u32),
     );

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -441,12 +441,12 @@ unsafe fn start() -> (
     // SENSORS
     //--------------------------------------------------------------------------
 
-    base_peripherals.twi0.configure(
+    base_peripherals.twi1.configure(
         nrf52833::pinmux::Pinmux::new(I2C_SCL_PIN as u32),
         nrf52833::pinmux::Pinmux::new(I2C_SDA_PIN as u32),
     );
 
-    let sensors_i2c_bus = components::i2c::I2CMuxComponent::new(&base_peripherals.twi0, None)
+    let sensors_i2c_bus = components::i2c::I2CMuxComponent::new(&base_peripherals.twi1, None)
         .finalize(components::i2c_mux_component_static!(
             nrf52833::i2c::TWI<'static>
         ));

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -483,9 +483,9 @@ pub unsafe fn start() -> (
     // SENSORS
     //--------------------------------------------------------------------------
 
-    let sensors_i2c_bus = components::i2c::I2CMuxComponent::new(&base_peripherals.twi0, None)
+    let sensors_i2c_bus = components::i2c::I2CMuxComponent::new(&base_peripherals.twi1, None)
         .finalize(components::i2c_mux_component_static!(nrf52840::i2c::TWI));
-    base_peripherals.twi0.configure(
+    base_peripherals.twi1.configure(
         nrf52840::pinmux::Pinmux::new(I2C_SCL_PIN as u32),
         nrf52840::pinmux::Pinmux::new(I2C_SDA_PIN as u32),
     );

--- a/boards/nano33ble_rev2/src/main.rs
+++ b/boards/nano33ble_rev2/src/main.rs
@@ -491,9 +491,9 @@ pub unsafe fn start() -> (
     // SENSORS
     //--------------------------------------------------------------------------
 
-    let sensors_i2c_bus = components::i2c::I2CMuxComponent::new(&base_peripherals.twi0, None)
+    let sensors_i2c_bus = components::i2c::I2CMuxComponent::new(&base_peripherals.twi1, None)
         .finalize(components::i2c_mux_component_static!(nrf52840::i2c::TWI));
-    base_peripherals.twi0.configure(
+    base_peripherals.twi1.configure(
         nrf52840::pinmux::Pinmux::new(I2C_SCL_PIN as u32),
         nrf52840::pinmux::Pinmux::new(I2C_SDA_PIN as u32),
     );

--- a/boards/tutorials/nrf52840dk-thread-tutorial/src/main.rs
+++ b/boards/tutorials/nrf52840dk-thread-tutorial/src/main.rs
@@ -124,15 +124,15 @@ pub unsafe fn main() {
     const SCREEN_I2C_SDA_PIN: Pin = Pin::P1_10;
     const SCREEN_I2C_SCL_PIN: Pin = Pin::P1_11;
 
-    let i2c_bus = components::i2c::I2CMuxComponent::new(&nrf52840_peripherals.nrf52.twi0, None)
+    let i2c_bus = components::i2c::I2CMuxComponent::new(&nrf52840_peripherals.nrf52.twi1, None)
         .finalize(components::i2c_mux_component_static!(nrf52840::i2c::TWI));
-    nrf52840_peripherals.nrf52.twi0.configure(
+    nrf52840_peripherals.nrf52.twi1.configure(
         nrf52840::pinmux::Pinmux::new(SCREEN_I2C_SCL_PIN as u32),
         nrf52840::pinmux::Pinmux::new(SCREEN_I2C_SDA_PIN as u32),
     );
     nrf52840_peripherals
         .nrf52
-        .twi0
+        .twi1
         .set_speed(nrf52840::i2c::Speed::K400);
 
     // I2C address is b011110X, and on this board D/C̅ is GND.

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -40,8 +40,6 @@ pub struct Nrf52DefaultPeripherals<'a> {
     pub timer2: crate::timer::Timer,
     pub uarte0: crate::uart::Uarte<'a>,
     pub spim0: crate::spi::SPIM<'a>,
-    pub twi0: crate::i2c::TWI<'a>,
-    pub spim1: crate::spi::SPIM<'a>,
     pub twi1: crate::i2c::TWI<'a>,
     pub spim2: crate::spi::SPIM<'a>,
     pub adc: crate::adc::Adc<'a>,
@@ -65,8 +63,6 @@ impl<'a> Nrf52DefaultPeripherals<'a> {
             timer2: crate::timer::Timer::new(2),
             uarte0: crate::uart::Uarte::new(crate::uart::UARTE0_BASE),
             spim0: crate::spi::SPIM::new(0),
-            twi0: crate::i2c::TWI::new_twi0(),
-            spim1: crate::spi::SPIM::new(1),
             twi1: crate::i2c::TWI::new_twi1(),
             spim2: crate::spi::SPIM::new(2),
             // Default to 3.3 V VDD reference.
@@ -98,34 +94,8 @@ impl<'a> kernel::platform::chip::InterruptService for Nrf52DefaultPeripherals<'a
             crate::peripheral_interrupts::TIMER1 => self.timer1.handle_interrupt(),
             crate::peripheral_interrupts::TIMER2 => self.timer2.handle_interrupt(),
             crate::peripheral_interrupts::UART0 => self.uarte0.handle_interrupt(),
-            crate::peripheral_interrupts::SPI0_TWI0 => {
-                // SPI0 and TWI0 share interrupts.
-                // Dispatch the correct handler.
-                match (self.spim0.is_enabled(), self.twi0.is_enabled()) {
-                    (false, false) => (),
-                    (true, false) => self.spim0.handle_interrupt(),
-                    (false, true) => self.twi0.handle_interrupt(),
-                    (true, true) => debug_assert!(
-                        false,
-                        "SPIM0 and TWIM0 cannot be \
-                         enabled at the same time."
-                    ),
-                }
-            }
-            crate::peripheral_interrupts::SPI1_TWI1 => {
-                // SPI1 and TWI1 share interrupts.
-                // Dispatch the correct handler.
-                match (self.spim1.is_enabled(), self.twi1.is_enabled()) {
-                    (false, false) => (),
-                    (true, false) => self.spim1.handle_interrupt(),
-                    (false, true) => self.twi1.handle_interrupt(),
-                    (true, true) => debug_assert!(
-                        false,
-                        "SPIM1 and TWIM1 cannot be \
-                         enabled at the same time."
-                    ),
-                }
-            }
+            crate::peripheral_interrupts::SPI0_TWI0 => self.spim0.handle_interrupt(),
+            crate::peripheral_interrupts::SPI1_TWI1 => self.twi1.handle_interrupt(),
             crate::peripheral_interrupts::SPIM2_SPIS2_SPI2 => self.spim2.handle_interrupt(),
             crate::peripheral_interrupts::ADC => self.adc.handle_interrupt(),
             _ => return false,


### PR DESCRIPTION
### Pull Request Overview

The [SPIM|TWI]* peripherals on the nrf are the same hardware. Right now we have a runtime check (which doesn't actually error) to verify both are not used. This enforces the restriction at compile time.

We don't have any boards which are using both SPI0/1 or both TWI0/1 (TWI is more crucial as there are three spi devices). So this PR changes the default to expose only compatible devices.

Note, this doesn't prevent using both TWI or both SPI, it just requires not using the default peripheral struct.


### Testing Strategy

Worked when I used the screen and flash on nrf52840dk.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
