### PR TITLE
kernel: debug: move UartDebugWriter to capsules/system

### DIFF
--- a/capsules/system/src/debug_writer/mod.rs
+++ b/capsules/system/src/debug_writer/mod.rs
@@ -1,0 +1,7 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+//! Implementations of `DebugWriter` for kernel-wide debug printing.
+
+pub mod uart_debug_writer;

--- a/capsules/system/src/debug_writer/uart_debug_writer.rs
+++ b/capsules/system/src/debug_writer/uart_debug_writer.rs
@@ -1,0 +1,164 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+//! Implementation of [`DebugWriter`] using UART.
+
+use kernel::collections::queue::Queue;
+use kernel::collections::ring_buffer::RingBuffer;
+use kernel::debug::DebugWriter;
+use kernel::debug::IoWrite;
+use kernel::hil;
+use kernel::utilities::cells::TakeCell;
+use kernel::ErrorCode;
+
+/// Buffered [`DebugWriter`] implementation using a UART.
+///
+/// Currently used as a default implementation of DebugWriterComponent.
+pub struct UartDebugWriter {
+    /// What provides the actual writing mechanism.
+    uart: &'static dyn hil::uart::Transmit<'static>,
+    /// The buffer that is passed to the writing mechanism.
+    output_buffer: TakeCell<'static, [u8]>,
+    /// An internal buffer that is used to hold debug!() calls as they come in.
+    internal_buffer: TakeCell<'static, RingBuffer<'static, u8>>,
+}
+
+impl UartDebugWriter {
+    pub fn new(
+        uart: &'static dyn hil::uart::Transmit,
+        out_buffer: &'static mut [u8],
+        internal_buffer: &'static mut RingBuffer<'static, u8>,
+    ) -> UartDebugWriter {
+        UartDebugWriter {
+            uart,
+            output_buffer: TakeCell::new(out_buffer),
+            internal_buffer: TakeCell::new(internal_buffer),
+        }
+    }
+}
+
+impl DebugWriter for UartDebugWriter {
+    fn write(&self, bytes: &[u8], overflow_message: &[u8]) -> usize {
+        // If we have a buffer, write to it.
+        if let Some(ring_buffer) = self.internal_buffer.take() {
+            let available_len = ring_buffer
+                .available_len()
+                .saturating_sub(overflow_message.len());
+            let total_written = if available_len >= bytes.len() {
+                for &b in bytes {
+                    ring_buffer.enqueue(b);
+                }
+                bytes.len()
+            } else {
+                // If we don't have enough space, write as much as we can and
+                // then write the overflow message.
+                for &b in &bytes[..available_len] {
+                    ring_buffer.enqueue(b);
+                }
+                for &b in overflow_message {
+                    ring_buffer.enqueue(b);
+                }
+                available_len + overflow_message.len()
+            };
+            // Put the buffer back.
+            self.internal_buffer.replace(ring_buffer);
+            total_written
+        } else {
+            // No buffer, so just return the number of bytes.
+            bytes.len()
+        }
+    }
+
+    fn publish(&self) -> usize {
+        // Can only publish if we have the output_buffer. If we don't that is
+        // fine, we will do it when the transmit done callback happens.
+        self.internal_buffer.map_or(0, |ring_buffer| {
+            if let Some(out_buffer) = self.output_buffer.take() {
+                let mut count = 0;
+
+                for dst in out_buffer.iter_mut() {
+                    match ring_buffer.dequeue() {
+                        Some(src) => {
+                            *dst = src;
+                            count += 1;
+                        }
+                        None => {
+                            break;
+                        }
+                    }
+                }
+
+                if count != 0 {
+                    // Transmit the data in the output buffer.
+                    if let Err((_err, buf)) = self.uart.transmit_buffer(out_buffer, count) {
+                        self.output_buffer.put(Some(buf));
+                    } else {
+                        self.output_buffer.put(None);
+                    }
+                }
+                count
+            } else {
+                0
+            }
+        })
+    }
+
+    fn flush(&self, writer: &mut dyn IoWrite) {
+        self.internal_buffer.map(|ring_buffer| {
+            writer.write_ring_buffer(ring_buffer);
+        });
+    }
+
+    fn available_len(&self) -> usize {
+        self.internal_buffer.map_or(0, |rb| rb.available_len())
+    }
+
+    fn to_write_len(&self) -> usize {
+        self.internal_buffer.map_or(0, |rb| rb.len())
+    }
+}
+
+impl hil::uart::TransmitClient for UartDebugWriter {
+    fn transmitted_buffer(
+        &self,
+        buffer: &'static mut [u8],
+        _tx_len: usize,
+        _rcode: Result<(), ErrorCode>,
+    ) {
+        // Replace this buffer since we are done with it.
+        self.output_buffer.replace(buffer);
+
+        if self.internal_buffer.map_or(false, |buf| buf.has_elements()) {
+            // Buffer not empty, go around again
+            self.publish();
+        }
+    }
+    fn transmitted_word(&self, _rcode: Result<(), ErrorCode>) {}
+}
+
+impl IoWrite for UartDebugWriter {
+    fn write(&mut self, bytes: &[u8]) -> usize {
+        const FULL_MSG: &[u8] = b"\n*** DEBUG BUFFER FULL ***\n";
+        self.internal_buffer.map_or(0, |ring_buffer| {
+            let available_len_for_msg = ring_buffer.available_len().saturating_sub(FULL_MSG.len());
+
+            if available_len_for_msg >= bytes.len() {
+                for &b in bytes {
+                    ring_buffer.enqueue(b);
+                }
+                bytes.len()
+            } else {
+                for &b in &bytes[..available_len_for_msg] {
+                    ring_buffer.enqueue(b);
+                }
+                // When the buffer is close to full, print a warning and drop the current
+                // string.
+                for &b in FULL_MSG {
+                    ring_buffer.enqueue(b);
+                }
+                available_len_for_msg
+            }
+        })
+    }
+}

--- a/capsules/system/src/lib.rs
+++ b/capsules/system/src/lib.rs
@@ -5,6 +5,7 @@
 #![forbid(unsafe_code)]
 #![no_std]
 
+pub mod debug_writer;
 pub mod process_checker;
 pub mod process_policies;
 pub mod process_printer;

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -100,7 +100,6 @@ use core::panic::PanicInfo;
 use core::str;
 
 use crate::capabilities::SetDebugWriterCapability;
-use crate::collections::queue::Queue;
 use crate::collections::ring_buffer::RingBuffer;
 use crate::hil;
 use crate::platform::chip::Chip;
@@ -109,10 +108,9 @@ use crate::process::ProcessPrinter;
 use crate::process::ProcessSlot;
 use crate::processbuffer::ReadableProcessSlice;
 use crate::utilities::binary_write::BinaryToWriteWrapper;
+use crate::utilities::cells::MapCell;
 use crate::utilities::cells::NumericCellExt;
-use crate::utilities::cells::{MapCell, TakeCell};
 use crate::utilities::single_thread_value::SingleThreadValue;
-use crate::ErrorCode;
 
 /// Implementation of `std::io::Write` for `no_std`.
 ///
@@ -436,157 +434,6 @@ pub fn set_debug_writer_wrapper<C: SetDebugWriterCapability>(
     _cap: C,
 ) {
     DEBUG_WRITER.get().map(|dw| dw.replace(debug_writer));
-}
-
-/// Buffered [`DebugWriter`] implementation using a UART.
-///
-/// Currently used as a default implementation of DebugWriterComponent.
-pub struct UartDebugWriter {
-    /// What provides the actual writing mechanism.
-    uart: &'static dyn hil::uart::Transmit<'static>,
-    /// The buffer that is passed to the writing mechanism.
-    output_buffer: TakeCell<'static, [u8]>,
-    /// An internal buffer that is used to hold debug!() calls as they come in.
-    internal_buffer: TakeCell<'static, RingBuffer<'static, u8>>,
-}
-
-impl UartDebugWriter {
-    pub fn new(
-        uart: &'static dyn hil::uart::Transmit,
-        out_buffer: &'static mut [u8],
-        internal_buffer: &'static mut RingBuffer<'static, u8>,
-    ) -> UartDebugWriter {
-        UartDebugWriter {
-            uart,
-            output_buffer: TakeCell::new(out_buffer),
-            internal_buffer: TakeCell::new(internal_buffer),
-        }
-    }
-}
-
-impl DebugWriter for UartDebugWriter {
-    fn write(&self, bytes: &[u8], overflow_message: &[u8]) -> usize {
-        // If we have a buffer, write to it.
-        if let Some(ring_buffer) = self.internal_buffer.take() {
-            let available_len = ring_buffer
-                .available_len()
-                .saturating_sub(overflow_message.len());
-            let total_written = if available_len >= bytes.len() {
-                for &b in bytes {
-                    ring_buffer.enqueue(b);
-                }
-                bytes.len()
-            } else {
-                // If we don't have enough space, write as much as we can and
-                // then write the overflow message.
-                for &b in &bytes[..available_len] {
-                    ring_buffer.enqueue(b);
-                }
-                for &b in overflow_message {
-                    ring_buffer.enqueue(b);
-                }
-                available_len + overflow_message.len()
-            };
-            // Put the buffer back.
-            self.internal_buffer.replace(ring_buffer);
-            total_written
-        } else {
-            // No buffer, so just return the number of bytes.
-            bytes.len()
-        }
-    }
-
-    fn publish(&self) -> usize {
-        // Can only publish if we have the output_buffer. If we don't that is
-        // fine, we will do it when the transmit done callback happens.
-        self.internal_buffer.map_or(0, |ring_buffer| {
-            if let Some(out_buffer) = self.output_buffer.take() {
-                let mut count = 0;
-
-                for dst in out_buffer.iter_mut() {
-                    match ring_buffer.dequeue() {
-                        Some(src) => {
-                            *dst = src;
-                            count += 1;
-                        }
-                        None => {
-                            break;
-                        }
-                    }
-                }
-
-                if count != 0 {
-                    // Transmit the data in the output buffer.
-                    if let Err((_err, buf)) = self.uart.transmit_buffer(out_buffer, count) {
-                        self.output_buffer.put(Some(buf));
-                    } else {
-                        self.output_buffer.put(None);
-                    }
-                }
-                count
-            } else {
-                0
-            }
-        })
-    }
-
-    fn flush(&self, writer: &mut dyn IoWrite) {
-        self.internal_buffer.map(|ring_buffer| {
-            writer.write_ring_buffer(ring_buffer);
-        });
-    }
-
-    fn available_len(&self) -> usize {
-        self.internal_buffer.map_or(0, |rb| rb.available_len())
-    }
-
-    fn to_write_len(&self) -> usize {
-        self.internal_buffer.map_or(0, |rb| rb.len())
-    }
-}
-
-impl hil::uart::TransmitClient for UartDebugWriter {
-    fn transmitted_buffer(
-        &self,
-        buffer: &'static mut [u8],
-        _tx_len: usize,
-        _rcode: Result<(), ErrorCode>,
-    ) {
-        // Replace this buffer since we are done with it.
-        self.output_buffer.replace(buffer);
-
-        if self.internal_buffer.map_or(false, |buf| buf.has_elements()) {
-            // Buffer not empty, go around again
-            self.publish();
-        }
-    }
-    fn transmitted_word(&self, _rcode: Result<(), ErrorCode>) {}
-}
-
-impl IoWrite for UartDebugWriter {
-    fn write(&mut self, bytes: &[u8]) -> usize {
-        const FULL_MSG: &[u8] = b"\n*** DEBUG BUFFER FULL ***\n";
-        self.internal_buffer.map_or(0, |ring_buffer| {
-            let available_len_for_msg = ring_buffer.available_len().saturating_sub(FULL_MSG.len());
-
-            if available_len_for_msg >= bytes.len() {
-                for &b in bytes {
-                    ring_buffer.enqueue(b);
-                }
-                bytes.len()
-            } else {
-                for &b in &bytes[..available_len_for_msg] {
-                    ring_buffer.enqueue(b);
-                }
-                // When the buffer is close to full, print a warning and drop the current
-                // string.
-                for &b in FULL_MSG {
-                    ring_buffer.enqueue(b);
-                }
-                available_len_for_msg
-            }
-        })
-    }
 }
 
 impl Write for &dyn DebugWriter {


### PR DESCRIPTION
### Pull Request Overview

Now that we have a debug writer trait we don't need the uart debug writer implementation to be in the kernel. This PR moves it to system capsules.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
