### PR TITLE
Backport #4275 for Release 2.2: Hail: Specify minimum stable rustc version, makefile auto updates if needed

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -130,6 +130,20 @@ ifneq ($(shell $(RUSTUP) target list | grep "$(TARGET) (installed)"),$(TARGET) (
   $(warning Consider updating 'targets' in 'rust-toolchain.toml')
   $(shell sleep 5s && $(RUSTUP) target add $(TARGET))
 endif
+
+# If the board the user is compiling is using the stable toolchain, verify that
+# the user's stable rustc toolchain is new enough to compile the board. If the
+# toolchain is too old, wait 5 seconds and then install for the user.
+ifneq ($(shell $(RUSTUP) show active-toolchain | grep "stable"),)
+  # If the error from running --version shows a version mismatch we know the
+  # installed toolchain is too old.
+  ifneq ($(shell $(CARGO) rustc -- --version 2>&1 | grep "is not supported by the following packages"),)
+    $(warning Your stable rustc is older than the MSRV of this board)
+    $(warning make will update your stable rustc in 5s)
+    $(shell sleep 5)
+    DUMMY := $(shell $(RUSTUP) update)
+  endif
+endif
 endif # $(NO_RUSTUP)
 
 # If the user is using the standard toolchain provided as part of the llvm-tools

--- a/boards/hail/Cargo.toml
+++ b/boards/hail/Cargo.toml
@@ -8,6 +8,7 @@ version.workspace = true
 authors.workspace = true
 build = "../build.rs"
 edition.workspace = true
+rust-version = "1.83"
 
 [dependencies]
 components = { path = "../components" }


### PR DESCRIPTION
### Pull Request Overview

This pull request backports the changes of #4275 onto the `dev/release-2.2` branch from which the final 2.2 release will be tagged.


### Testing Strategy

N/A


### TODO or Help Wanted

N/A


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
