### PR TITLE
Build docs for target-specific code independent of platform

### DIFF
--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -10,9 +10,6 @@
 
 use core::fmt::Write;
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
-use core::arch::global_asm;
-
 pub mod dcb;
 pub mod dwt;
 pub mod mpu;
@@ -116,7 +113,7 @@ pub trait CortexMVariant {
     unsafe fn print_cortexm_state(writer: &mut dyn Write);
 }
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 pub unsafe extern "C" fn unhandled_interrupt() {
     use core::arch::asm;
     let mut interrupt_number: u32;
@@ -133,7 +130,7 @@ pub unsafe extern "C" fn unhandled_interrupt() {
     panic!("Unhandled Interrupt. ISR {} is active.", interrupt_number);
 }
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 extern "C" {
     /// Assembly function to initialize the .bss and .data sections in RAM.
     ///
@@ -144,8 +141,8 @@ extern "C" {
     pub fn initialize_ram_jump_to_main();
 }
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
-global_asm!(
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+core::arch::global_asm!(
 "
     .section .initialize_ram_jump_to_main, \"ax\"
     .global initialize_ram_jump_to_main
@@ -384,12 +381,12 @@ pub unsafe fn print_cortexm_state(writer: &mut dyn Write) {
 // ARM assembly since it will not compile.
 ///////////////////////////////////////////////////////////////////
 
-#[cfg(not(all(target_arch = "arm", target_os = "none")))]
+#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
 pub unsafe extern "C" fn unhandled_interrupt() {
     unimplemented!()
 }
 
-#[cfg(not(all(target_arch = "arm", target_os = "none")))]
+#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
 pub unsafe extern "C" fn initialize_ram_jump_to_main() {
     unimplemented!()
 }

--- a/arch/cortex-m/src/scb.rs
+++ b/arch/cortex-m/src/scb.rs
@@ -300,7 +300,7 @@ pub unsafe fn set_vector_table_offset(offset: *const ()) {
 }
 
 /// Disable the FPU
-#[cfg(all(target_arch = "arm", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 pub unsafe fn disable_fpca() {
     use core::arch::asm;
     SCB.cpacr
@@ -316,7 +316,7 @@ pub unsafe fn disable_fpca() {
 }
 
 // Mock implementation for tests on Travis-CI.
-#[cfg(not(all(target_arch = "arm", target_os = "none")))]
+#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
 pub unsafe fn disable_fpca() {
     // Dummy read register, to satisfy the `Readable` trait import on
     // non-ARM platforms.

--- a/arch/cortex-m/src/support.rs
+++ b/arch/cortex-m/src/support.rs
@@ -4,7 +4,7 @@
 
 use crate::scb;
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 #[inline(always)]
 /// NOP instruction
 pub fn nop() {
@@ -14,7 +14,7 @@ pub fn nop() {
     }
 }
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 #[inline(always)]
 /// WFI instruction
 pub unsafe fn wfi() {
@@ -22,7 +22,7 @@ pub unsafe fn wfi() {
     asm!("wfi", options(nomem, preserves_flags));
 }
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 pub unsafe fn atomic<F, R>(f: F) -> R
 where
     F: FnOnce() -> R,
@@ -39,19 +39,19 @@ where
 }
 
 // Mock implementations for tests on Travis-CI.
-#[cfg(not(all(target_arch = "arm", target_os = "none")))]
+#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
 /// NOP instruction (mock)
 pub fn nop() {
     unimplemented!()
 }
 
-#[cfg(not(all(target_arch = "arm", target_os = "none")))]
+#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
 /// WFI instruction (mock)
 pub unsafe fn wfi() {
     unimplemented!()
 }
 
-#[cfg(not(all(target_arch = "arm", target_os = "none")))]
+#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
 pub unsafe fn atomic<F, R>(_f: F) -> R
 where
     F: FnOnce() -> R,

--- a/arch/cortex-m0/src/lib.rs
+++ b/arch/cortex-m0/src/lib.rs
@@ -10,9 +10,6 @@
 
 use core::fmt::Write;
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
-use core::arch::global_asm;
-
 // Re-export the base generic cortex-m functions here as they are
 // valid on cortex-m0.
 pub use cortexm::support;
@@ -20,7 +17,7 @@ pub use cortexm::support;
 pub use cortexm::nvic;
 pub use cortexm::syscall;
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 struct HardFaultStackedRegisters {
     r0: u32,
     r1: u32,
@@ -32,7 +29,7 @@ struct HardFaultStackedRegisters {
     xpsr: u32,
 }
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 /// Handle a hard fault that occurred in the kernel. This function is invoked
 /// by the naked hard_fault_handler function.
 unsafe extern "C" fn hard_fault_handler_kernel(faulting_stack: *mut u32) -> ! {
@@ -72,19 +69,19 @@ unsafe extern "C" fn hard_fault_handler_kernel(faulting_stack: *mut u32) -> ! {
 }
 
 // Mock implementation for tests on Travis-CI.
-#[cfg(not(all(target_arch = "arm", target_os = "none")))]
+#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
 unsafe extern "C" fn generic_isr() {
     unimplemented!()
 }
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 extern "C" {
     /// All ISRs are caught by this handler which disables the NVIC and switches to the kernel.
     pub fn generic_isr();
 }
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
-global_asm!(
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+core::arch::global_asm!(
     "
     .section .generic_isr, \"ax\"
     .global generic_isr
@@ -167,12 +164,12 @@ global_asm!(
 );
 
 // Mock implementation for tests on Travis-CI.
-#[cfg(not(all(target_arch = "arm", target_os = "none")))]
+#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
 unsafe extern "C" fn systick_handler_m0() {
     unimplemented!()
 }
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 extern "C" {
     /// The `systick_handler` is called when the systick interrupt occurs, signaling
     /// that an application executed for longer than its timeslice. This interrupt
@@ -183,8 +180,8 @@ extern "C" {
     pub fn systick_handler_m0();
 }
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
-global_asm!(
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+core::arch::global_asm!(
     "
     .section .systick_handler_m0, \"ax\"
     .global systick_handler_m0
@@ -210,18 +207,18 @@ global_asm!(
 );
 
 // Mock implementation for tests on Travis-CI.
-#[cfg(not(all(target_arch = "arm", target_os = "none")))]
+#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
 unsafe extern "C" fn svc_handler() {
     unimplemented!()
 }
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 extern "C" {
     pub fn svc_handler();
 }
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
-global_asm!(
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+core::arch::global_asm!(
     "
   .section .svc_handler, \"ax\"
   .global svc_handler
@@ -249,20 +246,20 @@ svc_handler:
 );
 
 // Mock implementation for tests on Travis-CI.
-#[cfg(not(all(target_arch = "arm", target_os = "none")))]
+#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
 unsafe extern "C" fn hard_fault_handler() {
     unimplemented!()
 }
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 extern "C" {
     pub fn hard_fault_handler();
 }
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 // If `kernel_stack` is non-zero, then hard-fault occurred in
 // kernel, otherwise the hard-fault occurred in user.
-global_asm!(
+core::arch::global_asm!(
 "
     .section .hard_fault_handler, \"ax\"
     .global hard_fault_handler
@@ -365,7 +362,7 @@ impl cortexm::CortexMVariant for CortexM0 {
     const HARD_FAULT_HANDLER: unsafe extern "C" fn() = hard_fault_handler;
 
     // Mock implementation for tests on Travis-CI.
-    #[cfg(not(all(target_arch = "arm", target_os = "none")))]
+    #[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
     unsafe fn switch_to_user(
         _user_stack: *const usize,
         _process_regs: &mut [usize; 8],
@@ -373,7 +370,7 @@ impl cortexm::CortexMVariant for CortexM0 {
         unimplemented!()
     }
 
-    #[cfg(all(target_arch = "arm", target_os = "none"))]
+    #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
     unsafe fn switch_to_user(
         mut user_stack: *const usize,
         process_regs: &mut [usize; 8],

--- a/arch/cortex-m0p/src/lib.rs
+++ b/arch/cortex-m0p/src/lib.rs
@@ -10,9 +10,6 @@
 
 use core::fmt::Write;
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
-use core::arch::global_asm;
-
 pub mod mpu {
     pub type MPU = cortexm::mpu::MPU<8, 256>;
 }
@@ -31,18 +28,18 @@ pub use cortexm::CortexMVariant;
 use cortexm0::CortexM0;
 
 // Mock implementation for tests on Travis-CI.
-#[cfg(not(all(target_arch = "arm", target_os = "none")))]
+#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
 pub unsafe extern "C" fn svc_handler_m0p() {
     unimplemented!()
 }
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 extern "C" {
     pub fn svc_handler_m0p();
 }
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
-global_asm!(
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+core::arch::global_asm!(
     "
   .section .svc_handler_m0p, \"ax\"
   .global svc_handler_m0p
@@ -88,7 +85,7 @@ impl cortexm::CortexMVariant for CortexM0P {
     const SVC_HANDLER: unsafe extern "C" fn() = svc_handler_m0p;
     const HARD_FAULT_HANDLER: unsafe extern "C" fn() = CortexM0::HARD_FAULT_HANDLER;
 
-    #[cfg(all(target_arch = "arm", target_os = "none"))]
+    #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
     unsafe fn switch_to_user(
         user_stack: *const usize,
         process_regs: &mut [usize; 8],
@@ -96,7 +93,7 @@ impl cortexm::CortexMVariant for CortexM0P {
         CortexM0::switch_to_user(user_stack, process_regs)
     }
 
-    #[cfg(not(all(target_arch = "arm", target_os = "none")))]
+    #[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
     unsafe fn switch_to_user(
         _user_stack: *const usize,
         _process_regs: &mut [usize; 8],

--- a/arch/cortex-v7m/src/lib.rs
+++ b/arch/cortex-v7m/src/lib.rs
@@ -8,16 +8,13 @@
 #![crate_type = "rlib"]
 #![no_std]
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
-use core::arch::global_asm;
-
 // These constants are defined in the linker script.
 extern "C" {
     static _estack: u8;
     static _sstack: u8;
 }
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 extern "C" {
     /// ARMv7-M systick handler function.
     ///
@@ -26,8 +23,8 @@ extern "C" {
     pub fn systick_handler_arm_v7m();
 }
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
-global_asm!(
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+core::arch::global_asm!(
     "
     .section .systick_handler_arm_v7m, \"ax\"
     .global systick_handler_arm_v7m
@@ -58,7 +55,7 @@ global_asm!(
     "
 );
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 extern "C" {
     /// Handler of `svc` instructions on ARMv7-M.
     ///
@@ -67,8 +64,8 @@ extern "C" {
     pub fn svc_handler_arm_v7m();
 }
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
-global_asm!(
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+core::arch::global_asm!(
     "
     .section .svc_handler_arm_v7m, \"ax\"
     .global svc_handler_arm_v7m
@@ -136,15 +133,15 @@ global_asm!(
     "
 );
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 extern "C" {
     /// Generic interrupt handler for ARMv7-M instruction sets.
     ///
     /// For documentation of this function, see `CortexMVariant::GENERIC_ISR`.
     pub fn generic_isr_arm_v7m();
 }
-#[cfg(all(target_arch = "arm", target_os = "none"))]
-global_asm!(
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+core::arch::global_asm!(
         "
     .section .generic_isr_arm_v7m, \"ax\"
     .global generic_isr_arm_v7m
@@ -220,7 +217,7 @@ global_asm!(
 ///
 /// For documentation of this function, please see
 /// `CortexMVariant::switch_to_user`.
-#[cfg(all(target_arch = "arm", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 pub unsafe fn switch_to_user_arm_v7m(
     mut user_stack: *const usize,
     process_regs: &mut [usize; 8],
@@ -281,7 +278,7 @@ pub unsafe fn switch_to_user_arm_v7m(
     user_stack
 }
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 /// Continue the hardfault handler for all hard-faults that occurred
 /// during kernel execution. This function must never return.
 unsafe extern "C" fn hard_fault_handler_arm_v7m_kernel(
@@ -434,7 +431,7 @@ unsafe extern "C" fn hard_fault_handler_arm_v7m_kernel(
     }
 }
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 extern "C" {
     /// ARMv7-M hardfault handler.
     ///
@@ -443,13 +440,13 @@ extern "C" {
     pub fn hard_fault_handler_arm_v7m();
 }
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 // First need to determine if this a kernel fault or a userspace fault, and store
 // the unmodified stack pointer. Place these values in registers, then call
 // a non-naked function, to allow for use of rust code alongside inline asm.
 // Because calling a function increases the stack pointer, we have to check for a kernel
 // stack overflow and adjust the stack pointer before we branch
-global_asm!(
+core::arch::global_asm!(
     "
         .section .hard_fault_handler_arm_v7m, \"ax\"
         .global hard_fault_handler_arm_v7m
@@ -556,22 +553,22 @@ pub fn ipsr_isr_number_to_str(isr_number: usize) -> &'static str {
 // ARM assembly since it will not compile.
 ///////////////////////////////////////////////////////////////////
 
-#[cfg(not(all(target_arch = "arm", target_os = "none")))]
+#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
 pub unsafe extern "C" fn systick_handler_arm_v7m() {
     unimplemented!()
 }
 
-#[cfg(not(all(target_arch = "arm", target_os = "none")))]
+#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
 pub unsafe extern "C" fn svc_handler_arm_v7m() {
     unimplemented!()
 }
 
-#[cfg(not(all(target_arch = "arm", target_os = "none")))]
+#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
 pub unsafe extern "C" fn generic_isr_arm_v7m() {
     unimplemented!()
 }
 
-#[cfg(not(all(target_arch = "arm", target_os = "none")))]
+#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
 pub unsafe extern "C" fn switch_to_user_arm_v7m(
     _user_stack: *const u8,
     _process_regs: &mut [usize; 8],
@@ -579,7 +576,7 @@ pub unsafe extern "C" fn switch_to_user_arm_v7m(
     unimplemented!()
 }
 
-#[cfg(not(all(target_arch = "arm", target_os = "none")))]
+#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
 pub unsafe extern "C" fn hard_fault_handler_arm_v7m() {
     unimplemented!()
 }

--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -16,9 +16,12 @@ pub const XLEN: usize = 32;
 pub const XLEN: usize = 64;
 
 // Default to 32 bit if no architecture is specified of if this is being
-// compiled for testing on a different architecture.
-#[cfg(not(all(
-    any(target_arch = "riscv32", target_arch = "riscv64"),
-    target_os = "none"
-)))]
+// compiled for docs or testing on a different architecture.
+#[cfg(any(
+    doc,
+    not(all(
+        any(target_arch = "riscv32", target_arch = "riscv64"),
+        target_os = "none"
+    ))
+))]
 pub const XLEN: usize = 32;

--- a/arch/rv32i/src/lib.rs
+++ b/arch/rv32i/src/lib.rs
@@ -10,9 +10,6 @@
 
 use core::fmt::Write;
 
-#[cfg(all(target_arch = "riscv32", target_os = "none"))]
-use core::arch::global_asm;
-
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 
 pub mod clic;
@@ -47,7 +44,7 @@ extern "C" {
     static __global_pointer: usize;
 }
 
-#[cfg(all(target_arch = "riscv32", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
 extern "C" {
     // Entry point of all programs (`_start`).
     ///
@@ -62,8 +59,8 @@ extern "C" {
     pub fn _start();
 }
 
-#[cfg(all(target_arch = "riscv32", target_os = "none"))]
-global_asm! ("
+#[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
+core::arch::global_asm!("
             .section .riscv.start, \"ax\"
             .globl _start
           _start:
@@ -175,12 +172,12 @@ pub unsafe fn configure_trap_handler() {
 }
 
 // Mock implementation for tests on Travis-CI.
-#[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
+#[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
 pub extern "C" fn _start_trap() {
     unimplemented!()
 }
 
-#[cfg(all(target_arch = "riscv32", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
 extern "C" {
     /// This is the trap handler function. This code is called on all traps,
     /// including interrupts, exceptions, and system calls from applications.
@@ -271,8 +268,8 @@ extern "C" {
     pub fn _start_trap();
 }
 
-#[cfg(all(target_arch = "riscv32", target_os = "none"))]
-global_asm!(
+#[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
+core::arch::global_asm!(
     "
             .section .riscv.trap, \"ax\"
             .globl _start_trap
@@ -397,7 +394,7 @@ global_asm!(
 /// <https://elixir.bootlin.com/linux/v5.12.10/source/arch/riscv/include/asm/jump_label.h#L21>
 /// as suggested by the RISC-V developers:
 /// <https://groups.google.com/a/groups.riscv.org/g/isa-dev/c/XKkYacERM04/m/CdpOcqtRAgAJ>
-#[cfg(all(target_arch = "riscv32", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
 pub unsafe fn semihost_command(command: usize, arg0: usize, arg1: usize) -> usize {
     use core::arch::asm;
     let res;
@@ -421,7 +418,7 @@ pub unsafe fn semihost_command(command: usize, arg0: usize, arg1: usize) -> usiz
 }
 
 // Mock implementation for tests on Travis-CI.
-#[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
+#[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
 pub unsafe fn semihost_command(_command: usize, _arg0: usize, _arg1: usize) -> usize {
     unimplemented!()
 }

--- a/arch/rv32i/src/support.rs
+++ b/arch/rv32i/src/support.rs
@@ -6,7 +6,7 @@
 
 use crate::csr::{mstatus::mstatus, CSR};
 
-#[cfg(all(target_arch = "riscv32", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
 #[inline(always)]
 /// NOP instruction
 pub fn nop() {
@@ -16,7 +16,7 @@ pub fn nop() {
     }
 }
 
-#[cfg(all(target_arch = "riscv32", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
 #[inline(always)]
 /// WFI instruction
 pub unsafe fn wfi() {
@@ -50,13 +50,13 @@ where
 }
 
 // Mock implementations for tests on Travis-CI.
-#[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
+#[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
 /// NOP instruction (mock)
 pub fn nop() {
     unimplemented!()
 }
 
-#[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
+#[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
 /// WFI instruction (mock)
 pub unsafe fn wfi() {
     unimplemented!()

--- a/arch/rv32i/src/syscall.rs
+++ b/arch/rv32i/src/syscall.rs
@@ -212,7 +212,7 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
     }
 
     // Mock implementation for tests on Travis-CI.
-    #[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
+    #[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
     unsafe fn switch_to_process(
         &self,
         _accessible_memory_start: *const u8,
@@ -225,7 +225,7 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
         unimplemented!()
     }
 
-    #[cfg(all(target_arch = "riscv32", target_os = "none"))]
+    #[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
     unsafe fn switch_to_process(
         &self,
         _accessible_memory_start: *const u8,

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -164,7 +164,7 @@ extern "C" {
     fn jump_to_bootloader();
 }
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 core::arch::global_asm!(
     "
     .section .jump_to_bootloader, \"ax\"

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -174,7 +174,7 @@ extern "C" {
     fn jump_to_bootloader();
 }
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 core::arch::global_asm!(
     "
     .section .jump_to_bootloader, \"ax\"

--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -165,7 +165,7 @@ extern "C" {
     fn jump_to_bootloader();
 }
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 core::arch::global_asm!(
     "
     .section .jump_to_bootloader, \"ax\"

--- a/chips/apollo3/src/lib.rs
+++ b/chips/apollo3/src/lib.rs
@@ -77,7 +77,7 @@ pub static PATCH: [unsafe extern "C" fn(); 16] = [unhandled_interrupt; 16];
 
 // The SVC call in this function means that we need to ensure it's inlined in
 // `main()` otherwise we end up with a clobbered stack.
-#[cfg(all(target_arch = "arm", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 #[inline(always)]
 pub unsafe fn init() {
     use core::arch::asm;
@@ -104,7 +104,7 @@ pub unsafe fn init() {
 }
 
 // Mock implementation for tests
-#[cfg(not(all(target_arch = "arm", target_os = "none")))]
+#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
 pub unsafe fn init() {
     // Prevent unused code warning.
     scb::disable_fpca();

--- a/chips/arty_e21_chip/src/chip.rs
+++ b/chips/arty_e21_chip/src/chip.rs
@@ -110,7 +110,7 @@ impl<'a, I: InterruptService + 'a> ArtyExx<'a, I> {
     /// This needs to be chip specific because how the CLIC works is configured
     /// when the trap handler address is specified in mtvec, and that is only
     /// valid for platforms with a CLIC.
-    #[cfg(all(target_arch = "riscv32", target_os = "none"))]
+    #[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
     pub unsafe fn configure_trap_handler(&self) {
         use core::arch::asm;
         asm!(
@@ -132,7 +132,7 @@ impl<'a, I: InterruptService + 'a> ArtyExx<'a, I> {
     }
 
     // Mock implementation for tests on Travis-CI.
-    #[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
+    #[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
     pub unsafe fn configure_trap_handler(&self) {
         unimplemented!()
     }

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -442,7 +442,7 @@ pub unsafe fn configure_trap_handler() {
 // Mock implementation for crate tests that does not include the section
 // specifier, as the test will not use our linker script, and the host
 // compilation environment may not allow the section name.
-#[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
+#[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
 pub extern "C" fn _earlgrey_start_trap_vectored() {
     use core::hint::unreachable_unchecked;
     unsafe {
@@ -450,12 +450,12 @@ pub extern "C" fn _earlgrey_start_trap_vectored() {
     }
 }
 
-#[cfg(all(target_arch = "riscv32", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
 extern "C" {
     pub fn _earlgrey_start_trap_vectored();
 }
 
-#[cfg(all(target_arch = "riscv32", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
 // According to the Ibex user manual:
 // [NMI] has interrupt ID 31, i.e., it has the highest priority of all
 // interrupts and the core jumps to the trap-handler base address (in

--- a/chips/esp32-c3/src/chip.rs
+++ b/chips/esp32-c3/src/chip.rs
@@ -288,7 +288,7 @@ pub unsafe fn configure_trap_handler() {
 // Mock implementation for crate tests that does not include the section
 // specifier, as the test will not use our linker script, and the host
 // compilation environment may not allow the section name.
-#[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
+#[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
 pub extern "C" fn _start_trap_vectored() {
     use core::hint::unreachable_unchecked;
     unsafe {
@@ -296,12 +296,12 @@ pub extern "C" fn _start_trap_vectored() {
     }
 }
 
-#[cfg(all(target_arch = "riscv32", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
 extern "C" {
     pub fn _start_trap_vectored();
 }
 
-#[cfg(all(target_arch = "riscv32", target_os = "none"))]
+#[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
 // Below are 32 (non-compressed) jumps to cover the entire possible
 // range of vectored traps.
 core::arch::global_asm!(

--- a/chips/litex_vexriscv/src/interrupt_controller.rs
+++ b/chips/litex_vexriscv/src/interrupt_controller.rs
@@ -102,12 +102,12 @@ mod vexriscv_irq_raw {
     /// defined in litex/soc/cores/cpu/vexriscv/csr-defs.h
     const CSR_IRQ_PENDING: usize = 0xFC0;
 
-    #[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
+    #[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
     pub unsafe fn irq_getmask() -> usize {
         0
     }
 
-    #[cfg(all(target_arch = "riscv32", target_os = "none"))]
+    #[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
     pub unsafe fn irq_getmask() -> usize {
         let mask: usize;
         use core::arch::asm;
@@ -117,10 +117,10 @@ mod vexriscv_irq_raw {
         mask
     }
 
-    #[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
+    #[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
     pub unsafe fn irq_setmask(_mask: usize) {}
 
-    #[cfg(all(target_arch = "riscv32", target_os = "none"))]
+    #[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
     pub unsafe fn irq_setmask(mask: usize) {
         use core::arch::asm;
         // TODO: If asm_const is stabilized, transition back to below
@@ -128,12 +128,12 @@ mod vexriscv_irq_raw {
         asm!("csrw 0xBC0, {mask}", mask = in(reg) mask);
     }
 
-    #[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
+    #[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
     pub unsafe fn irq_pending() -> usize {
         0
     }
 
-    #[cfg(all(target_arch = "riscv32", target_os = "none"))]
+    #[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
     pub unsafe fn irq_pending() -> usize {
         let pending: usize;
         use core::arch::asm;

--- a/chips/rp2040/src/clocks.rs
+++ b/chips/rp2040/src/clocks.rs
@@ -1042,7 +1042,7 @@ impl Clocks {
         (((source_freq as u64) << 8) / freq as u64) as u32
     }
 
-    #[cfg(all(target_arch = "arm", target_os = "none"))]
+    #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
     #[inline]
     fn loop_3_cycles(&self, clock: Clock) {
         if self.get_frequency(clock) > 0 {
@@ -1059,7 +1059,7 @@ impl Clocks {
         }
     }
 
-    #[cfg(not(all(target_arch = "arm", target_os = "none")))]
+    #[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
     fn loop_3_cycles(&self, _clock: Clock) {
         unimplemented!()
     }

--- a/chips/stm32f4xx/src/fsmc.rs
+++ b/chips/stm32f4xx/src/fsmc.rs
@@ -244,7 +244,7 @@ impl<'a> Fsmc<'a> {
         self.bank[bank as usize].map_or(None, |bank| Some(bank.ram.get()))
     }
 
-    #[cfg(all(target_arch = "arm", target_os = "none"))]
+    #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
     #[inline]
     fn write_reg(&self, bank: FsmcBanks, addr: u16) {
         use kernel::utilities::registers::interfaces::Writeable;
@@ -255,7 +255,7 @@ impl<'a> Fsmc<'a> {
         }
     }
 
-    #[cfg(all(target_arch = "arm", target_os = "none"))]
+    #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
     #[inline]
     fn write_data(&self, bank: FsmcBanks, data: u16) {
         use kernel::utilities::registers::interfaces::Writeable;
@@ -266,12 +266,12 @@ impl<'a> Fsmc<'a> {
         }
     }
 
-    #[cfg(not(all(target_arch = "arm", target_os = "none")))]
+    #[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
     fn write_reg(&self, _bank: FsmcBanks, _addr: u16) {
         unimplemented!()
     }
 
-    #[cfg(not(all(target_arch = "arm", target_os = "none")))]
+    #[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
     fn write_data(&self, _bank: FsmcBanks, _data: u16) {
         unimplemented!()
     }

--- a/libraries/riscv-csr/src/csr.rs
+++ b/libraries/riscv-csr/src/csr.rs
@@ -144,9 +144,12 @@ impl<R: RegisterLongName, const V: usize> ReadWriteRiscvCsr<usize, R, V> {
     /// This method corresponds to the RISC-V `CSRRW rd, csr, rs1`
     /// instruction where `rs1 = in(reg) value_to_set` and `rd =
     /// out(reg) <return value>`.
-    #[cfg(all(
-        any(target_arch = "riscv32", target_arch = "riscv64"),
-        target_os = "none"
+    #[cfg(any(
+        doc,
+        all(
+            any(target_arch = "riscv32", target_arch = "riscv64"),
+            target_os = "none"
+        )
     ))]
     #[inline]
     pub fn atomic_replace(&self, val_to_set: usize) -> usize {
@@ -171,9 +174,12 @@ impl<R: RegisterLongName, const V: usize> ReadWriteRiscvCsr<usize, R, V> {
     /// instruction where `rs1 = in(reg) value_to_set` and `rd =
     /// out(reg) <return value>`.
     // Mock implementations for tests on Travis-CI.
-    #[cfg(not(all(
-        any(target_arch = "riscv32", target_arch = "riscv64"),
-        target_os = "none"
+    #[cfg(not(any(
+        doc,
+        all(
+            any(target_arch = "riscv32", target_arch = "riscv64"),
+            target_os = "none"
+        )
     )))]
     pub fn atomic_replace(&self, _value_to_set: usize) -> usize {
         unimplemented!("RISC-V CSR {} Atomic Read/Write", V)
@@ -184,9 +190,12 @@ impl<R: RegisterLongName, const V: usize> ReadWriteRiscvCsr<usize, R, V> {
     /// This method corresponds to the RISC-V `CSRRS rd, csr, rs1`
     /// instruction where `rs1 = in(reg) bitmask` and `rd = out(reg)
     /// <return value>`.
-    #[cfg(all(
-        any(target_arch = "riscv32", target_arch = "riscv64"),
-        target_os = "none"
+    #[cfg(any(
+        doc,
+        all(
+            any(target_arch = "riscv32", target_arch = "riscv64"),
+            target_os = "none"
+        )
     ))]
     #[inline]
     pub fn read_and_set_bits(&self, bitmask: usize) -> usize {
@@ -207,9 +216,12 @@ impl<R: RegisterLongName, const V: usize> ReadWriteRiscvCsr<usize, R, V> {
     /// instruction where `rs1 = in(reg) bitmask` and `rd = out(reg)
     /// <return value>`.
     // Mock implementations for tests on Travis-CI.
-    #[cfg(not(all(
-        any(target_arch = "riscv32", target_arch = "riscv64"),
-        target_os = "none"
+    #[cfg(not(any(
+        doc,
+        all(
+            any(target_arch = "riscv32", target_arch = "riscv64"),
+            target_os = "none"
+        )
     )))]
     pub fn read_and_set_bits(&self, bitmask: usize) -> usize {
         unimplemented!(
@@ -224,9 +236,12 @@ impl<R: RegisterLongName, const V: usize> ReadWriteRiscvCsr<usize, R, V> {
     /// This method corresponds to the RISC-V `CSRRC rd, csr, rs1`
     /// instruction where `rs1 = in(reg) bitmask` and `rd = out(reg)
     /// <return value>`.
-    #[cfg(all(
-        any(target_arch = "riscv32", target_arch = "riscv64"),
-        target_os = "none"
+    #[cfg(any(
+        doc,
+        all(
+            any(target_arch = "riscv32", target_arch = "riscv64"),
+            target_os = "none"
+        )
     ))]
     #[inline]
     pub fn read_and_clear_bits(&self, bitmask: usize) -> usize {
@@ -247,9 +262,12 @@ impl<R: RegisterLongName, const V: usize> ReadWriteRiscvCsr<usize, R, V> {
     /// instruction where `rs1 = in(reg) bitmask` and `rd = out(reg)
     /// <return value>`.
     // Mock implementations for tests on Travis-CI.
-    #[cfg(not(all(
-        any(target_arch = "riscv32", target_arch = "riscv64"),
-        target_os = "none"
+    #[cfg(not(any(
+        doc,
+        all(
+            any(target_arch = "riscv32", target_arch = "riscv64"),
+            target_os = "none"
+        )
     )))]
     pub fn read_and_clear_bits(&self, bitmask: usize) -> usize {
         unimplemented!(
@@ -288,9 +306,12 @@ impl<R: RegisterLongName, const V: usize> Readable for ReadWriteRiscvCsr<usize, 
     type T = usize;
     type R = R;
 
-    #[cfg(all(
-        any(target_arch = "riscv32", target_arch = "riscv64"),
-        target_os = "none"
+    #[cfg(any(
+        doc,
+        all(
+            any(target_arch = "riscv32", target_arch = "riscv64"),
+            target_os = "none"
+        )
     ))]
     #[inline]
     fn get(&self) -> usize {
@@ -303,9 +324,12 @@ impl<R: RegisterLongName, const V: usize> Readable for ReadWriteRiscvCsr<usize, 
     }
 
     // Mock implementations for tests on Travis-CI.
-    #[cfg(not(all(
-        any(target_arch = "riscv32", target_arch = "riscv64"),
-        target_os = "none"
+    #[cfg(not(any(
+        doc,
+        all(
+            any(target_arch = "riscv32", target_arch = "riscv64"),
+            target_os = "none"
+        )
     )))]
     fn get(&self) -> usize {
         unimplemented!("reading RISC-V CSR {}", V)
@@ -316,9 +340,12 @@ impl<R: RegisterLongName, const V: usize> Writeable for ReadWriteRiscvCsr<usize,
     type T = usize;
     type R = R;
 
-    #[cfg(all(
-        any(target_arch = "riscv32", target_arch = "riscv64"),
-        target_os = "none"
+    #[cfg(any(
+        doc,
+        all(
+            any(target_arch = "riscv32", target_arch = "riscv64"),
+            target_os = "none"
+        )
     ))]
     #[inline]
     fn set(&self, val_to_set: usize) {
@@ -328,9 +355,12 @@ impl<R: RegisterLongName, const V: usize> Writeable for ReadWriteRiscvCsr<usize,
         }
     }
 
-    #[cfg(not(all(
-        any(target_arch = "riscv32", target_arch = "riscv64"),
-        target_os = "none"
+    #[cfg(not(any(
+        doc,
+        all(
+            any(target_arch = "riscv32", target_arch = "riscv64"),
+            target_os = "none"
+        )
     )))]
     fn set(&self, _val_to_set: usize) {
         unimplemented!("writing RISC-V CSR {}", V)


### PR DESCRIPTION
### Pull Request Overview

This pull request adds `any(doc, ...` to target-specific conditional compilation expressions, to ensure that such functions and expressions are always documented.

This makes their documentation comment be rendered in Rustdoc, and also allows us to jump to the correct (non-mock) function definitions from within the documentation.


### Testing Strategy

This pull request was tested by `cargo doc` and `cargo check`.


### TODO or Help Wanted

N/A


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
