### PR TITLE
hil: screen: add Pixel Format `Mono_8BitPage`

### DIFF
--- a/capsules/extra/src/screen.rs
+++ b/capsules/extra/src/screen.rs
@@ -53,6 +53,8 @@ fn screen_pixel_format_from(screen_pixel_format: usize) -> Option<ScreenPixelFor
         2 => Some(ScreenPixelFormat::RGB_565),
         3 => Some(ScreenPixelFormat::RGB_888),
         4 => Some(ScreenPixelFormat::ARGB_8888),
+        5 => Some(ScreenPixelFormat::RGB_4BIT),
+        6 => Some(ScreenPixelFormat::Mono_8BitPage),
         _ => None,
     }
 }

--- a/capsules/extra/src/sh1106.rs
+++ b/capsules/extra/src/sh1106.rs
@@ -265,7 +265,7 @@ impl<'a, I: hil::i2c::I2CDevice> hil::screen::ScreenSetup<'a> for Sh1106<'a, I> 
 
     fn get_supported_pixel_format(&self, index: usize) -> Option<hil::screen::ScreenPixelFormat> {
         match index {
-            0 => Some(hil::screen::ScreenPixelFormat::Mono),
+            0 => Some(hil::screen::ScreenPixelFormat::Mono_8BitPage),
             _ => None,
         }
     }
@@ -281,7 +281,7 @@ impl<'a, I: hil::i2c::I2CDevice> hil::screen::Screen<'a> for Sh1106<'a, I> {
     }
 
     fn get_pixel_format(&self) -> hil::screen::ScreenPixelFormat {
-        hil::screen::ScreenPixelFormat::Mono
+        hil::screen::ScreenPixelFormat::Mono_8BitPage
     }
 
     fn get_rotation(&self) -> hil::screen::ScreenRotation {

--- a/capsules/extra/src/ssd1306.rs
+++ b/capsules/extra/src/ssd1306.rs
@@ -417,7 +417,7 @@ impl<'a, I: hil::i2c::I2CDevice> hil::screen::ScreenSetup<'a> for Ssd1306<'a, I>
 
     fn get_supported_pixel_format(&self, index: usize) -> Option<hil::screen::ScreenPixelFormat> {
         match index {
-            0 => Some(hil::screen::ScreenPixelFormat::Mono),
+            0 => Some(hil::screen::ScreenPixelFormat::Mono_8BitPage),
             _ => None,
         }
     }
@@ -433,7 +433,7 @@ impl<'a, I: hil::i2c::I2CDevice> hil::screen::Screen<'a> for Ssd1306<'a, I> {
     }
 
     fn get_pixel_format(&self) -> hil::screen::ScreenPixelFormat {
-        hil::screen::ScreenPixelFormat::Mono
+        hil::screen::ScreenPixelFormat::Mono_8BitPage
     }
 
     fn get_rotation(&self) -> hil::screen::ScreenRotation {

--- a/doc/syscalls/90001_screen.md
+++ b/doc/syscalls/90001_screen.md
@@ -196,11 +196,15 @@ may return OFF when power is not enabled (see screen HIL for details).
     **Argument 2**: unused
 
     **Returns**: A single u32 value.
-    0: 8 pixels per byte monochromatic, pixels more to the left are more significant bits. 1 is light, 0 is dark.
-    1: RGB_233, 2-bit red channel, 3-bit green channel, 3-bit blue channel.
-    2: RGB_565, 5-bit red channel, 6-bit green channel, 5-bit blue channel.
-    3: RGB_888
-    4: ARGB_8888 (RGB with transparency)
+    - 0: 8 pixels per byte monochromatic, pixels more to the left are more significant bits. 1 is light, 0 is dark.
+    - 1: RGB_233, 2-bit red channel, 3-bit green channel, 3-bit blue channel.
+    - 2: RGB_565, 5-bit red channel, 6-bit green channel, 5-bit blue channel.
+    - 3: RGB_888
+    - 4: ARGB_8888 (RGB with transparency)
+    - 5: RGB_4BIT, 1-bit blue channel, 1-bit green, 1-bit red, 1-bit for opaque (1) vs transparent (0)
+    - 6: Mono_8BitPage, 8 pixels per byte monochromatic, each byte is displayed
+      vertically (pixels above are less significant bits) and tile
+      horizontally.
 
   * ### Command number: `26` 
 

--- a/kernel/src/hil/screen.rs
+++ b/kernel/src/hil/screen.rs
@@ -97,22 +97,32 @@ impl Sub for ScreenRotation {
 #[allow(non_camel_case_types)]
 pub enum ScreenPixelFormat {
     /// Pixels encoded as 1-bit, used for monochromatic displays.
-    Mono,
+    Mono = 0,
+    /// Pixels encoded as 1-bit, used for monochromatic displays.
+    ///
+    /// The pixel order uses 8-bit (1-byte) pages where each page is displayed
+    /// vertically. That is, buffer[0] bit0 is pixel (0,0), but buffer[0] bit1
+    /// is pixel (0,1). The page continues, so buffer[0] bit 7 is pixel
+    /// (0,7). Then the page advances horizontally, so buffer[1] bit0 is
+    /// pixel (1,0), and buffer[1] bit4 is pixel (1,4).
+    ///
+    /// An example of a screen driver that uses this format is the SSD1306.
+    Mono_8BitPage = 6,
     /// Pixels encoded as 1-bit blue, 1-bit green, 1-bit red,
     /// and 1-bit for opaque (1) vs transparent (0)
-    RGB_4BIT,
+    RGB_4BIT = 5,
     /// Pixels encoded as 3-bit red channel, 3-bit green channel, 2-bit blue
     /// channel.
-    RGB_332,
+    RGB_332 = 1,
     /// Pixels encoded as 5-bit red channel, 6-bit green channel, 5-bit blue
     /// channel.
-    RGB_565,
+    RGB_565 = 2,
     /// Pixels encoded as 8-bit red channel, 8-bit green channel, 8-bit blue
     /// channel.
-    RGB_888,
+    RGB_888 = 3,
     /// Pixels encoded as 8-bit alpha channel, 8-bit red channel, 8-bit green
     /// channel, 8-bit blue channel.
-    ARGB_8888,
+    ARGB_8888 = 4,
     // other pixel formats may be defined.
 }
 
@@ -120,6 +130,7 @@ impl ScreenPixelFormat {
     pub fn get_bits_per_pixel(&self) -> usize {
         match self {
             Self::Mono => 1,
+            Self::Mono_8BitPage => 1,
             Self::RGB_4BIT => 4,
             Self::RGB_332 => 8,
             Self::RGB_565 => 16,


### PR DESCRIPTION
### Pull Request Overview

This is the mono format that the SSD1306 uses. When I wrote the driver for the SSD1306 I thought it was a "normal" mono display, but the pixel ordering is (at least to me) not intuitive. I assume a `ScreenPixelFormat::Mono` display would have the pixels in order horizontally (e.g., buffer[2] bit3 would be pixel (x: 19, y:0)). However, on the SSD1306, buffer[2] bit0 is pixel (x:2, y:3) because the bytes are displayed vertically and tiled horizontally.

The new enum variant captures this. I updated the two SSD1306-esque drivers to reflect this format.

I also made the mapping of enum <-> usize consistent in both the Driver and the HIL.






### Testing Strategy

I haven't, but this should allow us to write screen code that actually checks the display format.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the syscall doc with the formats and their numbers.

### Formatting

- [x] Ran `make prepush`.
