### PR TITLE
capsules/process_console: emit CRLF with process termination message

### DIFF
--- a/capsules/core/src/process_console.rs
+++ b/capsules/core/src/process_console.rs
@@ -866,7 +866,10 @@ impl<
                                             let mut console_writer = ConsoleWriter::new();
                                             let _ = write(
                                                 &mut console_writer,
-                                                format_args!("Process {} terminated\n", proc_name),
+                                                format_args!(
+                                                    "Process {} terminated\r\n",
+                                                    proc_name
+                                                ),
                                             );
 
                                             let _ = self.write_bytes(


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the process console to emit a CRLF sequence on the process termination message, to ensure consistent output with many serial terminals that expect CRLF line breaks.


### Testing Strategy

N/A


### TODO or Help Wanted

N/A


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
