### PR TITLE
Add support for ECDSA NIST P256 signature credentials

### DIFF
--- a/boards/components/Cargo.toml
+++ b/boards/components/Cargo.toml
@@ -16,5 +16,7 @@ capsules-extra = { path = "../../capsules/extra" }
 capsules-system = { path = "../../capsules/system" }
 segger = { path = "../../chips/segger" }
 
+tock-tbf = { path = "../../libraries/tock-tbf" }
+
 [lints]
 workspace = true

--- a/boards/components/src/appid/checker_signature.rs
+++ b/boards/components/src/appid/checker_signature.rs
@@ -1,0 +1,106 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2024.
+
+//! Components for signature credential checkers.
+
+use core::mem::MaybeUninit;
+use kernel::component::Component;
+use kernel::hil::{digest, public_key_crypto};
+
+#[macro_export]
+macro_rules! app_checker_signature_component_static {
+    ($S:ty, $H:ty, $HL:expr, $SL:expr $(,)?) => {{
+        let hash_buffer = kernel::static_buf!([u8; $HL]);
+        let signature_buffer = kernel::static_buf!([u8; $SL]);
+        let checker = kernel::static_buf!(
+            capsules_system::process_checker::signature::AppCheckerSignature<
+                'static,
+                $S,
+                $H,
+                $HL,
+                $SL,
+            >
+        );
+
+        (checker, hash_buffer, signature_buffer)
+    };};
+}
+
+pub type AppCheckerSignatureComponentType<S, H, const HL: usize, const SL: usize> =
+    capsules_system::process_checker::signature::AppCheckerSignature<'static, S, H, HL, SL>;
+
+pub struct AppCheckerSignatureComponent<
+    S: kernel::hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL> + 'static,
+    H: kernel::hil::digest::DigestDataHash<'static, HL> + 'static,
+    const HL: usize,
+    const SL: usize,
+> {
+    hasher: &'static H,
+    verifier: &'static S,
+    credential_type: tock_tbf::types::TbfFooterV2CredentialsType,
+}
+
+impl<
+        S: kernel::hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL>,
+        H: kernel::hil::digest::DigestDataHash<'static, HL>,
+        const HL: usize,
+        const SL: usize,
+    > AppCheckerSignatureComponent<S, H, HL, SL>
+{
+    pub fn new(
+        hasher: &'static H,
+        verifier: &'static S,
+        credential_type: tock_tbf::types::TbfFooterV2CredentialsType,
+    ) -> Self {
+        Self {
+            hasher,
+            verifier,
+            credential_type,
+        }
+    }
+}
+
+impl<
+        S: kernel::hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL>,
+        H: kernel::hil::digest::DigestDataHash<'static, HL> + kernel::hil::digest::Digest<'static, HL>,
+        const HL: usize,
+        const SL: usize,
+    > Component for AppCheckerSignatureComponent<S, H, HL, SL>
+{
+    type StaticInput = (
+        &'static mut MaybeUninit<
+            capsules_system::process_checker::signature::AppCheckerSignature<'static, S, H, HL, SL>,
+        >,
+        &'static mut MaybeUninit<[u8; HL]>,
+        &'static mut MaybeUninit<[u8; SL]>,
+    );
+
+    type Output = &'static capsules_system::process_checker::signature::AppCheckerSignature<
+        'static,
+        S,
+        H,
+        HL,
+        SL,
+    >;
+
+    fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        let hash_buffer = s.1.write([0; HL]);
+        let signature_buffer = s.2.write([0; SL]);
+
+        let checker = s.0.write(
+            capsules_system::process_checker::signature::AppCheckerSignature::new(
+                self.hasher,
+                self.verifier,
+                hash_buffer,
+                signature_buffer,
+                self.credential_type,
+            ),
+        );
+
+        digest::Digest::set_client(self.hasher, checker);
+        public_key_crypto::signature::SignatureVerify::set_verify_client(self.verifier, checker);
+
+        checker
+    }
+}

--- a/boards/components/src/appid/mod.rs
+++ b/boards/components/src/appid/mod.rs
@@ -7,3 +7,4 @@ pub mod assigner_tbf;
 pub mod checker;
 pub mod checker_null;
 pub mod checker_sha;
+pub mod checker_signature;

--- a/libraries/tock-tbf/src/types.rs
+++ b/libraries/tock-tbf/src/types.rs
@@ -258,6 +258,7 @@ pub enum TbfFooterV2CredentialsType {
     SHA256 = 3,
     SHA384 = 4,
     SHA512 = 5,
+    EcdsaNistP256 = 6,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -603,6 +604,7 @@ impl core::convert::TryFrom<&'static [u8]> for TbfFooterV2Credentials {
             3 => TbfFooterV2CredentialsType::SHA256,
             4 => TbfFooterV2CredentialsType::SHA384,
             5 => TbfFooterV2CredentialsType::SHA512,
+            6 => TbfFooterV2CredentialsType::EcdsaNistP256,
             _ => {
                 return Err(TbfParseError::BadTlvEntry(
                     TbfHeaderTypes::TbfFooterCredentials as usize,
@@ -616,6 +618,7 @@ impl core::convert::TryFrom<&'static [u8]> for TbfFooterV2Credentials {
             TbfFooterV2CredentialsType::SHA256 => 32,
             TbfFooterV2CredentialsType::SHA384 => 48,
             TbfFooterV2CredentialsType::SHA512 => 64,
+            TbfFooterV2CredentialsType::EcdsaNistP256 => 64,
         };
         let data = &b
             .get(4..(length + 4))


### PR DESCRIPTION
### Pull Request Overview

Add support for verifying ECDSA NIST P256 signature credentials.

### Testing Strategy

Tested by verifying signature credentials created with https://github.com/tock/elf2tab/pull/87

Tested with https://github.com/tock/tock/pull/4154 and https://github.com/tock/tock/pull/4159

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
