### PR TITLE
DeferredCall: Port to `SingleThreadValue`

### DIFF
--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -217,9 +217,8 @@ pub extern "C" fn _start_trap() {
 ///
 /// 1. atomically swap s0 and the mscratch CSR,
 ///
-/// 2. execute the default kernel trap handler if s0 now contains `0`
-/// (meaning that the mscratch CSR contained `0` before entering this trap
-/// handler),
+/// 2. execute the default kernel trap handler if s0 now contains `0` (meaning
+///    that the mscratch CSR contained `0` before entering this trap handler),
 ///
 /// 3. otherwise, save s1 to `0*4(s0)`, and finally
 ///
@@ -233,6 +232,15 @@ pub extern "C" fn _start_trap() {
 /// will not execute an mret instruction). It will not modify CSRs that
 /// contain information on the trap source or the system state prior to
 /// entering the trap handler.
+///
+/// Before a trap handler executes any Rust code, or code that can
+/// transititively call any Rust code, it must indicate that a trap handler is
+/// currently active by writing an MXLEN-sized (usize), non-zero value to the
+/// address at `_trap_handler_active + (MXLEN / 8) * mhartid`. Before leaving
+/// the trap handler using `mret`, but after any Rust code has run, it must
+/// reset the value at this address back to zero. This is used to accurately
+/// determine the running thread ID, taking trap handlers into account as a
+/// separate thread.
 ///
 /// We deliberately clobber callee-saved instead of caller-saved registers,
 /// as this makes it easier to call other functions as part of the trap
@@ -325,9 +333,9 @@ pub extern "C" fn _start_trap() {
     // Restore s0. We reset mscratch to 0 (kernel trap handler mode)
     csrrw s0, mscratch, zero    // s0 = mscratch; mscratch = 0
 
-    // Make room for the caller saved registers we need to restore after
-    // running any trap handler code.
-    addi sp, sp, -16*4
+    // Make room for the caller saved registers we need to restore after running
+    // any trap handler code.
+    addi sp, sp, -20*4
 
     // Save all of the caller saved registers.
     sw   ra, 0*4(sp)
@@ -347,12 +355,33 @@ pub extern "C" fn _start_trap() {
     sw   a6, 14*4(sp)
     sw   a7, 15*4(sp)
 
+    // Save one callee-saved register (s0), which we place the address of
+    // the hart-specific 'are we in a trap handler' flag in:
+    sw   s0, 16*4(sp)
+
+    // Determine the address of the hart-specific 'are we in a trap handler'
+    // flag as an offset to the _trap_handler_active symbol. The chip crate
+    // is responsible for defining this symbol, and ensuring it is large
+    // enough to fit `max(mhartid) * MXLEN` bytes.
+    la   s0, _trap_handler_active // s0 = addr(_trap_handler_active)
+    csrr t0, mhartid              // t0 = hartid
+    slli t0, t0, 2                // t0 = t0 * 4
+    add  s0, s0, t0               // s0 = addr(_trap_handler_active[hartid])
+
+    // Indicate that we are in a trap handler on this hart:
+    li   t0, 1
+    sw   t0, 0(s0)
+
     // Jump to board-specific trap handler code. Likely this was an
     // interrupt and we want to disable a particular interrupt, but each
     // board/chip can customize this as needed.
     jal ra, _start_trap_rust_from_kernel
 
-    // Restore the registers from the stack.
+    // Indicate that we are no longer going to be in a trap handler on this
+    // hart:
+    sw   x0, 0(s0)
+
+    // Restore the caller saved registers from the stack.
     lw   ra, 0*4(sp)
     lw   t0, 1*4(sp)
     lw   t1, 2*4(sp)
@@ -370,8 +399,12 @@ pub extern "C" fn _start_trap() {
     lw   a6, 14*4(sp)
     lw   a7, 15*4(sp)
 
+    // Restore the one callee-saved register (s0), which used to hold the
+    // address of the hart-specific 'are we in a trap handler flag':
+    lw   s0, 16*4(sp)
+
     // Reset the stack pointer.
-    addi sp, sp, 16*4
+    addi sp, sp, 20*4
 
     // mret returns from the trap handler. The PC is set to what is in
     // mepc and execution proceeds from there. Since we did not modify

--- a/arch/riscv/src/support.rs
+++ b/arch/riscv/src/support.rs
@@ -61,3 +61,76 @@ pub fn nop() {
 pub unsafe fn wfi() {
     unimplemented!()
 }
+
+pub enum RiscvThreadIdProvider {}
+unsafe impl kernel::platform::chip::ThreadIdProvider for RiscvThreadIdProvider {
+    /// Return the current thread ID, computed using the `mhartid` (hardware thread
+    /// ID), and a flag indicating whether the current hart is currently in a trap
+    /// handler context.
+    fn running_thread_id() -> usize {
+        // Mock implementation for non-rv32 target builds:
+        #[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
+        {
+            unimplemented!()
+        }
+
+        // Proper rv32i-specific implementation:
+        #[cfg(all(target_arch = "riscv32", target_os = "none"))]
+        {
+            let hartid: usize;
+            let trap_handler_active_addr: *mut usize;
+
+            // Safety:
+            //
+            // This does not read any memory by itself, it merely loads a symbol
+            // address and reads the `mhartid` CSR:
+            unsafe {
+                core::arch::asm!(
+                    // Determine the hart id and save in the appropriate output
+                    // register:
+                    "csrr {hartid_reg}, mhartid",
+                    // Load the `_trap_handler_active` symbol address:
+                    "la {trap_handler_active_addr_reg}, _trap_handler_active",
+                    hartid_reg = out(reg) hartid,
+                    trap_handler_active_addr_reg = out(reg) trap_handler_active_addr,
+                    options(
+                    // The assembly code has no side effects, must eventually
+                    // return, and its outputs depend only on its direct inputs
+                    // (i.e. the values themselves, not what they point to) or
+                    // values read from memory (unless the nomem options is also
+                    // set).
+                    pure,
+                    // The assembly code does not read from or write to any memory
+                    // accessible outside of the assembly code.
+                    nomem,
+                    // The assembly code does not modify the flags register (for
+                    // RISC-V: `fflags`, `vtype`, `vl`, or `vcsr`).
+                    preserves_flags,
+                    // The assembly code does not push data to the stack, or write
+                    // to the stack red-zone (if supported by the target).
+                    nostack,
+                    ),
+                );
+            }
+
+            // Load the hart's trap_handler_active value.
+            //
+            // Safety:
+            //
+            // `hartid` * core::mem::size_of::<usize>() must fit into an `isize`. By
+            // allocating the `_trap_handler_active` array, the chip crate ensures
+            // that this array can fit all hart IDs for all harts on the target
+            // machine. The maximum size of any Rust allocation is `isize::MAX`
+            // bytes, and as such, by allocating this arrary in the first place, the
+            // chip crate maintains that indexing into it with `hartid` must stay in
+            // this object, and an index of `hartid` elements will not produce an
+            // offset larger than `isize::MAX` bytes.
+            let hart_trap_handler_active =
+                unsafe { core::ptr::read(trap_handler_active_addr.add(hartid)) };
+
+            // Determine the thread ID as a combination of the hart id, and whether
+            // it is currently in a trap handler context:
+            hartid.overflowing_shl(1).0 | ((hart_trap_handler_active != 0) as usize)
+        }
+    }
+}

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -85,6 +85,7 @@ use kernel::process::ProcessArray;
 use kernel::scheduler::round_robin::RoundRobinSched;
 #[allow(unused_imports)]
 use kernel::{capabilities, create_capability, debug, debug_gpio, debug_verbose, static_init};
+use nrf52840::chip::NRF52ThreadIdProvider;
 use nrf52840::gpio::Pin;
 use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
 use nrf52_components::{UartChannel, UartPins};
@@ -408,6 +409,9 @@ pub unsafe fn start_no_pconsole() -> (
 
     // Apply errata fixes and enable interrupts.
     nrf52840::init();
+
+    // Initialize deferred calls very early.
+    kernel::deferred_call::initialize_deferred_call_state::<NRF52ThreadIdProvider>();
 
     // Set up peripheral drivers. Called in separate function to reduce stack
     // usage.

--- a/chips/qemu_rv32_virt_chip/src/chip.rs
+++ b/chips/qemu_rv32_virt_chip/src/chip.rs
@@ -114,6 +114,7 @@ impl<'a, I: InterruptService + 'a> QemuRv32VirtChip<'a, I> {
 impl<'a, I: InterruptService + 'a> Chip for QemuRv32VirtChip<'a, I> {
     type MPU = QemuRv32VirtPMP;
     type UserspaceKernelBoundary = rv32i::syscall::SysCall;
+    type ThreadIdProvider = rv32i::support::RiscvThreadIdProvider;
 
     fn mpu(&self) -> &Self::MPU {
         &self.pmp
@@ -282,3 +283,16 @@ pub unsafe extern "C" fn disable_interrupt_trap_handler(mcause_val: u32) {
         }
     }
 }
+
+/// Array used to track the "trap handler active" state per hart.
+///
+/// The `riscv` crate requires chip crates to allocate an array to
+/// track whether any given hart is currently in a trap handler. The
+/// array must be zero-initialized.
+///
+/// While the QEMU rv32 virt target supports multiple harts, Tock
+/// currently always runs on the first hart, with ID zero. Hence, we
+/// allocate an array of `usizes` with length one for this purpose,
+/// intialized to zero:
+#[export_name = "_trap_handler_active"]
+static mut TRAP_HANDLER_ACTIVE: [usize; 1] = [0; 1];

--- a/kernel/src/deferred_call.rs
+++ b/kernel/src/deferred_call.rs
@@ -13,6 +13,21 @@
 //! component return the function call stack up to the scheduler, automatically
 //! being called again.
 //!
+//! Initialization
+//! --------------
+//!
+//! Before any [`DeferredCall`]s are created, the internal state used by the
+//! implementation must be initialized. Boards must initialize deferred calls
+//! by calling either [`initialize_deferred_call_state`] or
+//! [`initialize_deferred_call_state_unsafe`]. Depending on the hardware state
+//! available (i.e., atomic support), boards will only have one initialization
+//! routine available.
+//!
+//! On boards that must use the unsafe version
+//! ([`initialize_deferred_call_state_unsafe`]), they must be careful to only
+//! call [`initialize_deferred_call_state_unsafe`] once from the main execution
+//! thread to meet the safety requirements.
+//!
 //! Usage
 //! -----
 //!
@@ -53,11 +68,13 @@
 //! some_capsule.register();
 //! ```
 
+use crate::platform::chip::ThreadIdProvider;
+use crate::utilities::cells::MapCell;
 use crate::utilities::cells::OptionalCell;
+use crate::utilities::single_thread_value::SingleThreadValue;
 use core::cell::Cell;
 use core::marker::Copy;
 use core::marker::PhantomData;
-use core::ptr::addr_of;
 
 /// This trait should be implemented by clients which need to receive
 /// [`DeferredCall`]s.
@@ -117,19 +134,44 @@ impl DynDefCallRef<'_> {
 // thread. TODO: Once Tock decides on an approach to replace `static mut` with
 // some sort of `SyncCell`, migrate all three of these to that approach
 // (https://github.com/tock/tock/issues/1545).
-static mut CTR: Cell<usize> = Cell::new(0);
+static CTR: SingleThreadValue<Cell<usize>> = SingleThreadValue::new(Cell::new(0));
 
 /// This bitmask tracks which of the up to 32 existing deferred calls have been
 /// scheduled. Any bit that is set in that mask indicates the deferred call with
 /// its [`DeferredCall::idx`] field set to the index of that bit has been
 /// scheduled and not yet serviced.
-static mut BITMASK: Cell<u32> = Cell::new(0);
+static BITMASK: SingleThreadValue<Cell<u32>> = SingleThreadValue::new(Cell::new(0));
 
 /// An array that stores references to up to 32 `DeferredCall`s via the low-cost
 /// [`DynDefCallRef`].
 // This is a 256 byte array, but at least resides in `.bss`.
-static mut DEFCALLS: [OptionalCell<DynDefCallRef<'static>>; 32] =
-    [const { OptionalCell::empty() }; 32];
+static DEFCALLS: SingleThreadValue<MapCell<[OptionalCell<DynDefCallRef<'static>>; 32]>> =
+    SingleThreadValue::new(MapCell::new([const { OptionalCell::empty() }; 32]));
+
+/// Initialize the static state used by deferred calls.
+///
+/// This ensures it can safely be used as a global variable.
+#[cfg(target_has_atomic = "ptr")]
+pub fn initialize_deferred_call_state<P: ThreadIdProvider>() {
+    CTR.bind_to_thread::<P>();
+    BITMASK.bind_to_thread::<P>();
+    DEFCALLS.bind_to_thread::<P>();
+}
+
+/// Initialize the static state used by deferred calls.
+///
+/// This ensures it can safely be used as a global variable.
+///
+/// # Safety
+///
+/// Callers of this function must ensure that this function is never called
+/// concurrently with other calls to [`initialize_deferred_call_state_unsafe`].
+#[cfg(not(target_has_atomic = "ptr"))]
+pub unsafe fn initialize_deferred_call_state_unsafe<P: ThreadIdProvider>() {
+    CTR.bind_to_thread_unsafe::<P>();
+    BITMASK.bind_to_thread_unsafe::<P>();
+    DEFCALLS.bind_to_thread_unsafe::<P>();
+}
 
 pub struct DeferredCall {
     idx: usize,
@@ -138,30 +180,41 @@ pub struct DeferredCall {
 impl DeferredCall {
     /// Create a new deferred call with a unique ID.
     pub fn new() -> Self {
-        // SAFETY: No accesses to CTR are via an &mut, and the Tock kernel is
-        // single-threaded so all accesses will occur from this thread.
-        let ctr = unsafe { &*addr_of!(CTR) };
-        let idx = ctr.get();
-        ctr.set(idx + 1);
-        DeferredCall { idx }
+        if let Some(ctr) = CTR.get() {
+            let idx = ctr.get();
+            ctr.set(idx + 1);
+            DeferredCall { idx }
+        } else {
+            // If this panic occurs, the platform did not call
+            // `initialize_deferred_call_state()` or
+            // `initialize_deferred_call_state_unsafe()` before creating a
+            // DeferredCall.
+            //
+            // We panic here rather than return an option or result because
+            // there is no recourse for the caller. This is an unrecoverable
+            // issue in practice and a bug in the kernel. The board must call
+            // one of the initialization functions first.
+            panic!("DeferredCall state not initialized.");
+        }
     }
 
     // To reduce monomorphization bloat, the non-generic portion of register is
     // moved into this function without generic parameters.
     #[inline(never)]
     fn register_internal_non_generic(&self, handler: DynDefCallRef<'static>) {
-        // SAFETY: No accesses to DEFCALLS are via an &mut, and the Tock kernel
-        // is single-threaded so all accesses will occur from this thread.
-        let defcalls = unsafe { &*addr_of!(DEFCALLS) };
-        if self.idx >= defcalls.len() {
-            // This error will be caught by the scheduler at the beginning of
-            // the kernel loop, which is much better than panicking here, before
-            // the debug writer is setup. Also allows a single panic for
-            // creating too many deferred calls instead of NUM_DCS panics (this
-            // function is monomorphized).
-            return;
+        if let Some(defcalls_cell) = DEFCALLS.get() {
+            defcalls_cell.map(|defcalls| {
+                if self.idx >= defcalls.len() {
+                    // This error will be caught by the scheduler at the beginning of
+                    // the kernel loop, which is much better than panicking here, before
+                    // the debug writer is setup. Also allows a single panic for
+                    // creating too many deferred calls instead of NUM_DCS panics (this
+                    // function is monomorphized).
+                    return;
+                }
+                defcalls[self.idx].set(handler);
+            });
         }
-        defcalls[self.idx].set(handler);
     }
 
     /// This function registers the passed client with this deferred call, such
@@ -176,50 +229,56 @@ impl DeferredCall {
     /// Schedule a deferred callback on the client associated with this deferred
     /// call.
     pub fn set(&self) {
-        // SAFETY: No accesses to BITMASK are via an &mut, and the Tock kernel
-        // is single-threaded so all accesses will occur from this thread.
-        let bitmask = unsafe { &*addr_of!(BITMASK) };
-        bitmask.set(bitmask.get() | (1 << self.idx));
+        if let Some(bitmask) = BITMASK.get() {
+            bitmask.set(bitmask.get() | (1 << self.idx));
+        }
     }
 
     /// Check if a deferred callback has been set and not yet serviced on this
     /// deferred call.
     pub fn is_pending(&self) -> bool {
-        // SAFETY: No accesses to BITMASK are via an &mut, and the Tock kernel
-        // is single-threaded so all accesses will occur from this thread.
-        let bitmask = unsafe { &*addr_of!(BITMASK) };
-        bitmask.get() & (1 << self.idx) == 1
+        if let Some(bitmask) = BITMASK.get() {
+            bitmask.get() & (1 << self.idx) == 1
+        } else {
+            false
+        }
     }
 
     /// Services and clears the next pending [`DeferredCall`], returns which
     /// index was serviced.
     pub fn service_next_pending() -> Option<usize> {
-        // SAFETY: No accesses to BITMASK/DEFCALLS are via an &mut, and the Tock
-        // kernel is single-threaded so all accesses will occur from this
-        // thread.
-        let bitmask = unsafe { &*addr_of!(BITMASK) };
-        let defcalls = unsafe { &*addr_of!(DEFCALLS) };
-        let val = bitmask.get();
-        if val == 0 {
-            None
-        } else {
-            let bit = val.trailing_zeros() as usize;
-            let new_val = val & !(1 << bit);
-            bitmask.set(new_val);
-            defcalls[bit].map(|dc| {
-                dc.handle_deferred_call();
-                bit
+        if let Some(defcalls_cell) = DEFCALLS.get() {
+            defcalls_cell.map_or(None, |defcalls| {
+                if let Some(bitmask) = BITMASK.get() {
+                    let val = bitmask.get();
+                    if val == 0 {
+                        None
+                    } else {
+                        let bit = val.trailing_zeros() as usize;
+                        let new_val = val & !(1 << bit);
+                        bitmask.set(new_val);
+                        defcalls[bit].map(|dc| {
+                            dc.handle_deferred_call();
+                            bit
+                        })
+                    }
+                } else {
+                    None
+                }
             })
+        } else {
+            None
         }
     }
 
     /// Returns true if any deferred calls are waiting to be serviced, false
     /// otherwise.
     pub fn has_tasks() -> bool {
-        // SAFETY: No accesses to BITMASK are via an &mut, and the Tock kernel
-        // is single-threaded so all accesses will occur from this thread.
-        let bitmask = unsafe { &*addr_of!(BITMASK) };
-        bitmask.get() != 0
+        if let Some(bitmask) = BITMASK.get() {
+            bitmask.get() != 0
+        } else {
+            false
+        }
     }
 
     /// This function should be called at the beginning of the kernel loop to
@@ -243,20 +302,22 @@ impl DeferredCall {
     // IntoIterator is not implemented for OptionalCell.
     #[allow(clippy::iter_filter_is_some)]
     pub fn verify_setup() {
-        // SAFETY: No accesses to CTR/DEFCALLS are via an &mut, and the Tock
-        // kernel is single-threaded so all accesses will occur from this
-        // thread.
-        let ctr = unsafe { &*addr_of!(CTR) };
-        let defcalls = unsafe { &*addr_of!(DEFCALLS) };
-        let num_deferred_calls = ctr.get();
-        let num_registered_calls = defcalls.iter().filter(|opt| opt.is_some()).count();
-        if num_deferred_calls > defcalls.len() {
-            panic!("ERROR: too many deferred calls: {}", num_deferred_calls);
-        } else if num_deferred_calls != num_registered_calls {
-            panic!(
-                "ERROR: {} deferred calls, {} registered. A component may have forgotten to register a deferred call.",
-                num_deferred_calls, num_registered_calls
-            );
+        if let Some(defcalls_cell) = DEFCALLS.get() {
+            defcalls_cell.map(|defcalls| {
+                if let Some(ctr) = CTR.get() {
+                    let num_deferred_calls = ctr.get();
+                    let num_registered_calls = defcalls.iter().filter(|opt| opt.is_some()).count();
+                    if num_deferred_calls > defcalls.len() {
+                        panic!("ERROR: too many deferred calls: {}", num_deferred_calls);
+                    } else if num_deferred_calls != num_registered_calls {
+                        panic!(
+                            "ERROR: {} deferred calls, {} registered. \
+A component may have forgotten to register a deferred call.",
+                            num_deferred_calls, num_registered_calls
+                        );
+                    }
+                }
+            });
         }
     }
 }

--- a/kernel/src/platform/chip.rs
+++ b/kernel/src/platform/chip.rs
@@ -20,6 +20,9 @@ pub trait Chip {
     /// The particular Memory Protection Unit (MPU) for this chip.
     type MPU: mpu::MPU;
 
+    /// Provider to query the currently running thread ID.
+    type ThreadIdProvider: ThreadIdProvider;
+
     /// The implementation of the interface between userspace and the kernel for
     /// this specific chip. Likely this is architecture specific, but individual
     /// chips may have various custom requirements.
@@ -68,6 +71,37 @@ pub trait Chip {
     /// the Display trait.
     /// Used by panic.
     unsafe fn print_state(&self, writer: &mut dyn Write);
+}
+
+/// Interface for retrieving the currently executing thread.
+///
+/// This is used to enforce correctness with shared state that has access
+/// restrictions (e.g., only a single thread can access a specific value).
+///
+/// Many embedded platforms are single-core and only permit a single execution
+/// thread at a time. However, interrupts can typically occur at any time, and
+/// the execution of an interrupt service routine (ISR) constitutes a second
+/// thread. Implementations of this trait must be able to differentiate between
+/// at minimum the main thread of execution and an ISR execution, but may also
+/// consider multiple execution threads if available on a particular device.
+///
+/// # Safety
+///
+/// This thread is marked as `unsafe` as implementation must guarantee its
+/// correctness. Users of this trait are allowed to make soundness guarantees
+/// based on the implementation being correct. Failing to provide a correct
+/// implementation can lead to unsound behavior. By implementing this trait,
+/// providers are guaranteeing the implementations are always correct for the
+/// given hardware platform.
+pub unsafe trait ThreadIdProvider {
+    /// Return a unique ID for the currently executing thread.
+    ///
+    /// The unique ID must fit in a `usize` and must be unique and consistent
+    /// for the currently running thread. The actual value is opaque and there
+    /// is no assumption about the meaning of the assigned IDs. Implementations
+    /// are allowed to arbitrarily assign IDs to threads as long as the IDs are
+    /// unique and consistent.
+    fn running_thread_id() -> usize;
 }
 
 /// Interface for handling interrupts on a hardware chip.

--- a/kernel/src/utilities/mod.rs
+++ b/kernel/src/utilities/mod.rs
@@ -14,6 +14,7 @@ pub mod machine_register;
 pub mod math;
 pub mod mut_imut_buffer;
 pub mod peripheral_management;
+pub mod single_thread_value;
 pub mod static_init;
 pub mod storage_volume;
 pub mod streaming_process_slice;

--- a/kernel/src/utilities/single_thread_value.rs
+++ b/kernel/src/utilities/single_thread_value.rs
@@ -1,0 +1,524 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+//! A container for objects accessible to a single thread.
+
+use core::cell::UnsafeCell;
+use core::mem::MaybeUninit;
+use core::sync::atomic::AtomicUsize;
+use core::sync::atomic::Ordering;
+
+use crate::platform::chip::ThreadIdProvider;
+
+/// Stages of binding a [`SingleThreadValue`] to a given thread.
+///
+/// The [`SingleThreadValue`] starts out not being bound to, and thus not being
+/// usable by any thread. Only after its construction will it be bound to a
+/// particular thread, using either the [`SingleThreadValue::bind_to_thread`],
+/// or the [`SingleThreadValue::bind_to_thread_unsafe`] methods.
+///
+/// For other these and other methods to know whether a [`SingleThreadValue`]
+/// has been bound to a thread already, and thus whether its `thread_id_and_fn`
+/// field is initialized and holds a stable, it contains an `AtomicUsize` type
+/// to indicate its current "binding stage". Over its lifetime, this stage value
+/// is strictly increasing, transitioning through its variants as per their
+/// documentation.
+#[repr(usize)]
+enum BoundToThreadStage {
+    /// This state means that the [`SingleThreadValue`] has not been bound to a
+    /// particular thread yet, and its `thread_id_and_fn` field is not
+    /// initialized.
+    ///
+    /// For the `bind_to_thread` and `bind_to_thread_unsafe` methods, this value
+    /// further means that the value can be bound to the currently running
+    /// thread.
+    Unbound = 0,
+
+    /// To bind a [`SingleThreadValue`] to the currently running thread, the
+    /// `bind_to_thread` function atomically transitions it from the `Unbound`
+    /// stage to the `Binding` stage, through a compare-exchange operation.
+    ///
+    /// When this stage is active, the `thread_id_and_fn` are not initialized,
+    /// similar to `Unbound`. However, it guards other, concurrent calls to
+    /// `bind_to_thread` from attempting to bind the value to another thread
+    /// concurrently.
+    ///
+    /// Targets without support for compare-exchange atomic operations on
+    /// `usize` types can utilize `bind_to_thread_unsafe` instead: this method
+    /// requires callers to guarantee that there are no concurrent calls to
+    /// either `bind_to_thread` OR `bind_to_thread_unsafe`. Thus, it can skip
+    /// this intermediate state: it can directly transition from `Unbound` into
+    /// `Bound`.
+    #[allow(dead_code)]
+    Binding = 1,
+
+    /// This value indicates that the [`SingleThreadValue`] is bound to a
+    /// particular thread. The `thread_id_and_fn` value is initialized and
+    /// sealed: it must not be modified any longer beyond this point, and no
+    /// mutable references may exist to it. The `Bound` state cannot be
+    /// transitioned out of.
+    Bound = 2,
+}
+
+/// A container for objects accessible to a single thread.
+///
+/// This type wraps a value of type `T: ?Sync`, accessible to only a single
+/// thread. Only that thread can obtain references to the contained value, and
+/// that thread may obtain multiple _shared_ (`&`) references to the value
+/// concurrently.
+///
+/// This container is [`Sync`], regardless of whether `T` is `Sync`. This is
+/// similar to the standard library's `LocalKey`, and thus appropriate for
+/// static allocations of values that are not themselves [`Sync`]. However,
+/// unlike `LocalKey`, it only holds a value for a single thread, determined at
+/// runtime based on the first call to [`SingleThreadValue::bind_to_thread`].
+///
+/// # Example
+///
+/// ```
+/// use core::cell::Cell;
+/// use kernel::utilities::single_thread_value::SingleThreadValue;
+///
+/// // Binding to a thread requires a "ThreadIdProvider", used to query the
+/// // thread ID of the currently running thread at runtime:
+/// enum DummyThreadIdProvider {}
+/// unsafe impl kernel::platform::chip::ThreadIdProvider for DummyThreadIdProvider {
+///     fn running_thread_id() -> usize {
+///         // Return the current thread id. We return a constant for
+///         // demonstration purposes, but doing so in practice is unsound:
+///         42
+///     }
+/// }
+///
+/// static FOO: SingleThreadValue<Cell<usize>> = SingleThreadValue::new(Cell::new(123));
+///
+/// fn main() {
+///     // Bind the value contained in the `SingleThreadValue` to the currently
+///     // running thread:
+///     FOO.bind_to_thread::<DummyThreadIdProvider>();
+///
+///     // Attempt to access the value. Returns `Some(&T)` if running from the
+///     // thread that the `SingleThreadValue` is bound to:
+///     let foo_ref = FOO.get().unwrap();
+///     foo_ref.set(foo_ref.get() + 1);
+/// }
+/// ```
+///
+/// After creating the [`SingleThreadValue`] and before trying to access the
+/// wrapped value, the [`SingleThreadValue`] must have its
+/// [`bind_to_thread`](SingleThreadValue::bind_to_thread) method called. Failing
+/// to bind it to a thread will prevent any access to the wrapped value.
+///
+/// # Single-thread Synchronization
+///
+/// It is possible for the same thread to get multiple, shared, references. As a
+/// result, users must use interior mutability (e.g.
+/// [`Cell`](core::cell::Cell), [`MapCell`](tock_cells::map_cell::MapCell), or
+/// [`TakeCell`](tock_cells::take_cell::TakeCell)) to allow obtaining exclusive
+/// mutable access.
+///
+/// # Guaranteeing Single-Thread Access
+///
+/// [`SingleThreadValue`] is safe because it guarantees that the value is only
+/// ever accessed from a single thread. To do this, [`SingleThreadValue`]
+/// inspects the currently running thread on every access to the wrapped
+/// value. If the active thread is different than the original thread then the
+/// caller will not be able to access the value.
+///
+/// This requires that the system provides a correct implementation of
+/// [`ThreadIdProvider`] to identify the currently executing thread. Internally,
+/// [`SingleThreadValue`] uses the [`ThreadIdProvider::running_thread_id`]
+/// function to identify the current thread and compares it against the thread
+/// ID that the contained value is bound to.
+//
+// # Implementation Trade-Offs
+//
+// Correctly implementing a type which can be safely shared within a single
+// thread requires balancing the following trade-offs:
+//
+// 1. Automated enforcement (either by the compiler or at runtime) vs.
+//    programmer-checked correctness.
+// 2. Runtime overhead vs. compile-time checks.
+// 3. Simplicity for users vs. easy-to-make mistakes.
+//
+// Ideally, the guarantees this type provides would be verified at compile time
+// and be simple for users to use. However, as of July 2025, we don't know how
+// to realistically meet those goals.
+//
+// This approach first chooses to have automated enforcement rather than have
+// correctness (and avoiding unsoundness) based only on carefully written code
+// and scrutiny during code reviews. This is generally consistent with the Tock
+// ethos with using Rust and APIs to enforce correctness, even if the check
+// occurs at runtime.
+//
+// To implement the automated check, this type uses runtime checks. We don't
+// know a realistic way to move those checks to compile time.
+//
+// One downside to these decisions is the need to bind the value to a thread
+// _after_ the type is created. While this is conceptually similar to providing
+// a callback client after an object is constructed, which is widely used in
+// Tock, forgetting this operation will lead to the runtime check always failing
+// and will break the desired functionality of using the wrapped value.
+// However, passing in the type later is needed because the thread identifier is
+// likely not available where users want to construct this type.
+//
+// Ultimately, these trade-offs, runtime checks and an interface where missing a
+// call leads to failures, were deemed acceptable and worth the upside
+// (guaranteed soundness). In part, this is because this type should be used and
+// accessed sparingly within Tock. The complexity of creating this type stems
+// from its general risky-ness: enabling sharing static global variables. While
+// necessary for certain use cases within Tock, this should not be used lightly.
+pub struct SingleThreadValue<T> {
+    /// The contained value, made accessible to a single thread only.
+    value: T,
+
+    /// Shared atomic state to indicate whether this type is already bound to a
+    /// particular thread, or in the process of being bound to a particular
+    /// thread. Assumes values of [`BoundToThreadStage`]. Consider that type's
+    /// documentation for how `bound_to_thread` is used.
+    bound_to_thread: AtomicUsize,
+
+    /// Context used to determine which thread ID this type is bound to, and how
+    /// to determine the currently running thread ID.
+    ///
+    /// This value must only be used in accordance with the rules around
+    /// [`BoundToThreadStage`]. Consider that type's documentation for more
+    /// information. Whether this value is initialized, and when it is safe to
+    /// read and write depend on the value of `bound_to_thread`.
+    thread_id_and_fn: UnsafeCell<MaybeUninit<(fn() -> usize, usize)>>,
+}
+
+/// Mark that [`SingleThreadValue`] is [`Sync`] to enable multiple accesses.
+///
+/// # Safety
+///
+/// This is safe because [`SingleThreadValue`] enforces that the shared value
+/// is only ever accessed from a single thread.
+unsafe impl<T> Sync for SingleThreadValue<T> {}
+
+impl<T> SingleThreadValue<T> {
+    /// Create a [`SingleThreadValue`].
+    ///
+    /// Note, the value will not be accessible immediately after `new()` runs.
+    /// It must first be bound to a particular thread, using the
+    /// [`bind_to_thread`](SingleThreadValue::bind_to_thread) or
+    /// [`bind_to_thread_unsafe`](SingleThreadValue::bind_to_thread_unsafe) methods.
+    pub const fn new(value: T) -> Self {
+        Self {
+            value,
+            bound_to_thread: AtomicUsize::new(BoundToThreadStage::Unbound as usize),
+            thread_id_and_fn: UnsafeCell::new(MaybeUninit::uninit()),
+        }
+    }
+
+    /// Bind this [`SingleThreadValue`] to the currently running thread.
+    ///
+    /// If not already bound to or currently in the process of binding to a
+    /// thread, this binds the [`SingleThreadValue`] to the current thread.
+    ///
+    /// It further records the [`ThreadIdProvider::running_thread_id`] function
+    /// reference, and uses this function to determine the currently running
+    /// thread for any future queries.
+    ///
+    /// Returns `true` if this invocation successfully bound the value to the
+    /// current thread. Otherwise, if the value was already bound to this same
+    /// or another thread, or is concurrently being bound to a thread, it
+    /// returns `false`.
+    ///
+    /// This method requires the target to support atomic operations
+    /// (namely, `compare_exchange`) on `usize`-sized values, and thus
+    /// relies on the `cfg(target_has_atomic = "ptr")` conditional.
+    #[cfg(target_has_atomic = "ptr")]
+    pub fn bind_to_thread<P: ThreadIdProvider>(&self) -> bool {
+        // For the check whether we're already bound to a thread, `Relaxed`
+        // ordering is fine: we don't actually care about the value in
+        // `thread_id_and_fn`, and don't need previous writes to it to be
+        // visible to this thread.
+        //
+        // Perform a compare-exchange on the `bound_to_thread` value. If this
+        // operation is successful, the [`SingleThreadValue`] was in the
+        // `Unbound` stage, but is now in the `Binding` stage. This "reserves"
+        // to be initialized: other concurrent accesses observing a `Binding`
+        // stage must not assume that `thread_id_and_fn` is initialized, but
+        // also will not attempt to being initialization themselves:
+        if let Ok(_) = self.bound_to_thread.compare_exchange(
+            // Expected current value:
+            BoundToThreadStage::Unbound as usize,
+            // New value:
+            BoundToThreadStage::Binding as usize,
+            // Success memory ordering:
+            Ordering::Relaxed,
+            // Failure memory ordering:
+            Ordering::Relaxed,
+        ) {
+            // Great, we have reserved the value for initialization!
+            //
+            // Write the current thread ID, and the function symbol used to
+            // query the currently running thread ID.
+            let ptr_thread_id_and_fn = self.thread_id_and_fn.get();
+
+            // Safety:
+            //
+            // We must ensure that there are no (mutable) aliases or concurrent
+            // reads or writes of the thread_id_and_fn value.
+            //
+            // This value is accessed in three functions:
+            // `bind_to_thread_unsafe`, `bind_to_thread`, and
+            // `bound_to_current_thread`:
+            //
+            // - `bind_to_thread_unsafe`: Callers of that function guarantee
+            //   that there are no concurrent invocations of it together with
+            //   our current function, `bind_to_thread`. Thus, no concurrent
+            //   call to that other function can hold an alias, or perform a
+            //   read or write of this value.
+            //
+            // - `bind_to_thread`: Before obtaining a reference to the
+            //   `thread_id_and_fn` value or reading/writing it, this function
+            //   performs a compare-exchange operation on the `bound_to_thread`
+            //   value, ensuring that it is currently `Unbound`, and atomtically
+            //   transitioning it towards `Binding`.
+            //
+            //   Our own compare-exchange operation on this value was
+            //   successful. As `Binding` cannot transition back to `Unbound`,
+            //   there can only be a single `bind_to_thread` call to
+            //   successfully perform this compare-exchange operation per
+            //   [`SingleThreadValue`].
+            //
+            //   If another concurrent call had performed this compare-exchange
+            //   successfully, our own operation would have failed. Given that
+            //   we successfully performed this operation, all other concurrent
+            //   calls to this function must fail this operation instead, and
+            //   thus will not take this if-branch, and therefore will not
+            //   attempt to access the `thread_id_and_fn` value.
+            //
+            // - `bound_to_current_thread`: This function is allowed to run
+            //   concurrently with `bind_to_thread`. However, it only accesses
+            //   the `thread_id_and_fn` value when the `bound_to_thread` atomic
+            //   contains `Bound`.
+            //
+            //   The compare and swap has transitioned this value from `Unbound`
+            //   to `Binding`, and no concurrent call can further *modify*
+            //   `bound_to_thread` other than our own function instance. This
+            //   currently running function will only transition the
+            //   `bound_to_thread` value from `Binding` to `Bound` once it has
+            //   initialized `thread_id_and_fn` and all references to it cease
+            //   to exist. Thus, no concurrent calls to
+            //   `bound_to_current_thread` will read the `thread_id_and_fn`
+            //   before that point.
+            //
+            // Hence this operation is safe.
+            unsafe {
+                *ptr_thread_id_and_fn =
+                    MaybeUninit::new((P::running_thread_id, P::running_thread_id()));
+            }
+
+            // When initializing the `SingleThreadValue`, we must use `Release`
+            // ordering on the `bound_to_thread` store. This ensures that any
+            // subsequent atomic load of this value with at least `Acquire`
+            // ordering constraints will observe the previous write to
+            // `thread_id_and_fn`).
+            self.bound_to_thread
+                .store(BoundToThreadStage::Bound as usize, Ordering::Release);
+
+            // We have successfully bound this `SingleThreadValue` to the
+            // currently running thread:
+            true
+        } else {
+            // We have failed to reserve the value for initialization, either
+            // because it was already bound to a thread, or is in the process of
+            // being bound to a thread by a concurrent call.
+            false
+        }
+    }
+
+    /// Bind this [`SingleThreadValue`] to the currently running thread.
+    ///
+    /// If not already bound to or currently in the process of binding to a
+    /// thread, this binds the [`SingleThreadValue`] to the current thread.
+    ///
+    /// It further records the [`ThreadIdProvider::running_thread_id`] function
+    /// reference, and uses this function to determine the currently running
+    /// thread for any future queries.
+    ///
+    /// Returns `true` if this invocation successfully bound the value to the
+    /// current thread. Otherwise, if the value was already bound to this same
+    /// or another thread, it returns `false`.
+    ///
+    /// This method is `unsafe`, and does not require the target to support
+    /// atomic operations (namely, `compare_exchange`) on `usize`-sized values.
+    ///
+    /// # Safety
+    ///
+    /// Callers of this function must ensure that this function is never called
+    /// concurrently with other calls to
+    /// [`bind_to_thread`](SingleThreadValue::bind_to_thread) or
+    /// [`bind_to_thread_unsafe`](SingleThreadValue::bind_to_thread_unsafe) on
+    /// the same [`SingleThreadValue`] instance.
+    pub unsafe fn bind_to_thread_unsafe<P: ThreadIdProvider>(&self) -> bool {
+        // For the check whether we're already bound to a thread, `Relaxed`
+        // ordering is fine: we don't actually care about the value in
+        // `thread_id_and_fn`, and don't need previous writes to it to be
+        // visible to this thread.
+        if self.bound_to_thread.load(Ordering::Relaxed) == BoundToThreadStage::Unbound as usize {
+            // Write the current thread ID, and the function symbol used to
+            // query the currently running thread ID.
+            let ptr_thread_id_and_fn = self.thread_id_and_fn.get();
+
+            // Safety:
+            //
+            // We must ensure that there are no (mutable) aliases or concurrent
+            // reads or writes of the `thread_id_and_fn` value.
+            //
+            // This value is accessed in three functions: `bind_to_thread`,
+            // `bind_to_thread_unsafe`, and `bound_to_current_thread`:
+            //
+            // - `bind_to_thread` & `bind_to_thread_unsafe`: Callers of this
+            //   current function guarantee that there are no concurrent
+            //   invocations of either `bind_to_thread` or
+            //   `bind_to_thread_unsafe` on the same `SingleThreadValue`
+            //   object. Thus, no concurrent call to either of these functions
+            //   can hold an alias, or perform a read or write of the
+            //   `thread_id_and_fn` value.
+            //
+            // - `bound_to_current_thread`: This function is allowed to run
+            //   concurrently with `bind_to_thread`. However, it only accesses
+            //   this value when the `bound_to_thread` atomic contains
+            //   `Bound`. `bound_to_current_thread` never writes to
+            //   `bound_to_thread`.
+            //
+            //   This current function has, before taking this if-branch,
+            //   checked that `bound_to_thread` is currently `Unbound`, and will
+            //   continue to be `Unbound` for the duration of the write to
+            //   `thread_id_and_fn`, as there are no concurrent calls to
+            //   `bind_to_thread` or `bind_to_thread_unsafe`. It only
+            //   transitions `bound_to_thread` to `Bound` after completing the
+            //   initialization of `thread_id_and_fn` and all references to that
+            //   value cease to exist.
+            //
+            // Thus, this operation is safe.
+            unsafe {
+                *ptr_thread_id_and_fn =
+                    MaybeUninit::new((P::running_thread_id, P::running_thread_id()));
+            }
+
+            // When initializing the `SingleThreadValue`, we must use `Release`
+            // ordering on the `bound_to_thread` store. This ensures that any
+            // subsequent atomic load of this value with at least `Acquire`
+            // ordering constraints will observe the previous write to
+            // `thread_id_and_fn`).
+            self.bound_to_thread
+                .store(BoundToThreadStage::Bound as usize, Ordering::Release);
+
+            // We have successfully bound this `SingleThreadValue` to the
+            // currently running thread:
+            true
+        } else {
+            // This value is already bound to a thread:
+            false
+        }
+    }
+
+    /// Check whether this `SingleThreadValue` instance is bound to the
+    /// currently running thread ID.
+    ///
+    /// Returns `true` if the value is bound to the thread that is currently
+    /// running (as determined by the implementation of `ThreadIdProvider` used
+    /// in [`bind_to_thread`](SingleThreadValue::bind_to_thread) or
+    /// [`bind_to_thread_unsafe`](SingleThreadValue::bind_to_thread_unsafe)). Returns
+    /// `false` when a different thread is executing, when it is not bound to
+    /// any thread yet, or currently in the process of being bound to a thread.
+    pub fn bound_to_current_thread(&self) -> bool {
+        // This function loads the `thread_id_and_fn` field, written by either
+        // `bind_to_thread` or `bind_to_thread_unsafe` before setting
+        // `bound_to_thread` to `Bound` with `Release` ordering constraints. To
+        // make those writes visible, we need to load the `bound_to_thread`
+        // value with at least `Acquire` ordering constraints:
+        if self.bound_to_thread.load(Ordering::Acquire) == BoundToThreadStage::Bound as usize {
+            // The `SingleThreadValue` value is bound to _a_ thread, check
+            // whether it is the currently running thread:
+            let ptr_thread_id_and_fn: *mut MaybeUninit<(fn() -> usize, usize)> =
+                self.thread_id_and_fn.get();
+
+            // Safety:
+            //
+            // We must ensure that there are no (mutable) aliases or concurrent
+            // reads or writes of the thread_id_and_fn value.
+            //
+            // This value is accessed in three functions: `bind_to_thread`,
+            // `bind_to_thread_unsafe`, and `bound_to_current_thread`:
+            //
+            // - `bind_to_thread` / `bind_to_thread_unsafe`: Before creating a
+            //   reference to, reading from, or writing to the `bound_to_thread`
+            //   value, both functions check that `bound_to_thread` is not
+            //   already set to `Bound`. However, when reaching if-branch in
+            //   this current function, we have observed that `bound_to_thread`
+            //   is set to `Bound`. The state of `Bound` cannot be transitioned
+            //   out of. Thus, `bound_to_thread` will never be written again.
+            //
+            //   `bound_to_thread` is only ever set to `Bound`, *after*
+            //   `thread_id_and_fn` has been initialized, and all references to
+            //   `thread_id_and_fn` cease to exist.
+            //
+            //   When reaching this point, neither `bind_to_thread` nor
+            //   `bind_to_thread_unsafe` will ever read from, write to, or
+            //   create a reference to `thread_id_and_fn` again.
+            //
+            // - `bound_to_current_thread`: This function is allowed to run
+            //   concurrently with other calls to `bound_to_current_thread`.
+            //
+            //   However, this function only creates shared / immutable
+            //   references to this value that are never written. Multiple
+            //   shared references to this value are allowed to exist, so long
+            //   as they are not aliased by another exclusive / mutable
+            //   reference, and the underlying memory is not modified otherwise.
+            //
+            //   The only functions writing to `thread_id_and_fn` are
+            //   `bind_to_thread` and `bind_to_thread_unsafe`. As stated above,
+            //   when reaching this point, neither functions will ever write to
+            //   `thread_id_and_fn` again, and all of their internal references
+            //   have ceased to exist.
+            //
+            // Thus, this operation is safe.
+            let maybe_thread_id_and_fn: &MaybeUninit<(fn() -> usize, usize)> =
+                unsafe { &*(ptr_thread_id_and_fn as *const _) };
+
+            // Safety:
+            //
+            // Both `bind_to_thread` and `bind_to_thread_unsafe` are guaranteed
+            // to have initialized `thread_id_and_fn` *before* setting
+            // `bound_to_thread` to `Bound` with `Release` ordering constraints.
+            //
+            // In this if-branch, `bound_to_thread` has been observed to be
+            // `Bound`, a state that cannot be transitioned out of. We have
+            // loaded this value with `Acquire` ordering constraints, making all
+            // values written by other threads before a write to
+            // `bound_to_thread` with `Release` constraints visible to this
+            // thread.
+            //
+            // Thus, we can safely rely on `thread_id_and_fn` to be initialized:
+            let (running_thread_id_fn, bound_thread_id) =
+                unsafe { maybe_thread_id_and_fn.assume_init() };
+
+            // Finally, check if the thread this `SingleThreadValue` is bound to
+            // is the running thread ID:
+            bound_thread_id == running_thread_id_fn()
+        } else {
+            // The `SingleThreadValue` value is not yet bound to any thread:
+            false
+        }
+    }
+
+    /// Obtain a reference to the contained value.
+    ///
+    /// This function checks whether the [`SingleThreadValue`] is bound to the
+    /// currently running thread and, if so, returns a shared / immutable
+    /// reference to its contained value.
+    pub fn get(&self) -> Option<&T> {
+        if self.bound_to_current_thread() {
+            Some(&self.value)
+        } else {
+            None
+        }
+    }
+}


### PR DESCRIPTION
### Pull Request Overview

This is an example of using SingleThreadValue for DeferredCall. This is implemented on top of #4551.


### Testing Strategy

I tried the nrf with and without calling init, and verified it does not work if init isn't called.


### TODO or Help Wanted

All boards need to be updated to call deferred call state init.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
