### PR TITLE
Use safe api in `sbrk` 

### DIFF
--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -832,7 +832,7 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
             return Err(Error::InactiveApp);
         }
 
-        let new_break = unsafe { self.app_break.get().offset(increment) };
+        let new_break = self.app_break.get().wrapping_offset(increment);
         self.brk(new_break)
     }
 


### PR DESCRIPTION
### Pull Request Overview

I noticed that `sbrk` uses the unsafe `offset` function. It seems that this is called from `memop.rs` without any checks concerning pointer arithmetic overflows. As per [the Rust documentation for `offset`](https://doc.rust-lang.org/std/primitive.pointer.html#method.offset), overflow is UB. The resulting pointer is subsequently checked in `brk`, and I don't think it's ever used but I think it would still be good to use the safe variant of `offset` which doesn't have any UB for overflow.

### Testing Strategy

I haven't tested this but the change is very minor.

### TODO or Help Wanted

Nothing

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
