### PR TITLE
Core working group notes: September 17, 2025

### DIFF
--- a/doc/wg/core/notes/core-notes-2025-09-17.md
+++ b/doc/wg/core/notes/core-notes-2025-09-17.md
@@ -17,7 +17,7 @@
 
 ## Updates
 ### Lockfiles and External Dependencies
- - Leon: There's a discussion about adding lockfiles to repo. Still need fresh comments to bread deadlock. https://github.com/tock/tock/pull/4589
+ - Leon: There's a discussion about adding lockfiles to repo. Still need fresh comments to break deadlock. https://github.com/tock/tock/pull/4589
  - Pat: One resolution was a PR to add lockfiles, which can go in parallel with external dependency policy
  - Leon: I don't believe we finished the discussion on lockfiles yet. I can move it to a new PR
  - Pat: I think we support lockfiles. We're disassisfied with them, but they seem better than nothing


### PR DESCRIPTION
### Pull Request Overview

This pull request adds notes from the Core working group call on September 17th, 2025.

[Rendered](https://github.com/tock/tock/blob/cf0a0be834e5b87701ab16f2180913dfa03f45ae/doc/wg/core/notes/core-notes-2025-09-17.md)


### Testing Strategy

Documentation


### TODO or Help Wanted

Good to go


### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [N/A] Ran `make prepush`.
