### PR TITLE
Fix ci-job-rustdoc by building docs for host target

### DIFF
--- a/tools/build-all-docs.sh
+++ b/tools/build-all-docs.sh
@@ -25,8 +25,8 @@ else
 fi
 rm -f _COW _COW2
 
-# Make the documentation for all the boards.
-make alldoc
+# Make the documentation for all the boards, for the host's native target.
+cargo doc
 
 # Replace the default rust logo with our own Tock logo and the favicon with our
 # own favicon. Note, it is also possible to set this using a `#[doc]` attribute


### PR DESCRIPTION
### Pull Request Overview

This pull request replicates the `ci-job-rustdoc` behavior pre #4075 by building all docs for the host target. This fixes the docs.tockos.org builds.


### Testing Strategy

This pull request was tested by this PR.


### TODO or Help Wanted

Conversation in Slack as to whether we want this is still ongoing.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
