### PR TITLE
Make baud rate to never be nullable

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -10,6 +10,7 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::num::NonZeroU32;
 use core::ptr::{addr_of, addr_of_mut};
 
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
@@ -337,8 +338,10 @@ unsafe fn start() -> (
     //
 
     // Create a shared UART channel for the console and for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(rtt, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: 115200 != 0
+    let uart_mux =
+        components::console::UartMuxComponent::new(rtt, NonZeroU32::new(115200).unwrap())
+            .finalize(components::uart_mux_component_static!());
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(

--- a/boards/apollo3/lora_things_plus/src/main.rs
+++ b/boards/apollo3/lora_things_plus/src/main.rs
@@ -39,6 +39,7 @@
 #![test_runner(test_runner)]
 #![reexport_test_harness_main = "test_main"]
 
+use core::num::NonZeroU32;
 use core::ptr::addr_of;
 use core::ptr::addr_of_mut;
 
@@ -417,8 +418,12 @@ unsafe fn setup() -> (
     kernel::debug::assign_gpios(Some(&peripherals.gpio_port[26]), None, None);
 
     // Create a shared UART channel for the console and for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(&peripherals.uart0, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: 115200 != 0
+    let uart_mux = components::console::UartMuxComponent::new(
+        &peripherals.uart0,
+        NonZeroU32::new(115200).unwrap(),
+    )
+    .finalize(components::uart_mux_component_static!());
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(

--- a/boards/apollo3/redboard_artemis_atp/src/main.rs
+++ b/boards/apollo3/redboard_artemis_atp/src/main.rs
@@ -15,6 +15,7 @@
 #![test_runner(test_runner)]
 #![reexport_test_harness_main = "test_main"]
 
+use core::num::NonZeroU32;
 use core::ptr::addr_of;
 use core::ptr::addr_of_mut;
 
@@ -222,8 +223,12 @@ unsafe fn setup() -> (
     );
 
     // Create a shared UART channel for the console and for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(&peripherals.uart0, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: 115200 != 0
+    let uart_mux = components::console::UartMuxComponent::new(
+        &peripherals.uart0,
+        NonZeroU32::new(115200).unwrap(),
+    )
+    .finalize(components::uart_mux_component_static!());
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(

--- a/boards/apollo3/redboard_artemis_nano/src/main.rs
+++ b/boards/apollo3/redboard_artemis_nano/src/main.rs
@@ -15,6 +15,7 @@
 #![test_runner(test_runner)]
 #![reexport_test_harness_main = "test_main"]
 
+use core::num::NonZeroU32;
 use core::ptr::addr_of;
 use core::ptr::addr_of_mut;
 
@@ -236,8 +237,12 @@ unsafe fn setup() -> (
     );
 
     // Create a shared UART channel for the console and for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(&peripherals.uart0, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: 115200 != 0
+    let uart_mux = components::console::UartMuxComponent::new(
+        &peripherals.uart0,
+        NonZeroU32::new(115200).unwrap(),
+    )
+    .finalize(components::uart_mux_component_static!());
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(

--- a/boards/arty_e21/src/main.rs
+++ b/boards/arty_e21/src/main.rs
@@ -9,6 +9,7 @@
 // https://github.com/rust-lang/rust/issues/62184.
 #![cfg_attr(not(doc), no_main)]
 
+use core::num::NonZeroU32;
 use core::ptr::{addr_of, addr_of_mut};
 
 use arty_e21_chip::chip::ArtyExxDefaultPeripherals;
@@ -157,8 +158,12 @@ unsafe fn start() -> (
     PROCESS_PRINTER = Some(process_printer);
 
     // Create a shared UART channel for the console and for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(&peripherals.uart0, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: 115200 != 0
+    let uart_mux = components::console::UartMuxComponent::new(
+        &peripherals.uart0,
+        NonZeroU32::new(115200).unwrap(),
+    )
+    .finalize(components::uart_mux_component_static!());
 
     let console = components::console::ConsoleComponent::new(
         board_kernel,

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -12,6 +12,7 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::num::NonZeroU32;
 use core::ptr::addr_of;
 use core::ptr::addr_of_mut;
 
@@ -506,8 +507,10 @@ unsafe fn start() -> (
     CDC_REF_FOR_PANIC = Some(cdc); //for use by panic handler
 
     // Create a shared UART channel for the console and for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(cdc, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: 115200 != 0
+    let uart_mux =
+        components::console::UartMuxComponent::new(cdc, NonZeroU32::new(115200).unwrap())
+            .finalize(components::uart_mux_component_static!());
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(

--- a/boards/components/src/console.rs
+++ b/boards/components/src/console.rs
@@ -41,6 +41,7 @@ use capsules_core::console_ordered::ConsoleOrdered;
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules_core::virtualizers::virtual_uart::{MuxUart, UartDevice};
 use core::mem::MaybeUninit;
+use core::num::NonZeroU32;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
@@ -70,13 +71,13 @@ macro_rules! uart_mux_component_static {
 
 pub struct UartMuxComponent<const RX_BUF_LEN: usize> {
     uart: &'static dyn uart::Uart<'static>,
-    baud_rate: u32,
+    baud_rate: NonZeroU32,
 }
 
 impl<const RX_BUF_LEN: usize> UartMuxComponent<RX_BUF_LEN> {
     pub fn new(
         uart: &'static dyn uart::Uart<'static>,
-        baud_rate: u32,
+        baud_rate: NonZeroU32,
     ) -> UartMuxComponent<RX_BUF_LEN> {
         UartMuxComponent { uart, baud_rate }
     }

--- a/boards/components/src/debug_writer.rs
+++ b/boards/components/src/debug_writer.rs
@@ -24,6 +24,7 @@
 
 use capsules_core::virtualizers::virtual_uart::{MuxUart, UartDevice};
 use core::mem::MaybeUninit;
+use core::num::NonZeroU32;
 use kernel::capabilities;
 use kernel::collections::ring_buffer::RingBuffer;
 use kernel::component::Component;
@@ -182,7 +183,8 @@ impl<U: uart::Uart<'static> + uart::Transmit<'static> + 'static, const BUF_SIZE_
         }
 
         let _ = self.uart.configure(uart::Parameters {
-            baud_rate: 115200,
+            // PANIC: 115200 != 0
+            baud_rate: NonZeroU32::new(115200).unwrap(),
             width: uart::Width::Eight,
             stop_bits: uart::StopBits::One,
             parity: uart::Parity::None,

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-sha256/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-sha256/src/main.rs
@@ -10,6 +10,7 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::num::NonZeroU32;
 use core::ptr::{addr_of, addr_of_mut};
 
 use kernel::component::Component;
@@ -234,8 +235,10 @@ pub unsafe fn main() {
     ));
 
     // Virtualize the UART channel for the console and for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(uart_channel, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: 115200 != 0
+    let uart_mux =
+        components::console::UartMuxComponent::new(uart_channel, NonZeroU32::new(115200).unwrap())
+            .finalize(components::uart_mux_component_static!());
 
     // Setup the serial console for userspace.
     let console = components::console::ConsoleComponent::new(

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/main.rs
@@ -10,6 +10,7 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::num::NonZeroU32;
 use core::ptr::{addr_of, addr_of_mut};
 
 use kernel::component::Component;
@@ -253,8 +254,10 @@ pub unsafe fn main() {
     ));
 
     // Virtualize the UART channel for the console and for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(uart_channel, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: 115200 != 0
+    let uart_mux =
+        components::console::UartMuxComponent::new(uart_channel, NonZeroU32::new(115200).unwrap())
+            .finalize(components::uart_mux_component_static!());
 
     // Setup the serial console for userspace.
     let console = components::console::ConsoleComponent::new(

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/io.rs
@@ -3,6 +3,7 @@
 // Copyright Tock Contributors 2022.
 
 use core::fmt::Write;
+use core::num::NonZeroU32;
 use core::panic::PanicInfo;
 use cortexm4;
 use kernel::debug;
@@ -47,7 +48,8 @@ impl IoWrite for Writer {
                 if !*initialized {
                     *initialized = true;
                     let _ = uart.configure(uart::Parameters {
-                        baud_rate: 115200,
+                        // PANIC: 115200 != 0
+                        baud_rate: NonZeroU32::new(115200).unwrap(),
                         stop_bits: uart::StopBits::One,
                         parity: uart::Parity::None,
                         hw_flow_control: false,

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/main.rs
@@ -12,6 +12,7 @@
 
 use capsules_core::test::capsule_test::{CapsuleTestClient, CapsuleTestError};
 use core::cell::Cell;
+use core::num::NonZeroU32;
 use core::ptr::addr_of;
 use kernel::component::Component;
 use kernel::hil::time::Counter;
@@ -228,8 +229,10 @@ pub unsafe fn main() {
     ));
 
     // Virtualize the UART channel for the console and for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(uart_channel, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: 115200 != 0
+    let uart_mux =
+        components::console::UartMuxComponent::new(uart_channel, NonZeroU32::new(115200).unwrap())
+            .finalize(components::uart_mux_component_static!());
 
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux)

--- a/boards/esp32-c3-devkitM-1/src/main.rs
+++ b/boards/esp32-c3-devkitM-1/src/main.rs
@@ -13,6 +13,7 @@
 #![test_runner(test_runner)]
 #![reexport_test_harness_main = "test_main"]
 
+use core::num::NonZeroU32;
 use core::ptr::{addr_of, addr_of_mut};
 
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
@@ -171,8 +172,12 @@ unsafe fn setup() -> (
     kernel::debug::assign_gpios(None, None, None);
 
     // Create a shared UART channel for the console and for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(&peripherals.uart0, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: 115200 != 0
+    let uart_mux = components::console::UartMuxComponent::new(
+        &peripherals.uart0,
+        NonZeroU32::new(115200).unwrap(),
+    )
+    .finalize(components::uart_mux_component_static!());
 
     let gpio = components::gpio::GpioComponent::new(
         board_kernel,

--- a/boards/hail/src/io.rs
+++ b/boards/hail/src/io.rs
@@ -3,6 +3,7 @@
 // Copyright Tock Contributors 2022.
 
 use core::fmt::Write;
+use core::num::NonZeroU32;
 use core::panic::PanicInfo;
 use core::str;
 use kernel::debug;
@@ -37,7 +38,8 @@ impl IoWrite for Writer {
         if !self.initialized {
             self.initialized = true;
             let _ = uart.configure(uart::Parameters {
-                baud_rate: 115200,
+                // PANIC: 115200 != 0
+                baud_rate: NonZeroU32::new(115200).unwrap(),
                 width: uart::Width::Eight,
                 stop_bits: uart::StopBits::One,
                 parity: uart::Parity::None,

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -13,6 +13,7 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::num::NonZeroU32;
 use core::ptr::{addr_of, addr_of_mut};
 
 use kernel::capabilities;
@@ -280,8 +281,12 @@ unsafe fn start() -> (
     peripherals.usart0.set_mode(sam4l::usart::UsartMode::Uart);
 
     // Create a shared UART channel for the console and for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(&peripherals.usart0, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: 115200 != 0
+    let uart_mux = components::console::UartMuxComponent::new(
+        &peripherals.usart0,
+        NonZeroU32::new(115200).unwrap(),
+    )
+    .finalize(components::uart_mux_component_static!());
     uart_mux.initialize();
 
     hil::uart::Transmit::set_transmit_client(&peripherals.usart0, uart_mux);

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -13,6 +13,7 @@
 // https://github.com/rust-lang/rust/issues/62184.
 #![cfg_attr(not(doc), no_main)]
 
+use core::num::NonZeroU32;
 use core::ptr::{addr_of, addr_of_mut};
 
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
@@ -216,8 +217,12 @@ unsafe fn start() -> (
     );
 
     // Create a shared UART channel for the console and for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(&peripherals.e310x.uart0, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: 115200 != 0
+    let uart_mux = components::console::UartMuxComponent::new(
+        &peripherals.e310x.uart0,
+        NonZeroU32::new(115200).unwrap(),
+    )
+    .finalize(components::uart_mux_component_static!());
 
     // LEDs
     let led = components::led::LedsComponent::new().finalize(components::led_component_static!(

--- a/boards/hifive_inventor/src/main.rs
+++ b/boards/hifive_inventor/src/main.rs
@@ -11,6 +11,7 @@
 // https://github.com/rust-lang/rust/issues/62184.
 #![cfg_attr(not(doc), no_main)]
 
+use core::num::NonZeroU32;
 use core::ptr::{addr_of, addr_of_mut};
 
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
@@ -168,8 +169,12 @@ unsafe fn start() -> (
     kernel::debug::assign_gpios(None, None, None);
 
     // Create a shared UART channel for the console and for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(&peripherals.e310x.uart0, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: 115200 != 0
+    let uart_mux = components::console::UartMuxComponent::new(
+        &peripherals.e310x.uart0,
+        NonZeroU32::new(115200).unwrap(),
+    )
+    .finalize(components::uart_mux_component_static!());
 
     let hardware_timer = static_init!(
         e310_g003::chip::E310xClint,

--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -3,6 +3,7 @@
 // Copyright Tock Contributors 2022.
 
 use core::fmt::Write;
+use core::num::NonZeroU32;
 use core::panic::PanicInfo;
 use kernel::debug;
 use kernel::debug::IoWrite;
@@ -36,7 +37,8 @@ impl IoWrite for Writer {
         if !self.initialized {
             self.initialized = true;
             let _ = uart.configure(uart::Parameters {
-                baud_rate: 115200,
+                // PANIC: 115200 != 0
+                baud_rate: NonZeroU32::new(115200).unwrap(),
                 width: uart::Width::Eight,
                 stop_bits: uart::StopBits::One,
                 parity: uart::Parity::None,

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -14,6 +14,7 @@
 #![deny(missing_docs)]
 
 mod imix_components;
+use core::num::NonZeroU32;
 use core::ptr::{addr_of, addr_of_mut};
 
 use capsules_core::alarm::AlarmDriver;
@@ -365,7 +366,8 @@ unsafe fn start() -> (
     // # CONSOLE
     // Create a shared UART channel for the consoles and for kernel debug.
     peripherals.usart3.set_mode(sam4l::usart::UsartMode::Uart);
-    let uart_mux = UartMuxComponent::new(&peripherals.usart3, 115200)
+    // PANIC: 115200 != 0
+    let uart_mux = UartMuxComponent::new(&peripherals.usart3, NonZeroU32::new(115200).unwrap())
         .finalize(components::uart_mux_component_static!());
 
     // # TIMER

--- a/boards/imxrt1050-evkb/src/io.rs
+++ b/boards/imxrt1050-evkb/src/io.rs
@@ -3,6 +3,7 @@
 // Copyright Tock Contributors 2022.
 
 use core::fmt::Write;
+use core::num::NonZeroU32;
 use core::panic::PanicInfo;
 use core::ptr::addr_of;
 use core::ptr::addr_of_mut;
@@ -51,7 +52,8 @@ impl IoWrite for Writer {
             self.initialized = true;
 
             let _ = uart.configure(uart::Parameters {
-                baud_rate: 115200,
+                // PANIC: 115200 != 0
+                baud_rate: NonZeroU32::new(115200).unwrap(),
                 stop_bits: uart::StopBits::One,
                 parity: uart::Parity::None,
                 hw_flow_control: false,

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -10,6 +10,7 @@
 #![no_main]
 #![deny(missing_docs)]
 
+use core::num::NonZeroU32;
 use core::ptr::{addr_of, addr_of_mut};
 
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
@@ -302,8 +303,12 @@ unsafe fn start() -> (
     // Enable clock
     peripherals.lpuart1.enable_clock();
 
-    let lpuart_mux = components::console::UartMuxComponent::new(&peripherals.lpuart1, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: 115200 != 0
+    let lpuart_mux = components::console::UartMuxComponent::new(
+        &peripherals.lpuart1,
+        NonZeroU32::new(115200).unwrap(),
+    )
+    .finalize(components::uart_mux_component_static!());
     (*addr_of_mut!(io::WRITER)).set_initialized();
 
     // Create capabilities that the board needs to call certain protected kernel

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -10,6 +10,7 @@
 // https://github.com/rust-lang/rust/issues/62184.
 #![cfg_attr(not(doc), no_main)]
 
+use core::num::NonZeroU32;
 use core::ptr::{addr_of, addr_of_mut};
 
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
@@ -464,8 +465,12 @@ unsafe fn start() -> (
     PANIC_REFERENCES.uart = Some(uart0);
 
     // Create a shared UART channel for the console and for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(uart0, socc::UART_BAUDRATE)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: socc::UART_BAUDRATE != 0
+    let uart_mux = components::console::UartMuxComponent::new(
+        uart0,
+        NonZeroU32::new(socc::UART_BAUDRATE).unwrap(),
+    )
+    .finalize(components::uart_mux_component_static!());
 
     // ---------- ETHERNET ----------
 

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -9,6 +9,7 @@
 // https://github.com/rust-lang/rust/issues/62184.
 #![cfg_attr(not(doc), no_main)]
 
+use core::num::NonZeroU32;
 use core::ptr::{addr_of, addr_of_mut};
 
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
@@ -443,8 +444,10 @@ unsafe fn start() -> (
     //
     // The baudrate is ingnored, as no UART phy is present in the
     // verilated simulation.
-    let uart_mux = components::console::UartMuxComponent::new(uart0, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: 115200 != 0
+    let uart_mux =
+        components::console::UartMuxComponent::new(uart0, NonZeroU32::new(115200).unwrap())
+            .finalize(components::uart_mux_component_static!());
 
     // ---------- ETHERNET ----------
 

--- a/boards/makepython-nrf52840/src/main.rs
+++ b/boards/makepython-nrf52840/src/main.rs
@@ -12,6 +12,7 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::num::NonZeroU32;
 use core::ptr::{addr_of, addr_of_mut};
 
 use kernel::capabilities;
@@ -388,8 +389,10 @@ pub unsafe fn start() -> (
     PROCESS_PRINTER = Some(process_printer);
 
     // Create a shared UART channel for the console and for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(cdc, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: 115200 != 0
+    let uart_mux =
+        components::console::UartMuxComponent::new(cdc, NonZeroU32::new(115200).unwrap())
+            .finalize(components::uart_mux_component_static!());
 
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,

--- a/boards/microbit_v2/src/io.rs
+++ b/boards/microbit_v2/src/io.rs
@@ -3,6 +3,7 @@
 // Copyright Tock Contributors 2022.
 
 use core::fmt::Write;
+use core::num::NonZeroU32;
 use core::panic::PanicInfo;
 
 use kernel::debug;
@@ -47,7 +48,8 @@ impl IoWrite for Writer {
         if !self.initialized {
             self.initialized = true;
             let _ = uart.configure(uart::Parameters {
-                baud_rate: 115200,
+                // PANIC: 115200 != 0
+                baud_rate: NonZeroU32::new(115200).unwrap(),
                 stop_bits: uart::StopBits::One,
                 parity: uart::Parity::None,
                 hw_flow_control: false,

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -12,6 +12,7 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::num::NonZeroU32;
 use core::ptr::{addr_of, addr_of_mut};
 
 use kernel::capabilities;
@@ -440,8 +441,12 @@ unsafe fn start() -> (
     );
 
     // Create a shared UART channel for the console and for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(&base_peripherals.uarte0, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: NonZeroU32::new(115200).unwrap() != 0
+    let uart_mux = components::console::UartMuxComponent::new(
+        &base_peripherals.uarte0,
+        NonZeroU32::new(115200).unwrap(),
+    )
+    .finalize(components::uart_mux_component_static!());
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -12,6 +12,7 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::num::NonZeroU32;
 use core::ptr::{addr_of, addr_of_mut};
 
 use components::gpio::GpioComponent;
@@ -330,8 +331,13 @@ unsafe fn start() -> (
         create_capability!(capabilities::ProcessManagementCapability);
 
     // Setup UART0
-    let uart_mux = components::console::UartMuxComponent::new(&peripherals.uart0, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // // PANIC: 115200 != 0
+    // PANIC: NonZeroU32::new(115200).unwrap() != 0
+    let uart_mux = components::console::UartMuxComponent::new(
+        &peripherals.uart0,
+        NonZeroU32::new(115200).unwrap(),
+    )
+    .finalize(components::uart_mux_component_static!());
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -12,6 +12,7 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::num::NonZeroU32;
 use core::ptr::addr_of;
 use core::ptr::addr_of_mut;
 
@@ -382,8 +383,10 @@ pub unsafe fn start() -> (
     PROCESS_PRINTER = Some(process_printer);
 
     // Create a shared UART channel for the console and for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(cdc, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: 115200 != 0
+    let uart_mux =
+        components::console::UartMuxComponent::new(cdc, NonZeroU32::new(115200).unwrap())
+            .finalize(components::uart_mux_component_static!());
 
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,

--- a/boards/nano33ble_rev2/src/main.rs
+++ b/boards/nano33ble_rev2/src/main.rs
@@ -12,6 +12,7 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::num::NonZeroU32;
 use core::ptr::addr_of;
 use core::ptr::addr_of_mut;
 
@@ -390,8 +391,10 @@ pub unsafe fn start() -> (
     PROCESS_PRINTER = Some(process_printer);
 
     // Create a shared UART channel for the console and for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(cdc, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: 115200 != 0
+    let uart_mux =
+        components::console::UartMuxComponent::new(cdc, NonZeroU32::new(115200).unwrap())
+            .finalize(components::uart_mux_component_static!());
 
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,

--- a/boards/nano_rp2040_connect/src/io.rs
+++ b/boards/nano_rp2040_connect/src/io.rs
@@ -3,6 +3,7 @@
 // Copyright Tock Contributors 2022.
 
 use core::fmt::Write;
+use core::num::NonZeroU32;
 use core::panic::PanicInfo;
 
 use kernel::debug::{self, IoWrite};
@@ -55,7 +56,8 @@ impl IoWrite for Writer {
 
                 if !uart0.is_configured() {
                     let parameters = Parameters {
-                        baud_rate: 115200,
+                        // PANIC: 115200 != 0
+                        baud_rate: NonZeroU32::new(115200).unwrap(),
                         width: Width::Eight,
                         parity: Parity::None,
                         stop_bits: StopBits::One,

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -12,6 +12,7 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::num::NonZeroU32;
 use core::ptr::{addr_of, addr_of_mut};
 
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
@@ -359,8 +360,10 @@ pub unsafe fn start() -> (
 
     // UART
     // Create a shared UART channel for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(cdc, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: 115200 != 0
+    let uart_mux =
+        components::console::UartMuxComponent::new(cdc, NonZeroU32::new(115200).unwrap())
+            .finalize(components::uart_mux_component_static!());
 
     // Uncomment this to use UART as an output
     // let uart_mux2 = components::console::UartMuxComponent::new(

--- a/boards/nordic/nrf52840_dongle/src/io.rs
+++ b/boards/nordic/nrf52840_dongle/src/io.rs
@@ -3,6 +3,7 @@
 // Copyright Tock Contributors 2022.
 
 use core::fmt::Write;
+use core::num::NonZeroU32;
 use core::panic::PanicInfo;
 use kernel::debug;
 use kernel::debug::IoWrite;
@@ -37,7 +38,8 @@ impl IoWrite for Writer {
         if !self.initialized {
             self.initialized = true;
             let _ = uart.configure(uart::Parameters {
-                baud_rate: 115200,
+                // PANIC: 115200 != 0
+                baud_rate: NonZeroU32::new(115200).unwrap(),
                 stop_bits: uart::StopBits::One,
                 parity: uart::Parity::None,
                 hw_flow_control: false,

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -13,6 +13,7 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::num::NonZeroU32;
 use core::ptr::{addr_of, addr_of_mut};
 
 use capsules_core::virtualizers::virtual_aes_ccm::MuxAES128CCM;
@@ -328,8 +329,10 @@ pub unsafe fn start() -> (
     PROCESS_PRINTER = Some(process_printer);
 
     // Create a shared UART channel for the console and for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(channel, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: 115200 != 0
+    let uart_mux =
+        components::console::UartMuxComponent::new(channel, NonZeroU32::new(115200).unwrap())
+            .finalize(components::uart_mux_component_static!());
 
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -3,6 +3,7 @@
 // Copyright Tock Contributors 2022.
 
 use core::fmt::Write;
+use core::num::NonZeroU32;
 use kernel::debug::IoWrite;
 use kernel::hil::uart;
 use kernel::hil::uart::Configure;
@@ -39,7 +40,8 @@ impl IoWrite for Writer {
                 if !*initialized {
                     *initialized = true;
                     let _ = uart.configure(uart::Parameters {
-                        baud_rate: 115200,
+                        // PANIC: 115200 != 0
+                        baud_rate: NonZeroU32::new(115200).unwrap(),
                         stop_bits: uart::StopBits::One,
                         parity: uart::Parity::None,
                         hw_flow_control: false,

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -70,6 +70,7 @@
 #![no_std]
 #![deny(missing_docs)]
 
+use core::num::NonZeroU32;
 use core::ptr::addr_of;
 
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
@@ -594,8 +595,10 @@ pub unsafe fn start() -> (
     PROCESS_PRINTER = Some(process_printer);
 
     // Virtualize the UART channel for the console and for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(uart_channel, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: 115200 != 0
+    let uart_mux =
+        components::console::UartMuxComponent::new(uart_channel, NonZeroU32::new(115200).unwrap())
+            .finalize(components::uart_mux_component_static!());
 
     // Create the process console, an interactive terminal for managing
     // processes.

--- a/boards/nordic/nrf52dk/src/io.rs
+++ b/boards/nordic/nrf52dk/src/io.rs
@@ -3,6 +3,7 @@
 // Copyright Tock Contributors 2022.
 
 use core::fmt::Write;
+use core::num::NonZeroU32;
 use core::panic::PanicInfo;
 use kernel::debug;
 use kernel::debug::IoWrite;
@@ -37,7 +38,8 @@ impl IoWrite for Writer {
         if !self.initialized {
             self.initialized = true;
             let _ = uart.configure(uart::Parameters {
-                baud_rate: 115200,
+                // PANIC: 115200 != 0
+                baud_rate: NonZeroU32::new(115200).unwrap(),
                 stop_bits: uart::StopBits::One,
                 parity: uart::Parity::None,
                 hw_flow_control: false,

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -71,6 +71,7 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::num::NonZeroU32;
 use core::ptr::{addr_of, addr_of_mut};
 
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
@@ -374,8 +375,11 @@ pub unsafe fn start() -> (
     PROCESS_PRINTER = Some(process_printer);
 
     // Create a shared UART channel for the console and for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(channel, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // // PANIC: 115200 != 0
+    // PANIC: NonZeroU32::new(115200).unwrap() != 0
+    let uart_mux =
+        components::console::UartMuxComponent::new(channel, NonZeroU32::new(115200).unwrap())
+            .finalize(components::uart_mux_component_static!());
 
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,

--- a/boards/nucleo_f429zi/src/io.rs
+++ b/boards/nucleo_f429zi/src/io.rs
@@ -3,6 +3,7 @@
 // Copyright Tock Contributors 2022.
 
 use core::fmt::Write;
+use core::num::NonZeroU32;
 use core::panic::PanicInfo;
 use core::ptr::addr_of;
 use core::ptr::addr_of_mut;
@@ -54,7 +55,8 @@ impl IoWrite for Writer {
             self.initialized = true;
 
             let _ = uart.configure(uart::Parameters {
-                baud_rate: 115200,
+                // PANIC: 115200 != 0
+                baud_rate: NonZeroU32::new(115200).unwrap(),
                 stop_bits: uart::StopBits::One,
                 parity: uart::Parity::None,
                 hw_flow_control: false,

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -12,6 +12,7 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::num::NonZeroU32;
 use core::ptr::{addr_of, addr_of_mut};
 
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
@@ -372,8 +373,12 @@ unsafe fn start() -> (
 
     // Create a shared UART channel for kernel debug.
     base_peripherals.usart3.enable_clock();
-    let uart_mux = components::console::UartMuxComponent::new(&base_peripherals.usart3, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: 115200 != 0
+    let uart_mux = components::console::UartMuxComponent::new(
+        &base_peripherals.usart3,
+        NonZeroU32::new(115200).unwrap(),
+    )
+    .finalize(components::uart_mux_component_static!());
 
     (*addr_of_mut!(io::WRITER)).set_initialized();
 

--- a/boards/nucleo_f446re/src/io.rs
+++ b/boards/nucleo_f446re/src/io.rs
@@ -3,6 +3,7 @@
 // Copyright Tock Contributors 2022.
 
 use core::fmt::Write;
+use core::num::NonZeroU32;
 use core::panic::PanicInfo;
 use core::ptr::{addr_of, addr_of_mut};
 
@@ -53,7 +54,8 @@ impl IoWrite for Writer {
             self.initialized = true;
 
             let _ = uart.configure(uart::Parameters {
-                baud_rate: 115200,
+                // PANIC: 115200 != 0
+                baud_rate: NonZeroU32::new(115200).unwrap(),
                 stop_bits: uart::StopBits::One,
                 parity: uart::Parity::None,
                 hw_flow_control: false,

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -12,6 +12,7 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::num::NonZeroU32;
 use core::ptr::{addr_of, addr_of_mut};
 
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
@@ -317,8 +318,12 @@ unsafe fn start() -> (
 
     // Create a shared UART channel for kernel debug.
     base_peripherals.usart2.enable_clock();
-    let uart_mux = components::console::UartMuxComponent::new(&base_peripherals.usart2, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: 115200 != 0
+    let uart_mux = components::console::UartMuxComponent::new(
+        &base_peripherals.usart2,
+        NonZeroU32::new(115200).unwrap(),
+    )
+    .finalize(components::uart_mux_component_static!());
 
     // `finalize()` configures the underlying USART, so we need to
     // tell `send_byte()` not to configure the USART again.

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -20,6 +20,7 @@ use crate::pinmux_layout::BoardPinmuxLayout;
 use capsules_aes_gcm::aes_gcm;
 use capsules_core::virtualizers::virtual_aes_ccm;
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use core::num::NonZeroU32;
 use core::ptr::{addr_of, addr_of_mut};
 use earlgrey::chip::EarlGreyDefaultPeripherals;
 use earlgrey::chip_config::EarlGreyConfig;
@@ -65,7 +66,8 @@ impl EarlGreyConfig for ChipConfig {
     const CPU_FREQ: u32 = 24_000_000;
     const PERIPHERAL_FREQ: u32 = 6_000_000;
     const AON_TIMER_FREQ: u32 = 250_000;
-    const UART_BAUDRATE: u32 = 115200;
+    // PANIC: 115200 != 0
+    const UART_BAUDRATE: NonZeroU32 = NonZeroU32::new(115200).unwrap();
 }
 
 #[cfg(feature = "sim_verilator")]

--- a/boards/particle_boron/src/io.rs
+++ b/boards/particle_boron/src/io.rs
@@ -3,6 +3,7 @@
 // Copyright Tock Contributors 2022.
 
 use core::fmt::Write;
+use core::num::NonZeroU32;
 use core::panic::PanicInfo;
 use kernel::debug;
 use kernel::debug::IoWrite;
@@ -41,7 +42,8 @@ impl IoWrite for Writer {
                 if !*initialized {
                     *initialized = true;
                     let _ = uart.configure(uart::Parameters {
-                        baud_rate: 115200,
+                        // PANIC: 115200 != 0
+                        baud_rate: NonZeroU32::new(115200).unwrap(),
                         stop_bits: uart::StopBits::One,
                         parity: uart::Parity::None,
                         hw_flow_control: false,

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -13,6 +13,7 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::num::NonZeroU32;
 use core::ptr::addr_of;
 use core::ptr::addr_of_mut;
 
@@ -386,8 +387,10 @@ pub unsafe fn start_particle_boron() -> (
     PROCESS_PRINTER = Some(process_printer);
 
     // Create a shared UART channel for the console and for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(uart_channel, 115200)
-        .finalize(components::uart_mux_component_static!(132));
+    // PANIC: 115200 != 0
+    let uart_mux =
+        components::console::UartMuxComponent::new(uart_channel, NonZeroU32::new(115200).unwrap())
+            .finalize(components::uart_mux_component_static!(132));
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(

--- a/boards/pico_explorer_base/src/io.rs
+++ b/boards/pico_explorer_base/src/io.rs
@@ -3,6 +3,7 @@
 // Copyright Tock Contributors 2022.
 
 use core::fmt::Write;
+use core::num::NonZeroU32;
 use core::panic::PanicInfo;
 
 use kernel::debug::{self, IoWrite};
@@ -30,7 +31,8 @@ impl Writer {
     fn configure_uart(&self, uart: &Uart) {
         if !uart.is_configured() {
             let parameters = Parameters {
-                baud_rate: 115200,
+                // PANIC: 115200 != 0
+                baud_rate: NonZeroU32::new(115200).unwrap(),
                 width: Width::Eight,
                 parity: Parity::None,
                 stop_bits: StopBits::One,

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -12,6 +12,7 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::num::NonZeroU32;
 use core::ptr::{addr_of, addr_of_mut};
 
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
@@ -371,8 +372,11 @@ pub unsafe fn start() -> (
 
     // UART
     // Create a shared UART channel for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(cdc, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // // PANIC: 115200 != 0
+    // PANIC: NonZeroU32::new(115200).unwrap() != 0
+    let uart_mux =
+        components::console::UartMuxComponent::new(cdc, NonZeroU32::new(115200).unwrap())
+            .finalize(components::uart_mux_component_static!());
 
     // Uncomment this to use UART as an output
     // let uart_mux = components::console::UartMuxComponent::new(&peripherals.uart0, 115200)

--- a/boards/qemu_rv32_virt/src/main.rs
+++ b/boards/qemu_rv32_virt/src/main.rs
@@ -9,6 +9,7 @@
 // https://github.com/rust-lang/rust/issues/62184.
 #![cfg_attr(not(doc), no_main)]
 
+use core::num::NonZeroU32;
 use core::ptr::addr_of;
 use core::ptr::addr_of_mut;
 
@@ -241,8 +242,12 @@ unsafe fn start() -> (
     // Create a shared UART channel for the console and for kernel
     // debug over the provided memory-mapped 16550-compatible
     // UART.
-    let uart_mux = components::console::UartMuxComponent::new(&peripherals.uart0, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: 115200 != 0
+    let uart_mux = components::console::UartMuxComponent::new(
+        &peripherals.uart0,
+        NonZeroU32::new(115200).unwrap(),
+    )
+    .finalize(components::uart_mux_component_static!());
 
     // Use the RISC-V machine timer timesource
     let hardware_timer = static_init!(

--- a/boards/raspberry_pi_pico/src/io.rs
+++ b/boards/raspberry_pi_pico/src/io.rs
@@ -3,6 +3,7 @@
 // Copyright Tock Contributors 2022.
 
 use core::fmt::Write;
+use core::num::NonZeroU32;
 use core::panic::PanicInfo;
 
 use kernel::debug::{self, IoWrite};
@@ -30,7 +31,8 @@ impl Writer {
     fn configure_uart(&self, uart: &Uart) {
         if !uart.is_configured() {
             let parameters = Parameters {
-                baud_rate: 115200,
+                // PANIC: 115200 != 0
+                baud_rate: NonZeroU32::new(115200).unwrap(),
                 width: Width::Eight,
                 parity: Parity::None,
                 stop_bits: StopBits::One,

--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -12,6 +12,7 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::num::NonZeroU32;
 use core::ptr::{addr_of, addr_of_mut};
 
 use capsules_core::i2c_master::I2CMasterDriver;
@@ -360,8 +361,11 @@ pub unsafe fn start() -> (
 
     // UART
     // Create a shared UART channel for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(cdc, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // // PANIC: 115200 != 0
+    // PANIC: NonZeroU32::new(115200).unwrap() != 0
+    let uart_mux =
+        components::console::UartMuxComponent::new(cdc, NonZeroU32::new(115200).unwrap())
+            .finalize(components::uart_mux_component_static!());
 
     // Uncomment this to use UART as an output
     // let uart_mux2 = components::console::UartMuxComponent::new(

--- a/boards/redboard_redv/src/main.rs
+++ b/boards/redboard_redv/src/main.rs
@@ -13,6 +13,7 @@
 // https://github.com/rust-lang/rust/issues/62184.
 #![cfg_attr(not(doc), no_main)]
 
+use core::num::NonZeroU32;
 use core::ptr::{addr_of, addr_of_mut};
 
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
@@ -172,8 +173,13 @@ unsafe fn start() -> (
     );
 
     // Create a shared UART channel for the console and for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(&peripherals.e310x.uart0, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // // PANIC: 115200 != 0
+    // PANIC: NonZeroU32::new(115200).unwrap() != 0
+    let uart_mux = components::console::UartMuxComponent::new(
+        &peripherals.e310x.uart0,
+        NonZeroU32::new(115200).unwrap(),
+    )
+    .finalize(components::uart_mux_component_static!());
 
     // LEDs
     let led = components::led::LedsComponent::new().finalize(components::led_component_static!(

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -16,6 +16,7 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::num::NonZeroU32;
 use core::ptr::{addr_of, addr_of_mut};
 
 use capsules_core::virtualizers::virtual_aes_ccm::MuxAES128CCM;
@@ -307,8 +308,10 @@ pub unsafe fn start() -> (
     };
 
     // Create a shared UART channel for the console and for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(uart_channel, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: 115200 != 0
+    let uart_mux =
+        components::console::UartMuxComponent::new(uart_channel, NonZeroU32::new(115200).unwrap())
+            .finalize(components::uart_mux_component_static!());
 
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,

--- a/boards/stm32f3discovery/src/io.rs
+++ b/boards/stm32f3discovery/src/io.rs
@@ -3,6 +3,7 @@
 // Copyright Tock Contributors 2022.
 
 use core::fmt::Write;
+use core::num::NonZeroU32;
 use core::panic::PanicInfo;
 use core::ptr::addr_of;
 use core::ptr::addr_of_mut;
@@ -51,7 +52,8 @@ impl IoWrite for Writer {
             self.initialized = true;
 
             let _ = uart.configure(uart::Parameters {
-                baud_rate: 115200,
+                // PANIC: 115200 != 0
+                baud_rate: NonZeroU32::new(115200).unwrap(),
                 stop_bits: uart::StopBits::One,
                 parity: uart::Parity::None,
                 hw_flow_control: false,

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -12,6 +12,7 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::num::NonZeroU32;
 use core::ptr::addr_of;
 use core::ptr::addr_of_mut;
 
@@ -417,8 +418,12 @@ unsafe fn start() -> (
     peripherals.usart1.enable_clock();
     peripherals.usart2.enable_clock();
 
-    let uart_mux = components::console::UartMuxComponent::new(&peripherals.usart1, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: 115200 != 0
+    let uart_mux = components::console::UartMuxComponent::new(
+        &peripherals.usart1,
+        NonZeroU32::new(115200).unwrap(),
+    )
+    .finalize(components::uart_mux_component_static!());
 
     // `finalize()` configures the underlying USART, so we need to
     // tell `send_byte()` not to configure the USART again.

--- a/boards/stm32f412gdiscovery/src/io.rs
+++ b/boards/stm32f412gdiscovery/src/io.rs
@@ -3,6 +3,7 @@
 // Copyright Tock Contributors 2022.
 
 use core::fmt::Write;
+use core::num::NonZeroU32;
 use core::panic::PanicInfo;
 use core::ptr::addr_of;
 use core::ptr::addr_of_mut;
@@ -54,7 +55,8 @@ impl IoWrite for Writer {
             self.initialized = true;
 
             let _ = uart.configure(uart::Parameters {
-                baud_rate: 115200,
+                // PANIC: 115200 != 0
+                baud_rate: NonZeroU32::new(115200).unwrap(),
                 stop_bits: uart::StopBits::One,
                 parity: uart::Parity::None,
                 hw_flow_control: false,

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -11,6 +11,7 @@
 // https://github.com/rust-lang/rust/issues/62184.
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
+use core::num::NonZeroU32;
 use core::ptr::{addr_of, addr_of_mut};
 
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
@@ -459,8 +460,12 @@ unsafe fn start() -> (
 
     // Create a shared UART channel for kernel debug.
     base_peripherals.usart2.enable_clock();
-    let uart_mux = components::console::UartMuxComponent::new(&base_peripherals.usart2, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: 115200 != 0
+    let uart_mux = components::console::UartMuxComponent::new(
+        &base_peripherals.usart2,
+        NonZeroU32::new(115200).unwrap(),
+    )
+    .finalize(components::uart_mux_component_static!());
 
     (*addr_of_mut!(io::WRITER)).set_initialized();
 

--- a/boards/stm32f429idiscovery/src/io.rs
+++ b/boards/stm32f429idiscovery/src/io.rs
@@ -3,6 +3,7 @@
 // Copyright Tock Contributors 2022.
 
 use core::fmt::Write;
+use core::num::NonZeroU32;
 use core::panic::PanicInfo;
 use core::ptr::addr_of;
 use core::ptr::addr_of_mut;
@@ -54,7 +55,8 @@ impl IoWrite for Writer {
             self.initialized = true;
 
             let _ = uart.configure(uart::Parameters {
-                baud_rate: 115200,
+                // PANIC: 115200 != 0
+                baud_rate: NonZeroU32::new(115200).unwrap(),
                 stop_bits: uart::StopBits::One,
                 parity: uart::Parity::None,
                 hw_flow_control: false,

--- a/boards/stm32f429idiscovery/src/main.rs
+++ b/boards/stm32f429idiscovery/src/main.rs
@@ -12,6 +12,7 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::num::NonZeroU32;
 use core::ptr::{addr_of, addr_of_mut};
 
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
@@ -330,8 +331,12 @@ unsafe fn start() -> (
     // the STM32F429I boards, DISC0 does not have this connection and will
     // not have USART output available!
     base_peripherals.usart1.enable_clock();
-    let uart_mux = components::console::UartMuxComponent::new(&base_peripherals.usart1, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: 115200 != 0
+    let uart_mux = components::console::UartMuxComponent::new(
+        &base_peripherals.usart1,
+        NonZeroU32::new(115200).unwrap(),
+    )
+    .finalize(components::uart_mux_component_static!());
 
     (*addr_of_mut!(io::WRITER)).set_initialized();
 

--- a/boards/teensy40/src/io.rs
+++ b/boards/teensy40/src/io.rs
@@ -3,6 +3,7 @@
 // Copyright Tock Contributors 2022.
 
 use core::fmt::{self, Write};
+use core::num::NonZeroU32;
 use core::ptr::addr_of;
 
 use kernel::debug::{self, IoWrite};
@@ -18,7 +19,7 @@ struct Writer<'a> {
     output: &'a mut lpuart::Lpuart<'a>,
 }
 
-const BAUD_RATE: u32 = 115_200;
+const BAUD_RATE: NonZeroU32 = NonZeroU32::new(115_200).unwrap();
 
 impl<'a> Writer<'a> {
     pub unsafe fn new(output: &'a mut lpuart::Lpuart<'a>) -> Self {

--- a/boards/teensy40/src/main.rs
+++ b/boards/teensy40/src/main.rs
@@ -16,6 +16,7 @@
 mod fcb;
 mod io;
 
+use core::num::NonZeroU32;
 use core::ptr::{addr_of, addr_of_mut};
 
 use imxrt1060::gpio::PinId;
@@ -257,8 +258,11 @@ unsafe fn start() -> (&'static kernel::Kernel, Teensy40, &'static Chip) {
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
     // TODO how many of these should there be...?
 
-    let uart_mux = components::console::UartMuxComponent::new(&peripherals.lpuart2, 115_200)
-        .finalize(components::uart_mux_component_static!());
+    let uart_mux = components::console::UartMuxComponent::new(
+        &peripherals.lpuart2,
+        NonZeroU32::new(115_200).unwrap(),
+    )
+    .finalize(components::uart_mux_component_static!());
     // Create the debugger object that handles calls to `debug!()`
     components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());

--- a/boards/veer_el2_sim/src/main.rs
+++ b/boards/veer_el2_sim/src/main.rs
@@ -11,6 +11,7 @@
 #![cfg_attr(not(doc), no_main)]
 
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use core::num::NonZeroU32;
 use core::ptr::{addr_of, addr_of_mut};
 use kernel::capabilities;
 use kernel::component::Component;
@@ -131,8 +132,12 @@ unsafe fn start() -> (&'static kernel::Kernel, VeeR, &'static VeeRChip) {
     kernel::debug::assign_gpios(None, None, None);
 
     // Create a shared UART channel for the console and for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(&peripherals.sim_uart, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: 115200 != 0
+    let uart_mux = components::console::UartMuxComponent::new(
+        &peripherals.sim_uart,
+        NonZeroU32::new(115200).unwrap(),
+    )
+    .finalize(components::uart_mux_component_static!());
 
     let mtimer = static_init!(Clint, Clint::new(&CLINT_BASE));
 

--- a/boards/weact_f401ccu6/src/io.rs
+++ b/boards/weact_f401ccu6/src/io.rs
@@ -3,6 +3,7 @@
 // Copyright Tock Contributors 2022.
 
 use core::fmt::Write;
+use core::num::NonZeroU32;
 use core::panic::PanicInfo;
 use core::ptr::addr_of;
 use core::ptr::addr_of_mut;
@@ -54,7 +55,8 @@ impl IoWrite for Writer {
             self.initialized = true;
 
             let _ = uart.configure(uart::Parameters {
-                baud_rate: 115200,
+                // PANIC: 115200 != 0
+                baud_rate: NonZeroU32::new(115200).unwrap(),
                 stop_bits: uart::StopBits::One,
                 parity: uart::Parity::None,
                 hw_flow_control: false,

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -12,6 +12,7 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::num::NonZeroU32;
 use core::ptr::{addr_of, addr_of_mut};
 
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
@@ -273,8 +274,12 @@ unsafe fn start() -> (
 
     // Create a shared UART channel for kernel debug.
     base_peripherals.usart2.enable_clock();
-    let uart_mux = components::console::UartMuxComponent::new(&base_peripherals.usart2, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: 115200 != 0
+    let uart_mux = components::console::UartMuxComponent::new(
+        &base_peripherals.usart2,
+        NonZeroU32::new(115200).unwrap(),
+    )
+    .finalize(components::uart_mux_component_static!());
 
     (*addr_of_mut!(io::WRITER)).set_initialized();
 

--- a/boards/wm1110dev/src/io.rs
+++ b/boards/wm1110dev/src/io.rs
@@ -3,6 +3,7 @@
 // Copyright Tock Contributors 2023.
 
 use core::fmt::Write;
+use core::num::NonZeroU32;
 use core::panic::PanicInfo;
 
 use kernel::debug;
@@ -47,7 +48,8 @@ impl IoWrite for Writer {
         if !self.initialized {
             self.initialized = true;
             let _ = uart.configure(uart::Parameters {
-                baud_rate: 115200,
+                // PANIC: 115200 != 0
+                baud_rate: NonZeroU32::new(115200).unwrap(),
                 stop_bits: uart::StopBits::One,
                 parity: uart::Parity::None,
                 hw_flow_control: false,

--- a/boards/wm1110dev/src/main.rs
+++ b/boards/wm1110dev/src/main.rs
@@ -12,6 +12,7 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use core::num::NonZeroU32;
 use core::ptr::addr_of;
 use core::ptr::addr_of_mut;
 
@@ -308,8 +309,12 @@ pub unsafe fn start() -> (
     );
 
     // Create a shared UART channel for the console and for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(&base_peripherals.uarte0, 115200)
-        .finalize(components::uart_mux_component_static!());
+    // PANIC: 115200 != 0
+    let uart_mux = components::console::UartMuxComponent::new(
+        &base_peripherals.uarte0,
+        NonZeroU32::new(115200).unwrap(),
+    )
+    .finalize(components::uart_mux_component_static!());
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(

--- a/capsules/extra/src/nrf51822_serialization.rs
+++ b/capsules/extra/src/nrf51822_serialization.rs
@@ -25,6 +25,7 @@
 //! ```
 
 use core::cmp;
+use core::num::NonZeroU32;
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::hil;
@@ -118,7 +119,7 @@ impl<'a> Nrf51822Serialization<'a> {
 
     pub fn initialize(&self) {
         let _ = self.uart.configure(uart::Parameters {
-            baud_rate: 250000,
+            baud_rate: NonZeroU32::new(250000).unwrap(),
             width: uart::Width::Eight,
             stop_bits: uart::StopBits::One,
             parity: uart::Parity::Even,

--- a/chips/apollo3/src/uart.rs
+++ b/chips/apollo3/src/uart.rs
@@ -5,6 +5,7 @@
 //! UART driver.
 
 use core::cell::Cell;
+use core::num::NonZeroU32;
 use kernel::ErrorCode;
 
 use kernel::hil;
@@ -217,7 +218,8 @@ impl Uart<'_> {
         }
     }
 
-    fn set_baud_rate(&self, baud_rate: u32) {
+    fn set_baud_rate(&self, baud_rate: NonZeroU32) {
+        let baud_rate = baud_rate.get();
         let regs = self.registers;
 
         let baud_clk = 16 * baud_rate;

--- a/chips/earlgrey/src/chip_config.rs
+++ b/chips/earlgrey/src/chip_config.rs
@@ -12,6 +12,8 @@
 //! the UART baud rate to enable better debugging on platforms that can support
 //! it.
 
+use core::num::NonZeroU32;
+
 /// Earlgrey configuration based on the target device.
 pub trait EarlGreyConfig {
     /// Identifier for the platform. This is useful for debugging to confirm the
@@ -29,5 +31,5 @@ pub trait EarlGreyConfig {
 
     /// The baud rate for UART. This allows for a version of the chip that can
     /// support a faster baud rate to use it to help with debugging.
-    const UART_BAUDRATE: u32;
+    const UART_BAUDRATE: NonZeroU32;
 }

--- a/chips/imxrt10xx/src/lpuart.rs
+++ b/chips/imxrt10xx/src/lpuart.rs
@@ -803,7 +803,7 @@ impl<'a> hil::uart::Transmit<'a> for Lpuart<'a> {
 
 impl hil::uart::Configure for Lpuart<'_> {
     fn configure(&self, params: hil::uart::Parameters) -> Result<(), ErrorCode> {
-        if params.baud_rate != 115200
+        if params.baud_rate.get() != 115200
             || params.stop_bits != hil::uart::StopBits::One
             || params.parity != hil::uart::Parity::None
             || params.hw_flow_control

--- a/chips/litex/src/uart.rs
+++ b/chips/litex/src/uart.rs
@@ -308,13 +308,13 @@ impl<R: LiteXSoCRegisterConfiguration> uart::Configure for LiteXUart<'_, R> {
                 || params.hw_flow_control
             {
                 Err(ErrorCode::NOSUPPORT)
-            } else if params.baud_rate == 0 || params.baud_rate > system_clock {
+            } else if params.baud_rate.get() > system_clock {
                 Err(ErrorCode::INVAL)
             } else {
-                let tuning_word = if params.baud_rate == system_clock {
+                let tuning_word = if params.baud_rate.get() == system_clock {
                     u32::MAX
                 } else {
-                    (((params.baud_rate as u64) * (1 << 32)) / (system_clock as u64)) as u32
+                    (((params.baud_rate.get() as u64) * (1 << 32)) / (system_clock as u64)) as u32
                 };
                 phy_regs.tuning_word.set(tuning_word);
 

--- a/chips/lowrisc/src/uart.rs
+++ b/chips/lowrisc/src/uart.rs
@@ -5,6 +5,7 @@
 //! UART driver.
 
 use core::cell::Cell;
+use core::num::NonZeroU32;
 use kernel::ErrorCode;
 
 use kernel::deferred_call::{DeferredCall, DeferredCallClient};
@@ -72,11 +73,11 @@ impl<'a> Uart<'a> {
         }
     }
 
-    fn set_baud_rate(&self, baud_rate: u32) -> Result<(), ErrorCode> {
+    fn set_baud_rate(&self, baud_rate: NonZeroU32) -> Result<(), ErrorCode> {
         const NCO_BITS: u32 = u32::count_ones(CTRL::NCO.mask);
 
         let regs = self.registers;
-        let baud_adj = (baud_rate as u64) << (NCO_BITS + 4);
+        let baud_adj = (baud_rate.get() as u64) << (NCO_BITS + 4);
         let freq_clk = self.clock_frequency as u64;
         let uart_ctrl_nco = div_round_bounded(baud_adj, freq_clk)?;
 

--- a/chips/msp432/src/uart.rs
+++ b/chips/msp432/src/uart.rs
@@ -180,8 +180,10 @@ impl hil::uart::Configure for Uart<'_> {
         }
 
         // Setup baudrate, all the calculation from the datasheet p. 915
-        let n = (self.clock_frequency / params.baud_rate) as u16;
-        let n_float = (self.clock_frequency as f32) / (params.baud_rate as f32);
+        // DIVISION: no division by 0 can occur because of the `baud_rate` type.
+        let n = (self.clock_frequency / params.baud_rate.get()) as u16;
+        // DIVISION: no division by 0 can occur because of the `baud_rate` type.
+        let n_float = (self.clock_frequency as f32) / (params.baud_rate.get() as f32);
         let frac_part = n_float - (n as f32);
         if n > 16 {
             // Oversampling is enabled

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -12,6 +12,7 @@
 
 use core::cell::Cell;
 use core::cmp::min;
+use core::num::NonZeroU32;
 use kernel::hil::uart;
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
@@ -239,7 +240,8 @@ impl<'a> Uarte<'a> {
         self.enable_uart();
     }
 
-    fn set_baud_rate(&self, baud_rate: u32) {
+    fn set_baud_rate(&self, baud_rate: NonZeroU32) {
+        let baud_rate = baud_rate.get();
         match baud_rate {
             1200 => self.registers.baudrate.set(0x0004F000),
             2400 => self.registers.baudrate.set(0x0009D000),

--- a/chips/sam4l/src/usart.rs
+++ b/chips/sam4l/src/usart.rs
@@ -8,6 +8,7 @@
 
 use core::cell::Cell;
 use core::cmp;
+use core::num::NonZeroU32;
 use core::sync::atomic::{AtomicBool, Ordering};
 use kernel::deferred_call::{DeferredCall, DeferredCallClient};
 use kernel::hil::spi;
@@ -723,7 +724,8 @@ impl<'a> USART<'a> {
         usart.registers.cr.write(Control::RSTSTA::SET);
     }
 
-    fn set_baud_rate(&self, usart: &USARTRegManager, baud_rate: u32) {
+    fn set_baud_rate(&self, usart: &USARTRegManager, baud_rate: NonZeroU32) {
+        let baud_rate = baud_rate.get();
         let system_frequency = self.pm.get_system_frequency();
 
         // The clock divisor is calculated differently in UART and SPI modes.
@@ -1064,7 +1066,8 @@ impl<'a> spi::SpiMaster<'a> for USART<'a> {
         self.usart_mode.set(UsartMode::Spi);
 
         // Set baud rate, default to 2 MHz.
-        self.set_baud_rate(usart, 2000000);
+        // PANIC: 2_000_000 != 0
+        self.set_baud_rate(usart, NonZeroU32::new(2000000).unwrap());
 
         usart.registers.mr.write(
             Mode::MODE::SPI_MASTER
@@ -1201,12 +1204,17 @@ impl<'a> spi::SpiMaster<'a> for USART<'a> {
 
     /// Returns the actual rate set
     fn set_rate(&self, rate: u32) -> Result<u32, ErrorCode> {
+        let non_zero_rate = match NonZeroU32::new(rate) {
+            Some(non_zero_rate) => non_zero_rate,
+            None => return Err(ErrorCode::INVAL),
+        };
         let usart = &USARTRegManager::new(self);
-        self.set_baud_rate(usart, rate);
+        self.set_baud_rate(usart, non_zero_rate);
 
         // Calculate what rate will actually be
         let system_frequency = self.pm.get_system_frequency();
-        let cd = system_frequency / rate;
+        // DIVISION: No division by 0 can occur because of the `non_zero_rate` type
+        let cd = system_frequency / non_zero_rate.get();
         Ok(system_frequency / cd)
     }
 

--- a/chips/sifive/src/uart.rs
+++ b/chips/sifive/src/uart.rs
@@ -5,6 +5,7 @@
 //! UART driver.
 
 use core::cell::Cell;
+use core::num::NonZeroU32;
 use kernel::utilities::registers::FieldValue;
 use kernel::ErrorCode;
 
@@ -136,13 +137,15 @@ impl<'a> Uart<'a> {
         rx.iof0();
     }
 
-    fn set_baud_rate(&self, baud_rate: u32) {
+    fn set_baud_rate(&self, baud_rate: NonZeroU32) {
         let regs = self.registers;
 
         //            f_clk
         // f_baud = ---------
         //           div + 1
-        let divisor = (self.clock_frequency / baud_rate) - 1;
+        //
+        // DIVISION: the type of `baud_rate` guarantees that divide by 0 cannot be produced.
+        let divisor = (self.clock_frequency / baud_rate.get()) - 1;
 
         regs.div.write(div::div.val(divisor));
     }

--- a/chips/stm32f303xc/src/usart.rs
+++ b/chips/stm32f303xc/src/usart.rs
@@ -565,7 +565,7 @@ impl<'a> hil::uart::Transmit<'a> for Usart<'a> {
 
 impl hil::uart::Configure for Usart<'_> {
     fn configure(&self, params: hil::uart::Parameters) -> Result<(), ErrorCode> {
-        if params.baud_rate != 115200
+        if params.baud_rate.get() != 115200
             || params.stop_bits != hil::uart::StopBits::One
             || params.parity != hil::uart::Parity::None
             || params.hw_flow_control

--- a/chips/stm32f4xx/src/usart.rs
+++ b/chips/stm32f4xx/src/usart.rs
@@ -3,6 +3,8 @@
 // Copyright Tock Contributors 2022.
 
 use core::cell::Cell;
+use core::num::NonZeroU32;
+
 use kernel::deferred_call::{DeferredCall, DeferredCallClient};
 use kernel::hil;
 use kernel::platform::chip::ClockInterface;
@@ -506,7 +508,8 @@ impl<'a, DMA: dma::StreamServer<'a>> Usart<'a, DMA> {
         }
     }
 
-    fn set_baud_rate(&self, baud_rate: u32) -> Result<(), ErrorCode> {
+    fn set_baud_rate(&self, baud_rate: NonZeroU32) -> Result<(), ErrorCode> {
+        let baud_rate = baud_rate.get();
         // USARTDIV calculation based on stm32-rs stm32f4xx-hal:
         // https://github.com/stm32-rs/stm32f4xx-hal/blob/v0.20.0/src/serial/uart_impls.rs#L145
         //

--- a/kernel/src/hil/uart.rs
+++ b/kernel/src/hil/uart.rs
@@ -6,6 +6,8 @@
 
 use crate::ErrorCode;
 
+use core::num::NonZeroU32;
+
 /// Number of stop bits to send after each word.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum StopBits {
@@ -41,7 +43,7 @@ pub enum Width {
 #[derive(Copy, Clone, Debug)]
 pub struct Parameters {
     /// Baud rate in bit/s.
-    pub baud_rate: u32,
+    pub baud_rate: NonZeroU32,
     /// Number of bits per word.
     pub width: Width,
     /// Parity bit configuration.


### PR DESCRIPTION
### Pull Request Overview

This pull request makes the baud rate non-nullable. It doesn't make sense to configure the UART with a nullable UART. Changing its type to `NonZeroU32` improves type safety and avoids division by 0. 


### Testing Strategy

This pull request was tested by compiling. I will test it with Raspberry Pi Pico later.


### TODO or Help Wanted

I need help with testing other boards to ensure everything behaves as expected.


### Documentation Updated

- [x] No updates required.

### Formatting

- [x] Ran `make prepush`.
