### PR TITLE
Fixing deferred calls registering for rp2040 rtc

### DIFF
--- a/boards/components/src/date_time.rs
+++ b/boards/components/src/date_time.rs
@@ -67,7 +67,6 @@ impl<D: 'static + date_time::DateTime<'static> + kernel::deferred_call::Deferred
         let grant_date_time = self.board_kernel.create_grant(self.driver_num, &grant_dt);
 
         let date_time = s.write(DateTimeCapsule::new(self.rtc, grant_date_time));
-        kernel::deferred_call::DeferredCallClient::register(self.rtc);
         date_time::DateTime::set_client(self.rtc, date_time);
         date_time
     }

--- a/chips/rp2040/src/chip.rs
+++ b/chips/rp2040/src/chip.rs
@@ -166,6 +166,7 @@ impl<'a> Rp2040DefaultPeripherals<'a> {
         self.uart0.set_clocks(&self.clocks);
         kernel::deferred_call::DeferredCallClient::register(&self.uart0);
         kernel::deferred_call::DeferredCallClient::register(&self.uart1);
+        kernel::deferred_call::DeferredCallClient::register(&self.rtc);
         self.i2c0.resolve_dependencies(&self.clocks, &self.resets);
         self.usb.set_gpio(self.pins.get_pin(RPGpio::GPIO15));
         self.rtc.set_clocks(&self.clocks);


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the rp2040 chip's `rtc` driver to register its deferred call. Before this fix, the `DateTimeComponent` was registering it. This meant that any board that does not use the `DateTime` driver, like the Pico Explorer Base, panics at init due to unregistered deferred call.  


### Testing Strategy

This pull request was tested on Raspberry Pi Pico (connected to Pico Explorer Base).


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
