### PR TITLE
USB HID/CTAP: General cleanup

### DIFF
--- a/boards/components/src/ctap.rs
+++ b/boards/components/src/ctap.rs
@@ -119,7 +119,7 @@ impl<U: 'static + hil::usb::UsbController<'static>> Component for CtapComponent<
         let recv_buffer = s.3.write([0; 64]);
 
         let ctap_driver = s.1.write(capsules_extra::usb_hid_driver::UsbHidDriver::new(
-            Some(ctap),
+            ctap,
             send_buffer,
             recv_buffer,
             self.board_kernel.create_grant(self.driver_num, &grant_cap),

--- a/boards/components/src/keyboard_hid.rs
+++ b/boards/components/src/keyboard_hid.rs
@@ -127,7 +127,7 @@ impl<U: 'static + hil::usb::UsbController<'static>> Component for KeyboardHidCom
         let recv_buffer = s.3.write([0; 64]);
 
         let usb_hid_driver = s.1.write(capsules_extra::usb_hid_driver::UsbHidDriver::new(
-            Some(keyboard_hid),
+            keyboard_hid,
             send_buffer,
             recv_buffer,
             self.board_kernel.create_grant(self.driver_num, &grant_cap),

--- a/capsules/extra/src/usb/ctap.rs
+++ b/capsules/extra/src/usb/ctap.rs
@@ -6,7 +6,6 @@
 //!
 //! Based on the spec avaliable at: <https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-client-to-authenticator-protocol-v2.0-id-20180227.html>
 
-use core::cell::Cell;
 use core::cmp;
 
 use super::descriptors;
@@ -97,12 +96,6 @@ pub struct CtapHid<'a, U: 'a> {
     /// A holder for the buffer to receive bytes into. We use this as a flag as
     /// well, if we have a buffer then we are actively doing a receive.
     recv_buffer: TakeCell<'static, [u8; 64]>,
-    /// How many bytes the client wants us to receive.
-    recv_len: Cell<usize>,
-    /// How many bytes we have received so far.
-    recv_offset: Cell<usize>,
-
-    saved_endpoint: OptionalCell<usize>,
 }
 
 impl<'a, U: hil::usb::UsbController<'a>> CtapHid<'a, U> {
@@ -174,9 +167,6 @@ impl<'a, U: hil::usb::UsbController<'a>> CtapHid<'a, U> {
             client: OptionalCell::empty(),
             send_buffer: TakeCell::empty(),
             recv_buffer: TakeCell::empty(),
-            recv_len: Cell::new(0),
-            recv_offset: Cell::new(0),
-            saved_endpoint: OptionalCell::empty(),
         }
     }
 
@@ -187,12 +177,6 @@ impl<'a, U: hil::usb::UsbController<'a>> CtapHid<'a, U> {
 
     pub fn set_client(&'a self, client: &'a dyn hil::usb_hid::Client<'a, [u8; 64]>) {
         self.client.set(client);
-    }
-
-    fn can_receive(&'a self) -> bool {
-        self.client
-            .map(move |client| client.can_receive())
-            .unwrap_or(false)
     }
 }
 
@@ -221,28 +205,11 @@ impl<'a, U: hil::usb::UsbController<'a>> hil::usb_hid::UsbHid<'a, [u8; 64]> for 
         recv: &'static mut [u8; 64],
     ) -> Result<(), (ErrorCode, &'static mut [u8; 64])> {
         self.recv_buffer.replace(recv);
-
-        if self.saved_endpoint.is_some() {
-            // We have saved data from before, let's pass it.
-            if self.can_receive() {
-                self.recv_buffer.take().map(|buf| {
-                    self.client.map(move |client| {
-                        client.packet_received(Ok(()), buf, self.saved_endpoint.take().unwrap());
-                    });
-                });
-                // Reset the offset
-                self.recv_offset.set(0);
-            }
-        } else {
-            // If we have nothing to process, accept more data
-            self.controller().endpoint_resume_out(ENDPOINT_NUM);
-        }
-
+        self.controller().endpoint_resume_out(ENDPOINT_NUM);
         Ok(())
     }
 
     fn receive_cancel(&'a self) -> Result<&'static mut [u8; 64], ErrorCode> {
-        self.saved_endpoint.take();
         match self.recv_buffer.take() {
             Some(buf) => Ok(buf),
             None => Err(ErrorCode::BUSY),
@@ -345,51 +312,28 @@ impl<'a, U: hil::usb::UsbController<'a>> hil::usb::Client<'a> for CtapHid<'a, U>
     ) -> hil::usb::OutResult {
         match transfer_type {
             TransferType::Interrupt => {
+                // If we have a receive buffer we can copy the incoming data in.
+                // If we do not have a buffer, then we apply back pressure by
+                // returning `hil::usb::OutResult::Delay` to the USB stack until
+                // we get a receive call.
                 self.recv_buffer
                     .take()
-                    .map_or(hil::usb::OutResult::Error, |buf| {
-                        let recv_offset = self.recv_offset.get();
-
+                    .map_or(hil::usb::OutResult::Delay, |buf| {
                         // How many more bytes can we store in our RX buffer?
-                        let available_bytes = buf.len() - recv_offset;
-                        let copy_length = cmp::min(packet_bytes as usize, available_bytes);
+                        let copy_length = cmp::min(packet_bytes as usize, buf.len());
 
                         // Do the copy into the RX buffer.
                         let packet = &self.buffers[OUT_BUFFER].buf;
                         for i in 0..copy_length {
-                            buf[recv_offset + i] = packet[i].get();
+                            buf[i] = packet[i].get();
                         }
 
-                        // Keep track of how many bytes we have received so far.
-                        let total_received_bytes = recv_offset + copy_length;
+                        // Notify the client
+                        self.client.map(move |client| {
+                            client.packet_received(Ok(()), buf, endpoint);
+                        });
 
-                        // Update how many bytes we have gotten.
-                        self.recv_offset.set(total_received_bytes);
-
-                        // Check if we have received at least as many bytes as the
-                        // client asked for.
-                        if total_received_bytes >= self.recv_len.get() {
-                            if self.can_receive() {
-                                self.client.map(move |client| {
-                                    client.packet_received(Ok(()), buf, endpoint);
-                                });
-                                // Reset the offset
-                                self.recv_offset.set(0);
-                                // Delay the next packet until we have finished
-                                // processing this packet
-                                hil::usb::OutResult::Delay
-                            } else {
-                                // We can't receive data. Record that we have data to send later
-                                // and apply back pressure to USB
-                                self.saved_endpoint.set(endpoint);
-                                self.recv_buffer.replace(buf);
-                                hil::usb::OutResult::Delay
-                            }
-                        } else {
-                            // Make sure to put the RX buffer back.
-                            self.recv_buffer.replace(buf);
-                            hil::usb::OutResult::Ok
-                        }
+                        hil::usb::OutResult::Ok
                     })
             }
             TransferType::Bulk | TransferType::Control | TransferType::Isochronous => {

--- a/kernel/src/hil/usb_hid.rs
+++ b/kernel/src/hil/usb_hid.rs
@@ -43,14 +43,6 @@ pub trait Client<'a, T: UsbHidType> {
         buffer: &'static mut T,
         endpoint: usize,
     );
-
-    /// Called when checking if we can start a new receive operation.
-    /// Should return true if we are ready to receive and not currently
-    /// in the process of receiving anything. That is if we are currently
-    /// idle.
-    /// If there is an outstanding call to receive, a callback already
-    /// waiting to be called then this will return false.
-    fn can_receive(&'a self) -> bool;
 }
 
 pub trait UsbHid<'a, T: UsbHidType> {


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the HID and CTAP capsules to get them more inline with our typical capsule expectations. The notable changes are:

1. Remove `CtapHid::recv_len`. This value was never written. The other removed state variables were also never written.
2. Remove the option for the USB in `UsbHidDriver`. The USB driver is not optional as otherwise the capsule won't do anything.
3. Remove `can_receive()` from the HIL. This was never used.


### Testing Strategy

I ran the `libtock-c/examples/tests/keyboard_hid` test and it works.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
