### PR TITLE
QOL improvement for SMA_Q3 board and small fix for it's screen driver

### DIFF
--- a/boards/sma_q3/Embed.toml
+++ b/boards/sma_q3/Embed.toml
@@ -1,0 +1,31 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
+[default.general]
+chip = "nRF52840_xxAA"
+
+[default.flashing]
+enabled = false
+restore_unwritten_bytes = true
+
+[flash.flashing]
+enabled = true
+restore_unwritten_bytes = true
+
+[rtt.rtt]
+enabled = true
+up_channels = [
+    { channel = 0, mode = "BlockIfFull", format = "String", socket = "127.0.0.1:12345" },
+]
+# The UI configuration:
+tabs = [
+    { up_channel = 0, name = "Log" },
+]
+
+[full.flashing]
+enabled = true
+restore_unwritten_bytes = true
+
+[full.rtt]
+enabled = true

--- a/capsules/extra/src/lpm013m126.rs
+++ b/capsules/extra/src/lpm013m126.rs
@@ -670,7 +670,9 @@ impl<'a, A: Alarm<'a>, P: Pin, S: SpiMasterDevice<'a>> ScreenSetup<'a> for Lpm01
 
     fn set_pixel_format(&self, format: ScreenPixelFormat) -> Result<(), ErrorCode> {
         match format {
-            ScreenPixelFormat::RGB_4BIT | ScreenPixelFormat::RGB_332 => {
+            ScreenPixelFormat::RGB_4BIT
+            | ScreenPixelFormat::RGB_332
+            | ScreenPixelFormat::RGB_565 => {
                 self.pixel_format.set(format);
                 Ok(())
             }


### PR DESCRIPTION
### Pull Request Overview

This pull request combines to small additions/fixes around the SMA_Q3 board:

1. It adds an `Embed.toml` to the board directory to make using `probe-rs` and `cargo embed` simpler for programming and debugging.
2. It adds the (already supported) RGB_565 mode to the lpm013m126 screen driver---currently already the default, but being reject unnecessarily if switching to that mode.


### Testing Strategy

This pull request was tested by using both on the sma_q3


### TODO or Help Wanted

N/A


### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
