### PR TITLE
[STV] make new deferred call `new()` constructor not panic

### DIFF
--- a/kernel/src/deferred_call.rs
+++ b/kernel/src/deferred_call.rs
@@ -199,13 +199,17 @@ impl DeferredCall {
     /// Create a new deferred call with a unique ID.
     pub fn new() -> Self {
         if let Some(ctr) = CTR.get() {
-            let idx = ctr.get() + 1;
+            let idx = ctr.get();
             ctr.set(idx + 1);
-            if let Some(nonzero_idx) = NonZero::new(idx) {
+
+            // Check if `idx` is >= 32. If so, we have run out of deferred call
+            // spots and can't create this deferred call.
+            if idx < u32::BITS as usize {
                 DeferredCall {
-                    idx_plus_one: Some(nonzero_idx),
+                    idx_plus_one: NonZero::new(idx + 1),
                 }
             } else {
+                // Invalid deferred call.
                 DeferredCall { idx_plus_one: None }
             }
         } else {


### PR DESCRIPTION
### Pull Request Overview

The first version of updating deferred call to use STV had `DeferredCall::new()` panic if the STV was not initialized. This is reasonable because not initializing STV is a configuration error that is not recoverable. However, because deferred calls can be used really early in a board's boot, the panic may not actually work/print. This makes the (honestly, reasonable) mistake of forgetting to init deferred calls just silently crash the board. Not good for users.

Rather than panic, this patch would allow `DeferredCall`s to be created but not be usable. This still means nothing will work, but this allows the `verify_setup()` function to panic instead, which happens when the kernel loop starts so panic will print. Also, since the board will panic at the beginning of the kernel loop (if deferred call was not inited), no deferred call would have actually run anyway, so having broken deferred calls won't prevent the verify_setup from running and panic-ing.


### Testing Strategy

todo


### TODO or Help Wanted

There is probably a better way to implement this.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
