### PR TITLE
kernel: process loading: Fix bug where using all process slots loops forever

### DIFF
--- a/kernel/src/process_loading.rs
+++ b/kernel/src/process_loading.rs
@@ -277,6 +277,7 @@ fn load_processes_from_flash<C: Chip, D: ProcessStandardDebug + 'static>(
                 if config::CONFIG.debug_load_processes {
                     debug!("No more process slots to load processes into.");
                 }
+                break;
             }
         }
     }


### PR DESCRIPTION


### Pull Request Overview

If there is no additional slot to store loaded processes, then break the loading loop. This fixes a bug where reaching the maximum number of processes would cause the kernel to loop forever.


### Testing Strategy

Running 4 apps on QEMU and wondering why QEMU no longer runs.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
