### PR TITLE
avoid `egrep` obsolecent warning by switching to `grep -E`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,10 +249,10 @@ ci-help:
 	@echo "review the documentation at 'doc/CodeReview.md'."
 	@echo
 	@echo "The following CI runners are available:"
-	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$' | grep ci-runner | sed 's/^/ - /'
+	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | grep -E -v -e '^[^[:alnum:]]' -e '^$@$$' | grep ci-runner | sed 's/^/ - /'
 	@echo
 	@echo "The following CI jobs are available:"
-	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$' | grep ci-job | sed 's/^/ - /'
+	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | grep -E -v -e '^[^[:alnum:]]' -e '^$@$$' | grep ci-job | sed 's/^/ - /'
 	@echo
 	@echo To run the recommended local development CI run $$(tput bold)make prepush$$(tput sgr0).
 	@echo Developers are encouraged to always run this before pushing code.

--- a/tools/github_actions_size_changes.sh
+++ b/tools/github_actions_size_changes.sh
@@ -17,7 +17,7 @@ set -e
 
 # Bench the current commit that was pushed. Requires navigating back to build directory
 make allboards > /dev/null 2>&1
-for elf in $(find . -maxdepth 8 | grep 'release' | egrep '\.elf$'); do
+for elf in $(find . -maxdepth 8 | grep 'release' | grep -E '\.elf$'); do
     tmp=${elf#*release/}
     b=${tmp%.elf}
     ./tools/print_tock_memory_usage.py -w ${elf} > current-benchmark-${b}
@@ -29,7 +29,7 @@ git checkout "$UPSTREAM_REMOTE_NAME"/"$GITHUB_BASE_REF" > /dev/null 2>&1
 make allboards > /dev/null 2>&1
 
 # Find elfs compiled for release (for use in analyzing binaries in CI),
-for elf in $(find . -maxdepth 8 | grep 'release' | egrep '\.elf$'); do
+for elf in $(find . -maxdepth 8 | grep 'release' | grep -E '\.elf$'); do
     tmp=${elf#*release/}
     b=${tmp%.elf}
     ./tools/print_tock_memory_usage.py -w ${elf} > previous-benchmark-${b}
@@ -38,7 +38,7 @@ done
 DIFF_DETECTED=0
 
 # now calculate diff for each board, and post status to github for each non-0 diff
-for elf in $(find . -maxdepth 8 | grep 'release' | egrep '\.elf$'); do
+for elf in $(find . -maxdepth 8 | grep 'release' | grep -E '\.elf$'); do
     tmp=${elf#*release/}
     b=${tmp%.elf}
     # Compute a summary suitable for GitHub.

--- a/tools/list_boards.sh
+++ b/tools/list_boards.sh
@@ -5,7 +5,7 @@
 # Copyright Tock Contributors 2023.
 
 # Find boards based on folders with Makefiles
-for b in $(find boards -maxdepth 4 | egrep 'Makefile$'); do
+for b in $(find boards -maxdepth 4 | grep -E 'Makefile$'); do
     b1=${b#boards/}
     b2=${b1%/*}
     echo $b2

--- a/tools/list_lock.sh
+++ b/tools/list_lock.sh
@@ -5,7 +5,7 @@
 # Copyright Tock Contributors 2023.
 
 # Find crates based on folders with Cargo.lock files
-for b in $(find . -maxdepth 4 | egrep 'Cargo.lock$'); do
+for b in $(find . -maxdepth 4 | grep -E 'Cargo.lock$'); do
     b2=${b%/*}
     echo $b2
 done

--- a/tools/post_size_changes_to_github.sh
+++ b/tools/post_size_changes_to_github.sh
@@ -23,7 +23,7 @@ if [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ]; then
     # Bench the current commit that was pushed. Requires navigating back to build directory
     cd ${TRAVIS_BUILD_DIR}
     make allboards
-    for elf in $(find . -maxdepth 8 | grep 'release' | egrep '\.elf$'); do
+    for elf in $(find . -maxdepth 8 | grep 'release' | grep -E '\.elf$'); do
         tmp=${elf#*release/}
         b=${tmp%.elf}
         ${TRAVIS_BUILD_DIR}/tools/print_tock_memory_usage.py -s ${elf} | tee ${TRAVIS_BUILD_DIR}/current-benchmark-${b}
@@ -50,7 +50,7 @@ if [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ]; then
     make allboards
 
     # Find elfs compiled for release (for use in analyzing binaries in CI),
-    for elf in $(find . -maxdepth 8 | grep 'release' | egrep '\.elf$'); do
+    for elf in $(find . -maxdepth 8 | grep 'release' | grep -E '\.elf$'); do
         tmp=${elf#*release/}
         b=${tmp%.elf}
         ${TRAVIS_BUILD_DIR}/tools/print_tock_memory_usage.py -s ${elf} | tee ${TRAVIS_BUILD_DIR}/previous-benchmark-${b}
@@ -58,7 +58,7 @@ if [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ]; then
 
     # now calculate diff for each board, and post status to github for each non-0 diff
     cd ${TRAVIS_BUILD_DIR}
-    for elf in $(find . -maxdepth 8 | grep 'release' | egrep '\.elf$'); do
+    for elf in $(find . -maxdepth 8 | grep 'release' | grep -E '\.elf$'); do
         tmp=${elf#*release/}
         b=${tmp%.elf}
         # Print a detailed by raw line-by-line diff. Can be useful to


### PR DESCRIPTION
### Pull Request Overview
At some point GNU grep decided to deprecate the `egrep` utility in favor of `grep -E`.
I haven't tested other platforms/operating systems, but given that posix grep does define
the `-E` argument to grep, but does not appear to require an egrep command it seems like
one should prefer it.

https://pubs.opengroup.org/onlinepubs/9799919799/utilities/grep.html#top


### Testing Strategy

make ci-all

### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.

I did run it but it failed on some unchanged source file,
and cargo format didn't produce any differences, in the confusion I gave up.
