### PR TITLE
ci-nighly: fix creating GitHub issue

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -8,6 +8,10 @@ on:
   schedule:
   - cron: "0 0 * * *"
 
+  # Allow this workflow to be invoked manually, for an arbitrary ref
+  # (useful for testing PRs, etc)
+  workflow_dispatch:
+
 env:
   TERM: xterm # Makes tput work in actions output
 


### PR DESCRIPTION
### Pull Request Overview

Assinging a team to an issue is not supported. As a result, the nightly CI is currently failing on every run, but we didn't realize because the step to create a GitHub issue also fails.

This deliberately does not address the actual failure so we can see whether the action to create the issue now works.

Additionally, this includes a commit to pin the `dacbd/create-issue-action` to a specific version, namely `v2.0.0`, to avoid it silently breaking due to API changes.

To be able to test these changes, this further adds the ability to invoke the nightly workflow manually.

### Testing Strategy

This pull request will be tested the next time the CI runs with it merged.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
