### PR TITLE
Allow multiple Capabilities in `create_capability!`

### DIFF
--- a/kernel/src/utilities/helpers.rs
+++ b/kernel/src/utilities/helpers.rs
@@ -14,7 +14,6 @@
 /// ```
 /// # use kernel::capabilities::{ProcessManagementCapability, MemoryAllocationCapability};
 /// # use kernel::create_capability;
-///
 /// let process_mgmt_cap = create_capability!(ProcessManagementCapability);
 /// let unified_cap = create_capability!(ProcessManagementCapability, MemoryAllocationCapability);
 /// ```
@@ -29,6 +28,15 @@
 /// `unsafe`. Specifically, an internal `allow(unsafe_code)` directive
 /// will conflict with any `forbid(unsafe_code)` at the crate or block
 /// level.
+///
+/// ```compile_fail
+/// # use kernel::capabilities::ProcessManagementCapability;
+/// # use kernel::create_capability;
+/// #[forbid(unsafe_code)]
+/// fn untrusted_fn() {
+///     let process_mgmt_cap = create_capability!(ProcessManagementCapability);
+/// }
+/// ```
 #[macro_export]
 macro_rules! create_capability {
     ($($T:ty),+) => {{

--- a/kernel/src/utilities/helpers.rs
+++ b/kernel/src/utilities/helpers.rs
@@ -9,25 +9,35 @@
 //!
 //! The macros are exported through the top level of the `kernel` crate.
 
-/// Create an object with the given capability.
+/// Create an object with the given capabilities.
 ///
-/// ```ignore
-/// use kernel::capabilities::ProcessManagementCapability;
-/// use kernel;
+/// ```
+/// # use kernel::capabilities::{ProcessManagementCapability, MemoryAllocationCapability};
+/// # use kernel::create_capability;
 ///
 /// let process_mgmt_cap = create_capability!(ProcessManagementCapability);
+/// let unified_cap = create_capability!(ProcessManagementCapability, MemoryAllocationCapability);
 /// ```
 ///
 /// This helper macro cannot be called from `#![forbid(unsafe_code)]` crates,
 /// and is used by trusted code to generate a capability that it can either use
 /// or pass to another module.
+///
+/// # Safety
+///
+/// This macro can only be used in a context that is allowed to use
+/// `unsafe`. Specifically, an internal `allow(unsafe_code)` directive
+/// will conflict with any `forbid(unsafe_code)` at the crate or block
+/// level.
 #[macro_export]
 macro_rules! create_capability {
-    ($T:ty $(,)?) => {{
-        struct Cap;
+    ($($T:ty),+) => {{
         #[allow(unsafe_code)]
-        unsafe impl $T for Cap {}
-        Cap
+        struct Cap(());
+        $(
+            unsafe impl $T for Cap {}
+        )*
+        Cap(())
     }};
 }
 


### PR DESCRIPTION
### Pull Request Overview

Allows the caller of `create_capability` to pass one or more capabilities and the resulting value will be of a type that is an instance of all of them.

Existing call sites work unchanged, but a caller can now do the following:

```rust
let cap = create_capability!(ProcessManagementCapability, MemoryManagementCapability);
```

and `cap` will be a value of a type that implements both capabilities.

This PR also piggybacks two small nits:

1. It adds an explicit mention in the macro's doc that the inability to call `create_capability!` from a context that is not allowed to use `unsafe` (a capsule) relies on the `allow(unsafe_code)` directive and nothing else, with the hope that this will prevent some well meaning future contributor from removing that when noticing that it's not otherwise necessary.
2. It adds a zero-sized non-public field to the inner type declared inside the macro for good measure---ensuring that even if some other module should be able to name the new type (they can't since it's declared inside a local scope) that module would not be able to instantiate a value since the inner field is not public.

This addresses some of the issues raised in #4418.


### Testing Strategy

Compile-tested, and a cant-compile test added to a random capsule (to make sure it can't use `create_capability`. The doc test is also exposed now and passes `cargo test`.

### TODO or Help Wanted

N/A


### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
