### PR TITLE
Uninstall previous version when installing an app

### DIFF
--- a/capsules/extra/src/app_loader.rs
+++ b/capsules/extra/src/app_loader.rs
@@ -538,7 +538,7 @@ impl<
             6 => {
                 // Request the kernel to uninstall an app/binary
                 // by specifying its ShortId.
-                let result = self.storage_driver.uninstall(arg1);
+                let result = self.storage_driver.uninstall(arg1, arg2);
                 match result {
                     Ok(()) => CommandReturn::success(),
                     Err(e) => {

--- a/kernel/src/dynamic_binary_storage.rs
+++ b/kernel/src/dynamic_binary_storage.rs
@@ -675,21 +675,16 @@ impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileSto
                     self.process_metadata.set(metadata);
                 }
 
-                match self.loader_driver.reclaim_memory(shortid) {
-                    Ok(()) => {
-                        if let Some(metadata) = self.process_metadata.get() {
-                            match self.write_padding_app(
-                                metadata.new_app_length,
-                                metadata.new_app_start_addr,
-                            ) {
-                                Ok(()) => Ok(()),
-                                Err(_) => Err(ErrorCode::BUSY),
-                            }
-                        } else {
-                            Err(ErrorCode::FAIL)
-                        }
+                self.loader_driver.reclaim_memory(shortid);
+                if let Some(metadata) = self.process_metadata.get() {
+                    match self
+                        .write_padding_app(metadata.new_app_length, metadata.new_app_start_addr)
+                    {
+                        Ok(()) => Ok(()),
+                        Err(_) => Err(ErrorCode::BUSY),
                     }
-                    Err(_) => Err(ErrorCode::FAIL),
+                } else {
+                    Err(ErrorCode::FAIL)
                 }
             }
             _ => {

--- a/kernel/src/dynamic_binary_storage.rs
+++ b/kernel/src/dynamic_binary_storage.rs
@@ -89,7 +89,7 @@ pub trait DynamicBinaryStore {
     /// Call to abort the setup/writing process.
     fn abort(&self) -> Result<(), ErrorCode>;
 
-    /// Call to uninstall an app whose AppID is specified.
+    /// Call to uninstall an app with given ShortId and app version.
     fn uninstall(&self, short_id: usize, app_version: usize) -> Result<(), ErrorCode>;
 
     /// Sets a client for the SequentialDynamicBinaryStore Object

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -314,6 +314,20 @@ impl Kernel {
         Err(())
     }
 
+    /// Terminate a process if it exists, and remove it from ProcessArray.
+    pub(crate) fn reclaim_memory_by_shortid(&self, shortid: process::ShortId) -> bool {
+        for slot in self.processes.iter() {
+            if let Some(process) = slot.get() {
+                if process.short_app_id() == shortid {
+                    process.terminate(None);
+                    slot.proc.set(None);
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
     /// Cause all apps to fault.
     ///
     /// This will call `set_fault_state()` on each app, causing the app to enter

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -315,17 +315,16 @@ impl Kernel {
     }
 
     /// Terminate a process if it exists, and remove it from ProcessArray.
-    pub(crate) fn reclaim_memory_by_shortid(&self, shortid: process::ShortId) -> bool {
+    pub(crate) fn reclaim_memory_by_shortid(&self, shortid: process::ShortId) {
         for slot in self.processes.iter() {
             if let Some(process) = slot.get() {
                 if process.short_app_id() == shortid {
                     process.terminate(None);
                     slot.proc.set(None);
-                    return true;
+                    break;
                 }
             }
         }
-        false
     }
 
     /// Cause all apps to fault.

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -315,7 +315,7 @@ impl Kernel {
     }
 
     /// Terminate a process if it exists, and remove it from ProcessArray.
-    pub(crate) fn reclaim_memory_by_shortid(&self, shortid: process::ShortId) {
+    pub(crate) fn reclaim_app_memory(&self, shortid: process::ShortId) {
         for slot in self.processes.iter() {
             if let Some(process) = slot.get() {
                 if process.short_app_id() == shortid {

--- a/kernel/src/process_loading.rs
+++ b/kernel/src/process_loading.rs
@@ -1207,6 +1207,96 @@ impl<'a, C: Chip, D: ProcessStandardDebug> SequentialProcessLoaderMachine<'a, C,
         }
     }
 
+    pub fn finalize(
+        &self,
+        app_address: usize,
+        app_size: usize,
+    ) -> Result<Option<(u32, u32)>, ProcessLoadError> {
+        let flash = self.flash_bank.get();
+        let binary_address = app_address - flash.as_ptr() as usize;
+        let binary_flash = flash.get(binary_address..binary_address + app_size).ok_or(
+            ProcessLoadError::BinaryError(ProcessBinaryError::NotEnoughFlash),
+        )?;
+        let result = self.check_new_binary_validity(binary_address);
+        match result {
+            true => {
+                if let Ok((_remaining_flash, process_binary)) =
+                    discover_process_binary(binary_flash)
+                {
+                    let new_app_version = process_binary.header.get_binary_version();
+                    let app_short_id = self.policy.map_or(ShortId::LocallyUnique, |policy| {
+                        policy.to_short_id(&process_binary)
+                    });
+
+                    // Find the previous app binary with same ShortId and lower version
+                    let total_flash = self.flash_bank.get();
+                    const MAX_PROCS: usize = 10;
+                    let mut pb_start_address: [usize; MAX_PROCS] = [0; MAX_PROCS];
+                    let mut pb_end_address: [usize; MAX_PROCS] = [0; MAX_PROCS];
+
+                    self.scan_flash_for_process_binaries(
+                        total_flash,
+                        &mut pb_start_address,
+                        &mut pb_end_address,
+                    )
+                    .map_err(|()| ProcessLoadError::InternalError)?;
+
+                    let mut prev_version_addr: Option<u32> = None;
+                    let mut prev_version_size: Option<u32> = None;
+
+                    for i in 0..MAX_PROCS {
+                        if pb_start_address[i] == 0 || pb_end_address[i] == 0 {
+                            continue;
+                        }
+
+                        // Skip if same as new app
+                        if pb_start_address[i] == app_address {
+                            continue;
+                        }
+
+                        let start_offset = pb_start_address[i] - total_flash.as_ptr() as usize;
+                        let end_offset = pb_end_address[i] - total_flash.as_ptr() as usize;
+
+                        let binary_slice = total_flash.get(start_offset..end_offset).ok_or(
+                            ProcessLoadError::BinaryError(ProcessBinaryError::NotEnoughFlash),
+                        )?;
+
+                        if let Ok((_remaining_flash, other_binary)) =
+                            discover_process_binary(binary_slice)
+                        {
+                            let short_id = self.policy.map_or(ShortId::LocallyUnique, |policy| {
+                                policy.to_short_id(&other_binary)
+                            });
+                            let ver = other_binary.header.get_binary_version();
+
+                            if short_id == app_short_id && ver < new_app_version {
+                                prev_version_addr = Some(pb_start_address[i] as u32);
+                                prev_version_size =
+                                    Some((pb_end_address[i] - pb_start_address[i]) as u32);
+                            }
+                        }
+                    }
+
+                    // once we know the short_id of the new app, we can look for other versions of it on the device
+                    self.kernel.reclaim_app_memory(app_short_id);
+
+                    // return the address and size of the previous version binary
+                    match (prev_version_addr, prev_version_size) {
+                        (Some(addr), Some(size)) => Ok(Some((addr, size))),
+                        _ => Ok(None),
+                    }
+                } else {
+                    Err(ProcessLoadError::BinaryError(
+                        ProcessBinaryError::NotEnoughFlash,
+                    ))
+                }
+            }
+            false => Err(ProcessLoadError::BinaryError(
+                ProcessBinaryError::TbfHeaderNotFound,
+            )),
+        }
+    }
+
     /// Function to start loading the new application at address `app_address` with size
     /// `app_size`.
     pub fn load_new_process_binary(

--- a/kernel/src/process_loading.rs
+++ b/kernel/src/process_loading.rs
@@ -1244,6 +1244,7 @@ impl<'a, C: Chip, D: ProcessStandardDebug> SequentialProcessLoaderMachine<'a, C,
         }
     }
 
+    /// Function to check if the ShortId and version of the binary matches supplied values.
     fn app_match_check(
         &self,
         shortid: ShortId,
@@ -1257,6 +1258,8 @@ impl<'a, C: Chip, D: ProcessStandardDebug> SequentialProcessLoaderMachine<'a, C,
         false
     }
 
+    /// Function to return the address and size of the binary whose ShortId and version are passed
+    /// as input arguments.
     pub fn fetch_app_details(
         &self,
         shortid: ShortId,
@@ -1326,6 +1329,7 @@ impl<'a, C: Chip, D: ProcessStandardDebug> SequentialProcessLoaderMachine<'a, C,
         ))
     }
 
+    /// Function to terminate process and remove it from process array
     pub fn reclaim_memory(&self, shortid: ShortId) {
         self.kernel.reclaim_app_memory(shortid)
     }

--- a/kernel/src/process_loading.rs
+++ b/kernel/src/process_loading.rs
@@ -1229,6 +1229,20 @@ impl<'a, C: Chip, D: ProcessStandardDebug> SequentialProcessLoaderMachine<'a, C,
             )),
         }
     }
+
+    pub fn fetch_app_details(&self, shortid: ShortId) -> Result<(u32, u32), ProcessLoadError> {
+        for process in self.kernel.get_process_iter() {
+            if process.short_app_id() == shortid {
+                let app_address = process.flash_start();
+                let app_size = process.flash_size();
+                return Ok((app_address, app_size));
+            }
+        }
+
+        Err(ProcessLoadError::CheckError(
+            crate::process_checker::ProcessCheckError::InvalidCredential,
+        ))
+    }
 }
 
 impl<'a, C: Chip, D: ProcessStandardDebug> ProcessLoadingAsync<'a>


### PR DESCRIPTION
### Pull Request Overview

The reason I built this PR is because we deal with limited resources. At any point, one app only needs one binary and one process. We already have the memory taken care of via `check_if_blocked_by()`. However, we cannot simply deny apps to write new versions of themselves. On the other hand, I think it is also bad for apps to have binaries with various versions and deny storage to other apps. 

So, this pull request adds a feature where when a new binary is being installed, the kernel will look for a previous version of the same app in the storage. If it finds one, the kernel then terminates the process (if active) and erases the previous version binary. If there is no previous version on device, the new version gets installed like it always does.

This PR builds on top of #4528 and is blocked by said PR. 

Eventually, I want to build something that performs defragmentation (if that's even possible), so we have neat spaces for new apps. 


### Testing Strategy

This pull request was tested by installing a blink app with version 0. Then we use the dynamic app load helper app to install a blink app with version 2. We observe that the old version is uninstalled completely before the new version is loaded. 


### TODO or Help Wanted

I guess I was wondering if it made more sense to move the erase part to after successfully loading the new process instead. Actually, I think that makes the most sense, I will update the PR according to that.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
