### PR TITLE
Set stack's load address in ram

### DIFF
--- a/boards/build_scripts/tock_kernel_layout.ld
+++ b/boards/build_scripts/tock_kernel_layout.ld
@@ -286,7 +286,7 @@ SECTIONS
         KEEP(*(.stack_buffer))
         . = ALIGN(8);
         _estack = .;
-    } > ram
+    } > ram AT> ram
 
     /* Section for application binaries in flash.
      *


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the stack section placing in ram. Before this, it seems that the linker was setting the `.stack` section's load address in rom instead of ram. This increased the kernel size (only from the linker's point of view) with the stack's size.

##### Before

```
  3 .storage      000007a8  1001e858  1001e858  0001e9d8  2**0                                                                                                
                  CONTENTS, ALLOC, LOAD, READONLY, DATA                                                                                                       
  4 .relocate     00000000  20000000  1001f000  0001f180  2**0                                                                                                
                  CONTENTS, ALLOC, LOAD, READONLY, DATA                                                                                                       
  5 .stack        00001500  20000000  1001f000  0001f180  2**0                                                                                                
                  ALLOC                                                                                                                                       
  6 .apps         00000004  10040000  10040000  0001f180  2**0                                                                                                
                  ALLOC                                                                                                                                       
  7 .sram         0000221c  20001500  20001500  0001f180  2**3                                                                                                
                  ALLOC                                                                                                                                       
  8 .attributes   0000002c  1001f000  1003ffd4  0001f180  2**1                                                                                                
                  CONTENTS, ALLOC, LOAD, READONLY, DATA      
```

##### After

```
  3 .storage      000007a8  1001e858  1001e858  0001e9d8  2**0                                                                                                
                  CONTENTS, ALLOC, LOAD, READONLY, DATA                                                                                                       
  4 .relocate     00000000  20000000  20000000  0001f180  2**0                                                                                                
                  CONTENTS, ALLOC, LOAD, READONLY, DATA                                                                                                       
  5 .stack        00001500  20000000  20000000  0001f180  2**0                                                                                                
                  ALLOC                                                                                                                                       
  6 .apps         00000004  10040000  10040000  0001f180  2**0                                                                                                
                  ALLOC                                                                                                                                       
  7 .sram         0000221c  20001500  20001500  0001f180  2**3                                                                                                
                  ALLOC                                                                                                                                       
  8 .attributes   0000002c  1001f000  1003ffd4  0001f180  2**1
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
```

@genan2003 seems to run into this issue for #4601, https://github.com/tock/tock/pull/4601#discussion_r2373626044.


### Testing Strategy

This pull request was tested by @alexandruradovici using the `qemu_i486_q35` board.

### TODO or Help Wanted

This pull request still needs testing

- [ ] @genan2003 please test this on the LPC board
- [x] @JADarius please test this on the Raspberry Pi
- [ ] @irina-nita  please test this on the STM32 board

Testing on a RISC-V target would be useful.

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
