### PR TITLE
Network working group call notes: November 10, 2025

### DIFF
--- a/doc/wg/network/notes/network-notes-2025-11-10.md
+++ b/doc/wg/network/notes/network-notes-2025-11-10.md
@@ -21,7 +21,7 @@
 - Leon: Tyler's Thread tests have been merged. Known as "tensile"
 - Tyler: Thread network testing. I named it tensile.
 - Tyler: Thanks Leon for sending that over the finish line.
-- Leon: The abstract for Treadmill is that you specify the board you want and you get a shell that can run stuff. Tyler wrote scripts that initialize a Pi which has four nRF52840s attached. There's one thread router, and three Tock devices that communicate with it. The python script checks that stuff runs and messages get delivered. Now running every night around 3am! And if it fails it should file a github issue tagging Tyler.
+- Leon: The abstraction for Treadmill is that you specify the board you want and you get a shell that can run stuff. Tyler wrote scripts that initialize a Pi which has four nRF52840s attached. There's one thread router, and three Tock devices that communicate with it. The python script checks that stuff runs and messages get delivered. Now running every night around 3am! And if it fails it should file a github issue tagging Tyler.
 - Tyler: It also tests that libtock-c 802.15.4 test applications. Checks that a payload is received.
 
 


### PR DESCRIPTION
### Pull Request Overview

This pull request adds notes from the Network Working Group call on November 10th, 2025.

[Rendered](https://github.com/tock/tock/blob/7779636b9abbd183602c5ca750581d4fef04ca20/doc/wg/network/notes/network-notes-2025-11-10.md)


### Testing Strategy

Documentation


### TODO or Help Wanted

Good to go


### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [N/A] Ran `make prepush`.
