### PR TITLE
chips: nrf52: acomp: remove static mut

### DIFF
--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -407,11 +407,15 @@ pub unsafe fn start() -> (
 
     // Initialize AC using AIN5 (P0.29) as VIN+ and VIN- as AIN0 (P0.02)
     // These are hardcoded pin assignments specified in the driver
+    let analog_comparator_channel = static_init!(
+        nrf52840::acomp::Channel,
+        nrf52840::acomp::Channel::new(nrf52840::acomp::ChannelNumber::AC0)
+    );
     let analog_comparator = components::analog_comparator::AnalogComparatorComponent::new(
         &base_peripherals.acomp,
         components::analog_comparator_component_helper!(
             nrf52840::acomp::Channel,
-            &*addr_of!(nrf52840::acomp::CHANNEL_AC0)
+            analog_comparator_channel,
         ),
         board_kernel,
         capsules_extra::analog_comparator::DRIVER_NUM,

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -819,11 +819,15 @@ pub unsafe fn start_no_pconsole() -> (
 
     // Initialize AC using AIN5 (P0.29) as VIN+ and VIN- as AIN0 (P0.02)
     // These are hardcoded pin assignments specified in the driver
+    let analog_comparator_channel = static_init!(
+        nrf52840::acomp::Channel,
+        nrf52840::acomp::Channel::new(nrf52840::acomp::ChannelNumber::AC0)
+    );
     let analog_comparator = components::analog_comparator::AnalogComparatorComponent::new(
         &base_peripherals.acomp,
         components::analog_comparator_component_helper!(
             nrf52840::acomp::Channel,
-            &*addr_of!(nrf52840::acomp::CHANNEL_AC0)
+            analog_comparator_channel
         ),
         board_kernel,
         capsules_extra::analog_comparator::DRIVER_NUM,

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -430,11 +430,15 @@ pub unsafe fn start() -> (
 
     // Initialize AC using AIN5 (P0.29) as VIN+ and VIN- as AIN0 (P0.02)
     // These are hardcoded pin assignments specified in the driver
+    let analog_comparator_channel = static_init!(
+        nrf52832::acomp::Channel,
+        nrf52832::acomp::Channel::new(nrf52832::acomp::ChannelNumber::AC0)
+    );
     let analog_comparator = components::analog_comparator::AnalogComparatorComponent::new(
         &base_peripherals.acomp,
         components::analog_comparator_component_helper!(
             nrf52832::acomp::Channel,
-            &*addr_of!(nrf52832::acomp::CHANNEL_AC0)
+            analog_comparator_channel,
         ),
         board_kernel,
         capsules_extra::analog_comparator::DRIVER_NUM,

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -418,11 +418,15 @@ pub unsafe fn start() -> (
 
     // Initialize AC using AIN5 (P0.29) as VIN+ and VIN- as AIN0 (P0.02)
     // These are hardcoded pin assignments specified in the driver
+    let analog_comparator_channel = static_init!(
+        nrf52840::acomp::Channel,
+        nrf52840::acomp::Channel::new(nrf52840::acomp::ChannelNumber::AC0)
+    );
     let analog_comparator = components::analog_comparator::AnalogComparatorComponent::new(
         &base_peripherals.acomp,
         components::analog_comparator_component_helper!(
             nrf52840::acomp::Channel,
-            &*addr_of!(nrf52840::acomp::CHANNEL_AC0)
+            analog_comparator_channel,
         ),
         board_kernel,
         capsules_extra::analog_comparator::DRIVER_NUM,

--- a/chips/nrf52/src/acomp.rs
+++ b/chips/nrf52/src/acomp.rs
@@ -33,6 +33,13 @@ use kernel::utilities::registers::{
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 
+/// Only one channel
+#[derive(Copy, Clone, Debug)]
+#[repr(u8)]
+pub enum ChannelNumber {
+    AC0 = 0x00,
+}
+
 /// Analog comparator channels.
 ///
 /// The nrf52840 only has one analog comparator, so it does need channels
@@ -44,27 +51,17 @@ pub struct Channel {
     _chan_num: u32,
 }
 
-/// Only one channel
-#[derive(Copy, Clone, Debug)]
-#[repr(u8)]
-enum ChannelNumber {
-    AC0 = 0x00,
-}
-
 /// Initialization of an AC channel.
 impl Channel {
     /// Create a new AC channel.
     ///
     /// - `channel`: Channel enum representing the channel number
-    const fn new(channel: ChannelNumber) -> Channel {
+    pub const fn new(channel: ChannelNumber) -> Channel {
         Channel {
             _chan_num: (channel as u32) & 0x0F,
         }
     }
 }
-
-/// Uses only comparator, with VIN+=AIN5 and VIN-=AIN0
-pub static mut CHANNEL_AC0: Channel = Channel::new(ChannelNumber::AC0);
 
 register_structs! {
     CompRegisters {


### PR DESCRIPTION
### Pull Request Overview

Removes a `static mut` from the nrf52 crate. Rather than create the variable in the chip crate, just create it in the board.


### Testing Strategy

travis i suppose


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
