### PR TITLE
ci-nightly: fix artifact upload failures and file issue on workflow error

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -53,6 +53,14 @@ jobs:
           name: build-artifacts-${{ matrix.os }}
           path: tools/ci/ci-artifacts
 
+      - name: Create Issue on Failed Workflow
+        if: failure()
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/ci_nightly_failure_issue_template.md
+
   ci-tests:
     # Do not run job on forks
     if: github.repository == 'tock/tock'


### PR DESCRIPTION
### Pull Request Overview

- **ci-nightly: ci-build: add newlines in between workflow steps**
- **ci-nightly: fix upload-artifact failure of duplicate artifact names**
- **ci-nightly: ci-build: create issue on workflow failure**

### Testing Strategy

This pull request will be tested after merging.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
