### PR TITLE
[Cursor Test] Move PcComponent out of `chips/` and into `boards/components`

### DIFF
--- a/boards/components/Cargo.toml
+++ b/boards/components/Cargo.toml
@@ -15,6 +15,8 @@ capsules-core = { path = "../../capsules/core" }
 capsules-extra = { path = "../../capsules/extra" }
 capsules-system = { path = "../../capsules/system" }
 segger = { path = "../../chips/segger" }
+x86_q35 = { path = "../../chips/x86_q35" }
+x86 = { path = "../../arch/x86" }
 
 tock-tbf = { path = "../../libraries/tock-tbf" }
 

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -106,3 +106,4 @@ pub mod touch;
 pub mod udp_driver;
 pub mod udp_mux;
 pub mod usb;
+pub mod x86_pc_component;

--- a/boards/components/src/x86_pc_component.rs
+++ b/boards/components/src/x86_pc_component.rs
@@ -1,0 +1,90 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2024.
+
+//! Component for constructing the `x86_q35::Pc` chip instance on x86 PC boards.
+
+use core::mem::MaybeUninit;
+
+use kernel::component::Component;
+use x86::mpu::PagingMPU;
+use x86::registers::bits32::paging::{PD, PT};
+use x86::Boundary;
+
+use x86_q35::pit::Pit;
+use x86_q35::serial::{SerialPortComponent, COM1_BASE, COM2_BASE, COM3_BASE, COM4_BASE};
+use x86_q35::vga_uart_driver::VgaText;
+use x86_q35::Pc;
+
+pub struct X86PcComponent<'a> {
+    pd: &'a mut PD,
+    pt: &'a mut PT,
+}
+
+impl<'a> X86PcComponent<'a> {
+    /// ## Safety
+    /// Only one instance should ever be created for the lifetime of the kernel.
+    pub unsafe fn new(pd: &'a mut PD, pt: &'a mut PT) -> Self {
+        Self { pd, pt }
+    }
+}
+
+impl Component for X86PcComponent<'static> {
+    type StaticInput = (
+        <SerialPortComponent as Component>::StaticInput,
+        <SerialPortComponent as Component>::StaticInput,
+        <SerialPortComponent as Component>::StaticInput,
+        <SerialPortComponent as Component>::StaticInput,
+        &'static mut MaybeUninit<VgaText<'static>>,
+        &'static mut MaybeUninit<Pc<'static>>,
+    );
+    type Output = &'static Pc<'static>;
+
+    fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        // ### Safety
+        // - Running in ring zero.
+        // - Single instantiation across kernel lifetime.
+        unsafe {
+            x86::init();
+            x86_q35::pic::init();
+
+            let pd: &mut PD = &mut *core::ptr::from_mut(self.pd);
+            x86_q35::vga::new_text_console(pd);
+        }
+
+        let com1 = unsafe { SerialPortComponent::new(COM1_BASE).finalize(s.0) };
+        let com2 = unsafe { SerialPortComponent::new(COM2_BASE).finalize(s.1) };
+        let com3 = unsafe { SerialPortComponent::new(COM3_BASE).finalize(s.2) };
+        let com4 = unsafe { SerialPortComponent::new(COM4_BASE).finalize(s.3) };
+
+        let pit = unsafe { Pit::new() };
+
+        let vga = s.4.write(VgaText::new());
+        kernel::deferred_call::DeferredCallClient::register(vga);
+
+        let paging = unsafe {
+            let pd_addr = core::ptr::from_ref(self.pd) as usize;
+            let pt_addr = core::ptr::from_ref(self.pt) as usize;
+            PagingMPU::new(self.pd, pd_addr, self.pt, pt_addr)
+        };
+        paging.init();
+
+        let syscall = Boundary::new();
+
+        s.5.write(Pc::new(com1, com2, com3, com4, pit, vga, syscall, paging))
+    }
+}
+
+#[macro_export]
+macro_rules! x86_pc_component_static {
+    () => {{
+        (
+            (kernel::static_buf!(x86_q35::serial::SerialPort<'static>),),
+            (kernel::static_buf!(x86_q35::serial::SerialPort<'static>),),
+            (kernel::static_buf!(x86_q35::serial::SerialPort<'static>),),
+            (kernel::static_buf!(x86_q35::serial::SerialPort<'static>),),
+            kernel::static_buf!(x86_q35::vga_uart_driver::VgaText<'static>),
+            kernel::static_buf!(x86_q35::Pc<'static>),
+        )
+    }};
+}

--- a/boards/qemu_i486_q35/src/main.rs
+++ b/boards/qemu_i486_q35/src/main.rs
@@ -30,7 +30,7 @@ use kernel::{create_capability, static_init};
 use x86::registers::bits32::paging::{PDEntry, PTEntry, PD, PT};
 use x86::registers::irq;
 use x86_q35::pit::{Pit, RELOAD_1KHZ};
-use x86_q35::{Pc, PcComponent};
+use x86_q35::Pc;
 
 mod multiboot;
 use multiboot::MultibootV1Header;
@@ -149,11 +149,13 @@ unsafe extern "cdecl" fn main() {
     // ---------- BASIC INITIALIZATION -----------
 
     // Basic setup of the i486 platform
-    let chip = PcComponent::new(
-        &mut *ptr::addr_of_mut!(PAGE_DIR),
-        &mut *ptr::addr_of_mut!(PAGE_TABLE),
-    )
-    .finalize(x86_q35::x86_q35_component_static!());
+    let chip = unsafe {
+        components::x86_pc_component::X86PcComponent::new(
+            &mut *ptr::addr_of_mut!(PAGE_DIR),
+            &mut *ptr::addr_of_mut!(PAGE_TABLE),
+        )
+        .finalize(components::x86_pc_component_static!())
+    };
 
     // Acquire required capabilities
     let process_mgmt_cap = create_capability!(capabilities::ProcessManagementCapability);

--- a/chips/x86_q35/src/chip.rs
+++ b/chips/x86_q35/src/chip.rs
@@ -3,18 +3,14 @@
 // Copyright Tock Contributors 2024.
 
 use core::fmt::Write;
-use core::mem::MaybeUninit;
 
-use kernel::component::Component;
 use kernel::platform::chip::Chip;
-use kernel::static_init;
 use x86::mpu::PagingMPU;
-use x86::registers::bits32::paging::{PD, PT};
 use x86::support;
 use x86::{Boundary, InterruptPoller};
 
 use crate::pit::{Pit, RELOAD_1KHZ};
-use crate::serial::{SerialPort, SerialPortComponent, COM1_BASE, COM2_BASE, COM3_BASE, COM4_BASE};
+use crate::serial::SerialPort;
 use crate::vga_uart_driver::VgaText;
 
 /// Interrupt constants for legacy PC peripherals
@@ -60,6 +56,31 @@ pub struct Pc<'a, const PR: u16 = RELOAD_1KHZ> {
     /// System call context
     syscall: Boundary,
     paging: PagingMPU<'a>,
+}
+
+impl<'a, const PR: u16> Pc<'a, PR> {
+    /// Construct a new `Pc` chip instance from its constituent parts.
+    pub fn new(
+        com1: &'a SerialPort<'a>,
+        com2: &'a SerialPort<'a>,
+        com3: &'a SerialPort<'a>,
+        com4: &'a SerialPort<'a>,
+        pit: Pit<'a, PR>,
+        vga: &'a VgaText<'a>,
+        syscall: Boundary,
+        paging: PagingMPU<'a>,
+    ) -> Self {
+        Self {
+            com1,
+            com2,
+            com3,
+            com4,
+            pit,
+            vga,
+            syscall,
+            paging,
+        }
+    }
 }
 
 impl<'a, const PR: u16> Chip for Pc<'a, PR> {
@@ -157,110 +178,4 @@ impl<'a, const PR: u16> Chip for Pc<'a, PR> {
 
         let _ = writeln!(writer, "(placeholder)");
     }
-}
-
-/// Component helper for constructing a [`Pc`] chip instance.
-///
-/// During the call to `finalize()`, this helper will perform low-level initialization of the PC
-/// hardware to ensure a consistent CPU state. This includes initializing memory segmentation and
-/// interrupt handling. See [`x86::init`] for further details.
-pub struct PcComponent<'a> {
-    pd: &'a mut PD,
-    pt: &'a mut PT,
-}
-
-impl<'a> PcComponent<'a> {
-    /// Creates a new `PcComponent` instance.
-    ///
-    /// ## Safety
-    ///
-    /// It is unsafe to construct more than a single `PcComponent` during the entire lifetime of the
-    /// kernel.
-    ///
-    /// Before calling, memory must be identity-mapped. Otherwise, introduction of flat segmentation
-    /// will cause the kernel's code/data to move unexpectedly.
-    ///
-    /// See [`x86::init`] for further details.
-    pub unsafe fn new(pd: &'a mut PD, pt: &'a mut PT) -> Self {
-        Self { pd, pt }
-    }
-}
-
-impl Component for PcComponent<'static> {
-    type StaticInput = (
-        <SerialPortComponent as Component>::StaticInput,
-        <SerialPortComponent as Component>::StaticInput,
-        <SerialPortComponent as Component>::StaticInput,
-        <SerialPortComponent as Component>::StaticInput,
-        &'static mut MaybeUninit<Pc<'static>>,
-    );
-    type Output = &'static Pc<'static>;
-
-    fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        // Low-level hardware initialization. We do this first to guarantee the CPU is in a
-        // predictable state before initializing the chip object.
-        unsafe {
-            x86::init();
-            crate::pic::init();
-            // Enable the VGA path by building or running with the feature flag, e.g.:
-            //   `cargo run -- -display none`
-            // A plain `make run` / `cargo run` keeps everything on COM1.
-            //
-            // Initialise VGA and clear BIOS text if VGA is enabled
-            // Clear BIOS banner: the real-mode BIOS leaves its text (and the cursor off-screen) in
-            // 0xB8000.  Wiping the full 80×25 buffer gives us a clean screen and a visible cursor
-            // before the kernel prints its first message.
-            // SAFETY: PAGE_DIR is identity-mapped, aligned, and unique
-            let pd: &mut PD = &mut *core::ptr::from_mut(self.pd);
-            crate::vga::new_text_console(pd);
-        }
-
-        let com1 = unsafe { SerialPortComponent::new(COM1_BASE).finalize(s.0) };
-        let com2 = unsafe { SerialPortComponent::new(COM2_BASE).finalize(s.1) };
-        let com3 = unsafe { SerialPortComponent::new(COM3_BASE).finalize(s.2) };
-        let com4 = unsafe { SerialPortComponent::new(COM4_BASE).finalize(s.3) };
-
-        let pit = unsafe { Pit::new() };
-
-        let vga = unsafe { static_init!(VgaText, VgaText::new()) };
-
-        kernel::deferred_call::DeferredCallClient::register(vga);
-
-        let paging = unsafe {
-            let pd_addr = core::ptr::from_ref(self.pd) as usize;
-            let pt_addr = core::ptr::from_ref(self.pt) as usize;
-            PagingMPU::new(self.pd, pd_addr, self.pt, pt_addr)
-        };
-
-        paging.init();
-
-        let syscall = Boundary::new();
-
-        let pc = s.4.write(Pc {
-            com1,
-            com2,
-            com3,
-            com4,
-            pit,
-            vga,
-            syscall,
-            paging,
-        });
-
-        pc
-    }
-}
-
-/// Provides static buffers needed for `PcComponent::finalize()`.
-#[macro_export]
-macro_rules! x86_q35_component_static {
-    () => {{
-        (
-            $crate::serial_port_component_static!(),
-            $crate::serial_port_component_static!(),
-            $crate::serial_port_component_static!(),
-            $crate::serial_port_component_static!(),
-            kernel::static_buf!($crate::Pc<'static>),
-        )
-    };};
 }

--- a/chips/x86_q35/src/lib.rs
+++ b/chips/x86_q35/src/lib.rs
@@ -15,11 +15,11 @@
 #![no_std]
 
 mod chip;
-pub use chip::{Pc, PcComponent};
+pub use chip::Pc;
 
 mod interrupts;
 
-mod pic;
+pub mod pic;
 
 pub mod pit;
 

--- a/chips/x86_q35/src/pic.rs
+++ b/chips/x86_q35/src/pic.rs
@@ -57,7 +57,7 @@ const POST_PORT: u16 = 0x80;
 /// Calling this function will cause interrupts to start firing. This means the IDT must already be
 /// initialized with valid handlers for all possible interrupt numbers (i.e. by a call to
 /// [`handlers::init`][super::handlers::init]).
-pub(crate) unsafe fn init() {
+pub unsafe fn init() {
     unsafe {
         let wait = || io::outb(POST_PORT, 0);
 

--- a/chips/x86_q35/src/serial.rs
+++ b/chips/x86_q35/src/serial.rs
@@ -471,13 +471,8 @@ impl Component for SerialPortComponent {
     }
 }
 
-/// Statically allocates the storage needed to finalize a [`SerialPortComponent`].
-#[macro_export]
-macro_rules! serial_port_component_static {
-    () => {{
-        (kernel::static_buf!($crate::serial::SerialPort<'static>),)
-    }};
-}
+// Note: The `serial_port_component_static!` macro was moved to board components
+// where it is inlined within board-specific component macros.
 
 /// Serial port handle for blocking I/O
 ///

--- a/chips/x86_q35/src/vga.rs
+++ b/chips/x86_q35/src/vga.rs
@@ -457,7 +457,7 @@ pub fn framebuffer() -> Option<(*mut u8, usize)> {
 }
 
 /// Initialise 80×25 text mode and start with a clean screen.
-pub(crate) fn new_text_console(_page_dir_ptr: &mut x86::registers::bits32::paging::PD) {
+pub fn new_text_console(_page_dir_ptr: &mut x86::registers::bits32::paging::PD) {
     // Program 80×25 text mode
     VgaDevice::set_mode(VgaMode::Text80x25);
 


### PR DESCRIPTION


### Pull Request Overview

This PR was entirely authored by Cursor (model: gpt-5). I intentionally did not make any edits to the generated code -- I wanted to use this as a brief exercise to see how capable cursor was of making a basic refactor. I picked the most recently opened issue. I did not review the changes in depth (yet), but made some suggestions in response to the initial changes. I gave the following 5 prompts to get it here:

1. This file contains a component, but Tock components are all supposed to be defined in the boards/ crate. Can you move the component defined in this file into the boards crate in a similar style to how other components are defined, and update boards/qemu_i486_q35/src/main.rs accordingly so that board still builds?

2. The component should go in the boards/components directory alongside other components. Can you move it there, in a file named x86_pc_component.rs?

3. Please do not call static_init!() within finalize(), instead move that into x86_pc_component_static.

4. Thank you. Can you also move serial_port_component_static!() into this component file?

5. Can you just inline the macro rather than having it be a standalone macro? Also, please be sure to delete it from its original location

### Testing Strategy

This pull request has not been tested.


### TODO or Help Wanted

This pull request still careful review and testing.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
