### PR TITLE
Fix abort upcall bug

### DIFF
--- a/capsules/extra/src/app_loader.rs
+++ b/capsules/extra/src/app_loader.rs
@@ -504,7 +504,6 @@ impl<
                 match result {
                     Ok(()) => {
                         self.new_app_length.set(0);
-                        self.current_process.take();
                         CommandReturn::success()
                     }
                     Err(e) => {


### PR DESCRIPTION
### Pull Request Overview

Because of an extraneous `self.process.take()` in the synchronous response to the `abort` call, the capsule was unable to send the asynchronous upcall on a successful/unsuccessful abort operation. This PR fixes this issue.


### Testing Strategy

I tested both versions of the kernel on my nrf52840dk.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
