### PR TITLE
versioning: add micro, include in attrs

### DIFF
--- a/boards/build_scripts/tock_kernel_layout.ld
+++ b/boards/build_scripts/tock_kernel_layout.ld
@@ -385,6 +385,14 @@ SECTIONS
      */
     .attributes : AT (ORIGIN(rom) + LENGTH(rom) - SIZEOF(.attributes))
     {
+        /* TLV: Kernel Version
+         * This specifies the version of the kernel.
+         *
+         * Because we use the constants set in the kernel source code, we must
+         * create the TLV structure there and include it here.
+         */
+        KEEP(*(.tock.attr.kernel_version))
+
         /* TLV: Kernel Flash
          * This indicates the start address of the kernel flash and the size of
          * the kernel binary.

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -103,6 +103,47 @@ pub const KERNEL_MAJOR_VERSION: u16 = 2;
 /// This is compiled with the crate to enable for checking of compatibility with
 /// loaded apps.
 pub const KERNEL_MINOR_VERSION: u16 = 2;
+/// Kernel micro version.
+///
+/// Use to denote development kernels from release kernels.
+///
+/// Nonzero numbers are releases.
+///
+/// Negative numbers are development or pre-releases.
+/// - -1: "-dev"
+/// - -2: alpha
+/// - -3: beta, etc.
+pub const KERNEL_MICRO_VERSION: i16 = -1;
+
+/// Tock kernel attributes structure for version information.
+#[repr(C)]
+struct TockAttributesKernelVersion {
+    major: u16,
+    minor: u16,
+    micro: i16,
+    padding: u16,
+    tlv_type: u16,
+    tlv_len: u16,
+}
+
+/// Create a data structure which follows the Tock Kernel Attributes format
+/// for specifying the version of the Tock kernel.
+///
+/// More information on kernel attributes is
+/// [here](https://book.tockos.org/doc/kernel_attributes.html).
+///
+/// This is inserted into a specific section that the linker script includes at
+/// the correct location to be included in the attributes.
+#[link_section = ".tock.attr.kernel_version"]
+#[used]
+static TOCK_ATTRIBUTES_KERNEL_VERSION: TockAttributesKernelVersion = TockAttributesKernelVersion {
+    major: KERNEL_MAJOR_VERSION,
+    minor: KERNEL_MINOR_VERSION,
+    micro: KERNEL_MICRO_VERSION,
+    padding: 0,
+    tlv_type: 0x0103,
+    tlv_len: 8,
+};
 
 pub mod capabilities;
 pub mod collections;


### PR DESCRIPTION
### Pull Request Overview

This adds a flag for the micro version so we can differentiate a release from an ongoing development branch.

This also inserts the version into the kernel attributes so tools like tockloader can check the version. Nonzero numbers mean a release, negative numbers mean development or pre-release.






### Testing Strategy

With tockloader


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
