### PR TITLE
Hail: Specify minimum stable rustc version, makefile auto updates if needed

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -130,6 +130,20 @@ ifneq ($(shell $(RUSTUP) target list | grep "$(TARGET) (installed)"),$(TARGET) (
   $(warning Consider updating 'targets' in 'rust-toolchain.toml')
   $(shell sleep 5s && $(RUSTUP) target add $(TARGET))
 endif
+
+# If the board the user is compiling is using the stable toolchain, verify that
+# the user's stable rustc toolchain is new enough to compile the board. If the
+# toolchain is too old, wait 5 seconds and then install for the user.
+ifneq ($(shell $(RUSTUP) show active-toolchain | grep "stable"),)
+  # If the error from running --version shows a version mismatch we know the
+  # installed toolchain is too old.
+  ifneq ($(shell $(CARGO) rustc -- --version 2>&1 | grep "is not supported by the following packages"),)
+    $(warning Your stable rustc is older than the MSRV of this board)
+    $(warning make will update your stable rustc in 5s)
+    $(shell sleep 5)
+    DUMMY := $(shell $(RUSTUP) update)
+  endif
+endif
 endif # $(NO_RUSTUP)
 
 # If the user is using the standard toolchain provided as part of the llvm-tools

--- a/boards/hail/Cargo.toml
+++ b/boards/hail/Cargo.toml
@@ -8,6 +8,7 @@ version.workspace = true
 authors.workspace = true
 build = "../build.rs"
 edition.workspace = true
+rust-version = "1.83"
 
 [dependencies]
 components = { path = "../components" }


### PR DESCRIPTION
### Pull Request Overview

Hail needs a certain minimum rustc version (newer than 1.80). I don't know exactly what version that is, but the current version is good enough.

Also, apparently there is no way to specify a minimum rust version for a crate and then have rustup just install a suitable version for you automatically. Why? I have no idea. So, we implement this feature in our makefile.

This checks if the board is using stable, and if so, checks if there is an error from the stable compiler being too old. If so, it waits 5s and then installs a newer toolchain automatically.


### Testing Strategy

Me having an older rust version on my laptop and trying to build hail.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
