### PR TITLE
Change `tock-dev@googlegroups.com` to `devel@lists.tockos.org`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ resolver = "2"
 
 [workspace.package]
 version = "0.2.3-dev"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+authors = ["Tock Project Developers <devel@lists.tockos.org>"]
 edition = "2021"
 
 [profile.dev]

--- a/boards/particle_boron/Cargo.toml
+++ b/boards/particle_boron/Cargo.toml
@@ -6,7 +6,7 @@
 name = "particle_boron"
 version.workspace = true
 authors = [
-    "Tock Project Developers <tock-dev@googlegroups.com>",
+    "Tock Project Developers <devel@lists.tockos.org>",
     "Wilfred Mallawa <vindulawilfred@gmail.com>"
     ]
 build = "../build.rs"

--- a/boards/sma_q3/Cargo.toml
+++ b/boards/sma_q3/Cargo.toml
@@ -6,7 +6,7 @@
 name = "sma_q3"
 version.workspace = true
 authors = [
-    "Tock Project Developers <tock-dev@googlegroups.com>",
+    "Tock Project Developers <devel@lists.tockos.org>",
     "Dorota <gihu.dcz@porcupinefactory.org>"
 ]
 build = "../build.rs"

--- a/doc/reference/trd-appid.md
+++ b/doc/reference/trd-appid.md
@@ -9,7 +9,7 @@ Application IDs (AppID), Credentials, and Process Loading
 **Draft-Created:** 2021/09/01 <br/>
 **Draft-Modified:** 2022/10/14 <br/>
 **Draft-Version:** 10 <br/>
-**Draft-Discuss:** tock-dev@googlegroups.com<br/>
+**Draft-Discuss:** devel@lists.tockos.org<br/>
 
 Abstract
 -------------------------------

--- a/doc/reference/trd-digest.md
+++ b/doc/reference/trd-digest.md
@@ -9,7 +9,7 @@ Digest HIL
 **Draft-Created:** June 8, 2022<br/>
 **Draft-Modified:** June 8, 2022<br/>
 **Draft-Version:** 1<br/>
-**Draft-Discuss:** tock-dev@googlegroups.com</br>
+**Draft-Discuss:** devel@lists.tockos.org</br>
 
 Abstract
 -------------------------------

--- a/doc/reference/trd-radio.md
+++ b/doc/reference/trd-radio.md
@@ -9,7 +9,7 @@ Kernel 802.15.4 Radio HIL
 **Draft-Created:** Feb 14, 2017<br/>
 **Draft-Modified:** Mar 20, 2017<br/>
 **Draft-Version:** 2<br/>
-**Draft-Discuss:** tock-dev@googlegroups.com</br>
+**Draft-Discuss:** devel@lists.tockos.org</br>
 
 Abstract
 -------------------------------

--- a/doc/reference/trd-spi.md
+++ b/doc/reference/trd-spi.md
@@ -9,7 +9,7 @@ Kernel Serial Peripheral Interface (SPI) HIL
 **Draft-Created:** 2021/08/13 <br/>
 **Draft-Modified:** 2021/08/13 <br/>
 **Draft-Version:** 2 <br/>
-**Draft-Discuss:** tock-dev@googlegroups.com<br/>
+**Draft-Discuss:** devel@lists.tockos.org<br/>
 
 Abstract
 -------------------------------

--- a/doc/reference/trd-uart.md
+++ b/doc/reference/trd-uart.md
@@ -9,7 +9,7 @@ Universal Asynchronous Receiver Transmitter (UART)  HIL
 **Draft-Created:** August 5, 2021<br/>
 **Draft-Modified:** June 5, 2022<br/>
 **Draft-Version:** 5<br/>
-**Draft-Discuss:** tock-dev@googlegroups.com</br>
+**Draft-Discuss:** devel@lists.tockos.org</br>
 
 Abstract
 -------------------------------

--- a/doc/reference/trd-userspace-readable-allow-syscalls.md
+++ b/doc/reference/trd-userspace-readable-allow-syscalls.md
@@ -9,7 +9,7 @@ Userspace Readable Allow System Call
 **Draft-Created:** June 17, 2021<br/>
 **Draft-Modified:** Sep 8, 2021<br/>
 **Draft-Version:** 2<br/>
-**Draft-Discuss:** tock-dev@googlegroups.com</br>
+**Draft-Discuss:** devel@lists.tockos.org</br>
 
 Abstract
 -------------------------------

--- a/doc/reference/trd102-adc.md
+++ b/doc/reference/trd102-adc.md
@@ -9,7 +9,7 @@ Kernel Analog-to-Digital Conversion HIL
 **Draft-Created:** Dec 18, 2016<br/>
 **Draft-Modified:** June 12, 2017<br/>
 **Draft-Version:** 2<br/>
-**Draft-Discuss:** tock-dev@googlegroups.com</br>
+**Draft-Discuss:** devel@lists.tockos.org</br>
 
 Abstract
 -------------------------------

--- a/doc/reference/trd103-gpio.md
+++ b/doc/reference/trd103-gpio.md
@@ -9,7 +9,7 @@ Kernel General Purpose I/O (GPIO) HIL
 **Draft-Created:** Feb 05, 2017<br/>
 **Draft-Modified:** April 09, 2021<br/>
 **Draft-Version:** 3<br/>
-**Draft-Discuss:** tock-dev@googlegroups.com</br>
+**Draft-Discuss:** devel@lists.tockos.org</br>
 
 Abstract
 -------------------------------

--- a/doc/reference/trd104-syscalls.md
+++ b/doc/reference/trd104-syscalls.md
@@ -9,7 +9,7 @@ System Calls
 **Draft-Created:** August 31, 2020<br/>
 **Draft-Modified:** January 29, 2025<br/>
 **Draft-Version:** 11<br/>
-**Draft-Discuss:** tock-dev@googlegroups.com</br>
+**Draft-Discuss:** devel@lists.tockos.org</br>
 
 Abstract
 -------------------------------

--- a/doc/reference/trd106-completion-codes.md
+++ b/doc/reference/trd106-completion-codes.md
@@ -9,7 +9,7 @@ Application Completion Codes
 **Draft-Created:** December 6, 2021<br/>
 **Draft-Modified:** January 25, 2022<br/>
 **Draft-Version:** 1<br/>
-**Draft-Discuss:** tock-dev@googlegroups.com</br>
+**Draft-Discuss:** devel@lists.tockos.org</br>
 
 Abstract
 -------------------------------

--- a/libraries/riscv-csr/Cargo.toml
+++ b/libraries/riscv-csr/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "riscv-csr"
 version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+authors = ["Tock Project Developers <devel@lists.tockos.org>"]
 description = "RISC-V CSR interface developed for Tock."
 homepage = "https://www.tockos.org/"
 repository = "https://github.com/tock/tock/tree/master/libraries/riscv-csr"

--- a/libraries/tock-cells/Cargo.toml
+++ b/libraries/tock-cells/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "tock-cells"
 version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+authors = ["Tock Project Developers <devel@lists.tockos.org>"]
 edition = "2021"
 
 

--- a/libraries/tock-register-interface/Cargo.toml
+++ b/libraries/tock-register-interface/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "tock-registers"
 version = "0.10.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+authors = ["Tock Project Developers <devel@lists.tockos.org>"]
 description = "Memory-Mapped I/O and register interface developed for Tock."
 homepage = "https://www.tockos.org/"
 repository = "https://github.com/tock/tock/tree/master/libraries/tock-register-interface"

--- a/libraries/tock-tbf/Cargo.toml
+++ b/libraries/tock-tbf/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "tock-tbf"
 version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+authors = ["Tock Project Developers <devel@lists.tockos.org>"]
 edition = "2021"
 
 [lints]

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -17,5 +17,5 @@ members = [
 resolver = "2"
 
 [workspace.package]
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+authors = ["Tock Project Developers <devel@lists.tockos.org>"]
 edition = "2021"


### PR DESCRIPTION
### Pull Request Overview

This pull request changes all mentions of the old `tock-dev@googlegroups.com` to the new `devel@lists.tockos.org` mailing list thoughout the repository. I noticed that we're still including the old mailing list in releases to `crates.io` (e.g., for `tock-registers`).


### Testing Strategy

N/A


### TODO or Help Wanted

~~Can we update the metadata of stablized TRDs like that? I have a feeling that this is OK, because we're not materially changing the TRDs contents, and providing up to date and accurate metadata is important for if someone wants to engange in discussions on the TRD itself.~~

It seems like only draft TRDs have the `Draft-Discuss` header anyways:

> If a TRD is a Draft, then four additional fields MUST be included: Draft-Created, Draft-Modified, Draft-Version, and Draft-Discuss.

As for the version update, it's debatable if this change requires a version update:

> Draft-Version specifies the version of the draft, which MUST increase every time a modification is made.

We're not really changing anything about the TRD itself, so I think we're fine not incrementing the version.

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
