### PR TITLE
boards: tut: dynamic-apps: Add credential checking

### DIFF
--- a/boards/tutorials/nrf52840dk-dynamic-apps-and-policies/Cargo.toml
+++ b/boards/tutorials/nrf52840dk-dynamic-apps-and-policies/Cargo.toml
@@ -25,6 +25,10 @@ nrf52840dk = { path = "../../nordic/nrf52840dk" }
 capsules-core = { path = "../../../capsules/core" }
 capsules-extra = { path = "../../../capsules/extra" }
 capsules-system = { path = "../../../capsules/system" }
+ecdsa-sw = { path = "../../../capsules/ecdsa_sw" }
+
+tock-tbf = { path = "../../../libraries/tock-tbf" }
+
 nrf52_components = { path = "../../nordic/nrf52_components" }
 
 [build-dependencies]

--- a/boards/tutorials/nrf52840dk-dynamic-apps-and-policies/src/checker_credentials_not_required.rs
+++ b/boards/tutorials/nrf52840dk-dynamic-apps-and-policies/src/checker_credentials_not_required.rs
@@ -26,8 +26,8 @@ impl<'a, C: kernel::process_checker::AppCredentialsPolicy<'static>>
     }
 }
 
-impl<'a, C: kernel::process_checker::AppCredentialsPolicy<'static>> AppCredentialsPolicy<'static>
-    for AppCheckerCredentialsNotRequired<'a, C>
+impl<C: kernel::process_checker::AppCredentialsPolicy<'static>> AppCredentialsPolicy<'static>
+    for AppCheckerCredentialsNotRequired<'_, C>
 {
     fn require_credentials(&self) -> bool {
         false

--- a/boards/tutorials/nrf52840dk-dynamic-apps-and-policies/src/checker_credentials_not_required.rs
+++ b/boards/tutorials/nrf52840dk-dynamic-apps-and-policies/src/checker_credentials_not_required.rs
@@ -1,0 +1,47 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+//! Credential checker wrapper that does not require valid credentials.
+
+use kernel::process_checker::{AppCredentialsPolicy, AppCredentialsPolicyClient};
+use kernel::ErrorCode;
+use tock_tbf::types::TbfFooterV2Credentials;
+
+/// Wrapper struct that changes the return value from
+/// `require_credentials()` but otherwise just passes through calls and
+/// callbacks.
+pub struct AppCheckerCredentialsNotRequired<
+    'a,
+    C: kernel::process_checker::AppCredentialsPolicy<'static>,
+> {
+    checker: &'a C,
+}
+
+impl<'a, C: kernel::process_checker::AppCredentialsPolicy<'static>>
+    AppCheckerCredentialsNotRequired<'a, C>
+{
+    pub fn new(checker: &'a C) -> AppCheckerCredentialsNotRequired<'a, C> {
+        Self { checker }
+    }
+}
+
+impl<'a, C: kernel::process_checker::AppCredentialsPolicy<'static>> AppCredentialsPolicy<'static>
+    for AppCheckerCredentialsNotRequired<'a, C>
+{
+    fn require_credentials(&self) -> bool {
+        false
+    }
+
+    fn check_credentials(
+        &self,
+        credentials: TbfFooterV2Credentials,
+        binary: &'static [u8],
+    ) -> Result<(), (ErrorCode, TbfFooterV2Credentials, &'static [u8])> {
+        self.checker.check_credentials(credentials, binary)
+    }
+
+    fn set_client(&self, client: &'static dyn AppCredentialsPolicyClient<'static>) {
+        self.checker.set_client(client);
+    }
+}


### PR DESCRIPTION


### Pull Request Overview

Now that we have multiple credential key checking support, this adds credential checking to the tutorial board.

Because we want to support apps that are not signed as well, this adds a small wrapper that tells the credential checking machine that its ok to load apps without a valid credential.





### Testing Strategy

Running the libtock-c apps for the tutorial.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
