### PR TITLE
PoC: Proposed upstream format for assembly blocks (ARM core arch only)

### DIFF
--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -139,48 +139,46 @@ pub unsafe extern "C" fn unhandled_interrupt() {
 pub unsafe extern "C" fn initialize_ram_jump_to_main() {
     use core::arch::naked_asm;
     naked_asm!(
-        "
-    // Start by initializing .bss memory. The Tock linker script defines
-    // `_szero` and `_ezero` to mark the .bss segment.
-    ldr r0, ={sbss}     // r0 = first address of .bss
-    ldr r1, ={ebss}     // r1 = first address after .bss
+        "  // Start by initializing .bss memory. The Tock linker script defines",
+        "  // `_szero` and `_ezero` to mark the .bss segment.",
+        "  ldr r0, ={sbss}     // r0 = first address of .bss",
+        "  ldr r1, ={ebss}     // r1 = first address after .bss",
 
-    movs r2, #0         // r2 = 0
+        "  movs r2, #0         // r2 = 0",
 
-  100: // bss_init_loop
-    cmp r1, r0          // We increment r0. Check if we have reached r1
-                        // (end of .bss), and stop if so.
-    beq 101f            // If r0 == r1, we are done.
-    stm r0!, {{r2}}     // Write a word to the address in r0, and increment r0.
-                        // Since r2 contains zero, this will clear the memory
-                        // pointed to by r0. Using `stm` (store multiple) with the
-                        // bang allows us to also increment r0 automatically.
-    b 100b              // Continue the loop.
+        "100: // bss_init_loop",
+        "  cmp r1, r0          // We increment r0. Check if we have reached r1",
+        "                      // (end of .bss), and stop if so.",
+        "  beq 101f            // If r0 == r1, we are done.",
+        "  stm r0!, {{r2}}     // Write a word to the address in r0, and increment r0.",
+        "                      // Since r2 contains zero, this will clear the memory",
+        "                      // pointed to by r0. Using `stm` (store multiple) with the",
+        "                      // bang allows us to also increment r0 automatically.",
+        "  b 100b              // Continue the loop.",
 
-  101: // bss_init_done
+        "101: // bss_init_done",
 
-    // Now initialize .data memory. This involves coping the values right at the
-    // end of the .text section (in flash) into the .data section (in RAM).
-    ldr r0, ={sdata}    // r0 = first address of data section in RAM
-    ldr r1, ={edata}    // r1 = first address after data section in RAM
-    ldr r2, ={etext}    // r2 = address of stored data initial values
+        "  // Now initialize .data memory. This involves coping the values right at the",
+        "  // end of the .text section (in flash) into the .data section (in RAM).",
+        "  ldr r0, ={sdata}    // r0 = first address of data section in RAM",
+        "  ldr r1, ={edata}    // r1 = first address after data section in RAM",
+        "  ldr r2, ={etext}    // r2 = address of stored data initial values",
 
-  200: // data_init_loop
-    cmp r1, r0          // We increment r0. Check if we have reached the end
-                        // of the data section, and if so we are done.
-    beq 201f            // r0 == r1, and we have iterated through the .data section
-    ldm r2!, {{r3}}     // r3 = *(r2), r2 += 1. Load the initial value into r3,
-                        // and use the bang to increment r2.
-    stm r0!, {{r3}}     // *(r0) = r3, r0 += 1. Store the value to memory, and
-                        // increment r0.
-    b 200b              // Continue the loop.
+        "200: // data_init_loop",
+        "  cmp r1, r0          // We increment r0. Check if we have reached the end",
+        "                      // of the data section, and if so we are done.",
+        "  beq 201f            // r0 == r1, and we have iterated through the .data section",
+        "  ldm r2!, {{r3}}     // r3 = *(r2), r2 += 1. Load the initial value into r3,",
+        "                      // and use the bang to increment r2.",
+        "  stm r0!, {{r3}}     // *(r0) = r3, r0 += 1. Store the value to memory, and",
+        "                      // increment r0.",
+        "  b 200b              // Continue the loop.",
 
-  201: // data_init_done
+        "201: // data_init_done",
 
-    // Now that memory has been initialized, we can jump to main() where the
-    // board initialization takes place and Rust code starts.
-    bl main
-    ",
+        "  // Now that memory has been initialized, we can jump to main() where the",
+        "  // board initialization takes place and Rust code starts.",
+        "  bl main",
         sbss = sym _szero,
         ebss = sym _ezero,
         sdata = sym _srelocate,

--- a/arch/cortex-m0/src/lib.rs
+++ b/arch/cortex-m0/src/lib.rs
@@ -78,89 +78,88 @@ unsafe extern "C" fn generic_isr() {
 unsafe extern "C" fn generic_isr() {
     use core::arch::naked_asm;
     naked_asm!(
-        "
-    /* Skip saving process state if not coming from user-space */
-    ldr r0, 300f // MEXC_RETURN_PSP
-    cmp lr, r0
-    bne 100f
+        "  /* Skip saving process state if not coming from user-space */",
+        "  ldr r0, 300f // MEXC_RETURN_PSP",
+        "  cmp lr, r0",
+        "  bne 100f",
 
-    /* We need to make sure the kernel cotinues the execution after this ISR */
-    movs r0, #0
-    msr CONTROL, r0
-    /* CONTROL writes must be followed by ISB */
-    /* https://developer.arm.com/documentation/dui0662/b/The-Cortex-M0--Processor/Programmers-model/Core-registers */
-    isb
+        "  /* We need to make sure the kernel cotinues the execution after this ISR */",
+        "  movs r0, #0",
+        "  msr CONTROL, r0",
+        "  /* CONTROL writes must be followed by ISB */",
+        "  /* https://developer.arm.com/documentation/dui0662/b/The-Cortex-M0--Processor/Programmers-model/Core-registers */",
+        "  isb",
 
-    /* We need the most recent kernel's version of r1, which points */
-    /* to the Process struct's stored registers field. The kernel's r1 */
-    /* lives in the second word of the hardware stacked registers on MSP */
-    mov r1, sp
-    ldr r1, [r1, #4]
-    str r4, [r1, #16]
-    str r5, [r1, #20]
-    str r6, [r1, #24]
-    str r7, [r1, #28]
+        "  /* We need the most recent kernel's version of r1, which points */",
+        "  /* to the Process struct's stored registers field. The kernel's r1 */",
+        "  /* lives in the second word of the hardware stacked registers on MSP */",
+        "  mov r1, sp",
+        "  ldr r1, [r1, #4]",
+        "  str r4, [r1, #16]",
+        "  str r5, [r1, #20]",
+        "  str r6, [r1, #24]",
+        "  str r7, [r1, #28]",
 
-    push {{r4-r7}}
-    mov  r4, r8
-    mov  r5, r9
-    mov  r6, r10
-    mov  r7, r11
-    str r4, [r1, #0]
-    str r5, [r1, #4]
-    str r6, [r1, #8]
-    str r7, [r1, #12]
-    pop {{r4-r7}}
+        "  push {{r4-r7}}",
+        "  mov  r4, r8",
+        "  mov  r5, r9",
+        "  mov  r6, r10",
+        "  mov  r7, r11",
+        "  str r4, [r1, #0]",
+        "  str r5, [r1, #4]",
+        "  str r6, [r1, #8]",
+        "  str r7, [r1, #12]",
+        "  pop {{r4-r7}}",
 
-    ldr r0, 200f // MEXC_RETURN_MSP
-    mov lr, r0
-100: // _ggeneric_isr_no_stacking
-    /* Find the ISR number by looking at the low byte of the IPSR registers */
-    mrs r0, IPSR
-    movs r1, #0xff
-    ands r0, r1
-    /* ISRs start at 16, so subtract 16 to get zero-indexed */
-    subs r0, r0, #16
+        "  ldr r0, 200f // MEXC_RETURN_MSP",
+        "  mov lr, r0",
+        "100: // _ggeneric_isr_no_stacking",
+        "  /* Find the ISR number by looking at the low byte of the IPSR registers */",
+        "  mrs r0, IPSR",
+        "  movs r1, #0xff",
+        "  ands r0, r1",
+        "  /* ISRs start at 16, so subtract 16 to get zero-indexed */",
+        "  subs r0, r0, #16",
 
-    /*
-     * High level:
-     *    NVIC.ICER[r0 / 32] = 1 << (r0 & 31)
-     * */
-    /* r3 = &NVIC.ICER[r0 / 32] */
-    ldr r2, 101f      /* r2 = &NVIC.ICER */
-    lsrs r3, r0, #5   /* r3 = r0 / 32 */
-    lsls r3, r3, #2   /* ICER is word-sized, so multiply offset by 4 */
-    adds r3, r3, r2   /* r3 = r2 + r3 */
+        "  /*",
+        "   * High level:",
+        "   *    NVIC.ICER[r0 / 32] = 1 << (r0 & 31)",
+        "   * */",
+        "  /* r3 = &NVIC.ICER[r0 / 32] */",
+        "  ldr r2, 101f      /* r2 = &NVIC.ICER */",
+        "  lsrs r3, r0, #5   /* r3 = r0 / 32 */",
+        "  lsls r3, r3, #2   /* ICER is word-sized, so multiply offset by 4 */",
+        "  adds r3, r3, r2   /* r3 = r2 + r3 */",
 
-    /* r2 = 1 << (r0 & 31) */
-    movs r2, #31      /* r2 = 31 */
-    ands r0, r2       /* r0 = r0 & r2 */
-    subs r2, r2, #30  /* r2 = r2 - 30 i.e. r2 = 1 */
-    lsls r2, r2, r0   /* r2 = 1 << r0 */
+        "  /* r2 = 1 << (r0 & 31) */",
+        "  movs r2, #31      /* r2 = 31 */",
+        "  ands r0, r2       /* r0 = r0 & r2 */",
+        "  subs r2, r2, #30  /* r2 = r2 - 30 i.e. r2 = 1 */",
+        "  lsls r2, r2, r0   /* r2 = 1 << r0 */",
 
-    /* *r3 = r2 */
-    str r2, [r3]
+        "  /* *r3 = r2 */",
+        "  str r2, [r3]",
 
-    /* The pending bit in ISPR might be reset by hardware for pulse interrupts
-     * at this point. So set it here again so the interrupt does not get lost
-     * in service_pending_interrupts()
-     *
-     * The NVIC.ISPR base is 0xE000E200, which is 0x20 (aka #32) above the
-     * NVIC.ICER base.  Calculate the ISPR address by offsetting from the ICER
-     * address so as to avoid re-doing the [r0 / 32] index math.
-     */
-    adds r3, #32
-    str r2, [r3]
+        "  /* The pending bit in ISPR might be reset by hardware for pulse interrupts",
+        "   * at this point. So set it here again so the interrupt does not get lost",
+        "   * in service_pending_interrupts()",
+        "   *",
+        "   * The NVIC.ISPR base is 0xE000E200, which is 0x20 (aka #32) above the",
+        "   * NVIC.ICER base.  Calculate the ISPR address by offsetting from the ICER",
+        "   * address so as to avoid re-doing the [r0 / 32] index math.",
+        "   */",
+        "  adds r3, #32",
+        "  str r2, [r3]",
 
-    bx lr /* return here since we have extra words in the assembly */
+        "  bx lr /* return here since we have extra words in the assembly */",
 
-.align 4
-101: // NVICICER
-  .word 0xE000E180
-200: // MEXC_RETURN_MSP
-  .word 0xFFFFFFF9
-300: // MEXC_RETURN_PSP
-  .word 0xFFFFFFFD",
+        ".align 4",
+        "101: // NVICICER",
+        "  .word 0xE000E180",
+        "200: // MEXC_RETURN_MSP",
+        "  .word 0xFFFFFFF9",
+        "300: // MEXC_RETURN_PSP",
+        "  .word 0xFFFFFFFD",
     );
 }
 

--- a/arch/cortex-m0p/src/lib.rs
+++ b/arch/cortex-m0p/src/lib.rs
@@ -45,34 +45,32 @@ pub unsafe extern "C" fn svc_handler() {
 pub unsafe extern "C" fn svc_handler() {
     use core::arch::naked_asm;
     naked_asm!(
-        "
-  ldr r0, 100f // EXC_RETURN_MSP
-  cmp lr, r0
-  bne 300f // to_kernel
+        "  ldr r0, 100f // EXC_RETURN_MSP",
+        "  cmp lr, r0",
+        "  bne 300f // to_kernel",
 
-  // If we get here, then this is a context switch from the kernel to the
-  // application. Set thread mode to unprivileged to run the application.
-  movs r0, #1
-  msr CONTROL, r0
-  ldr r1, 200f // EXC_RETURN_PSP
-  bx r1
+        "  // If we get here, then this is a context switch from the kernel to the",
+        "  // application. Set thread mode to unprivileged to run the application.",
+        "  movs r0, #1",
+        "  msr CONTROL, r0",
+        "  ldr r1, 200f // EXC_RETURN_PSP",
+        "  bx r1",
 
-300: // to_kernel
-  ldr r0, =SYSCALL_FIRED
-  movs r1, #1
-  str r1, [r0, #0]
-  // Set thread mode to privileged as we switch back to the kernel.
-  movs r0, #0
-  msr CONTROL, r0
-  ldr r1, 100f // EXC_RETURN_MSP
-  bx r1
+        "300: // to_kernel",
+        "  ldr r0, =SYSCALL_FIRED",
+        "  movs r1, #1",
+        "  str r1, [r0, #0]",
+        "  // Set thread mode to privileged as we switch back to the kernel.",
+        "  movs r0, #0",
+        "  msr CONTROL, r0",
+        "  ldr r1, 100f // EXC_RETURN_MSP",
+        "  bx r1",
 
-.align 4
-100: // EXC_RETURN_MSP
-  .word 0xFFFFFFF9
-200: // EXC_RETURN_PSP
-  .word 0xFFFFFFFD
-  ",
+        ".align 4",
+        "100: // EXC_RETURN_MSP",
+        "  .word 0xFFFFFFF9",
+        "200: // EXC_RETURN_PSP",
+        "  .word 0xFFFFFFFD",
     );
 }
 

--- a/arch/cortex-v7m/src/lib.rs
+++ b/arch/cortex-v7m/src/lib.rs
@@ -21,31 +21,29 @@ extern "C" {
 pub unsafe extern "C" fn systick_handler_arm_v7m() {
     use core::arch::naked_asm;
     naked_asm!(
-        "
-    // Use the CONTROL register to set the thread mode to privileged to switch
-    // back to kernel mode.
-    //
-    // CONTROL[1]: Stack status
-    //   0 = Default stack (MSP) is used
-    //   1 = Alternate stack is used
-    // CONTROL[0]: Mode
-    //   0 = Privileged in thread mode
-    //   1 = User state in thread mode
-    mov r0, #0                        // r0 = 0
-    msr CONTROL, r0                   // CONTROL = 0
-    // CONTROL writes must be followed by an Instruction Synchronization Barrier
-    // (ISB). https://developer.arm.com/documentation/dai0321/latest
-    isb                               // synchronization barrier
+        "  // Use the CONTROL register to set the thread mode to privileged to switch",
+        "  // back to kernel mode.",
+        "  //",
+        "  // CONTROL[1]: Stack status",
+        "  //   0 = Default stack (MSP) is used",
+        "  //   1 = Alternate stack is used",
+        "  // CONTROL[0]: Mode",
+        "  //   0 = Privileged in thread mode",
+        "  //   1 = User state in thread mode",
+        "  mov r0, #0                        // r0 = 0",
+        "  msr CONTROL, r0                   // CONTROL = 0",
+        "  // CONTROL writes must be followed by an Instruction Synchronization Barrier",
+        "  // (ISB). https://developer.arm.com/documentation/dai0321/latest",
+        "  isb                               // synchronization barrier",
 
-    // The link register is set to the `EXC_RETURN` value on exception entry. To
-    // ensure we continue executing in the kernel we ensure the SPSEL bit is set
-    // to 0 to use the main (kernel) stack.
-    bfc lr, #2, #1                    // LR = LR & !(0x1<<2)
+        "  // The link register is set to the `EXC_RETURN` value on exception entry. To",
+        "  // ensure we continue executing in the kernel we ensure the SPSEL bit is set",
+        "  // to 0 to use the main (kernel) stack.",
+        "  bfc lr, #2, #1                    // LR = LR & !(0x1<<2)",
 
-    // This will resume in the switch_to_user function where application state
-    // is saved and the scheduler can choose what to do next.
-    bx lr
-    ",
+        "  // This will resume in the switch_to_user function where application state",
+        "  // is saved and the scheduler can choose what to do next.",
+        "  bx lr",
     );
 }
 
@@ -58,71 +56,69 @@ pub unsafe extern "C" fn systick_handler_arm_v7m() {
 pub unsafe extern "C" fn svc_handler_arm_v7m() {
     use core::arch::naked_asm;
     naked_asm!(
-        "
-    // First check to see which direction we are going in. If the link register
-    // (containing EXC_RETURN) has a 1 in the SPSEL bit (meaning the
-    // alternative/process stack was in use) then we are coming from a process
-    // which has called a syscall.
-    ubfx r0, lr, #2, #1               // r0 = (LR & (0x1<<2)) >> 2
-    cmp r0, #0                        // r0 (SPSEL bit) =≟ 0
-    bne 100f // to_kernel             // if SPSEL == 1, jump to to_kernel
+        "  // First check to see which direction we are going in. If the link register",
+        "  // (containing EXC_RETURN) has a 1 in the SPSEL bit (meaning the",
+        "  // alternative/process stack was in use) then we are coming from a process",
+        "  // which has called a syscall.",
+        "  ubfx r0, lr, #2, #1               // r0 = (LR & (0x1<<2)) >> 2",
+        "  cmp r0, #0                        // r0 (SPSEL bit) =≟ 0",
+        "  bne 100f // to_kernel             // if SPSEL == 1, jump to to_kernel",
 
-    // If we get here, then this is a context switch from the kernel to the
-    // application. Use the CONTROL register to set the thread mode to
-    // unprivileged to run the application.
-    //
-    // CONTROL[1]: Stack status
-    //   0 = Default stack (MSP) is used
-    //   1 = Alternate stack is used
-    // CONTROL[0]: Mode
-    //   0 = Privileged in thread mode
-    //   1 = User state in thread mode
-    mov r0, #1                        // r0 = 1
-    msr CONTROL, r0                   // CONTROL = 1
-    // CONTROL writes must be followed by an Instruction Synchronization Barrier
-    // (ISB). https://developer.arm.com/documentation/dai0321/latest
-    isb
+        "  // If we get here, then this is a context switch from the kernel to the",
+        "  // application. Use the CONTROL register to set the thread mode to",
+        "  // unprivileged to run the application.",
+        "  //",
+        "  // CONTROL[1]: Stack status",
+        "  //   0 = Default stack (MSP) is used",
+        "  //   1 = Alternate stack is used",
+        "  // CONTROL[0]: Mode",
+        "  //   0 = Privileged in thread mode",
+        "  //   1 = User state in thread mode",
+        "  mov r0, #1                        // r0 = 1",
+        "  msr CONTROL, r0                   // CONTROL = 1",
+        "  // CONTROL writes must be followed by an Instruction Synchronization Barrier",
+        "  // (ISB). https://developer.arm.com/documentation/dai0321/latest",
+        "  isb",
 
-    // The link register is set to the `EXC_RETURN` value on exception entry. To
-    // ensure we execute using the process stack we set the SPSEL bit to 1
-    // to use the alternate (process) stack.
-    orr lr, lr, #4                    // LR = LR | 0b100
+        "  // The link register is set to the `EXC_RETURN` value on exception entry. To",
+        "  // ensure we execute using the process stack we set the SPSEL bit to 1",
+        "  // to use the alternate (process) stack.",
+        "  orr lr, lr, #4                    // LR = LR | 0b100",
 
-    // Switch to the app.
-    bx lr
+        "  // Switch to the app.",
+        "  bx lr",
 
-  100: // to_kernel
-    // An application called a syscall. We mark this in the global variable
-    // `SYSCALL_FIRED` which is stored in the syscall file.
-    // `UserspaceKernelBoundary` will use this variable to decide why the app
-    // stopped executing.
-    ldr r0, =SYSCALL_FIRED            // r0 = &SYSCALL_FIRED
-    mov r1, #1                        // r1 = 1
-    str r1, [r0]                      // *SYSCALL_FIRED = 1
+        "100: // to_kernel",
+        "  // An application called a syscall. We mark this in the global variable",
+        "  // `SYSCALL_FIRED` which is stored in the syscall file.",
+        "  // `UserspaceKernelBoundary` will use this variable to decide why the app",
+        "  // stopped executing.",
+        "  ldr r0, =SYSCALL_FIRED            // r0 = &SYSCALL_FIRED",
+        "  mov r1, #1                        // r1 = 1",
+        "  str r1, [r0]                      // *SYSCALL_FIRED = 1",
 
-    // Use the CONTROL register to set the thread mode to privileged to switch
-    // back to kernel mode.
-    //
-    // CONTROL[1]: Stack status
-    //   0 = Default stack (MSP) is used
-    //   1 = Alternate stack is used
-    // CONTROL[0]: Mode
-    //   0 = Privileged in thread mode
-    //   1 = User state in thread mode
-    mov r0, #0                        // r0 = 0
-    msr CONTROL, r0                   // CONTROL = 0
-    // CONTROL writes must be followed by an Instruction Synchronization Barrier
-    // (ISB). https://developer.arm.com/documentation/dai0321/latest
-    isb
+        "  // Use the CONTROL register to set the thread mode to privileged to switch",
+        "  // back to kernel mode.",
+        "  //",
+        "  // CONTROL[1]: Stack status",
+        "  //   0 = Default stack (MSP) is used",
+        "  //   1 = Alternate stack is used",
+        "  // CONTROL[0]: Mode",
+        "  //   0 = Privileged in thread mode",
+        "  //   1 = User state in thread mode",
+        "  mov r0, #0                        // r0 = 0",
+        "  msr CONTROL, r0                   // CONTROL = 0",
+        "  // CONTROL writes must be followed by an Instruction Synchronization Barrier",
+        "  // (ISB). https://developer.arm.com/documentation/dai0321/latest",
+        "  isb",
 
-    // The link register is set to the `EXC_RETURN` value on exception entry. To
-    // ensure we continue executing in the kernel we ensure the SPSEL bit is set
-    // to 0 to use the main (kernel) stack.
-    bfc lr, #2, #1                    // LR = LR & !(0x1<<2)
+        "  // The link register is set to the `EXC_RETURN` value on exception entry. To",
+        "  // ensure we continue executing in the kernel we ensure the SPSEL bit is set",
+        "  // to 0 to use the main (kernel) stack.",
+        "  bfc lr, #2, #1                    // LR = LR & !(0x1<<2)",
 
-    // Return to the kernel.
-    bx lr
-    ",
+        "  // Return to the kernel.",
+        "  bx lr",
     );
 }
 
@@ -134,72 +130,70 @@ pub unsafe extern "C" fn svc_handler_arm_v7m() {
 pub unsafe extern "C" fn generic_isr_arm_v7m() {
     use core::arch::naked_asm;
     naked_asm!(
-        "
-    // Use the CONTROL register to set the thread mode to privileged to ensure
-    // we are executing as the kernel. This may be redundant if the interrupt
-    // happened while the kernel code was executing.
-    //
-    // CONTROL[1]: Stack status
-    //   0 = Default stack (MSP) is used
-    //   1 = Alternate stack is used
-    // CONTROL[0]: Mode
-    //   0 = Privileged in thread mode
-    //   1 = User state in thread mode
-    mov r0, #0                        // r0 = 0
-    msr CONTROL, r0                   // CONTROL = 0
-    // CONTROL writes must be followed by an Instruction Synchronization Barrier
-    // (ISB). https://developer.arm.com/documentation/dai0321/latest
-    isb
+        "  // Use the CONTROL register to set the thread mode to privileged to ensure",
+        "  // we are executing as the kernel. This may be redundant if the interrupt",
+        "  // happened while the kernel code was executing.",
+        "  //",
+        "  // CONTROL[1]: Stack status",
+        "  //   0 = Default stack (MSP) is used",
+        "  //   1 = Alternate stack is used",
+        "  // CONTROL[0]: Mode",
+        "  //   0 = Privileged in thread mode",
+        "  //   1 = User state in thread mode",
+        "  mov r0, #0                        // r0 = 0",
+        "  msr CONTROL, r0                   // CONTROL = 0",
+        "  // CONTROL writes must be followed by an Instruction Synchronization Barrier",
+        "  // (ISB). https://developer.arm.com/documentation/dai0321/latest",
+        "  isb",
 
-    // Now need to disable the interrupt that fired in the NVIC to ensure it
-    // does not trigger again before the scheduler has a chance to handle it. We
-    // do this here in assembly for performance.
-    //
-    // The general idea is:
-    // 1. Get the index of the interrupt that occurred.
-    // 2. Set the disable bit for that interrupt in the NVIC.
+        "  // Now need to disable the interrupt that fired in the NVIC to ensure it",
+        "  // does not trigger again before the scheduler has a chance to handle it. We",
+        "  // do this here in assembly for performance.",
+        "  //",
+        "  // The general idea is:",
+        "  // 1. Get the index of the interrupt that occurred.",
+        "  // 2. Set the disable bit for that interrupt in the NVIC.",
 
-    // Find the ISR number (`index`) by looking at the low byte of the IPSR
-    // registers.
-    mrs r0, IPSR                      // r0 = Interrupt Program Status Register (IPSR)
-    and r0, #0xff                     // r0 = r0 & 0xFF; Get lowest 8 bits
-    sub r0, #16                       // r0 = r0 - 16;   ISRs start at 16, so subtract 16 to get zero-indexed.
+        "  // Find the ISR number (`index`) by looking at the low byte of the IPSR",
+        "  // registers.",
+        "  mrs r0, IPSR                      // r0 = Interrupt Program Status Register (IPSR)",
+        "  and r0, #0xff                     // r0 = r0 & 0xFF; Get lowest 8 bits",
+        "  sub r0, #16                       // r0 = r0 - 16;   ISRs start at 16, so subtract 16 to get zero-indexed.",
 
-    // Now disable that interrupt in the NVIC.
-    // High level:
-    //    r0 = index
-    //    NVIC.ICER[r0 / 32] = 1 << (r0 & 31)
-    lsrs r2, r0, #5                   // r2 = r0 / 32
-    // r0 = 1 << (r0 & 31)
-    movs r3, #1                       // r3 = 1
-    and r0, r0, #31                   // r0 = r0 & 31
-    lsl r0, r3, r0                    // r0 = r3 << r0
+        "  // Now disable that interrupt in the NVIC.",
+        "  // High level:",
+        "  //    r0 = index",
+        "  //    NVIC.ICER[r0 / 32] = 1 << (r0 & 31)",
+        "  lsrs r2, r0, #5                   // r2 = r0 / 32",
+        "  // r0 = 1 << (r0 & 31)",
+        "  movs r3, #1                       // r3 = 1",
+        "  and r0, r0, #31                   // r0 = r0 & 31",
+        "  lsl r0, r3, r0                    // r0 = r3 << r0",
 
-    // Load the ICER register address.
-    ldr r3, =0xe000e180               // r3 = &NVIC.ICER
+        "  // Load the ICER register address.",
+        "  ldr r3, =0xe000e180               // r3 = &NVIC.ICER",
 
-    // Here:
-    // - `r2` is index / 32
-    // - `r3` is &NVIC.ICER
-    // - `r0` is 1 << (index & 31)
-    str r0, [r3, r2, lsl #2]          // *(r3 + r2 * 4) = r0
+        "  // Here:",
+        "  // - `r2` is index / 32",
+        "  // - `r3` is &NVIC.ICER",
+        "  // - `r0` is 1 << (index & 31)",
+        "  str r0, [r3, r2, lsl #2]          // *(r3 + r2 * 4) = r0",
 
-    // The pending bit in ISPR might be reset by hardware for pulse interrupts
-    // at this point. So set it here again so the interrupt does not get lost in
-    // `service_pending_interrupts()`.
-    ldr r3, =0xe000e200               // r3 = &NVIC.ISPR
-    str r0, [r3, r2, lsl #2]          // *(r3 + r2 * 4) = r0
+        "  // The pending bit in ISPR might be reset by hardware for pulse interrupts",
+        "  // at this point. So set it here again so the interrupt does not get lost in",
+        "  // `service_pending_interrupts()`.",
+        "  ldr r3, =0xe000e200               // r3 = &NVIC.ISPR",
+        "  str r0, [r3, r2, lsl #2]          // *(r3 + r2 * 4) = r0",
 
-    // The link register is set to the `EXC_RETURN` value on exception entry. To
-    // ensure we continue executing in the kernel we ensure the SPSEL bit is set
-    // to 0 to use the main (kernel) stack.
-    bfc lr, #2, #1                    // LR = LR & !(0x1<<2)
+        "  // The link register is set to the `EXC_RETURN` value on exception entry. To",
+        "  // ensure we continue executing in the kernel we ensure the SPSEL bit is set",
+        "  // to 0 to use the main (kernel) stack.",
+        "  bfc lr, #2, #1                    // LR = LR & !(0x1<<2)",
 
-    // Now we can return from the interrupt context and resume what we were
-    // doing. If an app was executing we will switch to the kernel so it can
-    // choose whether to service the interrupt.
-    bx lr
-    ",
+        "  // Now we can return from the interrupt context and resume what we were",
+        "  // doing. If an app was executing we will switch to the kernel so it can",
+        "  // choose whether to service the interrupt.",
+        "  bx lr",
     );
 }
 
@@ -215,56 +209,54 @@ pub unsafe fn switch_to_user_arm_v7m(
 ) -> *const usize {
     use core::arch::asm;
     asm!(
-    "
-    // Rust `asm!()` macro (as of May 2021) will not let us mark r6, r7 and r9
-    // as clobbers. r6 and r9 is used internally by LLVM, and r7 is used for
-    // the frame pointer. However, in the process of restoring and saving the
-    // process's registers, we do in fact clobber r6, r7 and r9. So, we work
-    // around this by doing our own manual saving of r6 using r2, r7 using r3,
-    // r9 using r12, and then mark those as clobbered.
-    mov r2, r6                        // r2 = r6
-    mov r3, r7                        // r3 = r7
-    mov r12, r9                       // r12 = r9
+        "  // Rust `asm!()` macro (as of May 2021) will not let us mark r6, r7 and r9",
+        "  // as clobbers. r6 and r9 is used internally by LLVM, and r7 is used for",
+        "  // the frame pointer. However, in the process of restoring and saving the",
+        "  // process's registers, we do in fact clobber r6, r7 and r9. So, we work",
+        "  // around this by doing our own manual saving of r6 using r2, r7 using r3,",
+        "  // r9 using r12, and then mark those as clobbered.",
+        "  mov r2, r6                        // r2 = r6",
+        "  mov r3, r7                        // r3 = r7",
+        "  mov r12, r9                       // r12 = r9",
 
-    // The arguments passed in are:
-    // - `r0` is the bottom of the user stack
-    // - `r1` is a reference to `CortexMStoredState.regs`
+        "  // The arguments passed in are:",
+        "  // - `r0` is the bottom of the user stack",
+        "  // - `r1` is a reference to `CortexMStoredState.regs`",
 
-    // Load bottom of stack into Process Stack Pointer.
-    msr psp, r0                       // PSP = r0
+        "  // Load bottom of stack into Process Stack Pointer.",
+        "  msr psp, r0                       // PSP = r0",
 
-    // Load non-hardware-stacked registers from the process stored state. Ensure
-    // that the address register (right now r1) is stored in a callee saved
-    // register.
-    ldmia r1, {{r4-r11}}              // r4 = r1[0], r5 = r1[1], ...
+        "  // Load non-hardware-stacked registers from the process stored state. Ensure",
+        "  // that the address register (right now r1) is stored in a callee saved",
+        "  // register.",
+        "  ldmia r1, {{r4-r11}}              // r4 = r1[0], r5 = r1[1], ...",
 
-    // Generate a SVC exception to handle the context switch from kernel to
-    // userspace. It doesn't matter which SVC number we use here as it is not
-    // used in the exception handler. Data being returned from a syscall is
-    // transferred on the app's stack.
-    svc 0xff
+        "  // Generate a SVC exception to handle the context switch from kernel to",
+        "  // userspace. It doesn't matter which SVC number we use here as it is not",
+        "  // used in the exception handler. Data being returned from a syscall is",
+        "  // transferred on the app's stack.",
+        "  svc 0xff",
 
-    // When execution returns here we have switched back to the kernel from the
-    // application.
+        "  // When execution returns here we have switched back to the kernel from the",
+        "  // application.",
 
-    // Push non-hardware-stacked registers into the saved state for the
-    // application.
-    stmia r1, {{r4-r11}}              // r1[0] = r4, r1[1] = r5, ...
+        "  // Push non-hardware-stacked registers into the saved state for the",
+        "  // application.",
+        "  stmia r1, {{r4-r11}}              // r1[0] = r4, r1[1] = r5, ...",
 
-    // Update the user stack pointer with the current value after the
-    // application has executed.
-    mrs r0, PSP                       // r0 = PSP
+        "  // Update the user stack pointer with the current value after the",
+        "  // application has executed.",
+        "  mrs r0, PSP                       // r0 = PSP",
 
-    // Need to restore r6, r7 and r12 since we clobbered them when switching to
-    // and from the app.
-    mov r6, r2                        // r6 = r2
-    mov r7, r3                        // r7 = r3
-    mov r9, r12                       // r9 = r12
-    ",
-    inout("r0") user_stack,
-    in("r1") process_regs,
-    out("r2") _, out("r3") _, out("r4") _, out("r5") _, out("r8") _, out("r10") _,
-    out("r11") _, out("r12") _);
+        "  // Need to restore r6, r7 and r12 since we clobbered them when switching to",
+        "  // and from the app.",
+        "  mov r6, r2                        // r6 = r2",
+        "  mov r7, r3                        // r7 = r3",
+        "  mov r9, r12                       // r9 = r12",
+        inout("r0") user_stack,
+        in("r1") process_regs,
+        out("r2") _, out("r3") _, out("r4") _, out("r5") _, out("r8") _, out("r10") _,
+        out("r11") _, out("r12") _);
 
     user_stack
 }
@@ -436,80 +428,79 @@ pub unsafe extern "C" fn hard_fault_handler_arm_v7m() {
     // Because calling a function increases the stack pointer, we have to check for a kernel
     // stack overflow and adjust the stack pointer before we branch
     naked_asm!(
-    "
-        mov    r2, 0     // r2 = 0
-        tst    lr, #4    // bitwise AND link register to 0b100
-        itte   eq        // if lr==4, run next two instructions, else, run 3rd instruction.
-        mrseq  r0, msp   // r0 = kernel stack pointer
-        addeq  r2, 1     // r2 = 1, kernel was executing
-        mrsne  r0, psp   // r0 = userland stack pointer
-        // Need to determine if we had a stack overflow before we push anything
-        // on to the stack. We check this by looking at the BusFault Status
-        // Register's (BFSR) `LSPERR` and `STKERR` bits to see if the hardware
-        // had any trouble stacking important registers to the stack during the
-        // fault. If so, then we cannot use this stack while handling this fault
-        // or we will trigger another fault.
-        ldr   r3, =0xE000ED29  // SCB BFSR register address
-        ldrb  r3, [r3]         // r3 = BFSR
-        tst   r3, #0x30        // r3 = BFSR & 0b00110000; LSPERR & STKERR bits
-        ite   ne               // check if the result of that bitwise AND was not 0
-        movne r1, #1           // BFSR & 0b00110000 != 0; r1 = 1
-        moveq r1, #0           // BFSR & 0b00110000 == 0; r1 = 0
-        and r5, r2, r1         // bitwise and r1 and r2, store in r5
-        cmp  r5, #1            //  update condition codes to reflect if r1 == 1 && r2 == 1
-        itt  eq                // if r5==1 run the next 2 instructions, else skip to branch
-        // if true, The hardware couldn't use the stack, so we have no saved data and
-        // we cannot use the kernel stack as is. We just want to report that
-        // the kernel's stack overflowed, since that is essential for
-        // debugging.
-        //
-        // To make room for a panic!() handler stack, we just re-use the
-        // kernel's original stack. This should in theory leave the bottom
-        // of the stack where the problem occurred untouched should one want
-        // to further debug.
-        ldreq  r4, ={estack} // load _estack into r4
-        moveq  sp, r4        // Set the stack pointer to _estack
-        // finally, if the fault occurred in privileged mode (r2 == 1), branch
-        // to non-naked handler.
-        cmp r2, #0
-        // Per ARM calling convention, faulting stack is passed in r0, whether
-        // there was a stack overflow in r1. This function must never return.
-        bne {kernel_hard_fault_handler} // branch to kernel hard fault handler
-        // Otherwise, the hard fault occurred in userspace. In this case, read
-        // the relevant SCB registers:
-        ldr r0, =SCB_REGISTERS    // Global variable address
-        ldr r1, =0xE000ED14       // SCB CCR register address
-        ldr r2, [r1, #0]          // CCR
-        str r2, [r0, #0]
-        ldr r2, [r1, #20]         // CFSR
-        str r2, [r0, #4]
-        ldr r2, [r1, #24]         // HFSR
-        str r2, [r0, #8]
-        ldr r2, [r1, #32]         // MMFAR
-        str r2, [r0, #12]
-        ldr r2, [r1, #36]         // BFAR
-        str r2, [r0, #16]
+        "  mov    r2, 0     // r2 = 0",
+        "  tst    lr, #4    // bitwise AND link register to 0b100",
+        "  itte   eq        // if lr==4, run next two instructions, else, run 3rd instruction.",
+        "  mrseq  r0, msp   // r0 = kernel stack pointer",
+        "  addeq  r2, 1     // r2 = 1, kernel was executing",
+        "  mrsne  r0, psp   // r0 = userland stack pointer",
+        "  // Need to determine if we had a stack overflow before we push anything",
+        "  // on to the stack. We check this by looking at the BusFault Status",
+        "  // Register's (BFSR) `LSPERR` and `STKERR` bits to see if the hardware",
+        "  // had any trouble stacking important registers to the stack during the",
+        "  // fault. If so, then we cannot use this stack while handling this fault",
+        "  // or we will trigger another fault.",
+        "  ldr   r3, =0xE000ED29  // SCB BFSR register address",
+        "  ldrb  r3, [r3]         // r3 = BFSR",
+        "  tst   r3, #0x30        // r3 = BFSR & 0b00110000; LSPERR & STKERR bits",
+        "  ite   ne               // check if the result of that bitwise AND was not 0",
+        "  movne r1, #1           // BFSR & 0b00110000 != 0; r1 = 1",
+        "  moveq r1, #0           // BFSR & 0b00110000 == 0; r1 = 0",
+        "  and r5, r2, r1         // bitwise and r1 and r2, store in r5",
+        "  cmp  r5, #1            //  update condition codes to reflect if r1 == 1 && r2 == 1",
+        "  itt  eq                // if r5==1 run the next 2 instructions, else skip to branch",
+        "  // if true, The hardware couldn't use the stack, so we have no saved data and",
+        "  // we cannot use the kernel stack as is. We just want to report that",
+        "  // the kernel's stack overflowed, since that is essential for",
+        "  // debugging.",
+        "  //",
+        "  // To make room for a panic!() handler stack, we just re-use the",
+        "  // kernel's original stack. This should in theory leave the bottom",
+        "  // of the stack where the problem occurred untouched should one want",
+        "  // to further debug.",
+        "  ldreq  r4, ={estack} // load _estack into r4",
+        "  moveq  sp, r4        // Set the stack pointer to _estack",
+        "  // finally, if the fault occurred in privileged mode (r2 == 1), branch",
+        "  // to non-naked handler.",
+        "  cmp r2, #0",
+        "  // Per ARM calling convention, faulting stack is passed in r0, whether",
+        "  // there was a stack overflow in r1. This function must never return.",
+        "  bne {kernel_hard_fault_handler} // branch to kernel hard fault handler",
+        "  // Otherwise, the hard fault occurred in userspace. In this case, read",
+        "  // the relevant SCB registers:",
+        "  ldr r0, =SCB_REGISTERS    // Global variable address",
+        "  ldr r1, =0xE000ED14       // SCB CCR register address",
+        "  ldr r2, [r1, #0]          // CCR",
+        "  str r2, [r0, #0]",
+        "  ldr r2, [r1, #20]         // CFSR",
+        "  str r2, [r0, #4]",
+        "  ldr r2, [r1, #24]         // HFSR",
+        "  str r2, [r0, #8]",
+        "  ldr r2, [r1, #32]         // MMFAR",
+        "  str r2, [r0, #12]",
+        "  ldr r2, [r1, #36]         // BFAR",
+        "  str r2, [r0, #16]",
 
-        ldr r0, =APP_HARD_FAULT  // Global variable address
-        mov r1, #1               // r1 = 1
-        str r1, [r0, #0]         // APP_HARD_FAULT = 1
+        "  ldr r0, =APP_HARD_FAULT  // Global variable address",
+        "  mov r1, #1               // r1 = 1",
+        "  str r1, [r0, #0]         // APP_HARD_FAULT = 1",
 
-        // Set thread mode to privileged
-        mov r0, #0
-        msr CONTROL, r0
-        // CONTROL writes must be followed by ISB
-        // http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dai0321a/BIHFJCAC.html
-        isb
+        "  // Set thread mode to privileged",
+        "  mov r0, #0",
+        "  msr CONTROL, r0",
+        "  // CONTROL writes must be followed by ISB",
+        "  // http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dai0321a/BIHFJCAC.html",
+        "  isb",
 
-        // The link register is set to the `EXC_RETURN` value on exception
-        // entry. To ensure we continue executing in the kernel we ensure the
-        // SPSEL bit is set to 0 to use the main (kernel) stack.
-        bfc lr, #2, #1                    // LR = LR & !(0x1<<2)
+        "  // The link register is set to the `EXC_RETURN` value on exception",
+        "  // entry. To ensure we continue executing in the kernel we ensure the",
+        "  // SPSEL bit is set to 0 to use the main (kernel) stack.",
+        "  bfc lr, #2, #1                    // LR = LR & !(0x1<<2)",
 
-        bx lr",
-    estack = sym _estack,
-    kernel_hard_fault_handler = sym hard_fault_handler_arm_v7m_kernel,
-    );
+        "  bx lr",
+        estack = sym _estack,
+        kernel_hard_fault_handler = sym hard_fault_handler_arm_v7m_kernel,
+        );
 }
 
 // Table 2.5


### PR DESCRIPTION
### Pull Request Overview

This PR does a (likely imperfect) job of porting core ARM assembly code to the proposed upstream asm fmt, as a comparison point for #4502.

### Testing Strategy

Untested.

### TODO or Help Wanted

Compare to #4502 proposal; keep discussion there, this is just a convenience for viewing.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
