### PR TITLE
doc: Remove obsolete information about app_hack section

### DIFF
--- a/boards/nucleo_f429zi/README.md
+++ b/boards/nucleo_f429zi/README.md
@@ -19,8 +19,7 @@ $ make flash-debug
 
 > **Note:** Unlike other Tock platforms, the default kernel image for this
 > board will clear flashed apps when the kernel is loaded. This is to support
-> the non-tockloader based app flash procedure below. To preserve loaded apps,
-> comment out the `APP_HACK` variable in `src/main.rs`.
+> the non-tockloader based app flash procedure below.
 
 ## Flashing app
 

--- a/boards/nucleo_f446re/README.md
+++ b/boards/nucleo_f446re/README.md
@@ -19,8 +19,7 @@ $ make flash-debug
 
 > **Note:** Unlike other Tock platforms, the default kernel image for this
 > board will clear flashed apps when the kernel is loaded. This is to support
-> the non-tockloader based app flash procedure below. To preserve loaded apps,
-> comment out the `APP_HACK` variable in `src/main.rs`.
+> the non-tockloader based app flash procedure below.
 
 ## Flashing app
 


### PR DESCRIPTION
### Pull Request Overview

This pull request removes obsolete information from README about app_hack section used in the past by some boards to preserve applications if the tockloader doesn't support the board.

### Testing Strategy

This pull request was tested by...


### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- no updates are required.

### Formatting

- [ ] Ran `make prepush`.
