### PR TITLE
Update Rust version to 2025-05-19

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
     "editor.defaultFormatter": "rust-lang.rust-analyzer",
     "editor.formatOnSave": true,
     "rust-analyzer.server.extraEnv": {
-        "RUSTUP_TOOLCHAIN": "nightly-2025-03-14"
+        "RUSTUP_TOOLCHAIN": "nightly-2025-05-19"
     },
     "rust-analyzer.check.allTargets": false,
 }

--- a/arch/cortex-m/src/mpu.rs
+++ b/arch/cortex-m/src/mpu.rs
@@ -261,8 +261,9 @@ pub struct CortexMRegion {
 
 impl PartialEq<mpu::Region> for CortexMRegion {
     fn eq(&self, other: &mpu::Region) -> bool {
-        self.location
-            .is_some_and(|(addr, size)| addr == other.start_address() && size == other.size())
+        self.location.is_some_and(|(addr, size)| {
+            core::ptr::eq(addr, other.start_address()) && size == other.size()
+        })
     }
 }
 

--- a/arch/riscv/src/pmp.rs
+++ b/arch/riscv/src/pmp.rs
@@ -1052,8 +1052,11 @@ impl<const MAX_REGIONS: usize, P: TORUserPMP<MAX_REGIONS> + 'static> kernel::pla
             .find(|(_i, r)| {
                 // `start as usize + size` in lieu of a safe pointer offset method
                 r.0 != TORUserPMPCFG::OFF
-                    && r.1 == region.start_address()
-                    && r.2 == (region.start_address() as usize + region.size()) as *const u8
+                    && core::ptr::eq(r.1, region.start_address())
+                    && core::ptr::eq(
+                        r.2,
+                        (region.start_address() as usize + region.size()) as *const u8,
+                    )
             })
             .map(|(i, _)| i)
             .ok_or(())?;

--- a/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/io.rs
+++ b/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/io.rs
@@ -69,7 +69,6 @@ impl IoWrite for Writer {
 ///
 /// We just use the standard default provided by the debug module in the kernel.
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // MicroBit v2 has an LED matrix, use the upper left LED

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/src/io.rs
@@ -6,7 +6,6 @@ use core::panic::PanicInfo;
 use nrf52840::gpio::Pin;
 
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 /// Panic handler
 pub unsafe fn panic_fmt(_pi: &PanicInfo) -> ! {

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/io.rs
@@ -62,7 +62,6 @@ impl IoWrite for Writer {
 }
 
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 /// Panic handler
 pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-invs/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-invs/src/io.rs
@@ -6,7 +6,6 @@ use core::panic::PanicInfo;
 use nrf52840::gpio::Pin;
 
 #[cfg(not(test))]
-#[no_mangle]
 #[panic_handler]
 /// Panic handler
 pub unsafe fn panic_fmt(_pi: &PanicInfo) -> ! {

--- a/capsules/extra/src/net/thread/thread_utils.rs
+++ b/capsules/extra/src/net/thread/thread_utils.rs
@@ -196,15 +196,15 @@ pub fn form_child_id_req(
     // Response TLV //
     let received_challenge_tlv: Result<&[u8], ErrorCode> = find_challenge(&recv_buf[1..]);
 
-    if received_challenge_tlv.is_err() {
-        // Challenge TLV not found; malformed request
-        return Err(ErrorCode::FAIL);
-    } else {
+    if let Ok(received_challenge_tlv_inner) = received_challenge_tlv {
         // Encode response into output
         let mut rsp_buf: [u8; 8] = [0; 8];
-        rsp_buf.copy_from_slice(received_challenge_tlv.unwrap());
+        rsp_buf.copy_from_slice(received_challenge_tlv_inner);
         rsp_buf.reverse(); // NEED TO DISCUSS BIG/LITTLE ENDIAN ASSUMPTIONS
         offset += unwrap_tlv_offset(Tlv::encode(&Tlv::Response(rsp_buf), &mut output[offset..]));
+    } else {
+        // Challenge TLV not found; malformed request
+        return Err(ErrorCode::FAIL);
     }
 
     // Link-layer Frame Counter TLV //

--- a/chips/litex/src/liteeth.rs
+++ b/chips/litex/src/liteeth.rs
@@ -155,6 +155,7 @@ impl<const MAX_TX_SLOTS: usize, R: LiteXSoCRegisterConfiguration> LiteEth<'_, MA
         self.initialized.set(true);
     }
 
+    #[allow(clippy::mut_from_ref)]
     unsafe fn get_slot_buffer(&self, tx: bool, slot_id: usize) -> Option<&mut [u8]> {
         if (tx && slot_id > self.tx_slots) || (!tx && slot_id > self.rx_slots) {
             return None;

--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -73,7 +73,7 @@ of installing some of these tools, but you can also install them yourself.
 
 #### Rust (nightly)
 
-We are using `nightly-2025-03-14`. We require
+We are using `nightly-2025-05-19`. We require
 installing it with [rustup](http://www.rustup.rs) so you can manage multiple
 versions of Rust and continue using stable versions for other Rust code:
 
@@ -88,7 +88,7 @@ to your `$PATH`.
 Then install the correct nightly version of Rust:
 
 ```bash
-$ rustup install nightly-2025-03-14
+$ rustup install nightly-2025-05-19
 ```
 
 ### Compiling the Kernel

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -745,6 +745,10 @@ struct SavedAllowRo {
     len: usize,
 }
 
+// This allow is still needed on the current stable compiler, but generates a warning
+// on the current nightly compiler, as of 05/18/2025. So allow this warning for now.
+// This can probably be fixed on the next nightly update.
+#[allow(clippy::derivable_impls)]
 impl Default for SavedAllowRo {
     fn default() -> Self {
         Self {
@@ -763,6 +767,10 @@ struct SavedAllowRw {
     len: usize,
 }
 
+// This allow is still needed on the current stable compiler, but generates a warning
+// on the current nightly compiler, as of 05/18/2025. So allow this warning for now.
+// This can probably be fixed on the next nightly update.
+#[allow(clippy::derivable_impls)]
 impl Default for SavedAllowRw {
     fn default() -> Self {
         Self {

--- a/kernel/src/scheduler/mlfq.rs
+++ b/kernel/src/scheduler/mlfq.rs
@@ -110,12 +110,12 @@ impl<'a, A: 'static + time::Alarm<'static>> MLFQSched<'a, A> {
             let next = queue
                 .iter()
                 .find(|node_ref| node_ref.proc.is_some_and(|proc| proc.ready()));
-            if next.is_some() {
+            if let Some(inner) = next {
                 // pop procs to back until we get to match
                 loop {
                     let cur = queue.pop_head();
                     if let Some(node) = cur {
-                        if core::ptr::eq(node, next.unwrap()) {
+                        if core::ptr::eq(node, inner) {
                             queue.push_head(node);
                             // match! Put back on front
                             return (next, idx);

--- a/kernel/src/utilities/binary_write.rs
+++ b/kernel/src/utilities/binary_write.rs
@@ -108,7 +108,7 @@ impl core::fmt::Write for WriteToBinaryOffsetWrapper<'_> {
                 0
             } else {
                 // We want to start in the middle.
-                self.offset - self.index
+                self.offset.saturating_sub(self.index)
             };
 
             // Calculate the number of bytes we are going to pass to the

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,6 +3,6 @@
 # Copyright Tock Contributors 2023.
 
 [toolchain]
-channel = "nightly-2025-03-14"
+channel = "nightly-2025-05-19"
 components = ["miri", "llvm-tools", "rust-src", "rustfmt", "clippy", "rust-analyzer"]
 targets = ["thumbv6m-none-eabi", "thumbv7em-none-eabi", "thumbv7em-none-eabihf", "riscv32imc-unknown-none-elf", "riscv32imac-unknown-none-elf"]

--- a/tools/netlify-build.sh
+++ b/tools/netlify-build.sh
@@ -17,7 +17,7 @@ set -u
 set -x
 
 # Install rust stuff that we need
-curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2025-03-14
+curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2025-05-19
 
 # And fixup path for the newly installed rust stuff
 export PATH="$PATH:$HOME/.cargo/bin"


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the Rust version to May 19, 2025 and fixes a few warnings that have surfaced with the new nightly.


### Testing Strategy

This pull request was tested by CI


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
