### PR TITLE
change app_loader capsule buffer size to 4096

### DIFF
--- a/capsules/extra/src/app_loader.rs
+++ b/capsules/extra/src/app_loader.rs
@@ -106,7 +106,7 @@ mod ro_allow {
     pub const COUNT: u8 = 1;
 }
 
-pub const BUF_LEN: usize = 512;
+pub const BUF_LEN: usize = 4096;
 
 #[derive(Default)]
 pub struct App {

--- a/capsules/extra/src/app_loader.rs
+++ b/capsules/extra/src/app_loader.rs
@@ -106,6 +106,8 @@ mod ro_allow {
     pub const COUNT: u8 = 1;
 }
 
+// Discussion regarding this buffer size value
+// can be found at: https://github.com/tock/tock/pull/4520
 pub const BUF_LEN: usize = 4096;
 
 #[derive(Default)]


### PR DESCRIPTION
### Pull Request Overview

This pull massively improves app write times (hopefully, with _some_ tradeoff. 
Essentially, I was benchmarking the Dynamic Process Loading capsules and found out the writes were taking too long. This boiled down to the NVMC driver erasing the page each time we perform a write. The `app_loader` capsule has a buffer of 512 bytes. On the nRF52840DK, the page size is 4K. So each page write essentially did 8 erases and then 8 writes.

The erase times on the nRD52840dk is ~85ms, whereas the write time itself for a page is ~45ms. With a buffer size of 512 bytes, the write time for each page was ~1.04 seconds. Which is not ideal. 


This code currently increases the buffer size for the capsule to 4096 bytes, so more data can be written at a less cost. This brings down the cost of writing to a page down to ~130ms, which is an ~8x improvement.

Of course, there is the trade off, systems with a smaller buffer size will have to perform more writes regardless, but this system does not punish systems with higher write capabilities. 

This change requires the userland app to also initialize a 4K buffer. I initialized it in the data section so it does not eat away at the stack. 

There is one more optimization to the nvmc driver I will push next that improves the write times further.

### Testing Strategy

This pull request was tested by running a userland app and verifying the times.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
