### PR TITLE
kernel/platform/mpu: make MPU an unsafe trait, change mock impl from `()` to `NopMPU`

### DIFF
--- a/arch/cortex-m/src/mpu.rs
+++ b/arch/cortex-m/src/mpu.rs
@@ -379,7 +379,10 @@ impl CortexMRegion {
     }
 }
 
-impl<const NUM_REGIONS: usize, const MIN_REGION_SIZE: usize> mpu::MPU
+// `MPU` is an unsafe trait, and with this implementation we guarantee
+// that we adhere to the semantics documented on that trait and its
+// associated types and methods.
+unsafe impl<const NUM_REGIONS: usize, const MIN_REGION_SIZE: usize> mpu::MPU
     for MPU<NUM_REGIONS, MIN_REGION_SIZE>
 {
     type MpuConfig = CortexMConfig<NUM_REGIONS>;

--- a/arch/cortex-m33/src/mpu_v8m.rs
+++ b/arch/cortex-m33/src/mpu_v8m.rs
@@ -394,7 +394,10 @@ impl CortexMRegion {
     }
 }
 
-impl<const NUM_REGIONS: usize> mpu::MPU for MPU<NUM_REGIONS> {
+// `MPU` is an unsafe trait, and with this implementation we guarantee
+// that we adhere to the semantics documented on that trait and its
+// associated types and methods.
+unsafe impl<const NUM_REGIONS: usize> mpu::MPU for MPU<NUM_REGIONS> {
     type MpuConfig = CortexMConfig<NUM_REGIONS>;
 
     fn enable_app_mpu(&self) {

--- a/arch/riscv/src/pmp.rs
+++ b/arch/riscv/src/pmp.rs
@@ -893,8 +893,11 @@ impl<const MAX_REGIONS: usize, P: TORUserPMP<MAX_REGIONS> + 'static> PMPUserMPU<
     }
 }
 
-impl<const MAX_REGIONS: usize, P: TORUserPMP<MAX_REGIONS> + 'static> kernel::platform::mpu::MPU
-    for PMPUserMPU<MAX_REGIONS, P>
+// `MPU` is an unsafe trait, and with this implementation we guarantee
+// that we adhere to the semantics documented on that trait and its
+// associated types and methods.
+unsafe impl<const MAX_REGIONS: usize, P: TORUserPMP<MAX_REGIONS> + 'static>
+    kernel::platform::mpu::MPU for PMPUserMPU<MAX_REGIONS, P>
 {
     type MpuConfig = PMPUserMPUConfig<MAX_REGIONS>;
 

--- a/arch/x86/src/mpu.rs
+++ b/arch/x86/src/mpu.rs
@@ -278,7 +278,10 @@ impl fmt::Display for PagingMPU<'_> {
     }
 }
 
-impl MPU for PagingMPU<'_> {
+// `MPU` is an unsafe trait, and with this implementation we guarantee
+// that we adhere to the semantics documented on that trait and its
+// associated types and methods.
+unsafe impl MPU for PagingMPU<'_> {
     type MpuConfig = MemoryProtectionConfig;
 
     fn new_config(&self) -> Option<Self::MpuConfig> {

--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -268,8 +268,24 @@ pub unsafe trait MPU {
     fn configure_mpu(&self, config: &Self::MpuConfig);
 }
 
-/// Implement default MPU trait for unit.
-unsafe impl MPU for () {
+/// No-op MPU implementation, providing no isolation guarantees.
+///
+/// Using this implementation violates Tock's isolation guarantees and results
+/// in applications having unrestricted access to kernel memory. As such,
+/// constructing this type is an `unsafe` operation.
+// By having this type contain a private field, we prevent constructing it from
+// outside this crate, except through the `unsafe fn new()` constructor.
+pub struct NopMPU(());
+
+impl NopMPU {
+    pub unsafe fn new() -> Self {
+        NopMPU(())
+    }
+}
+
+/// This type does not meet the safety requirements outlined on the `MPU` trait,
+/// hence constructing it is also an unsafe (and unsound) operation.
+unsafe impl MPU for NopMPU {
     type MpuConfig = MpuConfigDefault;
 
     fn enable_app_mpu(&self) {}

--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -79,7 +79,12 @@ impl Display for MpuConfigDefault {
 /// requirements, and also allows the MPU to specify some addresses used by the
 /// kernel when deciding where to place certain application memory regions so
 /// that the MPU can appropriately provide protection for those memory regions.
-pub trait MPU {
+///
+/// This is an `unsafe trait`, as it is crucial to uphold Tock's isolation
+/// properties, and thus safety of the Tock kernel. Users of this trait must be
+/// able to rely on its implementations being correct, and implementing the
+/// exact semantics as documented on its associated types and methods.
+pub unsafe trait MPU {
     /// MPU-specific state that defines a particular configuration for the MPU.
     /// That is, this should contain all of the required state such that the
     /// implementation can be passed an object of this type and it should be
@@ -264,7 +269,7 @@ pub trait MPU {
 }
 
 /// Implement default MPU trait for unit.
-impl MPU for () {
+unsafe impl MPU for () {
     type MpuConfig = MpuConfigDefault;
 
     fn enable_app_mpu(&self) {}


### PR DESCRIPTION
### Pull Request Overview

This PR changes `MPU` to be an unsafe trait. It is vital for Tock's isolation guarantees, and consumers of this trait must be able to rely on its implementations adhering to the trait's API contract.

It also changes the mock MPU implementation from the unit type `()` to a newtype `NoMPU` that itself is unsafe to construct, as doing so (and then using this type as an implementation of `MPU`) is unsound.


### Testing Strategy

N/A


### TODO or Help Wanted

N/A


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
