### PR TITLE
rustdoc: fix various warnings (Sep 2025)

### DIFF
--- a/arch/cortex-v7m/src/lib.rs
+++ b/arch/cortex-v7m/src/lib.rs
@@ -15,7 +15,7 @@ extern "C" {
 /// ARMv7-M systick handler function.
 ///
 /// For documentation of this function, please see
-/// [`CortexMVariant::SYSTICK_HANDLER`].
+/// `CortexMVariant::SYSTICK_HANDLER`.
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 #[unsafe(naked)]
 pub unsafe extern "C" fn systick_handler_arm_v7m() {
@@ -52,7 +52,7 @@ pub unsafe extern "C" fn systick_handler_arm_v7m() {
 /// Handler of `svc` instructions on ARMv7-M.
 ///
 /// For documentation of this function, please see
-/// [`CortexMVariant::SVC_HANDLER`].
+/// `CortexMVariant::SVC_HANDLER`.
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 #[unsafe(naked)]
 pub unsafe extern "C" fn svc_handler_arm_v7m() {
@@ -128,7 +128,7 @@ pub unsafe extern "C" fn svc_handler_arm_v7m() {
 
 /// Generic interrupt handler for ARMv7-M instruction sets.
 ///
-/// For documentation of this function, see [`CortexMVariant::GENERIC_ISR`].
+/// For documentation of this function, see `CortexMVariant::GENERIC_ISR`.
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 #[unsafe(naked)]
 pub unsafe extern "C" fn generic_isr_arm_v7m() {
@@ -432,7 +432,7 @@ unsafe extern "C" fn hard_fault_handler_arm_v7m_kernel(
 /// ARMv7-M hardfault handler.
 ///
 /// For documentation of this function, please see
-/// [`CortexMVariant::HARD_FAULT_HANDLER_HANDLER`].
+/// `CortexMVariant::HARD_FAULT_HANDLER_HANDLER`.
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 #[unsafe(naked)]
 pub unsafe extern "C" fn hard_fault_handler_arm_v7m() {

--- a/chips/virtio/src/devices/virtio_gpu/mod.rs
+++ b/chips/virtio/src/devices/virtio_gpu/mod.rs
@@ -31,14 +31,14 @@ use messages::{
 
 /// The total number of bytes occupied by a pixel in memory.
 ///
-/// All [`VideoFormat`]s supported by VirtIO have a pixel stride of 4.
+/// All `VideoFormat`s supported by VirtIO have a pixel stride of 4.
 pub const PIXEL_STRIDE: usize = 4;
 
-/// How many individual memory regions a backing buffer for a resouce
+/// How many individual memory regions a backing buffer for a resource
 /// can be split over.
 ///
-/// This constant is used in calculating the maxium size of a
-/// [`ResourceAttachBackingReq`], which in turn is used to calculate
+/// This constant is used in calculating the maximum size of a
+/// `ResourceAttachBackingReq`, which in turn is used to calculate
 /// the overall maximum request size issued by the [`VirtIOGPU`]
 /// driver.
 pub const MAX_ATTACH_BACKING_REQ_MEMORY_ENTRIES: usize = 1;
@@ -126,7 +126,7 @@ pub struct VirtIOGPU<'a, 'b> {
     // Slot for the client's write buffer, while it's attached to the GPU:
     write_buffer: TakeCell<'static, [u8]>,
 
-    // Current rect being transfered to the host:
+    // Current rect being transferred to the host:
     current_transfer_area_pixels: Cell<(Rect, usize)>,
 }
 

--- a/chips/x86_q35/src/vga.rs
+++ b/chips/x86_q35/src/vga.rs
@@ -12,20 +12,20 @@
 //!
 //! NOTE!!!
 //!
-//! This file compiles and provides working text-
-//! mode console support so the board can swap from the UART mux to a VGA
-//! console.  Graphical modes are *disabled at runtime* until a framebuffer
-//! capsule implementation lands.  The low-level register writes for 640×480 and 800×600 are
-//! nonetheless laid out so they can be enabled by flipping a constant.
+//! This file compiles and provides working text-mode console support so the
+//! board can swap from the UART mux to a VGA console.  Graphical modes
+//! are *disabled at runtime* until a framebuffer capsule implementation lands.
+//! The low-level register writes for 640×480 and 800×600 are nonetheless laid
+//! out so they can be enabled by flipping a constant.
 //!
 //! VGA peripheral driver for the x86_q35 chip.
 //!
 //! The driver currently focuses on **text mode** (colour attribute buffer at
-//! 0xB8000).  It also defines [`VgaMode`] and an [`init`] routine that writes
-//! the necessary CRT controller registers for text mode and two common planar
-//! 16-colour modes.  Other code (e.g. the board crate) can query the selected
-//! mode via `kernel::config::CONFIG.vga_mode` and decide whether to route the
-//! `ProcessConsole` to this driver or to the legacy serial mux.
+//! 0xB8000).  It also defines [`VgaMode`] and a `new_text_console` routine
+//! that writes the necessary CRT controller registers for text mode and two
+//! common planar 16-colour modes.  Other code (e.g. the board crate) can query
+//! the selected mode via `kernel::config::CONFIG.vga_mode` and decide whether
+//! to route the `ProcessConsole` to this driver or to the legacy serial mux.
 
 use core::cell::Cell;
 use kernel::utilities::StaticRef;

--- a/kernel/src/hil/keyboard.rs
+++ b/kernel/src/hil/keyboard.rs
@@ -14,7 +14,7 @@ pub trait KeyboardClient {
     /// same as the codes used by Linux to identify different keys.
     /// `is_pressed` is true if the key was pressed, and false if the key was
     /// un-pressed. A list of keycodes can be found here:
-    /// https://manpages.ubuntu.com/manpages/focal/man7/virkeycode-linux.7.html
+    /// <https://manpages.ubuntu.com/manpages/focal/man7/virkeycode-linux.7.html>
     ///
     /// `result` is `Ok(())` if the keys were received correctly.
     fn keys_pressed(&self, keys: &[(u16, bool)], result: Result<(), ErrorCode>);

--- a/kernel/src/hil/screen.rs
+++ b/kernel/src/hil/screen.rs
@@ -101,10 +101,10 @@ pub enum ScreenPixelFormat {
     /// Pixels encoded as 1-bit, used for monochromatic displays.
     ///
     /// The pixel order uses 8-bit (1-byte) pages where each page is displayed
-    /// vertically. That is, buffer[0] bit0 is pixel (0,0), but buffer[0] bit1
-    /// is pixel (0,1). The page continues, so buffer[0] bit 7 is pixel
-    /// (0,7). Then the page advances horizontally, so buffer[1] bit0 is
-    /// pixel (1,0), and buffer[1] bit4 is pixel (1,4).
+    /// vertically. That is, `buffer[0]` bit0 is pixel (0,0), but `buffer[0]`
+    /// bit1 is pixel (0,1). The page continues, so `buffer[0]` bit7 is
+    /// pixel (0,7). Then the page advances horizontally, so `buffer[1]` bit0 is
+    /// pixel (1,0), and `buffer[1]` bit4 is pixel (1,4).
     ///
     /// An example of a screen driver that uses this format is the SSD1306.
     Mono_8BitPage = 6,


### PR DESCRIPTION
### Pull Request Overview

Fix warnings including:

- things that look like markdown links but aren't
- links to private functions
- links to traits in a different crate which is not a dependency
- fix some spelling






### Testing Strategy

Seemingly this is not tested automatically. I ran `cargo doc`.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
