### PR TITLE
arch/x86: fix memory initialization routine

### DIFF
--- a/arch/x86/src/start.rs
+++ b/arch/x86/src/start.rs
@@ -11,12 +11,12 @@ pub unsafe extern "C" fn start() {
     naked_asm!(
         "
     # Initialize the stack
-    lea     esp, _estack
-    lea     ebp, _estack
+    lea     esp, [_estack]
+    lea     ebp, [_estack]
 
     # Zero out the .bss section
-    mov     eax, _szero
-    mov     ebx, _ezero
+    lea     eax, [_szero]
+    lea     ebx, [_ezero]
 200:
     cmp     eax, ebx
     je      201f
@@ -26,9 +26,9 @@ pub unsafe extern "C" fn start() {
 201:
 
     # Initialize contents of the .data section
-    mov     eax, _srelocate
-    mov     ebx, _erelocate
-    mov     ecx, _etext
+    lea     eax, [_srelocate]
+    lea     ebx, [_erelocate]
+    lea     ecx, [_etext]
 300:
     cmp     eax, ebx
     je      301f


### PR DESCRIPTION
### Pull Request Overview

Before this change, the assembly routine didn't load the adresses of the memory ranges to initialize, but instead the _contents_ behind those addresses.

These happen to be zero-initialized in QEMU, which means that no `.relocate` data was copied into RAM, and the stack wasn't zeroed. On platforms that don't zero-initialize their memory, the consequence can be much more severe. In any case, this can cause arbitrary undefined behavior.

This explains why using `MapCell` inside `SingleThreadValue` did not work for PR #4696. While the `static DEFCALL` is initialized with a populated `MapCell`, the `MapCellState` was zero-initialized, which made Rust believe that this cell is empty.

By switching to `lea`, we load the symbol addresses instead of their contents, fixing this issue.

[1]: https://github.com/tock/tock/pull/4696


### Testing Strategy

Tested by seeing `debug!` statements, which indicates that the `MapCell` in the `DEFCALLS` static is now properly initialized.


### TODO or Help Wanted

N/A


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
