### PR TITLE
litex-sim-ci: update pinned libtock-c revision

### DIFF
--- a/.github/workflows/litex_sim.yml
+++ b/.github/workflows/litex_sim.yml
@@ -57,7 +57,7 @@ jobs:
       # applications.
       - name: Install tockloader
         run: |
-          pip3 install tockloader==1.12.0
+          pip3 install tockloader==1.13.0
 
       # Clone tock-litex support repository under ./tock-litex, check out the
       # targeted release.

--- a/.github/workflows/litex_sim.yml
+++ b/.github/workflows/litex_sim.yml
@@ -104,8 +104,8 @@ jobs:
           # bugs fixed in libtock-c, backwards-incompatible changes in
           # Tock or new tests this might need to be updated.
           #
-          # libtock-c of Feb 9, 2024, 3:08 PM EST
-          ref: 0e72c922e13cd83a1aaae7a5f587099d45815e6a
+          # libtock-c of Mon Dec 9 21:35:38 2024 +0000
+          ref: 820579455300762558718510d89960fd693131c1
           path: libtock-c
 
       - name: Build libtock-c apps
@@ -118,13 +118,13 @@ jobs:
             rv32imc|rv32imc.0x00088080.0x40010000|0x00088080|0x40010000"
           export LIBTOCK_C_APPS="\
             c_hello \
-            tests/console_timeout \
-            tests/mpu_walk_region \
+            tests/console/console_timeout \
+            tests/mpu/mpu_walk_region \
             tests/printf_long \
             rot13_service \
             rot13_client \
-            tests/console_recv_short \
-            tests/console_recv_long"
+            tests/console/console_recv_short \
+            tests/console/console_recv_long"
           pushd libtock-c/examples
           for APP in $LIBTOCK_C_APPS; do
             make -C "$APP"

--- a/tools/litex-ci-runner/src/main.rs
+++ b/tools/litex-ci-runner/src/main.rs
@@ -190,7 +190,7 @@ fn run() -> Result<(), Error> {
     // should return that.
     //
     // Tests parts of the UART stack and the LiteX UART driver.
-    libtock_c_examples_test(&["tests/console_timeout"], |p, _| {
+    libtock_c_examples_test(&["tests/console/console_timeout"], |p, _| {
         p.send_line("Tock is awesome!")?;
         p.exp_string("Userspace call to read console returned: Tock is awesome!")?;
         Ok(())
@@ -212,7 +212,7 @@ fn run() -> Result<(), Error> {
     // "press" the overrun button. Once we receive the message that the
     // application will walk a region, it's already too late for that. Thus the
     // button is pressed immediately after the start of the prior run.
-    libtock_c_examples_test(&["tests/mpu_walk_region"], |p, gpio| {
+    libtock_c_examples_test(&["tests/mpu/mpu_walk_region"], |p, gpio| {
         p.exp_string("[TEST] MPU Walk Regions")?;
 
         // Start walking the entire flash region, should not panic
@@ -255,7 +255,7 @@ fn run() -> Result<(), Error> {
     //
     // Tests whether an overrun of the RAM region will trigger a process fault
     // by the MPU because of a load page fault.
-    libtock_c_examples_test(&["tests/mpu_walk_region"], |p, gpio| {
+    libtock_c_examples_test(&["tests/mpu/mpu_walk_region"], |p, gpio| {
         p.exp_string("[TEST] MPU Walk Regions")?;
 
         // Start walking the entire flash region.


### PR DESCRIPTION
### Pull Request Overview

In preparation of the upcoming Tock 2.2 release, this updates the pinned libtock-c revision for the LiteX sim CI workflow. This ensures that the latest version of the libtock-c userspace library and tests still work with the latest kernel changes.


### Testing Strategy

This pull request tests itself.


### TODO or Help Wanted

N/A


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
