### PR TITLE
Add `DriverNumber` type

### DIFF
--- a/boards/apollo3/lora_things_plus/src/main.rs
+++ b/boards/apollo3/lora_things_plus/src/main.rs
@@ -54,6 +54,7 @@ use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 use kernel::{create_capability, debug, static_init};
 
 #[cfg(feature = "atecc508a")]
@@ -114,8 +115,10 @@ static mut ATECC508A: Option<&'static capsules_extra::atecc508a::Atecc508a<'stat
 
 kernel::stack_size! {0x1000}
 
-const LORA_SPI_DRIVER_NUM: usize = capsules_core::driver::NUM::LoRaPhySPI as usize;
-const LORA_GPIO_DRIVER_NUM: usize = capsules_core::driver::NUM::LoRaPhyGPIO as usize;
+const LORA_SPI_DRIVER_NUM: DriverNumber =
+    DriverNumber::from_const(capsules_core::driver::NUM::LoRaPhySPI as usize);
+const LORA_GPIO_DRIVER_NUM: DriverNumber =
+    DriverNumber::from_const(capsules_core::driver::NUM::LoRaPhyGPIO as usize);
 
 type ChirpI2cMoistureType = components::chirp_i2c_moisture::ChirpI2cMoistureComponentType<
     capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, apollo3::iom::Iom<'static>>,
@@ -327,7 +330,7 @@ unsafe fn setup_dfrobot_i2c_rainfall(
 
 /// Mapping of integer syscalls to objects that implement syscalls.
 impl SyscallDriverLookup for LoRaThingsPlus {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/apollo3/redboard_artemis_atp/src/main.rs
+++ b/boards/apollo3/redboard_artemis_atp/src/main.rs
@@ -27,6 +27,7 @@ use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 use kernel::{create_capability, debug, static_init};
 
 /// Support routines for debugging I/O.
@@ -106,7 +107,7 @@ struct RedboardArtemisAtp {
 
 /// Mapping of integer syscalls to objects that implement syscalls.
 impl SyscallDriverLookup for RedboardArtemisAtp {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/apollo3/redboard_artemis_nano/src/main.rs
+++ b/boards/apollo3/redboard_artemis_nano/src/main.rs
@@ -27,6 +27,7 @@ use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 use kernel::{create_capability, debug, static_init};
 
 /// Support routines for debugging I/O.
@@ -117,7 +118,7 @@ struct RedboardArtemisNano {
 
 /// Mapping of integer syscalls to objects that implement syscalls.
 impl SyscallDriverLookup for RedboardArtemisNano {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/arty_e21/src/main.rs
+++ b/boards/arty_e21/src/main.rs
@@ -11,12 +11,12 @@ use arty_e21_chip::chip::ArtyExxDefaultPeripherals;
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 
 use crate::debug::PanicResources;
-use kernel::capabilities;
 use kernel::component::Component;
 use kernel::hil;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::priority::PrioritySched;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::{capabilities, DriverNumber};
 use kernel::{create_capability, debug, static_init};
 
 #[allow(dead_code)]
@@ -65,7 +65,7 @@ struct ArtyE21 {
 
 /// Mapping of integer syscalls to objects that implement syscalls.
 impl SyscallDriverLookup for ArtyE21 {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -30,6 +30,7 @@ use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::utilities::cells::MapCell;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
 
@@ -206,7 +207,7 @@ pub struct Platform {
 }
 
 impl SyscallDriverLookup for Platform {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/components/src/adc.rs
+++ b/boards/components/src/adc.rs
@@ -12,6 +12,7 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::adc;
+use kernel::DriverNumber;
 
 #[macro_export]
 macro_rules! adc_mux_component_static {
@@ -109,11 +110,14 @@ impl<A: 'static + adc::Adc<'static>> Component for AdcComponent<A> {
 
 pub struct AdcVirtualComponent {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
 }
 
 impl AdcVirtualComponent {
-    pub fn new(board_kernel: &'static kernel::Kernel, driver_num: usize) -> AdcVirtualComponent {
+    pub fn new(
+        board_kernel: &'static kernel::Kernel,
+        driver_num: DriverNumber,
+    ) -> AdcVirtualComponent {
         AdcVirtualComponent {
             board_kernel,
             driver_num,
@@ -155,7 +159,7 @@ pub struct AdcDedicatedComponent<
     adc: &'static A,
     channels: &'static [A::Channel],
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
 }
 
 impl<A: kernel::hil::adc::Adc<'static> + kernel::hil::adc::AdcHighSpeed<'static> + 'static>
@@ -165,7 +169,7 @@ impl<A: kernel::hil::adc::Adc<'static> + kernel::hil::adc::AdcHighSpeed<'static>
         adc: &'static A,
         channels: &'static [A::Channel],
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
     ) -> AdcDedicatedComponent<A> {
         AdcDedicatedComponent {
             adc,

--- a/boards/components/src/aes.rs
+++ b/boards/components/src/aes.rs
@@ -32,6 +32,7 @@ use kernel::hil;
 use kernel::hil::symmetric_encryption::{
     AES128Ctr, AES128, AES128CBC, AES128CCM, AES128ECB, AES128GCM,
 };
+use kernel::DriverNumber;
 
 const CRYPT_SIZE: usize = 7 * hil::symmetric_encryption::AES128_BLOCK_SIZE;
 
@@ -101,7 +102,7 @@ impl<A: 'static + AES128<'static> + AES128Ctr + AES128CBC + AES128ECB> Component
 
 pub struct AesDriverComponent<A: AES128<'static> + AES128CCM<'static> + 'static> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     aes: &'static A,
 }
 
@@ -110,7 +111,7 @@ impl<A: AES128<'static> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'static>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         aes: &'static A,
     ) -> AesDriverComponent<A> {
         AesDriverComponent {

--- a/boards/components/src/air_quality.rs
+++ b/boards/components/src/air_quality.rs
@@ -17,6 +17,7 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
+use kernel::DriverNumber;
 
 #[macro_export]
 macro_rules! air_quality_component_static {
@@ -27,14 +28,14 @@ macro_rules! air_quality_component_static {
 
 pub struct AirQualityComponent<T: 'static + hil::sensors::AirQualityDriver<'static>> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     temp_sensor: &'static T,
 }
 
 impl<T: 'static + hil::sensors::AirQualityDriver<'static>> AirQualityComponent<T> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         temp_sensor: &'static T,
     ) -> AirQualityComponent<T> {
         AirQualityComponent {

--- a/boards/components/src/alarm.rs
+++ b/boards/components/src/alarm.rs
@@ -26,10 +26,10 @@ use core::mem::MaybeUninit;
 
 use capsules_core::alarm::AlarmDriver;
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
-use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::time::{self, Alarm};
+use kernel::{capabilities, DriverNumber};
 
 // Setup static space for the objects.
 #[macro_export]
@@ -86,14 +86,14 @@ impl<A: 'static + time::Alarm<'static>> Component for AlarmMuxComponent<A> {
 
 pub struct AlarmDriverComponent<A: 'static + time::Alarm<'static>> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     alarm_mux: &'static MuxAlarm<'static, A>,
 }
 
 impl<A: 'static + time::Alarm<'static>> AlarmDriverComponent<A> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         mux: &'static MuxAlarm<'static, A>,
     ) -> AlarmDriverComponent<A> {
         AlarmDriverComponent {

--- a/boards/components/src/analog_comparator.rs
+++ b/boards/components/src/analog_comparator.rs
@@ -25,9 +25,9 @@
 
 use capsules_extra::analog_comparator::AnalogComparator;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
+use kernel::{capabilities, DriverNumber};
 
 #[macro_export]
 macro_rules! analog_comparator_component_helper {
@@ -58,7 +58,7 @@ pub struct AnalogComparatorComponent<
     comp: &'static AC,
     ac_channels: &'static [&'static AC::Channel],
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
 }
 
 impl<AC: 'static + kernel::hil::analog_comparator::AnalogComparator<'static>>
@@ -68,7 +68,7 @@ impl<AC: 'static + kernel::hil::analog_comparator::AnalogComparator<'static>>
         comp: &'static AC,
         ac_channels: &'static [&'static AC::Channel],
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
     ) -> Self {
         Self {
             comp,

--- a/boards/components/src/app_flash_driver.rs
+++ b/boards/components/src/app_flash_driver.rs
@@ -23,6 +23,7 @@ use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
 use kernel::hil::nonvolatile_storage::NonvolatileStorage;
+use kernel::DriverNumber;
 
 #[macro_export]
 macro_rules! app_flash_component_static {
@@ -42,7 +43,7 @@ pub struct AppFlashComponent<
     const BUF_LEN: usize,
 > {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     storage: &'static F,
 }
 
@@ -55,7 +56,7 @@ impl<
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         storage: &'static F,
     ) -> AppFlashComponent<F, BUF_LEN> {
         AppFlashComponent {

--- a/boards/components/src/app_loader.rs
+++ b/boards/components/src/app_loader.rs
@@ -37,6 +37,7 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::dynamic_binary_storage;
+use kernel::DriverNumber;
 
 // Setup static space for the objects.
 #[macro_export]
@@ -54,7 +55,7 @@ pub struct AppLoaderComponent<
     L: dynamic_binary_storage::DynamicProcessLoad + 'static,
 > {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     storage_driver: &'static S,
     load_driver: &'static L,
 }
@@ -66,7 +67,7 @@ impl<
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         storage_driver: &'static S,
         load_driver: &'static L,
     ) -> Self {

--- a/boards/components/src/ble.rs
+++ b/boards/components/src/ble.rs
@@ -12,11 +12,11 @@
 
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::ble_advertising::BleConfig;
 use kernel::hil::time::Alarm;
+use kernel::{capabilities, DriverNumber};
 
 #[macro_export]
 macro_rules! ble_component_static {
@@ -42,7 +42,7 @@ pub struct BLEComponent<
     B: kernel::hil::ble_advertising::BleAdvertisementDriver<'static> + BleConfig + 'static,
 > {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     radio: &'static B,
     mux_alarm: &'static capsules_core::virtualizers::virtual_alarm::MuxAlarm<'static, A>,
 }
@@ -54,7 +54,7 @@ impl<
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         radio: &'static B,
         mux_alarm: &'static capsules_core::virtualizers::virtual_alarm::MuxAlarm<'static, A>,
     ) -> Self {

--- a/boards/components/src/button.rs
+++ b/boards/components/src/button.rs
@@ -34,11 +34,11 @@
 
 use capsules_core::button::Button;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::gpio;
 use kernel::hil::gpio::InterruptWithValue;
+use kernel::{capabilities, DriverNumber};
 
 #[macro_export]
 macro_rules! button_component_helper_owned {
@@ -88,7 +88,7 @@ pub type ButtonComponentType<IP> = capsules_core::button::Button<'static, IP>;
 
 pub struct ButtonComponent<IP: 'static + gpio::InterruptPin<'static>> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     button_pins: &'static [(
         &'static gpio::InterruptValueWrapper<'static, IP>,
         gpio::ActivationMode,
@@ -99,7 +99,7 @@ pub struct ButtonComponent<IP: 'static + gpio::InterruptPin<'static>> {
 impl<IP: 'static + gpio::InterruptPin<'static>> ButtonComponent<IP> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         button_pins: &'static [(
             &'static gpio::InterruptValueWrapper<'static, IP>,
             gpio::ActivationMode,

--- a/boards/components/src/button_keyboard.rs
+++ b/boards/components/src/button_keyboard.rs
@@ -13,6 +13,7 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
+use kernel::DriverNumber;
 
 #[macro_export]
 macro_rules! keyboard_button_component_static {
@@ -25,7 +26,7 @@ pub type KeyboardButtonComponentType = capsules_extra::button_keyboard::ButtonKe
 
 pub struct KeyboardButtonComponent<K: 'static + hil::keyboard::Keyboard<'static>> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     keyboard: &'static K,
     key_codes: &'static [u16],
 }
@@ -33,7 +34,7 @@ pub struct KeyboardButtonComponent<K: 'static + hil::keyboard::Keyboard<'static>
 impl<K: 'static + hil::keyboard::Keyboard<'static>> KeyboardButtonComponent<K> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         keyboard: &'static K,
         key_codes: &'static [u16],
     ) -> Self {

--- a/boards/components/src/can.rs
+++ b/boards/components/src/can.rs
@@ -27,7 +27,7 @@ use capsules_extra::can::CanCapsule;
 use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::hil::can;
-use kernel::{capabilities, create_capability};
+use kernel::{capabilities, create_capability, DriverNumber};
 
 #[macro_export]
 macro_rules! can_component_static {
@@ -46,14 +46,14 @@ macro_rules! can_component_static {
 
 pub struct CanComponent<A: 'static + can::Can> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     can: &'static A,
 }
 
 impl<A: 'static + can::Can> CanComponent<A> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         can: &'static A,
     ) -> CanComponent<A> {
         CanComponent {

--- a/boards/components/src/console.rs
+++ b/boards/components/src/console.rs
@@ -41,12 +41,12 @@ use capsules_core::console_ordered::ConsoleOrdered;
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules_core::virtualizers::virtual_uart::{MuxUart, UartDevice};
 use core::mem::MaybeUninit;
-use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
 use kernel::hil::time::{self, Alarm};
 use kernel::hil::uart;
+use kernel::{capabilities, DriverNumber};
 
 use capsules_core::console::DEFAULT_BUF_SIZE;
 
@@ -126,14 +126,14 @@ macro_rules! console_component_static {
 
 pub struct ConsoleComponent<const RX_BUF_LEN: usize, const TX_BUF_LEN: usize> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     uart_mux: &'static MuxUart<'static>,
 }
 
 impl<const RX_BUF_LEN: usize, const TX_BUF_LEN: usize> ConsoleComponent<RX_BUF_LEN, TX_BUF_LEN> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         uart_mux: &'static MuxUart,
     ) -> ConsoleComponent<RX_BUF_LEN, TX_BUF_LEN> {
         ConsoleComponent {
@@ -191,7 +191,7 @@ macro_rules! console_ordered_component_static {
 
 pub struct ConsoleOrderedComponent<A: 'static + time::Alarm<'static>> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     uart_mux: &'static MuxUart<'static>,
     alarm_mux: &'static MuxAlarm<'static, A>,
     atomic_size: usize,
@@ -202,7 +202,7 @@ pub struct ConsoleOrderedComponent<A: 'static + time::Alarm<'static>> {
 impl<A: 'static + time::Alarm<'static>> ConsoleOrderedComponent<A> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         uart_mux: &'static MuxUart<'static>,
         alarm_mux: &'static MuxAlarm<'static, A>,
         atomic_size: usize,

--- a/boards/components/src/crc.rs
+++ b/boards/components/src/crc.rs
@@ -20,10 +20,10 @@
 
 use capsules_extra::crc::CrcDriver;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::crc::Crc;
+use kernel::{capabilities, DriverNumber};
 
 // Setup static space for the objects.
 #[macro_export]
@@ -38,14 +38,14 @@ macro_rules! crc_component_static {
 
 pub struct CrcComponent<C: 'static + Crc<'static>> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     crc: &'static C,
 }
 
 impl<C: 'static + Crc<'static>> CrcComponent<C> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         crc: &'static C,
     ) -> CrcComponent<C> {
         CrcComponent {

--- a/boards/components/src/ctap.rs
+++ b/boards/components/src/ctap.rs
@@ -36,6 +36,7 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
+use kernel::DriverNumber;
 
 // Setup static space for the objects.
 #[macro_export]
@@ -57,7 +58,7 @@ macro_rules! ctap_component_static {
 
 pub struct CtapComponent<U: 'static + hil::usb::UsbController<'static>> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     usb: &'static U,
     vendor_id: u16,
     product_id: u16,
@@ -67,7 +68,7 @@ pub struct CtapComponent<U: 'static + hil::usb::UsbController<'static>> {
 impl<U: 'static + hil::usb::UsbController<'static>> CtapComponent<U> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         usb: &'static U,
         vendor_id: u16,
         product_id: u16,

--- a/boards/components/src/date_time.rs
+++ b/boards/components/src/date_time.rs
@@ -22,10 +22,10 @@
 use core::mem::MaybeUninit;
 
 use capsules_extra::date_time::DateTimeCapsule;
-use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::date_time;
+use kernel::{capabilities, DriverNumber};
 
 #[macro_export]
 macro_rules! date_time_component_static {
@@ -37,14 +37,14 @@ macro_rules! date_time_component_static {
 
 pub struct DateTimeComponent<D: 'static + date_time::DateTime<'static>> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     rtc: &'static D,
 }
 
 impl<D: 'static + date_time::DateTime<'static>> DateTimeComponent<D> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         rtc: &'static D,
     ) -> DateTimeComponent<D> {
         DateTimeComponent {

--- a/boards/components/src/gpio.rs
+++ b/boards/components/src/gpio.rs
@@ -50,11 +50,11 @@
 
 use capsules_core::gpio::GPIO;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::gpio;
 use kernel::hil::gpio::InterruptWithValue;
+use kernel::{capabilities, DriverNumber};
 
 #[macro_export]
 macro_rules! gpio_component_helper_max_pin {
@@ -123,14 +123,14 @@ pub type GpioComponentType<IP> = GPIO<'static, IP>;
 
 pub struct GpioComponent<IP: 'static + gpio::InterruptPin<'static>> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     gpio_pins: &'static [Option<&'static gpio::InterruptValueWrapper<'static, IP>>],
 }
 
 impl<IP: 'static + gpio::InterruptPin<'static>> GpioComponent<IP> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         gpio_pins: &'static [Option<&'static gpio::InterruptValueWrapper<'static, IP>>],
     ) -> Self {
         Self {

--- a/boards/components/src/hmac.rs
+++ b/boards/components/src/hmac.rs
@@ -19,10 +19,10 @@
 
 use capsules_extra::hmac::HmacDriver;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::digest;
+use kernel::{capabilities, DriverNumber};
 
 #[macro_export]
 macro_rules! hmac_component_static {
@@ -40,14 +40,14 @@ pub type HmacComponentType<H, const L: usize> = capsules_extra::hmac::HmacDriver
 
 pub struct HmacComponent<A: 'static + digest::Digest<'static, L>, const L: usize> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     hmac: &'static A,
 }
 
 impl<A: 'static + digest::Digest<'static, L>, const L: usize> HmacComponent<A, L> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         hmac: &'static A,
     ) -> HmacComponent<A, L> {
         HmacComponent {

--- a/boards/components/src/humidity.rs
+++ b/boards/components/src/humidity.rs
@@ -17,6 +17,7 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
+use kernel::DriverNumber;
 
 #[macro_export]
 macro_rules! humidity_component_static {
@@ -29,14 +30,14 @@ pub type HumidityComponentType<H> = capsules_extra::humidity::HumiditySensor<'st
 
 pub struct HumidityComponent<T: 'static + hil::sensors::HumidityDriver<'static>> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     sensor: &'static T,
 }
 
 impl<T: 'static + hil::sensors::HumidityDriver<'static>> HumidityComponent<T> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         sensor: &'static T,
     ) -> HumidityComponent<T> {
         HumidityComponent {

--- a/boards/components/src/i2c.rs
+++ b/boards/components/src/i2c.rs
@@ -23,10 +23,10 @@
 
 use capsules_core::virtualizers::virtual_i2c::{I2CDevice, MuxI2C};
 use core::mem::MaybeUninit;
-use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::i2c::{self, NoSMBus};
+use kernel::{capabilities, DriverNumber};
 
 // Setup static space for the objects.
 #[macro_export]
@@ -125,12 +125,16 @@ impl<I: 'static + i2c::I2CMaster<'static>> Component for I2CComponent<I> {
 
 pub struct I2CMasterSlaveDriverComponent<I: 'static + i2c::I2CMasterSlave<'static>> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     i2c: &'static I,
 }
 
 impl<I: 'static + i2c::I2CMasterSlave<'static>> I2CMasterSlaveDriverComponent<I> {
-    pub fn new(board_kernel: &'static kernel::Kernel, driver_num: usize, i2c: &'static I) -> Self {
+    pub fn new(
+        board_kernel: &'static kernel::Kernel,
+        driver_num: DriverNumber,
+        i2c: &'static I,
+    ) -> Self {
         I2CMasterSlaveDriverComponent {
             board_kernel,
             driver_num,

--- a/boards/components/src/ieee802154.rs
+++ b/boards/components/src/ieee802154.rs
@@ -37,11 +37,11 @@ use capsules_core::virtualizers::virtual_aes_ccm::MuxAES128CCM;
 use capsules_extra::ieee802154::device::MacDevice;
 use capsules_extra::ieee802154::mac::{AwakeMac, Mac};
 use core::mem::MaybeUninit;
-use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::radio::{self, MAX_BUF_SIZE};
 use kernel::hil::symmetric_encryption::{self, AES128Ctr, AES128, AES128CBC, AES128CCM, AES128ECB};
+use kernel::{capabilities, DriverNumber};
 
 // This buffer is used as an intermediate buffer for AES CCM encryption. An
 // upper bound on the required size is `3 * BLOCK_SIZE + radio::MAX_BUF_SIZE`.
@@ -174,7 +174,7 @@ pub struct Ieee802154Component<
     A: 'static + AES128<'static> + AES128Ctr + AES128CBC + AES128ECB,
 > {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     radio: &'static R,
     aes_mux: &'static MuxAES128CCM<'static, A>,
     pan_id: capsules_extra::net::ieee802154::PanID,
@@ -189,7 +189,7 @@ impl<
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         radio: &'static R,
         aes_mux: &'static MuxAES128CCM<'static, A>,
         pan_id: capsules_extra::net::ieee802154::PanID,
@@ -376,14 +376,14 @@ pub type Ieee802154RawComponentType<R> =
 
 pub struct Ieee802154RawComponent<R: 'static + kernel::hil::radio::Radio<'static>> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     radio: &'static R,
 }
 
 impl<R: 'static + kernel::hil::radio::Radio<'static>> Ieee802154RawComponent<R> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         radio: &'static R,
     ) -> Self {
         Self {

--- a/boards/components/src/isl29035.rs
+++ b/boards/components/src/isl29035.rs
@@ -31,12 +31,12 @@ use capsules_core::virtualizers::virtual_i2c::{I2CDevice, MuxI2C};
 use capsules_extra::ambient_light::AmbientLight;
 use capsules_extra::isl29035::Isl29035;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
 use kernel::hil::i2c;
 use kernel::hil::time::{self, Alarm};
+use kernel::{capabilities, DriverNumber};
 
 // Setup static space for the objects.
 #[macro_export]
@@ -117,14 +117,14 @@ impl<A: 'static + time::Alarm<'static>, I: 'static + i2c::I2CMaster<'static>> Co
 
 pub struct AmbientLightComponent<L: 'static + hil::sensors::AmbientLight<'static>> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     light_sensor: &'static L,
 }
 
 impl<L: 'static + hil::sensors::AmbientLight<'static>> AmbientLightComponent<L> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         light_sensor: &'static L,
     ) -> Self {
         AmbientLightComponent {

--- a/boards/components/src/isolated_nonvolatile_storage.rs
+++ b/boards/components/src/isolated_nonvolatile_storage.rs
@@ -32,6 +32,7 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
+use kernel::DriverNumber;
 
 // How much storage space to allocate per-app. Currently, regions are not
 // growable, so this will be all the space the app gets.
@@ -67,7 +68,7 @@ pub struct IsolatedNonvolatileStorageComponent<
     const APP_REGION_SIZE: usize,
 > {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     flash: &'static F,
     userspace_start: usize,
     userspace_length: usize,
@@ -82,7 +83,7 @@ impl<
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         flash: &'static F,
         userspace_start: usize,
         userspace_length: usize,

--- a/boards/components/src/keyboard_hid.rs
+++ b/boards/components/src/keyboard_hid.rs
@@ -38,6 +38,7 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
+use kernel::DriverNumber;
 
 // Setup static space for the objects.
 #[macro_export]
@@ -64,7 +65,7 @@ pub type KeyboardHidComponentType<U> = capsules_extra::usb_hid_driver::UsbHidDri
 
 pub struct KeyboardHidComponent<U: 'static + hil::usb::UsbController<'static>> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     usb: &'static U,
     vendor_id: u16,
     product_id: u16,
@@ -74,7 +75,7 @@ pub struct KeyboardHidComponent<U: 'static + hil::usb::UsbController<'static>> {
 impl<U: 'static + hil::usb::UsbController<'static>> KeyboardHidComponent<U> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         usb: &'static U,
         vendor_id: u16,
         product_id: u16,

--- a/boards/components/src/kv.rs
+++ b/boards/components/src/kv.rs
@@ -10,10 +10,10 @@ use capsules_extra::tickv::{KVSystem, KeyType};
 use capsules_extra::tickv_kv_store::TicKVKVStore;
 use capsules_extra::virtualizers::virtual_kv::{MuxKVPermissions, VirtualKVPermissions};
 use core::mem::MaybeUninit;
-use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
+use kernel::{capabilities, DriverNumber};
 
 ///////////////////////
 // KV Userspace Driver
@@ -35,11 +35,15 @@ pub type KVDriverComponentType<V> = capsules_extra::kv_driver::KVStoreDriver<'st
 pub struct KVDriverComponent<V: hil::kv::KVPermissions<'static> + 'static> {
     kv: &'static V,
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
 }
 
 impl<V: hil::kv::KVPermissions<'static>> KVDriverComponent<V> {
-    pub fn new(kv: &'static V, board_kernel: &'static kernel::Kernel, driver_num: usize) -> Self {
+    pub fn new(
+        kv: &'static V,
+        board_kernel: &'static kernel::Kernel,
+        driver_num: DriverNumber,
+    ) -> Self {
         Self {
             kv,
             board_kernel,

--- a/boards/components/src/l3gd20.rs
+++ b/boards/components/src/l3gd20.rs
@@ -16,11 +16,11 @@
 use capsules_core::virtualizers::virtual_spi::{MuxSpiMaster, VirtualSpiMasterDevice};
 use capsules_extra::l3gd20::L3gd20Spi;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::spi;
 use kernel::hil::spi::SpiMasterDevice;
+use kernel::{capabilities, DriverNumber};
 
 // Setup static space for the objects.
 #[macro_export]
@@ -52,7 +52,7 @@ pub struct L3gd20Component<
     spi_mux: &'static MuxSpiMaster<'static, S>,
     chip_select: CS,
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
 }
 
 impl<
@@ -64,7 +64,7 @@ impl<
         spi_mux: &'static MuxSpiMaster<'static, S>,
         chip_select: CS,
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
     ) -> Self {
         Self {
             spi_mux,

--- a/boards/components/src/lldb.rs
+++ b/boards/components/src/lldb.rs
@@ -23,10 +23,10 @@
 use capsules_core::low_level_debug::LowLevelDebug;
 use capsules_core::virtualizers::virtual_uart::{MuxUart, UartDevice};
 use core::mem::MaybeUninit;
-use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
+use kernel::{capabilities, DriverNumber};
 
 #[macro_export]
 macro_rules! low_level_debug_component_static {
@@ -47,14 +47,14 @@ macro_rules! low_level_debug_component_static {
 
 pub struct LowLevelDebugComponent {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     uart_mux: &'static MuxUart<'static>,
 }
 
 impl LowLevelDebugComponent {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         uart_mux: &'static MuxUart,
     ) -> LowLevelDebugComponent {
         LowLevelDebugComponent {

--- a/boards/components/src/lps25hb.rs
+++ b/boards/components/src/lps25hb.rs
@@ -12,6 +12,7 @@ use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::gpio;
 use kernel::hil::i2c;
+use kernel::DriverNumber;
 
 #[macro_export]
 macro_rules! lps25hb_component_static {
@@ -35,7 +36,7 @@ pub struct Lps25hbComponent<I: 'static + i2c::I2CMaster<'static>> {
     i2c_address: u8,
     interrupt_pin: &'static dyn gpio::InterruptPin<'static>,
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
 }
 
 impl<I: 'static + i2c::I2CMaster<'static>> Lps25hbComponent<I> {
@@ -44,7 +45,7 @@ impl<I: 'static + i2c::I2CMaster<'static>> Lps25hbComponent<I> {
         i2c_address: u8,
         interrupt_pin: &'static dyn gpio::InterruptPin<'static>,
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
     ) -> Self {
         Lps25hbComponent {
             i2c_mux,

--- a/boards/components/src/lsm303agr.rs
+++ b/boards/components/src/lsm303agr.rs
@@ -27,10 +27,10 @@ use capsules_core::virtualizers::virtual_i2c::{I2CDevice, MuxI2C};
 use capsules_extra::lsm303agr::Lsm303agrI2C;
 use capsules_extra::lsm303xx;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::i2c;
+use kernel::{capabilities, DriverNumber};
 
 // Setup static space for the objects.
 #[macro_export]
@@ -57,7 +57,7 @@ pub struct Lsm303agrI2CComponent<I: 'static + i2c::I2CMaster<'static>> {
     accelerometer_i2c_address: u8,
     magnetometer_i2c_address: u8,
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
 }
 
 impl<I: 'static + i2c::I2CMaster<'static>> Lsm303agrI2CComponent<I> {
@@ -66,7 +66,7 @@ impl<I: 'static + i2c::I2CMaster<'static>> Lsm303agrI2CComponent<I> {
         accelerometer_i2c_address: Option<u8>,
         magnetometer_i2c_address: Option<u8>,
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
     ) -> Lsm303agrI2CComponent<I> {
         Lsm303agrI2CComponent {
             i2c_mux,

--- a/boards/components/src/lsm303dlhc.rs
+++ b/boards/components/src/lsm303dlhc.rs
@@ -28,6 +28,7 @@ use capsules_extra::lsm303xx;
 use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::hil::i2c;
+use kernel::DriverNumber;
 
 // Setup static space for the objects.
 #[macro_export]
@@ -54,7 +55,7 @@ pub struct Lsm303dlhcI2CComponent<I: 'static + i2c::I2CMaster<'static>> {
     accelerometer_i2c_address: u8,
     magnetometer_i2c_address: u8,
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
 }
 
 impl<I: 'static + i2c::I2CMaster<'static>> Lsm303dlhcI2CComponent<I> {
@@ -63,7 +64,7 @@ impl<I: 'static + i2c::I2CMaster<'static>> Lsm303dlhcI2CComponent<I> {
         accelerometer_i2c_address: Option<u8>,
         magnetometer_i2c_address: Option<u8>,
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
     ) -> Lsm303dlhcI2CComponent<I> {
         Lsm303dlhcI2CComponent {
             i2c_mux,

--- a/boards/components/src/lsm6dsox.rs
+++ b/boards/components/src/lsm6dsox.rs
@@ -31,10 +31,10 @@
 use capsules_core::virtualizers::virtual_i2c::{I2CDevice, MuxI2C};
 use capsules_extra::lsm6dsoxtr::Lsm6dsoxtrI2C;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::i2c;
+use kernel::{capabilities, DriverNumber};
 
 // Setup static space for the objects.
 #[macro_export]
@@ -58,7 +58,7 @@ pub struct Lsm6dsoxtrI2CComponent<I: 'static + i2c::I2CMaster<'static>> {
     i2c_mux: &'static MuxI2C<'static, I>,
     i2c_address: u8,
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
 }
 
 impl<I: 'static + i2c::I2CMaster<'static>> Lsm6dsoxtrI2CComponent<I> {
@@ -66,7 +66,7 @@ impl<I: 'static + i2c::I2CMaster<'static>> Lsm6dsoxtrI2CComponent<I> {
         i2c_mux: &'static MuxI2C<'static, I>,
         i2c_address: u8,
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
     ) -> Lsm6dsoxtrI2CComponent<I> {
         Lsm6dsoxtrI2CComponent {
             i2c_mux,

--- a/boards/components/src/ltc294x.rs
+++ b/boards/components/src/ltc294x.rs
@@ -23,6 +23,7 @@ use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::gpio;
 use kernel::hil::i2c;
+use kernel::DriverNumber;
 
 #[macro_export]
 macro_rules! ltc294x_component_static {
@@ -95,14 +96,14 @@ impl<I: 'static + i2c::I2CMaster<'static>> Component for Ltc294xComponent<I> {
 pub struct Ltc294xDriverComponent<I: 'static + i2c::I2CMaster<'static>> {
     ltc294x: &'static LTC294X<'static, I2CDevice<'static, I>>,
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
 }
 
 impl<I: 'static + i2c::I2CMaster<'static>> Ltc294xDriverComponent<I> {
     pub fn new(
         ltc294x: &'static LTC294X<'static, I2CDevice<'static, I>>,
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
     ) -> Self {
         Ltc294xDriverComponent {
             ltc294x,

--- a/boards/components/src/mlx90614.rs
+++ b/boards/components/src/mlx90614.rs
@@ -21,10 +21,10 @@
 use capsules_core::virtualizers::virtual_i2c::{MuxI2C, SMBusDevice};
 use capsules_extra::mlx90614::Mlx90614SMBus;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::i2c::{self, NoSMBus};
+use kernel::{capabilities, DriverNumber};
 
 // Setup static space for the objects.
 #[macro_export]
@@ -45,7 +45,7 @@ pub struct Mlx90614SMBusComponent<
     i2c_mux: &'static MuxI2C<'static, I, S>,
     i2c_address: u8,
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
 }
 
 impl<I: 'static + i2c::I2CMaster<'static>, S: 'static + i2c::SMBusMaster<'static>>
@@ -55,7 +55,7 @@ impl<I: 'static + i2c::I2CMaster<'static>, S: 'static + i2c::SMBusMaster<'static
         i2c: &'static MuxI2C<'static, I, S>,
         i2c_address: u8,
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
     ) -> Self {
         Mlx90614SMBusComponent {
             i2c_mux: i2c,

--- a/boards/components/src/moisture.rs
+++ b/boards/components/src/moisture.rs
@@ -21,6 +21,7 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
+use kernel::DriverNumber;
 
 #[macro_export]
 macro_rules! moisture_component_static {
@@ -33,14 +34,14 @@ pub type MoistureComponentType<H> = capsules_extra::moisture::MoistureSensor<'st
 
 pub struct MoistureComponent<T: 'static + hil::sensors::MoistureDriver<'static>> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     sensor: &'static T,
 }
 
 impl<T: 'static + hil::sensors::MoistureDriver<'static>> MoistureComponent<T> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         sensor: &'static T,
     ) -> MoistureComponent<T> {
         MoistureComponent {

--- a/boards/components/src/ninedof.rs
+++ b/boards/components/src/ninedof.rs
@@ -14,9 +14,9 @@
 
 use capsules_extra::ninedof::NineDof;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
+use kernel::{capabilities, DriverNumber};
 
 #[macro_export]
 macro_rules! ninedof_component_static {
@@ -38,11 +38,14 @@ macro_rules! ninedof_component_static {
 
 pub struct NineDofComponent {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
 }
 
 impl NineDofComponent {
-    pub fn new(board_kernel: &'static kernel::Kernel, driver_num: usize) -> NineDofComponent {
+    pub fn new(
+        board_kernel: &'static kernel::Kernel,
+        driver_num: DriverNumber,
+    ) -> NineDofComponent {
         NineDofComponent {
             board_kernel,
             driver_num,

--- a/boards/components/src/nonvolatile_storage.rs
+++ b/boards/components/src/nonvolatile_storage.rs
@@ -30,6 +30,7 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
+use kernel::DriverNumber;
 
 // Setup static space for the objects.
 #[macro_export]
@@ -54,7 +55,7 @@ pub struct NonvolatileStorageComponent<
     F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, NonvolatileToPages<'static, F>>,
 > {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     flash: &'static F,
     userspace_start: usize,
     userspace_length: usize,
@@ -70,7 +71,7 @@ impl<
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         flash: &'static F,
         userspace_start: usize,
         userspace_length: usize,

--- a/boards/components/src/nrf51822.rs
+++ b/boards/components/src/nrf51822.rs
@@ -24,6 +24,7 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
+use kernel::DriverNumber;
 
 #[macro_export]
 macro_rules! nrf51822_component_static {
@@ -45,7 +46,7 @@ pub struct Nrf51822Component<
     G: 'static + hil::gpio::Pin,
 > {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     uart: &'static U,
     reset_pin: &'static G,
 }
@@ -55,7 +56,7 @@ impl<U: 'static + hil::uart::UartAdvanced<'static>, G: 'static + hil::gpio::Pin>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         uart: &'static U,
         reset_pin: &'static G,
     ) -> Nrf51822Component<U, G> {

--- a/boards/components/src/pressure.rs
+++ b/boards/components/src/pressure.rs
@@ -17,6 +17,7 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
+use kernel::DriverNumber;
 
 #[macro_export]
 macro_rules! pressure_component_static {
@@ -27,14 +28,14 @@ macro_rules! pressure_component_static {
 
 pub struct PressureComponent<T: 'static + hil::sensors::PressureDriver<'static>> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     pressure_sensor: &'static T,
 }
 
 impl<T: 'static + hil::sensors::PressureDriver<'static>> PressureComponent<T> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         pressure_sensor: &'static T,
     ) -> PressureComponent<T> {
         PressureComponent {

--- a/boards/components/src/process_info_driver.rs
+++ b/boards/components/src/process_info_driver.rs
@@ -6,10 +6,10 @@
 
 use capsules_extra::process_info_driver::{self, ProcessInfo};
 use core::mem::MaybeUninit;
-use kernel::capabilities;
 use kernel::capabilities::{ProcessManagementCapability, ProcessStartCapability};
 use kernel::component::Component;
 use kernel::create_capability;
+use kernel::{capabilities, DriverNumber};
 
 #[macro_export]
 macro_rules! process_info_component_static {
@@ -26,12 +26,16 @@ macro_rules! process_info_component_static {
 
 pub struct ProcessInfoComponent<C: ProcessManagementCapability + ProcessStartCapability> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     capability: C,
 }
 
 impl<C: ProcessManagementCapability + ProcessStartCapability> ProcessInfoComponent<C> {
-    pub fn new(board_kernel: &'static kernel::Kernel, driver_num: usize, capability: C) -> Self {
+    pub fn new(
+        board_kernel: &'static kernel::Kernel,
+        driver_num: DriverNumber,
+        capability: C,
+    ) -> Self {
         Self {
             board_kernel,
             driver_num,

--- a/boards/components/src/proximity.rs
+++ b/boards/components/src/proximity.rs
@@ -17,6 +17,7 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
+use kernel::DriverNumber;
 
 #[macro_export]
 macro_rules! proximity_component_static {
@@ -28,14 +29,14 @@ macro_rules! proximity_component_static {
 pub struct ProximityComponent<P: hil::sensors::ProximityDriver<'static> + 'static> {
     sensor: &'static P,
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
 }
 
 impl<P: hil::sensors::ProximityDriver<'static>> ProximityComponent<P> {
     pub fn new(
         sensor: &'static P,
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
     ) -> ProximityComponent<P> {
         ProximityComponent {
             sensor,

--- a/boards/components/src/pwm.rs
+++ b/boards/components/src/pwm.rs
@@ -7,10 +7,10 @@
 use capsules_core::virtualizers::virtual_pwm::{MuxPwm, PwmPinUser};
 use capsules_extra::pwm::Pwm;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::pwm;
+use kernel::{capabilities, DriverNumber};
 
 #[macro_export]
 macro_rules! pwm_mux_component_static {
@@ -94,13 +94,13 @@ impl<P: 'static + pwm::Pwm> Component for PwmPinUserComponent<P> {
 
 pub struct PwmDriverComponent<const NUM_PINS: usize> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
 }
 
 impl<const NUM_PINS: usize> PwmDriverComponent<NUM_PINS> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
     ) -> PwmDriverComponent<NUM_PINS> {
         PwmDriverComponent {
             board_kernel,

--- a/boards/components/src/rainfall.rs
+++ b/boards/components/src/rainfall.rs
@@ -21,6 +21,7 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
+use kernel::DriverNumber;
 
 #[macro_export]
 macro_rules! rainfall_component_static {
@@ -33,14 +34,14 @@ pub type RainFallComponentType<H> = capsules_extra::rainfall::RainFallSensor<'st
 
 pub struct RainFallComponent<T: 'static + hil::sensors::RainFallDriver<'static>> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     sensor: &'static T,
 }
 
 impl<T: 'static + hil::sensors::RainFallDriver<'static>> RainFallComponent<T> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         sensor: &'static T,
     ) -> RainFallComponent<T> {
         RainFallComponent {

--- a/boards/components/src/rng.rs
+++ b/boards/components/src/rng.rs
@@ -32,11 +32,11 @@
 
 use capsules_core::rng;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::entropy::Entropy32;
 use kernel::hil::rng::Rng;
+use kernel::{capabilities, DriverNumber};
 
 #[macro_export]
 macro_rules! rng_component_static {
@@ -58,12 +58,16 @@ pub type RngComponentType<E> =
 
 pub struct RngComponent<E: Entropy32<'static> + 'static> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     trng: &'static E,
 }
 
 impl<E: Entropy32<'static>> RngComponent<E> {
-    pub fn new(board_kernel: &'static kernel::Kernel, driver_num: usize, trng: &'static E) -> Self {
+    pub fn new(
+        board_kernel: &'static kernel::Kernel,
+        driver_num: DriverNumber,
+        trng: &'static E,
+    ) -> Self {
         Self {
             board_kernel,
             driver_num,
@@ -115,12 +119,16 @@ pub type RngRandomComponentType<R> = rng::RngDriver<'static, R>;
 
 pub struct RngRandomComponent<R: Rng<'static> + 'static> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     rng: &'static R,
 }
 
 impl<R: Rng<'static>> RngRandomComponent<R> {
-    pub fn new(board_kernel: &'static kernel::Kernel, driver_num: usize, rng: &'static R) -> Self {
+    pub fn new(
+        board_kernel: &'static kernel::Kernel,
+        driver_num: DriverNumber,
+        rng: &'static R,
+    ) -> Self {
         Self {
             board_kernel,
             driver_num,

--- a/boards/components/src/screen.rs
+++ b/boards/components/src/screen.rs
@@ -38,6 +38,7 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
+use kernel::DriverNumber;
 
 #[macro_export]
 macro_rules! screen_split_mux_component_static {
@@ -147,7 +148,7 @@ pub type ScreenComponentType = capsules_extra::screen::screen::Screen<'static>;
 
 pub struct ScreenComponent<const SCREEN_BUF_LEN: usize> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     screen: &'static dyn kernel::hil::screen::Screen<'static>,
     screen_setup: Option<&'static dyn kernel::hil::screen::ScreenSetup<'static>>,
 }
@@ -155,7 +156,7 @@ pub struct ScreenComponent<const SCREEN_BUF_LEN: usize> {
 impl<const SCREEN_BUF_LEN: usize> ScreenComponent<SCREEN_BUF_LEN> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         screen: &'static dyn kernel::hil::screen::Screen,
         screen_setup: Option<&'static dyn kernel::hil::screen::ScreenSetup>,
     ) -> ScreenComponent<SCREEN_BUF_LEN> {
@@ -215,7 +216,7 @@ pub struct ScreenSharedComponent<
     S: hil::screen::Screen<'static> + 'static,
 > {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     screen: &'static S,
     apps_regions: &'static [capsules_extra::screen::screen_shared::AppScreenRegion],
 }
@@ -225,7 +226,7 @@ impl<const SCREEN_BUF_LEN: usize, S: hil::screen::Screen<'static>>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         screen: &'static S,
         apps_regions: &'static [capsules_extra::screen::screen_shared::AppScreenRegion],
     ) -> ScreenSharedComponent<SCREEN_BUF_LEN, S> {

--- a/boards/components/src/sha.rs
+++ b/boards/components/src/sha.rs
@@ -19,10 +19,10 @@
 
 use capsules_extra::sha::ShaDriver;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::digest;
+use kernel::{capabilities, DriverNumber};
 
 // Setup static space for the objects.
 #[macro_export]
@@ -45,14 +45,14 @@ macro_rules! sha_component_static {
 
 pub struct ShaComponent<A: 'static + digest::Digest<'static, L>, const L: usize> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     sha: &'static A,
 }
 
 impl<A: 'static + digest::Digest<'static, L>, const L: usize> ShaComponent<A, L> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         sha: &'static A,
     ) -> ShaComponent<A, L> {
         ShaComponent {

--- a/boards/components/src/sound_pressure.rs
+++ b/boards/components/src/sound_pressure.rs
@@ -17,6 +17,7 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
+use kernel::DriverNumber;
 
 #[macro_export]
 macro_rules! sound_pressure_component_static {
@@ -27,14 +28,14 @@ macro_rules! sound_pressure_component_static {
 
 pub struct SoundPressureComponent<S: 'static + hil::sensors::SoundPressure<'static>> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     sound_sensor: &'static S,
 }
 
 impl<S: 'static + hil::sensors::SoundPressure<'static>> SoundPressureComponent<S> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         sound_sensor: &'static S,
     ) -> SoundPressureComponent<S> {
         SoundPressureComponent {

--- a/boards/components/src/spi.rs
+++ b/boards/components/src/spi.rs
@@ -35,11 +35,11 @@ use capsules_core::spi_controller::{Spi, DEFAULT_READ_BUF_LENGTH, DEFAULT_WRITE_
 use capsules_core::spi_peripheral::SpiPeripheral;
 use capsules_core::virtualizers::virtual_spi;
 use capsules_core::virtualizers::virtual_spi::{MuxSpiMaster, VirtualSpiMasterDevice};
-use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::spi;
 use kernel::hil::spi::{SpiMasterDevice, SpiSlaveDevice};
+use kernel::{capabilities, DriverNumber};
 
 // Setup static space for the objects.
 #[macro_export]
@@ -117,13 +117,13 @@ pub struct SpiSyscallComponent<S: 'static + spi::SpiMaster<'static>> {
     board_kernel: &'static kernel::Kernel,
     spi_mux: &'static MuxSpiMaster<'static, S>,
     chip_select: S::ChipSelect,
-    driver_num: usize,
+    driver_num: DriverNumber,
 }
 
 pub struct SpiSyscallPComponent<S: 'static + spi::SpiSlave<'static>> {
     board_kernel: &'static kernel::Kernel,
     spi_slave: &'static S,
-    driver_num: usize,
+    driver_num: DriverNumber,
 }
 
 pub struct SpiComponent<
@@ -165,7 +165,7 @@ impl<S: 'static + spi::SpiMaster<'static>> SpiSyscallComponent<S> {
         board_kernel: &'static kernel::Kernel,
         mux: &'static MuxSpiMaster<'static, S>,
         chip_select: S::ChipSelect,
-        driver_num: usize,
+        driver_num: DriverNumber,
     ) -> Self {
         SpiSyscallComponent {
             board_kernel,
@@ -211,7 +211,7 @@ impl<S: 'static + spi::SpiSlave<'static>> SpiSyscallPComponent<S> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         slave: &'static S,
-        driver_num: usize,
+        driver_num: DriverNumber,
     ) -> Self {
         SpiSyscallPComponent {
             board_kernel,
@@ -289,14 +289,14 @@ impl<
 pub struct SpiPeripheralComponent<S: 'static + spi::SpiSlave<'static>> {
     board_kernel: &'static kernel::Kernel,
     device: &'static S,
-    driver_num: usize,
+    driver_num: DriverNumber,
 }
 
 impl<S: 'static + spi::SpiSlave<'static>> SpiPeripheralComponent<S> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         device: &'static S,
-        driver_num: usize,
+        driver_num: DriverNumber,
     ) -> Self {
         SpiPeripheralComponent {
             board_kernel,

--- a/boards/components/src/temperature.rs
+++ b/boards/components/src/temperature.rs
@@ -17,6 +17,7 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
+use kernel::DriverNumber;
 
 #[macro_export]
 macro_rules! temperature_component_static {
@@ -29,14 +30,14 @@ pub type TemperatureComponentType<T> = capsules_extra::temperature::TemperatureS
 
 pub struct TemperatureComponent<T: 'static + hil::sensors::TemperatureDriver<'static>> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     temp_sensor: &'static T,
 }
 
 impl<T: 'static + hil::sensors::TemperatureDriver<'static>> TemperatureComponent<T> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         temp_sensor: &'static T,
     ) -> TemperatureComponent<T> {
         TemperatureComponent {

--- a/boards/components/src/text_screen.rs
+++ b/boards/components/src/text_screen.rs
@@ -25,9 +25,9 @@
 
 use capsules_extra::text_screen::TextScreen;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
+use kernel::{capabilities, DriverNumber};
 
 #[macro_export]
 macro_rules! text_screen_component_static {
@@ -41,14 +41,14 @@ macro_rules! text_screen_component_static {
 
 pub struct TextScreenComponent<const SCREEN_BUF_LEN: usize> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     text_screen: &'static dyn kernel::hil::text_screen::TextScreen<'static>,
 }
 
 impl<const SCREEN_BUF_LEN: usize> TextScreenComponent<SCREEN_BUF_LEN> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         text_screen: &'static dyn kernel::hil::text_screen::TextScreen<'static>,
     ) -> TextScreenComponent<SCREEN_BUF_LEN> {
         TextScreenComponent {

--- a/boards/components/src/thread_network.rs
+++ b/boards/components/src/thread_network.rs
@@ -41,12 +41,12 @@ use capsules_extra::net::udp::udp_recv::MuxUdpReceiver;
 use capsules_extra::net::udp::udp_recv::UDPReceiver;
 use capsules_extra::net::udp::udp_send::{MuxUdpSender, UDPSendStruct, UDPSender};
 use core::mem::MaybeUninit;
-use kernel::capabilities;
 use kernel::capabilities::NetworkCapabilityCreationCapability;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::radio;
 use kernel::hil::time::Alarm;
+use kernel::{capabilities, DriverNumber};
 
 const MAX_PAYLOAD_LEN: usize = super::udp_mux::MAX_PAYLOAD_LEN;
 pub const CRYPT_SIZE: usize = 3 * symmetric_encryption::AES128_BLOCK_SIZE + radio::MAX_BUF_SIZE;
@@ -105,7 +105,7 @@ pub struct ThreadNetworkComponent<
     B: AES128<'static> + AES128Ctr + AES128CBC + AES128ECB + 'static,
 > {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     udp_send_mux:
         &'static MuxUdpSender<'static, IP6SendStruct<'static, VirtualMuxAlarm<'static, A>>>,
     udp_recv_mux: &'static MuxUdpReceiver<'static>,
@@ -122,7 +122,7 @@ impl<
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         udp_send_mux: &'static MuxUdpSender<
             'static,
             IP6SendStruct<'static, VirtualMuxAlarm<'static, A>>,

--- a/boards/components/src/touch.rs
+++ b/boards/components/src/touch.rs
@@ -36,9 +36,9 @@
 //! ```
 use capsules_extra::touch::Touch;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
+use kernel::{capabilities, DriverNumber};
 
 #[macro_export]
 macro_rules! touch_component_static {
@@ -49,7 +49,7 @@ macro_rules! touch_component_static {
 
 pub struct TouchComponent {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     touch: &'static dyn kernel::hil::touch::Touch<'static>,
     gesture: Option<&'static dyn kernel::hil::touch::Gesture<'static>>,
     screen: Option<&'static dyn kernel::hil::screen::Screen<'static>>,
@@ -58,7 +58,7 @@ pub struct TouchComponent {
 impl TouchComponent {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         touch: &'static dyn kernel::hil::touch::Touch<'static>,
         gesture: Option<&'static dyn kernel::hil::touch::Gesture<'static>>,
         screen: Option<&'static dyn kernel::hil::screen::Screen<'static>>,
@@ -99,7 +99,7 @@ impl Component for TouchComponent {
 
 pub struct MultiTouchComponent {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     multi_touch: &'static dyn kernel::hil::touch::MultiTouch<'static>,
     gesture: Option<&'static dyn kernel::hil::touch::Gesture<'static>>,
     screen: Option<&'static dyn kernel::hil::screen::Screen<'static>>,
@@ -108,7 +108,7 @@ pub struct MultiTouchComponent {
 impl MultiTouchComponent {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         multi_touch: &'static dyn kernel::hil::touch::MultiTouch<'static>,
         gesture: Option<&'static dyn kernel::hil::touch::Gesture<'static>>,
         screen: Option<&'static dyn kernel::hil::screen::Screen>,

--- a/boards/components/src/udp_driver.rs
+++ b/boards/components/src/udp_driver.rs
@@ -32,11 +32,11 @@ use capsules_extra::net::udp::udp_recv::MuxUdpReceiver;
 use capsules_extra::net::udp::udp_recv::UDPReceiver;
 use capsules_extra::net::udp::udp_send::{MuxUdpSender, UDPSendStruct, UDPSender};
 use core::mem::MaybeUninit;
-use kernel::capabilities;
 use kernel::capabilities::NetworkCapabilityCreationCapability;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::time::Alarm;
+use kernel::{capabilities, DriverNumber};
 
 const MAX_PAYLOAD_LEN: usize = super::udp_mux::MAX_PAYLOAD_LEN;
 
@@ -70,7 +70,7 @@ macro_rules! udp_driver_component_static {
 
 pub struct UDPDriverComponent<A: Alarm<'static> + 'static> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     udp_send_mux:
         &'static MuxUdpSender<'static, IP6SendStruct<'static, VirtualMuxAlarm<'static, A>>>,
     udp_recv_mux: &'static MuxUdpReceiver<'static>,
@@ -81,7 +81,7 @@ pub struct UDPDriverComponent<A: Alarm<'static> + 'static> {
 impl<A: Alarm<'static>> UDPDriverComponent<A> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         udp_send_mux: &'static MuxUdpSender<
             'static,
             IP6SendStruct<'static, VirtualMuxAlarm<'static, A>>,

--- a/boards/components/src/usb.rs
+++ b/boards/components/src/usb.rs
@@ -19,10 +19,10 @@
 //! ```
 
 use core::mem::MaybeUninit;
-use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::usb::UsbController;
+use kernel::{capabilities, DriverNumber};
 
 #[macro_export]
 macro_rules! usb_component_static {
@@ -40,12 +40,16 @@ macro_rules! usb_component_static {
 
 pub struct UsbComponent<U: UsbController<'static> + 'static> {
     board_kernel: &'static kernel::Kernel,
-    driver_num: usize,
+    driver_num: DriverNumber,
     usbc: &'static U,
 }
 
 impl<U: UsbController<'static> + 'static> UsbComponent<U> {
-    pub fn new(board_kernel: &'static kernel::Kernel, driver_num: usize, usbc: &'static U) -> Self {
+    pub fn new(
+        board_kernel: &'static kernel::Kernel,
+        driver_num: DriverNumber,
+        usbc: &'static U,
+    ) -> Self {
         Self {
             board_kernel,
             driver_num,

--- a/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
@@ -19,6 +19,7 @@ use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
@@ -160,7 +161,7 @@ pub struct MicroBit {
 }
 
 impl SyscallDriverLookup for MicroBit {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/src/main.rs
@@ -14,7 +14,7 @@ use kernel::hil::led::LedLow;
 use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
-use kernel::{capabilities, create_capability, static_init};
+use kernel::{capabilities, create_capability, static_init, DriverNumber};
 use nrf52840::gpio::Pin;
 use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
 use nrf52_components::{UartChannel, UartPins};
@@ -77,7 +77,7 @@ pub struct Platform {
 }
 
 impl SyscallDriverLookup for Platform {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-sha256/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-sha256/src/main.rs
@@ -13,7 +13,7 @@ use kernel::hil::led::LedLow;
 use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
-use kernel::{capabilities, create_capability, static_init};
+use kernel::{capabilities, create_capability, static_init, DriverNumber};
 use nrf52840::gpio::Pin;
 use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
 use nrf52_components::{UartChannel, UartPins};
@@ -66,7 +66,7 @@ pub struct Platform {
 }
 
 impl SyscallDriverLookup for Platform {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/main.rs
@@ -14,7 +14,7 @@ use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::process::{ProcessArray, ProcessLoadingAsync};
 use kernel::scheduler::round_robin::RoundRobinSched;
-use kernel::{capabilities, create_capability, static_init};
+use kernel::{capabilities, create_capability, static_init, DriverNumber};
 use nrf52840::gpio::Pin;
 use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
 use nrf52_components::{UartChannel, UartPins};
@@ -68,7 +68,7 @@ pub struct Platform {
 }
 
 impl SyscallDriverLookup for Platform {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
@@ -17,6 +17,7 @@ use kernel::process::ProcessArray;
 use kernel::process::ProcessLoadingAsync;
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 use kernel::{capabilities, create_capability, static_init};
 use nrf52840::gpio::Pin;
 use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
@@ -96,7 +97,7 @@ pub struct Platform {
 }
 
 impl SyscallDriverLookup for Platform {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-invs/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-invs/src/main.rs
@@ -13,7 +13,7 @@ use kernel::hil::led::LedLow;
 use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
-use kernel::{capabilities, create_capability, static_init};
+use kernel::{capabilities, create_capability, static_init, DriverNumber};
 use nrf52840::gpio::Pin;
 use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
 use nrf52_components::{UartChannel, UartPins};
@@ -88,7 +88,7 @@ pub struct Platform {
 }
 
 impl SyscallDriverLookup for Platform {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/main.rs
@@ -17,6 +17,7 @@ use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::utilities::cells::NumericCellExt;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 use kernel::{capabilities, create_capability, static_init};
 use nrf52840::chip::Nrf52DefaultPeripherals;
 use nrf52840::gpio::Pin;
@@ -58,7 +59,7 @@ pub struct Platform {
 }
 
 impl SyscallDriverLookup for Platform {
-    fn with_driver<F, R>(&self, _driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, _driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/cy8cproto_62_4343_w/src/main.rs
+++ b/boards/cy8cproto_62_4343_w/src/main.rs
@@ -22,6 +22,7 @@ use kernel::hil::led::LedHigh;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 use kernel::{capabilities, create_capability, static_init};
 
 #[allow(unused)]
@@ -62,7 +63,7 @@ pub struct Cy8cproto0624343w {
 }
 
 impl SyscallDriverLookup for Cy8cproto0624343w {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/esp32-c3-devkitM-1/src/main.rs
+++ b/boards/esp32-c3-devkitM-1/src/main.rs
@@ -20,6 +20,7 @@ use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::priority::PrioritySched;
 use kernel::utilities::registers::interfaces::ReadWriteable;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 use kernel::{create_capability, debug, hil, static_init};
 use rv32i::csr;
 
@@ -88,7 +89,7 @@ struct Esp32C3Board {
 
 /// Mapping of integer syscalls to objects that implement syscalls.
 impl SyscallDriverLookup for Esp32C3Board {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -20,6 +20,7 @@ use kernel::hil::Controller;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, static_init};
 use sam4l::chip::Sam4lDefaultPeripherals;
@@ -94,7 +95,7 @@ struct Hail {
 
 /// Mapping of integer syscalls to objects that implement syscalls.
 impl SyscallDriverLookup for Hail {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -22,6 +22,7 @@ use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::cooperative::CooperativeSched;
 use kernel::utilities::registers::interfaces::ReadWriteable;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 use kernel::Kernel;
 use kernel::{create_capability, debug, static_init};
 use rv32i::csr;
@@ -69,7 +70,7 @@ struct HiFive1 {
 
 /// Mapping of integer syscalls to objects that implement syscalls.
 impl SyscallDriverLookup for HiFive1 {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/hifive_inventor/src/main.rs
+++ b/boards/hifive_inventor/src/main.rs
@@ -19,6 +19,7 @@ use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::cooperative::CooperativeSched;
 use kernel::utilities::registers::interfaces::ReadWriteable;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 use kernel::{create_capability, debug, static_init};
 use rv32i::csr;
 
@@ -60,7 +61,7 @@ struct HiFiveInventor {
 
 /// Mapping of integer syscalls to objects that implement syscalls.
 impl SyscallDriverLookup for HiFiveInventor {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -33,6 +33,7 @@ use kernel::hil::symmetric_encryption::AES128;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 
 //use kernel::hil::time::Alarm;
 use kernel::hil::led::LedHigh;
@@ -173,7 +174,7 @@ struct Imix {
 }
 
 impl SyscallDriverLookup for Imix {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -23,6 +23,7 @@ use kernel::hil::led::LedLow;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 use kernel::{create_capability, static_init};
 
 // use components::fxos8700::Fxos8700Component;
@@ -98,7 +99,7 @@ struct Imxrt1050EVKB {
 
 /// Mapping of integer syscalls to objects that implement syscalls.
 impl SyscallDriverLookup for Imxrt1050EVKB {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -19,6 +19,7 @@ use kernel::scheduler::mlfq::MLFQSched;
 use kernel::utilities::registers::interfaces::ReadWriteable;
 use kernel::utilities::single_thread_value::SingleThreadValue;
 use kernel::utilities::StaticRef;
+use kernel::DriverNumber;
 use kernel::{create_capability, debug, static_init};
 use rv32i::csr;
 
@@ -127,7 +128,7 @@ struct LiteXArty {
 
 /// Mapping of integer syscalls to objects that implement syscalls
 impl SyscallDriverLookup for LiteXArty {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -19,6 +19,7 @@ use kernel::scheduler::mlfq::MLFQSched;
 use kernel::utilities::registers::interfaces::ReadWriteable;
 use kernel::utilities::single_thread_value::SingleThreadValue;
 use kernel::utilities::StaticRef;
+use kernel::DriverNumber;
 use kernel::{create_capability, debug, static_init};
 use rv32i::csr;
 
@@ -137,7 +138,7 @@ struct LiteXSim {
 
 /// Mapping of integer syscalls to objects that implement syscalls.
 impl SyscallDriverLookup for LiteXSim {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/makepython-nrf52840/src/main.rs
+++ b/boards/makepython-nrf52840/src/main.rs
@@ -22,6 +22,7 @@ use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::utilities::cells::MapCell;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
 
@@ -165,7 +166,7 @@ pub struct Platform {
 }
 
 impl SyscallDriverLookup for Platform {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -19,6 +19,7 @@ use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
@@ -149,7 +150,7 @@ pub struct MicroBit {
 }
 
 impl SyscallDriverLookup for MicroBit {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -18,6 +18,7 @@ use kernel::hil::gpio::Configure;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 use kernel::{create_capability, debug, static_init};
 
 /// Support routines for debugging I/O.
@@ -100,7 +101,7 @@ impl KernelResources<msp432::chip::Msp432<'static, msp432::chip::Msp432DefaultPe
 
 /// Mapping of integer syscalls to objects that implement syscalls.
 impl SyscallDriverLookup for MspExp432P401R {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -25,6 +25,7 @@ use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::utilities::cells::MapCell;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
 
@@ -181,7 +182,7 @@ pub struct Platform {
 }
 
 impl SyscallDriverLookup for Platform {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/nano33ble_rev2/src/main.rs
+++ b/boards/nano33ble_rev2/src/main.rs
@@ -25,6 +25,7 @@ use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::utilities::cells::MapCell;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
 
@@ -189,7 +190,7 @@ pub struct Platform {
 }
 
 impl SyscallDriverLookup for Platform {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -25,6 +25,7 @@ use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::syscall::SyscallDriver;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 use kernel::{capabilities, create_capability, static_init};
 use rp2040::adc::{Adc, Channel};
 use rp2040::chip::{Rp2040, Rp2040DefaultPeripherals};
@@ -99,7 +100,7 @@ pub struct NanoRP2040Connect {
 }
 
 impl SyscallDriverLookup for NanoRP2040Connect {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn SyscallDriver>) -> R,
     {

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -24,6 +24,7 @@ use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 #[allow(unused_imports)]
 use kernel::{capabilities, create_capability, debug, debug_gpio, debug_verbose, static_init};
 use nrf52840::gpio::Pin;
@@ -126,7 +127,7 @@ pub struct Platform {
 }
 
 impl SyscallDriverLookup for Platform {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -144,6 +144,7 @@ type ProcessPrinter = capsules_system::process_printer::ProcessPrinterText;
 pub const NUM_PROCS: usize = 8;
 
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
@@ -244,7 +245,7 @@ pub struct Platform {
 }
 
 impl SyscallDriverLookup for Platform {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -8,9 +8,9 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use kernel::debug;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::{capabilities, create_capability};
+use kernel::{debug, DriverNumber};
 
 // State for loading and holding applications.
 // How should the kernel respond when a process faults.
@@ -25,7 +25,7 @@ struct Platform {
 }
 
 impl SyscallDriverLookup for Platform {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -79,6 +79,7 @@ use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 #[allow(unused_imports)]
 use kernel::{capabilities, create_capability, debug, debug_gpio, debug_verbose, static_init};
 use nrf52832::gpio::Pin;
@@ -179,7 +180,7 @@ pub struct Platform {
 }
 
 impl SyscallDriverLookup for Platform {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -21,6 +21,7 @@ use kernel::hil::led::LedHigh;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 use kernel::{create_capability, debug, static_init};
 
 use stm32f429zi::chip_specs::Stm32f429Specs;
@@ -92,7 +93,7 @@ struct NucleoF429ZI {
 
 /// Mapping of integer syscalls to objects that implement syscalls.
 impl SyscallDriverLookup for NucleoF429ZI {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -22,6 +22,7 @@ use kernel::hil::led::LedHigh;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 use kernel::{create_capability, debug, static_init};
 use stm32f446re::chip_specs::Stm32f446Specs;
 use stm32f446re::clocks::hsi::HSI_FREQUENCY_MHZ;
@@ -82,7 +83,7 @@ struct NucleoF446RE {
 
 /// Mapping of integer syscalls to objects that implement syscalls.
 impl SyscallDriverLookup for NucleoF446RE {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/opentitan/earlgrey-cw310/src/main.rs
+++ b/boards/opentitan/earlgrey-cw310/src/main.rs
@@ -36,6 +36,7 @@ use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::priority::PrioritySched;
 use kernel::utilities::registers::interfaces::ReadWriteable;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 use kernel::{create_capability, debug, static_init};
 use lowrisc::flash_ctrl::FlashMPConfig;
 use rv32i::csr;
@@ -238,7 +239,7 @@ struct EarlGrey {
 
 /// Mapping of integer syscalls to objects that implement syscalls.
 impl SyscallDriverLookup for EarlGrey {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -26,6 +26,7 @@ use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 #[allow(unused_imports)]
 use kernel::{capabilities, create_capability, debug, debug_gpio, debug_verbose, static_init};
 use nrf52840::gpio::Pin;
@@ -131,7 +132,7 @@ pub struct Platform {
 }
 
 impl SyscallDriverLookup for Platform {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -23,6 +23,7 @@ use kernel::hil::usb::Client;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 use kernel::{capabilities, create_capability, static_init};
 use kernel::{debug, hil};
 
@@ -110,7 +111,7 @@ pub struct PicoExplorerBase {
 }
 
 impl SyscallDriverLookup for PicoExplorerBase {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/qemu_i486_q35/src/main.rs
+++ b/boards/qemu_i486_q35/src/main.rs
@@ -29,6 +29,7 @@ use kernel::scheduler::cooperative::CooperativeSched;
 use kernel::syscall::SyscallDriver;
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 use kernel::{create_capability, static_init};
 use virtio::devices::virtio_rng::VirtIORng;
 use virtio::devices::VirtIODeviceType;
@@ -160,7 +161,7 @@ pub struct QemuI386Q35Platform {
 }
 
 impl SyscallDriverLookup for QemuI386Q35Platform {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn SyscallDriver>) -> R,
     {

--- a/boards/qemu_rv32_virt/src/lib.rs
+++ b/boards/qemu_rv32_virt/src/lib.rs
@@ -17,6 +17,7 @@ use kernel::platform::SyscallDriverLookup;
 use kernel::scheduler::cooperative::CooperativeSched;
 use kernel::utilities::registers::interfaces::ReadWriteable;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 use kernel::{create_capability, debug, static_init};
 use qemu_rv32_virt_chip::chip::{QemuRv32VirtChip, QemuRv32VirtDefaultPeripherals};
 use rv32i::csr;
@@ -86,7 +87,7 @@ pub struct QemuRv32VirtPlatform {
 
 /// Mapping of integer syscalls to objects that implement syscalls.
 impl SyscallDriverLookup for QemuRv32VirtPlatform {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/qemu_rv32_virt/src/main.rs
+++ b/boards/qemu_rv32_virt/src/main.rs
@@ -11,6 +11,7 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::platform::KernelResources;
 use kernel::platform::SyscallDriverLookup;
+use kernel::DriverNumber;
 use kernel::{create_capability, debug};
 
 // How should the kernel respond when a process faults.
@@ -25,7 +26,7 @@ struct Platform {
 }
 
 impl SyscallDriverLookup for Platform {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -29,6 +29,7 @@ use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::syscall::SyscallDriver;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 use kernel::{capabilities, create_capability, static_init};
 
 use rp2040::adc::{Adc, Channel};
@@ -100,7 +101,7 @@ pub struct RaspberryPiPico {
 }
 
 impl SyscallDriverLookup for RaspberryPiPico {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn SyscallDriver>) -> R,
     {

--- a/boards/raspberry_pi_pico_2/src/main.rs
+++ b/boards/raspberry_pi_pico_2/src/main.rs
@@ -25,6 +25,7 @@ use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::syscall::SyscallDriver;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 use kernel::{capabilities, create_capability, static_init, Kernel};
 
 use rp2350::chip::{Rp2350, Rp2350DefaultPeripherals};
@@ -98,7 +99,7 @@ pub struct RaspberryPiPico2 {
 }
 
 impl SyscallDriverLookup for RaspberryPiPico2 {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn SyscallDriver>) -> R,
     {

--- a/boards/redboard_redv/src/main.rs
+++ b/boards/redboard_redv/src/main.rs
@@ -25,6 +25,7 @@ use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::cooperative::CooperativeSched;
 use kernel::utilities::registers::interfaces::ReadWriteable;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 use kernel::{create_capability, debug, static_init};
 use rv32i::csr;
 
@@ -71,7 +72,7 @@ struct RedV {
 
 /// Mapping of integer syscalls to objects that implement syscalls.
 impl SyscallDriverLookup for RedV {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -30,6 +30,7 @@ use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 #[allow(unused_imports)]
 use kernel::{capabilities, create_capability, debug, debug_gpio, debug_verbose, static_init};
 use nrf52840::gpio::Pin;
@@ -128,7 +129,7 @@ pub struct Platform {
 }
 
 impl SyscallDriverLookup for Platform {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -25,6 +25,7 @@ use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 use kernel::{create_capability, debug, static_init};
 use stm32f303xc::chip::Stm32f3xxDefaultPeripherals;
 use stm32f303xc::wdt;
@@ -97,7 +98,7 @@ struct STM32F3Discovery {
 
 /// Mapping of integer syscalls to objects that implement syscalls.
 impl SyscallDriverLookup for STM32F3Discovery {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -24,6 +24,7 @@ use kernel::hil::screen::ScreenRotation;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 use kernel::{create_capability, debug, static_init};
 use stm32f412g::chip_specs::Stm32f412Specs;
 use stm32f412g::clocks::hsi::HSI_FREQUENCY_MHZ;
@@ -84,7 +85,7 @@ struct STM32F412GDiscovery {
 
 /// Mapping of integer syscalls to objects that implement syscalls.
 impl SyscallDriverLookup for STM32F412GDiscovery {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/stm32f429idiscovery/src/main.rs
+++ b/boards/stm32f429idiscovery/src/main.rs
@@ -21,6 +21,7 @@ use kernel::hil::led::LedHigh;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 use kernel::{create_capability, debug, static_init};
 
 use stm32f429zi::chip_specs::Stm32f429Specs;
@@ -77,7 +78,7 @@ struct STM32F429IDiscovery {
 
 /// Mapping of integer syscalls to objects that implement syscalls.
 impl SyscallDriverLookup for STM32F429IDiscovery {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/teensy40/src/main.rs
+++ b/boards/teensy40/src/main.rs
@@ -27,6 +27,7 @@ use kernel::platform::chip::ClockInterface;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 use kernel::{create_capability, static_init};
 
 /// Number of concurrent processes this platform supports
@@ -65,7 +66,7 @@ struct Teensy40 {
 }
 
 impl SyscallDriverLookup for Teensy40 {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/tutorials/nrf52840dk-dynamic-apps-and-policies/src/main.rs
+++ b/boards/tutorials/nrf52840dk-dynamic-apps-and-policies/src/main.rs
@@ -13,7 +13,7 @@ use kernel::deferred_call::DeferredCallClient;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::process::ProcessLoadingAsync;
 use kernel::process::ShortId;
-use kernel::{capabilities, create_capability, static_init};
+use kernel::{capabilities, create_capability, static_init, DriverNumber};
 use nrf52840::gpio::Pin;
 use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
 
@@ -129,7 +129,7 @@ struct Platform {
 
 // Expose system call interfaces to userspace.
 impl SyscallDriverLookup for Platform {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/tutorials/nrf52840dk-hotp-tutorial/src/main.rs
+++ b/boards/tutorials/nrf52840dk-hotp-tutorial/src/main.rs
@@ -9,11 +9,11 @@
 #![deny(missing_docs)]
 
 use kernel::component::Component;
-use kernel::debug;
 use kernel::hil::usb::Client;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::static_init;
 use kernel::{capabilities, create_capability};
+use kernel::{debug, DriverNumber};
 use nrf52840::gpio::Pin;
 
 // State for loading and holding applications.
@@ -41,10 +41,11 @@ struct Platform {
     base: nrf52840dk_lib::Platform,
 }
 
-const KEYBOARD_HID_DRIVER_NUM: usize = capsules_core::driver::NUM::KeyboardHid as usize;
+const KEYBOARD_HID_DRIVER_NUM: DriverNumber =
+    DriverNumber::from_const(capsules_core::driver::NUM::KeyboardHid as usize);
 
 impl SyscallDriverLookup for Platform {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {
@@ -179,7 +180,7 @@ pub unsafe fn main() {
     // Generic HID Keyboard component usage
     let (keyboard_hid, keyboard_hid_driver) = components::keyboard_hid::KeyboardHidComponent::new(
         board_kernel,
-        capsules_core::driver::NUM::KeyboardHid as usize,
+        (capsules_core::driver::NUM::KeyboardHid as usize).into(),
         usb_device,
         0x1915, // Nordic Semiconductor
         0x503a,

--- a/boards/tutorials/nrf52840dk-root-of-trust-tutorial/src/main.rs
+++ b/boards/tutorials/nrf52840dk-root-of-trust-tutorial/src/main.rs
@@ -9,10 +9,10 @@
 #![deny(missing_docs)]
 
 use kernel::component::Component;
-use kernel::debug;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::static_init;
 use kernel::{capabilities, create_capability};
+use kernel::{debug, DriverNumber};
 use nrf52840::gpio::Pin;
 
 // State for loading and holding applications.
@@ -35,7 +35,7 @@ struct Platform {
 }
 
 impl SyscallDriverLookup for Platform {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/tutorials/nrf52840dk-thread-tutorial/src/main.rs
+++ b/boards/tutorials/nrf52840dk-thread-tutorial/src/main.rs
@@ -12,7 +12,7 @@ use core::ptr::addr_of;
 
 use kernel::component::Component;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::{capabilities, create_capability, static_init};
+use kernel::{capabilities, create_capability, static_init, DriverNumber};
 use nrf52840::gpio::Pin;
 use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
 use nrf52840dk_lib::{self, NUM_PROCS};
@@ -49,7 +49,7 @@ struct Platform {
 }
 
 impl SyscallDriverLookup for Platform {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/tutorials/qemu_rv32_virt-tutorial/src/main.rs
+++ b/boards/tutorials/qemu_rv32_virt-tutorial/src/main.rs
@@ -12,6 +12,7 @@ use kernel::component::Component;
 use kernel::deferred_call::DeferredCallClient;
 use kernel::platform::KernelResources;
 use kernel::platform::SyscallDriverLookup;
+use kernel::DriverNumber;
 use kernel::{create_capability, debug, static_init};
 
 mod checker_credentials_not_required;
@@ -81,7 +82,7 @@ struct Platform {
 }
 
 impl SyscallDriverLookup for Platform {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/veer_el2_sim/src/main.rs
+++ b/boards/veer_el2_sim/src/main.rs
@@ -17,6 +17,7 @@ use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::cooperative::CooperativeSched;
 use kernel::utilities::registers::interfaces::ReadWriteable;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 use kernel::{create_capability, debug, static_init};
 use rv32i::csr;
 use veer_el2::chip::VeeRDefaultPeripherals;
@@ -59,7 +60,7 @@ struct VeeR {
 
 /// Mapping of integer syscalls to objects that implement syscalls.
 impl SyscallDriverLookup for VeeR {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -21,6 +21,7 @@ use kernel::hil::led::LedLow;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 use kernel::{create_capability, debug, static_init};
 
 use stm32f401cc::chip_specs::Stm32f401Specs;
@@ -69,7 +70,7 @@ struct WeactF401CC {
 
 /// Mapping of integer syscalls to objects that implement syscalls.
 impl SyscallDriverLookup for WeactF401CC {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/boards/wm1110dev/src/main.rs
+++ b/boards/wm1110dev/src/main.rs
@@ -22,6 +22,7 @@ use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::DriverNumber;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
 
@@ -61,8 +62,10 @@ const LR_DIO9: Pin = Pin::P1_08;
 /// GPIO pin that controls VCC for the I2C bus and sensors.
 const I2C_PWR: Pin = Pin::P0_07;
 
-const LORA_SPI_DRIVER_NUM: usize = capsules_core::driver::NUM::LoRaPhySPI as usize;
-const LORA_GPIO_DRIVER_NUM: usize = capsules_core::driver::NUM::LoRaPhyGPIO as usize;
+const LORA_SPI_DRIVER_NUM: DriverNumber =
+    DriverNumber::from_const(capsules_core::driver::NUM::LoRaPhySPI as usize);
+const LORA_GPIO_DRIVER_NUM: DriverNumber =
+    DriverNumber::from_const(capsules_core::driver::NUM::LoRaPhyGPIO as usize);
 
 /// UART Writer for panic!()s.
 pub mod io;
@@ -129,7 +132,7 @@ pub struct Platform {
 }
 
 impl SyscallDriverLookup for Platform {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
     {

--- a/capsules/core/src/adc.rs
+++ b/capsules/core/src/adc.rs
@@ -56,16 +56,16 @@ use core::cell::Cell;
 use core::cmp;
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::hil;
 use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::{hil, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use crate::driver;
 use crate::virtualizers::virtual_adc::Operation;
-pub const DRIVER_NUM: usize = driver::NUM::Adc as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Adc as usize);
 
 /// Multiplexed ADC syscall driver, used by applications and capsules.
 ///

--- a/capsules/core/src/alarm.rs
+++ b/capsules/core/src/alarm.rs
@@ -8,11 +8,11 @@
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::hil::time::{self, Alarm, Ticks};
 use kernel::syscall::{CommandReturn, SyscallDriver};
-use kernel::{ErrorCode, ProcessId};
+use kernel::{DriverNumber, ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use crate::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Alarm as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Alarm as usize);
 
 #[derive(Copy, Clone, Debug)]
 struct Expiration<T: Ticks> {

--- a/capsules/core/src/button.rs
+++ b/capsules/core/src/button.rs
@@ -61,11 +61,11 @@ use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::hil::gpio;
 use kernel::hil::gpio::{Configure, Input, InterruptWithValue};
 use kernel::syscall::{CommandReturn, SyscallDriver};
-use kernel::{ErrorCode, ProcessId};
+use kernel::{DriverNumber, ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use crate::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Button as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Button as usize);
 
 /// Keeps track which buttons each app has a registered interrupt for.
 ///

--- a/capsules/core/src/console.rs
+++ b/capsules/core/src/console.rs
@@ -46,11 +46,11 @@ use kernel::hil::uart;
 use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
-use kernel::{ErrorCode, ProcessId};
+use kernel::{DriverNumber, ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use crate::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Console as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Console as usize);
 
 /// Default size for the read and write buffers used by the console.
 /// Boards may pass different-size buffers if needed.

--- a/capsules/core/src/console_ordered.rs
+++ b/capsules/core/src/console_ordered.rs
@@ -73,7 +73,7 @@ use core::cell::Cell;
 use core::cmp;
 
 use kernel::debug::debug_available_len;
-use kernel::debug_process_slice;
+use kernel::{debug_process_slice, DriverNumber};
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, GrantKernelData, UpcallCount};
 use kernel::hil::time::{Alarm, AlarmClient, ConvertTicks};
@@ -85,7 +85,7 @@ use kernel::{ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use crate::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Console as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Console as usize);
 
 /// Ids for read-only allow buffers
 mod ro_allow {

--- a/capsules/core/src/gpio.rs
+++ b/capsules/core/src/gpio.rs
@@ -53,13 +53,13 @@
 
 /// Syscall driver number.
 use crate::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Gpio as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Gpio as usize);
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::hil::gpio;
 use kernel::hil::gpio::{Configure, Input, InterruptWithValue, Output};
 use kernel::syscall::{CommandReturn, SyscallDriver};
-use kernel::{ErrorCode, ProcessId};
+use kernel::{DriverNumber, ErrorCode, ProcessId};
 
 /// ### `subscribe_num`
 ///

--- a/capsules/core/src/i2c_master.rs
+++ b/capsules/core/src/i2c_master.rs
@@ -11,11 +11,11 @@ use kernel::hil::i2c;
 use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{MapCell, OptionalCell, TakeCell};
-use kernel::{ErrorCode, ProcessId};
+use kernel::{DriverNumber, ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use crate::driver;
-pub const DRIVER_NUM: usize = driver::NUM::I2cMaster as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::I2cMaster as usize);
 
 /// Ids for read-write allow buffers
 mod rw_allow {

--- a/capsules/core/src/i2c_master_slave_driver.rs
+++ b/capsules/core/src/i2c_master_slave_driver.rs
@@ -18,10 +18,10 @@
 use core::cell::Cell;
 use core::cmp;
 
-use kernel::hil;
 use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::{hil, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
@@ -30,7 +30,7 @@ pub const BUFFER_LENGTH: usize = 256;
 
 /// Syscall driver number.
 use crate::driver;
-pub const DRIVER_NUM: usize = driver::NUM::I2cMasterSlave as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::I2cMasterSlave as usize);
 
 /// Ids for read-only allow buffers
 mod ro_allow {

--- a/capsules/core/src/led.rs
+++ b/capsules/core/src/led.rs
@@ -60,11 +60,11 @@
 
 use kernel::hil::led;
 use kernel::syscall::{CommandReturn, SyscallDriver};
-use kernel::{ErrorCode, ProcessId};
+use kernel::{DriverNumber, ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use crate::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Led as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Led as usize);
 
 /// Holds the array of LEDs and implements a `Driver` interface to
 /// control them.

--- a/capsules/core/src/low_level_debug/mod.rs
+++ b/capsules/core/src/low_level_debug/mod.rs
@@ -12,12 +12,13 @@ use core::cell::Cell;
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::hil::uart::{Transmit, TransmitClient};
 use kernel::syscall::CommandReturn;
-use kernel::{ErrorCode, ProcessId};
+use kernel::{DriverNumber, ErrorCode, ProcessId};
 
 // LowLevelDebug requires a &mut [u8] buffer of length at least BUF_LEN.
 pub use fmt::BUF_LEN;
 
-pub const DRIVER_NUM: usize = crate::driver::NUM::LowLevelDebug as usize;
+pub const DRIVER_NUM: DriverNumber =
+    DriverNumber::from_const(crate::driver::NUM::LowLevelDebug as usize);
 
 pub struct LowLevelDebug<'u, U: Transmit<'u>> {
     buffer: Cell<Option<&'static mut [u8]>>,

--- a/capsules/core/src/rng.rs
+++ b/capsules/core/src/rng.rs
@@ -37,11 +37,11 @@ use kernel::hil::rng::{Client, Continue, Random, Rng};
 use kernel::processbuffer::WriteableProcessBuffer;
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::OptionalCell;
-use kernel::{ErrorCode, ProcessId};
+use kernel::{DriverNumber, ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use crate::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Rng as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Rng as usize);
 
 /// Ids for read-write allow buffers
 mod rw_allow {

--- a/capsules/core/src/spi_controller.rs
+++ b/capsules/core/src/spi_controller.rs
@@ -16,11 +16,11 @@ use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{MapCell, OptionalCell};
 use kernel::utilities::leasable_buffer::SubSliceMut;
-use kernel::{ErrorCode, ProcessId};
+use kernel::{DriverNumber, ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use crate::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Spi as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Spi as usize);
 
 /// Ids for read-only allow buffers
 mod ro_allow {

--- a/capsules/core/src/spi_peripheral.rs
+++ b/capsules/core/src/spi_peripheral.rs
@@ -15,11 +15,11 @@ use kernel::hil::spi::{SpiSlaveClient, SpiSlaveDevice};
 use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
-use kernel::{ErrorCode, ProcessId};
+use kernel::{DriverNumber, ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use crate::driver;
-pub const DRIVER_NUM: usize = driver::NUM::SpiPeripheral as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::SpiPeripheral as usize);
 
 /// Ids for read-only allow buffers
 mod ro_allow {

--- a/capsules/core/src/test/double_grant_entry.rs
+++ b/capsules/core/src/test/double_grant_entry.rs
@@ -63,10 +63,10 @@
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::syscall::{CommandReturn, SyscallDriver};
-use kernel::{ErrorCode, ProcessId};
+use kernel::{DriverNumber, ErrorCode, ProcessId};
 
 /// Syscall driver number.
-pub const DRIVER_NUM: usize = 0xF001;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(0xF001);
 
 /// Need a grant for the process.
 #[derive(Default)]

--- a/capsules/extra/src/air_quality.rs
+++ b/capsules/extra/src/air_quality.rs
@@ -25,13 +25,13 @@
 
 use core::cell::Cell;
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::hil;
 use kernel::syscall::{CommandReturn, SyscallDriver};
+use kernel::{hil, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::AirQuality as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::AirQuality as usize);
 
 #[derive(Clone, Copy, PartialEq, Default)]
 enum Operation {

--- a/capsules/extra/src/ambient_light.rs
+++ b/capsules/extra/src/ambient_light.rs
@@ -19,13 +19,13 @@
 use core::cell::Cell;
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::hil;
 use kernel::syscall::{CommandReturn, SyscallDriver};
+use kernel::{hil, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::AmbientLight as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::AmbientLight as usize);
 
 /// IDs for subscribed upcalls.
 mod upcall {

--- a/capsules/extra/src/analog_comparator.rs
+++ b/capsules/extra/src/analog_comparator.rs
@@ -39,12 +39,13 @@
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::AnalogComparator as usize;
+pub const DRIVER_NUM: DriverNumber =
+    DriverNumber::from_const(driver::NUM::AnalogComparator as usize);
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::hil;
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::OptionalCell;
+use kernel::{hil, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 pub struct AnalogComparator<'a, A: hil::analog_comparator::AnalogComparator<'a> + 'a> {

--- a/capsules/extra/src/app_flash_driver.rs
+++ b/capsules/extra/src/app_flash_driver.rs
@@ -29,15 +29,15 @@
 use core::cmp;
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::hil;
 use kernel::processbuffer::ReadableProcessBuffer;
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::{hil, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::AppFlash as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::AppFlash as usize);
 
 /// IDs for subscribed upcalls.
 mod upcall {

--- a/capsules/extra/src/app_loader.rs
+++ b/capsules/extra/src/app_loader.rs
@@ -68,7 +68,6 @@
 use core::cell::Cell;
 use core::cmp;
 
-use kernel::dynamic_binary_storage;
 use kernel::errorcode::into_statuscode;
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::process::ProcessLoadError;
@@ -76,11 +75,12 @@ use kernel::processbuffer::ReadableProcessBuffer;
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::utilities::leasable_buffer::SubSliceMut;
+use kernel::{dynamic_binary_storage, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::AppLoader as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::AppLoader as usize);
 
 /// IDs for subscribed upcalls.
 mod upcall {

--- a/capsules/extra/src/ble_advertising_driver.rs
+++ b/capsules/extra/src/ble_advertising_driver.rs
@@ -109,7 +109,6 @@
 use core::cell::Cell;
 use core::cmp;
 
-use kernel::debug;
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, GrantKernelData, UpcallCount};
 use kernel::hil::ble_advertising;
 use kernel::hil::ble_advertising::RadioChannel;
@@ -118,11 +117,12 @@ use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::copy_slice::CopyOrErr;
+use kernel::{debug, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::BleAdvertising as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::BleAdvertising as usize);
 
 /// Ids for read-only allow buffers
 mod ro_allow {

--- a/capsules/extra/src/button_keyboard.rs
+++ b/capsules/extra/src/button_keyboard.rs
@@ -10,11 +10,11 @@
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::syscall::{CommandReturn, SyscallDriver};
-use kernel::{ErrorCode, ProcessId};
+use kernel::{DriverNumber, ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Button as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Button as usize);
 
 /// Keeps track for each app of which buttons it has a registered interrupt
 /// for.

--- a/capsules/extra/src/buzzer_driver.rs
+++ b/capsules/extra/src/buzzer_driver.rs
@@ -67,14 +67,14 @@
 use core::cmp;
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::hil;
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::OptionalCell;
+use kernel::{hil, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Buzzer as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Buzzer as usize);
 
 /// Standard max buzz time.
 pub const DEFAULT_MAX_BUZZ_TIME_MS: usize = 5000;

--- a/capsules/extra/src/can.rs
+++ b/capsules/extra/src/can.rs
@@ -57,11 +57,11 @@ use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::utilities::streaming_process_slice::StreamingProcessSlice;
-use kernel::ErrorCode;
 use kernel::ProcessId;
+use kernel::{DriverNumber, ErrorCode};
 
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Can as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Can as usize);
 pub const BYTE4_MASK: usize = 0xff000000;
 pub const BYTE3_MASK: usize = 0xff0000;
 pub const BYTE2_MASK: usize = 0xff00;

--- a/capsules/extra/src/crc.rs
+++ b/capsules/extra/src/crc.rs
@@ -88,11 +88,11 @@ use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::NumericCellExt;
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::utilities::leasable_buffer::SubSliceMut;
-use kernel::{ErrorCode, ProcessId};
+use kernel::{DriverNumber, ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Crc as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Crc as usize);
 pub const DEFAULT_CRC_BUF_LENGTH: usize = 256;
 
 /// Ids for read-only allow buffers

--- a/capsules/extra/src/cycle_count.rs
+++ b/capsules/extra/src/cycle_count.rs
@@ -15,12 +15,12 @@
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::CycleCount as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::CycleCount as usize);
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::OptionalCell;
-use kernel::{hil, ErrorCode, ProcessId};
+use kernel::{hil, DriverNumber, ErrorCode, ProcessId};
 
 #[derive(Default)]
 pub struct App;

--- a/capsules/extra/src/dac.rs
+++ b/capsules/extra/src/dac.rs
@@ -17,10 +17,10 @@
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Dac as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Dac as usize);
 
-use kernel::hil;
 use kernel::syscall::{CommandReturn, SyscallDriver};
+use kernel::{hil, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 pub struct Dac<'a> {

--- a/capsules/extra/src/date_time.rs
+++ b/capsules/extra/src/date_time.rs
@@ -41,9 +41,9 @@ use kernel::hil::date_time;
 use kernel::errorcode::into_statuscode;
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::OptionalCell;
-use kernel::{ErrorCode, ProcessId};
+use kernel::{DriverNumber, ErrorCode, ProcessId};
 
-pub const DRIVER_NUM: usize = NUM::DateTime as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(NUM::DateTime as usize);
 
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum DateTimeCommand {

--- a/capsules/extra/src/distance.rs
+++ b/capsules/extra/src/distance.rs
@@ -69,13 +69,13 @@
 use core::cell::Cell;
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::hil;
 use kernel::syscall::{CommandReturn, SyscallDriver};
+use kernel::{hil, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Distance as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Distance as usize);
 
 #[derive(Default)]
 pub struct App {

--- a/capsules/extra/src/ethernet_tap.rs
+++ b/capsules/extra/src/ethernet_tap.rs
@@ -169,11 +169,12 @@ use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::MapCell;
 use kernel::utilities::streaming_process_slice::StreamingProcessSlice;
-use kernel::ErrorCode;
 use kernel::ProcessId;
+use kernel::{DriverNumber, ErrorCode};
 
 /// Syscall driver number.
-pub const DRIVER_NUM: usize = capsules_core::driver::NUM::EthernetTap as usize;
+pub const DRIVER_NUM: DriverNumber =
+    DriverNumber::from_const(capsules_core::driver::NUM::EthernetTap as usize);
 
 /// Maximum size of a frame which can be transmitted over the underlying
 /// [`EthernetAdapterDatapath`] device.

--- a/capsules/extra/src/eui64.rs
+++ b/capsules/extra/src/eui64.rs
@@ -5,10 +5,10 @@
 //! Provides an EUI-64 (Extended Unique Identifier) interface for userspace.
 
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Eui64 as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Eui64 as usize);
 
 use kernel::syscall::{CommandReturn, SyscallDriver};
-use kernel::{ErrorCode, ProcessId};
+use kernel::{DriverNumber, ErrorCode, ProcessId};
 
 pub struct Eui64 {
     eui64: u64,

--- a/capsules/extra/src/gpio_async.rs
+++ b/capsules/extra/src/gpio_async.rs
@@ -30,14 +30,14 @@
 //! ```
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::hil;
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::OptionalCell;
+use kernel::{hil, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::GpioAsync as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::GpioAsync as usize);
 
 pub struct GPIOAsync<'a, Port: hil::gpio_async::Port> {
     ports: &'a [&'a Port],

--- a/capsules/extra/src/hmac.rs
+++ b/capsules/extra/src/hmac.rs
@@ -30,7 +30,7 @@
 use capsules_core::driver;
 use kernel::errorcode::into_statuscode;
 /// Syscall driver number.
-pub const DRIVER_NUM: usize = driver::NUM::Hmac as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Hmac as usize);
 
 /// Ids for read-only allow buffers
 mod ro_allow {
@@ -57,7 +57,7 @@ use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::utilities::leasable_buffer::SubSlice;
 use kernel::utilities::leasable_buffer::SubSliceMut;
-use kernel::{ErrorCode, ProcessId};
+use kernel::{DriverNumber, ErrorCode, ProcessId};
 
 enum ShaOperation {
     Sha256,

--- a/capsules/extra/src/humidity.rs
+++ b/capsules/extra/src/humidity.rs
@@ -54,13 +54,13 @@
 use core::cell::Cell;
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::hil;
 use kernel::syscall::{CommandReturn, SyscallDriver};
+use kernel::{hil, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Humidity as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Humidity as usize);
 
 #[derive(Clone, Copy, PartialEq)]
 pub enum HumidityCommand {

--- a/capsules/extra/src/ieee802154/driver.rs
+++ b/capsules/extra/src/ieee802154/driver.rs
@@ -65,7 +65,7 @@ use kernel::hil::radio;
 use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{MapCell, OptionalCell, TakeCell};
-use kernel::{ErrorCode, ProcessId};
+use kernel::{DriverNumber, ErrorCode, ProcessId};
 
 const MAX_NEIGHBORS: usize = 4;
 const MAX_KEYS: usize = 4;
@@ -106,7 +106,7 @@ mod rw_allow {
 }
 
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Ieee802154 as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Ieee802154 as usize);
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Default)]
 struct DeviceDescriptor {

--- a/capsules/extra/src/ieee802154/phy_driver.rs
+++ b/capsules/extra/src/ieee802154/phy_driver.rs
@@ -37,10 +37,10 @@
 //! issue by increasing the size of the ring buffer provided to the capsule.
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::hil;
 use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::{hil, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 /// IDs for subscribed upcalls.
@@ -70,7 +70,7 @@ mod rw_allow {
 }
 
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Ieee802154 as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Ieee802154 as usize);
 
 #[derive(Default)]
 pub struct App {

--- a/capsules/extra/src/isolated_nonvolatile_storage_driver.rs
+++ b/capsules/extra/src/isolated_nonvolatile_storage_driver.rs
@@ -96,16 +96,17 @@ use core::cmp;
 
 use kernel::errorcode::into_statuscode;
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::hil;
 use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::utilities::copy_slice::CopyOrErr;
+use kernel::{hil, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 use capsules_core::driver;
 
-pub const DRIVER_NUM: usize = driver::NUM::IsolatedNvmStorage as usize;
+pub const DRIVER_NUM: DriverNumber =
+    DriverNumber::from_const(driver::NUM::IsolatedNvmStorage as usize);
 
 /// Recommended size for the buffer provided to this capsule.
 ///

--- a/capsules/extra/src/kv_driver.rs
+++ b/capsules/extra/src/kv_driver.rs
@@ -42,10 +42,9 @@
 
 use capsules_core::driver;
 /// Syscall driver number.
-pub const DRIVER_NUM: usize = driver::NUM::Kv as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Kv as usize);
 
 use core::cmp;
-use kernel::errorcode;
 use kernel::grant::Grant;
 use kernel::grant::{AllowRoCount, AllowRwCount, UpcallCount};
 use kernel::hil::kv;
@@ -53,6 +52,7 @@ use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::utilities::leasable_buffer::SubSliceMut;
+use kernel::{errorcode, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 /// IDs for read-only allow buffers.

--- a/capsules/extra/src/l3gd20.rs
+++ b/capsules/extra/src/l3gd20.rs
@@ -114,10 +114,10 @@ use kernel::hil::spi;
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{MapCell, OptionalCell};
 use kernel::utilities::leasable_buffer::SubSliceMut;
-use kernel::{ErrorCode, ProcessId};
+use kernel::{DriverNumber, ErrorCode, ProcessId};
 
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::L3gd20 as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::L3gd20 as usize);
 
 /* Identification number */
 const L3GD20_WHO_AM_I: u8 = 0xD4;

--- a/capsules/extra/src/lps22hb.rs
+++ b/capsules/extra/src/lps22hb.rs
@@ -40,11 +40,11 @@ use core::cell::Cell;
 use kernel::hil::i2c::{self, I2CClient, I2CDevice};
 use kernel::hil::sensors::{PressureClient, PressureDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
-use kernel::ErrorCode;
+use kernel::{DriverNumber, ErrorCode};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Pressure as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Pressure as usize);
 
 /// Register values
 

--- a/capsules/extra/src/lps25hb.rs
+++ b/capsules/extra/src/lps25hb.rs
@@ -29,11 +29,11 @@ use kernel::hil::gpio;
 use kernel::hil::i2c;
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
-use kernel::{ErrorCode, ProcessId};
+use kernel::{DriverNumber, ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Lps25hb as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Lps25hb as usize);
 
 // Expected buffer length.
 pub const BUF_LEN: usize = 5;

--- a/capsules/extra/src/lsm303agr.rs
+++ b/capsules/extra/src/lsm303agr.rs
@@ -93,7 +93,7 @@ use kernel::hil::i2c;
 use kernel::hil::sensors;
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
-use kernel::{ErrorCode, ProcessId};
+use kernel::{DriverNumber, ErrorCode, ProcessId};
 
 use crate::lsm303xx::{
     AccelerometerRegisters, Lsm303AccelDataRate, Lsm303MagnetoDataRate, Lsm303Range, Lsm303Scale,
@@ -102,7 +102,7 @@ use crate::lsm303xx::{
 use capsules_core::driver;
 
 /// Syscall driver number.
-pub const DRIVER_NUM: usize = driver::NUM::Lsm303dlch as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Lsm303dlch as usize);
 
 /// Register values
 const REGISTER_AUTO_INCREMENT: u8 = 0x80;

--- a/capsules/extra/src/lsm303dlhc.rs
+++ b/capsules/extra/src/lsm303dlhc.rs
@@ -92,7 +92,7 @@ use kernel::hil::i2c;
 use kernel::hil::sensors;
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
-use kernel::{ErrorCode, ProcessId};
+use kernel::{DriverNumber, ErrorCode, ProcessId};
 
 use crate::lsm303xx::{
     AccelerometerRegisters, Lsm303AccelDataRate, Lsm303MagnetoDataRate, Lsm303Range, Lsm303Scale,
@@ -102,7 +102,7 @@ use crate::lsm303xx::{
 use capsules_core::driver;
 
 /// Syscall driver number.
-pub const DRIVER_NUM: usize = driver::NUM::Lsm303dlch as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Lsm303dlch as usize);
 
 /// Register values
 const REGISTER_AUTO_INCREMENT: u8 = 0x80;

--- a/capsules/extra/src/lsm6dsoxtr.rs
+++ b/capsules/extra/src/lsm6dsoxtr.rs
@@ -28,9 +28,9 @@ use kernel::hil::sensors::{NineDof, NineDofClient};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::utilities::registers::LocalRegisterCopy;
-use kernel::{ErrorCode, ProcessId};
+use kernel::{DriverNumber, ErrorCode, ProcessId};
 
-pub const DRIVER_NUM: usize = driver::NUM::Lsm6dsoxtr as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Lsm6dsoxtr as usize);
 
 use kernel::utilities::registers::register_bitfields;
 

--- a/capsules/extra/src/ltc294x.rs
+++ b/capsules/extra/src/ltc294x.rs
@@ -57,11 +57,11 @@ use kernel::hil::gpio;
 use kernel::hil::i2c;
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
-use kernel::{ErrorCode, ProcessId};
+use kernel::{DriverNumber, ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Ltc294x as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Ltc294x as usize);
 
 pub const BUF_LEN: usize = 20;
 

--- a/capsules/extra/src/max17205.rs
+++ b/capsules/extra/src/max17205.rs
@@ -49,11 +49,11 @@ use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::hil::i2c;
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
-use kernel::{ErrorCode, ProcessId};
+use kernel::{DriverNumber, ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Max17205 as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Max17205 as usize);
 
 pub const BUFFER_LENGTH: usize = 8;
 

--- a/capsules/extra/src/mlx90614.rs
+++ b/capsules/extra/src/mlx90614.rs
@@ -29,12 +29,12 @@ use kernel::hil::sensors;
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::utilities::registers::register_bitfields;
-use kernel::{ErrorCode, ProcessId};
+use kernel::{DriverNumber, ErrorCode, ProcessId};
 
 use capsules_core::driver;
 
 /// Syscall driver number.
-pub const DRIVER_NUM: usize = driver::NUM::Mlx90614 as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Mlx90614 as usize);
 
 register_bitfields![u16,
     CONFIG [

--- a/capsules/extra/src/moisture.rs
+++ b/capsules/extra/src/moisture.rs
@@ -47,13 +47,13 @@
 use core::cell::Cell;
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::hil;
 use kernel::syscall::{CommandReturn, SyscallDriver};
+use kernel::{hil, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Moisture as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Moisture as usize);
 
 #[derive(Clone, Copy, PartialEq)]
 enum MoistureCommand {

--- a/capsules/extra/src/net/thread/driver.rs
+++ b/capsules/extra/src/net/thread/driver.rs
@@ -63,10 +63,10 @@ use kernel::processbuffer::ReadableProcessBuffer;
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::MapCell;
 use kernel::utilities::leasable_buffer::SubSliceMut;
-use kernel::{ErrorCode, ProcessId};
+use kernel::{DriverNumber, ErrorCode, ProcessId};
 
 const SECURITY_SUITE_ENCRYP: u8 = 0;
-pub const DRIVER_NUM: usize = driver::NUM::Thread as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Thread as usize);
 
 /// Ids for read-only allow buffers
 mod ro_allow {

--- a/capsules/extra/src/net/udp/driver.rs
+++ b/capsules/extra/src/net/udp/driver.rs
@@ -31,10 +31,11 @@ use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::MapCell;
 use kernel::utilities::leasable_buffer::SubSliceMut;
+use kernel::DriverNumber;
 use kernel::{ErrorCode, ProcessId};
 
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Udp as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Udp as usize);
 
 /// IDs for subscribed upcalls.
 mod upcall {

--- a/capsules/extra/src/ninedof.rs
+++ b/capsules/extra/src/ninedof.rs
@@ -23,14 +23,14 @@
 //! ```
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::hil;
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::OptionalCell;
+use kernel::{hil, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::NINEDOF as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::NINEDOF as usize);
 
 #[derive(Clone, Copy, PartialEq)]
 pub enum NineDofCommand {

--- a/capsules/extra/src/nonvolatile_storage_driver.rs
+++ b/capsules/extra/src/nonvolatile_storage_driver.rs
@@ -62,15 +62,15 @@ use core::cell::Cell;
 use core::cmp;
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::hil;
 use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::{hil, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::NvmStorage as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::NvmStorage as usize);
 
 /// IDs for subscribed upcalls.
 mod upcall {

--- a/capsules/extra/src/nrf51822_serialization.rs
+++ b/capsules/extra/src/nrf51822_serialization.rs
@@ -27,16 +27,17 @@
 use core::cmp;
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::hil;
 use kernel::hil::uart;
 use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::{hil, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Nrf51822Serialization as usize;
+pub const DRIVER_NUM: DriverNumber =
+    DriverNumber::from_const(driver::NUM::Nrf51822Serialization as usize);
 
 /// IDs for subscribed upcalls.
 mod upcall {

--- a/capsules/extra/src/pca9544a.rs
+++ b/capsules/extra/src/pca9544a.rs
@@ -40,11 +40,11 @@ use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::hil::i2c;
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
-use kernel::{ErrorCode, ProcessId};
+use kernel::{DriverNumber, ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Pca9544a as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Pca9544a as usize);
 
 pub const BUFFER_LENGTH: usize = 5;
 

--- a/capsules/extra/src/pressure.rs
+++ b/capsules/extra/src/pressure.rs
@@ -56,13 +56,13 @@
 use core::cell::Cell;
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::hil;
 use kernel::syscall::{CommandReturn, SyscallDriver};
+use kernel::{hil, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Pressure as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Pressure as usize);
 
 #[derive(Default)]
 pub struct App {

--- a/capsules/extra/src/process_info_driver.rs
+++ b/capsules/extra/src/process_info_driver.rs
@@ -37,15 +37,15 @@
 
 use kernel::capabilities::{ProcessManagementCapability, ProcessStartCapability};
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::process;
 use kernel::processbuffer::WriteableProcessBuffer;
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::Kernel;
+use kernel::{process, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::ProcessInfo as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::ProcessInfo as usize);
 
 mod rw_allow {
     pub const INFO: usize = 0;

--- a/capsules/extra/src/proximity.rs
+++ b/capsules/extra/src/proximity.rs
@@ -55,13 +55,13 @@
 use core::cell::Cell;
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::hil;
 use kernel::syscall::{CommandReturn, SyscallDriver};
+use kernel::{hil, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Proximity as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Proximity as usize);
 
 #[derive(Default)]
 pub struct App {

--- a/capsules/extra/src/pwm.rs
+++ b/capsules/extra/src/pwm.rs
@@ -3,14 +3,14 @@
 // Copyright Tock Contributors 2022.
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::hil;
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::OptionalCell;
+use kernel::{hil, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Pwm as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Pwm as usize);
 
 // An empty app, for potential uses in future updates of the driver
 #[derive(Default)]

--- a/capsules/extra/src/rainfall.rs
+++ b/capsules/extra/src/rainfall.rs
@@ -37,13 +37,13 @@
 use core::cell::Cell;
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::hil;
 use kernel::syscall::{CommandReturn, SyscallDriver};
+use kernel::{hil, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::RainFall as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::RainFall as usize);
 
 #[derive(Clone, Copy, PartialEq)]
 enum RainFallCommand {

--- a/capsules/extra/src/screen/screen.rs
+++ b/capsules/extra/src/screen/screen.rs
@@ -17,17 +17,17 @@
 use core::cell::Cell;
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::hil;
 use kernel::hil::screen::{ScreenPixelFormat, ScreenRotation};
 use kernel::processbuffer::ReadableProcessBuffer;
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::utilities::leasable_buffer::SubSliceMut;
+use kernel::{hil, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Screen as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Screen as usize);
 
 /// Ids for read-only allow buffers
 mod ro_allow {

--- a/capsules/extra/src/screen/screen_shared.rs
+++ b/capsules/extra/src/screen/screen_shared.rs
@@ -27,16 +27,16 @@
 //! entire screen.
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::hil;
 use kernel::processbuffer::ReadableProcessBuffer;
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::utilities::leasable_buffer::SubSliceMut;
+use kernel::{hil, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Screen as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Screen as usize);
 
 /// Ids for read-only allow buffers
 mod ro_allow {

--- a/capsules/extra/src/sdcard.rs
+++ b/capsules/extra/src/sdcard.rs
@@ -78,17 +78,17 @@ use core::cell::Cell;
 use core::cmp;
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::hil;
 use kernel::hil::time::ConvertTicks;
 use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::utilities::leasable_buffer::SubSliceMut;
+use kernel::{hil, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::SdCard as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::SdCard as usize);
 
 /// Ids for read-only allow buffers
 mod ro_allow {

--- a/capsules/extra/src/servo.rs
+++ b/capsules/extra/src/servo.rs
@@ -35,13 +35,13 @@
 //! );
 //! ```
 
-use kernel::hil;
 use kernel::syscall::{CommandReturn, SyscallDriver};
+use kernel::{hil, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Servo as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Servo as usize);
 
 pub struct Servo<'a, const SERVO_COUNT: usize> {
     /// The service capsule servo.

--- a/capsules/extra/src/seven_segment.rs
+++ b/capsules/extra/src/seven_segment.rs
@@ -154,12 +154,12 @@ use kernel::hil::gpio::{ActivationMode, Pin};
 use kernel::hil::time::{Alarm, AlarmClient, ConvertTicks};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::TakeCell;
-use kernel::ErrorCode;
 use kernel::ProcessId;
+use kernel::{DriverNumber, ErrorCode};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::SevenSegment as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::SevenSegment as usize);
 
 /// Digit patterns
 //

--- a/capsules/extra/src/sha.rs
+++ b/capsules/extra/src/sha.rs
@@ -31,7 +31,7 @@ use capsules_core::driver;
 use kernel::errorcode::into_statuscode;
 
 /// Syscall driver number.
-pub const DRIVER_NUM: usize = driver::NUM::Sha as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Sha as usize);
 
 /// Ids for read-only allow buffers
 mod ro_allow {
@@ -57,7 +57,7 @@ use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::utilities::leasable_buffer::SubSlice;
 use kernel::utilities::leasable_buffer::SubSliceMut;
-use kernel::{ErrorCode, ProcessId};
+use kernel::{DriverNumber, ErrorCode, ProcessId};
 
 enum ShaOperation {
     Sha256,

--- a/capsules/extra/src/sound_pressure.rs
+++ b/capsules/extra/src/sound_pressure.rs
@@ -58,13 +58,13 @@
 
 use core::cell::Cell;
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::hil;
 use kernel::syscall::{CommandReturn, SyscallDriver};
+use kernel::{hil, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::SoundPressure as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::SoundPressure as usize);
 
 #[derive(Default)]
 pub struct App {

--- a/capsules/extra/src/symmetric_encryption/aes.rs
+++ b/capsules/extra/src/symmetric_encryption/aes.rs
@@ -6,7 +6,7 @@
 
 use capsules_core::driver;
 /// Syscall driver number.
-pub const DRIVER_NUM: usize = driver::NUM::Aes as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Aes as usize);
 
 use core::cell::Cell;
 
@@ -18,7 +18,7 @@ use kernel::hil::symmetric_encryption::{
 use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
-use kernel::{ErrorCode, ProcessId};
+use kernel::{DriverNumber, ErrorCode, ProcessId};
 
 /// Ids for read-only allow buffers
 mod ro_allow {

--- a/capsules/extra/src/temperature.rs
+++ b/capsules/extra/src/temperature.rs
@@ -58,13 +58,13 @@
 use core::cell::Cell;
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::hil;
 use kernel::syscall::{CommandReturn, SyscallDriver};
+use kernel::{hil, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Temperature as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Temperature as usize);
 
 #[derive(Default)]
 pub struct App {

--- a/capsules/extra/src/temperature_rp2040.rs
+++ b/capsules/extra/src/temperature_rp2040.rs
@@ -8,10 +8,11 @@ use core::cell::Cell;
 use kernel::hil::adc;
 use kernel::hil::sensors;
 use kernel::utilities::cells::OptionalCell;
+use kernel::DriverNumber;
 use kernel::ErrorCode;
 
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Temperature as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Temperature as usize);
 
 #[derive(Copy, Clone, PartialEq)]
 pub enum Status {

--- a/capsules/extra/src/temperature_stm.rs
+++ b/capsules/extra/src/temperature_stm.rs
@@ -8,10 +8,11 @@ use core::cell::Cell;
 use kernel::hil::adc;
 use kernel::hil::sensors;
 use kernel::utilities::cells::OptionalCell;
+use kernel::DriverNumber;
 use kernel::ErrorCode;
 
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Temperature as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Temperature as usize);
 
 #[derive(Copy, Clone, PartialEq)]
 pub enum Status {

--- a/capsules/extra/src/text_screen.rs
+++ b/capsules/extra/src/text_screen.rs
@@ -18,15 +18,15 @@
 use core::cmp;
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::hil;
 use kernel::processbuffer::ReadableProcessBuffer;
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::{hil, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::TextScreen as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::TextScreen as usize);
 
 /// Ids for read-only allow buffers
 mod ro_allow {

--- a/capsules/extra/src/touch.rs
+++ b/capsules/extra/src/touch.rs
@@ -19,16 +19,16 @@ use core::cell::Cell;
 use core::mem;
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::hil;
 use kernel::hil::screen::ScreenRotation;
 use kernel::hil::touch::{GestureEvent, TouchClient, TouchEvent, TouchStatus};
 use kernel::processbuffer::WriteableProcessBuffer;
 use kernel::syscall::{CommandReturn, SyscallDriver};
+use kernel::{hil, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Touch as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Touch as usize);
 
 /// Ids for read-write allow buffers
 mod rw_allow {

--- a/capsules/extra/src/tsl2561.rs
+++ b/capsules/extra/src/tsl2561.rs
@@ -24,11 +24,11 @@ use kernel::hil::gpio;
 use kernel::hil::i2c;
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
-use kernel::{ErrorCode, ProcessId};
+use kernel::{DriverNumber, ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::Tsl2561 as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::Tsl2561 as usize);
 
 // Buffer to use for I2C messages
 pub const BUFFER_LENGTH: usize = 4;

--- a/capsules/extra/src/tutorials/encryption_oracle_chkpt2.rs
+++ b/capsules/extra/src/tutorials/encryption_oracle_chkpt2.rs
@@ -5,10 +5,10 @@
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::hil::symmetric_encryption::{AES128Ctr, AES128};
 use kernel::syscall::{CommandReturn, SyscallDriver};
-use kernel::ErrorCode;
 use kernel::ProcessId;
+use kernel::{DriverNumber, ErrorCode};
 
-pub const DRIVER_NUM: usize = 0x99999;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(0x99999);
 
 pub static KEY: &[u8; kernel::hil::symmetric_encryption::AES128_KEY_SIZE] = b"InsecureAESKey12";
 

--- a/capsules/extra/src/tutorials/encryption_oracle_chkpt3.rs
+++ b/capsules/extra/src/tutorials/encryption_oracle_chkpt3.rs
@@ -6,10 +6,10 @@ use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::hil::symmetric_encryption::{AES128Ctr, AES128};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::OptionalCell;
-use kernel::ErrorCode;
 use kernel::ProcessId;
+use kernel::{DriverNumber, ErrorCode};
 
-pub const DRIVER_NUM: usize = 0x99999;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(0x99999);
 
 pub static KEY: &[u8; kernel::hil::symmetric_encryption::AES128_KEY_SIZE] = b"InsecureAESKey12";
 

--- a/capsules/extra/src/tutorials/encryption_oracle_chkpt4.rs
+++ b/capsules/extra/src/tutorials/encryption_oracle_chkpt4.rs
@@ -9,10 +9,10 @@ use kernel::hil::symmetric_encryption::{AES128Ctr, Client, AES128, AES128_BLOCK_
 use kernel::processbuffer::ReadableProcessBuffer;
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
-use kernel::ErrorCode;
 use kernel::ProcessId;
+use kernel::{DriverNumber, ErrorCode};
 
-pub const DRIVER_NUM: usize = 0x99999;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(0x99999);
 
 pub static KEY: &[u8; kernel::hil::symmetric_encryption::AES128_KEY_SIZE] = b"InsecureAESKey12";
 

--- a/capsules/extra/src/tutorials/encryption_oracle_chkpt5.rs
+++ b/capsules/extra/src/tutorials/encryption_oracle_chkpt5.rs
@@ -9,10 +9,10 @@ use kernel::hil::symmetric_encryption::{AES128Ctr, Client, AES128, AES128_BLOCK_
 use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
-use kernel::ErrorCode;
 use kernel::ProcessId;
+use kernel::{DriverNumber, ErrorCode};
 
-pub const DRIVER_NUM: usize = 0x99999;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(0x99999);
 
 pub static KEY: &[u8; kernel::hil::symmetric_encryption::AES128_KEY_SIZE] = b"InsecureAESKey12";
 

--- a/capsules/extra/src/usb/cdc.rs
+++ b/capsules/extra/src/usb/cdc.rs
@@ -233,14 +233,14 @@ impl<'a, U: hil::usb::UsbController<'a>, A: 'a + Alarm<'a>> CdcAcm<'a, U, A> {
 
         let endpoints: &[&[EndpointDescriptor]] = &[
             &[EndpointDescriptor {
-                endpoint_address: EndpointAddress::new_const(4, TransferDirection::DeviceToHost),
+                endpoint_address: EndpointAddress::from_const(4, TransferDirection::DeviceToHost),
                 transfer_type: TransferType::Interrupt,
                 max_packet_size: 8,
                 interval: 16,
             }],
             &[
                 EndpointDescriptor {
-                    endpoint_address: EndpointAddress::new_const(
+                    endpoint_address: EndpointAddress::from_const(
                         2,
                         TransferDirection::DeviceToHost,
                     ),
@@ -249,7 +249,7 @@ impl<'a, U: hil::usb::UsbController<'a>, A: 'a + Alarm<'a>> CdcAcm<'a, U, A> {
                     interval: 0,
                 },
                 EndpointDescriptor {
-                    endpoint_address: EndpointAddress::new_const(
+                    endpoint_address: EndpointAddress::from_const(
                         3,
                         TransferDirection::HostToDevice,
                     ),

--- a/capsules/extra/src/usb/ctap.rs
+++ b/capsules/extra/src/usb/ctap.rs
@@ -115,7 +115,7 @@ impl<'a, U: hil::usb::UsbController<'a>> CtapHid<'a, U> {
 
         let endpoints: &[&[EndpointDescriptor]] = &[&[
             EndpointDescriptor {
-                endpoint_address: EndpointAddress::new_const(
+                endpoint_address: EndpointAddress::from_const(
                     ENDPOINT_NUM,
                     TransferDirection::DeviceToHost,
                 ),
@@ -124,7 +124,7 @@ impl<'a, U: hil::usb::UsbController<'a>> CtapHid<'a, U> {
                 interval: 5,
             },
             EndpointDescriptor {
-                endpoint_address: EndpointAddress::new_const(
+                endpoint_address: EndpointAddress::from_const(
                     ENDPOINT_NUM,
                     TransferDirection::HostToDevice,
                 ),

--- a/capsules/extra/src/usb/descriptors.rs
+++ b/capsules/extra/src/usb/descriptors.rs
@@ -676,7 +676,7 @@ impl EndpointAddress {
     // TODO: Until https://github.com/rust-lang/rust/issues/49146 is resolved, we cannot use `match`
     // in const functions. As we need to initialize static endpoint addresses for the USB client
     // capsule, this function offers a workaround to have a const constructor.
-    pub const fn new_const(endpoint: usize, direction: TransferDirection) -> Self {
+    pub const fn from_const(endpoint: usize, direction: TransferDirection) -> Self {
         EndpointAddress(endpoint as u8 & 0xf | (direction as u8) << 7)
     }
 }

--- a/capsules/extra/src/usb/keyboard_hid.rs
+++ b/capsules/extra/src/usb/keyboard_hid.rs
@@ -122,7 +122,7 @@ impl<'a, U: hil::usb::UsbController<'a>> KeyboardHid<'a, U> {
         }];
 
         let endpoints: &[&[EndpointDescriptor]] = &[&[EndpointDescriptor {
-            endpoint_address: EndpointAddress::new_const(
+            endpoint_address: EndpointAddress::from_const(
                 ENDPOINT_NUM,
                 TransferDirection::DeviceToHost,
             ),

--- a/capsules/extra/src/usb/usb_user.rs
+++ b/capsules/extra/src/usb/usb_user.rs
@@ -31,13 +31,13 @@
 //! ```
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::hil;
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::OptionalCell;
+use kernel::{hil, DriverNumber};
 use kernel::{ErrorCode, ProcessId};
 
 use capsules_core::driver;
-pub const DRIVER_NUM: usize = driver::NUM::UsbUser as usize;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(driver::NUM::UsbUser as usize);
 
 #[derive(Default)]
 pub struct App {

--- a/capsules/extra/src/usb/usbc_client.rs
+++ b/capsules/extra/src/usb/usbc_client.rs
@@ -68,13 +68,13 @@ impl<'a, C: hil::usb::UsbController<'a>> Client<'a, C> {
 
         let endpoints: &[&[EndpointDescriptor]] = &mut [&[
             EndpointDescriptor {
-                endpoint_address: EndpointAddress::new_const(1, TransferDirection::DeviceToHost),
+                endpoint_address: EndpointAddress::from_const(1, TransferDirection::DeviceToHost),
                 transfer_type: TransferType::Bulk,
                 max_packet_size: 8,
                 interval: 0,
             },
             EndpointDescriptor {
-                endpoint_address: EndpointAddress::new_const(2, TransferDirection::HostToDevice),
+                endpoint_address: EndpointAddress::from_const(2, TransferDirection::HostToDevice),
                 transfer_type: TransferType::Bulk,
                 max_packet_size: 8,
                 interval: 0,

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -13,11 +13,11 @@ use crate::kernel::Kernel;
 use crate::process;
 use crate::process::ProcessId;
 use crate::processbuffer::ReadableProcessBuffer;
-use crate::syscall_driver::{CommandReturn, SyscallDriver};
+use crate::syscall_driver::{CommandReturn, DriverNumber, SyscallDriver};
 use crate::ErrorCode;
 
 /// Syscall number
-pub const DRIVER_NUM: usize = 0x10000;
+pub const DRIVER_NUM: DriverNumber = DriverNumber::from_const(0x10000);
 
 /// Ids for read-only allow buffers
 mod ro_allow {
@@ -55,7 +55,7 @@ pub struct IPC<const NUM_PROCS: u8> {
 impl<const NUM_PROCS: u8> IPC<NUM_PROCS> {
     pub fn new(
         kernel: &'static Kernel,
-        driver_num: usize,
+        driver_num: DriverNumber,
         capability: &dyn MemoryAllocationCapability,
     ) -> Self {
         Self {

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -33,6 +33,7 @@ use crate::syscall::SyscallDriver;
 use crate::syscall::{ContextSwitchReason, SyscallReturn};
 use crate::syscall::{Syscall, YieldCall};
 use crate::syscall_driver::CommandReturn;
+use crate::syscall_driver::DriverNumber;
 use crate::upcall::{Upcall, UpcallId};
 use crate::utilities::cells::NumericCellExt;
 
@@ -250,7 +251,7 @@ impl Kernel {
         AllowRWs: AllowRwSize,
     >(
         &'static self,
-        driver_num: usize,
+        driver_num: DriverNumber,
         _capability: &dyn capabilities::MemoryAllocationCapability,
     ) -> Grant<T, Upcalls, AllowROs, AllowRWs> {
         if self.grants_finalized.get() {
@@ -853,7 +854,7 @@ impl Kernel {
 
                     Ok(YieldCall::WaitFor) => {
                         let upcall_id = UpcallId {
-                            driver_num: param_a,
+                            driver_num: param_a.into(),
                             subscribe_num: param_b,
                         };
                         process.set_yielded_for_state(upcall_id);
@@ -997,11 +998,11 @@ impl Kernel {
                                                             alloc_failure,
                                                         ) {
                                                             (true, AllocResult::NoAllocation) => {
-                                                                debug!("[{:?}] WARN driver #{:x} did not allocate grant",
+                                                                debug!("[{:?}] WARN driver #{} did not allocate grant",
                                                                            process.processid(), driver_number);
                                                             }
                                                             (true, AllocResult::SameAllocation) => {
-                                                                debug!("[{:?}] ERROR driver #{:x} allocated wrong grant counts",
+                                                                debug!("[{:?}] ERROR driver #{} allocated wrong grant counts",
                                                                            process.processid(), driver_number);
                                                             }
                                                             _ => {}
@@ -1033,7 +1034,7 @@ impl Kernel {
 
                         if config::CONFIG.trace_syscalls {
                             debug!(
-                                "[{:?}] subscribe({:#x}, {}, @{:#x}, {:#x}) = {:?}",
+                                "[{:?}] subscribe({}, {}, @{:#x}, {:#x}) = {:?}",
                                 process.processid(),
                                 driver_number,
                                 subdriver_number,
@@ -1060,7 +1061,7 @@ impl Kernel {
 
                         if config::CONFIG.trace_syscalls {
                             debug!(
-                                "[{:?}] cmd({:#x}, {}, {:#x}, {:#x}) = {:?}",
+                                "[{:?}] cmd({}, {}, {:#x}, {:#x}) = {:?}",
                                 process.processid(),
                                 driver_number,
                                 subdriver_number,
@@ -1141,11 +1142,11 @@ impl Kernel {
                                                             alloc_failure,
                                                         ) {
                                                             (true, AllocResult::NoAllocation) => {
-                                                                debug!("[{:?}] WARN driver #{:x} did not allocate grant",
+                                                                debug!("[{:?}] WARN driver #{} did not allocate grant",
                                                                            process.processid(), driver_number);
                                                             }
                                                             (true, AllocResult::SameAllocation) => {
-                                                                debug!("[{:?}] ERROR driver #{:x} allocated wrong grant counts",
+                                                                debug!("[{:?}] ERROR driver #{} allocated wrong grant counts",
                                                                            process.processid(), driver_number);
                                                             }
                                                             _ => {}
@@ -1185,7 +1186,7 @@ impl Kernel {
 
                         if config::CONFIG.trace_syscalls {
                             debug!(
-                                "[{:?}] read-write allow({:#x}, {}, @{:#x}, {}) = {:?}",
+                                "[{:?}] read-write allow({}, {}, @{:#x}, {}) = {:?}",
                                 process.processid(),
                                 driver_number,
                                 subdriver_number,
@@ -1265,7 +1266,7 @@ impl Kernel {
 
                         if config::CONFIG.trace_syscalls {
                             debug!(
-                                "[{:?}] userspace readable allow({:#x}, {}, @{:#x}, {}) = {:?}",
+                                "[{:?}] userspace readable allow({}, {}, @{:#x}, {}) = {:?}",
                                 process.processid(),
                                 driver_number,
                                 subdriver_number,
@@ -1346,11 +1347,11 @@ impl Kernel {
                                                             alloc_failure,
                                                         ) {
                                                             (true, AllocResult::NoAllocation) => {
-                                                                debug!("[{:?}] WARN driver #{:x} did not allocate grant",
+                                                                debug!("[{:?}] WARN driver #{} did not allocate grant",
                                                                            process.processid(), driver_number);
                                                             }
                                                             (true, AllocResult::SameAllocation) => {
-                                                                debug!("[{:?}] ERROR driver #{:x} allocated wrong grant counts",
+                                                                debug!("[{:?}] ERROR driver #{} allocated wrong grant counts",
                                                                            process.processid(), driver_number);
                                                             }
                                                             _ => {}
@@ -1390,7 +1391,7 @@ impl Kernel {
 
                         if config::CONFIG.trace_syscalls {
                             debug!(
-                                "[{:?}] read-only allow({:#x}, {}, @{:#x}, {}) = {:?}",
+                                "[{:?}] read-only allow({}, {}, @{:#x}, {}) = {:?}",
                                 process.processid(),
                                 driver_number,
                                 subdriver_number,

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -192,3 +192,4 @@ pub use crate::errorcode::ErrorCode;
 pub use crate::kernel::Kernel;
 pub use crate::process::ProcessId;
 pub use crate::scheduler::Scheduler;
+pub use crate::syscall_driver::DriverNumber;

--- a/kernel/src/platform/platform.rs
+++ b/kernel/src/platform/platform.rs
@@ -11,6 +11,7 @@ use crate::platform::watchdog;
 use crate::process;
 use crate::scheduler::Scheduler;
 use crate::syscall;
+use crate::syscall_driver::DriverNumber;
 use crate::syscall_driver::SyscallDriver;
 
 /// Combination trait that boards provide to the kernel that includes all of
@@ -90,7 +91,7 @@ pub trait KernelResources<C: Chip> {
 /// }
 ///
 /// impl SyscallDriverLookup for Hail {
-///     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+///     fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
 ///     where
 ///         F: FnOnce(Option<&dyn kernel::SyscallDriver>) -> R,
 ///     {
@@ -110,7 +111,7 @@ pub trait SyscallDriverLookup {
     ///
     ///
     /// An implementation
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, driver_num: DriverNumber, f: F) -> R
     where
         F: FnOnce(Option<&dyn SyscallDriver>) -> R;
 }

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -18,6 +18,7 @@ use crate::platform::mpu::{self};
 use crate::processbuffer::{ReadOnlyProcessBuffer, ReadWriteProcessBuffer};
 use crate::storage_permissions;
 use crate::syscall::{self, Syscall, SyscallReturn};
+use crate::syscall_driver::DriverNumber;
 use crate::upcall::UpcallId;
 use crate::utilities::capability_ptr::CapabilityPtr;
 use crate::utilities::machine_register::MachineRegister;
@@ -660,7 +661,11 @@ pub trait Process {
     /// they are returned as a 64 bit bitmask for sequential command numbers.
     /// The offset indicates the multiple of 64 command numbers to get
     /// permissions for.
-    fn get_command_permissions(&self, driver_num: usize, offset: usize) -> CommandPermissions;
+    fn get_command_permissions(
+        &self,
+        driver_num: DriverNumber,
+        offset: usize,
+    ) -> CommandPermissions;
 
     /// Get the storage permissions for the process.
     ///
@@ -714,7 +719,7 @@ pub trait Process {
     fn allocate_grant(
         &self,
         grant_num: usize,
-        driver_num: usize,
+        driver_num: DriverNumber,
         size: usize,
         align: usize,
     ) -> Result<(), ()>;
@@ -789,7 +794,7 @@ pub trait Process {
 
     /// Get the grant number (grant_num) associated with a given driver number
     /// if there is a grant associated with that driver_num.
-    fn lookup_grant_from_driver_num(&self, driver_num: usize) -> Result<usize, Error>;
+    fn lookup_grant_from_driver_num(&self, driver_num: DriverNumber) -> Result<usize, Error>;
 
     // subscribe
 

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -68,10 +68,10 @@
 
 use core::fmt::Write;
 
-use crate::errorcode::ErrorCode;
 use crate::process;
 use crate::utilities::capability_ptr::CapabilityPtr;
 use crate::utilities::machine_register::MachineRegister;
+use crate::{errorcode::ErrorCode, syscall_driver::DriverNumber};
 
 pub use crate::syscall_driver::{CommandReturn, SyscallDriver};
 
@@ -153,7 +153,7 @@ pub enum Syscall {
     /// Structure representing an invocation of the Subscribe system call class.
     Subscribe {
         /// The driver identifier.
-        driver_number: usize,
+        driver_number: DriverNumber,
         /// The subscribe identifier.
         subdriver_number: usize,
         /// Upcall pointer to the upcall function.
@@ -165,7 +165,7 @@ pub enum Syscall {
     /// Structure representing an invocation of the Command system call class.
     Command {
         /// The driver identifier.
-        driver_number: usize,
+        driver_number: DriverNumber,
         /// The command identifier.
         subdriver_number: usize,
         /// Value passed to the `Command` implementation.
@@ -178,7 +178,7 @@ pub enum Syscall {
     /// class.
     ReadWriteAllow {
         /// The driver identifier.
-        driver_number: usize,
+        driver_number: DriverNumber,
         /// The buffer identifier.
         subdriver_number: usize,
         /// The address where the buffer starts.
@@ -191,7 +191,7 @@ pub enum Syscall {
     /// system call class that allows shared kernel and app access.
     UserspaceReadableAllow {
         /// The driver identifier.
-        driver_number: usize,
+        driver_number: DriverNumber,
         /// The buffer identifier.
         subdriver_number: usize,
         /// The address where the buffer starts.
@@ -204,7 +204,7 @@ pub enum Syscall {
     /// class.
     ReadOnlyAllow {
         /// The driver identifier.
-        driver_number: usize,
+        driver_number: DriverNumber,
         /// The buffer identifier.
         subdriver_number: usize,
         /// The address where the buffer starts.
@@ -253,31 +253,31 @@ impl Syscall {
                 param_b: r2.as_usize(),
             }),
             Ok(SyscallClass::Subscribe) => Some(Syscall::Subscribe {
-                driver_number: r0,
+                driver_number: r0.into(),
                 subdriver_number: r1.as_usize(),
                 upcall_ptr: r2.as_capability_ptr(),
                 appdata: r3,
             }),
             Ok(SyscallClass::Command) => Some(Syscall::Command {
-                driver_number: r0,
+                driver_number: r0.into(),
                 subdriver_number: r1.as_usize(),
                 arg0: r2.as_usize(),
                 arg1: r3.as_usize(),
             }),
             Ok(SyscallClass::ReadWriteAllow) => Some(Syscall::ReadWriteAllow {
-                driver_number: r0,
+                driver_number: r0.into(),
                 subdriver_number: r1.as_usize(),
                 allow_address: r2.as_capability_ptr().as_ptr::<u8>().cast_mut(),
                 allow_size: r3.as_usize(),
             }),
             Ok(SyscallClass::UserspaceReadableAllow) => Some(Syscall::UserspaceReadableAllow {
-                driver_number: r0,
+                driver_number: r0.into(),
                 subdriver_number: r1.as_usize(),
                 allow_address: r2.as_capability_ptr().as_ptr::<u8>().cast_mut(),
                 allow_size: r3.as_usize(),
             }),
             Ok(SyscallClass::ReadOnlyAllow) => Some(Syscall::ReadOnlyAllow {
-                driver_number: r0,
+                driver_number: r0.into(),
                 subdriver_number: r1.as_usize(),
                 allow_address: r2.as_capability_ptr().as_ptr(),
                 allow_size: r3.as_usize(),
@@ -295,7 +295,7 @@ impl Syscall {
     }
 
     /// Get the `driver_number` for the syscall classes that use driver numbers.
-    pub fn driver_number(&self) -> Option<usize> {
+    pub fn driver_number(&self) -> Option<DriverNumber> {
         match *self {
             Syscall::Subscribe {
                 driver_number,

--- a/kernel/src/syscall_driver.rs
+++ b/kernel/src/syscall_driver.rs
@@ -6,11 +6,47 @@
 //!
 //! Drivers implement these interfaces to expose operations to processes.
 
+use core::fmt::{Debug, Display};
+
 use crate::errorcode::ErrorCode;
 use crate::process;
 use crate::process::ProcessId;
 use crate::processbuffer::UserspaceReadableProcessBuffer;
 use crate::syscall::SyscallReturn;
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct DriverNumber(usize);
+
+impl DriverNumber {
+    pub const fn from_const(driver_num: usize) -> DriverNumber {
+        DriverNumber(driver_num)
+    }
+}
+
+impl From<DriverNumber> for usize {
+    fn from(driver_num: DriverNumber) -> Self {
+        driver_num.0
+    }
+}
+
+impl From<usize> for DriverNumber {
+    fn from(driver_num: usize) -> Self {
+        DriverNumber(driver_num)
+    }
+}
+
+impl Debug for DriverNumber {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:#x}", self.0)
+    }
+}
+
+impl Display for DriverNumber {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:#x}", self.0)
+    }
+}
 
 /// Possible return values of a `command` driver method, as specified in TRD104.
 ///

--- a/kernel/src/upcall.rs
+++ b/kernel/src/upcall.rs
@@ -9,9 +9,11 @@ use crate::debug;
 use crate::process;
 use crate::process::ProcessId;
 use crate::syscall::SyscallReturn;
+use crate::syscall_driver::DriverNumber;
 use crate::utilities::capability_ptr::CapabilityPtr;
 use crate::utilities::machine_register::MachineRegister;
 use crate::ErrorCode;
+use core::fmt::Debug;
 
 /// Type to uniquely identify an upcall subscription across all drivers.
 ///
@@ -20,7 +22,7 @@ use crate::ErrorCode;
 pub struct UpcallId {
     /// The [`SyscallDriver`](crate::syscall_driver::SyscallDriver)
     /// implementation this upcall corresponds to.
-    pub driver_num: usize,
+    pub driver_num: DriverNumber,
     /// The subscription index the upcall corresponds to. Subscribe numbers
     /// start at 0 and increment for each upcall defined for a particular
     /// [`SyscallDriver`](crate::syscall_driver::SyscallDriver).
@@ -173,7 +175,7 @@ impl Upcall {
 
         if config::CONFIG.trace_syscalls {
             debug!(
-                "[{:?}] schedule[{:#x}:{}] @{:#x}({:#x}, {:#x}, {:#x}, {:#x}) = {:?}",
+                "[{:?}] schedule[{}:{}] @{:#x}({:#x}, {:#x}, {:#x}, {:#x}) = {:?}",
                 self.process_id,
                 self.upcall_id.driver_num,
                 self.upcall_id.subscribe_num,

--- a/kernel/src/utilities/single_thread_value.rs
+++ b/kernel/src/utilities/single_thread_value.rs
@@ -78,7 +78,7 @@ enum BoundToThreadStage {
 ///
 /// ```
 /// use core::cell::Cell;
-/// use kernel::utilities::single_thread_value::SingleThreadValue;
+/// use kernel::utilities::single_thread_value::SingleThreadValue; use kernel::DriverNumber;
 ///
 /// // Binding to a thread requires a "ThreadIdProvider", used to query the
 /// // thread ID of the currently running thread at runtime:


### PR DESCRIPTION
### Pull Request Overview

This pull request adds the `DriverNumber` type. This is a transparent wrapper for `usize`.

The reasoning behind this change is the inconsistent way in which driver numbers were printed in debug messages. While driver numbers were printed as hex (`{:#x}` in system call traces, driver numbers were printed as a decimal when writing the process state `YieldedFor{....}`. The inconsistency comes due to the fact that process state printing uses the automatically derived `Debug` trait of `UpcallId` which prints `usize` values in decimal. 

The first approach to fix this was to write a custom implementation of `Debug` for `UpcallId` like the one below:

```rust
impl Debug for UpcallId {
    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
        f.debug_struct("UpcallId")
            .field("driver_num", &format_args!("{:#x}", &self.driver_num))
            .field("subscribe_num", &self.subscribe_num)
            .finish()
    }
}
```

While this is a simpler fix, it has the drawback that the debug formatting does not automatically update when the `UpcallId` structure is changed.


The approach proposed in this PR, while more complex, has a few advantages:
- makes the driver number an opaque type type that allows future changes to driver number information without impacting the rest of the code
- makes printing of the driver number consistent all over the code
- automatically updates the debug format of `UpcallId` when it changes


The changes should not impact code size.

### Testing Strategy

This pull request was tested by @alexandruradovici.


### TODO or Help Wanted

Feedback


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
