### PR TITLE
kernel/scheduler/mlfq: fix lockup by immediately servicing kernel interrupts

### DIFF
--- a/kernel/src/scheduler/mlfq.rs
+++ b/kernel/src/scheduler/mlfq.rs
@@ -28,7 +28,6 @@ use crate::collections::list::{List, ListLink, ListNode};
 use crate::hil::time::{self, ConvertTicks, Ticks};
 use crate::platform::chip::Chip;
 use crate::process::Process;
-use crate::process::ProcessId;
 use crate::process::StoppedExecutingReason;
 use crate::scheduler::{Scheduler, SchedulingDecision};
 
@@ -182,10 +181,5 @@ impl<A: 'static + time::Alarm<'static>, C: Chip> Scheduler<C> for MLFQSched<'_, 
         } else {
             self.processes[queue_idx].push_tail(self.processes[queue_idx].pop_head().unwrap());
         }
-    }
-
-    unsafe fn continue_process(&self, _: ProcessId, _: &C) -> bool {
-        // This MLFQ scheduler only preempts processes if there is a timeslice expiration
-        true
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes a potential lockup when using the MLFQ scheduler.

Previously the MLFQ scheduler overwrote the `continue_process` method, which can control whether the core kernel loop immediately continues executing a process or is allowed to do other work first (such as servicing interrupts and deferred calls). While this may be a fine decision on some chips, it leads to a scheduler lockup with an uncooperative process on LiteX (and probably all other platforms that use the `VirtualSchedulerTimer`).

This is because on some RISC-V platforms the scheduler timer is not a dedicated system attached to its own interrupt source, but a virtual scheduler timer based on an `Alarm` implementation that shares the "machine external interrupt" CPU input. When a process' timeslice expires, this alarm will raise an MEXT interrupt. To allow the kernel to do actual work and not get stuck in the trap handler, we disable MEXT interrupts by clearing the MIE::MEIE bit. Unfortunately, because of the overriden `continue_process` method, we then never handle this interrupt, which keeps the alarm interrupt asserted, and the MEXT CPU interrupt source disabled. While the kernel does set up a new alarm when scheduling back to the process, its interrupt never arrives. This can cause the kernel to never interrupt and deschedule an uncooperative process.

### Testing Strategy

This pull request was tested by running `whileone` and `hello_loop` next to each other in a LiteX simulation.


### TODO or Help Wanted

I'm not sure whether this is the right approach. I don't quite understand why the MLFQ overwrote `continue_process` in the first place. Also, it seems bad that a scheduler can cause a chip lockup this easily, and that there is not a way for the scheduler to distinguish between interrupts that are critical to be handled for the kernel to work reliably, and ones that are safe to defer.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
