### PR TITLE
Virtio Support for x86

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ members = [
     "chips/nrf52833",
     "chips/nrf52840",
     "chips/nrf5x",
+    "chips/pci-x86",
     "chips/x86_q35",
     "chips/qemu_rv32_virt_chip",
     "chips/psoc62xa",

--- a/boards/qemu_i486_q35/.cargo/config.toml
+++ b/boards/qemu_i486_q35/.cargo/config.toml
@@ -16,7 +16,7 @@ RUST_TARGET_PATH = "."
 target = "i486-unknown-none.json"
 
 [target.i486-unknown-none]
-runner = "qemu-system-i386 -cpu 486 -machine q35 -net none -device isa-debug-exit,iobase=0xf4,iosize=0x04 -serial stdio -kernel"
+runner = "qemu-system-i386 -cpu 486 -machine q35 -net none -device isa-debug-exit,iobase=0xf4,iosize=0x04 -device virtio-rng-pci,disable-legacy=on -serial stdio -kernel"
 
 [unstable]
 config-include = true

--- a/boards/qemu_i486_q35/Cargo.toml
+++ b/boards/qemu_i486_q35/Cargo.toml
@@ -12,6 +12,9 @@ build = "../build.rs"
 [dependencies]
 components = { path = "../components" }
 kernel = { path = "../../kernel" }
+pci-x86 = { path = "../../chips/pci-x86" }
+virtio = { path = "../../chips/virtio" }
+virtio-pci-x86 = { path = "../../chips/virtio-pci-x86" }
 x86_q35 = { path = "../../chips/x86_q35" }
 x86 = { path = "../../arch/x86" }
 

--- a/boards/qemu_i486_q35/Makefile
+++ b/boards/qemu_i486_q35/Makefile
@@ -16,12 +16,14 @@ WORKING_QEMU_VERSION := 7.2.0
 # Peripherals attached by default:
 # - 16550 UART (attached to stdio by default)
 # - VGA display (pass NOVGA=1 to disable)
+# - Virtio EntropySource RNG (attached to /dev/urandom)
 QEMU_BASE_CMDLINE := \
   $(QEMU_CMD) \
     -cpu 486 \
     -machine q35 \
     -net none \
-    -device isa-debug-exit,iobase=0xf4,iosize=0x04
+    -device isa-debug-exit,iobase=0xf4,iosize=0x04 \
+    -device virtio-rng-pci,disable-legacy=on
 
 ifeq ($(NOVGA),1)
 QEMU_BASE_CMDLINE += -nographic

--- a/chips/pci-x86/Cargo.toml
+++ b/chips/pci-x86/Cargo.toml
@@ -1,0 +1,16 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2025.
+
+[package]
+name = "pci-x86"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+
+[dependencies]
+tock-registers = { path = "../../libraries/tock-register-interface" }
+x86 = { path = "../../arch/x86" }
+
+[lints]
+workspace = true

--- a/chips/pci-x86/README.md
+++ b/chips/pci-x86/README.md
@@ -1,0 +1,9 @@
+PCI Local Bus
+=============
+
+This crate contains facilities for interacting with [PCI](https://wiki.osdev.org/PCI) devices using
+x86 I/O port operations. It adheres closely to the PCI Local Bus Specification, version 3.0, as
+published by the PCI Special Interest Group (PCI-SIG).
+
+This pseudo-chip can be included by any x86 chip or board that uses PCI for interacting with
+hardware devices.

--- a/chips/pci-x86/src/bdf.rs
+++ b/chips/pci-x86/src/bdf.rs
@@ -1,0 +1,70 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+use core::fmt::{self, Display, Formatter};
+
+/// Unique identifier of a PCI device
+///
+/// BDF stands for bus, device, function, which is the standard way to identify
+/// and address individual PCI devices on a system.
+///
+/// Internally this is a newtype around a u32, with the BDF fields packed in such
+/// a way that the can be used to easily construct PCI configuration addresses.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub struct Bdf(u32);
+
+impl Bdf {
+    /// Constructs a new BDF value from individual components.
+    ///
+    /// The valid range for `bus` is 0..=255, for `device` is 0..=31, and for
+    /// `function` is 0..=7. This function will silently truncate any extra leading
+    /// bits from the `device` and `function` parameters before constructing the
+    /// final BDF value.
+    pub const fn new(bus: u8, device: u8, function: u8) -> Self {
+        let bdf = ((bus as u32) << 16)
+            | (((device as u32) & 0x1F) << 11)
+            | (((function as u32) & 0x07) << 8);
+        Bdf(bdf)
+    }
+
+    /// Returns the bus number component of this BDF.
+    #[inline]
+    pub const fn bus(&self) -> u8 {
+        ((self.0 >> 16) & 0xFF) as u8
+    }
+
+    /// Returns the device number component of this BDF.
+    #[inline]
+    pub const fn device(&self) -> u8 {
+        ((self.0 >> 11) & 0x1F) as u8
+    }
+
+    /// Returns the function number component of this BDF.
+    #[inline]
+    pub const fn function(&self) -> u8 {
+        ((self.0 >> 8) & 0x07) as u8
+    }
+
+    /// Constructs the 32-bit CONFIG_ADDRESS value for a given register offset.
+    ///
+    /// Sets the enable bit (bit 31), includes the BDF tag, and aligns the
+    /// register offset to a 32-bit boundary as required by PCI spec.
+    #[inline]
+    pub(crate) const fn cfg_addr(&self, offset: u16) -> u32 {
+        let reg = (offset as u32) & 0xFC;
+        0x8000_0000 | self.0 | reg
+    }
+}
+
+impl Display for Bdf {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{:02x}:{:02x}.{}",
+            self.bus(),
+            self.device(),
+            self.function()
+        )
+    }
+}

--- a/chips/pci-x86/src/cap.rs
+++ b/chips/pci-x86/src/cap.rs
@@ -1,0 +1,215 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+//! PCI capabilities list
+//!
+//! This module provides functionality for traversing and interacting with
+//! the capability list of a PCI device, as described in section 6.7 of the
+//! PCI Local Bus specification.
+
+use core::ops::Deref;
+
+use crate::device::Device;
+
+/// A single capability within a specific device's configuration space.
+///
+/// This is a generic representation of a capability. It provides only
+/// low-level methods for reading and writing the capability fields. Other
+/// structs in this module will wrap this struct and provide higher level
+/// methods for accessing specific fields.
+///
+/// The `'a` lifetime references the [`Device`] this capability belongs to.
+#[derive(Copy, Clone, Debug)]
+pub struct BaseCap<'a> {
+    dev: &'a Device,
+    ptr: u16,
+}
+
+impl BaseCap<'_> {
+    /// Returns the ID of this capability.
+    pub fn id(&self) -> u8 {
+        self.dev.read8(self.ptr)
+    }
+
+    /// Returns the next capability pointer.
+    pub fn next(&self) -> u8 {
+        self.dev.read8(self.ptr + 1)
+    }
+
+    /// Reads an 8-bit value relative to the base of this capability.
+    #[inline]
+    pub fn read8(&self, offset: u16) -> u8 {
+        self.dev.read8(self.ptr + offset)
+    }
+
+    /// Writes an 8-bit value relative to the base of this capability.
+    #[inline]
+    pub fn write8(&self, offset: u16, val: u8) {
+        self.dev.write8(self.ptr + offset, val)
+    }
+
+    /// Reads a 16-bit value relative to the base of this capability.
+    #[inline]
+    pub fn read16(&self, offset: u16) -> u16 {
+        self.dev.read16(self.ptr + offset)
+    }
+
+    /// Writes a 16-bit value relative to the base of this capability.
+    #[inline]
+    pub fn write16(&self, offset: u16, val: u16) {
+        self.dev.write16(self.ptr + offset, val)
+    }
+
+    /// Reads a 32-bit value relative to the base of this capability.
+    #[inline]
+    pub fn read32(&self, offset: u16) -> u32 {
+        self.dev.read32(self.ptr + offset)
+    }
+
+    /// Writes a 32-bit value relative to the base of this capability.
+    #[inline]
+    pub fn write32(&self, offset: u16, val: u32) {
+        self.dev.write32(self.ptr + offset, val)
+    }
+}
+
+/// Message signaled interrupt (MSI) capability
+pub struct MsiCap<'a>(BaseCap<'a>);
+
+impl MsiCap<'_> {
+    /// Capability ID for MSI
+    pub const ID: u8 = 0x05;
+
+    /// Returns the MSI control register
+    pub fn control(&self) -> u16 {
+        self.0.dev.read16(self.0.ptr + 2)
+    }
+
+    /// Returns true if MSI is enabled
+    pub fn enabled(&self) -> bool {
+        self.control() & 0x0001 != 0
+    }
+
+    /// Disables MSI by clearing the enable bit
+    pub fn disable(&self) {
+        let mut ctrl = self.control();
+        ctrl &= !0x0001;
+        self.0.dev.write16(self.0.ptr + 2, ctrl);
+    }
+}
+
+/// Vendor specific capability
+///
+/// Implements `Deref` with `Target=BaseCap`, allowing the use of
+/// `BaseCap` methods to read/write raw capability data.
+pub struct VendorCap<'a>(BaseCap<'a>);
+
+impl VendorCap<'_> {
+    /// Capability ID for Vendor-Specific (0x09)
+    pub const ID: u8 = 0x09;
+
+    /// Returns the length field (at cap+2)
+    pub fn length(&self) -> u8 {
+        self.0.dev.read8(self.0.ptr + 2)
+    }
+}
+
+impl<'a> Deref for VendorCap<'a> {
+    type Target = BaseCap<'a>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// MSI-X Capability
+pub struct MsixCap<'a>(BaseCap<'a>);
+
+impl MsixCap<'_> {
+    /// Capability ID for MSI-X
+    pub const ID: u8 = 0x11;
+
+    /// Returns the MSI-X control register
+    pub fn control(&self) -> u16 {
+        self.0.dev.read16(self.0.ptr + 2)
+    }
+
+    /// Returns true if MSI-X is enabled
+    pub fn enabled(&self) -> bool {
+        self.control() & 0x8000 != 0
+    }
+
+    /// Disables MSI-X by clearing the enable bit
+    pub fn disable(&self) {
+        let mut ctrl = self.control();
+        ctrl &= !0x8000;
+        self.0.dev.write16(self.0.ptr + 2, ctrl);
+    }
+}
+
+/// Enum representing supported capability types
+pub enum Cap<'a> {
+    Msi(MsiCap<'a>),
+    Msix(MsixCap<'a>),
+    Vendor(VendorCap<'a>),
+    Other(BaseCap<'a>),
+}
+
+impl<'a> From<BaseCap<'a>> for Cap<'a> {
+    fn from(base: BaseCap<'a>) -> Self {
+        match base.id() {
+            MsiCap::ID => Cap::Msi(MsiCap(base)),
+            MsixCap::ID => Cap::Msix(MsixCap(base)),
+            VendorCap::ID => Cap::Vendor(VendorCap(base)),
+            _ => Cap::Other(base),
+        }
+    }
+}
+
+/// Iterator over supported capabilities for a given device.
+pub struct CapIter<'a> {
+    dev: &'a Device,
+    cur: u16,
+    visited: u8,
+}
+
+impl<'a> CapIter<'a> {
+    /// Creates a new capability iterator for the given device.
+    pub(crate) fn new(dev: &'a Device) -> Self {
+        let cur = dev.cap_ptr().unwrap_or(0) as u16;
+        Self {
+            dev,
+            cur,
+            visited: 0,
+        }
+    }
+}
+
+impl<'a> Iterator for CapIter<'a> {
+    type Item = Cap<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Pointer value of 0 marks end of capabilities list
+        if self.cur == 0 {
+            return None;
+        }
+
+        // Protect against malformed capabilities list
+        if self.cur >= 256 {
+            return None;
+        }
+        if self.visited > 64 {
+            return None;
+        }
+
+        let base = BaseCap {
+            dev: self.dev,
+            ptr: self.cur,
+        };
+
+        self.cur = base.next() as u16;
+        self.visited += 1;
+
+        Some(base.into())
+    }
+}

--- a/chips/pci-x86/src/cfg.rs
+++ b/chips/pci-x86/src/cfg.rs
@@ -1,0 +1,140 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+//! Constants and helpers for working with the PCI configuration space.
+
+use x86::registers::io;
+
+use crate::bdf::Bdf;
+
+/// PCI configuration address I/O port
+const CONFIG_ADDRESS: u16 = 0x0CF8;
+
+/// PCI configuration data I/O port
+const CONFIG_DATA: u16 = 0x0CFC;
+
+/// Reads a 32-bit value from the PCI configuration space.
+#[inline]
+pub fn read32(bdf: Bdf, offset: u16) -> u32 {
+    unsafe {
+        io::outl(CONFIG_ADDRESS, bdf.cfg_addr(offset));
+        io::inl(CONFIG_DATA)
+    }
+}
+
+/// Writes a 32-bit value to the PCI configuration space.
+#[inline]
+pub fn write32(bdf: Bdf, offset: u16, value: u32) {
+    unsafe {
+        io::outl(CONFIG_ADDRESS, bdf.cfg_addr(offset));
+        io::outl(CONFIG_DATA, value);
+    }
+}
+
+/// Reads a 16-bit value from the PCI configuration space.
+#[inline]
+pub fn read16(bdf: Bdf, offset: u16) -> u16 {
+    let aligned = offset & !0x3;
+    let shift = ((offset & 0x3) as u32) * 8;
+    (read32(bdf, aligned) >> shift) as u16
+}
+
+/// Writes a 16-bit value to the PCI configuration space.
+#[inline]
+pub fn write16(bdf: Bdf, offset: u16, value: u16) {
+    let aligned = offset & !0x3;
+    let shift = ((offset & 0x3) as u32) * 8;
+    let mask = !(0xFFFFu32 << shift);
+    let cur = read32(bdf, aligned);
+    let new = (cur & mask) | ((value as u32) << shift);
+    write32(bdf, aligned, new);
+}
+
+/// Reads an 8-bit value from the PCI configuration space.
+#[inline]
+pub fn read8(bdf: Bdf, offset: u16) -> u8 {
+    let aligned = offset & !0x3;
+    let shift = ((offset & 0x3) as u32) * 8;
+    (read32(bdf, aligned) >> shift) as u8
+}
+
+/// Writes an 8-bit value to the PCI configuration space.
+#[inline]
+pub fn write8(bdf: Bdf, offset: u16, value: u8) {
+    let aligned = offset & !0x3;
+    let shift = ((offset & 0x3) as u32) * 8;
+    let mask = !(0xFFu32 << shift);
+    let cur = read32(bdf, aligned);
+    let new = (cur & mask) | ((value as u32) << shift);
+    write32(bdf, aligned, new);
+}
+
+/// PCI configuration register offsets
+pub mod offset {
+    /// Vendor ID, 16 bits
+    pub const VENDOR_ID: u16 = 0x00;
+
+    /// Device ID, 16 bits
+    pub const DEVICE_ID: u16 = 0x02;
+
+    /// Command register, 16 bits
+    pub const COMMAND: u16 = 0x04;
+
+    /// Status register, 16 bits
+    pub const STATUS: u16 = 0x06;
+
+    /// Revision ID, 8 bits
+    pub const REVISION_ID: u16 = 0x08;
+
+    /// Programming interface, 8 bits
+    pub const PROG_IF: u16 = 0x09;
+
+    /// Subclass, 8 bits
+    pub const SUBCLASS: u16 = 0x0A;
+
+    /// Class code, 8 bits
+    pub const CLASS_CODE: u16 = 0x0B;
+
+    /// Cache line size, 8 bits
+    pub const CACHE_LINE_SIZE: u16 = 0x0C;
+
+    /// Latency timer, 8 bits
+    pub const LATENCY_TIMER: u16 = 0x0D;
+
+    /// Header type, 8 bits
+    pub const HEADER_TYPE: u16 = 0x0E;
+
+    /// Built-in self-test, 8 bits
+    pub const BIST: u16 = 0x0F;
+
+    /// Base address register 0, 32 bits
+    pub const BAR0: u16 = 0x10;
+
+    /// Base address register 1, 32 bits
+    pub const BAR1: u16 = 0x10;
+
+    /// Base address register 2, 32 bits
+    pub const BAR2: u16 = 0x10;
+
+    /// Base address register 3, 32 bits
+    pub const BAR3: u16 = 0x10;
+
+    /// Base address register 4, 32 bits
+    pub const BAR4: u16 = 0x10;
+
+    /// Base address register 5, 32 bits
+    pub const BAR5: u16 = 0x10;
+
+    /// Subsystem vendor ID, 16 bits
+    pub const SUBSYSTEM_VENDOR_ID: u16 = 0x2C;
+
+    /// Subsystem ID, 16 bits
+    pub const SUBSYSTEM_ID: u16 = 0x2E;
+
+    /// Capabilities pointer (head of capability list), 8 bits
+    pub const CAP_PTR: u16 = 0x34;
+
+    /// Interrupt line, 8 bits
+    pub const INT_LINE: u16 = 0x3C;
+}

--- a/chips/pci-x86/src/device.rs
+++ b/chips/pci-x86/src/device.rs
@@ -1,0 +1,304 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+use tock_registers::{register_bitfields, LocalRegisterCopy};
+
+use super::cfg::{self, offset};
+use super::Bdf;
+
+register_bitfields![u16,
+    /// PCI Command register bitfields
+    pub Command [
+        /// I/O space accesses enabled
+        IO_SPACE OFFSET(0) NUMBITS(1) [],
+
+        /// Memory space accesses enabled
+        MEM_SPACE OFFSET(1) NUMBITS(1) [],
+
+        /// Device is allowed to act as a bus master
+        BUS_MASTER OFFSET(2) NUMBITS(1) [],
+
+        /// Monitor/Special cycles on PCI bus
+        SPECIAL_CYCLES OFFSET(3) NUMBITS(1) [],
+
+        /// Memory Write and Invalidate enable
+        MEM_WRITE_INV OFFSET(4) NUMBITS(1) [],
+
+        /// VGA palette snoop enable
+        VGA_PALETTE OFFSET(5) NUMBITS(1) [],
+
+        /// Parity error response enable
+        PARITY_ERR_RESP OFFSET(6) NUMBITS(1) [],
+
+        /// SERR# driver enable
+        SERR_ENABLE OFFSET(8) NUMBITS(1) [],
+
+        /// Fast back-to-back transactions enable
+        FAST_BACK_TO_BACK OFFSET(9) NUMBITS(1) [],
+
+        /// Interrupt disable
+        INT_DISABLE OFFSET(10) NUMBITS(1) [],
+    ],
+
+    /// PCI Status register bitfields
+    pub Status [
+        /// Interrupt status (pending)
+        INT_STATUS OFFSET(3) NUMBITS(1) [],
+
+        /// Capabilities list present
+        CAP_LIST OFFSET(4) NUMBITS(1) [],
+
+        /// 66 MHz capable
+        CAP_66MHZ OFFSET(5) NUMBITS(1) [],
+
+        /// Fast back-to-back capable
+        FAST_BACK_TO_BACK_CAPABLE OFFSET(7) NUMBITS(1) [],
+
+        /// Master data parity error detected
+        MASTER_DATA_PARITY_ERROR OFFSET(8) NUMBITS(1) [],
+
+        /// DEVSEL timing encoding
+        DEVSEL OFFSET(9) NUMBITS(2) [],
+
+        /// Signaled target abort
+        SIGNALED_TARGET_ABORT OFFSET(11) NUMBITS(1) [],
+
+        /// Received target abort
+        RECEIVED_TARGET_ABORT OFFSET(12) NUMBITS(1) [],
+
+        /// Received master abort
+        RECEIVED_MASTER_ABORT OFFSET(13) NUMBITS(1) [],
+
+        /// Signaled system error (SERR#)
+        SIGNALED_SYSTEM_ERROR OFFSET(14) NUMBITS(1) [],
+
+        /// Detected parity error
+        DETECTED_PARITY_ERROR OFFSET(15) NUMBITS(1) [],
+    ]
+];
+
+/// Type-safe representation of PCI command register value
+pub type CommandVal = LocalRegisterCopy<u16, Command::Register>;
+
+/// Type-safe representation of PCI status register value
+pub type StatusVal = LocalRegisterCopy<u16, Status::Register>;
+
+/// Representation of a PCI device
+///
+/// This struct provides low-level methods for directly reading and writing
+/// values from the PCI configuration space for this device, as well as
+/// higer-level methods for accessing standard fields.
+///
+/// If you know the BDF of the device you want to access, you can directly create a [`Device`]
+/// instance and use it to interact with the device:
+///
+/// ```ignore
+/// let bdf = Bdf::new(0, 1, 0);
+/// let dev = Device::new(bdf);
+///
+/// // Check vendor and device ID:
+/// let vid = dev.vendor_id();
+/// let did = dev.device_id();
+/// if vid == 0x1234 && did == 0x5678 {
+///     // Found the device we were looking for!
+/// }
+/// ```
+///
+/// Alternatively, you can use the [`iter`][crate::iter] function to enumerate all PCI devices in
+/// the system. This method automatically filters out non-existent devices, and it returns an
+/// iterator which can be chained like any other Rust iterator:
+///
+/// ```ignore
+/// let dev = pci::iter().find(|d| d.vendor_id() == 0x1234 && d.device_id() == 0x5678);
+/// if dev.is_none() {
+///     // No such device found in the system.
+/// }
+/// ```
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct Device {
+    bdf: Bdf,
+}
+
+impl Device {
+    /// Constructs a new `Device` instance from a given BDF identifier.
+    pub const fn new(bdf: Bdf) -> Self {
+        Self { bdf }
+    }
+
+    /// Reads an 8-bit value from this device's PCI configuration space.
+    #[inline]
+    pub fn read8(&self, offset: u16) -> u8 {
+        cfg::read8(self.bdf, offset)
+    }
+
+    /// Writes an 8-bit value to this device's PCI configuration space.
+    #[inline]
+    pub fn write8(&self, offset: u16, val: u8) {
+        cfg::write8(self.bdf, offset, val)
+    }
+
+    /// Reads a 16-bit value from this device's PCI configuration space.
+    #[inline]
+    pub fn read16(&self, offset: u16) -> u16 {
+        cfg::read16(self.bdf, offset)
+    }
+
+    /// Writes a 16-bit value to this device's PCI configuration space.
+    #[inline]
+    pub fn write16(&self, offset: u16, val: u16) {
+        cfg::write16(self.bdf, offset, val)
+    }
+
+    /// Reads a 32-bit value from this device's PCI configuration space.
+    #[inline]
+    pub fn read32(&self, offset: u16) -> u32 {
+        cfg::read32(self.bdf, offset)
+    }
+
+    /// Writes a 32-bit value to this device's PCI configuration space.
+    #[inline]
+    pub fn write32(&self, offset: u16, val: u32) {
+        cfg::write32(self.bdf, offset, val)
+    }
+
+    /// Reads and returns the PCI vendor ID.
+    #[inline]
+    pub fn vendor_id(&self) -> u16 {
+        self.read16(offset::VENDOR_ID)
+    }
+
+    /// Reads and returns the PCI device ID.
+    #[inline]
+    pub fn device_id(&self) -> u16 {
+        self.read16(offset::DEVICE_ID)
+    }
+
+    /// Reads the command register of this device.
+    #[inline]
+    pub fn command(&self) -> CommandVal {
+        let value = self.read16(offset::COMMAND);
+        LocalRegisterCopy::new(value)
+    }
+
+    /// Sets the command register of this device.
+    #[inline]
+    pub fn set_command(&self, value: CommandVal) {
+        self.write16(offset::COMMAND, value.get());
+    }
+
+    /// Reads the status register of this device.
+    #[inline]
+    pub fn status(&self) -> StatusVal {
+        let value = self.read16(offset::STATUS);
+        LocalRegisterCopy::new(value)
+    }
+
+    /// Reset fields within status register of this device.
+    ///
+    /// The PCI status register implements "write 1 to reset" behavior for certain fields. This
+    /// method may be used to reset such fields.
+    #[inline]
+    pub fn reset_status(&self, value: StatusVal) {
+        self.write16(offset::STATUS, value.get());
+    }
+
+    /// Reads the header type of this device.
+    #[inline]
+    pub fn header_type(&self) -> u8 {
+        self.read8(offset::HEADER_TYPE)
+    }
+
+    pub fn bar(&self, index: usize) -> Option<u32> {
+        if index > 5 {
+            return None;
+        }
+        let off: u16 = offset::BAR0 + (index as u16) * 4u16;
+        Some(self.read32(off))
+    }
+
+    pub fn set_bar(&self, index: usize, val: u32) {
+        if index > 5 {
+            return;
+        }
+        let off: u16 = offset::BAR0 + (index as u16) * 4u16;
+        self.write32(off, val)
+    }
+
+    /// Decodes the BAR at `index` and returns its memory address.
+    ///
+    /// - Returns `None` if `index` is out of range, the BAR is an I/O BAR,
+    ///   or the BAR type is unsupported.
+    /// - For 64-bit memory BARs, this will read the high dword from the next
+    ///   BAR and combine them.
+    pub fn bar_addr(&self, index: u8) -> Option<usize> {
+        if index > 5 {
+            return None;
+        }
+
+        let v = self.bar(index as usize)?;
+
+        // I/O BARs not supported here
+        if (v & 0x1) != 0 {
+            return None;
+        }
+
+        let typ = (v >> 1) & 0x3;
+        match typ {
+            // 32-bit MMIO BAR
+            0 => Some((v & 0xFFFF_FFF0) as usize),
+
+            // 64-bit MMIO BAR (consumes the next BAR as high dword)
+            2 => {
+                if (index as usize) + 1 > 5 {
+                    return None;
+                }
+                let low = (v & 0xFFFF_FFF0) as u64;
+                let high = self.bar((index as usize) + 1)? as u64;
+                let addr = ((high << 32) | low) as usize;
+                Some(addr)
+            }
+
+            // Unsupported types
+            _ => None,
+        }
+    }
+
+    /// Returns the offset of the first capability pointer, if present.
+    pub fn cap_ptr(&self) -> Option<u8> {
+        // Check status register to see whether cap_ptr is valid (Capabilities List bit)
+        if !self.status().is_set(Status::CAP_LIST) {
+            return None;
+        }
+
+        let ptr = self.read8(offset::CAP_PTR);
+        if ptr == 0 {
+            None
+        } else {
+            Some(ptr)
+        }
+    }
+
+    /// Iterate over this device's capabilities list.
+    pub fn capabilities(&self) -> super::cap::CapIter<'_> {
+        super::cap::CapIter::new(self)
+    }
+
+    /// Returns the interrupt line assigned to this device, if applicable.
+    #[inline]
+    pub fn int_line(&self) -> Option<u8> {
+        // Config register only exists for normal devices
+        if self.header_type() != 0 {
+            return None;
+        }
+
+        let val = self.read8(offset::INT_LINE);
+
+        // Per the spec, 0xFF indicates the interrupt line is disconnected
+        if val == 0xFF {
+            return None;
+        }
+
+        Some(val)
+    }
+}

--- a/chips/pci-x86/src/iter.rs
+++ b/chips/pci-x86/src/iter.rs
@@ -1,0 +1,78 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+use crate::bdf::Bdf;
+use crate::device::Device;
+
+/// Iterator which enumerates all valid BDF combinations and yields those
+/// for which a device is present.
+struct Iter {
+    bus: u8,
+    dev: u8,
+    func: u8,
+}
+
+impl Iter {
+    /// Creates a new iterator starting from bus 0, device 0, function 0.
+    fn new() -> Self {
+        Self {
+            bus: 0,
+            dev: 0,
+            func: 0,
+        }
+    }
+}
+
+impl Iterator for Iter {
+    type Item = Device;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Loop over all valid bus indices 0..=255
+        loop {
+            // Loop over all valid device indices 0..=31
+            while self.dev <= 31 {
+                // Loop over all valid function indices 0..=7
+                while self.func <= 7 {
+                    let bdf = Bdf::new(self.bus, self.dev, self.func);
+
+                    // Increment function index before potentially returning
+                    // a device, so that the next call starts with the next
+                    // function.
+                    self.func += 1;
+
+                    // Query vendor ID and check if it is valid before yielding
+                    // this device instance
+                    let device = Device::new(bdf);
+                    if device.vendor_id() != 0xFFFF {
+                        return Some(device);
+                    }
+                }
+
+                // Reset function index and increment device index
+                self.func = 0;
+                self.dev += 1;
+            }
+
+            // Break early before incrementing bus index if we have reached the
+            // end (else we would overflow u8 and enumerate everything again).
+            if self.bus == 255 {
+                break;
+            }
+
+            // Reset device index and increment bus index
+            self.dev = 0;
+            self.bus += 1;
+        }
+
+        None
+    }
+}
+
+/// Returns an iterator over all present PCI devices.
+///
+/// A PCI device is considered "present" if the vendor ID read from its
+/// configuration space is not 0xFFFF.
+pub fn iter() -> impl Iterator<Item = Device> {
+    Iter::new()
+}

--- a/chips/pci-x86/src/lib.rs
+++ b/chips/pci-x86/src/lib.rs
@@ -1,0 +1,30 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+//! Tock PCI support library for x86 devices
+//!
+//! This crate provides types and helpers for working with PCI devices within Tock OS kernel
+//! drivers. It specifically targets the PCI Local Bus Specification, Revision 3.0, as published by
+//! the PCI-SIG. All references to the PCI specification throughout this crate's documentation and
+//! comments refer to this document.
+//!
+//! Limitations:
+//!
+//! * No support for PCI Express of any revision.
+//! * x86 only, using I/O ports to access configuration registers.
+
+#![no_std]
+
+mod bdf;
+pub use self::bdf::Bdf;
+
+pub mod cap;
+
+pub mod cfg;
+
+mod device;
+pub use self::device::{Command, CommandVal, Device, Status, StatusVal};
+
+mod iter;
+pub use self::iter::iter;

--- a/chips/virtio-pci-x86/Cargo.toml
+++ b/chips/virtio-pci-x86/Cargo.toml
@@ -1,0 +1,17 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2022.
+
+[package]
+name = "virtio-pci-x86"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+
+[dependencies]
+kernel = { path = "../../kernel" }
+pci-x86 = { path = "../pci-x86" }
+virtio = { path = "../virtio" }
+
+[lints]
+workspace = true

--- a/chips/virtio-pci-x86/README.md
+++ b/chips/virtio-pci-x86/README.md
@@ -1,0 +1,9 @@
+Virtio PCI Transport
+====================
+
+This crate provides an implementation of "Virtio Over PCI Bus", as described in section 4.1 of the
+[virtio specification](https://docs.oasis-open.org/virtio/virtio/v1.3/virtio-v1.3.pdf).
+
+Note that this crate can currently only be used on x86 platforms. This is because the underlying PCI
+support library carries a hard dependency on I/O port routines from the `x86` crate to access the
+PCI configuration space.

--- a/chips/virtio-pci-x86/src/lib.rs
+++ b/chips/virtio-pci-x86/src/lib.rs
@@ -1,0 +1,14 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+#![no_std]
+
+//! Virtio over PCI Local Bus
+//!
+//! This crate implements support for enumerating and interacting with Virtio
+//! devices over the legacy PCI Local Bus transport (i.e. non-PCIe), as defined
+//! in section 4.1 of the Virtio specification.
+
+mod pci;
+pub use self::pci::{VirtIOPCIDevice, DEVICE_ID_BASE, VENDOR_ID};

--- a/chips/virtio-pci-x86/src/pci.rs
+++ b/chips/virtio-pci-x86/src/pci.rs
@@ -1,0 +1,517 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+// Suppress clippy warning generated within a tock-registers macro
+#![allow(clippy::modulo_one)]
+
+use core::ptr;
+
+use kernel::utilities::cells::OptionalCell;
+use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
+use kernel::utilities::registers::{register_bitfields, register_structs, ReadOnly, ReadWrite};
+
+use pci_x86::cap::{Cap, VendorCap};
+use pci_x86::{Command, Device};
+
+use virtio::devices::{VirtIODeviceDriver, VirtIODeviceType};
+use virtio::queues::Virtqueue;
+use virtio::transports::{VirtIOInitializationError, VirtIOTransport};
+
+/// PCI vendor ID for all Virtio devices
+pub const VENDOR_ID: u16 = 0x1AF4;
+
+/// Base value for PCI device IDs for Virtio devices
+///
+/// Actual device ID of a Virtio device (as reported via PCI configuration space) will be this base
+/// value plus the device type ID as defined in section 5 of the Virtio spec.
+///
+/// For example, the PCI device ID of a Virtio network device (device type 1) would be
+/// `DEVICE_ID_BASE + 1 = 0x1041`.
+pub const DEVICE_ID_BASE: u16 = 0x1040;
+
+/// Enumeration of Virtio configuration structure types
+enum CfgType {
+    Common,
+    Notify,
+    Isr,
+    Device,
+    Pci,
+    SharedMemory,
+    Vendor,
+    Reserved,
+}
+
+/// A vendor-specific PCI capability which provides the location of a
+/// Virtio configuration structure.
+struct VirtioCap<'a>(VendorCap<'a>);
+
+impl VirtioCap<'_> {
+    /// Returns the type of configuration structure described by this
+    /// capability.
+    fn cfg_type(&self) -> CfgType {
+        match self.0.read8(3) {
+            1 => CfgType::Common,
+            2 => CfgType::Notify,
+            3 => CfgType::Isr,
+            4 => CfgType::Device,
+            5 => CfgType::Pci,
+            8 => CfgType::SharedMemory,
+            9 => CfgType::Vendor,
+            _ => CfgType::Reserved,
+        }
+    }
+
+    /// Returns index of the BAR containing the configuration structure.
+    fn bar(&self) -> u8 {
+        self.0.read8(4)
+    }
+
+    /// Returns the offset within the BAR region where the configuration
+    /// structure starts.
+    fn offset(&self) -> u32 {
+        self.0.read32(8)
+    }
+}
+
+register_bitfields![
+    u8,
+
+    /// Bits indicating the initialization status of a virtio device
+    ///
+    /// See virtio spec, section 2.1
+    DeviceStatus [
+        /// Guest OS has recognized this as a valid virtio device
+        ACKNOWLEDGE OFFSET(0) NUMBITS(1) [],
+
+        /// Guest OS has a driver available for this device
+        DRIVER OFFSET(1) NUMBITS(1) [],
+
+        /// Guest driver is loaded and ready to use
+        DRIVER_OK OFFSET(2) NUMBITS(1) [],
+
+        /// Guest OS has completed feature negotiation
+        FEATURES_OK OFFSET(3) NUMBITS(1) [],
+
+        /// Device has experienced an unrecoverable error
+        DEVICE_NEEDS_RESET OFFSET(6) NUMBITS(1) [],
+
+        /// Used by guest to indicate an unrecoverable error
+        FAILED OFFSET(7) NUMBITS(1) [],
+    ],
+
+    /// Virtio ISR status register
+    ///
+    /// See virtio spec, section 4.1.4.5
+    IsrStatus [
+        /// Indicates a pending virtqueue interrupt
+        QUEUE OFFSET(0) NUMBITS(1) [],
+
+        /// Indicates a device configuration change
+        DEVICE_CFG OFFSET(1) NUMBITS(1) [],
+    ]
+];
+
+register_structs! {
+    /// Virtio common configuration registers, as defined in section 4.1.4.3
+    CommonCfg {
+        //
+        // About the whole device
+        //
+
+        /// Selects feature bits to be offered by the device
+        (0x00 => device_feature_select: ReadWrite<u32>),
+
+        /// Reports feature bits offered by the device
+        (0x04 => device_feature: ReadOnly<u32>),
+
+        /// Selects feature bits accepted by the driver
+        (0x08 => driver_feature_select: ReadWrite<u32>),
+
+        /// Reports feature bits accepted by the driver
+        (0x0C => driver_feature: ReadWrite<u32>),
+
+        /// Selects the MSI-X vector used by the device to report
+        /// configuration changes.
+        (0x10 => config_msix_vector: ReadWrite<u16>),
+
+        /// Maximum number of virtqueues supported by the device (not
+        /// including administration queues).
+        (0x12 => num_queues: ReadOnly<u16>),
+
+        /// Reports device status, as defined in section 2.1
+        (0x14 => device_status: ReadWrite<u8, DeviceStatus::Register>),
+
+        /// Updated by device each time configuration noticeably changes.
+        (0x15 => config_generation: ReadOnly<u8>),
+
+        //
+        // About a specific virtqueue
+        //
+
+        /// Selects which virtqueue the following fields refer to
+        (0x16 => queue_select: ReadWrite<u16>),
+
+        /// Specifies the size of the selected virtqueue.
+        ///
+        /// On reset, specifies the maximum queue size supported by the
+        /// device. A value of 0 means the queue is not available.
+        (0x18 => queue_size: ReadWrite<u16>),
+
+        /// Selects the MSI-X vector used by the device for virtqueue
+        /// notifications.
+        (0x1A => queue_msix_vector: ReadWrite<u16>),
+
+        /// May be used by the driver to inhibit executiton of requests
+        /// from the selected virtqueue.
+        (0x1C => queue_enable: ReadWrite<u16>),
+
+        /// Offset of notification address for the selected virtqueue
+        ///
+        /// See section 4.1.4.4 for details on computing the absolute
+        /// notification address.
+        (0x1E => queue_notify_off: ReadOnly<u16>),
+
+        /// Physical address of descriptor area for the selected virtqueue
+        (0x20 => queue_desc: ReadWrite<u64>),
+
+        /// Physical address of driver area for the selected virtqueue
+        (0x28 => queue_driver: ReadWrite<u64>),
+
+        /// Physical address of device area for the selected virtqueue
+        (0x30 => queue_device: ReadWrite<u64>),
+
+        /// Value to be used by the driver when sending an available buffer
+        /// notification to the device.
+        ///
+        /// Only relevant if the NOTIF_CONFIG_DATA feature bit has been
+        /// negotiated.
+        (0x38 => queue_notif_config_data: ReadOnly<u16>),
+
+        /// Can be used to reset the selected virtqueue
+        (0x3A => queue_reset: ReadWrite<u16>),
+
+        //
+        // About the administration virtqueue
+        //
+
+        /// Index of the first administration virtqueue
+        (0x3C => admin_queue_index: ReadOnly<u16>),
+
+        /// Number of administration virtqueues supported by the device
+        (0x3E => admin_queue_num: ReadOnly<u16>),
+
+        (0x40 => @END),
+    },
+
+    /// Virtio ISR status register, as defined by section 4.1.4.5
+    IsrStatusCfg {
+        (0x00 => isr_status: ReadOnly<u8, IsrStatus::Register>),
+
+        (0x01 => @END),
+    }
+}
+
+// Transport feature bits used here
+const F_VERSION_1: u64 = 1u64 << 32;
+
+pub struct VirtIOPCIDevice {
+    dev: Device,
+    dev_type: VirtIODeviceType,
+    common_cfg: &'static CommonCfg,
+    isr_cfg: &'static IsrStatusCfg,
+    notify_base: usize,
+    notify_off_multiplier: usize,
+    queues: OptionalCell<&'static [&'static dyn Virtqueue]>,
+}
+
+impl VirtIOPCIDevice {
+    /// Construct from a PCI device by parsing virtio-pci capability list.
+    pub fn from_pci_device(dev: Device, dev_type: VirtIODeviceType) -> Option<Self> {
+        let mut common_cfg_ptr = ptr::null_mut::<CommonCfg>();
+        let mut isr_cfg_ptr = ptr::null_mut::<IsrStatusCfg>();
+        let mut notify_base = 0;
+        let mut notify_off_multiplier = 0;
+
+        // Iterate over Virtio capabilities
+        for cap in dev.capabilities() {
+            let Cap::Vendor(cap) = cap else { continue };
+            let cap = VirtioCap(cap);
+
+            // Read capability fields and compute address of the
+            // configuration structure
+            let bar = cap.bar();
+            let base = dev.bar_addr(bar)?;
+            let offset = cap.offset() as usize;
+            let addr = base + offset;
+
+            // Store the pointer, but only the first time we encounter
+            // it (as per the Virtio spec, section 4.1.4.1)
+            match cap.cfg_type() {
+                CfgType::Common => {
+                    if common_cfg_ptr.is_null() {
+                        common_cfg_ptr = addr as *mut CommonCfg;
+                    }
+                }
+
+                CfgType::Isr => {
+                    if isr_cfg_ptr.is_null() {
+                        isr_cfg_ptr = addr as *mut IsrStatusCfg;
+                    }
+                }
+
+                CfgType::Notify => {
+                    notify_base = addr;
+                    // virtio_pci_notify_cap.notify_off_multiplier at offset 16
+                    notify_off_multiplier = cap.0.read32(16) as usize;
+                }
+
+                _ => {}
+            }
+        }
+
+        // Return None if we were not able to find pointers for all the
+        // necessary configuration structures. Otherwise, construct and return
+        // the device object.
+        //
+        // Safety: We assume hardware is providing us with valid pointers.
+        let common_cfg = unsafe { common_cfg_ptr.as_ref() }?;
+        let isr_cfg = unsafe { isr_cfg_ptr.as_ref() }?;
+        if notify_base == 0 || notify_off_multiplier == 0 {
+            return None;
+        }
+
+        Some(Self {
+            dev,
+            dev_type,
+            common_cfg,
+            isr_cfg,
+            notify_base,
+            notify_off_multiplier,
+            queues: OptionalCell::empty(),
+        })
+    }
+
+    /// Helper method to negotiate device features during initialization.
+    fn negotiate_features(
+        &self,
+        driver: &dyn VirtIODeviceDriver,
+    ) -> Result<(), VirtIOInitializationError> {
+        // Read the first 64 feature bits (spec doesn't define anything beyond that)
+        let mut feats_offered = 0u64;
+        self.common_cfg.device_feature_select.set(0);
+        feats_offered |= self.common_cfg.device_feature.get() as u64;
+        self.common_cfg.device_feature_select.set(1);
+        feats_offered |= (self.common_cfg.device_feature.get() as u64) << 32;
+
+        let mut feats_requested = 0u64;
+
+        // Only transport feature we currently support or require is F_VERSION_1
+        if (feats_offered & F_VERSION_1) != 0 {
+            feats_requested |= F_VERSION_1;
+        } else {
+            return Err(VirtIOInitializationError::InvalidVirtIOVersion);
+        }
+
+        // Negotiate device-specific features
+        let drv_feats_offered = feats_offered & 0xFFF;
+        let drv_feats_requested = driver.negotiate_features(drv_feats_offered).ok_or(
+            VirtIOInitializationError::FeatureNegotiationFailed {
+                offered: feats_offered,
+                accepted: None,
+            },
+        )?;
+        feats_requested |= drv_feats_requested & 0xFFF;
+
+        // Write requested features back to device
+        self.common_cfg.driver_feature_select.set(0);
+        self.common_cfg
+            .driver_feature
+            .set((feats_requested & 0xFFFF_FFFF) as u32);
+        self.common_cfg.driver_feature_select.set(1);
+        self.common_cfg
+            .driver_feature
+            .set(((feats_requested >> 32) & 0xFFFF_FFFF) as u32);
+
+        // Lock in requested features and verify that the device accepted them
+        self.common_cfg
+            .device_status
+            .modify(DeviceStatus::FEATURES_OK::SET);
+        let feats_accepted = self
+            .common_cfg
+            .device_status
+            .is_set(DeviceStatus::FEATURES_OK);
+        if !feats_accepted {
+            return Err(VirtIOInitializationError::FeatureNegotiationFailed {
+                offered: feats_offered,
+                accepted: Some(feats_requested),
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Helper method to prepare virtqueues during initialization.
+    fn init_queues(
+        &self,
+        queues: &'static [&'static dyn Virtqueue],
+    ) -> Result<(), VirtIOInitializationError> {
+        for (index, queue) in queues.iter().enumerate() {
+            self.common_cfg.queue_select.set(index as u16);
+
+            // Must be disabled before configuration
+            let enabled = self.common_cfg.queue_enable.get();
+            if enabled != 0 {
+                return Err(VirtIOInitializationError::DeviceError);
+            }
+
+            // Read max queue size; 0 means unavailable
+            let max_size = self.common_cfg.queue_size.get() as usize;
+            if max_size == 0 {
+                return Err(VirtIOInitializationError::VirtqueueNotAvailable(index));
+            }
+
+            let size = queue.negotiate_queue_size(max_size);
+            queue.initialize(index as u32, size);
+
+            // Program selected size
+            self.common_cfg.queue_size.set(size as u16);
+
+            // Set queue addresses
+            let addrs = queue.physical_addresses();
+            self.common_cfg.queue_desc.set(addrs.descriptor_area);
+            self.common_cfg.queue_driver.set(addrs.driver_area);
+            self.common_cfg.queue_device.set(addrs.device_area);
+
+            // Enable queue
+            self.common_cfg.queue_enable.set(1);
+        }
+
+        self.queues.set(queues);
+
+        Ok(())
+    }
+
+    /// Handle interrupt by checking ISR status and dispatching to queues.
+    pub fn handle_interrupt(&self) {
+        // Reading clears
+        let isr = self.isr_cfg.isr_status.extract();
+
+        if isr.is_set(IsrStatus::QUEUE) {
+            self.queues.map(|queues| {
+                for q in queues.iter() {
+                    q.used_interrupt();
+                }
+            });
+        }
+
+        if isr.is_set(IsrStatus::DEVICE_CFG) {
+            // Config change is currently unhandled
+        }
+    }
+}
+
+impl VirtIOTransport for VirtIOPCIDevice {
+    fn initialize(
+        &self,
+        driver: &dyn VirtIODeviceDriver,
+        queues: &'static [&'static dyn Virtqueue],
+    ) -> Result<VirtIODeviceType, VirtIOInitializationError> {
+        // Ensure the given driver matches the device type reported by the PCI device
+        if self.dev_type != driver.device_type() {
+            return Err(VirtIOInitializationError::IncompatibleDriverDeviceType(
+                self.dev_type,
+            ));
+        }
+
+        // Ensure bus properties are configured on the PCI device
+        let mut cmd = self.dev.command();
+        cmd.modify(Command::MEM_SPACE::SET);
+        cmd.modify(Command::BUS_MASTER::SET);
+        self.dev.set_command(cmd);
+
+        //
+        // The following code implements the Virtio initialization sequence as described in section
+        // 3.1.1 of the spec, taking into account the specifics of the PCI transport as described in
+        // section 4.1.5.1.
+        //
+
+        // 1. Reset device
+        self.common_cfg.device_status.set(0);
+
+        // 2. Set ACKNOWLEDGE bit, indicating we have recognized the device
+        self.common_cfg
+            .device_status
+            .modify(DeviceStatus::ACKNOWLEDGE::SET);
+
+        // 3. Set DRIVER bit, indicating we know how to drive the device
+        self.common_cfg
+            .device_status
+            .modify(DeviceStatus::DRIVER::SET);
+
+        let res = (|| {
+            // 4-6. Feature negotiation
+            self.negotiate_features(driver)?;
+
+            // 7. Queue setup
+            self.init_queues(queues)?;
+
+            // Pre init hook
+            driver
+                .pre_device_initialization()
+                .map_err(VirtIOInitializationError::DriverPreInitializationError)?;
+
+            // 8. DRIVER_OK
+            self.common_cfg
+                .device_status
+                .modify(DeviceStatus::DRIVER_OK::SET);
+
+            // Live
+            driver.device_initialized().map_err(|err| {
+                VirtIOInitializationError::DriverInitializationError(self.dev_type, err)
+            })?;
+
+            Ok(self.dev_type)
+        })();
+
+        if res.is_err() {
+            self.common_cfg
+                .device_status
+                .modify(DeviceStatus::FAILED::SET);
+        }
+
+        res
+    }
+
+    fn queue_notify(&self, queue_id: u32) {
+        // When using PCI transport, available notifications are delivered by writing a value into
+        // the memory-mapped "notification area" of the device.
+        //
+        // Section 4.1.4.4 describes how to compute the address to write for a specific virtqueue.
+        //
+        // Section 4.1.5.2 describes the value that should be written. Note that the current PCI
+        // transport implementation in this module does not negotiate either the F_NOTIFICATION_DATA
+        // or F_NOTIF_CONFIG_DATA feature bits, so the value written is simply the 16-bit queue
+        // index.
+
+        self.common_cfg.queue_select.set(queue_id as u16);
+
+        // If queue index isn't valid, return early before attempting to write notification
+        if self.common_cfg.queue_size.get() == 0 {
+            return;
+        }
+
+        // Compute the byte address to write
+        let off = self.common_cfg.queue_notify_off.get() as usize;
+        let notify_addr = self.notify_base + (off * self.notify_off_multiplier);
+
+        // Write notification value to the computed address
+        //
+        // Safety: Address is computed according to virtio spec. We have verified the specified
+        // queue index is valid, and we assume all other values reported by the hardware are valid.
+        let notify_ptr = notify_addr as *mut u16;
+        unsafe {
+            notify_ptr.write_volatile(queue_id as u16);
+        }
+    }
+}

--- a/chips/virtio/README.md
+++ b/chips/virtio/README.md
@@ -1,10 +1,11 @@
-VIRTIO MMIO Devices
-===================
+VIRTIO Devices
+==============
 
 This crate contains drivers for interacting with
-[virtio](https://wiki.osdev.org/Virtio) devices via MMIO. The
+[virtio](https://wiki.osdev.org/Virtio) devices. The
 [formal specification](https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html)
-defines a "Virtio Over MMIO" that we implement here.
+defines a "Virtio Over MMIO" that we implement here. Other Virtio transports, which may require
+platform-specific dependencies, are broken out into separate `virtio-xxx` crates.
 
 This psuedo-chip can be included on platforms that use virtio to emulate I/O
 devices.


### PR DESCRIPTION
### Pull Request Overview

This PR enables the use of Virtio devices on the x86 architecture.

A new library, _chips/pci/_, provides lower-level facilities for interacting with PCI devices. It adheres closely to the PCI Local Bus specification, version 3, as published by PCI-SIG.

The existing _chips/virtio/_ library is expanded with an additional transport driver for PCI, using the above-mentioned library to interact with devices. This transport driver is a drop-in replacement for the existing MMIO-based transport; no code changes are needed in any of the shared Virtio code in order for a device to work on the new backend.

The QEMU Q35 emulated board is updated to enumerate and initialize a Virtio RNG device during kernel startup. This serves as an illustration not only of iterating and detecting Virtio PCI devices, but also of handling arbitrary PCI interrupts on the x86 platform using a custom `InterruptService` implementation.


### Testing Strategy

Ran `make run` on qemu_i486_q35 board, confirmed it continues to build and run cleanly with the added virtio driver.

Ran Pluton's internal RNG test suite against Virtio RNG driver.


### TODO or Help Wanted

The Pluton environment is somewhat different from upstream. I don't believe these differences are substantive with respect to testing integration of a Virtio RNG device. Nevertheless, having some other party validate the functionality of the Virtio RNG device on the upstream QEMU Q35 board would provide greater confidence in the correctness of this feature.


### Documentation Updated

Added code contains extensive doc comments.

### Formatting

- [x] Ran `make prepush`.
