### PR TITLE
lib: tbf: parse header lengths without 'static

### DIFF
--- a/libraries/tock-tbf/src/parse.rs
+++ b/libraries/tock-tbf/src/parse.rs
@@ -24,7 +24,7 @@ use crate::types;
 /// we can skip over it and check for the next app.
 /// - Err(InitialTbfParseError::InvalidHeader(app_length))
 pub fn parse_tbf_header_lengths(
-    app: &'static [u8; 8],
+    app: &[u8; 8],
 ) -> Result<(u16, u16, u32), types::InitialTbfParseError> {
     // Version is the first 16 bits of the app TBF contents. We need this to
     // correctly parse the other lengths.


### PR DESCRIPTION
### Pull Request Overview

Parsing TBF header lengths does not require the buffer to be static. I guess in our current use cases this didn't matter, but with the dynamic process loading we need to be able to call this function with a buffer the compiler does not think is static.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
