### PR TITLE
style: spell out constants used in crypto interfaces

### DIFF
--- a/boards/components/src/appid/checker_signature.rs
+++ b/boards/components/src/appid/checker_signature.rs
@@ -10,16 +10,16 @@ use kernel::hil::{digest, public_key_crypto};
 
 #[macro_export]
 macro_rules! app_checker_signature_component_static {
-    ($S:ty, $H:ty, $HL:expr, $SL:expr $(,)?) => {{
-        let hash_buffer = kernel::static_buf!([u8; $HL]);
-        let signature_buffer = kernel::static_buf!([u8; $SL]);
+    ($S:ty, $H:ty, $HASH_LEN:expr, $SIGNATURE_LEN:expr $(,)?) => {{
+        let hash_buffer = kernel::static_buf!([u8; $HASH_LEN]);
+        let signature_buffer = kernel::static_buf!([u8; $SIGNATURE_LEN]);
         let checker = kernel::static_buf!(
             capsules_system::process_checker::signature::AppCheckerSignature<
                 'static,
                 $S,
                 $H,
-                $HL,
-                $SL,
+                $HASH_LEN,
+                $SIGNATURE_LEN,
             >
         );
 
@@ -27,16 +27,22 @@ macro_rules! app_checker_signature_component_static {
     };};
 }
 
-pub type AppCheckerSignatureComponentType<S, H, const HL: usize, const SL: usize> =
-    capsules_system::process_checker::signature::AppCheckerSignature<'static, S, H, HL, SL>;
+pub type AppCheckerSignatureComponentType<S, H, const HASH_LEN: usize, const SIGNATURE_LEN: usize> =
+    capsules_system::process_checker::signature::AppCheckerSignature<
+        'static,
+        S,
+        H,
+        HASH_LEN,
+        SIGNATURE_LEN,
+    >;
 
 pub struct AppCheckerSignatureComponent<
-    S: kernel::hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL>
+    S: kernel::hil::public_key_crypto::signature::SignatureVerify<'static, HASH_LEN, SIGNATURE_LEN>
         + kernel::hil::public_key_crypto::keys::SelectKey<'static>
         + 'static,
-    H: kernel::hil::digest::DigestDataHash<'static, HL> + 'static,
-    const HL: usize,
-    const SL: usize,
+    H: kernel::hil::digest::DigestDataHash<'static, HASH_LEN> + 'static,
+    const HASH_LEN: usize,
+    const SIGNATURE_LEN: usize,
 > {
     hasher: &'static H,
     verifier: &'static S,
@@ -44,12 +50,15 @@ pub struct AppCheckerSignatureComponent<
 }
 
 impl<
-        S: kernel::hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL>
-            + kernel::hil::public_key_crypto::keys::SelectKey<'static>,
-        H: kernel::hil::digest::DigestDataHash<'static, HL>,
-        const HL: usize,
-        const SL: usize,
-    > AppCheckerSignatureComponent<S, H, HL, SL>
+        S: kernel::hil::public_key_crypto::signature::SignatureVerify<
+                'static,
+                HASH_LEN,
+                SIGNATURE_LEN,
+            > + kernel::hil::public_key_crypto::keys::SelectKey<'static>,
+        H: kernel::hil::digest::DigestDataHash<'static, HASH_LEN>,
+        const HASH_LEN: usize,
+        const SIGNATURE_LEN: usize,
+    > AppCheckerSignatureComponent<S, H, HASH_LEN, SIGNATURE_LEN>
 {
     pub fn new(
         hasher: &'static H,
@@ -65,32 +74,42 @@ impl<
 }
 
 impl<
-        S: kernel::hil::public_key_crypto::signature::SignatureVerify<'static, HL, SL>
-            + kernel::hil::public_key_crypto::keys::SelectKey<'static>,
-        H: kernel::hil::digest::DigestDataHash<'static, HL> + kernel::hil::digest::Digest<'static, HL>,
-        const HL: usize,
-        const SL: usize,
-    > Component for AppCheckerSignatureComponent<S, H, HL, SL>
+        S: kernel::hil::public_key_crypto::signature::SignatureVerify<
+                'static,
+                HASH_LEN,
+                SIGNATURE_LEN,
+            > + kernel::hil::public_key_crypto::keys::SelectKey<'static>,
+        H: kernel::hil::digest::DigestDataHash<'static, HASH_LEN>
+            + kernel::hil::digest::Digest<'static, HASH_LEN>,
+        const HASH_LEN: usize,
+        const SIGNATURE_LEN: usize,
+    > Component for AppCheckerSignatureComponent<S, H, HASH_LEN, SIGNATURE_LEN>
 {
     type StaticInput = (
         &'static mut MaybeUninit<
-            capsules_system::process_checker::signature::AppCheckerSignature<'static, S, H, HL, SL>,
+            capsules_system::process_checker::signature::AppCheckerSignature<
+                'static,
+                S,
+                H,
+                HASH_LEN,
+                SIGNATURE_LEN,
+            >,
         >,
-        &'static mut MaybeUninit<[u8; HL]>,
-        &'static mut MaybeUninit<[u8; SL]>,
+        &'static mut MaybeUninit<[u8; HASH_LEN]>,
+        &'static mut MaybeUninit<[u8; SIGNATURE_LEN]>,
     );
 
     type Output = &'static capsules_system::process_checker::signature::AppCheckerSignature<
         'static,
         S,
         H,
-        HL,
-        SL,
+        HASH_LEN,
+        SIGNATURE_LEN,
     >;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let hash_buffer = s.1.write([0; HL]);
-        let signature_buffer = s.2.write([0; SL]);
+        let hash_buffer = s.1.write([0; HASH_LEN]);
+        let signature_buffer = s.2.write([0; SIGNATURE_LEN]);
 
         let checker = s.0.write(
             capsules_system::process_checker::signature::AppCheckerSignature::new(

--- a/kernel/src/hil/public_key_crypto/signature.rs
+++ b/kernel/src/hil/public_key_crypto/signature.rs
@@ -7,7 +7,7 @@
 use crate::ErrorCode;
 
 /// This trait provides callbacks for when the verification has completed.
-pub trait ClientVerify<const HL: usize, const SL: usize> {
+pub trait ClientVerify<const HASH_LEN: usize, const SIGNATURE_LEN: usize> {
     /// Called when the verification is complete.
     ///
     /// If the verification operation encounters an error, result will be a
@@ -23,8 +23,8 @@ pub trait ClientVerify<const HL: usize, const SL: usize> {
     fn verification_done(
         &self,
         result: Result<bool, ErrorCode>,
-        hash: &'static mut [u8; HL],
-        signature: &'static mut [u8; SL],
+        hash: &'static mut [u8; HASH_LEN],
+        signature: &'static mut [u8; SIGNATURE_LEN],
     );
 }
 
@@ -33,12 +33,12 @@ pub trait ClientVerify<const HL: usize, const SL: usize> {
 /// This is a generic interface, and it is up to the implementation as to the
 /// signature verification algorithm being used.
 ///
-/// - `HL`: The length in bytes of the hash.
-/// - `SL`: The length in bytes of the signature.
-pub trait SignatureVerify<'a, const HL: usize, const SL: usize> {
+/// - `HASH_LEN`: The length in bytes of the hash.
+/// - `SIGNATURE_LEN`: The length in bytes of the signature.
+pub trait SignatureVerify<'a, const HASH_LEN: usize, const SIGNATURE_LEN: usize> {
     /// Set the client instance which will receive the `verification_done()`
     /// callback.
-    fn set_verify_client(&self, client: &'a dyn ClientVerify<HL, SL>);
+    fn set_verify_client(&self, client: &'a dyn ClientVerify<HASH_LEN, SIGNATURE_LEN>);
 
     /// Verify the signature matches the given hash.
     ///
@@ -53,9 +53,16 @@ pub trait SignatureVerify<'a, const HL: usize, const SL: usize> {
     ///   verification engine cannot accept another request.
     fn verify(
         &self,
-        hash: &'static mut [u8; HL],
-        signature: &'static mut [u8; SL],
-    ) -> Result<(), (ErrorCode, &'static mut [u8; HL], &'static mut [u8; SL])>;
+        hash: &'static mut [u8; HASH_LEN],
+        signature: &'static mut [u8; SIGNATURE_LEN],
+    ) -> Result<
+        (),
+        (
+            ErrorCode,
+            &'static mut [u8; HASH_LEN],
+            &'static mut [u8; SIGNATURE_LEN],
+        ),
+    >;
 }
 
 /// This trait provides callbacks for when the signing has completed.


### PR DESCRIPTION
### Pull Request Overview

This is inspired by [the impending addition of yet one more `_L` constant](https://github.com/tock/tock/pull/4395#discussion_r2074661289). I was going to suggest writing things out as a clearer alternative on that PR, but realized it was really just following the existing style.

While it is generally [*] convention to use single letters for trait bounds, the same isn't quite as universal for const generics. Our [Style Guide](doc/Style.md#using-descriptive-names) prefers descriptive names. This feels like a use case where there isn't huge overhead in physical space on the screen from writing these out, and there is much more clarity in reading standalone use, especially as uses get further from the defining/explaining site in the HIL. I went `_LEN` in favor of `_LENGTH` following a general preference for `len` in Rust.

[*] In my ever-so-humble-opinion, _a terrible convention_

### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

Vibes check? Am I just being curmudgeonly about a Rust-ism with single-letter nonsense, or do others also feel this improves the readability? [Again, _especially_ with an expectation of yet more `_L` constants coming]

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
