### PR TITLE
Exit qemu using the panic command

### DIFF
--- a/boards/qemu_i486_q35/Makefile
+++ b/boards/qemu_i486_q35/Makefile
@@ -20,7 +20,8 @@ QEMU_BASE_CMDLINE := \
     -cpu 486 \
     -machine q35 \
     -net none \
-    -nographic
+    -nographic \
+    -device isa-debug-exit,iobase=0xf4,iosize=0x04
 
 # Run the kernel inside a qemu-system-i386 "q35" machine type simulation
 #
@@ -38,7 +39,7 @@ QEMU_BASE_CMDLINE := \
 run: $(TARGET_PATH)/release/$(PLATFORM).elf
 	@echo
 	@echo Reordering ELF file sections
-	@objcopy $<
+	@$(OBJCOPY_PATH)objcopy  $<
 	@echo
 	@echo -e "Running $$(qemu-system-i386 --version | head -n1)"\
 	  "(tested: $(WORKING_QEMU_VERSION)) with\n"\

--- a/boards/qemu_i486_q35/Makefile
+++ b/boards/qemu_i486_q35/Makefile
@@ -39,7 +39,7 @@ QEMU_BASE_CMDLINE := \
 run: $(TARGET_PATH)/release/$(PLATFORM).elf
 	@echo
 	@echo Reordering ELF file sections
-	@$(OBJCOPY_PATH)objcopy  $<
+	@$(OBJCOPY)  $<
 	@echo
 	@echo -e "Running $$(qemu-system-i386 --version | head -n1)"\
 	  "(tested: $(WORKING_QEMU_VERSION)) with\n"\

--- a/boards/qemu_i486_q35/src/io.rs
+++ b/boards/qemu_i486_q35/src/io.rs
@@ -15,6 +15,8 @@ use crate::{CHIP, PROCESSES, PROCESS_PRINTER};
 #[cfg(not(test))]
 #[panic_handler]
 unsafe fn panic_handler(pi: &PanicInfo) -> ! {
+    use core::arch::asm;
+
     let mut com1 = BlockingSerialPort::new(COM1_BASE);
 
     debug::panic_print(
@@ -24,6 +26,15 @@ unsafe fn panic_handler(pi: &PanicInfo) -> ! {
         &*ptr::addr_of!(PROCESSES),
         &*ptr::addr_of!(CHIP),
         &*ptr::addr_of!(PROCESS_PRINTER),
+    );
+
+    // stop qemu
+    asm!(
+        "
+        mov dx, 0xf4
+        mov al, 0x01
+        out dx,al
+        "
     );
 
     loop {}

--- a/boards/qemu_i486_q35/src/io.rs
+++ b/boards/qemu_i486_q35/src/io.rs
@@ -39,7 +39,12 @@ fn exit_qemu() -> ! {
         \r\nHINT: Use `killall qemu-system-i386` or the Task Manager to stop.\
         \r\n"
     ));
-    loop {}
+
+    // We use the `htl` instruction in the infinite loop to prevent high CPU usage
+    // if QEMU did not exit.
+    loop {
+        unsafe { asm!("hlt") }
+    }
 }
 
 /// Panic handler.


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the panic handler of the `qemu_i486_q35` board to exit the QEMU instead of continuously looping. It uses a special QEMU debug device.


### Testing Strategy

This pull request was tested by @alexandruradovici.


### TODO or Help Wanted

N/A


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
