### PR TITLE
treadmill-ci: do not run on forks and PRs from other repositories

### DIFF
--- a/.github/workflows/treadmill-ci.yml
+++ b/.github/workflows/treadmill-ci.yml
@@ -29,7 +29,15 @@ on:
   push:
     branches:
       - master
-  pull_request: # Run CI for PRs on any branch
+  # Pull requests from forks will not have access to the required GitHub API
+  # secrets below, even if they are using an appropriate deployment environment
+  # and the workflow runs have been approved according to this environment's
+  # rules. We don't know whether this is a bug on GitHub's end or deliberate.
+  # Either way, for now we disable this workflow to run on PRs until we have
+  # an API proxy that securely performs these GitHub API calls (adding runners
+  # and starting Treadmill jobs with those runner registration tokens), which
+  # allows this workflow to run without access to repository secrets.
+  #pull_request:
   merge_group: # Run CI for the GitHub merge queue
 
 permissions:
@@ -38,6 +46,9 @@ permissions:
 jobs:
   test-prepare:
     runs-on: ubuntu-latest
+
+    # Do not run job on forks
+    if: github.repository == 'tock/tock'
 
     # This provides access to the secrets required below:
     # - for `treadmill-ci`: after approval by certain persons or GH teams


### PR DESCRIPTION
### Pull Request Overview

This (temporarily) disables the treadmill-ci from running on pull requests and in forks of the Tock repository.

Pull requests from forks will not have access to the required GitHub API secrets for the Treadmill CI, even if they are using an appropriate GitHub deployment environment and the workflow runs have been approved according to this environment's rules.

We don't know whether this is a bug on GitHub's end or deliberate.  Either way, for now we disable this workflow to run on PRs until we have an API proxy that securely performs these GitHub API calls (adding runners and starting Treadmill jobs with those runner registration tokens), which allows this workflow to run without access to repository secrets.

For forks themselves, there is no point in running this workflow -- they won't have any Treadmill API tokens configured in their repository secrets by default.


### Testing Strategy

This pull request is tested by this PR.


### TODO or Help Wanted

N/A


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
