### PR TITLE
`kernel/utilties/SubSlice`: various API & doc improvements

### DIFF
--- a/capsules/extra/src/bus.rs
+++ b/capsules/extra/src/bus.rs
@@ -299,7 +299,7 @@ impl<'a, A: BusAddr, S: SpiMasterDevice<'a>> Bus<'a, A> for SpiMasterBus<'a, S> 
                     buffer.slice(0..addr.len());
                     self.status.set(BusStatus::SetAddress);
                     buffer
-                        .as_slice()
+                        .as_mut_slice()
                         .iter_mut()
                         .zip(bytes)
                         .for_each(|(d, s)| *d = s);

--- a/capsules/extra/src/kv_store_permissions.rs
+++ b/capsules/extra/src/kv_store_permissions.rs
@@ -139,7 +139,7 @@ impl<'a, K: kv::KV<'a>> KVStorePermissions<'a, K> {
         };
 
         // Copy in the header to the buffer.
-        header.copy_to_buf(value.as_slice());
+        header.copy_to_buf(value.as_mut_slice());
 
         self.operation.set(operation);
 
@@ -453,7 +453,7 @@ impl<'a, K: kv::KV<'a>> kv::KVClient for KVStorePermissions<'a, K> {
 
                     if !read_allowed {
                         // Access denied or the header is invalid, zero the buffer.
-                        value.as_slice().iter_mut().for_each(|m| *m = 0)
+                        value.as_mut_slice().iter_mut().for_each(|m| *m = 0)
                     }
 
                     self.client.map(move |cb| {

--- a/capsules/extra/src/lpm013m126.rs
+++ b/capsules/extra/src/lpm013m126.rs
@@ -271,11 +271,14 @@ impl<'a> FrameBuffer<'a> {
     }
 
     fn rows(&mut self) -> impl Iterator<Item = RowMut> {
-        self.data.as_slice().chunks_mut(LINE_LEN).map_while(|c| {
-            c.get_mut(2..).map(|data| RowMut {
-                data: Cell::from_mut(data).as_slice_of_cells(),
+        self.data
+            .as_mut_slice()
+            .chunks_mut(LINE_LEN)
+            .map_while(|c| {
+                c.get_mut(2..).map(|data| RowMut {
+                    data: Cell::from_mut(data).as_slice_of_cells(),
+                })
             })
-        })
     }
 }
 

--- a/capsules/extra/src/sip_hash.rs
+++ b/capsules/extra/src/sip_hash.rs
@@ -256,7 +256,7 @@ impl<'a> Hasher<'a, 8> for SipHasher24<'a> {
         if hasher.ntail != 0 {
             needed = 8 - hasher.ntail;
             hasher.tail |=
-                u8to64_le(data.as_slice(), 0, cmp::min(length, needed)) << (8 * hasher.ntail);
+                u8to64_le(data.as_mut_slice(), 0, cmp::min(length, needed)) << (8 * hasher.ntail);
             if length < needed {
                 hasher.ntail += length;
                 return Ok(length);

--- a/capsules/extra/src/st77xx.rs
+++ b/capsules/extra/src/st77xx.rs
@@ -793,7 +793,7 @@ impl<'a, A: Alarm<'a>, B: Bus<'a, BusAddr8>, P: Pin> screen::Screen<'a> for ST77
         if self.status.get() == Status::Idle {
             // Data is provided as RGB565 ( RRRRR GGG | GGG BBBBB ), but the device expects it to come over the bus in little endian, so ( GGG BBBBB | RRRRR GGG ).
             // TODO(alevy): replace `chunks_mut` wit `array_chunks` when stable.
-            for pair in data.as_slice().chunks_mut(2) {
+            for pair in data.as_mut_slice().chunks_mut(2) {
                 pair.swap(0, 1);
             }
 

--- a/chips/apollo3/src/iom.rs
+++ b/chips/apollo3/src/iom.rs
@@ -602,19 +602,19 @@ impl<'a> Iom<'_> {
                     let d = self.registers.fifopop.get().to_ne_bytes();
                     let data_idx = self.read_index.get();
 
-                    if let Some(b) = buf.as_slice().get_mut(data_idx + 0) {
+                    if let Some(b) = buf.as_mut_slice().get_mut(data_idx + 0) {
                         *b = d[0];
                         self.read_index.set(data_idx + 1);
                     }
-                    if let Some(b) = buf.as_slice().get_mut(data_idx + 1) {
+                    if let Some(b) = buf.as_mut_slice().get_mut(data_idx + 1) {
                         *b = d[1];
                         self.read_index.set(data_idx + 2);
                     }
-                    if let Some(b) = buf.as_slice().get_mut(data_idx + 2) {
+                    if let Some(b) = buf.as_mut_slice().get_mut(data_idx + 2) {
                         *b = d[2];
                         self.read_index.set(data_idx + 3);
                     }
-                    if let Some(b) = buf.as_slice().get_mut(data_idx + 3) {
+                    if let Some(b) = buf.as_mut_slice().get_mut(data_idx + 3) {
                         *b = d[3];
                         self.read_index.set(data_idx + 4);
                     }

--- a/chips/lowrisc/src/spi_host.rs
+++ b/chips/lowrisc/src/spi_host.rs
@@ -262,7 +262,7 @@ impl SpiHost<'_> {
                             break;
                         }
                         val8 = ((val32 & shift_mask) >> (i * 8)) as u8;
-                        if let Some(ptr) = rx_buf.as_slice().get_mut(self.rx_offset.get()) {
+                        if let Some(ptr) = rx_buf.as_mut_slice().get_mut(self.rx_offset.get()) {
                             *ptr = val8;
                         } else {
                             // We have run out of rx buffer size
@@ -293,7 +293,7 @@ impl SpiHost<'_> {
         if self
             .tx_buf
             .take()
-            .map(|mut tx_buf| -> Result<(), ErrorCode> {
+            .map(|tx_buf| -> Result<(), ErrorCode> {
                 let regs = self.registers;
                 let mut t_byte: u32;
                 let mut tx_slice: [u8; 4];

--- a/kernel/src/utilities/leasable_buffer.rs
+++ b/kernel/src/utilities/leasable_buffer.rs
@@ -333,6 +333,44 @@ impl<'a, T> SubSliceMut<'a, T> {
         self.as_mut_slice().as_mut_ptr()
     }
 
+    /// Returns the bounds of the currently accessible `SubSliceMut` window,
+    /// relative to the underlying, internal buffer.
+    ///
+    /// This method can be used to re-construct a `SubSliceMut`, retaining its
+    /// active window, after `take()`ing its internal buffer. This is useful for
+    /// performing nested sub-slicing and interoperability with interfaces that take
+    /// a `&[u8]` buffer with an offset and length.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// use kernel::utilities::leasable_buffer::SubSliceMut;
+    /// let mut buffer: [u8; 8] = [0, 1, 2, 3, 4, 5, 6, 7];
+    ///
+    /// // Construct a SubSliceMut and activate a window:
+    /// let mut original_subslicemut = SubSliceMut::new(&mut buffer[..]);
+    /// original_subslicemut.slice(3..5);
+    /// assert!(original_subslicemut.as_slice() == &[3, 4]);
+    ///
+    /// // Destruct the SubSliceMut, extracting its underlying buffer, but
+    /// // remembering its active range:
+    /// let remembered_range = original_subslicemut.active_range();
+    /// let extracted_buffer = original_subslicemut.take();
+    /// assert!(remembered_range == (3..5));
+    ///
+    /// // Construct a new SubSliceMut, over the original buffer, with identical
+    /// // bounds:
+    /// let mut reconstructed_subslicemut = SubSliceMut::new(extracted_buffer);
+    /// reconstructed_subslicemut.slice(remembered_range);
+    ///
+    /// // The new, reconstructed SubSliceMut's window is identical to the
+    /// // original one's:
+    /// assert!(reconstructed_subslicemut.as_slice() == &[3, 4]);
+    /// ```
+    pub fn active_range(&self) -> Range<usize> {
+        self.active_range.clone()
+    }
+
     /// Returns a slice of the currently accessible portion of the
     /// LeasableBuffer.
     pub fn as_slice(&self) -> &[T] {
@@ -467,6 +505,44 @@ impl<'a, T> SubSlice<'a, T> {
     /// to try to use a sliced LeasableBuffer.
     pub fn is_sliced(&self) -> bool {
         self.internal.len() != self.len()
+    }
+
+    /// Returns the bounds of the currently accessible `SubSlice` window,
+    /// relative to the underlying, internal buffer.
+    ///
+    /// This method can be used to re-construct a `SubSlice`, retaining its
+    /// active window, after `take()`ing its internal buffer. This is useful for
+    /// performing nested sub-slicing and interoperability with interfaces that take
+    /// a `&[u8]` buffer with an offset and length.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// use kernel::utilities::leasable_buffer::SubSlice;
+    /// let mut buffer: [u8; 8] = [0, 1, 2, 3, 4, 5, 6, 7];
+    ///
+    /// // Construct a SubSlice and activate a window:
+    /// let mut original_subslicemut = SubSlice::new(&mut buffer[..]);
+    /// original_subslicemut.slice(3..5);
+    /// assert!(original_subslicemut.as_slice() == &[3, 4]);
+    ///
+    /// // Destruct the SubSlice, extracting its underlying buffer, but
+    /// // remembering its active range:
+    /// let remembered_range = original_subslicemut.active_range();
+    /// let extracted_buffer = original_subslicemut.take();
+    /// assert!(remembered_range == (3..5));
+    ///
+    /// // Construct a new SubSlice, over the original buffer, with identical
+    /// // bounds:
+    /// let mut reconstructed_subslicemut = SubSlice::new(extracted_buffer);
+    /// reconstructed_subslicemut.slice(remembered_range);
+    ///
+    /// // The new, reconstructed SubSlice's window is identical to the
+    /// // original one's:
+    /// assert!(reconstructed_subslicemut.as_slice() == &[3, 4]);
+    /// ```
+    pub fn active_range(&self) -> Range<usize> {
+        self.active_range.clone()
     }
 
     /// Reduces the range of the SubSlice that is accessible.

--- a/kernel/src/utilities/leasable_buffer.rs
+++ b/kernel/src/utilities/leasable_buffer.rs
@@ -296,14 +296,6 @@ impl<'a, T> SubSliceMut<'a, T> {
         }
     }
 
-    fn active_slice(&self) -> &[T] {
-        &self.internal[self.active_range.clone()]
-    }
-
-    fn active_slice_mut(&mut self) -> &mut [T] {
-        &mut self.internal[self.active_range.clone()]
-    }
-
     /// Retrieve the raw buffer used to create the SubSlice. Consumes the
     /// SubSlice.
     pub fn take(self) -> &'a mut [T] {
@@ -326,21 +318,27 @@ impl<'a, T> SubSliceMut<'a, T> {
 
     /// Returns the length of the currently accessible portion of the SubSlice.
     pub fn len(&self) -> usize {
-        self.active_slice().len()
+        self.as_slice().len()
     }
 
     /// Returns a pointer to the currently accessible portion of the SubSlice.
     pub fn as_ptr(&self) -> *const T {
-        self.active_slice().as_ptr()
+        self.as_slice().as_ptr()
     }
 
     pub fn as_mut_ptr(&mut self) -> *mut T {
-        self.active_slice_mut().as_mut_ptr()
+        self.as_mut_slice().as_mut_ptr()
     }
 
     /// Returns a slice of the currently accessible portion of the
     /// LeasableBuffer.
-    pub fn as_slice(&mut self) -> &mut [T] {
+    pub fn as_slice(&self) -> &[T] {
+        &self.internal[self.active_range.clone()]
+    }
+
+    /// Returns a mutable slice of the currently accessible portion of
+    /// the LeasableBuffer.
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
         &mut self.internal[self.active_range.clone()]
     }
 
@@ -422,10 +420,6 @@ impl<'a, T> SubSlice<'a, T> {
         }
     }
 
-    fn active_slice(&self) -> &[T] {
-        &self.internal[self.active_range.clone()]
-    }
-
     /// Retrieve the raw buffer used to create the SubSlice. Consumes the
     /// SubSlice.
     pub fn take(self) -> &'a [T] {
@@ -448,12 +442,12 @@ impl<'a, T> SubSlice<'a, T> {
 
     /// Returns the length of the currently accessible portion of the SubSlice.
     pub fn len(&self) -> usize {
-        self.active_slice().len()
+        self.as_slice().len()
     }
 
     /// Returns a pointer to the currently accessible portion of the SubSlice.
     pub fn as_ptr(&self) -> *const T {
-        self.active_slice().as_ptr()
+        self.as_slice().as_ptr()
     }
 
     /// Returns a slice of the currently accessible portion of the

--- a/kernel/src/utilities/leasable_buffer.rs
+++ b/kernel/src/utilities/leasable_buffer.rs
@@ -321,11 +321,14 @@ impl<'a, T> SubSliceMut<'a, T> {
         self.as_slice().len()
     }
 
-    /// Returns a pointer to the currently accessible portion of the SubSlice.
+    /// Returns a const pointer to the currently accessible portion of the
+    /// SubSlice.
     pub fn as_ptr(&self) -> *const T {
         self.as_slice().as_ptr()
     }
 
+    /// Returns a mutable pointer to the currently accessible portion of the
+    /// SubSlice.
     pub fn as_mut_ptr(&mut self) -> *mut T {
         self.as_mut_slice().as_mut_ptr()
     }


### PR DESCRIPTION
### Pull Request Overview

This pull request contains some `SubSlice` / `SubSliceMut` API improvements:

- **kernel/utilities/SubSlice: remove redundant internal active_slice fns**

  `SubSlice` / `SubSliceMut` had some internal `active_slice` functions which
  were identical to the public `as_slice` method implementations.

  However, `SubSliceMut` only featured `as_slice`, and did not have an
  additional `as_slice_mut`, which is inconsistent with Rust's standard library
  patterns around such interfaces. I've changed `as_slice` to return an
  immutable / shared reference, identical to the implementation of `SubSlice`,
  and fixed existing uses of that API to use the new `as_mut_slice` API instead.

- **kernel/utilities/SubSlice: add docs for `as_mut_ptr` function**

  Adds some docs to this lone undocumented function.

- **kernel/utilities/SubSlice: add `active_range` method for subslicing**

  Allows a developer to query the current active range / window, without using
  any pointer arithmetic on the returned slice. This is important to perform DMA
  operations on the SubSlice (in order to get an offset that can be passed to
  the hardware), or to perform nested subslicing, where a layer remembers the
  current active window, further slices into it, but restoring the original
  window on the upcall path.

### Testing Strategy

`active_range` features doctests.


### TODO or Help Wanted

N/A


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
