### PR TITLE
capsules/core/led: Expose `Led::read()` method

### DIFF
--- a/doc/syscalls/00002_leds.md
+++ b/doc/syscalls/00002_leds.md
@@ -57,6 +57,17 @@ main file.
 
     **Returns**: `Ok(())` if the LED index is valid, `INVAL` otherwise.
 
+  * ### Command number: `4`
+
+    **Description**: Get the state of a LED.
+
+    **Argument 1**: The index of the LED whose status needs to be retrieved, starting at 0.
+
+    **Argument 2**: unused
+
+    **Returns**: `INVAL` if the LED index is invalid, `Ok(0u32)` if the LED is off or `Ok(1u32)` if
+	the LED is on.
+
 ## Subscribe
 
 Unused for the LED driver. Will always return `ENOSUPPORT`.
@@ -64,4 +75,3 @@ Unused for the LED driver. Will always return `ENOSUPPORT`.
 ## Allow
 
 Unused for the LED driver. Will always return `ENOSUPPORT`.
-


### PR DESCRIPTION
### Pull Request Overview

This pull request exposes `Led::read()` method to userspace.


### Testing Strategy

This pull request was tested by running a simple `libtock-rs` app on Nucleo-F429ZI.


### TODO or Help Wanted

No help needed.


### Documentation Updated

- [x] Updated `00002_leds.md`

### Formatting

- [x] Ran `make prepush`.
