### PR TITLE
replace git hash with kernel version + clean/dirty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -485,22 +485,22 @@ ci-job-archs:
 	@for arch in `./tools/build/list_archs.sh`;\
 		do echo "$$(tput bold)Test $$arch";\
 		cd arch/$$arch;\
-		NOWARNINGS=true RUSTFLAGS="-D warnings" TOCK_KERNEL_VERSION=ci_test cargo test || exit 1;\
+		NOWARNINGS=true RUSTFLAGS="-D warnings" cargo test || exit 1;\
 		cd ../..;\
 		done
 
 .PHONY: ci-job-kernel
 ci-job-kernel:
 	$(call banner,CI-Job: Kernel)
-	@cd kernel && NOWARNINGS=true RUSTFLAGS="-D warnings" TOCK_KERNEL_VERSION=ci_test cargo test
+	@cd kernel && NOWARNINGS=true RUSTFLAGS="-D warnings" cargo test
 
 .PHONY: ci-job-capsules
 ci-job-capsules:
 	$(call banner,CI-Job: Capsules)
 	@# Capsule initialization depends on board/chip specific imports, so ignore doc tests
-	@cd capsules/core && NOWARNINGS=true RUSTFLAGS="-D warnings" TOCK_KERNEL_VERSION=ci_test cargo test
-	@cd capsules/extra && NOWARNINGS=true RUSTFLAGS="-D warnings" TOCK_KERNEL_VERSION=ci_test cargo test
-	@cd capsules/system && NOWARNINGS=true RUSTFLAGS="-D warnings" TOCK_KERNEL_VERSION=ci_test cargo test
+	@cd capsules/core && NOWARNINGS=true RUSTFLAGS="-D warnings" cargo test
+	@cd capsules/extra && NOWARNINGS=true RUSTFLAGS="-D warnings" cargo test
+	@cd capsules/system && NOWARNINGS=true RUSTFLAGS="-D warnings" cargo test
 
 .PHONY: ci-job-chips
 ci-job-chips:
@@ -508,7 +508,7 @@ ci-job-chips:
 	@for chip in `./tools/build/list_chips.sh`;\
 		do echo "$$(tput bold)Test $$chip";\
 		cd chips/$$chip;\
-		NOWARNINGS=true RUSTFLAGS="-D warnings" TOCK_KERNEL_VERSION=ci_test cargo test || exit 1;\
+		NOWARNINGS=true RUSTFLAGS="-D warnings" cargo test || exit 1;\
 		cd ../..;\
 		done
 

--- a/arch/cortex-m0/src/lib.rs
+++ b/arch/cortex-m0/src/lib.rs
@@ -54,7 +54,7 @@ unsafe extern "C" fn hard_fault_handler_kernel(faulting_stack: *mut u32) -> ! {
          \tpc  0x{:x}\r\n\
          \txpsr  0x{:x}\r\n\
          ",
-        option_env!("TOCK_KERNEL_VERSION").unwrap_or("unknown"),
+        kernel::TOCK_KERNEL_VERSION,
         hardfault_stacked_registers.r0,
         hardfault_stacked_registers.r1,
         hardfault_stacked_registers.r2,

--- a/arch/cortex-v7m/src/lib.rs
+++ b/arch/cortex-v7m/src/lib.rs
@@ -374,7 +374,7 @@ unsafe extern "C" fn hard_fault_handler_arm_v7m_kernel(
          \tBus Fault Address:       (valid: {}) {:#010X}\r\n\
          ",
             mode_str,
-            option_env!("TOCK_KERNEL_VERSION").unwrap_or("unknown"),
+            kernel::TOCK_KERNEL_VERSION,
             stacked_r0,
             stacked_r1,
             stacked_r2,

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -94,18 +94,6 @@ else
   DEVNULL = > /dev/null
 endif
 
-# Try to determine whether this is a clean, tagged release or not. This
-# result is embedded at the end of the version string built into the
-# kernel. The purpose is to have a little context for bug reports of
-# what kind of kernel was running. More specifically, the command below
-# does the following:
-#
-# Is this a git directory? [no] --> "nogit"
-#   Is the working directory clean? [no] --> "dirty"
-#      Is the current commit a tagged release? [no] --> "added"
-#        "clean"
-export TOCK_IS_TAGGED_RELEASE := $(shell if git rev-parse --is-inside-work-tree &> /dev/null; then if output=$(git status --porcelain) && [ -z "$output" ]; then if git describe --match 'release-*' --exact-match 2>/dev/null; then echo clean; else echo added; fi; else echo dirty; fi ; else echo nogit; fi)
-
 # Allow users to opt out of using rustup.
 ifeq ($(NO_RUSTUP),)
 # Validate that rustup exists.

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -94,10 +94,17 @@ else
   DEVNULL = > /dev/null
 endif
 
-# Ask git what version of the Tock kernel we are compiling, so we can include
-# this within the binary. If Tock is not within a git repo then we fallback to
-# a set string which should be updated with every release.
-export TOCK_KERNEL_VERSION := $(shell git describe --tags --always 2> /dev/null || echo "2.2+")
+# Try to determine whether this is a clean, tagged release or not. This
+# result is embedded at the end of the version string built into the
+# kernel. The purpose is to have a little context for bug reports of
+# what kind of kernel was running. More specifically, the command below
+# does the following:
+#
+# Is this a git directory? [no] --> "nogit"
+#   Is the working directory clean? [no] --> "dirty"
+#      Is the current commit a tagged release? [no] --> "added"
+#        "clean"
+export TOCK_IS_TAGGED_RELEASE := $(shell if git rev-parse --is-inside-work-tree &> /dev/null; then if output=$(git status --porcelain) && [ -z "$output" ]; then if git describe --match 'release-*' --exact-match 2>/dev/null; then echo clean; else echo added; fi; else echo dirty; fi ; else echo nogit; fi)
 
 # Allow users to opt out of using rustup.
 ifeq ($(NO_RUSTUP),)

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -178,7 +178,7 @@ pub unsafe fn panic_banner<W: Write>(writer: &mut W, panic_info: &PanicInfo) {
     // Print version of the kernel
     let _ = writer.write_fmt(format_args!(
         "\tKernel version {}\r\n",
-        option_env!("TOCK_KERNEL_VERSION").unwrap_or("unknown")
+        crate::TOCK_KERNEL_VERSION
     ));
 }
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -150,6 +150,18 @@ static TOCK_ATTRIBUTES_KERNEL_VERSION: TockAttributesKernelVersion = TockAttribu
     tlv_len: 8,
 };
 
+pub static TOCK_KERNEL_VERSION: &str = concat!(
+    stringify!(KERNEL_MAJOR_VERSION),
+    ".",
+    stringify!(KERNEL_MINOR_VERSION),
+    ".",
+    stringify!(KERNEL_PATCH_VERSION),
+    "-",
+    stringify!(KERNEL_PRERELEASE_VERSION),
+    "-",
+    stringify!(option_env!("TOCK_IS_TAGGED_RELEASE").unwrap_or("dirty")),
+);
+
 pub mod capabilities;
 pub mod collections;
 pub mod component;

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -158,8 +158,6 @@ pub static TOCK_KERNEL_VERSION: &str = concat!(
     stringify!(KERNEL_PATCH_VERSION),
     "-",
     stringify!(KERNEL_PRERELEASE_VERSION),
-    "-",
-    stringify!(option_env!("TOCK_IS_TAGGED_RELEASE").unwrap_or("dirty")),
 );
 
 pub mod capabilities;


### PR DESCRIPTION
### Pull Request Overview

Having the exact hash in the kernel crate leads to a lot of rebuilds. We're primarily interested in ensuring that dumps give enough information for support folks to have context of what kernel is running, and in cases where folks are doing active kernel development, `dirty` is sufficient to indicate that a kernel has been modified, and we can follow up with asks for hash if needed.

### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

N/A.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
