### PR TITLE
Fix intra-doc link.

### DIFF
--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -623,7 +623,7 @@ impl<'a> GrantKernelData<'a> {
     /// Search the work queue for the first pending operation with the given
     /// `subscribe_num` and if one exists remove it from the task queue.
     ///
-    /// Returns the associated [`Task`] if one was found, otherwise returns
+    /// Returns the associated [`Task`](crate::process::Task) if one was found, otherwise returns
     /// [`None`].
     pub fn remove_upcall(&self, subscribe_num: usize) -> Option<crate::process::Task> {
         self.process.remove_upcall(UpcallId {


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the link to `Task`, because there is no `use crate::process::Task` ,
we must make the destination explicit or rustdoc will complain, and fail to make a link.


### Testing Strategy

This pull request was tested by...


### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
