### PR TITLE
Update my affiliation.

### DIFF
--- a/doc/reference/trd-appid.md
+++ b/doc/reference/trd-appid.md
@@ -955,7 +955,7 @@ Stanford, CA 94305
 USA
 pal@cs.stanford.edu
 
-Johnathan Van Why <jrvanwhy@google.com>
+Johnathan Van Why <tock@jrvanwhy.net>
 
 Brad Campbell <bradjc@virginia.edu>
 ```

--- a/doc/reference/trd104-syscalls.md
+++ b/doc/reference/trd104-syscalls.md
@@ -1142,7 +1142,7 @@ Pat Pannuto <ppannuto@ucsd.edu>
 
 Leon Schuermann <leon@is.currently.online>
 
-Johnathan Van Why <jrvanwhy@google.com>
+Johnathan Van Why <tock@jrvanwhy.net>
 ```
 
 7 References and Additional Information

--- a/doc/wg/core/README.md
+++ b/doc/wg/core/README.md
@@ -45,7 +45,7 @@ are:
 - Pat Pannuto, [ppannuto](https://github.com/ppannuto), UCSD
 - Alexandru Radovici [alexandruradovici](https://github.com/alexandruradovici), Politehnica Bucharest & OxidOS
 - Leon Schuermann, [lschuermann](https://github.com/lschuermann), Princeton University
-- Johnathan Van Why, [jrvanwhy](https://github.com/jrvanwhy), Google
+- Johnathan Van Why, [jrvanwhy](https://github.com/jrvanwhy), Better Bytes
 
 ## Membership
 


### PR DESCRIPTION
I have moved on from Google and am currently at Better Bytes. This updates the core WG affiliation list as well as my email address in a couple of locations (as my @google.com email is no longer reachable).