### PR TITLE
[RFC,WIP] Render documentation in `docs/` subtree into Rustdoc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ members = [
     "chips/stm32f4xx",
     "chips/veer_el2",
     "chips/virtio",
+    "doc",
     "kernel",
     "libraries/enum_primitive",
     "libraries/riscv-csr",

--- a/doc/Cargo.toml
+++ b/doc/Cargo.toml
@@ -1,0 +1,11 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2022.
+
+[package]
+name = "tock-docs"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+
+[dependencies]

--- a/doc/src/lib.rs
+++ b/doc/src/lib.rs
@@ -1,0 +1,30 @@
+//! Documentation crate for the Tock Operating System.
+//!
+//! This crate contains markdown documentation rendered into Rustdoc comments on
+//! modules, mirroring the documentation of the Tock kernel repositories `doc/`
+//! subdiretory. It is intended for non-code documentation, documentation that
+//! spans multiple components, and official reference documents.
+#![no_std]
+
+#[doc = include_str!("../reference/README.md")]
+pub mod reference {
+    #[doc = include_str!("../reference/trd1-trds.md")]
+    pub mod trd1_trds {}
+
+    #[doc = include_str!("../reference/trd101-time.md")]
+    pub mod trd101_time {}
+
+    // ...
+
+    #[doc = include_str!("../reference/trd104-syscalls.md")]
+    pub mod trd104_syscalls {}
+}
+
+#[doc = include_str!("../ExternalDependencies.md")]
+pub mod external_dependencies {}
+
+#[doc = include_str!("../syscalls/README.md")]
+pub mod syscalls {
+    #[doc = include_str!("../syscalls/90001_screen.md")]
+    pub mod syscall_90001_screen {}
+}

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -9,6 +9,7 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
+tock-docs = { path = "../doc" }
 tock-registers = { path = "../libraries/tock-register-interface" }
 tock-cells = { path = "../libraries/tock-cells" }
 tock-tbf = { path = "../libraries/tock-tbf" }

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -138,7 +138,7 @@ impl TryFrom<u8> for SyscallClass {
     }
 }
 
-/// Decoded system calls as defined in TRD104.
+/// Decoded system calls as [defined in TRD104](tock_docs::reference::trd104_syscalls).
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Syscall {
     /// Structure representing an invocation of the [`SyscallClass::Yield`]


### PR DESCRIPTION
### Pull Request Overview

This PR is an early-stage RFC, to get feedback on an admittedly pretty wacky idea.

Tock has extensive documentation in its `docs/` subtree. This documentation is different from the other forms of documentation we have:
- It isn't necessarily user-facing, so it doesn't quite belong into the Tock book.
- It isn't tied to one particular code component, so it shouldn't be an inline Rust comment.

As a result, this documentation is not currently rendered anywhere, like the regular Rustdocs or the book are.

It also makes cross-referencing it from other components inconvenient and clunky. For instance, as shown by https://github.com/tock/tock/pull/4542#discussion_r2252531263, if we want to reference any inline code comments from within the `docs/` files, we need to point to the rendered version of a potentially different revision, with a link that isn't necessarily stable (as it encodes the module path and name of the component we reference). Similarly, for referencing `docs/` files from within code comments, we'd reference the current `master` revision of a given Markdown document rendered by GitHub.

This PR proposes a way to both render this documentation, and allow code to cross-reference it directly, with checked references and having the rendered docs-revision correspond to the revision of the code referencing it. It does so by introducing a new `tock-docs` crate in the `doc/` subdirectory, with a synthetic module hierarchy mirroring the various Markdown files in that directory, and including their content as their module-level documentation.

This allows us to have the documentation rendered and accessible under `docs.tockos.org/tock_docs`, and even allows other crates to depend on it and reference it directly. For the example of https://github.com/tock/tock/pull/4542#discussion_r2252531263, it could allow us to have the authoritative documentation of an interface live at e.g., `doc/syscalls/90001_screen.md`, and have Rust components implementing this interface reference that documentation by referring to the corresponding `tock_docs` module.

### Testing Strategy

N/A


### TODO or Help Wanted

This pull request is still in an early, RFC stage.

To get it over the finish line, we'd first need to decide if this is something we'd want to have, generally.

It still has a few issues: generating the synthetic module hierarchy is a manual task right now. Additionally, links in included Markdown documents don't resolve correctly yet. I think we could address these challenges pretty easily by generating this module automatically using a proc macro, and rewriting the internal Markdown links to point to the proper Rustdoc modules instead.

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
