### PR TITLE
capsules: tutorials: add FaultAllProcesses capsule for HWRoT tutorial

### DIFF
--- a/capsules/extra/src/tutorials/fault_all_processes.rs
+++ b/capsules/extra/src/tutorials/fault_all_processes.rs
@@ -1,0 +1,40 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! Driver for the hardware root of trust tutorial, to fault all apps when
+//! requested from a user application.
+
+use kernel::capabilities::ProcessManagementCapability;
+use kernel::syscall::{CommandReturn, SyscallDriver};
+use kernel::{ErrorCode, Kernel, ProcessId};
+
+pub struct FaultAllProcesses<C: ProcessManagementCapability> {
+    kernel: &'static Kernel,
+    capability: C,
+}
+
+impl<C: ProcessManagementCapability> FaultAllProcesses<C> {
+    pub fn new(kernel: &'static Kernel, capability: C) -> Self {
+        FaultAllProcesses { kernel, capability }
+    }
+}
+
+impl<C: ProcessManagementCapability> SyscallDriver for FaultAllProcesses<C> {
+    fn command(&self, command_num: usize, _: usize, _: usize, _: ProcessId) -> CommandReturn {
+        match command_num {
+            0 => CommandReturn::success(),
+            1 => {
+                kernel::debug!("Hardfaulting all applications...");
+                self.kernel.hardfault_all_apps(&self.capability);
+                kernel::debug!("All applications hardfaulted.");
+                CommandReturn::success()
+            }
+            _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
+        }
+    }
+
+    fn allocate_grant(&self, _: ProcessId) -> Result<(), kernel::process::Error> {
+        Ok(())
+    }
+}

--- a/capsules/extra/src/tutorials/mod.rs
+++ b/capsules/extra/src/tutorials/mod.rs
@@ -13,3 +13,4 @@ pub mod encryption_oracle_chkpt3;
 pub mod encryption_oracle_chkpt4;
 #[allow(dead_code)]
 pub mod encryption_oracle_chkpt5;
+pub mod fault_all_processes;


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a toy `FaultAllProcesses` capsule which calls `Kernel::hardfault_all_apps()` upon receiving a command with command num 1. 

### Testing Strategy

This pull request was tested by use with `examples/tutorials/root-of-trust/questionable_service/`.

### TODO or Help Wanted

None.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
