### PR TITLE
ProcessStandard: Make debugging data optional

### DIFF
--- a/boards/components/src/loader/sequential.rs
+++ b/boards/components/src/loader/sequential.rs
@@ -13,12 +13,13 @@ use kernel::component::Component;
 use kernel::deferred_call::DeferredCallClient;
 use kernel::platform::chip::Chip;
 use kernel::process::ProcessLoadingAsync;
+use kernel::process::ProcessStandardDebug;
 
 #[macro_export]
 macro_rules! process_loader_sequential_component_static {
-    ($C:ty, $NUMPROCS:expr $(,)?) => {{
+    ($C:ty, $D:ty, $NUMPROCS:expr $(,)?) => {{
         let loader = kernel::static_buf!(kernel::process::SequentialProcessLoaderMachine<
-            $C,
+            $C, $D
         >);
         let process_binary_array = kernel::static_buf!(
             [Option<kernel::process::ProcessBinary>; $NUMPROCS]
@@ -28,20 +29,26 @@ macro_rules! process_loader_sequential_component_static {
     };};
 }
 
-pub type ProcessLoaderSequentialComponentType<C> =
-    kernel::process::SequentialProcessLoaderMachine<'static, C>;
+pub type ProcessLoaderSequentialComponentType<C, D> =
+    kernel::process::SequentialProcessLoaderMachine<'static, C, D>;
 
-pub struct ProcessLoaderSequentialComponent<C: Chip + 'static, const NUM_PROCS: usize> {
+pub struct ProcessLoaderSequentialComponent<
+    C: Chip + 'static,
+    D: ProcessStandardDebug + 'static,
+    const NUM_PROCS: usize,
+> {
     checker: &'static kernel::process::ProcessCheckerMachine,
     processes: &'static mut [Option<&'static dyn kernel::process::Process>],
     kernel: &'static kernel::Kernel,
     chip: &'static C,
     fault_policy: &'static dyn kernel::process::ProcessFaultPolicy,
     appid_policy: &'static dyn kernel::process_checker::AppIdPolicy,
-    storage_policy: &'static dyn kernel::process::ProcessStandardStoragePermissionsPolicy<C>,
+    storage_policy: &'static dyn kernel::process::ProcessStandardStoragePermissionsPolicy<C, D>,
 }
 
-impl<C: Chip, const NUM_PROCS: usize> ProcessLoaderSequentialComponent<C, NUM_PROCS> {
+impl<C: Chip, D: ProcessStandardDebug, const NUM_PROCS: usize>
+    ProcessLoaderSequentialComponent<C, D, NUM_PROCS>
+{
     pub fn new(
         checker: &'static kernel::process::ProcessCheckerMachine,
         processes: &'static mut [Option<&'static dyn kernel::process::Process>],
@@ -49,7 +56,7 @@ impl<C: Chip, const NUM_PROCS: usize> ProcessLoaderSequentialComponent<C, NUM_PR
         chip: &'static C,
         fault_policy: &'static dyn kernel::process::ProcessFaultPolicy,
         appid_policy: &'static dyn kernel::process_checker::AppIdPolicy,
-        storage_policy: &'static dyn kernel::process::ProcessStandardStoragePermissionsPolicy<C>,
+        storage_policy: &'static dyn kernel::process::ProcessStandardStoragePermissionsPolicy<C, D>,
     ) -> Self {
         Self {
             checker,
@@ -63,13 +70,15 @@ impl<C: Chip, const NUM_PROCS: usize> ProcessLoaderSequentialComponent<C, NUM_PR
     }
 }
 
-impl<C: Chip, const NUM_PROCS: usize> Component for ProcessLoaderSequentialComponent<C, NUM_PROCS> {
+impl<C: Chip, D: ProcessStandardDebug, const NUM_PROCS: usize> Component
+    for ProcessLoaderSequentialComponent<C, D, NUM_PROCS>
+{
     type StaticInput = (
-        &'static mut MaybeUninit<kernel::process::SequentialProcessLoaderMachine<'static, C>>,
+        &'static mut MaybeUninit<kernel::process::SequentialProcessLoaderMachine<'static, C, D>>,
         &'static mut MaybeUninit<[Option<kernel::process::ProcessBinary>; NUM_PROCS]>,
     );
 
-    type Output = &'static kernel::process::SequentialProcessLoaderMachine<'static, C>;
+    type Output = &'static kernel::process::SequentialProcessLoaderMachine<'static, C, D>;
 
     fn finalize(mut self, s: Self::StaticInput) -> Self::Output {
         let proc_manage_cap =

--- a/boards/components/src/storage_permissions/individual.rs
+++ b/boards/components/src/storage_permissions/individual.rs
@@ -17,13 +17,15 @@ use core::mem::MaybeUninit;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::platform::chip::Chip;
+use kernel::process::ProcessStandardDebug;
 
 #[macro_export]
 macro_rules! storage_permissions_individual_component_static {
-    ($C:ty $(,)?) => {{
+    ($C:ty, $D:ty $(,)?) => {{
         kernel::static_buf!(
             capsules_system::storage_permissions::individual::IndividualStoragePermissions<
                 $C,
+                $D,
                 components::storage_permissions::individual::AppStoreCapability
             >
         )
@@ -33,34 +35,41 @@ macro_rules! storage_permissions_individual_component_static {
 pub struct AppStoreCapability;
 unsafe impl capabilities::ApplicationStorageCapability for AppStoreCapability {}
 
-pub type StoragePermissionsIndividualComponentType<C> =
+pub type StoragePermissionsIndividualComponentType<C, D> =
     capsules_system::storage_permissions::individual::IndividualStoragePermissions<
         C,
+        D,
         AppStoreCapability,
     >;
 
-pub struct StoragePermissionsIndividualComponent<C: Chip> {
+pub struct StoragePermissionsIndividualComponent<C: Chip, D: ProcessStandardDebug> {
     _chip: core::marker::PhantomData<C>,
+    _debug: core::marker::PhantomData<D>,
 }
 
-impl<C: Chip> StoragePermissionsIndividualComponent<C> {
+impl<C: Chip, D: ProcessStandardDebug> StoragePermissionsIndividualComponent<C, D> {
     pub fn new() -> Self {
         Self {
             _chip: core::marker::PhantomData,
+            _debug: core::marker::PhantomData,
         }
     }
 }
 
-impl<C: Chip + 'static> Component for StoragePermissionsIndividualComponent<C> {
+impl<C: Chip + 'static, D: ProcessStandardDebug + 'static> Component
+    for StoragePermissionsIndividualComponent<C, D>
+{
     type StaticInput = &'static mut MaybeUninit<
         capsules_system::storage_permissions::individual::IndividualStoragePermissions<
             C,
+            D,
             AppStoreCapability,
         >,
     >;
     type Output =
         &'static capsules_system::storage_permissions::individual::IndividualStoragePermissions<
             C,
+            D,
             AppStoreCapability,
         >;
 

--- a/boards/components/src/storage_permissions/null.rs
+++ b/boards/components/src/storage_permissions/null.rs
@@ -8,34 +8,39 @@
 use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::platform::chip::Chip;
+use kernel::process::ProcessStandardDebug;
 
 #[macro_export]
 macro_rules! storage_permissions_null_component_static {
-    ($C:ty $(,)?) => {{
-        kernel::static_buf!(capsules_system::storage_permissions::null::NullStoragePermissions<$C>)
+    ($C:ty, $D:ty $(,)?) => {{
+        kernel::static_buf!(capsules_system::storage_permissions::null::NullStoragePermissions<$C, $D>)
     };};
 }
 
-pub type StoragePermissionsNullComponentType<C> =
-    capsules_system::storage_permissions::null::NullStoragePermissions<C>;
+pub type StoragePermissionsNullComponentType<C, D> =
+    capsules_system::storage_permissions::null::NullStoragePermissions<C, D>;
 
-pub struct StoragePermissionsNullComponent<C: Chip> {
+pub struct StoragePermissionsNullComponent<C: Chip, D: ProcessStandardDebug> {
     _chip: core::marker::PhantomData<C>,
+    _debug: core::marker::PhantomData<D>,
 }
 
-impl<C: Chip> StoragePermissionsNullComponent<C> {
+impl<C: Chip, D: ProcessStandardDebug> StoragePermissionsNullComponent<C, D> {
     pub fn new() -> Self {
         Self {
             _chip: core::marker::PhantomData,
+            _debug: core::marker::PhantomData,
         }
     }
 }
 
-impl<C: Chip + 'static> Component for StoragePermissionsNullComponent<C> {
+impl<C: Chip + 'static, D: ProcessStandardDebug + 'static> Component
+    for StoragePermissionsNullComponent<C, D>
+{
     type StaticInput = &'static mut MaybeUninit<
-        capsules_system::storage_permissions::null::NullStoragePermissions<C>,
+        capsules_system::storage_permissions::null::NullStoragePermissions<C, D>,
     >;
-    type Output = &'static capsules_system::storage_permissions::null::NullStoragePermissions<C>;
+    type Output = &'static capsules_system::storage_permissions::null::NullStoragePermissions<C, D>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
         s.write(capsules_system::storage_permissions::null::NullStoragePermissions::new())

--- a/boards/components/src/storage_permissions/tbf_header.rs
+++ b/boards/components/src/storage_permissions/tbf_header.rs
@@ -8,6 +8,7 @@
 use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::platform::chip::Chip;
+use kernel::process::ProcessStandardDebug;
 
 #[macro_export]
 macro_rules! storage_permissions_tbf_header_component_static {
@@ -24,34 +25,41 @@ macro_rules! storage_permissions_tbf_header_component_static {
 pub struct AppStoreCapability;
 unsafe impl kernel::capabilities::ApplicationStorageCapability for AppStoreCapability {}
 
-pub type StoragePermissionsTbfHeaderComponentType<C> =
+pub type StoragePermissionsTbfHeaderComponentType<C, D> =
     capsules_system::storage_permissions::tbf_header::TbfHeaderStoragePermissions<
         C,
+        D,
         AppStoreCapability,
     >;
 
-pub struct StoragePermissionsTbfHeaderComponent<C: Chip> {
+pub struct StoragePermissionsTbfHeaderComponent<C: Chip, D: ProcessStandardDebug> {
     _chip: core::marker::PhantomData<C>,
+    _debug: core::marker::PhantomData<D>,
 }
 
-impl<C: Chip> StoragePermissionsTbfHeaderComponent<C> {
+impl<C: Chip, D: ProcessStandardDebug> StoragePermissionsTbfHeaderComponent<C, D> {
     pub fn new() -> Self {
         Self {
             _chip: core::marker::PhantomData,
+            _debug: core::marker::PhantomData,
         }
     }
 }
 
-impl<C: Chip + 'static> Component for StoragePermissionsTbfHeaderComponent<C> {
+impl<C: Chip + 'static, D: ProcessStandardDebug + 'static> Component
+    for StoragePermissionsTbfHeaderComponent<C, D>
+{
     type StaticInput = &'static mut MaybeUninit<
         capsules_system::storage_permissions::tbf_header::TbfHeaderStoragePermissions<
             C,
+            D,
             AppStoreCapability,
         >,
     >;
     type Output =
         &'static capsules_system::storage_permissions::tbf_header::TbfHeaderStoragePermissions<
             C,
+            D,
             AppStoreCapability,
         >;
 

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-sha256/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-sha256/src/main.rs
@@ -278,7 +278,8 @@ pub unsafe fn main() {
     let storage_permissions_policy =
         components::storage_permissions::null::StoragePermissionsNullComponent::new().finalize(
             components::storage_permissions_null_component_static!(
-                nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>
+                nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
+                kernel::process::ProcessStandardDebugFull,
             ),
         );
 
@@ -298,6 +299,7 @@ pub unsafe fn main() {
     )
     .finalize(components::process_loader_sequential_component_static!(
         nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
+        kernel::process::ProcessStandardDebugFull,
         NUM_PROCS
     ));
 

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/main.rs
@@ -313,7 +313,8 @@ pub unsafe fn main() {
     let storage_permissions_policy =
         components::storage_permissions::null::StoragePermissionsNullComponent::new().finalize(
             components::storage_permissions_null_component_static!(
-                nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>
+                nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
+                kernel::process::ProcessStandardDebugFull,
             ),
         );
 
@@ -333,6 +334,7 @@ pub unsafe fn main() {
     )
     .finalize(components::process_loader_sequential_component_static!(
         nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
+        kernel::process::ProcessStandardDebugFull,
         NUM_PROCS
     ));
 

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -716,7 +716,8 @@ unsafe fn start() -> (
         components::storage_permissions::individual::StoragePermissionsIndividualComponent::new()
             .finalize(
                 components::storage_permissions_individual_component_static!(
-                    sam4l::chip::Sam4l<Sam4lDefaultPeripherals>
+                    sam4l::chip::Sam4l<Sam4lDefaultPeripherals>,
+                    kernel::process::ProcessStandardDebugFull,
                 ),
             );
 
@@ -736,6 +737,7 @@ unsafe fn start() -> (
     )
     .finalize(components::process_loader_sequential_component_static!(
         sam4l::chip::Sam4l<Sam4lDefaultPeripherals>,
+        kernel::process::ProcessStandardDebugFull,
         NUM_PROCS
     ));
 

--- a/boards/makepython-nrf52840/src/main.rs
+++ b/boards/makepython-nrf52840/src/main.rs
@@ -659,7 +659,8 @@ pub unsafe fn start() -> (
         components::storage_permissions::individual::StoragePermissionsIndividualComponent::new()
             .finalize(
                 components::storage_permissions_individual_component_static!(
-                    nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>
+                    nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
+                    kernel::process::ProcessStandardDebugFull,
                 ),
             );
 
@@ -679,6 +680,7 @@ pub unsafe fn start() -> (
     )
     .finalize(components::process_loader_sequential_component_static!(
         nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
+        kernel::process::ProcessStandardDebugFull,
         NUM_PROCS
     ));
 

--- a/capsules/system/src/storage_permissions/individual.rs
+++ b/capsules/system/src/storage_permissions/individual.rs
@@ -10,25 +10,36 @@ use kernel::storage_permissions::StoragePermissions;
 
 /// Assign storage permissions that grant applications access to their own
 /// state.
-pub struct IndividualStoragePermissions<C: Chip, CAP: ApplicationStorageCapability> {
+pub struct IndividualStoragePermissions<
+    C: Chip,
+    D: kernel::process::ProcessStandardDebug,
+    CAP: ApplicationStorageCapability,
+> {
     cap: CAP,
     _chip: core::marker::PhantomData<C>,
+    _debug: core::marker::PhantomData<D>,
 }
 
-impl<C: Chip, CAP: ApplicationStorageCapability> IndividualStoragePermissions<C, CAP> {
+impl<C: Chip, D: kernel::process::ProcessStandardDebug, CAP: ApplicationStorageCapability>
+    IndividualStoragePermissions<C, D, CAP>
+{
     pub fn new(cap: CAP) -> Self {
         Self {
             cap,
             _chip: core::marker::PhantomData,
+            _debug: core::marker::PhantomData,
         }
     }
 }
 
-impl<C: Chip, CAP: ApplicationStorageCapability>
-    kernel::process::ProcessStandardStoragePermissionsPolicy<C>
-    for IndividualStoragePermissions<C, CAP>
+impl<C: Chip, D: kernel::process::ProcessStandardDebug, CAP: ApplicationStorageCapability>
+    kernel::process::ProcessStandardStoragePermissionsPolicy<C, D>
+    for IndividualStoragePermissions<C, D, CAP>
 {
-    fn get_permissions(&self, process: &kernel::process::ProcessStandard<C>) -> StoragePermissions {
+    fn get_permissions(
+        &self,
+        process: &kernel::process::ProcessStandard<C, D>,
+    ) -> StoragePermissions {
         // If we have a fixed ShortId then this process can have storage
         // permissions. Otherwise we get null permissions.
         match process.short_app_id() {

--- a/capsules/system/src/storage_permissions/null.rs
+++ b/capsules/system/src/storage_permissions/null.rs
@@ -6,24 +6,27 @@ use kernel::platform::chip::Chip;
 use kernel::storage_permissions::StoragePermissions;
 
 /// Always assign no storage permissions.
-pub struct NullStoragePermissions<C: Chip> {
+pub struct NullStoragePermissions<C: Chip, D: kernel::process::ProcessStandardDebug> {
     _chip: core::marker::PhantomData<C>,
+    _debug: core::marker::PhantomData<D>,
 }
 
-impl<C: Chip> NullStoragePermissions<C> {
+impl<C: Chip, D: kernel::process::ProcessStandardDebug> NullStoragePermissions<C, D> {
     pub fn new() -> Self {
         Self {
             _chip: core::marker::PhantomData,
+            _debug: core::marker::PhantomData,
         }
     }
 }
 
-impl<C: Chip> kernel::process::ProcessStandardStoragePermissionsPolicy<C>
-    for NullStoragePermissions<C>
+impl<C: Chip, D: kernel::process::ProcessStandardDebug>
+    kernel::process::ProcessStandardStoragePermissionsPolicy<C, D>
+    for NullStoragePermissions<C, D>
 {
     fn get_permissions(
         &self,
-        _process: &kernel::process::ProcessStandard<C>,
+        _process: &kernel::process::ProcessStandard<C, D>,
     ) -> StoragePermissions {
         StoragePermissions::new_null()
     }

--- a/capsules/system/src/storage_permissions/tbf_header.rs
+++ b/capsules/system/src/storage_permissions/tbf_header.rs
@@ -17,25 +17,36 @@ use kernel::storage_permissions::StoragePermissions;
 ///
 /// If the header is _not_ present, then the process will be assigned null
 /// permissions.
-pub struct TbfHeaderStoragePermissions<C: Chip, CAP: ApplicationStorageCapability> {
+pub struct TbfHeaderStoragePermissions<
+    C: Chip,
+    D: kernel::process::ProcessStandardDebug,
+    CAP: ApplicationStorageCapability,
+> {
     cap: CAP,
     _chip: core::marker::PhantomData<C>,
+    _debug: core::marker::PhantomData<D>,
 }
 
-impl<C: Chip, CAP: ApplicationStorageCapability> TbfHeaderStoragePermissions<C, CAP> {
+impl<C: Chip, D: kernel::process::ProcessStandardDebug, CAP: ApplicationStorageCapability>
+    TbfHeaderStoragePermissions<C, D, CAP>
+{
     pub fn new(cap: CAP) -> Self {
         Self {
             cap,
             _chip: core::marker::PhantomData,
+            _debug: core::marker::PhantomData,
         }
     }
 }
 
-impl<C: Chip, CAP: ApplicationStorageCapability>
-    kernel::process::ProcessStandardStoragePermissionsPolicy<C>
-    for TbfHeaderStoragePermissions<C, CAP>
+impl<C: Chip, D: kernel::process::ProcessStandardDebug, CAP: ApplicationStorageCapability>
+    kernel::process::ProcessStandardStoragePermissionsPolicy<C, D>
+    for TbfHeaderStoragePermissions<C, D, CAP>
 {
-    fn get_permissions(&self, process: &kernel::process::ProcessStandard<C>) -> StoragePermissions {
+    fn get_permissions(
+        &self,
+        process: &kernel::process::ProcessStandard<C, D>,
+    ) -> StoragePermissions {
         // If we have a fixed ShortId then this process can have storage
         // permissions. Otherwise we get null permissions.
         match process.short_app_id() {

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -32,6 +32,7 @@ pub use crate::process_loading::{ProcessLoadingAsync, ProcessLoadingAsyncClient}
 pub use crate::process_policies::{ProcessFaultPolicy, ProcessStandardStoragePermissionsPolicy};
 pub use crate::process_printer::{ProcessPrinter, ProcessPrinterContext};
 pub use crate::process_standard::ProcessStandard;
+pub use crate::process_standard::{ProcessStandardDebug, ProcessStandardDebugFull};
 
 /// Userspace process identifier.
 ///

--- a/kernel/src/process_policies.rs
+++ b/kernel/src/process_policies.rs
@@ -12,6 +12,7 @@ use crate::platform::chip::Chip;
 use crate::process;
 use crate::process::Process;
 use crate::process_standard::ProcessStandard;
+use crate::process_standard::ProcessStandardDebug;
 use crate::storage_permissions::StoragePermissions;
 
 /// Generic trait for implementing a policy on what to do when a process faults.
@@ -26,16 +27,16 @@ pub trait ProcessFaultPolicy {
 
 /// Generic trait for implementing a policy on how applications should be
 /// assigned storage permissions.
-pub trait ProcessStandardStoragePermissionsPolicy<C: Chip> {
+pub trait ProcessStandardStoragePermissionsPolicy<C: Chip, D: ProcessStandardDebug> {
     /// Return the storage permissions for the specified `process`.
-    fn get_permissions(&self, process: &ProcessStandard<C>) -> StoragePermissions;
+    fn get_permissions(&self, process: &ProcessStandard<C, D>) -> StoragePermissions;
 }
 
 // Any platforms that do not issue storage permissions can use `&()` as the
 // [`ProcessStandardStoragePermissionsPolicy`]. This will only provide null
 // permissions (that is, no permission to access persistent storage).
-impl<C: Chip> ProcessStandardStoragePermissionsPolicy<C> for () {
-    fn get_permissions(&self, _process: &ProcessStandard<C>) -> StoragePermissions {
+impl<C: Chip, D: ProcessStandardDebug> ProcessStandardStoragePermissionsPolicy<C, D> for () {
+    fn get_permissions(&self, _process: &ProcessStandard<C, D>) -> StoragePermissions {
         StoragePermissions::new_null()
     }
 }

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -40,11 +40,105 @@ use crate::utilities::cells::{MapCell, NumericCellExt, OptionalCell};
 
 use tock_tbf::types::CommandPermissions;
 
-/// State for helping with debugging apps.
+/// Interface supported by [`ProcessStandard`] for recording debug information.
+///
+/// This trait provides flexibility to users of [`ProcessStandard`] to determine
+/// how debugging information should be recorded, or if debugging information
+/// should be recorded at all.
+///
+/// Platforms that want to only maintain certain debugging information can
+/// implement only part of this trait.
+pub trait ProcessStandardDebug: Default {
+    /// Record the address in flash the process expects to start at.
+    fn set_fixed_address_flash(&self, address: u32);
+    /// Get the address in flash the process expects to start at, if it was
+    /// recorded.
+    fn get_fixed_address_flash(&self) -> Option<u32>;
+    /// Record the address in RAM the process expects to start at.
+    fn set_fixed_address_ram(&self, address: u32);
+    /// Get the address in RAM the process expects to start at, if it was
+    /// recorded.
+    fn get_fixed_address_ram(&self) -> Option<u32>;
+    /// Record the address where the process placed its heap.
+    fn set_app_heap_start_pointer(&self, ptr: *const u8);
+    /// Get the address where the process placed its heap, if it was recorded.
+    fn get_app_heap_start_pointer(&self) -> Option<*const u8>;
+    /// Record the address where the process placed its stack.
+    fn set_app_stack_start_pointer(&self, ptr: *const u8);
+    /// Get the address where the process placed its stack, if it was recorded.
+    fn get_app_stack_start_pointer(&self) -> Option<*const u8>;
+    /// Update the lowest address that the process's stack has reached.
+    fn set_app_stack_min_pointer(&self, ptr: *const u8);
+    /// Get the lowest address of the process's stack , if it was recorded.
+    fn get_app_stack_min_pointer(&self) -> Option<*const u8>;
+    /// Provide the current address of the bottom of the stack and record the
+    /// address if it is the lowest address that the process's stack has
+    /// reached.
+    fn set_new_app_stack_min_pointer(&self, ptr: *const u8);
+
+    /// Record the most recent system call the process called.
+    fn set_last_syscall(&self, syscall: Syscall);
+    /// Get the most recent system call the process called, if it was recorded.
+    fn get_last_syscall(&self) -> Option<Syscall>;
+    /// Clear any record of the most recent system call the process called.
+    fn reset_last_syscall(&self);
+
+    /// Increase the recorded count of the number of system calls the process
+    /// has called.
+    fn increment_syscall_count(&self);
+    /// Get the recorded count of the number of system calls the process has
+    /// called.
+    ///
+    /// This should return 0 if
+    /// [`ProcessStandardDebug::increment_syscall_count()`] is never called.
+    fn get_syscall_count(&self) -> usize;
+    /// Reset the recorded count of the number of system calls called by the app
+    /// to 0.
+    fn reset_syscall_count(&self);
+
+    /// Increase the recorded count of the number of upcalls that have been
+    /// dropped for the process.
+    fn increment_dropped_upcall_count(&self);
+    /// Get the recorded count of the number of upcalls that have been dropped
+    /// for the process.
+    ///
+    /// This should return 0 if
+    /// [`ProcessStandardDebug::increment_dropped_upcall_count()`] is never
+    /// called.
+    fn get_dropped_upcall_count(&self) -> usize;
+    /// Reset the recorded count of the number of upcalls that have been dropped
+    /// for the process to 0.
+    fn reset_dropped_upcall_count(&self);
+
+    /// Increase the recorded count of the number of times the process has
+    /// exceeded its timeslice.
+    fn increment_timeslice_expiration_count(&self);
+    /// Get the recorded count of the number times the process has exceeded its
+    /// timeslice.
+    ///
+    /// This should return 0 if
+    /// [`ProcessStandardDebug::increment_timeslice_expiration_count()`] is
+    /// never called.
+    fn get_timeslice_expiration_count(&self) -> usize;
+    /// Reset the recorded count of the number of the process has exceeded its
+    /// timeslice to 0.
+    fn reset_timeslice_expiration_count(&self);
+}
+
+/// A debugging implementation for [`ProcessStandard`] that records the full
+/// debugging state.
+pub struct ProcessStandardDebugFull {
+    /// Inner field for the debug state that is in a [`MapCell`] to provide
+    /// mutable access.
+    debug: MapCell<ProcessStandardDebugFullInner>,
+}
+
+/// Struct for debugging [`ProcessStandard`] processes that records the full set
+/// of debugging information.
 ///
 /// These pointers and counters are not strictly required for kernel operation,
 /// but provide helpful information when an app crashes.
-struct ProcessStandardDebug {
+struct ProcessStandardDebugFullInner {
     /// If this process was compiled for fixed addresses, save the address
     /// it must be at in flash. This is useful for debugging and saves having
     /// to re-parse the entire TBF header.
@@ -81,6 +175,156 @@ struct ProcessStandardDebug {
     timeslice_expiration_count: usize,
 }
 
+impl ProcessStandardDebug for ProcessStandardDebugFull {
+    fn set_fixed_address_flash(&self, address: u32) {
+        self.debug.map(|d| d.fixed_address_flash = Some(address));
+    }
+    fn get_fixed_address_flash(&self) -> Option<u32> {
+        self.debug.map_or(None, |d| d.fixed_address_flash)
+    }
+    fn set_fixed_address_ram(&self, address: u32) {
+        self.debug.map(|d| d.fixed_address_ram = Some(address));
+    }
+    fn get_fixed_address_ram(&self) -> Option<u32> {
+        self.debug.map_or(None, |d| d.fixed_address_ram)
+    }
+    fn set_app_heap_start_pointer(&self, ptr: *const u8) {
+        self.debug.map(|d| d.app_heap_start_pointer = Some(ptr));
+    }
+    fn get_app_heap_start_pointer(&self) -> Option<*const u8> {
+        self.debug.map_or(None, |d| d.app_heap_start_pointer)
+    }
+    fn set_app_stack_start_pointer(&self, ptr: *const u8) {
+        self.debug.map(|d| d.app_stack_start_pointer = Some(ptr));
+    }
+    fn get_app_stack_start_pointer(&self) -> Option<*const u8> {
+        self.debug.map_or(None, |d| d.app_stack_start_pointer)
+    }
+    fn set_app_stack_min_pointer(&self, ptr: *const u8) {
+        self.debug.map(|d| d.app_stack_min_pointer = Some(ptr));
+    }
+    fn get_app_stack_min_pointer(&self) -> Option<*const u8> {
+        self.debug.map_or(None, |d| d.app_stack_min_pointer)
+    }
+    fn set_new_app_stack_min_pointer(&self, ptr: *const u8) {
+        self.debug.map(|d| {
+            match d.app_stack_min_pointer {
+                None => d.app_stack_min_pointer = Some(ptr),
+                Some(asmp) => {
+                    // Update max stack depth if needed.
+                    if ptr < asmp {
+                        d.app_stack_min_pointer = Some(ptr);
+                    }
+                }
+            }
+        });
+    }
+
+    fn set_last_syscall(&self, syscall: Syscall) {
+        self.debug.map(|d| d.last_syscall = Some(syscall));
+    }
+    fn get_last_syscall(&self) -> Option<Syscall> {
+        self.debug.map_or(None, |d| d.last_syscall)
+    }
+    fn reset_last_syscall(&self) {
+        self.debug.map(|d| d.last_syscall = None);
+    }
+
+    fn increment_syscall_count(&self) {
+        self.debug.map(|d| d.syscall_count += 1);
+    }
+    fn get_syscall_count(&self) -> usize {
+        self.debug.map_or(0, |d| d.syscall_count)
+    }
+    fn reset_syscall_count(&self) {
+        self.debug.map(|d| d.syscall_count = 0);
+    }
+
+    fn increment_dropped_upcall_count(&self) {
+        self.debug.map(|d| d.dropped_upcall_count += 1);
+    }
+    fn get_dropped_upcall_count(&self) -> usize {
+        self.debug.map_or(0, |d| d.dropped_upcall_count)
+    }
+    fn reset_dropped_upcall_count(&self) {
+        self.debug.map(|d| d.dropped_upcall_count = 0);
+    }
+
+    fn increment_timeslice_expiration_count(&self) {
+        self.debug.map(|d| d.timeslice_expiration_count += 1);
+    }
+    fn get_timeslice_expiration_count(&self) -> usize {
+        self.debug.map_or(0, |d| d.timeslice_expiration_count)
+    }
+    fn reset_timeslice_expiration_count(&self) {
+        self.debug.map(|d| d.timeslice_expiration_count = 0);
+    }
+}
+
+impl Default for ProcessStandardDebugFull {
+    fn default() -> Self {
+        Self {
+            debug: MapCell::new(ProcessStandardDebugFullInner {
+                fixed_address_flash: None,
+                fixed_address_ram: None,
+                app_heap_start_pointer: None,
+                app_stack_start_pointer: None,
+                app_stack_min_pointer: None,
+                syscall_count: 0,
+                last_syscall: None,
+                dropped_upcall_count: 0,
+                timeslice_expiration_count: 0,
+            }),
+        }
+    }
+}
+
+impl ProcessStandardDebug for () {
+    fn set_fixed_address_flash(&self, _address: u32) {}
+    fn get_fixed_address_flash(&self) -> Option<u32> {
+        None
+    }
+    fn set_fixed_address_ram(&self, _address: u32) {}
+    fn get_fixed_address_ram(&self) -> Option<u32> {
+        None
+    }
+    fn set_app_heap_start_pointer(&self, _ptr: *const u8) {}
+    fn get_app_heap_start_pointer(&self) -> Option<*const u8> {
+        None
+    }
+    fn set_app_stack_start_pointer(&self, _ptr: *const u8) {}
+    fn get_app_stack_start_pointer(&self) -> Option<*const u8> {
+        None
+    }
+    fn set_app_stack_min_pointer(&self, _ptr: *const u8) {}
+    fn get_app_stack_min_pointer(&self) -> Option<*const u8> {
+        None
+    }
+    fn set_new_app_stack_min_pointer(&self, _ptr: *const u8) {}
+
+    fn set_last_syscall(&self, _syscall: Syscall) {}
+    fn get_last_syscall(&self) -> Option<Syscall> {
+        None
+    }
+    fn reset_last_syscall(&self) {}
+
+    fn increment_syscall_count(&self) {}
+    fn get_syscall_count(&self) -> usize {
+        0
+    }
+    fn reset_syscall_count(&self) {}
+    fn increment_dropped_upcall_count(&self) {}
+    fn get_dropped_upcall_count(&self) -> usize {
+        0
+    }
+    fn reset_dropped_upcall_count(&self) {}
+    fn increment_timeslice_expiration_count(&self) {}
+    fn get_timeslice_expiration_count(&self) -> usize {
+        0
+    }
+    fn reset_timeslice_expiration_count(&self) {}
+}
+
 /// Entry that is stored in the grant pointer table at the top of process
 /// memory.
 ///
@@ -103,7 +347,20 @@ struct GrantPointerEntry {
 }
 
 /// A type for userspace processes in Tock.
-pub struct ProcessStandard<'a, C: 'static + Chip> {
+///
+/// As its name implies, this is the standard implementation for Tock processes
+/// that exposes the full support for processes running on embedded hardware.
+///
+/// [`ProcessStandard`] is templated on two parameters:
+///
+/// - `C`: [`Chip`]: The implementation must know the [`Chip`] the kernel is
+///   running on to properly store architecture-specific and MPU state for the
+///   process.
+/// - `D`: [`ProcessStandardDebug`]: This configures the debugging mechanism the
+///   process uses for storing optional debugging data. Kernels that do not wish
+///   to store per-process debugging state can use the `()` type for this
+///   parameter.
+pub struct ProcessStandard<'a, C: 'static + Chip, D: 'static + ProcessStandardDebug + Default> {
     /// Identifier of this process and the index of the process in the process
     /// table.
     process_id: Cell<ProcessId>,
@@ -240,10 +497,10 @@ pub struct ProcessStandard<'a, C: 'static + Chip> {
     completion_code: OptionalCell<Option<u32>>,
 
     /// Values kept so that we can print useful debug messages when apps fault.
-    debug: MapCell<ProcessStandardDebug>,
+    debug: D,
 }
 
-impl<C: Chip> Process for ProcessStandard<'_, C> {
+impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_, C, D> {
     fn processid(&self) -> ProcessId {
         self.process_id.get()
     }
@@ -288,9 +545,7 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
         if ret.is_err() {
             // On any error we were unable to enqueue the task. Record the
             // error, but importantly do _not_ increment kernel work.
-            self.debug.map(|debug| {
-                debug.dropped_upcall_count += 1;
-            });
+            self.debug.increment_dropped_upcall_count();
         }
 
         ret
@@ -509,21 +764,16 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
 
     fn update_stack_start_pointer(&self, stack_pointer: *const u8) {
         if stack_pointer >= self.mem_start() && stack_pointer < self.mem_end() {
-            self.debug.map(|debug| {
-                debug.app_stack_start_pointer = Some(stack_pointer);
-
-                // We also reset the minimum stack pointer because whatever
-                // value we had could be entirely wrong by now.
-                debug.app_stack_min_pointer = Some(stack_pointer);
-            });
+            self.debug.set_app_stack_start_pointer(stack_pointer);
+            // We also reset the minimum stack pointer because whatever
+            // value we had could be entirely wrong by now.
+            self.debug.set_app_stack_min_pointer(stack_pointer);
         }
     }
 
     fn update_heap_start_pointer(&self, heap_pointer: *const u8) {
         if heap_pointer >= self.mem_start() && heap_pointer < self.mem_end() {
-            self.debug.map(|debug| {
-                debug.app_heap_start_pointer = Some(heap_pointer);
-            });
+            self.debug.set_app_heap_start_pointer(heap_pointer);
         }
     }
 
@@ -1113,49 +1363,35 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
         // If the UKB implementation passed us a stack pointer, update our
         // debugging state. This is completely optional.
         if let Some(sp) = stack_pointer {
-            self.debug.map(|debug| {
-                match debug.app_stack_min_pointer {
-                    None => debug.app_stack_min_pointer = Some(sp),
-                    Some(asmp) => {
-                        // Update max stack depth if needed.
-                        if sp < asmp {
-                            debug.app_stack_min_pointer = Some(sp);
-                        }
-                    }
-                }
-            });
+            self.debug.set_new_app_stack_min_pointer(sp);
         }
 
         switch_reason
     }
 
     fn debug_syscall_count(&self) -> usize {
-        self.debug.map_or(0, |debug| debug.syscall_count)
+        self.debug.get_syscall_count()
     }
 
     fn debug_dropped_upcall_count(&self) -> usize {
-        self.debug.map_or(0, |debug| debug.dropped_upcall_count)
+        self.debug.get_dropped_upcall_count()
     }
 
     fn debug_timeslice_expiration_count(&self) -> usize {
-        self.debug
-            .map_or(0, |debug| debug.timeslice_expiration_count)
+        self.debug.get_timeslice_expiration_count()
     }
 
     fn debug_timeslice_expired(&self) {
-        self.debug
-            .map(|debug| debug.timeslice_expiration_count += 1);
+        self.debug.increment_timeslice_expiration_count();
     }
 
     fn debug_syscall_called(&self, last_syscall: Syscall) {
-        self.debug.map(|debug| {
-            debug.syscall_count += 1;
-            debug.last_syscall = Some(last_syscall);
-        });
+        self.debug.increment_syscall_count();
+        self.debug.set_last_syscall(last_syscall);
     }
 
     fn debug_syscall_last(&self) -> Option<Syscall> {
-        self.debug.map_or(None, |debug| debug.last_syscall)
+        self.debug.get_last_syscall()
     }
 
     fn get_addresses(&self) -> ProcessAddresses {
@@ -1170,15 +1406,9 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
             sram_app_brk: self.app_memory_break() as usize,
             sram_grant_start: self.kernel_memory_break() as usize,
             sram_end: self.mem_end() as usize,
-            sram_heap_start: self.debug.map_or(None, |debug| {
-                debug.app_heap_start_pointer.map(|p| p as usize)
-            }),
-            sram_stack_top: self.debug.map_or(None, |debug| {
-                debug.app_stack_start_pointer.map(|p| p as usize)
-            }),
-            sram_stack_bottom: self.debug.map_or(None, |debug| {
-                debug.app_stack_min_pointer.map(|p| p as usize)
-            }),
+            sram_heap_start: self.debug.get_app_heap_start_pointer().map(|p| p as usize),
+            sram_stack_top: self.debug.get_app_stack_start_pointer().map(|p| p as usize),
+            sram_stack_bottom: self.debug.get_app_stack_min_pointer().map(|p| p as usize),
         }
     }
 
@@ -1257,31 +1487,29 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
         // generated for those addresses. If the process was already compiled
         // for a fixed address, then just generating a .lst file is fine.
 
-        self.debug.map(|debug| {
-            if debug.fixed_address_flash.is_some() {
-                // Fixed addresses, can just run `make lst`.
-                let _ = writer.write_fmt(format_args!(
-                    "\
+        if self.debug.get_fixed_address_flash().is_some() {
+            // Fixed addresses, can just run `make lst`.
+            let _ = writer.write_fmt(format_args!(
+                "\
                     \r\nTo debug libtock-c apps, run `make lst` in the app's\
                     \r\nfolder and open the arch.{:#x}.{:#x}.lst file.\r\n\r\n",
-                    debug.fixed_address_flash.unwrap_or(0),
-                    debug.fixed_address_ram.unwrap_or(0)
-                ));
-            } else {
-                // PIC, need to specify the addresses.
-                let sram_start = self.mem_start() as usize;
-                let flash_start = self.flash.as_ptr() as usize;
-                let flash_init_fn = flash_start + self.header.get_init_function_offset() as usize;
+                self.debug.get_fixed_address_flash().unwrap_or(0),
+                self.debug.get_fixed_address_ram().unwrap_or(0)
+            ));
+        } else {
+            // PIC, need to specify the addresses.
+            let sram_start = self.mem_start() as usize;
+            let flash_start = self.flash.as_ptr() as usize;
+            let flash_init_fn = flash_start + self.header.get_init_function_offset() as usize;
 
-                let _ = writer.write_fmt(format_args!(
-                    "\
+            let _ = writer.write_fmt(format_args!(
+                "\
                     \r\nTo debug libtock-c apps, run\
                     \r\n`make debug RAM_START={:#x} FLASH_INIT={:#x}`\
                     \r\nin the app's folder and open the .lst file.\r\n\r\n",
-                    sram_start, flash_init_fn
-                ));
-            }
-        });
+                sram_start, flash_init_fn
+            ));
+        }
     }
 
     fn get_stored_state(&self, out: &mut [u8]) -> Result<usize, ErrorCode> {
@@ -1295,13 +1523,13 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
     }
 }
 
-impl<C: 'static + Chip> ProcessStandard<'_, C> {
+impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C, D> {
     // Memory offset for upcall ring buffer (10 element length).
     const CALLBACK_LEN: usize = 10;
     const CALLBACKS_OFFSET: usize = mem::size_of::<Task>() * Self::CALLBACK_LEN;
 
     // Memory offset to make room for this process's metadata.
-    const PROCESS_STRUCT_OFFSET: usize = mem::size_of::<ProcessStandard<C>>();
+    const PROCESS_STRUCT_OFFSET: usize = mem::size_of::<ProcessStandard<C, D>>();
 
     /// Create a `ProcessStandard` object based on the found `ProcessBinary`.
     pub(crate) unsafe fn create<'a>(
@@ -1310,7 +1538,7 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
         pb: ProcessBinary,
         remaining_memory: &'a mut [u8],
         fault_policy: &'static dyn ProcessFaultPolicy,
-        storage_permissions_policy: &'static dyn ProcessStandardStoragePermissionsPolicy<C>,
+        storage_permissions_policy: &'static dyn ProcessStandardStoragePermissionsPolicy<C, D>,
         app_id: ShortId,
         index: usize,
     ) -> Result<(Option<&'static dyn Process>, &'a mut [u8]), (ProcessLoadError, &'a mut [u8])>
@@ -1643,8 +1871,8 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
         // Create the Process struct in the app grant region.
         // Note that this requires every field be explicitly initialized, as
         // we are just transforming a pointer into a structure.
-        let process: &mut ProcessStandard<C> =
-            &mut *(process_struct_memory_location as *mut ProcessStandard<'static, C>);
+        let process: &mut ProcessStandard<C, D> =
+            &mut *(process_struct_memory_location as *mut ProcessStandard<'static, C, D>);
 
         // Ask the kernel for a unique identifier for this process that is being
         // created.
@@ -1691,17 +1919,13 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
         ];
         process.tasks = MapCell::new(tasks);
 
-        process.debug = MapCell::new(ProcessStandardDebug {
-            fixed_address_flash,
-            fixed_address_ram,
-            app_heap_start_pointer: None,
-            app_stack_start_pointer: None,
-            app_stack_min_pointer: None,
-            syscall_count: 0,
-            last_syscall: None,
-            dropped_upcall_count: 0,
-            timeslice_expiration_count: 0,
-        });
+        process.debug = D::default();
+        if let Some(fix_addr_flash) = fixed_address_flash {
+            process.debug.set_fixed_address_flash(fix_addr_flash);
+        }
+        if let Some(fix_addr_ram) = fixed_address_ram {
+            process.debug.set_fixed_address_ram(fix_addr_ram);
+        }
 
         // Handle any architecture-specific requirements for a new process.
         //
@@ -1777,12 +2001,10 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
             .set(ProcessId::new(self.kernel, new_identifier, old_index));
 
         // Reset debug information that is per-execution and not per-process.
-        self.debug.map(|debug| {
-            debug.syscall_count = 0;
-            debug.last_syscall = None;
-            debug.dropped_upcall_count = 0;
-            debug.timeslice_expiration_count = 0;
-        });
+        self.debug.reset_last_syscall();
+        self.debug.reset_syscall_count();
+        self.debug.reset_dropped_upcall_count();
+        self.debug.reset_timeslice_expiration_count();
 
         // Reset MPU region configuration.
         //

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -142,6 +142,7 @@ pub struct ProcessStandardDebugFull {
 ///
 /// These pointers and counters are not strictly required for kernel operation,
 /// but provide helpful information when an app crashes.
+#[derive(Default)]
 struct ProcessStandardDebugFullInner {
     /// If this process was compiled for fixed addresses, save the address
     /// it must be at in flash. This is useful for debugging and saves having
@@ -268,17 +269,7 @@ impl ProcessStandardDebug for ProcessStandardDebugFull {
 impl Default for ProcessStandardDebugFull {
     fn default() -> Self {
         Self {
-            debug: MapCell::new(ProcessStandardDebugFullInner {
-                fixed_address_flash: None,
-                fixed_address_ram: None,
-                app_heap_start_pointer: None,
-                app_stack_start_pointer: None,
-                app_stack_min_pointer: None,
-                syscall_count: 0,
-                last_syscall: None,
-                dropped_upcall_count: 0,
-                timeslice_expiration_count: 0,
-            }),
+            debug: MapCell::new(ProcessStandardDebugFullInner::default()),
         }
     }
 }

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -48,6 +48,10 @@ use tock_tbf::types::CommandPermissions;
 ///
 /// Platforms that want to only maintain certain debugging information can
 /// implement only part of this trait.
+///
+/// Tock provides a default implementation of this trait on the `()` type.
+/// Kernels that wish to use [`ProcessStandard`] but do not need process-level
+/// debugging information can use `()` as the `ProcessStandardDebug` type.
 pub trait ProcessStandardDebug: Default {
     /// Record the address in flash the process expects to start at.
     fn set_fixed_address_flash(&self, address: u32);


### PR DESCRIPTION
### Pull Request Overview

Currently the `ProcessStandard` struct contains fields for debugging information. This leads to a tension: what is the right amount of debugging data to store? What if some kernels want to track more and others less? This attempts to shrink the size of the `ProcessStandard` object for kernels that may care about that.

This PR makes the debugging information for `ProcessStandard` only accessible via a trait. Different kernels can use different implementations for that trait which may or may not store debugging information.

By default we continue to use the full debugging information for any board that calls the `load_processes` functions. Boards that use the async process loader can choose via the component which debug implementation they use.


### Testing Strategy

Compiling.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

I added some more comments to process_standard.rs to give some context for what the `D` parameter is.

### Formatting

- [x] Ran `make prepush`.
