### PR TITLE
arch: cortex-m: fix docs

### DIFF
--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -140,7 +140,7 @@ extern "C" {
     /// We need to (unfortunately) do these operations in assembly because it is
     /// not valid to run Rust code without RAM initialized.
     ///
-    /// See https://github.com/tock/tock/issues/2222 for more information.
+    /// See <https://github.com/tock/tock/issues/2222> for more information.
     pub fn initialize_ram_jump_to_main();
 }
 

--- a/arch/cortex-v7m/src/lib.rs
+++ b/arch/cortex-v7m/src/lib.rs
@@ -22,7 +22,7 @@ extern "C" {
     /// ARMv7-M systick handler function.
     ///
     /// For documentation of this function, please see
-    /// [`CortexMVariant::SYSTICK_HANDLER`].
+    /// `CortexMVariant::SYSTICK_HANDLER`.
     pub fn systick_handler_arm_v7m();
 }
 
@@ -63,7 +63,7 @@ extern "C" {
     /// Handler of `svc` instructions on ARMv7-M.
     ///
     /// For documentation of this function, please see
-    /// [`CortexMVariant::SVC_HANDLER`].
+    /// `CortexMVariant::SVC_HANDLER`.
     pub fn svc_handler_arm_v7m();
 }
 
@@ -140,7 +140,7 @@ global_asm!(
 extern "C" {
     /// Generic interrupt handler for ARMv7-M instruction sets.
     ///
-    /// For documentation of this function, see [`CortexMVariant::GENERIC_ISR`].
+    /// For documentation of this function, see `CortexMVariant::GENERIC_ISR`.
     pub fn generic_isr_arm_v7m();
 }
 #[cfg(all(target_arch = "arm", target_os = "none"))]
@@ -219,7 +219,7 @@ global_asm!(
 /// state.
 ///
 /// For documentation of this function, please see
-/// [`CortexMVariant::switch_to_user`].
+/// `CortexMVariant::switch_to_user`.
 #[cfg(all(target_arch = "arm", target_os = "none"))]
 pub unsafe fn switch_to_user_arm_v7m(
     mut user_stack: *const usize,
@@ -439,7 +439,7 @@ extern "C" {
     /// ARMv7-M hardfault handler.
     ///
     /// For documentation of this function, please see
-    /// [`CortexMVariant::HARD_FAULT_HANDLER_HANDLER`].
+    /// `CortexMVariant::HARD_FAULT_HANDLER_HANDLER`.
     pub fn hard_fault_handler_arm_v7m();
 }
 


### PR DESCRIPTION
### Pull Request Overview

We can't link to the crate with CortexMVariant because it is not a dependency.

Include <> so that the tool which knows that is a link knows that is a link.






### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
