### PR TITLE
RFC: AES Symmetric Encryption HIL Redesign 

### DIFF
--- a/kernel/src/hil/symmetric_encryption.rs
+++ b/kernel/src/hil/symmetric_encryption.rs
@@ -4,14 +4,22 @@
 
 //! Interface for symmetric-cipher encryption
 //!
-//! see boards/imix/src/aes_test.rs for example usage
+//! (TODO) Update usage example.
 
-use crate::ErrorCode;
+use crate::{
+    utilities::leasable_buffer::{SubSlice, SubSliceMut},
+    ErrorCode,
+};
 
 /// Implement this trait and use `set_client()` in order to receive callbacks from an `AES128`
-/// instance.
+/// instance. This returns the provided source. The `dest` contains the result of the operation
+/// and in both cases the `SubSliceMut` provided to `crypt()` will be returned.
 pub trait Client<'a> {
-    fn crypt_done(&'a self, source: Option<&'static mut [u8]>, dest: &'static mut [u8]);
+    fn crypt_done(
+        &'a self,
+        source: Option<SubSlice<'static, u8>>,
+        dest: Result<SubSliceMut<'static, u8>, (ErrorCode, SubSliceMut<'static, u8>)>,
+    );
 }
 
 /// The number of bytes used for AES block operations.  Keys and IVs must have this length,
@@ -19,14 +27,8 @@ pub trait Client<'a> {
 pub const AES128_BLOCK_SIZE: usize = 16;
 pub const AES128_KEY_SIZE: usize = 16;
 
+/// Implement this trait for hardware supported AES128 operation.
 pub trait AES128<'a> {
-    /// Enable the AES hardware.
-    /// Must be called before any other methods
-    fn enable(&self);
-
-    /// Disable the AES hardware
-    fn disable(&self);
-
     /// Set the client instance which will receive `crypt_done()` callbacks
     fn set_client(&'a self, client: &'a dyn Client<'a>);
 
@@ -49,31 +51,25 @@ pub trait AES128<'a> {
 
     /// Request an encryption/decryption
     ///
-    /// If the source buffer is not `None`, the encryption input
-    /// will be that entire buffer.  Otherwise the destination buffer
-    /// at indices between `start_index` and `stop_index` will
-    /// provide the input, which will be overwritten.
+    /// If the source buffer is `Some`, the active region of the source
+    /// SubSlice serves as the crypt input. Otherwise the destination buffer
+    /// from the active subslice region will provide the input, which
+    /// will be overwritten.
     ///
-    /// If `None` is returned, the client's `crypt_done` method will eventually
-    /// be called, and the portion of the data buffer between `start_index`
-    /// and `stop_index` will hold the result of the encryption/decryption.
+    /// If `Ok(())` is returned, the client's `crypt_done` method will eventually
+    /// be called, and the portion of the active region of the destination buffer
+    /// will hold the result of the encryption/decryption.
     ///
-    /// If `Some(result, source, dest)` is returned, `result` is the
+    /// If `Err(result, source, dest)` is returned, `result` is the
     /// error condition and `source` and `dest` are the buffers that
     /// were passed to `crypt`.
     ///
-    /// The indices `start_index` and `stop_index` must be valid
-    /// offsets in the destination buffer, and the length
-    /// `stop_index - start_index` must be a multiple of
-    /// `AES128_BLOCK_SIZE`.  Otherwise, `Some(INVAL, ...)` will be
-    /// returned.
-    ///
-    /// If the source buffer is not `None`, its length must be
-    /// `stop_index - start_index`.  Otherwise, `Some(INVAL, ...)`
-    /// will be returned.
+    /// The active regions of the `source` and `dest` subslice must be the same
+    /// length (if a source buffer is provided) and a multiple of `AES128_BLOCK_SIZE`.
+    /// Otherwise, `Err(INVAL, ...)` will be returned.
     ///
     /// If an encryption operation is already in progress,
-    /// `Some(BUSY, ...)` will be returned.
+    /// `Err(BUSY, ...)` will be returned.
     ///
     /// For correct operation, the methods `set_key` and `set_iv` must have
     /// previously been called to set the buffers containing the
@@ -83,100 +79,44 @@ pub trait AES128<'a> {
     ///
     fn crypt(
         &self,
-        source: Option<&'static mut [u8]>,
-        dest: &'static mut [u8],
-        start_index: usize,
-        stop_index: usize,
-    ) -> Option<(
-        Result<(), ErrorCode>,
-        Option<&'static mut [u8]>,
-        &'static mut [u8],
-    )>;
+        source: Option<SubSlice<'static, u8>>,
+        dest: SubSliceMut<'static, u8>,
+    ) -> Result<
+        (),
+        (
+            ErrorCode,
+            Option<SubSlice<'static, u8>>,
+            SubSliceMut<'static, u8>,
+        ),
+    >;
 }
 
-pub trait AES128Ctr {
-    /// Call before `AES128::crypt()` to perform AES128Ctr
+/// Implement this trait for AES128 hardware that supports Ctr mode.
+pub trait AES128Ctr<'a>: AES128<'a> {
+    /// Call before `AES128::crypt()` to perform AES128Ctr.
     fn set_mode_aes128ctr(&self, encrypting: bool) -> Result<(), ErrorCode>;
 }
 
-pub trait AES128CBC {
-    /// Call before `AES128::crypt()` to perform AES128CBC
+/// Implement this trait for AES128 hardware that supports CBC mode.
+pub trait AES128CBC<'a>: AES128<'a> {
+    /// Call before `AES128::crypt()` to perform AES128CBC.
     fn set_mode_aes128cbc(&self, encrypting: bool) -> Result<(), ErrorCode>;
 }
 
-pub trait AES128ECB {
-    /// Call before `AES128::crypt()` to perform AES128ECB
+/// Implement this trait for AES128 hardware that supports ECB mode.
+pub trait AES128ECB<'a>: AES128<'a> {
+    /// Call before `AES128::crypt()` to perform AES128ECB.
     fn set_mode_aes128ecb(&self, encrypting: bool) -> Result<(), ErrorCode>;
 }
 
-pub trait CCMClient {
-    /// `res` is Ok(()) if the encryption/decryption process succeeded. This
-    /// does not mean that the message has been verified in the case of
-    /// decryption.
-    /// If we are encrypting: `tag_is_valid` is `true` iff `res` is Ok(()).
-    /// If we are decrypting: `tag_is_valid` is `true` iff `res` is Ok(()) and the
-    /// message authentication tag is valid.
-    fn crypt_done(&self, buf: &'static mut [u8], res: Result<(), ErrorCode>, tag_is_valid: bool);
+/// Implement this trait for AES128 hardware that supports CCM mode.
+pub trait AES128CCM<'a>: AES128<'a> {
+    /// Call before `AES128::crypt()` to perform AES128CCM.
+    fn set_mode_aes128ccm(&self, encrypting: bool) -> Result<(), ErrorCode>;
 }
 
-pub const CCM_NONCE_LENGTH: usize = 13;
-
-pub trait AES128CCM<'a> {
-    /// Set the client instance which will receive `crypt_done()` callbacks
-    fn set_client(&'a self, client: &'a dyn CCMClient);
-
-    /// Set the key to be used for CCM encryption
-    fn set_key(&self, key: &[u8]) -> Result<(), ErrorCode>;
-
-    /// Set the nonce (length NONCE_LENGTH) to be used for CCM encryption
-    fn set_nonce(&self, nonce: &[u8]) -> Result<(), ErrorCode>;
-
-    /// Try to begin the encryption/decryption process
-    fn crypt(
-        &self,
-        buf: &'static mut [u8],
-        a_off: usize,
-        m_off: usize,
-        m_len: usize,
-        mic_len: usize,
-        confidential: bool,
-        encrypting: bool,
-    ) -> Result<(), (ErrorCode, &'static mut [u8])>;
-}
-
-pub trait GCMClient {
-    /// `res` is Ok(()) if the encryption/decryption process succeeded. This
-    /// does not mean that the message has been verified in the case of
-    /// decryption.
-    /// If we are encrypting: `tag_is_valid` is `true` iff `res` is Ok(()).
-    /// If we are decrypting: `tag_is_valid` is `true` iff `res` is Ok(()) and the
-    /// message authentication tag is valid.
-    fn crypt_done(&self, buf: &'static mut [u8], res: Result<(), ErrorCode>, tag_is_valid: bool);
-}
-
-pub trait AES128GCM<'a> {
-    /// Set the client instance which will receive `crypt_done()` callbacks
-    fn set_client(&'a self, client: &'a dyn GCMClient);
-
-    /// Set the key to be used for GCM encryption
-    /// Returns `INVAL` if length is not `AES128_KEY_SIZE`
-    fn set_key(&self, key: &[u8]) -> Result<(), ErrorCode>;
-
-    /// Set the IV to be used for GCM encryption. The IV should be less
-    /// or equal to 12 bytes (96 bits) as recommened in NIST-800-38D.
-    /// Returns `INVAL` if length is greater then 12 bytes
-    fn set_iv(&self, nonce: &[u8]) -> Result<(), ErrorCode>;
-
-    /// Try to begin the encryption/decryption process
-    /// The possible ErrorCodes are:
-    ///     - `BUSY`: An operation is already in progress
-    ///     - `SIZE`: The offset and lengths don't fit inside the buffer
-    fn crypt(
-        &self,
-        buf: &'static mut [u8],
-        aad_offset: usize,
-        message_offset: usize,
-        message_len: usize,
-        encrypting: bool,
-    ) -> Result<(), (ErrorCode, &'static mut [u8])>;
+/// Implement this trait for AES128 hardware that supports GCM mode.
+pub trait AES128GCM<'a>: AES128<'a> {
+    /// Call before `AES128::crypt()` to perform AES128GCM.
+    fn set_mode_aes128gcm(&self, encrypting: bool) -> Result<(), ErrorCode>;
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request serves as an RFC for a redesign of the Symmetric Encryption HIL. This redesign attempts to separate the HIL into a generic AES crypto hardware trait and traits for each specific AES mode (e.g. CTR). With this separation, we can more easily represent encryption modes that may not have hardware support, but are built upon or depend upon underlying encryption (e.g. GCM requiring CTR). Additionally, separating AES modes per trait allows flexibility to encode the nuances of each encryption type (e.g. ECB does not require an initialization vector).

The current implementation has traits for a standard AES client, an AESGCM client, and an AESCCM client. This updates the HIL to only use one client to simplify the interface. In the case of a GCM tag failure, this now returns an `Err` as we no longer have a GCMClient. This is not a key feature of the redesign and can be reverted depending on others thoughts (note, RustCrypto does not return information to the validity of a tag and instead denotes this as an Error condition).

Some important notes when viewing this:
- The AESCtr capsule should not be closely reviewed as this remains untested. This is included in this PR to demonstrate this redesign.

Key Changes:
- Create capsules crypt directory
- Remove GCM / CCM Client
- New AES128Hw trait
- Trait per crypto mode
- Example AESCtr implementation to demonstrate new HIL's integration with the RustCrypto software AESCtr and AESCtr implementation based upon HW ECB support.

Minor Changes:
- Update to use subslices
- Refactor nested `Option`s to use `Result<(), ErrorCode>` pattern.
- Update `src` buffer to be immutable. This buffer should not be encrypted in place (`dst` for this purpose) so our HIL interface should be opinionated on this.

### Testing Strategy

As this remains a draft/RFC, the AESCtr implementations are untested. 

### TODO or Help Wanted

This pull request still needs...

- [ ] update of chip implementations for NRF5x, SAM4L, and Earlgray
- [ ] update of capsules that use AES128 methods (e.g. 802.15.4)
- [ ] testing of AESCtr capsule

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.