### PR TITLE
boards: Remove padding from the memory layout of Raspberry Pi Pico 2

### DIFF
--- a/boards/raspberry_pi_pico_2/layout.ld
+++ b/boards/raspberry_pi_pico_2/layout.ld
@@ -28,16 +28,6 @@ SECTIONS {
         KEEP (*(.flash_bootloader));
         . = ALIGN (256);
     } > bootloader
-
-    /*
-     * This padding has been added because arm-none-eabi-objcopy
-     * wrongly aligns the .stack section. This is a workaround, not a
-     * permanent fix. See https://github.com/tock/tock/pull/4416#discussion_r2237885703
-     * for details.
-     */
-   .padding (NOLOAD) : {
-        BYTE(0xFF)
-    } > ram
 }
 
 INCLUDE tock_kernel_layout.ld


### PR DESCRIPTION
### Pull Request Overview

This pull request removes the padding from the memory layout of the Raspberry Pi Pico 2 board. The padding is no longer needed because of https://github.com/tock/tock/pull/4610 that fixes the problem with the linker.

This should be merged after #4610 gets merged.

### Testing Strategy

This pull request was tested by flashing the kernel together with an app on a Raspberry Pi Pico 2 board.

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
