### PR TITLE
cryptography-wg: 12-12-25 Meeting Notes

### DIFF
--- a/doc/wg/cryptography/notes/cryptography-notes-2025-12-12.md
+++ b/doc/wg/cryptography/notes/cryptography-notes-2025-12-12.md
@@ -1,0 +1,11 @@
+# Tock Cryptography WG Meeting Notes
+- **Date:** December 12, 2025
+- **Participants:**
+    - Tyler Potyondy
+    - Amit Levy
+
+## 2026 Planning
+- Amit: I propose we reconvene in 2026. We should make a plan for what we would like to discuss.
+- Amit: Having a few focused topics we spend the first four meetings of the year discussing seems like it would be a good plan. 
+- Tyler: How should we go about discussing these topics?
+- Amit: Asynchronously in the matrix channel seems fine. 


### PR DESCRIPTION
### Pull Request Overview

This pull request adds the cryptography-wg meeting notes from 12-12-25 ([rendered](https://github.com/tyler-potyondy/tock/blob/4df718f21aa8942758f58eb16cbb3f761a91bab5/doc/wg/cryptography/notes/cryptography-notes-2025-12-12.md)).


### Testing Strategy

N/A

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
