### PR TITLE
Add support for DFRobot Rain Sensor

### DIFF
--- a/boards/apollo3/lora_things_plus/Cargo.toml
+++ b/boards/apollo3/lora_things_plus/Cargo.toml
@@ -47,3 +47,7 @@ atecc508a = []
 # If the sensor is attached via the I2C Qwiic connecter you should
 # enable this feature.
 chirp_i2c_moisture = []
+
+# This feature enables support for the DFRobot Rainfall Sensor.
+# https://wiki.dfrobot.com/SKU_SEN0575_Gravity_Rainfall_Sensor
+dfrobot_i2c_rainfall = []

--- a/boards/apollo3/lora_things_plus/Makefile
+++ b/boards/apollo3/lora_things_plus/Makefile
@@ -56,3 +56,8 @@ test-atecc508a:
 test-chirp_i2c_moisture:
 	$(Q)OBJCOPY=${OBJCOPY} PORT=$(PORT) $(CARGO) test $(NO_RUN) \
 	    --bin $(PLATFORM) --release --features chirp_i2c_moisture
+
+.PHONY: test-dfrobot_i2c_rainfall
+test-dfrobot_i2c_rainfall:
+	$(Q)OBJCOPY=${OBJCOPY} PORT=$(PORT) $(CARGO) test $(NO_RUN) \
+	    --bin $(PLATFORM) --release --features dfrobot_i2c_rainfall

--- a/boards/apollo3/lora_things_plus/src/main.rs
+++ b/boards/apollo3/lora_things_plus/src/main.rs
@@ -68,7 +68,7 @@ use {
     kernel::hil::rng::Rng,
 };
 
-#[cfg(feature = "chirp_i2c_moisture")]
+#[cfg(any(feature = "chirp_i2c_moisture", feature = "dfrobot_i2c_rainfall"))]
 use capsules_core::virtualizers::virtual_i2c::MuxI2C;
 
 /// Support routines for debugging I/O.
@@ -135,6 +135,13 @@ const LORA_GPIO_DRIVER_NUM: usize = capsules_core::driver::NUM::LoRaPhyGPIO as u
 type ChirpI2cMoistureType = components::chirp_i2c_moisture::ChirpI2cMoistureComponentType<
     capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, apollo3::iom::Iom<'static>>,
 >;
+type DFRobotRainFallType = components::dfrobot_rainfall_sensor::DFRobotRainFallSensorComponentType<
+    capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<
+        'static,
+        apollo3::stimer::STimer<'static>,
+    >,
+    capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, apollo3::iom::Iom<'static>>,
+>;
 type BME280Sensor = components::bme280::Bme280ComponentType<
     capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, apollo3::iom::Iom<'static>>,
 >;
@@ -177,6 +184,7 @@ struct LoRaThingsPlus {
     humidity: &'static HumidityDriver,
     air_quality: &'static capsules_extra::air_quality::AirQualitySensor<'static>,
     moisture: Option<&'static components::moisture::MoistureComponentType<ChirpI2cMoistureType>>,
+    rainfall: Option<&'static components::rainfall::RainFallComponentType<DFRobotRainFallType>>,
     rng: Option<
         &'static capsules_core::rng::RngDriver<
             'static,
@@ -295,6 +303,32 @@ unsafe fn setup_chirp_i2c_moisture(
     moisture
 }
 
+#[cfg(feature = "dfrobot_i2c_rainfall")]
+unsafe fn setup_dfrobot_i2c_rainfall(
+    board_kernel: &'static kernel::Kernel,
+    _memory_allocation_cap: &dyn capabilities::MemoryAllocationCapability,
+    mux_i2c: &'static MuxI2C<'static, apollo3::iom::Iom<'static>>,
+    mux_alarm: &'static MuxAlarm<'static, apollo3::stimer::STimer<'static>>,
+) -> &'static components::rainfall::RainFallComponentType<DFRobotRainFallType> {
+    let dfrobot_rainfall =
+        components::dfrobot_rainfall_sensor::DFRobotRainFallSensorComponent::new(
+            mux_i2c, 0x1D, mux_alarm,
+        )
+        .finalize(components::dfrobot_rainfall_sensor_component_static!(
+            apollo3::stimer::STimer<'static>,
+            apollo3::iom::Iom<'static>
+        ));
+
+    let rainfall = components::rainfall::RainFallComponent::new(
+        board_kernel,
+        capsules_extra::rainfall::DRIVER_NUM,
+        dfrobot_rainfall,
+    )
+    .finalize(components::rainfall_component_static!(DFRobotRainFallType));
+
+    rainfall
+}
+
 /// Mapping of integer syscalls to objects that implement syscalls.
 impl SyscallDriverLookup for LoRaThingsPlus {
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
@@ -324,6 +358,13 @@ impl SyscallDriverLookup for LoRaThingsPlus {
             capsules_extra::moisture::DRIVER_NUM => {
                 if let Some(moisture) = self.moisture {
                     f(Some(moisture))
+                } else {
+                    f(None)
+                }
+            }
+            capsules_extra::rainfall::DRIVER_NUM => {
+                if let Some(rainfall) = self.rainfall {
+                    f(Some(rainfall))
                 } else {
                     f(None)
                 }
@@ -539,6 +580,16 @@ unsafe fn setup() -> (
     ));
     #[cfg(not(feature = "chirp_i2c_moisture"))]
     let moisture = None;
+
+    #[cfg(feature = "dfrobot_i2c_rainfall")]
+    let rainfall = Some(setup_dfrobot_i2c_rainfall(
+        board_kernel,
+        &memory_allocation_cap,
+        mux_i2c,
+        mux_alarm,
+    ));
+    #[cfg(not(feature = "dfrobot_i2c_rainfall"))]
+    let rainfall = None;
 
     #[cfg(feature = "atecc508a")]
     let rng = Some(setup_atecc508a(
@@ -772,6 +823,7 @@ unsafe fn setup() -> (
             humidity,
             air_quality,
             moisture,
+            rainfall,
             rng,
             scheduler,
             systick,

--- a/boards/apollo3/lora_things_plus/src/main.rs
+++ b/boards/apollo3/lora_things_plus/src/main.rs
@@ -116,6 +116,13 @@ static mut BME280: Option<
 static mut CCS811: Option<&'static capsules_extra::ccs811::Ccs811<'static>> = None;
 #[cfg(feature = "atecc508a")]
 static mut ATECC508A: Option<&'static capsules_extra::atecc508a::Atecc508a<'static>> = None;
+#[cfg(feature = "chirp_i2c_moisture")]
+static mut CHIRP_I2C_MOISTURE: Option<
+    &'static capsules_extra::chirp_i2c_moisture::ChirpI2cMoisture<
+        'static,
+        capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, apollo3::iom::Iom<'static>>,
+    >,
+> = None;
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
@@ -276,6 +283,7 @@ unsafe fn setup_chirp_i2c_moisture(
         components::chirp_i2c_moisture::ChirpI2cMoistureComponent::new(mux_i2c, 0x20).finalize(
             components::chirp_i2c_moisture_component_static!(apollo3::iom::Iom<'static>),
         );
+    CHIRP_I2C_MOISTURE = Some(chirp_moisture);
 
     let moisture = components::moisture::MoistureComponent::new(
         board_kernel,

--- a/boards/apollo3/lora_things_plus/src/main.rs
+++ b/boards/apollo3/lora_things_plus/src/main.rs
@@ -116,24 +116,6 @@ static mut BME280: Option<
 static mut CCS811: Option<&'static capsules_extra::ccs811::Ccs811<'static>> = None;
 #[cfg(feature = "atecc508a")]
 static mut ATECC508A: Option<&'static capsules_extra::atecc508a::Atecc508a<'static>> = None;
-#[cfg(feature = "chirp_i2c_moisture")]
-static mut CHIRP_I2C_MOISTURE: Option<
-    &'static capsules_extra::chirp_i2c_moisture::ChirpI2cMoisture<
-        'static,
-        capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, apollo3::iom::Iom<'static>>,
-    >,
-> = None;
-#[cfg(feature = "dfrobot_i2c_rainfall")]
-static mut DFROBOT_I2C_RAINFALL: Option<
-    &'static capsules_extra::dfrobot_rainfall_sensor::DFRobotRainFall<
-        'static,
-        capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<
-            'static,
-            apollo3::stimer::STimer<'static>,
-        >,
-        capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, apollo3::iom::Iom<'static>>,
-    >,
-> = None;
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
@@ -302,7 +284,6 @@ unsafe fn setup_chirp_i2c_moisture(
         components::chirp_i2c_moisture::ChirpI2cMoistureComponent::new(mux_i2c, 0x20).finalize(
             components::chirp_i2c_moisture_component_static!(apollo3::iom::Iom<'static>),
         );
-    CHIRP_I2C_MOISTURE = Some(chirp_moisture);
 
     let moisture = components::moisture::MoistureComponent::new(
         board_kernel,
@@ -329,7 +310,6 @@ unsafe fn setup_dfrobot_i2c_rainfall(
             apollo3::stimer::STimer<'static>,
             apollo3::iom::Iom<'static>
         ));
-    DFROBOT_I2C_RAINFALL = Some(dfrobot_rainfall);
 
     let rainfall = components::rainfall::RainFallComponent::new(
         board_kernel,

--- a/boards/apollo3/lora_things_plus/src/main.rs
+++ b/boards/apollo3/lora_things_plus/src/main.rs
@@ -123,6 +123,17 @@ static mut CHIRP_I2C_MOISTURE: Option<
         capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, apollo3::iom::Iom<'static>>,
     >,
 > = None;
+#[cfg(feature = "dfrobot_i2c_rainfall")]
+static mut DFROBOT_I2C_RAINFALL: Option<
+    &'static capsules_extra::dfrobot_rainfall_sensor::DFRobotRainFall<
+        'static,
+        capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<
+            'static,
+            apollo3::stimer::STimer<'static>,
+        >,
+        capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, apollo3::iom::Iom<'static>>,
+    >,
+> = None;
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
@@ -318,6 +329,7 @@ unsafe fn setup_dfrobot_i2c_rainfall(
             apollo3::stimer::STimer<'static>,
             apollo3::iom::Iom<'static>
         ));
+    DFROBOT_I2C_RAINFALL = Some(dfrobot_rainfall);
 
     let rainfall = components::rainfall::RainFallComponent::new(
         board_kernel,

--- a/boards/apollo3/lora_things_plus/src/tests/environmental_sensors.rs
+++ b/boards/apollo3/lora_things_plus/src/tests/environmental_sensors.rs
@@ -11,14 +11,18 @@
 use crate::tests::run_kernel_op;
 #[cfg(feature = "chirp_i2c_moisture")]
 use crate::CHIRP_I2C_MOISTURE;
+#[cfg(feature = "dfrobot_i2c_rainfall")]
+use crate::DFROBOT_I2C_RAINFALL;
 use crate::{BME280, CCS811};
 use core::cell::Cell;
 use kernel::debug;
 #[cfg(feature = "chirp_i2c_moisture")]
 use kernel::hil::sensors::MoistureDriver;
+#[cfg(feature = "dfrobot_i2c_rainfall")]
+use kernel::hil::sensors::RainFallDriver;
 use kernel::hil::sensors::{
     AirQualityClient, AirQualityDriver, HumidityClient, HumidityDriver, MoistureClient,
-    TemperatureClient, TemperatureDriver,
+    RainFallClient, TemperatureClient, TemperatureDriver,
 };
 use kernel::ErrorCode;
 
@@ -28,6 +32,7 @@ struct SensorTestCallback {
     co2_done: Cell<bool>,
     tvoc_done: Cell<bool>,
     moisture_done: Cell<bool>,
+    rainfall_done: Cell<bool>,
     calibration_temp: Cell<Option<i32>>,
     calibration_humidity: Cell<Option<u32>>,
 }
@@ -42,6 +47,7 @@ impl<'a> SensorTestCallback {
             co2_done: Cell::new(false),
             tvoc_done: Cell::new(false),
             moisture_done: Cell::new(false),
+            rainfall_done: Cell::new(false),
             calibration_temp: Cell::new(None),
             calibration_humidity: Cell::new(None),
         }
@@ -85,6 +91,14 @@ impl<'a> MoistureClient for SensorTestCallback {
     }
 }
 
+impl<'a> RainFallClient for SensorTestCallback {
+    fn callback(&self, value: Result<usize, ErrorCode>) {
+        self.rainfall_done.set(true);
+
+        debug!("Rainfall in the last hour: {}mm", value.unwrap());
+    }
+}
+
 impl<'a> AirQualityClient for SensorTestCallback {
     fn environment_specified(&self, result: Result<(), ErrorCode>) {
         result.unwrap();
@@ -104,6 +118,29 @@ impl<'a> AirQualityClient for SensorTestCallback {
 }
 
 static CALLBACK: SensorTestCallback = SensorTestCallback::new();
+
+#[cfg(feature = "dfrobot_i2c_rainfall")]
+#[test_case]
+fn run_chirp_i2c_moisture() {
+    debug!("check run DFRobot Rainfall I2C Sensor... ");
+    run_kernel_op(100);
+
+    let dfrobot = unsafe { DFROBOT_I2C_RAINFALL.unwrap() };
+
+    // Make sure the device is ready for us.
+    run_kernel_op(1000);
+
+    RainFallDriver::set_client(dfrobot, &CALLBACK);
+    CALLBACK.reset();
+
+    dfrobot.read_rainfall(1).unwrap();
+
+    run_kernel_op(10_000);
+    assert_eq!(CALLBACK.rainfall_done.get(), true);
+
+    debug!("    [ok]");
+    run_kernel_op(100);
+}
 
 #[cfg(feature = "chirp_i2c_moisture")]
 #[test_case]

--- a/boards/apollo3/lora_things_plus/src/tests/environmental_sensors.rs
+++ b/boards/apollo3/lora_things_plus/src/tests/environmental_sensors.rs
@@ -9,9 +9,13 @@
 //! (https://www.sparkfun.com/products/14348).
 
 use crate::tests::run_kernel_op;
+#[cfg(feature = "chirp_i2c_moisture")]
+use crate::CHIRP_I2C_MOISTURE;
 use crate::{BME280, CCS811};
 use core::cell::Cell;
 use kernel::debug;
+#[cfg(feature = "chirp_i2c_moisture")]
+use kernel::hil::sensors::MoistureDriver;
 use kernel::hil::sensors::{
     AirQualityClient, AirQualityDriver, HumidityClient, HumidityDriver, MoistureClient,
     TemperatureClient, TemperatureDriver,
@@ -100,6 +104,29 @@ impl<'a> AirQualityClient for SensorTestCallback {
 }
 
 static CALLBACK: SensorTestCallback = SensorTestCallback::new();
+
+#[cfg(feature = "chirp_i2c_moisture")]
+#[test_case]
+fn run_chirp_i2c_moisture() {
+    debug!("check run Chirp I2C Moisture Sensor... ");
+    run_kernel_op(100);
+
+    let chirp = unsafe { CHIRP_I2C_MOISTURE.unwrap() };
+
+    // Make sure the device is ready for us.
+    run_kernel_op(1000);
+
+    MoistureDriver::set_client(chirp, &CALLBACK);
+    CALLBACK.reset();
+
+    chirp.read_moisture().unwrap();
+
+    run_kernel_op(10_000);
+    assert_eq!(CALLBACK.moisture_done.get(), true);
+
+    debug!("    [ok]");
+    run_kernel_op(100);
+}
 
 #[test_case]
 fn run_bme280_a_temperature() {

--- a/boards/components/src/dfrobot_rainfall_sensor.rs
+++ b/boards/components/src/dfrobot_rainfall_sensor.rs
@@ -1,0 +1,110 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! Components for the DFRobot Rainfall Sensor.
+//! <https://wiki.dfrobot.com/SKU_SEN0575_Gravity_Rainfall_Sensor>
+//!
+//! Usage
+//! -----
+//! ```rust
+//!     let dfrobot_rainfall =
+//!         components::dfrobot_rainfall_sensor::DFRobotRainFallSensorComponent::new(mux_i2c, 0x1D)
+//!             .finalize(components::dfrobot_rainfall_sensor_component_static!(
+//!                 apollo3::iom::Iom<'static>
+//!             ));
+//! ```
+
+use capsules_core::virtualizers::virtual_alarm::MuxAlarm;
+use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
+use capsules_core::virtualizers::virtual_i2c::{I2CDevice, MuxI2C};
+use capsules_extra::dfrobot_rainfall_sensor::{DFRobotRainFall, BUFFER_SIZE};
+use core::mem::MaybeUninit;
+use kernel::component::Component;
+use kernel::hil::i2c;
+use kernel::hil::time;
+use kernel::hil::time::Alarm;
+
+// Setup static space for the objects.
+#[macro_export]
+macro_rules! dfrobot_rainfall_sensor_component_static {
+    ($A:ty, $I:ty $(,)?) => {{
+        let i2c_device =
+            kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, $I>);
+        let i2c_buffer =
+            kernel::static_buf!([u8; capsules_extra::dfrobot_rainfall_sensor::BUFFER_SIZE]);
+        let dfrobot_rainfall_sensor = kernel::static_buf!(
+            capsules_extra::dfrobot_rainfall_sensor::DFRobotRainFall<
+                'static,
+                VirtualMuxAlarm<'static, $A>,
+                capsules_core::virtualizers::virtual_i2c::I2CDevice<$I>,
+            >
+        );
+        let alarm = kernel::static_buf!(
+            capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, $A>
+        );
+
+        (i2c_device, i2c_buffer, dfrobot_rainfall_sensor, alarm)
+    };};
+}
+
+pub type DFRobotRainFallSensorComponentType<A, I> =
+    capsules_extra::dfrobot_rainfall_sensor::DFRobotRainFall<'static, A, I>;
+
+pub struct DFRobotRainFallSensorComponent<
+    A: 'static + time::Alarm<'static>,
+    I: 'static + i2c::I2CMaster<'static>,
+> {
+    i2c_mux: &'static MuxI2C<'static, I>,
+    i2c_address: u8,
+    alarm_mux: &'static MuxAlarm<'static, A>,
+}
+
+impl<A: 'static + time::Alarm<'static>, I: 'static + i2c::I2CMaster<'static>>
+    DFRobotRainFallSensorComponent<A, I>
+{
+    pub fn new(
+        i2c: &'static MuxI2C<'static, I>,
+        i2c_address: u8,
+        alarm_mux: &'static MuxAlarm<'static, A>,
+    ) -> Self {
+        DFRobotRainFallSensorComponent {
+            i2c_mux: i2c,
+            i2c_address,
+            alarm_mux,
+        }
+    }
+}
+
+impl<A: 'static + time::Alarm<'static>, I: 'static + i2c::I2CMaster<'static>> Component
+    for DFRobotRainFallSensorComponent<A, I>
+{
+    type StaticInput = (
+        &'static mut MaybeUninit<I2CDevice<'static, I>>,
+        &'static mut MaybeUninit<[u8; BUFFER_SIZE]>,
+        &'static mut MaybeUninit<
+            DFRobotRainFall<'static, VirtualMuxAlarm<'static, A>, I2CDevice<'static, I>>,
+        >,
+        &'static mut MaybeUninit<VirtualMuxAlarm<'static, A>>,
+    );
+    type Output =
+        &'static DFRobotRainFall<'static, VirtualMuxAlarm<'static, A>, I2CDevice<'static, I>>;
+
+    fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        let dfrobot_rainfall_sensor_i2c = s.0.write(I2CDevice::new(self.i2c_mux, self.i2c_address));
+        let i2c_buffer = s.1.write([0; BUFFER_SIZE]);
+        let alarm = s.3.write(VirtualMuxAlarm::new(self.alarm_mux));
+        alarm.setup();
+
+        let dfrobot_rainfall_sensor = s.2.write(DFRobotRainFall::new(
+            dfrobot_rainfall_sensor_i2c,
+            i2c_buffer,
+            alarm,
+        ));
+
+        alarm.set_alarm_client(dfrobot_rainfall_sensor);
+        dfrobot_rainfall_sensor_i2c.set_client(dfrobot_rainfall_sensor);
+        dfrobot_rainfall_sensor.startup();
+        dfrobot_rainfall_sensor
+    }
+}

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -31,6 +31,7 @@ pub mod dac;
 pub mod date_time;
 pub mod debug_queue;
 pub mod debug_writer;
+pub mod dfrobot_rainfall_sensor;
 pub mod eui64;
 pub mod flash;
 pub mod fm25cl;

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -71,6 +71,7 @@ pub mod process_console;
 pub mod process_printer;
 pub mod proximity;
 pub mod pwm;
+pub mod rainfall;
 pub mod rf233;
 pub mod rng;
 pub mod sched;

--- a/boards/components/src/rainfall.rs
+++ b/boards/components/src/rainfall.rs
@@ -1,0 +1,69 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! Component for any rainfall sensor.
+//!
+//! Usage
+//! -----
+//! ```rust
+//!     let rainfall = components::rainfall::RainFallComponent::new(
+//!           board_kernel,
+//!           capsules_extra::rainfall::DRIVER_NUM,
+//!           dfrobot_rainfall,
+//!       )
+//!       .finalize(components::rainfall_component_static!(DFRobotRainFallType));
+//! ```
+
+use capsules_extra::rainfall::RainFallSensor;
+use core::mem::MaybeUninit;
+use kernel::capabilities;
+use kernel::component::Component;
+use kernel::create_capability;
+use kernel::hil;
+
+#[macro_export]
+macro_rules! rainfall_component_static {
+    ($H: ty $(,)?) => {{
+        kernel::static_buf!(capsules_extra::rainfall::RainFallSensor<'static, $H>)
+    };};
+}
+
+pub type RainFallComponentType<H> = capsules_extra::rainfall::RainFallSensor<'static, H>;
+
+pub struct RainFallComponent<T: 'static + hil::sensors::RainFallDriver<'static>> {
+    board_kernel: &'static kernel::Kernel,
+    driver_num: usize,
+    sensor: &'static T,
+}
+
+impl<T: 'static + hil::sensors::RainFallDriver<'static>> RainFallComponent<T> {
+    pub fn new(
+        board_kernel: &'static kernel::Kernel,
+        driver_num: usize,
+        sensor: &'static T,
+    ) -> RainFallComponent<T> {
+        RainFallComponent {
+            board_kernel,
+            driver_num,
+            sensor,
+        }
+    }
+}
+
+impl<T: 'static + hil::sensors::RainFallDriver<'static>> Component for RainFallComponent<T> {
+    type StaticInput = &'static mut MaybeUninit<RainFallSensor<'static, T>>;
+    type Output = &'static RainFallSensor<'static, T>;
+
+    fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+
+        let rainfall = s.write(RainFallSensor::new(
+            self.sensor,
+            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+        ));
+
+        hil::sensors::RainFallDriver::set_client(self.sensor, rainfall);
+        rainfall
+    }
+}

--- a/capsules/core/src/driver.rs
+++ b/capsules/core/src/driver.rs
@@ -69,6 +69,7 @@ pub enum NUM {
     Pressure              = 0x60008,
     Distance              = 0x60009,
     Moisture              = 0x6000A,
+    RainFall              = 0x6000B,
 
     // Sensor ICs
     Tsl2561               = 0x70000,

--- a/capsules/extra/README.md
+++ b/capsules/extra/README.md
@@ -130,6 +130,7 @@ These provide common and better abstractions for userspace.
 - **[Pressure](src/pressure.rs)**: Pressure sensors.
 - **[Proximity](src/proximity.rs)**: Proximity sensors.
 - **[PWM](src/pwm.rs)**: Pulse-width modulation support.
+- **[Rainfall](src/rainfall.rs)**: Query rainfall sensors.
 - **[Read Only State](src/read_only_state.rs)**: Read-only state sharing.
 - **[Screen](src/screen.rs)**: Displays and screens.
 - **[Screen Shared](src/screen_shared.rs)**: App-specific screen windows.

--- a/capsules/extra/README.md
+++ b/capsules/extra/README.md
@@ -25,6 +25,7 @@ These implement a driver to setup and read various physical sensors.
 - **[CCS811](src/ccs811.rs)**: VOC gas sensor.
 - **[Chirp I2C Moisture](src/chirp_i2c_moisture.rs)**: I2C moisture sensor
     from Chirp project.
+- **[DFRobot Rainfall Sensor](src/dfrobot_rainfall_sensor.rs)**: Rainfall sensor.
 - **[FXOS8700CQ](src/fxos8700cq.rs)**: Accelerometer and magnetometer.
 - **[HS3003](src/hs3003.rs)**: Temperature and humidity sensor.
 - **[HTS221](src/hts221.rs)**: Temperature and humidity sensor.

--- a/capsules/extra/src/dfrobot_rainfall_sensor.rs
+++ b/capsules/extra/src/dfrobot_rainfall_sensor.rs
@@ -171,7 +171,7 @@ impl<'a, A: Alarm<'a>, I: I2CDevice> I2CClient for DFRobotRainFall<'a, A, I> {
                         | (buffer[1] as u32) << 8
                         | (buffer[2] as u32) << 16
                         | (buffer[3] as u32) << 24)
-                        / 10000;
+                        / 10;
 
                     self.state.set(DeviceState::Normal);
                     self.buffer.replace(buffer);

--- a/capsules/extra/src/dfrobot_rainfall_sensor.rs
+++ b/capsules/extra/src/dfrobot_rainfall_sensor.rs
@@ -1,0 +1,207 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! DFRobot Gravity Rainfall sensor using the I2C bus.
+//!
+//! <https://wiki.dfrobot.com/SKU_SEN0575_Gravity_Rainfall_Sensor>
+//! <https://github.com/DFRobot/DFRobot_RainfallSensor/tree/master>
+//!
+
+use core::cell::Cell;
+use kernel::hil::i2c::{self, I2CClient, I2CDevice};
+use kernel::hil::sensors::{RainFallClient, RainFallDriver};
+use kernel::hil::time::{Alarm, AlarmClient, ConvertTicks};
+use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::ErrorCode;
+
+pub const BUFFER_SIZE: usize = 4;
+
+const PID_REGISTER: u8 = 0x00;
+const TIME_RAINFALL_REGISTER: u8 = 0x0C;
+const RAIN_HOUR_REGISTER: u8 = 0x26;
+
+#[derive(Clone, Copy, PartialEq)]
+enum DeviceState {
+    Identify,
+    Normal,
+    StartRainFall(usize),
+    ContinueRainFall,
+    FinalRainFall,
+    Broken,
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum Operation {
+    None,
+    RainFall,
+}
+
+pub struct DFRobotRainFall<'a, A: Alarm<'a>, I: I2CDevice> {
+    buffer: TakeCell<'static, [u8]>,
+    i2c: &'a I,
+    rainfall_client: OptionalCell<&'a dyn RainFallClient>,
+    state: Cell<DeviceState>,
+    op: Cell<Operation>,
+    alarm: &'a A,
+}
+
+impl<'a, A: Alarm<'a>, I: I2CDevice> DFRobotRainFall<'a, A, I> {
+    pub fn new(i2c: &'a I, buffer: &'static mut [u8], alarm: &'a A) -> Self {
+        DFRobotRainFall {
+            buffer: TakeCell::new(buffer),
+            i2c,
+            rainfall_client: OptionalCell::empty(),
+            state: Cell::new(DeviceState::Identify),
+            op: Cell::new(Operation::None),
+            alarm,
+        }
+    }
+
+    pub fn startup(&self) {
+        self.buffer.take().map(|buffer| {
+            if self.state.get() == DeviceState::Identify {
+                // Read the version register
+                buffer[0] = PID_REGISTER;
+                if let Err((_e, buf)) = self.i2c.write_read(buffer, 1, 4) {
+                    self.buffer.replace(buf);
+                }
+            } else {
+                self.buffer.replace(buffer);
+            }
+        });
+    }
+}
+
+impl<'a, A: Alarm<'a>, I: I2CDevice> RainFallDriver<'a> for DFRobotRainFall<'a, A, I> {
+    fn set_client(&self, client: &'a dyn RainFallClient) {
+        self.rainfall_client.set(client);
+    }
+
+    fn read_rainfall(&self, hours: usize) -> Result<(), ErrorCode> {
+        if self.state.get() == DeviceState::Broken {
+            return Err(ErrorCode::NOSUPPORT);
+        }
+
+        if self.state.get() != DeviceState::Normal {
+            return Err(ErrorCode::BUSY);
+        }
+
+        if self.op.get() != Operation::None {
+            return Err(ErrorCode::BUSY);
+        }
+
+        self.buffer.take().map_or(Err(ErrorCode::BUSY), |buffer| {
+            buffer[0] = RAIN_HOUR_REGISTER;
+            buffer[1] = hours as u8;
+
+            self.op.set(Operation::RainFall);
+            self.state.set(DeviceState::StartRainFall(hours));
+            if let Err((e, buf)) = self.i2c.write(buffer, 2) {
+                self.buffer.replace(buf);
+                return Err(e.into());
+            }
+
+            Ok(())
+        })
+    }
+}
+
+impl<'a, A: Alarm<'a>, I: I2CDevice> I2CClient for DFRobotRainFall<'a, A, I> {
+    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
+        if let Err(i2c_err) = status {
+            self.buffer.replace(buffer);
+
+            match self.op.get() {
+                Operation::None => (),
+                Operation::RainFall => {
+                    self.op.set(Operation::None);
+
+                    self.rainfall_client
+                        .map(|client| client.callback(Err(i2c_err.into())));
+                }
+            }
+
+            return;
+        }
+
+        match self.state.get() {
+            DeviceState::Identify => {
+                let pid =
+                    buffer[0] as u32 | (buffer[1] as u32) << 8 | ((buffer[3] as u32) & 0xC0) << 10;
+                let vid = buffer[2] as u16 | ((buffer[3] as u16) & 0x3F) << 8;
+
+                if vid != 0x3343 || pid != 0x100C0 {
+                    self.buffer.replace(buffer);
+                    self.state.set(DeviceState::Broken);
+                    self.op.set(Operation::None);
+                    return;
+                }
+
+                self.buffer.replace(buffer);
+                self.state.set(DeviceState::Normal);
+                self.op.set(Operation::None);
+            }
+            DeviceState::StartRainFall(_hours) => match self.op.get() {
+                Operation::None => (),
+                Operation::RainFall => {
+                    self.state.set(DeviceState::ContinueRainFall);
+                    buffer[0] = TIME_RAINFALL_REGISTER;
+                    if let Err((e, buf)) = self.i2c.write(buffer, 1) {
+                        self.buffer.replace(buf);
+                        self.op.set(Operation::None);
+
+                        self.rainfall_client
+                            .map(|client| client.callback(Err(e.into())));
+                    }
+                }
+            },
+            DeviceState::ContinueRainFall => match self.op.get() {
+                Operation::None => (),
+                Operation::RainFall => {
+                    self.buffer.replace(buffer);
+                    let delay = self.alarm.ticks_from_us(6400);
+                    self.alarm.set_alarm(self.alarm.now(), delay);
+                }
+            },
+            DeviceState::FinalRainFall => match self.op.get() {
+                Operation::None => (),
+                Operation::RainFall => {
+                    let rainfall = (buffer[0] as u32
+                        | (buffer[1] as u32) << 8
+                        | (buffer[2] as u32) << 16
+                        | (buffer[3] as u32) << 24)
+                        / 10000;
+
+                    self.state.set(DeviceState::Normal);
+                    self.buffer.replace(buffer);
+                    self.op.set(Operation::None);
+
+                    self.rainfall_client
+                        .map(|client| client.callback(Ok(rainfall as usize)));
+                }
+            },
+            DeviceState::Normal | DeviceState::Broken => {}
+        }
+    }
+}
+
+impl<'a, A: Alarm<'a>, I: I2CDevice> AlarmClient for DFRobotRainFall<'a, A, I> {
+    fn alarm(&self) {
+        match self.op.get() {
+            Operation::None => (),
+            Operation::RainFall => {
+                self.state.set(DeviceState::FinalRainFall);
+                self.buffer.take().map(|buffer| {
+                    if let Err((e, buf)) = self.i2c.read(buffer, 4) {
+                        self.buffer.replace(buf);
+                        self.op.set(Operation::None);
+
+                        self.rainfall_client
+                            .map(|client| client.callback(Err(e.into())));
+                    }
+                });
+            }
+        }
+    }
+}

--- a/capsules/extra/src/lib.rs
+++ b/capsules/extra/src/lib.rs
@@ -78,6 +78,7 @@ pub mod pressure;
 pub mod proximity;
 pub mod public_key_crypto;
 pub mod pwm;
+pub mod rainfall;
 pub mod read_only_state;
 pub mod rf233;
 pub mod rf233_const;

--- a/capsules/extra/src/lib.rs
+++ b/capsules/extra/src/lib.rs
@@ -35,6 +35,7 @@ pub mod cycle_count;
 pub mod dac;
 pub mod date_time;
 pub mod debug_process_restart;
+pub mod dfrobot_rainfall_sensor;
 pub mod distance;
 pub mod eui64;
 pub mod fm25cl;

--- a/capsules/extra/src/rainfall.rs
+++ b/capsules/extra/src/rainfall.rs
@@ -1,0 +1,158 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! Provides userspace with access to rain fall sensors.
+//!
+//! Userspace Interface
+//! -------------------
+//!
+//! ### `subscribe` System Call
+//!
+//! The `subscribe` system call supports the single `subscribe_number` zero,
+//! which is used to provide a callback that will return back the result of
+//! a rain fall reading.
+//!
+//! ### `command` System Call
+//!
+//! The `command` system call support one argument `cmd` which is used to specify the specific
+//! operation, currently the following cmd's are supported:
+//!
+//! * `0`: check whether the driver exists
+//! * `1`: read rainfall
+//!
+//!
+//! The possible return from the 'command' system call indicates the following:
+//!
+//! * `Ok(())`:    The operation has been successful.
+//! * `NOSUPPORT`: Invalid `cmd`.
+//! * `NOMEM`:     Insufficient memory available.
+//! * `INVAL`:     Invalid address of the buffer or other error.
+//!
+//! Usage
+//! -----
+//!
+//! You need a device that provides the `hil::sensors::RainFallDriver` trait.
+
+use core::cell::Cell;
+
+use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
+use kernel::hil;
+use kernel::syscall::{CommandReturn, SyscallDriver};
+use kernel::{ErrorCode, ProcessId};
+
+/// Syscall driver number.
+use capsules_core::driver;
+pub const DRIVER_NUM: usize = driver::NUM::RainFall as usize;
+
+#[derive(Clone, Copy, PartialEq)]
+enum RainFallCommand {
+    ReadRainFall,
+}
+
+#[derive(Default)]
+pub struct App {
+    subscribed: bool,
+}
+
+pub struct RainFallSensor<'a, H: hil::sensors::RainFallDriver<'a>> {
+    driver: &'a H,
+    apps: Grant<App, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
+    busy: Cell<bool>,
+}
+
+impl<'a, H: hil::sensors::RainFallDriver<'a>> RainFallSensor<'a, H> {
+    pub fn new(
+        driver: &'a H,
+        grant: Grant<App, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
+    ) -> RainFallSensor<'a, H> {
+        RainFallSensor {
+            driver,
+            apps: grant,
+            busy: Cell::new(false),
+        }
+    }
+
+    fn enqueue_command(
+        &self,
+        command: RainFallCommand,
+        arg1: usize,
+        processid: ProcessId,
+    ) -> CommandReturn {
+        self.apps
+            .enter(processid, |app, _| {
+                app.subscribed = true;
+
+                if !self.busy.get() {
+                    self.busy.set(true);
+                    self.call_driver(command, arg1)
+                } else {
+                    CommandReturn::success()
+                }
+            })
+            .unwrap_or_else(|err| CommandReturn::failure(err.into()))
+    }
+
+    fn call_driver(&self, command: RainFallCommand, hours: usize) -> CommandReturn {
+        match command {
+            RainFallCommand::ReadRainFall => {
+                let ret = self.driver.read_rainfall(hours);
+                if ret.is_err() {
+                    self.busy.set(false);
+                }
+                ret.into()
+            }
+        }
+    }
+}
+
+impl<'a, H: hil::sensors::RainFallDriver<'a>> hil::sensors::RainFallClient
+    for RainFallSensor<'a, H>
+{
+    fn callback(&self, value: Result<usize, ErrorCode>) {
+        self.busy.set(false);
+
+        for cntr in self.apps.iter() {
+            cntr.enter(|app, upcalls| {
+                if app.subscribed {
+                    app.subscribed = false;
+                    match value {
+                        Ok(rainfall_val) => upcalls
+                            .schedule_upcall(
+                                0,
+                                (kernel::errorcode::into_statuscode(Ok(())), rainfall_val, 0),
+                            )
+                            .ok(),
+                        Err(e) => upcalls
+                            .schedule_upcall(0, (kernel::errorcode::into_statuscode(Err(e)), 0, 0))
+                            .ok(),
+                    };
+                }
+            });
+        }
+    }
+}
+
+impl<'a, H: hil::sensors::RainFallDriver<'a>> SyscallDriver for RainFallSensor<'a, H> {
+    fn command(
+        &self,
+        command_num: usize,
+        arg1: usize,
+        _: usize,
+        processid: ProcessId,
+    ) -> CommandReturn {
+        match command_num {
+            // driver existence check
+            0 => CommandReturn::success(),
+
+            // single rainfall measurement
+            1 => self.enqueue_command(RainFallCommand::ReadRainFall, arg1, processid),
+
+            _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
+        }
+    }
+
+    fn allocate_grant(&self, processid: ProcessId) -> Result<(), kernel::process::Error> {
+        self.apps.enter(processid, |_, _| {})
+    }
+}

--- a/kernel/src/hil/sensors.rs
+++ b/kernel/src/hil/sensors.rs
@@ -311,7 +311,7 @@ pub trait RainFallDriver<'a> {
 pub trait RainFallClient {
     /// Called when a moisture reading has completed.
     ///
-    /// - `value`: the number of mm of rain in the time period specified,
+    /// - `value`: the number of um of rain in the time period specified,
     /// or Err on failure.
     ///
     /// This function might return the following errors:

--- a/kernel/src/hil/sensors.rs
+++ b/kernel/src/hil/sensors.rs
@@ -289,3 +289,34 @@ pub trait DistanceClient {
     ///                If there was an error, this will be `Err(ErrorCode)`.
     fn callback(&self, distance: Result<u32, ErrorCode>);
 }
+
+/// A basic interface for a rain fall sensor
+pub trait RainFallDriver<'a> {
+    fn set_client(&self, client: &'a dyn RainFallClient);
+
+    /// Read the rain fall value from a sensor. The value is returned
+    /// via the `RainFallClient` callback.
+    ///
+    /// - `hours`: the number of hours of rainfall to report. 1 to 24
+    /// hours are valid values (if supported by the hardware).
+    ///
+    /// This function might return the following errors:
+    /// - `BUSY`: Indicates that the hardware is busy with an existing
+    ///           operation or initialisation/calibration.
+    /// - `NOSUPPORT`: Indicates that the value of `hours` is not supported.
+    fn read_rainfall(&self, hours: usize) -> Result<(), ErrorCode>;
+}
+
+/// Client for receiving moisture readings.
+pub trait RainFallClient {
+    /// Called when a moisture reading has completed.
+    ///
+    /// - `value`: the number of mm of rain in the time period specified,
+    /// or Err on failure.
+    ///
+    /// This function might return the following errors:
+    /// - `BUSY`: Indicates that the hardware is busy with an existing
+    ///           operation or initialisation/calibration.
+    /// - `NOSUPPORT`: Indicates that the value of `hours` is not supported.
+    fn callback(&self, value: Result<usize, ErrorCode>);
+}


### PR DESCRIPTION
### Pull Request Overview

This adds support for a rainfall sensor HIL and capsule to allow collecting rainfall information.

On top of that it adds support for the [DFRobot rain sensor](https://wiki.dfrobot.com/SKU_SEN0575_Gravity_Rainfall_Sensor)

### Testing Strategy

Collecting data from the DFRobot rainfall sensor

### TODO or Help Wanted

N/A

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
