### PR TITLE
boards: tut: dyn apps: use signed apps key

### DIFF
--- a/boards/tutorials/nrf52840dk-dynamic-apps-and-policies/src/main.rs
+++ b/boards/tutorials/nrf52840dk-dynamic-apps-and-policies/src/main.rs
@@ -248,21 +248,21 @@ pub unsafe fn main() {
         [capsules_extra::screen_shared::AppScreenRegion; 3],
         [
             capsules_extra::screen_shared::AppScreenRegion::new(
-                create_short_id_from_name("process_manager", 0xf),
+                create_short_id_from_name("process_manager", 0x0),
                 0,      // x
                 0,      // y
                 16 * 8, // width
                 7 * 8   // height
             ),
             capsules_extra::screen_shared::AppScreenRegion::new(
-                create_short_id_from_name("counter", 0xf),
+                create_short_id_from_name("counter", 0x0),
                 0,     // x
                 7 * 8, // y
                 8 * 8, // width
                 1 * 8  // height
             ),
             capsules_extra::screen_shared::AppScreenRegion::new(
-                create_short_id_from_name("temperature", 0xf),
+                create_short_id_from_name("temperature", 0x0),
                 8 * 8, // x
                 7 * 8, // y
                 8 * 8, // width


### PR DESCRIPTION


### Pull Request Overview

This is a minor change as we've updated the tutorial. Initially none of the apps were signed so they all had ShortIds that started with `0xf`. Now we have signed apps automatically, so their shortids start with 0x0.




### Testing Strategy

Doing a practice run of the tutorial.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
