### PR TITLE
Soil Moisture Sensor Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -545,6 +545,7 @@ ci-job-cargo-test-build:
 	@$(MAKE) NO_RUN="--no-run" -C "boards/esp32-c3-devkitM-1" test
 	@$(MAKE) NO_RUN="--no-run" -C "boards/apollo3/lora_things_plus" test
 	@$(MAKE) NO_RUN="--no-run" -C "boards/apollo3/lora_things_plus" test-atecc508a
+	@$(MAKE) NO_RUN="--no-run" -C "boards/apollo3/lora_things_plus" test-chirp_i2c_moisture
 	@$(MAKE) NO_RUN="--no-run" -C "boards/apollo3/redboard_artemis_atp" test
 	@$(MAKE) NO_RUN="--no-run" -C "boards/apollo3/redboard_artemis_nano" test
 

--- a/boards/apollo3/lora_things_plus/Cargo.toml
+++ b/boards/apollo3/lora_things_plus/Cargo.toml
@@ -37,3 +37,11 @@ default = []
 # NOTE: That the first time this is used it will lock the device, which
 # can not be undone.
 atecc508a = []
+
+# This feature enables support for the Chirp I2C Soil Moisture Sensor.
+# This is the sensor avaliable from
+# https://www.tindie.com/products/miceuz/i2c-soil-moisture-sensor/
+#
+# If the sensor is attached via the I2C Qwiic connecter you should
+# enable this feature.
+chirp_i2c_moisture = []

--- a/boards/apollo3/lora_things_plus/Makefile
+++ b/boards/apollo3/lora_things_plus/Makefile
@@ -44,11 +44,13 @@ flash-app:
 
 .PHONY: test
 test:
-	$(Q)OBJCOPY=${OBJCOPY} PORT=$(PORT) $(CARGO) test $(NO_RUN) --bin $(PLATFORM) --release
+	$(Q)OBJCOPY=${OBJCOPY} PORT=$(PORT) $(CARGO) test $(NO_RUN) \
+	    --bin $(PLATFORM) --release
 
 .PHONY: test-atecc508a
 test-atecc508a:
-	$(Q)OBJCOPY=${OBJCOPY} PORT=$(PORT) $(CARGO) test $(NO_RUN) --bin $(PLATFORM) --release --features atecc508a
+	$(Q)OBJCOPY=${OBJCOPY} PORT=$(PORT) $(CARGO) test $(NO_RUN) \
+	    --bin $(PLATFORM) --release --features atecc508a
 
 .PHONY: test-chirp_i2c_moisture
 test-chirp_i2c_moisture:

--- a/boards/apollo3/lora_things_plus/Makefile
+++ b/boards/apollo3/lora_things_plus/Makefile
@@ -49,3 +49,8 @@ test:
 .PHONY: test-atecc508a
 test-atecc508a:
 	$(Q)OBJCOPY=${OBJCOPY} PORT=$(PORT) $(CARGO) test $(NO_RUN) --bin $(PLATFORM) --release --features atecc508a
+
+.PHONY: test-chirp_i2c_moisture
+test-chirp_i2c_moisture:
+	$(Q)OBJCOPY=${OBJCOPY} PORT=$(PORT) $(CARGO) test $(NO_RUN) \
+	    --bin $(PLATFORM) --release --features chirp_i2c_moisture

--- a/boards/apollo3/lora_things_plus/src/main.rs
+++ b/boards/apollo3/lora_things_plus/src/main.rs
@@ -116,13 +116,6 @@ static mut BME280: Option<
 static mut CCS811: Option<&'static capsules_extra::ccs811::Ccs811<'static>> = None;
 #[cfg(feature = "atecc508a")]
 static mut ATECC508A: Option<&'static capsules_extra::atecc508a::Atecc508a<'static>> = None;
-#[cfg(feature = "chirp_i2c_moisture")]
-static mut CHIRP_I2C_MOISTURE: Option<
-    &'static capsules_extra::chirp_i2c_moisture::ChirpI2cMoisture<
-        'static,
-        capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, apollo3::iom::Iom<'static>>,
-    >,
-> = None;
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
@@ -288,7 +281,6 @@ unsafe fn setup_chirp_i2c_moisture(
         components::chirp_i2c_moisture::ChirpI2cMoistureComponent::new(mux_i2c, 0x20).finalize(
             components::chirp_i2c_moisture_component_static!(apollo3::iom::Iom<'static>),
         );
-    CHIRP_I2C_MOISTURE = Some(chirp_moisture);
 
     let moisture = components::moisture::MoistureComponent::new(
         board_kernel,

--- a/boards/apollo3/lora_things_plus/src/main.rs
+++ b/boards/apollo3/lora_things_plus/src/main.rs
@@ -68,6 +68,9 @@ use {
     kernel::hil::rng::Rng,
 };
 
+#[cfg(feature = "chirp_i2c_moisture")]
+use capsules_core::virtualizers::virtual_i2c::MuxI2C;
+
 /// Support routines for debugging I/O.
 pub mod io;
 
@@ -113,6 +116,13 @@ static mut BME280: Option<
 static mut CCS811: Option<&'static capsules_extra::ccs811::Ccs811<'static>> = None;
 #[cfg(feature = "atecc508a")]
 static mut ATECC508A: Option<&'static capsules_extra::atecc508a::Atecc508a<'static>> = None;
+#[cfg(feature = "chirp_i2c_moisture")]
+static mut CHIRP_I2C_MOISTURE: Option<
+    &'static capsules_extra::chirp_i2c_moisture::ChirpI2cMoisture<
+        'static,
+        capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, apollo3::iom::Iom<'static>>,
+    >,
+> = None;
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
@@ -122,9 +132,13 @@ pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
 const LORA_SPI_DRIVER_NUM: usize = capsules_core::driver::NUM::LoRaPhySPI as usize;
 const LORA_GPIO_DRIVER_NUM: usize = capsules_core::driver::NUM::LoRaPhyGPIO as usize;
 
+type ChirpI2cMoistureType = components::chirp_i2c_moisture::ChirpI2cMoistureComponentType<
+    capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, apollo3::iom::Iom<'static>>,
+>;
 type BME280Sensor = components::bme280::Bme280ComponentType<
     capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, apollo3::iom::Iom<'static>>,
 >;
+
 type TemperatureDriver = components::temperature::TemperatureComponentType<BME280Sensor>;
 type HumidityDriver = components::humidity::HumidityComponentType<BME280Sensor>;
 
@@ -167,6 +181,7 @@ struct LoRaThingsPlus {
     temperature: &'static TemperatureDriver,
     humidity: &'static HumidityDriver,
     air_quality: &'static capsules_extra::air_quality::AirQualitySensor<'static>,
+    moisture: Option<&'static components::moisture::MoistureComponentType<ChirpI2cMoistureType>>,
     rng: Option<
         &'static capsules_core::rng::RngDriver<
             'static,
@@ -263,6 +278,28 @@ unsafe fn setup_atecc508a(
     rng_local
 }
 
+#[cfg(feature = "chirp_i2c_moisture")]
+unsafe fn setup_chirp_i2c_moisture(
+    board_kernel: &'static kernel::Kernel,
+    _memory_allocation_cap: &dyn capabilities::MemoryAllocationCapability,
+    mux_i2c: &'static MuxI2C<'static, apollo3::iom::Iom<'static>>,
+) -> &'static components::moisture::MoistureComponentType<ChirpI2cMoistureType> {
+    let chirp_moisture =
+        components::chirp_i2c_moisture::ChirpI2cMoistureComponent::new(mux_i2c, 0x20).finalize(
+            components::chirp_i2c_moisture_component_static!(apollo3::iom::Iom<'static>),
+        );
+    CHIRP_I2C_MOISTURE = Some(chirp_moisture);
+
+    let moisture = components::moisture::MoistureComponent::new(
+        board_kernel,
+        capsules_extra::moisture::DRIVER_NUM,
+        chirp_moisture,
+    )
+    .finalize(components::moisture_component_static!(ChirpI2cMoistureType));
+
+    moisture
+}
+
 /// Mapping of integer syscalls to objects that implement syscalls.
 impl SyscallDriverLookup for LoRaThingsPlus {
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
@@ -286,6 +323,13 @@ impl SyscallDriverLookup for LoRaThingsPlus {
             capsules_core::rng::DRIVER_NUM => {
                 if let Some(rng) = self.rng {
                     f(Some(rng))
+                } else {
+                    f(None)
+                }
+            }
+            capsules_extra::moisture::DRIVER_NUM => {
+                if let Some(moisture) = self.moisture {
+                    f(Some(moisture))
                 } else {
                     f(None)
                 }
@@ -493,6 +537,15 @@ unsafe fn setup() -> (
     )
     .finalize(components::air_quality_component_static!());
     CCS811 = Some(ccs811);
+
+    #[cfg(feature = "chirp_i2c_moisture")]
+    let moisture = Some(setup_chirp_i2c_moisture(
+        board_kernel,
+        &memory_allocation_cap,
+        mux_i2c,
+    ));
+    #[cfg(not(feature = "chirp_i2c_moisture"))]
+    let moisture = None;
 
     #[cfg(feature = "atecc508a")]
     let rng = Some(setup_atecc508a(
@@ -743,6 +796,7 @@ unsafe fn setup() -> (
             temperature,
             humidity,
             air_quality,
+            moisture,
             rng,
             scheduler,
             systick,

--- a/boards/apollo3/lora_things_plus/src/tests/environmental_sensors.rs
+++ b/boards/apollo3/lora_things_plus/src/tests/environmental_sensors.rs
@@ -9,13 +9,9 @@
 //! (https://www.sparkfun.com/products/14348).
 
 use crate::tests::run_kernel_op;
-#[cfg(feature = "chirp_i2c_moisture")]
-use crate::CHIRP_I2C_MOISTURE;
 use crate::{BME280, CCS811};
 use core::cell::Cell;
 use kernel::debug;
-#[cfg(feature = "chirp_i2c_moisture")]
-use kernel::hil::sensors::MoistureDriver;
 use kernel::hil::sensors::{
     AirQualityClient, AirQualityDriver, HumidityClient, HumidityDriver, MoistureClient,
     TemperatureClient, TemperatureDriver,
@@ -101,29 +97,6 @@ impl<'a> AirQualityClient for SensorTestCallback {
 }
 
 static CALLBACK: SensorTestCallback = SensorTestCallback::new();
-
-#[cfg(feature = "chirp_i2c_moisture")]
-#[test_case]
-fn run_chirp_i2c_moisture() {
-    debug!("check run Chirp I2C Moisture Sensor... ");
-    run_kernel_op(100);
-
-    let chirp = unsafe { CHIRP_I2C_MOISTURE.unwrap() };
-
-    // Make sure the device is ready for us.
-    run_kernel_op(1000);
-
-    MoistureDriver::set_client(chirp, &CALLBACK);
-    CALLBACK.reset();
-
-    chirp.read_moisture().unwrap();
-
-    run_kernel_op(10_000);
-    assert_eq!(CALLBACK.moisture_done.get(), true);
-
-    debug!("    [ok]");
-    run_kernel_op(100);
-}
 
 #[test_case]
 fn run_bme280_temperature() {

--- a/boards/apollo3/redboard_artemis_atp/Makefile
+++ b/boards/apollo3/redboard_artemis_atp/Makefile
@@ -44,4 +44,5 @@ flash-app:
 
 .PHONY: test
 test:
-	$(Q)OBJCOPY=${OBJCOPY} PORT=$(PORT) $(CARGO) test $(NO_RUN) --bin $(PLATFORM) --release
+	$(Q)OBJCOPY=${OBJCOPY} PORT=$(PORT) $(CARGO) test $(NO_RUN) \
+	    --bin $(PLATFORM) --release

--- a/boards/apollo3/redboard_artemis_nano/Makefile
+++ b/boards/apollo3/redboard_artemis_nano/Makefile
@@ -44,4 +44,5 @@ flash-app:
 
 .PHONY: test
 test:
-	$(Q)OBJCOPY=${OBJCOPY} PORT=$(PORT) $(CARGO) test $(NO_RUN) --bin $(PLATFORM) --release
+	$(Q)OBJCOPY=${OBJCOPY} PORT=$(PORT) $(CARGO) test $(NO_RUN) \
+	    --bin $(PLATFORM) --release

--- a/boards/components/src/chirp_i2c_moisture.rs
+++ b/boards/components/src/chirp_i2c_moisture.rs
@@ -1,0 +1,84 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! Components for the Chirp I2C Moisture Sensor.
+//! <https://www.tindie.com/products/miceuz/i2c-soil-moisture-sensor/>
+//!
+//! Usage
+//! -----
+//! ```rust
+//!    let chirp_moisture =
+//!        components::chirp_i2c_moisture::ChirpI2cMoistureComponent::new(mux_i2c, 0x20).finalize(
+//!            components::chirp_i2c_moisture_component_static!(apollo3::iom::Iom<'static>),
+//!        );
+//!
+//!    let moisture = components::moisture::MoistureComponent::new(
+//!        board_kernel,
+//!        capsules_extra::moisture::DRIVER_NUM,
+//!        chirp_moisture,
+//!    )
+//!    .finalize(components::moisture_component_static!(ChirpI2cMoistureType));
+//! ```
+
+use capsules_core::virtualizers::virtual_i2c::{I2CDevice, MuxI2C};
+use capsules_extra::chirp_i2c_moisture::{ChirpI2cMoisture, BUFFER_SIZE};
+use core::mem::MaybeUninit;
+use kernel::component::Component;
+use kernel::hil::i2c;
+
+// Setup static space for the objects.
+#[macro_export]
+macro_rules! chirp_i2c_moisture_component_static {
+    ($I:ty $(,)?) => {{
+        let i2c_device =
+            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, $I>);
+        let i2c_buffer = kernel::static_buf!([u8; capsules_extra::chirp_i2c_moisture::BUFFER_SIZE]);
+        let chirp_i2c_moisture = kernel::static_buf!(
+            capsules_extra::chirp_i2c_moisture::ChirpI2cMoisture<
+                'static,
+                capsules_core::virtualizers::virtual_i2c::I2CDevice<$I>,
+            >
+        );
+
+        (i2c_device, i2c_buffer, chirp_i2c_moisture)
+    };};
+}
+
+pub type ChirpI2cMoistureComponentType<I> =
+    capsules_extra::chirp_i2c_moisture::ChirpI2cMoisture<'static, I>;
+
+pub struct ChirpI2cMoistureComponent<I: 'static + i2c::I2CMaster<'static>> {
+    i2c_mux: &'static MuxI2C<'static, I>,
+    i2c_address: u8,
+}
+
+impl<I: 'static + i2c::I2CMaster<'static>> ChirpI2cMoistureComponent<I> {
+    pub fn new(i2c: &'static MuxI2C<'static, I>, i2c_address: u8) -> Self {
+        ChirpI2cMoistureComponent {
+            i2c_mux: i2c,
+            i2c_address,
+        }
+    }
+}
+
+impl<I: 'static + i2c::I2CMaster<'static>> Component for ChirpI2cMoistureComponent<I> {
+    type StaticInput = (
+        &'static mut MaybeUninit<I2CDevice<'static, I>>,
+        &'static mut MaybeUninit<[u8; BUFFER_SIZE]>,
+        &'static mut MaybeUninit<ChirpI2cMoisture<'static, I2CDevice<'static, I>>>,
+    );
+    type Output = &'static ChirpI2cMoisture<'static, I2CDevice<'static, I>>;
+
+    fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        let chirp_i2c_moisture_i2c = s.0.write(I2CDevice::new(self.i2c_mux, self.i2c_address));
+        let i2c_buffer = s.1.write([0; BUFFER_SIZE]);
+
+        let chirp_i2c_moisture =
+            s.2.write(ChirpI2cMoisture::new(chirp_i2c_moisture_i2c, i2c_buffer));
+
+        chirp_i2c_moisture_i2c.set_client(chirp_i2c_moisture);
+        chirp_i2c_moisture.initialise();
+        chirp_i2c_moisture
+    }
+}

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -59,6 +59,7 @@ pub mod lsm303dlhc;
 pub mod lsm6dsox;
 pub mod ltc294x;
 pub mod mlx90614;
+pub mod moisture;
 pub mod mx25r6435f;
 pub mod ninedof;
 pub mod nonvolatile_storage;

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -23,6 +23,7 @@ pub mod button;
 pub mod can;
 pub mod ccs811;
 pub mod cdc;
+pub mod chirp_i2c_moisture;
 pub mod console;
 pub mod crc;
 pub mod ctap;

--- a/boards/components/src/moisture.rs
+++ b/boards/components/src/moisture.rs
@@ -1,0 +1,69 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! Component for any moisture sensor.
+//!
+//! Usage
+//! -----
+//! ```rust
+//!     let moisture = components::moisture::MoistureComponent::new(
+//!         board_kernel,
+//!         capsules_extra::moisture::DRIVER_NUM,
+//!         chirp_moisture,
+//!     )
+//!     .finalize(components::moisture_component_static!(ChirpI2cMoistureType));
+//! ```
+
+use capsules_extra::moisture::MoistureSensor;
+use core::mem::MaybeUninit;
+use kernel::capabilities;
+use kernel::component::Component;
+use kernel::create_capability;
+use kernel::hil;
+
+#[macro_export]
+macro_rules! moisture_component_static {
+    ($H: ty $(,)?) => {{
+        kernel::static_buf!(capsules_extra::moisture::MoistureSensor<'static, $H>)
+    };};
+}
+
+pub type MoistureComponentType<H> = capsules_extra::moisture::MoistureSensor<'static, H>;
+
+pub struct MoistureComponent<T: 'static + hil::sensors::MoistureDriver<'static>> {
+    board_kernel: &'static kernel::Kernel,
+    driver_num: usize,
+    sensor: &'static T,
+}
+
+impl<T: 'static + hil::sensors::MoistureDriver<'static>> MoistureComponent<T> {
+    pub fn new(
+        board_kernel: &'static kernel::Kernel,
+        driver_num: usize,
+        sensor: &'static T,
+    ) -> MoistureComponent<T> {
+        MoistureComponent {
+            board_kernel,
+            driver_num,
+            sensor,
+        }
+    }
+}
+
+impl<T: 'static + hil::sensors::MoistureDriver<'static>> Component for MoistureComponent<T> {
+    type StaticInput = &'static mut MaybeUninit<MoistureSensor<'static, T>>;
+    type Output = &'static MoistureSensor<'static, T>;
+
+    fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+
+        let moisture = s.write(MoistureSensor::new(
+            self.sensor,
+            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+        ));
+
+        hil::sensors::MoistureDriver::set_client(self.sensor, moisture);
+        moisture
+    }
+}

--- a/capsules/core/src/driver.rs
+++ b/capsules/core/src/driver.rs
@@ -68,6 +68,7 @@ pub enum NUM {
     AirQuality            = 0x60007,
     Pressure              = 0x60008,
     Distance              = 0x60009,
+    Moisture              = 0x6000A,
 
     // Sensor ICs
     Tsl2561               = 0x70000,

--- a/capsules/extra/README.md
+++ b/capsules/extra/README.md
@@ -23,6 +23,8 @@ These implement a driver to setup and read various physical sensors.
 - **[BMM150](src/bmm150.rs)**: Geomagnetic sensor.
 - **[BMP280](src/bmp280.rs)**: Temperature (and air pressure) sensor.
 - **[CCS811](src/ccs811.rs)**: VOC gas sensor.
+- **[Chirp I2C Moisture](src/chirp_i2c_moisture.rs)**: I2C moisture sensor
+    from Chirp project.
 - **[FXOS8700CQ](src/fxos8700cq.rs)**: Accelerometer and magnetometer.
 - **[HS3003](src/hs3003.rs)**: Temperature and humidity sensor.
 - **[HTS221](src/hts221.rs)**: Temperature and humidity sensor.

--- a/capsules/extra/README.md
+++ b/capsules/extra/README.md
@@ -124,6 +124,7 @@ These provide common and better abstractions for userspace.
 - **[Humidity](src/humidity.rs)**: Query humidity sensors.
 - **[Key-Value Store](src/kv_driver.rs)**: Store key-value data.
 - **[LED Matrix](src/led_matrix.rs)**: Control a 2D array of LEDs.
+- **[Moisture](src/moisture.rs)**: Query moisture sensors.
 - **[Pressure](src/pressure.rs)**: Pressure sensors.
 - **[Proximity](src/proximity.rs)**: Proximity sensors.
 - **[PWM](src/pwm.rs)**: Pulse-width modulation support.

--- a/capsules/extra/src/chirp_i2c_moisture.rs
+++ b/capsules/extra/src/chirp_i2c_moisture.rs
@@ -1,0 +1,182 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! Chirp I2C Soil moisture sensor using the I2C bus.
+//!
+//! <https://www.tindie.com/products/2330/>
+//! <https://github.com/Miceuz/i2c-moisture-sensor/blob/master/README.md>
+//!
+
+use core::cell::Cell;
+use kernel::hil::i2c::{self, I2CClient, I2CDevice};
+use kernel::hil::sensors::{MoistureClient, MoistureDriver};
+use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::ErrorCode;
+
+const GET_CAPACITANCE: u8 = 0x00;
+#[allow(dead_code)]
+const SET_ADDRESS: u8 = 0x01;
+#[allow(dead_code)]
+const GET_ADDRESS: u8 = 0x02;
+#[allow(dead_code)]
+const MEASURE_LIGHT: u8 = 0x03;
+#[allow(dead_code)]
+const GET_LIGHT: u8 = 0x04;
+#[allow(dead_code)]
+const GET_TEMPERATURE: u8 = 0x05;
+#[allow(dead_code)]
+const RESET: u8 = 0x06;
+const GET_VERSION: u8 = 0x07;
+#[allow(dead_code)]
+const SLEEP: u8 = 0x08;
+#[allow(dead_code)]
+const GET_BUSY: u8 = 0x09;
+
+#[derive(Clone, Copy, PartialEq)]
+enum DeviceState {
+    Identify,
+    Normal,
+    StartMoisture,
+    FinalMoisture,
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Copy, PartialEq)]
+enum Operation {
+    None,
+    Moisture,
+}
+
+pub struct ChirpI2cMoisture<'a, I: I2CDevice> {
+    buffer: TakeCell<'static, [u8]>,
+    i2c: &'a I,
+    moisture_client: OptionalCell<&'a dyn MoistureClient>,
+    state: Cell<DeviceState>,
+    op: Cell<Operation>,
+}
+
+impl<'a, I: I2CDevice> ChirpI2cMoisture<'a, I> {
+    pub fn new(i2c: &'a I, buffer: &'static mut [u8]) -> Self {
+        ChirpI2cMoisture {
+            buffer: TakeCell::new(buffer),
+            i2c,
+            moisture_client: OptionalCell::empty(),
+            state: Cell::new(DeviceState::Identify),
+            op: Cell::new(Operation::None),
+        }
+    }
+
+    pub fn initialise(&self) {
+        self.buffer.take().map(|buffer| {
+            if self.state.get() == DeviceState::Identify {
+                // Read the version register
+                buffer[0] = GET_VERSION;
+                if let Err((_e, buf)) = self.i2c.write_read(buffer, 1, 1) {
+                    self.buffer.replace(buf);
+                }
+            } else {
+                self.buffer.replace(buffer);
+            }
+        });
+    }
+}
+
+impl<'a, I: I2CDevice> MoistureDriver<'a> for ChirpI2cMoisture<'a, I> {
+    fn set_client(&self, client: &'a dyn MoistureClient) {
+        self.moisture_client.set(client);
+    }
+
+    fn read_moisture(&self) -> Result<(), ErrorCode> {
+        if self.state.get() != DeviceState::Normal {
+            return Err(ErrorCode::BUSY);
+        }
+
+        if self.op.get() != Operation::None {
+            return Err(ErrorCode::BUSY);
+        }
+
+        self.buffer.take().map_or(Err(ErrorCode::BUSY), |buffer| {
+            buffer[0] = GET_CAPACITANCE;
+
+            self.op.set(Operation::Moisture);
+            self.state.set(DeviceState::StartMoisture);
+            if let Err((e, buf)) = self.i2c.write_read(buffer, 1, 2) {
+                self.buffer.replace(buf);
+                return Err(e.into());
+            }
+
+            Ok(())
+        })
+    }
+}
+
+impl<'a, I: I2CDevice> I2CClient for ChirpI2cMoisture<'a, I> {
+    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
+        if let Err(i2c_err) = status {
+            self.buffer.replace(buffer);
+
+            match self.op.get() {
+                Operation::None => (),
+                Operation::Moisture => {
+                    self.op.set(Operation::None);
+
+                    self.moisture_client
+                        .map(|client| client.callback(Err(i2c_err.into())));
+                }
+            }
+
+            return;
+        }
+
+        match self.state.get() {
+            DeviceState::Identify => {
+                if buffer[0] < 0x22 {
+                    // We don't have the correct version, this isn't the correct device
+                    // Just stop here
+                    self.buffer.replace(buffer);
+                    return;
+                }
+
+                self.buffer.replace(buffer);
+                self.state.set(DeviceState::Normal);
+                self.op.set(Operation::None);
+            }
+            DeviceState::StartMoisture => match self.op.get() {
+                Operation::None => (),
+                Operation::Moisture => {
+                    self.state.set(DeviceState::FinalMoisture);
+                    if let Err((e, buf)) = self.i2c.read(buffer, 2) {
+                        self.buffer.replace(buf);
+                        self.op.set(Operation::None);
+
+                        self.moisture_client
+                            .map(|client| client.callback(Err(e.into())));
+                    }
+                }
+            },
+            DeviceState::FinalMoisture => {
+                match self.op.get() {
+                    Operation::None => (),
+                    Operation::Moisture => {
+                        let capacitance = (((buffer[0] as u32) << 8) | (buffer[1] as u32)) as f32;
+
+                        // Based on results from
+                        // https://github.com/Miceuz/i2c-moisture-sensor/raw/master/Soil%20Moisture%20Sensor%20Calibration.pdf
+                        let moisture_content = (0.01007 * capacitance * capacitance)
+                            + (0.24885 * capacitance)
+                            - 625.0872;
+
+                        self.state.set(DeviceState::Normal);
+                        self.buffer.replace(buffer);
+                        self.op.set(Operation::None);
+
+                        self.moisture_client
+                            .map(|client| client.callback(Ok(moisture_content as usize)));
+                    }
+                }
+            }
+            DeviceState::Normal => {}
+        }
+    }
+}

--- a/capsules/extra/src/chirp_i2c_moisture.rs
+++ b/capsules/extra/src/chirp_i2c_moisture.rs
@@ -14,6 +14,8 @@ use kernel::hil::sensors::{MoistureClient, MoistureDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::ErrorCode;
 
+pub const BUFFER_SIZE: usize = 2;
+
 const GET_CAPACITANCE: u8 = 0x00;
 #[allow(dead_code)]
 const SET_ADDRESS: u8 = 0x01;

--- a/capsules/extra/src/lib.rs
+++ b/capsules/extra/src/lib.rs
@@ -29,6 +29,7 @@ pub mod buzzer_driver;
 pub mod buzzer_pwm;
 pub mod can;
 pub mod ccs811;
+pub mod chirp_i2c_moisture;
 pub mod crc;
 pub mod cycle_count;
 pub mod dac;

--- a/capsules/extra/src/lib.rs
+++ b/capsules/extra/src/lib.rs
@@ -65,6 +65,7 @@ pub mod ltc294x;
 pub mod max17205;
 pub mod mcp230xx;
 pub mod mlx90614;
+pub mod moisture;
 pub mod mx25r6435f;
 pub mod ninedof;
 pub mod nonvolatile_storage_driver;

--- a/capsules/extra/src/moisture.rs
+++ b/capsules/extra/src/moisture.rs
@@ -1,0 +1,168 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! Provides userspace with access to moisture sensors.
+//!
+//! Userspace Interface
+//! -------------------
+//!
+//! ### `subscribe` System Call
+//!
+//! The `subscribe` system call supports the single `subscribe_number` zero,
+//! which is used to provide a callback that will return back the result of
+//! a moisture reading.
+//!
+//! ### `command` System Call
+//!
+//! The `command` system call support one argument `cmd` which is used to specify the specific
+//! operation, currently the following cmd's are supported:
+//!
+//! * `0`: check whether the driver exists
+//! * `1`: read moisture
+//!
+//!
+//! The possible return from the 'command' system call indicates the following:
+//!
+//! * `Ok(())`:    The operation has been successful.
+//! * `NOSUPPORT`: Invalid `cmd`.
+//! * `NOMEM`:     Insufficient memory available.
+//! * `INVAL`:     Invalid address of the buffer or other error.
+//!
+//! Usage
+//! -----
+//!
+//! You need a device that provides the `hil::sensors::MoistureDriver` trait.
+//!
+//! ```rust,ignore
+//! # use kernel::static_init;
+//!
+//! let moisture = static_init!(
+//!        capsules::moisture::MoistureSensor<'static>,
+//!        capsules::moisture::MoistureSensor::new(si7021,
+//!                                                board_kernel.create_grant(&grant_cap)));
+//! kernel::hil::sensors::MoistureDriver::set_client(si7021, moisture);
+//! ```
+
+use core::cell::Cell;
+
+use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
+use kernel::hil;
+use kernel::syscall::{CommandReturn, SyscallDriver};
+use kernel::{ErrorCode, ProcessId};
+
+/// Syscall driver number.
+use capsules_core::driver;
+pub const DRIVER_NUM: usize = driver::NUM::Moisture as usize;
+
+#[derive(Clone, Copy, PartialEq)]
+enum MoistureCommand {
+    ReadMoisture,
+}
+
+#[derive(Default)]
+pub struct App {
+    subscribed: bool,
+}
+
+pub struct MoistureSensor<'a, H: hil::sensors::MoistureDriver<'a>> {
+    driver: &'a H,
+    apps: Grant<App, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
+    busy: Cell<bool>,
+}
+
+impl<'a, H: hil::sensors::MoistureDriver<'a>> MoistureSensor<'a, H> {
+    pub fn new(
+        driver: &'a H,
+        grant: Grant<App, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
+    ) -> MoistureSensor<'a, H> {
+        MoistureSensor {
+            driver,
+            apps: grant,
+            busy: Cell::new(false),
+        }
+    }
+
+    fn enqueue_command(
+        &self,
+        command: MoistureCommand,
+        _arg1: usize,
+        processid: ProcessId,
+    ) -> CommandReturn {
+        self.apps
+            .enter(processid, |app, _| {
+                app.subscribed = true;
+
+                if !self.busy.get() {
+                    self.busy.set(true);
+                    self.call_driver(command)
+                } else {
+                    CommandReturn::success()
+                }
+            })
+            .unwrap_or_else(|err| CommandReturn::failure(err.into()))
+    }
+
+    fn call_driver(&self, command: MoistureCommand) -> CommandReturn {
+        match command {
+            MoistureCommand::ReadMoisture => {
+                let ret = self.driver.read_moisture();
+                if ret.is_err() {
+                    self.busy.set(false);
+                }
+                ret.into()
+            }
+        }
+    }
+}
+
+impl<'a, H: hil::sensors::MoistureDriver<'a>> hil::sensors::MoistureClient
+    for MoistureSensor<'a, H>
+{
+    fn callback(&self, value: Result<usize, ErrorCode>) {
+        self.busy.set(false);
+
+        for cntr in self.apps.iter() {
+            cntr.enter(|app, upcalls| {
+                if app.subscribed {
+                    app.subscribed = false;
+                    match value {
+                        Ok(moisture_val) => upcalls
+                            .schedule_upcall(
+                                0,
+                                (kernel::errorcode::into_statuscode(Ok(())), moisture_val, 0),
+                            )
+                            .ok(),
+                        Err(e) => upcalls
+                            .schedule_upcall(0, (kernel::errorcode::into_statuscode(Err(e)), 0, 0))
+                            .ok(),
+                    };
+                }
+            });
+        }
+    }
+}
+
+impl<'a, H: hil::sensors::MoistureDriver<'a>> SyscallDriver for MoistureSensor<'a, H> {
+    fn command(
+        &self,
+        command_num: usize,
+        arg1: usize,
+        _: usize,
+        processid: ProcessId,
+    ) -> CommandReturn {
+        match command_num {
+            // driver existence check
+            0 => CommandReturn::success(),
+
+            // single moisture measurement
+            1 => self.enqueue_command(MoistureCommand::ReadMoisture, arg1, processid),
+
+            _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
+        }
+    }
+
+    fn allocate_grant(&self, processid: ProcessId) -> Result<(), kernel::process::Error> {
+        self.apps.enter(processid, |_, _| {})
+    }
+}

--- a/kernel/src/hil/sensors.rs
+++ b/kernel/src/hil/sensors.rs
@@ -35,6 +35,34 @@ pub trait HumidityClient {
     fn callback(&self, value: usize);
 }
 
+/// A basic interface for a moisture sensor
+pub trait MoistureDriver<'a> {
+    fn set_client(&self, client: &'a dyn MoistureClient);
+
+    /// Read the moisture value from a sensor. The value is returned
+    /// via the `MoistureClient` callback.
+    ///
+    /// This function might return the following errors:
+    /// - `BUSY`: Indicates that the hardware is busy with an existing
+    ///           operation or initialisation/calibration.
+    /// - `NOSUPPORT`: Indicates that this data type isn't supported.
+    fn read_moisture(&self) -> Result<(), ErrorCode>;
+}
+
+/// Client for receiving moisture readings.
+pub trait MoistureClient {
+    /// Called when a moisture reading has completed.
+    ///
+    /// - `value`: the most recently read moisture in hundredths of
+    /// percent, or Err on failure.
+    ///
+    /// This function might return the following errors:
+    /// - `BUSY`: Indicates that the hardware is busy with an existing
+    ///           operation or initialisation/calibration.
+    /// - `NOSUPPORT`: Indicates that this data type isn't supported.
+    fn callback(&self, value: Result<usize, ErrorCode>);
+}
+
 /// A basic interface for a Air Quality sensor
 pub trait AirQualityDriver<'a> {
     /// Set the client to be notified when the capsule has data ready.


### PR DESCRIPTION
### Pull Request Overview

This adds support for reading the soil moisture (from the new moisture HIL). This also includes support for the soil moisture sensor from the [Chirp project](https://www.tindie.com/products/miceuz/i2c-soil-moisture-sensor/).

This is all based on the existing humidity sensor, as they are both similar concepts, but slightly different so I think they need a new sensor type.

This also unfortunately adds another Cargo feature to the Apollo3 board, which is a bit clunky. But there isn't really a better way to allow adding support for sensors

### Testing Strategy

The unit tests in the PR

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.