### PR TITLE
RISCV: Allow extended values of interrupt IDs in MCAUSE

### DIFF
--- a/arch/riscv/src/csr/mcause.rs
+++ b/arch/riscv/src/csr/mcause.rs
@@ -12,10 +12,10 @@ register_bitfields![usize,
     // Per the spec, implementations are allowed to use the higher bits of the
     // interrupt/exception reason for their own purposes.  For regular parsing,
     // we only concern ourselves with the "standard" values.
-    reason [
+    /*reason [
         reserved OFFSET(4) NUMBITS(crate::XLEN - 5) [],
         std OFFSET(0) NUMBITS(4) []
-    ]
+    ] */
 ];
 
 /// Trap Cause
@@ -53,7 +53,7 @@ pub enum Interrupt {
     UserExternal,
     SupervisorExternal,
     MachineExternal,
-    Unknown,
+    Unknown(usize),
 }
 
 /// Exception
@@ -78,8 +78,8 @@ pub enum Exception {
 
 impl Interrupt {
     fn from_reason(val: usize) -> Self {
-        let reason = LocalRegisterCopy::<usize, reason::Register>::new(val);
-        match reason.read(reason::std) {
+        let mcause = LocalRegisterCopy::<usize, mcause::Register>::new(val);
+        match mcause.read(mcause::reason) {
             0 => Interrupt::UserSoft,
             1 => Interrupt::SupervisorSoft,
             3 => Interrupt::MachineSoft,
@@ -89,15 +89,15 @@ impl Interrupt {
             8 => Interrupt::UserExternal,
             9 => Interrupt::SupervisorExternal,
             11 => Interrupt::MachineExternal,
-            _ => Interrupt::Unknown,
+            val => Interrupt::Unknown(val),
         }
     }
 }
 
 impl Exception {
     fn from_reason(val: usize) -> Self {
-        let reason = LocalRegisterCopy::<usize, reason::Register>::new(val);
-        match reason.read(reason::std) {
+        let mcause = LocalRegisterCopy::<usize, mcause::Register>::new(val);
+        match mcause.read(mcause::reason) {
             0 => Exception::InstructionMisaligned,
             1 => Exception::InstructionFault,
             2 => Exception::IllegalInstruction,

--- a/arch/riscv/src/csr/mcause.rs
+++ b/arch/riscv/src/csr/mcause.rs
@@ -9,13 +9,6 @@ register_bitfields![usize,
         is_interrupt OFFSET(crate::XLEN - 1) NUMBITS(1) [],
         reason OFFSET(0) NUMBITS(crate::XLEN - 1) []
     ],
-    // Per the spec, implementations are allowed to use the higher bits of the
-    // interrupt/exception reason for their own purposes.  For regular parsing,
-    // we only concern ourselves with the "standard" values.
-    /*reason [
-        reserved OFFSET(4) NUMBITS(crate::XLEN - 5) [],
-        std OFFSET(0) NUMBITS(4) []
-    ] */
 ];
 
 /// Trap Cause

--- a/arch/rv32i/src/lib.rs
+++ b/arch/rv32i/src/lib.rs
@@ -454,7 +454,7 @@ pub unsafe fn print_mcause(mcval: csr::mcause::Trap, writer: &mut dyn Write) {
             csr::mcause::Interrupt::MachineExternal => {
                 let _ = writer.write_fmt(format_args!("Machine external interrupt"));
             }
-            csr::mcause::Interrupt::Unknown => {
+            csr::mcause::Interrupt::Unknown(_) => {
                 let _ = writer.write_fmt(format_args!("Reserved/Unknown"));
             }
         },

--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -245,7 +245,7 @@ unsafe fn handle_interrupt(intr: mcause::Interrupt) {
             }
         }
 
-        mcause::Interrupt::Unknown => {
+        mcause::Interrupt::Unknown(_) => {
             panic!("interrupt of unknown cause");
         }
     }

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -390,7 +390,7 @@ unsafe fn handle_interrupt(intr: mcause::Interrupt) {
             }
         }
 
-        mcause::Interrupt::Unknown => {
+        mcause::Interrupt::Unknown(_) => {
             panic!("interrupt of unknown cause");
         }
     }

--- a/chips/litex_vexriscv/src/chip.rs
+++ b/chips/litex_vexriscv/src/chip.rs
@@ -166,7 +166,7 @@ unsafe fn handle_interrupt(intr: mcause::Interrupt) {
             }
         }
 
-        mcause::Interrupt::Unknown => {
+        mcause::Interrupt::Unknown(_) => {
             debug!("interrupt of unknown cause");
         }
     }

--- a/chips/qemu_rv32_virt_chip/src/chip.rs
+++ b/chips/qemu_rv32_virt_chip/src/chip.rs
@@ -245,7 +245,7 @@ unsafe fn handle_interrupt(intr: mcause::Interrupt) {
             }
         }
 
-        mcause::Interrupt::Unknown => {
+        mcause::Interrupt::Unknown(_) => {
             panic!("interrupt of unknown cause");
         }
     }

--- a/chips/veer_el2/src/chip.rs
+++ b/chips/veer_el2/src/chip.rs
@@ -215,7 +215,7 @@ unsafe fn handle_interrupt(intr: mcause::Interrupt) {
             }
         }
 
-        mcause::Interrupt::Unknown => {
+        mcause::Interrupt::Unknown(_) => {
             panic!("interrupt of unknown cause");
         }
     }


### PR DESCRIPTION
Fixes #4352


### Pull Request Overview

The `mcause.EXCCODE` might contain values > 15 for specific implementations. These should be supported. The previous implementation only considered 4 bits of the code, misinterpreting any value >15.

This PR removes this limitation and allows passing the exact `macause.EXCCODE` value to the interrupt handler wrapped in `Interrupt::Unknown(_)` variant instead of just passing field-less `Interrupt::Unknown`.


### Testing Strategy

Tested on local simulated RISCV environment
Tested build only on affected RiscV board crates


### Help Wanted

Test on physical boards affected
