### PR TITLE
Small updates for better performance in screen driver

### DIFF
--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -27,6 +27,7 @@ use kernel::{create_capability, debug, static_init};
 use stm32f412g::chip_specs::Stm32f412Specs;
 use stm32f412g::clocks::hsi::HSI_FREQUENCY_MHZ;
 use stm32f412g::interrupt_service::Stm32f412gDefaultPeripherals;
+use stm32f412g::rcc::PllSource;
 
 /// Support routines for debugging I/O.
 pub mod io;
@@ -179,6 +180,7 @@ unsafe fn set_pin_primary_functions(
     syscfg: &stm32f412g::syscfg::Syscfg,
     i2c1: &stm32f412g::i2c::I2C,
     gpio_ports: &'static stm32f412g::gpio::GpioPorts<'static>,
+    system_frequency: usize,
 ) {
     use kernel::hil::gpio::Configure;
     use stm32f412g::gpio::{AlternateFunction, Mode, PinId, PortId};
@@ -269,7 +271,7 @@ unsafe fn set_pin_primary_functions(
     });
 
     i2c1.enable_clock();
-    i2c1.set_speed(stm32f412g::i2c::I2CSpeed::Speed100k, 16);
+    i2c1.set_speed(stm32f412g::i2c::I2CSpeed::Speed400k, system_frequency);
 
     // FT6206 interrupt
     gpio_ports.get_pin(PinId::PG05).map(|pin| {
@@ -414,6 +416,14 @@ unsafe fn start() -> (
     );
 
     peripherals.init();
+
+    let _ = clocks.set_ahb_prescaler(stm32f412g::rcc::AHBPrescaler::DivideBy1);
+    let _ = clocks.set_apb1_prescaler(stm32f412g::rcc::APBPrescaler::DivideBy4);
+    let _ = clocks.set_apb2_prescaler(stm32f412g::rcc::APBPrescaler::DivideBy2);
+    let _ = clocks.set_pll_frequency_mhz(PllSource::HSI, 100);
+    let _ = clocks.pll.enable();
+    let _ = clocks.set_sys_clock_source(stm32f412g::rcc::SysClockSource::PLL);
+
     let base_peripherals = &peripherals.stm32f4;
     setup_peripherals(
         &base_peripherals.tim2,
@@ -421,8 +431,12 @@ unsafe fn start() -> (
         &peripherals.trng,
     );
 
-    // We use the default HSI 16Mhz clock
-    set_pin_primary_functions(syscfg, &base_peripherals.i2c1, &base_peripherals.gpio_ports);
+    set_pin_primary_functions(
+        syscfg,
+        &base_peripherals.i2c1,
+        &base_peripherals.gpio_ports,
+        clocks.get_apb1_frequency_mhz(),
+    );
 
     setup_dma(
         dma1,
@@ -653,7 +667,7 @@ unsafe fn start() -> (
         tft,
         Some(tft),
     )
-    .finalize(components::screen_component_static!(57600));
+    .finalize(components::screen_component_static!(1024));
 
     let touch = components::touch::MultiTouchComponent::new(
         board_kernel,

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -180,7 +180,7 @@ unsafe fn set_pin_primary_functions(
     syscfg: &stm32f412g::syscfg::Syscfg,
     i2c1: &stm32f412g::i2c::I2C,
     gpio_ports: &'static stm32f412g::gpio::GpioPorts<'static>,
-    system_frequency: usize,
+    peripheral_clock_frequency: usize,
 ) {
     use kernel::hil::gpio::Configure;
     use stm32f412g::gpio::{AlternateFunction, Mode, PinId, PortId};
@@ -271,7 +271,10 @@ unsafe fn set_pin_primary_functions(
     });
 
     i2c1.enable_clock();
-    i2c1.set_speed(stm32f412g::i2c::I2CSpeed::Speed400k, system_frequency);
+    i2c1.set_speed(
+        stm32f412g::i2c::I2CSpeed::Speed400k,
+        peripheral_clock_frequency,
+    );
 
     // FT6206 interrupt
     gpio_ports.get_pin(PinId::PG05).map(|pin| {

--- a/capsules/extra/src/screen.rs
+++ b/capsules/extra/src/screen.rs
@@ -353,17 +353,19 @@ impl<'a> Screen<'a> {
                                     .get_readonly_processbuffer(ro_allow::SHARED)
                                     .and_then(|shared| {
                                         shared.enter(|s| {
+                                            let mut count = 0;
                                             let mut chunks = s.chunks(buffer_size);
                                             if let Some(chunk) = chunks.nth(chunk_number) {
                                                 for (i, byte) in chunk.iter().enumerate() {
                                                     if pos < len {
                                                         buffer[i] = byte.get();
-                                                        pos += 1
+                                                        count += 1;
+                                                        pos += 1;
                                                     } else {
                                                         break;
                                                     }
                                                 }
-                                                app.write_len - initial_pos
+                                                count
                                             } else {
                                                 // stop writing
                                                 0


### PR DESCRIPTION
### Pull Request Overview

This pull request changes two small things in service of making the screen driver more correct and efficient:

1. It allows the allocated kernel buffer for the screen to be arbitrarily small by correctly accounting for the number of actually copied bytes between a userspace buffer and the kernel buffer, and takes advantage of this to reduce the buffer allocated in the stm32f412g-disco board.
2. It increases the main clock speed of the stm32f412g on the disco board to 100MHz by enabling and configuring the PLL. In turn this dramatically increases of screen updates as the screen driver on this board uses a CPU (non-async) driver to communicate with the screen, and that bus's speed is limited by the CPU clock speed. Also, we have 100MHz, so we should use 100MHz!

### Testing Strategy

This pull request was tested running many LVGL examples and demos using libtock-c, including with animation and scrolling. I don't have a great idea for testing this automatically, especially since much of the improvement is in the form of perceived update speed on the screen itself.

### TODO or Help Wanted

N/A

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
