### PR TITLE
boards: make: fix stack-analysis dependency

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -71,7 +71,7 @@ $(call check_defined, PLATFORM)
 $(call check_defined, TARGET)
 
 # Location of target-specific build.
-# Make sure we delete the ".json" extension if we are building a custon TARGET 
+# Make sure we delete the ".json" extension if we are building a custon TARGET
 # defined in a JSON file as cargo defines the target folder without ".json".
 TARGET_PATH := $(TARGET_DIRECTORY)$(subst .json,,$(TARGET))
 
@@ -293,7 +293,7 @@ show-target:
 	$(info $(TARGET))
 
 .PHONY: stack-analysis
-stack-analysis: $(TARGET_PATH)/release/$(PLATFORM)
+stack-analysis: $(TARGET_PATH)/release/$(PLATFORM).elf
 	@$ echo $(PLATFORM)
 	@$ echo ----------------------
 	$(Q)$(TOCK_ROOT_DIRECTORY)/tools/stack_analysis.sh $(TARGET_PATH)/release/$(PLATFORM).elf


### PR DESCRIPTION
### Pull Request Overview

The command uses the .elf file, make sure that is actually built.

Otherwise:
```
❯ make stack-analysis
   Compiling nucleo_f429zi v0.2.3-dev (/Users/bradjc/git/tock/boards/nucleo_f429zi)
   Compiling kernel v0.2.3-dev (/Users/bradjc/git/tock/kernel)
   Compiling cortexv7m v0.2.3-dev (/Users/bradjc/git/tock/arch/cortex-v7m)
   Compiling cortexm v0.2.3-dev (/Users/bradjc/git/tock/arch/cortex-m)
   Compiling capsules-core v0.2.3-dev (/Users/bradjc/git/tock/capsules/core)
   Compiling segger v0.2.3-dev (/Users/bradjc/git/tock/chips/segger)
   Compiling capsules-system v0.2.3-dev (/Users/bradjc/git/tock/capsules/system)
   Compiling cortexm4f v0.2.3-dev (/Users/bradjc/git/tock/arch/cortex-m4f)
   Compiling cortexm4 v0.2.3-dev (/Users/bradjc/git/tock/arch/cortex-m4)
   Compiling stm32f4xx v0.2.3-dev (/Users/bradjc/git/tock/chips/stm32f4xx)
   Compiling capsules-extra v0.2.3-dev (/Users/bradjc/git/tock/capsules/extra)
   Compiling stm32f429zi v0.2.3-dev (/Users/bradjc/git/tock/chips/stm32f429zi)
   Compiling components v0.2.3-dev (/Users/bradjc/git/tock/boards/components)
    Finished `release` profile [optimized + debuginfo] target(s) in 20.84s
   text	   data	    bss	    dec	    hex	filename
 100356	     32	  19636	 120024	  1d4d8	/Users/bradjc/git/tock/target/thumbv7em-none-eabi/release/nucleo_f429zi
nucleo_f429zi
----------------------
/Users/bradjc/.rustup/toolchains/nightly-2025-05-19-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/bin/llvm-readobj: error: '/Users/bradjc/git/tock/target/thumbv7em-none-eabi/release/nucleo_f429zi.elf': No such file or directory
   main stack frame:

   5 largest stack frames:
```




### Testing Strategy

Running `make stack-analysis` on a board I don't usually build.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
