### PR TITLE
ci: do not run nightly on forks

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -19,6 +19,9 @@ permissions:
 
 jobs:
   ci-build:
+    # Do not run job on forks
+    if: github.repository == 'tock/tock'
+
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -43,6 +46,9 @@ jobs:
           path: tools/ci-artifacts
 
   ci-tests:
+    # Do not run job on forks
+    if: github.repository == 'tock/tock'
+
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]

--- a/.github/workflows/tockbot-nightly.yml
+++ b/.github/workflows/tockbot-nightly.yml
@@ -22,6 +22,9 @@ jobs:
   dispatcher:
     runs-on: ubuntu-latest
 
+    # Do not run job on forks
+    if: github.repository == 'tock/tock'
+
     # This job determines which other jobs should be run:
     outputs:
       run-maint-nightly: ${{ steps.dispatch-logic.outputs.run-maint-nightly }}


### PR DESCRIPTION
### Pull Request Overview

tock-nightly-ci and Tockbot currently run nightly on every Tock fork. I have marked these actions to not run on forks of the Tock repo.

Justification: Tockbot does not do anything on forks as it is trying to label the original Tock repo. Tock nightly ci is not needed on forks and is wasting many hours of compute across all the forks every night.

### Testing Strategy

I tested the actions and confirmed that GitHub Actions skips these two actions on forks. I confirmed that the repo name syntax is correct and that nightly will still work on tock/tock repo.

### TODO or Help Wanted

N/A


### Documentation Updated

- [x ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
