### PR TITLE
components: Remove `unsafe` from DebugWriterComponent

### DIFF
--- a/boards/apollo3/lora_things_plus/src/main.rs
+++ b/boards/apollo3/lora_things_plus/src/main.rs
@@ -461,8 +461,9 @@ unsafe fn setup() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     // LEDs
     let led = components::led::LedsComponent::new().finalize(components::led_component_static!(

--- a/boards/apollo3/redboard_artemis_atp/src/main.rs
+++ b/boards/apollo3/redboard_artemis_atp/src/main.rs
@@ -231,8 +231,9 @@ unsafe fn setup() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     // LEDs
     let led = components::led::LedsComponent::new().finalize(components::led_component_static!(

--- a/boards/apollo3/redboard_artemis_nano/src/main.rs
+++ b/boards/apollo3/redboard_artemis_nano/src/main.rs
@@ -245,8 +245,9 @@ unsafe fn setup() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     // LEDs
     let led = components::led::LedsComponent::new().finalize(components::led_component_static!(

--- a/boards/arty_e21/src/main.rs
+++ b/boards/arty_e21/src/main.rs
@@ -251,8 +251,9 @@ unsafe fn start() -> (
     };
 
     // Create virtual device for kernel debug.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     // arty_e21_chip::uart::UART0.initialize_gpio_pins(&peripherals.gpio_port[17], &peripherals.gpio_port[16]);
 

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -515,8 +515,9 @@ unsafe fn start() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     //--------------------------------------------------------------------------
     // RANDOM NUMBERS

--- a/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
@@ -459,8 +459,9 @@ unsafe fn start() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     //--------------------------------------------------------------------------
     // RANDOM NUMBERS

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/main.rs
@@ -280,8 +280,9 @@ pub unsafe fn main() {
     ));
 
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     //--------------------------------------------------------------------------
     // NRF CLOCK SETUP

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
@@ -307,8 +307,9 @@ pub unsafe fn main() {
     ));
 
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     //--------------------------------------------------------------------------
     // BUTTONS

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/main.rs
@@ -230,8 +230,9 @@ pub unsafe fn main() {
         .finalize(components::uart_mux_component_static!());
 
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     //--------------------------------------------------------------------------
     // NRF CLOCK SETUP

--- a/boards/cy8cproto_62_4343_w/src/main.rs
+++ b/boards/cy8cproto_62_4343_w/src/main.rs
@@ -167,8 +167,9 @@ pub unsafe fn main() {
         uart_mux,
     )
     .finalize(components::console_component_static!());
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     //--------------------------------------------------------------------------
     // ALARM & TIMER

--- a/boards/esp32-c3-devkitM-1/src/main.rs
+++ b/boards/esp32-c3-devkitM-1/src/main.rs
@@ -244,8 +244,9 @@ unsafe fn setup() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     // Create process printer for panic.
     let process_printer = components::process_printer::ProcessPrinterTextComponent::new()

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -306,8 +306,9 @@ unsafe fn start() -> (
     .finalize(components::process_console_component_static!(
         sam4l::ast::Ast<'static>
     ));
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     // Initialize USART3 for UART for the nRF serialization link.
     peripherals.usart3.set_mode(sam4l::usart::UsartMode::Uart);

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -309,8 +309,9 @@ unsafe fn start() -> (
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
     const DEBUG_BUFFER_KB: usize = 1;
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!(DEBUG_BUFFER_KB));
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     let lldb = components::lldb::LowLevelDebugComponent::new(
         board_kernel,

--- a/boards/hifive_inventor/src/main.rs
+++ b/boards/hifive_inventor/src/main.rs
@@ -246,8 +246,9 @@ unsafe fn start() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     let lldb = components::lldb::LowLevelDebugComponent::new(
         board_kernel,

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -398,7 +398,9 @@ unsafe fn start() -> (
     .finalize(components::console_ordered_component_static!(
         sam4l::ast::Ast
     ));
-    DebugWriterComponent::new(uart_mux).finalize(components::debug_writer_component_static!());
+    let debug_wrapper =
+        DebugWriterComponent::new(uart_mux).finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     // Allow processes to communicate over BLE through the nRF51822
     peripherals.usart2.set_mode(sam4l::usart::UsartMode::Uart);

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -320,8 +320,9 @@ unsafe fn start() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(lpuart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(lpuart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     // LEDs
 

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -589,8 +589,9 @@ unsafe fn start() -> (
     .finalize(components::console_component_static!());
 
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     let lldb = components::lldb::LowLevelDebugComponent::new(
         board_kernel,

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -662,8 +662,9 @@ unsafe fn start() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     let lldb = components::lldb::LowLevelDebugComponent::new(
         board_kernel,

--- a/boards/makepython-nrf52840/src/main.rs
+++ b/boards/makepython-nrf52840/src/main.rs
@@ -408,8 +408,9 @@ pub unsafe fn start() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     //--------------------------------------------------------------------------
     // RANDOM NUMBERS

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -449,8 +449,9 @@ unsafe fn start() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     //--------------------------------------------------------------------------
     // RANDOM NUMBERS

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -339,8 +339,9 @@ unsafe fn start() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     // Setup alarm
     let timer0 = &peripherals.timer_a0;

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -402,8 +402,9 @@ pub unsafe fn start() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     //--------------------------------------------------------------------------
     // RANDOM NUMBERS

--- a/boards/nano33ble_rev2/src/main.rs
+++ b/boards/nano33ble_rev2/src/main.rs
@@ -410,8 +410,9 @@ pub unsafe fn start() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     //--------------------------------------------------------------------------
     // RANDOM NUMBERS

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -375,8 +375,9 @@ pub unsafe fn start() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     cdc.enable();
     cdc.attach();

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -348,8 +348,9 @@ pub unsafe fn start() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     let ble_radio = components::ble::BLEComponent::new(
         board_kernel,

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -619,8 +619,9 @@ pub unsafe fn start() -> (
     .finalize(components::console_component_static!());
 
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     //--------------------------------------------------------------------------
     // BLE

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -392,8 +392,9 @@ pub unsafe fn start() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     let ble_radio = components::ble::BLEComponent::new(
         board_kernel,

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -389,8 +389,9 @@ unsafe fn start() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     // LEDs
 

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -336,8 +336,9 @@ unsafe fn start() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     // LEDs
     let gpio_ports = &base_peripherals.gpio_ports;

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -507,8 +507,9 @@ unsafe fn setup() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     let lldb = components::lldb::LowLevelDebugComponent::new(
         board_kernel,

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -395,8 +395,9 @@ pub unsafe fn start_particle_boron() -> (
     )
     .finalize(components::console_component_static!(132, 132));
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     //--------------------------------------------------------------------------
     // WIRELESS

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -384,8 +384,9 @@ pub unsafe fn start() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     cdc.enable();
     cdc.attach();

--- a/boards/qemu_i486_q35/src/main.rs
+++ b/boards/qemu_i486_q35/src/main.rs
@@ -244,7 +244,9 @@ unsafe extern "cdecl" fn main() {
         .finalize(components::console_component_static!());
 
     // Create the debugger object that handles calls to `debug!()`.
-    DebugWriterComponent::new(uart_mux).finalize(components::debug_writer_component_static!());
+    let debug_wrapper =
+        DebugWriterComponent::new(uart_mux).finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     let lldb = components::lldb::LowLevelDebugComponent::new(
         board_kernel,

--- a/boards/qemu_rv32_virt/src/main.rs
+++ b/boards/qemu_rv32_virt/src/main.rs
@@ -518,8 +518,9 @@ unsafe fn start() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     let lldb = components::lldb::LowLevelDebugComponent::new(
         board_kernel,

--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -376,8 +376,9 @@ pub unsafe fn start() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     cdc.enable();
     cdc.attach();

--- a/boards/redboard_redv/src/main.rs
+++ b/boards/redboard_redv/src/main.rs
@@ -261,8 +261,9 @@ unsafe fn start() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     let lldb = components::lldb::LowLevelDebugComponent::new(
         board_kernel,

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -327,8 +327,9 @@ pub unsafe fn start() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     let ble_radio = components::ble::BLEComponent::new(
         board_kernel,

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -436,8 +436,9 @@ unsafe fn start() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     // LEDs
 

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -476,8 +476,9 @@ unsafe fn start() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     // LEDs
 

--- a/boards/stm32f429idiscovery/src/main.rs
+++ b/boards/stm32f429idiscovery/src/main.rs
@@ -347,8 +347,9 @@ unsafe fn start() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     // LEDs
 

--- a/boards/teensy40/src/main.rs
+++ b/boards/teensy40/src/main.rs
@@ -260,8 +260,9 @@ unsafe fn start() -> (&'static kernel::Kernel, Teensy40, &'static Chip) {
     let uart_mux = components::console::UartMuxComponent::new(&peripherals.lpuart2, 115_200)
         .finalize(components::uart_mux_component_static!());
     // Create the debugger object that handles calls to `debug!()`
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     // Setup the console
     let console = components::console::ConsoleComponent::new(

--- a/boards/veer_el2_sim/src/main.rs
+++ b/boards/veer_el2_sim/src/main.rs
@@ -196,8 +196,9 @@ unsafe fn start() -> (&'static kernel::Kernel, VeeR, &'static VeeRChip) {
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     debug!("VeeR EL2 initialisation complete.");
     debug!("Entering main loop.");

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -290,8 +290,9 @@ unsafe fn start() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     // LEDs
     // Clock to Port A, B, C are enabled in `set_pin_primary_functions()`

--- a/boards/wm1110dev/src/main.rs
+++ b/boards/wm1110dev/src/main.rs
@@ -318,8 +318,9 @@ pub unsafe fn start() -> (
     .finalize(components::console_component_static!());
 
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux)
+    let debug_wrapper = components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     //--------------------------------------------------------------------------
     // SENSORS


### PR DESCRIPTION
### Pull Request Overview

The unsafe was needed to set the wrapper writer in the kernel's debug module. This function call now moves to main.rs.


### Testing Strategy

travis


### TODO or Help Wanted

This is an unfortunate change that won't cause a compiler error for any out-of-tree boards but will break debug functionality. Any ideas on how to make that not the case? It's not obvious to me if there is a way to handle that.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
