### PR TITLE
boards/hail: bump MSRV to 1.89

### DIFF
--- a/boards/hail/Cargo.toml
+++ b/boards/hail/Cargo.toml
@@ -8,7 +8,7 @@ version.workspace = true
 authors.workspace = true
 build = "../build.rs"
 edition.workspace = true
-rust-version = "1.88"
+rust-version = "1.89"
 
 [dependencies]
 components = { path = "../components" }


### PR DESCRIPTION
### Pull Request Overview

This allows us to use `NonNull::from_mut` [1], which is useful for PR #4702.

[1]: https://doc.rust-lang.org/stable/core/ptr/struct.NonNull.html#method.from_mut


### Testing Strategy

N/A

### TODO or Help Wanted

N/A


### Documentation Updated

- [X] ~Updated the relevant files in `/docs`, or~ no updates are required.

### Formatting

- [ ] Ran `make prepush`.
