### PR TITLE
stm32f4xx: usart disable

### DIFF
--- a/chips/stm32f4xx/src/usart.rs
+++ b/chips/stm32f4xx/src/usart.rs
@@ -562,6 +562,11 @@ impl<'a, DMA: dma::StreamServer<'a>> Usart<'a, DMA> {
         self.registers.brr.modify(BRR::DIV_Fraction.val(fraction));
         Ok(())
     }
+
+    // disable the USART
+    pub fn disable(&self) {
+        self.registers.cr1.modify(CR1::UE::CLEAR);
+    }
 }
 
 impl<'a, DMA: dma::StreamServer<'a>> DeferredCallClient for Usart<'a, DMA> {

--- a/chips/stm32f4xx/src/usart.rs
+++ b/chips/stm32f4xx/src/usart.rs
@@ -563,9 +563,17 @@ impl<'a, DMA: dma::StreamServer<'a>> Usart<'a, DMA> {
         Ok(())
     }
 
-    // disable the USART
-    pub fn disable(&self) {
-        self.registers.cr1.modify(CR1::UE::CLEAR);
+    // try to disable the USART and return BUSY if a transfer is taking place
+    pub fn disable(&self) -> Result<(), ErrorCode> {
+        if self.usart_tx_state.get() == USARTStateTX::DMA_Transmitting
+            || self.usart_tx_state.get() == USARTStateTX::Transfer_Completing
+            || self.usart_rx_state.get() == USARTStateRX::DMA_Receiving
+        {
+            Err(ErrorCode::BUSY)
+        } else {
+            self.registers.cr1.modify(CR1::UE::CLEAR);
+            Ok(())
+        }
     }
 }
 


### PR DESCRIPTION
### Pull Request Overview

This pull request addes an usart disable API, to help reduce power consumption

### Testing Strategy

This pull request was tested by disabling the usart and entering sleep mode, on a nucleo_f429zi board.

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
