### PR TITLE
boards: qemu_rv32_virt: fix typos in README

### DIFF
--- a/boards/qemu_rv32_virt/README.md
+++ b/boards/qemu_rv32_virt/README.md
@@ -57,7 +57,7 @@ QEMU standalone, or with a single app. These can be executed through the
   Entering main loop.
   ```
 
-- **`run`**: Start Tock on an emulated QEMU board without an app:
+- **`run-app`**: Start Tock on an emulated QEMU board with an app:
 
   ```
   tock/boards/qemu_rv32_virt $ make run-app APP=$PATH_TO_APP.tbf


### PR DESCRIPTION
### Pull Request Overview

Fix of copy-paste in README for `qemu_rv32_virt` board.

### Testing Strategy

Not required.

### TODO or Help Wanted

Not required.

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
