### PR TITLE
kernel: add conversions utility and `usize32_to_usize`

### DIFF
--- a/kernel/src/utilities/conversions.rs
+++ b/kernel/src/utilities/conversions.rs
@@ -7,6 +7,12 @@
 /// Helper function to convert create a full usize value from two 32-bit usize
 /// values.
 ///
+/// In C this would look like:
+///
+/// ```c
+/// size_t v = (hi << 32) | (uint32_t) lo;
+/// ```
+///
 /// This is useful when passing a machine-sized value (i.e. a `size_t`) via the
 /// system call interface in two 32-bit usize values. On a 32-bit machine this
 /// essentially has no effect; the full value is stored in the `lo` usize. On a

--- a/kernel/src/utilities/conversions.rs
+++ b/kernel/src/utilities/conversions.rs
@@ -1,0 +1,31 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+//! Helper functions for converting values and data types.
+
+/// Helper function to convert create a full usize value from two 32-bit usize
+/// values.
+///
+/// This is useful when passing a machine-sized value (i.e. a `size_t`) via the
+/// system call interface in two 32-bit usize values. On a 32-bit machine this
+/// essentially has no effect; the full value is stored in the `lo` usize. On a
+/// 64-bit machine, this creates a usize by concatenating the hi and lo 32-bit
+/// values.
+///
+/// TODO
+/// ----
+///
+/// This can be more succinctly implemented using
+/// [`unbounded_shl()`](https://doc.rust-lang.org/stable/std/primitive.usize.html#method.unbounded_shl).
+/// However, that method is currently a nightly-only feature.
+#[inline]
+pub fn usize32_to_usize(lo: usize, hi: usize) -> usize {
+    if usize::BITS <= 32 {
+        // Just return the lo value since it has the bits we need.
+        lo
+    } else {
+        // Create a 64-bit value.
+        (lo & 0xFFFFFFFF) | (hi << 32)
+    }
+}

--- a/kernel/src/utilities/conversions.rs
+++ b/kernel/src/utilities/conversions.rs
@@ -20,7 +20,7 @@
 /// [`unbounded_shl()`](https://doc.rust-lang.org/stable/std/primitive.usize.html#method.unbounded_shl).
 /// However, that method is currently a nightly-only feature.
 #[inline]
-pub fn usize32_to_usize(lo: usize, hi: usize) -> usize {
+pub const fn usize32_to_usize(lo: usize, hi: usize) -> usize {
     if usize::BITS <= 32 {
         // Just return the lo value since it has the bits we need.
         lo

--- a/kernel/src/utilities/mod.rs
+++ b/kernel/src/utilities/mod.rs
@@ -7,6 +7,7 @@
 pub mod arch_helpers;
 pub mod binary_write;
 pub mod capability_ptr;
+pub mod conversions;
 pub mod copy_slice;
 pub mod helpers;
 pub mod leasable_buffer;


### PR DESCRIPTION
Useful for converting data types.

### Pull Request Overview

This is a helper function for creating one `usize` from two 32-bit values stored in two usizes. On 32 bit platforms this does nothing. On 64-bit platforms this would assemble a 64-bit value (stored in a usize).

This is useful for implementing capsules that work on both 32 and 64-bit platforms.

Just doing `let out = hi << 32 | lo` doesn't work on 32 bit platforms in Rust.

### Testing Strategy

I'm using this in the isolated nonvolatile storage.


### TODO or Help Wanted

Does the description make sense?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
