### PR TITLE
spi: add support for variable chip-select polarity

### DIFF
--- a/boards/apollo3/lora_things_plus/src/main.rs
+++ b/boards/apollo3/lora_things_plus/src/main.rs
@@ -511,7 +511,9 @@ unsafe fn setup() -> (
     let external_spi_controller = components::spi::SpiSyscallComponent::new(
         board_kernel,
         external_mux_spi,
-        &peripherals.gpio_port[11], // A5
+        kernel::hil::spi::util::IntoChipSelect::<_, kernel::hil::spi::util::ActiveLow>::into_cs(
+            &peripherals.gpio_port[11], // A5
+        ),
         capsules_core::spi_controller::DRIVER_NUM,
     )
     .finalize(components::spi_syscall_component_static!(
@@ -526,7 +528,9 @@ unsafe fn setup() -> (
     let sx1262_spi_controller = components::spi::SpiSyscallComponent::new(
         board_kernel,
         sx1262_mux_spi,
-        &peripherals.gpio_port[36], // H6 - SX1262 Slave Select
+        kernel::hil::spi::util::IntoChipSelect::<_, kernel::hil::spi::util::ActiveLow>::into_cs(
+            &peripherals.gpio_port[36], // H6 - SX1262 Slave Select
+        ),
         LORA_SPI_DRIVER_NUM,
     )
     .finalize(components::spi_syscall_component_static!(
@@ -534,7 +538,12 @@ unsafe fn setup() -> (
     ));
     peripherals
         .iom3
-        .specify_chip_select(&peripherals.gpio_port[36])
+        .specify_chip_select(kernel::hil::spi::util::IntoChipSelect::<
+            _,
+            kernel::hil::spi::util::ActiveLow,
+        >::into_cs(
+            &peripherals.gpio_port[36], // H6 - SX1262 Slave Select
+        ))
         .unwrap();
 
     let sx1262_gpio = components::gpio::GpioComponent::new(

--- a/boards/apollo3/lora_things_plus/src/main.rs
+++ b/boards/apollo3/lora_things_plus/src/main.rs
@@ -511,7 +511,7 @@ unsafe fn setup() -> (
     let external_spi_controller = components::spi::SpiSyscallComponent::new(
         board_kernel,
         external_mux_spi,
-        kernel::hil::spi::util::IntoChipSelect::<_, kernel::hil::spi::util::ActiveLow>::into_cs(
+        kernel::hil::spi::cs::IntoChipSelect::<_, kernel::hil::spi::cs::ActiveLow>::into_cs(
             &peripherals.gpio_port[11], // A5
         ),
         capsules_core::spi_controller::DRIVER_NUM,
@@ -528,7 +528,7 @@ unsafe fn setup() -> (
     let sx1262_spi_controller = components::spi::SpiSyscallComponent::new(
         board_kernel,
         sx1262_mux_spi,
-        kernel::hil::spi::util::IntoChipSelect::<_, kernel::hil::spi::util::ActiveLow>::into_cs(
+        kernel::hil::spi::cs::IntoChipSelect::<_, kernel::hil::spi::cs::ActiveLow>::into_cs(
             &peripherals.gpio_port[36], // H6 - SX1262 Slave Select
         ),
         LORA_SPI_DRIVER_NUM,
@@ -538,9 +538,9 @@ unsafe fn setup() -> (
     ));
     peripherals
         .iom3
-        .specify_chip_select(kernel::hil::spi::util::IntoChipSelect::<
+        .specify_chip_select(kernel::hil::spi::cs::IntoChipSelect::<
             _,
-            kernel::hil::spi::util::ActiveLow,
+            kernel::hil::spi::cs::ActiveLow,
         >::into_cs(
             &peripherals.gpio_port[36], // H6 - SX1262 Slave Select
         ))

--- a/boards/apollo3/lora_things_plus/src/tests/spi_controller.rs
+++ b/boards/apollo3/lora_things_plus/src/tests/spi_controller.rs
@@ -6,7 +6,7 @@ use crate::tests::run_kernel_op;
 use crate::PERIPHERALS;
 use core::cell::Cell;
 #[allow(unused_imports)]
-use kernel::hil::spi::{ClockPhase, ClockPolarity};
+use kernel::hil::spi::{self, ClockPhase, ClockPolarity};
 use kernel::hil::spi::{SpiMaster, SpiMasterClient};
 use kernel::static_init;
 use kernel::utilities::cells::TakeCell;
@@ -150,9 +150,9 @@ fn spi_host_transfer_partial() {
 
     // Set iom2 Configs
     spi_host
-        .specify_chip_select(
+        .specify_chip_select(spi::cs::IntoChipSelect::<_, spi::cs::ActiveLow>::into_cs(
             &perf.gpio_port[11], // A5
-        )
+        ))
         .ok();
     spi_host.set_rate(100000).ok();
     spi_host.set_polarity(ClockPolarity::IdleLow).ok();

--- a/boards/apollo3/redboard_artemis_atp/src/main.rs
+++ b/boards/apollo3/redboard_artemis_atp/src/main.rs
@@ -326,7 +326,9 @@ unsafe fn setup() -> (
     let spi_controller = components::spi::SpiSyscallComponent::new(
         board_kernel,
         mux_spi,
-        &peripherals.gpio_port[13], // A13
+        kernel::hil::spi::util::IntoChipSelect::<_, kernel::hil::spi::util::ActiveLow>::into_cs(
+            &peripherals.gpio_port[13], // A13
+        ),
         capsules_core::spi_controller::DRIVER_NUM,
     )
     .finalize(components::spi_syscall_component_static!(

--- a/boards/apollo3/redboard_artemis_atp/src/main.rs
+++ b/boards/apollo3/redboard_artemis_atp/src/main.rs
@@ -326,7 +326,7 @@ unsafe fn setup() -> (
     let spi_controller = components::spi::SpiSyscallComponent::new(
         board_kernel,
         mux_spi,
-        kernel::hil::spi::util::IntoChipSelect::<_, kernel::hil::spi::util::ActiveLow>::into_cs(
+        kernel::hil::spi::cs::IntoChipSelect::<_, kernel::hil::spi::cs::ActiveLow>::into_cs(
             &peripherals.gpio_port[13], // A13
         ),
         capsules_core::spi_controller::DRIVER_NUM,

--- a/boards/apollo3/redboard_artemis_nano/src/main.rs
+++ b/boards/apollo3/redboard_artemis_nano/src/main.rs
@@ -350,7 +350,9 @@ unsafe fn setup() -> (
     let spi_controller = components::spi::SpiSyscallComponent::new(
         board_kernel,
         mux_spi,
-        &peripherals.gpio_port[35], // A14
+        kernel::hil::spi::util::IntoChipSelect::<_, kernel::hil::spi::util::ActiveLow>::into_cs(
+            &peripherals.gpio_port[35], // A14
+        ),
         capsules_core::spi_controller::DRIVER_NUM,
     )
     .finalize(components::spi_syscall_component_static!(

--- a/boards/apollo3/redboard_artemis_nano/src/main.rs
+++ b/boards/apollo3/redboard_artemis_nano/src/main.rs
@@ -350,7 +350,7 @@ unsafe fn setup() -> (
     let spi_controller = components::spi::SpiSyscallComponent::new(
         board_kernel,
         mux_spi,
-        kernel::hil::spi::util::IntoChipSelect::<_, kernel::hil::spi::util::ActiveLow>::into_cs(
+        kernel::hil::spi::cs::IntoChipSelect::<_, kernel::hil::spi::cs::ActiveLow>::into_cs(
             &peripherals.gpio_port[35], // A14
         ),
         capsules_core::spi_controller::DRIVER_NUM,

--- a/boards/apollo3/redboard_artemis_nano/src/tests/spi_controller.rs
+++ b/boards/apollo3/redboard_artemis_nano/src/tests/spi_controller.rs
@@ -6,7 +6,7 @@ use crate::tests::run_kernel_op;
 use crate::PERIPHERALS;
 use core::cell::Cell;
 #[allow(unused_imports)]
-use kernel::hil::spi::{ClockPhase, ClockPolarity};
+use kernel::hil::spi::{self, ClockPhase, ClockPolarity};
 use kernel::hil::spi::{SpiMaster, SpiMasterClient};
 use kernel::static_init;
 use kernel::utilities::cells::TakeCell;
@@ -150,9 +150,9 @@ fn spi_host_transfer_partial() {
 
     // Set iom0 Configs
     spi_host
-        .specify_chip_select(
+        .specify_chip_select(spi::cs::IntoChipSelect::<_, spi::cs::ActiveLow>::into_cs(
             &perf.gpio_port[35], // A14
-        )
+        ))
         .ok();
     spi_host.set_rate(100000).ok();
     spi_host.set_polarity(ClockPolarity::IdleLow).ok();

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -653,7 +653,7 @@ unsafe fn start() -> (
 
     let bus = components::bus::SpiMasterBusComponent::new(
         spi_mux,
-        hil::spi::util::IntoChipSelect::<_, hil::spi::util::ActiveLow>::into_cs(
+        hil::spi::cs::IntoChipSelect::<_, hil::spi::cs::ActiveLow>::into_cs(
             &nrf52840_peripherals.gpio_port[ST7789H2_CS],
         ),
         20_000_000,

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -19,6 +19,7 @@ use capsules_core::virtualizers::virtual_aes_ccm::MuxAES128CCM;
 
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::hil;
 use kernel::hil::buzzer::Buzzer;
 use kernel::hil::i2c::I2CMaster;
 use kernel::hil::led::LedHigh;
@@ -652,9 +653,8 @@ unsafe fn start() -> (
 
     let bus = components::bus::SpiMasterBusComponent::new(
         spi_mux,
-        kernel::hil::spi::util::ChipSelect::new(
+        hil::spi::util::IntoChipSelect::<_, hil::spi::util::ActiveLow>::into_cs(
             &nrf52840_peripherals.gpio_port[ST7789H2_CS],
-            kernel::hil::spi::util::ChipSelectActivePolarity::ActiveLow,
         ),
         20_000_000,
         kernel::hil::spi::ClockPhase::SampleLeading,

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -652,7 +652,10 @@ unsafe fn start() -> (
 
     let bus = components::bus::SpiMasterBusComponent::new(
         spi_mux,
-        &nrf52840_peripherals.gpio_port[ST7789H2_CS],
+        kernel::hil::spi::util::ChipSelect::new(
+            &nrf52840_peripherals.gpio_port[ST7789H2_CS],
+            kernel::hil::spi::util::ChipSelectActivePolarity::ActiveLow,
+        ),
         20_000_000,
         kernel::hil::spi::ClockPhase::SampleLeading,
         kernel::hil::spi::ClockPolarity::IdleLow,

--- a/boards/components/src/fm25cl.rs
+++ b/boards/components/src/fm25cl.rs
@@ -42,7 +42,7 @@ macro_rules! fm25cl_component_static {
 
 pub struct Fm25clComponent<
     S: 'static + spi::SpiMaster<'static>,
-    CS: spi::util::IntoChipSelect<S::ChipSelect, spi::util::ActiveLow>,
+    CS: spi::cs::IntoChipSelect<S::ChipSelect, spi::cs::ActiveLow>,
 > {
     spi_mux: &'static MuxSpiMaster<'static, S>,
     chip_select: CS,
@@ -50,7 +50,7 @@ pub struct Fm25clComponent<
 
 impl<
         S: 'static + spi::SpiMaster<'static>,
-        CS: spi::util::IntoChipSelect<S::ChipSelect, spi::util::ActiveLow>,
+        CS: spi::cs::IntoChipSelect<S::ChipSelect, spi::cs::ActiveLow>,
     > Fm25clComponent<S, CS>
 {
     pub fn new(spi_mux: &'static MuxSpiMaster<'static, S>, chip_select: CS) -> Self {
@@ -63,7 +63,7 @@ impl<
 
 impl<
         S: 'static + spi::SpiMaster<'static>,
-        CS: spi::util::IntoChipSelect<S::ChipSelect, spi::util::ActiveLow>,
+        CS: spi::cs::IntoChipSelect<S::ChipSelect, spi::cs::ActiveLow>,
     > Component for Fm25clComponent<S, CS>
 {
     type StaticInput = (

--- a/boards/components/src/fm25cl.rs
+++ b/boards/components/src/fm25cl.rs
@@ -40,24 +40,28 @@ macro_rules! fm25cl_component_static {
     };};
 }
 
-pub struct Fm25clComponent<S: 'static + spi::SpiMaster<'static>> {
+pub struct Fm25clComponent<
+    S: 'static + spi::SpiMaster<'static>,
+    CS: spi::util::IntoChipSelect<S::ChipSelect, true>,
+> {
     spi_mux: &'static MuxSpiMaster<'static, S>,
-    chip_select: S::ChipSelect,
+    chip_select: CS,
 }
 
-impl<S: 'static + spi::SpiMaster<'static>> Fm25clComponent<S> {
-    pub fn new(
-        spi_mux: &'static MuxSpiMaster<'static, S>,
-        chip_select: S::ChipSelect,
-    ) -> Fm25clComponent<S> {
-        Fm25clComponent {
+impl<S: 'static + spi::SpiMaster<'static>, CS: spi::util::IntoChipSelect<S::ChipSelect, true>>
+    Fm25clComponent<S, CS>
+{
+    pub fn new(spi_mux: &'static MuxSpiMaster<'static, S>, chip_select: CS) -> Self {
+        Self {
             spi_mux,
             chip_select,
         }
     }
 }
 
-impl<S: 'static + spi::SpiMaster<'static>> Component for Fm25clComponent<S> {
+impl<S: 'static + spi::SpiMaster<'static>, CS: spi::util::IntoChipSelect<S::ChipSelect, true>>
+    Component for Fm25clComponent<S, CS>
+{
     type StaticInput = (
         &'static mut MaybeUninit<VirtualSpiMasterDevice<'static, S>>,
         &'static mut MaybeUninit<FM25CL<'static, VirtualSpiMasterDevice<'static, S>>>,
@@ -67,9 +71,10 @@ impl<S: 'static + spi::SpiMaster<'static>> Component for Fm25clComponent<S> {
     type Output = &'static FM25CL<'static, VirtualSpiMasterDevice<'static, S>>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let spi_device = static_buffer
-            .0
-            .write(VirtualSpiMasterDevice::new(self.spi_mux, self.chip_select));
+        let spi_device = static_buffer.0.write(VirtualSpiMasterDevice::new(
+            self.spi_mux,
+            self.chip_select.into_cs(),
+        ));
         spi_device.setup();
 
         let txbuffer = static_buffer.2.write([0; capsules_extra::fm25cl::BUF_LEN]);

--- a/boards/components/src/fm25cl.rs
+++ b/boards/components/src/fm25cl.rs
@@ -42,14 +42,16 @@ macro_rules! fm25cl_component_static {
 
 pub struct Fm25clComponent<
     S: 'static + spi::SpiMaster<'static>,
-    CS: spi::util::IntoChipSelect<S::ChipSelect, true>,
+    CS: spi::util::IntoChipSelect<S::ChipSelect, spi::util::ActiveLow>,
 > {
     spi_mux: &'static MuxSpiMaster<'static, S>,
     chip_select: CS,
 }
 
-impl<S: 'static + spi::SpiMaster<'static>, CS: spi::util::IntoChipSelect<S::ChipSelect, true>>
-    Fm25clComponent<S, CS>
+impl<
+        S: 'static + spi::SpiMaster<'static>,
+        CS: spi::util::IntoChipSelect<S::ChipSelect, spi::util::ActiveLow>,
+    > Fm25clComponent<S, CS>
 {
     pub fn new(spi_mux: &'static MuxSpiMaster<'static, S>, chip_select: CS) -> Self {
         Self {
@@ -59,8 +61,10 @@ impl<S: 'static + spi::SpiMaster<'static>, CS: spi::util::IntoChipSelect<S::Chip
     }
 }
 
-impl<S: 'static + spi::SpiMaster<'static>, CS: spi::util::IntoChipSelect<S::ChipSelect, true>>
-    Component for Fm25clComponent<S, CS>
+impl<
+        S: 'static + spi::SpiMaster<'static>,
+        CS: spi::util::IntoChipSelect<S::ChipSelect, spi::util::ActiveLow>,
+    > Component for Fm25clComponent<S, CS>
 {
     type StaticInput = (
         &'static mut MaybeUninit<VirtualSpiMasterDevice<'static, S>>,

--- a/boards/components/src/l3gd20.rs
+++ b/boards/components/src/l3gd20.rs
@@ -47,7 +47,7 @@ pub type L3gd20ComponentType<S> = capsules_extra::l3gd20::L3gd20Spi<'static, S>;
 
 pub struct L3gd20Component<
     S: 'static + spi::SpiMaster<'static>,
-    CS: spi::util::IntoChipSelect<S::ChipSelect, true>,
+    CS: spi::util::IntoChipSelect<S::ChipSelect, spi::util::ActiveLow>,
 > {
     spi_mux: &'static MuxSpiMaster<'static, S>,
     chip_select: CS,
@@ -55,8 +55,10 @@ pub struct L3gd20Component<
     driver_num: usize,
 }
 
-impl<S: 'static + spi::SpiMaster<'static>, CS: spi::util::IntoChipSelect<S::ChipSelect, true>>
-    L3gd20Component<S, CS>
+impl<
+        S: 'static + spi::SpiMaster<'static>,
+        CS: spi::util::IntoChipSelect<S::ChipSelect, spi::util::ActiveLow>,
+    > L3gd20Component<S, CS>
 {
     pub fn new(
         spi_mux: &'static MuxSpiMaster<'static, S>,
@@ -73,8 +75,10 @@ impl<S: 'static + spi::SpiMaster<'static>, CS: spi::util::IntoChipSelect<S::Chip
     }
 }
 
-impl<S: 'static + spi::SpiMaster<'static>, CS: spi::util::IntoChipSelect<S::ChipSelect, true>>
-    Component for L3gd20Component<S, CS>
+impl<
+        S: 'static + spi::SpiMaster<'static>,
+        CS: spi::util::IntoChipSelect<S::ChipSelect, spi::util::ActiveLow>,
+    > Component for L3gd20Component<S, CS>
 {
     type StaticInput = (
         &'static mut MaybeUninit<VirtualSpiMasterDevice<'static, S>>,

--- a/boards/components/src/l3gd20.rs
+++ b/boards/components/src/l3gd20.rs
@@ -47,7 +47,7 @@ pub type L3gd20ComponentType<S> = capsules_extra::l3gd20::L3gd20Spi<'static, S>;
 
 pub struct L3gd20Component<
     S: 'static + spi::SpiMaster<'static>,
-    CS: spi::util::IntoChipSelect<S::ChipSelect, spi::util::ActiveLow>,
+    CS: spi::cs::IntoChipSelect<S::ChipSelect, spi::cs::ActiveLow>,
 > {
     spi_mux: &'static MuxSpiMaster<'static, S>,
     chip_select: CS,
@@ -57,7 +57,7 @@ pub struct L3gd20Component<
 
 impl<
         S: 'static + spi::SpiMaster<'static>,
-        CS: spi::util::IntoChipSelect<S::ChipSelect, spi::util::ActiveLow>,
+        CS: spi::cs::IntoChipSelect<S::ChipSelect, spi::cs::ActiveLow>,
     > L3gd20Component<S, CS>
 {
     pub fn new(
@@ -77,7 +77,7 @@ impl<
 
 impl<
         S: 'static + spi::SpiMaster<'static>,
-        CS: spi::util::IntoChipSelect<S::ChipSelect, spi::util::ActiveLow>,
+        CS: spi::cs::IntoChipSelect<S::ChipSelect, spi::cs::ActiveLow>,
     > Component for L3gd20Component<S, CS>
 {
     type StaticInput = (

--- a/boards/components/src/l3gd20.rs
+++ b/boards/components/src/l3gd20.rs
@@ -45,21 +45,26 @@ macro_rules! l3gd20_component_static {
 
 pub type L3gd20ComponentType<S> = capsules_extra::l3gd20::L3gd20Spi<'static, S>;
 
-pub struct L3gd20Component<S: 'static + spi::SpiMaster<'static>> {
+pub struct L3gd20Component<
+    S: 'static + spi::SpiMaster<'static>,
+    CS: spi::util::IntoChipSelect<S::ChipSelect, true>,
+> {
     spi_mux: &'static MuxSpiMaster<'static, S>,
-    chip_select: S::ChipSelect,
+    chip_select: CS,
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
 }
 
-impl<S: 'static + spi::SpiMaster<'static>> L3gd20Component<S> {
+impl<S: 'static + spi::SpiMaster<'static>, CS: spi::util::IntoChipSelect<S::ChipSelect, true>>
+    L3gd20Component<S, CS>
+{
     pub fn new(
         spi_mux: &'static MuxSpiMaster<'static, S>,
-        chip_select: S::ChipSelect,
+        chip_select: CS,
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
-    ) -> L3gd20Component<S> {
-        L3gd20Component {
+    ) -> Self {
+        Self {
             spi_mux,
             chip_select,
             board_kernel,
@@ -68,7 +73,9 @@ impl<S: 'static + spi::SpiMaster<'static>> L3gd20Component<S> {
     }
 }
 
-impl<S: 'static + spi::SpiMaster<'static>> Component for L3gd20Component<S> {
+impl<S: 'static + spi::SpiMaster<'static>, CS: spi::util::IntoChipSelect<S::ChipSelect, true>>
+    Component for L3gd20Component<S, CS>
+{
     type StaticInput = (
         &'static mut MaybeUninit<VirtualSpiMasterDevice<'static, S>>,
         &'static mut MaybeUninit<L3gd20Spi<'static, VirtualSpiMasterDevice<'static, S>>>,
@@ -81,9 +88,10 @@ impl<S: 'static + spi::SpiMaster<'static>> Component for L3gd20Component<S> {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
         let grant = self.board_kernel.create_grant(self.driver_num, &grant_cap);
 
-        let spi_device = static_buffer
-            .0
-            .write(VirtualSpiMasterDevice::new(self.spi_mux, self.chip_select));
+        let spi_device = static_buffer.0.write(VirtualSpiMasterDevice::new(
+            self.spi_mux,
+            self.chip_select.into_cs(),
+        ));
         spi_device.setup();
 
         let txbuffer = static_buffer

--- a/boards/components/src/lpm013m126.rs
+++ b/boards/components/src/lpm013m126.rs
@@ -87,9 +87,7 @@ where
     P: 'static + gpio::Pin,
     S: 'static + SpiMaster<'static>,
 {
-    pub fn new<
-        I: kernel::hil::spi::util::IntoChipSelect<S::ChipSelect, hil::spi::util::ActiveHigh>,
-    >(
+    pub fn new<I: kernel::hil::spi::cs::IntoChipSelect<S::ChipSelect, hil::spi::cs::ActiveHigh>>(
         spi: &'static MuxSpiMaster<'static, S>,
 
         chip_select: I,

--- a/boards/components/src/lpm013m126.rs
+++ b/boards/components/src/lpm013m126.rs
@@ -44,54 +44,6 @@ use kernel::hil::gpio;
 use kernel::hil::spi::{SpiMaster, SpiMasterDevice};
 use kernel::hil::time::Alarm;
 
-/// CS is active high
-pub struct Inverted<'a, P: gpio::Pin>(pub &'a P);
-
-impl<'a, P: gpio::Pin> gpio::Configure for Inverted<'a, P> {
-    fn configuration(&self) -> gpio::Configuration {
-        self.0.configuration()
-    }
-    fn make_output(&self) -> gpio::Configuration {
-        self.0.make_output()
-    }
-    fn disable_output(&self) -> gpio::Configuration {
-        self.0.disable_output()
-    }
-    fn make_input(&self) -> gpio::Configuration {
-        self.0.make_input()
-    }
-    fn disable_input(&self) -> gpio::Configuration {
-        self.0.disable_input()
-    }
-    fn deactivate_to_low_power(&self) {
-        self.0.deactivate_to_low_power()
-    }
-    fn set_floating_state(&self, _: gpio::FloatingState) {
-        unimplemented!() // not sure what it looks like with inversion
-    }
-    fn floating_state(&self) -> gpio::FloatingState {
-        unimplemented!() // not sure what it looks like with inversion
-    }
-}
-
-impl<'a, P: gpio::Pin> gpio::Output for Inverted<'a, P> {
-    fn set(&self) {
-        self.0.clear()
-    }
-    fn clear(&self) {
-        self.0.set()
-    }
-    fn toggle(&self) -> bool {
-        self.0.toggle()
-    }
-}
-
-impl<'a, P: gpio::Pin> gpio::Input for Inverted<'a, P> {
-    fn read(&self) -> bool {
-        !self.0.read()
-    }
-}
-
 /// Setup static space for the driver and its requirements.
 #[macro_export]
 macro_rules! lpm013m126_component_static {

--- a/boards/components/src/lpm013m126.rs
+++ b/boards/components/src/lpm013m126.rs
@@ -87,17 +87,17 @@ where
     P: 'static + gpio::Pin,
     S: 'static + SpiMaster<'static>,
 {
-    pub fn new(
+    pub fn new<I: kernel::hil::spi::util::IntoChipSelect<S::ChipSelect, false>>(
         spi: &'static MuxSpiMaster<'static, S>,
 
-        chip_select: S::ChipSelect,
+        chip_select: I,
         disp: &'static P,
         extcomin: &'static P,
         alarm_mux: &'static MuxAlarm<'static, A>,
     ) -> Self {
         Self {
             spi,
-            chip_select,
+            chip_select: chip_select.into_cs(),
             disp,
             extcomin,
             alarm_mux,

--- a/boards/components/src/lpm013m126.rs
+++ b/boards/components/src/lpm013m126.rs
@@ -40,9 +40,9 @@ use capsules_core::virtualizers::virtual_spi::{MuxSpiMaster, VirtualSpiMasterDev
 use capsules_extra::lpm013m126::Lpm013m126;
 use core::mem::MaybeUninit;
 use kernel::component::Component;
-use kernel::hil::gpio;
 use kernel::hil::spi::{SpiMaster, SpiMasterDevice};
 use kernel::hil::time::Alarm;
+use kernel::hil::{self, gpio};
 
 /// Setup static space for the driver and its requirements.
 #[macro_export]
@@ -87,7 +87,9 @@ where
     P: 'static + gpio::Pin,
     S: 'static + SpiMaster<'static>,
 {
-    pub fn new<I: kernel::hil::spi::util::IntoChipSelect<S::ChipSelect, false>>(
+    pub fn new<
+        I: kernel::hil::spi::util::IntoChipSelect<S::ChipSelect, hil::spi::util::ActiveHigh>,
+    >(
         spi: &'static MuxSpiMaster<'static, S>,
 
         chip_select: I,

--- a/boards/components/src/mx25r6435f.rs
+++ b/boards/components/src/mx25r6435f.rs
@@ -81,17 +81,17 @@ impl<
         A: 'static + hil::time::Alarm<'static>,
     > Mx25r6435fComponent<S, P, A>
 {
-    pub fn new(
+    pub fn new<CS: kernel::hil::spi::util::IntoChipSelect<S::ChipSelect, true>>(
         write_protect_pin: Option<&'static P>,
         hold_pin: Option<&'static P>,
-        chip_select: S::ChipSelect,
+        chip_select: CS,
         mux_alarm: &'static MuxAlarm<'static, A>,
         mux_spi: &'static MuxSpiMaster<'static, S>,
     ) -> Mx25r6435fComponent<S, P, A> {
         Mx25r6435fComponent {
             write_protect_pin,
             hold_pin,
-            chip_select,
+            chip_select: chip_select.into_cs(),
             mux_alarm,
             mux_spi,
         }

--- a/boards/components/src/mx25r6435f.rs
+++ b/boards/components/src/mx25r6435f.rs
@@ -81,7 +81,9 @@ impl<
         A: 'static + hil::time::Alarm<'static>,
     > Mx25r6435fComponent<S, P, A>
 {
-    pub fn new<CS: kernel::hil::spi::util::IntoChipSelect<S::ChipSelect, true>>(
+    pub fn new<
+        CS: kernel::hil::spi::util::IntoChipSelect<S::ChipSelect, hil::spi::util::ActiveLow>,
+    >(
         write_protect_pin: Option<&'static P>,
         hold_pin: Option<&'static P>,
         chip_select: CS,

--- a/boards/components/src/mx25r6435f.rs
+++ b/boards/components/src/mx25r6435f.rs
@@ -81,9 +81,7 @@ impl<
         A: 'static + hil::time::Alarm<'static>,
     > Mx25r6435fComponent<S, P, A>
 {
-    pub fn new<
-        CS: kernel::hil::spi::util::IntoChipSelect<S::ChipSelect, hil::spi::util::ActiveLow>,
-    >(
+    pub fn new<CS: kernel::hil::spi::cs::IntoChipSelect<S::ChipSelect, hil::spi::cs::ActiveLow>>(
         write_protect_pin: Option<&'static P>,
         hold_pin: Option<&'static P>,
         chip_select: CS,

--- a/boards/components/src/spi.rs
+++ b/boards/components/src/spi.rs
@@ -128,8 +128,8 @@ pub struct SpiSyscallPComponent<S: 'static + spi::SpiSlave<'static>> {
 
 pub struct SpiComponent<
     S: 'static + spi::SpiMaster<'static>,
-    CS: spi::util::IntoChipSelect<S::ChipSelect, AP>,
-    AP: spi::util::ChipSelect,
+    CS: spi::cs::IntoChipSelect<S::ChipSelect, AP>,
+    AP: spi::cs::ChipSelectActivePolarity,
 > {
     spi_mux: &'static MuxSpiMaster<'static, S>,
     chip_select: CS,
@@ -254,8 +254,8 @@ impl<S: 'static + spi::SpiSlave<'static>> Component for SpiSyscallPComponent<S> 
 
 impl<
         S: 'static + spi::SpiMaster<'static>,
-        CS: spi::util::IntoChipSelect<S::ChipSelect, AP>,
-        AP: spi::util::ChipSelect,
+        CS: spi::cs::IntoChipSelect<S::ChipSelect, AP>,
+        AP: spi::cs::ChipSelectActivePolarity,
     > SpiComponent<S, CS, AP>
 {
     pub fn new(mux: &'static MuxSpiMaster<'static, S>, chip_select: CS) -> Self {
@@ -269,8 +269,8 @@ impl<
 
 impl<
         S: 'static + spi::SpiMaster<'static>,
-        CS: spi::util::IntoChipSelect<S::ChipSelect, AP>,
-        AP: spi::util::ChipSelect,
+        CS: spi::cs::IntoChipSelect<S::ChipSelect, AP>,
+        AP: spi::cs::ChipSelectActivePolarity,
     > Component for SpiComponent<S, CS, AP>
 {
     type StaticInput = &'static mut MaybeUninit<VirtualSpiMasterDevice<'static, S>>;

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -381,7 +381,7 @@ unsafe fn start() -> (
     let spi_syscalls = components::spi::SpiSyscallComponent::new(
         board_kernel,
         mux_spi,
-        0,
+        sam4l::spi::CS(0),
         capsules_core::spi_controller::DRIVER_NUM,
     )
     .finalize(components::spi_syscall_component_static!(sam4l::spi::SpiHw));

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -381,7 +381,7 @@ unsafe fn start() -> (
     let spi_syscalls = components::spi::SpiSyscallComponent::new(
         board_kernel,
         mux_spi,
-        sam4l::spi::CS(0),
+        sam4l::spi::Peripheral::Peripheral0,
         capsules_core::spi_controller::DRIVER_NUM,
     )
     .finalize(components::spi_syscall_component_static!(sam4l::spi::SpiHw));

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -465,13 +465,13 @@ unsafe fn start() -> (
     let spi_syscalls = SpiSyscallComponent::new(
         board_kernel,
         mux_spi,
-        sam4l::spi::CS(2),
+        sam4l::spi::Peripheral::Peripheral2,
         capsules_core::spi_controller::DRIVER_NUM,
     )
     .finalize(components::spi_syscall_component_static!(
         sam4l::spi::SpiHw<'static>
     ));
-    let rf233_spi = SpiComponent::new(mux_spi, sam4l::spi::CS(3)).finalize(
+    let rf233_spi = SpiComponent::new(mux_spi, sam4l::spi::Peripheral::Peripheral3).finalize(
         components::spi_component_static!(sam4l::spi::SpiHw<'static>),
     );
     let rf233 = components::rf233::RF233Component::new(

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -465,15 +465,15 @@ unsafe fn start() -> (
     let spi_syscalls = SpiSyscallComponent::new(
         board_kernel,
         mux_spi,
-        2,
+        sam4l::spi::CS(2),
         capsules_core::spi_controller::DRIVER_NUM,
     )
     .finalize(components::spi_syscall_component_static!(
         sam4l::spi::SpiHw<'static>
     ));
-    let rf233_spi = SpiComponent::new(mux_spi, 3).finalize(components::spi_component_static!(
-        sam4l::spi::SpiHw<'static>
-    ));
+    let rf233_spi = SpiComponent::new(mux_spi, sam4l::spi::CS(3)).finalize(
+        components::spi_component_static!(sam4l::spi::SpiHw<'static>),
+    );
     let rf233 = components::rf233::RF233Component::new(
         rf233_spi,
         &peripherals.pa[09], // reset

--- a/boards/imix/src/test/spi_dummy.rs
+++ b/boards/imix/src/test/spi_dummy.rs
@@ -80,7 +80,8 @@ pub unsafe fn spi_dummy_test(spi: &'static sam4l::spi::SpiHw<'static>) {
     pin2.set();
 
     let spicb = kernel::static_init!(DummyCB, DummyCB::new(spi));
-    spi.set_active_peripheral(sam4l::spi::Peripheral::Peripheral0);
+    spi.specify_chip_select(sam4l::spi::Peripheral::Peripheral0)
+        .unwrap();
     spi.set_client(spicb);
 
     spi.init().unwrap();

--- a/boards/imix/src/test/spi_loopback.rs
+++ b/boards/imix/src/test/spi_loopback.rs
@@ -112,9 +112,9 @@ pub unsafe fn spi_loopback_test(
 #[inline(never)]
 #[allow(unused_variables, dead_code)]
 pub unsafe fn spi_two_loopback_test(mux: &'static MuxSpiMaster<'static, sam4l::spi::SpiHw>) {
-    let spi_fast = SpiComponent::new(mux, sam4l::spi::CS(0))
+    let spi_fast = SpiComponent::new(mux, sam4l::spi::Peripheral::Peripheral0)
         .finalize(components::spi_component_static!(sam4l::spi::SpiHw));
-    let spi_slow = SpiComponent::new(mux, sam4l::spi::CS(1))
+    let spi_slow = SpiComponent::new(mux, sam4l::spi::Peripheral::Peripheral1)
         .finalize(components::spi_component_static!(sam4l::spi::SpiHw));
 
     let spicb_fast = kernel::static_init!(SpiLoopback, SpiLoopback::new(spi_fast, 0, 0x80));

--- a/boards/imix/src/test/spi_loopback.rs
+++ b/boards/imix/src/test/spi_loopback.rs
@@ -112,10 +112,10 @@ pub unsafe fn spi_loopback_test(
 #[inline(never)]
 #[allow(unused_variables, dead_code)]
 pub unsafe fn spi_two_loopback_test(mux: &'static MuxSpiMaster<'static, sam4l::spi::SpiHw>) {
-    let spi_fast =
-        SpiComponent::new(mux, 0).finalize(components::spi_component_static!(sam4l::spi::SpiHw));
-    let spi_slow =
-        SpiComponent::new(mux, 1).finalize(components::spi_component_static!(sam4l::spi::SpiHw));
+    let spi_fast = SpiComponent::new(mux, sam4l::spi::CS(0))
+        .finalize(components::spi_component_static!(sam4l::spi::SpiHw));
+    let spi_slow = SpiComponent::new(mux, sam4l::spi::CS(1))
+        .finalize(components::spi_component_static!(sam4l::spi::SpiHw));
 
     let spicb_fast = kernel::static_init!(SpiLoopback, SpiLoopback::new(spi_fast, 0, 0x80));
     let spicb_slow = kernel::static_init!(SpiLoopback, SpiLoopback::new(spi_slow, 1, 0x00));

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -720,10 +720,7 @@ pub unsafe fn start() -> (
     let mx25r6435f = components::mx25r6435f::Mx25r6435fComponent::new(
         Some(&gpio_port[SPI_MX25R6435F_WRITE_PROTECT_PIN]),
         Some(&gpio_port[SPI_MX25R6435F_HOLD_PIN]),
-        kernel::hil::spi::util::ChipSelect::new(
-            &gpio_port[SPI_MX25R6435F_CHIP_SELECT],
-            kernel::hil::spi::util::ChipSelectActivePolarity::ActiveLow,
-        ),
+        &gpio_port[SPI_MX25R6435F_CHIP_SELECT],
         mux_alarm,
         mux_spi,
     )

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -697,7 +697,10 @@ pub unsafe fn start() -> (
     let spi_controller = components::spi::SpiSyscallComponent::new(
         board_kernel,
         mux_spi,
-        &gpio_port[SPI_CS],
+        kernel::hil::spi::util::ChipSelect::new(
+            &gpio_port[SPI_CS],
+            kernel::hil::spi::util::ChipSelectActivePolarity::ActiveLow,
+        ),
         capsules_core::spi_controller::DRIVER_NUM,
     )
     .finalize(components::spi_syscall_component_static!(
@@ -717,7 +720,10 @@ pub unsafe fn start() -> (
     let mx25r6435f = components::mx25r6435f::Mx25r6435fComponent::new(
         Some(&gpio_port[SPI_MX25R6435F_WRITE_PROTECT_PIN]),
         Some(&gpio_port[SPI_MX25R6435F_HOLD_PIN]),
-        &gpio_port[SPI_MX25R6435F_CHIP_SELECT] as &dyn kernel::hil::gpio::Pin,
+        kernel::hil::spi::util::ChipSelect::new(
+            &gpio_port[SPI_MX25R6435F_CHIP_SELECT],
+            kernel::hil::spi::util::ChipSelectActivePolarity::ActiveLow,
+        ),
         mux_alarm,
         mux_spi,
     )

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -697,9 +697,8 @@ pub unsafe fn start() -> (
     let spi_controller = components::spi::SpiSyscallComponent::new(
         board_kernel,
         mux_spi,
-        kernel::hil::spi::util::ChipSelect::new(
+        kernel::hil::spi::util::IntoChipSelect::<_, kernel::hil::spi::util::ActiveLow>::into_cs(
             &gpio_port[SPI_CS],
-            kernel::hil::spi::util::ChipSelectActivePolarity::ActiveLow,
         ),
         capsules_core::spi_controller::DRIVER_NUM,
     )

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -697,7 +697,7 @@ pub unsafe fn start() -> (
     let spi_controller = components::spi::SpiSyscallComponent::new(
         board_kernel,
         mux_spi,
-        kernel::hil::spi::util::IntoChipSelect::<_, kernel::hil::spi::util::ActiveLow>::into_cs(
+        kernel::hil::spi::cs::IntoChipSelect::<_, kernel::hil::spi::cs::ActiveLow>::into_cs(
             &gpio_port[SPI_CS],
         ),
         capsules_core::spi_controller::DRIVER_NUM,

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -550,7 +550,7 @@ unsafe fn setup() -> (
     let spi_controller = components::spi::SpiSyscallComponent::new(
         board_kernel,
         mux_spi,
-        0,
+        lowrisc::spi_host::CS(0),
         capsules_core::spi_controller::DRIVER_NUM,
     )
     .finalize(components::spi_syscall_component_static!(

--- a/boards/opentitan/src/tests/spi_host.rs
+++ b/boards/opentitan/src/tests/spi_host.rs
@@ -149,7 +149,7 @@ fn spi_host_transfer_partial() {
     cb.tx_len.set(tx.len());
 
     //Set SPI_HOST0 Configs
-    spi_host.specify_chip_select(0).ok();
+    spi_host.specify_chip_select(lowrisc::spi_host::CS(0)).ok();
     spi_host.set_rate(100000).ok();
     spi_host.set_polarity(ClockPolarity::IdleLow).ok();
     spi_host.set_phase(ClockPhase::SampleLeading).ok();
@@ -187,7 +187,7 @@ fn spi_host_transfer_single() {
     cb.tx_len.set(tx.len());
 
     //Set SPI_HOST0 Configs
-    spi_host.specify_chip_select(0).ok();
+    spi_host.specify_chip_select(lowrisc::spi_host::CS(0)).ok();
     spi_host.set_rate(100000).ok();
     spi_host.set_polarity(ClockPolarity::IdleLow).ok();
     spi_host.set_phase(ClockPhase::SampleLeading).ok();

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -465,7 +465,7 @@ pub unsafe fn start() -> (
 
     let bus = components::bus::SpiMasterBusComponent::new(
         mux_spi,
-        hil::spi::util::IntoChipSelect::<_, hil::spi::util::ActiveLow>::into_cs(
+        hil::spi::cs::IntoChipSelect::<_, hil::spi::cs::ActiveLow>::into_cs(
             peripherals.pins.get_pin(RPGpio::GPIO17),
         ),
         20_000_000,

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -465,7 +465,10 @@ pub unsafe fn start() -> (
 
     let bus = components::bus::SpiMasterBusComponent::new(
         mux_spi,
-        peripherals.pins.get_pin(RPGpio::GPIO17),
+        kernel::hil::spi::util::ChipSelect::new(
+            peripherals.pins.get_pin(RPGpio::GPIO17),
+            kernel::hil::spi::util::ChipSelectActivePolarity::ActiveLow,
+        ),
         20_000_000,
         kernel::hil::spi::ClockPhase::SampleLeading,
         kernel::hil::spi::ClockPolarity::IdleLow,

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -19,12 +19,12 @@ use components::gpio::GpioComponent;
 use components::led::LedsComponent;
 use enum_primitive::cast::FromPrimitive;
 use kernel::component::Component;
-use kernel::debug;
 use kernel::hil::led::LedHigh;
 use kernel::hil::usb::Client;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{capabilities, create_capability, static_init, Kernel};
+use kernel::{debug, hil};
 
 use rp2040::adc::{Adc, Channel};
 use rp2040::chip::{Rp2040, Rp2040DefaultPeripherals};
@@ -465,9 +465,8 @@ pub unsafe fn start() -> (
 
     let bus = components::bus::SpiMasterBusComponent::new(
         mux_spi,
-        kernel::hil::spi::util::ChipSelect::new(
+        hil::spi::util::IntoChipSelect::<_, hil::spi::util::ActiveLow>::into_cs(
             peripherals.pins.get_pin(RPGpio::GPIO17),
-            kernel::hil::spi::util::ChipSelectActivePolarity::ActiveLow,
         ),
         20_000_000,
         kernel::hil::spi::ClockPhase::SampleLeading,

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -454,10 +454,7 @@ pub unsafe fn start() -> (
         );
 
         let disp_pin = &nrf52840_peripherals.gpio_port[Pin::P0_07];
-        let cs_pin = kernel::hil::spi::util::ChipSelect::new(
-            &nrf52840_peripherals.gpio_port[Pin::P0_05],
-            kernel::hil::spi::util::ChipSelectActivePolarity::ActiveHigh,
-        );
+        let cs_pin = &nrf52840_peripherals.gpio_port[Pin::P0_05];
 
         let display = components::lpm013m126::Lpm013m126Component::new(
             mux_spi,

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -454,9 +454,9 @@ pub unsafe fn start() -> (
         );
 
         let disp_pin = &nrf52840_peripherals.gpio_port[Pin::P0_07];
-        let cs_pin = static_init!(
-            components::lpm013m126::Inverted<'static, nrf52840::gpio::GPIOPin>,
-            components::lpm013m126::Inverted(&nrf52840_peripherals.gpio_port[Pin::P0_05])
+        let cs_pin = kernel::hil::spi::util::ChipSelect::new(
+            &nrf52840_peripherals.gpio_port[Pin::P0_05],
+            kernel::hil::spi::util::ChipSelectActivePolarity::ActiveHigh,
         );
 
         let display = components::lpm013m126::Lpm013m126Component::new(

--- a/boards/wm1110dev/src/main.rs
+++ b/boards/wm1110dev/src/main.rs
@@ -373,7 +373,7 @@ pub unsafe fn start() -> (
     let lr1110_spi = components::spi::SpiSyscallComponent::new(
         board_kernel,
         mux_spi,
-        hil::spi::util::IntoChipSelect::<_, hil::spi::util::ActiveLow>::into_cs(
+        hil::spi::cs::IntoChipSelect::<_, hil::spi::cs::ActiveLow>::into_cs(
             &nrf52840_peripherals.gpio_port[SPI_CS_PIN],
         ),
         LORA_SPI_DRIVER_NUM,
@@ -391,7 +391,7 @@ pub unsafe fn start() -> (
     base_peripherals
         .spim0
         .specify_chip_select(
-            hil::spi::util::IntoChipSelect::<_, hil::spi::util::ActiveLow>::into_cs(
+            hil::spi::cs::IntoChipSelect::<_, hil::spi::cs::ActiveLow>::into_cs(
                 &nrf52840_peripherals.gpio_port[SPI_CS_PIN],
             ),
         )

--- a/boards/wm1110dev/src/main.rs
+++ b/boards/wm1110dev/src/main.rs
@@ -17,6 +17,7 @@ use core::ptr::addr_of_mut;
 
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::hil;
 use kernel::hil::gpio::Configure;
 use kernel::hil::gpio::Output;
 use kernel::hil::led::LedHigh;
@@ -372,9 +373,8 @@ pub unsafe fn start() -> (
     let lr1110_spi = components::spi::SpiSyscallComponent::new(
         board_kernel,
         mux_spi,
-        kernel::hil::spi::util::ChipSelect::new(
+        hil::spi::util::IntoChipSelect::<_, hil::spi::util::ActiveLow>::into_cs(
             &nrf52840_peripherals.gpio_port[SPI_CS_PIN],
-            kernel::hil::spi::util::ChipSelectActivePolarity::ActiveLow,
         ),
         LORA_SPI_DRIVER_NUM,
     )
@@ -390,10 +390,11 @@ pub unsafe fn start() -> (
 
     base_peripherals
         .spim0
-        .specify_chip_select(kernel::hil::spi::util::ChipSelect::new(
-            &nrf52840_peripherals.gpio_port[SPI_CS_PIN],
-            kernel::hil::spi::util::ChipSelectActivePolarity::ActiveLow,
-        ))
+        .specify_chip_select(
+            hil::spi::util::IntoChipSelect::<_, hil::spi::util::ActiveLow>::into_cs(
+                &nrf52840_peripherals.gpio_port[SPI_CS_PIN],
+            ),
+        )
         .unwrap();
 
     // Pin mappings from the original WM1110 source code.

--- a/boards/wm1110dev/src/main.rs
+++ b/boards/wm1110dev/src/main.rs
@@ -372,7 +372,10 @@ pub unsafe fn start() -> (
     let lr1110_spi = components::spi::SpiSyscallComponent::new(
         board_kernel,
         mux_spi,
-        &nrf52840_peripherals.gpio_port[SPI_CS_PIN],
+        kernel::hil::spi::util::ChipSelect::new(
+            &nrf52840_peripherals.gpio_port[SPI_CS_PIN],
+            kernel::hil::spi::util::ChipSelectActivePolarity::ActiveLow,
+        ),
         LORA_SPI_DRIVER_NUM,
     )
     .finalize(components::spi_syscall_component_static!(
@@ -387,7 +390,10 @@ pub unsafe fn start() -> (
 
     base_peripherals
         .spim0
-        .specify_chip_select(&nrf52840_peripherals.gpio_port[SPI_CS_PIN])
+        .specify_chip_select(kernel::hil::spi::util::ChipSelect::new(
+            &nrf52840_peripherals.gpio_port[SPI_CS_PIN],
+            kernel::hil::spi::util::ChipSelectActivePolarity::ActiveLow,
+        ))
         .unwrap();
 
     // Pin mappings from the original WM1110 source code.

--- a/chips/apollo3/src/iom.rs
+++ b/chips/apollo3/src/iom.rs
@@ -290,7 +290,7 @@ pub struct Iom<'a> {
 
     op: Cell<Operation>,
     spi_phase: Cell<ClockPhase>,
-    spi_cs: OptionalCell<ChipSelectPolar<&'a crate::gpio::GpioPin<'a>>>,
+    spi_cs: OptionalCell<ChipSelectPolar<'a, crate::gpio::GpioPin<'a>>>,
     smbus: Cell<bool>,
 }
 
@@ -1176,7 +1176,7 @@ impl<'a> hil::i2c::SMBusMaster<'a> for Iom<'a> {
 }
 
 impl<'a> SpiMaster<'a> for Iom<'a> {
-    type ChipSelect = ChipSelectPolar<&'a crate::gpio::GpioPin<'a>>;
+    type ChipSelect = ChipSelectPolar<'a, crate::gpio::GpioPin<'a>>;
 
     fn init(&self) -> Result<(), ErrorCode> {
         self.op.set(Operation::SPI);

--- a/chips/apollo3/src/iom.rs
+++ b/chips/apollo3/src/iom.rs
@@ -8,7 +8,7 @@ use core::cell::Cell;
 use kernel::hil;
 use kernel::hil::gpio::Configure;
 use kernel::hil::i2c;
-use kernel::hil::spi::util::ChipSelectPolar;
+use kernel::hil::spi::cs::ChipSelectPolar;
 use kernel::hil::spi::{ClockPhase, ClockPolarity, SpiMaster, SpiMasterClient};
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::cells::TakeCell;

--- a/chips/lowrisc/src/spi_host.rs
+++ b/chips/lowrisc/src/spi_host.rs
@@ -553,7 +553,7 @@ impl<'a> SpiHost<'a> {
 #[derive(Copy, Clone)]
 pub struct CS(pub u32);
 
-impl hil::spi::util::IntoChipSelect<CS, hil::spi::util::ActiveLow> for CS {
+impl hil::spi::cs::IntoChipSelect<CS, hil::spi::cs::ActiveLow> for CS {
     fn into_cs(self) -> CS {
         self
     }

--- a/chips/lowrisc/src/spi_host.rs
+++ b/chips/lowrisc/src/spi_host.rs
@@ -143,7 +143,6 @@ pub struct SpiHost<'a> {
     registers: StaticRef<SpiHostRegisters>,
     client: OptionalCell<&'a dyn hil::spi::SpiMasterClient>,
     busy: Cell<bool>,
-    chip_select: Cell<u32>,
     cpu_clk: u32,
     tsclk: Cell<u32>,
     tx_buf: TakeCell<'static, [u8]>,
@@ -164,7 +163,6 @@ impl<'a> SpiHost<'a> {
             registers: base,
             client: OptionalCell::empty(),
             busy: Cell::new(false),
-            chip_select: Cell::new(0),
             cpu_clk,
             tsclk: Cell::new(0),
             tx_buf: TakeCell::empty(),
@@ -552,8 +550,17 @@ impl<'a> SpiHost<'a> {
     }
 }
 
+#[derive(Copy, Clone)]
+pub struct CS(pub u32);
+
+impl hil::spi::util::IntoChipSelect<CS, hil::spi::util::ActiveLow> for CS {
+    fn into_cs(self) -> CS {
+        self
+    }
+}
+
 impl<'a> hil::spi::SpiMaster<'a> for SpiHost<'a> {
-    type ChipSelect = u32;
+    type ChipSelect = CS;
 
     fn init(&self) -> Result<(), ErrorCode> {
         let regs = self.registers;
@@ -660,8 +667,7 @@ impl<'a> hil::spi::SpiMaster<'a> for SpiHost<'a> {
         let regs = self.registers;
 
         //CSID will index the CONFIGOPTS multi-register
-        regs.csid.write(csid_ctrl::CSID.val(cs));
-        self.chip_select.set(cs);
+        regs.csid.write(csid_ctrl::CSID.val(cs.0));
 
         Ok(())
     }

--- a/chips/nrf52/src/spi.rs
+++ b/chips/nrf52/src/spi.rs
@@ -37,7 +37,7 @@ use core::cell::Cell;
 use core::{cmp, ptr};
 use kernel::hil;
 use kernel::hil::gpio::Configure;
-use kernel::hil::spi::util::ChipSelect;
+use kernel::hil::spi::util::ChipSelectPolar;
 use kernel::utilities::cells::{OptionalCell, TakeCell, VolatileCell};
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{register_bitfields, ReadWrite, WriteOnly};
@@ -242,7 +242,7 @@ impl Frequency {
 pub struct SPIM<'a> {
     registers: StaticRef<SpimRegisters>,
     client: OptionalCell<&'a dyn hil::spi::SpiMasterClient>,
-    chip_select: OptionalCell<ChipSelect<&'a crate::gpio::GPIOPin<'a>>>,
+    chip_select: OptionalCell<ChipSelectPolar<&'a crate::gpio::GPIOPin<'a>>>,
     busy: Cell<bool>,
     tx_buf: TakeCell<'static, [u8]>,
     rx_buf: TakeCell<'static, [u8]>,
@@ -339,7 +339,7 @@ impl<'a> SPIM<'a> {
 }
 
 impl<'a> hil::spi::SpiMaster<'a> for SPIM<'a> {
-    type ChipSelect = ChipSelect<&'a crate::gpio::GPIOPin<'a>>;
+    type ChipSelect = ChipSelectPolar<&'a crate::gpio::GPIOPin<'a>>;
 
     fn set_client(&self, client: &'a dyn hil::spi::SpiMasterClient) {
         self.client.set(client);

--- a/chips/nrf52/src/spi.rs
+++ b/chips/nrf52/src/spi.rs
@@ -242,7 +242,7 @@ impl Frequency {
 pub struct SPIM<'a> {
     registers: StaticRef<SpimRegisters>,
     client: OptionalCell<&'a dyn hil::spi::SpiMasterClient>,
-    chip_select: OptionalCell<ChipSelectPolar<&'a crate::gpio::GPIOPin<'a>>>,
+    chip_select: OptionalCell<ChipSelectPolar<'a, crate::gpio::GPIOPin<'a>>>,
     busy: Cell<bool>,
     tx_buf: TakeCell<'static, [u8]>,
     rx_buf: TakeCell<'static, [u8]>,
@@ -339,7 +339,7 @@ impl<'a> SPIM<'a> {
 }
 
 impl<'a> hil::spi::SpiMaster<'a> for SPIM<'a> {
-    type ChipSelect = ChipSelectPolar<&'a crate::gpio::GPIOPin<'a>>;
+    type ChipSelect = ChipSelectPolar<'a, crate::gpio::GPIOPin<'a>>;
 
     fn set_client(&self, client: &'a dyn hil::spi::SpiMasterClient) {
         self.client.set(client);

--- a/chips/nrf52/src/spi.rs
+++ b/chips/nrf52/src/spi.rs
@@ -37,7 +37,7 @@ use core::cell::Cell;
 use core::{cmp, ptr};
 use kernel::hil;
 use kernel::hil::gpio::Configure;
-use kernel::hil::spi::util::ChipSelectPolar;
+use kernel::hil::spi::cs::ChipSelectPolar;
 use kernel::utilities::cells::{OptionalCell, TakeCell, VolatileCell};
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{register_bitfields, ReadWrite, WriteOnly};

--- a/chips/nrf52/src/spi.rs
+++ b/chips/nrf52/src/spi.rs
@@ -36,6 +36,8 @@
 use core::cell::Cell;
 use core::{cmp, ptr};
 use kernel::hil;
+use kernel::hil::gpio::Configure;
+use kernel::hil::spi::util::ChipSelect;
 use kernel::utilities::cells::{OptionalCell, TakeCell, VolatileCell};
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{register_bitfields, ReadWrite, WriteOnly};
@@ -240,7 +242,7 @@ impl Frequency {
 pub struct SPIM<'a> {
     registers: StaticRef<SpimRegisters>,
     client: OptionalCell<&'a dyn hil::spi::SpiMasterClient>,
-    chip_select: OptionalCell<&'a dyn hil::gpio::Pin>,
+    chip_select: OptionalCell<ChipSelect<&'a crate::gpio::GPIOPin<'a>>>,
     busy: Cell<bool>,
     tx_buf: TakeCell<'static, [u8]>,
     rx_buf: TakeCell<'static, [u8]>,
@@ -270,7 +272,7 @@ impl<'a> SPIM<'a> {
                 return;
             }
 
-            self.chip_select.map(|cs| cs.set());
+            self.chip_select.map(|cs| cs.deactivate());
             self.registers.events_end.write(EVENT::EVENT::CLEAR);
 
             // When we are no longer active or busy we can disable the
@@ -337,7 +339,7 @@ impl<'a> SPIM<'a> {
 }
 
 impl<'a> hil::spi::SpiMaster<'a> for SPIM<'a> {
-    type ChipSelect = &'a dyn hil::gpio::Pin;
+    type ChipSelect = ChipSelect<&'a crate::gpio::GPIOPin<'a>>;
 
     fn set_client(&self, client: &'a dyn hil::spi::SpiMasterClient) {
         self.client.set(client);
@@ -365,7 +367,7 @@ impl<'a> hil::spi::SpiMaster<'a> for SPIM<'a> {
         if self.chip_select.is_none() {
             return Err((ErrorCode::NODEVICE, tx_buf, rx_buf));
         }
-        self.chip_select.map(|cs| cs.clear());
+        self.chip_select.map(|cs| cs.activate());
 
         // Setup transmit data registers
         let tx_len: u32 = cmp::min(len, tx_buf.len()) as u32;
@@ -418,8 +420,8 @@ impl<'a> hil::spi::SpiMaster<'a> for SPIM<'a> {
     // The type of the argument is based on what makes sense for the
     // peripheral when this trait is implemented.
     fn specify_chip_select(&self, cs: Self::ChipSelect) -> Result<(), ErrorCode> {
-        cs.make_output();
-        cs.set();
+        cs.pin.make_output();
+        cs.deactivate();
         self.chip_select.set(cs);
         Ok(())
     }

--- a/chips/rp2040/src/spi.rs
+++ b/chips/rp2040/src/spi.rs
@@ -6,7 +6,7 @@ use crate::clocks;
 use core::cell::Cell;
 use core::cmp;
 use kernel::hil;
-use kernel::hil::spi::util::ChipSelectPolar;
+use kernel::hil::spi::cs::ChipSelectPolar;
 use kernel::hil::spi::SpiMaster;
 use kernel::hil::spi::SpiMasterClient;
 use kernel::hil::spi::{ClockPhase, ClockPolarity};

--- a/chips/rp2040/src/spi.rs
+++ b/chips/rp2040/src/spi.rs
@@ -238,7 +238,7 @@ pub struct Spi<'a> {
     registers: StaticRef<SpiRegisters>,
     clocks: OptionalCell<&'a clocks::Clocks>,
     master_client: OptionalCell<&'a dyn hil::spi::SpiMasterClient>,
-    active_slave: OptionalCell<ChipSelectPolar<&'a crate::gpio::RPGpioPin<'a>>>,
+    active_slave: OptionalCell<ChipSelectPolar<'a, crate::gpio::RPGpioPin<'a>>>,
 
     tx_buffer: TakeCell<'static, [u8]>,
     tx_position: Cell<usize>,
@@ -482,7 +482,7 @@ impl<'a> Spi<'a> {
 }
 
 impl<'a> SpiMaster<'a> for Spi<'a> {
-    type ChipSelect = ChipSelectPolar<&'a crate::gpio::RPGpioPin<'a>>;
+    type ChipSelect = ChipSelectPolar<'a, crate::gpio::RPGpioPin<'a>>;
 
     fn set_client(&self, client: &'a dyn SpiMasterClient) {
         self.master_client.set(client);

--- a/chips/rp2040/src/spi.rs
+++ b/chips/rp2040/src/spi.rs
@@ -6,7 +6,7 @@ use crate::clocks;
 use core::cell::Cell;
 use core::cmp;
 use kernel::hil;
-use kernel::hil::spi::util::ChipSelect;
+use kernel::hil::spi::util::ChipSelectPolar;
 use kernel::hil::spi::SpiMaster;
 use kernel::hil::spi::SpiMasterClient;
 use kernel::hil::spi::{ClockPhase, ClockPolarity};
@@ -238,7 +238,7 @@ pub struct Spi<'a> {
     registers: StaticRef<SpiRegisters>,
     clocks: OptionalCell<&'a clocks::Clocks>,
     master_client: OptionalCell<&'a dyn hil::spi::SpiMasterClient>,
-    active_slave: OptionalCell<ChipSelect<&'a crate::gpio::RPGpioPin<'a>>>,
+    active_slave: OptionalCell<ChipSelectPolar<&'a crate::gpio::RPGpioPin<'a>>>,
 
     tx_buffer: TakeCell<'static, [u8]>,
     tx_position: Cell<usize>,
@@ -482,7 +482,7 @@ impl<'a> Spi<'a> {
 }
 
 impl<'a> SpiMaster<'a> for Spi<'a> {
-    type ChipSelect = ChipSelect<&'a crate::gpio::RPGpioPin<'a>>;
+    type ChipSelect = ChipSelectPolar<&'a crate::gpio::RPGpioPin<'a>>;
 
     fn set_client(&self, client: &'a dyn SpiMasterClient) {
         self.master_client.set(client);

--- a/chips/sam4l/src/spi.rs
+++ b/chips/sam4l/src/spi.rs
@@ -522,7 +522,7 @@ impl<'a> SpiHw<'a> {
 #[derive(Copy, Clone)]
 pub struct CS(pub u8);
 
-impl spi::util::IntoChipSelect<CS, true> for CS {
+impl spi::util::IntoChipSelect<CS, spi::util::ActiveLow> for CS {
     fn into_cs(self) -> CS {
         self
     }

--- a/chips/sam4l/src/spi.rs
+++ b/chips/sam4l/src/spi.rs
@@ -179,7 +179,7 @@ pub enum Peripheral {
     Peripheral3,
 }
 
-impl spi::util::IntoChipSelect<Peripheral, spi::util::ActiveLow> for Peripheral {
+impl spi::cs::IntoChipSelect<Peripheral, spi::cs::ActiveLow> for Peripheral {
     fn into_cs(self) -> Peripheral {
         self
     }

--- a/chips/sam4l/src/spi.rs
+++ b/chips/sam4l/src/spi.rs
@@ -519,8 +519,17 @@ impl<'a> SpiHw<'a> {
     }
 }
 
+#[derive(Copy, Clone)]
+pub struct CS(pub u8);
+
+impl spi::util::IntoChipSelect<CS, true> for CS {
+    fn into_cs(self) -> CS {
+        self
+    }
+}
+
 impl<'a> spi::SpiMaster<'a> for SpiHw<'a> {
-    type ChipSelect = u8;
+    type ChipSelect = CS;
 
     fn set_client(&self, client: &'a dyn SpiMasterClient) {
         self.client.set(client);
@@ -636,7 +645,7 @@ impl<'a> spi::SpiMaster<'a> for SpiHw<'a> {
     }
 
     fn specify_chip_select(&self, cs: Self::ChipSelect) -> Result<(), ErrorCode> {
-        match match cs {
+        match match cs.0 {
             0 => Some(Peripheral::Peripheral0),
             1 => Some(Peripheral::Peripheral1),
             2 => Some(Peripheral::Peripheral2),

--- a/chips/sam4l/src/usart.rs
+++ b/chips/sam4l/src/usart.rs
@@ -10,8 +10,8 @@ use core::cell::Cell;
 use core::cmp;
 use core::sync::atomic::{AtomicBool, Ordering};
 use kernel::deferred_call::{DeferredCall, DeferredCallClient};
-use kernel::hil;
 use kernel::hil::spi;
+use kernel::hil::spi::cs::ChipSelectPolar;
 use kernel::hil::uart;
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
@@ -406,7 +406,7 @@ pub struct USART<'a> {
 
     client: OptionalCell<UsartClient<'a>>,
 
-    spi_chip_select: OptionalCell<&'a dyn hil::gpio::Pin>,
+    spi_chip_select: OptionalCell<ChipSelectPolar<&'a crate::gpio::GPIOPin<'a>>>,
     pm: &'a pm::PowerManager,
     dc_state: OptionalCell<DeferredCallState>,
     deferred_call: DeferredCall,
@@ -685,7 +685,7 @@ impl<'a> USART<'a> {
                                 self.rts_disable_spi_deassert_cs(usart);
                             },
                             |cs| {
-                                cs.set();
+                                cs.deactivate();
                             },
                         );
 
@@ -1051,7 +1051,7 @@ impl<'a> uart::ReceiveAdvanced<'a> for USART<'a> {
 
 /// SPI
 impl<'a> spi::SpiMaster<'a> for USART<'a> {
-    type ChipSelect = Option<&'static dyn hil::gpio::Pin>;
+    type ChipSelect = ChipSelectPolar<&'a crate::gpio::GPIOPin<'a>>;
 
     fn init(&self) -> Result<(), ErrorCode> {
         let usart = &USARTRegManager::new(self);
@@ -1111,7 +1111,7 @@ impl<'a> spi::SpiMaster<'a> for USART<'a> {
                 self.rts_enable_spi_assert_cs(usart);
             },
             |cs| {
-                cs.clear();
+                cs.activate();
             },
         );
 
@@ -1185,7 +1185,7 @@ impl<'a> spi::SpiMaster<'a> for USART<'a> {
 
     /// Pass in a None to use the HW chip select pin on the USART (RTS).
     fn specify_chip_select(&self, cs: Self::ChipSelect) -> Result<(), ErrorCode> {
-        self.spi_chip_select.insert(cs);
+        self.spi_chip_select.set(cs);
         Ok(())
     }
 

--- a/chips/sam4l/src/usart.rs
+++ b/chips/sam4l/src/usart.rs
@@ -406,7 +406,7 @@ pub struct USART<'a> {
 
     client: OptionalCell<UsartClient<'a>>,
 
-    spi_chip_select: OptionalCell<ChipSelectPolar<&'a crate::gpio::GPIOPin<'a>>>,
+    spi_chip_select: OptionalCell<ChipSelectPolar<'a, crate::gpio::GPIOPin<'a>>>,
     pm: &'a pm::PowerManager,
     dc_state: OptionalCell<DeferredCallState>,
     deferred_call: DeferredCall,
@@ -1051,7 +1051,7 @@ impl<'a> uart::ReceiveAdvanced<'a> for USART<'a> {
 
 /// SPI
 impl<'a> spi::SpiMaster<'a> for USART<'a> {
-    type ChipSelect = ChipSelectPolar<&'a crate::gpio::GPIOPin<'a>>;
+    type ChipSelect = ChipSelectPolar<'a, crate::gpio::GPIOPin<'a>>;
 
     fn init(&self) -> Result<(), ErrorCode> {
         let usart = &USARTRegManager::new(self);

--- a/chips/stm32f303xc/src/spi.rs
+++ b/chips/stm32f303xc/src/spi.rs
@@ -191,7 +191,7 @@ pub struct Spi<'a> {
     // SPI slave support not yet implemented
     master_client: OptionalCell<&'a dyn hil::spi::SpiMasterClient>,
 
-    active_slave: OptionalCell<spi::util::ChipSelect<&'a crate::gpio::Pin<'a>>>,
+    active_slave: OptionalCell<spi::util::ChipSelectPolar<&'a crate::gpio::Pin<'a>>>,
 
     tx_buffer: TakeCell<'static, [u8]>,
     tx_position: Cell<usize>,
@@ -411,7 +411,7 @@ impl<'a> Spi<'a> {
 }
 
 impl<'a> spi::SpiMaster<'a> for Spi<'a> {
-    type ChipSelect = spi::util::ChipSelect<&'a crate::gpio::Pin<'a>>;
+    type ChipSelect = spi::util::ChipSelectPolar<&'a crate::gpio::Pin<'a>>;
 
     fn set_client(&self, client: &'a dyn SpiMasterClient) {
         self.master_client.set(client);

--- a/chips/stm32f303xc/src/spi.rs
+++ b/chips/stm32f303xc/src/spi.rs
@@ -191,7 +191,7 @@ pub struct Spi<'a> {
     // SPI slave support not yet implemented
     master_client: OptionalCell<&'a dyn hil::spi::SpiMasterClient>,
 
-    active_slave: OptionalCell<spi::cs::ChipSelectPolar<&'a crate::gpio::Pin<'a>>>,
+    active_slave: OptionalCell<spi::cs::ChipSelectPolar<'a, crate::gpio::Pin<'a>>>,
 
     tx_buffer: TakeCell<'static, [u8]>,
     tx_position: Cell<usize>,
@@ -411,7 +411,7 @@ impl<'a> Spi<'a> {
 }
 
 impl<'a> spi::SpiMaster<'a> for Spi<'a> {
-    type ChipSelect = spi::cs::ChipSelectPolar<&'a crate::gpio::Pin<'a>>;
+    type ChipSelect = spi::cs::ChipSelectPolar<'a, crate::gpio::Pin<'a>>;
 
     fn set_client(&self, client: &'a dyn SpiMasterClient) {
         self.master_client.set(client);

--- a/chips/stm32f303xc/src/spi.rs
+++ b/chips/stm32f303xc/src/spi.rs
@@ -191,7 +191,7 @@ pub struct Spi<'a> {
     // SPI slave support not yet implemented
     master_client: OptionalCell<&'a dyn hil::spi::SpiMasterClient>,
 
-    active_slave: OptionalCell<spi::util::ChipSelectPolar<&'a crate::gpio::Pin<'a>>>,
+    active_slave: OptionalCell<spi::cs::ChipSelectPolar<&'a crate::gpio::Pin<'a>>>,
 
     tx_buffer: TakeCell<'static, [u8]>,
     tx_position: Cell<usize>,
@@ -411,7 +411,7 @@ impl<'a> Spi<'a> {
 }
 
 impl<'a> spi::SpiMaster<'a> for Spi<'a> {
-    type ChipSelect = spi::util::ChipSelectPolar<&'a crate::gpio::Pin<'a>>;
+    type ChipSelect = spi::cs::ChipSelectPolar<&'a crate::gpio::Pin<'a>>;
 
     fn set_client(&self, client: &'a dyn SpiMasterClient) {
         self.master_client.set(client);

--- a/kernel/src/hil/gpio.rs
+++ b/kernel/src/hil/gpio.rs
@@ -176,20 +176,6 @@ pub trait Output {
     }
 }
 
-impl<'a, O: Output> Output for &'a O {
-    fn set(&self) {
-        (*self).set()
-    }
-
-    fn clear(&self) {
-        (*self).clear()
-    }
-
-    fn toggle(&self) -> bool {
-        (*self).toggle()
-    }
-}
-
 pub trait Input {
     /// Get the current state of an input GPIO pin. For an output
     /// pin, return the output; for an input pin, return the input;

--- a/kernel/src/hil/gpio.rs
+++ b/kernel/src/hil/gpio.rs
@@ -176,6 +176,20 @@ pub trait Output {
     }
 }
 
+impl<'a, O: Output> Output for &'a O {
+    fn set(&self) {
+        (*self).set()
+    }
+
+    fn clear(&self) {
+        (*self).clear()
+    }
+
+    fn toggle(&self) -> bool {
+        (*self).toggle()
+    }
+}
+
 pub trait Input {
     /// Get the current state of an input GPIO pin. For an output
     /// pin, return the output; for an input pin, return the input;

--- a/kernel/src/hil/spi.rs
+++ b/kernel/src/hil/spi.rs
@@ -87,6 +87,13 @@ pub mod cs {
     /// [SpiMaster::ChipSelect](super::SpiMaster::ChipSelect) for a
     /// particular `POLARITY`.
     ///
+    /// Instantiating a driver for any SPI peripheral should require a type that
+    /// implements [IntoChipSelect]. That enforces that whatever object is used
+    /// as the chip select can support the correct polarity for the particular SPI
+    /// peripheral. This is mostly commonly handled by the component for the
+    /// peripheral, which requires an object with type [IntoChipSelect] and then
+    /// converts the object to the [SpiMaster::ChipSelect](super::SpiMaster::ChipSelect)
+    /// type.
     /// # Examples:
     ///
     /// Some SPI host controllers only support active low or active

--- a/kernel/src/hil/spi.rs
+++ b/kernel/src/hil/spi.rs
@@ -40,7 +40,8 @@ pub enum ClockPhase {
     SampleTrailing,
 }
 
-pub mod util {
+/// Utility types for modeling chip select pins in a [SpiMaster] implementation.
+pub mod cs {
 
     #[derive(Copy, Clone)]
     pub enum Polarity {

--- a/kernel/src/hil/spi.rs
+++ b/kernel/src/hil/spi.rs
@@ -126,19 +126,26 @@ pub mod cs {
     /// A convenience wrapper type around
     /// [Output](crate::hil::gpio::Output) GPIO pins that implements
     /// [IntoChipSelect] for both [ActiveLow] and [ActiveHigh].
-    #[derive(Copy, Clone)]
-    pub struct ChipSelectPolar<P: crate::hil::gpio::Output> {
+    pub struct ChipSelectPolar<'a, P: crate::hil::gpio::Output> {
         /// The underlying chip select "pin"
-        pub pin: P,
+        pub pin: &'a P,
         /// The polarity from which this wrapper was derived using
         /// [IntoChipSelect]
         pub polarity: Polarity,
     }
 
-    impl<P: crate::hil::gpio::Output, A: ChipSelectActivePolarity>
-        IntoChipSelect<ChipSelectPolar<P>, A> for P
+    impl<'a, P: crate::hil::gpio::Output> Clone for ChipSelectPolar<'a, P> {
+        fn clone(&self) -> Self {
+            *self
+        }
+    }
+
+    impl<'a, P: crate::hil::gpio::Output> Copy for ChipSelectPolar<'a, P> {}
+
+    impl<'a, P: crate::hil::gpio::Output, A: ChipSelectActivePolarity>
+        IntoChipSelect<ChipSelectPolar<'a, P>, A> for &'a P
     {
-        fn into_cs(self) -> ChipSelectPolar<P> {
+        fn into_cs(self) -> ChipSelectPolar<'a, P> {
             ChipSelectPolar {
                 pin: self,
                 polarity: A::POLARITY,
@@ -150,7 +157,7 @@ pub mod cs {
     /// [gpio::Output](crate::hil::gpio::Output), users can use the
     /// `activate` and `deactivate` methods to automatically set or
     /// clear the chip select pin based on the stored polarity.
-    impl<P: crate::hil::gpio::Output> ChipSelectPolar<P> {
+    impl<'a, P: crate::hil::gpio::Output> ChipSelectPolar<'a, P> {
         /// Deactive the chip select pin
         ///
         /// High if active low, low if active high

--- a/kernel/src/hil/spi.rs
+++ b/kernel/src/hil/spi.rs
@@ -40,6 +40,42 @@ pub enum ClockPhase {
     SampleTrailing,
 }
 
+pub mod util {
+    #[derive(Copy, Clone)]
+    pub enum ChipSelectActivePolarity {
+        ActiveLow,
+        ActiveHigh,
+    }
+
+    #[derive(Copy, Clone)]
+    pub struct ChipSelect<P> {
+        pub pin: P,
+        pub polarity: ChipSelectActivePolarity,
+    }
+
+    impl<P> ChipSelect<P> {
+        pub fn new(pin: P, polarity: ChipSelectActivePolarity) -> Self {
+            Self { pin, polarity }
+        }
+    }
+
+    impl<P: crate::hil::gpio::Output> ChipSelect<P> {
+        pub fn deactivate(&self) {
+            match self.polarity {
+                ChipSelectActivePolarity::ActiveLow => self.pin.set(),
+                ChipSelectActivePolarity::ActiveHigh => self.pin.clear(),
+            }
+        }
+
+        pub fn activate(&self) {
+            match self.polarity {
+                ChipSelectActivePolarity::ActiveLow => self.pin.clear(),
+                ChipSelectActivePolarity::ActiveHigh => self.pin.set(),
+            }
+        }
+    }
+}
+
 /// Trait for clients of a SPI bus in master mode.
 pub trait SpiMasterClient {
     /// Callback when a read/write operation finishes: `read_buffer`

--- a/kernel/src/hil/spi.rs
+++ b/kernel/src/hil/spi.rs
@@ -41,7 +41,13 @@ pub enum ClockPhase {
 }
 
 pub mod util {
-    #[derive(Copy, Clone)]
+
+    pub trait IntoChipSelect<T, const ACTIVE_LOW: bool> {
+        fn into_cs(self) -> T;
+    }
+
+    #[repr(u8)]
+    #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
     pub enum ChipSelectActivePolarity {
         ActiveLow,
         ActiveHigh,
@@ -51,6 +57,19 @@ pub mod util {
     pub struct ChipSelect<P> {
         pub pin: P,
         pub polarity: ChipSelectActivePolarity,
+    }
+
+    impl<P, const A: bool> IntoChipSelect<ChipSelect<P>, A> for P {
+        fn into_cs(self) -> ChipSelect<P> {
+            ChipSelect {
+                pin: self,
+                polarity: if A {
+                    ChipSelectActivePolarity::ActiveLow
+                } else {
+                    ChipSelectActivePolarity::ActiveHigh
+                },
+            }
+        }
     }
 
     impl<P> ChipSelect<P> {

--- a/kernel/src/hil/spi.rs
+++ b/kernel/src/hil/spi.rs
@@ -123,14 +123,11 @@ pub mod cs {
         fn into_cs(self) -> T;
     }
 
-    /// A convenience wrapper type around any chip select type `P`,
-    /// and implements [IntoChipSelect] for both [ActiveLow] and
-    /// [ActiveHigh].
-    ///
-    /// Notably, there is a blanket implementation for all
-    /// [gpio::Output](crate::hil::gpio::Output) types.
+    /// A convenience wrapper type around
+    /// [Output](crate::hil::gpio::Output] GPIO pins that implements
+    /// [IntoChipSelect] for both [ActiveLow] and [ActiveHigh].
     #[derive(Copy, Clone)]
-    pub struct ChipSelectPolar<P> {
+    pub struct ChipSelectPolar<P: crate::hil::gpio::Output> {
         /// The underlying chip select "pin"
         pub pin: P,
         /// The polarity from which this wrapper was derived using
@@ -138,7 +135,9 @@ pub mod cs {
         pub polarity: Polarity,
     }
 
-    impl<P, A: ChipSelectActivePolarity> IntoChipSelect<ChipSelectPolar<P>, A> for P {
+    impl<P: crate::hil::gpio::Output, A: ChipSelectActivePolarity>
+        IntoChipSelect<ChipSelectPolar<P>, A> for P
+    {
         fn into_cs(self) -> ChipSelectPolar<P> {
             ChipSelectPolar {
                 pin: self,

--- a/kernel/src/hil/spi.rs
+++ b/kernel/src/hil/spi.rs
@@ -124,7 +124,7 @@ pub mod cs {
     }
 
     /// A convenience wrapper type around
-    /// [Output](crate::hil::gpio::Output] GPIO pins that implements
+    /// [Output](crate::hil::gpio::Output) GPIO pins that implements
     /// [IntoChipSelect] for both [ActiveLow] and [ActiveHigh].
     #[derive(Copy, Clone)]
     pub struct ChipSelectPolar<P: crate::hil::gpio::Output> {


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes #4133.

SPI chip select can be either active-low (most common) or active-high (less common, but exists). This PR adds type infrastructure for components to require a certain polarity and for chip implementations of SPI to both assert via types which polarities they are compatible with (some chips can only do active-low while anything that just uses GPIOs for chip-select can do both) as well as to dynamically act based on the specified polarity.

### Testing Strategy

Mostly compile tested, along with end-to-end testing of a few specific SPI peripherals on specific nRF boards. There is very little chance for something to go horribly wrong here, except for getting the polarity wrong on some peripheral---and it should be active low (was the assumed default) everywhere except for the LPM013[...].

This would be a wonderful case for having automated testing of things like end-to-end SPI peripheral functionality on actual hardware!

### TODO or Help Wanted

- [X] Testing
- [X] Document new types

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
