### PR TITLE
kernel: Implement `ProcessArray` to hold an array of `&Process`s with interior mutability

### DIFF
--- a/boards/apollo3/lora_things_plus/src/io.rs
+++ b/boards/apollo3/lora_things_plus/src/io.rs
@@ -53,7 +53,7 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
         writer,
         info,
         &cortexm4::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/apollo3/redboard_artemis_atp/src/io.rs
+++ b/boards/apollo3/redboard_artemis_atp/src/io.rs
@@ -53,7 +53,7 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
         writer,
         info,
         &cortexm4::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/apollo3/redboard_artemis_nano/src/io.rs
+++ b/boards/apollo3/redboard_artemis_nano/src/io.rs
@@ -53,7 +53,7 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
         writer,
         info,
         &cortexm4::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/apollo3/redboard_artemis_nano/src/main.rs
+++ b/boards/apollo3/redboard_artemis_nano/src/main.rs
@@ -13,9 +13,6 @@
 #![test_runner(test_runner)]
 #![reexport_test_harness_main = "test_main"]
 
-use core::ptr::addr_of;
-use core::ptr::addr_of_mut;
-
 use apollo3::chip::Apollo3DefaultPeripherals;
 use capsules_core::virtualizers::virtual_alarm::MuxAlarm;
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
@@ -27,6 +24,7 @@ use kernel::hil::i2c::I2CMaster;
 use kernel::hil::led::LedHigh;
 use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::process::ProcessArray;
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
 
@@ -39,8 +37,8 @@ mod tests;
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 4;
 
-// Actual memory for holding the active process structures.
-static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS] = [None; 4];
+/// Static variables used by io.rs.
+static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
 
 // Static reference to chip for panic dumps.
 static mut CHIP: Option<&'static apollo3::chip::Apollo3<Apollo3DefaultPeripherals>> = None;
@@ -197,7 +195,12 @@ unsafe fn setup() -> (
     let process_mgmt_cap = create_capability!(capabilities::ProcessManagementCapability);
     let memory_allocation_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
+    // Create an array to hold process references.
+    let processes = components::process_array::ProcessArrayComponent::new()
+        .finalize(components::process_array_component_static!(NUM_PROCS));
+    PROCESSES = Some(processes);
+
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
 
     // Power up components
     pwr_ctrl.enable_uart0();
@@ -396,7 +399,7 @@ unsafe fn setup() -> (
         static _eappmem: u8;
     }
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(processes)
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let systick = cortexm4::systick::SysTick::new_with_calibration(48_000_000);
@@ -436,7 +439,6 @@ unsafe fn setup() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_mgmt_cap,
     )

--- a/boards/arty_e21/src/io.rs
+++ b/boards/arty_e21/src/io.rs
@@ -71,7 +71,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         writer,
         pi,
         &rv32i::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/clue_nrf52840/src/io.rs
+++ b/boards/clue_nrf52840/src/io.rs
@@ -137,7 +137,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         writer,
         pi,
         &cortexm4::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -11,7 +11,6 @@
 #![deny(missing_docs)]
 
 use core::ptr::addr_of;
-use core::ptr::addr_of_mut;
 
 use capsules_core::virtualizers::virtual_aes_ccm::MuxAES128CCM;
 
@@ -27,6 +26,7 @@ use kernel::hil::time::Counter;
 use kernel::hil::usb::Client;
 use kernel::platform::chip::Chip;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::process::ProcessArray;
 use kernel::scheduler::round_robin::RoundRobinSched;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
@@ -108,9 +108,8 @@ const FAULT_RESPONSE: capsules_system::process_policies::StopWithDebugFaultPolic
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 8;
 
-static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS] =
-    [None; NUM_PROCS];
-
+/// Static variables used by io.rs.
+static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
 static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;
 static mut PROCESS_PRINTER: Option<&'static capsules_system::process_printer::ProcessPrinterText> =
     None;
@@ -291,7 +290,13 @@ unsafe fn start() -> (
     // bootloader.
     NRF52_POWER = Some(&base_peripherals.pwr_clk);
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
+    // Create an array to hold process references.
+    let processes = components::process_array::ProcessArrayComponent::new()
+        .finalize(components::process_array_component_static!(NUM_PROCS));
+    PROCESSES = Some(processes);
+
+    // Setup space to store the core kernel data structure.
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
 
     //--------------------------------------------------------------------------
     // CAPABILITIES
@@ -759,7 +764,7 @@ unsafe fn start() -> (
     // approach than this.
     nrf52_components::NrfClockComponent::new(&base_peripherals.clock).finalize(());
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(processes)
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let platform = Platform {
@@ -828,7 +833,6 @@ unsafe fn start() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -70,6 +70,7 @@ pub mod nonvolatile_storage;
 pub mod nrf51822;
 pub mod panic_button;
 pub mod pressure;
+pub mod process_array;
 pub mod process_console;
 pub mod process_info_driver;
 pub mod process_printer;

--- a/boards/components/src/loader/sequential.rs
+++ b/boards/components/src/loader/sequential.rs
@@ -38,7 +38,6 @@ pub struct ProcessLoaderSequentialComponent<
     const NUM_PROCS: usize,
 > {
     checker: &'static kernel::process::ProcessCheckerMachine,
-    processes: &'static mut [Option<&'static dyn kernel::process::Process>],
     kernel: &'static kernel::Kernel,
     chip: &'static C,
     fault_policy: &'static dyn kernel::process::ProcessFaultPolicy,
@@ -53,7 +52,6 @@ impl<C: Chip, D: ProcessStandardDebug, const NUM_PROCS: usize>
 {
     pub fn new(
         checker: &'static kernel::process::ProcessCheckerMachine,
-        processes: &'static mut [Option<&'static dyn kernel::process::Process>],
         kernel: &'static kernel::Kernel,
         chip: &'static C,
         fault_policy: &'static dyn kernel::process::ProcessFaultPolicy,
@@ -64,7 +62,6 @@ impl<C: Chip, D: ProcessStandardDebug, const NUM_PROCS: usize>
     ) -> Self {
         Self {
             checker,
-            processes,
             kernel,
             chip,
             fault_policy,
@@ -96,7 +93,6 @@ impl<C: Chip, D: ProcessStandardDebug, const NUM_PROCS: usize> Component
         let loader =
             s.0.write(kernel::process::SequentialProcessLoaderMachine::new(
                 self.checker,
-                self.processes,
                 process_binary_array,
                 self.kernel,
                 self.chip,

--- a/boards/components/src/process_array.rs
+++ b/boards/components/src/process_array.rs
@@ -1,0 +1,32 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+//! Component for the array of process references used by the kernel.
+
+use core::mem::MaybeUninit;
+use kernel::component::Component;
+
+#[macro_export]
+macro_rules! process_array_component_static {
+    ($NUM_PROCS:ty $(,)?) => {{
+        kernel::static_buf!(kernel::process::ProcessArray<$NUM_PROCS>)
+    };};
+}
+
+pub struct ProcessArrayComponent<const NUM_PROCS: usize> {}
+
+impl<const NUM_PROCS: usize> ProcessArrayComponent<NUM_PROCS> {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl<const NUM_PROCS: usize> Component for ProcessArrayComponent<NUM_PROCS> {
+    type StaticInput = &'static mut MaybeUninit<kernel::process::ProcessArray<NUM_PROCS>>;
+    type Output = &'static kernel::process::ProcessArray<NUM_PROCS>;
+
+    fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
+        static_buffer.write(kernel::process::ProcessArray::new())
+    }
+}

--- a/boards/components/src/sched/cooperative.rs
+++ b/boards/components/src/sched/cooperative.rs
@@ -17,7 +17,7 @@
 
 use core::mem::MaybeUninit;
 use kernel::component::Component;
-use kernel::process::Process;
+use kernel::process::ProcessArray;
 use kernel::scheduler::cooperative::{CoopProcessNode, CooperativeSched};
 
 #[macro_export]
@@ -34,13 +34,11 @@ macro_rules! cooperative_component_static {
 }
 
 pub struct CooperativeComponent<const NUM_PROCS: usize> {
-    processes: &'static [Option<&'static dyn Process>],
+    processes: &'static ProcessArray<NUM_PROCS>,
 }
 
 impl<const NUM_PROCS: usize> CooperativeComponent<NUM_PROCS> {
-    pub fn new(
-        processes: &'static [Option<&'static dyn Process>],
-    ) -> CooperativeComponent<NUM_PROCS> {
+    pub fn new(processes: &'static ProcessArray<NUM_PROCS>) -> CooperativeComponent<NUM_PROCS> {
         CooperativeComponent { processes }
     }
 }

--- a/boards/components/src/sched/mlfq.rs
+++ b/boards/components/src/sched/mlfq.rs
@@ -14,7 +14,7 @@ use core::mem::MaybeUninit;
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use kernel::component::Component;
 use kernel::hil::time;
-use kernel::process::Process;
+use kernel::process::ProcessArray;
 use kernel::scheduler::mlfq::{MLFQProcessNode, MLFQSched};
 
 #[macro_export]
@@ -39,13 +39,13 @@ macro_rules! mlfq_component_static {
 
 pub struct MLFQComponent<A: 'static + time::Alarm<'static>, const NUM_PROCS: usize> {
     alarm_mux: &'static MuxAlarm<'static, A>,
-    processes: &'static [Option<&'static dyn Process>],
+    processes: &'static ProcessArray<NUM_PROCS>,
 }
 
 impl<A: 'static + time::Alarm<'static>, const NUM_PROCS: usize> MLFQComponent<A, NUM_PROCS> {
     pub fn new(
         alarm_mux: &'static MuxAlarm<'static, A>,
-        processes: &'static [Option<&'static dyn Process>],
+        processes: &'static ProcessArray<NUM_PROCS>,
     ) -> MLFQComponent<A, NUM_PROCS> {
         MLFQComponent {
             alarm_mux,

--- a/boards/components/src/sched/round_robin.rs
+++ b/boards/components/src/sched/round_robin.rs
@@ -18,7 +18,7 @@
 
 use core::mem::MaybeUninit;
 use kernel::component::Component;
-use kernel::process::Process;
+use kernel::process::ProcessArray;
 use kernel::scheduler::round_robin::{RoundRobinProcessNode, RoundRobinSched};
 
 #[macro_export]
@@ -36,13 +36,11 @@ macro_rules! round_robin_component_static {
 }
 
 pub struct RoundRobinComponent<const NUM_PROCS: usize> {
-    processes: &'static [Option<&'static dyn Process>],
+    processes: &'static ProcessArray<NUM_PROCS>,
 }
 
 impl<const NUM_PROCS: usize> RoundRobinComponent<NUM_PROCS> {
-    pub fn new(
-        processes: &'static [Option<&'static dyn Process>],
-    ) -> RoundRobinComponent<NUM_PROCS> {
+    pub fn new(processes: &'static ProcessArray<NUM_PROCS>) -> RoundRobinComponent<NUM_PROCS> {
         RoundRobinComponent { processes }
     }
 }

--- a/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/io.rs
+++ b/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/io.rs
@@ -85,7 +85,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         writer,
         pi,
         &cortexm4::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/src/main.rs
@@ -8,13 +8,12 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use core::ptr::{addr_of, addr_of_mut};
-
 use kernel::component::Component;
 use kernel::deferred_call::DeferredCallClient;
 use kernel::hil::led::LedLow;
 use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::process::ProcessArray;
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{capabilities, create_capability, static_init};
 use nrf52840::gpio::Pin;
@@ -45,9 +44,8 @@ const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 8;
 
-static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS] =
-    [None; NUM_PROCS];
-
+/// Static variables used by io.rs.
+static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
 static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
@@ -173,8 +171,13 @@ pub unsafe fn main() {
     // pins.
     let uart_channel = UartChannel::Pins(UartPins::new(UART_RTS, UART_TXD, UART_CTS, UART_RXD));
 
+    // Create an array to hold process references.
+    let processes = components::process_array::ProcessArrayComponent::new()
+        .finalize(components::process_array_component_static!(NUM_PROCS));
+    PROCESSES = Some(processes);
+
     // Setup space to store the core kernel data structure.
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
 
     // Create (and save for panic debugging) a chip object to setup low-level
     // resources (e.g. MPU, systick).
@@ -412,7 +415,6 @@ pub unsafe fn main() {
     // Create and start the asynchronous process loader.
     let _loader = components::loader::sequential::ProcessLoaderSequentialComponent::new(
         checker,
-        &mut *addr_of_mut!(PROCESSES),
         board_kernel,
         chip,
         &FAULT_RESPONSE,
@@ -431,7 +433,7 @@ pub unsafe fn main() {
     // PLATFORM SETUP, SCHEDULER, AND START KERNEL LOOP
     //--------------------------------------------------------------------------
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(processes)
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let platform = Platform {

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-sha256/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-sha256/src/main.rs
@@ -8,12 +8,11 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use core::ptr::{addr_of, addr_of_mut};
-
 use kernel::component::Component;
 use kernel::hil::led::LedLow;
 use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::process::ProcessArray;
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{capabilities, create_capability, static_init};
 use nrf52840::gpio::Pin;
@@ -44,9 +43,8 @@ const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 8;
 
-static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS] =
-    [None; NUM_PROCS];
-
+/// Static variables used by io.rs.
+static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
 static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
@@ -162,8 +160,13 @@ pub unsafe fn main() {
     // pins.
     let uart_channel = UartChannel::Pins(UartPins::new(UART_RTS, UART_TXD, UART_CTS, UART_RXD));
 
+    // Create an array to hold process references.
+    let processes = components::process_array::ProcessArrayComponent::new()
+        .finalize(components::process_array_component_static!(NUM_PROCS));
+    PROCESSES = Some(processes);
+
     // Setup space to store the core kernel data structure.
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
 
     // Create (and save for panic debugging) a chip object to setup low-level
     // resources (e.g. MPU, systick).
@@ -309,7 +312,6 @@ pub unsafe fn main() {
     // Create and start the asynchronous process loader.
     let _loader = components::loader::sequential::ProcessLoaderSequentialComponent::new(
         checker,
-        &mut *addr_of_mut!(PROCESSES),
         board_kernel,
         chip,
         &FAULT_RESPONSE,
@@ -328,7 +330,7 @@ pub unsafe fn main() {
     // PLATFORM SETUP, SCHEDULER, AND START KERNEL LOOP
     //--------------------------------------------------------------------------
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(processes)
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let platform = Platform {

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/main.rs
@@ -8,12 +8,11 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use core::ptr::{addr_of, addr_of_mut};
-
 use kernel::component::Component;
 use kernel::hil::led::LedLow;
 use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::process::ProcessArray;
 use kernel::process::ProcessLoadingAsync;
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{capabilities, create_capability, static_init};
@@ -45,9 +44,8 @@ const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 8;
 
-static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS] =
-    [None; NUM_PROCS];
-
+/// Static variables used by io.rs.
+static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
 static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
@@ -72,7 +70,7 @@ pub struct Platform {
     alarm: &'static AlarmDriver,
     scheduler: &'static RoundRobinSched<'static>,
     systick: cortexm4::systick::SysTick,
-    processes: &'static [Option<&'static dyn kernel::process::Process>],
+    processes: &'static ProcessArray<NUM_PROCS>,
 }
 
 impl SyscallDriverLookup for Platform {
@@ -147,8 +145,8 @@ impl kernel::process::ProcessLoadingAsyncClient for Platform {
     fn process_loading_finished(&self) {
         kernel::debug!("Processes Loaded:");
 
-        for (i, proc) in self.processes.iter().enumerate() {
-            proc.map(|p| {
+        for (i, proc) in self.processes.as_slice().iter().enumerate() {
+            proc.get_active().map(|p| {
                 kernel::debug!("[{}] {}", i, p.get_process_name());
                 kernel::debug!("    ShortId: {}", p.short_app_id());
             });
@@ -174,15 +172,18 @@ pub unsafe fn main() {
     nrf52840_peripherals.init();
     let base_peripherals = &nrf52840_peripherals.nrf52;
 
-    let processes = &*addr_of!(PROCESSES);
-
     // Choose the channel for serial output. This board can be configured to use
     // either the Segger RTT channel or via UART with traditional TX/RX GPIO
     // pins.
     let uart_channel = UartChannel::Pins(UartPins::new(UART_RTS, UART_TXD, UART_CTS, UART_RXD));
 
+    // Create an array to hold process references.
+    let processes = components::process_array::ProcessArrayComponent::new()
+        .finalize(components::process_array_component_static!(NUM_PROCS));
+    PROCESSES = Some(processes);
+
     // Setup space to store the core kernel data structure.
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
 
     // Create (and save for panic debugging) a chip object to setup low-level
     // resources (e.g. MPU, systick).
@@ -348,7 +349,6 @@ pub unsafe fn main() {
     // Create and start the asynchronous process loader.
     let loader = components::loader::sequential::ProcessLoaderSequentialComponent::new(
         checker,
-        &mut *addr_of_mut!(PROCESSES),
         board_kernel,
         chip,
         &FAULT_RESPONSE,

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/main.rs
@@ -146,7 +146,7 @@ impl kernel::process::ProcessLoadingAsyncClient for Platform {
         kernel::debug!("Processes Loaded:");
 
         for (i, proc) in self.processes.as_slice().iter().enumerate() {
-            proc.get_active().map(|p| {
+            proc.get().map(|p| {
                 kernel::debug!("[{}] {}", i, p.get_process_name());
                 kernel::debug!("    ShortId: {}", p.short_app_id());
             });

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/io.rs
@@ -83,7 +83,7 @@ pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {
         writer,
         pi,
         &cortexm4::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
@@ -8,12 +8,11 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use core::ptr::{addr_of, addr_of_mut};
-
 use kernel::component::Component;
 use kernel::hil::led::LedLow;
 use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::process::ProcessArray;
 use kernel::process::ProcessLoadingAsync;
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{capabilities, create_capability, static_init};
@@ -50,9 +49,8 @@ const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 8;
 
-static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS] =
-    [None; NUM_PROCS];
-
+/// Static variables used by io.rs.
+static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
 static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;
 // Static reference to process printer for panic dumps.
 static mut PROCESS_PRINTER: Option<&'static capsules_system::process_printer::ProcessPrinterText> =
@@ -91,7 +89,7 @@ pub struct Platform {
     alarm: &'static AlarmDriver,
     scheduler: &'static RoundRobinSched<'static>,
     systick: cortexm4::systick::SysTick,
-    processes: &'static [Option<&'static dyn kernel::process::Process>],
+    processes: &'static ProcessArray<NUM_PROCS>,
     dynamic_app_loader: &'static capsules_extra::app_loader::AppLoader<
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
@@ -173,8 +171,8 @@ impl kernel::process::ProcessLoadingAsyncClient for Platform {
     fn process_loading_finished(&self) {
         kernel::debug!("Processes Loaded at Main:");
 
-        for (i, proc) in self.processes.iter().enumerate() {
-            proc.map(|p| {
+        for (i, proc) in self.processes.as_slice().iter().enumerate() {
+            proc.get_active().map(|p| {
                 kernel::debug!("[{}] {}", i, p.get_process_name());
                 kernel::debug!("    ShortId: {}", p.short_app_id());
             });
@@ -200,15 +198,18 @@ pub unsafe fn main() {
     nrf52840_peripherals.init();
     let base_peripherals = &nrf52840_peripherals.nrf52;
 
-    let processes = &*addr_of!(PROCESSES);
-
     // Choose the channel for serial output. This board can be configured to use
     // either the Segger RTT channel or via UART with traditional TX/RX GPIO
     // pins.
     let uart_channel = UartChannel::Pins(UartPins::new(UART_RTS, UART_TXD, UART_CTS, UART_RXD));
 
+    // Create an array to hold process references.
+    let processes = components::process_array::ProcessArrayComponent::new()
+        .finalize(components::process_array_component_static!(NUM_PROCS));
+    PROCESSES = Some(processes);
+
     // Setup space to store the core kernel data structure.
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
 
     // Create (and save for panic debugging) a chip object to setup low-level
     // resources (e.g. MPU, systick).
@@ -431,7 +432,6 @@ pub unsafe fn main() {
     // Create and start the asynchronous process loader.
     let loader = components::loader::sequential::ProcessLoaderSequentialComponent::new(
         checker,
-        &mut *addr_of_mut!(PROCESSES),
         board_kernel,
         chip,
         &FAULT_RESPONSE,

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
@@ -172,7 +172,7 @@ impl kernel::process::ProcessLoadingAsyncClient for Platform {
         kernel::debug!("Processes Loaded at Main:");
 
         for (i, proc) in self.processes.as_slice().iter().enumerate() {
-            proc.get_active().map(|p| {
+            proc.get().map(|p| {
                 kernel::debug!("[{}] {}", i, p.get_process_name());
                 kernel::debug!("    ShortId: {}", p.short_app_id());
             });

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/io.rs
@@ -80,7 +80,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         writer,
         pi,
         &cortexm4::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/cy8cproto_62_4343_w/src/io.rs
+++ b/boards/cy8cproto_62_4343_w/src/io.rs
@@ -57,7 +57,7 @@ pub unsafe fn panic_fmt(panic_info: &PanicInfo) -> ! {
         writer,
         panic_info,
         &cortexm0p::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     );

--- a/boards/esp32-c3-devkitM-1/src/io.rs
+++ b/boards/esp32-c3-devkitM-1/src/io.rs
@@ -44,7 +44,11 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
 
     debug::panic_banner(writer, pi);
     debug::panic_cpu_state(&*addr_of!(CHIP), writer);
-    debug::panic_process_info(&*addr_of!(PROCESSES), &*addr_of!(PROCESS_PRINTER), writer);
+    debug::panic_process_info(
+        PROCESSES.unwrap().as_slice(),
+        &*addr_of!(PROCESS_PRINTER),
+        writer,
+    );
 
     loop {
         rv32i::support::nop();
@@ -62,7 +66,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         writer,
         pi,
         &rv32i::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     );

--- a/boards/hail/src/io.rs
+++ b/boards/hail/src/io.rs
@@ -76,7 +76,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         writer,
         pi,
         &cortexm4::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -11,14 +11,13 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use core::ptr::{addr_of, addr_of_mut};
-
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::hil;
 use kernel::hil::led::LedLow;
 use kernel::hil::Controller;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::process::ProcessArray;
 use kernel::scheduler::round_robin::RoundRobinSched;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, static_init};
@@ -36,10 +35,8 @@ mod test_take_map_cell;
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 20;
 
-// Actual memory for holding the active process structures.
-static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS] =
-    [None; NUM_PROCS];
-
+/// Static variables used by io.rs.
+static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
 static mut CHIP: Option<&'static sam4l::chip::Sam4l<Sam4lDefaultPeripherals>> = None;
 static mut PROCESS_PRINTER: Option<&'static capsules_system::process_printer::ProcessPrinterText> =
     None;
@@ -268,7 +265,13 @@ unsafe fn start() -> (
         Some(&peripherals.pa[14]),
     );
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
+    // Create an array to hold process references.
+    let processes = components::process_array::ProcessArrayComponent::new()
+        .finalize(components::process_array_component_static!(NUM_PROCS));
+    PROCESSES = Some(processes);
+
+    // Setup space to store the core kernel data structure.
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
 
     let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
         .finalize(components::process_printer_text_component_static!());
@@ -490,7 +493,7 @@ unsafe fn start() -> (
         capsules_system::process_policies::ThresholdRestartThenPanicFaultPolicy::new(4)
     );
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(processes)
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let hail = Hail {
@@ -551,7 +554,6 @@ unsafe fn start() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut *addr_of_mut!(PROCESSES),
         fault_policy,
         &process_management_capability,
     )

--- a/boards/hifive1/src/io.rs
+++ b/boards/hifive1/src/io.rs
@@ -72,7 +72,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         writer,
         pi,
         &rv32i::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/hifive_inventor/src/io.rs
+++ b/boards/hifive_inventor/src/io.rs
@@ -52,7 +52,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         writer,
         pi,
         &rv32i::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -69,7 +69,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         writer,
         pi,
         &cortexm4::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/imxrt1050-evkb/src/io.rs
+++ b/boards/imxrt1050-evkb/src/io.rs
@@ -79,7 +79,7 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
         writer,
         info,
         &cortexm7::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/litex/arty/src/io.rs
+++ b/boards/litex/arty/src/io.rs
@@ -47,7 +47,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         writer,
         pi,
         &rv32i::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(PANIC_REFERENCES.chip),
         &*addr_of!(PANIC_REFERENCES.process_printer),
     )

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -8,8 +8,6 @@
 #![no_std]
 #![no_main]
 
-use core::ptr::{addr_of, addr_of_mut};
-
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 
 use kernel::capabilities;
@@ -18,6 +16,7 @@ use kernel::hil::time::{Alarm, Timer};
 use kernel::platform::chip::InterruptService;
 use kernel::platform::scheduler_timer::VirtualSchedulerTimer;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::process::ProcessArray;
 use kernel::scheduler::mlfq::MLFQSched;
 use kernel::utilities::registers::interfaces::ReadWriteable;
 use kernel::utilities::StaticRef;
@@ -85,10 +84,8 @@ impl InterruptService for LiteXArtyInterruptablePeripherals {
 
 const NUM_PROCS: usize = 4;
 
-// Actual memory for holding the active process structures. Need an
-// empty list at least.
-static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS] =
-    [None; NUM_PROCS];
+/// Static variables used by io.rs.
+static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
 
 // Reference to the chip, led controller, UART hardware, and process printer for
 // panic dumps.
@@ -329,7 +326,13 @@ unsafe fn start() -> (
     let process_mgmt_cap = create_capability!(capabilities::ProcessManagementCapability);
     let memory_allocation_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
+    // Create an array to hold process references.
+    let processes = components::process_array::ProcessArrayComponent::new()
+        .finalize(components::process_array_component_static!(NUM_PROCS));
+    PROCESSES = Some(processes);
+
+    // Setup space to store the core kernel data structure.
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
 
     // ---------- LED CONTROLLER HARDWARE ----------
 
@@ -602,8 +605,8 @@ unsafe fn start() -> (
     )
     .finalize(components::low_level_debug_component_static!());
 
-    let scheduler = components::sched::mlfq::MLFQComponent::new(mux_alarm, &*addr_of!(PROCESSES))
-        .finalize(components::mlfq_component_static!(
+    let scheduler = components::sched::mlfq::MLFQComponent::new(mux_alarm, processes).finalize(
+        components::mlfq_component_static!(
             litex_vexriscv::timer::LiteXAlarm<
                 'static,
                 'static,
@@ -611,7 +614,8 @@ unsafe fn start() -> (
                 socc::ClockFrequency,
             >,
             NUM_PROCS
-        ));
+        ),
+    );
 
     let litex_arty = LiteXArty {
         console,
@@ -642,7 +646,6 @@ unsafe fn start() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_mgmt_cap,
     )

--- a/boards/litex/sim/src/io.rs
+++ b/boards/litex/sim/src/io.rs
@@ -42,7 +42,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         writer,
         pi,
         &rv32i::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(PANIC_REFERENCES.chip),
         &*addr_of!(PANIC_REFERENCES.process_printer),
     );

--- a/boards/makepython-nrf52840/src/io.rs
+++ b/boards/makepython-nrf52840/src/io.rs
@@ -134,7 +134,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         writer,
         pi,
         &cortexm4::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/microbit_v2/src/io.rs
+++ b/boards/microbit_v2/src/io.rs
@@ -85,7 +85,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         writer,
         pi,
         &cortexm4::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -10,12 +10,13 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use core::ptr::{addr_of, addr_of_mut};
+use core::ptr::addr_of;
 
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::process::ProcessArray;
 use kernel::scheduler::round_robin::RoundRobinSched;
 
 #[allow(unused_imports)]
@@ -69,9 +70,8 @@ const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 4;
 
-static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS] =
-    [None; NUM_PROCS];
-
+/// Static variables used by io.rs.
+static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
 static mut CHIP: Option<&'static nrf52833::chip::NRF52<Nrf52833DefaultPeripherals>> = None;
 static mut PROCESS_PRINTER: Option<&'static capsules_system::process_printer::ProcessPrinterText> =
     None;
@@ -240,7 +240,13 @@ unsafe fn start() -> (
 
     let base_peripherals = &nrf52833_peripherals.nrf52;
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
+    // Create an array to hold process references.
+    let processes = components::process_array::ProcessArrayComponent::new()
+        .finalize(components::process_array_component_static!(NUM_PROCS));
+    PROCESSES = Some(processes);
+
+    // Setup space to store the core kernel data structure.
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
 
     //--------------------------------------------------------------------------
     // RAW 802.15.4
@@ -736,7 +742,7 @@ unsafe fn start() -> (
     while !base_peripherals.clock.low_started() {}
     while !base_peripherals.clock.high_started() {}
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(processes)
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let microbit = MicroBit {
@@ -802,7 +808,6 @@ unsafe fn start() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/msp_exp432p401r/src/io.rs
+++ b/boards/msp_exp432p401r/src/io.rs
@@ -52,7 +52,7 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
         writer,
         info,
         &cortexm4::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -10,13 +10,12 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use core::ptr::{addr_of, addr_of_mut};
-
 use components::gpio::GpioComponent;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::hil::gpio::Configure;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::process::ProcessArray;
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
 
@@ -26,9 +25,8 @@ pub mod io;
 /// Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 4;
 
-/// Actual memory for holding the active process structures.
-static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS] =
-    [None; NUM_PROCS];
+/// Static variables used by io.rs.
+static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
 
 /// Static reference to chip for panic dumps.
 static mut CHIP: Option<&'static msp432::chip::Msp432<msp432::chip::Msp432DefaultPeripherals>> =
@@ -231,7 +229,14 @@ unsafe fn start() -> (
     peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P01_2 as usize].enable_primary_function();
     peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P01_3 as usize].enable_primary_function();
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
+    // Create an array to hold process references.
+    let processes = components::process_array::ProcessArrayComponent::new()
+        .finalize(components::process_array_component_static!(NUM_PROCS));
+    PROCESSES = Some(processes);
+
+    // Setup space to store the core kernel data structure.
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
+
     let chip = static_init!(
         msp432::chip::Msp432<msp432::chip::Msp432DefaultPeripherals>,
         msp432::chip::Msp432::new(peripherals)
@@ -406,7 +411,7 @@ unsafe fn start() -> (
     // Enable the internal temperature sensor on ADC Channel 22
     peripherals.adc_ref.enable_temp_sensor(true);
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(processes)
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
@@ -455,7 +460,6 @@ unsafe fn start() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/nano33ble/src/io.rs
+++ b/boards/nano33ble/src/io.rs
@@ -136,7 +136,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         writer,
         pi,
         &cortexm4::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -11,7 +11,6 @@
 #![deny(missing_docs)]
 
 use core::ptr::addr_of;
-use core::ptr::addr_of_mut;
 
 use kernel::capabilities;
 use kernel::component::Component;
@@ -22,6 +21,7 @@ use kernel::hil::time::Counter;
 use kernel::hil::usb::Client;
 use kernel::platform::chip::Chip;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::process::ProcessArray;
 use kernel::scheduler::round_robin::RoundRobinSched;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
@@ -86,10 +86,8 @@ const FAULT_RESPONSE: capsules_system::process_policies::StopWithDebugFaultPolic
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 8;
 
-// State for loading and holding applications.
-static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS] =
-    [None; NUM_PROCS];
-
+/// Static variables used by io.rs.
+static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
 static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;
 static mut PROCESS_PRINTER: Option<&'static capsules_system::process_printer::ProcessPrinterText> =
     None;
@@ -264,7 +262,13 @@ pub unsafe fn start() -> (
     // bootloader.
     NRF52_POWER = Some(&base_peripherals.pwr_clk);
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
+    // Create an array to hold process references.
+    let processes = components::process_array::ProcessArrayComponent::new()
+        .finalize(components::process_array_component_static!(NUM_PROCS));
+    PROCESSES = Some(processes);
+
+    // Setup space to store the core kernel data structure.
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
 
     //--------------------------------------------------------------------------
     // CAPABILITIES
@@ -611,7 +615,7 @@ pub unsafe fn start() -> (
     // approach than this.
     nrf52_components::NrfClockComponent::new(&base_peripherals.clock).finalize(());
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(processes)
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let platform = Platform {
@@ -692,7 +696,6 @@ pub unsafe fn start() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/nano33ble_rev2/src/io.rs
+++ b/boards/nano33ble_rev2/src/io.rs
@@ -137,7 +137,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         writer,
         pi,
         &cortexm4::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/nano33ble_rev2/src/main.rs
+++ b/boards/nano33ble_rev2/src/main.rs
@@ -11,7 +11,6 @@
 #![deny(missing_docs)]
 
 use core::ptr::addr_of;
-use core::ptr::addr_of_mut;
 
 use kernel::capabilities;
 use kernel::component::Component;
@@ -22,6 +21,7 @@ use kernel::hil::time::Counter;
 use kernel::hil::usb::Client;
 use kernel::platform::chip::Chip;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::process::ProcessArray;
 use kernel::scheduler::round_robin::RoundRobinSched;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
@@ -83,10 +83,8 @@ const FAULT_RESPONSE: capsules_system::process_policies::StopWithDebugFaultPolic
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 8;
 
-// State for loading and holding applications.
-static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS] =
-    [None; NUM_PROCS];
-
+/// Static variables used by io.rs.
+static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
 static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;
 static mut PROCESS_PRINTER: Option<&'static capsules_system::process_printer::ProcessPrinterText> =
     None;
@@ -272,7 +270,13 @@ pub unsafe fn start() -> (
     // bootloader.
     NRF52_POWER = Some(&base_peripherals.pwr_clk);
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
+    // Create an array to hold process references.
+    let processes = components::process_array::ProcessArrayComponent::new()
+        .finalize(components::process_array_component_static!(NUM_PROCS));
+    PROCESSES = Some(processes);
+
+    // Setup space to store the core kernel data structure.
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
 
     //--------------------------------------------------------------------------
     // CAPABILITIES
@@ -633,7 +637,7 @@ pub unsafe fn start() -> (
     // approach than this.
     nrf52_components::NrfClockComponent::new(&base_peripherals.clock).finalize(());
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(processes)
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let platform = Platform {
@@ -715,7 +719,6 @@ pub unsafe fn start() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/nano_rp2040_connect/src/io.rs
+++ b/boards/nano_rp2040_connect/src/io.rs
@@ -98,7 +98,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         writer,
         pi,
         &cortexm0p::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/nordic/nrf52840_dongle/src/io.rs
+++ b/boards/nordic/nrf52840_dongle/src/io.rs
@@ -69,7 +69,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         writer,
         pi,
         &cortexm4::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -11,7 +11,7 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use core::ptr::{addr_of, addr_of_mut};
+use core::ptr::addr_of;
 
 use capsules_core::virtualizers::virtual_aes_ccm::MuxAES128CCM;
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
@@ -21,6 +21,7 @@ use kernel::hil::led::LedLow;
 use kernel::hil::symmetric_encryption::AES128;
 use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::process::ProcessArray;
 use kernel::scheduler::round_robin::RoundRobinSched;
 #[allow(unused_imports)]
 use kernel::{capabilities, create_capability, debug, debug_gpio, debug_verbose, static_init};
@@ -65,9 +66,8 @@ const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 8;
 
-static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS] =
-    [None; NUM_PROCS];
-
+/// Static variables used by io.rs.
+static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
 // Static reference to chip for panic dumps
 static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;
 // Static reference to process printer for panic dumps
@@ -209,7 +209,13 @@ pub unsafe fn start() -> (
     nrf52840_peripherals.init();
     let base_peripherals = &nrf52840_peripherals.nrf52;
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
+    // Create an array to hold process references.
+    let processes = components::process_array::ProcessArrayComponent::new()
+        .finalize(components::process_array_component_static!(NUM_PROCS));
+    PROCESSES = Some(processes);
+
+    // Setup space to store the core kernel data structure.
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
 
     // GPIOs
     let gpio = components::gpio::GpioComponent::new(
@@ -419,7 +425,7 @@ pub unsafe fn start() -> (
 
     nrf52_components::NrfClockComponent::new(&base_peripherals.clock).finalize(());
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(processes)
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let platform = Platform {
@@ -470,7 +476,6 @@ pub unsafe fn start() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -79,7 +79,7 @@ pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {
         writer,
         pi,
         &cortexm4::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -81,6 +81,7 @@ use kernel::hil::time::Counter;
 #[allow(unused_imports)]
 use kernel::hil::usb::Client;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::process::ProcessArray;
 use kernel::scheduler::round_robin::RoundRobinSched;
 #[allow(unused_imports)]
 use kernel::{capabilities, create_capability, debug, debug_gpio, debug_verbose, static_init};

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -453,10 +453,8 @@ pub unsafe fn start_no_pconsole() -> (
     };
 
     // Create an array to hold process references.
-    let processes = static_init!(
-        kernel::process::ProcessArray<NUM_PROCS>,
-        kernel::process::ProcessArray::new()
-    );
+    let processes = components::process_array::ProcessArrayComponent::new()
+        .finalize(components::process_array_component_static!(NUM_PROCS));
     PROCESSES = Some(processes);
 
     // Setup space to store the core kernel data structure.

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -8,12 +8,9 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use core::ptr::addr_of_mut;
-
 use kernel::debug;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::{capabilities, create_capability};
-use nrf52840dk_lib::{self, PROCESSES};
 
 // State for loading and holding applications.
 // How should the kernel respond when a process faults.
@@ -121,7 +118,6 @@ pub unsafe fn main() {
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/nordic/nrf52dk/src/io.rs
+++ b/boards/nordic/nrf52dk/src/io.rs
@@ -69,7 +69,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         writer,
         pi,
         &cortexm4::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -69,13 +69,14 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use core::ptr::{addr_of, addr_of_mut};
+use core::ptr::addr_of;
 
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use kernel::component::Component;
 use kernel::hil::led::LedLow;
 use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::process::ProcessArray;
 use kernel::scheduler::round_robin::RoundRobinSched;
 #[allow(unused_imports)]
 use kernel::{capabilities, create_capability, debug, debug_gpio, debug_verbose, static_init};
@@ -124,9 +125,8 @@ const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 4;
 
-static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS] = [None; 4];
-
-// Static reference to chip for panic dumps
+/// Static variables used by io.rs.
+static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
 static mut CHIP: Option<&'static nrf52832::chip::NRF52<Nrf52832DefaultPeripherals>> = None;
 static mut PROCESS_PRINTER: Option<&'static capsules_system::process_printer::ProcessPrinterText> =
     None;
@@ -254,7 +254,13 @@ pub unsafe fn start() -> (
     nrf52832_peripherals.init();
     let base_peripherals = &nrf52832_peripherals.nrf52;
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
+    // Create an array to hold process references.
+    let processes = components::process_array::ProcessArrayComponent::new()
+        .finalize(components::process_array_component_static!(NUM_PROCS));
+    PROCESSES = Some(processes);
+
+    // Setup space to store the core kernel data structure.
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
 
     let gpio = components::gpio::GpioComponent::new(
         board_kernel,
@@ -442,7 +448,7 @@ pub unsafe fn start() -> (
 
     nrf52_components::NrfClockComponent::new(&base_peripherals.clock).finalize(());
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(processes)
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let platform = Platform {
@@ -492,7 +498,6 @@ pub unsafe fn start() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/nucleo_f429zi/src/io.rs
+++ b/boards/nucleo_f429zi/src/io.rs
@@ -91,7 +91,7 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
         writer,
         info,
         &cortexm4::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -10,7 +10,7 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use core::ptr::{addr_of, addr_of_mut};
+use core::ptr::addr_of_mut;
 
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
@@ -18,6 +18,7 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::hil::led::LedHigh;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::process::ProcessArray;
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
 
@@ -32,10 +33,8 @@ pub mod io;
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 4;
 
-// Actual memory for holding the active process structures.
-static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS] =
-    [None, None, None, None];
-
+/// Static variables used by io.rs.
+static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
 static mut CHIP: Option<&'static stm32f429zi::chip::Stm32f4xx<Stm32f429ziDefaultPeripherals>> =
     None;
 static mut PROCESS_PRINTER: Option<&'static capsules_system::process_printer::ProcessPrinterText> =
@@ -358,7 +357,13 @@ unsafe fn start() -> (
         &base_peripherals.usart3,
     );
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
+    // Create an array to hold process references.
+    let processes = components::process_array::ProcessArrayComponent::new()
+        .finalize(components::process_array_component_static!(NUM_PROCS));
+    PROCESSES = Some(processes);
+
+    // Setup space to store the core kernel data structure.
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
 
     let chip = static_init!(
         stm32f429zi::chip::Stm32f4xx<Stm32f429ziDefaultPeripherals>,
@@ -644,7 +649,7 @@ unsafe fn start() -> (
     ));
     let _ = process_console.start();
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(processes)
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let nucleo_f429zi = NucleoF429ZI {
@@ -701,7 +706,6 @@ unsafe fn start() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/nucleo_f446re/src/io.rs
+++ b/boards/nucleo_f446re/src/io.rs
@@ -90,7 +90,7 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
         writer,
         info,
         &cortexm4::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -10,7 +10,7 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use core::ptr::{addr_of, addr_of_mut};
+use core::ptr::addr_of_mut;
 
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
@@ -19,6 +19,7 @@ use kernel::component::Component;
 use kernel::hil::gpio::Configure;
 use kernel::hil::led::LedHigh;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::process::ProcessArray;
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
 use stm32f446re::chip_specs::Stm32f446Specs;
@@ -36,9 +37,8 @@ mod virtual_uart_rx_test;
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 4;
 
-// Actual memory for holding the active process structures.
-static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS] =
-    [None, None, None, None];
+/// Static variables used by io.rs.
+static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
 
 // Static reference to chip for panic dumps.
 static mut CHIP: Option<&'static stm32f446re::chip::Stm32f4xx<Stm32f446reDefaultPeripherals>> =
@@ -303,7 +303,13 @@ unsafe fn start() -> (
         &base_peripherals.usart2,
     );
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
+    // Create an array to hold process references.
+    let processes = components::process_array::ProcessArrayComponent::new()
+        .finalize(components::process_array_component_static!(NUM_PROCS));
+    PROCESSES = Some(processes);
+
+    // Setup space to store the core kernel data structure.
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
 
     let chip = static_init!(
         stm32f446re::chip::Stm32f4xx<Stm32f446reDefaultPeripherals>,
@@ -490,7 +496,7 @@ unsafe fn start() -> (
     ));
     let _ = process_console.start();
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(processes)
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let nucleo_f446re = NucleoF446RE {
@@ -544,7 +550,6 @@ unsafe fn start() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/opentitan/src/io.rs
+++ b/boards/opentitan/src/io.rs
@@ -65,7 +65,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         writer,
         pi,
         &|| {},
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     );
@@ -76,7 +76,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         writer,
         pi,
         &rv32i::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     );
@@ -88,13 +88,20 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let writer = &mut WRITER;
 
     #[cfg(feature = "sim_verilator")]
-    debug::panic_print(writer, pi, &|| {}, &PROCESSES, &CHIP, &PROCESS_PRINTER);
+    debug::panic_print(
+        writer,
+        pi,
+        &|| {},
+        PROCESSES.unwrap().as_slice(),
+        &CHIP,
+        &PROCESS_PRINTER,
+    );
     #[cfg(not(feature = "sim_verilator"))]
     debug::panic_print(
         writer,
         pi,
         &rv32i::support::nop,
-        &PROCESSES,
+        PROCESSES.unwrap().as_slice(),
         &CHIP,
         &PROCESS_PRINTER,
     );

--- a/boards/particle_boron/src/io.rs
+++ b/boards/particle_boron/src/io.rs
@@ -75,7 +75,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         writer,
         pi,
         &cortexm4::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -11,9 +11,6 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use core::ptr::addr_of;
-use core::ptr::addr_of_mut;
-
 use capsules_core::i2c_master_slave_driver::I2CMasterSlaveDriver;
 use capsules_core::virtualizers::virtual_aes_ccm::MuxAES128CCM;
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
@@ -26,6 +23,7 @@ use kernel::hil::led::LedLow;
 use kernel::hil::symmetric_encryption::AES128;
 use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::process::ProcessArray;
 use kernel::scheduler::round_robin::RoundRobinSched;
 #[allow(unused_imports)]
 use kernel::{capabilities, create_capability, debug, debug_gpio, debug_verbose, static_init};
@@ -76,8 +74,8 @@ const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 8;
 
-static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS] =
-    [None; NUM_PROCS];
+/// Static variables used by io.rs.
+static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
 
 // Static reference to chip for panic dumps
 static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;
@@ -231,7 +229,13 @@ pub unsafe fn start_particle_boron() -> (
     // bootloader.
     NRF52_POWER = Some(&base_peripherals.pwr_clk);
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
+    // Create an array to hold process references.
+    let processes = components::process_array::ProcessArrayComponent::new()
+        .finalize(components::process_array_component_static!(NUM_PROCS));
+    PROCESSES = Some(processes);
+
+    // Setup space to store the core kernel data structure.
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
 
     //--------------------------------------------------------------------------
     // CAPABILITIES
@@ -555,7 +559,7 @@ pub unsafe fn start_particle_boron() -> (
 
     nrf52_components::NrfClockComponent::new(&base_peripherals.clock).finalize(());
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(processes)
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let platform = Platform {
@@ -614,7 +618,6 @@ pub unsafe fn start_particle_boron() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/pico_explorer_base/src/io.rs
+++ b/boards/pico_explorer_base/src/io.rs
@@ -100,7 +100,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         writer,
         pi,
         &cortexm0p::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -10,7 +10,7 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use core::ptr::{addr_of, addr_of_mut};
+use core::ptr::addr_of_mut;
 
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
@@ -20,8 +20,9 @@ use kernel::component::Component;
 use kernel::hil::led::LedHigh;
 use kernel::hil::usb::Client;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::process::ProcessArray;
 use kernel::scheduler::round_robin::RoundRobinSched;
-use kernel::{capabilities, create_capability, static_init, Kernel};
+use kernel::{capabilities, create_capability, static_init};
 use kernel::{debug, hil};
 
 use rp2040::adc::{Adc, Channel};
@@ -61,9 +62,8 @@ const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 4;
 
-static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS] =
-    [None; NUM_PROCS];
-
+/// Static variables used by io.rs.
+static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
 static mut CHIP: Option<&'static Rp2040<Rp2040DefaultPeripherals>> = None;
 static mut PROCESS_PRINTER: Option<&'static capsules_system::process_printer::ProcessPrinterText> =
     None;
@@ -326,7 +326,13 @@ pub unsafe fn start() -> (
 
     CHIP = Some(chip);
 
-    let board_kernel = static_init!(Kernel, Kernel::new(&*addr_of!(PROCESSES)));
+    // Create an array to hold process references.
+    let processes = components::process_array::ProcessArrayComponent::new()
+        .finalize(components::process_array_component_static!(NUM_PROCS));
+    PROCESSES = Some(processes);
+
+    // Setup space to store the core kernel data structure.
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
 
     let process_management_capability =
         create_capability!(capabilities::ProcessManagementCapability);
@@ -560,7 +566,7 @@ pub unsafe fn start() -> (
     .finalize(components::process_console_component_static!(RPTimer));
     let _ = process_console.start();
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(processes)
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     //--------------------------------------------------------------------------
@@ -682,7 +688,6 @@ pub unsafe fn start() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/qemu_i486_q35/src/io.rs
+++ b/boards/qemu_i486_q35/src/io.rs
@@ -57,7 +57,7 @@ unsafe fn panic_handler(pi: &PanicInfo) -> ! {
         &mut com1,
         pi,
         &x86::support::nop,
-        &*ptr::addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*ptr::addr_of!(CHIP),
         &*ptr::addr_of!(PROCESS_PRINTER),
     );

--- a/boards/qemu_rv32_virt/src/io.rs
+++ b/boards/qemu_rv32_virt/src/io.rs
@@ -44,7 +44,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         writer,
         pi,
         &rv32i::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     );

--- a/boards/raspberry_pi_pico/src/io.rs
+++ b/boards/raspberry_pi_pico/src/io.rs
@@ -100,7 +100,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         writer,
         pi,
         &cortexm0p::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -10,7 +10,7 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use core::ptr::{addr_of, addr_of_mut};
+use core::ptr::addr_of_mut;
 
 use capsules_core::i2c_master::I2CMasterDriver;
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
@@ -25,9 +25,10 @@ use kernel::hil::i2c::I2CMaster;
 use kernel::hil::led::LedHigh;
 use kernel::hil::usb::Client;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::process::ProcessArray;
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::syscall::SyscallDriver;
-use kernel::{capabilities, create_capability, static_init, Kernel};
+use kernel::{capabilities, create_capability, static_init};
 
 use rp2040::adc::{Adc, Channel};
 use rp2040::chip::{Rp2040, Rp2040DefaultPeripherals};
@@ -64,8 +65,8 @@ const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 4;
 
-static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS] =
-    [None; NUM_PROCS];
+/// Static variables used by io.rs.
+static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
 
 static mut CHIP: Option<&'static Rp2040<Rp2040DefaultPeripherals>> = None;
 static mut PROCESS_PRINTER: Option<&'static capsules_system::process_printer::ProcessPrinterText> =
@@ -315,7 +316,13 @@ pub unsafe fn start() -> (
 
     CHIP = Some(chip);
 
-    let board_kernel = static_init!(Kernel, Kernel::new(&*addr_of!(PROCESSES)));
+    // Create an array to hold process references.
+    let processes = components::process_array::ProcessArrayComponent::new()
+        .finalize(components::process_array_component_static!(NUM_PROCS));
+    PROCESSES = Some(processes);
+
+    // Setup space to store the core kernel data structure.
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
 
     let process_management_capability =
         create_capability!(capabilities::ProcessManagementCapability);
@@ -537,7 +544,7 @@ pub unsafe fn start() -> (
     i2c0.init(10 * 1000);
     i2c0.set_master_client(i2c);
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(processes)
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let raspberry_pi_pico = RaspberryPiPico {
@@ -595,7 +602,6 @@ pub unsafe fn start() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/redboard_redv/src/io.rs
+++ b/boards/redboard_redv/src/io.rs
@@ -72,7 +72,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         writer,
         pi,
         &rv32i::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/redboard_redv/src/main.rs
+++ b/boards/redboard_redv/src/main.rs
@@ -11,7 +11,8 @@
 #![no_std]
 #![no_main]
 
-use core::ptr::{addr_of, addr_of_mut};
+use core::ptr::addr_of;
+use core::ptr::addr_of_mut;
 
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use e310_g002::interrupt_service::E310G002DefaultPeripherals;
@@ -21,6 +22,7 @@ use kernel::hil;
 use kernel::hil::led::LedLow;
 use kernel::platform::scheduler_timer::VirtualSchedulerTimer;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::process::ProcessArray;
 use kernel::scheduler::cooperative::CooperativeSched;
 use kernel::utilities::registers::interfaces::ReadWriteable;
 use kernel::{create_capability, debug, static_init};
@@ -29,11 +31,9 @@ use rv32i::csr;
 pub mod io;
 
 pub const NUM_PROCS: usize = 4;
-//
-// Actual memory for holding the active process structures. Need an empty list
-// at least.
-static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS] =
-    [None; NUM_PROCS];
+
+/// Static variables used by io.rs.
+static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
 
 // Reference to the chip for panic dumps.
 static mut CHIP: Option<&'static e310_g002::chip::E310x<E310G002DefaultPeripherals>> = None;
@@ -160,7 +160,13 @@ unsafe fn start() -> (
         .prci
         .set_clock_frequency(sifive::prci::ClockFrequency::Freq16Mhz);
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
+    // Create an array to hold process references.
+    let processes = components::process_array::ProcessArrayComponent::new()
+        .finalize(components::process_array_component_static!(NUM_PROCS));
+    PROCESSES = Some(processes);
+
+    // Setup space to store the core kernel data structure.
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
 
     // Configure kernel debug gpios as early as possible
     kernel::debug::assign_gpios(
@@ -292,9 +298,8 @@ unsafe fn start() -> (
         static _eappmem: u8;
     }
 
-    let scheduler =
-        components::sched::cooperative::CooperativeComponent::new(&*addr_of!(PROCESSES))
-            .finalize(components::cooperative_component_static!(NUM_PROCS));
+    let scheduler = components::sched::cooperative::CooperativeComponent::new(processes)
+        .finalize(components::cooperative_component_static!(NUM_PROCS));
 
     let scheduler_timer = static_init!(
         VirtualSchedulerTimer<VirtualMuxAlarm<'static, e310_g002::chip::E310xClint<'static>>>,
@@ -321,7 +326,6 @@ unsafe fn start() -> (
             addr_of_mut!(_sappmem),
             addr_of!(_eappmem) as usize - addr_of!(_sappmem) as usize,
         ),
-        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_mgmt_cap,
     )

--- a/boards/sma_q3/src/io.rs
+++ b/boards/sma_q3/src/io.rs
@@ -57,7 +57,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         writer,
         pi,
         &cortexm4::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/stm32f3discovery/src/io.rs
+++ b/boards/stm32f3discovery/src/io.rs
@@ -85,7 +85,7 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
         writer,
         info,
         &cortexm4::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/stm32f412gdiscovery/src/io.rs
+++ b/boards/stm32f412gdiscovery/src/io.rs
@@ -90,7 +90,7 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
         writer,
         info,
         &cortexm4::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -9,7 +9,8 @@
 #![no_std]
 #![no_main]
 #![deny(missing_docs)]
-use core::ptr::{addr_of, addr_of_mut};
+
+use core::ptr::addr_of_mut;
 
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
@@ -20,6 +21,7 @@ use kernel::hil::gpio;
 use kernel::hil::led::LedLow;
 use kernel::hil::screen::ScreenRotation;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::process::ProcessArray;
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
 use stm32f412g::chip_specs::Stm32f412Specs;
@@ -33,10 +35,8 @@ pub mod io;
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 4;
 
-// Actual memory for holding the active process structures.
-static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS] =
-    [None, None, None, None];
-
+/// Static variables used by io.rs.
+static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
 static mut CHIP: Option<&'static stm32f412g::chip::Stm32f4xx<Stm32f412gDefaultPeripherals>> = None;
 static mut PROCESS_PRINTER: Option<&'static capsules_system::process_printer::ProcessPrinterText> =
     None;
@@ -445,7 +445,13 @@ unsafe fn start() -> (
         &base_peripherals.usart2,
     );
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
+    // Create an array to hold process references.
+    let processes = components::process_array::ProcessArrayComponent::new()
+        .finalize(components::process_array_component_static!(NUM_PROCS));
+    PROCESSES = Some(processes);
+
+    // Setup space to store the core kernel data structure.
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
 
     let chip = static_init!(
         stm32f412g::chip::Stm32f4xx<Stm32f412gDefaultPeripherals>,
@@ -764,7 +770,7 @@ unsafe fn start() -> (
     ));
     let _ = process_console.start();
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(processes)
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let stm32f412g = STM32F412GDiscovery {
@@ -832,7 +838,6 @@ unsafe fn start() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/stm32f429idiscovery/src/io.rs
+++ b/boards/stm32f429idiscovery/src/io.rs
@@ -92,7 +92,7 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
         writer,
         info,
         &cortexm4::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/teensy40/src/io.rs
+++ b/boards/teensy40/src/io.rs
@@ -13,6 +13,7 @@ use kernel::hil::{
 
 use crate::imxrt1060::gpio;
 use crate::imxrt1060::lpuart;
+use crate::PROCESSES;
 
 struct Writer<'a> {
     output: &'a mut lpuart::Lpuart<'a>,
@@ -62,7 +63,7 @@ unsafe fn panic_handler(panic_info: &core::panic::PanicInfo) -> ! {
         &mut writer,
         panic_info,
         &cortexm7::support::nop,
-        &*addr_of!(crate::PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(crate::CHIP),
         &*addr_of!(crate::PROCESS_PRINTER),
     )

--- a/boards/tutorials/nrf52840dk-dynamic-apps-and-policies/src/io.rs
+++ b/boards/tutorials/nrf52840dk-dynamic-apps-and-policies/src/io.rs
@@ -83,7 +83,7 @@ pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {
         writer,
         pi,
         &cortexm4::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/tutorials/nrf52840dk-hotp-tutorial/src/main.rs
+++ b/boards/tutorials/nrf52840dk-hotp-tutorial/src/main.rs
@@ -8,7 +8,6 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use core::ptr::addr_of_mut;
 use kernel::component::Component;
 use kernel::debug;
 use kernel::hil::usb::Client;
@@ -16,7 +15,6 @@ use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::static_init;
 use kernel::{capabilities, create_capability};
 use nrf52840::gpio::Pin;
-use nrf52840dk_lib::{self, PROCESSES};
 
 // State for loading and holding applications.
 // How should the kernel respond when a process faults.
@@ -229,7 +227,6 @@ pub unsafe fn main() {
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/tutorials/nrf52840dk-root-of-trust-tutorial/src/main.rs
+++ b/boards/tutorials/nrf52840dk-root-of-trust-tutorial/src/main.rs
@@ -8,14 +8,12 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use core::ptr::addr_of_mut;
 use kernel::component::Component;
 use kernel::debug;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::static_init;
 use kernel::{capabilities, create_capability};
 use nrf52840::gpio::Pin;
-use nrf52840dk_lib::{self, PROCESSES};
 
 // State for loading and holding applications.
 // How should the kernel respond when a process faults.
@@ -195,7 +193,6 @@ pub unsafe fn main() {
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/tutorials/nrf52840dk-thread-tutorial/src/main.rs
+++ b/boards/tutorials/nrf52840dk-thread-tutorial/src/main.rs
@@ -8,14 +8,14 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use core::ptr::{addr_of, addr_of_mut};
+use core::ptr::addr_of;
 
 use kernel::component::Component;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::{capabilities, create_capability, static_init};
 use nrf52840::gpio::Pin;
 use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
-use nrf52840dk_lib::{self, NUM_PROCS, PROCESSES};
+use nrf52840dk_lib::{self, NUM_PROCS};
 
 type ScreenDriver = components::screen::ScreenComponentType;
 
@@ -284,7 +284,6 @@ pub unsafe fn main() {
     // Create and start the asynchronous process loader.
     let _loader = components::loader::sequential::ProcessLoaderSequentialComponent::new(
         checker,
-        &mut *addr_of_mut!(PROCESSES),
         board_kernel,
         chip,
         &FAULT_RESPONSE,

--- a/boards/veer_el2_sim/src/io.rs
+++ b/boards/veer_el2_sim/src/io.rs
@@ -49,7 +49,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         writer,
         pi,
         &rv32i::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     );

--- a/boards/weact_f401ccu6/src/io.rs
+++ b/boards/weact_f401ccu6/src/io.rs
@@ -91,7 +91,7 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
         writer,
         info,
         &cortexm4::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -10,7 +10,7 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use core::ptr::{addr_of, addr_of_mut};
+use core::ptr::addr_of_mut;
 
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
@@ -18,6 +18,7 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::hil::led::LedLow;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::process::ProcessArray;
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
 
@@ -31,10 +32,8 @@ pub mod io;
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 4;
 
-// Actual memory for holding the active process structures.
-static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS] =
-    [None, None, None, None];
-
+/// Static variables used by io.rs.
+static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
 static mut CHIP: Option<&'static stm32f401cc::chip::Stm32f4xx<Stm32f401ccDefaultPeripherals>> =
     None;
 static mut PROCESS_PRINTER: Option<&'static capsules_system::process_printer::ProcessPrinterText> =
@@ -259,7 +258,13 @@ unsafe fn start() -> (
         &base_peripherals.usart2,
     );
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
+    // Create an array to hold process references.
+    let processes = components::process_array::ProcessArrayComponent::new()
+        .finalize(components::process_array_component_static!(NUM_PROCS));
+    PROCESSES = Some(processes);
+
+    // Setup space to store the core kernel data structure.
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
 
     let chip = static_init!(
         stm32f401cc::chip::Stm32f4xx<Stm32f401ccDefaultPeripherals>,
@@ -434,7 +439,7 @@ unsafe fn start() -> (
     ));
     let _ = process_console.start();
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(processes)
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let weact_f401cc = WeactF401CC {
@@ -480,7 +485,6 @@ unsafe fn start() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/boards/wm1110dev/src/io.rs
+++ b/boards/wm1110dev/src/io.rs
@@ -82,7 +82,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         writer,
         pi,
         &cortexm4::support::nop,
-        &*addr_of!(PROCESSES),
+        PROCESSES.unwrap().as_slice(),
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     )

--- a/boards/wm1110dev/src/main.rs
+++ b/boards/wm1110dev/src/main.rs
@@ -10,9 +10,6 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use core::ptr::addr_of;
-use core::ptr::addr_of_mut;
-
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::hil;
@@ -22,6 +19,7 @@ use kernel::hil::led::LedHigh;
 use kernel::hil::spi::SpiMaster;
 use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::process::ProcessArray;
 use kernel::scheduler::round_robin::RoundRobinSched;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
@@ -76,10 +74,8 @@ const FAULT_RESPONSE: capsules_system::process_policies::StopWithDebugFaultPolic
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 8;
 
-// State for loading and holding applications.
-static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS] =
-    [None; NUM_PROCS];
-
+/// Static variables used by io.rs.
+static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
 static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;
 static mut PROCESS_PRINTER: Option<&'static capsules_system::process_printer::ProcessPrinterText> =
     None;
@@ -216,7 +212,13 @@ pub unsafe fn start() -> (
     nrf52840_peripherals.init();
     let base_peripherals = &nrf52840_peripherals.nrf52;
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&*addr_of!(PROCESSES)));
+    // Create an array to hold process references.
+    let processes = components::process_array::ProcessArrayComponent::new()
+        .finalize(components::process_array_component_static!(NUM_PROCS));
+    PROCESSES = Some(processes);
+
+    // Setup space to store the core kernel data structure.
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
 
     nrf52_components::startup::NrfStartupComponent::new(
         false,
@@ -466,7 +468,7 @@ pub unsafe fn start() -> (
     // approach than this.
     nrf52_components::NrfClockComponent::new(&base_peripherals.clock).finalize(());
 
-    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&*addr_of!(PROCESSES))
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(processes)
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let platform = Platform {
@@ -533,7 +535,6 @@ pub unsafe fn start() -> (
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
         ),
-        &mut *addr_of_mut!(PROCESSES),
         &FAULT_RESPONSE,
         &process_management_capability,
     )

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -56,8 +56,8 @@ use crate::collections::queue::Queue;
 use crate::collections::ring_buffer::RingBuffer;
 use crate::hil;
 use crate::platform::chip::Chip;
-use crate::process::Process;
 use crate::process::ProcessPrinter;
+use crate::process::ProcessSlot;
 use crate::processbuffer::ReadableProcessSlice;
 use crate::utilities::binary_write::BinaryToWriteWrapper;
 use crate::utilities::cells::NumericCellExt;
@@ -110,7 +110,7 @@ pub unsafe fn panic_print<W: Write + IoWrite, C: Chip, PP: ProcessPrinter>(
     writer: &mut W,
     panic_info: &PanicInfo,
     nop: &dyn Fn(),
-    processes: &'static [Option<&'static dyn Process>],
+    processes: &'static [ProcessSlot],
     chip: &'static Option<&'static C>,
     process_printer: &'static Option<&'static PP>,
 ) {
@@ -142,7 +142,7 @@ pub unsafe fn panic<L: hil::led::Led, W: Write + IoWrite, C: Chip, PP: ProcessPr
     writer: &mut W,
     panic_info: &PanicInfo,
     nop: &dyn Fn(),
-    processes: &'static [Option<&'static dyn Process>],
+    processes: &'static [ProcessSlot],
     chip: &'static Option<&'static C>,
     process_printer: &'static Option<&'static PP>,
 ) -> ! {
@@ -198,7 +198,7 @@ pub unsafe fn panic_cpu_state<W: Write, C: Chip>(
 ///
 /// **NOTE:** The supplied `writer` must be synchronous.
 pub unsafe fn panic_process_info<PP: ProcessPrinter, W: Write>(
-    procs: &'static [Option<&'static dyn Process>],
+    procs: &'static [ProcessSlot],
     process_printer: &'static Option<&'static PP>,
     writer: &mut W,
 ) {
@@ -206,7 +206,7 @@ pub unsafe fn panic_process_info<PP: ProcessPrinter, W: Write>(
         // print data about each process
         let _ = writer.write_fmt(format_args!("\r\n---| App Status |---\r\n"));
         for proc in procs {
-            proc.map(|process| {
+            proc.proc.get().map(|process| {
                 // Print the memory map and basic process info.
                 //
                 // Because we are using a synchronous printer we do not need to

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -198,15 +198,15 @@ pub unsafe fn panic_cpu_state<W: Write, C: Chip>(
 ///
 /// **NOTE:** The supplied `writer` must be synchronous.
 pub unsafe fn panic_process_info<PP: ProcessPrinter, W: Write>(
-    procs: &'static [ProcessSlot],
+    processes: &'static [ProcessSlot],
     process_printer: &'static Option<&'static PP>,
     writer: &mut W,
 ) {
     process_printer.map(|printer| {
         // print data about each process
         let _ = writer.write_fmt(format_args!("\r\n---| App Status |---\r\n"));
-        for proc in procs {
-            proc.proc.get().map(|process| {
+        for slot in processes {
+            slot.proc.get().map(|process| {
                 // Print the memory map and basic process info.
                 //
                 // Because we are using a synchronous printer we do not need to

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -134,6 +134,7 @@ use core::ptr::{write, NonNull};
 use core::slice;
 
 use crate::kernel::Kernel;
+use crate::process::ProcessSlot;
 use crate::process::{Error, Process, ProcessCustomGrantIdentifier, ProcessId};
 use crate::processbuffer::{ReadOnlyProcessBuffer, ReadWriteProcessBuffer};
 use crate::processbuffer::{ReadOnlyProcessBufferRef, ReadWriteProcessBufferRef};
@@ -1818,8 +1819,8 @@ pub struct Iter<
 
     /// Iterator over valid processes.
     subiter: core::iter::FilterMap<
-        core::slice::Iter<'a, Option<&'static dyn Process>>,
-        fn(&Option<&'static dyn Process>) -> Option<&'static dyn Process>,
+        core::slice::Iter<'a, ProcessSlot>,
+        fn(&ProcessSlot) -> Option<&'static dyn Process>,
     >,
 }
 

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -104,23 +104,12 @@ impl Kernel {
         // However, we are not guaranteed that the app still exists at that
         // index in the processes array. To avoid additional overhead, we do the
         // lookup and check here, rather than calling `.index()`.
-        match self.processes.get(processid.index) {
-            Some(pslot) => {
-                match pslot.get_active() {
-                    Some(process) => {
-                        // Check that the process stored here matches the identifier
-                        // in the `processid`.
-                        if process.processid() == processid {
-                            Some(process)
-                        } else {
-                            None
-                        }
-                    }
-                    None => None,
-                }
-            }
-            _ => None,
-        }
+        self.processes
+            .get(processid.index)
+            .and_then(|pslot| pslot.get_active())
+            // Check that the process stored here matches the
+            // identifier in the `processid`.
+            .filter(|process| process.processid() == processid)
     }
 
     /// Run a closure on a specific process if it exists. If the process with a

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -26,6 +26,7 @@ use crate::platform::platform::KernelResources;
 use crate::platform::platform::{ProcessFault, SyscallDriverLookup, SyscallFilter};
 use crate::platform::scheduler_timer::SchedulerTimer;
 use crate::platform::watchdog::WatchDog;
+use crate::process::ProcessSlot;
 use crate::process::{self, ProcessId, Task};
 use crate::scheduler::{Scheduler, SchedulingDecision};
 use crate::syscall::SyscallDriver;
@@ -43,7 +44,7 @@ pub(crate) const MIN_QUANTA_THRESHOLD_US: u32 = 500;
 /// Main object for the kernel. Each board will need to create one.
 pub struct Kernel {
     /// This holds a pointer to the static array of Process pointers.
-    processes: &'static [Option<&'static dyn process::Process>],
+    processes: &'static [ProcessSlot],
 
     /// A counter which keeps track of how many process identifiers have been
     /// created. This is used to create new unique identifiers for processes.
@@ -87,7 +88,7 @@ impl Kernel {
     /// Crucially, the processes included in the `processes` array MUST be valid
     /// to execute. Any credential checks or validation MUST happen before the
     /// `Process` object is included in this array.
-    pub fn new(processes: &'static [Option<&'static dyn process::Process>]) -> Kernel {
+    pub const fn new(processes: &'static [ProcessSlot]) -> Kernel {
         Kernel {
             processes,
             process_identifier_max: Cell::new(0),
@@ -104,13 +105,18 @@ impl Kernel {
         // index in the processes array. To avoid additional overhead, we do the
         // lookup and check here, rather than calling `.index()`.
         match self.processes.get(processid.index) {
-            Some(Some(process)) => {
-                // Check that the process stored here matches the identifier
-                // in the `processid`.
-                if process.processid() == processid {
-                    Some(*process)
-                } else {
-                    None
+            Some(pslot) => {
+                match pslot.get_active() {
+                    Some(process) => {
+                        // Check that the process stored here matches the identifier
+                        // in the `processid`.
+                        if process.processid() == processid {
+                            Some(process)
+                        } else {
+                            None
+                        }
+                    }
+                    None => None,
                 }
             }
             _ => None,
@@ -169,30 +175,28 @@ impl Kernel {
 
     /// Run a closure on every valid process. This will iterate the array of
     /// processes and call the closure on every process that exists.
-    pub(crate) fn process_each<F>(&self, mut closure: F)
+    pub(crate) fn process_each<F>(&self, closure: F)
     where
         F: FnMut(&dyn process::Process),
     {
-        for process in self.processes.iter() {
-            if let Some(p) = process {
-                closure(*p);
-            }
-        }
+        self.get_process_iter().for_each(closure);
+    }
+
+    pub fn process_iter_capability(
+        &self,
+        _capability: &dyn capabilities::ProcessManagementCapability,
+    ) -> impl Iterator<Item = &dyn process::Process> {
+        self.get_process_iter()
     }
 
     /// Returns an iterator over all processes loaded by the kernel.
     pub(crate) fn get_process_iter(
         &self,
     ) -> core::iter::FilterMap<
-        core::slice::Iter<Option<&dyn process::Process>>,
-        fn(&Option<&'static dyn process::Process>) -> Option<&'static dyn process::Process>,
+        core::slice::Iter<ProcessSlot>,
+        fn(&ProcessSlot) -> Option<&'static dyn process::Process>,
     > {
-        fn keep_some(
-            &x: &Option<&'static dyn process::Process>,
-        ) -> Option<&'static dyn process::Process> {
-            x
-        }
-        self.processes.iter().filter_map(keep_some)
+        self.processes.iter().filter_map(ProcessSlot::get_active)
     }
 
     /// Run a closure on every valid process. This will iterate the array of
@@ -204,15 +208,11 @@ impl Kernel {
     pub fn process_each_capability<F>(
         &'static self,
         _capability: &dyn capabilities::ProcessManagementCapability,
-        mut closure: F,
+        closure: F,
     ) where
         F: FnMut(&dyn process::Process),
     {
-        for process in self.processes.iter() {
-            if let Some(p) = process {
-                closure(*p);
-            }
-        }
+        self.process_each(closure);
     }
 
     /// Run a closure on every process, but only continue if the closure returns
@@ -222,12 +222,10 @@ impl Kernel {
     where
         F: Fn(&dyn process::Process) -> Option<T>,
     {
-        for process in self.processes.iter() {
-            if let Some(p) = process {
-                let ret = closure(*p);
-                if ret.is_some() {
-                    return ret;
-                }
+        for process in self.get_process_iter() {
+            let ret = closure(process);
+            if ret.is_some() {
+                return ret;
             }
         }
         None
@@ -242,7 +240,7 @@ impl Kernel {
     pub(crate) fn processid_is_valid(&self, processid: &ProcessId) -> bool {
         self.processes
             .get(processid.index)
-            .is_some_and(|p| p.is_some_and(|process| process.processid().id() == processid.id()))
+            .is_some_and(|p| p.is_valid_for(processid.id()))
     }
 
     /// Create a new grant. This is used in board initialization to setup grants
@@ -314,6 +312,19 @@ impl Kernel {
         self.process_identifier_max.get_and_increment()
     }
 
+    /// Find the next slot that is available for storing a new [`&Process`]
+    /// (Process).
+    ///
+    /// Returns `Err(())` if there are no available slots.
+    pub(crate) fn next_available_process_slot(&self) -> Result<(usize, &ProcessSlot), ()> {
+        for (index, slot) in self.processes.iter().enumerate() {
+            if slot.proc.get().is_none() {
+                return Ok((index, slot));
+            }
+        }
+        Err(())
+    }
+
     /// Cause all apps to fault.
     ///
     /// This will call `set_fault_state()` on each app, causing the app to enter
@@ -325,10 +336,8 @@ impl Kernel {
     /// function, since capsules should not be able to arbitrarily restart all
     /// apps.
     pub fn hardfault_all_apps<C: capabilities::ProcessManagementCapability>(&self, _c: &C) {
-        for p in self.processes.iter() {
-            p.map(|process| {
-                process.set_fault_state();
-            });
+        for process in self.get_process_iter() {
+            process.set_fault_state();
         }
     }
 

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -106,7 +106,7 @@ impl Kernel {
         // lookup and check here, rather than calling `.index()`.
         self.processes
             .get(processid.index)
-            .and_then(|pslot| pslot.get_active())
+            .and_then(|pslot| pslot.get())
             // Check that the process stored here matches the
             // identifier in the `processid`.
             .filter(|process| process.processid() == processid)
@@ -185,7 +185,7 @@ impl Kernel {
         core::slice::Iter<ProcessSlot>,
         fn(&ProcessSlot) -> Option<&'static dyn process::Process>,
     > {
-        self.processes.iter().filter_map(ProcessSlot::get_active)
+        self.processes.iter().filter_map(ProcessSlot::get)
     }
 
     /// Run a closure on every valid process. This will iterate the array of

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -229,7 +229,7 @@ impl Kernel {
     pub(crate) fn processid_is_valid(&self, processid: &ProcessId) -> bool {
         self.processes
             .get(processid.index)
-            .is_some_and(|p| p.is_valid_for(processid.id()))
+            .is_some_and(|p| p.contains_process_with_id(processid.id()))
     }
 
     /// Create a new grant. This is used in board initialization to setup grants

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -128,6 +128,7 @@ pub mod utilities;
 mod config;
 mod kernel;
 mod memop;
+mod process_array;
 mod process_binary;
 mod process_loading;
 mod process_policies;

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -24,6 +24,7 @@ use crate::utilities::machine_register::MachineRegister;
 use tock_tbf::types::CommandPermissions;
 
 // Export all process related types via `kernel::process::`.
+pub use crate::process_array::{ProcessArray, ProcessSlot};
 pub use crate::process_binary::ProcessBinary;
 pub use crate::process_checker::AcceptedCredential;
 pub use crate::process_checker::{ProcessCheckerMachine, ProcessCheckerMachineClient};

--- a/kernel/src/process_array.rs
+++ b/kernel/src/process_array.rs
@@ -38,7 +38,7 @@ impl ProcessSlot {
 
     /// Return the underlying [`process::Process`] if the slot contains a
     /// process.
-    pub fn get_active(&self) -> Option<&'static dyn process::Process> {
+    pub fn get(&self) -> Option<&'static dyn process::Process> {
         self.proc.get()
     }
 

--- a/kernel/src/process_array.rs
+++ b/kernel/src/process_array.rs
@@ -1,0 +1,80 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+//! Data structure for storing `Process`es.
+//!
+//! Many Tock boards store a fixed-length array of process control blocks
+//! (PCB) for easy management and traversal of running processes. The
+//! `ProcessArray` type facilitates this.
+//!
+//! The general type for the process array abstraction is
+//! `[&Process; NUM_PROCS]`. That is, the array is only sized to store
+//! references to each PCB. The actual PCB is allocated in the process's
+//! allocated memory.
+
+use crate::process;
+use core::cell::Cell;
+
+/// Represents a slot for a process in a [`ProcessArray`].
+///
+/// A slot can be empty (`None`), or hold a reference to a
+/// [`Process`](process::Process).
+///
+/// The `ProcessSlot` type is useful for allowing slices of processes without
+/// knowing the fixed number of processes, or being templated on `NUM_PROCS`.
+/// That is, interfaces can use `[ProcessSlot]` to just use an array of process
+/// slots.
+#[derive(Clone)]
+pub struct ProcessSlot {
+    /// Optionally points to a process.
+    pub(crate) proc: Cell<Option<&'static dyn process::Process>>,
+}
+
+impl ProcessSlot {
+    pub(crate) fn set(&self, process: &'static dyn process::Process) {
+        self.proc.set(Some(process));
+    }
+
+    /// Return the underlying [`process::Process`] if the slot contains a
+    /// process.
+    pub fn get_active(&self) -> Option<&'static dyn process::Process> {
+        self.proc.get()
+    }
+
+    /// Check if the slot contains a process with a matching process ID.
+    pub fn is_valid_for(&self, identifier: usize) -> bool {
+        match self.proc.get() {
+            Some(process) => process.processid().id() == identifier,
+            None => false,
+        }
+    }
+}
+
+/// Storage for a fixed-size array of `Process`es.
+pub struct ProcessArray<const NUM_PROCS: usize> {
+    processes: [ProcessSlot; NUM_PROCS],
+}
+
+impl<const NUM_PROCS: usize> ProcessArray<NUM_PROCS> {
+    pub const fn new() -> Self {
+        const EMPTY: ProcessSlot = ProcessSlot {
+            proc: Cell::new(None),
+        };
+        Self {
+            processes: [EMPTY; NUM_PROCS],
+        }
+    }
+
+    pub fn as_slice(&self) -> &[ProcessSlot] {
+        &self.processes
+    }
+}
+
+impl<const NUM_PROCS: usize> core::ops::Index<usize> for ProcessArray<NUM_PROCS> {
+    type Output = ProcessSlot;
+
+    fn index(&self, i: usize) -> &ProcessSlot {
+        &self.processes[i]
+    }
+}

--- a/kernel/src/process_array.rs
+++ b/kernel/src/process_array.rs
@@ -58,11 +58,12 @@ pub struct ProcessArray<const NUM_PROCS: usize> {
 
 impl<const NUM_PROCS: usize> ProcessArray<NUM_PROCS> {
     pub const fn new() -> Self {
-        const EMPTY: ProcessSlot = ProcessSlot {
-            proc: Cell::new(None),
-        };
         Self {
-            processes: [EMPTY; NUM_PROCS],
+            processes: [const {
+                ProcessSlot {
+                    proc: Cell::new(None),
+                }
+            }; NUM_PROCS],
         }
     }
 

--- a/kernel/src/process_array.rs
+++ b/kernel/src/process_array.rs
@@ -43,7 +43,7 @@ impl ProcessSlot {
     }
 
     /// Check if the slot contains a process with a matching process ID.
-    pub fn is_valid_for(&self, identifier: usize) -> bool {
+    pub fn contains_process_with_id(&self, identifier: usize) -> bool {
         match self.proc.get() {
             Some(process) => process.processid().id() == identifier,
             None => false,

--- a/kernel/src/process_loading.rs
+++ b/kernel/src/process_loading.rs
@@ -141,7 +141,6 @@ pub fn load_processes<C: Chip>(
     chip: &'static C,
     app_flash: &'static [u8],
     app_memory: &'static mut [u8],
-    mut procs: &'static mut [Option<&'static dyn Process>],
     fault_policy: &'static dyn ProcessFaultPolicy,
     _capability_management: &dyn ProcessManagementCapability,
 ) -> Result<(), ProcessLoadError> {
@@ -150,19 +149,14 @@ pub fn load_processes<C: Chip>(
         chip,
         app_flash,
         app_memory,
-        &mut procs,
         fault_policy,
     )?;
 
     if config::CONFIG.debug_process_credentials {
         debug!("Checking: no checking, load and run all processes");
-    }
-    for proc in procs.iter() {
-        proc.map(|p| {
-            if config::CONFIG.debug_process_credentials {
-                debug!("Running {}", p.get_process_name());
-            }
-        });
+        for proc in kernel.get_process_iter() {
+            debug!("Running {}", proc.get_process_name());
+        }
     }
     Ok(())
 }
@@ -191,7 +185,6 @@ fn load_processes_from_flash<C: Chip, D: ProcessStandardDebug + 'static>(
     chip: &'static C,
     app_flash: &'static [u8],
     app_memory: &'static mut [u8],
-    procs: &mut &'static mut [Option<&'static dyn Process>],
     fault_policy: &'static dyn ProcessFaultPolicy,
 ) -> Result<(), ProcessLoadError> {
     if config::CONFIG.debug_load_processes {
@@ -206,75 +199,83 @@ fn load_processes_from_flash<C: Chip, D: ProcessStandardDebug + 'static>(
 
     let mut remaining_flash = app_flash;
     let mut remaining_memory = app_memory;
-    // Try to discover up to `procs.len()` processes in flash.
-    let mut index = 0;
-    let num_procs = procs.len();
-    while index < num_procs {
-        let load_binary_result = discover_process_binary(remaining_flash);
 
-        match load_binary_result {
-            Ok((new_flash, process_binary)) => {
-                remaining_flash = new_flash;
+    loop {
+        match kernel.next_available_process_slot() {
+            Ok((index, slot)) => {
+                let load_binary_result = discover_process_binary(remaining_flash);
 
-                let load_result = load_process::<C, D>(
-                    kernel,
-                    chip,
-                    process_binary,
-                    remaining_memory,
-                    ShortId::LocallyUnique,
-                    index,
-                    fault_policy,
-                    &(),
-                );
-                match load_result {
-                    Ok((new_mem, proc)) => {
-                        remaining_memory = new_mem;
-                        match proc {
-                            Some(p) => {
-                                if config::CONFIG.debug_load_processes {
-                                    debug!("Loaded process {}", p.get_process_name())
+                match load_binary_result {
+                    Ok((new_flash, process_binary)) => {
+                        remaining_flash = new_flash;
+
+                        let load_result = load_process::<C, D>(
+                            kernel,
+                            chip,
+                            process_binary,
+                            remaining_memory,
+                            ShortId::LocallyUnique,
+                            index,
+                            fault_policy,
+                            &(),
+                        );
+                        match load_result {
+                            Ok((new_mem, proc)) => {
+                                remaining_memory = new_mem;
+                                match proc {
+                                    Some(p) => {
+                                        if config::CONFIG.debug_load_processes {
+                                            debug!("Loaded process {}", p.get_process_name())
+                                        }
+                                        slot.set(p);
+                                    }
+                                    None => {
+                                        if config::CONFIG.debug_load_processes {
+                                            debug!("No process loaded.");
+                                        }
+                                    }
                                 }
-                                procs[index] = proc;
-                                index += 1;
                             }
-                            None => {
+                            Err((new_mem, err)) => {
+                                remaining_memory = new_mem;
                                 if config::CONFIG.debug_load_processes {
-                                    debug!("No process loaded.");
+                                    debug!("Processes load error: {:?}.", err);
                                 }
                             }
                         }
                     }
-                    Err((new_mem, err)) => {
-                        remaining_memory = new_mem;
-                        if config::CONFIG.debug_load_processes {
-                            debug!("Processes load error: {:?}.", err);
+                    Err((new_flash, err)) => {
+                        remaining_flash = new_flash;
+                        match err {
+                            ProcessBinaryError::NotEnoughFlash
+                            | ProcessBinaryError::TbfHeaderNotFound => {
+                                if config::CONFIG.debug_load_processes {
+                                    debug!("No more processes to load: {:?}.", err);
+                                }
+                                // No more processes to load.
+                                break;
+                            }
+
+                            ProcessBinaryError::TbfHeaderParseFailure(_)
+                            | ProcessBinaryError::IncompatibleKernelVersion { .. }
+                            | ProcessBinaryError::IncorrectFlashAddress { .. }
+                            | ProcessBinaryError::NotEnabledProcess
+                            | ProcessBinaryError::Padding => {
+                                if config::CONFIG.debug_load_processes {
+                                    debug!("Unable to use process binary: {:?}.", err);
+                                }
+
+                                // Skip this binary and move to the next one.
+                                continue;
+                            }
                         }
                     }
                 }
             }
-            Err((new_flash, err)) => {
-                remaining_flash = new_flash;
-                match err {
-                    ProcessBinaryError::NotEnoughFlash | ProcessBinaryError::TbfHeaderNotFound => {
-                        if config::CONFIG.debug_load_processes {
-                            debug!("No more processes to load: {:?}.", err);
-                        }
-                        // No more processes to load.
-                        break;
-                    }
-
-                    ProcessBinaryError::TbfHeaderParseFailure(_)
-                    | ProcessBinaryError::IncompatibleKernelVersion { .. }
-                    | ProcessBinaryError::IncorrectFlashAddress { .. }
-                    | ProcessBinaryError::NotEnabledProcess
-                    | ProcessBinaryError::Padding => {
-                        if config::CONFIG.debug_load_processes {
-                            debug!("Unable to use process binary: {:?}.", err);
-                        }
-
-                        // Skip this binary and move to the next one.
-                        continue;
-                    }
+            Err(()) => {
+                // No slot available.
+                if config::CONFIG.debug_load_processes {
+                    debug!("No more process slots to load processes into.");
                 }
             }
         }
@@ -500,8 +501,6 @@ pub struct SequentialProcessLoaderMachine<'a, C: Chip + 'static, D: ProcessStand
     runtime_client: OptionalCell<&'a dyn ProcessLoadingAsyncClient>,
     /// Machine to use to check process credentials.
     checker: &'static ProcessCheckerMachine,
-    /// Array of stored process references for loaded processes.
-    procs: MapCell<&'static mut [Option<&'static dyn Process>]>,
     /// Array to store `ProcessBinary`s after checking credentials.
     proc_binaries: MapCell<&'static mut [Option<ProcessBinary>]>,
     /// Total available flash for process binaries on this board.
@@ -535,7 +534,6 @@ impl<'a, C: Chip, D: ProcessStandardDebug> SequentialProcessLoaderMachine<'a, C,
     /// function.
     pub fn new(
         checker: &'static ProcessCheckerMachine,
-        procs: &'static mut [Option<&'static dyn Process>],
         proc_binaries: &'static mut [Option<ProcessBinary>],
         kernel: &'static Kernel,
         chip: &'static C,
@@ -552,7 +550,6 @@ impl<'a, C: Chip, D: ProcessStandardDebug> SequentialProcessLoaderMachine<'a, C,
             boot_client: OptionalCell::empty(),
             runtime_client: OptionalCell::empty(),
             run_mode: OptionalCell::empty(),
-            procs: MapCell::new(procs),
             proc_binaries: MapCell::new(proc_binaries),
             kernel,
             chip,
@@ -578,18 +575,6 @@ impl<'a, C: Chip, D: ProcessStandardDebug> SequentialProcessLoaderMachine<'a, C,
             SequentialProcessLoaderMachineRunMode::BootMode => self.boot_client.get(),
             SequentialProcessLoaderMachineRunMode::RuntimeMode => self.runtime_client.get(),
         }
-    }
-
-    /// Find a slot in the `PROCESSES` array to store this process.
-    fn find_open_process_slot(&self) -> Option<usize> {
-        self.procs.map_or(None, |procs| {
-            for (i, p) in procs.iter().enumerate() {
-                if p.is_none() {
-                    return Some(i);
-                }
-            }
-            None
-        })
     }
 
     /// Find a slot in the `PROCESS_BINARIES` array to store this process.
@@ -700,27 +685,21 @@ impl<'a, C: Chip, D: ProcessStandardDebug> SequentialProcessLoaderMachine<'a, C,
                 // doesn't conflict with any of those. Since those processes
                 // are already loaded, we just need to check if this process
                 // binary has the same AppID as an already loaded process.
-                self.procs.map(|procs| {
-                    for proc in procs.iter() {
-                        if let Some(p) = proc {
-                            let blocked =
-                                self.is_blocked_from_loading_by_process(&process_binary, *p);
-
-                            if blocked {
-                                ok_to_load = false;
-                                break;
-                            }
-                        }
+                for proc in self.kernel.get_process_iter() {
+                    let blocked = self.is_blocked_from_loading_by_process(&process_binary, proc);
+                    if blocked {
+                        ok_to_load = false;
+                        break;
                     }
-                });
+                }
 
                 if !ok_to_load {
                     continue;
                 }
 
                 // If we get here it is ok to load the process.
-                match self.find_open_process_slot() {
-                    Some(index) => {
+                match self.kernel.next_available_process_slot() {
+                    Ok((index, slot)) => {
                         // Calculate the ShortId for this new process.
                         let short_app_id = self.policy.map_or(ShortId::LocallyUnique, |policy| {
                             policy.to_short_id(&process_binary)
@@ -751,9 +730,7 @@ impl<'a, C: Chip, D: ProcessStandardDebug> SequentialProcessLoaderMachine<'a, C,
 
                                         // Store the `ProcessStandard` object in the `PROCESSES`
                                         // array.
-                                        self.procs.map(|procs| {
-                                            procs[index] = proc;
-                                        });
+                                        slot.set(p);
                                         // Notify the client the process was loaded
                                         // successfully.
                                         self.get_current_client().map(|client| {
@@ -778,7 +755,7 @@ impl<'a, C: Chip, D: ProcessStandardDebug> SequentialProcessLoaderMachine<'a, C,
                             }
                         }
                     }
-                    None => {
+                    Err(()) => {
                         // Nowhere to store the process.
                         self.get_current_client().map(|client| {
                             client.process_loaded(Err(ProcessLoadError::NoProcessSlot));

--- a/kernel/src/scheduler/cooperative.rs
+++ b/kernel/src/scheduler/cooperative.rs
@@ -72,7 +72,7 @@ impl<C: Chip> Scheduler<C> for CooperativeSched<'_> {
                     }
                 }
             }
-            match node.proc.get_active() {
+            match node.proc.get() {
                 Some(proc) => {
                     if proc.ready() {
                         let next = proc.processid();

--- a/kernel/src/scheduler/cooperative.rs
+++ b/kernel/src/scheduler/cooperative.rs
@@ -17,18 +17,18 @@
 
 use crate::collections::list::{List, ListLink, ListNode};
 use crate::platform::chip::Chip;
-use crate::process::Process;
+use crate::process::ProcessSlot;
 use crate::process::StoppedExecutingReason;
 use crate::scheduler::{Scheduler, SchedulingDecision};
 
 /// A node in the linked list the scheduler uses to track processes
 pub struct CoopProcessNode<'a> {
-    proc: &'static Option<&'static dyn Process>,
+    proc: &'static ProcessSlot,
     next: ListLink<'a, CoopProcessNode<'a>>,
 }
 
 impl<'a> CoopProcessNode<'a> {
-    pub fn new(proc: &'static Option<&'static dyn Process>) -> CoopProcessNode<'a> {
+    pub fn new(proc: &'static ProcessSlot) -> CoopProcessNode<'a> {
         CoopProcessNode {
             proc,
             next: ListLink::empty(),
@@ -72,7 +72,7 @@ impl<C: Chip> Scheduler<C> for CooperativeSched<'_> {
                     }
                 }
             }
-            match node.proc {
+            match node.proc.get_active() {
                 Some(proc) => {
                     if proc.ready() {
                         let next = proc.processid();

--- a/kernel/src/scheduler/mlfq.rs
+++ b/kernel/src/scheduler/mlfq.rs
@@ -109,7 +109,7 @@ impl<'a, A: 'static + time::Alarm<'static>> MLFQSched<'a, A> {
         for (idx, queue) in self.processes.iter().enumerate() {
             let next = queue
                 .iter()
-                .find(|node_ref| node_ref.proc.get_active().is_some_and(|proc| proc.ready()));
+                .find(|node_ref| node_ref.proc.get().is_some_and(|proc| proc.ready()));
             if let Some(inner) = next {
                 // pop procs to back until we get to match
                 loop {
@@ -151,7 +151,7 @@ impl<A: 'static + time::Alarm<'static>, C: Chip> Scheduler<C> for MLFQSched<'_, 
         }
         let node_ref = node_ref_opt.unwrap();
         let timeslice = self.get_timeslice_us(queue_idx) - node_ref.state.us_used_this_queue.get();
-        let next = node_ref.proc.get_active().unwrap().processid();
+        let next = node_ref.proc.get().unwrap().processid();
         self.last_queue_idx.set(queue_idx);
         self.last_timeslice.set(timeslice);
 

--- a/kernel/src/scheduler/mlfq.rs
+++ b/kernel/src/scheduler/mlfq.rs
@@ -27,7 +27,7 @@ use core::num::NonZeroU32;
 use crate::collections::list::{List, ListLink, ListNode};
 use crate::hil::time::{self, ConvertTicks, Ticks};
 use crate::platform::chip::Chip;
-use crate::process::Process;
+use crate::process::ProcessSlot;
 use crate::process::StoppedExecutingReason;
 use crate::scheduler::{Scheduler, SchedulingDecision};
 
@@ -39,13 +39,13 @@ struct MfProcState {
 
 /// Nodes store per-process state
 pub struct MLFQProcessNode<'a> {
-    proc: &'static Option<&'static dyn Process>,
+    proc: &'static ProcessSlot,
     state: MfProcState,
     next: ListLink<'a, MLFQProcessNode<'a>>,
 }
 
 impl<'a> MLFQProcessNode<'a> {
-    pub fn new(proc: &'static Option<&'static dyn Process>) -> MLFQProcessNode<'a> {
+    pub fn new(proc: &'static ProcessSlot) -> MLFQProcessNode<'a> {
         MLFQProcessNode {
             proc,
             state: MfProcState::default(),
@@ -109,7 +109,7 @@ impl<'a, A: 'static + time::Alarm<'static>> MLFQSched<'a, A> {
         for (idx, queue) in self.processes.iter().enumerate() {
             let next = queue
                 .iter()
-                .find(|node_ref| node_ref.proc.is_some_and(|proc| proc.ready()));
+                .find(|node_ref| node_ref.proc.get_active().is_some_and(|proc| proc.ready()));
             if let Some(inner) = next {
                 // pop procs to back until we get to match
                 loop {
@@ -151,7 +151,7 @@ impl<A: 'static + time::Alarm<'static>, C: Chip> Scheduler<C> for MLFQSched<'_, 
         }
         let node_ref = node_ref_opt.unwrap();
         let timeslice = self.get_timeslice_us(queue_idx) - node_ref.state.us_used_this_queue.get();
-        let next = node_ref.proc.unwrap().processid();
+        let next = node_ref.proc.get_active().unwrap().processid();
         self.last_queue_idx.set(queue_idx);
         self.last_timeslice.set(timeslice);
 

--- a/kernel/src/scheduler/round_robin.rs
+++ b/kernel/src/scheduler/round_robin.rs
@@ -92,7 +92,7 @@ impl<C: Chip> Scheduler<C> for RoundRobinSched<'_> {
                     }
                 }
             }
-            match node.proc.get_active() {
+            match node.proc.get() {
                 Some(proc) => {
                     if proc.ready() {
                         next = Some(proc.processid());

--- a/kernel/src/scheduler/round_robin.rs
+++ b/kernel/src/scheduler/round_robin.rs
@@ -23,19 +23,19 @@ use core::num::NonZeroU32;
 
 use crate::collections::list::{List, ListLink, ListNode};
 use crate::platform::chip::Chip;
-use crate::process::Process;
+use crate::process::ProcessSlot;
 use crate::process::StoppedExecutingReason;
 use crate::scheduler::{Scheduler, SchedulingDecision};
 
 /// A node in the linked list the scheduler uses to track processes
 /// Each node holds a pointer to a slot in the processes array
 pub struct RoundRobinProcessNode<'a> {
-    proc: &'static Option<&'static dyn Process>,
+    proc: &'static ProcessSlot,
     next: ListLink<'a, RoundRobinProcessNode<'a>>,
 }
 
 impl<'a> RoundRobinProcessNode<'a> {
-    pub fn new(proc: &'static Option<&'static dyn Process>) -> RoundRobinProcessNode<'a> {
+    pub const fn new(proc: &'static ProcessSlot) -> RoundRobinProcessNode<'a> {
         RoundRobinProcessNode {
             proc,
             next: ListLink::empty(),
@@ -92,7 +92,7 @@ impl<C: Chip> Scheduler<C> for RoundRobinSched<'_> {
                     }
                 }
             }
-            match node.proc {
+            match node.proc.get_active() {
                 Some(proc) => {
                     if proc.ready() {
                         next = Some(proc.processid());


### PR DESCRIPTION
### Pull Request Overview

This is variation of #4373.

The two main differences from #4373:

1. It tries to be closer to the minimal change needed to add ProcessArray
2. `ProcessArray` is a struct in its own file (versus a type alias).

This also reverts the change to how process slots are allocated from #4373 to closely match the current logic.

I think this is the outcome we talked about on the call on 5/21/2025. This PR is not meant to say we won't add the other changes from #4373, but hopefully that this version is easier to reason about and review.


### Testing Strategy

travis


### TODO or Help Wanted

I have only ported the nrf52840dk board. I plan to do the rest, but I wanted to get the PR out there before I had a chance to go through all of our boards. The board changes will be entirely repetitive (ie copies of the nrf). The major changes are in the kernel.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
