### PR TITLE
Fix subregion overlap in `allocate_app_memory_region`

### DIFF
--- a/arch/cortex-m/src/mpu.rs
+++ b/arch/cortex-m/src/mpu.rs
@@ -606,7 +606,11 @@ impl<const NUM_REGIONS: usize, const MIN_REGION_SIZE: usize> mpu::MPU
         // Size must be a power of two, so:
         // https://www.youtube.com/watch?v=ovo6zwv6DX4.
         let mut memory_size_po2 = math::closest_power_of_two(memory_size as u32) as usize;
-        let exponent = math::log_base_two(memory_size_po2 as u32);
+
+        // Region size is the actual size the MPU region will be set to, and is
+        // half of the total power of two size we are allocating to the app.
+        let mut region_size = memory_size_po2 / 2;
+        let exponent = math::log_base_two(region_size as u32);
 
         // Check for compliance with the constraints of the MPU.
         if exponent < 9 {
@@ -618,10 +622,6 @@ impl<const NUM_REGIONS: usize, const MIN_REGION_SIZE: usize> mpu::MPU
             // Region sizes must be 4GB or smaller.
             return None;
         }
-
-        // Region size is the actual size the MPU region will be set to, and is
-        // half of the total power of two size we are allocating to the app.
-        let mut region_size = memory_size_po2 / 2;
 
         // The region should start as close as possible to the start of the
         // unallocated memory.
@@ -653,11 +653,19 @@ impl<const NUM_REGIONS: usize, const MIN_REGION_SIZE: usize> mpu::MPU
         let kernel_memory_break = region_start + memory_size_po2 - initial_kernel_memory_size;
 
         // If the last subregion covering app-owned memory overlaps the start of
-        // kernel-owned memory, we make the entire process memory block twice as
-        // big so there is plenty of space between app-owned and kernel-owned
-        // memory.
+        // kernel-owned memory, we increase the process memory block by the minimum
+        // amount needed to make sure there is no overlap
+        //
+        // In general this will likely be `2` but we compute it precisely to make sure
+        // there are no edge cases left unhandled
         if subregions_enabled_end > kernel_memory_break {
+            memory_size_po2 *= 2;
             region_size *= 2;
+
+            // make sure the new region size is not too big
+            if exponent + 1 > 32 {
+                return None;
+            }
 
             if region_start % region_size != 0 {
                 region_start += region_size - (region_start % region_size);


### PR DESCRIPTION
### Pull Request Overview


1. Fixes #4366 
2. When checking whether the region sizes fit within the MPU's constraints, I believe the wrong variable is used. It checks whether `memory_size_po2` is less than 4gb but really it should be checking whether the region_size is less than 4gb.


### Testing Strategy

#### First issue listed above

There were some libtockc tests written for this bug [here](https://github.com/tock/libtock-c/pull/497). I'm not sure whether these have been run. I was also able to verify this change in our [verification fork](https://github.com/PLSysSec/tock/blob/1ac1766ea183cc9a0336d5b170bc39eab58ff3e5/arch/cortex-m/src/mpu.rs#L1089).

#### Second issue listed above 

I have not been able to test this but from reading the [ARM docs](https://developer.arm.com/documentation/dui0552/a/cortex-m3-peripherals/optional-memory-protection-unit/mpu-region-attribute-and-size-register?lang=en) and the code around this it definitely seems like the intention was to check whether the `region_size` fits the MPU constraints, not the total memory size.

### TODO or Help Wanted

Some help testing the second change would be great!

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
