### PR TITLE
Update rust to 2024-08-24 nightly + remove `#[feature(asm_const)]`

### DIFF
--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -141,6 +141,9 @@ impl<const COMMAND_HISTORY_LEN: usize, A: 'static + Alarm<'static>> Component
         // debugging in process console.
         // SAFETY: These statics are defined by the linker script, and we are merely creating
         // pointers to them.
+        // TODO (hudson ayers, 07-25-2024): Remove this allow+unsafe once we update our
+        // MSRV to 1.82.0 or later
+        #[allow(unused_unsafe)]
         let kernel_addresses = unsafe {
             process_console::KernelAddresses {
                 stack_start: core::ptr::addr_of!(_sstack),

--- a/chips/litex_vexriscv/src/interrupt_controller.rs
+++ b/chips/litex_vexriscv/src/interrupt_controller.rs
@@ -111,9 +111,7 @@ mod vexriscv_irq_raw {
     pub unsafe fn irq_getmask() -> usize {
         let mask: usize;
         use core::arch::asm;
-        // TODO: If asm_const is stabilized, transition back to below
-        //asm!("csrr {mask}, {csr}", mask = out(reg) mask, csr = const CSR_IRQ_MASK);
-        asm!("csrr {mask}, 0xBC0", mask = out(reg) mask);
+        asm!("csrr {mask}, {csr}", mask = out(reg) mask, csr = const CSR_IRQ_MASK);
         mask
     }
 
@@ -123,9 +121,7 @@ mod vexriscv_irq_raw {
     #[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
     pub unsafe fn irq_setmask(mask: usize) {
         use core::arch::asm;
-        // TODO: If asm_const is stabilized, transition back to below
-        //asm!("csrw {csr}, {mask}", csr = const CSR_IRQ_MASK, mask = in(reg) mask);
-        asm!("csrw 0xBC0, {mask}", mask = in(reg) mask);
+        asm!("csrw {csr}, {mask}", csr = const CSR_IRQ_MASK, mask = in(reg) mask);
     }
 
     #[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
@@ -137,9 +133,7 @@ mod vexriscv_irq_raw {
     pub unsafe fn irq_pending() -> usize {
         let pending: usize;
         use core::arch::asm;
-        // TODO: If asm_const is stabilized, transition back to below
-        //asm!("csrr {pending}, {csr}", pending = out(reg) pending, csr = const CSR_IRQ_PENDING);
-        asm!("csrr {pending}, 0xFC0", pending = out(reg) pending);
+        asm!("csrr {pending}, {csr}", pending = out(reg) pending, csr = const CSR_IRQ_PENDING);
         pending
     }
 }

--- a/chips/rp2040/src/pwm.rs
+++ b/chips/rp2040/src/pwm.rs
@@ -907,6 +907,7 @@ impl hil::pwm::PwmPin for PwmPin<'_> {
 /// PWM HIL trait OK
 /// ```
 
+#[allow(clippy::wildcard_imports)]
 pub mod unit_tests {
     use super::*;
 

--- a/chips/stm32f4xx/src/clocks/clocks.rs
+++ b/chips/stm32f4xx/src/clocks/clocks.rs
@@ -621,6 +621,7 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Stm32f4Clocks for Clocks<'a, ChipSpecs> {
 ///
 /// If there are any errors, open an issue ticket at <https://github.com/tock/tock>. Please provide the
 /// output of the test execution.
+#[allow(clippy::wildcard_imports)]
 pub mod tests {
     use super::*;
 

--- a/chips/stm32f4xx/src/clocks/hse.rs
+++ b/chips/stm32f4xx/src/clocks/hse.rs
@@ -184,6 +184,7 @@ impl<'a> Hse<'a> {
 /// ```
 ///
 /// **NOTE:** All these tests assume default boot configuration.
+#[allow(clippy::wildcard_imports)]
 pub mod tests {
     use super::*;
 

--- a/chips/stm32f4xx/src/clocks/hsi.rs
+++ b/chips/stm32f4xx/src/clocks/hsi.rs
@@ -166,6 +166,7 @@ impl<'a> Hsi<'a> {
 /// ```
 ///
 /// **NOTE:** All these tests assume default boot configuration.
+#[allow(clippy::wildcard_imports)]
 pub mod tests {
     use super::*;
 

--- a/chips/stm32f4xx/src/clocks/pll.rs
+++ b/chips/stm32f4xx/src/clocks/pll.rs
@@ -461,6 +461,7 @@ impl<'a, PllConstants: clock_constants::PllConstants> Pll<'a, PllConstants> {
 ///
 /// If there are any errors, open an issue ticket at <https://github.com/tock/tock>. Please provide the
 /// output of the test execution.
+#[allow(clippy::wildcard_imports)]
 pub mod tests {
     use super::*;
 

--- a/chips/stm32f4xx/src/flash.rs
+++ b/chips/stm32f4xx/src/flash.rs
@@ -268,6 +268,7 @@ impl<FlashChipSpecific: FlashChipSpecificTrait> Flash<FlashChipSpecific> {
 ///
 /// In case of any errors, open an issue ticket at <https://github.com/tock/tock>. Please provide
 /// the output of the test execution.
+#[allow(clippy::wildcard_imports)]
 pub mod tests {
     use super::*;
     use crate::clocks::hsi::HSI_FREQUENCY_MHZ;

--- a/libraries/riscv-csr/src/lib.rs
+++ b/libraries/riscv-csr/src/lib.rs
@@ -6,7 +6,6 @@
 //!
 //! Uses the Tock Register Interface to control RISC-V CSRs.
 
-#![feature(asm_const)]
 #![no_std]
 
 pub mod csr;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,6 +3,6 @@
 # Copyright Tock Contributors 2023.
 
 [toolchain]
-channel = "nightly-2024-07-08"
+channel = "nightly-2024-08-24"
 components = ["miri", "llvm-tools", "rust-src", "rustfmt", "clippy", "rust-analyzer"]
 targets = ["thumbv6m-none-eabi", "thumbv7em-none-eabi", "thumbv7em-none-eabihf", "riscv32imc-unknown-none-elf", "riscv32imac-unknown-none-elf"]


### PR DESCRIPTION
### Pull Request Overview

This pull request updates to the latest Rust nightly and removes the recently stabilized `#[feature(asm_const)`! It also reverts the litex riscv library to use the cleaner asm_const-based approach that we removed a while back when the bath to stabilization of asm_const was less clear.


### Testing Strategy

This pull request was tested by compiling/CI.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] no updates are required.

### Formatting

- [x] Ran `make prepush`.
