### PR TITLE
Improv(docs): Fixed doc errors

### DIFF
--- a/capsules/extra/src/ieee802154/framer.rs
+++ b/capsules/extra/src/ieee802154/framer.rs
@@ -17,14 +17,14 @@
 //! -----
 //!
 //! To use this capsule, we need an implementation of a hardware
-//! `capsules::ieee802154::mac::Mac`. Suppose we have such an implementation of type
+//! `capsules_extra::ieee802154::mac::Mac`. Suppose we have such an implementation of type
 //! `XMacDevice`.
 //!
 //! ```rust,ignore
 //! let xmac: &XMacDevice = /* ... */;
 //! let mac_device = static_init!(
-//!     capsules::ieee802154::mac::Framer<'static, XMacDevice>,
-//!     capsules::ieee802154::mac::Framer::new(xmac));
+//!     capsules_extra::ieee802154::mac::Framer<'static, XMacDevice>,
+//!     capsules_extra::ieee802154::mac::Framer::new(xmac));
 //! xmac.set_transmit_client(mac_device);
 //! xmac.set_receive_client(mac_device, &mut MAC_RX_BUF);
 //! xmac.set_config_client(mac_device);
@@ -59,11 +59,11 @@
 //! 802.15.4 frames:
 //!
 //! ```rust,ignore
-//! # use kernel::static_init;
+//! use kernel::static_init;
 //!
 //! let radio_capsule = static_init!(
-//!     capsules::ieee802154::RadioDriver<'static>,
-//!     capsules::ieee802154::RadioDriver::new(mac_device, board_kernel.create_grant(&grant_cap), &mut RADIO_BUF));
+//!     capsules_extra::ieee802154::RadioDriver<'static>,
+//!     capsules_extra::ieee802154::RadioDriver::new(mac_device, board_kernel.create_grant(&grant_cap), &mut RADIO_BUF));
 //! mac_device.set_key_procedure(radio_capsule);
 //! mac_device.set_device_procedure(radio_capsule);
 //! mac_device.set_transmit_client(radio_capsule);
@@ -318,13 +318,13 @@ enum RxState {
 }
 
 /// Wraps an IEEE 802.15.4 [kernel::hil::radio::Radio]
-/// and exposes [capsules::mac::Mac] functionality.
+/// and exposes [`capsules_extra::ieee802154::mac::Mac`](crate::ieee802154::mac::Mac) functionality.
 ///
 /// It hides header preparation, transmission and processing logic
 /// from the user by essentially maintaining multiple state machines
 /// corresponding to the transmission, reception and
 /// encryption/decryption pipelines. See the documentation in
-/// `capsules/src/mac.rs` for more details.
+/// `capsules/extra/src/ieee802154/mac.rs` for more details.
 pub struct Framer<'a, M: Mac<'a>, A: AES128CCM<'a>> {
     mac: &'a M,
     aes_ccm: &'a A,

--- a/chips/apollo3/src/iom.rs
+++ b/chips/apollo3/src/iom.rs
@@ -414,7 +414,7 @@ impl<'a> Iom<'_> {
     }
 
     /// The IOM has a few erratas when used in FIFO mode (as we do here).
-    /// See: https://ambiq.com/wp-content/uploads/2022/01/Apollo3-Blue-Errata-List.pdf
+    /// See: <https://ambiq.com/wp-content/uploads/2022/01/Apollo3-Blue-Errata-List.pdf>
     ///
     /// ERR009 means that we might get a THR interrupt incorrectly, it also
     /// appears that the FIFOxSIZ fields are a little slow to update, so even

--- a/chips/sifive/src/plic.rs
+++ b/chips/sifive/src/plic.rs
@@ -15,7 +15,7 @@ use kernel::utilities::StaticRef;
 /// appropriate bounds set
 
 ///    The generic SiFive PLIC specification:
-///    https://github.com/riscv/riscv-plic-spec/blob/master/riscv-plic.adoc
+///    <https://github.com/riscv/riscv-plic-spec/blob/master/riscv-plic.adoc>
 ///    is defining maximum of 1023 interrupt sources
 
 // TODO: replace with const generic for `priority` and `_reserved1` field
@@ -127,7 +127,7 @@ impl<const TOTAL_INTS: usize> Plic<TOTAL_INTS> {
     /// Clear all pending interrupts. The [`PLIC specification`] section 7:
     /// > A successful claim will also atomically clear the corresponding pending bit on the interrupt source..
     /// Note that this function will only clear the enabled interrupt sources, as only those can be claimed.
-    /// [`PLIC specification`]: https://github.com/riscv/riscv-plic-spec/blob/master/riscv-plic.adoc
+    /// [`PLIC specification`]: <https://github.com/riscv/riscv-plic-spec/blob/master/riscv-plic.adoc>
     pub fn clear_all_pending(&self) {
         let claim = self.registers.get_claim_reg();
         loop {

--- a/kernel/src/utilities/streaming_process_slice.rs
+++ b/kernel/src/utilities/streaming_process_slice.rs
@@ -72,7 +72,7 @@ use crate::ErrorCode;
 ///    buffer.
 ///
 /// As the kernel cannot track if an `allow`ed buffer for a particular
-/// [`SyscallDriver`] implementation is intended to be a
+/// [`SyscallDriver`](crate::syscall_driver::SyscallDriver) implementation is intended to be a
 /// [`StreamingProcessSlice`], the kernel must use the header in the buffer as
 /// provided by the process. The implementation of [`StreamingProcessSlice`]
 /// ensures that an incorrect header will not cause a panic, but incoming


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes errors generated when trying to compile docs for project.
Also a few examples looked wrong so fixed that.


### Testing Strategy

This pull request was tested by...
Running
`make doc`
and browsing the generated result

### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
