### PR TITLE
x86: Interrupt Handling Improvements

### DIFF
--- a/boards/qemu_i486_q35/Makefile
+++ b/boards/qemu_i486_q35/Makefile
@@ -15,12 +15,17 @@ WORKING_QEMU_VERSION := 7.2.0
 
 # Peripherals attached by default:
 # - 16550 UART (attached to stdio by default)
+# - VGA display (pass NOVGA=1 to disable)
 QEMU_BASE_CMDLINE := \
   $(QEMU_CMD) \
     -cpu 486 \
     -machine q35 \
     -net none \
     -device isa-debug-exit,iobase=0xf4,iosize=0x04
+
+ifeq ($(NOVGA),1)
+QEMU_BASE_CMDLINE += -nographic
+endif
 
 # Run the kernel inside a qemu-system-i386 "q35" machine type simulation
 #

--- a/boards/qemu_i486_q35/src/main.rs
+++ b/boards/qemu_i486_q35/src/main.rs
@@ -48,7 +48,7 @@ const NUM_PROCS: usize = 4;
 static mut PROCESSES: Option<&'static ProcessArray<NUM_PROCS>> = None;
 
 // Reference to the chip for panic dumps
-static mut CHIP: Option<&'static Pc> = None;
+static mut CHIP: Option<&'static Pc<'static, ()>> = None;
 
 // Reference to the process printer for panic dumps.
 static mut PROCESS_PRINTER: Option<&'static capsules_system::process_printer::ProcessPrinterText> =
@@ -152,8 +152,9 @@ unsafe extern "cdecl" fn main() {
     let chip = PcComponent::new(
         &mut *ptr::addr_of_mut!(PAGE_DIR),
         &mut *ptr::addr_of_mut!(PAGE_TABLE),
+        &(),
     )
-    .finalize(x86_q35::x86_q35_component_static!());
+    .finalize(x86_q35::x86_q35_component_static!(()));
 
     // Acquire required capabilities
     let process_mgmt_cap = create_capability!(capabilities::ProcessManagementCapability);

--- a/chips/x86_q35/src/chip.rs
+++ b/chips/x86_q35/src/chip.rs
@@ -6,13 +6,14 @@ use core::fmt::Write;
 use core::mem::MaybeUninit;
 
 use kernel::component::Component;
-use kernel::platform::chip::Chip;
+use kernel::platform::chip::{Chip, InterruptService};
 use kernel::static_init;
 use x86::mpu::PagingMPU;
 use x86::registers::bits32::paging::{PD, PT};
 use x86::support;
 use x86::{Boundary, InterruptPoller};
 
+use crate::pic::PIC1_OFFSET;
 use crate::pit::{Pit, RELOAD_1KHZ};
 use crate::serial::{SerialPort, SerialPortComponent, COM1_BASE, COM2_BASE, COM3_BASE, COM4_BASE};
 use crate::vga_uart_driver::VgaText;
@@ -38,7 +39,23 @@ mod interrupt {
 /// chip definition should be broadly compatible with most PC hardware.
 ///
 /// Parameter `PR` is the PIT reload value. See [`Pit`] for more information.
-pub struct Pc<'a, const PR: u16 = RELOAD_1KHZ> {
+///
+/// # Interrupt Handling
+///
+/// This chip automatically handles interrupts for legacy PC devices which are known to be present
+/// on QEMU's Q35 machine type. This includes the PIT timer and four serial ports. Other devices
+/// which are conditionally present (e.g. Virtio devices specified on the QEMU command line) may be
+/// handled via a board-specific implementation of [`InterruptService`].
+///
+/// This chip uses the legacy 8259 PIC to manage interrupts. This is relatively simple compared with
+/// using the Local APIC or I/O APIC and avoids needing to interact with ACPI or MP tables.
+///
+/// Internally, this chip re-maps the PIC interrupt numbers to avoid conflicts with ISA-defined
+/// exceptions. This remapping is fully encapsulated within the chip. **N.B.** Implementors of
+/// [`InterruptService`] will be passed the physical interrupt line number, _not_ the remapped
+/// number used internally by the chip. This should match the interrupt line number reported by
+/// documentation or read from the PCI configuration space.
+pub struct Pc<'a, I: InterruptService + 'a, const PR: u16 = RELOAD_1KHZ> {
     /// Legacy COM1 serial port
     pub com1: &'a SerialPort<'a>,
 
@@ -60,9 +77,12 @@ pub struct Pc<'a, const PR: u16 = RELOAD_1KHZ> {
     /// System call context
     syscall: Boundary,
     paging: PagingMPU<'a>,
+
+    /// Board-provided interrupt service for handling non-core IRQs (e.g., PCI devices)
+    int_svc: &'a I,
 }
 
-impl<'a, const PR: u16> Chip for Pc<'a, PR> {
+impl<'a, I: InterruptService + 'a, const PR: u16> Chip for Pc<'a, I, PR> {
     type ThreadIdProvider = x86::thread_id::X86ThreadIdProvider;
 
     type MPU = PagingMPU<'a>;
@@ -89,7 +109,12 @@ impl<'a, const PR: u16> Chip for Pc<'a, PR> {
                         self.com1.handle_interrupt();
                         self.com3.handle_interrupt();
                     }
-                    _ => handled = false,
+                    _ => {
+                        // Convert back to physical interrupt line number before passing to
+                        // board-specific handler
+                        let phys_num = num - PIC1_OFFSET as u32;
+                        handled = unsafe { self.int_svc.service_interrupt(phys_num) };
+                    }
                 }
 
                 poller.clear_pending(num);
@@ -176,12 +201,13 @@ impl<'a, const PR: u16> Chip for Pc<'a, PR> {
 /// During the call to `finalize()`, this helper will perform low-level initialization of the PC
 /// hardware to ensure a consistent CPU state. This includes initializing memory segmentation and
 /// interrupt handling. See [`x86::init`] for further details.
-pub struct PcComponent<'a> {
+pub struct PcComponent<'a, I: InterruptService + 'a> {
     pd: &'a mut PD,
     pt: &'a mut PT,
+    int_svc: &'a I,
 }
 
-impl<'a> PcComponent<'a> {
+impl<'a, I: InterruptService + 'a> PcComponent<'a, I> {
     /// Creates a new `PcComponent` instance.
     ///
     /// ## Safety
@@ -193,20 +219,20 @@ impl<'a> PcComponent<'a> {
     /// will cause the kernel's code/data to move unexpectedly.
     ///
     /// See [`x86::init`] for further details.
-    pub unsafe fn new(pd: &'a mut PD, pt: &'a mut PT) -> Self {
-        Self { pd, pt }
+    pub unsafe fn new(pd: &'a mut PD, pt: &'a mut PT, int_svc: &'a I) -> Self {
+        Self { pd, pt, int_svc }
     }
 }
 
-impl Component for PcComponent<'static> {
+impl<I: InterruptService + 'static> Component for PcComponent<'static, I> {
     type StaticInput = (
         <SerialPortComponent as Component>::StaticInput,
         <SerialPortComponent as Component>::StaticInput,
         <SerialPortComponent as Component>::StaticInput,
         <SerialPortComponent as Component>::StaticInput,
-        &'static mut MaybeUninit<Pc<'static>>,
+        &'static mut MaybeUninit<Pc<'static, I>>,
     );
-    type Output = &'static Pc<'static>;
+    type Output = &'static Pc<'static, I>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
         // Low-level hardware initialization. We do this first to guarantee the CPU is in a
@@ -257,6 +283,7 @@ impl Component for PcComponent<'static> {
             vga,
             syscall,
             paging,
+            int_svc: self.int_svc,
         });
 
         pc
@@ -266,13 +293,13 @@ impl Component for PcComponent<'static> {
 /// Provides static buffers needed for `PcComponent::finalize()`.
 #[macro_export]
 macro_rules! x86_q35_component_static {
-    () => {{
+    ($isr_ty:ty) => {{
         (
             $crate::serial_port_component_static!(),
             $crate::serial_port_component_static!(),
             $crate::serial_port_component_static!(),
             $crate::serial_port_component_static!(),
-            kernel::static_buf!($crate::Pc<'static>),
+            kernel::static_buf!($crate::Pc<'static, $isr_ty>),
         )
     };};
 }

--- a/chips/x86_q35/src/interrupts.rs
+++ b/chips/x86_q35/src/interrupts.rs
@@ -9,8 +9,9 @@ use super::pic;
 /// Handler for external interrupts.
 ///
 /// This function is called by the [`x86`] crate to handle interrupts from external devices.
-/// It calls [`InterruptPoller::set_pending`] to mark the interrupt as pending, then issues an EOI
-/// message to the system interrupt controller so that subsequent interrupts can be delivered.
+/// It calls [`InterruptPoller::set_pending`] to mark the interrupt as pending, masks the specific
+/// interrupt, then issues an EOI message to the system interrupt controller so that subsequent
+/// interrupts can be delivered.
 ///
 /// ## Safety
 ///
@@ -20,6 +21,7 @@ use super::pic;
 unsafe extern "cdecl" fn handle_external_interrupt(num: u32) {
     unsafe {
         InterruptPoller::set_pending(num);
+        pic::mask(num);
         pic::eoi(num);
     }
 }

--- a/chips/x86_q35/src/pic.rs
+++ b/chips/x86_q35/src/pic.rs
@@ -109,3 +109,50 @@ pub(crate) unsafe fn eoi(num: u32) {
         }
     });
 }
+
+/// Masks interrupt `num`, disabling its delivery to the CPU.
+///
+/// If `num` does not correspond to either the primary or secondary PIC, then no action is taken.
+///
+/// ## Safety
+///
+/// Must be called with interrupts disabled or from within an interrupt handler to avoid race
+/// conditions updating the IMR.
+pub(crate) unsafe fn mask(num: u32) {
+    let _ = u8::try_from(num).map(|n| unsafe {
+        if (PIC1_OFFSET..PIC1_OFFSET + 8).contains(&n) {
+            let bit = n - PIC1_OFFSET; // 0-7
+            let current = io::inb(PIC1_DATA);
+            io::outb(PIC1_DATA, current | (1u8 << bit));
+        } else if (PIC2_OFFSET..PIC2_OFFSET + 8).contains(&n) {
+            let bit = n - PIC2_OFFSET; // 0-7
+            let current = io::inb(PIC2_DATA);
+            io::outb(PIC2_DATA, current | (1u8 << bit));
+        }
+    });
+}
+
+/// Unmasks interrupt `num`, enabling its delivery to the CPU.
+///
+/// If `num` does not correspond to either the primary or secondary PIC, then no action is taken.
+///
+/// ## Safety
+///
+/// Must be called with interrupts disabled or from within an interrupt handler to avoid race
+/// conditions updating the IMR.
+///
+/// There must be an interrupt handler registered to properly handle `num`, as the interrupt may
+/// fire at any time once this function is called.
+pub(crate) unsafe fn unmask(num: u32) {
+    let _ = u8::try_from(num).map(|n| unsafe {
+        if (PIC1_OFFSET..PIC1_OFFSET + 8).contains(&n) {
+            let bit = n - PIC1_OFFSET; // 0-7
+            let current = io::inb(PIC1_DATA);
+            io::outb(PIC1_DATA, current & !(1u8 << bit));
+        } else if (PIC2_OFFSET..PIC2_OFFSET + 8).contains(&n) {
+            let bit = n - PIC2_OFFSET; // 0-7
+            let current = io::inb(PIC2_DATA);
+            io::outb(PIC2_DATA, current & !(1u8 << bit));
+        }
+    });
+}

--- a/chips/x86_q35/src/pic.rs
+++ b/chips/x86_q35/src/pic.rs
@@ -105,6 +105,7 @@ pub(crate) unsafe fn eoi(num: u32) {
             io::outb(PIC1_CMD, PIC_CMD_EOI);
         } else if (PIC2_OFFSET..PIC2_OFFSET + 8).contains(&num) {
             io::outb(PIC2_CMD, PIC_CMD_EOI);
+            io::outb(PIC1_CMD, PIC_CMD_EOI);
         }
     });
 }

--- a/kernel/src/platform/chip.rs
+++ b/kernel/src/platform/chip.rs
@@ -147,6 +147,13 @@ pub trait InterruptService {
     unsafe fn service_interrupt(&self, interrupt: u32) -> bool;
 }
 
+/// A default implementation of `InterruptService` that handles nothing and returns `false`.
+impl InterruptService for () {
+    unsafe fn service_interrupt(&self, _interrupt: u32) -> bool {
+        false
+    }
+}
+
 /// Generic operations that clock-like things are expected to support.
 pub trait ClockInterface {
     fn is_enabled(&self) -> bool;


### PR DESCRIPTION
### Pull Request Overview

Fix some bugs and improve flexibility of interrupt handling on x86:

* Ensure EOI message is properly dispatched to _both_ PIC instances for cascaded interrupts
* Mask/unmask interrupts to prevent floods from level-triggered interrupts
* Make Q35 chip generic over `I: InterruptService`, allowing downstream boards to add custom interrupt handlers
* Added NOVGA option to Q35 Makefile to allow running without QEMU GUI

See commit messages for more detail about each change.

The overarching goal of these changes is to set the stage for enabling Virtio peripherals on x86. This will be added in a subsequent PR.


### Testing Strategy

This pull request was tested by:

* Building and running Q35 kernel on QEMU, interacting with process console to ensure the system is responsive
* Passes Pluton's internal unit test suite


### TODO or Help Wanted

N/A


### Documentation Updated

Added and updated relevant doc comments within the code.

### Formatting

- [x] Ran `make prepush`.
