### PR TITLE
Propagate documentation of `static_init!` macros to Rustdoc (fixes #4383)

### DIFF
--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -623,7 +623,7 @@ impl<'a> GrantKernelData<'a> {
     /// Search the work queue for the first pending operation with the given
     /// `subscribe_num` and if one exists remove it from the task queue.
     ///
-    /// Returns the associated [`Task`] if one was found, otherwise returns
+    /// Returns the associated [`Task`](crate::process::Task) if one was found, otherwise returns
     /// [`None`].
     pub fn remove_upcall(&self, subscribe_num: usize) -> Option<crate::process::Task> {
         self.process.remove_upcall(UpcallId {

--- a/kernel/src/utilities/static_init.rs
+++ b/kernel/src/utilities/static_init.rs
@@ -28,6 +28,8 @@ macro_rules! static_init {
     }};
 }
 
+pub use static_init;
+
 /// Internal helper function for [`static_buf!()`](crate::static_buf).
 ///
 /// This must be public to work within the macro but should never be used
@@ -121,6 +123,8 @@ macro_rules! static_buf {
     }};
 }
 
+pub use static_buf;
+
 /// A version of [`static_buf!()`] that adds an exported name to the buffer.
 ///
 /// This creates a static buffer exactly as [`static_buf!()`] does. In general,
@@ -174,3 +178,4 @@ macro_rules! static_named_buf {
         &mut BUF.0
     }};
 }
+pub use static_named_buf;

--- a/kernel/src/utilities/static_init.rs
+++ b/kernel/src/utilities/static_init.rs
@@ -125,6 +125,8 @@ macro_rules! static_buf {
     }};
 }
 
+// Import the above macro to include its doc-comment into the generated public
+// API Rustdoc.
 pub use static_buf;
 
 /// A version of [`static_buf!()`] that adds an exported name to the buffer.

--- a/kernel/src/utilities/static_init.rs
+++ b/kernel/src/utilities/static_init.rs
@@ -28,6 +28,8 @@ macro_rules! static_init {
     }};
 }
 
+// Import the above macro to include its doc-comment into the generated public
+// API Rustdoc.
 pub use static_init;
 
 /// Internal helper function for [`static_buf!()`](crate::static_buf).

--- a/kernel/src/utilities/static_init.rs
+++ b/kernel/src/utilities/static_init.rs
@@ -180,4 +180,7 @@ macro_rules! static_named_buf {
         &mut BUF.0
     }};
 }
+
+// Import the above macro to include its doc-comment into the generated public
+// API Rustdoc.
 pub use static_named_buf;


### PR DESCRIPTION
### Pull Request Overview

Seems like you can `pub use ...` to import `#[macro_export]` docs, 

Fixes #4383 

This also fixes a broken intra-doc link because `crate::process::Task` isn't imported via `use` 

### Testing Strategy

This pull request was tested by...


### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
