### PR TITLE
treadmill-ci: pin CLI client revision, switch to ARM64 Raspberry Pi hosts

### DIFF
--- a/.github/workflows/treadmill-ci.yml
+++ b/.github/workflows/treadmill-ci.yml
@@ -111,10 +111,19 @@ jobs:
           # Currently, all tests run only on hosts attached to an nRF52840DK
           DUT_BOARD: nrf52840dk
 
-          # A Ubuntu 22.04 image with a GitHub Actions self-hosted runner pre-configured.
+          # A Raspberry Pi OS netboot (NBD) image with a GitHub Actions
+          # self-hosted runner pre-configured.
           #
-          # For the available images see https://book.treadmill.ci/treadmillci-deployment/images.html
-          IMAGE_ID: 0373bb7d728b36cb6083cfe12f27038b71972ceb90563b0037d4012df7b62bf4
+          # For the available images see
+          # https://book.treadmill.ci/treadmillci-deployment/images.html
+          IMAGE_ID: 5f4b61324c27472b5354cd11229a0936320148cd6e852fbf05e1b7ff5b4598e6
+
+          # Limit the supervisors to hosts that are compatible with this
+          # image. This is a hack until we introduce "image sets" which define
+          # multiple images for various supervisor hosts, but otherwise behave
+          # identically:
+          HOST_TYPE: nbd-netboot
+          HOST_ARCH: arm64
         run: |
           # When we eventually launch tests on multiple hardware platforms in
           # parallel, we need to supply different SUB_TEST_IDs here:
@@ -146,14 +155,14 @@ jobs:
             }, \
             \"gh-actions-runner-exec-stop-post-sh\": {\
               \"secret\": false, \
-              \"value\": \"if [ \\\"\$SERVICE_RESULT\\\" = \\\"success\\\" ]; then systemctl poweroff; fi\" \
+              \"value\": \"if [ \\\"\$SERVICE_RESULT\\\" = \\\"success\\\" ]; then tml-puppet job terminate; fi\" \
             }\
           }"
 
           echo "Enqueueing treadmill job:"
           TML_JOB_ID_JSON="$(tml job enqueue \
             "$IMAGE_ID" \
-            --tag-config "board:$DUT_BOARD" \
+            --tag-config "board:$DUT_BOARD;host-type:$HOST_TYPE;host-arch:$HOST_ARCH" \
             --parameters "$TML_JOB_PARAMETERS" \
           )"
 

--- a/.github/workflows/treadmill-ci.yml
+++ b/.github/workflows/treadmill-ci.yml
@@ -69,6 +69,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: treadmill-tb/treadmill
+          # treadmill-tb/treadmill main as of Oct 1, 2024, 3:05 PM EDT
+          ref: 'c82f4d7ebddd17f8275ba52139e64e04623f30cb'
           path: treadmill
 
       - name: Cache Treadmill CLI compilation artifacts


### PR DESCRIPTION
### Pull Request Overview

Treadmill now has a supervisor that launches jobs on physical Raspberry Pi boards with ephemeral network-boot images, in addition to the existing supervisor that launches jobs on ephemeral QEMU VMs. Naturally, these hosts require different operating system images and the previous image is only compatible with AMD64 QEMU VM supervisors. Furthermore, a supervisor cannot reliably detect that netboot target has issued an operating system shutdown; thus we introduce an explicit "job terminate" request that is issued when the CI job has finished.

While we will be introducing a way to dynamically select an OS image depending on the Treadmill host that was assigned to a given job, this is not yet possible. Thus we change this workflow definition to select both a specific host architecture (in this case, `arm64`), and a specific host type that dictates how the image is layed out (here, `nbd-netboot`).

This will thus run all tests on "NBD netboot" supervisors connected to Raspberry Pi 5s which have an nRF52840DK attached, of which we currently have four such devices connected to the system.

We are also pinning the Treadmill CLI source revision, to ensure that upstream CLI interface changes don't break this workflow.

**Note that, without this PR merged, other Treadmill jobs may fail / timeout right now. The previous workflow only filtered on the "nRF52840DK" board being attached, so it will be randomly assigned either an AMD64 VM or a Raspberry Pi 5 host. It will then try to launch an AMD64 image on the latter, which the supervisor will reject.**

### Testing Strategy

This PR is tested by this PR.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`, or~ no updates are required.

### Formatting

- [ ] Ran `make prepush`.
