### PR TITLE
Update .apps section

### DIFF
--- a/boards/build_scripts/tock_kernel_layout.ld
+++ b/boards/build_scripts/tock_kernel_layout.ld
@@ -222,43 +222,6 @@ SECTIONS
     } > ccfg
 
 
-    /* Section for application binaries in flash.
-     *
-     * This section is put into the "prog" memory, which is reserved for
-     * applications. This section is not used for the kernel, but including it
-     * in the .elf file allows for concatenating application binaries with the
-     * kernel. By default the loader will not include this section in the
-     * flashed binary. For boards that wish to use this section, it can be set
-     * to load with `objcopy` similar to:
-     *
-     *     arm-none-eabi-objcopy --set-section-flags .apps=LOAD <elf>
-     */
-    .apps (NOLOAD) :
-    {
-        /* _sapps symbol used by Tock to look for first application. */
-        . = ALIGN(4);
-        _sapps = .;
-
-        /* Include placeholder bytes in this section so that the linker
-         * includes a segment for it. Otherwise the section will be empty and
-         * the linker will ignore it when defining the segments.
-         * If less then 4 bytes, some linkers set this section to size 0
-         * and openocd fails to write it.
-         *
-         * An issue has been submitted https://github.com/raspberrypi/openocd/issues/25
-         */
-        BYTE(0xFF)
-        BYTE(0xFF)
-        BYTE(0xFF)
-        BYTE(0xFF)
-    } > prog
-    /* _eapps symbol used by tock to calculate the length of app flash */
-    _eapps = _sapps + LENGTH(prog);
-
-
-
-
-
 
 
     /* Kernel data that must be relocated. This is program data that is
@@ -299,6 +262,42 @@ SECTIONS
         . = ALIGN(4);
         _erelocate = .;
     } > ram
+
+
+
+    /* Section for application binaries in flash.
+     *
+     * This section is put into the "prog" memory, which is reserved for
+     * applications. This section is not used for the kernel, but including it
+     * in the .elf file allows for concatenating application binaries with the
+     * kernel. By default the loader will not include this section in the
+     * flashed binary. For boards that wish to use this section, it can be set
+     * to load with `objcopy` similar to:
+     *
+     *     arm-none-eabi-objcopy --set-section-flags .apps=LOAD,ALLOC <elf>
+     */
+    .apps (NOLOAD) :
+    {
+        /* _sapps symbol used by Tock to look for first application. */
+        . = ALIGN(4);
+        _sapps = .;
+
+        /* Include placeholder bytes in this section so that the linker
+         * includes a segment for it. Otherwise the section will be empty and
+         * the linker will ignore it when defining the segments.
+         * If less then 4 bytes, some linkers set this section to size 0
+         * and openocd fails to write it.
+         *
+         * An issue has been submitted https://github.com/raspberrypi/openocd/issues/25
+         */
+        BYTE(0xFF)
+        BYTE(0xFF)
+        BYTE(0xFF)
+        BYTE(0xFF)
+    } > prog
+    /* _eapps symbol used by tock to calculate the length of app flash */
+    _eapps = _sapps + LENGTH(prog);
+
 
 
     .sram (NOLOAD) :

--- a/boards/esp32-c3-devkitM-1/Makefile
+++ b/boards/esp32-c3-devkitM-1/Makefile
@@ -20,7 +20,8 @@ flash-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 ifeq ($(APP),)
 	$(error "Please specify an APP to be flashed")
 endif
-	$(RISC_PREFIX)-objcopy --set-section-flags .apps=LOAD --update-section .apps=$(APP) $^ $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf
+	$(RISC_PREFIX)-objcopy --set-section-flags .apps=LOAD,ALLOC $^ $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf
+	$(RISC_PREFIX)-objcopy --update-section .apps=$(APP) $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf
 	esptool.py --port /dev/ttyUSB0 --chip esp32c3 elf2image --use_segments --output binary.hex $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf --dont-append-digest
 	esptool.py --port /dev/ttyUSB0 --chip esp32c3 write_flash --flash_mode dio --flash_size detect --flash_freq 80m 0x0 binary.hex
 

--- a/boards/imxrt1050-evkb/Makefile
+++ b/boards/imxrt1050-evkb/Makefile
@@ -20,8 +20,10 @@ flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 .PHONY: flash-app
 flash-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	@: $(if $(value APP),,$(error Please set APP to the path of a TBF file to program applications))
-	arm-none-eabi-objcopy --set-section-flags .apps=LOAD --update-section .apps=$(APP) $< \
-		$(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-apps.elf
+	arm-none-eabi-objcopy --set-section-flags .apps=LOAD,ALLOC $< \
+	    $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-apps.elf
+	arm-none-eabi-objcopy --update-section .apps=$(APP) \
+	   $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-apps.elf
 	crt_emu_cm_redlink \
 		--flash-load-exec "$(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-apps.elf" \
 		-p MIMXRT1052xxxxB --ConnectScript RT1050_connect.scp \

--- a/boards/imxrt1050-evkb/README.md
+++ b/boards/imxrt1050-evkb/README.md
@@ -49,9 +49,11 @@ with your app(s) included.
 
 ```bash
 $ arm-none-eabi-objcopy  \
-    --set-section-flags .apps=LOAD \
-    --update-section .apps=../../../libtock-c/examples/c_hello/build/cortex-m7/cortex-m7.tbf \
+    --set-section-flags .apps=LOAD,ALLOC \
     target/thumbv7em-none-eabi/debug/imxrt1050-evkb.elf \
+    target/thumbv7em-none-eabi/debug/imxrt1050-evkb-app.axf
+arm-none-eabi-objcopy  \
+    --update-section .apps=../../../libtock-c/examples/c_hello/build/cortex-m7/cortex-m7.tbf \
     target/thumbv7em-none-eabi/debug/imxrt1050-evkb-app.axf
 ```
 
@@ -89,6 +91,3 @@ Next step, modify the LinkServer Debug, like this:
 ![image info](./pictures/config-link-server.png)
 
 Finally, press debug to run the code on the board and enjoy!
-
-
-

--- a/boards/nano_rp2040_connect/Makefile
+++ b/boards/nano_rp2040_connect/Makefile
@@ -28,8 +28,7 @@ flash-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
 ifeq ($(APP),)
 	$(error Please define the APP variable with the TBF file to flash an application)
 endif
-	arm-none-eabi-objcopy --set-section-flags .apps=LOAD --update-section .apps=$(APP) $(KERNEL) $(KERNEL_WITH_APP)
+	arm-none-eabi-objcopy --set-section-flags .apps=LOAD,ALLOC $(KERNEL) $(KERNEL_WITH_APP)
+	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL_WITH_APP)
 	elf2uf2-rs $(KERNEL_WITH_APP) $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2
 	@if [ -d $(BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2 "$(BOOTSEL_FOLDER)"; else echo; echo Please edit the BOOTSEL_FOLDER variable to point to you Nano RP2040 Flash Drive Folder; fi
-
-

--- a/boards/nucleo_f429zi/README.md
+++ b/boards/nucleo_f429zi/README.md
@@ -30,9 +30,11 @@ apps included.
 
 ```bash
 $ arm-none-eabi-objcopy  \
-    --set-section-flags .apps=LOAD \
-    --update-section .apps=../../../libtock-c/examples/c_hello/build/cortex-m4/cortex-m4.tbf \
+    --set-section-flags .apps=LOAD,ALLOC \
     target/thumbv7em-none-eabi/debug/nucleo_f429zi.elf \
+    target/thumbv7em-none-eabi/debug/nucleo_f429zi-app.elf
+$ arm-none-eabi-objcopy  \
+    --update-section .apps=../../../libtock-c/examples/c_hello/build/cortex-m4/cortex-m4.tbf \
     target/thumbv7em-none-eabi/debug/nucleo_f429zi-app.elf
 ```
 
@@ -45,7 +47,8 @@ KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/debug/$(PLATFORM)-app.el
 
 .PHONY: program
 program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf
-	arm-none-eabi-objcopy --set-section-flags .apps=LOAD --update-section .apps=$(APP) $(KERNEL) $(KERNEL_WITH_APP)
+	arm-none-eabi-objcopy --set-section-flags .apps=LOAD,ALLOC $(KERNEL) $(KERNEL_WITH_APP)
+	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL_WITH_APP)
 	$(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $(KERNEL_WITH_APP); verify_image $(KERNEL_WITH_APP); reset; shutdown"
 ```
 

--- a/boards/nucleo_f446re/README.md
+++ b/boards/nucleo_f446re/README.md
@@ -30,9 +30,11 @@ apps included.
 
 ```bash
 $ arm-none-eabi-objcopy  \
-    --set-section-flags .apps=LOAD \
-    --update-section .apps=../../../libtock-c/examples/c_hello/build/cortex-m4/cortex-m4.tbf \
+    --set-section-flags .apps=LOAD,ALLOC \
     target/thumbv7em-none-eabi/debug/nucleo_f446re.elf \
+    target/thumbv7em-none-eabi/debug/nucleo_f446re-app.elf
+$ arm-none-eabi-objcopy  \
+    --update-section .apps=../../../libtock-c/examples/c_hello/build/cortex-m4/cortex-m4.tbf \
     target/thumbv7em-none-eabi/debug/nucleo_f446re-app.elf
 ```
 
@@ -45,7 +47,8 @@ KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/debug/$(PLATFORM)-app.el
 
 .PHONY: program
 program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf
-	arm-none-eabi-objcopy --set-section-flags .apps=LOAD --update-section .apps=$(APP) $(KERNEL) $(KERNEL_WITH_APP)
+	arm-none-eabi-objcopy --set-section-flags .apps=LOAD,ALLOC $(KERNEL) $(KERNEL_WITH_APP)
+	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL_WITH_APP)
 	$(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $(KERNEL_WITH_APP); verify_image $(KERNEL_WITH_APP); reset; shutdown"
 ```
 

--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -81,7 +81,8 @@ flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
 	$(OPENTITAN_TREE)/bazel-bin/sw/host/opentitantool/opentitantool.runfiles/lowrisc_opentitan/sw/host/opentitantool/opentitantool --interface=cw310 bootstrap $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
 
 flash-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	$(RISC_PREFIX)-objcopy --set-section-flags .apps=LOAD --update-section .apps=$(APP) $^ $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf
+	$(RISC_PREFIX)-objcopy --set-section-flags .apps=LOAD,ALLOC $^ $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf
+	$(RISC_PREFIX)-objcopy --update-section .apps=$(APP) $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf
 	$(RISC_PREFIX)-objcopy --output-target=binary $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.bin
 	$(OPENTITAN_TREE)/bazel-bin/sw/host/opentitantool/opentitantool.runfiles/lowrisc_opentitan/sw/host/opentitantool/opentitantool --interface=cw310 bootstrap $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.bin
 
@@ -91,7 +92,8 @@ verilator: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	$(RISC_PREFIX)-objcopy $^ $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.elf
 ifneq ($(APP),)
 		$(info [CW-130: Verilator]: Linking App)
-		$(RISC_PREFIX)-objcopy --set-section-flags .apps=LOAD --update-section .apps=$(APP) $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.elf $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.elf
+		$(RISC_PREFIX)-objcopy --set-section-flags .apps=LOAD,ALLOC $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.elf $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.elf
+		$(RISC_PREFIX)-objcopy --update-section .apps=$(APP) $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.elf
 endif
 	$(info [CW-130: Verilator]: Starting)
 	$(RISC_PREFIX)-objcopy --output-target=binary $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.elf $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.bin

--- a/boards/pico_explorer_base/Makefile
+++ b/boards/pico_explorer_base/Makefile
@@ -34,7 +34,7 @@ program: $(KERNEL)
 ifeq ($(APP),)
 	$(error Please define the APP variable with the TBF file to flash an application)
 endif
-	arm-none-eabi-objcopy --set-section-flags .apps=LOAD --update-section .apps=$(APP) $(KERNEL) $(KERNEL_WITH_APP)
+	arm-none-eabi-objcopy --set-section-flags .apps=LOAD,ALLOC $(KERNEL) $(KERNEL_WITH_APP)
+	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL_WITH_APP)
 	elf2uf2-rs $(KERNEL_WITH_APP) $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2
 	@if [ -d $(BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2 "$(BOOTSEL_FOLDER)"; else echo; echo Please edit the BOOTSEL_FOLDER variable to point to you Raspberry Pi Pico Flash Drive Folder; echo You can download and flash $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2; fi
-

--- a/boards/raspberry_pi_pico/Makefile
+++ b/boards/raspberry_pi_pico/Makefile
@@ -34,7 +34,7 @@ program: $(KERNEL)
 ifeq ($(APP),)
 	$(error Please define the APP variable with the TBF file to flash an application)
 endif
-	arm-none-eabi-objcopy --set-section-flags .apps=LOAD --update-section .apps=$(APP) $(KERNEL) $(KERNEL_WITH_APP)
+	arm-none-eabi-objcopy --set-section-flags .apps=LOAD,ALLOC $(KERNEL) $(KERNEL_WITH_APP)
+	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL_WITH_APP)
 	elf2uf2-rs $(KERNEL_WITH_APP) $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2
 	@if [ -d $(BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2 "$(BOOTSEL_FOLDER)"; else echo; echo Please edit the BOOTSEL_FOLDER variable to point to you Raspberry Pi Pico Flash Drive Folder; echo You can download and flash $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2; fi
-

--- a/boards/teensy40/Makefile
+++ b/boards/teensy40/Makefile
@@ -22,7 +22,8 @@ program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).hex
 .PHONY: program-app
 program-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	@: $(if $(value APP),,$(error Please set APP to the path of a TBF file to program applications))
-	$(Q)arm-none-eabi-objcopy --set-section-flags .apps=LOAD --update-section .apps=$(APP) $< $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-apps.elf
+	$(Q)arm-none-eabi-objcopy --set-section-flags .apps=LOAD,ALLOC $< $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-apps.elf
+	$(Q)arm-none-eabi-objcopy --update-section .apps=$(APP) $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-apps.elf
 	$(Q)$(OBJCOPY) -O ihex $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-apps.elf $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-apps.hex
 	teensy_loader_cli --mcu=TEENSY40 -w -v $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-apps.hex
 

--- a/boards/teensy40/README.md
+++ b/boards/teensy40/README.md
@@ -42,9 +42,11 @@ with the Teensy 4 Tock kernel.
 
 ```bash
 $ arm-none-eabi-objcopy \
-    --set-section-flags .apps=LOAD \
-    --update-section .apps=../../../libtock-c/examples/blink/build/cortex-m7/cortex-m7.tbf \
+    --set-section-flags .apps=LOAD,ALLOC \
     ../../target/thumbv7em-none-eabi/release/teensy40.elf \
+    ../../target/thumbv7em-none-eabi/release/teensy40-app.elf
+$ arm-none-eabi-objcopy \
+    --update-section .apps=../../../libtock-c/examples/blink/build/cortex-m7/cortex-m7.tbf \
     ../../target/thumbv7em-none-eabi/release/teensy40-app.elf
 ```
 
@@ -73,7 +75,8 @@ KERNEL_WITH_APP_HEX=$(TOCK_ROOT_DIRECTORY)/target/teensy40/release/teensy40-app.
 
 .PHONY: program
 program: target/thumbv7em-none-eabi/release/teensy40.elf
-	arm-none-eabi-objcopy --set-section-flags .apps=LOAD --update-section .apps=$(APP) $(KERNEL) $(KERNEL_WITH_APP)
+	arm-none-eabi-objcopy --set-section-flags .apps=LOAD,ALLOC $(KERNEL) $(KERNEL_WITH_APP)
+	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL_WITH_APP)
 	arm-none-eabi-objcopy -O ihex $(KERNEL_WITH_APP) $(KERNEL_WITH_APP_HEX)
     teensy_loader_cli -w -v --mcu=TEENSY40 $(KERNEL_WITH_APP_HEX)
 ```

--- a/boards/weact_f401ccu6/Makefile
+++ b/boards/weact_f401ccu6/Makefile
@@ -19,5 +19,6 @@ flash: $(KERNEL)
 	$(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $<; verify_image $<; reset; shutdown"
 
 flash-app: $(KERNEL)
-	arm-none-eabi-objcopy --set-section-flags .apps=LOAD --update-section .apps=$(APP) $< $(KERNEL_WITH_APP)
+	arm-none-eabi-objcopy --set-section-flags .apps=LOAD,ALLOC $< $(KERNEL_WITH_APP)
+	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL_WITH_APP)
 	$(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $(KERNEL_WITH_APP); verify_image $(KERNEL_WITH_APP); reset; shutdown"

--- a/boards/weact_f401ccu6/README.md
+++ b/boards/weact_f401ccu6/README.md
@@ -34,9 +34,11 @@ ELF image with the apps included.
 
 ```bash
 $ arm-none-eabi-objcopy  \
-    --set-section-flags .apps=LOAD \
-    --update-section .apps=../../../libtock-c/examples/blink/build/cortex-m4/cortex-m4.tbf \
+    --set-section-flags .apps=LOAD,ALLOC \
     ../../target/thumbv7em-none-eabihf/release/weact-f401ccu6.elf \
+    ../../target/thumbv7em-none-eabihf/release/weact-f401ccu6-app.elf
+$ arm-none-eabi-objcopy  \
+    --update-section .apps=../../../libtock-c/examples/blink/build/cortex-m4/cortex-m4.tbf \
     ../../target/thumbv7em-none-eabihf/release/weact-f401ccu6-app.elf
 ```
 


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes a the linker script to allow the writing of applications into kernel's elf file.

While rebasing #4099, @inesmaria08 got the following error while adding apps into the kernel's elf file errors with:

```
arm-none-eabi-objcopy --set-section-flags .apps=LOAD --update-section .apps=../../../../../libtock-c/examples/tests/screen/build/cortex-m0/cortex-m0.tbf /Users/ines_maria/tock_wyliodrin/clona/tock/target/thumbv6m-none-eabi/release/pico_explorer_base.elf /Users/ines_maria/tock_wyliodrin/clona/tock//target/thumbv6m-none-eabi/release/pico_explorer_base-app.elf
arm-none-eabi-objcopy: /Users/ines_maria/tock_wyliodrin/clona/tock//target/thumbv6m-none-eabi/release/pico_explorer_base-app.elf: section `.relocate' can't be allocated in segment 2
LOAD: .ARM.exidx .storage .relocate
arm-none-eabi-objcopy: /Users/ines_maria/tock_wyliodrin/clona/tock//target/thumbv6m-none-eabi/release/pico_explorer_base-app.elf[.apps]: section has no contents
```

This seems to be a regression bug due the merge of #4169  which sets the `.apps` section to `NOLOAD`.

After further inquiry, it seems that the linker is not able to relocate the `.relocate` section. I am not an expert in liker files, and I think this should not happen as the `.relocate` section seems to be loaded in RAM.

Putting `.apps` after `.relocate` seems to fix the issue.

Furthermore, it seems that `gdb` and `probe-rs` refuse to load sections which are not tagged as `ALLOC`.

### Testing Strategy

This pull request was tested by @inesmaria08 using a Pico Explorer Base.


### TODO or Help Wanted

Feedback regarding the linker script.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
