### PR TITLE
platform: Be explicit about single-core "atomic"

### DIFF
--- a/arch/cortex-m/src/support.rs
+++ b/arch/cortex-m/src/support.rs
@@ -24,9 +24,9 @@ pub unsafe fn wfi() {
     asm!("wfi", options(nomem, preserves_flags));
 }
 
-/// Atomic operation
+/// Single-core critical section operation
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
-pub unsafe fn atomic<F, R>(f: F) -> R
+pub unsafe fn with_interrupts_disabled<F, R>(f: F) -> R
 where
     F: FnOnce() -> R,
 {
@@ -54,9 +54,9 @@ pub unsafe fn wfi() {
     unimplemented!()
 }
 
-/// Atomic operation (mock)
+/// Single-core critical section operation (mock)
 #[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
-pub unsafe fn atomic<F, R>(_f: F) -> R
+pub unsafe fn with_interrupts_disabled<F, R>(_f: F) -> R
 where
     F: FnOnce() -> R,
 {

--- a/arch/riscv/src/support.rs
+++ b/arch/riscv/src/support.rs
@@ -24,7 +24,8 @@ pub unsafe fn wfi() {
     asm!("wfi", options(nomem, nostack));
 }
 
-pub unsafe fn atomic<F, R>(f: F) -> R
+/// Single-core critical section operation
+pub unsafe fn with_interrupts_disabled<F, R>(f: F) -> R
 where
     F: FnOnce() -> R,
 {
@@ -38,8 +39,8 @@ where
         .read_and_clear_bits(mstatus::mie.mask << mstatus::mie.shift)
         & mstatus::mie.mask << mstatus::mie.shift;
 
-    // Machine mode interrupts are disabled, execute the atomic
-    // (uninterruptible) function
+    // Machine mode interrupts are disabled, execute the (uninterruptible)
+    // function
     let res = f();
 
     // If [`mstatus::mie`] was set before, set it again. Otherwise,

--- a/arch/x86/src/interrupts/poller.rs
+++ b/arch/x86/src/interrupts/poller.rs
@@ -61,13 +61,14 @@ static mut SINGLETON: InterruptPoller = InterruptPoller {
 impl InterruptPoller {
     /// Provides safe access to the singleton instance of `InterruptPoller`.
     ///
-    /// The given closure `f` is executed with interrupts disabled (using [`support::atomic`](crate::support::atomic)) and
-    /// passed a reference to the singleton.
+    /// The given closure `f` is executed with interrupts disabled (using
+    /// [`support::with_interrupts_disabled`](crate::support::with_interrupts_disabled))
+    /// and  passed a reference to the singleton.
     pub fn access<F, R>(f: F) -> R
     where
         F: FnOnce(&InterruptPoller) -> R,
     {
-        support::atomic(|| {
+        support::with_interrupts_disabled(|| {
             // Safety: Interrupts are disabled within this closure, so we can safely access the
             //         singleton without racing against interrupt handlers.
             let poller = unsafe { &*ptr::addr_of!(SINGLETON) };

--- a/arch/x86/src/support.rs
+++ b/arch/x86/src/support.rs
@@ -7,12 +7,13 @@
 #[cfg(any(doc, target_arch = "x86"))]
 use core::arch::asm;
 
-/// Execute a given closure atomically.
+/// Execute closure without allowing any interrupts on the current core.
 ///
-/// This function ensures interrupts are disabled before invoking the given closue `f`. This allows
-/// you to safely perform memory accesses which would otherwise race against interrupt handlers.
+/// This function ensures interrupts are disabled before invoking the given
+/// closue `f`. This allows / you to safely perform single-core operations
+/// which would otherwise race against interrupt handlers.
 #[cfg(any(doc, target_arch = "x86"))]
-pub fn atomic<F, R>(f: F) -> R
+pub fn with_interrupts_disabled<F, R>(f: F) -> R
 where
     F: FnOnce() -> R,
 {
@@ -41,7 +42,7 @@ where
 }
 
 #[cfg(not(any(doc, target_arch = "x86")))]
-pub fn atomic<F, R>(_: F) -> R
+pub fn with_interrupts_disabled<F, R>(_: F) -> R
 where
     F: FnOnce() -> R,
 {

--- a/chips/apollo3/src/chip.rs
+++ b/chips/apollo3/src/chip.rs
@@ -129,11 +129,11 @@ impl<I: InterruptService + 'static> Chip for Apollo3<I> {
         }
     }
 
-    unsafe fn atomic<F, R>(&self, f: F) -> R
+    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {
-        cortexm4f::support::atomic(f)
+        cortexm4f::support::with_interrupts_disabled(f)
     }
 
     unsafe fn print_state(&self, write: &mut dyn Write) {

--- a/chips/arty_e21_chip/src/chip.rs
+++ b/chips/arty_e21_chip/src/chip.rs
@@ -179,11 +179,11 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for ArtyExx<'a, 
         }
     }
 
-    unsafe fn atomic<F, R>(&self, f: F) -> R
+    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {
-        rv32i::support::atomic(f)
+        rv32i::support::with_interrupts_disabled(f)
     }
 
     unsafe fn print_state(&self, write: &mut dyn Write) {

--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -105,7 +105,7 @@ impl<'a, I: InterruptService + 'a> E310x<'a, I> {
             if !self.plic_interrupt_service.service_interrupt(interrupt) {
                 debug!("Pidx {}", interrupt);
             }
-            self.atomic(|| {
+            self.with_interrupts_disabled(|| {
                 self.plic.complete(interrupt);
             });
         }
@@ -167,11 +167,11 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for E310x<'a, I>
         }
     }
 
-    unsafe fn atomic<F, R>(&self, f: F) -> R
+    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {
-        rv32i::support::atomic(f)
+        rv32i::support::with_interrupts_disabled(f)
     }
 
     unsafe fn print_state(&self, writer: &mut dyn Write) {

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -196,7 +196,7 @@ impl<
                         // In order to stop an interrupt loop, we first disable the
                         // interrupt. `service_pending_interrupts()` will re-enable
                         // interrupts once they are all handled.
-                        self.atomic(|| {
+                        self.with_interrupts_disabled(|| {
                             // Safe as interrupts are disabled
                             self.plic.disable(interrupt);
                             self.plic.complete(interrupt);
@@ -211,7 +211,7 @@ impl<
             match interrupt {
                 interrupts::HMAC_HMACDONE..=interrupts::HMAC_HMACERR => {}
                 _ => {
-                    self.atomic(|| {
+                    self.with_interrupts_disabled(|| {
                         self.plic.complete(interrupt);
                     });
                 }
@@ -304,11 +304,11 @@ impl<
         }
     }
 
-    unsafe fn atomic<F, R>(&self, f: F) -> R
+    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {
-        rv32i::support::atomic(f)
+        rv32i::support::with_interrupts_disabled(f)
     }
 
     unsafe fn print_state(&self, writer: &mut dyn Write) {

--- a/chips/esp32-c3/src/chip.rs
+++ b/chips/esp32-c3/src/chip.rs
@@ -100,7 +100,7 @@ impl<'a, I: InterruptService + 'a> Esp32C3<'a, I> {
             if !self.pic_interrupt_service.service_interrupt(interrupt) {
                 panic!("Unhandled interrupt {}", interrupt);
             }
-            self.atomic(|| {
+            self.with_interrupts_disabled(|| {
                 // Safe as interrupts are disabled
                 self.intc.complete(interrupt);
             });
@@ -146,11 +146,11 @@ impl<'a, I: InterruptService + 'a> Chip for Esp32C3<'a, I> {
         }
     }
 
-    unsafe fn atomic<F, R>(&self, f: F) -> R
+    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {
-        rv32i::support::atomic(f)
+        rv32i::support::with_interrupts_disabled(f)
     }
 
     unsafe fn print_state(&self, writer: &mut dyn Write) {

--- a/chips/imxrt10xx/src/chip.rs
+++ b/chips/imxrt10xx/src/chip.rs
@@ -137,11 +137,11 @@ impl<I: InterruptService + 'static> Chip for Imxrt10xx<I> {
         }
     }
 
-    unsafe fn atomic<F, R>(&self, f: F) -> R
+    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {
-        cortexm7::support::atomic(f)
+        cortexm7::support::with_interrupts_disabled(f)
     }
 
     unsafe fn print_state(&self, write: &mut dyn Write) {

--- a/chips/imxrt10xx/src/gpio.rs
+++ b/chips/imxrt10xx/src/gpio.rs
@@ -26,7 +26,7 @@
 //! assert_eq!(pin_from_id as *const _, pin_from_port as *const _);
 //! ```
 
-use cortexm7::support::atomic;
+use cortexm7::support::with_interrupts_disabled;
 use enum_primitive::cast::FromPrimitive;
 use enum_primitive::enum_from_primitive;
 use kernel::hil;
@@ -333,7 +333,7 @@ impl<'a, const N: usize> Port<'a, N> {
         // 1 register (`rc_w1`). So, we only clear bits whose value has been
         // transferred to `isr`.
         let isr_val = unsafe {
-            atomic(|| {
+            with_interrupts_disabled(|| {
                 let isr_val = self.registers.isr.get();
                 self.registers.isr.set(isr_val);
                 isr_val
@@ -747,7 +747,7 @@ impl hil::gpio::Input for Pin<'_> {
 impl<'a> hil::gpio::Interrupt<'a> for Pin<'a> {
     fn enable_interrupts(&self, mode: hil::gpio::InterruptEdge) {
         unsafe {
-            atomic(|| {
+            with_interrupts_disabled(|| {
                 // disable the interrupt
                 self.mask_interrupt();
                 self.clear_pending();
@@ -760,7 +760,7 @@ impl<'a> hil::gpio::Interrupt<'a> for Pin<'a> {
 
     fn disable_interrupts(&self) {
         unsafe {
-            atomic(|| {
+            with_interrupts_disabled(|| {
                 self.mask_interrupt();
                 self.clear_pending();
             });

--- a/chips/imxrt10xx/src/gpt.rs
+++ b/chips/imxrt10xx/src/gpt.rs
@@ -3,7 +3,7 @@
 // Copyright Tock Contributors 2022.
 
 use core::sync::atomic::{AtomicU32, Ordering};
-use cortexm7::support::atomic;
+use cortexm7::support::with_interrupts_disabled;
 use kernel::hil;
 use kernel::hil::time::{Ticks, Ticks32, Time};
 use kernel::platform::chip::ClockInterface;
@@ -393,7 +393,7 @@ impl<'a, F: hil::time::Frequency> hil::time::Alarm<'a> for Gpt<'a, F> {
 
     fn disarm(&self) -> Result<(), ErrorCode> {
         unsafe {
-            atomic(|| {
+            with_interrupts_disabled(|| {
                 // Disable counter
                 self.registers.ir.modify(IR::OF1IE::CLEAR);
                 cortexm7::nvic::Nvic::new(self.irqn).clear_pending();

--- a/chips/litex_vexriscv/src/chip.rs
+++ b/chips/litex_vexriscv/src/chip.rs
@@ -94,11 +94,11 @@ impl<I: 'static + InterruptService> kernel::platform::chip::Chip for LiteXVexRis
         }
     }
 
-    unsafe fn atomic<F, R>(&self, f: F) -> R
+    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {
-        rv32i::support::atomic(f)
+        rv32i::support::with_interrupts_disabled(f)
     }
 
     unsafe fn print_state(&self, writer: &mut dyn Write) {

--- a/chips/msp432/src/chip.rs
+++ b/chips/msp432/src/chip.rs
@@ -140,11 +140,11 @@ impl<'a, I: InterruptService + 'a> Chip for Msp432<'a, I> {
         }
     }
 
-    unsafe fn atomic<F, R>(&self, f: F) -> R
+    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {
-        cortexm4::support::atomic(f)
+        cortexm4::support::with_interrupts_disabled(f)
     }
 
     unsafe fn print_state(&self, write: &mut dyn Write) {

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -139,11 +139,11 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for NRF52<'a, I>
         }
     }
 
-    unsafe fn atomic<F, R>(&self, f: F) -> R
+    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {
-        cortexm4f::support::atomic(f)
+        cortexm4f::support::with_interrupts_disabled(f)
     }
 
     unsafe fn print_state(&self, write: &mut dyn Write) {

--- a/chips/nrf52/src/usbd.rs
+++ b/chips/nrf52/src/usbd.rs
@@ -5,7 +5,7 @@
 //! Universal Serial Bus Device with EasyDMA (USBD)
 
 use core::cell::Cell;
-use cortexm4f::support::atomic;
+use cortexm4f::support::with_interrupts_disabled;
 use kernel::hil;
 use kernel::hil::usb::TransferType;
 use kernel::utilities::cells::{OptionalCell, VolatileCell};
@@ -792,7 +792,7 @@ impl<'a> Usbd<'a> {
     fn apply_errata_171(&self, val: u32) {
         if self.has_errata_171() {
             unsafe {
-                atomic(|| {
+                with_interrupts_disabled(|| {
                     if USBERRATA_BASE.reg_c00.get() == 0 {
                         USBERRATA_BASE.reg_c00.set(0x9375);
                         USBERRATA_BASE.reg_c14.set(val);
@@ -809,7 +809,7 @@ impl<'a> Usbd<'a> {
     fn apply_errata_187(&self, val: u32) {
         if self.has_errata_187() {
             unsafe {
-                atomic(|| {
+                with_interrupts_disabled(|| {
                     if USBERRATA_BASE.reg_c00.get() == 0 {
                         USBERRATA_BASE.reg_c00.set(0x9375);
                         USBERRATA_BASE.reg_d14.set(val);

--- a/chips/psoc62xa/src/chip.rs
+++ b/chips/psoc62xa/src/chip.rs
@@ -38,11 +38,11 @@ impl<I: InterruptService> Chip for Psoc62xa<'_, I> {
         }
     }
 
-    unsafe fn atomic<F, R>(&self, f: F) -> R
+    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {
-        cortexm0p::support::atomic(f)
+        cortexm0p::support::with_interrupts_disabled(f)
     }
 
     unsafe fn print_state(&self, writer: &mut dyn core::fmt::Write) {

--- a/chips/qemu_rv32_virt_chip/src/chip.rs
+++ b/chips/qemu_rv32_virt_chip/src/chip.rs
@@ -104,7 +104,7 @@ impl<'a, I: InterruptService + 'a> QemuRv32VirtChip<'a, I> {
             if !self.plic_interrupt_service.service_interrupt(interrupt) {
                 debug!("Pidx {}", interrupt);
             }
-            self.atomic(|| {
+            self.with_interrupts_disabled(|| {
                 self.plic.complete(interrupt);
             });
         }
@@ -166,11 +166,11 @@ impl<'a, I: InterruptService + 'a> Chip for QemuRv32VirtChip<'a, I> {
         }
     }
 
-    unsafe fn atomic<F, R>(&self, f: F) -> R
+    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {
-        rv32i::support::atomic(f)
+        rv32i::support::with_interrupts_disabled(f)
     }
 
     unsafe fn print_state(&self, writer: &mut dyn Write) {

--- a/chips/rp2040/src/chip.rs
+++ b/chips/rp2040/src/chip.rs
@@ -103,11 +103,11 @@ impl<I: InterruptService> Chip for Rp2040<'_, I> {
         }
     }
 
-    unsafe fn atomic<F, R>(&self, f: F) -> R
+    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {
-        cortexm0p::support::atomic(f)
+        cortexm0p::support::with_interrupts_disabled(f)
     }
 
     unsafe fn print_state(&self, writer: &mut dyn Write) {

--- a/chips/rp2040/src/timer.rs
+++ b/chips/rp2040/src/timer.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use cortexm0p::support::atomic;
+use cortexm0p::support::with_interrupts_disabled;
 use kernel::hil;
 use kernel::hil::time::{Alarm, Ticks, Ticks32, Time};
 use kernel::utilities::cells::OptionalCell;
@@ -200,7 +200,7 @@ impl<'a> RPTimer<'a> {
         // not fired. This means that the interrupt will be handled whenever the
         // next kernel tasks are processed.
         unsafe {
-            atomic(|| {
+            with_interrupts_disabled(|| {
                 let n = cortexm0p::nvic::Nvic::new(TIMER_IRQ_0);
                 n.enable();
             })
@@ -259,7 +259,7 @@ impl<'a> Alarm<'a> for RPTimer<'a> {
     fn disarm(&self) -> Result<(), ErrorCode> {
         self.registers.armed.set(1);
         unsafe {
-            atomic(|| {
+            with_interrupts_disabled(|| {
                 // Clear pending interrupts
                 cortexm0p::nvic::Nvic::new(TIMER_IRQ_0).clear_pending();
             });

--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -281,11 +281,11 @@ impl<I: InterruptService + 'static> Chip for Sam4l<I> {
         }
     }
 
-    unsafe fn atomic<F, R>(&self, f: F) -> R
+    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {
-        cortexm4::support::atomic(f)
+        cortexm4::support::with_interrupts_disabled(f)
     }
 
     unsafe fn print_state(&self, writer: &mut dyn Write) {

--- a/chips/stm32f303xc/src/chip.rs
+++ b/chips/stm32f303xc/src/chip.rs
@@ -137,11 +137,11 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32f3xx<'a, I> {
         }
     }
 
-    unsafe fn atomic<F, R>(&self, f: F) -> R
+    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {
-        cortexm4f::support::atomic(f)
+        cortexm4f::support::with_interrupts_disabled(f)
     }
 
     unsafe fn print_state(&self, write: &mut dyn Write) {

--- a/chips/stm32f303xc/src/exti.rs
+++ b/chips/stm32f303xc/src/exti.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use cortexm4f::support::atomic;
+use cortexm4f::support::with_interrupts_disabled;
 use enum_primitive::cast::FromPrimitive;
 use enum_primitive::enum_from_primitive;
 use kernel::platform::chip::ClockInterface;
@@ -743,7 +743,7 @@ impl<'a> Exti<'a> {
         // 1 register (`rc_w1`). So, we only clear bits whose value has been
         // transferred to `exti_pr`.
         unsafe {
-            atomic(|| {
+            with_interrupts_disabled(|| {
                 exti_pr = self.registers.pr1.get();
                 self.registers.pr1.set(exti_pr);
             });

--- a/chips/stm32f303xc/src/gpio.rs
+++ b/chips/stm32f303xc/src/gpio.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use cortexm4f::support::atomic;
+use cortexm4f::support::with_interrupts_disabled;
 use enum_primitive::cast::FromPrimitive;
 use enum_primitive::enum_from_primitive;
 use kernel::hil;
@@ -1115,7 +1115,7 @@ impl hil::gpio::Input for Pin<'_> {
 impl<'a> hil::gpio::Interrupt<'a> for Pin<'a> {
     fn enable_interrupts(&self, mode: hil::gpio::InterruptEdge) {
         unsafe {
-            atomic(|| {
+            with_interrupts_disabled(|| {
                 self.exti_lineid.map(|lineid| {
                     let l = lineid;
 
@@ -1146,7 +1146,7 @@ impl<'a> hil::gpio::Interrupt<'a> for Pin<'a> {
 
     fn disable_interrupts(&self) {
         unsafe {
-            atomic(|| {
+            with_interrupts_disabled(|| {
                 self.exti_lineid.map(|lineid| {
                     let l = lineid;
                     self.exti.mask_interrupt(l);

--- a/chips/stm32f303xc/src/tim2.rs
+++ b/chips/stm32f303xc/src/tim2.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use cortexm4f::support::atomic;
+use cortexm4f::support::with_interrupts_disabled;
 use kernel::hil::time::{
     Alarm, AlarmClient, Counter, Freq16KHz, OverflowClient, Ticks, Ticks32, Time,
 };
@@ -428,7 +428,7 @@ impl<'a> Alarm<'a> for Tim2<'a> {
 
     fn disarm(&self) -> Result<(), ErrorCode> {
         unsafe {
-            atomic(|| {
+            with_interrupts_disabled(|| {
                 // Disable counter
                 self.registers.dier.modify(DIER::CC1IE::CLEAR);
                 cortexm4f::nvic::Nvic::new(self.irqn).clear_pending();

--- a/chips/stm32f4xx/src/chip.rs
+++ b/chips/stm32f4xx/src/chip.rs
@@ -199,11 +199,11 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32f4xx<'a, I> {
         }
     }
 
-    unsafe fn atomic<F, R>(&self, f: F) -> R
+    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {
-        cortexm4f::support::atomic(f)
+        cortexm4f::support::with_interrupts_disabled(f)
     }
 
     unsafe fn print_state(&self, write: &mut dyn Write) {

--- a/chips/stm32f4xx/src/exti.rs
+++ b/chips/stm32f4xx/src/exti.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use cortexm4f::support::atomic;
+use cortexm4f::support::with_interrupts_disabled;
 use enum_primitive::cast::FromPrimitive;
 use enum_primitive::enum_from_primitive;
 use kernel::platform::chip::ClockInterface;
@@ -623,7 +623,7 @@ impl<'a> Exti<'a> {
         // 1 register (`rc_w1`). So, we only clear bits whose value has been
         // transferred to `exti_pr`.
         unsafe {
-            atomic(|| {
+            with_interrupts_disabled(|| {
                 exti_pr = self.registers.pr.get();
                 self.registers.pr.set(exti_pr);
             });

--- a/chips/stm32f4xx/src/gpio.rs
+++ b/chips/stm32f4xx/src/gpio.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use cortexm4f::support::atomic;
+use cortexm4f::support::with_interrupts_disabled;
 use enum_primitive::cast::FromPrimitive;
 use enum_primitive::enum_from_primitive;
 use kernel::hil;
@@ -1202,7 +1202,7 @@ impl hil::gpio::Input for Pin<'_> {
 impl<'a> hil::gpio::Interrupt<'a> for Pin<'a> {
     fn enable_interrupts(&self, mode: hil::gpio::InterruptEdge) {
         unsafe {
-            atomic(|| {
+            with_interrupts_disabled(|| {
                 self.exti_lineid.map(|lineid| {
                     let l = lineid;
 
@@ -1233,7 +1233,7 @@ impl<'a> hil::gpio::Interrupt<'a> for Pin<'a> {
 
     fn disable_interrupts(&self) {
         unsafe {
-            atomic(|| {
+            with_interrupts_disabled(|| {
                 self.exti_lineid.map(|lineid| {
                     let l = lineid;
                     self.exti.mask_interrupt(l);

--- a/chips/stm32f4xx/src/tim2.rs
+++ b/chips/stm32f4xx/src/tim2.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use cortexm4f::support::atomic;
+use cortexm4f::support::with_interrupts_disabled;
 use kernel::hil::time::{
     Alarm, AlarmClient, Counter, Freq16KHz, Frequency, OverflowClient, Ticks, Ticks32, Time,
 };
@@ -448,7 +448,7 @@ impl<'a> Alarm<'a> for Tim2<'a> {
 
     fn disarm(&self) -> Result<(), ErrorCode> {
         unsafe {
-            atomic(|| {
+            with_interrupts_disabled(|| {
                 // Disable counter
                 self.registers.dier.modify(DIER::CC1IE::CLEAR);
                 cortexm4f::nvic::Nvic::new(self.irqn).clear_pending();

--- a/chips/veer_el2/src/chip.rs
+++ b/chips/veer_el2/src/chip.rs
@@ -81,7 +81,7 @@ impl<'a, I: InterruptService + 'a> VeeR<'a, I> {
             if !self.pic_interrupt_service.service_interrupt(interrupt) {
                 panic!("Unhandled interrupt {}", interrupt);
             }
-            self.atomic(|| {
+            self.with_interrupts_disabled(|| {
                 // Safe as interrupts are disabled
                 self.pic.complete(interrupt);
             });
@@ -138,11 +138,11 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for VeeR<'a, I> 
         }
     }
 
-    unsafe fn atomic<F, R>(&self, f: F) -> R
+    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {
-        rv32i::support::atomic(f)
+        rv32i::support::with_interrupts_disabled(f)
     }
 
     unsafe fn print_state(&self, writer: &mut dyn Write) {

--- a/chips/x86_q35/src/chip.rs
+++ b/chips/x86_q35/src/chip.rs
@@ -137,11 +137,11 @@ impl<'a, const PR: u16> Chip for Pc<'a, PR> {
         unimplemented!()
     }
 
-    unsafe fn atomic<F, R>(&self, f: F) -> R
+    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {
-        support::atomic(f)
+        support::with_interrupts_disabled(f)
     }
 
     unsafe fn print_state(&self, writer: &mut dyn Write) {

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -385,7 +385,7 @@ impl Kernel {
                             // the running test does not generate
                             // any interrupts.
                             if !no_sleep {
-                                chip.atomic(|| {
+                                chip.with_interrupts_disabled(|| {
                                     // Cannot sleep if interrupts are pending,
                                     // as on most platforms unhandled interrupts
                                     // will wake the device. Also, if the only

--- a/kernel/src/platform/chip.rs
+++ b/kernel/src/platform/chip.rs
@@ -50,10 +50,11 @@ pub trait Chip {
     /// chip and resumes the scheduler.
     fn sleep(&self);
 
-    /// Run a function in an atomic state, which means that interrupts are
-    /// disabled so that an interrupt will not fire during the passed in
-    /// function's execution.
-    unsafe fn atomic<F, R>(&self, f: F) -> R
+    /// Run a function in an atomic state w.r.t. to the current core. This
+    /// means that interrupts are disabled so that an interrupt will not fire
+    /// during the passed in function's execution, but *does not* make any
+    /// guarantees about memory consistency on a multi-core system.
+    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R;
 


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the platform interface method `atomic` to be named ~`local_atomic`~ `with_interrupts_disabled`, and to be explicit that it creates a closure that is only atomic in behavior relative to the current core. I.e., on a multi-core machine, just disabling interrupts for the current core makes no assurances around memory consistency.

This is inspired by the impending rp2350, where the `atomic` is potentially misleading currently.

~I only updated one board for the moment, but will do the rest if folks agree this makes sense.~ Everything is ported over now.

### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

Thoughts?


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
