### PR TITLE
kernel/utilities: add `DmaSlice`, a sound abstraction for DMA to and from Rust slices

### DIFF
--- a/arch/cortex-m/src/dma_fence.rs
+++ b/arch/cortex-m/src/dma_fence.rs
@@ -1,0 +1,80 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+use kernel::platform::dma_fence::DmaFence;
+
+#[derive(Debug, Copy, Clone)]
+pub struct CortexMDmaFence {
+    _private: (),
+}
+
+/// An implementation of [DmaFence] for ARM Cortex-M systems.
+///
+/// The provided `release` and `acquire` methods use opaque assembly
+/// blocks and the THUMB `DMB` instructions to make prior writes to
+/// shared buffers visible to DMA devices, and DMA writes visible
+/// subsequent memory reads, as specified in the ARM Cortex-M
+/// Programming Guide to Memory Barrier Instructions [1].
+///
+/// [1]: https://developer.arm.com/documentation/dai0321/a/
+impl CortexMDmaFence {
+    /// Construct a new [CortexMDmaFence].
+    pub unsafe fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+unsafe impl DmaFence for CortexMDmaFence {
+    fn release<T>(self, buf: *mut [T]) {
+        if cfg!(target_arch = "arm") {
+            unsafe {
+                core::arch::asm!(
+                    "
+                        /*
+                         * This block is opaque to the compiler; the
+                         * compiler must assume that the block could
+                         * read to the entire buffer from which the
+                         * pointer stored in {dma_buffer_ptr_reg} was
+                         * derived.
+                         *
+                         * Do not reorder prior memory reads or writes
+                         * over subsequent I/O reads or writes.
+                         */
+                        dmb
+                    ",
+                    dma_buffer_ptr_reg = in(reg) buf.cast::<T>(),
+                );
+            }
+        } else {
+            // When building for another architecture, such as for tests or CI:
+            unimplemented!("CortexMDmaFence can only be used on cortex-m targets");
+        }
+    }
+
+    fn acquire<T>(self, buf: *mut [T]) {
+        if cfg!(target_arch = "arm") {
+            unsafe {
+                core::arch::asm!(
+                    "
+                        /*
+                         * This block is opaque to the compiler; the
+                         * compiler must assume that the block could
+                         * write to the entire buffer from which the
+                         * pointer stored in {dma_buffer_ptr_reg} was
+                         * derived.
+                         *
+                         * Do not reorder prior I/O reads or writes
+                         * over subsequent memory reads or writes.
+                         */
+                        dmb
+                    ",
+                    dma_buffer_ptr_reg = in(reg) buf.cast::<T>(),
+                );
+            }
+        } else {
+            // When building for another architecture, such as for tests or CI:
+            unimplemented!("CortexMDmaFence can only be used on cortex-m targets");
+        }
+    }
+}

--- a/arch/cortex-m/src/dma_fence.rs
+++ b/arch/cortex-m/src/dma_fence.rs
@@ -29,7 +29,8 @@ impl CortexMDmaFence {
 
 #[cfg(all(target_arch = "arm", target_os = "none"))]
 unsafe impl DmaFence for CortexMDmaFence {
-    fn release<T>(self, buf: *mut [T]) {
+    fn release<T>(self, slice_ptr: *mut [T]) {
+        let slice_start_ptr: *mut T = slice_ptr.cast();
         unsafe {
             core::arch::asm!(
                 "
@@ -41,12 +42,13 @@ unsafe impl DmaFence for CortexMDmaFence {
     // I/O reads or writes.
     dmb
                 ",
-                dma_buffer_ptr_reg = in(reg) buf.cast::<T>(),
+                dma_buffer_ptr_reg = in(reg) slice_start_ptr,
             );
         }
     }
 
-    fn acquire<T>(self, buf: *mut [T]) {
+    fn acquire<T>(self, slice_ptr: *mut [T]) {
+        let slice_start_ptr: *mut T = slice_ptr.cast();
         unsafe {
             core::arch::asm!(
                 "
@@ -58,7 +60,7 @@ unsafe impl DmaFence for CortexMDmaFence {
     // memory reads or writes.
     dmb
                 ",
-                dma_buffer_ptr_reg = in(reg) buf.cast::<T>(),
+                dma_buffer_ptr_reg = in(reg) slice_start_ptr,
             );
         }
     }

--- a/arch/cortex-m/src/dma_fence.rs
+++ b/arch/cortex-m/src/dma_fence.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2026.
 
+//! Cortex-M synchronization implementation for Rust when using DMA.
+
 use kernel::platform::dma_fence::DmaFence;
 
 #[derive(Debug, Copy, Clone)]
@@ -25,56 +27,52 @@ impl CortexMDmaFence {
     }
 }
 
+#[cfg(all(target_arch = "arm", target_os = "none"))]
 unsafe impl DmaFence for CortexMDmaFence {
     fn release<T>(self, buf: *mut [T]) {
-        if cfg!(target_arch = "arm") {
-            unsafe {
-                core::arch::asm!(
-                    "
-                        /*
-                         * This block is opaque to the compiler; the
-                         * compiler must assume that the block could
-                         * read to the entire buffer from which the
-                         * pointer stored in {dma_buffer_ptr_reg} was
-                         * derived.
-                         *
-                         * Do not reorder prior memory reads or writes
-                         * over subsequent I/O reads or writes.
-                         */
-                        dmb
-                    ",
-                    dma_buffer_ptr_reg = in(reg) buf.cast::<T>(),
-                );
-            }
-        } else {
-            // When building for another architecture, such as for tests or CI:
-            unimplemented!("CortexMDmaFence can only be used on cortex-m targets");
+        unsafe {
+            core::arch::asm!(
+                "
+    // This block is opaque to the compiler; the compiler must assume
+    // that the block could read to the entire buffer from which the
+    // pointer stored in {dma_buffer_ptr_reg} was derived.
+    //
+    // Do not reorder prior memory reads or writes over subsequent
+    // I/O reads or writes.
+    dmb
+                ",
+                dma_buffer_ptr_reg = in(reg) buf.cast::<T>(),
+            );
         }
     }
 
     fn acquire<T>(self, buf: *mut [T]) {
-        if cfg!(target_arch = "arm") {
-            unsafe {
-                core::arch::asm!(
-                    "
-                        /*
-                         * This block is opaque to the compiler; the
-                         * compiler must assume that the block could
-                         * write to the entire buffer from which the
-                         * pointer stored in {dma_buffer_ptr_reg} was
-                         * derived.
-                         *
-                         * Do not reorder prior I/O reads or writes
-                         * over subsequent memory reads or writes.
-                         */
-                        dmb
-                    ",
-                    dma_buffer_ptr_reg = in(reg) buf.cast::<T>(),
-                );
-            }
-        } else {
-            // When building for another architecture, such as for tests or CI:
-            unimplemented!("CortexMDmaFence can only be used on cortex-m targets");
+        unsafe {
+            core::arch::asm!(
+                "
+    // This block is opaque to the compiler; the compiler must assume
+    // that the block could write to the entire buffer from which the
+    // pointer stored in {dma_buffer_ptr_reg} was derived.
+    //
+    // Do not reorder prior I/O reads or writes over subsequent
+    // memory reads or writes.
+    dmb
+                ",
+                dma_buffer_ptr_reg = in(reg) buf.cast::<T>(),
+            );
         }
+    }
+}
+
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
+unsafe impl DmaFence for CortexMDmaFence {
+    fn release<T>(self, _buf: *mut [T]) {
+        // When building for another architecture, such as for tests or CI:
+        unimplemented!("CortexMDmaFence can only be used on cortex-m targets");
+    }
+
+    fn acquire<T>(self, _buf: *mut [T]) {
+        // When building for another architecture, such as for tests or CI:
+        unimplemented!("CortexMDmaFence can only be used on cortex-m targets");
     }
 }

--- a/arch/cortex-m/src/dma_fence.rs
+++ b/arch/cortex-m/src/dma_fence.rs
@@ -22,6 +22,13 @@ pub struct CortexMDmaFence {
 /// [1]: https://developer.arm.com/documentation/dai0321/a/
 impl CortexMDmaFence {
     /// Construct a new [CortexMDmaFence].
+    ///
+    /// # Safety
+    ///
+    /// Users of this function guarantee that this fence is an appropriate
+    /// implementation of [`DmaFence`] for the platform on which this code is
+    /// running. In practice, this means that users must assert to be running on
+    /// an ARM Cortex-M (ARM-v6m / ARM-v7m) CPU.
     pub unsafe fn new() -> Self {
         Self { _private: () }
     }

--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -9,6 +9,7 @@
 use core::fmt::Write;
 
 pub mod dcb;
+pub mod dma_fence;
 pub mod dwt;
 pub mod mpu;
 pub mod nvic;

--- a/arch/cortex-m4f/src/lib.rs
+++ b/arch/cortex-m4f/src/lib.rs
@@ -21,6 +21,7 @@ pub mod mpu {
     }
 }
 
+pub use cortexm::dma_fence;
 pub use cortexm::dwt;
 pub use cortexm::initialize_ram_jump_to_main;
 pub use cortexm::nvic;

--- a/arch/riscv/src/dma_fence.rs
+++ b/arch/riscv/src/dma_fence.rs
@@ -1,0 +1,164 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Leon Schuermann <leon@is.currently.online> 2026.
+// Copyright Tock Contributors 2026.
+
+use kernel::platform::dma_fence::DmaFence;
+
+/// An implementation of [`DmaFence`] for RISC-V systems with cache-coherent DMA
+/// memory accesses.
+///
+/// The provided `release` and `acquire` methods use opaque assembly blocks and
+/// RISC-V `FENCE` instructions to make prior writes to DMA buffers visible to
+/// DMA devices, and DMA writes visible to prior memory reads, respectively.
+///
+/// These primitives are sufficient to implement the `release` / `acquire`
+/// semantics of [`DmaFence`] for cache-coherent platforms where all memory
+/// writes written back are immediately visible to DMA devices, and all DMA
+/// writes are immediately visible to CPU fetches.
+///
+/// For platforms where explicit cache-flush instructions are required, this
+/// implementation alone is insufficient and must be extended with the necessary
+/// platform-specific instructions.
+#[derive(Debug, Copy, Clone)]
+pub struct RiscvCoherentDmaFence {
+    _private: (),
+}
+
+impl RiscvCoherentDmaFence {
+    /// Construct a new [`RiscvCoherentDmaFence`].
+    ///
+    /// Refer to the [type-level documentation](Self) and the documentation of
+    /// the [`DmaFence` trait](DmaFence) and [its implementation for
+    /// `RiscvCoherentDmaFence`](<RiscvCoherentDmaFence as DmaFence>) for more
+    /// details.
+    ///
+    /// # Safety
+    ///
+    /// This [`RiscvCoherentDmaFence`] implementation is insufficient for
+    /// platforms with non-coherent DMA, where explicit cache-flush instructions
+    /// are required. By using `unsafe`, callers of this function promise that
+    /// the resulting instance is not used for non-coherent DMA mappings.
+    pub unsafe fn new() -> Self {
+        RiscvCoherentDmaFence { _private: () }
+    }
+}
+
+unsafe impl DmaFence for RiscvCoherentDmaFence {
+    /// Expose prior writes to in-memory buffers to subsequent DMA operations.
+    ///
+    /// This assembly block ensures that neither the compiler, not the CPU
+    /// reorder any memory writes beyond the point at which a subsequent memory
+    /// or I/O access is made (e.g., to start a DMA transaction).
+    ///
+    /// Conventionally, we'd use the built-in `core::sync::atomic::fence` for
+    /// this, but that explicitly cannot be used to establish synchronization
+    /// among non-atomic accesses.
+    ///
+    /// Instead, to deal with any potential compiler re-ordering, we use an
+    /// `asm!()` that does **not** have the `nomem` clobber set. This block is
+    /// opaque to the compiler. We further explicitly pass in a pointer
+    /// originating from, and thus carrying provenance of our DMA buffer. This
+    /// should be sufficient to make the compiler assume that this function may
+    /// read the entire DMA buffer, and thus cause it to commit all pending
+    /// writes before this `asm!()` block.
+    ///
+    /// To deal with any hardware re-ordering, use manually issue RISC-V fence
+    /// instruction with a predecessor set including all memory writes (to make
+    /// the buffer contents visible to hardware), and a successor set of all
+    /// memory reads and memory writes, and I/O reads or writes. Then, all
+    /// updates to the buffer are guaranteed to be written out to memory before
+    /// starting a DMA operation by reading or writing an MMIO register. We
+    /// include memory reads or writes in the successor set too, in case the
+    /// memory containing the MMIO registers is incorrectly not mapped as I/O
+    /// memory.
+    ///
+    /// This is only sufficient for platforms or devices with coherent DMA. As
+    /// per the RISC-V unprivileged spec (version 20250508), "\[n\]on-coherent
+    /// DMA may need additional synchronization (such as cache flush or
+    /// invalidate mechanisms); currently any such extra synchronization will be
+    /// device-specific" [1].
+    ///
+    /// [1]: https://docs.riscv.org/reference/isa/_attachments/riscv-unprivileged.pdf
+    #[inline(always)]
+    fn release<T>(self, buf: *mut [T]) {
+        if cfg!(any(target_arch = "riscv32", target_arch = "riscv64")) {
+            unsafe {
+                core::arch::asm!(
+                    "
+                        // This block is opaque to the compiler; it must assume
+                        // that it could read the entire buffer from which the
+                        // pointer stored in {dma_buffer_ptr_reg} was derived.
+
+                        // Do not reorder prior memory writes over subsequent
+                        // I/O or memory reads or writes; see above Rust source
+                        // comment for explanation.
+                        fence w, iorw
+                    ",
+                    dma_buffer_ptr_reg = in(reg) buf as *mut T,
+                );
+            }
+        } else {
+            // When building for another architecture, such as for tests or CI:
+            unimplemented!("RiscvCoherentDmaFence can only be used on RISC-V targets");
+        }
+    }
+
+    /// Expose prior writes by DMA peripherals to subsequent memory reads.
+    ///
+    /// This assembly block ensures that neither the compiler, not the CPU
+    /// reorder any memory reads before the point at which a subsequent
+    /// memory or I/O access is made (e.g., to start a DMA transaction).
+    ///
+    /// Conventionally, we'd use the built-in `core::sync::atomic::fence` for
+    /// this, but that explicitly cannot be used to establish synchronization
+    /// among non-atomic accesses.
+    ///
+    /// Instead, to deal with any potential compiler re-ordering, we use an
+    /// `asm!()` that does **not** have the `nomem` clobber set. This block
+    /// is opaque to the compiler. We further explicitly pass in a pointer
+    /// originating from, and thus carrying provenance of our DMA
+    /// buffer. This should be sufficient to make the compiler assume that
+    /// this function may write to the entire DMA buffer, and thus prevent it
+    /// from moving reads to before this `asm!()` block.
+    ///
+    /// To deal with any hardware re-ordering, use manually issue RISC-V
+    /// fence instruction with a predecessor set including all memory reads
+    /// and I/O reads (to ensure that the DMA data is only read _after_ a
+    /// prior status register or in-memory descriptor indicates that the DMA
+    /// data is ready, and a successor set of all memory reads. This prevents
+    /// the CPU from issuing read instructions to the DMA buffer _before_ a
+    /// prior read confirmed that the data was ready.
+    ///
+    /// This is only sufficient for platforms or devices with coherent DMA. As
+    /// per the RISC-V unprivileged spec (version 20250508), "\[n\]on-coherent
+    /// DMA may need additional synchronization (such as cache flush or
+    /// invalidate mechanisms); currently any such extra synchronization will be
+    /// device-specific" [1].
+    ///
+    /// [1]: https://docs.riscv.org/reference/isa/_attachments/riscv-unprivileged.pdf
+    #[inline(always)]
+    fn acquire<T>(self, buf: *mut [T]) {
+        if cfg!(any(target_arch = "riscv32", target_arch = "riscv64")) {
+            unsafe {
+                core::arch::asm!(
+                    "
+                        // This block is opaque to the compiler; it must assume
+                        // that it could write to the entire buffer from which
+                        // the pointer stored in {dma_buffer_ptr_reg} was
+                        // derived.
+
+                        // Do not reorder subsequent memory reads over prior I/O
+                        // or memory reads; see above Rust source comment for
+                        // explanation.
+                        fence ir, r
+                    ",
+                    dma_buffer_ptr_reg = in(reg) buf as *mut T,
+                );
+            }
+        } else {
+            // When building for another architecture, such as for tests or CI:
+            unimplemented!("RiscvCoherentDmaFence can only be used on RISC-V targets");
+        }
+    }
+}

--- a/arch/riscv/src/dma_fence.rs
+++ b/arch/riscv/src/dma_fence.rs
@@ -81,8 +81,9 @@ unsafe impl DmaFence for RiscvCoherentDmaFence {
     ///
     /// [1]: https://docs.riscv.org/reference/isa/_attachments/riscv-unprivileged.pdf
     #[inline(always)]
-    fn release<T>(self, buf: *mut [T]) {
+    fn release<T>(self, slice_ptr: *mut [T]) {
         if cfg!(any(target_arch = "riscv32", target_arch = "riscv64")) {
+            let slice_start_ptr: *mut T = slice_ptr.cast();
             unsafe {
                 core::arch::asm!(
                     "
@@ -95,7 +96,7 @@ unsafe impl DmaFence for RiscvCoherentDmaFence {
                         // comment for explanation.
                         fence w, iorw
                     ",
-                    dma_buffer_ptr_reg = in(reg) buf as *mut T,
+                    dma_buffer_ptr_reg = in(reg) slice_start_ptr,
                 );
             }
         } else {
@@ -138,8 +139,9 @@ unsafe impl DmaFence for RiscvCoherentDmaFence {
     ///
     /// [1]: https://docs.riscv.org/reference/isa/_attachments/riscv-unprivileged.pdf
     #[inline(always)]
-    fn acquire<T>(self, buf: *mut [T]) {
+    fn acquire<T>(self, slice_ptr: *mut [T]) {
         if cfg!(any(target_arch = "riscv32", target_arch = "riscv64")) {
+            let slice_start_ptr: *mut T = slice_ptr.cast();
             unsafe {
                 core::arch::asm!(
                     "
@@ -153,7 +155,7 @@ unsafe impl DmaFence for RiscvCoherentDmaFence {
                         // explanation.
                         fence ir, r
                     ",
-                    dma_buffer_ptr_reg = in(reg) buf as *mut T,
+                    dma_buffer_ptr_reg = in(reg) slice_start_ptr,
                 );
             }
         } else {

--- a/arch/riscv/src/dma_fence.rs
+++ b/arch/riscv/src/dma_fence.rs
@@ -87,15 +87,15 @@ unsafe impl DmaFence for RiscvCoherentDmaFence {
         unsafe {
             core::arch::asm!(
                 "
-                        // This block is opaque to the compiler; it must assume
-                        // that it could read the entire buffer from which the
-                        // pointer stored in {dma_buffer_ptr_reg} was derived.
+    // This block is opaque to the compiler; it must assume
+    // that it could read the entire buffer from which the
+    // pointer stored in {dma_buffer_ptr_reg} was derived.
 
-                        // Do not reorder prior memory writes over subsequent
-                        // I/O or memory reads or writes; see above Rust source
-                        // comment for explanation.
-                        fence w, iorw
-                    ",
+    // Do not reorder prior memory writes over subsequent
+    // I/O or memory reads or writes; see above Rust source
+    // comment for explanation.
+    fence w, iorw
+                ",
                 dma_buffer_ptr_reg = in(reg) slice_start_ptr,
             );
         }
@@ -140,16 +140,16 @@ unsafe impl DmaFence for RiscvCoherentDmaFence {
         unsafe {
             core::arch::asm!(
                 "
-                        // This block is opaque to the compiler; it must assume
-                        // that it could write to the entire buffer from which
-                        // the pointer stored in {dma_buffer_ptr_reg} was
-                        // derived.
+    // This block is opaque to the compiler; it must assume
+    // that it could write to the entire buffer from which
+    // the pointer stored in {dma_buffer_ptr_reg} was
+    // derived.
 
-                        // Do not reorder subsequent memory reads over prior I/O
-                        // or memory reads; see above Rust source comment for
-                        // explanation.
-                        fence ir, r
-                    ",
+    // Do not reorder subsequent memory reads over prior I/O
+    // or memory reads; see above Rust source comment for
+    // explanation.
+    fence ir, r
+                ",
                 dma_buffer_ptr_reg = in(reg) slice_start_ptr,
             );
         }

--- a/arch/riscv/src/dma_fence.rs
+++ b/arch/riscv/src/dma_fence.rs
@@ -44,7 +44,7 @@ impl RiscvCoherentDmaFence {
     }
 }
 
-#[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
+#[cfg(any(doc, target_arch = "riscv32", target_arch = "riscv64"))]
 unsafe impl DmaFence for RiscvCoherentDmaFence {
     /// Expose prior writes to in-memory buffers to subsequent DMA operations.
     ///
@@ -156,7 +156,7 @@ unsafe impl DmaFence for RiscvCoherentDmaFence {
     }
 }
 
-#[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
+#[cfg(not(any(doc, target_arch = "riscv32", target_arch = "riscv64")))]
 unsafe impl DmaFence for RiscvCoherentDmaFence {
     fn release<T>(self, _slice_ptr: *mut [T]) {
         // When building for another architecture, such as for tests or CI:

--- a/arch/riscv/src/dma_fence.rs
+++ b/arch/riscv/src/dma_fence.rs
@@ -44,6 +44,7 @@ impl RiscvCoherentDmaFence {
     }
 }
 
+#[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
 unsafe impl DmaFence for RiscvCoherentDmaFence {
     /// Expose prior writes to in-memory buffers to subsequent DMA operations.
     ///
@@ -82,11 +83,10 @@ unsafe impl DmaFence for RiscvCoherentDmaFence {
     /// [1]: https://docs.riscv.org/reference/isa/_attachments/riscv-unprivileged.pdf
     #[inline(always)]
     fn release<T>(self, slice_ptr: *mut [T]) {
-        if cfg!(any(target_arch = "riscv32", target_arch = "riscv64")) {
-            let slice_start_ptr: *mut T = slice_ptr.cast();
-            unsafe {
-                core::arch::asm!(
-                    "
+        let slice_start_ptr: *mut T = slice_ptr.cast();
+        unsafe {
+            core::arch::asm!(
+                "
                         // This block is opaque to the compiler; it must assume
                         // that it could read the entire buffer from which the
                         // pointer stored in {dma_buffer_ptr_reg} was derived.
@@ -96,12 +96,8 @@ unsafe impl DmaFence for RiscvCoherentDmaFence {
                         // comment for explanation.
                         fence w, iorw
                     ",
-                    dma_buffer_ptr_reg = in(reg) slice_start_ptr,
-                );
-            }
-        } else {
-            // When building for another architecture, such as for tests or CI:
-            unimplemented!("RiscvCoherentDmaFence can only be used on RISC-V targets");
+                dma_buffer_ptr_reg = in(reg) slice_start_ptr,
+            );
         }
     }
 
@@ -140,11 +136,10 @@ unsafe impl DmaFence for RiscvCoherentDmaFence {
     /// [1]: https://docs.riscv.org/reference/isa/_attachments/riscv-unprivileged.pdf
     #[inline(always)]
     fn acquire<T>(self, slice_ptr: *mut [T]) {
-        if cfg!(any(target_arch = "riscv32", target_arch = "riscv64")) {
-            let slice_start_ptr: *mut T = slice_ptr.cast();
-            unsafe {
-                core::arch::asm!(
-                    "
+        let slice_start_ptr: *mut T = slice_ptr.cast();
+        unsafe {
+            core::arch::asm!(
+                "
                         // This block is opaque to the compiler; it must assume
                         // that it could write to the entire buffer from which
                         // the pointer stored in {dma_buffer_ptr_reg} was
@@ -155,12 +150,20 @@ unsafe impl DmaFence for RiscvCoherentDmaFence {
                         // explanation.
                         fence ir, r
                     ",
-                    dma_buffer_ptr_reg = in(reg) slice_start_ptr,
-                );
-            }
-        } else {
-            // When building for another architecture, such as for tests or CI:
-            unimplemented!("RiscvCoherentDmaFence can only be used on RISC-V targets");
+                dma_buffer_ptr_reg = in(reg) slice_start_ptr,
+            );
         }
+    }
+}
+
+#[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
+unsafe impl DmaFence for RiscvCoherentDmaFence {
+    fn release<T>(self, _slice_ptr: *mut [T]) {
+        // When building for another architecture, such as for tests or CI:
+        unimplemented!("RiscvCoherentDmaFence can only be used on RISC-V targets");
+    }
+    fn acquire<T>(self, _slice_ptr: *mut [T]) {
+        // When building for another architecture, such as for tests or CI:
+        unimplemented!("RiscvCoherentDmaFence can only be used on RISC-V targets");
     }
 }

--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -11,6 +11,7 @@ use core::fmt::Write;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 
 pub mod csr;
+pub mod dma_fence;
 pub mod pmp;
 pub mod support;
 pub mod syscall;

--- a/arch/rv32i/src/lib.rs
+++ b/arch/rv32i/src/lib.rs
@@ -21,5 +21,6 @@ pub use riscv::thread_id;
 pub use riscv::PermissionMode;
 pub use riscv::_start_trap;
 pub use riscv::configure_trap_handler;
+pub use riscv::dma_fence;
 pub use riscv::print_mcause;
 pub use riscv::semihost_command;

--- a/arch/x86/src/dma_fence.rs
+++ b/arch/x86/src/dma_fence.rs
@@ -1,0 +1,124 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Leon Schuermann <leon@is.currently.online> 2026.
+// Copyright Tock Contributors 2026.
+
+use kernel::platform::dma_fence::DmaFence;
+
+/// An implementation of [`DmaFence`] for x86 CPUs.
+///
+/// This implementation assumes that all DMA peripherals are cache-coherent
+/// w.r.t. the CPU.
+///
+/// The provided `release` and `acquire` methods use opaque assembly blocks to
+/// make prior writes to DMA buffers visible to DMA devices, and DMA writes
+/// visible to prior memory reads, respectively.
+///
+/// This implementation is insufficient when used for write-combining (WC)
+/// memory (e.g., for video buffers or specific non-coherent regions mapped via
+/// PAT).
+#[derive(Debug, Copy, Clone)]
+pub struct X86DmaFence {
+    _private: (),
+}
+
+impl X86DmaFence {
+    /// Construct a new [`X86DmaFence`].
+    ///
+    /// Refer to the [type-level documentation](Self) and the documentation of
+    /// the [`DmaFence` trait](DmaFence) and [its implementation for
+    /// `X86DmaFence`](<X86DmaFence as DmaFence>) for more details.
+    ///
+    /// # Safety
+    ///
+    /// This [`X86DmaFence`] implementation is insufficient when used for
+    /// write-combining (WC) memory. By using `unsafe`, callers of this function
+    /// promise that the resulting instance is not used to fence DMA memory
+    /// accesses over write-combining memory.
+    pub unsafe fn new() -> Self {
+        X86DmaFence { _private: () }
+    }
+}
+
+unsafe impl DmaFence for X86DmaFence {
+    /// Expose prior writes to in-memory buffers to subsequent DMA operations.
+    ///
+    /// This assembly block ensures that neither the compiler, not the CPU
+    /// reorder any memory writes beyond the point at which a subsequent memory
+    /// or I/O access is made (e.g., to start a DMA transaction).
+    ///
+    /// Conventionally, we'd use the built-in `core::sync::atomic::fence` for
+    /// this, but that explicitly cannot be used to establish synchronization
+    /// among non-atomic accesses.
+    ///
+    /// Instead, to deal with any potential compiler re-ordering, we use an
+    /// `asm!()` that does **not** have the `nomem` clobber set. This block is
+    /// opaque to the compiler. We further explicitly pass in a pointer
+    /// originating from, and thus carrying provenance of our DMA buffer. This
+    /// should be sufficient to make the compiler assume that this function may
+    /// read the entire DMA buffer, and thus cause it to commit all pending
+    /// writes before this `asm!()` block.
+    ///
+    /// We expect that x86 CPUs do not perform any observable hardware
+    /// re-ordering, and that all DMA access are coherent with CPU instructions
+    /// accessing memory.
+    #[inline(always)]
+    fn release<T>(self, buf: *mut [T]) {
+        if cfg!(any(target_arch = "x86", target_arch = "x86_64")) {
+            unsafe {
+                core::arch::asm!(
+                    "
+                        // This block is opaque to the compiler; it must assume
+                        // that it could read the entire buffer from which the
+                        // pointer stored in {dma_buffer_ptr_reg} was derived.
+                    ",
+                    dma_buffer_ptr_reg = in(reg) buf as *mut T,
+                );
+            }
+        } else {
+            // When building for another architecture, such as for tests or CI:
+            unimplemented!("X86DmaFence can only be used on x86 targets");
+        }
+    }
+
+    /// Expose prior writes by DMA peripherals to subsequent memory reads.
+    ///
+    /// This assembly block ensures that neither the compiler, not the CPU
+    /// reorder any memory reads before the point at which a subsequent
+    /// memory or I/O access is made (e.g., to start a DMA transaction).
+    ///
+    /// Conventionally, we'd use the built-in `core::sync::atomic::fence` for
+    /// this, but that explicitly cannot be used to establish synchronization
+    /// among non-atomic accesses.
+    ///
+    /// Instead, to deal with any potential compiler re-ordering, we use an
+    /// `asm!()` that does **not** have the `nomem` clobber set. This block
+    /// is opaque to the compiler. We further explicitly pass in a pointer
+    /// originating from, and thus carrying provenance of our DMA
+    /// buffer. This should be sufficient to make the compiler assume that
+    /// this function may write to the entire DMA buffer, and thus prevent it
+    /// from moving reads to before this `asm!()` block.
+    ///
+    /// We expect that x86 CPUs do not perform any observable hardware
+    /// re-ordering, and that all DMA access are coherent with CPU instructions
+    /// accessing memory.
+    #[inline(always)]
+    fn acquire<T>(self, buf: *mut [T]) {
+        if cfg!(any(target_arch = "x86", target_arch = "x86_64")) {
+            unsafe {
+                core::arch::asm!(
+                    "
+                        // This block is opaque to the compiler; it must assume
+                        // that it could write to the entire buffer from which
+                        // the pointer stored in {dma_buffer_ptr_reg} was
+                        // derived.
+                    ",
+                    dma_buffer_ptr_reg = in(reg) buf as *mut T,
+                );
+            }
+        } else {
+            // When building for another architecture, such as for tests or CI:
+            unimplemented!("X86DmaFence can only be used on x86 targets");
+        }
+    }
+}

--- a/arch/x86/src/dma_fence.rs
+++ b/arch/x86/src/dma_fence.rs
@@ -40,6 +40,7 @@ impl X86DmaFence {
     }
 }
 
+#[cfg(any(doc, target_arch = "x86"))]
 unsafe impl DmaFence for X86DmaFence {
     /// Expose prior writes to in-memory buffers to subsequent DMA operations.
     ///
@@ -64,21 +65,16 @@ unsafe impl DmaFence for X86DmaFence {
     /// accessing memory.
     #[inline(always)]
     fn release<T>(self, slice_ptr: *mut [T]) {
-        if cfg!(any(target_arch = "x86", target_arch = "x86_64")) {
-            let slice_start_ptr: *mut T = slice_ptr.cast();
-            unsafe {
-                core::arch::asm!(
-                    "
+        let slice_start_ptr: *mut T = slice_ptr.cast();
+        unsafe {
+            core::arch::asm!(
+                "
                         // This block is opaque to the compiler; it must assume
                         // that it could read the entire buffer from which the
                         // pointer stored in {dma_buffer_ptr_reg} was derived.
                     ",
-                    dma_buffer_ptr_reg = in(reg) slice_start_ptr,
-                );
-            }
-        } else {
-            // When building for another architecture, such as for tests or CI:
-            unimplemented!("X86DmaFence can only be used on x86 targets");
+                dma_buffer_ptr_reg = in(reg) slice_start_ptr,
+            );
         }
     }
 
@@ -105,22 +101,29 @@ unsafe impl DmaFence for X86DmaFence {
     /// accessing memory.
     #[inline(always)]
     fn acquire<T>(self, slice_ptr: *mut [T]) {
-        if cfg!(any(target_arch = "x86", target_arch = "x86_64")) {
-            let slice_start_ptr: *mut T = slice_ptr.cast();
-            unsafe {
-                core::arch::asm!(
-                    "
+        let slice_start_ptr: *mut T = slice_ptr.cast();
+        unsafe {
+            core::arch::asm!(
+                "
                         // This block is opaque to the compiler; it must assume
                         // that it could write to the entire buffer from which
                         // the pointer stored in {dma_buffer_ptr_reg} was
                         // derived.
                     ",
-                    dma_buffer_ptr_reg = in(reg) slice_start_ptr,
-                );
-            }
-        } else {
-            // When building for another architecture, such as for tests or CI:
-            unimplemented!("X86DmaFence can only be used on x86 targets");
+                dma_buffer_ptr_reg = in(reg) slice_start_ptr,
+            );
         }
+    }
+}
+
+#[cfg(not(any(doc, target_arch = "x86")))]
+unsafe impl DmaFence for X86DmaFence {
+    fn release<T>(self, _slice_ptr: *mut [T]) {
+        // When building for another architecture, such as for tests or CI:
+        unimplemented!("X86DmaFence can only be used on x86 targets");
+    }
+    fn acquire<T>(self, _slice_ptr: *mut [T]) {
+        // When building for another architecture, such as for tests or CI:
+        unimplemented!("X86DmaFence can only be used on x86 targets");
     }
 }

--- a/arch/x86/src/dma_fence.rs
+++ b/arch/x86/src/dma_fence.rs
@@ -63,8 +63,9 @@ unsafe impl DmaFence for X86DmaFence {
     /// re-ordering, and that all DMA access are coherent with CPU instructions
     /// accessing memory.
     #[inline(always)]
-    fn release<T>(self, buf: *mut [T]) {
+    fn release<T>(self, slice_ptr: *mut [T]) {
         if cfg!(any(target_arch = "x86", target_arch = "x86_64")) {
+            let slice_start_ptr: *mut T = slice_ptr.cast();
             unsafe {
                 core::arch::asm!(
                     "
@@ -72,7 +73,7 @@ unsafe impl DmaFence for X86DmaFence {
                         // that it could read the entire buffer from which the
                         // pointer stored in {dma_buffer_ptr_reg} was derived.
                     ",
-                    dma_buffer_ptr_reg = in(reg) buf as *mut T,
+                    dma_buffer_ptr_reg = in(reg) slice_start_ptr,
                 );
             }
         } else {
@@ -103,8 +104,9 @@ unsafe impl DmaFence for X86DmaFence {
     /// re-ordering, and that all DMA access are coherent with CPU instructions
     /// accessing memory.
     #[inline(always)]
-    fn acquire<T>(self, buf: *mut [T]) {
+    fn acquire<T>(self, slice_ptr: *mut [T]) {
         if cfg!(any(target_arch = "x86", target_arch = "x86_64")) {
+            let slice_start_ptr: *mut T = slice_ptr.cast();
             unsafe {
                 core::arch::asm!(
                     "
@@ -113,7 +115,7 @@ unsafe impl DmaFence for X86DmaFence {
                         // the pointer stored in {dma_buffer_ptr_reg} was
                         // derived.
                     ",
-                    dma_buffer_ptr_reg = in(reg) buf as *mut T,
+                    dma_buffer_ptr_reg = in(reg) slice_start_ptr,
                 );
             }
         } else {

--- a/arch/x86/src/dma_fence.rs
+++ b/arch/x86/src/dma_fence.rs
@@ -69,10 +69,10 @@ unsafe impl DmaFence for X86DmaFence {
         unsafe {
             core::arch::asm!(
                 "
-                        // This block is opaque to the compiler; it must assume
-                        // that it could read the entire buffer from which the
-                        // pointer stored in {dma_buffer_ptr_reg} was derived.
-                    ",
+    // This block is opaque to the compiler; it must assume
+    // that it could read the entire buffer from which the
+    // pointer stored in {dma_buffer_ptr_reg} was derived.
+                ",
                 dma_buffer_ptr_reg = in(reg) slice_start_ptr,
             );
         }
@@ -105,11 +105,11 @@ unsafe impl DmaFence for X86DmaFence {
         unsafe {
             core::arch::asm!(
                 "
-                        // This block is opaque to the compiler; it must assume
-                        // that it could write to the entire buffer from which
-                        // the pointer stored in {dma_buffer_ptr_reg} was
-                        // derived.
-                    ",
+    // This block is opaque to the compiler; it must assume
+    // that it could write to the entire buffer from which
+    // the pointer stored in {dma_buffer_ptr_reg} was
+    // derived.
+                ",
                 dma_buffer_ptr_reg = in(reg) slice_start_ptr,
             );
         }

--- a/arch/x86/src/lib.rs
+++ b/arch/x86/src/lib.rs
@@ -49,6 +49,7 @@ pub mod support;
 
 pub mod mpu;
 
+pub mod dma_fence;
 pub mod registers;
 pub mod thread_id;
 

--- a/boards/qemu_i486_q35/src/main.rs
+++ b/boards/qemu_i486_q35/src/main.rs
@@ -32,6 +32,7 @@ use kernel::{create_capability, static_init};
 use virtio::devices::virtio_rng::VirtIORng;
 use virtio::devices::VirtIODeviceType;
 use virtio_pci_x86::VirtIOPCIDevice;
+use x86::dma_fence::X86DmaFence;
 use x86::registers::bits32::paging::{PDEntry, PTEntry, PD, PT};
 use x86::registers::irq;
 use x86_q35::pit::{Pit, RELOAD_1KHZ};
@@ -157,7 +158,7 @@ pub struct QemuI386Q35Platform {
     ipc: IPC<{ NUM_PROCS as u8 }>,
     scheduler: &'static SchedulerInUse,
     scheduler_timer: &'static SchedulerTimerHw,
-    rng: Option<&'static RngDriver<'static, VirtIORng<'static, 'static>>>,
+    rng: Option<&'static RngDriver<'static, VirtIORng<'static, 'static, X86DmaFence>>>,
 }
 
 impl SyscallDriverLookup for QemuI386Q35Platform {
@@ -291,6 +292,9 @@ unsafe extern "cdecl" fn main() {
     // Setup space to store the core kernel data structure.
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
 
+    // We use the default x86 implementation of `DmaFence`:
+    let dma_fence = X86DmaFence::new();
+
     // ---------- QEMU-SYSTEM-I386 "Q35" MACHINE PERIPHERALS ----------
 
     // Create a shared UART channel for the console and for kernel
@@ -376,7 +380,8 @@ unsafe extern "cdecl" fn main() {
 
     // If there is a VirtIO EntropySource present, use the appropriate VirtIORng
     // driver and expose it to userspace though the RngDriver
-    let virtio_rng: Option<&'static VirtIORng> = if let Some(rng_dev) = virtio_rng_dev {
+    let virtio_rng: Option<&'static VirtIORng<X86DmaFence>> = if let Some(rng_dev) = virtio_rng_dev
+    {
         use virtio::queues::split_queue::{
             SplitVirtqueue, VirtqueueAvailableRing, VirtqueueDescriptors, VirtqueueUsedRing,
         };
@@ -394,13 +399,13 @@ unsafe extern "cdecl" fn main() {
             static_init!(VirtqueueAvailableRing<1>, VirtqueueAvailableRing::default(),);
         let used_ring = static_init!(VirtqueueUsedRing<1>, VirtqueueUsedRing::default(),);
         let queue = static_init!(
-            SplitVirtqueue<1>,
-            SplitVirtqueue::new(descriptors, available_ring, used_ring),
+            SplitVirtqueue<1, X86DmaFence>,
+            SplitVirtqueue::new(descriptors, available_ring, used_ring, dma_fence),
         );
         queue.set_transport(transport);
 
         // VirtIO EntropySource device driver instantiation
-        let rng = static_init!(VirtIORng, VirtIORng::new(queue));
+        let rng = static_init!(VirtIORng<X86DmaFence>, VirtIORng::new(queue));
         DeferredCallClient::register(rng);
         queue.set_client(rng);
 
@@ -486,7 +491,9 @@ unsafe extern "cdecl" fn main() {
     // Userspace RNG driver over the VirtIO EntropySource
     let rng_driver = virtio_rng.map(|rng| {
         components::rng::RngRandomComponent::new(board_kernel, capsules_core::rng::DRIVER_NUM, rng)
-            .finalize(components::rng_random_component_static!(VirtIORng))
+            .finalize(components::rng_random_component_static!(
+                VirtIORng<X86DmaFence>
+            ))
     });
 
     let scheduler = components::sched::cooperative::CooperativeComponent::new(processes)

--- a/boards/qemu_rv32_virt/src/lib.rs
+++ b/boards/qemu_rv32_virt/src/lib.rs
@@ -19,6 +19,7 @@ use kernel::utilities::single_thread_value::SingleThreadValue;
 use kernel::{create_capability, debug, static_init};
 use qemu_rv32_virt_chip::chip::{QemuRv32VirtChip, QemuRv32VirtDefaultPeripherals};
 use rv32i::csr;
+use rv32i::dma_fence::RiscvCoherentDmaFence;
 
 pub mod io;
 
@@ -28,9 +29,17 @@ pub type ChipHw = QemuRv32VirtChip<'static, QemuRv32VirtDefaultPeripherals<'stat
 type ProcessPrinter = capsules_system::process_printer::ProcessPrinterText;
 
 type RngDriver = components::rng::RngRandomComponentType<
-    qemu_rv32_virt_chip::virtio::devices::virtio_rng::VirtIORng<'static, 'static>,
+    qemu_rv32_virt_chip::virtio::devices::virtio_rng::VirtIORng<
+        'static,
+        'static,
+        RiscvCoherentDmaFence,
+    >,
 >;
-pub type ScreenHw = qemu_rv32_virt_chip::virtio::devices::virtio_gpu::VirtIOGPU<'static, 'static>;
+pub type ScreenHw = qemu_rv32_virt_chip::virtio::devices::virtio_gpu::VirtIOGPU<
+    'static,
+    'static,
+    RiscvCoherentDmaFence,
+>;
 
 type AlarmHw = qemu_rv32_virt_chip::chip::QemuRv32VirtClint<'static>;
 type SchedulerTimerHw =
@@ -71,7 +80,10 @@ pub struct QemuRv32VirtPlatform {
     virtio_ethernet_tap: Option<
         &'static capsules_extra::ethernet_tap::EthernetTapDriver<
             'static,
-            qemu_rv32_virt_chip::virtio::devices::virtio_net::VirtIONet<'static>,
+            qemu_rv32_virt_chip::virtio::devices::virtio_net::VirtIONet<
+                'static,
+                RiscvCoherentDmaFence,
+            >,
         >,
     >,
     pub virtio_gpu_screen: Option<
@@ -80,8 +92,12 @@ pub struct QemuRv32VirtPlatform {
             ScreenHw,
         >,
     >,
-    pub virtio_input_keyboard:
-        Option<&'static qemu_rv32_virt_chip::virtio::devices::virtio_input::VirtIOInput<'static>>,
+    pub virtio_input_keyboard: Option<
+        &'static qemu_rv32_virt_chip::virtio::devices::virtio_input::VirtIOInput<
+            'static,
+            RiscvCoherentDmaFence,
+        >,
+    >,
 }
 
 /// Mapping of integer syscalls to objects that implement syscalls.
@@ -250,6 +266,11 @@ pub unsafe fn start() -> (
     // Setup space to store the core kernel data structure.
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
 
+    // Create a DmaFence instance. Under QEMU, DMA peripherals are
+    // cache-coherent with the main CPU, and therefore we can use the
+    // `RiscvCoherentDmaFence`:
+    let dma_fence = RiscvCoherentDmaFence::new();
+
     // ---------- QEMU-SYSTEM-RISCV32 "virt" MACHINE PERIPHERALS ----------
 
     let peripherals = static_init!(
@@ -357,8 +378,8 @@ pub unsafe fn start() -> (
             static_init!(VirtqueueAvailableRing<2>, VirtqueueAvailableRing::default(),);
         let used_ring = static_init!(VirtqueueUsedRing<2>, VirtqueueUsedRing::default(),);
         let control_queue = static_init!(
-            SplitVirtqueue<2>,
-            SplitVirtqueue::new(descriptors, available_ring, used_ring),
+            SplitVirtqueue<2, RiscvCoherentDmaFence>,
+            SplitVirtqueue::new(descriptors, available_ring, used_ring, dma_fence),
         );
         control_queue.set_transport(&peripherals.virtio_mmio[gpu_idx]);
 
@@ -372,7 +393,7 @@ pub unsafe fn start() -> (
 
         // VirtIO GPU device driver instantiation
         let gpu = static_init!(
-            VirtIOGPU,
+            VirtIOGPU<RiscvCoherentDmaFence>,
             VirtIOGPU::new(
                 control_queue,
                 req_buffer,
@@ -416,49 +437,49 @@ pub unsafe fn start() -> (
 
     // If there is a VirtIO EntropySource present, use the appropriate VirtIORng
     // driver and expose it to userspace though the RngDriver
-    let virtio_rng: Option<&'static qemu_rv32_virt_chip::virtio::devices::virtio_rng::VirtIORng> =
-        if let Some(rng_idx) = virtio_rng_idx {
-            use qemu_rv32_virt_chip::virtio::devices::virtio_rng::VirtIORng;
-            use qemu_rv32_virt_chip::virtio::queues::split_queue::{
-                SplitVirtqueue, VirtqueueAvailableRing, VirtqueueDescriptors, VirtqueueUsedRing,
-            };
-            use qemu_rv32_virt_chip::virtio::queues::Virtqueue;
-            use qemu_rv32_virt_chip::virtio::transports::VirtIOTransport;
-
-            // EntropySource requires a single Virtqueue for retrieved entropy
-            let descriptors =
-                static_init!(VirtqueueDescriptors<1>, VirtqueueDescriptors::default(),);
-            let available_ring =
-                static_init!(VirtqueueAvailableRing<1>, VirtqueueAvailableRing::default(),);
-            let used_ring = static_init!(VirtqueueUsedRing<1>, VirtqueueUsedRing::default(),);
-            let queue = static_init!(
-                SplitVirtqueue<1>,
-                SplitVirtqueue::new(descriptors, available_ring, used_ring),
-            );
-            queue.set_transport(&peripherals.virtio_mmio[rng_idx]);
-
-            // VirtIO EntropySource device driver instantiation
-            let rng = static_init!(VirtIORng, VirtIORng::new(queue));
-            kernel::deferred_call::DeferredCallClient::register(rng);
-            queue.set_client(rng);
-
-            // Register the queues and driver with the transport, so interrupts
-            // are routed properly
-            let mmio_queues = static_init!([&'static dyn Virtqueue; 1], [queue; 1]);
-            peripherals.virtio_mmio[rng_idx]
-                .initialize(rng, mmio_queues)
-                .unwrap();
-
-            // Provide an internal randomness buffer
-            let rng_buffer = static_init!([u8; 64], [0; 64]);
-            rng.provide_buffer(rng_buffer)
-                .expect("rng: providing initial buffer failed");
-
-            Some(rng)
-        } else {
-            // No VirtIO EntropySource discovered
-            None
+    let virtio_rng: Option<
+        &'static qemu_rv32_virt_chip::virtio::devices::virtio_rng::VirtIORng<RiscvCoherentDmaFence>,
+    > = if let Some(rng_idx) = virtio_rng_idx {
+        use qemu_rv32_virt_chip::virtio::devices::virtio_rng::VirtIORng;
+        use qemu_rv32_virt_chip::virtio::queues::split_queue::{
+            SplitVirtqueue, VirtqueueAvailableRing, VirtqueueDescriptors, VirtqueueUsedRing,
         };
+        use qemu_rv32_virt_chip::virtio::queues::Virtqueue;
+        use qemu_rv32_virt_chip::virtio::transports::VirtIOTransport;
+
+        // EntropySource requires a single Virtqueue for retrieved entropy
+        let descriptors = static_init!(VirtqueueDescriptors<1>, VirtqueueDescriptors::default(),);
+        let available_ring =
+            static_init!(VirtqueueAvailableRing<1>, VirtqueueAvailableRing::default(),);
+        let used_ring = static_init!(VirtqueueUsedRing<1>, VirtqueueUsedRing::default(),);
+        let queue = static_init!(
+            SplitVirtqueue<1, RiscvCoherentDmaFence>,
+            SplitVirtqueue::new(descriptors, available_ring, used_ring, dma_fence),
+        );
+        queue.set_transport(&peripherals.virtio_mmio[rng_idx]);
+
+        // VirtIO EntropySource device driver instantiation
+        let rng = static_init!(VirtIORng<RiscvCoherentDmaFence>, VirtIORng::new(queue));
+        kernel::deferred_call::DeferredCallClient::register(rng);
+        queue.set_client(rng);
+
+        // Register the queues and driver with the transport, so interrupts
+        // are routed properly
+        let mmio_queues = static_init!([&'static dyn Virtqueue; 1], [queue; 1]);
+        peripherals.virtio_mmio[rng_idx]
+            .initialize(rng, mmio_queues)
+            .unwrap();
+
+        // Provide an internal randomness buffer
+        let rng_buffer = static_init!([u8; 64], [0; 64]);
+        rng.provide_buffer(rng_buffer)
+            .expect("rng: providing initial buffer failed");
+
+        Some(rng)
+    } else {
+        // No VirtIO EntropySource discovered
+        None
+    };
 
     // If there is a VirtIO NetworkCard present, use the appropriate VirtIONet
     // driver, and expose this device through the Ethernet Tap driver
@@ -466,7 +487,10 @@ pub unsafe fn start() -> (
     let virtio_ethernet_tap: Option<
         &'static capsules_extra::ethernet_tap::EthernetTapDriver<
             'static,
-            qemu_rv32_virt_chip::virtio::devices::virtio_net::VirtIONet<'static>,
+            qemu_rv32_virt_chip::virtio::devices::virtio_net::VirtIONet<
+                'static,
+                RiscvCoherentDmaFence,
+            >,
         >,
     > = if let Some(net_idx) = virtio_net_idx {
         use capsules_extra::ethernet_tap::EthernetTapDriver;
@@ -490,8 +514,8 @@ pub unsafe fn start() -> (
             static_init!(VirtqueueAvailableRing<2>, VirtqueueAvailableRing::default(),);
         let tx_used_ring = static_init!(VirtqueueUsedRing<2>, VirtqueueUsedRing::default(),);
         let tx_queue = static_init!(
-            SplitVirtqueue<2>,
-            SplitVirtqueue::new(tx_descriptors, tx_available_ring, tx_used_ring),
+            SplitVirtqueue<2, RiscvCoherentDmaFence>,
+            SplitVirtqueue::new(tx_descriptors, tx_available_ring, tx_used_ring, dma_fence),
         );
         tx_queue.set_transport(&peripherals.virtio_mmio[net_idx]);
 
@@ -502,8 +526,8 @@ pub unsafe fn start() -> (
             static_init!(VirtqueueAvailableRing<2>, VirtqueueAvailableRing::default(),);
         let rx_used_ring = static_init!(VirtqueueUsedRing<2>, VirtqueueUsedRing::default(),);
         let rx_queue = static_init!(
-            SplitVirtqueue<2>,
-            SplitVirtqueue::new(rx_descriptors, rx_available_ring, rx_used_ring),
+            SplitVirtqueue<2, RiscvCoherentDmaFence>,
+            SplitVirtqueue::new(rx_descriptors, rx_available_ring, rx_used_ring, dma_fence),
         );
         rx_queue.set_transport(&peripherals.virtio_mmio[net_idx]);
 
@@ -518,7 +542,7 @@ pub unsafe fn start() -> (
 
         // Instantiate the VirtIONet (NetworkCard) driver and set the queues
         let virtio_net = static_init!(
-            VirtIONet<'static>,
+            VirtIONet<'static, RiscvCoherentDmaFence>,
             VirtIONet::new(tx_queue, tx_header_buf, rx_queue, rx_header_buf, rx_buffer),
         );
         tx_queue.set_client(virtio_net);
@@ -537,7 +561,7 @@ pub unsafe fn start() -> (
             [0; capsules_extra::ethernet_tap::MAX_MTU],
         );
         let virtio_ethernet_tap = static_init!(
-            EthernetTapDriver<'static, VirtIONet<'static>>,
+            EthernetTapDriver<'static, VirtIONet<'static, RiscvCoherentDmaFence>>,
             EthernetTapDriver::new(
                 virtio_net,
                 board_kernel.create_grant(
@@ -552,14 +576,19 @@ pub unsafe fn start() -> (
         // This enables reception on the underlying device:
         virtio_ethernet_tap.initialize();
 
-        Some(virtio_ethernet_tap as &'static EthernetTapDriver<'static, VirtIONet<'static>>)
+        Some(
+            virtio_ethernet_tap
+                as &'static EthernetTapDriver<'static, VirtIONet<'static, RiscvCoherentDmaFence>>,
+        )
     } else {
         // No VirtIO NetworkCard discovered
         None
     };
 
     let virtio_input_keyboard: Option<
-        &'static qemu_rv32_virt_chip::virtio::devices::virtio_input::VirtIOInput,
+        &'static qemu_rv32_virt_chip::virtio::devices::virtio_input::VirtIOInput<
+            RiscvCoherentDmaFence,
+        >,
     > = if let Some(input_idx) = virtio_input_idx {
         use qemu_rv32_virt_chip::virtio::devices::virtio_input::VirtIOInput;
         use qemu_rv32_virt_chip::virtio::queues::split_queue::{
@@ -575,8 +604,8 @@ pub unsafe fn start() -> (
             static_init!(VirtqueueAvailableRing<3>, VirtqueueAvailableRing::default(),);
         let event_used_ring = static_init!(VirtqueueUsedRing<3>, VirtqueueUsedRing::default(),);
         let event_queue = static_init!(
-            SplitVirtqueue<3>,
-            SplitVirtqueue::new(event_descriptors, event_available_ring, event_used_ring),
+            SplitVirtqueue<3, RiscvCoherentDmaFence>,
+            SplitVirtqueue::new(event_descriptors, event_available_ring, event_used_ring, dma_fence),
         );
         event_queue.set_transport(&peripherals.virtio_mmio[input_idx]);
 
@@ -587,8 +616,8 @@ pub unsafe fn start() -> (
             static_init!(VirtqueueAvailableRing<1>, VirtqueueAvailableRing::default(),);
         let status_used_ring = static_init!(VirtqueueUsedRing<1>, VirtqueueUsedRing::default(),);
         let status_queue = static_init!(
-            SplitVirtqueue<1>,
-            SplitVirtqueue::new(status_descriptors, status_available_ring, status_used_ring),
+            SplitVirtqueue<1, RiscvCoherentDmaFence>,
+            SplitVirtqueue::new(status_descriptors, status_available_ring, status_used_ring, dma_fence),
         );
         status_queue.set_transport(&peripherals.virtio_mmio[input_idx]);
 
@@ -600,7 +629,7 @@ pub unsafe fn start() -> (
 
         // Instantiate the input driver
         let virtio_input = static_init!(
-            VirtIOInput<'static>,
+            VirtIOInput<'static, RiscvCoherentDmaFence>,
             VirtIOInput::new(event_queue, status_queue, status_buf),
         );
         event_queue.set_client(virtio_input);
@@ -690,7 +719,7 @@ pub unsafe fn start() -> (
     let rng_driver = virtio_rng.map(|rng| {
         components::rng::RngRandomComponent::new(board_kernel, capsules_core::rng::DRIVER_NUM, rng)
             .finalize(components::rng_random_component_static!(
-                qemu_rv32_virt_chip::virtio::devices::virtio_rng::VirtIORng
+                qemu_rv32_virt_chip::virtio::devices::virtio_rng::VirtIORng<RiscvCoherentDmaFence>
             ))
     });
 

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -11,10 +11,11 @@
 //! * Date: March 10 2018
 
 use core::cell::Cell;
-use core::cmp::min;
 use kernel::hil::uart;
-use kernel::utilities::cells::OptionalCell;
+use kernel::utilities::cells::{MapCell, OptionalCell};
+use kernel::utilities::dma_slice::DmaSubSliceMut;
 use kernel::utilities::io_write::IoWrite;
+use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::utilities::StaticRef;
@@ -22,7 +23,7 @@ use kernel::ErrorCode;
 use nrf5x::gpio::Pin;
 use nrf5x::pinmux;
 
-const UARTE_MAX_BUFFER_SIZE: u32 = 0xff;
+const UARTE_MAX_BUFFER_SIZE: usize = 0xff;
 
 static mut BYTE: u8 = 0;
 
@@ -161,20 +162,148 @@ register_bitfields! [u32,
     ]
 ];
 
+/// Wrapper for managing MMIO for UARTE.
+struct UarteRegistersManager {
+    /// MMIO registers for the UARTE peripheral.
+    registers: StaticRef<UarteRegisters>,
+    /// Holding place for the TX DMA buffer while DMA in progress.
+    tx_dma_buf: MapCell<DmaSubSliceMut<'static, u8>>,
+    /// Holding place for the RX DMA buffer while DMA in progress.
+    rx_dma_buf: MapCell<DmaSubSliceMut<'static, u8>>,
+}
+
+impl UarteRegistersManager {
+    pub fn new(regs: StaticRef<UarteRegisters>) -> Self {
+        Self {
+            registers: regs,
+            tx_dma_buf: MapCell::empty(),
+            rx_dma_buf: MapCell::empty(),
+        }
+    }
+
+    pub fn start_tx_dma(&self, buf: SubSliceMut<'static, u8>) {
+        // To create a DmaFence we must trust the implementation.
+        //
+        // # Safety
+        //
+        // The architecture-provided version is correct for the nRF52.
+        let fence = unsafe { cortexm4f::dma_fence::CortexMDmaFence::new() };
+
+        // Create DmaSlice for the TX buffer. This ensures that we can soundly
+        // share it with the DMA hardware.
+        let tx_dma_slice = DmaSubSliceMut::new_static(buf, fence);
+
+        // Provide the DmaSlice buffer to the hardware DMA engine.
+        self.registers.txd_ptr.set(tx_dma_slice.as_mut_ptr() as u32);
+
+        // Specify the length to transmit.
+        self.registers
+            .txd_maxcnt
+            .write(Counter::COUNTER.val(tx_dma_slice.len() as u32));
+
+        // Save the DmaSlice while the DMA operation executes.
+        self.tx_dma_buf.replace(tx_dma_slice);
+
+        // Start the TX DMA operation
+        self.registers.task_starttx.write(Task::ENABLE::SET);
+    }
+
+    pub fn finish_tx_dma(&self) -> Option<(SubSliceMut<'static, u8>, usize)> {
+        // End the DMA operation so it is safe to retrieve the buffer.
+        self.registers.event_endtx.write(Event::READY::CLEAR);
+
+        self.tx_dma_buf.take().map(|dma_slice| {
+            // To create a DmaFence we must trust the implementation.
+            //
+            // # Safety
+            //
+            // The architecture-provided version is correct for the nRF52.
+            let fence = unsafe { cortexm4f::dma_fence::CortexMDmaFence::new() };
+
+            // # Safety
+            //
+            // We must ensure that the DMA hardware no longer has any access
+            // to this buffer. We ensure that by setting the `event_endtx`
+            // event before taking the dma slice back.
+            let buf = unsafe { dma_slice.take(fence) };
+
+            let tx_bytes = self.registers.txd_amount.get() as usize;
+
+            (buf, tx_bytes)
+        })
+    }
+
+    pub fn tx_dma_pending(&self) -> bool {
+        self.tx_dma_buf.is_some()
+    }
+
+    pub fn start_rx_dma(&self, buf: SubSliceMut<'static, u8>) {
+        // To create a DmaFence we must trust the implementation.
+        //
+        // # Safety
+        //
+        // The architecture-provided version is correct for the nRF52.
+        let fence = unsafe { cortexm4f::dma_fence::CortexMDmaFence::new() };
+
+        // Create DmaSlice for the RX buffer. This ensures that we can soundly
+        // share it with the DMA hardware.
+        let rx_dma_slice = DmaSubSliceMut::new_static(buf, fence);
+
+        // Provide the DmaSlice buffer to the hardware DMA engine.
+        self.registers.rxd_ptr.set(rx_dma_slice.as_mut_ptr() as u32);
+
+        // Specify the length to transmit.
+        self.registers
+            .rxd_maxcnt
+            .write(Counter::COUNTER.val(rx_dma_slice.len() as u32));
+
+        // Save the DmaSlice while the DMA operation executes.
+        self.rx_dma_buf.replace(rx_dma_slice);
+
+        // Start the RX DMA operation
+        self.registers.task_startrx.write(Task::ENABLE::SET);
+    }
+
+    pub fn finish_rx_dma(&self) -> Option<(SubSliceMut<'static, u8>, usize)> {
+        // End the DMA operation so it is safe to retrieve the buffer.
+        self.registers.event_endrx.write(Event::READY::CLEAR);
+
+        self.rx_dma_buf.take().map(|dma_slice| {
+            // To create a DmaFence we must trust the implementation.
+            //
+            // # Safety
+            //
+            // The architecture-provided version is correct for the nRF52.
+            let fence = unsafe { cortexm4f::dma_fence::CortexMDmaFence::new() };
+
+            // # Safety
+            //
+            // We must ensure that the DMA hardware no longer has any access
+            // to this buffer. We ensure that by setting the `event_endrx`
+            // event before taking the dma slice back.
+            let buf = unsafe { dma_slice.take(fence) };
+
+            let rx_bytes = self.registers.rxd_amount.get() as usize;
+
+            (buf, rx_bytes)
+        })
+    }
+
+    pub fn rx_dma_pending(&self) -> bool {
+        self.rx_dma_buf.is_some()
+    }
+}
+
 /// UARTE
 // It should never be instanced outside this module but because a static mutable reference to it
 // is exported outside this module it must be `pub`
 pub struct Uarte<'a> {
-    registers: StaticRef<UarteRegisters>,
+    registers: UarteRegistersManager,
     tx_client: OptionalCell<&'a dyn uart::TransmitClient>,
-    tx_buffer: kernel::utilities::cells::TakeCell<'static, [u8]>,
     tx_len: Cell<usize>,
-    tx_remaining_bytes: Cell<usize>,
     rx_client: OptionalCell<&'a dyn uart::ReceiveClient>,
-    rx_buffer: kernel::utilities::cells::TakeCell<'static, [u8]>,
-    rx_remaining_bytes: Cell<usize>,
+    rx_len: Cell<usize>,
     rx_abort_in_progress: Cell<bool>,
-    offset: Cell<usize>,
 }
 
 #[derive(Copy, Clone)]
@@ -185,18 +314,16 @@ pub struct UARTParams {
 impl<'a> Uarte<'a> {
     /// Constructor
     // This should only be constructed once
-    pub const fn new(regs: StaticRef<UarteRegisters>) -> Uarte<'a> {
+    pub fn new(regs: StaticRef<UarteRegisters>) -> Uarte<'a> {
         Uarte {
-            registers: regs,
+            registers: UarteRegistersManager::new(regs),
             tx_client: OptionalCell::empty(),
-            tx_buffer: kernel::utilities::cells::TakeCell::empty(),
+            // tx_buffer: kernel::utilities::cells::TakeCell::empty(),
             tx_len: Cell::new(0),
-            tx_remaining_bytes: Cell::new(0),
+            // tx_remaining_bytes: Cell::new(0),
             rx_client: OptionalCell::empty(),
-            rx_buffer: kernel::utilities::cells::TakeCell::empty(),
-            rx_remaining_bytes: Cell::new(0),
+            rx_len: Cell::new(0),
             rx_abort_in_progress: Cell::new(false),
-            offset: Cell::new(0),
         }
     }
 
@@ -204,8 +331,14 @@ impl<'a> Uarte<'a> {
         self.disable_uart();
 
         // Stop any ongoing TX or RX DMA transmissions
-        self.registers.task_stoptx.write(Task::ENABLE::SET);
-        self.registers.task_stoprx.write(Task::ENABLE::SET);
+        self.registers
+            .registers
+            .task_stoptx
+            .write(Task::ENABLE::SET);
+        self.registers
+            .registers
+            .task_stoprx
+            .write(Task::ENABLE::SET);
 
         // Make sure we clear the endtx and endrx interrupts since
         // that is what we rely on to know when the DMA TX
@@ -213,29 +346,47 @@ impl<'a> Uarte<'a> {
         // it, so this is not necessary. However, a bootloader (or
         // some other startup code) may have setup TX interrupts, and
         // there may be one pending. We clear it to be safe.
-        self.registers.event_endtx.write(Event::READY::CLEAR);
-        self.registers.event_endrx.write(Event::READY::CLEAR);
+        self.registers
+            .registers
+            .event_endtx
+            .write(Event::READY::CLEAR);
+        self.registers
+            .registers
+            .event_endrx
+            .write(Event::READY::CLEAR);
 
-        self.registers.pseltxd.write(Psel::PIN.val(txd as _));
-        self.registers.pselrxd.write(Psel::PIN.val(rxd as _));
+        self.registers
+            .registers
+            .pseltxd
+            .write(Psel::PIN.val(txd as _));
+        self.registers
+            .registers
+            .pselrxd
+            .write(Psel::PIN.val(rxd as _));
         cts.map_or_else(
             || {
                 // If no CTS pin is provided, then we need to mark it as
                 // disconnected in the register.
-                self.registers.pselcts.write(Psel::CONNECT::SET);
+                self.registers.registers.pselcts.write(Psel::CONNECT::SET);
             },
             |c| {
-                self.registers.pselcts.write(Psel::PIN.val(c as _));
+                self.registers
+                    .registers
+                    .pselcts
+                    .write(Psel::PIN.val(c as _));
             },
         );
         rts.map_or_else(
             || {
                 // If no RTS pin is provided, then we need to mark it as
                 // disconnected in the register.
-                self.registers.pselrts.write(Psel::CONNECT::SET);
+                self.registers.registers.pselrts.write(Psel::CONNECT::SET);
             },
             |r| {
-                self.registers.pselrts.write(Psel::PIN.val(r as _));
+                self.registers
+                    .registers
+                    .pselrts
+                    .write(Psel::PIN.val(r as _));
             },
         );
 
@@ -284,35 +435,47 @@ impl<'a> Uarte<'a> {
 
     fn set_baud_rate(&self, baud_rate: u32) -> Result<(), ErrorCode> {
         let divider = self.get_divider_for_baud(baud_rate)?;
-        self.registers.baudrate.set(divider);
+        self.registers.registers.baudrate.set(divider);
 
         Ok(())
     }
 
     // Enable UART peripheral, this need to disabled for low power applications
     fn enable_uart(&self) {
-        self.registers.enable.write(Uart::ENABLE::ON);
+        self.registers.registers.enable.write(Uart::ENABLE::ON);
     }
 
     #[allow(dead_code)]
     fn disable_uart(&self) {
-        self.registers.enable.write(Uart::ENABLE::OFF);
+        self.registers.registers.enable.write(Uart::ENABLE::OFF);
     }
 
     fn enable_rx_interrupts(&self) {
-        self.registers.intenset.write(Interrupt::ENDRX::SET);
+        self.registers
+            .registers
+            .intenset
+            .write(Interrupt::ENDRX::SET);
     }
 
     fn enable_tx_interrupts(&self) {
-        self.registers.intenset.write(Interrupt::ENDTX::SET);
+        self.registers
+            .registers
+            .intenset
+            .write(Interrupt::ENDTX::SET);
     }
 
     fn disable_rx_interrupts(&self) {
-        self.registers.intenclr.write(Interrupt::ENDRX::SET);
+        self.registers
+            .registers
+            .intenclr
+            .write(Interrupt::ENDRX::SET);
     }
 
     fn disable_tx_interrupts(&self) {
-        self.registers.intenclr.write(Interrupt::ENDTX::SET);
+        self.registers
+            .registers
+            .intenclr
+            .write(Interrupt::ENDTX::SET);
     }
 
     /// UART interrupt handler that listens for both tx_end and rx_end events
@@ -320,32 +483,44 @@ impl<'a> Uarte<'a> {
     pub fn handle_interrupt(&self) {
         if self.tx_ready() {
             self.disable_tx_interrupts();
-            self.registers.event_endtx.write(Event::READY::CLEAR);
-            let tx_bytes = self.registers.txd_amount.get() as usize;
 
-            let rem = match self.tx_remaining_bytes.get().checked_sub(tx_bytes) {
-                None => return,
-                Some(r) => r,
-            };
+            if let Some((mut buf, transmitted_length)) = self.registers.finish_tx_dma() {
+                let active_range = buf.active_range();
 
-            // All bytes have been transmitted
-            if rem == 0 {
-                // Signal client write done
-                self.tx_client.map(|client| {
-                    self.tx_buffer.take().map(|tx_buffer| {
-                        client.transmitted_buffer(tx_buffer, self.tx_len.get(), Ok(()));
+                // Calculate the remaining bytes to transmit based on the length to
+                // transmit, the window we just tried to transmit, and how many
+                // bytes we actually did transmit.
+                //
+                // <-----buffer------------------->
+                //          <-active range->
+                // [        [              ]      ]
+                let remaining_bytes = self
+                    .tx_len
+                    .get()
+                    .saturating_sub(active_range.start)
+                    .saturating_sub(transmitted_length);
+
+                if remaining_bytes == 0 {
+                    // We sent everything.
+                    self.tx_client.map(|client| {
+                        client.transmitted_buffer(buf.take(), self.tx_len.get(), Ok(()));
                     });
-                });
-            } else {
-                // Not all bytes have been transmitted then update offset and continue transmitting
-                self.offset.set(self.offset.get() + tx_bytes);
-                self.tx_remaining_bytes.set(rem);
-                self.set_tx_dma_pointer_to_buffer();
-                self.registers
-                    .txd_maxcnt
-                    .write(Counter::COUNTER.val(min(rem as u32, UARTE_MAX_BUFFER_SIZE)));
-                self.registers.task_starttx.write(Task::ENABLE::SET);
-                self.enable_tx_interrupts();
+                } else {
+                    // Send the next portion of the buffer.
+
+                    // Reset back to the original slice.
+                    buf.reset();
+                    // Limit to just the portion of the buffer we are transmitting from.
+                    buf.slice(0..self.tx_len.get());
+                    // Skip what has already been transmitted.
+                    buf.slice((self.tx_len.get() - remaining_bytes)..);
+                    // Limit to at most the `UARTE_MAX_BUFFER_SIZE` bytes.
+                    buf.slice(0..UARTE_MAX_BUFFER_SIZE);
+                    // Send via DMA.
+                    self.registers.start_tx_dma(buf);
+                    // Re-enable interrupts.
+                    self.enable_tx_interrupts();
+                }
             }
         }
 
@@ -353,60 +528,75 @@ impl<'a> Uarte<'a> {
             self.disable_rx_interrupts();
 
             // Clear the ENDRX event
-            self.registers.event_endrx.write(Event::READY::CLEAR);
+            self.registers
+                .registers
+                .event_endrx
+                .write(Event::READY::CLEAR);
 
-            // Get the number of bytes in the buffer that was received this time
-            let rx_bytes = self.registers.rxd_amount.get() as usize;
+            if let Some((mut buf, received_length)) = self.registers.finish_rx_dma() {
+                let active_range = buf.active_range();
 
-            // Check if this ENDRX is due to an abort. If so, we want to
-            // do the receive callback immediately.
-            if self.rx_abort_in_progress.get() {
-                self.rx_abort_in_progress.set(false);
-                self.rx_client.map(|client| {
-                    self.rx_buffer.take().map(|rx_buffer| {
+                // Check if this ENDRX is due to an abort. If so, we want to
+                // do the receive callback immediately.
+                if self.rx_abort_in_progress.get() {
+                    self.rx_abort_in_progress.set(false);
+
+                    // Calculate how many bytes we actually received.
+                    let received_bytes = active_range.start + received_length;
+
+                    // Notify the client.
+                    self.rx_client.map(|client| {
                         client.received_buffer(
-                            rx_buffer,
-                            self.offset.get() + rx_bytes,
+                            buf.take(),
+                            received_bytes,
                             Err(ErrorCode::CANCEL),
                             uart::Error::None,
                         );
                     });
-                });
-            } else {
-                // In the normal case, we need to either pass call the callback
-                // or do another read to get more bytes.
+                } else {
+                    // In the normal case, we need to either pass call the callback
+                    // or do another read to get more bytes.
 
-                // Update how many bytes we still need to receive and
-                // where we are storing in the buffer.
-                self.rx_remaining_bytes
-                    .set(self.rx_remaining_bytes.get().saturating_sub(rx_bytes));
-                self.offset.set(self.offset.get() + rx_bytes);
+                    // Calculate the remaining bytes to receive based on the length to
+                    // receive, the window we just tried to receive into, and how many
+                    // bytes we actually did receive.
+                    //
+                    //
+                    // <-----buffer------------------->
+                    //          <-active range->
+                    // [        [              ]      ]
+                    let remaining_bytes = self
+                        .rx_len
+                        .get()
+                        .saturating_sub(active_range.start)
+                        .saturating_sub(received_length);
 
-                let rem = self.rx_remaining_bytes.get();
-                if rem == 0 {
-                    // Signal client that the read is done
-                    self.rx_client.map(|client| {
-                        self.rx_buffer.take().map(|rx_buffer| {
+                    if remaining_bytes == 0 {
+                        // Signal client that the read is done
+                        self.rx_client.map(|client| {
                             client.received_buffer(
-                                rx_buffer,
-                                self.offset.get(),
+                                buf.take(),
+                                self.rx_len.get(),
                                 Ok(()),
                                 uart::Error::None,
                             );
                         });
-                    });
-                } else {
-                    // Setup how much we can read. We already made sure that
-                    // this will fit in the buffer.
-                    let to_read = core::cmp::min(rem, 255);
-                    self.registers
-                        .rxd_maxcnt
-                        .write(Counter::COUNTER.val(to_read as u32));
+                    } else {
+                        // Receive into the next portion of the buffer.
 
-                    // Actually do the receive.
-                    self.set_rx_dma_pointer_to_buffer();
-                    self.registers.task_startrx.write(Task::ENABLE::SET);
-                    self.enable_rx_interrupts();
+                        // Reset back to the original slice.
+                        buf.reset();
+                        // Limit to just the portion of the buffer we are receiving into.
+                        buf.slice(0..self.rx_len.get());
+                        // Skip what has already been received.
+                        buf.slice((self.rx_len.get() - remaining_bytes)..);
+                        // Limit to at most the `UARTE_MAX_BUFFER_SIZE` bytes.
+                        buf.slice(0..UARTE_MAX_BUFFER_SIZE);
+                        // Receive via DMA.
+                        self.registers.start_rx_dma(buf);
+                        // Re-enable interrupts.
+                        self.enable_rx_interrupts();
+                    }
                 }
             }
         }
@@ -415,55 +605,74 @@ impl<'a> Uarte<'a> {
     /// Transmit one byte at the time and the client is responsible for polling
     /// This is used by the panic handler
     pub unsafe fn send_byte(&self, byte: u8) {
-        self.tx_remaining_bytes.set(1);
-        self.registers.event_endtx.write(Event::READY::CLEAR);
+        // self.tx_remaining_bytes.set(1);
+        self.registers
+            .registers
+            .event_endtx
+            .write(Event::READY::CLEAR);
         // precaution: copy value into variable with static lifetime
         BYTE = byte;
-        self.registers.txd_ptr.set(core::ptr::addr_of!(BYTE) as u32);
-        self.registers.txd_maxcnt.write(Counter::COUNTER.val(1));
-        self.registers.task_starttx.write(Task::ENABLE::SET);
+        self.registers
+            .registers
+            .txd_ptr
+            .set(core::ptr::addr_of!(BYTE) as u32);
+        self.registers
+            .registers
+            .txd_maxcnt
+            .write(Counter::COUNTER.val(1));
+        self.registers
+            .registers
+            .task_starttx
+            .write(Task::ENABLE::SET);
     }
 
     /// Check if the UART transmission is done
     pub fn tx_ready(&self) -> bool {
-        self.registers.event_endtx.is_set(Event::READY)
+        self.registers.registers.event_endtx.is_set(Event::READY)
     }
 
     /// Check if either the rx_buffer is full or the UART has timed out
     pub fn rx_ready(&self) -> bool {
-        self.registers.event_endrx.is_set(Event::READY)
-    }
-
-    fn set_tx_dma_pointer_to_buffer(&self) {
-        self.tx_buffer.map(|tx_buffer| {
-            self.registers
-                .txd_ptr
-                .set(tx_buffer[self.offset.get()..].as_ptr() as u32);
-        });
-    }
-
-    fn set_rx_dma_pointer_to_buffer(&self) {
-        self.rx_buffer.map(|rx_buffer| {
-            self.registers
-                .rxd_ptr
-                .set(rx_buffer[self.offset.get()..].as_ptr() as u32);
-        });
+        self.registers.registers.event_endrx.is_set(Event::READY)
     }
 
     // Helper function used by both transmit_word and transmit_buffer
     fn setup_buffer_transmit(&self, buf: &'static mut [u8], tx_len: usize) {
-        self.tx_remaining_bytes.set(tx_len);
+        // Save the total length to transmit as we may need to send over
+        // multiple iterations.
         self.tx_len.set(tx_len);
-        self.offset.set(0);
-        self.tx_buffer.replace(buf);
-        self.set_tx_dma_pointer_to_buffer();
 
-        self.registers
-            .txd_maxcnt
-            .write(Counter::COUNTER.val(min(tx_len as u32, UARTE_MAX_BUFFER_SIZE)));
-        self.registers.task_starttx.write(Task::ENABLE::SET);
+        // Create a `SubSlice` to simplify tracking which part we are sending,
+        // and slice the sub slice to either the total buffer to send or what
+        // fits in one send buffer.
+        let mut slice_to_send = SubSliceMut::new(buf);
+        slice_to_send.slice(0..core::cmp::min(tx_len, UARTE_MAX_BUFFER_SIZE));
 
+        // Send the buffer using DMA. This is managed by the register manager to
+        // ensure we are safely using DMA.
+        self.registers.start_tx_dma(slice_to_send);
+
+        // Enable interrupts so we get a interrupt when the transmission has
+        // finished.
         self.enable_tx_interrupts();
+    }
+
+    fn setup_buffer_receive(&self, buf: &'static mut [u8], rx_len: usize) {
+        // Save the total length to receive.
+        self.rx_len.set(rx_len);
+
+        // Create a `SubSlice` to simplify tracking which part we have received
+        // into.
+        let mut slice_to_receive = SubSliceMut::new(buf);
+        slice_to_receive.slice(0..core::cmp::min(rx_len, UARTE_MAX_BUFFER_SIZE));
+
+        // Use the buffer with DMA. This is managed by the register manager to
+        // ensure we are safely using DMA.
+        self.registers.start_rx_dma(slice_to_receive);
+
+        // Enable interrupts so we get a interrupt when the receive has
+        // finished.
+        self.enable_rx_interrupts();
     }
 }
 
@@ -479,7 +688,7 @@ impl<'a> uart::Transmit<'a> for Uarte<'a> {
     ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         if tx_len == 0 || tx_len > tx_data.len() {
             Err((ErrorCode::SIZE, tx_data))
-        } else if self.tx_buffer.is_some() {
+        } else if self.registers.tx_dma_pending() {
             Err((ErrorCode::BUSY, tx_data))
         } else {
             self.setup_buffer_transmit(tx_data, tx_len);
@@ -526,27 +735,14 @@ impl<'a> uart::Receive<'a> for Uarte<'a> {
         rx_buf: &'static mut [u8],
         rx_len: usize,
     ) -> Result<(), (ErrorCode, &'static mut [u8])> {
-        if self.rx_buffer.is_some() {
-            return Err((ErrorCode::BUSY, rx_buf));
+        if rx_len > rx_buf.len() {
+            Err((ErrorCode::SIZE, rx_buf))
+        } else if self.registers.rx_dma_pending() {
+            Err((ErrorCode::BUSY, rx_buf))
+        } else {
+            self.setup_buffer_receive(rx_buf, rx_len);
+            Ok(())
         }
-        // truncate rx_len if necessary
-        let truncated_length = core::cmp::min(rx_len, rx_buf.len());
-
-        self.rx_remaining_bytes.set(truncated_length);
-        self.offset.set(0);
-        self.rx_buffer.replace(rx_buf);
-        self.set_rx_dma_pointer_to_buffer();
-
-        let truncated_uart_max_length = core::cmp::min(truncated_length, 255);
-
-        self.registers
-            .rxd_maxcnt
-            .write(Counter::COUNTER.val(truncated_uart_max_length as u32));
-        self.registers.task_stoprx.write(Task::ENABLE::SET);
-        self.registers.task_startrx.write(Task::ENABLE::SET);
-
-        self.enable_rx_interrupts();
-        Ok(())
     }
 
     fn receive_word(&self) -> Result<(), ErrorCode> {
@@ -555,11 +751,14 @@ impl<'a> uart::Receive<'a> for Uarte<'a> {
 
     fn receive_abort(&self) -> Result<(), ErrorCode> {
         // Trigger the STOPRX event to cancel the current receive call.
-        if self.rx_buffer.is_none() {
+        if !self.registers.rx_dma_pending() {
             Ok(())
         } else {
             self.rx_abort_in_progress.set(true);
-            self.registers.task_stoprx.write(Task::ENABLE::SET);
+            self.registers
+                .registers
+                .task_stoprx
+                .write(Task::ENABLE::SET);
             Err(ErrorCode::BUSY)
         }
     }

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -181,7 +181,17 @@ impl UarteRegistersManager {
         }
     }
 
-    pub fn start_tx_dma(&self, buf: SubSliceMut<'static, u8>) {
+    /// Start a UART transmission with DMA.
+    ///
+    /// # Return
+    ///
+    /// `Ok(())` on successfully starting the DMA operation. `Err(())` if the
+    /// DMA is busy and the operation could not be started.
+    pub fn start_tx_dma(&self, buf: SubSliceMut<'static, u8>) -> Result<(), ()> {
+        if self.tx_dma_pending() {
+            return Err(());
+        }
+
         // To create a DmaFence we must trust the implementation.
         //
         // # Safety
@@ -206,6 +216,8 @@ impl UarteRegistersManager {
 
         // Start the TX DMA operation
         self.registers.task_starttx.write(Task::ENABLE::SET);
+
+        Ok(())
     }
 
     pub fn finish_tx_dma(&self) -> Option<(SubSliceMut<'static, u8>, usize)> {
@@ -237,7 +249,17 @@ impl UarteRegistersManager {
         self.tx_dma_buf.is_some()
     }
 
-    pub fn start_rx_dma(&self, buf: SubSliceMut<'static, u8>) {
+    /// Start a UART reception with DMA.
+    ///
+    /// # Return
+    ///
+    /// `Ok(())` on successfully starting the DMA operation. `Err(())` if the
+    /// DMA is busy and the operation could not be started.
+    pub fn start_rx_dma(&self, buf: SubSliceMut<'static, u8>) -> Result<(), ()> {
+        if self.rx_dma_pending() {
+            return Err(());
+        }
+
         // To create a DmaFence we must trust the implementation.
         //
         // # Safety
@@ -262,6 +284,8 @@ impl UarteRegistersManager {
 
         // Start the RX DMA operation
         self.registers.task_startrx.write(Task::ENABLE::SET);
+
+        Ok(())
     }
 
     pub fn finish_rx_dma(&self) -> Option<(SubSliceMut<'static, u8>, usize)> {
@@ -517,7 +541,7 @@ impl<'a> Uarte<'a> {
                     // Limit to at most the `UARTE_MAX_BUFFER_SIZE` bytes.
                     buf.slice(0..UARTE_MAX_BUFFER_SIZE);
                     // Send via DMA.
-                    self.registers.start_tx_dma(buf);
+                    let _ = self.registers.start_tx_dma(buf);
                     // Re-enable interrupts.
                     self.enable_tx_interrupts();
                 }
@@ -593,7 +617,7 @@ impl<'a> Uarte<'a> {
                         // Limit to at most the `UARTE_MAX_BUFFER_SIZE` bytes.
                         buf.slice(0..UARTE_MAX_BUFFER_SIZE);
                         // Receive via DMA.
-                        self.registers.start_rx_dma(buf);
+                        let _ = self.registers.start_rx_dma(buf);
                         // Re-enable interrupts.
                         self.enable_rx_interrupts();
                     }
@@ -650,7 +674,7 @@ impl<'a> Uarte<'a> {
 
         // Send the buffer using DMA. This is managed by the register manager to
         // ensure we are safely using DMA.
-        self.registers.start_tx_dma(slice_to_send);
+        let _ = self.registers.start_tx_dma(slice_to_send);
 
         // Enable interrupts so we get a interrupt when the transmission has
         // finished.
@@ -668,7 +692,7 @@ impl<'a> Uarte<'a> {
 
         // Use the buffer with DMA. This is managed by the register manager to
         // ensure we are safely using DMA.
-        self.registers.start_rx_dma(slice_to_receive);
+        let _ = self.registers.start_rx_dma(slice_to_receive);
 
         // Enable interrupts so we get a interrupt when the receive has
         // finished.

--- a/chips/virtio/src/devices/virtio_gpu/messages/mod.rs
+++ b/chips/virtio/src/devices/virtio_gpu/messages/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2025.
 
+use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::ErrorCode;
 
 pub(crate) mod ctrl_header;
@@ -24,6 +25,13 @@ pub trait VirtIOGPUReq {
         &self,
         dst: &mut impl Iterator<Item = &'a mut u8>,
     ) -> Result<(), ErrorCode>;
+
+    fn reset_and_write_to_sub_slice(&self, dst: &mut SubSliceMut<'_, u8>) -> Result<(), ErrorCode> {
+        dst.reset();
+        self.write_to_byte_iter(&mut dst.as_mut_slice().iter_mut())?;
+        dst.slice(0..Self::ENCODED_SIZE);
+        Ok(())
+    }
 }
 
 pub trait VirtIOGPUResp {

--- a/chips/virtio/src/queues/split_queue.rs
+++ b/chips/virtio/src/queues/split_queue.rs
@@ -388,7 +388,7 @@ impl<'b> VirtqueueDmaBuffer<'b> {
                 dma_sub_slice_mut_immut.as_ptr()
             }
             VirtqueueDmaBuffer::DeviceWriteable(dma_sub_slice_mut) => {
-                dma_sub_slice_mut.as_mut_ptr() as *const u8
+                dma_sub_slice_mut.as_mut_ptr().cast_const()
             }
         }
     }

--- a/chips/virtio/src/queues/split_queue.rs
+++ b/chips/virtio/src/queues/split_queue.rs
@@ -356,13 +356,13 @@ impl<'b> VirtqueueDmaBuffer<'b> {
     ) -> Self {
         match virtqueue_buffer {
             VirtqueueBuffer::DeviceReadable(sub_slice_mut_immut) => {
-                VirtqueueDmaBuffer::DeviceReadable(DmaSubSliceMutImmut::from_sub_slice_mut_immut(
+                VirtqueueDmaBuffer::DeviceReadable(DmaSubSliceMutImmut::new(
                     sub_slice_mut_immut,
                     fence,
                 ))
             }
             VirtqueueBuffer::DeviceWriteable(sub_slice_mut) => VirtqueueDmaBuffer::DeviceWriteable(
-                DmaSubSliceMut::from_sub_slice_mut(sub_slice_mut, fence),
+                DmaSubSliceMut::new_unsafe(sub_slice_mut, fence),
             ),
         }
     }
@@ -370,14 +370,10 @@ impl<'b> VirtqueueDmaBuffer<'b> {
     unsafe fn into_virtqueue_buffer(self, fence: impl DmaFence) -> VirtqueueBuffer<'b> {
         match self {
             VirtqueueDmaBuffer::DeviceReadable(dma_sub_slice_mut_immut) => {
-                VirtqueueBuffer::DeviceReadable(
-                    dma_sub_slice_mut_immut.restore_sub_slice_mut_immut(),
-                )
+                VirtqueueBuffer::DeviceReadable(dma_sub_slice_mut_immut.take())
             }
             VirtqueueDmaBuffer::DeviceWriteable(dma_sub_slice_mut) => {
-                VirtqueueBuffer::DeviceWriteable(unsafe {
-                    dma_sub_slice_mut.restore_sub_slice_mut(fence)
-                })
+                VirtqueueBuffer::DeviceWriteable(unsafe { dma_sub_slice_mut.take(fence) })
             }
         }
     }

--- a/chips/virtio/src/queues/split_queue.rs
+++ b/chips/virtio/src/queues/split_queue.rs
@@ -361,9 +361,9 @@ impl<'b> VirtqueueDmaBuffer<'b> {
                     fence,
                 ))
             }
-            VirtqueueBuffer::DeviceWriteable(sub_slice_mut) => VirtqueueDmaBuffer::DeviceWriteable(
-                DmaSubSliceMut::new_unsafe(sub_slice_mut, fence),
-            ),
+            VirtqueueBuffer::DeviceWriteable(sub_slice_mut) => {
+                VirtqueueDmaBuffer::DeviceWriteable(DmaSubSliceMut::new(sub_slice_mut, fence))
+            }
         }
     }
 

--- a/kernel/src/platform/dma_fence.rs
+++ b/kernel/src/platform/dma_fence.rs
@@ -1,0 +1,82 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Leon Schuermann <leon@is.currently.online> 2026.
+// Copyright Tock Contributors 2026.
+
+//! DMA fence synchronization primitives for sharing memory with DMA
+//! peripherals.
+
+/// Synchronization primitives for safely sharing memory with DMA peripherals.
+///
+/// An implementation of _acquire_ and _release_ memory fence operations to
+/// expose memory reads and writes by Rust and DMA peripherals to each other.
+/// These operations are from the perspective of Rust and the Tock kernel: a
+/// memory buffer is _released_ to the DMA peripheral, and then after the DMA
+/// operation is fully completed, _aquired_ back from the DMA peripheral.
+///
+/// When starting a DMA operation over a buffer prepared from Rust, it is
+/// important that the buffer's current contents are actually observable by the
+/// DMA hardware. Similarly, when a DMA operation is finished, we must ensure
+/// that Rust can see the latest buffer contents, as written by a DMA
+/// peripheral. However, instruction reordering by both the compiler, hardware,
+/// and non cache-coherent platforms complicate this story. These optimizations
+/// can mean that a write from within Rust may not be visible to a DMA
+/// peripheral, or a write performed by a DMA peripheral may not be visible to
+/// Rust.
+///
+/// This trait provides [`acquire`](Self::acquire) and
+/// [`release`](Self::release) memory fences that recover these guarantees for
+/// DMA buffers in the presence of compiler reordering and, if present on the
+/// target platform, hardware reordering or non-coherent caches.
+///
+/// Ordinarily, we'd use the built-in [`core::sync::atomic::fence`] for this,
+/// but that explicitly cannot be used to establish synchronization among
+/// non-atomic accesses. Additionally, certain platforms require
+/// platform-specific instructions to synchronize memory: for instance, the
+/// RISC-V unprivileged spec (version 20250508) states that "\[n\]on-coherent
+/// DMA may need additional synchronization (such as cache flush or invalidate
+/// mechanisms); currently any such extra synchronization will be
+/// device-specific" [1]. Therefore, Tock uses a DMA-specific trait implemented
+/// by its target architecture and platform crates.
+///
+/// [1]: https://docs.riscv.org/reference/isa/_attachments/riscv-unprivileged.pdf
+///
+/// # Implementations
+///
+/// Implementations may assume this trait is only used for DMA peripherals,
+/// where hardware has access to memory separate from normal load and store
+/// instructions executed on the CPU. Implementations do not need to provide
+/// any synchronization between loads and stores, for example to support
+/// multi-core execution. Implementations must correctly synchronize for all
+/// possible DMA operations on the chip.
+///
+/// Implementations may use any chip-specific DMA synchronization features that
+/// may exist on a particular microcontroller.
+///
+/// # Safety
+///
+/// This is an `unsafe` trait, as users of it rely on correct
+/// [`acquire`](Self::acquire) and [`release`](Self::acquire) implementations to
+/// maintain soundness. Specifically, an incorrect [`acquire`](Self::acquire)
+/// operation could cause DMA-issued writes to memory to be visible to Rust only
+/// *after* a shared or immutable reference to this buffer is made accessible,
+/// which effectively violates Rust's no-alias assumptions.
+pub unsafe trait DmaFence: core::fmt::Debug + Send + Sync + Copy {
+    /// Expose prior writes to in-memory buffers to subsequent DMA operations.
+    ///
+    /// Specifically, this function must ensure that any writes from Rust to the
+    /// buffer described by `ptr` and `len` _before_ this function, are visible
+    /// to any DMA operations initiated by an MMIO read or write operation
+    /// _after_ this function returns.
+    fn release<T>(self, buf: *mut [T]);
+
+    /// Expose prior writes by DMA peripherals to subsequent memory reads.
+    ///
+    /// Specifically, this function must ensure that any reads from Rust to the
+    /// buffer described by `ptr` and `len` _after_ this function returns
+    /// reflect all writes made by DMA operations finished _before_ this
+    /// function ran. Implementations can assume that this function is called
+    /// _after_ the program observed that the DMA operation finished, by reading
+    /// a status field through an MMIO or memory read.
+    fn acquire<T>(self, buf: *mut [T]);
+}

--- a/kernel/src/platform/dma_fence.rs
+++ b/kernel/src/platform/dma_fence.rs
@@ -57,10 +57,13 @@
 ///
 /// This is an `unsafe` trait, as users of it rely on correct
 /// [`acquire`](Self::acquire) and [`release`](Self::acquire) implementations to
-/// maintain soundness. Specifically, an incorrect [`acquire`](Self::acquire)
-/// operation could cause DMA-issued writes to memory to be visible to Rust only
-/// *after* a shared or immutable reference to this buffer is made accessible,
-/// which effectively violates Rust's no-alias assumptions.
+/// maintain soundness.
+///
+/// Incorrect implementations of this trait can introduce undefined
+/// behavior. For example, an incorrect [`acquire`](Self::acquire) operation
+/// could cause DMA-issued writes to memory to be visible to Rust only *after* a
+/// shared or immutable reference to this buffer is made accessible, which
+/// effectively violates Rust's no-alias assumptions.
 pub unsafe trait DmaFence: core::fmt::Debug + Send + Sync + Copy {
     /// Expose prior writes to in-memory buffers to subsequent DMA operations.
     ///

--- a/kernel/src/platform/dma_fence.rs
+++ b/kernel/src/platform/dma_fence.rs
@@ -12,7 +12,7 @@
 /// expose memory reads and writes by Rust and DMA peripherals to each other.
 /// These operations are from the perspective of Rust and the Tock kernel: a
 /// memory buffer is _released_ to the DMA peripheral, and then after the DMA
-/// operation is fully completed, _aquired_ back from the DMA peripheral.
+/// operation is fully completed, _acquired_ back from the DMA peripheral.
 ///
 /// When starting a DMA operation over a buffer prepared from Rust, it is
 /// important that the buffer's current contents are actually observable by the
@@ -69,17 +69,15 @@ pub unsafe trait DmaFence: core::fmt::Debug + Send + Sync + Copy {
     ///
     /// Specifically, this function must ensure that any writes from Rust to the
     /// buffer described by `ptr` and `len` _before_ this function, are visible
-    /// to any DMA operations initiated by an MMIO read or write operation
-    /// _after_ this function returns.
+    /// to any DMA operations, as long as these operations are initiated by MMIO read or write operations issued _after_ this function returns.
     fn release<T>(self, buf: *mut [T]);
 
     /// Expose prior writes by DMA peripherals to subsequent memory reads.
     ///
-    /// Specifically, this function must ensure that any reads from Rust to the
-    /// buffer described by `ptr` and `len` _after_ this function returns
+    /// Specifically, this function must ensure that any Rust reads of the buffer described by `ptr` and `len`, performed _after_ this function returns,
     /// reflect all writes made by DMA operations finished _before_ this
-    /// function ran. Implementations can assume that this function is called
-    /// _after_ the program observed that the DMA operation finished, by reading
-    /// a status field through an MMIO or memory read.
+    /// function ran.
+    ///
+    /// This function must be called _after_ the program has observed that the DMA operation finished, by reading a status field through an MMIO or memory read.
     fn acquire<T>(self, buf: *mut [T]);
 }

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -7,6 +7,7 @@
 //! Implementations of these traits are used by the core kernel.
 
 pub mod chip;
+pub mod dma_fence;
 pub mod mpu;
 pub mod scheduler_timer;
 pub mod watchdog;

--- a/kernel/src/utilities/copy_range.rs
+++ b/kernel/src/utilities/copy_range.rs
@@ -1,0 +1,35 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+//! A copyable twin of `core::ops::Range`.
+
+use core::ops::Range;
+
+/// A copyable twin of `core::ops::Range`.
+///
+/// This is useful to be able to store an equivalent of
+/// [`core::ops::Range`] in a type with `#[derive(Copy)]`
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct CopyRange<Idx> {
+    pub start: Idx,
+    pub end: Idx,
+}
+
+impl<Idx> From<Range<Idx>> for CopyRange<Idx> {
+    fn from(r: Range<Idx>) -> Self {
+        CopyRange {
+            start: r.start,
+            end: r.end,
+        }
+    }
+}
+
+impl<Idx> From<CopyRange<Idx>> for Range<Idx> {
+    fn from(c: CopyRange<Idx>) -> Self {
+        Range {
+            start: c.start,
+            end: c.end,
+        }
+    }
+}

--- a/kernel/src/utilities/dma_slice.rs
+++ b/kernel/src/utilities/dma_slice.rs
@@ -1,0 +1,898 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Leon Schuermann <leon@is.currently.online> 2026.
+// Copyright Tock Contributors 2026.
+
+//! Mechanism for sharing buffers with DMA peripherals.
+
+use core::marker::PhantomData;
+use core::ops::Range;
+use core::ptr::{self, NonNull};
+
+use super::leasable_buffer::{SubSlice, SubSliceMut, SubSliceMutImmut};
+use crate::platform::dma_fence::DmaFence;
+
+/// An immutable buffer that can be safely used for read-only DMA operations.
+///
+/// Creating a [`DmaSlice`] over an immutable Rust slice ensures that all prior
+/// Rust writes to this slice are observable by any DMA operations initiated
+/// through an MMIO write operation, where that MMIO write is performed after
+/// constructing the [`DmaSlice`].
+///
+/// For this guarantee to hold, the [`DmaSlice`] struct must exist for the
+/// duration of the entire DMA operation, until the Rust program has observed
+/// that the operation is complete (such as by reading a status bit in memory or
+/// an MMIO register).
+///
+/// [`DmaSlice`] wraps an immutable, shared Rust slice reference. As such, its
+/// contents must not be modified by the DMA operation. For a DMA operation that
+/// may write to the supplied buffer, use [`DmaSliceMut`] instead.
+#[derive(Debug)]
+pub struct DmaSlice<'a, T> {
+    slice: &'a [T],
+}
+
+impl<'a, T> DmaSlice<'a, T> {
+    /// Create a [`DmaSlice`] from a shared, immutable Rust slice.
+    ///
+    /// This function uses the supplied `fence` object to ensure that all prior
+    /// writes to `slice` are exposed to any DMA operations initiated by an MMIO
+    /// read or write operation after this function returns, and which finish
+    /// before the resulting [`DmaSlice`] is dropped.
+    pub fn from_slice_ref(slice: &[T], fence: impl DmaFence) -> DmaSlice<'_, T> {
+        // Ensure that all prior writes to this slice are exposed to any DMA
+        // operations initiated by an MMIO read or write operation after this
+        // function returns.
+        fence.release::<T>(ptr::from_ref(slice) as *mut [T]);
+
+        DmaSlice { slice }
+    }
+
+    /// Returns the pointer to the first element of the wrapped slice reference.
+    pub fn as_ptr(&self) -> *const T {
+        self.slice.as_ptr()
+    }
+
+    /// Returns the length of the wrapped slice reference.
+    pub fn len(&self) -> usize {
+        self.slice.len()
+    }
+
+    /// Retrieve the inner slice reference.
+    pub fn as_slice_ref(&self) -> &'a [T] {
+        self.slice
+    }
+}
+
+/// A mutable buffer that can be safely used for DMA operations that read from
+/// and/or write to the buffer's contents.
+///
+/// Creating a [`DmaSliceMut`] over a mutable Rust slice ensures that all prior
+/// Rust writes to this slice are observable by any DMA operations initiated
+/// through an MMIO write operation, where that MMIO write is performed
+/// **after** constructing the `DmaSliceMut`. All writes by the DMA operation
+/// will be observable by Rust when calling
+/// [`restore_mut_slice_ref`](Self::restore_mut_slice_ref) **after** the DMA
+/// operation is finished.
+///
+/// # Safety Considerations
+///
+/// Users **must** eventually call
+/// [`restore_mut_slice_ref`](Self::restore_mut_slice_ref) to retrieve the
+/// underlying buffer. The [`DmaSliceMut`] must exist for the entire duration of
+/// the DMA operation. Users must never drop a [`DmaSliceMut`] with a
+/// non-`'static` lifetime, as this could provide access to the underlying
+/// buffer without guaranteeing that the DMA operation has finished, and without
+/// issuing a DMA memory fence to ensure that writes by the DMA operation are
+/// visible to Rust.
+///
+/// [`restore_mut_slice_ref`](Self::restore_mut_slice_ref) must only be called
+/// after the DMA operation has been observed to be complete (such as through a
+/// memory or MMIO read). Callers must ensure that the hardware will not perform
+/// any further writes to the buffer at the point where
+/// [`restore_mut_slice_ref`](Self::restore_mut_slice_ref) is called.
+///
+/// Callers must further ensure that they start DMA operations only after
+/// constructing the [`DmaSliceMut`], and only in the memory region described by
+/// [`as_mut_ptr`](Self::as_mut_ptr) and [`len`](Self::len).
+///
+/// Users are responsible to ensure that, after the DMA operation completes and
+/// before calling [`restore_mut_slice_ref`](Self::restore_mut_slice_ref), every
+/// element in the underlying slice represents a well-initialized and valid
+/// instance of its type (with the exception of padding bytes). See the
+/// [zerocopy crate](https://docs.rs/zerocopy/0.8.31/zerocopy/) for an more
+/// in-depth explanation of these requirements.
+#[derive(Debug)]
+pub struct DmaSliceMut<'a, T> {
+    slice_ptr: NonNull<[T]>,
+    _lt: PhantomData<&'a mut [T]>,
+}
+
+impl<'a, T> DmaSliceMut<'a, T> {
+    /// Create a [`DmaSliceMut`] from a unique, mutable Rust slice.
+    ///
+    /// This function uses the supplied `fence` object to ensure that all prior
+    /// writes to `slice` are exposed to any DMA operations initiated by an MMIO
+    /// read or write operation after this function returns, and which finish
+    /// before calling [`restore_mut_slice_ref`](Self::restore_mut_slice_ref).
+    ///
+    /// # Safety
+    ///
+    /// Refer the safety documentation of the [`DmaSliceMut`] type.
+    ///
+    /// This function is unsafe, as dropping or
+    /// [`forget`](core::mem::forget)ting its return value is not allowed when
+    /// the lifetime `'b` is not `'static`. Users **must** eventually call
+    /// [`restore_mut_slice_ref`](Self::restore_mut_slice_ref) to retrieve the
+    /// underlying buffer.
+    #[must_use]
+    pub unsafe fn from_mut_slice_ref(slice: &mut [T], fence: impl DmaFence) -> DmaSliceMut<'_, T> {
+        let dma_slice_mut = DmaSliceMut {
+            slice_ptr: NonNull::from_mut(slice),
+            _lt: PhantomData,
+        };
+
+        // Ensure that all prior writes to this slice are exposed to any DMA
+        // operations initiated by an MMIO read or write operation after this
+        // function returns:
+        fence.release::<T>(dma_slice_mut.slice_ptr.as_ptr());
+
+        dma_slice_mut
+    }
+
+    /// Create a [`DmaSliceMut`] from a unique, mutable Rust slice with
+    /// `'static` lifetime.
+    ///
+    /// This function uses the supplied `fence` object to ensure that all prior
+    /// writes to `slice` are exposed to any DMA operations initiated by an MMIO
+    /// read or write operation after this function returns, and which finish
+    /// before calling [`restore_mut_slice_ref`](Self::restore_mut_slice_ref).
+    ///
+    /// # Comparsion with [`from_mut_slice_ref`](Self::from_mut_slice_ref)
+    ///
+    /// In contrast to [`from_mut_slice_ref`](Self::from_mut_slice_ref) this
+    /// function is safe, as dropping or forgetting its return value is safe, it
+    /// would merely leak memory and make the underlying slice inaccessible.
+    ///
+    /// The other safety considerations of the [`DmaSliceMut`] type still apply.
+    pub fn from_static_mut_slice_ref(
+        slice: &'static mut [T],
+        fence: impl DmaFence,
+    ) -> DmaSliceMut<'static, T> {
+        unsafe { Self::from_mut_slice_ref(slice, fence) }
+    }
+
+    /// Returns the pointer to the first element of the wrapped slice reference.
+    pub fn as_mut_ptr(&self) -> *mut T {
+        // TODO: switch `.cast()` to `.as_mut_ptr()` on the slice pointer (`*mut
+        // [T]`) to obtain the "thin", raw pointer to its first element. This is
+        // blocked on the nightly `slice_ptr_get` feature.
+        self.slice_ptr.as_ptr().cast()
+    }
+
+    /// Returns the length of the wrapped slice reference.
+    pub fn len(&self) -> usize {
+        self.slice_ptr.len()
+    }
+
+    /// Recover the original, unique (mutable) slice used to construct this
+    /// [`DmaSliceMut`] object.
+    ///
+    /// This function uses the supplied `fence` object to ensure that all prior
+    /// writes to `slice` by any completed DMA operations are exposed to any
+    /// subsequent Rust reads.
+    ///
+    /// # Safety
+    ///
+    /// Refer the safety documentation of the [`DmaSliceMut`] type.
+    ///
+    /// In particular, [`restore_mut_slice_ref`](Self::restore_mut_slice_ref)
+    /// must only be called after the DMA operation has been observed to be
+    /// complete (such as through a memory or MMIO read). Callers must ensure
+    /// that the hardware will not perform any further writes to the buffer at
+    /// the point where [`restore_mut_slice_ref`](Self::restore_mut_slice_ref)
+    /// is called.
+    pub unsafe fn restore_mut_slice_ref(mut self, fence: impl DmaFence) -> &'a mut [T] {
+        // Ensure that any reads from Rust to the buffer described by
+        // `slice_ptr` _after_ this function returns reflect all writes made by
+        // DMA operations finished _before_ this function ran:
+        fence.acquire::<T>(self.slice_ptr.as_ptr());
+
+        unsafe { self.slice_ptr.as_mut() }
+    }
+}
+
+/// A buffer that can be safely used for read-only DMA operations, backed by
+/// either a shared (immutable) or unique (mutable) Rust slice.
+///
+/// Creating a [`DmaSliceMutImmut`] over a Rust slice ensures that all prior
+/// Rust writes to this slice are observable by any DMA operations initiated
+/// through an MMIO write operation, where that MMIO write is performed after
+/// constructing the `DmaSliceMutImmut`.
+///
+/// For this guarantee to hold, the `DmaSliceMutImmut` instance must exist for
+/// the duration of the entire DMA operation, until the Rust program has
+/// observed that the operation is complete (such as by reading a status bit in
+/// memory or an MMIO register).
+///
+/// [`DmaSliceMutImmut`] may wrap an immutable, shared Rust slice
+/// reference. Furthermore, in contrast to `DmaSliceMut`, `DmaSliceMutImmut`
+/// may not expose writes performed by a DMA operation back to Rust. As such,
+/// its contents *must* not be modified by the DMA operation. For a DMA
+/// operation that may write to the supplied buffer, use [`DmaSliceMut`]
+/// instead.
+#[derive(Debug)]
+pub enum DmaSliceMutImmut<'a, T> {
+    Immutable(DmaSlice<'a, T>),
+    Mutable(DmaSliceMut<'a, T>),
+}
+
+impl<'a, T> DmaSliceMutImmut<'a, T> {
+    /// Create a [`DmaSliceMutImmut`] from a shared, immutable Rust slice.
+    ///
+    /// This function uses the supplied `fence` object to ensure that all prior
+    /// writes to `slice` are exposed to any DMA operations initiated by an MMIO
+    /// read or write operation after this function returns, and which finish
+    /// before the resulting [`DmaSliceMutImmut`] is dropped.
+    pub fn from_slice_ref(slice: &[T], fence: impl DmaFence) -> DmaSliceMutImmut<'_, T> {
+        DmaSliceMutImmut::Immutable(DmaSlice::from_slice_ref(slice, fence))
+    }
+
+    /// Create a [`DmaSliceMutImmut`] from a unique, mutable Rust slice.
+    ///
+    /// This function uses the supplied `fence` object to ensure that all prior
+    /// writes to `slice` are exposed to any DMA operations initiated by an MMIO
+    /// read or write operation after this function returns, and which finish
+    /// before the resulting [`DmaSliceMutImmut`] is dropped.
+    ///
+    /// Even though this method takes a unique, mutable Rust slice, DMA
+    /// operations must not modify the buffers contents.
+    pub fn from_mut_slice_ref(slice: &mut [T], fence: impl DmaFence) -> DmaSliceMutImmut<'_, T> {
+        // # Safety
+        //
+        // `DmaSliceMut::from_mut_slice_ref` is unsafe, as dropping its return
+        // value without calling `restore_mut_slice_ref` may make the underlying
+        // buffer accessible as a Rust slice, potentially before the DMA
+        // operation is complete, and without using `fence.acquire` to make DMA
+        // writes visible to Rust. However, this struct does not permit DMA
+        // operations which write to the slice, and hence it can be safely
+        // dropped without risk of concurrent modifications or incoherence.
+        DmaSliceMutImmut::Mutable(unsafe { DmaSliceMut::from_mut_slice_ref(slice, fence) })
+    }
+
+    /// Returns the pointer to the first element of the wrapped slice reference.
+    pub fn as_ptr(&self) -> *const T {
+        match self {
+            DmaSliceMutImmut::Immutable(dma_slice) => dma_slice.as_ptr(),
+            DmaSliceMutImmut::Mutable(dma_slice_mut) => dma_slice_mut.as_mut_ptr() as *const T,
+        }
+    }
+
+    /// Returns the length of the wrapped slice reference.
+    pub fn len(&self) -> usize {
+        match self {
+            DmaSliceMutImmut::Immutable(dma_slice) => dma_slice.len(),
+            DmaSliceMutImmut::Mutable(dma_slice_mut) => dma_slice_mut.len(),
+        }
+    }
+
+    /// Retrieve the inner slice reference.
+    pub fn as_slice_ref(&self) -> &'a [T] {
+        match self {
+            DmaSliceMutImmut::Immutable(dma_slice) => dma_slice.as_slice_ref(),
+            DmaSliceMutImmut::Mutable(dma_slice_mut) => unsafe {
+                // # Safety
+                //
+                // Over the duration that [`DmaSliceMutImmut`] the user
+                // guarantees that no DMA operation modifies the buffer (and
+                // doing so would require an MMIO write, which is itself
+                // unsafe). The `dma_slice_mut` is capturing a unique, mutable
+                // borrow of the underlying slice over its lifetime `'a`. As
+                // such, we can safely hand out immutable references over this
+                // slice, which are also bound to the lifetime `'a`.
+                core::slice::from_raw_parts(
+                    dma_slice_mut.as_mut_ptr() as *const T,
+                    dma_slice_mut.len(),
+                )
+            },
+        }
+    }
+}
+
+/// An immutable buffer that can be safely used for read-only DMA operations,
+/// created from a `SubSlice` describing an active range in a larger buffer.
+///
+/// Creating a [`DmaSubSlice`] over a [`SubSlice`] ensures that all prior Rust
+/// writes to the active region of this slice are observable by any DMA
+/// operations initiated through an MMIO write operation, where that MMIO write
+/// is performed *after* constructing the `DmaSubSlice`.
+///
+/// For this guarantee to hold, the `DmaSubSlice` struct must exist for the
+/// duration of the entire DMA operation, until the Rust program has observed
+/// that the operation is complete (such as by reading a status bit in memory or
+/// an MMIO register).
+///
+/// [`DmaSubSlice`] wraps an immutable, shared Rust slice reference. As such,
+/// its contents must not be modified by the DMA operation. For a DMA operation
+/// that may write to the supplied buffer, use [`DmaSubSliceMut`] instead.
+#[derive(Debug)]
+pub struct DmaSubSlice<'a, T> {
+    sub_slice: SubSlice<'a, T>,
+}
+
+impl<'a, T> DmaSubSlice<'a, T> {
+    /// Create a [`DmaSubSlice`] from a shared, immutable Rust slice.
+    ///
+    /// This function uses the supplied `fence` object to ensure that all prior
+    /// writes to `slice` are exposed to any DMA operations initiated by an MMIO
+    /// read or write operation after this function returns, and which finish
+    /// before the resulting [`DmaSubSlice`] is dropped.
+    pub fn from_sub_slice(sub_slice: SubSlice<'_, T>, fence: impl DmaFence) -> DmaSubSlice<'_, T> {
+        // Ensure that all prior writes to this slice are exposed to any DMA
+        // operations initiated by an MMIO read or write operation after this
+        // function returns:
+        //
+        // Clippy says we should be using `.as_mut_ptr()` instead of `.as_ptr()
+        // as *mut T`, but that method doesn't exist. The cast doesn't matter
+        // here, `DmaFence::release` will not actually dereference the memory.
+        #[allow(clippy::as_ptr_cast_mut)]
+        fence.release::<T>(ptr::slice_from_raw_parts_mut(
+            // `SubSlice::as_ptr()` returns a pointer to the currently
+            // accessible portion of the `SubSlice`.
+            sub_slice.as_ptr() as *mut T,
+            // `SubSlice::len()` returns the length of the currently accessible
+            // portion of the `SubSlice`.
+            sub_slice.len(),
+        ));
+
+        DmaSubSlice { sub_slice }
+    }
+
+    /// Returns the pointer to the first element of the currently accessible
+    /// portion of the wrapped `SubSlice`.
+    pub fn as_ptr(&self) -> *const T {
+        self.sub_slice.as_ptr()
+    }
+
+    /// Returns the length of the currently accessible range of the wrapped
+    /// `SubSlice`.
+    pub fn len(&self) -> usize {
+        self.sub_slice.len()
+    }
+
+    /// Retrieve the wrapped `SubSlice`.
+    pub fn as_sub_slice(&self) -> SubSlice<'a, T> {
+        self.sub_slice
+    }
+}
+
+/// An mutable buffer that can be safely used for DMA operations that read from
+/// and/or write to the buffer's contents.
+///
+/// Creating a [`DmaSubSliceMut`] over a [`SubSliceMut`] ensures that all prior
+/// Rust writes to this slice's active range are observable by any DMA
+/// operations initiated through an MMIO write operation, where that MMIO write
+/// is performed **after** constructing the `DmaSubSliceMut`. All writes by the
+/// DMA operation will be observable by Rust when calling
+/// [`restore_sub_slice_mut`](Self::restore_sub_slice_mut) **after** the DMA
+/// operation is finished.
+///
+/// # Safety
+///
+/// Users **must** eventually call
+/// [`restore_sub_slice_mut`](Self::restore_sub_slice_mut) to retrieve the
+/// underlying buffer. The [`DmaSubSliceMut`] must exist for the entire duration
+/// of the DMA operation. Users must never drop a [`DmaSubSliceMut`] with a
+/// non-`'static` lifetime, as this could provide access to the underlying
+/// buffer without guaranteeing that the DMA operation has finished, and without
+/// issuing a DMA memory fence to ensure that writes by the DMA operation are
+/// visible to Rust.
+///
+/// [`restore_sub_slice_mut`](Self::restore_sub_slice_mut) must only be called
+/// after the DMA operation has been observed to be complete (such as through a
+/// memory or MMIO read). Callers must ensure that the hardware will not perform
+/// any further writes to the buffer at the point where
+/// [`restore_sub_slice_mut`](Self::restore_sub_slice_mut) is called.
+///
+/// Callers must further ensure that they start DMA operations only after
+/// constructing the [`DmaSubSliceMut`], and only in the memory region described
+/// by [`as_mut_ptr`](Self::as_mut_ptr) and [`len`](Self::len).
+///
+/// Users are responsible to ensure that, after the DMA operation completes and
+/// before calling [`restore_mut_slice_ref`](Self::restore_sub_slice_mut), every
+/// element in the underlying slice represents a well-initialized and valid
+/// instance of its type (with the exception of padding bytes). See the
+/// [zerocopy crate](https://docs.rs/zerocopy/0.8.31/zerocopy/) for an more
+/// in-depth explanation of these requirements.
+#[derive(Debug)]
+pub struct DmaSubSliceMut<'a, T> {
+    internal_slice_ptr: NonNull<[T]>,
+    active_range: Range<usize>,
+    _lt: PhantomData<&'a mut [T]>,
+}
+
+impl<'a, T> DmaSubSliceMut<'a, T> {
+    /// Create a [`DmaSubSliceMut`] from a [`SubSliceMut`].
+    ///
+    /// This function uses the supplied `fence` object to ensure that all prior
+    /// writes to the active region of `slice` are exposed to any DMA operations
+    /// initiated by an MMIO read or write operation after this function
+    /// returns, and which finish before calling
+    /// [`restore_sub_slice_mut`](Self::restore_sub_slice_mut).
+    ///
+    /// # Safety
+    ///
+    /// Refer the safety documentation of the [`DmaSubSliceMut`] type.
+    ///
+    /// This function is unsafe, as dropping or
+    /// [`forget`](core::mem::forget)ting its return value is not allowed when
+    /// the lifetime `'b` is not `'static`. Users **must** eventually call
+    /// [`restore_sub_slice_mut`](Self::restore_sub_slice_mut) to retrieve the
+    /// underlying buffer.
+    #[must_use]
+    pub unsafe fn from_sub_slice_mut(
+        sub_slice_mut: SubSliceMut<'_, T>,
+        fence: impl DmaFence,
+    ) -> DmaSubSliceMut<'_, T> {
+        let active_range = sub_slice_mut.active_range();
+        let internal_slice_ptr = sub_slice_mut.take();
+
+        // Store only a fat raw pointer to the inner slice:
+        let dma_sub_slice_mut = DmaSubSliceMut {
+            internal_slice_ptr: NonNull::from_mut(internal_slice_ptr),
+            active_range,
+            _lt: PhantomData,
+        };
+
+        // Ensure that all prior writes to the currently active portion of this
+        // SubSliceMut are exposed to any DMA operations initiated by an MMIO
+        // read or write operation after this function returns:
+        fence.release::<T>(ptr::slice_from_raw_parts_mut(
+            dma_sub_slice_mut.as_mut_ptr(),
+            dma_sub_slice_mut.len(),
+        ));
+
+        dma_sub_slice_mut
+    }
+
+    /// Create a [`DmaSubSliceMut`] from a [`SubSliceMut`] with `'static`
+    /// lifetime.
+    ///
+    /// This function uses the supplied `fence` object to ensure that all prior
+    /// writes to `slice` are exposed to any DMA operations initiated by an MMIO
+    /// read or write operation after this function returns, and which finish
+    /// before calling [`restore_sub_slice_mut`](Self::restore_sub_slice_mut).
+    ///
+    /// # Safety
+    ///
+    /// Refer the safety documentation of the [`DmaSubSliceMut`] type.
+    ///
+    /// In contrast to `from_slice_ref` this function is safe, as dropping or
+    /// forgetting its return value is safe, it would merely leak memory and
+    /// make the underlying slice inaccessible.
+    pub fn from_static_sub_slice_mut(
+        sub_slice: SubSliceMut<'static, T>,
+        fence: impl DmaFence,
+    ) -> DmaSubSliceMut<'static, T> {
+        unsafe { Self::from_sub_slice_mut(sub_slice, fence) }
+    }
+
+    /// Returns the pointer to the first element of the active range of the
+    /// wrapped [`SubSliceMut`].
+    pub fn as_mut_ptr(&self) -> *mut T {
+        // TODO: switch `.cast()` to `.as_mut_ptr()` on the slice pointer (`*mut
+        // [T]`) to obtain the "thin", raw pointer to its first element. This is
+        // blocked on the nightly `slice_ptr_get` feature.
+        self.internal_slice_ptr.as_ptr().cast::<T>().wrapping_add(
+            if self.active_range.start >= self.internal_slice_ptr.len() {
+                // `range.start` is out of bounds, return a pointer that's one
+                // after the last byte in this buffer, and length `0`:
+                self.internal_slice_ptr.len()
+            } else {
+                // Start is in bounds:
+                self.active_range.start
+            },
+        )
+    }
+
+    /// Returns the length of the active range of the wrapped [`SubSliceMut`].
+    pub fn len(&self) -> usize {
+        core::cmp::min(
+            self.active_range
+                .end
+                .saturating_sub(self.active_range.start),
+            self.internal_slice_ptr.len(),
+        )
+    }
+
+    /// Recover the original [`SubSliceMut`] used to construct this
+    /// [`DmaSubSliceMut`] object.
+    ///
+    /// This function uses the supplied `fence` object to ensure that all prior
+    /// writes to the active range of `slice` by any completed DMA operations
+    /// are exposed to any subsequent Rust reads.
+    ///
+    /// # Safety
+    ///
+    /// Refer the safety documentation of the [`DmaSubSliceMut`] type.
+    ///
+    /// In particular, [`restore_sub_slice_mut`](Self::restore_sub_slice_mut)
+    /// must only be called after the DMA operation has been observed to be
+    /// complete (such as through a memory or MMIO read). Callers must ensure
+    /// that the hardware will not perform any further writes to the buffer at
+    /// the point where [`restore_sub_slice_mut`](Self::restore_sub_slice_mut)
+    /// is called.
+    pub unsafe fn restore_sub_slice_mut(mut self, fence: impl DmaFence) -> SubSliceMut<'a, T> {
+        // Ensure that any reads from Rust to the active range of the buffer
+        // (described by `self.as_mut_ptr()` and `self.len()`) _after_ this
+        // function returns reflect all writes made by DMA operations finished
+        // _before_ this function ran:
+        fence.acquire::<T>(ptr::slice_from_raw_parts_mut(self.as_mut_ptr(), self.len()));
+
+        // Restore the original `SubSliceMut` configuration:
+        let mut sub_slice_mut = SubSliceMut::new(unsafe { self.internal_slice_ptr.as_mut() });
+        sub_slice_mut.slice(self.active_range);
+        sub_slice_mut
+    }
+
+    /// Recover the original [`SubSliceMut`] used to construct this
+    /// [`DmaSubSliceMut`] object, without performing an acquire DMA fence.
+    ///
+    /// # Safety
+    ///
+    /// Refer the safety documentation of the [`DmaSubSliceMut`] type.
+    ///
+    /// This function does not necessarily expose any writes to the underlying
+    /// buffer to Rust. It must only be used when the underlying buffer's
+    /// contents have not been modified by a DMA operation (i.e., any DMA
+    /// operations operating on the buffer while this `DmaSubSliceMut` existed
+    /// were read-only).
+    unsafe fn restore_sub_slice_mut_no_acquire(mut self) -> SubSliceMut<'a, T> {
+        // Restore the original `SubSliceMut` configuration:
+        let mut sub_slice_mut = SubSliceMut::new(unsafe { self.internal_slice_ptr.as_mut() });
+        sub_slice_mut.slice(self.active_range);
+        sub_slice_mut
+    }
+}
+
+/// A buffer that can be safely used for read-only DMA operations, backed by
+/// either a [`SubSliceMutImmut`].
+///
+/// Creating a [`DmaSubSliceMutImmut`] over a [`SubSliceMutImmut`] ensures that all
+/// prior Rust writes to the active region of this slice are observable by any
+/// DMA operations initiated through an MMIO write operation, where that MMIO
+/// write is performed *after* constructing the `DmaSubSliceMutImmut`.
+///
+/// For this guarantee to hold, the `DmaSubSliceMutImmut` struct must exist for the
+/// duration of the entire DMA operation, until the Rust program has observed
+/// that the operation is complete (such as by reading a status bit in memory or
+/// an MMIO register).
+///
+/// [`DmaSliceMutImmut`] may wrap an immutable, shared Rust slice
+/// reference. Furthermore, in contrast to `DmaSubSliceMut`,
+/// `DmaSubSliceMutImmut` may not expose writes performed by a DMA operation
+/// back to Rust. As such, its contents *must* not be modified by the DMA
+/// operation. For a DMA operation that may write to the active range of the
+/// supplied sub slice, use [`DmaSubSliceMut`] instead.
+#[derive(Debug)]
+pub enum DmaSubSliceMutImmut<'a, T> {
+    Immutable(DmaSubSlice<'a, T>),
+    Mutable(DmaSubSliceMut<'a, T>),
+}
+
+impl<'a, T> DmaSubSliceMutImmut<'a, T> {
+    /// Create a [`DmaSubSliceMutImmut`] from a [`SubSliceMutImmut`].
+    ///
+    /// This function uses the supplied `fence` object to ensure that all prior
+    /// writes to `slice` are exposed to any DMA operations initiated by an MMIO
+    /// read or write operation after this function returns, and which finish
+    /// before the resulting [`DmaSubSlice`] is dropped.
+    pub fn from_sub_slice_mut_immut(
+        sub_slice: SubSliceMutImmut<'_, T>,
+        fence: impl DmaFence,
+    ) -> DmaSubSliceMutImmut<'_, T> {
+        match sub_slice {
+            SubSliceMutImmut::Immutable(sub_slice) => {
+                DmaSubSliceMutImmut::Immutable(DmaSubSlice::from_sub_slice(sub_slice, fence))
+            }
+            SubSliceMutImmut::Mutable(sub_slice_mut) => DmaSubSliceMutImmut::Mutable(unsafe {
+                // # Safety
+                //
+                // `DmaSubSliceMut::from_sub_slice_mut` is unsafe, as dropping
+                // its return value without calling `restore_sub_slice_mut` may
+                // make the underlying buffer accessible as a Rust slice,
+                // potentially before the DMA operation is complete, and without
+                // using `fence.acquire` to make DMA writes visible to
+                // Rust. However, this struct does not permit DMA operations
+                // which write to the slice, and hence it can be safely dropped
+                // without risk of concurrent modifications or incoherence.
+                DmaSubSliceMut::from_sub_slice_mut(sub_slice_mut, fence)
+            }),
+        }
+    }
+
+    /// Returns the pointer to the first element of the currently accessible
+    /// portion of the wrapped `SubSlice`.
+    pub fn as_ptr(&self) -> *const T {
+        match self {
+            DmaSubSliceMutImmut::Immutable(dma_sub_slice) => dma_sub_slice.as_ptr(),
+            DmaSubSliceMutImmut::Mutable(dma_sub_slice_mut) => {
+                dma_sub_slice_mut.as_mut_ptr() as *const T
+            }
+        }
+    }
+
+    /// Returns the length of the currently accessible range of the wrapped
+    /// `SubSlice`.
+    pub fn len(&self) -> usize {
+        match self {
+            DmaSubSliceMutImmut::Immutable(dma_sub_slice) => dma_sub_slice.len(),
+            DmaSubSliceMutImmut::Mutable(dma_sub_slice_mut) => dma_sub_slice_mut.len(),
+        }
+    }
+
+    /// Reconstruct the original `SubSliceMutImmut`.
+    ///
+    /// This function must be called only when the Rust program has observed
+    /// that the DMA operation over the buffer is complete (such as by reading a
+    /// status bit in memory or an MMIO register). Otherwise, any future reads
+    /// by the DMA peripheral may not be consistent with the buffer contents.
+    pub fn restore_sub_slice_mut_immut(self) -> SubSliceMutImmut<'a, T> {
+        // We don't need to perform an `acquire` fence, as any DMA operation on
+        // the underlying slice must not have changed its contents:
+        match self {
+            DmaSubSliceMutImmut::Immutable(dma_sub_slice) => {
+                SubSliceMutImmut::Immutable(dma_sub_slice.as_sub_slice())
+            }
+            DmaSubSliceMutImmut::Mutable(dma_sub_slice_mut) => SubSliceMutImmut::Mutable(unsafe {
+                // # Safety
+                //
+                // The user guarantees that there has not been any DMA operation
+                // that changed the buffers contents while the
+                // `DmaSubSliceMutImmut` existed, and hence restoring a unique
+                // Rust slice through `restore_sub_slice_mut` is safe. No
+                // acquire-fence is needed, given the bufer contents have not
+                // been modified.
+                dma_sub_slice_mut.restore_sub_slice_mut_no_acquire()
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod miri_tests {
+    use core::ptr;
+
+    use super::super::leasable_buffer::{SubSlice, SubSliceMut};
+    use super::{DmaSlice, DmaSliceMut, DmaSubSlice, DmaSubSliceMut};
+
+    /// A mock fence that does nothing, as Miri operations are sequential within
+    /// a single thread for this test.
+    #[derive(Debug, Clone, Copy)]
+    struct MockFence {
+        _private: (),
+    }
+
+    impl MockFence {
+        /// `MockFence` does not actually deliver any guarantees and is only
+        /// used for testing, thus make it unsafe to construct:
+        unsafe fn new() -> Self {
+            MockFence { _private: () }
+        }
+    }
+
+    unsafe impl super::DmaFence for MockFence {
+        fn release<T>(self, _buf: *mut [T]) {
+            // In a real system, this flushes caches. In Miri, memory is
+            // perfectly coherent, and our "DMA" reads are simply raw pointer
+            // reads.
+        }
+
+        fn acquire<T>(self, _buf: *mut [T]) {
+            // In a real system, this invalidates caches. In Miri, memory is
+            // perfectly coherent, and our "DMA" writes are simply raw pointer
+            // writes.
+        }
+    }
+
+    // Helper to simulate a DMA peripheral writing to memory. This writes to the
+    // memory using the pointer exposed by the DMA wrapper, which is legal
+    // because the wrapper owns the mutable borrow.
+    unsafe fn simulate_dma_write<T: Copy>(dst: *mut T, val: T, offset: usize) {
+        let target = dst.add(offset);
+        ptr::write(target, val);
+    }
+
+    #[test]
+    fn test_dma_slice_immut_basic() {
+        let fence = unsafe { MockFence::new() };
+
+        let data = [10u8, 20, 30, 40];
+
+        // 1. Create DmaSlice
+        let dma = DmaSlice::from_slice_ref(&data, fence);
+
+        // 2. Verify properties
+        assert_eq!(dma.len(), 4);
+        assert_eq!(dma.as_ptr(), data.as_ptr());
+
+        // 3. Simulate DMA Read (peripheral reads from host memory)
+        //
+        // In Miri, we just check if we can read via the raw pointer while the
+        // borrow is active.
+        let val = unsafe { ptr::read(dma.as_ptr().add(1)) };
+        assert_eq!(val, 20);
+
+        // 4. Drop (Safe)
+        drop(dma);
+    }
+
+    #[test]
+    fn test_dma_slice_mut_write_cycle() {
+        let fence = unsafe { MockFence::new() };
+
+        let mut data = [0u8; 4];
+        let data_ptr = data.as_mut_ptr();
+
+        // 1. Create DmaSliceMut
+        //
+        // SAFETY: We call `restore_slice_ref` at the end.
+        let dma = unsafe { DmaSliceMut::from_mut_slice_ref(&mut data, fence) };
+
+        // 2. Verify basic pointer integrity
+        assert_eq!(dma.as_mut_ptr(), data_ptr);
+        assert_eq!(dma.len(), 4);
+
+        // 3. Simulate DMA Write
+        //
+        // The peripheral writes `0xAA` to index 2.
+        unsafe {
+            simulate_dma_write(dma.as_mut_ptr(), 0xAA_u8, 2);
+        }
+
+        // 4. Restore
+        //
+        // SAFETY: DMA is "done".
+        let restored_slice = unsafe { dma.restore_mut_slice_ref(fence) };
+
+        // 5. Verify that the writes are reflected in the buffer:
+        assert_eq!(restored_slice, &[0, 0, 0xAA, 0]);
+    }
+
+    #[test]
+    fn test_dma_slice_mut_static() {
+        let fence = unsafe { MockFence::new() };
+
+        // Test specifically for the static constructor which is safe:
+        static mut BUFFER: [u32; 2] = [1, 2];
+
+        // 1. Create from static
+        //
+        // Note: access to static mut is unsafe, but the from_static_slice_ref call itself is safe
+        let dma = DmaSliceMut::from_static_mut_slice_ref(unsafe { &mut *(&raw mut BUFFER) }, fence);
+
+        // 2. Simulate DMA Write
+        unsafe {
+            simulate_dma_write(dma.as_mut_ptr(), 99u32, 0);
+        }
+
+        // 3. Restore
+        let restored = unsafe { dma.restore_mut_slice_ref(fence) };
+
+        assert_eq!(restored[0], 99);
+        assert_eq!(restored[1], 2);
+    }
+
+    #[test]
+    fn test_dma_sub_slice_immut() {
+        let fence = unsafe { MockFence::new() };
+
+        let data = [100u8, 101, 102, 103, 104];
+
+        // Create a SubSlice with an active range of 1..=2
+        let mut sub = SubSlice::new(&data);
+        sub.slice(1..=2);
+
+        let dma = DmaSubSlice::from_sub_slice(sub, fence);
+        assert_eq!(dma.len(), 2);
+
+        unsafe {
+            assert_eq!(*dma.as_ptr(), 101);
+            assert_eq!(*dma.as_ptr().add(1), 102);
+        }
+    }
+
+    #[test]
+    fn test_dma_sub_slice_mut_offset() {
+        let fence = unsafe { MockFence::new() };
+
+        let mut data = [0u64, 1, 2, 3, 4]; // u64 to test stride sizes > 1 byte
+
+        // Create a SubSliceMut with an active range of 2..4
+        let mut sub = SubSliceMut::new(&mut data);
+        sub.slice(2..4);
+
+        let dma = unsafe { DmaSubSliceMut::from_sub_slice_mut(sub, fence) };
+        assert_eq!(dma.len(), 2);
+
+        // Verify Pointer logic
+        //
+        // dma.as_ptr() should point to data[2]
+        unsafe {
+            // Write to index 0 of the DMA view (which is index 2 of underlying)
+            simulate_dma_write(dma.as_mut_ptr(), 0xFF_FF_FF_FF_u64, 0);
+
+            // Write to index 1 of the DMA view (index 3 of underlying)
+            simulate_dma_write(dma.as_mut_ptr(), 0xEE_EE_EE_EE_u64, 1);
+        }
+
+        // 3. Restore
+        let restored_sub = unsafe { dma.restore_sub_slice_mut(fence) };
+        let full_slice = restored_sub.take();
+
+        // 4. Validate
+        assert_eq!(full_slice[0], 0); // Untouched
+        assert_eq!(full_slice[1], 1); // Untouched
+        assert_eq!(full_slice[2], 0xFF_FF_FF_FF); // Written
+        assert_eq!(full_slice[3], 0xEE_EE_EE_EE); // Written
+        assert_eq!(full_slice[4], 4); // Untouched
+    }
+
+    #[test]
+    fn test_dma_sub_slice_mut_edge_cases() {
+        let fence = unsafe { MockFence::new() };
+
+        let mut data = [0u8; 10];
+        let data_ptr = data.as_mut_ptr();
+
+        // Case A: Empty Range
+        {
+            let mut sub = SubSliceMut::new(&mut data);
+            sub.slice(5..5);
+
+            let dma = unsafe { DmaSubSliceMut::from_sub_slice_mut(sub, fence) };
+            assert_eq!(dma.len(), 0);
+
+            // Verify we return the correct ptr, even if we shouldn't deref it
+            assert_eq!(dma.as_mut_ptr(), data_ptr.wrapping_add(5));
+            unsafe { dma.restore_sub_slice_mut(fence) };
+        }
+
+        // Case B: Range at exact end
+        {
+            let base_addr = data.as_ptr() as usize;
+
+            let mut sub = SubSliceMut::new(&mut data);
+            sub.slice(10..10); // End of buffer
+
+            let dma = unsafe { DmaSubSliceMut::from_sub_slice_mut(sub, fence) };
+
+            // Pointer should point one past the end of the array
+            let ptr_addr = dma.as_mut_ptr() as usize;
+            assert_eq!(ptr_addr, base_addr + 10);
+
+            unsafe { dma.restore_sub_slice_mut(fence) };
+        }
+
+        // Case C: Range out of bounds (Should be clamped by implementation)
+        {
+            let mut sub = SubSliceMut::new(&mut data);
+            sub.slice(8..15); // End is past 10
+
+            let dma = unsafe { DmaSubSliceMut::from_sub_slice_mut(sub, fence) };
+
+            // Length should be clamped to available (10 - 8 = 2)
+            assert_eq!(dma.len(), 2);
+
+            unsafe {
+                simulate_dma_write(dma.as_mut_ptr(), 99u8, 0); // index 8
+                simulate_dma_write(dma.as_mut_ptr(), 88u8, 1); // index 9
+            }
+
+            let res = unsafe { dma.restore_sub_slice_mut(fence) };
+            let arr = res.take();
+            assert_eq!(arr[8], 99);
+            assert_eq!(arr[9], 88);
+        }
+    }
+}

--- a/kernel/src/utilities/dma_slice.rs
+++ b/kernel/src/utilities/dma_slice.rs
@@ -181,8 +181,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSlice<'a, T> {
 ///
 /// # Safety Considerations
 ///
-/// Users **must** eventually call
-/// [`take`](Self::take) to retrieve the
+/// Users **must** eventually call [`take`](Self::take) to retrieve the
 /// underlying buffer. The [`DmaSliceMut`] must exist for the entire duration of
 /// the DMA operation. Users must never drop a [`DmaSliceMut`] with a
 /// non-`'static` lifetime, as this could provide access to the underlying
@@ -190,11 +189,10 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSlice<'a, T> {
 /// issuing a DMA memory fence to ensure that writes by the DMA operation are
 /// visible to Rust.
 ///
-/// [`take`](Self::take) must only be called
-/// after the DMA operation has been observed to be complete (such as through a
-/// memory or MMIO read). Callers must ensure that the hardware will not perform
-/// any further writes to the buffer at the point where
-/// [`restore_mut_slice_ref`](Self::restore_mut_slice_ref) is called.
+/// [`take`](Self::take) must only be called after the DMA operation has been
+/// observed to be complete (such as through a memory or MMIO read). Callers
+/// must ensure that the hardware will not perform any further writes to the
+/// buffer at the point where [`take`](Self::take) is called.
 ///
 /// Callers must further ensure that they start DMA operations only after
 /// constructing the [`DmaSliceMut`], and only in the memory region described by
@@ -229,9 +227,9 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSliceMut<'a, T
     ///
     /// Callers must ensure to not[`forget`](core::mem::forget) the returned
     /// [`DmaSliceMut`]. This could provide access to the underlying buffer
-    /// without guaranteeing that the DMA operation has finished.
-    /// Users **must** eventually call[`restore_mut_slice_ref`]
-    /// (Self::restore_mut_slice_ref) to retrieve the underlying buffer.
+    /// without guaranteeing that the DMA operation has finished.  Users
+    /// **must** eventually call [`take`](Self::take) to retrieve the underlying
+    /// buffer.
     #[must_use]
     pub unsafe fn new(slice: &mut [T], fence: impl DmaFence) -> DmaSliceMut<'_, T> {
         let dma_slice_mut = DmaSliceMut {
@@ -330,12 +328,12 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSliceMutImmut<
         // # Safety
         //
         // `DmaSliceMut::from_mut_slice_ref` is unsafe, as dropping its return
-        // value without calling `restore_mut_slice_ref` may make the underlying
-        // buffer accessible as a Rust slice, potentially before the DMA
-        // operation is complete, and without using `fence.acquire` to make DMA
-        // writes visible to Rust. However, this struct does not permit DMA
-        // operations which write to the slice, and hence it can be safely
-        // dropped without risk of concurrent modifications or incoherence.
+        // value without calling `take` may make the underlying buffer
+        // accessible as a Rust slice, potentially before the DMA operation is
+        // complete, and without using `fence.acquire` to make DMA writes
+        // visible to Rust. However, this struct does not permit DMA operations
+        // which write to the slice, and hence it can be safely dropped without
+        // risk of concurrent modifications or incoherence.
         DmaSliceMutImmut::Mutable(unsafe { DmaSliceMut::new(slice, fence) })
     }
 
@@ -410,7 +408,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSlice<'a, T
     /// writes to `slice` are exposed to any DMA operations initiated by an MMIO
     /// read or write operation after this function returns, and which finish
     /// before the resulting [`DmaSubSlice`] is dropped.
-    pub fn from_sub_slice(sub_slice: SubSlice<'_, T>, fence: impl DmaFence) -> DmaSubSlice<'_, T> {
+    pub fn new(sub_slice: SubSlice<'_, T>, fence: impl DmaFence) -> DmaSubSlice<'_, T> {
         // Ensure that all prior writes to this slice are exposed to any DMA
         // operations initiated by an MMIO read or write operation after this
         // function returns:
@@ -457,14 +455,13 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSlice<'a, T
 /// Rust writes to this slice's active range are observable by any DMA
 /// operations initiated through an MMIO write operation, where that MMIO write
 /// is performed **after** constructing the `DmaSubSliceMut`. All writes by the
-/// DMA operation will be observable by Rust when calling
-/// [`restore_sub_slice_mut`](Self::restore_sub_slice_mut) **after** the DMA
-/// operation is finished.
+/// DMA operation will be observable by Rust when calling [`take`](Self::take)
+/// **after** the DMA operation is finished.
 ///
 /// # Safety
 ///
 /// Users **must** eventually call
-/// [`restore_sub_slice_mut`](Self::restore_sub_slice_mut) to retrieve the
+/// [`take`](Self::take) to retrieve the
 /// underlying buffer. The [`DmaSubSliceMut`] must exist for the entire duration
 /// of the DMA operation. Users must never drop a [`DmaSubSliceMut`] with a
 /// non-`'static` lifetime, as this could provide access to the underlying
@@ -472,22 +469,22 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSlice<'a, T
 /// issuing a DMA memory fence to ensure that writes by the DMA operation are
 /// visible to Rust.
 ///
-/// [`restore_sub_slice_mut`](Self::restore_sub_slice_mut) must only be called
+/// [`take`](Self::take) must only be called
 /// after the DMA operation has been observed to be complete (such as through a
 /// memory or MMIO read). Callers must ensure that the hardware will not perform
 /// any further writes to the buffer at the point where
-/// [`restore_sub_slice_mut`](Self::restore_sub_slice_mut) is called.
+/// [`take`](Self::take) is called.
 ///
 /// Callers must further ensure that they start DMA operations only after
 /// constructing the [`DmaSubSliceMut`], and only in the memory region described
 /// by [`as_mut_ptr`](Self::as_mut_ptr) and [`len`](Self::len).
 ///
 /// Users are responsible to ensure that, after the DMA operation completes and
-/// before calling [`restore_mut_slice_ref`](Self::restore_sub_slice_mut), every
-/// element in the underlying slice represents a well-initialized and valid
-/// instance of its type (with the exception of padding bytes). See the
-/// [zerocopy crate](https://docs.rs/zerocopy/0.8.31/zerocopy/) for an more
-/// in-depth explanation of these requirements.
+/// before calling [`take`](Self::take), every element in the underlying slice
+/// represents a well-initialized and valid instance of its type (with the
+/// exception of padding bytes). See the [zerocopy
+/// crate](https://docs.rs/zerocopy/0.8.31/zerocopy/) for an more in-depth
+/// explanation of these requirements.
 #[derive(Debug)]
 pub struct DmaSubSliceMut<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> {
     internal_slice_ptr: NonNull<[T]>,
@@ -501,8 +498,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMut<'a
     /// This function uses the supplied `fence` object to ensure that all prior
     /// writes to the active region of `slice` are exposed to any DMA operations
     /// initiated by an MMIO read or write operation after this function
-    /// returns, and which finish before calling
-    /// [`restore_sub_slice_mut`](Self::restore_sub_slice_mut).
+    /// returns, and which finish before calling [`take`](Self::take).
     ///
     /// # Safety
     ///
@@ -511,10 +507,9 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMut<'a
     /// This function is unsafe, as dropping or
     /// [`forget`](core::mem::forget)ting its return value is not allowed when
     /// the lifetime `'b` is not `'static`. Users **must** eventually call
-    /// [`restore_sub_slice_mut`](Self::restore_sub_slice_mut) to retrieve the
-    /// underlying buffer.
+    /// [`take`](Self::take) to retrieve the underlying buffer.
     #[must_use]
-    pub unsafe fn new_unsafe(
+    pub unsafe fn new(
         sub_slice_mut: SubSliceMut<'_, T>,
         fence: impl DmaFence,
     ) -> DmaSubSliceMut<'_, T> {
@@ -545,20 +540,20 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMut<'a
     /// This function uses the supplied `fence` object to ensure that all prior
     /// writes to `slice` are exposed to any DMA operations initiated by an MMIO
     /// read or write operation after this function returns, and which finish
-    /// before calling [`restore_sub_slice_mut`](Self::restore_sub_slice_mut).
+    /// before calling [`take`](Self::take).
     ///
     /// # Safety
     ///
     /// Refer the safety documentation of the [`DmaSubSliceMut`] type.
     ///
-    /// In contrast to [`from_sub_slice_mut`] this function is safe, as dropping
-    /// or forgetting its return value is safe, it would merely leak memory and
+    /// In contrast to [`new`](Self::new) this function is safe, as dropping or
+    /// forgetting its return value is safe, it would merely leak memory and
     /// make the underlying slice inaccessible.
-    pub fn new(
+    pub fn new_static(
         sub_slice: SubSliceMut<'static, T>,
         fence: impl DmaFence,
     ) -> DmaSubSliceMut<'static, T> {
-        unsafe { Self::new_unsafe(sub_slice, fence) }
+        unsafe { Self::new(sub_slice, fence) }
     }
 
     /// Returns the pointer to the first element of the active range of the
@@ -600,12 +595,11 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMut<'a
     ///
     /// Refer the safety documentation of the [`DmaSubSliceMut`] type.
     ///
-    /// In particular, [`restore_sub_slice_mut`](Self::restore_sub_slice_mut)
-    /// must only be called after the DMA operation has been observed to be
-    /// complete (such as through a memory or MMIO read). Callers must ensure
-    /// that the hardware will not perform any further writes to the buffer at
-    /// the point where [`restore_sub_slice_mut`](Self::restore_sub_slice_mut)
-    /// is called.
+    /// In particular, [`take`](Self::take) must only be called after the DMA
+    /// operation has been observed to be complete (such as through a memory or
+    /// MMIO read). Callers must ensure that the hardware will not perform any
+    /// further writes to the buffer at the point where [`take`](Self::take) is
+    /// called.
     pub unsafe fn take(mut self, fence: impl DmaFence) -> SubSliceMut<'a, T> {
         // Ensure that any reads from Rust to the active range of the buffer
         // (described by `self.as_mut_ptr()` and `self.len()`) _after_ this
@@ -631,7 +625,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMut<'a
     /// contents have not been modified by a DMA operation (i.e., any DMA
     /// operations operating on the buffer while this `DmaSubSliceMut` existed
     /// were read-only).
-    unsafe fn restore_sub_slice_mut_no_acquire(mut self) -> SubSliceMut<'a, T> {
+    unsafe fn take_no_acquire(mut self) -> SubSliceMut<'a, T> {
         // Restore the original `SubSliceMut` configuration:
         let mut sub_slice_mut = SubSliceMut::new(unsafe { self.internal_slice_ptr.as_mut() });
         sub_slice_mut.slice(self.active_range);
@@ -677,20 +671,20 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMutImm
     ) -> DmaSubSliceMutImmut<'_, T> {
         match sub_slice {
             SubSliceMutImmut::Immutable(sub_slice) => {
-                DmaSubSliceMutImmut::Immutable(DmaSubSlice::from_sub_slice(sub_slice, fence))
+                DmaSubSliceMutImmut::Immutable(DmaSubSlice::new(sub_slice, fence))
             }
             SubSliceMutImmut::Mutable(sub_slice_mut) => DmaSubSliceMutImmut::Mutable(unsafe {
                 // # Safety
                 //
-                // `DmaSubSliceMut::from_sub_slice_mut` is unsafe, as dropping
-                // its return value without calling `restore_sub_slice_mut` may
-                // make the underlying buffer accessible as a Rust slice,
-                // potentially before the DMA operation is complete, and without
-                // using `fence.acquire` to make DMA writes visible to
-                // Rust. However, this struct does not permit DMA operations
-                // which write to the slice, and hence it can be safely dropped
-                // without risk of concurrent modifications or incoherence.
-                DmaSubSliceMut::new_unsafe(sub_slice_mut, fence)
+                // `DmaSubSliceMut::new` is unsafe, as dropping its return value
+                // without calling `take` may make the underlying buffer
+                // accessible as a Rust slice, potentially before the DMA
+                // operation is complete, and without using `fence.acquire` to
+                // make DMA writes visible to Rust. However, this struct does
+                // not permit DMA operations which write to the slice, and hence
+                // it can be safely dropped without risk of concurrent
+                // modifications or incoherence.
+                DmaSubSliceMut::new(sub_slice_mut, fence)
             }),
         }
     }
@@ -734,10 +728,9 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMutImm
                 // The user guarantees that there has not been any DMA operation
                 // that changed the buffers contents while the
                 // `DmaSubSliceMutImmut` existed, and hence restoring a unique
-                // Rust slice through `restore_sub_slice_mut` is safe. No
-                // acquire-fence is needed, given the bufer contents have not
-                // been modified.
-                dma_sub_slice_mut.restore_sub_slice_mut_no_acquire()
+                // Rust slice through `take` is safe. No acquire-fence is
+                // needed, given the bufer contents have not been modified.
+                dma_sub_slice_mut.take_no_acquire()
             }),
         }
     }
@@ -858,7 +851,7 @@ mod miri_tests {
 
         // 1. Create DmaSliceMut
         //
-        // SAFETY: We call `restore_slice_ref` at the end.
+        // SAFETY: We call `take` at the end.
         let dma = unsafe { DmaSliceMut::new(&mut data, fence) };
 
         // 2. Verify basic pointer integrity
@@ -915,7 +908,7 @@ mod miri_tests {
         let mut sub = SubSlice::new(&data);
         sub.slice(1..=2);
 
-        let dma = DmaSubSlice::from_sub_slice(sub, fence);
+        let dma = DmaSubSlice::new(sub, fence);
         assert_eq!(dma.len(), 2);
 
         unsafe {
@@ -934,7 +927,7 @@ mod miri_tests {
         let mut sub = SubSliceMut::new(&mut data);
         sub.slice(2..4);
 
-        let dma = unsafe { DmaSubSliceMut::from_sub_slice_mut(sub, fence) };
+        let dma = unsafe { DmaSubSliceMut::new(sub, fence) };
         assert_eq!(dma.len(), 2);
 
         // Verify Pointer logic
@@ -949,7 +942,7 @@ mod miri_tests {
         }
 
         // 3. Restore
-        let restored_sub = unsafe { dma.restore_sub_slice_mut(fence) };
+        let restored_sub = unsafe { dma.take(fence) };
         let full_slice = restored_sub.take();
 
         // 4. Validate
@@ -972,12 +965,12 @@ mod miri_tests {
             let mut sub = SubSliceMut::new(&mut data);
             sub.slice(5..5);
 
-            let dma = unsafe { DmaSubSliceMut::from_sub_slice_mut(sub, fence) };
+            let dma = unsafe { DmaSubSliceMut::new(sub, fence) };
             assert_eq!(dma.len(), 0);
 
             // Verify we return the correct ptr, even if we shouldn't deref it
             assert_eq!(dma.as_mut_ptr(), data_ptr.wrapping_add(5));
-            unsafe { dma.restore_sub_slice_mut(fence) };
+            unsafe { dma.take(fence) };
         }
 
         // Case B: Range at exact end
@@ -987,13 +980,13 @@ mod miri_tests {
             let mut sub = SubSliceMut::new(&mut data);
             sub.slice(10..10); // End of buffer
 
-            let dma = unsafe { DmaSubSliceMut::from_sub_slice_mut(sub, fence) };
+            let dma = unsafe { DmaSubSliceMut::new(sub, fence) };
 
             // Pointer should point one past the end of the array
             let ptr_addr = dma.as_mut_ptr() as usize;
             assert_eq!(ptr_addr, base_addr + 10);
 
-            unsafe { dma.restore_sub_slice_mut(fence) };
+            unsafe { dma.take(fence) };
         }
 
         // Case C: Range out of bounds (Should be clamped by implementation)
@@ -1001,7 +994,7 @@ mod miri_tests {
             let mut sub = SubSliceMut::new(&mut data);
             sub.slice(8..15); // End is past 10
 
-            let dma = unsafe { DmaSubSliceMut::from_sub_slice_mut(sub, fence) };
+            let dma = unsafe { DmaSubSliceMut::new(sub, fence) };
 
             // Length should be clamped to available (10 - 8 = 2)
             assert_eq!(dma.len(), 2);
@@ -1011,7 +1004,7 @@ mod miri_tests {
                 simulate_dma_write(dma.as_mut_ptr(), 88u8, 1); // index 9
             }
 
-            let res = unsafe { dma.restore_sub_slice_mut(fence) };
+            let res = unsafe { dma.take(fence) };
             let arr = res.take();
             assert_eq!(arr[8], 99);
             assert_eq!(arr[9], 88);

--- a/kernel/src/utilities/dma_slice.rs
+++ b/kernel/src/utilities/dma_slice.rs
@@ -96,7 +96,7 @@ pub struct DmaSlice<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> {
     slice: &'a [T],
 }
 
-impl<'a, T: utilities::slices::JustBytes> DmaSlice<'a, T> {
+impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSlice<'a, T> {
     /// Create a [`DmaSlice`] from an immutable slice.
     pub fn new(slice: &[T], fence: impl DmaFence) -> DmaSlice<'_, T> {
         // Ensure that all prior writes to this slice are exposed to any DMA
@@ -117,8 +117,11 @@ impl<'a, T: utilities::slices::JustBytes> DmaSlice<'a, T> {
         self.slice.len()
     }
 
-    /// Retrieve the slice. Consumes the [`DmaSlice`].
-    pub fn take(&self) -> &'a [T] {
+    /// Retrieve the inner slice reference.
+    ///
+    /// This is safe, as the slice is immutable. Therefore, the DMA hardware and
+    /// software may read it concurrently.
+    pub fn get(&self) -> &'a [T] {
         self.slice
     }
 }
@@ -179,13 +182,13 @@ pub struct DmaSliceMut<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes>
 
 impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSliceMut<'a, T> {
     /// Create a [`DmaSliceMut`] from a static mutable slice.
-    pub fn new(slice: &'static mut [T], fence: impl DmaFence) -> DmaSliceMut<'static, T> {
+    pub fn new_static(slice: &'static mut [T], fence: impl DmaFence) -> DmaSliceMut<'static, T> {
         // # Safety
         //
         // This operation is safe, as dropping or forgetting its return value
         // is safe. This would merely leak memory and make the underlying
         // slice inaccessible.
-        unsafe { Self::from_mut_slice_ref(slice, fence) }
+        unsafe { Self::new(slice, fence) }
     }
 
     /// Create a [`DmaSliceMut`] from a mutable slice.
@@ -198,7 +201,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSliceMut<'a, T
     /// Users **must** eventually call[`restore_mut_slice_ref`]
     /// (Self::restore_mut_slice_ref) to retrieve the underlying buffer.
     #[must_use]
-    pub unsafe fn new_unsafe(slice: &mut [T], fence: impl DmaFence) -> DmaSliceMut<'_, T> {
+    pub unsafe fn new(slice: &mut [T], fence: impl DmaFence) -> DmaSliceMut<'_, T> {
         let dma_slice_mut = DmaSliceMut {
             slice_ptr: NonNull::from_mut(slice),
             _lt: PhantomData,
@@ -278,8 +281,8 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSliceMutImmut<
     /// writes to `slice` are exposed to any DMA operations initiated by an MMIO
     /// read or write operation after this function returns, and which finish
     /// before the resulting [`DmaSliceMutImmut`] is dropped.
-    pub fn from_slice_ref(slice: &[T], fence: impl DmaFence) -> DmaSliceMutImmut<'_, T> {
-        DmaSliceMutImmut::Immutable(DmaSlice::from_slice_ref(slice, fence))
+    pub fn new(slice: &[T], fence: impl DmaFence) -> DmaSliceMutImmut<'_, T> {
+        DmaSliceMutImmut::Immutable(DmaSlice::new(slice, fence))
     }
 
     /// Create a [`DmaSliceMutImmut`] from a unique, mutable Rust slice.
@@ -291,7 +294,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSliceMutImmut<
     ///
     /// Even though this method takes a unique, mutable Rust slice, DMA
     /// operations must not modify the buffers contents.
-    pub fn from_mut_slice_ref(slice: &mut [T], fence: impl DmaFence) -> DmaSliceMutImmut<'_, T> {
+    pub fn new_mut(slice: &mut [T], fence: impl DmaFence) -> DmaSliceMutImmut<'_, T> {
         // # Safety
         //
         // `DmaSliceMut::from_mut_slice_ref` is unsafe, as dropping its return
@@ -301,7 +304,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSliceMutImmut<
         // writes visible to Rust. However, this struct does not permit DMA
         // operations which write to the slice, and hence it can be safely
         // dropped without risk of concurrent modifications or incoherence.
-        DmaSliceMutImmut::Mutable(unsafe { DmaSliceMut::from_mut_slice_ref(slice, fence) })
+        DmaSliceMutImmut::Mutable(unsafe { DmaSliceMut::new(slice, fence) })
     }
 
     /// Returns the pointer to the first element of the wrapped slice reference.
@@ -321,9 +324,13 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSliceMutImmut<
     }
 
     /// Retrieve the inner slice reference.
-    pub fn as_slice_ref(&self) -> &'a [T] {
+    ///
+    /// This is safe, as [`DmaSliceMutImmut`] can only be used for read-only DMA
+    /// operations. The DMA hardware and software may read the underlying slice
+    /// concurrently.
+    pub fn get(&self) -> &'a [T] {
         match self {
-            DmaSliceMutImmut::Immutable(dma_slice) => dma_slice.as_slice_ref(),
+            DmaSliceMutImmut::Immutable(dma_slice) => dma_slice.get(),
             DmaSliceMutImmut::Mutable(dma_slice_mut) => unsafe {
                 // # Safety
                 //
@@ -511,8 +518,8 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMut<'a
     ///
     /// Refer the safety documentation of the [`DmaSubSliceMut`] type.
     ///
-    /// In contrast to `from_slice_ref` this function is safe, as dropping or
-    /// forgetting its return value is safe, it would merely leak memory and
+    /// In contrast to [`from_sub_slice_mut`] this function is safe, as dropping
+    /// or forgetting its return value is safe, it would merely leak memory and
     /// make the underlying slice inaccessible.
     pub fn from_static_sub_slice_mut(
         sub_slice: SubSliceMut<'static, T>,
@@ -792,7 +799,7 @@ mod miri_tests {
         let data = [10u8, 20, 30, 40];
 
         // 1. Create DmaSlice
-        let dma = DmaSlice::from_slice_ref(&data, fence);
+        let dma = DmaSlice::new(&data, fence);
 
         // 2. Verify properties
         assert_eq!(dma.len(), 4);
@@ -819,7 +826,7 @@ mod miri_tests {
         // 1. Create DmaSliceMut
         //
         // SAFETY: We call `restore_slice_ref` at the end.
-        let dma = unsafe { DmaSliceMut::from_mut_slice_ref(&mut data, fence) };
+        let dma = unsafe { DmaSliceMut::new(&mut data, fence) };
 
         // 2. Verify basic pointer integrity
         assert_eq!(dma.as_mut_ptr(), data_ptr);
@@ -835,7 +842,7 @@ mod miri_tests {
         // 4. Restore
         //
         // SAFETY: DMA is "done".
-        let restored_slice = unsafe { dma.restore_mut_slice_ref(fence) };
+        let restored_slice = unsafe { dma.take(fence) };
 
         // 5. Verify that the writes are reflected in the buffer:
         assert_eq!(restored_slice, &[0, 0, 0xAA, 0]);
@@ -851,7 +858,7 @@ mod miri_tests {
         // 1. Create from static
         //
         // Note: access to static mut is unsafe, but the from_static_slice_ref call itself is safe
-        let dma = DmaSliceMut::from_static_mut_slice_ref(unsafe { &mut *(&raw mut BUFFER) }, fence);
+        let dma = DmaSliceMut::new_static(unsafe { &mut *(&raw mut BUFFER) }, fence);
 
         // 2. Simulate DMA Write
         unsafe {
@@ -859,7 +866,7 @@ mod miri_tests {
         }
 
         // 3. Restore
-        let restored = unsafe { dma.restore_mut_slice_ref(fence) };
+        let restored = unsafe { dma.take(fence) };
 
         assert_eq!(restored[0], 99);
         assert_eq!(restored[1], 2);

--- a/kernel/src/utilities/dma_slice.rs
+++ b/kernel/src/utilities/dma_slice.rs
@@ -514,7 +514,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMut<'a
     /// [`restore_sub_slice_mut`](Self::restore_sub_slice_mut) to retrieve the
     /// underlying buffer.
     #[must_use]
-    pub unsafe fn from_sub_slice_mut(
+    pub unsafe fn new_unsafe(
         sub_slice_mut: SubSliceMut<'_, T>,
         fence: impl DmaFence,
     ) -> DmaSubSliceMut<'_, T> {
@@ -554,11 +554,11 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMut<'a
     /// In contrast to [`from_sub_slice_mut`] this function is safe, as dropping
     /// or forgetting its return value is safe, it would merely leak memory and
     /// make the underlying slice inaccessible.
-    pub fn from_static_sub_slice_mut(
+    pub fn new(
         sub_slice: SubSliceMut<'static, T>,
         fence: impl DmaFence,
     ) -> DmaSubSliceMut<'static, T> {
-        unsafe { Self::from_sub_slice_mut(sub_slice, fence) }
+        unsafe { Self::new_unsafe(sub_slice, fence) }
     }
 
     /// Returns the pointer to the first element of the active range of the
@@ -606,7 +606,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMut<'a
     /// that the hardware will not perform any further writes to the buffer at
     /// the point where [`restore_sub_slice_mut`](Self::restore_sub_slice_mut)
     /// is called.
-    pub unsafe fn restore_sub_slice_mut(mut self, fence: impl DmaFence) -> SubSliceMut<'a, T> {
+    pub unsafe fn take(mut self, fence: impl DmaFence) -> SubSliceMut<'a, T> {
         // Ensure that any reads from Rust to the active range of the buffer
         // (described by `self.as_mut_ptr()` and `self.len()`) _after_ this
         // function returns reflect all writes made by DMA operations finished
@@ -671,7 +671,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMutImm
     /// writes to `slice` are exposed to any DMA operations initiated by an MMIO
     /// read or write operation after this function returns, and which finish
     /// before the resulting [`DmaSubSlice`] is dropped.
-    pub fn from_sub_slice_mut_immut(
+    pub fn new(
         sub_slice: SubSliceMutImmut<'_, T>,
         fence: impl DmaFence,
     ) -> DmaSubSliceMutImmut<'_, T> {
@@ -690,7 +690,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMutImm
                 // Rust. However, this struct does not permit DMA operations
                 // which write to the slice, and hence it can be safely dropped
                 // without risk of concurrent modifications or incoherence.
-                DmaSubSliceMut::from_sub_slice_mut(sub_slice_mut, fence)
+                DmaSubSliceMut::new_unsafe(sub_slice_mut, fence)
             }),
         }
     }
@@ -721,7 +721,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMutImm
     /// that the DMA operation over the buffer is complete (such as by reading a
     /// status bit in memory or an MMIO register). Otherwise, any future reads
     /// by the DMA peripheral may not be consistent with the buffer contents.
-    pub fn restore_sub_slice_mut_immut(self) -> SubSliceMutImmut<'a, T> {
+    pub fn take(self) -> SubSliceMutImmut<'a, T> {
         // We don't need to perform an `acquire` fence, as any DMA operation on
         // the underlying slice must not have changed its contents:
         match self {

--- a/kernel/src/utilities/dma_slice.rs
+++ b/kernel/src/utilities/dma_slice.rs
@@ -28,11 +28,11 @@ use crate::platform::dma_fence::DmaFence;
 /// contents must not be modified by the DMA operation. For a DMA operation that
 /// may write to the supplied buffer, use [`DmaSliceMut`] instead.
 #[derive(Debug)]
-pub struct DmaSlice<'a, T> {
+pub struct DmaSlice<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> {
     slice: &'a [T],
 }
 
-impl<'a, T> DmaSlice<'a, T> {
+impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSlice<'a, T> {
     /// Create a [`DmaSlice`] from a shared, immutable Rust slice.
     ///
     /// This function uses the supplied `fence` object to ensure that all prior
@@ -103,12 +103,12 @@ impl<'a, T> DmaSlice<'a, T> {
 /// [zerocopy crate](https://docs.rs/zerocopy/0.8.31/zerocopy/) for an more
 /// in-depth explanation of these requirements.
 #[derive(Debug)]
-pub struct DmaSliceMut<'a, T> {
+pub struct DmaSliceMut<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> {
     slice_ptr: NonNull<[T]>,
     _lt: PhantomData<&'a mut [T]>,
 }
 
-impl<'a, T> DmaSliceMut<'a, T> {
+impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSliceMut<'a, T> {
     /// Create a [`DmaSliceMut`] from a unique, mutable Rust slice.
     ///
     /// This function uses the supplied `fence` object to ensure that all prior
@@ -222,12 +222,12 @@ impl<'a, T> DmaSliceMut<'a, T> {
 /// operation that may write to the supplied buffer, use [`DmaSliceMut`]
 /// instead.
 #[derive(Debug)]
-pub enum DmaSliceMutImmut<'a, T> {
+pub enum DmaSliceMutImmut<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> {
     Immutable(DmaSlice<'a, T>),
     Mutable(DmaSliceMut<'a, T>),
 }
 
-impl<'a, T> DmaSliceMutImmut<'a, T> {
+impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSliceMutImmut<'a, T> {
     /// Create a [`DmaSliceMutImmut`] from a shared, immutable Rust slice.
     ///
     /// This function uses the supplied `fence` object to ensure that all prior
@@ -316,11 +316,11 @@ impl<'a, T> DmaSliceMutImmut<'a, T> {
 /// its contents must not be modified by the DMA operation. For a DMA operation
 /// that may write to the supplied buffer, use [`DmaSubSliceMut`] instead.
 #[derive(Debug)]
-pub struct DmaSubSlice<'a, T> {
+pub struct DmaSubSlice<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> {
     sub_slice: SubSlice<'a, T>,
 }
 
-impl<'a, T> DmaSubSlice<'a, T> {
+impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSlice<'a, T> {
     /// Create a [`DmaSubSlice`] from a shared, immutable Rust slice.
     ///
     /// This function uses the supplied `fence` object to ensure that all prior
@@ -405,13 +405,13 @@ impl<'a, T> DmaSubSlice<'a, T> {
 /// [zerocopy crate](https://docs.rs/zerocopy/0.8.31/zerocopy/) for an more
 /// in-depth explanation of these requirements.
 #[derive(Debug)]
-pub struct DmaSubSliceMut<'a, T> {
+pub struct DmaSubSliceMut<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> {
     internal_slice_ptr: NonNull<[T]>,
     active_range: Range<usize>,
     _lt: PhantomData<&'a mut [T]>,
 }
 
-impl<'a, T> DmaSubSliceMut<'a, T> {
+impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMut<'a, T> {
     /// Create a [`DmaSubSliceMut`] from a [`SubSliceMut`].
     ///
     /// This function uses the supplied `fence` object to ensure that all prior
@@ -575,12 +575,12 @@ impl<'a, T> DmaSubSliceMut<'a, T> {
 /// operation. For a DMA operation that may write to the active range of the
 /// supplied sub slice, use [`DmaSubSliceMut`] instead.
 #[derive(Debug)]
-pub enum DmaSubSliceMutImmut<'a, T> {
+pub enum DmaSubSliceMutImmut<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> {
     Immutable(DmaSubSlice<'a, T>),
     Mutable(DmaSubSliceMut<'a, T>),
 }
 
-impl<'a, T> DmaSubSliceMutImmut<'a, T> {
+impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMutImmut<'a, T> {
     /// Create a [`DmaSubSliceMutImmut`] from a [`SubSliceMutImmut`].
     ///
     /// This function uses the supplied `fence` object to ensure that all prior
@@ -657,6 +657,44 @@ impl<'a, T> DmaSubSliceMutImmut<'a, T> {
             }),
         }
     }
+}
+
+pub mod immutable_from_into_bytes {
+    /// Sealing module for [`ImmutableFromIntoBytes`]
+    mod private {
+        /// Sealing trait for [`ImmutableFromIntoBytes`]
+        pub trait Sealed {}
+    }
+
+    /// A type that is can be safely converted to an initialized sequence of bytes,
+    /// from an arbitrary initialized sequence of bytes, and does not feature
+    /// interior mutability.
+    ///
+    /// The requirements on implementors of this trait are effectively the same as
+    /// the combination of zerocopy's [`FromBytes`][zerocopy-frombytes],
+    /// [`IntoBytes`][zerocopy-intobytes], and [`Immutable`][zerocopy-immutable]
+    /// traits.
+    ///
+    /// This trait is only implemented for a few select primitives, intended to be
+    /// used for DMA operations. It is sealed; all extensions to future types must
+    /// ensure they conform to the above trait's requirements and are safe for DMA
+    /// operations.
+    ///
+    /// [zerocopy-frombytes]: https://docs.rs/zerocopy/0.8.42/zerocopy/trait.FromBytes.html
+    /// [zerocopy-intobytes]: https://docs.rs/zerocopy/0.8.42/zerocopy/trait.IntoBytes.html
+    /// [zerocopy-immutable]: https://docs.rs/zerocopy/0.8.42/zerocopy/trait.Immutable.html
+    pub unsafe trait ImmutableFromIntoBytes: private::Sealed {}
+
+    impl private::Sealed for u8 {}
+    unsafe impl ImmutableFromIntoBytes for u8 {}
+    impl private::Sealed for u16 {}
+    unsafe impl ImmutableFromIntoBytes for u16 {}
+    impl private::Sealed for u32 {}
+    unsafe impl ImmutableFromIntoBytes for u32 {}
+    impl private::Sealed for u64 {}
+    unsafe impl ImmutableFromIntoBytes for u64 {}
+    impl private::Sealed for u128 {}
+    unsafe impl ImmutableFromIntoBytes for u128 {}
 }
 
 #[cfg(test)]

--- a/kernel/src/utilities/dma_slice.rs
+++ b/kernel/src/utilities/dma_slice.rs
@@ -94,7 +94,7 @@ pub struct DmaSlice<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> {
     slice: &'a [T],
 }
 
-impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSlice<'a, T> {
+impl<'a, T: utilities::slices::JustBytes> DmaSlice<'a, T> {
     /// Create a [`DmaSlice`] from an immutable slice.
     pub fn new(slice: &[T], fence: impl DmaFence) -> DmaSlice<'_, T> {
         // Ensure that all prior writes to this slice are exposed to any DMA

--- a/kernel/src/utilities/dma_slice.rs
+++ b/kernel/src/utilities/dma_slice.rs
@@ -4,6 +4,58 @@
 // Copyright Tock Contributors 2026.
 
 //! Mechanism for sharing buffers with DMA peripherals.
+//!
+//! When implementing a chip peripheral driver using DMA, the driver must use
+//! a `DmaSlice` when passing a buffer to the DMA hardware. This ensures that
+//! Rust's memory requirements are preserved when hardware is accessing
+//! memory in a way the Rust compiler cannot reason about.
+//!
+//! Tock provides multiple implementations of `DmaSlice` depending on the
+//! needs of the user. These include:
+//!
+//! - [`DmaSlice`]: For immutable buffers and read-only DMA operations.
+//! - [`DmaSliceMut`]: For mutable buffers and writable DMA operations.
+//! - [`DmaSubSlice`]: For immutable [`SubSlice`]s and read-only DMA
+//!   operations.
+//! - [`DmaSubSliceMut`]: For mutable [`SubSliceMut`]s and writable DMA
+//!   operations.
+//!
+//! Internally, all implementations of `DmaSlice` use an architecture or
+//! chip-provided implementation of [`DmaFence`] to manually ensure that the
+//! Rust compiler cannot assume the memory passed to the DMA hardware is not
+//! modified.
+//!
+//! Conceptually, a `DmaSlice` consumes a memory buffer, and once consumed a
+//! pointer to that memory can then be safely provided to DMA hardware. When
+//! the buffer is consumed, the `DmaSlice` implementations uphold the Rust
+//! memory soundness requirements now that hardware can directly read and/or
+//! write the memory in a way that the Rust compiler cannot reason about.
+//! Once the DMA operation finishes, the buffer must be extracted from the
+//! `DmaSlice`. Before extracting the buffer, the user must guarantee that
+//! the DMA hardware can no longer access the memory.
+//!
+//! # Usage
+//!
+//! This is a rough sketch of how to use a `DmaSlice`:
+//!
+//! ```ignore
+//! // Buffer that will be used by the DMA hardware.
+//! let buffer: [u8] = ...;
+//!
+//! // Create the `DmaSlice` that can be provided to the DMA hardware.
+//! let dma_slice = DmaSlice::new(buffer, cortexm::dma_fence::DmaFence);
+//!
+//! // Provide the pointer to the buffer to the DMA hardware registers.
+//! self.registers.dma.set(dma_slice.as_ptr());
+//!
+//! // Wait for the DMA operation to finish...
+//!
+//! // Disable the DMA engine to ensure it cannot access the buffer.
+//! self.registers.dma.set(DMA::STOP);
+//!
+//! // Extract the buffer to retrieve the Rust slice.
+//! let buffer = dma_slice.take();
+//! ```
 
 use core::marker::PhantomData;
 use core::ops::Range;
@@ -13,6 +65,15 @@ use super::leasable_buffer::{SubSlice, SubSliceMut, SubSliceMutImmut};
 use crate::platform::dma_fence::DmaFence;
 
 /// An immutable buffer that can be safely used for read-only DMA operations.
+///
+/// The buffer can be a slice of any type that is guaranteed to be initialized
+/// without interior mutability, for example a `[u8]` or `[u32]`.
+///
+/// [`DmaSlice`] wraps an immutable slice. As such, its
+/// contents MUST NOT be modified by the DMA operation. For a DMA operation that
+/// may write to the supplied buffer, use [`DmaSliceMut`] instead.
+///
+/// # Use with DMA
 ///
 /// Creating a [`DmaSlice`] over an immutable Rust slice ensures that all prior
 /// Rust writes to this slice are observable by any DMA operations initiated
@@ -24,22 +85,18 @@ use crate::platform::dma_fence::DmaFence;
 /// that the operation is complete (such as by reading a status bit in memory or
 /// an MMIO register).
 ///
-/// [`DmaSlice`] wraps an immutable, shared Rust slice reference. As such, its
-/// contents must not be modified by the DMA operation. For a DMA operation that
-/// may write to the supplied buffer, use [`DmaSliceMut`] instead.
+/// This struct uses a [`DmaFence`] implementation to ensure that all prior
+/// writes to `slice` are exposed to any DMA operations initiated by an MMIO
+/// read or write operation after this function returns, and which finish
+/// before the resulting [`DmaSlice`] is dropped.
 #[derive(Debug)]
 pub struct DmaSlice<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> {
     slice: &'a [T],
 }
 
 impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSlice<'a, T> {
-    /// Create a [`DmaSlice`] from a shared, immutable Rust slice.
-    ///
-    /// This function uses the supplied `fence` object to ensure that all prior
-    /// writes to `slice` are exposed to any DMA operations initiated by an MMIO
-    /// read or write operation after this function returns, and which finish
-    /// before the resulting [`DmaSlice`] is dropped.
-    pub fn from_slice_ref(slice: &[T], fence: impl DmaFence) -> DmaSlice<'_, T> {
+    /// Create a [`DmaSlice`] from an immutable slice.
+    pub fn new(slice: &[T], fence: impl DmaFence) -> DmaSlice<'_, T> {
         // Ensure that all prior writes to this slice are exposed to any DMA
         // operations initiated by an MMIO read or write operation after this
         // function returns.
@@ -48,37 +105,47 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSlice<'a, T> {
         DmaSlice { slice }
     }
 
-    /// Returns the pointer to the first element of the wrapped slice reference.
+    /// Returns a pointer to the start of the slice.
     pub fn as_ptr(&self) -> *const T {
         self.slice.as_ptr()
     }
 
-    /// Returns the length of the wrapped slice reference.
+    /// Returns the length of the slice.
     pub fn len(&self) -> usize {
         self.slice.len()
     }
 
-    /// Retrieve the inner slice reference.
-    pub fn as_slice_ref(&self) -> &'a [T] {
+    /// Retrieve the slice. Consumes the [`DmaSlice`].
+    pub fn take(&self) -> &'a [T] {
         self.slice
     }
 }
 
-/// A mutable buffer that can be safely used for DMA operations that read from
-/// and/or write to the buffer's contents.
+/// A mutable buffer that can be safely used for DMA operations that read or
+/// write the buffer's contents.
+///
+/// The buffer can be a slice of any type that is guaranteed to be initialized
+/// without interior mutability, for example a `[u8]` or `[u32]`.
+///
+/// # Use with DMA
 ///
 /// Creating a [`DmaSliceMut`] over a mutable Rust slice ensures that all prior
 /// Rust writes to this slice are observable by any DMA operations initiated
 /// through an MMIO write operation, where that MMIO write is performed
 /// **after** constructing the `DmaSliceMut`. All writes by the DMA operation
 /// will be observable by Rust when calling
-/// [`restore_mut_slice_ref`](Self::restore_mut_slice_ref) **after** the DMA
+/// [`take`](Self::take) **after** the DMA
 /// operation is finished.
+///
+/// This struct uses a [`DmaFence`] implementation to ensure that all prior
+/// writes to `slice` are exposed to any DMA operations initiated by an MMIO
+/// read or write operation after this function returns, and which finish
+/// before calling [`take`](Self::take).
 ///
 /// # Safety Considerations
 ///
 /// Users **must** eventually call
-/// [`restore_mut_slice_ref`](Self::restore_mut_slice_ref) to retrieve the
+/// [`take`](Self::take) to retrieve the
 /// underlying buffer. The [`DmaSliceMut`] must exist for the entire duration of
 /// the DMA operation. Users must never drop a [`DmaSliceMut`] with a
 /// non-`'static` lifetime, as this could provide access to the underlying
@@ -86,7 +153,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSlice<'a, T> {
 /// issuing a DMA memory fence to ensure that writes by the DMA operation are
 /// visible to Rust.
 ///
-/// [`restore_mut_slice_ref`](Self::restore_mut_slice_ref) must only be called
+/// [`take`](Self::take) must only be called
 /// after the DMA operation has been observed to be complete (such as through a
 /// memory or MMIO read). Callers must ensure that the hardware will not perform
 /// any further writes to the buffer at the point where
@@ -97,7 +164,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSlice<'a, T> {
 /// [`as_mut_ptr`](Self::as_mut_ptr) and [`len`](Self::len).
 ///
 /// Users are responsible to ensure that, after the DMA operation completes and
-/// before calling [`restore_mut_slice_ref`](Self::restore_mut_slice_ref), every
+/// before calling [`take`](Self::take), every
 /// element in the underlying slice represents a well-initialized and valid
 /// instance of its type (with the exception of padding bytes). See the
 /// [zerocopy crate](https://docs.rs/zerocopy/0.8.31/zerocopy/) for an more
@@ -109,24 +176,27 @@ pub struct DmaSliceMut<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes>
 }
 
 impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSliceMut<'a, T> {
-    /// Create a [`DmaSliceMut`] from a unique, mutable Rust slice.
-    ///
-    /// This function uses the supplied `fence` object to ensure that all prior
-    /// writes to `slice` are exposed to any DMA operations initiated by an MMIO
-    /// read or write operation after this function returns, and which finish
-    /// before calling [`restore_mut_slice_ref`](Self::restore_mut_slice_ref).
+    /// Create a [`DmaSliceMut`] from a static mutable slice.
+    pub fn new(slice: &'static mut [T], fence: impl DmaFence) -> DmaSliceMut<'static, T> {
+        // # Safety
+        //
+        // This operation is safe, as dropping or forgetting its return value
+        // is safe. This would merely leak memory and make the underlying
+        // slice inaccessible.
+        unsafe { Self::from_mut_slice_ref(slice, fence) }
+    }
+
+    /// Create a [`DmaSliceMut`] from a mutable slice.
     ///
     /// # Safety
     ///
-    /// Refer the safety documentation of the [`DmaSliceMut`] type.
-    ///
-    /// This function is unsafe, as dropping or
-    /// [`forget`](core::mem::forget)ting its return value is not allowed when
-    /// the lifetime `'b` is not `'static`. Users **must** eventually call
-    /// [`restore_mut_slice_ref`](Self::restore_mut_slice_ref) to retrieve the
-    /// underlying buffer.
+    /// Callers must ensure to not[`forget`](core::mem::forget) the returned
+    /// [`DmaSliceMut`]. This could provide access to the underlying buffer
+    /// without guaranteeing that the DMA operation has finished.
+    /// Users **must** eventually call[`restore_mut_slice_ref`]
+    /// (Self::restore_mut_slice_ref) to retrieve the underlying buffer.
     #[must_use]
-    pub unsafe fn from_mut_slice_ref(slice: &mut [T], fence: impl DmaFence) -> DmaSliceMut<'_, T> {
+    pub unsafe fn new_unsafe(slice: &mut [T], fence: impl DmaFence) -> DmaSliceMut<'_, T> {
         let dma_slice_mut = DmaSliceMut {
             slice_ptr: NonNull::from_mut(slice),
             _lt: PhantomData,
@@ -140,29 +210,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSliceMut<'a, T
         dma_slice_mut
     }
 
-    /// Create a [`DmaSliceMut`] from a unique, mutable Rust slice with
-    /// `'static` lifetime.
-    ///
-    /// This function uses the supplied `fence` object to ensure that all prior
-    /// writes to `slice` are exposed to any DMA operations initiated by an MMIO
-    /// read or write operation after this function returns, and which finish
-    /// before calling [`restore_mut_slice_ref`](Self::restore_mut_slice_ref).
-    ///
-    /// # Comparsion with [`from_mut_slice_ref`](Self::from_mut_slice_ref)
-    ///
-    /// In contrast to [`from_mut_slice_ref`](Self::from_mut_slice_ref) this
-    /// function is safe, as dropping or forgetting its return value is safe, it
-    /// would merely leak memory and make the underlying slice inaccessible.
-    ///
-    /// The other safety considerations of the [`DmaSliceMut`] type still apply.
-    pub fn from_static_mut_slice_ref(
-        slice: &'static mut [T],
-        fence: impl DmaFence,
-    ) -> DmaSliceMut<'static, T> {
-        unsafe { Self::from_mut_slice_ref(slice, fence) }
-    }
-
-    /// Returns the pointer to the first element of the wrapped slice reference.
+    /// Returns the pointer to the start of the slice.
     pub fn as_mut_ptr(&self) -> *mut T {
         // TODO: switch `.cast()` to `.as_mut_ptr()` on the slice pointer (`*mut
         // [T]`) to obtain the "thin", raw pointer to its first element. This is
@@ -170,29 +218,23 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSliceMut<'a, T
         self.slice_ptr.as_ptr().cast()
     }
 
-    /// Returns the length of the wrapped slice reference.
+    /// Returns the length of the slice.
     pub fn len(&self) -> usize {
         self.slice_ptr.len()
     }
 
-    /// Recover the original, unique (mutable) slice used to construct this
-    /// [`DmaSliceMut`] object.
+    /// Recover the original mutable slice.
     ///
-    /// This function uses the supplied `fence` object to ensure that all prior
-    /// writes to `slice` by any completed DMA operations are exposed to any
-    /// subsequent Rust reads.
+    /// The caller MUST ensure the hardware DMA will no longer write to
+    /// the buffer.
     ///
     /// # Safety
     ///
-    /// Refer the safety documentation of the [`DmaSliceMut`] type.
-    ///
-    /// In particular, [`restore_mut_slice_ref`](Self::restore_mut_slice_ref)
-    /// must only be called after the DMA operation has been observed to be
-    /// complete (such as through a memory or MMIO read). Callers must ensure
-    /// that the hardware will not perform any further writes to the buffer at
-    /// the point where [`restore_mut_slice_ref`](Self::restore_mut_slice_ref)
-    /// is called.
-    pub unsafe fn restore_mut_slice_ref(mut self, fence: impl DmaFence) -> &'a mut [T] {
+    /// Callers must guarantee no hardware DMA have access to the buffer
+    /// before calling `take()`. All DMA operations must have completed
+    /// before calling this function and the caller must ensure no future
+    /// operations will occur using the underlying buffer.
+    pub unsafe fn take(mut self, fence: impl DmaFence) -> &'a mut [T] {
         // Ensure that any reads from Rust to the buffer described by
         // `slice_ptr` _after_ this function returns reflect all writes made by
         // DMA operations finished _before_ this function ran:

--- a/kernel/src/utilities/dma_slice.rs
+++ b/kernel/src/utilities/dma_slice.rs
@@ -38,25 +38,56 @@
 //!
 //! # Usage
 //!
-//! This is a rough sketch of how to use a `DmaSlice`:
+//! This example shows how a developer might use the `DmaSlice` infrastructure
+//! in a driver. The [`DmaSliceMut::new`] operation can be replaced by the safe
+//! [`DmaSliceMut::new_static`] alternative if the provided slice reference has
+//! a `'static` lifetime.
 //!
-//! ```ignore
+//! ```
+//! # use core::cell::Cell;
+//! # use kernel::platform::dma_fence::DmaFence;
+//! # use kernel::utilities::dma_slice::DmaSliceMut;
+//! #
+//! # #[derive(Debug, Copy, Clone)]
+//! # struct SomeDmaFence;
+//! # unsafe impl DmaFence for SomeDmaFence {
+//! #     fn release<T>(self, _buf: *mut [T]) {}
+//! #     fn acquire<T>(self, _buf: *mut [T]) {}
+//! # }
+//! #
+//! # enum DmaOp {
+//! #     Stop,
+//! # }
+//! #
+//! # struct Registers {
+//! #     dma_ptr: Cell<*mut u8>,
+//! #     dma_ctrl: Cell<DmaOp>,
+//! # }
+//! #
+//! # let regs = Registers {
+//! #     dma_ptr: Cell::new(core::ptr::null_mut()),
+//! #     dma_ctrl: Cell::new(DmaOp::Stop),
+//! # };
+//! #
 //! // Buffer that will be used by the DMA hardware.
-//! let buffer: [u8] = ...;
+//! let mut buffer: [u8; 16] = [0_u8; 16];
 //!
 //! // Create the `DmaSlice` that can be provided to the DMA hardware.
-//! let dma_slice = DmaSlice::new(buffer, cortexm::dma_fence::DmaFence);
+//! //
+//! // For a static slice, users can instead use the safe `new_static`
+//! // constructor.
+//! let dma_slice = unsafe { DmaSliceMut::new(&mut buffer, SomeDmaFence) };
 //!
 //! // Provide the pointer to the buffer to the DMA hardware registers.
-//! self.registers.dma.set(dma_slice.as_ptr());
+//! regs.dma_ptr.set(dma_slice.as_mut_ptr());
 //!
 //! // Wait for the DMA operation to finish...
 //!
 //! // Disable the DMA engine to ensure it cannot access the buffer.
-//! self.registers.dma.set(DMA::STOP);
+//! regs.dma_ctrl.set(DmaOp::Stop);
 //!
 //! // Extract the buffer to retrieve the Rust slice.
-//! let buffer = dma_slice.take();
+//! let buffer = unsafe { dma_slice.take(SomeDmaFence) };
 //! ```
 
 use core::marker::PhantomData;

--- a/kernel/src/utilities/dma_slice.rs
+++ b/kernel/src/utilities/dma_slice.rs
@@ -133,7 +133,8 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSlice<'a, T> {
         // Ensure that all prior writes to this slice are exposed to any DMA
         // operations initiated by an MMIO read or write operation after this
         // function returns.
-        fence.release::<T>(ptr::from_ref(slice) as *mut [T]);
+        let mut_slice_ptr: *mut [T] = ptr::from_ref(slice).cast_mut();
+        fence.release::<T>(mut_slice_ptr);
 
         DmaSlice { slice }
     }
@@ -342,7 +343,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSliceMutImmut<
     pub fn as_ptr(&self) -> *const T {
         match self {
             DmaSliceMutImmut::Immutable(dma_slice) => dma_slice.as_ptr(),
-            DmaSliceMutImmut::Mutable(dma_slice_mut) => dma_slice_mut.as_mut_ptr() as *const T,
+            DmaSliceMutImmut::Mutable(dma_slice_mut) => dma_slice_mut.as_mut_ptr().cast_const(),
         }
     }
 
@@ -373,7 +374,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSliceMutImmut<
                 // such, we can safely hand out immutable references over this
                 // slice, which are also bound to the lifetime `'a`.
                 core::slice::from_raw_parts(
-                    dma_slice_mut.as_mut_ptr() as *const T,
+                    dma_slice_mut.as_mut_ptr().cast_const(),
                     dma_slice_mut.len(),
                 )
             },
@@ -417,11 +418,12 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSlice<'a, T
         // Clippy says we should be using `.as_mut_ptr()` instead of `.as_ptr()
         // as *mut T`, but that method doesn't exist. The cast doesn't matter
         // here, `DmaFence::release` will not actually dereference the memory.
+        let sub_slice_ptr: *mut T = sub_slice.as_ptr().cast_mut();
         #[allow(clippy::as_ptr_cast_mut)]
         fence.release::<T>(ptr::slice_from_raw_parts_mut(
             // `SubSlice::as_ptr()` returns a pointer to the currently
             // accessible portion of the `SubSlice`.
-            sub_slice.as_ptr() as *mut T,
+            sub_slice_ptr,
             // `SubSlice::len()` returns the length of the currently accessible
             // portion of the `SubSlice`.
             sub_slice.len(),
@@ -699,7 +701,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMutImm
         match self {
             DmaSubSliceMutImmut::Immutable(dma_sub_slice) => dma_sub_slice.as_ptr(),
             DmaSubSliceMutImmut::Mutable(dma_sub_slice_mut) => {
-                dma_sub_slice_mut.as_mut_ptr() as *const T
+                dma_sub_slice_mut.as_mut_ptr().cast_const()
             }
         }
     }

--- a/kernel/src/utilities/dma_slice.rs
+++ b/kernel/src/utilities/dma_slice.rs
@@ -5,10 +5,12 @@
 
 //! Mechanism for sharing buffers with DMA peripherals.
 //!
-//! When implementing a chip peripheral driver using DMA, the driver must use
-//! a `DmaSlice` when passing a buffer to the DMA hardware. This ensures that
-//! Rust's memory requirements are preserved when hardware is accessing
-//! memory in a way the Rust compiler cannot reason about.
+//! When implementing a chip peripheral driver using DMA, the driver must be
+//! careful to not intoduce any undefined behavior. This module provides
+//! `DmaSlice` types, which drivers can use when passing a buffer to the DMA
+//! hardware. When used correctly, types ensure that Rust's memory requirements
+//! are preserved when hardware is accessing memory in a way the Rust compiler
+//! cannot reason about.
 //!
 //! Tock provides multiple implementations of `DmaSlice` depending on the
 //! needs of the user. These include:
@@ -25,14 +27,14 @@
 //! Rust compiler cannot assume the memory passed to the DMA hardware is not
 //! modified.
 //!
-//! Conceptually, a `DmaSlice` consumes a memory buffer, and once consumed a
-//! pointer to that memory can then be safely provided to DMA hardware. When
-//! the buffer is consumed, the `DmaSlice` implementations uphold the Rust
-//! memory soundness requirements now that hardware can directly read and/or
-//! write the memory in a way that the Rust compiler cannot reason about.
-//! Once the DMA operation finishes, the buffer must be extracted from the
-//! `DmaSlice`. Before extracting the buffer, the user must guarantee that
-//! the DMA hardware can no longer access the memory.
+//! Conceptually, a `DmaSlice` consumes a memory buffer. Once consumed, a
+//! pointer to that memory can then be safely provided to DMA hardware. When the
+//! buffer is consumed, the `DmaSlice` prevent the Rust compiler from making
+//! assumptions about the state of the memory accessed by DMA hardware that
+//! would be incorrect and introduce undefined behavior. Once the DMA operation
+//! finishes, the buffer must be extracted from the `DmaSlice`. Before
+//! extracting the buffer, the user must guarantee that the DMA hardware can no
+//! longer access the memory.
 //!
 //! # Usage
 //!

--- a/kernel/src/utilities/dma_slice.rs
+++ b/kernel/src/utilities/dma_slice.rs
@@ -6,9 +6,9 @@
 //! Mechanism for sharing buffers with DMA peripherals.
 //!
 //! When implementing a chip peripheral driver using DMA, the driver must be
-//! careful to not intoduce any undefined behavior. This module provides
+//! careful to not introduce any undefined behavior. This module provides
 //! `DmaSlice` types, which drivers can use when passing a buffer to the DMA
-//! hardware. When used correctly, types ensure that Rust's memory requirements
+//! hardware. When used correctly, these types ensure that Rust's memory requirements
 //! are preserved when hardware is accessing memory in a way the Rust compiler
 //! cannot reason about.
 //!
@@ -23,13 +23,13 @@
 //!   operations.
 //!
 //! Internally, all implementations of `DmaSlice` use an architecture or
-//! chip-provided implementation of [`DmaFence`] to manually ensure that the
+//! chip-provided implementation of [`DmaFence`] to ensure that the
 //! Rust compiler cannot assume the memory passed to the DMA hardware is not
 //! modified.
 //!
 //! Conceptually, a `DmaSlice` consumes a memory buffer. Once consumed, a
 //! pointer to that memory can then be safely provided to DMA hardware. When the
-//! buffer is consumed, the `DmaSlice` prevent the Rust compiler from making
+//! buffer is consumed, the `DmaSlice` prevents the Rust compiler from making
 //! assumptions about the state of the memory accessed by DMA hardware that
 //! would be incorrect and introduce undefined behavior. Once the DMA operation
 //! finishes, the buffer must be extracted from the `DmaSlice`. Before
@@ -99,12 +99,13 @@ use crate::platform::dma_fence::DmaFence;
 
 /// An immutable buffer that can be safely used for read-only DMA operations.
 ///
-/// The buffer can be a slice of any type that is guaranteed to be initialized
-/// without interior mutability, for example a `[u8]` or `[u32]`.
+/// The buffer can be a slice of any type which implements
+/// [`ImmutableFromIntoBytes`](immutable_from_into_bytes::ImmutableFromIntoBytes),
+/// such as `u8` or `u32`.
 ///
-/// [`DmaSlice`] wraps an immutable slice. As such, its
-/// contents MUST NOT be modified by the DMA operation. For a DMA operation that
-/// may write to the supplied buffer, use [`DmaSliceMut`] instead.
+/// [`DmaSlice`] wraps an immutable slice. As such, its contents MUST NOT be
+/// modified by the DMA operation. For a DMA operation that may write to the
+/// supplied buffer, use [`DmaSliceMut`] instead.
 ///
 /// # Use with DMA
 ///
@@ -113,14 +114,14 @@ use crate::platform::dma_fence::DmaFence;
 /// through an MMIO write operation, where that MMIO write is performed after
 /// constructing the [`DmaSlice`].
 ///
-/// For this guarantee to hold, the [`DmaSlice`] struct must exist for the
+/// For this guarantee to hold, the [`DmaSlice`] instance must exist for the
 /// duration of the entire DMA operation, until the Rust program has observed
 /// that the operation is complete (such as by reading a status bit in memory or
 /// an MMIO register).
 ///
 /// This struct uses a [`DmaFence`] implementation to ensure that all prior
 /// writes to `slice` are exposed to any DMA operations initiated by an MMIO
-/// read or write operation after this function returns, and which finish
+/// read or write operation issued after this function returns, and which finish
 /// before the resulting [`DmaSlice`] is dropped.
 #[derive(Debug)]
 pub struct DmaSlice<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> {
@@ -161,8 +162,9 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSlice<'a, T> {
 /// A mutable buffer that can be safely used for DMA operations that read or
 /// write the buffer's contents.
 ///
-/// The buffer can be a slice of any type that is guaranteed to be initialized
-/// without interior mutability, for example a `[u8]` or `[u32]`.
+/// The buffer can be a slice of any type which implements
+/// [`ImmutableFromIntoBytes`](immutable_from_into_bytes::ImmutableFromIntoBytes),
+/// such as `u8` or `u32`.
 ///
 /// # Use with DMA
 ///
@@ -170,14 +172,13 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSlice<'a, T> {
 /// Rust writes to this slice are observable by any DMA operations initiated
 /// through an MMIO write operation, where that MMIO write is performed
 /// **after** constructing the `DmaSliceMut`. All writes by the DMA operation
-/// will be observable by Rust when calling
-/// [`take`](Self::take) **after** the DMA
-/// operation is finished.
+/// will be observable by Rust when calling [`take`](Self::take) **after** the
+/// DMA operation is finished.
 ///
 /// This struct uses a [`DmaFence`] implementation to ensure that all prior
 /// writes to `slice` are exposed to any DMA operations initiated by an MMIO
-/// read or write operation after this function returns, and which finish
-/// before calling [`take`](Self::take).
+/// read or write operation after this function returns, and which finish before
+/// calling [`take`](Self::take).
 ///
 /// # Safety Considerations
 ///
@@ -190,20 +191,23 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSlice<'a, T> {
 /// visible to Rust.
 ///
 /// [`take`](Self::take) must only be called after the DMA operation has been
-/// observed to be complete (such as through a memory or MMIO read). Callers
+/// observed to be complete through an explicit memory or MMIO read. Callers
 /// must ensure that the hardware will not perform any further writes to the
 /// buffer at the point where [`take`](Self::take) is called.
 ///
-/// Callers must further ensure that they start DMA operations only after
-/// constructing the [`DmaSliceMut`], and only in the memory region described by
-/// [`as_mut_ptr`](Self::as_mut_ptr) and [`len`](Self::len).
+/// Callers must further ensure that they start DMA operations through a memory
+/// or MMIO write only after constructing the [`DmaSliceMut`], and only in the
+/// memory region described by [`as_mut_ptr`](Self::as_mut_ptr) and
+/// [`len`](Self::len).
 ///
 /// Users are responsible to ensure that, after the DMA operation completes and
-/// before calling [`take`](Self::take), every
-/// element in the underlying slice represents a well-initialized and valid
-/// instance of its type (with the exception of padding bytes). See the
-/// [zerocopy crate](https://docs.rs/zerocopy/0.8.31/zerocopy/) for an more
-/// in-depth explanation of these requirements.
+/// before calling [`take`](Self::take), every element in the underlying slice
+/// represents a well-initialized and valid instance of its type (with the
+/// exception of padding bytes). Concretely, all elements in the slice must meet
+/// the requirements of the
+/// [`ImmutableFromIntoBytes`](immutable_from_into_bytes::ImmutableFromIntoBytes)
+/// trait. See the [zerocopy crate](https://docs.rs/zerocopy/0.8.31/zerocopy/)
+/// for a more in-depth explanation of these requirements.
 #[derive(Debug)]
 pub struct DmaSliceMut<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> {
     slice_ptr: NonNull<[T]>,
@@ -215,9 +219,9 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSliceMut<'a, T
     pub fn new_static(slice: &'static mut [T], fence: impl DmaFence) -> DmaSliceMut<'static, T> {
         // # Safety
         //
-        // This operation is safe, as dropping or forgetting its return value
-        // is safe. This would merely leak memory and make the underlying
-        // slice inaccessible.
+        // This operation is safe, as dropping or forgetting its return value is
+        // safe. This would merely leak memory and make the underlying slice
+        // inaccessible.
         unsafe { Self::new(slice, fence) }
     }
 
@@ -225,11 +229,10 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSliceMut<'a, T
     ///
     /// # Safety
     ///
-    /// Callers must ensure to not[`forget`](core::mem::forget) the returned
-    /// [`DmaSliceMut`]. This could provide access to the underlying buffer
-    /// without guaranteeing that the DMA operation has finished.  Users
-    /// **must** eventually call [`take`](Self::take) to retrieve the underlying
-    /// buffer.
+    /// Callers must ensure to not drop the returned [`DmaSliceMut`]. This could
+    /// provide access to the underlying buffer without guaranteeing that the
+    /// DMA operation has finished.  Users **must** eventually call
+    /// [`take`](Self::take) to retrieve the underlying buffer.
     #[must_use]
     pub unsafe fn new(slice: &mut [T], fence: impl DmaFence) -> DmaSliceMut<'_, T> {
         let dma_slice_mut = DmaSliceMut {
@@ -260,19 +263,19 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSliceMut<'a, T
 
     /// Recover the original mutable slice.
     ///
-    /// The caller MUST ensure the hardware DMA will no longer write to
-    /// the buffer.
+    /// The caller MUST ensure the hardware DMA will no longer write to the
+    /// buffer.
     ///
     /// # Safety
     ///
-    /// Callers must guarantee no hardware DMA have access to the buffer
-    /// before calling `take()`. All DMA operations must have completed
-    /// before calling this function and the caller must ensure no future
-    /// operations will occur using the underlying buffer.
+    /// Callers must guarantee no hardware DMA have access to the buffer before
+    /// calling `take()`. All DMA operations must have completed before calling
+    /// this function and the caller must ensure no future operations will occur
+    /// using the underlying buffer.
     pub unsafe fn take(mut self, fence: impl DmaFence) -> &'a mut [T] {
         // Ensure that any reads from Rust to the buffer described by
-        // `slice_ptr` _after_ this function returns reflect all writes made by
-        // DMA operations finished _before_ this function ran:
+        // `slice_ptr` issued _after_ this function returns reflect all writes
+        // made by DMA operations finished _before_ this function ran:
         fence.acquire::<T>(self.slice_ptr.as_ptr());
 
         unsafe { self.slice_ptr.as_mut() }
@@ -293,11 +296,10 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSliceMut<'a, T
 /// memory or an MMIO register).
 ///
 /// [`DmaSliceMutImmut`] may wrap an immutable, shared Rust slice
-/// reference. Furthermore, in contrast to `DmaSliceMut`, `DmaSliceMutImmut`
-/// may not expose writes performed by a DMA operation back to Rust. As such,
-/// its contents *must* not be modified by the DMA operation. For a DMA
-/// operation that may write to the supplied buffer, use [`DmaSliceMut`]
-/// instead.
+/// reference. Furthermore, in contrast to `DmaSliceMut`, `DmaSliceMutImmut` may
+/// not expose writes performed by a DMA operation back to Rust. As such, its
+/// contents *must* not be modified by the DMA operation. For a DMA operation
+/// that may write to the supplied buffer, use [`DmaSliceMut`] instead.
 #[derive(Debug)]
 pub enum DmaSliceMutImmut<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> {
     Immutable(DmaSlice<'a, T>),
@@ -448,20 +450,30 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSlice<'a, T
     }
 }
 
-/// An mutable buffer that can be safely used for DMA operations that read from
-/// and/or write to the buffer's contents.
+/// A mutable buffer that can be safely used for DMA operations that read or
+/// write the buffer's contents.
+///
+/// The buffer can be a slice of any type which implements
+/// [`ImmutableFromIntoBytes`](immutable_from_into_bytes::ImmutableFromIntoBytes),
+/// such as `u8` or `u32`.
+///
+/// # Use with DMA
 ///
 /// Creating a [`DmaSubSliceMut`] over a [`SubSliceMut`] ensures that all prior
-/// Rust writes to this slice's active range are observable by any DMA
+/// Rust writes to the active range of this slice are observable by any DMA
 /// operations initiated through an MMIO write operation, where that MMIO write
 /// is performed **after** constructing the `DmaSubSliceMut`. All writes by the
 /// DMA operation will be observable by Rust when calling [`take`](Self::take)
 /// **after** the DMA operation is finished.
 ///
-/// # Safety
+/// This struct uses a [`DmaFence`] implementation to ensure that all prior
+/// writes to `slice` are exposed to any DMA operations initiated by an MMIO
+/// read or write operation after this function returns, and which finish before
+/// calling [`take`](Self::take).
 ///
-/// Users **must** eventually call
-/// [`take`](Self::take) to retrieve the
+/// # Safety Considerations
+///
+/// Users **must** eventually call [`take`](Self::take) to retrieve the
 /// underlying buffer. The [`DmaSubSliceMut`] must exist for the entire duration
 /// of the DMA operation. Users must never drop a [`DmaSubSliceMut`] with a
 /// non-`'static` lifetime, as this could provide access to the underlying
@@ -469,22 +481,24 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSlice<'a, T
 /// issuing a DMA memory fence to ensure that writes by the DMA operation are
 /// visible to Rust.
 ///
-/// [`take`](Self::take) must only be called
-/// after the DMA operation has been observed to be complete (such as through a
-/// memory or MMIO read). Callers must ensure that the hardware will not perform
-/// any further writes to the buffer at the point where
-/// [`take`](Self::take) is called.
+/// [`take`](Self::take) must only be called after the DMA operation has been
+/// observed to be complete through an explicit memory or MMIO read. Callers
+/// must ensure that the hardware will not perform any further writes to the
+/// buffer at the point where [`take`](Self::take) is called.
 ///
-/// Callers must further ensure that they start DMA operations only after
-/// constructing the [`DmaSubSliceMut`], and only in the memory region described
-/// by [`as_mut_ptr`](Self::as_mut_ptr) and [`len`](Self::len).
+/// Callers must further ensure that they start DMA operations through a memory
+/// or MMIO write only after constructing the [`DmaSubSliceMut`], and only in
+/// the memory region described by [`as_mut_ptr`](Self::as_mut_ptr) and
+/// [`len`](Self::len).
 ///
 /// Users are responsible to ensure that, after the DMA operation completes and
 /// before calling [`take`](Self::take), every element in the underlying slice
 /// represents a well-initialized and valid instance of its type (with the
-/// exception of padding bytes). See the [zerocopy
-/// crate](https://docs.rs/zerocopy/0.8.31/zerocopy/) for an more in-depth
-/// explanation of these requirements.
+/// exception of padding bytes). Concretely, all elements in the slice must meet
+/// the requirements of the
+/// [`ImmutableFromIntoBytes`](immutable_from_into_bytes::ImmutableFromIntoBytes)
+/// trait. See the [zerocopy crate](https://docs.rs/zerocopy/0.8.31/zerocopy/)
+/// for a more in-depth explanation of these requirements.
 #[derive(Debug)]
 pub struct DmaSubSliceMut<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> {
     internal_slice_ptr: NonNull<[T]>,
@@ -493,20 +507,27 @@ pub struct DmaSubSliceMut<'a, T: immutable_from_into_bytes::ImmutableFromIntoByt
 }
 
 impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMut<'a, T> {
+    /// Create a [`DmaSubSliceMut`] from a [`SubSliceMut`] with `'static`
+    /// lifetime.
+    pub fn new_static(
+        sub_slice: SubSliceMut<'static, T>,
+        fence: impl DmaFence,
+    ) -> DmaSubSliceMut<'static, T> {
+        // # Safety
+        //
+        // This operation is safe, as dropping or forgetting its return value is
+        // safe. This would merely leak memory and make the underlying slice
+        // inaccessible.
+        unsafe { Self::new(sub_slice, fence) }
+    }
+
     /// Create a [`DmaSubSliceMut`] from a [`SubSliceMut`].
-    ///
-    /// This function uses the supplied `fence` object to ensure that all prior
-    /// writes to the active region of `slice` are exposed to any DMA operations
-    /// initiated by an MMIO read or write operation after this function
-    /// returns, and which finish before calling [`take`](Self::take).
     ///
     /// # Safety
     ///
-    /// Refer the safety documentation of the [`DmaSubSliceMut`] type.
-    ///
-    /// This function is unsafe, as dropping or
-    /// [`forget`](core::mem::forget)ting its return value is not allowed when
-    /// the lifetime `'b` is not `'static`. Users **must** eventually call
+    /// Callers must ensure to not drop the returned [`DmaSubSliceMut`]. This
+    /// could provide access to the underlying buffer without guaranteeing that
+    /// the DMA operation has finished. Users **must** eventually call
     /// [`take`](Self::take) to retrieve the underlying buffer.
     #[must_use]
     pub unsafe fn new(
@@ -532,28 +553,6 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMut<'a
         ));
 
         dma_sub_slice_mut
-    }
-
-    /// Create a [`DmaSubSliceMut`] from a [`SubSliceMut`] with `'static`
-    /// lifetime.
-    ///
-    /// This function uses the supplied `fence` object to ensure that all prior
-    /// writes to `slice` are exposed to any DMA operations initiated by an MMIO
-    /// read or write operation after this function returns, and which finish
-    /// before calling [`take`](Self::take).
-    ///
-    /// # Safety
-    ///
-    /// Refer the safety documentation of the [`DmaSubSliceMut`] type.
-    ///
-    /// In contrast to [`new`](Self::new) this function is safe, as dropping or
-    /// forgetting its return value is safe, it would merely leak memory and
-    /// make the underlying slice inaccessible.
-    pub fn new_static(
-        sub_slice: SubSliceMut<'static, T>,
-        fence: impl DmaFence,
-    ) -> DmaSubSliceMut<'static, T> {
-        unsafe { Self::new(sub_slice, fence) }
     }
 
     /// Returns the pointer to the first element of the active range of the
@@ -587,19 +586,12 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMut<'a
     /// Recover the original [`SubSliceMut`] used to construct this
     /// [`DmaSubSliceMut`] object.
     ///
-    /// This function uses the supplied `fence` object to ensure that all prior
-    /// writes to the active range of `slice` by any completed DMA operations
-    /// are exposed to any subsequent Rust reads.
-    ///
     /// # Safety
     ///
-    /// Refer the safety documentation of the [`DmaSubSliceMut`] type.
-    ///
-    /// In particular, [`take`](Self::take) must only be called after the DMA
-    /// operation has been observed to be complete (such as through a memory or
-    /// MMIO read). Callers must ensure that the hardware will not perform any
-    /// further writes to the buffer at the point where [`take`](Self::take) is
-    /// called.
+    /// Callers must guarantee no hardware DMA have access to the buffer before
+    /// calling `take()`. All DMA operations must have completed before calling
+    /// this function and the caller must ensure no future operations will occur
+    /// using the underlying buffer.
     pub unsafe fn take(mut self, fence: impl DmaFence) -> SubSliceMut<'a, T> {
         // Ensure that any reads from Rust to the active range of the buffer
         // (described by `self.as_mut_ptr()` and `self.len()`) _after_ this
@@ -614,11 +606,9 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMut<'a
     }
 
     /// Recover the original [`SubSliceMut`] used to construct this
-    /// [`DmaSubSliceMut`] object, without performing an acquire DMA fence.
+    /// [`DmaSubSliceMut`] object, without performing an `acquire` fence.
     ///
     /// # Safety
-    ///
-    /// Refer the safety documentation of the [`DmaSubSliceMut`] type.
     ///
     /// This function does not necessarily expose any writes to the underlying
     /// buffer to Rust. It must only be used when the underlying buffer's
@@ -636,15 +626,15 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMut<'a
 /// A buffer that can be safely used for read-only DMA operations, backed by
 /// either a [`SubSliceMutImmut`].
 ///
-/// Creating a [`DmaSubSliceMutImmut`] over a [`SubSliceMutImmut`] ensures that all
-/// prior Rust writes to the active region of this slice are observable by any
-/// DMA operations initiated through an MMIO write operation, where that MMIO
-/// write is performed *after* constructing the `DmaSubSliceMutImmut`.
+/// Creating a [`DmaSubSliceMutImmut`] over a [`SubSliceMutImmut`] ensures that
+/// all prior Rust writes to the active region of this slice are observable by
+/// any DMA operations initiated through an MMIO write operation, where that
+/// MMIO write is performed *after* constructing the `DmaSubSliceMutImmut`.
 ///
-/// For this guarantee to hold, the `DmaSubSliceMutImmut` struct must exist for the
-/// duration of the entire DMA operation, until the Rust program has observed
-/// that the operation is complete (such as by reading a status bit in memory or
-/// an MMIO register).
+/// For this guarantee to hold, the `DmaSubSliceMutImmut` struct must exist for
+/// the duration of the entire DMA operation, until the Rust program has
+/// observed that the operation is complete (such as by reading a status bit in
+/// memory or an MMIO register).
 ///
 /// [`DmaSliceMutImmut`] may wrap an immutable, shared Rust slice
 /// reference. Furthermore, in contrast to `DmaSubSliceMut`,
@@ -743,19 +733,19 @@ pub mod immutable_from_into_bytes {
         pub trait Sealed {}
     }
 
-    /// A type that is can be safely converted to an initialized sequence of bytes,
-    /// from an arbitrary initialized sequence of bytes, and does not feature
-    /// interior mutability.
+    /// A type that is can be safely converted to an initialized sequence of
+    /// bytes, from an arbitrary initialized sequence of bytes, and does not
+    /// feature interior mutability.
     ///
-    /// The requirements on implementors of this trait are effectively the same as
-    /// the combination of zerocopy's [`FromBytes`][zerocopy-frombytes],
+    /// The requirements on implementors of this trait are effectively the same
+    /// as the combination of zerocopy's [`FromBytes`][zerocopy-frombytes],
     /// [`IntoBytes`][zerocopy-intobytes], and [`Immutable`][zerocopy-immutable]
     /// traits.
     ///
-    /// This trait is only implemented for a few select primitives, intended to be
-    /// used for DMA operations. It is sealed; all extensions to future types must
-    /// ensure they conform to the above trait's requirements and are safe for DMA
-    /// operations.
+    /// This trait is only implemented for a few select primitives, intended to
+    /// be used for DMA operations. It is sealed; all extensions to future types
+    /// must ensure they conform to the above trait's requirements and are safe
+    /// for DMA operations.
     ///
     /// [zerocopy-frombytes]: https://docs.rs/zerocopy/0.8.42/zerocopy/trait.FromBytes.html
     /// [zerocopy-intobytes]: https://docs.rs/zerocopy/0.8.42/zerocopy/trait.IntoBytes.html
@@ -883,7 +873,8 @@ mod miri_tests {
 
         // 1. Create from static
         //
-        // Note: access to static mut is unsafe, but the from_static_slice_ref call itself is safe
+        // Note: access to static mut is unsafe, but the from_static_slice_ref
+        // call itself is safe
         let dma = DmaSliceMut::new_static(unsafe { &mut *(&raw mut BUFFER) }, fence);
 
         // 2. Simulate DMA Write

--- a/kernel/src/utilities/leasable_buffer.rs
+++ b/kernel/src/utilities/leasable_buffer.rs
@@ -171,6 +171,8 @@ use core::ops::{Bound, Range, RangeBounds};
 use core::ops::{Index, IndexMut};
 use core::slice::SliceIndex;
 
+use super::copy_range::CopyRange;
+
 /// A mutable leasable buffer implementation.
 ///
 /// A leasable buffer can be used to pass a section of a larger mutable buffer
@@ -195,18 +197,30 @@ impl<'a, T> From<&'a mut [T]> for SubSliceMut<'a, T> {
 ///
 /// A leasable buffer can be used to pass a section of a larger mutable buffer
 /// but still get the entire buffer back in a callback.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct SubSlice<'a, T> {
-    internal: &'a [T],
-    active_range: Range<usize>,
+    pub(crate) internal: &'a [T],
+    pub(crate) active_range: CopyRange<usize>,
 }
+
+// Rust's derive fail to automatically infer that `SubSlice` can be
+// `Clone` even if `T: !Clone`.
+impl<T> Clone for SubSlice<'_, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+// Rust's derive fail to automatically infer that `SubSlice` can be
+// `Copy` even if `T: !Copy`.
+impl<T> Copy for SubSlice<'_, T> {}
 
 impl<'a, T> From<&'a [T]> for SubSlice<'a, T> {
     fn from(internal: &'a [T]) -> Self {
         let active_range = 0..(internal.len());
         Self {
             internal,
-            active_range,
+            active_range: active_range.into(),
         }
     }
 }
@@ -457,7 +471,7 @@ impl<'a, T> SubSlice<'a, T> {
         let len = buffer.len();
         SubSlice {
             internal: buffer,
-            active_range: 0..len,
+            active_range: (0..len).into(),
         }
     }
 
@@ -478,7 +492,7 @@ impl<'a, T> SubSlice<'a, T> {
     /// Most commonly, this is called once a sliced leasable buffer is returned
     /// through a callback.
     pub fn reset(&mut self) {
-        self.active_range = 0..self.internal.len();
+        self.active_range = (0..self.internal.len()).into();
     }
 
     /// Returns the length of the currently accessible portion of the SubSlice.
@@ -494,7 +508,7 @@ impl<'a, T> SubSlice<'a, T> {
     /// Returns a slice of the currently accessible portion of the
     /// LeasableBuffer.
     pub fn as_slice(&self) -> &[T] {
-        &self.internal[self.active_range.clone()]
+        &self.internal[Range::from(self.active_range)]
     }
 
     /// Returns `true` if the LeasableBuffer is sliced internally.
@@ -542,7 +556,7 @@ impl<'a, T> SubSlice<'a, T> {
     /// assert!(reconstructed_subslicemut.as_slice() == &[3, 4]);
     /// ```
     pub fn active_range(&self) -> Range<usize> {
-        self.active_range.clone()
+        self.active_range.into()
     }
 
     /// Reduces the range of the SubSlice that is accessible.
@@ -578,7 +592,7 @@ impl<'a, T> SubSlice<'a, T> {
         let new_start = min(self.active_range.start + start, self.active_range.end);
         let new_end = min(new_start + (end - start), self.active_range.end);
 
-        self.active_range = Range {
+        self.active_range = CopyRange {
             start: new_start,
             end: new_end,
         };
@@ -592,7 +606,7 @@ where
     type Output = <I as SliceIndex<[T]>>::Output;
 
     fn index(&self, idx: I) -> &Self::Output {
-        &self.internal[self.active_range.clone()][idx]
+        &self.internal[Range::from(self.active_range)][idx]
     }
 }
 

--- a/kernel/src/utilities/leasable_buffer.rs
+++ b/kernel/src/utilities/leasable_buffer.rs
@@ -230,6 +230,7 @@ impl<'a, T> From<&'a [T]> for SubSlice<'a, T> {
 /// In cases where code needs to support either a mutable or immutable SubSlice,
 /// `SubSliceMutImmut` allows the code to store a single type which can
 /// represent either option.
+#[derive(Debug)]
 pub enum SubSliceMutImmut<'a, T> {
     Immutable(SubSlice<'a, T>),
     Mutable(SubSliceMut<'a, T>),

--- a/kernel/src/utilities/mod.rs
+++ b/kernel/src/utilities/mod.rs
@@ -9,6 +9,7 @@ pub mod binary_write;
 pub mod capability_ptr;
 pub mod copy_range;
 pub mod copy_slice;
+pub mod dma_slice;
 pub mod helpers;
 pub mod io_write;
 pub mod leasable_buffer;

--- a/kernel/src/utilities/mod.rs
+++ b/kernel/src/utilities/mod.rs
@@ -7,6 +7,7 @@
 pub mod arch_helpers;
 pub mod binary_write;
 pub mod capability_ptr;
+pub mod copy_range;
 pub mod copy_slice;
 pub mod helpers;
 pub mod io_write;


### PR DESCRIPTION
### Pull Request Overview

This pull request adds `DmaSlice` types, which help facilitate sound DMA operations over Rust slices.

The way Tock performs DMA operations today has long been known to be unsound [1]. We generally move buffers around using unique (mutable), `'static` slice references. This works great, as we can pass these buffers like owned objects. However, Rust also places a strong set of assumptions over these types: for instance, that their contents are not aliased, and can only be accessed (read or modified) through that particular Rust reference.

When we perform DMA operations that read from or write to the backing memory behind these slices, we violate those assumptions. A DMA-capable peripheral may modify the buffer's contents, whereas Rust believed to have exclusive control over it. This introduces undefined behavior in general. We also don't currently attempt any synchronization or fencing. In practice, that can, at the very least, lead to writes to the exposed buffer not being fully exposed to the DMA hardware, or writes by DMA hardware not fully exposed to Rust.

This PR introduces `DmaSlice`-types which make interacting with DMA-capable peripherals easier. Through a clearly documented API, developers can convert their Rust slices to `DmaSlice` types *before* starting a DMA operation, and can re-obtain their original slice types *after* a DMA operation has completed. These types internally ensure that we uphold Rust's invariants around aliasing and provenance, and ensure that all intended writes are exposed from Rust to the hardware, or from the hardware to Rust, even in the presence of compiler-reordering, hardware-reordering, or non-coherent hardware caches.

For more details I encourage reading the documentation on these types directly. In short, it turns out that we cannot use standard library builtin fences to obtain the guarantees we want [2]. Furthermore, some platforms (especially around RISC-V, e.g., LiteX) require CPU-specific instruction to flush caches over DMA'd memory. Hence, we need to establish a custom, hardware-specific `DmaFence` mechanism that can be implemented by individual architectures or platforms (using `asm!()` blocks, as suggested in [2]). This common mechanism is then used to build various higher-level abstractions offering convenient APIs, such as ones that accept `SubSlice`s directly.

For now, this PR is still a draft: ~I haven't actually used these types~ *now implemented for VirtIO!*, but wanted to get it out there as this already was a substantial amount of work, and is in a good state to get feedback on soundness, the ergonomics, and especially the documentation.

[1]: https://github.com/tock/tock/issues/2637
[2]: https://users.rust-lang.org/t/compiler-fence-dma/132027/61?page=4


### Testing Strategy

This pull request ships some tests. I wrote all of the `DmaFence` and `DmaSlice`-related code myself, but used Gemini 3-Pro to generate, and then modified the Miri test cases alongside this infrastructure.

### TODO or Help Wanted

This pull request still needs

- [x] a careful soundness review,
- [x] actually using this infrastructure in 1-2 chips, to gain confidence that this interface makes sense.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
