### PR TITLE
Update Rust + bring back naked functions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
     "editor.defaultFormatter": "rust-lang.rust-analyzer",
     "editor.formatOnSave": true,
     "rust-analyzer.server.extraEnv": {
-        "RUSTUP_TOOLCHAIN": "nightly-2025-03-14"
+        "RUSTUP_TOOLCHAIN": "nightly-2025-05-19"
     },
     "rust-analyzer.check.allTargets": false,
 }

--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -128,24 +128,18 @@ pub unsafe extern "C" fn unhandled_interrupt() {
     panic!("Unhandled Interrupt. ISR {} is active.", interrupt_number);
 }
 
+/// Assembly function to initialize the .bss and .data sections in RAM.
+///
+/// We need to (unfortunately) do these operations in assembly because it is
+/// not valid to run Rust code without RAM initialized.
+///
+/// See https://github.com/tock/tock/issues/2222 for more information.
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
-extern "C" {
-    /// Assembly function to initialize the .bss and .data sections in RAM.
-    ///
-    /// We need to (unfortunately) do these operations in assembly because it is
-    /// not valid to run Rust code without RAM initialized.
-    ///
-    /// See <https://github.com/tock/tock/issues/2222> for more information.
-    pub fn initialize_ram_jump_to_main();
-}
-
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
-core::arch::global_asm!(
-"
-    .section .initialize_ram_jump_to_main, \"ax\"
-    .global initialize_ram_jump_to_main
-    .thumb_func
-  initialize_ram_jump_to_main:
+#[unsafe(naked)]
+pub unsafe extern "C" fn initialize_ram_jump_to_main() {
+    use core::arch::naked_asm;
+    naked_asm!(
+        "
     // Start by initializing .bss memory. The Tock linker script defines
     // `_szero` and `_ezero` to mark the .bss segment.
     ldr r0, ={sbss}     // r0 = first address of .bss
@@ -187,12 +181,13 @@ core::arch::global_asm!(
     // board initialization takes place and Rust code starts.
     bl main
     ",
-    sbss = sym _szero,
-    ebss = sym _ezero,
-    sdata = sym _srelocate,
-    edata = sym _erelocate,
-    etext = sym _etext,
-);
+        sbss = sym _szero,
+        ebss = sym _ezero,
+        sdata = sym _srelocate,
+        edata = sym _erelocate,
+        etext = sym _etext,
+    );
+}
 
 pub unsafe fn print_cortexm_state(writer: &mut dyn Write) {
     let _ccr = syscall::SCB_REGISTERS[0];

--- a/arch/cortex-m/src/mpu.rs
+++ b/arch/cortex-m/src/mpu.rs
@@ -261,8 +261,9 @@ pub struct CortexMRegion {
 
 impl PartialEq<mpu::Region> for CortexMRegion {
     fn eq(&self, other: &mpu::Region) -> bool {
-        self.location
-            .is_some_and(|(addr, size)| addr == other.start_address() && size == other.size())
+        self.location.is_some_and(|(addr, size)| {
+            core::ptr::eq(addr, other.start_address()) && size == other.size()
+        })
     }
 }
 

--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -45,104 +45,101 @@ extern "C" {
     static __global_pointer: usize;
 }
 
+/// Entry point of all programs (`_start`).
+///
+/// This assembly does three functions:
+///
+/// 1. It initializes the stack pointer, the frame pointer (needed for closures
+///    to work in start_rust) and the global pointer.
+/// 2. It initializes the .bss and .data RAM segments. This must be done before
+///    any Rust code runs. See https://github.com/tock/tock/issues/2222 for more
+///    information.
+/// 3. Finally it calls `main()`, the main entry point for Tock boards.
 #[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
-extern "C" {
-    // Entry point of all programs (`_start`).
-    ///
-    /// This assembly does three functions:
-    ///
-    /// 1. It initializes the stack pointer, the frame pointer (needed for closures
-    ///    to work in start_rust) and the global pointer.
-    /// 2. It initializes the .bss and .data RAM segments. This must be done before
-    ///    any Rust code runs. See <https://github.com/tock/tock/issues/2222> for more
-    ///    information.
-    /// 3. Finally it calls `main()`, the main entry point for Tock boards.
-    pub fn _start();
+#[link_section = ".riscv.start"]
+#[export_name = "_start"]
+#[unsafe(naked)]
+pub extern "C" fn _start() {
+    use core::arch::naked_asm;
+    naked_asm! ("
+        // Set the global pointer register using the variable defined in the
+        // linker script. This register is only set once. The global pointer
+        // is a method for sharing state between the linker and the CPU so
+        // that the linker can emit code with offsets that are relative to
+        // the gp register, and the CPU can successfully execute them.
+        //
+        // https://gnu-mcu-eclipse.github.io/arch/riscv/programmer/#the-gp-global-pointer-register
+        // https://groups.google.com/a/groups.riscv.org/forum/#!msg/sw-dev/60IdaZj27dY/5MydPLnHAQAJ
+        // https://www.sifive.com/blog/2017/08/28/all-aboard-part-3-linker-relaxation-in-riscv-toolchain/
+        //
+        // Disable linker relaxation for code that sets up GP so that this doesn't
+        // get turned into `mv gp, gp`.
+        .option push
+        .option norelax
+
+        la gp, {gp}                 // Set the global pointer from linker script.
+
+        // Re-enable linker relaxations.
+        .option pop
+
+        // Initialize the stack pointer register. This comes directly from
+        // the linker script.
+        la sp, {estack}             // Set the initial stack pointer.
+
+        // Set s0 (the frame pointer) to the start of the stack.
+        add  s0, sp, zero           // s0 = sp
+
+        // Initialize mscratch to 0 so that we know that we are currently
+        // in the kernel. This is used for the check in the trap handler.
+        csrw 0x340, zero            // CSR=0x340=mscratch
+
+        // INITIALIZE MEMORY
+
+        // Start by initializing .bss memory. The Tock linker script defines
+        // `_szero` and `_ezero` to mark the .bss segment.
+        la a0, {sbss}               // a0 = first address of .bss
+        la a1, {ebss}               // a1 = first address after .bss
+
+      100: // bss_init_loop
+        beq  a0, a1, 101f           // If a0 == a1, we are done.
+        sw   zero, 0(a0)            // *a0 = 0. Write 0 to the memory location in a0.
+        addi a0, a0, 4              // a0 = a0 + 4. Increment pointer to next word.
+        j 100b                      // Continue the loop.
+
+      101: // bss_init_done
+
+
+        // Now initialize .data memory. This involves coping the values right at the
+        // end of the .text section (in flash) into the .data section (in RAM).
+        la a0, {sdata}              // a0 = first address of data section in RAM
+        la a1, {edata}              // a1 = first address after data section in RAM
+        la a2, {etext}              // a2 = address of stored data initial values
+
+      200: // data_init_loop
+        beq  a0, a1, 201f           // If we have reached the end of the .data
+                                    // section then we are done.
+        lw   a3, 0(a2)              // a3 = *a2. Load value from initial values into a3.
+        sw   a3, 0(a0)              // *a0 = a3. Store initial value into
+                                    // next place in .data.
+        addi a0, a0, 4              // a0 = a0 + 4. Increment to next word in memory.
+        addi a2, a2, 4              // a2 = a2 + 4. Increment to next word in flash.
+        j 200b                      // Continue the loop.
+
+      201: // data_init_done
+
+        // With that initial setup out of the way, we now branch to the main
+        // code, likely defined in a board's main.rs.
+        j main
+    ",
+        gp = sym __global_pointer,
+        estack = sym _estack,
+        sbss = sym _szero,
+        ebss = sym _ezero,
+        sdata = sym _srelocate,
+        edata = sym _erelocate,
+        etext = sym _etext,
+    );
 }
-
-#[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
-core::arch::global_asm!("
-            .section .riscv.start, \"ax\"
-            .globl _start
-          _start:
-
-            // Set the global pointer register using the variable defined in the
-            // linker script. This register is only set once. The global pointer
-            // is a method for sharing state between the linker and the CPU so
-            // that the linker can emit code with offsets that are relative to
-            // the gp register, and the CPU can successfully execute them.
-            //
-            // https://gnu-mcu-eclipse.github.io/arch/riscv/programmer/#the-gp-global-pointer-register
-            // https://groups.google.com/a/groups.riscv.org/forum/#!msg/sw-dev/60IdaZj27dY/5MydPLnHAQAJ
-            // https://www.sifive.com/blog/2017/08/28/all-aboard-part-3-linker-relaxation-in-riscv-toolchain/
-            //
-            // Disable linker relaxation for code that sets up GP so that this doesn't
-            // get turned into `mv gp, gp`.
-            .option push
-            .option norelax
-
-            la gp, {gp}                 // Set the global pointer from linker script.
-
-            // Re-enable linker relaxations.
-            .option pop
-
-            // Initialize the stack pointer register. This comes directly from
-            // the linker script.
-            la sp, {estack}             // Set the initial stack pointer.
-
-            // Set s0 (the frame pointer) to the start of the stack.
-            add  s0, sp, zero           // s0 = sp
-
-            // Initialize mscratch to 0 so that we know that we are currently
-            // in the kernel. This is used for the check in the trap handler.
-            csrw 0x340, zero            // CSR=0x340=mscratch
-
-            // INITIALIZE MEMORY
-
-            // Start by initializing .bss memory. The Tock linker script defines
-            // `_szero` and `_ezero` to mark the .bss segment.
-            la a0, {sbss}               // a0 = first address of .bss
-            la a1, {ebss}               // a1 = first address after .bss
-
-          100: // bss_init_loop
-            beq  a0, a1, 101f           // If a0 == a1, we are done.
-            sw   zero, 0(a0)            // *a0 = 0. Write 0 to the memory location in a0.
-            addi a0, a0, 4              // a0 = a0 + 4. Increment pointer to next word.
-            j 100b                      // Continue the loop.
-
-          101: // bss_init_done
-
-
-            // Now initialize .data memory. This involves coping the values right at the
-            // end of the .text section (in flash) into the .data section (in RAM).
-            la a0, {sdata}              // a0 = first address of data section in RAM
-            la a1, {edata}              // a1 = first address after data section in RAM
-            la a2, {etext}              // a2 = address of stored data initial values
-
-          200: // data_init_loop
-            beq  a0, a1, 201f           // If we have reached the end of the .data
-                                        // section then we are done.
-            lw   a3, 0(a2)              // a3 = *a2. Load value from initial values into a3.
-            sw   a3, 0(a0)              // *a0 = a3. Store initial value into
-                                        // next place in .data.
-            addi a0, a0, 4              // a0 = a0 + 4. Increment to next word in memory.
-            addi a2, a2, 4              // a2 = a2 + 4. Increment to next word in flash.
-            j 200b                      // Continue the loop.
-
-          201: // data_init_done
-
-            // With that initial setup out of the way, we now branch to the main
-            // code, likely defined in a board's main.rs.
-            j main
-        ",
-gp = sym __global_pointer,
-estack = sym _estack,
-sbss = sym _szero,
-ebss = sym _ezero,
-sdata = sym _srelocate,
-edata = sym _erelocate,
-etext = sym _etext,
-);
 
 // Mock implementation for tests on Travis-CI.
 #[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
@@ -184,211 +181,209 @@ pub extern "C" fn _start_trap() {
     unimplemented!()
 }
 
+/// This is the trap handler function. This code is called on all traps,
+/// including interrupts, exceptions, and system calls from applications.
+///
+/// Tock uses only the single trap handler, and does not use any vectored
+/// interrupts or other exception handling. The trap handler has to
+/// determine why the trap handler was called, and respond
+/// accordingly. Generally, there are two reasons the trap handler gets
+/// called: an interrupt occurred or an application called a syscall.
+///
+/// In the case of an interrupt while the kernel was executing we only need
+/// to save the kernel registers and then run whatever interrupt handling
+/// code we need to. If the trap happens while an application was executing,
+/// we have to save the application state and then resume the `switch_to()`
+/// function to correctly return back to the kernel.
+///
+/// We implement this distinction through a branch on the value of the
+/// `mscratch` CSR. If, at the time the trap was taken, it contains `0`, we
+/// assume that the hart is currently executing kernel code.
+///
+/// If it contains any other value, we interpret it to be a memory address
+/// pointing to a particular data structure:
+///
+/// ```text
+/// mscratch           0               1               2               3
+///  \->|--------------------------------------------------------------|
+///     | scratch word, overwritten with s1 register contents          |
+///     |--------------------------------------------------------------|
+///     | trap handler address, continue trap handler execution here   |
+///     |--------------------------------------------------------------|
+/// ```
+///
+/// Thus, process implementations can define their own strategy for how
+/// traps should be handled when they occur during process execution. This
+/// global trap handler behavior is well defined. It will:
+///
+/// 1. atomically swap s0 and the mscratch CSR,
+///
+/// 2. execute the default kernel trap handler if s0 now contains `0`
+/// (meaning that the mscratch CSR contained `0` before entering this trap
+/// handler),
+///
+/// 3. otherwise, save s1 to `0*4(s0)`, and finally
+///
+/// 4. load the address at `1*4(s0)` into s1, and jump to it.
+///
+/// No registers other than s0, s1 and the mscratch CSR are to be clobbered
+/// before continuing execution at the address loaded into the mscratch CSR
+/// or the _start_kernel_trap kernel trap handler.  Execution with these
+/// second-stage trap handlers must continue in the same trap handler
+/// context as originally invoked by the trap (e.g., the global trap handler
+/// will not execute an mret instruction). It will not modify CSRs that
+/// contain information on the trap source or the system state prior to
+/// entering the trap handler.
+///
+/// We deliberately clobber callee-saved instead of caller-saved registers,
+/// as this makes it easier to call other functions as part of the trap
+/// handler (for example to to disable interrupts from within Rust
+/// code). This global trap handler saves the previous values of these
+/// clobbered registers ensuring that they can be restored later.  It places
+/// new values into these clobbered registers (such as the previous `s0`
+/// register contents) that are required to be retained for correctly
+/// returning from the trap handler, and as such need to be saved across
+/// C-ABI function calls. Loading them into saved registers avoids the need
+/// to manually save them across such calls.
+///
+/// When a custom trap handler stack is registered in `mscratch`, the custom
+/// handler is responsible for restoring the kernel trap handler (by setting
+/// mscratch=0) before returning to kernel execution from the trap handler
+/// context.
+///
+/// If a board or chip must, for whichever reason, use a different global
+/// trap handler, it should abide to the above contract and emulate its
+/// behavior for all traps and interrupts that are required to be handled by
+/// the respective kernel or other trap handler as registered in mscratch.
+///
+/// For instance, a chip that does not support non-vectored trap handlers
+/// can register a vectored trap handler that routes each trap source to
+/// this global trap handler.
+///
+/// Alternatively, a board can be allowed to ignore certain traps or
+/// interrupts, some or all of the time, provided they are not vital to
+/// Tock's execution. These boards may choose to register an alternative
+/// handler for some or all trap sources. When this alternative handler is
+/// invoked, it may, for instance, choose to ignore a certain trap, access
+/// global state (subject to synchronization), etc. It must still abide to
+/// the contract as stated above.
 #[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
-extern "C" {
-    /// This is the trap handler function. This code is called on all traps,
-    /// including interrupts, exceptions, and system calls from applications.
-    ///
-    /// Tock uses only the single trap handler, and does not use any vectored
-    /// interrupts or other exception handling. The trap handler has to
-    /// determine why the trap handler was called, and respond
-    /// accordingly. Generally, there are two reasons the trap handler gets
-    /// called: an interrupt occurred or an application called a syscall.
-    ///
-    /// In the case of an interrupt while the kernel was executing we only need
-    /// to save the kernel registers and then run whatever interrupt handling
-    /// code we need to. If the trap happens while an application was executing,
-    /// we have to save the application state and then resume the `switch_to()`
-    /// function to correctly return back to the kernel.
-    ///
-    /// We implement this distinction through a branch on the value of the
-    /// `mscratch` CSR. If, at the time the trap was taken, it contains `0`, we
-    /// assume that the hart is currently executing kernel code.
-    ///
-    /// If it contains any other value, we interpret it to be a memory address
-    /// pointing to a particular data structure:
-    ///
-    /// ```text
-    /// mscratch           0               1               2               3
-    ///  \->|--------------------------------------------------------------|
-    ///     | scratch word, overwritten with s1 register contents          |
-    ///     |--------------------------------------------------------------|
-    ///     | trap handler address, continue trap handler execution here   |
-    ///     |--------------------------------------------------------------|
-    /// ```
-    ///
-    /// Thus, process implementations can define their own strategy for how
-    /// traps should be handled when they occur during process execution. This
-    /// global trap handler behavior is well defined. It will:
-    ///
-    /// 1. atomically swap s0 and the mscratch CSR,
-    ///
-    /// 2. execute the default kernel trap handler if s0 now contains `0`
-    /// (meaning that the mscratch CSR contained `0` before entering this trap
-    /// handler),
-    ///
-    /// 3. otherwise, save s1 to `0*4(s0)`, and finally
-    ///
-    /// 4. load the address at `1*4(s0)` into s1, and jump to it.
-    ///
-    /// No registers other than s0, s1 and the mscratch CSR are to be clobbered
-    /// before continuing execution at the address loaded into the mscratch CSR
-    /// or the _start_kernel_trap kernel trap handler.  Execution with these
-    /// second-stage trap handlers must continue in the same trap handler
-    /// context as originally invoked by the trap (e.g., the global trap handler
-    /// will not execute an mret instruction). It will not modify CSRs that
-    /// contain information on the trap source or the system state prior to
-    /// entering the trap handler.
-    ///
-    /// We deliberately clobber callee-saved instead of caller-saved registers,
-    /// as this makes it easier to call other functions as part of the trap
-    /// handler (for example to to disable interrupts from within Rust
-    /// code). This global trap handler saves the previous values of these
-    /// clobbered registers ensuring that they can be restored later.  It places
-    /// new values into these clobbered registers (such as the previous `s0`
-    /// register contents) that are required to be retained for correctly
-    /// returning from the trap handler, and as such need to be saved across
-    /// C-ABI function calls. Loading them into saved registers avoids the need
-    /// to manually save them across such calls.
-    ///
-    /// When a custom trap handler stack is registered in `mscratch`, the custom
-    /// handler is responsible for restoring the kernel trap handler (by setting
-    /// mscratch=0) before returning to kernel execution from the trap handler
-    /// context.
-    ///
-    /// If a board or chip must, for whichever reason, use a different global
-    /// trap handler, it should abide to the above contract and emulate its
-    /// behavior for all traps and interrupts that are required to be handled by
-    /// the respective kernel or other trap handler as registered in mscratch.
-    ///
-    /// For instance, a chip that does not support non-vectored trap handlers
-    /// can register a vectored trap handler that routes each trap source to
-    /// this global trap handler.
-    ///
-    /// Alternatively, a board can be allowed to ignore certain traps or
-    /// interrupts, some or all of the time, provided they are not vital to
-    /// Tock's execution. These boards may choose to register an alternative
-    /// handler for some or all trap sources. When this alternative handler is
-    /// invoked, it may, for instance, choose to ignore a certain trap, access
-    /// global state (subject to synchronization), etc. It must still abide to
-    /// the contract as stated above.
-    pub fn _start_trap();
-}
+#[link_section = ".riscv.trap"]
+#[export_name = "_start_trap"]
+#[unsafe(naked)]
+pub extern "C" fn _start_trap() {
+    use core::arch::naked_asm;
+    naked_asm!(
+        "
+        // This is the global trap handler. By default, Tock expects this
+        // trap handler to be registered at all times, and that all traps
+        // and interrupts occurring in all modes of execution (M-, S-, and
+        // U-mode) will cause this trap handler to be executed.
+        //
+        // For documentation of its behavior, and how process
+        // implementations can hook their own trap handler code, see the
+        // comment on the `extern C _start_trap` symbol above.
 
-#[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
-core::arch::global_asm!(
-    "
-            .section .riscv.trap, \"ax\"
-            .globl _start_trap
-          _start_trap:
-            // This is the global trap handler. By default, Tock expects this
-            // trap handler to be registered at all times, and that all traps
-            // and interrupts occurring in all modes of execution (M-, S-, and
-            // U-mode) will cause this trap handler to be executed.
-            //
-            // For documentation of its behavior, and how process
-            // implementations can hook their own trap handler code, see the
-            // comment on the `extern C _start_trap` symbol above.
+        // Atomically swap s0 and mscratch:
+        csrrw s0, mscratch, s0        // s0 = mscratch; mscratch = s0
 
-            // Atomically swap s0 and mscratch:
-            csrrw s0, mscratch, s0        // s0 = mscratch; mscratch = s0
+        // If mscratch contained 0, invoke the kernel trap handler.
+        beq   s0, x0, 100f      // if s0==x0: goto 100
 
-            // If mscratch contained 0, invoke the kernel trap handler.
-            beq   s0, x0, 100f      // if s0==x0: goto 100
+        // Else, save the current value of s1 to `0*4(s0)`, load `1*4(s0)`
+        // into s1 and jump to it (invoking a custom trap handler).
+        sw    s1, 0*4(s0)       // *s0 = s1
+        lw    s1, 1*4(s0)       // s1 = *(s0+4)
+        jr    s1                // goto s1
 
-            // Else, save the current value of s1 to `0*4(s0)`, load `1*4(s0)`
-            // into s1 and jump to it (invoking a custom trap handler).
-            sw    s1, 0*4(s0)       // *s0 = s1
-            lw    s1, 1*4(s0)       // s1 = *(s0+4)
-            jr    s1                // goto s1
+      100: // _start_kernel_trap
 
-          100: // _start_kernel_trap
+        // The global trap handler has swapped s0 into mscratch. We can thus
+        // freely clobber s0 without losing any information.
+        //
+        // Since we want to use the stack to save kernel registers, we
+        // first need to make sure that the trap wasn't the result of a
+        // stack overflow, in which case we can't use the current stack
+        // pointer. Use s0 as a scratch register:
 
-            // The global trap handler has swapped s0 into mscratch. We can thus
-            // freely clobber s0 without losing any information.
-            //
-            // Since we want to use the stack to save kernel registers, we
-            // first need to make sure that the trap wasn't the result of a
-            // stack overflow, in which case we can't use the current stack
-            // pointer. Use s0 as a scratch register:
+        // Load the address of the bottom of the stack (`_sstack`) into our
+        // newly freed-up s0 register.
+        la s0, {sstack}                     // s0 = _sstack
 
-            // Load the address of the bottom of the stack (`_sstack`) into our
-            // newly freed-up s0 register.
-            la s0, {sstack}                     // s0 = _sstack
+        // Compare the kernel stack pointer to the bottom of the stack. If
+        // the stack pointer is above the bottom of the stack, then continue
+        // handling the fault as normal.
+        bgtu sp, s0, 200f                   // branch if sp > s0
 
-            // Compare the kernel stack pointer to the bottom of the stack. If
-            // the stack pointer is above the bottom of the stack, then continue
-            // handling the fault as normal.
-            bgtu sp, s0, 200f                   // branch if sp > s0
+        // If we get here, then we did encounter a stack overflow. We are
+        // going to panic at this point, but for that to work we need a
+        // valid stack to run the panic code. We do this by just starting
+        // over with the kernel stack and placing the stack pointer at the
+        // top of the original stack.
+        la sp, {estack}                     // sp = _estack
 
-            // If we get here, then we did encounter a stack overflow. We are
-            // going to panic at this point, but for that to work we need a
-            // valid stack to run the panic code. We do this by just starting
-            // over with the kernel stack and placing the stack pointer at the
-            // top of the original stack.
-            la sp, {estack}                     // sp = _estack
+    200: // _start_kernel_trap_continue
 
-        200: // _start_kernel_trap_continue
+        // Restore s0. We reset mscratch to 0 (kernel trap handler mode)
+        csrrw s0, mscratch, zero    // s0 = mscratch; mscratch = 0
 
-            // Restore s0. We reset mscratch to 0 (kernel trap handler mode)
-            csrrw s0, mscratch, zero    // s0 = mscratch; mscratch = 0
+        // Make room for the caller saved registers we need to restore after
+        // running any trap handler code.
+        addi sp, sp, -16*4
 
-            // Make room for the caller saved registers we need to restore after
-            // running any trap handler code.
-            addi sp, sp, -16*4
+        // Save all of the caller saved registers.
+        sw   ra, 0*4(sp)
+        sw   t0, 1*4(sp)
+        sw   t1, 2*4(sp)
+        sw   t2, 3*4(sp)
+        sw   t3, 4*4(sp)
+        sw   t4, 5*4(sp)
+        sw   t5, 6*4(sp)
+        sw   t6, 7*4(sp)
+        sw   a0, 8*4(sp)
+        sw   a1, 9*4(sp)
+        sw   a2, 10*4(sp)
+        sw   a3, 11*4(sp)
+        sw   a4, 12*4(sp)
+        sw   a5, 13*4(sp)
+        sw   a6, 14*4(sp)
+        sw   a7, 15*4(sp)
 
-            // Save all of the caller saved registers.
-            sw   ra, 0*4(sp)
-            sw   t0, 1*4(sp)
-            sw   t1, 2*4(sp)
-            sw   t2, 3*4(sp)
-            sw   t3, 4*4(sp)
-            sw   t4, 5*4(sp)
-            sw   t5, 6*4(sp)
-            sw   t6, 7*4(sp)
-            sw   a0, 8*4(sp)
-            sw   a1, 9*4(sp)
-            sw   a2, 10*4(sp)
-            sw   a3, 11*4(sp)
-            sw   a4, 12*4(sp)
-            sw   a5, 13*4(sp)
-            sw   a6, 14*4(sp)
-            sw   a7, 15*4(sp)
+        // Jump to board-specific trap handler code. Likely this was an
+        // interrupt and we want to disable a particular interrupt, but each
+        // board/chip can customize this as needed.
+        jal ra, _start_trap_rust_from_kernel
 
-            // Jump to board-specific trap handler code. Likely this was an
-            // interrupt and we want to disable a particular interrupt, but each
-            // board/chip can customize this as needed.
-            jal ra, _start_trap_rust_from_kernel
+        // Restore the registers from the stack.
+        lw   ra, 0*4(sp)
+        lw   t0, 1*4(sp)
+        lw   t1, 2*4(sp)
+        lw   t2, 3*4(sp)
+        lw   t3, 4*4(sp)
+        lw   t4, 5*4(sp)
+        lw   t5, 6*4(sp)
+        lw   t6, 7*4(sp)
+        lw   a0, 8*4(sp)
+        lw   a1, 9*4(sp)
+        lw   a2, 10*4(sp)
+        lw   a3, 11*4(sp)
+        lw   a4, 12*4(sp)
+        lw   a5, 13*4(sp)
+        lw   a6, 14*4(sp)
+        lw   a7, 15*4(sp)
 
-            // Restore the registers from the stack.
-            lw   ra, 0*4(sp)
-            lw   t0, 1*4(sp)
-            lw   t1, 2*4(sp)
-            lw   t2, 3*4(sp)
-            lw   t3, 4*4(sp)
-            lw   t4, 5*4(sp)
-            lw   t5, 6*4(sp)
-            lw   t6, 7*4(sp)
-            lw   a0, 8*4(sp)
-            lw   a1, 9*4(sp)
-            lw   a2, 10*4(sp)
-            lw   a3, 11*4(sp)
-            lw   a4, 12*4(sp)
-            lw   a5, 13*4(sp)
-            lw   a6, 14*4(sp)
-            lw   a7, 15*4(sp)
+        // Reset the stack pointer.
+        addi sp, sp, 16*4
 
-            // Reset the stack pointer.
-            addi sp, sp, 16*4
-
-            // mret returns from the trap handler. The PC is set to what is in
-            // mepc and execution proceeds from there. Since we did not modify
-            // mepc we will return to where the exception occurred.
-            mret
+        // mret returns from the trap handler. The PC is set to what is in
+        // mepc and execution proceeds from there. Since we did not modify
+        // mepc we will return to where the exception occurred.
+        mret
     ",
     estack = sym _estack,
     sstack = sym _sstack,
-);
+    );
+}
 
 /// RISC-V semihosting needs three exact instructions in uncompressed form.
 ///

--- a/arch/riscv/src/pmp.rs
+++ b/arch/riscv/src/pmp.rs
@@ -1052,8 +1052,11 @@ impl<const MAX_REGIONS: usize, P: TORUserPMP<MAX_REGIONS> + 'static> kernel::pla
             .find(|(_i, r)| {
                 // `start as usize + size` in lieu of a safe pointer offset method
                 r.0 != TORUserPMPCFG::OFF
-                    && r.1 == region.start_address()
-                    && r.2 == (region.start_address() as usize + region.size()) as *const u8
+                    && core::ptr::eq(r.1, region.start_address())
+                    && core::ptr::eq(
+                        r.2,
+                        (region.start_address() as usize + region.size()) as *const u8,
+                    )
             })
             .map(|(i, _)| i)
             .ok_or(())?;

--- a/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/io.rs
+++ b/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/io.rs
@@ -69,7 +69,6 @@ impl IoWrite for Writer {
 ///
 /// We just use the standard default provided by the debug module in the kernel.
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // MicroBit v2 has an LED matrix, use the upper left LED

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/src/io.rs
@@ -6,7 +6,6 @@ use core::panic::PanicInfo;
 use nrf52840::gpio::Pin;
 
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 /// Panic handler
 pub unsafe fn panic_fmt(_pi: &PanicInfo) -> ! {

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/io.rs
@@ -62,7 +62,6 @@ impl IoWrite for Writer {
 }
 
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 /// Panic handler
 pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-invs/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-invs/src/io.rs
@@ -6,7 +6,6 @@ use core::panic::PanicInfo;
 use nrf52840::gpio::Pin;
 
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 /// Panic handler
 pub unsafe fn panic_fmt(_pi: &PanicInfo) -> ! {

--- a/capsules/extra/src/net/thread/thread_utils.rs
+++ b/capsules/extra/src/net/thread/thread_utils.rs
@@ -196,15 +196,15 @@ pub fn form_child_id_req(
     // Response TLV //
     let received_challenge_tlv: Result<&[u8], ErrorCode> = find_challenge(&recv_buf[1..]);
 
-    if received_challenge_tlv.is_err() {
-        // Challenge TLV not found; malformed request
-        return Err(ErrorCode::FAIL);
-    } else {
+    if let Ok(received_challenge_tlv_inner) = received_challenge_tlv {
         // Encode response into output
         let mut rsp_buf: [u8; 8] = [0; 8];
-        rsp_buf.copy_from_slice(received_challenge_tlv.unwrap());
+        rsp_buf.copy_from_slice(received_challenge_tlv_inner);
         rsp_buf.reverse(); // NEED TO DISCUSS BIG/LITTLE ENDIAN ASSUMPTIONS
         offset += unwrap_tlv_offset(Tlv::encode(&Tlv::Response(rsp_buf), &mut output[offset..]));
+    } else {
+        // Challenge TLV not found; malformed request
+        return Err(ErrorCode::FAIL);
     }
 
     // Link-layer Frame Counter TLV //

--- a/chips/litex/src/liteeth.rs
+++ b/chips/litex/src/liteeth.rs
@@ -155,6 +155,7 @@ impl<const MAX_TX_SLOTS: usize, R: LiteXSoCRegisterConfiguration> LiteEth<'_, MA
         self.initialized.set(true);
     }
 
+    #[allow(clippy::mut_from_ref)]
     unsafe fn get_slot_buffer(&self, tx: bool, slot_id: usize) -> Option<&mut [u8]> {
         if (tx && slot_id > self.tx_slots) || (!tx && slot_id > self.rx_slots) {
             return None;

--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -73,7 +73,7 @@ of installing some of these tools, but you can also install them yourself.
 
 #### Rust (nightly)
 
-We are using `nightly-2025-03-14`. We require
+We are using `nightly-2025-05-19`. We require
 installing it with [rustup](http://www.rustup.rs) so you can manage multiple
 versions of Rust and continue using stable versions for other Rust code:
 
@@ -88,7 +88,7 @@ to your `$PATH`.
 Then install the correct nightly version of Rust:
 
 ```bash
-$ rustup install nightly-2025-03-14
+$ rustup install nightly-2025-05-19
 ```
 
 ### Compiling the Kernel

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -745,6 +745,10 @@ struct SavedAllowRo {
     len: usize,
 }
 
+// This allow is still needed on the current stable compiler, but generates a warning
+// on the current nightly compiler, as of 05/18/2025. So allow this warning for now.
+// This can probably be fixed on the next nightly update.
+#[allow(clippy::derivable_impls)]
 impl Default for SavedAllowRo {
     fn default() -> Self {
         Self {
@@ -763,6 +767,10 @@ struct SavedAllowRw {
     len: usize,
 }
 
+// This allow is still needed on the current stable compiler, but generates a warning
+// on the current nightly compiler, as of 05/18/2025. So allow this warning for now.
+// This can probably be fixed on the next nightly update.
+#[allow(clippy::derivable_impls)]
 impl Default for SavedAllowRw {
     fn default() -> Self {
         Self {

--- a/kernel/src/scheduler/mlfq.rs
+++ b/kernel/src/scheduler/mlfq.rs
@@ -110,12 +110,12 @@ impl<'a, A: 'static + time::Alarm<'static>> MLFQSched<'a, A> {
             let next = queue
                 .iter()
                 .find(|node_ref| node_ref.proc.is_some_and(|proc| proc.ready()));
-            if next.is_some() {
+            if let Some(inner) = next {
                 // pop procs to back until we get to match
                 loop {
                     let cur = queue.pop_head();
                     if let Some(node) = cur {
-                        if core::ptr::eq(node, next.unwrap()) {
+                        if core::ptr::eq(node, inner) {
                             queue.push_head(node);
                             // match! Put back on front
                             return (next, idx);

--- a/kernel/src/utilities/binary_write.rs
+++ b/kernel/src/utilities/binary_write.rs
@@ -108,7 +108,7 @@ impl core::fmt::Write for WriteToBinaryOffsetWrapper<'_> {
                 0
             } else {
                 // We want to start in the middle.
-                self.offset - self.index
+                self.offset.saturating_sub(self.index)
             };
 
             // Calculate the number of bytes we are going to pass to the

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,6 +3,6 @@
 # Copyright Tock Contributors 2023.
 
 [toolchain]
-channel = "nightly-2025-03-14"
+channel = "nightly-2025-05-19"
 components = ["miri", "llvm-tools", "rust-src", "rustfmt", "clippy", "rust-analyzer"]
 targets = ["thumbv6m-none-eabi", "thumbv7em-none-eabi", "thumbv7em-none-eabihf", "riscv32imc-unknown-none-elf", "riscv32imac-unknown-none-elf"]

--- a/tools/netlify-build.sh
+++ b/tools/netlify-build.sh
@@ -17,7 +17,7 @@ set -u
 set -x
 
 # Install rust stuff that we need
-curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2025-03-14
+curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2025-05-19
 
 # And fixup path for the newly installed rust stuff
 export PATH="$PATH:$HOME/.cargo/bin"


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the Rust compiler to May 18, 2025 and brings back naked functions instead of global_asm!() now that naked functions have been [stabilized](https://github.com/rust-lang/rust/pull/134213). Unfortunately I did not realize when I created this PR that naked functions is not in any released stable compiler until June 26, so this will just need to be rebased once that date passes, because otherwise it breaks Hail compiling on stable.

You should definitely hide whitespace changes when reviewing this PR.

### Testing Strategy

This pull request was tested by compiling.

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
