### PR TITLE
HIL: uart: Add associated type for baud rate

### DIFF
--- a/boards/components/src/debug_writer.rs
+++ b/boards/components/src/debug_writer.rs
@@ -29,7 +29,6 @@ use kernel::collections::ring_buffer::RingBuffer;
 use kernel::component::Component;
 use kernel::hil;
 use kernel::hil::uart;
-use kernel::hil::uart::BaudRate;
 
 // The sum of the output_buf and internal_buf is set to a multiple of 1024 bytes in order to avoid excessive
 // padding between kernel memory and application memory (which often needs to be aligned to at
@@ -185,7 +184,7 @@ impl<U: uart::Uart<'static> + uart::Transmit<'static> + 'static, const BUF_SIZE_
         }
 
         let _ = self.uart.configure(uart::Parameters {
-            baud_rate: U::BaudRate::from_nonzero(115200),
+            baud_rate: core::num::NonZeroU32::new(115200).unwrap().into(),
             width: uart::Width::Eight,
             stop_bits: uart::StopBits::One,
             parity: uart::Parity::None,

--- a/boards/components/src/nrf51822.rs
+++ b/boards/components/src/nrf51822.rs
@@ -72,11 +72,11 @@ impl<U: 'static + hil::uart::UartAdvanced<'static>, G: 'static + hil::gpio::Pin>
     for Nrf51822Component<U, G>
 {
     type StaticInput = (
-        &'static mut MaybeUninit<Nrf51822Serialization<'static>>,
+        &'static mut MaybeUninit<Nrf51822Serialization<'static, U>>,
         &'static mut MaybeUninit<[u8; capsules_extra::nrf51822_serialization::WRITE_BUF_LEN]>,
         &'static mut MaybeUninit<[u8; capsules_extra::nrf51822_serialization::READ_BUF_LEN]>,
     );
-    type Output = &'static Nrf51822Serialization<'static>;
+    type Output = &'static Nrf51822Serialization<'static, U>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -39,7 +39,7 @@ impl IoWrite for Writer {
                 if !*initialized {
                     *initialized = true;
                     let _ = uart.configure(uart::Parameters {
-                        baud_rate: 115200,
+                        baud_rate: nrf52840::uart::UarteBaudRate::Baud115200,
                         stop_bits: uart::StopBits::One,
                         parity: uart::Parity::None,
                         hw_flow_control: false,

--- a/boards/nordic/nrf52_components/src/lib.rs
+++ b/boards/nordic/nrf52_components/src/lib.rs
@@ -6,6 +6,4 @@
 
 pub mod startup;
 
-pub use self::startup::{
-    NrfClockComponent, NrfStartupComponent, UartChannel, UartChannelComponent, UartPins,
-};
+pub use self::startup::{NrfClockComponent, NrfStartupComponent, UartChannel, UartPins};

--- a/boards/nordic/nrf52_components/src/startup.rs
+++ b/boards/nordic/nrf52_components/src/startup.rs
@@ -185,54 +185,54 @@ pub enum UartChannel<'a> {
     Rtt(components::segger_rtt::SeggerRttMemoryRefs<'a>),
 }
 
-pub struct UartChannelComponent {
-    uart_channel: UartChannel<'static>,
-    mux_alarm: &'static MuxAlarm<'static, nrf52::rtc::Rtc<'static>>,
-    uarte0: &'static nrf52::uart::Uarte<'static>,
-}
+// pub struct UartChannelComponent {
+//     uart_channel: UartChannel<'static>,
+//     mux_alarm: &'static MuxAlarm<'static, nrf52::rtc::Rtc<'static>>,
+//     uarte0: &'static nrf52::uart::Uarte<'static>,
+// }
 
-impl UartChannelComponent {
-    pub fn new(
-        uart_channel: UartChannel<'static>,
-        mux_alarm: &'static MuxAlarm<'static, nrf52::rtc::Rtc<'static>>,
-        uarte0: &'static nrf52::uart::Uarte<'static>,
-    ) -> Self {
-        Self {
-            uart_channel,
-            mux_alarm,
-            uarte0,
-        }
-    }
-}
+// impl UartChannelComponent {
+//     pub fn new(
+//         uart_channel: UartChannel<'static>,
+//         mux_alarm: &'static MuxAlarm<'static, nrf52::rtc::Rtc<'static>>,
+//         uarte0: &'static nrf52::uart::Uarte<'static>,
+//     ) -> Self {
+//         Self {
+//             uart_channel,
+//             mux_alarm,
+//             uarte0,
+//         }
+//     }
+// }
 
-impl Component for UartChannelComponent {
-    type StaticInput = (
-        &'static mut MaybeUninit<VirtualMuxAlarm<'static, nrf52::rtc::Rtc<'static>>>,
-        &'static mut MaybeUninit<
-            SeggerRtt<'static, VirtualMuxAlarm<'static, nrf52::rtc::Rtc<'static>>>,
-        >,
-    );
-    type Output = &'static dyn kernel::hil::uart::Uart<'static>;
+// impl Component for UartChannelComponent {
+//     type StaticInput = (
+//         &'static mut MaybeUninit<VirtualMuxAlarm<'static, nrf52::rtc::Rtc<'static>>>,
+//         &'static mut MaybeUninit<
+//             SeggerRtt<'static, VirtualMuxAlarm<'static, nrf52::rtc::Rtc<'static>>>,
+//         >,
+//     );
+//     type Output = &'static dyn kernel::hil::uart::Uart<'static>;
 
-    fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        match self.uart_channel {
-            UartChannel::Pins(uart_pins) => {
-                unsafe {
-                    self.uarte0.initialize(
-                        nrf52::pinmux::Pinmux::new(uart_pins.txd as u32),
-                        nrf52::pinmux::Pinmux::new(uart_pins.rxd as u32),
-                        uart_pins.cts.map(|x| nrf52::pinmux::Pinmux::new(x as u32)),
-                        uart_pins.rts.map(|x| nrf52::pinmux::Pinmux::new(x as u32)),
-                    )
-                };
-                self.uarte0
-            }
-            UartChannel::Rtt(rtt_memory) => {
-                let rtt =
-                    components::segger_rtt::SeggerRttComponent::new(self.mux_alarm, rtt_memory)
-                        .finalize(s);
-                rtt
-            }
-        }
-    }
-}
+//     fn finalize(self, s: Self::StaticInput) -> Self::Output {
+//         match self.uart_channel {
+//             UartChannel::Pins(uart_pins) => {
+//                 unsafe {
+//                     self.uarte0.initialize(
+//                         nrf52::pinmux::Pinmux::new(uart_pins.txd as u32),
+//                         nrf52::pinmux::Pinmux::new(uart_pins.rxd as u32),
+//                         uart_pins.cts.map(|x| nrf52::pinmux::Pinmux::new(x as u32)),
+//                         uart_pins.rts.map(|x| nrf52::pinmux::Pinmux::new(x as u32)),
+//                     )
+//                 };
+//                 self.uarte0
+//             }
+//             UartChannel::Rtt(rtt_memory) => {
+//                 let rtt =
+//                     components::segger_rtt::SeggerRttComponent::new(self.mux_alarm, rtt_memory)
+//                         .finalize(s);
+//                 rtt
+//             }
+//         }
+//     }
+// }

--- a/capsules/core/src/test/virtual_uart.rs
+++ b/capsules/core/src/test/virtual_uart.rs
@@ -12,14 +12,14 @@ use kernel::hil::uart::Receive;
 use kernel::utilities::cells::TakeCell;
 use kernel::ErrorCode;
 
-pub struct TestVirtualUartReceive {
-    device: &'static UartDevice<'static>,
+pub struct TestVirtualUartReceive<U: uart::Uart<'static> + 'static> {
+    device: &'static UartDevice<'static, U>,
     buffer: TakeCell<'static, [u8]>,
 }
 
-impl TestVirtualUartReceive {
-    pub fn new(device: &'static UartDevice<'static>, buffer: &'static mut [u8]) -> Self {
-        TestVirtualUartReceive {
+impl<U: uart::Uart<'static> + 'static> TestVirtualUartReceive<U> {
+    pub fn new(device: &'static UartDevice<'static, U>, buffer: &'static mut [u8]) -> Self {
+        Self {
             device,
             buffer: TakeCell::new(buffer),
         }
@@ -35,7 +35,7 @@ impl TestVirtualUartReceive {
     }
 }
 
-impl uart::ReceiveClient for TestVirtualUartReceive {
+impl<U: uart::Uart<'static> + 'static> uart::ReceiveClient for TestVirtualUartReceive<U> {
     fn received_buffer(
         &self,
         rx_buffer: &'static mut [u8],

--- a/capsules/extra/src/nrf51822_serialization.rs
+++ b/capsules/extra/src/nrf51822_serialization.rs
@@ -29,7 +29,6 @@ use core::cmp;
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::hil;
 use kernel::hil::uart;
-use kernel::hil::uart::BaudRate;
 use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
@@ -119,7 +118,7 @@ impl<'a, U: uart::UartAdvanced<'a>> Nrf51822Serialization<'a, U> {
 
     pub fn initialize(&self) {
         let _ = self.uart.configure(uart::Parameters {
-            baud_rate: U::BaudRate::from_nonzero(250000),
+            baud_rate: core::num::NonZeroU32::new(250000).unwrap().into(),
             width: uart::Width::Eight,
             stop_bits: uart::StopBits::One,
             parity: uart::Parity::Even,

--- a/capsules/extra/src/usb/cdc.rs
+++ b/capsules/extra/src/usb/cdc.rs
@@ -651,7 +651,7 @@ impl<'a, U: hil::usb::UsbController<'a>, A: 'a + Alarm<'a>> hil::usb::Client<'a>
 }
 
 impl<'a, U: hil::usb::UsbController<'a>, A: 'a + Alarm<'a>> uart::Configure for CdcAcm<'a, U, A> {
-    type BaudRate = ();
+    type BaudRate = uart::NonexistentBaudRate;
 
     fn configure(&self, _parameters: uart::Parameters<Self::BaudRate>) -> Result<(), ErrorCode> {
         // Since this is not a real UART, we don't need to consider these

--- a/capsules/extra/src/usb/cdc.rs
+++ b/capsules/extra/src/usb/cdc.rs
@@ -651,7 +651,9 @@ impl<'a, U: hil::usb::UsbController<'a>, A: 'a + Alarm<'a>> hil::usb::Client<'a>
 }
 
 impl<'a, U: hil::usb::UsbController<'a>, A: 'a + Alarm<'a>> uart::Configure for CdcAcm<'a, U, A> {
-    fn configure(&self, _parameters: uart::Parameters) -> Result<(), ErrorCode> {
+    type BaudRate = ();
+
+    fn configure(&self, _parameters: uart::Parameters<Self::BaudRate>) -> Result<(), ErrorCode> {
         // Since this is not a real UART, we don't need to consider these
         // parameters.
         Ok(())

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -179,9 +179,9 @@ pub enum UarteBaudRate {
     Baud1000000,
 }
 
-impl uart::BaudRate for UarteBaudRate {
-    fn from_nonzero(baud_rate: u32) -> Self {
-        match baud_rate {
+impl From<core::num::NonZeroU32> for UarteBaudRate {
+    fn from(baud_rate: core::num::NonZeroU32) -> Self {
+        match baud_rate.get() {
             1200 => UarteBaudRate::Baud1200,
             2400 => UarteBaudRate::Baud2400,
             4800 => UarteBaudRate::Baud4800,

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -159,6 +159,50 @@ register_bitfields! [u32,
     ]
 ];
 
+#[derive(Copy, Clone)]
+pub enum UarteBaudRate {
+    Baud1200,
+    Baud2400,
+    Baud4800,
+    Baud9600,
+    Baud14400,
+    Baud19200,
+    Baud28800,
+    Baud38400,
+    Baud57600,
+    Baud76800,
+    Baud115200,
+    Baud230400,
+    Baud250000,
+    Baud460800,
+    Baud921600,
+    Baud1000000,
+}
+
+impl uart::BaudRate for UarteBaudRate {
+    fn from_nonzero(baud_rate: u32) -> Self {
+        match baud_rate {
+            1200 => UarteBaudRate::Baud1200,
+            2400 => UarteBaudRate::Baud2400,
+            4800 => UarteBaudRate::Baud4800,
+            9600 => UarteBaudRate::Baud9600,
+            14400 => UarteBaudRate::Baud14400,
+            19200 => UarteBaudRate::Baud19200,
+            28800 => UarteBaudRate::Baud28800,
+            38400 => UarteBaudRate::Baud38400,
+            57600 => UarteBaudRate::Baud57600,
+            76800 => UarteBaudRate::Baud76800,
+            115200 => UarteBaudRate::Baud115200,
+            230400 => UarteBaudRate::Baud230400,
+            250000 => UarteBaudRate::Baud250000,
+            460800 => UarteBaudRate::Baud460800,
+            921600 => UarteBaudRate::Baud921600,
+            1000000 => UarteBaudRate::Baud1000000,
+            _ => UarteBaudRate::Baud115200,
+        }
+    }
+}
+
 /// UARTE
 // It should never be instanced outside this module but because a static mutable reference to it
 // is exported outside this module it must be `pub`
@@ -239,25 +283,24 @@ impl<'a> Uarte<'a> {
         self.enable_uart();
     }
 
-    fn set_baud_rate(&self, baud_rate: u32) {
+    fn set_baud_rate(&self, baud_rate: UarteBaudRate) {
         match baud_rate {
-            1200 => self.registers.baudrate.set(0x0004F000),
-            2400 => self.registers.baudrate.set(0x0009D000),
-            4800 => self.registers.baudrate.set(0x0013B000),
-            9600 => self.registers.baudrate.set(0x00275000),
-            14400 => self.registers.baudrate.set(0x003AF000),
-            19200 => self.registers.baudrate.set(0x004EA000),
-            28800 => self.registers.baudrate.set(0x0075C000),
-            38400 => self.registers.baudrate.set(0x009D0000),
-            57600 => self.registers.baudrate.set(0x00EB0000),
-            76800 => self.registers.baudrate.set(0x013A9000),
-            115200 => self.registers.baudrate.set(0x01D60000),
-            230400 => self.registers.baudrate.set(0x03B00000),
-            250000 => self.registers.baudrate.set(0x04000000),
-            460800 => self.registers.baudrate.set(0x07400000),
-            921600 => self.registers.baudrate.set(0x0F000000),
-            1000000 => self.registers.baudrate.set(0x10000000),
-            _ => self.registers.baudrate.set(0x01D60000), //setting default to 115200
+            UarteBaudRate::Baud1200 => self.registers.baudrate.set(0x0004F000),
+            UarteBaudRate::Baud2400 => self.registers.baudrate.set(0x0009D000),
+            UarteBaudRate::Baud4800 => self.registers.baudrate.set(0x0013B000),
+            UarteBaudRate::Baud9600 => self.registers.baudrate.set(0x00275000),
+            UarteBaudRate::Baud14400 => self.registers.baudrate.set(0x003AF000),
+            UarteBaudRate::Baud19200 => self.registers.baudrate.set(0x004EA000),
+            UarteBaudRate::Baud28800 => self.registers.baudrate.set(0x0075C000),
+            UarteBaudRate::Baud38400 => self.registers.baudrate.set(0x009D0000),
+            UarteBaudRate::Baud57600 => self.registers.baudrate.set(0x00EB0000),
+            UarteBaudRate::Baud76800 => self.registers.baudrate.set(0x013A9000),
+            UarteBaudRate::Baud115200 => self.registers.baudrate.set(0x01D60000),
+            UarteBaudRate::Baud230400 => self.registers.baudrate.set(0x03B00000),
+            UarteBaudRate::Baud250000 => self.registers.baudrate.set(0x04000000),
+            UarteBaudRate::Baud460800 => self.registers.baudrate.set(0x07400000),
+            UarteBaudRate::Baud921600 => self.registers.baudrate.set(0x0F000000),
+            UarteBaudRate::Baud1000000 => self.registers.baudrate.set(0x10000000),
         }
     }
 
@@ -469,7 +512,9 @@ impl<'a> uart::Transmit<'a> for Uarte<'a> {
 }
 
 impl uart::Configure for Uarte<'_> {
-    fn configure(&self, params: uart::Parameters) -> Result<(), ErrorCode> {
+    type BaudRate = UarteBaudRate;
+
+    fn configure(&self, params: uart::Parameters<Self::BaudRate>) -> Result<(), ErrorCode> {
         // These could probably be implemented, but are currently ignored, so
         // throw an error.
         if params.stop_bits != uart::StopBits::One {

--- a/chips/segger/src/rtt.rs
+++ b/chips/segger/src/rtt.rs
@@ -335,7 +335,9 @@ impl<'a, A: hil::time::Alarm<'a>> hil::time::AlarmClient for SeggerRtt<'a, A> {
 // Dummy implementation so this can act as the underlying UART for a
 // virtualized UART MUX. -pal 1/10/19
 impl<'a, A: hil::time::Alarm<'a>> uart::Configure for SeggerRtt<'a, A> {
-    fn configure(&self, _parameters: uart::Parameters) -> Result<(), ErrorCode> {
+    type BaudRate = ();
+
+    fn configure(&self, _parameters: uart::Parameters<Self::BaudRate>) -> Result<(), ErrorCode> {
         Err(ErrorCode::FAIL)
     }
 }

--- a/chips/segger/src/rtt.rs
+++ b/chips/segger/src/rtt.rs
@@ -335,7 +335,7 @@ impl<'a, A: hil::time::Alarm<'a>> hil::time::AlarmClient for SeggerRtt<'a, A> {
 // Dummy implementation so this can act as the underlying UART for a
 // virtualized UART MUX. -pal 1/10/19
 impl<'a, A: hil::time::Alarm<'a>> uart::Configure for SeggerRtt<'a, A> {
-    type BaudRate = ();
+    type BaudRate = uart::NonexistentBaudRate;
 
     fn configure(&self, _parameters: uart::Parameters<Self::BaudRate>) -> Result<(), ErrorCode> {
         Err(ErrorCode::FAIL)

--- a/kernel/src/hil/uart.rs
+++ b/kernel/src/hil/uart.rs
@@ -37,11 +37,21 @@ pub enum Width {
     Eight = 8,
 }
 
+pub trait BaudRate {
+    fn from_nonzero(baud_rate: u32) -> Self;
+}
+
+impl BaudRate for () {
+    fn from_nonzero(_baud_rate: u32) -> Self {
+        ()
+    }
+}
+
 /// UART parameters for configuring the bus.
 #[derive(Copy, Clone, Debug)]
-pub struct Parameters {
+pub struct Parameters<BaudRateType: BaudRate> {
     /// Baud rate in bit/s.
-    pub baud_rate: u32,
+    pub baud_rate: BaudRateType,
     /// Number of bits per word.
     pub width: Width,
     /// Parity bit configuration.
@@ -110,6 +120,8 @@ impl<T: ReceiveClient + TransmitClient> Client for T {}
 
 /// Trait for configuring a UART.
 pub trait Configure {
+    type BaudRate: BaudRate + Copy;
+
     /// Set the configuration parameters for the UART bus.
     ///
     /// ### Return values
@@ -122,7 +134,7 @@ pub trait Configure {
     ///   of 0).
     /// - `Err(ENOSUPPORT)`: The underlying UART cannot satisfy this
     ///   configuration.
-    fn configure(&self, params: Parameters) -> Result<(), ErrorCode>;
+    fn configure(&self, params: Parameters<Self::BaudRate>) -> Result<(), ErrorCode>;
 }
 
 /// Trait for sending data via a UART bus.

--- a/kernel/src/hil/uart.rs
+++ b/kernel/src/hil/uart.rs
@@ -37,19 +37,19 @@ pub enum Width {
     Eight = 8,
 }
 
-pub trait BaudRate {
-    fn from_nonzero(baud_rate: u32) -> Self;
-}
+// pub trait BaudRate:  {}
 
-impl BaudRate for () {
-    fn from_nonzero(_baud_rate: u32) -> Self {
-        ()
+#[derive(Copy, Clone)]
+pub struct NonexistentBaudRate {}
+impl From<core::num::NonZeroU32> for NonexistentBaudRate {
+    fn from(_baud_rate: core::num::NonZeroU32) -> Self {
+        NonexistentBaudRate {}
     }
 }
 
 /// UART parameters for configuring the bus.
 #[derive(Copy, Clone, Debug)]
-pub struct Parameters<BaudRateType: BaudRate> {
+pub struct Parameters<BaudRateType: From<core::num::NonZeroU32> + Copy> {
     /// Baud rate in bit/s.
     pub baud_rate: BaudRateType,
     /// Number of bits per word.
@@ -120,7 +120,7 @@ impl<T: ReceiveClient + TransmitClient> Client for T {}
 
 /// Trait for configuring a UART.
 pub trait Configure {
-    type BaudRate: BaudRate + Copy;
+    type BaudRate: From<core::num::NonZeroU32> + Copy;
 
     /// Set the configuration parameters for the UART bus.
     ///


### PR DESCRIPTION
### Pull Request Overview

This is a sketch of my proposal for #4255. It compiles (with a couple warnings) for the nrf52840dk.

The core value of the change is in `hil/uart.rs` where we add a BaudRate associated type:

```rust
pub trait Configure {
    type BaudRate: From<core::num::NonZeroU32> + Copy;

    fn configure(&self, params: Parameters<Self::BaudRate>) -> Result<(), ErrorCode>;
}
```

After that, all of the capsules, etc. that the nrf use need to be templated on U rather than use `dyn`. (This would have to be extended further.)

### Testing Strategy

Running make


### TODO or Help Wanted

The part I couldn't figure out is what to do with `UartChannelComponent`. I would appreciate the help if someone can look at that and knows what a reasonable change would be. The issue is the output type cannot be `dyn`.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
