### PR TITLE
Isolated NonVolatile Storage Capsule Bug Fixes

### DIFF
--- a/capsules/extra/src/isolated_nonvolatile_storage_driver.rs
+++ b/capsules/extra/src/isolated_nonvolatile_storage_driver.rs
@@ -868,8 +868,7 @@ impl<'a, const APP_REGION_SIZE: usize> IsolatedNonvolatileStorage<'a, APP_REGION
                 // command is with respect to the app's region address
                 // space. This means that userspace accesses start at 0
                 // which is the start of the app's region.
-                let physical_address =
-                    app_region.offset + command_offset + self.userspace_start_address;
+                let physical_address = app_region.offset + command_offset;
 
                 let res = self
                     .buffer


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes #4453 and #4454. 

Respectively:
- Commit (afbcb89d5868f45b4b777ce330cec76e6bae444a) fixes #4453 
- Commit (08855c8a732fbb34c32a4a649a2cccc1dba3401e) fixes #4454 

This PR also adds some naming fixes for the `AppRegion` member `offset` as this name is somewhat a misnomer given this member representing an absolute address.

### Testing Strategy

This pull request was tested using the `libtock-c/examples/tests/isolated_nonvolatile_storage/invs_read_write` test and the OpenThread apps (which use the isolated nv capsule).

### TODO or Help Wanted

I would appreciate a sanity check from @bradjc and @atar13 on the `offset` member in fact being an absolute address as mentioned in the doc comment. Looking at all usages, this appears to be true.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
