### PR TITLE
shell.nix: bump Tockloader to v1.14.0

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -24,8 +24,8 @@ let
   tockloader = import (pkgs.fetchFromGitHub {
     owner = "tock";
     repo = "tockloader";
-    rev = "v1.12.0";
-    sha256 = "sha256-VgbAKDY/7ZVINDkqSHF7C0zRzVgtk8YG6O/ZmUpsh/g=";
+    rev = "v1.14.0";
+    sha256 = "sha256-TsJEPQhJVTJt1g/EEIaGuwVIjD5Q65mHKkpbY5ru+JI=";
   }) { inherit pkgs withUnfreePkgs; };
 
   rust_overlay = import "${pkgs.fetchFromGitHub {


### PR DESCRIPTION
### Pull Request Overview

This pull request bumps the pinned Tockloader version in `shell.nix` to v1.14.0.


### Testing Strategy

This pull request was not tested yet.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
