### PR TITLE
kernel: add patch version, separate pre-release counter in attrs

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -102,7 +102,7 @@ pub const KERNEL_MAJOR_VERSION: u16 = 2;
 ///
 /// This is compiled with the crate to enable for checking of compatibility with
 /// loaded apps.
-pub const KERNEL_MINOR_VERSION: u16 = 2;
+pub const KERNEL_MINOR_VERSION: u16 = 3;
 /// Kernel patch version.
 pub const KERNEL_PATCH_VERSION: u16 = 0;
 /// Kernel in-development version counter.
@@ -118,7 +118,7 @@ pub const KERNEL_PATCH_VERSION: u16 = 0;
 /// A value other than `0` indicates that this is a development revision, before
 /// (older than) the next release described by [`KERNEL_MAJOR_VERSION`],
 /// [`KERNEL_MINOR_VERSION`] and [`KERNEL_PATCH_VERSION`].
-pub const KERNEL_PRERELEASE_VERSION: u16 = 0;
+pub const KERNEL_PRERELEASE_VERSION: u16 = 1;
 
 /// Tock kernel attributes structure for version information.
 #[repr(C)]


### PR DESCRIPTION
### Pull Request Overview

PR #4567 added a "micro" version number constant to the kernel, and to the kernel attributes. While I agree in principle with the need to distinguish a pre-release / in-development kernel from released versions, I think that the concept of a "micro" version number is odd.

Tock already has a rarely used, although well-defined concept of a "patch" version number. Overloading this with a "micro" version, which uses positive and negative integers to denote different types of revisions is confusing.

Additionally, the "micro" version number doesn't allow for the ability to order development versions alongside patch releases. Tock's release strategy usually does not involve creating patch releases, but when we do, they would branch off from the minor release revision. For a patch release that takes longer (multiple commits) to develop, it seems misguided to revert back to a "micro" version that indicates "-dev", which is the same exact version tuple already used when preparing that initial, minor release.

Given that we're including a `u16` padding field in the kernel version attributes anyways, I think a much less confusing and cleaner option is to store dedicated "patch" and "prerelease" revision fields. This way, versioning would work as follows:

Let's assume we start from a release `2.3.0`. Then, the kernel attributes would indicate: `(major: 2, minor: 3, patch: 0, prerelease: 0)`.

Immediately after tagging the release, on the `master` branch, we'd increment the version to the next presumptive release, setting the prerelease counter to 1: `(major: 2, minor: 4, patch: 0, prerelease: 1)`

Note that this won't mean we have to release a `2.4.0` -- if we introduce breaking features, we can, with the introduction of that breakage, increment the major version number to `(3, 0, 0, 1)` and simply never tag a `(2, 4, 0, 0)`.

When we realize that a patch release for `2.3` is necessary, we'll create a branch starting at that tag, and then immediately increment that branch's version from `(2, 3, 0, 0)` to `(2, 3, 1, 1)`.  Then, we develop whatever fix we intend on including in the patch release. Finally, after testing, we tag the patch release as `(2, 3, 1, 0)`.

With this proposal, the tuples cannot be ordered using simple lexicographic comparison. Instead, a comparison would need to special case `0` as being order after all other pre-release versions (such as by doing a `wrapping_sub(1)` on the prerelease version): `(2, 3, 0, 0) <= (2, 3, 1, 1) <= (2, 3, 1, 0) <= (2, 4, 0, 1) <= (2, 4, 0, 0) <= (3, 0, 0, 1)`.

If we end up going with this approach, as a next step I'd document this versioning and release process explicitly, in the book or the repo's `doc/` folder.

### Testing Strategy

N/A


### TODO or Help Wanted

N/A


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
