### PR TITLE
Update ubuntu package name for QEMU i386

### DIFF
--- a/boards/qemu_i486_q35/README.md
+++ b/boards/qemu_i486_q35/README.md
@@ -16,7 +16,7 @@ To install QEMU follow these steps:
 **Linux**
 ```bash
 sudo apt update
-sudo apt install qemu-system-i386
+sudo apt install qemu-system-x86
 ```
 
 **MacOS**


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the README for the qemu_i486_q35 board to update the Ubuntu package name for installing QEMU.

To my knowledge `qemu-system-x86` is the correct package name for Ubuntu 22.04 and 24.04 and up. It's possible that the name was different in Ubuntu 20.04, but that hit end-of-life already for Desktop users.


### Testing Strategy

I installed QEMU via that command and Tock ran correctly.


### TODO or Help Wanted

Good to go


### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [N/A] Ran `make prepush`.
