### PR TITLE
Add Software-Based ECDSA P256 Signature Verification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ members = [
     "boards/tutorials/nrf52840dk-hotp-tutorial",
     "boards/tutorials/nrf52840dk-thread-tutorial",
     "capsules/aes_gcm",
+    "capsules/ecdsa_sw",
     "capsules/core",
     "capsules/extra",
     "capsules/system",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ members = [
     "boards/nano33ble_rev2",
     "boards/qemu_rv32_virt",
     "boards/weact_f401ccu6/",
+    "boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256",
     "boards/configurations/nrf52840dk/nrf52840dk-test-appid-sha256",
     "boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf",
     "boards/configurations/nrf52840dk/nrf52840dk-test-kernel",

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/Cargo.toml
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/Cargo.toml
@@ -1,0 +1,31 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2025.
+
+[package]
+name = "nrf52840dk-test-appid-ecdsap256"
+version.workspace = true
+authors.workspace = true
+build = "../../../build.rs"
+edition.workspace = true
+
+[dependencies]
+components = { path = "../../../components" }
+cortexm4 = { path = "../../../../arch/cortex-m4" }
+kernel = { path = "../../../../kernel" }
+nrf52840 = { path = "../../../../chips/nrf52840" }
+segger = { path = "../../../../chips/segger" }
+nrf52_components = { path = "../../../nordic/nrf52_components" }
+
+capsules-core = { path = "../../../../capsules/core" }
+capsules-extra = { path = "../../../../capsules/extra" }
+capsules-system = { path = "../../../../capsules/system" }
+ecdsa-sw = { path = "../../../../capsules/ecdsa_sw" }
+
+tock-tbf = { path = "../../../../libraries/tock-tbf" }
+
+[build-dependencies]
+tock_build_scripts = { path = "../../../build_scripts" }
+
+[lints]
+workspace = true

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/Makefile
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/Makefile
@@ -1,0 +1,6 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
+include ../../../Makefile.common
+include ../nrf52840dk.mk

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/README.md
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/README.md
@@ -1,0 +1,4 @@
+nRF52840-DK ECDSA P256 AppID Test Board
+=======================================
+
+This is a minimal kernel for testing with ECDSA P256 signature checking.

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/layout.ld
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/layout.ld
@@ -1,0 +1,6 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2023.                                  */
+
+INCLUDE ../../../nordic/nrf52840_chip_layout.ld
+INCLUDE tock_kernel_layout.ld

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/src/io.rs
@@ -1,0 +1,17 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2024.
+
+use core::panic::PanicInfo;
+use nrf52840::gpio::Pin;
+
+#[cfg(not(test))]
+#[no_mangle]
+#[panic_handler]
+/// Panic handler
+pub unsafe fn panic_fmt(_pi: &PanicInfo) -> ! {
+    // The nRF52840DK LEDs (see back of board)
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
+    let led = &mut kernel::hil::led::LedLow::new(led_kernel_pin);
+    kernel::debug::panic_blink_forever(&mut [led])
+}

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/src/main.rs
@@ -1,0 +1,381 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! Tock kernel for the Nordic Semiconductor nRF52840 development kit (DK).
+
+#![no_std]
+// Disable this attribute when documenting, as a workaround for
+// https://github.com/rust-lang/rust/issues/62184.
+#![cfg_attr(not(doc), no_main)]
+#![deny(missing_docs)]
+
+use core::ptr::{addr_of, addr_of_mut};
+
+use kernel::component::Component;
+use kernel::deferred_call::DeferredCallClient;
+use kernel::hil::led::LedLow;
+use kernel::hil::time::Counter;
+use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::scheduler::round_robin::RoundRobinSched;
+use kernel::{capabilities, create_capability, static_init};
+use nrf52840::gpio::Pin;
+use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
+use nrf52_components::{UartChannel, UartPins};
+
+// The nRF52840DK LEDs (see back of board)
+const LED1_PIN: Pin = Pin::P0_13;
+const LED2_PIN: Pin = Pin::P0_14;
+const LED3_PIN: Pin = Pin::P0_15;
+const LED4_PIN: Pin = Pin::P0_16;
+
+const BUTTON_RST_PIN: Pin = Pin::P0_18;
+
+const UART_RTS: Option<Pin> = Some(Pin::P0_05);
+const UART_TXD: Pin = Pin::P0_06;
+const UART_CTS: Option<Pin> = Some(Pin::P0_07);
+const UART_RXD: Pin = Pin::P0_08;
+
+/// Debug Writer
+pub mod io;
+
+// State for loading and holding applications.
+// How should the kernel respond when a process faults.
+const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
+    capsules_system::process_policies::PanicFaultPolicy {};
+
+// Number of concurrent processes this platform supports.
+const NUM_PROCS: usize = 8;
+
+static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS] =
+    [None; NUM_PROCS];
+
+static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;
+
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x2000] = [0; 0x2000];
+
+//------------------------------------------------------------------------------
+// SYSCALL DRIVER TYPE DEFINITIONS
+//------------------------------------------------------------------------------
+
+type AlarmDriver = components::alarm::AlarmDriverComponentType<nrf52840::rtc::Rtc<'static>>;
+
+/// Supported drivers by the platform
+pub struct Platform {
+    console: &'static capsules_core::console::Console<'static>,
+    led: &'static capsules_core::led::LedDriver<
+        'static,
+        kernel::hil::led::LedLow<'static, nrf52840::gpio::GPIOPin<'static>>,
+        4,
+    >,
+    alarm: &'static AlarmDriver,
+    scheduler: &'static RoundRobinSched<'static>,
+    systick: cortexm4::systick::SysTick,
+}
+
+impl SyscallDriverLookup for Platform {
+    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    where
+        F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
+    {
+        match driver_num {
+            capsules_core::console::DRIVER_NUM => f(Some(self.console)),
+            capsules_core::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules_core::led::DRIVER_NUM => f(Some(self.led)),
+            _ => f(None),
+        }
+    }
+}
+
+/// This is in a separate, inline(never) function so that its stack frame is
+/// removed when this function returns. Otherwise, the stack space used for
+/// these static_inits is wasted.
+#[inline(never)]
+unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> {
+    let ieee802154_ack_buf = static_init!(
+        [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
+        [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
+    );
+    // Initialize chip peripheral drivers
+    let nrf52840_peripherals = static_init!(
+        Nrf52840DefaultPeripherals,
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf)
+    );
+
+    nrf52840_peripherals
+}
+
+impl KernelResources<nrf52840::chip::NRF52<'static, Nrf52840DefaultPeripherals<'static>>>
+    for Platform
+{
+    type SyscallDriverLookup = Self;
+    type SyscallFilter = ();
+    type ProcessFault = ();
+    type Scheduler = RoundRobinSched<'static>;
+    type SchedulerTimer = cortexm4::systick::SysTick;
+    type WatchDog = ();
+    type ContextSwitchCallback = ();
+
+    fn syscall_driver_lookup(&self) -> &Self::SyscallDriverLookup {
+        self
+    }
+    fn syscall_filter(&self) -> &Self::SyscallFilter {
+        &()
+    }
+    fn process_fault(&self) -> &Self::ProcessFault {
+        &()
+    }
+    fn scheduler(&self) -> &Self::Scheduler {
+        self.scheduler
+    }
+    fn scheduler_timer(&self) -> &Self::SchedulerTimer {
+        &self.systick
+    }
+    fn watchdog(&self) -> &Self::WatchDog {
+        &()
+    }
+    fn context_switch_callback(&self) -> &Self::ContextSwitchCallback {
+        &()
+    }
+}
+
+/// Main function called after RAM initialized.
+#[no_mangle]
+pub unsafe fn main() {
+    //--------------------------------------------------------------------------
+    // INITIAL SETUP
+    //--------------------------------------------------------------------------
+
+    // Apply errata fixes and enable interrupts.
+    nrf52840::init();
+
+    // Set up peripheral drivers. Called in separate function to reduce stack
+    // usage.
+    let nrf52840_peripherals = create_peripherals();
+
+    // Set up circular peripheral dependencies.
+    nrf52840_peripherals.init();
+    let base_peripherals = &nrf52840_peripherals.nrf52;
+
+    // Choose the channel for serial output. This board can be configured to use
+    // either the Segger RTT channel or via UART with traditional TX/RX GPIO
+    // pins.
+    let uart_channel = UartChannel::Pins(UartPins::new(UART_RTS, UART_TXD, UART_CTS, UART_RXD));
+
+    // Setup space to store the core kernel data structure.
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
+
+    // Create (and save for panic debugging) a chip object to setup low-level
+    // resources (e.g. MPU, systick).
+    let chip = static_init!(
+        nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
+        nrf52840::chip::NRF52::new(nrf52840_peripherals)
+    );
+    CHIP = Some(chip);
+
+    // Do nRF configuration and setup. This is shared code with other nRF-based
+    // platforms.
+    nrf52_components::startup::NrfStartupComponent::new(
+        false,
+        BUTTON_RST_PIN,
+        nrf52840::uicr::Regulator0Output::DEFAULT,
+        &base_peripherals.nvmc,
+    )
+    .finalize(());
+
+    //--------------------------------------------------------------------------
+    // CAPABILITIES
+    //--------------------------------------------------------------------------
+
+    // Create capabilities that the board needs to call certain protected kernel
+    // functions.
+    let main_loop_capability = create_capability!(capabilities::MainLoopCapability);
+
+    //--------------------------------------------------------------------------
+    // LEDs
+    //--------------------------------------------------------------------------
+
+    let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
+        LedLow<'static, nrf52840::gpio::GPIOPin>,
+        LedLow::new(&nrf52840_peripherals.gpio_port[LED1_PIN]),
+        LedLow::new(&nrf52840_peripherals.gpio_port[LED2_PIN]),
+        LedLow::new(&nrf52840_peripherals.gpio_port[LED3_PIN]),
+        LedLow::new(&nrf52840_peripherals.gpio_port[LED4_PIN]),
+    ));
+
+    //--------------------------------------------------------------------------
+    // TIMER
+    //--------------------------------------------------------------------------
+
+    let rtc = &base_peripherals.rtc;
+    let _ = rtc.start();
+    let mux_alarm = components::alarm::AlarmMuxComponent::new(rtc)
+        .finalize(components::alarm_mux_component_static!(nrf52840::rtc::Rtc));
+    let alarm = components::alarm::AlarmDriverComponent::new(
+        board_kernel,
+        capsules_core::alarm::DRIVER_NUM,
+        mux_alarm,
+    )
+    .finalize(components::alarm_component_static!(nrf52840::rtc::Rtc));
+
+    //--------------------------------------------------------------------------
+    // UART & CONSOLE & DEBUG
+    //--------------------------------------------------------------------------
+
+    let uart_channel = nrf52_components::UartChannelComponent::new(
+        uart_channel,
+        mux_alarm,
+        &base_peripherals.uarte0,
+    )
+    .finalize(nrf52_components::uart_channel_component_static!(
+        nrf52840::rtc::Rtc
+    ));
+
+    // Virtualize the UART channel for the console and for kernel debug.
+    let uart_mux = components::console::UartMuxComponent::new(uart_channel, 115200)
+        .finalize(components::uart_mux_component_static!());
+
+    // Setup the serial console for userspace.
+    let console = components::console::ConsoleComponent::new(
+        board_kernel,
+        capsules_core::console::DRIVER_NUM,
+        uart_mux,
+    )
+    .finalize(components::console_component_static!());
+
+    //--------------------------------------------------------------------------
+    // NRF CLOCK SETUP
+    //--------------------------------------------------------------------------
+
+    nrf52_components::NrfClockComponent::new(&base_peripherals.clock).finalize(());
+
+    //--------------------------------------------------------------------------
+    // Credential Checking
+    //--------------------------------------------------------------------------
+
+    // Create the software-based SHA engine.
+    let sha = components::sha::ShaSoftware256Component::new()
+        .finalize(components::sha_software_256_component_static!());
+
+    // Create the credential checker.
+    //
+    // Setup an example key.
+    //
+    // - `ec-secp256r1-priv-key.pem`:
+    //   ```
+    //   -----BEGIN EC PRIVATE KEY-----
+    //   MHcCAQEEIGU0zCXHLqxDmrHHAWEQP5zNfWRQrAiIpH9YwxHlqysmoAoGCCqGSM49
+    //   AwEHoUQDQgAE4BM6kKdKNWFRjuFECfFpwc9q239+Uvi3QXniTVdBI1IuthIDs4UQ
+    //   5fMlB2KPVJWCV0VQvaPiF+g0MIkmTCNisQ==
+    //   -----END EC PRIVATE KEY-----
+    //   ```
+    //
+    // - `ec-secp256r1-pub-key.pem`:
+    //   ```
+    //   -----BEGIN PUBLIC KEY-----
+    //   MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE4BM6kKdKNWFRjuFECfFpwc9q239+
+    //   Uvi3QXniTVdBI1IuthIDs4UQ5fMlB2KPVJWCV0VQvaPiF+g0MIkmTCNisQ==
+    //   -----END PUBLIC KEY-----
+    //   ```
+    //
+    // You can add the correct signature to a TBF by saving the private key to
+    // a file and then running:
+    //
+    //     tockloader tbf credential add ecdsap256 --private-key ec-secp256r1-priv-key.pem
+    //
+    let verifying_key = kernel::static_init!(
+        [u8; 64],
+        [
+            0xe0, 0x13, 0x3a, 0x90, 0xa7, 0x4a, 0x35, 0x61, 0x51, 0x8e, 0xe1, 0x44, 0x09, 0xf1,
+            0x69, 0xc1, 0xcf, 0x6a, 0xdb, 0x7f, 0x7e, 0x52, 0xf8, 0xb7, 0x41, 0x79, 0xe2, 0x4d,
+            0x57, 0x41, 0x23, 0x52, 0x2e, 0xb6, 0x12, 0x03, 0xb3, 0x85, 0x10, 0xe5, 0xf3, 0x25,
+            0x07, 0x62, 0x8f, 0x54, 0x95, 0x82, 0x57, 0x45, 0x50, 0xbd, 0xa3, 0xe2, 0x17, 0xe8,
+            0x34, 0x30, 0x89, 0x26, 0x4c, 0x23, 0x62, 0xb1
+        ]
+    );
+
+    // Setup the ECDSA-P256 verifier.
+    let ecdsa_p256_verifier = kernel::static_init!(
+        ecdsa_sw::p256_verifier::EcdsaP256SignatureVerifier<'static>,
+        ecdsa_sw::p256_verifier::EcdsaP256SignatureVerifier::new(verifying_key)
+    );
+    ecdsa_p256_verifier.register();
+
+    // Policy checks for a valid EcdsaNistP256 signature.
+    let checking_policy = components::appid::checker_signature::AppCheckerSignatureComponent::new(
+        sha,
+        ecdsa_p256_verifier,
+        tock_tbf::types::TbfFooterV2CredentialsType::EcdsaNistP256,
+    )
+    .finalize(components::app_checker_signature_component_static!(
+        ecdsa_sw::p256_verifier::EcdsaP256SignatureVerifier<'static>,
+        capsules_extra::sha256::Sha256Software<'static>,
+        32,
+        64,
+    ));
+
+    // Create the AppID assigner.
+    let assigner = components::appid::assigner_name::AppIdAssignerNamesComponent::new()
+        .finalize(components::appid_assigner_names_component_static!());
+
+    // Create the process checking machine.
+    let checker = components::appid::checker::ProcessCheckerMachineComponent::new(checking_policy)
+        .finalize(components::process_checker_machine_component_static!());
+
+    //--------------------------------------------------------------------------
+    // STORAGE PERMISSIONS
+    //--------------------------------------------------------------------------
+
+    let storage_permissions_policy =
+        components::storage_permissions::null::StoragePermissionsNullComponent::new().finalize(
+            components::storage_permissions_null_component_static!(
+                nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
+                kernel::process::ProcessStandardDebugFull,
+            ),
+        );
+
+    //--------------------------------------------------------------------------
+    // PROCESS LOADING
+    //--------------------------------------------------------------------------
+
+    // Create and start the asynchronous process loader.
+    let _loader = components::loader::sequential::ProcessLoaderSequentialComponent::new(
+        checker,
+        &mut *addr_of_mut!(PROCESSES),
+        board_kernel,
+        chip,
+        &FAULT_RESPONSE,
+        assigner,
+        storage_permissions_policy,
+    )
+    .finalize(components::process_loader_sequential_component_static!(
+        nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
+        kernel::process::ProcessStandardDebugFull,
+        NUM_PROCS
+    ));
+
+    //--------------------------------------------------------------------------
+    // PLATFORM SETUP, SCHEDULER, AND START KERNEL LOOP
+    //--------------------------------------------------------------------------
+
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
+        .finalize(components::round_robin_component_static!(NUM_PROCS));
+
+    let platform = Platform {
+        console,
+        led,
+        alarm,
+        scheduler,
+        systick: cortexm4::systick::SysTick::new_with_calibration(64000000),
+    };
+
+    board_kernel.kernel_loop(
+        &platform,
+        chip,
+        None::<&kernel::ipc::IPC<0>>,
+        &main_loop_capability,
+    );
+}

--- a/capsules/ecdsa_sw/Cargo.toml
+++ b/capsules/ecdsa_sw/Cargo.toml
@@ -1,0 +1,13 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2025.
+
+[package]
+name = "ecdsa-sw"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+
+[dependencies]
+kernel = { path = "../../kernel" }
+p256 = { version = "0.13.0", default-features = false, features = ["ecdsa"] }

--- a/capsules/ecdsa_sw/README.md
+++ b/capsules/ecdsa_sw/README.md
@@ -1,0 +1,78 @@
+ECDSA Software Implementation
+=============================
+
+This crate provides a software-based implementation of ECDSA algorithms using
+the RustCrypto crates.
+
+Supported Operations
+--------------------
+
+- Signature Verification
+  - P256 (secp256r1)
+
+Dependency Tree
+---------------
+
+```
+ecdsa-sw v0.2.3-dev (/Users/bradjc/git/tock/capsules/ecdsa_sw)
+├── kernel v0.2.3-dev (/Users/bradjc/git/tock/kernel)
+│   ├── tock-cells v0.1.0 (/Users/bradjc/git/tock/libraries/tock-cells)
+│   ├── tock-registers v0.9.0 (/Users/bradjc/git/tock/libraries/tock-register-interface)
+│   └── tock-tbf v0.1.0 (/Users/bradjc/git/tock/libraries/tock-tbf)
+└── p256 v0.13.2
+    ├── ecdsa v0.16.9
+    │   ├── der v0.7.9
+    │   │   ├── const-oid v0.9.6
+    │   │   └── zeroize v1.8.1
+    │   ├── digest v0.10.7
+    │   │   ├── block-buffer v0.10.4
+    │   │   │   └── generic-array v0.14.7
+    │   │   │       ├── typenum v1.17.0
+    │   │   │       └── zeroize v1.8.1
+    │   │   │       [build-dependencies]
+    │   │   │       └── version_check v0.9.5
+    │   │   ├── const-oid v0.9.6
+    │   │   ├── crypto-common v0.1.6
+    │   │   │   ├── generic-array v0.14.7 (*)
+    │   │   │   └── typenum v1.17.0
+    │   │   └── subtle v2.4.1
+    │   ├── elliptic-curve v0.13.8
+    │   │   ├── base16ct v0.2.0
+    │   │   ├── crypto-bigint v0.5.5
+    │   │   │   ├── generic-array v0.14.7 (*)
+    │   │   │   ├── rand_core v0.6.4
+    │   │   │   ├── subtle v2.4.1
+    │   │   │   └── zeroize v1.8.1
+    │   │   ├── digest v0.10.7 (*)
+    │   │   ├── ff v0.13.1
+    │   │   │   ├── rand_core v0.6.4
+    │   │   │   └── subtle v2.4.1
+    │   │   ├── generic-array v0.14.7 (*)
+    │   │   ├── group v0.13.0
+    │   │   │   ├── ff v0.13.1 (*)
+    │   │   │   ├── rand_core v0.6.4
+    │   │   │   └── subtle v2.4.1
+    │   │   ├── rand_core v0.6.4
+    │   │   ├── sec1 v0.7.3
+    │   │   │   ├── base16ct v0.2.0
+    │   │   │   ├── der v0.7.9 (*)
+    │   │   │   ├── generic-array v0.14.7 (*)
+    │   │   │   ├── subtle v2.4.1
+    │   │   │   └── zeroize v1.8.1
+    │   │   ├── subtle v2.4.1
+    │   │   └── zeroize v1.8.1
+    │   ├── rfc6979 v0.4.0
+    │   │   ├── hmac v0.12.1
+    │   │   │   └── digest v0.10.7 (*)
+    │   │   └── subtle v2.4.1
+    │   └── signature v2.2.0
+    │       ├── digest v0.10.7 (*)
+    │       └── rand_core v0.6.4
+    ├── elliptic-curve v0.13.8 (*)
+    ├── primeorder v0.13.6
+    │   └── elliptic-curve v0.13.8 (*)
+    └── sha2 v0.10.8
+        ├── cfg-if v1.0.0
+        ├── cpufeatures v0.2.16
+        └── digest v0.10.7 (*)
+```

--- a/capsules/ecdsa_sw/src/lib.rs
+++ b/capsules/ecdsa_sw/src/lib.rs
@@ -1,0 +1,8 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+#![forbid(unsafe_code)]
+#![no_std]
+
+pub mod p256_verifier;

--- a/capsules/ecdsa_sw/src/p256_verifier.rs
+++ b/capsules/ecdsa_sw/src/p256_verifier.rs
@@ -1,0 +1,97 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+//! ECDSA Signature Verifier for P256 signatures.
+
+use p256::ecdsa;
+use p256::ecdsa::signature::hazmat::PrehashVerifier;
+
+use core::cell::Cell;
+use kernel::hil;
+use kernel::utilities::cells::{MapCell, OptionalCell, TakeCell};
+
+pub struct EcdsaP256SignatureVerifier<'a> {
+    verified: Cell<bool>,
+    client: OptionalCell<&'a dyn hil::public_key_crypto::signature::ClientVerify<32, 64>>,
+    verifying_key: MapCell<ecdsa::VerifyingKey>,
+    hash_storage: TakeCell<'static, [u8; 32]>,
+    signature_storage: TakeCell<'static, [u8; 64]>,
+    deferred_call: kernel::deferred_call::DeferredCall,
+}
+
+impl EcdsaP256SignatureVerifier<'_> {
+    pub fn new(verifying_key_bytes: &[u8; 64]) -> Self {
+        let ep = p256::EncodedPoint::from_untagged_bytes(verifying_key_bytes.into());
+        let key = ecdsa::VerifyingKey::from_encoded_point(&ep);
+
+        let verifying_key = key.map_or_else(|_e| MapCell::empty(), MapCell::new);
+
+        Self {
+            verified: Cell::new(false),
+            client: OptionalCell::empty(),
+            verifying_key,
+            hash_storage: TakeCell::empty(),
+            signature_storage: TakeCell::empty(),
+            deferred_call: kernel::deferred_call::DeferredCall::new(),
+        }
+    }
+}
+
+impl<'a> hil::public_key_crypto::signature::SignatureVerify<'a, 32, 64>
+    for EcdsaP256SignatureVerifier<'a>
+{
+    fn set_verify_client(
+        &self,
+        client: &'a dyn hil::public_key_crypto::signature::ClientVerify<32, 64>,
+    ) {
+        self.client.replace(client);
+    }
+
+    fn verify(
+        &self,
+        hash: &'static mut [u8; 32],
+        signature: &'static mut [u8; 64],
+    ) -> Result<
+        (),
+        (
+            kernel::ErrorCode,
+            &'static mut [u8; 32],
+            &'static mut [u8; 64],
+        ),
+    > {
+        if self.verifying_key.is_some() {
+            if let Ok(sig) = ecdsa::Signature::from_slice(signature) {
+                self.verifying_key
+                    .map(|vkey| {
+                        self.verified.set(vkey.verify_prehash(hash, &sig).is_ok());
+                        self.hash_storage.replace(hash);
+                        self.signature_storage.replace(signature);
+                        self.deferred_call.set();
+                        Ok(())
+                    })
+                    .unwrap()
+            } else {
+                Err((kernel::ErrorCode::FAIL, hash, signature))
+            }
+        } else {
+            Err((kernel::ErrorCode::FAIL, hash, signature))
+        }
+    }
+}
+
+impl kernel::deferred_call::DeferredCallClient for EcdsaP256SignatureVerifier<'_> {
+    fn handle_deferred_call(&self) {
+        self.client.map(|client| {
+            if let Some(h) = self.hash_storage.take() {
+                if let Some(s) = self.signature_storage.take() {
+                    client.verification_done(Ok(self.verified.get()), h, s);
+                }
+            }
+        });
+    }
+
+    fn register(&'static self) {
+        self.deferred_call.register(self);
+    }
+}

--- a/capsules/ecdsa_sw/src/p256_verifier.rs
+++ b/capsules/ecdsa_sw/src/p256_verifier.rs
@@ -72,7 +72,7 @@ impl<'a> hil::public_key_crypto::signature::SignatureVerify<'a, 32, 64>
                     })
                     .unwrap()
             } else {
-                Err((kernel::ErrorCode::FAIL, hash, signature))
+                Err((kernel::ErrorCode::INVAL, hash, signature))
             }
         } else {
             Err((kernel::ErrorCode::FAIL, hash, signature))


### PR DESCRIPTION
### Pull Request Overview

This pull request adds an implementation of `hil::public_key_crypto::signature::SignatureVerify` with a software-based ECDSA-P256 implementation. This can be used to verify TBF signatures signed with that algorithm.

There is also a configuration board that sets up the app loading credential checker with this signature check.

Note, this does add an external dependency. I think it is fine as 1) it is a rust crypto library, 2) it's contained to a capsule, 3) I included the tree output so it's somewhat transparent.

#### External Dependency Requirements

1. **Provides Important Functionality**: Dependency implements a standard cryptographic algorithm [explicitly identified](https://github.com/tock/tock/blob/master/doc/ExternalDependencies.md#provide-important-functionality) as a use case for external repositories. 
2. **Project Maturity**: The crate is provided by the RustCrypto project.
3. **Limited Sub-dependencies**: The dependencies are listed in the included README. Without looking into each one, from their name they seem related to cryptographic functions.
4. **Included as a board or optional capsule**: The dependency is only for a new, independent capsule crate that boards have to explicitly opt-in to.

### Testing Strategy

If you want to try this you need to:

1. Copy the example private key to a file.
2. Install tockloader from the repo and run
      
        tockloader tbf credential add ecdsap256 --private-key ec-secp256r1-priv-key.pem
    to sign an app.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
