### PR TITLE
ci: update github action versions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -24,7 +24,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: ci-job-syntax
         run: make ci-job-syntax
@@ -67,7 +67,7 @@ jobs:
         run: |
           brew install zeromq
         if: matrix.os == 'macos-latest'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: ci-job-libraries
         run: make ci-job-libraries
       - name: ci-job-archs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
       - name:      ci-job-format
         run:  make ci-job-format
@@ -50,7 +50,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name:      ci-job-clippy
         run:  make ci-job-clippy
 
@@ -61,7 +61,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name:      ci-job-syntax
         run:  make ci-job-syntax
       - name:      ci-job-compilation
@@ -91,7 +91,7 @@ jobs:
         run: |
           sudo apt install libudev-dev libzmq3-dev
         if: matrix.os == 'ubuntu-latest'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name:      ci-job-libraries
         run:  make ci-job-libraries
       - name:      ci-job-archs
@@ -121,6 +121,6 @@ jobs:
         continue-on-error: true
         run: |
           sudo apt install meson
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name:      ci-job-qemu
         run:  make ci-job-qemu

--- a/.github/workflows/litex_sim.yml
+++ b/.github/workflows/litex_sim.yml
@@ -39,7 +39,7 @@ jobs:
       # that other steps (such as the Rust toolchain) depend on files
       # in this repo.
       - name: Checkout the current repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Install basic packages required for the GitHub actions workflow
       - name: Update packages and install dependencies
@@ -62,7 +62,7 @@ jobs:
       # Clone tock-litex support repository under ./tock-litex, check out the
       # targeted release.
       - name: Checkout the tock-litex repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: lschuermann/tock-litex
           # The pinned revision is different from the targeted release as
@@ -97,7 +97,7 @@ jobs:
       # Revision to checkout defined in the main tock repository in
       # .libtock_c_ci_rev
       - name: Checkout libtock-c CI revision
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: tock/libtock-c
           # Pins a libtock-c revision for LiteX CI tests. In case of

--- a/.github/workflows/mergequeue_docs.yml
+++ b/.github/workflows/mergequeue_docs.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - # This also sets up the rustup environment
         name: ci-netlify-build
         run: tools/netlify-build.sh


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the ci actions "checkout" and "upload-artifact" from v3 to v4, which uses newer non-deprecated Node versions.

### Testing Strategy

This PR is the test?

### TODO or Help Wanted

N/A

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
