### PR TITLE
rp2040: pio: replace unnecessary OptionalCell

### DIFF
--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -699,8 +699,7 @@ pub unsafe fn start() -> (
 
     let mut pio: Pio = Pio::new_pio0();
 
-    let pio_pwm = PioPwm::new(&mut pio);
-    pio_pwm.set_clocks(&peripherals.clocks);
+    let _pio_pwm = PioPwm::new(&mut pio, &peripherals.clocks);
     // This will start a PWM with PIO with the set frequency and duty cycle on the specified pin.
     // pio_pwm
     //     .start(

--- a/chips/rp2040/src/pio_pwm.rs
+++ b/chips/rp2040/src/pio_pwm.rs
@@ -9,24 +9,20 @@ use crate::clocks::{self};
 use crate::gpio::RPGpio;
 use crate::pio::{PIONumber, Pio, SMNumber, StateMachineConfiguration};
 
-use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::utilities::cells::TakeCell;
 use kernel::{hil, ErrorCode};
 
 pub struct PioPwm<'a> {
-    clocks: OptionalCell<&'a clocks::Clocks>,
+    clocks: &'a clocks::Clocks,
     pio: TakeCell<'a, Pio>,
 }
 
 impl<'a> PioPwm<'a> {
-    pub fn new(pio: &'a mut Pio) -> Self {
+    pub fn new(pio: &'a mut Pio, clocks: &'a clocks::Clocks) -> Self {
         Self {
-            clocks: OptionalCell::empty(),
+            clocks,
             pio: TakeCell::new(pio),
         }
-    }
-
-    pub fn set_clocks(&self, clocks: &'a clocks::Clocks) {
-        self.clocks.set(clocks);
     }
 }
 
@@ -101,8 +97,6 @@ impl<'a> hil::pwm::Pwm for PioPwm<'a> {
     // For the rp2040, this will always return 125_000_000. Watch out as any value above
     // 1_000_000 is not precise and WILL give modified frequency and duty cycle values.
     fn get_maximum_frequency_hz(&self) -> usize {
-        self.clocks
-            .unwrap_or_panic()
-            .get_frequency(clocks::Clock::System) as usize
+        self.clocks.get_frequency(clocks::Clock::System) as usize
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull replaces the `OptionalCell` field in the rp2040 PWM driver with a `Cell` since the `clocks` should be available at construction time, and should never be `None`. This gets rid of a potential panic in the `get_maximum_frequency_hz` method.

### Testing Strategy

Compile tested


### TODO or Help Wanted

N/A

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
