### PR TITLE
ot/earlgrey-cw310: custom build.rs that supports alternative linker script for tests

### DIFF
--- a/boards/apollo3/lora_things_plus/Makefile
+++ b/boards/apollo3/lora_things_plus/Makefile
@@ -44,10 +44,8 @@ flash-app:
 
 .PHONY: test
 test:
-	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)OBJCOPY=${OBJCOPY} PORT=$(PORT) $(CARGO) test $(NO_RUN) --bin $(PLATFORM) --release
 
 .PHONY: test-atecc508a
 test-atecc508a:
-	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)OBJCOPY=${OBJCOPY} PORT=$(PORT) $(CARGO) test $(NO_RUN) --bin $(PLATFORM) --release --features atecc508a

--- a/boards/apollo3/redboard_artemis_atp/Makefile
+++ b/boards/apollo3/redboard_artemis_atp/Makefile
@@ -44,5 +44,4 @@ flash-app:
 
 .PHONY: test
 test:
-	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)OBJCOPY=${OBJCOPY} PORT=$(PORT) $(CARGO) test $(NO_RUN) --bin $(PLATFORM) --release

--- a/boards/apollo3/redboard_artemis_nano/Makefile
+++ b/boards/apollo3/redboard_artemis_nano/Makefile
@@ -44,5 +44,4 @@ flash-app:
 
 .PHONY: test
 test:
-	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)OBJCOPY=${OBJCOPY} PORT=$(PORT) $(CARGO) test $(NO_RUN) --bin $(PLATFORM) --release

--- a/boards/build_scripts/src/lib.rs
+++ b/boards/build_scripts/src/lib.rs
@@ -2,6 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2024.
 
-mod default;
+pub mod default;
 
 pub use default::default_linker_script;

--- a/boards/esp32-c3-devkitM-1/Makefile
+++ b/boards/esp32-c3-devkitM-1/Makefile
@@ -25,5 +25,4 @@ endif
 	esptool.py --port /dev/ttyUSB0 --chip esp32c3 write_flash --flash_mode dio --flash_size detect --flash_freq 80m 0x0 binary.hex
 
 test:
-	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)$(CARGO) test $(NO_RUN) --bin $(PLATFORM) --release

--- a/boards/opentitan/earlgrey-cw310/Cargo.toml
+++ b/boards/opentitan/earlgrey-cw310/Cargo.toml
@@ -6,7 +6,7 @@
 name = "earlgrey-cw310"
 version.workspace = true
 authors.workspace = true
-build = "../../build.rs"
+build = "build.rs"
 edition.workspace = true
 
 [dependencies]

--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -108,16 +108,10 @@ test:
 ifneq ($(OPENTITAN_TREE),)
 	$(error "Running on QEMU, use test-hardware to run on hardware")
 endif
-	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
-	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
-	$(Q)TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} QEMU_ENTRY_POINT=${QEMU_ENTRY_POINT} TARGET=${TARGET} $(CARGO) test $(CARGO_FLAGS) $(NO_RUN) --bin $(PLATFORM) --release
+	$(Q)TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} QEMU_ENTRY_POINT=${QEMU_ENTRY_POINT} TARGET=${TARGET} LINKER_SCRIPT_OVERRIDE=test_layout.ld $(CARGO) test $(CARGO_FLAGS) $(NO_RUN) --bin $(PLATFORM) --release
 
 test-hardware: ot-check
-	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
-	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
-	$(Q)OBJCOPY=$(RISC_PREFIX)-objcopy TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} TARGET=${TARGET} $(CARGO) test $(CARGO_FLAGS) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests
+	$(Q)OBJCOPY=$(RISC_PREFIX)-objcopy TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} TARGET=${TARGET} LINKER_SCRIPT_OVERRIDE=test_layout.ld $(CARGO) test $(CARGO_FLAGS) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests
 
 test-verilator: ot-check
-	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
-	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
-	$(Q)VERILATOR="yes" OBJCOPY=$(RISC_PREFIX)-objcopy TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} TARGET=${TARGET} $(CARGO) test $(CARGO_FLAGS) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests,sim_verilator
+	$(Q)VERILATOR="yes" OBJCOPY=$(RISC_PREFIX)-objcopy TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} TARGET=${TARGET} LINKER_SCRIPT_OVERRIDE=test_layout.ld $(CARGO) test $(CARGO_FLAGS) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests,sim_verilator

--- a/boards/opentitan/earlgrey-cw310/build.rs
+++ b/boards/opentitan/earlgrey-cw310/build.rs
@@ -1,0 +1,29 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2024.
+
+//! This board uses a custom build script to enable selecting a different layout
+//! file for tests, which require a different layout than normal kernel builds.
+//! The script is lightly adapted from the `default_linker_script` in
+//! `tock_build_scripts`, and uses the functions provided by that crate.
+
+use std::path::Path;
+
+const LINKER_SCRIPT_OVERRIDE_ENV: &str = "LINKER_SCRIPT_OVERRIDE";
+
+fn main() {
+    let linker_script =
+        std::env::var(LINKER_SCRIPT_OVERRIDE_ENV).unwrap_or("layout.ld".to_string());
+    println!("cargo:rerun-if-env-changed={}", LINKER_SCRIPT_OVERRIDE_ENV);
+
+    if !Path::new(&linker_script).exists() {
+        panic!(
+            "Boards must provide a linker script file; path does not exist: {:?}",
+            linker_script
+        );
+    }
+    tock_build_scripts::default::rustflags_check();
+    tock_build_scripts::default::include_tock_kernel_layout();
+    tock_build_scripts::default::add_board_dir_to_linker_search_path();
+    tock_build_scripts::default::set_and_track_linker_script(linker_script);
+}

--- a/boards/opentitan/earlgrey-cw310/run.sh
+++ b/boards/opentitan/earlgrey-cw310/run.sh
@@ -6,9 +6,6 @@
 
 BUILD_DIR="verilator_build/"
 
-# Preemptively cleanup layout (incase this was a test) so that following apps (non-tests) load the correct layout.
-rm $TOCK_ROOT_DIRECTORY/target/$TARGET/release/deps/layout.ld
-
 if [[ "${VERILATOR}" == "yes" ]]; then
 		if [ -d "$BUILD_DIR" ]; then
 			# Cleanup before we build again


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the hack where OT currently relies on overwriting the linker script in the target directory, instead using a custom build.rs to allow this board to override the linker script in use based on the value of an environment variable. Rather than copy much of the existing default build.rs, I refactored it into a few standalone functions that I believe best represent its core functionality. This allowed me to reuse most of those functions in this script, to make it less likely that changes to one fail to propagate to the other.

This PR also includes some cleanup to remove some lines that I believe are no longer necessary in the current build system. These line were scattered around the "test" rule for various boards as a holdover from when those tests would directly copy files into the build directory, which is no longer done.

This PR will unblock https://github.com/tock/tock/pull/4150.

### Testing Strategy

This pull request was tested by compiling + running the tests + looking at the output of `cargo build -vv`.

### TODO or Help Wanted

N/A.

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
