### PR TITLE
boards/qemu_rv32_virt: unbreak QEMU >= 9.2.3, specify ELF file entry

### DIFF
--- a/boards/build_scripts/tock_kernel_layout.ld
+++ b/boards/build_scripts/tock_kernel_layout.ld
@@ -406,6 +406,15 @@ _sattributes = LOADADDR(.attributes);
 _eattributes = LOADADDR(.attributes) + SIZEOF(.attributes);
 _erom = ORIGIN(rom) + LENGTH(rom);
 
+/* Set the ENTRY attribute to the start of the text section, _stext. For RISC-V
+ * this should point to `.riscv.start`, which contains the `_start` symbol. For
+ * Cortex-M, this starts with the interrupt vector table.
+ *
+ * This variable is used by, e.g., QEMU to determine the entrypoint to start
+ * program execution.
+ */
+ENTRY(_stext);
+
 /* This.. this is a dirty, not-fully-understood, hack. In some way, linking is
  * a multi-pass process. i.e., if you were to ASSERT(0, "how many links")
  * you'll get three assertions printed for one invocation of rust-lld.

--- a/boards/qemu_rv32_virt/Makefile
+++ b/boards/qemu_rv32_virt/Makefile
@@ -8,8 +8,8 @@
 include ../Makefile.common
 
 QEMU_CMD              := qemu-system-riscv32
-WORKING_QEMU_VERSIONS := 8.2.7, 9.1.3
-BROKEN_QEMU_VERSIONS  := <= 8.1.5, >= 9.2.3
+WORKING_QEMU_VERSIONS := 8.2.7, 9.1.3, 9.2.3, 10.0.2
+BROKEN_QEMU_VERSIONS  := <= 8.1.5
 
 # Whether a VirtIO network device shall be attached to the QEMU
 # machine, and which backend should be used. The following options are


### PR DESCRIPTION
### Pull Request Overview

Since somewhere around v9.2.3, QEMU has started respecting the BIOS ELF file header's entrypoint, which we're setting to 0x0 for all boards. This caused QEMU to jump into the middle of invalid / unmapped memory, thus busy-looping in trying to trap on the resulting illegal instruction fault.

This adds the ELF file's entrypoint and sets it to the correct, expected address, fixing this issue.


### Testing Strategy

This pull request was tested by running Tock in QEMU v9.2.3 and v10.0.2.


### TODO or Help Wanted

@ppannuto @bradjc (and anyone else deeply familiar with ELF magic): is this the right way to do this? I'd rather have `ENTRY(_start)` (i.e., reference our actual start symbol directly, instead of the start of the text section), but that doesn't seem to work. I _think_ this should be relatively stable, as our liker script should guarantee that nothing's placed before the contents of `.riscv.start` (which itself exclusively contains the `_start` symbol).

Also, should we perhaps do this for all boards? Specifying `ENTRY` seems like the _right_ thing to do, even though it probably doesn't matter much for all other boards.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
