### PR TITLE
arch/rv32i: allow full address range to be covered by `{TOR,NAPOT}RegionSpec`

### DIFF
--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -158,25 +158,25 @@ impl NAPOTRegionSpec {
     /// `Some(region)` when all constraints specified in the
     /// [`NAPOTRegionSpec`]'s documentation are satisfied, otherwise `None`.
     pub fn from_start_size(start: *const u8, size: usize) -> Option<Self> {
-        if !size.is_power_of_two() || (start as usize) % size != 0 || size < 8 {
+        if !size.is_power_of_two() || start.addr() % size != 0 || size < 8 {
             return None;
         }
 
         Self::from_pmpaddr_csr(
-            ((start as usize) + (size - 1).overflowing_shr(1).0)
+            (start.addr() + (size - 1).overflowing_shr(1).0)
                 .overflowing_shr(2)
                 .0,
         )
     }
 
-    /// Construct a new [`NAPOTRegionSpec`] from a start .
+    /// Construct a new [`NAPOTRegionSpec`] from a start address and end address.
     ///
-    /// This method accepts a `start` and `end` address. It returns
-    /// `Some(region)` when all constraints specified in the
-    /// [`NAPOTRegionSpec`]'s documentation are satisfied, otherwise `None`.
+    /// This method accepts a `start` address (inclusive) and `end` address
+    /// (exclusive). It returns `Some(region)` when all constraints specified in
+    /// the [`NAPOTRegionSpec`]'s documentation are satisfied, otherwise `None`.
     pub fn from_start_end(start: *const u8, end: *const u8) -> Option<Self> {
-        (end as usize)
-            .checked_sub(start as usize)
+        end.addr()
+            .checked_sub(start.addr())
             .and_then(|size| Self::from_start_size(start, size))
     }
 
@@ -262,7 +262,7 @@ impl TORRegionSpec {
             return None;
         }
 
-        Self::from_pmpaddr_csrs((start as usize) >> 2, (end as usize) >> 2)
+        Self::from_pmpaddr_csrs(start.addr() >> 2, end.addr() >> 2)
     }
 
     /// Get the first `pmpaddrX` CSR value that this TORRegionSpec encodes.

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -293,28 +293,28 @@ unsafe fn start() -> (
     // memory protection.
     let pmp = rv32i::pmp::kernel_protection::KernelProtectionPMP::new(
         rv32i::pmp::kernel_protection::FlashRegion(
-            rv32i::pmp::NAPOTRegionSpec::new(
+            rv32i::pmp::NAPOTRegionSpec::from_start_end(
                 core::ptr::addr_of!(_sflash),
-                core::ptr::addr_of!(_eflash) as usize - core::ptr::addr_of!(_sflash) as usize,
+                core::ptr::addr_of!(_eflash),
             )
             .unwrap(),
         ),
         rv32i::pmp::kernel_protection::RAMRegion(
-            rv32i::pmp::NAPOTRegionSpec::new(
+            rv32i::pmp::NAPOTRegionSpec::from_start_end(
                 core::ptr::addr_of!(_ssram),
-                core::ptr::addr_of!(_esram) as usize - core::ptr::addr_of!(_ssram) as usize,
+                core::ptr::addr_of!(_esram),
             )
             .unwrap(),
         ),
         rv32i::pmp::kernel_protection::MMIORegion(
-            rv32i::pmp::NAPOTRegionSpec::new(
+            rv32i::pmp::NAPOTRegionSpec::from_start_size(
                 0xf0000000 as *const u8, // start
                 0x10000000,              // size
             )
             .unwrap(),
         ),
         rv32i::pmp::kernel_protection::KernelTextRegion(
-            rv32i::pmp::TORRegionSpec::new(
+            rv32i::pmp::TORRegionSpec::from_start_end(
                 core::ptr::addr_of!(_stext),
                 core::ptr::addr_of!(_etext),
             )

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -292,28 +292,28 @@ unsafe fn start() -> (
     // memory protection.
     let pmp = rv32i::pmp::kernel_protection::KernelProtectionPMP::new(
         rv32i::pmp::kernel_protection::FlashRegion(
-            rv32i::pmp::NAPOTRegionSpec::new(
+            rv32i::pmp::NAPOTRegionSpec::from_start_end(
                 core::ptr::addr_of!(_sflash),
-                core::ptr::addr_of!(_eflash) as usize - core::ptr::addr_of!(_sflash) as usize,
+                core::ptr::addr_of!(_eflash),
             )
             .unwrap(),
         ),
         rv32i::pmp::kernel_protection::RAMRegion(
-            rv32i::pmp::NAPOTRegionSpec::new(
+            rv32i::pmp::NAPOTRegionSpec::from_start_end(
                 core::ptr::addr_of!(_ssram),
-                core::ptr::addr_of!(_esram) as usize - core::ptr::addr_of!(_ssram) as usize,
+                core::ptr::addr_of!(_esram),
             )
             .unwrap(),
         ),
         rv32i::pmp::kernel_protection::MMIORegion(
-            rv32i::pmp::NAPOTRegionSpec::new(
+            rv32i::pmp::NAPOTRegionSpec::from_start_size(
                 0xf0000000 as *const u8, // start
                 0x10000000,              // size
             )
             .unwrap(),
         ),
         rv32i::pmp::kernel_protection::KernelTextRegion(
-            rv32i::pmp::TORRegionSpec::new(
+            rv32i::pmp::TORRegionSpec::from_start_end(
                 core::ptr::addr_of!(_stext),
                 core::ptr::addr_of!(_etext),
             )

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -338,28 +338,28 @@ unsafe fn setup() -> (
     // protection.
     let earlgrey_epmp = earlgrey::epmp::EarlGreyEPMP::new_debug(
         earlgrey::epmp::FlashRegion(
-            rv32i::pmp::NAPOTRegionSpec::new(
+            rv32i::pmp::NAPOTRegionSpec::from_start_end(
                 core::ptr::addr_of!(_sflash),
-                core::ptr::addr_of!(_eflash) as usize - core::ptr::addr_of!(_sflash) as usize,
+                core::ptr::addr_of!(_eflash),
             )
             .unwrap(),
         ),
         earlgrey::epmp::RAMRegion(
-            rv32i::pmp::NAPOTRegionSpec::new(
+            rv32i::pmp::NAPOTRegionSpec::from_start_end(
                 core::ptr::addr_of!(_ssram),
-                core::ptr::addr_of!(_esram) as usize - core::ptr::addr_of!(_ssram) as usize,
+                core::ptr::addr_of!(_esram),
             )
             .unwrap(),
         ),
         earlgrey::epmp::MMIORegion(
-            rv32i::pmp::NAPOTRegionSpec::new(
+            rv32i::pmp::NAPOTRegionSpec::from_start_size(
                 0x40000000 as *const u8, // start
                 0x10000000,              // size
             )
             .unwrap(),
         ),
         earlgrey::epmp::KernelTextRegion(
-            rv32i::pmp::TORRegionSpec::new(
+            rv32i::pmp::TORRegionSpec::from_start_end(
                 core::ptr::addr_of!(_stext),
                 core::ptr::addr_of!(_etext),
             )
@@ -370,7 +370,7 @@ unsafe fn setup() -> (
         // parameter `EPMPDebugConfig` to `EPMPDebugDisable`, in which case
         // this expects to be passed a unit (`()`) type.
         earlgrey::epmp::RVDMRegion(
-            rv32i::pmp::NAPOTRegionSpec::new(
+            rv32i::pmp::NAPOTRegionSpec::from_start_size(
                 0x00010000 as *const u8, // start
                 0x00001000,              // size
             )

--- a/boards/qemu_rv32_virt/src/main.rs
+++ b/boards/qemu_rv32_virt/src/main.rs
@@ -194,28 +194,28 @@ unsafe fn start() -> (
     // protection.
     let epmp = rv32i::pmp::kernel_protection_mml_epmp::KernelProtectionMMLEPMP::new(
         rv32i::pmp::kernel_protection_mml_epmp::FlashRegion(
-            rv32i::pmp::NAPOTRegionSpec::new(
+            rv32i::pmp::NAPOTRegionSpec::from_start_end(
                 core::ptr::addr_of!(_sflash),
-                core::ptr::addr_of!(_eflash) as usize - core::ptr::addr_of!(_sflash) as usize,
+                core::ptr::addr_of!(_eflash),
             )
             .unwrap(),
         ),
         rv32i::pmp::kernel_protection_mml_epmp::RAMRegion(
-            rv32i::pmp::NAPOTRegionSpec::new(
+            rv32i::pmp::NAPOTRegionSpec::from_start_end(
                 core::ptr::addr_of!(_ssram),
-                core::ptr::addr_of!(_esram) as usize - core::ptr::addr_of!(_ssram) as usize,
+                core::ptr::addr_of!(_esram),
             )
             .unwrap(),
         ),
         rv32i::pmp::kernel_protection_mml_epmp::MMIORegion(
-            rv32i::pmp::NAPOTRegionSpec::new(
+            rv32i::pmp::NAPOTRegionSpec::from_start_size(
                 core::ptr::null::<u8>(), // start
                 0x20000000,              // size
             )
             .unwrap(),
         ),
         rv32i::pmp::kernel_protection_mml_epmp::KernelTextRegion(
-            rv32i::pmp::TORRegionSpec::new(
+            rv32i::pmp::TORRegionSpec::from_start_end(
                 core::ptr::addr_of!(_stext),
                 core::ptr::addr_of!(_etext),
             )

--- a/chips/earlgrey/src/epmp.rs
+++ b/chips/earlgrey/src/epmp.rs
@@ -444,8 +444,8 @@ impl<const HANDOVER_CONFIG_CHECK: bool> EarlGreyEPMP<{ HANDOVER_CONFIG_CHECK }, 
 
         // Provide R/X access to the kernel .text as passed to us above.
         // Allocate a TOR region in PMP entries 2 and 3:
-        csr::CSR.pmpaddr2.set((kernel_text.0.start() as usize) >> 2);
-        csr::CSR.pmpaddr3.set((kernel_text.0.end() as usize) >> 2);
+        csr::CSR.pmpaddr2.set(kernel_text.0.pmpaddr_a());
+        csr::CSR.pmpaddr3.set(kernel_text.0.pmpaddr_b());
 
         // Set the appropriate `pmpcfg0` register value:
         //
@@ -467,14 +467,14 @@ impl<const HANDOVER_CONFIG_CHECK: bool> EarlGreyEPMP<{ HANDOVER_CONFIG_CHECK }, 
 
         // Configure a Read-Only NAPOT region for the entire flash (spanning
         // kernel & apps, but overlayed by the R/X kernel text TOR section)
-        csr::CSR.pmpaddr12.set(flash.0.napot_addr());
+        csr::CSR.pmpaddr12.set(flash.0.pmpaddr());
 
         // Configure a Read-Write NAPOT region for MMIO.
-        csr::CSR.pmpaddr14.set(mmio.0.napot_addr());
+        csr::CSR.pmpaddr14.set(mmio.0.pmpaddr());
 
         // Configure a Read-Write NAPOT region for the entire RAM (spanning
         // kernel & apps)
-        csr::CSR.pmpaddr15.set(ram.0.napot_addr());
+        csr::CSR.pmpaddr15.set(ram.0.pmpaddr());
 
         // With the FLASH, RAM and MMIO configured in separate regions, we can
         // activate this new configuration, and further adjust the permissions
@@ -516,11 +516,11 @@ impl<const HANDOVER_CONFIG_CHECK: bool> EarlGreyEPMP<{ HANDOVER_CONFIG_CHECK }, 
             || csr::CSR.pmpcfg1.get() != 0x00000000
             || csr::CSR.pmpcfg2.get() != 0x00000000
             || csr::CSR.pmpcfg3.get() != 0x9B9B8099
-            || csr::CSR.pmpaddr2.get() != (kernel_text.0.start() as usize) >> 2
-            || csr::CSR.pmpaddr3.get() != (kernel_text.0.end() as usize) >> 2
-            || csr::CSR.pmpaddr12.get() != flash.0.napot_addr()
-            || csr::CSR.pmpaddr14.get() != mmio.0.napot_addr()
-            || csr::CSR.pmpaddr15.get() != ram.0.napot_addr()
+            || csr::CSR.pmpaddr2.get() != kernel_text.0.pmpaddr_a()
+            || csr::CSR.pmpaddr3.get() != kernel_text.0.pmpaddr_b()
+            || csr::CSR.pmpaddr12.get() != flash.0.pmpaddr()
+            || csr::CSR.pmpaddr14.get() != mmio.0.pmpaddr()
+            || csr::CSR.pmpaddr15.get() != ram.0.pmpaddr()
         {
             return Err(EarlGreyEPMPError::SanityCheckFail);
         }
@@ -581,8 +581,8 @@ impl<const HANDOVER_CONFIG_CHECK: bool> EarlGreyEPMP<{ HANDOVER_CONFIG_CHECK }, 
 
         // Provide R/X access to the kernel .text as passed to us above.
         // Allocate a TOR region in PMP entries 0 and 1:
-        csr::CSR.pmpaddr0.set((kernel_text.0.start() as usize) >> 2);
-        csr::CSR.pmpaddr1.set((kernel_text.0.end() as usize) >> 2);
+        csr::CSR.pmpaddr0.set(kernel_text.0.pmpaddr_a());
+        csr::CSR.pmpaddr1.set(kernel_text.0.pmpaddr_b());
 
         // Set the appropriate `pmpcfg0` register value:
         //
@@ -602,15 +602,15 @@ impl<const HANDOVER_CONFIG_CHECK: bool> EarlGreyEPMP<{ HANDOVER_CONFIG_CHECK }, 
         // region to retain MMIO access while reconfiguring the `pmpcfg3` /
         // `pmpaddr15` register. Thus, write the MMIO region access into
         // `pmpaddr12`:
-        csr::CSR.pmpaddr12.set(mmio.0.napot_addr());
+        csr::CSR.pmpaddr12.set(mmio.0.pmpaddr());
 
         // Configure a Read-Only NAPOT region for the entire flash (spanning
         // kernel & apps, but overlayed by the R/X kernel text TOR section)
-        csr::CSR.pmpaddr13.set(flash.0.napot_addr());
+        csr::CSR.pmpaddr13.set(flash.0.pmpaddr());
 
         // Configure a Read-Write NAPOT region for the entire RAM (spanning
         // kernel & apps)
-        csr::CSR.pmpaddr14.set(ram.0.napot_addr());
+        csr::CSR.pmpaddr14.set(ram.0.pmpaddr());
 
         // With the FLASH, RAM and MMIO configured in separate regions, we can
         // activate this new configuration, and further adjust the permissions
@@ -626,7 +626,7 @@ impl<const HANDOVER_CONFIG_CHECK: bool> EarlGreyEPMP<{ HANDOVER_CONFIG_CHECK }, 
 
         // With the new configuration in place, we can adjust the last region's
         // address to be limited to the MMIO region, ...
-        csr::CSR.pmpaddr15.set(mmio.0.napot_addr());
+        csr::CSR.pmpaddr15.set(mmio.0.pmpaddr());
 
         // ...and then deactivate the `pmpaddr12` fallback MMIO region
         //
@@ -672,11 +672,11 @@ impl<const HANDOVER_CONFIG_CHECK: bool> EarlGreyEPMP<{ HANDOVER_CONFIG_CHECK }, 
             || csr::CSR.pmpcfg1.get() != 0x00000000
             || csr::CSR.pmpcfg2.get() != 0x00000000
             || csr::CSR.pmpcfg3.get() != 0x9B9B9980
-            || csr::CSR.pmpaddr0.get() != (kernel_text.0.start() as usize) >> 2
-            || csr::CSR.pmpaddr1.get() != (kernel_text.0.end() as usize) >> 2
-            || csr::CSR.pmpaddr13.get() != flash.0.napot_addr()
-            || csr::CSR.pmpaddr14.get() != ram.0.napot_addr()
-            || csr::CSR.pmpaddr15.get() != mmio.0.napot_addr()
+            || csr::CSR.pmpaddr0.get() != kernel_text.0.pmpaddr_a()
+            || csr::CSR.pmpaddr1.get() != kernel_text.0.pmpaddr_b()
+            || csr::CSR.pmpaddr13.get() != flash.0.pmpaddr()
+            || csr::CSR.pmpaddr14.get() != ram.0.pmpaddr()
+            || csr::CSR.pmpaddr15.get() != mmio.0.pmpaddr()
         {
             return Err(EarlGreyEPMPError::SanityCheckFail);
         }
@@ -737,10 +737,8 @@ impl<const HANDOVER_CONFIG_CHECK: bool> EarlGreyEPMP<{ HANDOVER_CONFIG_CHECK }, 
 
         // Provide R/X access to the kernel .text as passed to us above.
         // Allocate a TOR region in PMP entries 10 and 11:
-        csr::CSR
-            .pmpaddr10
-            .set((kernel_text.0.start() as usize) >> 2);
-        csr::CSR.pmpaddr11.set((kernel_text.0.end() as usize) >> 2);
+        csr::CSR.pmpaddr10.set(kernel_text.0.pmpaddr_a());
+        csr::CSR.pmpaddr11.set(kernel_text.0.pmpaddr_b());
 
         // Set the appropriate `pmpcfg2` register value:
         //
@@ -755,15 +753,15 @@ impl<const HANDOVER_CONFIG_CHECK: bool> EarlGreyEPMP<{ HANDOVER_CONFIG_CHECK }, 
         // region to retain MMIO access while reconfiguring the `pmpcfg3` /
         // `pmpaddr15` register. Thus, write the MMIO region access into
         // `pmpaddr12`:
-        csr::CSR.pmpaddr12.set(mmio.0.napot_addr());
+        csr::CSR.pmpaddr12.set(mmio.0.pmpaddr());
 
         // Configure a Read-Only NAPOT region for the entire flash (spanning
         // kernel & apps, but overlayed by the R/X kernel text TOR section)
-        csr::CSR.pmpaddr13.set(flash.0.napot_addr());
+        csr::CSR.pmpaddr13.set(flash.0.pmpaddr());
 
         // Configure a Read-Write NAPOT region for the entire RAM (spanning
         // kernel & apps)
-        csr::CSR.pmpaddr14.set(ram.0.napot_addr());
+        csr::CSR.pmpaddr14.set(ram.0.pmpaddr());
 
         // With the FLASH, RAM and MMIO configured in separate regions, we can
         // activate this new configuration, and further adjust the permissions
@@ -779,10 +777,10 @@ impl<const HANDOVER_CONFIG_CHECK: bool> EarlGreyEPMP<{ HANDOVER_CONFIG_CHECK }, 
 
         // With the new configuration in place, we can adjust the last region's
         // address to be limited to the MMIO region, ...
-        csr::CSR.pmpaddr15.set(mmio.0.napot_addr());
+        csr::CSR.pmpaddr15.set(mmio.0.pmpaddr());
 
         // ...and then repurpose `pmpaddr12` for the debug port:
-        csr::CSR.pmpaddr12.set(debug_memory.0.napot_addr());
+        csr::CSR.pmpaddr12.set(debug_memory.0.pmpaddr());
 
         // 0x9F = 0b10011111, for RVDM R/W/X memory region
         //        setting L(7) = 1, A(4-3) = NAPOT, X(2) = 1, W(1) = 1, R(0) = 1
@@ -824,12 +822,12 @@ impl<const HANDOVER_CONFIG_CHECK: bool> EarlGreyEPMP<{ HANDOVER_CONFIG_CHECK }, 
             || csr::CSR.pmpcfg1.get() != 0x00000000
             || csr::CSR.pmpcfg2.get() != 0x8d800000
             || csr::CSR.pmpcfg3.get() != 0x9B9B999F
-            || csr::CSR.pmpaddr10.get() != (kernel_text.0.start() as usize) >> 2
-            || csr::CSR.pmpaddr11.get() != (kernel_text.0.end() as usize) >> 2
-            || csr::CSR.pmpaddr12.get() != debug_memory.0.napot_addr()
-            || csr::CSR.pmpaddr13.get() != flash.0.napot_addr()
-            || csr::CSR.pmpaddr14.get() != ram.0.napot_addr()
-            || csr::CSR.pmpaddr15.get() != mmio.0.napot_addr()
+            || csr::CSR.pmpaddr10.get() != kernel_text.0.pmpaddr_a()
+            || csr::CSR.pmpaddr11.get() != kernel_text.0.pmpaddr_b()
+            || csr::CSR.pmpaddr12.get() != debug_memory.0.pmpaddr()
+            || csr::CSR.pmpaddr13.get() != flash.0.pmpaddr()
+            || csr::CSR.pmpaddr14.get() != ram.0.pmpaddr()
+            || csr::CSR.pmpaddr15.get() != mmio.0.pmpaddr()
         {
             return Err(EarlGreyEPMPError::SanityCheckFail);
         }


### PR DESCRIPTION
### Pull Request Overview

This changes the TORRegionSpec and NAPOTRegionSpec struct's internal representation to store pre-generated `pmpaddrX` CSR values, which removes artificial restrictions to them covering only addresses in `[0; usize::MAX)` (that is, excluding address 2**XLEN - 1) due to the prior internal representation using an (addr, len) specification.

It retains the constructors---albeit renamed to clarify their semantics---to generate such a pmpaddr value from a size and address. It also adds a constructor to build a TORRegionSpec and NAPOTRegionSpec directly from a (pair of) raw pmpaddrX CSR values. These constructors still uphold the same invariants over these types, but need to perform less checks due to the nature of the `pmpaddrX` CSR encoding.

It removes the `addr` and `len` methods that these types previously had, as they now can return values out of range for the `usize` integer type. Convenience-methods to introspect the `RegionSpec` structs apart from retrieving the `pmpaddrX` CSR value may be re-added later, either with using a 64-bit integer type (which can hold all legal addresses and lengths even for 64-bit platforms), or alternative representations. This is not currently required.

The change also adds an additional convenience method to create a `NAPOTRegionSpec` from a pair of start and end addresses, removing pointer arithmetic in the board's initialization routines.


Additionally, RV64 platforms support only a 56 bit physical address space. For this reason (and because addresses in `pmpaddrX` CSRs are left-shifted by 2 bit) the uppermost 10 bits of a `pmpaddrX` CSR are defined as WARL-0. To avoid unexpected behavior when configuring the PMP with such violating addresses, a second commit introduces checks that any `pmpaddrX` values represented and encoded by TORRegionSpec or NAPOTRegionSpec instances maintain the above invariant.


Fixes #4333.

### Testing Strategy

This pull request needs testing.


### TODO or Help Wanted

I still want to write unit tests for this code.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
