### PR TITLE
Fixed the remove_pending_upcalls return value computation

### DIFF
--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -574,7 +574,7 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
                     count_before - count_after,
                 );
             }
-            count_after - count_before
+            count_before - count_after
         })
     }
 


### PR DESCRIPTION
### Pull Request Overview

This pull request adds/changes/fixes the computation of remaining upcalls when using `remove_pending_upcalls` function in `process_standard.rs`.


### Testing Strategy

This pull request was tested by @addrian-77 when implementing `yield_wait_for` in `libtock-rs`.


### TODO or Help Wanted

N/A


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
