### PR TITLE
Switch SPI master HIL to leasable buffers instead of raw slices

### DIFF
--- a/boards/apollo3/lora_things_plus/src/tests/spi_controller.rs
+++ b/boards/apollo3/lora_things_plus/src/tests/spi_controller.rs
@@ -9,14 +9,15 @@ use core::cell::Cell;
 use kernel::hil::spi::{self, ClockPhase, ClockPolarity};
 use kernel::hil::spi::{SpiMaster, SpiMasterClient};
 use kernel::static_init;
-use kernel::utilities::cells::TakeCell;
+use kernel::utilities::cells::MapCell;
+use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::{debug, ErrorCode};
 
 struct SpiHostCallback {
     transfer_done: Cell<bool>,
     tx_len: Cell<usize>,
-    tx_data: TakeCell<'static, [u8]>,
-    rx_data: TakeCell<'static, [u8]>,
+    tx_data: MapCell<SubSliceMut<'static, u8>>,
+    rx_data: MapCell<SubSliceMut<'static, u8>>,
 }
 
 impl<'a> SpiHostCallback {
@@ -24,8 +25,8 @@ impl<'a> SpiHostCallback {
         SpiHostCallback {
             transfer_done: Cell::new(false),
             tx_len: Cell::new(0),
-            tx_data: TakeCell::new(tx_data),
-            rx_data: TakeCell::new(rx_data),
+            tx_data: MapCell::new(tx_data.into()),
+            rx_data: MapCell::new(rx_data.into()),
         }
     }
 
@@ -38,14 +39,12 @@ impl<'a> SpiHostCallback {
 impl<'a> SpiMasterClient for SpiHostCallback {
     fn read_write_done(
         &self,
-        tx_data: &'static mut [u8],
-        rx_done: Option<&'static mut [u8]>,
-        tx_len: usize,
-        rc: Result<(), ErrorCode>,
+        tx_data: SubSliceMut<'static, u8>,
+        rx_done: Option<SubSliceMut<'static, u8>>,
+        rc: Result<usize, ErrorCode>,
     ) {
         // Transfer Complete
-        assert_eq!(rc, Ok(()));
-        assert_eq!(tx_len, self.tx_len.get());
+        assert_eq!(rc, Ok(self.tx_len.get()));
 
         // Capture Buffers
         match rx_done {
@@ -59,9 +58,7 @@ impl<'a> SpiMasterClient for SpiHostCallback {
 
         self.tx_data.replace(tx_data);
 
-        if self.tx_len.get() == tx_len {
-            self.transfer_done.set(true);
-        }
+        self.transfer_done.set(true);
     }
 }
 
@@ -159,7 +156,7 @@ fn spi_host_transfer_partial() {
     spi_host.set_phase(ClockPhase::SampleLeading).ok();
 
     assert_eq!(
-        spi_host.read_write_bytes(tx, Some(rx), cb.tx_len.get()),
+        spi_host.read_write_bytes(tx.into(), Some(rx.into())),
         Ok(())
     );
     run_kernel_op(5000);
@@ -197,7 +194,7 @@ fn spi_host_transfer_single() {
     spi_host.set_phase(ClockPhase::SampleLeading).ok();
 
     assert_eq!(
-        spi_host.read_write_bytes(tx, Some(rx), cb.tx_len.get()),
+        spi_host.read_write_bytes(tx.into(), Some(rx.into())),
         Ok(())
     );
     run_kernel_op(5000);
@@ -218,7 +215,7 @@ fn spi_host_transfer_single() {
     cb.tx_len.set(tx2.len());
 
     assert_eq!(
-        spi_host.read_write_bytes(tx2, Some(rx2), cb.tx_len.get()),
+        spi_host.read_write_bytes(tx2.into(), Some(rx2.into())),
         Ok(())
     );
     run_kernel_op(5000);

--- a/boards/apollo3/redboard_artemis_nano/src/tests/spi_controller.rs
+++ b/boards/apollo3/redboard_artemis_nano/src/tests/spi_controller.rs
@@ -9,14 +9,15 @@ use core::cell::Cell;
 use kernel::hil::spi::{self, ClockPhase, ClockPolarity};
 use kernel::hil::spi::{SpiMaster, SpiMasterClient};
 use kernel::static_init;
-use kernel::utilities::cells::TakeCell;
+use kernel::utilities::cells::MapCell;
+use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::{debug, ErrorCode};
 
 struct SpiHostCallback {
     transfer_done: Cell<bool>,
     tx_len: Cell<usize>,
-    tx_data: TakeCell<'static, [u8]>,
-    rx_data: TakeCell<'static, [u8]>,
+    tx_data: MapCell<SubSliceMut<'static, u8>>,
+    rx_data: MapCell<SubSliceMut<'static, u8>>,
 }
 
 impl<'a> SpiHostCallback {
@@ -24,8 +25,8 @@ impl<'a> SpiHostCallback {
         SpiHostCallback {
             transfer_done: Cell::new(false),
             tx_len: Cell::new(0),
-            tx_data: TakeCell::new(tx_data),
-            rx_data: TakeCell::new(rx_data),
+            tx_data: MapCell::new(tx_data.into()),
+            rx_data: MapCell::new(rx_data.into()),
         }
     }
 
@@ -38,14 +39,12 @@ impl<'a> SpiHostCallback {
 impl<'a> SpiMasterClient for SpiHostCallback {
     fn read_write_done(
         &self,
-        tx_data: &'static mut [u8],
-        rx_done: Option<&'static mut [u8]>,
-        tx_len: usize,
-        rc: Result<(), ErrorCode>,
+        tx_data: SubSliceMut<'static, u8>,
+        rx_done: Option<SubSliceMut<'static, u8>>,
+        rc: Result<usize, ErrorCode>,
     ) {
         // Transfer Complete
-        assert_eq!(rc, Ok(()));
-        assert_eq!(tx_len, self.tx_len.get());
+        assert_eq!(rc, Ok(self.tx_len.get()));
 
         // Capture Buffers
         match rx_done {
@@ -59,9 +58,7 @@ impl<'a> SpiMasterClient for SpiHostCallback {
 
         self.tx_data.replace(tx_data);
 
-        if self.tx_len.get() == tx_len {
-            self.transfer_done.set(true);
-        }
+        self.transfer_done.set(true);
     }
 }
 
@@ -158,10 +155,7 @@ fn spi_host_transfer_partial() {
     spi_host.set_polarity(ClockPolarity::IdleLow).ok();
     spi_host.set_phase(ClockPhase::SampleLeading).ok();
 
-    assert_eq!(
-        spi_host.read_write_bytes(tx, Some(rx), cb.tx_len.get()),
-        Ok(())
-    );
+    assert_eq!(spi_host.read_write_bytes(tx, Some(rx)), Ok(()));
     run_kernel_op(5000);
 
     assert_eq!(cb.transfer_done.get(), true);
@@ -196,10 +190,7 @@ fn spi_host_transfer_single() {
     spi_host.set_polarity(ClockPolarity::IdleLow).ok();
     spi_host.set_phase(ClockPhase::SampleLeading).ok();
 
-    assert_eq!(
-        spi_host.read_write_bytes(tx, Some(rx), cb.tx_len.get()),
-        Ok(())
-    );
+    assert_eq!(spi_host.read_write_bytes(tx, Some(rx)), Ok(()));
     run_kernel_op(5000);
 
     assert_eq!(cb.transfer_done.get(), true);
@@ -217,10 +208,7 @@ fn spi_host_transfer_single() {
     let rx2 = cb.rx_data.take().unwrap();
     cb.tx_len.set(tx2.len());
 
-    assert_eq!(
-        spi_host.read_write_bytes(tx2, Some(rx2), cb.tx_len.get()),
-        Ok(())
-    );
+    assert_eq!(spi_host.read_write_bytes(tx2, Some(rx2)), Ok(()));
     run_kernel_op(5000);
 
     assert_eq!(cb.transfer_done.get(), true);

--- a/boards/imix/src/test/spi_dummy.rs
+++ b/boards/imix/src/test/spi_dummy.rs
@@ -8,6 +8,7 @@ use core::ptr::addr_of_mut;
 
 use kernel::hil::gpio::Configure;
 use kernel::hil::spi::{self, SpiMaster};
+use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::ErrorCode;
 
 #[allow(unused_variables, dead_code)]
@@ -31,17 +32,16 @@ impl spi::SpiMasterClient for DummyCB {
     #[allow(unused_variables, dead_code)]
     fn read_write_done(
         &self,
-        write: &'static mut [u8],
-        read: Option<&'static mut [u8]>,
-        len: usize,
-        _status: Result<(), ErrorCode>,
+        write: SubSliceMut<'static, u8>,
+        read: Option<SubSliceMut<'static, u8>>,
+        status: Result<usize, ErrorCode>,
     ) {
         unsafe {
             // do actual stuff
             // TODO verify SPI return value
             let _ = self
                 .spi
-                .read_write_bytes(&mut *addr_of_mut!(A5), None, A5.len());
+                .read_write_bytes((&mut *addr_of_mut!(A5) as &mut [u8]).into(), None);
 
             // FLOP = !FLOP;
             // let len: usize = BUF1.len();
@@ -89,9 +89,8 @@ pub unsafe fn spi_dummy_test(spi: &'static sam4l::spi::SpiHw<'static>) {
 
     let len = BUF2.len();
     if spi.read_write_bytes(
-        &mut *addr_of_mut!(BUF2),
-        Some(&mut *addr_of_mut!(BUF1)),
-        len,
+        (&mut *addr_of_mut!(BUF2) as &mut [u8]).into(),
+        Some((&mut *addr_of_mut!(BUF1) as &mut [u8]).into()),
     ) != Ok(())
     {
         loop {

--- a/boards/imix/src/test/spi_loopback.rs
+++ b/boards/imix/src/test/spi_loopback.rs
@@ -21,6 +21,7 @@ use core::ptr::addr_of_mut;
 use kernel::component::Component;
 use kernel::debug;
 use kernel::hil::spi::{self, SpiMasterDevice};
+use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::ErrorCode;
 
 #[allow(unused_variables, dead_code)]
@@ -49,14 +50,13 @@ impl spi::SpiMasterClient for SpiLoopback {
     #[allow(unused_variables, dead_code)]
     fn read_write_done(
         &self,
-        write: &'static mut [u8],
-        read: Option<&'static mut [u8]>,
-        len: usize,
-        status: Result<(), ErrorCode>,
+        mut write: SubSliceMut<'static, u8>,
+        read: Option<SubSliceMut<'static, u8>>,
+        status: Result<usize, ErrorCode>,
     ) {
         let mut good = true;
         let read = read.unwrap();
-        for (c, v) in write.iter().enumerate() {
+        for (c, v) in write[..].iter().enumerate() {
             if read[c] != *v {
                 debug!(
                     "SPI test error at index {}: wrote {} but read {}",
@@ -75,7 +75,7 @@ impl spi::SpiMasterClient for SpiLoopback {
             write[i] = counter.wrapping_add(i as u8);
         }
 
-        if let Err((e, _, _)) = self.spi.read_write_bytes(write, Some(read), len) {
+        if let Err((e, _, _)) = self.spi.read_write_bytes(write, Some(read)) {
             panic!(
                 "Could not continue SPI test, error on read_write_bytes is {:?}",
                 e
@@ -98,9 +98,8 @@ pub unsafe fn spi_loopback_test(
 
     let len = WBUF.len();
     if let Err((e, _, _)) = spi.read_write_bytes(
-        &mut *addr_of_mut!(WBUF),
-        Some(&mut *addr_of_mut!(RBUF)),
-        len,
+        (&mut *addr_of_mut!(WBUF) as &mut [u8]).into(),
+        Some((&mut *addr_of_mut!(RBUF) as &mut [u8]).into()),
     ) {
         panic!(
             "Could not start SPI test, error on read_write_bytes is {:?}",
@@ -130,9 +129,8 @@ pub unsafe fn spi_two_loopback_test(mux: &'static MuxSpiMaster<'static, sam4l::s
 
     let len = WBUF.len();
     if let Err((e, _, _)) = spi_fast.read_write_bytes(
-        &mut *addr_of_mut!(WBUF),
-        Some(&mut *addr_of_mut!(RBUF)),
-        len,
+        (&mut *addr_of_mut!(WBUF) as &mut [u8]).into(),
+        Some((&mut *addr_of_mut!(RBUF) as &mut [u8]).into()),
     ) {
         panic!(
             "Could not start SPI test, error on read_write_bytes is {:?}",
@@ -142,9 +140,8 @@ pub unsafe fn spi_two_loopback_test(mux: &'static MuxSpiMaster<'static, sam4l::s
 
     let len = WBUF2.len();
     if let Err((e, _, _)) = spi_slow.read_write_bytes(
-        &mut *addr_of_mut!(WBUF2),
-        Some(&mut *addr_of_mut!(RBUF2)),
-        len,
+        (&mut *addr_of_mut!(WBUF2) as &mut [u8]).into(),
+        Some((&mut *addr_of_mut!(RBUF2) as &mut [u8]).into()),
     ) {
         panic!(
             "Could not start SPI test, error on read_write_bytes is {:?}",

--- a/capsules/extra/src/bus.rs
+++ b/capsules/extra/src/bus.rs
@@ -217,13 +217,12 @@ impl<'a, S: SpiMasterDevice<'a>> Bus<'a> for SpiMasterBus<'a, S> {
                     let mut buffer_slice: SubSliceMut<'static, u8> = buffer.into();
                     buffer_slice.slice(0..(len * bytes));
                     self.status.set(BusStatus::Read);
-                    if let Err((error, write_buffer, buffer)) = self
-                        .spi
-                        .read_write_bytes(write_buffer.into(), Some(buffer_slice))
+                    if let Err((error, write_buffer, buffer)) =
+                        self.spi.read_write_bytes(write_buffer, Some(buffer_slice))
                     {
                         self.status.set(BusStatus::Idle);
                         self.read_write_buffer.replace(write_buffer);
-                        Err((error, buffer.map(|b| b.take()).unwrap_or(&mut [])))
+                        Err((error, buffer.map_or(&mut [] as &mut [u8], |b| b.take())))
                     } else {
                         Ok(())
                     }

--- a/capsules/extra/src/fm25cl.rs
+++ b/capsules/extra/src/fm25cl.rs
@@ -47,7 +47,8 @@
 use core::cell::Cell;
 use core::cmp;
 use kernel::hil;
-use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::utilities::cells::{MapCell, OptionalCell, TakeCell};
+use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::ErrorCode;
 
 pub const BUF_LEN: usize = 512;
@@ -92,8 +93,8 @@ pub trait FM25CLClient {
 pub struct FM25CL<'a, S: hil::spi::SpiMasterDevice<'a>> {
     spi: &'a S,
     state: Cell<State>,
-    txbuffer: TakeCell<'static, [u8]>,
-    rxbuffer: TakeCell<'static, [u8]>,
+    txbuffer: MapCell<SubSliceMut<'static, u8>>,
+    rxbuffer: MapCell<SubSliceMut<'static, u8>>,
     client: OptionalCell<&'a dyn hil::nonvolatile_storage::NonvolatileStorageClient>,
     client_custom: OptionalCell<&'a dyn FM25CLClient>,
     client_buffer: TakeCell<'static, [u8]>, // Store buffer and state for passing back to client
@@ -111,8 +112,8 @@ impl<'a, S: hil::spi::SpiMasterDevice<'a>> FM25CL<'a, S> {
         FM25CL {
             spi,
             state: Cell::new(State::Idle),
-            txbuffer: TakeCell::new(txbuffer),
-            rxbuffer: TakeCell::new(rxbuffer),
+            txbuffer: MapCell::new(txbuffer.into()),
+            rxbuffer: MapCell::new(rxbuffer.into()),
             client: OptionalCell::empty(),
             client_custom: OptionalCell::empty(),
             client_buffer: TakeCell::empty(),
@@ -144,9 +145,7 @@ impl<'a, S: hil::spi::SpiMasterDevice<'a>> FM25CL<'a, S> {
 
         self.txbuffer
             .take()
-            .map_or(Err(ErrorCode::RESERVE), move |txbuffer| {
-                txbuffer[0] = Opcodes::WriteEnable as u8;
-
+            .map_or(Err(ErrorCode::RESERVE), move |mut txbuffer| {
                 let write_len = cmp::min(txbuffer.len(), len as usize);
 
                 // Need to save the buffer passed to us so we can give it back.
@@ -156,7 +155,10 @@ impl<'a, S: hil::spi::SpiMasterDevice<'a>> FM25CL<'a, S> {
                 self.client_write_len.set(write_len as u16);
 
                 self.state.set(State::WriteEnable);
-                let res = self.spi.read_write_bytes(txbuffer, None, 1);
+                txbuffer[0] = Opcodes::WriteEnable as u8;
+                txbuffer.slice(..1);
+                let res = self.spi.read_write_bytes(txbuffer, None);
+
                 match res {
                     Ok(()) => Ok(()),
                     Err((err, txbuffer, _)) => {
@@ -172,10 +174,10 @@ impl<'a, S: hil::spi::SpiMasterDevice<'a>> FM25CL<'a, S> {
 
         self.txbuffer
             .take()
-            .map_or(Err(ErrorCode::RESERVE), |txbuffer| {
+            .map_or(Err(ErrorCode::RESERVE), |mut txbuffer| {
                 self.rxbuffer
                     .take()
-                    .map_or(Err(ErrorCode::RESERVE), move |rxbuffer| {
+                    .map_or(Err(ErrorCode::RESERVE), move |mut rxbuffer| {
                         txbuffer[0] = Opcodes::ReadMemory as u8;
                         txbuffer[1] = ((address >> 8) & 0xFF) as u8;
                         txbuffer[2] = (address & 0xFF) as u8;
@@ -183,12 +185,12 @@ impl<'a, S: hil::spi::SpiMasterDevice<'a>> FM25CL<'a, S> {
                         // Save the user buffer for later
                         self.client_buffer.replace(buffer);
 
-                        let read_len = cmp::min(rxbuffer.len() - 3, len as usize);
+                        rxbuffer.reset();
+                        let read_len = cmp::min(rxbuffer.len(), 3 + len as usize);
+                        rxbuffer.slice(..read_len);
 
                         self.state.set(State::ReadMemory);
-                        let res = self
-                            .spi
-                            .read_write_bytes(txbuffer, Some(rxbuffer), read_len + 3);
+                        let res = self.spi.read_write_bytes(txbuffer, Some(rxbuffer));
                         match res {
                             Ok(()) => Ok(()),
                             Err((err, txbuffer, rxbuffer)) => {
@@ -205,11 +207,11 @@ impl<'a, S: hil::spi::SpiMasterDevice<'a>> FM25CL<'a, S> {
 impl<'a, S: hil::spi::SpiMasterDevice<'a>> hil::spi::SpiMasterClient for FM25CL<'a, S> {
     fn read_write_done(
         &self,
-        write_buffer: &'static mut [u8],
-        read_buffer: Option<&'static mut [u8]>,
-        len: usize,
-        _status: Result<(), ErrorCode>,
+        mut write_buffer: SubSliceMut<'static, u8>,
+        read_buffer: Option<SubSliceMut<'static, u8>>,
+        _status: Result<usize, ErrorCode>,
     ) {
+        write_buffer.reset();
         match self.state.get() {
             State::ReadStatus => {
                 self.state.set(State::Idle);
@@ -238,10 +240,9 @@ impl<'a, S: hil::spi::SpiMasterDevice<'a>> hil::spi::SpiMasterClient for FM25CL<
                         cmp::min(write_buffer.len(), self.client_write_len.get() as usize);
 
                     write_buffer[3..(write_len + 3)].copy_from_slice(&buffer[..write_len]);
+                    write_buffer.slice(..write_len + 3);
 
-                    let _ = self
-                        .spi
-                        .read_write_bytes(write_buffer, read_buffer, write_len + 3);
+                    let _ = self.spi.read_write_bytes(write_buffer, read_buffer);
                 });
             }
             State::WriteMemory => {
@@ -269,7 +270,7 @@ impl<'a, S: hil::spi::SpiMasterDevice<'a>> hil::spi::SpiMasterClient for FM25CL<
 
                 read_buffer.map(|read_buffer| {
                     self.client_buffer.take().map(move |buffer| {
-                        let read_len = cmp::min(buffer.len(), len);
+                        let read_len = buffer.len();
 
                         buffer[..(read_len - 3)]
                             .copy_from_slice(&read_buffer[3..((read_len - 3) + 3)]);
@@ -293,16 +294,18 @@ impl<'a, S: hil::spi::SpiMasterDevice<'a>> FM25CLCustom for FM25CL<'a, S> {
 
         self.txbuffer
             .take()
-            .map_or(Err(ErrorCode::RESERVE), |txbuffer| {
+            .map_or(Err(ErrorCode::RESERVE), |mut txbuffer| {
                 self.rxbuffer
                     .take()
-                    .map_or(Err(ErrorCode::RESERVE), move |rxbuffer| {
+                    .map_or(Err(ErrorCode::RESERVE), move |mut rxbuffer| {
                         txbuffer[0] = Opcodes::ReadStatusRegister as u8;
 
                         // Use 4 bytes instead of the required 2 because that works better
                         // with DMA for some reason.
                         // TODO verify SPI return value
-                        let _ = self.spi.read_write_bytes(txbuffer, Some(rxbuffer), 4);
+                        rxbuffer.reset();
+                        rxbuffer.slice(..4);
+                        let _ = self.spi.read_write_bytes(txbuffer, Some(rxbuffer));
                         self.state.set(State::ReadStatus);
                         Ok(())
                     })

--- a/capsules/extra/src/l3gd20.rs
+++ b/capsules/extra/src/l3gd20.rs
@@ -112,7 +112,8 @@ use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::hil::sensors;
 use kernel::hil::spi;
 use kernel::syscall::{CommandReturn, SyscallDriver};
-use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::utilities::cells::{MapCell, OptionalCell};
+use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::{ErrorCode, ProcessId};
 
 use capsules_core::driver;
@@ -186,8 +187,8 @@ pub struct App {}
 
 pub struct L3gd20Spi<'a, S: spi::SpiMasterDevice<'a>> {
     spi: &'a S,
-    txbuffer: TakeCell<'static, [u8]>,
-    rxbuffer: TakeCell<'static, [u8]>,
+    txbuffer: MapCell<SubSliceMut<'static, u8>>,
+    rxbuffer: MapCell<SubSliceMut<'static, u8>>,
     status: Cell<L3gd20Status>,
     hpf_enabled: Cell<bool>,
     hpf_mode: Cell<u8>,
@@ -209,8 +210,8 @@ impl<'a, S: spi::SpiMasterDevice<'a>> L3gd20Spi<'a, S> {
         // setup and return struct
         L3gd20Spi {
             spi,
-            txbuffer: TakeCell::new(txbuffer),
-            rxbuffer: TakeCell::new(rxbuffer),
+            txbuffer: MapCell::new((&mut txbuffer[..]).into()),
+            rxbuffer: MapCell::new((&mut rxbuffer[..]).into()),
             status: Cell::new(L3gd20Status::Idle),
             hpf_enabled: Cell::new(false),
             hpf_mode: Cell::new(0),
@@ -225,33 +226,39 @@ impl<'a, S: spi::SpiMasterDevice<'a>> L3gd20Spi<'a, S> {
 
     pub fn is_present(&self) -> bool {
         self.status.set(L3gd20Status::IsPresent);
-        self.txbuffer.take().map(|buf| {
+        self.txbuffer.take().map(|mut buf| {
+            buf.reset();
             buf[0] = L3GD20_REG_WHO_AM_I | 0x80;
             buf[1] = 0x00;
+            buf.slice(..2);
             // TODO verify SPI return value
-            let _ = self.spi.read_write_bytes(buf, self.rxbuffer.take(), 2);
+            let _ = self.spi.read_write_bytes(buf, self.rxbuffer.take());
         });
         false
     }
 
     pub fn power_on(&self) {
         self.status.set(L3gd20Status::PowerOn);
-        self.txbuffer.take().map(|buf| {
+        self.txbuffer.take().map(|mut buf| {
+            buf.reset();
             buf[0] = L3GD20_REG_CTRL_REG1;
             buf[1] = 0x0F;
+            buf.slice(..2);
             // TODO verify SPI return value
-            let _ = self.spi.read_write_bytes(buf, None, 2);
+            let _ = self.spi.read_write_bytes(buf, None);
         });
     }
 
     fn enable_hpf(&self, enabled: bool) {
         self.status.set(L3gd20Status::EnableHpf);
         self.hpf_enabled.set(enabled);
-        self.txbuffer.take().map(|buf| {
+        self.txbuffer.take().map(|mut buf| {
+            buf.reset();
             buf[0] = L3GD20_REG_CTRL_REG5;
             buf[1] = u8::from(enabled) << 4;
+            buf.slice(..2);
             // TODO verify SPI return value
-            let _ = self.spi.read_write_bytes(buf, None, 2);
+            let _ = self.spi.read_write_bytes(buf, None);
         });
     }
 
@@ -259,28 +266,33 @@ impl<'a, S: spi::SpiMasterDevice<'a>> L3gd20Spi<'a, S> {
         self.status.set(L3gd20Status::SetHpfParameters);
         self.hpf_mode.set(mode);
         self.hpf_divider.set(divider);
-        self.txbuffer.take().map(|buf| {
+        self.txbuffer.take().map(|mut buf| {
+            buf.reset();
             buf[0] = L3GD20_REG_CTRL_REG2;
             buf[1] = (mode & 0x03) << 4 | (divider & 0x0F);
+            buf.slice(..2);
             // TODO verify SPI return value
-            let _ = self.spi.read_write_bytes(buf, None, 2);
+            let _ = self.spi.read_write_bytes(buf, None);
         });
     }
 
     fn set_scale(&self, scale: u8) {
         self.status.set(L3gd20Status::SetScale);
         self.scale.set(scale);
-        self.txbuffer.take().map(|buf| {
+        self.txbuffer.take().map(|mut buf| {
+            buf.reset();
             buf[0] = L3GD20_REG_CTRL_REG4;
             buf[1] = (scale & 0x03) << 4;
+            buf.slice(..2);
             // TODO verify SPI return value
-            let _ = self.spi.read_write_bytes(buf, None, 2);
+            let _ = self.spi.read_write_bytes(buf, None);
         });
     }
 
     fn read_xyz(&self) {
         self.status.set(L3gd20Status::ReadXYZ);
-        self.txbuffer.take().map(|buf| {
+        self.txbuffer.take().map(|mut buf| {
+            buf.reset();
             buf[0] = L3GD20_REG_OUT_X_L | 0x80 | 0x40;
             buf[1] = 0x00;
             buf[2] = 0x00;
@@ -288,18 +300,21 @@ impl<'a, S: spi::SpiMasterDevice<'a>> L3gd20Spi<'a, S> {
             buf[4] = 0x00;
             buf[5] = 0x00;
             buf[6] = 0x00;
+            buf.slice(..7);
             // TODO verify SPI return value
-            let _ = self.spi.read_write_bytes(buf, self.rxbuffer.take(), 7);
+            let _ = self.spi.read_write_bytes(buf, self.rxbuffer.take());
         });
     }
 
     fn read_temperature(&self) {
         self.status.set(L3gd20Status::ReadTemperature);
-        self.txbuffer.take().map(|buf| {
+        self.txbuffer.take().map(|mut buf| {
+            buf.reset();
             buf[0] = L3GD20_REG_OUT_TEMP | 0x80;
             buf[1] = 0x00;
+            buf.slice(..2);
             // TODO verify SPI return value
-            let _ = self.spi.read_write_bytes(buf, self.rxbuffer.take(), 2);
+            let _ = self.spi.read_write_bytes(buf, self.rxbuffer.take());
         });
     }
 
@@ -417,10 +432,9 @@ impl<'a, S: spi::SpiMasterDevice<'a>> SyscallDriver for L3gd20Spi<'a, S> {
 impl<'a, S: spi::SpiMasterDevice<'a>> spi::SpiMasterClient for L3gd20Spi<'a, S> {
     fn read_write_done(
         &self,
-        write_buffer: &'static mut [u8],
-        read_buffer: Option<&'static mut [u8]>,
-        len: usize,
-        _status: Result<(), ErrorCode>,
+        write_buffer: SubSliceMut<'static, u8>,
+        read_buffer: Option<SubSliceMut<'static, u8>>,
+        status: Result<usize, ErrorCode>,
     ) {
         self.current_process.map(|proc_id| {
             let _result = self.grants.enter(proc_id, |_app, upcalls| {
@@ -442,7 +456,7 @@ impl<'a, S: spi::SpiMasterDevice<'a>> spi::SpiMasterClient for L3gd20Spi<'a, S> 
                         let mut y: usize = 0;
                         let mut z: usize = 0;
                         let values = if let Some(ref buf) = read_buffer {
-                            if len >= 7 {
+                            if status.unwrap_or(0) >= 7 {
                                 self.nine_dof_client.map(|client| {
                                     // compute using only integers
                                     let scale = match self.scale.get() {
@@ -490,7 +504,7 @@ impl<'a, S: spi::SpiMasterDevice<'a>> spi::SpiMasterClient for L3gd20Spi<'a, S> 
                     L3gd20Status::ReadTemperature => {
                         let mut temperature = 0;
                         let value = if let Some(ref buf) = read_buffer {
-                            if len >= 2 {
+                            if status.unwrap_or(0) >= 2 {
                                 temperature = buf[1] as i32;
                                 self.temperature_client.map(|client| {
                                     client.callback(Ok(temperature * 100));

--- a/capsules/extra/src/mx25r6435f.rs
+++ b/capsules/extra/src/mx25r6435f.rs
@@ -59,8 +59,9 @@ use core::ops::{Index, IndexMut};
 use kernel::debug;
 use kernel::hil;
 use kernel::hil::time::ConvertTicks;
-use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::cells::TakeCell;
+use kernel::utilities::cells::{MapCell, OptionalCell};
+use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::ErrorCode;
 
 pub const TX_BUF_LEN: usize = PAGE_SIZE as usize + 4;
@@ -184,8 +185,8 @@ pub struct MX25R6435F<
     state: Cell<State>,
     write_protect_pin: Option<&'a P>,
     hold_pin: Option<&'a P>,
-    txbuffer: TakeCell<'static, [u8]>,
-    rxbuffer: TakeCell<'static, [u8]>,
+    txbuffer: MapCell<SubSliceMut<'static, u8>>,
+    rxbuffer: MapCell<SubSliceMut<'static, u8>>,
     client: OptionalCell<&'a dyn hil::flash::Client<MX25R6435F<'a, S, P, A>>>,
     client_sector: TakeCell<'static, Mx25r6435fSector>,
 }
@@ -211,8 +212,8 @@ impl<
             state: Cell::new(State::Idle),
             write_protect_pin,
             hold_pin,
-            txbuffer: TakeCell::new(txbuffer),
-            rxbuffer: TakeCell::new(rxbuffer),
+            txbuffer: MapCell::new(txbuffer.into()),
+            rxbuffer: MapCell::new(rxbuffer.into()),
             client: OptionalCell::empty(),
             client_sector: TakeCell::empty(),
         }
@@ -237,15 +238,17 @@ impl<
 
         self.txbuffer
             .take()
-            .map_or(Err(ErrorCode::RESERVE), |txbuffer| {
+            .map_or(Err(ErrorCode::RESERVE), |mut txbuffer| {
                 self.rxbuffer
                     .take()
                     .map_or(Err(ErrorCode::RESERVE), move |rxbuffer| {
+                        txbuffer.reset();
                         txbuffer[0] = Opcodes::RDID as u8;
+                        txbuffer.slice(0..4);
 
                         self.state.set(State::ReadId);
                         if let Err((err, txbuffer, rxbuffer)) =
-                            self.spi.read_write_bytes(txbuffer, Some(rxbuffer), 4)
+                            self.spi.read_write_bytes(txbuffer, Some(rxbuffer))
                         {
                             self.txbuffer.replace(txbuffer);
                             self.rxbuffer.replace(rxbuffer.unwrap());
@@ -263,9 +266,11 @@ impl<
         });
         self.txbuffer
             .take()
-            .map_or(Err(ErrorCode::RESERVE), |txbuffer| {
+            .map_or(Err(ErrorCode::RESERVE), |mut txbuffer| {
+                txbuffer.reset();
                 txbuffer[0] = Opcodes::WREN as u8;
-                if let Err((err, txbuffer, _)) = self.spi.read_write_bytes(txbuffer, None, 1) {
+                txbuffer.slice(0..1);
+                if let Err((err, txbuffer, _)) = self.spi.read_write_bytes(txbuffer, None) {
                     self.txbuffer.replace(txbuffer);
                     Err(err)
                 } else {
@@ -290,37 +295,41 @@ impl<
     ) -> Result<(), (ErrorCode, &'static mut Mx25r6435fSector)> {
         match self.configure_spi() {
             Ok(()) => {
-                let retval = self
-                    .txbuffer
-                    .take()
-                    .map_or(Err(ErrorCode::RESERVE), |txbuffer| {
-                        self.rxbuffer
-                            .take()
-                            .map_or(Err(ErrorCode::RESERVE), move |rxbuffer| {
-                                // Setup the read instruction
-                                txbuffer[0] = Opcodes::READ as u8;
-                                txbuffer[1] = ((sector_index * SECTOR_SIZE) >> 16) as u8;
-                                txbuffer[2] = ((sector_index * SECTOR_SIZE) >> 8) as u8;
-                                txbuffer[3] = ((sector_index * SECTOR_SIZE) >> 0) as u8;
+                let retval =
+                    self.txbuffer
+                        .take()
+                        .map_or(Err(ErrorCode::RESERVE), |mut txbuffer| {
+                            self.rxbuffer.take().map_or(
+                                Err(ErrorCode::RESERVE),
+                                move |mut rxbuffer| {
+                                    // Setup the read instruction
+                                    txbuffer.reset();
+                                    txbuffer[0] = Opcodes::READ as u8;
+                                    txbuffer[1] = ((sector_index * SECTOR_SIZE) >> 16) as u8;
+                                    txbuffer[2] = ((sector_index * SECTOR_SIZE) >> 8) as u8;
+                                    txbuffer[3] = ((sector_index * SECTOR_SIZE) >> 0) as u8;
+                                    txbuffer.slice(0..(PAGE_SIZE as usize + 4));
 
-                                // Call the SPI driver to kick things off.
-                                self.state.set(State::ReadSector {
-                                    sector_index,
-                                    page_index: 0,
-                                });
-                                if let Err((err, txbuffer, rxbuffer)) = self.spi.read_write_bytes(
-                                    txbuffer,
-                                    Some(rxbuffer),
-                                    (PAGE_SIZE + 4) as usize,
-                                ) {
-                                    self.txbuffer.replace(txbuffer);
-                                    self.rxbuffer.replace(rxbuffer.unwrap());
-                                    Err(err)
-                                } else {
-                                    Ok(())
-                                }
-                            })
-                    });
+                                    rxbuffer.reset();
+                                    rxbuffer.slice(0..(PAGE_SIZE as usize + 4));
+
+                                    // Call the SPI driver to kick things off.
+                                    self.state.set(State::ReadSector {
+                                        sector_index,
+                                        page_index: 0,
+                                    });
+                                    if let Err((err, txbuffer, rxbuffer)) =
+                                        self.spi.read_write_bytes(txbuffer, Some(rxbuffer))
+                                    {
+                                        self.txbuffer.replace(txbuffer);
+                                        self.rxbuffer.replace(rxbuffer.unwrap());
+                                        Err(err)
+                                    } else {
+                                        Ok(())
+                                    }
+                                },
+                            )
+                        });
 
                 match retval {
                     Ok(()) => {
@@ -369,10 +378,9 @@ impl<
 {
     fn read_write_done(
         &self,
-        write_buffer: &'static mut [u8],
-        read_buffer: Option<&'static mut [u8]>,
-        len: usize,
-        read_write_status: Result<(), ErrorCode>,
+        mut write_buffer: SubSliceMut<'static, u8>,
+        read_buffer: Option<SubSliceMut<'static, u8>>,
+        read_write_status: Result<usize, ErrorCode>,
     ) {
         match self.state.get() {
             State::ReadId => {
@@ -409,22 +417,21 @@ impl<
                         } else {
                             let address =
                                 (sector_index * SECTOR_SIZE) + ((page_index + 1) * PAGE_SIZE);
+                            write_buffer.reset();
                             write_buffer[0] = Opcodes::READ as u8;
                             write_buffer[1] = (address >> 16) as u8;
                             write_buffer[2] = (address >> 8) as u8;
                             write_buffer[3] = (address >> 0) as u8;
+                            write_buffer.slice(0..(PAGE_SIZE as usize + 4));
 
                             self.state.set(State::ReadSector {
                                 sector_index,
                                 page_index: page_index + 1,
                             });
                             self.client_sector.replace(sector);
+
                             // TODO verify SPI return value
-                            let _ = self.spi.read_write_bytes(
-                                write_buffer,
-                                Some(read_buffer),
-                                (PAGE_SIZE + 4) as usize,
-                            );
+                            let _ = self.spi.read_write_bytes(write_buffer, Some(read_buffer));
                         }
                     });
                 });
@@ -434,13 +441,16 @@ impl<
                 operation,
             } => {
                 self.state.set(State::EraseSectorErase { operation });
+
+                write_buffer.reset();
                 write_buffer[0] = Opcodes::SE as u8;
                 write_buffer[1] = ((sector_index * SECTOR_SIZE) >> 16) as u8;
                 write_buffer[2] = ((sector_index * SECTOR_SIZE) >> 8) as u8;
                 write_buffer[3] = ((sector_index * SECTOR_SIZE) >> 0) as u8;
+                write_buffer.slice(0..4);
 
                 // TODO verify SPI return value
-                let _ = self.spi.read_write_bytes(write_buffer, None, 4);
+                let _ = self.spi.read_write_bytes(write_buffer, None);
             }
             State::EraseSectorErase { operation } => {
                 self.state.set(State::EraseSectorCheckDone { operation });
@@ -457,9 +467,7 @@ impl<
                     // Check the status byte to see if the erase is done or not.
                     if status & 0x01 == 0x01 {
                         // Erase is still in progress.
-                        let _ = self
-                            .spi
-                            .read_write_bytes(write_buffer, Some(read_buffer), 2);
+                        let _ = self.spi.read_write_bytes(write_buffer, Some(read_buffer));
                     } else {
                         // Erase has finished, so jump to the next state.
                         let next_state = match operation {
@@ -471,7 +479,7 @@ impl<
                         };
                         self.state.set(next_state);
                         self.rxbuffer.replace(read_buffer);
-                        self.read_write_done(write_buffer, None, len, read_write_status);
+                        self.read_write_done(write_buffer, None, read_write_status);
                     }
                 });
             }
@@ -505,8 +513,9 @@ impl<
                     });
                     // Need to write enable before each PP
                     write_buffer[0] = Opcodes::WREN as u8;
+                    write_buffer.slice(0..1);
                     // TODO verify SPI return value
-                    let _ = self.spi.read_write_bytes(write_buffer, None, 1);
+                    let _ = self.spi.read_write_bytes(write_buffer, None);
                 }
             }
             State::WriteSectorWrite {
@@ -519,6 +528,9 @@ impl<
                     page_index: page_index + 1,
                 });
                 let address = (sector_index * SECTOR_SIZE) + (page_index * PAGE_SIZE);
+                write_buffer.reset();
+                write_buffer.slice(0..(PAGE_SIZE as usize + 4));
+
                 write_buffer[0] = Opcodes::PP as u8;
                 write_buffer[1] = (address >> 16) as u8;
                 write_buffer[2] = (address >> 8) as u8;
@@ -530,9 +542,7 @@ impl<
                     }
                 });
 
-                let _ = self
-                    .spi
-                    .read_write_bytes(write_buffer, None, (PAGE_SIZE + 4) as usize);
+                let _ = self.spi.read_write_bytes(write_buffer, None);
             }
             State::WriteSectorCheckDone {
                 sector_index,
@@ -552,15 +562,15 @@ impl<
                 sector_index,
                 page_index,
             } => {
-                read_buffer.map(move |read_buffer| {
+                read_buffer.map(move |mut read_buffer| {
                     let status = read_buffer[1];
+
+                    read_buffer.slice(0..2);
 
                     // Check the status byte to see if the write is done or not.
                     if status & 0x01 == 0x01 {
                         // Write is still in progress.
-                        let _ = self
-                            .spi
-                            .read_write_bytes(write_buffer, Some(read_buffer), 2);
+                        let _ = self.spi.read_write_bytes(write_buffer, Some(read_buffer));
                     } else {
                         // Write has finished, so go back to writing.
                         self.state.set(State::WriteSectorWriteEnable {
@@ -568,7 +578,7 @@ impl<
                             page_index,
                         });
                         self.rxbuffer.replace(read_buffer);
-                        self.read_write_done(write_buffer, None, len, read_write_status);
+                        self.read_write_done(write_buffer, None, read_write_status);
                     }
                 });
             }
@@ -587,12 +597,12 @@ impl<
     fn alarm(&self) {
         // After the timer expires we still have to check that the erase/write
         // operation has finished.
-        self.txbuffer.take().map(|write_buffer| {
+        self.txbuffer.take().map(|mut write_buffer| {
             self.rxbuffer.take().map(move |read_buffer| {
+                write_buffer.reset();
+                write_buffer.slice(0..2);
                 write_buffer[0] = Opcodes::RDSR as u8;
-                let _ = self
-                    .spi
-                    .read_write_bytes(write_buffer, Some(read_buffer), 2);
+                let _ = self.spi.read_write_bytes(write_buffer, Some(read_buffer));
             });
         });
     }

--- a/chips/apollo3/src/iom.rs
+++ b/chips/apollo3/src/iom.rs
@@ -1237,7 +1237,7 @@ impl<'a> SpiMaster<'a> for Iom<'a> {
         ),
     > {
         let write_len = write_buffer.len();
-        let read_len = read_buffer.as_ref().map(|b| b.len()).unwrap_or(0);
+        let read_len = read_buffer.as_ref().map_or(0, |b| b.len());
 
         // Disable DMA as we don't support it
         self.registers.dmacfg.write(DMACFG::DMAEN::CLEAR);

--- a/chips/sam4l/src/usart.rs
+++ b/chips/sam4l/src/usart.rs
@@ -14,6 +14,7 @@ use kernel::hil::spi;
 use kernel::hil::spi::cs::ChipSelectPolar;
 use kernel::hil::uart;
 use kernel::utilities::cells::OptionalCell;
+use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::utilities::StaticRef;
@@ -702,7 +703,11 @@ impl<'a> USART<'a> {
                         // state.
                         let len = self.tx_len.get();
                         self.tx_len.set(0);
-                        client.read_write_done(txbuffer.unwrap(), rxbuf, len, Ok(()));
+                        client.read_write_done(
+                            txbuffer.unwrap().into(),
+                            rxbuf.map(|b| b.into()),
+                            Ok(len),
+                        );
                     }
                 }
             });
@@ -1086,20 +1091,25 @@ impl<'a> spi::SpiMaster<'a> for USART<'a> {
 
     fn read_write_bytes(
         &self,
-        write_buffer: &'static mut [u8],
-        read_buffer: Option<&'static mut [u8]>,
-        len: usize,
-    ) -> Result<(), (ErrorCode, &'static mut [u8], Option<&'static mut [u8]>)> {
+        write_buffer: SubSliceMut<'static, u8>,
+        read_buffer: Option<SubSliceMut<'static, u8>>,
+    ) -> Result<
+        (),
+        (
+            ErrorCode,
+            SubSliceMut<'static, u8>,
+            Option<SubSliceMut<'static, u8>>,
+        ),
+    > {
         let usart = &USARTRegManager::new(self);
 
         self.enable_tx(usart);
         self.enable_rx(usart);
 
         // Calculate the correct length for the transmission
-        let buflen = read_buffer.as_ref().map_or(write_buffer.len(), |rbuf| {
+        let count = read_buffer.as_ref().map_or(write_buffer.len(), |rbuf| {
             cmp::min(rbuf.len(), write_buffer.len())
         });
-        let count = cmp::min(buflen, len);
 
         self.tx_len.set(count);
 
@@ -1128,12 +1138,12 @@ impl<'a> spi::SpiMaster<'a> for USART<'a> {
                         self.usart_tx_state.set(USARTStateTX::DMA_Transmitting);
                         self.usart_rx_state.set(USARTStateRX::Idle);
                         dma.enable();
-                        dma.do_transfer(self.tx_dma_peripheral, write_buffer, count);
+                        dma.do_transfer(self.tx_dma_peripheral, write_buffer.take(), count);
 
                         // Start the read transaction.
                         self.usart_rx_state.set(USARTStateRX::DMA_Receiving);
                         read.enable();
-                        read.do_transfer(self.rx_dma_peripheral, rbuf, count);
+                        read.do_transfer(self.rx_dma_peripheral, rbuf.take(), count);
                     });
                 });
             });
@@ -1143,7 +1153,7 @@ impl<'a> spi::SpiMaster<'a> for USART<'a> {
                 self.usart_tx_state.set(USARTStateTX::DMA_Transmitting);
                 self.usart_rx_state.set(USARTStateRX::Idle);
                 dma.enable();
-                dma.do_transfer(self.tx_dma_peripheral, write_buffer, count);
+                dma.do_transfer(self.tx_dma_peripheral, write_buffer.take(), count);
             });
         }
 

--- a/chips/stm32f303xc/src/spi.rs
+++ b/chips/stm32f303xc/src/spi.rs
@@ -4,12 +4,14 @@
 
 use core::cell::Cell;
 use core::cmp;
+use kernel::utilities::cells::MapCell;
+use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::ErrorCode;
 
 use kernel::hil;
 use kernel::hil::spi::{self, ClockPhase, ClockPolarity, SpiMasterClient};
 use kernel::platform::chip::ClockInterface;
-use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite};
 use kernel::utilities::StaticRef;
@@ -193,10 +195,10 @@ pub struct Spi<'a> {
 
     active_slave: OptionalCell<spi::cs::ChipSelectPolar<'a, crate::gpio::Pin<'a>>>,
 
-    tx_buffer: TakeCell<'static, [u8]>,
+    tx_buffer: MapCell<SubSliceMut<'static, u8>>,
     tx_position: Cell<usize>,
 
-    rx_buffer: TakeCell<'static, [u8]>,
+    rx_buffer: MapCell<SubSliceMut<'static, u8>>,
     rx_position: Cell<usize>,
     len: Cell<usize>,
 
@@ -214,10 +216,10 @@ impl<'a> Spi<'a> {
             master_client: OptionalCell::empty(),
             active_slave: OptionalCell::empty(),
 
-            tx_buffer: TakeCell::empty(),
+            tx_buffer: MapCell::empty(),
             tx_position: Cell::new(0),
 
-            rx_buffer: TakeCell::empty(),
+            rx_buffer: MapCell::empty(),
             rx_position: Cell::new(0),
 
             len: Cell::new(0),
@@ -294,7 +296,7 @@ impl<'a> Spi<'a> {
             self.transfers.set(SPI_IDLE);
             self.master_client.map(|client| {
                 self.tx_buffer.take().map(|buf| {
-                    client.read_write_done(buf, self.rx_buffer.take(), self.len.get(), Ok(()))
+                    client.read_write_done(buf, self.rx_buffer.take(), Ok(self.len.get()))
                 })
             });
             self.transfers.set(SPI_IDLE);
@@ -346,21 +348,16 @@ impl<'a> Spi<'a> {
 
     fn read_write_bytes(
         &self,
-        write_buffer: Option<&'static mut [u8]>,
-        read_buffer: Option<&'static mut [u8]>,
-        len: usize,
+        write_buffer: SubSliceMut<'static, u8>,
+        read_buffer: Option<SubSliceMut<'static, u8>>,
     ) -> Result<
         (),
         (
             ErrorCode,
-            Option<&'static mut [u8]>,
-            Option<&'static mut [u8]>,
+            SubSliceMut<'static, u8>,
+            Option<SubSliceMut<'static, u8>>,
         ),
     > {
-        if write_buffer.is_none() && read_buffer.is_none() {
-            return Err((ErrorCode::INVAL, write_buffer, read_buffer));
-        }
-
         if self.transfers.get() == 0 {
             self.registers.cr2.modify(CR2::RXNEIE::CLEAR);
             self.active_slave.map(|p| {
@@ -369,18 +366,13 @@ impl<'a> Spi<'a> {
 
             self.transfers.set(self.transfers.get() | SPI_IN_PROGRESS);
 
-            let mut count: usize = len;
-            write_buffer
-                .as_ref()
-                .map(|buf| count = cmp::min(count, buf.len()));
+            let mut count: usize = write_buffer.len();
             read_buffer
                 .as_ref()
                 .map(|buf| count = cmp::min(count, buf.len()));
 
-            if write_buffer.is_some() {
-                self.transfers
-                    .set(self.transfers.get() | SPI_WRITE_IN_PROGRESS);
-            }
+            self.transfers
+                .set(self.transfers.get() | SPI_WRITE_IN_PROGRESS);
 
             if read_buffer.is_some() {
                 self.transfers
@@ -396,12 +388,10 @@ impl<'a> Spi<'a> {
 
             self.registers.cr2.modify(CR2::RXNEIE::SET);
 
-            write_buffer.map(|buf| {
-                self.tx_buffer.replace(buf);
-                self.len.set(count);
-                self.tx_position.set(0);
-                self.registers.cr2.modify(CR2::TXEIE::SET);
-            });
+            self.tx_buffer.replace(write_buffer);
+            self.len.set(count);
+            self.tx_position.set(0);
+            self.registers.cr2.modify(CR2::TXEIE::SET);
 
             Ok(())
         } else {
@@ -463,19 +453,25 @@ impl<'a> spi::SpiMaster<'a> for Spi<'a> {
 
     fn read_write_bytes(
         &self,
-        write_buffer: &'static mut [u8],
-        read_buffer: Option<&'static mut [u8]>,
-        len: usize,
-    ) -> Result<(), (ErrorCode, &'static mut [u8], Option<&'static mut [u8]>)> {
+        write_buffer: SubSliceMut<'static, u8>,
+        read_buffer: Option<SubSliceMut<'static, u8>>,
+    ) -> Result<
+        (),
+        (
+            ErrorCode,
+            SubSliceMut<'static, u8>,
+            Option<SubSliceMut<'static, u8>>,
+        ),
+    > {
         // If busy, don't start
         if self.is_busy() {
             return Err((ErrorCode::BUSY, write_buffer, read_buffer));
         }
 
         if let Err((err, write_buffer, read_buffer)) =
-            self.read_write_bytes(Some(write_buffer), read_buffer, len)
+            self.read_write_bytes(write_buffer, read_buffer)
         {
-            Err((err, write_buffer.unwrap(), read_buffer))
+            Err((err, write_buffer, read_buffer))
         } else {
             Ok(())
         }

--- a/chips/stm32f4xx/src/spi.rs
+++ b/chips/stm32f4xx/src/spi.rs
@@ -4,6 +4,7 @@
 
 use core::cell::Cell;
 use core::cmp;
+use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::ErrorCode;
 
 use kernel::hil;
@@ -287,29 +288,21 @@ impl<'a> Spi<'a> {
 
     fn read_write_bytes(
         &self,
-        write_buffer: Option<&'static mut [u8]>,
-        read_buffer: Option<&'static mut [u8]>,
-        len: usize,
+        write_buffer: SubSliceMut<'static, u8>,
+        read_buffer: Option<SubSliceMut<'static, u8>>,
     ) -> Result<
         (),
         (
             ErrorCode,
-            Option<&'static mut [u8]>,
-            Option<&'static mut [u8]>,
+            SubSliceMut<'static, u8>,
+            Option<SubSliceMut<'static, u8>>,
         ),
     > {
-        if write_buffer.is_none() && read_buffer.is_none() {
-            return Err((ErrorCode::INVAL, write_buffer, read_buffer));
-        }
-
         self.active_slave.map(|p| {
             p.clear();
         });
 
-        let mut count: usize = len;
-        write_buffer
-            .as_ref()
-            .map(|buf| count = cmp::min(count, buf.len()));
+        let mut count: usize = write_buffer.len();
         read_buffer
             .as_ref()
             .map(|buf| count = cmp::min(count, buf.len()));
@@ -322,19 +315,17 @@ impl<'a> Spi<'a> {
             self.transfers_in_progress
                 .set(self.transfers_in_progress.get() + 1);
             self.rx_dma.map(move |dma| {
-                dma.do_transfer(rx_buffer, count);
+                dma.do_transfer(rx_buffer);
             });
             self.enable_rx();
         });
 
-        write_buffer.map(|tx_buffer| {
-            self.transfers_in_progress
-                .set(self.transfers_in_progress.get() + 1);
-            self.tx_dma.map(move |dma| {
-                dma.do_transfer(tx_buffer, count);
-            });
-            self.enable_tx();
+        self.transfers_in_progress
+            .set(self.transfers_in_progress.get() + 1);
+        self.tx_dma.map(move |dma| {
+            dma.do_transfer(write_buffer);
         });
+        self.enable_tx();
 
         Ok(())
     }
@@ -397,22 +388,22 @@ impl<'a> spi::SpiMaster<'a> for Spi<'a> {
 
     fn read_write_bytes(
         &self,
-        write_buffer: &'static mut [u8],
-        read_buffer: Option<&'static mut [u8]>,
-        len: usize,
-    ) -> Result<(), (ErrorCode, &'static mut [u8], Option<&'static mut [u8]>)> {
+        write_buffer: SubSliceMut<'static, u8>,
+        read_buffer: Option<SubSliceMut<'static, u8>>,
+    ) -> Result<
+        (),
+        (
+            ErrorCode,
+            SubSliceMut<'static, u8>,
+            Option<SubSliceMut<'static, u8>>,
+        ),
+    > {
         // If busy, don't start
         if self.is_busy() {
             return Err((ErrorCode::BUSY, write_buffer, read_buffer));
         }
 
-        if let Err((e, write_buffer, read_buffer)) =
-            self.read_write_bytes(Some(write_buffer), read_buffer, len)
-        {
-            Err((e, write_buffer.unwrap(), read_buffer))
-        } else {
-            Ok(())
-        }
+        self.read_write_bytes(write_buffer, read_buffer)
     }
 
     /// We *only* support 1Mhz and 4MHz. If `rate` is set to any value other than
@@ -503,7 +494,7 @@ impl<'a> dma::StreamClient<'a, Dma1<'a>> for Spi<'a> {
 
             self.master_client.map(|client| {
                 tx_buffer.map(|t| {
-                    client.read_write_done(t, rx_buffer, length, Ok(()));
+                    client.read_write_done(t, rx_buffer, Ok(length));
                 });
             });
         }

--- a/chips/stm32f4xx/src/usart.rs
+++ b/chips/stm32f4xx/src/usart.rs
@@ -7,6 +7,7 @@ use kernel::deferred_call::{DeferredCall, DeferredCallClient};
 use kernel::hil;
 use kernel::platform::chip::ClockInterface;
 use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{register_bitfields, ReadWrite};
 use kernel::utilities::StaticRef;
@@ -324,6 +325,7 @@ impl<'a, DMA: dma::StreamServer<'a>> Usart<'a, DMA> {
                 // alert client
                 self.tx_client.map(|client| {
                     buffer.map(|buf| {
+                        let buf = buf.take();
                         client.transmitted_buffer(buf, len, Ok(()));
                     });
                 });
@@ -352,6 +354,7 @@ impl<'a, DMA: dma::StreamServer<'a>> Usart<'a, DMA> {
                 // alert client
                 self.rx_client.map(|client| {
                     buffer.map(|buf| {
+                        let buf = buf.take();
                         client.received_buffer(
                             buf,
                             count,
@@ -422,6 +425,7 @@ impl<'a, DMA: dma::StreamServer<'a>> Usart<'a, DMA> {
         self.tx_len.set(0);
 
         if let Some(buf) = buffer.take() {
+            let buf = buf.take();
             self.partial_tx_buffer.replace(buf);
             self.partial_tx_len.set(count);
 
@@ -449,6 +453,7 @@ impl<'a, DMA: dma::StreamServer<'a>> Usart<'a, DMA> {
         self.rx_len.set(0);
 
         if let Some(buf) = buffer.take() {
+            let buf = buf.take();
             self.partial_rx_buffer.replace(buf);
             self.partial_rx_len.set(count);
 
@@ -493,6 +498,7 @@ impl<'a, DMA: dma::StreamServer<'a>> Usart<'a, DMA> {
                 // alert client
                 self.rx_client.map(|client| {
                     buffer.map(|buf| {
+                        let buf = buf.take();
                         client.received_buffer(buf, length, Ok(()), hil::uart::Error::None);
                     });
                 });
@@ -608,7 +614,9 @@ impl<'a, DMA: dma::StreamServer<'a>> hil::uart::Transmit<'a> for Usart<'a, DMA> 
         // setup and enable dma stream
         self.tx_dma.map(move |dma| {
             self.tx_len.set(tx_len);
-            dma.do_transfer(tx_data, tx_len);
+            let mut tx_data: SubSliceMut<u8> = tx_data.into();
+            tx_data.slice(..tx_len);
+            dma.do_transfer(tx_data);
         });
 
         self.usart_tx_state.set(USARTStateTX::DMA_Transmitting);
@@ -687,7 +695,9 @@ impl<'a, DMA: dma::StreamServer<'a>> hil::uart::Receive<'a> for Usart<'a, DMA> {
         // setup and enable dma stream
         self.rx_dma.map(move |dma| {
             self.rx_len.set(rx_len);
-            dma.do_transfer(rx_buffer, rx_len);
+            let mut rx_buffer: SubSliceMut<u8> = rx_buffer.into();
+            rx_buffer.slice(..rx_len);
+            dma.do_transfer(rx_buffer);
         });
 
         self.usart_rx_state.set(USARTStateRX::DMA_Receiving);

--- a/kernel/src/hil/spi.rs
+++ b/kernel/src/hil/spi.rs
@@ -198,9 +198,18 @@ pub mod cs {
 
 /// Trait for clients of a SPI bus in master mode.
 pub trait SpiMasterClient {
-    /// Callback when a read/write operation finishes: `read_buffer` is an
-    /// `Option` because the call passes an `Option` (with `None` if it's a
-    /// write-only operation.
+    /// Callback issued when a read/write operation finishes.
+    ///
+    /// `write_buffer` and `read_buffer` always contain the buffers
+    /// passed to the [SpiMaster::read_write_bytes]
+    /// down-call, with `read_buffer` as an `Option` because the
+    /// down-call passes an `Option`. The contents of `write_buffer`
+    /// is unmodified, while `read_buffer` contains the bytes read
+    /// over SPI. Each buffer's bounds are unmodified from their state
+    /// when `read_write_bytes` is called.
+    ///
+    /// `status` signals if the operation was successful, and if so,
+    /// the length of the operation, or an appropriate `ErrorCode`.
     fn read_write_done(
         &self,
         write_buffer: SubSliceMut<'static, u8>,

--- a/kernel/src/utilities/leasable_buffer.rs
+++ b/kernel/src/utilities/leasable_buffer.rs
@@ -181,6 +181,16 @@ pub struct SubSliceMut<'a, T> {
     active_range: Range<usize>,
 }
 
+impl<'a, T> From<&'a mut [T]> for SubSliceMut<'a, T> {
+    fn from(internal: &'a mut [T]) -> Self {
+        let active_range = 0..(internal.len());
+        Self {
+            internal,
+            active_range,
+        }
+    }
+}
+
 /// An immutable leasable buffer implementation.
 ///
 /// A leasable buffer can be used to pass a section of a larger mutable buffer
@@ -191,6 +201,16 @@ pub struct SubSlice<'a, T> {
     active_range: Range<usize>,
 }
 
+impl<'a, T> From<&'a [T]> for SubSlice<'a, T> {
+    fn from(internal: &'a [T]) -> Self {
+        let active_range = 0..(internal.len());
+        Self {
+            internal,
+            active_range,
+        }
+    }
+}
+
 /// Holder for either a mutable or immutable SubSlice.
 ///
 /// In cases where code needs to support either a mutable or immutable SubSlice,
@@ -199,6 +219,18 @@ pub struct SubSlice<'a, T> {
 pub enum SubSliceMutImmut<'a, T> {
     Immutable(SubSlice<'a, T>),
     Mutable(SubSliceMut<'a, T>),
+}
+
+impl<'a, T> From<&'a [T]> for SubSliceMutImmut<'a, T> {
+    fn from(value: &'a [T]) -> Self {
+        Self::Immutable(value.into())
+    }
+}
+
+impl<'a, T> From<&'a mut [T]> for SubSliceMutImmut<'a, T> {
+    fn from(value: &'a mut [T]) -> Self {
+        Self::Mutable(value.into())
+    }
 }
 
 impl<'a, T> SubSliceMutImmut<'a, T> {
@@ -222,6 +254,20 @@ impl<'a, T> SubSliceMutImmut<'a, T> {
         match *self {
             SubSliceMutImmut::Immutable(ref mut buf) => buf.slice(range),
             SubSliceMutImmut::Mutable(ref mut buf) => buf.slice(range),
+        }
+    }
+
+    pub fn as_ptr(&self) -> *const T {
+        match *self {
+            SubSliceMutImmut::Immutable(ref buf) => buf.as_ptr(),
+            SubSliceMutImmut::Mutable(ref buf) => buf.as_ptr(),
+        }
+    }
+
+    pub fn map_mut(&mut self, f: impl Fn(&mut SubSliceMut<'a, T>)) {
+        match self {
+            SubSliceMutImmut::Immutable(_) => (),
+            SubSliceMutImmut::Mutable(subslice) => f(subslice),
         }
     }
 }
@@ -254,6 +300,10 @@ impl<'a, T> SubSliceMut<'a, T> {
         &self.internal[self.active_range.clone()]
     }
 
+    fn active_slice_mut(&mut self) -> &mut [T] {
+        &mut self.internal[self.active_range.clone()]
+    }
+
     /// Retrieve the raw buffer used to create the SubSlice. Consumes the
     /// SubSlice.
     pub fn take(self) -> &'a mut [T] {
@@ -282,6 +332,10 @@ impl<'a, T> SubSliceMut<'a, T> {
     /// Returns a pointer to the currently accessible portion of the SubSlice.
     pub fn as_ptr(&self) -> *const T {
         self.active_slice().as_ptr()
+    }
+
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self.active_slice_mut().as_mut_ptr()
     }
 
     /// Returns a slice of the currently accessible portion of the


### PR DESCRIPTION
### Pull Request Overview

This pull request migrates the SPI master HIL to use leasable buffers (SubSliceMut) rather than raw
slices, in accordance with the draft SPI TRD. As a result, this touches every module that either implements or uses the SPI master HIL, as well as a some dependencies in some cases (e.g. DMA modules).

While it is _mostly_ a mechanical transformation aided by some additional helper methods in leasable buffers, the length parameter, is notably, redundant for both the `read_write_bytes` downcall and client callback, which requires adapting some of the length computations in various implementations. In cases where the implementation is shared with other HIL implementations that have not migrated to `SubSliceMut` there is some ultimately unnecessary complexity.

### Testing Strategy

This touches many chips and thus almost every board as well as a few capsules for peripherals I don't have currently access to. The shared code is fairly straight forward, but the devil is mostly going to be in specific chip implementations.

I've tested on an NRF52-based platform with _a_ SPI peripheral, but that's it for now.

### TODO or Help Wanted

- Double checking my logic for length computations as well as for resetting and slicing the `SubSliceMut`s in capsules... kind of everywhere?
- What's the bar for testing this? One option is to block merging until everything is properly tested, though we don't necessarily have infrastructure for that. Another is to defer that to release testing.
- Should `write_buffer` also be an `Option`?

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
