### PR TITLE
tock-registers: release v0.10.0

### DIFF
--- a/libraries/tock-register-interface/CHANGELOG.md
+++ b/libraries/tock-register-interface/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 ## master
 
+## v0.10.0
+
+This release contains some improvements to `tock-registers`. It should
+not contain breaking changes for the majority of users, except for
+those who provide custom implementations of the `UIntLike` trait.
+
+### **Breaking Changes**
+
+To support new debug infrastructure for registers, the `UIntLike` trait now has
+a supertrait-bound for the core library's `Debug` trait. To upgrade to this
+version, users who have custom implementations of `UIntLike` for downstream
+types will need to ensure that their types also implement the `Debug` trait.
+
+### Register Debugging Support
+
+https://github.com/tock/tock/pull/3771
+84a281c4a640f0216112affd3da16963d804e7ef
+add `debug()` method in registers for better human readable debug output
+
+This version adds a `debug()` method to registers implementing the `Readable`
+trait (through an auto-impl of the new `Debuggable` trait). It performs a read
+of the underlying register value and returns a type that implements
+`core::fmt::Debug` to print the register's fields and current values.
+
+### Other changes
+
+- #4230: add an example expansion of the `register_bitfields!` macro to the
+  crate's README
+- #4197: various documentation improvements
+- #3901: `test_fields!`: stringify offset and size in error messages. This
+  allows constant expressions to be used in the `register_structs!` macro.
+
 ## v0.9
 
 There is a small breaking change, described below, which addresses semantic

--- a/libraries/tock-register-interface/Cargo.toml
+++ b/libraries/tock-register-interface/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "tock-registers"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 description = "Memory-Mapped I/O and register interface developed for Tock."
 homepage = "https://www.tockos.org/"

--- a/libraries/tock-register-interface/README.md
+++ b/libraries/tock-register-interface/README.md
@@ -193,7 +193,7 @@ register_bitfields! [
 ```
 
 This generates the modules `Control`, `Status`, and `InterruptFlags`
-    
+
 ```rust
 
 mod Control {
@@ -244,7 +244,7 @@ mod Control {
             }
         }
     }
-}   
+}
 ```
 
 The macro generates a module for each register (e.g., Control, Status, InterruptFlags) that includes:

--- a/libraries/tock-register-interface/src/debug.rs
+++ b/libraries/tock-register-interface/src/debug.rs
@@ -20,8 +20,8 @@ use crate::{
 /// `FieldValueEnumSeq` is a debug helper trait representing a sequence of
 /// [field enum types](crate::fields::Field::read_as_enum).
 ///
-/// It provides methods to recurse through this sequence of types and
-/// thus call methods on them, such as
+/// It provides methods to recurse through this sequence of types and thus call
+/// methods on them, such as
 /// [`try_from_value`](crate::fields::TryFromValue::try_from_value).
 ///
 /// Its primary use lies in the [`RegisterDebugInfo`] trait. This trait provides
@@ -35,11 +35,12 @@ pub trait FieldValueEnumSeq<U: UIntLike> {
     /// Iterates over the sequence of types and performs the following steps:
     ///
     /// 1. Invokes the `data` function argument. This is expected to provide the
-    ///    numeric (`UIntLike`) value of the register field that the current type
-    ///    corresponds to.
+    ///    numeric (`UIntLike`) value of the register field that the current
+    ///    type corresponds to.
     ///
-    /// 2. Invoke [`try_from_value`](crate::fields::TryFromValue::try_from_value)
-    ///    on the current [field enum type](crate::fields::Field::read_as_enum),
+    /// 2. Invoke
+    ///    [`try_from_value`](crate::fields::TryFromValue::try_from_value) on
+    ///    the current [field enum type](crate::fields::Field::read_as_enum),
     ///    passing the value returned by `data`.
     ///
     /// 3. Provide the returned value to the `f` function argument. This is
@@ -50,8 +51,8 @@ pub trait FieldValueEnumSeq<U: UIntLike> {
     /// runtime-accessible information in tandem, to produce a human-readable
     /// register dump.
     ///
-    /// Importantly, `data` is invoked for every type in the sequence, and
-    /// every invocation of `data` is followed by a single invocation of `f`.
+    /// Importantly, `data` is invoked for every type in the sequence, and every
+    /// invocation of `data` is followed by a single invocation of `f`.
     fn recurse_try_from_value(data: &mut impl FnMut() -> U, f: &mut impl FnMut(&dyn fmt::Debug));
 }
 
@@ -116,8 +117,8 @@ pub trait RegisterDebugInfo<T: UIntLike>: RegisterLongName {
     /// correspond to indices of values returned from the [`fields`] and
     /// [`field_names`] methods.
     ///
-    /// [`field_names`]: RegisterDebugInfo::field_names
-    /// [`fields`]: RegisterDebugInfo::fields
+    /// [`field_names`]: RegisterDebugInfo::field_names [`fields`]:
+    /// RegisterDebugInfo::fields
     type FieldValueEnumTypes: FieldValueEnumSeq<T>;
 
     /// The name of the register.

--- a/libraries/tock-register-interface/src/fields.rs
+++ b/libraries/tock-register-interface/src/fields.rs
@@ -4,35 +4,30 @@
 
 //! Register bitfield types and macros
 //!
-//! To conveniently access and manipulate fields of a register, this
-//! library provides types and macros to describe and access bitfields
-//! of a register. This can be especially useful in conjunction with
-//! the APIs defined in [`interfaces`](crate::interfaces), which make
-//! use of these types and hence allow to access and manipulate
-//! bitfields of proper registers directly.
+//! To conveniently access and manipulate fields of a register, this library
+//! provides types and macros to describe and access bitfields of a
+//! register. This can be especially useful in conjunction with the APIs defined
+//! in [`interfaces`](crate::interfaces), which make use of these types and
+//! hence allow to access and manipulate bitfields of proper registers directly.
 //!
-//! A specific section (bitfield) in a register is described by the
-//! [`Field`] type, consisting of an unshifted bitmask over the base
-//! register [`UIntLike`] type, and a shift
-//! parameter. It is further associated with a specific
-//! [`RegisterLongName`], which can prevent its use with incompatible
-//! registers.
+//! A specific section (bitfield) in a register is described by the [`Field`]
+//! type, consisting of an unshifted bitmask over the base register [`UIntLike`]
+//! type, and a shift parameter. It is further associated with a specific
+//! [`RegisterLongName`], which can prevent its use with incompatible registers.
 //!
-//! A value of a section of a register is described by the
-//! [`FieldValue`] type. It stores the information of the respective
-//! section in the register, as well as the associated value. A
-//! [`FieldValue`] can be created from a [`Field`] through the
-//! [`val`](Field::val) method.
+//! A value of a section of a register is described by the [`FieldValue`]
+//! type. It stores the information of the respective section in the register,
+//! as well as the associated value. A [`FieldValue`] can be created from a
+//! [`Field`] through the [`val`](Field::val) method.
 //!
 //! ## `register_bitfields` macro
 //!
-//! For defining register layouts with an associated
-//! [`RegisterLongName`], along with
-//! [`Field`]s and matching [`FieldValue`]s, a convenient macro-based
+//! For defining register layouts with an associated [`RegisterLongName`], along
+//! with [`Field`]s and matching [`FieldValue`]s, a convenient macro-based
 //! interface can be used.
 //!
-//! The following example demonstrates how two registers can be
-//! defined, over a `u32` base type:
+//! The following example demonstrates how two registers can be defined, over a
+//! `u32` base type:
 //!
 //! ```rust
 //! # use tock_registers::register_bitfields;
@@ -51,12 +46,11 @@
 //!     ],
 //! ];
 //!
-//! // In this scope, `Uart` is a module, representing the register and
-//! // its fields. `Uart::Register` is a `RegisterLongName` type
-//! // identifying this register. `Uart::ENABLE` is a field covering the
-//! // first 4 bits of this register. `Uart::ENABLE::ON` is a
-//! // `FieldValue` over that field, with the associated value 8.
-//! // We can now use the types like so:
+//! // In this scope, `Uart` is a module, representing the register and its
+//! // fields. `Uart::Register` is a `RegisterLongName` type identifying this
+//! // register. `Uart::ENABLE` is a field covering the first 4 bits of this
+//! // register. `Uart::ENABLE::ON` is a `FieldValue` over that field, with the
+//! // associated value 8. We can now use the types like so:
 //! let reg: InMemoryRegister<u32, Uart::Register> = InMemoryRegister::new(0);
 //! assert!(reg.read(Uart::ENABLE) == 0x00000000);
 //! reg.modify(Uart::ENABLE::ON);
@@ -152,10 +146,10 @@ impl<T: UIntLike, R: RegisterLongName> Field<T, R> {
     }
 }
 
-// #[derive(Copy, Clone)] won't work here because it will use
-// incorrect bounds, as a result of using a PhantomData over the
-// generic R. The PhantomData<R> implements Copy regardless of whether
-// R does, but the #[derive(Copy, Clone)] generates
+// #[derive(Copy, Clone)] won't work here because it will use incorrect bounds,
+// as a result of using a PhantomData over the generic R. The PhantomData<R>
+// implements Copy regardless of whether R does, but the #[derive(Copy, Clone)]
+// generates
 //
 //    #[automatically_derived]
 //    #[allow(unused_qualifications)]
@@ -205,8 +199,8 @@ pub struct FieldValue<T: UIntLike, R: RegisterLongName> {
 
 macro_rules! FieldValue_impl_for {
     ($type:ty) => {
-        // Necessary to split the implementation of new() out because the bitwise
-        // math isn't treated as const when the type is generic.
+        // Necessary to split the implementation of new() out because the
+        // bitwise math isn't treated as const when the type is generic.
         // Tracking issue: https://github.com/rust-lang/rfcs/pull/2632
         impl<R: RegisterLongName> FieldValue<$type, R> {
             pub const fn new(mask: $type, shift: usize, value: $type) -> Self {
@@ -218,8 +212,9 @@ macro_rules! FieldValue_impl_for {
             }
         }
 
-        // Necessary to split the implementation of From<> out because of the orphan rule
-        // for foreign trait implementation (see [E0210](https://doc.rust-lang.org/error-index.html#E0210)).
+        // Necessary to split the implementation of From<> out because of the
+        // orphan rule for foreign trait implementation (see
+        // [E0210](https://doc.rust-lang.org/error-index.html#E0210)).
         impl<R: RegisterLongName> From<FieldValue<$type, R>> for $type {
             fn from(val: FieldValue<$type, R>) -> $type {
                 val.value
@@ -262,9 +257,8 @@ impl<T: UIntLike, R: RegisterLongName> FieldValue<T, R> {
         (val & !self.mask) | self.value
     }
 
-    /// Check if any of the bits covered by the mask for this
-    /// `FieldValue` and set in the `FieldValue` are also set
-    /// in the passed value
+    /// Check if any of the bits covered by the mask for this `FieldValue` and
+    /// set in the `FieldValue` are also set in the passed value
     #[inline]
     pub fn any_matching_bits_set(&self, val: T) -> bool {
         val & self.mask & self.value != T::zero()
@@ -300,8 +294,8 @@ impl<T: UIntLike, R: RegisterLongName> AddAssign for FieldValue<T, R> {
     }
 }
 
-/// Conversion of raw register value into enumerated values member.
-/// Implemented inside register_bitfields! macro for each bit field.
+/// Conversion of raw register value into enumerated values member. Implemented
+/// inside register_bitfields! macro for each bit field.
 pub trait TryFromValue<V> {
     type EnumType;
 
@@ -374,8 +368,10 @@ macro_rules! register_bitmasks {
         $valtype:ident, $reg_desc:ident, $(#[$outer:meta])* $field:ident,
                     $offset:expr, $numbits:expr,
                     [$( $(#[$inner:meta])* $valname:ident = $value:expr ),+ $(,)?]
-    } => { // this match arm is duplicated below with an allowance for 0 elements in the valname -> value array,
-        // to separately support the case of zero-variant enums not supporting non-default
+    } => {
+        // this match arm is duplicated below with an allowance for 0 elements
+        // in the valname -> value array, to separately support the case of
+        // zero-variant enums not supporting non-default
         // representations.
         #[allow(non_upper_case_globals)]
         #[allow(unused)]
@@ -449,7 +445,9 @@ macro_rules! register_bitmasks {
         $valtype:ident, $reg_desc:ident, $(#[$outer:meta])* $field:ident,
                     $offset:expr, $numbits:expr,
                     []
-    } => { //same pattern as previous match arm, for 0 elements in array. Removes code associated with array.
+    } => {
+        // same pattern as previous match arm, for 0 elements in array. Removes
+        // code associated with array.
         #[allow(non_upper_case_globals)]
         #[allow(unused)]
         pub const $field: Field<$valtype, $reg_desc> =

--- a/libraries/tock-register-interface/src/interfaces.rs
+++ b/libraries/tock-register-interface/src/interfaces.rs
@@ -4,46 +4,43 @@
 
 //! Interfaces (traits) to register types
 //!
-//! This module contains traits which reflect standardized interfaces
-//! to different types of registers. Examples of registers
-//! implementing these interfaces are [`ReadWrite`](crate::registers::ReadWrite) or
+//! This module contains traits which reflect standardized interfaces to
+//! different types of registers. Examples of registers implementing these
+//! interfaces are [`ReadWrite`](crate::registers::ReadWrite) or
 //! [`InMemoryRegister`](crate::registers::InMemoryRegister).
 //!
 //! Each trait has two associated type parameters, namely:
 //!
-//! - `T`: [`UIntLike`], indicating the underlying
-//!   integer type used to represent the register's raw contents.
+//! - `T`: [`UIntLike`], indicating the underlying integer type used to
+//!   represent the register's raw contents.
 //!
-//! - `R`: [`RegisterLongName`], functioning
-//!   as a type to identify this register's descriptive name and
-//!   semantic meaning. It is further used to impose type constraints
-//!   on values passed through the API, such as
+//! - `R`: [`RegisterLongName`], functioning as a type to identify this
+//!   register's descriptive name and semantic meaning. It is further used to
+//!   impose type constraints on values passed through the API, such as
 //!   [`FieldValue`].
 //!
-//! Registers can have different access levels, which are mapped to
-//! different traits respectively:
+//! Registers can have different access levels, which are mapped to different
+//! traits respectively:
 //!
-//! - [`Readable`]: indicates that the current value of this register
-//!   can be read. Implementations will need to provide the
+//! - [`Readable`]: indicates that the current value of this register can be
+//!   read. Implementations will need to provide the
 //!   [`get`](crate::interfaces::Readable::get) method.
 //!
 //! - [`Writeable`]: indicates that the value of this register can be
 //!   set. Implementations will need to provide the
 //!   [`set`](crate::interfaces::Writeable::set) method.
 //!
-//! - [`ReadWriteable`]: indicates that this register can be
-//!   _modified_. It is not sufficient for registers to be both read-
-//!   and writable, they must also have the same semantic meaning when
-//!   read from and written to. This is not true in general, for
-//!   example a memory-mapped UART register might transmit when
-//!   writing and receive when reading.
+//! - [`ReadWriteable`]: indicates that this register can be _modified_. It is
+//!   not sufficient for registers to be both read- and writable, they must also
+//!   have the same semantic meaning when read from and written to. This is not
+//!   true in general, for example a memory-mapped UART register might transmit
+//!   when writing and receive when reading.
 //!
-//!   If a type implements both [`Readable`] and [`Writeable`], and
-//!   the associated [`RegisterLongName`]
-//!   type parameters are identical, it will automatically implement
-//!   [`ReadWriteable`]. In particular, for
-//!   [`Aliased`](crate::registers::Aliased) this is -- in general --
-//!   not the case, so
+//!   If a type implements both [`Readable`] and [`Writeable`], and the
+//!   associated [`RegisterLongName`] type parameters are identical, it will
+//!   automatically implement [`ReadWriteable`]. In particular, for
+//!   [`Aliased`](crate::registers::Aliased) this is -- in general -- not the
+//!   case, so
 //!
 //!   ```rust
 //!   # use tock_registers::interfaces::{Readable, Writeable, ReadWriteable};
@@ -82,21 +79,19 @@
 //!   ```
 //!
 //! - [`Debuggable`]: indicates that the register supports producing
-//!   human-readable debug output using the `RegisterDebugValue` type.
-//!   This type can be produced with the
-//!   [`debug`](crate::interfaces::Debuggable::debug) method.  This
-//!   will return a value that implements [`Debug`](core::fmt::Debug).
-//!   It is automticaly implemented for any register implementing
-//!   [`Readable`].
+//!   human-readable debug output using the `RegisterDebugValue` type. This type
+//!   can be produced with the [`debug`](crate::interfaces::Debuggable::debug)
+//!   method. This will return a value that implements
+//!   [`Debug`](core::fmt::Debug). It is automticaly implemented for any
+//!   register implementing [`Readable`].
 //!
 //!
 //! ## Example: implementing a custom register type
 //!
-//! These traits can be used to implement custom register types, which
-//! are compatible to the ones shipped in this crate. For example, to
-//! define a register which sets a `u8` value using a Cell reference,
-//! always reads the bitwise-negated vale and prints every written
-//! value to the console:
+//! These traits can be used to implement custom register types, which are
+//! compatible to the ones shipped in this crate. For example, to define a
+//! register which sets a `u8` value using a Cell reference, always reads the
+//! bitwise-negated vale and prints every written value to the console:
 //!
 //! ```rust
 //! # use core::cell::Cell;
@@ -150,13 +145,13 @@
 //!     _register_long_name: PhantomData,
 //! };
 //!
-//! // Set a value and read it back. This demonstrates the raw getters
-//! // and setters of Writeable and Readable
+//! // Set a value and read it back. This demonstrates the raw getters and
+//! // setters of Writeable and Readable
 //! dummy.set(0xFA);
 //! assert!(dummy.get() == 0x05);
 //!
-//! // Use some of the automatically derived APIs, such as
-//! // ReadWriteable::modify and Readable::read
+//! // Use some of the automatically derived APIs, such as ReadWriteable::modify
+//! // and Readable::read
 //! dummy.modify(DummyReg::HIGH::C);
 //! assert!(dummy.read(DummyReg::HIGH) == 0xb);
 //! ```
@@ -167,8 +162,8 @@ use crate::{LocalRegisterCopy, RegisterLongName, UIntLike};
 /// Readable register
 ///
 /// Register which at least supports reading the current value. Only
-/// [`Readable::get`] must be implemented, as for other methods a
-/// default implementation is provided.
+/// [`Readable::get`] must be implemented, as for other methods a default
+/// implementation is provided.
 ///
 /// A register that is both [`Readable`] and [`Writeable`] will also
 /// automatically be [`ReadWriteable`], if the [`RegisterLongName`] of
@@ -244,10 +239,10 @@ pub trait Readable {
         field.is_set(self.get())
     }
 
-    /// Check if any bits corresponding to the mask in the passed `FieldValue` are set.
-    /// This function is identical to `is_set()` but operates on a `FieldValue` rather
-    /// than a `Field`, allowing for checking if any bits are set across multiple,
-    /// non-contiguous portions of a bitfield.
+    /// Check if any bits corresponding to the mask in the passed `FieldValue`
+    /// are set.  This function is identical to `is_set()` but operates on a
+    /// `FieldValue` rather than a `Field`, allowing for checking if any bits
+    /// are set across multiple, non-contiguous portions of a bitfield.
     #[inline]
     fn any_matching_bits_set(&self, field: FieldValue<Self::T, Self::R>) -> bool {
         field.any_matching_bits_set(self.get())
@@ -260,8 +255,8 @@ pub trait Readable {
     }
 
     /// Check if any of the passed parts of a field exactly match the contained
-    /// value. This allows for matching on unset bits, or matching on specific values
-    /// in multi-bit fields.
+    /// value. This allows for matching on unset bits, or matching on specific
+    /// values in multi-bit fields.
     #[inline]
     fn matches_any(&self, fields: &[FieldValue<Self::T, Self::R>]) -> bool {
         fields
@@ -274,7 +269,8 @@ pub trait Readable {
 /// output with [`core::fmt::Debug`].  It extends the [`Readable`] trait and
 /// doesn't require manual implementation.
 ///
-/// This is implemented for the register when using the [`register_bitfields`] macro.
+/// This is implemented for the register when using the [`register_bitfields`]
+/// macro.
 ///
 /// The `debug` method returns a value that implements [`core::fmt::Debug`].
 ///
@@ -300,9 +296,9 @@ impl<T: Readable> Debuggable for T {}
 
 /// Writeable register
 ///
-/// Register which at least supports setting a value. Only
-/// [`Writeable::set`] must be implemented, as for other methods a
-/// default implementation is provided.
+/// Register which at least supports setting a value. Only [`Writeable::set`]
+/// must be implemented, as for other methods a default implementation is
+/// provided.
 ///
 /// A register that is both [`Readable`] and [`Writeable`] will also
 /// automatically be [`ReadWriteable`], if the [`RegisterLongName`] of
@@ -316,14 +312,16 @@ pub trait Writeable {
     fn set(&self, value: Self::T);
 
     #[inline]
-    /// Write the value of one or more fields, overwriting the other fields with zero
+    /// Write the value of one or more fields, overwriting the other fields with
+    /// zero
     fn write(&self, field: FieldValue<Self::T, Self::R>) {
         self.set(field.value);
     }
 
     #[inline]
-    /// Write the value of one or more fields, maintaining the value of unchanged fields via a
-    /// provided original value, rather than a register read.
+    /// Write the value of one or more fields, maintaining the value of
+    /// unchanged fields via a provided original value, rather than a register
+    /// read.
     fn modify_no_read(
         &self,
         original: LocalRegisterCopy<Self::T, Self::R>,
@@ -333,20 +331,20 @@ pub trait Writeable {
     }
 }
 
-/// [`Readable`] and [`Writeable`] register, over the same
-/// [`RegisterLongName`]
+/// [`Readable`] and [`Writeable`] register, over the same [`RegisterLongName`]
 ///
 /// Register which supports both reading and setting a value.
 ///
-/// **This trait does not have to be implemented manually!** It is
-/// automatically implemented for every type that is both [`Readable`]
-/// and [`Writeable`], as long as [`Readable::R`] == [`Writeable::R`]
-/// (i.e. not for [`Aliased`](crate::registers::Aliased) registers).
+/// **This trait does not have to be implemented manually!** It is automatically
+/// implemented for every type that is both [`Readable`] and [`Writeable`], as
+/// long as [`Readable::R`] == [`Writeable::R`] (i.e. not for
+/// [`Aliased`](crate::registers::Aliased) registers).
 pub trait ReadWriteable {
     type T: UIntLike;
     type R: RegisterLongName;
 
-    /// Write the value of one or more fields, leaving the other fields unchanged
+    /// Write the value of one or more fields, leaving the other fields
+    /// unchanged
     fn modify(&self, field: FieldValue<Self::T, Self::R>);
 }
 

--- a/libraries/tock-register-interface/src/lib.rs
+++ b/libraries/tock-register-interface/src/lib.rs
@@ -4,8 +4,8 @@
 
 //! Tock Register Interface
 //!
-//! Provides efficient mechanisms to express and use type-checked
-//! memory mapped registers and bitfields.
+//! Provides efficient mechanisms to express and use type-checked memory mapped
+//! registers and bitfields.
 //!
 //! ```rust
 //! # fn main() {}
@@ -58,8 +58,8 @@
 //! - Shane Leonard <shanel@stanford.edu>
 
 #![no_std]
-// If we don't build any actual register types, we don't need unsafe
-// code in this crate
+// If we don't build any actual register types, we don't need unsafe code in
+// this crate
 #![cfg_attr(not(feature = "register_types"), forbid(unsafe_code))]
 
 pub mod fields;
@@ -79,13 +79,11 @@ use core::ops::{BitAnd, BitOr, BitOrAssign, Not, Shl, Shr};
 
 /// Trait representing the base type of registers.
 ///
-/// UIntLike defines basic properties of types required to
-/// read/write/modify a register through its methods and supertrait
-/// requirements.
+/// UIntLike defines basic properties of types required to read/write/modify a
+/// register through its methods and supertrait requirements.
 ///
-/// It features a range of default implementations for common unsigned
-/// integer types, such as [`u8`], [`u16`], [`u32`], [`u64`], [`u128`],
-/// and [`usize`].
+/// It features a range of default implementations for common unsigned integer
+/// types, such as [`u8`], [`u16`], [`u32`], [`u64`], [`u128`], and [`usize`].
 pub trait UIntLike:
     BitAnd<Output = Self>
     + BitOr<Output = Self>
@@ -98,19 +96,16 @@ pub trait UIntLike:
     + Clone
     + Debug
 {
-    /// Return the representation of the value `0` in the implementing
-    /// type.
+    /// Return the representation of the value `0` in the implementing type.
     ///
-    /// This can be used to acquire values of the [`UIntLike`] type,
-    /// even in generic implementations. For instance, to get the
-    /// value `1`, one can use `<T as UIntLike>::zero() + 1`. To get
-    /// the largest representable value, use a bitwise negation: `~(<T
-    /// as UIntLike>::zero())`.
+    /// This can be used to acquire values of the [`UIntLike`] type, even in
+    /// generic implementations. For instance, to get the value `1`, one can use
+    /// `<T as UIntLike>::zero() + 1`. To get the largest representable value,
+    /// use a bitwise negation: `~(<T as UIntLike>::zero())`.
     fn zero() -> Self;
 }
 
-// Helper macro for implementing the UIntLike trait on different
-// types.
+// Helper macro for implementing the UIntLike trait on different types.
 macro_rules! UIntLike_impl_for {
     ($type:ty) => {
         impl UIntLike for $type {
@@ -131,6 +126,6 @@ UIntLike_impl_for!(usize);
 /// Descriptive name for each register.
 pub trait RegisterLongName {}
 
-// Useful implementation for when no RegisterLongName is required
-// (e.g. no fields need to be accessed, just the raw register values)
+// Useful implementation for when no RegisterLongName is required (e.g. no
+// fields need to be accessed, just the raw register values)
 impl RegisterLongName for () {}

--- a/libraries/tock-register-interface/src/local_register.rs
+++ b/libraries/tock-register-interface/src/local_register.rs
@@ -15,20 +15,19 @@ use crate::{RegisterLongName, UIntLike};
 ///
 /// This behaves very similarly to a read-write register, but instead of doing a
 /// volatile read to MMIO to get the value for each function call, a copy of the
-/// register contents are stored locally in memory. This allows a peripheral
-/// to do a single read on a register, and then check which bits are set without
+/// register contents are stored locally in memory. This allows a peripheral to
+/// do a single read on a register, and then check which bits are set without
 /// having to do a full MMIO read each time. It also allows the value of the
 /// register to be "cached" in case the peripheral driver needs to clear the
-/// register in hardware yet still be able to check the bits.
-/// You can write to a local register, which will modify the stored value, but
-/// will not modify any hardware because it operates only on local copy.
+/// register in hardware yet still be able to check the bits.  You can write to
+/// a local register, which will modify the stored value, but will not modify
+/// any hardware because it operates only on local copy.
 ///
-/// This type does not implement the
-/// [`Readable`](crate::interfaces::Readable) and
-/// [`Writeable`](crate::interfaces::Writeable) traits because it
-/// requires a mutable reference to modify the contained value. It
-/// still mirrors the interface which would be exposed by a type
-/// implementing [`Readable`](crate::interfaces::Readable),
+/// This type does not implement the [`Readable`](crate::interfaces::Readable)
+/// and [`Writeable`](crate::interfaces::Writeable) traits because it requires a
+/// mutable reference to modify the contained value. It still mirrors the
+/// interface which would be exposed by a type implementing
+/// [`Readable`](crate::interfaces::Readable),
 /// [`Writeable`](crate::interfaces::Writeable) and
 /// [`ReadWriteable`](crate::interfaces::ReadWriteable).
 #[derive(Copy, Clone)]
@@ -69,13 +68,15 @@ impl<T: UIntLike, R: RegisterLongName> LocalRegisterCopy<T, R> {
         field.read_as_enum(self.get())
     }
 
-    /// Write the value of one or more fields, overwriting the other fields with zero
+    /// Write the value of one or more fields, overwriting the other fields with
+    /// zero
     #[inline]
     pub fn write(&mut self, field: FieldValue<T, R>) {
         self.set(field.value);
     }
 
-    /// Write the value of one or more fields, leaving the other fields unchanged
+    /// Write the value of one or more fields, leaving the other fields
+    /// unchanged
     #[inline]
     pub fn modify(&mut self, field: FieldValue<T, R>) {
         self.set(field.modify(self.get()));
@@ -87,7 +88,8 @@ impl<T: UIntLike, R: RegisterLongName> LocalRegisterCopy<T, R> {
         field.is_set(self.get())
     }
 
-    /// Check if any bits corresponding to the mask in the passed `FieldValue` are set.
+    /// Check if any bits corresponding to the mask in the passed `FieldValue`
+    /// are set.
     #[inline]
     pub fn any_matching_bits_set(&self, field: FieldValue<T, R>) -> bool {
         field.any_matching_bits_set(self.get())
@@ -100,8 +102,8 @@ impl<T: UIntLike, R: RegisterLongName> LocalRegisterCopy<T, R> {
     }
 
     /// Check if any of the passed parts of a field exactly match the contained
-    /// value. This allows for matching on unset bits, or matching on specific values
-    /// in multi-bit fields.
+    /// value. This allows for matching on unset bits, or matching on specific
+    /// values in multi-bit fields.
     #[inline]
     pub fn matches_any(&self, fields: &[FieldValue<T, R>]) -> bool {
         fields

--- a/libraries/tock-register-interface/src/macros.rs
+++ b/libraries/tock-register-interface/src/macros.rs
@@ -90,16 +90,14 @@ macro_rules! register_fields {
 // test the desired assertion any longer. This should be switched to a
 // `should_panic`-akin attribute which works for const panics, once that is
 // available.
-/// Statically validate the size and offsets of the fields defined
-/// within the register struct through the `register_structs!()`
-/// macro.
+/// Statically validate the size and offsets of the fields defined within the
+/// register struct through the `register_structs!()` macro.
 ///
-/// This macro expands to an expression which contains static
-/// assertions about various parameters of the individual fields in
-/// the register struct definition. It will test for:
+/// This macro expands to an expression which contains static assertions about
+/// various parameters of the individual fields in the register struct
+/// definition. It will test for:
 ///
-/// - Proper start offset of padding fields. It will fail in cases
-///   such as
+/// - Proper start offset of padding fields. It will fail in cases such as
 ///
 ///   ```should_fail
 ///   # #[macro_use]
@@ -147,7 +145,7 @@ macro_rules! register_fields {
 /// - Invalid alignment of fields.
 ///
 /// - That the end marker matches the actual generated struct size. This will
-///   fail in cases such as
+/// fail in cases such as
 ///
 ///   ```should_fail
 ///   # #[macro_use]

--- a/libraries/tock-register-interface/src/registers.rs
+++ b/libraries/tock-register-interface/src/registers.rs
@@ -4,21 +4,20 @@
 
 //! Implementation of included register types.
 //!
-//! This module provides a standard set of register types, which can
-//! describe different access levels:
+//! This module provides a standard set of register types, which can describe
+//! different access levels:
 //!
 //! - [`ReadWrite`] for registers which can be read and written to
 //! - [`ReadOnly`] for registers which can only be read
 //! - [`WriteOnly`] for registers which can only be written to
-//! - [`Aliased`] for registers which can be both read and written,
-//!   but represent different registers depending on the operation
-//! - [`InMemoryRegister`] provide a register-type in RAM using
-//!   volatile operations
+//! - [`Aliased`] for registers which can be both read and written, but
+//!   represent different registers depending on the operation
+//! - [`InMemoryRegister`] provide a register-type in RAM using volatile
+//!   operations
 //!
-//! These types can be disabled by removing the `register_types` crate
-//! feature (part of the default features). This is useful if this
-//! crate should be used only as an interface library, or if all
-//! unsafe code should be disabled.
+//! These types can be disabled by removing the `register_types` crate feature
+//! (part of the default features). This is useful if this crate should be used
+//! only as an interface library, or if all unsafe code should be disabled.
 
 use core::cell::UnsafeCell;
 use core::marker::PhantomData;
@@ -28,10 +27,9 @@ use crate::{RegisterLongName, UIntLike};
 
 /// Read/Write registers.
 ///
-/// For accessing and manipulating the register contents, the
-/// [`Readable`], [`Writeable`] and
-/// [`ReadWriteable`](crate::interfaces::ReadWriteable) traits are
-/// implemented.
+/// For accessing and manipulating the register contents, the [`Readable`],
+/// [`Writeable`] and [`ReadWriteable`](crate::interfaces::ReadWriteable) traits
+/// are implemented.
 // To successfully alias this structure onto hardware registers in memory, this
 // struct must be exactly the size of the `T` and is thus marked
 // `repr(transparent)` over an `UnsafeCell<T>`, which itself is
@@ -68,8 +66,7 @@ impl<T: UIntLike, R: RegisterLongName> Writeable for ReadWrite<T, R> {
 
 /// Read-only registers.
 ///
-/// For accessing the register contents the [`Readable`] trait is
-/// implemented.
+/// For accessing the register contents the [`Readable`] trait is implemented.
 // To successfully alias this structure onto hardware registers in memory, this
 // struct must be exactly the size of the `T` and is thus marked
 // `repr(transparent)` over an `UnsafeCell<T>`, which itself is
@@ -97,8 +94,7 @@ impl<T: UIntLike, R: RegisterLongName> Readable for ReadOnly<T, R> {
 
 /// Write-only registers.
 ///
-/// For setting the register contents the [`Writeable`] trait is
-/// implemented.
+/// For setting the register contents the [`Writeable`] trait is implemented.
 // To successfully alias this structure onto hardware registers in memory, this
 // struct must be exactly the size of the `T` and is thus marked
 // `repr(transparent)` over an `UnsafeCell<T>`, which itself is
@@ -126,17 +122,15 @@ impl<T: UIntLike, R: RegisterLongName> Writeable for WriteOnly<T, R> {
 
 /// Read-only and write-only registers aliased to the same address.
 ///
-/// Unlike the [`ReadWrite`] register, this represents a register
-/// which has different meanings based on if it is written or read.
-/// This might be found on a device where control and status registers
-/// are accessed via the same memory address via writes and reads,
-/// respectively.
+/// Unlike the [`ReadWrite`] register, this represents a register which has
+/// different meanings based on if it is written or read.  This might be found
+/// on a device where control and status registers are accessed via the same
+/// memory address via writes and reads, respectively.
 ///
-/// This register implements [`Readable`] and [`Writeable`], but in
-/// general does not implement
-/// [`ReadWriteable`](crate::interfaces::ReadWriteable) (only if the
-/// type parameters `R` and `W` are identical, in which case a
-/// [`ReadWrite`] register might be a better choice).
+/// This register implements [`Readable`] and [`Writeable`], but in general does
+/// not implement [`ReadWriteable`](crate::interfaces::ReadWriteable) (only if
+/// the type parameters `R` and `W` are identical, in which case a [`ReadWrite`]
+/// register might be a better choice).
 // To successfully alias this structure onto hardware registers in memory, this
 // struct must be exactly the size of the `T` and is thus marked
 // `repr(transparent)` over an `UnsafeCell<T>`, which itself is
@@ -174,13 +168,12 @@ impl<T: UIntLike, R: RegisterLongName, W: RegisterLongName> Writeable for Aliase
 /// In memory volatile register.
 ///
 /// Like [`ReadWrite`], but can be safely constructed using the
-/// [`InMemoryRegister::new`] method. It will always be initialized to
-/// the passed in, well-defined initial value.
+/// [`InMemoryRegister::new`] method. It will always be initialized to the
+/// passed in, well-defined initial value.
 ///
-/// For accessing and manipulating the register contents, the
-/// [`Readable`], [`Writeable`] and
-/// [`ReadWriteable`](crate::interfaces::ReadWriteable) traits are
-/// implemented.
+/// For accessing and manipulating the register contents, the [`Readable`],
+/// [`Writeable`] and [`ReadWriteable`](crate::interfaces::ReadWriteable) traits
+/// are implemented.
 // To successfully alias this structure onto hardware registers in memory, this
 // struct must be exactly the size of the `T`.
 #[repr(transparent)]


### PR DESCRIPTION
### Pull Request Overview

This release contains some improvements to `tock-registers`. It should not contain breaking changes for the majority of users, except for those who provide custom implementations of the `UIntLike` trait.

##### **Breaking Changes**

To support new debug infrastructure for registers, the `UIntLike` trait now has a supertrait-bound for the core library's `Debug` trait. To upgrade to this version, users who have custom implementations of `UIntLike` for downstream types will need to ensure that their types also implement the `Debug` trait.

##### Register Debugging Support

https://github.com/tock/tock/pull/3771

84a281c4a640f0216112affd3da16963d804e7ef

add `debug()` method in registers for better human readable debug output

This version adds a `debug()` method to registers implementing the `Readable` trait (through an auto-impl of the new `Debuggable` trait). It performs a read of the underlying register value and returns a type that implements `core::fmt::Debug` to print the register's fields and current values.

##### Other changes

- #4230: add an example expansion of the `register_bitfields!` macro to the crate's README
- #4197: various documentation improvements
- #3901: `test_fields!`: stringify offset and size in error messages. This allows constant expressions to be used in the `register_structs!` macro.


### Testing Strategy

This pull request was tested by `cargo-semver-check`, which pointed out the issue about adding the `Debug` supertrait to `UIntLike`.


### TODO or Help Wanted

N/A


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
