### PR TITLE
Backport #4292 to Release 2.2: kernel/scheduler/mlfq: fix lockup by immediately servicing kernel interrupts

### DIFF
--- a/kernel/src/scheduler/mlfq.rs
+++ b/kernel/src/scheduler/mlfq.rs
@@ -28,7 +28,6 @@ use crate::collections::list::{List, ListLink, ListNode};
 use crate::hil::time::{self, ConvertTicks, Ticks};
 use crate::platform::chip::Chip;
 use crate::process::Process;
-use crate::process::ProcessId;
 use crate::process::StoppedExecutingReason;
 use crate::scheduler::{Scheduler, SchedulingDecision};
 
@@ -182,10 +181,5 @@ impl<A: 'static + time::Alarm<'static>, C: Chip> Scheduler<C> for MLFQSched<'_, 
         } else {
             self.processes[queue_idx].push_tail(self.processes[queue_idx].pop_head().unwrap());
         }
-    }
-
-    unsafe fn continue_process(&self, _: ProcessId, _: &C) -> bool {
-        // This MLFQ scheduler only preempts processes if there is a timeslice expiration
-        true
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request backports PR #4292 to the `dev/release-2.2` branch, for inclusion in the upcoming release.


### Testing Strategy

This pull request will be tested as part of release testing.


### TODO or Help Wanted

N/A


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
