### PR TITLE
arch/cortex-m: Add functions to disable exceptions.

### DIFF
--- a/arch/cortex-m/src/scb.rs
+++ b/arch/cortex-m/src/scb.rs
@@ -340,3 +340,36 @@ pub unsafe fn disable_fpca() {
 
     unimplemented!()
 }
+
+/// Disable the MemFault exception.
+///
+/// # Notes
+///
+/// This escalates the exception to a HardFault instead of triggering a
+/// MemFault exception, so it does not _disable_ MemFault completely.
+pub unsafe fn disable_memfault() {
+    SCB.shcsr
+        .modify(SystemHandlerControlAndState::MEMFAULTENA::CLEAR);
+}
+
+/// Disable the UsageFault exception.
+///
+/// # Notes
+///
+/// This escalates the exception to a HardFault instead of triggering a
+/// UsageFault exception, so it does not _disable_ UsageFault completely.
+pub unsafe fn disable_usagefault() {
+    SCB.shcsr
+        .modify(SystemHandlerControlAndState::USGFAULTENA::CLEAR);
+}
+
+/// Disable the BusFault exception.
+///
+/// # Notes
+///
+/// This escalates the exception to a HardFault instead of triggering a
+/// BusFault exception, so it does not _disable_ BusFault completely.
+pub unsafe fn disable_busfault() {
+    SCB.shcsr
+        .modify(SystemHandlerControlAndState::BUSFAULTENA::CLEAR);
+}


### PR DESCRIPTION
### Pull Request Overview

This adds functions to disable the MemFault, UsageFault and BusFault exceptions, which if not disabled will cause the board to emit a "Unhandled Interrupt. ..." message as these exceptions will not be elevated to a HardFault.

### Testing Strategy

Tested on a custom board.

### Formatting

- [x] Ran `make prepush`.