### PR TITLE
tock-registers: update import versioning

### DIFF
--- a/arch/riscv/Cargo.toml
+++ b/arch/riscv/Cargo.toml
@@ -10,7 +10,7 @@ edition.workspace = true
 
 [dependencies]
 kernel = { path = "../../kernel" }
-tock-registers = { path = "../../libraries/tock-register-interface" }
+tock-registers = "0.10.0"
 riscv-csr = { path = "../../libraries/riscv-csr" }
 
 

--- a/arch/rv32i/Cargo.toml
+++ b/arch/rv32i/Cargo.toml
@@ -10,7 +10,7 @@ edition.workspace = true
 
 [dependencies]
 kernel = { path = "../../kernel" }
-tock-registers = { path = "../../libraries/tock-register-interface" }
+tock-registers = "0.10.0"
 riscv-csr = { path = "../../libraries/riscv-csr" }
 riscv = { path = "../riscv" }
 

--- a/arch/x86/Cargo.toml
+++ b/arch/x86/Cargo.toml
@@ -11,7 +11,7 @@ edition.workspace = true
 [dependencies]
 kernel = { path = "../../kernel" }
 tock-cells = { path = "../../libraries/tock-cells" }
-tock-registers = { path = "../../libraries/tock-register-interface" }
+tock-registers = "0.10.0"
 
 [lints]
 workspace = true

--- a/chips/litex/Cargo.toml
+++ b/chips/litex/Cargo.toml
@@ -9,7 +9,7 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-tock-registers = { path = "../../libraries/tock-register-interface" }
+tock-registers = "0.10.0"
 kernel = { path = "../../kernel" }
 
 [lints]

--- a/chips/x86_q35/Cargo.toml
+++ b/chips/x86_q35/Cargo.toml
@@ -11,7 +11,7 @@ edition.workspace = true
 [dependencies]
 kernel = { path = "../../kernel" }
 x86 = { path = "../../arch/x86" }
-tock-registers = { path = "../../libraries/tock-register-interface" }
+tock-registers = "0.10.0"
 tock-cells = { path = "../../libraries/tock-cells" }
 
 [lints]

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -9,7 +9,7 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-tock-registers = { path = "../libraries/tock-register-interface" }
+tock-registers = "0.10.0"
 tock-cells = { path = "../libraries/tock-cells" }
 tock-tbf = { path = "../libraries/tock-tbf" }
 

--- a/libraries/riscv-csr/Cargo.toml
+++ b/libraries/riscv-csr/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2021"
 travis-ci = { repository = "tock/tock", branch = "master" }
 
 [dependencies]
-tock-registers = { path = "../tock-register-interface", default-features = false }
+tock-registers = {version = "0.10.0", default-features = false }
 
 [lints]
 workspace = true


### PR DESCRIPTION


### Pull Request Overview

This pull request updates how Tock uses `tock-registers` as a dependency. 

The current method for including `tock-registers` is via the Cargo path specifier. If an external crate A relies on `tock-registers` as a dependency, using A in Tock will be flagged as a version mismatch (even if both are in fact the same version) since Cargo believes the same version crate to be different versions if one is specified as:

```
tock-registers = "0.10.0"
```

while the other is specified as:
```
tock-registers = { path = "path_to_tock_registers" } # also v0.10.0
```

I imagine this may be an artifact from:
(1) before `tock-registers` was published to crates.io
(2) Tock will automatically use the most recent version of `tock-registers` as changes are made.

The downside to this is that we will now need to update the dependency version in Tock as changes are made in `tock-registers`. However, this seems like something we should always be doing, and also is likely a good forcing function for us to make new releases of `tock-registers` as changes/fixes are made.

### Testing Strategy

Build system.

### TODO or Help Wanted

I may be missing other reasons for why this change is a bad idea.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
