### PR TITLE
x86_q35: add ps/2 controller to connect mouse and keyboard peripherals for VGA

### DIFF
--- a/boards/qemu_i486_q35/src/main.rs
+++ b/boards/qemu_i486_q35/src/main.rs
@@ -129,7 +129,7 @@ impl<C: Chip> KernelResources<C> for QemuI386Q35Platform {
     }
 
     type SchedulerTimer =
-    VirtualSchedulerTimer<VirtualMuxAlarm<'static, Pit<'static, RELOAD_1KHZ>>>;
+        VirtualSchedulerTimer<VirtualMuxAlarm<'static, Pit<'static, RELOAD_1KHZ>>>;
     fn scheduler_timer(&self) -> &Self::SchedulerTimer {
         self.scheduler_timer
     }
@@ -154,8 +154,8 @@ unsafe extern "cdecl" fn main() {
         &mut *ptr::addr_of_mut!(PAGE_DIR),
         &mut *ptr::addr_of_mut!(PAGE_TABLE),
         &(),
-            )
-        .finalize(x86_q35::x86_q35_component_static!(()));
+    )
+    .finalize(x86_q35::x86_q35_component_static!(()));
 
     // Acquire required capabilities
     let process_mgmt_cap = create_capability!(capabilities::ProcessManagementCapability);
@@ -246,7 +246,7 @@ unsafe extern "cdecl" fn main() {
         process_printer,
         None,
     )
-        .finalize(components::process_console_component_static!(
+    .finalize(components::process_console_component_static!(
         Pit<'static, RELOAD_1KHZ>
     ));
 
@@ -261,13 +261,12 @@ unsafe extern "cdecl" fn main() {
     )
     .finalize(components::debug_writer_component_static!());
 
-
     let lldb = components::lldb::LowLevelDebugComponent::new(
         board_kernel,
         capsules_core::low_level_debug::DRIVER_NUM,
         uart_mux,
     )
-        .finalize(components::low_level_debug_component_static!());
+    .finalize(components::low_level_debug_component_static!());
 
     let scheduler = components::sched::cooperative::CooperativeComponent::new(processes)
         .finalize(components::cooperative_component_static!(NUM_PROCS));
@@ -325,10 +324,10 @@ unsafe extern "cdecl" fn main() {
         &FAULT_RESPONSE,
         &process_mgmt_cap,
     )
-        .unwrap_or_else(|err| {
-            debug!("Error loading processes!");
-            debug!("{:?}", err);
-        });
+    .unwrap_or_else(|err| {
+        debug!("Error loading processes!");
+        debug!("{:?}", err);
+    });
 
     board_kernel.kernel_loop(&platform, chip, Some(&platform.ipc), &main_loop_cap);
 }

--- a/boards/qemu_i486_q35/src/main.rs
+++ b/boards/qemu_i486_q35/src/main.rs
@@ -154,7 +154,7 @@ unsafe extern "cdecl" fn main() {
         &mut *ptr::addr_of_mut!(PAGE_TABLE),
         &(),
     )
-    .finalize(x86_q35::x86_q35_component_static!(()));
+        .finalize(x86_q35::x86_q35_component_static!(()));
 
     // Acquire required capabilities
     let process_mgmt_cap = create_capability!(capabilities::ProcessManagementCapability);

--- a/boards/qemu_i486_q35/src/main.rs
+++ b/boards/qemu_i486_q35/src/main.rs
@@ -129,7 +129,7 @@ impl<C: Chip> KernelResources<C> for QemuI386Q35Platform {
     }
 
     type SchedulerTimer =
-        VirtualSchedulerTimer<VirtualMuxAlarm<'static, Pit<'static, RELOAD_1KHZ>>>;
+    VirtualSchedulerTimer<VirtualMuxAlarm<'static, Pit<'static, RELOAD_1KHZ>>>;
     fn scheduler_timer(&self) -> &Self::SchedulerTimer {
         self.scheduler_timer
     }
@@ -144,6 +144,7 @@ impl<C: Chip> KernelResources<C> for QemuI386Q35Platform {
         &()
     }
 }
+
 #[no_mangle]
 unsafe extern "cdecl" fn main() {
     // ---------- BASIC INITIALIZATION -----------
@@ -180,14 +181,8 @@ unsafe extern "cdecl" fn main() {
     let vga_uart_mux = components::console::UartMuxComponent::new(chip.vga, 115_200)
         .finalize(components::uart_mux_component_static!());
 
-    // Debug output: default to the VGA mux is
-    // active.  If you prefer to keep debug on the serial port even with VGA
-    // enabled, comment the line below and uncomment the next one.
-
     // Debug output uses VGA when available, otherwise COM1
     let debug_uart_device = vga_uart_mux;
-
-    // let debug_uart_device  = com1_uart_mux;
 
     // Create a shared virtualization mux layer on top of a single hardware
     // alarm.
@@ -238,12 +233,6 @@ unsafe extern "cdecl" fn main() {
         .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
-    // ProcessConsole stays on COM1 because we have no keyboard input yet.
-    // As soon as keyboard support will be added, the process console
-    // may be used with the VGA and keyboard.
-    //
-    // let console_uart_device = vga_uart_mux;
-
     // For now the ProcessConsole (interactive shell) is wired to COM1 so the user can
     // type commands over the serial port.  Once keyboard input is implemented
     // we can switch `console_uart_device` to `vga_uart_mux`.
@@ -257,7 +246,7 @@ unsafe extern "cdecl" fn main() {
         process_printer,
         None,
     )
-    .finalize(components::process_console_component_static!(
+        .finalize(components::process_console_component_static!(
         Pit<'static, RELOAD_1KHZ>
     ));
 
@@ -270,14 +259,14 @@ unsafe extern "cdecl" fn main() {
         debug_uart_device,
         create_capability!(capabilities::SetDebugWriterCapability),
     )
-    .finalize(components::debug_writer_component_static!());
+        .finalize(components::debug_writer_component_static!());
 
     let lldb = components::lldb::LowLevelDebugComponent::new(
         board_kernel,
         capsules_core::low_level_debug::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::low_level_debug_component_static!());
+        .finalize(components::low_level_debug_component_static!());
 
     let scheduler = components::sched::cooperative::CooperativeComponent::new(processes)
         .finalize(components::cooperative_component_static!(NUM_PROCS));
@@ -335,10 +324,10 @@ unsafe extern "cdecl" fn main() {
         &FAULT_RESPONSE,
         &process_mgmt_cap,
     )
-    .unwrap_or_else(|err| {
-        debug!("Error loading processes!");
-        debug!("{:?}", err);
-    });
+        .unwrap_or_else(|err| {
+            debug!("Error loading processes!");
+            debug!("{:?}", err);
+        });
 
     board_kernel.kernel_loop(&platform, chip, Some(&platform.ipc), &main_loop_cap);
 }

--- a/boards/qemu_i486_q35/src/main.rs
+++ b/boards/qemu_i486_q35/src/main.rs
@@ -261,6 +261,9 @@ unsafe extern "cdecl" fn main() {
     )
         .finalize(components::debug_writer_component_static!());
 
+    // Now we can safely log via `debug!()`
+    debug!("ps/2 health: {}", chip.ps2.health_snapshot());
+
     let lldb = components::lldb::LowLevelDebugComponent::new(
         board_kernel,
         capsules_core::low_level_debug::DRIVER_NUM,

--- a/boards/qemu_i486_q35/src/main.rs
+++ b/boards/qemu_i486_q35/src/main.rs
@@ -154,7 +154,7 @@ unsafe extern "cdecl" fn main() {
         &mut *ptr::addr_of_mut!(PAGE_DIR),
         &mut *ptr::addr_of_mut!(PAGE_TABLE),
         &(),
-    )
+            )
         .finalize(x86_q35::x86_q35_component_static!(()));
 
     // Acquire required capabilities
@@ -259,10 +259,8 @@ unsafe extern "cdecl" fn main() {
         debug_uart_device,
         create_capability!(capabilities::SetDebugWriterCapability),
     )
-        .finalize(components::debug_writer_component_static!());
+    .finalize(components::debug_writer_component_static!());
 
-    // Now we can safely log via `debug!()`
-    debug!("ps/2 health: {}", chip.ps2.health_snapshot());
 
     let lldb = components::lldb::LowLevelDebugComponent::new(
         board_kernel,

--- a/chips/x86_q35/src/chip.rs
+++ b/chips/x86_q35/src/chip.rs
@@ -288,7 +288,7 @@ impl<'a, I: InterruptService + 'a> PcComponent<'a, I> {
             unsafe { static_init!(crate::ps2::Ps2Controller, crate::ps2::Ps2Controller::new()) };
         kernel::deferred_call::DeferredCallClient::register(ps2);
 
-        // controller bring-up owned by the chip
+        // controller bring-up owned by the chip (no logging here)
         let _ = ps2.init_early();
 
         let pc = s.4.write(Pc {

--- a/chips/x86_q35/src/chip.rs
+++ b/chips/x86_q35/src/chip.rs
@@ -31,6 +31,8 @@ mod interrupt {
     /// Interrupt number shared by COM1 and COM3 serial devices
     pub(super) const COM1_COM3: u32 = (PIC1_OFFSET as u32) + 4;
 
+    /// Interrupt number used by the PS/2 keyboard (i8042, IRQ1).
+    /// Raised when the controller’s output buffer has data ready (OB=1).
     pub(super) const KEYBOARD: u32 = (PIC1_OFFSET as u32) + 1;
 }
 

--- a/chips/x86_q35/src/chip.rs
+++ b/chips/x86_q35/src/chip.rs
@@ -76,7 +76,7 @@ pub struct Pc<'a, I: InterruptService + 'a, const PR: u16 = RELOAD_1KHZ> {
     /// Vga
     pub vga: &'a VgaText<'a>,
 
-    /// PS/2
+    /// PS/2 Controller
     pub ps2: &'a crate::ps2::Ps2Controller,
 
     /// System call context
@@ -216,7 +216,6 @@ pub struct PcComponent<'a, I: InterruptService + 'a> {
     int_svc: &'a I,
 }
 
-
 impl<'a, I: InterruptService + 'a> PcComponent<'a, I> {
     /// Creates a new `PcComponent` instance.
     ///
@@ -234,7 +233,7 @@ impl<'a, I: InterruptService + 'a> PcComponent<'a, I> {
     }
 }
 
-impl<I: InterruptService + 'static> Component for PcComponent<'static, I> {
+    impl<I: InterruptService + 'static> Component for PcComponent<'static, I> {
     type StaticInput = (
         <SerialPortComponent as Component>::StaticInput,
         <SerialPortComponent as Component>::StaticInput,

--- a/chips/x86_q35/src/chip.rs
+++ b/chips/x86_q35/src/chip.rs
@@ -127,7 +127,6 @@ impl<'a, I: InterruptService + 'a, const PR: u16> Chip for Pc<'a, I, PR> {
                     }
                 }
 
-
                 poller.clear_pending(num);
 
                 // Unmask the interrupt so it can fire again, but only if we know how to handle it
@@ -234,7 +233,7 @@ impl<'a, I: InterruptService + 'a> PcComponent<'a, I> {
     }
 }
 
-    impl<I: InterruptService + 'static> Component for PcComponent<'static, I> {
+impl<I: InterruptService + 'static> Component for PcComponent<'static, I> {
     type StaticInput = (
         <SerialPortComponent as Component>::StaticInput,
         <SerialPortComponent as Component>::StaticInput,

--- a/chips/x86_q35/src/chip.rs
+++ b/chips/x86_q35/src/chip.rs
@@ -287,7 +287,7 @@ impl<'a, I: InterruptService + 'a> PcComponent<'a, I> {
             unsafe { static_init!(crate::ps2::Ps2Controller, crate::ps2::Ps2Controller::new()) };
         kernel::deferred_call::DeferredCallClient::register(ps2);
 
-        // controller bring-up owned by the chip (no logging here)
+        // controller bring-up owned by the chip
         let _ = ps2.init_early();
 
         let pc = s.4.write(Pc {

--- a/chips/x86_q35/src/chip.rs
+++ b/chips/x86_q35/src/chip.rs
@@ -198,7 +198,6 @@ impl<'a, I: InterruptService + 'a, const PR: u16> Chip for Pc<'a, I, PR> {
         let _ = writeln!(writer);
         let _ = writeln!(writer, "---| PC State |---");
         let _ = writeln!(writer);
-
         // todo: print out anything that might be useful
 
         let _ = writeln!(writer, "(placeholder)");

--- a/chips/x86_q35/src/lib.rs
+++ b/chips/x86_q35/src/lib.rs
@@ -23,6 +23,7 @@ mod pic;
 
 pub mod pit;
 
+pub mod ps2;
 pub mod serial;
 
 pub mod vga;

--- a/chips/x86_q35/src/ps2.rs
+++ b/chips/x86_q35/src/ps2.rs
@@ -20,7 +20,7 @@ const BUFFER_SIZE: usize = 32;
 /// Depth of the scan-code ring buffer
 const TIMEOUT_LIMIT: usize = 1_000_000;
 
-// Define the two status‐register bits
+// Status-register bits returned by inb(0x64)
 register_bitfields![u8,
     pub STATUS [
         OUTPUT_FULL OFFSET(0) NUMBITS(1), // data ready
@@ -31,6 +31,8 @@ register_bitfields![u8,
 /// Note: There is no hardware interrupt when the input buffer empties, so we must poll bit 1.
 /// See OSDev documentation:
 /// https://wiki.osdev.org/I8042_PS/2_Controller#Status_Register
+///
+/// Block until the controller’s input buffer is empty (ready for a command).
 #[inline(always)]
 fn wait_input_ready() {
     let mut s = LocalRegisterCopy::<u8, STATUS::Register>::new(0);
@@ -52,6 +54,8 @@ fn wait_input_ready() {
 /// Data-ready events trigger IRQ1, handled asynchronously in `handle_interrupt()`.
 /// See OSDev documentation:
 /// https://wiki.osdev.org/I8042_PS/2_Controller#Status_Register
+///
+/// Block until there is data ready to read in the output buffer.
 #[inline(always)]
 fn wait_output_ready() {
     let mut s = LocalRegisterCopy::<u8, STATUS::Register>::new(0);

--- a/chips/x86_q35/src/ps2.rs
+++ b/chips/x86_q35/src/ps2.rs
@@ -1,0 +1,240 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+use core::cell::{Cell, RefCell};
+use core::marker::PhantomData;
+use kernel::debug;
+use kernel::utilities::registers::register_bitfields;
+use tock_registers::LocalRegisterCopy;
+use x86::registers::io;
+
+/// PS/2 controller ports
+const PS2_DATA_PORT: u16 = 0x60;
+const PS2_STATUS_PORT: u16 = 0x64;
+const PIC1_DATA_PORT: u16 = 0x21;
+
+/// Timeout limit for spin loops
+const BUFFER_SIZE: usize = 32;
+
+/// Depth of the scan-code ring buffer
+const TIMEOUT_LIMIT: usize = 1_000_000;
+
+// Define the two status‐register bits
+register_bitfields![u8,
+    pub STATUS [
+        OUTPUT_FULL OFFSET(0) NUMBITS(1), // data ready
+        INPUT_FULL  OFFSET(1) NUMBITS(1), // input buffer full
+    ]
+];
+
+/// Note: There is no hardware interrupt when the input buffer empties, so we must poll bit 1.
+/// See OSDev documentation:
+/// https://wiki.osdev.org/I8042_PS/2_Controller#Status_Register
+#[inline(always)]
+fn wait_input_ready() {
+    let mut s = LocalRegisterCopy::<u8, STATUS::Register>::new(0);
+    let mut n = 0;
+    while {
+        s.set(unsafe { io::inb(PS2_STATUS_PORT) });
+        s.is_set(STATUS::INPUT_FULL)
+    } {
+        if {
+            n += 1;
+            n
+        } >= TIMEOUT_LIMIT
+        {
+            break;
+        }
+    }
+}
+
+/// Data-ready events trigger IRQ1, handled asynchronously in `handle_interrupt()`.
+/// See OSDev documentation:
+/// https://wiki.osdev.org/I8042_PS/2_Controller#Status_Register
+#[inline(always)]
+fn wait_output_ready() {
+    let mut s = LocalRegisterCopy::<u8, STATUS::Register>::new(0);
+    let mut n = 0;
+    while {
+        s.set(unsafe { io::inb(PS2_STATUS_PORT) });
+        !s.is_set(STATUS::OUTPUT_FULL)
+    } {
+        if {
+            n += 1;
+            n
+        } >= TIMEOUT_LIMIT
+        {
+            break;
+        }
+    }
+}
+
+/// Read one byte from the data port (0x60).
+#[inline(always)]
+fn read_data() -> u8 {
+    wait_output_ready();
+    unsafe { io::inb(PS2_DATA_PORT) }
+}
+
+/// Send a command byte to the controller (port 0x64).
+#[inline(always)]
+fn write_command(c: u8) {
+    wait_input_ready();
+    unsafe { io::outb(PS2_STATUS_PORT, c) }
+}
+/// Write a data byte to the data port (0x60).
+#[inline(always)]
+fn write_data(d: u8) {
+    wait_input_ready();
+    unsafe { io::outb(PS2_DATA_PORT, d) }
+}
+
+/// Send a byte to the keyboard and wait for ACK (`0xFA`).
+/// If the device replies RESEND (`0xFE`) we retry **once**.
+fn send_with_ack(byte: u8) -> bool {
+    for _ in 0..=1 {
+        write_data(byte);
+        let resp = read_data();
+        match resp {
+            0xFA => return true, // ACK
+            0xFE => continue,    // RESEND -> try again
+            _ => return false,   // error
+        }
+    }
+    false
+}
+
+/// PS/2 controller driver (the “8042” peripheral)
+pub struct Ps2Controller {
+    buffer: RefCell<[u8; BUFFER_SIZE]>,
+    head: Cell<usize>,
+    tail: Cell<usize>,
+    count: Cell<usize>, // new field to track number of valid entries
+    _p: PhantomData<()>,
+}
+
+impl Ps2Controller {
+    pub const fn new() -> Self {
+        Self {
+            buffer: RefCell::new([0; BUFFER_SIZE]),
+            head: Cell::new(0),
+            tail: Cell::new(0),
+            count: Cell::new(0), // ← initialize count
+            _p: PhantomData,
+        }
+    }
+    pub fn init(&self) {
+        unsafe {
+            /* disable both ports */
+            write_command(0xAD);
+            write_command(0xA7);
+
+            /* flush any stale byte */
+            while io::inb(PS2_STATUS_PORT) & 1 != 0 {
+                let _ = io::inb(PS2_DATA_PORT);
+            }
+
+            /* controller self-test */
+            write_command(0xAA);
+            let _ = {
+                wait_output_ready();
+                read_data()
+            } == 0x55;
+
+            // IRQ1 fire test
+            write_command(0x20); // request config byte
+            wait_output_ready();
+            let mut cfg = read_data();
+            cfg |= 1 << 0; // set bit0 = IRQ1 enable
+            write_command(0x60); // tell controller we’ll write it
+            write_data(cfg);
+
+            /* enable keyboard clock */
+            write_command(0xAE);
+
+            if !send_with_ack(0xF4) {
+                debug!("ps2: enable-scan failed");
+            }
+
+            /* unmask IRQ 1 */
+            let mask = io::inb(PIC1_DATA_PORT);
+            io::outb(PIC1_DATA_PORT, mask & !(1 << 1));
+            debug!("ps2: clock on, IRQ1 unmasked");
+        }
+    }
+
+    /// Handle a keyboard interrupt: read a scan-code and buffer it.
+    pub fn handle_interrupt(&self) {
+        loop {
+            if unsafe { io::inb(PS2_STATUS_PORT) } & 0x01 == 0 {
+                break;
+            }
+            let byte = unsafe { io::inb(PS2_DATA_PORT) };
+            self.push_code(byte);
+            debug!("ps2 irq 0x{:02X}", byte);
+        }
+    }
+
+    /// Pop the next scan-code, or None if buffer is empty.
+    pub fn pop_scan_code(&self) -> Option<u8> {
+        if self.count.get() == 0 {
+            return None;
+        }
+        let t = self.tail.get();
+        let b = self.buffer.borrow()[t];
+        self.tail.set((t + 1) % BUFFER_SIZE);
+        self.count.set(self.count.get() - 1);
+        Some(b)
+    }
+
+    /// Internal: push a scan-code into the ring buffer, dropping oldest if full.
+    fn push_code(&self, b: u8) {
+        let h = self.head.get();
+        self.buffer.borrow_mut()[h] = b;
+        let nh = (h + 1) % BUFFER_SIZE;
+        self.head.set(nh);
+
+        // track count and drop oldest if full:
+        if self.count.get() < BUFFER_SIZE {
+            self.count.set(self.count.get() + 1);
+        } else {
+            self.tail.set((self.tail.get() + 1) % BUFFER_SIZE);
+        }
+    }
+}
+
+// ---------- Unit tests for ring buffer only ----------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ring_buffer_basic() {
+        let dev = Ps2Controller::new();
+        // buffer empty
+        assert_eq!(dev.pop_scan_code(), None);
+        // simulate push via the internal helper
+        dev.push_code(0x10);
+        assert_eq!(dev.pop_scan_code(), Some(0x10));
+        assert_eq!(dev.pop_scan_code(), None);
+    }
+
+    #[test]
+    fn test_ring_buffer_overflow() {
+        let dev = Ps2Controller::new();
+        // fill buffer
+        for i in 0..BUFFER_SIZE {
+            dev.push_code(i as u8);
+        }
+        // overflow one slot
+        dev.push_code(0xFF);
+        // should have dropped the first (0), yielding 1..BUFFER_SIZE-1 then 0xFF
+        for expected in 1..BUFFER_SIZE {
+            assert_eq!(dev.pop_scan_code(), Some(expected as u8));
+        }
+        assert_eq!(dev.pop_scan_code(), Some(0xFF));
+        assert_eq!(dev.pop_scan_code(), None);
+    }
+}

--- a/chips/x86_q35/src/ps2.rs
+++ b/chips/x86_q35/src/ps2.rs
@@ -18,52 +18,61 @@ const BUFFER_SIZE: usize = 32;
 /// Timeout limit for spin loops
 const TIMEOUT_LIMIT: usize = 1_000_000;
 
+/// Controller Configuration Byte bits (check OSDev)
+const CFG_IRQ1: u8 = 1 << 0; // keyboard IRQ enable
+const CFG_IRQ12: u8 = 1 << 1; // mouse IRQ enable
+const CFG_DISABLE_KBD: u8 = 1 << 4; // 1=disable keyboard clock
+const CFG_DISABLE_AUX: u8 = 1 << 5; // 1=disable mouse clock
+const CFG_TRANSLATION: u8 = 1 << 6; // 1=translate Set-2->Set-1
+
 // Status-register bits returned by inb(0x64)
 register_bitfields![u8,
     pub STATUS [
-        OUTPUT_FULL OFFSET(0) NUMBITS(1), // data ready
-        INPUT_FULL  OFFSET(1) NUMBITS(1), // input buffer full
+        OUTPUT_FULL OFFSET(0) NUMBITS(1), // OB has data
+        INPUT_FULL  OFFSET(1) NUMBITS(1), // IB is full (busy)
+        // (bit2 SYSFLAG and bit3 CMD/DATA not used here)
+        AUX_OBF     OFFSET(5) NUMBITS(1), // 1 = from mouse/port2
+        TIMEOUT_ERR OFFSET(6) NUMBITS(1),
+        PARITY_ERR  OFFSET(7) NUMBITS(1),
     ]
 ];
 
-/// This will be explained in the future but we need this
-/// to separate possible errors/issues so we don't hang the kernel
-/// if the controller breaks, for now, we return something on failure
+/// Error types that  the controller can return
+/// so we don't bring the whole kernel down
+/// if something breaks in a peripheral
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Ps2Error {
-    InitFailed,
+    TimeoutIB,
+    TimeoutOB,
+    SelfTestFailed,
+    Port1TestFailed,
+    AckError,
+    ControllerTimeout,
+    UnexpectedResponse(u8),
 }
+
+pub type Ps2Result<T> = core::result::Result<T, Ps2Error>;
 
 /// Note: There is no hardware interrupt when the input buffer empties, so we must poll bit 1.
 /// See OSDev documentation:
 /// https://wiki.osdev.org/I8042_PS/2_Controller#Status_Register
 ///
 /// Block until the controller’s input buffer is empty (ready for a command).
+
 #[inline(always)]
-fn wait_input_ready() {
-    // Local copy of the status register
-    let mut status_reg = LocalRegisterCopy::<u8, STATUS::Register>::new(0);
-    // Loop counter to avoid infinite spin
+fn wait_ib_empty() -> Ps2Result<()> {
+    let mut status = LocalRegisterCopy::<u8, STATUS::Register>::new(0);
     let mut loops = 0;
-
-    // Continue spinning while the INPUT_FULL bit is set
     while {
-        // Fetch latest status from hardware port
-        let raw = read_status();
-
-        status_reg.set(raw);
-
-        // Check if controller is still busy (input buffer full)
-        status_reg.is_set(STATUS::INPUT_FULL)
+        status.set(read_status());
+        status.is_set(STATUS::INPUT_FULL)
     } {
-        // Increment our loop counter and bail out on timeout
         loops += 1;
         if loops >= TIMEOUT_LIMIT {
-            // We could log a debug here if desired:
-            // debug!("ps2: wait_input_ready timed out after {} loops", loops);
-            break;
+            return Err(Ps2Error::TimeoutIB);
         }
     }
+    Ok(())
 }
 
 /// Data-ready events trigger IRQ1, handled asynchronously in `handle_interrupt()`.
@@ -72,53 +81,178 @@ fn wait_input_ready() {
 ///
 /// Block until there is data ready to read in the output buffer.
 #[inline(always)]
-fn wait_output_ready() {
-    // Local copy of the status register
-    let mut status_reg = LocalRegisterCopy::<u8, STATUS::Register>::new(0);
-    // Loop counter to prevent infinite spin
+fn wait_ob_full() -> Ps2Result<()> {
+    let mut status = LocalRegisterCopy::<u8, STATUS::Register>::new(0);
     let mut loops = 0;
-
-    // Continue spinning while the OUTPUT_FULL bit is *not* set
     while {
-        // Read current status from the controller
-        let raw = unsafe { io::inb(PS2_STATUS_PORT) };
-        status_reg.set(raw);
-
-        // Keep looping if no data is available yet
-        !status_reg.is_set(STATUS::OUTPUT_FULL)
+        status.set(read_status());
+        !status.is_set(STATUS::OUTPUT_FULL)
     } {
-        // Increment loop counter and abort on timeout
         loops += 1;
         if loops >= TIMEOUT_LIMIT {
-            // Optionally log a timeout here:
-            // debug!("ps2: wait_output_ready timed out after {} loops", loops);
-            break;
+            return Err(Ps2Error::TimeoutOB);
         }
     }
+    Ok(())
 }
 
 /// Read one byte from the data port (0x60).
 #[inline(always)]
-fn read_data() -> u8 {
-    wait_output_ready();
-    unsafe { io::inb(PS2_DATA_PORT) }
+fn read_data() -> Ps2Result<u8> {
+    wait_ob_full()?;
+    Ok(unsafe { io::inb(PS2_DATA_PORT) })
 }
 
 /// Send a command byte to the controller (port 0x64).
 #[inline(always)]
-fn write_command(c: u8) {
-    wait_input_ready();
+fn write_command(c: u8) -> Ps2Result<()> {
+    wait_ib_empty()?;
     unsafe { io::outb(PS2_STATUS_PORT, c) }
+    Ok(())
 }
+
 /// Write a data byte to the data port (0x60).
 #[inline(always)]
-fn write_data(d: u8) {
-    wait_input_ready();
+fn write_data(d: u8) -> Ps2Result<()> {
+    wait_ib_empty()?;
     unsafe { io::outb(PS2_DATA_PORT, d) }
+    Ok(())
 }
+
 #[inline(always)]
 fn read_status() -> u8 {
     unsafe { io::inb(PS2_STATUS_PORT) }
+}
+
+fn read_config() -> Ps2Result<u8> {
+    write_command(0x20)?; // Read Controller Configuration Byte
+    read_data()
+}
+
+fn write_config(cfg: u8) -> Ps2Result<()> {
+    write_command(0x60)?; // Write Controller Configuration Byte
+    write_data(cfg)
+}
+
+fn update_config<F: FnOnce(u8) -> u8>(f: F) -> Ps2Result<u8> {
+    let cur = read_config()?;
+    let new = f(cur);
+    write_config(new)?;
+    Ok(new)
+}
+
+/// Config helpers so we don't break the whole address in the init
+/// we can do it sequentially
+
+fn cfg_set_translation(enabled: bool) -> Ps2Result<u8> {
+    update_config(|mut c| {
+        if enabled {
+            c |= CFG_TRANSLATION
+        } else {
+            c &= !CFG_TRANSLATION
+        }
+        c
+    })
+}
+
+fn cfg_set_port1_clock(enabled: bool) -> Ps2Result<u8> {
+    // enabled => clear DISABLE_KBD bit
+    update_config(|mut c| {
+        if enabled {
+            c &= !CFG_DISABLE_KBD
+        } else {
+            c |= CFG_DISABLE_KBD
+        }
+        c
+    })
+}
+
+fn cfg_set_port2_clock(enabled: bool) -> Ps2Result<u8> {
+    // enabled => clear DISABLE_AUX bit
+    update_config(|mut c| {
+        if enabled {
+            c &= !CFG_DISABLE_AUX
+        } else {
+            c |= CFG_DISABLE_AUX
+        }
+        c
+    })
+}
+
+fn cfg_set_irq1(enabled: bool) -> Ps2Result<u8> {
+    update_config(|mut c| {
+        if enabled {
+            c |= CFG_IRQ1
+        } else {
+            c &= !CFG_IRQ1
+        }
+        c
+    })
+}
+
+fn cfg_set_irq12(enabled: bool) -> Ps2Result<u8> {
+    update_config(|mut c| {
+        if enabled {
+            c |= CFG_IRQ12
+        } else {
+            c &= !CFG_IRQ12
+        }
+        c
+    })
+}
+fn disable_ports() -> Ps2Result<()> {
+    write_command(0xAD)?; // disable keyboard (port 1)
+    write_command(0xA7)?; // disable aux (port 2)
+    Ok(())
+}
+
+fn flush_output_buffer() -> Ps2Result<()> {
+    while read_status() & 0x01 != 0 {
+        let _ = read_data()?; // non-blocking-ish: read_data waits only if OB set
+    }
+    Ok(())
+}
+
+fn controller_self_test() -> Ps2Result<()> {
+    write_command(0xAA)?;
+    match read_data()? {
+        0x55 => Ok(()),
+        other => Err(Ps2Error::UnexpectedResponse(other)),
+    }
+}
+
+fn port1_interface_test() -> Ps2Result<()> {
+    write_command(0xAB)?;
+    match read_data()? {
+        0x00 => Ok(()),
+        other => Err(Ps2Error::UnexpectedResponse(other)),
+    }
+}
+
+fn enable_port1_clock() -> Ps2Result<()> {
+    write_command(0xAE)
+}
+
+fn kbd_disable_scan() -> Ps2Result<()> {
+    send_with_ack(0xF5, 3)
+}
+
+fn kbd_reset_and_wait_bat() -> Ps2Result<()> {
+    send_with_ack(0xFF, 3)?; // ACK for reset
+    match read_data()? {
+        // BAT result
+        0xAA => Ok(()),
+        other => Err(Ps2Error::UnexpectedResponse(other)),
+    }
+}
+
+fn kbd_set_scancode_set2() -> Ps2Result<()> {
+    send_with_ack(0xF0, 3)?;
+    send_with_ack(0x02, 3)
+}
+
+fn kbd_enable_scan() -> Ps2Result<()> {
+    send_with_ack(0xF4, 3)
 }
 
 /// Send a byte to the keyboard and wait for ACK (`0xFA`).
@@ -126,18 +260,19 @@ fn read_status() -> u8 {
 ///
 /// Heads-up: this will be modified in the keyboard driver
 /// to better handle command requests,
-/// this is just a showcase... for now
-fn send_with_ack(byte: u8) -> bool {
-    for _ in 0..=1 {
-        write_data(byte);
-        let resp = read_data();
+fn send_with_ack(byte: u8, tries: u8) -> Ps2Result<()> {
+    let mut attempts = 0;
+    loop {
+        attempts += 1;
+        write_data(byte)?;
+        let resp = read_data()?;
         match resp {
-            0xFA => return true, // ACK
-            0xFE => continue,    // RESEND -> try again
-            _ => return false,   // error
+            0xFA => return Ok(()),                // ACK
+            0xFE if attempts < tries => continue, // RESEND -> retry
+            0xFE => return Err(Ps2Error::AckError),
+            other => return Err(Ps2Error::UnexpectedResponse(other)),
         }
     }
-    false
 }
 
 /// PS/2 controller driver (the “8042” peripheral)
@@ -146,6 +281,9 @@ pub struct Ps2Controller {
     head: Cell<usize>,
     tail: Cell<usize>,
     count: Cell<usize>, // new field to track number of valid entries
+    // track prefix bytes for logging => press/release only inputs
+    break_next: Cell<bool>, // saw 0xF0; next data byte is a BREAK
+    ext_next: Cell<bool>,   // saw 0xE0; next data byte is extended
 }
 
 impl Ps2Controller {
@@ -155,74 +293,52 @@ impl Ps2Controller {
             head: Cell::new(0),
             tail: Cell::new(0),
             count: Cell::new(0),
+            break_next: Cell::new(false),
+            ext_next: Cell::new(false),
         }
     }
 
     /// Pure controller + device bring-up.
     /// No logging, no PIC masking/unmasking, no CPU-IRQ enabling. (hopefully)
     /// Called by PcComponent::finalize() (chip layer).
+    ///
     /// Whole goal of this change is to stop nagging the memory directly
-    pub fn init_early(&self) -> Result<(), Ps2Error> {
-        // disable both ports
-        write_command(0xAD); // disable keyboard (port 1)
-        write_command(0xA7); // disable aux/mouse (port 2)
+    /// We created tiny wrappers and helpers, so we can configure the init
+    /// much easier
+    pub fn init_early(&self) -> Ps2Result<()> {
+        // disable ports; flush OB
+        disable_ports()?;
+        flush_output_buffer()?;
 
-        // flush any stale bytes from the output buffer
-        while read_status() & 0x01 != 0 {
-            let _ = unsafe { io::inb(PS2_DATA_PORT) };
-        }
+        // controller self-test
+        controller_self_test()?;
 
-        // controller self-test: 0xAA -> expect 0x55
-        write_command(0xAA);
-        wait_output_ready();
-        if read_data() != 0x55 {
-            return Err(Ps2Error::InitFailed);
-        }
+        // config policy (do not generate IRQs during tests)
+        cfg_set_irq1(false)?; // IRQ1 off
+        cfg_set_irq12(false)?; // IRQ12 off
+        cfg_set_translation(false)?; // translation OFF (we want Set2)
+        cfg_set_port1_clock(true)?; // keyboard clock enabled
+        cfg_set_port2_clock(false)?; // mouse clock disabled (for now)
 
-        // read config, ensure IRQ1 off during tests
-        write_command(0x20); // read config
-        wait_output_ready();
-        let mut cfg = read_data();
-        cfg &= !(1 << 0); // IRQ1 = 0 (off)
-        write_command(0x60); // write config
-        write_data(cfg);
+        // port1 test then enable keyboard clock at the controller command level
+        port1_interface_test()?;
+        enable_port1_clock()?; // 0xAE
 
-        // port 1 (keyboard) interface test: 0xAB -> expect 0x00
-        write_command(0xAB);
-        wait_output_ready();
-        if read_data() != 0x00 {
-            return Err(Ps2Error::InitFailed);
-        }
-
-        // enable keyboard clock
-        write_command(0xAE);
-
-        // enable scanning (strict Set-2 policy comes in the future)
-        if !send_with_ack(0xF4) {
-            return Err(Ps2Error::InitFailed);
-        }
-
-        // re-enable IRQ1 in the *controller* (PIC unmask is done in chip)
-        write_command(0x20);
-        wait_output_ready();
-        let mut cfg2 = read_data();
-        cfg2 |= 1 << 0; // IRQ1 = 1 (on)
-        write_command(0x60);
-        write_data(cfg2);
+        // device sequence (keyboard)
+        kbd_disable_scan()?; // F5
+        kbd_reset_and_wait_bat()?; // FF -> BAT=AA
+        kbd_set_scancode_set2()?; // F0 02
+        cfg_set_irq1(true)?; // turn on controller-side IRQ1 (PIC policy lives in chip)
+        kbd_enable_scan()?; // F4
 
         Ok(())
     }
 
-    /// Legacy wrapper: keep around short-term so old call sites compile.
-    /// Chip will call `init_early()` instead.
-    /// for now
-    #[deprecated(note = "Use init_early() from the chip bring-up.")]
-    pub fn init(&self) {
-        let _ = self.init_early();
-    }
-
     /// Handle a keyboard interrupt: read a scan-code and buffer it.
-    pub fn handle_interrupt(&self) {
+    /// as of now it works, but it prints press/release as well
+    /// which gets messy in the terminal
+    /// for testing, i'll make it so we only log make/break events
+    /* pub fn handle_interrupt(&self) {
         loop {
             if unsafe { io::inb(PS2_STATUS_PORT) } & 0x01 == 0 {
                 break;
@@ -230,6 +346,78 @@ impl Ps2Controller {
             let byte = unsafe { io::inb(PS2_DATA_PORT) };
             self.push_code(byte);
             debug!("ps2 irq 0x{:02X}", byte);
+        }
+    }*/
+
+    pub fn handle_interrupt(&self) {
+        loop {
+            // Snapshot the controller status. Bit0 (OUTPUT_FULL) says whether
+            // there's a byte waiting in the output buffer (OB) at 0x60.
+            let status = read_status();
+            if (status & 0x01) == 0 {
+                // OUTPUT_FULL == 0 => no more data
+                break;
+            }
+
+            // Reading 0x60 pops one byte from OB and (for that byte) clears OUTPUT_FULL.
+            let b = unsafe { io::inb(PS2_DATA_PORT) };
+
+            // Check error flags associated with this byte:
+            // bit7 PARITY_ERR
+            // bit6 TIMEOUT_ERR
+            // If either is set we drop the byte (we already consumed OB by reading).
+            let parity = (status & (1 << 7)) != 0;
+            let timeout = (status & (1 << 6)) != 0;
+            if parity || timeout {
+                debug!(
+                    "ps2: dropped byte {:02X} ({}{})",
+                    b,
+                    if parity { "PARITY" } else { "" },
+                    if timeout {
+                        if parity {
+                            "+"
+                        } else {
+                            ""
+                        }
+                    } else {
+                        ""
+                    }
+                );
+                continue; // don’t push/log corrupted data
+            }
+
+            // Always preserve the raw stream (including prefixes) for the future keyboard driver.
+            self.push_code(b);
+
+            // Set-2 uses prefixes:
+            // - 0xE0 marks "extended" keys (next data byte is extended)
+            // - 0xF0 marks a BREAK (key release) for the next data byte
+            // We don't log prefixes themselves; we just remember them.
+            if b == 0xE0 {
+                self.ext_next.set(true);
+                continue;
+            }
+            if b == 0xF0 {
+                self.break_next.set(true);
+                continue;
+            }
+
+            // At this point `b` is a real scancode byte (not a prefix).
+            // Consume the remembered prefix flags to print exactly one MAKE/BREAK line.
+            let ext = self.ext_next.get();
+            let brk = self.break_next.get();
+            if ext {
+                self.ext_next.set(false);
+            }
+            if brk {
+                self.break_next.set(false);
+            }
+
+            if brk {
+                debug!("ps2: BREAK {}{:02X}", if ext { "E0 " } else { "" }, b);
+            } else {
+                debug!("ps2: MAKE  {}{:02X}", if ext { "E0 " } else { "" }, b);
+            }
         }
     }
 
@@ -257,40 +445,5 @@ impl Ps2Controller {
         } else {
             self.tail.set((self.tail.get() + 1) % BUFFER_SIZE);
         }
-    }
-}
-
-// ---------- Unit tests for ring buffer only ----------
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_ring_buffer_basic() {
-        let dev = Ps2Controller::new();
-        // buffer empty
-        assert_eq!(dev.pop_scan_code(), None);
-        // simulate push via the internal helper
-        dev.push_code(0x10);
-        assert_eq!(dev.pop_scan_code(), Some(0x10));
-        assert_eq!(dev.pop_scan_code(), None);
-    }
-
-    #[test]
-    fn test_ring_buffer_overflow() {
-        let dev = Ps2Controller::new();
-        // fill buffer
-        for i in 0..BUFFER_SIZE {
-            dev.push_code(i as u8);
-        }
-        // overflow one slot
-        dev.push_code(0xFF);
-        // should have dropped the first (0), yielding 1..BUFFER_SIZE-1 then 0xFF
-        for expected in 1..BUFFER_SIZE {
-            assert_eq!(dev.pop_scan_code(), Some(expected as u8));
-        }
-        assert_eq!(dev.pop_scan_code(), Some(0xFF));
-        assert_eq!(dev.pop_scan_code(), None);
     }
 }

--- a/chips/x86_q35/src/ps2.rs
+++ b/chips/x86_q35/src/ps2.rs
@@ -121,7 +121,7 @@ pub type Ps2Result<T> = core::result::Result<T, Ps2Error>;
 /// Block until the controller’s input buffer is empty (ready for a command).
 
 #[inline(always)]
-fn wait_ib_empty_with(limit: usize) -> Ps2Result<()> {
+fn wait_ib_empty_with_timeout(limit: usize) -> Ps2Result<()> {
     let mut spins = 0usize;
     while read_status().is_set(STATUS::INPUT_FULL) {
         spins += 1;
@@ -138,7 +138,7 @@ fn wait_ib_empty_with(limit: usize) -> Ps2Result<()> {
 ///
 /// Block until there is data ready to read in the output buffer.
 #[inline(always)]
-fn wait_ob_full_with(limit: usize) -> Ps2Result<()> {
+fn wait_ob_full_with_timeout(limit: usize) -> Ps2Result<()> {
     let mut spins = 0usize;
     while !read_status().is_set(STATUS::OUTPUT_FULL) {
         spins += 1;
@@ -152,14 +152,14 @@ fn wait_ob_full_with(limit: usize) -> Ps2Result<()> {
 /// Read one byte from the data port (0x60).
 #[inline(always)]
 fn read_data_with(limit: usize) -> Ps2Result<u8> {
-    wait_ob_full_with(limit)?;
+    wait_ob_full_with_timeout(limit)?;
     Ok(unsafe { io::inb(PS2_DATA_PORT) })
 }
 
 /// Send a command byte to the controller (port 0x64).
 #[inline(always)]
 fn write_command_with(c: u8, limit: usize) -> Ps2Result<()> {
-    wait_ib_empty_with(limit)?;
+    wait_ib_empty_with_timeout(limit)?;
     unsafe { io::outb(PS2_STATUS_PORT, c) }
     Ok(())
 }
@@ -167,7 +167,7 @@ fn write_command_with(c: u8, limit: usize) -> Ps2Result<()> {
 /// Write a data byte to the data port (0x60).
 #[inline(always)]
 fn write_data_with(d: u8, limit: usize) -> Ps2Result<()> {
-    wait_ib_empty_with(limit)?;
+    wait_ib_empty_with_timeout(limit)?;
     unsafe { io::outb(PS2_DATA_PORT, d) }
     Ok(())
 }

--- a/chips/x86_q35/src/ps2.rs
+++ b/chips/x86_q35/src/ps2.rs
@@ -113,8 +113,6 @@ impl core::fmt::Display for Ps2Health {
     }
 }
 
-pub type Ps2Result<T> = core::result::Result<T, Ps2Error>;
-
 /// Note: There is no hardware interrupt when the input buffer empties, so we must poll bit 1.
 /// See OSDev documentation:
 /// https://wiki.osdev.org/I8042_PS/2_Controller#Status_Register
@@ -122,7 +120,7 @@ pub type Ps2Result<T> = core::result::Result<T, Ps2Error>;
 /// Block until the controller’s input buffer is empty (ready for a command).
 
 #[inline(always)]
-fn wait_ib_empty_with_timeout(limit: usize) -> Ps2Result<()> {
+fn wait_ib_empty_with_timeout(limit: usize) -> Result<(), Ps2Error> {
     let mut spins = 0usize;
     while read_status().is_set(STATUS::INPUT_FULL) {
         spins += 1;
@@ -139,7 +137,7 @@ fn wait_ib_empty_with_timeout(limit: usize) -> Ps2Result<()> {
 ///
 /// Block until there is data ready to read in the output buffer.
 #[inline(always)]
-fn wait_ob_full_with_timeout(limit: usize) -> Ps2Result<()> {
+fn wait_ob_full_with_timeout(limit: usize) -> Result<(), Ps2Error> {
     let mut spins = 0usize;
     while !read_status().is_set(STATUS::OUTPUT_FULL) {
         spins += 1;
@@ -152,14 +150,14 @@ fn wait_ob_full_with_timeout(limit: usize) -> Ps2Result<()> {
 
 /// Read one byte from the data port (0x60).
 #[inline(always)]
-fn read_data_with(limit: usize) -> Ps2Result<u8> {
+fn read_data_with(limit: usize) -> Result<u8, Ps2Error> {
     wait_ob_full_with_timeout(limit)?;
     Ok(unsafe { io::inb(PS2_DATA_PORT) })
 }
 
 /// Send a command byte to the controller (port 0x64).
 #[inline(always)]
-fn write_command_with(c: u8, limit: usize) -> Ps2Result<()> {
+fn write_command_with(c: u8, limit: usize) -> Result<(), Ps2Error> {
     wait_ib_empty_with_timeout(limit)?;
     unsafe { io::outb(PS2_STATUS_PORT, c) }
     Ok(())
@@ -167,7 +165,7 @@ fn write_command_with(c: u8, limit: usize) -> Ps2Result<()> {
 
 /// Write a data byte to the data port (0x60).
 #[inline(always)]
-fn write_data_with(d: u8, limit: usize) -> Ps2Result<()> {
+fn write_data_with(d: u8, limit: usize) -> Result<(), Ps2Error> {
     wait_ib_empty_with_timeout(limit)?;
     unsafe { io::outb(PS2_DATA_PORT, d) }
     Ok(())
@@ -178,7 +176,7 @@ fn read_status() -> LocalRegisterCopy<u8, STATUS::Register> {
 }
 
 #[inline(always)]
-fn read_config_reg_with(limit: usize) -> Ps2Result<LocalRegisterCopy<u8, CONFIG::Register>> {
+fn read_config_reg_with(limit: usize) -> Result<LocalRegisterCopy<u8, CONFIG::Register>, Ps2Error> {
     write_command_with(0x20, limit)?; // Read Controller Configuration Byte
     Ok(LocalRegisterCopy::new(read_data_with(limit)?))
 }
@@ -187,12 +185,12 @@ fn read_config_reg_with(limit: usize) -> Ps2Result<LocalRegisterCopy<u8, CONFIG:
 fn write_config_reg_with(
     cfg: LocalRegisterCopy<u8, CONFIG::Register>,
     limit: usize,
-) -> Ps2Result<()> {
+) -> Result<(), Ps2Error> {
     write_command_with(0x60, limit)?; // Write Controller Configuration Byte
     write_data_with(cfg.get(), limit)
 }
 
-fn update_config_with<F>(limit: usize, f: F) -> Ps2Result<u8>
+fn update_config_with<F>(limit: usize, f: F) -> Result<u8, Ps2Error>
 where
     F: FnOnce(LocalRegisterCopy<u8, CONFIG::Register>) -> LocalRegisterCopy<u8, CONFIG::Register>,
 {
@@ -202,7 +200,7 @@ where
     Ok(new.get())
 }
 
-fn flush_output_buffer() -> Ps2Result<()> {
+fn flush_output_buffer() -> Result<(), Ps2Error> {
     // Poll status; if OB has data, read once and loop.
     // Use the small runtime budget for the read.
     while read_status().is_set(STATUS::OUTPUT_FULL) {
@@ -280,7 +278,7 @@ impl Ps2Controller {
 
     /// Count controller wait timeouts
     #[inline(always)]
-    fn tally_timeout<T>(&self, r: Ps2Result<T>) -> Ps2Result<T> {
+    fn tally_timeout<T>(&self, r: Result<T, Ps2Error>) -> Result<T, Ps2Error> {
         if matches!(r, Err(Ps2Error::TimeoutIB) | Err(Ps2Error::TimeoutOB)) {
             self.timeouts.set(self.timeouts.get().wrapping_add(1));
         }
@@ -297,7 +295,7 @@ impl Ps2Controller {
     /// `Ok(())` on ACK
     /// `Err(Ps2Error::AckError)` if RESEND persists after all retries
     /// `Err(Ps2Error::UnexpectedResponse(_))` for any other response byte
-    fn send_with_ack_limit(&self, byte: u8, tries: u8, limit: usize) -> Ps2Result<()> {
+    fn send_with_ack_limit(&self, byte: u8, tries: u8, limit: usize) -> Result<(), Ps2Error> {
         let mut attempts = 0;
         loop {
             attempts += 1;
@@ -327,7 +325,7 @@ impl Ps2Controller {
     ///
     /// For testing and health of the controller, we'll wrap each call with
     /// tally_timeout helper
-    pub fn init_early_with_spins(&self, spins: usize) -> Ps2Result<()> {
+    pub fn init_early_with_spins(&self, spins: usize) -> Result<(), Ps2Error> {
         // disable ports; flush OB
         self.tally_timeout(write_command_with(0xAD, spins))?;
         self.tally_timeout(write_command_with(0xA7, spins))?;
@@ -395,7 +393,7 @@ impl Ps2Controller {
     }
 
     /// Back-compat wrapper: long spin budget during bring-up.
-    pub fn init_early(&self) -> Ps2Result<()> {
+    pub fn init_early(&self) -> Result<(), Ps2Error> {
         self.init_early_with_spins(SPINS_INIT)
     }
     pub fn handle_interrupt(&self) {

--- a/chips/x86_q35/src/ps2.rs
+++ b/chips/x86_q35/src/ps2.rs
@@ -199,13 +199,9 @@ fn write_config_reg(cfg: LocalRegisterCopy<u8, CONFIG::Register>) -> Ps2Result<(
     write_data(cfg.get())
 }
 
-
-fn update_config<F>(
-    f: F,
-) -> Ps2Result<u8>
+fn update_config<F>(f: F) -> Ps2Result<u8>
 where
-    F: FnOnce(LocalRegisterCopy<u8, CONFIG::Register>)
-        -> LocalRegisterCopy<u8, CONFIG::Register>,
+    F: FnOnce(LocalRegisterCopy<u8, CONFIG::Register>) -> LocalRegisterCopy<u8, CONFIG::Register>,
 {
     let cur = read_config_reg()?;
     let new = f(cur);
@@ -213,14 +209,16 @@ where
     Ok(new.get())
 }
 
-
 /// Config helpers so we don't break the whole address in the init
 /// we can do it sequentially
 
 fn cfg_set_translation(enabled: bool) -> Ps2Result<u8> {
     update_config(|mut c| {
-        if enabled { c.modify(CONFIG::TRANSLATION::SET); }
-        else       { c.modify(CONFIG::TRANSLATION::CLEAR); }
+        if enabled {
+            c.modify(CONFIG::TRANSLATION::SET);
+        } else {
+            c.modify(CONFIG::TRANSLATION::CLEAR);
+        }
         c
     })
 }
@@ -228,8 +226,11 @@ fn cfg_set_translation(enabled: bool) -> Ps2Result<u8> {
 fn cfg_set_port1_clock(enabled: bool) -> Ps2Result<u8> {
     // enabled => clear DISABLE_KBD bit
     update_config(|mut c| {
-        if enabled { c.modify(CONFIG::DISABLE_KBD::CLEAR); }
-        else       { c.modify(CONFIG::DISABLE_KBD::SET); }
+        if enabled {
+            c.modify(CONFIG::DISABLE_KBD::CLEAR);
+        } else {
+            c.modify(CONFIG::DISABLE_KBD::SET);
+        }
         c
     })
 }
@@ -237,24 +238,33 @@ fn cfg_set_port1_clock(enabled: bool) -> Ps2Result<u8> {
 fn cfg_set_port2_clock(enabled: bool) -> Ps2Result<u8> {
     // enabled => clear DISABLE_AUX bit
     update_config(|mut c| {
-        if enabled { c.modify(CONFIG::DISABLE_AUX::CLEAR); }
-        else       { c.modify(CONFIG::DISABLE_AUX::SET); }
+        if enabled {
+            c.modify(CONFIG::DISABLE_AUX::CLEAR);
+        } else {
+            c.modify(CONFIG::DISABLE_AUX::SET);
+        }
         c
     })
 }
 
 fn cfg_set_irq1(enabled: bool) -> Ps2Result<u8> {
     update_config(|mut c| {
-        if enabled { c.modify(CONFIG::IRQ1::SET); }
-        else       { c.modify(CONFIG::IRQ1::CLEAR); }
+        if enabled {
+            c.modify(CONFIG::IRQ1::SET);
+        } else {
+            c.modify(CONFIG::IRQ1::CLEAR);
+        }
         c
     })
 }
 
 fn cfg_set_irq12(enabled: bool) -> Ps2Result<u8> {
     update_config(|mut c| {
-        if enabled { c.modify(CONFIG::IRQ12::SET); }
-        else       { c.modify(CONFIG::IRQ12::CLEAR); }
+        if enabled {
+            c.modify(CONFIG::IRQ12::SET);
+        } else {
+            c.modify(CONFIG::IRQ12::CLEAR);
+        }
         c
     })
 }

--- a/chips/x86_q35/src/ps2.rs
+++ b/chips/x86_q35/src/ps2.rs
@@ -118,7 +118,6 @@ impl core::fmt::Display for Ps2Health {
 /// https://wiki.osdev.org/I8042_PS/2_Controller#Status_Register
 ///
 /// Block until the controller’s input buffer is empty (ready for a command).
-
 #[inline(always)]
 fn wait_ib_empty_with_timeout(limit: usize) -> Result<(), Ps2Error> {
     let mut spins = 0usize;


### PR DESCRIPTION
### Pull Request Overview

This pull request adds an i8042 PS/2 controller for the x86_q35 platform and wires it into the board/chip (all was done according to https://wiki.osdev.org/I8042_PS/2_Controller)

- Implements controller bring-up (init_early): disable ports, flush OB, self-test, typed config byte updates (translation OFF, clocks/IRQs as needed), keyboard port test/enable, and device init (F5, FF => AA, F0 02, F4).

- Interrupt/top-half: reads OB, drops bytes with parity/timeout errors, enqueues scan codes, and schedules a deferred call.

- Deferred/bottom-half: drains a ring buffer and currently logs Set-2 MAKE/BREAK lines; also exposes a client hook:
`pub trait Ps2Client { fn receive_scancode(&self, code: u8); }`
`pub fn set_client(&self, client: &'static dyn Ps2Client)`

- Observability: adds `Ps2Health { bytes_rx, overruns, parity_err, timeout_err, timeouts, resends }` and `health_snapshot()`, with periodic debug logging.

- Uses `LocalRegisterCopy<u8, CONFIG::Register>` for typed, safe CONFIG-byte manipulation.

- Integrates with PcComponent: registers as a DeferredCallClient, dispatches IRQ1 to the controller, and runs bring-up during finalize.

### Testing Strategy

This pull request was tested by running on QEMU 

- Verified IRQ1 fires, ISR queues bytes, and deferred call drains/logs MAKE/BREAK for key presses.

- Observed bytes_rx increasing in health logs; no parity/timeout drops seen during normal typing.

- Confirmed no regressions in PIT and serial console paths; kernel boots and services interrupts normally.


### TODO or Help Wanted
- Keyboard driver which connects to this controller, (https://github.com/tock/tock/pull/4595)
- Keyboard capsule: consume Set-2 stream via Ps2Client, translate to key events, and plumb into the process console (soon!!!!)
- Optional port 2 (mouse) probing/enable remains off by default; add probe + support in a follow-up.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
