### PR TITLE
update upstream tock url to use https protocol

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -85,7 +85,7 @@ out your copy locally.
 ```text
 $ git clone git@github.com:username/tock.git
 $ cd tock
-$ git remote add upstream git://github.com/tock/tock.git
+$ git remote add upstream https://github.com/tock/tock.git
 ```
 
 ### Step 2: Branch


### PR DESCRIPTION
When the upstream url is prefaced by git://, git fetch upstream hangs and fails with

    fatal: unable to connect to github.com:
    github.com[0: 140.82.114.3]: errno=Operation timed out

but succeeds when the upstream url is prefaced by https://. This is likely because Github no longer supports the git:// protocol.

### Pull Request Overview

This pull request fixes the failing `git fetch upstream` command due to an upstream url specifying the no-longer supported `git://` protocol. 


### Testing Strategy

This pull request was tested by running `git fetch upstream` on both the `git://`- and `https://`-prefaced upstream urls, both from behind a firewall and not. 


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or **no updates are required**.

### Formatting

- [x] Ran `make prepush`.
