### PR TITLE
Board Panic Handler `static mut`s: Port to `SingleThreadValue`

### DIFF
--- a/boards/arty_e21/src/io.rs
+++ b/boards/arty_e21/src/io.rs
@@ -4,21 +4,13 @@
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::ptr::addr_of;
-use core::ptr::addr_of_mut;
 use core::str;
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::gpio;
 use kernel::hil::led;
 
-use crate::CHIP;
-use crate::PROCESSES;
-use crate::PROCESS_PRINTER;
-
 struct Writer {}
-
-static mut WRITER: Writer = Writer {};
 
 impl Write for Writer {
     fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
@@ -65,14 +57,12 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     );
 
     let led_red = &mut led::LedHigh::new(led_red_pin);
-    let writer = &mut *addr_of_mut!(WRITER);
-    debug::panic(
+    let mut writer = Writer {};
+    debug::panic_new(
         &mut [led_red],
-        writer,
+        &mut writer,
         pi,
         &rv32i::support::nop,
-        PROCESSES.unwrap().as_slice(),
-        &*addr_of!(CHIP),
-        &*addr_of!(PROCESS_PRINTER),
+        crate::PANIC_RESOURCES.get(),
     )
 }

--- a/boards/arty_e21/src/main.rs
+++ b/boards/arty_e21/src/main.rs
@@ -10,12 +10,13 @@
 use arty_e21_chip::chip::ArtyExxDefaultPeripherals;
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 
+use crate::debug::PanicResources;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::hil;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::process::ProcessArray;
 use kernel::scheduler::priority::PrioritySched;
+use kernel::utilities::single_thread_value::SingleThreadValue;
 use kernel::{create_capability, debug, static_init};
 
 #[allow(dead_code)]
@@ -34,13 +35,12 @@ type ChipHw = arty_e21_chip::chip::ArtyExx<'static, ArtyExxDefaultPeripherals<'s
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
     capsules_system::process_policies::PanicFaultPolicy {};
 
-/// Static variables used by io.rs.
-static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
+type Chip = arty_e21_chip::chip::ArtyExx<'static, ArtyExxDefaultPeripherals<'static>>;
+type ProcessPrinter = capsules_system::process_printer::ProcessPrinterText;
 
-// Reference to the chip for panic dumps.
-static mut CHIP: Option<&'static arty_e21_chip::chip::ArtyExx<ArtyExxDefaultPeripherals>> = None;
-static mut PROCESS_PRINTER: Option<&'static capsules_system::process_printer::ProcessPrinterText> =
-    None;
+/// Resources for when a board panics used by io.rs.
+static PANIC_RESOURCES: SingleThreadValue<PanicResources<Chip, ProcessPrinter>> =
+    SingleThreadValue::new(PanicResources::new());
 
 kernel::stack_size! {0x1000}
 
@@ -126,6 +126,8 @@ unsafe fn start() -> (
     ArtyE21,
     &'static arty_e21_chip::chip::ArtyExx<'static, ArtyExxDefaultPeripherals<'static>>,
 ) {
+    PANIC_RESOURCES.bind_to_thread::<<Chip as kernel::platform::chip::Chip>::ThreadIdProvider>();
+
     let peripherals = static_init!(ArtyExxDefaultPeripherals, ArtyExxDefaultPeripherals::new());
     peripherals.init();
 
@@ -133,7 +135,9 @@ unsafe fn start() -> (
         arty_e21_chip::chip::ArtyExx<ArtyExxDefaultPeripherals>,
         arty_e21_chip::chip::ArtyExx::new(&peripherals.machinetimer, peripherals)
     );
-    CHIP = Some(chip);
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.chip.put(chip);
+    });
     chip.initialize();
 
     let process_mgmt_cap = create_capability!(capabilities::ProcessManagementCapability);
@@ -141,7 +145,9 @@ unsafe fn start() -> (
     // Create an array to hold process references.
     let processes = components::process_array::ProcessArrayComponent::new()
         .finalize(components::process_array_component_static!(NUM_PROCS));
-    PROCESSES = Some(processes);
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.processes.put(processes.as_slice());
+    });
 
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
 
@@ -154,7 +160,9 @@ unsafe fn start() -> (
 
     let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
         .finalize(components::process_printer_text_component_static!());
-    PROCESS_PRINTER = Some(process_printer);
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.printer.put(process_printer);
+    });
 
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = components::console::UartMuxComponent::new(&peripherals.uart0, 115200)

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -16,6 +16,7 @@ use capsules_core::virtualizers::virtual_aes_ccm::MuxAES128CCM;
 
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::debug::PanicResources;
 use kernel::hil;
 use kernel::hil::buzzer::Buzzer;
 use kernel::hil::i2c::I2CMaster;
@@ -24,10 +25,11 @@ use kernel::hil::symmetric_encryption::AES128;
 use kernel::hil::time::Alarm;
 use kernel::hil::time::Counter;
 use kernel::hil::usb::Client;
-use kernel::platform::chip::Chip;
+use kernel::platform::chip::Chip as _Chip;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::process::ProcessArray;
 use kernel::scheduler::round_robin::RoundRobinSched;
+use kernel::utilities::cells::MapCell;
+use kernel::utilities::single_thread_value::SingleThreadValue;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
 
@@ -109,20 +111,20 @@ const FAULT_RESPONSE: capsules_system::process_policies::StopWithDebugFaultPolic
 const NUM_PROCS: usize = 8;
 
 type ChipHw = nrf52840::chip::NRF52<'static, Nrf52840DefaultPeripherals<'static>>;
+type ProcessPrinter = capsules_system::process_printer::ProcessPrinterText;
+type CdcAcm = capsules_extra::usb::cdc::CdcAcm<
+    'static,
+    nrf52::usbd::Usbd<'static>,
+    capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, nrf52::rtc::Rtc<'static>>,
+>;
 
-/// Static variables used by io.rs.
-static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
-static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;
-static mut PROCESS_PRINTER: Option<&'static capsules_system::process_printer::ProcessPrinterText> =
-    None;
-static mut CDC_REF_FOR_PANIC: Option<
-    &'static capsules_extra::usb::cdc::CdcAcm<
-        'static,
-        nrf52::usbd::Usbd,
-        capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, nrf52::rtc::Rtc>,
-    >,
-> = None;
-static mut NRF52_POWER: Option<&'static nrf52840::power::Power> = None;
+/// Resources for when a board panics used by io.rs.
+static PANIC_RESOURCES: SingleThreadValue<PanicResources<Chip, ProcessPrinter>> =
+    SingleThreadValue::new(PanicResources::new());
+static CDC_REF_FOR_PANIC: SingleThreadValue<MapCell<&'static CdcAcm>> =
+    SingleThreadValue::new(MapCell::empty());
+static NRF52_POWER: SingleThreadValue<MapCell<&'static nrf52840::power::Power>> =
+    SingleThreadValue::new(MapCell::empty());
 
 kernel::stack_size! {0x1000}
 
@@ -131,7 +133,11 @@ fn baud_rate_reset_bootloader_enter() {
     unsafe {
         // 0x4e is the magic value the Adafruit nRF52 Bootloader expects
         // as defined by https://github.com/adafruit/Adafruit_nRF52_Bootloader/blob/master/src/main.c
-        NRF52_POWER.unwrap().set_gpregret(0x90);
+        NRF52_POWER.get().map(|power_cell| {
+            power_cell.map(|power| {
+                power.set_gpregret(0x90);
+            });
+        });
         // uncomment to use with Adafruit nRF52 Bootloader
         // NRF52_POWER.unwrap().set_gpregret(0x4e);
         cortexm4::scb::reset();
@@ -270,6 +276,11 @@ unsafe fn start() -> (
 ) {
     nrf52840::init();
 
+    // Bind global variables to this thread.
+    PANIC_RESOURCES.bind_to_thread::<<Chip as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    CDC_REF_FOR_PANIC.bind_to_thread::<<Chip as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    NRF52_POWER.bind_to_thread::<<Chip as kernel::platform::chip::Chip>::ThreadIdProvider>();
+
     let ieee802154_ack_buf = static_init!(
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
@@ -287,12 +298,16 @@ unsafe fn start() -> (
 
     // Save a reference to the power module for resetting the board into the
     // bootloader.
-    NRF52_POWER = Some(&base_peripherals.pwr_clk);
+    NRF52_POWER.get().map(|power_cell| {
+        power_cell.put(&base_peripherals.pwr_clk);
+    });
 
     // Create an array to hold process references.
     let processes = components::process_array::ProcessArrayComponent::new()
         .finalize(components::process_array_component_static!(NUM_PROCS));
-    PROCESSES = Some(processes);
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.processes.put(processes.as_slice());
+    });
 
     // Setup space to store the core kernel data structure.
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
@@ -505,7 +520,9 @@ unsafe fn start() -> (
         nrf52::usbd::Usbd,
         nrf52::rtc::Rtc
     ));
-    CDC_REF_FOR_PANIC = Some(cdc); //for use by panic handler
+    CDC_REF_FOR_PANIC.get().map(|cdc_cell| {
+        cdc_cell.put(cdc);
+    });
 
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = components::console::UartMuxComponent::new(cdc, 115200)
@@ -743,7 +760,9 @@ unsafe fn start() -> (
 
     let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
         .finalize(components::process_printer_text_component_static!());
-    PROCESS_PRINTER = Some(process_printer);
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.printer.put(process_printer);
+    });
 
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
@@ -796,7 +815,9 @@ unsafe fn start() -> (
         nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
         nrf52840::chip::NRF52::new(nrf52840_peripherals)
     );
-    CHIP = Some(chip);
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.chip.put(chip);
+    });
 
     // Need to disable the MPU because the bootloader seems to set it up.
     chip.mpu().clear_mpu();

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/src/main.rs
@@ -13,7 +13,6 @@ use kernel::deferred_call::DeferredCallClient;
 use kernel::hil::led::LedLow;
 use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::process::ProcessArray;
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{capabilities, create_capability, static_init};
 use nrf52840::gpio::Pin;
@@ -43,10 +42,6 @@ const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
 
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 8;
-
-/// Static variables used by io.rs.
-static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
-static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;
 
 kernel::stack_size! {0x2000}
 
@@ -171,7 +166,6 @@ pub unsafe fn main() {
     // Create an array to hold process references.
     let processes = components::process_array::ProcessArrayComponent::new()
         .finalize(components::process_array_component_static!(NUM_PROCS));
-    PROCESSES = Some(processes);
 
     // Setup space to store the core kernel data structure.
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
@@ -182,7 +176,6 @@ pub unsafe fn main() {
         nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
         nrf52840::chip::NRF52::new(nrf52840_peripherals)
     );
-    CHIP = Some(chip);
 
     // Do nRF configuration and setup. This is shared code with other nRF-based
     // platforms.

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-sha256/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-sha256/src/main.rs
@@ -12,7 +12,6 @@ use kernel::component::Component;
 use kernel::hil::led::LedLow;
 use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::process::ProcessArray;
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{capabilities, create_capability, static_init};
 use nrf52840::gpio::Pin;
@@ -42,10 +41,6 @@ const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
 
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 8;
-
-/// Static variables used by io.rs.
-static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
-static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;
 
 kernel::stack_size! {0x2000}
 
@@ -160,7 +155,6 @@ pub unsafe fn main() {
     // Create an array to hold process references.
     let processes = components::process_array::ProcessArrayComponent::new()
         .finalize(components::process_array_component_static!(NUM_PROCS));
-    PROCESSES = Some(processes);
 
     // Setup space to store the core kernel data structure.
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
@@ -171,7 +165,6 @@ pub unsafe fn main() {
         nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
         nrf52840::chip::NRF52::new(nrf52840_peripherals)
     );
-    CHIP = Some(chip);
 
     // Do nRF configuration and setup. This is shared code with other nRF-based
     // platforms.

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/main.rs
@@ -12,8 +12,7 @@ use kernel::component::Component;
 use kernel::hil::led::LedLow;
 use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::process::ProcessArray;
-use kernel::process::ProcessLoadingAsync;
+use kernel::process::{ProcessArray, ProcessLoadingAsync};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{capabilities, create_capability, static_init};
 use nrf52840::gpio::Pin;
@@ -45,10 +44,6 @@ const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
 const NUM_PROCS: usize = 8;
 
 type ChipHw = nrf52840::chip::NRF52<'static, Nrf52840DefaultPeripherals<'static>>;
-
-/// Static variables used by io.rs.
-static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
-static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;
 
 kernel::stack_size! {0x2000}
 
@@ -179,7 +174,6 @@ pub unsafe fn main() {
     // Create an array to hold process references.
     let processes = components::process_array::ProcessArrayComponent::new()
         .finalize(components::process_array_component_static!(NUM_PROCS));
-    PROCESSES = Some(processes);
 
     // Setup space to store the core kernel data structure.
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
@@ -190,7 +184,6 @@ pub unsafe fn main() {
         nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
         nrf52840::chip::NRF52::new(nrf52840_peripherals)
     );
-    CHIP = Some(chip);
 
     // Do nRF configuration and setup. This is shared code with other nRF-based
     // platforms.

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/io.rs
@@ -9,16 +9,14 @@ use kernel::hil::uart::Configure;
 
 use nrf52840::uart::{Uarte, UARTE0_BASE};
 
-enum Writer {
-    WriterUart(/* initialized */ bool),
-    WriterRtt(&'static segger::rtt::SeggerRttMemory<'static>),
+struct Writer {
+    initialized: bool,
 }
 
-static mut WRITER: Writer = Writer::WriterUart(false);
-
-/// Set the RTT memory buffer used to output panic messages.
-pub unsafe fn set_rtt_memory(rtt_memory: &'static segger::rtt::SeggerRttMemory<'static>) {
-    WRITER = Writer::WriterRtt(rtt_memory);
+impl Writer {
+    fn new() -> Self {
+        Self { initialized: false }
+    }
 }
 
 impl Write for Writer {
@@ -30,33 +28,27 @@ impl Write for Writer {
 
 impl IoWrite for Writer {
     fn write(&mut self, buf: &[u8]) -> usize {
-        match self {
-            Writer::WriterUart(ref mut initialized) => {
-                // Here, we create a second instance of the Uarte struct.
-                // This is okay because we only call this during a panic, and
-                // we will never actually process the interrupts
-                let uart = Uarte::new(UARTE0_BASE);
-                if !*initialized {
-                    *initialized = true;
-                    let _ = uart.configure(uart::Parameters {
-                        baud_rate: 115200,
-                        stop_bits: uart::StopBits::One,
-                        parity: uart::Parity::None,
-                        hw_flow_control: false,
-                        width: uart::Width::Eight,
-                    });
-                }
-                for &c in buf {
-                    unsafe {
-                        uart.send_byte(c);
-                    }
-                    while !uart.tx_ready() {}
-                }
-            }
-            Writer::WriterRtt(rtt_memory) => {
-                rtt_memory.write_sync(buf);
-            }
+        // Here, we create a second instance of the Uarte struct.
+        // This is okay because we only call this during a panic, and
+        // we will never actually process the interrupts
+        let uart = Uarte::new(UARTE0_BASE);
+        if !self.initialized {
+            self.initialized = true;
+            let _ = uart.configure(uart::Parameters {
+                baud_rate: 115200,
+                stop_bits: uart::StopBits::One,
+                parity: uart::Parity::None,
+                hw_flow_control: false,
+                width: uart::Width::Eight,
+            });
         }
+        for &c in buf {
+            unsafe {
+                uart.send_byte(c);
+            }
+            while !uart.tx_ready() {}
+        }
+
         buf.len()
     }
 }
@@ -65,26 +57,19 @@ impl IoWrite for Writer {
 #[panic_handler]
 /// Panic handler
 pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {
-    use core::ptr::{addr_of, addr_of_mut};
     use kernel::debug;
     use kernel::hil::led;
     use nrf52840::gpio::Pin;
 
-    use crate::CHIP;
-    use crate::PROCESSES;
-    use crate::PROCESS_PRINTER;
-
     // The nRF52840DK LEDs (see back of board)
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
     let led = &mut led::LedLow::new(led_kernel_pin);
-    let writer = &mut *addr_of_mut!(WRITER);
-    debug::panic(
+    let mut writer = Writer::new();
+    debug::panic_new(
         &mut [led],
-        writer,
+        &mut writer,
         pi,
         &cortexm4::support::nop,
-        PROCESSES.unwrap().as_slice(),
-        &*addr_of!(CHIP),
-        &*addr_of!(PROCESS_PRINTER),
+        crate::PANIC_RESOURCES.get(),
     )
 }

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
@@ -9,12 +9,14 @@
 #![deny(missing_docs)]
 
 use kernel::component::Component;
+use kernel::debug::PanicResources;
 use kernel::hil::led::LedLow;
 use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::process::ProcessArray;
 use kernel::process::ProcessLoadingAsync;
 use kernel::scheduler::round_robin::RoundRobinSched;
+use kernel::utilities::single_thread_value::SingleThreadValue;
 use kernel::{capabilities, create_capability, static_init};
 use nrf52840::gpio::Pin;
 use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
@@ -50,13 +52,11 @@ const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
 const NUM_PROCS: usize = 8;
 
 type ChipHw = nrf52840::chip::NRF52<'static, Nrf52840DefaultPeripherals<'static>>;
+type ProcessPrinter = capsules_system::process_printer::ProcessPrinterText;
 
-/// Static variables used by io.rs.
-static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
-static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;
-// Static reference to process printer for panic dumps.
-static mut PROCESS_PRINTER: Option<&'static capsules_system::process_printer::ProcessPrinterText> =
-    None;
+/// Resources for when a board panics used by io.rs.
+static PANIC_RESOURCES: SingleThreadValue<PanicResources<Chip, ProcessPrinter>> =
+    SingleThreadValue::new(PanicResources::new());
 
 kernel::stack_size! {0x2000}
 
@@ -189,6 +189,9 @@ pub unsafe fn main() {
     // Apply errata fixes and enable interrupts.
     nrf52840::init();
 
+    // Bind global variables to this thread.
+    PANIC_RESOURCES.bind_to_thread::<<Chip as kernel::platform::chip::Chip>::ThreadIdProvider>();
+
     // Set up peripheral drivers. Called in separate function to reduce stack
     // usage.
     let nrf52840_peripherals = create_peripherals();
@@ -205,7 +208,9 @@ pub unsafe fn main() {
     // Create an array to hold process references.
     let processes = components::process_array::ProcessArrayComponent::new()
         .finalize(components::process_array_component_static!(NUM_PROCS));
-    PROCESSES = Some(processes);
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.processes.put(processes.as_slice());
+    });
 
     // Setup space to store the core kernel data structure.
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
@@ -216,7 +221,9 @@ pub unsafe fn main() {
         nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
         nrf52840::chip::NRF52::new(nrf52840_peripherals)
     );
-    CHIP = Some(chip);
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.chip.put(chip);
+    });
 
     // Do nRF configuration and setup. This is shared code with other nRF-based
     // platforms.
@@ -291,7 +298,9 @@ pub unsafe fn main() {
     // Tool for displaying information about processes.
     let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
         .finalize(components::process_printer_text_component_static!());
-    PROCESS_PRINTER = Some(process_printer);
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.printer.put(process_printer);
+    });
 
     // Create the process console, an interactive terminal for managing
     // processes.

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-invs/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-invs/src/main.rs
@@ -12,7 +12,6 @@ use kernel::component::Component;
 use kernel::hil::led::LedLow;
 use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::process::ProcessArray;
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{capabilities, create_capability, static_init};
 use nrf52840::gpio::Pin;
@@ -52,10 +51,6 @@ const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
 
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 8;
-
-/// Static variables used by io.rs.
-static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
-static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;
 
 kernel::stack_size! {0x2000}
 
@@ -183,7 +178,6 @@ pub unsafe fn main() {
     // Create an array to hold process references.
     let processes = components::process_array::ProcessArrayComponent::new()
         .finalize(components::process_array_component_static!(NUM_PROCS));
-    PROCESSES = Some(processes);
 
     // Setup space to store the core kernel data structure.
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
@@ -194,7 +188,6 @@ pub unsafe fn main() {
         nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
         nrf52840::chip::NRF52::new(nrf52840_peripherals)
     );
-    CHIP = Some(chip);
 
     // Do nRF configuration and setup. This is shared code with other nRF-based
     // platforms.

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/io.rs
@@ -1,32 +1,22 @@
 // Licensed under the Apache License, Version 2.0 or the MIT License.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
+// Copyright Tock Contributors 2024.
 
 use core::fmt::Write;
-use core::panic::PanicInfo;
-use cortexm4;
-use kernel::debug;
 use kernel::debug::IoWrite;
-use kernel::hil::led;
 use kernel::hil::uart;
 use kernel::hil::uart::Configure;
-use nrf52840::gpio::Pin;
+
 use nrf52840::uart::{Uarte, UARTE0_BASE};
 
-use crate::CHIP;
-use crate::PROCESSES;
-use crate::PROCESS_PRINTER;
-
-enum Writer {
-    WriterUart(/* initialized */ bool),
-    WriterRtt(&'static segger::rtt::SeggerRttMemory<'static>),
+struct Writer {
+    initialized: bool,
 }
 
-static mut WRITER: Writer = Writer::WriterUart(false);
-
-/// Set the RTT memory buffer used to output panic messages.
-pub unsafe fn set_rtt_memory(rtt_memory: &'static segger::rtt::SeggerRttMemory<'static>) {
-    WRITER = Writer::WriterRtt(rtt_memory);
+impl Writer {
+    fn new() -> Self {
+        Self { initialized: false }
+    }
 }
 
 impl Write for Writer {
@@ -38,29 +28,27 @@ impl Write for Writer {
 
 impl IoWrite for Writer {
     fn write(&mut self, buf: &[u8]) -> usize {
-        match self {
-            Writer::WriterUart(ref mut initialized) => {
-                // Here, we create a second instance of the Uarte struct.
-                // This is okay because we only call this during a panic, and
-                // we will never actually process the interrupts
-                let uart = Uarte::new(UARTE0_BASE);
-                if !*initialized {
-                    *initialized = true;
-                    let _ = uart.configure(uart::Parameters {
-                        baud_rate: 115200,
-                        stop_bits: uart::StopBits::One,
-                        parity: uart::Parity::None,
-                        hw_flow_control: false,
-                        width: uart::Width::Eight,
-                    });
-                }
-                for &c in buf {
-                    unsafe { uart.send_byte(c) }
-                    while !uart.tx_ready() {}
-                }
-            }
-            Writer::WriterRtt(rtt_memory) => rtt_memory.write_sync(buf),
+        // Here, we create a second instance of the Uarte struct.
+        // This is okay because we only call this during a panic, and
+        // we will never actually process the interrupts
+        let uart = Uarte::new(UARTE0_BASE);
+        if !self.initialized {
+            self.initialized = true;
+            let _ = uart.configure(uart::Parameters {
+                baud_rate: 115200,
+                stop_bits: uart::StopBits::One,
+                parity: uart::Parity::None,
+                hw_flow_control: false,
+                width: uart::Width::Eight,
+            });
         }
+        for &c in buf {
+            unsafe {
+                uart.send_byte(c);
+            }
+            while !uart.tx_ready() {}
+        }
+
         buf.len()
     }
 }
@@ -68,20 +56,20 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[panic_handler]
 /// Panic handler
-pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    // The nRF52840DK LEDs (see back of board)
+pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {
+    use kernel::debug;
+    use kernel::hil::led;
+    use nrf52840::gpio::Pin;
 
-    use core::ptr::{addr_of, addr_of_mut};
+    // The nRF52840DK LEDs (see back of board)
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
     let led = &mut led::LedLow::new(led_kernel_pin);
-    let writer = &mut *addr_of_mut!(WRITER);
-    debug::panic(
+    let mut writer = Writer::new();
+    debug::panic_new(
         &mut [led],
-        writer,
+        &mut writer,
         pi,
         &cortexm4::support::nop,
-        PROCESSES.unwrap().as_slice(),
-        &*addr_of!(CHIP),
-        &*addr_of!(PROCESS_PRINTER),
+        crate::PANIC_RESOURCES.get(),
     )
 }

--- a/boards/esp32-c3-devkitM-1/src/io.rs
+++ b/boards/esp32-c3-devkitM-1/src/io.rs
@@ -46,7 +46,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     debug::panic_cpu_state(&*addr_of!(CHIP), writer);
     debug::panic_process_info(
         PROCESSES.unwrap().as_slice(),
-        &*addr_of!(PROCESS_PRINTER),
+        *addr_of!(PROCESS_PRINTER),
         writer,
     );
 

--- a/boards/hail/src/io.rs
+++ b/boards/hail/src/io.rs
@@ -10,15 +10,20 @@ use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart::{self, Configure};
 
-use crate::CHIP;
-use crate::PROCESSES;
-use crate::PROCESS_PRINTER;
-
 struct Writer {
     initialized: bool,
+    uart: sam4l::usart::USART<'static>,
 }
 
-static mut WRITER: Writer = Writer { initialized: false };
+impl Writer {
+    fn new(chip: &'static crate::Chip) -> Self {
+        let uart = sam4l::usart::USART::new_usart0(chip.pm);
+        Self {
+            initialized: false,
+            uart,
+        }
+    }
+}
 
 impl Write for Writer {
     fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
@@ -32,7 +37,8 @@ impl IoWrite for Writer {
         // Here, we create a second instance of the USART0 struct.
         // This is okay because we only call this during a panic, and
         // we will never actually process the interrupts
-        let uart = unsafe { sam4l::usart::USART::new_usart0(CHIP.unwrap().pm) };
+        // let uart = unsafe { sam4l::usart::USART::new_usart0(CHIP.unwrap().pm) };
+        let uart = &self.uart;
         let regs_manager = &sam4l::usart::USARTRegManager::panic_new(&uart);
         if !self.initialized {
             self.initialized = true;
@@ -59,8 +65,6 @@ impl IoWrite for Writer {
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // turn off the non panic leds, just in case
-
-    use core::ptr::{addr_of, addr_of_mut};
     let led_green = sam4l::gpio::GPIOPin::new(sam4l::gpio::Pin::PA14);
     led_green.enable_output();
     led_green.set();
@@ -70,14 +74,22 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
 
     let red_pin = sam4l::gpio::GPIOPin::new(sam4l::gpio::Pin::PA13);
     let led_red = &mut led::LedLow::new(&red_pin);
-    let writer = &mut *addr_of_mut!(WRITER);
-    debug::panic(
-        &mut [led_red],
-        writer,
-        pi,
-        &cortexm4::support::nop,
-        PROCESSES.unwrap().as_slice(),
-        &*addr_of!(CHIP),
-        &*addr_of!(PROCESS_PRINTER),
-    )
+
+    crate::PANIC_RESOURCES.with(|resources| {
+        resources.chip.take().map_or_else(
+            || debug::panic_blink_forever(&mut [led_red]),
+            |c| {
+                let writer = kernel::static_init!(Writer, Writer::new(c));
+                resources.set_chip(c);
+
+                debug::panic(
+                    &mut [led_red],
+                    writer,
+                    pi,
+                    &cortexm4::support::nop,
+                    resources,
+                )
+            },
+        )
+    })
 }

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -13,12 +13,14 @@
 
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::debug::PanicResources;
 use kernel::hil;
 use kernel::hil::led::LedLow;
 use kernel::hil::Controller;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::process::ProcessArray;
 use kernel::scheduler::round_robin::RoundRobinSched;
+use kernel::utilities::single_thread_value::SingleThreadValue;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, static_init};
 use sam4l::chip::Sam4lDefaultPeripherals;
@@ -43,7 +45,14 @@ static mut CHIP: Option<&'static sam4l::chip::Sam4l<Sam4lDefaultPeripherals>> = 
 static mut PROCESS_PRINTER: Option<&'static capsules_system::process_printer::ProcessPrinterText> =
     None;
 
+/// Resources for when a board panics used by io.rs.
+static PANIC_RESOURCES: SingleThreadValue<PanicResources<Chip, ProcessPrinter>> =
+    SingleThreadValue::new(PanicResources::new());
+
 kernel::stack_size! {0x1000}
+
+type Chip = sam4l::chip::Sam4l<Sam4lDefaultPeripherals>;
+type ProcessPrinter = capsules_system::process_printer::ProcessPrinterText;
 
 type SI7021Sensor = components::si7021::SI7021ComponentType<
     capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>,

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -13,14 +13,12 @@
 
 use kernel::capabilities;
 use kernel::component::Component;
-use kernel::debug::PanicResources;
 use kernel::hil;
 use kernel::hil::led::LedLow;
 use kernel::hil::Controller;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::process::ProcessArray;
 use kernel::scheduler::round_robin::RoundRobinSched;
-use kernel::utilities::single_thread_value::SingleThreadValue;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, static_init};
 use sam4l::chip::Sam4lDefaultPeripherals;
@@ -45,14 +43,7 @@ static mut CHIP: Option<&'static sam4l::chip::Sam4l<Sam4lDefaultPeripherals>> = 
 static mut PROCESS_PRINTER: Option<&'static capsules_system::process_printer::ProcessPrinterText> =
     None;
 
-/// Resources for when a board panics used by io.rs.
-static PANIC_RESOURCES: SingleThreadValue<PanicResources<Chip, ProcessPrinter>> =
-    SingleThreadValue::new(PanicResources::new());
-
 kernel::stack_size! {0x1000}
-
-type Chip = sam4l::chip::Sam4l<Sam4lDefaultPeripherals>;
-type ProcessPrinter = capsules_system::process_printer::ProcessPrinterText;
 
 type SI7021Sensor = components::si7021::SI7021ComponentType<
     capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>,

--- a/boards/makepython-nrf52840/src/io.rs
+++ b/boards/makepython-nrf52840/src/io.rs
@@ -4,48 +4,67 @@
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::ptr::{addr_of, addr_of_mut};
+use kernel::ErrorCode;
 
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;
+use kernel::hil::uart::Transmit;
 use kernel::hil::uart::{self};
-use kernel::ErrorCode;
+use kernel::static_init;
+use kernel::utilities::cells::MapCell;
+use kernel::utilities::cells::TakeCell;
+use kernel::utilities::cells::VolatileCell;
 use nrf52840::gpio::Pin;
 
-use crate::CHIP;
-use crate::PROCESSES;
-use crate::PROCESS_PRINTER;
-use kernel::hil::uart::Transmit;
-use kernel::utilities::cells::VolatileCell;
-
-struct Writer {
-    initialized: bool,
-}
-
-static mut WRITER: Writer = Writer { initialized: false };
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
 const BUF_LEN: usize = 512;
-static mut STATIC_PANIC_BUF: [u8; BUF_LEN] = [0; BUF_LEN];
-
-static mut DUMMY: DummyUsbClient = DummyUsbClient {
-    fired: VolatileCell::new(false),
-};
 
 struct DummyUsbClient {
     fired: VolatileCell<bool>,
 }
 
+impl DummyUsbClient {
+    fn new() -> Self {
+        Self {
+            fired: VolatileCell::new(false),
+        }
+    }
+
+    fn fired(&self) -> bool {
+        self.fired.get()
+    }
+
+    fn clear(&self) {
+        self.fired.set(false)
+    }
+}
+
 impl uart::TransmitClient for DummyUsbClient {
     fn transmitted_buffer(&self, _: &'static mut [u8], _: usize, _: Result<(), ErrorCode>) {
         self.fired.set(true);
+    }
+}
+
+struct Writer {
+    initialized: bool,
+    buffer: TakeCell<'static, [u8]>,
+    client: &'static DummyUsbClient,
+}
+
+impl Writer {
+    fn new(client: &'static DummyUsbClient, buffer: &'static mut [u8]) -> Self {
+        Self {
+            initialized: false,
+            buffer: TakeCell::new(buffer),
+            client,
+        }
+    }
+}
+
+impl Write for Writer {
+    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
     }
 }
 
@@ -80,62 +99,58 @@ impl IoWrite for Writer {
             max = buf.len();
         }
 
-        unsafe {
-            // If CDC_REF_FOR_PANIC is not yet set we panicked very early,
-            // and not much we can do. Don't want to double fault,
-            // so just return.
-            super::CDC_REF_FOR_PANIC.map(|cdc| {
-                // Lots of unsafe dereferencing of global static mut objects here.
-                // However, this should be okay, because it all happens within
-                // a single thread, and:
-                // - This is the only place the global CDC_REF_FOR_PANIC is used, the logic is the same
-                //   as applies for the global CHIP variable used in the panic handler.
-                // - We do create multiple mutable references to the STATIC_PANIC_BUF, but we never
-                //   access the STATIC_PANIC_BUF after a slice of it is passed to transmit_buffer
-                //   until the slice has been returned in the uart callback.
-                // - Similarly, only this function uses the global DUMMY variable, and we do not
-                //   mutate it.
+        // If CDC_REF_FOR_PANIC is not yet set we panicked very early,
+        // and not much we can do. Don't want to double fault,
+        // so just return.
+        super::CDC_REF_FOR_PANIC
+            .get()
+            .and_then(MapCell::get)
+            .map(|cdc| {
                 let usb = &mut cdc.controller();
-                STATIC_PANIC_BUF[..max].copy_from_slice(&buf[..max]);
-                let static_buf = &mut *addr_of_mut!(STATIC_PANIC_BUF);
-                cdc.set_transmit_client(&*addr_of!(DUMMY));
-                let _ = cdc.transmit_buffer(static_buf, max);
+                self.buffer.take().map(|buffer| {
+                    buffer[..max].copy_from_slice(&buf[..max]);
+                    cdc.set_transmit_client(self.client);
+                    let _ = cdc.transmit_buffer(buffer, max);
+                });
+
                 loop {
-                    if let Some(interrupt) = cortexm4::nvic::next_pending() {
+                    if let Some(interrupt) = unsafe { cortexm4::nvic::next_pending() } {
                         if interrupt == 39 {
                             usb.handle_interrupt();
                         }
-                        let n = cortexm4::nvic::Nvic::new(interrupt);
+                        let n = unsafe { cortexm4::nvic::Nvic::new(interrupt) };
                         n.clear_pending();
                         n.enable();
                     }
-                    if (*addr_of!(DUMMY)).fired.get() {
+                    if self.client.fired() {
                         // buffer finished transmitting, return so we can output additional
                         // messages when requested by the panic handler.
                         break;
                     }
                 }
-                (*addr_of!(DUMMY)).fired.set(false);
+                self.client.clear();
             });
-        }
+
         buf.len()
     }
 }
 
+/// Default panic handler for the Adafruit CLUE nRF52480 Express Board.
+///
 /// We just use the standard default provided by the debug module in the kernel.
 #[cfg(not(test))]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P1_10);
     let led = &mut led::LedLow::new(led_kernel_pin);
-    let writer = &mut *addr_of_mut!(WRITER);
-    debug::panic(
+    let static_buf = static_init!([u8; BUF_LEN], [0; BUF_LEN]);
+    let dummy_usb_client = static_init!(DummyUsbClient, DummyUsbClient::new());
+    let mut writer = Writer::new(dummy_usb_client, static_buf);
+    debug::panic_new(
         &mut [led],
-        writer,
+        &mut writer,
         pi,
         &cortexm4::support::nop,
-        PROCESSES.unwrap().as_slice(),
-        &*addr_of!(CHIP),
-        &*addr_of!(PROCESS_PRINTER),
+        crate::PANIC_RESOURCES.get(),
     )
 }

--- a/boards/makepython-nrf52840/src/main.rs
+++ b/boards/makepython-nrf52840/src/main.rs
@@ -14,12 +14,14 @@ use core::ptr::addr_of;
 
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::debug::PanicResources;
 use kernel::hil::led::LedLow;
 use kernel::hil::time::Counter;
 use kernel::hil::usb::Client;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::process::ProcessArray;
 use kernel::scheduler::round_robin::RoundRobinSched;
+use kernel::utilities::cells::MapCell;
+use kernel::utilities::single_thread_value::SingleThreadValue;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
 
@@ -71,20 +73,20 @@ const FAULT_RESPONSE: capsules_system::process_policies::StopWithDebugFaultPolic
 const NUM_PROCS: usize = 8;
 
 type ChipHw = nrf52840::chip::NRF52<'static, Nrf52840DefaultPeripherals<'static>>;
+type ProcessPrinter = capsules_system::process_printer::ProcessPrinterText;
+type CdcAcm = capsules_extra::usb::cdc::CdcAcm<
+    'static,
+    nrf52::usbd::Usbd<'static>,
+    capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, nrf52::rtc::Rtc<'static>>,
+>;
 
-/// Static variables used by io.rs.
-static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
-static mut CHIP: Option<&'static ChipHw> = None;
-static mut PROCESS_PRINTER: Option<&'static capsules_system::process_printer::ProcessPrinterText> =
-    None;
-static mut CDC_REF_FOR_PANIC: Option<
-    &'static capsules_extra::usb::cdc::CdcAcm<
-        'static,
-        nrf52::usbd::Usbd,
-        capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, nrf52::rtc::Rtc>,
-    >,
-> = None;
-static mut NRF52_POWER: Option<&'static nrf52840::power::Power> = None;
+/// Resources for when a board panics used by io.rs.
+static PANIC_RESOURCES: SingleThreadValue<PanicResources<Chip, ProcessPrinter>> =
+    SingleThreadValue::new(PanicResources::new());
+static CDC_REF_FOR_PANIC: SingleThreadValue<MapCell<&'static CdcAcm>> =
+    SingleThreadValue::new(MapCell::empty());
+static NRF52_POWER: SingleThreadValue<MapCell<&'static nrf52840::power::Power>> =
+    SingleThreadValue::new(MapCell::empty());
 
 kernel::stack_size! {0x1000}
 
@@ -92,7 +94,11 @@ kernel::stack_size! {0x1000}
 fn baud_rate_reset_bootloader_enter() {
     unsafe {
         // 0x90 is the magic value the bootloader expects
-        NRF52_POWER.unwrap().set_gpregret(0x90);
+        NRF52_POWER.get().map(|power_cell| {
+            power_cell.map(|power| {
+                power.set_gpregret(0x90);
+            });
+        });
         cortexm4::scb::reset();
     }
 }
@@ -226,6 +232,11 @@ pub unsafe fn start() -> (
 ) {
     nrf52840::init();
 
+    // Bind global variables to this thread.
+    PANIC_RESOURCES.bind_to_thread::<<Chip as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    CDC_REF_FOR_PANIC.bind_to_thread::<<Chip as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    NRF52_POWER.bind_to_thread::<<Chip as kernel::platform::chip::Chip>::ThreadIdProvider>();
+
     let ieee802154_ack_buf = static_init!(
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
@@ -243,12 +254,16 @@ pub unsafe fn start() -> (
 
     // Save a reference to the power module for resetting the board into the
     // bootloader.
-    NRF52_POWER = Some(&base_peripherals.pwr_clk);
+    NRF52_POWER.get().map(|power_cell| {
+        power_cell.put(&base_peripherals.pwr_clk);
+    });
 
     // Create an array to hold process references.
     let processes = components::process_array::ProcessArrayComponent::new()
         .finalize(components::process_array_component_static!(NUM_PROCS));
-    PROCESSES = Some(processes);
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.processes.put(processes.as_slice());
+    });
 
     // Setup space to store the core kernel data structure.
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
@@ -267,7 +282,9 @@ pub unsafe fn start() -> (
         nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
         nrf52840::chip::NRF52::new(nrf52840_peripherals)
     );
-    CHIP = Some(chip);
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.chip.put(chip);
+    });
 
     //--------------------------------------------------------------------------
     // CAPABILITIES
@@ -382,12 +399,16 @@ pub unsafe fn start() -> (
         nrf52::usbd::Usbd,
         nrf52::rtc::Rtc
     ));
-    CDC_REF_FOR_PANIC = Some(cdc); //for use by panic handler
+    CDC_REF_FOR_PANIC.get().map(|cdc_cell| {
+        cdc_cell.put(cdc);
+    });
 
     // Process Printer for displaying process information.
     let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
         .finalize(components::process_printer_text_component_static!());
-    PROCESS_PRINTER = Some(process_printer);
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.printer.put(process_printer);
+    });
 
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = components::console::UartMuxComponent::new(cdc, 115200)

--- a/boards/nano33ble/src/io.rs
+++ b/boards/nano33ble/src/io.rs
@@ -4,48 +4,67 @@
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::ptr::{addr_of, addr_of_mut};
+use kernel::ErrorCode;
 
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;
+use kernel::hil::uart::Transmit;
 use kernel::hil::uart::{self};
-use kernel::ErrorCode;
+use kernel::static_init;
+use kernel::utilities::cells::MapCell;
+use kernel::utilities::cells::TakeCell;
+use kernel::utilities::cells::VolatileCell;
 use nrf52840::gpio::Pin;
 
-use crate::CHIP;
-use crate::PROCESSES;
-use crate::PROCESS_PRINTER;
-use kernel::hil::uart::Transmit;
-use kernel::utilities::cells::VolatileCell;
-
-struct Writer {
-    initialized: bool,
-}
-
-static mut WRITER: Writer = Writer { initialized: false };
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
 const BUF_LEN: usize = 512;
-static mut STATIC_PANIC_BUF: [u8; BUF_LEN] = [0; BUF_LEN];
-
-static mut DUMMY: DummyUsbClient = DummyUsbClient {
-    fired: VolatileCell::new(false),
-};
 
 struct DummyUsbClient {
     fired: VolatileCell<bool>,
 }
 
+impl DummyUsbClient {
+    fn new() -> Self {
+        Self {
+            fired: VolatileCell::new(false),
+        }
+    }
+
+    fn fired(&self) -> bool {
+        self.fired.get()
+    }
+
+    fn clear(&self) {
+        self.fired.set(false)
+    }
+}
+
 impl uart::TransmitClient for DummyUsbClient {
     fn transmitted_buffer(&self, _: &'static mut [u8], _: usize, _: Result<(), ErrorCode>) {
         self.fired.set(true);
+    }
+}
+
+struct Writer {
+    initialized: bool,
+    buffer: TakeCell<'static, [u8]>,
+    client: &'static DummyUsbClient,
+}
+
+impl Writer {
+    fn new(client: &'static DummyUsbClient, buffer: &'static mut [u8]) -> Self {
+        Self {
+            initialized: false,
+            buffer: TakeCell::new(buffer),
+            client,
+        }
+    }
+}
+
+impl Write for Writer {
+    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
     }
 }
 
@@ -80,44 +99,38 @@ impl IoWrite for Writer {
             max = buf.len();
         }
 
-        unsafe {
-            // If CDC_REF_FOR_PANIC is not yet set we panicked very early,
-            // and not much we can do. Don't want to double fault,
-            // so just return.
-            super::CDC_REF_FOR_PANIC.map(|cdc| {
-                // Lots of unsafe dereferencing of global static mut objects here.
-                // However, this should be okay, because it all happens within
-                // a single thread, and:
-                // - This is the only place the global CDC_REF_FOR_PANIC is used, the logic is the same
-                //   as applies for the global CHIP variable used in the panic handler.
-                // - We do create multiple mutable references to the STATIC_PANIC_BUF, but we never
-                //   access the STATIC_PANIC_BUF after a slice of it is passed to transmit_buffer
-                //   until the slice has been returned in the uart callback.
-                // - Similarly, only this function uses the global DUMMY variable, and we do not
-                //   mutate it.
+        // If CDC_REF_FOR_PANIC is not yet set we panicked very early,
+        // and not much we can do. Don't want to double fault,
+        // so just return.
+        super::CDC_REF_FOR_PANIC
+            .get()
+            .and_then(MapCell::get)
+            .map(|cdc| {
                 let usb = &mut cdc.controller();
-                STATIC_PANIC_BUF[..max].copy_from_slice(&buf[..max]);
-                let static_buf = &mut *addr_of_mut!(STATIC_PANIC_BUF);
-                cdc.set_transmit_client(&*addr_of!(DUMMY));
-                let _ = cdc.transmit_buffer(static_buf, max);
+                self.buffer.take().map(|buffer| {
+                    buffer[..max].copy_from_slice(&buf[..max]);
+                    cdc.set_transmit_client(self.client);
+                    let _ = cdc.transmit_buffer(buffer, max);
+                });
+
                 loop {
-                    if let Some(interrupt) = cortexm4::nvic::next_pending() {
+                    if let Some(interrupt) = unsafe { cortexm4::nvic::next_pending() } {
                         if interrupt == 39 {
                             usb.handle_interrupt();
                         }
-                        let n = cortexm4::nvic::Nvic::new(interrupt);
+                        let n = unsafe { cortexm4::nvic::Nvic::new(interrupt) };
                         n.clear_pending();
                         n.enable();
                     }
-                    if (*addr_of!(DUMMY)).fired.get() {
+                    if self.client.fired() {
                         // buffer finished transmitting, return so we can output additional
                         // messages when requested by the panic handler.
                         break;
                     }
                 }
-                (*addr_of!(DUMMY)).fired.set(false);
+                self.client.clear();
             });
-        }
+
         buf.len()
     }
 }
@@ -129,15 +142,15 @@ impl IoWrite for Writer {
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
-    let led = &mut led::LedLow::new(led_kernel_pin);
-    let writer = &mut *addr_of_mut!(WRITER);
-    debug::panic(
+    let led = &mut led::LedHigh::new(led_kernel_pin);
+    let static_buf = static_init!([u8; BUF_LEN], [0; BUF_LEN]);
+    let dummy_usb_client = static_init!(DummyUsbClient, DummyUsbClient::new());
+    let mut writer = Writer::new(dummy_usb_client, static_buf);
+    debug::panic_new(
         &mut [led],
-        writer,
+        &mut writer,
         pi,
         &cortexm4::support::nop,
-        PROCESSES.unwrap().as_slice(),
-        &*addr_of!(CHIP),
-        &*addr_of!(PROCESS_PRINTER),
+        crate::PANIC_RESOURCES.get(),
     )
 }

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -14,15 +14,16 @@ use core::ptr::addr_of;
 
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::debug::PanicResources;
 use kernel::hil::gpio::Configure;
 use kernel::hil::gpio::Output;
 use kernel::hil::led::LedLow;
 use kernel::hil::time::Counter;
 use kernel::hil::usb::Client;
-use kernel::platform::chip::Chip;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::process::ProcessArray;
 use kernel::scheduler::round_robin::RoundRobinSched;
+use kernel::utilities::cells::MapCell;
+use kernel::utilities::single_thread_value::SingleThreadValue;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
 
@@ -87,28 +88,33 @@ const FAULT_RESPONSE: capsules_system::process_policies::StopWithDebugFaultPolic
 const NUM_PROCS: usize = 8;
 
 type ChipHw = nrf52840::chip::NRF52<'static, Nrf52840DefaultPeripherals<'static>>;
+type ProcessPrinter = capsules_system::process_printer::ProcessPrinterText;
+type CdcAcm = capsules_extra::usb::cdc::CdcAcm<
+    'static,
+    nrf52::usbd::Usbd<'static>,
+    capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, nrf52::rtc::Rtc<'static>>,
+>;
 
 /// Static variables used by io.rs.
-static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
-static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;
-static mut PROCESS_PRINTER: Option<&'static capsules_system::process_printer::ProcessPrinterText> =
-    None;
-static mut CDC_REF_FOR_PANIC: Option<
-    &'static capsules_extra::usb::cdc::CdcAcm<
-        'static,
-        nrf52::usbd::Usbd,
-        capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, nrf52::rtc::Rtc>,
-    >,
-> = None;
-static mut NRF52_POWER: Option<&'static nrf52840::power::Power> = None;
+/// Resources for when a board panics used by io.rs.
+static PANIC_RESOURCES: SingleThreadValue<PanicResources<Chip, ProcessPrinter>> =
+    SingleThreadValue::new(PanicResources::new());
+static CDC_REF_FOR_PANIC: SingleThreadValue<MapCell<&'static CdcAcm>> =
+    SingleThreadValue::new(MapCell::empty());
+static NRF52_POWER: SingleThreadValue<MapCell<&'static nrf52840::power::Power>> =
+    SingleThreadValue::new(MapCell::empty());
 
 kernel::stack_size! {0x1000}
 
 // Function for the CDC/USB stack to use to enter the bootloader.
 fn baud_rate_reset_bootloader_enter() {
+    // 0x90 is the magic value the bootloader expects
+    NRF52_POWER.get().map(|power_cell| {
+        power_cell.map(|power| {
+            power.set_gpregret(0x90);
+        });
+    });
     unsafe {
-        // 0x90 is the magic value the bootloader expects
-        NRF52_POWER.unwrap().set_gpregret(0x90);
         cortexm4::scb::reset();
     }
 }
@@ -242,6 +248,9 @@ pub unsafe fn start() -> (
 ) {
     nrf52840::init();
 
+    // Bind global variables to this thread.
+    PANIC_RESOURCES.bind_to_thread::<<Chip as kernel::platform::chip::Chip>::ThreadIdProvider>();
+
     let ieee802154_ack_buf = static_init!(
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
@@ -259,12 +268,16 @@ pub unsafe fn start() -> (
 
     // Save a reference to the power module for resetting the board into the
     // bootloader.
-    NRF52_POWER = Some(&base_peripherals.pwr_clk);
+    NRF52_POWER.get().map(|power_cell| {
+        power_cell.put(&base_peripherals.pwr_clk);
+    });
 
     // Create an array to hold process references.
     let processes = components::process_array::ProcessArrayComponent::new()
         .finalize(components::process_array_component_static!(NUM_PROCS));
-    PROCESSES = Some(processes);
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.processes.put(processes.as_slice());
+    });
 
     // Setup space to store the core kernel data structure.
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
@@ -375,12 +388,16 @@ pub unsafe fn start() -> (
         nrf52::usbd::Usbd,
         nrf52::rtc::Rtc
     ));
-    CDC_REF_FOR_PANIC = Some(cdc); //for use by panic handler
+    CDC_REF_FOR_PANIC.get().map(|cdc_cell| {
+        cdc_cell.put(cdc);
+    });
 
     // Process Printer for displaying process information.
     let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
         .finalize(components::process_printer_text_component_static!());
-    PROCESS_PRINTER = Some(process_printer);
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.printer.put(process_printer);
+    });
 
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = components::console::UartMuxComponent::new(cdc, 115200)
@@ -646,10 +663,15 @@ pub unsafe fn start() -> (
         nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
         nrf52840::chip::NRF52::new(nrf52840_peripherals)
     );
-    CHIP = Some(chip);
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.chip.put(chip);
+    });
 
     // Need to disable the MPU because the bootloader seems to set it up.
-    chip.mpu().clear_mpu();
+    {
+        use kernel::platform::chip::Chip;
+        chip.mpu().clear_mpu();
+    }
 
     // Configure the USB stack to enable a serial port over CDC-ACM.
     cdc.enable();

--- a/boards/nano33ble_rev2/src/io.rs
+++ b/boards/nano33ble_rev2/src/io.rs
@@ -1,52 +1,70 @@
 // Licensed under the Apache License, Version 2.0 or the MIT License.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2023.
+// Copyright Tock Contributors 2022.
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::ptr::{addr_of, addr_of_mut};
+use kernel::ErrorCode;
 
-use cortexm4;
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;
+use kernel::hil::uart::Transmit;
 use kernel::hil::uart::{self};
-use kernel::ErrorCode;
+use kernel::static_init;
+use kernel::utilities::cells::MapCell;
+use kernel::utilities::cells::TakeCell;
+use kernel::utilities::cells::VolatileCell;
 use nrf52840::gpio::Pin;
 
-use crate::CHIP;
-use crate::PROCESSES;
-use crate::PROCESS_PRINTER;
-use kernel::hil::uart::Transmit;
-use kernel::utilities::cells::VolatileCell;
-
-struct Writer {
-    initialized: bool,
-}
-
-static mut WRITER: Writer = Writer { initialized: false };
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
 const BUF_LEN: usize = 512;
-static mut STATIC_PANIC_BUF: [u8; BUF_LEN] = [0; BUF_LEN];
-
-static mut DUMMY: DummyUsbClient = DummyUsbClient {
-    fired: VolatileCell::new(false),
-};
 
 struct DummyUsbClient {
     fired: VolatileCell<bool>,
 }
 
+impl DummyUsbClient {
+    fn new() -> Self {
+        Self {
+            fired: VolatileCell::new(false),
+        }
+    }
+
+    fn fired(&self) -> bool {
+        self.fired.get()
+    }
+
+    fn clear(&self) {
+        self.fired.set(false)
+    }
+}
+
 impl uart::TransmitClient for DummyUsbClient {
     fn transmitted_buffer(&self, _: &'static mut [u8], _: usize, _: Result<(), ErrorCode>) {
         self.fired.set(true);
+    }
+}
+
+struct Writer {
+    initialized: bool,
+    buffer: TakeCell<'static, [u8]>,
+    client: &'static DummyUsbClient,
+}
+
+impl Writer {
+    fn new(client: &'static DummyUsbClient, buffer: &'static mut [u8]) -> Self {
+        Self {
+            initialized: false,
+            buffer: TakeCell::new(buffer),
+            client,
+        }
+    }
+}
+
+impl Write for Writer {
+    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
     }
 }
 
@@ -81,44 +99,38 @@ impl IoWrite for Writer {
             max = buf.len();
         }
 
-        unsafe {
-            // If CDC_REF_FOR_PANIC is not yet set we panicked very early,
-            // and not much we can do. Don't want to double fault,
-            // so just return.
-            super::CDC_REF_FOR_PANIC.map(|cdc| {
-                // Lots of unsafe dereferencing of global static mut objects here.
-                // However, this should be okay, because it all happens within
-                // a single thread, and:
-                // - This is the only place the global CDC_REF_FOR_PANIC is used, the logic is the same
-                //   as applies for the global CHIP variable used in the panic handler.
-                // - We do create multiple mutable references to the STATIC_PANIC_BUF, but we never
-                //   access the STATIC_PANIC_BUF after a slice of it is passed to transmit_buffer
-                //   until the slice has been returned in the uart callback.
-                // - Similarly, only this function uses the global DUMMY variable, and we do not
-                //   mutate it.
+        // If CDC_REF_FOR_PANIC is not yet set we panicked very early,
+        // and not much we can do. Don't want to double fault,
+        // so just return.
+        super::CDC_REF_FOR_PANIC
+            .get()
+            .and_then(MapCell::get)
+            .map(|cdc| {
                 let usb = &mut cdc.controller();
-                STATIC_PANIC_BUF[..max].copy_from_slice(&buf[..max]);
-                let static_buf = &mut *addr_of_mut!(STATIC_PANIC_BUF);
-                cdc.set_transmit_client(&*addr_of!(DUMMY));
-                let _ = cdc.transmit_buffer(static_buf, max);
+                self.buffer.take().map(|buffer| {
+                    buffer[..max].copy_from_slice(&buf[..max]);
+                    cdc.set_transmit_client(self.client);
+                    let _ = cdc.transmit_buffer(buffer, max);
+                });
+
                 loop {
-                    if let Some(interrupt) = cortexm4::nvic::next_pending() {
+                    if let Some(interrupt) = unsafe { cortexm4::nvic::next_pending() } {
                         if interrupt == 39 {
                             usb.handle_interrupt();
                         }
-                        let n = cortexm4::nvic::Nvic::new(interrupt);
+                        let n = unsafe { cortexm4::nvic::Nvic::new(interrupt) };
                         n.clear_pending();
                         n.enable();
                     }
-                    if (*addr_of!(DUMMY)).fired.get() {
+                    if self.client.fired() {
                         // buffer finished transmitting, return so we can output additional
                         // messages when requested by the panic handler.
                         break;
                     }
                 }
-                (*addr_of!(DUMMY)).fired.set(false);
+                self.client.clear();
             });
-        }
+
         buf.len()
     }
 }
@@ -130,15 +142,15 @@ impl IoWrite for Writer {
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
-    let led = &mut led::LedLow::new(led_kernel_pin);
-    let writer = &mut *addr_of_mut!(WRITER);
-    debug::panic(
+    let led = &mut led::LedHigh::new(led_kernel_pin);
+    let static_buf = static_init!([u8; BUF_LEN], [0; BUF_LEN]);
+    let dummy_usb_client = static_init!(DummyUsbClient, DummyUsbClient::new());
+    let mut writer = Writer::new(dummy_usb_client, static_buf);
+    debug::panic_new(
         &mut [led],
-        writer,
+        &mut writer,
         pi,
         &cortexm4::support::nop,
-        PROCESSES.unwrap().as_slice(),
-        &*addr_of!(CHIP),
-        &*addr_of!(PROCESS_PRINTER),
+        crate::PANIC_RESOURCES.get(),
     )
 }

--- a/boards/nano33ble_rev2/src/main.rs
+++ b/boards/nano33ble_rev2/src/main.rs
@@ -14,15 +14,16 @@ use core::ptr::addr_of;
 
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::debug::PanicResources;
 use kernel::hil::gpio::Configure;
 use kernel::hil::gpio::Output;
 use kernel::hil::led::LedLow;
 use kernel::hil::time::Counter;
 use kernel::hil::usb::Client;
-use kernel::platform::chip::Chip;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::process::ProcessArray;
 use kernel::scheduler::round_robin::RoundRobinSched;
+use kernel::utilities::cells::MapCell;
+use kernel::utilities::single_thread_value::SingleThreadValue;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
 
@@ -84,28 +85,34 @@ const FAULT_RESPONSE: capsules_system::process_policies::StopWithDebugFaultPolic
 const NUM_PROCS: usize = 8;
 
 type ChipHw = nrf52840::chip::NRF52<'static, Nrf52840DefaultPeripherals<'static>>;
+type ProcessPrinter = capsules_system::process_printer::ProcessPrinterText;
+type CdcAcm = capsules_extra::usb::cdc::CdcAcm<
+    'static,
+    nrf52::usbd::Usbd<'static>,
+    capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, nrf52::rtc::Rtc<'static>>,
+>;
 
 /// Static variables used by io.rs.
-static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
-static mut CHIP: Option<&'static ChipHw> = None;
-static mut PROCESS_PRINTER: Option<&'static capsules_system::process_printer::ProcessPrinterText> =
-    None;
-static mut CDC_REF_FOR_PANIC: Option<
-    &'static capsules_extra::usb::cdc::CdcAcm<
-        'static,
-        nrf52::usbd::Usbd,
-        capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, nrf52::rtc::Rtc>,
-    >,
-> = None;
-static mut NRF52_POWER: Option<&'static nrf52840::power::Power> = None;
+/// Resources for when a board panics used by io.rs.
+static PANIC_RESOURCES: SingleThreadValue<PanicResources<Chip, ProcessPrinter>> =
+    SingleThreadValue::new(PanicResources::new());
+static CDC_REF_FOR_PANIC: SingleThreadValue<MapCell<&'static CdcAcm>> =
+    SingleThreadValue::new(MapCell::empty());
+static NRF52_POWER: SingleThreadValue<MapCell<&'static nrf52840::power::Power>> =
+    SingleThreadValue::new(MapCell::empty());
 
 kernel::stack_size! {0x1000}
 
 // Function for the CDC/USB stack to use to enter the bootloader.
 fn baud_rate_reset_bootloader_enter() {
+    // 0x90 is the magic value the bootloader expects
+    NRF52_POWER.get().map(|power_cell| {
+        power_cell.map(|power| {
+            power.set_gpregret(0x90);
+        });
+    });
+
     unsafe {
-        // 0x90 is the magic value the bootloader expects
-        NRF52_POWER.unwrap().set_gpregret(0x90);
         cortexm4::scb::reset();
     }
 }
@@ -267,12 +274,16 @@ pub unsafe fn start() -> (
 
     // Save a reference to the power module for resetting the board into the
     // bootloader.
-    NRF52_POWER = Some(&base_peripherals.pwr_clk);
+    NRF52_POWER.get().map(|power_cell| {
+        power_cell.put(&base_peripherals.pwr_clk);
+    });
 
     // Create an array to hold process references.
     let processes = components::process_array::ProcessArrayComponent::new()
         .finalize(components::process_array_component_static!(NUM_PROCS));
-    PROCESSES = Some(processes);
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.processes.put(processes.as_slice());
+    });
 
     // Setup space to store the core kernel data structure.
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
@@ -383,12 +394,16 @@ pub unsafe fn start() -> (
         nrf52::usbd::Usbd,
         nrf52::rtc::Rtc
     ));
-    CDC_REF_FOR_PANIC = Some(cdc); //for use by panic handler
+    CDC_REF_FOR_PANIC.get().map(|cdc_cell| {
+        cdc_cell.put(cdc);
+    });
 
     // Process Printer for displaying process information.
     let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
         .finalize(components::process_printer_text_component_static!());
-    PROCESS_PRINTER = Some(process_printer);
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.printer.put(process_printer);
+    });
 
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = components::console::UartMuxComponent::new(cdc, 115200)
@@ -669,10 +684,15 @@ pub unsafe fn start() -> (
         nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
         nrf52840::chip::NRF52::new(nrf52840_peripherals)
     );
-    CHIP = Some(chip);
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.chip.put(chip);
+    });
 
     // Need to disable the MPU because the bootloader seems to set it up.
-    chip.mpu().clear_mpu();
+    {
+        use kernel::platform::chip::Chip;
+        chip.mpu().clear_mpu();
+    }
 
     // Configure the USB stack to enable a serial port over CDC-ACM.
     cdc.enable();

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -70,7 +70,7 @@ pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {
             |buffer| static_init!(Writer, Writer::WriterRtt(buffer)),
          );
 
-    debug::panic(
+    debug::panic_new(
         &mut [led],
         writer,
         pi,

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -6,19 +6,13 @@ use core::fmt::Write;
 use kernel::debug::IoWrite;
 use kernel::hil::uart;
 use kernel::hil::uart::Configure;
+use kernel::static_init;
 
 use nrf52840::uart::{Uarte, UARTE0_BASE};
 
 enum Writer {
     WriterUart(/* initialized */ bool),
     WriterRtt(&'static segger::rtt::SeggerRttMemory<'static>),
-}
-
-static mut WRITER: Writer = Writer::WriterUart(false);
-
-/// Set the RTT memory buffer used to output panic messages.
-pub unsafe fn set_rtt_memory(rtt_memory: &'static segger::rtt::SeggerRttMemory<'static>) {
-    WRITER = Writer::WriterRtt(rtt_memory);
 }
 
 impl Write for Writer {
@@ -61,26 +55,22 @@ impl IoWrite for Writer {
 #[panic_handler]
 /// Panic handler
 pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {
-    use core::ptr::{addr_of, addr_of_mut};
     use kernel::debug;
     use kernel::hil::led;
     use nrf52840::gpio::Pin;
 
-    use crate::CHIP;
-    use crate::PROCESSES;
-    use crate::PROCESS_PRINTER;
-
     // The nRF52840DK LEDs (see back of board)
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
     let led = &mut led::LedLow::new(led_kernel_pin);
-    let writer = &mut *addr_of_mut!(WRITER);
-    debug::panic(
-        &mut [led],
-        writer,
-        pi,
-        &cortexm4::support::nop,
-        PROCESSES.unwrap().as_slice(),
-        &*addr_of!(CHIP),
-        &*addr_of!(PROCESS_PRINTER),
-    )
+
+    crate::PANIC_RESOURCES.with(|resources| {
+        crate::RTT_BUFFER.with(|rtt_buffer| {
+            let writer = rtt_buffer.take().map_or_else(
+                || static_init!(Writer, Writer::WriterUart(false)),
+                |buffer| static_init!(Writer, Writer::WriterRtt(buffer)),
+            );
+
+            debug::panic(&mut [led], writer, pi, &cortexm4::support::nop, resources)
+        })
+    })
 }

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -64,11 +64,10 @@ pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
     let led = &mut led::LedLow::new(led_kernel_pin);
 
-    let writer = crate::RTT_BUFFER.get().and_then(MapCell::take)
-	.map_or_else(
-	    || static_init!(Writer, Writer::WriterUart(false)),
-            |buffer| static_init!(Writer, Writer::WriterRtt(buffer)),
-         );
+    let writer = crate::RTT_BUFFER.get().and_then(MapCell::take).map_or_else(
+        || static_init!(Writer, Writer::WriterUart(false)),
+        |buffer| static_init!(Writer, Writer::WriterRtt(buffer)),
+    );
 
     debug::panic_new(
         &mut [led],

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -448,7 +448,7 @@ pub unsafe fn start_no_pconsole() -> (
         // rtt_memory. This aliases reference is only used inside a panic
         // handler, which should be OK, but maybe we should use a const
         // reference to rtt_memory and leverage interior mutability instead.
-        RTT_BUFFER.with(|rtt_buffer_cell| {
+        RTT_BUFFER.get().map(|rtt_buffer_cell| {
             rtt_buffer_cell.replace(*core::ptr::addr_of!(rtt_memory_refs.rtt_memory))
         });
 
@@ -460,8 +460,8 @@ pub unsafe fn start_no_pconsole() -> (
     // Create an array to hold process references.
     let processes = components::process_array::ProcessArrayComponent::new()
         .finalize(components::process_array_component_static!(NUM_PROCS));
-    PANIC_RESOURCES.with(|resources| {
-        resources.set_processes(processes.as_slice());
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.processes.put(processes.as_slice());
     });
 
     // Setup space to store the core kernel data structure.
@@ -470,8 +470,8 @@ pub unsafe fn start_no_pconsole() -> (
     // Create (and save for panic debugging) a chip object to setup low-level
     // resources (e.g. MPU, systick).
     let chip = static_init!(ChipHw, nrf52840::chip::NRF52::new(nrf52840_peripherals));
-    PANIC_RESOURCES.with(|resources| {
-        resources.set_chip(chip);
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.chip.put(chip);
     });
 
     // Do nRF configuration and setup. This is shared code with other nRF-based
@@ -604,8 +604,8 @@ pub unsafe fn start_no_pconsole() -> (
     // Tool for displaying information about processes.
     let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
         .finalize(components::process_printer_text_component_static!());
-    PANIC_RESOURCES.with(|resources| {
-        resources.set_process_printer(process_printer);
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.printer.put(process_printer);
     });
 
     // Virtualize the UART channel for the console and for kernel debug.

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -412,6 +412,10 @@ pub unsafe fn start_no_pconsole() -> (
     // Apply errata fixes and enable interrupts.
     nrf52840::init();
 
+    // Bind global variables to this thread.
+    PANIC_RESOURCES.bind_to_thread::<<Chip as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    RTT_BUFFER.bind_to_thread::<<Chip as kernel::platform::chip::Chip>::ThreadIdProvider>();
+
     // Set up peripheral drivers. Called in separate function to reduce stack
     // usage.
     let ieee802154_ack_buf = static_init!(

--- a/boards/qemu_rv32_virt/src/io.rs
+++ b/boards/qemu_rv32_virt/src/io.rs
@@ -9,13 +9,7 @@ use core::str;
 use kernel::debug;
 use kernel::debug::IoWrite;
 
-use crate::CHIP;
-use crate::PROCESSES;
-use crate::PROCESS_PRINTER;
-
 struct Writer {}
-
-static mut WRITER: Writer = Writer {};
 
 impl Write for Writer {
     fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
@@ -36,17 +30,13 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    use core::ptr::{addr_of, addr_of_mut};
+    let mut writer = Writer {};
 
-    let writer = &mut *addr_of_mut!(WRITER);
-
-    debug::panic_print::<_, _, _>(
-        writer,
+    debug::panic_print_new::<_, _, _>(
+        &mut writer,
         pi,
         &rv32i::support::nop,
-        PROCESSES.unwrap().as_slice(),
-        &*addr_of!(CHIP),
-        &*addr_of!(PROCESS_PRINTER),
+        crate::PANIC_RESOURCES.get(),
     );
 
     // The system is no longer in a well-defined state. Use

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -145,6 +145,66 @@ pub trait IoWrite {
 ///////////////////////////////////////////////////////////////////
 // panic! support routines
 
+/// Resources needed by the main panic routines.
+pub struct PanicResources<C: Chip + 'static, PP: ProcessPrinter + 'static> {
+    /// The array of process slots.
+    pub processes: MapCell<&'static [ProcessSlot]>,
+    /// The board-specific chip object.
+    pub chip: MapCell<&'static C>,
+    /// The tool for printing process details.
+    pub printer: MapCell<&'static PP>,
+}
+
+impl<C: Chip, PP: ProcessPrinter> PanicResources<C, PP> {
+    /// Create a new [`BoardPanic`] with nothing stored.
+    pub const fn new() -> Self {
+        Self {
+            processes: MapCell::empty(),
+            chip: MapCell::empty(),
+            printer: MapCell::empty(),
+        }
+    }
+
+    /// Set the process slot array.
+    pub fn set_processes(&self, processes: &'static [ProcessSlot]) {
+        self.processes.put(processes);
+    }
+
+    /// Set the chip reference.
+    pub fn set_chip(&self, chip: &'static C) {
+        self.chip.put(chip);
+    }
+
+    /// Set the process printer reference.
+    pub fn set_process_printer(&self, printer: &'static PP) {
+        self.printer.put(printer);
+    }
+}
+
+/// Tock default panic routine.
+///
+/// **NOTE:** The supplied `writer` must be synchronous.
+///
+/// This will print a detailed debugging message and then loop forever while
+/// blinking an LED in a recognizable pattern.
+pub unsafe fn panic<L: hil::led::Led, W: Write + IoWrite, C: Chip, PP: ProcessPrinter>(
+    leds: &mut [&L],
+    writer: &mut W,
+    panic_info: &PanicInfo,
+    nop: &dyn Fn(),
+    panic_resources: &PanicResources<C, PP>,
+) -> ! {
+    // Call `panic_print` first which will print out the panic information and
+    // return
+    panic_print(writer, panic_info, nop, panic_resources);
+
+    // The system is no longer in a well-defined state, we cannot
+    // allow this function to return
+    //
+    // Forever blink LEDs in an infinite loop
+    panic_blink_forever(leds)
+}
+
 /// Tock panic routine, without the infinite LED-blinking loop.
 ///
 /// This is useful for boards which do not feature LEDs to blink or want to
@@ -160,9 +220,7 @@ pub unsafe fn panic_print<W: Write + IoWrite, C: Chip, PP: ProcessPrinter>(
     writer: &mut W,
     panic_info: &PanicInfo,
     nop: &dyn Fn(),
-    processes: &'static [ProcessSlot],
-    chip: &'static Option<&'static C>,
-    process_printer: &'static Option<&'static PP>,
+    panic_resources: &PanicResources<C, PP>,
 ) {
     panic_begin(nop);
     // Flush debug buffer if needed
@@ -170,41 +228,17 @@ pub unsafe fn panic_print<W: Write + IoWrite, C: Chip, PP: ProcessPrinter>(
     panic_banner(writer, panic_info);
     panic_cpu_state(chip, writer);
 
-    // Some systems may enforce memory protection regions for the kernel, making
-    // application memory inaccessible. However, printing process information
-    // will attempt to access memory. If we are provided a chip reference,
-    // attempt to disable userspace memory protection first:
-    chip.map(|c| {
+    panic_resources.chip.take().map(|c| {
+        // Some systems may enforce memory protection regions for the kernel,
+        // making application memory inaccessible. However, printing process
+        // information will attempt to access memory. If we are provided a chip
+        // reference, attempt to disable userspace memory protection first:
         use crate::platform::mpu::MPU;
         c.mpu().disable_app_mpu()
     });
-    panic_process_info(processes, process_printer, writer);
-}
-
-/// Tock default panic routine.
-///
-/// **NOTE:** The supplied `writer` must be synchronous.
-///
-/// This will print a detailed debugging message and then loop forever while
-/// blinking an LED in a recognizable pattern.
-pub unsafe fn panic<L: hil::led::Led, W: Write + IoWrite, C: Chip, PP: ProcessPrinter>(
-    leds: &mut [&L],
-    writer: &mut W,
-    panic_info: &PanicInfo,
-    nop: &dyn Fn(),
-    processes: &'static [ProcessSlot],
-    chip: &'static Option<&'static C>,
-    process_printer: &'static Option<&'static PP>,
-) -> ! {
-    // Call `panic_print` first which will print out the panic information and
-    // return
-    panic_print(writer, panic_info, nop, processes, chip, process_printer);
-
-    // The system is no longer in a well-defined state, we cannot
-    // allow this function to return
-    //
-    // Forever blink LEDs in an infinite loop
-    panic_blink_forever(leds)
+    panic_resources.processes.take().map(|p| {
+        panic_process_info(p, panic_resources.printer.take(), writer);
+    });
 }
 
 /// Generic panic entry.
@@ -259,7 +293,7 @@ pub unsafe fn panic_cpu_state<W: Write, C: Chip>(
 /// **NOTE:** The supplied `writer` must be synchronous.
 pub unsafe fn panic_process_info<PP: ProcessPrinter, W: Write>(
     processes: &'static [ProcessSlot],
-    process_printer: &'static Option<&'static PP>,
+    process_printer: Option<&'static PP>,
     writer: &mut W,
 ) {
     process_printer.map(|printer| {

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -164,21 +164,30 @@ impl<C: Chip, PP: ProcessPrinter> PanicResources<C, PP> {
             printer: MapCell::empty(),
         }
     }
+}
 
-    /// Set the process slot array.
-    pub fn set_processes(&self, processes: &'static [ProcessSlot]) {
-        self.processes.put(processes);
-    }
+/// Tock default panic routine.
+///
+/// **NOTE:** The supplied `writer` must be synchronous.
+///
+/// This will print a detailed debugging message and then loop forever while
+/// blinking an LED in a recognizable pattern.
+pub unsafe fn panic_new<L: hil::led::Led, W: Write + IoWrite, C: Chip, PP: ProcessPrinter>(
+    leds: &mut [&L],
+    writer: &mut W,
+    panic_info: &PanicInfo,
+    nop: &dyn Fn(),
+    panic_resources: Option<&PanicResources<C, PP>>,
+) -> ! {
+    // Call `panic_print` first which will print out the panic information and
+    // return
+    panic_print_new(writer, panic_info, nop, panic_resources);
 
-    /// Set the chip reference.
-    pub fn set_chip(&self, chip: &'static C) {
-        self.chip.put(chip);
-    }
-
-    /// Set the process printer reference.
-    pub fn set_process_printer(&self, printer: &'static PP) {
-        self.printer.put(printer);
-    }
+    // The system is no longer in a well-defined state, we cannot
+    // allow this function to return
+    //
+    // Forever blink LEDs in an infinite loop
+    panic_blink_forever(leds)
 }
 
 /// Tock default panic routine.
@@ -192,11 +201,13 @@ pub unsafe fn panic<L: hil::led::Led, W: Write + IoWrite, C: Chip, PP: ProcessPr
     writer: &mut W,
     panic_info: &PanicInfo,
     nop: &dyn Fn(),
-    panic_resources: &PanicResources<C, PP>,
+    processes: &'static [ProcessSlot],
+    chip: &'static Option<&'static C>,
+    process_printer: &'static Option<&'static PP>,
 ) -> ! {
     // Call `panic_print` first which will print out the panic information and
     // return
-    panic_print(writer, panic_info, nop, panic_resources);
+    panic_print(writer, panic_info, nop, processes, chip, process_printer);
 
     // The system is no longer in a well-defined state, we cannot
     // allow this function to return
@@ -216,11 +227,53 @@ pub unsafe fn panic<L: hil::led::Led, W: Write + IoWrite, C: Chip, PP: ProcessPr
 /// returns.
 ///
 /// **NOTE:** The supplied `writer` must be synchronous.
+pub unsafe fn panic_print_new<W: Write + IoWrite, C: Chip, PP: ProcessPrinter>(
+    writer: &mut W,
+    panic_info: &PanicInfo,
+    nop: &dyn Fn(),
+    panic_resources: Option<&PanicResources<C, PP>>,
+) {
+    panic_begin(nop);
+    // Flush debug buffer if needed
+    flush(writer);
+    panic_banner(writer, panic_info);
+
+    panic_resources.map(|pr| {
+        let chip = pr.chip.take();
+        panic_cpu_state(chip, writer);
+
+        chip.map(|c| {
+            // Some systems may enforce memory protection regions for the kernel,
+            // making application memory inaccessible. However, printing process
+            // information will attempt to access memory. If we are provided a chip
+            // reference, attempt to disable userspace memory protection first:
+            use crate::platform::mpu::MPU;
+            c.mpu().disable_app_mpu()
+        });
+        pr.processes.take().map(|p| {
+            panic_process_info(p, pr.printer.take(), writer);
+        });
+    });
+}
+
+/// Tock panic routine, without the infinite LED-blinking loop.
+///
+/// This is useful for boards which do not feature LEDs to blink or want to
+/// implement their own behavior. This method returns after performing the panic
+/// dump.
+///
+/// After this method returns, the system is no longer in a well-defined state.
+/// Care must be taken on how one interacts with the system once this function
+/// returns.
+///
+/// **NOTE:** The supplied `writer` must be synchronous.
 pub unsafe fn panic_print<W: Write + IoWrite, C: Chip, PP: ProcessPrinter>(
     writer: &mut W,
     panic_info: &PanicInfo,
     nop: &dyn Fn(),
-    panic_resources: &PanicResources<C, PP>,
+    processes: &'static [ProcessSlot],
+    chip: &'static Option<&'static C>,
+    process_printer: &'static Option<&'static PP>,
 ) {
     panic_begin(nop);
     // Flush debug buffer if needed
@@ -228,17 +281,15 @@ pub unsafe fn panic_print<W: Write + IoWrite, C: Chip, PP: ProcessPrinter>(
     panic_banner(writer, panic_info);
     panic_cpu_state(chip, writer);
 
-    panic_resources.chip.take().map(|c| {
-        // Some systems may enforce memory protection regions for the kernel,
-        // making application memory inaccessible. However, printing process
-        // information will attempt to access memory. If we are provided a chip
-        // reference, attempt to disable userspace memory protection first:
+    // Some systems may enforce memory protection regions for the kernel, making
+    // application memory inaccessible. However, printing process information
+    // will attempt to access memory. If we are provided a chip reference,
+    // attempt to disable userspace memory protection first:
+    chip.map(|c| {
         use crate::platform::mpu::MPU;
         c.mpu().disable_app_mpu()
     });
-    panic_resources.processes.take().map(|p| {
-        panic_process_info(p, panic_resources.printer.take(), writer);
-    });
+    panic_process_info(processes, *process_printer, writer);
 }
 
 /// Generic panic entry.
@@ -281,11 +332,20 @@ pub unsafe fn panic_banner<W: Write>(writer: &mut W, panic_info: &PanicInfo) {
 /// Print current machine (CPU) state.
 ///
 /// **NOTE:** The supplied `writer` must be synchronous.
+pub unsafe fn panic_cpu_state<W: Write, C: Chip>(chip: Option<&'static C>, writer: &mut W) {
+    C::print_state(chip, writer);
+}
+
+/// Print current machine (CPU) state.
+///
+/// **NOTE:** The supplied `writer` must be synchronous.
 pub unsafe fn panic_cpu_state<W: Write, C: Chip>(
     chip: &'static Option<&'static C>,
     writer: &mut W,
 ) {
-    C::print_state(*chip, writer);
+    chip.map(|c| {
+        c.print_state(writer);
+    });
 }
 
 /// More detailed prints about all processes.


### PR DESCRIPTION
### Pull Request Overview

This builds on #4517 and riffs on #3945.

This adds a `BoardPanic` struct that holds the resources commonly shared between main.rs and io.rs. The key change is here:

```diff
- static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
- static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;
- static mut PROCESS_PRINTER: Option<&'static capsules_system::process_printer::ProcessPrinterText> =
-     None;

+ /// Resources for when a board panics used by io.rs.
+ pub static PANIC_RESOURCES: SingleThreadValue<
+     BoardPanic<
+         nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
+         capsules_system::process_printer::ProcessPrinterText,
+     >,
+ > = unsafe { SingleThreadValue::new(BoardPanic::new()) };
```
and
```diff
-    CHIP = Some(chip);
+    PANIC_RESOURCES.with(|resources| {
+        resources.set_chip(chip);
+    });
```


### Testing Strategy

todo


### TODO or Help Wanted

This is a first pass attempt; I get the feeling there is a better abstraction than the current `BoardPanic` type. Specifically, it seems like it might be better to wrap `SingleThreadValue` in somehow to make it easier for board authors? Or maybe this is already closer to what we want so that it is more explicit how the sharing is done correctly.

#### Boards to Update

- [ ] apollo3/lora_things_plus
- [ ] apollo3/redboard_artemis_atp
- [ ] apollo3/redboard_artemis_nano
- [x] arty_e21
- [x] clue_nrf52840
- [ ] configurations/microbit_v2/microbit_v2-test-dynamic-app-load
- [x] configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256
- [x] configurations/nrf52840dk/nrf52840dk-test-appid-sha256
- [x] configurations/nrf52840dk/nrf52840dk-test-appid-tbf
- [x] configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load
- [x] configurations/nrf52840dk/nrf52840dk-test-invs
- [x] configurations/nrf52840dk/nrf52840dk-test-kernel
- [ ] cy8cproto_62_4343_w
- [ ] esp32-c3-devkitM-1
- [x] hail
- [ ] hifive1
- [ ] hifive_inventor
- [ ] imix
- [ ] imxrt1050-evkb
- [ ] litex/arty
- [ ] litex/sim
- [x] makepython-nrf52840
- [ ] microbit_v2
- [ ] msp_exp432p401r
- [x] nano33ble
- [x] nano33ble_rev2
- [ ] nano_rp2040_connect
- [ ] nordic/nrf52840_dongle
- [x] nordic/nrf52840dk
- [ ] nordic/nrf52_components
- [ ] nordic/nrf52dk
- [ ] nucleo_f429zi
- [ ] nucleo_f446re
- [ ] opentitan/earlgrey-cw310
- [ ] particle_boron
- [ ] pico_explorer_base
- [ ] qemu_i486_q35
- [x] qemu_rv32_virt
- [ ] raspberry_pi_pico
- [ ] raspberry_pi_pico_2
- [ ] redboard_redv
- [ ] sma_q3
- [ ] stm32f3discovery
- [ ] stm32f412gdiscovery
- [ ] stm32f429idiscovery
- [ ] teensy40
- [ ] tutorials/nrf52840dk-dynamic-apps-and-policies
- [ ] tutorials/nrf52840dk-hotp-tutorial
- [ ] tutorials/nrf52840dk-root-of-trust-tutorial
- [ ] tutorials/nrf52840dk-thread-tutorial
- [ ] tutorials/qemu_rv32_virt-tutorial
- [ ] veer_el2_sim
- [ ] weact_f401ccu6
- [x] wm1110dev




### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
