### PR TITLE
Enable app signature checking to support multiple keys, add SetKey and SelectKey HILs, update ECDSA config board to use two signature verify keys

### DIFF
--- a/boards/components/src/appid/checker_signature.rs
+++ b/boards/components/src/appid/checker_signature.rs
@@ -31,7 +31,9 @@ pub type AppCheckerSignatureComponentType<S, H, const HL: usize, const SL: usize
     capsules_system::process_checker::signature::AppCheckerSignature<'static, S, H, HL, SL>;
 
 pub struct AppCheckerSignatureComponent<
-    S: kernel::hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL> + 'static,
+    S: kernel::hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL>
+        + kernel::hil::public_key_crypto::keys::KeySelect<'static>
+        + 'static,
     H: kernel::hil::digest::DigestDataHash<'static, HL> + 'static,
     const HL: usize,
     const SL: usize,
@@ -42,7 +44,8 @@ pub struct AppCheckerSignatureComponent<
 }
 
 impl<
-        S: kernel::hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL>,
+        S: kernel::hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL>
+            + kernel::hil::public_key_crypto::keys::KeySelect<'static>,
         H: kernel::hil::digest::DigestDataHash<'static, HL>,
         const HL: usize,
         const SL: usize,
@@ -62,7 +65,8 @@ impl<
 }
 
 impl<
-        S: kernel::hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL>,
+        S: kernel::hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL>
+            + kernel::hil::public_key_crypto::keys::KeySelect<'static>,
         H: kernel::hil::digest::DigestDataHash<'static, HL> + kernel::hil::digest::Digest<'static, HL>,
         const HL: usize,
         const SL: usize,
@@ -99,6 +103,7 @@ impl<
         );
 
         digest::Digest::set_client(self.hasher, checker);
+        kernel::hil::public_key_crypto::keys::KeySelect::set_client(self.verifier, checker);
         public_key_crypto::signature::SignatureVerify::set_verify_client(self.verifier, checker);
 
         checker

--- a/boards/components/src/appid/checker_signature.rs
+++ b/boards/components/src/appid/checker_signature.rs
@@ -32,7 +32,7 @@ pub type AppCheckerSignatureComponentType<S, H, const HL: usize, const SL: usize
 
 pub struct AppCheckerSignatureComponent<
     S: kernel::hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL>
-        + kernel::hil::public_key_crypto::keys::KeySelect<'static>
+        + kernel::hil::public_key_crypto::keys::SelectKey<'static>
         + 'static,
     H: kernel::hil::digest::DigestDataHash<'static, HL> + 'static,
     const HL: usize,
@@ -45,7 +45,7 @@ pub struct AppCheckerSignatureComponent<
 
 impl<
         S: kernel::hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL>
-            + kernel::hil::public_key_crypto::keys::KeySelect<'static>,
+            + kernel::hil::public_key_crypto::keys::SelectKey<'static>,
         H: kernel::hil::digest::DigestDataHash<'static, HL>,
         const HL: usize,
         const SL: usize,
@@ -66,7 +66,7 @@ impl<
 
 impl<
         S: kernel::hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL>
-            + kernel::hil::public_key_crypto::keys::KeySelect<'static>,
+            + kernel::hil::public_key_crypto::keys::SelectKey<'static>,
         H: kernel::hil::digest::DigestDataHash<'static, HL> + kernel::hil::digest::Digest<'static, HL>,
         const HL: usize,
         const SL: usize,
@@ -103,7 +103,7 @@ impl<
         );
 
         digest::Digest::set_client(self.hasher, checker);
-        kernel::hil::public_key_crypto::keys::KeySelect::set_client(self.verifier, checker);
+        kernel::hil::public_key_crypto::keys::SelectKey::set_client(self.verifier, checker);
         public_key_crypto::signature::SignatureVerify::set_verify_client(self.verifier, checker);
 
         checker

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -87,6 +87,7 @@ pub mod sha;
 pub mod sht3x;
 pub mod sht4x;
 pub mod si7021;
+pub mod signature_verify_in_memory_keys;
 pub mod siphash;
 pub mod sound_pressure;
 pub mod spi;

--- a/boards/components/src/signature_verify_in_memory_keys.rs
+++ b/boards/components/src/signature_verify_in_memory_keys.rs
@@ -42,7 +42,7 @@ pub type SignatureVerifyInMemoryKeysComponentType<
 
 pub struct SignatureVerifyInMemoryKeysComponent<
     S: kernel::hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL>
-        + kernel::hil::public_key_crypto::keys::KeySet<'static, KL>
+        + kernel::hil::public_key_crypto::keys::SetKey<'static, KL>
         + 'static,
     const NUM_KEYS: usize,
     const KL: usize,
@@ -55,7 +55,7 @@ pub struct SignatureVerifyInMemoryKeysComponent<
 
 impl<
         S: kernel::hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL>
-            + kernel::hil::public_key_crypto::keys::KeySet<'static, KL>
+            + kernel::hil::public_key_crypto::keys::SetKey<'static, KL>
             + 'static,
         const NUM_KEYS: usize,
         const KL: usize,
@@ -70,7 +70,7 @@ impl<
 
 impl<
         S: kernel::hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL>
-            + kernel::hil::public_key_crypto::keys::KeySet<'static, KL>
+            + kernel::hil::public_key_crypto::keys::SetKey<'static, KL>
             + 'static,
         const NUM_KEYS: usize,
         const KL: usize,

--- a/boards/components/src/signature_verify_in_memory_keys.rs
+++ b/boards/components/src/signature_verify_in_memory_keys.rs
@@ -1,0 +1,115 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+//! Component for SignatureVerifyInMemoryKeys.
+
+use core::mem::MaybeUninit;
+use kernel::component::Component;
+
+#[macro_export]
+macro_rules! signature_verify_in_memory_keys_component_static {
+    ($S:ty, $NUM_KEYS:expr, $KL:expr, $HL:expr, $SL:expr $(,)?) => {{
+        let verifier = kernel::static_buf!(
+            capsules_extra::signature_verify_in_memory_keys::SignatureVerifyInMemoryKeys<
+                'static,
+                $S,
+                $NUM_KEYS,
+                $KL,
+                $HL,
+                $SL,
+            >
+        );
+
+        verifier
+    };};
+}
+
+pub type SignatureVerifyInMemoryKeysComponentType<
+    S,
+    const NUM_KEYS: usize,
+    const KL: usize,
+    const HL: usize,
+    const SL: usize,
+> = capsules_extra::signature_verify_in_memory_keys::SignatureVerifyInMemoryKeys<
+    'static,
+    S,
+    NUM_KEYS,
+    KL,
+    HL,
+    SL,
+>;
+
+pub struct SignatureVerifyInMemoryKeysComponent<
+    S: kernel::hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL>
+        + kernel::hil::public_key_crypto::keys::KeySet<'static, KL>
+        + 'static,
+    const NUM_KEYS: usize,
+    const KL: usize,
+    const HL: usize,
+    const SL: usize,
+> {
+    verifier: &'static S,
+    keys: &'static mut [&'static mut [u8; KL]],
+}
+
+impl<
+        S: kernel::hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL>
+            + kernel::hil::public_key_crypto::keys::KeySet<'static, KL>
+            + 'static,
+        const NUM_KEYS: usize,
+        const KL: usize,
+        const HL: usize,
+        const SL: usize,
+    > SignatureVerifyInMemoryKeysComponent<S, NUM_KEYS, KL, HL, SL>
+{
+    pub fn new(verifier: &'static S, keys: &'static mut [&'static mut [u8; KL]]) -> Self {
+        Self { verifier, keys }
+    }
+}
+
+impl<
+        S: kernel::hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL>
+            + kernel::hil::public_key_crypto::keys::KeySet<'static, KL>
+            + 'static,
+        const NUM_KEYS: usize,
+        const KL: usize,
+        const HL: usize,
+        const SL: usize,
+    > Component for SignatureVerifyInMemoryKeysComponent<S, NUM_KEYS, KL, HL, SL>
+{
+    type StaticInput = &'static mut MaybeUninit<
+        capsules_extra::signature_verify_in_memory_keys::SignatureVerifyInMemoryKeys<
+            'static,
+            S,
+            NUM_KEYS,
+            KL,
+            HL,
+            SL,
+        >,
+    >;
+
+    type Output =
+        &'static capsules_extra::signature_verify_in_memory_keys::SignatureVerifyInMemoryKeys<
+            'static,
+            S,
+            NUM_KEYS,
+            KL,
+            HL,
+            SL,
+        >;
+
+    fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        let verifier_multiple_keys = s.write(
+            capsules_extra::signature_verify_in_memory_keys::SignatureVerifyInMemoryKeys::new(
+                self.verifier,
+            ),
+        );
+        self.verifier.set_client(verifier_multiple_keys);
+
+        for (i, k) in self.keys.iter_mut().enumerate() {
+            let _ = verifier_multiple_keys.init_key(i, k);
+        }
+        verifier_multiple_keys
+    }
+}

--- a/boards/components/src/signature_verify_in_memory_keys.rs
+++ b/boards/components/src/signature_verify_in_memory_keys.rs
@@ -43,7 +43,7 @@ pub type SignatureVerifyInMemoryKeysComponentType<
 
 pub struct SignatureVerifyInMemoryKeysComponent<
     S: kernel::hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL>
-        + kernel::hil::public_key_crypto::keys::SetKey<'static, KL>
+        + kernel::hil::public_key_crypto::keys::SetKeyBySlice<'static, KL>
         + 'static,
     const NUM_KEYS: usize,
     const KL: usize,
@@ -56,7 +56,7 @@ pub struct SignatureVerifyInMemoryKeysComponent<
 
 impl<
         S: kernel::hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL>
-            + kernel::hil::public_key_crypto::keys::SetKey<'static, KL>
+            + kernel::hil::public_key_crypto::keys::SetKeyBySlice<'static, KL>
             + 'static,
         const NUM_KEYS: usize,
         const KL: usize,
@@ -71,7 +71,7 @@ impl<
 
 impl<
         S: kernel::hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL>
-            + kernel::hil::public_key_crypto::keys::SetKey<'static, KL>
+            + kernel::hil::public_key_crypto::keys::SetKeyBySlice<'static, KL>
             + 'static,
         const NUM_KEYS: usize,
         const KL: usize,

--- a/boards/components/src/signature_verify_in_memory_keys.rs
+++ b/boards/components/src/signature_verify_in_memory_keys.rs
@@ -6,6 +6,7 @@
 
 use core::mem::MaybeUninit;
 use kernel::component::Component;
+use kernel::deferred_call::DeferredCallClient;
 
 #[macro_export]
 macro_rules! signature_verify_in_memory_keys_component_static {
@@ -110,6 +111,7 @@ impl<
         for (i, k) in self.keys.iter_mut().enumerate() {
             let _ = verifier_multiple_keys.init_key(i, k);
         }
+        verifier_multiple_keys.register();
         verifier_multiple_keys
     }
 }

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/src/main.rs
@@ -65,7 +65,7 @@ type Verifier = ecdsa_sw::p256_verifier::EcdsaP256SignatureVerifier<'static>;
 type SignatureVerifyInMemoryKeys =
     components::signature_verify_in_memory_keys::SignatureVerifyInMemoryKeysComponentType<
         Verifier,
-        1,
+        2,
         64,
         32,
         64,
@@ -294,7 +294,7 @@ pub unsafe fn main() {
     //
     //     tockloader tbf credential add ecdsap256 --private-key ec-secp256r1-priv-key.pem
     //
-    let verifying_key = kernel::static_init!(
+    let verifying_key0 = kernel::static_init!(
         [u8; 64],
         [
             0xe0, 0x13, 0x3a, 0x90, 0xa7, 0x4a, 0x35, 0x61, 0x51, 0x8e, 0xe1, 0x44, 0x09, 0xf1,
@@ -304,8 +304,35 @@ pub unsafe fn main() {
             0x34, 0x30, 0x89, 0x26, 0x4c, 0x23, 0x62, 0xb1
         ]
     );
-    let verifying_keys = kernel::static_init!([&'static mut [u8; 64]; 1], [verifying_key]);
-
+    // - `ec-secp256r1-priv-key2.pem`:
+    //   ```
+    //   -----BEGIN EC PRIVATE KEY-----
+    //   MHcCAQEEIMlpHXMiwjFiTRH015zyxsur59JVKzBUzM9jQTUSjcC9oAoGCCqGSM49
+    //   AwEHoUQDQgAEyT04ecALSi9cv8r8AyQUe++on+X1K3ec2fNR/bw35wwp5u7DxO1X
+    //   bZWNw8Bzh031jaY+je/40/CnCCKt9/ejqg==
+    //   -----END EC PRIVATE KEY-----
+    //   ```
+    //
+    // - `ec-secp256r1-pub-key2.pem`:
+    //   ```
+    //   -----BEGIN PUBLIC KEY-----
+    //   MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEyT04ecALSi9cv8r8AyQUe++on+X1
+    //   K3ec2fNR/bw35wwp5u7DxO1XbZWNw8Bzh031jaY+je/40/CnCCKt9/ejqg==
+    //   -----END PUBLIC KEY-----
+    //   ```
+    let verifying_key1 = kernel::static_init!(
+        [u8; 64],
+        [
+            0xc9, 0x3d, 0x38, 0x79, 0xc0, 0x0b, 0x4a, 0x2f, 0x5c, 0xbf, 0xca, 0xfc, 0x03, 0x24,
+            0x14, 0x7b, 0xef, 0xa8, 0x9f, 0xe5, 0xf5, 0x2b, 0x77, 0x9c, 0xd9, 0xf3, 0x51, 0xfd,
+            0xbc, 0x37, 0xe7, 0x0c, 0x29, 0xe6, 0xee, 0xc3, 0xc4, 0xed, 0x57, 0x6d, 0x95, 0x8d,
+            0xc3, 0xc0, 0x73, 0x87, 0x4d, 0xf5, 0x8d, 0xa6, 0x3e, 0x8d, 0xef, 0xf8, 0xd3, 0xf0,
+            0xa7, 0x08, 0x22, 0xad, 0xf7, 0xf7, 0xa3, 0xaa,
+        ]
+    );
+    let verifying_keys =
+        kernel::static_init!([&'static mut [u8; 64]; 2], [verifying_key0, verifying_key1]);
+    // kernel::static_init!([&'static mut [u8; 64]; 1], [verifying_key0]);
     // Setup the ECDSA-P256 verifier.
     let ecdsa_p256_verifier = kernel::static_init!(
         ecdsa_sw::p256_verifier::EcdsaP256SignatureVerifier<'static>,
@@ -320,7 +347,7 @@ pub unsafe fn main() {
             verifying_keys,
         )
         .finalize(
-            components::signature_verify_in_memory_keys_component_static!(Verifier, 1, 64, 32, 64,),
+            components::signature_verify_in_memory_keys_component_static!(Verifier, 2, 64, 32, 64,),
         );
 
     // Policy checks for a valid EcdsaNistP256 signature.

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/src/main.rs
@@ -334,9 +334,10 @@ pub unsafe fn main() {
         kernel::static_init!([&'static mut [u8; 64]; 2], [verifying_key0, verifying_key1]);
     // kernel::static_init!([&'static mut [u8; 64]; 1], [verifying_key0]);
     // Setup the ECDSA-P256 verifier.
+    let ecdsa_p256_verifying_key = kernel::static_init!([u8; 64], [0; 64]);
     let ecdsa_p256_verifier = kernel::static_init!(
         ecdsa_sw::p256_verifier::EcdsaP256SignatureVerifier<'static>,
-        ecdsa_sw::p256_verifier::EcdsaP256SignatureVerifier::new()
+        ecdsa_sw::p256_verifier::EcdsaP256SignatureVerifier::new(ecdsa_p256_verifying_key)
     );
     ecdsa_p256_verifier.register();
 

--- a/capsules/ecdsa_sw/src/p256_verifier.rs
+++ b/capsules/ecdsa_sw/src/p256_verifier.rs
@@ -9,7 +9,7 @@ use p256::ecdsa::signature::hazmat::PrehashVerifier;
 
 use core::cell::Cell;
 use kernel::hil;
-use kernel::hil::public_key_crypto::keys::KeySetClient;
+use kernel::hil::public_key_crypto::keys::SetKeyClient;
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::ErrorCode;
 
@@ -21,7 +21,7 @@ enum State {
 pub struct EcdsaP256SignatureVerifier<'a> {
     verified: Cell<bool>,
     client: OptionalCell<&'a dyn hil::public_key_crypto::signature::ClientVerify<32, 64>>,
-    client_key_set: OptionalCell<&'a dyn hil::public_key_crypto::keys::KeySetClient<64>>,
+    client_key_set: OptionalCell<&'a dyn hil::public_key_crypto::keys::SetKeyClient<64>>,
     verifying_key: TakeCell<'static, [u8; 64]>,
     hash_storage: TakeCell<'static, [u8; 32]>,
     signature_storage: TakeCell<'static, [u8; 64]>,
@@ -100,7 +100,7 @@ impl<'a> hil::public_key_crypto::signature::SignatureVerify<'a, 32, 64>
     }
 }
 
-impl<'a> hil::public_key_crypto::keys::KeySet<'a, 64> for EcdsaP256SignatureVerifier<'a> {
+impl<'a> hil::public_key_crypto::keys::SetKey<'a, 64> for EcdsaP256SignatureVerifier<'a> {
     fn set_key(
         &self,
         key: &'static mut [u8; 64],
@@ -112,7 +112,7 @@ impl<'a> hil::public_key_crypto::keys::KeySet<'a, 64> for EcdsaP256SignatureVeri
         Ok(())
     }
 
-    fn set_client(&self, client: &'a dyn KeySetClient<64>) {
+    fn set_client(&self, client: &'a dyn SetKeyClient<64>) {
         self.client_key_set.replace(client);
     }
 }

--- a/capsules/ecdsa_sw/src/p256_verifier.rs
+++ b/capsules/ecdsa_sw/src/p256_verifier.rs
@@ -9,32 +9,44 @@ use p256::ecdsa::signature::hazmat::PrehashVerifier;
 
 use core::cell::Cell;
 use kernel::hil;
-use kernel::utilities::cells::{MapCell, OptionalCell, TakeCell};
+use kernel::hil::public_key_crypto::keys::KeySetClient;
+use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::ErrorCode;
+
+enum State {
+    Verifying,
+    ChangingKey(&'static mut [u8; 64]),
+}
 
 pub struct EcdsaP256SignatureVerifier<'a> {
     verified: Cell<bool>,
     client: OptionalCell<&'a dyn hil::public_key_crypto::signature::ClientVerify<32, 64>>,
-    verifying_key: MapCell<ecdsa::VerifyingKey>,
+    client_key_set: OptionalCell<&'a dyn hil::public_key_crypto::keys::KeySetClient<64>>,
+    verifying_key: TakeCell<'static, [u8; 64]>,
     hash_storage: TakeCell<'static, [u8; 32]>,
     signature_storage: TakeCell<'static, [u8; 64]>,
     deferred_call: kernel::deferred_call::DeferredCall,
+    state: OptionalCell<State>,
 }
 
 impl EcdsaP256SignatureVerifier<'_> {
-    pub fn new(verifying_key_bytes: &[u8; 64]) -> Self {
-        let ep = p256::EncodedPoint::from_untagged_bytes(verifying_key_bytes.into());
-        let key = ecdsa::VerifyingKey::from_encoded_point(&ep);
-
-        let verifying_key = key.map_or_else(|_e| MapCell::empty(), MapCell::new);
-
+    pub fn new() -> Self {
         Self {
             verified: Cell::new(false),
             client: OptionalCell::empty(),
-            verifying_key,
+            client_key_set: OptionalCell::empty(),
+            verifying_key: TakeCell::empty(),
             hash_storage: TakeCell::empty(),
             signature_storage: TakeCell::empty(),
             deferred_call: kernel::deferred_call::DeferredCall::new(),
+            state: OptionalCell::empty(),
         }
+    }
+}
+
+impl Default for EcdsaP256SignatureVerifier<'_> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -64,11 +76,19 @@ impl<'a> hil::public_key_crypto::signature::SignatureVerify<'a, 32, 64>
             if let Ok(sig) = ecdsa::Signature::from_slice(signature) {
                 self.verifying_key
                     .map(|vkey| {
-                        self.verified.set(vkey.verify_prehash(hash, &sig).is_ok());
-                        self.hash_storage.replace(hash);
-                        self.signature_storage.replace(signature);
-                        self.deferred_call.set();
-                        Ok(())
+                        let vkey: &[u8; 64] = vkey;
+                        let ep = p256::EncodedPoint::from_untagged_bytes(vkey.into());
+                        let key = ecdsa::VerifyingKey::from_encoded_point(&ep);
+                        key.map(|ecdsa_key| {
+                            self.verified
+                                .set(ecdsa_key.verify_prehash(hash, &sig).is_ok());
+                            self.hash_storage.replace(hash);
+                            self.signature_storage.replace(signature);
+                            self.state.set(State::Verifying);
+                            self.deferred_call.set();
+                            Ok(())
+                        })
+                        .unwrap()
                     })
                     .unwrap()
             } else {
@@ -80,15 +100,45 @@ impl<'a> hil::public_key_crypto::signature::SignatureVerify<'a, 32, 64>
     }
 }
 
+impl<'a> hil::public_key_crypto::keys::KeySet<'a, 64> for EcdsaP256SignatureVerifier<'a> {
+    fn set_key(
+        &self,
+        key: &'static mut [u8; 64],
+    ) -> Result<(), (ErrorCode, &'static mut [u8; 64])> {
+        // Just wait for the deferred call to make the change so we can keep
+        // both the old and the new key in the meantime.
+        self.state.set(State::ChangingKey(key));
+        self.deferred_call.set();
+        Ok(())
+    }
+
+    fn set_client(&self, client: &'a dyn KeySetClient<64>) {
+        self.client_key_set.replace(client);
+    }
+}
+
 impl kernel::deferred_call::DeferredCallClient for EcdsaP256SignatureVerifier<'_> {
     fn handle_deferred_call(&self) {
-        self.client.map(|client| {
-            if let Some(h) = self.hash_storage.take() {
-                if let Some(s) = self.signature_storage.take() {
-                    client.verification_done(Ok(self.verified.get()), h, s);
+        if let Some(s) = self.state.take() {
+            match s {
+                State::Verifying => {
+                    self.client.map(|client| {
+                        if let Some(h) = self.hash_storage.take() {
+                            if let Some(s) = self.signature_storage.take() {
+                                client.verification_done(Ok(self.verified.get()), h, s);
+                            }
+                        }
+                    });
+                }
+                State::ChangingKey(key) => {
+                    let previous_key = self.verifying_key.replace(key);
+
+                    self.client_key_set.map(|client| {
+                        client.set_key_done(previous_key, Ok(()));
+                    });
                 }
             }
-        });
+        }
     }
 
     fn register(&'static self) {

--- a/capsules/ecdsa_sw/src/p256_verifier.rs
+++ b/capsules/ecdsa_sw/src/p256_verifier.rs
@@ -44,21 +44,6 @@ impl EcdsaP256SignatureVerifier<'_> {
     }
 }
 
-impl Default for EcdsaP256SignatureVerifier<'_> {
-    fn default() -> Self {
-        Self {
-            verified: Cell::new(false),
-            client: OptionalCell::empty(),
-            client_key_set: OptionalCell::empty(),
-            verifying_key: TakeCell::empty(),
-            hash_storage: TakeCell::empty(),
-            signature_storage: TakeCell::empty(),
-            deferred_call: kernel::deferred_call::DeferredCall::new(),
-            state: OptionalCell::empty(),
-        }
-    }
-}
-
 impl<'a> hil::public_key_crypto::signature::SignatureVerify<'a, 32, 64>
     for EcdsaP256SignatureVerifier<'a>
 {

--- a/capsules/extra/README.md
+++ b/capsules/extra/README.md
@@ -178,6 +178,8 @@ Other capsules that implement reusable logic.
 - **[Nonvolatile to Pages](src/nonvolatile_to_pages.rs)**: Map arbitrary reads
   and writes to flash pages.
 - **[SHA256](src/sha256.rs)**: SHA256 software hash.
+- **[SignatureVerifyInMemoryKeys](src/signature_verify_in_memory_keys.rs)**:
+  Signature verification with multiple in-memory keys.
 - **[SipHash](src/sip_hash.rs)**: SipHash software hash.
 - **[TicKV](src/tickv.rs)**: Key-value storage.
 - **[TicKV KV Store](src/tickv_kv_store.rs)**: Provide `hil::kv::KV` with TickV.

--- a/capsules/extra/src/atecc508a.rs
+++ b/capsules/extra/src/atecc508a.rs
@@ -12,11 +12,11 @@
 //! must be pulled low.
 //!
 //! The ATECC508A is shipped in an unlocked state. That is, the configuration
-//! can be changed. The ATECC508A is practically usless while it's unlocked
+//! can be changed. The ATECC508A is practically useless while it's unlocked
 //! though. Even the random number generator only returns
 //! 0xFF, 0xFF, 0x00, 0x00 when the device is unlocked.
 //!
-//! Locking the device is permanant! Once the device is locked it can not be
+//! Locking the device is permanent! Once the device is locked it can not be
 //! unlocked. Be very careful about locking the configurations. In saying that
 //! the device must be locked before it can be used.
 //!
@@ -26,6 +26,7 @@
 use core::cell::Cell;
 use kernel::debug;
 use kernel::hil::i2c::{self, I2CClient, I2CDevice};
+use kernel::hil::public_key_crypto::keys;
 use kernel::hil::public_key_crypto::signature::{ClientVerify, SignatureVerify};
 use kernel::hil::{digest, entropy, entropy::Entropy32};
 use kernel::utilities::cells::{MapCell, OptionalCell, TakeCell};
@@ -201,6 +202,9 @@ pub struct Atecc508a<'a> {
     message_data: TakeCell<'static, [u8; 32]>,
     signature_data: TakeCell<'static, [u8; 64]>,
     ext_public_key: TakeCell<'static, [u8; 64]>,
+    previous_ext_public_key: TakeCell<'static, [u8; 64]>,
+    key_set_client: OptionalCell<&'a dyn keys::KeySetClient<64>>,
+    deferred_call: kernel::deferred_call::DeferredCall,
 
     wakeup_device: fn(),
 
@@ -235,6 +239,9 @@ impl<'a> Atecc508a<'a> {
             message_data: TakeCell::empty(),
             signature_data: TakeCell::empty(),
             ext_public_key: TakeCell::empty(),
+            previous_ext_public_key: TakeCell::empty(),
+            key_set_client: OptionalCell::empty(),
+            deferred_call: kernel::deferred_call::DeferredCall::new(),
             wakeup_device,
             config_lock: Cell::new(false),
             data_lock: Cell::new(false),
@@ -451,7 +458,7 @@ impl<'a> Atecc508a<'a> {
     /// This will return the previous key if one was stored. Pass in
     /// `None` to retrieve the key without providing a new one.
     pub fn set_public_key(
-        &'a self,
+        &self,
         public_key: Option<&'static mut [u8; 64]>,
     ) -> Option<&'static mut [u8; 64]> {
         let ret = self.ext_public_key.take();
@@ -1391,5 +1398,36 @@ impl<'a> SignatureVerify<'a, 32, 64> for Atecc508a<'a> {
         self.send_command(COMMAND_OPCODE_NONCE, NONCE_MODE_PASSTHROUGH, 0x0000, 32);
 
         Ok(())
+    }
+}
+
+impl<'a> keys::KeySet<'a, 64> for Atecc508a<'a> {
+    fn set_key(
+        &self,
+        key: &'static mut [u8; 64],
+    ) -> Result<(), (ErrorCode, &'static mut [u8; 64])> {
+        if let Some(previous) = self.set_public_key(Some(key)) {
+            self.previous_ext_public_key.replace(previous);
+        }
+        self.deferred_call.set();
+        Ok(())
+    }
+
+    fn set_client(&self, client: &'a dyn keys::KeySetClient<64>) {
+        self.key_set_client.replace(client);
+    }
+}
+
+impl kernel::deferred_call::DeferredCallClient for Atecc508a<'_> {
+    fn handle_deferred_call(&self) {
+        let previous_key = self.previous_ext_public_key.take();
+
+        self.key_set_client.map(|client| {
+            client.set_key_done(previous_key, Ok(()));
+        });
+    }
+
+    fn register(&'static self) {
+        self.deferred_call.register(self);
     }
 }

--- a/capsules/extra/src/atecc508a.rs
+++ b/capsules/extra/src/atecc508a.rs
@@ -203,7 +203,7 @@ pub struct Atecc508a<'a> {
     signature_data: TakeCell<'static, [u8; 64]>,
     ext_public_key: TakeCell<'static, [u8; 64]>,
     previous_ext_public_key: TakeCell<'static, [u8; 64]>,
-    key_set_client: OptionalCell<&'a dyn keys::KeySetClient<64>>,
+    key_set_client: OptionalCell<&'a dyn keys::SetKeyClient<64>>,
     deferred_call: kernel::deferred_call::DeferredCall,
 
     wakeup_device: fn(),
@@ -1401,7 +1401,7 @@ impl<'a> SignatureVerify<'a, 32, 64> for Atecc508a<'a> {
     }
 }
 
-impl<'a> keys::KeySet<'a, 64> for Atecc508a<'a> {
+impl<'a> keys::SetKey<'a, 64> for Atecc508a<'a> {
     fn set_key(
         &self,
         key: &'static mut [u8; 64],
@@ -1413,7 +1413,7 @@ impl<'a> keys::KeySet<'a, 64> for Atecc508a<'a> {
         Ok(())
     }
 
-    fn set_client(&self, client: &'a dyn keys::KeySetClient<64>) {
+    fn set_client(&self, client: &'a dyn keys::SetKeyClient<64>) {
         self.key_set_client.replace(client);
     }
 }

--- a/capsules/extra/src/lib.rs
+++ b/capsules/extra/src/lib.rs
@@ -99,6 +99,7 @@ pub mod sha256;
 pub mod sht3x;
 pub mod sht4x;
 pub mod si7021;
+pub mod signature_verify_in_memory_keys;
 pub mod sip_hash;
 pub mod sound_pressure;
 pub mod ssd1306;

--- a/capsules/extra/src/signature_verify_in_memory_keys.rs
+++ b/capsules/extra/src/signature_verify_in_memory_keys.rs
@@ -139,14 +139,6 @@ impl<
     }
 
     fn select_key(&self, index: usize) -> Result<(), ErrorCode> {
-        if let Some(active_key) = self.active_key.get() {
-            // Check if we already have the requested key active and don't need
-            // to do anything.
-            if index == active_key {
-                return Err(ErrorCode::ALREADY);
-            }
-        }
-
         // Extract the key from our stored list of buffers holding keys. Return
         // `INVAL` if the index is greater than the number of keys we have and
         // return `NOMEM` if the key is not in our storage.

--- a/capsules/extra/src/signature_verify_in_memory_keys.rs
+++ b/capsules/extra/src/signature_verify_in_memory_keys.rs
@@ -21,14 +21,14 @@
 //!   │ (e.g., `AppCheckerSignature`)         │
 //!   │                                       │
 //!   └───────────────────────────────────────┘
-//!     SignatureVerify + KeySelect      ^
+//!     SignatureVerify + SelectKey      ^
 //!   ┌─────────────────────────────┐    │
 //!   │                             │    │
 //!   │ SignatureVerifyInMemoryKeys │    │SignatureVerifyClient
 //!   │    (this module)            │    │
 //!   │                             │    │
 //!   └─────────────────────────────┘    │
-//!     SignatureVerify + KeySet         │
+//!     SignatureVerify + SetKey         │
 //!   ┌───────────────────────────────────────┐
 //!   │                                       │
 //!   │         Signature Verifier            │
@@ -46,7 +46,7 @@ use kernel::ErrorCode;
 pub struct SignatureVerifyInMemoryKeys<
     'a,
     S: hil::public_key_crypto::signature::SignatureVerify<'a, HL, SL>
-        + hil::public_key_crypto::keys::KeySet<'a, KL>,
+        + hil::public_key_crypto::keys::SetKey<'a, KL>,
     const NUM_KEYS: usize,
     const KL: usize,
     const HL: usize,
@@ -58,13 +58,13 @@ pub struct SignatureVerifyInMemoryKeys<
     active_key: OptionalCell<usize>,
     active_key_previous: Cell<usize>,
 
-    client_key_select: OptionalCell<&'a dyn hil::public_key_crypto::keys::KeySelectClient>,
+    client_key_select: OptionalCell<&'a dyn hil::public_key_crypto::keys::SelectKeyClient>,
 }
 
 impl<
         'a,
         S: hil::public_key_crypto::signature::SignatureVerify<'a, HL, SL>
-            + hil::public_key_crypto::keys::KeySet<'a, KL>,
+            + hil::public_key_crypto::keys::SetKey<'a, KL>,
         const NUM_KEYS: usize,
         const KL: usize,
         const HL: usize,
@@ -91,7 +91,7 @@ impl<
 impl<
         'a,
         S: hil::public_key_crypto::signature::SignatureVerify<'a, HL, SL>
-            + hil::public_key_crypto::keys::KeySet<'a, KL>,
+            + hil::public_key_crypto::keys::SetKey<'a, KL>,
         const NUM_KEYS: usize,
         const KL: usize,
         const HL: usize,
@@ -125,12 +125,12 @@ impl<
 impl<
         'a,
         S: hil::public_key_crypto::signature::SignatureVerify<'a, HL, SL>
-            + hil::public_key_crypto::keys::KeySet<'a, KL>,
+            + hil::public_key_crypto::keys::SetKey<'a, KL>,
         const NUM_KEYS: usize,
         const KL: usize,
         const HL: usize,
         const SL: usize,
-    > hil::public_key_crypto::keys::KeySelect<'a>
+    > hil::public_key_crypto::keys::SelectKey<'a>
     for SignatureVerifyInMemoryKeys<'a, S, NUM_KEYS, KL, HL, SL>
 {
     fn get_key_count(&self) -> usize {
@@ -165,7 +165,7 @@ impl<
         self.verifier.set_key(key).map_err(|(e, _key)| e)
     }
 
-    fn set_client(&self, client: &'a dyn hil::public_key_crypto::keys::KeySelectClient) {
+    fn set_client(&self, client: &'a dyn hil::public_key_crypto::keys::SelectKeyClient) {
         self.client_key_select.replace(client);
     }
 }
@@ -173,12 +173,12 @@ impl<
 impl<
         'a,
         S: hil::public_key_crypto::signature::SignatureVerify<'a, HL, SL>
-            + hil::public_key_crypto::keys::KeySet<'a, KL>,
+            + hil::public_key_crypto::keys::SetKey<'a, KL>,
         const NUM_KEYS: usize,
         const KL: usize,
         const HL: usize,
         const SL: usize,
-    > hil::public_key_crypto::keys::KeySetClient<KL>
+    > hil::public_key_crypto::keys::SetKeyClient<KL>
     for SignatureVerifyInMemoryKeys<'a, S, NUM_KEYS, KL, HL, SL>
 {
     fn set_key_done(

--- a/capsules/extra/src/signature_verify_in_memory_keys.rs
+++ b/capsules/extra/src/signature_verify_in_memory_keys.rs
@@ -1,0 +1,199 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+//! Mechanism for verifying signatures with multiple in-memory keys.
+//!
+//! This capsule should be used when a system wants to be able to verify
+//! signatures with multiple keys and the underlying signature verifier stores
+//! keys in memory and only stores one key at a time.
+//!
+//! This capsule stores `NUM_KEYS` buffers holding keys. Users should construct
+//! this capsule and then call `init_key()` `NUM_KEYS` times to set all of the
+//! internal keys to store.
+//!
+//! The intended layering with this capsule looks like this:
+//!
+//! ```text
+//!   ┌───────────────────────────────────────┐
+//!   │                                       │
+//!   │         Signature User                │
+//!   │ (e.g., `AppCheckerSignature`)         │
+//!   │                                       │
+//!   └───────────────────────────────────────┘
+//!     SignatureVerify + KeySelect      ^
+//!   ┌─────────────────────────────┐    │
+//!   │                             │    │
+//!   │ SignatureVerifyInMemoryKeys │    │SignatureVerifyClient
+//!   │    (this module)            │    │
+//!   │                             │    │
+//!   └─────────────────────────────┘    │
+//!     SignatureVerify + KeySet         │
+//!   ┌───────────────────────────────────────┐
+//!   │                                       │
+//!   │         Signature Verifier            │
+//!   │  (e.g., `EcdsaP256SignatureVerifier`) │
+//!   │                                       │
+//!   └───────────────────────────────────────┘
+//! ```
+
+use core::cell::Cell;
+use kernel::hil;
+use kernel::utilities::cells::MapCell;
+use kernel::utilities::cells::OptionalCell;
+use kernel::ErrorCode;
+
+pub struct SignatureVerifyInMemoryKeys<
+    'a,
+    S: hil::public_key_crypto::signature::SignatureVerify<'a, HL, SL>
+        + hil::public_key_crypto::keys::KeySet<'a, KL>,
+    const NUM_KEYS: usize,
+    const KL: usize,
+    const HL: usize,
+    const SL: usize,
+> {
+    verifier: &'a S,
+
+    keys: [MapCell<&'static mut [u8; KL]>; NUM_KEYS],
+    active_key: OptionalCell<usize>,
+    active_key_previous: Cell<usize>,
+
+    client_key_select: OptionalCell<&'a dyn hil::public_key_crypto::keys::KeySelectClient>,
+}
+
+impl<
+        'a,
+        S: hil::public_key_crypto::signature::SignatureVerify<'a, HL, SL>
+            + hil::public_key_crypto::keys::KeySet<'a, KL>,
+        const NUM_KEYS: usize,
+        const KL: usize,
+        const HL: usize,
+        const SL: usize,
+    > SignatureVerifyInMemoryKeys<'a, S, NUM_KEYS, KL, HL, SL>
+{
+    pub fn new(verifier: &'a S) -> Self {
+        Self {
+            verifier,
+            keys: [const { MapCell::empty() }; NUM_KEYS],
+            active_key: OptionalCell::empty(),
+            active_key_previous: Cell::new(0),
+            client_key_select: OptionalCell::empty(),
+        }
+    }
+
+    /// Set the keys this module should store.
+    pub fn init_key(&self, index: usize, key: &'static mut [u8; KL]) -> Result<(), ()> {
+        self.keys.get(index).ok_or(())?.replace(key);
+        Ok(())
+    }
+}
+
+impl<
+        'a,
+        S: hil::public_key_crypto::signature::SignatureVerify<'a, HL, SL>
+            + hil::public_key_crypto::keys::KeySet<'a, KL>,
+        const NUM_KEYS: usize,
+        const KL: usize,
+        const HL: usize,
+        const SL: usize,
+    > hil::public_key_crypto::signature::SignatureVerify<'a, HL, SL>
+    for SignatureVerifyInMemoryKeys<'a, S, NUM_KEYS, KL, HL, SL>
+{
+    fn set_verify_client(
+        &self,
+        client: &'a dyn hil::public_key_crypto::signature::ClientVerify<HL, SL>,
+    ) {
+        self.verifier.set_verify_client(client);
+    }
+
+    fn verify(
+        &self,
+        hash: &'static mut [u8; HL],
+        signature: &'static mut [u8; SL],
+    ) -> Result<
+        (),
+        (
+            kernel::ErrorCode,
+            &'static mut [u8; HL],
+            &'static mut [u8; SL],
+        ),
+    > {
+        self.verifier.verify(hash, signature)
+    }
+}
+
+impl<
+        'a,
+        S: hil::public_key_crypto::signature::SignatureVerify<'a, HL, SL>
+            + hil::public_key_crypto::keys::KeySet<'a, KL>,
+        const NUM_KEYS: usize,
+        const KL: usize,
+        const HL: usize,
+        const SL: usize,
+    > hil::public_key_crypto::keys::KeySelect<'a>
+    for SignatureVerifyInMemoryKeys<'a, S, NUM_KEYS, KL, HL, SL>
+{
+    fn get_key_count(&self) -> usize {
+        NUM_KEYS
+    }
+
+    fn select_key(&self, index: usize) -> Result<(), ErrorCode> {
+        if let Some(active_key) = self.active_key.get() {
+            // Check if we already have the requested key active and don't need
+            // to do anything.
+            if index == active_key {
+                return Err(ErrorCode::ALREADY);
+            }
+
+            // Keep track of where to store the old key once we get it back.
+            self.active_key_previous.set(active_key);
+        }
+
+        // Mark which key is now active.
+        self.active_key.set(index);
+
+        // Extract the key from our stored list of buffers holding keys. Return
+        // `INVAL` if the index is greater than the number of keys we have and
+        // return `NOMEM` if the key is not in our storage.
+        let key = self
+            .keys
+            .get(index)
+            .ok_or(ErrorCode::INVAL)?
+            .take()
+            .ok_or(ErrorCode::NOMEM)?;
+
+        self.verifier.set_key(key).map_err(|(e, _key)| e)
+    }
+
+    fn set_client(&self, client: &'a dyn hil::public_key_crypto::keys::KeySelectClient) {
+        self.client_key_select.replace(client);
+    }
+}
+
+impl<
+        'a,
+        S: hil::public_key_crypto::signature::SignatureVerify<'a, HL, SL>
+            + hil::public_key_crypto::keys::KeySet<'a, KL>,
+        const NUM_KEYS: usize,
+        const KL: usize,
+        const HL: usize,
+        const SL: usize,
+    > hil::public_key_crypto::keys::KeySetClient<KL>
+    for SignatureVerifyInMemoryKeys<'a, S, NUM_KEYS, KL, HL, SL>
+{
+    fn set_key_done(
+        &self,
+        previous_key: Option<&'static mut [u8; KL]>,
+        error: Result<(), ErrorCode>,
+    ) {
+        // If we had set a key previously and got it back, re-store it.
+        if let Some(k) = previous_key {
+            if let Some(slot) = self.keys.get(self.active_key_previous.get()) {
+                slot.replace(k);
+            }
+        }
+        self.client_key_select.map(|client| {
+            client.select_key_done(self.active_key.get().unwrap_or(0), error);
+        });
+    }
+}

--- a/capsules/extra/src/signature_verify_in_memory_keys.rs
+++ b/capsules/extra/src/signature_verify_in_memory_keys.rs
@@ -149,9 +149,6 @@ impl<
             self.active_key_previous.set(active_key);
         }
 
-        // Mark which key is now active.
-        self.active_key.set(index);
-
         // Extract the key from our stored list of buffers holding keys. Return
         // `INVAL` if the index is greater than the number of keys we have and
         // return `NOMEM` if the key is not in our storage.
@@ -161,6 +158,9 @@ impl<
             .ok_or(ErrorCode::INVAL)?
             .take()
             .ok_or(ErrorCode::NOMEM)?;
+
+        // Mark which key is now active.
+        self.active_key.set(index);
 
         self.verifier.set_key(key).map_err(|(e, _key)| e)
     }

--- a/capsules/system/src/process_checker/signature.rs
+++ b/capsules/system/src/process_checker/signature.rs
@@ -154,22 +154,12 @@ impl<
         // We have the hash, we know how many keys, now we need to select the
         // first key to check. Activate the first key.
         self.active_key_index.set((0, count));
-        match self.verifier.select_key(0) {
-            Err(select_key_error) => match select_key_error {
-                ErrorCode::ALREADY => {
-                    // The key was already selected so we can go ahead
-                    // to do the verification now.
-                    self.do_verify()
-                }
-                _ => {
-                    self.client.map(|c| {
-                        let binary = self.binary.take().unwrap();
-                        let cred = self.credentials.take().unwrap();
-                        c.check_done(Err(ErrorCode::FAIL), cred, binary)
-                    });
-                }
-            },
-            Ok(()) => {}
+        if let Err(_e) = self.verifier.select_key(0) {
+            self.client.map(|c| {
+                let binary = self.binary.take().unwrap();
+                let cred = self.credentials.take().unwrap();
+                c.check_done(Err(ErrorCode::FAIL), cred, binary)
+            });
         }
     }
 

--- a/capsules/system/src/process_checker/signature.rs
+++ b/capsules/system/src/process_checker/signature.rs
@@ -26,7 +26,7 @@ use tock_tbf::types::TbfFooterV2CredentialsType;
 pub struct AppCheckerSignature<
     'a,
     S: hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL>
-        + hil::public_key_crypto::keys::KeySelect<'a>,
+        + hil::public_key_crypto::keys::SelectKey<'a>,
     H: hil::digest::DigestDataHash<'a, HL>,
     const HL: usize,
     const SL: usize,
@@ -45,7 +45,7 @@ pub struct AppCheckerSignature<
 impl<
         'a,
         S: hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL>
-            + hil::public_key_crypto::keys::KeySelect<'a>,
+            + hil::public_key_crypto::keys::SelectKey<'a>,
         H: hil::digest::DigestDataHash<'a, HL>,
         const HL: usize,
         const SL: usize,
@@ -106,7 +106,7 @@ impl<
 impl<
         'a,
         S: hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL>
-            + hil::public_key_crypto::keys::KeySelect<'a>,
+            + hil::public_key_crypto::keys::SelectKey<'a>,
         H: hil::digest::DigestDataHash<'a, HL>,
         const HL: usize,
         const SL: usize,
@@ -144,11 +144,11 @@ impl<
 impl<
         'a,
         S: hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL>
-            + hil::public_key_crypto::keys::KeySelect<'a>,
+            + hil::public_key_crypto::keys::SelectKey<'a>,
         H: hil::digest::DigestDataHash<'a, HL>,
         const HL: usize,
         const SL: usize,
-    > hil::public_key_crypto::keys::KeySelectClient for AppCheckerSignature<'a, S, H, HL, SL>
+    > hil::public_key_crypto::keys::SelectKeyClient for AppCheckerSignature<'a, S, H, HL, SL>
 {
     fn select_key_done(&self, _index: usize, error: Result<(), ErrorCode>) {
         match error {
@@ -168,7 +168,7 @@ impl<
 impl<
         'a,
         S: hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL>
-            + hil::public_key_crypto::keys::KeySelect<'a>,
+            + hil::public_key_crypto::keys::SelectKey<'a>,
         H: hil::digest::DigestDataHash<'a, HL>,
         const HL: usize,
         const SL: usize,
@@ -218,7 +218,7 @@ impl<
 impl<
         'a,
         S: hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL>
-            + hil::public_key_crypto::keys::KeySelect<'a>,
+            + hil::public_key_crypto::keys::SelectKey<'a>,
         H: hil::digest::DigestDataHash<'a, HL>,
         const HL: usize,
         const SL: usize,
@@ -233,7 +233,7 @@ impl<
 impl<
         'a,
         S: hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL>
-            + hil::public_key_crypto::keys::KeySelect<'a>,
+            + hil::public_key_crypto::keys::SelectKey<'a>,
         H: hil::digest::DigestDataHash<'a, HL>,
         const HL: usize,
         const SL: usize,
@@ -300,7 +300,7 @@ impl<
 impl<
         'a,
         S: hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL>
-            + hil::public_key_crypto::keys::KeySelect<'a>,
+            + hil::public_key_crypto::keys::SelectKey<'a>,
         H: hil::digest::DigestDataHash<'a, HL>,
         const HL: usize,
         const SL: usize,

--- a/kernel/src/hil/public_key_crypto/keys.rs
+++ b/kernel/src/hil/public_key_crypto/keys.rs
@@ -16,7 +16,7 @@ pub trait PubPrivKeyGenerateClient<'a> {
     );
 }
 
-/// An internal representation of a asymmetric Public key.
+/// An internal representation of an asymmetric Public key.
 ///
 /// This trait is useful for managing keys internally in Tock.
 ///
@@ -58,7 +58,7 @@ pub trait PubKey {
     fn len(&self) -> usize;
 }
 
-/// An internal representation of a asymmetric Public key.
+/// An internal representation of an asymmetric Public key.
 ///
 /// This trait is useful for managing keys internally in Tock.
 ///
@@ -100,7 +100,7 @@ pub trait PubKeyMut {
     fn len(&self) -> usize;
 }
 
-/// An internal representation of a asymetric Public and Private key.
+/// An internal representation of an asymmetric Public and Private key.
 ///
 /// This trait is useful for managing keys internally in Tock.
 ///
@@ -142,7 +142,7 @@ pub trait PubPrivKey: PubKey {
     fn len(&self) -> usize;
 }
 
-/// An internal representation of a asymetric Public and Private key.
+/// An internal representation of an asymmetric Public and Private key.
 ///
 /// This trait is useful for managing keys internally in Tock.
 ///
@@ -184,7 +184,7 @@ pub trait PubPrivKeyMut: PubKeyMut {
     fn len(&self) -> usize;
 }
 
-/// An internal representation of generating asymetric Public/Private key
+/// An internal representation of generating asymmetric Public/Private key
 /// pairs.
 ///
 /// This trait is useful for managing keys internally in Tock.

--- a/kernel/src/hil/public_key_crypto/keys.rs
+++ b/kernel/src/hil/public_key_crypto/keys.rs
@@ -344,7 +344,6 @@ pub trait SelectKey<'a> {
     ///
     /// `Ok()` if the key select operation was accepted. Otherwise:
     /// - `Err(ErrorCode::INVAL)` if the index is not valid.
-    /// - `Err(ErrorCode::ALREADY)` if the key is already selected.
     fn select_key(&self, index: usize) -> Result<(), ErrorCode>;
 
     fn set_client(&self, client: &'a dyn SelectKeyClient);

--- a/kernel/src/hil/public_key_crypto/keys.rs
+++ b/kernel/src/hil/public_key_crypto/keys.rs
@@ -286,6 +286,9 @@ pub trait RsaPrivKeyMut: PubPrivKeyMut + RsaKeyMut {
 
 /// Client for selecting keys.
 pub trait SelectKeyClient {
+    /// Called when the number of keys available is known.
+    fn get_key_count_done(&self, count: usize);
+
     /// Called when the specified key is active and ready to use for the next
     /// cryptographic operation.
     ///
@@ -318,7 +321,16 @@ pub trait SelectKey<'a> {
     /// Return the number of keys that the device can switch among.
     ///
     /// Each key must be identifiable by a consistent index.
-    fn get_key_count(&self) -> usize;
+    ///
+    /// This operation is asynchronous and its completion is signaled by
+    /// `get_key_count_done()`.
+    ///
+    /// ## Return
+    ///
+    /// `Ok()` if getting the count has started. Otherwise:
+    /// - `Err(ErrorCode::FAIL)` if the key count could not be started and there
+    ///   will be no callback.
+    fn get_key_count(&self) -> Result<(), ErrorCode>;
 
     /// Set the key identified by its index as the active key.
     ///

--- a/kernel/src/hil/public_key_crypto/keys.rs
+++ b/kernel/src/hil/public_key_crypto/keys.rs
@@ -285,7 +285,7 @@ pub trait RsaPrivKeyMut: PubPrivKeyMut + RsaKeyMut {
 }
 
 /// Client for selecting keys.
-pub trait KeySelectClient {
+pub trait SelectKeyClient {
     /// Called when the specified key is active and ready to use for the next
     /// cryptographic operation.
     ///
@@ -314,7 +314,7 @@ pub trait KeySelectClient {
 /// `get_key_count()-1`.
 ///
 /// The stored keys can be public or private keys.
-pub trait KeySelect<'a> {
+pub trait SelectKey<'a> {
     /// Return the number of keys that the device can switch among.
     ///
     /// Each key must be identifiable by a consistent index.
@@ -334,11 +334,11 @@ pub trait KeySelect<'a> {
     /// - `Err(ErrorCode::ALREADY)` if the key is already selected.
     fn select_key(&self, index: usize) -> Result<(), ErrorCode>;
 
-    fn set_client(&self, client: &'a dyn KeySelectClient);
+    fn set_client(&self, client: &'a dyn SelectKeyClient);
 }
 
 /// Client for setting keys.
-pub trait KeySetClient<const KL: usize> {
+pub trait SetKeyClient<const KL: usize> {
     /// Called when the key has been set.
     ///
     /// Returns the previous key if one was set.
@@ -363,7 +363,7 @@ pub trait KeySetClient<const KL: usize> {
 /// used for implementations that hold keys in memory. However, this interface
 /// is asynchronous as keys may be stored in external storage or an external
 /// chip and require an asynchronous operations.
-pub trait KeySet<'a, const KL: usize> {
+pub trait SetKey<'a, const KL: usize> {
     /// Set the current key.
     ///
     /// This is asynchronous. If there is an existing key that key will be
@@ -376,5 +376,5 @@ pub trait KeySet<'a, const KL: usize> {
     fn set_key(&self, key: &'static mut [u8; KL])
         -> Result<(), (ErrorCode, &'static mut [u8; KL])>;
 
-    fn set_client(&self, client: &'a dyn KeySetClient<KL>);
+    fn set_client(&self, client: &'a dyn SetKeyClient<KL>);
 }

--- a/kernel/src/hil/public_key_crypto/keys.rs
+++ b/kernel/src/hil/public_key_crypto/keys.rs
@@ -314,7 +314,8 @@ pub trait SelectKeyClient {
 /// or waiting for an interrupt.
 ///
 /// Keys are specified by an index starting at zero and going to
-/// `get_key_count()-1`.
+/// `get_key_count()-1`, without gaps. Selecting a key between `0` and
+/// `get_key_count()-1` must not fail with `ErrorCode::INVAL`.
 ///
 /// The stored keys can be public or private keys.
 pub trait SelectKey<'a> {


### PR DESCRIPTION
### Pull Request Overview

This pull request is part of the effort to enable per-app policies by supporting more than one signature verification key when loading and checking apps. This updates the AppCheckerSignature to iterate through signature verification keys when checking app credentials, and include the index of the valid key in the credential accepted metadata. That enables different policies based on which key was accepted.

To do this, I had to add two key-related HILs: `KeySelect` and `KeySet`. `KeySelect` is opaque in that it does not handle slices of actual keys. It simply allows the user to select which key should be active with an index. `KeySet` does use actual slices with keys. It is implemented by capsules that can be configured with a specific key (like the software ECDSA layer). We need both because we want to support hardware key stores that do not expose the ability to set key with a byte slice.

The other piece of machinery needed is an abstraction layer that holds multiple keys and passes the correct key to the actual verification layer when needed. This makes the changes required to a signature verifier (we have two in Tock) pretty small to support multiple keys.

The layering ends up looking like:

```
┌───────────────────────────────────────┐
│                                       │
│         Signature User                │
│ (e.g., `AppCheckerSignature`)         │
│                                       │
└───────────────────────────────────────┘
 SignatureVerify + KeySelect      ^
┌─────────────────────────────┐   │
│                             │   │
│ SignatureVerifyInMemoryKeys │   │SignatureVerifyClient
│                             │   │
│                             │   │
└─────────────────────────────┘   │
 SignatureVerify + KeySetBySlice  │
┌───────────────────────────────────────┐
│                                       │
│         Signature Verifier            │
│  (e.g., `EcdsaP256SignatureVerifier`) │
│                                       │
└───────────────────────────────────────┘
```
The `SignatureVerifyInMemoryKeys` capsule is new which is what stores an array of keys. When a key is selected, it sets the key in the actual verifier.

Finally, I modified the ECDSA config board to have two keys it will accept for signature verification.

### Testing Strategy

I verified that I can install two apps with different keys and they both run on the nRF52840dk config board.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
