### PR TITLE
capsules: kv: Expose garbage_collection to userspace

### DIFF
--- a/capsules/extra/src/kv_driver.rs
+++ b/capsules/extra/src/kv_driver.rs
@@ -88,6 +88,7 @@ enum UserSpaceOp {
     Delete,
     Add,
     Update,
+    GarbageCollect,
 }
 
 /// Contents of the grant for each app.
@@ -266,6 +267,11 @@ impl<'a, V: kv::KVPermissions<'a>> KVStoreDriver<'a, V> {
                                 return e;
                             }
                         }
+                        Some(UserSpaceOp::GarbageCollect) => {
+                            self.kv.garbage_collect()?;
+                            return Ok(());
+                        }
+
                         _ => {}
                     }
 
@@ -465,6 +471,24 @@ impl<'a, V: kv::KVPermissions<'a>> kv::KVClient for KVStoreDriver<'a, V> {
         self.processid.clear();
         self.check_queue();
     }
+
+    fn garbage_collection_complete(&self, result: Result<(), ErrorCode>) {
+        self.processid.map(move |id| {
+            self.apps.enter(id, move |app, upcalls| {
+                if app.op.contains(&UserSpaceOp::GarbageCollect) {
+                    app.op.clear();
+                    upcalls
+                        .schedule_upcall(upcalls::VALUE, (errorcode::into_statuscode(result), 0, 0))
+                        .ok();
+                }
+            })
+        });
+
+        // We have completed the operation so see if there is a queued operation
+        // to run next.
+        self.processid.clear();
+        self.check_queue();
+    }
 }
 
 impl<'a, V: kv::KVPermissions<'a>> SyscallDriver for KVStoreDriver<'a, V> {
@@ -479,8 +503,8 @@ impl<'a, V: kv::KVPermissions<'a>> SyscallDriver for KVStoreDriver<'a, V> {
             // check if present
             0 => CommandReturn::success(),
 
-            // get, set, delete, add, update
-            1 | 2 | 3 | 4 | 5 => {
+            // get, set, delete, add, update, garbage collect
+            1 | 2 | 3 | 4 | 5 | 6 => {
                 if self.processid.is_none() {
                     // Nothing is using the KV store, so we can handle this
                     // request.
@@ -491,6 +515,7 @@ impl<'a, V: kv::KVPermissions<'a>> SyscallDriver for KVStoreDriver<'a, V> {
                         3 => app.op.set(UserSpaceOp::Delete),
                         4 => app.op.set(UserSpaceOp::Add),
                         5 => app.op.set(UserSpaceOp::Update),
+                        6 => app.op.set(UserSpaceOp::GarbageCollect),
                         _ => {}
                     });
                     let ret = self.run();
@@ -520,6 +545,7 @@ impl<'a, V: kv::KVPermissions<'a>> SyscallDriver for KVStoreDriver<'a, V> {
                                     3 => app.op.set(UserSpaceOp::Delete),
                                     4 => app.op.set(UserSpaceOp::Add),
                                     5 => app.op.set(UserSpaceOp::Update),
+                                    6 => app.op.set(UserSpaceOp::GarbageCollect),
                                     _ => {}
                                 }
                                 CommandReturn::success()

--- a/capsules/extra/src/kv_store_permissions.rs
+++ b/capsules/extra/src/kv_store_permissions.rs
@@ -40,6 +40,7 @@ enum Operation {
     Add,
     Update,
     Delete,
+    GarbageCollect,
 }
 
 /// Current version of the Tock K-V header.
@@ -288,6 +289,16 @@ impl<'a, K: kv::KV<'a>> kv::KVPermissions<'a> for KVStorePermissions<'a, K> {
         }
     }
 
+    fn garbage_collect(&self) -> Result<(), ErrorCode> {
+        if self.operation.is_some() {
+            return Err(ErrorCode::BUSY);
+        }
+
+        self.operation.set(Operation::GarbageCollect);
+
+        self.kv.garbage_collect()
+    }
+
     fn header_size(&self) -> usize {
         HEADER_LENGTH
     }
@@ -501,6 +512,13 @@ impl<'a, K: kv::KV<'a>> kv::KVClient for KVStorePermissions<'a, K> {
         self.operation.clear();
         self.client.map(move |cb| {
             cb.delete_complete(result, key);
+        });
+    }
+
+    fn garbage_collection_complete(&self, result: Result<(), ErrorCode>) {
+        self.operation.clear();
+        self.client.map(move |cb| {
+            cb.garbage_collection_complete(result);
         });
     }
 }

--- a/capsules/extra/src/tickv_kv_store.rs
+++ b/capsules/extra/src/tickv_kv_store.rs
@@ -40,6 +40,7 @@ enum Operation {
     Add,
     Update,
     Delete,
+    GarbageCollect,
 }
 
 /// `TicKVKVStore` implements the KV interface using the TicKV KVSystem
@@ -209,6 +210,21 @@ impl<'a, K: KVSystem<'a, K = T>, T: KeyType> kv::KV<'a> for TicKVKVStore<'a, K, 
             None => Err((key, ErrorCode::FAIL)),
         }
     }
+
+    fn garbage_collect(&self) -> Result<(), ErrorCode> {
+        if self.operation.is_some() {
+            return Err(ErrorCode::BUSY);
+        }
+
+        self.operation.set(Operation::GarbageCollect);
+
+        if let Err(e) = self.kv.garbage_collect() {
+            self.operation.clear();
+            Err(e)
+        } else {
+            Ok(())
+        }
+    }
 }
 
 impl<'a, K: KVSystem<'a, K = T>, T: KeyType> KVSystemClient<T> for TicKVKVStore<'a, K, T> {
@@ -260,6 +276,7 @@ impl<'a, K: KVSystem<'a, K = T>, T: KeyType> KVSystemClient<T> for TicKVKVStore<
                             cb.delete_complete(Err(ErrorCode::FAIL), unhashed_key);
                         });
                     }
+                    Operation::GarbageCollect => {}
                 }
             } else {
                 match op {
@@ -350,6 +367,7 @@ impl<'a, K: KVSystem<'a, K = T>, T: KeyType> KVSystemClient<T> for TicKVKVStore<
                             }
                         };
                     }
+                    Operation::GarbageCollect => {}
                 }
             }
         });
@@ -441,6 +459,7 @@ impl<'a, K: KVSystem<'a, K = T>, T: KeyType> KVSystemClient<T> for TicKVKVStore<
                     });
                 });
             }
+            Operation::GarbageCollect => {}
         });
     }
 
@@ -564,8 +583,14 @@ impl<'a, K: KVSystem<'a, K = T>, T: KeyType> KVSystemClient<T> for TicKVKVStore<
                     });
                 });
             }
+            Operation::GarbageCollect => {}
         });
     }
 
-    fn garbage_collect_complete(&self, _result: Result<(), ErrorCode>) {}
+    fn garbage_collect_complete(&self, result: Result<(), ErrorCode>) {
+        self.operation.clear();
+        self.client.map(move |cb| {
+            cb.garbage_collection_complete(result);
+        });
+    }
 }

--- a/kernel/src/hil/kv.rs
+++ b/kernel/src/hil/kv.rs
@@ -145,6 +145,16 @@ pub trait KVClient {
     ///     completed.
     /// - `key`: The key buffer.
     fn delete_complete(&self, result: Result<(), ErrorCode>, key: SubSliceMut<'static, u8>);
+
+    /// This callback is called when the garbage collection operation completes.
+    ///
+    /// ### Return Values
+    ///
+    /// - `result`: `Ok(())` on success, `Err(ErrorCode)` on error. Valid
+    ///   `ErrorCode`s:
+    ///   - `FAIL`: An internal error occurred and the operation cannot be
+    ///     completed.
+    fn garbage_collection_complete(&self, result: Result<(), ErrorCode>);
 }
 
 /// Key-Value interface with permissions.
@@ -319,6 +329,20 @@ pub trait KVPermissions<'a> {
         permissions: StoragePermissions,
     ) -> Result<(), (SubSliceMut<'static, u8>, ErrorCode)>;
 
+    /// Run garbage collection on the underlying Key/Value store.
+    ///
+    /// This is generally used to reclaim keys that have been removed with
+    /// the `delete()` call.
+    ///
+    /// ### Return
+    ///
+    /// - On success returns `Ok(())`. A callback will be issued.
+    /// - On error, returns the buffers and:
+    ///   - `BUSY`: An operation is already in progress.
+    ///   - `FAIL`: An internal error occurred and the operation cannot be
+    ///     completed.
+    fn garbage_collect(&self) -> Result<(), ErrorCode>;
+
     /// Returns the length of the key-value store's header in bytes.
     ///
     /// Room for this header must be accommodated in a `set`, `add`, or `update`
@@ -478,4 +502,18 @@ pub trait KV<'a> {
         &self,
         key: SubSliceMut<'static, u8>,
     ) -> Result<(), (SubSliceMut<'static, u8>, ErrorCode)>;
+
+    /// Run garbage collection on the underlying Key/Value store.
+    ///
+    /// This is generally used to reclaim keys that have been removed with
+    /// the `delete()` call.
+    ///
+    /// ### Return
+    ///
+    /// - On success returns `Ok(())`. A callback will be issued.
+    /// - On error, returns the buffers and:
+    ///   - `BUSY`: An operation is already in progress.
+    ///   - `FAIL`: An internal error occurred and the operation cannot be
+    ///     completed.
+    fn garbage_collect(&self) -> Result<(), ErrorCode>;
 }


### PR DESCRIPTION
### Pull Request Overview

Expose the garbage collection functionality to userspace so that userspace can cleanup deleted entries after it has marked them as invalid.

### Testing Strategy

https://github.com/tock/libtock-c/pull/484

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
