### PR TITLE
chips/virtio: return raw device ID for unknown VirtIO devices

### DIFF
--- a/boards/qemu_rv32_virt/src/main.rs
+++ b/boards/qemu_rv32_virt/src/main.rs
@@ -309,10 +309,10 @@ unsafe fn start() -> (
     for (i, virtio_device) in peripherals.virtio_mmio.iter().enumerate() {
         use qemu_rv32_virt_chip::virtio::devices::VirtIODeviceType;
         match virtio_device.query() {
-            Some(VirtIODeviceType::NetworkCard) => {
+            Ok(VirtIODeviceType::NetworkCard) => {
                 virtio_net_idx = Some(i);
             }
-            Some(VirtIODeviceType::EntropySource) => {
+            Ok(VirtIODeviceType::EntropySource) => {
                 virtio_rng_idx = Some(i);
             }
             _ => (),


### PR DESCRIPTION
### Pull Request Overview

This makes it easier to debug which MMIO slots have VirtIO devices
present, even when their device types are not yet known.

### Testing Strategy

N/A


### TODO or Help Wanted

N/A


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
