### PR TITLE
capsules: system: null process printer

### DIFF
--- a/capsules/system/src/process_printer.rs
+++ b/capsules/system/src/process_printer.rs
@@ -250,3 +250,23 @@ fn exceeded_check(size: usize, allocated: usize) -> &'static str {
         "          "
     }
 }
+
+/// A Process Printer that does nothing.
+pub struct ProcessPrinterNull {}
+
+impl ProcessPrinterNull {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl ProcessPrinter for ProcessPrinterNull {
+    fn print_overview(
+        &self,
+        _process: &dyn Process,
+        _writer: &mut dyn BinaryWrite,
+        _context: Option<ProcessPrinterContext>,
+    ) -> Option<ProcessPrinterContext> {
+        None
+    }
+}


### PR DESCRIPTION


### Pull Request Overview

This pull request adds a null process printer for boards that want to print panic state but do not need to print any process state.

This is useful for the switch to `PANIC_RESOURCES` in #4519 for boards that want to print some panic state but do not run processes or do not want to print process debug information. The reason is the `PanicResources` type is templated on `ProcessPrinter`.

```
pub struct PanicResources<C: Chip + 'static, PP: ProcessPrinter + 'static> {
    pub processes: MapCell<&'static [ProcessSlot]>,
    pub chip: MapCell<&'static C>,
    pub printer: MapCell<&'static PP>,
}
```


### Testing Strategy

Building a configuration board in with `PanicResources` templated on it.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
