### PR TITLE
clippy: deny `from-over-into`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,7 +196,6 @@ upper_case_acronyms = "allow"
 
 
 declare-interior-mutable-const = "allow"
-from-over-into = "allow"
 let_and_return = "allow"
 missing_safety_doc = "allow"
 needless-range-loop = "allow"

--- a/chips/nrf5x/src/pinmux.rs
+++ b/chips/nrf5x/src/pinmux.rs
@@ -45,8 +45,8 @@ impl Pinmux {
     }
 }
 
-impl Into<u32> for Pinmux {
-    fn into(self) -> u32 {
-        self.0
+impl From<Pinmux> for u32 {
+    fn from(val: Pinmux) -> Self {
+        val.0
     }
 }

--- a/chips/rp2040/src/deferred_calls.rs
+++ b/chips/rp2040/src/deferred_calls.rs
@@ -26,8 +26,8 @@ impl TryFrom<usize> for DeferredCallTask {
     }
 }
 
-impl Into<usize> for DeferredCallTask {
-    fn into(self) -> usize {
-        self as usize
+impl From<DeferredCallTask> for usize {
+    fn from(val: DeferredCallTask) -> Self {
+        val as usize
     }
 }

--- a/chips/stm32f4xx/src/chip_specific/flash.rs
+++ b/chips/stm32f4xx/src/chip_specific/flash.rs
@@ -67,8 +67,8 @@ impl RegisterToFlashLatency for FlashLatency16 {
     }
 }
 
-impl Into<u32> for FlashLatency16 {
-    fn into(self) -> u32 {
-        self as u32
+impl From<FlashLatency16> for u32 {
+    fn from(val: FlashLatency16) -> Self {
+        val as u32
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This one is maybe more subjective. The lint says:

> an implementation of `From` is preferred since it gives you `Into<_>` for free where the reverse isn't true

So maybe we should advocate for `From`?


### Testing Strategy

`cargo clippy`


### TODO or Help Wanted

Is there a good reason to only use `Into` in certain cases and we shouldn't turn on this lint?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
