### PR TITLE
Update Rust Nightly 2025-03-14 to avoid litex errors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
     "editor.defaultFormatter": "rust-lang.rust-analyzer",
     "editor.formatOnSave": true,
     "rust-analyzer.server.extraEnv": {
-        "RUSTUP_TOOLCHAIN": "nightly-2025-02-19"
+        "RUSTUP_TOOLCHAIN": "nightly-2025-03-14"
     },
     "rust-analyzer.check.allTargets": false,
 }

--- a/capsules/extra/src/net/network_capabilities.rs
+++ b/capsules/extra/src/net/network_capabilities.rs
@@ -43,7 +43,7 @@ impl AddrRange {
         match self {
             AddrRange::Any => true,
             AddrRange::NoAddrs => false,
-            AddrRange::AddrSet(allowed_addrs) => allowed_addrs.iter().any(|&a| a == addr),
+            AddrRange::AddrSet(allowed_addrs) => allowed_addrs.contains(&addr),
             AddrRange::Addr(allowed_addr) => addr == *allowed_addr, //TODO: refs?
             AddrRange::Subnet(allowed_addr, prefix_len) => {
                 let full_bytes: usize = prefix_len / 8;
@@ -76,7 +76,7 @@ impl PortRange {
         match self {
             PortRange::Any => true,
             PortRange::NoPorts => false,
-            PortRange::PortSet(allowed_ports) => allowed_ports.iter().any(|&p| p == port), // TODO: check refs
+            PortRange::PortSet(allowed_ports) => allowed_ports.contains(&port), // TODO: check refs
             PortRange::Range(low, high) => *low <= port && port <= *high,
             PortRange::Port(allowed_port) => port == *allowed_port,
         }

--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -73,7 +73,7 @@ of installing some of these tools, but you can also install them yourself.
 
 #### Rust (nightly)
 
-We are using `nightly-2025-02-19`. We require
+We are using `nightly-2025-03-14`. We require
 installing it with [rustup](http://www.rustup.rs) so you can manage multiple
 versions of Rust and continue using stable versions for other Rust code:
 
@@ -88,7 +88,7 @@ to your `$PATH`.
 Then install the correct nightly version of Rust:
 
 ```bash
-$ rustup install nightly-2025-02-19
+$ rustup install nightly-2025-03-14
 ```
 
 ### Compiling the Kernel

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,6 +3,6 @@
 # Copyright Tock Contributors 2023.
 
 [toolchain]
-channel = "nightly-2025-02-19"
+channel = "nightly-2025-03-14"
 components = ["miri", "llvm-tools", "rust-src", "rustfmt", "clippy", "rust-analyzer"]
 targets = ["thumbv6m-none-eabi", "thumbv7em-none-eabi", "thumbv7em-none-eabihf", "riscv32imc-unknown-none-elf", "riscv32imac-unknown-none-elf"]

--- a/tools/netlify-build.sh
+++ b/tools/netlify-build.sh
@@ -17,7 +17,7 @@ set -u
 set -x
 
 # Install rust stuff that we need
-curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2025-02-19
+curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2025-03-14
 
 # And fixup path for the newly installed rust stuff
 export PATH="$PATH:$HOME/.cargo/bin"


### PR DESCRIPTION
### Pull Request Overview

I don't know what is happening with the litex failures but it makes all CI runs fail. Updating the nightly seems like it will avoid the issue until we can dig into exactly what is going on with the riscv compilation.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
