### PR TITLE
arch: cortex-m (v7m): Only check and set the stack bit in `EXC_RETURN`

### DIFF
--- a/arch/cortex-v7m/src/lib.rs
+++ b/arch/cortex-v7m/src/lib.rs
@@ -74,10 +74,10 @@ core::arch::global_asm!(
   svc_handler_arm_v7m:
     // First check to see which direction we are going in. If the link register
     // (containing EXC_RETURN) has a 1 in the SPSEL bit (meaning the
-    // alternative/process stack was in use) then we are coming from an app
+    // alternative/process stack was in use) then we are coming from a process
     // which has called a syscall.
     ubfx r0, lr, #2, #1               // r0 = (LR & (0x1<<2)) >> 2
-    cmp r0, #0                        // r0 (SPSEL bit) ≟ 0
+    cmp r0, #0                        // r0 (SPSEL bit) =≟ 0
     bne 100f // to_kernel             // if SPSEL == 1, jump to to_kernel
 
     // If we get here, then this is a context switch from the kernel to the
@@ -97,7 +97,7 @@ core::arch::global_asm!(
     isb
 
     // The link register is set to the `EXC_RETURN` value on exception entry. To
-    // ensure we execute using the application stack we set the SPSEL bit to 1
+    // ensure we execute using the process stack we set the SPSEL bit to 1
     // to use the alternate (process) stack.
     mov r0, #1                        // r0 = 1
     bfi lr, r0, #2, #1                // LR = LR | (0x1<<2)

--- a/arch/cortex-v7m/src/lib.rs
+++ b/arch/cortex-v7m/src/lib.rs
@@ -77,8 +77,8 @@ core::arch::global_asm!(
     // alternative/process stack was in use) then we are coming from an app
     // which has called a syscall.
     ubfx r0, lr, #2, #1               // r0 = (LR & (0x1<<2)) >> 2
-    cmp r0, #0                        // LR ≟ 0
-    bne 100f // to_kernel             // if LR != 1, jump to to_kernel
+    cmp r0, #0                        // r0 (SPSEL bit) ≟ 0
+    bne 100f // to_kernel             // if SPSEL == 1, jump to to_kernel
 
     // If we get here, then this is a context switch from the kernel to the
     // application. Use the CONTROL register to set the thread mode to


### PR DESCRIPTION
### Pull Request Overview

In the exception handling assembly for the cortex-m v7m platform we have been using the full value of `EXC_RETURN` for checking if we are coming from userspace and for directing where we should go to after the exception handler returns. This has been effective, but has two drawbacks:

1. It will not work for full floating point-enabled hardware/software that uses the larger exception frame.
2. It will not work for the v8m architecture which uses more of the bits that are reserved on v7m.

Obviously we don't need the v7m crate to support the v8m architecture. However, this might still be a good fix, as I think this is what we want to be doing in these exception routines, and we don't actually need to be setting all of the other bits. This should also help with porting to hard float.





### Testing Strategy

Could this be a test case for HWCI?


### TODO or Help Wanted

I can say this change matters for a v8m platform. But we may not want exactly this change.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
