### PR TITLE
atecc508a: Support SHA256 Digests

### DIFF
--- a/boards/apollo3/lora_things_plus/src/tests/mod.rs
+++ b/boards/apollo3/lora_things_plus/src/tests/mod.rs
@@ -38,6 +38,8 @@ fn trivial_assertion() {
 mod atecc508a;
 #[cfg(feature = "atecc508a")]
 mod csrng;
+#[cfg(feature = "atecc508a")]
+mod sha;
 
 mod environmental_sensors;
 mod multi_alarm;

--- a/boards/apollo3/lora_things_plus/src/tests/sha.rs
+++ b/boards/apollo3/lora_things_plus/src/tests/sha.rs
@@ -1,0 +1,130 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+use crate::tests::run_kernel_op;
+use crate::ATECC508A;
+use core::cell::Cell;
+use kernel::hil::digest::{self, DigestData, DigestHash};
+use kernel::static_init;
+use kernel::utilities::cells::TakeCell;
+use kernel::utilities::leasable_buffer::SubSlice;
+use kernel::utilities::leasable_buffer::SubSliceMut;
+use kernel::{debug, ErrorCode};
+
+struct ShaTestCallback {
+    add_mut_data_done: Cell<bool>,
+    digest_done: Cell<bool>,
+    input_buffer: TakeCell<'static, [u8]>,
+    digest_buffer: TakeCell<'static, [u8; 32]>,
+}
+
+unsafe impl Sync for ShaTestCallback {}
+
+impl<'a> ShaTestCallback {
+    fn new(input_buffer: &'static mut [u8], digest_buffer: &'static mut [u8; 32]) -> Self {
+        ShaTestCallback {
+            add_mut_data_done: Cell::new(false),
+            digest_done: Cell::new(false),
+            input_buffer: TakeCell::new(input_buffer),
+            digest_buffer: TakeCell::new(digest_buffer),
+        }
+    }
+
+    fn reset(&self) {
+        self.add_mut_data_done.set(false);
+        self.digest_done.set(false);
+    }
+}
+
+impl<'a> digest::ClientData<32> for ShaTestCallback {
+    fn add_mut_data_done(&self, result: Result<(), ErrorCode>, data: SubSliceMut<'static, u8>) {
+        self.add_mut_data_done.set(true);
+        // Check that all of the data was accepted and the active slice is length 0
+        assert_eq!(data.len(), 0);
+        // Input data has been loaded, hold copy of data
+        self.input_buffer.replace(data.take());
+        assert_eq!(result, Ok(()));
+    }
+
+    fn add_data_done(&self, _result: Result<(), ErrorCode>, _data: SubSlice<'static, u8>) {
+        unimplemented!()
+    }
+}
+
+impl<'a> digest::ClientHash<32> for ShaTestCallback {
+    fn hash_done(&self, result: Result<(), ErrorCode>, digest: &'static mut [u8; 32]) {
+        debug!("Hash: {digest:x?}");
+
+        self.digest_buffer.replace(digest);
+        self.digest_done.set(true);
+        assert_eq!(result, Ok(()));
+    }
+}
+
+/// Static init an ShaTestCallback, with
+/// respective buffers allocated for data fields.
+macro_rules! static_init_test_cb {
+    () => {{
+        let input_data = static_init!([u8; 32], [32; 32]);
+        let digest_data = static_init!(
+            [u8; 32],
+            [
+                0x23, 0x85, 0x1d, 0x3e, 0x42, 0x62, 0xc4, 0x94, 0xb5, 0xe2, 0x6e, 0xd6, 0x4f, 0xf4,
+                0xaf, 0xb9, 0xf7, 0x80, 0xfb, 0xc8, 0xd1, 0x22, 0x13, 0x4a, 0xce, 0xfb, 0xea, 0x75,
+                0x0a, 0x41, 0xf7, 0x1a
+            ]
+        );
+
+        static_init!(
+            ShaTestCallback,
+            ShaTestCallback::new(input_data, digest_data)
+        )
+    }};
+}
+
+#[test_case]
+fn hmac_check_load_binary() {
+    let atecc508a = unsafe { ATECC508A.unwrap() };
+
+    let callback = unsafe { static_init_test_cb!() };
+
+    debug!("check hmac load binary... ");
+    run_kernel_op(100);
+
+    digest::DigestDataHash::set_client(atecc508a, callback);
+    callback.reset();
+
+    debug!("    adding 1st data... ");
+    let buf = SubSliceMut::new(callback.input_buffer.take().unwrap());
+    assert_eq!(atecc508a.add_mut_data(buf), Ok(()));
+    run_kernel_op(30_000);
+    assert_eq!(callback.add_mut_data_done.get(), true);
+    callback.reset();
+
+    debug!("    adding 2nd data... ");
+    let buf = SubSliceMut::new(callback.input_buffer.take().unwrap());
+    assert_eq!(atecc508a.add_mut_data(buf), Ok(()));
+    run_kernel_op(350_000);
+    assert_eq!(callback.add_mut_data_done.get(), true);
+    callback.reset();
+
+    debug!("    adding 3rd data... ");
+    let buf = SubSliceMut::new(callback.input_buffer.take().unwrap());
+    assert_eq!(atecc508a.add_mut_data(buf), Ok(()));
+    run_kernel_op(30_000);
+    assert_eq!(callback.add_mut_data_done.get(), true);
+    callback.reset();
+
+    debug!("    performing hash... ");
+    assert_eq!(
+        atecc508a.run(callback.digest_buffer.take().unwrap()),
+        Ok(())
+    );
+
+    run_kernel_op(150_000);
+    assert_eq!(callback.digest_done.get(), true);
+
+    debug!("    [ok]");
+    run_kernel_op(100);
+}

--- a/boards/components/src/atecc508a.rs
+++ b/boards/components/src/atecc508a.rs
@@ -23,11 +23,18 @@ macro_rules! atecc508a_component_static {
     ($I:ty $(,)?) => {{
         let i2c_device =
             kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, $I>);
-        let i2c_buffer = kernel::static_buf!([u8; 70]);
+        let i2c_buffer = kernel::static_buf!([u8; 72]);
         let entropy_buffer = kernel::static_buf!([u8; 32]);
+        let digest_buffer = kernel::static_buf!([u8; 64]);
         let atecc508a = kernel::static_buf!(capsules_extra::atecc508a::Atecc508a<'static>);
 
-        (i2c_device, i2c_buffer, entropy_buffer, atecc508a)
+        (
+            i2c_device,
+            i2c_buffer,
+            entropy_buffer,
+            digest_buffer,
+            atecc508a,
+        )
     };};
 }
 
@@ -50,8 +57,9 @@ impl<I: 'static + i2c::I2CMaster<'static>> Atecc508aComponent<I> {
 impl<I: 'static + i2c::I2CMaster<'static>> Component for Atecc508aComponent<I> {
     type StaticInput = (
         &'static mut MaybeUninit<I2CDevice<'static, I>>,
-        &'static mut MaybeUninit<[u8; 70]>,
+        &'static mut MaybeUninit<[u8; 72]>,
         &'static mut MaybeUninit<[u8; 32]>,
+        &'static mut MaybeUninit<[u8; 64]>,
         &'static mut MaybeUninit<Atecc508a<'static>>,
     );
     type Output = &'static Atecc508a<'static>;
@@ -59,13 +67,15 @@ impl<I: 'static + i2c::I2CMaster<'static>> Component for Atecc508aComponent<I> {
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
         let atecc508a_i2c = s.0.write(I2CDevice::new(self.i2c_mux, self.i2c_address));
 
-        let i2c_buffer = s.1.write([0; 70]);
+        let i2c_buffer = s.1.write([0; 72]);
         let entropy_buffer = s.2.write([0; 32]);
+        let digest_buffer = s.3.write([0; 64]);
 
-        let atecc508a = s.3.write(Atecc508a::new(
+        let atecc508a = s.4.write(Atecc508a::new(
             atecc508a_i2c,
             i2c_buffer,
             entropy_buffer,
+            digest_buffer,
             self.wakeup_device,
         ));
 

--- a/capsules/extra/src/atecc508a.rs
+++ b/capsules/extra/src/atecc508a.rs
@@ -254,7 +254,7 @@ impl<'a> Atecc508a<'a> {
 
         self.op_len.set(length);
 
-        self.send_command(COMMAND_OPCODE_READ, zone_calc, address, 0)?;
+        self.send_command(COMMAND_OPCODE_READ, zone_calc, address, 0);
 
         Ok(())
     }
@@ -270,7 +270,7 @@ impl<'a> Atecc508a<'a> {
 
         self.op_len.set(length);
 
-        self.send_command(COMMAND_OPCODE_WRITE, zone_calc, address, length)?;
+        self.send_command(COMMAND_OPCODE_WRITE, zone_calc, address, length);
 
         Ok(())
     }
@@ -293,13 +293,7 @@ impl<'a> Atecc508a<'a> {
         });
     }
 
-    fn send_command(
-        &self,
-        command_opcode: u8,
-        param1: u8,
-        param2: u16,
-        length: usize,
-    ) -> Result<(), ErrorCode> {
+    fn send_command(&self, command_opcode: u8, param1: u8, param2: u16, length: usize) {
         let i2c_length = length + ATRCC508A_PROTOCOL_OVERHEAD;
 
         self.buffer.take().map(|buffer| {
@@ -323,8 +317,6 @@ impl<'a> Atecc508a<'a> {
 
             self.i2c.write(buffer, i2c_length).unwrap();
         });
-
-        Ok(())
     }
 
     /// Read information from the configuration zone and print it
@@ -400,7 +392,7 @@ impl<'a> Atecc508a<'a> {
     pub fn lock_zone_config(&self) -> Result<(), ErrorCode> {
         self.op.set(Operation::LockZoneConfig(0));
 
-        self.send_command(COMMAND_OPCODE_LOCK, LOCK_MODE_ZONE_CONFIG, 0x0000, 0)?;
+        self.send_command(COMMAND_OPCODE_LOCK, LOCK_MODE_ZONE_CONFIG, 0x0000, 0);
 
         Ok(())
     }
@@ -411,7 +403,7 @@ impl<'a> Atecc508a<'a> {
 
         (self.wakeup_device)();
 
-        self.send_command(COMMAND_OPCODE_GENKEY, GENKEY_MODE_NEW_PRIVATE, slot, 0)?;
+        self.send_command(COMMAND_OPCODE_GENKEY, GENKEY_MODE_NEW_PRIVATE, slot, 0);
 
         Ok(())
     }
@@ -436,7 +428,7 @@ impl<'a> Atecc508a<'a> {
 
         (self.wakeup_device)();
 
-        self.send_command(COMMAND_OPCODE_LOCK, LOCK_MODE_ZONE_DATA_AND_OTP, 0x0000, 0)?;
+        self.send_command(COMMAND_OPCODE_LOCK, LOCK_MODE_ZONE_DATA_AND_OTP, 0x0000, 0);
 
         Ok(())
     }
@@ -447,7 +439,7 @@ impl<'a> Atecc508a<'a> {
 
         (self.wakeup_device)();
 
-        self.send_command(COMMAND_OPCODE_LOCK, LOCK_MODE_SLOT0, 0x0000, 0)?;
+        self.send_command(COMMAND_OPCODE_LOCK, LOCK_MODE_SLOT0, 0x0000, 0);
 
         Ok(())
     }
@@ -656,8 +648,7 @@ impl<'a> I2CClient for Atecc508a<'a> {
                     }
 
                     self.op.set(Operation::GenerateEntropyCommand(run + 1));
-                    self.send_command(COMMAND_OPCODE_RANDOM, 0x00, 0x0000, 0)
-                        .unwrap();
+                    self.send_command(COMMAND_OPCODE_RANDOM, 0x00, 0x0000, 0);
 
                     return;
                 }
@@ -765,8 +756,7 @@ impl<'a> I2CClient for Atecc508a<'a> {
                     }
 
                     self.op.set(Operation::LockZoneConfig(run + 1));
-                    self.send_command(COMMAND_OPCODE_LOCK, LOCK_MODE_ZONE_CONFIG, 0x0000, 0)
-                        .unwrap();
+                    self.send_command(COMMAND_OPCODE_LOCK, LOCK_MODE_ZONE_CONFIG, 0x0000, 0);
                     return;
                 }
 
@@ -819,8 +809,7 @@ impl<'a> I2CClient for Atecc508a<'a> {
                     }
 
                     self.op.set(Operation::CreateKeyPair(run + 1, slot));
-                    self.send_command(COMMAND_OPCODE_GENKEY, GENKEY_MODE_NEW_PRIVATE, slot, 0)
-                        .unwrap();
+                    self.send_command(COMMAND_OPCODE_GENKEY, GENKEY_MODE_NEW_PRIVATE, slot, 0);
                     return;
                 }
 
@@ -868,8 +857,7 @@ impl<'a> I2CClient for Atecc508a<'a> {
                     }
 
                     self.op.set(Operation::LockDataOtp(run + 1));
-                    self.send_command(COMMAND_OPCODE_LOCK, LOCK_MODE_ZONE_DATA_AND_OTP, 0x0000, 0)
-                        .unwrap();
+                    self.send_command(COMMAND_OPCODE_LOCK, LOCK_MODE_ZONE_DATA_AND_OTP, 0x0000, 0);
                     return;
                 }
 
@@ -893,8 +881,7 @@ impl<'a> I2CClient for Atecc508a<'a> {
                     }
 
                     self.op.set(Operation::LockSlot0(run + 1));
-                    self.send_command(COMMAND_OPCODE_LOCK, LOCK_MODE_SLOT0, 0x0000, 0)
-                        .unwrap();
+                    self.send_command(COMMAND_OPCODE_LOCK, LOCK_MODE_SLOT0, 0x0000, 0);
                     return;
                 }
 
@@ -918,8 +905,7 @@ impl<'a> I2CClient for Atecc508a<'a> {
                     }
 
                     self.op.set(Operation::StartSha(run + 1));
-                    self.send_command(COMMAND_OPCODE_SHA, SHA_START, 0x0000, 0)
-                        .unwrap();
+                    self.send_command(COMMAND_OPCODE_SHA, SHA_START, 0x0000, 0);
                     return;
                 }
 
@@ -953,8 +939,7 @@ impl<'a> I2CClient for Atecc508a<'a> {
                 self.buffer.replace(buffer);
 
                 if self.sha_update() {
-                    self.send_command(COMMAND_OPCODE_SHA, SHA_UPDATE, 64, 64)
-                        .unwrap();
+                    self.send_command(COMMAND_OPCODE_SHA, SHA_UPDATE, 64, 64);
                 }
             }
             Operation::ShaLoadResponse(run) => {
@@ -966,8 +951,7 @@ impl<'a> I2CClient for Atecc508a<'a> {
                     }
 
                     self.op.set(Operation::ShaLoadResponse(run + 1));
-                    self.send_command(COMMAND_OPCODE_SHA, SHA_UPDATE, 64, 64)
-                        .unwrap();
+                    self.send_command(COMMAND_OPCODE_SHA, SHA_UPDATE, 64, 64);
 
                     return;
                 }
@@ -996,8 +980,7 @@ impl<'a> I2CClient for Atecc508a<'a> {
                         SHA_END,
                         self.remain_len.get() as u16,
                         self.remain_len.get(),
-                    )
-                    .unwrap();
+                    );
                     return;
                 }
 
@@ -1074,7 +1057,7 @@ impl<'a> entropy::Entropy32<'a> for Atecc508a<'a> {
 
         (self.wakeup_device)();
 
-        self.send_command(COMMAND_OPCODE_RANDOM, 0x00, 0x0000, 0)?;
+        self.send_command(COMMAND_OPCODE_RANDOM, 0x00, 0x0000, 0);
 
         Ok(())
     }
@@ -1105,24 +1088,12 @@ impl<'a> digest::DigestData<'a, 32> for Atecc508a<'a> {
         if self.op.get() == Operation::Ready {
             self.op.set(Operation::StartSha(0));
 
-            if let Err(e) = self.send_command(COMMAND_OPCODE_SHA, SHA_START, 0x0000, 0) {
-                return Err(self
-                    .hash_data
-                    .take()
-                    .map(|buf| match buf {
-                        SubSliceMutImmut::Immutable(b) => (e, b),
-                        SubSliceMutImmut::Mutable(_b) => {
-                            unreachable!()
-                        }
-                    })
-                    .unwrap());
-            }
+            self.send_command(COMMAND_OPCODE_SHA, SHA_START, 0x0000, 0);
         } else {
             self.op.set(Operation::ShaLoad(0));
 
             if self.sha_update() {
-                self.send_command(COMMAND_OPCODE_SHA, SHA_UPDATE, 64, 64)
-                    .unwrap();
+                self.send_command(COMMAND_OPCODE_SHA, SHA_UPDATE, 64, 64);
             }
         }
 
@@ -1145,26 +1116,14 @@ impl<'a> digest::DigestData<'a, 32> for Atecc508a<'a> {
 
             (self.wakeup_device)();
 
-            if let Err(e) = self.send_command(COMMAND_OPCODE_SHA, SHA_START, 0x0000, 0) {
-                return Err(self
-                    .hash_data
-                    .take()
-                    .map(|buf| match buf {
-                        SubSliceMutImmut::Immutable(_b) => {
-                            unreachable!()
-                        }
-                        SubSliceMutImmut::Mutable(b) => (e, b),
-                    })
-                    .unwrap());
-            }
+            self.send_command(COMMAND_OPCODE_SHA, SHA_START, 0x0000, 0);
         } else {
             self.op.set(Operation::ShaLoad(0));
 
             if self.sha_update() {
                 (self.wakeup_device)();
 
-                self.send_command(COMMAND_OPCODE_SHA, SHA_UPDATE, 64, 64)
-                    .unwrap();
+                self.send_command(COMMAND_OPCODE_SHA, SHA_UPDATE, 64, 64);
             }
         }
 
@@ -1210,14 +1169,12 @@ impl<'a> digest::DigestHash<'a, 32> for Atecc508a<'a> {
             });
         }
 
-        if let Err(e) = self.send_command(
+        self.send_command(
             COMMAND_OPCODE_SHA,
             SHA_END,
             self.remain_len.get() as u16,
             remain_len,
-        ) {
-            return Err((e, self.digest_data.take().unwrap()));
-        }
+        );
 
         Ok(())
     }

--- a/capsules/extra/src/atecc508a.rs
+++ b/capsules/extra/src/atecc508a.rs
@@ -279,7 +279,7 @@ impl<'a> Atecc508a<'a> {
         self.buffer.take().map(|buffer| {
             buffer[ATRCC508A_PROTOCOL_FIELD_COMMAND] = WORD_ADDRESS_VALUE_IDLE;
 
-            self.i2c.write(buffer, 1).unwrap();
+            let _ = self.i2c.write(buffer, 1);
         });
     }
 
@@ -289,7 +289,7 @@ impl<'a> Atecc508a<'a> {
 
             buffer[ATRCC508A_PROTOCOL_FIELD_COMMAND] = WORD_ADDRESS_VALUE_RESET;
 
-            self.i2c.write(buffer, 1).unwrap();
+            let _ = self.i2c.write(buffer, 1);
         });
     }
 
@@ -315,7 +315,7 @@ impl<'a> Atecc508a<'a> {
             buffer[i2c_length - ATRCC508A_PROTOCOL_FIELD_SIZE_CRC] = (crc & 0xFF) as u8;
             buffer[i2c_length - ATRCC508A_PROTOCOL_FIELD_SIZE_CRC + 1] = ((crc >> 8) & 0xFF) as u8;
 
-            self.i2c.write(buffer, i2c_length).unwrap();
+            let _ = self.i2c.write(buffer, i2c_length);
         });
     }
 
@@ -536,9 +536,9 @@ impl<'a> I2CClient for Atecc508a<'a> {
             Operation::ReadConfigZeroCommand => {
                 self.op.set(Operation::ReadConfigZeroResult(0));
 
-                self.i2c
-                    .read(buffer, self.op_len.get() + RESPONSE_COUNT_SIZE + CRC_SIZE)
-                    .unwrap();
+                let _ = self
+                    .i2c
+                    .read(buffer, self.op_len.get() + RESPONSE_COUNT_SIZE + CRC_SIZE);
             }
             Operation::ReadConfigZeroResult(run) => {
                 if status == Err(i2c::Error::DataNak) || status == Err(i2c::Error::AddressNak) {
@@ -549,9 +549,9 @@ impl<'a> I2CClient for Atecc508a<'a> {
 
                     self.op.set(Operation::ReadConfigZeroResult(run + 1));
 
-                    self.i2c
-                        .read(buffer, self.op_len.get() + RESPONSE_COUNT_SIZE + CRC_SIZE)
-                        .unwrap();
+                    let _ = self
+                        .i2c
+                        .read(buffer, self.op_len.get() + RESPONSE_COUNT_SIZE + CRC_SIZE);
 
                     return;
                 }
@@ -569,19 +569,18 @@ impl<'a> I2CClient for Atecc508a<'a> {
 
                 self.buffer.replace(buffer);
 
-                self.read(
+                let _ = self.read(
                     ZONE_CONFIG,
                     ADDRESS_CONFIG_READ_BLOCK_2,
                     CONFIG_ZONE_READ_SIZE,
-                )
-                .unwrap();
+                );
             }
             Operation::ReadConfigTwoCommand => {
                 self.op.set(Operation::ReadConfigTwoResult(0));
 
-                self.i2c
-                    .read(buffer, self.op_len.get() + RESPONSE_COUNT_SIZE + CRC_SIZE)
-                    .unwrap();
+                let _ = self
+                    .i2c
+                    .read(buffer, self.op_len.get() + RESPONSE_COUNT_SIZE + CRC_SIZE);
             }
             Operation::ReadConfigTwoResult(run) => {
                 if status == Err(i2c::Error::DataNak) || status == Err(i2c::Error::AddressNak) {
@@ -592,9 +591,9 @@ impl<'a> I2CClient for Atecc508a<'a> {
 
                     self.op.set(Operation::ReadConfigTwoResult(run + 1));
 
-                    self.i2c
-                        .read(buffer, self.op_len.get() + RESPONSE_COUNT_SIZE + CRC_SIZE)
-                        .unwrap();
+                    let _ = self
+                        .i2c
+                        .read(buffer, self.op_len.get() + RESPONSE_COUNT_SIZE + CRC_SIZE);
 
                     return;
                 }
@@ -655,12 +654,10 @@ impl<'a> I2CClient for Atecc508a<'a> {
 
                 self.op.set(Operation::GenerateEntropyResult(0));
 
-                self.i2c
-                    .read(
-                        buffer,
-                        RESPONSE_COUNT_SIZE + RESPONSE_RANDOM_SIZE + CRC_SIZE,
-                    )
-                    .unwrap();
+                let _ = self.i2c.read(
+                    buffer,
+                    RESPONSE_COUNT_SIZE + RESPONSE_RANDOM_SIZE + CRC_SIZE,
+                );
             }
             Operation::GenerateEntropyResult(run) => {
                 if status == Err(i2c::Error::DataNak) || status == Err(i2c::Error::AddressNak) {
@@ -679,12 +676,10 @@ impl<'a> I2CClient for Atecc508a<'a> {
 
                     self.op.set(Operation::GenerateEntropyResult(run + 1));
 
-                    self.i2c
-                        .read(
-                            buffer,
-                            RESPONSE_COUNT_SIZE + RESPONSE_RANDOM_SIZE + CRC_SIZE,
-                        )
-                        .unwrap();
+                    let _ = self.i2c.read(
+                        buffer,
+                        RESPONSE_COUNT_SIZE + RESPONSE_RANDOM_SIZE + CRC_SIZE,
+                    );
 
                     return;
                 }
@@ -726,7 +721,7 @@ impl<'a> I2CClient for Atecc508a<'a> {
                     self.buffer.replace(buffer);
                 });
 
-                self.write(ZONE_CONFIG, 20 / 4, 4).unwrap();
+                let _ = self.write(ZONE_CONFIG, 20 / 4, 4);
             }
             Operation::SetupConfigTwo(run) => {
                 self.buffer.replace(buffer);
@@ -739,7 +734,7 @@ impl<'a> I2CClient for Atecc508a<'a> {
                     }
 
                     self.op.set(Operation::SetupConfigTwo(run + 1));
-                    self.write(ZONE_CONFIG, 20 / 4, 4).unwrap();
+                    let _ = self.write(ZONE_CONFIG, 20 / 4, 4);
                     return;
                 }
 
@@ -762,12 +757,10 @@ impl<'a> I2CClient for Atecc508a<'a> {
 
                 self.op.set(Operation::LockResponse(0));
 
-                self.i2c
-                    .read(
-                        buffer,
-                        RESPONSE_COUNT_SIZE + RESPONSE_SIGNAL_SIZE + CRC_SIZE,
-                    )
-                    .unwrap();
+                let _ = self.i2c.read(
+                    buffer,
+                    RESPONSE_COUNT_SIZE + RESPONSE_SIGNAL_SIZE + CRC_SIZE,
+                );
             }
             Operation::LockResponse(run) => {
                 if status == Err(i2c::Error::DataNak) || status == Err(i2c::Error::AddressNak) {
@@ -779,12 +772,10 @@ impl<'a> I2CClient for Atecc508a<'a> {
                     }
 
                     self.op.set(Operation::LockResponse(run + 1));
-                    self.i2c
-                        .read(
-                            buffer,
-                            RESPONSE_COUNT_SIZE + RESPONSE_SIGNAL_SIZE + CRC_SIZE,
-                        )
-                        .unwrap();
+                    let _ = self.i2c.read(
+                        buffer,
+                        RESPONSE_COUNT_SIZE + RESPONSE_SIGNAL_SIZE + CRC_SIZE,
+                    );
                     return;
                 }
 
@@ -815,9 +806,9 @@ impl<'a> I2CClient for Atecc508a<'a> {
 
                 self.op.set(Operation::ReadKeyPair(0));
 
-                self.i2c
-                    .read(buffer, RESPONSE_COUNT_SIZE + PUBLIC_KEY_SIZE + CRC_SIZE)
-                    .unwrap();
+                let _ = self
+                    .i2c
+                    .read(buffer, RESPONSE_COUNT_SIZE + PUBLIC_KEY_SIZE + CRC_SIZE);
             }
             Operation::ReadKeyPair(run) => {
                 if status == Err(i2c::Error::DataNak) || status == Err(i2c::Error::AddressNak) {
@@ -830,9 +821,9 @@ impl<'a> I2CClient for Atecc508a<'a> {
                     }
 
                     self.op.set(Operation::ReadKeyPair(run + 1));
-                    self.i2c
-                        .read(buffer, RESPONSE_COUNT_SIZE + PUBLIC_KEY_SIZE + CRC_SIZE)
-                        .unwrap();
+                    let _ = self
+                        .i2c
+                        .read(buffer, RESPONSE_COUNT_SIZE + PUBLIC_KEY_SIZE + CRC_SIZE);
                     return;
                 }
 
@@ -863,12 +854,10 @@ impl<'a> I2CClient for Atecc508a<'a> {
 
                 self.op.set(Operation::LockResponse(0));
 
-                self.i2c
-                    .read(
-                        buffer,
-                        RESPONSE_COUNT_SIZE + RESPONSE_SIGNAL_SIZE + CRC_SIZE,
-                    )
-                    .unwrap();
+                let _ = self.i2c.read(
+                    buffer,
+                    RESPONSE_COUNT_SIZE + RESPONSE_SIGNAL_SIZE + CRC_SIZE,
+                );
             }
             Operation::LockSlot0(run) => {
                 if status == Err(i2c::Error::DataNak) || status == Err(i2c::Error::AddressNak) {
@@ -887,12 +876,10 @@ impl<'a> I2CClient for Atecc508a<'a> {
 
                 self.op.set(Operation::LockResponse(0));
 
-                self.i2c
-                    .read(
-                        buffer,
-                        RESPONSE_COUNT_SIZE + RESPONSE_SIGNAL_SIZE + CRC_SIZE,
-                    )
-                    .unwrap();
+                let _ = self.i2c.read(
+                    buffer,
+                    RESPONSE_COUNT_SIZE + RESPONSE_SIGNAL_SIZE + CRC_SIZE,
+                );
             }
             Operation::StartSha(run) => {
                 if status == Err(i2c::Error::DataNak) || status == Err(i2c::Error::AddressNak) {
@@ -911,12 +898,10 @@ impl<'a> I2CClient for Atecc508a<'a> {
 
                 self.op.set(Operation::ShaLoad(0));
 
-                self.i2c
-                    .read(
-                        buffer,
-                        RESPONSE_COUNT_SIZE + RESPONSE_SIGNAL_SIZE + CRC_SIZE,
-                    )
-                    .unwrap();
+                let _ = self.i2c.read(
+                    buffer,
+                    RESPONSE_COUNT_SIZE + RESPONSE_SIGNAL_SIZE + CRC_SIZE,
+                );
             }
             Operation::ShaLoad(run) => {
                 if status == Err(i2c::Error::DataNak) || status == Err(i2c::Error::AddressNak) {
@@ -927,12 +912,10 @@ impl<'a> I2CClient for Atecc508a<'a> {
                     }
 
                     self.op.set(Operation::ShaLoad(run + 1));
-                    self.i2c
-                        .read(
-                            buffer,
-                            RESPONSE_COUNT_SIZE + RESPONSE_SIGNAL_SIZE + CRC_SIZE,
-                        )
-                        .unwrap();
+                    let _ = self.i2c.read(
+                        buffer,
+                        RESPONSE_COUNT_SIZE + RESPONSE_SIGNAL_SIZE + CRC_SIZE,
+                    );
                     return;
                 }
 
@@ -957,12 +940,10 @@ impl<'a> I2CClient for Atecc508a<'a> {
                 }
 
                 self.op.set(Operation::ShaLoad(0));
-                self.i2c
-                    .read(
-                        buffer,
-                        RESPONSE_COUNT_SIZE + RESPONSE_SIGNAL_SIZE + CRC_SIZE,
-                    )
-                    .unwrap();
+                let _ = self.i2c.read(
+                    buffer,
+                    RESPONSE_COUNT_SIZE + RESPONSE_SIGNAL_SIZE + CRC_SIZE,
+                );
             }
             Operation::ShaRun(run) => {
                 if status == Err(i2c::Error::DataNak) || status == Err(i2c::Error::AddressNak) {
@@ -987,9 +968,9 @@ impl<'a> I2CClient for Atecc508a<'a> {
                 self.op.set(Operation::ShaEnd(0));
                 self.remain_len.set(0);
 
-                self.i2c
-                    .read(buffer, RESPONSE_COUNT_SIZE + RESPONSE_SHA_SIZE + CRC_SIZE)
-                    .unwrap();
+                let _ = self
+                    .i2c
+                    .read(buffer, RESPONSE_COUNT_SIZE + RESPONSE_SHA_SIZE + CRC_SIZE);
             }
             Operation::ShaEnd(run) => {
                 if status == Err(i2c::Error::DataNak) || status == Err(i2c::Error::AddressNak) {
@@ -1000,9 +981,9 @@ impl<'a> I2CClient for Atecc508a<'a> {
                     }
 
                     self.op.set(Operation::ShaEnd(run + 1));
-                    self.i2c
-                        .read(buffer, RESPONSE_COUNT_SIZE + RESPONSE_SHA_SIZE + CRC_SIZE)
-                        .unwrap();
+                    let _ = self
+                        .i2c
+                        .read(buffer, RESPONSE_COUNT_SIZE + RESPONSE_SHA_SIZE + CRC_SIZE);
                     return;
                 }
 


### PR DESCRIPTION
### Pull Request Overview

Support hardware accelerated SHA256 digests using the ATECC508A.

### Testing Strategy

Running the Apollo3 unit tests against a ATECC508A.

### TODO or Help Wanted

N/A

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
