### PR TITLE
stm32f4xx: fix EXTI pending register mask

### DIFF
--- a/chips/stm32f4xx/src/exti.rs
+++ b/chips/stm32f4xx/src/exti.rs
@@ -631,7 +631,7 @@ impl<'a> Exti<'a> {
 
         // ignore the "reserved" EXTI bits. Use bits [22:0]. See `EXTI_PR` for
         // details.
-        exti_pr |= 0x007fffff;
+        exti_pr &= 0x007fffff;
 
         let mut flagged_bit = 0;
 


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes a bug in the external interrupt handler of the `stm32f4` chips that resulted in executing the handlers for all the pins (with interrupts enabled) each time an interrupt occured on an EXTI line.

### Testing Strategy

This pull request was tested by @DanutAldea on a NucleoF429ZI board.

### Formatting

- [x] Ran `make prepush`.