### PR TITLE
kernel/utilities/streaming_process_slice: fix off-by-one error

### DIFF
--- a/kernel/src/utilities/streaming_process_slice.rs
+++ b/kernel/src/utilities/streaming_process_slice.rs
@@ -138,7 +138,7 @@ impl<'a> StreamingProcessSlice<'a> {
     const RANGE_VERSION: Range<usize> = 0..2;
     const RANGE_FLAGS: Range<usize> = (Self::RANGE_VERSION.end)..(Self::RANGE_VERSION.end + 2);
     const RANGE_OFFSET: Range<usize> = (Self::RANGE_FLAGS.end)..(Self::RANGE_FLAGS.end + 4);
-    const RANGE_DATA: RangeFrom<usize> = (Self::RANGE_OFFSET.end + 1)..;
+    const RANGE_DATA: RangeFrom<usize> = (Self::RANGE_OFFSET.end)..;
 
     pub fn new(slice: &'a WriteableProcessSlice) -> StreamingProcessSlice<'a> {
         StreamingProcessSlice { slice }


### PR DESCRIPTION
### Pull Request Overview

The streaming process slice as added in #4208 would write data leaving a one-byte gap between the header and payload. This caused a mismatch between the kernel behavior and the documented interface or assumptions made in userspace respectively.


### Testing Strategy

This pull request was tested by porting the Ethernet tap driver to `StreamingProcessSlice`.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
