### PR TITLE
arch: Cortex-M: Set MPU address per arch

### DIFF
--- a/arch/cortex-m/src/mpu.rs
+++ b/arch/cortex-m/src/mpu.rs
@@ -129,9 +129,6 @@ register_bitfields![u32,
     ]
 ];
 
-const MPU_BASE_ADDRESS: StaticRef<MpuRegisters> =
-    unsafe { StaticRef::new(0xE000ED90 as *const MpuRegisters) };
-
 /// State related to the real physical MPU.
 ///
 /// There should only be one instantiation of this object as it represents
@@ -149,9 +146,9 @@ pub struct MPU<const NUM_REGIONS: usize, const MIN_REGION_SIZE: usize> {
 }
 
 impl<const NUM_REGIONS: usize, const MIN_REGION_SIZE: usize> MPU<NUM_REGIONS, MIN_REGION_SIZE> {
-    pub const unsafe fn new() -> Self {
+    pub const unsafe fn new(registers: StaticRef<MpuRegisters>) -> Self {
         Self {
-            registers: MPU_BASE_ADDRESS,
+            registers,
             config_count: Cell::new(NonZeroUsize::MIN),
             hardware_is_configured_for: OptionalCell::empty(),
         }

--- a/arch/cortex-m0p/src/lib.rs
+++ b/arch/cortex-m0p/src/lib.rs
@@ -11,7 +11,16 @@
 use core::fmt::Write;
 
 pub mod mpu {
+    use kernel::utilities::StaticRef;
+
     pub type MPU = cortexm::mpu::MPU<8, 256>;
+
+    const MPU_BASE_ADDRESS: StaticRef<cortexm::mpu::MpuRegisters> =
+        unsafe { StaticRef::new(0xE000ED90 as *const cortexm::mpu::MpuRegisters) };
+
+    pub unsafe fn new() -> MPU {
+        MPU::new(MPU_BASE_ADDRESS)
+    }
 }
 
 // Re-export the base generic cortex-m functions here as they are

--- a/arch/cortex-m3/src/lib.rs
+++ b/arch/cortex-m3/src/lib.rs
@@ -11,7 +11,16 @@
 use core::fmt::Write;
 
 pub mod mpu {
+    use kernel::utilities::StaticRef;
+
     pub type MPU = cortexm::mpu::MPU<8, 32>;
+
+    const MPU_BASE_ADDRESS: StaticRef<cortexm::mpu::MpuRegisters> =
+        unsafe { StaticRef::new(0xE000ED90 as *const cortexm::mpu::MpuRegisters) };
+
+    pub unsafe fn new() -> MPU {
+        MPU::new(MPU_BASE_ADDRESS)
+    }
 }
 
 pub use cortexm::initialize_ram_jump_to_main;

--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -11,7 +11,16 @@
 use core::fmt::Write;
 
 pub mod mpu {
+    use kernel::utilities::StaticRef;
+
     pub type MPU = cortexm::mpu::MPU<8, 32>;
+
+    const MPU_BASE_ADDRESS: StaticRef<cortexm::mpu::MpuRegisters> =
+        unsafe { StaticRef::new(0xE000ED90 as *const cortexm::mpu::MpuRegisters) };
+
+    pub unsafe fn new() -> MPU {
+        MPU::new(MPU_BASE_ADDRESS)
+    }
 }
 
 pub use cortexm::dwt;

--- a/arch/cortex-m4f/src/lib.rs
+++ b/arch/cortex-m4f/src/lib.rs
@@ -11,7 +11,16 @@
 use core::fmt::Write;
 
 pub mod mpu {
+    use kernel::utilities::StaticRef;
+
     pub type MPU = cortexm::mpu::MPU<8, 32>;
+
+    const MPU_BASE_ADDRESS: StaticRef<cortexm::mpu::MpuRegisters> =
+        unsafe { StaticRef::new(0xE000ED90 as *const cortexm::mpu::MpuRegisters) };
+
+    pub unsafe fn new() -> MPU {
+        MPU::new(MPU_BASE_ADDRESS)
+    }
 }
 
 pub use cortexm::dwt;

--- a/arch/cortex-m7/src/lib.rs
+++ b/arch/cortex-m7/src/lib.rs
@@ -11,7 +11,16 @@
 use core::fmt::Write;
 
 pub mod mpu {
+    use kernel::utilities::StaticRef;
+
     pub type MPU = cortexm::mpu::MPU<16, 32>; // Cortex-M7 MPU has 16 regions
+
+    const MPU_BASE_ADDRESS: StaticRef<cortexm::mpu::MpuRegisters> =
+        unsafe { StaticRef::new(0xE000ED90 as *const cortexm::mpu::MpuRegisters) };
+
+    pub unsafe fn new() -> MPU {
+        MPU::new(MPU_BASE_ADDRESS)
+    }
 }
 
 pub use cortexm::initialize_ram_jump_to_main;

--- a/chips/apollo3/src/chip.rs
+++ b/chips/apollo3/src/chip.rs
@@ -18,7 +18,7 @@ pub struct Apollo3<I: InterruptService + 'static> {
 impl<I: InterruptService + 'static> Apollo3<I> {
     pub unsafe fn new(interrupt_service: &'static I) -> Self {
         Self {
-            mpu: cortexm4f::mpu::MPU::new(),
+            mpu: cortexm4f::mpu::new(),
             userspace_kernel_boundary: cortexm4f::syscall::SysCall::new(),
             interrupt_service,
         }

--- a/chips/imxrt10xx/src/chip.rs
+++ b/chips/imxrt10xx/src/chip.rs
@@ -20,7 +20,7 @@ pub struct Imxrt10xx<I: InterruptService + 'static> {
 impl<I: InterruptService + 'static> Imxrt10xx<I> {
     pub unsafe fn new(interrupt_service: &'static I) -> Self {
         Imxrt10xx {
-            mpu: cortexm7::mpu::MPU::new(),
+            mpu: cortexm7::mpu::new(),
             userspace_kernel_boundary: cortexm7::syscall::SysCall::new(),
             interrupt_service,
         }

--- a/chips/msp432/src/chip.rs
+++ b/chips/msp432/src/chip.rs
@@ -97,7 +97,7 @@ impl kernel::platform::chip::InterruptService for Msp432DefaultPeripherals<'_> {
 impl<'a, I: InterruptService + 'a> Msp432<'a, I> {
     pub unsafe fn new(interrupt_service: &'a I) -> Self {
         Self {
-            mpu: cortexm4::mpu::MPU::new(),
+            mpu: cortexm4::mpu::new(),
             userspace_kernel_boundary: cortexm4::syscall::SysCall::new(),
             interrupt_service,
         }

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -15,7 +15,7 @@ pub struct NRF52<'a, I: InterruptService + 'a> {
 impl<'a, I: InterruptService + 'a> NRF52<'a, I> {
     pub unsafe fn new(interrupt_service: &'a I) -> Self {
         Self {
-            mpu: cortexm4f::mpu::MPU::new(),
+            mpu: cortexm4f::mpu::new(),
             userspace_kernel_boundary: cortexm4f::syscall::SysCall::new(),
             interrupt_service,
         }

--- a/chips/psoc62xa/src/chip.rs
+++ b/chips/psoc62xa/src/chip.rs
@@ -17,7 +17,7 @@ pub struct Psoc62xa<'a, I: InterruptService + 'a> {
 impl<'a, I: InterruptService> Psoc62xa<'a, I> {
     pub fn new(interrupt_service: &'a I) -> Self {
         Self {
-            mpu: unsafe { cortexm0p::mpu::MPU::new() },
+            mpu: unsafe { cortexm0p::mpu::new() },
             userspace_kernel_boundary: unsafe { cortexm0p::syscall::SysCall::new() },
             interrupt_service,
         }

--- a/chips/rp2040/src/chip.rs
+++ b/chips/rp2040/src/chip.rs
@@ -44,7 +44,7 @@ pub struct Rp2040<'a, I: InterruptService + 'a> {
 impl<'a, I: InterruptService> Rp2040<'a, I> {
     pub unsafe fn new(interrupt_service: &'a I, sio: &'a SIO) -> Self {
         Self {
-            mpu: cortexm0p::mpu::MPU::new(),
+            mpu: cortexm0p::mpu::new(),
             userspace_kernel_boundary: cortexm0p::syscall::SysCall::new(),
             interrupt_service,
             sio,

--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -20,7 +20,7 @@ pub struct Sam4l<I: InterruptService + 'static> {
 impl<I: InterruptService + 'static> Sam4l<I> {
     pub unsafe fn new(pm: &'static crate::pm::PowerManager, interrupt_service: &'static I) -> Self {
         Self {
-            mpu: cortexm4::mpu::MPU::new(),
+            mpu: cortexm4::mpu::new(),
             userspace_kernel_boundary: cortexm4::syscall::SysCall::new(),
             pm,
             interrupt_service,

--- a/chips/stm32f303xc/src/chip.rs
+++ b/chips/stm32f303xc/src/chip.rs
@@ -94,7 +94,7 @@ impl InterruptService for Stm32f3xxDefaultPeripherals<'_> {
 impl<'a, I: InterruptService + 'a> Stm32f3xx<'a, I> {
     pub unsafe fn new(interrupt_service: &'a I) -> Self {
         Self {
-            mpu: cortexm4f::mpu::MPU::new(),
+            mpu: cortexm4f::mpu::new(),
             userspace_kernel_boundary: cortexm4f::syscall::SysCall::new(),
             interrupt_service,
         }

--- a/chips/stm32f4xx/src/chip.rs
+++ b/chips/stm32f4xx/src/chip.rs
@@ -155,7 +155,7 @@ impl<ChipSpecs: ChipSpecsTrait> InterruptService for Stm32f4xxDefaultPeripherals
 impl<'a, I: InterruptService + 'a> Stm32f4xx<'a, I> {
     pub unsafe fn new(interrupt_service: &'a I) -> Self {
         Self {
-            mpu: cortexm4f::mpu::MPU::new(),
+            mpu: cortexm4f::mpu::new(),
             userspace_kernel_boundary: cortexm4f::syscall::SysCall::new(),
             interrupt_service,
         }


### PR DESCRIPTION
### Pull Request Overview

It seems that newer Cortex-M variants (eg Cortex-M33) support the same MPU but at a different (not secure) address. This generalizes setting the address to per-arch, so that each cortex-m arch can choose the appropriate register start address.

This is inspired by #4416 because I think we want to avoid having a `StaticRef` to registers that don't actually exist at that address.

### Testing Strategy

travis


### TODO or Help Wanted

The tradeoff is we now have the unsafe StaticRef definition in several places rather than one, but I think that is still worth it. I added a `new()` function to each arch's `mpu` module so that choosing the register is up to the arch and not the chip. Let me know if you see a better way to do this.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
