### PR TITLE
Fix broken link in docs

### DIFF
--- a/doc/syscalls/README.md
+++ b/doc/syscalls/README.md
@@ -28,7 +28,7 @@ provided syscalls, and the driver specific interfaces (using `allow`,
 
 ## Syscall Binary Interface
 
-Details of the [application binary interface](../Syscalls.md).
+Details of the [application binary interface](https://book.tockos.org/doc/syscalls.html).
 
 ## Core Kernel Provided Syscalls
 


### PR DESCRIPTION
### Pull Request Overview

b98f638 moved the Syscalls to the book, but missed updating this link

### Testing Strategy

N/A

### TODO or Help Wanted

N/A

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
