### PR TITLE
apollo3: Support deep sleep

### DIFF
--- a/arch/cortex-m/src/scb.rs
+++ b/arch/cortex-m/src/scb.rs
@@ -275,9 +275,25 @@ const SCB: StaticRef<ScbRegisters> = unsafe { StaticRef::new(0xE000ED00 as *cons
 /// Allow the core to go into deep sleep on WFI.
 ///
 /// The specific definition of "deep sleep" is chip specific.
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 pub unsafe fn set_sleepdeep() {
+    use core::arch::asm;
+
     SCB.scr.modify(SystemControl::SLEEPDEEP::SET);
+
+    asm!("dsb", "isb", options(nomem, nostack, preserves_flags));
 }
+
+// Mock implementation for tests on Travis-CI.
+#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+pub unsafe fn set_sleepdeep() {
+    // Dummy operation to satisfy the `Writable` trait import on
+    // non-ARM platforms.
+    SCB.scr.modify(SystemControl::SLEEPDEEP::SET);
+
+    unimplemented!()
+}
+
 /// Do not allow the core to go into deep sleep on WFI.
 ///
 /// The specific definition of "deep sleep" is chip specific.

--- a/chips/apollo3/src/chip.rs
+++ b/chips/apollo3/src/chip.rs
@@ -128,7 +128,7 @@ impl<I: InterruptService + 'static> Chip for Apollo3<I> {
 
     fn sleep(&self) {
         unsafe {
-            cortexm4f::scb::unset_sleepdeep();
+            cortexm4f::scb::set_sleepdeep();
             cortexm4f::support::wfi();
         }
     }


### PR DESCRIPTION
### Pull Request Overview

This lowers the power consumption of the Apollo3 board, from ~6mA in sleep to ~3mA. Without starting to dynamically power down components, shutting down RAM/Flash banks or possibly changing the clock speeds this seems to be the lowest power usage possible.

### Testing Strategy

Running applications with long delays

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
