### PR TITLE
arch/riscv/pmp: fix underflow in region_overlaps

### DIFF
--- a/arch/riscv/src/pmp.rs
+++ b/arch/riscv/src/pmp.rs
@@ -316,9 +316,9 @@ fn region_overlaps(
     !region_range.is_empty()
         && !other_range.is_empty()
         && (region_range.contains(&other_range.start)
-            || region_range.contains(&(other_range.end - 1))
+            || region_range.contains(&(other_range.end.saturating_sub(1)))
             || other_range.contains(&region_range.start)
-            || other_range.contains(&(region_range.end - 1)))
+            || other_range.contains(&(region_range.end.saturating_sub(1))))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Pull Request Overview

This PR fixes an underflow issue in the RISC-V PMP's `region_overlaps` method.

Reported-by: Vivien Rindisbacher <vrindisbacher77@gmail.com>
Fixes: https://github.com/tock/tock/issues/4462

### Testing Strategy

N/A


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
