### PR TITLE
boards: litex: use AlarmHw

### DIFF
--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -125,46 +125,16 @@ struct LiteXArty {
     pconsole: &'static capsules_core::process_console::ProcessConsole<
         'static,
         { capsules_core::process_console::DEFAULT_COMMAND_HISTORY_LEN },
-        VirtualMuxAlarm<
-            'static,
-            litex_vexriscv::timer::LiteXAlarm<
-                'static,
-                'static,
-                socc::SoCRegisterFmt,
-                socc::ClockFrequency,
-            >,
-        >,
+        VirtualMuxAlarm<'static, AlarmHw>,
         components::process_console::Capability,
     >,
     lldb: &'static capsules_core::low_level_debug::LowLevelDebug<
         'static,
         capsules_core::virtualizers::virtual_uart::UartDevice<'static>,
     >,
-    alarm: &'static capsules_core::alarm::AlarmDriver<
-        'static,
-        VirtualMuxAlarm<
-            'static,
-            litex_vexriscv::timer::LiteXAlarm<
-                'static,
-                'static,
-                socc::SoCRegisterFmt,
-                socc::ClockFrequency,
-            >,
-        >,
-    >,
+    alarm: &'static capsules_core::alarm::AlarmDriver<'static, VirtualMuxAlarm<'static, AlarmHw>>,
     ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
-    scheduler: &'static MLFQSched<
-        'static,
-        VirtualMuxAlarm<
-            'static,
-            litex_vexriscv::timer::LiteXAlarm<
-                'static,
-                'static,
-                socc::SoCRegisterFmt,
-                socc::ClockFrequency,
-            >,
-        >,
-    >,
+    scheduler: &'static MLFQSched<'static, VirtualMuxAlarm<'static, AlarmHw>>,
     scheduler_timer: &'static SchedulerTimerHw,
 }
 
@@ -191,18 +161,7 @@ impl KernelResources<litex_vexriscv::chip::LiteXVexRiscv<LiteXArtyInterruptableP
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
     type ProcessFault = ();
-    type Scheduler = MLFQSched<
-        'static,
-        VirtualMuxAlarm<
-            'static,
-            litex_vexriscv::timer::LiteXAlarm<
-                'static,
-                'static,
-                socc::SoCRegisterFmt,
-                socc::ClockFrequency,
-            >,
-        >,
-    >;
+    type Scheduler = MLFQSched<'static, VirtualMuxAlarm<'static, AlarmHw>>;
     type SchedulerTimer = SchedulerTimerHw;
     type WatchDog = ();
     type ContextSwitchCallback = ();
@@ -359,12 +318,7 @@ unsafe fn start() -> (
     // Create the LiteXAlarm based on the hardware LiteXTimer core and
     // the uptime peripheral
     let litex_alarm = static_init!(
-        litex_vexriscv::timer::LiteXAlarm<
-            'static,
-            'static,
-            socc::SoCRegisterFmt,
-            socc::ClockFrequency,
-        >,
+        AlarmHw,
         litex_vexriscv::timer::LiteXAlarm::new(timer0_uptime, timer0)
     );
     timer0.set_timer_client(litex_alarm);
@@ -372,48 +326,18 @@ unsafe fn start() -> (
 
     // Create a shared virtualization mux layer on top of a single hardware
     // alarm.
-    let mux_alarm = static_init!(
-        MuxAlarm<
-            'static,
-            litex_vexriscv::timer::LiteXAlarm<
-                'static,
-                'static,
-                socc::SoCRegisterFmt,
-                socc::ClockFrequency,
-            >,
-        >,
-        MuxAlarm::new(litex_alarm)
-    );
+    let mux_alarm = static_init!(MuxAlarm<'static, AlarmHw>, MuxAlarm::new(litex_alarm));
     litex_alarm.set_alarm_client(mux_alarm);
 
     // Userspace alarm driver
     let virtual_alarm_user = static_init!(
-        VirtualMuxAlarm<
-            'static,
-            litex_vexriscv::timer::LiteXAlarm<
-                'static,
-                'static,
-                socc::SoCRegisterFmt,
-                socc::ClockFrequency,
-            >,
-        >,
+        VirtualMuxAlarm<'static, AlarmHw>,
         VirtualMuxAlarm::new(mux_alarm)
     );
     virtual_alarm_user.setup();
 
     let alarm = static_init!(
-        capsules_core::alarm::AlarmDriver<
-            'static,
-            VirtualMuxAlarm<
-                'static,
-                litex_vexriscv::timer::LiteXAlarm<
-                    'static,
-                    'static,
-                    socc::SoCRegisterFmt,
-                    socc::ClockFrequency,
-                >,
-            >,
-        >,
+        capsules_core::alarm::AlarmDriver<'static, VirtualMuxAlarm<'static, AlarmHw>>,
         capsules_core::alarm::AlarmDriver::new(
             virtual_alarm_user,
             board_kernel.create_grant(capsules_core::alarm::DRIVER_NUM, &memory_allocation_cap)
@@ -531,14 +455,7 @@ unsafe fn start() -> (
         process_printer,
         None,
     )
-    .finalize(components::process_console_component_static!(
-        litex_vexriscv::timer::LiteXAlarm<
-            'static,
-            'static,
-            socc::SoCRegisterFmt,
-            socc::ClockFrequency,
-        >
-    ));
+    .finalize(components::process_console_component_static!(AlarmHw));
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(


### PR DESCRIPTION
### Pull Request Overview

Use the `AlarmHw` type alias throughout main.rs for the litex boards. This simplifies many types.


### Testing Strategy

n/a


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
