### PR TITLE
make: clippy error on warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -396,7 +396,7 @@ ci-job-readme-check:
 .PHONY: ci-job-clippy
 ci-job-clippy:
 	$(call banner,CI-Job: Clippy)
-	@NOWARNINGS=true cargo clippy
+	@cargo clippy -- -D warnings
 
 
 


### PR DESCRIPTION
### Pull Request Overview

Fix our CI to reject code with clippy warnings.


### Testing Strategy

Running locally. This should also fail in CI until the other PR is merged.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
