### PR TITLE
ci-nightly: switch to `JasonEtco/create-an-issue` action

### DIFF
--- a/.github/ci_nightly_failure_issue_template.md
+++ b/.github/ci_nightly_failure_issue_template.md
@@ -1,0 +1,6 @@
+---
+title: Nightly CI Failed
+---
+
+- [Failed Run](https://github.com/{{ repo.owner }}/{{ repo.repo }}/actions/runs/{{ env.GITHUB_RUN_ID }})
+- [Codebase](https://github.com/{{ repo.owner }}/{{ repo.repo }}/tree/{{ sha }})

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -82,16 +82,11 @@ jobs:
         run: make ci-job-chips
       - name: ci-job-tools
         run: make ci-job-tools
-      - name: Create Issue on Failed workflow
+
+      - name: Create Issue on Failed Workflow
         if: failure()
-        uses: dacbd/create-issue-action@v2.0.0
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          token: ${{ github.token }}
-          title: Nightly CI failed
-          body: |
-            ### Context
-            [Failed Run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
-            [Codebase](https://github.com/${{ github.repository }}/tree/${{ github.sha }})
-            Workflow name - `${{ github.workflow }}`
-            Job -           `${{ github.job }}`
-            status -        `${{ job.status }}`
+          filename: .github/ci_nightly_failure_issue_template.md


### PR DESCRIPTION
### Pull Request Overview

It looks like the nightly workflow with tock/tock#4648 still doesn't work, producing a "SERVER ERROR" when trying to create an issue. Switch to JasonEtco's `create-an-issue`, which we're successfully using on tock/mirrorcheck.


### Testing Strategy

This pull request is tested after merging.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
