### PR TITLE
Update Network working group charter

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -37,6 +37,7 @@ WG-OpenTitan:
 WG-Network:
   - capsules/extra/src/ble_advertising_driver.rs
   - capsules/extra/src/can.rs
+  - capsules/extra/src/ethernet_tap.rs
   - capsules/extra/src/ieee802154/**/*
   - capsules/extra/src/net/**/*
   - capsules/extra/src/rf233.rs
@@ -51,6 +52,7 @@ WG-Network:
   - doc/wg/network/**/*
   - kernel/src/hil/ble_advertising.rs
   - kernel/src/hil/can.rs
+  - kernel/src/hil/ethernet.rs
   - kernel/src/hil/radio.rs
 
 # add kernel label unless already covered by hil label

--- a/doc/wg/network/README.md
+++ b/doc/wg/network/README.md
@@ -9,18 +9,16 @@ Network Working Group (NWG)
 The goals of the Network Tock Working Group (NWG) are to:
 
 - design a set of interfaces (traits) for networking
-- design the user land interfaces for networking
+- design the userland interfaces for networking
 - define how buffer management should be implemented
 - determine other kernel infrastructure useful for networking
 
 ## Members
 
-- Alexandru Radovici (Chair), Politehnica University of Bucharest
-- Branden Ghena, Northwestern University
+- Alexandru Radovici, Politehnica University of Bucharest
+- Branden Ghena (Chair), Northwestern University
 - Leon Schuermann, Princeton University
 - Tyler Potyondy, UCSD
-- Cristian Rusu, University of Bucharest
-- Felix Mada, OxidOS Automotive
 
 ## Membership and Communication
 
@@ -46,4 +44,9 @@ transcription of what is said.
 
 ## Code Purview
 
-At this time, the network working group does not have responsibility for code in any particular directories of Tock. That may change as work progresses, with the possibility of a subdirectory within `capsules/` being created under the purview of this working group.
+The Network working group is responsible for reviewing, approving, and merging
+pull requests related to networking in Tock. This includes the Tock kernel,
+libtock-c, and libtock-rs. Within the Tock kernel, this includes but is not
+limited to, capsules supporting BLE, CAN, Ethernet, IEEE 802.15.4, and WiFi.
+This also includes chip drivers and kernel HILs related to similar subsystems.
+


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the main README (charter) for the Network working group.

Based on https://github.com/tock/tock/pull/4604, I realized that the Network working group README was rather outdated. Primary members have changed slightly, and I've taken over leading the discussions. We also do have a specific purview in Tock.

This also updates the Github labeler to add some Ethernet stuff we forgot to add.

### Testing Strategy

Documentation


### TODO or Help Wanted

An omission from the Network Working Group's purview is USB. We have not historically maintained USB or spent time considering it. However, I could see it reasonably being included in our purview.

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [N/A] Ran `make prepush`.
