### PR TITLE
GitHub actions: update upload-artifact action to v4

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -40,7 +40,7 @@ jobs:
       - name: ci-job-collect-artifacts
         run: make ci-job-collect-artifacts
       - name: upload-build-artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-artifacts
           path: tools/ci-artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name:      ci-job-collect-artifacts
         run:  make ci-job-collect-artifacts
       - name: upload-build-artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-artifacts
           path: tools/ci-artifacts


### PR DESCRIPTION
### Pull Request Overview

Our CI has started failing as GitHub deprecated the `upload-artifact@v3` action. This updates it to v4. None of the API changes should affect us.


### Testing Strategy

This PR tests itself.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
