### PR TITLE
.gitattributes: don't hide Cargo.lock diff by default on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2025.
+
 # Don't treat Cargo.lock as generated files, show full diff
 # https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github
 Cargo.lock -linguist-generated


### PR DESCRIPTION
### Pull Request Overview

This commit should cause GitHub to no longer hide `Cargo.lock` lockfile diffs on GitHub.


### Testing Strategy

This pull request tests itself.


### TODO or Help Wanted

N/A


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
