### PR TITLE
Delete no_mangle from panic handler

### DIFF
--- a/boards/apollo3/lora_things_plus/src/io.rs
+++ b/boards/apollo3/lora_things_plus/src/io.rs
@@ -36,7 +36,6 @@ impl IoWrite for Writer {
 }
 
 /// Panic handler.
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     // just create a new pin reference here instead of using global

--- a/boards/apollo3/redboard_artemis_atp/src/io.rs
+++ b/boards/apollo3/redboard_artemis_atp/src/io.rs
@@ -36,7 +36,6 @@ impl IoWrite for Writer {
 }
 
 /// Panic handler.
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     // just create a new pin reference here instead of using global

--- a/boards/apollo3/redboard_artemis_nano/src/io.rs
+++ b/boards/apollo3/redboard_artemis_nano/src/io.rs
@@ -36,7 +36,6 @@ impl IoWrite for Writer {
 }
 
 /// Panic handler.
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     // just create a new pin reference here instead of using global

--- a/boards/arty_e21/src/io.rs
+++ b/boards/arty_e21/src/io.rs
@@ -36,7 +36,6 @@ impl IoWrite for Writer {
 
 /// Panic handler.
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // turn off the non panic leds, just in case

--- a/boards/clue_nrf52840/src/io.rs
+++ b/boards/clue_nrf52840/src/io.rs
@@ -127,7 +127,6 @@ impl IoWrite for Writer {
 ///
 /// We just use the standard default provided by the debug module in the kernel.
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P1_01);

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-sha256/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-sha256/src/io.rs
@@ -6,7 +6,6 @@ use core::panic::PanicInfo;
 use nrf52840::gpio::Pin;
 
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 /// Panic handler
 pub unsafe fn panic_fmt(_pi: &PanicInfo) -> ! {

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/io.rs
@@ -6,7 +6,6 @@ use core::panic::PanicInfo;
 use nrf52840::gpio::Pin;
 
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 /// Panic handler
 pub unsafe fn panic_fmt(_pi: &PanicInfo) -> ! {

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/io.rs
@@ -66,7 +66,6 @@ impl IoWrite for Writer {
 }
 
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 /// Panic handler
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {

--- a/boards/esp32-c3-devkitM-1/src/io.rs
+++ b/boards/esp32-c3-devkitM-1/src/io.rs
@@ -36,7 +36,6 @@ impl IoWrite for Writer {
 
 /// Panic handler.
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     use core::ptr::addr_of_mut;
@@ -53,7 +52,6 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
 }
 
 #[cfg(test)]
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     use core::ptr::addr_of_mut;

--- a/boards/hail/src/io.rs
+++ b/boards/hail/src/io.rs
@@ -56,7 +56,6 @@ impl IoWrite for Writer {
 
 /// Panic handler.
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // turn off the non panic leds, just in case

--- a/boards/hifive1/src/io.rs
+++ b/boards/hifive1/src/io.rs
@@ -37,7 +37,6 @@ impl IoWrite for Writer {
 
 /// Panic handler.
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // turn off the non panic leds, just in case

--- a/boards/hifive_inventor/src/io.rs
+++ b/boards/hifive_inventor/src/io.rs
@@ -34,7 +34,6 @@ impl IoWrite for Writer {
 
 /// Panic handler.
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     use core::ptr::{addr_of, addr_of_mut};

--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -57,7 +57,6 @@ impl IoWrite for Writer {
 
 /// Panic handler.
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     use core::ptr::{addr_of, addr_of_mut};

--- a/boards/imxrt1050-evkb/src/io.rs
+++ b/boards/imxrt1050-evkb/src/io.rs
@@ -67,7 +67,6 @@ impl IoWrite for Writer {
 }
 
 /// Panic handler.
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     // User Led is connected to AdB0_09

--- a/boards/litex/arty/src/io.rs
+++ b/boards/litex/arty/src/io.rs
@@ -32,7 +32,6 @@ impl IoWrite for Writer {
 
 /// Panic handler.
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     use core::ptr::{addr_of, addr_of_mut};

--- a/boards/litex/sim/src/io.rs
+++ b/boards/litex/sim/src/io.rs
@@ -32,7 +32,6 @@ impl IoWrite for Writer {
 
 /// Panic handler.
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     use core::ptr::{addr_of, addr_of_mut};

--- a/boards/makepython-nrf52840/src/io.rs
+++ b/boards/makepython-nrf52840/src/io.rs
@@ -124,7 +124,6 @@ impl IoWrite for Writer {
 
 /// We just use the standard default provided by the debug module in the kernel.
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P1_10);

--- a/boards/microbit_v2/src/io.rs
+++ b/boards/microbit_v2/src/io.rs
@@ -69,7 +69,6 @@ impl IoWrite for Writer {
 ///
 /// We just use the standard default provided by the debug module in the kernel.
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // MicroBit v2 has an LED matrix, use the upper left LED

--- a/boards/msp_exp432p401r/src/io.rs
+++ b/boards/msp_exp432p401r/src/io.rs
@@ -38,7 +38,6 @@ impl IoWrite for Uart {
 }
 
 /// Panic handler
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     const LED1_PIN: IntPinNr = IntPinNr::P01_0;

--- a/boards/nano33ble/src/io.rs
+++ b/boards/nano33ble/src/io.rs
@@ -126,7 +126,6 @@ impl IoWrite for Writer {
 ///
 /// We just use the standard default provided by the debug module in the kernel.
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);

--- a/boards/nano33ble_rev2/src/io.rs
+++ b/boards/nano33ble_rev2/src/io.rs
@@ -127,7 +127,6 @@ impl IoWrite for Writer {
 ///
 /// We just use the standard default provided by the debug module in the kernel.
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);

--- a/boards/nano_rp2040_connect/src/io.rs
+++ b/boards/nano_rp2040_connect/src/io.rs
@@ -84,7 +84,6 @@ impl IoWrite for Writer {
 ///
 /// We just use the standard default provided by the debug module in the kernel.
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // LED is connected to GPIO 25

--- a/boards/nordic/nrf52840_dongle/src/io.rs
+++ b/boards/nordic/nrf52840_dongle/src/io.rs
@@ -55,7 +55,6 @@ impl IoWrite for Writer {
 }
 
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 /// Panic handler
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -58,7 +58,6 @@ impl IoWrite for Writer {
 }
 
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 /// Panic handler
 pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {

--- a/boards/nordic/nrf52dk/src/io.rs
+++ b/boards/nordic/nrf52dk/src/io.rs
@@ -55,7 +55,6 @@ impl IoWrite for Writer {
 }
 
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 /// Panic handler
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {

--- a/boards/nucleo_f429zi/src/io.rs
+++ b/boards/nucleo_f429zi/src/io.rs
@@ -70,7 +70,6 @@ impl IoWrite for Writer {
 }
 
 /// Panic handler.
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     // User LD2 is connected to PB07

--- a/boards/nucleo_f446re/src/io.rs
+++ b/boards/nucleo_f446re/src/io.rs
@@ -69,7 +69,6 @@ impl IoWrite for Writer {
 }
 
 /// Panic handler.
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     // User LD2 is connected to PA05

--- a/boards/opentitan/src/io.rs
+++ b/boards/opentitan/src/io.rs
@@ -44,7 +44,6 @@ use kernel::hil::led;
 
 /// Panic handler.
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     use core::ptr::{addr_of, addr_of_mut};
@@ -84,7 +83,6 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
 }
 
 #[cfg(test)]
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let writer = &mut WRITER;

--- a/boards/particle_boron/src/io.rs
+++ b/boards/particle_boron/src/io.rs
@@ -61,7 +61,6 @@ impl IoWrite for Writer {
 const LED2_R_PIN: Pin = Pin::P0_13;
 
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 /// Panic handler
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {

--- a/boards/pico_explorer_base/src/io.rs
+++ b/boards/pico_explorer_base/src/io.rs
@@ -86,7 +86,6 @@ impl IoWrite for Writer {
 ///
 /// We just use the standard default provided by the debug module in the kernel.
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // LED is conneted to GPIO 25

--- a/boards/qemu_rv32_virt/src/io.rs
+++ b/boards/qemu_rv32_virt/src/io.rs
@@ -34,7 +34,6 @@ impl IoWrite for Writer {
 
 /// Panic handler.
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     use core::ptr::{addr_of, addr_of_mut};

--- a/boards/raspberry_pi_pico/src/io.rs
+++ b/boards/raspberry_pi_pico/src/io.rs
@@ -86,7 +86,6 @@ impl IoWrite for Writer {
 ///
 /// We just use the standard default provided by the debug module in the kernel.
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // LED is connected to GPIO 25

--- a/boards/redboard_redv/src/io.rs
+++ b/boards/redboard_redv/src/io.rs
@@ -35,7 +35,6 @@ impl IoWrite for Writer {
 
 /// Panic handler.
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // turn off the non panic leds, just in case

--- a/boards/sma_q3/src/io.rs
+++ b/boards/sma_q3/src/io.rs
@@ -43,7 +43,6 @@ impl IoWrite for Writer {
 }
 
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 /// Panic handler
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {

--- a/boards/stm32f3discovery/src/io.rs
+++ b/boards/stm32f3discovery/src/io.rs
@@ -67,7 +67,6 @@ impl IoWrite for Writer {
 }
 
 /// Panic handler.
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     // User LD3 is connected to PE09

--- a/boards/stm32f412gdiscovery/src/io.rs
+++ b/boards/stm32f412gdiscovery/src/io.rs
@@ -71,7 +71,6 @@ impl IoWrite for Writer {
 }
 
 /// Panic handler.
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     // User LD2 is connected to PB07

--- a/boards/stm32f429idiscovery/src/io.rs
+++ b/boards/stm32f429idiscovery/src/io.rs
@@ -71,7 +71,6 @@ impl IoWrite for Writer {
 }
 
 /// Panic handler.
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     // User LD4 is connected to PG14

--- a/boards/teensy40/src/io.rs
+++ b/boards/teensy40/src/io.rs
@@ -50,7 +50,6 @@ impl Write for Writer<'_> {
     }
 }
 
-#[no_mangle]
 #[panic_handler]
 unsafe fn panic_handler(panic_info: &core::panic::PanicInfo) -> ! {
     let ccm = crate::imxrt1060::ccm::Ccm::new();

--- a/boards/veer_el2_sim/src/io.rs
+++ b/boards/veer_el2_sim/src/io.rs
@@ -41,7 +41,6 @@ impl IoWrite for Writer {
 /// # Safety
 /// Accesses memory-mapped registers.
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let writer = &mut *addr_of_mut!(WRITER);

--- a/boards/weact_f401ccu6/src/io.rs
+++ b/boards/weact_f401ccu6/src/io.rs
@@ -70,7 +70,6 @@ impl IoWrite for Writer {
 }
 
 /// Panic handler.
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     // On-board LED C13 is connected to PC13

--- a/boards/wm1110dev/src/io.rs
+++ b/boards/wm1110dev/src/io.rs
@@ -69,7 +69,6 @@ impl IoWrite for Writer {
 ///
 /// We just use the standard default provided by the debug module in the kernel.
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // Red Led


### PR DESCRIPTION
### Pull Request Overview

This pull request deletes the `#[no_mangle]` directive from the `#[panic_handler]` as instructed by https://github.com/rust-lang/rust/issues/139923. This allows us to update the rust nightly version past 2025-03-19 without getting the `undefined symbol: __rustc::rust_begin_unwind` error.


### Testing Strategy

This pull request was tested by @alexandruradovici.


### TODO or Help Wanted

N/A


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
