### PR TITLE
chips/virtio/virtio_net: implement common EthernetAdapterDatapath HIL

### DIFF
--- a/boards/qemu_rv32_virt/src/main.rs
+++ b/boards/qemu_rv32_virt/src/main.rs
@@ -419,18 +419,10 @@ unsafe fn start() -> (
         // incoming packets into
         let rx_buffer = static_init!([u8; 1526], [0; 1526]);
 
-        // Instantiate the VirtIONet (NetworkCard) driver and set
-        // the queues
+        // Instantiate the VirtIONet (NetworkCard) driver and set the queues
         let virtio_net = static_init!(
             VirtIONet<'static>,
-            VirtIONet::new(
-                0,
-                tx_queue,
-                tx_header_buf,
-                rx_queue,
-                rx_header_buf,
-                rx_buffer,
-            ),
+            VirtIONet::new(tx_queue, tx_header_buf, rx_queue, rx_header_buf, rx_buffer),
         );
         tx_queue.set_client(virtio_net);
         rx_queue.set_client(virtio_net);


### PR DESCRIPTION
### Pull Request Overview

This changes the VirtIO NetworkDevice driver implementation to conform to Tock's new EthernetAdapterDatapath HIL. Most notably it changes how receive buffers are handled. Instead of handing out a `&'static mut`---and thus effectively owned---buffer, it hands out a short-lived reference to the buffer as part of the `frame_received` callback. It now also supports disabling packet reception.

### Testing Strategy

These changes stem mostly from the `tock-ethernet` branch, where they have been tested with the TAP ethernet driver. This PR adapts them slightly to the new, overhauled `EthernetAdapterDatapath` HIL, and those changes have not been tested.

We currently lack a client for this HIL, which will be ported over next. That effort will also include tests of this driver.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
