### PR TITLE
chips: apollo3: stimer: Reset the timer at startup

### DIFF
--- a/chips/apollo3/src/stimer.rs
+++ b/chips/apollo3/src/stimer.rs
@@ -102,11 +102,16 @@ pub struct STimer<'a> {
 
 impl<'a> STimer<'a> {
     // Unsafe bc of use of STIMER_BASE internally
-    pub const fn new() -> STimer<'a> {
-        STimer {
+    pub fn new() -> STimer<'a> {
+        let timer = STimer {
             registers: STIMER_BASE,
             client: OptionalCell::empty(),
-        }
+        };
+
+        // Reset so that time starts at 0
+        let _ = timer.reset();
+
+        timer
     }
 
     pub fn handle_interrupt(&self) {

--- a/chips/apollo3/src/stimer.rs
+++ b/chips/apollo3/src/stimer.rs
@@ -153,7 +153,8 @@ impl<'a> Counter<'a> for STimer<'a> {
     }
 
     fn reset(&self) -> Result<(), ErrorCode> {
-        Err(ErrorCode::FAIL)
+        self.registers.stcfg.write(STCFG::CLEAR::SET);
+        Ok(())
     }
 
     fn is_running(&self) -> bool {


### PR DESCRIPTION
### Pull Request Overview

Support resetting the stimer and reset it at startup as the initial value is random. This just makes is simpler when debugging timer issues as you can see see the timer starting from zero.

### Testing Strategy

Running timers

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
