### PR TITLE
kernel/process_standard: zero-initialize app-accessible memory

### DIFF
--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -974,7 +974,6 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
                 Err(Error::OutOfMemory)
             } else {
                 let old_break: *const u8 = self.app_break.get();
-                let old_break: *const () = old_break.cast();
                 self.app_break.set(new_break);
 
                 // # Safety
@@ -993,13 +992,39 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
                     self.chip.mpu().configure_mpu(config);
                 }
 
+                if new_break > old_break {
+                    // We need to initialize (zero) the newly accessible memory
+                    // region at `[old_break; new_break)`. This serves two
+                    // purposes:
+                    //
+                    // 1. It prevents a process from accessing any information
+                    //    still contained in this memory from prior kernel
+                    //    instances or processes.
+                    //
+                    // 2. It satisfies Rust's requirements that all
+                    //    dereferencable memory be properly initialized. This is
+                    //    important, as we'll be creating references into this
+                    //    process-accessible memory region through the process
+                    //    buffer infrastructure.
+                    let old_break_mut_ptr: *mut u8 = old_break.cast_mut();
+                    unsafe {
+                        core::ptr::write_bytes(
+                            old_break_mut_ptr,
+                            // Set the newly app-accessible memory to `0`:
+                            0_u8,
+                            new_break.addr() - old_break.addr(),
+                        );
+                    }
+                }
+
                 let base = self.mem_start() as usize;
+                let old_break_unit_ptr: *const () = old_break.cast();
                 // # Safety
                 // The passed range [base, new_break) exactly matches the process' memory range,
                 // and a process should have RW access to its own memory.
                 let break_result = unsafe {
                     CapabilityPtr::new_with_authority(
-                        old_break,
+                        old_break_unit_ptr,
                         base,
                         (new_break as usize) - base,
                         CapabilityPtrPermissions::ReadWrite,
@@ -1955,6 +1980,24 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
         // Slice off the process-accessible memory:
         let (app_accessible_memory, allocated_kernel_memory) =
             raw_slice_split_at_mut(allocated_memory, min_process_memory_size);
+
+        // Initialize (zero) the initial process-accessible memory region. This
+        // serves two purposes:
+        //
+        // 1. It prevents a process from accessing any information still
+        //    contained in this memory from prior kernel instances or processes.
+        //
+        // 2. It satisfies Rust's requirements that all dereferencable memory be
+        //    properly initialized. This is important, as we'll be creating
+        //    references into this process-accessible memory region through the
+        //    process buffer infrastructure.
+        let app_accessible_memory_bytes: *mut u8 = app_accessible_memory.cast();
+        core::ptr::write_bytes(
+            app_accessible_memory_bytes,
+            // Set the entire app-accessible memory region to `0`:
+            0_u8,
+            app_accessible_memory.len(),
+        );
 
         // Set the initial process-accessible memory:
         let initial_app_brk = app_accessible_memory


### PR DESCRIPTION
### Pull Request Overview

We need to zero-initialize all app-accessible memory before allowing a process to access it. This avoids leaking data from prior system boots, prior process instances, or kernel grants that used to occupy this memory.

Additionally, Rust requires that all dereferencable memory is properly initialized. As we are creating references into this process-accessible memory region through the process buffer infrastructure, we must initialize it beforehand.

This PR builds on the raw pointer transformation of tock/tock#4714.

### Testing Strategy

Not tested.


### TODO or Help Wanted

N/A


### Documentation Updated

- [X] ~Updated the relevant files in `/docs`, or~ no updates are required.

### Formatting

- [X] Ran `make prepush`.
