### PR TITLE
arch: specify u128 for interrupt_mask to avoid shift overflow

### DIFF
--- a/arch/cortex-m/src/nvic.rs
+++ b/arch/cortex-m/src/nvic.rs
@@ -32,6 +32,11 @@ macro_rules! interrupt_mask {
         let mut high_interrupt: u128 = 0;
         let mut low_interrupt: u128 = 0;
         $(
+            // Validate that the interrupt index is within the high and low
+            // interrupt range.
+            const{ assert!($interrupt < 256); }
+            const{ assert!($interrupt >= 0); }
+
             if ($interrupt < 128) {
                 low_interrupt |= (1u128 << $interrupt)
             }

--- a/arch/cortex-m/src/nvic.rs
+++ b/arch/cortex-m/src/nvic.rs
@@ -33,11 +33,11 @@ macro_rules! interrupt_mask {
         let mut low_interrupt: u128 = 0;
         $(
             if ($interrupt < 128) {
-                low_interrupt |= (1 << $interrupt) as u128
+                low_interrupt |= (1u128 << $interrupt) as u128
             }
             else
             {
-                high_interrupt |= (1 << ($interrupt-128)) as u128
+                high_interrupt |= (1u128 << ($interrupt-128)) as u128
             }
         );+
         (high_interrupt, low_interrupt)

--- a/arch/cortex-m/src/nvic.rs
+++ b/arch/cortex-m/src/nvic.rs
@@ -33,11 +33,11 @@ macro_rules! interrupt_mask {
         let mut low_interrupt: u128 = 0;
         $(
             if ($interrupt < 128) {
-                low_interrupt |= (1u128 << $interrupt) as u128
+                low_interrupt |= (1u128 << $interrupt)
             }
             else
             {
-                high_interrupt |= (1u128 << ($interrupt-128)) as u128
+                high_interrupt |= (1u128 << ($interrupt-128))
             }
         );+
         (high_interrupt, low_interrupt)


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a type specifier for the `1` from the `interrupt_mask` macro from `arch/cortex-m/src/nvic.rs`.
While working on a port for another chip, I encountered a panic with `attempt to shift left with overflow` and I fixed it by adding the `u128` specifier to the `1`. 

### Testing Strategy

This pull request was tested by flashing the code to a Raspberry Pi Pico board.

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
