### PR TITLE
boards: make: sleep on mac no units

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -128,7 +128,8 @@ endif
 ifneq ($(shell $(RUSTUP) target list | grep "$(TARGET) (installed)"),$(TARGET) (installed))
   $(warning Request to compile for a missing TARGET, make will install in 5s)
   $(warning Consider updating 'targets' in 'rust-toolchain.toml')
-  $(shell sleep 5s && $(RUSTUP) target add $(TARGET))
+  $(shell sleep 5)
+  $(shell $(RUSTUP) target add $(TARGET))
 endif
 endif # $(NO_RUSTUP)
 


### PR DESCRIPTION
On my mac, the sleep command does not accept a unit:

```
$ sleep 5s
usage: sleep seconds
```

So this just removes the 's' and makes the format match the other if block we have.




### Testing Strategy

Should be straightforward


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
