### PR TITLE
kernel: hil: ethernet: fix doc links

### DIFF
--- a/kernel/src/hil/ethernet.rs
+++ b/kernel/src/hil/ethernet.rs
@@ -107,17 +107,17 @@ pub trait EthernetAdapterDatapath<'a> {
     /// Enable reception of Ethernet frames.
     ///
     /// Ethernet adapters must not invoke any
-    /// [`EthernetAdapaterClient::received_frame`] client methods before this
-    /// function is called, and not after [`EthernetAdapater::disable_receive`]
-    /// is called.
+    /// [`EthernetAdapterDatapathClient::received_frame`] client methods before
+    /// this function is called, and not after
+    /// [`EthernetAdapterDatapath::disable_receive`] is called.
     fn enable_receive(&self);
 
     /// Disable reception of Ethernet frames.
     ///
     /// Ethernet adapters must not invoke any
-    /// [`EthernetAdapaterClient::received_frame`] client methods after this
-    /// function is called, until a subsequent call to
-    /// [`EthernetAdapater::enable_receive`].
+    /// [`EthernetAdapterDatapathClient::received_frame`] client methods after
+    /// this function is called, until a subsequent call to
+    /// [`EthernetAdapterDatapath::enable_receive`].
     fn disable_receive(&self);
 
     /// Transmit an Ethernet frame / enqueue a frame for transmission.


### PR DESCRIPTION
### Pull Request Overview

Fix links in ethernet HIL docs.


### Testing Strategy

Nothing I guess?? I ran `cargo doc` locally without warnings.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
