### PR TITLE
dyn_binary_storage: fix load process done callback

### DIFF
--- a/kernel/src/dynamic_binary_storage.rs
+++ b/kernel/src/dynamic_binary_storage.rs
@@ -443,7 +443,11 @@ impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileSto
         });
     }
 
-    fn process_loading_finished(&self) {}
+    fn process_loading_finished(&self) {
+        self.load_client.map(|client| {
+            client.load_done(Ok(()));
+        });
+    }
 }
 
 /// Storage interface exposed to the app_loader capsule


### PR DESCRIPTION

### Pull Request Overview

This pull request fixes the dynamic process load not returning an upcall when the last app in the load scheme is a duplicate. This causes the process loader to hang because there is no load_done callback from the `SequentialProcessLoadingMachine`.


### Testing Strategy

This pull request was tested by verifying a fault causing action no longer causes the fault via a libtock-c app.


### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
