### PR TITLE
boards: apollo3: Support loading signed applications

### DIFF
--- a/boards/apollo3/lora_things_plus/Cargo.toml
+++ b/boards/apollo3/lora_things_plus/Cargo.toml
@@ -20,6 +20,8 @@ capsules-core = { path = "../../../capsules/core" }
 capsules-extra = { path = "../../../capsules/extra" }
 capsules-system = { path = "../../../capsules/system" }
 
+tock-tbf = { path = "../../../libraries/tock-tbf" }
+
 [build-dependencies]
 tock_build_scripts = { path = "../../build_scripts" }
 

--- a/boards/components/src/storage_permissions/tbf_header.rs
+++ b/boards/components/src/storage_permissions/tbf_header.rs
@@ -12,10 +12,11 @@ use kernel::process::ProcessStandardDebug;
 
 #[macro_export]
 macro_rules! storage_permissions_tbf_header_component_static {
-    ($C:ty $(,)?) => {{
+    ($C:ty, $D:ty $(,)?) => {{
         kernel::static_buf!(
             capsules_system::storage_permissions::tbf_header::TbfHeaderStoragePermissions<
                 $C,
+                $D,
                 components::storage_permissions::tbf_header::AppStoreCapability
             >
         )

--- a/capsules/extra/src/atecc508a.rs
+++ b/capsules/extra/src/atecc508a.rs
@@ -1016,7 +1016,7 @@ impl<'a> I2CClient for Atecc508a<'a> {
             Operation::ShaEnd(run) => {
                 if status == Err(i2c::Error::DataNak) || status == Err(i2c::Error::AddressNak) {
                     // The device isn't ready yet, try again
-                    if run == 50 {
+                    if run == 500 {
                         self.op.set(Operation::Ready);
                         return;
                     }

--- a/capsules/extra/src/atecc508a.rs
+++ b/capsules/extra/src/atecc508a.rs
@@ -1296,6 +1296,11 @@ impl<'a> digest::DigestData<'a, 32> for Atecc508a<'a> {
         Ok(())
     }
 
+    /// This will reset the device to clear the data
+    ///
+    /// This is an async operation though, as it requires the I2C operation
+    /// to complete and the I2C callback to occur, but the `clear_data()`
+    /// definition is syncronous, so this can race.
     fn clear_data(&self) {
         (self.wakeup_device)();
 


### PR DESCRIPTION
### Pull Request Overview

If the "atecc508a" feature is enabled we can do application signature verification.

The application is signed like this

```shell
elf2tab -n sensor-receive --stack 2048 --app-heap 1024 --kernel-heap 1024 \
    --kernel-major 2 --kernel-minor 0 --minimum-footer-size 3000 \
    -o build/sensor-receive.tab \
    build/cortex-m0/cortex-m0.elf \
    build/cortex-m3/cortex-m3.elf \
    build/cortex-m4/cortex-m4.elf \
    build/cortex-m7/cortex-m7.elf \
    build/rv32imac/rv32imac.0x20040080.0x80002800.elf \
    build/rv32imac/rv32imac.0x403B0080.0x3FCC0000.elf \
    build/rv32imc/rv32imc.0x41000080.0x42008000.elf \
    build/rv32imc/rv32imc.0x00080080.0x40008000.elf \
    build/rv32imc/rv32imc.0x20030080.0x10005000.elf \
    build/rv32imc/rv32imc.0x20030880.0x10008000.elf \
    build/rv32imc/rv32imc.0x20032080.0x10008000.elf \
    build/rv32imc/rv32imc.0x20034080.0x10008000.elf \
    build/rv32imac/rv32imac.0x40430080.0x80004000.elf \
    build/rv32imac/rv32imac.0x40440080.0x80007000.elf \
    --ecdsa-nist-p256-private p256-private-key.p8 \
    --verbose
```

Which then generates the following log with debug prints enabled

```
Initialization complete. Entering main loop
Looking for process binary in flash=0x00040000-0x000D5FFF
Checking: Checking Some("sensor-receive") footer 0
Checking: Integrity region is 40000-50798; footers at 50798-60000
Checking: Current footer slice 50798-60000
ProcessCheck: @50798 found a len 68 footer: EcdsaNistP256
Checking: Found 0, checking
Checking: Check status for process sensor-receive, footer 0: Checking
Checking: check_done gave result Ok(Accept(None))
Loading: Check succeeded for process sensor-receive
Looking for process binary in flash=0x00060000-0x000D5FFF
Loading: process flash=0x00040000-0x0005FFFF ram=0x100082B8-0x1005FFFF
Loading: sensor-receive [0] flash=0x00040000-0x00060000 ram=0x1000A000-0x1000DFFF
Loading: Loaded process sensor-receive
```

### Testing Strategy

Loading a signed application, with this diff

```diff
diff --git a/boards/apollo3/lora_things_plus/Cargo.toml b/boards/apollo3/lora_things_plus/Cargo.toml
index dccb1e2f6..e1023f1de 100644
--- a/boards/apollo3/lora_things_plus/Cargo.toml
+++ b/boards/apollo3/lora_things_plus/Cargo.toml
@@ -29,7 +29,7 @@ tock_build_scripts = { path = "../../build_scripts" }
 workspace = true
 
 [features]
-default = []
+default = ["atecc508a"]
 
 # This feature enables support for the ATECC508A Cryptographic Co-Processor
 # Breakout. If you connect one of these
diff --git a/kernel/src/config.rs b/kernel/src/config.rs
index 043d0c045..a0dd44e9e 100644
--- a/kernel/src/config.rs
+++ b/kernel/src/config.rs
@@ -89,7 +89,7 @@ pub(crate) struct Config {
 /// Cargo features.
 pub(crate) const CONFIG: Config = Config {
     trace_syscalls: cfg!(feature = "trace_syscalls"),
-    debug_load_processes: cfg!(feature = "debug_load_processes"),
+    debug_load_processes: true,
     debug_panics: !cfg!(feature = "no_debug_panics"),
-    debug_process_credentials: cfg!(feature = "debug_process_credentials"),
+    debug_process_credentials: true,
 };
```

### TODO or Help Wanted

N/A

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
