### PR TITLE
kernel/process_standard: fix upcall task queue initialization

### DIFF
--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -2119,6 +2119,9 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
         kernel_memory_break =
             unsafe { kernel_memory_break.offset(-(Self::CALLBACKS_OFFSET as isize)) };
 
+        // Set up ring buffer for upcalls to the process.
+        let upcall_buf: *mut MaybeUninit<Task> = kernel_memory_break.cast();
+
         // # Safety
         //
         // This is safe today, as MPU constraints ensure that `memory_start`
@@ -2130,9 +2133,27 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
         //
         // TODO: https://github.com/tock/tock/issues/1739
         #[allow(clippy::cast_ptr_alignment)]
-        // Set up ring buffer for upcalls to the process.
-        let upcall_buf: *mut Task = kernel_memory_break.cast();
         let upcall_buf = unsafe { slice::from_raw_parts_mut(upcall_buf, Self::CALLBACK_LEN) };
+        for upcall_task in upcall_buf.iter_mut() {
+            // TODO: Task does not implement Default, nor should it need
+            // to. Instead, RingBuffer should need to be constructed over a
+            // fully initialized slice. It should internally use MaybeUninit,
+            // which would absolve us from coming with non-sensical default
+            // values here:
+            upcall_task.write(Task::ReturnValue(super::process::ReturnArguments {
+                upcall_id: UpcallId {
+                    driver_num: 0,
+                    subscribe_num: 0,
+                },
+                argument0: 0,
+                argument1: 0,
+                argument2: 0,
+            }));
+        }
+        // # Safety
+        //
+        // All values in this slice have been properly initialized.
+        let upcall_buf = unsafe { maybe_uninit_slice_assume_init_mut(upcall_buf) };
         let tasks = RingBuffer::new(upcall_buf);
 
         // Last thing in the kernel region of process RAM is the process struct.


### PR DESCRIPTION
### Pull Request Overview

This avoids creating a Rust slice reference to `Task` elements over uninitialized memory. Instead, we must create a slice reference over `MaybeUninit`s, which we then progressively initialize and finally convert to an initialized slice type.

This is awkward, however, as we don't actually want to create such `Task` structures. Instead, we want to merely provide backing memory for the `RingBuffer`, which by default doesn't actually contain any `Task`s. However, because of the way it is implemented, we need to construct it over a fully initialized slice of elements.

The correct fix is to make `RingBuffer` work over `MaybeUninit` slices, but that's a much more invasive change. This commit fixes the immediate unsoundness we have in `ProcessStandard` right now, at the cost of constructing a fictional `Task` instance to use as an initializer for the upcall task queue.

### Testing Strategy

Compiling?


### TODO or Help Wanted

N/A


### Documentation Updated

- [X] ~Updated the relevant files in `/docs`, or~ no updates are required.

### Formatting

- [X] Ran `make prepush`.
