### PR TITLE
arch: fix clippy warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -397,6 +397,10 @@ ci-job-readme-check:
 ci-job-clippy:
 	$(call banner,CI-Job: Clippy)
 	@cargo clippy -- -D warnings
+	# Run `cargo clippy` in select boards so we run clippy with targets that
+	# actually check the arch-specific functions.
+	@cd boards/nordic/nrf52840dk && cargo clippy -- -D warnings
+	@cd boards/hifive1 && cargo clippy -- -D warnings
 
 
 

--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -128,7 +128,7 @@ pub unsafe extern "C" fn unhandled_interrupt() {
         options(nomem, nostack, preserves_flags)
     );
 
-    interrupt_number = interrupt_number & 0x1ff;
+    interrupt_number &= 0x1ff;
 
     panic!("Unhandled Interrupt. ISR {} is active.", interrupt_number);
 }

--- a/arch/cortex-m/src/support.rs
+++ b/arch/cortex-m/src/support.rs
@@ -35,7 +35,7 @@ where
 
     // Unset PRIMASK
     asm!("cpsie i", options(nomem, nostack));
-    return res;
+    res
 }
 
 // Mock implementations for tests on Travis-CI.

--- a/arch/rv32i/src/syscall.rs
+++ b/arch/rv32i/src/syscall.rs
@@ -601,7 +601,7 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
             // We pass the per-process state struct in a register we are allowed
             // to clobber (not s0 or s1), but still fits into 3-bit register
             // arguments of compressed load- & store-instructions.
-            in("x10") state as *mut Riscv32iStoredState,
+            in("x10") core::ptr::from_mut::<Riscv32iStoredState>(state),
 
             // Clobber all registers which can be marked as clobbered, except
             // for `a0` / `x10`. By making it retain the value of `&mut state`,


### PR DESCRIPTION
### Pull Request Overview

For reasons, clippy does not fully check our arch crates. Once #4075 lands, running `cargo clippy` in a board directly will check more code than we are today, and this fixes the new warnings that come up.

This also adds two fairly arbitrarily selected boards to the clippy CI to automate these checks somewhat.


### Testing Strategy

Running `cargo clippy` on #4075


### TODO or Help Wanted

I picked one cortex-m board and one risc-v board. I'm not sure we want to run all boards in CI. Maybe this is good enough? Thoughts?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
