### PR TITLE
make: check that rustup succeeded

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -143,15 +143,19 @@ endif
 
 # If the board the user is compiling is using the stable toolchain, verify that
 # the user's stable rustc toolchain is new enough to compile the board. If the
-# toolchain is too old, wait 5 seconds and then install for the user.
+# toolchain is too old, wait 10 seconds and then install for the user.
 ifneq ($(shell $(RUSTUP) show active-toolchain | grep "stable"),)
   # If the error from running --version shows a version mismatch we know the
   # installed toolchain is too old.
   ifneq ($(shell $(CARGO) rustc -- --version 2>&1 | grep "is not supported by the following packages"),)
-    $(warning Your stable rustc is older than the MSRV of this board)
-    $(warning make will update your stable rustc in 5s)
-    $(shell sleep 5)
+    $(warning Your stable rustc is older than the MSRV of this board.)
+    $(warning )
+    $(warning make will run `$(RUSTUP) update` to update your stable rustc in 10s.)
+    $(shell sleep 10)
     DUMMY := $(shell $(RUSTUP) update)
+  endif
+  ifneq ($(shell $(CARGO) rustc -- --version 2>&1 | grep "is not supported by the following packages"),)
+    $(error Rustup update failed. Please fix your rustup or update your rustc manually.)
   endif
 endif
 endif # $(NO_RUSTUP)


### PR DESCRIPTION
### Pull Request Overview

This verifies that `rustup update` actually succeeds when the Makefile runs it own your behalf. It also ups the timeout to auto-run slightly from 5s to 10s, as there's non-trivial text to read and 5s is kind of quick when stuff is flying in the terminal.

### Testing Strategy

This pull request was tested by building a few times on my Mac (in particular, after removing the `rls-preview` component from my local install, which had been causing the update to fail, but the build kept going confusingly).


### TODO or Help Wanted

N/A


### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
