### PR TITLE
shell.nix: remove llvm workaround and prevent env var name collision

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -142,9 +142,9 @@ endif
 
 # Set variables of the key tools we need to compile a Tock kernel. Need to do
 # this after we handle if we are using the LLVM tools or not.
-SIZE    ?= $(TOOLCHAIN)-size
-OBJCOPY ?= $(TOOLCHAIN)-objcopy
-OBJDUMP ?= $(TOOLCHAIN)-objdump
+SIZE    = $(TOOLCHAIN)-size
+OBJCOPY = $(TOOLCHAIN)-objcopy
+OBJDUMP = $(TOOLCHAIN)-objdump
 
 # Set additional flags to produce binary from .elf.
 #

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -23,24 +23,24 @@ RUSTC_SYSROOT := "$(shell rustc --print sysroot)"
 
 # Common defaults that specific boards can override, but likely do not need to.
 #
-# The TOOLCHAIN parameter is set to the magic value "llvm-tools", which will
-# cause the Makefile to resolve the llvm toolchain installed as part of the
-# rustup component "llvm-tools". In case a system toolchain shall be used, this
-# can be overridden to specify the toolchain prefix, e.g. "llvm" for
+# The `TOCK_TOOLCHAIN` parameter is set to the magic value "llvm-tools", which
+# will cause the Makefile to resolve the llvm toolchain installed as part of
+# the rustup component "llvm-tools". In case a system toolchain shall be used,
+# this can be overridden to specify the toolchain prefix, e.g. "llvm" for
 # llvm-{objdump,objcopy,...} or "arm-none-eabi".
-TOOLCHAIN ?= llvm-tools
-CARGO     ?= cargo
+TOCK_TOOLCHAIN ?= llvm-tools
+TOCK_CARGO     ?= cargo
 
 # Not all platforms support the rustup tool. Those that do not can pass
-# `NO_RUSTUP=1` to make and then all of the rustup commands will be ignored.
-ifeq ($(NO_RUSTUP),)
-  RUSTUP ?= rustup
+# `TOCK_TOCK_NO_RUSTUP=1` to make and then all of the rustup commands will be ignored.
+ifeq ($(TOCK_NO_RUSTUP),)
+  TOCK_RUSTUP ?= rustup
 else
-  RUSTUP ?= true
+  TOCK_RUSTUP ?= true
 endif
 
 # Default location of target directory (relative to board makefile).
-TARGET_DIRECTORY ?= $(TOCK_ROOT_DIRECTORY)target/
+TOCK_TARGET_DIRECTORY ?= $(TOCK_ROOT_DIRECTORY)target/
 
 # http://stackoverflow.com/questions/10858261/abort-makefile-if-variable-not-set
 # Check that given variables are set and all have non-empty values, print an
@@ -54,11 +54,11 @@ check_defined = $(strip $(foreach 1,$1,$(if $(value $1),,$(error Undefined varia
 # wm1110dev v0.1.0 (/Users/bradjc/git/tock/boards/wm1110dev)
 # ├── capsules-core v0.1.0 (/Users/bradjc/git/tock/capsules/core)
 # │   ├── enum_primitive v0.1.0 (/Users/bradjc/git/tock/libraries/enum_primitive)
-PLATFORM := $(firstword $(shell $(CARGO) tree))
+PLATFORM := $(firstword $(shell $(TOCK_CARGO) tree))
 # Set `TARGET` if not already defined. Note: this only works on nightly.
 ifeq ($(TARGET),)
   # Get the specified target using the unstable `cargo config get` command.
-  TARGET_QUOTES := $(shell $(CARGO) config get --format json-value build.target)
+  TARGET_QUOTES := $(shell $(TOCK_CARGO) config get --format json-value build.target)
   # Remove the quotes from around the target name.
   TARGET := $(patsubst "%",%,$(TARGET_QUOTES))
 endif
@@ -71,7 +71,7 @@ $(call check_defined, PLATFORM)
 $(call check_defined, TARGET)
 
 # Location of target-specific build.
-TARGET_PATH := $(TARGET_DIRECTORY)$(TARGET)
+TARGET_PATH := $(TOCK_TARGET_DIRECTORY)$(TARGET)
 
 # If environment variable V or VERBOSE is non-empty, be verbose.
 ifneq ($(V),)
@@ -98,53 +98,53 @@ endif
 export TOCK_KERNEL_VERSION := $(shell git describe --tags --always 2> /dev/null || echo "2.1+")
 
 # Allow users to opt out of using rustup.
-ifeq ($(NO_RUSTUP),)
+ifeq ($(TOCK_NO_RUSTUP),)
 # Validate that rustup exists.
-RUSTUP_ERROR := $(shell $(RUSTUP) --version > /dev/null 2>&1; echo $$?)
+RUSTUP_ERROR := $(shell $(TOCK_RUSTUP) --version > /dev/null 2>&1; echo $$?)
 ifneq ($(RUSTUP_ERROR),0)
   $(info Error! rustup not found.)
   $(info Please follow the instructions at https://rustup.rs/ to install rustup.)
-  $(info Alternatively, install all required tools and Rust targets and set NO_RUSTUP=1 to disable this check.)
+  $(info Alternatively, install all required tools and Rust targets and set TOCK_NO_RUSTUP=1 to disable this check.)
   $(info )
   $(error Rustup required to build Tock.)
 endif
 
 # Validate that rustup is new enough.
 MINIMUM_RUSTUP_VERSION := 1.23.0
-RUSTUP_VERSION := $(strip $(word 2, $(shell $(RUSTUP) --version 2> /dev/null)))
+RUSTUP_VERSION := $(strip $(word 2, $(shell $(TOCK_RUSTUP) --version 2> /dev/null)))
 # Check that the semver script exists.
 ifneq (,$(wildcard $(TOCK_ROOT_DIRECTORY)tools/semver.sh))
 ifeq ($(shell $(TOCK_ROOT_DIRECTORY)tools/semver.sh $(RUSTUP_VERSION) \< $(MINIMUM_RUSTUP_VERSION)), true)
-  $(warning Required tool `$(RUSTUP)` is out-of-date.)
-  $(warning Running `$(RUSTUP) update` in 3 seconds (ctrl-c to cancel))
+  $(warning Required tool `$(TOCK_RUSTUP)` is out-of-date.)
+  $(warning Running `$(TOCK_RUSTUP) update` in 3 seconds (ctrl-c to cancel))
   $(shell sleep 3)
-  DUMMY := $(shell $(RUSTUP) update)
+  DUMMY := $(shell $(TOCK_RUSTUP) update)
 endif
 endif
 
 # Verify that various required Rust components are installed. All of these steps
 # only have to be done once per Rust version, but will take some time when
 # compiling for the first time.
-ifneq ($(shell $(RUSTUP) target list | grep "$(TARGET) (installed)"),$(TARGET) (installed))
+ifneq ($(shell $(TOCK_RUSTUP) target list | grep "$(TARGET) (installed)"),$(TARGET) (installed))
   $(warning Request to compile for a missing TARGET, make will install in 5s)
   $(warning Consider updating 'targets' in 'rust-toolchain.toml')
-  $(shell sleep 5s && $(RUSTUP) target add $(TARGET))
+  $(shell sleep 5s && $(TOCK_RUSTUP) target add $(TARGET))
 endif
-endif # $(NO_RUSTUP)
+endif # $(TOCK_NO_RUSTUP)
 
 # If the user is using the standard toolchain provided as part of the llvm-tools
 # rustup component we need to get the full path. rustup should take care of this
 # for us by putting in a proxy in .cargo/bin, but until that is setup we
 # workaround it.
-ifeq ($(TOOLCHAIN),llvm-tools)
-  TOOLCHAIN = "$(shell dirname $(shell find $(RUSTC_SYSROOT) -name llvm-size))/llvm"
+ifeq ($(TOCK_TOOLCHAIN),llvm-tools)
+  TOCK_TOOLCHAIN = "$(shell dirname $(shell find $(RUSTC_SYSROOT) -name llvm-size))/llvm"
 endif
 
 # Set variables of the key tools we need to compile a Tock kernel. Need to do
 # this after we handle if we are using the LLVM tools or not.
-SIZE    = $(TOOLCHAIN)-size
-OBJCOPY = $(TOOLCHAIN)-objcopy
-OBJDUMP = $(TOOLCHAIN)-objdump
+SIZE    = $(TOCK_TOOLCHAIN)-size
+OBJCOPY = $(TOCK_TOOLCHAIN)-objcopy
+OBJDUMP = $(TOCK_TOOLCHAIN)-objdump
 
 # Set additional flags to produce binary from .elf.
 #
@@ -155,29 +155,29 @@ OBJDUMP = $(TOOLCHAIN)-objdump
 #   the kernel binary file. This section is a placeholder for optionally
 #   including application binaries, and only needs to exist in the .elf. By
 #   removing it, we prevent the kernel binary from overwriting applications.
-OBJCOPY_FLAGS ?= --strip-sections --strip-all --remove-section .apps
+TOCK_OBJCOPY_FLAGS ?= --strip-sections --strip-all --remove-section .apps
 
 # Set the default flags we need for objdump to get a .lst file.
-OBJDUMP_FLAGS ?= --disassemble-all --source --section-headers --demangle
+TOCK_OBJDUMP_FLAGS ?= --disassemble-all --source --section-headers --demangle
 
 # Set default flags for size.
-SIZE_FLAGS ?=
+TOCK_SIZE_FLAGS ?=
 
 # Need an extra flag for OBJDUMP if we are on a thumb platform.
 ifneq (,$(findstring thumb,$(TARGET)))
-  OBJDUMP_FLAGS += --arch-name=thumb
+  TOCK_OBJDUMP_FLAGS += --arch-name=thumb
 endif
 
 # Additional flags that can be passed to print_tock_memory_usage.py via an
 # environment variable. By default, pass an empty string.
-PTMU_ARGS ?=
+TOCK_PTMU_ARGS ?=
 
 # Check whether the system already has a sha256sum or shasum application
 # present. If not, use the custom shipped one.
 ifeq (, $(shell sha256sum --version 2>/dev/null))
   ifeq (, $(shell shasum --version 2>/dev/null))
     # No system sha256sum available.
-    SHA256SUM := $(CARGO) run --manifest-path $(TOCK_ROOT_DIRECTORY)tools/sha256sum/Cargo.toml -- 2>/dev/null
+    SHA256SUM := $(TOCK_CARGO) run --manifest-path $(TOCK_ROOT_DIRECTORY)tools/sha256sum/Cargo.toml -- 2>/dev/null
   else
     # Use shasum found on MacOS.
     SHA256SUM := shasum -a 256
@@ -189,35 +189,35 @@ endif
 
 # Dump configuration for verbose builds
 ifeq ($(VERBOSE_MODE),1)
-RUST_FLAGS = $(shell $(CARGO) -Zunstable-options config get build.rustflags --format json-value 2> /dev/null || echo "Listing Rust flags only accessible on nightly cargo")
+RUST_FLAGS = $(shell $(TOCK_CARGO) -Zunstable-options config get build.rustflags --format json-value 2> /dev/null || echo "Listing Rust flags only accessible on nightly cargo")
   $(info )
   $(info *******************************************************)
   $(info TOCK KERNEL BUILD SYSTEM -- VERBOSE BUILD CONFIGURATION)
   $(info *******************************************************)
   $(info MAKEFILE_COMMON_PATH          = $(MAKEFILE_COMMON_PATH))
   $(info TOCK_ROOT_DIRECTORY           = $(TOCK_ROOT_DIRECTORY))
-  $(info TARGET_DIRECTORY              = $(TARGET_DIRECTORY))
+  $(info TOCK_TARGET_DIRECTORY         = $(TOCK_TARGET_DIRECTORY))
   $(info )
   $(info PLATFORM                      = $(PLATFORM))
   $(info TARGET                        = $(TARGET))
   $(info TOCK_KERNEL_VERSION           = $(TOCK_KERNEL_VERSION))
   $(info RUSTFLAGS                     = $(RUST_FLAGS))
   $(info MAKEFLAGS                     = $(MAKEFLAGS))
-  $(info OBJDUMP_FLAGS                 = $(OBJDUMP_FLAGS))
-  $(info OBJCOPY_FLAGS                 = $(OBJCOPY_FLAGS))
-  $(info SIZE_FLAGS                    = $(SIZE_FLAGS))
+  $(info TOCK_OBJDUMP_FLAGS            = $(TOCK_OBJDUMP_FLAGS))
+  $(info TOCK_OBJCOPY_FLAGS            = $(TOCK_OBJCOPY_FLAGS))
+  $(info TOCK_SIZE_FLAGS               = $(TOCK_SIZE_FLAGS))
   $(info )
-  $(info TOOLCHAIN                     = $(TOOLCHAIN))
+  $(info TOCK_TOOLCHAIN                = $(TOCK_TOOLCHAIN))
   $(info SIZE                          = $(SIZE))
   $(info OBJCOPY                       = $(OBJCOPY))
   $(info OBJDUMP                       = $(OBJDUMP))
-  $(info CARGO                         = $(CARGO))
-  $(info RUSTUP                        = $(RUSTUP))
+  $(info TOCK_CARGO                    = $(TOCK_CARGO))
+  $(info TOCK_RUSTUP                   = $(TOCK_RUSTUP))
   $(info SHA256SUM                     = $(SHA256SUM))
   $(info )
-  $(info cargo --version               = $(shell $(CARGO) --version))
+  $(info cargo --version               = $(shell $(TOCK_CARGO) --version))
   $(info rustc --version               = $(shell rustc --version))
-  $(info rustup --version              = $(shell $(RUSTUP) --version 2>/dev/null))
+  $(info rustup --version              = $(shell $(TOCK_RUSTUP) --version 2>/dev/null))
   $(info *******************************************************)
   $(info )
 endif
@@ -233,12 +233,12 @@ all: release
 # binary. This makes checking for Rust errors much faster.
 .PHONY: check
 check:
-	$(Q)$(CARGO) check $(VERBOSE_FLAGS)
+	$(Q)$(TOCK_CARGO) check $(VERBOSE_FLAGS)
 
 
 .PHONY: clean
 clean::
-	$(Q)$(CARGO) clean $(VERBOSE_FLAGS)
+	$(Q)$(TOCK_CARGO) clean $(VERBOSE_FLAGS)
 
 .PHONY: release
 release:  $(TARGET_PATH)/release/$(PLATFORM).bin
@@ -251,7 +251,7 @@ debug-lst:  $(TARGET_PATH)/debug/$(PLATFORM).lst
 
 .PHONY: doc
 doc:
-	$(Q)$(CARGO) --color=always doc $(VERBOSE_FLAGS) --release --package $(PLATFORM)
+	$(Q)$(TOCK_CARGO) --color=always doc $(VERBOSE_FLAGS) --release --package $(PLATFORM)
 
 
 .PHONY: lst
@@ -272,7 +272,7 @@ stack-analysis: $(TARGET_PATH)/release/$(PLATFORM)
 # Run the `print_tock_memory_usage.py` script for this board.
 .PHONY: memory
 memory: $(TARGET_PATH)/release/$(PLATFORM).elf
-	$(TOCK_ROOT_DIRECTORY)tools/print_tock_memory_usage.py --objdump $(OBJDUMP) -w $(PTMU_ARGS) $<
+	$(TOCK_ROOT_DIRECTORY)tools/print_tock_memory_usage.py --objdump $(OBJDUMP) -w $(TOCK_PTMU_ARGS) $<
 
 # Support rules
 
@@ -282,15 +282,15 @@ memory: $(TARGET_PATH)/release/$(PLATFORM).elf
 
 
 %.bin: %.elf
-	$(Q)$(OBJCOPY) --output-target=binary $(OBJCOPY_FLAGS) $< $@
+	$(Q)$(OBJCOPY) --output-target=binary $(TOCK_OBJCOPY_FLAGS) $< $@
 	$(Q)$(SHA256SUM) $@
 
 %.lst: %.elf
-	$(Q)$(OBJDUMP) $(OBJDUMP_FLAGS) $< > $@
+	$(Q)$(OBJDUMP) $(TOCK_OBJDUMP_FLAGS) $< > $@
 
 
 $(TOCK_ROOT_DIRECTORY)tools/sha256sum/target/debug/sha256sum:
-	$(Q)$(CARGO) build $(VERBOSE_FLAGS) --manifest-path $(TOCK_ROOT_DIRECTORY)tools/sha256sum/Cargo.toml
+	$(Q)$(TOCK_CARGO) build $(VERBOSE_FLAGS) --manifest-path $(TOCK_ROOT_DIRECTORY)tools/sha256sum/Cargo.toml
 
 
 # Cargo-drivers
@@ -299,10 +299,10 @@ $(TOCK_ROOT_DIRECTORY)tools/sha256sum/target/debug/sha256sum:
 
 .PHONY: $(TARGET_PATH)/release/$(PLATFORM)
 $(TARGET_PATH)/release/$(PLATFORM):
-	$(Q)$(CARGO) rustc $(VERBOSE_FLAGS) --bin $(PLATFORM) --release
-	$(Q)$(SIZE) $(SIZE_FLAGS) $@
+	$(Q)$(TOCK_CARGO) rustc $(VERBOSE_FLAGS) --bin $(PLATFORM) --release
+	$(Q)$(SIZE) $(TOCK_SIZE_FLAGS) $@
 
 .PHONY: $(TARGET_PATH)/debug/$(PLATFORM)
 $(TARGET_PATH)/debug/$(PLATFORM):
-	$(Q)$(CARGO) build $(VERBOSE_FLAGS) --bin $(PLATFORM)
-	$(Q)$(SIZE) $(SIZE_FLAGS) $@
+	$(Q)$(TOCK_CARGO) build $(VERBOSE_FLAGS) --bin $(PLATFORM)
+	$(Q)$(SIZE) $(TOCK_SIZE_FLAGS) $@

--- a/boards/apollo3/lora_things_plus/Makefile
+++ b/boards/apollo3/lora_things_plus/Makefile
@@ -47,4 +47,4 @@ test:
 	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
-	$(Q)OBJCOPY=${OBJCOPY} PORT=$(PORT) $(CARGO) test $(NO_RUN) --bin $(PLATFORM) --release
+	$(Q)OBJCOPY=${OBJCOPY} PORT=$(PORT) $(TOCK_CARGO) test $(NO_RUN) --bin $(PLATFORM) --release

--- a/boards/apollo3/redboard_artemis_atp/Makefile
+++ b/boards/apollo3/redboard_artemis_atp/Makefile
@@ -47,4 +47,4 @@ test:
 	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
-	$(Q)OBJCOPY=${OBJCOPY} PORT=$(PORT) $(CARGO) test $(NO_RUN) --bin $(PLATFORM) --release
+	$(Q)OBJCOPY=${OBJCOPY} PORT=$(PORT) $(TOCK_CARGO) test $(NO_RUN) --bin $(PLATFORM) --release

--- a/boards/apollo3/redboard_artemis_nano/Makefile
+++ b/boards/apollo3/redboard_artemis_nano/Makefile
@@ -47,4 +47,4 @@ test:
 	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
-	$(Q)OBJCOPY=${OBJCOPY} PORT=$(PORT) $(CARGO) test $(NO_RUN) --bin $(PLATFORM) --release
+	$(Q)OBJCOPY=${OBJCOPY} PORT=$(PORT) $(TOCK_CARGO) test $(NO_RUN) --bin $(PLATFORM) --release

--- a/boards/esp32-c3-devkitM-1/Makefile
+++ b/boards/esp32-c3-devkitM-1/Makefile
@@ -28,4 +28,4 @@ test:
 	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp ../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/
-	$(Q)$(CARGO) test $(NO_RUN) --bin $(PLATFORM) --release
+	$(Q)$(TOCK_CARGO) test $(NO_RUN) --bin $(PLATFORM) --release

--- a/boards/hifive1/Makefile
+++ b/boards/hifive1/Makefile
@@ -4,7 +4,7 @@
 
 # Makefile for building the tock kernel for the HiFive1 platform
 
-QEMU ?= qemu-system-riscv32
+TOCK_QEMU ?= qemu-system-riscv32
 
 include ../Makefile.common
 
@@ -17,10 +17,10 @@ flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 		-c "source [find board/sifive-hifive1-revb.cfg]; program $<; resume 0x20000000; exit"
 
 qemu: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	$(QEMU) -M sifive_e,revb=true -kernel $^  -nographic
+	$(TOCK_QEMU) -M sifive_e,revb=true -kernel $^  -nographic
 
 qemu-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	$(QEMU) -M sifive_e,revb=true -kernel $^ -device loader,file=$(APP),addr=0x20040000 -nographic
+	$(TOCK_QEMU) -M sifive_e,revb=true -kernel $^ -device loader,file=$(APP),addr=0x20040000 -nographic
 
 
 TOCKLOADER=tockloader

--- a/boards/hifive_inventor/Makefile
+++ b/boards/hifive_inventor/Makefile
@@ -4,7 +4,7 @@
 
 # Makefile for building the tock kernel for the HiFive Inventor platform
 
-QEMU ?= qemu-system-riscv32
+TOCK_QEMU ?= qemu-system-riscv32
 
 include ../Makefile.common
 

--- a/boards/nano_rp2040_connect/Makefile
+++ b/boards/nano_rp2040_connect/Makefile
@@ -9,7 +9,7 @@ include ../Makefile.common
 KERNEL=$(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/release/$(PLATFORM)-app.elf
 
-BOOTSEL_FOLDER?=/media/$(USER)/RPI-RP2
+TOCK_BOOTSEL_FOLDER?=/media/$(USER)/RPI-RP2
 
 # Default target for installing the kernel.
 .PHONY: install
@@ -21,7 +21,7 @@ flash-openocd: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 .PHONY: flash
 flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	elf2uf2-rs $< $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2
-	@if [ -d $(BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2 "$(BOOTSEL_FOLDER)"; else echo; echo Please edit the BOOTSEL_FOLDER variable to point to you Nano RP2040 Flash Drive Folder; fi
+	@if [ -d $(TOCK_TOCK_BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2 "$(TOCK_TOCK_BOOTSEL_FOLDER)"; else echo; echo Please edit the TOCK_TOCK_BOOTSEL_FOLDER variable to point to you Nano RP2040 Flash Drive Folder; fi
 
 .PHONY: flash-app
 flash-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
@@ -30,6 +30,6 @@ ifeq ($(APP),)
 endif 
 	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL) $(KERNEL_WITH_APP)
 	elf2uf2-rs $(KERNEL_WITH_APP) $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2
-	@if [ -d $(BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2 "$(BOOTSEL_FOLDER)"; else echo; echo Please edit the BOOTSEL_FOLDER variable to point to you Nano RP2040 Flash Drive Folder; fi
+	@if [ -d $(TOCK_BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2 "$(TOCK_BOOTSEL_FOLDER)"; else echo; echo Please edit the TOCK_BOOTSEL_FOLDER variable to point to you Nano RP2040 Flash Drive Folder; fi
 
 

--- a/boards/nano_rp2040_connect/README.md
+++ b/boards/nano_rp2040_connect/README.md
@@ -51,7 +51,7 @@ $ make flash
 $ make flash-debug
 ```
 
-> Note: The Makefile provides the BOOTSEL_FOLDER variable that points towards the mount point of
+> Note: The Makefile provides the `TOCK_BOOTSEL_FOLDER` variable that points towards the mount point of
 > the Nano RP2040 flash drive. By default, this is located in `/media/$(USER)/RP2040`. This might
 > be different on several systems, make sure to adjust it.
 

--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -5,8 +5,8 @@
 # Makefile for building the tock kernel for the OpenTitan platform
 
 FLASHID=--dev-id="0403:6010"
-RISC_PREFIX ?= riscv64-linux-gnu
-QEMU ?= ../../../tools/qemu/build/qemu-system-riscv32
+TOCK_RISC_PREFIX ?= riscv64-linux-gnu
+TOCK_QEMU ?= ../../../tools/qemu/build/qemu-system-riscv32
 # Override for the entry point
 # This offset is calculated (from the linker file) as:
 # ORIGIN(rom) + size_manifest = 0x20000000 + 0x400
@@ -27,16 +27,16 @@ endif
 
 .PHONY: check
 check:
-	$(Q)$(CARGO) check $(VERBOSE_FLAGS) $(CARGO_FLAGS)
+	$(Q)$(TOCK_CARGO) check $(VERBOSE_FLAGS) $(CARGO_FLAGS)
 
 .PHONY: $(TARGET_PATH)/release/$(PLATFORM)
 $(TARGET_PATH)/release/$(PLATFORM):
-	$(Q)$(CARGO) build $(VERBOSE_FLAGS) $(CARGO_FLAGS) --release
+	$(Q)$(TOCK_CARGO) build $(VERBOSE_FLAGS) $(CARGO_FLAGS) --release
 	$(Q)$(SIZE) $(SIZE_FLAGS) $@
 
 .PHONY: $(TARGET_PATH)/debug/$(PLATFORM)
 $(TARGET_PATH)/debug/$(PLATFORM):
-	$(Q)$(CARGO) build $(VERBOSE_FLAGS) $(CARGO_FLAGS)
+	$(Q)$(TOCK_CARGO) build $(VERBOSE_FLAGS) $(CARGO_FLAGS)
 	$(Q)$(SIZE) $(SIZE_FLAGS) $@
 
 .PHONY: ot-check
@@ -66,35 +66,35 @@ endif
 install: flash
 
 qemu: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	$(QEMU) -M opentitan -kernel $^ -nographic -serial mon:stdio -global driver=riscv.lowrisc.ibex.soc,property=resetvec,value=${QEMU_ENTRY_POINT}
+	$(TOCK_QEMU) -M opentitan -kernel $^ -nographic -serial mon:stdio -global driver=riscv.lowrisc.ibex.soc,property=resetvec,value=${QEMU_ENTRY_POINT}
 
 qemu-gdb: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	$(QEMU) -s -S -M opentitan -kernel $^ -nographic -serial mon:stdio -global driver=riscv.lowrisc.ibex.soc,property=resetvec,value=${QEMU_ENTRY_POINT}
+	$(TOCK_QEMU) -s -S -M opentitan -kernel $^ -nographic -serial mon:stdio -global driver=riscv.lowrisc.ibex.soc,property=resetvec,value=${QEMU_ENTRY_POINT}
 
 qemu-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	$(QEMU) -M opentitan -kernel $^ -device loader,file=$(APP),addr=0x20030000 -nographic -serial mon:stdio -global driver=riscv.lowrisc.ibex.soc,property=resetvec,value=${QEMU_ENTRY_POINT}
+	$(TOCK_QEMU) -M opentitan -kernel $^ -device loader,file=$(APP),addr=0x20030000 -nographic -serial mon:stdio -global driver=riscv.lowrisc.ibex.soc,property=resetvec,value=${QEMU_ENTRY_POINT}
 
 qemu-app-gdb : $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	$(QEMU) -s -S -M opentitan -kernel $^ -device loader,file=$(APP),addr=0x20030000 -nographic -serial mon:stdio -global driver=riscv.lowrisc.ibex.soc,property=resetvec,value=${QEMU_ENTRY_POINT}
+	$(TOCK_QEMU) -s -S -M opentitan -kernel $^ -device loader,file=$(APP),addr=0x20030000 -nographic -serial mon:stdio -global driver=riscv.lowrisc.ibex.soc,property=resetvec,value=${QEMU_ENTRY_POINT}
 
 flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
 	$(OPENTITAN_TREE)/bazel-bin/sw/host/opentitantool/opentitantool.runfiles/lowrisc_opentitan/sw/host/opentitantool/opentitantool --interface=cw310 bootstrap $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
 
 flash-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	$(RISC_PREFIX)-objcopy --update-section .apps=$(APP) $^ $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf
-	$(RISC_PREFIX)-objcopy --output-target=binary $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.bin
+	$(TOCK_RISC_PREFIX)-objcopy --update-section .apps=$(APP) $^ $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf
+	$(TOCK_RISC_PREFIX)-objcopy --output-target=binary $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.bin
 	$(OPENTITAN_TREE)/bazel-bin/sw/host/opentitantool/opentitantool.runfiles/lowrisc_opentitan/sw/host/opentitantool/opentitantool --interface=cw310 bootstrap $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.bin
 
 verilator: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	$(call check_defined, OPENTITAN_TREE)
 #	Make a copy so we dont modify the original elf when linkng apps
-	$(RISC_PREFIX)-objcopy $^ $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.elf
+	$(TOCK_RISC_PREFIX)-objcopy $^ $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.elf
 ifneq ($(APP),)
 		$(info [CW-130: Verilator]: Linking App)
-		$(RISC_PREFIX)-objcopy --update-section .apps=$(APP) $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.elf $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.elf
+		$(TOCK_RISC_PREFIX)-objcopy --update-section .apps=$(APP) $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.elf $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.elf
 endif
 	$(info [CW-130: Verilator]: Starting)
-	$(RISC_PREFIX)-objcopy --output-target=binary $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.elf $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.bin
+	$(TOCK_RISC_PREFIX)-objcopy --output-target=binary $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.elf $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.bin
 	srec_cat $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.bin \
 		--binary --offset 0 --byte-swap 8 --fill 0xff \
 		-within $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.bin\
@@ -111,16 +111,16 @@ endif
 	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
-	$(Q)TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} QEMU_ENTRY_POINT=${QEMU_ENTRY_POINT} TARGET=${TARGET} $(CARGO) test $(CARGO_FLAGS) $(NO_RUN) --bin $(PLATFORM) --release
+	$(Q)TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} QEMU_ENTRY_POINT=${QEMU_ENTRY_POINT} TARGET=${TARGET} $(TOCK_CARGO) test $(CARGO_FLAGS) $(NO_RUN) --bin $(PLATFORM) --release
 
 test-hardware: ot-check
 	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
-	$(Q)OBJCOPY=$(RISC_PREFIX)-objcopy TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} TARGET=${TARGET} $(CARGO) test $(CARGO_FLAGS) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests
+	$(Q)OBJCOPY=$(TOCK_RISC_PREFIX)-objcopy TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} TARGET=${TARGET} $(TOCK_CARGO) test $(CARGO_FLAGS) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests
 
 test-verilator: ot-check
 	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
-	$(Q)VERILATOR="yes" OBJCOPY=$(RISC_PREFIX)-objcopy TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} TARGET=${TARGET} $(CARGO) test $(CARGO_FLAGS) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests,sim_verilator
+	$(Q)VERILATOR="yes" OBJCOPY=$(TOCK_RISC_PREFIX)-objcopy TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} TARGET=${TARGET} $(TOCK_CARGO) test $(CARGO_FLAGS) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests,sim_verilator

--- a/boards/pico_explorer_base/Makefile
+++ b/boards/pico_explorer_base/Makefile
@@ -10,7 +10,7 @@ OPENOCD=openocd
 OPENOCD_INTERFACE=swd
 OPENOCD_OPTIONS=-f openocd-$(OPENOCD_INTERFACE).cfg
 
-BOOTSEL_FOLDER?=/media/$(USER)/RPI-RP2
+TOCK_BOOTSEL_FOLDER?=/media/$(USER)/RPI-RP2
 
 KERNEL=$(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/release/$(PLATFORM)-app.elf
@@ -27,7 +27,7 @@ flash-openocd: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 .PHONY: flash
 flash: $(KERNEL)
 	elf2uf2-rs $< $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2
-	@if [ -d $(BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2 "$(BOOTSEL_FOLDER)"; else echo; echo Please edit the BOOTSEL_FOLDER variable to point to you Raspberry Pi Pico Flash Drive Folder; echo You can download and flash $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2; fi
+	@if [ -d $(TOCK_BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2 "$(TOCK_BOOTSEL_FOLDER)"; else echo; echo Please edit the TOCK_BOOTSEL_FOLDER variable to point to you Raspberry Pi Pico Flash Drive Folder; echo You can download and flash $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2; fi
 
 .PHONY: program
 program: $(KERNEL)
@@ -36,5 +36,5 @@ ifeq ($(APP),)
 endif 
 	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL) $(KERNEL_WITH_APP)
 	elf2uf2-rs $(KERNEL_WITH_APP) $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2
-	@if [ -d $(BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2 "$(BOOTSEL_FOLDER)"; else echo; echo Please edit the BOOTSEL_FOLDER variable to point to you Raspberry Pi Pico Flash Drive Folder; echo You can download and flash $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2; fi
+	@if [ -d $(TOCK_BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2 "$(TOCK_BOOTSEL_FOLDER)"; else echo; echo Please edit the TOCK_BOOTSEL_FOLDER variable to point to you Raspberry Pi Pico Flash Drive Folder; echo You can download and flash $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2; fi
 

--- a/boards/pico_explorer_base/README.md
+++ b/boards/pico_explorer_base/README.md
@@ -41,7 +41,7 @@ $ make flash
 $ make flash-debug
 ```
 
-> Note: The Makefile provides the BOOTSEL_FOLDER variable that points towards the mount point of
+> Note: The Makefile provides the `TOCK_BOOTSEL_FOLDER` variable that points towards the mount point of
 > the Pico RP2040 flash drive. By default, this is located in `/media/$(USER)/RP2040`. This might
 > be different on several systems, make sure to adjust it.
 

--- a/boards/qemu_rv32_virt/Makefile
+++ b/boards/qemu_rv32_virt/Makefile
@@ -19,13 +19,13 @@ WORKING_QEMU_VERSION := 7.2.0
 #   Use the QEMU userspace slirp network backend. This causes QEMU to
 #   behave as a NAT-router and gateway to the VM, transparently
 #   routing any outgoing traffic through the host's userspace network
-#   sockets. This option also accepts an optional NETDEV_SLIRP_ARGS
+#   sockets. This option also accepts an optional TOCK_NETDEV_SLIRP_ARGS
 #   which is appended to the provided string.
 #
 #   To forward TCP port 1234 on the emulated Tock device (having IP
 #   192.168.1.50) to the host port 5678, set the following variable:
 #
-#       NETDEV_SLIRP_ARGS=hostfwd=tcp::5678-192.168.1.50:1234
+#       TOCK_NETDEV_SLIRP_ARGS=hostfwd=tcp::5678-192.168.1.50:1234
 #
 # - NETDEV: TAP
 #
@@ -33,28 +33,28 @@ WORKING_QEMU_VERSION := 7.2.0
 #   connection between the guest interface and the host. Must have the
 #   proper permissions to let QEMU create the tap interface on the
 #   host. Use SUDO-TAP instead to run QEMU through `sudo`.
-NETDEV            ?= NONE
-ifneq ($(NETDEV_SLIRP_ARGS),)
-  NETDEV_SLIRP_ARGS_INT := ,$(NETDEV_SLIRP_ARGS)
+TOCK_NETDEV            ?= NONE
+ifneq ($(TOCK_NETDEV_SLIRP_ARGS),)
+  NETDEV_SLIRP_ARGS_INT := ,$(TOCK_NETDEV_SLIRP_ARGS)
 else
   NETDEV_SLIRP_ARGS_INT :=
 endif
 
-ifeq ($(NETDEV),NONE)
+ifeq ($(TOCK_NETDEV),NONE)
   QEMU_NETDEV_CMDLINE = ""
-else ifeq ($(NETDEV),SLIRP)
+else ifeq ($(TOCK_NETDEV),SLIRP)
   QEMU_NETDEV_CMDLINE = \
     -netdev user,id=n0,net=192.168.1.0/24,dhcpstart=192.168.1.255$(NETDEV_SLIRP_ARGS_INT) \
     -device virtio-net-device,netdev=n0
-else ifneq (,$(filter $(NETDEV),TAP SUDO-TAP))
+else ifneq (,$(filter $(TOCK_NETDEV),TAP SUDO-TAP))
   QEMU_NETDEV_CMDLINE = \
     -netdev tap,id=n0,script=no,downscript=no \
     -device virtio-net-device,netdev=n0
-  ifeq ($(NETDEV),SUDO-TAP)
+  ifeq ($(TOCK_NETDEV),SUDO-TAP)
     QEMU_CMD := sudo $(QEMU_CMD)
   endif
 else
-  $(error Invalid argument provided for variable NETDEV)
+  $(error Invalid argument provided for variable TOCK_NETDEV)
 endif
 
 # Peripherals attached by default:

--- a/boards/qemu_rv32_virt/README.md
+++ b/boards/qemu_rv32_virt/README.md
@@ -63,29 +63,29 @@ QEMU standalone, or with a single app. These can be executed through the
   tock/boards/qemu_rv32_virt $ make run-app APP=$PATH_TO_APP.tbf
   ```
 
-Through the **`NETDEV`** environment variable, QEMU can be instructed to attach
+Through the **`TOCK_NETDEV`** environment variable, QEMU can be instructed to attach
 a VirtIO-based network adapter to the target. The following options are available:
 
-- `NETDEV=NONE` (default): Do not expose a network adapter to the guest.
+- `TOCK_NETDEV=NONE` (default): Do not expose a network adapter to the guest.
 
-- `NETDEV=SLIRP`: Use QEMU's userspace networking capabilities (through
+- `TOCK_NETDEV=SLIRP`: Use QEMU's userspace networking capabilities (through
   `libslirp`), which provides the target with an emulated network and a gateway
   bridging outgoing TCP and UDP connections onto sockets of the host operating
-  system. `NETDEV_SLIRP_ARGS` can be used to pass further arguments to the
+  system. `TOCK_NETDEV_SLIRP_ARGS` can be used to pass further arguments to the
   `netdev`, for instance to forward ports from host to guest. For example, to
   forward the TCP port `8080` to the guest at `192.168.1.50:80`, use the
   following command line:
 
   ```
-  $ make run NETDEV=SLIRP NETDEV_SLIRP_ARGS=hostfwd=tcp::8080-192.168.1.50:80
+  $ make run TOCK_NETDEV=SLIRP TOCK_NETDEV_SLIRP_ARGS=hostfwd=tcp::8080-192.168.1.50:80
   ```
 
-- `NETDEV=TAP`: Create a TAP network device on the host and expose the
+- `TOCK_NETDEV=TAP`: Create a TAP network device on the host and expose the
   corresponding remote end to the guest's VirtIO network card. This establishes
   a layer-2 link between the host and guest. This option assumes that QEMU has
   the necessary permissions to use (or create) the device on the host. The
   interface will be unconfigured and needs to be made active and be assigned an
   IP address manually.
 
-- `NETDEV=SUDO-TAP`: Like `TAP`, but run QEMU as root through `sudo`. This will
+- `TOCK_NETDEV=SUDO-TAP`: Like `TAP`, but run QEMU as root through `sudo`. This will
   likely prompt for a password.

--- a/boards/raspberry_pi_pico/Makefile
+++ b/boards/raspberry_pi_pico/Makefile
@@ -10,7 +10,7 @@ OPENOCD=openocd
 OPENOCD_INTERFACE=swd
 OPENOCD_OPTIONS=-f openocd-$(OPENOCD_INTERFACE).cfg
 
-BOOTSEL_FOLDER?=/media/$(USER)/RPI-RP2
+TOCK_BOOTSEL_FOLDER?=/media/$(USER)/RPI-RP2
 
 KERNEL=$(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/release/$(PLATFORM)-app.elf
@@ -27,7 +27,7 @@ flash-openocd: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 .PHONY: flash
 flash: $(KERNEL)
 	elf2uf2-rs $< $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2
-	@if [ -d $(BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2 "$(BOOTSEL_FOLDER)"; else echo; echo Please edit the BOOTSEL_FOLDER variable to point to you Raspberry Pi Pico Flash Drive Folder; echo You can download and flash $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2; fi
+	@if [ -d $(TOCK_BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2 "$(TOCK_BOOTSEL_FOLDER)"; else echo; echo Please edit the TOCK_BOOTSEL_FOLDER variable to point to you Raspberry Pi Pico Flash Drive Folder; echo You can download and flash $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2; fi
 
 .PHONY: program
 program: $(KERNEL)
@@ -36,5 +36,5 @@ ifeq ($(APP),)
 endif 
 	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL) $(KERNEL_WITH_APP)
 	elf2uf2-rs $(KERNEL_WITH_APP) $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2
-	@if [ -d $(BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2 "$(BOOTSEL_FOLDER)"; else echo; echo Please edit the BOOTSEL_FOLDER variable to point to you Raspberry Pi Pico Flash Drive Folder; echo You can download and flash $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2; fi
+	@if [ -d $(TOCK_BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2 "$(TOCK_BOOTSEL_FOLDER)"; else echo; echo Please edit the TOCK_BOOTSEL_FOLDER variable to point to you Raspberry Pi Pico Flash Drive Folder; echo You can download and flash $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2; fi
 

--- a/boards/raspberry_pi_pico/README.md
+++ b/boards/raspberry_pi_pico/README.md
@@ -40,7 +40,7 @@ $ make flash
 $ make flash-debug
 ```
 
-> Note: The Makefile provides the BOOTSEL_FOLDER variable that points towards the mount point of
+> Note: The Makefile provides the `TOCK_BOOTSEL_FOLDER` variable that points towards the mount point of
 > the Pico RP2040 flash drive. By default, this is located in `/media/$(USER)/RP2040`. This might
 > be different on several systems, make sure to adjust it.
 

--- a/boards/redboard_redv/Makefile
+++ b/boards/redboard_redv/Makefile
@@ -4,7 +4,7 @@
 
 # Makefile for building the tock kernel for the RedV platform
 
-QEMU ?= qemu-system-riscv32
+TOCK_QEMU ?= qemu-system-riscv32
 
 include ../Makefile.common
 
@@ -17,10 +17,10 @@ flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 		-c "source [find board/sifive-hifive1-revb.cfg]; program $<; resume 0x20000000; exit"
 
 qemu: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	$(QEMU) -M sifive_e,revb=true -kernel $^  -nographic
+	$(TOCK_QEMU) -M sifive_e,revb=true -kernel $^  -nographic
 
 qemu-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	$(QEMU) -M sifive_e,revb=true -kernel $^ -device loader,file=$(APP),addr=0x20010000 -nographic
+	$(TOCK_QEMU) -M sifive_e,revb=true -kernel $^ -device loader,file=$(APP),addr=0x20010000 -nographic
 
 
 TOCKLOADER=tockloader

--- a/shell.nix
+++ b/shell.nix
@@ -81,5 +81,5 @@ in
 
     # Instruct the Tock gnumake-based build system to not check for rustup and
     # assume all requirend tools are installed and available in the $PATH
-    NO_RUSTUP = "1";
+    TOCK_NO_RUSTUP = "1";
   }

--- a/shell.nix
+++ b/shell.nix
@@ -82,11 +82,4 @@ in
     # Instruct the Tock gnumake-based build system to not check for rustup and
     # assume all requirend tools are installed and available in the $PATH
     NO_RUSTUP = "1";
-
-    # The defaults "objcopy" and "objdump" are wrong (stem from the standard
-    # environment for x86), use "llvm-obj{copy,dump}" as defined in the makefile
-    shellHook = ''
-      unset OBJCOPY
-      unset OBJDUMP
-    '';
   }


### PR DESCRIPTION
### Pull Request Overview

`llvm-obj{copy,dump}` used to be provided by the `llvm` Nix package,
 but now these are supplied by the cargo `llvm-tools` package. This
`unset` workaround is no longer needed and prevents Tock from working out of the box with `rustup` on Nix. No OSes other than the Nix standard env provide these `OBJ`* vars, so these should be set unconditionally.

In order to prevent name clobbering from your environment from happening in the future, I have prepended variables with `TOCK_` to prevent collisions.

### Testing Strategy

CI works. `nix-shell -p rustup` and `make prepush` now work in a Nix shell.

### TODO or Help Wanted

I edited env var names in boards/. I did not find any scripts that this renaming would break, but I am open to reverting this if these should not be changed.


### Documentation Updated

N/A

### Formatting

- [x] Ran `make prepush`.

CC: @lschuermann 