### PR TITLE
Refactor App memory MPU configuring methods 

### DIFF
--- a/arch/cortex-m/src/mpu.rs
+++ b/arch/cortex-m/src/mpu.rs
@@ -588,7 +588,7 @@ impl<const NUM_REGIONS: usize, const MIN_REGION_SIZE: usize> mpu::MPU
         initial_kernel_memory_size: usize,
         permissions: mpu::Permissions,
         config: &mut Self::MpuConfig,
-    ) -> Option<(*const u8, usize)> {
+    ) -> Option<mpu::AllocatedBreaksAndSize> {
         // Check that no previously allocated regions overlap the unallocated
         // memory.
         for region in config.regions.iter() {
@@ -706,7 +706,12 @@ impl<const NUM_REGIONS: usize, const MIN_REGION_SIZE: usize> mpu::MPU
         config.regions[1] = region1;
         config.is_dirty.set(true);
 
-        Some((region_start as *const u8, memory_size_po2))
+        let app_size = num_enabled_subregions * (region_size / 8);
+        Some(mpu::AllocatedBreaksAndSize::new(
+            region_start as *const u8,
+            app_size,
+            memory_size_po2,
+        ))
     }
 
     fn update_app_memory_region(
@@ -715,7 +720,7 @@ impl<const NUM_REGIONS: usize, const MIN_REGION_SIZE: usize> mpu::MPU
         kernel_memory_break: *const u8,
         permissions: mpu::Permissions,
         config: &mut Self::MpuConfig,
-    ) -> Result<(), ()> {
+    ) -> Result<*const u8, ()> {
         // Get first region, or error if the process tried to update app memory
         // MPU region before it was created.
         let (region_start_ptr, region_size) = config.regions[0].location().ok_or(())?;
@@ -781,7 +786,7 @@ impl<const NUM_REGIONS: usize, const MIN_REGION_SIZE: usize> mpu::MPU
         config.regions[1] = region1;
         config.is_dirty.set(true);
 
-        Ok(())
+        Ok((region_start + num_enabled_subregions * (region_size / 8)) as *const u8)
     }
 
     fn configure_mpu(&self, config: &Self::MpuConfig) {

--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -240,7 +240,8 @@ pub trait MPU {
     ///
     /// # Return Value
     ///
-    /// This function returns the start address and the size of the memory block
+    /// This function returns the start address of the accessible region,
+    /// size of the accessible region, and the total size of the memory block
     /// chosen for the process. If it is infeasible to find a memory block or
     /// allocate the MPU region, or if the function has already been called,
     /// returns None. If None is returned no changes are made.
@@ -269,6 +270,8 @@ pub trait MPU {
     /// - `config`:              MPU region configuration
     ///
     /// # Return Value
+    ///
+    /// Returns a pointer to the end of the app accessible region if updating succeeds.
     ///
     /// Returns an error if it is infeasible to update the MPU region, or if it
     /// was never created. If an error is returned no changes are made to the

--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -53,6 +53,36 @@ impl Region {
     }
 }
 
+// Breaks returned by the `allocate_app_memory_region` method
+#[derive(Clone, Copy)]
+pub struct AllocatedBreaksAndSize {
+    app_start: *const u8,
+    app_size: usize,
+    memory_size: usize,
+}
+
+impl AllocatedBreaksAndSize {
+    pub fn new(app_start: *const u8, app_size: usize, memory_size: usize) -> Self {
+        Self {
+            app_start,
+            app_size,
+            memory_size,
+        }
+    }
+
+    pub fn app_start(&self) -> *const u8 {
+        self.app_start
+    }
+
+    pub fn app_size(&self) -> usize {
+        self.app_size
+    }
+
+    pub fn memory_size(&self) -> usize {
+        self.memory_size
+    }
+}
+
 /// Null type for the default type of the `MpuConfig` type in an implementation
 /// of the `MPU` trait.
 ///
@@ -223,7 +253,7 @@ pub trait MPU {
         initial_kernel_memory_size: usize,
         permissions: Permissions,
         config: &mut Self::MpuConfig,
-    ) -> Option<(*const u8, usize)>;
+    ) -> Option<AllocatedBreaksAndSize>;
 
     /// Updates the MPU region for app-owned memory.
     ///
@@ -249,7 +279,7 @@ pub trait MPU {
         kernel_memory_break: *const u8,
         permissions: Permissions,
         config: &mut Self::MpuConfig,
-    ) -> Result<(), ()>;
+    ) -> Result<*const u8, ()>;
 
     /// Configures the MPU with the provided region configuration.
     ///
@@ -313,7 +343,7 @@ impl MPU for () {
         initial_kernel_memory_size: usize,
         _permissions: Permissions,
         _config: &mut Self::MpuConfig,
-    ) -> Option<(*const u8, usize)> {
+    ) -> Option<AllocatedBreaksAndSize> {
         let memory_size = cmp::max(
             min_memory_size,
             initial_app_memory_size + initial_kernel_memory_size,
@@ -321,7 +351,11 @@ impl MPU for () {
         if memory_size > unallocated_memory_size {
             None
         } else {
-            Some((unallocated_memory_start, memory_size))
+            Some(AllocatedBreaksAndSize::new(
+                unallocated_memory_start,
+                initial_app_memory_size,
+                memory_size,
+            ))
         }
     }
 
@@ -331,11 +365,11 @@ impl MPU for () {
         kernel_memory_break: *const u8,
         _permissions: Permissions,
         _config: &mut Self::MpuConfig,
-    ) -> Result<(), ()> {
+    ) -> Result<*const u8, ()> {
         if (app_memory_break as usize) > (kernel_memory_break as usize) {
             Err(())
         } else {
-            Ok(())
+            Ok(app_memory_break)
         }
     }
 

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -847,15 +847,14 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
                 Err(Error::AddressOutOfBounds)
             } else if new_break > self.kernel_memory_break.get() {
                 Err(Error::OutOfMemory)
-            } else if let Err(()) = self.chip.mpu().update_app_memory_region(
+            } else if let Ok(new_break) = self.chip.mpu().update_app_memory_region(
                 new_break,
                 self.kernel_memory_break.get(),
                 mpu::Permissions::ReadWriteOnly,
                 config,
             ) {
-                Err(Error::OutOfMemory)
-            } else {
                 let old_break = self.app_break.get();
+                // set the app break to the end of the MPU accesible region
                 self.app_break.set(new_break);
                 self.chip.mpu().configure_mpu(config);
 
@@ -870,6 +869,9 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
                 };
 
                 Ok(break_result)
+            } else {
+                // MPU could not allocate a region without overlapping the kernel owned memory
+                Err(Error::OutOfMemory)
             }
         })
     }
@@ -1691,7 +1693,7 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
         // - the kernel-owned allocation growing downward starting at the end
         //   of this allocation, `initial_kernel_memory_size` bytes long.
         //
-        let (allocation_start, allocation_size) = match chip.mpu().allocate_app_memory_region(
+        let allocated_breaks_and_size = match chip.mpu().allocate_app_memory_region(
             remaining_memory.as_ptr(),
             remaining_memory.len(),
             min_total_memory_size,
@@ -1700,7 +1702,7 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
             mpu::Permissions::ReadWriteOnly,
             &mut mpu_config,
         ) {
-            Some((memory_start, memory_size)) => (memory_start, memory_size),
+            Some(breaks_and_size) => breaks_and_size,
             None => {
                 // Failed to load process. Insufficient memory.
                 if config::CONFIG.debug_load_processes {
@@ -1715,6 +1717,8 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
                 return Err((ProcessLoadError::NotEnoughMemory, remaining_memory));
             }
         };
+        let allocation_start = allocated_breaks_and_size.app_start();
+        let allocation_size = allocated_breaks_and_size.memory_size();
 
         // Determine the offset of the app-owned part of the above memory
         // allocation. An MPU may not place it at the very start of
@@ -1778,7 +1782,7 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
         //   1. optional padding at the start of the memory region of
         //      `app_memory_start_offset` bytes,
         //
-        //   2. the app accessible memory region of `min_process_memory_size`,
+        //   2. the app accessible memory region given by the MPU,
         //
         //   3. optional unallocated memory, and
         //
@@ -1802,8 +1806,9 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
         let allocated_memory_len = allocated_memory.len();
 
         // Slice off the process-accessible memory:
+        let accessible_process_memory_size = allocated_breaks_and_size.app_size();
         let (app_accessible_memory, allocated_kernel_memory) =
-            allocated_memory.split_at_mut(min_process_memory_size);
+            allocated_memory.split_at_mut(accessible_process_memory_size);
 
         // Set the initial process-accessible memory:
         let initial_app_brk = app_accessible_memory
@@ -2071,32 +2076,33 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
         let initial_kernel_memory_size =
             grant_ptrs_offset + Self::CALLBACKS_OFFSET + Self::PROCESS_STRUCT_OFFSET;
 
-        let app_mpu_mem = self.chip.mpu().allocate_app_memory_region(
-            self.mem_start(),
-            self.memory_len,
-            self.memory_len, //we want exactly as much as we had before restart
-            min_process_memory_size,
-            initial_kernel_memory_size,
-            mpu::Permissions::ReadWriteOnly,
-            &mut mpu_config,
-        );
-        let (app_mpu_mem_start, app_mpu_mem_len) = match app_mpu_mem {
-            Some((start, len)) => (start, len),
-            None => {
-                // We couldn't configure the MPU for the process. This shouldn't
-                // happen since we were able to start the process before, but at
-                // this point it is better to leave the app faulted and not
-                // schedule it.
-                return Err(ErrorCode::NOMEM);
-            }
-        };
+        let app_mpu_mem = self
+            .chip
+            .mpu()
+            .allocate_app_memory_region(
+                self.mem_start(),
+                self.memory_len,
+                self.memory_len, //we want exactly as much as we had before restart
+                min_process_memory_size,
+                initial_kernel_memory_size,
+                mpu::Permissions::ReadWriteOnly,
+                &mut mpu_config,
+            )
+            // We couldn't configure the MPU for the process. This shouldn't
+            // happen since we were able to start the process before, but at
+            // this point it is better to leave the app faulted and not
+            // schedule it.
+            .ok_or(ErrorCode::NOMEM)?;
+        let app_mpu_mem_start = app_mpu_mem.app_start();
+        let app_mpu_mem_len = app_mpu_mem.memory_size();
 
         // Reset memory pointers now that we know the layout of the process
         // memory and know that we can configure the MPU.
 
         // app_brk is set based on minimum syscall size above the start of
         // memory.
-        let app_brk = app_mpu_mem_start.wrapping_add(min_process_memory_size);
+        let app_accessible_mem_size = app_mpu_mem.app_size();
+        let app_brk = app_mpu_mem_start.wrapping_add(app_accessible_mem_size);
         self.app_break.set(app_brk);
         // kernel_brk is calculated backwards from the end of memory the size of
         // the initial kernel data structures.
@@ -2220,57 +2226,51 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
     /// accessible region from the new kernel memory break after doing the
     /// allocation, then this will return `None`.
     fn allocate_in_grant_region_internal(&self, size: usize, align: usize) -> Option<NonNull<u8>> {
-        self.mpu_config.and_then(|config| {
-            // First, compute the candidate new pointer. Note that at this point
-            // we have not yet checked whether there is space for this
-            // allocation or that it meets alignment requirements.
-            let new_break_unaligned = self.kernel_memory_break.get().wrapping_sub(size);
+        // First, compute the candidate new pointer. Note that at this point
+        // we have not yet checked whether there is space for this
+        // allocation or that it meets alignment requirements.
+        let new_break_unaligned = self.kernel_memory_break.get().wrapping_sub(size);
 
-            // Our minimum alignment requirement is two bytes, so that the
-            // lowest bit of the address will always be zero and we can use it
-            // as a flag. It doesn't hurt to increase the alignment (except for
-            // potentially a wasted byte) so we make sure `align` is at least
-            // two.
-            let align = cmp::max(align, 2);
+        // Our minimum alignment requirement is two bytes, so that the
+        // lowest bit of the address will always be zero and we can use it
+        // as a flag. It doesn't hurt to increase the alignment (except for
+        // potentially a wasted byte) so we make sure `align` is at least
+        // two.
+        let align = cmp::max(align, 2);
 
-            // The alignment must be a power of two, 2^a. The expression
-            // `!(align - 1)` then returns a mask with leading ones, followed by
-            // `a` trailing zeros.
-            let alignment_mask = !(align - 1);
-            let new_break = (new_break_unaligned as usize & alignment_mask) as *const u8;
+        // The alignment must be a power of two, 2^a. The expression
+        // `!(align - 1)` then returns a mask with leading ones, followed by
+        // `a` trailing zeros.
+        let alignment_mask = !(align - 1);
+        let new_break = (new_break_unaligned as usize & alignment_mask) as *const u8;
 
-            // Verify there is space for this allocation
-            if new_break < self.app_break.get() {
-                None
-                // Verify it didn't wrap around
-            } else if new_break > self.kernel_memory_break.get() {
-                None
-                // Verify this is compatible with the MPU.
-            } else if let Err(()) = self.chip.mpu().update_app_memory_region(
-                self.app_break.get(),
-                new_break,
-                mpu::Permissions::ReadWriteOnly,
-                config,
-            ) {
-                None
-            } else {
-                // Allocation is valid.
+        // Verify there is space for this allocation
+        if new_break < self.app_break.get() {
+            None
+            // Verify it didn't wrap around
+        } else if new_break > self.kernel_memory_break.get() {
+            None
+            // Verify this is compatible with the MPU.
+        } else {
+            // Allocation is valid.
+            //
+            // **IMPORTANT NOTE**: because the app break is precisely what the mpu covers,
+            // there is no need to check compatibility with the MPU
+            //
+            // We always allocate down, so we must lower the
+            // kernel_memory_break.
+            self.kernel_memory_break.set(new_break);
 
-                // We always allocate down, so we must lower the
-                // kernel_memory_break.
-                self.kernel_memory_break.set(new_break);
+            // We need `grant_ptr` as a mutable pointer.
+            let grant_ptr = new_break as *mut u8;
 
-                // We need `grant_ptr` as a mutable pointer.
-                let grant_ptr = new_break as *mut u8;
-
-                // ### Safety
-                //
-                // Here we are guaranteeing that `grant_ptr` is not null. We can
-                // ensure this because we just created `grant_ptr` based on the
-                // process's allocated memory, and we know it cannot be null.
-                unsafe { Some(NonNull::new_unchecked(grant_ptr)) }
-            }
-        })
+            // ### Safety
+            //
+            // Here we are guaranteeing that `grant_ptr` is not null. We can
+            // ensure this because we just created `grant_ptr` based on the
+            // process's allocated memory, and we know it cannot be null.
+            unsafe { Some(NonNull::new_unchecked(grant_ptr)) }
+        }
     }
 
     /// Create the identifier for a custom grant that grant.rs uses to access


### PR DESCRIPTION

### Pull Request Overview

This PR changes the application memory MPU configuring methods to return specific values. Specifically: 
- `allocate_app_memory_region` now also returns the size of the process accessible memory based on the region(s) it configured
- `update_app_memory_region` now returns a pointer to the end of the process accessible memory

Using this approach, the `process_standard` code can be simplified. Since the `app_break` is now set to the precise end of the process accesible region there is no need to call any `MPU` methods when allocating grant memory. We just need to perform the same bounds checks as before, and if those pass, we can allocate. This should save quite a few instructions. 


### Testing Strategy

**Working on it! That's why it's a draft :)**


### TODO or Help Wanted

I'm interested in what people think of this PR. At first, I thought it a bit strange for the `MPU` to decide how much memory a process gets, but I think acknowledging this in the MPU interface should help make things clearer. Happy to take feedback on this though!

### Documentation Updated

I don't think any docs need to updated. I updated comments in the code to reflect the changes.

### Formatting

- [x] Ran `make prepush`.
