### PR TITLE
doc/ExternalDependencies: carve out exception for Tock-maintained crates

### DIFF
--- a/doc/ExternalDependencies.md
+++ b/doc/ExternalDependencies.md
@@ -26,7 +26,7 @@ External Dependencies
 <!-- tocstop -->
 
 Tock's general policy is the kernel does not include external dependencies (i.e.
-rust crates outside of the `tock/tock` repository) that are not part of the Rust
+Rust crates outside of the `tock/tock` repository) that are not part of the Rust
 standard library. However, on a limited, case-by-case basis with appropriate
 safeguards, external dependencies can be used in the Tock kernel. The rationale
 and policy for this is described in this document. This document only applies to


### PR DESCRIPTION
### Pull Request Overview

Motivated by #4588, this carves out an exception for Tock-controlled and maintained dependencies in our policy around external dependencies.


### Testing Strategy

N/A


### TODO or Help Wanted

N/A


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
