### PR TITLE
ESP32-C3: Update makefile to use tockloader to install apps

### DIFF
--- a/boards/esp32-c3-devkitM-1/Makefile
+++ b/boards/esp32-c3-devkitM-1/Makefile
@@ -12,18 +12,26 @@ include ../Makefile.common
 .PHONY: install
 install: flash
 
-flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	esptool.py --chip esp32c3 elf2image --use_segments --output binary.hex $^ --dont-append-digest
-	esptool.py --chip esp32c3 write_flash --flash_mode dio --flash_size detect --flash_freq 80m  0x0 binary.hex
+.PHONY: init
+init:
+	tockloader local-board set esp32_c3_devkitm1 --binary-path esp32_c3_devkitm1.bin --arch rv32imc --app-address 0x403B0000 --flash-address 0x40380000
 
-flash-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-ifeq ($(APP),)
-	$(error "Please specify an APP to be flashed")
-endif
-	$(RISC_PREFIX)-objcopy --set-section-flags .apps=LOAD,ALLOC $^ $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf
-	$(RISC_PREFIX)-objcopy --update-section .apps=$(APP) $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf
-	esptool.py --port /dev/ttyUSB0 --chip esp32c3 elf2image --use_segments --output binary.hex $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf --dont-append-digest
-	esptool.py --port /dev/ttyUSB0 --chip esp32c3 write_flash --flash_mode dio --flash_size detect --flash_freq 80m 0x0 binary.hex
+# Write the kernel to the flash file with tockloader
+.PHONY: write-kernel
+write-kernel: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+	tockloader flash --local-board --address 0x40380000 $<
+
+esp32_c3_devkitm1.bin: write-kernel
+
+flash: esp32_c3_devkitm1.bin
+	# esp32_c3_devkitm1.bin contains the kernel and all apps. Convert that to a
+	# very simple ELF file.
+	$(OBJCOPY) --input-target=binary --output-target=elf32-littleriscv --change-section-address=.data=0x40380000 --set-start=0x40380000 esp32_c3_devkitm1.bin esp32_c3_devkitm1.bin.elf
+	# Convert our simple ELF file with the kernel and apps to an ESP32-C3
+	# compatible binary we can flash to the board.
+	esptool.py --chip esp32c3 elf2image --output esp32_c3_devkitm1.flash.bin esp32_c3_devkitm1.bin.elf --dont-append-digest
+	# Write the ESP32-C3 binary to the board.
+	esptool.py --chip esp32c3 write_flash --flash_mode dio --flash_size detect --flash_freq 80m 0x0 esp32_c3_devkitm1.flash.bin
 
 test:
 	$(Q)$(CARGO) test $(NO_RUN) --bin $(PLATFORM) --release

--- a/boards/esp32-c3-devkitM-1/README.md
+++ b/boards/esp32-c3-devkitM-1/README.md
@@ -14,7 +14,14 @@ compact design, security, high performance, and reliability.
 
 ## Setup
 
-Install the ESP tool
+Install the ESP tool:
+
+```shell
+# macOS
+brew install esptool
+```
+
+of from source:
 
 ```shell
 git clone https://github.com/espressif/esptool.git
@@ -26,12 +33,13 @@ The first time you are installing Tock you probably want to erase the
 flash first. This can be done with:
 
 ```shell
-esptool.py --port /dev/ttyUSB0 --chip esp32c3 erase_flash
+esptool.py --chip esp32c3 erase_flash
 ```
 
 After that you can run:
 
 ```shell
+make init
 make flash
 ```
 
@@ -72,14 +80,21 @@ Apps are built out-of-tree, for example:
 
 ```bash
 $ cd libtock-c/examples/<app>
-$ make RISCV=1
+$ make
 ```
 
-Then to flash an app:
+To "flash" an app, we first write it to a binary file that is combined with the
+kernel which we will write in its entirety to the board.
+
+```bash
+$ tockloader install --local-board
+```
+
+Then to flash the kernel with the app:
 
 ```
 $ cd tock/boards/esp32-c3-devkitM-1
-$ make flash-app APP=../../../libtock-c/examples/<app>/build/rv32imac/rv32imac.0x403B0060.0x3FCC0000.tbf
+$ make flash
 ```
 
 ## JTAG Debugging


### PR DESCRIPTION
### Pull Request Overview

Use the local board feature in tockloader to flash the kernel and apps all at once.

You'll love the solution I came up with for this. The esptool needs a very specific format to flash apps the bootloader will run. The only way in esptool v5+ to create the format is to convert an elf. We want to make a binary file that has the kernel code and apps in the same file. SO, this converts our local board binary file to an elf, then uses that elf to create the esp32c3 image, which we then flash.


### Testing Strategy

Running both blink and buttons on the board.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
