### PR TITLE
clippy: deny `type_repetition_in_bounds`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -247,7 +247,6 @@ trait_duplication_in_bounds = "allow"
 useless_let_if_seq = "allow"
 as_ptr_cast_mut = "allow"
 unnecessary_struct_initialization = "allow"
-type_repetition_in_bounds = "allow"
 
 
 # PEDANTIC

--- a/boards/components/src/lpm013m126.rs
+++ b/boards/components/src/lpm013m126.rs
@@ -121,7 +121,6 @@ pub struct Lpm013m126Component<A, P, S>
 where
     A: 'static + Alarm<'static>,
     P: 'static + gpio::Pin,
-    P: gpio::Pin,
     S: 'static + SpiMaster<'static>,
 {
     spi: &'static MuxSpiMaster<'static, S>,
@@ -135,7 +134,6 @@ impl<A, P, S> Lpm013m126Component<A, P, S>
 where
     A: 'static + Alarm<'static>,
     P: 'static + gpio::Pin,
-    P: gpio::Pin,
     S: 'static + SpiMaster<'static>,
 {
     pub fn new(

--- a/libraries/tock-register-interface/src/debug.rs
+++ b/libraries/tock-register-interface/src/debug.rs
@@ -170,8 +170,7 @@ where
 impl<T, E> fmt::Debug for RegisterDebugValue<T, E>
 where
     T: UIntLike + 'static,
-    E: RegisterDebugInfo<T>,
-    E: 'static,
+    E: RegisterDebugInfo<T> + 'static,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // This is using the core library's formatting facilities to produce an


### PR DESCRIPTION
### Pull Request Overview

Removes some repetition in types. I'm surprised this isn't a rust error.


### Testing Strategy

`cargo clippy`


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
