### PR TITLE
RP2040 PIO Interrupts + Program relocation

### DIFF
--- a/chips/rp2040/src/chip.rs
+++ b/chips/rp2040/src/chip.rs
@@ -182,10 +182,7 @@ impl InterruptService for Rp2040DefaultPeripherals<'_> {
     unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
             interrupts::PIO0_IRQ_0 => {
-                // As the current PIO interface does not provide support for interrupts, they are
-                // simply ignored.
-                //
-                // Note that PIO interrupts are raised only during unit tests.
+                self.pio0.handle_interrupt();
                 true
             }
             interrupts::TIMER_IRQ_0 => {

--- a/chips/rp2040/src/gpio.rs
+++ b/chips/rp2040/src/gpio.rs
@@ -410,6 +410,10 @@ impl<'a> RPGpioPin<'a> {
         }
     }
 
+    pub(crate) fn pin(&self) -> usize {
+        self.pin
+    }
+
     fn get_mode(&self) -> hil::gpio::Configuration {
         //TODO - read alternate function
         let pad_output_disable = !self.gpio_pad_registers.gpio_pad[self.pin].is_set(GPIO_PAD::OD);

--- a/chips/rp2040/src/pio.rs
+++ b/chips/rp2040/src/pio.rs
@@ -1416,7 +1416,7 @@ impl Pio {
         match origin {
             Some(origin) => self
                 .try_load_program_at(origin as usize, program)
-                .map(|_| origin)
+                .map(|()| origin)
                 .map_err(|_| ProgramError::AddrInUse(origin)),
             None => {
                 for origin in 0..NUMBER_INSTR_MEMORY_LOCATIONS {
@@ -1471,7 +1471,10 @@ impl Pio {
 }
 
 mod examples {
-    use super::*;
+    use super::{
+        debug, Pio, RPGpio, RPGpioPin, Readable, SMNumber, SMx_EXECCTRL, SMx_INSTR, SMx_PINCTRL,
+        StateMachineConfiguration, DBG_PADOUT, FDEBUG,
+    };
 
     impl RPGpio {
         fn from_u32(value: u32) -> RPGpio {

--- a/chips/rp2040/src/pio.rs
+++ b/chips/rp2040/src/pio.rs
@@ -515,8 +515,10 @@ const PIO1_SET_BASE: StaticRef<PioRegisters> =
 const PIO1_CLEAR_BASE: StaticRef<PioRegisters> =
     unsafe { StaticRef::new((PIO_1_BASE_ADDRESS + 0x3000) as *const PioRegisters) };
 
-/// Used to relocate program in the PIO memory.
-/// Given program, relocates JMP instruction by adding an offset
+/// Represents a relocated PIO program.
+///
+/// An [Iterator] that yields the original program except `JMP` instructions have
+/// relocated target addresses based on an offset.
 pub struct RelocatedProgram<'a, I>
 where
     I: Iterator<Item = &'a u16>,

--- a/chips/rp2040/src/pio.rs
+++ b/chips/rp2040/src/pio.rs
@@ -27,7 +27,7 @@ struct InstrMem {
 }
 
 #[repr(C)]
-struct StateMachine {
+struct StateMachineReg {
     // Clock divisor register for state machine x
     // Frequency = clock freq / (CLKDIV_INT + CLKDIV_FRAC / 256)
     clkdiv: ReadWrite<u32, SMx_CLKDIV::Register>,
@@ -105,7 +105,7 @@ PioRegisters {
         // Write-only access to instruction memory locations 0-31
         (0x048 => instr_mem: [InstrMem; NUMBER_INSTR_MEMORY_LOCATIONS]),
         // State Machines
-        (0x0c8 => sm: [StateMachine; NUMBER_STATE_MACHINES]),
+        (0x0c8 => sm: [StateMachineReg; NUMBER_STATE_MACHINES]),
         // Raw Interrupts
         (0x128 => intr: ReadWrite<u32, INTR::Register>),
         // Interrupt Enable for irq0
@@ -176,9 +176,15 @@ FSTAT [
     TXFULL1 OFFSET(17) NUMBITS(1) [],
     TXFULL0 OFFSET(16) NUMBITS(1) [],
     // State machine RX FIFO is empty
-    RXEMPTY OFFSET(8) NUMBITS(4) [],
+    RXEMPTY3 OFFSET(11) NUMBITS(1) [],
+    RXEMPTY2 OFFSET(10) NUMBITS(1) [],
+    RXEMPTY1 OFFSET(9) NUMBITS(1) [],
+    RXEMPTY0 OFFSET(8) NUMBITS(1) [],
     // State machine RX FIFO is full
-    RXFULL OFFSET(0) NUMBITS(4) []
+    RXFULL3 OFFSET(3) NUMBITS(1) [],
+    RXFULL2 OFFSET(2) NUMBITS(1) [],
+    RXFULL1 OFFSET(1) NUMBITS(1) [],
+    RXFULL0 OFFSET(0) NUMBITS(1) []
 ],
 FDEBUG [
     // State machine has stalled on empty TX FIFO during a
@@ -509,6 +515,52 @@ const PIO1_SET_BASE: StaticRef<PioRegisters> =
 const PIO1_CLEAR_BASE: StaticRef<PioRegisters> =
     unsafe { StaticRef::new((PIO_1_BASE_ADDRESS + 0x3000) as *const PioRegisters) };
 
+/// Used to relocate program in the PIO memory.
+pub struct RelocatedProgram<'a, I>
+where
+    I: Iterator<Item = &'a u16>,
+{
+    iter: I,
+    offset: u8,
+}
+
+impl<'a, I> RelocatedProgram<'a, I>
+where
+    I: Iterator<Item = &'a u16>,
+{
+    fn new(iter: I, offset: u8) -> Self {
+        Self { iter, offset }
+    }
+}
+
+impl<'a, I> Iterator for RelocatedProgram<'a, I>
+where
+    I: Iterator<Item = &'a u16>,
+{
+    type Item = u16;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(|&instr| {
+            if instr & 0b1110_0000_0000_0000 == 0 {
+                // this is a JMP instruction -> add offset to address
+                let address = (instr & 0b1_1111) as u8;
+                let address = address.wrapping_add(self.offset) % 32;
+                instr & (!0b11111) | address as u16
+            } else {
+                instr
+            }
+        })
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ProgramError {
+    /// Insufficient consecutive free instruction space to load program.
+    InsufficientSpace,
+    /// Loading a program would overwrite the existing one
+    AddrInUse(u8),
+}
+
 /// There are a total of 4 State Machines per PIO.
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum SMNumber {
@@ -518,52 +570,13 @@ pub enum SMNumber {
     SM3 = 3,
 }
 
+const SM_NUMBERS: [SMNumber; 4] = [SMNumber::SM0, SMNumber::SM1, SMNumber::SM2, SMNumber::SM3];
+
 /// There can be 2 PIOs per RP2040.
 #[derive(PartialEq)]
 pub enum PIONumber {
     PIO0 = 0,
     PIO1 = 1,
-}
-
-impl RPGpio {
-    fn from_u32(value: u32) -> RPGpio {
-        match value {
-            0 => RPGpio::GPIO0,
-            1 => RPGpio::GPIO1,
-            2 => RPGpio::GPIO2,
-            3 => RPGpio::GPIO3,
-            4 => RPGpio::GPIO4,
-            5 => RPGpio::GPIO5,
-            6 => RPGpio::GPIO6,
-            7 => RPGpio::GPIO7,
-            8 => RPGpio::GPIO8,
-            9 => RPGpio::GPIO9,
-            10 => RPGpio::GPIO10,
-            11 => RPGpio::GPIO11,
-            12 => RPGpio::GPIO12,
-            13 => RPGpio::GPIO13,
-            14 => RPGpio::GPIO14,
-            15 => RPGpio::GPIO15,
-            16 => RPGpio::GPIO16,
-            17 => RPGpio::GPIO17,
-            18 => RPGpio::GPIO18,
-            19 => RPGpio::GPIO19,
-            20 => RPGpio::GPIO20,
-            21 => RPGpio::GPIO21,
-            22 => RPGpio::GPIO22,
-            23 => RPGpio::GPIO23,
-            24 => RPGpio::GPIO24,
-            25 => RPGpio::GPIO25,
-            26 => RPGpio::GPIO26,
-            27 => RPGpio::GPIO27,
-            28 => RPGpio::GPIO28,
-            29 => RPGpio::GPIO29,
-            _ => panic!(
-                "Unknown value for GPIO pin: {} (should be from 0 to 29)",
-                value
-            ),
-        }
-    }
 }
 
 /// The FIFO queues can be joined together for twice the length in one direction.
@@ -591,11 +604,12 @@ pub enum InterruptSources {
     Sm3RXNotEmpty = 11,
 }
 
-const STATE_MACHINE_NUMBERS: [SMNumber; NUMBER_STATE_MACHINES] =
-    [SMNumber::SM0, SMNumber::SM1, SMNumber::SM2, SMNumber::SM3];
-
 pub trait PioTxClient {
     fn on_buffer_space_available(&self);
+}
+
+pub trait PioRxClient {
+    fn on_data_received(&self, data: u32);
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -605,13 +619,503 @@ enum StateMachineState {
     Waiting,
 }
 
+pub struct StateMachine {
+    sm_number: SMNumber,
+    registers: StaticRef<PioRegisters>,
+    xor_registers: StaticRef<PioRegisters>,
+    set_registers: StaticRef<PioRegisters>,
+    tx_state: Cell<StateMachineState>,
+    tx_client: OptionalCell<&'static dyn PioTxClient>,
+    rx_state: Cell<StateMachineState>,
+    rx_client: OptionalCell<&'static dyn PioRxClient>,
+}
+
+impl StateMachine {
+    fn new(
+        sm_id: SMNumber,
+        registers: StaticRef<PioRegisters>,
+        xor_registers: StaticRef<PioRegisters>,
+        set_registers: StaticRef<PioRegisters>,
+    ) -> StateMachine {
+        StateMachine {
+            sm_number: sm_id,
+            registers,
+            xor_registers,
+            set_registers,
+            tx_state: Cell::new(StateMachineState::Ready),
+            tx_client: OptionalCell::empty(),
+            rx_state: Cell::new(StateMachineState::Ready),
+            rx_client: OptionalCell::empty(),
+        }
+    }
+
+    /// State machine configuration with any config structure.
+    pub fn config(&self, config: &StateMachineConfiguration) {
+        self.set_in_pins(config.in_pins_base);
+        self.set_out_pins(config.out_pins_base, config.out_pins_count);
+        self.set_set_pins(config.set_pins_base, config.set_pins_count);
+        self.set_side_set_pins(config.side_set_base);
+        self.set_side_set(
+            config.side_set_bit_count,
+            config.side_set_opt_enable,
+            config.side_set_pindirs,
+        );
+        self.set_in_shift(
+            config.in_shift_direction_right,
+            config.in_autopush,
+            config.in_push_threshold,
+        );
+        self.set_out_shift(
+            config.out_shift_direction_right,
+            config.out_autopull,
+            config.out_pull_threshold,
+        );
+        self.set_jmp_pin(config.jmp_pin);
+        self.set_wrap(config.wrap_to, config.wrap);
+        self.set_mov_status(config.mov_status_sel, config.mov_status_n);
+        self.set_out_special(
+            config.out_special_sticky,
+            config.out_special_has_enable_pin,
+            config.out_special_enable_pin_index,
+        );
+        self.set_clkdiv_int_frac(config.div_int, config.div_frac);
+    }
+
+    /// Set tx client for a state machine.
+    pub fn set_tx_client(&self, client: &'static dyn PioTxClient) {
+        self.tx_client.set(client);
+    }
+
+    /// Set rx client for a state machine.
+    pub fn set_rx_client(&self, client: &'static dyn PioRxClient) {
+        self.rx_client.set(client);
+    }
+
+    /// Set every config for the IN pins.
+    ///
+    /// in_base => the starting location for the input pins
+    pub fn set_in_pins(&self, in_base: u32) {
+        self.registers.sm[self.sm_number as usize]
+            .pinctrl
+            .modify(SMx_PINCTRL::IN_BASE.val(in_base));
+    }
+
+    /// Set every config for the SET pins.
+    ///
+    /// set_base => the starting location for the SET pins
+    /// set_count => the number of SET pins
+    pub fn set_set_pins(&self, set_base: u32, set_count: u32) {
+        self.registers.sm[self.sm_number as usize]
+            .pinctrl
+            .modify(SMx_PINCTRL::SET_BASE.val(set_base));
+        self.registers.sm[self.sm_number as usize]
+            .pinctrl
+            .modify(SMx_PINCTRL::SET_COUNT.val(set_count));
+    }
+
+    /// Set every config for the OUT pins.
+    ///
+    /// out_base => the starting location for the OUT pins
+    /// out_count => the number of OUT pins
+    pub fn set_out_pins(&self, out_base: u32, out_count: u32) {
+        self.registers.sm[self.sm_number as usize]
+            .pinctrl
+            .modify(SMx_PINCTRL::OUT_BASE.val(out_base));
+        self.registers.sm[self.sm_number as usize]
+            .pinctrl
+            .modify(SMx_PINCTRL::OUT_COUNT.val(out_count));
+    }
+
+    /// Setup 'in' shifting parameters.
+    ///
+    ///  shift_right => true to shift ISR to right or false to shift to left
+    ///  autopush => true to enable, false to disable
+    ///  push_threshold => threshold in bits to shift in before auto/conditional re-pushing of the ISR
+    pub fn set_in_shift(&self, shift_right: bool, autopush: bool, push_threshold: u32) {
+        self.registers.sm[self.sm_number as usize]
+            .shiftctrl
+            .modify(SMx_SHIFTCTRL::IN_SHIFTDIR.val(shift_right.into()));
+        self.registers.sm[self.sm_number as usize]
+            .shiftctrl
+            .modify(SMx_SHIFTCTRL::AUTOPUSH.val(autopush.into()));
+        self.registers.sm[self.sm_number as usize]
+            .shiftctrl
+            .modify(SMx_SHIFTCTRL::PUSH_THRESH.val(push_threshold));
+    }
+
+    /// Setup 'out' shifting parameters.
+    ///
+    /// shift_right => `true` to shift OSR to right or false to shift to left
+    /// autopull => true to enable, false to disable
+    /// pull_threshold => threshold in bits to shift out before auto/conditional re-pulling of the OSR
+    pub fn set_out_shift(&self, shift_right: bool, autopull: bool, pull_threshold: u32) {
+        self.registers.sm[self.sm_number as usize]
+            .shiftctrl
+            .modify(SMx_SHIFTCTRL::OUT_SHIFTDIR.val(shift_right.into()));
+        self.registers.sm[self.sm_number as usize]
+            .shiftctrl
+            .modify(SMx_SHIFTCTRL::AUTOPULL.val(autopull.into()));
+        self.registers.sm[self.sm_number as usize]
+            .shiftctrl
+            .modify(SMx_SHIFTCTRL::PULL_THRESH.val(pull_threshold));
+    }
+
+    /// Set special OUT operations in a state machine.
+    ///
+    /// sticky
+    /// => true to enable sticky output (rere-asserting most recent OUT/SET pin values on subsequent cycles)
+    /// => false to disable sticky output
+    /// has_enable_pin
+    /// => true to enable auxiliary OUT enable pin
+    /// => false to disable auxiliary OUT enable pin
+    /// enable_pin_index => pin index for auxiliary OUT enable
+    pub fn set_out_special(&self, sticky: bool, has_enable_pin: bool, enable_pin_index: u32) {
+        self.registers.sm[self.sm_number as usize]
+            .execctrl
+            .modify(SMx_EXECCTRL::OUT_STICKY.val(sticky as u32));
+        self.registers.sm[self.sm_number as usize]
+            .execctrl
+            .modify(SMx_EXECCTRL::INLINE_OUT_EN.val(has_enable_pin as u32));
+        self.registers.sm[self.sm_number as usize]
+            .execctrl
+            .modify(SMx_EXECCTRL::OUT_EN_SEL.val(enable_pin_index));
+    }
+
+    /// Set the 'jmp' pin.
+    ///
+    /// pin => the raw GPIO pin number to use as the source for a jmp pin instruction
+    pub fn set_jmp_pin(&self, pin: u32) {
+        self.registers.sm[self.sm_number as usize]
+            .execctrl
+            .modify(SMx_EXECCTRL::JMP_PIN.val(pin));
+    }
+
+    /// Set the clock divider for a state machine.
+    ///
+    /// div_int => Integer part of the divisor
+    /// div_frac => Fractional part in 1/256ths
+    pub fn set_clkdiv_int_frac(&self, div_int: u32, div_frac: u32) {
+        self.registers.sm[self.sm_number as usize]
+            .clkdiv
+            .modify(SMx_CLKDIV::INT.val(div_int));
+        self.registers.sm[self.sm_number as usize]
+            .clkdiv
+            .modify(SMx_CLKDIV::FRAC.val(div_frac));
+    }
+
+    /// Setup the FIFO joining in a state machine.
+    ///
+    /// fifo_join => specifies the join type - see the `PioFifoJoin` type
+    pub fn set_fifo_join(&self, fifo_join: PioFifoJoin) {
+        if fifo_join == PioFifoJoin::PioFifoJoinRx {
+            self.registers.sm[self.sm_number as usize]
+                .shiftctrl
+                .modify(SMx_SHIFTCTRL::FJOIN_RX.val(fifo_join as u32));
+        } else if fifo_join == PioFifoJoin::PioFifoJoinTx {
+            self.registers.sm[self.sm_number as usize]
+                .shiftctrl
+                .modify(SMx_SHIFTCTRL::FJOIN_TX.val(fifo_join as u32));
+        }
+    }
+
+    /// Set the starting location for the sideset pins.
+    pub fn set_side_set_pins(&self, sideset_base: u32) {
+        self.registers.sm[self.sm_number as usize]
+            .pinctrl
+            .modify(SMx_PINCTRL::SIDESET_BASE.val(sideset_base));
+    }
+
+    /// Set every config for the SIDESET pins.
+    ///
+    /// bit_count => number of SIDESET bits per instruction - max 5
+    /// optional
+    /// => true to use the topmost sideset bit as a flag for whether to apply side set on that instruction
+    /// => false to use sideset with every instruction
+    /// pindirs
+    /// => true to affect pin direction
+    /// => false to affect value of a pin
+    pub fn set_side_set(&self, bit_count: u32, optional: bool, pindirs: bool) {
+        self.registers.sm[self.sm_number as usize]
+            .pinctrl
+            .modify(SMx_PINCTRL::SIDESET_COUNT.val(bit_count));
+        self.registers.sm[self.sm_number as usize]
+            .execctrl
+            .modify(SMx_EXECCTRL::SIDE_EN.val(optional as u32));
+        self.registers.sm[self.sm_number as usize]
+            .execctrl
+            .modify(SMx_EXECCTRL::SIDE_PINDIR.val(pindirs as u32));
+    }
+
+    /// Use a state machine to set the same pin direction for multiple consecutive pins for the PIO instance.
+    /// This is the pio_sm_set_consecutive_pindirs function from the pico sdk, renamed to be more clear.
+    ///
+    /// pin => starting pin
+    /// count => how many pins (including the base) should be changed
+    /// is_out
+    /// => true to set the pin as OUT
+    /// => false to set the pin as IN
+    pub fn set_pins_out(&self, mut pin: u32, mut count: u32, is_out: bool) {
+        // "set pindirs, 0" command created by pioasm
+        let set_pindirs_0: u32 = 0b1110000010000000;
+        let pinctrl = self.registers.sm[self.sm_number as usize].pinctrl.get();
+        let execctrl = self.registers.sm[self.sm_number as usize].execctrl.get();
+        self.registers.sm[self.sm_number as usize]
+            .execctrl
+            .modify(SMx_EXECCTRL::OUT_STICKY.val(0));
+        let mut pindir_val: u8 = 0x00;
+        if is_out {
+            pindir_val = 0x1f;
+        }
+        while count > 5 {
+            self.registers.sm[self.sm_number as usize]
+                .pinctrl
+                .modify(SMx_PINCTRL::SET_COUNT.val(5));
+            self.registers.sm[self.sm_number as usize]
+                .pinctrl
+                .modify(SMx_PINCTRL::SET_BASE.val(pin));
+            self.exec((set_pindirs_0) | (pindir_val as u32));
+            count -= 5;
+            pin = (pin + 5) & 0x1f;
+        }
+        self.registers.sm[self.sm_number as usize]
+            .pinctrl
+            .modify(SMx_PINCTRL::SET_COUNT.val(count));
+        self.registers.sm[self.sm_number as usize]
+            .pinctrl
+            .modify(SMx_PINCTRL::SET_BASE.val(pin));
+        self.exec((set_pindirs_0) | (pindir_val as u32));
+        self.registers.sm[self.sm_number as usize]
+            .execctrl
+            .set(execctrl);
+        self.registers.sm[self.sm_number as usize]
+            .pinctrl
+            .set(pinctrl);
+    }
+
+    /// Restart a state machine.
+    pub fn restart(&self) {
+        match self.sm_number {
+            SMNumber::SM0 => self.set_registers.ctrl.modify(CTRL::SM0_RESTART::SET),
+            SMNumber::SM1 => self.set_registers.ctrl.modify(CTRL::SM1_RESTART::SET),
+            SMNumber::SM2 => self.set_registers.ctrl.modify(CTRL::SM2_RESTART::SET),
+            SMNumber::SM3 => self.set_registers.ctrl.modify(CTRL::SM3_RESTART::SET),
+        }
+    }
+
+    /// Clear a state machine’s TX and RX FIFOs.
+    pub fn clear_fifos(&self) {
+        self.xor_registers.sm[self.sm_number as usize]
+            .shiftctrl
+            .modify(SMx_SHIFTCTRL::FJOIN_RX::SET);
+        self.xor_registers.sm[self.sm_number as usize]
+            .shiftctrl
+            .modify(SMx_SHIFTCTRL::FJOIN_RX::SET);
+    }
+
+    /// Restart a state machine's clock divider.
+    pub fn clkdiv_restart(&self) {
+        match self.sm_number {
+            SMNumber::SM0 => self.set_registers.ctrl.modify(CTRL::CLKDIV0_RESTART::SET),
+            SMNumber::SM1 => self.set_registers.ctrl.modify(CTRL::CLKDIV1_RESTART::SET),
+            SMNumber::SM2 => self.set_registers.ctrl.modify(CTRL::CLKDIV2_RESTART::SET),
+            SMNumber::SM3 => self.set_registers.ctrl.modify(CTRL::CLKDIV3_RESTART::SET),
+        }
+    }
+
+    /// Set the wrap addresses for a state machine.
+    ///
+    /// wrap_target => the instruction memory address to wrap to
+    /// wrap => the instruction memory address after which the program counters wraps to the target
+    pub fn set_wrap(&self, wrap_target: u32, wrap: u32) {
+        self.registers.sm[self.sm_number as usize]
+            .execctrl
+            .modify(SMx_EXECCTRL::WRAP_BOTTOM.val(wrap_target));
+        self.registers.sm[self.sm_number as usize]
+            .execctrl
+            .modify(SMx_EXECCTRL::WRAP_TOP.val(wrap));
+    }
+
+    /// Returns true if the TX FIFO is full.
+    pub fn tx_full(&self) -> bool {
+        let field = match self.sm_number {
+            SMNumber::SM0 => FSTAT::TXFULL0,
+            SMNumber::SM1 => FSTAT::TXFULL1,
+            SMNumber::SM2 => FSTAT::TXFULL2,
+            SMNumber::SM3 => FSTAT::TXFULL3,
+        };
+        self.registers.fstat.read(field) != 0
+    }
+
+    /// Returns true if the RX FIFO is empty.
+    pub fn rx_empty(&self) -> bool {
+        let field = match self.sm_number {
+            SMNumber::SM0 => FSTAT::RXEMPTY0,
+            SMNumber::SM1 => FSTAT::RXEMPTY1,
+            SMNumber::SM2 => FSTAT::RXEMPTY2,
+            SMNumber::SM3 => FSTAT::RXEMPTY3,
+        };
+        self.registers.fstat.read(field) != 0
+    }
+
+    /// Immediately execute an instruction on a state machine.
+    pub fn exec(&self, instr: u32) {
+        self.registers.sm[self.sm_number as usize]
+            .instr
+            .modify(SMx_INSTR::INSTR.val(instr));
+    }
+
+    /// Set source for 'mov status' in a state machine.
+    ///
+    /// status_sel => comparison used for the `MOV x, STATUS` instruction
+    /// status_n => comparison level for the `MOV x, STATUS` instruction
+    pub fn set_mov_status(&self, status_sel: PioMovStatusType, status_n: u32) {
+        self.registers.sm[self.sm_number as usize]
+            .execctrl
+            .modify(SMx_EXECCTRL::STATUS_SEL.val(status_sel as u32));
+        self.registers.sm[self.sm_number as usize]
+            .execctrl
+            .modify(SMx_EXECCTRL::STATUS_N.val(status_n));
+    }
+
+    /// Set a state machine's state to enabled or to disabled.
+    pub fn set_enabled(&self, enabled: bool) {
+        match self.sm_number {
+            SMNumber::SM0 => self.registers.ctrl.modify(match enabled {
+                true => CTRL::SM0_ENABLE::SET,
+                false => CTRL::SM0_ENABLE::CLEAR,
+            }),
+            SMNumber::SM1 => self.registers.ctrl.modify(match enabled {
+                true => CTRL::SM1_ENABLE::SET,
+                false => CTRL::SM1_ENABLE::CLEAR,
+            }),
+            SMNumber::SM2 => self.registers.ctrl.modify(match enabled {
+                true => CTRL::SM2_ENABLE::SET,
+                false => CTRL::SM2_ENABLE::CLEAR,
+            }),
+            SMNumber::SM3 => self.registers.ctrl.modify(match enabled {
+                true => CTRL::SM3_ENABLE::SET,
+                false => CTRL::SM3_ENABLE::CLEAR,
+            }),
+        }
+    }
+
+    /// Resets the state machine to a consistent state, and configures it.
+    pub fn init(&self) {
+        self.clear_fifos();
+        self.restart();
+        self.clkdiv_restart();
+        self.registers.sm[self.sm_number as usize]
+            .instr
+            .modify(SMx_INSTR::INSTR.val(0));
+    }
+
+    /// Write a word of data to a state machine’s TX FIFO.
+    pub fn put(&self, data: u32) -> Result<(), ErrorCode> {
+        match self.tx_state.get() {
+            StateMachineState::Ready => {
+                if self.tx_full() {
+                    // TX queue is full, set interrupt
+                    let field = match self.sm_number {
+                        SMNumber::SM0 => IRQ0_INTE::SM0_TXNFULL::SET,
+                        SMNumber::SM1 => IRQ0_INTE::SM1_TXNFULL::SET,
+                        SMNumber::SM2 => IRQ0_INTE::SM2_TXNFULL::SET,
+                        SMNumber::SM3 => IRQ0_INTE::SM3_TXNFULL::SET,
+                    };
+                    self.registers.irq0_inte.modify(field);
+                    self.tx_state.set(StateMachineState::Waiting);
+                    Err(ErrorCode::BUSY)
+                } else {
+                    self.registers.txf[self.sm_number as usize].set(data);
+                    Ok(())
+                }
+            }
+            StateMachineState::Waiting => Err(ErrorCode::BUSY),
+        }
+    }
+
+    /// Wait until a state machine's TX FIFO is empty, then write a word of data to it.
+    pub fn put_blocking(&self, data: u32) {
+        while self.tx_full() {}
+        self.registers.txf[self.sm_number as usize].set(data);
+    }
+
+    pub fn read_txf(&self) -> Result<u32, ErrorCode> {
+        match self.rx_state.get() {
+            StateMachineState::Ready => {
+                if self.rx_empty() {
+                    // RX queue is empty, set interrupt
+                    let field = match self.sm_number {
+                        SMNumber::SM0 => IRQ0_INTE::SM0_RXNEMPTY::SET,
+                        SMNumber::SM1 => IRQ0_INTE::SM1_RXNEMPTY::SET,
+                        SMNumber::SM2 => IRQ0_INTE::SM2_RXNEMPTY::SET,
+                        SMNumber::SM3 => IRQ0_INTE::SM3_RXNEMPTY::SET,
+                    };
+                    self.registers.irq0_inte.modify(field);
+                    self.rx_state.set(StateMachineState::Waiting);
+                    Err(ErrorCode::BUSY)
+                } else {
+                    Ok(self.registers.rxf[self.sm_number as usize].read(RXFx::RXF))
+                }
+            }
+            StateMachineState::Waiting => Err(ErrorCode::BUSY),
+        }
+    }
+
+    pub fn read_blocking(&self) -> u32 {
+        while self.rx_empty() {}
+        self.registers.rxf[self.sm_number as usize].read(RXFx::RXF)
+    }
+
+    /// Handle a TX interrupt - notify that buffer space is available.
+    fn handle_tx_interrupt(&self) {
+        match self.tx_state.get() {
+            StateMachineState::Waiting => {
+                // TX queue has emptied, clear interrupt
+                let field = match self.sm_number {
+                    SMNumber::SM0 => IRQ0_INTE::SM0_TXNFULL::CLEAR,
+                    SMNumber::SM1 => IRQ0_INTE::SM1_TXNFULL::CLEAR,
+                    SMNumber::SM2 => IRQ0_INTE::SM2_TXNFULL::CLEAR,
+                    SMNumber::SM3 => IRQ0_INTE::SM3_TXNFULL::CLEAR,
+                };
+                self.registers.irq0_inte.modify(field);
+                self.tx_state.set(StateMachineState::Ready);
+                self.tx_client.map(|client| {
+                    client.on_buffer_space_available();
+                });
+            }
+            StateMachineState::Ready => {}
+        }
+    }
+
+    /// Handle an RX interrupt - notify that data has been received.
+    fn handle_rx_interrupt(&self) {
+        match self.rx_state.get() {
+            StateMachineState::Waiting => {
+                // RX queue has data, clear interrupt
+                let field = match self.sm_number {
+                    SMNumber::SM0 => IRQ0_INTE::SM0_RXNEMPTY::CLEAR,
+                    SMNumber::SM1 => IRQ0_INTE::SM1_RXNEMPTY::CLEAR,
+                    SMNumber::SM2 => IRQ0_INTE::SM2_RXNEMPTY::CLEAR,
+                    SMNumber::SM3 => IRQ0_INTE::SM3_RXNEMPTY::CLEAR,
+                };
+                self.registers.irq0_inte.modify(field);
+                self.rx_state.set(StateMachineState::Ready);
+                self.rx_client.map(|client| {
+                    client.on_data_received(
+                        self.registers.rxf[self.sm_number as usize].read(RXFx::RXF),
+                    );
+                });
+            }
+            StateMachineState::Ready => {}
+        }
+    }
+}
+
 pub struct Pio {
     registers: StaticRef<PioRegisters>,
     pio_number: PIONumber,
-    xor_registers: StaticRef<PioRegisters>,
-    set_registers: StaticRef<PioRegisters>,
-    sm_state: [Cell<StateMachineState>; NUMBER_STATE_MACHINES],
-    tx_clients: [OptionalCell<&'static dyn PioTxClient>; NUMBER_STATE_MACHINES],
+    sms: [StateMachine; NUMBER_STATE_MACHINES],
+    instructions_used: Cell<u32>,
     _clear_registers: StaticRef<PioRegisters>,
 }
 
@@ -686,74 +1190,6 @@ impl Default for StateMachineConfiguration {
 }
 
 impl Pio {
-    /// State machine configuration with any config structure.
-    pub fn sm_config(&self, sm_number: SMNumber, config: &StateMachineConfiguration) {
-        self.set_in_pins(sm_number, config.in_pins_base);
-        self.set_out_pins(sm_number, config.out_pins_base, config.out_pins_count);
-        self.set_set_pins(sm_number, config.set_pins_base, config.set_pins_count);
-        self.set_side_set_pins(sm_number, config.side_set_base);
-        self.set_side_set(
-            sm_number,
-            config.side_set_bit_count,
-            config.side_set_opt_enable,
-            config.side_set_pindirs,
-        );
-        self.set_in_shift(
-            sm_number,
-            config.in_shift_direction_right,
-            config.in_autopush,
-            config.in_push_threshold,
-        );
-        self.set_out_shift(
-            sm_number,
-            config.out_shift_direction_right,
-            config.out_autopull,
-            config.out_pull_threshold,
-        );
-        self.set_jmp_pin(sm_number, config.jmp_pin);
-        self.set_wrap(sm_number, config.wrap_to, config.wrap);
-        self.set_mov_status(sm_number, config.mov_status_sel, config.mov_status_n);
-        self.set_out_special(
-            sm_number,
-            config.out_special_sticky,
-            config.out_special_has_enable_pin,
-            config.out_special_enable_pin_index,
-        );
-        self.set_clkdiv_int_frac(sm_number, config.div_int, config.div_frac);
-    }
-
-    /// Resets the state machine to a consistent state, and configures it.
-    pub fn sm_init(&self, sm_number: SMNumber) {
-        self.sm_clear_fifos(sm_number);
-        self.restart_sm(sm_number);
-        self.sm_clkdiv_restart(sm_number);
-        self.registers.sm[sm_number as usize]
-            .instr
-            .modify(SMx_INSTR::INSTR.val(0));
-    }
-
-    /// Set a state machine's state to enabled or to disabled.
-    pub fn sm_set_enabled(&self, sm_number: SMNumber, enabled: bool) {
-        match sm_number {
-            SMNumber::SM0 => self.registers.ctrl.modify(match enabled {
-                true => CTRL::SM0_ENABLE::SET,
-                false => CTRL::SM0_ENABLE::CLEAR,
-            }),
-            SMNumber::SM1 => self.registers.ctrl.modify(match enabled {
-                true => CTRL::SM1_ENABLE::SET,
-                false => CTRL::SM1_ENABLE::CLEAR,
-            }),
-            SMNumber::SM2 => self.registers.ctrl.modify(match enabled {
-                true => CTRL::SM2_ENABLE::SET,
-                false => CTRL::SM2_ENABLE::CLEAR,
-            }),
-            SMNumber::SM3 => self.registers.ctrl.modify(match enabled {
-                true => CTRL::SM3_ENABLE::SET,
-                false => CTRL::SM3_ENABLE::CLEAR,
-            }),
-        }
-    }
-
     /// Setup the function select for a GPIO to use output from the given PIO instance.
     pub fn gpio_init(&self, pin: &RPGpioPin) {
         if self.pio_number == PIONumber::PIO1 {
@@ -767,12 +1203,10 @@ impl Pio {
     pub fn new_pio0() -> Self {
         Self {
             registers: PIO0_BASE,
-            xor_registers: PIO0_XOR_BASE,
-            set_registers: PIO0_SET_BASE,
             _clear_registers: PIO0_CLEAR_BASE,
             pio_number: PIONumber::PIO0,
-            sm_state: core::array::from_fn(|_| Cell::default()),
-            tx_clients: core::array::from_fn(|_| OptionalCell::default()),
+            sms: SM_NUMBERS.map(|x| StateMachine::new(x, PIO0_BASE, PIO0_XOR_BASE, PIO0_SET_BASE)),
+            instructions_used: Cell::new(0),
         }
     }
 
@@ -780,254 +1214,16 @@ impl Pio {
     pub fn new_pio1() -> Self {
         Self {
             registers: PIO1_BASE,
-            xor_registers: PIO1_XOR_BASE,
-            set_registers: PIO1_SET_BASE,
             _clear_registers: PIO1_CLEAR_BASE,
             pio_number: PIONumber::PIO1,
-            sm_state: core::array::from_fn(|_| Cell::default()),
-            tx_clients: core::array::from_fn(|_| OptionalCell::default()),
+            sms: SM_NUMBERS.map(|x| StateMachine::new(x, PIO1_BASE, PIO1_XOR_BASE, PIO1_SET_BASE)),
+            instructions_used: Cell::new(0),
         }
     }
 
-    /// Set every config for the IN pins.
-    ///
-    /// in_base => the starting location for the input pins
-    pub fn set_in_pins(&self, sm_number: SMNumber, in_base: u32) {
-        self.registers.sm[sm_number as usize]
-            .pinctrl
-            .modify(SMx_PINCTRL::IN_BASE.val(in_base));
-    }
-
-    /// Set every config for the SET pins.
-    ///
-    /// set_base => the starting location for the SET pins
-    /// set_count => the number of SET pins
-    pub fn set_set_pins(&self, sm_number: SMNumber, set_base: u32, set_count: u32) {
-        self.registers.sm[sm_number as usize]
-            .pinctrl
-            .modify(SMx_PINCTRL::SET_BASE.val(set_base));
-        self.registers.sm[sm_number as usize]
-            .pinctrl
-            .modify(SMx_PINCTRL::SET_COUNT.val(set_count));
-    }
-
-    /// Set every config for the OUT pins.
-    ///
-    /// out_base => the starting location for the OUT pins
-    /// out_count => the number of OUT pins
-    pub fn set_out_pins(&self, sm_number: SMNumber, out_base: u32, out_count: u32) {
-        self.registers.sm[sm_number as usize]
-            .pinctrl
-            .modify(SMx_PINCTRL::OUT_BASE.val(out_base));
-        self.registers.sm[sm_number as usize]
-            .pinctrl
-            .modify(SMx_PINCTRL::OUT_COUNT.val(out_count));
-    }
-
-    /// Setup 'in' shifting parameters.
-    ///
-    ///  shift_right => true to shift ISR to right or false to shift to left
-    ///  autopush => true to enable, false to disable
-    ///  push_threshold => threshold in bits to shift in before auto/conditional re-pushing of the ISR
-    pub fn set_in_shift(
-        &self,
-        sm_number: SMNumber,
-        shift_right: bool,
-        autopush: bool,
-        push_threshold: u32,
-    ) {
-        self.registers.sm[sm_number as usize]
-            .shiftctrl
-            .modify(SMx_SHIFTCTRL::IN_SHIFTDIR.val(shift_right.into()));
-        self.registers.sm[sm_number as usize]
-            .shiftctrl
-            .modify(SMx_SHIFTCTRL::AUTOPUSH.val(autopush.into()));
-        self.registers.sm[sm_number as usize]
-            .shiftctrl
-            .modify(SMx_SHIFTCTRL::PUSH_THRESH.val(push_threshold));
-    }
-
-    /// Setup 'out' shifting parameters.
-    ///
-    /// shift_right => `true` to shift OSR to right or false to shift to left
-    /// autopull => true to enable, false to disable
-    /// pull_threshold => threshold in bits to shift out before auto/conditional re-pulling of the OSR
-    pub fn set_out_shift(
-        &self,
-        sm_number: SMNumber,
-        shift_right: bool,
-        autopull: bool,
-        pull_threshold: u32,
-    ) {
-        self.registers.sm[sm_number as usize]
-            .shiftctrl
-            .modify(SMx_SHIFTCTRL::OUT_SHIFTDIR.val(shift_right.into()));
-        self.registers.sm[sm_number as usize]
-            .shiftctrl
-            .modify(SMx_SHIFTCTRL::AUTOPULL.val(autopull.into()));
-        self.registers.sm[sm_number as usize]
-            .shiftctrl
-            .modify(SMx_SHIFTCTRL::PULL_THRESH.val(pull_threshold));
-    }
-
-    /// Set the 'jmp' pin.
-    ///
-    /// pin => the raw GPIO pin number to use as the source for a jmp pin instruction
-    pub fn set_jmp_pin(&self, sm_number: SMNumber, pin: u32) {
-        self.registers.sm[sm_number as usize]
-            .execctrl
-            .modify(SMx_EXECCTRL::JMP_PIN.val(pin));
-    }
-
-    /// Set the clock divider for a state machine.
-    ///
-    /// div_int => Integer part of the divisor
-    /// div_frac => Fractional part in 1/256ths
-    pub fn set_clkdiv_int_frac(&self, sm_number: SMNumber, div_int: u32, div_frac: u32) {
-        self.registers.sm[sm_number as usize]
-            .clkdiv
-            .modify(SMx_CLKDIV::INT.val(div_int));
-        self.registers.sm[sm_number as usize]
-            .clkdiv
-            .modify(SMx_CLKDIV::FRAC.val(div_frac));
-    }
-
-    /// Setup the FIFO joining in a state machine.
-    ///
-    /// fifo_join => specifies the join type - see the `PioFifoJoin` type
-    pub fn set_fifo_join(&self, sm_number: SMNumber, fifo_join: PioFifoJoin) {
-        if fifo_join == PioFifoJoin::PioFifoJoinRx {
-            self.registers.sm[sm_number as usize]
-                .shiftctrl
-                .modify(SMx_SHIFTCTRL::FJOIN_RX.val(fifo_join as u32));
-        } else if fifo_join == PioFifoJoin::PioFifoJoinTx {
-            self.registers.sm[sm_number as usize]
-                .shiftctrl
-                .modify(SMx_SHIFTCTRL::FJOIN_TX.val(fifo_join as u32));
-        }
-    }
-
-    /// Set the starting location for the sideset pins.
-    pub fn set_side_set_pins(&self, sm_number: SMNumber, sideset_base: u32) {
-        self.registers.sm[sm_number as usize]
-            .pinctrl
-            .modify(SMx_PINCTRL::SIDESET_BASE.val(sideset_base));
-    }
-
-    /// Set every config for the SIDESET pins.
-    ///
-    /// bit_count => number of SIDESET bits per instruction - max 5
-    /// optional
-    /// => true to use the topmost sideset bit as a flag for whether to apply side set on that instruction
-    /// => false to use sideset with every instruction
-    /// pindirs
-    /// => true to affect pin direction
-    /// => false to affect value of a pin
-    pub fn set_side_set(&self, sm_number: SMNumber, bit_count: u32, optional: bool, pindirs: bool) {
-        self.registers.sm[sm_number as usize]
-            .pinctrl
-            .modify(SMx_PINCTRL::SIDESET_COUNT.val(bit_count));
-        self.registers.sm[sm_number as usize]
-            .execctrl
-            .modify(SMx_EXECCTRL::SIDE_EN.val(optional as u32));
-        self.registers.sm[sm_number as usize]
-            .execctrl
-            .modify(SMx_EXECCTRL::SIDE_PINDIR.val(pindirs as u32));
-    }
-
-    /// Set the wrap addresses for a state machine.
-    ///
-    /// wrap_target => the instruction memory address to wrap to
-    /// wrap => the instruction memory address after which the program counters wraps to the target
-    pub fn set_wrap(&self, sm_number: SMNumber, wrap_target: u32, wrap: u32) {
-        self.registers.sm[sm_number as usize]
-            .execctrl
-            .modify(SMx_EXECCTRL::WRAP_BOTTOM.val(wrap_target));
-        self.registers.sm[sm_number as usize]
-            .execctrl
-            .modify(SMx_EXECCTRL::WRAP_TOP.val(wrap));
-    }
-
-    /// Set source for 'mov status' in a state machine.
-    ///
-    /// status_sel => comparison used for the `MOV x, STATUS` instruction
-    /// status_n => comparison level for the `MOV x, STATUS` instruction
-    pub fn set_mov_status(&self, sm_number: SMNumber, status_sel: PioMovStatusType, status_n: u32) {
-        self.registers.sm[sm_number as usize]
-            .execctrl
-            .modify(SMx_EXECCTRL::STATUS_SEL.val(status_sel as u32));
-        self.registers.sm[sm_number as usize]
-            .execctrl
-            .modify(SMx_EXECCTRL::STATUS_N.val(status_n));
-    }
-
-    /// Set special OUT operations in a state machine.
-    ///
-    /// sticky
-    /// => true to enable sticky output (rere-asserting most recent OUT/SET pin values on subsequent cycles)
-    /// => false to disable sticky output
-    /// has_enable_pin
-    /// => true to enable auxiliary OUT enable pin
-    /// => false to disable auxiliary OUT enable pin
-    /// enable_pin_index => pin index for auxiliary OUT enable
-    pub fn set_out_special(
-        &self,
-        sm_number: SMNumber,
-        sticky: bool,
-        has_enable_pin: bool,
-        enable_pin_index: u32,
-    ) {
-        self.registers.sm[sm_number as usize]
-            .execctrl
-            .modify(SMx_EXECCTRL::OUT_STICKY.val(sticky as u32));
-        self.registers.sm[sm_number as usize]
-            .execctrl
-            .modify(SMx_EXECCTRL::INLINE_OUT_EN.val(has_enable_pin as u32));
-        self.registers.sm[sm_number as usize]
-            .execctrl
-            .modify(SMx_EXECCTRL::OUT_EN_SEL.val(enable_pin_index));
-    }
-
-    /// Use a state machine to set the same pin direction for multiple consecutive pins for the PIO instance.
-    /// This is the pio_sm_set_consecutive_pindirs function from the pico sdk, renamed to be more clear.
-    ///
-    /// pin => starting pin
-    /// count => how many pins (including the base) should be changed
-    /// is_out
-    /// => true to set the pin as OUT
-    /// => false to set the pin as IN
-    pub fn set_pins_out(&self, sm_number: SMNumber, mut pin: u32, mut count: u32, is_out: bool) {
-        // "set pindirs, 0" command created by pioasm
-        let set_pindirs_0: u32 = 0b1110000010000000;
-        let pinctrl = self.registers.sm[sm_number as usize].pinctrl.get();
-        let execctrl = self.registers.sm[sm_number as usize].execctrl.get();
-        self.registers.sm[sm_number as usize]
-            .execctrl
-            .modify(SMx_EXECCTRL::OUT_STICKY.val(0));
-        let mut pindir_val: u8 = 0x00;
-        if is_out {
-            pindir_val = 0x1f;
-        }
-        while count > 5 {
-            self.registers.sm[sm_number as usize]
-                .pinctrl
-                .modify(SMx_PINCTRL::SET_COUNT.val(5));
-            self.registers.sm[sm_number as usize]
-                .pinctrl
-                .modify(SMx_PINCTRL::SET_BASE.val(pin));
-            self.sm_exec(sm_number, (set_pindirs_0) | (pindir_val as u32));
-            count -= 5;
-            pin = (pin + 5) & 0x1f;
-        }
-        self.registers.sm[sm_number as usize]
-            .pinctrl
-            .modify(SMx_PINCTRL::SET_COUNT.val(count));
-        self.registers.sm[sm_number as usize]
-            .pinctrl
-            .modify(SMx_PINCTRL::SET_BASE.val(pin));
-        self.sm_exec(sm_number, (set_pindirs_0) | (pindir_val as u32));
-        self.registers.sm[sm_number as usize].execctrl.set(execctrl);
-        self.registers.sm[sm_number as usize].pinctrl.set(pinctrl);
+    /// Get state machine
+    pub fn sm(&self, sm_number: SMNumber) -> &StateMachine {
+        &self.sms[sm_number as usize]
     }
 
     /// Enable/Disable a single source on a PIO's IRQ index.
@@ -1176,123 +1372,83 @@ impl Pio {
         }
     }
 
-    /// Immediately execute an instruction on a state machine.
-    pub fn sm_exec(&self, sm_number: SMNumber, instr: u32) {
-        self.registers.sm[sm_number as usize]
-            .instr
-            .modify(SMx_INSTR::INSTR.val(instr));
-    }
-
-    /// Write a word of data to a state machine’s TX FIFO.
-    pub fn sm_put(&self, sm_number: SMNumber, data: u32) -> Result<(), ErrorCode> {
-        match self.sm_state[sm_number as usize].get() {
-            StateMachineState::Ready => {
-                if self.txf_full(sm_number) {
-                    // TX queue is full, set interrupt
-                    let field = match sm_number {
-                        SMNumber::SM0 => IRQ0_INTE::SM0_TXNFULL::SET,
-                        SMNumber::SM1 => IRQ0_INTE::SM1_TXNFULL::SET,
-                        SMNumber::SM2 => IRQ0_INTE::SM2_TXNFULL::SET,
-                        SMNumber::SM3 => IRQ0_INTE::SM3_TXNFULL::SET,
-                    };
-                    self.registers.irq0_inte.modify(field);
-                    self.sm_state[sm_number as usize].set(StateMachineState::Waiting);
-                    Err(ErrorCode::BUSY)
-                } else {
-                    self.registers.txf[sm_number as usize].set(data);
-                    Ok(())
-                }
-            }
-            StateMachineState::Waiting => Err(ErrorCode::BUSY),
-        }
-    }
-
-    fn handle_tx_interrupt(&self, sm_number: SMNumber) {
-        match self.sm_state[sm_number as usize].get() {
-            StateMachineState::Waiting => {
-                // TX queue is full, set interrupt
-                let field = match sm_number {
-                    SMNumber::SM0 => IRQ0_INTE::SM0_TXNFULL::CLEAR,
-                    SMNumber::SM1 => IRQ0_INTE::SM1_TXNFULL::CLEAR,
-                    SMNumber::SM2 => IRQ0_INTE::SM2_TXNFULL::CLEAR,
-                    SMNumber::SM3 => IRQ0_INTE::SM3_TXNFULL::CLEAR,
-                };
-                self.registers.irq0_inte.modify(field);
-                self.sm_state[sm_number as usize].set(StateMachineState::Ready);
-                self.tx_clients[sm_number as usize].map(|client| {
-                    client.on_buffer_space_available();
-                });
-            }
-            StateMachineState::Ready => {}
-        }
-    }
-
     /// Handle interrupts
-    /// todo distinguish between irq0 and irq1
     pub fn handle_interrupt(&self) {
         let ints = &self.registers.irq0_ints;
-        for sm_number in [SMNumber::SM0, SMNumber::SM1, SMNumber::SM2, SMNumber::SM3].iter() {
-            if ints.is_set(match sm_number {
-                SMNumber::SM0 => IRQ0_INTS::SM0_TXNFULL,
-                SMNumber::SM1 => IRQ0_INTS::SM1_TXNFULL,
-                SMNumber::SM2 => IRQ0_INTS::SM2_TXNFULL,
-                SMNumber::SM3 => IRQ0_INTS::SM3_TXNFULL,
-            }) {
-                self.handle_tx_interrupt(*sm_number);
+        for (sm, irq) in self.sms.iter().zip([
+            IRQ0_INTS::SM0_TXNFULL,
+            IRQ0_INTS::SM1_TXNFULL,
+            IRQ0_INTS::SM2_TXNFULL,
+            IRQ0_INTS::SM3_TXNFULL,
+        ]) {
+            if ints.is_set(irq) {
+                sm.handle_tx_interrupt();
             }
         }
-    }
-
-    /// Wait until a state machine's TX FIFO is empty, then write a word of data to it.
-    pub fn sm_put_blocking(&self, sm_number: SMNumber, data: u32) {
-        while self.registers.fstat.read(FSTAT::TXFULL0) != 0 {}
-        self.registers.txf[sm_number as usize].set(data);
-    }
-
-    /// Restart a state machine.
-    pub fn restart_sm(&self, sm_number: SMNumber) {
-        match sm_number {
-            SMNumber::SM0 => self.set_registers.ctrl.modify(CTRL::SM0_RESTART::SET),
-            SMNumber::SM1 => self.set_registers.ctrl.modify(CTRL::SM1_RESTART::SET),
-            SMNumber::SM2 => self.set_registers.ctrl.modify(CTRL::SM2_RESTART::SET),
-            SMNumber::SM3 => self.set_registers.ctrl.modify(CTRL::SM3_RESTART::SET),
-        }
-    }
-
-    /// Clear a state machine’s TX and RX FIFOs.
-    pub fn sm_clear_fifos(&self, sm_number: SMNumber) {
-        self.xor_registers.sm[sm_number as usize]
-            .shiftctrl
-            .modify(SMx_SHIFTCTRL::FJOIN_RX::SET);
-        self.xor_registers.sm[sm_number as usize]
-            .shiftctrl
-            .modify(SMx_SHIFTCTRL::FJOIN_RX::SET);
-    }
-
-    /// Restart a state machine's clock divider.
-    pub fn sm_clkdiv_restart(&self, sm_number: SMNumber) {
-        match sm_number {
-            SMNumber::SM0 => self.set_registers.ctrl.modify(CTRL::CLKDIV0_RESTART::SET),
-            SMNumber::SM1 => self.set_registers.ctrl.modify(CTRL::CLKDIV1_RESTART::SET),
-            SMNumber::SM2 => self.set_registers.ctrl.modify(CTRL::CLKDIV2_RESTART::SET),
-            SMNumber::SM3 => self.set_registers.ctrl.modify(CTRL::CLKDIV3_RESTART::SET),
+        for (sm, irq) in self.sms.iter().zip([
+            IRQ0_INTS::SM0_RXNEMPTY,
+            IRQ0_INTS::SM1_RXNEMPTY,
+            IRQ0_INTS::SM2_RXNEMPTY,
+            IRQ0_INTS::SM3_RXNEMPTY,
+        ]) {
+            if ints.is_set(irq) {
+                sm.handle_rx_interrupt();
+            }
         }
     }
 
     /// Adds a program to PIO.
     /// Call this with add_program(include_bytes!("path_to_file")).
-    pub fn add_program(&self, program: &[u8]) {
-        self.clear_instr_registers();
-        let iter = program.chunks(2);
-        for (x, i) in iter.enumerate() {
-            if x == NUMBER_INSTR_MEMORY_LOCATIONS {
-                debug!("Maximum limit of instructions reached!");
-                break;
-            }
-            self.registers.instr_mem[x]
-                .instr_mem
-                .modify(INSTR_MEMx::INSTR_MEM.val((i[0] as u32) << 8 | (i[1] as u32)));
+    pub fn add_program(&self, origin: Option<u8>, program: &[u8]) -> Result<u8, ProgramError> {
+        let mut program_u16: [u16; NUMBER_INSTR_MEMORY_LOCATIONS / 2] =
+            [0; NUMBER_INSTR_MEMORY_LOCATIONS / 2];
+        for (i, chunk) in program.chunks(2).enumerate() {
+            program_u16[i] = ((chunk[0] as u16) << 8) | (chunk[1] as u16);
         }
+
+        self.add_program16(origin, &program_u16[0..program.len() / 2])
+    }
+
+    /// Adds a program to PIO.
+    /// Takes `&[u16]` as input, cause pio-asm operations are 16bit.
+    pub fn add_program16(&self, origin: Option<u8>, program: &[u16]) -> Result<u8, ProgramError> {
+        // if origin is not set, try naively to find an empty space
+        match origin {
+            Some(origin) => self
+                .try_load_program_at(origin as usize, program)
+                .map(|_| origin)
+                .map_err(|_| ProgramError::AddrInUse(origin)),
+            None => {
+                for origin in 0..NUMBER_INSTR_MEMORY_LOCATIONS {
+                    if self.try_load_program_at(origin, program).is_ok() {
+                        return Ok(origin as u8);
+                    }
+                }
+                Err(ProgramError::InsufficientSpace)
+            }
+        }
+    }
+
+    /// Try to load program at a specific origin, relocate operations if necessary.
+    fn try_load_program_at(&self, origin: usize, program: &[u16]) -> Result<(), ProgramError> {
+        // Relocate program
+        let program = RelocatedProgram::new(program.iter(), origin as u8);
+        let mut used_mask = 0;
+        for (i, instr) in program.enumerate() {
+            // wrapping around the end of program memory is valid
+            let addr = (i + origin) % 32;
+            let mask = 1 << addr;
+            if (self.instructions_used.get() | used_mask) & mask != 0 {
+                return Err(ProgramError::AddrInUse(addr as u8));
+            }
+            self.registers.instr_mem[addr]
+                .instr_mem
+                .modify(INSTR_MEMx::INSTR_MEM.val(instr as u32));
+            used_mask |= mask;
+        }
+        self.instructions_used
+            .set(self.instructions_used.get() | used_mask);
+        Ok(())
     }
 
     /// Clears all of a PIO instance's instruction memory.
@@ -1307,180 +1463,209 @@ impl Pio {
     /// Initialize a new PIO with the same default configuration for all four state machines.
     pub fn init(&self) {
         let default_config: StateMachineConfiguration = StateMachineConfiguration::default();
-        for state_machine in STATE_MACHINE_NUMBERS {
-            self.sm_config(state_machine, &default_config);
+        for state_machine in self.sms.iter() {
+            state_machine.config(&default_config);
+        }
+        self.clear_instr_registers()
+    }
+}
+
+mod examples {
+    use super::*;
+
+    impl RPGpio {
+        fn from_u32(value: u32) -> RPGpio {
+            match value {
+                0 => RPGpio::GPIO0,
+                1 => RPGpio::GPIO1,
+                2 => RPGpio::GPIO2,
+                3 => RPGpio::GPIO3,
+                4 => RPGpio::GPIO4,
+                5 => RPGpio::GPIO5,
+                6 => RPGpio::GPIO6,
+                7 => RPGpio::GPIO7,
+                8 => RPGpio::GPIO8,
+                9 => RPGpio::GPIO9,
+                10 => RPGpio::GPIO10,
+                11 => RPGpio::GPIO11,
+                12 => RPGpio::GPIO12,
+                13 => RPGpio::GPIO13,
+                14 => RPGpio::GPIO14,
+                15 => RPGpio::GPIO15,
+                16 => RPGpio::GPIO16,
+                17 => RPGpio::GPIO17,
+                18 => RPGpio::GPIO18,
+                19 => RPGpio::GPIO19,
+                20 => RPGpio::GPIO20,
+                21 => RPGpio::GPIO21,
+                22 => RPGpio::GPIO22,
+                23 => RPGpio::GPIO23,
+                24 => RPGpio::GPIO24,
+                25 => RPGpio::GPIO25,
+                26 => RPGpio::GPIO26,
+                27 => RPGpio::GPIO27,
+                28 => RPGpio::GPIO28,
+                29 => RPGpio::GPIO29,
+                _ => panic!(
+                    "Unknown value for GPIO pin: {} (should be from 0 to 29)",
+                    value
+                ),
+            }
         }
     }
 
-    // # Examples
-    /// Used for the examples in the pico explorer base main.rs file.
+    impl Pio {
+        // # Examples
+        /// Used for the examples in the pico explorer base main.rs file.
 
-    pub fn blinking_hello_program_init(
-        &mut self,
-        pio_number: PIONumber,
-        sm_number: SMNumber,
-        pin: u32,
-        config: &StateMachineConfiguration,
-    ) {
-        self.sm_config(sm_number, config);
-        self.pio_number = pio_number;
-        self.gpio_init(&RPGpioPin::new(RPGpio::from_u32(pin)));
-        self.sm_set_enabled(sm_number, false);
-        self.set_pins_out(sm_number, pin, 1, true);
-        self.set_set_pins(sm_number, pin, 1);
-        self.sm_init(sm_number);
-        self.sm_set_enabled(sm_number, true);
-    }
+        pub fn blinking_hello_program_init(
+            &self,
+            sm_number: SMNumber,
+            pin: u32,
+            config: &StateMachineConfiguration,
+        ) {
+            let sm = &self.sms[sm_number as usize];
+            sm.config(config);
+            self.gpio_init(&RPGpioPin::new(RPGpio::from_u32(pin)));
+            sm.set_enabled(false);
+            sm.set_pins_out(pin, 1, true);
+            sm.set_set_pins(pin, 1);
+            sm.init();
+            sm.set_enabled(true);
+        }
 
-    pub fn blink_program_init(
-        &mut self,
-        pio_number: PIONumber,
-        sm_number: SMNumber,
-        pin: u32,
-        config: &StateMachineConfiguration,
-    ) {
-        self.sm_config(sm_number, config);
-        self.pio_number = pio_number;
-        self.gpio_init(&RPGpioPin::new(RPGpio::from_u32(pin)));
-        self.sm_set_enabled(sm_number, false);
-        self.set_pins_out(sm_number, pin, 1, true);
-        self.set_set_pins(sm_number, pin, 1);
-        self.sm_init(sm_number);
-        self.sm_set_enabled(sm_number, true);
-    }
+        pub fn blink_program_init(
+            &self,
+            sm_number: SMNumber,
+            pin: u32,
+            config: &StateMachineConfiguration,
+        ) {
+            let sm = &self.sms[sm_number as usize];
+            sm.config(config);
+            self.gpio_init(&RPGpioPin::new(RPGpio::from_u32(pin)));
+            sm.set_enabled(false);
+            sm.set_pins_out(pin, 1, true);
+            sm.set_set_pins(pin, 1);
+            sm.init();
+            sm.set_enabled(true);
+        }
 
-    pub fn sideset_program_init(
-        &mut self,
-        pio_number: PIONumber,
-        sm_number: SMNumber,
-        pin: u32,
-        config: &StateMachineConfiguration,
-    ) {
-        self.sm_config(sm_number, config);
-        self.pio_number = pio_number;
-        self.gpio_init(&RPGpioPin::new(RPGpio::from_u32(pin)));
-        self.gpio_init(&RPGpioPin::new(RPGpio::GPIO7));
-        self.sm_set_enabled(sm_number, false);
-        self.set_pins_out(sm_number, pin, 1, true);
-        self.set_pins_out(sm_number, 7, 1, true);
-        self.set_set_pins(sm_number, pin, 1);
-        self.set_side_set_pins(sm_number, 7);
-        self.sm_init(sm_number);
-        self.sm_set_enabled(sm_number, true);
-    }
+        pub fn sideset_program_init(
+            &self,
+            sm_number: SMNumber,
+            pin: u32,
+            config: &StateMachineConfiguration,
+        ) {
+            let sm = &self.sms[sm_number as usize];
+            sm.config(config);
+            self.gpio_init(&RPGpioPin::new(RPGpio::from_u32(pin)));
+            self.gpio_init(&RPGpioPin::new(RPGpio::GPIO7));
+            sm.set_enabled(false);
+            sm.set_pins_out(pin, 1, true);
+            sm.set_pins_out(7, 1, true);
+            sm.set_set_pins(pin, 1);
+            sm.set_side_set_pins(7);
+            sm.init();
+            sm.set_enabled(true);
+        }
 
-    pub fn hello_program_init(
-        &mut self,
-        pio_number: PIONumber,
-        sm_number: SMNumber,
-        pin1: u32,
-        pin2: u32,
-        config: &StateMachineConfiguration,
-    ) {
-        // This is used to turn on specifically GPIOs 6 and 7 - LSB is for GPIO 0, next bit is for GPIO 1 etc.
-        let turn_on_gpio_6_7 = 0b11000000;
-        self.sm_config(sm_number, config);
-        self.pio_number = pio_number;
-        self.gpio_init(&RPGpioPin::new(RPGpio::from_u32(pin1)));
-        self.gpio_init(&RPGpioPin::new(RPGpio::from_u32(pin2)));
-        self.sm_set_enabled(sm_number, false);
-        self.set_pins_out(sm_number, pin1, 1, true);
-        self.set_pins_out(sm_number, pin2, 1, true);
-        self.sm_init(sm_number);
-        self.sm_set_enabled(sm_number, true);
-        self.sm_put_blocking(sm_number, turn_on_gpio_6_7);
-        self.sm_put_blocking(sm_number, 0);
-    }
+        pub fn hello_program_init(
+            &self,
+            sm_number: SMNumber,
+            pin1: u32,
+            pin2: u32,
+            config: &StateMachineConfiguration,
+        ) {
+            let sm = &self.sms[sm_number as usize];
+            // This is used to turn on specifically GPIOs 6 and 7 - LSB is for GPIO 0, next bit is for GPIO 1 etc.
+            let turn_on_gpio_6_7 = 0b11000000;
+            sm.config(config);
+            self.gpio_init(&RPGpioPin::new(RPGpio::from_u32(pin1)));
+            self.gpio_init(&RPGpioPin::new(RPGpio::from_u32(pin2)));
+            sm.set_enabled(false);
+            sm.set_pins_out(pin1, 1, true);
+            sm.set_pins_out(pin2, 1, true);
+            sm.init();
+            sm.set_enabled(true);
+            sm.put_blocking(turn_on_gpio_6_7);
+            sm.put_blocking(0);
+        }
 
-    pub fn pwm_program_init(
-        &mut self,
-        pio_number: PIONumber,
-        sm_number: SMNumber,
-        pin: u32,
-        pwm_period: u32,
-        config: &StateMachineConfiguration,
-    ) {
-        // "pull" command created by pioasm
-        let pull_command = 0x8080_u32;
-        // "out isr, 32" command created by pioasm
-        let out_isr_32_command = 0x60c0_u32;
-        self.sm_config(sm_number, config);
-        self.pio_number = pio_number;
-        self.gpio_init(&RPGpioPin::new(RPGpio::from_u32(pin)));
-        self.sm_set_enabled(sm_number, false);
-        self.set_pins_out(sm_number, pin, 1, true);
-        self.set_side_set_pins(sm_number, pin);
-        self.sm_init(sm_number);
-        self.sm_put_blocking(sm_number, pwm_period);
-        self.sm_exec(sm_number, pull_command);
-        self.sm_exec(sm_number, out_isr_32_command);
-        self.sm_set_enabled(sm_number, true);
-    }
+        pub fn pwm_program_init(
+            &self,
+            sm_number: SMNumber,
+            pin: u32,
+            pwm_period: u32,
+            config: &StateMachineConfiguration,
+        ) {
+            let sm = &self.sms[sm_number as usize];
+            // "pull" command created by pioasm
+            let pull_command = 0x8080_u32;
+            // "out isr, 32" command created by pioasm
+            let out_isr_32_command = 0x60c0_u32;
+            sm.config(config);
+            self.gpio_init(&RPGpioPin::new(RPGpio::from_u32(pin)));
+            sm.set_enabled(false);
+            sm.set_pins_out(pin, 1, true);
+            sm.set_side_set_pins(pin);
+            sm.init();
+            sm.put_blocking(pwm_period);
+            sm.exec(pull_command);
+            sm.exec(out_isr_32_command);
+            sm.set_enabled(true);
+        }
 
-    // # Debugging
-    /// Returns current instruction running on the state machine.
-    pub fn read_instr(&self, sm_number: SMNumber) -> u32 {
-        self.registers.sm[sm_number as usize]
-            .instr
-            .read(SMx_INSTR::INSTR)
-    }
-
-    pub fn read_sideset_reg(&self, sm_number: SMNumber) {
-        debug!(
-            "{}",
+        // # Debugging
+        /// Returns current instruction running on the state machine.
+        pub fn read_instr(&self, sm_number: SMNumber) -> u32 {
             self.registers.sm[sm_number as usize]
-                .pinctrl
-                .read(SMx_PINCTRL::SIDESET_COUNT)
-        );
-        debug!(
-            "{}",
-            self.registers.sm[sm_number as usize]
-                .execctrl
-                .read(SMx_EXECCTRL::SIDE_EN)
-        );
-        debug!(
-            "{}",
-            self.registers.sm[sm_number as usize]
-                .execctrl
-                .read(SMx_EXECCTRL::SIDE_PINDIR)
-        );
-        debug!(
-            "{}",
-            self.registers.sm[sm_number as usize]
-                .pinctrl
-                .read(SMx_PINCTRL::SIDESET_BASE)
-        );
-    }
+                .instr
+                .read(SMx_INSTR::INSTR)
+        }
 
-    pub fn read_txf(&self, sm_number: SMNumber) -> u32 {
-        self.registers.txf[sm_number as usize].read(TXFx::TXF)
-    }
+        pub fn read_sideset_reg(&self, sm_number: SMNumber) {
+            debug!(
+                "{}",
+                self.registers.sm[sm_number as usize]
+                    .pinctrl
+                    .read(SMx_PINCTRL::SIDESET_COUNT)
+            );
+            debug!(
+                "{}",
+                self.registers.sm[sm_number as usize]
+                    .execctrl
+                    .read(SMx_EXECCTRL::SIDE_EN)
+            );
+            debug!(
+                "{}",
+                self.registers.sm[sm_number as usize]
+                    .execctrl
+                    .read(SMx_EXECCTRL::SIDE_PINDIR)
+            );
+            debug!(
+                "{}",
+                self.registers.sm[sm_number as usize]
+                    .pinctrl
+                    .read(SMx_PINCTRL::SIDESET_BASE)
+            );
+        }
 
-    pub fn txf_full(&self, sm_number: SMNumber) -> bool {
-        let field = match sm_number {
-            SMNumber::SM0 => FSTAT::TXFULL0,
-            SMNumber::SM1 => FSTAT::TXFULL1,
-            SMNumber::SM2 => FSTAT::TXFULL2,
-            SMNumber::SM3 => FSTAT::TXFULL3,
-        };
-        self.registers.fstat.read(field) != 0
-    }
+        pub fn read_dbg_padout(&self) -> u32 {
+            self.registers.dbg_padout.read(DBG_PADOUT::DBG_PADOUT)
+        }
 
-    pub fn read_dbg_padout(&self) -> u32 {
-        self.registers.dbg_padout.read(DBG_PADOUT::DBG_PADOUT)
-    }
-
-    pub fn read_fdebug(&self, tx: bool, stall: bool) -> u32 {
-        if tx {
-            if stall {
-                self.registers.fdebug.read(FDEBUG::TXSTALL)
+        pub fn read_fdebug(&self, tx: bool, stall: bool) -> u32 {
+            if tx {
+                if stall {
+                    self.registers.fdebug.read(FDEBUG::TXSTALL)
+                } else {
+                    self.registers.fdebug.read(FDEBUG::TXOVER)
+                }
+            } else if stall {
+                self.registers.fdebug.read(FDEBUG::RXSTALL)
             } else {
-                self.registers.fdebug.read(FDEBUG::TXOVER)
+                self.registers.fdebug.read(FDEBUG::RXUNDER)
             }
-        } else if stall {
-            self.registers.fdebug.read(FDEBUG::RXSTALL)
-        } else {
-            self.registers.fdebug.read(FDEBUG::RXUNDER)
         }
     }
 }

--- a/chips/rp2040/src/pio.rs
+++ b/chips/rp2040/src/pio.rs
@@ -516,6 +516,7 @@ const PIO1_CLEAR_BASE: StaticRef<PioRegisters> =
     unsafe { StaticRef::new((PIO_1_BASE_ADDRESS + 0x3000) as *const PioRegisters) };
 
 /// Used to relocate program in the PIO memory.
+/// Given program, relocates JMP instruction by adding an offset
 pub struct RelocatedProgram<'a, I>
 where
     I: Iterator<Item = &'a u16>,
@@ -1399,6 +1400,9 @@ impl Pio {
 
     /// Adds a program to PIO.
     /// Call this with add_program(include_bytes!("path_to_file")).
+    /// => origin: the address in the PIO instruction memory to start the program at or None to find an empty space
+    /// => program: the program to load into the PIO
+    /// Returns the address in the PIO instruction memory where the program was loaded.
     pub fn add_program(&self, origin: Option<u8>, program: &[u8]) -> Result<u8, ProgramError> {
         let mut program_u16: [u16; NUMBER_INSTR_MEMORY_LOCATIONS / 2] =
             [0; NUMBER_INSTR_MEMORY_LOCATIONS / 2];
@@ -1411,6 +1415,9 @@ impl Pio {
 
     /// Adds a program to PIO.
     /// Takes `&[u16]` as input, cause pio-asm operations are 16bit.
+    /// => origin: the address in the PIO instruction memory to start the program at or None to find an empty space
+    /// => program: the program to load into the PIO
+    /// Returns the address in the PIO instruction memory where the program was loaded.
     pub fn add_program16(&self, origin: Option<u8>, program: &[u16]) -> Result<u8, ProgramError> {
         // if origin is not set, try naively to find an empty space
         match origin {

--- a/chips/rp2040/src/pio_pwm.rs
+++ b/chips/rp2040/src/pio_pwm.rs
@@ -72,15 +72,9 @@ impl<'a> hil::pwm::Pwm for PioPwm<'a> {
             let pwm_period = ((max_freq / frequency_hz) / 3) as u32;
             let sm_number = SMNumber::SM0;
             let duty_cycle = duty_cycle_percentage as u32;
-            pio.pwm_program_init(
-                sm_number,
-                pin_nr,
-                pwm_period,
-                &custom_config,
-            );
-            pio.sm(sm_number).put_blocking(
-                pwm_period * duty_cycle / (self.get_maximum_duty_cycle()) as u32,
-            );
+            pio.pwm_program_init(sm_number, pin_nr, pwm_period, &custom_config);
+            pio.sm(sm_number)
+                .put_blocking(pwm_period * duty_cycle / (self.get_maximum_duty_cycle()) as u32);
         });
 
         Ok(())

--- a/chips/rp2040/src/pio_pwm.rs
+++ b/chips/rp2040/src/pio_pwm.rs
@@ -7,7 +7,7 @@
 //! Programmable Input Output (PIO) hardware test file.
 use crate::clocks::{self};
 use crate::gpio::RPGpio;
-use crate::pio::{PIONumber, Pio, SMNumber, StateMachineConfiguration};
+use crate::pio::{Pio, SMNumber, StateMachineConfiguration};
 
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::{hil, ErrorCode};
@@ -58,7 +58,7 @@ impl<'a> hil::pwm::Pwm for PioPwm<'a> {
 
         self.pio.map(|pio| {
             pio.init();
-            pio.add_program(&path);
+            pio.add_program(Some(0), &path).ok();
             let mut custom_config = StateMachineConfiguration::default();
 
             let pin_nr = *pin as u32;
@@ -73,14 +73,12 @@ impl<'a> hil::pwm::Pwm for PioPwm<'a> {
             let sm_number = SMNumber::SM0;
             let duty_cycle = duty_cycle_percentage as u32;
             pio.pwm_program_init(
-                PIONumber::PIO0,
                 sm_number,
                 pin_nr,
                 pwm_period,
                 &custom_config,
             );
-            pio.sm_put_blocking(
-                sm_number,
+            pio.sm(sm_number).put_blocking(
                 pwm_period * duty_cycle / (self.get_maximum_duty_cycle()) as u32,
             );
         });

--- a/chips/rp2040/src/pio_pwm.rs
+++ b/chips/rp2040/src/pio_pwm.rs
@@ -74,7 +74,8 @@ impl<'a> hil::pwm::Pwm for PioPwm<'a> {
             let duty_cycle = duty_cycle_percentage as u32;
             pio.pwm_program_init(sm_number, pin_nr, pwm_period, &custom_config);
             pio.sm(sm_number)
-                .put_blocking(pwm_period * duty_cycle / (self.get_maximum_duty_cycle()) as u32);
+                .push_blocking(pwm_period * duty_cycle / (self.get_maximum_duty_cycle()) as u32)
+                .ok();
         });
 
         Ok(())


### PR DESCRIPTION
### Pull Request Overview

This is an implementation for tx/rx interrupts to avoid overpushing and overpulling data from PIO FIFOs. The StateMachines should be seperated from PIO, so as to show distinct SM states. 
Added support for multiple programs on PIO, with address relocation. 
Removed some unnecessary mutable borrows to stay with tock directions, however still some examples require redefining peripherals. 



### Testing Strategy

This PR does not modify significantly work on registers, however pio_pwm examples work without any problems on rp2040

### TODO or Help Wanted

I'm working on further PIO support and I think if examples should be included in `chips/rp2040/src/pio.rs`. Also there are more mutable borrows which conflicts with peripherals definition.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
