### PR TITLE
capsules: spi controller: set rlen length

### DIFF
--- a/capsules/core/src/spi_controller.rs
+++ b/capsules/core/src/spi_controller.rs
@@ -186,8 +186,12 @@ impl<'a, S: SpiMasterDevice<'a>> Spi<'a, S> {
                 .take()
                 .unwrap_or((&mut [] as &'static mut [u8]).into());
             kwbuf.slice(0..write_len);
-            self.spi_master
-                .read_write_bytes(kwbuf, self.kernel_read.take())
+            if let Some(mut krbuf) = self.kernel_read.take() {
+                krbuf.slice(0..rlen);
+                self.spi_master.read_write_bytes(kwbuf, Some(krbuf))
+            } else {
+                self.spi_master.read_write_bytes(kwbuf, None)
+            }
         };
     }
 }


### PR DESCRIPTION
### Pull Request Overview

If both write buffer and read buffers are set we need to set both lengths.






### Testing Strategy

Trying to get the LR1110 radio to work.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
