### PR TITLE
chips/litex_vexriscv/interrupt_controller: reintroduce asm_const usage

### DIFF
--- a/chips/litex_vexriscv/src/interrupt_controller.rs
+++ b/chips/litex_vexriscv/src/interrupt_controller.rs
@@ -111,9 +111,7 @@ mod vexriscv_irq_raw {
     pub unsafe fn irq_getmask() -> usize {
         let mask: usize;
         use core::arch::asm;
-        // TODO: If asm_const is stabilized, transition back to below
-        //asm!("csrr {mask}, {csr}", mask = out(reg) mask, csr = const CSR_IRQ_MASK);
-        asm!("csrr {mask}, 0xBC0", mask = out(reg) mask);
+        asm!("csrr {mask}, {csr}", mask = out(reg) mask, csr = const CSR_IRQ_MASK);
         mask
     }
 
@@ -123,9 +121,7 @@ mod vexriscv_irq_raw {
     #[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
     pub unsafe fn irq_setmask(mask: usize) {
         use core::arch::asm;
-        // TODO: If asm_const is stabilized, transition back to below
-        //asm!("csrw {csr}, {mask}", csr = const CSR_IRQ_MASK, mask = in(reg) mask);
-        asm!("csrw 0xBC0, {mask}", mask = in(reg) mask);
+        asm!("csrw {csr}, {mask}", csr = const CSR_IRQ_MASK, mask = in(reg) mask);
     }
 
     #[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
@@ -137,9 +133,7 @@ mod vexriscv_irq_raw {
     pub unsafe fn irq_pending() -> usize {
         let pending: usize;
         use core::arch::asm;
-        // TODO: If asm_const is stabilized, transition back to below
-        //asm!("csrr {pending}, {csr}", pending = out(reg) pending, csr = const CSR_IRQ_PENDING);
-        asm!("csrr {pending}, 0xFC0", pending = out(reg) pending);
+        asm!("csrr {pending}, {csr}", pending = out(reg) pending, csr = const CSR_IRQ_PENDING);
         pending
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request reintroduces `asm_const` usage in the LiteX interrupt controller and thus addresses the TODOs left in the code for that.


### Testing Strategy

N/A


### TODO or Help Wanted

N/A


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
