### PR TITLE
ci: use `-q` to suppress apt progress indicators

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           pip install --user cxxfilt
-          sudo apt install llvm
+          sudo apt install -q llvm
       - name: size report
         run: |
           ./tools/ci/github_actions_size_changes.sh

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -61,7 +61,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
       - name: Install dependencies for ubuntu-latest
         run: |
-          sudo apt install libudev-dev libzmq3-dev
+          sudo apt install -q libudev-dev libzmq3-dev
         if: matrix.os == 'ubuntu-latest'
       - name: Install dependencies for macos-latest
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
       - name: Install dependencies for ubuntu-latest
         run: |
-          sudo apt install libudev-dev libzmq3-dev
+          sudo apt install -q libudev-dev libzmq3-dev
         if: matrix.os == 'ubuntu-latest'
       - uses: actions/checkout@v4
       - name:      ci-job-libraries
@@ -122,7 +122,7 @@ jobs:
       - name: Install dependencies
         continue-on-error: true
         run: |
-          sudo apt install meson libglib2.0-dev
+          sudo apt install -q meson libglib2.0-dev
       - uses: actions/checkout@v4
       - name:      ci-job-qemu
         run:  make ci-job-qemu

--- a/.github/workflows/litex_sim.yml
+++ b/.github/workflows/litex_sim.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Update packages and install dependencies
         run: |
           sudo apt update
-          sudo apt install python3-pip python3-venv gcc-riscv64-unknown-elf \
+          sudo apt install -q python3-pip python3-venv gcc-riscv64-unknown-elf \
             verilator libevent-dev libjson-c-dev libz-dev libzmq3-dev
 
       # Install elf2tab to be able to build userspace apps


### PR DESCRIPTION
### Pull Request Overview

This switches apt to "quieter" mode (as opposed to the "completely quiet" `-qq`); it suppresses things like download progress indicators, but still shows warnings and errors.

### Testing Strategy

This pull request was tested by — you're looking at it.

### TODO or Help Wanted

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
