### PR TITLE
doc: Fix `make doc` exiting with errors

### DIFF
--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -10,18 +10,10 @@
 
 pub mod csr;
 
-#[cfg(all(target_arch = "riscv32", not(doc)))]
-pub const XLEN: usize = 32;
-#[cfg(all(target_arch = "riscv64", not(doc)))]
-pub const XLEN: usize = 64;
-
 // Default to 32 bit if no architecture is specified of if this is being
 // compiled for docs or testing on a different architecture.
-#[cfg(any(
-    doc,
-    not(all(
-        any(target_arch = "riscv32", target_arch = "riscv64"),
-        target_os = "none"
-    ))
-))]
-pub const XLEN: usize = 32;
+pub const XLEN: usize = if cfg!(target_arch = "riscv64") {
+    64
+} else {
+    32
+};

--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -10,9 +10,9 @@
 
 pub mod csr;
 
-#[cfg(target_arch = "riscv32")]
+#[cfg(all(target_arch = "riscv32", not(doc)))]
 pub const XLEN: usize = 32;
-#[cfg(target_arch = "riscv64")]
+#[cfg(all(target_arch = "riscv64", not(doc)))]
 pub const XLEN: usize = 64;
 
 // Default to 32 bit if no architecture is specified of if this is being

--- a/capsules/extra/src/servo.rs
+++ b/capsules/extra/src/servo.rs
@@ -19,7 +19,7 @@
 //! capsules_extra::sg90::Sg90<
 //!    'static,
 //!    capsules_core::virtualizers::virtual_pwm::PwmPinUser<'static, rp2040::pwm::Pwm>,
-//! >,
+//! \>,
 //! capsules_extra::sg90::Sg90::new(virtual_pwm_servo)
 //! );
 //!

--- a/capsules/extra/src/servo.rs
+++ b/capsules/extra/src/servo.rs
@@ -7,6 +7,7 @@
 //! Usage
 //! -----
 //!
+//! ```ignore
 //! use kernel::static_init;
 //! let mux_pwm = components::pwm::PwmMuxComponent::new(&peripherals.pwm)
 //! .finalize(components::pwm_mux_component_static!(rp2040::pwm::Pwm));
@@ -19,7 +20,7 @@
 //! capsules_extra::sg90::Sg90<
 //!    'static,
 //!    capsules_core::virtualizers::virtual_pwm::PwmPinUser<'static, rp2040::pwm::Pwm>,
-//! \>,
+//! >,
 //! capsules_extra::sg90::Sg90::new(virtual_pwm_servo)
 //! );
 //!
@@ -32,6 +33,7 @@
 //! capsules_extra::servo::Servo<'static, 2>,
 //! capsules_extra::servo::Servo::new(multi_servo)
 //! );
+//! ```
 
 use kernel::hil;
 use kernel::syscall::{CommandReturn, SyscallDriver};


### PR DESCRIPTION
### Pull Request Overview

This pull request adds/changes/fixes...
This PR fixes `make doc` failing when run from root of tock project as discussed in https://github.com/tock/tock/issues/4216


### Testing Strategy

This pull request was tested by...
1. By running `make doc` and seeing the resultant command pass
2. Running a qemu virtual machine for riscv32 to test the changes in riscv file don't negatively affect the kernel.


### TODO or Help Wanted

This pull request still needs...
NA

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.
NA
### Formatting

- [ ] Ran `make prepush`.
yes. but getting,
```
./.venv/bin/tockloader:3: error: license header missing
./.venv/pyvenv.cfg:6: error: license header missing
```
errors. everything else before this works. Not sure what this is about?