### PR TITLE
Enable RISC-V bitmanip extensions for OpenTitan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -551,7 +551,7 @@ ci-job-cargo-test-build:
 
 
 ### ci-runner-github-qemu jobs:
-QEMU_COMMIT_HASH=0ff5ab6f57a2427a3e83969b2e7dd71e04caae39
+QEMU_COMMIT_HASH=abb1565d3d863cf210f18f70c4a42b0f39b8ccdb
 define ci_setup_qemu_riscv
 	$(call banner,CI-Setup: Build QEMU)
 	@# Use the latest QEMU as it has OpenTitan support

--- a/boards/cargo/riscv_bitmanip.toml
+++ b/boards/cargo/riscv_bitmanip.toml
@@ -1,0 +1,11 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
+# bitmanip instruction support for RISC-V.
+
+[build]
+rustflags = [
+  # These are the ratified bitmanip extensions supported by LLVM.
+  "-Ctarget-feature=+zba,+zbb,+zbc,+zbs",
+]

--- a/boards/opentitan/earlgrey-cw310/.cargo/config.toml
+++ b/boards/opentitan/earlgrey-cw310/.cargo/config.toml
@@ -6,6 +6,7 @@ include = [
   "../../../cargo/tock_flags.toml",
   "../../../cargo/unstable_flags.toml",
   "../../../cargo/riscv_flags.toml",
+  "../../../cargo/riscv_bitmanip.toml",
   "../../../cargo/virtual_function_elimination.toml",
   "../../../cargo/panic_abort_tests.toml",
 ]


### PR DESCRIPTION
### Pull Request Overview

This pull request enables RISC-V bitmanip extension support when compiling OpenTitan.

Ibex in OpenTitan supports all the bitmanip extensions in addition to the IMC already enabled. The ratified subset of these extensions is supported upstream in LLVM but not exposed in any of the default Rust targets. We can manually enable them via this flag.

I'm not sure how important these extensions are for Tock but the `.text` size did reduce by 1024 bytes.

### Testing Strategy

This pull request was tested by compiling for OpenTitan. I haven't run any proper tests.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
