### PR TITLE
Remove semicolon from `debug_writer_no_mux_component_static` macro

### DIFF
--- a/boards/components/src/debug_writer.rs
+++ b/boards/components/src/debug_writer.rs
@@ -79,7 +79,7 @@ macro_rules! debug_writer_no_mux_component_static {
     };};
     () => {{
         use $crate::debug_writer::DEFAULT_DEBUG_BUFFER_KBYTE;
-        $crate::debug_writer_no_mux_component_static!(DEFAULT_DEBUG_BUFFER_KBYTE);
+        $crate::debug_writer_no_mux_component_static!(DEFAULT_DEBUG_BUFFER_KBYTE)
     };};
 }
 


### PR DESCRIPTION

### Pull Request Overview

There is a stray semicolon at the end of the parameter-less variant of the macro `debug_writer_no_mux_component_static` which is causing the return type to be `()` instead of the required tuple.

This PR is to remove it. No existing code is affected.