### PR TITLE
libraries: tock-cells and enum_primitive: specify edition

### DIFF
--- a/libraries/enum_primitive/Cargo.toml
+++ b/libraries/enum_primitive/Cargo.toml
@@ -5,3 +5,5 @@
 [package]
 name = "enum_primitive"
 version = "0.1.0"
+edition = "2021"
+

--- a/libraries/tock-cells/Cargo.toml
+++ b/libraries/tock-cells/Cargo.toml
@@ -6,4 +6,5 @@
 name = "tock-cells"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+edition = "2021"
 

--- a/libraries/tock-cells/src/map_cell.rs
+++ b/libraries/tock-cells/src/map_cell.rs
@@ -327,7 +327,7 @@ impl<T> MapCell<T> {
 
 #[cfg(test)]
 mod tests {
-    use map_cell::MapCell;
+    use super::MapCell;
 
     struct DropCheck<'a> {
         flag: &'a mut bool,


### PR DESCRIPTION
### Pull Request Overview

New nightlies give:

```
warning: /Users/bradjc/git/tock/libraries/tock-cells/Cargo.toml: no edition set: defaulting to the 2015 edition while the latest is 2021
warning: /Users/bradjc/git/tock/libraries/enum_primitive/Cargo.toml: no edition set: defaulting to the 2015 edition while the latest is 2021
```






### Testing Strategy

n/a


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
