### PR TITLE
x86_q35: add keyboard driver over i8042 controller

### DIFF
--- a/boards/qemu_i486_q35/src/main.rs
+++ b/boards/qemu_i486_q35/src/main.rs
@@ -129,7 +129,7 @@ impl<C: Chip> KernelResources<C> for QemuI386Q35Platform {
     }
 
     type SchedulerTimer =
-    VirtualSchedulerTimer<VirtualMuxAlarm<'static, Pit<'static, RELOAD_1KHZ>>>;
+        VirtualSchedulerTimer<VirtualMuxAlarm<'static, Pit<'static, RELOAD_1KHZ>>>;
     fn scheduler_timer(&self) -> &Self::SchedulerTimer {
         self.scheduler_timer
     }
@@ -154,8 +154,8 @@ unsafe extern "cdecl" fn main() {
         &mut *ptr::addr_of_mut!(PAGE_DIR),
         &mut *ptr::addr_of_mut!(PAGE_TABLE),
         &(),
-            )
-        .finalize(x86_q35::x86_q35_component_static!(()));
+    )
+    .finalize(x86_q35::x86_q35_component_static!(()));
 
     // Acquire required capabilities
     let process_mgmt_cap = create_capability!(capabilities::ProcessManagementCapability);
@@ -246,7 +246,7 @@ unsafe extern "cdecl" fn main() {
         process_printer,
         None,
     )
-        .finalize(components::process_console_component_static!(
+    .finalize(components::process_console_component_static!(
         Pit<'static, RELOAD_1KHZ>
     ));
 
@@ -261,13 +261,12 @@ unsafe extern "cdecl" fn main() {
     )
     .finalize(components::debug_writer_component_static!());
 
-
     let lldb = components::lldb::LowLevelDebugComponent::new(
         board_kernel,
         capsules_core::low_level_debug::DRIVER_NUM,
         uart_mux,
     )
-        .finalize(components::low_level_debug_component_static!());
+    .finalize(components::low_level_debug_component_static!());
 
     let scheduler = components::sched::cooperative::CooperativeComponent::new(processes)
         .finalize(components::cooperative_component_static!(NUM_PROCS));
@@ -325,10 +324,10 @@ unsafe extern "cdecl" fn main() {
         &FAULT_RESPONSE,
         &process_mgmt_cap,
     )
-        .unwrap_or_else(|err| {
-            debug!("Error loading processes!");
-            debug!("{:?}", err);
-        });
+    .unwrap_or_else(|err| {
+        debug!("Error loading processes!");
+        debug!("{:?}", err);
+    });
 
     board_kernel.kernel_loop(&platform, chip, Some(&platform.ipc), &main_loop_cap);
 }

--- a/boards/qemu_i486_q35/src/main.rs
+++ b/boards/qemu_i486_q35/src/main.rs
@@ -154,7 +154,7 @@ unsafe extern "cdecl" fn main() {
         &mut *ptr::addr_of_mut!(PAGE_TABLE),
         &(),
     )
-    .finalize(x86_q35::x86_q35_component_static!(()));
+        .finalize(x86_q35::x86_q35_component_static!(()));
 
     // Acquire required capabilities
     let process_mgmt_cap = create_capability!(capabilities::ProcessManagementCapability);

--- a/boards/qemu_i486_q35/src/main.rs
+++ b/boards/qemu_i486_q35/src/main.rs
@@ -129,7 +129,7 @@ impl<C: Chip> KernelResources<C> for QemuI386Q35Platform {
     }
 
     type SchedulerTimer =
-        VirtualSchedulerTimer<VirtualMuxAlarm<'static, Pit<'static, RELOAD_1KHZ>>>;
+    VirtualSchedulerTimer<VirtualMuxAlarm<'static, Pit<'static, RELOAD_1KHZ>>>;
     fn scheduler_timer(&self) -> &Self::SchedulerTimer {
         self.scheduler_timer
     }
@@ -144,6 +144,7 @@ impl<C: Chip> KernelResources<C> for QemuI386Q35Platform {
         &()
     }
 }
+
 #[no_mangle]
 unsafe extern "cdecl" fn main() {
     // ---------- BASIC INITIALIZATION -----------
@@ -180,14 +181,8 @@ unsafe extern "cdecl" fn main() {
     let vga_uart_mux = components::console::UartMuxComponent::new(chip.vga, 115_200)
         .finalize(components::uart_mux_component_static!());
 
-    // Debug output: default to the VGA mux is
-    // active.  If you prefer to keep debug on the serial port even with VGA
-    // enabled, comment the line below and uncomment the next one.
-
     // Debug output uses VGA when available, otherwise COM1
     let debug_uart_device = vga_uart_mux;
-
-    // let debug_uart_device  = com1_uart_mux;
 
     // Create a shared virtualization mux layer on top of a single hardware
     // alarm.
@@ -238,12 +233,6 @@ unsafe extern "cdecl" fn main() {
         .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
-    // ProcessConsole stays on COM1 because we have no keyboard input yet.
-    // As soon as keyboard support will be added, the process console
-    // may be used with the VGA and keyboard.
-    //
-    // let console_uart_device = vga_uart_mux;
-
     // For now the ProcessConsole (interactive shell) is wired to COM1 so the user can
     // type commands over the serial port.  Once keyboard input is implemented
     // we can switch `console_uart_device` to `vga_uart_mux`.
@@ -257,7 +246,7 @@ unsafe extern "cdecl" fn main() {
         process_printer,
         None,
     )
-    .finalize(components::process_console_component_static!(
+        .finalize(components::process_console_component_static!(
         Pit<'static, RELOAD_1KHZ>
     ));
 
@@ -270,14 +259,14 @@ unsafe extern "cdecl" fn main() {
         debug_uart_device,
         create_capability!(capabilities::SetDebugWriterCapability),
     )
-    .finalize(components::debug_writer_component_static!());
+        .finalize(components::debug_writer_component_static!());
 
     let lldb = components::lldb::LowLevelDebugComponent::new(
         board_kernel,
         capsules_core::low_level_debug::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::low_level_debug_component_static!());
+        .finalize(components::low_level_debug_component_static!());
 
     let scheduler = components::sched::cooperative::CooperativeComponent::new(processes)
         .finalize(components::cooperative_component_static!(NUM_PROCS));
@@ -335,10 +324,10 @@ unsafe extern "cdecl" fn main() {
         &FAULT_RESPONSE,
         &process_mgmt_cap,
     )
-    .unwrap_or_else(|err| {
-        debug!("Error loading processes!");
-        debug!("{:?}", err);
-    });
+        .unwrap_or_else(|err| {
+            debug!("Error loading processes!");
+            debug!("{:?}", err);
+        });
 
     board_kernel.kernel_loop(&platform, chip, Some(&platform.ipc), &main_loop_cap);
 }

--- a/boards/qemu_i486_q35/src/main.rs
+++ b/boards/qemu_i486_q35/src/main.rs
@@ -261,6 +261,9 @@ unsafe extern "cdecl" fn main() {
     )
         .finalize(components::debug_writer_component_static!());
 
+    // Now we can safely log via `debug!()`
+    debug!("ps/2 health: {}", chip.ps2.health_snapshot());
+
     let lldb = components::lldb::LowLevelDebugComponent::new(
         board_kernel,
         capsules_core::low_level_debug::DRIVER_NUM,

--- a/boards/qemu_i486_q35/src/main.rs
+++ b/boards/qemu_i486_q35/src/main.rs
@@ -154,7 +154,7 @@ unsafe extern "cdecl" fn main() {
         &mut *ptr::addr_of_mut!(PAGE_DIR),
         &mut *ptr::addr_of_mut!(PAGE_TABLE),
         &(),
-    )
+            )
         .finalize(x86_q35::x86_q35_component_static!(()));
 
     // Acquire required capabilities
@@ -259,10 +259,8 @@ unsafe extern "cdecl" fn main() {
         debug_uart_device,
         create_capability!(capabilities::SetDebugWriterCapability),
     )
-        .finalize(components::debug_writer_component_static!());
+    .finalize(components::debug_writer_component_static!());
 
-    // Now we can safely log via `debug!()`
-    debug!("ps/2 health: {}", chip.ps2.health_snapshot());
 
     let lldb = components::lldb::LowLevelDebugComponent::new(
         board_kernel,

--- a/chips/x86_q35/src/chip.rs
+++ b/chips/x86_q35/src/chip.rs
@@ -13,10 +13,10 @@ use x86::registers::bits32::paging::{PD, PT};
 use x86::support;
 use x86::{Boundary, InterruptPoller};
 
+use crate::keyboard::Keyboard;
 use crate::pit::{Pit, RELOAD_1KHZ};
 use crate::serial::{SerialPort, SerialPortComponent, COM1_BASE, COM2_BASE, COM3_BASE, COM4_BASE};
 use crate::vga_uart_driver::VgaText;
-use crate::keyboard::Keyboard;
 
 /// Interrupt constants for legacy PC peripherals
 mod interrupt {

--- a/chips/x86_q35/src/chip.rs
+++ b/chips/x86_q35/src/chip.rs
@@ -288,7 +288,7 @@ impl<'a, I: InterruptService + 'a> PcComponent<'a, I> {
             unsafe { static_init!(crate::ps2::Ps2Controller, crate::ps2::Ps2Controller::new()) };
         kernel::deferred_call::DeferredCallClient::register(ps2);
 
-        // controller bring-up owned by the chip
+        // controller bring-up owned by the chip (no logging here)
         let _ = ps2.init_early();
 
         let pc = s.4.write(Pc {

--- a/chips/x86_q35/src/chip.rs
+++ b/chips/x86_q35/src/chip.rs
@@ -31,6 +31,8 @@ mod interrupt {
     /// Interrupt number shared by COM1 and COM3 serial devices
     pub(super) const COM1_COM3: u32 = (PIC1_OFFSET as u32) + 4;
 
+    /// Interrupt number used by the PS/2 keyboard (i8042, IRQ1).
+    /// Raised when the controller’s output buffer has data ready (OB=1).
     pub(super) const KEYBOARD: u32 = (PIC1_OFFSET as u32) + 1;
 }
 

--- a/chips/x86_q35/src/chip.rs
+++ b/chips/x86_q35/src/chip.rs
@@ -76,7 +76,7 @@ pub struct Pc<'a, I: InterruptService + 'a, const PR: u16 = RELOAD_1KHZ> {
     /// Vga
     pub vga: &'a VgaText<'a>,
 
-    /// PS/2
+    /// PS/2 Controller
     pub ps2: &'a crate::ps2::Ps2Controller,
 
     /// System call context
@@ -216,7 +216,6 @@ pub struct PcComponent<'a, I: InterruptService + 'a> {
     int_svc: &'a I,
 }
 
-
 impl<'a, I: InterruptService + 'a> PcComponent<'a, I> {
     /// Creates a new `PcComponent` instance.
     ///
@@ -234,7 +233,7 @@ impl<'a, I: InterruptService + 'a> PcComponent<'a, I> {
     }
 }
 
-impl<I: InterruptService + 'static> Component for PcComponent<'static, I> {
+    impl<I: InterruptService + 'static> Component for PcComponent<'static, I> {
     type StaticInput = (
         <SerialPortComponent as Component>::StaticInput,
         <SerialPortComponent as Component>::StaticInput,

--- a/chips/x86_q35/src/chip.rs
+++ b/chips/x86_q35/src/chip.rs
@@ -127,7 +127,6 @@ impl<'a, I: InterruptService + 'a, const PR: u16> Chip for Pc<'a, I, PR> {
                     }
                 }
 
-
                 poller.clear_pending(num);
 
                 // Unmask the interrupt so it can fire again, but only if we know how to handle it
@@ -234,7 +233,7 @@ impl<'a, I: InterruptService + 'a> PcComponent<'a, I> {
     }
 }
 
-    impl<I: InterruptService + 'static> Component for PcComponent<'static, I> {
+impl<I: InterruptService + 'static> Component for PcComponent<'static, I> {
     type StaticInput = (
         <SerialPortComponent as Component>::StaticInput,
         <SerialPortComponent as Component>::StaticInput,

--- a/chips/x86_q35/src/chip.rs
+++ b/chips/x86_q35/src/chip.rs
@@ -301,6 +301,12 @@ impl<I: InterruptService + 'static> Component for PcComponent<'static, I> {
         // connect keyboard as the ps/2 client, controller will call `receive_scancode`
         ps2.set_client(keyboard);
         keyboard.init_device();
+
+        // allow IRQ1 to fire
+        unsafe {
+            crate::pic::unmask(interrupt::KEYBOARD);
+        }
+
         let pc = s.4.write(Pc {
             com1,
             com2,

--- a/chips/x86_q35/src/chip.rs
+++ b/chips/x86_q35/src/chip.rs
@@ -287,7 +287,7 @@ impl<'a, I: InterruptService + 'a> PcComponent<'a, I> {
             unsafe { static_init!(crate::ps2::Ps2Controller, crate::ps2::Ps2Controller::new()) };
         kernel::deferred_call::DeferredCallClient::register(ps2);
 
-        // controller bring-up owned by the chip (no logging here)
+        // controller bring-up owned by the chip
         let _ = ps2.init_early();
 
         let pc = s.4.write(Pc {

--- a/chips/x86_q35/src/chip.rs
+++ b/chips/x86_q35/src/chip.rs
@@ -198,7 +198,6 @@ impl<'a, I: InterruptService + 'a, const PR: u16> Chip for Pc<'a, I, PR> {
         let _ = writeln!(writer);
         let _ = writeln!(writer, "---| PC State |---");
         let _ = writeln!(writer);
-
         // todo: print out anything that might be useful
 
         let _ = writeln!(writer, "(placeholder)");

--- a/chips/x86_q35/src/chip.rs
+++ b/chips/x86_q35/src/chip.rs
@@ -6,7 +6,7 @@ use core::fmt::Write;
 use core::mem::MaybeUninit;
 
 use kernel::component::Component;
-use kernel::platform::chip::Chip;
+use kernel::platform::chip::{Chip, InterruptService};
 use kernel::static_init;
 use x86::mpu::PagingMPU;
 use x86::registers::bits32::paging::{PD, PT};
@@ -14,6 +14,7 @@ use x86::support;
 use x86::{Boundary, InterruptPoller};
 
 use crate::keyboard::Keyboard;
+use crate::pic::PIC1_OFFSET;
 use crate::pit::{Pit, RELOAD_1KHZ};
 use crate::serial::{SerialPort, SerialPortComponent, COM1_BASE, COM2_BASE, COM3_BASE, COM4_BASE};
 use crate::vga_uart_driver::VgaText;
@@ -43,7 +44,23 @@ mod interrupt {
 /// chip definition should be broadly compatible with most PC hardware.
 ///
 /// Parameter `PR` is the PIT reload value. See [`Pit`] for more information.
-pub struct Pc<'a, const PR: u16 = RELOAD_1KHZ> {
+///
+/// # Interrupt Handling
+///
+/// This chip automatically handles interrupts for legacy PC devices which are known to be present
+/// on QEMU's Q35 machine type. This includes the PIT timer and four serial ports. Other devices
+/// which are conditionally present (e.g. Virtio devices specified on the QEMU command line) may be
+/// handled via a board-specific implementation of [`InterruptService`].
+///
+/// This chip uses the legacy 8259 PIC to manage interrupts. This is relatively simple compared with
+/// using the Local APIC or I/O APIC and avoids needing to interact with ACPI or MP tables.
+///
+/// Internally, this chip re-maps the PIC interrupt numbers to avoid conflicts with ISA-defined
+/// exceptions. This remapping is fully encapsulated within the chip. **N.B.** Implementors of
+/// [`InterruptService`] will be passed the physical interrupt line number, _not_ the remapped
+/// number used internally by the chip. This should match the interrupt line number reported by
+/// documentation or read from the PCI configuration space.
+pub struct Pc<'a, I: InterruptService + 'a, const PR: u16 = RELOAD_1KHZ> {
     /// Legacy COM1 serial port
     pub com1: &'a SerialPort<'a>,
 
@@ -71,9 +88,14 @@ pub struct Pc<'a, const PR: u16 = RELOAD_1KHZ> {
     /// System call context
     syscall: Boundary,
     paging: PagingMPU<'a>,
+
+    /// Board-provided interrupt service for handling non-core IRQs (e.g., PCI devices)
+    int_svc: &'a I,
 }
 
-impl<'a, const PR: u16> Chip for Pc<'a, PR> {
+impl<'a, I: InterruptService + 'a, const PR: u16> Chip for Pc<'a, I, PR> {
+    type ThreadIdProvider = x86::thread_id::X86ThreadIdProvider;
+
     type MPU = PagingMPU<'a>;
     fn mpu(&self) -> &Self::MPU {
         &self.paging
@@ -87,6 +109,7 @@ impl<'a, const PR: u16> Chip for Pc<'a, PR> {
     fn service_pending_interrupts(&self) {
         InterruptPoller::access(|poller| {
             while let Some(num) = poller.next_pending() {
+                let mut handled = true;
                 match num {
                     interrupt::PIT => self.pit.handle_interrupt(),
                     interrupt::COM2_COM4 => {
@@ -97,16 +120,27 @@ impl<'a, const PR: u16> Chip for Pc<'a, PR> {
                         self.com1.handle_interrupt();
                         self.com3.handle_interrupt();
                     }
-
-                    // new PS/2 keyboard interrupt handler
                     interrupt::KEYBOARD => {
                         self.ps2.handle_interrupt();
                     }
-
-                    _ => unimplemented!("interrupt {num}"),
+                    _ => {
+                        // Convert back to physical interrupt line number before passing to
+                        // board-specific handler
+                        let phys_num = num - PIC1_OFFSET as u32;
+                        handled = unsafe { self.int_svc.service_interrupt(phys_num) };
+                    }
                 }
 
                 poller.clear_pending(num);
+
+                // Unmask the interrupt so it can fire again, but only if we know how to handle it
+                if handled {
+                    unsafe {
+                        crate::pic::unmask(num);
+                    }
+                } else {
+                    kernel::debug!("Unhandled external interrupt {} left masked", num);
+                }
             }
         })
     }
@@ -180,12 +214,13 @@ impl<'a, const PR: u16> Chip for Pc<'a, PR> {
 /// During the call to `finalize()`, this helper will perform low-level initialization of the PC
 /// hardware to ensure a consistent CPU state. This includes initializing memory segmentation and
 /// interrupt handling. See [`x86::init`] for further details.
-pub struct PcComponent<'a> {
+pub struct PcComponent<'a, I: InterruptService + 'a> {
     pd: &'a mut PD,
     pt: &'a mut PT,
+    int_svc: &'a I,
 }
 
-impl<'a> PcComponent<'a> {
+impl<'a, I: InterruptService + 'a> PcComponent<'a, I> {
     /// Creates a new `PcComponent` instance.
     ///
     /// ## Safety
@@ -197,21 +232,21 @@ impl<'a> PcComponent<'a> {
     /// will cause the kernel's code/data to move unexpectedly.
     ///
     /// See [`x86::init`] for further details.
-    pub unsafe fn new(pd: &'a mut PD, pt: &'a mut PT) -> Self {
-        Self { pd, pt }
+    pub unsafe fn new(pd: &'a mut PD, pt: &'a mut PT, int_svc: &'a I) -> Self {
+        Self { pd, pt, int_svc }
     }
 }
 
-impl Component for PcComponent<'static> {
+impl<I: InterruptService + 'static> Component for PcComponent<'static, I> {
     type StaticInput = (
         <SerialPortComponent as Component>::StaticInput,
         <SerialPortComponent as Component>::StaticInput,
         <SerialPortComponent as Component>::StaticInput,
         <SerialPortComponent as Component>::StaticInput,
-        &'static mut MaybeUninit<Pc<'static>>,
+        &'static mut MaybeUninit<Pc<'static, I>>,
         &'static mut MaybeUninit<crate::keyboard::Keyboard<'static>>,
     );
-    type Output = &'static Pc<'static>;
+    type Output = &'static Pc<'static, I>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
         // Low-level hardware initialization. We do this first to guarantee the CPU is in a
@@ -277,6 +312,7 @@ impl Component for PcComponent<'static> {
             keyboard,
             syscall,
             paging,
+            int_svc: self.int_svc,
         });
 
         pc
@@ -286,13 +322,13 @@ impl Component for PcComponent<'static> {
 /// Provides static buffers needed for `PcComponent::finalize()`.
 #[macro_export]
 macro_rules! x86_q35_component_static {
-    () => {{
+    ($isr_ty:ty) => {{
         (
             $crate::serial_port_component_static!(),
             $crate::serial_port_component_static!(),
             $crate::serial_port_component_static!(),
             $crate::serial_port_component_static!(),
-            kernel::static_buf!($crate::Pc<'static>),
+            kernel::static_buf!($crate::Pc<'static, $isr_ty>),
             kernel::static_buf!($crate::keyboard::Keyboard<'static>),
         )
     };};

--- a/chips/x86_q35/src/cmd_fifo.rs
+++ b/chips/x86_q35/src/cmd_fifo.rs
@@ -1,0 +1,83 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+//! Minimal, non-alloc ring FIFO for small fixed-size queues.
+
+// Why `FifoItem::EMPTY` and const init?
+// We need to create the FIFO in static memory (no heap). That means the backing
+// array `[T; N]` must be initialized in a `const` context. I believe we can't  directly
+// call `T::default()` in `const fn`, so `[T::default(); N]` won’t work.
+// By requiring `T: FifoItem` with a `const EMPTY`, we can do `[T::EMPTY; N]`
+// and safely build the FIFO at compile time
+
+pub(crate) trait FifoItem: Copy {
+    /// Const zero/empty value used to initialize the backing array.
+    const EMPTY: Self;
+}
+
+pub(crate) struct Fifo<T: FifoItem, const N: usize> {
+    buf: [T; N],
+    head: usize,
+    tail: usize,
+    len: usize,
+}
+
+impl<T: FifoItem, const N: usize> Fifo<T, N> {
+    pub(crate) const fn new() -> Self {
+        Self {
+            buf: [T::EMPTY; N],
+            head: 0,
+            tail: 0,
+            len: 0,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+    #[inline]
+    pub(crate) fn is_full(&self) -> bool {
+        self.len == N
+    }
+    #[inline]
+    pub(crate) fn push(&mut self, item: T) -> Result<(), ()> {
+        if self.is_full() {
+            return Err(());
+        }
+        self.buf[self.head] = item;
+        self.head = (self.head + 1) % N;
+        self.len += 1;
+        Ok(())
+    }
+
+    #[inline]
+    pub(crate) fn peek(&self) -> Option<&T> {
+        if self.is_empty() {
+            None
+        } else {
+            Some(&self.buf[self.tail])
+        }
+    }
+
+    #[inline]
+    pub(crate) fn peek_mut(&mut self) -> Option<&mut T> {
+        if self.is_empty() {
+            None
+        } else {
+            Some(&mut self.buf[self.tail])
+        }
+    }
+
+    #[inline]
+    pub(crate) fn pop(&mut self) -> Option<T> {
+        if self.is_empty() {
+            return None;
+        }
+        let item = self.buf[self.tail];
+        self.tail = (self.tail + 1) % N;
+        self.len -= 1;
+        Some(item)
+    }
+}

--- a/chips/x86_q35/src/keyboard.rs
+++ b/chips/x86_q35/src/keyboard.rs
@@ -8,6 +8,7 @@
 //! - I8042 (ports available on 0X60/0X64) delivers keyboard bytes via IRQ1
 //! - We use scan Code set 2 (no translation). 0xE0/0xE1 are prefixes; 0xF0 marks BREAK
 //! - Keyboard speaks simple command/ACK (0xFA) / RESEND (0xFE) protocol
+//!
 //! References:
 //! - OSDev: i8042 PS/2 Controller — https://wiki.osdev.org/I8042_PS/2_Controller
 //! - OSDev: PS/2 Keyboard — https://wiki.osdev.org/PS/2_Keyboard
@@ -17,7 +18,6 @@ use crate::cmd_fifo::Fifo as CmdFifo;
 use crate::ps2::Ps2Client;
 use crate::ps2::Ps2Controller;
 use core::cell::Cell;
-use kernel::debug;
 use kernel::hil::keyboard::{Keyboard as HilKeyboard, KeyboardClient as HilKeyboardClient};
 use kernel::utilities::cells::OptionalCell;
 
@@ -334,13 +334,13 @@ impl<'a> Keyboard<'a> {
         let breaking = self.got_f0.replace(false);
         let pressed = !breaking;
 
-        // log the final key event (after prefixes are applied)
-        debug!(
-            "ps2kbd: {} {}{:02X}",
-            if pressed { "MAKE " } else { "BREAK" },
-            if extended { "E0 " } else { "" },
-            byte
-        );
+        // // log the final key event (after prefixes are applied)
+        // debug!(
+        // "ps2kbd: {} {}{:02X}",
+        // if pressed { "MAKE " } else { "BREAK" },
+        // if extended { "E0 " } else { "" },
+        // byte
+        // );
 
         // Emit Linux keycode to the HIL client
         if let Some(code) = linux_key_for(extended, byte) {

--- a/chips/x86_q35/src/keyboard.rs
+++ b/chips/x86_q35/src/keyboard.rs
@@ -100,13 +100,6 @@ const RESP_ACK: u8 = 0xFA;
 const RESP_RESEND: u8 = 0xFE;
 const RESP_BAT_OK: u8 = 0xAA; // BAT after reset
 
-/// Optional byte send for ASCII output (useful for a later capsule)
-/// Not used by the current ASCII-only console path. Subject to change.
-/// Called from the keyboard's deferred (bottom-half) context; keep it non-blocking.
-pub(crate) trait AsciiClient {
-    fn put_byte(&self, b: u8);
-}
-
 /// We will add a small "command engine" (command/response state machine)
 /// with ACK/RESEND handling.
 /// A fixed-size FIFO holds short command sequences (e.g., F0 02, F4).
@@ -167,7 +160,6 @@ impl Default for CmdEntry {
 pub struct Keyboard<'a> {
     ps2: &'a Ps2Controller,
     client: OptionalCell<&'a dyn HilKeyboardClient>,
-    ascii: OptionalCell<&'static dyn AsciiClient>,
 
     // decoder state
     got_e0: Cell<bool>,   // sau 0xE0: next code is extended
@@ -202,7 +194,6 @@ impl<'a> Keyboard<'a> {
         Self {
             ps2,
             client: OptionalCell::empty(),
-            ascii: OptionalCell::empty(),
 
             // decoder state
             got_e0: Cell::new(false),
@@ -231,112 +222,6 @@ impl<'a> Keyboard<'a> {
     /// This will use the command engine (ACK/RESEND) and can run with IRQ1 enabled.
     pub fn init_device(&self) {
         // TODO
-    }
-
-    /// Not used by the current ASCII-only console path. Subject to change.
-    /// Will expand when writing a capsule for PC
-    #[allow(dead_code)]
-    pub(crate) fn set_ascii_client(&self, c: &'static dyn AsciiClient) {
-        self.ascii.set(c);
-    }
-
-    /// Translate a Set-2 scancode to US-ASCII (press only, non-extended)
-    /// Returns None for unmapped keys
-    /**
-     * ASCII mapping: US layout, press-only, non-extended keys.
-     * Shift + Caps for letters; digits/punct respect Shift.
-     * Enter => '\n', Backspace => 0x08, Tab => '\t'. Extended keypad Enter and arrows return None.
-     */
-    #[inline(always)]
-    fn ascii_for(&self, code: u8, pressed: bool, extended: bool) -> Option<u8> {
-        if !pressed || extended {
-            return None;
-        }
-        // modifier states
-        let shift = self.shift_l.get() || self.shift_r.get();
-        let caps = self.caps.get();
-
-        // letters
-        let letter = match code {
-            0x1C => b'a',
-            0x32 => b'b',
-            0x21 => b'c',
-            0x23 => b'd',
-            0x24 => b'e',
-            0x2B => b'f',
-            0x34 => b'g',
-            0x33 => b'h',
-            0x43 => b'i',
-            0x3B => b'j',
-            0x42 => b'k',
-            0x4B => b'l',
-            0x3A => b'm',
-            0x31 => b'n',
-            0x44 => b'o',
-            0x4D => b'p',
-            0x15 => b'q',
-            0x2D => b'r',
-            0x1B => b's',
-            0x2C => b't',
-            0x3C => b'u',
-            0x2A => b'v',
-            0x1D => b'w',
-            0x22 => b'x',
-            0x35 => b'y',
-            0x1A => b'z',
-            _ => 0,
-        };
-        if letter != 0 {
-            let upper = shift ^ caps;
-            return Some(if upper {
-                letter.to_ascii_uppercase()
-            } else {
-                letter
-            });
-        }
-
-        // Digits
-        let digit = match code {
-            0x16 => (b'1', b'!'),
-            0x1E => (b'2', b'@'),
-            0x26 => (b'3', b'#'),
-            0x25 => (b'4', b'$'),
-            0x2E => (b'5', b'%'),
-            0x36 => (b'6', b'^'),
-            0x3D => (b'7', b'&'),
-            0x3E => (b'8', b'*'),
-            0x46 => (b'9', b'('),
-            0x45 => (b'0', b')'),
-            _ => (0, 0),
-        };
-        if digit.0 != 0 {
-            return Some(if shift { digit.1 } else { digit.0 });
-        }
-
-        // Punctuation / misc (US)
-        let punct = match code {
-            0x0E => (b'`', b'~'),
-            0x4E => (b'-', b'_'),
-            0x55 => (b'=', b'+'),
-            0x54 => (b'[', b'{'),
-            0x5B => (b']', b'}'),
-            0x5D => (b'\\', b'|'),
-            0x4C => (b';', b':'),
-            0x52 => (b'\'', b'"'),
-            0x41 => (b',', b'<'),
-            0x49 => (b'.', b'>'),
-            0x4A => (b'/', b'?'),
-            0x29 => (b' ', b' '),   // space
-            0x0D => (b'\t', b'\t'), // tab
-            0x5A => (b'\n', b'\n'), // enter
-            0x66 => (0x08, 0x08),   // backspace
-            _ => (0, 0),
-        };
-        if punct.0 != 0 {
-            return Some(if shift { punct.1 } else { punct.0 });
-        }
-
-        None
     }
 
     /// Command engine public API
@@ -472,12 +357,6 @@ impl<'a> Keyboard<'a> {
             (SC_RSHIFT, false) => self.shift_r.set(pressed),
             (SC_CAPS, _) if pressed => self.caps.set(!self.caps.get()), // toggle on make; ignore break
             _ => {}
-        }
-
-        if let Some(b) = self.ascii_for(byte, pressed, extended) {
-            if self.ascii.is_some() {
-                self.ascii.map(|c| c.put_byte(b));
-            }
         }
     }
 }

--- a/chips/x86_q35/src/keyboard.rs
+++ b/chips/x86_q35/src/keyboard.rs
@@ -6,11 +6,11 @@
 
 #![allow(dead_code)] // ONLY FOR THIS MILESTONE SKELETON, WILL BE REMOVED
 
-use core::cell::Cell;
-use kernel::debug;
-use kernel::utilities::cells::OptionalCell;
 use crate::ps2::Ps2Client;
 use crate::ps2::Ps2Controller;
+use core::cell::{Cell, RefCell};
+use kernel::debug;
+use kernel::utilities::cells::OptionalCell;
 
 // Minimal, layout-free key event (future commits will populate this)
 #[derive(Copy, Clone, Debug)]
@@ -20,13 +20,43 @@ pub struct KeyEvent {
     /// true = make (press), false = break (release)
     pub pressed: bool,
     /// true if the event came via the E0 prefix (extended)
-    pub extended: bool
+    pub extended: bool,
 }
 
 /// Callback that the keyboard will use to deliver events
 pub trait KeyboardClient {
-    fn key_event (&self, _ev: KeyEvent) {
+    fn key_event(&self, _ev: KeyEvent) {
         // TODO
+    }
+}
+
+/// We will add a small "command engine" (command/response state machine)
+/// with ACK/RESEND handling.
+/// A fixed-size FIFO holds short command sequences (e.g., F0 02, F4).
+/// One byte is in flight at a time; 0xFA ACK advances, 0xFE RESEND retries.
+
+const CMDQ_LEN: usize = 8;
+const CMD_MAX_LEN: usize = 3;
+const MAX_RETRIES: u8 = 3; // to not be confused with the deff call "good bytes" we do for telemetry
+
+#[derive(Copy, Clone)]
+struct CmdEntry {
+    bytes: [u8; CMD_MAX_LEN],
+    len: u8,
+    idx: u8, //next byte to send
+}
+
+impl CmdEntry {
+    const fn empty() -> Self {
+        Self {
+            bytes: [0; CMD_MAX_LEN],
+            len: 0,
+            idx: 0,
+        }
+    }
+
+    fn is_done(&self) -> bool {
+        (self.idx as usize) >= (self.len as usize)
     }
 }
 
@@ -37,10 +67,23 @@ pub trait KeyboardClient {
 
 pub struct Keyboard<'a> {
     ps2: &'a Ps2Controller,
-    client: OptionalCell<&'a dyn KeyboardClient>,
+    client: OptionalCell<&'static dyn KeyboardClient>,
 
-    // we only track bytes for now
     bytes_seen: Cell<u32>,
+    // here comes the engine
+    cmd_q: RefCell<[CmdEntry; CMDQ_LEN]>,
+    q_head: Cell<usize>,  // write cursor
+    q_tail: Cell<usize>,  // read cursor
+    q_count: Cell<usize>, // number of entries enqueued
+
+    in_flight: Cell<bool>,  // waiting for ACK/RESEND to the last sent byte
+    retries_left: Cell<u8>, // remaining entries for the current byte
+    // telemetry
+    cmd_sent_bytes: Cell<u32>,  //bytes attempted to send
+    cmd_acks: Cell<u32>,        // ACKs observed
+    cmd_resends: Cell<u32>,     // RESENDs observed
+    cmd_drops: Cell<u32>,       //commands dropped after retry execution
+    cmd_send_errors: Cell<u32>, // controller TX errors/timeouts
 }
 
 impl<'a> Keyboard<'a> {
@@ -49,6 +92,20 @@ impl<'a> Keyboard<'a> {
             ps2,
             client: OptionalCell::empty(),
             bytes_seen: Cell::new(0),
+
+            cmd_q: RefCell::new([CmdEntry::empty(); CMDQ_LEN]),
+            q_head: Cell::new(0),
+            q_tail: Cell::new(0),
+            q_count: Cell::new(0),
+
+            in_flight: Cell::new(false),
+            retries_left: Cell::new(0),
+
+            cmd_sent_bytes: Cell::new(0),
+            cmd_acks: Cell::new(0),
+            cmd_resends: Cell::new(0),
+            cmd_drops: Cell::new(0),
+            cmd_send_errors: Cell::new(0),
         }
     }
 
@@ -62,22 +119,162 @@ impl<'a> Keyboard<'a> {
     pub fn init_device(&self) {
         // TODO
     }
-}
 
-impl<'a> Ps2Client for Keyboard<'a> {
+    /// Command engine public API
+    ///
+    /// Enqueue a short command sequence
+    /// Returns false if the queue is full or seq is too long
+
+    pub fn enqueue_command(&self, seq: &[u8]) -> bool {
+        if seq.is_empty() || seq.len() > CMD_MAX_LEN {
+            return false;
+        }
+        if self.q_count.get() >= CMDQ_LEN {
+            return false;
+        }
+        // Copy into the queue at head
+        let head = self.q_head.get();
+        {
+            let mut q = self.cmd_q.borrow_mut();
+            let e = &mut q[head];
+            e.bytes = [0; CMD_MAX_LEN];
+            e.bytes[..seq.len()].copy_from_slice(seq);
+            e.len = seq.len() as u8;
+            e.idx = 0;
+        }
+        self.q_head.set((head + 1) % CMDQ_LEN);
+        self.q_count.set(self.q_count.get() + 1);
+        self.drive_tx();
+
+        true
+    }
+
+    /// Try to transmit the next byte of the current command
+    fn drive_tx(&self) {
+        if self.in_flight.get() || self.q_count.get() == 0 {
+            return;
+        }
+
+        // Peek current entry at tail and the next byte to send
+        let (byte_opt, done) = {
+            let q = self.cmd_q.borrow();
+            let e = &q[self.q_tail.get()];
+            if e.is_done() {
+                (None, true)
+            } else {
+                (Some(e.bytes[e.idx as usize]), false)
+            }
+        };
+
+        if done {
+            // This shouldn't persist-pop and try again
+            self.pop_cmd();
+            self.drive_tx();
+            return;
+        }
+
+        if let Some(b) = byte_opt {
+            // Attempt to send. If the controller times out, do not mark inflight,
+            // so a later call may retry. We also don't advance idx here, only on ACK
+            match self.ps2.send_port1(b) {
+                Ok(()) => {
+                    self.in_flight.set(true);
+                    if self.retries_left.get() == 0 {
+                        // first attempt for this byte
+                        self.retries_left.set(MAX_RETRIES);
+                    }
+                    self.cmd_sent_bytes
+                        .set(self.cmd_sent_bytes.get().wrapping_add(1));
+                }
+
+                Err(_e) => {
+                    // Controller busy/timeout; count and let a later tick retry
+                    self.cmd_send_errors
+                        .set(self.cmd_send_errors.get().wrapping_add(1));
+                }
+            }
+        }
+    }
+
+    fn pop_cmd(&self) {
+        if self.q_count.get() == 0 {
+            return;
+        }
+        self.q_tail.set((self.q_tail.get() + 1) % CMDQ_LEN);
+        self.q_count.set(self.q_count.get() - 1);
+    }
+
+    fn advance_idx_after_ack(&self) {
+        // Increment idx of the current entry; if complete, pop
+        let mut finished = false;
+        {
+            let mut q = self.cmd_q.borrow_mut();
+            let e = &mut q[self.q_tail.get()];
+            if !e.is_done() {
+                e.idx = e.idx.saturating_add(1)
+            }
+            if e.is_done() {
+                finished = true;
+            }
+        }
+        if finished {
+            self.pop_cmd();
+        }
+
+        // New byte will get a fresh budget retry on first send
+        self.retries_left.set(0);
+    }
+}
+impl Ps2Client for Keyboard<'_> {
     /// Called by the controller (in def context) for each byte)
     fn receive_scancode(&self, byte: u8) {
+        // First, if a command byte is in flight, interpret 0XFA/0XFE
+        if self.in_flight.get() {
+            match byte {
+                0xFA => {
+                    // ACK
+                    self.cmd_acks.set(self.cmd_acks.get().wrapping_add(1));
+                    self.in_flight.set(false);
+                    self.advance_idx_after_ack();
+                    // Immediately try to send the next byte/command
+                    self.drive_tx();
+                    return;
+                }
+                0xFE => {
+                    // RESEND - bounded retry of the same byte
+                    self.cmd_resends.set(self.cmd_resends.get().wrapping_add(1));
+                    let left = self.retries_left.get();
+                    if left > 1 {
+                        self.retries_left.set(left - 1);
+                        self.in_flight.set(false);
+                        self.drive_tx(); // resend same byte, don't reset retries
+                    } else {
+                        // Give up on this command
+                        self.cmd_drops.set(self.cmd_drops.get().wrapping_add(1));
+                        self.in_flight.set(false);
+                        self.pop_cmd();
+                        self.retries_left.set(0); // clear for the next new byte
+                        self.drive_tx();
+                    }
+                    return;
+                }
+                _ => {
+                    // Not an ACK/RESEND. For now we ignore it
+                    // Keep waiting for ACK/RESEND
+                }
+            }
+        }
         // For now: basic init + counter
         let n = self.bytes_seen.get().wrapping_add(1);
         self.bytes_seen.set(n);
 
         // keep the log basic
-        if n<= 8 || (n & 0x0F) == 0 {
+        if n <= 8 || (n & 0x0F) == 0 {
             debug!("ps2-kbd: byte {:02x} (count={})", byte, n);
         }
 
         // Decoder and event emitter come in the future
-        // Do not call the keyboardClient yet
         let _ = &self.ps2;
+        let _ = &self.client;
     }
 }

--- a/chips/x86_q35/src/keyboard.rs
+++ b/chips/x86_q35/src/keyboard.rs
@@ -1,0 +1,83 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+//! PS/2 keyboard device skeleton over the i8042 controller.
+
+#![allow(dead_code)] // ONLY FOR THIS MILESTONE SKELETON, WILL BE REMOVED
+
+use core::cell::Cell;
+use kernel::debug;
+use kernel::utilities::cells::OptionalCell;
+use crate::ps2::Ps2Client;
+use crate::ps2::Ps2Controller;
+
+// Minimal, layout-free key event (future commits will populate this)
+#[derive(Copy, Clone, Debug)]
+pub struct KeyEvent {
+    /// Derive key identifier (based on Set-2)
+    pub keycode: u16,
+    /// true = make (press), false = break (release)
+    pub pressed: bool,
+    /// true if the event came via the E0 prefix (extended)
+    pub extended: bool
+}
+
+/// Callback that the keyboard will use to deliver events
+pub trait KeyboardClient {
+    fn key_event (&self, _ev: KeyEvent) {
+        // TODO
+    }
+}
+
+/// We capture bytes and will later add:
+/// 1) Command FIFO with ACK/RESEND handling
+/// 2) Set-2 decoder state machine (e0/f0/e1)
+/// Modifier tracking and ASCII/layout mapping in upper layers
+
+pub struct Keyboard<'a> {
+    ps2: &'a Ps2Controller,
+    client: OptionalCell<&'a dyn KeyboardClient>,
+
+    // we only track bytes for now
+    bytes_seen: Cell<u32>,
+}
+
+impl<'a> Keyboard<'a> {
+    pub const fn new(ps2: &'a Ps2Controller) -> Self {
+        Self {
+            ps2,
+            client: OptionalCell::empty(),
+            bytes_seen: Cell::new(0),
+        }
+    }
+
+    /// Install the client which will receive the events
+    pub fn set_client(&self, client: &'static dyn KeyboardClient) {
+        self.client.set(client);
+    }
+
+    /// Device-level init hook. No-op for now since the `init_early()`
+    /// already is done by the controller
+    pub fn init_device(&self) {
+        // TODO
+    }
+}
+
+impl<'a> Ps2Client for Keyboard<'a> {
+    /// Called by the controller (in def context) for each byte)
+    fn receive_scancode(&self, byte: u8) {
+        // For now: basic init + counter
+        let n = self.bytes_seen.get().wrapping_add(1);
+        self.bytes_seen.set(n);
+
+        // keep the log basic
+        if n<= 8 || (n & 0x0F) == 0 {
+            debug!("ps2-kbd: byte {:02x} (count={})", byte, n);
+        }
+
+        // Decoder and event emitter come in the future
+        // Do not call the keyboardClient yet
+        let _ = &self.ps2;
+    }
+}

--- a/chips/x86_q35/src/lib.rs
+++ b/chips/x86_q35/src/lib.rs
@@ -23,6 +23,7 @@ mod pic;
 
 pub mod pit;
 
+pub mod ps2;
 pub mod serial;
 
 pub mod vga;

--- a/chips/x86_q35/src/lib.rs
+++ b/chips/x86_q35/src/lib.rs
@@ -28,3 +28,4 @@ pub mod serial;
 
 pub mod vga;
 pub mod vga_uart_driver;
+pub mod keyboard;

--- a/chips/x86_q35/src/lib.rs
+++ b/chips/x86_q35/src/lib.rs
@@ -26,6 +26,7 @@ pub mod pit;
 pub mod ps2;
 pub mod serial;
 
+mod cmd_fifo;
 pub mod keyboard;
 pub mod vga;
 pub mod vga_uart_driver;

--- a/chips/x86_q35/src/lib.rs
+++ b/chips/x86_q35/src/lib.rs
@@ -26,6 +26,6 @@ pub mod pit;
 pub mod ps2;
 pub mod serial;
 
+pub mod keyboard;
 pub mod vga;
 pub mod vga_uart_driver;
-pub mod keyboard;

--- a/chips/x86_q35/src/ps2.rs
+++ b/chips/x86_q35/src/ps2.rs
@@ -20,7 +20,7 @@ const BUFFER_SIZE: usize = 32;
 /// Depth of the scan-code ring buffer
 const TIMEOUT_LIMIT: usize = 1_000_000;
 
-// Define the two status‐register bits
+// Status-register bits returned by inb(0x64)
 register_bitfields![u8,
     pub STATUS [
         OUTPUT_FULL OFFSET(0) NUMBITS(1), // data ready
@@ -31,6 +31,8 @@ register_bitfields![u8,
 /// Note: There is no hardware interrupt when the input buffer empties, so we must poll bit 1.
 /// See OSDev documentation:
 /// https://wiki.osdev.org/I8042_PS/2_Controller#Status_Register
+///
+/// Block until the controller’s input buffer is empty (ready for a command).
 #[inline(always)]
 fn wait_input_ready() {
     let mut s = LocalRegisterCopy::<u8, STATUS::Register>::new(0);
@@ -52,6 +54,8 @@ fn wait_input_ready() {
 /// Data-ready events trigger IRQ1, handled asynchronously in `handle_interrupt()`.
 /// See OSDev documentation:
 /// https://wiki.osdev.org/I8042_PS/2_Controller#Status_Register
+///
+/// Block until there is data ready to read in the output buffer.
 #[inline(always)]
 fn wait_output_ready() {
     let mut s = LocalRegisterCopy::<u8, STATUS::Register>::new(0);

--- a/chips/x86_q35/src/ps2.rs
+++ b/chips/x86_q35/src/ps2.rs
@@ -1,0 +1,240 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+use core::cell::{Cell, RefCell};
+use core::marker::PhantomData;
+use kernel::debug;
+use kernel::utilities::registers::register_bitfields;
+use tock_registers::LocalRegisterCopy;
+use x86::registers::io;
+
+/// PS/2 controller ports
+const PS2_DATA_PORT: u16 = 0x60;
+const PS2_STATUS_PORT: u16 = 0x64;
+const PIC1_DATA_PORT: u16 = 0x21;
+
+/// Timeout limit for spin loops
+const BUFFER_SIZE: usize = 32;
+
+/// Depth of the scan-code ring buffer
+const TIMEOUT_LIMIT: usize = 1_000_000;
+
+// Define the two status‐register bits
+register_bitfields![u8,
+    pub STATUS [
+        OUTPUT_FULL OFFSET(0) NUMBITS(1), // data ready
+        INPUT_FULL  OFFSET(1) NUMBITS(1), // input buffer full
+    ]
+];
+
+/// Note: There is no hardware interrupt when the input buffer empties, so we must poll bit 1.
+/// See OSDev documentation:
+/// https://wiki.osdev.org/I8042_PS/2_Controller#Status_Register
+#[inline(always)]
+fn wait_input_ready() {
+    let mut s = LocalRegisterCopy::<u8, STATUS::Register>::new(0);
+    let mut n = 0;
+    while {
+        s.set(unsafe { io::inb(PS2_STATUS_PORT) });
+        s.is_set(STATUS::INPUT_FULL)
+    } {
+        if {
+            n += 1;
+            n
+        } >= TIMEOUT_LIMIT
+        {
+            break;
+        }
+    }
+}
+
+/// Data-ready events trigger IRQ1, handled asynchronously in `handle_interrupt()`.
+/// See OSDev documentation:
+/// https://wiki.osdev.org/I8042_PS/2_Controller#Status_Register
+#[inline(always)]
+fn wait_output_ready() {
+    let mut s = LocalRegisterCopy::<u8, STATUS::Register>::new(0);
+    let mut n = 0;
+    while {
+        s.set(unsafe { io::inb(PS2_STATUS_PORT) });
+        !s.is_set(STATUS::OUTPUT_FULL)
+    } {
+        if {
+            n += 1;
+            n
+        } >= TIMEOUT_LIMIT
+        {
+            break;
+        }
+    }
+}
+
+/// Read one byte from the data port (0x60).
+#[inline(always)]
+fn read_data() -> u8 {
+    wait_output_ready();
+    unsafe { io::inb(PS2_DATA_PORT) }
+}
+
+/// Send a command byte to the controller (port 0x64).
+#[inline(always)]
+fn write_command(c: u8) {
+    wait_input_ready();
+    unsafe { io::outb(PS2_STATUS_PORT, c) }
+}
+/// Write a data byte to the data port (0x60).
+#[inline(always)]
+fn write_data(d: u8) {
+    wait_input_ready();
+    unsafe { io::outb(PS2_DATA_PORT, d) }
+}
+
+/// Send a byte to the keyboard and wait for ACK (`0xFA`).
+/// If the device replies RESEND (`0xFE`) we retry **once**.
+fn send_with_ack(byte: u8) -> bool {
+    for _ in 0..=1 {
+        write_data(byte);
+        let resp = read_data();
+        match resp {
+            0xFA => return true, // ACK
+            0xFE => continue,    // RESEND -> try again
+            _ => return false,   // error
+        }
+    }
+    false
+}
+
+/// PS/2 controller driver (the “8042” peripheral)
+pub struct Ps2Controller {
+    buffer: RefCell<[u8; BUFFER_SIZE]>,
+    head: Cell<usize>,
+    tail: Cell<usize>,
+    count: Cell<usize>, // new field to track number of valid entries
+    _p: PhantomData<()>,
+}
+
+impl Ps2Controller {
+    pub const fn new() -> Self {
+        Self {
+            buffer: RefCell::new([0; BUFFER_SIZE]),
+            head: Cell::new(0),
+            tail: Cell::new(0),
+            count: Cell::new(0), // ← initialize count
+            _p: PhantomData,
+        }
+    }
+    pub fn init(&self) {
+        unsafe {
+            /* disable both ports */
+            write_command(0xAD);
+            write_command(0xA7);
+
+            /* flush any stale byte */
+            while io::inb(PS2_STATUS_PORT) & 1 != 0 {
+                let _ = io::inb(PS2_DATA_PORT);
+            }
+
+            /* controller self-test */
+            write_command(0xAA);
+            let _ = {
+                wait_output_ready();
+                read_data()
+            } == 0x55;
+
+            // IRQ1 fire test
+            write_command(0x20); // request config byte
+            wait_output_ready();
+            let mut cfg = read_data();
+            cfg |= 1 << 0; // set bit0 = IRQ1 enable
+            write_command(0x60); // tell controller we’ll write it
+            write_data(cfg);
+
+            /* enable keyboard clock */
+            write_command(0xAE);
+
+            if !send_with_ack(0xF4) {
+                debug!("ps2: enable-scan failed");
+            }
+
+            /* unmask IRQ 1 */
+            let mask = io::inb(PIC1_DATA_PORT);
+            io::outb(PIC1_DATA_PORT, mask & !(1 << 1));
+            debug!("ps2: clock on, IRQ1 unmasked");
+        }
+    }
+
+    /// Handle a keyboard interrupt: read a scan-code and buffer it.
+    pub fn handle_interrupt(&self) {
+        loop {
+            if unsafe { io::inb(PS2_STATUS_PORT) } & 0x01 == 0 {
+                break;
+            }
+            let byte = unsafe { io::inb(PS2_DATA_PORT) };
+            self.push_code(byte);
+            debug!("ps2 irq 0x{:02X}", byte);
+        }
+    }
+
+    /// Pop the next scan-code, or None if buffer is empty.
+    pub fn pop_scan_code(&self) -> Option<u8> {
+        if self.count.get() == 0 {
+            return None;
+        }
+        let t = self.tail.get();
+        let b = self.buffer.borrow()[t];
+        self.tail.set((t + 1) % BUFFER_SIZE);
+        self.count.set(self.count.get() - 1);
+        Some(b)
+    }
+
+    /// Internal: push a scan-code into the ring buffer, dropping oldest if full.
+    fn push_code(&self, b: u8) {
+        let h = self.head.get();
+        self.buffer.borrow_mut()[h] = b;
+        let nh = (h + 1) % BUFFER_SIZE;
+        self.head.set(nh);
+
+        // track count and drop oldest if full:
+        if self.count.get() < BUFFER_SIZE {
+            self.count.set(self.count.get() + 1);
+        } else {
+            self.tail.set((self.tail.get() + 1) % BUFFER_SIZE);
+        }
+    }
+}
+
+// ---------- Unit tests for ring buffer only ----------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ring_buffer_basic() {
+        let dev = Ps2Controller::new();
+        // buffer empty
+        assert_eq!(dev.pop_scan_code(), None);
+        // simulate push via the internal helper
+        dev.push_code(0x10);
+        assert_eq!(dev.pop_scan_code(), Some(0x10));
+        assert_eq!(dev.pop_scan_code(), None);
+    }
+
+    #[test]
+    fn test_ring_buffer_overflow() {
+        let dev = Ps2Controller::new();
+        // fill buffer
+        for i in 0..BUFFER_SIZE {
+            dev.push_code(i as u8);
+        }
+        // overflow one slot
+        dev.push_code(0xFF);
+        // should have dropped the first (0), yielding 1..BUFFER_SIZE-1 then 0xFF
+        for expected in 1..BUFFER_SIZE {
+            assert_eq!(dev.pop_scan_code(), Some(expected as u8));
+        }
+        assert_eq!(dev.pop_scan_code(), Some(0xFF));
+        assert_eq!(dev.pop_scan_code(), None);
+    }
+}

--- a/chips/x86_q35/src/ps2.rs
+++ b/chips/x86_q35/src/ps2.rs
@@ -18,52 +18,61 @@ const BUFFER_SIZE: usize = 32;
 /// Timeout limit for spin loops
 const TIMEOUT_LIMIT: usize = 1_000_000;
 
+/// Controller Configuration Byte bits (check OSDev)
+const CFG_IRQ1: u8 = 1 << 0; // keyboard IRQ enable
+const CFG_IRQ12: u8 = 1 << 1; // mouse IRQ enable
+const CFG_DISABLE_KBD: u8 = 1 << 4; // 1=disable keyboard clock
+const CFG_DISABLE_AUX: u8 = 1 << 5; // 1=disable mouse clock
+const CFG_TRANSLATION: u8 = 1 << 6; // 1=translate Set-2->Set-1
+
 // Status-register bits returned by inb(0x64)
 register_bitfields![u8,
     pub STATUS [
-        OUTPUT_FULL OFFSET(0) NUMBITS(1), // data ready
-        INPUT_FULL  OFFSET(1) NUMBITS(1), // input buffer full
+        OUTPUT_FULL OFFSET(0) NUMBITS(1), // OB has data
+        INPUT_FULL  OFFSET(1) NUMBITS(1), // IB is full (busy)
+        // (bit2 SYSFLAG and bit3 CMD/DATA not used here)
+        AUX_OBF     OFFSET(5) NUMBITS(1), // 1 = from mouse/port2
+        TIMEOUT_ERR OFFSET(6) NUMBITS(1),
+        PARITY_ERR  OFFSET(7) NUMBITS(1),
     ]
 ];
 
-/// This will be explained in the future but we need this
-/// to separate possible errors/issues so we don't hang the kernel
-/// if the controller breaks, for now, we return something on failure
+/// Error types that  the controller can return
+/// so we don't bring the whole kernel down
+/// if something breaks in a peripheral
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Ps2Error {
-    InitFailed,
+    TimeoutIB,
+    TimeoutOB,
+    SelfTestFailed,
+    Port1TestFailed,
+    AckError,
+    ControllerTimeout,
+    UnexpectedResponse(u8),
 }
+
+pub type Ps2Result<T> = core::result::Result<T, Ps2Error>;
 
 /// Note: There is no hardware interrupt when the input buffer empties, so we must poll bit 1.
 /// See OSDev documentation:
 /// https://wiki.osdev.org/I8042_PS/2_Controller#Status_Register
 ///
 /// Block until the controller’s input buffer is empty (ready for a command).
+
 #[inline(always)]
-fn wait_input_ready() {
-    // Local copy of the status register
-    let mut status_reg = LocalRegisterCopy::<u8, STATUS::Register>::new(0);
-    // Loop counter to avoid infinite spin
+fn wait_ib_empty() -> Ps2Result<()> {
+    let mut status = LocalRegisterCopy::<u8, STATUS::Register>::new(0);
     let mut loops = 0;
-
-    // Continue spinning while the INPUT_FULL bit is set
     while {
-        // Fetch latest status from hardware port
-        let raw = read_status();
-
-        status_reg.set(raw);
-
-        // Check if controller is still busy (input buffer full)
-        status_reg.is_set(STATUS::INPUT_FULL)
+        status.set(read_status());
+        status.is_set(STATUS::INPUT_FULL)
     } {
-        // Increment our loop counter and bail out on timeout
         loops += 1;
         if loops >= TIMEOUT_LIMIT {
-            // We could log a debug here if desired:
-            // debug!("ps2: wait_input_ready timed out after {} loops", loops);
-            break;
+            return Err(Ps2Error::TimeoutIB);
         }
     }
+    Ok(())
 }
 
 /// Data-ready events trigger IRQ1, handled asynchronously in `handle_interrupt()`.
@@ -72,53 +81,178 @@ fn wait_input_ready() {
 ///
 /// Block until there is data ready to read in the output buffer.
 #[inline(always)]
-fn wait_output_ready() {
-    // Local copy of the status register
-    let mut status_reg = LocalRegisterCopy::<u8, STATUS::Register>::new(0);
-    // Loop counter to prevent infinite spin
+fn wait_ob_full() -> Ps2Result<()> {
+    let mut status = LocalRegisterCopy::<u8, STATUS::Register>::new(0);
     let mut loops = 0;
-
-    // Continue spinning while the OUTPUT_FULL bit is *not* set
     while {
-        // Read current status from the controller
-        let raw = unsafe { io::inb(PS2_STATUS_PORT) };
-        status_reg.set(raw);
-
-        // Keep looping if no data is available yet
-        !status_reg.is_set(STATUS::OUTPUT_FULL)
+        status.set(read_status());
+        !status.is_set(STATUS::OUTPUT_FULL)
     } {
-        // Increment loop counter and abort on timeout
         loops += 1;
         if loops >= TIMEOUT_LIMIT {
-            // Optionally log a timeout here:
-            // debug!("ps2: wait_output_ready timed out after {} loops", loops);
-            break;
+            return Err(Ps2Error::TimeoutOB);
         }
     }
+    Ok(())
 }
 
 /// Read one byte from the data port (0x60).
 #[inline(always)]
-fn read_data() -> u8 {
-    wait_output_ready();
-    unsafe { io::inb(PS2_DATA_PORT) }
+fn read_data() -> Ps2Result<u8> {
+    wait_ob_full()?;
+    Ok(unsafe { io::inb(PS2_DATA_PORT) })
 }
 
 /// Send a command byte to the controller (port 0x64).
 #[inline(always)]
-fn write_command(c: u8) {
-    wait_input_ready();
+fn write_command(c: u8) -> Ps2Result<()> {
+    wait_ib_empty()?;
     unsafe { io::outb(PS2_STATUS_PORT, c) }
+    Ok(())
 }
+
 /// Write a data byte to the data port (0x60).
 #[inline(always)]
-fn write_data(d: u8) {
-    wait_input_ready();
+fn write_data(d: u8) -> Ps2Result<()> {
+    wait_ib_empty()?;
     unsafe { io::outb(PS2_DATA_PORT, d) }
+    Ok(())
 }
+
 #[inline(always)]
 fn read_status() -> u8 {
     unsafe { io::inb(PS2_STATUS_PORT) }
+}
+
+fn read_config() -> Ps2Result<u8> {
+    write_command(0x20)?; // Read Controller Configuration Byte
+    read_data()
+}
+
+fn write_config(cfg: u8) -> Ps2Result<()> {
+    write_command(0x60)?; // Write Controller Configuration Byte
+    write_data(cfg)
+}
+
+fn update_config<F: FnOnce(u8) -> u8>(f: F) -> Ps2Result<u8> {
+    let cur = read_config()?;
+    let new = f(cur);
+    write_config(new)?;
+    Ok(new)
+}
+
+/// Config helpers so we don't break the whole address in the init
+/// we can do it sequentially
+
+fn cfg_set_translation(enabled: bool) -> Ps2Result<u8> {
+    update_config(|mut c| {
+        if enabled {
+            c |= CFG_TRANSLATION
+        } else {
+            c &= !CFG_TRANSLATION
+        }
+        c
+    })
+}
+
+fn cfg_set_port1_clock(enabled: bool) -> Ps2Result<u8> {
+    // enabled => clear DISABLE_KBD bit
+    update_config(|mut c| {
+        if enabled {
+            c &= !CFG_DISABLE_KBD
+        } else {
+            c |= CFG_DISABLE_KBD
+        }
+        c
+    })
+}
+
+fn cfg_set_port2_clock(enabled: bool) -> Ps2Result<u8> {
+    // enabled => clear DISABLE_AUX bit
+    update_config(|mut c| {
+        if enabled {
+            c &= !CFG_DISABLE_AUX
+        } else {
+            c |= CFG_DISABLE_AUX
+        }
+        c
+    })
+}
+
+fn cfg_set_irq1(enabled: bool) -> Ps2Result<u8> {
+    update_config(|mut c| {
+        if enabled {
+            c |= CFG_IRQ1
+        } else {
+            c &= !CFG_IRQ1
+        }
+        c
+    })
+}
+
+fn cfg_set_irq12(enabled: bool) -> Ps2Result<u8> {
+    update_config(|mut c| {
+        if enabled {
+            c |= CFG_IRQ12
+        } else {
+            c &= !CFG_IRQ12
+        }
+        c
+    })
+}
+fn disable_ports() -> Ps2Result<()> {
+    write_command(0xAD)?; // disable keyboard (port 1)
+    write_command(0xA7)?; // disable aux (port 2)
+    Ok(())
+}
+
+fn flush_output_buffer() -> Ps2Result<()> {
+    while read_status() & 0x01 != 0 {
+        let _ = read_data()?; // non-blocking-ish: read_data waits only if OB set
+    }
+    Ok(())
+}
+
+fn controller_self_test() -> Ps2Result<()> {
+    write_command(0xAA)?;
+    match read_data()? {
+        0x55 => Ok(()),
+        other => Err(Ps2Error::UnexpectedResponse(other)),
+    }
+}
+
+fn port1_interface_test() -> Ps2Result<()> {
+    write_command(0xAB)?;
+    match read_data()? {
+        0x00 => Ok(()),
+        other => Err(Ps2Error::UnexpectedResponse(other)),
+    }
+}
+
+fn enable_port1_clock() -> Ps2Result<()> {
+    write_command(0xAE)
+}
+
+fn kbd_disable_scan() -> Ps2Result<()> {
+    send_with_ack(0xF5, 3)
+}
+
+fn kbd_reset_and_wait_bat() -> Ps2Result<()> {
+    send_with_ack(0xFF, 3)?; // ACK for reset
+    match read_data()? {
+        // BAT result
+        0xAA => Ok(()),
+        other => Err(Ps2Error::UnexpectedResponse(other)),
+    }
+}
+
+fn kbd_set_scancode_set2() -> Ps2Result<()> {
+    send_with_ack(0xF0, 3)?;
+    send_with_ack(0x02, 3)
+}
+
+fn kbd_enable_scan() -> Ps2Result<()> {
+    send_with_ack(0xF4, 3)
 }
 
 /// Send a byte to the keyboard and wait for ACK (`0xFA`).
@@ -126,18 +260,19 @@ fn read_status() -> u8 {
 ///
 /// Heads-up: this will be modified in the keyboard driver
 /// to better handle command requests,
-/// this is just a showcase... for now
-fn send_with_ack(byte: u8) -> bool {
-    for _ in 0..=1 {
-        write_data(byte);
-        let resp = read_data();
+fn send_with_ack(byte: u8, tries: u8) -> Ps2Result<()> {
+    let mut attempts = 0;
+    loop {
+        attempts += 1;
+        write_data(byte)?;
+        let resp = read_data()?;
         match resp {
-            0xFA => return true, // ACK
-            0xFE => continue,    // RESEND -> try again
-            _ => return false,   // error
+            0xFA => return Ok(()),                // ACK
+            0xFE if attempts < tries => continue, // RESEND -> retry
+            0xFE => return Err(Ps2Error::AckError),
+            other => return Err(Ps2Error::UnexpectedResponse(other)),
         }
     }
-    false
 }
 
 /// PS/2 controller driver (the “8042” peripheral)
@@ -146,6 +281,9 @@ pub struct Ps2Controller {
     head: Cell<usize>,
     tail: Cell<usize>,
     count: Cell<usize>, // new field to track number of valid entries
+    // track prefix bytes for logging => press/release only inputs
+    break_next: Cell<bool>, // saw 0xF0; next data byte is a BREAK
+    ext_next: Cell<bool>,   // saw 0xE0; next data byte is extended
 }
 
 impl Ps2Controller {
@@ -155,74 +293,52 @@ impl Ps2Controller {
             head: Cell::new(0),
             tail: Cell::new(0),
             count: Cell::new(0),
+            break_next: Cell::new(false),
+            ext_next: Cell::new(false),
         }
     }
 
     /// Pure controller + device bring-up.
     /// No logging, no PIC masking/unmasking, no CPU-IRQ enabling. (hopefully)
     /// Called by PcComponent::finalize() (chip layer).
+    ///
     /// Whole goal of this change is to stop nagging the memory directly
-    pub fn init_early(&self) -> Result<(), Ps2Error> {
-        // disable both ports
-        write_command(0xAD); // disable keyboard (port 1)
-        write_command(0xA7); // disable aux/mouse (port 2)
+    /// We created tiny wrappers and helpers, so we can configure the init
+    /// much easier
+    pub fn init_early(&self) -> Ps2Result<()> {
+        // disable ports; flush OB
+        disable_ports()?;
+        flush_output_buffer()?;
 
-        // flush any stale bytes from the output buffer
-        while read_status() & 0x01 != 0 {
-            let _ = unsafe { io::inb(PS2_DATA_PORT) };
-        }
+        // controller self-test
+        controller_self_test()?;
 
-        // controller self-test: 0xAA -> expect 0x55
-        write_command(0xAA);
-        wait_output_ready();
-        if read_data() != 0x55 {
-            return Err(Ps2Error::InitFailed);
-        }
+        // config policy (do not generate IRQs during tests)
+        cfg_set_irq1(false)?; // IRQ1 off
+        cfg_set_irq12(false)?; // IRQ12 off
+        cfg_set_translation(false)?; // translation OFF (we want Set2)
+        cfg_set_port1_clock(true)?; // keyboard clock enabled
+        cfg_set_port2_clock(false)?; // mouse clock disabled (for now)
 
-        // read config, ensure IRQ1 off during tests
-        write_command(0x20); // read config
-        wait_output_ready();
-        let mut cfg = read_data();
-        cfg &= !(1 << 0); // IRQ1 = 0 (off)
-        write_command(0x60); // write config
-        write_data(cfg);
+        // port1 test then enable keyboard clock at the controller command level
+        port1_interface_test()?;
+        enable_port1_clock()?; // 0xAE
 
-        // port 1 (keyboard) interface test: 0xAB -> expect 0x00
-        write_command(0xAB);
-        wait_output_ready();
-        if read_data() != 0x00 {
-            return Err(Ps2Error::InitFailed);
-        }
-
-        // enable keyboard clock
-        write_command(0xAE);
-
-        // enable scanning (strict Set-2 policy comes in the future)
-        if !send_with_ack(0xF4) {
-            return Err(Ps2Error::InitFailed);
-        }
-
-        // re-enable IRQ1 in the *controller* (PIC unmask is done in chip)
-        write_command(0x20);
-        wait_output_ready();
-        let mut cfg2 = read_data();
-        cfg2 |= 1 << 0; // IRQ1 = 1 (on)
-        write_command(0x60);
-        write_data(cfg2);
+        // device sequence (keyboard)
+        kbd_disable_scan()?; // F5
+        kbd_reset_and_wait_bat()?; // FF -> BAT=AA
+        kbd_set_scancode_set2()?; // F0 02
+        cfg_set_irq1(true)?; // turn on controller-side IRQ1 (PIC policy lives in chip)
+        kbd_enable_scan()?; // F4
 
         Ok(())
     }
 
-    /// Legacy wrapper: keep around short-term so old call sites compile.
-    /// Chip will call `init_early()` instead.
-    /// for now
-    #[deprecated(note = "Use init_early() from the chip bring-up.")]
-    pub fn init(&self) {
-        let _ = self.init_early();
-    }
-
     /// Handle a keyboard interrupt: read a scan-code and buffer it.
-    pub fn handle_interrupt(&self) {
+    /// as of now it works, but it prints press/release as well
+    /// which gets messy in the terminal
+    /// for testing, i'll make it so we only log make/break events
+    /* pub fn handle_interrupt(&self) {
         loop {
             if unsafe { io::inb(PS2_STATUS_PORT) } & 0x01 == 0 {
                 break;
@@ -230,6 +346,78 @@ impl Ps2Controller {
             let byte = unsafe { io::inb(PS2_DATA_PORT) };
             self.push_code(byte);
             debug!("ps2 irq 0x{:02X}", byte);
+        }
+    }*/
+
+    pub fn handle_interrupt(&self) {
+        loop {
+            // Snapshot the controller status. Bit0 (OUTPUT_FULL) says whether
+            // there's a byte waiting in the output buffer (OB) at 0x60.
+            let status = read_status();
+            if (status & 0x01) == 0 {
+                // OUTPUT_FULL == 0 => no more data
+                break;
+            }
+
+            // Reading 0x60 pops one byte from OB and (for that byte) clears OUTPUT_FULL.
+            let b = unsafe { io::inb(PS2_DATA_PORT) };
+
+            // Check error flags associated with this byte:
+            // bit7 PARITY_ERR
+            // bit6 TIMEOUT_ERR
+            // If either is set we drop the byte (we already consumed OB by reading).
+            let parity = (status & (1 << 7)) != 0;
+            let timeout = (status & (1 << 6)) != 0;
+            if parity || timeout {
+                debug!(
+                    "ps2: dropped byte {:02X} ({}{})",
+                    b,
+                    if parity { "PARITY" } else { "" },
+                    if timeout {
+                        if parity {
+                            "+"
+                        } else {
+                            ""
+                        }
+                    } else {
+                        ""
+                    }
+                );
+                continue; // don’t push/log corrupted data
+            }
+
+            // Always preserve the raw stream (including prefixes) for the future keyboard driver.
+            self.push_code(b);
+
+            // Set-2 uses prefixes:
+            // - 0xE0 marks "extended" keys (next data byte is extended)
+            // - 0xF0 marks a BREAK (key release) for the next data byte
+            // We don't log prefixes themselves; we just remember them.
+            if b == 0xE0 {
+                self.ext_next.set(true);
+                continue;
+            }
+            if b == 0xF0 {
+                self.break_next.set(true);
+                continue;
+            }
+
+            // At this point `b` is a real scancode byte (not a prefix).
+            // Consume the remembered prefix flags to print exactly one MAKE/BREAK line.
+            let ext = self.ext_next.get();
+            let brk = self.break_next.get();
+            if ext {
+                self.ext_next.set(false);
+            }
+            if brk {
+                self.break_next.set(false);
+            }
+
+            if brk {
+                debug!("ps2: BREAK {}{:02X}", if ext { "E0 " } else { "" }, b);
+            } else {
+                debug!("ps2: MAKE  {}{:02X}", if ext { "E0 " } else { "" }, b);
+            }
         }
     }
 
@@ -257,40 +445,5 @@ impl Ps2Controller {
         } else {
             self.tail.set((self.tail.get() + 1) % BUFFER_SIZE);
         }
-    }
-}
-
-// ---------- Unit tests for ring buffer only ----------
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_ring_buffer_basic() {
-        let dev = Ps2Controller::new();
-        // buffer empty
-        assert_eq!(dev.pop_scan_code(), None);
-        // simulate push via the internal helper
-        dev.push_code(0x10);
-        assert_eq!(dev.pop_scan_code(), Some(0x10));
-        assert_eq!(dev.pop_scan_code(), None);
-    }
-
-    #[test]
-    fn test_ring_buffer_overflow() {
-        let dev = Ps2Controller::new();
-        // fill buffer
-        for i in 0..BUFFER_SIZE {
-            dev.push_code(i as u8);
-        }
-        // overflow one slot
-        dev.push_code(0xFF);
-        // should have dropped the first (0), yielding 1..BUFFER_SIZE-1 then 0xFF
-        for expected in 1..BUFFER_SIZE {
-            assert_eq!(dev.pop_scan_code(), Some(expected as u8));
-        }
-        assert_eq!(dev.pop_scan_code(), Some(0xFF));
-        assert_eq!(dev.pop_scan_code(), None);
     }
 }

--- a/chips/x86_q35/src/ps2.rs
+++ b/chips/x86_q35/src/ps2.rs
@@ -121,7 +121,7 @@ pub type Ps2Result<T> = core::result::Result<T, Ps2Error>;
 /// Block until the controller’s input buffer is empty (ready for a command).
 
 #[inline(always)]
-fn wait_ib_empty_with(limit: usize) -> Ps2Result<()> {
+fn wait_ib_empty_with_timeout(limit: usize) -> Ps2Result<()> {
     let mut spins = 0usize;
     while read_status().is_set(STATUS::INPUT_FULL) {
         spins += 1;
@@ -138,7 +138,7 @@ fn wait_ib_empty_with(limit: usize) -> Ps2Result<()> {
 ///
 /// Block until there is data ready to read in the output buffer.
 #[inline(always)]
-fn wait_ob_full_with(limit: usize) -> Ps2Result<()> {
+fn wait_ob_full_with_timeout(limit: usize) -> Ps2Result<()> {
     let mut spins = 0usize;
     while !read_status().is_set(STATUS::OUTPUT_FULL) {
         spins += 1;
@@ -152,14 +152,14 @@ fn wait_ob_full_with(limit: usize) -> Ps2Result<()> {
 /// Read one byte from the data port (0x60).
 #[inline(always)]
 fn read_data_with(limit: usize) -> Ps2Result<u8> {
-    wait_ob_full_with(limit)?;
+    wait_ob_full_with_timeout(limit)?;
     Ok(unsafe { io::inb(PS2_DATA_PORT) })
 }
 
 /// Send a command byte to the controller (port 0x64).
 #[inline(always)]
 fn write_command_with(c: u8, limit: usize) -> Ps2Result<()> {
-    wait_ib_empty_with(limit)?;
+    wait_ib_empty_with_timeout(limit)?;
     unsafe { io::outb(PS2_STATUS_PORT, c) }
     Ok(())
 }
@@ -167,7 +167,7 @@ fn write_command_with(c: u8, limit: usize) -> Ps2Result<()> {
 /// Write a data byte to the data port (0x60).
 #[inline(always)]
 fn write_data_with(d: u8, limit: usize) -> Ps2Result<()> {
-    wait_ib_empty_with(limit)?;
+    wait_ib_empty_with_timeout(limit)?;
     unsafe { io::outb(PS2_DATA_PORT, d) }
     Ok(())
 }

--- a/chips/x86_q35/src/ps2.rs
+++ b/chips/x86_q35/src/ps2.rs
@@ -270,7 +270,7 @@ impl Ps2Controller {
 
     /// Send one byte to port 0x60 (device), small runtime spin budget.
     #[inline(always)]
-    pub(crate) fn send_port1(&self, byte: u8) -> Ps2Result<()> {
+    pub(crate) fn send_port1(&self, byte: u8) -> Result<(), Ps2Error> {
         write_data_with(byte, SPINS_RUNTIME)
     }
 

--- a/chips/x86_q35/src/ps2.rs
+++ b/chips/x86_q35/src/ps2.rs
@@ -113,8 +113,6 @@ impl core::fmt::Display for Ps2Health {
     }
 }
 
-pub type Ps2Result<T> = core::result::Result<T, Ps2Error>;
-
 /// Note: There is no hardware interrupt when the input buffer empties, so we must poll bit 1.
 /// See OSDev documentation:
 /// https://wiki.osdev.org/I8042_PS/2_Controller#Status_Register
@@ -122,7 +120,7 @@ pub type Ps2Result<T> = core::result::Result<T, Ps2Error>;
 /// Block until the controller’s input buffer is empty (ready for a command).
 
 #[inline(always)]
-fn wait_ib_empty_with_timeout(limit: usize) -> Ps2Result<()> {
+fn wait_ib_empty_with_timeout(limit: usize) -> Result<(), Ps2Error> {
     let mut spins = 0usize;
     while read_status().is_set(STATUS::INPUT_FULL) {
         spins += 1;
@@ -139,7 +137,7 @@ fn wait_ib_empty_with_timeout(limit: usize) -> Ps2Result<()> {
 ///
 /// Block until there is data ready to read in the output buffer.
 #[inline(always)]
-fn wait_ob_full_with_timeout(limit: usize) -> Ps2Result<()> {
+fn wait_ob_full_with_timeout(limit: usize) -> Result<(), Ps2Error> {
     let mut spins = 0usize;
     while !read_status().is_set(STATUS::OUTPUT_FULL) {
         spins += 1;
@@ -152,14 +150,14 @@ fn wait_ob_full_with_timeout(limit: usize) -> Ps2Result<()> {
 
 /// Read one byte from the data port (0x60).
 #[inline(always)]
-fn read_data_with(limit: usize) -> Ps2Result<u8> {
+fn read_data_with(limit: usize) -> Result<u8, Ps2Error> {
     wait_ob_full_with_timeout(limit)?;
     Ok(unsafe { io::inb(PS2_DATA_PORT) })
 }
 
 /// Send a command byte to the controller (port 0x64).
 #[inline(always)]
-fn write_command_with(c: u8, limit: usize) -> Ps2Result<()> {
+fn write_command_with(c: u8, limit: usize) -> Result<(), Ps2Error> {
     wait_ib_empty_with_timeout(limit)?;
     unsafe { io::outb(PS2_STATUS_PORT, c) }
     Ok(())
@@ -167,7 +165,7 @@ fn write_command_with(c: u8, limit: usize) -> Ps2Result<()> {
 
 /// Write a data byte to the data port (0x60).
 #[inline(always)]
-fn write_data_with(d: u8, limit: usize) -> Ps2Result<()> {
+fn write_data_with(d: u8, limit: usize) -> Result<(), Ps2Error> {
     wait_ib_empty_with_timeout(limit)?;
     unsafe { io::outb(PS2_DATA_PORT, d) }
     Ok(())
@@ -178,7 +176,7 @@ fn read_status() -> LocalRegisterCopy<u8, STATUS::Register> {
 }
 
 #[inline(always)]
-fn read_config_reg_with(limit: usize) -> Ps2Result<LocalRegisterCopy<u8, CONFIG::Register>> {
+fn read_config_reg_with(limit: usize) -> Result<LocalRegisterCopy<u8, CONFIG::Register>, Ps2Error> {
     write_command_with(0x20, limit)?; // Read Controller Configuration Byte
     Ok(LocalRegisterCopy::new(read_data_with(limit)?))
 }
@@ -187,12 +185,12 @@ fn read_config_reg_with(limit: usize) -> Ps2Result<LocalRegisterCopy<u8, CONFIG:
 fn write_config_reg_with(
     cfg: LocalRegisterCopy<u8, CONFIG::Register>,
     limit: usize,
-) -> Ps2Result<()> {
+) -> Result<(), Ps2Error> {
     write_command_with(0x60, limit)?; // Write Controller Configuration Byte
     write_data_with(cfg.get(), limit)
 }
 
-fn update_config_with<F>(limit: usize, f: F) -> Ps2Result<u8>
+fn update_config_with<F>(limit: usize, f: F) -> Result<u8, Ps2Error>
 where
     F: FnOnce(LocalRegisterCopy<u8, CONFIG::Register>) -> LocalRegisterCopy<u8, CONFIG::Register>,
 {
@@ -202,7 +200,7 @@ where
     Ok(new.get())
 }
 
-fn flush_output_buffer() -> Ps2Result<()> {
+fn flush_output_buffer() -> Result<(), Ps2Error> {
     // Poll status; if OB has data, read once and loop.
     // Use the small runtime budget for the read.
     while read_status().is_set(STATUS::OUTPUT_FULL) {
@@ -280,7 +278,7 @@ impl Ps2Controller {
 
     /// Count controller wait timeouts
     #[inline(always)]
-    fn tally_timeout<T>(&self, r: Ps2Result<T>) -> Ps2Result<T> {
+    fn tally_timeout<T>(&self, r: Result<T, Ps2Error>) -> Result<T, Ps2Error> {
         if matches!(r, Err(Ps2Error::TimeoutIB) | Err(Ps2Error::TimeoutOB)) {
             self.timeouts.set(self.timeouts.get().wrapping_add(1));
         }
@@ -297,7 +295,7 @@ impl Ps2Controller {
     /// `Ok(())` on ACK
     /// `Err(Ps2Error::AckError)` if RESEND persists after all retries
     /// `Err(Ps2Error::UnexpectedResponse(_))` for any other response byte
-    fn send_with_ack_limit(&self, byte: u8, tries: u8, limit: usize) -> Ps2Result<()> {
+    fn send_with_ack_limit(&self, byte: u8, tries: u8, limit: usize) -> Result<(), Ps2Error> {
         let mut attempts = 0;
         loop {
             attempts += 1;
@@ -327,7 +325,7 @@ impl Ps2Controller {
     ///
     /// For testing and health of the controller, we'll wrap each call with
     /// tally_timeout helper
-    pub fn init_early_with_spins(&self, spins: usize) -> Ps2Result<()> {
+    pub fn init_early_with_spins(&self, spins: usize) -> Result<(), Ps2Error> {
         // disable ports; flush OB
         self.tally_timeout(write_command_with(0xAD, spins))?;
         self.tally_timeout(write_command_with(0xA7, spins))?;
@@ -395,7 +393,7 @@ impl Ps2Controller {
     }
 
     /// Back-compat wrapper: long spin budget during bring-up.
-    pub fn init_early(&self) -> Ps2Result<()> {
+    pub fn init_early(&self) -> Result<(), Ps2Error> {
         self.init_early_with_spins(SPINS_INIT)
     }
     pub fn handle_interrupt(&self) {

--- a/chips/x86_q35/src/ps2.rs
+++ b/chips/x86_q35/src/ps2.rs
@@ -199,13 +199,9 @@ fn write_config_reg(cfg: LocalRegisterCopy<u8, CONFIG::Register>) -> Ps2Result<(
     write_data(cfg.get())
 }
 
-
-fn update_config<F>(
-    f: F,
-) -> Ps2Result<u8>
+fn update_config<F>(f: F) -> Ps2Result<u8>
 where
-    F: FnOnce(LocalRegisterCopy<u8, CONFIG::Register>)
-        -> LocalRegisterCopy<u8, CONFIG::Register>,
+    F: FnOnce(LocalRegisterCopy<u8, CONFIG::Register>) -> LocalRegisterCopy<u8, CONFIG::Register>,
 {
     let cur = read_config_reg()?;
     let new = f(cur);
@@ -213,14 +209,16 @@ where
     Ok(new.get())
 }
 
-
 /// Config helpers so we don't break the whole address in the init
 /// we can do it sequentially
 
 fn cfg_set_translation(enabled: bool) -> Ps2Result<u8> {
     update_config(|mut c| {
-        if enabled { c.modify(CONFIG::TRANSLATION::SET); }
-        else       { c.modify(CONFIG::TRANSLATION::CLEAR); }
+        if enabled {
+            c.modify(CONFIG::TRANSLATION::SET);
+        } else {
+            c.modify(CONFIG::TRANSLATION::CLEAR);
+        }
         c
     })
 }
@@ -228,8 +226,11 @@ fn cfg_set_translation(enabled: bool) -> Ps2Result<u8> {
 fn cfg_set_port1_clock(enabled: bool) -> Ps2Result<u8> {
     // enabled => clear DISABLE_KBD bit
     update_config(|mut c| {
-        if enabled { c.modify(CONFIG::DISABLE_KBD::CLEAR); }
-        else       { c.modify(CONFIG::DISABLE_KBD::SET); }
+        if enabled {
+            c.modify(CONFIG::DISABLE_KBD::CLEAR);
+        } else {
+            c.modify(CONFIG::DISABLE_KBD::SET);
+        }
         c
     })
 }
@@ -237,24 +238,33 @@ fn cfg_set_port1_clock(enabled: bool) -> Ps2Result<u8> {
 fn cfg_set_port2_clock(enabled: bool) -> Ps2Result<u8> {
     // enabled => clear DISABLE_AUX bit
     update_config(|mut c| {
-        if enabled { c.modify(CONFIG::DISABLE_AUX::CLEAR); }
-        else       { c.modify(CONFIG::DISABLE_AUX::SET); }
+        if enabled {
+            c.modify(CONFIG::DISABLE_AUX::CLEAR);
+        } else {
+            c.modify(CONFIG::DISABLE_AUX::SET);
+        }
         c
     })
 }
 
 fn cfg_set_irq1(enabled: bool) -> Ps2Result<u8> {
     update_config(|mut c| {
-        if enabled { c.modify(CONFIG::IRQ1::SET); }
-        else       { c.modify(CONFIG::IRQ1::CLEAR); }
+        if enabled {
+            c.modify(CONFIG::IRQ1::SET);
+        } else {
+            c.modify(CONFIG::IRQ1::CLEAR);
+        }
         c
     })
 }
 
 fn cfg_set_irq12(enabled: bool) -> Ps2Result<u8> {
     update_config(|mut c| {
-        if enabled { c.modify(CONFIG::IRQ12::SET); }
-        else       { c.modify(CONFIG::IRQ12::CLEAR); }
+        if enabled {
+            c.modify(CONFIG::IRQ12::SET);
+        } else {
+            c.modify(CONFIG::IRQ12::CLEAR);
+        }
         c
     })
 }

--- a/chips/x86_q35/src/ps2.rs
+++ b/chips/x86_q35/src/ps2.rs
@@ -272,6 +272,14 @@ impl Ps2Controller {
         }
     }
 
+    /// Send one byte to the keyboard data port (0x60).
+    /// Busy-waits with a small runtime spin budget.
+    /// No ACK/RESEND handling here; that lives in the keyboard.
+    #[inline(always)]
+    pub(crate) fn send_port1(&self, byte: u8) -> Ps2Result<()> {
+        write_data_with(byte, SPINS_RUNTIME)
+    }
+
     /// Install the "keyboard" client, we'll wire calls to this later
     /// for now it's just the hook
     pub fn set_client(&self, client: &'static dyn Ps2Client) {

--- a/chips/x86_q35/src/ps2.rs
+++ b/chips/x86_q35/src/ps2.rs
@@ -118,7 +118,6 @@ impl core::fmt::Display for Ps2Health {
 /// https://wiki.osdev.org/I8042_PS/2_Controller#Status_Register
 ///
 /// Block until the controller’s input buffer is empty (ready for a command).
-
 #[inline(always)]
 fn wait_ib_empty_with_timeout(limit: usize) -> Result<(), Ps2Error> {
     let mut spins = 0usize;


### PR DESCRIPTION
### Pull Request Overview

This adds a PS/2 keyboard driver for x86_q35, layered over the i8042 controller.

- Set-2 decoder: handles E0 (extended), F0 (break), and swallows the E1 Pause sequence.

- Minimal event model (KeyEvent): make/break + extended bit.

- Optional ASCII path (US layout): press-only, non-extended, with Shift/Caps handling.

- Small command engine (non-alloc FIFO) for device commands with ACK (0xFA) / RESEND (0xFE) retry logic.

- Defensive indexing via bounds-checked access in the command queue (no panics).

### Dependencies

- Depends on #4594 (PS/2 controller). This PR is stacked on it; the diff will shrink after #4594 lands.


### Testing Strategy

Built and ran under QEMU; typed sequences to verify:

- MAKE/BREAK decoding (including E0-extended keys).

- ASCII emission path (letters, digits, common punctuation; Shift/Caps).

- Non-keystroke device responses (0xFA/0xFE/0xAA) are ignored unless a command is in flight.

- Command engine present and compiled; it will be exercised when we move device init from the controller to the keyboard/capsule.


### TODO or Help Wanted

- Move the keyboard init sequence (F5 -> FF -> F0 02 -> F4) from the controller into the keyboard using the command engine.

- Hook a capsule (client) to consume KeyEvent / ASCII (e.g., process console over VGA).


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
