### PR TITLE
clippy: deny as_ptr_cast_mut

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -264,7 +264,6 @@ derive_partial_eq_without_eq = "allow"
 empty_line_after_doc_comments = "allow"
 trait_duplication_in_bounds = "allow"
 useless_let_if_seq = "allow"
-as_ptr_cast_mut = "allow"
 
 
 # PEDANTIC

--- a/chips/sam4l/src/usbc/mod.rs
+++ b/chips/sam4l/src/usbc/mod.rs
@@ -481,7 +481,7 @@ impl<'a> Usbc<'a> {
     ) {
         let e: usize = From::from(endpoint);
         let b: usize = From::from(bank);
-        let p = buf.as_ptr() as *mut u8;
+        let p = buf.as_ptr() as *const u8 as *mut u8;
 
         debug1!("Set Endpoint{}/Bank{} addr={:8?}", e, b, p);
         self.descriptors[e][b].set_addr(p);


### PR DESCRIPTION


### Pull Request Overview

Use `.as_mut_ptr()` instead. In this case using `as_mut_ptr` doesn't work:

```
error[E0308]: mismatched types
   --> chips/sam4l/src/usbc/mod.rs:487:41
    |
487 |         self.descriptors[e][b].set_addr(p);
    |                                -------- ^ expected `*mut u8`, found `*mut VolatileCell<u8>`
    |                                |
    |                                arguments to this method are incorrect
    |
    = note: expected raw pointer `*mut u8`
               found raw pointer `*mut kernel::utilities::cells::VolatileCell<u8>`
note: method defined here
   --> chips/sam4l/src/usbc/mod.rs:405:12
    |
405 |     pub fn set_addr(&self, addr: *mut u8) {
    |            ^^^^^^^^        -------------
```

but casting twice avoids the lint.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
