### PR TITLE
Refactored the PMP address check for RV32 vs RV64

### DIFF
--- a/arch/riscv/src/pmp.rs
+++ b/arch/riscv/src/pmp.rs
@@ -43,7 +43,9 @@ register_bitfields![u8,
 /// this mask achieves the same effect; thus it can be used to determine whether
 /// a given PMP region spec would be legal and applied before writing it to a
 /// `pmpaddrX` CSR.
-const PMPADDR_RV64_MASK: u64 = 0x003F_FFFF_FFFF_FFFF;
+/// This mask will have the value `0x003F_FFFF_FFFF_FFFF` on RV64 platforms, and
+/// `0xFFFFFFFF` on RV32 platforms.
+const PMPADDR_RV64_MASK: usize = (0x003F_FFFF_FFFF_FFFFu64 & usize::MAX as u64) as usize;
 
 /// A `pmpcfg` octet for a user-mode (non-locked) TOR-addressed PMP region.
 ///
@@ -142,14 +144,11 @@ impl NAPOTRegionSpec {
     /// rejects the `pmpaddr` (tests whether any of the 10 most significant bits
     /// are non-zero).
     pub fn from_pmpaddr_csr(pmpaddr: usize) -> Option<Self> {
-        // On 64-bit platforms, the 10 most significant bits must be 0:
-        if core::mem::size_of::<usize>() == core::mem::size_of::<u64>() {
-            if (pmpaddr as u64) & !PMPADDR_RV64_MASK != 0 {
-                return None;
-            }
-        }
-
-        Some(NAPOTRegionSpec { pmpaddr })
+        // On 64-bit platforms, the 10 most significant bits must be 0
+        // Prevent the `&-masking with zero` lint error in case of RV32
+        // The redundant checks in this case are optimized out by the compiler on any 1-3,z opt-level
+        #[allow(clippy::bad_bit_mask)]
+        (pmpaddr & !PMPADDR_RV64_MASK == 0).then_some(NAPOTRegionSpec { pmpaddr })
     }
 
     /// Construct a new [`NAPOTRegionSpec`] from a start address and size.
@@ -241,26 +240,16 @@ impl TORRegionSpec {
     /// this case, returns `None` (tests whether any of the 10 most significant
     /// bits of either `pmpaddr` are non-zero).
     pub fn from_pmpaddr_csrs(pmpaddr_a: usize, pmpaddr_b: usize) -> Option<TORRegionSpec> {
-        if pmpaddr_a >= pmpaddr_b {
-            return None;
-        }
-
-        // On 64-bit platforms, the 10 most significant bits must be 0:
-        if core::mem::size_of::<usize>() == core::mem::size_of::<u64>() {
-            // Checking pmpaddr_b should be sufficient (as it must be greater),
-            // but we'll leave it up to the compiler to be smart enough to
-            // figure that out:
-            if (pmpaddr_a as u64) & !PMPADDR_RV64_MASK != 0
-                || (pmpaddr_b as u64) & !PMPADDR_RV64_MASK != 0
-            {
-                return None;
-            }
-        }
-
-        Some(TORRegionSpec {
-            pmpaddr_a,
-            pmpaddr_b,
-        })
+        // Prevent the `&-masking with zero` lint error in case of RV32
+        // The redundant checks in this case are optimized out by the compiler on any 1-3,z opt-level
+        #[allow(clippy::bad_bit_mask)]
+        ((pmpaddr_a < pmpaddr_b)
+            && (pmpaddr_a & !PMPADDR_RV64_MASK == 0)
+            && (pmpaddr_b & !PMPADDR_RV64_MASK == 0))
+            .then_some(TORRegionSpec {
+                pmpaddr_a,
+                pmpaddr_b,
+            })
     }
 
     /// Construct a new [`TORRegionSpec`] from a range of addresses.


### PR DESCRIPTION
### Pull Request Overview

Removing runtime checks for the size of  `usize` in favor of compile-time mask calculation. 
Some "rustification" of condition checks


### Testing Strategy

Unit-tested in isolation. Functionally tested on RV32 QEMU  


### TODO or Help Wanted

N/A


### Documentation Updated

N/A

### Formatting

- [x] Ran `make prepush`.
