### PR TITLE
Thread tutorial board: Fix link to thread tutorials

### DIFF
--- a/boards/tutorials/nrf52840dk-thread-tutorial/README.md
+++ b/boards/tutorials/nrf52840dk-thread-tutorial/README.md
@@ -2,7 +2,7 @@ nRF52840DK Board Definition for the Tock Thread Tutorial
 ========================================================
 
 This is the board definition for the nRF52840DK target used in the
-[Thread Network tutorial](https://book.tockos.org/course/thread-net/overview).
+[Thread Network tutorial](https://book.tockos.org/course/thread-tutorials/overview).
 
 Please follow the instructions in that tutorial. You may also want to look at
 the documentation of the base nRF52840DK board definition


### PR DESCRIPTION
-------

### Pull Request Overview

This pull request fixes the link to the thread tutorial in the thread tutorial board


### Testing Strategy

N/A


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.