### PR TITLE
treadmill-ci: add manual workflow dispatch trigger

### DIFF
--- a/.github/workflows/treadmill-ci.yml
+++ b/.github/workflows/treadmill-ci.yml
@@ -42,9 +42,25 @@ on:
   # allows this workflow to run without access to repository secrets.
   #pull_request:
   merge_group: # Run CI for the GitHub merge queue
+  # Manually dispatch for a specific branch (will require approval
+  # through the treadmill-ci-merged environment:
+  workflow_dispatch:
+    inputs:
+      tock-kernel-ref:
+        description: 'Ref (revision/branch/tag) of the upstream Tock repo to test'
+        required: true
+        default: 'master'
+      libtock-c-ref:
+        description: 'Ref (revision/branch/tag) of the upstream libtock-c repo to test'
+        required: true
+        default: 'master'
+      tests-json:
+        description: 'tests-json value passed to HWCI workflow (if empty, output from determine-tests step is used)'
+        required: false
 
 permissions:
   contents: read
+
 jobs:
   determine-tests:
     runs-on: ubuntu-latest
@@ -94,7 +110,7 @@ jobs:
 
     # This checks whether there is at least one test to run, see
     # https://github.com/orgs/community/discussions/27125#discussioncomment-3254720
-    if: fromJSON(needs.determine-tests.outputs.hwci-tests-json)[0] != null
+    if: fromJSON(needs.determine-tests.outputs.hwci-tests-json)[0] != null || github.event_name == 'workflow_dispatch'
 
     # The main tock-hardware-ci workflow is imported from another repository. It
     # can be reused across multiple Tock repositories such as the kernel,
@@ -108,21 +124,21 @@ jobs:
       repository-filter: 'tock/tock'
 
       # Provide access to the required Treadmill secrets by running in the
-      # appropriate environment (depending on the on: triggers above)
-      job-environment: ${{ github.event_name == 'pull_request' && 'treadmill-ci' || 'treadmill-ci-merged' }}
-
-      # Use the latest upstream Tock hardware CI tests and userspace components:
-      libtock-c-ref: 'master'
+      # appropriate environment (depending on the `on:` triggers above)
+      job-environment: ${{ (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') && 'treadmill-ci' || 'treadmill-ci-merged' }}
 
       # Reference for tock-hardware-ci repo, change if you want a specific test
-      # suite.  In this case, you should also update the branch reference in the
+      # suite. In this case, you should also update the branch reference in the
       # "uses" line above.
       tock-hardware-ci-ref: 'main'
 
-      # Test the tock kernel revision that triggered this workflow
-      tock-kernel-ref: ${{ github.sha }}
+      # Test the tock kernel revision that triggered this workflow:
+      tock-kernel-ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tock-kernel-ref || github.sha }}
 
-      # Pass the selected tests
-      tests-json: ${{ needs.determine-tests.outputs.hwci-tests-json }}
+      # Use the latest upstream libtock-c library:
+      libtock-c-ref: ${{ github.event_name == 'workflow_dispatch' && inputs.libtock-c-ref || 'master' }}
+
+      # Pass the selected tests:
+      tests-json: ${{ (github.event_name == 'workflow_dispatch' && inputs.tests-json != '') && inputs.tests-json || needs.determine-tests.outputs.hwci-tests-json }}
 
     secrets: inherit


### PR DESCRIPTION
### Pull Request Overview

This adds the ability to manually dispatch Treadmill hardware CI workflows for arbitrary branches of the Tock kernel and libtock-c repositories. This can be used to, e.g., test PRs made from branches of the kernel repository before merge, or test branches other than master (like release branches).

### Testing Strategy

This pull request will be tested by CI after merge.


### TODO or Help Wanted

N/A


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
