### PR TITLE
Add rust-analyzer to rust-toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -4,5 +4,5 @@
 
 [toolchain]
 channel = "nightly-2024-07-08"
-components = ["miri", "llvm-tools", "rust-src", "rustfmt", "clippy"]
+components = ["miri", "llvm-tools", "rust-src", "rustfmt", "clippy", "rust-analyzer"]
 targets = ["thumbv6m-none-eabi", "thumbv7em-none-eabi", "thumbv7em-none-eabihf", "riscv32imc-unknown-none-elf", "riscv32imac-unknown-none-elf"]


### PR DESCRIPTION
### Pull Request Overview

Adds `rust-analzyer` to `rust-toolchain.toml`, which ensures that a compatible version of the LSP server is available when using rustup

### Testing Strategy

Open emacs


### TODO or Help Wanted

N/A


### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
