### PR TITLE
Implement custom Debug for UpcallId to driver num using hex

### DIFF
--- a/kernel/src/upcall.rs
+++ b/kernel/src/upcall.rs
@@ -12,11 +12,12 @@ use crate::syscall::SyscallReturn;
 use crate::utilities::capability_ptr::CapabilityPtr;
 use crate::utilities::machine_register::MachineRegister;
 use crate::ErrorCode;
+use core::fmt::Debug;
 
 /// Type to uniquely identify an upcall subscription across all drivers.
 ///
 /// This contains the driver number and the subscribe number within the driver.
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 pub struct UpcallId {
     /// The [`SyscallDriver`](crate::syscall_driver::SyscallDriver)
     /// implementation this upcall corresponds to.
@@ -25,6 +26,15 @@ pub struct UpcallId {
     /// start at 0 and increment for each upcall defined for a particular
     /// [`SyscallDriver`](crate::syscall_driver::SyscallDriver).
     pub subscribe_num: usize,
+}
+
+impl Debug for UpcallId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("UpcallId")
+            .field("driver_num", &format_args!("{:#x}", &self.driver_num))
+            .field("subscribe_num", &self.subscribe_num)
+            .finish()
+    }
 }
 
 /// Errors which can occur when scheduling a process Upcall.


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a custom `Debug` formatting implementation for `UpcallId`.

The reasoning behind this change is the inconsistent way in which driver numbers were printed in debug messages. While driver numbers were printed as hex ({:#x} in system call traces, driver numbers were printed as a decimal when writing the process state YieldedFor{....}. The inconsistency comes due to the fact that process state printing uses the automatically derived Debug trait of UpcallId which prints usize values in decimal.

This is an alternative to #4689.

The downside of this approach is that the `Debug` formatting does not automatically change if the `UpcallId` structure is changes, it must be manually changed.

### Testing Strategy

This pull request was tested by @alexandruradovici.


### TODO or Help Wanted

Feedback


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
