### PR TITLE
Add `ProcessInfo` capsule that allows userspace to inspect and control processes

### DIFF
--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -71,6 +71,7 @@ pub mod nrf51822;
 pub mod panic_button;
 pub mod pressure;
 pub mod process_console;
+pub mod process_info_driver;
 pub mod process_printer;
 pub mod proximity;
 pub mod pwm;

--- a/boards/components/src/process_info_driver.rs
+++ b/boards/components/src/process_info_driver.rs
@@ -1,0 +1,58 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+//! Component for the process info capsule.
+
+use capsules_extra::process_info_driver::{self, ProcessInfo};
+use core::mem::MaybeUninit;
+use kernel::capabilities;
+use kernel::component::Component;
+use kernel::create_capability;
+
+#[macro_export]
+macro_rules! process_info_component_static {
+    () => {{
+        let process_info = kernel::static_buf!(
+            capsules_extra::process_info_driver::ProcessInfo<
+                components::process_info_driver::Capability,
+            >
+        );
+
+        process_info
+    };};
+}
+
+pub struct ProcessInfoComponent {
+    board_kernel: &'static kernel::Kernel,
+    driver_num: usize,
+}
+
+impl ProcessInfoComponent {
+    pub fn new(board_kernel: &'static kernel::Kernel, driver_num: usize) -> Self {
+        Self {
+            board_kernel,
+            driver_num,
+        }
+    }
+}
+
+pub struct Capability;
+unsafe impl capabilities::ProcessManagementCapability for Capability {}
+
+impl Component for ProcessInfoComponent {
+    type StaticInput = (&'static mut MaybeUninit<ProcessInfo<Capability>>,);
+    type Output = &'static process_info_driver::ProcessInfo<Capability>;
+
+    fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
+        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+
+        let process_info = static_buffer.0.write(ProcessInfo::new(
+            self.board_kernel,
+            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            Capability,
+        ));
+
+        process_info
+    }
+}

--- a/capsules/core/src/driver.rs
+++ b/capsules/core/src/driver.rs
@@ -27,6 +27,7 @@ pub enum NUM {
     // Kernel
     Ipc                   = 0x10000,
     AppLoader             = 0x10001,
+    ProcessInfo           = 0x10002,
 
     // HW Buses
     Spi                   = 0x20001,

--- a/capsules/extra/README.md
+++ b/capsules/extra/README.md
@@ -195,3 +195,5 @@ various elements of Tock.
 - **[Debug Process Restart](src/debug_process_restart.rs)**: Force all processes
   to enter a fault state when a button is pressed.
 - **[Panic Button](src/panic_button.rs)**: Use a button to force a `panic!()`.
+- **[Process Info](src/process_info_driver.rs)**: Inspect and control processes.
+

--- a/capsules/extra/src/lib.rs
+++ b/capsules/extra/src/lib.rs
@@ -79,6 +79,7 @@ pub mod nrf51822_serialization;
 pub mod panic_button;
 pub mod pca9544a;
 pub mod pressure;
+pub mod process_info_driver;
 pub mod proximity;
 pub mod public_key_crypto;
 pub mod pwm;

--- a/capsules/extra/src/process_info_driver.rs
+++ b/capsules/extra/src/process_info_driver.rs
@@ -53,7 +53,7 @@ mod rw_allow {
     pub const COUNT: u8 = 1;
 }
 
-pub struct ProcessInfo<C: ProcessManagementCapability> {
+pub struct ProcessInfo<C: ProcessManagementCapability + ProcessStartCapability> {
     apps: Grant<(), UpcallCount<0>, AllowRoCount<0>, AllowRwCount<{ rw_allow::COUNT }>>,
     /// Reference to the kernel object so we can access process state.
     kernel: &'static Kernel,
@@ -61,7 +61,7 @@ pub struct ProcessInfo<C: ProcessManagementCapability> {
     capability: C,
 }
 
-impl<C: ProcessManagementCapability> ProcessInfo<C> {
+impl<C: ProcessManagementCapability + ProcessStartCapability> ProcessInfo<C> {
     pub fn new(
         kernel: &'static Kernel,
         grant: Grant<(), UpcallCount<0>, AllowRoCount<0>, AllowRwCount<{ rw_allow::COUNT }>>,

--- a/capsules/extra/src/process_info_driver.rs
+++ b/capsules/extra/src/process_info_driver.rs
@@ -1,0 +1,254 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+//! Allow userspace to inspect and control processes on the board.
+//!
+//! ## Warning!
+//!
+//! This capsule is designed for testing and experimental use cases only. It
+//! should not be used in production! It was originally written for use in an
+//! educational tutorial to make it easy to interact with processes stored on
+//! the board from userspace using a screen.
+//!
+//! This capsule does require a capability to also indicate that this interacts
+//! with processes in a way that common capsules should not.
+//!
+//! ## Commands
+//!
+//! - 0: Check driver exists.
+//! - 1: Get the count of processes running on the board.
+//! - 2: Fill the allow RW buffer with the process IDs for the running processes
+//!   on the board. Returns the number of running processes.
+//! - 3: Fill the allow RW buffer with the short IDs for the running processes
+//!   on the board. Returns the number of running processes.
+//! - 4: Put the name of the process specified by the process ID in `data1` in
+//!   the allow RW buffer.
+//! - 5: Fill the allow RW buffer with the following information for the process
+//!   specified by the process ID in `data1`.
+//!   - The number of timeslice expirations.
+//!   - The number of syscalls called.
+//!   - The number of restarts.
+//!   - The current process state (running=0, yielded=1, yieldedfor=2,
+//!     stopped=3, faulted=4, terminated=5).
+//! - 10: Change the process state. `data1` is the process ID, and `data2 is the
+//!   new state.(1=start, 2=stop, 3=fault, 4=terminate, 5=boot).
+
+use kernel::capabilities::{ProcessManagementCapability, ProcessStartCapability};
+use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
+use kernel::process;
+use kernel::processbuffer::WriteableProcessBuffer;
+use kernel::syscall::{CommandReturn, SyscallDriver};
+use kernel::Kernel;
+use kernel::{ErrorCode, ProcessId};
+
+/// Syscall driver number.
+use capsules_core::driver;
+pub const DRIVER_NUM: usize = driver::NUM::ProcessInfo as usize;
+
+mod rw_allow {
+    pub const INFO: usize = 0;
+    /// The number of allow buffers the kernel stores for this grant
+    pub const COUNT: u8 = 1;
+}
+
+pub struct ProcessInfo<C: ProcessManagementCapability> {
+    apps: Grant<(), UpcallCount<0>, AllowRoCount<0>, AllowRwCount<{ rw_allow::COUNT }>>,
+    /// Reference to the kernel object so we can access process state.
+    kernel: &'static Kernel,
+    /// Capability needed to interact with and control processes.
+    capability: C,
+}
+
+impl<C: ProcessManagementCapability> ProcessInfo<C> {
+    pub fn new(
+        kernel: &'static Kernel,
+        grant: Grant<(), UpcallCount<0>, AllowRoCount<0>, AllowRwCount<{ rw_allow::COUNT }>>,
+        capability: C,
+    ) -> Self {
+        Self {
+            kernel,
+            apps: grant,
+            capability,
+        }
+    }
+
+    fn iterate_u32<F>(&self, process_id: ProcessId, func: F) -> u32
+    where
+        F: Fn(&dyn kernel::process::Process) -> u32,
+    {
+        let mut count = 0;
+        let _ = self.apps.enter(process_id, |_app, kernel_data| {
+            let _ = kernel_data
+                .get_readwrite_processbuffer(rw_allow::INFO)
+                .and_then(|shared| {
+                    shared.mut_enter(|s| {
+                        let mut chunks = s.chunks(size_of::<u32>());
+
+                        self.kernel
+                            .process_each_capability(&self.capability, |process| {
+                                // Get the next chunk to write the next
+                                // PID into.
+                                if let Some(chunk) = chunks.nth(0) {
+                                    let _ =
+                                        chunk.copy_from_slice_or_err(&func(process).to_le_bytes());
+                                }
+                                count += 1;
+                            });
+                    })
+                });
+        });
+        count as u32
+    }
+}
+
+impl<C: ProcessManagementCapability + ProcessStartCapability> SyscallDriver for ProcessInfo<C> {
+    fn command(
+        &self,
+        command_num: usize,
+        data1: usize,
+        data2: usize,
+        process_id: ProcessId,
+    ) -> CommandReturn {
+        match command_num {
+            // Driver existence check
+            0 => CommandReturn::success(),
+
+            1 => {
+                let mut count = 0;
+                self.kernel
+                    .process_each_capability(&self.capability, |_process| {
+                        count += 1;
+                    });
+                CommandReturn::success_u32(count)
+            }
+
+            2 => {
+                let count = self.iterate_u32(process_id, |process| process.processid().id() as u32);
+                CommandReturn::success_u32(count)
+            }
+
+            3 => {
+                let count = self.iterate_u32(process_id, |process| match process.short_app_id() {
+                    kernel::process::ShortId::LocallyUnique => 0,
+                    kernel::process::ShortId::Fixed(id) => id.into(),
+                });
+                CommandReturn::success_u32(count)
+            }
+
+            4 => {
+                let _ = self.apps.enter(process_id, |_app, kernel_data| {
+                    let _ = kernel_data
+                        .get_readwrite_processbuffer(rw_allow::INFO)
+                        .and_then(|shared| {
+                            shared.mut_enter(|s| {
+                                self.kernel
+                                    .process_each_capability(&self.capability, |process| {
+                                        if process.processid().id() == data1 {
+                                            let n = process.get_process_name().as_bytes();
+                                            let _ = s[0..n.len()].copy_from_slice_or_err(n);
+                                            s[n.len()].set(0);
+                                        }
+                                    });
+                            })
+                        });
+                });
+                CommandReturn::success()
+            }
+
+            5 => {
+                let _ = self.apps.enter(process_id, |_app, kernel_data| {
+                    let _ = kernel_data
+                        .get_readwrite_processbuffer(rw_allow::INFO)
+                        .and_then(|shared| {
+                            shared.mut_enter(|s| {
+                                let mut chunks = s.chunks(size_of::<u32>());
+                                self.kernel
+                                    .process_each_capability(&self.capability, |process| {
+                                        if process.processid().id() == data1 {
+                                            if let Some(chunk) = chunks.nth(0) {
+                                                let _ = chunk.copy_from_slice_or_err(
+                                                    &process
+                                                        .debug_timeslice_expiration_count()
+                                                        .to_le_bytes(),
+                                                );
+                                            }
+                                            if let Some(chunk) = chunks.nth(0) {
+                                                let _ = chunk.copy_from_slice_or_err(
+                                                    &process.debug_syscall_count().to_le_bytes(),
+                                                );
+                                            }
+                                            if let Some(chunk) = chunks.nth(0) {
+                                                let _ = chunk.copy_from_slice_or_err(
+                                                    &process.get_restart_count().to_le_bytes(),
+                                                );
+                                            }
+                                            if let Some(chunk) = chunks.nth(0) {
+                                                let process_state_id: u32 =
+                                                    match process.get_state() {
+                                                        process::State::Running => 0,
+                                                        process::State::Yielded => 1,
+                                                        process::State::YieldedFor(_) => 2,
+                                                        process::State::Stopped(_) => 3,
+                                                        process::State::Faulted => 4,
+                                                        process::State::Terminated => 5,
+                                                    };
+
+                                                let _ = chunk.copy_from_slice_or_err(
+                                                    &process_state_id.to_le_bytes(),
+                                                );
+                                            }
+                                        }
+                                    });
+                            })
+                        });
+                });
+                CommandReturn::success()
+            }
+
+            10 => {
+                self.kernel
+                    .process_each_capability(&self.capability, |process| {
+                        if process.processid().id() == data1 {
+                            match data2 {
+                                1 => {
+                                    // START
+                                    process.resume();
+                                }
+                                2 => {
+                                    // STOP
+                                    process.stop();
+                                }
+
+                                3 => {
+                                    // FAULT
+                                    process.set_fault_state();
+                                }
+
+                                4 => {
+                                    // TERMINATE
+                                    process.terminate(None);
+                                }
+
+                                5 => {
+                                    // BOOT
+                                    if process.get_state() == process::State::Terminated {
+                                        process.start(&self.capability);
+                                    }
+                                }
+
+                                _ => {}
+                            }
+                        }
+                    });
+                CommandReturn::success()
+            }
+
+            _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
+        }
+    }
+
+    fn allocate_grant(&self, processid: ProcessId) -> Result<(), kernel::process::Error> {
+        self.apps.enter(processid, |_, _| {})
+    }
+}

--- a/doc/syscalls/README.md
+++ b/doc/syscalls/README.md
@@ -57,6 +57,7 @@ the tables below. The "2.0" column indicates whether the driver has been
 |   | 0x00009       | [ROS](00009_ros.md) | Read Only State, access system information |
 |   | 0x10000       | IPC              | Inter-process communication                |
 |   | 0x10001       | DBS              | Dynamic Binary Storage/Process Loading     |
+|   | 0x10002       | ProcessInfo      | Inspect and control processes              |
 
 ### Hardware Access
 


### PR DESCRIPTION
### Pull Request Overview

This capsule is used for the dynamic process loading tutorial by allowing users to list the processes on a screen and start/stop/inspect the processes.


### Testing Strategy

There is a libtock-c implementation that uses this capsule.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
