### PR TITLE
Fix module name for TextScreen

### DIFF
--- a/boards/components/src/text_screen.rs
+++ b/boards/components/src/text_screen.rs
@@ -33,7 +33,7 @@ use kernel::create_capability;
 macro_rules! text_screen_component_static {
     ($s:literal $(,)?) => {{
         let buffer = kernel::static_buf!([u8; $s]);
-        let screen = kernel::static_buf!(capsules_extra::screen::TextScreen);
+        let screen = kernel::static_buf!(capsules_extra::text_screen::TextScreen);
 
         (buffer, screen)
     };};


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes an incorrect module reference. The module `capsules_extra::screen::TextScreen` was incorrectly referenced, and has been corrected to `capsules_extra::text_screen::TextScreen`.


### Testing Strategy

This pull request was tested by using the component and ensuring it works as intended


### TODO or Help Wanted

No help is required.

### Documentation Updated

No updates are required.

### Formatting

- [x] Ran `make prepush`.
