### PR TITLE
Fix the GPIO pins of the Pico Explorer Base

### DIFF
--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -414,8 +414,9 @@ pub unsafe fn start() -> (
             20 => peripherals.pins.get_pin(RPGpio::GPIO20),
             21 => peripherals.pins.get_pin(RPGpio::GPIO21),
             22 => peripherals.pins.get_pin(RPGpio::GPIO22),
-            23 => peripherals.pins.get_pin(RPGpio::GPIO23),
-            24 => peripherals.pins.get_pin(RPGpio::GPIO24),
+            26 => peripherals.pins.get_pin(RPGpio::GPIO26),
+            27 => peripherals.pins.get_pin(RPGpio::GPIO27),
+            28 => peripherals.pins.get_pin(RPGpio::GPIO28),
         ),
     )
     .finalize(components::gpio_component_static!(RPGpioPin<'static>));

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -414,9 +414,6 @@ pub unsafe fn start() -> (
             20 => peripherals.pins.get_pin(RPGpio::GPIO20),
             21 => peripherals.pins.get_pin(RPGpio::GPIO21),
             22 => peripherals.pins.get_pin(RPGpio::GPIO22),
-            26 => peripherals.pins.get_pin(RPGpio::GPIO26),
-            27 => peripherals.pins.get_pin(RPGpio::GPIO27),
-            28 => peripherals.pins.get_pin(RPGpio::GPIO28),
         ),
     )
     .finalize(components::gpio_component_static!(RPGpioPin<'static>));


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the GPIO pins of the Pico Explorer Base kit to be consistent with the notations on the physical kit

<details>
<summary>Notations on the kit</summary>

![image](https://github.com/user-attachments/assets/606f8c09-c91f-4bdc-a5b6-9a2c033cabc2)

</details>


### Testing Strategy

This pull request was tested by flashing Tock on the board and checking that everything works well


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
