### PR TITLE
`tock_kernel_layout.ld`: place `.stack` at bottom of SRAM

### DIFF
--- a/boards/build_scripts/tock_kernel_layout.ld
+++ b/boards/build_scripts/tock_kernel_layout.ld
@@ -236,9 +236,12 @@ SECTIONS
     {
         /* Kernel stack.
          *
-         * Tock places the kernel stack at the bottom of SRAM so that the
-         * kernel will trigger memory fault if it exceeds its stack depth,
-         * rather than silently overwriting valuable data.
+         * Tock places the kernel stack at the bottom of (the lowest address in)
+         * SRAM. This is to ensure that when the kernel stack grows from
+         * `_estack` down towards `_sstack` and ultimately overflows the
+         * latter, it overflows into unmapped / inaccessible memory. This causes
+         * the hardware to trigger a memory fault if the kernel exceeds its
+         * stack depth, rather than silently overwriting valuable data.
          */
         . = ALIGN(8);
         _sstack = .;


### PR DESCRIPTION
### Pull Request Overview

This is a partial revert of PR tock/tock#4518. That PR incorrectly swapped the `.stack` and `.relocate` sections in the kernel linker script, causing the `.stack` section to no longer be placed at the bottom (the lowest address) in SRAM.

This defeats a core safety mechanism in Tock: when the kernel stack grows from `_estack` down towards `_sstack` and ultimately overflows the latter, it should overflow into unmapped / inaccessible memory. However, with the changes of tock/tock#4518, it would instead overwrite kernel data.

It also clarifies the comment in the linker script to more explicitly document that we expect the stack to grow downwards, and that "bottom" of SRAM means the lowest SRAM address.

### Testing Strategy

This needs testing for all supported architectures, similar to what's done in #4518.


### TODO or Help Wanted

Still needs testing!


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
