### PR TITLE
doc: Fix table formatting in TRD-spi

### DIFF
--- a/doc/reference/trd-spi.md
+++ b/doc/reference/trd-spi.md
@@ -137,14 +137,12 @@ is too small), `set_rate` MUST return `Err(INVAL)`.
 The relationship of phase and polarity follows the standard SPI
 specification[1]:
 
-+------------+------------------+-------------+----------------+----------------+
 |  Polarity  |      Phase       |  Idle Level |    Data Out    |     Data In    |
-+------------+------------------+-------------+----------------+----------------+
+|------------|------------------|-------------|----------------|----------------|
 |  IdleLow   |  SampleLeading   |     Low     |  Rising Edge   |  Falling Edge  |
 |  IdleLow   |  SampleTrailing  |     Low     |  Falling Edge  |  Rising Edge   |
 |  IdleHigh  |  SampleLeading   |     High    |  Rising Edge   |  Rising Edge   |
 |  IdleHigh  |  SampleTrailing  |     High    |  Falling Edge  |  Falling Edge  |
-+------------+------------------+-------------+----------------+----------------+
 
 If the SPI bus is in the middle an outstanding operation
 (`Controller::read_write_bytes` or `Peripheral::read_write_bytes`),


### PR DESCRIPTION
### Pull Request Overview

This fixes a formatting issue where the table in TRD-spi comes out garbled:

<img width="500" alt="Screenshot 2025-08-12 at 17-10-06 TRD SPI - The Tock Book" src="https://github.com/user-attachments/assets/0432455d-9ae2-4705-b6f5-8bbc72f85d32" />

### Testing Strategy

Tested by rebuilding the Tock Book with a symlink to the actual file rather than going through the web; maybe you have better ways of doing this test:

```patch
diff --git a/src/trd/trd-spi.md b/src/trd/trd-spi.md
deleted file mode 100644
index ce05cb8..0000000
--- a/src/trd/trd-spi.md
+++ /dev/null
@@ -1 +0,0 @@
-{{#webinclude https://raw.githubusercontent.com/tock/tock/master/doc/reference/trd-spi.md}}
diff --git a/src/trd/trd-spi.md b/src/trd/trd-spi.md
new file mode 120000
index 0000000..3cc2267
--- /dev/null
+++ b/src/trd/trd-spi.md
@@ -0,0 +1 @@
+../../../tock/doc/reference/trd-spi.md
\ No newline at end of file
```

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.