### PR TITLE
kernel: scheduler: Use NonZeroU32 instead of u32 for `start()` and `get_remaining_us()`

### DIFF
--- a/kernel/src/scheduler.rs
+++ b/kernel/src/scheduler.rs
@@ -14,6 +14,8 @@ use crate::platform::chip::Chip;
 use crate::process::ProcessId;
 use crate::process::StoppedExecutingReason;
 
+use core::num::NonZeroU32;
+
 /// Trait which any scheduler must implement.
 pub trait Scheduler<C: Chip> {
     /// Decide which process to run next.
@@ -91,7 +93,7 @@ pub enum SchedulingDecision {
     /// Tell the kernel to run the specified process with the passed timeslice.
     /// If `None` is passed as a timeslice, the process will be run
     /// cooperatively.
-    RunProcess((ProcessId, Option<u32>)),
+    RunProcess((ProcessId, Option<NonZeroU32>)),
 
     /// Tell the kernel to go to sleep. Notably, if the scheduler asks the
     /// kernel to sleep when kernel tasks are ready, the kernel will not sleep,

--- a/kernel/src/scheduler/mlfq.rs
+++ b/kernel/src/scheduler/mlfq.rs
@@ -22,6 +22,7 @@
 //!           topmost queue.
 
 use core::cell::Cell;
+use core::num::NonZeroU32;
 
 use crate::collections::list::{List, ListLink, ListNode};
 use crate::hil::time::{self, ConvertTicks, Ticks};
@@ -156,7 +157,7 @@ impl<A: 'static + time::Alarm<'static>, C: Chip> Scheduler<C> for MLFQSched<'_, 
         self.last_queue_idx.set(queue_idx);
         self.last_timeslice.set(timeslice);
 
-        SchedulingDecision::RunProcess((next, Some(timeslice)))
+        SchedulingDecision::RunProcess((next, NonZeroU32::new(timeslice)))
     }
 
     fn result(&self, result: StoppedExecutingReason, execution_time_us: Option<u32>) {

--- a/kernel/src/scheduler/round_robin.rs
+++ b/kernel/src/scheduler/round_robin.rs
@@ -19,6 +19,7 @@
 //! interrupted.
 
 use core::cell::Cell;
+use core::num::NonZeroU32;
 
 use crate::collections::list::{List, ListLink, ListNode};
 use crate::platform::chip::Chip;
@@ -120,9 +121,10 @@ impl<C: Chip> Scheduler<C> for RoundRobinSched<'_> {
             self.time_remaining.set(self.timeslice_length);
             self.timeslice_length
         };
-        assert!(timeslice != 0);
+        // Why should this panic?
+        let non_zero_timeslice = NonZeroU32::new(timeslice).unwrap();
 
-        SchedulingDecision::RunProcess((next, Some(timeslice)))
+        SchedulingDecision::RunProcess((next, Some(non_zero_timeslice)))
     }
 
     fn result(&self, result: StoppedExecutingReason, execution_time_us: Option<u32>) {


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the type of the `us` argument for `SchedulerTimer::start()` and `SchedulerTimer::get_remaining_us()` return type. Using `NonZeroU32` has two benefits:

1. Convey the meaning that the scheduler timer cannot be started with 0 micro seconds. All use cases present in Tock expect the scheduler timer to be started with a non-null value and some of them even assume that the value is non-null. See code comments. Using the `NonZeroU32` type also forces the programmer to check for null values, thus it provides better type safety.
2. The memory layout of `Option<NonZeroU32>` can be optimized, thus reducing the memory footprint of the kernel, albeit by a few bytes:

```
# Before the change

## Debug
   text	   data	    bss	    dec	    hex	filename
 126952	     32	  13500	 140484	  224c4	../../target/thumbv6m-none-eabi/debug/raspberry_pi_pico.elf

## Release
   text	   data	    bss	    dec	    hex	filename
  98272	     32	  13500	 111804	  1b4bc	../../target/thumbv6m-none-eabi/release/raspberry_pi_pico.elf


# After the change

## Debug
   text	   data	    bss	    dec	    hex	filename
 126940	     32	  13500	 140472	  224b8	../../target/thumbv6m-none-eabi/debug/raspberry_pi_pico.elf

## Release
   text	   data	    bss	    dec	    hex	filename
  98280	     32	  13500	 111812	  1b4c4	../../target/thumbv6m-none-eabi/release/raspberry_pi_pico.elf
``` 

As a side effect, this PR requires the change of the `SchedulingDecision::RunProcess` variant since the scheduler may never decide to run a process for 0 micro seconds. 


### Testing Strategy

This pull request was tested by running `c_hello` and `blink` applications on Raspberry Pi Pico using the round robin scheduler.


### TODO or Help Wanted

No help needed.


### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
