### PR TITLE
chips: nrf5x: forbid unsafe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1064,6 +1064,15 @@ dependencies = [
  "cortexm4f",
  "enum_primitive",
  "kernel",
+ "nrf5x-unsafe",
+]
+
+[[package]]
+name = "nrf5x-unsafe"
+version = "0.2.3-dev"
+dependencies = [
+ "cortexm4f",
+ "kernel",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1061,7 +1061,6 @@ dependencies = [
 name = "nrf5x"
 version = "0.2.3-dev"
 dependencies = [
- "cortexm4f",
  "enum_primitive",
  "kernel",
  "nrf5x-unsafe",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1061,6 +1061,7 @@ dependencies = [
 name = "nrf5x"
 version = "0.2.3-dev"
 dependencies = [
+ "cortexm4f",
  "enum_primitive",
  "kernel",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ members = [
     "chips/nrf52833",
     "chips/nrf52840",
     "chips/nrf5x",
+    "chips/nrf5x-unsafe",
     "chips/pci-x86",
     "chips/x86_q35",
     "chips/qemu_rv32_virt_chip",

--- a/boards/clue_nrf52840/src/io.rs
+++ b/boards/clue_nrf52840/src/io.rs
@@ -125,7 +125,11 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P1_01);
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
+        Pin::P1_01,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT1,
+    );
     let led = &mut led::LedHigh::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
     debug::panic_old(

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -290,10 +290,11 @@ unsafe fn start() -> (
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
     );
 
     // set up circular peripheral dependencies

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -443,7 +443,7 @@ unsafe fn start() -> (
         capsules_core::virtualizers::virtual_pwm::PwmPinUser<'static, nrf52840::pwm::Pwm>,
         capsules_core::virtualizers::virtual_pwm::PwmPinUser::new(
             mux_pwm,
-            nrf52840::pinmux::Pinmux::new(SPEAKER_PIN)
+            nrf52840::pinmux::Pinmux::from_pin(SPEAKER_PIN)
         )
     );
     virtual_pwm_buzzer.add_to_mux();
@@ -628,8 +628,8 @@ unsafe fn start() -> (
     );
     kernel::deferred_call::DeferredCallClient::register(sensors_i2c_bus);
     base_peripherals.twi1.configure(
-        nrf52840::pinmux::Pinmux::new(I2C_SCL_PIN),
-        nrf52840::pinmux::Pinmux::new(I2C_SDA_PIN),
+        nrf52840::pinmux::Pinmux::from_pin(I2C_SCL_PIN),
+        nrf52840::pinmux::Pinmux::from_pin(I2C_SDA_PIN),
     );
     base_peripherals.twi1.set_master_client(sensors_i2c_bus);
 
@@ -678,9 +678,9 @@ unsafe fn start() -> (
         .finalize(components::spi_mux_component_static!(nrf52840::spi::SPIM));
 
     base_peripherals.spim0.configure(
-        nrf52840::pinmux::Pinmux::new(ST7789H2_MOSI),
-        nrf52840::pinmux::Pinmux::new(ST7789H2_MISO),
-        nrf52840::pinmux::Pinmux::new(ST7789H2_SCK),
+        nrf52840::pinmux::Pinmux::from_pin(ST7789H2_MOSI),
+        nrf52840::pinmux::Pinmux::from_pin(ST7789H2_MISO),
+        nrf52840::pinmux::Pinmux::from_pin(ST7789H2_SCK),
     );
 
     let bus = components::bus::SpiMasterBusComponent::new(

--- a/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/io.rs
+++ b/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/io.rs
@@ -73,7 +73,11 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // MicroBit v2 has a microphone LED, use it for panic
 
     use core::ptr::addr_of_mut;
-    let led_kernel_pin = &nrf52833::gpio::GPIOPin::new(Pin::P0_20);
+    let led_kernel_pin = &nrf52833::gpio::GPIOPin::new(
+        Pin::P0_20,
+        nrf52833::gpio::GPIOTE_BASE,
+        nrf52833::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
     debug::panic_old(

--- a/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
@@ -250,10 +250,11 @@ unsafe fn start() -> (
         [u8; nrf52833::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52833::ieee802154_radio::ACK_BUF_SIZE]
     );
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
     // Initialize chip peripheral drivers
     let nrf52833_peripherals = static_init!(
         Nrf52833DefaultPeripherals,
-        Nrf52833DefaultPeripherals::new(ieee802154_ack_buf)
+        Nrf52833DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
     );
 
     // set up circular peripheral dependencies

--- a/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
@@ -391,7 +391,7 @@ unsafe fn start() -> (
 
     let virtual_pwm_buzzer = components::pwm::PwmPinUserComponent::new(
         mux_pwm,
-        nrf52833::pinmux::Pinmux::new(SPEAKER_PIN),
+        nrf52833::pinmux::Pinmux::from_pin(SPEAKER_PIN),
     )
     .finalize(components::pwm_pin_user_component_static!(
         nrf52833::pwm::Pwm
@@ -445,11 +445,13 @@ unsafe fn start() -> (
 
     virtual_alarm_buzzer.set_alarm_client(pwm_buzzer);
 
-    let virtual_pwm_driver =
-        components::pwm::PwmPinUserComponent::new(mux_pwm, nrf52833::pinmux::Pinmux::new(GPIO_P8))
-            .finalize(components::pwm_pin_user_component_static!(
-                nrf52833::pwm::Pwm
-            ));
+    let virtual_pwm_driver = components::pwm::PwmPinUserComponent::new(
+        mux_pwm,
+        nrf52833::pinmux::Pinmux::from_pin(GPIO_P8),
+    )
+    .finalize(components::pwm_pin_user_component_static!(
+        nrf52833::pwm::Pwm
+    ));
 
     let pwm =
         components::pwm::PwmDriverComponent::new(board_kernel, capsules_extra::pwm::DRIVER_NUM)
@@ -460,8 +462,8 @@ unsafe fn start() -> (
     //--------------------------------------------------------------------------
 
     base_peripherals.uarte0.initialize(
-        nrf52::pinmux::Pinmux::new(UART_TX_PIN),
-        nrf52::pinmux::Pinmux::new(UART_RX_PIN),
+        nrf52::pinmux::Pinmux::from_pin(UART_TX_PIN),
+        nrf52::pinmux::Pinmux::from_pin(UART_RX_PIN),
         None,
         None,
     );
@@ -502,8 +504,8 @@ unsafe fn start() -> (
     //--------------------------------------------------------------------------
 
     base_peripherals.twi1.configure(
-        nrf52833::pinmux::Pinmux::new(I2C_SCL_PIN),
-        nrf52833::pinmux::Pinmux::new(I2C_SDA_PIN),
+        nrf52833::pinmux::Pinmux::from_pin(I2C_SCL_PIN),
+        nrf52833::pinmux::Pinmux::from_pin(I2C_SDA_PIN),
     );
 
     let sensors_i2c_bus = components::i2c::I2CMuxComponent::new(&base_peripherals.twi1, None)

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/src/io.rs
@@ -10,7 +10,11 @@ use nrf52840::gpio::Pin;
 /// Panic handler
 pub unsafe fn panic_fmt(_pi: &PanicInfo) -> ! {
     // The nRF52840DK LEDs (see back of board)
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
+        Pin::P0_13,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut kernel::hil::led::LedLow::new(led_kernel_pin);
     kernel::debug::panic_blink_forever(&mut [led])
 }

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/src/main.rs
@@ -100,10 +100,11 @@ unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'stati
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
     );
 
     nrf52840_peripherals

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-sha256/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-sha256/src/io.rs
@@ -10,7 +10,11 @@ use nrf52840::gpio::Pin;
 /// Panic handler
 pub unsafe fn panic_fmt(_pi: &PanicInfo) -> ! {
     // The nRF52840DK LEDs (see back of board)
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
+        Pin::P0_13,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut kernel::hil::led::LedLow::new(led_kernel_pin);
     kernel::debug::panic_blink_forever(&mut [led])
 }

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-sha256/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-sha256/src/main.rs
@@ -89,10 +89,11 @@ unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'stati
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
     );
 
     nrf52840_peripherals

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/io.rs
@@ -10,7 +10,11 @@ use nrf52840::gpio::Pin;
 /// Panic handler
 pub unsafe fn panic_fmt(_pi: &PanicInfo) -> ! {
     // The nRF52840DK LEDs (see back of board)
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
+        Pin::P0_13,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut kernel::hil::led::LedLow::new(led_kernel_pin);
     kernel::debug::panic_blink_forever(&mut [led])
 }

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/main.rs
@@ -91,10 +91,11 @@ unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'stati
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
     );
 
     nrf52840_peripherals

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/io.rs
@@ -62,7 +62,11 @@ pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {
     use nrf52840::gpio::Pin;
 
     // The nRF52840DK LEDs (see back of board)
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
+        Pin::P0_13,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut led::LedLow::new(led_kernel_pin);
     let mut writer = Writer::new();
     debug::panic_old(

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
@@ -122,10 +122,11 @@ unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'stati
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
     );
 
     nrf52840_peripherals

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-invs/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-invs/src/io.rs
@@ -10,7 +10,11 @@ use nrf52840::gpio::Pin;
 /// Panic handler
 pub unsafe fn panic_fmt(_pi: &PanicInfo) -> ! {
     // The nRF52840DK LEDs (see back of board)
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
+        Pin::P0_13,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut kernel::hil::led::LedLow::new(led_kernel_pin);
     kernel::debug::panic_blink_forever(&mut [led])
 }

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-invs/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-invs/src/main.rs
@@ -112,10 +112,11 @@ unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'stati
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
     );
 
     nrf52840_peripherals

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-invs/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-invs/src/main.rs
@@ -276,9 +276,9 @@ pub unsafe fn main() {
         .finalize(components::spi_mux_component_static!(nrf52840::spi::SPIM));
 
     base_peripherals.spim0.configure(
-        nrf52840::pinmux::Pinmux::new(SPI_MOSI),
-        nrf52840::pinmux::Pinmux::new(SPI_MISO),
-        nrf52840::pinmux::Pinmux::new(SPI_CLK),
+        nrf52840::pinmux::Pinmux::from_pin(SPI_MOSI),
+        nrf52840::pinmux::Pinmux::from_pin(SPI_MISO),
+        nrf52840::pinmux::Pinmux::from_pin(SPI_CLK),
     );
 
     let mx25r6435f = components::mx25r6435f::Mx25r6435fComponent::new(

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/io.rs
@@ -62,7 +62,11 @@ pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {
     use nrf52840::gpio::Pin;
 
     // The nRF52840DK LEDs (see back of board)
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
+        Pin::P0_13,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut led::LedLow::new(led_kernel_pin);
     let mut writer = Writer::new();
     debug::panic_old(

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/main.rs
@@ -113,10 +113,11 @@ unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'stati
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
     );
 
     nrf52840_peripherals

--- a/boards/makepython-nrf52840/src/io.rs
+++ b/boards/makepython-nrf52840/src/io.rs
@@ -123,7 +123,11 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P1_10);
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
+        Pin::P1_10,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
     debug::panic_old(

--- a/boards/makepython-nrf52840/src/main.rs
+++ b/boards/makepython-nrf52840/src/main.rs
@@ -244,11 +244,12 @@ pub unsafe fn start() -> (
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
 
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
     );
 
     // set up circular peripheral dependencies

--- a/boards/makepython-nrf52840/src/main.rs
+++ b/boards/makepython-nrf52840/src/main.rs
@@ -530,8 +530,8 @@ pub unsafe fn start() -> (
     let i2c_bus = components::i2c::I2CMuxComponent::new(&base_peripherals.twi1, None)
         .finalize(components::i2c_mux_component_static!(nrf52840::i2c::TWI));
     base_peripherals.twi1.configure(
-        nrf52840::pinmux::Pinmux::new(I2C_SCL_PIN),
-        nrf52840::pinmux::Pinmux::new(I2C_SDA_PIN),
+        nrf52840::pinmux::Pinmux::from_pin(I2C_SCL_PIN),
+        nrf52840::pinmux::Pinmux::from_pin(I2C_SDA_PIN),
     );
 
     // I2C address is b011110X, and on this board D/C̅ is GND.

--- a/boards/microbit_v2/src/io.rs
+++ b/boards/microbit_v2/src/io.rs
@@ -73,7 +73,11 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // MicroBit v2 has a microphone LED, use it for panic
 
     use core::ptr::addr_of_mut;
-    let led_kernel_pin = &nrf52833::gpio::GPIOPin::new(Pin::P0_20);
+    let led_kernel_pin = &nrf52833::gpio::GPIOPin::new(
+        Pin::P0_20,
+        nrf52833::gpio::GPIOTE_BASE,
+        nrf52833::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
     debug::panic_old(

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -238,10 +238,11 @@ unsafe fn start() -> (
         [u8; nrf52833::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52833::ieee802154_radio::ACK_BUF_SIZE]
     );
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
     // Initialize chip peripheral drivers
     let nrf52833_peripherals = static_init!(
         Nrf52833DefaultPeripherals,
-        Nrf52833DefaultPeripherals::new(ieee802154_ack_buf)
+        Nrf52833DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
     );
 
     // set up circular peripheral dependencies

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -381,7 +381,7 @@ unsafe fn start() -> (
 
     let virtual_pwm_buzzer = components::pwm::PwmPinUserComponent::new(
         mux_pwm,
-        nrf52833::pinmux::Pinmux::new(SPEAKER_PIN),
+        nrf52833::pinmux::Pinmux::from_pin(SPEAKER_PIN),
     )
     .finalize(components::pwm_pin_user_component_static!(
         nrf52833::pwm::Pwm
@@ -435,11 +435,13 @@ unsafe fn start() -> (
 
     virtual_alarm_buzzer.set_alarm_client(pwm_buzzer);
 
-    let virtual_pwm_driver =
-        components::pwm::PwmPinUserComponent::new(mux_pwm, nrf52833::pinmux::Pinmux::new(GPIO_P8))
-            .finalize(components::pwm_pin_user_component_static!(
-                nrf52833::pwm::Pwm
-            ));
+    let virtual_pwm_driver = components::pwm::PwmPinUserComponent::new(
+        mux_pwm,
+        nrf52833::pinmux::Pinmux::from_pin(GPIO_P8),
+    )
+    .finalize(components::pwm_pin_user_component_static!(
+        nrf52833::pwm::Pwm
+    ));
 
     let pwm =
         components::pwm::PwmDriverComponent::new(board_kernel, capsules_extra::pwm::DRIVER_NUM)
@@ -450,8 +452,8 @@ unsafe fn start() -> (
     //--------------------------------------------------------------------------
 
     base_peripherals.uarte0.initialize(
-        nrf52::pinmux::Pinmux::new(UART_TX_PIN),
-        nrf52::pinmux::Pinmux::new(UART_RX_PIN),
+        nrf52::pinmux::Pinmux::from_pin(UART_TX_PIN),
+        nrf52::pinmux::Pinmux::from_pin(UART_RX_PIN),
         None,
         None,
     );
@@ -492,8 +494,8 @@ unsafe fn start() -> (
     //--------------------------------------------------------------------------
 
     base_peripherals.twi1.configure(
-        nrf52833::pinmux::Pinmux::new(I2C_SCL_PIN),
-        nrf52833::pinmux::Pinmux::new(I2C_SDA_PIN),
+        nrf52833::pinmux::Pinmux::from_pin(I2C_SCL_PIN),
+        nrf52833::pinmux::Pinmux::from_pin(I2C_SDA_PIN),
     );
 
     let sensors_i2c_bus = components::i2c::I2CMuxComponent::new(&base_peripherals.twi1, None)

--- a/boards/nano33ble/src/io.rs
+++ b/boards/nano33ble/src/io.rs
@@ -125,7 +125,11 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
+        Pin::P0_13,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
     debug::panic_old(

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -261,11 +261,12 @@ pub unsafe fn start() -> (
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
 
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
     );
 
     // set up circular peripheral dependencies

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -518,8 +518,8 @@ pub unsafe fn start() -> (
     let sensors_i2c_bus = components::i2c::I2CMuxComponent::new(&base_peripherals.twi1, None)
         .finalize(components::i2c_mux_component_static!(nrf52840::i2c::TWI));
     base_peripherals.twi1.configure(
-        nrf52840::pinmux::Pinmux::new(I2C_SCL_PIN),
-        nrf52840::pinmux::Pinmux::new(I2C_SDA_PIN),
+        nrf52840::pinmux::Pinmux::from_pin(I2C_SCL_PIN),
+        nrf52840::pinmux::Pinmux::from_pin(I2C_SDA_PIN),
     );
 
     nrf52840_peripherals.gpio_port[I2C_PULLUP_PIN].make_output();

--- a/boards/nano33ble/src/test/log_test.rs
+++ b/boards/nano33ble/src/test/log_test.rs
@@ -84,7 +84,11 @@ pub unsafe fn run(mux_alarm: &'static MuxAlarm<'static, Rtc>, flash_controller: 
     test.alarm.set_alarm_client(test);
 
     // Configure GPIO pin P1.08 as the log erase pin.
-    let log_erase_pin = GPIOPin::new(Pin::P1_08);
+    let log_erase_pin = GPIOPin::new(
+        Pin::P1_08,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT1,
+    );
     log_erase_pin.enable_interrupts(InterruptEdge::RisingEdge);
     log_erase_pin.set_client(test);
 

--- a/boards/nano33ble_rev2/src/io.rs
+++ b/boards/nano33ble_rev2/src/io.rs
@@ -126,7 +126,11 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
+        Pin::P0_13,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
     debug::panic_old(

--- a/boards/nano33ble_rev2/src/main.rs
+++ b/boards/nano33ble_rev2/src/main.rs
@@ -270,11 +270,12 @@ pub unsafe fn start() -> (
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
 
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
     );
 
     // set up circular peripheral dependencies

--- a/boards/nano33ble_rev2/src/main.rs
+++ b/boards/nano33ble_rev2/src/main.rs
@@ -527,8 +527,8 @@ pub unsafe fn start() -> (
     let sensors_i2c_bus = components::i2c::I2CMuxComponent::new(&base_peripherals.twi1, None)
         .finalize(components::i2c_mux_component_static!(nrf52840::i2c::TWI));
     base_peripherals.twi1.configure(
-        nrf52840::pinmux::Pinmux::new(I2C_SCL_PIN),
-        nrf52840::pinmux::Pinmux::new(I2C_SDA_PIN),
+        nrf52840::pinmux::Pinmux::from_pin(I2C_SCL_PIN),
+        nrf52840::pinmux::Pinmux::from_pin(I2C_SDA_PIN),
     );
 
     let _ = &nrf52840_peripherals.gpio_port[I2C_PULLUP_PIN].make_output();

--- a/boards/nordic/nrf52840_dongle/src/io.rs
+++ b/boards/nordic/nrf52840_dongle/src/io.rs
@@ -57,7 +57,11 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // The nRF52840 Dongle LEDs (see back of board)
 
     use core::ptr::addr_of_mut;
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_06);
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
+        Pin::P0_06,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
     debug::panic_old(

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -208,10 +208,11 @@ pub unsafe fn start() -> (
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
     );
 
     // set up circular peripheral dependencies

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -13,7 +13,11 @@ use nrf52840::gpio::Pin;
 /// Panic handler
 pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {
     // The nRF52840DK LEDs (see back of board)
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
+        Pin::P0_13,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut led::LedLow::new(led_kernel_pin);
 
     if crate::USB_DEBUGGING {

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -436,10 +436,11 @@ pub unsafe fn start_no_pconsole() -> (
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
     );
 
     // Set up circular peripheral dependencies.

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -749,9 +749,9 @@ pub unsafe fn start_no_pconsole() -> (
     ));
 
     base_peripherals.spim0.configure(
-        nrf52840::pinmux::Pinmux::new(SPI_MOSI),
-        nrf52840::pinmux::Pinmux::new(SPI_MISO),
-        nrf52840::pinmux::Pinmux::new(SPI_CLK),
+        nrf52840::pinmux::Pinmux::from_pin(SPI_MOSI),
+        nrf52840::pinmux::Pinmux::from_pin(SPI_MISO),
+        nrf52840::pinmux::Pinmux::from_pin(SPI_CLK),
     );
 
     //--------------------------------------------------------------------------
@@ -846,8 +846,8 @@ pub unsafe fn start_no_pconsole() -> (
     ));
 
     base_peripherals.twi1.configure(
-        nrf52840::pinmux::Pinmux::new(I2C_SCL_PIN),
-        nrf52840::pinmux::Pinmux::new(I2C_SDA_PIN),
+        nrf52840::pinmux::Pinmux::from_pin(I2C_SCL_PIN),
+        nrf52840::pinmux::Pinmux::from_pin(I2C_SDA_PIN),
     );
     base_peripherals.twi1.set_speed(nrf52840::i2c::Speed::K400);
 

--- a/boards/nordic/nrf52_components/src/startup.rs
+++ b/boards/nordic/nrf52_components/src/startup.rs
@@ -219,10 +219,10 @@ impl Component for UartChannelComponent {
             UartChannel::Pins(uart_pins) => {
                 unsafe {
                     self.uarte0.initialize(
-                        nrf52::pinmux::Pinmux::new(uart_pins.txd),
-                        nrf52::pinmux::Pinmux::new(uart_pins.rxd),
-                        uart_pins.cts.map(|x| nrf52::pinmux::Pinmux::new(x)),
-                        uart_pins.rts.map(|x| nrf52::pinmux::Pinmux::new(x)),
+                        nrf52::pinmux::Pinmux::new(uart_pins.txd as u32),
+                        nrf52::pinmux::Pinmux::new(uart_pins.rxd as u32),
+                        uart_pins.cts.map(|x| nrf52::pinmux::Pinmux::new(x as u32)),
+                        uart_pins.rts.map(|x| nrf52::pinmux::Pinmux::new(x as u32)),
                     )
                 };
                 self.uarte0

--- a/boards/nordic/nrf52_components/src/startup.rs
+++ b/boards/nordic/nrf52_components/src/startup.rs
@@ -217,14 +217,12 @@ impl Component for UartChannelComponent {
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
         match self.uart_channel {
             UartChannel::Pins(uart_pins) => {
-                unsafe {
-                    self.uarte0.initialize(
-                        nrf52::pinmux::Pinmux::new(uart_pins.txd as u32),
-                        nrf52::pinmux::Pinmux::new(uart_pins.rxd as u32),
-                        uart_pins.cts.map(|x| nrf52::pinmux::Pinmux::new(x as u32)),
-                        uart_pins.rts.map(|x| nrf52::pinmux::Pinmux::new(x as u32)),
-                    )
-                };
+                self.uarte0.initialize(
+                    nrf52::pinmux::Pinmux::from_pin(uart_pins.txd),
+                    nrf52::pinmux::Pinmux::from_pin(uart_pins.rxd),
+                    uart_pins.cts.map(nrf52::pinmux::Pinmux::from_pin),
+                    uart_pins.rts.map(nrf52::pinmux::Pinmux::from_pin),
+                );
                 self.uarte0
             }
             UartChannel::Rtt(rtt_memory) => {

--- a/boards/nordic/nrf52dk/src/io.rs
+++ b/boards/nordic/nrf52dk/src/io.rs
@@ -13,7 +13,12 @@ use nrf52832::gpio::Pin;
 /// Panic handler
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // The nRF52 DK LEDs (see back of board)
-    let led_kernel_pin = &nrf52832::gpio::GPIOPin::new(Pin::P0_17);
+    let led_kernel_pin = &nrf52832::gpio::GPIOPin::new(
+        Pin::P0_17,
+        nrf52832::gpio::GPIOTE_BASE,
+        nrf52832::gpio::GPIO_BASE_PORT0,
+    );
+
     let led = &mut led::LedLow::new(led_kernel_pin);
 
     debug::panic::<_, nrf52832::uart::Uarte, _, _>(

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -256,9 +256,10 @@ pub unsafe fn start() -> (
             PanicResources::new(),
         );
 
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
     let nrf52832_peripherals = static_init!(
         Nrf52832DefaultPeripherals,
-        Nrf52832DefaultPeripherals::new()
+        Nrf52832DefaultPeripherals::new(aes_ecb_buf)
     );
 
     // set up circular peripheral dependencies

--- a/boards/particle_boron/src/io.rs
+++ b/boards/particle_boron/src/io.rs
@@ -63,7 +63,11 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // The nRF52840DK LEDs (see back of board)
 
     use core::ptr::addr_of_mut;
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(LED2_R_PIN);
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
+        LED2_R_PIN,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
     debug::panic_old(

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -195,10 +195,11 @@ unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'stati
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
     );
 
     nrf52840_peripherals

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -554,8 +554,8 @@ pub unsafe fn start_particle_boron() -> (
         )
     );
     base_peripherals.twi1.configure(
-        nrf52840::pinmux::Pinmux::new(I2C_SCL_PIN),
-        nrf52840::pinmux::Pinmux::new(I2C_SDA_PIN),
+        nrf52840::pinmux::Pinmux::from_pin(I2C_SCL_PIN),
+        nrf52840::pinmux::Pinmux::from_pin(I2C_SDA_PIN),
     );
     base_peripherals.twi1.set_master_client(i2c_master_slave);
     base_peripherals.twi1.set_slave_client(i2c_master_slave);

--- a/boards/sma_q3/src/io.rs
+++ b/boards/sma_q3/src/io.rs
@@ -45,7 +45,11 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // The display LEDs (see back of board)
 
     use core::ptr::addr_of_mut;
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
+        Pin::P0_13,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
     debug::panic_old(

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -211,10 +211,11 @@ pub unsafe fn start() -> (
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
     );
 
     // set up circular peripheral dependencies

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -414,8 +414,8 @@ pub unsafe fn start() -> (
     sensors_i2c_bus.register();
 
     base_peripherals.twi1.configure(
-        nrf52840::pinmux::Pinmux::new(I2C_TEMP_SCL_PIN),
-        nrf52840::pinmux::Pinmux::new(I2C_TEMP_SDA_PIN),
+        nrf52840::pinmux::Pinmux::from_pin(I2C_TEMP_SCL_PIN),
+        nrf52840::pinmux::Pinmux::from_pin(I2C_TEMP_SDA_PIN),
     );
     base_peripherals.twi1.set_master_client(sensors_i2c_bus);
 
@@ -484,9 +484,9 @@ pub unsafe fn start() -> (
             .expect("SPIM2 set rate");
 
         base_peripherals.spim2.configure(
-            nrf52840::pinmux::Pinmux::new(Pin::P0_27),
-            nrf52840::pinmux::Pinmux::new(Pin::P0_28),
-            nrf52840::pinmux::Pinmux::new(Pin::P0_26),
+            nrf52840::pinmux::Pinmux::from_pin(Pin::P0_27),
+            nrf52840::pinmux::Pinmux::from_pin(Pin::P0_28),
+            nrf52840::pinmux::Pinmux::from_pin(Pin::P0_26),
         );
 
         let disp_pin = &nrf52840_peripherals.gpio_port[Pin::P0_07];

--- a/boards/tutorials/nrf52840dk-dynamic-apps-and-policies/src/main.rs
+++ b/boards/tutorials/nrf52840dk-dynamic-apps-and-policies/src/main.rs
@@ -219,8 +219,8 @@ pub unsafe fn main() {
     let i2c_bus = components::i2c::I2CMuxComponent::new(&nrf52840_peripherals.nrf52.twi1, None)
         .finalize(components::i2c_mux_component_static!(nrf52840::i2c::TWI));
     nrf52840_peripherals.nrf52.twi1.configure(
-        nrf52840::pinmux::Pinmux::new(SCREEN_I2C_SCL_PIN),
-        nrf52840::pinmux::Pinmux::new(SCREEN_I2C_SDA_PIN),
+        nrf52840::pinmux::Pinmux::from_pin(SCREEN_I2C_SCL_PIN),
+        nrf52840::pinmux::Pinmux::from_pin(SCREEN_I2C_SDA_PIN),
     );
     nrf52840_peripherals
         .nrf52

--- a/boards/tutorials/nrf52840dk-hotp-tutorial/src/main.rs
+++ b/boards/tutorials/nrf52840dk-hotp-tutorial/src/main.rs
@@ -152,8 +152,8 @@ pub unsafe fn main() {
     let i2c_bus = components::i2c::I2CMuxComponent::new(&nrf52840_peripherals.nrf52.twi1, None)
         .finalize(components::i2c_mux_component_static!(nrf52840::i2c::TWI));
     nrf52840_peripherals.nrf52.twi1.configure(
-        nrf52840::pinmux::Pinmux::new(SCREEN_I2C_SCL_PIN),
-        nrf52840::pinmux::Pinmux::new(SCREEN_I2C_SDA_PIN),
+        nrf52840::pinmux::Pinmux::from_pin(SCREEN_I2C_SCL_PIN),
+        nrf52840::pinmux::Pinmux::from_pin(SCREEN_I2C_SDA_PIN),
     );
     nrf52840_peripherals
         .nrf52

--- a/boards/tutorials/nrf52840dk-root-of-trust-tutorial/src/main.rs
+++ b/boards/tutorials/nrf52840dk-root-of-trust-tutorial/src/main.rs
@@ -101,8 +101,8 @@ pub unsafe fn main() {
     let i2c_bus = components::i2c::I2CMuxComponent::new(&nrf52840_peripherals.nrf52.twi1, None)
         .finalize(components::i2c_mux_component_static!(nrf52840::i2c::TWI));
     nrf52840_peripherals.nrf52.twi1.configure(
-        nrf52840::pinmux::Pinmux::new(SCREEN_I2C_SCL_PIN),
-        nrf52840::pinmux::Pinmux::new(SCREEN_I2C_SDA_PIN),
+        nrf52840::pinmux::Pinmux::from_pin(SCREEN_I2C_SCL_PIN),
+        nrf52840::pinmux::Pinmux::from_pin(SCREEN_I2C_SDA_PIN),
     );
     nrf52840_peripherals
         .nrf52

--- a/boards/tutorials/nrf52840dk-thread-tutorial/src/main.rs
+++ b/boards/tutorials/nrf52840dk-thread-tutorial/src/main.rs
@@ -164,8 +164,8 @@ pub unsafe fn main() {
     let i2c_bus = components::i2c::I2CMuxComponent::new(&nrf52840_peripherals.nrf52.twi1, None)
         .finalize(components::i2c_mux_component_static!(nrf52840::i2c::TWI));
     nrf52840_peripherals.nrf52.twi1.configure(
-        nrf52840::pinmux::Pinmux::new(SCREEN_I2C_SCL_PIN),
-        nrf52840::pinmux::Pinmux::new(SCREEN_I2C_SDA_PIN),
+        nrf52840::pinmux::Pinmux::from_pin(SCREEN_I2C_SCL_PIN),
+        nrf52840::pinmux::Pinmux::from_pin(SCREEN_I2C_SDA_PIN),
     );
     nrf52840_peripherals
         .nrf52

--- a/boards/wm1110dev/src/io.rs
+++ b/boards/wm1110dev/src/io.rs
@@ -16,7 +16,11 @@ use nrf52840::gpio::Pin;
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // Red Led
-    let led_red_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_14);
+    let led_red_pin = &nrf52840::gpio::GPIOPin::new(
+        Pin::P0_14,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut led::LedHigh::new(led_red_pin);
 
     debug::panic::<_, nrf52840::uart::Uarte, _, _>(

--- a/boards/wm1110dev/src/main.rs
+++ b/boards/wm1110dev/src/main.rs
@@ -213,11 +213,12 @@ pub unsafe fn start() -> (
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
 
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
     );
 
     // set up circular peripheral dependencies

--- a/boards/wm1110dev/src/main.rs
+++ b/boards/wm1110dev/src/main.rs
@@ -322,8 +322,8 @@ pub unsafe fn start() -> (
     //--------------------------------------------------------------------------
 
     base_peripherals.uarte0.initialize(
-        nrf52::pinmux::Pinmux::new(UART_TX_PIN),
-        nrf52::pinmux::Pinmux::new(UART_RX_PIN),
+        nrf52::pinmux::Pinmux::from_pin(UART_TX_PIN),
+        nrf52::pinmux::Pinmux::from_pin(UART_RX_PIN),
         None,
         None,
     );
@@ -360,8 +360,8 @@ pub unsafe fn start() -> (
     let mux_i2c = components::i2c::I2CMuxComponent::new(&base_peripherals.twi1, None)
         .finalize(components::i2c_mux_component_static!(nrf52840::i2c::TWI));
     base_peripherals.twi1.configure(
-        nrf52840::pinmux::Pinmux::new(I2C_SCL_PIN),
-        nrf52840::pinmux::Pinmux::new(I2C_SDA_PIN),
+        nrf52840::pinmux::Pinmux::from_pin(I2C_SCL_PIN),
+        nrf52840::pinmux::Pinmux::from_pin(I2C_SDA_PIN),
     );
 
     let sht4x = components::sht4x::SHT4xComponent::new(
@@ -409,9 +409,9 @@ pub unsafe fn start() -> (
     ));
 
     base_peripherals.spim0.configure(
-        nrf52840::pinmux::Pinmux::new(SPI_MOSI_PIN),
-        nrf52840::pinmux::Pinmux::new(SPI_MISO_PIN),
-        nrf52840::pinmux::Pinmux::new(SPI_SCK_PIN),
+        nrf52840::pinmux::Pinmux::from_pin(SPI_MOSI_PIN),
+        nrf52840::pinmux::Pinmux::from_pin(SPI_MISO_PIN),
+        nrf52840::pinmux::Pinmux::from_pin(SPI_SCK_PIN),
     );
 
     base_peripherals

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -5,6 +5,32 @@
 use core::fmt::Write;
 use cortexm4f::{nvic, CortexM4F, CortexMVariant};
 use kernel::platform::chip::InterruptService;
+use kernel::utilities::StaticRef;
+
+//
+// Peripheral Registers Instantiations
+//
+
+const AESECB_BASE: StaticRef<crate::aes::AesEcbRegisters> =
+    unsafe { StaticRef::new(0x4000E000 as *const crate::aes::AesEcbRegisters) };
+
+const RTC1_BASE: StaticRef<crate::rtc::RtcRegisters> =
+    unsafe { StaticRef::new(0x40011000 as *const crate::rtc::RtcRegisters) };
+
+const TEMP_BASE: StaticRef<crate::temperature::TempRegisters> =
+    unsafe { StaticRef::new(0x4000C000 as *const crate::temperature::TempRegisters) };
+
+const TIMER0_BASE: StaticRef<crate::timer::TimerRegisters> =
+    unsafe { StaticRef::new(0x40008000 as *const crate::timer::TimerRegisters) };
+
+const TIMER1_BASE: StaticRef<crate::timer::TimerRegisters> =
+    unsafe { StaticRef::new(0x40009000 as *const crate::timer::TimerRegisters) };
+
+const TIMER2_BASE: StaticRef<crate::timer::TimerRegisters> =
+    unsafe { StaticRef::new(0x4000A000 as *const crate::timer::TimerRegisters) };
+
+const RNG_BASE: StaticRef<crate::trng::RngRegisters> =
+    unsafe { StaticRef::new(0x4000D000 as *const crate::trng::RngRegisters) };
 
 pub struct NRF52<'a, I: InterruptService + 'a> {
     mpu: cortexm4f::mpu::MPU,
@@ -49,18 +75,18 @@ pub struct Nrf52DefaultPeripherals<'a> {
 }
 
 impl Nrf52DefaultPeripherals<'_> {
-    pub fn new() -> Self {
+    pub fn new(aes_ecb_buffer: &'static mut [u8; 48]) -> Self {
         Self {
             acomp: crate::acomp::Comparator::new(),
-            ecb: crate::aes::AesECB::new(),
+            ecb: crate::aes::AesECB::new(AESECB_BASE, aes_ecb_buffer),
             pwr_clk: crate::power::Power::new(),
             ble_radio: crate::ble_radio::Radio::new(),
-            trng: crate::trng::Trng::new(),
-            rtc: crate::rtc::Rtc::new(),
-            temp: crate::temperature::Temp::new(),
-            timer0: crate::timer::TimerAlarm::new(0),
-            timer1: crate::timer::TimerAlarm::new(1),
-            timer2: crate::timer::Timer::new(2),
+            trng: crate::trng::Trng::new(RNG_BASE),
+            rtc: crate::rtc::Rtc::new(RTC1_BASE),
+            temp: crate::temperature::Temp::new(TEMP_BASE),
+            timer0: crate::timer::TimerAlarm::new(TIMER0_BASE),
+            timer1: crate::timer::TimerAlarm::new(TIMER1_BASE),
+            timer2: crate::timer::Timer::new(TIMER2_BASE),
             uarte0: crate::uart::Uarte::new(crate::uart::UARTE0_BASE),
             spim0: crate::spi::SPIM::new(0),
             twi1: crate::i2c::TWI::new_twi1(),

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -76,9 +76,14 @@ pub struct Nrf52DefaultPeripherals<'a> {
 
 impl Nrf52DefaultPeripherals<'_> {
     pub fn new(aes_ecb_buffer: &'static mut [u8; 48]) -> Self {
+        // # Safety
+        //
+        // This must only get constructed once.
+        let aes_registers = unsafe { crate::aes::AesEcbRegistersManager::new(AESECB_BASE) };
+
         Self {
             acomp: crate::acomp::Comparator::new(),
-            ecb: crate::aes::AesECB::new(AESECB_BASE, aes_ecb_buffer),
+            ecb: crate::aes::AesECB::new(aes_registers, aes_ecb_buffer),
             pwr_clk: crate::power::Power::new(),
             ble_radio: crate::ble_radio::Radio::new(),
             trng: crate::trng::Trng::new(RNG_BASE),

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -844,8 +844,8 @@ impl kernel::platform::chip::PanicWriter for Uarte<'_> {
         inner.initialize(
             pinmux::Pinmux::from_pin(config.txd),
             pinmux::Pinmux::from_pin(config.rxd),
-            config.cts.map(|c| unsafe { pinmux::Pinmux::from_pin(c) }),
-            config.rts.map(|r| unsafe { pinmux::Pinmux::from_pin(r) }),
+            config.cts.map(pinmux::Pinmux::from_pin),
+            config.rts.map(pinmux::Pinmux::from_pin),
         );
         let _ = inner.configure(config.params);
         UartPanicWriter { inner }

--- a/chips/nrf52832/src/gpio.rs
+++ b/chips/nrf52832/src/gpio.rs
@@ -2,43 +2,51 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-pub use nrf52::gpio::{GPIOPin, Pin, Port};
+use kernel::utilities::StaticRef;
+pub use nrf52::gpio::{GPIOPin, Pin, Port, GPIO_BASE_ADDRESS, GPIO_SIZE};
+pub use nrf52::gpio::{GpioRegisters, GpioteRegisters};
 
 pub const NUM_PINS: usize = 32;
 
+pub const GPIOTE_BASE: StaticRef<GpioteRegisters> =
+    unsafe { StaticRef::new(0x40006000 as *const GpioteRegisters) };
+
+pub const GPIO_BASE_PORT0: StaticRef<GpioRegisters> =
+    unsafe { StaticRef::new((GPIO_BASE_ADDRESS) as *const GpioRegisters) };
+
 pub fn nrf52832_gpio_create<'a>() -> Port<'a, NUM_PINS> {
     Port::new([
-        GPIOPin::new(Pin::P0_00),
-        GPIOPin::new(Pin::P0_01),
-        GPIOPin::new(Pin::P0_02),
-        GPIOPin::new(Pin::P0_03),
-        GPIOPin::new(Pin::P0_04),
-        GPIOPin::new(Pin::P0_05),
-        GPIOPin::new(Pin::P0_06),
-        GPIOPin::new(Pin::P0_07),
-        GPIOPin::new(Pin::P0_08),
-        GPIOPin::new(Pin::P0_09),
-        GPIOPin::new(Pin::P0_10),
-        GPIOPin::new(Pin::P0_11),
-        GPIOPin::new(Pin::P0_12),
-        GPIOPin::new(Pin::P0_13),
-        GPIOPin::new(Pin::P0_14),
-        GPIOPin::new(Pin::P0_15),
-        GPIOPin::new(Pin::P0_16),
-        GPIOPin::new(Pin::P0_17),
-        GPIOPin::new(Pin::P0_18),
-        GPIOPin::new(Pin::P0_19),
-        GPIOPin::new(Pin::P0_20),
-        GPIOPin::new(Pin::P0_21),
-        GPIOPin::new(Pin::P0_22),
-        GPIOPin::new(Pin::P0_23),
-        GPIOPin::new(Pin::P0_24),
-        GPIOPin::new(Pin::P0_25),
-        GPIOPin::new(Pin::P0_26),
-        GPIOPin::new(Pin::P0_27),
-        GPIOPin::new(Pin::P0_28),
-        GPIOPin::new(Pin::P0_29),
-        GPIOPin::new(Pin::P0_30),
-        GPIOPin::new(Pin::P0_31),
+        GPIOPin::new(Pin::P0_00, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_01, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_02, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_03, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_04, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_05, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_06, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_07, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_08, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_09, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_10, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_11, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_12, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_13, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_14, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_15, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_16, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_17, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_18, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_19, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_20, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_21, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_22, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_23, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_24, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_25, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_26, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_27, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_28, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_29, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_30, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_31, GPIOTE_BASE, GPIO_BASE_PORT0),
     ])
 }

--- a/chips/nrf52832/src/interrupt_service.rs
+++ b/chips/nrf52832/src/interrupt_service.rs
@@ -14,9 +14,9 @@ pub struct Nrf52832DefaultPeripherals<'a> {
     pub gpio_port: crate::gpio::Port<'a, { crate::gpio::NUM_PINS }>,
 }
 impl Nrf52832DefaultPeripherals<'_> {
-    pub unsafe fn new() -> Self {
+    pub unsafe fn new(aes_ecb_buf: &'static mut [u8; 48]) -> Self {
         Self {
-            nrf52: Nrf52DefaultPeripherals::new(),
+            nrf52: Nrf52DefaultPeripherals::new(aes_ecb_buf),
             gpio_port: crate::gpio::nrf52832_gpio_create(),
         }
     }

--- a/chips/nrf52833/src/gpio.rs
+++ b/chips/nrf52833/src/gpio.rs
@@ -2,59 +2,69 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-pub use nrf52::gpio::{GPIOPin, Pin, Port};
+use kernel::utilities::StaticRef;
+pub use nrf52::gpio::{GPIOPin, Pin, Port, GPIO_BASE_ADDRESS, GPIO_SIZE};
+pub use nrf52::gpio::{GpioRegisters, GpioteRegisters};
 
 pub const NUM_PINS: usize = 48;
 
+pub const GPIOTE_BASE: StaticRef<GpioteRegisters> =
+    unsafe { StaticRef::new(0x40006000 as *const GpioteRegisters) };
+
+pub const GPIO_BASE_PORT0: StaticRef<GpioRegisters> =
+    unsafe { StaticRef::new((GPIO_BASE_ADDRESS) as *const GpioRegisters) };
+pub const GPIO_BASE_PORT1: StaticRef<GpioRegisters> =
+    unsafe { StaticRef::new((GPIO_BASE_ADDRESS + GPIO_SIZE) as *const GpioRegisters) };
+
 pub fn nrf52833_gpio_create<'a>() -> Port<'a, NUM_PINS> {
     Port::new([
-        GPIOPin::new(Pin::P0_00),
-        GPIOPin::new(Pin::P0_01),
-        GPIOPin::new(Pin::P0_02),
-        GPIOPin::new(Pin::P0_03),
-        GPIOPin::new(Pin::P0_04),
-        GPIOPin::new(Pin::P0_05),
-        GPIOPin::new(Pin::P0_06),
-        GPIOPin::new(Pin::P0_07),
-        GPIOPin::new(Pin::P0_08),
-        GPIOPin::new(Pin::P0_09),
-        GPIOPin::new(Pin::P0_10),
-        GPIOPin::new(Pin::P0_11),
-        GPIOPin::new(Pin::P0_12),
-        GPIOPin::new(Pin::P0_13),
-        GPIOPin::new(Pin::P0_14),
-        GPIOPin::new(Pin::P0_15),
-        GPIOPin::new(Pin::P0_16),
-        GPIOPin::new(Pin::P0_17),
-        GPIOPin::new(Pin::P0_18),
-        GPIOPin::new(Pin::P0_19),
-        GPIOPin::new(Pin::P0_20),
-        GPIOPin::new(Pin::P0_21),
-        GPIOPin::new(Pin::P0_22),
-        GPIOPin::new(Pin::P0_23),
-        GPIOPin::new(Pin::P0_24),
-        GPIOPin::new(Pin::P0_25),
-        GPIOPin::new(Pin::P0_26),
-        GPIOPin::new(Pin::P0_27),
-        GPIOPin::new(Pin::P0_28),
-        GPIOPin::new(Pin::P0_29),
-        GPIOPin::new(Pin::P0_30),
-        GPIOPin::new(Pin::P0_31),
-        GPIOPin::new(Pin::P1_00),
-        GPIOPin::new(Pin::P1_01),
-        GPIOPin::new(Pin::P1_02),
-        GPIOPin::new(Pin::P1_03),
-        GPIOPin::new(Pin::P1_04),
-        GPIOPin::new(Pin::P1_05),
-        GPIOPin::new(Pin::P1_06),
-        GPIOPin::new(Pin::P1_07),
-        GPIOPin::new(Pin::P1_08),
-        GPIOPin::new(Pin::P1_09),
-        GPIOPin::new(Pin::P1_10),
-        GPIOPin::new(Pin::P1_11),
-        GPIOPin::new(Pin::P1_12),
-        GPIOPin::new(Pin::P1_13),
-        GPIOPin::new(Pin::P1_14),
-        GPIOPin::new(Pin::P1_15),
+        GPIOPin::new(Pin::P0_00, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_01, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_02, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_03, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_04, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_05, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_06, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_07, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_08, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_09, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_10, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_11, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_12, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_13, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_14, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_15, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_16, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_17, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_18, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_19, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_20, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_21, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_22, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_23, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_24, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_25, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_26, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_27, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_28, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_29, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_30, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_31, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P1_00, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_01, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_02, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_03, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_04, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_05, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_06, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_07, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_08, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_09, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_10, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_11, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_12, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_13, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_14, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_15, GPIOTE_BASE, GPIO_BASE_PORT1),
     ])
 }

--- a/chips/nrf52833/src/interrupt_service.rs
+++ b/chips/nrf52833/src/interrupt_service.rs
@@ -18,9 +18,10 @@ pub struct Nrf52833DefaultPeripherals<'a> {
 impl Nrf52833DefaultPeripherals<'_> {
     pub unsafe fn new(
         ieee802154_radio_ack_buf: &'static mut [u8; crate::ieee802154_radio::ACK_BUF_SIZE],
+        aes_ecb_buf: &'static mut [u8; 48],
     ) -> Self {
         Self {
-            nrf52: Nrf52DefaultPeripherals::new(),
+            nrf52: Nrf52DefaultPeripherals::new(aes_ecb_buf),
             ieee802154_radio: crate::ieee802154_radio::Radio::new(ieee802154_radio_ack_buf),
             gpio_port: crate::gpio::nrf52833_gpio_create(),
         }

--- a/chips/nrf52840/src/gpio.rs
+++ b/chips/nrf52840/src/gpio.rs
@@ -2,59 +2,69 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-pub use nrf52::gpio::{GPIOPin, Pin, Port};
+use kernel::utilities::StaticRef;
+pub use nrf52::gpio::{GPIOPin, Pin, Port, GPIO_BASE_ADDRESS, GPIO_SIZE};
+pub use nrf52::gpio::{GpioRegisters, GpioteRegisters};
 
 pub const NUM_PINS: usize = 48;
 
+pub const GPIOTE_BASE: StaticRef<GpioteRegisters> =
+    unsafe { StaticRef::new(0x40006000 as *const GpioteRegisters) };
+
+pub const GPIO_BASE_PORT0: StaticRef<GpioRegisters> =
+    unsafe { StaticRef::new((GPIO_BASE_ADDRESS) as *const GpioRegisters) };
+pub const GPIO_BASE_PORT1: StaticRef<GpioRegisters> =
+    unsafe { StaticRef::new((GPIO_BASE_ADDRESS + GPIO_SIZE) as *const GpioRegisters) };
+
 pub const fn nrf52840_gpio_create<'a>() -> Port<'a, NUM_PINS> {
     Port::new([
-        GPIOPin::new(Pin::P0_00),
-        GPIOPin::new(Pin::P0_01),
-        GPIOPin::new(Pin::P0_02),
-        GPIOPin::new(Pin::P0_03),
-        GPIOPin::new(Pin::P0_04),
-        GPIOPin::new(Pin::P0_05),
-        GPIOPin::new(Pin::P0_06),
-        GPIOPin::new(Pin::P0_07),
-        GPIOPin::new(Pin::P0_08),
-        GPIOPin::new(Pin::P0_09),
-        GPIOPin::new(Pin::P0_10),
-        GPIOPin::new(Pin::P0_11),
-        GPIOPin::new(Pin::P0_12),
-        GPIOPin::new(Pin::P0_13),
-        GPIOPin::new(Pin::P0_14),
-        GPIOPin::new(Pin::P0_15),
-        GPIOPin::new(Pin::P0_16),
-        GPIOPin::new(Pin::P0_17),
-        GPIOPin::new(Pin::P0_18),
-        GPIOPin::new(Pin::P0_19),
-        GPIOPin::new(Pin::P0_20),
-        GPIOPin::new(Pin::P0_21),
-        GPIOPin::new(Pin::P0_22),
-        GPIOPin::new(Pin::P0_23),
-        GPIOPin::new(Pin::P0_24),
-        GPIOPin::new(Pin::P0_25),
-        GPIOPin::new(Pin::P0_26),
-        GPIOPin::new(Pin::P0_27),
-        GPIOPin::new(Pin::P0_28),
-        GPIOPin::new(Pin::P0_29),
-        GPIOPin::new(Pin::P0_30),
-        GPIOPin::new(Pin::P0_31),
-        GPIOPin::new(Pin::P1_00),
-        GPIOPin::new(Pin::P1_01),
-        GPIOPin::new(Pin::P1_02),
-        GPIOPin::new(Pin::P1_03),
-        GPIOPin::new(Pin::P1_04),
-        GPIOPin::new(Pin::P1_05),
-        GPIOPin::new(Pin::P1_06),
-        GPIOPin::new(Pin::P1_07),
-        GPIOPin::new(Pin::P1_08),
-        GPIOPin::new(Pin::P1_09),
-        GPIOPin::new(Pin::P1_10),
-        GPIOPin::new(Pin::P1_11),
-        GPIOPin::new(Pin::P1_12),
-        GPIOPin::new(Pin::P1_13),
-        GPIOPin::new(Pin::P1_14),
-        GPIOPin::new(Pin::P1_15),
+        GPIOPin::new(Pin::P0_00, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_01, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_02, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_03, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_04, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_05, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_06, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_07, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_08, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_09, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_10, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_11, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_12, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_13, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_14, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_15, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_16, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_17, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_18, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_19, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_20, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_21, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_22, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_23, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_24, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_25, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_26, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_27, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_28, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_29, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_30, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_31, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P1_00, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_01, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_02, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_03, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_04, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_05, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_06, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_07, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_08, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_09, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_10, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_11, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_12, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_13, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_14, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_15, GPIOTE_BASE, GPIO_BASE_PORT1),
     ])
 }

--- a/chips/nrf52840/src/interrupt_service.rs
+++ b/chips/nrf52840/src/interrupt_service.rs
@@ -21,9 +21,10 @@ pub struct Nrf52840DefaultPeripherals<'a> {
 impl Nrf52840DefaultPeripherals<'_> {
     pub unsafe fn new(
         ieee802154_radio_ack_buf: &'static mut [u8; crate::ieee802154_radio::ACK_BUF_SIZE],
+        aes_ecb_buf: &'static mut [u8; 48],
     ) -> Self {
         Self {
-            nrf52: Nrf52DefaultPeripherals::new(),
+            nrf52: Nrf52DefaultPeripherals::new(aes_ecb_buf),
             ieee802154_radio: crate::ieee802154_radio::Radio::new(ieee802154_radio_ack_buf),
             usbd: crate::usbd::Usbd::new(),
             gpio_port: crate::gpio::nrf52840_gpio_create(),

--- a/chips/nrf5x-unsafe/Cargo.toml
+++ b/chips/nrf5x-unsafe/Cargo.toml
@@ -1,24 +1,16 @@
 # Licensed under the Apache License, Version 2.0 or the MIT License.
 # SPDX-License-Identifier: Apache-2.0 OR MIT
-# Copyright Tock Contributors 2022.
+# Copyright Tock Contributors 2026.
 
 [package]
-name = "nrf5x"
+name = "nrf5x-unsafe"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-nrf5x-unsafe = { path = "../nrf5x-unsafe" }
 cortexm4f = { path = "../../arch/cortex-m4f" }
 kernel = { path = "../../kernel" }
-enum_primitive = { path = "../../libraries/enum_primitive" }
-
-[features]
-default = []
-
-nrf51 = []
-nrf52 = []
 
 [lints]
 workspace = true

--- a/chips/nrf5x-unsafe/README.md
+++ b/chips/nrf5x-unsafe/README.md
@@ -1,0 +1,3 @@
+# Nordic Semiconductor nRF5X Series SoC - Unsafe
+
+This contains the `unsafe` code for the nrf5x chip.

--- a/chips/nrf5x-unsafe/src/aes.rs
+++ b/chips/nrf5x-unsafe/src/aes.rs
@@ -14,10 +14,10 @@ use kernel::utilities::StaticRef;
 pub struct AesEcbRegisters {
     /// Start ECB block encrypt
     /// - Address 0x000 - 0x004
-    pub task_startecb: WriteOnly<u32, Task::Register>,
+    task_startecb: WriteOnly<u32, Task::Register>,
     /// Abort a possible executing ECB operation
     /// - Address: 0x004 - 0x008
-    pub task_stopecb: WriteOnly<u32, Task::Register>,
+    task_stopecb: WriteOnly<u32, Task::Register>,
     /// Reserved
     _reserved1: [u32; 62],
     /// ECB block encrypt complete

--- a/chips/nrf5x-unsafe/src/aes.rs
+++ b/chips/nrf5x-unsafe/src/aes.rs
@@ -1,0 +1,156 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! AES128 driver, nRF5X-family, unsafe code
+
+use kernel::utilities::cells::MapCell;
+use kernel::utilities::dma_slice::DmaSliceMut;
+use kernel::utilities::registers::interfaces::Writeable;
+use kernel::utilities::registers::{register_bitfields, ReadWrite, WriteOnly};
+use kernel::utilities::StaticRef;
+
+#[repr(C)]
+pub struct AesEcbRegisters {
+    /// Start ECB block encrypt
+    /// - Address 0x000 - 0x004
+    pub task_startecb: WriteOnly<u32, Task::Register>,
+    /// Abort a possible executing ECB operation
+    /// - Address: 0x004 - 0x008
+    pub task_stopecb: WriteOnly<u32, Task::Register>,
+    /// Reserved
+    _reserved1: [u32; 62],
+    /// ECB block encrypt complete
+    /// - Address: 0x100 - 0x104
+    pub event_endecb: ReadWrite<u32, Event::Register>,
+    /// ECB block encrypt aborted because of a STOPECB task or due to an error
+    /// - Address: 0x104 - 0x108
+    pub event_errorecb: ReadWrite<u32, Event::Register>,
+    /// Reserved
+    _reserved2: [u32; 127],
+    /// Enable interrupt
+    /// - Address: 0x304 - 0x308
+    pub intenset: ReadWrite<u32, Intenset::Register>,
+    /// Disable interrupt
+    /// - Address: 0x308 - 0x30c
+    pub intenclr: ReadWrite<u32, Intenclr::Register>,
+    /// Reserved
+    _reserved3: [u32; 126],
+    /// ECB block encrypt memory pointers
+    /// - Address: 0x504 - 0x508
+    ecbdataptr: ReadWrite<u32, EcbDataPointer::Register>,
+}
+
+register_bitfields! [u32,
+    /// Start task
+    pub Task [
+        ENABLE OFFSET(0) NUMBITS(1)
+    ],
+
+    /// Read event
+    pub Event [
+        READY OFFSET(0) NUMBITS(1)
+    ],
+
+    /// Enabled interrupt
+    pub Intenset [
+        ENDECB OFFSET(0) NUMBITS(1),
+        ERRORECB OFFSET(1) NUMBITS(1)
+    ],
+
+    /// Disable interrupt
+    pub Intenclr [
+        ENDECB OFFSET(0) NUMBITS(1),
+        ERRORECB OFFSET(1) NUMBITS(1)
+    ],
+
+    /// ECB block encrypt memory pointers
+    EcbDataPointer [
+        POINTER OFFSET(0) NUMBITS(32)
+    ]
+];
+
+/// Wrapper for managing MMIO for the AES ECB peripheral.
+pub struct AesEcbRegistersManager {
+    /// MMIO registers for the AES ECB peripheral.
+    pub registers: StaticRef<AesEcbRegisters>,
+    /// Holding place for the DMA buffer while DMA is in progress.
+    dma_buf: MapCell<DmaSliceMut<'static, u8>>,
+}
+
+impl AesEcbRegistersManager {
+    pub fn new(regs: StaticRef<AesEcbRegisters>) -> Self {
+        Self {
+            registers: regs,
+            dma_buf: MapCell::empty(),
+        }
+    }
+
+    /// Start an ECB encryption with DMA.
+    ///
+    /// The buffer must cover the full 48-byte ECB data block:
+    /// bytes 0–15 = key, bytes 16–31 = plaintext/counter, bytes 32–47 = ciphertext output.
+    ///
+    /// # Return
+    ///
+    /// `Ok(())` on successfully starting the DMA operation. `Err(())` if DMA
+    /// is already busy.
+    pub fn start_ecb_dma(&self, buf: &'static mut [u8]) -> Result<(), ()> {
+        if self.dma_pending() {
+            return Err(());
+        }
+
+        // To create a DmaFence we must trust the implementation.
+        //
+        // # Safety
+        //
+        // The architecture-provided version is correct for the nRF52.
+        let fence = unsafe { cortexm4f::dma_fence::CortexMDmaFence::new() };
+
+        // Create DmaSubSliceMut for the ECB data buffer. This ensures that we
+        // can soundly share it with the DMA hardware.
+        let ecb_dma_slice = DmaSliceMut::new_static(buf, fence);
+
+        // Provide the buffer pointer to the ECB hardware. The hardware expects
+        // the pointer to point at byte 0 of the 48-byte data block (the key).
+        // The SubSliceMut covers the full ecb_data buffer (never sliced), so
+        // as_mut_ptr() correctly points to byte 0.
+        self.registers
+            .ecbdataptr
+            .write(EcbDataPointer::POINTER.val(ecb_dma_slice.as_mut_ptr() as u32));
+
+        // Save the DmaSubSliceMut while the DMA operation executes.
+        self.dma_buf.replace(ecb_dma_slice);
+
+        // Clear the end event and start the ECB task.
+        self.registers.event_endecb.write(Event::READY::CLEAR);
+        self.registers.task_startecb.write(Task::ENABLE::SET);
+
+        Ok(())
+    }
+
+    pub fn finish_ecb_dma(&self) -> Option<&'static mut [u8]> {
+        // Clear the end event before releasing the buffer.
+        self.registers.event_endecb.write(Event::READY::CLEAR);
+
+        self.dma_buf.take().map(|dma_slice| {
+            // To create a DmaFence we must trust the implementation.
+            //
+            // # Safety
+            //
+            // The architecture-provided version is correct for the nRF52.
+            let fence = unsafe { cortexm4f::dma_fence::CortexMDmaFence::new() };
+
+            // # Safety
+            //
+            // We must ensure that the DMA hardware no longer has any access to
+            // this buffer. We ensure that by clearing `event_endecb` above;
+            // the hardware sets this event only after completing the operation.
+            unsafe { dma_slice.take(fence) }
+        })
+    }
+
+    pub fn dma_pending(&self) -> bool {
+        self.dma_buf.is_some()
+    }
+}

--- a/chips/nrf5x-unsafe/src/aes.rs
+++ b/chips/nrf5x-unsafe/src/aes.rs
@@ -79,7 +79,7 @@ pub struct AesEcbRegistersManager {
 }
 
 impl AesEcbRegistersManager {
-    pub fn new(regs: StaticRef<AesEcbRegisters>) -> Self {
+    pub unsafe fn new(regs: StaticRef<AesEcbRegisters>) -> Self {
         Self {
             registers: regs,
             dma_buf: MapCell::empty(),

--- a/chips/nrf5x-unsafe/src/lib.rs
+++ b/chips/nrf5x-unsafe/src/lib.rs
@@ -1,0 +1,7 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+#![no_std]
+
+pub mod aes;

--- a/chips/nrf5x/Cargo.toml
+++ b/chips/nrf5x/Cargo.toml
@@ -10,7 +10,6 @@ edition.workspace = true
 
 [dependencies]
 nrf5x-unsafe = { path = "../nrf5x-unsafe" }
-cortexm4f = { path = "../../arch/cortex-m4f" }
 kernel = { path = "../../kernel" }
 enum_primitive = { path = "../../libraries/enum_primitive" }
 

--- a/chips/nrf5x/Cargo.toml
+++ b/chips/nrf5x/Cargo.toml
@@ -9,6 +9,7 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
+cortexm4f = { path = "../../arch/cortex-m4f" }
 kernel = { path = "../../kernel" }
 enum_primitive = { path = "../../libraries/enum_primitive" }
 

--- a/chips/nrf5x/src/aes.rs
+++ b/chips/nrf5x/src/aes.rs
@@ -71,7 +71,7 @@ pub struct AesECB<'a> {
     client: OptionalCell<&'a dyn kernel::hil::symmetric_encryption::Client<'a>>,
 }
 
-impl<'a> AesECB<'a> {
+impl AesECB<'_> {
     pub fn new(registers: StaticRef<AesEcbRegisters>, ecb_data: &'static mut [u8; 48]) -> Self {
         Self {
             registers: AesEcbRegistersManager::new(registers),

--- a/chips/nrf5x/src/aes.rs
+++ b/chips/nrf5x/src/aes.rs
@@ -24,11 +24,6 @@
 //! ### Payload
 //! Data to be encrypted or decrypted it is XOR:ed with the generated keystream
 //!
-//! ### Things to highlight that can be improved:
-//!
-//! * ECB_DATA must be a static mut \[u8\] and can't be located in the struct
-//! * PAYLOAD size is restricted to 128 bytes
-//!
 //! Authors
 //! --------
 //! * Niklas Adolfsson <niklasadolfsson1@gmail.com>
@@ -37,24 +32,17 @@
 
 use core::cell::Cell;
 use kernel::hil::symmetric_encryption;
-use kernel::utilities::cells::{MapCell, OptionalCell, TakeCell};
-use kernel::utilities::dma_slice::DmaSubSliceMut;
+use kernel::utilities::cells::{MapCell, OptionalCell};
+use kernel::utilities::dma_slice::DmaSliceMut;
 use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 use kernel::utilities::registers::{register_bitfields, ReadWrite, WriteOnly};
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 
-#[allow(dead_code)]
 const KEY_START: usize = 0;
-#[allow(dead_code)]
-const KEY_END: usize = 15;
 const PLAINTEXT_START: usize = 16;
 const PLAINTEXT_END: usize = 32;
-#[allow(dead_code)]
-const CIPHERTEXT_START: usize = 33;
-#[allow(dead_code)]
-const CIPHERTEXT_END: usize = 47;
 
 #[repr(C)]
 pub struct AesEcbRegisters {
@@ -123,29 +111,33 @@ enum AESMode {
     CBC,
 }
 
+/// Wrapper for managing MMIO for the AES ECB peripheral.
 struct AesEcbRegistersManager {
-    /// MMIO registers for the UARTE peripheral.
+    /// MMIO registers for the AES ECB peripheral.
     registers: StaticRef<AesEcbRegisters>,
-    /// Holding place for the DMA buffer while DMA in progress.
-    dma_buf: MapCell<DmaSubSliceMut<'static, u8>>,
+    /// Holding place for the DMA buffer while DMA is in progress.
+    dma_buf: MapCell<DmaSliceMut<'static, u8>>,
 }
 
 impl AesEcbRegistersManager {
-    pub fn new(regs: StaticRef<UarteRegisters>) -> Self {
+    pub fn new(regs: StaticRef<AesEcbRegisters>) -> Self {
         Self {
             registers: regs,
             dma_buf: MapCell::empty(),
         }
     }
 
-    /// Start a UART transmission with DMA.
+    /// Start an ECB encryption with DMA.
+    ///
+    /// The buffer must cover the full 48-byte ECB data block:
+    /// bytes 0–15 = key, bytes 16–31 = plaintext/counter, bytes 32–47 = ciphertext output.
     ///
     /// # Return
     ///
-    /// `Ok(())` on successfully starting the DMA operation. `Err(())` if the
-    /// DMA is busy and the operation could not be started.
-    pub fn start_dma(&self, buf: SubSliceMut<'static, u8>) -> Result<(), ()> {
-        if self.tx_dma_pending() {
+    /// `Ok(())` on successfully starting the DMA operation. `Err(())` if DMA
+    /// is already busy.
+    pub fn start_ecb_dma(&self, buf: &'static mut [u8]) -> Result<(), ()> {
+        if self.dma_pending() {
             return Err(());
         }
 
@@ -156,32 +148,33 @@ impl AesEcbRegistersManager {
         // The architecture-provided version is correct for the nRF52.
         let fence = unsafe { cortexm4f::dma_fence::CortexMDmaFence::new() };
 
-        // Create DmaSlice for the TX buffer. This ensures that we can soundly
-        // share it with the DMA hardware.
-        let tx_dma_slice = DmaSubSliceMut::new_static(buf, fence);
+        // Create DmaSubSliceMut for the ECB data buffer. This ensures that we
+        // can soundly share it with the DMA hardware.
+        let ecb_dma_slice = DmaSliceMut::new_static(buf, fence);
 
-        // Provide the DmaSlice buffer to the hardware DMA engine.
-        self.registers.txd_ptr.set(tx_dma_slice.as_mut_ptr() as u32);
-
-        // Specify the length to transmit.
+        // Provide the buffer pointer to the ECB hardware. The hardware expects
+        // the pointer to point at byte 0 of the 48-byte data block (the key).
+        // The SubSliceMut covers the full ecb_data buffer (never sliced), so
+        // as_mut_ptr() correctly points to byte 0.
         self.registers
-            .txd_maxcnt
-            .write(Counter::COUNTER.val(tx_dma_slice.len() as u32));
+            .ecbdataptr
+            .write(EcbDataPointer::POINTER.val(ecb_dma_slice.as_mut_ptr() as u32));
 
-        // Save the DmaSlice while the DMA operation executes.
-        self.tx_dma_buf.replace(tx_dma_slice);
+        // Save the DmaSubSliceMut while the DMA operation executes.
+        self.dma_buf.replace(ecb_dma_slice);
 
-        // Start the TX DMA operation
-        self.registers.task_starttx.write(Task::ENABLE::SET);
+        // Clear the end event and start the ECB task.
+        self.registers.event_endecb.write(Event::READY::CLEAR);
+        self.registers.task_startecb.write(Task::ENABLE::SET);
 
         Ok(())
     }
 
-    pub fn finish_dma(&self) -> Option<(SubSliceMut<'static, u8>, usize)> {
-        // End the DMA operation so it is safe to retrieve the buffer.
-        self.registers.event_endtx.write(Event::READY::CLEAR);
+    pub fn finish_ecb_dma(&self) -> Option<&'static mut [u8]> {
+        // Clear the end event before releasing the buffer.
+        self.registers.event_endecb.write(Event::READY::CLEAR);
 
-        self.tx_dma_buf.take().map(|dma_slice| {
+        self.dma_buf.take().map(|dma_slice| {
             // To create a DmaFence we must trust the implementation.
             //
             // # Safety
@@ -191,14 +184,10 @@ impl AesEcbRegistersManager {
 
             // # Safety
             //
-            // We must ensure that the DMA hardware no longer has any access
-            // to this buffer. We ensure that by setting the `event_endtx`
-            // event before taking the dma slice back.
-            let buf = unsafe { dma_slice.take(fence) };
-
-            let tx_bytes = self.registers.txd_amount.get() as usize;
-
-            (buf, tx_bytes)
+            // We must ensure that the DMA hardware no longer has any access to
+            // this buffer. We ensure that by clearing `event_endecb` above;
+            // the hardware sets this event only after completing the operation.
+            unsafe { dma_slice.take(fence) }
         })
     }
 
@@ -209,90 +198,110 @@ impl AesEcbRegistersManager {
 
 pub struct AesECB<'a> {
     registers: AesEcbRegistersManager,
-    /// DMA buffer that the aes chip will mutate during encryption
-    /// Byte 0-15   - Key
-    /// Byte 16-32  - Payload
-    /// Byte 33-47  - Ciphertext
-    ecb_data: TakeCell<'static, [u8; 48]>,
-    ecb_data_in_dma: TakeCell<'static, [u8; 48]>,
     mode: Cell<AESMode>,
+    /// DMA buffer for the ECB engine. Needed because we need to set the key and
+    /// payload in specific bytes, and then read the ciphertext from the same
+    /// buffer.
+    ///
+    /// - Byte 0-15   - Key
+    /// - Byte 16-32  - Payload
+    /// - Byte 33-47  - Ciphertext
+    ecb_data: MapCell<&'static mut [u8]>,
+    /// Input plaintext or ciphertext. SubSliceMut window advances one block at
+    /// a time as encryption proceeds. Empty when using in-place (dest-only) mode.
+    input: MapCell<SubSliceMut<'static, u8>>,
+    /// Output buffer, pre-sliced to the requested start..stop range. Window
+    /// advances one block at a time as encryption proceeds.
+    output: MapCell<SubSliceMut<'static, u8>>,
     client: OptionalCell<&'a dyn kernel::hil::symmetric_encryption::Client<'a>>,
-    /// Input either plaintext or ciphertext to be encrypted or decrypted.
-    input: TakeCell<'static, [u8]>,
-    output: TakeCell<'static, [u8]>,
-    current_idx: Cell<usize>,
-    start_idx: Cell<usize>,
-    end_idx: Cell<usize>,
 }
 
 impl<'a> AesECB<'a> {
     pub fn new(registers: StaticRef<AesEcbRegisters>, ecb_data: &'static mut [u8; 48]) -> Self {
         Self {
             registers: AesEcbRegistersManager::new(registers),
-            ecb_data: TakeCell::new(ecb_data),
-            ecb_data_in_dma: TakeCell::empty(),
             mode: Cell::new(AESMode::CTR),
+            ecb_data: MapCell::new(ecb_data),
+            input: MapCell::empty(),
+            output: MapCell::empty(),
             client: OptionalCell::empty(),
-            input: TakeCell::empty(),
-            output: TakeCell::empty(),
-            current_idx: Cell::new(0),
-            start_idx: Cell::new(0),
-            end_idx: Cell::new(0),
         }
     }
 
-    fn set_dma(&self) {
-        self.ecb_data.take().map(|buf| {
-            self.registers
-                .ecbdataptr
-                .set(core::ptr::from_ref::<[u8; 48]>(buf) as u32);
-            self.ecb_data_in_dma.replace(buf);
-        });
+    /// Returns the number of bytes remaining in the current operation.
+    fn remaining_len(&self) -> usize {
+        self.input
+            .map_or(self.output.map_or(0, |o| o.len()), |i| i.len())
     }
 
-    fn unset_dma(&self) {
-        self.ecb_data_in_dma.take().map(|buf| {
-            self.ecb_data.replace(buf);
-        });
-    }
+    fn copy_plaintext(&self) {
+        fn copy_to_ecb(
+            ecb: &MapCell<&'static mut [u8]>,
+            buf: &MapCell<SubSliceMut<'static, u8>>,
+            len: usize,
+        ) {
+            ecb.map(|ecb| {
+                buf.map(|buf| {
+                    ecb[PLAINTEXT_START..PLAINTEXT_START + len].copy_from_slice(&buf[0..len]);
+                });
+            });
+        }
 
-    /// Verify that the provided start and stop indices work with the given
-    /// buffers.
-    fn try_set_indices(&self, start_index: usize, stop_index: usize) -> bool {
-        stop_index.checked_sub(start_index).is_some_and(|sublen| {
-            sublen % symmetric_encryption::AES128_BLOCK_SIZE == 0 && {
-                self.input.map_or_else(
-                    || {
-                        // The destination buffer is also the input
-                        if self.output.map_or(false, |dest| stop_index <= dest.len()) {
-                            self.current_idx.set(0);
-                            self.start_idx.set(start_index);
-                            self.end_idx.set(stop_index);
-                            true
-                        } else {
-                            false
-                        }
-                    },
-                    |source| {
-                        if sublen == source.len()
-                            && self.output.map_or(false, |dest| stop_index <= dest.len())
-                        {
-                            // We will start writing to the AES from the
-                            // beginning of `source`, and end at its end
-                            self.current_idx.set(0);
+        fn xor_to_ecb(
+            ecb: &MapCell<&'static mut [u8]>,
+            buf: &MapCell<SubSliceMut<'static, u8>>,
+            len: usize,
+        ) {
+            ecb.map(|ecb| {
+                buf.map(|buf| {
+                    for i in 0..len {
+                        ecb[PLAINTEXT_START + i] ^= buf[i];
+                    }
+                });
+            });
+        }
 
-                            // We will start reading from the AES into `dest` at
-                            // `start_index`, and continue until `stop_index`
-                            self.start_idx.set(start_index);
-                            self.end_idx.set(stop_index);
-                            true
-                        } else {
-                            false
-                        }
-                    },
-                )
+        let take = core::cmp::min(
+            symmetric_encryption::AES128_BLOCK_SIZE,
+            self.remaining_len(),
+        );
+
+        match self.mode.get() {
+            AESMode::ECB => {
+                // Copy the current plaintext block into the ECB data buffer.
+                if self.input.is_some() {
+                    copy_to_ecb(&self.ecb_data, &self.input, take);
+                } else {
+                    copy_to_ecb(&self.ecb_data, &self.output, take);
+                }
             }
-        })
+
+            AESMode::CBC => {
+                // XOR the existing ECB plaintext slot (IV or previous ciphertext)
+                // with the current plaintext block.
+                if self.input.is_some() {
+                    xor_to_ecb(&self.ecb_data, &self.input, take);
+                } else {
+                    xor_to_ecb(&self.ecb_data, &self.output, take);
+                }
+            }
+
+            AESMode::CTR => {
+                // The counter is already in the ECB plaintext slot; no copy needed.
+            }
+        }
+    }
+
+    /// Start a single ECB encryption block via DMA, preparing the ECB data
+    /// buffer with the current plaintext block if needed.
+    fn do_crypt(&self) {
+        self.copy_plaintext();
+
+        if let Some(ecb_data) = self.ecb_data.take() {
+            let _ = self.registers.start_ecb_dma(ecb_data);
+        }
+
+        self.enable_interrupts();
     }
 
     // FIXME: should this be performed in constant time i.e. skip the break part
@@ -300,7 +309,7 @@ impl<'a> AesECB<'a> {
     fn update_ctr(&self) {
         self.ecb_data.map(|buf| {
             for i in (PLAINTEXT_START..PLAINTEXT_END).rev() {
-                buf[i] += 1;
+                buf[i] = buf[i].wrapping_add(1);
                 if buf[i] != 0 {
                     break;
                 }
@@ -308,222 +317,108 @@ impl<'a> AesECB<'a> {
         });
     }
 
-    /// Get the relevant positions of our input data whether we are using a
-    /// source buffer or overwriting the destination buffer.
-    fn get_start_end_take(&self) -> (usize, usize, usize) {
-        let current_idx = self.current_idx.get();
+    /// AesEcb Interrupt handler
+    pub fn handle_interrupt(&self) {
+        self.disable_interrupts();
 
-        // Location in the appropriate source buffer we are currently working
-        // on.
-        let start = current_idx + self.input.map_or(self.start_idx.get(), |_| 0);
-        // Last index in the appropriate source buffer we need to work on.
-        let end = self.end_idx.get() - self.input.map_or(0, |_| self.start_idx.get());
-
-        // Get the number of bytes that were used in the keystream/block.
-        let take = match end.checked_sub(start) {
-            Some(v) if v > symmetric_encryption::AES128_BLOCK_SIZE => {
-                symmetric_encryption::AES128_BLOCK_SIZE
+        if self.registers.registers.event_endecb.is_set(Event::READY) {
+            // Recover the ECB data buffer from the DMA manager.
+            if let Some(ecb_data) = self.registers.finish_ecb_dma() {
+                self.ecb_data.replace(ecb_data);
             }
-            Some(v) => v,
-            None => 0,
-        };
 
-        (start, end, take)
-    }
+            let take = core::cmp::min(
+                symmetric_encryption::AES128_BLOCK_SIZE,
+                self.remaining_len(),
+            );
 
-    fn copy_plaintext(&self) {
-        let (start, _end, take) = self.get_start_end_take();
-
-        // Copy the plaintext either from the source if it exists or from the
-        // destination buffer.
-        if take > 0 {
-            match self.mode.get() {
-                AESMode::ECB => {
-                    self.input.map_or_else(
-                        || {
+            if take > 0 {
+                match self.mode.get() {
+                    AESMode::ECB => {
+                        // Copy ciphertext from the ECB output slot to the output buffer.
+                        self.ecb_data.map(|ecb| {
                             self.output.map(|output| {
-                                self.ecb_data.map(|buf| {
-                                    // Copy into static mut DMA buffer
-                                    buf[PLAINTEXT_START..(take + PLAINTEXT_START)]
-                                        .copy_from_slice(&output[start..(take + start)]);
+                                output[0..take]
+                                    .copy_from_slice(&ecb[PLAINTEXT_END..PLAINTEXT_END + take]);
+                            });
+                        });
+                    }
+
+                    AESMode::CBC => {
+                        // Copy ciphertext to output and save it in the ECB plaintext
+                        // slot for CBC chaining on the next block.
+                        self.ecb_data.map(|ecb| {
+                            self.output.map(|output| {
+                                for i in 0..take {
+                                    let byte = ecb[PLAINTEXT_END + i];
+                                    output[i] = byte;
+                                    ecb[PLAINTEXT_START + i] = byte;
+                                }
+                            });
+                        });
+                    }
+
+                    AESMode::CTR => {
+                        // XOR keystream output with plaintext to produce ciphertext.
+                        if self.input.is_some() {
+                            self.ecb_data.map(|ecb| {
+                                self.input.map(|input| {
+                                    self.output.map(|output| {
+                                        for i in 0..take {
+                                            output[i] = input[i] ^ ecb[PLAINTEXT_END + i];
+                                        }
+                                    });
                                 });
                             });
-                        },
-                        |input| {
-                            self.ecb_data.map(|buf| {
-                                // Copy into static mut DMA buffer
-                                buf[PLAINTEXT_START..(take + PLAINTEXT_START)]
-                                    .copy_from_slice(&input[start..(take + start)]);
-                            });
-                        },
-                    );
-                }
-
-                AESMode::CBC => {
-                    self.input.map_or_else(
-                        || {
-                            self.output.map(|output| {
-                                self.ecb_data.map(|buf| {
+                        } else {
+                            self.ecb_data.map(|ecb| {
+                                self.output.map(|output| {
                                     for i in 0..take {
-                                        let ecb_idx = i + PLAINTEXT_START;
-
-                                        // Copy into static mut DMA buffer
-                                        buf[ecb_idx] ^= output[i + start];
+                                        output[i] ^= ecb[PLAINTEXT_END + i];
                                     }
                                 });
                             });
-                        },
-                        |input| {
-                            self.ecb_data.map(|buf| {
-                                for i in 0..take {
-                                    let ecb_idx = i + PLAINTEXT_START;
-                                    // Copy into static mut DMA buffer
-                                    buf[ecb_idx] ^= input[i + start];
-                                }
-                            });
-                        },
-                    );
-                }
-
-                AESMode::CTR => {
-                    // no copying plaintext in ctr mode
-                }
-            }
-        }
-    }
-
-    fn crypt(&self) {
-        match self.mode.get() {
-            AESMode::CTR => {}
-            AESMode::ECB => {
-                // Need to copy the plaintext to the ECB buffer.
-                self.copy_plaintext();
-            }
-            AESMode::CBC => {
-                self.copy_plaintext();
-            }
-        }
-
-        self.set_dma();
-        self.registers.event_endecb.write(Event::READY::CLEAR);
-        self.registers.task_startecb.set(1);
-
-        self.enable_interrupts();
-    }
-
-    /// AesEcb Interrupt handler
-    pub fn handle_interrupt(&self) {
-        // disable interrupts
-        self.disable_interrupts();
-        self.unset_dma();
-
-        if self.registers.event_endecb.get() == 1 {
-            let (start, end, take) = self.get_start_end_take();
-            let start_idx = self.start_idx.get();
-            let current_idx = self.current_idx.get();
-
-            match self.mode.get() {
-                AESMode::CTR => {
-                    // Fill in the ciphertext in the output buffer.
-                    if take > 0 {
-                        self.input.map_or_else(
-                            || {
-                                // No input buffer, so source data comes from
-                                // output buffer.
-                                self.output.map(|output| {
-                                    self.ecb_data.map(|buf| {
-                                        for i in 0..take {
-                                            let in_byte = output[start + i];
-                                            let keystream_byte = buf[i + PLAINTEXT_END];
-
-                                            output[start + i] = keystream_byte ^ in_byte;
-                                        }
-                                    });
-                                });
-                            },
-                            |input| {
-                                self.output.map(|output| {
-                                    self.ecb_data.map(|buf| {
-                                        let start_idx = self.start_idx.get();
-
-                                        for i in 0..take {
-                                            let in_byte = input[start + i];
-                                            let keystream_byte = buf[i + PLAINTEXT_END];
-
-                                            output[start_idx + current_idx + i] =
-                                                keystream_byte ^ in_byte;
-                                        }
-                                    });
-                                });
-                            },
-                        );
-
+                        }
                         self.update_ctr();
                     }
                 }
 
-                AESMode::ECB => {
-                    // Copy ciphertext to output.
-                    if take > 0 {
-                        self.output.map(|output| {
-                            self.ecb_data.map(|buf| {
-                                for i in 0..take {
-                                    // We write to the buffer starting at the
-                                    // originally provided start index, plus our
-                                    // offset at current_idx.
-                                    let dest_idx = start_idx + current_idx + i;
-                                    // Copy out of static mut DMA buffer
-                                    output[dest_idx] = buf[i + PLAINTEXT_END];
-                                }
-                            });
-                        });
-                    }
-                }
-                AESMode::CBC => {
-                    // Copy ciphertext to both output AND the ECB payload to use
-                    // on the next iteration.
-                    if take > 0 {
-                        self.output.map(|output| {
-                            self.ecb_data.map(|buf| {
-                                for i in 0..take {
-                                    // We write to the buffer starting at the
-                                    // originally provided start index, plus our
-                                    // offset at current_idx.
-                                    let dest_idx = start_idx + current_idx + i;
-                                    // Copy out of static mut DMA buffer
-                                    output[dest_idx] = buf[i + PLAINTEXT_END];
-                                    buf[i + PLAINTEXT_START] = buf[i + PLAINTEXT_END];
-                                }
-                            });
-                        });
-                    }
-                }
+                // Advance both SubSliceMut windows past the block just processed.
+                self.output.map(|buf| {
+                    buf.slice(take..);
+                });
+                self.input.map(|buf| {
+                    buf.slice(take..);
+                });
             }
 
-            // Advance through the buffer.
-            self.current_idx.set(current_idx + take);
-
-            // Check if we are done or if we need to crypt another block.
-            if start + take < end {
-                // More to do.
-                self.crypt();
+            if self.remaining_len() > 0 {
+                self.do_crypt();
             } else {
-                self.output.take().map(|output| {
-                    self.client
-                        .map(move |client| client.crypt_done(self.input.take(), output));
-                });
+                // Recover the original buffers (SubSliceMut::take returns the
+                // full underlying &'static mut [u8] regardless of the current
+                // window position) and notify the client.
+                let input_buf = self.input.take().map(|s| s.take());
+                if let Some(output_sub) = self.output.take() {
+                    let output = output_sub.take();
+                    self.client.map(move |client| {
+                        client.crypt_done(input_buf, output);
+                    });
+                }
             }
         }
     }
 
     fn enable_interrupts(&self) {
         self.registers
+            .registers
             .intenset
             .write(Intenset::ENDECB::SET + Intenset::ERRORECB::SET);
     }
 
     fn disable_interrupts(&self) {
         self.registers
+            .registers
             .intenclr
             .write(Intenclr::ENDECB::SET + Intenclr::ERRORECB::SET);
     }
@@ -533,7 +428,10 @@ impl<'a> kernel::hil::symmetric_encryption::AES128<'a> for AesECB<'a> {
     fn enable(&self) {}
 
     fn disable(&self) {
-        self.registers.task_stopecb.write(Task::ENABLE::CLEAR);
+        self.registers
+            .registers
+            .task_stopecb
+            .write(Task::ENABLE::CLEAR);
         self.disable_interrupts();
     }
 
@@ -546,9 +444,8 @@ impl<'a> kernel::hil::symmetric_encryption::AES128<'a> for AesECB<'a> {
             Err(ErrorCode::INVAL)
         } else {
             self.ecb_data.map(|buf| {
-                for (i, c) in key.iter().enumerate() {
-                    buf[i] = *c;
-                }
+                buf[KEY_START..KEY_START + symmetric_encryption::AES128_KEY_SIZE]
+                    .copy_from_slice(key);
             });
             Ok(())
         }
@@ -559,9 +456,7 @@ impl<'a> kernel::hil::symmetric_encryption::AES128<'a> for AesECB<'a> {
             Err(ErrorCode::INVAL)
         } else {
             self.ecb_data.map(|buf| {
-                for (i, c) in iv.iter().enumerate() {
-                    buf[i + PLAINTEXT_START] = *c;
-                }
+                buf[PLAINTEXT_START..PLAINTEXT_END].copy_from_slice(iv);
             });
             Ok(())
         }
@@ -581,18 +476,32 @@ impl<'a> kernel::hil::symmetric_encryption::AES128<'a> for AesECB<'a> {
         Option<&'static mut [u8]>,
         &'static mut [u8],
     )> {
-        self.input.put(source);
-        self.output.replace(dest);
-        if self.try_set_indices(start_index, stop_index) {
-            self.crypt();
-            None
-        } else {
-            Some((
-                Err(ErrorCode::INVAL),
-                self.input.take(),
-                self.output.take().unwrap(),
-            ))
+        // Validate indices and buffer sizes before consuming any buffers.
+        let len = match stop_index.checked_sub(start_index) {
+            Some(l) if l % symmetric_encryption::AES128_BLOCK_SIZE == 0 => l,
+            _ => return Some((Err(ErrorCode::INVAL), source, dest)),
+        };
+
+        if stop_index > dest.len() {
+            return Some((Err(ErrorCode::INVAL), source, dest));
         }
+
+        if let Some(ref src) = source {
+            if src.len() != len {
+                return Some((Err(ErrorCode::INVAL), source, dest));
+            }
+        }
+
+        if let Some(src) = source {
+            self.input.replace(SubSliceMut::new(src));
+        }
+
+        let mut output_slice = SubSliceMut::new(dest);
+        output_slice.slice(start_index..stop_index);
+        self.output.replace(output_slice);
+
+        self.do_crypt();
+        None
     }
 }
 

--- a/chips/nrf5x/src/aes.rs
+++ b/chips/nrf5x/src/aes.rs
@@ -37,8 +37,9 @@
 
 use core::cell::Cell;
 use kernel::hil::symmetric_encryption;
-use kernel::utilities::cells::OptionalCell;
-use kernel::utilities::cells::TakeCell;
+use kernel::utilities::cells::{MapCell, OptionalCell, TakeCell};
+use kernel::utilities::dma_slice::DmaSubSliceMut;
+use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 use kernel::utilities::registers::{register_bitfields, ReadWrite, WriteOnly};
 use kernel::utilities::StaticRef;
@@ -122,8 +123,92 @@ enum AESMode {
     CBC,
 }
 
-pub struct AesECB<'a> {
+struct AesEcbRegistersManager {
+    /// MMIO registers for the UARTE peripheral.
     registers: StaticRef<AesEcbRegisters>,
+    /// Holding place for the DMA buffer while DMA in progress.
+    dma_buf: MapCell<DmaSubSliceMut<'static, u8>>,
+}
+
+impl AesEcbRegistersManager {
+    pub fn new(regs: StaticRef<UarteRegisters>) -> Self {
+        Self {
+            registers: regs,
+            dma_buf: MapCell::empty(),
+        }
+    }
+
+    /// Start a UART transmission with DMA.
+    ///
+    /// # Return
+    ///
+    /// `Ok(())` on successfully starting the DMA operation. `Err(())` if the
+    /// DMA is busy and the operation could not be started.
+    pub fn start_dma(&self, buf: SubSliceMut<'static, u8>) -> Result<(), ()> {
+        if self.tx_dma_pending() {
+            return Err(());
+        }
+
+        // To create a DmaFence we must trust the implementation.
+        //
+        // # Safety
+        //
+        // The architecture-provided version is correct for the nRF52.
+        let fence = unsafe { cortexm4f::dma_fence::CortexMDmaFence::new() };
+
+        // Create DmaSlice for the TX buffer. This ensures that we can soundly
+        // share it with the DMA hardware.
+        let tx_dma_slice = DmaSubSliceMut::new_static(buf, fence);
+
+        // Provide the DmaSlice buffer to the hardware DMA engine.
+        self.registers.txd_ptr.set(tx_dma_slice.as_mut_ptr() as u32);
+
+        // Specify the length to transmit.
+        self.registers
+            .txd_maxcnt
+            .write(Counter::COUNTER.val(tx_dma_slice.len() as u32));
+
+        // Save the DmaSlice while the DMA operation executes.
+        self.tx_dma_buf.replace(tx_dma_slice);
+
+        // Start the TX DMA operation
+        self.registers.task_starttx.write(Task::ENABLE::SET);
+
+        Ok(())
+    }
+
+    pub fn finish_dma(&self) -> Option<(SubSliceMut<'static, u8>, usize)> {
+        // End the DMA operation so it is safe to retrieve the buffer.
+        self.registers.event_endtx.write(Event::READY::CLEAR);
+
+        self.tx_dma_buf.take().map(|dma_slice| {
+            // To create a DmaFence we must trust the implementation.
+            //
+            // # Safety
+            //
+            // The architecture-provided version is correct for the nRF52.
+            let fence = unsafe { cortexm4f::dma_fence::CortexMDmaFence::new() };
+
+            // # Safety
+            //
+            // We must ensure that the DMA hardware no longer has any access
+            // to this buffer. We ensure that by setting the `event_endtx`
+            // event before taking the dma slice back.
+            let buf = unsafe { dma_slice.take(fence) };
+
+            let tx_bytes = self.registers.txd_amount.get() as usize;
+
+            (buf, tx_bytes)
+        })
+    }
+
+    pub fn dma_pending(&self) -> bool {
+        self.dma_buf.is_some()
+    }
+}
+
+pub struct AesECB<'a> {
+    registers: AesEcbRegistersManager,
     /// DMA buffer that the aes chip will mutate during encryption
     /// Byte 0-15   - Key
     /// Byte 16-32  - Payload
@@ -141,12 +226,9 @@ pub struct AesECB<'a> {
 }
 
 impl<'a> AesECB<'a> {
-    pub fn new(
-        registers: StaticRef<AesEcbRegisters>,
-        ecb_data: &'static mut [u8; 48],
-    ) -> AesECB<'a> {
-        AesECB {
-            registers,
+    pub fn new(registers: StaticRef<AesEcbRegisters>, ecb_data: &'static mut [u8; 48]) -> Self {
+        Self {
+            registers: AesEcbRegistersManager::new(registers),
             ecb_data: TakeCell::new(ecb_data),
             ecb_data_in_dma: TakeCell::empty(),
             mode: Cell::new(AESMode::CTR),

--- a/chips/nrf5x/src/aes.rs
+++ b/chips/nrf5x/src/aes.rs
@@ -33,167 +33,22 @@
 use core::cell::Cell;
 use kernel::hil::symmetric_encryption;
 use kernel::utilities::cells::{MapCell, OptionalCell};
-use kernel::utilities::dma_slice::DmaSliceMut;
 use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
-use kernel::utilities::registers::{register_bitfields, ReadWrite, WriteOnly};
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
+pub use nrf5x_unsafe::aes::AesEcbRegisters;
+use nrf5x_unsafe::aes::AesEcbRegistersManager;
 
 const KEY_START: usize = 0;
 const PLAINTEXT_START: usize = 16;
 const PLAINTEXT_END: usize = 32;
-
-#[repr(C)]
-pub struct AesEcbRegisters {
-    /// Start ECB block encrypt
-    /// - Address 0x000 - 0x004
-    task_startecb: WriteOnly<u32, Task::Register>,
-    /// Abort a possible executing ECB operation
-    /// - Address: 0x004 - 0x008
-    task_stopecb: WriteOnly<u32, Task::Register>,
-    /// Reserved
-    _reserved1: [u32; 62],
-    /// ECB block encrypt complete
-    /// - Address: 0x100 - 0x104
-    event_endecb: ReadWrite<u32, Event::Register>,
-    /// ECB block encrypt aborted because of a STOPECB task or due to an error
-    /// - Address: 0x104 - 0x108
-    event_errorecb: ReadWrite<u32, Event::Register>,
-    /// Reserved
-    _reserved2: [u32; 127],
-    /// Enable interrupt
-    /// - Address: 0x304 - 0x308
-    intenset: ReadWrite<u32, Intenset::Register>,
-    /// Disable interrupt
-    /// - Address: 0x308 - 0x30c
-    intenclr: ReadWrite<u32, Intenclr::Register>,
-    /// Reserved
-    _reserved3: [u32; 126],
-    /// ECB block encrypt memory pointers
-    /// - Address: 0x504 - 0x508
-    ecbdataptr: ReadWrite<u32, EcbDataPointer::Register>,
-}
-
-register_bitfields! [u32,
-    /// Start task
-    Task [
-        ENABLE OFFSET(0) NUMBITS(1)
-    ],
-
-    /// Read event
-    Event [
-        READY OFFSET(0) NUMBITS(1)
-    ],
-
-    /// Enabled interrupt
-    Intenset [
-        ENDECB OFFSET(0) NUMBITS(1),
-        ERRORECB OFFSET(1) NUMBITS(1)
-    ],
-
-    /// Disable interrupt
-    Intenclr [
-        ENDECB OFFSET(0) NUMBITS(1),
-        ERRORECB OFFSET(1) NUMBITS(1)
-    ],
-
-    /// ECB block encrypt memory pointers
-    EcbDataPointer [
-        POINTER OFFSET(0) NUMBITS(32)
-    ]
-];
 
 #[derive(Copy, Clone, Debug)]
 enum AESMode {
     ECB,
     CTR,
     CBC,
-}
-
-/// Wrapper for managing MMIO for the AES ECB peripheral.
-struct AesEcbRegistersManager {
-    /// MMIO registers for the AES ECB peripheral.
-    registers: StaticRef<AesEcbRegisters>,
-    /// Holding place for the DMA buffer while DMA is in progress.
-    dma_buf: MapCell<DmaSliceMut<'static, u8>>,
-}
-
-impl AesEcbRegistersManager {
-    pub fn new(regs: StaticRef<AesEcbRegisters>) -> Self {
-        Self {
-            registers: regs,
-            dma_buf: MapCell::empty(),
-        }
-    }
-
-    /// Start an ECB encryption with DMA.
-    ///
-    /// The buffer must cover the full 48-byte ECB data block:
-    /// bytes 0–15 = key, bytes 16–31 = plaintext/counter, bytes 32–47 = ciphertext output.
-    ///
-    /// # Return
-    ///
-    /// `Ok(())` on successfully starting the DMA operation. `Err(())` if DMA
-    /// is already busy.
-    pub fn start_ecb_dma(&self, buf: &'static mut [u8]) -> Result<(), ()> {
-        if self.dma_pending() {
-            return Err(());
-        }
-
-        // To create a DmaFence we must trust the implementation.
-        //
-        // # Safety
-        //
-        // The architecture-provided version is correct for the nRF52.
-        let fence = unsafe { cortexm4f::dma_fence::CortexMDmaFence::new() };
-
-        // Create DmaSubSliceMut for the ECB data buffer. This ensures that we
-        // can soundly share it with the DMA hardware.
-        let ecb_dma_slice = DmaSliceMut::new_static(buf, fence);
-
-        // Provide the buffer pointer to the ECB hardware. The hardware expects
-        // the pointer to point at byte 0 of the 48-byte data block (the key).
-        // The SubSliceMut covers the full ecb_data buffer (never sliced), so
-        // as_mut_ptr() correctly points to byte 0.
-        self.registers
-            .ecbdataptr
-            .write(EcbDataPointer::POINTER.val(ecb_dma_slice.as_mut_ptr() as u32));
-
-        // Save the DmaSubSliceMut while the DMA operation executes.
-        self.dma_buf.replace(ecb_dma_slice);
-
-        // Clear the end event and start the ECB task.
-        self.registers.event_endecb.write(Event::READY::CLEAR);
-        self.registers.task_startecb.write(Task::ENABLE::SET);
-
-        Ok(())
-    }
-
-    pub fn finish_ecb_dma(&self) -> Option<&'static mut [u8]> {
-        // Clear the end event before releasing the buffer.
-        self.registers.event_endecb.write(Event::READY::CLEAR);
-
-        self.dma_buf.take().map(|dma_slice| {
-            // To create a DmaFence we must trust the implementation.
-            //
-            // # Safety
-            //
-            // The architecture-provided version is correct for the nRF52.
-            let fence = unsafe { cortexm4f::dma_fence::CortexMDmaFence::new() };
-
-            // # Safety
-            //
-            // We must ensure that the DMA hardware no longer has any access to
-            // this buffer. We ensure that by clearing `event_endecb` above;
-            // the hardware sets this event only after completing the operation.
-            unsafe { dma_slice.take(fence) }
-        })
-    }
-
-    pub fn dma_pending(&self) -> bool {
-        self.dma_buf.is_some()
-    }
 }
 
 pub struct AesECB<'a> {
@@ -321,7 +176,12 @@ impl<'a> AesECB<'a> {
     pub fn handle_interrupt(&self) {
         self.disable_interrupts();
 
-        if self.registers.registers.event_endecb.is_set(Event::READY) {
+        if self
+            .registers
+            .registers
+            .event_endecb
+            .is_set(nrf5x_unsafe::aes::Event::READY)
+        {
             // Recover the ECB data buffer from the DMA manager.
             if let Some(ecb_data) = self.registers.finish_ecb_dma() {
                 self.ecb_data.replace(ecb_data);
@@ -410,17 +270,15 @@ impl<'a> AesECB<'a> {
     }
 
     fn enable_interrupts(&self) {
-        self.registers
-            .registers
-            .intenset
-            .write(Intenset::ENDECB::SET + Intenset::ERRORECB::SET);
+        self.registers.registers.intenset.write(
+            nrf5x_unsafe::aes::Intenset::ENDECB::SET + nrf5x_unsafe::aes::Intenset::ERRORECB::SET,
+        );
     }
 
     fn disable_interrupts(&self) {
-        self.registers
-            .registers
-            .intenclr
-            .write(Intenclr::ENDECB::SET + Intenclr::ERRORECB::SET);
+        self.registers.registers.intenclr.write(
+            nrf5x_unsafe::aes::Intenclr::ENDECB::SET + nrf5x_unsafe::aes::Intenclr::ERRORECB::SET,
+        );
     }
 }
 
@@ -431,7 +289,7 @@ impl<'a> kernel::hil::symmetric_encryption::AES128<'a> for AesECB<'a> {
         self.registers
             .registers
             .task_stopecb
-            .write(Task::ENABLE::CLEAR);
+            .write(nrf5x_unsafe::aes::Task::ENABLE::CLEAR);
         self.disable_interrupts();
     }
 

--- a/chips/nrf5x/src/aes.rs
+++ b/chips/nrf5x/src/aes.rs
@@ -35,10 +35,9 @@ use kernel::hil::symmetric_encryption;
 use kernel::utilities::cells::{MapCell, OptionalCell};
 use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
-use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 pub use nrf5x_unsafe::aes::AesEcbRegisters;
-use nrf5x_unsafe::aes::AesEcbRegistersManager;
+pub use nrf5x_unsafe::aes::AesEcbRegistersManager;
 
 const KEY_START: usize = 0;
 const PLAINTEXT_START: usize = 16;
@@ -72,9 +71,9 @@ pub struct AesECB<'a> {
 }
 
 impl AesECB<'_> {
-    pub fn new(registers: StaticRef<AesEcbRegisters>, ecb_data: &'static mut [u8; 48]) -> Self {
+    pub fn new(registers: AesEcbRegistersManager, ecb_data: &'static mut [u8; 48]) -> Self {
         Self {
-            registers: AesEcbRegistersManager::new(registers),
+            registers,
             mode: Cell::new(AESMode::CTR),
             ecb_data: MapCell::new(ecb_data),
             input: MapCell::empty(),

--- a/chips/nrf5x/src/aes.rs
+++ b/chips/nrf5x/src/aes.rs
@@ -286,10 +286,7 @@ impl<'a> kernel::hil::symmetric_encryption::AES128<'a> for AesECB<'a> {
     fn enable(&self) {}
 
     fn disable(&self) {
-        self.registers
-            .registers
-            .task_stopecb
-            .write(nrf5x_unsafe::aes::Task::ENABLE::CLEAR);
+        self.registers.finish_ecb_dma();
         self.disable_interrupts();
     }
 

--- a/chips/nrf5x/src/gpio.rs
+++ b/chips/nrf5x/src/gpio.rs
@@ -32,19 +32,18 @@ const NUM_GPIOTE: usize = 4;
 
 const GPIO_PER_PORT: usize = 32;
 
-const GPIOTE_BASE: StaticRef<GpioteRegisters> =
-    unsafe { StaticRef::new(0x40006000 as *const GpioteRegisters) };
+pub const GPIO_BASE_ADDRESS: usize = 0x50000000;
+pub const GPIO_SIZE: usize = 0x300;
 
-const GPIO_BASE_ADDRESS: usize = 0x50000000;
-const GPIO_SIZE: usize = 0x300;
-
+/// nRF5x GPIOTE Registers
+///
 /// The nRF5x doesn't automatically provide GPIO interrupts. Instead, to receive
 /// interrupts from a GPIO line, you must allocate a GPIOTE (GPIO Task and
 /// Event) channel, and bind the channel to the desired pin. There are 4
 /// channels for the nrf51 and 8 channels for the nrf52. This means that
 /// requesting an interrupt can fail, if they are all already allocated.
 #[repr(C)]
-struct GpioteRegisters {
+pub struct GpioteRegisters {
     /// Task for writing to pin specified in CONFIG\[n\].PSEL.
     /// Action on pin is configured in CONFIG\[n\].POLARITY
     ///
@@ -84,7 +83,7 @@ struct GpioteRegisters {
 }
 
 #[repr(C)]
-struct GpioRegisters {
+pub struct GpioRegisters {
     /// Reserved
     _reserved1: [u32; 321],
     /// Write GPIO port
@@ -369,18 +368,17 @@ pub struct GPIOPin<'a> {
 }
 
 impl<'a> GPIOPin<'a> {
-    pub const fn new(pin: Pin) -> GPIOPin<'a> {
+    pub const fn new(
+        pin: Pin,
+        gpiote_registers: StaticRef<GpioteRegisters>,
+        gpio_registers: StaticRef<GpioRegisters>,
+    ) -> GPIOPin<'a> {
         GPIOPin {
             pin: ((pin as usize) % GPIO_PER_PORT) as u8,
             port: ((pin as usize) / GPIO_PER_PORT) as u8,
             client: OptionalCell::empty(),
-            gpio_registers: unsafe {
-                StaticRef::new(
-                    (GPIO_BASE_ADDRESS + ((pin as usize) / GPIO_PER_PORT) * GPIO_SIZE)
-                        as *const GpioRegisters,
-                )
-            },
-            gpiote_registers: GPIOTE_BASE,
+            gpio_registers,
+            gpiote_registers,
             allocated_channel: OptionalCell::empty(),
         }
     }

--- a/chips/nrf5x/src/lib.rs
+++ b/chips/nrf5x/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
+#![forbid(unsafe_code)]
 #![no_std]
 
 pub mod aes;

--- a/chips/nrf5x/src/pinmux.rs
+++ b/chips/nrf5x/src/pinmux.rs
@@ -9,43 +9,12 @@
 //! configuration should create `Pinmux`s and pass them into controller drivers
 //! during initialization.
 
-use kernel::utilities::cells::VolatileCell;
-
-use crate::gpio::Pin;
-
-// Note: only the nrf52840 has two ports, but we create two ports to avoid
-// gating this code by a feature.
-const NUM_PORTS: usize = 2;
-
-const PIN_PER_PORT: usize = 32;
-
-// Keep track of which pins has a `Pinmux` been created for.
-static mut USED_PINS: [VolatileCell<u32>; NUM_PORTS] = [VolatileCell::new(0), VolatileCell::new(0)];
-
 /// An opaque wrapper around a configurable pin.
 #[derive(Copy, Clone)]
 pub struct Pinmux(Pin);
 
 impl Pinmux {
     /// Creates a new `Pinmux` wrapping the numbered pin.
-    ///
-    /// # Panics
-    ///
-    /// If a `Pinmux` for this pin has already
-    /// been created.
-    ///
-    pub unsafe fn new(pin: Pin) -> Pinmux {
-        let port: usize = (pin as usize) / PIN_PER_PORT;
-        let pin_idx: usize = (pin as usize) % PIN_PER_PORT;
-        let used_pins = USED_PINS[port].get();
-        if used_pins & (1 << pin_idx) != 0 {
-            panic!("Pin {:?} is already in use!", pin);
-        } else {
-            USED_PINS[port].set(used_pins | 1 << pin_idx);
-            Pinmux(pin)
-        }
-    }
-
     pub unsafe fn from_pin(pin: crate::gpio::Pin) -> Pinmux {
         Pinmux(pin)
     }

--- a/chips/nrf5x/src/pinmux.rs
+++ b/chips/nrf5x/src/pinmux.rs
@@ -11,11 +11,11 @@
 
 /// An opaque wrapper around a configurable pin.
 #[derive(Copy, Clone)]
-pub struct Pinmux(Pin);
+pub struct Pinmux(crate::gpio::Pin);
 
 impl Pinmux {
     /// Creates a new `Pinmux` wrapping the numbered pin.
-    pub unsafe fn from_pin(pin: crate::gpio::Pin) -> Pinmux {
+    pub fn from_pin(pin: crate::gpio::Pin) -> Pinmux {
         Pinmux(pin)
     }
 }

--- a/chips/nrf5x/src/rtc.rs
+++ b/chips/nrf5x/src/rtc.rs
@@ -12,11 +12,8 @@ use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite, Writ
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 
-const RTC1_BASE: StaticRef<RtcRegisters> =
-    unsafe { StaticRef::new(0x40011000 as *const RtcRegisters) };
-
 #[repr(C)]
-struct RtcRegisters {
+pub struct RtcRegisters {
     /// Start RTC Counter.
     tasks_start: WriteOnly<u32, Task::Register>,
     /// Stop RTC Counter.
@@ -96,9 +93,9 @@ pub struct Rtc<'a> {
 }
 
 impl Rtc<'_> {
-    pub const fn new() -> Self {
+    pub const fn new(registers: StaticRef<RtcRegisters>) -> Self {
         Self {
-            registers: RTC1_BASE,
+            registers,
             overflow_client: OptionalCell::empty(),
             alarm_client: OptionalCell::empty(),
             enabled: Cell::new(false),

--- a/chips/nrf5x/src/temperature.rs
+++ b/chips/nrf5x/src/temperature.rs
@@ -18,11 +18,8 @@ use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite, Writ
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 
-const TEMP_BASE: StaticRef<TempRegisters> =
-    unsafe { StaticRef::new(0x4000C000 as *const TempRegisters) };
-
 #[repr(C)]
-struct TempRegisters {
+pub struct TempRegisters {
     /// Start temperature measurement
     /// Address: 0x000 - 0x004
     pub task_start: WriteOnly<u32, Task::Register>,
@@ -30,14 +27,14 @@ struct TempRegisters {
     /// Address: 0x004 - 0x008
     pub task_stop: WriteOnly<u32, Task::Register>,
     /// Reserved
-    pub _reserved1: [u32; 62],
+    _reserved1: [u32; 62],
     /// Temperature measurement complete, data ready
     /// Address: 0x100 - 0x104
     pub event_datardy: ReadWrite<u32, Event::Register>,
     /// Reserved
     // Note, `inten` register on nRF51 is ignored because it's not supported by nRF52
     // And intenset and intenclr provide the same functionality
-    pub _reserved2: [u32; 128],
+    _reserved2: [u32; 128],
     /// Enable interrupt
     /// Address: 0x304 - 0x308
     pub intenset: ReadWrite<u32, Intenset::Register>,
@@ -45,22 +42,22 @@ struct TempRegisters {
     /// Address: 0x308 - 0x30c
     pub intenclr: ReadWrite<u32, Intenclr::Register>,
     /// Reserved
-    pub _reserved3: [u32; 127],
+    _reserved3: [u32; 127],
     /// Temperature in °C (0.25° steps)
     /// Address: 0x508 - 0x50c
     pub temp: ReadOnly<u32, Temperature::Register>,
     /// Reserved
-    pub _reserved4: [u32; 5],
+    _reserved4: [u32; 5],
     /// Slope of piece wise linear function (nRF52 only)
     /// Address 0x520 - 0x534
     #[cfg(feature = "nrf52")]
     pub a: [ReadWrite<u32, A::Register>; 6],
-    pub _reserved5: [u32; 2],
+    _reserved5: [u32; 2],
     /// y-intercept of 5th piece wise linear function (nRF52 only)
     /// Address: 0x540 - 0x554
     #[cfg(feature = "nrf52")]
     pub b: [ReadWrite<u32, B::Register>; 6],
-    pub _reserved6: [u32; 2],
+    _reserved6: [u32; 2],
     /// End point of 1st piece wise linear function (nRF52 only)
     /// Address: 0x560 - 0x570
     #[cfg(feature = "nrf52")]
@@ -115,9 +112,9 @@ pub struct Temp<'a> {
 }
 
 impl<'a> Temp<'a> {
-    pub const fn new() -> Temp<'a> {
+    pub const fn new(registers: StaticRef<TempRegisters>) -> Temp<'a> {
         Temp {
-            registers: TEMP_BASE,
+            registers,
             client: OptionalCell::empty(),
         }
     }

--- a/chips/nrf5x/src/timer.rs
+++ b/chips/nrf5x/src/timer.rs
@@ -34,16 +34,8 @@ use kernel::utilities::registers::{register_bitfields, ReadWrite, WriteOnly};
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 
-const INSTANCES: [StaticRef<TimerRegisters>; 3] = unsafe {
-    [
-        StaticRef::new(0x40008000 as *const TimerRegisters),
-        StaticRef::new(0x40009000 as *const TimerRegisters),
-        StaticRef::new(0x4000A000 as *const TimerRegisters),
-    ]
-};
-
 #[repr(C)]
-struct TimerRegisters {
+pub struct TimerRegisters {
     /// Start Timer
     tasks_start: WriteOnly<u32, Task::Register>,
     /// Stop Timer
@@ -220,9 +212,9 @@ pub struct Timer {
 }
 
 impl Timer {
-    pub const fn new(instance: usize) -> Timer {
+    pub const fn new(registers: StaticRef<TimerRegisters>) -> Timer {
         Timer {
-            registers: INSTANCES[instance],
+            registers,
             client: OptionalCell::empty(),
         }
     }
@@ -271,9 +263,9 @@ const CC_CAPTURE: usize = 0;
 const CC_COMPARE: usize = 1;
 
 impl<'a> TimerAlarm<'a> {
-    pub const fn new(instance: usize) -> TimerAlarm<'a> {
+    pub const fn new(registers: StaticRef<TimerRegisters>) -> TimerAlarm<'a> {
         TimerAlarm {
-            registers: INSTANCES[instance],
+            registers,
             client: OptionalCell::empty(),
         }
     }

--- a/chips/nrf5x/src/trng.rs
+++ b/chips/nrf5x/src/trng.rs
@@ -32,9 +32,6 @@ use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite, Writ
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 
-const RNG_BASE: StaticRef<RngRegisters> =
-    unsafe { StaticRef::new(0x4000D000 as *const RngRegisters) };
-
 #[repr(C)]
 pub struct RngRegisters {
     /// Task starting the random number generator
@@ -117,9 +114,9 @@ pub struct Trng<'a> {
 }
 
 impl<'a> Trng<'a> {
-    pub const fn new() -> Trng<'a> {
+    pub const fn new(registers: StaticRef<RngRegisters>) -> Trng<'a> {
         Trng {
-            registers: RNG_BASE,
+            registers,
             client: OptionalCell::empty(),
             index: Cell::new(0),
             randomness: Cell::new(0),


### PR DESCRIPTION
### Pull Request Overview

This pull request converts the nrf5x crate to be forbid unsafe. This is in some ways an example of what it might look like to try to split our chip crates into safe and unsafe, with all of the drivers moved to safe, and the instantiations in unsafe.

There are hidden `static mut` in the nrf5x crate which I removed. The AES change was bigger than anticipated and needs testing.

I removed the pinmux check. Having a global variable for that runtime check does not seem worth it.


### Testing Strategy

todo


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
