### PR TITLE
kernel: debug: remove `Debug` trait

### DIFF
--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -714,10 +714,6 @@ macro_rules! debug_expr {
     };
 }
 
-pub trait Debug {
-    fn write(&self, buf: &'static mut [u8], len: usize) -> usize;
-}
-
 pub unsafe fn flush<W: Write + IoWrite>(writer: &mut W) {
     if let Some(debug_writer) = try_get_debug_writer() {
         if let Some(ring_buffer) = debug_writer.extract() {


### PR DESCRIPTION
### Pull Request Overview

I don't know why this is here as it is not used anywhere.






### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
