### PR TITLE
Update Rust Nightly Oct 2024

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
     "editor.defaultFormatter": "rust-lang.rust-analyzer",
     "editor.formatOnSave": true,
     "rust-analyzer.server.extraEnv": {
-        "RUSTUP_TOOLCHAIN": "nightly-2024-07-08"
+        "RUSTUP_TOOLCHAIN": "nightly-2024-10-09"
     },
     "rust-analyzer.check.allTargets": false,
 }

--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -141,18 +141,16 @@ impl<const COMMAND_HISTORY_LEN: usize, A: 'static + Alarm<'static>> Component
         // debugging in process console.
         // SAFETY: These statics are defined by the linker script, and we are merely creating
         // pointers to them.
-        let kernel_addresses = unsafe {
-            process_console::KernelAddresses {
-                stack_start: core::ptr::addr_of!(_sstack),
-                stack_end: core::ptr::addr_of!(_estack),
-                text_start: core::ptr::addr_of!(_stext),
-                text_end: core::ptr::addr_of!(_etext),
-                read_only_data_start: core::ptr::addr_of!(_srodata),
-                relocations_start: core::ptr::addr_of!(_srelocate),
-                relocations_end: core::ptr::addr_of!(_erelocate),
-                bss_start: core::ptr::addr_of!(_szero),
-                bss_end: core::ptr::addr_of!(_ezero),
-            }
+        let kernel_addresses = process_console::KernelAddresses {
+            stack_start: core::ptr::addr_of!(_sstack),
+            stack_end: core::ptr::addr_of!(_estack),
+            text_start: core::ptr::addr_of!(_stext),
+            text_end: core::ptr::addr_of!(_etext),
+            read_only_data_start: core::ptr::addr_of!(_srodata),
+            relocations_start: core::ptr::addr_of!(_srelocate),
+            relocations_end: core::ptr::addr_of!(_erelocate),
+            bss_start: core::ptr::addr_of!(_szero),
+            bss_end: core::ptr::addr_of!(_ezero),
         };
 
         let console_alarm = static_buffer.0.write(VirtualMuxAlarm::new(self.alarm_mux));

--- a/capsules/extra/src/ambient_light.rs
+++ b/capsules/extra/src/ambient_light.rs
@@ -54,8 +54,8 @@ impl<'a> AmbientLight<'a> {
     pub fn new(
         sensor: &'a dyn hil::sensors::AmbientLight<'a>,
         grant: Grant<App, UpcallCount<{ upcall::COUNT }>, AllowRoCount<0>, AllowRwCount<0>>,
-    ) -> AmbientLight {
-        AmbientLight {
+    ) -> Self {
+        Self {
             sensor,
             command_pending: Cell::new(false),
             apps: grant,

--- a/capsules/extra/src/net/sixlowpan/sixlowpan_state.rs
+++ b/capsules/extra/src/net/sixlowpan/sixlowpan_state.rs
@@ -646,7 +646,7 @@ pub struct RxState<'a> {
 }
 
 impl<'a> ListNode<'a, RxState<'a>> for RxState<'a> {
-    fn next(&'a self) -> &'a ListLink<RxState<'a>> {
+    fn next(&'a self) -> &'a ListLink<'a, RxState<'a>> {
         &self.next
     }
 }

--- a/chips/rp2040/src/pwm.rs
+++ b/chips/rp2040/src/pwm.rs
@@ -627,7 +627,7 @@ impl<'a> Pwm<'a> {
     /// The returned structure can be used to control the PWM pin.
     ///
     /// See [PwmPin]
-    pub fn gpio_to_pwm_pin(&'a self, gpio: RPGpio) -> PwmPin {
+    pub fn gpio_to_pwm_pin(&'a self, gpio: RPGpio) -> PwmPin<'a> {
         let (channel_number, channel_pin) = self.gpio_to_pwm(gpio);
         self.new_pwm_pin(channel_number, channel_pin)
     }

--- a/chips/sam4l/src/adc.rs
+++ b/chips/sam4l/src/adc.rs
@@ -326,8 +326,8 @@ impl<'a> Adc<'a> {
     /// Create a new ADC driver.
     ///
     /// - `rx_dma_peripheral`: type used for DMA transactions
-    pub fn new(rx_dma_peripheral: dma::DMAPeripheral, pm: &'static pm::PowerManager) -> Adc {
-        Adc {
+    pub fn new(rx_dma_peripheral: dma::DMAPeripheral, pm: &'static pm::PowerManager) -> Self {
+        Self {
             // pointer to memory mapped I/O registers
             registers: BASE_ADDRESS,
 

--- a/chips/stm32f303xc/src/syscfg.rs
+++ b/chips/stm32f303xc/src/syscfg.rs
@@ -125,8 +125,8 @@ pub struct Syscfg<'a> {
 }
 
 impl<'a> Syscfg<'a> {
-    pub const fn new(rcc: &'a rcc::Rcc) -> Syscfg {
-        Syscfg {
+    pub const fn new(rcc: &'a rcc::Rcc) -> Self {
+        Self {
             registers: SYSCFG_BASE,
             clock: SyscfgClock(rcc::PeripheralClock::new(
                 rcc::PeripheralClockType::APB2(rcc::PCLK2::SYSCFG),

--- a/chips/stm32f4xx/src/adc.rs
+++ b/chips/stm32f4xx/src/adc.rs
@@ -314,8 +314,8 @@ pub struct Adc<'a> {
 }
 
 impl<'a> Adc<'a> {
-    pub const fn new(clocks: &'a dyn Stm32f4Clocks) -> Adc {
-        Adc {
+    pub const fn new(clocks: &'a dyn Stm32f4Clocks) -> Self {
+        Self {
             registers: ADC1_BASE,
             common_registers: ADC_COMMON_BASE,
             clock: AdcClock(phclk::PeripheralClock::new(

--- a/chips/stm32f4xx/src/dma.rs
+++ b/chips/stm32f4xx/src/dma.rs
@@ -1543,8 +1543,8 @@ pub struct Dma1<'a> {
 }
 
 impl<'a> Dma1<'a> {
-    pub const fn new(clocks: &'a dyn Stm32f4Clocks) -> Dma1 {
-        Dma1 {
+    pub const fn new(clocks: &'a dyn Stm32f4Clocks) -> Self {
+        Self {
             registers: DMA1_BASE,
             clock: DmaClock(phclk::PeripheralClock::new(
                 phclk::PeripheralClockType::AHB1(phclk::HCLK1::DMA1),
@@ -1664,8 +1664,8 @@ pub struct Dma2<'a> {
 }
 
 impl<'a> Dma2<'a> {
-    pub const fn new(clocks: &'a dyn Stm32f4Clocks) -> Dma2 {
-        Dma2 {
+    pub const fn new(clocks: &'a dyn Stm32f4Clocks) -> Self {
+        Self {
             registers: DMA2_BASE,
             clock: DmaClock(phclk::PeripheralClock::new(
                 phclk::PeripheralClockType::AHB1(phclk::HCLK1::DMA2),

--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -72,7 +72,7 @@ of installing some of these tools, but you can also install them yourself.
 
 #### Rust (nightly)
 
-We are using `nightly-2024-07-08`. We require
+We are using `nightly-2024-10-09`. We require
 installing it with [rustup](http://www.rustup.rs) so you can manage multiple
 versions of Rust and continue using stable versions for other Rust code:
 
@@ -87,7 +87,7 @@ to your `$PATH`.
 Then install the correct nightly version of Rust:
 
 ```bash
-$ rustup install nightly-2024-07-08
+$ rustup install nightly-2024-10-09
 ```
 
 ### Compiling the Kernel

--- a/kernel/src/scheduler/cooperative.rs
+++ b/kernel/src/scheduler/cooperative.rs
@@ -37,7 +37,7 @@ impl<'a> CoopProcessNode<'a> {
 }
 
 impl<'a> ListNode<'a, CoopProcessNode<'a>> for CoopProcessNode<'a> {
-    fn next(&'a self) -> &'a ListLink<'a, CoopProcessNode> {
+    fn next(&'a self) -> &'a ListLink<'a, CoopProcessNode<'a>> {
         &self.next
     }
 }

--- a/kernel/src/scheduler/round_robin.rs
+++ b/kernel/src/scheduler/round_robin.rs
@@ -43,7 +43,7 @@ impl<'a> RoundRobinProcessNode<'a> {
 }
 
 impl<'a> ListNode<'a, RoundRobinProcessNode<'a>> for RoundRobinProcessNode<'a> {
-    fn next(&'a self) -> &'a ListLink<'a, RoundRobinProcessNode> {
+    fn next(&'a self) -> &'a ListLink<'a, RoundRobinProcessNode<'a>> {
         &self.next
     }
 }

--- a/kernel/src/utilities/binary_write.rs
+++ b/kernel/src/utilities/binary_write.rs
@@ -65,8 +65,8 @@ pub struct WriteToBinaryOffsetWrapper<'a> {
 }
 
 impl<'a> WriteToBinaryOffsetWrapper<'a> {
-    pub fn new(binary_writer: &'a mut dyn BinaryWrite) -> WriteToBinaryOffsetWrapper {
-        WriteToBinaryOffsetWrapper {
+    pub fn new(binary_writer: &'a mut dyn BinaryWrite) -> Self {
+        Self {
             binary_writer,
             index: 0,
             offset: 0,
@@ -153,8 +153,8 @@ pub(crate) struct BinaryToWriteWrapper<'a> {
 }
 
 impl<'a> BinaryToWriteWrapper<'a> {
-    pub(crate) fn new(writer: &'a mut dyn core::fmt::Write) -> BinaryToWriteWrapper {
-        BinaryToWriteWrapper { writer }
+    pub(crate) fn new(writer: &'a mut dyn core::fmt::Write) -> Self {
+        Self { writer }
     }
 }
 

--- a/libraries/riscv-csr/src/lib.rs
+++ b/libraries/riscv-csr/src/lib.rs
@@ -6,7 +6,6 @@
 //!
 //! Uses the Tock Register Interface to control RISC-V CSRs.
 
-#![feature(asm_const)]
 #![no_std]
 
 pub mod csr;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,6 +3,6 @@
 # Copyright Tock Contributors 2023.
 
 [toolchain]
-channel = "nightly-2024-07-08"
+channel = "nightly-2024-10-09"
 components = ["miri", "llvm-tools", "rust-src", "rustfmt", "clippy", "rust-analyzer"]
 targets = ["thumbv6m-none-eabi", "thumbv7em-none-eabi", "thumbv7em-none-eabihf", "riscv32imc-unknown-none-elf", "riscv32imac-unknown-none-elf"]

--- a/tools/netlify-build.sh
+++ b/tools/netlify-build.sh
@@ -17,7 +17,7 @@ set -u
 set -x
 
 # Install rust stuff that we need
-curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2024-07-08
+curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2024-10-09
 
 # And fixup path for the newly installed rust stuff
 export PATH="$PATH:$HOME/.cargo/bin"


### PR DESCRIPTION
### Pull Request Overview

Update to a new nightly.

The changes to use `Self` are to fix warnings like these:

```
warning: elided lifetime has a name
  --> capsules/extra/src/ambient_light.rs:57:10
   |
53 | impl<'a> AmbientLight<'a> {
   |      -- lifetime `'a` declared here
...
57 |     ) -> AmbientLight {
   |          ^^^^^^^^^^^^ this elided lifetime gets resolved as `'a`
```

### Testing Strategy

travis


### TODO or Help Wanted

This adds a bunch of warnings like:

```
warning: `raspberry_pi_pico` (bin "raspberry_pi_pico") generated 1 warning
warning: creating a shared reference to mutable static is discouraged
   --> chips/sam4l/src/dma.rs:223:17
    |
223 |                 NUM_ENABLED.fetch_add(1, atomic::Ordering::Relaxed);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ shared reference to mutable static
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
    = note: `#[warn(static_mut_refs)]` on by default
```

so...we need to do something about that.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

Ran the update script.

### Formatting

- [x] Ran `make prepush`.
