### PR TITLE
Add `is_success` utility function to SyscallReturn

### DIFF
--- a/kernel/src/syscall_driver.rs
+++ b/kernel/src/syscall_driver.rs
@@ -29,6 +29,19 @@ impl CommandReturn {
         self.0
     }
 
+    /// Check whether the inner `SyscallReturn` value is successful
+    pub fn is_success(&self) -> bool {
+        matches!(
+            self.0,
+            SyscallReturn::Success
+                | SyscallReturn::SuccessU32(_)
+                | SyscallReturn::SuccessU32U32(_, _)
+                | SyscallReturn::SuccessU32U32U32(_, _, _)
+                | SyscallReturn::SuccessU32U64(_, _)
+                | SyscallReturn::SuccessU64(_)
+        )
+    }
+
     /// Command error
     pub fn failure(rc: ErrorCode) -> Self {
         CommandReturn(SyscallReturn::Failure(rc))


### PR DESCRIPTION
### Pull Request Overview

This PR upstreams a patch from [`OpenSK`](https://github.com/google/OpenSK/blob/2.1/patches/tock/05-kernel-utility-method.patch)

### Testing Strategy

Compile tested, this is a simple utility function.

### TODO or Help Wanted

N/A

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
