### PR TITLE
capsules/core/driver: rename "Radio" to "Networking", reserve "EthernetTap" syscall driver number

### DIFF
--- a/capsules/core/src/driver.rs
+++ b/capsules/core/src/driver.rs
@@ -43,6 +43,7 @@ pub enum NUM {
     LoRaPhyGPIO           = 0x30004,
     Thread                = 0x30005,
     Eui64                 = 0x30006,
+    EthernetTap           = 0x30007,
 
     // Cryptography
     Rng                   = 0x40001,

--- a/capsules/core/src/driver.rs
+++ b/capsules/core/src/driver.rs
@@ -35,7 +35,7 @@ pub enum NUM {
     I2cMasterSlave        = 0x20006,
     Can                   = 0x20007,
 
-    // Radio
+    // Networking
     BleAdvertising        = 0x30000,
     Ieee802154            = 0x30001,
     Udp                   = 0x30002,


### PR DESCRIPTION
### Pull Request Overview

This pull request renames the "Radio" section in the system call driver numbers file (`capsules/core/src/driver.rs`) to "Networking". This brings it in line with the syscall driver docs: https://github.com/tock/tock/tree/1dbe75e0443bfecc6c79895bfd8cbc4758ad08e4/doc/syscalls#networking (although a lot of drivers are still missing there).

It also reserves a driver number for the "EthernetTap" driver, to be merged into `tock-ethernet-staging` in #4342. This is to prevent me wasting yet another debugging session caused by driver numbers going out of sync when the tap driver is maintained in another branch.


### Testing Strategy

N/A


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
