### PR TITLE
boards/pico_explorer_base/src/main.rs: remove unused imports to fix clippy checks

### DIFF
--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -35,7 +35,7 @@ use rp2040::clocks::{
     SystemAuxiliaryClockSource, SystemClockSource, UsbAuxiliaryClockSource,
 };
 use rp2040::gpio::{GpioFunction, RPGpio, RPGpioPin};
-use rp2040::pio::{PIONumber, Pio, SMNumber, StateMachineConfiguration};
+use rp2040::pio::Pio;
 use rp2040::pio_pwm::PioPwm;
 use rp2040::resets::Peripheral;
 use rp2040::spi::Spi;


### PR DESCRIPTION
### Pull Request Overview

Merging #4179 broke the Clippy CI due to unused imports. We did not wait for that workflow in our merge-queue checks, which I also fixed in the repository settings (alongside a bunch of other missing workflows).


### Testing Strategy

This pull request was tested by this pull request.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`, or~ no updates are required.

### Formatting

- [x] Ran `make prepush`.
