### PR TITLE
arch: cortex-m: Do a pass on Cortex-M crate comments/docs

### DIFF
--- a/arch/cortex-m/src/dcb.rs
+++ b/arch/cortex-m/src/dcb.rs
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-//! ARM Debug Control Block
+//! Cortex-M Debug Control Block (DCB)
 //!
 //! <https://developer.arm.com/documentation/ddi0403/latest>
+//!
 //! Implementation matches `ARM DDI 0403E.e`
 
 use kernel::utilities::registers::interfaces::ReadWriteable;
@@ -31,30 +32,38 @@ register_structs! {
 
 register_bitfields![u32,
     DebugHaltingControlAndStatus [
-        /// Debug key. 0xA05F must be written to enable write access to bits 15 through 0.
+        /// Debug key. 0xA05F must be written to enable write access to bits 15
+        /// through 0.
+        ///
         /// WO.
         DBGKEY          OFFSET(16)  NUMBITS(16),
 
-        /// Is 1 if at least one reset happend since last read of this register. Is cleared to 0 on
-        /// read.
+        /// Is 1 if at least one reset happened since last read of this
+        /// register. Is cleared to 0 on read.
+        ///
         /// RO.
         S_RESET_ST      OFFSET(25)  NUMBITS(1),
 
-        /// Is 1 if at least one instruction was retired since last read of this register.
-        /// It is cleared to 0 after a read of this register.
+        /// Is 1 if at least one instruction was retired since last read of this
+        /// register. It is cleared to 0 after a read of this register.
+        ///
         /// RO.
         S_RETIRE_ST     OFFSET(24)  NUMBITS(1),
 
-        /// Is 1 when the processor is locked up doe tu an unrecoverable instruction.
+        /// Is 1 when the processor is locked up doe tu an unrecoverable
+        /// instruction.
+        ///
         /// RO.
         S_LOCKUP        OFFSET(20)  NUMBITS(4),
 
         /// Is 1 if processor is in debug state.
+        ///
         /// RO.
         S_SLEEP         OFFSET(18)  NUMBITS(1),
 
-        /// Is used as a handshake flag for transfers through DCRDR. Writing to DCRSR clears this
-        /// bit to 0. Is 0 if there is a transfer that has not completed and 1 on completion of the DCRSR transfer.
+        /// Is used as a handshake flag for transfers through DCRDR. Writing to
+        /// DCRSR clears this bit to 0. Is 0 if there is a transfer that has
+        /// not completed and 1 on completion of the DCRSR transfer.
         ///
         /// RW.
         S_REGREADY      OFFSET(16)  NUMBITS(1),
@@ -69,12 +78,12 @@ register_bitfields![u32,
         /// Write 1 to globally enable all DWT and ITM features.
         TRCENA          OFFSET(24)  NUMBITS(1),
 
-        /// Debug monitor semaphore bit.
-        /// Monitor software defined.
+        /// Debug monitor semaphore bit. Monitor software defined.
         MON_REQ         OFFSET(19)  NUMBITS(1),
 
         /// Write 1 to make step request pending.
         MON_STEP        OFFSET(18)  NUMBITS(1),
+
         /// Write 0 to clear the pending state of the DebugMonitor exception.
         /// Writing 1 pends the exception.
         MON_PEND        OFFSET(17)  NUMBITS(1),
@@ -86,14 +95,15 @@ register_bitfields![u32,
 
 const DCB: StaticRef<DcbRegisters> = unsafe { StaticRef::new(0xE000EDF0 as *const DcbRegisters) };
 
-/// Enable the Debug and Trace unit `DWT`
-/// This has to be enabled before using any feature of the `DWT`
+/// Enable the Debug and Trace unit `DWT`.
+///
+/// This has to be enabled before using any feature of the `DWT`.
 pub fn enable_debug_and_trace() {
     DCB.demcr
         .modify(DebugExceptionAndMonitorControl::TRCENA::SET);
 }
 
-/// Disable the Debug and Trace unit `DWT`
+/// Disable the Debug and Trace unit `DWT`.
 pub fn disable_debug_and_trace() {
     DCB.demcr
         .modify(DebugExceptionAndMonitorControl::TRCENA::CLEAR);

--- a/arch/cortex-m/src/dwt.rs
+++ b/arch/cortex-m/src/dwt.rs
@@ -118,89 +118,90 @@ register_bitfields![u32,
 
         /// Writing 1 enables event counter packets generation if
         /// [`PCSAMPLENA`] is set to 0. Defaults to 0b0 on reset.
-        /// WARN: This bit is UNKNOWN if `NOTPRCPKT` or `NOCYCCNT` is read as one.
+        /// WARN: This bit is UNKNOWN if [`NOTPRCPKT`] or [`NOCYCCNT`] is read
+        /// as one.
         /// RW
         CYCEVTENA       OFFSET(22)  NUMBITS(1),
 
         /// Writing 1 enables generation of folded instruction counter overflow
         /// event. Defaults to 0b0 on reset.
-        /// WARN: This bit is UNKNOWN if `NOPERFCNT` reads as one.
+        /// WARN: This bit is UNKNOWN if [`NOPERFCNT`] reads as one.
         /// RW
         FOLDEVTENA      OFFSET(21)  NUMBITS(1),
 
         /// Writing 1 enables generation of LSU counter overflow event.
         /// Defaults to 0b0 on reset.
-        /// WARN: This bit is UNKNOWN if `NOPERFCNT` reads as one.
+        /// WARN: This bit is UNKNOWN if [`NOPERFCNT`] reads as one.
         /// RW
         LSUEVTENA       OFFSET(20)  NUMBITS(1),
 
         /// Writing 1 enables generation of sleep counter overflow event.
         /// Defaults to 0b0 on reset.
-        /// WARN: This bit is UNKNOWN if `NOPERFCNT` reads as one.
+        /// WARN: This bit is UNKNOWN if [`NOPERFCNT`] reads as one.
         /// RW
         SLEEPEVTENA     OFFSET(19)  NUMBITS(1),
 
         /// Writing 1 enables generation of exception overhead counter overflow event.
         /// Defaults to 0b0 on reset.
-        /// WARN: This bit is UNKNOWN if `NOPERFCNT` reads as one.
+        /// WARN: This bit is UNKNOWN if [`NOPERFCNT`] reads as one.
         /// RW
         EXCEVTENA       OFFSET(18)  NUMBITS(1),
 
         /// Writing 1 enables generation of the CPI counter overlow event.
         /// Defaults to 0b0 on reset.
-        /// WARN: This bit is UNKNOWN if `NOPERFCNT` reads as one.
+        /// WARN: This bit is UNKNOWN if [`NOPERFCNT`] reads as one.
         /// RW
         CPIEVTENA       OFFSET(17)  NUMBITS(1),
 
         /// Writing 1 enables generation of exception trace.
         /// Defaults to 0b0 on reset.
-        /// WARN: This bit is UNKNOWN if `NOTRCPKT` reads as one.
+        /// WARN: This bit is UNKNOWN if [`NOTRCPKT`] reads as one.
         /// RW
         EXCTRCENA       OFFSET(16)  NUMBITS(1),
 
         /// Writing 1 enables use of [`POSTCNT`] counter as a timer for Periodic
         /// PC sample packet generation.
         /// Defaults to 0b0 on reset.
-        /// WARN: This bit is UNKNOWN if `NOTRCPKT` or `NOCYCCNT` read as one.
+        /// WARN: This bit is UNKNOWN if [`NOTRCPKT`] or [`NOCYCCNT`] read as one.
         /// RW
         PCSAMPLENA      OFFSET(12)  NUMBITS(1),
 
         /// Determines the position of synchronisation packet counter tap on the
         /// `CYCCNT` counter and thus the synchronisation packet rate. Defaults
         /// to UNKNOWN on reset.
-        /// WARN: This bit is UNKNOWN if `NOCYCCNT` reads as one.
+        /// WARN: This bit is UNKNOWN if [`NOCYCCNT`] reads as one.
         /// RW
         SYNCTAP         OFFSET(10)  NUMBITS(2),
 
-        /// Determines the position of the `POSTCNT` tap on the `CYCCNT` counter.
+        /// Determines the position of the [`POSTCNT`] tap on the [`CYCCNT`] counter.
         /// Defaults to UNKNOWN on reset.
-        /// WARN: This bit is UNKNOWN if `NOCYCCNT` reads as one.
+        /// WARN: This bit is UNKNOWN if [`NOCYCCNT`] reads as one.
         /// RW
         CYCTAP          OFFSET(9)  NUMBITS(1),
 
-        /// Initial value for the `POSTCNT` counter.
+        /// Initial value for the [`POSTCNT`] counter.
         /// Defaults to UNKNOWN on reset.
-        /// WARN: This bit is UNKNOWN if `NOCYCCNT` reads as one.
+        /// WARN: This bit is UNKNOWN if [`NOCYCCNT`] reads as one.
         /// RW
         POSTINIT        OFFSET(8)  NUMBITS(4),
 
-        /// Reload value for the `POSTCNT` counter.
+        /// Reload value for the [`POSTCNT`] counter.
         /// Defaults to UNKNOWN on reset.
-        /// WARN: This bit is UNKNOWN if `NOCYCCNT` reads as one.
+        /// WARN: This bit is UNKNOWN if [`NOCYCCNT`] reads as one.
         /// RW
         POSTPRESET      OFFSET(1)  NUMBITS(4),
 
-        /// Writing 1 enables `CYCCNT`.
+        /// Writing 1 enables [`CYCCNT`].
         /// Defaults to 0b0 on reset.
-        /// WARN: This bit is UNKNOWN if `NOCYCCNT` reads as one.
+        /// WARN: This bit is UNKNOWN if [`NOCYCCNT`] reads as one.
         /// RW
         CYCNTENA       OFFSET(0)  NUMBITS(1),
     ],
 
     CycleCount[
         /// When enabled, increases on each processor clock cycle when
-        /// Control::CYCNTENA and DEMCRL::TRCENA read as one. Wraps to zero on
-        /// overflow.
+        /// [`Control::CYCNTENA`] and [`DEMCRL::TRCENA`] read as one. Wraps to
+        /// zero on overflow.
         CYCCNT          OFFSET(0)   NUMBITS(32),
     ],
 
@@ -282,7 +283,7 @@ register_bitfields![u32,
         CYCMATCH    OFFSET(7)    NUMBITS(1),
 
         /// Write 1 to enable generation of data trace address packets.
-        /// WARN: If `Control::NOTRCPKT` reads as zero, this bit is UNKNOWN.
+        /// WARN: If [`Control::NOTRCPKT`] reads as zero, this bit is UNKNOWN.
         /// RW.
         EMITRANGE   OFFSET(5)    NUMBITS(1),
 
@@ -316,7 +317,7 @@ register_bitfields![u32,
         DATAVADDR1  OFFSET(16)   NUMBITS(4),
 
         /// Comparator number for linked address comparison.
-        /// Works, when `DATAVMATCH` reads as one.
+        /// Works, when [`DATAVMATCH`] reads as one.
         /// RW.
         DATAVADDR0  OFFSET(12)   NUMBITS(4),
 
@@ -362,7 +363,7 @@ register_bitfields![u32,
         MATCHED     OFFSET(24)   NUMBITS(1),
 
         /// Second comparator number for linked address comparison.
-        /// Works, when `DATAVMATCH` and `LNK1ENA` read as one.
+        /// Works, when [`DATAVMATCH`] and [`LNK1ENA`] read as one.
         /// RW.
         DATAVADDR1  OFFSET(16)   NUMBITS(4),
 

--- a/arch/cortex-m/src/dwt.rs
+++ b/arch/cortex-m/src/dwt.rs
@@ -299,8 +299,9 @@ register_bitfields![u32,
 
     Comparator1Mask[
         /// Size of ignore mask applied to the access address for address range
-        /// matching by comparator 0. WARN: Maximum Mask size is IMPLEMENTATION
-        /// DEFINED.
+        /// matching by comparator 0.
+        ///
+        /// WARN: Maximum Mask size is IMPLEMENTATION DEFINED.
         MASK       OFFSET(0)   NUMBITS(5),
     ],
 
@@ -349,8 +350,9 @@ register_bitfields![u32,
 
     Comparator2Mask[
         /// Size of ignore mask applied to the access address for address range
-        /// matching by comparator 0. WARN: Maximum Mask size is IMPLEMENTATION
-        /// DEFINED.
+        /// matching by comparator 0.
+        ///
+        /// WARN: Maximum Mask size is IMPLEMENTATION DEFINED.
         MASK       OFFSET(0)   NUMBITS(5),
     ],
 
@@ -399,8 +401,9 @@ register_bitfields![u32,
 
     Comparator3Mask[
         /// Size of ignore mask applied to the access address for address range
-        /// matching by comparator 0. WARN: Maximum Mask size is IMPLEMENTATION
-        /// DEFINED.
+        /// matching by comparator 0.
+        ///
+        /// WARN: Maximum Mask size is IMPLEMENTATION DEFINED.
         MASK       OFFSET(0)   NUMBITS(5),
     ],
 

--- a/arch/cortex-m/src/dwt.rs
+++ b/arch/cortex-m/src/dwt.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-//! ARM Data Watchpoint and Trace Unit
+//! Cortex-M Data Watchpoint and Trace Unit (DWT)
 //!
 //! <https://developer.arm.com/documentation/100166/0001/Data-Watchpoint-and-Trace-Unit/DWT-Programmers--model?lang=en>
 
@@ -116,14 +116,14 @@ register_bitfields![u32,
         /// RO
         NOPERFCNT       OFFSET(24)  NUMBITS(1),
 
-        /// Writing 1 enables event counter packets generation if [`PCSAMPLENA`] is set to 0.
-        /// Defaults to 0b0 on reset.
+        /// Writing 1 enables event counter packets generation if
+        /// [`PCSAMPLENA`] is set to 0. Defaults to 0b0 on reset.
         /// WARN: This bit is UNKNOWN if `NOTPRCPKT` or `NOCYCCNT` is read as one.
         /// RW
         CYCEVTENA       OFFSET(22)  NUMBITS(1),
 
-        /// Writing 1 enables generation of folded instruction counter overflow event. Defaults to
-        /// 0b0 on reset.
+        /// Writing 1 enables generation of folded instruction counter overflow
+        /// event. Defaults to 0b0 on reset.
         /// WARN: This bit is UNKNOWN if `NOPERFCNT` reads as one.
         /// RW
         FOLDEVTENA      OFFSET(21)  NUMBITS(1),
@@ -158,16 +158,16 @@ register_bitfields![u32,
         /// RW
         EXCTRCENA       OFFSET(16)  NUMBITS(1),
 
-        /// Writing 1 enables use of [`POSTCNT`] counter as a timer for Periodic PC sample packet
-        /// generation.
+        /// Writing 1 enables use of [`POSTCNT`] counter as a timer for Periodic
+        /// PC sample packet generation.
         /// Defaults to 0b0 on reset.
         /// WARN: This bit is UNKNOWN if `NOTRCPKT` or `NOCYCCNT` read as one.
         /// RW
         PCSAMPLENA      OFFSET(12)  NUMBITS(1),
 
-        /// Determines the position of synchronisation packet counter tap on the `CYCCNT` counter
-        /// and thus the synchronisation packet rate.
-        /// Defaults to UNKNOWN on reset.
+        /// Determines the position of synchronisation packet counter tap on the
+        /// `CYCCNT` counter and thus the synchronisation packet rate. Defaults
+        /// to UNKNOWN on reset.
         /// WARN: This bit is UNKNOWN if `NOCYCCNT` reads as one.
         /// RW
         SYNCTAP         OFFSET(10)  NUMBITS(2),
@@ -198,9 +198,9 @@ register_bitfields![u32,
     ],
 
     CycleCount[
-        /// When enabled, increases on each processor clock cycle when Control::CYCNTENA and
-        /// DEMCRL::TRCENA read as one.
-        /// Wraps to zero on overflow.
+        /// When enabled, increases on each processor clock cycle when
+        /// Control::CYCNTENA and DEMCRL::TRCENA read as one. Wraps to zero on
+        /// overflow.
         CYCCNT          OFFSET(0)   NUMBITS(32),
     ],
 
@@ -220,12 +220,14 @@ register_bitfields![u32,
     ],
 
     LsuCount[
-        /// Counts additional cycles required to execute all load store instructions
+        /// Counts additional cycles required to execute all load store
+        /// instructions
         LSUCNT          OFFSET(0)   NUMBITS(8),
     ],
 
     FoldedInstructionCount[
-        /// Increments by one for each instruction that takes 0 cycles to execute.
+        /// Increments by one for each instruction that takes 0 cycles to
+        /// execute.
         FOLDCNT          OFFSET(0)   NUMBITS(8),
     ],
 
@@ -241,8 +243,9 @@ register_bitfields![u32,
     ],
 
     Comparator0Mask[
-        /// Size of ignore mask applied to the access address for address range matching by comparator 0.
-        /// WARN: Maximum Mask size is IMPLEMENTATION DEFINED.
+        /// Size of ignore mask applied to the access address for address range
+        /// matching by comparator 0. WARN: Maximum Mask size is IMPLEMENTATION
+        /// DEFINED.
         MASK       OFFSET(0)   NUMBITS(5),
     ],
 
@@ -295,8 +298,9 @@ register_bitfields![u32,
     ],
 
     Comparator1Mask[
-        /// Size of ignore mask applied to the access address for address range matching by comparator 0.
-        /// WARN: Maximum Mask size is IMPLEMENTATION DEFINED.
+        /// Size of ignore mask applied to the access address for address range
+        /// matching by comparator 0. WARN: Maximum Mask size is IMPLEMENTATION
+        /// DEFINED.
         MASK       OFFSET(0)   NUMBITS(5),
     ],
 
@@ -344,8 +348,9 @@ register_bitfields![u32,
     ],
 
     Comparator2Mask[
-        /// Size of ignore mask applied to the access address for address range matching by comparator 0.
-        /// WARN: Maximum Mask size is IMPLEMENTATION DEFINED.
+        /// Size of ignore mask applied to the access address for address range
+        /// matching by comparator 0. WARN: Maximum Mask size is IMPLEMENTATION
+        /// DEFINED.
         MASK       OFFSET(0)   NUMBITS(5),
     ],
 
@@ -393,8 +398,9 @@ register_bitfields![u32,
     ],
 
     Comparator3Mask[
-        /// Size of ignore mask applied to the access address for address range matching by comparator 0.
-        /// WARN: Maximum Mask size is IMPLEMENTATION DEFINED.
+        /// Size of ignore mask applied to the access address for address range
+        /// matching by comparator 0. WARN: Maximum Mask size is IMPLEMENTATION
+        /// DEFINED.
         MASK       OFFSET(0)   NUMBITS(5),
     ],
 
@@ -449,7 +455,7 @@ impl Dwt {
         Self { registers: DWT }
     }
 
-    /// Returns wether a cycle counter is present on the chip.
+    /// Returns whether a cycle counter is present on the chip.
     pub fn is_cycle_counter_present(&self) -> bool {
         DWT.ctrl.read(Control::NOCYCCNT) == 0
     }
@@ -473,7 +479,9 @@ impl hil::hw_debug::CycleCounter for Dwt {
     }
 
     fn reset(&self) {
-        self.registers.ctrl.modify(Control::CYCNTENA::CLEAR); // disable the counter
-        self.registers.cyccnt.set(0); // reset the counter
+        // disable the counter
+        self.registers.ctrl.modify(Control::CYCNTENA::CLEAR);
+        // reset the counter
+        self.registers.cyccnt.set(0);
     }
 }

--- a/arch/cortex-m/src/dwt.rs
+++ b/arch/cortex-m/src/dwt.rs
@@ -245,8 +245,9 @@ register_bitfields![u32,
 
     Comparator0Mask[
         /// Size of ignore mask applied to the access address for address range
-        /// matching by comparator 0. WARN: Maximum Mask size is IMPLEMENTATION
-        /// DEFINED.
+        /// matching by comparator 0.
+        ///
+        /// WARN: Maximum Mask size is IMPLEMENTATION DEFINED.
         MASK       OFFSET(0)   NUMBITS(5),
     ],
 

--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -48,28 +48,28 @@ extern "C" {
 // functions via symbols, as done before this change (tock/tock#3080):
 //
 // - By using a trait carrying proper first-level Rust functions, the type
-//   signatures of the trait and implementing functions are properly
-//   validated. Before these changes, some Cortex-M variants previously used
-//   incorrect type signatures (e.g. `*mut u8` instead of `*const usize`) for
-//   the user_stack argument. It also ensures that all functions are provided by
-//   a respective sub-architecture at compile time, instead of throwing linker
+//   signatures of the trait and implementing functions are properly validated.
+//   Before these changes, some Cortex-M variants previously used incorrect
+//   type signatures (e.g. `*mut u8` instead of `*const usize`) for the
+//   user_stack argument. It also ensures that all functions are provided by a
+//   respective sub-architecture at compile time, instead of throwing linker
 //   errors.
 //
 // - Determining the respective functions at compile time, Rust might be able to
-//   perform more aggressive inlining, especially if more device-specific proper
-//   Rust functions (non hardware-exposed symbols, i.e. not fault or interrupt
-//   handlers) were to be added.
+//   perform more aggressive inlining, especially if more device-specific
+//   proper Rust functions (non hardware-exposed symbols, i.e. not fault or
+//   interrupt handlers) were to be added.
 //
 // - Most importantly, this avoid ambiguity with respect to a compiler fence
 //   being inserted by the compiler around calls to switch_to_user. The asm!
 //   macro in that function call will cause Rust to emit a compiler fence given
 //   the nomem option is not passed, but the opaque extern "C" function call
-//   obscured that code path. While this is probably fine and Rust is obliged to
-//   generate a compiler fence when switching to C code, having a traceable code
-//   path for Rust to the asm! macro will remove any remaining ambiguity and
-//   allow us to argue against requiring volatile accesses to userspace memory
-//   (during context switches). See tock/tock#2582 for further discussion of
-//   this issue.
+//   obscured that code path. While this is probably fine and Rust is obliged
+//   to generate a compiler fence when switching to C code, having a traceable
+//   code path for Rust to the asm! macro will remove any remaining ambiguity
+//   and allow us to argue against requiring volatile accesses to userspace
+//   memory(during context switches). See tock/tock#2582 for further discussion
+//   of this issue.
 pub trait CortexMVariant {
     /// All ISRs not caught by a more specific handler are caught by this
     /// handler. This must ensure the interrupt is disabled (per Tock's
@@ -83,11 +83,11 @@ pub trait CortexMVariant {
     const GENERIC_ISR: unsafe extern "C" fn();
 
     /// The `systick_handler` is called when the systick interrupt occurs,
-    /// signaling that an application executed for longer than its
-    /// timeslice. This interrupt handler is no longer responsible for signaling
-    /// to the kernel thread that an interrupt has occurred, but is slightly
-    /// more efficient than the `generic_isr` handler on account of not needing
-    /// to mark the interrupt as pending.
+    /// signaling that an application executed for longer than its timeslice.
+    /// This interrupt handler is no longer responsible for signaling to the
+    /// kernel thread that an interrupt has occurred, but is slightly more
+    /// efficient than the `generic_isr` handler on account of not needing to
+    /// mark the interrupt as pending.
     const SYSTICK_HANDLER: unsafe extern "C" fn();
 
     /// This is called after a `svc` instruction, both when switching to

--- a/arch/cortex-m/src/mpu.rs
+++ b/arch/cortex-m/src/mpu.rs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
+//! Cortex-M Memory Protection Unit (MPU)
+//!
 //! Implementation of the memory protection unit for the Cortex-M0+, Cortex-M3,
-//! Cortex-M4, and Cortex-M7
+//! Cortex-M4, and Cortex-M7.
 
 use core::cell::Cell;
 use core::cmp;

--- a/arch/cortex-m/src/nvic.rs
+++ b/arch/cortex-m/src/nvic.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-//! Cortex-M NVIC
+//! Cortex-M Nested Vectored Interrupt Controller (NVIC)
 //!
 //! Most NVIC configuration is in the NVIC registers:
 //! <https://developer.arm.com/docs/100165/0201/nested-vectored-interrupt-controller/nvic-programmers-model/table-of-nvic-registers>
@@ -21,11 +21,13 @@ use kernel::utilities::StaticRef;
 /// Generates the (u128, u128) tuple used for the NVIC's mask functions
 /// `next_pending_with_mask` and `next_pending_with_mask`.
 ///
+/// ```rust,ignore
 /// if let Some(interrupt) =
 ///     cortexm0p::nvic::next_pending_with_mask(interrupt_mask!(interrupts::SIO_IRQ_PROC1))
 /// {
 ///     // ...
 /// }
+/// ```
 #[macro_export]
 macro_rules! interrupt_mask {
     ($($interrupt: expr),+) => {{
@@ -169,13 +171,13 @@ pub unsafe fn next_pending() -> Option<u32> {
     None
 }
 
-/// Get the index (0-240) the lowest number pending interrupt while ignoring the interrupts
-/// that correspond to the bits set in mask, or `None` if none
-/// are pending.
+/// Get the index (0-240) the lowest number pending interrupt while ignoring the
+/// interrupts that correspond to the bits set in mask, or `None` if none are
+/// pending.
 ///
-/// Mask is defined as two u128 fields,
-///   mask.0 has the bits corresponding to interrupts from 128 to 240
-///   mask.1 has the bits corresponding to interrupts from 0 to 127
+/// Mask is defined as two `u128` fields,
+///   `mask.0` has the bits corresponding to interrupts from 128 to 240
+///   `mask.1` has the bits corresponding to interrupts from 0 to 127.
 pub unsafe fn next_pending_with_mask(mask: (u128, u128)) -> Option<u32> {
     for (block, ispr) in NVIC
         .ispr
@@ -207,9 +209,9 @@ pub unsafe fn has_pending() -> bool {
 /// Returns whether there are any pending interrupt bits set while ignoring
 /// the indices that correspond to the bits set in mask
 ///
-/// Mask is defined as two u128 fields,
-///   mask.0 has the bits corresponding to interrupts from 128 to 240
-///   mask.1 has the bits corresponding to interrupts from 0 to 127
+/// Mask is defined as two `u128` fields,
+///   `mask.0` has the bits corresponding to interrupts from 128 to 240
+///   `mask.1` has the bits corresponding to interrupts from 0 to 127.
 pub unsafe fn has_pending_with_mask(mask: (u128, u128)) -> bool {
     NVIC.ispr
         .iter()
@@ -229,7 +231,7 @@ pub unsafe fn has_pending_with_mask(mask: (u128, u128)) -> bool {
 pub struct Nvic(u32);
 
 impl Nvic {
-    /// Creates a new `Nvic`
+    /// Creates a new `Nvic`.
     ///
     /// Marked unsafe because only chip/platform configuration code should be
     /// able to create these.

--- a/arch/cortex-m/src/nvic.rs
+++ b/arch/cortex-m/src/nvic.rs
@@ -176,7 +176,7 @@ pub unsafe fn next_pending() -> Option<u32> {
 /// pending.
 ///
 /// Mask is defined as two `u128` fields,
-///   `mask.0` has the bits corresponding to interrupts from 128 to 240
+///   `mask.0` has the bits corresponding to interrupts from 128 to 240.
 ///   `mask.1` has the bits corresponding to interrupts from 0 to 127.
 pub unsafe fn next_pending_with_mask(mask: (u128, u128)) -> Option<u32> {
     for (block, ispr) in NVIC
@@ -210,7 +210,7 @@ pub unsafe fn has_pending() -> bool {
 /// the indices that correspond to the bits set in mask
 ///
 /// Mask is defined as two `u128` fields,
-///   `mask.0` has the bits corresponding to interrupts from 128 to 240
+///   `mask.0` has the bits corresponding to interrupts from 128 to 240.
 ///   `mask.1` has the bits corresponding to interrupts from 0 to 127.
 pub unsafe fn has_pending_with_mask(mask: (u128, u128)) -> bool {
     NVIC.ispr

--- a/arch/cortex-m/src/scb.rs
+++ b/arch/cortex-m/src/scb.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-//! ARM System Control Block
+//! Cortex-M System Control Block (SCB)
 //!
 //! <http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0553a/CIHFDJCA.html>
 

--- a/arch/cortex-m/src/support.rs
+++ b/arch/cortex-m/src/support.rs
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
+//! Helper functions for the Cortex-M architecture.
+
 use crate::scb;
 
+/// NOP instruction
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 #[inline(always)]
-/// NOP instruction
 pub fn nop() {
     use core::arch::asm;
     unsafe {
@@ -14,14 +16,15 @@ pub fn nop() {
     }
 }
 
+/// WFI instruction
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 #[inline(always)]
-/// WFI instruction
 pub unsafe fn wfi() {
     use core::arch::asm;
     asm!("wfi", options(nomem, preserves_flags));
 }
 
+/// Atomic operation
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 pub unsafe fn atomic<F, R>(f: F) -> R
 where
@@ -38,19 +41,20 @@ where
     res
 }
 
+/// NOP instruction (mock)
 // Mock implementations for tests on Travis-CI.
 #[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
-/// NOP instruction (mock)
 pub fn nop() {
     unimplemented!()
 }
 
-#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
 /// WFI instruction (mock)
+#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
 pub unsafe fn wfi() {
     unimplemented!()
 }
 
+/// Atomic operation (mock)
 #[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
 pub unsafe fn atomic<F, R>(_f: F) -> R
 where
@@ -59,6 +63,7 @@ where
     unimplemented!()
 }
 
+/// Reset the chip.
 pub fn reset() -> ! {
     unsafe {
         scb::reset();

--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
+//! Cortex-M System Call Interface
+//!
 //! Implementation of the architecture-specific portions of the kernel-userland
 //! system call interface.
 
@@ -40,9 +42,6 @@ pub static mut APP_HARD_FAULT: usize = 0;
 #[used]
 pub static mut SCB_REGISTERS: [u32; 5] = [0; 5];
 
-// Space for 8 u32s: r0-r3, r12, lr, pc, and xPSR
-const SVC_FRAME_SIZE: usize = 32;
-
 /// This holds all of the state that the kernel must keep for the process when
 /// the process is not executing.
 #[derive(Default)]
@@ -52,6 +51,9 @@ pub struct CortexMStoredState {
     psr: usize,
     psp: usize,
 }
+
+// Space for 8 u32s: r0-r3, r12, lr, pc, and xPSR
+const SVC_FRAME_SIZE: usize = 32;
 
 /// Values for encoding the stored state buffer in a binary slice.
 const VERSION: usize = 1;
@@ -69,6 +71,7 @@ const REGS_IDX: usize = 6;
 const REGS_RANGE: Range<usize> = REGS_IDX..REGS_IDX + 8;
 
 const USIZE_SZ: usize = size_of::<usize>();
+
 fn usize_byte_range(index: usize) -> Range<usize> {
     index * USIZE_SZ..(index + 1) * USIZE_SZ
 }
@@ -113,8 +116,9 @@ impl core::convert::TryFrom<&[u8]> for CortexMStoredState {
     }
 }
 
-/// Implementation of the `UserspaceKernelBoundary` for the Cortex-M non-floating point
-/// architecture.
+/// Implementation of the
+/// [`UserspaceKernelBoundary`](kernel::syscall::UserspaceKernelBoundary) for
+/// the Cortex-M non-floating point architecture.
 pub struct SysCall<A: CortexMVariant>(PhantomData<A>);
 
 impl<A: CortexMVariant> SysCall<A> {

--- a/arch/cortex-m/src/systick.rs
+++ b/arch/cortex-m/src/systick.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-//! ARM Cortex-M SysTick peripheral.
+//! Cortex-M SysTick timer
 
 use core::cell::Cell;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
@@ -11,7 +11,7 @@ use kernel::utilities::StaticRef;
 
 use core::num::NonZeroU32;
 
-/// The `SysTickFrequencyCapability` allows the holder to change the Cortex M
+/// The `SysTickFrequencyCapability` allows the holder to change the Cortex-M
 /// SysTick `hertz` field.
 pub unsafe trait SysTickFrequencyCapability {}
 
@@ -60,9 +60,9 @@ register_bitfields![u32,
     ]
 ];
 
-/// The ARM Cortex-M SysTick peripheral
+/// The ARM Cortex-M SysTick peripheral.
 ///
-/// Documented in the Cortex-MX Devices Generic User Guide, Chapter 4.4
+/// Documented in the Cortex-MX Devices Generic User Guide, Chapter 4.4.
 pub struct SysTick {
     hertz: Cell<u32>,
     external_clock: bool,
@@ -72,7 +72,7 @@ const BASE_ADDR: *const SystickRegisters = 0xE000E010 as *const SystickRegisters
 const SYSTICK_BASE: StaticRef<SystickRegisters> = unsafe { StaticRef::new(BASE_ADDR) };
 
 impl SysTick {
-    /// Initialize the `SysTick` with default values
+    /// Initialize the `SysTick` with default values.
     ///
     /// Use this constructor if the core implementation has a pre-calibration
     /// value in hardware.
@@ -83,27 +83,30 @@ impl SysTick {
         }
     }
 
-    /// Initialize the `SysTick` with an explicit clock speed
+    /// Initialize the `SysTick` with an explicit clock speed.
     ///
     /// Use this constructor if the core implementation does not have a
     /// pre-calibration value.
     ///
-    ///   * `clock_speed` - the frequency of SysTick tics in Hertz. For example,
-    ///   if the SysTick is driven by the CPU clock, it is simply the CPU speed.
+    /// * `clock_speed` - the frequency of SysTick tics in Hertz. For example,
+    ///   if the SysTick is driven by the CPU clock, it is simply the CPU
+    ///   speed.
     pub unsafe fn new_with_calibration(clock_speed: u32) -> SysTick {
         let res = SysTick::new();
         res.hertz.set(clock_speed);
         res
     }
 
-    /// Initialize the `SysTick` with an explicit clock speed and external source
+    /// Initialize the `SysTick` with an explicit clock speed and external
+    /// source.
     ///
     /// Use this constructor if the core implementation does not have a
-    /// pre-calibration value and you need an external clock source for
-    /// the Systick.
+    /// pre-calibration value and you need an external clock source for the
+    /// Systick.
     ///
-    ///   * `clock_speed` - the frequency of SysTick tics in Hertz. For example,
-    ///   if the SysTick is driven by the CPU clock, it is simply the CPU speed.
+    /// * `clock_speed` - the frequency of SysTick tics in Hertz. For example,
+    ///   if the SysTick is driven by the CPU clock, it is simply the CPU
+    ///   speed.
     pub unsafe fn new_with_calibration_and_external_clock(clock_speed: u32) -> SysTick {
         let mut res = SysTick::new();
         res.hertz.set(clock_speed);
@@ -111,10 +114,11 @@ impl SysTick {
         res
     }
 
-    // Return the tic frequency in hertz. If the value is configured by the
-    // user using the `new_with_calibration` constructor return `self.hertz`.
-    // Otherwise, compute the frequncy using the calibration value that is set
-    // in hardware.
+    // Return the tic frequency in hertz.
+    //
+    // If the value is configured by the user using the `new_with_calibration`
+    // constructor return `self.hertz`. Otherwise, compute the frequency using
+    // the calibration value that is set in hardware.
     fn hertz(&self) -> u32 {
         let hz = self.hertz.get();
         if hz != 0 {
@@ -127,13 +131,13 @@ impl SysTick {
         }
     }
 
-    /// Modifies the locally stored frequncy
+    /// Modifies the locally stored frequency.
     ///
     /// # Important
     ///
-    /// This function does not change the actual systick frequency.
-    /// This function must be called only while the clock is not armed.
-    /// When changing the hardware systick frequency, the reload value register
+    /// This function does not change the actual systick frequency. This
+    /// function must be called only while the clock is not armed. When
+    /// changing the hardware systick frequency, the reload value register
     /// should be updated and the current value register should be reset, in
     /// order for the tick count to match the current frequency.
     pub fn set_hertz(&self, clock_speed: u32, _capability: &dyn SysTickFrequencyCapability) {
@@ -144,9 +148,10 @@ impl SysTick {
 impl kernel::platform::scheduler_timer::SchedulerTimer for SysTick {
     fn start(&self, us: NonZeroU32) {
         let reload = {
-            // We need to convert from microseconds to native tics, which could overflow in 32-bit
-            // arithmetic. So we convert to 64-bit. 64-bit division is an expensive subroutine, but
-            // if `us` is a power of 10 the compiler will simplify it with the 1_000_000 divisor
+            // We need to convert from microseconds to native tics, which could
+            // overflow in 32-bit arithmetic. So we convert to 64-bit. 64-bit
+            // division is an expensive subroutine, but if `us` is a power of
+            // 10 the compiler will simplify it with the 1_000_000 divisor
             // instead.
             let us = us.get() as u64;
             let hertz = self.hertz() as u64;
@@ -168,10 +173,10 @@ impl kernel::platform::scheduler_timer::SchedulerTimer for SysTick {
             .write(ReloadValue::RELOAD.val(reload as u32));
         SYSTICK_BASE.syst_cvr.set(0);
 
-        // OK, arm it
-        // We really just need to set the TICKINT bit here, but can't use modify() because
-        // readying the CSR register will throw away evidence of expiration if one
-        // occurred, so we re-write entire value instead.
+        // OK, arm it. We really just need to set the TICKINT bit here, but
+        // can't use modify() because readying the CSR register will throw away
+        // evidence of expiration if one occurred, so we re-write entire value
+        // instead.
         SYSTICK_BASE
             .syst_csr
             .write(ControlAndStatus::TICKINT::SET + ControlAndStatus::ENABLE::SET + clock_source);
@@ -193,9 +198,9 @@ impl kernel::platform::scheduler_timer::SchedulerTimer for SysTick {
             ControlAndStatus::CLKSOURCE::SET
         };
 
-        // We really just need to set the TICKINT bit here, but can't use modify() because
-        // readying the CSR register will throw away evidence of expiration if one
-        // occurred, so we re-write entire value instead.
+        // We really just need to set the TICKINT bit here, but can't use modify
+        // () because readying the CSR register will throw away evidence of
+        // expiration if one occurred, so we re-write entire value instead.
         SYSTICK_BASE
             .syst_csr
             .write(ControlAndStatus::TICKINT::SET + ControlAndStatus::ENABLE::SET + clock_source);
@@ -211,9 +216,9 @@ impl kernel::platform::scheduler_timer::SchedulerTimer for SysTick {
             ControlAndStatus::CLKSOURCE::SET
         };
 
-        // We really just need to set the TICKINT bit here, but can't use modify() because
-        // readying the CSR register will throw away evidence of expiration if one
-        // occurred, so we re-write entire value instead.
+        // We really just need to set the TICKINT bit here, but can't use modify
+        // () because readying the CSR register will throw away evidence of
+        // expiration if one occurred, so we re-write entire value instead.
         SYSTICK_BASE
             .syst_csr
             .write(ControlAndStatus::TICKINT::CLEAR + ControlAndStatus::ENABLE::SET + clock_source);

--- a/arch/cortex-m/src/systick.rs
+++ b/arch/cortex-m/src/systick.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-//! Cortex-M SysTick timer
+//! Cortex-M SysTick Timer
 
 use core::cell::Cell;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
@@ -198,8 +198,8 @@ impl kernel::platform::scheduler_timer::SchedulerTimer for SysTick {
             ControlAndStatus::CLKSOURCE::SET
         };
 
-        // We really just need to set the TICKINT bit here, but can't use modify
-        // () because readying the CSR register will throw away evidence of
+        // We really just need to set the TICKINT bit here, but can't `modify()`
+        // because readying the CSR register will throw away evidence of
         // expiration if one occurred, so we re-write entire value instead.
         SYSTICK_BASE
             .syst_csr
@@ -216,8 +216,8 @@ impl kernel::platform::scheduler_timer::SchedulerTimer for SysTick {
             ControlAndStatus::CLKSOURCE::SET
         };
 
-        // We really just need to set the TICKINT bit here, but can't use modify
-        // () because readying the CSR register will throw away evidence of
+        // We really just need to set the TICKINT bit here, but can't `modify()`
+        // because readying the CSR register will throw away evidence of
         // expiration if one occurred, so we re-write entire value instead.
         SYSTICK_BASE
             .syst_csr


### PR DESCRIPTION
### Pull Request Overview

I went through and tried to make the cortex-m docs more consistent and a little better for the generated [rustdocs](https://docs.tockos.org).

I didn't make any content changes other than making the generated docs for links to modules more consistent:

<img width="801" alt="image" src="https://github.com/user-attachments/assets/d062faed-8723-4fb6-b0b0-269f526b053f" />



### Testing Strategy

travis. But I ran cargo doc locally without warnings.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
