### PR TITLE
Enhance SiFive PLIC support

### DIFF
--- a/chips/sifive/src/plic.rs
+++ b/chips/sifive/src/plic.rs
@@ -18,6 +18,8 @@ use kernel::utilities::StaticRef;
 ///    https://github.com/riscv/riscv-plic-spec/blob/master/riscv-plic.adoc
 ///    is defining maximum of 1023 interrupt sources
 
+// TODO: replace with const generic for `priority` and `_reserved1` field
+// in the [PlicRegisters] when const generic expressions are stable
 const MAX_INTERRUPTS: usize = 1023;
 /// maximum number of bit-coded registers, 1 bit per interrupt
 const MAX_BIT_REGS: usize = MAX_INTERRUPTS.div_ceil(32);

--- a/chips/sifive/src/plic.rs
+++ b/chips/sifive/src/plic.rs
@@ -10,6 +10,10 @@ use kernel::utilities::registers::LocalRegisterCopy;
 use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite};
 use kernel::utilities::StaticRef;
 
+/// Place the register map definition in a private module to disallow direct access to it's
+/// fields from the Plic struct implementation, which should only use a getter/setter with
+/// appropriate bounds set
+
 ///    The generic SiFive PLIC specification:
 ///    https://github.com/riscv/riscv-plic-spec/blob/master/riscv-plic.adoc
 ///    is defining maximum of 1023 interrupt sources
@@ -17,12 +21,10 @@ use kernel::utilities::StaticRef;
 const MAX_INTERRUPTS: usize = 1023;
 /// maximum number of bit-coded registers, 1 bit per interrupt
 const MAX_BIT_REGS: usize = MAX_INTERRUPTS.div_ceil(32);
-
 /// PLIC registers for *machine mode* context only at this time.
 /// The spec defines extra sets of registers for additional contexts,
 /// that is supervisor, user and other modes, but these aren't supported
 /// by the current code.
-
 #[repr(C)]
 pub struct PlicRegisters {
     /// Interrupt Priority Register
@@ -48,6 +50,49 @@ const _: () = assert!(core::mem::offset_of!(PlicRegisters, enable) == 0x2000);
 const _: () = assert!(core::mem::offset_of!(PlicRegisters, threshold) == 0x20_0000);
 const _: () = assert!(core::mem::offset_of!(PlicRegisters, claim) == 0x20_0004);
 
+/// A wrapper around the PLIC registers to provide safe access to the registers
+/// within the defined interrupt number range
+struct RegsWrapper {
+    registers: StaticRef<PlicRegisters>,
+    total_ints: usize,
+}
+
+impl RegsWrapper {
+    const fn new(registers: StaticRef<PlicRegisters>, total_ints: usize) -> Self {
+        Self {
+            registers,
+            total_ints,
+        }
+    }
+
+    fn enable(&self) -> &[ReadWrite<u32>] {
+        // One bit per interrupt, total number of registers is
+        // the number of interrupts divided by 32 rounded up
+        &self.registers.enable[0..self.total_ints.div_ceil(32)]
+    }
+
+    // Unused by the current code
+    #[allow(dead_code)]
+    fn pending(&self) -> &[ReadOnly<u32>] {
+        // One bit per interrupt, total number of registers is
+        // the number of interrupts divided by 32 rounded up
+        &self.registers.pending[0..self.total_ints.div_ceil(32)]
+    }
+
+    fn priority(&self) -> &[ReadWrite<u32, priority::Register>] {
+        // One 32-bit register per interrupt source
+        &self.registers.priority[0..self.total_ints]
+    }
+
+    fn threshold(&self) -> &ReadWrite<u32, priority::Register> {
+        &self.registers.threshold
+    }
+
+    fn claim(&self) -> &ReadWrite<u32> {
+        &self.registers.claim
+    }
+}
+
 register_bitfields![u32,
     priority [
         Priority OFFSET(0) NUMBITS(3) []
@@ -58,14 +103,14 @@ register_bitfields![u32,
 /// implemented on the specific chip. 51 is a default for backwards compatibility with the SiFive
 /// based platforms implemented without the generic parameter.
 pub struct Plic<const TOTAL_INTS: usize = 51> {
-    registers: StaticRef<PlicRegisters>,
+    registers: RegsWrapper,
     saved: [VolatileCell<LocalRegisterCopy<u32>>; 2],
 }
 
 impl<const TOTAL_INTS: usize> Plic<TOTAL_INTS> {
     pub const fn new(base: StaticRef<PlicRegisters>) -> Self {
         Plic {
-            registers: base,
+            registers: RegsWrapper::new(base, TOTAL_INTS),
             saved: [
                 VolatileCell::new(LocalRegisterCopy::new(0)),
                 VolatileCell::new(LocalRegisterCopy::new(0)),
@@ -78,22 +123,19 @@ impl<const TOTAL_INTS: usize> Plic<TOTAL_INTS> {
     /// Note that this function will only clear the enabled interrupt sources, as only those can be claimed.
     /// [`PLIC specification`]: https://github.com/riscv/riscv-plic-spec/blob/master/riscv-plic.adoc
     pub fn clear_all_pending(&self) {
-        let regs = self.registers;
-
         loop {
-            let id = regs.claim.get();
+            let id = self.registers.claim().get();
             if id == 0 {
                 break;
             }
-            regs.claim.set(id);
+            self.registers.claim().set(id);
         }
     }
 
     /// Enable a list of interrupt IDs. The IDs must be in the range 1..TOTAL_INTS.
     pub fn enable_specific_interrupts(&self, interrupts: &[u32]) {
+        let enable_regs = self.registers.enable();
         for interrupt in interrupts {
-            let enable_regs = &self.registers.enable[0..TOTAL_INTS.div_ceil(32)];
-            let priority_regs = &self.registers.priority[0..TOTAL_INTS];
             let offset = interrupt / 32;
             let irq = interrupt % 32;
             let old_value = enable_regs[offset as usize].get();
@@ -103,14 +145,14 @@ impl<const TOTAL_INTS: usize> Plic<TOTAL_INTS> {
             // at this point.
             // The priority registers indexed 0 for interrupt 1, 1 for interrupt 2, etc.
             // so we subtract 1 from the interrupt number to get the correct index.
-            priority_regs[*interrupt as usize - 1].write(priority::Priority.val(4));
+            self.registers.priority()[*interrupt as usize - 1].write(priority::Priority.val(4));
         }
         // Accept all interrupts.
-        self.registers.threshold.write(priority::Priority.val(0));
+        self.registers.threshold().write(priority::Priority.val(0));
     }
 
     pub fn disable_specific_interrupts(&self, interrupts: &[u32]) {
-        let enable_regs = &self.registers.enable[0..TOTAL_INTS.div_ceil(32)];
+        let enable_regs = self.registers.enable();
         for interrupt in interrupts {
             let offset = interrupt / 32;
             let irq = interrupt % 32;
@@ -121,8 +163,8 @@ impl<const TOTAL_INTS: usize> Plic<TOTAL_INTS> {
 
     /// Enable all interrupts.
     pub fn enable_all(&self) {
-        let enable_regs = &self.registers.enable[0..TOTAL_INTS.div_ceil(32)];
-        let priority_regs = &self.registers.priority[0..TOTAL_INTS];
+        let enable_regs = self.registers.enable();
+        let priority_regs = &self.registers.priority();
 
         for enable in enable_regs.iter() {
             enable.set(0xFFFF_FFFF);
@@ -135,12 +177,12 @@ impl<const TOTAL_INTS: usize> Plic<TOTAL_INTS> {
         }
 
         // Accept all interrupts.
-        self.registers.threshold.write(priority::Priority.val(0));
+        self.registers.threshold().write(priority::Priority.val(0));
     }
 
     /// Disable all interrupts.
     pub fn disable_all(&self) {
-        let enable_regs = &self.registers.enable[0..TOTAL_INTS.div_ceil(32)];
+        let enable_regs = self.registers.enable();
 
         for enable in enable_regs.iter() {
             enable.set(0);
@@ -151,7 +193,7 @@ impl<const TOTAL_INTS: usize> Plic<TOTAL_INTS> {
     /// none is pending. RISC-V PLIC has a "claim" register which makes it easy
     /// to grab the highest priority pending interrupt.
     pub fn next_pending(&self) -> Option<u32> {
-        let claim = self.registers.claim.get();
+        let claim = self.registers.claim().get();
         if claim == 0 {
             None
         } else {
@@ -193,7 +235,7 @@ impl<const TOTAL_INTS: usize> Plic<TOTAL_INTS> {
     /// called from the normal main loop (not the interrupt handler).
     /// Interrupts must be disabled before this is called.
     pub unsafe fn complete(&self, index: u32) {
-        self.registers.claim.set(index);
+        self.registers.claim().set(index);
 
         let offset = usize::from(index >= 32);
         let irq = index % 32;
@@ -209,6 +251,6 @@ impl<const TOTAL_INTS: usize> Plic<TOTAL_INTS> {
     /// some platforms have added more bits to the `mtvec` register.
     pub fn suppress_all(&self) {
         // Accept all interrupts.
-        self.registers.threshold.write(priority::Priority.val(0));
+        self.registers.threshold().write(priority::Priority.val(0));
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request enhances the SiFive PLIC support. The current implementation has the following limitations:
1) The number of interrupt sources is hardcoded to be 51, while the [generic SiFive PLIC specification ](https://github.com/riscv/riscv-plic-spec/blob/master/riscv-plic.adoc)has a limit of 1023.
2) The current implementation is only allows enabling/disabling *all* of the interrupt sources, which is both inefficient and also introducing starving in case a higher priority interrupt cannot be cleared (as in if a switch wired to a same/higher priority interrupt is not switched back, it will always be pending and not allowing other interrupts to be served).

The proposed change is to address the above limitations:
1) Remove the hardcoded number of sources, and set it to maximum 1023, while adding a generic parameter setting the actual number of chip-implemented sources for runtime checks. This could be enhanced to compile-time setting with `generic_const_exprs`, but it is not clear when it gets stabilized.
2) Add two extra API functions to enable/disable only select interrupt IDs.


### Testing Strategy

This pull request was tested by:
1) Running on physical Arty A7 board with existing `arty_e21` platform implementation
2) Running on qemu_rv32_virt platform
3) Running on QEMU simulation of HiFive1 platform
4) Running on a proprietary SiFive-based core on Arty A7 board with a higher number of PLIC interrupt sources


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

