### PR TITLE
nordic: components: startup: fix uicr pin check

### DIFF
--- a/boards/nordic/nrf52_components/src/startup.rs
+++ b/boards/nordic/nrf52_components/src/startup.rs
@@ -83,7 +83,7 @@ impl Component for NrfStartupComponent<'_> {
         // Configure reset pins
         if uicr
             .get_psel0_reset_pin()
-            .is_some_and(|pin| pin != self.button_rst_pin)
+            .is_none_or(|pin| pin != self.button_rst_pin)
         {
             uicr.set_psel0_reset_pin(self.button_rst_pin);
             while !self.nvmc.is_ready() {}
@@ -91,7 +91,7 @@ impl Component for NrfStartupComponent<'_> {
         }
         if uicr
             .get_psel1_reset_pin()
-            .is_some_and(|pin| pin != self.button_rst_pin)
+            .is_none_or(|pin| pin != self.button_rst_pin)
         {
             uicr.set_psel1_reset_pin(self.button_rst_pin);
             while !self.nvmc.is_ready() {}


### PR DESCRIPTION
### Pull Request Overview

8025e585e676528f32cd8656ffc68ea6598fe2ac incorrectly translated `map_or(true, ...)` to `is_some_and(...)` instead of `is_none_or(...)` resulting in the the Nordic startup component incorrectly setting the reset pin behavior in some cases (specifically if it's not already set properly, e.g., by a previous Tock installation).

### Testing Strategy

I tested this by checking for the kernel and process console booting on the nrf52840dk following a:

```bash
$ nrfjprog --recover
$ make flash
```

### TODO or Help Wanted

N/A

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
