### PR TITLE
clippy: deny `wrong-self-convention`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,7 +205,6 @@ option_map_or_none = "allow"
 redundant_field_names = "allow"
 redundant_pattern_matching = "allow"
 unusual-byte-groupings = "allow"
-wrong-self-convention = "allow"
 doc_lazy_continuation = "allow"
 
 

--- a/chips/imxrt10xx/src/gpio.rs
+++ b/chips/imxrt10xx/src/gpio.rs
@@ -555,7 +555,7 @@ pub struct Pin<'a> {
 trait U32Ext {
     fn set_bit(self, offset: usize) -> Self;
     fn clear_bit(self, offset: usize) -> Self;
-    fn is_bit_set(self, offset: usize) -> bool;
+    fn is_bit_set(&self, offset: usize) -> bool;
 }
 
 impl U32Ext for u32 {
@@ -568,7 +568,7 @@ impl U32Ext for u32 {
         self & !(1 << offset)
     }
     #[inline(always)]
-    fn is_bit_set(self, offset: usize) -> bool {
+    fn is_bit_set(&self, offset: usize) -> bool {
         (self & (1 << offset)) != 0
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the clippy lint `wrong-self-convention` to deny.


### Testing Strategy

`cargo clippy`


### TODO or Help Wanted

I think this change is ok and makes sense?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
