### PR TITLE
802.15.4 Add radio enable syscall to standard driver

### DIFF
--- a/capsules/extra/src/ieee802154/device.rs
+++ b/capsules/extra/src/ieee802154/device.rs
@@ -48,6 +48,17 @@ pub trait MacDevice<'a> {
     /// Returns if the MAC device is currently on.
     fn is_on(&self) -> bool;
 
+    /// Start the radio.
+    ///
+    /// This serves as a passthrough to the underlying radio's `start` method.
+    ///
+    /// ## Return
+    ///
+    /// `Ok(())` on success. On `Err()`, valid errors are:
+    ///
+    /// - `ErrorCode::FAIL`: Internal error occurred.
+    fn start(&self) -> Result<(), ErrorCode>;
+
     /// Prepares a mutable buffer slice as an 802.15.4 frame by writing the appropriate
     /// header bytes into the buffer. This needs to be done before adding the
     /// payload because the length of the header is not fixed.

--- a/capsules/extra/src/ieee802154/driver.rs
+++ b/capsules/extra/src/ieee802154/driver.rs
@@ -668,6 +668,7 @@ impl<'a, M: device::MacDevice<'a>> SyscallDriver for RadioDriver<'a, M> {
     ///        parameters to encrypt, form headers, and transmit the frame.
     /// - `28`: Set long address.
     /// - `29`: Get the long MAC address.
+    /// - `30`: Turn the radio on.
     fn command(
         &self,
         command_number: usize,
@@ -967,6 +968,7 @@ impl<'a, M: device::MacDevice<'a>> SyscallDriver for RadioDriver<'a, M> {
                 let addr = u64::from_be_bytes(self.mac.get_address_long());
                 CommandReturn::success_u64(addr)
             }
+            30 => self.mac.start().into(),
             _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
         }
     }

--- a/capsules/extra/src/ieee802154/framer.rs
+++ b/capsules/extra/src/ieee802154/framer.rs
@@ -774,6 +774,10 @@ impl<'a, M: Mac<'a>, A: AES128CCM<'a>> MacDevice<'a> for Framer<'a, M, A> {
         self.mac.is_on()
     }
 
+    fn start(&self) -> Result<(), ErrorCode> {
+        self.mac.start()
+    }
+
     fn prepare_data_frame(
         &self,
         buf: &'static mut [u8],

--- a/capsules/extra/src/ieee802154/mac.rs
+++ b/capsules/extra/src/ieee802154/mac.rs
@@ -57,6 +57,17 @@ pub trait Mac<'a> {
     /// Indicates whether or not the MAC protocol is active and can send frames
     fn is_on(&self) -> bool;
 
+    /// Start the radio.
+    ///
+    /// This serves as a passthrough to the underlying radio's `start` method.
+    ///
+    /// ## Return
+    ///
+    /// `Ok(())` on success. On `Err()`, valid errors are:
+    ///
+    /// - `ErrorCode::FAIL`: Internal error occurred.
+    fn start(&self) -> Result<(), ErrorCode>;
+
     /// Transmits complete MAC frames, which must be prepared by an ieee802154::device::MacDevice
     /// before being passed to the Mac layer. Returns the frame buffer in case of an error.
     fn transmit(
@@ -96,6 +107,10 @@ impl<'a, R: radio::Radio<'a>> Mac<'a> for AwakeMac<'a, R> {
 
     fn is_on(&self) -> bool {
         self.radio.is_on()
+    }
+
+    fn start(&self) -> Result<(), ErrorCode> {
+        self.radio.start()
     }
 
     fn set_config_client(&self, client: &'a dyn radio::ConfigClient) {

--- a/capsules/extra/src/ieee802154/virtual_mac.rs
+++ b/capsules/extra/src/ieee802154/virtual_mac.rs
@@ -288,6 +288,10 @@ impl<'a, M: device::MacDevice<'a>> device::MacDevice<'a> for MacUser<'a, M> {
         self.mux.mac.is_on()
     }
 
+    fn start(&self) -> Result<(), ErrorCode> {
+        self.mux.mac.start()
+    }
+
     fn prepare_data_frame(
         &self,
         buf: &'static mut [u8],

--- a/capsules/extra/src/ieee802154/xmac.rs
+++ b/capsules/extra/src/ieee802154/xmac.rs
@@ -369,6 +369,11 @@ impl<'a, R: radio::Radio<'a>, A: Alarm<'a>> Mac<'a> for XMac<'a, R, A> {
         self.radio.is_on()
     }
 
+    fn start(&self) -> Result<(), ErrorCode> {
+        self.state.set(XMacState::STARTUP);
+        self.radio.start()
+    }
+
     fn set_config_client(&self, client: &'a dyn radio::ConfigClient) {
         self.radio.set_config_client(client)
     }


### PR DESCRIPTION
### Pull Request Overview

The 15.4 driver is separated into a PHY driver (giving direct radio control to the app) and the "standard" 15.4 driver that forms packets etc. With the addition of the PHY 15.4 driver, the nrf52 radio was altered to be off-by-default. Because the standard 15.4 driver does not have the ability to enable the radio, the existing 15.4 tx test (that use the standard driver) do not function. 

This PR alters the standard driver interface to include an "enable" syscall. To facilitate this, a `start(...)` method was added to the `Mac` and `MacDevice` traits. This implementation faces the downside of allowing applications to naively turn on the radio. However, implementers of the `Mac` and `MacDevice` traits can elect to have this operation fail if the proper  radio behavior is to remain disabled (e.g. for power conservation). As the 15.4 subsystem is currently implemented, I do not think this presents a major problem (barring perhaps `xmac.rs` which I believe to be primarily unused?).


### Testing Strategy

This pull request was tested through the tensile hwci tests that automate the tx, rx, tx_raw, and openthread_hello tests. All tests are passing with these changes.

### TODO or Help Wanted

I am not very familiar with how `xmac.rs` functions. Although this, to my knowledge, is not currently used, I would appreciate confirmation that: 

1. These changes make sense.
2. This is not being currently used in a meaningful way.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
