### PR TITLE
QEMU Makefile Fixes for 9.2.0

### DIFF
--- a/boards/qemu_rv32_virt/Makefile
+++ b/boards/qemu_rv32_virt/Makefile
@@ -41,7 +41,7 @@ else
 endif
 
 ifeq ($(NETDEV),NONE)
-  QEMU_NETDEV_CMDLINE = ""
+  QEMU_NETDEV_CMDLINE =
 else ifeq ($(NETDEV),SLIRP)
   QEMU_NETDEV_CMDLINE = \
     -netdev user,id=n0,net=192.168.1.0/24,dhcpstart=192.168.1.255$(NETDEV_SLIRP_ARGS_INT) \
@@ -74,7 +74,7 @@ QEMU_BASE_CMDLINE := \
 .PHONY: run
 run: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	@echo
-	@echo -e "Running $$(qemu-system-riscv32 --version | head -n1)"\
+	@echo -e "Running $$($(QEMU_CMD) --version | head -n1)"\
 	  "(tested: $(WORKING_QEMU_VERSION)) with\n"\
           " - kernel $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf"
 	@echo "To exit type C-a x"
@@ -87,7 +87,7 @@ run: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 .PHONY: run-app
 run-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	@echo
-	@echo -e "Running $$(qemu-system-riscv32 --version | head -n1)"\
+	@echo -e "Running $$($(QEMU_CMD) --version | head -n1)"\
 	  "(tested: $(WORKING_QEMU_VERSION)) with\n"\
           " - kernel $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf\n"\
 	  " - app $(APP)"


### PR DESCRIPTION
### Pull Request Overview

Minor change to QEMU makefile to leave `QEMU_NETDEV_CMDLINE` empty if it is unused. Right now, it's set to `""` instead of being left empty. Also the wrong QEMU was used when checking version number, so I fixed that too.

For QEMU 8.2.2 (and presumably 7.2.0) this is fine. For QEMU 9.2.0, this results in an error (note the `""` between `virtio-rng-device` and `-nographic`)
```
qemu-system-riscv32 -machine virt -semihosting -global driver=riscv-cpu,property=smepmp,value=true -global virtio-mmio.force-legacy=false -device virtio-rng-device "" -nographic \
  -bios /home/branden/Dropbox/repos/tock/tock/target/riscv32imac-unknown-none-elf/release/qemu_rv32_virt.elf
qemu-system-riscv32: : Device needs media, but drive is empty
```

### Testing Strategy

This pull request was tested by running it on Ubuntu 24.04 with QEMU from Apt (8.2.2) and QEMU built from source (9.2.0).


### TODO or Help Wanted

**Problem** QEMU 9.2.0 also crashes immediately on boot. This seems to be an issue unrelated to these changes.

A panic is triggered in `uart.rs` here: https://github.com/tock/tock/blob/038222d86c4896bd897594b642f81e61699a8331/chips/qemu_rv32_virt_chip/src/uart.rs#L250-L253

```
/home/branden/scratch/qemu-9.2.0/build/qemu-system-riscv32 -machine virt -semihosting -global driver=riscv-cpu,property=smepmp,value=true -global virtio-mmio.force-legacy=false -device virtio-rng-device  -nographic \
  -bios /home/branden/Dropbox/repos/tock/tock/target/riscv32imac-unknown-none-elf/release/qemu_rv32_virt.elf
QEMU RISC-V 32-bit "virt" machine, initialization complete.
Entering main loop.
tock$ 
---| No debug queue found. You can set it with the DebugQueue component.

panicked at chips/qemu_rv32_virt_chip/src/uart.rs:252:13:
UART 16550: interrupt without interrupt
	Kernel version release-2.2-rc1-23-g038222d86

---| RISC-V Machine State |---
Last cause (mcause): Machine external interrupt (interrupt=1, exception code=0x0000000B)
Last value (mtval):  0x00000000

System register dump:
 mepc:    0x8000037C    mstatus:     0x00000088
 mcycle:  0x4290B32A    minstret:    0x4290DE39
 mtvec:   0x80000100
 mstatus: 0x00000088
  uie:    false  upie:   false
  sie:    false  spie:   false
  mie:    true   mpie:   true
  spp:    false
 mie:   0x00000888   mip:   0x00000000
  usoft:  false               false 
  ssoft:  false               false 
  msoft:  true                false 
  utimer: false               false 
  stimer: false               false 
  mtimer: true                false 
  uext:   false               false 
  sext:   false               false 
  mext:   true                false 
 ePMP configuration:
  mseccfg: 0x000003, user-mode PMP active: false, entries:
  [00]: pmpaddr=0x20000000, end=0x00000000, cfg=0x80 (OFF  ) (l---)
  [01]:   start=0x80000000, end=0x800145FF, cfg=0x8D (TOR  ) (lr-x)
  [02]: pmpaddr=0x00000000, end=0x00000000, cfg=0x00 (OFF  ) (----)
  [03]: pmpaddr=0x00000000, end=0x00000000, cfg=0x00 (OFF  ) (----)
  [04]: pmpaddr=0x00000000, end=0x00000000, cfg=0x00 (OFF  ) (----)
  [05]: pmpaddr=0x00000000, end=0x00000000, cfg=0x00 (OFF  ) (----)
  [06]: pmpaddr=0x00000000, end=0x00000000, cfg=0x00 (OFF  ) (----)
  [07]: pmpaddr=0x00000000, end=0x00000000, cfg=0x00 (OFF  ) (----)
  [08]: pmpaddr=0x00000000, end=0x00000000, cfg=0x00 (OFF  ) (----)
  [09]: pmpaddr=0x00000000, end=0x00000000, cfg=0x00 (OFF  ) (----)
  [10]: pmpaddr=0x00000000, end=0x00000000, cfg=0x00 (OFF  ) (----)
  [11]: pmpaddr=0x00000000, end=0x00000000, cfg=0x00 (OFF  ) (----)
  [12]: pmpaddr=0x00000000, end=0x00000000, cfg=0x00 (OFF  ) (----)
  [13]:   start=0x80000000, end=0x801FFFFF, cfg=0x99 (NAPOT) (lr--)
  [14]:   start=0x80200000, end=0x803FFFFF, cfg=0x9B (NAPOT) (lrw-)
  [15]:   start=0x00000000, end=0x1FFFFFFF, cfg=0x9B (NAPOT) (lrw-)
  Shadow PMP entries for user-mode:
  [03]: pmpaddr=0x00000000, end=0x00000000, cfg=0x00 (OFF  ) (----)
  [05]: pmpaddr=0x00000000, end=0x00000000, cfg=0x00 (OFF  ) (----)
  [07]: pmpaddr=0x00000000, end=0x00000000, cfg=0x00 (OFF  ) (----)
  [09]: pmpaddr=0x00000000, end=0x00000000, cfg=0x00 (OFF  ) (----)
  [11]: pmpaddr=0x00000000, end=0x00000000, cfg=0x00 (OFF  ) (----)

---| App Status |---
make: *** [Makefile:80: run] Error 1
```


### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
