### PR TITLE
chips/litex/liteeth: implement common EthernetAdapterDatapath HIL

### DIFF
--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -51,7 +51,11 @@ struct LiteXArtyInterruptablePeripherals {
         socc::SoCRegisterFmt,
         socc::ClockFrequency,
     >,
-    ethmac0: &'static litex_vexriscv::liteeth::LiteEth<'static, socc::SoCRegisterFmt>,
+    ethmac0: &'static litex_vexriscv::liteeth::LiteEth<
+        'static,
+        { socc::ETHMAC_TX_SLOTS },
+        socc::SoCRegisterFmt,
+    >,
 }
 
 impl LiteXArtyInterruptablePeripherals {
@@ -491,15 +495,9 @@ unsafe fn start() -> (
 
     // ---------- ETHERNET ----------
 
-    // TX packet metadata
-    let ethmac0_txinfo = static_init!(
-        [(usize, u16); socc::ETHMAC_TX_SLOTS],
-        [(0, 0); socc::ETHMAC_TX_SLOTS]
-    );
-
     // ETHMAC peripheral
     let ethmac0 = static_init!(
-        litex_vexriscv::liteeth::LiteEth<socc::SoCRegisterFmt>,
+        litex_vexriscv::liteeth::LiteEth<{socc::ETHMAC_TX_SLOTS}, socc::SoCRegisterFmt>,
         litex_vexriscv::liteeth::LiteEth::new(
             StaticRef::new(
                 socc::CSR_ETHMAC_BASE
@@ -510,7 +508,6 @@ unsafe fn start() -> (
             socc::ETHMAC_SLOT_SIZE,
             socc::ETHMAC_RX_SLOTS,
             socc::ETHMAC_TX_SLOTS,
-            ethmac0_txinfo,
         )
     );
 

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -491,8 +491,11 @@ unsafe fn start() -> (
 
     // ---------- ETHERNET ----------
 
-    // Packet receive buffer
-    let ethmac0_rxbuf0 = static_init!([u8; 1522], [0; 1522]);
+    // TX packet metadata
+    let ethmac0_txinfo = static_init!(
+        [(usize, u16); socc::ETHMAC_TX_SLOTS],
+        [(0, 0); socc::ETHMAC_TX_SLOTS]
+    );
 
     // ETHMAC peripheral
     let ethmac0 = static_init!(
@@ -507,7 +510,7 @@ unsafe fn start() -> (
             socc::ETHMAC_SLOT_SIZE,
             socc::ETHMAC_RX_SLOTS,
             socc::ETHMAC_TX_SLOTS,
-            ethmac0_rxbuf0,
+            ethmac0_txinfo,
         )
     );
 

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -51,7 +51,11 @@ struct LiteXSimInterruptablePeripherals {
         socc::SoCRegisterFmt,
         socc::ClockFrequency,
     >,
-    ethmac0: &'static litex_vexriscv::liteeth::LiteEth<'static, socc::SoCRegisterFmt>,
+    ethmac0: &'static litex_vexriscv::liteeth::LiteEth<
+        'static,
+        { socc::ETHMAC_TX_SLOTS },
+        socc::SoCRegisterFmt,
+    >,
 }
 
 impl LiteXSimInterruptablePeripherals {
@@ -470,15 +474,9 @@ unsafe fn start() -> (
 
     // ---------- ETHERNET ----------
 
-    // TX packet metadata
-    let ethmac0_txinfo = static_init!(
-        [(usize, u16); socc::ETHMAC_TX_SLOTS],
-        [(0, 0); socc::ETHMAC_TX_SLOTS]
-    );
-
     // ETHMAC peripheral
     let ethmac0 = static_init!(
-        litex_vexriscv::liteeth::LiteEth<socc::SoCRegisterFmt>,
+        litex_vexriscv::liteeth::LiteEth<{socc::ETHMAC_TX_SLOTS}, socc::SoCRegisterFmt>,
         litex_vexriscv::liteeth::LiteEth::new(
             StaticRef::new(
                 socc::CSR_ETHMAC_BASE
@@ -489,7 +487,6 @@ unsafe fn start() -> (
             socc::ETHMAC_SLOT_SIZE,
             socc::ETHMAC_RX_SLOTS,
             socc::ETHMAC_TX_SLOTS,
-            ethmac0_txinfo,
         )
     );
 

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -470,8 +470,11 @@ unsafe fn start() -> (
 
     // ---------- ETHERNET ----------
 
-    // Packet receive buffer
-    let ethmac0_rxbuf0 = static_init!([u8; 1522], [0; 1522]);
+    // TX packet metadata
+    let ethmac0_txinfo = static_init!(
+        [(usize, u16); socc::ETHMAC_TX_SLOTS],
+        [(0, 0); socc::ETHMAC_TX_SLOTS]
+    );
 
     // ETHMAC peripheral
     let ethmac0 = static_init!(
@@ -486,7 +489,7 @@ unsafe fn start() -> (
             socc::ETHMAC_SLOT_SIZE,
             socc::ETHMAC_RX_SLOTS,
             socc::ETHMAC_TX_SLOTS,
-            ethmac0_rxbuf0,
+            ethmac0_txinfo,
         )
     );
 

--- a/chips/litex/src/liteeth.rs
+++ b/chips/litex/src/liteeth.rs
@@ -4,8 +4,7 @@
 
 //! LiteX LiteEth peripheral
 //!
-//! The hardware source and any documentation can be found in the
-//! [LiteEth Git
+//! The hardware source and any documentation can be found in the [LiteEth Git
 //! repository](https://github.com/enjoy-digital/liteeth).
 
 use crate::event_manager::LiteXEventManager;
@@ -13,12 +12,13 @@ use crate::litex_registers::{LiteXSoCRegisterConfiguration, Read, Write};
 use core::cell::Cell;
 use core::slice;
 use kernel::debug;
+use kernel::hil::ethernet::{EthernetAdapterDatapath, EthernetAdapterDatapathClient};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 
-// Both events have the same index since they are located on different
-// event manager instances
+// Both events have the same index since they are located on different event
+// manager instances
 const LITEETH_TX_EVENT: usize = 0;
 const LITEETH_RX_EVENT: usize = 0;
 
@@ -46,8 +46,11 @@ pub struct LiteEthMacRegisters<R: LiteXSoCRegisterConfiguration> {
 
     /// ETHMAC_SRAM_READER_START
     tx_start: R::ReadWrite8,
+    /// ETHMAC_SRAM_READER_READY
     tx_ready: R::ReadOnly8,
+    /// ETHMAC_SRAM_READER_LEVEL
     tx_level: R::ReadOnly8,
+    /// ETHMAC_SRAM_READER_SLOT
     tx_slot: R::ReadWrite8,
     /// ETHMAC_SRAM_READER_LENGTH
     tx_length: R::ReadWrite16,
@@ -74,11 +77,6 @@ impl<R: LiteXSoCRegisterConfiguration> LiteEthMacRegisters<R> {
     }
 }
 
-pub trait LiteEthClient {
-    fn tx_done(&self, rc: Result<(), ErrorCode>, packet_buffer: &'static mut [u8]);
-    fn rx_packet(&self, packet: &'static mut [u8], len: usize);
-}
-
 pub struct LiteEth<'a, R: LiteXSoCRegisterConfiguration> {
     mac_regs: StaticRef<LiteEthMacRegisters<R>>,
     mac_memory_base: usize,
@@ -86,9 +84,9 @@ pub struct LiteEth<'a, R: LiteXSoCRegisterConfiguration> {
     slot_size: usize,
     rx_slots: usize,
     tx_slots: usize,
-    client: OptionalCell<&'a dyn LiteEthClient>,
-    tx_packet: TakeCell<'static, [u8]>,
-    rx_buffer: TakeCell<'static, [u8]>,
+    client: OptionalCell<&'a dyn EthernetAdapterDatapathClient>,
+    tx_frame: TakeCell<'static, [u8]>,
+    tx_frame_info: TakeCell<'static, [(usize, u16)]>,
     initialized: Cell<bool>,
 }
 
@@ -100,7 +98,7 @@ impl<'a, R: LiteXSoCRegisterConfiguration> LiteEth<'a, R> {
         slot_size: usize,
         rx_slots: usize,
         tx_slots: usize,
-        rx_buffer: &'static mut [u8],
+        tx_frame_info: &'static mut [(usize, u16)],
     ) -> LiteEth<'a, R> {
         LiteEth {
             mac_regs,
@@ -110,24 +108,19 @@ impl<'a, R: LiteXSoCRegisterConfiguration> LiteEth<'a, R> {
             rx_slots,
             tx_slots,
             client: OptionalCell::empty(),
-            tx_packet: TakeCell::empty(),
-            rx_buffer: TakeCell::new(rx_buffer),
+            tx_frame: TakeCell::empty(),
+            tx_frame_info: TakeCell::new(tx_frame_info),
             initialized: Cell::new(false),
         }
-    }
-
-    pub fn set_client(&self, client: &'a dyn LiteEthClient) {
-        self.client.set(client);
     }
 
     pub fn initialize(&self) {
         // Sanity check the memory parameters
         //
-        // Technically the constructor is unsafe as it will (over the
-        // lifetime of this struct) "cast" the raw mac_memory pointer
-        // (and slot offsets) into pointers and access them
-        // directly. However checking it at runtime once seems like a
-        // good idea.
+        // Technically the constructor is unsafe as it will (over the lifetime
+        // of this struct) "cast" the raw mac_memory pointer (and slot offsets)
+        // into pointers and access them directly. However checking it at
+        // runtime once seems like a good idea.
         assert!(
             (self.rx_slots + self.tx_slots) * self.slot_size <= self.mac_memory_len,
             "LiteEth: slots would exceed assigned MAC memory area"
@@ -136,15 +129,27 @@ impl<'a, R: LiteXSoCRegisterConfiguration> LiteEth<'a, R> {
         assert!(self.rx_slots > 0, "LiteEth: no RX slot");
         assert!(self.tx_slots > 0, "LiteEth: no TX slot");
 
-        // Clear any pending EV events
-        self.mac_regs.rx_ev().clear_event(LITEETH_RX_EVENT);
-        self.mac_regs.tx_ev().clear_event(LITEETH_TX_EVENT);
+        // Sanity check the length of the frame_info buffer, must be the same as
+        // the number of tx slots
+        assert!(
+            self.tx_frame_info.map(|i| i.len()).unwrap() == self.tx_slots,
+            "LiteEth: tx_frame_info.len() must be equal to tx_slots"
+        );
 
-        // Disable TX events (only enabled when a packet is sent)
+        // Disable TX events (first enabled when a frame is sent)
         self.mac_regs.tx_ev().disable_event(LITEETH_TX_EVENT);
 
-        // Enable RX events
-        self.mac_regs.rx_ev().enable_event(LITEETH_RX_EVENT);
+        // Clear all pending RX & TX events (there might be leftovers from the
+        // bootloader or a reboot, for which we don't want to generate an event)
+        //
+        // This is not sufficient to guarantee that all events will be cleared
+        // then. A frame could still be in reception or transmit.
+        while self.mac_regs.rx_ev().event_pending(LITEETH_RX_EVENT) {
+            self.mac_regs.rx_ev().clear_event(LITEETH_RX_EVENT);
+        }
+        while self.mac_regs.tx_ev().event_pending(LITEETH_TX_EVENT) {
+            self.mac_regs.tx_ev().clear_event(LITEETH_TX_EVENT);
+        }
 
         self.initialized.set(true);
     }
@@ -167,135 +172,155 @@ impl<'a, R: LiteXSoCRegisterConfiguration> LiteEth<'a, R> {
         ))
     }
 
-    pub fn return_rx_buffer(&self, rx_buffer: &'static mut [u8]) {
-        // Assert that we won't overwrite a buffer
-        assert!(
-            self.rx_buffer.is_none(),
-            "LiteEth: return RX buffer while one is registered"
-        );
+    fn rx_interrupt(&self) {
+        // Get the frame length
+        let pkt_len = self.mac_regs.rx_length.get();
 
-        // Put the buffer back
-        self.rx_buffer.replace(rx_buffer);
+        // Obtain the frame slot id
+        let slot_id: usize = self.mac_regs.rx_slot.get().into();
 
-        // In case we received a packet RX interrupt but couldn't
-        // handle it due to the missing buffer, reenable RX interrupts
+        // Obtain the frame reception timestamp. The `rx_timestamp` register is
+        // optional and disabled by default.
+        //
+        // let timestamp = self.mac_regs.rx_timestamp.get();
+
+        // Get the slot buffer reference
+        let slot = unsafe {
+            self.get_slot_buffer(false, slot_id)
+                .expect("LiteEth: invalid RX slot id")
+        };
+
+        // Give the client read-only access to the frame data
+        self.client
+            .map(|client| client.received_frame(&slot[..(pkt_len as usize)], None));
+
+        // Since all data is copied, acknowledge the interrupt so that the slot
+        // is ready for use again
+        self.mac_regs.rx_ev().clear_event(LITEETH_RX_EVENT);
+    }
+
+    fn tx_interrupt(&self) {
+        // Store information about the frame that has been sent (from the return
+        // channel). Uncomment the below lines if hardware timestamping is
+        // enabled and frame TX timestamps are supposed to be recorded.
+        //
+        // let res_slot = self.mac_regs.tx_timestamp_slot.get();
+        // let res_timestamp = self.mac_regs.tx_timestamp.get();
+
+        // Acknowledge the event, removing the tx_res fields from the FIFO
+        self.mac_regs.tx_ev().clear_event(LITEETH_TX_EVENT);
+
+        if self.tx_frame.is_none() {
+            debug!("LiteEth: tx interrupt called without tx_frame set");
+        }
+
+        // We use only one slot, so this event is unambiguous
+        let frame = self
+            .tx_frame
+            .take()
+            .expect("LiteEth: TakeCell empty in tx callback");
+
+        // Retrieve the previously stored frame information for this slot.
+        let slot_id = 0; // currently only use one TX slot
+        let (frame_identifier, len) = self
+            .tx_frame_info
+            .map(|pkt_info| pkt_info[slot_id])
+            .unwrap();
+
+        self.client.map(move |client| {
+            client.transmit_frame_done(Ok(()), frame, len, frame_identifier, None)
+        });
+    }
+
+    pub fn service_interrupt(&self) {
+        // The interrupt could've been generated by both a frame being received
+        // or finished transmitting. Check and handle both cases.
+
+        while self.mac_regs.tx_ev().event_asserted(LITEETH_TX_EVENT) {
+            self.tx_interrupt();
+        }
+
+        // `event_asserted` checks that the event is both pending _and_ enabled
+        // (raising a CPU interrupt). This means that reception is enabled, and
+        // we must handle it:
+        while self.mac_regs.rx_ev().event_asserted(LITEETH_RX_EVENT) {
+            self.rx_interrupt();
+        }
+    }
+}
+
+impl<'a, R: LiteXSoCRegisterConfiguration> EthernetAdapterDatapath<'a> for LiteEth<'a, R> {
+    fn set_client(&self, client: &'a dyn EthernetAdapterDatapathClient) {
+        self.client.set(client);
+    }
+
+    fn enable_receive(&self) {
+        // Enable RX event interrupts:
+        if !self.initialized.get() {
+            panic!("LiteEth: cannot enable_receive without prior initialization!");
+        }
+
         self.mac_regs.rx_ev().enable_event(LITEETH_RX_EVENT);
     }
 
-    fn rx_interrupt(&self) {
-        // Check whether we have a buffer to read the packet into. If
-        // not, we must disable, but not clear the event and enable it
-        // again as soon as we get the buffer back from the client
-        if self.rx_buffer.is_none() {
-            self.mac_regs.rx_ev().disable_event(LITEETH_RX_EVENT);
-        } else {
-            // Get the buffer first to be able to check the length
-            let rx_buffer = self.rx_buffer.take().unwrap();
-
-            // Get the frame length. If it exceeds the length of the
-            // rx_buffer, discard the packet, put the buffer back
-            let pkt_len = self.mac_regs.rx_length.get() as usize;
-            if pkt_len > rx_buffer.len() {
-                debug!("LiteEth: discarding ethernet packet with len {}", pkt_len);
-
-                // Acknowledge the interrupt so that the HW may use the slot again
-                self.mac_regs.rx_ev().clear_event(LITEETH_RX_EVENT);
-
-                // Replace the buffer
-                self.rx_buffer.replace(rx_buffer);
-            } else {
-                // Obtain the packet slot id
-                let slot_id: usize = self.mac_regs.rx_slot.get().into();
-
-                // Get the slot buffer reference
-                let slot = unsafe {
-                    self.get_slot_buffer(false, slot_id).unwrap() // Unwrap fail = LiteEth: invalid RX slot id
-                };
-
-                // Copy the packet into the buffer
-                rx_buffer[..pkt_len].copy_from_slice(&slot[..pkt_len]);
-
-                // Since all data is copied, acknowledge the interrupt
-                // so that the slot is ready for use again
-                self.mac_regs.rx_ev().clear_event(LITEETH_RX_EVENT);
-
-                self.client
-                    .map(move |client| client.rx_packet(rx_buffer, pkt_len));
-            }
-        }
+    fn disable_receive(&self) {
+        // Disable RX event interrupts:
+        self.mac_regs.rx_ev().disable_event(LITEETH_RX_EVENT);
     }
 
-    /// Transmit an ethernet packet over the interface
+    /// Transmit an Ethernet frame over the interface
     ///
-    /// For now this will only use a single slot on the interface and
-    /// is therefore blocking. A client must wait until a callback to
-    /// `tx_done` prior to sending a new packet.
-    pub fn transmit(
+    /// For now this will only use a single slot on the interface and is
+    /// therefore blocking. A client must wait until a callback to `tx_done`
+    /// prior to sending a new frame.
+    fn transmit_frame(
         &self,
-        packet: &'static mut [u8],
-        len: usize,
-    ) -> Result<(), (Result<(), ErrorCode>, &'static mut [u8])> {
-        if packet.len() < len || len > u16::MAX as usize {
-            return Err((Err(ErrorCode::INVAL), packet));
+        frame: &'static mut [u8],
+        len: u16,
+        frame_identifier: usize,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+        if frame.len() < (len as usize) {
+            return Err((ErrorCode::INVAL, frame));
         }
 
-        if self.tx_packet.is_some() {
-            return Err((Err(ErrorCode::BUSY), packet));
+        if self.tx_frame.is_some() {
+            return Err((ErrorCode::BUSY, frame));
         }
 
-        let slot = unsafe { self.get_slot_buffer(true, 0) }.unwrap(); // Unwrap fail = LiteEth: no TX slot
-        if slot.len() < len {
-            return Err((Err(ErrorCode::SIZE), packet));
+        // For now, we always use slot 0
+        let slot_id = 0;
+
+        let slot = unsafe { self.get_slot_buffer(true, slot_id) }.expect("LiteEth: no TX slot");
+        if slot.len() < (len as usize) {
+            return Err((ErrorCode::SIZE, frame));
         }
 
-        // Copy the packet into the slot HW buffer
-        slot[..len].copy_from_slice(&packet[..len]);
+        // Set the slot's frame information
+        self.tx_frame_info
+            .map(|pkt_info| {
+                pkt_info[slot_id as usize] = (frame_identifier, len);
+            })
+            .unwrap();
 
-        // Put the currently transmitting packet into the designated
-        // TakeCell
-        self.tx_packet.replace(packet);
+        // Copy the frame into the slot HW buffer
+        slot[..(len as usize)].copy_from_slice(&frame[..(len as usize)]);
 
-        // Set the slot and packet length
+        // Put the currently transmitting frame into the designated TakeCell
+        self.tx_frame.replace(frame);
+
+        // Set the slot and frame length
         self.mac_regs.tx_slot.set(0);
-        self.mac_regs.tx_length.set(len as u16);
+        self.mac_regs.tx_length.set(len);
 
         // Wait for the device to be ready to transmit
         while self.mac_regs.tx_ready.get() == 0 {}
 
-        // Enable TX interrupts
+        // Enable TX events
         self.mac_regs.tx_ev().enable_event(LITEETH_TX_EVENT);
 
         // Start the transmission
         self.mac_regs.tx_start.set(1);
 
         Ok(())
-    }
-
-    fn tx_interrupt(&self) {
-        // Deassert the interrupt, but can be left enabled
-        self.mac_regs.tx_ev().clear_event(LITEETH_TX_EVENT);
-
-        if self.tx_packet.is_none() {
-            debug!("LiteEth: tx interrupt called without tx_packet set");
-        }
-
-        // We use only one slot, so this event is unambiguous
-        let packet = self.tx_packet.take().unwrap(); // Unwrap fail = LiteEth: TakeCell empty in tx callback
-        self.client
-            .map(move |client| client.tx_done(Ok(()), packet));
-    }
-
-    pub fn service_interrupt(&self) {
-        // The interrupt could've been generated by both a packet
-        // being received or finished transmitting. Check and handle
-        // both cases
-
-        if self.mac_regs.rx_ev().event_asserted(LITEETH_RX_EVENT) {
-            self.rx_interrupt();
-        }
-
-        if self.mac_regs.tx_ev().event_asserted(LITEETH_TX_EVENT) {
-            self.tx_interrupt();
-        }
     }
 }

--- a/chips/litex/src/liteeth.rs
+++ b/chips/litex/src/liteeth.rs
@@ -90,7 +90,7 @@ pub struct LiteEth<'a, const MAX_TX_SLOTS: usize, R: LiteXSoCRegisterConfigurati
     initialized: Cell<bool>,
 }
 
-impl<'a, const MAX_TX_SLOTS: usize, R: LiteXSoCRegisterConfiguration> LiteEth<'a, MAX_TX_SLOTS, R> {
+impl<const MAX_TX_SLOTS: usize, R: LiteXSoCRegisterConfiguration> LiteEth<'_, MAX_TX_SLOTS, R> {
     pub unsafe fn new(
         mac_regs: StaticRef<LiteEthMacRegisters<R>>,
         mac_memory_base: usize,
@@ -301,7 +301,7 @@ impl<'a, const MAX_TX_SLOTS: usize, R: LiteXSoCRegisterConfiguration> EthernetAd
         // Set the slot's frame information
         self.tx_frame_info
             .map(|pkt_info| {
-                pkt_info[slot_id as usize] = (frame_identifier, len);
+                pkt_info[slot_id] = (frame_identifier, len);
             })
             .unwrap();
 


### PR DESCRIPTION
### Pull Request Overview

This changes the LiteX LiteEth driver implementation to conform to Tock's new EthernetAdapterDatapath HIL.

It also changes the `tx_info_buf` buffer to be owned by the driver, instead of being a `&'static mut` reference that needs to be initialized externally. This is done by adding a const generic indicating the maximum number of supported TX slots for the hardware.


### Testing Strategy

This PR will be tested once the EthernetTapDriver from #4342 is integrated with it.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
