### PR TITLE
x86: fix doc warnings and links

### DIFF
--- a/arch/x86/src/interrupts/poller.rs
+++ b/arch/x86/src/interrupts/poller.rs
@@ -23,7 +23,7 @@ use super::NUM_VECTORS;
 /// `e310x` chip crate.
 ///
 /// Internally, it maintains a large bitfield with a separate flag for every possible interrupt
-/// vector (total of [`NUM_VECTORS`]). When an interrupt occurs, a very lightweight ISR is
+/// vector (total of `NUM_VECTORS`). When an interrupt occurs, a very lightweight ISR is
 /// responsible for setting the corresponding flag. To poll for pending interrupts from within the
 /// kernel loop, we simply need to iterate over this bitfield and return the index of each active
 /// bit.
@@ -61,7 +61,7 @@ static mut SINGLETON: InterruptPoller = InterruptPoller {
 impl InterruptPoller {
     /// Provides safe access to the singleton instance of `InterruptPoller`.
     ///
-    /// The given closure `f` is executed with interrupts disabled (using [`support::atomic`]) and
+    /// The given closure `f` is executed with interrupts disabled (using [`support::atomic`](crate::support::atomic)) and
     /// passed a reference to the singleton.
     pub fn access<F, R>(f: F) -> R
     where

--- a/arch/x86/src/support.rs
+++ b/arch/x86/src/support.rs
@@ -4,14 +4,14 @@
 
 //! Miscellaneous low-level operations
 
-#[cfg(target_arch = "x86")]
+#[cfg(any(doc, target_arch = "x86"))]
 use core::arch::asm;
 
 /// Execute a given closure atomically.
 ///
 /// This function ensures interrupts are disabled before invoking the given closue `f`. This allows
 /// you to safely perform memory accesses which would otherwise race against interrupt handlers.
-#[cfg(target_arch = "x86")]
+#[cfg(any(doc, target_arch = "x86"))]
 pub fn atomic<F, R>(f: F) -> R
 where
     F: FnOnce() -> R,
@@ -49,7 +49,7 @@ where
 }
 
 /// Executes a single NOP instruction.
-#[cfg(target_arch = "x86")]
+#[cfg(any(doc, target_arch = "x86"))]
 #[inline(always)]
 pub fn nop() {
     unsafe {

--- a/boards/qemu_i486_q35/src/multiboot.rs
+++ b/boards/qemu_i486_q35/src/multiboot.rs
@@ -4,7 +4,7 @@
 
 //! Minimal implementation of Multiboot V1
 //!
-//! https://www.gnu.org/software/grub/manual/multiboot/multiboot.html
+//! <https://www.gnu.org/software/grub/manual/multiboot/multiboot.html>
 
 /// Magic number for Multboot V1 header
 const MAGIC_NUMBER: u32 = 0x1BADB002;

--- a/chips/x86_q35/src/pic.rs
+++ b/chips/x86_q35/src/pic.rs
@@ -6,8 +6,8 @@
 //!
 //! This implementation is based on guidance from the following sources:
 //!
-//! * https://wiki.osdev.org/8259_PIC
-//! * https://github.com/rust-osdev/pic8259
+//! * <https://wiki.osdev.org/8259_PIC>
+//! * <https://github.com/rust-osdev/pic8259>
 
 use x86::registers::io;
 use x86::IDT_RESERVED_EXCEPTIONS;

--- a/chips/x86_q35/src/pit.rs
+++ b/chips/x86_q35/src/pit.rs
@@ -14,8 +14,8 @@
 //!
 //! This implementation is based on guidance from the following sources:
 //!
-//! * https://wiki.osdev.org/Programmable_Interval_Timer
-//! * https://en.wikipedia.org/wiki/Intel_8253
+//! * <https://wiki.osdev.org/Programmable_Interval_Timer>
+//! * <https://en.wikipedia.org/wiki/Intel_8253>
 
 use core::cell::Cell;
 

--- a/chips/x86_q35/src/serial.rs
+++ b/chips/x86_q35/src/serial.rs
@@ -9,9 +9,9 @@
 //!
 //! This implementation is based on guidance from the following sources:
 //!
-//! * https://en.wikibooks.org/wiki/Serial_Programming/8250_UART_Programming
-//! * https://wiki.osdev.org/Serial_Ports
-//! * https://docs.freebsd.org/en/articles/serial-uart/index.html
+//! * <https://en.wikibooks.org/wiki/Serial_Programming/8250_UART_Programming>
+//! * <https://wiki.osdev.org/Serial_Ports>
+//! * <https://docs.freebsd.org/en/articles/serial-uart/index.html>
 
 use core::cell::Cell;
 use core::fmt::{self, Write};
@@ -47,7 +47,7 @@ pub const COM4_BASE: u16 = 0x02E8;
 const BAUD_CLOCK: u32 = 115_200;
 
 /// The following offsets are relative to the base I/O port address of an 8250-compatible UART
-/// device. Reference: https://en.wikibooks.org/wiki/Serial_Programming/8250_UART_Programming
+/// device. Reference: <https://en.wikibooks.org/wiki/Serial_Programming/8250_UART_Programming>
 mod offsets {
     /// Transmit Holding Register
     pub(crate) const THR: u16 = 0;


### PR DESCRIPTION
### Pull Request Overview

Update warnings in x86 docs.


### Testing Strategy

Nothing I guess?? I ran `cargo doc` locally without warnings.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
