### PR TITLE
make: simplify cargo doc rule

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -378,9 +378,7 @@ debug-lst:  $(TARGET_PATH)/debug/$(PLATFORM).lst
 
 .PHONY: doc
 doc: | target
-	@# This mess is all to work around rustdoc giving no way to return an
-	@# error if there are warnings. This effectively simulates that.
-	$(Q)RUSTDOCFLAGS='$(RUSTDOC_FLAGS_TOCK)' $(CARGO) --color=always doc $(VERBOSE_FLAGS) --release --package $(PLATFORM) --target-dir=$(TARGET_DIRECTORY) 2>&1 | grep -C 9999 warning && (echo "Warnings detected during doc build" && if [[ $$NOWARNINGS == "true" ]]; then echo "Erroring due to CI context" && exit 33; fi) || if [ $$? -eq 33 ]; then exit 1; fi
+	$(Q)RUSTDOCFLAGS='$(RUSTDOC_FLAGS_TOCK)' $(CARGO) --color=always doc $(VERBOSE_FLAGS) --release --package $(PLATFORM)
 
 
 .PHONY: lst


### PR DESCRIPTION
### Pull Request Overview

-D warnings now works so we don't need the custom version.






### Testing Strategy

This patch failed CI: https://app.netlify.com/sites/docs-tockosorg/deploys/668d9722ca0c450008a48095


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
