### PR TITLE
treadmill-ci: add dummy pull_request trigger to allow using as required check

### DIFF
--- a/.github/workflows/treadmill-ci.yml
+++ b/.github/workflows/treadmill-ci.yml
@@ -65,14 +65,14 @@ on:
         required: true
         default: 'master'
       tests-json:
-        description: 'tests-json value passed to HWCI workflow (if empty, output from determine-tests step is used)'
+        description: 'tests-json value passed to HWCI workflow (if empty, output from hwci-determine-tests step is used)'
         required: false
 
 permissions:
   contents: read
 
 jobs:
-  determine-tests:
+  hwci-determine-tests:
     runs-on: ubuntu-latest
 
     # Don't run on a pull request, as explained above.
@@ -118,14 +118,14 @@ jobs:
           hwci_tests_json=$(cat selected_tests.json | jq -c '.')
           echo "hwci-tests-json=${hwci_tests_json}" >> "$GITHUB_OUTPUT"
 
-  treadmill-ci:
-    needs: [determine-tests]
+  hwci-treadmill-dispatch:
+    needs: [hwci-determine-tests]
 
     # This checks whether there is at least one test to run, see
     # https://github.com/orgs/community/discussions/27125#discussioncomment-3254720
     #
     # Don't run on a pull request, as explained above.
-    if: github.event_name != 'pull_request' && (fromJSON(needs.determine-tests.outputs.hwci-tests-json)[0] != null || github.event_name == 'workflow_dispatch')
+    if: github.event_name != 'pull_request' && (fromJSON(needs.hwci-determine-tests.outputs.hwci-tests-json)[0] != null || github.event_name == 'workflow_dispatch')
 
     # The main tock-hardware-ci workflow is imported from another repository. It
     # can be reused across multiple Tock repositories such as the kernel,
@@ -154,25 +154,25 @@ jobs:
       libtock-c-ref: ${{ github.event_name == 'workflow_dispatch' && inputs.libtock-c-ref || 'master' }}
 
       # Pass the selected tests:
-      tests-json: ${{ (github.event_name == 'workflow_dispatch' && inputs.tests-json != '') && inputs.tests-json || needs.determine-tests.outputs.hwci-tests-json }}
+      tests-json: ${{ (github.event_name == 'workflow_dispatch' && inputs.tests-json != '') && inputs.tests-json || needs.hwci-determine-tests.outputs.hwci-tests-json }}
 
     secrets: inherit
 
-  # We cannot depend on *all* test-execute jobs of treadmill-ci as required
-  # checks for pull requests and merge queues. Thus, we run another single dummy
-  # step here that waits for all the treadmill-ci jobs to complete and report
-  # success.
+  # We cannot depend on *all* test-execute jobs of hwci-treadmill-dispatch as
+  # required checks for pull requests and merge queues. Thus, we run another
+  # single dummy step here that waits for all the hwci-treadmill-dispatch jobs
+  # to complete and report success.
   #
   # We also use this to report a "dummy" success value for the "pull_request"
   # trigger, as explained in the comment of the "on:" parameters above.
-  report-success:
-    needs: [determine-tests, treadmill-ci]
+  hwci-report-success:
+    needs: [hwci-determine-tests, hwci-treadmill-dispatch]
 
     if: always()
 
     runs-on: ubuntu-latest
 
     steps:
-      - name: Fail if any of the 'treadmill-ci' jobs failed
+      - name: Fail if any of the 'hwci-treadmill-dispatch' jobs failed
         if: github.event_name != 'pull_request' && contains(needs.*.result, 'failure')
         run: exit 1

--- a/.github/workflows/treadmill-ci.yml
+++ b/.github/workflows/treadmill-ci.yml
@@ -32,16 +32,26 @@ on:
       - master
       # Add any additional branches you want to include
       # - dev/test_ci_branch
+
   # Pull requests from forks will not have access to the required GitHub API
   # secrets below, even if they are using an appropriate deployment environment
   # and the workflow runs have been approved according to this environment's
   # rules. We don't know whether this is a bug on GitHub's end or deliberate.
+  #
   # Either way, for now we disable this workflow to run on PRs until we have
   # an API proxy that securely performs these GitHub API calls (adding runners
   # and starting Treadmill jobs with those runner registration tokens), which
   # allows this workflow to run without access to repository secrets.
-  #pull_request:
+  #
+  # However, because GitHub's merge queues don't allow to differentiate required
+  # checks for *entering* the merge queue from those that are required to *pass*
+  # it, we also can't disable this trigger entirely. Instead, we use a selector
+  # to avoid running any actual checks on this trigger, while still technically
+  # succeeding for PRs.
+  pull_request:
+
   merge_group: # Run CI for the GitHub merge queue
+
   # Manually dispatch for a specific branch (will require approval
   # through the treadmill-ci-merged environment:
   workflow_dispatch:
@@ -64,6 +74,9 @@ permissions:
 jobs:
   determine-tests:
     runs-on: ubuntu-latest
+
+    # Don't run on a pull request, as explained above.
+    if: github.event_name != 'pull_request'
 
     outputs:
       hwci-tests-json: ${{ steps.determine-tests.outputs.hwci-tests-json }}
@@ -110,7 +123,9 @@ jobs:
 
     # This checks whether there is at least one test to run, see
     # https://github.com/orgs/community/discussions/27125#discussioncomment-3254720
-    if: fromJSON(needs.determine-tests.outputs.hwci-tests-json)[0] != null || github.event_name == 'workflow_dispatch'
+    #
+    # Don't run on a pull request, as explained above.
+    if: github.event_name != 'pull_request' && (fromJSON(needs.determine-tests.outputs.hwci-tests-json)[0] != null || github.event_name == 'workflow_dispatch')
 
     # The main tock-hardware-ci workflow is imported from another repository. It
     # can be reused across multiple Tock repositories such as the kernel,
@@ -142,3 +157,22 @@ jobs:
       tests-json: ${{ (github.event_name == 'workflow_dispatch' && inputs.tests-json != '') && inputs.tests-json || needs.determine-tests.outputs.hwci-tests-json }}
 
     secrets: inherit
+
+  # We cannot depend on *all* test-execute jobs of treadmill-ci as required
+  # checks for pull requests and merge queues. Thus, we run another single dummy
+  # step here that waits for all the treadmill-ci jobs to complete and report
+  # success.
+  #
+  # We also use this to report a "dummy" success value for the "pull_request"
+  # trigger, as explained in the comment of the "on:" parameters above.
+  report-success:
+    needs: [determine-tests, treadmill-ci]
+
+    if: always()
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fail if any of the 'treadmill-ci' jobs failed
+        if: github.event_name != 'pull_request' && contains(needs.*.result, 'failure')
+        run: exit 1


### PR DESCRIPTION
### Pull Request Overview

Because GitHub's merge queues don't allow to differentiate required checks for *entering* the merge queue from those that are required to *pass* it, we cannot depend on this workflow only in the merge queue, without also executing it on PRs.

At the same time, pull requests from forks do not have access to the required GitHub API secrets in this workflow, even if they are using an appropriate deployment environment and the workflow runs have been approved according to this environment's rules.

Thus, this allows running this workflow on PR triggers, but not actually running any tests. This allows us to then depend on it for passing the merge queue.

### Testing Strategy

This pull request tests itself.


### TODO or Help Wanted

N/A


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
