### PR TITLE
Introduce the `PanicWriter` trait, a standard mechanism for implementing synchronous writers for panic messages

### DIFF
--- a/boards/apollo3/lora_things_plus/src/io.rs
+++ b/boards/apollo3/lora_things_plus/src/io.rs
@@ -44,7 +44,7 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     let led = &mut led::LedLow::new(led_pin);
     let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         writer,
         info,

--- a/boards/apollo3/lora_things_plus/src/io.rs
+++ b/boards/apollo3/lora_things_plus/src/io.rs
@@ -7,8 +7,8 @@ use core::panic::PanicInfo;
 use core::ptr::addr_of_mut;
 
 use kernel::debug;
-use kernel::debug::IoWrite;
 use kernel::hil::led;
+use kernel::utilities::io_write::IoWrite;
 
 /// Writer is used by kernel::debug to panic message to the serial port.
 pub struct Writer {}

--- a/boards/apollo3/redboard_artemis_atp/src/io.rs
+++ b/boards/apollo3/redboard_artemis_atp/src/io.rs
@@ -44,7 +44,7 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     let led = &mut led::LedLow::new(led_pin);
     let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         writer,
         info,

--- a/boards/apollo3/redboard_artemis_atp/src/io.rs
+++ b/boards/apollo3/redboard_artemis_atp/src/io.rs
@@ -7,8 +7,8 @@ use core::panic::PanicInfo;
 use core::ptr::addr_of_mut;
 
 use kernel::debug;
-use kernel::debug::IoWrite;
 use kernel::hil::led;
+use kernel::utilities::io_write::IoWrite;
 
 /// Writer is used by kernel::debug to panic message to the serial port.
 pub struct Writer {}

--- a/boards/apollo3/redboard_artemis_nano/src/io.rs
+++ b/boards/apollo3/redboard_artemis_nano/src/io.rs
@@ -44,7 +44,7 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     let led = &mut led::LedLow::new(led_pin);
     let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         writer,
         info,

--- a/boards/apollo3/redboard_artemis_nano/src/io.rs
+++ b/boards/apollo3/redboard_artemis_nano/src/io.rs
@@ -7,8 +7,8 @@ use core::panic::PanicInfo;
 use core::ptr::addr_of_mut;
 
 use kernel::debug;
-use kernel::debug::IoWrite;
 use kernel::hil::led;
+use kernel::utilities::io_write::IoWrite;
 
 /// Writer is used by kernel::debug to panic message to the serial port.
 pub struct Writer {}

--- a/boards/arty_e21/src/io.rs
+++ b/boards/arty_e21/src/io.rs
@@ -2,31 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::str;
 use kernel::debug;
-use kernel::debug::IoWrite;
 use kernel::hil::gpio;
 use kernel::hil::led;
-
-struct Writer {}
-
-static mut WRITER: Writer = Writer {};
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        sifive::uart::Uart::new(arty_e21_chip::uart::UART0_BASE, 32_000_000).transmit_sync(buf);
-        buf.len()
-    }
-}
 
 /// Panic handler.
 #[cfg(not(test))]
@@ -59,10 +38,20 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     );
 
     let led_red = &mut led::LedHigh::new(led_red_pin);
-    let writer = &mut *core::ptr::addr_of_mut!(WRITER);
-    debug::panic(
+
+    debug::panic::<_, sifive::uart::Uart, _, _>(
         &mut [led_red],
-        writer,
+        sifive::uart::UartPanicWriterConfig {
+            registers: arty_e21_chip::uart::UART0_BASE,
+            clock_frequency: 32_000_000,
+            params: kernel::hil::uart::Parameters {
+                baud_rate: 115200,
+                stop_bits: kernel::hil::uart::StopBits::One,
+                parity: kernel::hil::uart::Parity::None,
+                hw_flow_control: false,
+                width: kernel::hil::uart::Width::Eight,
+            },
+        },
         pi,
         &rv32i::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/clue_nrf52840/src/io.rs
+++ b/boards/clue_nrf52840/src/io.rs
@@ -128,7 +128,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P1_01);
     let led = &mut led::LedHigh::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         writer,
         pi,

--- a/boards/clue_nrf52840/src/io.rs
+++ b/boards/clue_nrf52840/src/io.rs
@@ -9,11 +9,11 @@ use core::ptr::addr_of_mut;
 use kernel::ErrorCode;
 
 use kernel::debug;
-use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart::Transmit;
 use kernel::hil::uart::{self};
 use kernel::utilities::cells::VolatileCell;
+use kernel::utilities::io_write::IoWrite;
 use nrf52840::gpio::Pin;
 
 struct Writer {

--- a/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/io.rs
+++ b/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/io.rs
@@ -76,7 +76,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_kernel_pin = &nrf52833::gpio::GPIOPin::new(Pin::P0_20);
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         writer,
         pi,

--- a/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/io.rs
+++ b/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/io.rs
@@ -6,9 +6,9 @@ use core::fmt::Write;
 use core::panic::PanicInfo;
 
 use kernel::debug;
-use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart;
+use kernel::utilities::io_write::IoWrite;
 use nrf52833::gpio::Pin;
 use nrf52833::uart::{Uarte, UARTE0_BASE};
 

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/io.rs
@@ -65,7 +65,7 @@ pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
     let led = &mut led::LedLow::new(led_kernel_pin);
     let mut writer = Writer::new();
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         &mut writer,
         pi,

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/io.rs
@@ -3,9 +3,9 @@
 // Copyright Tock Contributors 2024.
 
 use core::fmt::Write;
-use kernel::debug::IoWrite;
 use kernel::hil::uart;
 use kernel::hil::uart::Configure;
+use kernel::utilities::io_write::IoWrite;
 
 use nrf52840::uart::{Uarte, UARTE0_BASE};
 

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/io.rs
@@ -65,7 +65,7 @@ pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
     let led = &mut led::LedLow::new(led_kernel_pin);
     let mut writer = Writer::new();
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         &mut writer,
         pi,

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/io.rs
@@ -3,9 +3,9 @@
 // Copyright Tock Contributors 2024.
 
 use core::fmt::Write;
-use kernel::debug::IoWrite;
 use kernel::hil::uart;
 use kernel::hil::uart::Configure;
+use kernel::utilities::io_write::IoWrite;
 
 use nrf52840::uart::{Uarte, UARTE0_BASE};
 

--- a/boards/cy8cproto_62_4343_w/src/io.rs
+++ b/boards/cy8cproto_62_4343_w/src/io.rs
@@ -49,7 +49,7 @@ pub unsafe fn panic_fmt(panic_info: &PanicInfo) -> ! {
     let led_kernel_pin = &GpioPin::new(psoc62xa::gpio::PsocPin::P13_7);
     let led = &mut LedHigh::new(led_kernel_pin);
 
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         writer,
         panic_info,

--- a/boards/cy8cproto_62_4343_w/src/io.rs
+++ b/boards/cy8cproto_62_4343_w/src/io.rs
@@ -8,8 +8,9 @@ use kernel::utilities::cells::OptionalCell;
 use psoc62xa::gpio::GpioPin;
 use psoc62xa::scb::Scb;
 
-use kernel::debug::{self, IoWrite};
+use kernel::debug;
 use kernel::hil::led::LedHigh;
+use kernel::utilities::io_write::IoWrite;
 
 /// Writer is used by kernel::debug to panic message to the serial port.
 pub struct Writer {

--- a/boards/esp32-c3-devkitM-1/src/io.rs
+++ b/boards/esp32-c3-devkitM-1/src/io.rs
@@ -37,7 +37,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
 
     let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic_print(
+    debug::panic_print_old(
         writer,
         pi,
         &rv32i::support::nop,
@@ -56,7 +56,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
 
     let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic_print(
+    debug::panic_print_old(
         writer,
         pi,
         &rv32i::support::nop,

--- a/boards/esp32-c3-devkitM-1/src/io.rs
+++ b/boards/esp32-c3-devkitM-1/src/io.rs
@@ -6,7 +6,7 @@ use core::fmt::Write;
 use core::panic::PanicInfo;
 use core::str;
 use kernel::debug;
-use kernel::debug::IoWrite;
+use kernel::utilities::io_write::IoWrite;
 
 struct Writer {}
 

--- a/boards/esp32-c3-devkitM-1/src/io.rs
+++ b/boards/esp32-c3-devkitM-1/src/io.rs
@@ -49,6 +49,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         crate::PANIC_RESOURCES.get(),
     );
 
-    let _ = writeln!(writer, "{}", pi);
-    loop {}
+    loop {
+        rv32i::support::nop();
+    }
 }

--- a/boards/esp32-c3-devkitM-1/src/io.rs
+++ b/boards/esp32-c3-devkitM-1/src/io.rs
@@ -2,43 +2,24 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::str;
 use kernel::debug;
-use kernel::utilities::io_write::IoWrite;
-
-struct Writer {}
-
-static mut WRITER: Writer = Writer {};
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        let uart = esp32::uart::Uart::new(esp32::uart::UART0_BASE);
-        uart.disable_tx_interrupt();
-        uart.disable_rx_interrupt();
-        uart.transmit_sync(buf);
-        buf.len()
-    }
-}
 
 /// Panic handler.
 #[cfg(not(test))]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    use core::ptr::addr_of_mut;
-
-    let writer = &mut *addr_of_mut!(WRITER);
-
-    debug::panic_print_old(
-        writer,
+    debug::panic_print::<esp32::uart::Uart, _, _>(
+        esp32::uart::UartPanicWriterConfig {
+            registers: esp32::uart::UART0_BASE,
+            params: kernel::hil::uart::Parameters {
+                baud_rate: 115200,
+                stop_bits: kernel::hil::uart::StopBits::One,
+                parity: kernel::hil::uart::Parity::None,
+                hw_flow_control: false,
+                width: kernel::hil::uart::Width::Eight,
+            },
+        },
         pi,
         &rv32i::support::nop,
         crate::PANIC_RESOURCES.get(),
@@ -52,12 +33,17 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
 #[cfg(test)]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    use core::ptr::addr_of_mut;
-
-    let writer = &mut *addr_of_mut!(WRITER);
-
-    debug::panic_print_old(
-        writer,
+    debug::panic_print::<esp32::uart::Uart, _, _>(
+        esp32::uart::UartPanicWriterConfig {
+            registers: esp32::uart::UART0_BASE,
+            params: kernel::hil::uart::Parameters {
+                baud_rate: 115200,
+                stop_bits: kernel::hil::uart::StopBits::One,
+                parity: kernel::hil::uart::Parity::None,
+                hw_flow_control: false,
+                width: kernel::hil::uart::Width::Eight,
+            },
+        },
         pi,
         &rv32i::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/hail/src/io.rs
+++ b/boards/hail/src/io.rs
@@ -6,9 +6,9 @@ use core::fmt::Write;
 use core::panic::PanicInfo;
 use core::str;
 use kernel::debug;
-use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart::{self, Configure};
+use kernel::utilities::io_write::IoWrite;
 
 struct Writer {
     initialized: bool,

--- a/boards/hail/src/io.rs
+++ b/boards/hail/src/io.rs
@@ -70,7 +70,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let red_pin = sam4l::gpio::GPIOPin::new(sam4l::gpio::Pin::PA13);
     let led_red = &mut led::LedLow::new(&red_pin);
     let writer = &mut *addr_of_mut!(WRITER);
-    debug::panic(
+    debug::panic_old(
         &mut [led_red],
         writer,
         pi,

--- a/boards/hifive1/src/io.rs
+++ b/boards/hifive1/src/io.rs
@@ -7,9 +7,9 @@ use core::panic::PanicInfo;
 use core::ptr::addr_of_mut;
 use core::str;
 use kernel::debug;
-use kernel::debug::IoWrite;
 use kernel::hil::gpio;
 use kernel::hil::led;
+use kernel::utilities::io_write::IoWrite;
 
 struct Writer {}
 

--- a/boards/hifive1/src/io.rs
+++ b/boards/hifive1/src/io.rs
@@ -62,7 +62,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_red = &mut led::LedLow::new(&led_red_pin);
     let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic(
+    debug::panic_old(
         &mut [led_red],
         writer,
         pi,

--- a/boards/hifive_inventor/src/io.rs
+++ b/boards/hifive_inventor/src/io.rs
@@ -6,8 +6,8 @@ use core::fmt::Write;
 use core::panic::PanicInfo;
 use core::str;
 use kernel::debug;
-use kernel::debug::IoWrite;
 use kernel::hil::led;
+use kernel::utilities::io_write::IoWrite;
 
 struct Writer {}
 

--- a/boards/hifive_inventor/src/io.rs
+++ b/boards/hifive_inventor/src/io.rs
@@ -43,7 +43,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led = &mut led::LedLow::new(&led);
     let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         writer,
         pi,

--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -60,7 +60,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_pin = sam4l::gpio::GPIOPin::new(sam4l::gpio::Pin::PC22);
     let led = &mut led::LedLow::new(&led_pin);
     let writer = &mut *addr_of_mut!(WRITER);
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         writer,
         pi,

--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -5,9 +5,9 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
 use kernel::debug;
-use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart::{self, Configure};
+use kernel::utilities::io_write::IoWrite;
 
 struct Writer {
     initialized: bool,

--- a/boards/imxrt1050-evkb/src/io.rs
+++ b/boards/imxrt1050-evkb/src/io.rs
@@ -7,10 +7,10 @@ use core::panic::PanicInfo;
 use core::ptr::addr_of_mut;
 
 use kernel::debug;
-use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart;
 use kernel::hil::uart::Configure;
+use kernel::utilities::io_write::IoWrite;
 
 use crate::imxrt1050;
 use imxrt1050::gpio::PinId;

--- a/boards/imxrt1050-evkb/src/io.rs
+++ b/boards/imxrt1050-evkb/src/io.rs
@@ -69,7 +69,7 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     let led = &mut led::LedLow::new(&pin);
     let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         writer,
         info,

--- a/boards/litex/arty/src/io.rs
+++ b/boards/litex/arty/src/io.rs
@@ -60,7 +60,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     );
     let panic_led = led0.panic_led(0);
 
-    debug::panic(
+    debug::panic_old(
         &mut [&mut panic_led.unwrap()],
         &mut writer,
         pi,

--- a/boards/litex/arty/src/io.rs
+++ b/boards/litex/arty/src/io.rs
@@ -6,7 +6,7 @@ use core::fmt::Write;
 use core::panic::PanicInfo;
 use core::str;
 use kernel::debug;
-use kernel::debug::IoWrite;
+use kernel::utilities::io_write::IoWrite;
 
 struct Writer {
     uart: litex_vexriscv::uart::LiteXUart<'static, crate::socc::SoCRegisterFmt>,

--- a/boards/litex/sim/src/io.rs
+++ b/boards/litex/sim/src/io.rs
@@ -45,7 +45,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         ),
     };
 
-    debug::panic_print(
+    debug::panic_print_old(
         &mut writer,
         pi,
         &rv32i::support::nop,

--- a/boards/litex/sim/src/io.rs
+++ b/boards/litex/sim/src/io.rs
@@ -6,7 +6,7 @@ use core::fmt::Write;
 use core::panic::PanicInfo;
 use core::str;
 use kernel::debug;
-use kernel::debug::IoWrite;
+use kernel::utilities::io_write::IoWrite;
 
 struct Writer {
     uart: litex_vexriscv::uart::LiteXUart<'static, crate::socc::SoCRegisterFmt>,

--- a/boards/lora_e5_mini/src/io.rs
+++ b/boards/lora_e5_mini/src/io.rs
@@ -6,8 +6,8 @@ use core::fmt::Write;
 use core::panic::PanicInfo;
 use core::ptr::addr_of_mut;
 
-use kernel::debug::IoWrite;
 use kernel::hil::led;
+use kernel::utilities::io_write::IoWrite;
 
 use kernel::hil::led::Led;
 use kernel::hil::uart;
@@ -111,7 +111,7 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
         width: uart::Width::Eight,
     });
 
-    kernel::debug::panic_print(
+    kernel::debug::panic_print_old(
         &mut *addr_of_mut!(WRITER),
         info,
         &cortexm4::support::nop,

--- a/boards/lpc55s69-evk/src/io.rs
+++ b/boards/lpc55s69-evk/src/io.rs
@@ -23,11 +23,12 @@ use crate::LPCPin;
 use core::fmt::Write;
 use core::panic::PanicInfo;
 use core::ptr::addr_of_mut;
-use kernel::debug::{self, IoWrite};
+use kernel::debug;
 use kernel::hil::gpio::Configure;
 use kernel::hil::led::LedHigh;
 use kernel::hil::uart::{Configure as UARTconfig, Parameters, Parity, StopBits, Width};
 use kernel::utilities::cells::OptionalCell;
+use kernel::utilities::io_write::IoWrite;
 use lpc55s6x::gpio::GpioPin;
 use lpc55s6x::iocon::{Config, Function, Iocon, Pull, Slew};
 use lpc55s6x::uart::Uart;
@@ -143,7 +144,7 @@ pub unsafe fn panic_fmt(panic_info: &PanicInfo) -> ! {
     let led = &mut LedHigh::new(&red_led);
     let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         writer,
         panic_info,

--- a/boards/makepython-nrf52840/src/io.rs
+++ b/boards/makepython-nrf52840/src/io.rs
@@ -7,9 +7,9 @@ use core::panic::PanicInfo;
 use core::ptr::{addr_of, addr_of_mut};
 
 use kernel::debug;
-use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart::{self};
+use kernel::utilities::io_write::IoWrite;
 use kernel::ErrorCode;
 use nrf52840::gpio::Pin;
 

--- a/boards/makepython-nrf52840/src/io.rs
+++ b/boards/makepython-nrf52840/src/io.rs
@@ -126,7 +126,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P1_10);
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         writer,
         pi,

--- a/boards/microbit_v2/src/io.rs
+++ b/boards/microbit_v2/src/io.rs
@@ -76,7 +76,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_kernel_pin = &nrf52833::gpio::GPIOPin::new(Pin::P0_20);
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         writer,
         pi,

--- a/boards/microbit_v2/src/io.rs
+++ b/boards/microbit_v2/src/io.rs
@@ -6,9 +6,9 @@ use core::fmt::Write;
 use core::panic::PanicInfo;
 
 use kernel::debug;
-use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart;
+use kernel::utilities::io_write::IoWrite;
 use nrf52833::gpio::Pin;
 use nrf52833::uart::{Uarte, UARTE0_BASE};
 

--- a/boards/msp_exp432p401r/src/io.rs
+++ b/boards/msp_exp432p401r/src/io.rs
@@ -6,8 +6,8 @@ use core::fmt::Write;
 use core::panic::PanicInfo;
 use core::ptr::addr_of_mut;
 use kernel::debug;
-use kernel::debug::IoWrite;
 use kernel::hil::led;
+use kernel::utilities::io_write::IoWrite;
 use msp432::gpio::IntPinNr;
 use msp432::wdt::Wdt;
 

--- a/boards/msp_exp432p401r/src/io.rs
+++ b/boards/msp_exp432p401r/src/io.rs
@@ -42,7 +42,7 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     let wdt = Wdt::new();
 
     wdt.disable();
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         writer,
         info,

--- a/boards/nano33ble/src/io.rs
+++ b/boards/nano33ble/src/io.rs
@@ -128,7 +128,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         writer,
         pi,

--- a/boards/nano33ble/src/io.rs
+++ b/boards/nano33ble/src/io.rs
@@ -7,9 +7,9 @@ use core::panic::PanicInfo;
 use core::ptr::{addr_of, addr_of_mut};
 
 use kernel::debug;
-use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart::{self};
+use kernel::utilities::io_write::IoWrite;
 use kernel::ErrorCode;
 use nrf52840::gpio::Pin;
 

--- a/boards/nano33ble_rev2/src/io.rs
+++ b/boards/nano33ble_rev2/src/io.rs
@@ -8,9 +8,9 @@ use core::ptr::{addr_of, addr_of_mut};
 
 use cortexm4;
 use kernel::debug;
-use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart::{self};
+use kernel::utilities::io_write::IoWrite;
 use kernel::ErrorCode;
 use nrf52840::gpio::Pin;
 

--- a/boards/nano33ble_rev2/src/io.rs
+++ b/boards/nano33ble_rev2/src/io.rs
@@ -129,7 +129,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         writer,
         pi,

--- a/boards/nano_rp2040_connect/src/io.rs
+++ b/boards/nano_rp2040_connect/src/io.rs
@@ -5,10 +5,11 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
 
-use kernel::debug::{self, IoWrite};
+use kernel::debug;
 use kernel::hil::led::LedHigh;
 use kernel::hil::uart::{Configure, Parameters, Parity, StopBits, Width};
 use kernel::utilities::cells::OptionalCell;
+use kernel::utilities::io_write::IoWrite;
 
 use rp2040::gpio::{GpioFunction, RPGpio, RPGpioPin};
 use rp2040::uart::Uart;

--- a/boards/nano_rp2040_connect/src/io.rs
+++ b/boards/nano_rp2040_connect/src/io.rs
@@ -90,7 +90,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led = &mut LedHigh::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         writer,
         pi,

--- a/boards/nordic/nrf52840_dongle/src/io.rs
+++ b/boards/nordic/nrf52840_dongle/src/io.rs
@@ -60,7 +60,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_06);
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         writer,
         pi,

--- a/boards/nordic/nrf52840_dongle/src/io.rs
+++ b/boards/nordic/nrf52840_dongle/src/io.rs
@@ -5,9 +5,9 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
 use kernel::debug;
-use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart::{self, Configure};
+use kernel::utilities::io_write::IoWrite;
 use nrf52840::gpio::Pin;
 use nrf52840::uart::{Uarte, UARTE0_BASE};
 

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -3,9 +3,9 @@
 // Copyright Tock Contributors 2022.
 
 use core::fmt::Write;
-use kernel::debug::IoWrite;
 use kernel::hil::uart;
 use kernel::hil::uart::Configure;
+use kernel::utilities::io_write::IoWrite;
 
 use nrf52840::uart::{Uarte, UARTE0_BASE};
 

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -70,7 +70,7 @@ pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         writer,
         pi,

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -2,79 +2,56 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
+use kernel::debug;
+use kernel::hil::led;
 use kernel::hil::uart;
-use kernel::hil::uart::Configure;
-use kernel::utilities::io_write::IoWrite;
-
-use nrf52840::uart::{Uarte, UARTE0_BASE};
-
-enum Writer {
-    WriterUart(/* initialized */ bool),
-    WriterRtt(&'static segger::rtt::SeggerRttMemory<'static>),
-}
-
-static mut WRITER: Writer = Writer::WriterUart(false);
-
-/// Set the RTT memory buffer used to output panic messages.
-pub unsafe fn set_rtt_memory(rtt_memory: &'static segger::rtt::SeggerRttMemory<'static>) {
-    WRITER = Writer::WriterRtt(rtt_memory);
-}
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        match self {
-            Writer::WriterUart(ref mut initialized) => {
-                // Here, we create a second instance of the Uarte struct.
-                // This is okay because we only call this during a panic, and
-                // we will never actually process the interrupts
-                let uart = Uarte::new(UARTE0_BASE);
-                if !*initialized {
-                    *initialized = true;
-                    let _ = uart.configure(uart::Parameters {
-                        baud_rate: 115200,
-                        stop_bits: uart::StopBits::One,
-                        parity: uart::Parity::None,
-                        hw_flow_control: false,
-                        width: uart::Width::Eight,
-                    });
-                }
-                for &c in buf {
-                    unsafe { uart.send_byte(c) }
-                    while !uart.tx_ready() {}
-                }
-            }
-            Writer::WriterRtt(rtt_memory) => rtt_memory.write_sync(buf),
-        }
-        buf.len()
-    }
-}
+use kernel::utilities::cells::MapCell;
+use nrf52840::gpio::Pin;
 
 #[cfg(not(test))]
 #[panic_handler]
 /// Panic handler
 pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {
-    use core::ptr::addr_of_mut;
-    use kernel::debug;
-    use kernel::hil::led;
-    use nrf52840::gpio::Pin;
-
     // The nRF52840DK LEDs (see back of board)
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
     let led = &mut led::LedLow::new(led_kernel_pin);
-    let writer = &mut *addr_of_mut!(WRITER);
-    debug::panic_old(
-        &mut [led],
-        writer,
-        pi,
-        &cortexm4::support::nop,
-        crate::PANIC_RESOURCES.get(),
-    )
+
+    if crate::USB_DEBUGGING {
+        // Use the RTT output that needs to be setup in main.rs.
+
+        crate::RTT_BUFFER.get().and_then(MapCell::take).map_or_else(
+            || debug::panic_blink_forever(&mut [led]),
+            |rtt| {
+                debug::panic::<_, segger::rtt::SeggerRttMemory, _, _>(
+                    &mut [led],
+                    rtt,
+                    pi,
+                    &cortexm4::support::nop,
+                    crate::PANIC_RESOURCES.get(),
+                )
+            },
+        )
+    } else {
+        // Use the nRF52 UART for panic output.
+
+        debug::panic::<_, nrf52840::uart::Uarte, _, _>(
+            &mut [led],
+            nrf52840::uart::UartPanicWriterConfig {
+                params: uart::Parameters {
+                    baud_rate: 115200,
+                    stop_bits: uart::StopBits::One,
+                    parity: uart::Parity::None,
+                    hw_flow_control: false,
+                    width: uart::Width::Eight,
+                },
+                txd: crate::UART_TXD,
+                rxd: crate::UART_RXD,
+                cts: crate::UART_CTS,
+                rts: crate::UART_CTS,
+            },
+            pi,
+            &cortexm4::support::nop,
+            crate::PANIC_RESOURCES.get(),
+        )
+    }
 }

--- a/boards/nordic/nrf52dk/src/io.rs
+++ b/boards/nordic/nrf52dk/src/io.rs
@@ -16,7 +16,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_kernel_pin = &nrf52832::gpio::GPIOPin::new(Pin::P0_17);
     let led = &mut led::LedLow::new(led_kernel_pin);
 
-    debug::panic_new::<nrf52832::uart::Uarte, _, _, _>(
+    debug::panic::<_, nrf52832::uart::Uarte, _, _>(
         &mut [led],
         nrf52832::uart::UartPanicWriterConfig {
             params: uart::Parameters {

--- a/boards/nordic/nrf52dk/src/io.rs
+++ b/boards/nordic/nrf52dk/src/io.rs
@@ -2,67 +2,35 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
 use kernel::debug;
-use kernel::debug::IoWrite;
 use kernel::hil::led;
-use kernel::hil::uart::{self, Configure};
+use kernel::hil::uart;
 use nrf52832::gpio::Pin;
-use nrf52832::uart::{Uarte, UARTE0_BASE};
-
-struct Writer {
-    initialized: bool,
-}
-
-static mut WRITER: Writer = Writer { initialized: false };
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        // Here, we create a second instance of the Uarte struct.
-        // This is okay because we only call this during a panic, and
-        // we will never actually process the interrupts
-        let uart = Uarte::new(UARTE0_BASE);
-        if !self.initialized {
-            self.initialized = true;
-            let _ = uart.configure(uart::Parameters {
-                baud_rate: 115200,
-                stop_bits: uart::StopBits::One,
-                parity: uart::Parity::None,
-                hw_flow_control: false,
-                width: uart::Width::Eight,
-            });
-        }
-        for &c in buf {
-            unsafe {
-                uart.send_byte(c);
-            }
-            while !uart.tx_ready() {}
-        }
-        buf.len()
-    }
-}
 
 #[cfg(not(test))]
 #[panic_handler]
 /// Panic handler
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // The nRF52 DK LEDs (see back of board)
-
-    use core::ptr::addr_of_mut;
     let led_kernel_pin = &nrf52832::gpio::GPIOPin::new(Pin::P0_17);
     let led = &mut led::LedLow::new(led_kernel_pin);
-    let writer = &mut *addr_of_mut!(WRITER);
-    debug::panic(
+
+    debug::panic_new::<nrf52832::uart::Uarte, _, _, _>(
         &mut [led],
-        writer,
+        nrf52832::uart::UartPanicWriterConfig {
+            params: uart::Parameters {
+                baud_rate: 115200,
+                stop_bits: uart::StopBits::One,
+                parity: uart::Parity::None,
+                hw_flow_control: false,
+                width: uart::Width::Eight,
+            },
+            txd: crate::UART_TXD,
+            rxd: crate::UART_RXD,
+            cts: crate::UART_CTS,
+            rts: crate::UART_CTS,
+        },
         pi,
         &cortexm4::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/nucleo_f429zi/src/io.rs
+++ b/boards/nucleo_f429zi/src/io.rs
@@ -7,10 +7,10 @@ use core::panic::PanicInfo;
 use core::ptr::addr_of_mut;
 
 use kernel::debug;
-use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart;
 use kernel::hil::uart::Configure;
+use kernel::utilities::io_write::IoWrite;
 
 use stm32f429zi::chip_specs::Stm32f429Specs;
 use stm32f429zi::gpio::PinId;

--- a/boards/nucleo_f429zi/src/io.rs
+++ b/boards/nucleo_f429zi/src/io.rs
@@ -81,7 +81,7 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
 
     let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         writer,
         info,

--- a/boards/nucleo_f446re/src/io.rs
+++ b/boards/nucleo_f446re/src/io.rs
@@ -7,10 +7,10 @@ use core::panic::PanicInfo;
 use core::ptr::addr_of_mut;
 
 use kernel::debug;
-use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart;
 use kernel::hil::uart::Configure;
+use kernel::utilities::io_write::IoWrite;
 
 use stm32f446re::chip_specs::Stm32f446Specs;
 use stm32f446re::gpio::PinId;

--- a/boards/nucleo_f446re/src/io.rs
+++ b/boards/nucleo_f446re/src/io.rs
@@ -81,7 +81,7 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
 
     let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         writer,
         info,

--- a/boards/opentitan/earlgrey-cw310/src/io.rs
+++ b/boards/opentitan/earlgrey-cw310/src/io.rs
@@ -56,7 +56,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let writer = &mut *addr_of_mut!(WRITER);
 
     #[cfg(feature = "sim_verilator")]
-    debug::panic(
+    debug::panic_old(
         &mut [first_led],
         writer,
         pi,
@@ -65,7 +65,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     );
 
     #[cfg(not(feature = "sim_verilator"))]
-    debug::panic(
+    debug::panic_old(
         &mut [first_led],
         writer,
         pi,
@@ -80,9 +80,9 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let writer = &mut WRITER;
 
     #[cfg(feature = "sim_verilator")]
-    debug::panic_print(writer, pi, &|| {}, crate::PANIC_RESOURCES.get());
+    debug::panic_print_old(writer, pi, &|| {}, crate::PANIC_RESOURCES.get());
     #[cfg(not(feature = "sim_verilator"))]
-    debug::panic_print(
+    debug::panic_print_old(
         writer,
         pi,
         &rv32i::support::nop,

--- a/boards/opentitan/earlgrey-cw310/src/io.rs
+++ b/boards/opentitan/earlgrey-cw310/src/io.rs
@@ -7,7 +7,7 @@ use core::panic::PanicInfo;
 use core::str;
 use earlgrey::chip_config::EarlGreyConfig;
 use kernel::debug;
-use kernel::debug::IoWrite;
+use kernel::utilities::io_write::IoWrite;
 
 struct Writer {}
 

--- a/boards/particle_boron/src/io.rs
+++ b/boards/particle_boron/src/io.rs
@@ -66,7 +66,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(LED2_R_PIN);
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         writer,
         pi,

--- a/boards/particle_boron/src/io.rs
+++ b/boards/particle_boron/src/io.rs
@@ -5,10 +5,10 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
 use kernel::debug;
-use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart;
 use kernel::hil::uart::Configure;
+use kernel::utilities::io_write::IoWrite;
 use nrf52840::gpio::Pin;
 use nrf52840::uart::{Uarte, UARTE0_BASE};
 

--- a/boards/pico_explorer_base/src/io.rs
+++ b/boards/pico_explorer_base/src/io.rs
@@ -5,10 +5,11 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
 
-use kernel::debug::{self, IoWrite};
+use kernel::debug;
 use kernel::hil::led::LedHigh;
 use kernel::hil::uart::{Configure, Parameters, Parity, StopBits, Width};
 use kernel::utilities::cells::OptionalCell;
+use kernel::utilities::io_write::IoWrite;
 
 use rp2040::gpio::{GpioFunction, RPGpio, RPGpioPin};
 use rp2040::uart::Uart;

--- a/boards/pico_explorer_base/src/io.rs
+++ b/boards/pico_explorer_base/src/io.rs
@@ -92,7 +92,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led = &mut LedHigh::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         writer,
         pi,

--- a/boards/qemu_i486_q35/src/io.rs
+++ b/boards/qemu_i486_q35/src/io.rs
@@ -50,7 +50,7 @@ fn exit_qemu() -> ! {
 unsafe fn panic_handler(pi: &PanicInfo) -> ! {
     let mut com1 = BlockingSerialPort::new(COM1_BASE);
 
-    debug::panic_print(
+    debug::panic_print_old(
         &mut com1,
         pi,
         &x86::support::nop,

--- a/boards/qemu_rv32_virt/src/io.rs
+++ b/boards/qemu_rv32_virt/src/io.rs
@@ -2,42 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::str;
 
 use kernel::debug;
-use kernel::utilities::io_write::IoWrite;
-
-struct Writer {}
-
-static mut WRITER: Writer = Writer {};
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        let uart = qemu_rv32_virt_chip::uart::Uart16550::new(qemu_rv32_virt_chip::uart::UART0_BASE);
-        uart.transmit_sync(buf);
-        buf.len()
-    }
-}
+use kernel::hil::uart;
 
 /// Panic handler.
 #[cfg(not(test))]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    use core::ptr::addr_of_mut;
-
-    let writer = &mut *addr_of_mut!(WRITER);
-
-    debug::panic_print_old::<_, _, _>(
-        writer,
+    debug::panic_print::<qemu_rv32_virt_chip::uart::Uart16550, _, _>(
+        qemu_rv32_virt_chip::uart::UartPanicWriterConfig {
+            params: uart::Parameters {
+                baud_rate: 115200,
+                stop_bits: uart::StopBits::One,
+                parity: uart::Parity::None,
+                hw_flow_control: false,
+                width: uart::Width::Eight,
+            },
+        },
         pi,
         &rv32i::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/qemu_rv32_virt/src/io.rs
+++ b/boards/qemu_rv32_virt/src/io.rs
@@ -7,7 +7,7 @@ use core::panic::PanicInfo;
 use core::str;
 
 use kernel::debug;
-use kernel::debug::IoWrite;
+use kernel::utilities::io_write::IoWrite;
 
 struct Writer {}
 

--- a/boards/qemu_rv32_virt/src/io.rs
+++ b/boards/qemu_rv32_virt/src/io.rs
@@ -36,7 +36,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
 
     let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic_print::<_, _, _>(
+    debug::panic_print_old::<_, _, _>(
         writer,
         pi,
         &rv32i::support::nop,

--- a/boards/raspberry_pi_pico/src/io.rs
+++ b/boards/raspberry_pi_pico/src/io.rs
@@ -5,10 +5,11 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
 
-use kernel::debug::{self, IoWrite};
+use kernel::debug;
 use kernel::hil::led::LedHigh;
 use kernel::hil::uart::{Configure, Parameters, Parity, StopBits, Width};
 use kernel::utilities::cells::OptionalCell;
+use kernel::utilities::io_write::IoWrite;
 
 use rp2040::gpio::{GpioFunction, RPGpio, RPGpioPin};
 use rp2040::uart::Uart;

--- a/boards/raspberry_pi_pico/src/io.rs
+++ b/boards/raspberry_pi_pico/src/io.rs
@@ -92,7 +92,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led = &mut LedHigh::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         writer,
         pi,

--- a/boards/raspberry_pi_pico_2/src/io.rs
+++ b/boards/raspberry_pi_pico_2/src/io.rs
@@ -92,7 +92,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led = &mut LedHigh::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         writer,
         pi,

--- a/boards/raspberry_pi_pico_2/src/io.rs
+++ b/boards/raspberry_pi_pico_2/src/io.rs
@@ -5,10 +5,11 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
 
-use kernel::debug::{self, IoWrite};
+use kernel::debug;
 use kernel::hil::led::LedHigh;
 use kernel::hil::uart::{Configure, Parameters, Parity, StopBits, Width};
 use kernel::utilities::cells::OptionalCell;
+use kernel::utilities::io_write::IoWrite;
 
 use rp2350::gpio::{GpioFunction, RPGpio, RPGpioPin};
 use rp2350::uart::Uart;

--- a/boards/raspberry_pi_pico_w/src/io.rs
+++ b/boards/raspberry_pi_pico_w/src/io.rs
@@ -6,9 +6,10 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
 
-use kernel::debug::{self, IoWrite};
+use kernel::debug;
 use kernel::hil::uart::{Configure, Parameters, Parity, StopBits, Width};
 use kernel::utilities::cells::OptionalCell;
+use kernel::utilities::io_write::IoWrite;
 
 use rp2040::gpio::{GpioFunction, RPGpio, RPGpioPin};
 use rp2040::uart::Uart;

--- a/boards/raspberry_pi_pico_w/src/io.rs
+++ b/boards/raspberry_pi_pico_w/src/io.rs
@@ -88,7 +88,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     use core::ptr::addr_of_mut;
     let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic_print(
+    debug::panic_print_old(
         writer,
         pi,
         &cortexm0p::support::nop,

--- a/boards/redboard_redv/src/io.rs
+++ b/boards/redboard_redv/src/io.rs
@@ -63,7 +63,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_red = &mut led::LedLow::new(&led_red_pin);
     let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic(
+    debug::panic_old(
         &mut [led_red],
         writer,
         pi,

--- a/boards/redboard_redv/src/io.rs
+++ b/boards/redboard_redv/src/io.rs
@@ -6,9 +6,9 @@ use core::fmt::Write;
 use core::panic::PanicInfo;
 use core::str;
 use kernel::debug;
-use kernel::debug::IoWrite;
 use kernel::hil::gpio;
 use kernel::hil::led;
+use kernel::utilities::io_write::IoWrite;
 
 struct Writer {}
 

--- a/boards/sma_q3/src/io.rs
+++ b/boards/sma_q3/src/io.rs
@@ -5,8 +5,8 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
 use kernel::debug;
-use kernel::debug::IoWrite;
 use kernel::hil::led;
+use kernel::utilities::io_write::IoWrite;
 use nrf52840::gpio::Pin;
 
 enum Writer {

--- a/boards/sma_q3/src/io.rs
+++ b/boards/sma_q3/src/io.rs
@@ -48,7 +48,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         writer,
         pi,

--- a/boards/stm32f3discovery/src/io.rs
+++ b/boards/stm32f3discovery/src/io.rs
@@ -75,7 +75,7 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     let led = &mut led::LedHigh::new(&pin);
     let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         writer,
         info,

--- a/boards/stm32f3discovery/src/io.rs
+++ b/boards/stm32f3discovery/src/io.rs
@@ -7,10 +7,10 @@ use core::panic::PanicInfo;
 use core::ptr::addr_of_mut;
 
 use kernel::debug;
-use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart;
 use kernel::hil::uart::Configure;
+use kernel::utilities::io_write::IoWrite;
 
 use stm32f303xc::gpio::PinId;
 

--- a/boards/stm32f412gdiscovery/src/io.rs
+++ b/boards/stm32f412gdiscovery/src/io.rs
@@ -80,7 +80,7 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     let led = &mut led::LedHigh::new(&pin);
     let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         writer,
         info,

--- a/boards/stm32f412gdiscovery/src/io.rs
+++ b/boards/stm32f412gdiscovery/src/io.rs
@@ -7,10 +7,10 @@ use core::panic::PanicInfo;
 use core::ptr::addr_of_mut;
 
 use kernel::debug;
-use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart;
 use kernel::hil::uart::Configure;
+use kernel::utilities::io_write::IoWrite;
 
 use stm32f412g::chip_specs::Stm32f412Specs;
 use stm32f412g::gpio::PinId;

--- a/boards/stm32f429idiscovery/src/io.rs
+++ b/boards/stm32f429idiscovery/src/io.rs
@@ -82,7 +82,7 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
 
     let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         writer,
         info,

--- a/boards/stm32f429idiscovery/src/io.rs
+++ b/boards/stm32f429idiscovery/src/io.rs
@@ -7,10 +7,10 @@ use core::panic::PanicInfo;
 use core::ptr::addr_of_mut;
 
 use kernel::debug;
-use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart;
 use kernel::hil::uart::Configure;
+use kernel::utilities::io_write::IoWrite;
 
 use stm32f429zi::chip_specs::Stm32f429Specs;
 use stm32f429zi::gpio::PinId;

--- a/boards/teensy40/src/io.rs
+++ b/boards/teensy40/src/io.rs
@@ -4,11 +4,12 @@
 
 use core::fmt::{self, Write};
 
-use kernel::debug::{self, IoWrite};
+use kernel::debug;
 use kernel::hil::{
     led,
     uart::{self, Configure},
 };
+use kernel::utilities::io_write::IoWrite;
 
 use crate::imxrt1060::gpio;
 use crate::imxrt1060::lpuart;

--- a/boards/teensy40/src/io.rs
+++ b/boards/teensy40/src/io.rs
@@ -57,7 +57,7 @@ unsafe fn panic_handler(panic_info: &core::panic::PanicInfo) -> ! {
     let led = &mut led::LedHigh::new(&pin);
     let mut lpuart2 = lpuart::Lpuart::new_lpuart2(&ccm);
     let mut writer = Writer::new(&mut lpuart2);
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         &mut writer,
         panic_info,

--- a/boards/veer_el2_sim/src/io.rs
+++ b/boards/veer_el2_sim/src/io.rs
@@ -7,7 +7,7 @@ use core::panic::PanicInfo;
 use core::ptr::addr_of_mut;
 use core::ptr::write_volatile;
 use kernel::debug;
-use kernel::debug::IoWrite;
+use kernel::utilities::io_write::IoWrite;
 
 struct Writer {}
 

--- a/boards/veer_el2_sim/src/io.rs
+++ b/boards/veer_el2_sim/src/io.rs
@@ -41,7 +41,7 @@ impl IoWrite for Writer {
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic_print(
+    debug::panic_print_old(
         writer,
         pi,
         &rv32i::support::nop,

--- a/boards/weact_f401ccu6/src/io.rs
+++ b/boards/weact_f401ccu6/src/io.rs
@@ -81,7 +81,7 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
 
     let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic(
+    debug::panic_old(
         &mut [led],
         writer,
         info,

--- a/boards/weact_f401ccu6/src/io.rs
+++ b/boards/weact_f401ccu6/src/io.rs
@@ -7,10 +7,10 @@ use core::panic::PanicInfo;
 use core::ptr::addr_of_mut;
 
 use kernel::debug;
-use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart;
 use kernel::hil::uart::Configure;
+use kernel::utilities::io_write::IoWrite;
 
 use stm32f401cc::chip_specs::Stm32f401Specs;
 use stm32f401cc::gpio::PinId;

--- a/boards/wm1110dev/src/io.rs
+++ b/boards/wm1110dev/src/io.rs
@@ -2,64 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2023.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
 
 use kernel::debug;
-use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart;
 use nrf52840::gpio::Pin;
-use nrf52840::uart::UARTE0_BASE;
-
-/// Writer is used by kernel::debug to panic message to the serial port.
-pub struct Writer {
-    initialized: bool,
-}
-
-impl Writer {
-    /// Indicate that USART has already been initialized.
-    pub fn set_initialized(&mut self) {
-        self.initialized = true;
-    }
-}
-
-/// Global static for debug writer
-pub static mut WRITER: Writer = Writer { initialized: false };
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        let uart = nrf52840::uart::Uarte::new(UARTE0_BASE);
-
-        use kernel::hil::uart::Configure;
-
-        if !self.initialized {
-            self.initialized = true;
-            let _ = uart.configure(uart::Parameters {
-                baud_rate: 115200,
-                stop_bits: uart::StopBits::One,
-                parity: uart::Parity::None,
-                hw_flow_control: false,
-                width: uart::Width::Eight,
-            });
-        }
-
-        unsafe {
-            for &c in buf {
-                uart.send_byte(c);
-                while !uart.tx_ready() {}
-            }
-        }
-        buf.len()
-    }
-}
 
 /// Default panic handler for the microbit board.
 ///
@@ -68,14 +16,24 @@ impl IoWrite for Writer {
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // Red Led
-
-    use core::ptr::addr_of_mut;
     let led_red_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_14);
     let led = &mut led::LedHigh::new(led_red_pin);
-    let writer = &mut *addr_of_mut!(WRITER);
-    debug::panic(
+
+    debug::panic::<_, nrf52840::uart::Uarte, _, _>(
         &mut [led],
-        writer,
+        nrf52840::uart::UartPanicWriterConfig {
+            params: uart::Parameters {
+                baud_rate: 115200,
+                stop_bits: uart::StopBits::One,
+                parity: uart::Parity::None,
+                hw_flow_control: false,
+                width: uart::Width::Eight,
+            },
+            txd: crate::UART_TX_PIN,
+            rxd: crate::UART_RX_PIN,
+            cts: None,
+            rts: None,
+        },
         pi,
         &cortexm4::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/capsules/system/src/debug_writer/uart_debug_writer.rs
+++ b/capsules/system/src/debug_writer/uart_debug_writer.rs
@@ -7,9 +7,9 @@
 use kernel::collections::queue::Queue;
 use kernel::collections::ring_buffer::RingBuffer;
 use kernel::debug::DebugWriter;
-use kernel::debug::IoWrite;
 use kernel::hil;
 use kernel::utilities::cells::TakeCell;
+use kernel::utilities::io_write::IoWrite;
 use kernel::ErrorCode;
 
 /// Buffered [`DebugWriter`] implementation using a UART.
@@ -135,6 +135,13 @@ impl hil::uart::TransmitClient for UartDebugWriter {
         }
     }
     fn transmitted_word(&self, _rcode: Result<(), ErrorCode>) {}
+}
+
+impl core::fmt::Write for UartDebugWriter {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
 }
 
 impl IoWrite for UartDebugWriter {

--- a/chips/esp32/src/uart.rs
+++ b/chips/esp32/src/uart.rs
@@ -469,3 +469,56 @@ impl<'a> hil::uart::Receive<'a> for Uart<'a> {
         Err(ErrorCode::FAIL)
     }
 }
+
+use kernel::utilities::io_write::IoWrite;
+
+/// A synchronous writer for the esp32 useful for panics.
+///
+/// For boards that want to use the UART to display panic messages, this
+/// provides an implementation of
+/// [`PanicWriter`](kernel::platform::chip::PanicWriter) with synchronous
+/// output.
+///
+/// This is only to be used by panic messages and is not used within the normal
+/// operation of the Tock kernel.
+struct UartPanicWriter<'a> {
+    uart: Uart<'a>,
+}
+
+impl IoWrite for UartPanicWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> usize {
+        self.uart.transmit_sync(buf);
+        buf.len()
+    }
+}
+
+impl core::fmt::Write for UartPanicWriter<'_> {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+/// Configuration for the synchronous UART panic writer.
+///
+/// This captures everything needed to setup the UART for panic display, even
+/// if the normal kernel had initialized it differently.
+pub struct UartPanicWriterConfig {
+    pub registers: StaticRef<UartRegisters>,
+    pub params: kernel::hil::uart::Parameters,
+}
+
+impl kernel::platform::chip::PanicWriter for Uart<'_> {
+    type Config = UartPanicWriterConfig;
+
+    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite {
+        use kernel::hil::uart::Configure as _;
+
+        let uart = Uart::new(config.registers);
+
+        // Configure the UART correctly for panics.
+        let _ = uart.configure(config.params);
+
+        UartPanicWriter { uart }
+    }
+}

--- a/chips/esp32/src/uart.rs
+++ b/chips/esp32/src/uart.rs
@@ -481,6 +481,8 @@ use kernel::utilities::io_write::IoWrite;
 ///
 /// This is only to be used by panic messages and is not used within the normal
 /// operation of the Tock kernel.
+///
+/// TODO: Validate this [`UartPanicWriter`] is always sound to create.
 struct UartPanicWriter<'a> {
     uart: Uart<'a>,
 }

--- a/chips/esp32/src/uart.rs
+++ b/chips/esp32/src/uart.rs
@@ -511,7 +511,7 @@ pub struct UartPanicWriterConfig {
 impl kernel::platform::chip::PanicWriter for Uart<'_> {
     type Config = UartPanicWriterConfig;
 
-    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite {
+    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write {
         use kernel::hil::uart::Configure as _;
 
         let uart = Uart::new(config.registers);

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -12,12 +12,14 @@
 
 use core::cell::Cell;
 use core::cmp::min;
+use kernel::debug::{IoWrite, PanicWriter};
 use kernel::hil::uart;
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
+use nrf5x::gpio::Pin;
 use nrf5x::pinmux;
 
 const UARTE_MAX_BUFFER_SIZE: u32 = 0xff;
@@ -180,6 +182,57 @@ pub struct UARTParams {
     pub baud_rate: u32,
 }
 
+struct UartPanicWriter<'a> {
+    inner: Uarte<'a>,
+}
+
+impl kernel::debug::IoWrite for UartPanicWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> usize {
+        for &c in buf {
+            unsafe {
+                self.inner.send_byte(c);
+            }
+            while !self.inner.tx_ready() {}
+        }
+        buf.len()
+    }
+}
+
+impl core::fmt::Write for UartPanicWriter<'_> {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+pub struct UartPanicWriterConfig {
+    pub params: uart::Parameters,
+    pub txd: Pin,
+    pub rxd: Pin,
+    pub cts: Option<Pin>,
+    pub rts: Option<Pin>,
+}
+
+impl PanicWriter for Uarte<'_> {
+    type Config = UartPanicWriterConfig;
+
+    unsafe fn create_panic_writer(
+        config: Self::Config,
+    ) -> impl kernel::debug::IoWrite {
+        use uart::Configure as _;
+
+        let inner = Uarte::new(UARTE0_BASE);
+        inner.initialize(
+            pinmux::Pinmux::from_pin(config.txd),
+            pinmux::Pinmux::from_pin(config.rxd),
+            config.cts.map(|c| unsafe { pinmux::Pinmux::from_pin(c) }),
+            config.rts.map(|r| unsafe { pinmux::Pinmux::from_pin(r) }),
+        );
+        let _ = inner.configure(config.params);
+        UartPanicWriter { inner }
+    }
+}
+
 impl<'a> Uarte<'a> {
     /// Constructor
     // This should only be constructed once
@@ -198,16 +251,24 @@ impl<'a> Uarte<'a> {
         }
     }
 
-    /// Configure which pins the UART should use for txd, rxd, cts and rts
-    pub fn initialize(
-        &self,
-        txd: pinmux::Pinmux,
-        rxd: pinmux::Pinmux,
-        cts: Option<pinmux::Pinmux>,
-        rts: Option<pinmux::Pinmux>,
-    ) {
-        self.registers.pseltxd.write(Psel::PIN.val(txd.into()));
-        self.registers.pselrxd.write(Psel::PIN.val(rxd.into()));
+    fn initialize_inner(&self, txd: Pin, rxd: Pin, cts: Option<Pin>, rts: Option<Pin>) {
+        self.disable_uart();
+
+        // Stop any ongoing TX or RX DMA transmissions
+        self.registers.task_stoptx.write(Task::ENABLE::SET);
+        self.registers.task_stoprx.write(Task::ENABLE::SET);
+
+        // Make sure we clear the endtx and endrx interrupts since
+        // that is what we rely on to know when the DMA TX
+        // finishes. Normally, we clear this interrupt as we handle
+        // it, so this is not necessary. However, a bootloader (or
+        // some other startup code) may have setup TX interrupts, and
+        // there may be one pending. We clear it to be safe.
+        self.registers.event_endtx.write(Event::READY::CLEAR);
+        self.registers.event_endrx.write(Event::READY::CLEAR);
+
+        self.registers.pseltxd.write(Psel::PIN.val(txd as _));
+        self.registers.pselrxd.write(Psel::PIN.val(rxd as _));
         cts.map_or_else(
             || {
                 // If no CTS pin is provided, then we need to mark it as
@@ -215,7 +276,7 @@ impl<'a> Uarte<'a> {
                 self.registers.pselcts.write(Psel::CONNECT::SET);
             },
             |c| {
-                self.registers.pselcts.write(Psel::PIN.val(c.into()));
+                self.registers.pselcts.write(Psel::PIN.val(c as _));
             },
         );
         rts.map_or_else(
@@ -225,18 +286,27 @@ impl<'a> Uarte<'a> {
                 self.registers.pselrts.write(Psel::CONNECT::SET);
             },
             |r| {
-                self.registers.pselrts.write(Psel::PIN.val(r.into()));
+                self.registers.pselrts.write(Psel::PIN.val(r as _));
             },
         );
 
-        // Make sure we clear the endtx interrupt since that is what we rely on
-        // to know when the DMA TX finishes. Normally, we clear this interrupt
-        // as we handle it, so this is not necessary. However, a bootloader (or
-        // some other startup code) may have setup TX interrupts, and there may
-        // be one pending. We clear it to be safe.
-        self.registers.event_endtx.write(Event::READY::CLEAR);
-
         self.enable_uart();
+    }
+
+    /// Configure which pins the UART should use for txd, rxd, cts and rts
+    pub fn initialize(
+        &self,
+        txd: pinmux::Pinmux,
+        rxd: pinmux::Pinmux,
+        cts: Option<pinmux::Pinmux>,
+        rts: Option<pinmux::Pinmux>,
+    ) {
+        self.initialize_inner(
+            txd.into(),
+            rxd.into(),
+            cts.map(Into::into),
+            rts.map(Into::into),
+        )
     }
 
     // The datasheet gives a non-exhaustive list of example settings for

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -12,9 +12,9 @@
 
 use core::cell::Cell;
 use core::cmp::min;
-use kernel::debug::{IoWrite, PanicWriter};
 use kernel::hil::uart;
 use kernel::utilities::cells::OptionalCell;
+use kernel::utilities::io_write::IoWrite;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::utilities::StaticRef;
@@ -186,7 +186,7 @@ struct UartPanicWriter<'a> {
     inner: Uarte<'a>,
 }
 
-impl kernel::debug::IoWrite for UartPanicWriter<'_> {
+impl IoWrite for UartPanicWriter<'_> {
     fn write(&mut self, buf: &[u8]) -> usize {
         for &c in buf {
             unsafe {
@@ -213,12 +213,10 @@ pub struct UartPanicWriterConfig {
     pub rts: Option<Pin>,
 }
 
-impl PanicWriter for Uarte<'_> {
+impl kernel::platform::chip::PanicWriter for Uarte<'_> {
     type Config = UartPanicWriterConfig;
 
-    unsafe fn create_panic_writer(
-        config: Self::Config,
-    ) -> impl kernel::debug::IoWrite {
+    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite {
         use uart::Configure as _;
 
         let inner = Uarte::new(UARTE0_BASE);

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -574,6 +574,8 @@ impl<'a> uart::Receive<'a> for Uarte<'a> {
 ///
 /// This is only to be used by panic messages and is not used within the normal
 /// operation of the Tock kernel.
+///
+/// TODO: Validate this [`UartPanicWriter`] is always sound to create.
 struct UartPanicWriter<'a> {
     inner: Uarte<'a>,
 }

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -612,7 +612,7 @@ pub struct UartPanicWriterConfig {
 impl kernel::platform::chip::PanicWriter for Uarte<'_> {
     type Config = UartPanicWriterConfig;
 
-    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite {
+    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write {
         use uart::Configure as _;
 
         let inner = Uarte::new(UARTE0_BASE);

--- a/chips/qemu_rv32_virt_chip/src/uart.rs
+++ b/chips/qemu_rv32_virt_chip/src/uart.rs
@@ -528,6 +528,8 @@ impl<'a> hil::uart::Receive<'a> for Uart16550<'a> {
 ///
 /// This is only to be used by panic messages and is not used within the normal
 /// operation of the Tock kernel.
+///
+/// TODO: Validate this [`UartPanicWriter`] is always sound to create.
 struct UartPanicWriter<'a> {
     inner: Uart16550<'a>,
 }

--- a/chips/qemu_rv32_virt_chip/src/uart.rs
+++ b/chips/qemu_rv32_virt_chip/src/uart.rs
@@ -557,7 +557,7 @@ pub struct UartPanicWriterConfig {
 impl kernel::platform::chip::PanicWriter for Uart16550<'_> {
     type Config = UartPanicWriterConfig;
 
-    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite {
+    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write {
         use hil::uart::Configure as _;
 
         let inner = Uart16550::new(UART0_BASE);

--- a/chips/segger/src/rtt.rs
+++ b/chips/segger/src/rtt.rs
@@ -90,6 +90,7 @@ use kernel::hil;
 use kernel::hil::time::ConvertTicks;
 use kernel::hil::uart;
 use kernel::utilities::cells::{OptionalCell, TakeCell, VolatileCell};
+use kernel::utilities::io_write::IoWrite;
 use kernel::ErrorCode;
 
 /// Suggested length for the up buffer to pass to the Segger RTT capsule.
@@ -366,5 +367,40 @@ impl<'a, A: hil::time::Alarm<'a>> uart::Receive<'a> for SeggerRtt<'a, A> {
 
     fn receive_abort(&self) -> Result<(), ErrorCode> {
         Ok(())
+    }
+}
+
+/// A synchronous writer for Segger RTT.
+///
+/// For boards that want to use RTT to display panic messages, this
+/// provides an implementation of
+/// [`PanicWriter`](kernel::platform::chip::PanicWriter) with synchronous
+/// output.
+///
+/// This is only to be used by panic messages and is not used within the normal
+/// operation of the Tock kernel.
+struct RttPanicWriter<'a> {
+    inner: &'a SeggerRttMemory<'a>,
+}
+
+impl IoWrite for RttPanicWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> usize {
+        self.inner.write_sync(buf);
+        buf.len()
+    }
+}
+
+impl<'a> core::fmt::Write for RttPanicWriter<'a> {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+impl<'a> kernel::platform::chip::PanicWriter for SeggerRttMemory<'a> {
+    type Config = &'a SeggerRttMemory<'a>;
+
+    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite {
+        RttPanicWriter { inner: config }
     }
 }

--- a/chips/segger/src/rtt.rs
+++ b/chips/segger/src/rtt.rs
@@ -390,7 +390,7 @@ impl IoWrite for RttPanicWriter<'_> {
     }
 }
 
-impl<'a> core::fmt::Write for RttPanicWriter<'a> {
+impl core::fmt::Write for RttPanicWriter<'_> {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
         self.write(s.as_bytes());
         Ok(())

--- a/chips/segger/src/rtt.rs
+++ b/chips/segger/src/rtt.rs
@@ -400,7 +400,7 @@ impl core::fmt::Write for RttPanicWriter<'_> {
 impl<'a> kernel::platform::chip::PanicWriter for SeggerRttMemory<'a> {
     type Config = &'a SeggerRttMemory<'a>;
 
-    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite {
+    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write {
         RttPanicWriter { inner: config }
     }
 }

--- a/chips/segger/src/rtt.rs
+++ b/chips/segger/src/rtt.rs
@@ -379,6 +379,8 @@ impl<'a, A: hil::time::Alarm<'a>> uart::Receive<'a> for SeggerRtt<'a, A> {
 ///
 /// This is only to be used by panic messages and is not used within the normal
 /// operation of the Tock kernel.
+///
+/// TODO: Validate this [`RttPanicWriter`] is always sound to create.
 struct RttPanicWriter<'a> {
     inner: &'a SeggerRttMemory<'a>,
 }

--- a/chips/sifive/src/uart.rs
+++ b/chips/sifive/src/uart.rs
@@ -446,3 +446,57 @@ impl<'a> hil::uart::Receive<'a> for Uart<'a> {
         Err(ErrorCode::FAIL)
     }
 }
+
+use kernel::utilities::io_write::IoWrite;
+
+/// A synchronous writer for the sifive useful for panics.
+///
+/// For boards that want to use the UART to display panic messages, this
+/// provides an implementation of
+/// [`PanicWriter`](kernel::platform::chip::PanicWriter) with synchronous
+/// output.
+///
+/// This is only to be used by panic messages and is not used within the normal
+/// operation of the Tock kernel.
+struct UartPanicWriter<'a> {
+    uart: Uart<'a>,
+}
+
+impl IoWrite for UartPanicWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> usize {
+        self.uart.transmit_sync(buf);
+        buf.len()
+    }
+}
+
+impl core::fmt::Write for UartPanicWriter<'_> {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+/// Configuration for the synchronous UART panic writer.
+///
+/// This captures everything needed to setup the UART for panic display, even
+/// if the normal kernel had initialized it differently.
+pub struct UartPanicWriterConfig {
+    pub registers: StaticRef<UartRegisters>,
+    pub clock_frequency: u32,
+    pub params: kernel::hil::uart::Parameters,
+}
+
+impl kernel::platform::chip::PanicWriter for Uart<'_> {
+    type Config = UartPanicWriterConfig;
+
+    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite {
+        use kernel::hil::uart::Configure as _;
+
+        let uart = Uart::new(config.registers, config.clock_frequency);
+
+        // Configure the UART correctly for panics.
+        let _ = uart.configure(config.params);
+
+        UartPanicWriter { uart }
+    }
+}

--- a/chips/sifive/src/uart.rs
+++ b/chips/sifive/src/uart.rs
@@ -489,7 +489,7 @@ pub struct UartPanicWriterConfig {
 impl kernel::platform::chip::PanicWriter for Uart<'_> {
     type Config = UartPanicWriterConfig;
 
-    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite {
+    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write {
         use kernel::hil::uart::Configure as _;
 
         let uart = Uart::new(config.registers, config.clock_frequency);

--- a/chips/sifive/src/uart.rs
+++ b/chips/sifive/src/uart.rs
@@ -458,6 +458,8 @@ use kernel::utilities::io_write::IoWrite;
 ///
 /// This is only to be used by panic messages and is not used within the normal
 /// operation of the Tock kernel.
+///
+/// TODO: Validate this [`UartPanicWriter`] is always sound to create.
 struct UartPanicWriter<'a> {
     uart: Uart<'a>,
 }

--- a/chips/x86_q35/src/serial.rs
+++ b/chips/x86_q35/src/serial.rs
@@ -20,13 +20,13 @@ use core::mem::MaybeUninit;
 use x86::registers::io;
 
 use kernel::component::Component;
-use kernel::debug::IoWrite;
 use kernel::deferred_call::{DeferredCall, DeferredCallClient};
 use kernel::hil::uart::{
     Configure, Error, Parameters, Parity, Receive, ReceiveClient, StopBits, Transmit,
     TransmitClient, Width,
 };
 use kernel::utilities::cells::OptionalCell;
+use kernel::utilities::io_write::IoWrite;
 use kernel::ErrorCode;
 use tock_cells::take_cell::TakeCell;
 use tock_registers::{register_bitfields, LocalRegisterCopy};

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -173,8 +173,23 @@ impl<C: Chip, PP: ProcessPrinter> PanicResources<C, PP> {
     }
 }
 
+/// Interface for chips to create a synchronous writer for panics.
+///
+/// Any mechanism that can output a panic message during a panic must implement
+/// [`PanicWriter`] to enable the `panic()` functions to write the output. This
+/// requires the mechanism to provide a new constructor for the writer that
+/// creates a synchronous writer that implements [`IoWrite`].
 pub trait PanicWriter {
+    /// The configuration data the mechanism needs to configure the writer for
+    /// panic output.
     type Config;
+
+    /// Create a new synchronous writer capable of sending panic messages.
+    ///
+    /// The constructed writer must be created on the stack. Because panic
+    /// will never return this is effectively a static allocation.
+    ///
+    /// The writer must implement [`IoWrite`].
     unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite;
 }
 

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -133,7 +133,7 @@ use crate::utilities::single_thread_value::SingleThreadValue;
 ///
 /// See also the tracking issue:
 /// <https://github.com/rust-lang/rfcs/issues/2262>.
-pub trait IoWrite {
+pub trait IoWrite: Write {
     fn write(&mut self, buf: &[u8]) -> usize;
 
     fn write_ring_buffer(&mut self, buf: &RingBuffer<'_, u8>) -> usize {
@@ -171,6 +171,11 @@ impl<C: Chip, PP: ProcessPrinter> PanicResources<C, PP> {
             printer: MapCell::empty(),
         }
     }
+}
+
+pub trait PanicWriter {
+    type Config;
+    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite;
 }
 
 /// Tock panic routine, without the infinite LED-blinking loop.

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -213,6 +213,70 @@ pub unsafe fn panic<L: hil::led::Led, PW: PanicWriter, C: Chip, PP: ProcessPrint
     panic_blink_forever(leds)
 }
 
+/// Tock panic routine, without the infinite LED-blinking loop.
+///
+/// This is useful for boards which do not feature LEDs to blink or want to
+/// implement their own behavior. This method returns after performing the panic
+/// dump.
+///
+/// After this method returns, the system is no longer in a well-defined state.
+/// Care must be taken on how one interacts with the system once this function
+/// returns.
+///
+/// **NOTE:** The supplied `writer` must be synchronous.
+pub unsafe fn panic_print_old<W: Write + IoWrite, C: Chip, PP: ProcessPrinter>(
+    writer: &mut W,
+    panic_info: &PanicInfo,
+    nop: &dyn Fn(),
+    panic_resources: Option<&PanicResources<C, PP>>,
+) {
+    panic_begin(nop);
+    // Flush debug buffer if needed
+    flush(writer);
+    panic_banner(writer, panic_info);
+
+    panic_resources.map(|pr| {
+        let chip = pr.chip.take();
+        panic_cpu_state(chip, writer);
+
+        chip.map(|c| {
+            // Some systems may enforce memory protection regions for the kernel,
+            // making application memory inaccessible. However, printing process
+            // information will attempt to access memory. If we are provided a chip
+            // reference, attempt to disable userspace memory protection first:
+            use crate::platform::mpu::MPU;
+            c.mpu().disable_app_mpu()
+        });
+        pr.processes.take().map(|p| {
+            panic_process_info(p, pr.printer.take(), writer);
+        });
+    });
+}
+
+/// Tock default panic routine.
+///
+/// **NOTE:** The supplied `writer` must be synchronous.
+///
+/// This will print a detailed debugging message and then loop forever while
+/// blinking an LED in a recognizable pattern.
+pub unsafe fn panic_old<L: hil::led::Led, W: Write + IoWrite, C: Chip, PP: ProcessPrinter>(
+    leds: &mut [&L],
+    writer: &mut W,
+    panic_info: &PanicInfo,
+    nop: &dyn Fn(),
+    panic_resources: Option<&PanicResources<C, PP>>,
+) -> ! {
+    // Call `panic_print` first which will print out the panic information and
+    // return
+    panic_print_old(writer, panic_info, nop, panic_resources);
+
+    // The system is no longer in a well-defined state, we cannot
+    // allow this function to return
+    //
+    // Forever blink LEDs in an infinite loop
+    panic_blink_forever(leds)
+}
+
 /// Generic panic entry.
 ///
 /// This opaque method should always be called at the beginning of a board's

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -111,6 +111,7 @@ use core::str;
 use crate::capabilities::SetDebugWriterCapability;
 use crate::hil;
 use crate::platform::chip::Chip;
+use crate::platform::chip::PanicWriter;
 use crate::platform::chip::ThreadIdProvider;
 use crate::process::ProcessPrinter;
 use crate::process::ProcessSlot;
@@ -156,20 +157,23 @@ impl<C: Chip, PP: ProcessPrinter> PanicResources<C, PP> {
 /// returns.
 ///
 /// **NOTE:** The supplied `writer` must be synchronous.
-pub unsafe fn panic_print<W: Write + IoWrite, C: Chip, PP: ProcessPrinter>(
-    writer: &mut W,
+pub unsafe fn panic_print<PW: PanicWriter, C: Chip, PP: ProcessPrinter>(
+    writer_config: PW::Config,
     panic_info: &PanicInfo,
     nop: &dyn Fn(),
     panic_resources: Option<&PanicResources<C, PP>>,
 ) {
+    // Create the synchronous writer we can use to output the panic message.
+    let mut writer = PW::create_panic_writer(writer_config);
+
     panic_begin(nop);
     // Flush debug buffer if needed
-    flush(writer);
-    panic_banner(writer, panic_info);
+    flush(&mut writer);
+    panic_banner(&mut writer, panic_info);
 
     panic_resources.map(|pr| {
         let chip = pr.chip.take();
-        panic_cpu_state(chip, writer);
+        panic_cpu_state(chip, &mut writer);
 
         chip.map(|c| {
             // Some systems may enforce memory protection regions for the kernel,
@@ -180,7 +184,7 @@ pub unsafe fn panic_print<W: Write + IoWrite, C: Chip, PP: ProcessPrinter>(
             c.mpu().disable_app_mpu()
         });
         pr.processes.take().map(|p| {
-            panic_process_info(p, pr.printer.take(), writer);
+            panic_process_info(p, pr.printer.take(), &mut writer);
         });
     });
 }
@@ -191,16 +195,16 @@ pub unsafe fn panic_print<W: Write + IoWrite, C: Chip, PP: ProcessPrinter>(
 ///
 /// This will print a detailed debugging message and then loop forever while
 /// blinking an LED in a recognizable pattern.
-pub unsafe fn panic<L: hil::led::Led, W: Write + IoWrite, C: Chip, PP: ProcessPrinter>(
+pub unsafe fn panic<L: hil::led::Led, PW: PanicWriter, C: Chip, PP: ProcessPrinter>(
     leds: &mut [&L],
-    writer: &mut W,
+    writer_config: PW::Config,
     panic_info: &PanicInfo,
     nop: &dyn Fn(),
     panic_resources: Option<&PanicResources<C, PP>>,
 ) -> ! {
     // Call `panic_print` first which will print out the panic information and
     // return
-    panic_print(writer, panic_info, nop, panic_resources);
+    panic_print::<PW, C, PP>(writer_config, panic_info, nop, panic_resources);
 
     // The system is no longer in a well-defined state, we cannot
     // allow this function to return

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -109,7 +109,6 @@ use core::panic::PanicInfo;
 use core::str;
 
 use crate::capabilities::SetDebugWriterCapability;
-use crate::collections::ring_buffer::RingBuffer;
 use crate::hil;
 use crate::platform::chip::Chip;
 use crate::platform::chip::ThreadIdProvider;
@@ -119,35 +118,8 @@ use crate::processbuffer::ReadableProcessSlice;
 use crate::utilities::binary_write::BinaryToWriteWrapper;
 use crate::utilities::cells::MapCell;
 use crate::utilities::cells::NumericCellExt;
+use crate::utilities::io_write::IoWrite;
 use crate::utilities::single_thread_value::SingleThreadValue;
-
-/// Implementation of `std::io::Write` for `no_std`.
-///
-/// This takes bytes instead of a string (contrary to [`core::fmt::Write`]), but
-/// we cannot use `std::io::Write' as it isn't available in `no_std` (due to
-/// `std::io::Error` not being available).
-///
-/// Also, in our use cases, writes are infallible, so the write function cannot
-/// return an `Err`, however it might not be able to write everything, so it
-/// returns the number of bytes written.
-///
-/// See also the tracking issue:
-/// <https://github.com/rust-lang/rfcs/issues/2262>.
-pub trait IoWrite: Write {
-    fn write(&mut self, buf: &[u8]) -> usize;
-
-    fn write_ring_buffer(&mut self, buf: &RingBuffer<'_, u8>) -> usize {
-        let (left, right) = buf.as_slices();
-        let mut total = 0;
-        if let Some(slice) = left {
-            total += self.write(slice);
-        }
-        if let Some(slice) = right {
-            total += self.write(slice);
-        }
-        total
-    }
-}
 
 ///////////////////////////////////////////////////////////////////
 // panic! support routines
@@ -171,26 +143,6 @@ impl<C: Chip, PP: ProcessPrinter> PanicResources<C, PP> {
             printer: MapCell::empty(),
         }
     }
-}
-
-/// Interface for chips to create a synchronous writer for panics.
-///
-/// Any mechanism that can output a panic message during a panic must implement
-/// [`PanicWriter`] to enable the `panic()` functions to write the output. This
-/// requires the mechanism to provide a new constructor for the writer that
-/// creates a synchronous writer that implements [`IoWrite`].
-pub trait PanicWriter {
-    /// The configuration data the mechanism needs to configure the writer for
-    /// panic output.
-    type Config;
-
-    /// Create a new synchronous writer capable of sending panic messages.
-    ///
-    /// The constructed writer must be created on the stack. Because panic
-    /// will never return this is effectively a static allocation.
-    ///
-    /// The writer must implement [`IoWrite`].
-    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite;
 }
 
 /// Tock panic routine, without the infinite LED-blinking loop.

--- a/kernel/src/platform/chip.rs
+++ b/kernel/src/platform/chip.rs
@@ -6,6 +6,7 @@
 
 use crate::platform::mpu;
 use crate::syscall;
+use crate::utilities::io_write::IoWrite;
 use core::fmt::Write;
 
 /// Interface for individual MCUs.
@@ -176,3 +177,23 @@ impl ClockInterface for NoClockControl {
 /// Instance of NoClockControl for things that need references to
 /// `ClockInterface` objects.
 pub const NO_CLOCK_CONTROL: NoClockControl = NoClockControl {};
+
+/// Interface for chips to create a synchronous writer for panics.
+///
+/// Any mechanism that can output a panic message during a panic must implement
+/// [`PanicWriter`] to enable the `panic()` functions to write the output. This
+/// requires the mechanism to provide a new constructor for the writer that
+/// creates a synchronous writer that implements [`IoWrite`].
+pub trait PanicWriter {
+    /// The configuration data the mechanism needs to configure the writer for
+    /// panic output.
+    type Config;
+
+    /// Create a new synchronous writer capable of sending panic messages.
+    ///
+    /// The constructed writer must be created on the stack. Because panic
+    /// will never return this is effectively a static allocation.
+    ///
+    /// The writer must implement [`IoWrite`].
+    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite;
+}

--- a/kernel/src/platform/chip.rs
+++ b/kernel/src/platform/chip.rs
@@ -197,5 +197,5 @@ pub trait PanicWriter {
     ///
     /// The writer must implement [`IoWrite`] (which is just `std:io::Write`
     /// implemented for no_std).
-    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite;
+    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write;
 }

--- a/kernel/src/platform/chip.rs
+++ b/kernel/src/platform/chip.rs
@@ -184,6 +184,10 @@ pub const NO_CLOCK_CONTROL: NoClockControl = NoClockControl {};
 /// [`PanicWriter`] to enable the `panic()` functions to write the output. This
 /// requires the mechanism to provide a new constructor for the writer that
 /// creates a synchronous writer that implements [`IoWrite`].
+///
+/// This is a dedicated trait because synchronous I/O is only used for panic
+/// handling. This allows chips to clearly separate synchronous implementations
+/// that are a special case only for panics.
 pub trait PanicWriter {
     /// The configuration data the mechanism needs to configure the writer for
     /// panic output.
@@ -191,9 +195,7 @@ pub trait PanicWriter {
 
     /// Create a new synchronous writer capable of sending panic messages.
     ///
-    /// The constructed writer must be created on the stack. Because panic
-    /// will never return this is effectively a static allocation.
-    ///
-    /// The writer must implement [`IoWrite`].
+    /// The writer must implement [`IoWrite`] (which is just `std:io::Write`
+    /// implemented for no_std).
     unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite;
 }

--- a/kernel/src/utilities/io_write.rs
+++ b/kernel/src/utilities/io_write.rs
@@ -1,0 +1,35 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! Re-implementation of `std:io` traits not available in `no_std`.
+
+use crate::collections::ring_buffer::RingBuffer;
+
+/// Implementation of `std::io::Write` for `no_std`.
+///
+/// This takes bytes instead of a string (contrary to [`core::fmt::Write`]), but
+/// we cannot use `std::io::Write' as it isn't available in `no_std` (due to
+/// `std::io::Error` not being available).
+///
+/// Also, in our use cases, writes are infallible, so the write function cannot
+/// return an `Err`, however it might not be able to write everything, so it
+/// returns the number of bytes written.
+///
+/// See also the tracking issue:
+/// <https://github.com/rust-lang/rfcs/issues/2262>.
+pub trait IoWrite: core::fmt::Write {
+    fn write(&mut self, buf: &[u8]) -> usize;
+
+    fn write_ring_buffer(&mut self, buf: &RingBuffer<'_, u8>) -> usize {
+        let (left, right) = buf.as_slices();
+        let mut total = 0;
+        if let Some(slice) = left {
+            total += self.write(slice);
+        }
+        if let Some(slice) = right {
+            total += self.write(slice);
+        }
+        total
+    }
+}

--- a/kernel/src/utilities/io_write.rs
+++ b/kernel/src/utilities/io_write.rs
@@ -18,7 +18,7 @@ use crate::collections::ring_buffer::RingBuffer;
 ///
 /// See also the tracking issue:
 /// <https://github.com/rust-lang/rfcs/issues/2262>.
-pub trait IoWrite: core::fmt::Write {
+pub trait IoWrite {
     fn write(&mut self, buf: &[u8]) -> usize;
 
     fn write_ring_buffer(&mut self, buf: &RingBuffer<'_, u8>) -> usize {

--- a/kernel/src/utilities/mod.rs
+++ b/kernel/src/utilities/mod.rs
@@ -9,6 +9,7 @@ pub mod binary_write;
 pub mod capability_ptr;
 pub mod copy_slice;
 pub mod helpers;
+pub mod io_write;
 pub mod leasable_buffer;
 pub mod machine_register;
 pub mod math;


### PR DESCRIPTION
### Pull Request Overview

For a long time, Tock's kernel-provided panic utilities required some type that implements `IoWrite` to display panic messages. How a board created such a type was up to each board, and the io.rs files we have in boards have used a variety of methods to do this. This has had the effect of creating three issues:

1. These types (that implement `IoWrite`) are often instantiated as `static mut`s, which we are trying to get rid of.
2. These types often make assumptions about the state of the underlying hardware when the panic happens, and assume the kernel initialized the hardware correctly and that the object used by the normal kernel operation can still be used during a panic.
3. Implementations of the types are duplicated across many boards, sometimes identically and sometimes with minor changes.

To try to fix these issues, this PR (from the static mut task force) proposes a new trait `PanicWriter` that chips would implement to provide a synchronous writer suitable for panic messages. Boards then only need to select the implementation of `PanicWriter` they want to use for panics, and the chip-provided implementation is used by debug.rs to correctly display the panic message.

The trait looks like this:

```rust
pub trait PanicWriter {
    /// The configuration data the mechanism needs to configure the writer for panic output.
    type Config;

    /// Create a new synchronous writer capable of sending panic messages.
    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite;
}
```

The config type permits the board to provide whatever settings are necessary for the implementation to correctly configure the hardware for panic output.

This addresses the three concerns by:

1. The `create_panic_writer()` function must instantiate the object on the stack, so it is not declared as a `static mut`.
2. The chip-provided implementations must create a new hardware object instantiation, eliminating sharing between the main kernel and the panic handler. Also, the config provides a method for communicating exactly the settings needed by the writer.
3. The implementations are provided by chips and not each board, eliminating redundancy.


### Testing Strategy

todo


### TODO or Help Wanted

Thoughts?

Need to port every chip.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
