### PR TITLE
`SingleThreadValue` to allow sharing of static muts

### DIFF
--- a/kernel/src/utilities/mod.rs
+++ b/kernel/src/utilities/mod.rs
@@ -14,6 +14,7 @@ pub mod machine_register;
 pub mod math;
 pub mod mut_imut_buffer;
 pub mod peripheral_management;
+pub mod single_thread_value;
 pub mod static_init;
 pub mod storage_volume;
 pub mod streaming_process_slice;

--- a/kernel/src/utilities/single_thread_value.rs
+++ b/kernel/src/utilities/single_thread_value.rs
@@ -64,7 +64,7 @@ impl<T> SingleThreadValue<T> {
     where
         F: FnOnce(&T) -> R,
     {
-        f(unsafe { &*self.0.get() })
+        f(&self.0)
     }
 }
 

--- a/kernel/src/utilities/single_thread_value.rs
+++ b/kernel/src/utilities/single_thread_value.rs
@@ -1,0 +1,71 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2024.
+
+//! Objects guaranteed to be used by a single thread.
+
+/// A single-thread store that owns its contents.
+///
+/// This type wraps a value of type `T` by a single thread. Only that thread may
+/// access the value, and that thread may have multiple _shared_ (`&`)
+/// references to the value.
+///
+/// It is [`Sync`] and thus appropriate for static allocations of values
+/// that are not themselves [`Sync`].
+///
+/// # Example
+///
+/// ```
+/// static FOO: SingleThreadValue<Cell<usize>> = unsafe { SingleThreadValue::new(Cell::new(123)) };
+///
+/// fn main() {
+///   FOO.with(|foo| foo.set(foo.get() + 1));
+/// }
+/// ```
+///
+/// # Single-thread synchronization
+///
+/// It is possible for the same thread to get multiple, shared, references. As a
+/// result, users must use other synchronization primitives (e.g. [`Cell`]
+/// (core::cell::Cell),[`MapCell`](tock_cells::map_cell::MapCell),[`TakeCell`]
+/// (tock_cells::take_cell::TakeCell) to allow obtaining exclusive mutable
+/// access.
+///
+/// # Safety
+///
+/// Creators of a [`SingleThreadValue`] must ensure that the object is **ONLY**
+/// accessible from the single thread.
+pub struct SingleThreadValue<T>(T);
+
+impl<T> SingleThreadValue<T> {
+    /// Create a [`SingleThreadValue`].
+    ///
+    /// # Safety
+    ///
+    /// A [`SingleThreadValue`] must only be created when it can be guaranteed
+    /// that only a single thread will access the value. Even on single-core
+    /// systems with no threading runtime, there may be additional threads of
+    /// execution, such as Interrupt Service Routines (ISRs) or signal
+    /// handlers, that could race with the main thread if sharing a
+    /// [`SingleThreadValue`]. It is safety-critical that such contexts do not
+    /// access [`SingleThreadValue`]s.
+    ///
+    /// By convention, users should declare [`SingleThreadValue`] variables in
+    /// scopes that are inaccessible to ISRs or signal handler, e.g. in
+    /// module-private or function-local scopes.
+    pub const unsafe fn new(val: T) -> Self {
+        Self(val)
+    }
+}
+
+impl<T> SingleThreadValue<T> {
+    /// Acquires a reference to value in [`SingleThreadValue`].
+    pub fn with<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&T) -> R,
+    {
+        f(unsafe { &*self.0.get() })
+    }
+}
+
+unsafe impl<T> Sync for SingleThreadValue<T> {}

--- a/kernel/src/utilities/single_thread_value.rs
+++ b/kernel/src/utilities/single_thread_value.rs
@@ -29,7 +29,7 @@
 /// # Single-thread synchronization
 ///
 /// It is possible for the same thread to get multiple, shared, references. As a
-/// result, users must use other synchronization primitives (e.g.
+/// result, users must use interior mutability (e.g.
 /// [`Cell`](core::cell::Cell), [`MapCell`](tock_cells::map_cell::MapCell), or
 /// [`TakeCell`](tock_cells::take_cell::TakeCell)) to allow obtaining exclusive
 /// mutable access.

--- a/kernel/src/utilities/single_thread_value.rs
+++ b/kernel/src/utilities/single_thread_value.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache License, Version 2.0 or the MIT License.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2024.
+// Copyright Tock Contributors 2025.
 
 //! Objects guaranteed to be used by a single thread.
 
@@ -10,12 +10,15 @@
 /// access the value, and that thread may have multiple _shared_ (`&`)
 /// references to the value.
 ///
-/// It is [`Sync`] and thus appropriate for static allocations of values
-/// that are not themselves [`Sync`].
+/// It is [`Sync`] and thus appropriate for static allocations of values that
+/// are not themselves [`Sync`].
 ///
 /// # Example
 ///
 /// ```
+/// use core::cell::Cell;
+/// use kernel::utilities::single_thread_value::SingleThreadValue;
+///
 /// static FOO: SingleThreadValue<Cell<usize>> = unsafe { SingleThreadValue::new(Cell::new(123)) };
 ///
 /// fn main() {
@@ -26,10 +29,10 @@
 /// # Single-thread synchronization
 ///
 /// It is possible for the same thread to get multiple, shared, references. As a
-/// result, users must use other synchronization primitives (e.g. [`Cell`]
-/// (core::cell::Cell),[`MapCell`](tock_cells::map_cell::MapCell),[`TakeCell`]
-/// (tock_cells::take_cell::TakeCell) to allow obtaining exclusive mutable
-/// access.
+/// result, users must use other synchronization primitives (e.g.
+/// [`Cell`](core::cell::Cell), [`MapCell`](tock_cells::map_cell::MapCell), or
+/// [`TakeCell`](tock_cells::take_cell::TakeCell)) to allow obtaining exclusive
+/// mutable access.
 ///
 /// # Safety
 ///


### PR DESCRIPTION
### Pull Request Overview

Evolution of #3945.

This is my take on and attempt to resurrect `CoreLocal` and safely sharing static mut values. Initially this only adds the type with my name changes and comment rewording.

I didn't understand the `CoreLocal` name because we primarily only have single core MCUs, yet we have this issue. On most MCUs all of our values are already local to one core.

I can work on actually using this type, but we need to make progress on deciding what this type is and what it should be called. There have also been a lot of changes since the original PR (specifically the PROCESSES array).






### Testing Strategy

todo


### TODO or Help Wanted

Decide on a type and then use it.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
