### PR TITLE
capsules: kv: Support 512 byte KV values

### DIFF
--- a/boards/components/src/kv.rs
+++ b/boards/components/src/kv.rs
@@ -24,7 +24,7 @@ macro_rules! kv_driver_component_static {
     ($V:ty $(,)?) => {{
         let kv = kernel::static_buf!(capsules_extra::kv_driver::KVStoreDriver<'static, $V>);
         let key_buffer = kernel::static_buf!([u8; 64]);
-        let value_buffer = kernel::static_buf!([u8; 256]);
+        let value_buffer = kernel::static_buf!([u8; 512]);
 
         (kv, key_buffer, value_buffer)
     };};
@@ -52,7 +52,7 @@ impl<V: hil::kv::KVPermissions<'static>> Component for KVDriverComponent<V> {
     type StaticInput = (
         &'static mut MaybeUninit<KVStoreDriver<'static, V>>,
         &'static mut MaybeUninit<[u8; 64]>,
-        &'static mut MaybeUninit<[u8; 256]>,
+        &'static mut MaybeUninit<[u8; 512]>,
     );
     type Output = &'static KVStoreDriver<'static, V>;
 
@@ -60,7 +60,7 @@ impl<V: hil::kv::KVPermissions<'static>> Component for KVDriverComponent<V> {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
         let key_buffer = static_buffer.1.write([0; 64]);
-        let value_buffer = static_buffer.2.write([0; 256]);
+        let value_buffer = static_buffer.2.write([0; 512]);
 
         let driver = static_buffer.0.write(KVStoreDriver::new(
             self.kv,


### PR DESCRIPTION
### Pull Request Overview

Some of the new LoRaWAN examples are writing more then 256 bytes, so let's up the buffer size to allow larger payloads.

### Testing Strategy

Writing larger K/V values

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
