### PR TITLE
RFC: AES Encryption HIL Updates + Virtualizers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ members = [
     "boards/tutorials/nrf52840dk-thread-tutorial",
     "boards/tutorials/qemu_rv32_virt-tutorial",
     "capsules/aes_gcm",
+    "capsules/aes_ctr",
     "capsules/ecdsa_sw",
     "capsules/core",
     "capsules/extra",

--- a/boards/nordic/nrf52840dk/Cargo.toml
+++ b/boards/nordic/nrf52840dk/Cargo.toml
@@ -27,6 +27,7 @@ nrf52_components = { path = "../nrf52_components" }
 capsules-core = { path = "../../../capsules/core" }
 capsules-extra = { path = "../../../capsules/extra" }
 capsules-system = { path = "../../../capsules/system" }
+capsules-aes-ctr = { path = "../../../capsules/aes_ctr" }
 
 [build-dependencies]
 tock_build_scripts = { path = "../../build_scripts" }

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -77,6 +77,7 @@ use capsules_extra::net::ieee802154::MacAddress;
 use capsules_extra::net::ipv6::ip_utils::IPAddr;
 use kernel::component::Component;
 use kernel::hil::led::LedLow;
+use kernel::hil::symmetric_encryption::AES128_BLOCK_SIZE;
 use kernel::hil::time::Counter;
 #[allow(unused_imports)]
 use kernel::hil::usb::Client;
@@ -239,6 +240,20 @@ pub struct Platform {
     kv_driver: &'static KVDriver,
     scheduler: &'static RoundRobinSched<'static>,
     systick: cortexm4::systick::SysTick,
+    aes: &'static capsules_extra::symmetric_encryption::aes::AesDriver<
+        'static,
+        capsules_core::virtualizers::virtual_aes::AesVirtualHw<
+            'static,
+            nrf52840::aes::AesECB<'static>,
+        >,
+        capsules_aes_ctr::aes_ctr::Aes128CtrEcbBase<
+            'static,
+            capsules_core::virtualizers::virtual_aes::AesVirtualHw<
+                'static,
+                nrf52840::aes::AesECB<'static>,
+            >,
+        >,
+    >,
 }
 
 impl SyscallDriverLookup for Platform {
@@ -254,6 +269,7 @@ impl SyscallDriverLookup for Platform {
             capsules_core::button::DRIVER_NUM => f(Some(self.button)),
             capsules_core::rng::DRIVER_NUM => f(Some(self.rng)),
             capsules_core::adc::DRIVER_NUM => f(Some(self.adc)),
+            capsules_extra::symmetric_encryption::aes::DRIVER_NUM => f(Some(self.aes)),
             capsules_extra::ble_advertising_driver::DRIVER_NUM => f(Some(self.ble_radio)),
             capsules_extra::temperature::DRIVER_NUM => f(Some(self.temp)),
             capsules_extra::analog_comparator::DRIVER_NUM => f(Some(self.analog_comparator)),
@@ -833,6 +849,85 @@ pub unsafe fn start_no_pconsole() -> (
     ));
 
     //--------------------------------------------------------------------------
+    // AES
+    //-------------------------------------------------------------------------
+
+    // (todo) bundle into components
+
+    // (todo) not fully implemented for CCM / GCM, but shows how we have 1 hw mux / virtualizer
+    // per underlying hardware that underpins the crypto functionality.
+    let aes_hw_mux = static_init!(
+        capsules_core::virtualizers::virtual_aes::AesHwMux<'static, nrf52840::aes::AesECB<'static>>,
+        capsules_core::virtualizers::virtual_aes::AesHwMux::new(&base_peripherals.ecb)
+    );
+
+    let key_buf = static_init!([u8; AES128_BLOCK_SIZE], [0; AES128_BLOCK_SIZE]);
+    let iv_buf = static_init!([u8; AES128_BLOCK_SIZE], [0; AES128_BLOCK_SIZE]);
+
+    let virtual_aes_ecb = static_init!(
+        capsules_core::virtualizers::virtual_aes::AesVirtualHw<
+            'static,
+            nrf52840::aes::AesECB<'static>,
+        >,
+        capsules_core::virtualizers::virtual_aes::AesVirtualHw::new(aes_hw_mux, key_buf, iv_buf)
+    );
+
+    let key_buf = static_init!([u8; AES128_BLOCK_SIZE], [0; AES128_BLOCK_SIZE]);
+    let iv_buf = static_init!([u8; AES128_BLOCK_SIZE], [0; AES128_BLOCK_SIZE]);
+    let ecb_for_ctr = static_init!(
+        capsules_core::virtualizers::virtual_aes::AesVirtualHw<
+            'static,
+            nrf52840::aes::AesECB<'static>,
+        >,
+        capsules_core::virtualizers::virtual_aes::AesVirtualHw::new(aes_hw_mux, key_buf, iv_buf)
+    );
+
+    let ctr_buf = static_init!([u8; AES128_BLOCK_SIZE], [0; AES128_BLOCK_SIZE]);
+    let sw_ctr = static_init!(
+        capsules_aes_ctr::aes_ctr::Aes128CtrEcbBase<
+            'static,
+            capsules_core::virtualizers::virtual_aes::AesVirtualHw<
+                'static,
+                nrf52840::aes::AesECB<'static>,
+            >,
+        >,
+        capsules_aes_ctr::aes_ctr::Aes128CtrEcbBase::new(ecb_for_ctr, ctr_buf)
+    );
+
+    let grant = board_kernel.create_grant(
+        capsules_extra::symmetric_encryption::aes::DRIVER_NUM,
+        &memory_allocation_capability,
+    );
+
+    const AES128_CRYPT_BUF_SIZE: usize = AES128_BLOCK_SIZE * 16;
+    let crypt_dest_buf = static_init!([u8; AES128_CRYPT_BUF_SIZE], [0; AES128_CRYPT_BUF_SIZE]);
+    let crypt_src_buf = static_init!([u8; AES128_CRYPT_BUF_SIZE], [0; AES128_CRYPT_BUF_SIZE]);
+
+    let aes_driver = static_init!(
+        capsules_extra::symmetric_encryption::aes::AesDriver<
+            'static,
+            capsules_core::virtualizers::virtual_aes::AesVirtualHw<
+                'static,
+                nrf52840::aes::AesECB<'static>,
+            >,
+            capsules_aes_ctr::aes_ctr::Aes128CtrEcbBase<
+                'static,
+                capsules_core::virtualizers::virtual_aes::AesVirtualHw<
+                    'static,
+                    nrf52840::aes::AesECB<'static>,
+                >,
+            >,
+        >,
+        capsules_extra::symmetric_encryption::aes::AesDriver::new(
+            virtual_aes_ecb,
+            sw_ctr,
+            grant,
+            crypt_dest_buf,
+            crypt_src_buf,
+        )
+    );
+
+    //--------------------------------------------------------------------------
     // NRF CLOCK SETUP
     //--------------------------------------------------------------------------
 
@@ -914,6 +1009,7 @@ pub unsafe fn start_no_pconsole() -> (
         kv_driver,
         scheduler,
         systick: cortexm4::systick::SysTick::new_with_calibration(64000000),
+        aes: aes_driver,
     };
 
     base_peripherals.adc.calibrate();

--- a/capsules/aes_ctr/Cargo.toml
+++ b/capsules/aes_ctr/Cargo.toml
@@ -1,0 +1,20 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Western Digital 2023.
+
+[package]
+name = "capsules-aes-ctr"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+
+[dependencies]
+kernel = { path = "../../kernel" }
+capsules-core = { path = "../core"}
+enum_primitive = { path = "../../libraries/enum_primitive" }
+tickv = { path = "../../libraries/tickv" }
+ctr = "0.9.2"
+aes = "0.8.4" 
+
+[lints]
+workspace = true

--- a/capsules/aes_ctr/README.md
+++ b/capsules/aes_ctr/README.md
@@ -1,0 +1,3 @@
+AES CTR Capsule
+===============
+TODO

--- a/capsules/aes_ctr/src/aes_ctr.rs
+++ b/capsules/aes_ctr/src/aes_ctr.rs
@@ -1,0 +1,295 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// 2 options: AESCTR fully in sw or AES CTR that uses
+// some block cipher in hw.
+
+use core::cmp::min;
+use kernel::utilities::copy_slice::CopyOrErr;
+use kernel::utilities::leasable_buffer::SubSliceMut;
+// HW backed
+use kernel::hil::symmetric_encryption::{self, AES128_BLOCK_SIZE};
+use kernel::utilities::cells::{MapCell, OptionalCell, TakeCell};
+use kernel::ErrorCode;
+
+use ctr::cipher::{KeyIvInit, StreamCipher};
+
+type Aes128Ctr128LE = ctr::Ctr128LE<aes::Aes128>;
+
+type AESKey = [u8; 16]; // AES-128 key size
+type AESIv = [u8; 16]; // AES-128 IV size
+
+/// Fully software implementation of AES-128 CTR mode using
+/// the RustCrypto library. This implementation does not use
+/// any hardware acceleration and is suitable for platforms
+/// that do not have AES hardware support or where the hardware
+/// support is not available.
+///
+/// This uses the `ctr` and `aes` crates from RustCrypto to expose AES128Ctr support.
+struct Aes128CtrSw<'a> {
+    client: OptionalCell<&'a dyn symmetric_encryption::Client<'a>>,
+    iv: TakeCell<'a, AESIv>,   // Initialization vector
+    key: TakeCell<'a, AESKey>, // AES key
+}
+
+impl<'a> Aes128CtrSw<'a> {
+    pub fn new(iv: &'a mut AESIv, key: &'a mut AESKey) -> Aes128CtrSw<'a> {
+        Aes128CtrSw {
+            client: OptionalCell::empty(),
+            iv: TakeCell::new(iv),
+            key: TakeCell::new(key),
+        }
+    }
+}
+
+impl<'a> capsules_core::aes::Aes128Ctr<'a> for Aes128CtrSw<'a> {
+    fn set_client(&self, client: &'a dyn symmetric_encryption::Client<'a>) {
+        self.client.set(client)
+    }
+
+    fn setup_cipher(
+        &self,
+        key: &[u8; symmetric_encryption::AES128_KEY_SIZE],
+        iv: &[u8],
+    ) -> Result<(), ErrorCode> {
+        // (TODO) IV length check
+        let iv: &[u8; symmetric_encryption::AES128_BLOCK_SIZE] =
+            iv.try_into().map_err(|_| ErrorCode::INVAL)?;
+
+        self.iv.map(|iv_buf| iv_buf.copy_from_slice(iv));
+        self.key.map(|key_buf| key_buf.copy_from_slice(key));
+        Ok(())
+    }
+
+    fn crypt(
+        &self,
+        source: Option<SubSliceMut<'static, u8>>,
+        mut dest: SubSliceMut<'static, u8>,
+    ) -> Result<
+        (),
+        (
+            ErrorCode,
+            Option<SubSliceMut<'static, u8>>,
+            SubSliceMut<'static, u8>,
+        ),
+    > {
+        let mut local_key = [0u8; symmetric_encryption::AES128_KEY_SIZE];
+        let mut local_iv = [0u8; symmetric_encryption::AES128_BLOCK_SIZE];
+
+        self.key.map(|key_buf| local_key.copy_from_slice(key_buf));
+        self.iv.map(|iv_buf| local_iv.copy_from_slice(iv_buf));
+
+        // Create cipher to be used from key and IV.
+        let mut cipher = Aes128Ctr128LE::new(&local_key.into(), &local_iv.into());
+
+        // If the source is Some, copy the keystream to dest.
+        // If source is None, encrypt in place the dest buf.
+        let source = if let Some(src_buf) = source {
+            // `crypt` documentation states that the src and dst
+            // buffers must be the same length, so error if they are not.
+            if let Err(_) = dest
+                .as_mut_slice()
+                .copy_from_slice_or_err(src_buf.as_slice())
+            {
+                return Err((ErrorCode::INVAL, Some(src_buf), dest));
+            } else {
+                // Since we bind/move src_buf, return src_buf
+                // so we can keep using source later.
+                Some(src_buf)
+            }
+        } else {
+            None
+        };
+
+        if let Err(_) = cipher.try_apply_keystream(dest.as_mut_slice()) {
+            // If the keystream could not be applied, return an error.
+            return Err((ErrorCode::INVAL, source, dest));
+        };
+
+        // Finished crypto operation since the sw crypto
+        // func in RustCrypto are blocking and sync.
+        self.client.map(|client| {
+            client.crypt_done(source, Ok(dest));
+        });
+
+        Ok(())
+    }
+}
+
+/// Hardware-backed AES-128 CTR mode implementation.
+/// This implementation uses a generic AES hardware
+/// ECB cipher to perform the CTR mode encryption/decryption.
+pub struct Aes128CtrEcbBase<'a, ECB: capsules_core::aes::Aes128Ecb<'a>> {
+    client: OptionalCell<&'a dyn symmetric_encryption::Client<'a>>,
+    counter_block: TakeCell<'static, [u8; AES128_BLOCK_SIZE]>, // Initialization vector
+    plaintext: MapCell<SubSliceMut<'static, u8>>,              // Buffer for plaintext
+    aes_ecb: &'a ECB,
+}
+
+// (todo) is this the buf size we want to use?
+impl<'a, ECB> Aes128CtrEcbBase<'a, ECB>
+where
+    ECB: capsules_core::aes::Aes128Ecb<'a>,
+{
+    pub fn new(
+        aes_ecb: &'a ECB,
+        buf: &'static mut [u8; symmetric_encryption::AES128_BLOCK_SIZE],
+    ) -> Aes128CtrEcbBase<'a, ECB> {
+        Aes128CtrEcbBase {
+            client: OptionalCell::empty(),
+            counter_block: TakeCell::new(buf),
+            plaintext: MapCell::empty(),
+            aes_ecb,
+        }
+    }
+
+    // TODO: Add cargo test for this function.
+    /// Helper method to update the counter block, a 16byte block.
+    ///
+    /// We start from the least significat byte (little endian)
+    /// and increment it, propagating any carry on overflow to
+    /// the next byte.
+    ///
+    /// We need each counter block to be unique. We take our 16-byte
+    /// counter block and increment it by 1 each time we encrypt a block.
+    /// This allows us to encrypt 2^128 counter blocks per IV. It is
+    /// good practice to use a unique IV for each message.
+    fn update_ctr_le(&self, ctr_block: &mut [u8; symmetric_encryption::AES128_BLOCK_SIZE]) {
+        for i in 0..symmetric_encryption::AES128_BLOCK_SIZE {
+            let (res, carry) = ctr_block[i].overflowing_add(1);
+            ctr_block[i] = res;
+            if !carry {
+                // If there was no carry, we can stop incrementing.
+                break;
+            }
+        }
+    }
+
+    /// Helper method to perform block XOR for CTR.
+    ///
+    /// XOR plaintext up to but not past the AES128 block size.
+    fn perform_xor(
+        &self,
+        plaintext: &mut [u8],
+        ctr_block: &[u8; symmetric_encryption::AES128_BLOCK_SIZE],
+    ) {
+        // XOR the plaintext with the counter block to produce the ciphertext.
+        for i in 0..(min(plaintext.len(), symmetric_encryption::AES128_BLOCK_SIZE)) {
+            plaintext[i] ^= ctr_block[i];
+        }
+    }
+}
+
+impl<'a, ECB> capsules_core::aes::Aes128Ctr<'a> for Aes128CtrEcbBase<'a, ECB>
+where
+    ECB: capsules_core::aes::Aes128Ecb<'a>,
+{
+    fn set_client(&self, client: &'a dyn symmetric_encryption::Client<'a>) {
+        self.client.set(client);
+    }
+
+    fn setup_cipher(
+        &self,
+        key: &[u8; symmetric_encryption::AES128_KEY_SIZE],
+        iv: &[u8],
+    ) -> Result<(), ErrorCode> {
+        // Set the key and IV for AES128CTR operation.
+        // The IV can be of variable length, and must be
+        // checked by the implementor to ensure it is
+        // valid.
+        self.aes_ecb.setup_cipher(key)?;
+
+        self.counter_block
+            .map(|ctr_block| {
+                // Copy the IV into the counter block.
+                ctr_block.as_mut_slice().copy_from_slice(iv);
+                Ok(())
+            })
+            .map_or(Err(ErrorCode::NODEVICE), |result| result)
+    }
+
+    fn crypt(
+        &self,
+        source: Option<SubSliceMut<'static, u8>>,
+        dest: SubSliceMut<'static, u8>,
+    ) -> Result<
+        (),
+        (
+            kernel::ErrorCode,
+            Option<SubSliceMut<'static, u8>>,
+            SubSliceMut<'static, u8>,
+        ),
+    > {
+        // Obtain CTR block and perform ECB.
+        match self.counter_block.take() {
+            Some(ctr_block) => {
+                // We must store the source or destination buffer since
+                // we will only perform the CTR XOR after the ECB crypt
+                // operation is complete.
+                self.plaintext.put(dest);
+                self.aes_ecb.crypt(None, SubSliceMut::new(ctr_block))
+            }
+            None => return Err((ErrorCode::NODEVICE, source, dest)),
+        }
+    }
+}
+
+impl<'a, ECB> symmetric_encryption::Client<'a> for Aes128CtrEcbBase<'a, ECB>
+where
+    ECB: capsules_core::aes::Aes128Ecb<'a>,
+{
+    fn crypt_done(
+        &self,
+        source: Option<SubSliceMut<'static, u8>>,
+        result: Result<SubSliceMut<'static, u8>, (kernel::ErrorCode, SubSliceMut<'static, u8>)>,
+    ) {
+        // ECB completed operation on counter block. Update the counter
+        // block and replace.
+        let _ = match result {
+            Ok(mut ctr_block) => {
+                let ctr_block_slice: &mut [u8; symmetric_encryption::AES128_BLOCK_SIZE] = ctr_block
+                    .as_mut_slice()
+                    .try_into()
+                    .expect("ctr_block returned here must be 16 bytes");
+
+                let mut completed_ctr_op = false;
+                // XOR with the first 16 bytes of the plaintext
+                self.plaintext.map(|plaintext| {
+                    // Obtain plaintext to XOR with the counter block.
+
+                    self.perform_xor(plaintext.as_mut_slice(), ctr_block_slice);
+
+                    // Shrink buffer to remaining data to be processed.
+                    plaintext.slice(symmetric_encryption::AES128_BLOCK_SIZE..);
+
+                    // Determine if there are more blocks to encrypt/decrypt.
+                    if plaintext.len() == 0 {
+                        completed_ctr_op = true;
+                    }
+                });
+
+                if completed_ctr_op {
+                    // If we are done with processing all blocks, notify the CTR client.
+                    self.client.map(|client| {
+                        if let Some(dest_buf) = self.plaintext.take() {
+                            client.crypt_done(source, Ok(dest_buf));
+                        };
+                    });
+                    Ok(())
+                } else {
+                    // There are more blocks to process. Increment the counter then
+                    // continue.
+                    self.update_ctr_le(ctr_block_slice);
+                    self.aes_ecb.crypt(None, ctr_block)
+                }
+            }
+            Err((error_code, dest_buf)) => Err((error_code, source, dest_buf)),
+        }
+        .map_err(|(error_code, src, dest)| {
+            // notify client of the error
+            self.client.map(|client| {
+                client.crypt_done(src, Err((error_code, dest)));
+            });
+        });
+    }
+}

--- a/capsules/aes_ctr/src/lib.rs
+++ b/capsules/aes_ctr/src/lib.rs
@@ -1,0 +1,8 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Western Digital 2023.
+
+#![forbid(unsafe_code)]
+#![no_std]
+
+pub mod aes_ctr;

--- a/capsules/core/src/aes.rs
+++ b/capsules/core/src/aes.rs
@@ -1,0 +1,161 @@
+use kernel::{hil::symmetric_encryption, utilities::leasable_buffer::SubSliceMut, ErrorCode};
+pub trait Aes128Ctr<'a> {
+    /// Set the client instance which will receive `crypt_done()` callbacks.
+    fn set_client(&self, client: &'a dyn symmetric_encryption::Client<'a>);
+
+    /// Set the key and IV for AES128CTR operation.
+    ///
+    /// The IV can be of variable length, and must be
+    /// checked by the implementor to ensure it is
+    /// valid.
+    fn setup_cipher(
+        &self,
+        key: &[u8; symmetric_encryption::AES128_KEY_SIZE],
+        iv: &[u8],
+    ) -> Result<(), ErrorCode>;
+
+    /// Perform AES128CTR crypt operation. This must be used after `setup_cipher()`
+    /// and will use whatever the key and IV have been set to.
+    ///
+    /// CAUTION: The IV must be set to a value that is unique for each
+    /// crypt operation. If the same IV is used for multiple operations,
+    /// it can lead to security vulnerabilities.
+    fn crypt(
+        &self,
+        source: Option<SubSliceMut<'static, u8>>,
+        dest: SubSliceMut<'static, u8>,
+    ) -> Result<
+        (),
+        (
+            ErrorCode,
+            Option<SubSliceMut<'static, u8>>,
+            SubSliceMut<'static, u8>,
+        ),
+    >;
+}
+
+pub trait Aes128Cbc<'a> {
+    /// Set the client instance which will receive `crypt_done()` callbacks.
+    fn set_client(&self, client: &'a dyn symmetric_encryption::Client<'a>);
+
+    /// Set the key and IV for AES128CBC operation.
+    ///
+    /// The IV must be of length `AES128_BLOCK_SIZE`.
+    fn setup_cipher(
+        &self,
+        key: &[u8; symmetric_encryption::AES128_KEY_SIZE],
+        iv: &[u8; symmetric_encryption::AES128_BLOCK_SIZE],
+    ) -> Result<(), ErrorCode>;
+
+    /// Perform AES128CBC crypt operation. This must be used after `setup_cipher()`
+    /// and will use whatever key and IV have been set to.
+    fn crypt(
+        &self,
+        source: Option<SubSliceMut<'static, u8>>,
+        dest: SubSliceMut<'static, u8>,
+    ) -> Result<
+        (),
+        (
+            ErrorCode,
+            Option<SubSliceMut<'static, u8>>,
+            SubSliceMut<'static, u8>,
+        ),
+    >;
+}
+
+pub trait Aes128Ecb<'a> {
+    /// Set the client instance which will receive `crypt_done()` callbacks.
+    fn set_client(&self, client: &'a dyn symmetric_encryption::Client<'a>);
+
+    /// Set the key for AES128ECB operation.
+    ///
+    /// The key must be of length `AES128_KEY_SIZE`.
+    /// Note: ECB does not use an IV.
+    fn setup_cipher(
+        &self,
+        key: &[u8; symmetric_encryption::AES128_KEY_SIZE],
+    ) -> Result<(), ErrorCode>;
+
+    /// Perform AES128ECB crypt operation.
+    ///
+    /// This must be used after `setup_cipher()`
+    /// and will use whatever key has been set to.
+    fn crypt(
+        &self,
+        source: Option<SubSliceMut<'static, u8>>,
+        dest: SubSliceMut<'static, u8>,
+    ) -> Result<
+        (),
+        (
+            ErrorCode,
+            Option<SubSliceMut<'static, u8>>,
+            SubSliceMut<'static, u8>,
+        ),
+    >;
+}
+
+pub const CCM_NONCE_LENGTH: usize = 13;
+
+pub trait Aes128Ccm<'a> {
+    /// Set the client instance which will receive `crypt_done()` callbacks.
+    fn set_client(&self, client: &'a dyn symmetric_encryption::Client<'a>);
+
+    /// Set the key and nonce for AES128CCM operation.
+    ///
+    /// CCM allows a nonce of variable length, but it
+    /// must be at least 7 bytes and at most 13 bytes.
+    /// This invariant must be checked and enforced by
+    /// the implementor.
+    fn setup_cipher(
+        &self,
+        key: &[u8; symmetric_encryption::AES128_KEY_SIZE],
+        nonce: &[u8],
+    ) -> Result<(), ErrorCode>;
+
+    /// Perform AES128CCM crypt operation.
+    fn crypt(
+        &self,
+        source: Option<SubSliceMut<'static, u8>>,
+        dest: SubSliceMut<'static, u8>,
+    ) -> Result<
+        (),
+        (
+            ErrorCode,
+            Option<SubSliceMut<'static, u8>>,
+            SubSliceMut<'static, u8>,
+        ),
+    >;
+}
+
+pub trait Aes128Gcm<'a> {
+    /// Set the client instance which will receive `crypt_done()` callbacks.
+    fn set_client(&self, client: &'a dyn symmetric_encryption::Client<'a>);
+
+    /// Set the key and nonce for AES128GCM operation.
+    ///
+    /// CCM allows a nonce of variable length,
+    /// but it must be at least 7 bytes and at most 13 bytes.
+    /// This invariant must be checked and enforced by
+    /// the implementor.
+    fn setup_cipher(
+        &self,
+        key: &[u8; symmetric_encryption::AES128_KEY_SIZE],
+        nonce: &[u8; 12],
+    ) -> Result<(), ErrorCode>;
+
+    /// Perform AES128GCM crypt operation. Although technically flexible in
+    /// the length of the nonce, it is recommended to use a 12-byte nonce.
+    /// For simplicity and consistency, a 12-byte nonce is enforced.
+    fn crypt(
+        &self,
+        source: Option<SubSliceMut<'static, u8>>,
+        dest: SubSliceMut<'static, u8>,
+    ) -> Result<
+        (),
+        (
+            ErrorCode,
+            Option<SubSliceMut<'static, u8>>,
+            SubSliceMut<'static, u8>,
+        ),
+    >;
+}

--- a/capsules/core/src/lib.rs
+++ b/capsules/core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod test;
 pub mod stream;
 
 pub mod adc;
+pub mod aes;
 pub mod alarm;
 pub mod button;
 pub mod console;

--- a/capsules/core/src/virtualizers/mod.rs
+++ b/capsules/core/src/virtualizers/mod.rs
@@ -3,7 +3,8 @@
 // Copyright Tock Contributors 2023.
 
 pub mod virtual_adc;
-pub mod virtual_aes_ccm;
+//pub mod virtual_aes_ccm;
+pub mod virtual_aes;
 pub mod virtual_alarm;
 pub mod virtual_flash;
 pub mod virtual_i2c;

--- a/capsules/core/src/virtualizers/virtual_aes.rs
+++ b/capsules/core/src/virtualizers/virtual_aes.rs
@@ -1,0 +1,432 @@
+use core::cell::Cell;
+use kernel::{
+    collections::list::{List, ListLink, ListNode},
+    hil::symmetric_encryption::{self, AES128_BLOCK_SIZE, AES128_KEY_SIZE},
+    utilities::{
+        cells::{MapCell, TakeCell},
+        leasable_buffer::SubSliceMut,
+    },
+    ErrorCode,
+};
+
+use crate::aes;
+
+// Wrapper for IV buffer.
+//
+// The IV buffer is needed for AES modes besides
+// ECB. `IVBuf` denotes if the buffer has been
+// passed to the pending AES work object.
+enum IvBuf<'a> {
+    NotProvided(TakeCell<'a, [u8; AES128_KEY_SIZE]>),
+    Provided(TakeCell<'a, [u8; AES128_KEY_SIZE]>),
+}
+
+impl<'a> IvBuf<'a> {
+    fn replace_buffer(&self, new_buf: &[u8]) -> Option<Self> {
+        // get buffer length, we will pad with zeros if needed
+        let new_buf_len = new_buf.len();
+        let padded_buf = &mut [0u8; AES128_BLOCK_SIZE];
+        padded_buf[..new_buf_len].copy_from_slice(new_buf);
+
+        let buf = match self {
+            IvBuf::NotProvided(take_cell) => take_cell.take(),
+            IvBuf::Provided(take_cell) => take_cell.take(),
+        }?;
+
+        Some(IvBuf::Provided(TakeCell::new(buf)))
+    }
+}
+
+// Work object for AES HW virtualizer.
+// Contains all state needed to perform
+// an AES operation on the underlying HW.
+//
+// This allows for crypto operations to
+// be enqueued and executed later when
+// the HW is available. The work object
+// contains static buffers for the iv/key
+// (copied into from caller) and receives
+// static buffers from the caller for src/dest.
+struct WorkAesHw<'a, T> {
+    key: TakeCell<'a, [u8; AES128_KEY_SIZE]>,
+    mode: MapCell<SetModeFn<'a, T>>,
+    iv: IvBuf<'a>,
+    buffers: MapCell<(Option<SubSliceMut<'static, u8>>, SubSliceMut<'static, u8>)>,
+    client: MapCell<&'a dyn symmetric_encryption::Client<'a>>,
+    ready: Cell<bool>,
+}
+
+impl<'a, T> WorkAesHw<'a, T> {
+    fn new(key_buf: &'a mut [u8; AES128_KEY_SIZE], iv_buf: &'a mut [u8; AES128_KEY_SIZE]) -> Self {
+        WorkAesHw {
+            key: TakeCell::new(key_buf),
+            mode: MapCell::empty(),
+            iv: IvBuf::NotProvided(TakeCell::new(iv_buf)),
+            buffers: MapCell::empty(),
+            client: MapCell::empty(),
+            ready: Cell::new(false),
+        }
+    }
+}
+
+impl<'a, A: symmetric_encryption::AES128<'a>> ListNode<'a, AesVirtualHw<'a, A>>
+    for AesVirtualHw<'a, A>
+{
+    fn next(&'a self) -> &'a ListLink<'a, AesVirtualHw<'a, A>> {
+        &self.next
+    }
+}
+
+/// Virtualizer for AES HW implementations.
+///
+/// This provides an abstraction to for multiple clients
+/// to use and share a single underlying AES hardware. This
+/// virtualizer is not specific to a given AES mode.
+pub struct AesVirtualHw<'a, A: symmetric_encryption::AES128<'a>> {
+    aes_hw_mux: &'a AesHwMux<'a, A>,
+    next: ListLink<'a, Self>,
+    work: WorkAesHw<'a, A>,
+}
+
+impl<'a, A: symmetric_encryption::AES128<'a>> AesVirtualHw<'a, A> {
+    pub fn new(
+        aes_hw_mux: &'a AesHwMux<'a, A>,
+        key_buf: &'a mut [u8; AES128_KEY_SIZE],
+        iv_buf: &'a mut [u8; AES128_KEY_SIZE],
+    ) -> Self {
+        AesVirtualHw {
+            aes_hw_mux,
+            next: ListLink::empty(),
+            work: WorkAesHw::new(key_buf, iv_buf),
+        }
+    }
+
+    fn setup_work_config(
+        &self,
+        key: &[u8; AES128_KEY_SIZE],
+        iv: Option<&[u8]>,
+        fn_ptr: SetModeFn<'a, A>,
+    ) -> Result<(), ErrorCode> {
+        let work = &self.work;
+
+        work.key.map_or_else(
+            || Err(ErrorCode::BUSY),
+            |worker_key| {
+                worker_key.copy_from_slice(key);
+                Ok(())
+            },
+        )?;
+
+        work.mode.replace(fn_ptr);
+
+        if let Some(iv) = iv {
+            work.iv
+                .replace_buffer(iv)
+                .map_or(Err(ErrorCode::BUSY), |_| Ok(()))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn setup_work_buffers(
+        &self,
+        src: Option<SubSliceMut<'static, u8>>,
+        dest: SubSliceMut<'static, u8>,
+    ) {
+        let work = &self.work;
+
+        work.buffers.replace((src, dest));
+    }
+}
+
+impl<'a, A: symmetric_encryption::AES128<'a>> kernel::hil::symmetric_encryption::Client<'a>
+    for AesVirtualHw<'a, A>
+{
+    fn crypt_done(
+        &'a self,
+        source: Option<SubSliceMut<'static, u8>>,
+        dest: Result<SubSliceMut<'static, u8>, (ErrorCode, SubSliceMut<'static, u8>)>,
+    ) {
+        self.work.client.map(|client| {
+            client.crypt_done(source, dest);
+        });
+    }
+}
+
+// (todo) we potentially have unbounded linked list?
+pub struct AesHwMux<'a, A: symmetric_encryption::AES128<'a>> {
+    aes_hw: &'a A,
+    virtual_aes_hw_list: List<'a, AesVirtualHw<'a, A>>,
+    current_virtualhw_client: MapCell<&'a dyn symmetric_encryption::Client<'a>>,
+}
+
+impl<'a, A: symmetric_encryption::AES128<'a>> symmetric_encryption::Client<'a> for AesHwMux<'a, A> {
+    fn crypt_done(
+        &'a self,
+        source: Option<SubSliceMut<'static, u8>>,
+        dest: Result<SubSliceMut<'static, u8>, (ErrorCode, SubSliceMut<'static, u8>)>,
+    ) {
+        // We set the client of our AesHwMux to be the current AesVirtualHw that
+        // is using the HW.
+        self.current_virtualhw_client.map(|client| {
+            client.crypt_done(source, dest);
+        });
+
+        // start next operation.
+        self.do_next_op();
+    }
+}
+
+// Type to represent a function pointer to configure the
+// specific AES HW mode.
+type SetModeFn<'a, T> = fn(&T) -> Result<(), ErrorCode>;
+
+impl<'a, A: symmetric_encryption::AES128<'a>> AesHwMux<'a, A> {
+    pub fn new(aes_hw: &'a A) -> Self {
+        AesHwMux {
+            aes_hw: aes_hw,
+            virtual_aes_hw_list: List::new(),
+            current_virtualhw_client: MapCell::empty(),
+        }
+    }
+
+    fn do_next_op(&self) {
+        // (todo) Potentially, a greedy first node in the list starves
+        // others. This can be mitigated, but I think we can assume
+        // that clients will be well-behaved.
+
+        // Iterate through list and find first ready work item.
+        self.virtual_aes_hw_list
+            .iter()
+            .find(|aes_virtual_hw| aes_virtual_hw.work.ready.get())
+            .and_then(|aes_virtual_hw| {
+                let work = &aes_virtual_hw.work;
+
+                // Mark as not ready (we are servicing it now).
+                work.ready.set(false);
+
+                // Configure for needed HW mode (set hw into proper mode and set key/iv).
+                work.key.map(|key| {
+                    self.aes_hw.set_key(key);
+                })?;
+
+                // Take the buffers to be encrypted/decrypted.
+                let (src, dest) = work.buffers.take()?;
+
+                if let IvBuf::Provided(iv) = &work.iv {
+                    if let Err(code) = iv.map(|iv| self.aes_hw.set_iv(iv))? {
+                        // notify client of failure
+                        work.client.map(|client| {
+                            client.crypt_done(src, Err((code, dest)));
+                        });
+
+                        return None;
+                    }
+                }
+
+                // Set AES HW into proper mode.
+                let mode = work.mode.get()?;
+
+                if let Err(err) = (mode)(self.aes_hw) {
+                    // notify client of failure
+                    work.client.map(|client| {
+                        client.crypt_done(src, Err((err, dest)));
+                    });
+
+                    return None;
+                }
+
+                self.current_virtualhw_client.replace(aes_virtual_hw);
+
+                // Start the operation.
+                self.aes_hw.crypt(src, dest).map_or_else(
+                    |(err, src, dest)| {
+                        // notify client of failure
+                        work.client.map(|client| {
+                            client.crypt_done(src, Err((err, dest)));
+                        });
+
+                        None
+                    },
+                    |_| Some(()),
+                )
+            })
+            .map_or_else(
+                || {
+                    // None indicates something went wrong (e.g. buffer not provided) or
+                    // the crypt operation returned an error.
+                    // (todo) error handling here
+                    self.do_next_op();
+                },
+                |_| (),
+            );
+    }
+}
+
+// Interface for ECB Device
+impl<'a, A: symmetric_encryption::AES128ECB<'a>> aes::Aes128Ecb<'a> for AesVirtualHw<'a, A> {
+    fn crypt(
+        &self,
+        source: Option<SubSliceMut<'static, u8>>,
+        dest: SubSliceMut<'static, u8>,
+    ) -> Result<
+        (),
+        (
+            ErrorCode,
+            Option<SubSliceMut<'static, u8>>,
+            SubSliceMut<'static, u8>,
+        ),
+    > {
+        self.setup_work_buffers(source, dest);
+        self.work.ready.set(true);
+        self.aes_hw_mux.do_next_op();
+        Ok(())
+    }
+
+    fn set_client(&self, client: &'a dyn symmetric_encryption::Client<'a>) {
+        self.work.client.replace(client);
+    }
+
+    fn setup_cipher(
+        &self,
+        key: &[u8; symmetric_encryption::AES128_KEY_SIZE],
+    ) -> Result<(), ErrorCode> {
+        self.setup_work_config(key, None, A::set_mode_aes128ecb)
+    }
+}
+
+impl<'a, A: symmetric_encryption::AES128CBC<'a>> aes::Aes128Cbc<'a> for AesVirtualHw<'a, A> {
+    fn crypt(
+        &self,
+        source: Option<SubSliceMut<'static, u8>>,
+        dest: SubSliceMut<'static, u8>,
+    ) -> Result<
+        (),
+        (
+            ErrorCode,
+            Option<SubSliceMut<'static, u8>>,
+            SubSliceMut<'static, u8>,
+        ),
+    > {
+        self.setup_work_buffers(source, dest);
+        self.work.ready.set(true);
+        self.aes_hw_mux.do_next_op();
+        Ok(())
+    }
+
+    fn set_client(&self, client: &'a dyn symmetric_encryption::Client<'a>) {
+        self.work.client.replace(client);
+    }
+
+    fn setup_cipher(
+        &self,
+        key: &[u8; symmetric_encryption::AES128_KEY_SIZE],
+        _iv: &[u8; symmetric_encryption::AES128_BLOCK_SIZE],
+    ) -> Result<(), ErrorCode> {
+        self.setup_work_config(key, None, A::set_mode_aes128cbc)
+    }
+}
+
+impl<'a, A: symmetric_encryption::AES128Ctr<'a>> aes::Aes128Ctr<'a> for AesVirtualHw<'a, A> {
+    fn crypt(
+        &self,
+        source: Option<SubSliceMut<'static, u8>>,
+        dest: SubSliceMut<'static, u8>,
+    ) -> Result<
+        (),
+        (
+            ErrorCode,
+            Option<SubSliceMut<'static, u8>>,
+            SubSliceMut<'static, u8>,
+        ),
+    > {
+        self.setup_work_buffers(source, dest);
+        self.work.ready.set(true);
+        self.aes_hw_mux.do_next_op();
+        Ok(())
+    }
+
+    fn set_client(&self, client: &'a dyn symmetric_encryption::Client<'a>) {
+        self.work.client.replace(client);
+    }
+
+    fn setup_cipher(
+        &self,
+        key: &[u8; symmetric_encryption::AES128_KEY_SIZE],
+        iv: &[u8],
+    ) -> Result<(), ErrorCode> {
+        // Check that IV is less than 16 and greater than [..] (TODO)
+        let iv_len = iv.len();
+        if iv_len < 13 || iv_len > 16 {
+            return Err(ErrorCode::INVAL);
+        }
+
+        self.setup_work_config(key, Some(iv), A::set_mode_aes128ctr)
+    }
+}
+
+impl<'a, A: symmetric_encryption::AES128CCM<'a>> aes::Aes128Ccm<'a> for AesVirtualHw<'a, A> {
+    fn crypt(
+        &self,
+        source: Option<SubSliceMut<'static, u8>>,
+        dest: SubSliceMut<'static, u8>,
+    ) -> Result<
+        (),
+        (
+            ErrorCode,
+            Option<SubSliceMut<'static, u8>>,
+            SubSliceMut<'static, u8>,
+        ),
+    > {
+        self.setup_work_buffers(source, dest);
+        self.work.ready.set(true);
+        self.aes_hw_mux.do_next_op();
+        Ok(())
+    }
+
+    fn set_client(&self, client: &'a dyn symmetric_encryption::Client<'a>) {
+        self.work.client.replace(client);
+    }
+
+    fn setup_cipher(
+        &self,
+        key: &[u8; symmetric_encryption::AES128_KEY_SIZE],
+        iv: &[u8],
+    ) -> Result<(), ErrorCode> {
+        // Check that 7 <= iv_len <= 13
+        let iv_len = iv.len();
+        if iv_len < 7 || iv_len > 13 {
+            return Err(ErrorCode::INVAL);
+        }
+
+        self.setup_work_config(key, Some(iv), A::set_mode_aes128ccm)
+    }
+}
+
+impl<'a, A: symmetric_encryption::AES128GCM<'a>> aes::Aes128Gcm<'a> for AesVirtualHw<'a, A> {
+    fn crypt(
+        &self,
+        source: Option<SubSliceMut<'static, u8>>,
+        dest: SubSliceMut<'static, u8>,
+    ) -> Result<
+        (),
+        (
+            ErrorCode,
+            Option<SubSliceMut<'static, u8>>,
+            SubSliceMut<'static, u8>,
+        ),
+    > {
+        self.setup_work_buffers(source, dest);
+        self.work.ready.set(true);
+        self.aes_hw_mux.do_next_op();
+        Ok(())
+    }
+
+    fn set_client(&self, client: &'a dyn symmetric_encryption::Client<'a>) {
+        self.work.client.replace(client);
+    }
+
+    fn setup_cipher(&self, key: &[u8; 16], iv: &[u8; 12]) -> Result<(), ErrorCode> {
+        self.setup_work_config(key, Some(iv), A::set_mode_aes128gcm)
+    }
+}


### PR DESCRIPTION
### Pull Request Overview

This pull request introduces updates to the AES Symmetric Encryption HIL, adds traits that specify the semantics for each AES encryption mode, and adds a generic AES HW encryption virtualizer. This PR demonstrates these changes across the `Nrf5x` AES crypto engine and `nRF52840dk` board file. Importantly, this is currently untested and remains a draft. The primary purpose of this PR is to solicit feedback before spending additional time finalizing / testing / incorporating these changes for the other AES crypto hardware.

The current AES stack uses a combination of virtualizers / overloaded traits to provide the needed crypto interfaces (e.g. ECB, CTR, CCM, GCM, CBC are required for the userspace symmetric encryption capsule, but the kernel 15.4 stack also requires CCM). The current design does not scale well and struggles when building higher level crypto modes (e.g. GCM) from HW supported ECB. This design attempts to provide a single generic AES HW virtualizer (to avoid each mode needing to implement a virtualizer). 

Key Changes:
- Remove GCM / CCM Client in HIL (use single standard Client)
- Add traits at the `capsule` level to encapsulate the behavior of each crypto mode. This allows us to statically enforce requirements for each crypto mode.
- Update the userspace symmetric encryption driver to now use virtualized aes hw. The implementation is greatly simplified as it no longer requires tracking state to correctly overload traits / configure on the fly as this is now abstracted by the virtualizer. 
- Example AESCtr implementation to demonstrate new HIL's integration with the RustCrypto software AESCtr and AESCtr implementation based upon HW ECB support.

### Testing Strategy

N/A, testing will follow based on RFC discussion.


### TODO or Help Wanted

This pull request still needs...
- [ ] update of chip implementations for  SAM4L, and Earlgray
- [ ] update of capsules that use AES128 methods (e.g. 802.15.4)
- [ ] testing of AESCtr capsule
- [ ] testing of symmetric encryption capsule

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
