### PR TITLE
boards: tutorials: Add  root of trust tutorial board

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ members = [
     "boards/configurations/nrf52840dk/nrf52840dk-test-kernel",
     "boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load",
     "boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load",
+    "boards/tutorials/nrf52840dk-root-of-trust-tutorial",
     "boards/tutorials/nrf52840dk-dynamic-apps-and-policies",
     "boards/tutorials/nrf52840dk-hotp-tutorial",
     "boards/tutorials/nrf52840dk-thread-tutorial",

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -396,7 +396,7 @@ pub unsafe fn ieee802154_udp(
 /// removed when this function returns. Otherwise, the stack space used for
 /// these static_inits is wasted.
 #[inline(never)]
-pub unsafe fn start() -> (
+pub unsafe fn start_no_pconsole() -> (
     &'static kernel::Kernel,
     Platform,
     &'static Chip,
@@ -915,7 +915,6 @@ pub unsafe fn start() -> (
         systick: cortexm4::systick::SysTick::new_with_calibration(64000000),
     };
 
-    let _ = platform.pconsole.start();
     base_peripherals.adc.calibrate();
 
     debug!("Initialization complete. Entering main loop\r");
@@ -928,4 +927,20 @@ pub unsafe fn start() -> (
         nrf52840_peripherals,
         mux_alarm,
     )
+}
+
+/// This is in a separate, inline(never) function so that its stack frame is
+/// removed when this function returns. Otherwise, the stack space used for
+/// these static_inits is wasted.
+#[inline(never)]
+pub unsafe fn start() -> (
+    &'static kernel::Kernel,
+    Platform,
+    &'static Chip,
+    &'static Nrf52840DefaultPeripherals<'static>,
+    &'static MuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
+) {
+    let (kernel, platform, chip, peripherals, mux_alarm) = start_no_pconsole();
+    let _ = platform.pconsole.start();
+    (kernel, platform, chip, peripherals, mux_alarm)
 }

--- a/boards/tutorials/nrf52840dk-root-of-trust-tutorial/.cargo/config.toml
+++ b/boards/tutorials/nrf52840dk-root-of-trust-tutorial/.cargo/config.toml
@@ -1,0 +1,14 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
+include = [
+  "../../../cargo/tock_flags.toml",
+  "../../../cargo/unstable_flags.toml",
+]
+
+[build]
+target = "thumbv7em-none-eabi"
+
+[unstable]
+config-include = true

--- a/boards/tutorials/nrf52840dk-root-of-trust-tutorial/Cargo.toml
+++ b/boards/tutorials/nrf52840dk-root-of-trust-tutorial/Cargo.toml
@@ -1,0 +1,30 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
+[package]
+name = "nrf52840dk-root-of-trust-tutorial"
+version.workspace = true
+authors.workspace = true
+build = "../../build.rs"
+edition.workspace = true
+
+[features]
+default = ["screen_ssd1306"]
+screen_ssd1306 = []
+screen_sh1106 = []
+
+[dependencies]
+kernel = { path = "../../../kernel" }
+nrf52840 = { path = "../../../chips/nrf52840" }
+nrf52840dk = { path = "../../nordic/nrf52840dk" }
+capsules-core = { path = "../../../capsules/core" }
+capsules-extra = { path = "../../../capsules/extra" }
+capsules-system = { path = "../../../capsules/system" }
+components = { path = "../../components" }
+
+[build-dependencies]
+tock_build_scripts = { path = "../../build_scripts" }
+
+[lints]
+workspace = true

--- a/boards/tutorials/nrf52840dk-root-of-trust-tutorial/Makefile
+++ b/boards/tutorials/nrf52840dk-root-of-trust-tutorial/Makefile
@@ -1,0 +1,6 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2024.
+
+include ../../Makefile.common
+include ../../configurations/nrf52840dk/nrf52840dk.mk

--- a/boards/tutorials/nrf52840dk-root-of-trust-tutorial/README.md
+++ b/boards/tutorials/nrf52840dk-root-of-trust-tutorial/README.md
@@ -1,0 +1,9 @@
+nRF52840DK Board Definition for the Tock Attestation Tutorial
+=============================================================
+
+This is the board definition for the nRF52840DK target used in the
+[attestation tutorial](https://book.tockos.org/course/attestation/overview).
+
+Please follow the instructions in that tutorial. You may also want to look at
+the documentation of the base nRF52840DK board definition
+[here](../../nordic/nrf52840dk/README.md).

--- a/boards/tutorials/nrf52840dk-root-of-trust-tutorial/layout.ld
+++ b/boards/tutorials/nrf52840dk-root-of-trust-tutorial/layout.ld
@@ -1,0 +1,6 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2024.                                  */
+
+INCLUDE ../../nordic/nrf52840_chip_layout.ld
+INCLUDE tock_kernel_layout.ld

--- a/boards/tutorials/nrf52840dk-root-of-trust-tutorial/src/main.rs
+++ b/boards/tutorials/nrf52840dk-root-of-trust-tutorial/src/main.rs
@@ -1,0 +1,213 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2024.
+
+//! Tock kernel for the Nordic Semiconductor nRF52840 development kit (DK).
+
+#![no_std]
+#![no_main]
+#![deny(missing_docs)]
+
+use core::ptr::addr_of_mut;
+use kernel::component::Component;
+use kernel::debug;
+use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::static_init;
+use kernel::{capabilities, create_capability};
+use nrf52840::gpio::Pin;
+use nrf52840dk_lib::{self, PROCESSES};
+
+// State for loading and holding applications.
+// How should the kernel respond when a process faults.
+const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
+    capsules_system::process_policies::PanicFaultPolicy {};
+
+const CRYPT_SIZE: usize = 7 * kernel::hil::symmetric_encryption::AES128_BLOCK_SIZE;
+
+// Screen
+type ScreenDriver = components::screen::ScreenComponentType;
+
+struct Platform {
+    base: nrf52840dk_lib::Platform,
+    screen: &'static ScreenDriver,
+    oracle: &'static capsules_extra::tutorials::encryption_oracle_chkpt5::EncryptionOracleDriver<
+        'static,
+        nrf52840::aes::AesECB<'static>,
+    >,
+}
+
+impl SyscallDriverLookup for Platform {
+    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    where
+        F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
+    {
+        match driver_num {
+            capsules_extra::screen::DRIVER_NUM => f(Some(self.screen)),
+            capsules_extra::tutorials::encryption_oracle_chkpt5::DRIVER_NUM => f(Some(self.oracle)),
+            _ => self.base.with_driver(driver_num, f),
+        }
+    }
+}
+
+type Chip = nrf52840dk_lib::Chip;
+
+impl KernelResources<Chip> for Platform {
+    type SyscallDriverLookup = Self;
+    type SyscallFilter = <nrf52840dk_lib::Platform as KernelResources<Chip>>::SyscallFilter;
+    type ProcessFault = <nrf52840dk_lib::Platform as KernelResources<Chip>>::ProcessFault;
+    type Scheduler = <nrf52840dk_lib::Platform as KernelResources<Chip>>::Scheduler;
+    type SchedulerTimer = <nrf52840dk_lib::Platform as KernelResources<Chip>>::SchedulerTimer;
+    type WatchDog = <nrf52840dk_lib::Platform as KernelResources<Chip>>::WatchDog;
+    type ContextSwitchCallback =
+        <nrf52840dk_lib::Platform as KernelResources<Chip>>::ContextSwitchCallback;
+
+    fn syscall_driver_lookup(&self) -> &Self::SyscallDriverLookup {
+        self
+    }
+    fn syscall_filter(&self) -> &Self::SyscallFilter {
+        self.base.syscall_filter()
+    }
+    fn process_fault(&self) -> &Self::ProcessFault {
+        self.base.process_fault()
+    }
+    fn scheduler(&self) -> &Self::Scheduler {
+        self.base.scheduler()
+    }
+    fn scheduler_timer(&self) -> &Self::SchedulerTimer {
+        self.base.scheduler_timer()
+    }
+    fn watchdog(&self) -> &Self::WatchDog {
+        self.base.watchdog()
+    }
+    fn context_switch_callback(&self) -> &Self::ContextSwitchCallback {
+        self.base.context_switch_callback()
+    }
+}
+
+/// Main function called after RAM initialized.
+#[no_mangle]
+pub unsafe fn main() {
+    let main_loop_capability = create_capability!(capabilities::MainLoopCapability);
+
+    // Create the base board:
+    let (board_kernel, base_platform, chip, nrf52840_peripherals, _mux_alarm) =
+        nrf52840dk_lib::start_no_pconsole();
+
+    //--------------------------------------------------------------------------
+    // SCREEN
+    //--------------------------------------------------------------------------
+
+    const SCREEN_I2C_SDA_PIN: Pin = Pin::P1_10;
+    const SCREEN_I2C_SCL_PIN: Pin = Pin::P1_11;
+
+    let i2c_bus = components::i2c::I2CMuxComponent::new(&nrf52840_peripherals.nrf52.twi1, None)
+        .finalize(components::i2c_mux_component_static!(nrf52840::i2c::TWI));
+    nrf52840_peripherals.nrf52.twi1.configure(
+        nrf52840::pinmux::Pinmux::new(SCREEN_I2C_SCL_PIN as u32),
+        nrf52840::pinmux::Pinmux::new(SCREEN_I2C_SDA_PIN as u32),
+    );
+    nrf52840_peripherals
+        .nrf52
+        .twi1
+        .set_speed(nrf52840::i2c::Speed::K400);
+
+    // I2C address is b011110X, and on this board D/C̅ is GND.
+    let ssd1306_sh1106_i2c = components::i2c::I2CComponent::new(i2c_bus, 0x3c)
+        .finalize(components::i2c_component_static!(nrf52840::i2c::TWI));
+
+    // Create the ssd1306 object for the actual screen driver.
+    #[cfg(feature = "screen_ssd1306")]
+    let ssd1306_sh1106 = components::ssd1306::Ssd1306Component::new(ssd1306_sh1106_i2c, true)
+        .finalize(components::ssd1306_component_static!(nrf52840::i2c::TWI));
+
+    #[cfg(feature = "screen_sh1106")]
+    let ssd1306_sh1106 = components::sh1106::Sh1106Component::new(ssd1306_sh1106_i2c, true)
+        .finalize(components::sh1106_component_static!(nrf52840::i2c::TWI));
+
+    let screen = components::screen::ScreenComponent::new(
+        board_kernel,
+        capsules_extra::screen::DRIVER_NUM,
+        ssd1306_sh1106,
+        None,
+    )
+    .finalize(components::screen_component_static!(1032));
+
+    ssd1306_sh1106.init_screen();
+
+    //--------------------------------------------------------------------------
+    // ENCRYPTION ORACLE
+    //--------------------------------------------------------------------------
+
+    let aes_src_buffer = kernel::static_init!([u8; 16], [0; 16]);
+    let aes_dst_buffer = kernel::static_init!([u8; CRYPT_SIZE], [0; CRYPT_SIZE]);
+
+    let oracle = static_init!(
+        capsules_extra::tutorials::encryption_oracle_chkpt5::EncryptionOracleDriver<
+            'static,
+            nrf52840::aes::AesECB<'static>,
+        >,
+        capsules_extra::tutorials::encryption_oracle_chkpt5::EncryptionOracleDriver::new(
+            &nrf52840_peripherals.nrf52.ecb,
+            aes_src_buffer,
+            aes_dst_buffer,
+            board_kernel.create_grant(
+                capsules_extra::tutorials::encryption_oracle_chkpt5::DRIVER_NUM, // our driver number
+                &create_capability!(capabilities::MemoryAllocationCapability)
+            ),
+        ),
+    );
+
+    kernel::hil::symmetric_encryption::AES128::set_client(&nrf52840_peripherals.nrf52.ecb, oracle);
+
+    //--------------------------------------------------------------------------
+    // PLATFORM SETUP, SCHEDULER, AND START KERNEL LOOP
+    //--------------------------------------------------------------------------
+
+    let platform = Platform {
+        base: base_platform,
+        screen,
+        oracle,
+    };
+
+    // These symbols are defined in the linker script.
+    extern "C" {
+        /// Beginning of the ROM region containing app images.
+        static _sapps: u8;
+        /// End of the ROM region containing app images.
+        static _eapps: u8;
+        /// Beginning of the RAM region for app memory.
+        static mut _sappmem: u8;
+        /// End of the RAM region for app memory.
+        static _eappmem: u8;
+    }
+
+    let process_management_capability =
+        create_capability!(capabilities::ProcessManagementCapability);
+
+    kernel::process::load_processes(
+        board_kernel,
+        chip,
+        core::slice::from_raw_parts(
+            core::ptr::addr_of!(_sapps),
+            core::ptr::addr_of!(_eapps) as usize - core::ptr::addr_of!(_sapps) as usize,
+        ),
+        core::slice::from_raw_parts_mut(
+            core::ptr::addr_of_mut!(_sappmem),
+            core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
+        ),
+        &mut *addr_of_mut!(PROCESSES),
+        &FAULT_RESPONSE,
+        &process_management_capability,
+    )
+    .unwrap_or_else(|err| {
+        debug!("Error loading processes!");
+        debug!("{:?}", err);
+    });
+
+    board_kernel.kernel_loop(
+        &platform,
+        chip,
+        Some(&platform.base.ipc),
+        &main_loop_capability,
+    );
+}


### PR DESCRIPTION
### Pull Request Overview

This pull request adds the board definition necessary for the root of trust tutorial.

### Testing Strategy

This pull request was tested by using it with the Root of Trust tutorial applications, specifically by loading and testing the encryption service to be pushed in a separate libtock-c PR.

### TODO or Help Wanted

None.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
