### PR TITLE
clippy: deny while-let-loop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,6 @@ option_map_unit_fn = "allow"
 # nonminimal if statements, particularly when matching hardware or datasheets.
 nonminimal_bool = "allow"
 identity-op = "allow"
-while-let-loop = "allow"
 manual-range-patterns = "allow"
 manual-flatten = "allow"
 

--- a/chips/apollo3/src/chip.rs
+++ b/chips/apollo3/src/chip.rs
@@ -98,18 +98,14 @@ impl<I: InterruptService + 'static> Chip for Apollo3<I> {
 
     fn service_pending_interrupts(&self) {
         unsafe {
-            loop {
-                if let Some(interrupt) = cortexm4f::nvic::next_pending() {
-                    if !self.interrupt_service.service_interrupt(interrupt) {
-                        panic!("unhandled interrupt, {}", interrupt);
-                    }
-
-                    let n = cortexm4f::nvic::Nvic::new(interrupt);
-                    n.clear_pending();
-                    n.enable();
-                } else {
-                    break;
+            while let Some(interrupt) = cortexm4f::nvic::next_pending() {
+                if !self.interrupt_service.service_interrupt(interrupt) {
+                    panic!("unhandled interrupt, {}", interrupt);
                 }
+
+                let n = cortexm4f::nvic::Nvic::new(interrupt);
+                n.clear_pending();
+                n.enable();
             }
         }
     }

--- a/chips/imxrt10xx/src/chip.rs
+++ b/chips/imxrt10xx/src/chip.rs
@@ -108,16 +108,12 @@ impl<I: InterruptService + 'static> Chip for Imxrt10xx<I> {
 
     fn service_pending_interrupts(&self) {
         unsafe {
-            loop {
-                if let Some(interrupt) = cortexm7::nvic::next_pending() {
-                    let handled = self.interrupt_service.service_interrupt(interrupt);
-                    assert!(handled, "Unhandled interrupt number {}", interrupt);
-                    let n = cortexm7::nvic::Nvic::new(interrupt);
-                    n.clear_pending();
-                    n.enable();
-                } else {
-                    break;
-                }
+            while let Some(interrupt) = cortexm7::nvic::next_pending() {
+                let handled = self.interrupt_service.service_interrupt(interrupt);
+                assert!(handled, "Unhandled interrupt number {}", interrupt);
+                let n = cortexm7::nvic::Nvic::new(interrupt);
+                n.clear_pending();
+                n.enable();
             }
         }
     }

--- a/chips/msp432/src/chip.rs
+++ b/chips/msp432/src/chip.rs
@@ -110,18 +110,14 @@ impl<'a, I: InterruptService + 'a> Chip for Msp432<'a, I> {
 
     fn service_pending_interrupts(&self) {
         unsafe {
-            loop {
-                if let Some(interrupt) = cortexm4::nvic::next_pending() {
-                    if !self.interrupt_service.service_interrupt(interrupt) {
-                        panic!("unhandled interrupt {}", interrupt);
-                    }
-
-                    let n = cortexm4::nvic::Nvic::new(interrupt);
-                    n.clear_pending();
-                    n.enable();
-                } else {
-                    break;
+            while let Some(interrupt) = cortexm4::nvic::next_pending() {
+                if !self.interrupt_service.service_interrupt(interrupt) {
+                    panic!("unhandled interrupt {}", interrupt);
                 }
+
+                let n = cortexm4::nvic::Nvic::new(interrupt);
+                n.clear_pending();
+                n.enable();
             }
         }
     }

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -118,17 +118,13 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for NRF52<'a, I>
 
     fn service_pending_interrupts(&self) {
         unsafe {
-            loop {
-                if let Some(interrupt) = nvic::next_pending() {
-                    if !self.interrupt_service.service_interrupt(interrupt) {
-                        panic!("unhandled interrupt {}", interrupt);
-                    }
-                    let n = nvic::Nvic::new(interrupt);
-                    n.clear_pending();
-                    n.enable();
-                } else {
-                    break;
+            while let Some(interrupt) = nvic::next_pending() {
+                if !self.interrupt_service.service_interrupt(interrupt) {
+                    panic!("unhandled interrupt {}", interrupt);
                 }
+                let n = nvic::Nvic::new(interrupt);
+                n.clear_pending();
+                n.enable();
             }
         }
     }

--- a/chips/psoc62xa/src/chip.rs
+++ b/chips/psoc62xa/src/chip.rs
@@ -59,17 +59,13 @@ impl<I: InterruptService> Chip for Psoc62xa<'_, I> {
 
     fn service_pending_interrupts(&self) {
         unsafe {
-            loop {
-                if let Some(interrupt) = cortexm0p::nvic::next_pending() {
-                    if !self.interrupt_service.service_interrupt(interrupt) {
-                        panic!("unhandled interrupt {}", interrupt);
-                    }
-                    let n = cortexm0p::nvic::Nvic::new(interrupt);
-                    n.clear_pending();
-                    n.enable();
-                } else {
-                    break;
+            while let Some(interrupt) = cortexm0p::nvic::next_pending() {
+                if !self.interrupt_service.service_interrupt(interrupt) {
+                    panic!("unhandled interrupt {}", interrupt);
                 }
+                let n = cortexm0p::nvic::Nvic::new(interrupt);
+                n.clear_pending();
+                n.enable();
             }
             while let Some(interrupt) = cortexm0p::nvic::next_pending() {
                 let nvic = cortexm0p::nvic::Nvic::new(interrupt);

--- a/chips/rp2040/src/chip.rs
+++ b/chips/rp2040/src/chip.rs
@@ -64,20 +64,16 @@ impl<I: InterruptService> Chip for Rp2040<'_, I> {
                 Processor::Processor0 => self.processor0_interrupt_mask,
                 Processor::Processor1 => self.processor1_interrupt_mask,
             };
-            loop {
-                if let Some(interrupt) = cortexm0p::nvic::next_pending_with_mask(mask) {
-                    // ignore SIO_IRQ_PROC1 as it is intended for processor 1
-                    // not able to unset its pending status
-                    // probably only processor 1 can unset the pending by reading the fifo
-                    if !self.interrupt_service.service_interrupt(interrupt) {
-                        panic!("unhandled interrupt {}", interrupt);
-                    }
-                    let n = cortexm0p::nvic::Nvic::new(interrupt);
-                    n.clear_pending();
-                    n.enable();
-                } else {
-                    break;
+            while let Some(interrupt) = cortexm0p::nvic::next_pending_with_mask(mask) {
+                // ignore SIO_IRQ_PROC1 as it is intended for processor 1
+                // not able to unset its pending status
+                // probably only processor 1 can unset the pending by reading the fifo
+                if !self.interrupt_service.service_interrupt(interrupt) {
+                    panic!("unhandled interrupt {}", interrupt);
                 }
+                let n = cortexm0p::nvic::Nvic::new(interrupt);
+                n.clear_pending();
+                n.enable();
             }
         }
     }

--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -241,18 +241,14 @@ impl<I: InterruptService + 'static> Chip for Sam4l<I> {
 
     fn service_pending_interrupts(&self) {
         unsafe {
-            loop {
-                if let Some(interrupt) = cortexm4::nvic::next_pending() {
-                    match self.interrupt_service.service_interrupt(interrupt) {
-                        true => {}
-                        false => panic!("unhandled interrupt"),
-                    }
-                    let n = cortexm4::nvic::Nvic::new(interrupt);
-                    n.clear_pending();
-                    n.enable();
-                } else {
-                    break;
+            while let Some(interrupt) = cortexm4::nvic::next_pending() {
+                match self.interrupt_service.service_interrupt(interrupt) {
+                    true => {}
+                    false => panic!("unhandled interrupt"),
                 }
+                let n = cortexm4::nvic::Nvic::new(interrupt);
+                n.clear_pending();
+                n.enable();
             }
         }
     }

--- a/chips/stm32f303xc/src/chip.rs
+++ b/chips/stm32f303xc/src/chip.rs
@@ -107,17 +107,13 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32f3xx<'a, I> {
 
     fn service_pending_interrupts(&self) {
         unsafe {
-            loop {
-                if let Some(interrupt) = cortexm4f::nvic::next_pending() {
-                    if !self.interrupt_service.service_interrupt(interrupt) {
-                        panic!("unhandled interrupt {}", interrupt);
-                    }
-                    let n = cortexm4f::nvic::Nvic::new(interrupt);
-                    n.clear_pending();
-                    n.enable();
-                } else {
-                    break;
+            while let Some(interrupt) = cortexm4f::nvic::next_pending() {
+                if !self.interrupt_service.service_interrupt(interrupt) {
+                    panic!("unhandled interrupt {}", interrupt);
                 }
+                let n = cortexm4f::nvic::Nvic::new(interrupt);
+                n.clear_pending();
+                n.enable();
             }
         }
     }

--- a/chips/stm32f4xx/src/chip.rs
+++ b/chips/stm32f4xx/src/chip.rs
@@ -168,18 +168,14 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32f4xx<'a, I> {
 
     fn service_pending_interrupts(&self) {
         unsafe {
-            loop {
-                if let Some(interrupt) = cortexm4f::nvic::next_pending() {
-                    if !self.interrupt_service.service_interrupt(interrupt) {
-                        panic!("unhandled interrupt {}", interrupt);
-                    }
-
-                    let n = cortexm4f::nvic::Nvic::new(interrupt);
-                    n.clear_pending();
-                    n.enable();
-                } else {
-                    break;
+            while let Some(interrupt) = cortexm4f::nvic::next_pending() {
+                if !self.interrupt_service.service_interrupt(interrupt) {
+                    panic!("unhandled interrupt {}", interrupt);
                 }
+
+                let n = cortexm4f::nvic::Nvic::new(interrupt);
+                n.clear_pending();
+                n.enable();
             }
         }
     }


### PR DESCRIPTION


### Pull Request Overview

This triggers in several of our chips, and it is cleaner to use `while let` rather than a C-style loop and break.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
