### PR TITLE
pconsole: increase command buffer size to 64

### DIFF
--- a/capsules/core/src/process_console.rs
+++ b/capsules/core/src/process_console.rs
@@ -36,7 +36,7 @@ pub const QUEUE_BUF_LEN: usize = 300;
 pub const READ_BUF_LEN: usize = 4;
 /// Commands can be up to 32 bytes long: since commands themselves are 4-5
 /// characters, limiting arguments to 25 bytes or so seems fine for now.
-pub const COMMAND_BUF_LEN: usize = 32;
+pub const COMMAND_BUF_LEN: usize = 64;
 /// Default size for the history command.
 pub const DEFAULT_COMMAND_HISTORY_LEN: usize = 10;
 


### PR DESCRIPTION
### Pull Request Overview

Long process names (e.g. with the reverse domain naming scheme) causes pconsole to not work because the commands with process names don't fit.

Found this with the thread tutorial (app name `org.tockos.thread-tutorial.sensor`).





### Testing Strategy

This pull request was tested by...


### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.
 
### Formatting

- [x] Ran `make prepush`.
