### PR TITLE
nrf52: nvmc: Erase page only if it is not empty

### DIFF
--- a/chips/nrf52/src/nvmc.rs
+++ b/chips/nrf52/src/nvmc.rs
@@ -270,6 +270,16 @@ impl Nvmc {
         }
     }
 
+    fn is_page_blank(&self, page_number: usize) -> bool {
+        let address = (page_number * PAGE_SIZE) as *const u32;
+        for i in 0..(PAGE_SIZE / 4) {
+            if unsafe { core::ptr::read(address.add(i)) } != 0xFFFFFFFF {
+                return false;
+            }
+        }
+        true
+    }
+
     fn erase_page_helper(&self, page_number: usize) {
         // Put the NVMC in erase mode.
         self.registers.config.write(Configuration::WEN::Een);
@@ -315,8 +325,11 @@ impl Nvmc {
         page_number: usize,
         data: &'static mut NrfPage,
     ) -> Result<(), (ErrorCode, &'static mut NrfPage)> {
-        // Need to erase the page first.
-        self.erase_page_helper(page_number);
+        // Need to erase the page if the page is not filled
+        // with 0xFF.
+        if !self.is_page_blank(page_number) {
+            self.erase_page_helper(page_number);
+        }
 
         // Put the NVMC in write mode.
         self.registers.config.write(Configuration::WEN::Wen);


### PR DESCRIPTION
### Pull Request Overview

This pull request improves the low level nvmc write by only performing an erase when the page is not empty. We define empty as 0xFF. This pr is in conjunction with #4520. 

Before #4520 and this pr, it took 2078.554ms, approximately 2.08 seconds to write the 7892 bytes that made up the `blink` binary. With the buffer size now increased to align with the page size of the nrf52840DK, and the fact that we only erase the flash when the page is not empty (has some data that is not 0xFF), we reduce the time to write the same `blink` app to ~176ms, a 11x improvement. 

Here's a comparison of write timings for two apps, `blink` and `temperature`. Their sizes are indicated in the table, and the time units are milliseconds.

| | Baseline |    PR 4520    |     This PR    |
|:-------------------------:|:--------:|:-------------:|:--------------:|
|     Blink (7892 Bytes)    | 2078.554 |  260.28 (~8x) | 176.347 (~12x) |
| Temperature (15484 Bytes) | 4027.221 | 520.530 (~8x) | 268.923 ~(15x) |

The gains scale with the size of the binary. This one check before erasing a page prior to writing to it yields a 2x improvement to write times for a ~16KiB app, and a 15x improvement over the current implementation upstream.

The flash driver needs to be optimized and I think this may be a good first step in that direction. I think the gains are worth the tradeoffs. 


### Testing Strategy

This pull request was tested by timing userspace app write times during dynamic process loading.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
