### PR TITLE
Sma q3 readme links

### DIFF
--- a/boards/particle_boron/README.md
+++ b/boards/particle_boron/README.md
@@ -11,7 +11,7 @@ The [Particle_Boron](https://docs.particle.io/reference/datasheets/b-series/boro
 To program the [Particle_Boron](https://docs.particle.io/reference/datasheets/b-series/boron-datasheet/) with Tock, you will need a JLink JTAG device and the
 appropriate cables.
 
-Then, follow the [Tock Getting Started guide](../../../doc/Getting_Started.md)
+Then, follow the [Tock Getting Started guide](../../doc/Getting_Started.md)
 
 ## Programming the kernel
 

--- a/boards/sma_q3/README.md
+++ b/boards/sma_q3/README.md
@@ -12,9 +12,9 @@ The smart watch exposes 2 SWD pins, and includes 1 button, 1 backlight LED and a
 To program the SMA Q3 with Tock, you will need a STLink 2.0 device and the
 appropriate cables. An example setup is going to be available on the Jazda website.
 
-You'll also need to install [OpenOCD](../../../doc/Getting_Started.md) to proress with the programming.
+You'll also need to install [OpenOCD](../../doc/Getting_Started.md#installing-openocd) to proress with the programming.
 
-Then, follow the [Tock Getting Started guide](../../../doc/Getting_Started.md)
+Then, follow the [Tock Getting Started guide](../../doc/Getting_Started.md)
 
 ## Programming the kernel
 Once you have all software installed, you should be able to simply run

--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -187,6 +187,7 @@ with:
 ```bash
 (Ubuntu): sudo apt-get install openocd
 (MacOS): brew install open-ocd
+(Fedora): sudo dnf install openocd
 ```
 
 We require at least version `0.10.0`.


### PR DESCRIPTION
### Pull Request Overview
It looks like the README.md in sma_q3 originally derived from a board within `nordic/`,
this updates the path, along the way I also updated `particle_born` which had a similar problem.

add openocd installation instructions for fedora.

### Testing Strategy

Navigated to my [branch](https://github.com/ratmice/tock/tree/sma_q3_readme_links/boards/sma_q3), clicked on the changed links. 


### TODO or Help Wanted



### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
