### PR TITLE
Update Rust nightly toolchain to nightly-2024-07-08

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
     "editor.defaultFormatter": "rust-lang.rust-analyzer",
     "editor.formatOnSave": true,
     "rust-analyzer.server.extraEnv": {
-        "RUSTUP_TOOLCHAIN": "nightly-2024-05-26"
+        "RUSTUP_TOOLCHAIN": "nightly-2024-07-08"
     },
     "rust-analyzer.check.allTargets": false,
 }

--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -873,6 +873,7 @@ impl<const MAX_REGIONS: usize, P: TORUserPMP<MAX_REGIONS> + 'static> kernel::pla
     }
 }
 
+#[cfg(test)]
 pub mod test {
     use super::{TORUserPMP, TORUserPMPCFG};
 

--- a/capsules/core/src/spi_controller.rs
+++ b/capsules/core/src/spi_controller.rs
@@ -411,7 +411,7 @@ impl<'a, S: SpiMasterDevice<'a>> SpiMasterClient for Spi<'a, S> {
     ) {
         self.current_process.map(|process_id| {
             let _ = self.grants.enter(process_id, move |app, kernel_data| {
-                let rbuf = readbuf.map(|src| {
+                let rbuf = readbuf.inspect(|src| {
                     let index = app.index;
                     let _ = kernel_data
                         .get_readwrite_processbuffer(rw_allow::READ)
@@ -442,7 +442,6 @@ impl<'a, S: SpiMasterDevice<'a>> SpiMasterClient for Spi<'a, S> {
                                 }
                             })
                         });
-                    src
                 });
 
                 if rbuf.is_some() {

--- a/capsules/core/src/spi_peripheral.rs
+++ b/capsules/core/src/spi_peripheral.rs
@@ -273,7 +273,7 @@ impl<'a, S: SpiSlaveDevice<'a>> SpiSlaveClient for SpiPeripheral<'a, S> {
     ) {
         self.current_process.map(|process_id| {
             let _ = self.grants.enter(process_id, move |app, kernel_data| {
-                let rbuf = readbuf.map(|src| {
+                let rbuf = readbuf.inspect(|src| {
                     let index = app.index;
                     let _ = kernel_data
                         .get_readwrite_processbuffer(rw_allow::READ)
@@ -303,7 +303,6 @@ impl<'a, S: SpiSlaveDevice<'a>> SpiSlaveClient for SpiPeripheral<'a, S> {
                                 }
                             })
                         });
-                    src
                 });
 
                 self.kernel_read.put(rbuf);

--- a/capsules/extra/src/screen_shared.rs
+++ b/capsules/extra/src/screen_shared.rs
@@ -222,9 +222,8 @@ impl<'a, S: hil::screen::Screen<'a>> ScreenShared<'a, S> {
                                 absolute_frame.width,
                                 absolute_frame.height,
                             )
-                            .map_err(|e| {
+                            .inspect_err(|_| {
                                 app.command = None;
-                                e
                             })
                     }
                     Some(ScreenCommand::WriteBuffer) => {

--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -72,7 +72,7 @@ of installing some of these tools, but you can also install them yourself.
 
 #### Rust (nightly)
 
-We are using `nightly-2024-05-26`. We require
+We are using `nightly-2024-07-08`. We require
 installing it with [rustup](http://www.rustup.rs) so you can manage multiple
 versions of Rust and continue using stable versions for other Rust code:
 
@@ -87,7 +87,7 @@ to your `$PATH`.
 Then install the correct nightly version of Rust:
 
 ```bash
-$ rustup install nightly-2024-05-26
+$ rustup install nightly-2024-07-08
 ```
 
 ### Compiling the Kernel

--- a/libraries/tock-register-interface/src/registers.rs
+++ b/libraries/tock-register-interface/src/registers.rs
@@ -33,7 +33,15 @@ use crate::{RegisterLongName, UIntLike};
 /// [`ReadWriteable`](crate::interfaces::ReadWriteable) traits are
 /// implemented.
 // To successfully alias this structure onto hardware registers in memory, this
-// struct must be exactly the size of the `T`.
+// struct must be exactly the size of the `T` and is thus marked
+// `repr(transparent)` over an `UnsafeCell<T>`, which itself is
+// `repr(transparent)` over `T`.
+//
+// This struct is constructed by casting a pointer to it (or, implicitly, by
+// casting a pointer to a larger struct that containts this type). As such, it
+// does not have a public constructor and Rust thinks it's dead code and should
+// be removed. We `allow(dead_code)` here to suppress this warning.
+#[allow(dead_code)]
 #[repr(transparent)]
 pub struct ReadWrite<T: UIntLike, R: RegisterLongName = ()> {
     value: UnsafeCell<T>,
@@ -63,7 +71,15 @@ impl<T: UIntLike, R: RegisterLongName> Writeable for ReadWrite<T, R> {
 /// For accessing the register contents the [`Readable`] trait is
 /// implemented.
 // To successfully alias this structure onto hardware registers in memory, this
-// struct must be exactly the size of the `T`.
+// struct must be exactly the size of the `T` and is thus marked
+// `repr(transparent)` over an `UnsafeCell<T>`, which itself is
+// `repr(transparent)` over `T`.
+//
+// This struct is constructed by casting a pointer to it (or, implicitly, by
+// casting a pointer to a larger struct that containts this type). As such, it
+// does not have a public constructor and Rust thinks it's dead code and should
+// be removed. We `allow(dead_code)` here to suppress this warning.
+#[allow(dead_code)]
 #[repr(transparent)]
 pub struct ReadOnly<T: UIntLike, R: RegisterLongName = ()> {
     value: T,
@@ -84,7 +100,15 @@ impl<T: UIntLike, R: RegisterLongName> Readable for ReadOnly<T, R> {
 /// For setting the register contents the [`Writeable`] trait is
 /// implemented.
 // To successfully alias this structure onto hardware registers in memory, this
-// struct must be exactly the size of the `T`.
+// struct must be exactly the size of the `T` and is thus marked
+// `repr(transparent)` over an `UnsafeCell<T>`, which itself is
+// `repr(transparent)` over `T`.
+//
+// This struct is constructed by casting a pointer to it (or, implicitly, by
+// casting a pointer to a larger struct that containts this type). As such, it
+// does not have a public constructor and Rust thinks it's dead code and should
+// be removed. We `allow(dead_code)` here to suppress this warning.
+#[allow(dead_code)]
 #[repr(transparent)]
 pub struct WriteOnly<T: UIntLike, R: RegisterLongName = ()> {
     value: UnsafeCell<T>,
@@ -114,7 +138,15 @@ impl<T: UIntLike, R: RegisterLongName> Writeable for WriteOnly<T, R> {
 /// type parameters `R` and `W` are identical, in which case a
 /// [`ReadWrite`] register might be a better choice).
 // To successfully alias this structure onto hardware registers in memory, this
-// struct must be exactly the size of the `T`.
+// struct must be exactly the size of the `T` and is thus marked
+// `repr(transparent)` over an `UnsafeCell<T>`, which itself is
+// `repr(transparent)` over `T`.
+//
+// This struct is constructed by casting a pointer to it (or, implicitly, by
+// casting a pointer to a larger struct that containts this type). As such, it
+// does not have a public constructor and Rust thinks it's dead code and should
+// be removed. We `allow(dead_code)` here to suppress this warning.
+#[allow(dead_code)]
 #[repr(transparent)]
 pub struct Aliased<T: UIntLike, R: RegisterLongName = (), W: RegisterLongName = ()> {
     value: UnsafeCell<T>,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,6 +3,6 @@
 # Copyright Tock Contributors 2023.
 
 [toolchain]
-channel = "nightly-2024-05-26"
+channel = "nightly-2024-07-08"
 components = ["miri", "llvm-tools", "rust-src", "rustfmt", "clippy"]
 targets = ["thumbv6m-none-eabi", "thumbv7em-none-eabi", "thumbv7em-none-eabihf", "riscv32imc-unknown-none-elf", "riscv32imac-unknown-none-elf"]

--- a/tools/netlify-build.sh
+++ b/tools/netlify-build.sh
@@ -17,7 +17,7 @@ set -u
 set -x
 
 # Install rust stuff that we need
-curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2024-05-26
+curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2024-07-08
 
 # And fixup path for the newly installed rust stuff
 export PATH="$PATH:$HOME/.cargo/bin"


### PR DESCRIPTION
### Pull Request Overview

This pull request updates our Rust nightly toolchain to that of July 8, 2024. Also fixes new warnings introduced by this update by
- removing some dead code,
- marking tock-registers types as `allow(dead_code)` (we never
  construct them directly, but cast pointers into MMIO memory into
  these types)
- adding a missing `cfg(test)` attribute in the RISC-V PMP test module.

This gets us rust-lang/cargo#14196, which we want for #4054.


### Testing Strategy

This pull request is tested by CI.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
