### PR TITLE
Add `stack_size!()` macro from libtock-rs

### DIFF
--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -147,10 +147,7 @@ static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripheral
 static mut PROCESS_PRINTER: Option<&'static capsules_system::process_printer::ProcessPrinterText> =
     None;
 
-/// Dummy buffer that causes the linker to reserve enough space for the stack.
-#[no_mangle]
-#[link_section = ".stack_buffer"]
-static mut STACK_MEMORY: [u8; 0x2000] = [0; 0x2000];
+kernel::stack_size! {0x2000}
 
 //------------------------------------------------------------------------------
 // SYSCALL DRIVER TYPE DEFINITIONS

--- a/kernel/src/utilities/helpers.rs
+++ b/kernel/src/utilities/helpers.rs
@@ -80,7 +80,7 @@ macro_rules! stack_size {
         /// Size to allocate for the stack.
         #[no_mangle]
         #[link_section = ".stack_buffer"]
-        pub static mut STACK_MEMORY: [u8; $size] = [0; $size];
+        static mut STACK_MEMORY: [u8; $size] = [0; $size];
     }
 }
 

--- a/kernel/src/utilities/helpers.rs
+++ b/kernel/src/utilities/helpers.rs
@@ -69,7 +69,7 @@ macro_rules! count_expressions {
 /// Executables must specify their stack size by using the `stack_size!` macro.
 /// It takes a single argument, the desired stack size in bytes. Example:
 /// ```
-/// stack_size!{0x1000}
+/// kernel::stack_size!{0x1000}
 /// ```
 // stack_size works by putting a symbol equal to the size of the stack in the
 // .stack_buffer section. The linker script uses the .stack_buffer section to

--- a/kernel/src/utilities/helpers.rs
+++ b/kernel/src/utilities/helpers.rs
@@ -66,6 +66,24 @@ macro_rules! count_expressions {
     ($head:expr, $($tail:expr),* $(,)?) => (1usize + count_expressions!($($tail),*));
 }
 
+/// Executables must specify their stack size by using the `stack_size!` macro.
+/// It takes a single argument, the desired stack size in bytes. Example:
+/// ```
+/// stack_size!{0x400}
+/// ```
+// stack_size works by putting a symbol equal to the size of the stack in the
+// .stack_buffer section. The linker script uses the .stack_buffer section to
+// size the stack.
+#[macro_export]
+macro_rules! stack_size {
+    {$size:expr} => {
+        /// Size to allocate for the stack.
+        #[no_mangle]
+        #[link_section = ".stack_buffer"]
+        pub static mut STACK_MEMORY: [u8; $size] = [0; $size];
+    }
+}
+
 /// Compute a POSIX-style CRC32 checksum of a slice.
 ///
 /// Online calculator: <https://crccalc.com/>

--- a/kernel/src/utilities/helpers.rs
+++ b/kernel/src/utilities/helpers.rs
@@ -69,7 +69,7 @@ macro_rules! count_expressions {
 /// Executables must specify their stack size by using the `stack_size!` macro.
 /// It takes a single argument, the desired stack size in bytes. Example:
 /// ```
-/// stack_size!{0x400}
+/// stack_size!{0x1000}
 /// ```
 // stack_size works by putting a symbol equal to the size of the stack in the
 // .stack_buffer section. The linker script uses the .stack_buffer section to


### PR DESCRIPTION
### Pull Request Overview

I wrote a libtock-rs app yesterday and thought the macro to define the stack size was pretty straightforward and a better abstraction than creating a buffer with a special linker section.

This copies the macro from https://github.com/tock/libtock-rs/blob/5b4d692956fe834ec734e2541d3354356a4d5ae0/runtime/src/startup/mod.rs#L51 to the kernel.


### Testing Strategy

travis


### TODO or Help Wanted

We should probably switch all boards if we want to go this way?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
