### PR TITLE
Add the possibility of using async in drivers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ members = [
     "libraries/riscv-csr",
     "libraries/tock-cells",
     "libraries/tock-register-interface",
-    "libraries/tickv",
+    "libraries/tickv", "kernel-async",
 ]
 exclude = ["tools/"]
 resolver = "2"

--- a/boards/cargo/unstable_flags.toml
+++ b/boards/cargo/unstable_flags.toml
@@ -9,7 +9,7 @@ unstable-options = true
 #   sizes, and makes debugging easier since debug information for the core
 #   library is included in the resulting .elf file. See
 #   https://github.com/tock/tock/pull/2847 for more details.
-build-std = ["core", "compiler_builtins" ]
+build-std = ["core", "alloc", "compiler_builtins" ]
 # - `optimize_for_size`: Sets a feature flag in the core library that aims to
 #   produce smaller implementations for certain algorithms. See
 #   https://github.com/rust-lang/rust/pull/125011 for more details.

--- a/boards/microbit_v2/Cargo.toml
+++ b/boards/microbit_v2/Cargo.toml
@@ -21,6 +21,8 @@ capsules-core = { path = "../../capsules/core" }
 capsules-extra = { path = "../../capsules/extra" }
 capsules-system = { path = "../../capsules/system" }
 
+kernel-async = { path = "../../kernel-async" }
+
 [build-dependencies]
 tock_build_scripts = { path = "../build_scripts" }
 

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -21,6 +21,8 @@ use kernel::scheduler::round_robin::RoundRobinSched;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
 
+use kernel_async::delay::{Delay, DelayInstance};
+use kernel_async::examples::{create_hello_print_driver, HelloPrintDriver};
 use nrf52833::gpio::Pin;
 use nrf52833::interrupt_service::Nrf52833DefaultPeripherals;
 
@@ -149,6 +151,8 @@ pub struct MicroBit {
 
     scheduler: &'static RoundRobinSched<'static>,
     systick: cortexm4::systick::SysTick,
+
+    hello_print: &'static HelloPrintDriver,
 }
 
 impl SyscallDriverLookup for MicroBit {
@@ -175,6 +179,7 @@ impl SyscallDriverLookup for MicroBit {
             capsules_extra::eui64::DRIVER_NUM => f(Some(self.eui64)),
             capsules_extra::ieee802154::DRIVER_NUM => f(Some(self.ieee802154)),
             kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
+            100 => f(Some(self.hello_print)),
             _ => f(None),
         }
     }
@@ -736,6 +741,27 @@ unsafe fn start() -> (
     let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
+    let virtual_alarm_delay = static_init!(
+        capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, nrf52833::rtc::Rtc>,
+        capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm::new(mux_alarm)
+    );
+    virtual_alarm_delay.setup();
+
+    kernel_async::init();
+
+    let delay = static_init!(
+        Delay<
+            capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<
+                'static,
+                nrf52833::rtc::Rtc,
+            >,
+        >,
+        Delay::new(virtual_alarm_delay)
+    );
+    virtual_alarm_delay.set_alarm_client(delay);
+
+    let hello_print = static_init!(HelloPrintDriver, create_hello_print_driver(delay));
+
     let microbit = MicroBit {
         ble_radio,
         ieee802154,
@@ -762,6 +788,7 @@ unsafe fn start() -> (
 
         scheduler,
         systick: cortexm4::systick::SysTick::new_with_calibration(64000000),
+        hello_print,
     };
 
     let chip = static_init!(
@@ -807,6 +834,8 @@ unsafe fn start() -> (
         debug!("Error loading processes!");
         debug!("{:?}", err);
     });
+
+    hello_print.execute();
 
     (board_kernel, microbit, chip)
 }

--- a/boards/qemu_i486_q35/Cargo.toml
+++ b/boards/qemu_i486_q35/Cargo.toml
@@ -14,6 +14,7 @@ components = { path = "../components" }
 kernel = { path = "../../kernel" }
 x86_q35 = { path = "../../chips/x86_q35" }
 x86 = { path = "../../arch/x86" }
+kernel-async = { path = "../../kernel-async" }
 
 capsules-core = { path = "../../capsules/core" }
 capsules-extra = { path = "../../capsules/extra" }

--- a/boards/qemu_i486_q35/Makefile
+++ b/boards/qemu_i486_q35/Makefile
@@ -20,7 +20,8 @@ QEMU_BASE_CMDLINE := \
     -cpu 486 \
     -machine q35 \
     -net none \
-    -nographic
+    -nographic \
+    -device isa-debug-exit,iobase=0xf4,iosize=0x04
 
 # Run the kernel inside a qemu-system-i386 "q35" machine type simulation
 #
@@ -38,7 +39,7 @@ QEMU_BASE_CMDLINE := \
 run: $(TARGET_PATH)/release/$(PLATFORM).elf
 	@echo
 	@echo Reordering ELF file sections
-	@objcopy $<
+	@/opt/homebrew/opt/binutils/bin/objcopy  $<
 	@echo
 	@echo -e "Running $$(qemu-system-i386 --version | head -n1)"\
 	  "(tested: $(WORKING_QEMU_VERSION)) with\n"\

--- a/boards/qemu_i486_q35/src/io.rs
+++ b/boards/qemu_i486_q35/src/io.rs
@@ -15,6 +15,8 @@ use crate::{CHIP, PROCESSES, PROCESS_PRINTER};
 #[cfg(not(test))]
 #[panic_handler]
 unsafe fn panic_handler(pi: &PanicInfo) -> ! {
+    use core::arch::asm;
+
     let mut com1 = BlockingSerialPort::new(COM1_BASE);
 
     debug::panic_print(
@@ -24,6 +26,15 @@ unsafe fn panic_handler(pi: &PanicInfo) -> ! {
         &*ptr::addr_of!(PROCESSES),
         &*ptr::addr_of!(CHIP),
         &*ptr::addr_of!(PROCESS_PRINTER),
+    );
+
+    // stop qemu
+    asm!(
+        "
+        mov dx, 0xf4
+        mov al, 0x01
+        out dx,al
+        "
     );
 
     loop {}

--- a/boards/qemu_i486_q35/src/main.rs
+++ b/boards/qemu_i486_q35/src/main.rs
@@ -275,8 +275,6 @@ unsafe extern "cdecl" fn main() {
     );
     virtual_alarm_delay.setup();
 
-    kernel_async::init();
-
     let delay = static_init!(
         Delay<
             capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<

--- a/capsules/core/src/virtualizers/virtual_alarm.rs
+++ b/capsules/core/src/virtualizers/virtual_alarm.rs
@@ -10,7 +10,7 @@ use core::cell::Cell;
 use kernel::collections::list::{List, ListLink, ListNode};
 use kernel::hil::time::{self, Alarm, Ticks, Time};
 use kernel::utilities::cells::OptionalCell;
-use kernel::ErrorCode;
+use kernel::{debug, ErrorCode};
 
 #[derive(Copy, Clone)]
 struct TickDtReference<T: Ticks> {

--- a/capsules/core/src/virtualizers/virtual_alarm.rs
+++ b/capsules/core/src/virtualizers/virtual_alarm.rs
@@ -10,7 +10,7 @@ use core::cell::Cell;
 use kernel::collections::list::{List, ListLink, ListNode};
 use kernel::hil::time::{self, Alarm, Ticks, Time};
 use kernel::utilities::cells::OptionalCell;
-use kernel::{debug, ErrorCode};
+use kernel::ErrorCode;
 
 #[derive(Copy, Clone)]
 struct TickDtReference<T: Ticks> {

--- a/kernel-async/Cargo.toml
+++ b/kernel-async/Cargo.toml
@@ -8,7 +8,7 @@ edition.workspace = true
 kernel = { path = "../kernel" }
 embedded-hal-async = "1.0.0"
 embedded-alloc = "0.6.0"
-cortex-m = { version = "0.7.6", features = ["critical-section-single-core"]}
+critical-section = "1.2.0"
 
 [lints]
 workspace = true

--- a/kernel-async/Cargo.toml
+++ b/kernel-async/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "kernel-async"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+
+[dependencies]
+kernel = { path = "../kernel" }
+embedded-hal-async = "1.0.0"
+embedded-alloc = "0.6.0"
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"]}
+
+[lints]
+workspace = true

--- a/kernel-async/Cargo.toml
+++ b/kernel-async/Cargo.toml
@@ -7,8 +7,6 @@ edition.workspace = true
 [dependencies]
 kernel = { path = "../kernel" }
 embedded-hal-async = "1.0.0"
-embedded-alloc = "0.6.0"
-critical-section = "1.2.0"
 
 [lints]
 workspace = true

--- a/kernel-async/src/delay.rs
+++ b/kernel-async/src/delay.rs
@@ -26,7 +26,7 @@ pub struct Delay<'a, A: Alarm<'a>> {
 impl<'a, A: Alarm<'a>> Delay<'a, A> {
     pub fn new(alarm: &'a A) -> Delay<'a, A> {
         Delay {
-            has_instance: AtomicBool::new(false),
+            has_instance: AtomicBool::new(true),
             alarm,
             waker: Cell::new(None),
         }
@@ -86,6 +86,7 @@ impl<'a, A: Alarm<'a>> Future for DelayInstance<'a, A> {
             }
             State::Sleeping => {
                 if !self.alarm.is_armed() {
+                    self.state = State::Off;
                     Poll::Ready(())
                 } else {
                     Poll::Pending

--- a/kernel-async/src/delay.rs
+++ b/kernel-async/src/delay.rs
@@ -33,7 +33,7 @@ impl<'a, A: Alarm<'a>> Delay<'a, A> {
     }
 
     fn drop_instance(&self) {
-        self.has_instance.store(false, Ordering::Relaxed);
+        self.has_instance.store(true, Ordering::Relaxed);
     }
 
     // is 'static required?

--- a/kernel-async/src/delay.rs
+++ b/kernel-async/src/delay.rs
@@ -1,0 +1,123 @@
+use core::{
+    cell::Cell,
+    future::Future,
+    pin::Pin,
+    sync::atomic::{AtomicBool, Ordering},
+    task::{Context, Poll, Waker},
+};
+
+use embedded_hal_async::delay::DelayNs;
+use kernel::{
+    debug,
+    hil::time::{Alarm, AlarmClient, ConvertTicks},
+};
+
+enum State {
+    Off,
+    Sleeping,
+}
+
+pub struct Delay<'a, A: Alarm<'a>> {
+    has_instance: AtomicBool,
+    alarm: &'a A,
+    waker: Cell<Option<Waker>>,
+}
+
+impl<'a, A: Alarm<'a>> Delay<'a, A> {
+    pub fn new(alarm: &'a A) -> Delay<'a, A> {
+        Delay {
+            has_instance: AtomicBool::new(false),
+            alarm,
+            waker: Cell::new(None),
+        }
+    }
+
+    fn drop_instance(&self) {
+        self.has_instance.store(false, Ordering::Relaxed);
+    }
+
+    // is 'static required?
+    pub fn get_instance(&'static self) -> Option<DelayInstance<'a, A>> {
+        if self.has_instance.load(Ordering::Relaxed) {
+            self.has_instance.store(true, Ordering::Relaxed);
+            Some(DelayInstance::new(self.alarm, self))
+        } else {
+            None
+        }
+    }
+
+    fn set_waker(&self, waker: Option<Waker>) {
+        self.waker.set(waker);
+    }
+}
+
+pub struct DelayInstance<'a, A: Alarm<'a>> {
+    ns: u32,
+    state: State,
+    alarm: &'a A,
+    delay: &'a Delay<'a, A>,
+}
+
+impl<'a, A: Alarm<'a>> DelayInstance<'a, A> {
+    fn new(alarm: &'a A, delay: &'a Delay<'a, A>) -> DelayInstance<'a, A> {
+        DelayInstance {
+            ns: 0,
+            state: State::Off,
+            alarm,
+            delay,
+        }
+    }
+}
+
+impl<'a, A: Alarm<'a>> Future for DelayInstance<'a, A> {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.delay.set_waker(Some(cx.waker().clone()));
+        match self.state {
+            State::Off => {
+                debug!("set alarm {:?}", self.alarm.ticks_from_us(self.ns / 1000));
+                self.alarm.set_alarm(
+                    self.alarm.get_alarm(),
+                    self.alarm.ticks_from_us(self.ns / 1000),
+                );
+                self.state = State::Sleeping;
+                Poll::Pending
+            }
+            State::Sleeping => {
+                if !self.alarm.is_armed() {
+                    Poll::Ready(())
+                } else {
+                    Poll::Pending
+                }
+            }
+        }
+    }
+}
+
+impl<'a, A: Alarm<'a>> DelayNs for DelayInstance<'a, A> {
+    async fn delay_ns(&mut self, ns: u32) {
+        if let State::Off = self.state {
+            self.ns = ns;
+            self.await
+        } else {
+            panic!("already seeping")
+        }
+    }
+}
+
+impl<'a, A: Alarm<'a>> AlarmClient for Delay<'a, A> {
+    fn alarm(&self) {
+        debug!("alarm");
+        let waker = self.waker.take();
+        waker.map(|waker| {
+            waker.wake();
+        });
+    }
+}
+
+impl<'a, A: Alarm<'a>> Drop for DelayInstance<'a, A> {
+    fn drop(&mut self) {
+        self.delay.drop_instance();
+    }
+}

--- a/kernel-async/src/examples/hello_delay.rs
+++ b/kernel-async/src/examples/hello_delay.rs
@@ -47,8 +47,11 @@ impl<A: Alarm<'static> + 'static> SyscallDriver for HelloPrintDriver<A> {
         match command_num {
             0 => CommandReturn::success(),
             1 => {
-                let _ = self.runner.get().unwrap().execute();
-                CommandReturn::success()
+                if let Err(err) = self.runner.get().unwrap().execute() {
+                    CommandReturn::failure(err)
+                } else {
+                    CommandReturn::success()
+                }
             }
             _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
         }

--- a/kernel-async/src/examples/hello_delay.rs
+++ b/kernel-async/src/examples/hello_delay.rs
@@ -1,4 +1,5 @@
-use alloc::boxed::Box;
+use core::{cell::Cell, future::Future};
+
 use embedded_hal_async::delay::DelayNs;
 use kernel::{
     debug,
@@ -10,30 +11,32 @@ use kernel::{
 
 use crate::{
     delay::Delay,
-    executor::{Executor, ExecutorClient, Runner},
+    executor::{AsyncDriver, Runner},
 };
 
-pub struct HelloPrintDriver {
-    runner: &'static dyn Runner<()>,
+pub struct HelloPrintDriver<A: Alarm<'static> + 'static> {
+    runner: Cell<Option<&'static dyn Runner>>,
+    delay: &'static Delay<'static, A>,
 }
 
-impl HelloPrintDriver {
-    pub fn new(runner: &'static dyn Runner<()>) -> HelloPrintDriver {
-        HelloPrintDriver { runner }
+impl<A: Alarm<'static> + 'static> HelloPrintDriver<A> {
+    pub fn new(delay: &'static Delay<'static, A>) -> HelloPrintDriver<A> {
+        HelloPrintDriver {
+            runner: Cell::new(None),
+            delay,
+        }
     }
 
-    pub fn execute(&self) {
-        self.runner.execute(()).unwrap();
+    pub fn set_runner(&self, runner: Option<&'static dyn Runner>) {
+        self.runner.replace(runner);
+    }
+
+    pub fn execute(&self) -> Result<(), ErrorCode> {
+        self.runner.get().unwrap().execute()
     }
 }
 
-impl ExecutorClient for HelloPrintDriver {
-    fn ready(&self, _t: ()) {
-        todo!()
-    }
-}
-
-impl SyscallDriver for HelloPrintDriver {
+impl<A: Alarm<'static> + 'static> SyscallDriver for HelloPrintDriver<A> {
     fn command(
         &self,
         command_num: usize,
@@ -44,7 +47,7 @@ impl SyscallDriver for HelloPrintDriver {
         match command_num {
             0 => CommandReturn::success(),
             1 => {
-                let _ = self.runner.execute(());
+                let _ = self.runner.get().unwrap().execute();
                 CommandReturn::success()
             }
             _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
@@ -56,18 +59,24 @@ impl SyscallDriver for HelloPrintDriver {
     }
 }
 
-pub unsafe fn create_hello_print_driver<'a, A: Alarm<'a>>(
-    delay: &'static Delay<'a, A>,
-) -> HelloPrintDriver {
-    let runner = Box::leak(Box::new(Executor::new(|_| async {
-        // you should not be able to run two futures at the same time
-        // so this should never panic
-        let mut delay_instance = delay.get_instance().unwrap();
-        loop {
+impl<A: Alarm<'static> + 'static> AsyncDriver for HelloPrintDriver<A> {
+    type F = impl Future<Output = ()> + 'static;
+
+    fn run(&'static self) -> Self::F {
+        async {
+            // you should not be able to run two futures at the same time
+            // so this should never panic
+            let mut delay_instance = self.delay.get_instance().unwrap();
+            // loop {
             debug!("Hello");
             delay_instance.delay_ns(1_000_000_000).await;
             debug!("awaited");
+            // }
         }
-    })));
-    HelloPrintDriver::new(runner)
+    }
+
+    fn done(&self) {
+        debug!("done");
+        self.runner.get().unwrap().execute().unwrap();
+    }
 }

--- a/kernel-async/src/examples/hello_delay.rs
+++ b/kernel-async/src/examples/hello_delay.rs
@@ -75,7 +75,7 @@ impl<A: Alarm<'static> + 'static> AsyncDriver for HelloPrintDriver<A> {
         }
     }
 
-    fn done(&self) {
+    fn done(&self, _value: ()) {
         debug!("done");
         self.runner.get().unwrap().execute().unwrap();
     }

--- a/kernel-async/src/examples/hello_delay.rs
+++ b/kernel-async/src/examples/hello_delay.rs
@@ -1,0 +1,73 @@
+use alloc::boxed::Box;
+use embedded_hal_async::delay::DelayNs;
+use kernel::{
+    debug,
+    hil::time::Alarm,
+    process::Error,
+    syscall::{CommandReturn, SyscallDriver},
+    ErrorCode, ProcessId,
+};
+
+use crate::{
+    delay::Delay,
+    executor::{Executor, ExecutorClient, Runner},
+};
+
+pub struct HelloPrintDriver {
+    runner: &'static dyn Runner<()>,
+}
+
+impl HelloPrintDriver {
+    pub fn new(runner: &'static dyn Runner<()>) -> HelloPrintDriver {
+        HelloPrintDriver { runner }
+    }
+
+    pub fn execute(&self) {
+        self.runner.execute(()).unwrap();
+    }
+}
+
+impl ExecutorClient for HelloPrintDriver {
+    fn ready(&self, _t: ()) {
+        todo!()
+    }
+}
+
+impl SyscallDriver for HelloPrintDriver {
+    fn command(
+        &self,
+        command_num: usize,
+        _r2: usize,
+        _r3: usize,
+        _process_id: ProcessId,
+    ) -> kernel::syscall::CommandReturn {
+        match command_num {
+            0 => CommandReturn::success(),
+            1 => {
+                let _ = self.runner.execute(());
+                CommandReturn::success()
+            }
+            _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
+        }
+    }
+
+    fn allocate_grant(&self, _process_id: ProcessId) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+pub unsafe fn create_hello_print_driver<'a, A: Alarm<'a>>(
+    delay: &'static Delay<'a, A>,
+) -> HelloPrintDriver {
+    let runner = Box::leak(Box::new(Executor::new(|_| async {
+        // you should not be able to run two futures at the same time
+        // so this should never panic
+        let mut delay_instance = delay.get_instance().unwrap();
+        loop {
+            debug!("Hello");
+            delay_instance.delay_ns(1_000_000).await;
+            debug!("awaited");
+        }
+    })));
+    HelloPrintDriver::new(runner)
+}

--- a/kernel-async/src/examples/hello_delay.rs
+++ b/kernel-async/src/examples/hello_delay.rs
@@ -65,7 +65,7 @@ pub unsafe fn create_hello_print_driver<'a, A: Alarm<'a>>(
         let mut delay_instance = delay.get_instance().unwrap();
         loop {
             debug!("Hello");
-            delay_instance.delay_ns(1_000_000).await;
+            delay_instance.delay_ns(1_000_000_000).await;
             debug!("awaited");
         }
     })));

--- a/kernel-async/src/examples/mod.rs
+++ b/kernel-async/src/examples/mod.rs
@@ -1,0 +1,3 @@
+mod hello_delay;
+
+pub use hello_delay::{create_hello_print_driver, HelloPrintDriver};

--- a/kernel-async/src/examples/mod.rs
+++ b/kernel-async/src/examples/mod.rs
@@ -1,3 +1,3 @@
 mod hello_delay;
 
-pub use hello_delay::{create_hello_print_driver, HelloPrintDriver};
+pub use hello_delay::HelloPrintDriver;

--- a/kernel-async/src/executor.rs
+++ b/kernel-async/src/executor.rs
@@ -1,0 +1,136 @@
+use core::future::Future;
+use core::pin::Pin;
+
+use core::task::Context;
+use core::task::Poll;
+use core::task::RawWaker;
+use core::task::RawWakerVTable;
+use core::task::Waker;
+
+use kernel::debug;
+use kernel::static_init;
+use kernel::utilities::cells::MapCell;
+use kernel::utilities::cells::OptionalCell;
+use kernel::ErrorCode;
+
+fn waker_clone<'a, T: 'static, F: Future<Output = T> + 'static, I: Fn(T) -> F>(
+    ptr_poller: *const (),
+) -> RawWaker {
+    debug!("clone");
+    let executor = unsafe { &*(ptr_poller as *const Executor<'a, T, F, I>) };
+    RawWaker::new(ptr_poller, executor.waker_vtable())
+}
+
+fn waker_wake<'a, T: 'static, F: Future<Output = T> + 'static, I: Fn(T) -> F>(
+    ptr_poller: *const (),
+) {
+    debug!("wake");
+    // let vtable_ptr_poller = unsafe { ptr_poller.offset(1) };
+    // let poller: &dyn Poller = unsafe { transmute((ptr_poller, vtable_ptr_poller)) };
+    let poller: &dyn Poller =
+        unsafe { &*(ptr_poller as *const Executor<'a, T, F, I> as *const dyn Poller) };
+    poller.poll();
+}
+
+fn waker_wake_by_ref<'a, T: 'static, F: Future<Output = T> + 'static, I: Fn(T) -> F>(
+    ptr_poller: *const (),
+) {
+    debug!("wake_by_ref");
+    // let vtable_ptr_poller = unsafe { ptr_poller.offset(1) };
+    // let poller: &dyn Poller = unsafe { transmute((ptr_poller, vtable_ptr_poller)) };
+    let poller: &dyn Poller =
+        unsafe { &*(ptr_poller as *const Executor<'a, T, F, I> as *const dyn Poller) };
+    poller.poll();
+}
+
+fn waker_drop(_ptr_poller: *const ()) {
+    debug!("drop");
+}
+
+pub trait Runner<T: 'static> {
+    fn execute(&'static self, t: T) -> Result<(), (ErrorCode, T)>;
+}
+
+pub trait Poller {
+    fn poll(&'static self);
+}
+
+pub trait ExecutorClient<T: 'static = ()> {
+    fn ready(&self, t: T);
+}
+
+pub struct Executor<'a, T: 'static, F: Future<Output = T> + 'static, I: Fn(T) -> F> {
+    init: I,
+    future: MapCell<F>,
+    client: OptionalCell<&'a dyn ExecutorClient<T>>,
+    waker_vtable: &'static RawWakerVTable,
+}
+
+impl<'a, T: 'static, F: Future<Output = T> + 'static, I: Fn(T) -> F> Executor<'a, T, F, I> {
+    pub fn new(init: I) -> Executor<'a, T, F, I> {
+        Executor {
+            init,
+            future: MapCell::empty(),
+            client: OptionalCell::empty(),
+            waker_vtable: unsafe {
+                static_init!(
+                    RawWakerVTable,
+                    RawWakerVTable::new(
+                        waker_clone::<T, F, I>,
+                        waker_wake::<T, F, I>,
+                        waker_wake_by_ref::<T, F, I>,
+                        waker_drop,
+                    )
+                )
+            },
+        }
+    }
+
+    pub fn set_client(&self, client: &'a dyn ExecutorClient<T>) {
+        self.client.replace(client);
+    }
+
+    fn ready(&self, v: T) {
+        self.client.map(|client| {
+            client.ready(v);
+        });
+    }
+
+    fn waker_vtable(&self) -> &'static RawWakerVTable {
+        self.waker_vtable
+    }
+}
+
+impl<'a, T: 'static, F: Future<Output = T> + 'static, I: Fn(T) -> F> Runner<T>
+    for Executor<'a, T, F, I>
+{
+    fn execute(&'static self, t: T) -> Result<(), (ErrorCode, T)> {
+        if self.future.is_none() {
+            self.future.replace((self.init)(t));
+            self.poll();
+            Ok(())
+        } else {
+            Err((ErrorCode::BUSY, t))
+        }
+    }
+}
+
+impl<'a, T: 'static, F: Future<Output = T> + 'static, I: Fn(T) -> F> Poller
+    for Executor<'a, T, F, I>
+{
+    fn poll(&'static self) {
+        debug!("poll");
+        let self_ptr = self as *const Self as *const ();
+        self.future.map(|future| {
+            let waker = unsafe { Waker::from_raw(RawWaker::new(self_ptr, self.waker_vtable)) };
+            let mut context = Context::from_waker(&waker);
+            match unsafe { Pin::new_unchecked(future) }.poll(&mut context) {
+                Poll::Ready(v) => {
+                    self.future.take();
+                    self.ready(v)
+                }
+                Poll::Pending => {}
+            }
+        });
+    }
+}

--- a/kernel-async/src/lib.rs
+++ b/kernel-async/src/lib.rs
@@ -1,0 +1,21 @@
+#![no_std]
+#![feature(type_alias_impl_trait)]
+
+pub mod delay;
+pub mod examples;
+pub mod executor;
+
+extern crate alloc;
+extern crate cortex_m;
+
+use embedded_alloc::LlffHeap as Heap;
+
+#[global_allocator]
+static HEAP: Heap = Heap::empty();
+
+pub fn init() {
+    use core::mem::MaybeUninit;
+    const HEAP_SIZE: usize = 1024;
+    static mut HEAP_MEM: [MaybeUninit<u8>; HEAP_SIZE] = [MaybeUninit::uninit(); HEAP_SIZE];
+    unsafe { HEAP.init(&raw mut HEAP_MEM as usize, HEAP_SIZE) }
+}

--- a/kernel-async/src/lib.rs
+++ b/kernel-async/src/lib.rs
@@ -6,9 +6,19 @@ pub mod examples;
 pub mod executor;
 
 extern crate alloc;
-extern crate cortex_m;
 
+use critical_section::RawRestoreState;
 use embedded_alloc::LlffHeap as Heap;
+
+struct MyCriticalSection;
+critical_section::set_impl!(MyCriticalSection);
+
+// Tock is single threaded, so locking is not required
+unsafe impl critical_section::Impl for MyCriticalSection {
+    unsafe fn acquire() -> RawRestoreState {}
+
+    unsafe fn release(_token: RawRestoreState) {}
+}
 
 #[global_allocator]
 static HEAP: Heap = Heap::empty();

--- a/kernel-async/src/lib.rs
+++ b/kernel-async/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
-#![feature(type_alias_impl_trait)]
+// #![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 pub mod delay;
 pub mod examples;

--- a/kernel-async/src/lib.rs
+++ b/kernel-async/src/lib.rs
@@ -1,32 +1,6 @@
 #![no_std]
-// #![feature(type_alias_impl_trait)]
 #![feature(impl_trait_in_assoc_type)]
 
 pub mod delay;
 pub mod examples;
 pub mod executor;
-
-extern crate alloc;
-
-use critical_section::RawRestoreState;
-use embedded_alloc::LlffHeap as Heap;
-
-struct MyCriticalSection;
-critical_section::set_impl!(MyCriticalSection);
-
-// Tock is single threaded, so locking is not required
-unsafe impl critical_section::Impl for MyCriticalSection {
-    unsafe fn acquire() -> RawRestoreState {}
-
-    unsafe fn release(_token: RawRestoreState) {}
-}
-
-#[global_allocator]
-static HEAP: Heap = Heap::empty();
-
-pub fn init() {
-    use core::mem::MaybeUninit;
-    const HEAP_SIZE: usize = 1024;
-    static mut HEAP_MEM: [MaybeUninit<u8>; HEAP_SIZE] = [MaybeUninit::uninit(); HEAP_SIZE];
-    unsafe { HEAP.init(&raw mut HEAP_MEM as usize, HEAP_SIZE) }
-}


### PR DESCRIPTION
### Pull Request Overview

This pull request adds an initial kernel library that allows running async code in drivers.

#### Rationale

The Rust embedded ecosystem is getting more and more traction. The rust embedded working group has stabilised a set of traits, [`rust-embedded-hal`](https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal) and their asynchronous version [`rust-embedded-hal-async`](https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-async). Driver implementers can use them to write hardware independent drivers. Users seems to embrace then and are starting to write more and more driver crates based on these. 

Synchronous drivers, those using `rust-embedded-hal`, are not portable to Tock as they break the way in which Tock works. Asynchronous drivers should be portable to Tock,  as Tock's driver model is asynchronous. The main difference is that Tock does not support `async/.await`.

This library tries to add *limited* support for using drivers based upon the `rust-embedded-hal-async` traits.

#### Implementation

The code is placed into the `async-kernel` crate that is fully separated from the kernel. It does not need any kernel changes.

The crate provides the following:
- the `AsyncDriver` trait
- an `Executor` that runs futures
- a `Runner` trait that abstracts the executor

```rust
pub trait AsyncDriver {
    type F: Future + 'static;

    /// The asynchronous part of
    /// the driver
    fn run(&'static self) -> Self::F;

    /// Optional methods that is used by the [`Executor`] to
    /// notify the driver that the execution of the future
    /// ended.
    fn done(&self, _value: <Self::F as IntoFuture>::Output) {}
}

```

To avoid the requirement of dynamic allocation, the driver has the implement the `AsyncDriver` trait using the `#![feature(impl_trait_in_assoc_type)]` feature.

```rust
impl<A: Alarm<'static> + 'static> AsyncDriver for HelloPrintDriver<A> {
    type F = impl Future<Output = ()> + 'static;

    fn run(&'static self) -> Self::F {
        async {
            // async/.await
        }
    }

    fn done(&self, _value: ()) {
        debug!("done");
    }
}
```

#### Example

This pull request provides an example using the `qemu_i486_q35` board that uses the `delay` traits.

```rust
impl<A: Alarm<'static> + 'static> SyscallDriver for HelloPrintDriver<A> {
    fn command(
        &self,
        command_num: usize,
        _r2: usize,
        _r3: usize,
        _process_id: ProcessId,
    ) -> kernel::syscall::CommandReturn {
        match command_num {
            0 => CommandReturn::success(),
            1 => {
                if let Err(err) = self.runner.get().unwrap().execute() {
                    CommandReturn::failure(err)
                } else {
                    CommandReturn::success()
                }
            }
            _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
        }
    }

    fn allocate_grant(&self, _process_id: ProcessId) -> Result<(), Error> {
        Ok(())
    }
}

impl<A: Alarm<'static> + 'static> AsyncDriver for HelloPrintDriver<A> {
    type F = impl Future<Output = ()> + 'static;

    fn run(&'static self) -> Self::F {
        async {
            // you should not be able to run two futures at the same time
            // so this should never panic
            let mut delay_instance = self.delay.get_instance().unwrap();
            // loop {
            debug!("Hello");
            delay_instance.delay_ns(1_000_000_000).await;
            debug!("awaited");
            // }
        }
    }

    fn done(&self, _value: ()) {
        debug!("done");
        self.runner.get().unwrap().execute().unwrap();
    }
}
```

#### External Dependencies

This library depends on the `embedded-hal-async` crate that defines the Embedded HAL traits.

#### Roadmap

- [x] implement an executor
- [ ] implement the `digital` traits
- [x] implement the `delay` trait
- [ ] implement the `i2c` traits
- [ ] implement the `spi` traits


### Testing Strategy

This pull request was tested by...


### TODO or Help Wanted

Feedback and any ideas on how to avoid dynamic allocation and using stable rust is welcome.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
