### PR TITLE
x86: fix boot issue and use naked functions

### DIFF
--- a/arch/x86/src/boundary/return_from_user.rs
+++ b/arch/x86/src/boundary/return_from_user.rs
@@ -33,14 +33,13 @@
 // From the perspective of the code that originally called switch_to_user, it should look like a
 // regular cdecl function call occurred.
 
-use core::arch::global_asm;
+use core::arch::naked_asm;
 
-global_asm!(
-    "
-    .section .text
-    .global return_from_user
-    return_from_user:
-
+#[unsafe(naked)]
+#[unsafe(no_mangle)]
+pub extern "C" fn return_from_user() {
+    naked_asm!(
+        "
         mov     ecx, dword ptr [esp+76]       # UserContext
 
         # First switch back to the kernel's data segment. Once this is done, we are safe to start
@@ -98,4 +97,5 @@ global_asm!(
         # Return to whoever called switch_to_user
         ret
 "
-);
+    );
+}

--- a/arch/x86/src/boundary/switch_to_user.rs
+++ b/arch/x86/src/boundary/switch_to_user.rs
@@ -33,16 +33,13 @@
 // return_from_user, which performs the inverse of the above steps and returns control back to
 // the original caller of switch_to_user. See return_from_user.rs for more information.
 
-use core::arch::global_asm;
+use core::arch::naked_asm;
 
-global_asm!(
-    "
-.section .text
-.global switch_to_user
-.global _switch_to_user
-switch_to_user:
-_switch_to_user:
-
+#[unsafe(naked)]
+#[unsafe(no_mangle)]
+pub extern "C" fn switch_to_user() {
+    naked_asm!(
+        "
     # Save kernel state
     push    edi
     push    esi
@@ -96,4 +93,5 @@ _switch_to_user:
     pop     eax
 
     iretd"
-);
+    );
+}

--- a/arch/x86/src/start.rs
+++ b/arch/x86/src/start.rs
@@ -2,16 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2024.
 
-use core::arch::global_asm;
+use core::arch::naked_asm;
 
-global_asm!(
-    "
-.section .text
-
-.global main
-
-.global _start
-_start:
+#[unsafe(link_section = ".start_x86")]
+#[unsafe(naked)]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn start() {
+    naked_asm!(
+        "
     # Initialize the stack
     lea     esp, _estack
     lea     ebp, _estack
@@ -19,27 +17,27 @@ _start:
     # Zero out the .bss section
     mov     eax, _szero
     mov     ebx, _ezero
-100:
+200:
     cmp     eax, ebx
-    je      101f
+    je      201f
     mov     byte ptr [eax], 0
     inc     eax
-    jmp     100b
-101:
+    jmp     200b
+201:
 
     # Initialize contents of the .data section
     mov     eax, _srelocate
     mov     ebx, _erelocate
     mov     ecx, _etext
-200:
+300:
     cmp     eax, ebx
-    je      201f
+    je      301f
     mov     dl, byte ptr [ecx]
     mov     byte ptr [eax], dl
     inc     eax
     inc     ecx
-    jmp     200b
-201:
+    jmp     300b
+301:
 
     # Now we hand control over to the Rust main function
     call    main
@@ -50,4 +48,5 @@ _start:
     jmp     3b
 
 "
-);
+    );
+}

--- a/arch/x86/src/start.rs
+++ b/arch/x86/src/start.rs
@@ -4,7 +4,7 @@
 
 use core::arch::naked_asm;
 
-#[unsafe(link_section = ".start_x86")]
+#[unsafe(link_section = ".x86.start")]
 #[unsafe(naked)]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn start() {

--- a/boards/build_scripts/tock_kernel_layout.ld
+++ b/boards/build_scripts/tock_kernel_layout.ld
@@ -85,6 +85,7 @@ SECTIONS
          *
          * http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0553a/BABIFJFG.html
          */
+
         KEEP(*(.vectors .vectors.*))
         KEEP(*(.irqs))
 
@@ -108,6 +109,9 @@ SECTIONS
         . = DEFINED(_start_trap) ? ALIGN(256) : ALIGN(1);
         KEEP(*(.riscv.trap_vectored));
         KEEP(*(.riscv.trap));
+
+        /* x86 */     
+        KEEP(*(.start_x86))
 
         /* .text and .rodata hold most program code and immutable constants */
         /* .gnu.linkonce hold C++ elements with vague linkage

--- a/boards/build_scripts/tock_kernel_layout.ld
+++ b/boards/build_scripts/tock_kernel_layout.ld
@@ -96,7 +96,7 @@ SECTIONS
         KEEP(*(.riscv.trap));
 
         /* x86 */     
-        KEEP(*(.start_x86))
+        KEEP(*(.x86.start))
 
         /* .text and .rodata hold most program code and immutable constants */
         /* .gnu.linkonce hold C++ elements with vague linkage

--- a/boards/build_scripts/tock_kernel_layout.ld
+++ b/boards/build_scripts/tock_kernel_layout.ld
@@ -49,8 +49,8 @@ SECTIONS
      * The order matters here for the x86 platform.
 
      * We need to make sure that qemu-system-i386 finds the multiboot header within the
-     * first 8K of the ELF. The multiboot header is placed at the begining of the .text section, so
-     * this section has to be is placed first in the file.
+     * first 8K of the ELF. The multiboot header is placed at the beginning of the .text section, so
+     * this section has to be placed first in the file.
      *  
      * This is the reason why the .text section has to be the first.
      */

--- a/boards/build_scripts/tock_kernel_layout.ld
+++ b/boards/build_scripts/tock_kernel_layout.ld
@@ -46,8 +46,12 @@ SECTIONS
 
     
     /**
-     * The order matters here for the x86 platform, the .text section has to be the first one.
-     * Please see the details bellow where the .x86.start is stored.
+     * The order that section contents ends up emitted in the final physical ELF file is
+     * significant for systems like QEMU that use multiboot. Only the first 8192 bytes of the file
+     * are scanned ( https://www.gnu.org/software/grub/manual/multiboot/multiboot.html ).
+     *
+     * For this reason, it is important that the `.text` section, which contains the `.multiboot`
+     * section, is defined first in this file as tools tend to write sections out in linear order.
      */
     
    

--- a/boards/build_scripts/tock_kernel_layout.ld
+++ b/boards/build_scripts/tock_kernel_layout.ld
@@ -43,33 +43,7 @@ PAGE_SIZE = DEFINED(PAGE_SIZE) ? PAGE_SIZE : 512;
 
 SECTIONS
 {
-   .stack (NOLOAD) :
-    {
-        /* Kernel stack.
-         *
-         * Tock places the kernel stack at the bottom of SRAM so that the
-         * kernel will trigger memory fault if it exceeds its stack depth,
-         * rather than silently overwriting valuable data.
-         */
-        . = ALIGN(8);
-         _sstack = .;
-
-         /* For GNU LD, we can just advance the location pointer (".") here to
-          * reserve space for the stack. That, however, doesn't seem to work
-          * for LLVM LLD. The resulting ELF has a stack section that shows the
-          * correct size, but the next section (in our case .relocate) is not
-          * moved down as well, instead it sits at the same address as .stack.
-          * To work around this, we declare a dummy buffer and then insert it
-          * here in the .stack section. This sets the stack size correctly and
-          * places the .relocate section at the correct address. */
-         KEEP(*(.stack_buffer))
-         /*. = . + 0x1000;*/  /*This is the original method. */
-
-         . = ALIGN(8);
-         _estack = .;
-    } > ram
-
-
+   
     /* STATIC ELEMENTS FOR TOCK KERNEL */
     .text :
     {
@@ -227,6 +201,31 @@ SECTIONS
 
 
 
+    .stack (NOLOAD) :
+    {
+        /* Kernel stack.
+         *
+         * Tock places the kernel stack at the bottom of SRAM so that the
+         * kernel will trigger memory fault if it exceeds its stack depth,
+         * rather than silently overwriting valuable data.
+         */
+        . = ALIGN(8);
+         _sstack = .;
+
+         /* For GNU LD, we can just advance the location pointer (".") here to
+          * reserve space for the stack. That, however, doesn't seem to work
+          * for LLVM LLD. The resulting ELF has a stack section that shows the
+          * correct size, but the next section (in our case .relocate) is not
+          * moved down as well, instead it sits at the same address as .stack.
+          * To work around this, we declare a dummy buffer and then insert it
+          * here in the .stack section. This sets the stack size correctly and
+          * places the .relocate section at the correct address. */
+         KEEP(*(.stack_buffer))
+         /*. = . + 0x1000;*/  /*This is the original method. */
+
+         . = ALIGN(8);
+         _estack = .;
+    } > ram
 
     /* Kernel data that must be relocated. This is program data that is
      * expected to live in SRAM, but is initialized with a value. This data is

--- a/boards/build_scripts/tock_kernel_layout.ld
+++ b/boards/build_scripts/tock_kernel_layout.ld
@@ -47,7 +47,7 @@ SECTIONS
     
     /**
      * The order matters here for the x86 platform.
-
+     *
      * We need to make sure that qemu-system-i386 finds the multiboot header within the
      * first 8K of the ELF. The multiboot header is placed at the beginning of the .text section, so
      * this section has to be placed first in the file.

--- a/boards/build_scripts/tock_kernel_layout.ld
+++ b/boards/build_scripts/tock_kernel_layout.ld
@@ -51,7 +51,15 @@ SECTIONS
      * We need to make sure that qemu-system-i386 finds the multiboot header within the
      * first 8K of the ELF. The multiboot header is placed at the beginning of the .text section, so
      * this section has to be placed first in the file.
-     *  
+     *
+     * The multiboot header's documentation is available at
+     * https://www.gnu.org/software/grub/manual/multiboot/multiboot.html.
+     * This allows Tock to be booted using a bootloader that supports multiboot v1.
+     * QEMU provides for x86 such a bootloader when used with the `-kernel` flag.
+     *
+     * The bootloader is responsable for loading the kernel into RAM and executing it. Without it,
+     * the Tock kernel should provide a bootloader that starts reading the kernel into RAM.
+     *
      * This is the reason why the .text section has to be the first.
      */
    

--- a/boards/build_scripts/tock_kernel_layout.ld
+++ b/boards/build_scripts/tock_kernel_layout.ld
@@ -46,22 +46,10 @@ SECTIONS
 
     
     /**
-     * The order matters here for the x86 platform.
-     *
-     * We need to make sure that qemu-system-i386 finds the multiboot header within the
-     * first 8K of the ELF. The multiboot header is placed at the beginning of the .text section, so
-     * this section has to be placed first in the file.
-     *
-     * The multiboot header's documentation is available at
-     * https://www.gnu.org/software/grub/manual/multiboot/multiboot.html.
-     * This allows Tock to be booted using a bootloader that supports multiboot v1.
-     * QEMU provides for x86 such a bootloader when used with the `-kernel` flag.
-     *
-     * The bootloader is responsable for loading the kernel into RAM and executing it. Without it,
-     * the Tock kernel should provide a bootloader that starts reading the kernel into RAM.
-     *
-     * This is the reason why the .text section has to be the first.
+     * The order matters here for the x86 platform, the .text section has to be the first one.
+     * Please see the details bellow where the .x86.start is stored.
      */
+    
    
     /* STATIC ELEMENTS FOR TOCK KERNEL */
     .text :
@@ -103,7 +91,21 @@ SECTIONS
         KEEP(*(.riscv.trap_vectored));
         KEEP(*(.riscv.trap));
 
-        /* x86 */     
+        /* x86     
+         * We need to make sure that qemu-system-i386 finds the multiboot header within the
+         * first 8K of the ELF. The multiboot header is placed at the beginning of the .text section, so
+         * this section has to be placed first in the file.
+         *
+         * The multiboot header's documentation is available at
+         * https://www.gnu.org/software/grub/manual/multiboot/multiboot.html.
+         * This allows Tock to be booted using a bootloader that supports multiboot v1.
+         * QEMU provides for x86 such a bootloader when used with the `-kernel` flag.
+         *
+         * The bootloader is responsable for loading the kernel into RAM and executing it. Without it,
+         * the Tock kernel should provide a bootloader that starts reading the kernel into RAM.
+         *
+         * This is the reason why the .text section has to be the first.
+         */
         KEEP(*(.x86.start))
 
         /* .text and .rodata hold most program code and immutable constants */

--- a/boards/build_scripts/tock_kernel_layout.ld
+++ b/boards/build_scripts/tock_kernel_layout.ld
@@ -62,6 +62,23 @@ SECTIONS
         _textstart = .;         /* Symbol expected by some MS build toolchains */
         _stext = .;         /* First of standard s,e (start/end) pair */
 
+        /* x86     
+         * We need to make sure that qemu-system-i386 finds the multiboot header within the
+         * first 8K of the ELF. The multiboot header is placed at the beginning of the .text section, so
+         * this section has to be placed first in the file.
+         *
+         * The multiboot header's documentation is available at
+         * https://www.gnu.org/software/grub/manual/multiboot/multiboot.html.
+         * This allows Tock to be booted using a bootloader that supports multiboot v1.
+         * QEMU provides for x86 such a bootloader when used with the `-kernel` flag.
+         *
+         * The bootloader is responsable for loading the kernel into RAM and executing it. Without it,
+         * the Tock kernel should provide a bootloader that starts reading the kernel into RAM.
+         *
+         * This is the reason why the .text section has to be the first.
+         */
+        KEEP(*(.multiboot))
+
         /* Place vector table at the beginning of ROM.
          *
          * The first 16 entries in the ARM vector table are defined by ARM and
@@ -95,21 +112,7 @@ SECTIONS
         KEEP(*(.riscv.trap_vectored));
         KEEP(*(.riscv.trap));
 
-        /* x86     
-         * We need to make sure that qemu-system-i386 finds the multiboot header within the
-         * first 8K of the ELF. The multiboot header is placed at the beginning of the .text section, so
-         * this section has to be placed first in the file.
-         *
-         * The multiboot header's documentation is available at
-         * https://www.gnu.org/software/grub/manual/multiboot/multiboot.html.
-         * This allows Tock to be booted using a bootloader that supports multiboot v1.
-         * QEMU provides for x86 such a bootloader when used with the `-kernel` flag.
-         *
-         * The bootloader is responsable for loading the kernel into RAM and executing it. Without it,
-         * the Tock kernel should provide a bootloader that starts reading the kernel into RAM.
-         *
-         * This is the reason why the .text section has to be the first.
-         */
+        /* x86 */
         KEEP(*(.x86.start))
 
         /* .text and .rodata hold most program code and immutable constants */

--- a/boards/build_scripts/tock_kernel_layout.ld
+++ b/boards/build_scripts/tock_kernel_layout.ld
@@ -43,6 +43,17 @@ PAGE_SIZE = DEFINED(PAGE_SIZE) ? PAGE_SIZE : 512;
 
 SECTIONS
 {
+
+    
+    /**
+     * The order matters here for the x86 platform.
+
+     * We need to make sure that qemu-system-i386 finds the multiboot header within the
+     * first 8K of the ELF. The multiboot header is placed at the begining of the .text section, so
+     * this section has to be is placed first in the file.
+     *  
+     * This is the reason why the .text section has to be the first.
+     */
    
     /* STATIC ELEMENTS FOR TOCK KERNEL */
     .text :

--- a/boards/build_scripts/tock_kernel_layout.ld
+++ b/boards/build_scripts/tock_kernel_layout.ld
@@ -87,7 +87,6 @@ SECTIONS
          *
          * http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0553a/BABIFJFG.html
          */
-
         KEEP(*(.vectors .vectors.*))
         KEEP(*(.irqs))
 

--- a/boards/build_scripts/tock_kernel_layout.ld
+++ b/boards/build_scripts/tock_kernel_layout.ld
@@ -219,33 +219,6 @@ SECTIONS
     } > ccfg
 
 
-
-    .stack (NOLOAD) :
-    {
-        /* Kernel stack.
-         *
-         * Tock places the kernel stack at the bottom of SRAM so that the
-         * kernel will trigger memory fault if it exceeds its stack depth,
-         * rather than silently overwriting valuable data.
-         */
-        . = ALIGN(8);
-         _sstack = .;
-
-         /* For GNU LD, we can just advance the location pointer (".") here to
-          * reserve space for the stack. That, however, doesn't seem to work
-          * for LLVM LLD. The resulting ELF has a stack section that shows the
-          * correct size, but the next section (in our case .relocate) is not
-          * moved down as well, instead it sits at the same address as .stack.
-          * To work around this, we declare a dummy buffer and then insert it
-          * here in the .stack section. This sets the stack size correctly and
-          * places the .relocate section at the correct address. */
-         KEEP(*(.stack_buffer))
-         /*. = . + 0x1000;*/  /*This is the original method. */
-
-         . = ALIGN(8);
-         _estack = .;
-    } > ram
-
     /* Kernel data that must be relocated. This is program data that is
      * expected to live in SRAM, but is initialized with a value. This data is
      * physically placed into flash and is copied into SRAM by Tock. The
@@ -286,6 +259,31 @@ SECTIONS
     } > ram
 
 
+   .stack (NOLOAD) :
+    {
+        /* Kernel stack.
+         *
+         * Tock places the kernel stack at the bottom of SRAM so that the
+         * kernel will trigger memory fault if it exceeds its stack depth,
+         * rather than silently overwriting valuable data.
+         */
+        . = ALIGN(8);
+         _sstack = .;
+
+         /* For GNU LD, we can just advance the location pointer (".") here to
+          * reserve space for the stack. That, however, doesn't seem to work
+          * for LLVM LLD. The resulting ELF has a stack section that shows the
+          * correct size, but the next section (in our case .relocate) is not
+          * moved down as well, instead it sits at the same address as .stack.
+          * To work around this, we declare a dummy buffer and then insert it
+          * here in the .stack section. This sets the stack size correctly and
+          * places the .relocate section at the correct address. */
+         KEEP(*(.stack_buffer))
+         /*. = . + 0x1000;*/  /*This is the original method. */
+
+         . = ALIGN(8);
+         _estack = .;
+    } > ram
 
     /* Section for application binaries in flash.
      *

--- a/boards/qemu_i486_q35/Makefile
+++ b/boards/qemu_i486_q35/Makefile
@@ -38,7 +38,7 @@ QEMU_BASE_CMDLINE := \
 .PHONY: run
 run: $(TARGET_PATH)/release/$(PLATFORM).elf
 	@echo
-	@echo Reordering ELF file sections
+#	@echo Reordering ELF file sections
 #	@$(OBJCOPY)  $<
 	@echo
 	@echo -e "Running $$(qemu-system-i386 --version | head -n1)"\

--- a/boards/qemu_i486_q35/Makefile
+++ b/boards/qemu_i486_q35/Makefile
@@ -34,12 +34,12 @@ QEMU_BASE_CMDLINE := \
 # sections within the ELF file such that .text comes first and the Multiboot header is discoverable.
 #
 # If tock fails to boot with the following error: "qemu_i486_q35: cannot execute binary file",
-# replace objcopy with the full path to GNU objcopy.
+# replace objcopy with the full path to GNU objcopy and uncomment the "@$(OBJCOPY) $<".
 .PHONY: run
 run: $(TARGET_PATH)/release/$(PLATFORM).elf
 	@echo
 	@echo Reordering ELF file sections
-	@$(OBJCOPY)  $<
+#	@$(OBJCOPY)  $<
 	@echo
 	@echo -e "Running $$(qemu-system-i386 --version | head -n1)"\
 	  "(tested: $(WORKING_QEMU_VERSION)) with\n"\

--- a/boards/qemu_i486_q35/layout.ld
+++ b/boards/qemu_i486_q35/layout.ld
@@ -22,6 +22,14 @@ MEMORY
  */
 PAGE_SIZE = 4K;
 
+/**
+ * The order matters here as we need to make sure that qemu finds the multiboot header within the
+ * first 8K of the ELF. The multiboot header is placed at the begining of the .text section, so
+ * this section has to be is placed first in the file.
+ *  
+ * This is the reason why this INCLUDE has to be before the .pages declaration
+ */
+
 INCLUDE tock_kernel_layout.ld
 
 SECTIONS

--- a/boards/qemu_i486_q35/layout.ld
+++ b/boards/qemu_i486_q35/layout.ld
@@ -22,6 +22,8 @@ MEMORY
  */
 PAGE_SIZE = 4K;
 
+INCLUDE tock_kernel_layout.ld
+
 SECTIONS
 {
     /**
@@ -36,4 +38,3 @@ SECTIONS
     } > pages
 }
 
-INCLUDE tock_kernel_layout.ld

--- a/boards/qemu_i486_q35/layout.ld
+++ b/boards/qemu_i486_q35/layout.ld
@@ -24,7 +24,7 @@ PAGE_SIZE = 4K;
 
 /**
  * The order matters here as we need to make sure that qemu finds the multiboot header within the
- * first 8K of the ELF. The multiboot header is placed at the begining of the .text section, so
+ * first 8K of the ELF. The multiboot header is placed at the beginning of the .text section, so
  * this section has to be is placed first in the file.
  *  
  * This is the reason why this INCLUDE has to be before the .pages declaration

--- a/boards/qemu_i486_q35/layout.ld
+++ b/boards/qemu_i486_q35/layout.ld
@@ -27,6 +27,14 @@ PAGE_SIZE = 4K;
  * first 8K of the ELF. The multiboot header is placed at the beginning of the .text section, so
  * this section has to be is placed first in the file.
  *  
+ * The multiboot header's documentation is available at
+ * https://www.gnu.org/software/grub/manual/multiboot/multiboot.html.
+ * This allows Tock to be booted using a bootloader that supports multiboot v1.
+ * QEMU provides for x86 such a bootloader when used with the `-kernel` flag.
+ *
+ * The bootloader is responsable for loading the kernel into RAM and executing it. Without it,
+ * the Tock kernel should provide a bootloader that starts reading the kernel into RAM.
+ *
  * This is the reason why this INCLUDE has to be before the .pages declaration
  */
 

--- a/boards/qemu_i486_q35/src/main.rs
+++ b/boards/qemu_i486_q35/src/main.rs
@@ -41,7 +41,7 @@ use multiboot::MultibootV1Header;
 mod io;
 
 /// Multiboot V1 header, allowing this kernel to be booted directly by QEMU
-#[link_section = ".vectors"]
+#[link_section = ".multiboot"]
 #[used]
 static MULTIBOOT_V1_HEADER: MultibootV1Header = MultibootV1Header::new(0);
 


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes:
- migrates the `x86` target from `global_asm!` to naked functions 
- fixes the boot freeze issue due to adding `ENTRY` to `kernel_layout` in #4509, the system does not boot without this fix
- reorders the sections in the kernel ELF file so that the `.text` section is placed first in the ELF file 


### Testing Strategy

This pull request was tested by @alexandruradovici.


### TODO or Help Wanted

This pull request still needs testing that the context switch works, @reynoldsbd could you test this?

- [x] Test on ARMv6M boards - Raspberry Pi Pico @JADarius 
- [x] Test on ARMv7M boards - STM32
- [x] Test on RISC-V - @lschuermann 
- [x] Test applications on x86 - @reynoldsbd @domnudragota


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
