### PR TITLE
chips/qemu_rv32_virt_chip/uart: ignore spurious interrupts

### DIFF
--- a/boards/qemu_rv32_virt/Makefile
+++ b/boards/qemu_rv32_virt/Makefile
@@ -7,8 +7,9 @@
 
 include ../Makefile.common
 
-QEMU_CMD             := qemu-system-riscv32
-WORKING_QEMU_VERSION := 7.2.0
+QEMU_CMD              := qemu-system-riscv32
+WORKING_QEMU_VERSIONS := 8.2.7, 9.1.3
+BROKEN_QEMU_VERSIONS  := <= 8.1.5, >= 9.2.3
 
 # Whether a VirtIO network device shall be attached to the QEMU
 # machine, and which backend should be used. The following options are
@@ -75,7 +76,7 @@ QEMU_BASE_CMDLINE := \
 run: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	@echo
 	@echo -e "Running $$($(QEMU_CMD) --version | head -n1)"\
-	  "(tested: $(WORKING_QEMU_VERSION)) with\n"\
+	  "(tested: $(WORKING_QEMU_VERSIONS); known broken: $(BROKEN_QEMU_VERSIONS)) with\n"\
           " - kernel $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf"
 	@echo "To exit type C-a x"
 	@echo
@@ -88,7 +89,7 @@ run: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 run-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	@echo
 	@echo -e "Running $$($(QEMU_CMD) --version | head -n1)"\
-	  "(tested: $(WORKING_QEMU_VERSION)) with\n"\
+	  "(tested: $(WORKING_QEMU_VERSIONS); known broken: $(BROKEN_QEMU_VERSIONS)) with\n"\
           " - kernel $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf\n"\
 	  " - app $(APP)"
 	@echo "To exit type C-a x"

--- a/boards/qemu_rv32_virt/README.md
+++ b/boards/qemu_rv32_virt/README.md
@@ -14,13 +14,6 @@ stable QEMU target for using Tock in a virtualized RISC-V environment. This can
 be useful for CI and other purposes. In the future, this target can be extended
 to support VirtIO peripherals.
 
-Starting from at least QEMU v7.0.0 up to and including v7.1.0, QEMU cotained a
-bug which caused spurious memory access faults raised by the emulated Physical
-Memory Protection (PMP), part of the emulated RISC-V CPU core. Therefore, **this
-board requires at least QEMU v7.2.0** to function properly. Symptomps of the
-aforementioned bug are crashes of userspace processes with a memory-access fault
-reported by the kernel.
-
 Running QEMU
 ------------
 
@@ -37,24 +30,27 @@ QEMU standalone, or with a single app. These can be executed through the
 - **`run`**: Start Tock on an emulated QEMU board without an app:
 
   ```
-  tock/boards/qemu_rv32_virt $ make run
-      Finished release [optimized + debuginfo] target(s) in 0.05s
+      Finished `release` profile [optimized + debuginfo] target(s) in 0.08s
      text    data     bss     dec     hex filename
-    64880      12   11248   76140   1296c tock/target/riscv32imac-unknown-none-elf/release/qemu_rv32_virt
-  a9de4df9486d724e6bf6a3423af669903dfd2bd1fd65c1dd867ddf9d7bcbec9b  tock/target/riscv32imac-unknown-none-elf/release/qemu_rv32_virt.bin
+    87552      48   41940  129540   1fa04 target/riscv32imac-unknown-none-elf/release/qemu_rv32_virt
 
-  Running QEMU emulator version 7.0.0 (tested: 7.0.0) with
-    - kernel tock/target/riscv32imac-unknown-none-elf/release/qemu_rv32_virt.bin
+  Running QEMU emulator version 10.0.2 (tested: 8.2.7, 9.1.3; known broken: <= 8.1.5, >= 9.2.3) with
+    - kernel target/riscv32imac-unknown-none-elf/release/qemu_rv32_virt.elf
   To exit type C-a x
 
   qemu-system-riscv32 \
     -machine virt \
-    -bios tock/target/riscv32imac-unknown-none-elf/release/qemu_rv32_virt.bin \
+    -semihosting \
+    -global driver=riscv-cpu,property=smepmp,value=true \
     -global virtio-mmio.force-legacy=false \
-    -device virtio-rng-device \
-    -nographic
+    -device virtio-rng-device  \
+    -nographic \
+    -bios target/riscv32imac-unknown-none-elf/release/qemu_rv32_virt.elf
   QEMU RISC-V 32-bit "virt" machine, initialization complete.
+  - Found VirtIO EntropySource device, enabling RngDriver
+  - VirtIO NetworkCard device not found, disabling EthernetTapDriver
   Entering main loop.
+  tock$
   ```
 
 - **`run-app`**: Start Tock on an emulated QEMU board with an app:


### PR DESCRIPTION
### Pull Request Overview

This PR ships a long overdue fix to an issue causing the QEMU board to panic on boot. This is in response to QEMU change 59fad1ebad [1], which fixed their PLIC implementation to not un-assert interrupts when the source's level has changed (i.e., implement rising-edge triggered interrupts).

For some (to me still) inexplicable reason, the 16550 UART asserts an interrupt briefly when Tock starts using it, but that interrupt is not visible in the peripheral's status / pending interrupt registers. In this patch, we simply ignore these spurious interrupts.

Additionally, we update the working QEMU versions and add known-broken ones to the Makefile. QEMU did not support the `riscv-cpu.smepmp` property in versions older than or at 8.1.5, and the board ends up in a busy loop starting with versions newer than or at 9.2.3. These are conservative estimates from the QEMU binaries that I had lying around my system to test, there may be other broken versions slightly newer or older, respectively.

The working QEMU versions have been updated and are known good following the fix in the previous commit [2].

[1]: https://gitlab.com/qemu-project/qemu/-/commit/59fad1ebadc28995c5d356d097ba6a4d42cae7e7
[2]: 6940ef59970873 ("chips/qemu_rv32_virt_chip: ignore spurious interrupts without panic")


### Testing Strategy

This pull request was tested by running in QEMU.


### TODO or Help Wanted

N/A

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
