### PR TITLE
Fix: ignore vendored and submodule directories in rustfmt (#4404)

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -14,3 +14,10 @@ error_on_unformatted = true
 # repository, it does not search parent directories for a rustfmt.toml file.
 # This allows projects with their own rustfmt.toml file to include tock as a
 # submodule without changing the behavior of `make prepush`.
+ignore = [
+  "**/vendor/**",
+  "**/third_party/**",
+  "**/third-party/**",
+  "**/external/**",
+  "**/extern/**"
+]


### PR DESCRIPTION
### Summary
This pull request updates `rustfmt.toml` to exclude vendored and submodule directories
from formatting. These directories often contain tab characters and non-standard
formatting that should not be modified by `cargo fmt` or `make format`.

### Changes
- Added `ignore` patterns in `rustfmt.toml` for:
  - vendor/
  - third_party/
  - third-party/
  - external/
  - extern/

### Impact
- Prevents formatting errors caused by tab characters in vendored or submodule code.
- Ensures `make format` and `cargo fmt` run cleanly on Tock's source without touching
  external dependencies.

Closes #4410