### PR TITLE
LPM013m126 Screen: Support RGB color formats

### DIFF
--- a/capsules/extra/src/screen.rs
+++ b/capsules/extra/src/screen.rs
@@ -49,7 +49,7 @@ fn screen_rotation_from(screen_rotation: usize) -> Option<ScreenRotation> {
 fn screen_pixel_format_from(screen_pixel_format: usize) -> Option<ScreenPixelFormat> {
     match screen_pixel_format {
         0 => Some(ScreenPixelFormat::Mono),
-        1 => Some(ScreenPixelFormat::RGB_233),
+        1 => Some(ScreenPixelFormat::RGB_332),
         2 => Some(ScreenPixelFormat::RGB_565),
         3 => Some(ScreenPixelFormat::RGB_888),
         4 => Some(ScreenPixelFormat::ARGB_8888),

--- a/kernel/src/hil/screen.rs
+++ b/kernel/src/hil/screen.rs
@@ -98,9 +98,12 @@ impl Sub for ScreenRotation {
 pub enum ScreenPixelFormat {
     /// Pixels encoded as 1-bit, used for monochromatic displays.
     Mono,
-    /// Pixels encoded as 2-bit red channel, 3-bit green channel, 3-bit blue
+    /// Pixels encoded as 1-bit blue, 1-bit green, 1-bit red,
+    /// and 1-bit for opaque (1) vs transparent (0)
+    RGB_4BIT,
+    /// Pixels encoded as 3-bit red channel, 3-bit green channel, 2-bit blue
     /// channel.
-    RGB_233,
+    RGB_332,
     /// Pixels encoded as 5-bit red channel, 6-bit green channel, 5-bit blue
     /// channel.
     RGB_565,
@@ -117,7 +120,8 @@ impl ScreenPixelFormat {
     pub fn get_bits_per_pixel(&self) -> usize {
         match self {
             Self::Mono => 1,
-            Self::RGB_233 => 8,
+            Self::RGB_4BIT => 4,
+            Self::RGB_332 => 8,
             Self::RGB_565 => 16,
             Self::RGB_888 => 24,
             Self::ARGB_8888 => 32,


### PR DESCRIPTION
### Pull Request Overview

This pull request adds color support to SMA_Q3's LPM013m126 screen, making it work with LVGL (and presumably other userspace graphics libraries) and just generally... you know... show colors!

In the process, this also fixes a bug with the screen generally where the screen wasn't reliably updating after an update operation. It also deals with some quirky aspects of the screen's interface that don't quite match regular RGB formats, and don't natively support arbitrary frame's as required by both the screen HIL and most graphics libraries.

There is also a fix (I think!) of one of the RGB format names, from `RGB_233` to `RGB_332` (the former is odd, the latter is a standard format).

High level, the PR introduces the following changes the following (broken into a commit per change):

#### Add a `NoUpdate` command before each update

Sends a `NoUpdate` command to the screen in a separate SPI transaction before updating the screen's framebuffer.

This is a noop, but relatively cheap, that empirically seems to ensure that the screen actually updates. This seems to be the behavior in the Beaglejs port of this platform, but the screen is not super well documented and there aren't many other drivers I could find in the wild. The datasheet does not suggest this is necessary, but it seems to be.

#### LPM013M126 4-bit color format

The LPM013M126 only supports one bit per color (R-G-B) per pixel, and has two non-standard color formats for the frame buffer: a 3-bit format where pixels are packed together and thus mostly not byte-aligned; a 4-bit format where the 4th bit is ignored.

The 3-bit format saves some RAM (1-bit per pixel over 176x176 pixels, so ~3.8KB) in principal but adds significant complexity and code size to do the correct bit-shifting when copying from a client frame to the full frame-buffer.

The 4-bit format cost some extra RAM, but is reasonably simple to copy, since all pixels are either byte- or half-byte aligned, which is reasonable to compute.

This PR chooses the 4-bit format, adds a 4-bit format to the HIL _and_ uses the 4th bit as a transparency marker---a kind of one-bit version of sRGB's opacity, which happens to make it work well with imagemagick converted transparent images.

#### Support complete frame offset interface

Before this PR, the LPM013M126 only supported certain frame alignments---the columns had to be at a byte offset, and would simply return an error to the client if it wasn't. This isn't a problem on other screens because pixels are typically word-aligned anyway---and definitely byte-aligned.

To do this cleanly, this PR introduces an iterator abstraction over frame buffers that allows the user of the abstraction (all internal to the driver though) to address each individual pixel as a byte where only the bottom 4 bits are meaningful, and the abstraction takes care of bit-shifting behind the scenes.

While verbose, the abstract doesn't introduce a measurable difference in code size or memory over manual bit-shifting. Presumably because the compiler is doing it's job well, or because any differences are overwhelmed by alignment requirements elsewhere.

#### Support for RGB-332 and RGB-565 in the LPM driver

The 4-bit format is basically unused anywhere as far as I can tell. Instead, much more common are RGB-332 and RGB-565, including in LVGL. It's possible, though, to convert from these formats to the 4-bit RGB used by the LPM with some heuristic approximation (just threshold levels for each color to turn them on or off). The resulting colors aren't exactly what you'd want (there are probably better thresholds or algorithms for approximating this conversion), but it works and the results are at least general legible, if not the exact colors you'd hope for.

#### Only transfer rows relevant to the current frame

This is an obvious optimization that only transfers the portion of the frame buffer that the client may have updated (the current "frame"). It required the changes from #4173 since the entire frame buffer _must_ be retained to be able to update only certain columns of a row (when the current frame doesn't span the entire width), so we need to be able to begin a SPI transaction from a certain offset of the buffer.

Otherwise this is straightforward and results in a dramatic performance improvement since screen updates on the peripheral itself are fairly slow.

### Testing Strategy

Testing this by running an LVGL-based graphics application on the SMA_Q3 using color and incremental updates to portions of the screen. This has no impact on other hardware except a name-change to an otherwise unused variant of the color format in the screen HIL.

### TODO or Help Wanted

This raised some questions about clarifying the semantics of the screen HIL. For example, the byte ordering of multi-byte RGB formats isn't specified and, in practice, seems to be a hardware-specific non-standard one (LVGL supports flipping the bytes for transferring over SPI, which is what libtock-c's port of LVGL does by default).

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
