### PR TITLE
clippy: deny unused_result_ok

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,9 @@ codegen-units = 1
 # 3. The third section are lints that we do want we just need to fixup the code
 #    to pass the lint checks.
 [workspace.lints.clippy]
-restriction = "allow"
+# RESTRICTION LINTS
+restriction = { level = "allow", priority = -1 }
+unused_result_ok = "deny"
 
 # COMPLEXITY LINTS
 complexity = { level = "deny", priority = -1 }

--- a/capsules/core/src/adc.rs
+++ b/capsules/core/src/adc.rs
@@ -753,16 +753,14 @@ impl<'a, A: hil::adc::Adc<'a> + hil::adc::AdcHighSpeed<'a>> hil::adc::Client
                 self.apps
                     .enter(id, |_app, upcalls| {
                         calledback = true;
-                        upcalls
-                            .schedule_upcall(
-                                0,
-                                (
-                                    AdcMode::SingleSample as usize,
-                                    self.channel.get(),
-                                    sample as usize,
-                                ),
-                            )
-                            .ok();
+                        let _ = upcalls.schedule_upcall(
+                            0,
+                            (
+                                AdcMode::SingleSample as usize,
+                                self.channel.get(),
+                                sample as usize,
+                            ),
+                        );
                     })
                     .map_err(|err| {
                         if err == kernel::process::Error::NoSuchApp
@@ -780,16 +778,14 @@ impl<'a, A: hil::adc::Adc<'a> + hil::adc::AdcHighSpeed<'a>> hil::adc::Client
                 self.apps
                     .enter(id, |_app, upcalls| {
                         calledback = true;
-                        upcalls
-                            .schedule_upcall(
-                                0,
-                                (
-                                    AdcMode::ContinuousSample as usize,
-                                    self.channel.get(),
-                                    sample as usize,
-                                ),
-                            )
-                            .ok();
+                        let _ = upcalls.schedule_upcall(
+                            0,
+                            (
+                                AdcMode::ContinuousSample as usize,
+                                self.channel.get(),
+                                sample as usize,
+                            ),
+                        );
                     })
                     .map_err(|err| {
                         if err == kernel::process::Error::NoSuchApp
@@ -1060,12 +1056,10 @@ impl<'a, A: hil::adc::Adc<'a> + hil::adc::AdcHighSpeed<'a>> hil::adc::HighSpeedC
                         if perform_callback {
                             // actually schedule the callback
                             let len_chan = ((buf_len / 2) << 8) | (self.channel.get() & 0xFF);
-                            kernel_data
-                                .schedule_upcall(
-                                    0,
-                                    (self.mode.get() as usize, len_chan, buf_ptr as usize),
-                                )
-                                .ok();
+                            let _ = kernel_data.schedule_upcall(
+                                0,
+                                (self.mode.get() as usize, len_chan, buf_ptr as usize),
+                            );
 
                             // if the mode is SingleBuffer, the operation is
                             // complete. Clean up state
@@ -1334,12 +1328,10 @@ impl hil::adc::Client for AdcVirtualized<'_> {
             let _ = self.apps.enter(processid, |app, upcalls| {
                 app.pending_command = false;
                 let channel = app.channel;
-                upcalls
-                    .schedule_upcall(
-                        0,
-                        (AdcMode::SingleSample as usize, channel, sample as usize),
-                    )
-                    .ok();
+                let _ = upcalls.schedule_upcall(
+                    0,
+                    (AdcMode::SingleSample as usize, channel, sample as usize),
+                );
             });
         });
         self.run_next_command();

--- a/capsules/core/src/alarm.rs
+++ b/capsules/core/src/alarm.rs
@@ -166,19 +166,17 @@ impl<'a, A: Alarm<'a>> AlarmDriver<'a, A> {
                 alarm_state.expiration = None;
 
                 // Deliver the upcall:
-                upcalls
-                    .schedule_upcall(
-                        ALARM_CALLBACK_NUM,
-                        (
-                            now.into_u32_left_justified() as usize,
-                            expired
-                                .reference
-                                .wrapping_add(expired.dt)
-                                .into_u32_left_justified() as usize,
-                            0,
-                        ),
-                    )
-                    .ok();
+                let _ = upcalls.schedule_upcall(
+                    ALARM_CALLBACK_NUM,
+                    (
+                        now.into_u32_left_justified() as usize,
+                        expired
+                            .reference
+                            .wrapping_add(expired.dt)
+                            .into_u32_left_justified() as usize,
+                        0,
+                    ),
+                );
             });
 
             // Proceed iteration across expirations:

--- a/capsules/core/src/button.rs
+++ b/capsules/core/src/button.rs
@@ -236,9 +236,8 @@ impl<'a, P: gpio::InterruptPin<'a>> gpio::ClientWithValue for Button<'a, P> {
         self.apps.each(|_, cntr, upcalls| {
             if cntr.subscribe_map & (1 << pin_num) != 0 {
                 interrupt_count.set(interrupt_count.get() + 1);
-                upcalls
-                    .schedule_upcall(UPCALL_NUM, (pin_num as usize, button_state as usize, 0))
-                    .ok();
+                let _ = upcalls
+                    .schedule_upcall(UPCALL_NUM, (pin_num as usize, button_state as usize, 0));
             }
         });
 

--- a/capsules/core/src/console.rs
+++ b/capsules/core/src/console.rs
@@ -221,7 +221,7 @@ impl<'a> Console<'a> {
                     // Go ahead and signal the application
                     let written = app.write_len;
                     app.write_len = 0;
-                    kernel_data.schedule_upcall(1, (written, 0, 0)).ok();
+                    let _ = kernel_data.schedule_upcall(1, (written, 0, 0));
                 }
             });
         } else {
@@ -343,9 +343,7 @@ impl uart::TransmitClient for Console<'_> {
                         // Go ahead and signal the application
                         let written = app.write_len;
                         app.write_len = 0;
-                        kernel_data
-                            .schedule_upcall(upcall::WRITE_DONE, (written, 0, 0))
-                            .ok();
+                        let _ = kernel_data.schedule_upcall(upcall::WRITE_DONE, (written, 0, 0));
                     }
                 }
             })
@@ -441,31 +439,21 @@ impl uart::ReceiveClient for Console<'_> {
                                     (rcode, rx_len)
                                 };
 
-                                kernel_data
-                                    .schedule_upcall(
-                                        upcall::READ_DONE,
-                                        (
-                                            kernel::errorcode::into_statuscode(ret),
-                                            received_length,
-                                            0,
-                                        ),
-                                    )
-                                    .ok();
+                                let _ = kernel_data.schedule_upcall(
+                                    upcall::READ_DONE,
+                                    (kernel::errorcode::into_statuscode(ret), received_length, 0),
+                                );
                             }
                             _ => {
                                 // Some UART error occurred
-                                kernel_data
-                                    .schedule_upcall(
-                                        upcall::READ_DONE,
-                                        (
-                                            kernel::errorcode::into_statuscode(Err(
-                                                ErrorCode::FAIL,
-                                            )),
-                                            0,
-                                            0,
-                                        ),
-                                    )
-                                    .ok();
+                                let _ = kernel_data.schedule_upcall(
+                                    upcall::READ_DONE,
+                                    (
+                                        kernel::errorcode::into_statuscode(Err(ErrorCode::FAIL)),
+                                        0,
+                                        0,
+                                    ),
+                                );
                             }
                         }
                     })

--- a/capsules/core/src/console_ordered.rs
+++ b/capsules/core/src/console_ordered.rs
@@ -521,31 +521,21 @@ impl<'a, A: Alarm<'a>> uart::ReceiveClient for ConsoleOrdered<'a, A> {
                                     // case.
                                     (rcode, rx_len)
                                 };
-                                kernel_data
-                                    .schedule_upcall(
-                                        2,
-                                        (
-                                            kernel::errorcode::into_statuscode(ret),
-                                            received_length,
-                                            0,
-                                        ),
-                                    )
-                                    .ok();
+                                let _ = kernel_data.schedule_upcall(
+                                    2,
+                                    (kernel::errorcode::into_statuscode(ret), received_length, 0),
+                                );
                             }
                             _ => {
                                 // Some UART error occurred
-                                kernel_data
-                                    .schedule_upcall(
-                                        2,
-                                        (
-                                            kernel::errorcode::into_statuscode(Err(
-                                                ErrorCode::FAIL,
-                                            )),
-                                            0,
-                                            0,
-                                        ),
-                                    )
-                                    .ok();
+                                let _ = kernel_data.schedule_upcall(
+                                    2,
+                                    (
+                                        kernel::errorcode::into_statuscode(Err(ErrorCode::FAIL)),
+                                        0,
+                                        0,
+                                    ),
+                                );
                             }
                         }
                     })

--- a/capsules/core/src/gpio.rs
+++ b/capsules/core/src/gpio.rs
@@ -146,9 +146,8 @@ impl<'a, IP: gpio::InterruptPin<'a>> gpio::ClientWithValue for GPIO<'a, IP> {
 
             // schedule callback with the pin number and value
             self.apps.each(|_, _, upcalls| {
-                upcalls
-                    .schedule_upcall(UPCALL_NUM, (pin_num as usize, pin_state as usize, 0))
-                    .ok();
+                let _ =
+                    upcalls.schedule_upcall(UPCALL_NUM, (pin_num as usize, pin_state as usize, 0));
             });
         }
     }

--- a/capsules/core/src/i2c_master.rs
+++ b/capsules/core/src/i2c_master.rs
@@ -205,16 +205,14 @@ impl<'a, I: i2c::I2CMaster<'a>> i2c::I2CHwMasterClient for I2CMasterDriver<'a, I
                 }
 
                 // signal to driver that tx complete
-                kernel_data
-                    .schedule_upcall(
+                let _ = kernel_data.schedule_upcall(
+                    0,
+                    (
+                        kernel::errorcode::into_statuscode(status.map_err(|e| e.into())),
                         0,
-                        (
-                            kernel::errorcode::into_statuscode(status.map_err(|e| e.into())),
-                            0,
-                            0,
-                        ),
-                    )
-                    .ok();
+                        0,
+                    ),
+                );
             })
         });
 

--- a/capsules/core/src/i2c_master_slave_driver.rs
+++ b/capsules/core/src/i2c_master_slave_driver.rs
@@ -118,7 +118,7 @@ impl<'a, I: hil::i2c::I2CMasterSlave<'a>> hil::i2c::I2CHwMasterClient
 
                 self.app.map(|app| {
                     let _ = self.apps.enter(app, |_, kernel_data| {
-                        kernel_data.schedule_upcall(0, (0, status, 0)).ok();
+                        let _ = kernel_data.schedule_upcall(0, (0, status, 0));
                     });
                 });
             }
@@ -148,7 +148,7 @@ impl<'a, I: hil::i2c::I2CMasterSlave<'a>> hil::i2c::I2CHwMasterClient
                                 })
                             })
                             .unwrap_or(0);
-                        kernel_data.schedule_upcall(0, (1, status, 0)).ok();
+                        let _ = kernel_data.schedule_upcall(0, (1, status, 0));
                     });
                 });
             }
@@ -174,7 +174,7 @@ impl<'a, I: hil::i2c::I2CMasterSlave<'a>> hil::i2c::I2CHwMasterClient
                                 })
                             })
                             .unwrap_or(0);
-                        kernel_data.schedule_upcall(0, (7, status, 0)).ok();
+                        let _ = kernel_data.schedule_upcall(0, (7, status, 0));
                     });
                 });
             }
@@ -232,7 +232,7 @@ impl<'a, I: hil::i2c::I2CMasterSlave<'a>> hil::i2c::I2CHwSlaveClient
                             })
                             .unwrap_or(0);
 
-                        kernel_data.schedule_upcall(0, (3, length, 0)).ok();
+                        let _ = kernel_data.schedule_upcall(0, (3, length, 0));
                     });
                 });
             }
@@ -243,7 +243,7 @@ impl<'a, I: hil::i2c::I2CMasterSlave<'a>> hil::i2c::I2CHwSlaveClient
                 // Notify the app that the read finished
                 self.app.map(|app| {
                     let _ = self.apps.enter(app, |_, kernel_data| {
-                        kernel_data.schedule_upcall(0, (4, length, 0)).ok();
+                        let _ = kernel_data.schedule_upcall(0, (4, length, 0));
                     });
                 });
             }
@@ -258,7 +258,7 @@ impl<'a, I: hil::i2c::I2CMasterSlave<'a>> hil::i2c::I2CHwSlaveClient
                 // Ask the app to setup a read buffer. The app must call
                 // command 3 after it has setup the shared read buffer with
                 // the correct bytes.
-                kernel_data.schedule_upcall(0, (2, 0, 0)).ok();
+                let _ = kernel_data.schedule_upcall(0, (2, 0, 0));
             });
         });
     }

--- a/capsules/core/src/rng.rs
+++ b/capsules/core/src/rng.rs
@@ -152,7 +152,7 @@ impl<'a, R: Rng<'a>> rng::Client for RngDriver<'a, R> {
                     if app.remaining > 0 {
                         done = false;
                     } else {
-                        kernel_data.schedule_upcall(0, (0, newidx, 0)).ok();
+                        let _ = kernel_data.schedule_upcall(0, (0, newidx, 0));
                     }
                 }
             });

--- a/capsules/core/src/spi_controller.rs
+++ b/capsules/core/src/spi_controller.rs
@@ -472,7 +472,7 @@ impl<'a, S: SpiMasterDevice<'a>> SpiMasterClient for Spi<'a, S> {
                     let len = app.len;
                     app.len = 0;
                     app.index = 0;
-                    kernel_data.schedule_upcall(0, (len, 0, 0)).ok();
+                    let _ = kernel_data.schedule_upcall(0, (len, 0, 0));
                 } else {
                     self.do_next_read_write(app, kernel_data);
                 }

--- a/capsules/core/src/spi_peripheral.rs
+++ b/capsules/core/src/spi_peripheral.rs
@@ -313,7 +313,7 @@ impl<'a, S: SpiSlaveDevice<'a>> SpiSlaveClient for SpiPeripheral<'a, S> {
                     let len = app.len;
                     app.len = 0;
                     app.index = 0;
-                    kernel_data.schedule_upcall(0, (len, 0, 0)).ok();
+                    let _ = kernel_data.schedule_upcall(0, (len, 0, 0));
                 } else {
                     self.do_next_read_write(app, kernel_data);
                 }
@@ -326,7 +326,7 @@ impl<'a, S: SpiSlaveDevice<'a>> SpiSlaveClient for SpiPeripheral<'a, S> {
         self.current_process.map(|process_id| {
             let _ = self.grants.enter(process_id, move |app, kernel_data| {
                 let len = app.len;
-                kernel_data.schedule_upcall(1, (len, 0, 0)).ok();
+                let _ = kernel_data.schedule_upcall(1, (len, 0, 0));
             });
         });
     }

--- a/capsules/extra/src/air_quality.rs
+++ b/capsules/extra/src/air_quality.rs
@@ -99,13 +99,11 @@ impl hil::sensors::AirQualityClient for AirQualitySensor<'_> {
         for cntr in self.apps.iter() {
             cntr.enter(|app, upcalls| {
                 if app.operation == Operation::CO2 {
-                    value
-                        .map(|co2| {
-                            self.busy.set(false);
-                            app.operation = Operation::None;
-                            upcalls.schedule_upcall(0, (co2 as usize, 0, 0)).ok();
-                        })
-                        .ok();
+                    let _ = value.map(|co2| {
+                        self.busy.set(false);
+                        app.operation = Operation::None;
+                        let _ = upcalls.schedule_upcall(0, (co2 as usize, 0, 0));
+                    });
                 }
             });
         }
@@ -115,13 +113,11 @@ impl hil::sensors::AirQualityClient for AirQualitySensor<'_> {
         for cntr in self.apps.iter() {
             cntr.enter(|app, upcalls| {
                 if app.operation == Operation::TVOC {
-                    value
-                        .map(|tvoc| {
-                            self.busy.set(false);
-                            app.operation = Operation::None;
-                            upcalls.schedule_upcall(0, (tvoc as usize, 0, 0)).ok();
-                        })
-                        .ok();
+                    let _ = value.map(|tvoc| {
+                        self.busy.set(false);
+                        app.operation = Operation::None;
+                        let _ = upcalls.schedule_upcall(0, (tvoc as usize, 0, 0));
+                    });
                 }
             });
         }

--- a/capsules/extra/src/ambient_light.rs
+++ b/capsules/extra/src/ambient_light.rs
@@ -120,9 +120,7 @@ impl hil::sensors::AmbientLightClient for AmbientLight<'_> {
         self.apps.each(|_, app, upcalls| {
             if app.pending {
                 app.pending = false;
-                upcalls
-                    .schedule_upcall(upcall::LIGHT_INTENSITY, (lux, 0, 0))
-                    .ok();
+                let _ = upcalls.schedule_upcall(upcall::LIGHT_INTENSITY, (lux, 0, 0));
             }
         });
     }

--- a/capsules/extra/src/analog_comparator.rs
+++ b/capsules/extra/src/analog_comparator.rs
@@ -178,7 +178,7 @@ impl<'a, A: hil::analog_comparator::AnalogComparator<'a>> hil::analog_comparator
     fn fired(&self, channel: usize) {
         self.current_process.map(|processid| {
             let _ = self.grants.enter(processid, |_app, upcalls| {
-                upcalls.schedule_upcall(0, (channel, 0, 0)).ok();
+                let _ = upcalls.schedule_upcall(0, (channel, 0, 0));
             });
         });
     }

--- a/capsules/extra/src/app_flash_driver.rs
+++ b/capsules/extra/src/app_flash_driver.rs
@@ -157,7 +157,7 @@ impl hil::nonvolatile_storage::NonvolatileStorageClient for AppFlash<'_> {
         // Notify the current application that the command finished.
         self.current_app.take().map(|processid| {
             let _ = self.apps.enter(processid, |_app, upcalls| {
-                upcalls.schedule_upcall(upcall::WRITE_DONE, (0, 0, 0)).ok();
+                let _ = upcalls.schedule_upcall(upcall::WRITE_DONE, (0, 0, 0));
             });
         });
 

--- a/capsules/extra/src/app_loader.rs
+++ b/capsules/extra/src/app_loader.rs
@@ -245,9 +245,8 @@ impl<
             let _ = self.apps.enter(processid, move |app, kernel_data| {
                 app.pending_command = false;
                 // Signal the app.
-                kernel_data
-                    .schedule_upcall(upcall::SETUP_DONE, (into_statuscode(result), 0, 0))
-                    .ok();
+                let _ = kernel_data
+                    .schedule_upcall(upcall::SETUP_DONE, (into_statuscode(result), 0, 0));
             });
         });
     }
@@ -262,9 +261,8 @@ impl<
                 app.pending_command = false;
 
                 // And then signal the app.
-                kernel_data
-                    .schedule_upcall(upcall::WRITE_DONE, (into_statuscode(result), length, 0))
-                    .ok();
+                let _ = kernel_data
+                    .schedule_upcall(upcall::WRITE_DONE, (into_statuscode(result), length, 0));
             });
         });
     }
@@ -277,9 +275,8 @@ impl<
                 app.pending_command = false;
 
                 self.current_process.take();
-                kernel_data
-                    .schedule_upcall(upcall::FINALIZE_DONE, (into_statuscode(result), 0, 0))
-                    .ok();
+                let _ = kernel_data
+                    .schedule_upcall(upcall::FINALIZE_DONE, (into_statuscode(result), 0, 0));
             });
         });
     }
@@ -292,9 +289,8 @@ impl<
                 app.pending_command = false;
 
                 self.current_process.take();
-                kernel_data
-                    .schedule_upcall(upcall::ABORT_DONE, (into_statuscode(result), 0, 0))
-                    .ok();
+                let _ = kernel_data
+                    .schedule_upcall(upcall::ABORT_DONE, (into_statuscode(result), 0, 0));
             });
         });
     }
@@ -340,9 +336,8 @@ impl<
                 app.pending_command = false;
                 // Signal the app.
                 self.current_process.take();
-                kernel_data
-                    .schedule_upcall(upcall::LOAD_DONE, (into_statuscode(status_code), 0, 0))
-                    .ok();
+                let _ = kernel_data
+                    .schedule_upcall(upcall::LOAD_DONE, (into_statuscode(status_code), 0, 0));
             });
         });
     }

--- a/capsules/extra/src/ble_advertising_driver.rs
+++ b/capsules/extra/src/ble_advertising_driver.rs
@@ -509,12 +509,10 @@ where
                         .unwrap_or(false);
 
                     if success {
-                        kernel_data
-                            .schedule_upcall(
-                                0,
-                                (kernel::errorcode::into_statuscode(result), len as usize, 0),
-                            )
-                            .ok();
+                        let _ = kernel_data.schedule_upcall(
+                            0,
+                            (kernel::errorcode::into_statuscode(result), len as usize, 0),
+                        );
                     }
                 }
 

--- a/capsules/extra/src/buzzer_driver.rs
+++ b/capsules/extra/src/buzzer_driver.rs
@@ -192,9 +192,8 @@ impl<'a, B: hil::buzzer::Buzzer<'a>> hil::buzzer::BuzzerClient for Buzzer<'a, B>
         // Mark the active app as None and see if there is a callback.
         self.active_app.take().map(|processid| {
             let _ = self.apps.enter(processid, |_app, upcalls| {
-                upcalls
-                    .schedule_upcall(0, (kernel::errorcode::into_statuscode(status), 0, 0))
-                    .ok();
+                let _ =
+                    upcalls.schedule_upcall(0, (kernel::errorcode::into_statuscode(status), 0, 0));
             });
         });
 

--- a/capsules/extra/src/can.rs
+++ b/capsules/extra/src/can.rs
@@ -144,9 +144,7 @@ impl<'a, Can: can::Can> CanCapsule<'a, Can> {
     fn schedule_callback(&self, callback_number: usize, data: (usize, usize, usize)) {
         self.processid.map(|processid| {
             let _ = self.processes.enter(processid, |_app, kernel_data| {
-                kernel_data
-                    .schedule_upcall(callback_number, (data.0, data.1, data.2))
-                    .ok();
+                let _ = kernel_data.schedule_upcall(callback_number, (data.0, data.1, data.2));
             });
         });
     }

--- a/capsules/extra/src/crc.rs
+++ b/capsules/extra/src/crc.rs
@@ -223,12 +223,10 @@ impl<'a, C: Crc<'a>> CrcDriver<'a, C> {
                     Ok(()) => Ok(()),
                     Err(e) => {
                         if grant.request.is_some() {
-                            kernel_data
-                                .schedule_upcall(
-                                    0,
-                                    (kernel::errorcode::into_statuscode(Err(e)), 0, 0),
-                                )
-                                .ok();
+                            let _ = kernel_data.schedule_upcall(
+                                0,
+                                (kernel::errorcode::into_statuscode(Err(e)), 0, 0),
+                            );
                             grant.request = None;
                         }
                         Err(e)
@@ -411,18 +409,14 @@ impl<'a, C: Crc<'a>> Client for CrcDriver<'a, C> {
                             // through a system call: regardless, the request is gone, so cancel
                             // the CRC.
                             if grant.request.is_none() {
-                                kernel_data
-                                    .schedule_upcall(
+                                let _ = kernel_data.schedule_upcall(
+                                    0,
+                                    (
+                                        kernel::errorcode::into_statuscode(Err(ErrorCode::FAIL)),
                                         0,
-                                        (
-                                            kernel::errorcode::into_statuscode(Err(
-                                                ErrorCode::FAIL,
-                                            )),
-                                            0,
-                                            0,
-                                        ),
-                                    )
-                                    .ok();
+                                        0,
+                                    ),
+                                );
                                 return;
                             }
 
@@ -446,18 +440,16 @@ impl<'a, C: Crc<'a>> Client for CrcDriver<'a, C> {
                                     }
                                     Err(_) => {
                                         grant.request = None;
-                                        kernel_data
-                                            .schedule_upcall(
+                                        let _ = kernel_data.schedule_upcall(
+                                            0,
+                                            (
+                                                kernel::errorcode::into_statuscode(Err(
+                                                    ErrorCode::FAIL,
+                                                )),
                                                 0,
-                                                (
-                                                    kernel::errorcode::into_statuscode(Err(
-                                                        ErrorCode::FAIL,
-                                                    )),
-                                                    0,
-                                                    0,
-                                                ),
-                                            )
-                                            .ok();
+                                                0,
+                                            ),
+                                        );
                                     }
                                 }
                             } else {
@@ -475,18 +467,16 @@ impl<'a, C: Crc<'a>> Client for CrcDriver<'a, C> {
                                     .unwrap_or(0);
                                 if amount == 0 {
                                     grant.request = None;
-                                    kernel_data
-                                        .schedule_upcall(
+                                    let _ = kernel_data.schedule_upcall(
+                                        0,
+                                        (
+                                            kernel::errorcode::into_statuscode(Err(
+                                                ErrorCode::NOMEM,
+                                            )),
                                             0,
-                                            (
-                                                kernel::errorcode::into_statuscode(Err(
-                                                    ErrorCode::NOMEM,
-                                                )),
-                                                0,
-                                                0,
-                                            ),
-                                        )
-                                        .ok();
+                                            0,
+                                        ),
+                                    );
                                 } else {
                                     self.app_buffer_written.add(amount);
                                 }
@@ -503,12 +493,10 @@ impl<'a, C: Crc<'a>> Client for CrcDriver<'a, C> {
                             self.current_process.map(|pid| {
                                 let _res = self.grant.enter(pid, |grant, kernel_data| {
                                     grant.request = None;
-                                    kernel_data
-                                        .schedule_upcall(
-                                            0,
-                                            (kernel::errorcode::into_statuscode(Err(e)), 0, 0),
-                                        )
-                                        .ok();
+                                    let _ = kernel_data.schedule_upcall(
+                                        0,
+                                        (kernel::errorcode::into_statuscode(Err(e)), 0, 0),
+                                    );
                                 });
                             });
                         }
@@ -521,9 +509,8 @@ impl<'a, C: Crc<'a>> Client for CrcDriver<'a, C> {
                 self.current_process.map(|pid| {
                     let _res = self.grant.enter(pid, |grant, kernel_data| {
                         grant.request = None;
-                        kernel_data
-                            .schedule_upcall(0, (kernel::errorcode::into_statuscode(Err(e)), 0, 0))
-                            .ok();
+                        let _ = kernel_data
+                            .schedule_upcall(0, (kernel::errorcode::into_statuscode(Err(e)), 0, 0));
                     });
                 });
             }
@@ -544,21 +531,18 @@ impl<'a, C: Crc<'a>> Client for CrcDriver<'a, C> {
                 match result {
                     Ok(output) => {
                         let (val, user_int) = encode_upcall_crc_output(output);
-                        kernel_data
-                            .schedule_upcall(
-                                0,
-                                (
-                                    kernel::errorcode::into_statuscode(Ok(())),
-                                    val as usize,
-                                    user_int as usize,
-                                ),
-                            )
-                            .ok();
+                        let _ = kernel_data.schedule_upcall(
+                            0,
+                            (
+                                kernel::errorcode::into_statuscode(Ok(())),
+                                val as usize,
+                                user_int as usize,
+                            ),
+                        );
                     }
                     Err(e) => {
-                        kernel_data
-                            .schedule_upcall(0, (kernel::errorcode::into_statuscode(Err(e)), 0, 0))
-                            .ok();
+                        let _ = kernel_data
+                            .schedule_upcall(0, (kernel::errorcode::into_statuscode(Err(e)), 0, 0));
                     }
                 }
             });

--- a/capsules/extra/src/date_time.rs
+++ b/capsules/extra/src/date_time.rs
@@ -257,7 +257,7 @@ impl<'a, DateTime: date_time::DateTime<'a>> DateTimeCapsule<'a, DateTime> {
                         Ok(()) => Some(()),
                         Err(e) => {
                             let upcall_status = into_statuscode(Err(e));
-                            kernel.schedule_upcall(0, (upcall_status, 0, 0)).ok();
+                            let _ = kernel.schedule_upcall(0, (upcall_status, 0, 0));
                             None
                         }
                     }
@@ -299,9 +299,7 @@ impl<'a, DateTime: date_time::DateTime<'a>> date_time::DateTimeClient
                         }
                     }
 
-                    upcalls
-                        .schedule_upcall(0, (upcall_status, upcall_r1, upcall_r2))
-                        .ok();
+                    let _ = upcalls.schedule_upcall(0, (upcall_status, upcall_r1, upcall_r2));
                 }
             });
         }
@@ -315,9 +313,7 @@ impl<'a, DateTime: date_time::DateTime<'a>> date_time::DateTimeClient
         let _enter_grant = self.apps.enter(processid, |app, upcalls| {
             app.task = None;
 
-            upcalls
-                .schedule_upcall(0, (into_statuscode(result), 0, 0))
-                .ok();
+            let _ = upcalls.schedule_upcall(0, (into_statuscode(result), 0, 0));
         });
 
         self.queue_next_command();

--- a/capsules/extra/src/distance.rs
+++ b/capsules/extra/src/distance.rs
@@ -141,10 +141,10 @@ impl<'a, T: hil::sensors::Distance<'a>> hil::sensors::DistanceClient for Distanc
                     app.subscribed = false; // Clear the subscribed flag.
                     match distance_val {
                         Ok(distance) => {
-                            upcalls.schedule_upcall(0, (0, distance as usize, 0)).ok();
+                            let _ = upcalls.schedule_upcall(0, (0, distance as usize, 0));
                         }
                         Err(e) => {
-                            upcalls.schedule_upcall(0, (e as usize, 0, 0)).ok();
+                            let _ = upcalls.schedule_upcall(0, (e as usize, 0, 0));
                         }
                     }
                 }

--- a/capsules/extra/src/ethernet_tap.rs
+++ b/capsules/extra/src/ethernet_tap.rs
@@ -407,16 +407,14 @@ impl<'a, E: EthernetAdapterDatapath<'a>> EthernetTapDriver<'a, E> {
                 u32::from_be_bytes([flags_bytes[0], flags_bytes[1], len_bytes[0], len_bytes[1]])
             };
 
-            kernel_data
-                .schedule_upcall(
-                    upcall::TX_FRAME,
-                    (
-                        into_statuscode(err),
-                        flags_len as usize,
-                        transmission_identifier as usize,
-                    ),
-                )
-                .ok();
+            let _ = kernel_data.schedule_upcall(
+                upcall::TX_FRAME,
+                (
+                    into_statuscode(err),
+                    flags_len as usize,
+                    transmission_identifier as usize,
+                ),
+            );
 
             // Reset the `tx_pending` state of this app:
             grant.tx_pending = None;

--- a/capsules/extra/src/gpio_async.rs
+++ b/capsules/extra/src/gpio_async.rs
@@ -102,7 +102,7 @@ impl<Port: hil::gpio_async::Port> hil::gpio_async::Client for GPIOAsync<'_, Port
     fn fired(&self, pin: usize, identifier: usize) {
         // schedule callback with the pin number and value for all apps
         self.grants.each(|_, _app, upcalls| {
-            upcalls.schedule_upcall(1, (identifier, pin, 0)).ok();
+            let _ = upcalls.schedule_upcall(1, (identifier, pin, 0));
         });
     }
 
@@ -110,7 +110,7 @@ impl<Port: hil::gpio_async::Port> hil::gpio_async::Client for GPIOAsync<'_, Port
         // alert currently configuring app
         self.configuring_process.map(|pid| {
             let _ = self.grants.enter(pid, |_app, upcalls| {
-                upcalls.schedule_upcall(0, (0, value, 0)).ok();
+                let _ = upcalls.schedule_upcall(0, (0, value, 0));
             });
         });
         // then clear currently configuring app

--- a/capsules/extra/src/hmac.rs
+++ b/capsules/extra/src/hmac.rs
@@ -339,9 +339,8 @@ impl<
                     // If we get here we are ready to run the digest, reset the copied data
                     if app.op.get().unwrap() == UserSpaceOp::Run {
                         if let Err(e) = self.calculate_digest() {
-                            kernel_data
-                                .schedule_upcall(0, (into_statuscode(e.into()), 0, 0))
-                                .ok();
+                            let _ =
+                                kernel_data.schedule_upcall(0, (into_statuscode(e.into()), 0, 0));
                         }
                     } else if app.op.get().unwrap() == UserSpaceOp::Verify {
                         let _ = kernel_data
@@ -367,12 +366,11 @@ impl<
                             });
 
                         if let Err(e) = self.verify_digest() {
-                            kernel_data
-                                .schedule_upcall(1, (into_statuscode(e.into()), 0, 0))
-                                .ok();
+                            let _ =
+                                kernel_data.schedule_upcall(1, (into_statuscode(e.into()), 0, 0));
                         }
                     } else {
-                        kernel_data.schedule_upcall(0, (0, 0, 0)).ok();
+                        let _ = kernel_data.schedule_upcall(0, (0, 0, 0));
                     }
                 })
                 .map_err(|err| {
@@ -419,12 +417,11 @@ impl<
                             })
                         });
 
-                    match result {
+                    let _ = match result {
                         Ok(()) => kernel_data.schedule_upcall(0, (0, pointer as usize, 0)),
                         Err(e) => kernel_data
                             .schedule_upcall(0, (into_statuscode(e.into()), pointer as usize, 0)),
-                    }
-                    .ok();
+                    };
 
                     // Clear the current processid as it has finished running
                     self.processid.clear();
@@ -462,11 +459,10 @@ impl<
                 .enter(id, |_app, kernel_data| {
                     self.hmac.clear_data();
 
-                    match result {
+                    let _ = match result {
                         Ok(equal) => kernel_data.schedule_upcall(1, (0, equal as usize, 0)),
                         Err(e) => kernel_data.schedule_upcall(1, (into_statuscode(e.into()), 0, 0)),
-                    }
-                    .ok();
+                    };
 
                     // Clear the current processid as it has finished running
                     self.processid.clear();
@@ -685,12 +681,10 @@ impl<
                     3 => {
                         if app_match {
                             if let Err(e) = self.calculate_digest() {
-                                kernel_data
-                                    .schedule_upcall(
-                                        0,
-                                        (kernel::errorcode::into_statuscode(e.into()), 0, 0),
-                                    )
-                                    .ok();
+                                let _ = kernel_data.schedule_upcall(
+                                    0,
+                                    (kernel::errorcode::into_statuscode(e.into()), 0, 0),
+                                );
                             }
                             CommandReturn::success()
                         } else {
@@ -743,9 +737,8 @@ impl<
                                 });
 
                             if let Err(e) = self.verify_digest() {
-                                kernel_data
-                                    .schedule_upcall(1, (into_statuscode(e.into()), 0, 0))
-                                    .ok();
+                                let _ = kernel_data
+                                    .schedule_upcall(1, (into_statuscode(e.into()), 0, 0));
                             }
                             CommandReturn::success()
                         } else {

--- a/capsules/extra/src/humidity.rs
+++ b/capsules/extra/src/humidity.rs
@@ -129,7 +129,7 @@ impl<'a, H: hil::sensors::HumidityDriver<'a>> hil::sensors::HumidityClient
             cntr.enter(|app, upcalls| {
                 if app.subscribed {
                     app.subscribed = false;
-                    upcalls.schedule_upcall(0, (humidity_val, 0, 0)).ok();
+                    let _ = upcalls.schedule_upcall(0, (humidity_val, 0, 0));
                 }
             });
         }

--- a/capsules/extra/src/ieee802154/driver.rs
+++ b/capsules/extra/src/ieee802154/driver.rs
@@ -538,18 +538,16 @@ impl<'a, M: device::MacDevice<'a>> DeferredCallClient for RadioDriver<'a, M> {
             .apps
             .enter(self.saved_processid.unwrap_or_panic(), |_app, upcalls| {
                 // Unwrap fail = missing processid
-                upcalls
-                    .schedule_upcall(
-                        upcall::FRAME_TRANSMITTED,
-                        (
-                            kernel::errorcode::into_statuscode(
-                                self.saved_result.unwrap_or_panic(), // Unwrap fail = missing result
-                            ),
-                            0,
-                            0,
+                let _ = upcalls.schedule_upcall(
+                    upcall::FRAME_TRANSMITTED,
+                    (
+                        kernel::errorcode::into_statuscode(
+                            self.saved_result.unwrap_or_panic(), // Unwrap fail = missing result
                         ),
-                    )
-                    .ok();
+                        0,
+                        0,
+                    ),
+                );
             });
     }
 
@@ -980,16 +978,14 @@ impl<'a, M: device::MacDevice<'a>> device::TxClient for RadioDriver<'a, M> {
         self.kernel_tx.replace(spi_buf);
         self.current_app.take().map(|processid| {
             let _ = self.apps.enter(processid, |_app, upcalls| {
-                upcalls
-                    .schedule_upcall(
-                        upcall::FRAME_TRANSMITTED,
-                        (
-                            kernel::errorcode::into_statuscode(result),
-                            acked as usize,
-                            0,
-                        ),
-                    )
-                    .ok();
+                let _ = upcalls.schedule_upcall(
+                    upcall::FRAME_TRANSMITTED,
+                    (
+                        kernel::errorcode::into_statuscode(result),
+                        acked as usize,
+                        0,
+                    ),
+                );
             });
         });
         self.do_next_tx_async();
@@ -1085,9 +1081,7 @@ impl<'a, M: device::MacDevice<'a>> device::RxClient for RadioDriver<'a, M> {
                 .unwrap_or(false);
             if read_present {
                 // Place lqi as argument to be included in upcall.
-                kernel_data
-                    .schedule_upcall(upcall::FRAME_RECEIVED, (lqi as usize, 0, 0))
-                    .ok();
+                let _ = kernel_data.schedule_upcall(upcall::FRAME_RECEIVED, (lqi as usize, 0, 0));
             }
         });
     }

--- a/capsules/extra/src/ieee802154/phy_driver.rs
+++ b/capsules/extra/src/ieee802154/phy_driver.rs
@@ -307,12 +307,10 @@ impl<'a, R: hil::radio::Radio<'a>> hil::radio::TxClient for RadioDriver<'a, R> {
         self.kernel_tx.replace(spi_buf);
         self.current_app.take().map(|processid| {
             let _ = self.apps.enter(processid, |_app, upcalls| {
-                upcalls
-                    .schedule_upcall(
-                        upcall::FRAME_TRANSMITTED,
-                        (kernel::errorcode::into_statuscode(result), acked.into(), 0),
-                    )
-                    .ok();
+                let _ = upcalls.schedule_upcall(
+                    upcall::FRAME_TRANSMITTED,
+                    (kernel::errorcode::into_statuscode(result), acked.into(), 0),
+                );
             });
         });
         self.do_next_tx();
@@ -441,9 +439,7 @@ impl<'a, R: hil::radio::Radio<'a>> hil::radio::RxClient for RadioDriver<'a, R> {
                 .unwrap_or(false);
             if read_present {
                 // Place lqi as argument to be included in upcall.
-                kernel_data
-                    .schedule_upcall(upcall::FRAME_RECEIVED, (lqi as usize, 0, 0))
-                    .ok();
+                let _ = kernel_data.schedule_upcall(upcall::FRAME_RECEIVED, (lqi as usize, 0, 0));
             }
         });
 

--- a/capsules/extra/src/isolated_nonvolatile_storage_driver.rs
+++ b/capsules/extra/src/isolated_nonvolatile_storage_driver.rs
@@ -769,12 +769,10 @@ impl<'a, const APP_REGION_SIZE: usize> IsolatedNonvolatileStorage<'a, APP_REGION
                                 Ok(started_operation) => started_operation,
                                 Err(e) => {
                                     app.pending_operation = None;
-                                    kernel_data
-                                        .schedule_upcall(
-                                            nvm_command.upcall(),
-                                            (into_statuscode(Err(e)), 0, 0),
-                                        )
-                                        .ok();
+                                    let _ = kernel_data.schedule_upcall(
+                                        nvm_command.upcall(),
+                                        (into_statuscode(Err(e)), 0, 0),
+                                    );
 
                                     false
                                 }
@@ -804,12 +802,10 @@ impl<'a, const APP_REGION_SIZE: usize> IsolatedNonvolatileStorage<'a, APP_REGION
                         // clear pending syscall
                         app.pending_operation = None;
                         // signal app with the result
-                        kernel_data
-                            .schedule_upcall(
-                                upcall::GET_SIZE_DONE,
-                                (into_statuscode(Ok(())), region.length, 0),
-                            )
-                            .ok();
+                        let _ = kernel_data.schedule_upcall(
+                            upcall::GET_SIZE_DONE,
+                            (into_statuscode(Ok(())), region.length, 0),
+                        );
                         Ok(false)
                     }
                     None => Err(ErrorCode::NOMEM),
@@ -961,12 +957,10 @@ impl<const APP_REGION_SIZE: usize> hil::nonvolatile_storage::NonvolatileStorageC
                         // clear pending syscall
                         app.pending_operation = None;
                         // And then signal the app.
-                        kernel_data
-                            .schedule_upcall(
-                                upcall::READ_DONE,
-                                (into_statuscode(Ok(())), read_len, 0),
-                            )
-                            .ok();
+                        let _ = kernel_data.schedule_upcall(
+                            upcall::READ_DONE,
+                            (into_statuscode(Ok(())), read_len, 0),
+                        );
                     });
 
                     self.check_queue();
@@ -1062,12 +1056,10 @@ impl<const APP_REGION_SIZE: usize> hil::nonvolatile_storage::NonvolatileStorageC
                         // clear pending syscall
                         app.pending_operation = None;
                         // Notify app that its write has completed.
-                        kernel_data
-                            .schedule_upcall(
-                                upcall::WRITE_DONE,
-                                (into_statuscode(Ok(())), length, 0),
-                            )
-                            .ok();
+                        let _ = kernel_data.schedule_upcall(
+                            upcall::WRITE_DONE,
+                            (into_statuscode(Ok(())), length, 0),
+                        );
                     });
                     self.current_user.clear();
                     self.check_queue();

--- a/capsules/extra/src/kv_driver.rs
+++ b/capsules/extra/src/kv_driver.rs
@@ -324,12 +324,10 @@ impl<'a, V: kv::KVPermissions<'a>> kv::KVClient for KVStoreDriver<'a, V> {
                     app.op.clear();
 
                     if let Err(e) = result {
-                        upcalls
-                            .schedule_upcall(
-                                upcalls::VALUE,
-                                (errorcode::into_statuscode(e.into()), 0, 0),
-                            )
-                            .ok();
+                        let _ = upcalls.schedule_upcall(
+                            upcalls::VALUE,
+                            (errorcode::into_statuscode(e.into()), 0, 0),
+                        );
                     } else {
                         let value_len = value.len();
                         let ret = upcalls
@@ -352,12 +350,10 @@ impl<'a, V: kv::KVPermissions<'a>> kv::KVClient for KVStoreDriver<'a, V> {
                         // error and only read the portion that would fit in the
                         // buffer if the value was larger than the provided
                         // processbuffer.
-                        upcalls
-                            .schedule_upcall(
-                                upcalls::VALUE,
-                                (errorcode::into_statuscode(ret), value_len, 0),
-                            )
-                            .ok();
+                        let _ = upcalls.schedule_upcall(
+                            upcalls::VALUE,
+                            (errorcode::into_statuscode(ret), value_len, 0),
+                        );
                     }
                 }
 
@@ -385,9 +381,10 @@ impl<'a, V: kv::KVPermissions<'a>> kv::KVClient for KVStoreDriver<'a, V> {
             self.apps.enter(id, move |app, upcalls| {
                 if app.op.contains(&UserSpaceOp::Set) {
                     app.op.clear();
-                    upcalls
-                        .schedule_upcall(upcalls::VALUE, (errorcode::into_statuscode(result), 0, 0))
-                        .ok();
+                    let _ = upcalls.schedule_upcall(
+                        upcalls::VALUE,
+                        (errorcode::into_statuscode(result), 0, 0),
+                    );
                 }
             })
         });
@@ -412,9 +409,10 @@ impl<'a, V: kv::KVPermissions<'a>> kv::KVClient for KVStoreDriver<'a, V> {
             self.apps.enter(id, move |app, upcalls| {
                 if app.op.contains(&UserSpaceOp::Add) {
                     app.op.clear();
-                    upcalls
-                        .schedule_upcall(upcalls::VALUE, (errorcode::into_statuscode(result), 0, 0))
-                        .ok();
+                    let _ = upcalls.schedule_upcall(
+                        upcalls::VALUE,
+                        (errorcode::into_statuscode(result), 0, 0),
+                    );
                 }
             })
         });
@@ -439,9 +437,10 @@ impl<'a, V: kv::KVPermissions<'a>> kv::KVClient for KVStoreDriver<'a, V> {
             self.apps.enter(id, move |app, upcalls| {
                 if app.op.contains(&UserSpaceOp::Update) {
                     app.op.clear();
-                    upcalls
-                        .schedule_upcall(upcalls::VALUE, (errorcode::into_statuscode(result), 0, 0))
-                        .ok();
+                    let _ = upcalls.schedule_upcall(
+                        upcalls::VALUE,
+                        (errorcode::into_statuscode(result), 0, 0),
+                    );
                 }
             })
         });
@@ -459,9 +458,10 @@ impl<'a, V: kv::KVPermissions<'a>> kv::KVClient for KVStoreDriver<'a, V> {
             self.apps.enter(id, move |app, upcalls| {
                 if app.op.contains(&UserSpaceOp::Delete) {
                     app.op.clear();
-                    upcalls
-                        .schedule_upcall(upcalls::VALUE, (errorcode::into_statuscode(result), 0, 0))
-                        .ok();
+                    let _ = upcalls.schedule_upcall(
+                        upcalls::VALUE,
+                        (errorcode::into_statuscode(result), 0, 0),
+                    );
                 }
             })
         });
@@ -477,9 +477,10 @@ impl<'a, V: kv::KVPermissions<'a>> kv::KVClient for KVStoreDriver<'a, V> {
             self.apps.enter(id, move |app, upcalls| {
                 if app.op.contains(&UserSpaceOp::GarbageCollect) {
                     app.op.clear();
-                    upcalls
-                        .schedule_upcall(upcalls::VALUE, (errorcode::into_statuscode(result), 0, 0))
-                        .ok();
+                    let _ = upcalls.schedule_upcall(
+                        upcalls::VALUE,
+                        (errorcode::into_statuscode(result), 0, 0),
+                    );
                 }
             })
         });

--- a/capsules/extra/src/l3gd20.rs
+++ b/capsules/extra/src/l3gd20.rs
@@ -445,9 +445,7 @@ impl<'a, S: spi::SpiMasterDevice<'a>> spi::SpiMasterClient for L3gd20Spi<'a, S> 
                         } else {
                             false
                         };
-                        upcalls
-                            .schedule_upcall(0, (1, usize::from(present), 0))
-                            .ok();
+                        let _ = upcalls.schedule_upcall(0, (1, usize::from(present), 0));
                         L3gd20Status::Idle
                     }
 
@@ -494,9 +492,9 @@ impl<'a, S: spi::SpiMasterDevice<'a>> spi::SpiMasterClient for L3gd20Spi<'a, S> 
                             false
                         };
                         if values {
-                            upcalls.schedule_upcall(0, (x, y, z)).ok();
+                            let _ = upcalls.schedule_upcall(0, (x, y, z));
                         } else {
-                            upcalls.schedule_upcall(0, (0, 0, 0)).ok();
+                            let _ = upcalls.schedule_upcall(0, (0, 0, 0));
                         }
                         L3gd20Status::Idle
                     }
@@ -520,17 +518,15 @@ impl<'a, S: spi::SpiMasterDevice<'a>> spi::SpiMasterClient for L3gd20Spi<'a, S> 
                             false
                         };
                         if value {
-                            upcalls
-                                .schedule_upcall(0, (temperature as usize, 0, 0))
-                                .ok();
+                            let _ = upcalls.schedule_upcall(0, (temperature as usize, 0, 0));
                         } else {
-                            upcalls.schedule_upcall(0, (0, 0, 0)).ok();
+                            let _ = upcalls.schedule_upcall(0, (0, 0, 0));
                         }
                         L3gd20Status::Idle
                     }
 
                     _ => {
-                        upcalls.schedule_upcall(0, (0, 0, 0)).ok();
+                        let _ = upcalls.schedule_upcall(0, (0, 0, 0));
                         L3gd20Status::Idle
                     }
                 });

--- a/capsules/extra/src/lps25hb.rs
+++ b/capsules/extra/src/lps25hb.rs
@@ -182,7 +182,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for LPS25HB<'_, I> {
             self.buffer.replace(buffer);
             self.owning_process.map(|pid| {
                 let _ = self.apps.enter(pid, |_app, upcalls| {
-                    upcalls.schedule_upcall(0, (0, 0, 0)).ok();
+                    let _ = upcalls.schedule_upcall(0, (0, 0, 0));
                 });
             });
             return;
@@ -208,9 +208,8 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for LPS25HB<'_, I> {
                     self.buffer.replace(buffer);
                     self.owning_process.map(|pid| {
                         let _ = self.apps.enter(pid, |_app, upcalls| {
-                            upcalls
-                                .schedule_upcall(0, (into_statuscode(Err(error.into())), 0, 0))
-                                .ok();
+                            let _ = upcalls
+                                .schedule_upcall(0, (into_statuscode(Err(error.into())), 0, 0));
                         });
                     });
                 } else {
@@ -223,9 +222,8 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for LPS25HB<'_, I> {
                     self.buffer.replace(buffer);
                     self.owning_process.map(|pid| {
                         let _ = self.apps.enter(pid, |_app, upcalls| {
-                            upcalls
-                                .schedule_upcall(0, (into_statuscode(Err(error.into())), 0, 0))
-                                .ok();
+                            let _ = upcalls
+                                .schedule_upcall(0, (into_statuscode(Err(error.into())), 0, 0));
                         });
                     });
                 } else {
@@ -242,9 +240,8 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for LPS25HB<'_, I> {
                     self.buffer.replace(buffer);
                     self.owning_process.map(|pid| {
                         let _ = self.apps.enter(pid, |_app, upcalls| {
-                            upcalls
-                                .schedule_upcall(0, (into_statuscode(Err(error.into())), 0, 0))
-                                .ok();
+                            let _ = upcalls
+                                .schedule_upcall(0, (into_statuscode(Err(error.into())), 0, 0));
                         });
                     });
                 } else {
@@ -257,9 +254,8 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for LPS25HB<'_, I> {
                     self.buffer.replace(buffer);
                     self.owning_process.map(|pid| {
                         let _ = self.apps.enter(pid, |_app, upcalls| {
-                            upcalls
-                                .schedule_upcall(0, (into_statuscode(Err(error.into())), 0, 0))
-                                .ok();
+                            let _ = upcalls
+                                .schedule_upcall(0, (into_statuscode(Err(error.into())), 0, 0));
                         });
                     });
                 } else {
@@ -275,9 +271,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for LPS25HB<'_, I> {
 
                 self.owning_process.map(|pid| {
                     let _ = self.apps.enter(pid, |_app, upcalls| {
-                        upcalls
-                            .schedule_upcall(0, (pressure_ubar as usize, 0, 0))
-                            .ok();
+                        let _ = upcalls.schedule_upcall(0, (pressure_ubar as usize, 0, 0));
                     });
                 });
 
@@ -289,9 +283,8 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for LPS25HB<'_, I> {
                     self.buffer.replace(buffer);
                     self.owning_process.map(|pid| {
                         let _ = self.apps.enter(pid, |_app, upcalls| {
-                            upcalls
-                                .schedule_upcall(0, (into_statuscode(Err(error.into())), 0, 0))
-                                .ok();
+                            let _ = upcalls
+                                .schedule_upcall(0, (into_statuscode(Err(error.into())), 0, 0));
                         });
                     });
                 } else {

--- a/capsules/extra/src/lsm303agr.rs
+++ b/capsules/extra/src/lsm303agr.rs
@@ -412,9 +412,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303agrI2C<'_, I> {
                 let present = status.is_ok() && buffer[0] == 60;
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(pid, |_app, upcalls| {
-                        upcalls
-                            .schedule_upcall(0, (usize::from(present), 0, 0))
-                            .ok();
+                        let _ = upcalls.schedule_upcall(0, (usize::from(present), 0, 0));
                     });
                 });
                 self.buffer.replace(buffer);
@@ -425,9 +423,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303agrI2C<'_, I> {
                 let set_power = status == Ok(());
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(pid, |_app, upcalls| {
-                        upcalls
-                            .schedule_upcall(0, (usize::from(set_power), 0, 0))
-                            .ok();
+                        let _ = upcalls.schedule_upcall(0, (usize::from(set_power), 0, 0));
                     });
                 });
                 self.buffer.replace(buffer);
@@ -446,9 +442,8 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303agrI2C<'_, I> {
                 let set_scale_and_resolution = status == Ok(());
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(pid, |_app, upcalls| {
-                        upcalls
-                            .schedule_upcall(0, (usize::from(set_scale_and_resolution), 0, 0))
-                            .ok();
+                        let _ = upcalls
+                            .schedule_upcall(0, (usize::from(set_scale_and_resolution), 0, 0));
                     });
                 });
                 self.buffer.replace(buffer);
@@ -496,9 +491,9 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303agrI2C<'_, I> {
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(pid, |_app, upcalls| {
                         if values {
-                            upcalls.schedule_upcall(0, (x, y, z)).ok();
+                            let _ = upcalls.schedule_upcall(0, (x, y, z));
                         } else {
-                            upcalls.schedule_upcall(0, (0, 0, 0)).ok();
+                            let _ = upcalls.schedule_upcall(0, (0, 0, 0));
                         }
                     });
                 });
@@ -510,9 +505,8 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303agrI2C<'_, I> {
                 let set_magneto_data_rate = status == Ok(());
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(pid, |_app, upcalls| {
-                        upcalls
-                            .schedule_upcall(0, (usize::from(set_magneto_data_rate), 0, 0))
-                            .ok();
+                        let _ =
+                            upcalls.schedule_upcall(0, (usize::from(set_magneto_data_rate), 0, 0));
                     });
                 });
                 self.buffer.replace(buffer);
@@ -528,9 +522,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303agrI2C<'_, I> {
                 let set_range = status == Ok(());
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(pid, |_app, upcalls| {
-                        upcalls
-                            .schedule_upcall(0, (usize::from(set_range), 0, 0))
-                            .ok();
+                        let _ = upcalls.schedule_upcall(0, (usize::from(set_range), 0, 0));
                     });
                 });
                 if self.config_in_progress.get() {
@@ -551,9 +543,9 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303agrI2C<'_, I> {
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(pid, |_app, upcalls| {
                         if let Ok(temp) = values {
-                            upcalls.schedule_upcall(0, (temp as usize, 0, 0)).ok();
+                            let _ = upcalls.schedule_upcall(0, (temp as usize, 0, 0));
                         } else {
-                            upcalls.schedule_upcall(0, (0, 0, 0)).ok();
+                            let _ = upcalls.schedule_upcall(0, (0, 0, 0));
                         }
                     });
                 });
@@ -591,9 +583,9 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303agrI2C<'_, I> {
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(pid, |_app, upcalls| {
                         if values {
-                            upcalls.schedule_upcall(0, (x, y, z)).ok();
+                            let _ = upcalls.schedule_upcall(0, (x, y, z));
                         } else {
-                            upcalls.schedule_upcall(0, (0, 0, 0)).ok();
+                            let _ = upcalls.schedule_upcall(0, (0, 0, 0));
                         }
                     });
                 });

--- a/capsules/extra/src/lsm303dlhc.rs
+++ b/capsules/extra/src/lsm303dlhc.rs
@@ -406,9 +406,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303dlhcI2C<'_, I> {
 
                 self.current_process.map(|process_id| {
                     let _ = self.apps.enter(process_id, |_grant, upcalls| {
-                        upcalls
-                            .schedule_upcall(0, (usize::from(present), 0, 0))
-                            .ok();
+                        let _ = upcalls.schedule_upcall(0, (usize::from(present), 0, 0));
                     });
                 });
 
@@ -421,9 +419,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303dlhcI2C<'_, I> {
 
                 self.current_process.map(|process_id| {
                     let _ = self.apps.enter(process_id, |_grant, upcalls| {
-                        upcalls
-                            .schedule_upcall(0, (usize::from(set_power), 0, 0))
-                            .ok();
+                        let _ = upcalls.schedule_upcall(0, (usize::from(set_power), 0, 0));
                     });
                 });
 
@@ -442,9 +438,8 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303dlhcI2C<'_, I> {
 
                 self.current_process.map(|process_id| {
                     let _ = self.apps.enter(process_id, |_grant, upcalls| {
-                        upcalls
-                            .schedule_upcall(0, (usize::from(set_scale_and_resolution), 0, 0))
-                            .ok();
+                        let _ = upcalls
+                            .schedule_upcall(0, (usize::from(set_scale_and_resolution), 0, 0));
                     });
                 });
 
@@ -497,9 +492,9 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303dlhcI2C<'_, I> {
                 self.current_process.map(|process_id| {
                     let _ = self.apps.enter(process_id, |_grant, upcalls| {
                         if values {
-                            upcalls.schedule_upcall(0, (x, y, z)).ok();
+                            let _ = upcalls.schedule_upcall(0, (x, y, z));
                         } else {
-                            upcalls.schedule_upcall(0, (0, 0, 0)).ok();
+                            let _ = upcalls.schedule_upcall(0, (0, 0, 0));
                         }
                     });
                 });
@@ -513,12 +508,10 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303dlhcI2C<'_, I> {
 
                 self.current_process.map(|process_id| {
                     let _ = self.apps.enter(process_id, |_grant, upcalls| {
-                        upcalls
-                            .schedule_upcall(
-                                0,
-                                (usize::from(set_temperature_and_magneto_data_rate), 0, 0),
-                            )
-                            .ok();
+                        let _ = upcalls.schedule_upcall(
+                            0,
+                            (usize::from(set_temperature_and_magneto_data_rate), 0, 0),
+                        );
                     });
                 });
 
@@ -536,9 +529,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303dlhcI2C<'_, I> {
 
                 self.current_process.map(|process_id| {
                     let _ = self.apps.enter(process_id, |_grant, upcalls| {
-                        upcalls
-                            .schedule_upcall(0, (usize::from(set_range), 0, 0))
-                            .ok();
+                        let _ = upcalls.schedule_upcall(0, (usize::from(set_range), 0, 0));
                     });
                 });
 
@@ -564,9 +555,9 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303dlhcI2C<'_, I> {
                 self.current_process.map(|process_id| {
                     let _ = self.apps.enter(process_id, |_grant, upcalls| {
                         if let Ok(temp) = values {
-                            upcalls.schedule_upcall(0, (temp as usize, 0, 0)).ok();
+                            let _ = upcalls.schedule_upcall(0, (temp as usize, 0, 0));
                         } else {
-                            upcalls.schedule_upcall(0, (0, 0, 0)).ok();
+                            let _ = upcalls.schedule_upcall(0, (0, 0, 0));
                         }
                     });
                 });
@@ -606,9 +597,9 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303dlhcI2C<'_, I> {
                 self.current_process.map(|process_id| {
                     let _ = self.apps.enter(process_id, |_grant, upcalls| {
                         if values {
-                            upcalls.schedule_upcall(0, (x, y, z)).ok();
+                            let _ = upcalls.schedule_upcall(0, (x, y, z));
                         } else {
-                            upcalls.schedule_upcall(0, (0, 0, 0)).ok();
+                            let _ = upcalls.schedule_upcall(0, (0, 0, 0));
                         }
                     });
                 });

--- a/capsules/extra/src/lsm6dsoxtr.rs
+++ b/capsules/extra/src/lsm6dsoxtr.rs
@@ -405,16 +405,14 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm6dsoxtrI2C<'_, I> {
 
                 self.syscall_process.take().map(|pid| {
                     let _res = self.apps.enter(pid, |_app, upcalls| {
-                        upcalls
-                            .schedule_upcall(
+                        let _ = upcalls.schedule_upcall(
+                            0,
+                            (
+                                into_statuscode(status.map_err(|i2c_error| i2c_error.into())),
+                                usize::from(self.is_present.get()),
                                 0,
-                                (
-                                    into_statuscode(status.map_err(|i2c_error| i2c_error.into())),
-                                    usize::from(self.is_present.get()),
-                                    0,
-                                ),
-                            )
-                            .ok();
+                            ),
+                        );
                     });
                 });
             }
@@ -510,16 +508,14 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm6dsoxtrI2C<'_, I> {
                 }
                 self.syscall_process.take().map(|pid| {
                     let _res = self.apps.enter(pid, |_app, upcalls| {
-                        upcalls
-                            .schedule_upcall(
+                        let _ = upcalls.schedule_upcall(
+                            0,
+                            (
+                                into_statuscode(status.map_err(|i2c_error| i2c_error.into())),
+                                usize::from(status == Ok(())),
                                 0,
-                                (
-                                    into_statuscode(status.map_err(|i2c_error| i2c_error.into())),
-                                    usize::from(status == Ok(())),
-                                    0,
-                                ),
-                            )
-                            .ok();
+                            ),
+                        );
                     });
                 });
             }
@@ -531,16 +527,14 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm6dsoxtrI2C<'_, I> {
                 self.config_in_progress.set(false);
                 self.syscall_process.take().map(|pid| {
                     let _res = self.apps.enter(pid, |_app, upcalls| {
-                        upcalls
-                            .schedule_upcall(
+                        let _ = upcalls.schedule_upcall(
+                            0,
+                            (
+                                into_statuscode(status.map_err(|i2c_error| i2c_error.into())),
+                                usize::from(status == Ok(())),
                                 0,
-                                (
-                                    into_statuscode(status.map_err(|i2c_error| i2c_error.into())),
-                                    usize::from(status == Ok(())),
-                                    0,
-                                ),
-                            )
-                            .ok();
+                            ),
+                        );
                     });
                 });
             }

--- a/capsules/extra/src/ltc294x.rs
+++ b/capsules/extra/src/ltc294x.rs
@@ -464,9 +464,7 @@ impl<I: i2c::I2CDevice> LTC294XClient for LTC294XDriver<'_, I> {
     fn interrupt(&self) {
         self.owning_process.map(|pid| {
             let _res = self.grants.enter(pid, |_app, upcalls| {
-                upcalls
-                    .schedule_upcall(upcall::EVENT_FINISHED, (0, 0, 0))
-                    .ok();
+                let _ = upcalls.schedule_upcall(upcall::EVENT_FINISHED, (0, 0, 0));
             });
         });
     }
@@ -486,12 +484,10 @@ impl<I: i2c::I2CDevice> LTC294XClient for LTC294XDriver<'_, I> {
             | ((accumulated_charge_overflow as usize) << 4);
         self.owning_process.map(|pid| {
             let _res = self.grants.enter(pid, |_app, upcalls| {
-                upcalls
-                    .schedule_upcall(
-                        upcall::EVENT_FINISHED,
-                        (1, ret, self.ltc294x.model.get() as usize),
-                    )
-                    .ok();
+                let _ = upcalls.schedule_upcall(
+                    upcall::EVENT_FINISHED,
+                    (1, ret, self.ltc294x.model.get() as usize),
+                );
             });
         });
     }
@@ -499,9 +495,7 @@ impl<I: i2c::I2CDevice> LTC294XClient for LTC294XDriver<'_, I> {
     fn charge(&self, charge: u16) {
         self.owning_process.map(|pid| {
             let _res = self.grants.enter(pid, |_app, upcalls| {
-                upcalls
-                    .schedule_upcall(upcall::EVENT_FINISHED, (2, charge as usize, 0))
-                    .ok();
+                let _ = upcalls.schedule_upcall(upcall::EVENT_FINISHED, (2, charge as usize, 0));
             });
         });
     }
@@ -509,9 +503,7 @@ impl<I: i2c::I2CDevice> LTC294XClient for LTC294XDriver<'_, I> {
     fn done(&self) {
         self.owning_process.map(|pid| {
             let _res = self.grants.enter(pid, |_app, upcalls| {
-                upcalls
-                    .schedule_upcall(upcall::EVENT_FINISHED, (3, 0, 0))
-                    .ok();
+                let _ = upcalls.schedule_upcall(upcall::EVENT_FINISHED, (3, 0, 0));
             });
         });
     }
@@ -519,9 +511,7 @@ impl<I: i2c::I2CDevice> LTC294XClient for LTC294XDriver<'_, I> {
     fn voltage(&self, voltage: u16) {
         self.owning_process.map(|pid| {
             let _res = self.grants.enter(pid, |_app, upcalls| {
-                upcalls
-                    .schedule_upcall(upcall::EVENT_FINISHED, (4, voltage as usize, 0))
-                    .ok();
+                let _ = upcalls.schedule_upcall(upcall::EVENT_FINISHED, (4, voltage as usize, 0));
             });
         });
     }
@@ -529,9 +519,7 @@ impl<I: i2c::I2CDevice> LTC294XClient for LTC294XDriver<'_, I> {
     fn current(&self, current: u16) {
         self.owning_process.map(|pid| {
             let _res = self.grants.enter(pid, |_app, upcalls| {
-                upcalls
-                    .schedule_upcall(upcall::EVENT_FINISHED, (5, current as usize, 0))
-                    .ok();
+                let _ = upcalls.schedule_upcall(upcall::EVENT_FINISHED, (5, current as usize, 0));
             });
         });
     }

--- a/capsules/extra/src/max17205.rs
+++ b/capsules/extra/src/max17205.rs
@@ -428,16 +428,14 @@ impl<I: i2c::I2CDevice> MAX17205Client for MAX17205Driver<'_, I> {
     fn status(&self, status: u16, error: Result<(), ErrorCode>) {
         self.owning_process.map(|pid| {
             let _ = self.apps.enter(pid, |_app, upcalls| {
-                upcalls
-                    .schedule_upcall(
-                        upcall::EVENT_COMPLETE,
-                        (
-                            kernel::errorcode::into_statuscode(error),
-                            status as usize,
-                            0,
-                        ),
-                    )
-                    .ok();
+                let _ = upcalls.schedule_upcall(
+                    upcall::EVENT_COMPLETE,
+                    (
+                        kernel::errorcode::into_statuscode(error),
+                        status as usize,
+                        0,
+                    ),
+                );
             });
         });
     }
@@ -451,16 +449,14 @@ impl<I: i2c::I2CDevice> MAX17205Client for MAX17205Driver<'_, I> {
     ) {
         self.owning_process.map(|pid| {
             let _ = self.apps.enter(pid, |_app, upcalls| {
-                upcalls
-                    .schedule_upcall(
-                        upcall::EVENT_COMPLETE,
-                        (
-                            kernel::errorcode::into_statuscode(error),
-                            percent as usize,
-                            (capacity as usize) << 16 | (full_capacity as usize),
-                        ),
-                    )
-                    .ok();
+                let _ = upcalls.schedule_upcall(
+                    upcall::EVENT_COMPLETE,
+                    (
+                        kernel::errorcode::into_statuscode(error),
+                        percent as usize,
+                        (capacity as usize) << 16 | (full_capacity as usize),
+                    ),
+                );
             });
         });
     }
@@ -468,16 +464,14 @@ impl<I: i2c::I2CDevice> MAX17205Client for MAX17205Driver<'_, I> {
     fn voltage_current(&self, voltage: u16, current: u16, error: Result<(), ErrorCode>) {
         self.owning_process.map(|pid| {
             let _ = self.apps.enter(pid, |_app, upcalls| {
-                upcalls
-                    .schedule_upcall(
-                        upcall::EVENT_COMPLETE,
-                        (
-                            kernel::errorcode::into_statuscode(error),
-                            voltage as usize,
-                            current as usize,
-                        ),
-                    )
-                    .ok();
+                let _ = upcalls.schedule_upcall(
+                    upcall::EVENT_COMPLETE,
+                    (
+                        kernel::errorcode::into_statuscode(error),
+                        voltage as usize,
+                        current as usize,
+                    ),
+                );
             });
         });
     }
@@ -485,16 +479,14 @@ impl<I: i2c::I2CDevice> MAX17205Client for MAX17205Driver<'_, I> {
     fn coulomb(&self, coulomb: u16, error: Result<(), ErrorCode>) {
         self.owning_process.map(|pid| {
             let _ = self.apps.enter(pid, |_app, upcalls| {
-                upcalls
-                    .schedule_upcall(
-                        upcall::EVENT_COMPLETE,
-                        (
-                            kernel::errorcode::into_statuscode(error),
-                            coulomb as usize,
-                            0,
-                        ),
-                    )
-                    .ok();
+                let _ = upcalls.schedule_upcall(
+                    upcall::EVENT_COMPLETE,
+                    (
+                        kernel::errorcode::into_statuscode(error),
+                        coulomb as usize,
+                        0,
+                    ),
+                );
             });
         });
     }
@@ -502,16 +494,14 @@ impl<I: i2c::I2CDevice> MAX17205Client for MAX17205Driver<'_, I> {
     fn romid(&self, rid: u64, error: Result<(), ErrorCode>) {
         self.owning_process.map(|pid| {
             let _ = self.apps.enter(pid, |_app, upcalls| {
-                upcalls
-                    .schedule_upcall(
-                        upcall::EVENT_COMPLETE,
-                        (
-                            kernel::errorcode::into_statuscode(error),
-                            (rid & 0xffffffff) as usize,
-                            (rid >> 32) as usize,
-                        ),
-                    )
-                    .ok();
+                let _ = upcalls.schedule_upcall(
+                    upcall::EVENT_COMPLETE,
+                    (
+                        kernel::errorcode::into_statuscode(error),
+                        (rid & 0xffffffff) as usize,
+                        (rid >> 32) as usize,
+                    ),
+                );
             });
         });
     }

--- a/capsules/extra/src/mlx90614.rs
+++ b/capsules/extra/src/mlx90614.rs
@@ -130,9 +130,7 @@ impl<S: i2c::SMBusDevice> i2c::I2CClient for Mlx90614SMBus<'_, S> {
 
                 self.owning_process.map(|pid| {
                     let _ = self.apps.enter(pid, |_app, upcalls| {
-                        upcalls
-                            .schedule_upcall(0, (usize::from(present), 0, 0))
-                            .ok();
+                        let _ = upcalls.schedule_upcall(0, (usize::from(present), 0, 0));
                     });
                 });
                 self.buffer.replace(buffer);
@@ -153,13 +151,13 @@ impl<S: i2c::SMBusDevice> i2c::I2CClient for Mlx90614SMBus<'_, S> {
                 if let Ok(temp) = values {
                     self.owning_process.map(|pid| {
                         let _ = self.apps.enter(pid, |_app, upcalls| {
-                            upcalls.schedule_upcall(0, (temp as usize, 0, 0)).ok();
+                            let _ = upcalls.schedule_upcall(0, (temp as usize, 0, 0));
                         });
                     });
                 } else {
                     self.owning_process.map(|pid| {
                         let _ = self.apps.enter(pid, |_app, upcalls| {
-                            upcalls.schedule_upcall(0, (0, 0, 0)).ok();
+                            let _ = upcalls.schedule_upcall(0, (0, 0, 0));
                         });
                     });
                 }

--- a/capsules/extra/src/net/thread/driver.rs
+++ b/capsules/extra/src/net/thread/driver.rs
@@ -314,9 +314,7 @@ impl<'a, A: time::Alarm<'a>> ThreadNetworkDriver<'a, A> {
         // userland of the reason for termination with the first argument.
 
         self.apps.each(|_, _, kernel_data| {
-            kernel_data
-                .schedule_upcall(upcall::JOINCOMPLETE, (into_statuscode(res), 0, 0))
-                .ok();
+            let _ = kernel_data.schedule_upcall(upcall::JOINCOMPLETE, (into_statuscode(res), 0, 0));
         });
     }
 

--- a/capsules/extra/src/net/udp/driver.rs
+++ b/capsules/extra/src/net/udp/driver.rs
@@ -208,12 +208,10 @@ impl<'a> UDPDriver<'a> {
         let result = self.perform_tx_sync(processid);
         if result != Ok(()) {
             let _ = self.apps.enter(processid, |_app, upcalls| {
-                upcalls
-                    .schedule_upcall(
-                        upcall::PACKET_TRANSMITTED,
-                        (kernel::errorcode::into_statuscode(result), 0, 0),
-                    )
-                    .ok();
+                let _ = upcalls.schedule_upcall(
+                    upcall::PACKET_TRANSMITTED,
+                    (kernel::errorcode::into_statuscode(result), 0, 0),
+                );
             });
         }
     }
@@ -562,12 +560,10 @@ impl UDPSendClient for UDPDriver<'_> {
         self.kernel_buffer.replace(dgram);
         self.current_app.get().map(|processid| {
             let _ = self.apps.enter(processid, |_app, upcalls| {
-                upcalls
-                    .schedule_upcall(
-                        upcall::PACKET_TRANSMITTED,
-                        (kernel::errorcode::into_statuscode(result), 0, 0),
-                    )
-                    .ok();
+                let _ = upcalls.schedule_upcall(
+                    upcall::PACKET_TRANSMITTED,
+                    (kernel::errorcode::into_statuscode(result), 0, 0),
+                );
             });
         });
         self.current_app.set(None);
@@ -613,9 +609,7 @@ impl UDPRecvClient for UDPDriver<'_> {
                             addr: src_addr,
                             port: src_port,
                         };
-                        kernel_data
-                            .schedule_upcall(upcall::PACKET_RECEIVED, (len, 0, 0))
-                            .ok();
+                        let _ = kernel_data.schedule_upcall(upcall::PACKET_RECEIVED, (len, 0, 0));
                         const CFG_LEN: usize = 2 * size_of::<UDPEndpoint>();
                         let _ = kernel_data
                             .get_readwrite_processbuffer(rw_allow::RX_CFG)

--- a/capsules/extra/src/ninedof.rs
+++ b/capsules/extra/src/ninedof.rs
@@ -158,7 +158,7 @@ impl hil::sensors::NineDofClient for NineDof<'_> {
                 app.pending_command = false;
                 finished_command = app.command;
                 finished_command_arg = app.arg1;
-                upcalls.schedule_upcall(0, (arg1, arg2, arg3)).ok();
+                let _ = upcalls.schedule_upcall(0, (arg1, arg2, arg3));
             });
         });
 
@@ -173,7 +173,7 @@ impl hil::sensors::NineDofClient for NineDof<'_> {
                     // Don't bother re-issuing this command, just use
                     // the existing result.
                     app.pending_command = false;
-                    upcalls.schedule_upcall(0, (arg1, arg2, arg3)).ok();
+                    let _ = upcalls.schedule_upcall(0, (arg1, arg2, arg3));
                     false
                 } else if app.pending_command {
                     app.pending_command = false;

--- a/capsules/extra/src/nonvolatile_storage_driver.rs
+++ b/capsules/extra/src/nonvolatile_storage_driver.rs
@@ -464,9 +464,7 @@ impl hil::nonvolatile_storage::NonvolatileStorageClient for NonvolatileStorage<'
                         self.buffer.replace(buffer);
 
                         // And then signal the app.
-                        kernel_data
-                            .schedule_upcall(upcall::READ_DONE, (length, 0, 0))
-                            .ok();
+                        let _ = kernel_data.schedule_upcall(upcall::READ_DONE, (length, 0, 0));
                     });
                 }
             }
@@ -490,9 +488,7 @@ impl hil::nonvolatile_storage::NonvolatileStorageClient for NonvolatileStorage<'
                         self.buffer.replace(buffer);
 
                         // And then signal the app.
-                        kernel_data
-                            .schedule_upcall(upcall::WRITE_DONE, (length, 0, 0))
-                            .ok();
+                        let _ = kernel_data.schedule_upcall(upcall::WRITE_DONE, (length, 0, 0));
                     });
                 }
             }

--- a/capsules/extra/src/nrf51822_serialization.rs
+++ b/capsules/extra/src/nrf51822_serialization.rs
@@ -280,9 +280,7 @@ impl uart::TransmitClient for Nrf51822Serialization<'_> {
         self.active_app.map(|processid| {
             let _ = self.apps.enter(processid, |_app, kernel_data| {
                 // Call the callback after TX has finished
-                kernel_data
-                    .schedule_upcall(upcall::TX_DONE_RX_READY, (1, 0, 0))
-                    .ok();
+                let _ = kernel_data.schedule_upcall(upcall::TX_DONE_RX_READY, (1, 0, 0));
             });
         });
     }
@@ -331,9 +329,7 @@ impl uart::ReceiveClient for Nrf51822Serialization<'_> {
                 // Note: This indicates how many bytes were received by
                 // hardware, regardless of how much space (if any) was
                 // available in the buffer provided by the app.
-                kernel_data
-                    .schedule_upcall(upcall::TX_DONE_RX_READY, (4, rx_len, len))
-                    .ok();
+                let _ = kernel_data.schedule_upcall(upcall::TX_DONE_RX_READY, (4, rx_len, len));
             }) {
                 // The app we had as active no longer exists. Clear that and
                 // stop receiving. This puts us back in an idle state. A new app

--- a/capsules/extra/src/pca9544a.rs
+++ b/capsules/extra/src/pca9544a.rs
@@ -164,12 +164,10 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for PCA9544A<'_, I> {
 
                 self.owning_process.map(|pid| {
                     let _ = self.apps.enter(pid, |_app, upcalls| {
-                        upcalls
-                            .schedule_upcall(
-                                upcall::CHANNEL_DONE,
-                                (field as usize + 1, ret as usize, 0),
-                            )
-                            .ok();
+                        let _ = upcalls.schedule_upcall(
+                            upcall::CHANNEL_DONE,
+                            (field as usize + 1, ret as usize, 0),
+                        );
                     });
                 });
 
@@ -180,9 +178,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for PCA9544A<'_, I> {
             State::Done => {
                 self.owning_process.map(|pid| {
                     let _ = self.apps.enter(pid, |_app, upcalls| {
-                        upcalls
-                            .schedule_upcall(upcall::CHANNEL_DONE, (0, 0, 0))
-                            .ok();
+                        let _ = upcalls.schedule_upcall(upcall::CHANNEL_DONE, (0, 0, 0));
                     });
                 });
 

--- a/capsules/extra/src/pressure.rs
+++ b/capsules/extra/src/pressure.rs
@@ -124,7 +124,7 @@ impl<'a, T: hil::sensors::PressureDriver<'a>> hil::sensors::PressureClient
                         ),
                         Err(err) => (kernel::errorcode::into_statuscode(Err(err)), 0, 0),
                     };
-                    upcalls.schedule_upcall(0, result).ok();
+                    let _ = upcalls.schedule_upcall(0, result);
                 }
             })
         }

--- a/capsules/extra/src/proximity.rs
+++ b/capsules/extra/src/proximity.rs
@@ -266,13 +266,13 @@ impl hil::sensors::ProximityClient for ProximitySensor<'_> {
                         // Case: ReadProximityOnInterrupt
                         // Only callback to those apps which we expect would want to know about this threshold reading.
                         if (temp_val > app.upper_proximity) || (temp_val < app.lower_proximity) {
-                            upcalls.schedule_upcall(0, (temp_val as usize, 0, 0)).ok();
+                            let _ = upcalls.schedule_upcall(0, (temp_val as usize, 0, 0));
                             app.subscribed = false; // dequeue
                         }
                     } else {
                         // Case: ReadProximity
                         // Upcall to all apps waiting on read_proximity.
-                        upcalls.schedule_upcall(0, (temp_val as usize, 0, 0)).ok();
+                        let _ = upcalls.schedule_upcall(0, (temp_val as usize, 0, 0));
                         app.subscribed = false; // dequeue
                     }
                 }

--- a/capsules/extra/src/screen.rs
+++ b/capsules/extra/src/screen.rs
@@ -299,7 +299,7 @@ impl<'a> Screen<'a> {
         self.current_process.take().map(|process_id| {
             let _ = self.apps.enter(process_id, |app, upcalls| {
                 app.pending_command = false;
-                upcalls.schedule_upcall(0, (data1, data2, data3)).ok();
+                let _ = upcalls.schedule_upcall(0, (data1, data2, data3));
             });
         });
     }

--- a/capsules/extra/src/screen_shared.rs
+++ b/capsules/extra/src/screen_shared.rs
@@ -267,7 +267,7 @@ impl<'a, S: hil::screen::Screen<'a>> ScreenShared<'a, S> {
 
     fn schedule_callback(&self, process_id: ProcessId, data1: usize, data2: usize, data3: usize) {
         let _ = self.apps.enter(process_id, |_app, kernel_data| {
-            kernel_data.schedule_upcall(0, (data1, data2, data3)).ok();
+            let _ = kernel_data.schedule_upcall(0, (data1, data2, data3));
         });
     }
 

--- a/capsules/extra/src/sdcard.rs
+++ b/capsules/extra/src/sdcard.rs
@@ -1521,9 +1521,7 @@ impl<'a, A: hil::time::Alarm<'a>> SDCardClient for SDCardDriver<'a, A> {
     fn card_detection_changed(&self, installed: bool) {
         self.current_process.map(|process_id| {
             let _ = self.grants.enter(process_id, |_app, kernel_data| {
-                kernel_data
-                    .schedule_upcall(0, (0, installed as usize, 0))
-                    .ok();
+                let _ = kernel_data.schedule_upcall(0, (0, installed as usize, 0));
             });
         });
     }
@@ -1532,9 +1530,7 @@ impl<'a, A: hil::time::Alarm<'a>> SDCardClient for SDCardDriver<'a, A> {
         self.current_process.map(|process_id| {
             let _ = self.grants.enter(process_id, |_app, kernel_data| {
                 let size_in_kb = ((total_size >> 10) & 0xFFFFFFFF) as usize;
-                kernel_data
-                    .schedule_upcall(0, (1, block_size as usize, size_in_kb))
-                    .ok();
+                let _ = kernel_data.schedule_upcall(0, (1, block_size as usize, size_in_kb));
             });
         });
     }
@@ -1568,7 +1564,7 @@ impl<'a, A: hil::time::Alarm<'a>> SDCardClient for SDCardDriver<'a, A> {
                 // perform callback
                 // Note that we are explicitly performing the callback even if no
                 // data was read or if the app's read_buffer doesn't exist
-                kernel_data.schedule_upcall(0, (2, read_len, 0)).ok();
+                let _ = kernel_data.schedule_upcall(0, (2, read_len, 0));
             });
         });
     }
@@ -1578,7 +1574,7 @@ impl<'a, A: hil::time::Alarm<'a>> SDCardClient for SDCardDriver<'a, A> {
 
         self.current_process.map(|process_id| {
             let _ = self.grants.enter(process_id, |_app, kernel_data| {
-                kernel_data.schedule_upcall(0, (3, 0, 0)).ok();
+                let _ = kernel_data.schedule_upcall(0, (3, 0, 0));
             });
         });
     }
@@ -1586,7 +1582,7 @@ impl<'a, A: hil::time::Alarm<'a>> SDCardClient for SDCardDriver<'a, A> {
     fn error(&self, error: u32) {
         self.current_process.map(|process_id| {
             let _ = self.grants.enter(process_id, |_app, kernel_data| {
-                kernel_data.schedule_upcall(0, (4, error as usize, 0)).ok();
+                let _ = kernel_data.schedule_upcall(0, (4, error as usize, 0));
             });
         });
     }

--- a/capsules/extra/src/sha.rs
+++ b/capsules/extra/src/sha.rs
@@ -308,9 +308,8 @@ impl<
                     // If we get here we are ready to run the digest, reset the copied data
                     if app.op.get().unwrap() == UserSpaceOp::Run {
                         if let Err(e) = self.calculate_digest() {
-                            kernel_data
-                                .schedule_upcall(0, (into_statuscode(e.into()), 0, 0))
-                                .ok();
+                            let _ =
+                                kernel_data.schedule_upcall(0, (into_statuscode(e.into()), 0, 0));
                         }
                     } else if app.op.get().unwrap() == UserSpaceOp::Verify {
                         let _ = kernel_data
@@ -336,12 +335,11 @@ impl<
                             });
 
                         if let Err(e) = self.verify_digest() {
-                            kernel_data
-                                .schedule_upcall(1, (into_statuscode(e.into()), 0, 0))
-                                .ok();
+                            let _ =
+                                kernel_data.schedule_upcall(1, (into_statuscode(e.into()), 0, 0));
                         }
                     } else {
-                        kernel_data.schedule_upcall(0, (0, 0, 0)).ok();
+                        let _ = kernel_data.schedule_upcall(0, (0, 0, 0));
                     }
                 })
                 .map_err(|err| {
@@ -385,13 +383,10 @@ impl<
                             })
                         });
 
-                    match result {
-                        Ok(()) => kernel_data
-                            .schedule_upcall(0, (0, pointer as usize, 0))
-                            .ok(),
+                    let _ = match result {
+                        Ok(()) => kernel_data.schedule_upcall(0, (0, pointer as usize, 0)),
                         Err(e) => kernel_data
-                            .schedule_upcall(0, (into_statuscode(e.into()), pointer as usize, 0))
-                            .ok(),
+                            .schedule_upcall(0, (into_statuscode(e.into()), pointer as usize, 0)),
                     };
 
                     // Clear the current processid as it has finished running
@@ -427,11 +422,10 @@ impl<
                 .enter(id, |_app, kernel_data| {
                     self.sha.clear_data();
 
-                    match result {
+                    let _ = match result {
                         Ok(equal) => kernel_data.schedule_upcall(1, (0, equal as usize, 0)),
                         Err(e) => kernel_data.schedule_upcall(1, (into_statuscode(e.into()), 0, 0)),
-                    }
-                    .ok();
+                    };
 
                     // Clear the current processid as it has finished running
                     self.processid.clear();
@@ -628,9 +622,8 @@ impl<
                     3 => {
                         if app_match {
                             if let Err(e) = self.calculate_digest() {
-                                kernel_data
-                                    .schedule_upcall(0, (into_statuscode(e.into()), 0, 0))
-                                    .ok();
+                                let _ = kernel_data
+                                    .schedule_upcall(0, (into_statuscode(e.into()), 0, 0));
                             }
                             CommandReturn::success()
                         } else {
@@ -683,9 +676,8 @@ impl<
                                 });
 
                             if let Err(e) = self.verify_digest() {
-                                kernel_data
-                                    .schedule_upcall(1, (into_statuscode(e.into()), 0, 0))
-                                    .ok();
+                                let _ = kernel_data
+                                    .schedule_upcall(1, (into_statuscode(e.into()), 0, 0));
                             }
                             CommandReturn::success()
                         } else {

--- a/capsules/extra/src/sound_pressure.rs
+++ b/capsules/extra/src/sound_pressure.rs
@@ -134,7 +134,7 @@ impl hil::sensors::SoundPressureClient for SoundPressureSensor<'_> {
                     self.busy.set(false);
                     app.subscribed = false;
                     if ret == Ok(()) {
-                        upcalls.schedule_upcall(0, (sound_val.into(), 0, 0)).ok();
+                        let _ = upcalls.schedule_upcall(0, (sound_val.into(), 0, 0));
                     }
                 }
             });

--- a/capsules/extra/src/symmetric_encryption/aes.rs
+++ b/capsules/extra/src/symmetric_encryption/aes.rs
@@ -450,7 +450,7 @@ impl<
                             // No data buffer, clear the processid and data
                             self.aes.disable();
                             self.processid.clear();
-                            kernel_data.schedule_upcall(0, (e as usize, 0, 0)).ok();
+                            let _ = kernel_data.schedule_upcall(0, (e as usize, 0, 0));
                             exit = true;
                         }
                     });
@@ -490,7 +490,7 @@ impl<
                             // No data buffer, clear the processid and data
                             self.aes.disable();
                             self.processid.clear();
-                            kernel_data.schedule_upcall(0, (e as usize, 0, 0)).ok();
+                            let _ = kernel_data.schedule_upcall(0, (e as usize, 0, 0));
                             exit = true;
                         }
                     });
@@ -532,9 +532,7 @@ impl<
                     }
 
                     // If we get here we have finished all the crypto operations
-                    kernel_data
-                        .schedule_upcall(0, (0, self.data_copied.get(), 0))
-                        .ok();
+                    let _ = kernel_data.schedule_upcall(0, (0, self.data_copied.get(), 0));
                     self.data_copied.set(0);
                 })
                 .map_err(|err| {
@@ -566,7 +564,7 @@ impl<
                     let mut exit = false;
 
                     if let Err(e) = res {
-                        kernel_data.schedule_upcall(0, (e as usize, 0, 0)).ok();
+                        let _ = kernel_data.schedule_upcall(0, (e as usize, 0, 0));
                         return;
                     }
 
@@ -598,7 +596,7 @@ impl<
                             // No data buffer, clear the processid and data
                             self.aes.disable();
                             self.processid.clear();
-                            kernel_data.schedule_upcall(0, (e as usize, 0, 0)).ok();
+                            let _ = kernel_data.schedule_upcall(0, (e as usize, 0, 0));
                             exit = true;
                         }
                     });
@@ -609,9 +607,8 @@ impl<
 
                     // AES CCM is online only we can't send any more data in, so
                     // just report what we did to the app.
-                    kernel_data
-                        .schedule_upcall(0, (0, self.data_copied.get(), tag_is_valid as usize))
-                        .ok();
+                    let _ = kernel_data
+                        .schedule_upcall(0, (0, self.data_copied.get(), tag_is_valid as usize));
                     self.data_copied.set(0);
                 })
                 .map_err(|err| {
@@ -643,7 +640,7 @@ impl<
                     let mut exit = false;
 
                     if let Err(e) = res {
-                        kernel_data.schedule_upcall(0, (e as usize, 0, 0)).ok();
+                        let _ = kernel_data.schedule_upcall(0, (e as usize, 0, 0));
                         return;
                     }
 
@@ -675,7 +672,7 @@ impl<
                             // No data buffer, clear the appid and data
                             self.aes.disable();
                             self.processid.clear();
-                            kernel_data.schedule_upcall(0, (e as usize, 0, 0)).ok();
+                            let _ = kernel_data.schedule_upcall(0, (e as usize, 0, 0));
                             exit = true;
                         }
                     });
@@ -686,9 +683,8 @@ impl<
 
                     // AES GCM is online only we can't send any more data in, so
                     // just report what we did to the app.
-                    kernel_data
-                        .schedule_upcall(0, (0, self.data_copied.get(), tag_is_valid as usize))
-                        .ok();
+                    let _ = kernel_data
+                        .schedule_upcall(0, (0, self.data_copied.get(), tag_is_valid as usize));
                     self.data_copied.set(0);
                 })
                 .map_err(|err| {
@@ -878,12 +874,10 @@ impl<
                                 })
                                 .unwrap_or(Err(ErrorCode::RESERVE))
                             {
-                                kernel_data
-                                    .schedule_upcall(
-                                        0,
-                                        (kernel::errorcode::into_statuscode(e.into()), 0, 0),
-                                    )
-                                    .ok();
+                                let _ = kernel_data.schedule_upcall(
+                                    0,
+                                    (kernel::errorcode::into_statuscode(e.into()), 0, 0),
+                                );
                             }
                             CommandReturn::success()
                         } else {

--- a/capsules/extra/src/temperature.rs
+++ b/capsules/extra/src/temperature.rs
@@ -128,7 +128,7 @@ impl<'a, T: hil::sensors::TemperatureDriver<'a>> hil::sensors::TemperatureClient
                 cntr.enter(|app, upcalls| {
                     if app.subscribed {
                         app.subscribed = false;
-                        upcalls.schedule_upcall(0, (temp_val as usize, 0, 0)).ok();
+                        let _ = upcalls.schedule_upcall(0, (temp_val as usize, 0, 0));
                     }
                 });
             }

--- a/capsules/extra/src/text_screen.rs
+++ b/capsules/extra/src/text_screen.rs
@@ -238,7 +238,7 @@ impl<'a> TextScreen<'a> {
         self.current_app.take().map(|processid| {
             let _ = self.apps.enter(processid, |app, kernel_data| {
                 app.pending_command = false;
-                kernel_data.schedule_upcall(0, (data1, data2, data3)).ok();
+                let _ = kernel_data.schedule_upcall(0, (data1, data2, data3));
             });
         });
     }

--- a/capsules/extra/src/touch.rs
+++ b/capsules/extra/src/touch.rs
@@ -211,16 +211,14 @@ impl hil::touch::TouchClient for Touch<'_> {
                         Some(size) => size as usize,
                         None => 0,
                     };
-                    kernel_data
-                        .schedule_upcall(
-                            0,
-                            (
-                                event_status,
-                                (event.x as usize) << 16 | event.y as usize,
-                                pressure_size,
-                            ),
-                        )
-                        .ok();
+                    let _ = kernel_data.schedule_upcall(
+                        0,
+                        (
+                            event_status,
+                            (event.x as usize) << 16 | event.y as usize,
+                            pressure_size,
+                        ),
+                    );
                 }
             });
         }
@@ -296,9 +294,8 @@ impl hil::touch::MultiTouchClient for Touch<'_> {
                         let dropped_events = app.dropped_events;
                         if num > 0 {
                             app.ack = false;
-                            kernel_data
-                                .schedule_upcall(2, (num, dropped_events, len.saturating_sub(num)))
-                                .ok();
+                            let _ = kernel_data
+                                .schedule_upcall(2, (num, dropped_events, len.saturating_sub(num)));
                         }
                     } else {
                         app.dropped_events += 1;
@@ -321,7 +318,7 @@ impl hil::touch::GestureClient for Touch<'_> {
                     GestureEvent::ZoomIn => 5,
                     GestureEvent::ZoomOut => 6,
                 };
-                kernel_data.schedule_upcall(1, (gesture_id, 0, 0)).ok();
+                let _ = kernel_data.schedule_upcall(1, (gesture_id, 0, 0));
             });
         }
     }

--- a/capsules/extra/src/tsl2561.rs
+++ b/capsules/extra/src/tsl2561.rs
@@ -429,7 +429,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for TSL2561<'_, I> {
 
                 self.owning_process.map(|pid| {
                     let _ = self.apps.enter(pid, |_, upcalls| {
-                        upcalls.schedule_upcall(0, (0, lux, 0)).ok();
+                        let _ = upcalls.schedule_upcall(0, (0, lux, 0));
                     });
                 });
 

--- a/capsules/extra/src/tutorials/encryption_oracle_chkpt4.rs
+++ b/capsules/extra/src/tutorials/encryption_oracle_chkpt4.rs
@@ -251,12 +251,10 @@ impl<'a, A: AES128<'a> + AES128Ctr> EncryptionOracleDriver<'a, A> {
                 grant.request_pending = false;
 
                 if let Err(e) = res {
-                    kernel_data
-                        .schedule_upcall(
-                            upcall::DONE,
-                            (kernel::errorcode::into_statuscode(Err(e)), 0, 0),
-                        )
-                        .ok();
+                    let _ = kernel_data.schedule_upcall(
+                        upcall::DONE,
+                        (kernel::errorcode::into_statuscode(Err(e)), 0, 0),
+                    );
                 }
             });
         }

--- a/capsules/extra/src/tutorials/encryption_oracle_chkpt5.rs
+++ b/capsules/extra/src/tutorials/encryption_oracle_chkpt5.rs
@@ -251,12 +251,10 @@ impl<'a, A: AES128<'a> + AES128Ctr> EncryptionOracleDriver<'a, A> {
                 grant.request_pending = false;
 
                 if let Err(e) = res {
-                    kernel_data
-                        .schedule_upcall(
-                            upcall::DONE,
-                            (kernel::errorcode::into_statuscode(Err(e)), 0, 0),
-                        )
-                        .ok();
+                    let _ = kernel_data.schedule_upcall(
+                        upcall::DONE,
+                        (kernel::errorcode::into_statuscode(Err(e)), 0, 0),
+                    );
                 }
             });
         }
@@ -364,7 +362,7 @@ impl<'a, A: AES128<'a> + AES128Ctr> Client<'a> for EncryptionOracleDriver<'a, A>
                         .map_or(0, |dest| dest.len()),
                 );
 
-                kernel_data.schedule_upcall(upcall::DONE, (0, len, 0)).ok();
+                let _ = kernel_data.schedule_upcall(upcall::DONE, (0, len, 0));
             });
 
             // Attempt to schedule another operation for a new process:

--- a/capsules/extra/src/usb/usb_user.rs
+++ b/capsules/extra/src/usb/usb_user.rs
@@ -84,12 +84,10 @@ where
                             self.usbc_client.attach();
 
                             // Schedule a callback immediately
-                            upcalls
-                                .schedule_upcall(
-                                    0,
-                                    (kernel::errorcode::into_statuscode(Ok(())), 0, 0),
-                                )
-                                .ok();
+                            let _ = upcalls.schedule_upcall(
+                                0,
+                                (kernel::errorcode::into_statuscode(Ok(())), 0, 0),
+                            );
                             app.awaiting = None;
                         }
                     }

--- a/capsules/extra/src/usb_hid_driver.rs
+++ b/capsules/extra/src/usb_hid_driver.rs
@@ -91,7 +91,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> usb_hid::Client<'a, [u8; 64]> for Usb
                         })
                     });
 
-                kernel_data.schedule_upcall(0, (0, 0, 0)).ok();
+                let _ = kernel_data.schedule_upcall(0, (0, 0, 0));
             });
         });
 
@@ -106,7 +106,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> usb_hid::Client<'a, [u8; 64]> for Usb
     ) {
         self.processid.map(|id| {
             let _ = self.app.enter(id, |_app, kernel_data| {
-                kernel_data.schedule_upcall(0, (1, 0, 0)).ok();
+                let _ = kernel_data.schedule_upcall(0, (1, 0, 0));
             });
         });
 

--- a/chips/rp2040/src/pio.rs
+++ b/chips/rp2040/src/pio.rs
@@ -1729,8 +1729,8 @@ mod examples {
             sm.set_pins_dirs(pin2, 1, true);
             sm.init();
             sm.set_enabled(true);
-            sm.push_blocking(turn_on_gpio_6_7).ok();
-            sm.push_blocking(0).ok();
+            let _ = sm.push_blocking(turn_on_gpio_6_7);
+            let _ = sm.push_blocking(0);
         }
 
         pub fn pwm_program_init(
@@ -1751,7 +1751,7 @@ mod examples {
             sm.set_pins_dirs(pin, 1, true);
             sm.set_side_set_pins(pin, 1, false, true);
             sm.init();
-            sm.push_blocking(pwm_period).ok();
+            let _ = sm.push_blocking(pwm_period);
             sm.exec(pull_command);
             sm.exec(out_isr_32_command);
             sm.set_enabled(true);

--- a/chips/rp2040/src/pio_pwm.rs
+++ b/chips/rp2040/src/pio_pwm.rs
@@ -54,7 +54,7 @@ impl hil::pwm::Pwm for PioPwm<'_> {
 
         self.pio.map(|pio| {
             pio.init();
-            pio.add_program(Some(0), &path).ok();
+            let _ = pio.add_program(Some(0), &path);
             let mut custom_config = StateMachineConfiguration::default();
 
             let pin_nr = *pin as u32;
@@ -69,9 +69,9 @@ impl hil::pwm::Pwm for PioPwm<'_> {
             let sm_number = SMNumber::SM0;
             let duty_cycle = duty_cycle_percentage as u32;
             pio.pwm_program_init(sm_number, pin_nr, pwm_period, &custom_config);
-            pio.sm(sm_number)
-                .push_blocking(pwm_period * duty_cycle / (self.get_maximum_duty_cycle()) as u32)
-                .ok();
+            let _ = pio
+                .sm(sm_number)
+                .push_blocking(pwm_period * duty_cycle / (self.get_maximum_duty_cycle()) as u32);
         });
 
         Ok(())


### PR DESCRIPTION
### Pull Request Overview

Standardize on `let _ = ` to ignore a result. With this lint on, using `.ok()` gives:

```
error: ignoring a result with `.ok()` is misleading
```

because it converts the result to an option which can just be ignored.






### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
