### PR TITLE
boards: fixed STM systick frequency

### DIFF
--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -24,6 +24,7 @@ use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
 
 use stm32f429zi::chip_specs::Stm32f429Specs;
+use stm32f429zi::clocks::hsi::HSI_FREQUENCY_MHZ;
 use stm32f429zi::gpio::{AlternateFunction, Mode, PinId, PortId};
 use stm32f429zi::interrupt_service::Stm32f429ziDefaultPeripherals;
 
@@ -663,7 +664,9 @@ unsafe fn start() -> (
         rng,
 
         scheduler,
-        systick: cortexm4::systick::SysTick::new(),
+        systick: cortexm4::systick::SysTick::new_with_calibration(
+            (HSI_FREQUENCY_MHZ * 1_000_000) as u32,
+        ),
         can,
         date_time,
     };

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -24,6 +24,7 @@ use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
 use stm32f446re::chip_specs::Stm32f446Specs;
+use stm32f446re::clocks::hsi::HSI_FREQUENCY_MHZ;
 use stm32f446re::gpio::{AlternateFunction, Mode, PinId, PortId};
 use stm32f446re::interrupt_service::Stm32f446reDefaultPeripherals;
 
@@ -507,7 +508,9 @@ unsafe fn start() -> (
         gpio,
 
         scheduler,
-        systick: cortexm4::systick::SysTick::new(),
+        systick: cortexm4::systick::SysTick::new_with_calibration(
+            (HSI_FREQUENCY_MHZ * 1_000_000) as u32,
+        ),
     };
 
     // // Optional kernel tests

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -806,7 +806,8 @@ unsafe fn start() -> (
         nonvolatile_storage,
 
         scheduler,
-        systick: cortexm4::systick::SysTick::new(),
+        // Systick uses the HSI, which runs at 8MHz
+        systick: cortexm4::systick::SysTick::new_with_calibration(8_000_000),
         watchdog: &peripherals.watchdog,
     };
 

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -25,6 +25,7 @@ use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
 use stm32f412g::chip_specs::Stm32f412Specs;
+use stm32f412g::clocks::hsi::HSI_FREQUENCY_MHZ;
 use stm32f412g::interrupt_service::Stm32f412gDefaultPeripherals;
 
 /// Support routines for debugging I/O.
@@ -766,7 +767,9 @@ unsafe fn start() -> (
         rng,
 
         scheduler,
-        systick: cortexm4::systick::SysTick::new(),
+        systick: cortexm4::systick::SysTick::new_with_calibration(
+            (HSI_FREQUENCY_MHZ * 1_000_000) as u32,
+        ),
     };
 
     // // Optional kernel tests

--- a/boards/stm32f429idiscovery/src/main.rs
+++ b/boards/stm32f429idiscovery/src/main.rs
@@ -24,6 +24,7 @@ use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
 
 use stm32f429zi::chip_specs::Stm32f429Specs;
+use stm32f429zi::clocks::hsi::HSI_FREQUENCY_MHZ;
 use stm32f429zi::gpio::{AlternateFunction, Mode, PinId, PortId};
 use stm32f429zi::interrupt_service::Stm32f429ziDefaultPeripherals;
 
@@ -591,7 +592,9 @@ unsafe fn start() -> (
         gpio,
 
         scheduler,
-        systick: cortexm4::systick::SysTick::new(),
+        systick: cortexm4::systick::SysTick::new_with_calibration(
+            (HSI_FREQUENCY_MHZ * 1_000_000) as u32,
+        ),
     };
 
     // // Optional kernel tests

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -24,6 +24,7 @@ use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
 
 use stm32f401cc::chip_specs::Stm32f401Specs;
+use stm32f401cc::clocks::hsi::HSI_FREQUENCY_MHZ;
 use stm32f401cc::interrupt_service::Stm32f401ccDefaultPeripherals;
 
 /// Support routines for debugging I/O.
@@ -448,7 +449,9 @@ unsafe fn start() -> (
         alarm,
         gpio,
         scheduler,
-        systick: cortexm4::systick::SysTick::new(),
+        systick: cortexm4::systick::SysTick::new_with_calibration(
+            (HSI_FREQUENCY_MHZ * 1_000_000) as u32,
+        ),
     };
 
     debug!("Initialization complete. Entering main loop");


### PR DESCRIPTION
Initialized the systick with the correct frequency. The default one provided by the SYST_CALIB register is fixed for the STM chips and does not reflect the actual systick frequency.

### Pull Request Overview

This pull request fixes the systick frequency of boards using STM chips. Prior to this, they used the default `cortexm4::systick::SysTick::new()`, which causes the `hertz()` function to return a value computed from the `TENMS` field of the `SYST_CALIB` register. This field is fixed at the equivalent of 18.75 MHz for STM32F429 and STM32F446, 10.5 MHz for STM32F412 and 9 MHz for STM32F303, and does not reflect the real systick running frequency. At the moment, it uses the CPU clock (High Speed Internal clock) as reference and runs at 16 MHz for all boards except the `stm32f303xc`, which runs at 8 MHz.

In these changes, `cortexm4::systick::SysTick::new_with_calibration()` was used with the correct frequency.


### Testing Strategy

This pull request was tested by flashing two applications on the `nucleo_f429zi` and `stm32f412gdiscovery` boards, each writing HIGH/LOW on a pin. This way, the process's real time slice could be measured using an oscilloscope. In the current implementation, the time slice measured differs from the one configured. With the modifications this PR adds, the two coincide.


### TODO or Help Wanted

Additional testing on `nucleo_f446re`, `stm32f3discovery`, `stm32f429idiscovery` and `weact_f401ccu6` would be nice, as I do not have access to any of these boards.


### Documentation Updated

No updates are required.

### Formatting

- [x] Ran `make prepush`.

### Authors

* Dănuț Aldea danut.aldea@oxidos.io 
* Gabriel Păvăloiu gabriel.pavaloiu@oxidos.io