### PR TITLE
Reclaim RAM for terminated apps

### DIFF
--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -314,6 +314,19 @@ impl Kernel {
         Err(())
     }
 
+    /// Terminate a process if it exists, and remove it from ProcessArray.
+    pub(crate) fn reclaim_app_memory(&self, shortid: process::ShortId) {
+        for slot in self.processes.iter() {
+            if let Some(process) = slot.get() {
+                if process.short_app_id() == shortid {
+                    process.terminate(None);
+                    slot.proc.set(None);
+                    break;
+                }
+            }
+        }
+    }
+
     /// Cause all apps to fault.
     ///
     /// This will call `set_fault_state()` on each app, causing the app to enter

--- a/kernel/src/process_loading.rs
+++ b/kernel/src/process_loading.rs
@@ -1230,6 +1230,11 @@ impl<'a, C: Chip, D: ProcessStandardDebug> SequentialProcessLoaderMachine<'a, C,
             )),
         }
     }
+
+    /// Function to terminate process and remove it from process array
+    pub fn reclaim_memory(&self, shortid: ShortId) {
+        self.kernel.reclaim_app_memory(shortid)
+    }
 }
 
 impl<'a, C: Chip, D: ProcessStandardDebug> ProcessLoadingAsync<'a>


### PR DESCRIPTION
### Pull Request Overview

This lets the kernel reclaim the RAM region by terminating an application if running, and then removing the pointer from the ProcessesArray, freeing the region up for future applications.


### Testing Strategy

This pull request was tested by installing and uninstalling apps. 


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
