### PR TITLE
kernel/platform/chip: change `print_state` to take optional `&self`

### DIFF
--- a/chips/apollo3/src/chip.rs
+++ b/chips/apollo3/src/chip.rs
@@ -137,7 +137,7 @@ impl<I: InterruptService + 'static> Chip for Apollo3<I> {
         cortexm4f::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(&self, write: &mut dyn Write) {
+    unsafe fn print_state(_this: Option<&Self>, write: &mut dyn Write) {
         CortexM4F::print_cortexm_state(write);
     }
 }

--- a/chips/arty_e21_chip/src/chip.rs
+++ b/chips/arty_e21_chip/src/chip.rs
@@ -187,7 +187,7 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for ArtyExx<'a, 
         rv32i::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(&self, write: &mut dyn Write) {
+    unsafe fn print_state(_this: Option<&Self>, write: &mut dyn Write) {
         rv32i::print_riscv_state(write);
     }
 }

--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -175,7 +175,7 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for E310x<'a, I>
         rv32i::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(&self, writer: &mut dyn Write) {
+    unsafe fn print_state(_this: Option<&Self>, writer: &mut dyn Write) {
         rv32i::print_riscv_state(writer);
     }
 }

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -312,13 +312,15 @@ impl<
         rv32i::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(&self, writer: &mut dyn Write) {
+    unsafe fn print_state(this: Option<&Self>, writer: &mut dyn Write) {
         let _ = writer.write_fmt(format_args!(
             "\r\n---| OpenTitan Earlgrey configuration for {} |---",
             CFG::NAME
         ));
         rv32i::print_riscv_state(writer);
-        let _ = writer.write_fmt(format_args!("{}", self.mpu.pmp));
+        if let Some(t) = this {
+            let _ = writer.write_fmt(format_args!("{}", t.mpu.pmp));
+        }
     }
 }
 

--- a/chips/esp32-c3/src/chip.rs
+++ b/chips/esp32-c3/src/chip.rs
@@ -154,7 +154,7 @@ impl<'a, I: InterruptService + 'a> Chip for Esp32C3<'a, I> {
         rv32i::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(&self, writer: &mut dyn Write) {
+    unsafe fn print_state(_this: Option<&Self>, writer: &mut dyn Write) {
         let mcval: csr::mcause::Trap = core::convert::From::from(csr::CSR.mcause.extract());
         let _ = writer.write_fmt(format_args!("\r\n---| RISC-V Machine State |---\r\n"));
         let _ = writer.write_fmt(format_args!("Last cause (mcause): "));

--- a/chips/imxrt10xx/src/chip.rs
+++ b/chips/imxrt10xx/src/chip.rs
@@ -145,7 +145,7 @@ impl<I: InterruptService + 'static> Chip for Imxrt10xx<I> {
         cortexm7::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(&self, write: &mut dyn Write) {
+    unsafe fn print_state(_this: Option<&Self>, write: &mut dyn Write) {
         CortexM7::print_cortexm_state(write);
     }
 }

--- a/chips/litex_vexriscv/src/chip.rs
+++ b/chips/litex_vexriscv/src/chip.rs
@@ -102,13 +102,16 @@ impl<I: 'static + InterruptService> kernel::platform::chip::Chip for LiteXVexRis
         rv32i::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(&self, writer: &mut dyn Write) {
+    unsafe fn print_state(this: Option<&Self>, writer: &mut dyn Write) {
         let _ = writer.write_fmt(format_args!(
             "\r\n---| LiteX configuration for {} |---",
-            self.soc_identifier,
+            this.map_or("unknown board (in trap handler thread)", |t| t
+                .soc_identifier),
         ));
         rv32i::print_riscv_state(writer);
-        let _ = writer.write_fmt(format_args!("{}", self.pmp_mpu.pmp));
+        if let Some(t) = this {
+            let _ = writer.write_fmt(format_args!("{}", t.pmp_mpu.pmp));
+        }
     }
 }
 

--- a/chips/msp432/src/chip.rs
+++ b/chips/msp432/src/chip.rs
@@ -148,7 +148,7 @@ impl<'a, I: InterruptService + 'a> Chip for Msp432<'a, I> {
         cortexm4::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(&self, write: &mut dyn Write) {
+    unsafe fn print_state(_this: Option<&Self>, write: &mut dyn Write) {
         CortexM4::print_cortexm_state(write);
     }
 }

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -147,7 +147,7 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for NRF52<'a, I>
         cortexm4f::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(&self, write: &mut dyn Write) {
+    unsafe fn print_state(_this: Option<&Self>, write: &mut dyn Write) {
         CortexM4F::print_cortexm_state(write);
     }
 }

--- a/chips/psoc62xa/src/chip.rs
+++ b/chips/psoc62xa/src/chip.rs
@@ -46,7 +46,7 @@ impl<I: InterruptService> Chip for Psoc62xa<'_, I> {
         cortexm0p::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(&self, writer: &mut dyn core::fmt::Write) {
+    unsafe fn print_state(_this: Option<&Self>, writer: &mut dyn core::fmt::Write) {
         CortexM0P::print_cortexm_state(writer);
     }
 

--- a/chips/qemu_rv32_virt_chip/src/chip.rs
+++ b/chips/qemu_rv32_virt_chip/src/chip.rs
@@ -174,9 +174,11 @@ impl<'a, I: InterruptService + 'a> Chip for QemuRv32VirtChip<'a, I> {
         rv32i::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(&self, writer: &mut dyn Write) {
+    unsafe fn print_state(this: Option<&Self>, writer: &mut dyn Write) {
         rv32i::print_riscv_state(writer);
-        let _ = writer.write_fmt(format_args!("{}", self.pmp.pmp));
+        if let Some(t) = this {
+            let _ = writer.write_fmt(format_args!("{}", t.pmp.pmp));
+        }
     }
 }
 

--- a/chips/rp2040/src/chip.rs
+++ b/chips/rp2040/src/chip.rs
@@ -111,7 +111,7 @@ impl<I: InterruptService> Chip for Rp2040<'_, I> {
         cortexm0p::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(&self, writer: &mut dyn Write) {
+    unsafe fn print_state(_this: Option<&Self>, writer: &mut dyn Write) {
         CortexM0P::print_cortexm_state(writer);
     }
 }

--- a/chips/rp2350/src/chip.rs
+++ b/chips/rp2350/src/chip.rs
@@ -100,7 +100,7 @@ impl<I: InterruptService> Chip for Rp2350<'_, I> {
         cortexm33::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(&self, writer: &mut dyn Write) {
+    unsafe fn print_state(_this: Option<&Self>, writer: &mut dyn Write) {
         CortexM33::print_cortexm_state(writer);
     }
 }

--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -289,7 +289,7 @@ impl<I: InterruptService + 'static> Chip for Sam4l<I> {
         cortexm4::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(&self, writer: &mut dyn Write) {
+    unsafe fn print_state(_this: Option<&Self>, writer: &mut dyn Write) {
         CortexM4::print_cortexm_state(writer);
     }
 }

--- a/chips/stm32f303xc/src/chip.rs
+++ b/chips/stm32f303xc/src/chip.rs
@@ -145,7 +145,7 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32f3xx<'a, I> {
         cortexm4f::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(&self, write: &mut dyn Write) {
+    unsafe fn print_state(_this: Option<&Self>, write: &mut dyn Write) {
         CortexM4F::print_cortexm_state(write);
     }
 }

--- a/chips/stm32f4xx/src/chip.rs
+++ b/chips/stm32f4xx/src/chip.rs
@@ -207,7 +207,7 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32f4xx<'a, I> {
         cortexm4f::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(&self, write: &mut dyn Write) {
+    unsafe fn print_state(_this: Option<&Self>, write: &mut dyn Write) {
         CortexM4F::print_cortexm_state(write);
     }
 }

--- a/chips/veer_el2/src/chip.rs
+++ b/chips/veer_el2/src/chip.rs
@@ -146,7 +146,7 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for VeeR<'a, I> 
         rv32i::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(&self, writer: &mut dyn Write) {
+    unsafe fn print_state(_this: Option<&Self>, writer: &mut dyn Write) {
         rv32i::print_riscv_state(writer);
     }
 }

--- a/chips/x86_q35/src/chip.rs
+++ b/chips/x86_q35/src/chip.rs
@@ -185,7 +185,7 @@ impl<'a, I: InterruptService + 'a, const PR: u16> Chip for Pc<'a, I, PR> {
         support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(&self, writer: &mut dyn Write) {
+    unsafe fn print_state(_this: Option<&Self>, writer: &mut dyn Write) {
         let _ = writeln!(writer);
         let _ = writeln!(writer, "---| PC State |---");
         let _ = writeln!(writer);

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -201,9 +201,7 @@ pub unsafe fn panic_cpu_state<W: Write, C: Chip>(
     chip: &'static Option<&'static C>,
     writer: &mut W,
 ) {
-    chip.map(|c| {
-        c.print_state(writer);
-    });
+    C::print_state(*chip, writer);
 }
 
 /// More detailed prints about all processes.

--- a/kernel/src/platform/chip.rs
+++ b/kernel/src/platform/chip.rs
@@ -61,17 +61,19 @@ pub trait Chip {
     where
         F: FnOnce() -> R;
 
-    /// Print out chip state (system registers) to a supplied
-    /// writer. This does not print out the execution context
-    /// (data registers), as this depends on how they are stored;
-    /// that is implemented by
-    /// `syscall::UserspaceKernelBoundary::print_context`.
-    /// This also does not print out a process memory state,
-    /// that is implemented by `process::Process::print_memory_map`.
-    /// The MPU state is printed by the MPU's implementation of
-    /// the Display trait.
-    /// Used by panic.
-    unsafe fn print_state(&self, writer: &mut dyn Write);
+    /// Print out debug information about the current chip state (system
+    /// registers, MPU configuration, etc.) to a supplied writer.
+    ///
+    /// This function may be called across thread boundaries (such as from a
+    /// panic handler). As implementors of `Chip` do not have to be `Send` or
+    /// `Sync`, `&self` may not be available in these contexts. Therefore, this
+    /// function instead accepts an `Option<&Self>` parameter named `this`. In
+    /// contexts where `&self` is available, callers should invoke this function
+    /// by passing `Some(&self)` to `this`. Otherwise, `this` will be set to
+    /// `None`. The implementation of `print_state` may not print certain
+    /// information if it depends on runtime-accessible state in `Self`, but
+    /// that reference is not provided.
+    unsafe fn print_state(this: Option<&Self>, writer: &mut dyn Write);
 }
 
 /// Interface for retrieving the currently executing thread.


### PR DESCRIPTION
### Pull Request Overview

The changes in tock/tock#4519 mean that a reference to the `Chip` instance is no longer available in panic contexts invoked from within a trap handler. However, especially in these cases it is vital to get some basic information about the chip's state: what execution context are we in, what are the register contents, ...

If `print_state` requires an `&self` reference, then this function is not callable in those contexts. Conversely, if it didn't take `&self`, it would mean that panic messages can only include state that can be recovered from CPU registers. This, for example, excludes certain PMP state useful to debug memory-protection related issues.

This PR implements tries to strike a tradeoff: in contexts where the `Chip` instance is available, it can be used to print useful software-state, in addition to CPU register state. Otherwise, `print_state` falls back to just printing CPU register state.

Without this change, trap-handler panics in tock/tock#4519 (such as because of kernel stack overflows, hard faults, or unhandled interrupts) will not print any useful CPU state information.


### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

N/A


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
