### PR TITLE
kernel: make scheduler trait functions safe

### DIFF
--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -509,11 +509,9 @@ impl Kernel {
             }
 
             // Check if the scheduler wishes to continue running this process.
-            let continue_process = unsafe {
-                resources
-                    .scheduler()
-                    .continue_process(process.processid(), chip)
-            };
+            let continue_process = resources
+                .scheduler()
+                .continue_process(process.processid(), chip);
             if !continue_process {
                 return_reason = process::StoppedExecutingReason::KernelPreemption;
                 break;

--- a/kernel/src/scheduler.rs
+++ b/kernel/src/scheduler.rs
@@ -61,7 +61,7 @@ pub trait Scheduler<C: Chip> {
     /// processes to handle kernel tasks. Most schedulers will use this default
     /// implementation, which always prioritizes kernel work, but schedulers
     /// that wish to defer interrupt handling may reimplement it.
-    unsafe fn do_kernel_work_now(&self, chip: &C) -> bool {
+    fn do_kernel_work_now(&self, chip: &C) -> bool {
         chip.has_pending_interrupts() || DeferredCall::has_tasks()
     }
 
@@ -81,7 +81,7 @@ pub trait Scheduler<C: Chip> {
     /// returns `false`, then `do_process` will exit with a `KernelPreemption`.
     ///
     /// `id` is the identifier of the currently active process.
-    unsafe fn continue_process(&self, _id: ProcessId, chip: &C) -> bool {
+    fn continue_process(&self, _id: ProcessId, chip: &C) -> bool {
         !(chip.has_pending_interrupts() || DeferredCall::has_tasks())
     }
 }

--- a/kernel/src/scheduler/priority.rs
+++ b/kernel/src/scheduler/priority.rs
@@ -54,7 +54,7 @@ impl<C: Chip> Scheduler<C> for PrioritySched {
         })
     }
 
-    unsafe fn continue_process(&self, _: ProcessId, chip: &C) -> bool {
+    fn continue_process(&self, _: ProcessId, chip: &C) -> bool {
         // In addition to checking for interrupts, also checks if any higher
         // priority processes have become ready. This check is necessary because
         // a system call by this process could make another process ready, if


### PR DESCRIPTION


### Pull Request Overview

The implementations of the scheduler functions are not relevant for tock/rust memory safety. Historically, these implementations used unsafe deferred call functions and the idea was to not hide the unsafe. But since then there is no longer a need to declare the unsafe. As you can see from the patch there is no hidden unsafe.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
