### PR TITLE
clippy: deny declare-interior-mutable-const

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,7 +216,6 @@ unusual-byte-groupings = "allow"
 upper_case_acronyms = "allow"
 
 
-declare-interior-mutable-const = "allow"
 missing_safety_doc = "allow"
 doc_lazy_continuation = "allow"
 

--- a/arch/riscv/src/pmp.rs
+++ b/arch/riscv/src/pmp.rs
@@ -2264,10 +2264,9 @@ pub mod kernel_protection_mml_epmp {
             }
 
             // Setup complete
-            const DEFAULT_USER_PMPCFG_OCTET: Cell<TORUserPMPCFG> = Cell::new(TORUserPMPCFG::OFF);
             Ok(KernelProtectionMMLEPMP {
                 user_pmp_enabled: Cell::new(false),
-                shadow_user_pmpcfgs: [DEFAULT_USER_PMPCFG_OCTET; MPU_REGIONS],
+                shadow_user_pmpcfgs: [const { Cell::new(TORUserPMPCFG::OFF) }; MPU_REGIONS],
             })
         }
     }

--- a/boards/components/src/sched/cooperative.rs
+++ b/boards/components/src/sched/cooperative.rs
@@ -55,8 +55,9 @@ impl<const NUM_PROCS: usize> Component for CooperativeComponent<NUM_PROCS> {
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let scheduler = static_buffer.0.write(CooperativeSched::new());
 
-        const UNINIT: MaybeUninit<CoopProcessNode<'static>> = MaybeUninit::uninit();
-        let nodes = static_buffer.1.write([UNINIT; NUM_PROCS]);
+        let nodes = static_buffer
+            .1
+            .write([const { MaybeUninit::uninit() }; NUM_PROCS]);
 
         for (i, node) in nodes.iter_mut().enumerate() {
             let init_node = node.write(CoopProcessNode::new(&self.processes[i]));

--- a/boards/components/src/sched/mlfq.rs
+++ b/boards/components/src/sched/mlfq.rs
@@ -70,8 +70,9 @@ impl<A: 'static + time::Alarm<'static>, const NUM_PROCS: usize> Component
 
         let scheduler = static_buffer.1.write(MLFQSched::new(scheduler_alarm));
 
-        const UNINIT: MaybeUninit<MLFQProcessNode<'static>> = MaybeUninit::uninit();
-        let nodes = static_buffer.2.write([UNINIT; NUM_PROCS]);
+        let nodes = static_buffer
+            .2
+            .write([const { MaybeUninit::uninit() }; NUM_PROCS]);
 
         for (i, node) in nodes.iter_mut().enumerate() {
             let init_node = node.write(MLFQProcessNode::new(&self.processes[i]));

--- a/boards/components/src/sched/round_robin.rs
+++ b/boards/components/src/sched/round_robin.rs
@@ -57,8 +57,9 @@ impl<const NUM_PROCS: usize> Component for RoundRobinComponent<NUM_PROCS> {
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let scheduler = static_buffer.0.write(RoundRobinSched::new());
 
-        const UNINIT: MaybeUninit<RoundRobinProcessNode<'static>> = MaybeUninit::uninit();
-        let nodes = static_buffer.1.write([UNINIT; NUM_PROCS]);
+        let nodes = static_buffer
+            .1
+            .write([const { MaybeUninit::uninit() }; NUM_PROCS]);
 
         for (i, node) in nodes.iter_mut().enumerate() {
             let init_node = node.write(RoundRobinProcessNode::new(&self.processes[i]));

--- a/capsules/extra/src/pwm.rs
+++ b/capsules/extra/src/pwm.rs
@@ -31,11 +31,10 @@ impl<'a, const NUM_PINS: usize> Pwm<'a, NUM_PINS> {
         grant: Grant<App, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
     ) -> Pwm<'a, NUM_PINS> {
         assert!(u16::try_from(NUM_PINS).is_ok());
-        const EMPTY: OptionalCell<ProcessId> = OptionalCell::empty();
         Pwm {
             pwm_pins,
             apps: grant,
-            active_process: [EMPTY; NUM_PINS],
+            active_process: [const { OptionalCell::empty() }; NUM_PINS],
         }
     }
 

--- a/chips/earlgrey/src/epmp.rs
+++ b/chips/earlgrey/src/epmp.rs
@@ -526,10 +526,10 @@ impl<const HANDOVER_CONFIG_CHECK: bool> EarlGreyEPMP<{ HANDOVER_CONFIG_CHECK }, 
         }
 
         // The ePMP hardware was correctly configured, build the ePMP struct:
-        const DEFAULT_USER_PMPCFG_OCTET: Cell<TORUserPMPCFG> = Cell::new(TORUserPMPCFG::OFF);
         Ok(EarlGreyEPMP {
             user_pmp_enabled: Cell::new(false),
-            shadow_user_pmpcfgs: [DEFAULT_USER_PMPCFG_OCTET; TOR_USER_REGIONS_DEBUG_DISABLE],
+            shadow_user_pmpcfgs: [const { Cell::new(TORUserPMPCFG::OFF) };
+                TOR_USER_REGIONS_DEBUG_DISABLE],
             _pd: PhantomData,
         })
     }
@@ -682,10 +682,10 @@ impl<const HANDOVER_CONFIG_CHECK: bool> EarlGreyEPMP<{ HANDOVER_CONFIG_CHECK }, 
         }
 
         // The ePMP hardware was correctly configured, build the ePMP struct:
-        const DEFAULT_USER_PMPCFG_OCTET: Cell<TORUserPMPCFG> = Cell::new(TORUserPMPCFG::OFF);
         Ok(EarlGreyEPMP {
             user_pmp_enabled: Cell::new(false),
-            shadow_user_pmpcfgs: [DEFAULT_USER_PMPCFG_OCTET; TOR_USER_REGIONS_DEBUG_DISABLE],
+            shadow_user_pmpcfgs: [const { Cell::new(TORUserPMPCFG::OFF) };
+                TOR_USER_REGIONS_DEBUG_DISABLE],
             _pd: PhantomData,
         })
     }
@@ -855,10 +855,10 @@ impl<const HANDOVER_CONFIG_CHECK: bool> EarlGreyEPMP<{ HANDOVER_CONFIG_CHECK }, 
         csr::CSR.pmpcfg2.set(0x8d81800);
 
         // The ePMP hardware was correctly configured, build the ePMP struct:
-        const DEFAULT_USER_PMPCFG_OCTET: Cell<TORUserPMPCFG> = Cell::new(TORUserPMPCFG::OFF);
         let epmp = EarlGreyEPMP {
             user_pmp_enabled: Cell::new(false),
-            shadow_user_pmpcfgs: [DEFAULT_USER_PMPCFG_OCTET; TOR_USER_REGIONS_DEBUG_DISABLE],
+            shadow_user_pmpcfgs: [const { Cell::new(TORUserPMPCFG::OFF) };
+                TOR_USER_REGIONS_DEBUG_DISABLE],
             _pd: PhantomData,
         };
 

--- a/chips/imxrt10xx/src/dma.rs
+++ b/chips/imxrt10xx/src/dma.rs
@@ -465,7 +465,7 @@ impl DmaChannel {
             base: DMA_BASE,
             mux: DMA_MUX_BASE,
             channel,
-            client: OptionalCell::empty(),
+            client: const { OptionalCell::empty() },
             hardware_source: Cell::new(None),
         }
     }
@@ -734,7 +734,42 @@ impl<'a> Dma<'a> {
     /// Create a DMA peripheral.
     pub const fn new(ccm: &'a ccm::Ccm) -> Self {
         Dma {
-            channels: DMA_CHANNELS,
+            channels: const {
+                [
+                    DmaChannel::new(0),
+                    DmaChannel::new(1),
+                    DmaChannel::new(2),
+                    DmaChannel::new(3),
+                    DmaChannel::new(4),
+                    DmaChannel::new(5),
+                    DmaChannel::new(6),
+                    DmaChannel::new(7),
+                    DmaChannel::new(8),
+                    DmaChannel::new(9),
+                    DmaChannel::new(10),
+                    DmaChannel::new(11),
+                    DmaChannel::new(12),
+                    DmaChannel::new(13),
+                    DmaChannel::new(14),
+                    DmaChannel::new(15),
+                    DmaChannel::new(16),
+                    DmaChannel::new(17),
+                    DmaChannel::new(18),
+                    DmaChannel::new(19),
+                    DmaChannel::new(20),
+                    DmaChannel::new(21),
+                    DmaChannel::new(22),
+                    DmaChannel::new(23),
+                    DmaChannel::new(24),
+                    DmaChannel::new(25),
+                    DmaChannel::new(26),
+                    DmaChannel::new(27),
+                    DmaChannel::new(28),
+                    DmaChannel::new(29),
+                    DmaChannel::new(30),
+                    DmaChannel::new(31),
+                ]
+            },
             clock_gate: ccm::PeripheralClock::ccgr5(ccm, ccm::HCLK5::DMA),
             registers: DMA_BASE,
         }
@@ -770,39 +805,3 @@ impl<'a> Dma<'a> {
         })
     }
 }
-
-/// Helper constant for allocating DMA channels.
-const DMA_CHANNELS: [DmaChannel; 32] = [
-    DmaChannel::new(0),
-    DmaChannel::new(1),
-    DmaChannel::new(2),
-    DmaChannel::new(3),
-    DmaChannel::new(4),
-    DmaChannel::new(5),
-    DmaChannel::new(6),
-    DmaChannel::new(7),
-    DmaChannel::new(8),
-    DmaChannel::new(9),
-    DmaChannel::new(10),
-    DmaChannel::new(11),
-    DmaChannel::new(12),
-    DmaChannel::new(13),
-    DmaChannel::new(14),
-    DmaChannel::new(15),
-    DmaChannel::new(16),
-    DmaChannel::new(17),
-    DmaChannel::new(18),
-    DmaChannel::new(19),
-    DmaChannel::new(20),
-    DmaChannel::new(21),
-    DmaChannel::new(22),
-    DmaChannel::new(23),
-    DmaChannel::new(24),
-    DmaChannel::new(25),
-    DmaChannel::new(26),
-    DmaChannel::new(27),
-    DmaChannel::new(28),
-    DmaChannel::new(29),
-    DmaChannel::new(30),
-    DmaChannel::new(31),
-];

--- a/kernel/src/deferred_call.rs
+++ b/kernel/src/deferred_call.rs
@@ -109,10 +109,6 @@ impl DynDefCallRef<'_> {
     }
 }
 
-// The below constant lets us get around Rust not allowing short array
-// initialization for non-default types.
-const EMPTY: OptionalCell<DynDefCallRef<'static>> = OptionalCell::empty();
-
 /// Counter for the number of deferred calls that have been created, this is
 /// used to track that no more than 32 deferred calls have been created.
 // All 3 of the below global statics are accessed only in this file, and all
@@ -132,7 +128,8 @@ static mut BITMASK: Cell<u32> = Cell::new(0);
 /// An array that stores references to up to 32 `DeferredCall`s via the low-cost
 /// [`DynDefCallRef`].
 // This is a 256 byte array, but at least resides in `.bss`.
-static mut DEFCALLS: [OptionalCell<DynDefCallRef<'static>>; 32] = [EMPTY; 32];
+static mut DEFCALLS: [OptionalCell<DynDefCallRef<'static>>; 32] =
+    [const { OptionalCell::empty() }; 32];
 
 pub struct DeferredCall {
     idx: usize,

--- a/libraries/tock-cells/src/take_cell.rs
+++ b/libraries/tock-cells/src/take_cell.rs
@@ -20,12 +20,10 @@ pub struct TakeCell<'a, T: 'a + ?Sized> {
 }
 
 impl<'a, T: ?Sized> TakeCell<'a, T> {
-    const EMPTY: Self = Self {
-        val: Cell::new(None),
-    };
-
     pub const fn empty() -> TakeCell<'a, T> {
-        Self::EMPTY
+        Self {
+            val: Cell::new(None),
+        }
     }
 
     /// Creates a new `TakeCell` containing `value`


### PR DESCRIPTION
### Pull Request Overview

I think there are two issues this lint prevents:

1. It doesn't make sense to have a const that can be changed via interior mutability.
2. It can be counter intuitive that using the same const twice will use two different copies.

However, these changes feel a little more significant than other clippy lint fixes so I made it its own PR.




### Testing Strategy

n/a


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
