### PR TITLE
tools/license-checker: update syntect rev to accelerate tests

### DIFF
--- a/tools/license-checker/Cargo.toml
+++ b/tools/license-checker/Cargo.toml
@@ -18,4 +18,9 @@ thiserror = "1.0.44"
 [dependencies.syntect]
 default-features = false
 features = ["default-syntaxes", "regex-onig", "yaml-load"]
-version = "5.2.0"
+# version = "5.2.0"
+
+# v5.2.0-23-g31bce65, including a patch to accelerate compressed
+# bincode dumps in debug builds
+git = "https://github.com/trishume/syntect.git"
+rev = "31bce65e2989d594f226af7e7868a96f9d38bef8"


### PR DESCRIPTION
### Pull Request Overview

By integrating a `BufWriter` as part of syntect's serialization & compression routine (https://github.com/trishume/syntect/pull/554), updating to this git revision speeds up debug builds & tests by about 30x, and should shave minutes off of the CI test workflow.

### Testing Strategy

This pull request was tested by this PR.


### TODO or Help Wanted

This pull request still needs a reminder to switch back to a regular cargo release once one exists that includes this patch.

Alternatively, we can just tolerate the long CI runs for now and keep this PR around until a new release exists.

### Documentation Updated

- [x] ~Updated the relevant files in `/docs`, or~ no updates are required.

### Formatting

- [x] Ran `make prepush`.
