### PR TITLE
Bring back naked functions

### DIFF
--- a/arch/cortex-v7m/src/lib.rs
+++ b/arch/cortex-v7m/src/lib.rs
@@ -435,7 +435,6 @@ pub unsafe extern "C" fn hard_fault_handler_arm_v7m() {
     // a non-naked function, to allow for use of rust code alongside inline asm.
     // Because calling a function increases the stack pointer, we have to check for a kernel
     // stack overflow and adjust the stack pointer before we branch
-
     naked_asm!(
     "
         mov    r2, 0     // r2 = 0

--- a/arch/cortex-v7m/src/lib.rs
+++ b/arch/cortex-v7m/src/lib.rs
@@ -12,22 +12,16 @@ extern "C" {
     static _sstack: u8;
 }
 
+/// ARMv7-M systick handler function.
+///
+/// For documentation of this function, please see
+/// [`CortexMVariant::SYSTICK_HANDLER`].
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
-extern "C" {
-    /// ARMv7-M systick handler function.
-    ///
-    /// For documentation of this function, please see
-    /// `CortexMVariant::SYSTICK_HANDLER`.
-    pub fn systick_handler_arm_v7m();
-}
-
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
-core::arch::global_asm!(
-    "
-    .section .systick_handler_arm_v7m, \"ax\"
-    .global systick_handler_arm_v7m
-    .thumb_func
-  systick_handler_arm_v7m:
+#[unsafe(naked)]
+pub unsafe extern "C" fn systick_handler_arm_v7m() {
+    use core::arch::naked_asm;
+    naked_asm!(
+        "
     // Use the CONTROL register to set the thread mode to privileged to switch
     // back to kernel mode.
     //
@@ -51,25 +45,20 @@ core::arch::global_asm!(
     // This will resume in the switch_to_user function where application state
     // is saved and the scheduler can choose what to do next.
     bx lr
-    "
-);
-
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
-extern "C" {
-    /// Handler of `svc` instructions on ARMv7-M.
-    ///
-    /// For documentation of this function, please see
-    /// `CortexMVariant::SVC_HANDLER`.
-    pub fn svc_handler_arm_v7m();
+    ",
+    );
 }
 
+/// Handler of `svc` instructions on ARMv7-M.
+///
+/// For documentation of this function, please see
+/// [`CortexMVariant::SVC_HANDLER`].
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
-core::arch::global_asm!(
-    "
-    .section .svc_handler_arm_v7m, \"ax\"
-    .global svc_handler_arm_v7m
-    .thumb_func
-  svc_handler_arm_v7m:
+#[unsafe(naked)]
+pub unsafe extern "C" fn svc_handler_arm_v7m() {
+    use core::arch::naked_asm;
+    naked_asm!(
+        "
     // First check to see which direction we are going in. If the link register
     // (containing EXC_RETURN) has a 1 in the SPSEL bit (meaning the
     // alternative/process stack was in use) then we are coming from a process
@@ -133,23 +122,19 @@ core::arch::global_asm!(
 
     // Return to the kernel.
     bx lr
-    "
-);
-
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
-extern "C" {
-    /// Generic interrupt handler for ARMv7-M instruction sets.
-    ///
-    /// For documentation of this function, see `CortexMVariant::GENERIC_ISR`.
-    pub fn generic_isr_arm_v7m();
+    ",
+    );
 }
+
+/// Generic interrupt handler for ARMv7-M instruction sets.
+///
+/// For documentation of this function, see [`CortexMVariant::GENERIC_ISR`].
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
-core::arch::global_asm!(
+#[unsafe(naked)]
+pub unsafe extern "C" fn generic_isr_arm_v7m() {
+    use core::arch::naked_asm;
+    naked_asm!(
         "
-    .section .generic_isr_arm_v7m, \"ax\"
-    .global generic_isr_arm_v7m
-    .thumb_func
-  generic_isr_arm_v7m:
     // Use the CONTROL register to set the thread mode to privileged to ensure
     // we are executing as the kernel. This may be redundant if the interrupt
     // happened while the kernel code was executing.
@@ -214,7 +199,9 @@ core::arch::global_asm!(
     // doing. If an app was executing we will switch to the kernel so it can
     // choose whether to service the interrupt.
     bx lr
-    ");
+    ",
+    );
+}
 
 /// Assembly function to switch into userspace and store/restore application
 /// state.
@@ -435,27 +422,22 @@ unsafe extern "C" fn hard_fault_handler_arm_v7m_kernel(
     }
 }
 
+/// ARMv7-M hardfault handler.
+///
+/// For documentation of this function, please see
+/// [`CortexMVariant::HARD_FAULT_HANDLER_HANDLER`].
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
-extern "C" {
-    /// ARMv7-M hardfault handler.
-    ///
-    /// For documentation of this function, please see
-    /// `CortexMVariant::HARD_FAULT_HANDLER_HANDLER`.
-    pub fn hard_fault_handler_arm_v7m();
-}
+#[unsafe(naked)]
+pub unsafe extern "C" fn hard_fault_handler_arm_v7m() {
+    use core::arch::naked_asm;
+    // First need to determine if this a kernel fault or a userspace fault, and store
+    // the unmodified stack pointer. Place these values in registers, then call
+    // a non-naked function, to allow for use of rust code alongside inline asm.
+    // Because calling a function increases the stack pointer, we have to check for a kernel
+    // stack overflow and adjust the stack pointer before we branch
 
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
-// First need to determine if this a kernel fault or a userspace fault, and store
-// the unmodified stack pointer. Place these values in registers, then call
-// a non-naked function, to allow for use of rust code alongside inline asm.
-// Because calling a function increases the stack pointer, we have to check for a kernel
-// stack overflow and adjust the stack pointer before we branch
-core::arch::global_asm!(
+    naked_asm!(
     "
-        .section .hard_fault_handler_arm_v7m, \"ax\"
-        .global hard_fault_handler_arm_v7m
-        .thumb_func
-    hard_fault_handler_arm_v7m:
         mov    r2, 0     // r2 = 0
         tst    lr, #4    // bitwise AND link register to 0b100
         itte   eq        // if lr==4, run next two instructions, else, run 3rd instruction.
@@ -528,7 +510,8 @@ core::arch::global_asm!(
         bx lr",
     estack = sym _estack,
     kernel_hard_fault_handler = sym hard_fault_handler_arm_v7m_kernel,
-);
+    );
+}
 
 // Table 2.5
 // http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0553a/CHDBIBGJ.html

--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -45,104 +45,101 @@ extern "C" {
     static __global_pointer: usize;
 }
 
+/// Entry point of all programs (`_start`).
+///
+/// This assembly does three functions:
+///
+/// 1. It initializes the stack pointer, the frame pointer (needed for closures
+///    to work in start_rust) and the global pointer.
+/// 2. It initializes the .bss and .data RAM segments. This must be done before
+///    any Rust code runs. See <https://github.com/tock/tock/issues/2222> for more
+///    information.
+/// 3. Finally it calls `main()`, the main entry point for Tock boards.
 #[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
-extern "C" {
-    // Entry point of all programs (`_start`).
-    ///
-    /// This assembly does three functions:
-    ///
-    /// 1. It initializes the stack pointer, the frame pointer (needed for closures
-    ///    to work in start_rust) and the global pointer.
-    /// 2. It initializes the .bss and .data RAM segments. This must be done before
-    ///    any Rust code runs. See <https://github.com/tock/tock/issues/2222> for more
-    ///    information.
-    /// 3. Finally it calls `main()`, the main entry point for Tock boards.
-    pub fn _start();
+#[link_section = ".riscv.start"]
+#[export_name = "_start"]
+#[unsafe(naked)]
+pub extern "C" fn _start() {
+    use core::arch::naked_asm;
+    naked_asm! ("
+        // Set the global pointer register using the variable defined in the
+        // linker script. This register is only set once. The global pointer
+        // is a method for sharing state between the linker and the CPU so
+        // that the linker can emit code with offsets that are relative to
+        // the gp register, and the CPU can successfully execute them.
+        //
+        // https://gnu-mcu-eclipse.github.io/arch/riscv/programmer/#the-gp-global-pointer-register
+        // https://groups.google.com/a/groups.riscv.org/forum/#!msg/sw-dev/60IdaZj27dY/5MydPLnHAQAJ
+        // https://www.sifive.com/blog/2017/08/28/all-aboard-part-3-linker-relaxation-in-riscv-toolchain/
+        //
+        // Disable linker relaxation for code that sets up GP so that this doesn't
+        // get turned into `mv gp, gp`.
+        .option push
+        .option norelax
+
+        la gp, {gp}                 // Set the global pointer from linker script.
+
+        // Re-enable linker relaxations.
+        .option pop
+
+        // Initialize the stack pointer register. This comes directly from
+        // the linker script.
+        la sp, {estack}             // Set the initial stack pointer.
+
+        // Set s0 (the frame pointer) to the start of the stack.
+        add  s0, sp, zero           // s0 = sp
+
+        // Initialize mscratch to 0 so that we know that we are currently
+        // in the kernel. This is used for the check in the trap handler.
+        csrw 0x340, zero            // CSR=0x340=mscratch
+
+        // INITIALIZE MEMORY
+
+        // Start by initializing .bss memory. The Tock linker script defines
+        // `_szero` and `_ezero` to mark the .bss segment.
+        la a0, {sbss}               // a0 = first address of .bss
+        la a1, {ebss}               // a1 = first address after .bss
+
+      100: // bss_init_loop
+        beq  a0, a1, 101f           // If a0 == a1, we are done.
+        sw   zero, 0(a0)            // *a0 = 0. Write 0 to the memory location in a0.
+        addi a0, a0, 4              // a0 = a0 + 4. Increment pointer to next word.
+        j 100b                      // Continue the loop.
+
+      101: // bss_init_done
+
+
+        // Now initialize .data memory. This involves coping the values right at the
+        // end of the .text section (in flash) into the .data section (in RAM).
+        la a0, {sdata}              // a0 = first address of data section in RAM
+        la a1, {edata}              // a1 = first address after data section in RAM
+        la a2, {etext}              // a2 = address of stored data initial values
+
+      200: // data_init_loop
+        beq  a0, a1, 201f           // If we have reached the end of the .data
+                                    // section then we are done.
+        lw   a3, 0(a2)              // a3 = *a2. Load value from initial values into a3.
+        sw   a3, 0(a0)              // *a0 = a3. Store initial value into
+                                    // next place in .data.
+        addi a0, a0, 4              // a0 = a0 + 4. Increment to next word in memory.
+        addi a2, a2, 4              // a2 = a2 + 4. Increment to next word in flash.
+        j 200b                      // Continue the loop.
+
+      201: // data_init_done
+
+        // With that initial setup out of the way, we now branch to the main
+        // code, likely defined in a board's main.rs.
+        j main
+    ",
+        gp = sym __global_pointer,
+        estack = sym _estack,
+        sbss = sym _szero,
+        ebss = sym _ezero,
+        sdata = sym _srelocate,
+        edata = sym _erelocate,
+        etext = sym _etext,
+    );
 }
-
-#[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
-core::arch::global_asm!("
-            .section .riscv.start, \"ax\"
-            .globl _start
-          _start:
-
-            // Set the global pointer register using the variable defined in the
-            // linker script. This register is only set once. The global pointer
-            // is a method for sharing state between the linker and the CPU so
-            // that the linker can emit code with offsets that are relative to
-            // the gp register, and the CPU can successfully execute them.
-            //
-            // https://gnu-mcu-eclipse.github.io/arch/riscv/programmer/#the-gp-global-pointer-register
-            // https://groups.google.com/a/groups.riscv.org/forum/#!msg/sw-dev/60IdaZj27dY/5MydPLnHAQAJ
-            // https://www.sifive.com/blog/2017/08/28/all-aboard-part-3-linker-relaxation-in-riscv-toolchain/
-            //
-            // Disable linker relaxation for code that sets up GP so that this doesn't
-            // get turned into `mv gp, gp`.
-            .option push
-            .option norelax
-
-            la gp, {gp}                 // Set the global pointer from linker script.
-
-            // Re-enable linker relaxations.
-            .option pop
-
-            // Initialize the stack pointer register. This comes directly from
-            // the linker script.
-            la sp, {estack}             // Set the initial stack pointer.
-
-            // Set s0 (the frame pointer) to the start of the stack.
-            add  s0, sp, zero           // s0 = sp
-
-            // Initialize mscratch to 0 so that we know that we are currently
-            // in the kernel. This is used for the check in the trap handler.
-            csrw 0x340, zero            // CSR=0x340=mscratch
-
-            // INITIALIZE MEMORY
-
-            // Start by initializing .bss memory. The Tock linker script defines
-            // `_szero` and `_ezero` to mark the .bss segment.
-            la a0, {sbss}               // a0 = first address of .bss
-            la a1, {ebss}               // a1 = first address after .bss
-
-          100: // bss_init_loop
-            beq  a0, a1, 101f           // If a0 == a1, we are done.
-            sw   zero, 0(a0)            // *a0 = 0. Write 0 to the memory location in a0.
-            addi a0, a0, 4              // a0 = a0 + 4. Increment pointer to next word.
-            j 100b                      // Continue the loop.
-
-          101: // bss_init_done
-
-
-            // Now initialize .data memory. This involves coping the values right at the
-            // end of the .text section (in flash) into the .data section (in RAM).
-            la a0, {sdata}              // a0 = first address of data section in RAM
-            la a1, {edata}              // a1 = first address after data section in RAM
-            la a2, {etext}              // a2 = address of stored data initial values
-
-          200: // data_init_loop
-            beq  a0, a1, 201f           // If we have reached the end of the .data
-                                        // section then we are done.
-            lw   a3, 0(a2)              // a3 = *a2. Load value from initial values into a3.
-            sw   a3, 0(a0)              // *a0 = a3. Store initial value into
-                                        // next place in .data.
-            addi a0, a0, 4              // a0 = a0 + 4. Increment to next word in memory.
-            addi a2, a2, 4              // a2 = a2 + 4. Increment to next word in flash.
-            j 200b                      // Continue the loop.
-
-          201: // data_init_done
-
-            // With that initial setup out of the way, we now branch to the main
-            // code, likely defined in a board's main.rs.
-            j main
-        ",
-gp = sym __global_pointer,
-estack = sym _estack,
-sbss = sym _szero,
-ebss = sym _ezero,
-sdata = sym _srelocate,
-edata = sym _erelocate,
-etext = sym _etext,
-);
 
 // Mock implementation for tests on Travis-CI.
 #[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
@@ -184,211 +181,209 @@ pub extern "C" fn _start_trap() {
     unimplemented!()
 }
 
+/// This is the trap handler function. This code is called on all traps,
+/// including interrupts, exceptions, and system calls from applications.
+///
+/// Tock uses only the single trap handler, and does not use any vectored
+/// interrupts or other exception handling. The trap handler has to
+/// determine why the trap handler was called, and respond
+/// accordingly. Generally, there are two reasons the trap handler gets
+/// called: an interrupt occurred or an application called a syscall.
+///
+/// In the case of an interrupt while the kernel was executing we only need
+/// to save the kernel registers and then run whatever interrupt handling
+/// code we need to. If the trap happens while an application was executing,
+/// we have to save the application state and then resume the `switch_to()`
+/// function to correctly return back to the kernel.
+///
+/// We implement this distinction through a branch on the value of the
+/// `mscratch` CSR. If, at the time the trap was taken, it contains `0`, we
+/// assume that the hart is currently executing kernel code.
+///
+/// If it contains any other value, we interpret it to be a memory address
+/// pointing to a particular data structure:
+///
+/// ```text
+/// mscratch           0               1               2               3
+///  \->|--------------------------------------------------------------|
+///     | scratch word, overwritten with s1 register contents          |
+///     |--------------------------------------------------------------|
+///     | trap handler address, continue trap handler execution here   |
+///     |--------------------------------------------------------------|
+/// ```
+///
+/// Thus, process implementations can define their own strategy for how
+/// traps should be handled when they occur during process execution. This
+/// global trap handler behavior is well defined. It will:
+///
+/// 1. atomically swap s0 and the mscratch CSR,
+///
+/// 2. execute the default kernel trap handler if s0 now contains `0`
+/// (meaning that the mscratch CSR contained `0` before entering this trap
+/// handler),
+///
+/// 3. otherwise, save s1 to `0*4(s0)`, and finally
+///
+/// 4. load the address at `1*4(s0)` into s1, and jump to it.
+///
+/// No registers other than s0, s1 and the mscratch CSR are to be clobbered
+/// before continuing execution at the address loaded into the mscratch CSR
+/// or the _start_kernel_trap kernel trap handler.  Execution with these
+/// second-stage trap handlers must continue in the same trap handler
+/// context as originally invoked by the trap (e.g., the global trap handler
+/// will not execute an mret instruction). It will not modify CSRs that
+/// contain information on the trap source or the system state prior to
+/// entering the trap handler.
+///
+/// We deliberately clobber callee-saved instead of caller-saved registers,
+/// as this makes it easier to call other functions as part of the trap
+/// handler (for example to to disable interrupts from within Rust
+/// code). This global trap handler saves the previous values of these
+/// clobbered registers ensuring that they can be restored later.  It places
+/// new values into these clobbered registers (such as the previous `s0`
+/// register contents) that are required to be retained for correctly
+/// returning from the trap handler, and as such need to be saved across
+/// C-ABI function calls. Loading them into saved registers avoids the need
+/// to manually save them across such calls.
+///
+/// When a custom trap handler stack is registered in `mscratch`, the custom
+/// handler is responsible for restoring the kernel trap handler (by setting
+/// mscratch=0) before returning to kernel execution from the trap handler
+/// context.
+///
+/// If a board or chip must, for whichever reason, use a different global
+/// trap handler, it should abide to the above contract and emulate its
+/// behavior for all traps and interrupts that are required to be handled by
+/// the respective kernel or other trap handler as registered in mscratch.
+///
+/// For instance, a chip that does not support non-vectored trap handlers
+/// can register a vectored trap handler that routes each trap source to
+/// this global trap handler.
+///
+/// Alternatively, a board can be allowed to ignore certain traps or
+/// interrupts, some or all of the time, provided they are not vital to
+/// Tock's execution. These boards may choose to register an alternative
+/// handler for some or all trap sources. When this alternative handler is
+/// invoked, it may, for instance, choose to ignore a certain trap, access
+/// global state (subject to synchronization), etc. It must still abide to
+/// the contract as stated above.
 #[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
-extern "C" {
-    /// This is the trap handler function. This code is called on all traps,
-    /// including interrupts, exceptions, and system calls from applications.
-    ///
-    /// Tock uses only the single trap handler, and does not use any vectored
-    /// interrupts or other exception handling. The trap handler has to
-    /// determine why the trap handler was called, and respond
-    /// accordingly. Generally, there are two reasons the trap handler gets
-    /// called: an interrupt occurred or an application called a syscall.
-    ///
-    /// In the case of an interrupt while the kernel was executing we only need
-    /// to save the kernel registers and then run whatever interrupt handling
-    /// code we need to. If the trap happens while an application was executing,
-    /// we have to save the application state and then resume the `switch_to()`
-    /// function to correctly return back to the kernel.
-    ///
-    /// We implement this distinction through a branch on the value of the
-    /// `mscratch` CSR. If, at the time the trap was taken, it contains `0`, we
-    /// assume that the hart is currently executing kernel code.
-    ///
-    /// If it contains any other value, we interpret it to be a memory address
-    /// pointing to a particular data structure:
-    ///
-    /// ```text
-    /// mscratch           0               1               2               3
-    ///  \->|--------------------------------------------------------------|
-    ///     | scratch word, overwritten with s1 register contents          |
-    ///     |--------------------------------------------------------------|
-    ///     | trap handler address, continue trap handler execution here   |
-    ///     |--------------------------------------------------------------|
-    /// ```
-    ///
-    /// Thus, process implementations can define their own strategy for how
-    /// traps should be handled when they occur during process execution. This
-    /// global trap handler behavior is well defined. It will:
-    ///
-    /// 1. atomically swap s0 and the mscratch CSR,
-    ///
-    /// 2. execute the default kernel trap handler if s0 now contains `0`
-    /// (meaning that the mscratch CSR contained `0` before entering this trap
-    /// handler),
-    ///
-    /// 3. otherwise, save s1 to `0*4(s0)`, and finally
-    ///
-    /// 4. load the address at `1*4(s0)` into s1, and jump to it.
-    ///
-    /// No registers other than s0, s1 and the mscratch CSR are to be clobbered
-    /// before continuing execution at the address loaded into the mscratch CSR
-    /// or the _start_kernel_trap kernel trap handler.  Execution with these
-    /// second-stage trap handlers must continue in the same trap handler
-    /// context as originally invoked by the trap (e.g., the global trap handler
-    /// will not execute an mret instruction). It will not modify CSRs that
-    /// contain information on the trap source or the system state prior to
-    /// entering the trap handler.
-    ///
-    /// We deliberately clobber callee-saved instead of caller-saved registers,
-    /// as this makes it easier to call other functions as part of the trap
-    /// handler (for example to to disable interrupts from within Rust
-    /// code). This global trap handler saves the previous values of these
-    /// clobbered registers ensuring that they can be restored later.  It places
-    /// new values into these clobbered registers (such as the previous `s0`
-    /// register contents) that are required to be retained for correctly
-    /// returning from the trap handler, and as such need to be saved across
-    /// C-ABI function calls. Loading them into saved registers avoids the need
-    /// to manually save them across such calls.
-    ///
-    /// When a custom trap handler stack is registered in `mscratch`, the custom
-    /// handler is responsible for restoring the kernel trap handler (by setting
-    /// mscratch=0) before returning to kernel execution from the trap handler
-    /// context.
-    ///
-    /// If a board or chip must, for whichever reason, use a different global
-    /// trap handler, it should abide to the above contract and emulate its
-    /// behavior for all traps and interrupts that are required to be handled by
-    /// the respective kernel or other trap handler as registered in mscratch.
-    ///
-    /// For instance, a chip that does not support non-vectored trap handlers
-    /// can register a vectored trap handler that routes each trap source to
-    /// this global trap handler.
-    ///
-    /// Alternatively, a board can be allowed to ignore certain traps or
-    /// interrupts, some or all of the time, provided they are not vital to
-    /// Tock's execution. These boards may choose to register an alternative
-    /// handler for some or all trap sources. When this alternative handler is
-    /// invoked, it may, for instance, choose to ignore a certain trap, access
-    /// global state (subject to synchronization), etc. It must still abide to
-    /// the contract as stated above.
-    pub fn _start_trap();
-}
+#[link_section = ".riscv.trap"]
+#[export_name = "_start_trap"]
+#[unsafe(naked)]
+pub extern "C" fn _start_trap() {
+    use core::arch::naked_asm;
+    naked_asm!(
+        "
+        // This is the global trap handler. By default, Tock expects this
+        // trap handler to be registered at all times, and that all traps
+        // and interrupts occurring in all modes of execution (M-, S-, and
+        // U-mode) will cause this trap handler to be executed.
+        //
+        // For documentation of its behavior, and how process
+        // implementations can hook their own trap handler code, see the
+        // comment on the `extern C _start_trap` symbol above.
 
-#[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
-core::arch::global_asm!(
-    "
-            .section .riscv.trap, \"ax\"
-            .globl _start_trap
-          _start_trap:
-            // This is the global trap handler. By default, Tock expects this
-            // trap handler to be registered at all times, and that all traps
-            // and interrupts occurring in all modes of execution (M-, S-, and
-            // U-mode) will cause this trap handler to be executed.
-            //
-            // For documentation of its behavior, and how process
-            // implementations can hook their own trap handler code, see the
-            // comment on the `extern C _start_trap` symbol above.
+        // Atomically swap s0 and mscratch:
+        csrrw s0, mscratch, s0        // s0 = mscratch; mscratch = s0
 
-            // Atomically swap s0 and mscratch:
-            csrrw s0, mscratch, s0        // s0 = mscratch; mscratch = s0
+        // If mscratch contained 0, invoke the kernel trap handler.
+        beq   s0, x0, 100f      // if s0==x0: goto 100
 
-            // If mscratch contained 0, invoke the kernel trap handler.
-            beq   s0, x0, 100f      // if s0==x0: goto 100
+        // Else, save the current value of s1 to `0*4(s0)`, load `1*4(s0)`
+        // into s1 and jump to it (invoking a custom trap handler).
+        sw    s1, 0*4(s0)       // *s0 = s1
+        lw    s1, 1*4(s0)       // s1 = *(s0+4)
+        jr    s1                // goto s1
 
-            // Else, save the current value of s1 to `0*4(s0)`, load `1*4(s0)`
-            // into s1 and jump to it (invoking a custom trap handler).
-            sw    s1, 0*4(s0)       // *s0 = s1
-            lw    s1, 1*4(s0)       // s1 = *(s0+4)
-            jr    s1                // goto s1
+      100: // _start_kernel_trap
 
-          100: // _start_kernel_trap
+        // The global trap handler has swapped s0 into mscratch. We can thus
+        // freely clobber s0 without losing any information.
+        //
+        // Since we want to use the stack to save kernel registers, we
+        // first need to make sure that the trap wasn't the result of a
+        // stack overflow, in which case we can't use the current stack
+        // pointer. Use s0 as a scratch register:
 
-            // The global trap handler has swapped s0 into mscratch. We can thus
-            // freely clobber s0 without losing any information.
-            //
-            // Since we want to use the stack to save kernel registers, we
-            // first need to make sure that the trap wasn't the result of a
-            // stack overflow, in which case we can't use the current stack
-            // pointer. Use s0 as a scratch register:
+        // Load the address of the bottom of the stack (`_sstack`) into our
+        // newly freed-up s0 register.
+        la s0, {sstack}                     // s0 = _sstack
 
-            // Load the address of the bottom of the stack (`_sstack`) into our
-            // newly freed-up s0 register.
-            la s0, {sstack}                     // s0 = _sstack
+        // Compare the kernel stack pointer to the bottom of the stack. If
+        // the stack pointer is above the bottom of the stack, then continue
+        // handling the fault as normal.
+        bgtu sp, s0, 200f                   // branch if sp > s0
 
-            // Compare the kernel stack pointer to the bottom of the stack. If
-            // the stack pointer is above the bottom of the stack, then continue
-            // handling the fault as normal.
-            bgtu sp, s0, 200f                   // branch if sp > s0
+        // If we get here, then we did encounter a stack overflow. We are
+        // going to panic at this point, but for that to work we need a
+        // valid stack to run the panic code. We do this by just starting
+        // over with the kernel stack and placing the stack pointer at the
+        // top of the original stack.
+        la sp, {estack}                     // sp = _estack
 
-            // If we get here, then we did encounter a stack overflow. We are
-            // going to panic at this point, but for that to work we need a
-            // valid stack to run the panic code. We do this by just starting
-            // over with the kernel stack and placing the stack pointer at the
-            // top of the original stack.
-            la sp, {estack}                     // sp = _estack
+    200: // _start_kernel_trap_continue
 
-        200: // _start_kernel_trap_continue
+        // Restore s0. We reset mscratch to 0 (kernel trap handler mode)
+        csrrw s0, mscratch, zero    // s0 = mscratch; mscratch = 0
 
-            // Restore s0. We reset mscratch to 0 (kernel trap handler mode)
-            csrrw s0, mscratch, zero    // s0 = mscratch; mscratch = 0
+        // Make room for the caller saved registers we need to restore after
+        // running any trap handler code.
+        addi sp, sp, -16*4
 
-            // Make room for the caller saved registers we need to restore after
-            // running any trap handler code.
-            addi sp, sp, -16*4
+        // Save all of the caller saved registers.
+        sw   ra, 0*4(sp)
+        sw   t0, 1*4(sp)
+        sw   t1, 2*4(sp)
+        sw   t2, 3*4(sp)
+        sw   t3, 4*4(sp)
+        sw   t4, 5*4(sp)
+        sw   t5, 6*4(sp)
+        sw   t6, 7*4(sp)
+        sw   a0, 8*4(sp)
+        sw   a1, 9*4(sp)
+        sw   a2, 10*4(sp)
+        sw   a3, 11*4(sp)
+        sw   a4, 12*4(sp)
+        sw   a5, 13*4(sp)
+        sw   a6, 14*4(sp)
+        sw   a7, 15*4(sp)
 
-            // Save all of the caller saved registers.
-            sw   ra, 0*4(sp)
-            sw   t0, 1*4(sp)
-            sw   t1, 2*4(sp)
-            sw   t2, 3*4(sp)
-            sw   t3, 4*4(sp)
-            sw   t4, 5*4(sp)
-            sw   t5, 6*4(sp)
-            sw   t6, 7*4(sp)
-            sw   a0, 8*4(sp)
-            sw   a1, 9*4(sp)
-            sw   a2, 10*4(sp)
-            sw   a3, 11*4(sp)
-            sw   a4, 12*4(sp)
-            sw   a5, 13*4(sp)
-            sw   a6, 14*4(sp)
-            sw   a7, 15*4(sp)
+        // Jump to board-specific trap handler code. Likely this was an
+        // interrupt and we want to disable a particular interrupt, but each
+        // board/chip can customize this as needed.
+        jal ra, _start_trap_rust_from_kernel
 
-            // Jump to board-specific trap handler code. Likely this was an
-            // interrupt and we want to disable a particular interrupt, but each
-            // board/chip can customize this as needed.
-            jal ra, _start_trap_rust_from_kernel
+        // Restore the registers from the stack.
+        lw   ra, 0*4(sp)
+        lw   t0, 1*4(sp)
+        lw   t1, 2*4(sp)
+        lw   t2, 3*4(sp)
+        lw   t3, 4*4(sp)
+        lw   t4, 5*4(sp)
+        lw   t5, 6*4(sp)
+        lw   t6, 7*4(sp)
+        lw   a0, 8*4(sp)
+        lw   a1, 9*4(sp)
+        lw   a2, 10*4(sp)
+        lw   a3, 11*4(sp)
+        lw   a4, 12*4(sp)
+        lw   a5, 13*4(sp)
+        lw   a6, 14*4(sp)
+        lw   a7, 15*4(sp)
 
-            // Restore the registers from the stack.
-            lw   ra, 0*4(sp)
-            lw   t0, 1*4(sp)
-            lw   t1, 2*4(sp)
-            lw   t2, 3*4(sp)
-            lw   t3, 4*4(sp)
-            lw   t4, 5*4(sp)
-            lw   t5, 6*4(sp)
-            lw   t6, 7*4(sp)
-            lw   a0, 8*4(sp)
-            lw   a1, 9*4(sp)
-            lw   a2, 10*4(sp)
-            lw   a3, 11*4(sp)
-            lw   a4, 12*4(sp)
-            lw   a5, 13*4(sp)
-            lw   a6, 14*4(sp)
-            lw   a7, 15*4(sp)
+        // Reset the stack pointer.
+        addi sp, sp, 16*4
 
-            // Reset the stack pointer.
-            addi sp, sp, 16*4
-
-            // mret returns from the trap handler. The PC is set to what is in
-            // mepc and execution proceeds from there. Since we did not modify
-            // mepc we will return to where the exception occurred.
-            mret
+        // mret returns from the trap handler. The PC is set to what is in
+        // mepc and execution proceeds from there. Since we did not modify
+        // mepc we will return to where the exception occurred.
+        mret
     ",
     estack = sym _estack,
     sstack = sym _sstack,
-);
+    );
+}
 
 /// RISC-V semihosting needs three exact instructions in uncompressed form.
 ///

--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -57,7 +57,6 @@ extern "C" {
 /// 3. Finally it calls `main()`, the main entry point for Tock boards.
 #[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
 #[link_section = ".riscv.start"]
-#[export_name = "_start"]
 #[unsafe(naked)]
 pub extern "C" fn _start() {
     use core::arch::naked_asm;
@@ -269,7 +268,6 @@ pub extern "C" fn _start_trap() {
 /// the contract as stated above.
 #[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
 #[link_section = ".riscv.trap"]
-#[export_name = "_start_trap"]
 #[unsafe(naked)]
 pub extern "C" fn _start_trap() {
     use core::arch::naked_asm;

--- a/boards/hail/Cargo.toml
+++ b/boards/hail/Cargo.toml
@@ -8,7 +8,7 @@ version.workspace = true
 authors.workspace = true
 build = "../build.rs"
 edition.workspace = true
-rust-version = "1.84"
+rust-version = "1.88"
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -147,7 +147,7 @@ impl KernelResources<Rp2040<'static, Rp2040DefaultPeripherals<'static>>> for Nan
     }
 }
 
-/// Entry point used for debuger
+/// Entry point used for debugger.
 ///
 /// When loaded using gdb, the Arduino Nano RP2040 Connect is not reset
 /// by default. Without this function, gdb sets the PC to the
@@ -156,7 +156,7 @@ impl KernelResources<Rp2040<'static, Rp2040DefaultPeripherals<'static>>> for Nan
 ///
 /// This function is set to be the entry point for gdb and is used
 /// to send the RP2040 back in the bootloader so that all the boot
-/// sqeuence is performed.
+/// sequence is performed.
 #[no_mangle]
 #[unsafe(naked)]
 pub unsafe extern "C" fn jump_to_bootloader() {

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -147,36 +147,31 @@ impl KernelResources<Rp2040<'static, Rp2040DefaultPeripherals<'static>>> for Nan
     }
 }
 
-#[allow(dead_code)]
-extern "C" {
-    /// Entry point used for debugger
-    ///
-    /// When loaded using gdb, the Arduino Nano RP2040 Connect is not reset
-    /// by default. Without this function, gdb sets the PC to the
-    /// beginning of the flash. This is not correct, as the RP2040
-    /// has a more complex boot process.
-    ///
-    /// This function is set to be the entry point for gdb and is used
-    /// to send the RP2040 back in the bootloader so that all the boot
-    /// sequence is performed.
-    fn jump_to_bootloader();
-}
-
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
-core::arch::global_asm!(
-    "
-    .section .jump_to_bootloader, \"ax\"
-    .global jump_to_bootloader
-    .thumb_func
-  jump_to_bootloader:
+/// Entry point used for debuger
+///
+/// When loaded using gdb, the Arduino Nano RP2040 Connect is not reset
+/// by default. Without this function, gdb sets the PC to the
+/// beginning of the flash. This is not correct, as the RP2040
+/// has a more complex boot process.
+///
+/// This function is set to be the entry point for gdb and is used
+/// to send the RP2040 back in the bootloader so that all the boot
+/// sqeuence is performed.
+#[no_mangle]
+#[unsafe(naked)]
+pub unsafe extern "C" fn jump_to_bootloader() {
+    use core::arch::naked_asm;
+    naked_asm!(
+        "
     movs r0, #0
     ldr r1, =(0xe0000000 + 0x0000ed08)
     str r0, [r1]
     ldmia r0!, {{r1, r2}}
     msr msp, r1
     bx r2
-    "
-);
+    ",
+    );
+}
 
 fn init_clocks(peripherals: &Rp2040DefaultPeripherals) {
     // Start tick in watchdog

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -159,7 +159,7 @@ impl KernelResources<Rp2040<'static, Rp2040DefaultPeripherals<'static>>> for Pic
     }
 }
 
-/// Entry point used for debuger
+/// Entry point used for debugger.
 ///
 /// When loaded using gdb, the Raspberry Pi Pico is not reset
 /// by default. Without this function, gdb sets the PC to the
@@ -168,7 +168,7 @@ impl KernelResources<Rp2040<'static, Rp2040DefaultPeripherals<'static>>> for Pic
 ///
 /// This function is set to be the entry point for gdb and is used
 /// to send the RP2040 back in the bootloader so that all the boot
-/// sqeuence is performed.
+/// sequence is performed.
 #[no_mangle]
 #[unsafe(naked)]
 pub unsafe extern "C" fn jump_to_bootloader() {

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -159,36 +159,31 @@ impl KernelResources<Rp2040<'static, Rp2040DefaultPeripherals<'static>>> for Pic
     }
 }
 
-#[allow(dead_code)]
-extern "C" {
-    /// Entry point used for debugger
-    ///
-    /// When loaded using gdb, the Raspberry Pi Pico is not reset
-    /// by default. Without this function, gdb sets the PC to the
-    /// beginning of the flash. This is not correct, as the RP2040
-    /// has a more complex boot process.
-    ///
-    /// This function is set to be the entry point for gdb and is used
-    /// to send the RP2040 back in the bootloader so that all the boot
-    /// sequence is performed.
-    fn jump_to_bootloader();
-}
-
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
-core::arch::global_asm!(
-    "
-    .section .jump_to_bootloader, \"ax\"
-    .global jump_to_bootloader
-    .thumb_func
-  jump_to_bootloader:
+/// Entry point used for debuger
+///
+/// When loaded using gdb, the Raspberry Pi Pico is not reset
+/// by default. Without this function, gdb sets the PC to the
+/// beginning of the flash. This is not correct, as the RP2040
+/// has a more complex boot process.
+///
+/// This function is set to be the entry point for gdb and is used
+/// to send the RP2040 back in the bootloader so that all the boot
+/// sqeuence is performed.
+#[no_mangle]
+#[unsafe(naked)]
+pub unsafe extern "C" fn jump_to_bootloader() {
+    use core::arch::naked_asm;
+    naked_asm!(
+        "
     movs r0, #0
     ldr r1, =(0xe0000000 + 0x0000ed08)
     str r0, [r1]
     ldmia r0!, {{r1, r2}}
     msr msp, r1
     bx r2
-    "
-);
+    ",
+    );
+}
 
 fn init_clocks(peripherals: &Rp2040DefaultPeripherals) {
     // Start tick in watchdog

--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -149,36 +149,31 @@ impl KernelResources<Rp2040<'static, Rp2040DefaultPeripherals<'static>>> for Ras
     }
 }
 
-#[allow(dead_code)]
-extern "C" {
-    /// Entry point used for debugger
-    ///
-    /// When loaded using gdb, the Raspberry Pi Pico is not reset
-    /// by default. Without this function, gdb sets the PC to the
-    /// beginning of the flash. This is not correct, as the RP2040
-    /// has a more complex boot process.
-    ///
-    /// This function is set to be the entry point for gdb and is used
-    /// to send the RP2040 back in the bootloader so that all the boot
-    /// sequence is performed.
-    fn jump_to_bootloader();
-}
-
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
-core::arch::global_asm!(
-    "
-    .section .jump_to_bootloader, \"ax\"
-    .global jump_to_bootloader
-    .thumb_func
-  jump_to_bootloader:
+/// Entry point used for debugger
+///
+/// When loaded using gdb, the Raspberry Pi Pico is not reset
+/// by default. Without this function, gdb sets the PC to the
+/// beginning of the flash. This is not correct, as the RP2040
+/// has a more complex boot process.
+///
+/// This function is set to be the entry point for gdb and is used
+/// to send the RP2040 back in the bootloader so that all the boot
+/// sequence is performed.
+#[no_mangle]
+#[unsafe(naked)]
+pub unsafe extern "C" fn jump_to_bootloader() {
+    use core::arch::naked_asm;
+    naked_asm!(
+        "
     movs r0, #0
     ldr r1, =(0xe0000000 + 0x0000ed08)
     str r0, [r1]
     ldmia r0!, {{r1, r2}}
     msr msp, r1
     bx r2
-    "
-);
+    ",
+    );
+}
 
 fn init_clocks(peripherals: &Rp2040DefaultPeripherals) {
     // Start tick in watchdog

--- a/chips/arty_e21_chip/src/chip.rs
+++ b/chips/arty_e21_chip/src/chip.rs
@@ -12,10 +12,6 @@ use crate::clint;
 use crate::interrupts;
 use rv32i::pmp::{simple::SimplePMP, PMPUserMPU};
 
-extern "C" {
-    fn _start_trap();
-}
-
 pub type ArtyExxClint<'a> = sifive::clint::Clint<'a, Freq32KHz>;
 
 pub struct ArtyExx<'a, I: InterruptService + 'a> {
@@ -122,11 +118,12 @@ impl<'a, I: InterruptService + 'a> ArtyExx<'a, I> {
             // address of the trap handler. We do not care about its old value,
             // so we don't bother reading it. We want to enable direct CLIC mode
             // so we set the second lowest bit.
-            lui  t0, %hi(_start_trap)
-            addi t0, t0, %lo(_start_trap)
+            lui  t0, %hi({start_trap})
+            addi t0, t0, %lo({start_trap})
             ori  t0, t0, 0x02 // Set CLIC direct mode
             csrw 0x305, t0    // Write the mtvec CSR.
             ",
+            start_trap = sym rv32i::_start_trap,
             out("t0") _
         );
     }

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -452,56 +452,53 @@ pub extern "C" fn _earlgrey_start_trap_vectored() {
 }
 
 #[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
-extern "C" {
-    pub fn _earlgrey_start_trap_vectored();
+#[link_section = ".riscv.trap_vectored"]
+#[export_name = "_start_trap_vectored"]
+#[unsafe(naked)]
+pub extern "C" fn _earlgrey_start_trap_vectored() -> ! {
+    use core::arch::naked_asm;
+    // According to the Ibex user manual:
+    // [NMI] has interrupt ID 31, i.e., it has the highest priority of all
+    // interrupts and the core jumps to the trap-handler base address (in
+    // mtvec) plus 0x7C to handle the NMI.
+    //
+    // Below are 32 (non-compressed) jumps to cover the entire possible
+    // range of vectored traps.
+    naked_asm!(
+        "
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        ",
+        start_trap = sym rv32i::_start_trap,
+    );
 }
-
-#[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
-// According to the Ibex user manual:
-// [NMI] has interrupt ID 31, i.e., it has the highest priority of all
-// interrupts and the core jumps to the trap-handler base address (in
-// mtvec) plus 0x7C to handle the NMI.
-//
-// Below are 32 (non-compressed) jumps to cover the entire possible
-// range of vectored traps.
-core::arch::global_asm!(
-    "
-            .section .riscv.trap_vectored, \"ax\"
-            .globl _start_trap_vectored
-          _earlgrey_start_trap_vectored:
-
-            j {start_trap}
-            j {start_trap}
-            j {start_trap}
-            j {start_trap}
-            j {start_trap}
-            j {start_trap}
-            j {start_trap}
-            j {start_trap}
-            j {start_trap}
-            j {start_trap}
-            j {start_trap}
-            j {start_trap}
-            j {start_trap}
-            j {start_trap}
-            j {start_trap}
-            j {start_trap}
-            j {start_trap}
-            j {start_trap}
-            j {start_trap}
-            j {start_trap}
-            j {start_trap}
-            j {start_trap}
-            j {start_trap}
-            j {start_trap}
-            j {start_trap}
-            j {start_trap}
-            j {start_trap}
-            j {start_trap}
-            j {start_trap}
-            j {start_trap}
-            j {start_trap}
-            j {start_trap}
-    ",
-    start_trap = sym rv32i::_start_trap,
-);

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -453,7 +453,6 @@ pub extern "C" fn _earlgrey_start_trap_vectored() {
 
 #[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
 #[link_section = ".riscv.trap_vectored"]
-#[export_name = "_start_trap_vectored"]
 #[unsafe(naked)]
 pub extern "C" fn _earlgrey_start_trap_vectored() -> ! {
     use core::arch::naked_asm;

--- a/chips/esp32-c3/src/chip.rs
+++ b/chips/esp32-c3/src/chip.rs
@@ -299,7 +299,6 @@ pub extern "C" fn _start_trap_vectored() {
 
 #[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
 #[link_section = ".riscv.trap_vectored"]
-#[export_name = "_start_trap_vectored"]
 #[unsafe(naked)]
 pub extern "C" fn _start_trap_vectored() -> ! {
     use core::arch::naked_asm;
@@ -307,37 +306,39 @@ pub extern "C" fn _start_trap_vectored() -> ! {
     // range of vectored traps.
     naked_asm!(
         "
-        j _start_trap
-        j _start_trap
-        j _start_trap
-        j _start_trap
-        j _start_trap
-        j _start_trap
-        j _start_trap
-        j _start_trap
-        j _start_trap
-        j _start_trap
-        j _start_trap
-        j _start_trap
-        j _start_trap
-        j _start_trap
-        j _start_trap
-        j _start_trap
-        j _start_trap
-        j _start_trap
-        j _start_trap
-        j _start_trap
-        j _start_trap
-        j _start_trap
-        j _start_trap
-        j _start_trap
-        j _start_trap
-        j _start_trap
-        j _start_trap
-        j _start_trap
-        j _start_trap
-        j _start_trap
-        j _start_trap
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
+        j {start_trap}
         ",
+        start_trap = sym rv32i::_start_trap,
     );
 }

--- a/chips/esp32-c3/src/chip.rs
+++ b/chips/esp32-c3/src/chip.rs
@@ -298,48 +298,46 @@ pub extern "C" fn _start_trap_vectored() {
 }
 
 #[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
-extern "C" {
-    pub fn _start_trap_vectored();
-}
-
-#[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
-// Below are 32 (non-compressed) jumps to cover the entire possible
-// range of vectored traps.
-core::arch::global_asm!(
-    "
-            .section .riscv.trap_vectored, \"ax\"
-            .globl _start_trap_vectored
-          _start_trap_vectored:
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
-            j _start_trap
+#[link_section = ".riscv.trap_vectored"]
+#[export_name = "_start_trap_vectored"]
+#[unsafe(naked)]
+pub extern "C" fn _start_trap_vectored() -> ! {
+    use core::arch::naked_asm;
+    // Below are 32 (non-compressed) jumps to cover the entire possible
+    // range of vectored traps.
+    naked_asm!(
         "
-);
+        j _start_trap
+        j _start_trap
+        j _start_trap
+        j _start_trap
+        j _start_trap
+        j _start_trap
+        j _start_trap
+        j _start_trap
+        j _start_trap
+        j _start_trap
+        j _start_trap
+        j _start_trap
+        j _start_trap
+        j _start_trap
+        j _start_trap
+        j _start_trap
+        j _start_trap
+        j _start_trap
+        j _start_trap
+        j _start_trap
+        j _start_trap
+        j _start_trap
+        j _start_trap
+        j _start_trap
+        j _start_trap
+        j _start_trap
+        j _start_trap
+        j _start_trap
+        j _start_trap
+        j _start_trap
+        j _start_trap
+        ",
+    );
+}


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the Rust compiler to the newly-released 1.88.0 and brings back naked functions instead of global_asm!() now that naked functions have been [stabilized](https://github.com/rust-lang/rust/pull/134213). 

You should definitely hide whitespace changes when reviewing this PR.

### Testing Strategy

This pull request was tested by compiling hail and imix.

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
