### PR TITLE
ARMv6: fix setting the CONTROL register

### DIFF
--- a/arch/cortex-m0/src/lib.rs
+++ b/arch/cortex-m0/src/lib.rs
@@ -247,7 +247,7 @@ svc_handler:
   movs r0, #0
   msr CONTROL, r0
   /* CONTROL writes must be followed by ISB */
-  /* http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dai0321a/BIHFJCAC.html */
+    /* https://developer.arm.com/documentation/dui0662/b/The-Cortex-M0--Processor/Programmers-model/Core-registers */
   isb
   ldr r0, =SYSCALL_FIRED
   movs r1, #1

--- a/arch/cortex-m0/src/lib.rs
+++ b/arch/cortex-m0/src/lib.rs
@@ -96,7 +96,7 @@ core::arch::global_asm!(
     movs r0, #0
     msr CONTROL, r0
     /* CONTROL writes must be followed by ISB */
-    /* http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dai0321a/BIHFJCAC.html */
+    /* https://developer.arm.com/documentation/dui0662/b/The-Cortex-M0--Processor/Programmers-model/Core-registers */
     isb
 
     /* We need the most recent kernel's version of r1, which points */

--- a/arch/cortex-m0/src/lib.rs
+++ b/arch/cortex-m0/src/lib.rs
@@ -238,7 +238,7 @@ svc_handler:
   movs r0, #1
   msr CONTROL, r0
   /* CONTROL writes must be followed by ISB */
-  /* http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dai0321a/BIHFJCAC.html */
+    /* https://developer.arm.com/documentation/dui0662/b/The-Cortex-M0--Processor/Programmers-model/Core-registers */
   isb
   ldr r1, 300f // EXC_RETURN_PSP
   bx r1


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes a fault in `generic_isr` and `svc_handler` by setting the `CONTROL` register accordingly. Without this fix, after an interrupt, applications continue to work in privileged mode.

This fixes #4245 and fixes #4246.


### Testing Strategy

This pull request was tested using a Raspberry Pi Pico by @JADarius.


### TODO or Help Wanted

Feedback from @ppannuto and others that are more experienced in ARM architecture.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
