### PR TITLE
systick: made frequency mutable

### DIFF
--- a/arch/cortex-m/src/systick.rs
+++ b/arch/cortex-m/src/systick.rs
@@ -5,6 +5,7 @@
 //! ARM Cortex-M SysTick peripheral.
 
 use core::cell::Cell;
+use kernel::capabilities::SysTickFrequencyCapability;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 use kernel::utilities::registers::{register_bitfields, FieldValue, ReadOnly, ReadWrite};
 use kernel::utilities::StaticRef;
@@ -132,7 +133,7 @@ impl SysTick {
     /// When changing the hardware systick frequency, the reload value register
     /// should be updated and the current value register should be reset, in
     /// order for the tick count to match the current frequency.
-    pub unsafe fn set_hertz(&self, clock_speed: u32) {
+    pub fn set_hertz(&self, clock_speed: u32, _capability: &dyn SysTickFrequencyCapability) {
         self.hertz.set(clock_speed);
     }
 }

--- a/arch/cortex-m/src/systick.rs
+++ b/arch/cortex-m/src/systick.rs
@@ -5,12 +5,15 @@
 //! ARM Cortex-M SysTick peripheral.
 
 use core::cell::Cell;
-use kernel::capabilities::SysTickFrequencyCapability;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 use kernel::utilities::registers::{register_bitfields, FieldValue, ReadOnly, ReadWrite};
 use kernel::utilities::StaticRef;
 
 use core::num::NonZeroU32;
+
+/// The `SysTickFrequencyCapability` allows the holder to change the Cortex M
+/// SysTick `hertz` field.
+pub unsafe trait SysTickFrequencyCapability {}
 
 #[repr(C)]
 struct SystickRegisters {

--- a/arch/cortex-m/src/systick.rs
+++ b/arch/cortex-m/src/systick.rs
@@ -4,6 +4,7 @@
 
 //! ARM Cortex-M SysTick peripheral.
 
+use core::cell::Cell;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 use kernel::utilities::registers::{register_bitfields, FieldValue, ReadOnly, ReadWrite};
 use kernel::utilities::StaticRef;
@@ -59,7 +60,7 @@ register_bitfields![u32,
 ///
 /// Documented in the Cortex-MX Devices Generic User Guide, Chapter 4.4
 pub struct SysTick {
-    hertz: u32,
+    hertz: Cell<u32>,
     external_clock: bool,
 }
 
@@ -73,7 +74,7 @@ impl SysTick {
     /// value in hardware.
     pub unsafe fn new() -> SysTick {
         SysTick {
-            hertz: 0,
+            hertz: Cell::new(0),
             external_clock: false,
         }
     }
@@ -87,7 +88,7 @@ impl SysTick {
     ///   if the SysTick is driven by the CPU clock, it is simply the CPU speed.
     pub unsafe fn new_with_calibration(clock_speed: u32) -> SysTick {
         let mut res = SysTick::new();
-        res.hertz = clock_speed;
+        res.hertz = Cell::new(clock_speed);
         res
     }
 
@@ -101,7 +102,7 @@ impl SysTick {
     ///   if the SysTick is driven by the CPU clock, it is simply the CPU speed.
     pub unsafe fn new_with_calibration_and_external_clock(clock_speed: u32) -> SysTick {
         let mut res = SysTick::new();
-        res.hertz = clock_speed;
+        res.hertz = Cell::new(clock_speed);
         res.external_clock = true;
         res
     }
@@ -111,8 +112,9 @@ impl SysTick {
     // Otherwise, compute the frequncy using the calibration value that is set
     // in hardware.
     fn hertz(&self) -> u32 {
-        if self.hertz != 0 {
-            self.hertz
+        let hz = self.hertz.get();
+        if hz != 0 {
+            hz
         } else {
             // The `tenms` register is the reload value for 10ms, so
             // Hertz = number of tics in 1 second = tenms * 100

--- a/arch/cortex-m/src/systick.rs
+++ b/arch/cortex-m/src/systick.rs
@@ -87,8 +87,8 @@ impl SysTick {
     ///   * `clock_speed` - the frequency of SysTick tics in Hertz. For example,
     ///   if the SysTick is driven by the CPU clock, it is simply the CPU speed.
     pub unsafe fn new_with_calibration(clock_speed: u32) -> SysTick {
-        let mut res = SysTick::new();
-        res.hertz = Cell::new(clock_speed);
+        let res = SysTick::new();
+        res.hertz.set(clock_speed);
         res
     }
 
@@ -102,7 +102,7 @@ impl SysTick {
     ///   if the SysTick is driven by the CPU clock, it is simply the CPU speed.
     pub unsafe fn new_with_calibration_and_external_clock(clock_speed: u32) -> SysTick {
         let mut res = SysTick::new();
-        res.hertz = Cell::new(clock_speed);
+        res.hertz.set(clock_speed);
         res.external_clock = true;
         res
     }
@@ -121,6 +121,19 @@ impl SysTick {
             let tenms = SYSTICK_BASE.syst_calib.read(CalibrationValue::TENMS);
             tenms * 100
         }
+    }
+
+    /// Modifies the locally stored frequncy
+    ///
+    /// # Important
+    ///
+    /// This function does not change the actual systick frequency.
+    /// This function must be called only while the clock is not armed.
+    /// When changing the hardware systick frequency, the reload value register
+    /// should be updated and the current value register should be reset, in
+    /// order for the tick count to match the current frequency.
+    pub unsafe fn set_hertz(&self, clock_speed: u32) {
+        self.hertz.set(clock_speed);
     }
 }
 

--- a/kernel/src/capabilities.rs
+++ b/kernel/src/capabilities.rs
@@ -117,7 +117,3 @@ pub unsafe trait CreatePortTableCapability {}
 /// A capsule would never hold this capability although it may hold
 /// capabilities created via this capability.
 pub unsafe trait NetworkCapabilityCreationCapability {}
-
-/// The `SysTickFrequencyCapability` allows the holder to change the Cortex M
-/// SysTick `hertz` field.
-pub unsafe trait SysTickFrequencyCapability {}

--- a/kernel/src/capabilities.rs
+++ b/kernel/src/capabilities.rs
@@ -117,3 +117,7 @@ pub unsafe trait CreatePortTableCapability {}
 /// A capsule would never hold this capability although it may hold
 /// capabilities created via this capability.
 pub unsafe trait NetworkCapabilityCreationCapability {}
+
+/// The `SysTickFrequencyCapability` allows the holder to change the Cortex M
+/// SysTick `hertz` field.
+pub unsafe trait SysTickFrequencyCapability {}


### PR DESCRIPTION

### Pull Request Overview

This pull request changes the `hertz` field of the Cortex M `SysTick` struct from `u32` to `Cell<u32>`, to allow interior mutability.
This is required in order to change the hardware clock frequency successfully.

### Testing Strategy

This pull request was tested by running tock on the stm nucleo f429zi board.

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
