### PR TITLE
kernel: debug panic: Use Capabilities instead of `unsafe`

### DIFF
--- a/boards/arty_e21/src/io.rs
+++ b/boards/arty_e21/src/io.rs
@@ -39,7 +39,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
 
     let led_red = &mut led::LedHigh::new(led_red_pin);
 
-    debug::panic::<_, sifive::uart::Uart, _, _>(
+    debug::panic::<_, sifive::uart::Uart, _, _, _>(
         &mut [led_red],
         sifive::uart::UartPanicWriterConfig {
             registers: arty_e21_chip::uart::UART0_BASE,
@@ -55,5 +55,6 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         pi,
         &rv32i::support::nop,
         crate::PANIC_RESOURCES.get(),
+        &kernel::create_capability!(kernel::capabilities::PanicCapability),
     )
 }

--- a/boards/esp32-c3-devkitM-1/src/io.rs
+++ b/boards/esp32-c3-devkitM-1/src/io.rs
@@ -9,7 +9,7 @@ use kernel::debug;
 #[cfg(not(test))]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    debug::panic_print::<esp32::uart::Uart, _, _>(
+    debug::panic_print::<esp32::uart::Uart, _, _, _>(
         esp32::uart::UartPanicWriterConfig {
             registers: esp32::uart::UART0_BASE,
             params: kernel::hil::uart::Parameters {
@@ -23,6 +23,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         pi,
         &rv32i::support::nop,
         crate::PANIC_RESOURCES.get(),
+        &kernel::create_capability!(kernel::capabilities::PanicCapability),
     );
 
     loop {
@@ -33,7 +34,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
 #[cfg(test)]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    debug::panic_print::<esp32::uart::Uart, _, _>(
+    debug::panic_print::<esp32::uart::Uart, _, _, _>(
         esp32::uart::UartPanicWriterConfig {
             registers: esp32::uart::UART0_BASE,
             params: kernel::hil::uart::Parameters {
@@ -47,6 +48,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         pi,
         &rv32i::support::nop,
         crate::PANIC_RESOURCES.get(),
+        &kernel::create_capability!(kernel::capabilities::PanicCapability),
     );
 
     loop {

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -22,19 +22,20 @@ pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {
         crate::RTT_BUFFER.get().and_then(MapCell::take).map_or_else(
             || debug::panic_blink_forever(&mut [led]),
             |rtt| {
-                debug::panic::<_, segger::rtt::SeggerRttMemory, _, _>(
+                debug::panic::<_, segger::rtt::SeggerRttMemory, _, _, _>(
                     &mut [led],
                     rtt,
                     pi,
                     &cortexm4::support::nop,
                     crate::PANIC_RESOURCES.get(),
+                    &kernel::create_capability!(kernel::capabilities::PanicCapability),
                 )
             },
         )
     } else {
         // Use the nRF52 UART for panic output.
 
-        debug::panic::<_, nrf52840::uart::Uarte, _, _>(
+        debug::panic::<_, nrf52840::uart::Uarte, _, _, _>(
             &mut [led],
             nrf52840::uart::UartPanicWriterConfig {
                 params: uart::Parameters {
@@ -52,6 +53,7 @@ pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {
             pi,
             &cortexm4::support::nop,
             crate::PANIC_RESOURCES.get(),
+            &kernel::create_capability!(kernel::capabilities::PanicCapability),
         )
     }
 }

--- a/boards/nordic/nrf52dk/src/io.rs
+++ b/boards/nordic/nrf52dk/src/io.rs
@@ -16,7 +16,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_kernel_pin = &nrf52832::gpio::GPIOPin::new(Pin::P0_17);
     let led = &mut led::LedLow::new(led_kernel_pin);
 
-    debug::panic::<_, nrf52832::uart::Uarte, _, _>(
+    debug::panic::<_, nrf52832::uart::Uarte, _, _, _>(
         &mut [led],
         nrf52832::uart::UartPanicWriterConfig {
             params: uart::Parameters {
@@ -34,5 +34,6 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         pi,
         &cortexm4::support::nop,
         crate::PANIC_RESOURCES.get(),
+        &kernel::create_capability!(kernel::capabilities::PanicCapability),
     )
 }

--- a/boards/qemu_rv32_virt/src/io.rs
+++ b/boards/qemu_rv32_virt/src/io.rs
@@ -11,7 +11,7 @@ use kernel::hil::uart;
 #[cfg(not(test))]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    debug::panic_print::<qemu_rv32_virt_chip::uart::Uart16550, _, _>(
+    debug::panic_print::<qemu_rv32_virt_chip::uart::Uart16550, _, _, _>(
         qemu_rv32_virt_chip::uart::UartPanicWriterConfig {
             params: uart::Parameters {
                 baud_rate: 115200,
@@ -24,6 +24,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         pi,
         &rv32i::support::nop,
         crate::PANIC_RESOURCES.get(),
+        &kernel::create_capability!(kernel::capabilities::PanicCapability),
     );
 
     // The system is no longer in a well-defined state. Use

--- a/boards/wm1110dev/src/io.rs
+++ b/boards/wm1110dev/src/io.rs
@@ -19,7 +19,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_red_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_14);
     let led = &mut led::LedHigh::new(led_red_pin);
 
-    debug::panic::<_, nrf52840::uart::Uarte, _, _>(
+    debug::panic::<_, nrf52840::uart::Uarte, _, _, _>(
         &mut [led],
         nrf52840::uart::UartPanicWriterConfig {
             params: uart::Parameters {
@@ -37,5 +37,6 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         pi,
         &cortexm4::support::nop,
         crate::PANIC_RESOURCES.get(),
+        &kernel::create_capability!(kernel::capabilities::PanicCapability),
     )
 }

--- a/kernel/src/capabilities.rs
+++ b/kernel/src/capabilities.rs
@@ -125,3 +125,10 @@ pub unsafe trait NetworkCapabilityCreationCapability {}
 /// debug writer mechanism has access to debugging print messages which may
 /// contain information about the operation of the kernel.
 pub unsafe trait SetDebugWriterCapability {}
+
+/// The `PanicCapability` allows the holder to use the kernel-provided panic
+/// functions.
+///
+/// These functions can both loop indefinitely and access internal debugging
+/// state. Only trusted code should use these APIs.
+pub unsafe trait PanicCapability {}

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -104,7 +104,7 @@
 //! ```
 
 use core::cell::Cell;
-use core::fmt::{write, Arguments, Write};
+use core::fmt::{Arguments, Write, write};
 use core::panic::PanicInfo;
 use core::str;
 
@@ -705,9 +705,7 @@ macro_rules! debug {
 /// In-kernel `println()` debugging that can take a process slice.
 #[macro_export]
 macro_rules! debug_process_slice {
-    ($msg:expr $(,)?) => {{
-        $crate::debug::debug_slice($msg)
-    }};
+    ($msg:expr $(,)?) => {{ $crate::debug::debug_slice($msg) }};
 }
 
 /// In-kernel `println()` debugging with filename and line numbers.

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -104,10 +104,11 @@
 //! ```
 
 use core::cell::Cell;
-use core::fmt::{Arguments, Write, write};
+use core::fmt::{write, Arguments, Write};
 use core::panic::PanicInfo;
 use core::str;
 
+use crate::capabilities::PanicCapability;
 use crate::capabilities::SetDebugWriterCapability;
 use crate::hil;
 use crate::platform::chip::Chip;
@@ -157,38 +158,61 @@ impl<C: Chip, PP: ProcessPrinter> PanicResources<C, PP> {
 /// returns.
 ///
 /// **NOTE:** The supplied `writer` must be synchronous.
-pub unsafe fn panic_print<PW: PanicWriter, C: Chip, PP: ProcessPrinter>(
+pub fn panic_print<PW: PanicWriter, C: Chip, PP: ProcessPrinter, CAP: PanicCapability>(
     writer_config: PW::Config,
     panic_info: &PanicInfo,
     nop: &dyn Fn(),
     panic_resources: Option<&PanicResources<C, PP>>,
+    cap: &CAP,
 ) {
-    unsafe {
-        // Create the synchronous writer we can use to output the panic message.
-        let mut writer = PW::create_panic_writer(writer_config);
+    // Create the synchronous writer we can use to output the panic message.
+    //
+    // # Safety
+    //
+    // Because the capability ensures we are only calling this function during a
+    // panic, we know that nothing else will be trying to use the same
+    // underlying hardware as the panic_writer we are creating.
+    let mut writer = unsafe { PW::create_panic_writer(writer_config) };
 
-        panic_begin(nop);
-        // Flush debug buffer if needed
-        flush(&mut writer);
-        panic_banner(&mut writer, panic_info);
+    panic_begin(nop, cap);
+    // Flush debug buffer if needed
+    flush(&mut writer);
+    panic_banner(&mut writer, panic_info);
 
-        panic_resources.map(|pr| {
-            let chip = pr.chip.take();
-            panic_cpu_state(chip, &mut writer);
+    panic_resources.map(|pr| {
+        let chip = pr.chip.take();
 
-            chip.map(|c| {
-                // Some systems may enforce memory protection regions for the kernel,
-                // making application memory inaccessible. However, printing process
-                // information will attempt to access memory. If we are provided a chip
-                // reference, attempt to disable userspace memory protection first:
-                use crate::platform::mpu::MPU;
-                c.mpu().disable_app_mpu()
-            });
-            pr.processes.take().map(|p| {
-                panic_process_info(p, pr.printer.take(), &mut writer);
-            });
+        // # Safety
+        //
+        // Printing chip state can access HW directly. However, this function is
+        // only ever called from a panic context and there is no risk if the HW
+        // state is corrupted.
+        unsafe {
+            C::print_state(chip, &mut writer);
+        }
+
+        chip.map(|c| {
+            use crate::platform::mpu::MPU;
+
+            // Some systems may enforce memory protection regions for the
+            // kernel, making application memory inaccessible. However, printing
+            // process information will attempt to access memory. If we are
+            // provided a chip reference, attempt to disable userspace memory
+            // protection first:
+            //
+            // # Safety
+            //
+            // Because of the capability we know we are only calling this from a
+            // panic handler. The applications can never run again, so it is
+            // safe to disable the MPU.
+            unsafe {
+                c.mpu().disable_app_mpu();
+            }
         });
-    }
+        pr.processes.take().map(|p| {
+            panic_process_info(p, pr.printer.take(), &mut writer, cap);
+        });
+    });
 }
 
 /// Tock default panic routine.
@@ -197,24 +221,29 @@ pub unsafe fn panic_print<PW: PanicWriter, C: Chip, PP: ProcessPrinter>(
 ///
 /// This will print a detailed debugging message and then loop forever while
 /// blinking an LED in a recognizable pattern.
-pub unsafe fn panic<L: hil::led::Led, PW: PanicWriter, C: Chip, PP: ProcessPrinter>(
+pub fn panic<
+    L: hil::led::Led,
+    PW: PanicWriter,
+    C: Chip,
+    PP: ProcessPrinter,
+    CAP: PanicCapability,
+>(
     leds: &mut [&L],
     writer_config: PW::Config,
     panic_info: &PanicInfo,
     nop: &dyn Fn(),
     panic_resources: Option<&PanicResources<C, PP>>,
+    cap: &CAP,
 ) -> ! {
-    unsafe {
-        // Call `panic_print` first which will print out the panic information and
-        // return
-        panic_print::<PW, C, PP>(writer_config, panic_info, nop, panic_resources);
+    // Call `panic_print` first which will print out the panic information and
+    // return
+    panic_print::<PW, C, PP, CAP>(writer_config, panic_info, nop, panic_resources, cap);
 
-        // The system is no longer in a well-defined state, we cannot
-        // allow this function to return
-        //
-        // Forever blink LEDs in an infinite loop
-        panic_blink_forever(leds)
-    }
+    // The system is no longer in a well-defined state, we cannot
+    // allow this function to return
+    //
+    // Forever blink LEDs in an infinite loop
+    panic_blink_forever(leds)
 }
 
 /// Tock panic routine, without the infinite LED-blinking loop.
@@ -234,29 +263,46 @@ pub unsafe fn panic_print_old<W: Write + IoWrite, C: Chip, PP: ProcessPrinter>(
     nop: &dyn Fn(),
     panic_resources: Option<&PanicResources<C, PP>>,
 ) {
-    unsafe {
-        panic_begin(nop);
-        // Flush debug buffer if needed
-        flush(writer);
-        panic_banner(writer, panic_info);
+    let cap = crate::create_capability!(PanicCapability);
 
-        panic_resources.map(|pr| {
-            let chip = pr.chip.take();
-            panic_cpu_state(chip, writer);
+    panic_begin(nop, &cap);
+    // Flush debug buffer if needed
+    flush(writer);
+    panic_banner(writer, panic_info);
 
-            chip.map(|c| {
-                // Some systems may enforce memory protection regions for the kernel,
-                // making application memory inaccessible. However, printing process
-                // information will attempt to access memory. If we are provided a chip
-                // reference, attempt to disable userspace memory protection first:
-                use crate::platform::mpu::MPU;
-                c.mpu().disable_app_mpu()
-            });
-            pr.processes.take().map(|p| {
-                panic_process_info(p, pr.printer.take(), writer);
-            });
+    panic_resources.map(|pr| {
+        let chip = pr.chip.take();
+
+        // # Safety
+        //
+        // Printing chip state can access HW directly. However, this function is
+        // only ever called from a panic context and there is no risk if the HW
+        // state is corrupted.
+        unsafe {
+            C::print_state(chip, writer);
+        }
+
+        chip.map(|c| {
+            use crate::platform::mpu::MPU;
+
+            // Some systems may enforce memory protection regions for the kernel,
+            // making application memory inaccessible. However, printing process
+            // information will attempt to access memory. If we are provided a chip
+            // reference, attempt to disable userspace memory protection first:
+            //
+            // # Safety
+            //
+            // Because of the capability we know we are only calling this from a
+            // panic handler. The applications can never run again, so it is
+            // safe to disable the MPU.
+            unsafe {
+                c.mpu().disable_app_mpu();
+            }
         });
-    }
+        pr.processes.take().map(|p| {
+            panic_process_info(p, pr.printer.take(), writer, &cap);
+        });
+    });
 }
 
 /// Tock default panic routine.
@@ -290,7 +336,7 @@ pub unsafe fn panic_old<L: hil::led::Led, W: Write + IoWrite, C: Chip, PP: Proce
 /// This opaque method should always be called at the beginning of a board's
 /// panic method to allow hooks for any core kernel cleanups that may be
 /// appropriate.
-pub unsafe fn panic_begin(nop: &dyn Fn()) {
+pub fn panic_begin<CAP: PanicCapability>(nop: &dyn Fn(), _cap: &CAP) {
     // Let any outstanding uart DMA's finish
     for _ in 0..200000 {
         nop();
@@ -300,7 +346,7 @@ pub unsafe fn panic_begin(nop: &dyn Fn()) {
 /// Lightweight prints about the current panic and kernel version.
 ///
 /// **NOTE:** The supplied `writer` must be synchronous.
-pub unsafe fn panic_banner<W: Write>(writer: &mut W, panic_info: &PanicInfo) {
+pub fn panic_banner<W: Write>(writer: &mut W, panic_info: &PanicInfo) {
     let _ = writer.write_fmt(format_args!("\r\n{}\r\n", panic_info));
 
     // Print version of the kernel
@@ -322,22 +368,14 @@ pub unsafe fn panic_banner<W: Write>(writer: &mut W, panic_info: &PanicInfo) {
     }
 }
 
-/// Print current machine (CPU) state.
-///
-/// **NOTE:** The supplied `writer` must be synchronous.
-pub unsafe fn panic_cpu_state<W: Write, C: Chip>(chip: Option<&'static C>, writer: &mut W) {
-    unsafe {
-        C::print_state(chip, writer);
-    }
-}
-
 /// More detailed prints about all processes.
 ///
 /// **NOTE:** The supplied `writer` must be synchronous.
-pub unsafe fn panic_process_info<PP: ProcessPrinter, W: Write>(
+pub fn panic_process_info<PP: ProcessPrinter, W: Write, CAP: PanicCapability>(
     processes: &'static [ProcessSlot],
     process_printer: Option<&'static PP>,
     writer: &mut W,
+    _cap: &CAP,
 ) {
     process_printer.map(|printer| {
         // print data about each process
@@ -667,7 +705,9 @@ macro_rules! debug {
 /// In-kernel `println()` debugging that can take a process slice.
 #[macro_export]
 macro_rules! debug_process_slice {
-    ($msg:expr $(,)?) => {{ $crate::debug::debug_slice($msg) }};
+    ($msg:expr $(,)?) => {{
+        $crate::debug::debug_slice($msg)
+    }};
 }
 
 /// In-kernel `println()` debugging with filename and line numbers.


### PR DESCRIPTION
### Pull Request Overview

This is a step towards enabling the lint `missing_safety_doc` (https://rust-lang.github.io/rust-clippy/master/#/missing_safety_doc).

One place we have undocumented `unsafe` APIs in the kernel is in debug, particularly for the panic helpers. It seems to me that these are `unsafe` because we don't want capsules to call them, not because we are signaling that there are Rust invariants that must be considered before calling them.

This adds a `DebugCapability` capability and switches the debug panic APIs from `unsafe` to using the capability. This propagates into chips and arch. Again, I don't know if specifying `print_state` as `unsafe` was intentional or just propagated the `unsafe`.

Draft because switching to capabilities may not be the way to go. However, having this PR I think is still helpful because we should either switch to capabilities or document the unsafe expectations.


### Testing Strategy

draft


### TODO or Help Wanted

- Do you agree that capabilities are more appropriate for the panic debug APIs?
- Can you help write the safety doc for `arch/cortex-m/src/lib.rs::print_cortexm_state`?
- Is the safety doc for `debug::flush()` correct?


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
