### PR TITLE
grant: added remove_pending_upcalls function

### DIFF
--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -619,13 +619,27 @@ impl<'a> GrantKernelData<'a> {
         )
     }
 
+    /// Search the work queue for the first pending operation with the given
+    /// `subscribe_num` and if one exists remove it from the task queue.
+    ///
+    /// Returns the associated [`Task`] if one was found, otherwise returns
+    /// [`None`].
+    pub fn remove_upcall(&self, subscribe_num: usize) -> Option<crate::process::Task> {
+        self.process.remove_upcall(UpcallId {
+            subscribe_num,
+            driver_num: self.driver_num,
+        })
+    }
+
     /// Remove all scheduled upcalls with the given `subscribe_num` from the
     /// task queue.
-    pub fn remove_pending_upcalls(&self, subscribe_num: usize) {
+    ///
+    /// Returns the number of removed upcalls.
+    pub fn remove_pending_upcalls(&self, subscribe_num: usize) -> usize {
         self.process.remove_pending_upcalls(UpcallId {
             subscribe_num,
             driver_num: self.driver_num,
-        });
+        })
     }
 
     /// Returns a lifetime limited reference to the requested

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -619,6 +619,15 @@ impl<'a> GrantKernelData<'a> {
         )
     }
 
+    /// Remove all scheduled upcalls with the given `subscribe_num` from the
+    /// task queue.
+    pub fn remove_pending_upcalls(&self, subscribe_num: usize) {
+        self.process.remove_pending_upcalls(UpcallId {
+            subscribe_num,
+            driver_num: self.driver_num,
+        });
+    }
+
     /// Returns a lifetime limited reference to the requested
     /// [`ReadOnlyProcessBuffer`].
     ///

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -1017,7 +1017,7 @@ impl Kernel {
                             // that there are no pending upcalls with the same
                             // identifier but with the old function pointer, we
                             // clear them now.
-                            process.remove_pending_upcalls(upcall_id);
+                            let _ =process.remove_pending_upcalls(upcall_id);
                         }
 
                         if config::CONFIG.trace_syscalls {

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -391,7 +391,9 @@ pub trait Process {
 
     /// Remove all scheduled upcalls with the given `upcall_id` from the task
     /// queue.
-    fn remove_pending_upcalls(&self, upcall_id: UpcallId);
+    ///
+    /// Returns the number of removed upcalls.
+    fn remove_pending_upcalls(&self, upcall_id: UpcallId) -> usize;
 
     /// Returns the current state the process is in.
     fn get_state(&self) -> State;


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a method to `GrantKernelData` that removes all pending upcalls of the current driver with the given `subscriber_num` from the process's upcall queue.

This was needed in order to remove outdated upcalls from within a capsule.


### Testing Strategy

This pull request was tested by implementing a capsule that uses this feature.

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
