### PR TITLE
Document process for stabilizing a syscall driver

### DIFF
--- a/doc/Maintenance.md
+++ b/doc/Maintenance.md
@@ -15,6 +15,8 @@ group](wg/core/README.md) maintains the Tock project.
     + [Tagging a release candidate](#tagging-a-release-candidate)
     + [Release testing](#release-testing)
     + [Tagging a release](#tagging-a-release)
+- [Stabilizing a Syscall Driver](#stabilizing-a-syscall-driver)
+  * [Syscall Driver Stabilization Process](#syscall-driver-stabilization-process)
 
 <!-- tocstop -->
 
@@ -113,3 +115,44 @@ will decide whether new release candidates require re-testing all boards or not.
 
 Once all tests pass for all boards, and the changelog is updated, a release can
 be tagged.
+
+## Stabilizing a Syscall Driver
+
+Tock maintains a list of stabilized system call drivers that the kernel
+guarantees not to break in subsequent releases of the kernel with the same major
+version number. These are the drivers that implement `SyscallDriver` and are
+commonly found in capsules. Note, these stabilization guarantees are separate
+from the stability of the system call interface itself (i.e., `command`,
+`allow`, etc.).
+
+The goal of this stability guarantee is to ensure that applications that use a
+particular system call driver will continue to work with a kernel of the same
+major version number. However, Tock does not prohibit expanding a stabilized
+interface within the same major version number. This enables new functionality
+to be added, or for bug fixes to be added without breaking backwards
+compatibility.
+
+### Syscall Driver Stabilization Process
+
+The general process is a syscall driver, identified by its driver number, is
+proposed to be stabilized. The driver must have a documented interface in the
+`docs/syscalls` directory. The interface has a waiting period (which can have
+started in the past) where if no changes have been made to the interface the
+interface is marked as stable as of the next release of Tock.
+
+Syscall driver stabilization process:
+
+1. The driver has complete documentation in the `doc/syscalls` directory.
+1. A Tock developer proposes that a specific driver, as identified by its driver
+   number and source code in the upstream Tock repository, should be stabilized.
+1. The core working group must support the stabilization. If there is support
+   the syscall driver must be moved to the `capsules/core` crate and the
+   stabilization column in `doc/syscalls/README.md` is marked with a ⏰.
+1. The syscall driver must be unchanged for a period of four months. This period
+   may start from a point before the stabilization process started. The driver
+   must be reasonably tested during this period.
+1. If changes are required the waiting period resets.
+1. After the probationary period, the syscall driver is marked stabilized at the
+   next Tock major or minor release. The syscall driver is marked stable by
+   updating the stabilization column in `doc/syscalls/README.md` with the Tock
+   release version number.

--- a/doc/Maintenance.md
+++ b/doc/Maintenance.md
@@ -144,10 +144,11 @@ Syscall driver stabilization process:
 
 1. The driver has complete documentation in the `doc/syscalls` directory.
 1. A Tock developer proposes that a specific driver, as identified by its driver
-   number and source code in the upstream Tock repository, should be stabilized.
-1. The core working group must support the stabilization. If there is support
-   the syscall driver must be moved to the `capsules/core` crate and the
-   stabilization column in `doc/syscalls/README.md` is marked with a ⏰.
+   number and source code in the upstream Tock repository, should be stabilized
+   by creating a pull request that moves the driver to the `capsules/core` crate and
+   marks the stabilization column in `doc/syscalls/README.md` with a ⏰.
+1. Stabilization PRs are always considered `P-Significant`, which requires the core
+   working group to support the stabilization.
 1. The syscall driver must be unchanged for a period of four months. This period
    may start from a point before the stabilization process started. The driver
    must be reasonably tested during this period.

--- a/doc/Maintenance.md
+++ b/doc/Maintenance.md
@@ -143,17 +143,17 @@ interface is marked as stable as of the next release of Tock.
 Syscall driver stabilization process:
 
 1. The driver has complete documentation in the `doc/syscalls` directory.
-1. A Tock developer proposes that a specific driver, as identified by its driver
+2. A Tock developer proposes that a specific driver, as identified by its driver
    number and source code in the upstream Tock repository, should be stabilized
    by creating a pull request that moves the driver to the `capsules/core` crate and
    marks the stabilization column in `doc/syscalls/README.md` with a ⏰.
-1. Stabilization PRs are always considered `P-Significant`, which requires the core
+3. Stabilization PRs are always considered `P-Significant`, which requires the core
    working group to support the stabilization.
-1. The syscall driver must be unchanged for a period of four months. This period
+4. The syscall driver must be unchanged for a period of four months. This period
    may start from a point before the stabilization process started. The driver
    must be reasonably tested during this period.
-1. If changes are required the waiting period resets.
-1. After the probationary period, the syscall driver is marked stabilized at the
+5. If changes are required the waiting period resets.
+6. After the probationary period, the syscall driver is marked stabilized at the
    next Tock major or minor release. The syscall driver is marked stable by
    updating the stabilization column in `doc/syscalls/README.md` with the Tock
    release version number.

--- a/doc/syscalls/README.md
+++ b/doc/syscalls/README.md
@@ -38,7 +38,7 @@ Details of the [application binary interface](../Syscalls.md).
 
 Each driver type that has been allocated a permanent driver number is listed in
 the tables below. The "2.0" column indicates whether the driver has been
-stabilized or not (a "✓" indicates stability) in the Tock 2.0 release.
+[stabilized](../Maintenance.md#stabilizing-a-syscall-driver) or not (a "✓" indicates stability) in the Tock 2.0 release.
 
 ### Base
 


### PR DESCRIPTION
### Pull Request Overview

We had a discussion on the core call about stabilizing drivers. This tries to capture a process that we seemed to be converging on. I added some mechanistic details.


### Testing Strategy

n/a


### TODO or Help Wanted

- I chose four months arbitrarily. Seemed like an ok balance of giving enough time for issues to arise while not waiting _too_ long.
- I left it vague about what testing is required, but there should be some effort to make sure the interface works.
- I added a bit about moving the driver to `capsules/core`. Seems fair that a stabilized driver is a core driver.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
