### PR TITLE
kernel: Stub out device pass through support

### DIFF
--- a/kernel/src/hil/mod.rs
+++ b/kernel/src/hil/mod.rs
@@ -26,6 +26,7 @@ pub mod kv;
 pub mod led;
 pub mod log;
 pub mod nonvolatile_storage;
+pub mod passthrough;
 pub mod public_key_crypto;
 pub mod pwm;
 pub mod radio;

--- a/kernel/src/hil/passthrough.rs
+++ b/kernel/src/hil/passthrough.rs
@@ -1,0 +1,47 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2024.
+
+//! Interfaces for device pass through
+
+/// Simple interface for pass through devices.
+///
+/// This should be implemented before `filter_passthrough()`
+/// allows the device to be passed through to userspace.
+pub trait PassThroughDevice<'a> {
+    fn set_client(&self, client: &'a dyn Client);
+}
+
+/// Trait for handling callbacks from passed through devices.
+///
+/// This should be called whenever an interrupt occurs for the
+/// device. The interrupt should be disabled and cleared then
+/// the interrupt information passed to userspace via the
+/// `interrupt_occurred()` upcall.
+///
+/// An example implementation would look like this
+///
+/// ```rust,ignore
+///    pub fn handle_interrupt(&self) {
+///        let irqs = self.registers.intstat.extract();
+///
+///        // Disable and clear interrupts
+///        self.disable_interrupts();
+///
+///        // Pass the information to the device passthrough
+///        // and then stop processing the interrupt
+///        if self.passthrough_client.is_some() {
+///            self.passthrough_client.map(|client| {
+///                client.interrupt_occurred(irqs.get() as usize);
+///            });
+///        } else {
+///             // Do normal IRQ processing
+///         }
+///     }
+/// ```
+pub trait Client {
+    /// Called when an interrupt occurs. `interrupt_status`
+    /// should contain the interrupt information from hardware that
+    /// was cleared.
+    fn interrupt_occurred(&self, interrupt_status: usize);
+}

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -14,6 +14,7 @@ pub mod watchdog;
 pub(crate) mod platform;
 
 pub use self::platform::ContextSwitchCallback;
+pub use self::platform::DevicePassthroughFilter;
 pub use self::platform::KernelResources;
 pub use self::platform::ProcessFault;
 pub use self::platform::SyscallDriverLookup;


### PR DESCRIPTION
### Pull Request Overview

This is an implementation of device pass through support, as mentioned in https://github.com/tock/tock/issues/4020

This creates the Rust traits to implement device pass through to a userspace application.

This is disabled by default in the kernel. A board and a chip implementation must explicitly opt into it

### Testing Strategy

I have a BLE client up and running in userspace using this. I can connect to a Tock board and read Gatt data, with the entire BLE stack running in userspace.

### TODO or Help Wanted

This feels ready to review. If this is accepted I will start to send PRs for the implementations

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
