### PR TITLE
Isolated Nonvolatile Storage Capsule

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ members = [
     "boards/weact_f401ccu6/",
     "boards/configurations/nrf52840dk/nrf52840dk-test-appid-sha256",
     "boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf",
+    "boards/configurations/nrf52840dk/nrf52840dk-test-invs",
     "boards/configurations/nrf52840dk/nrf52840dk-test-kernel",
     "boards/tutorials/nrf52840dk-hotp-tutorial",
     "boards/tutorials/nrf52840dk-thread-tutorial",

--- a/boards/components/src/isolated_nonvolatile_storage.rs
+++ b/boards/components/src/isolated_nonvolatile_storage.rs
@@ -33,9 +33,9 @@ use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
 
-// How much storage space to allocate per-app. Currently, regions are not 
+// How much storage space to allocate per-app. Currently, regions are not
 // growable, so this will be all the space the app gets.
-// Only affects newly allocated regions. Old regions can remain the same size. 
+// Only affects newly allocated regions. Old regions can remain the same size.
 pub const ISOLATED_NONVOLATILE_STORAGE_APP_REGION_SIZE_DEFAULT: usize = 2048;
 
 // Setup static space for the objects.
@@ -52,7 +52,8 @@ macro_rules! isolated_nonvolatile_storage_component_static {
                 $APP_REGION_SIZE,
             >
         );
-        let buffer = kernel::static_buf!([u8; capsules_extra::isolated_nonvolatile_storage_driver::BUF_LEN]);
+        let buffer =
+            kernel::static_buf!([u8; capsules_extra::isolated_nonvolatile_storage_driver::BUF_LEN]);
 
         (page, ntp, ns, buffer)
     };};
@@ -107,7 +108,9 @@ impl<
         &'static mut MaybeUninit<<F as hil::flash::Flash>::Page>,
         &'static mut MaybeUninit<NonvolatileToPages<'static, F>>,
         &'static mut MaybeUninit<IsolatedNonvolatileStorage<'static, APP_REGION_SIZE>>,
-        &'static mut MaybeUninit<[u8; capsules_extra::isolated_nonvolatile_storage_driver::BUF_LEN]>,
+        &'static mut MaybeUninit<
+            [u8; capsules_extra::isolated_nonvolatile_storage_driver::BUF_LEN],
+        >,
     );
     type Output = &'static IsolatedNonvolatileStorage<'static, APP_REGION_SIZE>;
 

--- a/boards/components/src/isolated_nonvolatile_storage.rs
+++ b/boards/components/src/isolated_nonvolatile_storage.rs
@@ -1,0 +1,140 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! Component for isolated non-volatile storage Drivers.
+//!
+//! This provides one component, IsolatedNonvolatileStorageComponent, which provides
+//! a system call interface to isolated non-volatile storage.
+//!
+//! This differs from NonvolatileStorageComponent in that it provides isolation
+//! between apps. Each app has it's own storage address space (that starts at 0)
+//! which doesn't interfere with other apps.
+//!
+//! Usage
+//! -----
+//! ```rust
+//! let nonvolatile_storage = components::isolated_nonvolatile_storage::IsolatedNonvolatileStorageComponent::new(
+//!     board_kernel,
+//!     &sam4l::flashcalw::FLASH_CONTROLLER,
+//!     0x60000,
+//!     0x20000,
+//! )
+//! .finalize(components::isolated_nonvolatile_storage_component_static!(
+//!     sam4l::flashcalw::FLASHCALW
+//! ));
+//! ```
+
+use capsules_extra::isolated_nonvolatile_storage_driver::IsolatedNonvolatileStorage;
+use capsules_extra::nonvolatile_to_pages::NonvolatileToPages;
+use core::mem::MaybeUninit;
+use kernel::capabilities;
+use kernel::component::Component;
+use kernel::create_capability;
+use kernel::hil;
+
+// How much storage space to allocate per-app. Currently, regions are not 
+// growable, so this will be all the space the app gets.
+// Only affects newly allocated regions. Old regions can remain the same size. 
+pub const ISOLATED_NONVOLATILE_STORAGE_APP_REGION_SIZE_DEFAULT: usize = 2048;
+
+// Setup static space for the objects.
+#[macro_export]
+macro_rules! isolated_nonvolatile_storage_component_static {
+    ($F:ty, $APP_REGION_SIZE:expr $(,)?) => {{
+        let page = kernel::static_buf!(<$F as kernel::hil::flash::Flash>::Page);
+        let ntp = kernel::static_buf!(
+            capsules_extra::nonvolatile_to_pages::NonvolatileToPages<'static, $F>
+        );
+        let ns = kernel::static_buf!(
+            capsules_extra::isolated_nonvolatile_storage_driver::IsolatedNonvolatileStorage<
+                'static,
+                $APP_REGION_SIZE,
+            >
+        );
+        let buffer = kernel::static_buf!([u8; capsules_extra::isolated_nonvolatile_storage_driver::BUF_LEN]);
+
+        (page, ntp, ns, buffer)
+    };};
+}
+
+pub type IsolatedNonvolatileStorageComponentType<const APP_REGION_SIZE: usize> =
+    IsolatedNonvolatileStorage<'static, APP_REGION_SIZE>;
+
+pub struct IsolatedNonvolatileStorageComponent<
+    F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, NonvolatileToPages<'static, F>>,
+    const APP_REGION_SIZE: usize,
+> {
+    board_kernel: &'static kernel::Kernel,
+    driver_num: usize,
+    flash: &'static F,
+    userspace_start: usize,
+    userspace_length: usize,
+}
+
+impl<
+        F: 'static
+            + hil::flash::Flash
+            + hil::flash::HasClient<'static, NonvolatileToPages<'static, F>>,
+        const APP_REGION_SIZE: usize,
+    > IsolatedNonvolatileStorageComponent<F, APP_REGION_SIZE>
+{
+    pub fn new(
+        board_kernel: &'static kernel::Kernel,
+        driver_num: usize,
+        flash: &'static F,
+        userspace_start: usize,
+        userspace_length: usize,
+    ) -> Self {
+        Self {
+            board_kernel,
+            driver_num,
+            flash,
+            userspace_start,
+            userspace_length,
+        }
+    }
+}
+
+impl<
+        F: 'static
+            + hil::flash::Flash
+            + hil::flash::HasClient<'static, NonvolatileToPages<'static, F>>,
+        const APP_REGION_SIZE: usize,
+    > Component for IsolatedNonvolatileStorageComponent<F, APP_REGION_SIZE>
+{
+    type StaticInput = (
+        &'static mut MaybeUninit<<F as hil::flash::Flash>::Page>,
+        &'static mut MaybeUninit<NonvolatileToPages<'static, F>>,
+        &'static mut MaybeUninit<IsolatedNonvolatileStorage<'static, APP_REGION_SIZE>>,
+        &'static mut MaybeUninit<[u8; capsules_extra::isolated_nonvolatile_storage_driver::BUF_LEN]>,
+    );
+    type Output = &'static IsolatedNonvolatileStorage<'static, APP_REGION_SIZE>;
+
+    fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
+        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+
+        let buffer = static_buffer
+            .3
+            .write([0; capsules_extra::isolated_nonvolatile_storage_driver::BUF_LEN]);
+
+        let flash_pagebuffer = static_buffer
+            .0
+            .write(<F as hil::flash::Flash>::Page::default());
+
+        let nv_to_page = static_buffer
+            .1
+            .write(NonvolatileToPages::new(self.flash, flash_pagebuffer));
+        hil::flash::HasClient::set_client(self.flash, nv_to_page);
+
+        let nonvolatile_storage = static_buffer.2.write(IsolatedNonvolatileStorage::new(
+            nv_to_page,
+            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.userspace_start, // Start address for userspace accessible region
+            self.userspace_length, // Length of userspace accessible region
+            buffer,
+        ));
+        hil::nonvolatile_storage::NonvolatileStorage::set_client(nv_to_page, nonvolatile_storage);
+        nonvolatile_storage
+    }
+}

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -45,6 +45,7 @@ pub mod humidity;
 pub mod i2c;
 pub mod ieee802154;
 pub mod isl29035;
+pub mod isolated_nonvolatile_storage;
 pub mod keyboard_hid;
 pub mod kv;
 pub mod l3gd20;

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-invs/Cargo.toml
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-invs/Cargo.toml
@@ -1,0 +1,28 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
+[package]
+name = "nrf52840dk-test-invs"
+version.workspace = true
+authors.workspace = true
+build = "../../../build.rs"
+edition.workspace = true
+
+[dependencies]
+components = { path = "../../../components" }
+cortexm4 = { path = "../../../../arch/cortex-m4" }
+kernel = { path = "../../../../kernel" }
+nrf52840 = { path = "../../../../chips/nrf52840" }
+segger = { path = "../../../../chips/segger" }
+nrf52_components = { path = "../../../nordic/nrf52_components" }
+
+capsules-core = { path = "../../../../capsules/core" }
+capsules-extra = { path = "../../../../capsules/extra" }
+capsules-system = { path = "../../../../capsules/system" }
+
+[build-dependencies]
+tock_build_scripts = { path = "../../../build_scripts" }
+
+[lints]
+workspace = true

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-invs/Makefile
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-invs/Makefile
@@ -1,0 +1,6 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
+include ../../../Makefile.common
+include ../nrf52840dk.mk

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-invs/README.md
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-invs/README.md
@@ -1,0 +1,6 @@
+nRF52840-DK Isolated Nonvolatile Storage Test Board
+===================================
+
+This is a minimal kernel for testing isolated storage.
+
+The board uses the external flash for the storage area.

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-invs/layout.ld
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-invs/layout.ld
@@ -1,0 +1,6 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
+INCLUDE ../../../nordic/nrf52840_chip_layout.ld
+INCLUDE tock_kernel_layout.ld

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-invs/src/invs_permissions.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-invs/src/invs_permissions.rs
@@ -1,0 +1,68 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+use capsules_system::storage_permissions::tbf_header::TbfHeaderStoragePermissions;
+use kernel::capabilities::ApplicationStorageCapability;
+use kernel::platform::chip::Chip;
+use kernel::process::Process;
+use kernel::process::ShortId;
+use kernel::storage_permissions::StoragePermissions;
+
+/// Assign storage permissions from the TBF header if they exist, or default to
+/// accessing own state.
+pub struct InvsStoragePermissions<
+    C: Chip,
+    D: kernel::process::ProcessStandardDebug,
+    CAP: ApplicationStorageCapability + Clone,
+> {
+    tbf_permissions: TbfHeaderStoragePermissions<C, D, CAP>,
+    cap: CAP,
+    _chip: core::marker::PhantomData<C>,
+    _debug: core::marker::PhantomData<D>,
+}
+
+impl<
+        C: Chip,
+        D: kernel::process::ProcessStandardDebug,
+        CAP: ApplicationStorageCapability + Clone,
+    > InvsStoragePermissions<C, D, CAP>
+{
+    pub fn new(cap: CAP) -> Self {
+        Self {
+            tbf_permissions: TbfHeaderStoragePermissions::new(cap.clone()),
+            cap,
+            _chip: core::marker::PhantomData,
+            _debug: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<
+        C: Chip,
+        D: kernel::process::ProcessStandardDebug,
+        CAP: ApplicationStorageCapability + Clone,
+    > kernel::process::ProcessStandardStoragePermissionsPolicy<C, D>
+    for InvsStoragePermissions<C, D, CAP>
+{
+    fn get_permissions(
+        &self,
+        process: &kernel::process::ProcessStandard<C, D>,
+    ) -> StoragePermissions {
+        // If we have a fixed ShortId then this process can have storage
+        // permissions. Otherwise we get null permissions.
+        match process.short_app_id() {
+            ShortId::Fixed(id) => {
+                // Check if we can get permissions from the TBF. If so, use
+                // those, otherwise default to "individual" (ie can only write
+                // its own state) permissions.
+                if process.get_tbf_storage_permissions().is_some() {
+                    self.tbf_permissions.get_permissions(process)
+                } else {
+                    StoragePermissions::new_self_only(id, &self.cap)
+                }
+            }
+            ShortId::LocallyUnique => StoragePermissions::new_null(),
+        }
+    }
+}

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-invs/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-invs/src/io.rs
@@ -1,0 +1,17 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2024.
+
+use core::panic::PanicInfo;
+use nrf52840::gpio::Pin;
+
+#[cfg(not(test))]
+#[no_mangle]
+#[panic_handler]
+/// Panic handler
+pub unsafe fn panic_fmt(_pi: &PanicInfo) -> ! {
+    // The nRF52840DK LEDs (see back of board)
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
+    let led = &mut kernel::hil::led::LedLow::new(led_kernel_pin);
+    kernel::debug::panic_blink_forever(&mut [led])
+}

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-invs/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-invs/src/main.rs
@@ -1,0 +1,402 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! Tock kernel for the Nordic Semiconductor nRF52840 development kit (DK).
+
+#![no_std]
+// Disable this attribute when documenting, as a workaround for
+// https://github.com/rust-lang/rust/issues/62184.
+#![cfg_attr(not(doc), no_main)]
+#![deny(missing_docs)]
+
+use core::ptr::{addr_of, addr_of_mut};
+
+use kernel::component::Component;
+use kernel::hil::led::LedLow;
+use kernel::hil::time::Counter;
+use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::scheduler::round_robin::RoundRobinSched;
+use kernel::{capabilities, create_capability, static_init};
+use nrf52840::gpio::Pin;
+use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
+use nrf52_components::{UartChannel, UartPins};
+
+mod invs_permissions;
+
+// The nRF52840DK LEDs (see back of board)
+const LED1_PIN: Pin = Pin::P0_13;
+const LED2_PIN: Pin = Pin::P0_14;
+const LED3_PIN: Pin = Pin::P0_15;
+const LED4_PIN: Pin = Pin::P0_16;
+
+const BUTTON_RST_PIN: Pin = Pin::P0_18;
+
+const UART_RTS: Option<Pin> = Some(Pin::P0_05);
+const UART_TXD: Pin = Pin::P0_06;
+const UART_CTS: Option<Pin> = Some(Pin::P0_07);
+const UART_RXD: Pin = Pin::P0_08;
+
+const SPI_MOSI: Pin = Pin::P0_20;
+const SPI_MISO: Pin = Pin::P0_21;
+const SPI_CLK: Pin = Pin::P0_19;
+
+const SPI_MX25R6435F_CHIP_SELECT: Pin = Pin::P0_17;
+const SPI_MX25R6435F_WRITE_PROTECT_PIN: Pin = Pin::P0_22;
+const SPI_MX25R6435F_HOLD_PIN: Pin = Pin::P0_23;
+
+/// Debug Writer
+pub mod io;
+
+// State for loading and holding applications.
+// How should the kernel respond when a process faults.
+const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
+    capsules_system::process_policies::PanicFaultPolicy {};
+
+// Number of concurrent processes this platform supports.
+const NUM_PROCS: usize = 8;
+
+static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS] =
+    [None; NUM_PROCS];
+
+static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;
+
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x2000] = [0; 0x2000];
+
+const APP_STORAGE_REGION_SIZE: usize = 4096;
+
+//------------------------------------------------------------------------------
+// SYSCALL DRIVER TYPE DEFINITIONS
+//------------------------------------------------------------------------------
+
+type AlarmDriver = components::alarm::AlarmDriverComponentType<nrf52840::rtc::Rtc<'static>>;
+
+type Mx25r6435f = components::mx25r6435f::Mx25r6435fComponentType<
+    nrf52840::spi::SPIM<'static>,
+    nrf52840::gpio::GPIOPin<'static>,
+    nrf52840::rtc::Rtc<'static>,
+>;
+type InvsDriver = components::isolated_nonvolatile_storage::IsolatedNonvolatileStorageComponentType<
+    APP_STORAGE_REGION_SIZE,
+>;
+
+/// Supported drivers by the platform
+pub struct Platform {
+    console: &'static capsules_core::console::Console<'static>,
+    led: &'static capsules_core::led::LedDriver<
+        'static,
+        kernel::hil::led::LedLow<'static, nrf52840::gpio::GPIOPin<'static>>,
+        4,
+    >,
+    alarm: &'static AlarmDriver,
+    invs: &'static InvsDriver,
+    scheduler: &'static RoundRobinSched<'static>,
+    systick: cortexm4::systick::SysTick,
+}
+
+impl SyscallDriverLookup for Platform {
+    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    where
+        F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
+    {
+        match driver_num {
+            capsules_core::console::DRIVER_NUM => f(Some(self.console)),
+            capsules_core::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules_core::led::DRIVER_NUM => f(Some(self.led)),
+            capsules_extra::isolated_nonvolatile_storage_driver::DRIVER_NUM => f(Some(self.invs)),
+            _ => f(None),
+        }
+    }
+}
+
+/// This is in a separate, inline(never) function so that its stack frame is
+/// removed when this function returns. Otherwise, the stack space used for
+/// these static_inits is wasted.
+#[inline(never)]
+unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> {
+    let ieee802154_ack_buf = static_init!(
+        [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
+        [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
+    );
+    // Initialize chip peripheral drivers
+    let nrf52840_peripherals = static_init!(
+        Nrf52840DefaultPeripherals,
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf)
+    );
+
+    nrf52840_peripherals
+}
+
+impl KernelResources<nrf52840::chip::NRF52<'static, Nrf52840DefaultPeripherals<'static>>>
+    for Platform
+{
+    type SyscallDriverLookup = Self;
+    type SyscallFilter = ();
+    type ProcessFault = ();
+    type Scheduler = RoundRobinSched<'static>;
+    type SchedulerTimer = cortexm4::systick::SysTick;
+    type WatchDog = ();
+    type ContextSwitchCallback = ();
+
+    fn syscall_driver_lookup(&self) -> &Self::SyscallDriverLookup {
+        self
+    }
+    fn syscall_filter(&self) -> &Self::SyscallFilter {
+        &()
+    }
+    fn process_fault(&self) -> &Self::ProcessFault {
+        &()
+    }
+    fn scheduler(&self) -> &Self::Scheduler {
+        self.scheduler
+    }
+    fn scheduler_timer(&self) -> &Self::SchedulerTimer {
+        &self.systick
+    }
+    fn watchdog(&self) -> &Self::WatchDog {
+        &()
+    }
+    fn context_switch_callback(&self) -> &Self::ContextSwitchCallback {
+        &()
+    }
+}
+
+/// Main function called after RAM initialized.
+#[no_mangle]
+pub unsafe fn main() {
+    //--------------------------------------------------------------------------
+    // INITIAL SETUP
+    //--------------------------------------------------------------------------
+
+    // Apply errata fixes and enable interrupts.
+    nrf52840::init();
+
+    // Set up peripheral drivers. Called in separate function to reduce stack
+    // usage.
+    let nrf52840_peripherals = create_peripherals();
+
+    // Set up circular peripheral dependencies.
+    nrf52840_peripherals.init();
+    let base_peripherals = &nrf52840_peripherals.nrf52;
+
+    // Choose the channel for serial output. This board can be configured to use
+    // either the Segger RTT channel or via UART with traditional TX/RX GPIO
+    // pins.
+    let uart_channel = UartChannel::Pins(UartPins::new(UART_RTS, UART_TXD, UART_CTS, UART_RXD));
+
+    // Setup space to store the core kernel data structure.
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
+
+    // Create (and save for panic debugging) a chip object to setup low-level
+    // resources (e.g. MPU, systick).
+    let chip = static_init!(
+        nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
+        nrf52840::chip::NRF52::new(nrf52840_peripherals)
+    );
+    CHIP = Some(chip);
+
+    // Do nRF configuration and setup. This is shared code with other nRF-based
+    // platforms.
+    nrf52_components::startup::NrfStartupComponent::new(
+        false,
+        BUTTON_RST_PIN,
+        nrf52840::uicr::Regulator0Output::DEFAULT,
+        &base_peripherals.nvmc,
+    )
+    .finalize(());
+
+    //--------------------------------------------------------------------------
+    // CAPABILITIES
+    //--------------------------------------------------------------------------
+
+    // Create capabilities that the board needs to call certain protected kernel
+    // functions.
+    let main_loop_capability = create_capability!(capabilities::MainLoopCapability);
+
+    //--------------------------------------------------------------------------
+    // LEDs
+    //--------------------------------------------------------------------------
+
+    let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
+        LedLow<'static, nrf52840::gpio::GPIOPin>,
+        LedLow::new(&nrf52840_peripherals.gpio_port[LED1_PIN]),
+        LedLow::new(&nrf52840_peripherals.gpio_port[LED2_PIN]),
+        LedLow::new(&nrf52840_peripherals.gpio_port[LED3_PIN]),
+        LedLow::new(&nrf52840_peripherals.gpio_port[LED4_PIN]),
+    ));
+
+    //--------------------------------------------------------------------------
+    // TIMER
+    //--------------------------------------------------------------------------
+
+    let rtc = &base_peripherals.rtc;
+    let _ = rtc.start();
+    let mux_alarm = components::alarm::AlarmMuxComponent::new(rtc)
+        .finalize(components::alarm_mux_component_static!(nrf52840::rtc::Rtc));
+    let alarm = components::alarm::AlarmDriverComponent::new(
+        board_kernel,
+        capsules_core::alarm::DRIVER_NUM,
+        mux_alarm,
+    )
+    .finalize(components::alarm_component_static!(nrf52840::rtc::Rtc));
+
+    //--------------------------------------------------------------------------
+    // UART & CONSOLE & DEBUG
+    //--------------------------------------------------------------------------
+
+    let uart_channel = nrf52_components::UartChannelComponent::new(
+        uart_channel,
+        mux_alarm,
+        &base_peripherals.uarte0,
+    )
+    .finalize(nrf52_components::uart_channel_component_static!(
+        nrf52840::rtc::Rtc
+    ));
+
+    // Virtualize the UART channel for the console and for kernel debug.
+    let uart_mux = components::console::UartMuxComponent::new(uart_channel, 115200)
+        .finalize(components::uart_mux_component_static!());
+
+    // Setup the serial console for userspace.
+    let console = components::console::ConsoleComponent::new(
+        board_kernel,
+        capsules_core::console::DRIVER_NUM,
+        uart_mux,
+    )
+    .finalize(components::console_component_static!());
+
+    //--------------------------------------------------------------------------
+    // ONBOARD EXTERNAL FLASH
+    //--------------------------------------------------------------------------
+
+    let mux_spi = components::spi::SpiMuxComponent::new(&base_peripherals.spim0)
+        .finalize(components::spi_mux_component_static!(nrf52840::spi::SPIM));
+
+    base_peripherals.spim0.configure(
+        nrf52840::pinmux::Pinmux::new(SPI_MOSI as u32),
+        nrf52840::pinmux::Pinmux::new(SPI_MISO as u32),
+        nrf52840::pinmux::Pinmux::new(SPI_CLK as u32),
+    );
+
+    let mx25r6435f = components::mx25r6435f::Mx25r6435fComponent::new(
+        Some(&nrf52840_peripherals.gpio_port[SPI_MX25R6435F_WRITE_PROTECT_PIN]),
+        Some(&nrf52840_peripherals.gpio_port[SPI_MX25R6435F_HOLD_PIN]),
+        &nrf52840_peripherals.gpio_port[SPI_MX25R6435F_CHIP_SELECT],
+        mux_alarm,
+        mux_spi,
+    )
+    .finalize(components::mx25r6435f_component_static!(
+        nrf52840::spi::SPIM,
+        nrf52840::gpio::GPIOPin,
+        nrf52840::rtc::Rtc
+    ));
+
+    //--------------------------------------------------------------------------
+    // NONVOLATILE STORAGE
+    //--------------------------------------------------------------------------
+
+    let invs = components::isolated_nonvolatile_storage::IsolatedNonvolatileStorageComponent::new(
+        board_kernel,
+        capsules_extra::isolated_nonvolatile_storage_driver::DRIVER_NUM,
+        mx25r6435f,
+        0x40000,  // start address
+        0x100000, // length
+    )
+    .finalize(components::isolated_nonvolatile_storage_component_static!(
+        Mx25r6435f,
+        APP_STORAGE_REGION_SIZE
+    ));
+
+    //--------------------------------------------------------------------------
+    // NRF CLOCK SETUP
+    //--------------------------------------------------------------------------
+
+    nrf52_components::NrfClockComponent::new(&base_peripherals.clock).finalize(());
+
+    //--------------------------------------------------------------------------
+    // Credential Checking
+    //--------------------------------------------------------------------------
+
+    // Create the software-based SHA engine.
+    let sha = components::sha::ShaSoftware256Component::new()
+        .finalize(components::sha_software_256_component_static!());
+
+    // Create the credential checker.
+    let checking_policy = components::appid::checker_sha::AppCheckerSha256Component::new(sha)
+        .finalize(components::app_checker_sha256_component_static!());
+
+    // Create the AppID assigner.
+    let assigner = components::appid::assigner_name::AppIdAssignerNamesComponent::new()
+        .finalize(components::appid_assigner_names_component_static!());
+
+    // Create the process checking machine.
+    let checker = components::appid::checker::ProcessCheckerMachineComponent::new(checking_policy)
+        .finalize(components::process_checker_machine_component_static!());
+
+    //--------------------------------------------------------------------------
+    // STORAGE PERMISSIONS
+    //--------------------------------------------------------------------------
+
+    // We use a custom storage permissions assigner that is based on the TBF
+    // header if present, and otherwise defaults to allowing apps to access
+    // their own state.
+
+    #[derive(Clone)]
+    pub struct AppStoreCapability;
+    unsafe impl capabilities::ApplicationStorageCapability for AppStoreCapability {}
+
+    let storage_permissions_policy = static_init!(
+        invs_permissions::InvsStoragePermissions<
+            nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
+            kernel::process::ProcessStandardDebugFull,
+            AppStoreCapability,
+        >,
+        invs_permissions::InvsStoragePermissions::new(AppStoreCapability)
+    );
+
+    //--------------------------------------------------------------------------
+    // PROCESS LOADING
+    //--------------------------------------------------------------------------
+
+    // Create and start the asynchronous process loader.
+    let _loader = components::loader::sequential::ProcessLoaderSequentialComponent::new(
+        checker,
+        &mut *addr_of_mut!(PROCESSES),
+        board_kernel,
+        chip,
+        &FAULT_RESPONSE,
+        assigner,
+        storage_permissions_policy,
+    )
+    .finalize(components::process_loader_sequential_component_static!(
+        nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
+        kernel::process::ProcessStandardDebugFull,
+        NUM_PROCS
+    ));
+
+    //--------------------------------------------------------------------------
+    // PLATFORM SETUP, SCHEDULER, AND START KERNEL LOOP
+    //--------------------------------------------------------------------------
+
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
+        .finalize(components::round_robin_component_static!(NUM_PROCS));
+
+    let platform = Platform {
+        console,
+        led,
+        alarm,
+        invs,
+        scheduler,
+        systick: cortexm4::systick::SysTick::new_with_calibration(64000000),
+    };
+
+    board_kernel.kernel_loop(
+        &platform,
+        chip,
+        None::<&kernel::ipc::IPC<0>>,
+        &main_loop_capability,
+    );
+}

--- a/boards/tutorials/nrf52840dk-thread-tutorial/src/main.rs
+++ b/boards/tutorials/nrf52840dk-thread-tutorial/src/main.rs
@@ -13,7 +13,6 @@
 use core::ptr::{addr_of, addr_of_mut};
 
 use kernel::component::Component;
-use kernel::debug;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::{capabilities, create_capability};
 use nrf52840::gpio::Pin;

--- a/capsules/core/src/driver.rs
+++ b/capsules/core/src/driver.rs
@@ -58,6 +58,7 @@ pub enum NUM {
     NvmStorage            = 0x50001,
     SdCard                = 0x50002,
     Kv                    = 0x50003,
+    IsolatedNvmStorage    = 0x50004,
 
     // Sensors
     Temperature           = 0x60000,

--- a/capsules/extra/README.md
+++ b/capsules/extra/README.md
@@ -155,6 +155,8 @@ simultaneously) support for generic sensor interfaces.
   gyroscope).
 - **[Nonvolatile Storage](src/nonvolatile_storage_driver.rs)**: Persistent
   storage for userspace.
+- **[Isolated Nonvolatile Storage](src/isolated_nonvolatile_storage_driver.rs)**:
+  Per-app isolated persistent storage for userspace.
 
 
 Utility Capsules

--- a/capsules/extra/src/isolated_nonvolatile_storage_driver.rs
+++ b/capsules/extra/src/isolated_nonvolatile_storage_driver.rs
@@ -755,6 +755,7 @@ impl<'a, const APP_REGION_SIZE: usize> IsolatedNonvolatileStorage<'a, APP_REGION
                             match res {
                                 Ok(started_operation) => started_operation,
                                 Err(e) => {
+                                    app.pending_operation = None;
                                     kernel_data
                                         .schedule_upcall(
                                             nvm_command.upcall(),

--- a/capsules/extra/src/isolated_nonvolatile_storage_driver.rs
+++ b/capsules/extra/src/isolated_nonvolatile_storage_driver.rs
@@ -332,6 +332,38 @@ pub struct App {
     pending_operation: Option<NvmCommand>,
 }
 
+/// Helper function to convert create a full, single usize value from two 32-bit
+/// values stored in usizes.
+///
+/// In C this would look like:
+///
+/// ```c
+/// size_t v = (hi << 32) | (uint32_t) lo;
+/// ```
+///
+/// This is useful when passing a machine-sized value (i.e. a `size_t`) via the
+/// system call interface in two 32-bit usize values. On a 32-bit machine this
+/// essentially has no effect; the full value is stored in the `lo` usize. On a
+/// 64-bit machine, this creates a usize by concatenating the hi and lo 32-bit
+/// values.
+///
+/// TODO
+/// ----
+///
+/// This can be more succinctly implemented using
+/// [`unbounded_shl()`](https://doc.rust-lang.org/stable/std/primitive.usize.html#method.unbounded_shl).
+/// However, that method is currently a nightly-only feature.
+#[inline]
+pub const fn usize32s_to_usize(lo: usize, hi: usize) -> usize {
+    if usize::BITS <= 32 {
+        // Just return the lo value since it has the bits we need.
+        lo
+    } else {
+        // Create a 64-bit value.
+        (lo & 0xFFFFFFFF) | (hi << 32)
+    }
+}
+
 pub struct IsolatedNonvolatileStorage<'a, const APP_REGION_SIZE: usize> {
     /// The underlying physical storage device.
     driver: &'a dyn hil::nonvolatile_storage::NonvolatileStorage<'a>,
@@ -1081,11 +1113,7 @@ impl<const APP_REGION_SIZE: usize> SyscallDriver
             1 | 2 | 3 => {
                 // We want to handle both 64-bit and 32-bit platforms, but on
                 // 32-bit platforms shifting `offset_hi` doesn't make sense.
-                let offset: usize = if usize::BITS <= 32 {
-                    offset_lo
-                } else {
-                    (offset_lo & 0xFFFFFFFF) | (offset_hi << 32)
-                };
+                let offset: usize = usize32s_to_usize(offset_lo, offset_hi);
                 let nvm_command = match command_num {
                     1 => NvmCommand::GetSize,
                     2 => NvmCommand::Read { offset },

--- a/capsules/extra/src/isolated_nonvolatile_storage_driver.rs
+++ b/capsules/extra/src/isolated_nonvolatile_storage_driver.rs
@@ -52,18 +52,18 @@
 //! This capsule caches the location of an application's storage region in
 //! grant. This cached location is set on the first usage of this capsule.
 //!
-//! Here is a general high-level overview of what happens when an
-//! app makes their first syscall:
-//!  1. App engages with the capsule by making any syscall.
-//!  2. Capsule searches through storage to see if that app
-//!     has an existing region.
-//!  3. a. If the capsule finds a matching region:
-//!         - Cache the app's region information in its grant.
-//!     b. If the capsule DOESN'T find a matching region:
-//!         - Allocate a new region for that app.
-//!         - Erase the region's usable area.
-//!   4. Handle the syscall that the app originally made.
-//!   5. When the syscall finishes, notify the app via upcall.
+//! Here is a general high-level overview of what happens when an app makes its
+//! first syscall:
+//! 1. App engages with the capsule by making any syscall.
+//! 2. Capsule searches through storage to see if that app has an existing
+//!    region.
+//! 3. a. If the capsule finds a matching region:
+//!    - Cache the app's region information in its grant.
+//!    b. If the capsule DOESN'T find a matching region:
+//!    - Allocate a new region for that app.
+//!    - Erase the region's usable area.
+//! 4. Handle the syscall that the app originally made.
+//! 5. When the syscall finishes, notify the app via upcall.
 //!
 //! ## Example Software Stack
 //!
@@ -938,7 +938,7 @@ impl<const APP_REGION_SIZE: usize> hil::nonvolatile_storage::NonvolatileStorageC
                             }
                         }
                         _ => {}
-                    };
+                    }
                 }
                 User::App { processid } => {
                     let _ = self.apps.enter(processid, move |app, kernel_data| {
@@ -1057,7 +1057,7 @@ impl<const APP_REGION_SIZE: usize> hil::nonvolatile_storage::NonvolatileStorageC
                             }
                         }
                         _ => {}
-                    };
+                    }
                 }
                 User::App { processid } => {
                     let _ = self.apps.enter(processid, move |app, kernel_data| {

--- a/capsules/extra/src/isolated_nonvolatile_storage_driver.rs
+++ b/capsules/extra/src/isolated_nonvolatile_storage_driver.rs
@@ -1,0 +1,1044 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! This provides userspace access to isolated nonvolatile memory.
+//!
+//! This implementation provides isolation between individual userland
+//! applications. Each application only has access to its region of nonvolatile
+//! memory and cannot read/write to nonvolatile memory of other applications.
+//!
+//! Currently, each app is assigned a fixed amount of nonvolatile memory.
+//! This number is configurable at capsule creation time. Future implementations
+//! should consider giving each app more freedom over configuring the amount
+//! of nonvolatile memory they will use.
+//!
+//! Here is the sequence of events that happen when this initialization syscall is invoked:
+//!  1. The capsule starts traversing a "linked-list" of app regions to find
+//!     any existing regions that might already exist in storage for the app
+//!     making the syscall. This traversal is possible due to headers that exist
+//!     right before the start of each app's region. These headers describe the
+//!     app that owns the region and size of the region. During traversal of these
+//!     regions, the capsule uses the length to determine where the next region
+//!     header starts.
+//!  2. The capsule reads the header and performs a check to see if the region header
+//!     is valid. If it is valid, we move to step 3. If not, we move to step 4.
+//!  3. If the capsule finds a valid region header, it tries to save the informaton of the region
+//!     to the grant of the app that has the same ShortID of the header it just read. It's
+//!     possible that the app previously owned a region but currently isn't running on the
+//!     board. If the app is running, it saves the location and length of the region to the
+//!     app's grant memory where it can be retrieved later during reads/writes. Then it
+//!     continues to traverse the "list" of regions by using length of the previous region
+//!     to determine the start of the next one.
+//!  4. If the capsule finds an invalid region header, it knows that it has
+//!     reached the area of storage where regions have not been initialized.
+//!     Therefore, it will begin to allocate regions at the end of the "list"
+//!     for any apps that made initialization requests and don't already have a region.
+//!  4. Once an app is known to have a valid region (either by discovering it during
+//!     traversal or allocating a new one), initialization completes and the app
+//!     receives an upcall. Now it can go ahead and start reading/writing only
+//!     within its isolated region.
+//!
+//! However, the kernel accessible memory does not have to be the same range
+//! as the userspace accessible address space. The kernel memory can overlap
+//! if desired, or can be a completely separate range.
+//!
+//! Here is a diagram of the expected stack with this capsule:
+//! Boxes are components and between the boxes are the traits that are the
+//! interfaces between components. This capsule provides both a kernel and
+//! userspace interface.
+//!
+//! ```text
+//! +--------------------------------------------+     +--------------+
+//! |                                            |     |              |
+//! |                  kernel                    |     |  userspace   |
+//! |                                            |     |              |
+//! +--------------------------------------------+     +--------------+
+//!  hil::nonvolatile_storage::NonvolatileStorage       kernel::Driver
+//! +-----------------------------------------------------------------+
+//! |                                                                 |
+//! | capsules::nonvolatile_storage_driver::NonvolatileStorage (this) |
+//! |                                                                 |
+//! +-----------------------------------------------------------------+
+//!            hil::nonvolatile_storage::NonvolatileStorage
+//! +-----------------------------------------------------------------+
+//! |                                                                 |
+//! |               Physical nonvolatile storage driver               |
+//! |                                                                 |
+//! +-----------------------------------------------------------------+
+//! ```
+//!
+//! Example nonvolatile storage layout:
+//!
+//! ```text
+//!     ╒════════ ← Start of kernel region
+//!     │
+//!     ╘════════ ← End of kernel region
+//!
+//!     ╒════════ ← Start of userspace region
+//!     ├──────── ← Start of App 1's region header
+//!     │ Region version number (8 bits) | Region length (24 bits) (Note that | inidcates bitwise concatenation)
+//!     │ App 1's ShortID (u32)
+//!     │ XOR of previous two u32 fields (u32)
+//!     ├──────── ← Start of App 1's Region          ═╗
+//!     │                                             ║
+//!     │
+//!     │                                            region 1
+//!     │                                            length
+//!     │
+//!     │                                             ║
+//!     │                                            ═╝
+//!     ├──────── ← Start of App 2's region header
+//!     │ Region version number (8 bits) | Region length (24 bits) (Note that | inidcates bitwise concatenation)
+//!     │ App 2's ShortID (u32)
+//!     │ XOR of previous two u32 fields (u32)
+//!     ├──────── ← Start of App 2's Region          ═╗
+//!     │                                             ║
+//!     │
+//!     │
+//!     │                                            region 2
+//!     │                                            length
+//!     │
+//!     │
+//!     │                                             ║
+//!     ...                                          ═╝
+//!     ╘════════ ← End of userspace region
+//! ```
+
+//!
+//!
+//! Example instantiation:
+//!
+//! ```rust,ignore
+//! # use kernel::static_init;
+//!
+//! let nonvolatile_storage = static_init!(
+//!     capsules::isolated_nonvolatile_storage_driver::IsolatedNonvolatileStorage<'static>,
+//!     capsules::isolated_nonvolatile_storage_driver::IsolatedNonvolatileStorage::new(
+//!         fm25cl,                      // The underlying storage driver.
+//!         board_kernel.create_grant(&grant_cap),     // Storage for app-specific state.
+//!         3000,                        // The byte start address for the userspace
+//!                                      // accessible memory region.
+//!         2000,                        // The length of the userspace region.
+//!         0,                           // The byte start address of the region
+//!                                      // that is accessible by the kernel.
+//!         &mut [u8; capsules::isolated_nonvolatile_storage_driver::BUF_LEN],    // buffer for reading/writing
+//! hil::nonvolatile_storage::NonvolatileStorage::set_client(fm25cl, nonvolatile_storage);
+//! ```
+
+use core::cmp;
+
+use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
+use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
+use kernel::syscall::{CommandReturn, SyscallDriver};
+use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::utilities::copy_slice::CopyOrErr;
+use kernel::hil;
+use kernel::{ErrorCode, ProcessId};
+
+/// Syscall driver number.
+use capsules_core::driver;
+
+pub const DRIVER_NUM: usize = driver::NUM::IsolatedNvmStorage as usize;
+
+/// IDs for subscribed upcalls.
+mod upcall {
+    /// Read done callback.
+    pub const READ_DONE: usize = 0;
+    /// Write done callback.
+    pub const WRITE_DONE: usize = 1;
+    /// Initialization done callback.
+    pub const INIT_DONE: usize = 2;
+    /// Number of upcalls.
+    pub const COUNT: u8 = 3;
+}
+
+/// Ids for read-only allow buffers
+mod ro_allow {
+    /// Setup a buffer to write bytes to the nonvolatile storage.
+    pub const WRITE: usize = 0;
+    /// The number of allow buffers the kernel stores for this grant
+    pub const COUNT: u8 = 1;
+}
+
+/// Ids for read-write allow buffers
+mod rw_allow {
+    /// Setup a buffer to read from the nonvolatile storage into.
+    pub const READ: usize = 0;
+    /// The number of allow buffers the kernel stores for this grant
+    pub const COUNT: u8 = 1;
+}
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+enum HeaderVersion {
+    V1,
+}
+
+impl HeaderVersion {
+    const fn value(&self) -> u8 {
+        match self {
+            HeaderVersion::V1 => 0x01,
+        }
+    }
+}
+
+// Current header version to allocate new regions with.
+const CURRENT_HEADER_VERSION: HeaderVersion = HeaderVersion::V1;
+
+/// Describes a region of nonvolatile memory that is assigned to a
+/// certain app.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct AppRegion {
+    version: HeaderVersion,
+    /// Absolute address to describe where an app's nonvolatile region
+    /// starts. Note that this is the address following the region's header.
+    offset: usize,
+    /// How many bytes allocated to a certain app. Note that this describes
+    /// the length of the usable storage region and does not include the
+    /// region's header.
+    length: usize,
+}
+
+// Metadata to be written before every app's region to describe
+// the owner and size of the region.
+#[derive(Clone, Copy, Debug)]
+struct AppRegionHeader {
+    // an 8 bit version number concatenated with a 24 bit length value
+    version_and_length: u32,
+    /// Unique per-app identifier. This comes from
+    /// the Fixed variant of the ShortID type.
+    shortid: u32,
+    // xor between version_and_length and shortid fields
+    xor: u32,
+}
+// Enough space to store the three u32 field of the header
+pub const REGION_HEADER_LEN: usize = 3 * core::mem::size_of::<u32>();
+
+impl AppRegionHeader {
+    fn new(version: HeaderVersion, shortid: u32, length: usize) -> Option<Self> {
+        // check that length will fit in 3 bytes
+        if length > (2 << 23) {
+            return None;
+        }
+
+        let version_and_length = ((version.value() as u32) << 24) | length as u32;
+
+        let xor = version_and_length ^ shortid;
+
+        Some(AppRegionHeader {
+            version_and_length,
+            shortid,
+            xor,
+        })
+    }
+
+    fn from_bytes(bytes: [u8; REGION_HEADER_LEN]) -> Option<Self> {
+        // first 4 bytes are split between a 8 bit version and 24 bit length
+        let version = bytes[0];
+        let length_slice = &bytes[1..4];
+        let version_and_length_slice = [version, length_slice[0], length_slice[1], length_slice[2]];
+        let version_and_length = u32::from_le_bytes(version_and_length_slice);
+
+        let shortid_slice = bytes[4..8].try_into().ok()?;
+        let shortid = u32::from_le_bytes(shortid_slice);
+
+        let xor_slice = bytes[8..12].try_into().ok()?;
+        let xor = u32::from_le_bytes(xor_slice);
+
+        Some(AppRegionHeader {
+            version_and_length,
+            shortid,
+            xor,
+        })
+    }
+
+    fn to_bytes(self) -> [u8; REGION_HEADER_LEN] {
+        let mut header_slice = [0; REGION_HEADER_LEN];
+
+        // copy version and length
+        let version_and_length_slice = u32::to_le_bytes(self.version_and_length);
+        let version_and_length_start_idx = 0;
+        let version_and_length_end_idx = version_and_length_slice.len();
+        header_slice[version_and_length_start_idx..version_and_length_end_idx]
+            .copy_from_slice(&version_and_length_slice);
+
+        // copy shortid
+        let shortid_slice = u32::to_le_bytes(self.shortid);
+        let shortid_start_idx = version_and_length_end_idx;
+        let shortid_end_idx = shortid_start_idx + shortid_slice.len();
+        header_slice[shortid_start_idx..shortid_end_idx].copy_from_slice(&shortid_slice);
+
+        // copy version and length
+        let xor_slice = u32::to_le_bytes(self.xor);
+        let xor_start_idx = shortid_end_idx;
+        let xor_end_idx = xor_start_idx + xor_slice.len();
+        header_slice[xor_start_idx..xor_end_idx].copy_from_slice(&xor_slice);
+
+        header_slice
+    }
+
+    fn is_valid(&self) -> bool {
+        self.version().is_some() && self.xor == (self.version_and_length ^ self.shortid)
+    }
+
+    fn version(&self) -> Option<HeaderVersion> {
+        // need to do this since we can't pattern match
+        // against a method call
+        const HEADER_V1: u8 = HeaderVersion::V1.value();
+
+        // extract the 8 most significant bits from
+        // the concatenated version and length
+        match (self.version_and_length >> 24) as u8 {
+            HEADER_V1 => Some(HeaderVersion::V1),
+            _ => None,
+        }
+    }
+
+    fn length(&self) -> u32 {
+        // Extract the 24 least significant bits from the concatenated version
+        // and length.
+        self.version_and_length & 0x00ffffff
+    }
+}
+
+// Enough space for a buffer to be used for reading/writing userspace data
+pub const BUF_LEN: usize = 512;
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum RegionState {
+    ReadHeader(usize),
+    WriteHeader(ProcessId, AppRegion),
+    EraseRegion {
+        processid: ProcessId,
+        next_erase_start: usize,
+        remaining_bytes: usize,
+    },
+}
+
+#[derive(Clone, Copy, PartialEq)]
+pub enum Command {
+    Read { offset: usize, length: usize },
+    Write { offset: usize, length: usize },
+}
+
+impl Command {
+    fn offset(&self) -> usize {
+        match self {
+            Command::Read { offset, length } => *offset,
+            Command::Write { offset, length } => *offset,
+        }
+    }
+    fn length(&self) -> usize {
+        match self {
+            Command::Read { offset, length } => *length,
+            Command::Write { offset, length } => *length,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub enum User {
+    App { processid: ProcessId },
+    RegionManager(RegionState),
+}
+
+#[derive(Default)]
+pub struct App {
+    /// The operation the app has requested, if any.
+    command: Option<Command>,
+    /// Whether this app has previously requested to initialize its nonvolatile
+    /// storage.
+    has_requested_region: bool,
+    /// Describe the location and size of an app's region (if it has been
+    /// initialized).
+    region: Option<AppRegion>,
+}
+
+pub struct IsolatedNonvolatileStorage<'a, const APP_REGION_SIZE: usize> {
+    /// The underlying physical storage device.
+    driver: &'a dyn hil::nonvolatile_storage::NonvolatileStorage<'a>,
+    /// Per-app state.
+    apps: Grant<
+        App,
+        UpcallCount<{ upcall::COUNT }>,
+        AllowRoCount<{ ro_allow::COUNT }>,
+        AllowRwCount<{ rw_allow::COUNT }>,
+    >,
+
+    /// Internal buffer for copying appslices into.
+    buffer: TakeCell<'static, [u8]>,
+    /// What issued the currently executing call. This can be an app or the kernel.
+    current_user: OptionalCell<User>,
+
+    /// The first byte that is accessible from userspace.
+    userspace_start_address: usize,
+    /// How many bytes allocated to userspace.
+    userspace_length: usize,
+
+    /// Absolute address of the header of the next region of userspace
+    /// that's not allocated to an app yet. Each time an app uses this
+    /// capsule, a new region of storage will be handed out and this
+    /// address will point to the header of a new unallocated region.
+    next_unallocated_region_header_address: OptionalCell<usize>,
+}
+
+impl<'a, const APP_REGION_SIZE: usize> IsolatedNonvolatileStorage<'a, APP_REGION_SIZE> {
+    pub fn new(
+        driver: &'a dyn hil::nonvolatile_storage::NonvolatileStorage<'a>,
+        grant: Grant<
+            App,
+            UpcallCount<{ upcall::COUNT }>,
+            AllowRoCount<{ ro_allow::COUNT }>,
+            AllowRwCount<{ rw_allow::COUNT }>,
+        >,
+        userspace_start_address: usize,
+        userspace_length: usize,
+        buffer: &'static mut [u8],
+    ) -> Self {
+        Self {
+            driver,
+            apps: grant,
+            buffer: TakeCell::new(buffer),
+            current_user: OptionalCell::empty(),
+            userspace_start_address,
+            userspace_length,
+            next_unallocated_region_header_address: OptionalCell::empty(),
+        }
+    }
+
+    // App-level initialization that allocates a region for an app or fetches
+    // an app's existing region from nonvolatile storage
+    fn init_app(&self, processid: ProcessId) -> Result<(), ErrorCode> {
+        // Mark that this app requested a storage region. If it isn't
+        // allocated immediately, it will be handled after previous requests
+        // are handled.
+        self.apps.enter(processid, |app, _kernel_data| {
+            app.has_requested_region = true;
+        })?;
+
+        // Start traversing the storage regions to find where the requesting
+        // app's storage region is located. If it doesn't exist, a new one will
+        // be allocated.
+        self.start_region_traversal()
+    }
+
+    // Start reading app region headers.
+    fn start_region_traversal(&self) -> Result<(), ErrorCode> {
+        self.read_region_header(self.userspace_start_address)
+    }
+
+    fn allocate_app_region(&self, processid: ProcessId) -> Result<(), ErrorCode> {
+        // can't allocate a region if we haven't previously traversed existing regions
+        // and found where they stop
+        let new_header_addr = self
+            .next_unallocated_region_header_address
+            .get()
+            .ok_or(ErrorCode::FAIL)?;
+
+        // Get an app's write_id (same as ShortID) for saving to region header. Note that
+        // if an app doesn't have the valid permissions, it will be unable to create
+        // storage regions.
+        let shortid = processid
+            .get_storage_permissions()
+            .ok_or(ErrorCode::NOSUPPORT)?
+            .get_write_id()
+            .ok_or(ErrorCode::NOSUPPORT)?;
+
+        let region = AppRegion {
+            version: CURRENT_HEADER_VERSION,
+            // Have this region start where all the existing regions end.
+            // Note that the app's actual region starts after the region header.
+            offset: new_header_addr + REGION_HEADER_LEN,
+            length: APP_REGION_SIZE,
+        };
+
+        // fail if new region is outside userpace area
+        if region.offset > self.userspace_start_address + self.userspace_length
+            || region.offset + region.length > self.userspace_start_address + self.userspace_length
+        {
+            return Err(ErrorCode::NOMEM);
+        }
+
+        let Some(header) = AppRegionHeader::new(region.version, shortid, region.length) else {
+            return Err(ErrorCode::FAIL);
+        };
+
+        // write this new region header to the end of the existing ones
+        self.write_region_header(processid, &region, &header, new_header_addr)
+    }
+
+    // Read the header of an app's storage region. The region_header_address
+    // argument describes the start of the **header** and not the usable region
+    // itself.
+    fn read_region_header(&self, region_header_address: usize) -> Result<(), ErrorCode> {
+        self.check_header_access(region_header_address, APP_REGION_SIZE)?;
+
+        if self.current_user.is_some() {
+            return Err(ErrorCode::BUSY);
+        }
+
+        self.buffer.take().map_or_else(
+            || {
+                Err(ErrorCode::NOMEM)
+            },
+            |buffer| {
+                let active_len = cmp::min(APP_REGION_SIZE, buffer.len());
+
+                self.current_user
+                    .set(User::RegionManager(RegionState::ReadHeader(
+                        region_header_address,
+                    )));
+                self.driver.read(buffer, region_header_address, active_len)
+            },
+        )
+    }
+
+    fn write_region_header(
+        &self,
+        processid: ProcessId,
+        region: &AppRegion,
+        region_header: &AppRegionHeader,
+        region_header_address: usize,
+    ) -> Result<(), ErrorCode> {
+        self.check_header_access(region.offset, region.length)?;
+
+        if self.current_user.is_some() {
+            return Err(ErrorCode::BUSY);
+        }
+
+        let header_slice = region_header.to_bytes();
+
+        self.buffer.take().map_or(Err(ErrorCode::NOMEM), |buffer| {
+            let _ = buffer
+                .get_mut(0..REGION_HEADER_LEN)
+                .ok_or(ErrorCode::NOMEM)?
+                .copy_from_slice_or_err(
+                    header_slice
+                        .get(0..REGION_HEADER_LEN)
+                        .ok_or(ErrorCode::NOMEM)?,
+                );
+
+            let active_len = cmp::min(region.length, buffer.len());
+
+            self.current_user
+                .set(User::RegionManager(RegionState::WriteHeader(
+                    processid, *region,
+                )));
+            self.driver.write(buffer, region_header_address, active_len)
+        })
+    }
+
+    fn erase_region_content(
+        &self,
+        processid: ProcessId,
+        offset: usize,
+        length: usize,
+    ) -> Result<(), ErrorCode> {
+        self.check_header_access(offset, length)?;
+
+        if self.current_user.is_some() {
+            return Err(ErrorCode::BUSY);
+        }
+
+        self.buffer.take().map_or(Err(ErrorCode::NOMEM), |buffer| {
+            let active_len = cmp::min(length, buffer.len());
+
+            // Clear the erase buffer in case there was any data
+            // remaining from a previous operation.
+            for c in buffer.iter_mut() {
+                *c = 0xFF;
+            }
+
+            // how many more bytes to erase after this operation
+            let remaining_len = if length > buffer.len() {
+                length - buffer.len()
+            } else {
+                0
+            };
+
+            self.current_user.set(User::RegionManager(
+                // need to pass on where the next erase should start
+                // how long it should be.
+                RegionState::EraseRegion {
+                    processid,
+                    next_erase_start: offset + active_len,
+                    remaining_bytes: remaining_len,
+                },
+            ));
+            self.driver.write(buffer, offset, active_len)
+        })
+    }
+
+    fn header_read_done(&self, region_header_address: usize) -> Result<(), ErrorCode> {
+        // reconstruct header from bytes we just read
+        let header = self.buffer.map_or(Err(ErrorCode::NOMEM), |buffer| {
+            // Need to copy over bytes since we need to convert a &[u8]
+            // into a [u8; REGION_HEADER_LEN]. The &[u8] refers to a
+            // slice of size BUF_LEN (which could be different than REGION_HEADER_LEN).
+            // Using buffer.try_into() will fail at runtime since the underlying buffer
+            // is not the same length as what we're trying to convert into.
+            let mut header_buffer = [0; REGION_HEADER_LEN];
+            header_buffer
+                .copy_from_slice_or_err(&buffer[..REGION_HEADER_LEN])
+                .or(Err(ErrorCode::FAIL))?;
+            AppRegionHeader::from_bytes(header_buffer).ok_or(ErrorCode::FAIL)
+        })?;
+
+        // If a header is invalid, we've reached the end
+        // of all previously allocated regions.
+        if header.is_valid() {
+            // Find the app with the corresponding shortid.
+            for app in self.apps.iter() {
+                // skip an app if it doesn't have the proper storage permissions
+                let write_id = match app.processid().get_storage_permissions() {
+                    Some(perms) => match perms.get_write_id() {
+                        Some(write_id) => write_id,
+                        None => continue,
+                    },
+                    None => continue,
+                };
+                if write_id == header.shortid {
+                    app.enter(|app, kernel_data| {
+                        // only populate region and signal app that explicitly
+                        // requested to initialize storage
+                        if app.has_requested_region && app.region.is_none() {
+                            let version = header.version().ok_or(ErrorCode::FAIL)?;
+                            app.region.replace(AppRegion {
+                                version,
+                                // the app's actual region starts after the
+                                // region header
+                                offset: region_header_address + REGION_HEADER_LEN,
+                                length: header.length() as usize,
+                            });
+
+                            kernel_data
+                                .schedule_upcall(
+                                    upcall::INIT_DONE,
+                                    (kernel::errorcode::into_statuscode(Ok(())), 0, 0),
+                                )
+                                .ok();
+                        }
+                        Ok::<(), ErrorCode>(())
+                    })?;
+
+                    break;
+                }
+            }
+
+            let next_header_address =
+                region_header_address + REGION_HEADER_LEN + header.length() as usize;
+            self.read_region_header(next_header_address)
+        } else {
+            // save this region header address so that we can allocate new regions
+            // here later
+            self.next_unallocated_region_header_address
+                .set(region_header_address);
+
+            self.check_queue();
+            Ok(())
+        }
+    }
+
+    fn check_userspace_perms(
+        &self,
+        processid: Option<ProcessId>,
+        command: Command,
+    ) -> Result<(), ErrorCode> {
+        processid.map_or(Err(ErrorCode::FAIL), |processid| {
+            let perms = processid
+                .get_storage_permissions()
+                .ok_or(ErrorCode::NOSUPPORT)?;
+            let write_id = perms.get_write_id().ok_or(ErrorCode::NOSUPPORT)?;
+            match command {
+                Command::Read { offset, length } => perms
+                    .check_read_permission(write_id)
+                    .then_some(())
+                    .ok_or(ErrorCode::NOSUPPORT),
+                Command::Write { offset, length } => perms
+                    .check_modify_permission(write_id)
+                    .then_some(())
+                    .ok_or(ErrorCode::NOSUPPORT),
+                _ => Err(ErrorCode::FAIL),
+            }
+        })
+    }
+
+    fn check_userspace_access(
+        &self,
+        offset: usize,
+        length: usize,
+        processid: Option<ProcessId>,
+    ) -> Result<(), ErrorCode> {
+        // check that access is within this app's isolated nonvolatile region.
+        // this is to prevent an app from reading/writing to another app's
+        // nonvolatile storage.
+        processid.map_or(Err(ErrorCode::FAIL), |processid| {
+            // enter the grant to query what the app's
+            // nonvolatile region is
+            self.apps
+                .enter(processid, |app, _kernel_data| {
+                    match &app.region {
+                        Some(app_region) => {
+                            if offset >= app_region.length
+                                || length > app_region.length
+                                || offset + length > app_region.length
+                            {
+                                return Err(ErrorCode::INVAL);
+                            }
+
+                            Ok(())
+                        }
+
+                        // fail if this app's nonvolatile region hasn't been assigned
+                        None => Err(ErrorCode::FAIL),
+                    }
+                })
+                .unwrap_or_else(|err| Err(err.into()))
+        })
+    }
+
+    fn check_header_access(&self, offset: usize, length: usize) -> Result<(), ErrorCode> {
+        // check that we're within the entire userspace region
+        if offset < self.userspace_start_address
+            || offset >= self.userspace_start_address + self.userspace_length
+            || length > self.userspace_length
+            || offset + length >= self.userspace_start_address + self.userspace_length
+        {
+            return Err(ErrorCode::INVAL);
+        }
+
+        Ok(())
+    }
+
+    // Check so see if we are doing something. If not, go ahead and do this
+    // command. If so, this is queued and will be run when the pending
+    // command completes.
+    fn enqueue_userspace_command(
+        &self,
+        command: Command,
+        processid: Option<ProcessId>,
+    ) -> Result<(), ErrorCode> {
+        self.check_userspace_access(command.offset(), command.length(), processid)?;
+        self.check_userspace_perms(processid, command)?;
+
+        processid.map_or(Err(ErrorCode::FAIL), |processid| {
+            self.apps
+                .enter(processid, |app, kernel_data| {
+                    // Get the length of the correct allowed buffer.
+                    let allow_buf_len = match command {
+                        Command::Read {
+                            offset: _,
+                            length: _,
+                        } => kernel_data
+                            .get_readwrite_processbuffer(rw_allow::READ)
+                            .map_or(0, |read| read.len()),
+                        Command::Write {
+                            offset: _,
+                            length: _,
+                        } => kernel_data
+                            .get_readonly_processbuffer(ro_allow::WRITE)
+                            .map_or(0, |read| read.len()),
+                        _ => 0,
+                    };
+
+                    // Check that the matching allowed buffer exists.
+                    if allow_buf_len == 0 {
+                        return Err(ErrorCode::RESERVE);
+                    }
+
+                    // Fail if the app doesn't have a region assigned to it.
+                    let Some(app_region) = &app.region else {
+                        return Err(ErrorCode::FAIL);
+                    };
+
+                    let (command_offset, command_len) = match command {
+                        Command::Read { offset, length } => (offset, length),
+                        Command::Write { offset, length } => (offset, length),
+                    };
+
+                    // Shorten the length if the application gave us nowhere to
+                    // put it.
+                    let active_len = cmp::min(command_len, allow_buf_len);
+
+                    // No app is currently using the underlying storage.
+                    // Mark this app as active, and then execute the command.
+                    self.current_user.set(User::App { processid });
+
+                    // Need to copy bytes if this is a write!
+                    if let Command::Write {
+                        offset: _,
+                        length: _,
+                    } = command
+                    {
+                        let _ = kernel_data
+                            .get_readonly_processbuffer(ro_allow::WRITE)
+                            .and_then(|write| {
+                                write.enter(|app_buffer| {
+                                    self.buffer.map(|kernel_buffer| {
+                                        // Check that the internal buffer and the buffer that was
+                                        // allowed are long enough.
+                                        let write_len = cmp::min(active_len, kernel_buffer.len());
+
+                                        let d = &app_buffer[0..write_len];
+                                        for (i, c) in
+                                            kernel_buffer[0..write_len].iter_mut().enumerate()
+                                        {
+                                            *c = d[i].get();
+                                        }
+                                    });
+                                })
+                            });
+                    }
+
+                    // Note that the given offset for this command is with respect to
+                    // the app's region address space. This means that userspace accesses
+                    // start at 0 which is the start of the app's region.
+                    self.userspace_call_driver(
+                        command,
+                        app_region.offset + command_offset,
+                        active_len,
+                    )
+                })
+                .unwrap_or_else(|err| Err(err.into()))
+        })
+    }
+
+    fn userspace_call_driver(
+        &self,
+        command: Command,
+        offset: usize,
+        length: usize,
+    ) -> Result<(), ErrorCode> {
+        // Calculate where we want to actually read from in the physical
+        // storage.
+        let physical_address = offset + self.userspace_start_address;
+
+        self.buffer
+            .take()
+            .map_or(Err(ErrorCode::RESERVE), |buffer| {
+                // Check that the internal buffer and the buffer that was
+                // allowed are long enough.
+                let active_len = cmp::min(length, buffer.len());
+
+                match command {
+                    Command::Read { offset, length } => {
+                        self.driver.read(buffer, physical_address, active_len)
+                    }
+                    Command::Write { offset, length } => {
+                        self.driver.write(buffer, physical_address, active_len)
+                    }
+                    _ => Err(ErrorCode::FAIL),
+                }
+            })
+    }
+
+    fn check_queue(&self) {
+        // Check if there are any pending events.
+        for app in self.apps.iter() {
+            let processid = app.processid();
+            let started = app.enter(|app, _| {
+                if app.has_requested_region && app.region.is_none() {
+                    // This app needs its region allocated.
+                    self.allocate_app_region(processid).is_ok()
+                } else {
+                    false
+                }
+            });
+            if started {
+                break;
+            }
+        }
+    }
+}
+
+/// This is the callback client for the underlying physical storage driver.
+impl<const APP_REGION_SIZE: usize> hil::nonvolatile_storage::NonvolatileStorageClient
+    for IsolatedNonvolatileStorage<'_, APP_REGION_SIZE>
+{
+    fn read_done(&self, buffer: &'static mut [u8], length: usize) {
+        // Switch on which user of this capsule generated this callback.
+        self.current_user.take().map(|user| {
+            match user {
+                User::RegionManager(state) => {
+                    self.buffer.replace(buffer);
+                    let _ = match state {
+                        RegionState::ReadHeader(action) => self.header_read_done(action),
+                        _ => Err(ErrorCode::FAIL),
+                    };
+                }
+                User::App { processid } => {
+                    let _ = self.apps.enter(processid, move |_, kernel_data| {
+                        // Need to copy in the contents of the buffer
+                        let _ = kernel_data
+                            .get_readwrite_processbuffer(rw_allow::READ)
+                            .and_then(|read| {
+                                read.mut_enter(|app_buffer| {
+                                    let read_len = cmp::min(app_buffer.len(), length);
+
+                                    let d = &app_buffer[0..read_len];
+                                    for (i, c) in buffer[0..read_len].iter().enumerate() {
+                                        d[i].set(*c);
+                                    }
+                                })
+                            });
+
+                        // Replace the buffer we used to do this read.
+                        self.buffer.replace(buffer);
+
+                        // And then signal the app.
+                        kernel_data
+                            .schedule_upcall(upcall::READ_DONE, (length, 0, 0))
+                            .ok();
+                    });
+                }
+            }
+        });
+
+        self.check_queue();
+    }
+
+    fn write_done(&self, buffer: &'static mut [u8], length: usize) {
+        // Replace the buffer we used to do this write.
+        self.buffer.replace(buffer);
+
+        // Switch on which user of this capsule generated this callback.
+        self.current_user.take().map(|user| {
+            match user {
+                User::RegionManager(state) => {
+                    match state {
+                        RegionState::WriteHeader(processid, region) => {
+                            // Now that we have written the header for the app we can store its region in its grant.
+                            let _ = self.apps.enter(processid, |app, _kernel_data| {
+                                // set region data in app's grant
+                                app.region.replace(region);
+                            });
+
+                            // Update our metadata about where the next unallocated region is.
+                            let next_header_addr = region.offset + region.length;
+                            self.next_unallocated_region_header_address
+                                .set(next_header_addr);
+
+                            // Erase the userspace accessible content of the region
+                            // before handing it off to an app.
+                            let _ =
+                                self.erase_region_content(processid, region.offset, region.length);
+                        }
+                        RegionState::EraseRegion {
+                            processid,
+                            next_erase_start,
+                            remaining_bytes,
+                        } => {
+                            if remaining_bytes > 0 {
+                                // we still have more to erase, so kick off another one
+                                // where we left off
+                                let _ = self.erase_region_content(
+                                    processid,
+                                    next_erase_start,
+                                    remaining_bytes,
+                                );
+                            } else {
+                                // done erasing entire region
+                                let _ = self.apps.enter(processid, |_app, kernel_data| {
+                                    // region is erased and we're ready to let the app
+                                    // know that it's region is ready
+                                    kernel_data
+                                        .schedule_upcall(upcall::INIT_DONE, (0, 0, 0))
+                                        .ok();
+                                });
+                            }
+                        }
+                        _ => {}
+                    };
+                }
+                User::App { processid } => {
+                    let _ = self.apps.enter(processid, move |_app, kernel_data| {
+                        // Notify app that its write has completed.
+                        kernel_data
+                            .schedule_upcall(upcall::WRITE_DONE, (length, 0, 0))
+                            .ok();
+                    });
+                }
+            }
+        });
+
+        self.check_queue();
+    }
+}
+
+/// Provide an interface for userland.
+impl<const APP_REGION_SIZE: usize> SyscallDriver
+    for IsolatedNonvolatileStorage<'_, APP_REGION_SIZE>
+{
+    /// Command interface.
+    ///
+    /// Commands are selected by the lowest 8 bits of the first argument.
+    ///
+    /// ### `command_num`
+    ///
+    /// - `0`: Return Ok(()) if this driver is included on the platform.
+    /// - `1`: Return the number of bytes available to each app.
+    /// - `2`: Start a read from the nonvolatile storage.
+    /// - `3`: Start a write to the nonvolatile_storage.
+    /// - `4`: Initialize an app's nonvolatile_storage.
+    fn command(
+        &self,
+        command_num: usize,
+        offset: usize,
+        length: usize,
+        processid: ProcessId,
+    ) -> CommandReturn {
+        match command_num {
+            0 => CommandReturn::success(),
+
+            1 => {
+                // How many bytes are accessible to each app
+                let res = self.apps.enter(processid, |app, _kernel_data| app.region);
+
+                // handle case where we fail to enter grant
+                res.map_or(CommandReturn::failure(ErrorCode::NOMEM), |region| {
+                    // handle case where app's region is not assigned
+                    region.map_or(CommandReturn::failure(ErrorCode::FAIL), |region| {
+                        CommandReturn::success_u32(region.length as u32)
+                    })
+                })
+            }
+
+            2 => {
+                // Issue a read command
+                let res = self
+                    .enqueue_userspace_command(Command::Read { offset, length }, Some(processid));
+
+                match res {
+                    Ok(()) => CommandReturn::success(),
+                    Err(e) => CommandReturn::failure(e),
+                }
+            }
+
+            3 => {
+                // Issue a write command
+                let res = self
+                    .enqueue_userspace_command(Command::Write { offset, length }, Some(processid));
+
+                match res {
+                    Ok(()) => CommandReturn::success(),
+                    Err(e) => CommandReturn::failure(e),
+                }
+            }
+            4 => {
+                // Initialize an app's storage region
+                let res = self.init_app(processid);
+
+                match res {
+                    Ok(()) => CommandReturn::success(),
+                    Err(e) => CommandReturn::failure(e),
+                }
+            }
+
+            _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
+        }
+    }
+
+    fn allocate_grant(&self, processid: ProcessId) -> Result<(), kernel::process::Error> {
+        self.apps.enter(processid, |_, _| {})
+    }
+}

--- a/capsules/extra/src/isolated_nonvolatile_storage_driver.rs
+++ b/capsules/extra/src/isolated_nonvolatile_storage_driver.rs
@@ -1,66 +1,25 @@
 // Licensed under the Apache License, Version 2.0 or the MIT License.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
+// Copyright Tock Contributors 2025.
 
-//! This provides userspace access to isolated nonvolatile memory.
+//! This provides userspace access to nonvolatile storage.
 //!
-//! This implementation provides isolation between individual userland
-//! applications. Each application only has access to its region of nonvolatile
-//! memory and cannot read/write to nonvolatile memory of other applications.
+//! This driver provides isolation between individual userland applications.
+//! Each application only has access to its region of nonvolatile memory and
+//! cannot read/write to nonvolatile memory of other applications.
 //!
-//! Currently, each app is assigned a fixed amount of nonvolatile memory.
-//! This number is configurable at capsule creation time. Future implementations
-//! should consider giving each app more freedom over configuring the amount
-//! of nonvolatile memory they will use.
+//! Each app is assigned a fixed amount of nonvolatile memory. This amount is
+//! set at compile time.
 //!
-//! In case, the app previously had data in persistent storage, we need
-//! to find where that is. Therefore, there's an initialization sequence
-//! that happens on every app's first syscall.
+//! ## Storage Layout
 //!
-//! Here is a general high-level overview of what happens when an
-//! app makes their first syscall:
-//!  1. App engages with the capsule by making any syscall.
-//!  2. Capsule searches through storage to see if that app
-//!     has an existing region.
-//!  3. a. If the capsule finds a matching region:
-//!         - Cache the app's region information in its grant.
-//!     b. If the capsule DOESN'T find a matching region:
-//!         - Allocate a new region for that app.
-//!         - Erase the region's usable area.
-//!   4. Handle the syscall that the app originally made.
-//!   5. When the syscall finishes, notify the app via upcall.
-//!
-//! Here is a diagram of the expected stack with this capsule:
-//! Boxes are components and between the boxes are the traits that are the
-//! interfaces between components. This capsule only provides a
-//! userspace interface.
+//! Example nonvolatile storage layout (note that `|` indicates bitwise
+//! concatenation):
 //!
 //! ```text
-//! +-----------------------------------------------------------------+
-//! |                                                                 |
-//! |                             userspace                           |
-//! |                                                                 |
-//! +-----------------------------------------------------------------+
-//!                             kernel::Driver
-//! +-----------------------------------------------------------------+
-//! |                                                                 |
-//! | capsules::nonvolatile_storage_driver::NonvolatileStorage (this) |
-//! |                                                                 |
-//! +-----------------------------------------------------------------+
-//!            hil::nonvolatile_storage::NonvolatileStorage
-//! +-----------------------------------------------------------------+
-//! |                                                                 |
-//! |               Physical nonvolatile storage driver               |
-//! |                                                                 |
-//! +-----------------------------------------------------------------+
-//! ```
-//!
-//! Example nonvolatile storage layout:
-//!
-//! ```text
-//!     ╒════════ ← Start of userspace region
+//!     ╒════════ ← Start of nonvolatile region
 //!     ├──────── ← Start of App 1's region header
-//!     │ Region version number (8 bits) | Region length (24 bits) (Note that | inidcates bitwise concatenation)
+//!     │ Region version number (8 bits) | Region length (24 bits)
 //!     │ App 1's ShortID (u32)
 //!     │ XOR of previous two u32 fields (u32)
 //!     ├──────── ← Start of App 1's Region          ═╗
@@ -72,7 +31,7 @@
 //!     │                                             ║
 //!     │                                            ═╝
 //!     ├──────── ← Start of App 2's region header
-//!     │ Region version number (8 bits) | Region length (24 bits) (Note that | inidcates bitwise concatenation)
+//!     │ Region version number (8 bits) | Region length (24 bits)
 //!     │ App 2's ShortID (u32)
 //!     │ XOR of previous two u32 fields (u32)
 //!     ├──────── ← Start of App 2's Region          ═╗
@@ -87,27 +46,51 @@
 //!     ...                                          ═╝
 //!     ╘════════ ← End of userspace region
 //! ```
-
 //!
+//! ## Storage Initialization
 //!
-//! Example instantiation:
+//! This capsule caches the location of an application's storage region in
+//! grant. This cached location is set on the first usage of this capsule.
 //!
-//! ```rust,ignore
-//! # use kernel::static_init;
+//! Here is a general high-level overview of what happens when an
+//! app makes their first syscall:
+//!  1. App engages with the capsule by making any syscall.
+//!  2. Capsule searches through storage to see if that app
+//!     has an existing region.
+//!  3. a. If the capsule finds a matching region:
+//!         - Cache the app's region information in its grant.
+//!     b. If the capsule DOESN'T find a matching region:
+//!         - Allocate a new region for that app.
+//!         - Erase the region's usable area.
+//!   4. Handle the syscall that the app originally made.
+//!   5. When the syscall finishes, notify the app via upcall.
 //!
-//! let nonvolatile_storage = static_init!(
-//!     capsules::isolated_nonvolatile_storage_driver::IsolatedNonvolatileStorage<'static>,
-//!     capsules::isolated_nonvolatile_storage_driver::IsolatedNonvolatileStorage::new(
-//!         fm25cl,                      // The underlying storage driver.
-//!         board_kernel.create_grant(&grant_cap),     // Storage for app-specific state.
-//!         3000,                        // The byte start address for the userspace
-//!                                      // accessible memory region.
-//!         2000,                        // The length of the userspace region.
-//!         0,                           // The byte start address of the region
-//!                                      // that is accessible by the kernel.
-//!         &mut [u8; capsules::isolated_nonvolatile_storage_driver::BUF_LEN],    // buffer for reading/writing
-//! hil::nonvolatile_storage::NonvolatileStorage::set_client(fm25cl, nonvolatile_storage);
+//! ## Example Software Stack
+//!
+//! Here is a diagram of the expected stack with this capsule: Boxes are
+//! components and between the boxes are the traits that are the interfaces
+//! between components. This capsule only provides a userspace interface.
+//!
+//! ```text
+//! +------------------------------------------------------------------------+
+//! |                                                                        |
+//! |                             userspace                                  |
+//! |                                                                        |
+//! +------------------------------------------------------------------------+
+//!                             kernel::Driver
+//! +------------------------------------------------------------------------+
+//! |                                                                        |
+//! | isolated_nonvolatile_storage_driver::IsolatedNonvolatileStorage (this) |
+//! |                                                                        |
+//! +------------------------------------------------------------------------+
+//!            hil::nonvolatile_storage::NonvolatileStorage
+//! +------------------------------------------------------------------------+
+//! |                                                                        |
+//! |               Physical nonvolatile storage driver                      |
+//! |                                                                        |
+//! +------------------------------------------------------------------------+
 //! ```
+//!
 
 use core::cmp;
 
@@ -120,10 +103,15 @@ use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::utilities::copy_slice::CopyOrErr;
 use kernel::{ErrorCode, ProcessId};
 
-/// Syscall driver number.
 use capsules_core::driver;
 
 pub const DRIVER_NUM: usize = driver::NUM::IsolatedNvmStorage as usize;
+
+/// Recommended size for the buffer provided to this capsule.
+///
+/// This is enough space for a buffer to be used for reading/writing userspace
+/// data.
+pub const BUF_LEN: usize = 512;
 
 /// IDs for subscribed upcalls.
 mod upcall {
@@ -154,49 +142,47 @@ mod rw_allow {
 }
 
 #[derive(Clone, Copy, PartialEq, Debug)]
+#[repr(u8)]
 enum HeaderVersion {
-    V1,
-}
-
-impl HeaderVersion {
-    const fn value(&self) -> u8 {
-        match self {
-            HeaderVersion::V1 => 0x01,
-        }
-    }
+    V1 = 0x01,
 }
 
 // Current header version to allocate new regions with.
 const CURRENT_HEADER_VERSION: HeaderVersion = HeaderVersion::V1;
 
-/// Describes a region of nonvolatile memory that is assigned to a
-/// certain app.
+/// Describes a region of nonvolatile memory that is assigned to a certain app.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AppRegion {
+    /// The version is based on the capsule version and layout format in use
+    /// when the region was created. This is set to a fixed value for all new
+    /// regions. An existing region may have been created with a newer or
+    /// earlier version of this capsule and therefore might have a different
+    /// version than what we currently initialize new regions with.
     version: HeaderVersion,
-    /// Absolute address to describe where an app's nonvolatile region
-    /// starts. Note that this is the address FOLLOWING the region's header.
+    /// Absolute address to describe where an app's nonvolatile region starts.
+    /// Note that this is the address FOLLOWING the region's header.
     offset: usize,
-    /// How many bytes allocated to a certain app. Note that this describes
-    /// the length of the usable storage region and does not include the
-    /// region's header.
+    /// How many bytes allocated to a certain app. Note that this describes the
+    /// length of the usable storage region and does not include the region's
+    /// header.
     length: usize,
 }
 
-// Metadata to be written before every app's region to describe
-// the owner and size of the region.
+// Metadata to be written before every app's region to describe the owner and
+// size of the region.
 #[derive(Clone, Copy, Debug)]
 struct AppRegionHeader {
-    // an 8 bit version number concatenated with a 24 bit length value
+    /// An 8 bit version number concatenated with a 24 bit length value.
     version_and_length: u32,
-    /// Unique per-app identifier. This comes from
-    /// the Fixed variant of the ShortID type.
+    /// Unique per-app identifier. This comes from the Fixed variant of the
+    /// ShortID type.
     shortid: u32,
-    // xor between version_and_length and shortid fields
+    /// xor between `version_and_length` and `shortid` fields. This serves as a
+    /// checksum.
     xor: u32,
 }
-// Enough space to store the three u32 field of the header
-pub const REGION_HEADER_LEN: usize = 3 * core::mem::size_of::<u32>();
+/// The size of the `AppRegionHeader` stored in the nonvolatile storage.
+const REGION_HEADER_LEN: usize = 3 * core::mem::size_of::<u32>();
 
 impl AppRegionHeader {
     fn new(version: HeaderVersion, shortid: u32, length: usize) -> Option<Self> {
@@ -205,7 +191,7 @@ impl AppRegionHeader {
             return None;
         }
 
-        let version_and_length = ((version.value() as u32) << 24) | length as u32;
+        let version_and_length = ((version as u8 as u32) << 24) | length as u32;
 
         let xor = version_and_length ^ shortid;
 
@@ -266,12 +252,11 @@ impl AppRegionHeader {
     }
 
     fn version(&self) -> Option<HeaderVersion> {
-        // need to do this since we can't pattern match
-        // against a method call
-        const HEADER_V1: u8 = HeaderVersion::V1.value();
+        // Need to do this since we can't pattern match against a method call.
+        const HEADER_V1: u8 = HeaderVersion::V1 as u8;
 
-        // extract the 8 most significant bits from
-        // the concatenated version and length
+        // Extract the 8 most significant bits from the concatenated version and
+        // length.
         match (self.version_and_length >> 24) as u8 {
             HEADER_V1 => Some(HeaderVersion::V1),
             _ => None,
@@ -285,13 +270,16 @@ impl AppRegionHeader {
     }
 }
 
-// Enough space for a buffer to be used for reading/writing userspace data
-pub const BUF_LEN: usize = 512;
-
+/// Operation referencing a particular region.
 #[derive(Clone, Copy, PartialEq, Debug)]
-pub enum RegionState {
-    ReadHeader(usize),
+pub enum ManagerTask {
+    /// Read the contents of the header in the region. The `usize` is the
+    /// address of the start of the header.
+    DiscoverRegions(usize),
+    /// Write a valid header to the storage.
     WriteHeader(ProcessId, AppRegion),
+    /// Erase the contents of a region. This supports using multiple nonvolatile
+    /// storage operations to complete the entire erase.
     EraseRegion {
         processid: ProcessId,
         next_erase_start: usize,
@@ -299,41 +287,40 @@ pub enum RegionState {
     },
 }
 
-#[derive(Clone, Copy, PartialEq)]
-pub enum Command {
-    Read { offset: usize, length: usize },
-    Write { offset: usize, length: usize },
-}
-
-impl Command {
-    fn offset(&self) -> usize {
-        match self {
-            Command::Read { offset, length: _ } => *offset,
-            Command::Write { offset, length: _ } => *offset,
-        }
-    }
-    fn length(&self) -> usize {
-        match self {
-            Command::Read { offset: _, length } => *length,
-            Command::Write { offset: _, length } => *length,
-        }
-    }
-}
-
-#[derive(Clone, Copy)]
+/// What is currently using the underlying nonvolatile storage driver.
+#[derive(Clone, Copy, Debug)]
 pub enum User {
+    /// The operation is from a userspace process.
     App { processid: ProcessId },
-    RegionManager(RegionState),
+    /// The operation is from this capsule.
+    RegionManager(ManagerTask),
 }
 
-#[derive(Clone, Copy)]
-pub enum Syscall {
+/// The operation the process requested.
+#[derive(Clone, Copy, Debug)]
+pub enum NvmCommand {
     GetSize,
     Read { offset: usize, length: usize },
     Write { offset: usize, length: usize },
 }
 
-impl Syscall {
+impl NvmCommand {
+    fn offset(&self) -> usize {
+        match self {
+            NvmCommand::Read { offset, length: _ } => *offset,
+            NvmCommand::Write { offset, length: _ } => *offset,
+            NvmCommand::GetSize => 0,
+        }
+    }
+
+    fn length(&self) -> usize {
+        match self {
+            NvmCommand::Read { offset: _, length } => *length,
+            NvmCommand::Write { offset: _, length } => *length,
+            NvmCommand::GetSize => 0,
+        }
+    }
+
     fn upcall(&self) -> usize {
         match self {
             Self::GetSize => upcall::GET_SIZE_DONE,
@@ -349,16 +336,14 @@ impl Syscall {
     }
 }
 
+/// State stored in the grant region on behalf of each app.
 #[derive(Default)]
 pub struct App {
-    /// Whether this app has previously requested to initialize its nonvolatile
-    /// storage.
-    has_requested_region: bool,
     /// Describe the location and size of an app's region (if it has been
     /// initialized).
     region: Option<AppRegion>,
-    /// Syscall that will be handled once init sequence is complete
-    pending_syscall: Option<Syscall>,
+    /// Operation that will be handled once init sequence is complete.
+    pending_operation: Option<NvmCommand>,
 }
 
 pub struct IsolatedNonvolatileStorage<'a, const APP_REGION_SIZE: usize> {
@@ -374,7 +359,8 @@ pub struct IsolatedNonvolatileStorage<'a, const APP_REGION_SIZE: usize> {
 
     /// Internal buffer for copying appslices into.
     buffer: TakeCell<'static, [u8]>,
-    /// What issued the currently executing call. This can be an app or the kernel.
+    /// What issued the currently executing call. This can be an app or the
+    /// kernel.
     current_user: OptionalCell<User>,
 
     /// The first byte that is accessible from userspace.
@@ -382,10 +368,10 @@ pub struct IsolatedNonvolatileStorage<'a, const APP_REGION_SIZE: usize> {
     /// How many bytes allocated to userspace.
     userspace_length: usize,
 
-    /// Absolute address of the header of the next region of userspace
-    /// that's not allocated to an app yet. Each time an app uses this
-    /// capsule, a new region of storage will be handed out and this
-    /// address will point to the header of a new unallocated region.
+    /// Absolute address of the header of the next region of userspace that's
+    /// not allocated to an app yet. Each time an app uses this capsule, a new
+    /// region of storage will be handed out and this address will point to the
+    /// header of a new unallocated region.
     next_unallocated_region_header_address: OptionalCell<usize>,
 }
 
@@ -413,48 +399,43 @@ impl<'a, const APP_REGION_SIZE: usize> IsolatedNonvolatileStorage<'a, APP_REGION
         }
     }
 
-    // App-level initialization that allocates a region for an app or fetches
-    // an app's existing region from nonvolatile storage
-    fn init_app(&self, syscall: Syscall, processid: ProcessId) -> Result<(), ErrorCode> {
-        self.apps.enter(processid, |app, _kernel_data| {
-            // Mark that this app requested a storage region. If it isn't
-            // allocated immediately, it will be handled after previous requests
-            // are handled.
-            app.has_requested_region = true;
-
-            // can't buffer more than one syscall per app
-            if app.pending_syscall.is_some() {
-                return Err(ErrorCode::BUSY);
-            }
-
-            // Save syscall information to handle after init finishes
-            app.pending_syscall = Some(syscall);
-            Ok(())
-        })??;
-
-        // Start traversing the storage regions to find where the requesting
-        // app's storage region is located. If it doesn't exist, a new one will
-        // be allocated.
-        self.start_region_traversal()
-    }
-
     // Start reading app region headers.
     fn start_region_traversal(&self) -> Result<(), ErrorCode> {
-        self.read_region_header(self.userspace_start_address)
+        if self.current_user.is_some() {
+            // Can't traverse the regions right now because the underlying
+            // driver is already in use.
+            return Err(ErrorCode::BUSY);
+        }
+
+        let res = self.read_region_header(self.userspace_start_address);
+        match res {
+            Ok(()) => {
+                // Mark that we started the discover operation.
+                self.current_user
+                    .set(User::RegionManager(ManagerTask::DiscoverRegions(
+                        self.userspace_start_address,
+                    )));
+                Ok(())
+            }
+            Err(e) => {
+                // We did not successfully start the discover, return the error.
+                Err(e)
+            }
+        }
     }
 
     fn allocate_app_region(&self, processid: ProcessId) -> Result<(), ErrorCode> {
-        // can't allocate a region if we haven't previously traversed existing regions
-        // and found where they stop
+        // Can't allocate a region if we haven't previously traversed existing
+        // regions and found where they stop.
         let new_header_addr = self
             .next_unallocated_region_header_address
             .get()
             .ok_or(ErrorCode::FAIL)?;
 
-        // Get an app's write_id (same as ShortID) for saving to region header. Note that
-        // if an app doesn't have the valid permissions, it will be unable to create
-        // storage regions.
-        let shortid = processid
+        // Get an app's write_id (same as ShortID) for saving to region header.
+        // Note that if an app doesn't have the valid permissions, it will be
+        // unable to create storage regions.
+        let write_id = processid
             .get_storage_permissions()
             .ok_or(ErrorCode::NOSUPPORT)?
             .get_write_id()
@@ -475,12 +456,27 @@ impl<'a, const APP_REGION_SIZE: usize> IsolatedNonvolatileStorage<'a, APP_REGION
             return Err(ErrorCode::NOMEM);
         }
 
-        let Some(header) = AppRegionHeader::new(region.version, shortid, region.length) else {
+        let Some(header) = AppRegionHeader::new(region.version, write_id, region.length) else {
             return Err(ErrorCode::FAIL);
         };
 
-        // write this new region header to the end of the existing ones
-        self.write_region_header(processid, &region, &header, new_header_addr)
+        // Write this new region header to the end of the existing regions.
+        let res = self.write_region_header(&region, &header, new_header_addr);
+        match res {
+            Ok(()) => {
+                // Mark that we started the initialize region task.
+                self.current_user
+                    .set(User::RegionManager(ManagerTask::WriteHeader(
+                        processid, region,
+                    )));
+                Ok(())
+            }
+            Err(e) => {
+                // We did not successfully start the region initialization,
+                // return the error.
+                Err(e)
+            }
+        }
     }
 
     // Read the header of an app's storage region. The region_header_address
@@ -489,21 +485,10 @@ impl<'a, const APP_REGION_SIZE: usize> IsolatedNonvolatileStorage<'a, APP_REGION
     fn read_region_header(&self, region_header_address: usize) -> Result<(), ErrorCode> {
         self.check_header_access(region_header_address, APP_REGION_SIZE)?;
 
-        if self.current_user.is_some() {
-            return Err(ErrorCode::BUSY);
-        }
-
-        self.buffer.take().map_or_else(
-            || Err(ErrorCode::NOMEM),
-            |buffer| {
-                self.current_user
-                    .set(User::RegionManager(RegionState::ReadHeader(
-                        region_header_address,
-                    )));
-                self.driver
-                    .read(buffer, region_header_address, REGION_HEADER_LEN)
-            },
-        )
+        self.buffer.take().map_or(Err(ErrorCode::NOMEM), |buffer| {
+            self.driver
+                .read(buffer, region_header_address, REGION_HEADER_LEN)
+        })
     }
 
     // Write the header of an app's storage region. The region_header_address
@@ -511,16 +496,11 @@ impl<'a, const APP_REGION_SIZE: usize> IsolatedNonvolatileStorage<'a, APP_REGION
     // itself.
     fn write_region_header(
         &self,
-        processid: ProcessId,
         region: &AppRegion,
         region_header: &AppRegionHeader,
         region_header_address: usize,
     ) -> Result<(), ErrorCode> {
         self.check_header_access(region.offset, region.length)?;
-
-        if self.current_user.is_some() {
-            return Err(ErrorCode::BUSY);
-        }
 
         let header_slice = region_header.to_bytes();
 
@@ -534,10 +514,6 @@ impl<'a, const APP_REGION_SIZE: usize> IsolatedNonvolatileStorage<'a, APP_REGION
                         .ok_or(ErrorCode::NOMEM)?,
                 );
 
-            self.current_user
-                .set(User::RegionManager(RegionState::WriteHeader(
-                    processid, *region,
-                )));
             self.driver
                 .write(buffer, region_header_address, REGION_HEADER_LEN)
         })
@@ -545,15 +521,10 @@ impl<'a, const APP_REGION_SIZE: usize> IsolatedNonvolatileStorage<'a, APP_REGION
 
     fn erase_region_content(
         &self,
-        processid: ProcessId,
         offset: usize,
         length: usize,
-    ) -> Result<(), ErrorCode> {
+    ) -> Result<(usize, usize), ErrorCode> {
         self.check_header_access(offset, length)?;
-
-        if self.current_user.is_some() {
-            return Err(ErrorCode::BUSY);
-        }
 
         self.buffer.take().map_or(Err(ErrorCode::NOMEM), |buffer| {
             let active_len = cmp::min(length, buffer.len());
@@ -571,38 +542,37 @@ impl<'a, const APP_REGION_SIZE: usize> IsolatedNonvolatileStorage<'a, APP_REGION
                 0
             };
 
-            self.current_user.set(User::RegionManager(
-                // need to pass on where the next erase should start
-                // how long it should be.
-                RegionState::EraseRegion {
-                    processid,
-                    next_erase_start: offset + active_len,
-                    remaining_bytes: remaining_len,
-                },
-            ));
-            self.driver.write(buffer, offset, active_len)
+            let next_erase_start = offset + active_len;
+
+            self.driver
+                .write(buffer, offset, active_len)
+                .and(Ok((next_erase_start, remaining_len)))
         })
     }
 
-    fn header_read_done(&self, region_header_address: usize) -> Result<(), ErrorCode> {
+    // Returns `Ok()` with the address of the next header to be read if a new
+    // header read was started.
+    fn header_read_done(&self, region_header_address: usize) -> Result<Option<usize>, ErrorCode> {
         // Cases when a header read completes:
         // 1. Read a valid header
-        //     - The valid header belongs to a Tock app (might not be currently running)
-        //     - Search for the owner of the region within the apps that have previously
-        //       requested to use nonvolatile storage
-        //     - Find the owner of the region that has a matching shortid (from the header)
-        //     - Then, startup another read operation to read the header of the next
-        //       storage region.
+        //     - The valid header belongs to a Tock app (might not be currently
+        //       running).
+        //     - Search for the owner of the region within the apps.
+        //     - Find the owner of the region that has a matching shortid (from
+        //       the header).
+        //     - Then, startup another read operation to read the header of the
+        //       next storage region.
         // 2. Read an invalid header
-        //     - We've reached the end of all previously allocated regions
-        //     - Allocate new app region here
+        //     - We've reached the end of all previously allocated regions.
+        //     - Allocate new app region here.
 
         let header = self.buffer.map_or(Err(ErrorCode::NOMEM), |buffer| {
-            // Need to copy over bytes since we need to convert a &[u8]
-            // into a [u8; REGION_HEADER_LEN]. The &[u8] refers to a
-            // slice of size BUF_LEN (which could be different than REGION_HEADER_LEN).
-            // Using buffer.try_into() will fail at runtime since the underlying buffer
-            // is not the same length as what we're trying to convert into.
+            // Need to copy over bytes since we need to convert a &[u8] into a
+            // [u8; REGION_HEADER_LEN]. The &[u8] refers to a slice of size
+            // BUF_LEN (which could be different than REGION_HEADER_LEN). Using
+            // buffer.try_into() will fail at runtime since the underlying
+            // buffer is not the same length as what we're trying to convert
+            // into.
             let mut header_buffer = [0; REGION_HEADER_LEN];
             header_buffer
                 .copy_from_slice_or_err(&buffer[..REGION_HEADER_LEN])
@@ -616,7 +586,8 @@ impl<'a, const APP_REGION_SIZE: usize> IsolatedNonvolatileStorage<'a, APP_REGION
             // Find the app with the corresponding shortid.
             for app in self.apps.iter() {
                 let processid = app.processid();
-                // skip an app if it doesn't have the proper storage permissions
+                // Skip an app if it doesn't have the proper storage
+                // permissions.
                 let write_id = match processid.get_storage_permissions() {
                     Some(perms) => match perms.get_write_id() {
                         Some(write_id) => write_id,
@@ -626,14 +597,12 @@ impl<'a, const APP_REGION_SIZE: usize> IsolatedNonvolatileStorage<'a, APP_REGION
                 };
                 if write_id == header.shortid {
                     app.enter(|app, _kernel_data| {
-                        // only populate region and signal app that explicitly
-                        // requested to initialize storage
-                        if app.has_requested_region && app.region.is_none() {
+                        if app.region.is_none() {
                             let version = header.version().ok_or(ErrorCode::FAIL)?;
                             let region = AppRegion {
                                 version,
-                                // the app's actual region starts after the
-                                // region header
+                                // The app's actual region starts after the
+                                // region header.
                                 offset: region_header_address + REGION_HEADER_LEN,
                                 length: header.length() as usize,
                             };
@@ -641,102 +610,78 @@ impl<'a, const APP_REGION_SIZE: usize> IsolatedNonvolatileStorage<'a, APP_REGION
                         }
                         Ok::<(), ErrorCode>(())
                     })?;
-
-                    // Now that we have found the region, app's storage is
-                    // initialized and we can handle its original syscall
-                    self.check_pending_syscalls();
-
                     break;
                 }
             }
 
             let next_header_address =
                 region_header_address + REGION_HEADER_LEN + header.length() as usize;
-
-            // kick off another read for the next region
+            // Kick off another read for the next region.
             self.read_region_header(next_header_address)
+                .and(Ok(Some(next_header_address)))
         } else {
-            // This is the end of the region traversal.
-            // If a header is invalid, we've reached the end
-            // of all previously allocated regions.
+            // This is the end of the region traversal. If a header is invalid,
+            // we've reached the end of all previously allocated regions.
 
-            // save this region header address so that we can allocate new regions
-            // here later
+            // Save this region header address so that we can allocate new
+            // regions here later.
             self.next_unallocated_region_header_address
                 .set(region_header_address);
 
-            // Check any pending requests and allocate new regions
-            // after any existing regions.
-            self.check_unallocated_regions();
-            Ok(())
+            Ok(None)
         }
     }
 
     fn check_userspace_perms(
         &self,
-        processid: Option<ProcessId>,
-        command: Command,
+        processid: ProcessId,
+        command: NvmCommand,
     ) -> Result<(), ErrorCode> {
-        processid.map_or(Err(ErrorCode::FAIL), |processid| {
-            let perms = processid
-                .get_storage_permissions()
-                .ok_or(ErrorCode::NOSUPPORT)?;
-            let write_id = perms.get_write_id().ok_or(ErrorCode::NOSUPPORT)?;
-            match command {
-                Command::Read {
-                    offset: _,
-                    length: _,
-                } => perms
-                    .check_read_permission(write_id)
-                    .then_some(())
-                    .ok_or(ErrorCode::NOSUPPORT),
-                Command::Write {
-                    offset: _,
-                    length: _,
-                } => perms
-                    .check_modify_permission(write_id)
-                    .then_some(())
-                    .ok_or(ErrorCode::NOSUPPORT),
+        let perms = processid
+            .get_storage_permissions()
+            .ok_or(ErrorCode::NOSUPPORT)?;
+        let write_id = perms.get_write_id().ok_or(ErrorCode::NOSUPPORT)?;
+        match command {
+            NvmCommand::Read {
+                offset: _,
+                length: _,
+            } => perms
+                .check_read_permission(write_id)
+                .then_some(())
+                .ok_or(ErrorCode::NOSUPPORT),
+            NvmCommand::Write {
+                offset: _,
+                length: _,
+            } => perms
+                .check_modify_permission(write_id)
+                .then_some(())
+                .ok_or(ErrorCode::NOSUPPORT),
+            NvmCommand::GetSize => {
+                // If we have a `write_id` then we can return the size.
+                Ok(())
             }
-        })
+        }
     }
 
     fn check_userspace_access(
         &self,
         offset: usize,
         length: usize,
-        processid: Option<ProcessId>,
+        region: &AppRegion,
     ) -> Result<(), ErrorCode> {
-        // check that access is within this app's isolated nonvolatile region.
-        // this is to prevent an app from reading/writing to another app's
+        // Check that access is within this app's isolated nonvolatile region.
+        // This is to prevent an app from reading/writing to another app's
         // nonvolatile storage.
-        processid.map_or(Err(ErrorCode::FAIL), |processid| {
-            // enter the grant to query what the app's
-            // nonvolatile region is
-            self.apps
-                .enter(processid, |app, _kernel_data| {
-                    match &app.region {
-                        Some(app_region) => {
-                            if offset >= app_region.length
-                                || length > app_region.length
-                                || offset + length > app_region.length
-                            {
-                                return Err(ErrorCode::INVAL);
-                            }
 
-                            Ok(())
-                        }
+        if offset >= region.length || length > region.length || offset + length > region.length {
+            return Err(ErrorCode::INVAL);
+        }
 
-                        // fail if this app's nonvolatile region hasn't been assigned
-                        None => Err(ErrorCode::FAIL),
-                    }
-                })
-                .unwrap_or_else(|err| Err(err.into()))
-        })
+        Ok(())
     }
 
     fn check_header_access(&self, offset: usize, length: usize) -> Result<(), ErrorCode> {
-        // check that we're within the entire userspace region
+        // Check that we're within the entire userspace region.
         if offset < self.userspace_start_address
             || offset >= self.userspace_start_address + self.userspace_length
             || length > self.userspace_length
@@ -749,258 +694,221 @@ impl<'a, const APP_REGION_SIZE: usize> IsolatedNonvolatileStorage<'a, APP_REGION
     }
 
     // Check so see if we are doing something. If not, go ahead and do this
-    // command. If so, this is queued and will be run when the pending
-    // command completes.
+    // command. If so, this is queued and will be run when the pending command
+    // completes.
     fn enqueue_userspace_command(
         &self,
-        command: Command,
-        processid: Option<ProcessId>,
+        command: NvmCommand,
+        processid: ProcessId,
     ) -> Result<(), ErrorCode> {
-        self.check_userspace_access(command.offset(), command.length(), processid)?;
         self.check_userspace_perms(processid, command)?;
 
-        processid.map_or(Err(ErrorCode::FAIL), |processid| {
-            self.apps
-                .enter(processid, |app, kernel_data| {
-                    // Get the length of the correct allowed buffer.
-                    let allow_buf_len = match command {
-                        Command::Read {
-                            offset: _,
-                            length: _,
-                        } => kernel_data
-                            .get_readwrite_processbuffer(rw_allow::READ)
-                            .map_or(0, |read| read.len()),
-                        Command::Write {
-                            offset: _,
-                            length: _,
-                        } => kernel_data
-                            .get_readonly_processbuffer(ro_allow::WRITE)
-                            .map_or(0, |read| read.len()),
-                    };
-
-                    // Check that the matching allowed buffer exists.
-                    if allow_buf_len == 0 {
-                        return Err(ErrorCode::RESERVE);
-                    }
-
-                    // Fail if the app doesn't have a region assigned to it.
-                    let Some(app_region) = &app.region else {
-                        return Err(ErrorCode::FAIL);
-                    };
-
-                    let (command_offset, command_len) = match command {
-                        Command::Read { offset, length } => (offset, length),
-                        Command::Write { offset, length } => (offset, length),
-                    };
-
-                    // Shorten the length if the application gave us nowhere to
-                    // put it.
-                    let active_len = cmp::min(command_len, allow_buf_len);
-
-                    // No app is currently using the underlying storage.
-                    // Mark this app as active, and then execute the command.
-                    self.current_user.set(User::App { processid });
-
-                    // Need to copy bytes if this is a write!
-                    if let Command::Write {
-                        offset: _,
-                        length: _,
-                    } = command
-                    {
-                        let _ = kernel_data
-                            .get_readonly_processbuffer(ro_allow::WRITE)
-                            .and_then(|write| {
-                                write.enter(|app_buffer| {
-                                    self.buffer.map(|kernel_buffer| {
-                                        // Check that the internal buffer and the buffer that was
-                                        // allowed are long enough.
-                                        let write_len = cmp::min(active_len, kernel_buffer.len());
-
-                                        let d = &app_buffer[0..write_len];
-                                        for (i, c) in
-                                            kernel_buffer[0..write_len].iter_mut().enumerate()
-                                        {
-                                            *c = d[i].get();
-                                        }
-                                    });
-                                })
-                            });
-                    }
-
-                    // Note that the given offset for this command is with respect to
-                    // the app's region address space. This means that userspace accesses
-                    // start at 0 which is the start of the app's region.
-                    self.userspace_call_driver(
-                        command,
-                        app_region.offset + command_offset,
-                        active_len,
-                    )
-                })
-                .unwrap_or_else(|err| Err(err.into()))
-        })
-    }
-
-    fn userspace_call_driver(
-        &self,
-        command: Command,
-        offset: usize,
-        length: usize,
-    ) -> Result<(), ErrorCode> {
-        // Calculate where we want to actually read from in the physical
-        // storage.
-        let physical_address = offset + self.userspace_start_address;
-
-        self.buffer
-            .take()
-            .map_or(Err(ErrorCode::RESERVE), |buffer| {
-                // Check that the internal buffer and the buffer that was
-                // allowed are long enough.
-                let active_len = cmp::min(length, buffer.len());
-
-                match command {
-                    Command::Read {
-                        offset: _,
-                        length: _,
-                    } => self.driver.read(buffer, physical_address, active_len),
-                    Command::Write {
-                        offset: _,
-                        length: _,
-                    } => self.driver.write(buffer, physical_address, active_len),
+        self.apps
+            .enter(processid, |app, _kernel_data| {
+                if app.pending_operation.is_some() {
+                    return Err(ErrorCode::BUSY);
                 }
+                app.pending_operation = Some(command);
+                Ok(())
             })
-    }
+            .unwrap_or_else(|err| Err(err.into()))?;
 
-    // Find apps that made syscalls and have a region assigned to them already
-    fn find_app_to_handle_syscall(&self) -> Option<(ProcessId, Syscall)> {
-        for app in self.apps.iter() {
-            let processid = app.processid();
-            let pending_syscall = app.enter(|app, _| {
-                // hasn't finished init yet, so don't handle syscall
-                if app.region.is_none() {
-                    None
-                } else {
-                    app.pending_syscall
-                }
-            });
-
-            if let Some(syscall) = pending_syscall {
-                return Some((processid, syscall));
-            }
-        }
-        None
-    }
-
-    // Check for pending events such as unallocated regions or unhandled syscalls
-    fn check_unallocated_regions(&self) -> bool {
-        // If this is none, we haven't traversed the existing regions yet
-        if self.next_unallocated_region_header_address.is_none() {
-            return self.start_region_traversal().is_ok();
-        }
-
-        // Allocate regions for any apps that we didn't find
-        // while traversing existing regions
-        for app in self.apps.iter() {
-            let processid = app.processid();
-            let started = app.enter(|app, _| {
-                if app.has_requested_region && app.region.is_none() {
-                    // This app needs its region allocated.
-                    self.allocate_app_region(processid).is_ok()
-                } else {
-                    false
-                }
-            });
-            if started {
-                return true;
-            }
-        }
-        false
-    }
-
-    fn check_pending_syscalls(&self) -> bool {
-        // Handle any pending syscalls
-        if let Some((processid, syscall)) = self.find_app_to_handle_syscall() {
-            let res = self.handle_syscall(syscall, processid);
-
-            // Only notify apps if an error occurred.
-            // Later on, when the syscall successfully finishes,
-            // they will get an upcall.
-            if res.is_err() {
-                let _ = self.apps.enter(processid, |_app, kernel_data| {
-                    kernel_data
-                        .schedule_upcall(syscall.upcall(), (into_statuscode(res), 0, 0))
-                        .ok();
-                });
-                return false;
-            }
-
-            // no error ocurred when starting up syscall
-            return true;
-        }
-        false
+        self.check_queue();
+        Ok(())
     }
 
     fn check_queue(&self) {
-        let started_allocating = self.check_unallocated_regions();
-        // if we didn't need to allocate any new regions, take care of
-        // pending syscalls
-        if !started_allocating {
-            self.check_pending_syscalls();
+        if self.current_user.is_some() {
+            // If the driver is busy we can't start a new operation and do not
+            // need to check the queue.
+            return;
         }
-    }
 
-    fn handle_syscall(&self, syscall: Syscall, processid: ProcessId) -> Result<(), ErrorCode> {
-        match syscall {
-            Syscall::GetSize => self.handle_get_size_syscall(processid),
-            Syscall::Read { offset, length } => self.handle_read_syscall(processid, offset, length),
-            Syscall::Write { offset, length } => {
-                self.handle_write_syscall(processid, offset, length)
+        // If this is none, we haven't traversed the existing regions yet.
+        if self.next_unallocated_region_header_address.is_none() {
+            match self.start_region_traversal() {
+                Ok(()) => {
+                    // We started an operation so we can return and let that
+                    // operation finish.
+                    return;
+                }
+                Err(_e) => {
+                    // We did not start the traversal which is a problem. This
+                    // shouldn't happen, but if it does then we could overwrite
+                    // existing regions.
+                    return;
+                }
+            }
+        }
+
+        // Iterate apps and run an operation if one is pending.
+        for app in self.apps.iter() {
+            let processid = app.processid();
+            let started = app.enter(|app, kernel_data| {
+                match app.pending_operation {
+                    Some(nvm_command) => {
+                        if app.region.is_none() {
+                            // This app needs its region allocated.
+                            self.allocate_app_region(processid).is_ok()
+                        } else {
+                            let res = self.handle_syscall(nvm_command, processid, app, kernel_data);
+                            match res {
+                                Ok(started_operation) => started_operation,
+                                Err(e) => {
+                                    kernel_data
+                                        .schedule_upcall(
+                                            nvm_command.upcall(),
+                                            (into_statuscode(Err(e)), 0, 0),
+                                        )
+                                        .ok();
+
+                                    false
+                                }
+                            }
+                        }
+                    }
+                    None => false,
+                }
+            });
+            if started {
+                break;
             }
         }
     }
 
-    fn handle_get_size_syscall(&self, processid: ProcessId) -> Result<(), ErrorCode> {
-        // How many bytes are accessible to each app
-        let res = self
-            .apps
-            .enter(processid, |app, kernel_data| match app.region {
-                Some(region) => {
-                    // clear pending syscall
-                    app.pending_syscall = None;
-                    // signal app with the result
-                    kernel_data
-                        .schedule_upcall(
-                            upcall::GET_SIZE_DONE,
-                            (into_statuscode(Ok(())), region.length, 0),
-                        )
-                        .ok();
-                    Ok(())
+    fn handle_syscall(
+        &self,
+        command: NvmCommand,
+        processid: ProcessId,
+        app: &mut App,
+        kernel_data: &kernel::grant::GrantKernelData,
+    ) -> Result<bool, ErrorCode> {
+        match command {
+            NvmCommand::GetSize => {
+                match app.region {
+                    Some(region) => {
+                        // clear pending syscall
+                        app.pending_operation = None;
+                        // signal app with the result
+                        kernel_data
+                            .schedule_upcall(
+                                upcall::GET_SIZE_DONE,
+                                (into_statuscode(Ok(())), region.length, 0),
+                            )
+                            .ok();
+                        Ok(false)
+                    }
+                    None => Err(ErrorCode::NOMEM),
                 }
-                None => Err(ErrorCode::FAIL),
-            })?;
-        if res.is_ok() {
-            self.check_queue();
+            }
+
+            NvmCommand::Read {
+                offset: _,
+                length: _,
+            }
+            | NvmCommand::Write {
+                offset: _,
+                length: _,
+            } => {
+                // Get the length of the correct allowed buffer.
+                let allow_buf_len = match command {
+                    NvmCommand::Read {
+                        offset: _,
+                        length: _,
+                    } => kernel_data
+                        .get_readwrite_processbuffer(rw_allow::READ)
+                        .map_or(0, |read| read.len()),
+                    NvmCommand::Write {
+                        offset: _,
+                        length: _,
+                    } => kernel_data
+                        .get_readonly_processbuffer(ro_allow::WRITE)
+                        .map_or(0, |read| read.len()),
+                    NvmCommand::GetSize => 0,
+                };
+
+                // Check that the matching allowed buffer exists.
+                if allow_buf_len == 0 {
+                    return Err(ErrorCode::RESERVE);
+                }
+
+                // Fail if the app doesn't have a region assigned to it.
+                let Some(app_region) = &app.region else {
+                    return Err(ErrorCode::FAIL);
+                };
+
+                let command_offset = command.offset();
+                let command_len = command.length();
+
+                self.check_userspace_access(command_offset, command_len, app_region)?;
+
+                // Shorten the length if the application gave us nowhere to
+                // put it.
+                let active_len = cmp::min(command_len, allow_buf_len);
+
+                // Need to copy bytes if this is a write!
+                if let NvmCommand::Write {
+                    offset: _,
+                    length: _,
+                } = command
+                {
+                    let _ = kernel_data
+                        .get_readonly_processbuffer(ro_allow::WRITE)
+                        .and_then(|write| {
+                            write.enter(|app_buffer| {
+                                self.buffer.map(|kernel_buffer| {
+                                    // Check that the internal buffer and
+                                    // the buffer that was allowed are long
+                                    // enough.
+                                    let write_len = cmp::min(active_len, kernel_buffer.len());
+
+                                    let d = &app_buffer[0..write_len];
+                                    for (i, c) in kernel_buffer[0..write_len].iter_mut().enumerate()
+                                    {
+                                        *c = d[i].get();
+                                    }
+                                });
+                            })
+                        });
+                }
+
+                // Calculate where we want to actually read from in the
+                // physical storage. Note that the given offset for this
+                // command is with respect to the app's region address
+                // space. This means that userspace accesses start at 0
+                // which is the start of the app's region.
+                let physical_address =
+                    app_region.offset + command_offset + self.userspace_start_address;
+
+                let res = self
+                    .buffer
+                    .take()
+                    .map_or(Err(ErrorCode::RESERVE), |buffer| {
+                        // Check that the internal buffer and the buffer that was
+                        // allowed are long enough.
+                        let active_len_buf = cmp::min(active_len, buffer.len());
+
+                        match command {
+                            NvmCommand::Read {
+                                offset: _,
+                                length: _,
+                            } => self.driver.read(buffer, physical_address, active_len_buf),
+                            NvmCommand::Write {
+                                offset: _,
+                                length: _,
+                            } => self.driver.write(buffer, physical_address, active_len_buf),
+                            NvmCommand::GetSize => Err(ErrorCode::FAIL),
+                        }
+                    });
+                match res {
+                    Ok(()) => {
+                        self.current_user.set(User::App { processid });
+                        Ok(true)
+                    }
+                    Err(e) => Err(e),
+                }
+            }
         }
-        res
-    }
-
-    fn handle_read_syscall(
-        &self,
-        processid: ProcessId,
-        offset: usize,
-        length: usize,
-    ) -> Result<(), ErrorCode> {
-        // Issue a read command
-        self.enqueue_userspace_command(Command::Read { offset, length }, Some(processid))
-    }
-
-    fn handle_write_syscall(
-        &self,
-        processid: ProcessId,
-        offset: usize,
-        length: usize,
-    ) -> Result<(), ErrorCode> {
-        // Issue a write command
-        self.enqueue_userspace_command(Command::Write { offset, length }, Some(processid))
     }
 }
 
@@ -1014,13 +922,35 @@ impl<const APP_REGION_SIZE: usize> hil::nonvolatile_storage::NonvolatileStorageC
             match user {
                 User::RegionManager(state) => {
                     self.buffer.replace(buffer);
-                    let _ = match state {
-                        RegionState::ReadHeader(action) => self.header_read_done(action),
-                        _ => Err(ErrorCode::FAIL),
+                    match state {
+                        ManagerTask::DiscoverRegions(address) => {
+                            let res = self.header_read_done(address);
+                            match res {
+                                Ok(addr) => match addr {
+                                    Some(next_header_address) => {
+                                        self.current_user.set(User::RegionManager(
+                                            ManagerTask::DiscoverRegions(next_header_address),
+                                        ));
+                                    }
+                                    None => {
+                                        // We finished the scan of existing
+                                        // regions. Now we can check the queue
+                                        // to see if there is any work to be
+                                        // done.
+                                        self.check_queue();
+                                    }
+                                },
+                                Err(_e) => {
+                                    // Not clear what to do here.
+                                    self.check_queue();
+                                }
+                            }
+                        }
+                        _ => {}
                     };
                 }
                 User::App { processid } => {
-                    let res = self.apps.enter(processid, move |app, kernel_data| {
+                    let _ = self.apps.enter(processid, move |app, kernel_data| {
                         // Need to copy in the contents of the buffer
                         let read_len = kernel_data
                             .get_readwrite_processbuffer(rw_allow::READ)
@@ -1034,13 +964,14 @@ impl<const APP_REGION_SIZE: usize> hil::nonvolatile_storage::NonvolatileStorageC
                                     }
                                     read_len
                                 })
-                            })?;
+                            })
+                            .unwrap_or(0);
 
                         // Replace the buffer we used to do this read.
                         self.buffer.replace(buffer);
 
                         // clear pending syscall
-                        app.pending_syscall = None;
+                        app.pending_operation = None;
                         // And then signal the app.
                         kernel_data
                             .schedule_upcall(
@@ -1048,14 +979,9 @@ impl<const APP_REGION_SIZE: usize> hil::nonvolatile_storage::NonvolatileStorageC
                                 (into_statuscode(Ok(())), read_len, 0),
                             )
                             .ok();
-                        Ok::<(), kernel::process::Error>(())
                     });
 
-                    if let Ok(closure_res) = res {
-                        if closure_res.is_ok() {
-                            self.check_queue();
-                        }
-                    }
+                    self.check_queue();
                 }
             }
         });
@@ -1070,48 +996,82 @@ impl<const APP_REGION_SIZE: usize> hil::nonvolatile_storage::NonvolatileStorageC
             match user {
                 User::RegionManager(state) => {
                     match state {
-                        RegionState::WriteHeader(processid, region) => {
-                            // Now that we have written the header for the app we can store its region in its grant.
+                        ManagerTask::WriteHeader(processid, region) => {
+                            // Now that we have written the header for the app
+                            // we can store its region in its grant.
                             let _ = self.apps.enter(processid, |app, _kernel_data| {
                                 // set region data in app's grant
                                 app.region.replace(region);
                             });
 
-                            // Update our metadata about where the next unallocated region is.
+                            // Update our metadata about where the next
+                            // unallocated region is.
                             let next_header_addr = region.offset + region.length;
                             self.next_unallocated_region_header_address
                                 .set(next_header_addr);
 
                             // Erase the userspace accessible content of the region
                             // before handing it off to an app.
-                            let _ =
-                                self.erase_region_content(processid, region.offset, region.length);
+                            let res = self.erase_region_content(region.offset, region.length);
+                            match res {
+                                Ok((next_erase_start, remaining_bytes)) => {
+                                    self.current_user.set(User::RegionManager(
+                                        // need to pass on where the next erase should start
+                                        // how long it should be.
+                                        ManagerTask::EraseRegion {
+                                            processid,
+                                            next_erase_start,
+                                            remaining_bytes,
+                                        },
+                                    ));
+                                }
+                                Err(_e) => {
+                                    // Not clear what to do here.
+                                    self.current_user.clear();
+                                    self.check_queue();
+                                }
+                            }
                         }
-                        RegionState::EraseRegion {
+                        ManagerTask::EraseRegion {
                             processid,
                             next_erase_start,
                             remaining_bytes,
                         } => {
                             if remaining_bytes > 0 {
-                                // we still have more to erase, so kick off another one
-                                // where we left off
-                                let _ = self.erase_region_content(
-                                    processid,
-                                    next_erase_start,
-                                    remaining_bytes,
-                                );
+                                // We still have more to erase, so kick off
+                                // another one where we left off.
+                                let res =
+                                    self.erase_region_content(next_erase_start, remaining_bytes);
+                                match res {
+                                    Ok((next_erase_start, remaining_bytes)) => {
+                                        self.current_user.set(User::RegionManager(
+                                            ManagerTask::EraseRegion {
+                                                processid,
+                                                next_erase_start,
+                                                remaining_bytes,
+                                            },
+                                        ));
+                                    }
+                                    Err(_e) => {
+                                        // Not clear what to do here.
+                                        self.current_user.clear();
+                                        self.check_queue();
+                                    }
+                                }
                             } else {
-                                // done erasing entire region.
-                                self.check_pending_syscalls();
+                                // Done erasing entire region. Can go on with
+                                // normal tasks.
+                                self.current_user.clear();
+                                self.check_queue();
                             }
                         }
                         _ => {}
                     };
                 }
                 User::App { processid } => {
-                    let res = self.apps.enter(processid, move |app, kernel_data| {
+                    let _ = self.apps.enter(processid, move |app, kernel_data| {
                         // clear pending syscall
-                        app.pending_syscall = None;
+                        app.pending_operation = None;
                         // Notify app that its write has completed.
                         kernel_data
                             .schedule_upcall(
@@ -1120,10 +1080,8 @@ impl<const APP_REGION_SIZE: usize> hil::nonvolatile_storage::NonvolatileStorageC
                             )
                             .ok();
                     });
-
-                    if res.is_ok() {
-                        self.check_queue();
-                    }
+                    self.current_user.clear();
+                    self.check_queue();
                 }
             }
         });
@@ -1155,36 +1113,22 @@ impl<const APP_REGION_SIZE: usize> SyscallDriver
             0 => CommandReturn::success(),
 
             // For the get_bytes, read, and write syscalls we need to first
-            // initialize the app's isolated nonvolatile storage.
-            // This involves searching the storage area for an existing
-            // region that belongs to this app. If we don't find an existing region
-            // we allocate a new one.
-            // Only once the initialization is complete, can we service
-            // the original syscall. So, we can store the syscall data
-            // in the app's grant and handle it when initialization finishes.
+            // initialize the app's isolated nonvolatile storage. This involves
+            // searching the storage area for an existing region that belongs to
+            // this app. If we don't find an existing region we allocate a new
+            // one. Only once the initialization is complete, can we service the
+            // original syscall. So, we can store the syscall data in the app's
+            // grant and handle it when initialization finishes.
             1 | 2 | 3 => {
-                let syscall = match command_num {
-                    1 => Syscall::GetSize,
-                    2 => Syscall::Read { offset, length },
-                    3 => Syscall::Write { offset, length },
+                let nvm_command = match command_num {
+                    1 => NvmCommand::GetSize,
+                    2 => NvmCommand::Read { offset, length },
+                    3 => NvmCommand::Write { offset, length },
                     _ => return CommandReturn::failure(ErrorCode::NOSUPPORT),
                 };
 
-                let res = if let Ok(has_region) = self
-                    .apps
-                    .enter(processid, |app, _kernel_data| app.region.is_some())
-                {
-                    if has_region {
-                        // already initialized this app's region, can directly handle syscall
-                        self.handle_syscall(syscall, processid)
-                    } else {
-                        // need to initialize app region before handling syscall
-                        self.init_app(syscall, processid)
-                    }
-                } else {
-                    Err(ErrorCode::NOMEM)
-                };
-
+                // Enqueue the operation for the app.
+                let res = self.enqueue_userspace_command(nvm_command, processid);
                 match res {
                     Ok(()) => CommandReturn::success(),
                     Err(e) => CommandReturn::failure(e),

--- a/capsules/extra/src/isolated_nonvolatile_storage_driver.rs
+++ b/capsules/extra/src/isolated_nonvolatile_storage_driver.rs
@@ -834,7 +834,7 @@ impl<'a, const APP_REGION_SIZE: usize> IsolatedNonvolatileStorage<'a, APP_REGION
 
                 // Fail if the app doesn't have a region assigned to it.
                 let Some(app_region) = &app.region else {
-                    return Err(ErrorCode::FAIL);
+                    return Err(ErrorCode::NOMEM);
                 };
 
                 let command_offset = command.offset();
@@ -892,11 +892,17 @@ impl<'a, const APP_REGION_SIZE: usize> IsolatedNonvolatileStorage<'a, APP_REGION
                             NvmCommand::Read {
                                 offset: _,
                                 length: _,
-                            } => self.driver.read(buffer, physical_address, active_len_buf),
+                            } => self
+                                .driver
+                                .read(buffer, physical_address, active_len_buf)
+                                .or(Err(ErrorCode::FAIL)),
                             NvmCommand::Write {
                                 offset: _,
                                 length: _,
-                            } => self.driver.write(buffer, physical_address, active_len_buf),
+                            } => self
+                                .driver
+                                .write(buffer, physical_address, active_len_buf)
+                                .or(Err(ErrorCode::FAIL)),
                             NvmCommand::GetSize => Err(ErrorCode::FAIL),
                         }
                     });

--- a/capsules/extra/src/lib.rs
+++ b/capsules/extra/src/lib.rs
@@ -51,6 +51,7 @@ pub mod hts221;
 pub mod humidity;
 pub mod ieee802154;
 pub mod isl29035;
+pub mod isolated_nonvolatile_storage_driver;
 pub mod kv_driver;
 pub mod kv_store_permissions;
 pub mod l3gd20;

--- a/doc/syscalls/50004_isolated_nonvolatile_storage.md
+++ b/doc/syscalls/50004_isolated_nonvolatile_storage.md
@@ -5,7 +5,8 @@ driver number: 0x50004
 # Isolated Nonvolatile Storage
 
 This Driver provides access to a contiguous, fixed-size region of nonvolatile
-storage the application can use.
+storage the application can use. This interface supports both 32-bit and 64-bit
+address spaces for the nonvolatile storage.
 
 Note: use of this interface is protected by `StoragePermissions`, so
 applications will need storage permissions to use this interface.
@@ -65,9 +66,7 @@ applications will need storage permissions to use this interface.
 
   The read is specified by the offset (in bytes) from the beginning of the app's
   allocated nonvolatile storage region and the length (in bytes) of the read.
-  The driver will read up to the number of bytes specified by length. The copy
-  length is the smaller of the length requested and the size of the allowed
-  buffer.
+  The length is equal to the size of the allowed read buffer.
 
   Calling this command will allocate a storage region if one was not previously
   allocated to the application.
@@ -78,8 +77,8 @@ applications will need storage permissions to use this interface.
 
   #### Arguments
 
-  - **1**: read offset, in bytes
-  - **2**: read length, in bytes
+  - **1**: read offset, in bytes (lower 32 bits)
+  - **2**: read offset, in bytes (upper 32 bits)
 
   #### Returns
 
@@ -108,9 +107,7 @@ applications will need storage permissions to use this interface.
 
   The write is specified by the offset (in bytes) from the beginning of the
   app's allocated nonvolatile storage region and the length (in bytes) of the
-  write. The driver will write up to the number of bytes specified by length.
-  The write length is the smaller of the length requested and the size of the
-  allowed buffer.
+  write. The length is equal to the size of the allowed buffer.
 
   Calling this command will allocate a storage region if one was not previously
   allocated to the application.
@@ -121,8 +118,8 @@ applications will need storage permissions to use this interface.
 
   #### Arguments
 
-  - **1**: write offset, in bytes
-  - **2**: write length, in bytes
+  - **1**: write offset, in bytes (lower 32 bits)
+  - **2**: write offset, in bytes (upper 32 bits)
 
   #### Returns
 
@@ -181,12 +178,12 @@ applications will need storage permissions to use this interface.
   The upcall signature looks like:
 
   ```rust
-  fn upcall(s: Statuscode, length: usize);
+  fn upcall(s: Statuscode);
   ```
 
   Upcall arguments:
   - 0: A `Statuscode` returning the success or failure of the operation.
-  - 1: The number of bytes read into the allowed buffer.
+  - 1: unused
   - 2: unused
 
   The `length` argument is only valid if the status code is `SUCCESS`.
@@ -213,12 +210,12 @@ applications will need storage permissions to use this interface.
   The upcall signature looks like:
 
   ```rust
-  fn upcall(s: Statuscode, length: usize);
+  fn upcall(s: Statuscode);
   ```
 
   Upcall arguments:
   - 0: A `Statuscode` returning the success or failure of the operation.
-  - 1: The number of bytes written to the storage region.
+  - 1: unused
   - 2: unused
 
   The `length` argument is only valid if the status code is `SUCCESS`.

--- a/doc/syscalls/50004_isolated_nonvolatile_storage.md
+++ b/doc/syscalls/50004_isolated_nonvolatile_storage.md
@@ -173,7 +173,7 @@ applications will need storage permissions to use this interface.
 
 - ### Subscribe number: `1`
 
-  Subscribe to get read done upcalls. This upcall fires after a read command
+  Subscribe to read done upcalls. This upcall fires after a read command
   completes or encounters an error.
 
   #### Upcall Signature
@@ -195,7 +195,8 @@ applications will need storage permissions to use this interface.
 
   - `SUCCESS`: The read command succeeded and `length` is set to the number
     of bytes read into the allowed buffer.
-  - `RESERVE`: No buffer was allowed for read-write allow 0.
+  - `RESERVE`: No buffer was allowed for read-write allow 0 or the allowed
+    buffer has a length of 0.
   - `NOMEM`: The app has no nonvolatile storage region.
   - `NOSUPPORT`: The application does not have permissions to access the
     nonvolatile storage.
@@ -204,7 +205,7 @@ applications will need storage permissions to use this interface.
 
 - ### Subscribe number: `2`
 
-  Subscribe to get write done upcalls. This upcall fires after a write command
+  Subscribe to write done upcalls. This upcall fires after a write command
   completes or encounters an error.
 
   #### Upcall Signature
@@ -226,7 +227,8 @@ applications will need storage permissions to use this interface.
 
   - `SUCCESS`: The read command succeeded and `length` is set to the number
     of bytes written from the allowed buffer.
-  - `RESERVE`: No buffer was allowed for read-only allow 0.
+  - `RESERVE`: No buffer was allowed for read-only allow 0 or the allowed
+    buffer has a length of 0.
   - `NOMEM`: The app has no nonvolatile storage region.
   - `NOSUPPORT`: The application does not have permissions to access the
     nonvolatile storage.

--- a/doc/syscalls/50004_isolated_nonvolatile_storage.md
+++ b/doc/syscalls/50004_isolated_nonvolatile_storage.md
@@ -1,0 +1,139 @@
+---
+driver number: 0x50004
+---
+
+# Isolated Nonvolatile Storage
+
+This Driver provides access to a contiguous, fixed-size region of nonvolatile
+storage the application can use.
+
+Note: use of this interface is protected by `StoragePermissions`, so
+applications will need storage permissions to use this interface.
+
+## Command
+
+- ### Command number: `0`
+
+  Does the driver exist?
+
+  #### Arguments
+
+  - **1**: unused
+  - **2**: unused
+
+  #### Returns
+
+  `SUCCESS` if it exists, otherwise `NODEVICE`.
+
+- ### Command number: `1`
+
+  **Get Size**. Query the size of the nonvolatile storage region the application
+  has access to in bytes.
+
+  Calling this command will allocate a storage region if one was not previously
+  allocated to the application.
+
+  #### Arguments
+
+  - **1**: unused
+  - **2**: unused
+
+  #### Returns
+
+  ##### Success
+
+  The get size command was accepted and the response will be issued via an
+  upcall.
+
+  ##### Failure
+
+  If the command does not succeed then no upcall will be issued and the command
+  returns type `SyscallReturn::Failure` with one of these error codes:
+
+  - `NOSUPPORT`: The application does not have permissions to access the
+    nonvolatile storage.
+  - `BUSY`: A prior request is pending.
+
+
+## Subscribe
+
+- ### Subscribe number: `0`
+
+  Subscribe to operation completion upcalls. All K-V operations will trigger
+  this upcall when complete.
+
+  #### Upcall Signature
+
+  The upcall signature looks like:
+
+  ```rust
+  fn upcall(s: Statuscode, value_length: usize, unused: usize);
+  ```
+
+  If the requested operation was set/add/update/delete, the other fields are
+  always 0.
+
+  If the requested operation was a GET, `value_length` will be set to the length
+  of the value in bytes. If the value was longer than what fit in the RW allowed
+  buffer, `s` will be a `SIZE` error. If a different error occurred
+  `value_length` will be set to 0.
+
+  The third argument `unused` is always 0.
+
+  ##### `Statuscode` Values
+
+  If the operation succeeded `s` will be `SUCCESS`.
+
+  On failure, the following errors will be returned:
+
+  - For GET:
+    - `SIZE`: The value is longer than the provided buffer.
+    - `NOSUPPORT`: The key could not be found or the app does not have
+      permission to read this key.
+    - `FAIL`: An internal error occurred.
+  - For SET:
+    - `NOSUPPORT`: The app does not have permission to store this key.
+  - For ADD:
+    - `NOSUPPORT`: The key already exists and cannot be added or the app does
+      not have permission to add this key.
+  - For UPDATE:
+    - `NOSUPPORT`: The key does not already exist and cannot be modified or the
+      app does not have permission to modify this key.
+  - For SET/ADD/UPDATE:
+    - `NOMEM`: The key could not be updated because the KV store is full.
+    - `SIZE`: The key or value is too many bytes.
+    - `FAIL`: An internal error occurred.
+  - For DELETE:
+    - `NOSUPPORT`: The key does not exist or the app does not have permission to
+      delete this key.
+    - `FAIL`: An internal error occurred.
+
+## Read-Only Allow
+
+- ### RO Allow number: `0`
+
+  The key to use for the intended operation. The length of the allowed buffer
+  must match the length of the key.
+
+
+- ### RO Allow number: `1`
+
+  The value to use for the intended write operation. The length of the allowed
+  buffer must match the length of the value.
+
+  This is only used for set/add/update operations.
+
+## Read-Write Allow
+
+- ### RW Allow number: `0`
+
+  Storage for the value after a GET operation. The kernel will write the value
+  read from the database here.
+
+  If the read value is longer than the size of the allowed buffer the driver
+  will provide the portion of the value that does fit. The `value_length` in the
+  callback will still be set to the full size of the original value.
+
+  As the kernel must be able to write the buffer to provide userspace the value
+  this must be a read-write allow, and separate from the RO allow for setting
+  the value.

--- a/doc/syscalls/50004_isolated_nonvolatile_storage.md
+++ b/doc/syscalls/50004_isolated_nonvolatile_storage.md
@@ -55,6 +55,46 @@ applications will need storage permissions to use this interface.
   - `BUSY`: A prior request is pending.
 
 
+- ### Command number: `2`
+
+  **Read**. Read a region of the app's nonvolatile storage.
+
+  The read is asynchronous as the nonvolatile storage may not be attached to
+  main memory bus or mapped to the main address space. The data will be copied
+  into the buffer shared with the kernel via read-write allow 0.
+
+  The read is specified by the offset (in bytes) from the beginning of the app's
+  allocated nonvolatile storage region and the length (in bytes) of the read.
+  The driver will copy up to the number of bytes specified by length. The copy
+  length is the smallest of the length requested, the size of the specified read
+  range that is withing the app's allocated nonvolatile region, and the size of
+  the allowed buffer.
+
+  Calling this command will allocate a storage region if one was not previously
+  allocated to the application.
+
+  #### Arguments
+
+  - **1**: read offset, in bytes
+  - **2**: read length, in bytes
+
+  #### Returns
+
+  ##### Success
+
+  The read command was accepted and a response will be issued via the upcall.
+
+  ##### Failure
+
+  If the command does not succeed then no upcall will be issued and the command
+  returns type `SyscallReturn::Failure` with one of these error codes:
+
+  - `NOSUPPORT`: The application does not have permissions to access the
+    nonvolatile storage.
+  - `BUSY`: A prior request is pending.
+
+
+
 ## Subscribe
 
 - ### Subscribe number: `0`

--- a/doc/syscalls/README.md
+++ b/doc/syscalls/README.md
@@ -100,6 +100,7 @@ _Note:_ GPIO is slated for re-numbering in Tock 2.0.
 |   | 0x50001       | Nonvolatile Storage | Generic interface for persistent storage |
 |   | 0x50002       | SDCard           | Raw block access to an SD card             |
 |   | 0x50003       | [Key-Value](50003_key_value.md) | Access to a key-value storage database |
+|   | 0x50004       | [Isolated Nonvolatile Storage](50004_isolated_nonvolatile_storage.md) | Per-application nonvolatile storage |
 
 ### Sensors
 


### PR DESCRIPTION
### Pull Request Overview

Updated version of #4109 which creates a new capsule that maintains isolation between each app's nonvolatile storage. 
Original motivation: https://github.com/tock/tock/issues/3905

Major changes from #4109:
- Removed extra init syscall
- Storage initialization now happens on each app's first syscall (any syscall)
  - Initialization is needed to find an app's existing storage region (or to allocate a new one)
- Syscall interface designed to support both 32 and 64 bit memory address spaces. The capsule is still designed to support only memory sizes that match the CPU's address size.

### Testing Strategy

This pull request was tested by running this libtock-c test with multiple apps https://github.com/atar13/libtock-c/blob/a14cd9c5c04bf9ef154581b63e205c7040eac271/examples/tests/isolated_nonvolatile_storage/main.c.

I also verified that apps keep their previously owned regions through board reboots (checked by added some kernel debug statements that indicate which storage region each app owns) 


### Documentation Updated

~Update libtock-c example to show how the kernel needs to be modified to add this capsule https://github.com/atar13/libtock-c/blob/a14cd9c5c04bf9ef154581b63e205c7040eac271/examples/tests/isolated_nonvolatile_storage/README.md~

### Formatting

- [x] Ran `make prepush`.
