### PR TITLE
components: remove `unsafe` from SeggerRtt

### DIFF
--- a/boards/components/src/segger_rtt.rs
+++ b/boards/components/src/segger_rtt.rs
@@ -62,13 +62,7 @@ macro_rules! segger_rtt_component_static {
 }
 
 pub struct SeggerRttMemoryRefs<'a> {
-    rtt_memory: &'a mut SeggerRttMemory<'a>,
-}
-
-impl<'a> SeggerRttMemoryRefs<'a> {
-    pub unsafe fn get_rtt_memory_ptr(&mut self) -> *mut SeggerRttMemory<'a> {
-        core::ptr::from_mut(self.rtt_memory)
-    }
+    pub rtt_memory: &'a mut SeggerRttMemory<'a>,
 }
 
 pub struct SeggerRttMemoryComponent {}

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -439,14 +439,14 @@ pub unsafe fn start() -> (
     let uart_channel = if USB_DEBUGGING {
         // Initialize early so any panic beyond this point can use the RTT
         // memory object.
-        let mut rtt_memory_refs = components::segger_rtt::SeggerRttMemoryComponent::new()
+        let rtt_memory_refs = components::segger_rtt::SeggerRttMemoryComponent::new()
             .finalize(components::segger_rtt_memory_component_static!());
 
         // XXX: This is inherently unsafe as it aliases the mutable reference to
         // rtt_memory. This aliases reference is only used inside a panic
         // handler, which should be OK, but maybe we should use a const
         // reference to rtt_memory and leverage interior mutability instead.
-        self::io::set_rtt_memory(&*rtt_memory_refs.get_rtt_memory_ptr());
+        self::io::set_rtt_memory(&*core::ptr::from_mut(rtt_memory_refs.rtt_memory));
 
         UartChannel::Rtt(rtt_memory_refs)
     } else {

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -292,13 +292,13 @@ pub unsafe fn start() -> (
     // Initialize early so any panic beyond this point can use the RTT memory object.
     let uart_channel = {
         // RTT communication channel
-        let mut rtt_memory = components::segger_rtt::SeggerRttMemoryComponent::new()
+        let rtt_memory = components::segger_rtt::SeggerRttMemoryComponent::new()
             .finalize(components::segger_rtt_memory_component_static!());
 
         // TODO: This is inherently unsafe as it aliases the mutable reference to rtt_memory. This
         // aliases reference is only used inside a panic handler, which should be OK, but maybe we
         // should use a const reference to rtt_memory and leverage interior mutability instead.
-        self::io::set_rtt_memory(&*rtt_memory.get_rtt_memory_ptr());
+        self::io::set_rtt_memory(&*core::ptr::from_mut(rtt_memory.rtt_memory));
 
         components::segger_rtt::SeggerRttComponent::new(mux_alarm, rtt_memory)
             .finalize(components::segger_rtt_component_static!(nrf52840::rtc::Rtc))


### PR DESCRIPTION
### Pull Request Overview

The unsafe was needed for getting a pointer to the internal RTT memory. This has moved to main.rs.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
