### PR TITLE
fmt: make `panic!` error messages greppable

### DIFF
--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -1070,8 +1070,7 @@ pub mod test {
                 }
                 None => {
                     panic!(
-                        "Failed to allocate region that does not overlap and \
-                         should meet alignment constraints: {:?}",
+                        "Failed to allocate region that does not overlap and should meet alignment constraints: {:?}",
                         region
                     );
                 }

--- a/boards/build.rs
+++ b/boards/build.rs
@@ -45,8 +45,7 @@ fn main() {
             .any(|f| f.contains("cfg_tock_buildflagssentinel"))
         {
             panic!(
-                "Incorrect build configuration. \
-            Verify you have not unintentionally set the RUSTFLAGS environment variable."
+                "Incorrect build configuration. Verify you are using unstable cargo and have not unintentionally set the RUSTFLAGS environment variable."
             );
         }
     }


### PR DESCRIPTION
Keep the error text contiguous in error messages so that they are easy to locate.

Fixes #4141 by making the dependency on unstable cargo for build explicit.

### Formatting

- [x] Ran `make prepush`.
