### PR TITLE
app_loader: add uninstall functionailty

### DIFF
--- a/capsules/extra/src/app_loader.rs
+++ b/capsules/extra/src/app_loader.rs
@@ -538,7 +538,7 @@ impl<
             6 => {
                 // Request the kernel to uninstall an app/binary
                 // by specifying its ShortId.
-                let result = self.storage_driver.uninstall(arg1);
+                let result = self.storage_driver.uninstall(arg1, arg2);
                 match result {
                     Ok(()) => CommandReturn::success(),
                     Err(e) => {

--- a/kernel/src/dynamic_binary_storage.rs
+++ b/kernel/src/dynamic_binary_storage.rs
@@ -675,21 +675,16 @@ impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileSto
                     self.process_metadata.set(metadata);
                 }
 
-                match self.loader_driver.reclaim_memory(shortid) {
-                    Ok(()) => {
-                        if let Some(metadata) = self.process_metadata.get() {
-                            match self.write_padding_app(
-                                metadata.new_app_length,
-                                metadata.new_app_start_addr,
-                            ) {
-                                Ok(()) => Ok(()),
-                                Err(_) => Err(ErrorCode::BUSY),
-                            }
-                        } else {
-                            Err(ErrorCode::FAIL)
-                        }
+                self.loader_driver.reclaim_memory(shortid);
+                if let Some(metadata) = self.process_metadata.get() {
+                    match self
+                        .write_padding_app(metadata.new_app_length, metadata.new_app_start_addr)
+                    {
+                        Ok(()) => Ok(()),
+                        Err(_) => Err(ErrorCode::BUSY),
                     }
-                    Err(_) => Err(ErrorCode::FAIL),
+                } else {
+                    Err(ErrorCode::FAIL)
                 }
             }
             _ => {

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -314,6 +314,20 @@ impl Kernel {
         Err(())
     }
 
+    /// Terminate a process if it exists, and remove it from ProcessArray.
+    pub(crate) fn reclaim_memory_by_shortid(&self, shortid: process::ShortId) -> bool {
+        for slot in self.processes.iter() {
+            if let Some(process) = slot.get() {
+                if process.short_app_id() == shortid {
+                    process.terminate(None);
+                    slot.proc.set(None);
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
     /// Cause all apps to fault.
     ///
     /// This will call `set_fault_state()` on each app, causing the app to enter

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -315,17 +315,16 @@ impl Kernel {
     }
 
     /// Terminate a process if it exists, and remove it from ProcessArray.
-    pub(crate) fn reclaim_memory_by_shortid(&self, shortid: process::ShortId) -> bool {
+    pub(crate) fn reclaim_memory_by_shortid(&self, shortid: process::ShortId) {
         for slot in self.processes.iter() {
             if let Some(process) = slot.get() {
                 if process.short_app_id() == shortid {
                     process.terminate(None);
                     slot.proc.set(None);
-                    return true;
+                    break;
                 }
             }
         }
-        false
     }
 
     /// Cause all apps to fault.

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -315,7 +315,7 @@ impl Kernel {
     }
 
     /// Terminate a process if it exists, and remove it from ProcessArray.
-    pub(crate) fn reclaim_memory_by_shortid(&self, shortid: process::ShortId) {
+    pub(crate) fn reclaim_app_memory(&self, shortid: process::ShortId) {
         for slot in self.processes.iter() {
             if let Some(process) = slot.get() {
                 if process.short_app_id() == shortid {

--- a/kernel/src/process_loading.rs
+++ b/kernel/src/process_loading.rs
@@ -1229,6 +1229,20 @@ impl<'a, C: Chip, D: ProcessStandardDebug> SequentialProcessLoaderMachine<'a, C,
             )),
         }
     }
+
+    pub fn fetch_app_details(&self, shortid: ShortId) -> Result<(u32, u32), ProcessLoadError> {
+        for process in self.kernel.get_process_iter() {
+            if process.short_app_id() == shortid {
+                let app_address = process.flash_start();
+                let app_size = process.flash_size();
+                return Ok((app_address, app_size));
+            }
+        }
+
+        Err(ProcessLoadError::CheckError(
+            crate::process_checker::ProcessCheckError::InvalidCredential,
+        ))
+    }
 }
 
 impl<'a, C: Chip, D: ProcessStandardDebug> ProcessLoadingAsync<'a>


### PR DESCRIPTION
### Pull Request Overview

This pr introduces an `uninstall(ShortId, app_version)` function to the dynamic process loader.

The uninstall operation supports two cases:
1. The application is currently enabled (i.e., running as a process)
2. The application is installed but disabled (i.e., present in storage, but not loaded as a process)

The uninstall procedure involves three steps:
1. Locate the Binary
    - Scan the storage to find a binary that matches the ShortId and app_version values

2. Terminate if Running
If the binary corresponds to a currently running process:
    - Terminate the process
    - Remove it from the process array

If the binary is not enabled, this step does nothing.

3. Remove and Pad
    - Erase the binary from flash, and write a padding app in its place


### Testing Strategy

This pull request was tested by running a blink app on an nRF52840dk and then using a helper app to uninstall it.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
