### PR TITLE
arm: replace two asm instructions with one equivalent

### DIFF
--- a/arch/cortex-v7m/src/lib.rs
+++ b/arch/cortex-v7m/src/lib.rs
@@ -99,8 +99,7 @@ core::arch::global_asm!(
     // The link register is set to the `EXC_RETURN` value on exception entry. To
     // ensure we execute using the process stack we set the SPSEL bit to 1
     // to use the alternate (process) stack.
-    mov r0, #1                        // r0 = 1
-    bfi lr, r0, #2, #1                // LR = LR | (0x1<<2)
+    orr lr, lr, #4                    // LR = LR | 0b100
 
     // Switch to the app.
     bx lr


### PR DESCRIPTION
### Pull Request Overview

Finally got a chance to go back and review #4256, which looks good. This is just a little micro-optimization I saw while reviewing.

### Testing Strategy

This pull request was tested by compiling (and treadmill, yay!)

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
