### PR TITLE
Alarm Syscall: fix computed `dt` when both unshifted `reference` and `dt` from userspace have low-order bits.

### DIFF
--- a/capsules/core/src/alarm.rs
+++ b/capsules/core/src/alarm.rs
@@ -171,7 +171,10 @@ impl<'a, A: Alarm<'a>> AlarmDriver<'a, A> {
                         ALARM_CALLBACK_NUM,
                         (
                             now.into_u32_left_justified() as usize,
-                            expired.reference.wrapping_add(expired.dt).into_usize(),
+                            expired
+                                .reference
+                                .wrapping_add(expired.dt)
+                                .into_u32_left_justified() as usize,
                             0,
                         ),
                     )


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes two issues in the alarm syscall driver, both necessary to correctly handle alarms that overflow in userspace. Each issue separated into its own commit:

1. The second argument to the alarm upcall is the time the alarm was scheduled to expire. This PR fixes it to be left-justified and thus expressed in the same units as all other counter values exposed to userspace.
2. Computing `dt` for a userspace alarm when userspace values are left-shifted to be u32 (e.g. on the 24-bit nRF52 RTC implementation) underestimated `dt` in some cases where both `reference` and `dt` had low-order bits that were rounded off. It is necessary to compute `dt` _considering_ the `reference` value when it is provided, so this PR computes `dt` from the computed expiration in the shifted domain.

### Testing Strategy

The second commit adds test cases for 24-bit alarms with provided reference counters. Running `cargo test` without the changes in the second commit fail, and succeed with the changes. The first commit is tested via changes to libtock-c in a different PR to that repo.

### TODO or Help Wanted

It would be good to be able to test upcall values in unit tests, but I decided to avoid figuring out how to do that for this PR since the relevant change is pretty trivially correct, and was unnoticed simply because that value was never used.

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
