### PR TITLE
enforcing alignment for allocate_app_memory_region

### DIFF
--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -6,7 +6,7 @@
 
 use core::cmp;
 use core::fmt::{self, Display};
-use kernel::utilities::math;
+use crate::utilities::math;
 
 /// User mode access permissions.
 #[derive(Copy, Clone, Debug)]
@@ -323,7 +323,7 @@ impl MPU for () {
 
         // Region size is the actual size the MPU region will be set to, and is
         // half of the total power of two size we are allocating to the app.
-        let mut region_size = memory_size_po2 / 2;
+        let region_size = memory_size_po2 / 2;
 
         // The region should start as close as possible to the start of the
         // unallocated memory.
@@ -337,7 +337,7 @@ impl MPU for () {
         if memory_size_po2 > unallocated_memory_size {
             None
         } else {
-            Some((region_start, memory_size_po2))
+            Some((region_start as *const u8, memory_size_po2))
         }
     }
 

--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -328,13 +328,11 @@ impl MPU for () {
         // The region should start as close as possible to the start of the
         // unallocated memory.
         let mut region_start = unallocated_memory_start as usize;
+        // If the start and length don't align, move region so that it does.
+        let alignment_shift = (region_size - (region_start % region_size)) % region_size;
+        region_start += alignment_shift;
 
-        // If the start and length don't align, move region up until it does.
-        if region_start % region_size != 0 {
-            region_start += region_size - (region_start % region_size);
-        }
-
-        if memory_size_po2 > unallocated_memory_size {
+        if memory_size_po2 + alignment_shift > unallocated_memory_size {
             None
         } else {
             Some((region_start as *const u8, memory_size_po2))


### PR DESCRIPTION
Tackling my first Open source issue: https://github.com/tock/tock/issues/1739

From the issue description, I figured I can just add the alignment logic I see in the implementation for allocate_app_memory_region in the cortex-m implementation for MPU.

So I changed allocate_app_memory_region in kernel/src/platform/mpu.rs to this to enforce alignment.
```
fn allocate_app_memory_region(
        &self,
        unallocated_memory_start: *const u8,
        unallocated_memory_size: usize,
        min_memory_size: usize,
        initial_app_memory_size: usize,
        initial_kernel_memory_size: usize,
        _permissions: Permissions,
        _config: &mut Self::MpuConfig,
    ) -> Option<(*const u8, usize)> {
        let memory_size = cmp::max(
            min_memory_size,
            initial_app_memory_size + initial_kernel_memory_size,
        );
        let memory_size_po2 = math::closest_power_of_two(memory_size as u32) as usize;

        // Region size is the actual size the MPU region will be set to, and is
        // half of the total power of two size we are allocating to the app.
        let mut region_size = memory_size_po2 / 2;

        // The region should start as close as possible to the start of the
        // unallocated memory.
        let mut region_start = unallocated_memory_start as usize;

        // If the start and length don't align, move region up until it does.
        if region_start % region_size != 0 {
            region_start += region_size - (region_start % region_size);
        }

        if memory_size_po2 > unallocated_memory_size {
            None
        } else {
            Some((region_start, memory_size_po2))
        }
    }

```

