### PR TITLE
CI: add MSRV check with the cargo-hack tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
         run:  make ci-job-syntax
       - name:      ci-job-compilation
         run:  make ci-job-compilation
+      - name:      ci-job-msrv
+        run:  make ci-job-msrv
       - name:      ci-job-debug-support-targets
         run:  make ci-job-debug-support-targets
       - name:      ci-job-collect-artifacts

--- a/Makefile
+++ b/Makefile
@@ -353,13 +353,6 @@ ci-runner-netlify:\
 
 
 
-### ci-runner-github-setup jobs:
-.PHONY: ci-job-cargo-hack
-ci-job-cargo-hack:
-	$(call banner,CI-Job: Install cargo-hack)
-	cargo install cargo-hack
-	$(call banner,CI-Job: Install cargo-hack DONE)
-
 
 ### ci-runner-github-format jobs:
 .PHONY: ci-job-format
@@ -424,10 +417,28 @@ ci-job-compilation:
 	$(call banner,CI-Job: Compilation)
 	@NOWARNINGS=true $(MAKE) allboards
 
-.PHONY: ci-job-msrv
-ci-job-msrv: ci-job-cargo-hack
+
+define ci_setup_msrv
+	$(call banner,CI-Setup: Install cargo-hack)
+	cargo install cargo-hack
+endef
+
+.PHONY: ci-setup-msrv
+ci-setup-msrv:
+	$(call ci_setup_helper,\
+		cargo hack -V &> /dev/null && echo yes,\
+		Install 'cargo-hack' using cargo,\
+		ci_setup_msrv,\
+		CI_JOB_MSRV)
+
+define ci_job_msrv
 	$(call banner,CI-Job: MSRV Check)
 	@cd boards/hail && cargo hack check --rust-version --target thumbv7em-none-eabihf
+endef
+
+.PHONY: ci-job-msrv
+ci-job-msrv: ci-setup-msrv
+	$(if $(CI_JOB_MSRV),$(call ci_job_msrv))
 
 .PHONY: ci-job-debug-support-targets
 ci-job-debug-support-targets:

--- a/Makefile
+++ b/Makefile
@@ -307,6 +307,7 @@ ci-runner-github-clippy:\
 ci-runner-github-build:\
 	ci-job-syntax\
 	ci-job-compilation\
+	ci-job-msrv\
 	ci-job-debug-support-targets\
 	ci-job-collect-artifacts
 	$(call banner,CI-Runner: GitHub build runner DONE)
@@ -350,6 +351,14 @@ ci-runner-netlify:\
 ## The order of rules within a runner try to optimize for performance if
 ## executed in linear order.
 
+
+
+### ci-runner-github-setup jobs:
+.PHONY: ci-job-cargo-hack
+ci-job-cargo-hack:
+	$(call banner,CI-Job: Install cargo-hack)
+	cargo install cargo-hack
+	$(call banner,CI-Job: Install cargo-hack DONE)
 
 
 ### ci-runner-github-format jobs:
@@ -414,6 +423,11 @@ ci-job-syntax:
 ci-job-compilation:
 	$(call banner,CI-Job: Compilation)
 	@NOWARNINGS=true $(MAKE) allboards
+
+.PHONY: ci-job-msrv
+ci-job-msrv: ci-job-cargo-hack
+	$(call banner,CI-Job: MSRV Check)
+	@cd boards/hail && cargo hack check --rust-version --target thumbv7em-none-eabihf
 
 .PHONY: ci-job-debug-support-targets
 ci-job-debug-support-targets:


### PR DESCRIPTION
### Pull Request Overview

This pull request builds the hail target with `cargo hack` to check the MSRV.


### Testing Strategy

I ran the make target locally and it fails with rust version 1.81 which is too old.


### TODO or Help Wanted

I'm not sure this is the correct way to install cargo-hack in our make system.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
