### PR TITLE
boards: cy8cproto_62_4343_w: use probe-rs

### DIFF
--- a/boards/cy8cproto_62_4343_w/Makefile
+++ b/boards/cy8cproto_62_4343_w/Makefile
@@ -4,7 +4,6 @@
 
 include ../Makefile.common
 
-OPENOCD_OPTIONS= -s ${OPENOCD_ROOT}/scripts -f openocd.cfg
 # Define the path to the TBF file to flash an application
 APP=
 KERNEL=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/release/$(PLATFORM).elf
@@ -13,9 +12,10 @@ KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/release/$(PLATFORM)-app.
 install: flash
 .PHONY: install
 
-flash: release
-	${OPENOCD_ROOT}/bin/openocd $(OPENOCD_OPTIONS) -c "program $(KERNEL); verify_image $(KERNEL); reset; shutdown"
 .PHONY: flash
+flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+	probe-rs download --chip CY8C624AAZI-S2D44 --binary-format bin --base-address 0x10000000 $<
+
 
 .PHONY: program
 program: release

--- a/boards/cy8cproto_62_4343_w/README.md
+++ b/boards/cy8cproto_62_4343_w/README.md
@@ -7,12 +7,13 @@ The [Cypress CY8CPROTO-062-4343W](https://www.infineon.com/cms/en/product/evalua
 
 ## Getting started
 
-1. Download the [Infineon Customized OpenOCD](https://github.com/Infineon/openocd/releases/latest)
-2. Set OPENOCD_ROOT to the directory from extracted archive.
-3. Connect the computer to the `KitProg3` USB connector.
-4. Add the udev rule for `KitProg3`:
-```bash
-$ sudo bash -c "echo 'ATTRS{idVendor}==\"04b4\", ATTRS{idProduct}==\"f155\", MODE=\"0666\"' > /etc/udev/rules.d/99-kitprog3.rules"
+Install `probe-rs`.
+
+```
+cargo install probe-rs-tools
+
+# on macOS:
+brew install probe-rs
 ```
 
 ## Flashing the kernel
@@ -29,4 +30,4 @@ Apps are built out-of-tree. Once an app is built, you must add the path to the g
 $ make program
 ```
 
-This will generate a new ELF file that can be deployed on the CY8CPROTO-062-4343W via gdb and OpenOCD.
+This will generate a new ELF file that can be deployed on the CY8CPROTO-062-4343W via gdb and probe-rs.

--- a/boards/cy8cproto_62_4343_w/openocd.cfg
+++ b/boards/cy8cproto_62_4343_w/openocd.cfg
@@ -1,8 +1,0 @@
-# Licensed under the Apache License, Version 2.0 or the MIT License.
-# SPDX-License-Identifier: Apache-2.0 OR MIT
-# Copyright OxidOS Automotive 2025 SRL.
-#
-# OpenOCD configuration for the CY8CPROTO-062 development board
-
-source [find interface/kitprog3.cfg]
-source [find target/psoc6_2m.cfg]


### PR DESCRIPTION
### Pull Request Overview

Having to install a custom openocd is clunky compared to just using probe-rs.


### Testing Strategy

Flashing the kernel using probe-rs on this board.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
