### PR TITLE
Fix something that was not the root cause of relocation bug from #2219 at the time, the root cause was a bug in LLD, and now that bug is fixed, so we can use the canonical way of ensuring the relocation section has a predictable LMA

### DIFF
--- a/boards/kernel_layout.ld
+++ b/boards/kernel_layout.ld
@@ -265,7 +265,7 @@ SECTIONS
      * Tock assumes the relocation section follows all static elements and will
      * copy (_erelocate - _srelocate) bytes from _etext to _srelocate.
      */
-    .relocate :
+    .relocate : AT (_etext)
     {
         . = ALIGN(4);
         _srelocate = .;
@@ -294,7 +294,7 @@ SECTIONS
 
         . = ALIGN(4);
         _erelocate = .;
-    } > ram AT>rom
+    } > ram
 
 
     .sram (NOLOAD) :


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the actual root cause of #2219 and fixed originally in #2336

Currently we rely on `-nmagic` for the linker not to do funny things with the beginning of the relocation section such that it always actually is stored starting at `_etext`. This is a hack. Instead, we can force the load-memory-address (LMA) of the relocate section to be exactly `_etext` using `AT (_etext)`.

see <https://sourceware.org/binutils/docs/ld/Output-Section-LMA.html>

### Testing Strategy

This is compile tested. In practice, this doesn't actually remove `-nmagic` since that's still nice to have (the linker won't inject zero padding unnecessarily to the binary).

I validated that this precisely places the relocation section by removing `-nmagic`, and also by modifying the `AT (_etext)` statement to be various offsets from `_etext` and manually inspecting the binary.

### TODO or Help Wanted

N/A


### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
