### PR TITLE
kernel/debug: panic_banner: print actual kernel version values

### DIFF
--- a/arch/cortex-m0/src/lib.rs
+++ b/arch/cortex-m0/src/lib.rs
@@ -45,7 +45,6 @@ unsafe extern "C" fn hard_fault_handler_kernel(faulting_stack: *mut u32) -> ! {
 
     panic!(
         "Kernel HardFault.\r\n\
-         \tKernel version {}\r\n\
          \tr0  0x{:x}\r\n\
          \tr1  0x{:x}\r\n\
          \tr2  0x{:x}\r\n\
@@ -55,7 +54,6 @@ unsafe extern "C" fn hard_fault_handler_kernel(faulting_stack: *mut u32) -> ! {
          \tpc  0x{:x}\r\n\
          \txpsr  0x{:x}\r\n\
          ",
-        kernel::TOCK_KERNEL_VERSION,
         hardfault_stacked_registers.r0,
         hardfault_stacked_registers.r1,
         hardfault_stacked_registers.r2,

--- a/arch/cortex-v7m/src/lib.rs
+++ b/arch/cortex-v7m/src/lib.rs
@@ -336,7 +336,6 @@ unsafe extern "C" fn hard_fault_handler_arm_v7m_kernel(
 
         panic!(
             "{} HardFault.\r\n\
-         \tKernel version {}\r\n\
          \tr0  0x{:x}\r\n\
          \tr1  0x{:x}\r\n\
          \tr2  0x{:x}\r\n\
@@ -374,7 +373,6 @@ unsafe extern "C" fn hard_fault_handler_arm_v7m_kernel(
          \tBus Fault Address:       (valid: {}) {:#010X}\r\n\
          ",
             mode_str,
-            kernel::TOCK_KERNEL_VERSION,
             stacked_r0,
             stacked_r1,
             stacked_r2,

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -176,10 +176,22 @@ pub unsafe fn panic_banner<W: Write>(writer: &mut W, panic_info: &PanicInfo) {
     let _ = writer.write_fmt(format_args!("\r\n{}\r\n", panic_info));
 
     // Print version of the kernel
-    let _ = writer.write_fmt(format_args!(
-        "\tKernel version {}\r\n",
-        crate::TOCK_KERNEL_VERSION
-    ));
+    if crate::KERNEL_PRERELEASE_VERSION != 0 {
+        let _ = writer.write_fmt(format_args!(
+            "\tKernel version {}.{}.{}-dev{}\r\n",
+            crate::KERNEL_MAJOR_VERSION,
+            crate::KERNEL_MINOR_VERSION,
+            crate::KERNEL_PATCH_VERSION,
+            crate::KERNEL_PRERELEASE_VERSION,
+        ));
+    } else {
+        let _ = writer.write_fmt(format_args!(
+            "\tKernel version {}.{}.{}\r\n",
+            crate::KERNEL_MAJOR_VERSION,
+            crate::KERNEL_MINOR_VERSION,
+            crate::KERNEL_PATCH_VERSION,
+        ));
+    }
 }
 
 /// Print current machine (CPU) state.

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -150,16 +150,6 @@ static TOCK_ATTRIBUTES_KERNEL_VERSION: TockAttributesKernelVersion = TockAttribu
     tlv_len: 8,
 };
 
-pub static TOCK_KERNEL_VERSION: &str = concat!(
-    stringify!(KERNEL_MAJOR_VERSION),
-    ".",
-    stringify!(KERNEL_MINOR_VERSION),
-    ".",
-    stringify!(KERNEL_PATCH_VERSION),
-    "-",
-    stringify!(KERNEL_PRERELEASE_VERSION),
-);
-
 pub mod capabilities;
 pub mod collections;
 pub mod component;


### PR DESCRIPTION
### Pull Request Overview

Prior to this change, `panic_banner` used to instead print:

    panicked at ./capsules/core/src/process_console.rs:1007:29:
    Process Console forced a kernel panic.
            Kernel version KERNEL_MAJOR_VERSION.KERNEL_MINOR_VERSION.KERNEL_PATCH_VERSION-KERNEL_PRERELEASE_VERSION

This is because `stringify!` only generates string representations of the argument tokens, not their values.

### Testing Strategy

This pull request was tested by manually triggering a kernel panic.


### TODO or Help Wanted

N/A


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
