### PR TITLE
tock-tbf: generalize header slice lifetime

### DIFF
--- a/kernel/src/process_binary.rs
+++ b/kernel/src/process_binary.rs
@@ -124,7 +124,7 @@ pub struct ProcessBinary {
     pub footers: &'static [u8],
 
     /// Collection of pointers to the TBF header in flash.
-    pub header: tock_tbf::types::TbfHeader,
+    pub header: tock_tbf::types::TbfHeader<'static>,
 
     /// Optional credential that was used to approve this application. This is
     /// set if the process is checked by a credential checker and a specific

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -439,7 +439,7 @@ pub struct ProcessStandard<'a, C: 'static + Chip, D: 'static + ProcessStandardDe
     footers: &'static [u8],
 
     /// Collection of pointers to the TBF header in flash.
-    header: tock_tbf::types::TbfHeader,
+    header: tock_tbf::types::TbfHeader<'static>,
 
     /// Credential that was approved for this process, or `None` if the
     /// credential was permitted to run without an accepted credential.

--- a/libraries/tock-tbf/src/parse.rs
+++ b/libraries/tock-tbf/src/parse.rs
@@ -69,7 +69,7 @@ pub fn parse_tbf_header_lengths(
 /// should use the `parse_tbf_header_lengths()` function to determine this
 /// length to create the correct sized slice.
 pub fn parse_tbf_header(
-    header: &'static [u8],
+    header: &[u8],
     version: u16,
 ) -> Result<types::TbfHeader, types::TbfParseError> {
     match version {
@@ -122,11 +122,11 @@ pub fn parse_tbf_header(
                 // options.
                 let mut main_pointer: Option<types::TbfHeaderV2Main> = None;
                 let mut program_pointer: Option<types::TbfHeaderV2Program> = None;
-                let mut wfr_pointer: Option<&'static [u8]> = None;
+                let mut wfr_pointer: Option<&[u8]> = None;
                 let mut app_name_str = "";
-                let mut fixed_address_pointer: Option<&'static [u8]> = None;
-                let mut permissions_pointer: Option<&'static [u8]> = None;
-                let mut storage_permissions_pointer: Option<&'static [u8]> = None;
+                let mut fixed_address_pointer: Option<&[u8]> = None;
+                let mut permissions_pointer: Option<&[u8]> = None;
+                let mut storage_permissions_pointer: Option<&[u8]> = None;
                 let mut kernel_version: Option<types::TbfHeaderV2KernelVersion> = None;
                 let mut short_id: Option<types::TbfHeaderV2ShortId> = None;
 

--- a/libraries/tock-tbf/src/types.rs
+++ b/libraries/tock-tbf/src/types.rs
@@ -650,15 +650,15 @@ pub enum CommandPermissions {
 /// four since we need to statically know the length of the array to store in
 /// this type.
 #[derive(Clone, Copy, Debug)]
-pub struct TbfHeaderV2 {
+pub struct TbfHeaderV2<'a> {
     pub(crate) base: TbfHeaderV2Base,
     pub(crate) main: Option<TbfHeaderV2Main>,
     pub(crate) program: Option<TbfHeaderV2Program>,
-    pub(crate) package_name: Option<&'static str>,
-    pub(crate) writeable_regions: Option<&'static [u8]>,
-    pub(crate) fixed_addresses: Option<&'static [u8]>,
-    pub(crate) permissions: Option<&'static [u8]>,
-    pub(crate) storage_permissions: Option<&'static [u8]>,
+    pub(crate) package_name: Option<&'a str>,
+    pub(crate) writeable_regions: Option<&'a [u8]>,
+    pub(crate) fixed_addresses: Option<&'a [u8]>,
+    pub(crate) permissions: Option<&'a [u8]>,
+    pub(crate) storage_permissions: Option<&'a [u8]>,
     pub(crate) kernel_version: Option<TbfHeaderV2KernelVersion>,
     pub(crate) short_id: Option<TbfHeaderV2ShortId>,
 }
@@ -670,12 +670,12 @@ pub struct TbfHeaderV2 {
 /// The kernel can also use this header to keep persistent state about
 /// the application.
 #[derive(Debug)]
-pub enum TbfHeader {
-    TbfHeaderV2(TbfHeaderV2),
+pub enum TbfHeader<'a> {
+    TbfHeaderV2(TbfHeaderV2<'a>),
     Padding(TbfHeaderV2Base),
 }
 
-impl TbfHeader {
+impl<'a> TbfHeader<'a> {
     /// Return the length of the header.
     pub fn length(&self) -> u16 {
         match *self {
@@ -772,7 +772,7 @@ impl TbfHeader {
     }
 
     /// Get the name of the app.
-    pub fn get_package_name(&self) -> Option<&'static str> {
+    pub fn get_package_name(&self) -> Option<&'a str> {
         match *self {
             TbfHeader::TbfHeaderV2(hd) => hd.package_name,
             _ => None,
@@ -795,7 +795,7 @@ impl TbfHeader {
         match *self {
             TbfHeader::TbfHeaderV2(hd) => hd.writeable_regions.map_or((0, 0), |wr_slice| {
                 fn get_region(
-                    wr_slice: &'static [u8],
+                    wr_slice: &[u8],
                     index: usize,
                 ) -> Result<TbfHeaderV2WriteableFlashRegion, ()> {
                     let wfr_len = size_of::<TbfHeaderV2WriteableFlashRegion>();
@@ -866,7 +866,7 @@ impl TbfHeader {
                 Some(permissions_tlv_slice) => {
                     // Helper function to wrap the return in a Result.
                     fn get_command_permissions_result(
-                        permissions_tlv_slice: &'static [u8],
+                        permissions_tlv_slice: &[u8],
                         driver_num: usize,
                         offset: usize,
                     ) -> Result<CommandPermissions, ()> {


### PR DESCRIPTION
### Pull Request Overview

Update TBF parsing logic to accept bytes slices of any lifetime, not just 'static. This makes it easier to use tock-tbf from command line tools where raw TBF data is dynamically allocated in e.g. a Vec.


### Testing Strategy

Ran `make prepush` to ensure project continues to compile.

This PR strictly relaxes the lifetime requirements for parsing TBF headers. None of the procedural logic is modified in any way; only type signatures. For this reason, extensive testing does not seem necessary.

For what it's worth, this patch has been applied to Microsoft's internal fork for roughly 2 years without issue.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
