### PR TITLE
makefile: run miri on all capsules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -528,6 +528,7 @@ ci-job-miri:
 	@for a in $$(tools/list_archs.sh); do cd arch/$$a && NOWARNINGS=true cargo miri test && cd ../..; done
 	@cd capsules/core && NOWARNINGS=true cargo miri test
 	@cd capsules/extra && NOWARNINGS=true cargo miri test
+	@cd capsules/system && NOWARNINGS=true cargo miri test
 	@for c in $$(tools/list_chips.sh); do cd chips/$$c && NOWARNINGS=true cargo miri test && cd ../..; done
 
 

--- a/Makefile
+++ b/Makefile
@@ -526,7 +526,8 @@ ci-job-miri:
 	@#cd libraries/tock-register-interface && NOWARNINGS=true cargo miri test
 	@cd kernel && NOWARNINGS=true cargo miri test
 	@for a in $$(tools/list_archs.sh); do cd arch/$$a && NOWARNINGS=true cargo miri test && cd ../..; done
-	@cd capsules && NOWARNINGS=true cargo miri test
+	@cd capsules/core && NOWARNINGS=true cargo miri test
+	@cd capsules/extra && NOWARNINGS=true cargo miri test
 	@for c in $$(tools/list_chips.sh); do cd chips/$$c && NOWARNINGS=true cargo miri test && cd ../..; done
 
 


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the main makefile to run miri on all capsule crates.


### Testing Strategy

travis, which I guess in this case means not at all.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
