### PR TITLE
Add 802154 support to the nrf52833 and microbit v2

### DIFF
--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -88,6 +88,8 @@ pub static mut STACK_MEMORY: [u8; 0x2000] = [0; 0x2000];
 type TemperatureDriver =
     components::temperature::TemperatureComponentType<nrf52::temperature::Temp<'static>>;
 type RngDriver = components::rng::RngComponentType<nrf52833::trng::Trng<'static>>;
+type Ieee802154RawDriver =
+    components::ieee802154::Ieee802154RawComponentType<nrf52833::ieee802154_radio::Radio<'static>>;
 
 /// Supported drivers by the platform
 pub struct MicroBit {
@@ -99,6 +101,8 @@ pub struct MicroBit {
             nrf52::rtc::Rtc<'static>,
         >,
     >,
+    eui64: &'static capsules_extra::eui64::Eui64,
+    ieee802154: &'static Ieee802154RawDriver,
     console: &'static capsules_core::console::Console<'static>,
     gpio: &'static capsules_core::gpio::GPIO<'static, nrf52::gpio::GPIOPin<'static>>,
     led: &'static capsules_core::led::LedDriver<
@@ -170,6 +174,8 @@ impl SyscallDriverLookup for MicroBit {
             capsules_extra::pwm::DRIVER_NUM => f(Some(self.pwm)),
             capsules_extra::app_flash_driver::DRIVER_NUM => f(Some(self.app_flash)),
             capsules_extra::sound_pressure::DRIVER_NUM => f(Some(self.sound_pressure)),
+            capsules_extra::eui64::DRIVER_NUM => f(Some(self.eui64)),
+            capsules_extra::ieee802154::DRIVER_NUM => f(Some(self.ieee802154)),
             kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
             _ => f(None),
         }
@@ -221,9 +227,14 @@ unsafe fn start() -> (
 ) {
     nrf52833::init();
 
+    let ieee802154_ack_buf = static_init!(
+        [u8; nrf52833::ieee802154_radio::ACK_BUF_SIZE],
+        [0; nrf52833::ieee802154_radio::ACK_BUF_SIZE]
+    );
+    // Initialize chip peripheral drivers
     let nrf52833_peripherals = static_init!(
         Nrf52833DefaultPeripherals,
-        Nrf52833DefaultPeripherals::new()
+        Nrf52833DefaultPeripherals::new(ieee802154_ack_buf)
     );
 
     // set up circular peripheral dependencies
@@ -233,6 +244,23 @@ unsafe fn start() -> (
 
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
 
+    //--------------------------------------------------------------------------
+    // RAW 802.15.4
+    //--------------------------------------------------------------------------
+
+    let device_id = nrf52833::ficr::FICR_INSTANCE.id();
+
+    let eui64 = components::eui64::Eui64Component::new(u64::from_le_bytes(device_id))
+        .finalize(components::eui64_component_static!());
+
+    let ieee802154 = components::ieee802154::Ieee802154RawComponent::new(
+        board_kernel,
+        capsules_extra::ieee802154::DRIVER_NUM,
+        &nrf52833_peripherals.ieee802154_radio,
+    )
+    .finalize(components::ieee802154_raw_component_static!(
+        nrf52833::ieee802154_radio::Radio,
+    ));
     //--------------------------------------------------------------------------
     // CAPABILITIES
     //--------------------------------------------------------------------------
@@ -712,6 +740,8 @@ unsafe fn start() -> (
 
     let microbit = MicroBit {
         ble_radio,
+        ieee802154,
+        eui64,
         console,
         gpio,
         button,

--- a/chips/nrf52/src/ieee802154_radio.rs
+++ b/chips/nrf52/src/ieee802154_radio.rs
@@ -74,7 +74,7 @@ use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite, Writ
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 
-use nrf52::constants::TxPower;
+use crate::constants::TxPower;
 
 const RADIO_BASE: StaticRef<RadioRegisters> =
     unsafe { StaticRef::new(0x40001000 as *const RadioRegisters) };
@@ -951,7 +951,7 @@ impl<'a> Radio<'a> {
 
                     // Ready event from Tx ramp up will be in radio internal
                     // TXIDLE state
-                    if self.registers.state.get() == nrf52::constants::RADIO_STATE_TXIDLE {
+                    if self.registers.state.get() == crate::constants::RADIO_STATE_TXIDLE {
                         start_task = true;
                     }
                 }
@@ -1126,10 +1126,10 @@ impl<'a> Radio<'a> {
             .write(CrcConfiguration::LEN::TWO + CrcConfiguration::SKIPADDR::IEEE802154);
         self.registers
             .crcinit
-            .set(nrf52::constants::RADIO_CRCINIT_IEEE802154);
+            .set(crate::constants::RADIO_CRCINIT_IEEE802154);
         self.registers
             .crcpoly
-            .set(nrf52::constants::RADIO_CRCPOLY_IEEE802154);
+            .set(crate::constants::RADIO_CRCPOLY_IEEE802154);
     }
 
     fn ieee802154_set_rampup_mode(&self) {
@@ -1140,10 +1140,10 @@ impl<'a> Radio<'a> {
 
     fn ieee802154_set_cca_config(&self) {
         self.registers.ccactrl.write(
-            CCAControl::CCAMODE.val(nrf52::constants::IEEE802154_CCA_MODE)
-                + CCAControl::CCAEDTHRESH.val(nrf52::constants::IEEE802154_CCA_ED_THRESH)
-                + CCAControl::CCACORRTHRESH.val(nrf52::constants::IEEE802154_CCA_CORR_THRESH)
-                + CCAControl::CCACORRCNT.val(nrf52::constants::IEEE802154_CCA_CORR_CNT),
+            CCAControl::CCAMODE.val(crate::constants::IEEE802154_CCA_MODE)
+                + CCAControl::CCAEDTHRESH.val(crate::constants::IEEE802154_CCA_ED_THRESH)
+                + CCAControl::CCACORRTHRESH.val(crate::constants::IEEE802154_CCA_CORR_THRESH)
+                + CCAControl::CCACORRCNT.val(crate::constants::IEEE802154_CCA_CORR_CNT),
         );
     }
 
@@ -1158,7 +1158,7 @@ impl<'a> Radio<'a> {
 
         self.registers
             .pcnf1
-            .write(PacketConfiguration1::MAXLEN.val(nrf52::constants::RADIO_PAYLOAD_LENGTH as u32));
+            .write(PacketConfiguration1::MAXLEN.val(crate::constants::RADIO_PAYLOAD_LENGTH as u32));
     }
 
     fn ieee802154_set_channel_rate(&self) {
@@ -1319,7 +1319,7 @@ impl<'a> kernel::hil::radio::RadioConfig<'a> for Radio<'a> {
 
     fn set_tx_power(&self, tx_power: i8) -> Result<(), ErrorCode> {
         // Convert u8 to TxPower
-        match nrf52::constants::TxPower::try_from(tx_power as u8) {
+        match crate::constants::TxPower::try_from(tx_power as u8) {
             // Invalid transmitting power, propagate error
             Err(()) => Err(ErrorCode::NOSUPPORT),
             // Valid transmitting power, propagate success

--- a/chips/nrf52/src/lib.rs
+++ b/chips/nrf52/src/lib.rs
@@ -15,6 +15,7 @@ pub mod clock;
 pub mod crt1;
 pub mod ficr;
 pub mod i2c;
+pub mod ieee802154_radio;
 pub mod nvmc;
 pub mod power;
 pub mod ppi;

--- a/chips/nrf52833/src/interrupt_service.rs
+++ b/chips/nrf52833/src/interrupt_service.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
+use kernel::hil::time::Alarm;
 use nrf52::chip::Nrf52DefaultPeripherals;
 
 /// This struct, when initialized, instantiates all peripheral drivers for the nrf52840.
@@ -10,17 +11,24 @@ use nrf52::chip::Nrf52DefaultPeripherals;
 /// constructed manually in main.rs.
 pub struct Nrf52833DefaultPeripherals<'a> {
     pub nrf52: Nrf52DefaultPeripherals<'a>,
+    pub ieee802154_radio: crate::ieee802154_radio::Radio<'a>,
     pub gpio_port: crate::gpio::Port<'a, { crate::gpio::NUM_PINS }>,
 }
 impl<'a> Nrf52833DefaultPeripherals<'a> {
-    pub unsafe fn new() -> Self {
+    pub unsafe fn new(
+        ieee802154_radio_ack_buf: &'static mut [u8; crate::ieee802154_radio::ACK_BUF_SIZE],
+    ) -> Self {
         Self {
             nrf52: Nrf52DefaultPeripherals::new(),
+            ieee802154_radio: crate::ieee802154_radio::Radio::new(ieee802154_radio_ack_buf),
             gpio_port: crate::gpio::nrf52833_gpio_create(),
         }
     }
     // Necessary for setting up circular dependencies
     pub fn init(&'static self) {
+        self.ieee802154_radio.set_timer_ref(&self.nrf52.timer0);
+        self.nrf52.timer0.set_alarm_client(&self.ieee802154_radio);
+        kernel::deferred_call::DeferredCallClient::register(&self.ieee802154_radio);
         self.nrf52.init();
     }
 }
@@ -28,6 +36,19 @@ impl<'a> kernel::platform::chip::InterruptService for Nrf52833DefaultPeripherals
     unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
             nrf52::peripheral_interrupts::GPIOTE => self.gpio_port.handle_interrupt(),
+            nrf52::peripheral_interrupts::RADIO => {
+                match (
+                    self.ieee802154_radio.is_enabled(),
+                    self.nrf52.ble_radio.is_enabled(),
+                ) {
+                    (false, false) => (),
+                    (true, false) => self.ieee802154_radio.handle_interrupt(),
+                    (false, true) => self.nrf52.ble_radio.handle_interrupt(),
+                    (true, true) => kernel::debug!(
+                        "nRF 802.15.4 and BLE radios cannot be simultaneously enabled!"
+                    ),
+                }
+            }
             _ => return self.nrf52.service_interrupt(interrupt),
         }
         true

--- a/chips/nrf52833/src/lib.rs
+++ b/chips/nrf52833/src/lib.rs
@@ -7,8 +7,8 @@
 // FIXME: Move ieee802154_radio to an nrf528xx crate so this can access it.
 
 pub use nrf52::{
-    acomp, adc, aes, ble_radio, chip, clock, constants, crt1, ficr, i2c, init, nvmc,
-    peripheral_interrupts as base_interrupts, pinmux, power, ppi, pwm, rtc, spi, temperature,
+    acomp, adc, aes, ble_radio, chip, clock, constants, crt1, ficr, i2c, ieee802154_radio, init,
+    nvmc, peripheral_interrupts as base_interrupts, pinmux, power, ppi, pwm, rtc, spi, temperature,
     timer, trng, uart, uicr,
 };
 pub mod gpio;

--- a/chips/nrf52840/src/lib.rs
+++ b/chips/nrf52840/src/lib.rs
@@ -4,16 +4,11 @@
 
 #![no_std]
 pub use nrf52::{
-    acomp, adc, aes, ble_radio, chip, clock, constants, crt1, ficr, i2c, init, nvmc,
-    peripheral_interrupts as base_interrupts, pinmux, power, ppi, pwm, rtc, spi, temperature,
+    acomp, adc, aes, ble_radio, chip, clock, constants, crt1, ficr, i2c, ieee802154_radio, init,
+    nvmc, peripheral_interrupts as base_interrupts, pinmux, power, ppi, pwm, rtc, spi, temperature,
     timer, trng, uart, uicr, usbd,
 };
 pub mod gpio;
 pub mod interrupt_service;
-
-// FIXME: We need a nrf528xx crate as well. The nrf52832 does NOT support 15.4,
-// but the nrf52833 and nrf52840 do support it. That's a more substantial
-// restructuring than belongs in the ACK-fix PR, however.
-pub mod ieee802154_radio;
 
 pub mod peripheral_interrupts;


### PR DESCRIPTION
### Pull Request Overview

This pull request ports the ieee802154 from the nrf52840 to the nrf52833 by sharing the implementation through the `nrf52` crate and integrating into the the nrf52833 crate. It also adds support in the microbit_v2 board.

### Testing Strategy

This pull request was tested by running both the `openthread_udp_rx` (which is actually slightly too big, but works) and `tests/ieee802154/radio_tx_raw` examples/tests from libtock-c. I didn't test with another board, so didn't confirm that packets are actually being sent/received over the air, but the apps otherwise work.

### TODO or Help Wanted

- [x] It would be nice to test with on a real network or another device

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
