### PR TITLE
Fix `is_pending` method in `DeferredCall` to check for any set bits

### DIFF
--- a/kernel/src/deferred_call.rs
+++ b/kernel/src/deferred_call.rs
@@ -251,7 +251,7 @@ impl DeferredCall {
     /// deferred call.
     pub fn is_pending(&self) -> bool {
         if let Some(bitmask) = BITMASK.get() {
-            bitmask.get() & (1 << self.idx) == 1
+            bitmask.get() & (1 << self.idx) != 0
         } else {
             false
         }


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes a potential issue identified in the `is_pending()` method of  [deferred_call.rs](https://github.com/tock/tock/blob/b8338a8c9507b2d64fcfa4700372aabe3a785032/kernel/src/deferred_call.rs#L254C13-L254C49).

It seems that the check for pending deferred calls may be wrong. `DeferredCall::is_pending()` currently returns true only for deferred calls with `idx == 0`. 

### TODO or Help Wanted

This pull request still needs help with testing / validation of the issue.

### Documentation Updated

No updates seem to be required to the docs.
- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
