### PR TITLE
{gpio/InterruptPin, button, led}: allow the use of dyn instead of concrete types

### DIFF
--- a/boards/components/src/led_matrix.rs
+++ b/boards/components/src/led_matrix.rs
@@ -144,6 +144,24 @@ macro_rules! led_matrix_leds {
     };};
 }
 
+#[macro_export]
+macro_rules! led_matrix_leds_dynamic {
+    ($Pin:ty, $A: ty, $led_matrix: expr, $(($col: expr, $row: expr)),+) => {{
+        use capsules_extra::led_matrix::LedMatrixLed;
+        use kernel::count_expressions;
+        use kernel::hil::led::Led;
+
+        const NUM_LEDS: usize = count_expressions!($(($col, $row)),+);
+        let leds = static_init!(
+            [&dyn Led; NUM_LEDS],
+            [$(
+                $crate::led_matrix_led! ($Pin, $A, $led_matrix, $col, $row)
+            ),+]
+        );
+        leds
+    };};
+}
+
 pub struct LedMatrixComponent<
     L: 'static + Pin,
     A: 'static + Alarm<'static>,

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -16,6 +16,7 @@ use core::ptr::{addr_of, addr_of_mut};
 
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::hil::led::Led;
 use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
@@ -105,18 +106,7 @@ pub struct MicroBit {
     ieee802154: &'static Ieee802154RawDriver,
     console: &'static capsules_core::console::Console<'static>,
     gpio: &'static capsules_core::gpio::GPIO<'static, nrf52::gpio::GPIOPin<'static>>,
-    led: &'static capsules_core::led::LedDriver<
-        'static,
-        capsules_extra::led_matrix::LedMatrixLed<
-            'static,
-            nrf52::gpio::GPIOPin<'static>,
-            capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<
-                'static,
-                nrf52::rtc::Rtc<'static>,
-            >,
-        >,
-        25,
-    >,
+    led: &'static capsules_core::led::LedDriver<'static, dyn Led, 25>,
     button: &'static capsules_core::button::Button<'static, nrf52::gpio::GPIOPin<'static>>,
     rng: &'static RngDriver,
     ninedof: &'static capsules_extra::ninedof::NineDof<'static>,
@@ -657,19 +647,8 @@ unsafe fn start() -> (
     ));
 
     let led = static_init!(
-        capsules_core::led::LedDriver<
-            'static,
-            capsules_extra::led_matrix::LedMatrixLed<
-                'static,
-                nrf52::gpio::GPIOPin<'static>,
-                capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<
-                    'static,
-                    nrf52::rtc::Rtc<'static>,
-                >,
-            >,
-            25,
-        >,
-        capsules_core::led::LedDriver::new(components::led_matrix_leds!(
+        capsules_core::led::LedDriver<'static, dyn Led, 25>,
+        capsules_core::led::LedDriver::new(components::led_matrix_leds_dynamic!(
             nrf52::gpio::GPIOPin<'static>,
             capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<
                 'static,

--- a/capsules/core/src/button.rs
+++ b/capsules/core/src/button.rs
@@ -85,7 +85,7 @@ pub struct App {
 
 /// Manages the list of GPIO pins that are connected to buttons and which apps
 /// are listening for interrupts from which buttons.
-pub struct Button<'a, P: gpio::InterruptPin<'a>> {
+pub struct Button<'a, P: gpio::InterruptPin<'a> + ?Sized> {
     pins: &'a [(
         &'a gpio::InterruptValueWrapper<'a, P>,
         gpio::ActivationMode,
@@ -94,7 +94,7 @@ pub struct Button<'a, P: gpio::InterruptPin<'a>> {
     apps: Grant<App, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
 }
 
-impl<'a, P: gpio::InterruptPin<'a>> Button<'a, P> {
+impl<'a, P: gpio::InterruptPin<'a> + ?Sized> Button<'a, P> {
     pub fn new(
         pins: &'a [(
             &'a gpio::InterruptValueWrapper<'a, P>,
@@ -127,7 +127,7 @@ impl<'a, P: gpio::InterruptPin<'a>> Button<'a, P> {
 ///   button.
 const UPCALL_NUM: usize = 0;
 
-impl<'a, P: gpio::InterruptPin<'a>> SyscallDriver for Button<'a, P> {
+impl<'a, P: gpio::InterruptPin<'a> + ?Sized> SyscallDriver for Button<'a, P> {
     /// Configure interrupts and read state for buttons.
     ///
     /// `data` is the index of the button in the button array as passed to
@@ -226,7 +226,7 @@ impl<'a, P: gpio::InterruptPin<'a>> SyscallDriver for Button<'a, P> {
     }
 }
 
-impl<'a, P: gpio::InterruptPin<'a>> gpio::ClientWithValue for Button<'a, P> {
+impl<'a, P: gpio::InterruptPin<'a> + ?Sized> gpio::ClientWithValue for Button<'a, P> {
     fn fired(&self, pin_num: u32) {
         // Read the value of the pin and get the button state.
         let button_state = self.get_button_state(pin_num);

--- a/capsules/core/src/gpio.rs
+++ b/capsules/core/src/gpio.rs
@@ -67,12 +67,12 @@ use kernel::{ErrorCode, ProcessId};
 ///        The callback signature is `fn(pin_num: usize, pin_state: bool)`
 const UPCALL_NUM: usize = 0;
 
-pub struct GPIO<'a, IP: gpio::InterruptPin<'a>> {
+pub struct GPIO<'a, IP: gpio::InterruptPin<'a> + ?Sized> {
     pins: &'a [Option<&'a gpio::InterruptValueWrapper<'a, IP>>],
     apps: Grant<(), UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
 }
 
-impl<'a, IP: gpio::InterruptPin<'a>> GPIO<'a, IP> {
+impl<'a, IP: gpio::InterruptPin<'a> + ?Sized> GPIO<'a, IP> {
     pub fn new(
         pins: &'a [Option<&'a gpio::InterruptValueWrapper<'a, IP>>],
         grant: Grant<(), UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
@@ -137,7 +137,7 @@ impl<'a, IP: gpio::InterruptPin<'a>> GPIO<'a, IP> {
     }
 }
 
-impl<'a, IP: gpio::InterruptPin<'a>> gpio::ClientWithValue for GPIO<'a, IP> {
+impl<'a, IP: gpio::InterruptPin<'a> + ?Sized> gpio::ClientWithValue for GPIO<'a, IP> {
     fn fired(&self, pin_num: u32) {
         // read the value of the pin
         let pins = self.pins;
@@ -154,7 +154,7 @@ impl<'a, IP: gpio::InterruptPin<'a>> gpio::ClientWithValue for GPIO<'a, IP> {
     }
 }
 
-impl<'a, IP: gpio::InterruptPin<'a>> SyscallDriver for GPIO<'a, IP> {
+impl<'a, IP: gpio::InterruptPin<'a> + ?Sized> SyscallDriver for GPIO<'a, IP> {
     /// Query and control pin values and states.
     ///
     /// Each byte of the `data` argument is treated as its own field.

--- a/capsules/core/src/led.rs
+++ b/capsules/core/src/led.rs
@@ -64,11 +64,11 @@ pub const DRIVER_NUM: usize = driver::NUM::Led as usize;
 
 /// Holds the array of LEDs and implements a `Driver` interface to
 /// control them.
-pub struct LedDriver<'a, L: led::Led, const NUM_LEDS: usize> {
+pub struct LedDriver<'a, L: led::Led + ?Sized, const NUM_LEDS: usize> {
     leds: &'a [&'a L; NUM_LEDS],
 }
 
-impl<'a, L: led::Led, const NUM_LEDS: usize> LedDriver<'a, L, NUM_LEDS> {
+impl<'a, L: led::Led + ?Sized, const NUM_LEDS: usize> LedDriver<'a, L, NUM_LEDS> {
     pub fn new(leds: &'a [&'a L; NUM_LEDS]) -> Self {
         // Initialize all LEDs and turn them off
         for led in leds.iter() {
@@ -80,7 +80,7 @@ impl<'a, L: led::Led, const NUM_LEDS: usize> LedDriver<'a, L, NUM_LEDS> {
     }
 }
 
-impl<L: led::Led, const NUM_LEDS: usize> SyscallDriver for LedDriver<'_, L, NUM_LEDS> {
+impl<L: led::Led + ?Sized, const NUM_LEDS: usize> SyscallDriver for LedDriver<'_, L, NUM_LEDS> {
     /// Control the LEDs.
     ///
     /// ### `command_num`

--- a/kernel/src/hil/gpio.rs
+++ b/kernel/src/hil/gpio.rs
@@ -269,13 +269,13 @@ pub trait ClientWithValue {
 /// Standard implementation of InterruptWithValue: handles an
 /// `gpio::Client::fired` and passes it up as a
 /// `gpio::ClientWithValue::fired`.
-pub struct InterruptValueWrapper<'a, IP: InterruptPin<'a>> {
+pub struct InterruptValueWrapper<'a, IP: InterruptPin<'a> + ?Sized> {
     value: Cell<u32>,
     client: OptionalCell<&'a dyn ClientWithValue>,
     source: &'a IP,
 }
 
-impl<'a, IP: InterruptPin<'a>> InterruptValueWrapper<'a, IP> {
+impl<'a, IP: InterruptPin<'a> + ?Sized> InterruptValueWrapper<'a, IP> {
     pub fn new(pin: &'a IP) -> Self {
         Self {
             value: Cell::new(0),
@@ -290,7 +290,7 @@ impl<'a, IP: InterruptPin<'a>> InterruptValueWrapper<'a, IP> {
     }
 }
 
-impl<'a, IP: InterruptPin<'a>> InterruptWithValue<'a> for InterruptValueWrapper<'a, IP> {
+impl<'a, IP: InterruptPin<'a> + ?Sized> InterruptWithValue<'a> for InterruptValueWrapper<'a, IP> {
     fn set_value(&self, value: u32) {
         self.value.set(value);
     }
@@ -317,13 +317,13 @@ impl<'a, IP: InterruptPin<'a>> InterruptWithValue<'a> for InterruptValueWrapper<
     }
 }
 
-impl<'a, IP: InterruptPin<'a>> Input for InterruptValueWrapper<'a, IP> {
+impl<'a, IP: InterruptPin<'a> + ?Sized> Input for InterruptValueWrapper<'a, IP> {
     fn read(&self) -> bool {
         self.source.read()
     }
 }
 
-impl<'a, IP: InterruptPin<'a>> Configure for InterruptValueWrapper<'a, IP> {
+impl<'a, IP: InterruptPin<'a> + ?Sized> Configure for InterruptValueWrapper<'a, IP> {
     fn configuration(&self) -> Configuration {
         self.source.configuration()
     }
@@ -365,7 +365,7 @@ impl<'a, IP: InterruptPin<'a>> Configure for InterruptValueWrapper<'a, IP> {
     }
 }
 
-impl<'a, IP: InterruptPin<'a>> Output for InterruptValueWrapper<'a, IP> {
+impl<'a, IP: InterruptPin<'a> + ?Sized> Output for InterruptValueWrapper<'a, IP> {
     fn set(&self) {
         self.source.set();
     }
@@ -379,7 +379,7 @@ impl<'a, IP: InterruptPin<'a>> Output for InterruptValueWrapper<'a, IP> {
     }
 }
 
-impl<'a, IP: InterruptPin<'a>> Client for InterruptValueWrapper<'a, IP> {
+impl<'a, IP: InterruptPin<'a> + ?Sized> Client for InterruptValueWrapper<'a, IP> {
     fn fired(&self) {
         self.client.map(|c| c.fired(self.value()));
     }


### PR DESCRIPTION
### Pull Request Overview

This pull request adds the possibility of using `dyn Hil` instead of exact types by relaxing the trait bound with `+ ?Sized`.

Most of the capsules take arrays or slices of devices that implement a certain `Hil` trait. As they never actually own the device, the trait bound should be relaxed to be able to supply unsized types.

For now, most of the capsules take homogenous types when it comes to the devices. LEDs of a board will most probably be of the same type, GPIOs the same. When it comes to more complex devices, like servos or sensors, these can be of different types. The way in which capsules are written right now, they either:
- accept any type if the capsule uses `&dyn Trait` - which involves a penalty
- accept one single type if the capsule uses generics

The pull request is still a draft and changes only the `Led`, `Gpio` and `Buttons` capsules. As an example, LEDs in the `microbit_v2` board are supplied as `&dyn Led`. This example will be removed before the pull request becomes ready to be merged.

### Testing Strategy

This pull request compiles on the `microbit_v2`.


### TODO or Help Wanted

Feedback


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
