### PR TITLE
pconsole: change `boot` cmd to use process.start()

### DIFF
--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -109,6 +109,7 @@ extern "C" {
 
 pub struct Capability;
 unsafe impl capabilities::ProcessManagementCapability for Capability {}
+unsafe impl capabilities::ProcessStartCapability for Capability {}
 
 impl<const COMMAND_HISTORY_LEN: usize, A: 'static + Alarm<'static>> Component
     for ProcessConsoleComponent<COMMAND_HISTORY_LEN, A>

--- a/capsules/core/src/process_console.rs
+++ b/capsules/core/src/process_console.rs
@@ -12,6 +12,7 @@ use core::fmt;
 use core::fmt::write;
 use core::str;
 use kernel::capabilities::ProcessManagementCapability;
+use kernel::capabilities::ProcessStartCapability;
 use kernel::hil::time::ConvertTicks;
 use kernel::utilities::cells::MapCell;
 use kernel::utilities::cells::TakeCell;
@@ -225,7 +226,7 @@ pub struct ProcessConsole<
     'a,
     const COMMAND_HISTORY_LEN: usize,
     A: Alarm<'a>,
-    C: ProcessManagementCapability,
+    C: ProcessManagementCapability + ProcessStartCapability,
 > {
     uart: &'a dyn uart::UartData<'a>,
     alarm: &'a A,
@@ -433,8 +434,12 @@ impl BinaryWrite for ConsoleWriter {
     }
 }
 
-impl<'a, const COMMAND_HISTORY_LEN: usize, A: Alarm<'a>, C: ProcessManagementCapability>
-    ProcessConsole<'a, COMMAND_HISTORY_LEN, A, C>
+impl<
+        'a,
+        const COMMAND_HISTORY_LEN: usize,
+        A: Alarm<'a>,
+        C: ProcessManagementCapability + ProcessStartCapability,
+    > ProcessConsole<'a, COMMAND_HISTORY_LEN, A, C>
 {
     pub fn new(
         uart: &'a dyn uart::UartData<'a>,
@@ -879,7 +884,7 @@ impl<'a, const COMMAND_HISTORY_LEN: usize, A: Alarm<'a>, C: ProcessManagementCap
                                         if proc_name == name
                                             && proc.get_state() == State::Terminated
                                         {
-                                            proc.try_restart(None);
+                                            proc.start(&self.capability);
                                         }
                                     });
                             });
@@ -1122,8 +1127,12 @@ impl<'a, const COMMAND_HISTORY_LEN: usize, A: Alarm<'a>, C: ProcessManagementCap
     }
 }
 
-impl<'a, const COMMAND_HISTORY_LEN: usize, A: Alarm<'a>, C: ProcessManagementCapability> AlarmClient
-    for ProcessConsole<'a, COMMAND_HISTORY_LEN, A, C>
+impl<
+        'a,
+        const COMMAND_HISTORY_LEN: usize,
+        A: Alarm<'a>,
+        C: ProcessManagementCapability + ProcessStartCapability,
+    > AlarmClient for ProcessConsole<'a, COMMAND_HISTORY_LEN, A, C>
 {
     fn alarm(&self) {
         self.prompt();
@@ -1133,8 +1142,12 @@ impl<'a, const COMMAND_HISTORY_LEN: usize, A: Alarm<'a>, C: ProcessManagementCap
     }
 }
 
-impl<'a, const COMMAND_HISTORY_LEN: usize, A: Alarm<'a>, C: ProcessManagementCapability>
-    uart::TransmitClient for ProcessConsole<'a, COMMAND_HISTORY_LEN, A, C>
+impl<
+        'a,
+        const COMMAND_HISTORY_LEN: usize,
+        A: Alarm<'a>,
+        C: ProcessManagementCapability + ProcessStartCapability,
+    > uart::TransmitClient for ProcessConsole<'a, COMMAND_HISTORY_LEN, A, C>
 {
     fn transmitted_buffer(
         &self,
@@ -1169,8 +1182,12 @@ impl<'a, const COMMAND_HISTORY_LEN: usize, A: Alarm<'a>, C: ProcessManagementCap
     }
 }
 
-impl<'a, const COMMAND_HISTORY_LEN: usize, A: Alarm<'a>, C: ProcessManagementCapability>
-    uart::ReceiveClient for ProcessConsole<'a, COMMAND_HISTORY_LEN, A, C>
+impl<
+        'a,
+        const COMMAND_HISTORY_LEN: usize,
+        A: Alarm<'a>,
+        C: ProcessManagementCapability + ProcessStartCapability,
+    > uart::ReceiveClient for ProcessConsole<'a, COMMAND_HISTORY_LEN, A, C>
 {
     fn received_buffer(
         &self,


### PR DESCRIPTION
### Pull Request Overview

With the changes to the process loading, `process.try_restart` only has an effect if the process is running. If the process is terminated it does nothing. The function we need to call is `process.start()` for the boot command.

With this change we can actually start a terminated process using the process console.

Process console output with this change:

```
Valid commands are: help status list stop start fault boot terminate process kernel reset panic console-start console-stop
tock$ list
 PID    ShortID    Name                Quanta  Syscalls  Restarts  Grants  State
 3      Unique     circle                   0      6046         2   2/16   Yielded
 1      Unique     org.tockos.thread-tutorial.sensor     0        13         0   0/16   Terminated
tock$ boot org.tockos.thread-tutorial.sensor
tock$ Hello World, the temperature is: 24.25
list
 PID    ShortID    Name                Quanta  Syscalls  Restarts  Grants  State
 3      Unique     circle                   0      6950         2   2/16   Yielded
 4      Unique     org.tockos.thread-tutorial.sensor     0        13         1   0/16   Terminated
tock$
``






### Testing Strategy

Working with the thread tutorial and trying to restart a process which has exited.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
