### PR TITLE
Migrate build to be entirely cargo-based, with make as integration tool

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,13 @@
+[build]
+rustflags = [
+  "-C", "linker=rust-lld",
+  "-C", "linker-flavor=ld.lld",
+  "-C", "relocation-model=static",
+  "-C", "link-arg=-nmagic",
+  "-C", "link-arg=-icf=all",
+  "-C", "symbol-mangling-version=v0",
+]
+
+[unstable]
+unstable-options = true
+build-std = ["core", "alloc", "compiler_builtins" ]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,11 +1,28 @@
 [build]
 rustflags = [
+  # Tell rustc to use the LLVM linker. This avoids needing GCC as a dependency
+  # to build the kernel.
   "-C", "linker=rust-lld",
+  # Use the LLVM lld executable with the `-flavor gnu` flag.
   "-C", "linker-flavor=ld.lld",
+  # Use static relocation model. See https://github.com/tock/tock/pull/2853
   "-C", "relocation-model=static",
+  # lld by default uses a default page size to align program sections. Tock
+  # expects that program sections are set back-to-back. `-nmagic` instructs the
+  # linker to not page-align sections.
   "-C", "link-arg=-nmagic",
+  # Identical Code Folding (ICF) set to all. This tells the linker to be more
+  # aggressive about removing duplicate code. The default is `safe`, and the
+  # downside to `all` is that different functions in the code can end up with
+  # the same address in the binary. However, it can save a fair bit of code
+  # size.
   "-C", "link-arg=-icf=all",
+  # Opt-in to Rust v0 symbol mangling scheme.  See
+  # https://github.com/rust-lang/rust/issues/60705 and
+  # https://github.com/tock/tock/issues/3529.
   "-C", "symbol-mangling-version=v0",
+  # Enable link-time-optimization
+  "-C", "lto",
 ]
 
 [unstable]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ edition = "2021"
 
 [profile.dev]
 panic = "abort"
-lto = false
+lto = true
 opt-level = "z"
 debug = true
 

--- a/boards/.cargo/config.toml
+++ b/boards/.cargo/config.toml
@@ -27,4 +27,5 @@ rustflags = [
 
 [unstable]
 unstable-options = true
-build-std = ["core", "alloc", "compiler_builtins" ]
+build-std = ["core", "compiler_builtins" ]
+

--- a/boards/.cargo/config.toml
+++ b/boards/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 rustflags = [
   # Tell rustc to use the LLVM linker. This avoids needing GCC as a dependency

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -43,35 +43,6 @@ endif
 # cargo `--target_dir`.
 TARGET_DIRECTORY ?= $(TOCK_ROOT_DIRECTORY)target/
 
-# RUSTC_FLAGS allows boards to define board-specific options.
-# This will hopefully move into Cargo.toml (or Cargo.toml.local) eventually.
-#
-# - `-Tlayout.ld`: Use the linker script `layout.ld` all boards must provide.
-# - `linker=rust-lld`: Tell rustc to use the LLVM linker. This avoids needing
-#   GCC as a dependency to build the kernel.
-# - `linker-flavor=ld.lld`: Use the LLVM lld executable with the `-flavor gnu`
-#   flag.
-# - `relocation-model=static`: See https://github.com/tock/tock/pull/2853
-# - `-nmagic`: lld by default uses a default page size to align program
-#   sections. Tock expects that program sections are set back-to-back. `-nmagic`
-#   instructs the linker to not page-align sections.
-# - `-icf=all`: Identical Code Folding (ICF) set to all. This tells the linker
-#   to be more aggressive about removing duplicate code. The default is `safe`,
-#   and the downside to `all` is that different functions in the code can end up
-#   with the same address in the binary. However, it can save a fair bit of code
-#   size.
-# - `-C symbol-mangling-version=v0`: Opt-in to Rust v0 symbol mangling scheme.
-#   See https://github.com/rust-lang/rust/issues/60705 and
-#   https://github.com/tock/tock/issues/3529.
-RUSTC_FLAGS ?= \
-  -C link-arg=-Tlayout.ld \
-  -C linker=rust-lld \
-  -C linker-flavor=ld.lld \
-  -C relocation-model=static \
-  -C link-arg=-nmagic \
-  -C link-arg=-icf=all \
-  -C symbol-mangling-version=v0 \
-
 # RISC-V-specific flags.
 ifneq ($(findstring riscv32i, $(TARGET)),)
   # NOTE: This flag causes kernel panics on some ARM cores. Since the size

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -18,7 +18,7 @@ MAKEFILE_COMMON_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 TOCK_ROOT_DIRECTORY := $(dir $(abspath $(MAKEFILE_COMMON_PATH)))
 
 # The path to the root of the rust installation used for this build.
-# Useful for remapping paths and for finding already-installed llvm tools.
+# Useful for finding already-installed llvm tools.
 RUSTC_SYSROOT := "$(shell rustc --print sysroot)"
 
 # Common defaults that specific boards can override, but likely do not need to.

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -158,11 +158,6 @@ ifneq (,$(findstring thumb,$(TARGET)))
   OBJDUMP_FLAGS += --arch-name=thumb
 endif
 
-# Additional flags that can be passed to cargo bloat via an environment
-# variable. Allows users to pass arbitrary flags supported by cargo bloat to
-# customize the output. By default, pass an empty string.
-CARGO_BLOAT_FLAGS ?=
-
 # Additional flags that can be passed to print_tock_memory_usage.py via an
 # environment variable. By default, pass an empty string.
 PTMU_ARGS ?=
@@ -200,7 +195,6 @@ ifeq ($(VERBOSE_MODE),1)
   $(info OBJCOPY_FLAGS                 = $(OBJCOPY_FLAGS))
   $(info CARGO_FLAGS                   = $(CARGO_FLAGS))
   $(info SIZE_FLAGS                    = $(SIZE_FLAGS))
-  $(info CARGO_BLOAT_FLAGS             = $(CARGO_BLOAT_FLAGS))
   $(info )
   $(info TOOLCHAIN                     = $(TOOLCHAIN))
   $(info SIZE                          = $(SIZE))
@@ -257,19 +251,6 @@ lst: $(TARGET_PATH)/release/$(PLATFORM).lst
 .PHONY: show-target
 show-target:
 	$(info $(TARGET))
-
-# This rule is a copy of the rule used to build the release target, but `cargo
-# rustc` has been replaced with `cargo bloat`.
-.PHONY: cargobloat
-cargobloat:
-	$(Q)$(CARGO) bloat --bin $(PLATFORM) --release $(CARGO_BLOAT_FLAGS)
-
-# To pass additional flags to `cargo cargobloatnoinline`, populate the
-# CARGO_BLOAT_FLAGS environment variable, e.g. run `CARGO_BLOAT_FLAGS=--crates
-# make cargobloatnoinline`
-.PHONY: cargobloatnoinline
-cargobloatnoinline:
-	$(Q)RUSTFLAGS="-C inline-threshold=0" $(CARGO) bloat $(CARGO_FLAGS_TOCK) --bin $(PLATFORM) --release $(CARGO_BLOAT_FLAGS)
 
 .PHONY: stack-analysis
 stack-analysis: $(TARGET_PATH)/release/$(PLATFORM)

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -39,8 +39,7 @@ else
   RUSTUP ?= true
 endif
 
-# Default location of target directory (relative to board makefile) passed to
-# cargo `--target_dir`.
+# Default location of target directory (relative to board makefile).
 TARGET_DIRECTORY ?= $(TOCK_ROOT_DIRECTORY)target/
 
 # http://stackoverflow.com/questions/10858261/abort-makefile-if-variable-not-set
@@ -256,7 +255,7 @@ debug:  $(TARGET_PATH)/debug/$(PLATFORM).bin
 debug-lst:  $(TARGET_PATH)/debug/$(PLATFORM).lst
 
 .PHONY: doc
-doc: | target
+doc:
 	$(Q)$(CARGO) --color=always doc $(VERBOSE_FLAGS) --release --package $(PLATFORM)
 
 
@@ -281,9 +280,6 @@ memory: $(TARGET_PATH)/release/$(PLATFORM).elf
 	$(TOCK_ROOT_DIRECTORY)tools/print_tock_memory_usage.py --objdump $(OBJDUMP) -w $(PTMU_ARGS) $<
 
 # Support rules
-
-target:
-	@mkdir -p $(TARGET_PATH)
 
 # Cargo outputs an elf file (just without a file extension)
 %.elf: %

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -195,6 +195,7 @@ endif
 
 # Dump configuration for verbose builds
 ifeq ($(VERBOSE_MODE),1)
+RUST_FLAGS = $(shell $(CARGO) -Zunstable-options config get build.rustflags --format json-value 2> /dev/null || echo "Listing Rust flags only accessible on nightly cargo")
   $(info )
   $(info *******************************************************)
   $(info TOCK KERNEL BUILD SYSTEM -- VERBOSE BUILD CONFIGURATION)
@@ -206,6 +207,7 @@ ifeq ($(VERBOSE_MODE),1)
   $(info PLATFORM                      = $(PLATFORM))
   $(info TARGET                        = $(TARGET))
   $(info TOCK_KERNEL_VERSION           = $(TOCK_KERNEL_VERSION))
+  $(info RUSTFLAGS                     = $(RUST_FLAGS))
   $(info MAKEFLAGS                     = $(MAKEFLAGS))
   $(info OBJDUMP_FLAGS                 = $(OBJDUMP_FLAGS))
   $(info OBJCOPY_FLAGS                 = $(OBJCOPY_FLAGS))

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -48,6 +48,23 @@ TARGET_DIRECTORY ?= $(TOCK_ROOT_DIRECTORY)target/
 # error otherwise.
 check_defined = $(strip $(foreach 1,$1,$(if $(value $1),,$(error Undefined variable "$1"))))
 
+
+# Get the name of the package by hacking the `cargo tree` command. This prints
+# the local package name first so we can use that to get the package name. Ex:
+#
+# wm1110dev v0.1.0 (/Users/bradjc/git/tock/boards/wm1110dev)
+# ├── capsules-core v0.1.0 (/Users/bradjc/git/tock/capsules/core)
+# │   ├── enum_primitive v0.1.0 (/Users/bradjc/git/tock/libraries/enum_primitive)
+PLATFORM := $(firstword $(shell $(CARGO) tree))
+# Set `TARGET` if not already defined. Note: this only works on nightly.
+ifeq ($(TARGET),)
+  # Get the specified target using the unstable `cargo config get` command.
+  TARGET_QUOTES := $(shell $(CARGO) config get --format json-value build.target)
+  # Remove the quotes from around the target name.
+  TARGET := $(patsubst "%",%,$(TARGET_QUOTES))
+endif
+
+
 # Check that we know the basics of what we are compiling for.
 # - `PLATFORM`: The name of the board that the kernel is being compiled for.
 # - `TARGET`  : The Rust target architecture the kernel is being compiled for.

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -43,17 +43,6 @@ endif
 # cargo `--target_dir`.
 TARGET_DIRECTORY ?= $(TOCK_ROOT_DIRECTORY)target/
 
-# RISC-V-specific flags.
-ifneq ($(findstring riscv32i, $(TARGET)),)
-  # NOTE: This flag causes kernel panics on some ARM cores. Since the size
-  # benefit is almost exclusively for RISC-V, we only apply it for those
-  # targets.
-  RUSTC_FLAGS += -C force-frame-pointers=no
-  # Ensure relocations generated is eligible for linker relaxation.
-  # This provide huge space savings.
-  RUSTC_FLAGS += -C target-feature=+relax
-endif
-
 # RUSTC_FLAGS_TOCK by default extends RUSTC_FLAGS with options that are global
 # to all Tock boards.
 #

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -241,16 +241,6 @@ else
   SHA256SUM := sha256sum
 endif
 
-# virtual-function-elimination reduces the size of binaries, but is still
-# experimental and has some possible miscompilation issues. This is only enabled
-# for some boards by default, but is exposed via the `VFUNC_ELIM=1` option.
-#
-# For details on virtual-function-elimination see: https://github.com/rust-lang/rust/pull/96285
-# See https://github.com/rust-lang/rust/issues/68262 for general tracking
-ifneq ($(VFUNC_ELIM),)
-	RUSTC_FLAGS += -C lto -Z virtual-function-elimination
-endif
-
 # Dump configuration for verbose builds
 ifeq ($(VERBOSE_MODE),1)
   $(info )

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -157,12 +157,6 @@ OBJDUMP ?= $(TOOLCHAIN)-objdump
 #   removing it, we prevent the kernel binary from overwriting applications.
 OBJCOPY_FLAGS ?= --strip-sections --strip-all --remove-section .apps
 
-# This make variable allows board-specific Makefiles to pass down options to
-# the Cargo build command. For example, in boards/<custom_board>/Makefile:
-# `CARGO_FLAGS += --features=foo` would pass feature `foo` to the top level
-# Cargo.toml.
-CARGO_FLAGS ?=
-
 # Set the default flags we need for objdump to get a .lst file.
 OBJDUMP_FLAGS ?= --disassemble-all --source --section-headers --demangle
 
@@ -211,7 +205,6 @@ RUST_FLAGS = $(shell $(CARGO) -Zunstable-options config get build.rustflags --fo
   $(info MAKEFLAGS                     = $(MAKEFLAGS))
   $(info OBJDUMP_FLAGS                 = $(OBJDUMP_FLAGS))
   $(info OBJCOPY_FLAGS                 = $(OBJCOPY_FLAGS))
-  $(info CARGO_FLAGS                   = $(CARGO_FLAGS))
   $(info SIZE_FLAGS                    = $(SIZE_FLAGS))
   $(info )
   $(info TOOLCHAIN                     = $(TOOLCHAIN))
@@ -240,7 +233,7 @@ all: release
 # binary. This makes checking for Rust errors much faster.
 .PHONY: check
 check:
-	$(Q)$(CARGO) check $(VERBOSE_FLAGS) $(CARGO_FLAGS)
+	$(Q)$(CARGO) check $(VERBOSE_FLAGS)
 
 
 .PHONY: clean
@@ -306,10 +299,10 @@ $(TOCK_ROOT_DIRECTORY)tools/sha256sum/target/debug/sha256sum:
 
 .PHONY: $(TARGET_PATH)/release/$(PLATFORM)
 $(TARGET_PATH)/release/$(PLATFORM):
-	$(Q)$(CARGO) rustc $(VERBOSE_FLAGS) $(CARGO_FLAGS) --bin $(PLATFORM) --release
+	$(Q)$(CARGO) rustc $(VERBOSE_FLAGS) --bin $(PLATFORM) --release
 	$(Q)$(SIZE) $(SIZE_FLAGS) $@
 
 .PHONY: $(TARGET_PATH)/debug/$(PLATFORM)
 $(TARGET_PATH)/debug/$(PLATFORM):
-	$(Q)$(CARGO) build $(VERBOSE_FLAGS) $(CARGO_FLAGS) --bin $(PLATFORM)
+	$(Q)$(CARGO) build $(VERBOSE_FLAGS) --bin $(PLATFORM)
 	$(Q)$(SIZE) $(SIZE_FLAGS) $@

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -43,47 +43,6 @@ endif
 # cargo `--target_dir`.
 TARGET_DIRECTORY ?= $(TOCK_ROOT_DIRECTORY)target/
 
-# RUSTC_FLAGS_TOCK by default extends RUSTC_FLAGS with options that are global
-# to all Tock boards.
-#
-# We use `remap-path-prefix` to remove user-specific filepath strings for error
-# reporting from appearing in the generated binary. The first line is used for
-# remapping the tock directory, and the second line is for remapping paths to
-# the source code of the core library, which end up in the binary as a result of
-# our use of `-Zbuild-std=core`.
-RUSTC_FLAGS_TOCK ?= \
-  $(RUSTC_FLAGS) \
-  --remap-path-prefix=$(TOCK_ROOT_DIRECTORY)= \
-  --remap-path-prefix=$(RUSTC_SYSROOT)/lib/rustlib/src/rust/library/core=/core/
-
-# Disallow warnings only for continuous integration builds. Disallowing them
-# here using the `RUSTC_FLAGS_TOCK` variable ensures that warnings during
-# testing won't prevent compilation from succeeding.
-ifeq ($(NOWARNINGS),true)
-  RUSTC_FLAGS_TOCK += -D warnings
-endif
-
-# The following flags should only be passed to the board's binary crate, but
-# not to any of its dependencies (the kernel, capsules, chips, etc.). The
-# dependencies wouldn't use it, but because the link path is different for each
-# board, Cargo wouldn't be able to cache builds of the dependencies.
-#
-# Indeed, as far as Cargo is concerned, building the kernel with
-# `-C link-arg=-L/tock/boards/imix` is different than building the kernel with
-# `-C link-arg=-L/tock/boards/hail`, so Cargo would have to rebuild the kernel
-# for each board instead of caching it per board (even if in reality the same
-# kernel is built because the link-arg isn't used by the kernel).
-#
-# Ultimately, this should move to the Cargo.toml, for example when
-# https://github.com/rust-lang/cargo/pull/7811 is merged into Cargo.
-#
-# The difference between `RUSTC_FLAGS_TOCK` and `RUSTC_FLAGS_FOR_BIN` is that
-# the former is forwarded to all the dependencies (being passed to cargo via
-# the `RUSTFLAGS` environment variable), whereas the latter is only applied to
-# the final binary crate (being passed as parameter to `cargo rustc`).
-RUSTC_FLAGS_FOR_BIN ?= \
-  -C link-arg=-L$(abspath .) \
-
 # http://stackoverflow.com/questions/10858261/abort-makefile-if-variable-not-set
 # Check that given variables are set and all have non-empty values, print an
 # error otherwise.
@@ -188,17 +147,6 @@ OBJCOPY_FLAGS ?= --strip-sections --strip-all --remove-section .apps
 # Cargo.toml.
 CARGO_FLAGS ?=
 
-# Add default flags to cargo. Boards can add additional options in
-# `CARGO_FLAGS`.
-CARGO_FLAGS_TOCK ?= \
-  $(VERBOSE_FLAGS) \
-  --target=$(TARGET) \
-  --package $(PLATFORM) \
-  --target-dir=$(TARGET_DIRECTORY) $(CARGO_FLAGS)
-
-# Add default flags to rustdoc.
-RUSTDOC_FLAGS_TOCK ?= -D warnings --document-private-items
-
 # Set the default flags we need for objdump to get a .lst file.
 OBJDUMP_FLAGS ?= --disassemble-all --source --section-headers --demangle
 
@@ -218,13 +166,6 @@ CARGO_BLOAT_FLAGS ?=
 # Additional flags that can be passed to print_tock_memory_usage.py via an
 # environment variable. By default, pass an empty string.
 PTMU_ARGS ?=
-
-# `cargo bloat` does not support `-Z build-std`, so we must remove it from cargo
-# flags. See https://github.com/RazrFalcon/cargo-bloat/issues/62.
-# As we aren't building the library we also remove the
-# `-Z build-std-features="core/optimize_for_size"` argument.
-CARGO_FLAGS_TOCK_NO_BUILD_STD := $(filter-out -Z build-std=core,$(CARGO_FLAGS_TOCK))
-CARGO_FLAGS_TOCK_NO_BUILD_STD := $(filter-out -Z build-std-features="core/optimize_for_size",$(CARGO_FLAGS_TOCK))
 
 # Check whether the system already has a sha256sum or shasum application
 # present. If not, use the custom shipped one.
@@ -254,14 +195,10 @@ ifeq ($(VERBOSE_MODE),1)
   $(info PLATFORM                      = $(PLATFORM))
   $(info TARGET                        = $(TARGET))
   $(info TOCK_KERNEL_VERSION           = $(TOCK_KERNEL_VERSION))
-  $(info RUSTC_FLAGS                   = $(RUSTC_FLAGS))
-  $(info RUSTC_FLAGS_TOCK              = $(RUSTC_FLAGS_TOCK))
   $(info MAKEFLAGS                     = $(MAKEFLAGS))
   $(info OBJDUMP_FLAGS                 = $(OBJDUMP_FLAGS))
   $(info OBJCOPY_FLAGS                 = $(OBJCOPY_FLAGS))
   $(info CARGO_FLAGS                   = $(CARGO_FLAGS))
-  $(info CARGO_FLAGS_TOCK              = $(CARGO_FLAGS_TOCK))
-  $(info CARGO_FLAGS_TOCK_NO_BUILD_STD = $(CARGO_FLAGS_TOCK_NO_BUILD_STD))
   $(info SIZE_FLAGS                    = $(SIZE_FLAGS))
   $(info CARGO_BLOAT_FLAGS             = $(CARGO_BLOAT_FLAGS))
   $(info )
@@ -291,12 +228,12 @@ all: release
 # binary. This makes checking for Rust errors much faster.
 .PHONY: check
 check:
-	$(Q)$(CARGO) check $(VERBOSE_FLAGS) $(CARGO_FLAGS_TOCK)
+	$(Q)$(CARGO) check $(VERBOSE_FLAGS) $(CARGO_FLAGS)
 
 
 .PHONY: clean
 clean::
-	$(Q)$(CARGO) clean $(VERBOSE_FLAGS) --target-dir=$(TARGET_DIRECTORY)
+	$(Q)$(CARGO) clean $(VERBOSE_FLAGS)
 
 .PHONY: release
 release:  $(TARGET_PATH)/release/$(PLATFORM).bin
@@ -309,7 +246,7 @@ debug-lst:  $(TARGET_PATH)/debug/$(PLATFORM).lst
 
 .PHONY: doc
 doc: | target
-	$(Q)RUSTDOCFLAGS='$(RUSTDOC_FLAGS_TOCK)' $(CARGO) --color=always doc $(VERBOSE_FLAGS) --release --package $(PLATFORM)
+	$(Q)$(CARGO) --color=always doc $(VERBOSE_FLAGS) --release --package $(PLATFORM)
 
 
 .PHONY: lst
@@ -322,32 +259,22 @@ show-target:
 	$(info $(TARGET))
 
 # This rule is a copy of the rule used to build the release target, but `cargo
-# rustc` has been replaced with `cargo bloat`. `cargo bloat` replicates the
-# interface of `cargo build`, rather than `cargo rustc`, so we need to move
-# `RUSTC_FLAGS_FOR_BIN` into the `RUSTFLAGS` environment variable. This only
-# means that cargo cannot reuse built dependencies built using `cargo bloat`.
-# See the discussion on `RUSTC_FLAGS_FOR_BIN` above for additional details. To
-# pass additional flags to `cargo bloat`, populate the CARGO_BLOAT_FLAGS
-# environment variable, e.g. run `CARGO_BLOAT_FLAGS=--crates make cargobloat`
+# rustc` has been replaced with `cargo bloat`.
 .PHONY: cargobloat
 cargobloat:
-	$(Q)$(CARGO) install cargo-bloat > /dev/null 2>&1 ||  echo 'Error: Failed to install cargo-bloat'
-	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK) $(RUSTC_FLAGS_FOR_BIN)" CARGO_FLAGS="-Z build-std=core" $(CARGO) bloat $(CARGO_FLAGS_TOCK_NO_BUILD_STD) --bin $(PLATFORM) --release $(CARGO_BLOAT_FLAGS)
+	$(Q)$(CARGO) bloat --bin $(PLATFORM) --release $(CARGO_BLOAT_FLAGS)
 
 # To pass additional flags to `cargo cargobloatnoinline`, populate the
 # CARGO_BLOAT_FLAGS environment variable, e.g. run `CARGO_BLOAT_FLAGS=--crates
 # make cargobloatnoinline`
 .PHONY: cargobloatnoinline
 cargobloatnoinline:
-	$(Q)$(CARGO) install cargo-bloat > \dev\null 2>&1 ||  echo 'Error: Failed to install cargo-bloat'
-	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK) -C inline-threshold=0 $(RUSTC_FLAGS_FOR_BIN)" $(CARGO) bloat $(CARGO_FLAGS_TOCK) --bin $(PLATFORM) --release $(CARGO_BLOAT_FLAGS)
+	$(Q)RUSTFLAGS="-C inline-threshold=0" $(CARGO) bloat $(CARGO_FLAGS_TOCK) --bin $(PLATFORM) --release $(CARGO_BLOAT_FLAGS)
 
 .PHONY: stack-analysis
-#stack_analysis: RUSTC_FLAGS_TOCK += -Z emit-stack-sizes
-stack-analysis:
+stack-analysis: $(TARGET_PATH)/release/$(PLATFORM)
 	@$ echo $(PLATFORM)
 	@$ echo ----------------------
-	$(Q)$(MAKE) release RUSTC_FLAGS="$(RUSTC_FLAGS) -Z emit-stack-sizes" $(DEVNULL) 2>&1
 	$(Q)$(TOCK_ROOT_DIRECTORY)/tools/stack_analysis.sh $(TARGET_PATH)/release/$(PLATFORM).elf
 
 # Run the `print_tock_memory_usage.py` script for this board.
@@ -383,10 +310,10 @@ $(TOCK_ROOT_DIRECTORY)tools/sha256sum/target/debug/sha256sum:
 
 .PHONY: $(TARGET_PATH)/release/$(PLATFORM)
 $(TARGET_PATH)/release/$(PLATFORM):
-	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" $(CARGO) rustc  $(CARGO_FLAGS_TOCK) --bin $(PLATFORM) --release -- $(RUSTC_FLAGS_FOR_BIN)
+	$(Q)$(CARGO) rustc  $(CARGO_FLAGS) --bin $(PLATFORM) --release
 	$(Q)$(SIZE) $(SIZE_FLAGS) $@
 
 .PHONY: $(TARGET_PATH)/debug/$(PLATFORM)
 $(TARGET_PATH)/debug/$(PLATFORM):
-	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" $(CARGO) rustc  $(CARGO_FLAGS_TOCK) --bin $(PLATFORM) -- $(RUSTC_FLAGS_FOR_BIN)
+	$(Q)$(CARGO) build  $(CARGO_FLAGS) --bin $(PLATFORM)
 	$(Q)$(SIZE) $(SIZE_FLAGS) $@

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -210,25 +210,6 @@ CARGO_FLAGS_TOCK ?= \
 # Add default flags to rustdoc.
 RUSTDOC_FLAGS_TOCK ?= -D warnings --document-private-items
 
-# Add flags if we are compiling on nightly. If we are on stable, disallow
-# features.
-#
-# - `-Z build-std=core,compiler_builtins`: Build the std library from source
-#   using our optimization settings. This leads to significantly smaller binary
-#   sizes, and makes debugging easier since debug information for the core
-#   library is included in the resulting .elf file. See
-#   https://github.com/tock/tock/pull/2847 for more details.
-# - `optimize_for_size`: Sets a feature flag in the core library that aims to
-#   produce smaller implementations for certain algorithms. See
-#   https://github.com/rust-lang/rust/pull/125011 for more details.
-# - `--document-hidden-items`: Document internal interfaces when building
-#   rustdoc API documentation.
-ifneq ($(USE_STABLE_RUST),1)
-  CARGO_FLAGS_TOCK += \
-    -Z build-std=core,compiler_builtins \
-    -Z build-std-features="core/optimize_for_size"
-endif
-
 # Set the default flags we need for objdump to get a .lst file.
 OBJDUMP_FLAGS ?= --disassemble-all --source --section-headers --demangle
 

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -304,10 +304,10 @@ $(TOCK_ROOT_DIRECTORY)tools/sha256sum/target/debug/sha256sum:
 
 .PHONY: $(TARGET_PATH)/release/$(PLATFORM)
 $(TARGET_PATH)/release/$(PLATFORM):
-	$(Q)$(CARGO) rustc  $(CARGO_FLAGS) --bin $(PLATFORM) --release
+	$(Q)$(CARGO) rustc $(VERBOSE_FLAGS) $(CARGO_FLAGS) --bin $(PLATFORM) --release
 	$(Q)$(SIZE) $(SIZE_FLAGS) $@
 
 .PHONY: $(TARGET_PATH)/debug/$(PLATFORM)
 $(TARGET_PATH)/debug/$(PLATFORM):
-	$(Q)$(CARGO) build  $(CARGO_FLAGS) --bin $(PLATFORM)
+	$(Q)$(CARGO) build $(VERBOSE_FLAGS) $(CARGO_FLAGS) --bin $(PLATFORM)
 	$(Q)$(SIZE) $(SIZE_FLAGS) $@

--- a/boards/acd52832/.cargo/config.toml
+++ b/boards/acd52832/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "thumbv7em-none-eabi"
 

--- a/boards/acd52832/.cargo/config.toml
+++ b/boards/acd52832/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "thumbv7em-none-eabi"
+

--- a/boards/acd52832/.cargo/config.toml
+++ b/boards/acd52832/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "thumbv7em-none-eabi"
 
+[unstable]
+config-include = true

--- a/boards/acd52832/Makefile
+++ b/boards/acd52832/Makefile
@@ -4,9 +4,6 @@
 
 # Makefile for building the tock kernel for the nRF development kit
 
-TARGET=thumbv7em-none-eabi
-PLATFORM=acd52832
-
 include ../Makefile.common
 
 TOCKLOADER=tockloader

--- a/boards/apollo3/.cargo/config.toml
+++ b/boards/apollo3/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "thumbv7em-none-eabi"
 

--- a/boards/apollo3/.cargo/config.toml
+++ b/boards/apollo3/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "thumbv7em-none-eabi"
+

--- a/boards/apollo3/.cargo/config.toml
+++ b/boards/apollo3/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "thumbv7em-none-eabi"
 
+[unstable]
+config-include = true

--- a/boards/apollo3/lora_things_plus/.cargo/config.toml
+++ b/boards/apollo3/lora_things_plus/.cargo/config.toml
@@ -1,6 +1,17 @@
 # Licensed under the Apache License, Version 2.0 or the MIT License.
 # SPDX-License-Identifier: Apache-2.0 OR MIT
-# Copyright Tock Contributors 2022.
+# Copyright Tock Contributors 2024.
+
+include = [
+  "../../../cargo/tock_flags.toml",
+  "../../../cargo/unstable_flags.toml",
+]
+
+[build]
+target = "thumbv7em-none-eabi"
 
 [target.'cfg(target_arch = "arm")']
 runner = "./run.sh"
+
+[unstable]
+config-include = true

--- a/boards/apollo3/lora_things_plus/Makefile
+++ b/boards/apollo3/lora_things_plus/Makefile
@@ -4,8 +4,6 @@
 
 # Makefile for building the tock kernel for the SparkFun LoRa Thing Plus - expLoRaBLE
 #
-TARGET=thumbv7em-none-eabi
-PLATFORM=lora_things_plus
 
 include ../../Makefile.common
 

--- a/boards/apollo3/lora_things_plus/Makefile
+++ b/boards/apollo3/lora_things_plus/Makefile
@@ -49,4 +49,4 @@ test:
 	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
-	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" OBJCOPY=${OBJCOPY} PORT=$(PORT) $(CARGO) test $(CARGO_FLAGS_TOCK_NO_BUILD_STD) $(NO_RUN) --bin $(PLATFORM) --release
+	$(Q)OBJCOPY=${OBJCOPY} PORT=$(PORT) $(CARGO) test $(NO_RUN) --bin $(PLATFORM) --release

--- a/boards/apollo3/redboard_artemis_atp/.cargo/config.toml
+++ b/boards/apollo3/redboard_artemis_atp/.cargo/config.toml
@@ -1,6 +1,17 @@
 # Licensed under the Apache License, Version 2.0 or the MIT License.
 # SPDX-License-Identifier: Apache-2.0 OR MIT
-# Copyright Tock Contributors 2022.
+# Copyright Tock Contributors 2024.
+
+include = [
+  "../../../cargo/tock_flags.toml",
+  "../../../cargo/unstable_flags.toml",
+]
+
+[build]
+target = "thumbv7em-none-eabi"
 
 [target.'cfg(target_arch = "arm")']
 runner = "./run.sh"
+
+[unstable]
+config-include = true

--- a/boards/apollo3/redboard_artemis_atp/Makefile
+++ b/boards/apollo3/redboard_artemis_atp/Makefile
@@ -4,8 +4,6 @@
 
 # Makefile for building the tock kernel for the RedBoard Artemis ATP platform
 #
-TARGET=thumbv7em-none-eabi
-PLATFORM=redboard_artemis_atp
 
 include ../../Makefile.common
 

--- a/boards/apollo3/redboard_artemis_atp/Makefile
+++ b/boards/apollo3/redboard_artemis_atp/Makefile
@@ -49,4 +49,4 @@ test:
 	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
-	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" OBJCOPY=${OBJCOPY} PORT=$(PORT) $(CARGO) test $(CARGO_FLAGS_TOCK_NO_BUILD_STD) $(NO_RUN) --bin $(PLATFORM) --release
+	$(Q)OBJCOPY=${OBJCOPY} PORT=$(PORT) $(CARGO) test $(NO_RUN) --bin $(PLATFORM) --release

--- a/boards/apollo3/redboard_artemis_nano/.cargo/config.toml
+++ b/boards/apollo3/redboard_artemis_nano/.cargo/config.toml
@@ -1,6 +1,17 @@
 # Licensed under the Apache License, Version 2.0 or the MIT License.
 # SPDX-License-Identifier: Apache-2.0 OR MIT
-# Copyright Tock Contributors 2022.
+# Copyright Tock Contributors 2024.
+
+include = [
+  "../../../cargo/tock_flags.toml",
+  "../../../cargo/unstable_flags.toml",
+]
+
+[build]
+target = "thumbv7em-none-eabi"
 
 [target.'cfg(target_arch = "arm")']
 runner = "./run.sh"
+
+[unstable]
+config-include = true

--- a/boards/apollo3/redboard_artemis_nano/Makefile
+++ b/boards/apollo3/redboard_artemis_nano/Makefile
@@ -49,4 +49,4 @@ test:
 	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
-	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" OBJCOPY=${OBJCOPY} PORT=$(PORT) $(CARGO) test $(CARGO_FLAGS_TOCK_NO_BUILD_STD) $(NO_RUN) --bin $(PLATFORM) --release
+	$(Q)OBJCOPY=${OBJCOPY} PORT=$(PORT) $(CARGO) test $(NO_RUN) --bin $(PLATFORM) --release

--- a/boards/apollo3/redboard_artemis_nano/Makefile
+++ b/boards/apollo3/redboard_artemis_nano/Makefile
@@ -4,8 +4,6 @@
 
 # Makefile for building the tock kernel for the RedBoard Artemis Nano platform
 #
-TARGET=thumbv7em-none-eabi
-PLATFORM=redboard_artemis_nano
 
 include ../../Makefile.common
 

--- a/boards/arty_e21/.cargo/config.toml
+++ b/boards/arty_e21/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "riscv32imac-unknown-none-elf"
 

--- a/boards/arty_e21/.cargo/config.toml
+++ b/boards/arty_e21/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "riscv32imac-unknown-none-elf"
 
+[unstable]
+config-include = true

--- a/boards/arty_e21/.cargo/config.toml
+++ b/boards/arty_e21/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "riscv32imac-unknown-none-elf"
+

--- a/boards/arty_e21/.cargo/config.toml
+++ b/boards/arty_e21/.cargo/config.toml
@@ -5,6 +5,7 @@
 include = [
   "../../cargo/tock_flags.toml",
   "../../cargo/unstable_flags.toml",
+  "../../cargo/riscv_flags.toml",
 ]
 
 [build]

--- a/boards/arty_e21/Makefile
+++ b/boards/arty_e21/Makefile
@@ -4,9 +4,6 @@
 
 # Makefile for building the tock kernel for the HiFive1 platform
 
-TARGET=riscv32imac-unknown-none-elf
-PLATFORM=arty_e21
-
 include ../Makefile.common
 
 TOCKLOADER=tockloader

--- a/boards/build.rs
+++ b/boards/build.rs
@@ -24,6 +24,8 @@ fn main() {
         panic!("Boards must provide a `layout.ld` link script file");
     }
 
+    println!("cargo:rustc-link-arg=-L{}", std::env!("CARGO_MANIFEST_DIR"));
+
     track_linker_script(LINKER_SCRIPT);
 }
 

--- a/boards/build.rs
+++ b/boards/build.rs
@@ -24,6 +24,8 @@ fn main() {
         panic!("Boards must provide a `layout.ld` link script file");
     }
 
+    // Include the folder where the board's Cargo.toml is in the linker file
+    // search path.
     println!("cargo:rustc-link-arg=-L{}", std::env!("CARGO_MANIFEST_DIR"));
     // `-Tlayout.ld`: Use the linker script `layout.ld` all boards must provide.
     println!("cargo:rustc-link-arg=-T{}", LINKER_SCRIPT);

--- a/boards/build.rs
+++ b/boards/build.rs
@@ -25,6 +25,7 @@ fn main() {
     }
 
     println!("cargo:rustc-link-arg=-L{}", std::env!("CARGO_MANIFEST_DIR"));
+    println!("cargo:rustc-link-arg=-T{}", LINKER_SCRIPT);
 
     track_linker_script(LINKER_SCRIPT);
 }

--- a/boards/build.rs
+++ b/boards/build.rs
@@ -25,6 +25,7 @@ fn main() {
     }
 
     println!("cargo:rustc-link-arg=-L{}", std::env!("CARGO_MANIFEST_DIR"));
+    // `-Tlayout.ld`: Use the linker script `layout.ld` all boards must provide.
     println!("cargo:rustc-link-arg=-T{}", LINKER_SCRIPT);
 
     track_linker_script(LINKER_SCRIPT);

--- a/boards/build.rs
+++ b/boards/build.rs
@@ -24,6 +24,33 @@ fn main() {
         panic!("Boards must provide a `layout.ld` link script file");
     }
 
+    // The `RUSTFLAGS` that the Tock config files set can be easily overridden
+    // by command line flags. The build will still succeed but the resulting
+    // binary may be invalid as it was not built with the intended flags. This
+    // check seeks to prevent that. Our approach is we set a sentinel flag in
+    // our configuration file and then check that it is set here. If it isn't,
+    // the flags were overwritten and the build will be invalid.
+    //
+    // We only do this check if we are actually building for an embedded target
+    // (i.e., the TARGET is not the same as the HOST). This avoids a false
+    // positive when running tools like `cargo clippy`.
+    //
+    // If you are intentionally not using the standard Tock config files, set
+    // `cfg-tock-buildflagssentinel` in your cargo config to prevent this
+    // error.
+    if std::env::var("HOST") != std::env::var("TARGET") {
+        let rust_flags = std::env::var("CARGO_ENCODED_RUSTFLAGS");
+        if !rust_flags
+            .iter()
+            .any(|f| f.contains("cfg_tock_buildflagssentinel"))
+        {
+            panic!(
+                "Incorrect build configuration. \
+            Verify you have not unintentionally set the RUSTFLAGS environment variable."
+            );
+        }
+    }
+
     // Include the folder where the board's Cargo.toml is in the linker file
     // search path.
     println!("cargo:rustc-link-arg=-L{}", std::env!("CARGO_MANIFEST_DIR"));

--- a/boards/cargo/README.md
+++ b/boards/cargo/README.md
@@ -1,0 +1,27 @@
+Cargo Configuration Files
+=========================
+
+This folder contains [cargo configuration
+files](https://doc.rust-lang.org/cargo/reference/config.html) that Tock uses for
+building the kernel for different boards. As different platforms use different
+flags, each board can individually include these configuration files as needed.
+
+
+Using a Cargo Configuration File
+--------------------------------
+
+To use one of these configurations in a board build file, the board's
+`.cargo/config.toml` file must use the `include` key. This currently (as of July
+2024) requires the `config-include` nightly feature.
+
+Example:
+
+```toml
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
+[unstable]
+config-include = true
+```

--- a/boards/cargo/panic_abort_tests.toml
+++ b/boards/cargo/panic_abort_tests.toml
@@ -1,0 +1,9 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
+[unstable]
+# Build test crates with the `panic = "abort"` strategy. Tests use `unwind` by
+# default which causes incompatibility with `core` built via `-Zbuild-std`.
+# This should be included on platforms that have tests defined.
+panic-abort-tests = true

--- a/boards/cargo/riscv_flags.toml
+++ b/boards/cargo/riscv_flags.toml
@@ -1,0 +1,16 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
+# RISC-V-specific flags.
+
+[build]
+rustflags = [
+  # NOTE: This flag causes kernel panics on some ARM cores. Since the size
+  # benefit is almost exclusively for RISC-V, we only apply it for those
+  # targets.
+  "-C", "force-frame-pointers=no",
+  # Ensure relocations generated is eligible for linker relaxation.
+  # This provides huge space savings.
+  "-C", "target-feature=+relax",
+]

--- a/boards/cargo/tock_flags.toml
+++ b/boards/cargo/tock_flags.toml
@@ -28,8 +28,3 @@ rustflags = [
   # Enable link-time-optimization
   "-C", "lto",
 ]
-
-[unstable]
-unstable-options = true
-build-std = ["core", "compiler_builtins" ]
-

--- a/boards/cargo/tock_flags.toml
+++ b/boards/cargo/tock_flags.toml
@@ -29,3 +29,9 @@ rustflags = [
   # Enable link-time-optimization
   "-C", "lto",
 ]
+
+[target.test]
+rustdocflags = [
+  "-D", "warnings",
+  "--document-private-items"
+]

--- a/boards/cargo/tock_flags.toml
+++ b/boards/cargo/tock_flags.toml
@@ -24,6 +24,7 @@ rustflags = [
   # Opt-in to Rust v0 symbol mangling scheme.  See
   # https://github.com/rust-lang/rust/issues/60705 and
   # https://github.com/tock/tock/issues/3529.
+  # https://github.com/rust-lang/rust/pull/89917 tracks this becoming the default, then we can remove this.
   "-C", "symbol-mangling-version=v0",
   # Enable link-time-optimization
   "-C", "lto",

--- a/boards/cargo/tock_flags.toml
+++ b/boards/cargo/tock_flags.toml
@@ -4,6 +4,9 @@
 
 [build]
 rustflags = [
+  # Set a sentinel cfg flag so that we know this configuration file was included
+  # in the build. This is checked in build.rs.
+  "--cfg", "cfg_tock_buildflagssentinel",
   # Tell rustc to use the LLVM linker. This avoids needing GCC as a dependency
   # to build the kernel.
   "-C", "linker=rust-lld",

--- a/boards/cargo/tock_flags.toml
+++ b/boards/cargo/tock_flags.toml
@@ -24,13 +24,18 @@ rustflags = [
   # Opt-in to Rust v0 symbol mangling scheme.  See
   # https://github.com/rust-lang/rust/issues/60705 and
   # https://github.com/tock/tock/issues/3529.
-  # https://github.com/rust-lang/rust/pull/89917 tracks this becoming the default, then we can remove this.
+  # https://github.com/rust-lang/rust/pull/89917 tracks this becoming the
+  # default, then we can remove this.
   "-C", "symbol-mangling-version=v0",
   # Enable link-time-optimization
   "-C", "lto",
+  # Have rustc generate stack sizes for analyzing the size of stack frames.
+  "-Z", "emit-stack-sizes",
 ]
-
 rustdocflags = [
+  # Error if there are warnings. This allows CI to fail on warnings.
   "-D", "warnings",
+  # Document internal code. This is helpful for understanding how the kernel
+  # works and developing within crates.
   "--document-private-items"
 ]

--- a/boards/cargo/tock_flags.toml
+++ b/boards/cargo/tock_flags.toml
@@ -30,7 +30,6 @@ rustflags = [
   "-C", "lto",
 ]
 
-[target.test]
 rustdocflags = [
   "-D", "warnings",
   "--document-private-items"

--- a/boards/cargo/unstable_flags.toml
+++ b/boards/cargo/unstable_flags.toml
@@ -14,3 +14,6 @@ build-std = ["core", "compiler_builtins" ]
 #   produce smaller implementations for certain algorithms. See
 #   https://github.com/rust-lang/rust/pull/125011 for more details.
 build-std-features = ["core/optimize_for_size"]
+# Remove machine-specific paths from the binary. This helps create reproducible
+# builds.
+trim-paths = true

--- a/boards/cargo/unstable_flags.toml
+++ b/boards/cargo/unstable_flags.toml
@@ -4,4 +4,13 @@
 
 [unstable]
 unstable-options = true
+# - `-Z build-std=core,compiler_builtins`: Build the std library from source
+#   using our optimization settings. This leads to significantly smaller binary
+#   sizes, and makes debugging easier since debug information for the core
+#   library is included in the resulting .elf file. See
+#   https://github.com/tock/tock/pull/2847 for more details.
 build-std = ["core", "compiler_builtins" ]
+# - `optimize_for_size`: Sets a feature flag in the core library that aims to
+#   produce smaller implementations for certain algorithms. See
+#   https://github.com/rust-lang/rust/pull/125011 for more details.
+build-std-features = ["core/optimize_for_size"]

--- a/boards/cargo/unstable_flags.toml
+++ b/boards/cargo/unstable_flags.toml
@@ -1,0 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
+[unstable]
+unstable-options = true
+build-std = ["core", "compiler_builtins" ]

--- a/boards/cargo/virtual_function_elimination.toml
+++ b/boards/cargo/virtual_function_elimination.toml
@@ -1,0 +1,14 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
+[build]
+rustflags = [
+  # `virtual-function-elimination` reduces the size of binaries, but is still
+  # experimental and has some possible miscompilation issues.
+  #
+  # For details on virtual-function-elimination see:
+  # https://github.com/rust-lang/rust/pull/96285 and
+  # https://github.com/rust-lang/rust/issues/68262 for general tracking
+  "-Z", "virtual-function-elimination",
+]

--- a/boards/clue_nrf52840/.cargo/config.toml
+++ b/boards/clue_nrf52840/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "thumbv7em-none-eabi"
 

--- a/boards/clue_nrf52840/.cargo/config.toml
+++ b/boards/clue_nrf52840/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "thumbv7em-none-eabi"
+

--- a/boards/clue_nrf52840/.cargo/config.toml
+++ b/boards/clue_nrf52840/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "thumbv7em-none-eabi"
 
+[unstable]
+config-include = true

--- a/boards/clue_nrf52840/Makefile
+++ b/boards/clue_nrf52840/Makefile
@@ -4,10 +4,6 @@
 
 # Makefile for building the tock kernel for the CLUE nRF52840 board.
 
-TOCK_ARCH=cortex-m4
-TARGET=thumbv7em-none-eabi
-PLATFORM=clue_nrf52840
-
 include ../Makefile.common
 
 ifdef PORT

--- a/boards/configurations/nrf52840dk/.cargo/config.toml
+++ b/boards/configurations/nrf52840dk/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "thumbv7em-none-eabi"
 

--- a/boards/configurations/nrf52840dk/.cargo/config.toml
+++ b/boards/configurations/nrf52840dk/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "thumbv7em-none-eabi"
+

--- a/boards/configurations/nrf52840dk/.cargo/config.toml
+++ b/boards/configurations/nrf52840dk/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../../cargo/tock_flags.toml",
+  "../../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "thumbv7em-none-eabi"
 
+[unstable]
+config-include = true

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-sha256/Makefile
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-sha256/Makefile
@@ -2,8 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
-TARGET=thumbv7em-none-eabi
-PLATFORM=nrf52840dk-test-appid-sha256
-
 include ../../../Makefile.common
 include ../nrf52840dk.mk

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/Makefile
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/Makefile
@@ -2,8 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
-TARGET=thumbv7em-none-eabi
-PLATFORM=nrf52840dk-test-appid-tbf
-
 include ../../../Makefile.common
 include ../nrf52840dk.mk

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/Makefile
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/Makefile
@@ -2,8 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
-TARGET=thumbv7em-none-eabi
-PLATFORM=nrf52840dk-test-kernel
-
 include ../../../Makefile.common
 include ../nrf52840dk.mk

--- a/boards/esp32-c3-devkitM-1/.cargo/config.toml
+++ b/boards/esp32-c3-devkitM-1/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2022.
+
 [build]
 target = "riscv32imc-unknown-none-elf"
 

--- a/boards/esp32-c3-devkitM-1/.cargo/config.toml
+++ b/boards/esp32-c3-devkitM-1/.cargo/config.toml
@@ -1,6 +1,5 @@
-# Licensed under the Apache License, Version 2.0 or the MIT License.
-# SPDX-License-Identifier: Apache-2.0 OR MIT
-# Copyright Tock Contributors 2022.
+[build]
+target = "riscv32imc-unknown-none-elf"
 
 [target.'cfg(target_arch = "riscv32")']
 runner = "./run.sh"

--- a/boards/esp32-c3-devkitM-1/.cargo/config.toml
+++ b/boards/esp32-c3-devkitM-1/.cargo/config.toml
@@ -6,6 +6,7 @@ include = [
   "../../cargo/tock_flags.toml",
   "../../cargo/unstable_flags.toml",
   "../../cargo/riscv_flags.toml",
+  "../../cargo/panic_abort_tests.toml",
 ]
 
 [build]

--- a/boards/esp32-c3-devkitM-1/.cargo/config.toml
+++ b/boards/esp32-c3-devkitM-1/.cargo/config.toml
@@ -2,8 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2022.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "riscv32imc-unknown-none-elf"
 
 [target.'cfg(target_arch = "riscv32")']
 runner = "./run.sh"
+
+[unstable]
+config-include = true

--- a/boards/esp32-c3-devkitM-1/.cargo/config.toml
+++ b/boards/esp32-c3-devkitM-1/.cargo/config.toml
@@ -5,6 +5,7 @@
 include = [
   "../../cargo/tock_flags.toml",
   "../../cargo/unstable_flags.toml",
+  "../../cargo/riscv_flags.toml",
 ]
 
 [build]

--- a/boards/esp32-c3-devkitM-1/Makefile
+++ b/boards/esp32-c3-devkitM-1/Makefile
@@ -30,4 +30,4 @@ test:
 	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp ../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/
-	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" $(CARGO) test $(CARGO_FLAGS_TOCK_NO_BUILD_STD) $(NO_RUN) --bin $(PLATFORM) --release
+	$(Q)$(CARGO) test $(NO_RUN) --bin $(PLATFORM) --release

--- a/boards/esp32-c3-devkitM-1/Makefile
+++ b/boards/esp32-c3-devkitM-1/Makefile
@@ -4,8 +4,6 @@
 
 # Makefile for building the tock kernel for the ESP32-C3 platform
 
-TARGET=riscv32imc-unknown-none-elf
-PLATFORM=esp32-c3-board
 RISC_PREFIX = riscv64-linux-gnu
 
 include ../Makefile.common

--- a/boards/hail/.cargo/config.toml
+++ b/boards/hail/.cargo/config.toml
@@ -4,4 +4,28 @@
 
 [build]
 target = "thumbv7em-none-eabi"
-
+rustflags = [
+  # Tell rustc to use the LLVM linker. This avoids needing GCC as a dependency
+  # to build the kernel.
+  "-C", "linker=rust-lld",
+  # Use the LLVM lld executable with the `-flavor gnu` flag.
+  "-C", "linker-flavor=ld.lld",
+  # Use static relocation model. See https://github.com/tock/tock/pull/2853
+  "-C", "relocation-model=static",
+  # lld by default uses a default page size to align program sections. Tock
+  # expects that program sections are set back-to-back. `-nmagic` instructs the
+  # linker to not page-align sections.
+  "-C", "link-arg=-nmagic",
+  # Identical Code Folding (ICF) set to all. This tells the linker to be more
+  # aggressive about removing duplicate code. The default is `safe`, and the
+  # downside to `all` is that different functions in the code can end up with
+  # the same address in the binary. However, it can save a fair bit of code
+  # size.
+  "-C", "link-arg=-icf=all",
+  # Opt-in to Rust v0 symbol mangling scheme.  See
+  # https://github.com/rust-lang/rust/issues/60705 and
+  # https://github.com/tock/tock/issues/3529.
+  "-C", "symbol-mangling-version=v0",
+  # Enable link-time-optimization
+  "-C", "lto",
+]

--- a/boards/hail/.cargo/config.toml
+++ b/boards/hail/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "thumbv7em-none-eabi"
 

--- a/boards/hail/.cargo/config.toml
+++ b/boards/hail/.cargo/config.toml
@@ -8,6 +8,9 @@
 [build]
 target = "thumbv7em-none-eabi"
 rustflags = [
+  # Set a sentinel cfg flag so that we know this configuration file was included
+  # in the build. This is checked in build.rs.
+  "--cfg", "cfg_tock_buildflagssentinel",
   # Tell rustc to use the LLVM linker. This avoids needing GCC as a dependency
   # to build the kernel.
   "-C", "linker=rust-lld",

--- a/boards/hail/.cargo/config.toml
+++ b/boards/hail/.cargo/config.toml
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+# Because we compile hail with stable rust we cannot use the `include =` key in
+# this config file. Therefore we have to copy the relevant flags here.
+
 [build]
 target = "thumbv7em-none-eabi"
 rustflags = [

--- a/boards/hail/.cargo/config.toml
+++ b/boards/hail/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "thumbv7em-none-eabi"
+

--- a/boards/hail/Makefile
+++ b/boards/hail/Makefile
@@ -5,7 +5,6 @@
 # Makefile for building the tock kernel for the Hail platform
 
 TARGET=thumbv7em-none-eabi
-PLATFORM=hail
 USE_STABLE_RUST=1
 
 include ../Makefile.common

--- a/boards/hifive1/.cargo/config.toml
+++ b/boards/hifive1/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "riscv32imac-unknown-none-elf"
 

--- a/boards/hifive1/.cargo/config.toml
+++ b/boards/hifive1/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "riscv32imac-unknown-none-elf"
 
+[unstable]
+config-include = true

--- a/boards/hifive1/.cargo/config.toml
+++ b/boards/hifive1/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "riscv32imac-unknown-none-elf"
+

--- a/boards/hifive1/.cargo/config.toml
+++ b/boards/hifive1/.cargo/config.toml
@@ -5,6 +5,7 @@
 include = [
   "../../cargo/tock_flags.toml",
   "../../cargo/unstable_flags.toml",
+  "../../cargo/riscv_flags.toml",
 ]
 
 [build]

--- a/boards/hifive1/Makefile
+++ b/boards/hifive1/Makefile
@@ -4,8 +4,6 @@
 
 # Makefile for building the tock kernel for the HiFive1 platform
 
-TARGET=riscv32imac-unknown-none-elf
-PLATFORM=hifive1
 QEMU ?= qemu-system-riscv32
 
 include ../Makefile.common

--- a/boards/hifive_inventor/.cargo/config.toml
+++ b/boards/hifive_inventor/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "riscv32imac-unknown-none-elf"
 

--- a/boards/hifive_inventor/.cargo/config.toml
+++ b/boards/hifive_inventor/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "riscv32imac-unknown-none-elf"
 
+[unstable]
+config-include = true

--- a/boards/hifive_inventor/.cargo/config.toml
+++ b/boards/hifive_inventor/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "riscv32imac-unknown-none-elf"
+

--- a/boards/hifive_inventor/.cargo/config.toml
+++ b/boards/hifive_inventor/.cargo/config.toml
@@ -5,6 +5,7 @@
 include = [
   "../../cargo/tock_flags.toml",
   "../../cargo/unstable_flags.toml",
+  "../../cargo/riscv_flags.toml",
 ]
 
 [build]

--- a/boards/hifive_inventor/Makefile
+++ b/boards/hifive_inventor/Makefile
@@ -4,8 +4,6 @@
 
 # Makefile for building the tock kernel for the HiFive Inventor platform
 
-TARGET=riscv32imac-unknown-none-elf
-PLATFORM=hifive_inventor
 QEMU ?= qemu-system-riscv32
 
 include ../Makefile.common

--- a/boards/imix/.cargo/config.toml
+++ b/boards/imix/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "thumbv7em-none-eabi"
 

--- a/boards/imix/.cargo/config.toml
+++ b/boards/imix/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "thumbv7em-none-eabi"
+

--- a/boards/imix/.cargo/config.toml
+++ b/boards/imix/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "thumbv7em-none-eabi"
 
+[unstable]
+config-include = true

--- a/boards/imix/Makefile
+++ b/boards/imix/Makefile
@@ -4,9 +4,6 @@
 
 # Makefile for building the tock kernel for the Imix platform
 
-TARGET=thumbv7em-none-eabi
-PLATFORM=imix
-
 include ../Makefile.common
 
 TOCKLOADER=tockloader

--- a/boards/imxrt1050-evkb/.cargo/config.toml
+++ b/boards/imxrt1050-evkb/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "thumbv7em-none-eabi"
 

--- a/boards/imxrt1050-evkb/.cargo/config.toml
+++ b/boards/imxrt1050-evkb/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "thumbv7em-none-eabi"
+

--- a/boards/imxrt1050-evkb/.cargo/config.toml
+++ b/boards/imxrt1050-evkb/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "thumbv7em-none-eabi"
 
+[unstable]
+config-include = true

--- a/boards/imxrt1050-evkb/Makefile
+++ b/boards/imxrt1050-evkb/Makefile
@@ -4,9 +4,6 @@
 
 # Makefile for building the tock kernel for the i.MX RT1052 platform
 
-TARGET=thumbv7em-none-eabi
-PLATFORM=imxrt1050-evkb
-
 include ../Makefile.common
 
 # Default target for installing the kernel.

--- a/boards/litex/.cargo/config.toml
+++ b/boards/litex/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "riscv32imc-unknown-none-elf"
 

--- a/boards/litex/.cargo/config.toml
+++ b/boards/litex/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "riscv32imc-unknown-none-elf"
 
+[unstable]
+config-include = true

--- a/boards/litex/.cargo/config.toml
+++ b/boards/litex/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "riscv32imc-unknown-none-elf"
+

--- a/boards/litex/.cargo/config.toml
+++ b/boards/litex/.cargo/config.toml
@@ -5,6 +5,7 @@
 include = [
   "../../cargo/tock_flags.toml",
   "../../cargo/unstable_flags.toml",
+  "../../cargo/riscv_flags.toml",
 ]
 
 [build]

--- a/boards/litex/arty/.cargo/config.toml
+++ b/boards/litex/arty/.cargo/config.toml
@@ -3,9 +3,9 @@
 # Copyright Tock Contributors 2024.
 
 include = [
-  "../../cargo/tock_flags.toml",
-  "../../cargo/unstable_flags.toml",
-  "../../cargo/riscv_flags.toml",
+  "../../../cargo/tock_flags.toml",
+  "../../../cargo/unstable_flags.toml",
+  "../../../cargo/riscv_flags.toml",
 ]
 
 [build]

--- a/boards/litex/arty/Makefile
+++ b/boards/litex/arty/Makefile
@@ -5,8 +5,5 @@
 # Makefile for building the tock kernel for a LiteX SoC targeting a
 # Digilent Arty-A7 FPGA development board
 
-TARGET=riscv32imc-unknown-none-elf
-PLATFORM=litex_arty
-
 include ../../Makefile.common
 

--- a/boards/litex/sim/.cargo/config.toml
+++ b/boards/litex/sim/.cargo/config.toml
@@ -3,12 +3,13 @@
 # Copyright Tock Contributors 2024.
 
 include = [
-  "../../cargo/tock_flags.toml",
-  "../../cargo/unstable_flags.toml",
+  "../../../cargo/tock_flags.toml",
+  "../../../cargo/unstable_flags.toml",
+  "../../../cargo/riscv_flags.toml",
 ]
 
 [build]
-target = "thumbv7em-none-eabi"
+target = "riscv32imc-unknown-none-elf"
 
 [unstable]
 config-include = true

--- a/boards/litex/sim/Makefile
+++ b/boards/litex/sim/Makefile
@@ -5,8 +5,5 @@
 # Makefile for building the tock kernel for a LiteX SoC running in a
 # Verilated simulation
 
-TARGET=riscv32imc-unknown-none-elf
-PLATFORM=litex_sim
-
 include ../../Makefile.common
 

--- a/boards/makepython-nrf52840/.cargo/config.toml
+++ b/boards/makepython-nrf52840/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "thumbv7em-none-eabi"
 

--- a/boards/makepython-nrf52840/.cargo/config.toml
+++ b/boards/makepython-nrf52840/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "thumbv7em-none-eabi"
+

--- a/boards/makepython-nrf52840/.cargo/config.toml
+++ b/boards/makepython-nrf52840/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "thumbv7em-none-eabi"
 
+[unstable]
+config-include = true

--- a/boards/makepython-nrf52840/Makefile
+++ b/boards/makepython-nrf52840/Makefile
@@ -4,10 +4,6 @@
 
 # Makefile for building the tock kernel for the Arduino Nano 33 BLE board.
 
-TOCK_ARCH=cortex-m4
-TARGET=thumbv7em-none-eabi
-PLATFORM=makepython-nrf52840
-
 include ../Makefile.common
 
 ifdef PORT

--- a/boards/microbit_v2/.cargo/config.toml
+++ b/boards/microbit_v2/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "thumbv7em-none-eabi"
 

--- a/boards/microbit_v2/.cargo/config.toml
+++ b/boards/microbit_v2/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "thumbv7em-none-eabi"
+

--- a/boards/microbit_v2/.cargo/config.toml
+++ b/boards/microbit_v2/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "thumbv7em-none-eabi"
 
+[unstable]
+config-include = true

--- a/boards/microbit_v2/Makefile
+++ b/boards/microbit_v2/Makefile
@@ -4,10 +4,6 @@
 
 # Makefile for building the tock kernel for the BBC microbit v2 board.
 
-TOCK_ARCH=cortex-m4
-TARGET=thumbv7em-none-eabi
-PLATFORM=microbit_v2
-
 include ../Makefile.common
 
 OPENOCD=openocd

--- a/boards/msp_exp432p401r/.cargo/config.toml
+++ b/boards/msp_exp432p401r/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "thumbv7em-none-eabi"
 

--- a/boards/msp_exp432p401r/.cargo/config.toml
+++ b/boards/msp_exp432p401r/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "thumbv7em-none-eabi"
+

--- a/boards/msp_exp432p401r/.cargo/config.toml
+++ b/boards/msp_exp432p401r/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "thumbv7em-none-eabi"
 
+[unstable]
+config-include = true

--- a/boards/msp_exp432p401r/Makefile
+++ b/boards/msp_exp432p401r/Makefile
@@ -4,8 +4,6 @@
 
 # Makefile for building the tock kernel for the MSP-EXP432P401 launchpad
 #
-TARGET=thumbv7em-none-eabi
-PLATFORM=msp-exp432p401r
 
 include ../Makefile.common
 

--- a/boards/nano33ble/.cargo/config.toml
+++ b/boards/nano33ble/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "thumbv7em-none-eabi"
 

--- a/boards/nano33ble/.cargo/config.toml
+++ b/boards/nano33ble/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "thumbv7em-none-eabi"
+

--- a/boards/nano33ble/.cargo/config.toml
+++ b/boards/nano33ble/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "thumbv7em-none-eabi"
 
+[unstable]
+config-include = true

--- a/boards/nano33ble/Makefile
+++ b/boards/nano33ble/Makefile
@@ -4,10 +4,6 @@
 
 # Makefile for building the tock kernel for the Arduino Nano 33 BLE board.
 
-TOCK_ARCH=cortex-m4
-TARGET=thumbv7em-none-eabi
-PLATFORM=nano33ble
-
 include ../Makefile.common
 
 ifdef PORT

--- a/boards/nano33ble_rev2/.cargo/config.toml
+++ b/boards/nano33ble_rev2/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "thumbv7em-none-eabi"
 

--- a/boards/nano33ble_rev2/.cargo/config.toml
+++ b/boards/nano33ble_rev2/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "thumbv7em-none-eabi"
+

--- a/boards/nano33ble_rev2/.cargo/config.toml
+++ b/boards/nano33ble_rev2/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "thumbv7em-none-eabi"
 
+[unstable]
+config-include = true

--- a/boards/nano33ble_rev2/Makefile
+++ b/boards/nano33ble_rev2/Makefile
@@ -4,10 +4,6 @@
 
 # Makefile for building the tock kernel for the Arduino Nano 33 BLE Sense Rev2 board.
 
-TOCK_ARCH=cortex-m4
-TARGET=thumbv7em-none-eabi
-PLATFORM=nano33ble_rev2
-
 include ../Makefile.common
 
 ifdef PORT

--- a/boards/nano_rp2040_connect/.cargo/config.toml
+++ b/boards/nano_rp2040_connect/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "thumbv6m-none-eabi"
 
+[unstable]
+config-include = true

--- a/boards/nano_rp2040_connect/.cargo/config.toml
+++ b/boards/nano_rp2040_connect/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "thumbv6m-none-eabi"
 

--- a/boards/nano_rp2040_connect/.cargo/config.toml
+++ b/boards/nano_rp2040_connect/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "thumbv6m-none-eabi"
+

--- a/boards/nano_rp2040_connect/Makefile
+++ b/boards/nano_rp2040_connect/Makefile
@@ -4,10 +4,6 @@
 
 # Makefile for building the tock kernel for the Arduino Nano RP2040 Connect board.
 
-TOCK_ARCH=cortex-m0p
-TARGET=thumbv6m-none-eabi
-PLATFORM=nano_rp2040_connect
-
 include ../Makefile.common
 
 KERNEL=$(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf

--- a/boards/nordic/.cargo/config.toml
+++ b/boards/nordic/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "thumbv7em-none-eabi"
 

--- a/boards/nordic/.cargo/config.toml
+++ b/boards/nordic/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "thumbv7em-none-eabi"
+

--- a/boards/nordic/.cargo/config.toml
+++ b/boards/nordic/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "thumbv7em-none-eabi"
 
+[unstable]
+config-include = true

--- a/boards/nordic/nrf52840_dongle/.cargo/config.toml
+++ b/boards/nordic/nrf52840_dongle/.cargo/config.toml
@@ -3,8 +3,8 @@
 # Copyright Tock Contributors 2024.
 
 include = [
-  "../../cargo/tock_flags.toml",
-  "../../cargo/unstable_flags.toml",
+  "../../../cargo/tock_flags.toml",
+  "../../../cargo/unstable_flags.toml",
 ]
 
 [build]

--- a/boards/nordic/nrf52840_dongle/Makefile
+++ b/boards/nordic/nrf52840_dongle/Makefile
@@ -4,9 +4,6 @@
 
 # Makefile for building the tock kernel for the nRF development kit
 
-TARGET=thumbv7em-none-eabi
-PLATFORM=nrf52840_dongle
-
 include ../../Makefile.common
 
 TOCKLOADER=tockloader

--- a/boards/nordic/nrf52840dk/.cargo/config.toml
+++ b/boards/nordic/nrf52840dk/.cargo/config.toml
@@ -1,0 +1,14 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
+include = [
+  "../../../cargo/tock_flags.toml",
+  "../../../cargo/unstable_flags.toml",
+]
+
+[build]
+target = "thumbv7em-none-eabi"
+
+[unstable]
+config-include = true

--- a/boards/nordic/nrf52840dk/.cargo/config.toml
+++ b/boards/nordic/nrf52840dk/.cargo/config.toml
@@ -1,0 +1,7 @@
+[build]
+target = "thumbv7em-none-eabi"
+rustflags = [
+  "-C", "link-arg=-Tlayout.ld",
+  "-C", "lto",
+]
+

--- a/boards/nordic/nrf52840dk/.cargo/config.toml
+++ b/boards/nordic/nrf52840dk/.cargo/config.toml
@@ -1,7 +1,0 @@
-[build]
-target = "thumbv7em-none-eabi"
-rustflags = [
-  "-C", "link-arg=-Tlayout.ld",
-  "-C", "lto",
-]
-

--- a/boards/nordic/nrf52840dk/Makefile
+++ b/boards/nordic/nrf52840dk/Makefile
@@ -4,9 +4,6 @@
 
 # Makefile for building the tock kernel for the nRF development kit
 
-TARGET=thumbv7em-none-eabi
-PLATFORM=nrf52840dk
-
 include ../../Makefile.common
 
 TOCKLOADER=tockloader

--- a/boards/nordic/nrf52dk/.cargo/config.toml
+++ b/boards/nordic/nrf52dk/.cargo/config.toml
@@ -1,0 +1,14 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
+include = [
+  "../../../cargo/tock_flags.toml",
+  "../../../cargo/unstable_flags.toml",
+]
+
+[build]
+target = "thumbv7em-none-eabi"
+
+[unstable]
+config-include = true

--- a/boards/nordic/nrf52dk/Makefile
+++ b/boards/nordic/nrf52dk/Makefile
@@ -4,9 +4,6 @@
 
 # Makefile for building the tock kernel for the nRF52 development kit
 
-TARGET=thumbv7em-none-eabi
-PLATFORM=nrf52dk
-
 include ../../Makefile.common
 
 TOCKLOADER=tockloader

--- a/boards/nucleo_f429zi/.cargo/config.toml
+++ b/boards/nucleo_f429zi/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "thumbv7em-none-eabi"
 

--- a/boards/nucleo_f429zi/.cargo/config.toml
+++ b/boards/nucleo_f429zi/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "thumbv7em-none-eabi"
+

--- a/boards/nucleo_f429zi/.cargo/config.toml
+++ b/boards/nucleo_f429zi/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "thumbv7em-none-eabi"
 
+[unstable]
+config-include = true

--- a/boards/nucleo_f429zi/Makefile
+++ b/boards/nucleo_f429zi/Makefile
@@ -4,8 +4,6 @@
 
 # Makefile for building the tock kernel for the NUCLEO-429ZI platform
 #
-TARGET=thumbv7em-none-eabi
-PLATFORM=nucleo_f429zi
 
 include ../Makefile.common
 

--- a/boards/nucleo_f446re/.cargo/config.toml
+++ b/boards/nucleo_f446re/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "thumbv7em-none-eabi"
 

--- a/boards/nucleo_f446re/.cargo/config.toml
+++ b/boards/nucleo_f446re/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "thumbv7em-none-eabi"
+

--- a/boards/nucleo_f446re/.cargo/config.toml
+++ b/boards/nucleo_f446re/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "thumbv7em-none-eabi"
 
+[unstable]
+config-include = true

--- a/boards/nucleo_f446re/Makefile
+++ b/boards/nucleo_f446re/Makefile
@@ -4,8 +4,6 @@
 
 # Makefile for building the tock kernel for the NUCLEO-446RE platform
 #
-TARGET=thumbv7em-none-eabi
-PLATFORM=nucleo_f446re
 
 include ../Makefile.common
 

--- a/boards/opentitan/.cargo/config.toml
+++ b/boards/opentitan/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "riscv32imc-unknown-none-elf"
 

--- a/boards/opentitan/.cargo/config.toml
+++ b/boards/opentitan/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "riscv32imc-unknown-none-elf"
+

--- a/boards/opentitan/.cargo/config.toml
+++ b/boards/opentitan/.cargo/config.toml
@@ -1,7 +1,0 @@
-# Licensed under the Apache License, Version 2.0 or the MIT License.
-# SPDX-License-Identifier: Apache-2.0 OR MIT
-# Copyright Tock Contributors 2024.
-
-[build]
-target = "riscv32imc-unknown-none-elf"
-

--- a/boards/opentitan/earlgrey-cw310/.cargo/config.toml
+++ b/boards/opentitan/earlgrey-cw310/.cargo/config.toml
@@ -2,6 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2022.
 
+include = [
+  "../../../cargo/tock_flags.toml",
+  "../../../cargo/unstable_flags.toml",
+  "../../cargo/riscv_flags.toml",
+]
+
 [build]
 target = "riscv32imc-unknown-none-elf"
 rustflags = [
@@ -11,3 +17,5 @@ rustflags = [
 [target.'cfg(target_arch = "riscv32")']
 runner = "./run.sh"
 
+[unstable]
+config-include = true

--- a/boards/opentitan/earlgrey-cw310/.cargo/config.toml
+++ b/boards/opentitan/earlgrey-cw310/.cargo/config.toml
@@ -1,5 +1,9 @@
 # Licensed under the Apache License, Version 2.0 or the MIT License.
 # SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2022.
 
 [target.'cfg(target_arch = "riscv32")']

--- a/boards/opentitan/earlgrey-cw310/.cargo/config.toml
+++ b/boards/opentitan/earlgrey-cw310/.cargo/config.toml
@@ -6,13 +6,11 @@ include = [
   "../../../cargo/tock_flags.toml",
   "../../../cargo/unstable_flags.toml",
   "../../../cargo/riscv_flags.toml",
+  "../../../cargo/virtual_function_elimination.toml",
 ]
 
 [build]
 target = "riscv32imc-unknown-none-elf"
-rustflags = [
-  "-Z", "virtual-function-elimination"
-]
 
 [target.'cfg(target_arch = "riscv32")']
 runner = "./run.sh"

--- a/boards/opentitan/earlgrey-cw310/.cargo/config.toml
+++ b/boards/opentitan/earlgrey-cw310/.cargo/config.toml
@@ -7,6 +7,7 @@ include = [
   "../../../cargo/unstable_flags.toml",
   "../../../cargo/riscv_flags.toml",
   "../../../cargo/virtual_function_elimination.toml",
+  "../../../cargo/panic_abort_tests.toml",
 ]
 
 [build]

--- a/boards/opentitan/earlgrey-cw310/.cargo/config.toml
+++ b/boards/opentitan/earlgrey-cw310/.cargo/config.toml
@@ -1,10 +1,13 @@
 # Licensed under the Apache License, Version 2.0 or the MIT License.
 # SPDX-License-Identifier: Apache-2.0 OR MIT
-# Copyright Tock Contributors 2024.
-
-# Licensed under the Apache License, Version 2.0 or the MIT License.
-# SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2022.
+
+[build]
+target = "riscv32imc-unknown-none-elf"
+rustflags = [
+  "-Z", "virtual-function-elimination"
+]
 
 [target.'cfg(target_arch = "riscv32")']
 runner = "./run.sh"
+

--- a/boards/opentitan/earlgrey-cw310/.cargo/config.toml
+++ b/boards/opentitan/earlgrey-cw310/.cargo/config.toml
@@ -5,7 +5,7 @@
 include = [
   "../../../cargo/tock_flags.toml",
   "../../../cargo/unstable_flags.toml",
-  "../../cargo/riscv_flags.toml",
+  "../../../cargo/riscv_flags.toml",
 ]
 
 [build]

--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -17,8 +17,6 @@ QEMU_ENTRY_POINT=0x20000400
 # earlgrey_es branch. earlgrey_es is what is being taped out in the first
 # Earlgrey chip.
 OPENTITAN_SUPPORTED_SHA := edf5e35f5d50a5377641c90a315109a351de7635
-# Enable virtual function elimination
-VFUNC_ELIM=1
 
 
 include ../../Makefile.common

--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -27,10 +27,6 @@ ifneq ($(BOARD_CONFIGURATION),)
 	CARGO_FLAGS += --no-default-features --features=$(BOARD_CONFIGURATION)
 endif
 
-# Build test crates with the `panic = "abort"` strategy. Tests use `unwind` by
-# default which causes incompatability with `core` built via `-Zbuild-std`.
-CARGO_FLAGS += -Zpanic-abort-tests
-
 .PHONY: ot-check
 ifneq ($(OPENTITAN_TREE),)
     OPENTITAN_ACTUAL_SHA := $(shell cd $(OPENTITAN_TREE); git show --pretty=format:"%H" --no-patch)

--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -4,8 +4,6 @@
 
 # Makefile for building the tock kernel for the OpenTitan platform
 
-TARGET=riscv32imc-unknown-none-elf
-PLATFORM=earlgrey-cw310
 FLASHID=--dev-id="0403:6010"
 RISC_PREFIX ?= riscv64-linux-gnu
 QEMU ?= ../../../tools/qemu/build/qemu-system-riscv32

--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -22,8 +22,22 @@ include ../../Makefile.common
 # Pass OpenTitan board configuration option in `BOARD_CONFIGURATION` through
 # Cargo `--features`. Please see `Cargo.toml` for available options.
 ifneq ($(BOARD_CONFIGURATION),)
-	CARGO_FLAGS += --no-default-features --features=$(BOARD_CONFIGURATION)
+	CARGO_FLAGS = --no-default-features --features=$(BOARD_CONFIGURATION)
 endif
+
+.PHONY: check
+check:
+	$(Q)$(CARGO) check $(VERBOSE_FLAGS) $(CARGO_FLAGS)
+
+.PHONY: $(TARGET_PATH)/release/$(PLATFORM)
+$(TARGET_PATH)/release/$(PLATFORM):
+	$(Q)$(CARGO) build $(VERBOSE_FLAGS) $(CARGO_FLAGS) --release
+	$(Q)$(SIZE) $(SIZE_FLAGS) $@
+
+.PHONY: $(TARGET_PATH)/debug/$(PLATFORM)
+$(TARGET_PATH)/debug/$(PLATFORM):
+	$(Q)$(CARGO) build $(VERBOSE_FLAGS) $(CARGO_FLAGS)
+	$(Q)$(SIZE) $(SIZE_FLAGS) $@
 
 .PHONY: ot-check
 ifneq ($(OPENTITAN_TREE),)

--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -99,16 +99,16 @@ endif
 	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
-	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} QEMU_ENTRY_POINT=${QEMU_ENTRY_POINT} TARGET=${TARGET} $(CARGO) test $(CARGO_FLAGS_TOCK) $(NO_RUN) --bin $(PLATFORM) --release
+	$(Q)TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} QEMU_ENTRY_POINT=${QEMU_ENTRY_POINT} TARGET=${TARGET} $(CARGO) test $(CARGO_FLAGS) $(NO_RUN) --bin $(PLATFORM) --release
 
 test-hardware: ot-check
 	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
-	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" OBJCOPY=$(RISC_PREFIX)-objcopy TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} TARGET=${TARGET} $(CARGO) test $(CARGO_FLAGS_TOCK) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests
+	$(Q)OBJCOPY=$(RISC_PREFIX)-objcopy TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} TARGET=${TARGET} $(CARGO) test $(CARGO_FLAGS) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests
 
 test-verilator: ot-check
 	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
-	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" VERILATOR="yes" OBJCOPY=$(RISC_PREFIX)-objcopy TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} TARGET=${TARGET} $(CARGO) test $(CARGO_FLAGS_TOCK) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests,sim_verilator
+	$(Q)VERILATOR="yes" OBJCOPY=$(RISC_PREFIX)-objcopy TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} TARGET=${TARGET} $(CARGO) test $(CARGO_FLAGS) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests,sim_verilator

--- a/boards/particle_boron/.cargo/config.toml
+++ b/boards/particle_boron/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "thumbv7em-none-eabi"
 

--- a/boards/particle_boron/.cargo/config.toml
+++ b/boards/particle_boron/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "thumbv7em-none-eabi"
+

--- a/boards/particle_boron/.cargo/config.toml
+++ b/boards/particle_boron/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "thumbv7em-none-eabi"
 
+[unstable]
+config-include = true

--- a/boards/particle_boron/Makefile
+++ b/boards/particle_boron/Makefile
@@ -4,9 +4,6 @@
 
 # Makefile for building the tock kernel for the Particle Boron
 
-TARGET=thumbv7em-none-eabi
-PLATFORM=particle_boron
-
 include ../Makefile.common
 
 TOCKLOADER=tockloader

--- a/boards/pico_explorer_base/.cargo/config.toml
+++ b/boards/pico_explorer_base/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "thumbv6m-none-eabi"
 
+[unstable]
+config-include = true

--- a/boards/pico_explorer_base/.cargo/config.toml
+++ b/boards/pico_explorer_base/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "thumbv6m-none-eabi"
 

--- a/boards/pico_explorer_base/.cargo/config.toml
+++ b/boards/pico_explorer_base/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "thumbv6m-none-eabi"
+

--- a/boards/pico_explorer_base/Makefile
+++ b/boards/pico_explorer_base/Makefile
@@ -4,10 +4,6 @@
 
 # Makefile for building the tock kernel for the Pico Explorer Base board.
 
-TOCK_ARCH=cortex-m0p
-TARGET=thumbv6m-none-eabi
-PLATFORM=pico_explorer_base
-
 include ../Makefile.common
 
 OPENOCD=openocd

--- a/boards/qemu_rv32_virt/.cargo/config.toml
+++ b/boards/qemu_rv32_virt/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "riscv32imac-unknown-none-elf"
 

--- a/boards/qemu_rv32_virt/.cargo/config.toml
+++ b/boards/qemu_rv32_virt/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "riscv32imac-unknown-none-elf"
 
+[unstable]
+config-include = true

--- a/boards/qemu_rv32_virt/.cargo/config.toml
+++ b/boards/qemu_rv32_virt/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "riscv32imac-unknown-none-elf"
+

--- a/boards/qemu_rv32_virt/.cargo/config.toml
+++ b/boards/qemu_rv32_virt/.cargo/config.toml
@@ -5,6 +5,7 @@
 include = [
   "../../cargo/tock_flags.toml",
   "../../cargo/unstable_flags.toml",
+  "../../cargo/riscv_flags.toml",
 ]
 
 [build]

--- a/boards/qemu_rv32_virt/Makefile
+++ b/boards/qemu_rv32_virt/Makefile
@@ -5,9 +5,6 @@
 # Makefile for building the Tock kernel for the qemu-system-riscv32 `virt`
 # platform / machine type.
 
-TARGET   = riscv32imac-unknown-none-elf
-PLATFORM = qemu_rv32_virt
-
 include ../Makefile.common
 
 QEMU_CMD             := qemu-system-riscv32

--- a/boards/raspberry_pi_pico/.cargo/config.toml
+++ b/boards/raspberry_pi_pico/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "thumbv6m-none-eabi"
 
+[unstable]
+config-include = true

--- a/boards/raspberry_pi_pico/.cargo/config.toml
+++ b/boards/raspberry_pi_pico/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "thumbv6m-none-eabi"
 

--- a/boards/raspberry_pi_pico/.cargo/config.toml
+++ b/boards/raspberry_pi_pico/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "thumbv6m-none-eabi"
+

--- a/boards/raspberry_pi_pico/Makefile
+++ b/boards/raspberry_pi_pico/Makefile
@@ -4,10 +4,6 @@
 
 # Makefile for building the tock kernel for the Pico Explorer Base board.
 
-TOCK_ARCH=cortex-m0p
-TARGET=thumbv6m-none-eabi
-PLATFORM=raspberry_pi_pico
-
 include ../Makefile.common
 
 OPENOCD=openocd

--- a/boards/redboard_redv/.cargo/config.toml
+++ b/boards/redboard_redv/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "riscv32imac-unknown-none-elf"
 

--- a/boards/redboard_redv/.cargo/config.toml
+++ b/boards/redboard_redv/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "riscv32imac-unknown-none-elf"
 
+[unstable]
+config-include = true

--- a/boards/redboard_redv/.cargo/config.toml
+++ b/boards/redboard_redv/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "riscv32imac-unknown-none-elf"
+

--- a/boards/redboard_redv/.cargo/config.toml
+++ b/boards/redboard_redv/.cargo/config.toml
@@ -5,6 +5,7 @@
 include = [
   "../../cargo/tock_flags.toml",
   "../../cargo/unstable_flags.toml",
+  "../../cargo/riscv_flags.toml",
 ]
 
 [build]

--- a/boards/redboard_redv/Makefile
+++ b/boards/redboard_redv/Makefile
@@ -4,8 +4,6 @@
 
 # Makefile for building the tock kernel for the RedV platform
 
-TARGET=riscv32imac-unknown-none-elf
-PLATFORM=redboard_redv
 QEMU ?= qemu-system-riscv32
 
 include ../Makefile.common

--- a/boards/sma_q3/.cargo/config.toml
+++ b/boards/sma_q3/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "thumbv7em-none-eabi"
 

--- a/boards/sma_q3/.cargo/config.toml
+++ b/boards/sma_q3/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "thumbv7em-none-eabi"
+

--- a/boards/sma_q3/.cargo/config.toml
+++ b/boards/sma_q3/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "thumbv7em-none-eabi"
 
+[unstable]
+config-include = true

--- a/boards/sma_q3/Makefile
+++ b/boards/sma_q3/Makefile
@@ -4,9 +4,6 @@
 
 # Makefile for building the tock kernel for the SMA Q3 smart watch
 
-TARGET=thumbv7em-none-eabi
-PLATFORM=sma_q3
-
 include ../Makefile.common
 
 TOCKLOADER=tockloader

--- a/boards/stm32f3discovery/.cargo/config.toml
+++ b/boards/stm32f3discovery/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "thumbv7em-none-eabi"
 

--- a/boards/stm32f3discovery/.cargo/config.toml
+++ b/boards/stm32f3discovery/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "thumbv7em-none-eabi"
+

--- a/boards/stm32f3discovery/.cargo/config.toml
+++ b/boards/stm32f3discovery/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "thumbv7em-none-eabi"
 
+[unstable]
+config-include = true

--- a/boards/stm32f3discovery/Makefile
+++ b/boards/stm32f3discovery/Makefile
@@ -4,8 +4,6 @@
 
 # Makefile for building the tock kernel for the STM32F3DISCOVERY platform
 #
-TARGET=thumbv7em-none-eabi
-PLATFORM=stm32f3discovery
 
 include ../Makefile.common
 

--- a/boards/stm32f412gdiscovery/.cargo/config.toml
+++ b/boards/stm32f412gdiscovery/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "thumbv7em-none-eabi"
 

--- a/boards/stm32f412gdiscovery/.cargo/config.toml
+++ b/boards/stm32f412gdiscovery/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "thumbv7em-none-eabi"
+

--- a/boards/stm32f412gdiscovery/.cargo/config.toml
+++ b/boards/stm32f412gdiscovery/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "thumbv7em-none-eabi"
 
+[unstable]
+config-include = true

--- a/boards/stm32f412gdiscovery/Makefile
+++ b/boards/stm32f412gdiscovery/Makefile
@@ -4,8 +4,6 @@
 
 # Makefile for building the tock kernel for the stm32412gdiscovery platform
 #
-TARGET=thumbv7em-none-eabi
-PLATFORM=stm32f412gdiscovery
 
 include ../Makefile.common
 

--- a/boards/stm32f429idiscovery/.cargo/config.toml
+++ b/boards/stm32f429idiscovery/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "thumbv7em-none-eabi"
 

--- a/boards/stm32f429idiscovery/.cargo/config.toml
+++ b/boards/stm32f429idiscovery/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "thumbv7em-none-eabi"
+

--- a/boards/stm32f429idiscovery/.cargo/config.toml
+++ b/boards/stm32f429idiscovery/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "thumbv7em-none-eabi"
 
+[unstable]
+config-include = true

--- a/boards/stm32f429idiscovery/Makefile
+++ b/boards/stm32f429idiscovery/Makefile
@@ -4,8 +4,6 @@
 
 # Makefile for building the tock kernel for the STM32F429i Discovery board
 #
-TARGET=thumbv7em-none-eabi
-PLATFORM=stm32f429idiscovery
 
 include ../Makefile.common
 

--- a/boards/swervolf/.cargo/config.toml
+++ b/boards/swervolf/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "riscv32imc-unknown-none-elf"
 

--- a/boards/swervolf/.cargo/config.toml
+++ b/boards/swervolf/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "riscv32imc-unknown-none-elf"
 
+[unstable]
+config-include = true

--- a/boards/swervolf/.cargo/config.toml
+++ b/boards/swervolf/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "riscv32imc-unknown-none-elf"
+

--- a/boards/swervolf/.cargo/config.toml
+++ b/boards/swervolf/.cargo/config.toml
@@ -5,6 +5,7 @@
 include = [
   "../../cargo/tock_flags.toml",
   "../../cargo/unstable_flags.toml",
+  "../../cargo/riscv_flags.toml",
 ]
 
 [build]

--- a/boards/swervolf/Makefile
+++ b/boards/swervolf/Makefile
@@ -4,9 +4,6 @@
 
 # Makefile for building the tock kernel for the SweRVolf platform
 
-TARGET=riscv32imc-unknown-none-elf
-PLATFORM=swervolf
-
 include ../Makefile.common
 
 # Default target for installing the kernel.

--- a/boards/teensy40/.cargo/config.toml
+++ b/boards/teensy40/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "thumbv7em-none-eabi"
 

--- a/boards/teensy40/.cargo/config.toml
+++ b/boards/teensy40/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "thumbv7em-none-eabi"
+

--- a/boards/teensy40/.cargo/config.toml
+++ b/boards/teensy40/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "thumbv7em-none-eabi"
 
+[unstable]
+config-include = true

--- a/boards/teensy40/Makefile
+++ b/boards/teensy40/Makefile
@@ -4,9 +4,6 @@
 
 # Makefile for building the tock kernel for the Teensy 4
 
-TARGET=thumbv7em-none-eabi
-PLATFORM=teensy40
-
 include ../Makefile.common
 
 # Default target for installing the kernel.

--- a/boards/tutorials/nrf52840dk-hotp-tutorial/.cargo/config.toml
+++ b/boards/tutorials/nrf52840dk-hotp-tutorial/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "thumbv7em-none-eabi"
 

--- a/boards/tutorials/nrf52840dk-hotp-tutorial/.cargo/config.toml
+++ b/boards/tutorials/nrf52840dk-hotp-tutorial/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "thumbv7em-none-eabi"
+

--- a/boards/tutorials/nrf52840dk-hotp-tutorial/.cargo/config.toml
+++ b/boards/tutorials/nrf52840dk-hotp-tutorial/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../../cargo/tock_flags.toml",
+  "../../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "thumbv7em-none-eabi"
 
+[unstable]
+config-include = true

--- a/boards/tutorials/nrf52840dk-hotp-tutorial/Makefile
+++ b/boards/tutorials/nrf52840dk-hotp-tutorial/Makefile
@@ -2,8 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
-TARGET=thumbv7em-none-eabi
-PLATFORM=nrf52840dk-hotp-tutorial
-
 include ../../Makefile.common
 include ../../configurations/nrf52840dk/nrf52840dk.mk

--- a/boards/tutorials/nrf52840dk-thread-tutorial/.cargo/config.toml
+++ b/boards/tutorials/nrf52840dk-thread-tutorial/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "thumbv7em-none-eabi"
 

--- a/boards/tutorials/nrf52840dk-thread-tutorial/.cargo/config.toml
+++ b/boards/tutorials/nrf52840dk-thread-tutorial/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "thumbv7em-none-eabi"
+

--- a/boards/tutorials/nrf52840dk-thread-tutorial/.cargo/config.toml
+++ b/boards/tutorials/nrf52840dk-thread-tutorial/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../../cargo/tock_flags.toml",
+  "../../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "thumbv7em-none-eabi"
 
+[unstable]
+config-include = true

--- a/boards/tutorials/nrf52840dk-thread-tutorial/Makefile
+++ b/boards/tutorials/nrf52840dk-thread-tutorial/Makefile
@@ -2,8 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2022.
 
-TARGET=thumbv7em-none-eabi
-PLATFORM=nrf52840dk-thread-tutorial
-
 include ../../Makefile.common
 include ../../configurations/nrf52840dk/nrf52840dk.mk

--- a/boards/weact_f401ccu6/.cargo/config.toml
+++ b/boards/weact_f401ccu6/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "thumbv7em-none-eabihf"
+

--- a/boards/weact_f401ccu6/.cargo/config.toml
+++ b/boards/weact_f401ccu6/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "thumbv7em-none-eabihf"
 
+[unstable]
+config-include = true

--- a/boards/weact_f401ccu6/.cargo/config.toml
+++ b/boards/weact_f401ccu6/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "thumbv7em-none-eabihf"
 

--- a/boards/weact_f401ccu6/Makefile
+++ b/boards/weact_f401ccu6/Makefile
@@ -3,8 +3,6 @@
 # Copyright Tock Contributors 2022.
 
 # Makefile for building the tock kernel for the WeAct STM32F401CCU6 Core Board
-TARGET=thumbv7em-none-eabihf
-PLATFORM=weact-f401ccu6
 KERNEL=$(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf
 

--- a/boards/wm1110dev/.cargo/config.toml
+++ b/boards/wm1110dev/.cargo/config.toml
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
 [build]
 target = "thumbv7em-none-eabi"
 

--- a/boards/wm1110dev/.cargo/config.toml
+++ b/boards/wm1110dev/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "thumbv7em-none-eabi"
+

--- a/boards/wm1110dev/.cargo/config.toml
+++ b/boards/wm1110dev/.cargo/config.toml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2024.
 
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+]
+
 [build]
 target = "thumbv7em-none-eabi"
 
+[unstable]
+config-include = true

--- a/boards/wm1110dev/Makefile
+++ b/boards/wm1110dev/Makefile
@@ -4,10 +4,6 @@
 
 # Makefile for building the tock kernel for the Arduino Nano 33 BLE board.
 
-TOCK_ARCH=cortex-m4
-TARGET=thumbv7em-none-eabi
-PLATFORM=wm1110dev
-
 include ../Makefile.common
 
 ifdef PORT


### PR DESCRIPTION
### Pull Request Overview

(Supplants #4054)

Adds support to all boards for building using plain-old-cargo with make as an instrumentation tool. Building in both ways are identical to building using `make` before this PR.

Without this change, in order to build with `cargo` , one needs a large number of `RUSTFLAGS` along with cargo-specific arguments. With this change, simply:

```sh
$ cd boards/[BOARD-OF-CHOICE]
$ cargo build --release
```
This is done by adding `.cargo/config.toml` files to each board which include config TOMLs from `boards/cargo`.

With this change, it is also easy to use tools such as `cargo-binutils` and `probe-rs` which rely on being able to run `cargo build` with normal arguments. For example, in the sma_q3 board, it is now possible to flash and attach the JLink RTT by simply installing `probe-rs` and running:

```sh
cargo embed --release
```

### Testing Strategy

Continuous Integration

### TODO or Help Wanted

- [x]  Why do we still have CARGO_FLAGS in the makefile? I think those should be set in config.toml files now.
- [x] What do we do about the non-additive nature of setting RUSTFLAGS?
- [x] Can we use cargo config get to improve the make V=1 print out? This would help users not have to dig through unstable cargo docs to figure out how to view the current configuration.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
