### PR TITLE
Prepare GitHub Actions workflows for Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Install dependencies
         continue-on-error: true
         run: |
-          sudo apt install meson
+          sudo apt install meson libglib2.0-dev
       - uses: actions/checkout@v4
       - name:      ci-job-qemu
         run:  make ci-job-qemu

--- a/.github/workflows/litex_sim.yml
+++ b/.github/workflows/litex_sim.yml
@@ -28,7 +28,7 @@ jobs:
   litex-sim-ci:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
 
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
### Pull Request Overview

This PR prepares our GitHub Actions workflows to run on Ubuntu 24.04. It adds a missing `glib-2.0` dependency to the QEMU workflow, and pins the LiteX workflow to use Ubuntu 22.04 until all dependencies have been updated.

### Testing Strategy

This PR tests itself.


### TODO or Help Wanted

N/A


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
