### PR TITLE
kernel/SingleThreadValue: don't move `T: !Send` across threads

### DIFF
--- a/boards/apollo3/lora_things_plus/src/main.rs
+++ b/boards/apollo3/lora_things_plus/src/main.rs
@@ -81,7 +81,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =

--- a/boards/apollo3/lora_things_plus/src/main.rs
+++ b/boards/apollo3/lora_things_plus/src/main.rs
@@ -417,12 +417,10 @@ unsafe fn setup() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     let peripherals = static_init!(Apollo3DefaultPeripherals, Apollo3DefaultPeripherals::new());
     PERIPHERALS = Some(peripherals);

--- a/boards/apollo3/lora_things_plus/src/main.rs
+++ b/boards/apollo3/lora_things_plus/src/main.rs
@@ -81,7 +81,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
@@ -417,7 +417,12 @@ unsafe fn setup() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     let peripherals = static_init!(Apollo3DefaultPeripherals, Apollo3DefaultPeripherals::new());
     PERIPHERALS = Some(peripherals);

--- a/boards/apollo3/redboard_artemis_atp/src/main.rs
+++ b/boards/apollo3/redboard_artemis_atp/src/main.rs
@@ -42,7 +42,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =

--- a/boards/apollo3/redboard_artemis_atp/src/main.rs
+++ b/boards/apollo3/redboard_artemis_atp/src/main.rs
@@ -171,12 +171,10 @@ unsafe fn setup() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     let peripherals = static_init!(Apollo3DefaultPeripherals, Apollo3DefaultPeripherals::new());
 

--- a/boards/apollo3/redboard_artemis_atp/src/main.rs
+++ b/boards/apollo3/redboard_artemis_atp/src/main.rs
@@ -42,7 +42,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
@@ -171,7 +171,12 @@ unsafe fn setup() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     let peripherals = static_init!(Apollo3DefaultPeripherals, Apollo3DefaultPeripherals::new());
 

--- a/boards/apollo3/redboard_artemis_nano/src/main.rs
+++ b/boards/apollo3/redboard_artemis_nano/src/main.rs
@@ -42,7 +42,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =

--- a/boards/apollo3/redboard_artemis_nano/src/main.rs
+++ b/boards/apollo3/redboard_artemis_nano/src/main.rs
@@ -42,7 +42,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
@@ -184,7 +184,12 @@ unsafe fn setup() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     let peripherals = static_init!(Apollo3DefaultPeripherals, Apollo3DefaultPeripherals::new());
 

--- a/boards/apollo3/redboard_artemis_nano/src/main.rs
+++ b/boards/apollo3/redboard_artemis_nano/src/main.rs
@@ -184,12 +184,10 @@ unsafe fn setup() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     let peripherals = static_init!(Apollo3DefaultPeripherals, Apollo3DefaultPeripherals::new());
 

--- a/boards/arty_e21/src/main.rs
+++ b/boards/arty_e21/src/main.rs
@@ -39,7 +39,7 @@ type ProcessPrinter = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<Chip, ProcessPrinter>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 kernel::stack_size! {0x1000}
 

--- a/boards/arty_e21/src/main.rs
+++ b/boards/arty_e21/src/main.rs
@@ -39,7 +39,7 @@ type ProcessPrinter = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<Chip, ProcessPrinter>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 kernel::stack_size! {0x1000}
 
@@ -136,7 +136,12 @@ unsafe fn start() -> (
         <ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider,
     >();
 
-    PANIC_RESOURCES.bind_to_thread::<<Chip as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<Chip as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     let peripherals = static_init!(ArtyExxDefaultPeripherals, ArtyExxDefaultPeripherals::new());
     peripherals.init();

--- a/boards/arty_e21/src/main.rs
+++ b/boards/arty_e21/src/main.rs
@@ -136,12 +136,10 @@ unsafe fn start() -> (
         <ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider,
     >();
 
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<Chip as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     let peripherals = static_init!(ArtyExxDefaultPeripherals, ArtyExxDefaultPeripherals::new());
     peripherals.init();

--- a/boards/clue_nrf52840/README.md
+++ b/boards/clue_nrf52840/README.md
@@ -102,9 +102,13 @@ fn baud_rate_reset_bootloader_enter() {
     unsafe {
         // 0x4e is the magic value the Adafruit nRF52 Bootloader expects
         // as defined by https://github.com/adafruit/Adafruit_nRF52_Bootloader/blob/master/src/main.c
-        // NRF52_POWER.unwrap().set_gpregret(0x90);
+        // NRF52_POWER.get().map(|power| {
+        //     power.set_gpregret(0x90);
+        // });
         // uncomment to use with Adafruit nRF52 Bootloader
-        NRF52_POWER.unwrap().set_gpregret(0x4e);
+        NRF52_POWER.get().map(|power| {
+            power.set_gpregret(0x4e);
+        });
         cortexm4::scb::reset();
     }
 }

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -121,9 +121,9 @@ static mut CDC_REF_FOR_PANIC: Option<
 > = None;
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 static NRF52_POWER: SingleThreadValue<MapCell<&'static nrf52840::power::Power>> =
-    SingleThreadValue::new(MapCell::empty());
+    SingleThreadValue::new(MapCell::empty);
 
 kernel::stack_size! {0x1000}
 

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -27,7 +27,6 @@ use kernel::hil::time::Counter;
 use kernel::hil::usb::Client;
 use kernel::platform::chip::Chip;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::utilities::cells::MapCell;
 use kernel::utilities::single_thread_value::SingleThreadValue;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
@@ -122,8 +121,7 @@ static mut CDC_REF_FOR_PANIC: Option<
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
     SingleThreadValue::new();
-static NRF52_POWER: SingleThreadValue<MapCell<&'static nrf52840::power::Power>> =
-    SingleThreadValue::new();
+static NRF52_POWER: SingleThreadValue<&'static nrf52840::power::Power> = SingleThreadValue::new();
 
 kernel::stack_size! {0x1000}
 
@@ -132,13 +130,13 @@ fn baud_rate_reset_bootloader_enter() {
     unsafe {
         // 0x4e is the magic value the Adafruit nRF52 Bootloader expects
         // as defined by https://github.com/adafruit/Adafruit_nRF52_Bootloader/blob/master/src/main.c
-        NRF52_POWER.get().map(|power_cell| {
-            power_cell.map(|power| {
-                power.set_gpregret(0x90);
-            });
+        NRF52_POWER.get().map(|power| {
+            power.set_gpregret(0x90);
         });
         // uncomment to use with Adafruit nRF52 Bootloader
-        // NRF52_POWER.unwrap().set_gpregret(0x4e);
+        // NRF52_POWER.get().map(|power| {
+        //     power.set_gpregret(0x4e);
+        // });
         cortexm4::scb::reset();
     }
 }
@@ -287,10 +285,6 @@ unsafe fn start() -> (
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
         );
-    let _ = NRF52_POWER
-        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
-            MapCell::empty(),
-        );
 
     let ieee802154_ack_buf = static_init!(
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
@@ -309,9 +303,10 @@ unsafe fn start() -> (
 
     // Save a reference to the power module for resetting the board into the
     // bootloader.
-    NRF52_POWER.get().map(|power_cell| {
-        power_cell.put(&base_peripherals.pwr_clk);
-    });
+    let _ = NRF52_POWER
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            &base_peripherals.pwr_clk,
+        );
 
     // Create an array to hold process references.
     let processes = components::process_array::ProcessArrayComponent::new()

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -121,9 +121,9 @@ static mut CDC_REF_FOR_PANIC: Option<
 > = None;
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 static NRF52_POWER: SingleThreadValue<MapCell<&'static nrf52840::power::Power>> =
-    SingleThreadValue::new(MapCell::empty);
+    SingleThreadValue::new();
 
 kernel::stack_size! {0x1000}
 
@@ -283,8 +283,18 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
-    NRF52_POWER.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
+    NRF52_POWER
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            MapCell::empty(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     let ieee802154_ack_buf = static_init!(
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -283,18 +283,14 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
-    NRF52_POWER
+        );
+    let _ = NRF52_POWER
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             MapCell::empty(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     let ieee802154_ack_buf = static_init!(
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],

--- a/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
@@ -75,7 +75,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 kernel::stack_size! {0x2000}
 

--- a/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
@@ -241,12 +241,10 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     let ieee802154_ack_buf = static_init!(
         [u8; nrf52833::ieee802154_radio::ACK_BUF_SIZE],

--- a/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
@@ -75,7 +75,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 kernel::stack_size! {0x2000}
 
@@ -241,7 +241,12 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     let ieee802154_ack_buf = static_init!(
         [u8; nrf52833::ieee802154_radio::ACK_BUF_SIZE],

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
@@ -55,7 +55,7 @@ type ProcessPrinter = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 kernel::stack_size! {0x2000}
 

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
@@ -55,7 +55,7 @@ type ProcessPrinter = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 kernel::stack_size! {0x2000}
 
@@ -196,7 +196,12 @@ pub unsafe fn main() {
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     // Set up peripheral drivers. Called in separate function to reduce stack
     // usage.

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
@@ -196,12 +196,10 @@ pub unsafe fn main() {
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     // Set up peripheral drivers. Called in separate function to reduce stack
     // usage.

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/main.rs
@@ -42,7 +42,7 @@ type ProcessPrinter = capsules_system::process_printer::ProcessPrinterNull;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 kernel::stack_size! {0x2000}
 

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/main.rs
@@ -42,7 +42,7 @@ type ProcessPrinter = capsules_system::process_printer::ProcessPrinterNull;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 kernel::stack_size! {0x2000}
 

--- a/boards/cy8cproto_62_4343_w/src/main.rs
+++ b/boards/cy8cproto_62_4343_w/src/main.rs
@@ -44,7 +44,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
 

--- a/boards/cy8cproto_62_4343_w/src/main.rs
+++ b/boards/cy8cproto_62_4343_w/src/main.rs
@@ -44,7 +44,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
 
@@ -130,7 +130,11 @@ pub unsafe fn main() {
 
     // Bind global variables to this thread.
     PANIC_RESOURCES
-        .bind_to_thread_unsafe::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+        .bind_to_thread_unsafe::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     let peripherals = static_init!(
         PsoC62xaDefaultPeripherals,

--- a/boards/cy8cproto_62_4343_w/src/main.rs
+++ b/boards/cy8cproto_62_4343_w/src/main.rs
@@ -129,12 +129,10 @@ pub unsafe fn main() {
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread_unsafe::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     let peripherals = static_init!(
         PsoC62xaDefaultPeripherals,

--- a/boards/esp32-c3-devkitM-1/src/main.rs
+++ b/boards/esp32-c3-devkitM-1/src/main.rs
@@ -37,7 +37,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =

--- a/boards/esp32-c3-devkitM-1/src/main.rs
+++ b/boards/esp32-c3-devkitM-1/src/main.rs
@@ -162,12 +162,10 @@ unsafe fn setup() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread_unsafe::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     //
     // PERIPHERALS

--- a/boards/esp32-c3-devkitM-1/src/main.rs
+++ b/boards/esp32-c3-devkitM-1/src/main.rs
@@ -37,7 +37,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
@@ -163,7 +163,11 @@ unsafe fn setup() -> (
 
     // Bind global variables to this thread.
     PANIC_RESOURCES
-        .bind_to_thread_unsafe::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+        .bind_to_thread_unsafe::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     //
     // PERIPHERALS

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -40,7 +40,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 kernel::stack_size! {0x1000}
 

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -40,7 +40,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 kernel::stack_size! {0x1000}
 
@@ -236,7 +236,12 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     let pm = static_init!(sam4l::pm::PowerManager, sam4l::pm::PowerManager::new());
     let peripherals = static_init!(Sam4lDefaultPeripherals, Sam4lDefaultPeripherals::new(pm));

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -236,12 +236,10 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     let pm = static_init!(sam4l::pm::PowerManager, sam4l::pm::PowerManager::new());
     let peripherals = static_init!(Sam4lDefaultPeripherals, Sam4lDefaultPeripherals::new(pm));

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -37,7 +37,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -37,7 +37,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
@@ -185,7 +185,12 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     let peripherals = static_init!(
         E310G002DefaultPeripherals,

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -185,12 +185,10 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     let peripherals = static_init!(
         E310G002DefaultPeripherals,

--- a/boards/hifive_inventor/src/main.rs
+++ b/boards/hifive_inventor/src/main.rs
@@ -33,7 +33,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =

--- a/boards/hifive_inventor/src/main.rs
+++ b/boards/hifive_inventor/src/main.rs
@@ -33,7 +33,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
@@ -126,7 +126,12 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     let peripherals = static_init!(
         E310G003DefaultPeripherals,

--- a/boards/hifive_inventor/src/main.rs
+++ b/boards/hifive_inventor/src/main.rs
@@ -126,12 +126,10 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     let peripherals = static_init!(
         E310G003DefaultPeripherals,

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -102,7 +102,7 @@ static mut CHIP: Option<&'static sam4l::chip::Sam4l<Sam4lDefaultPeripherals>> = 
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 kernel::stack_size! {0x2000}
 

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -324,12 +324,10 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     let pm = static_init!(sam4l::pm::PowerManager, sam4l::pm::PowerManager::new());
     let peripherals = static_init!(Sam4lDefaultPeripherals, Sam4lDefaultPeripherals::new(pm));

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -102,7 +102,7 @@ static mut CHIP: Option<&'static sam4l::chip::Sam4l<Sam4lDefaultPeripherals>> = 
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 kernel::stack_size! {0x2000}
 
@@ -324,7 +324,12 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     let pm = static_init!(sam4l::pm::PowerManager, sam4l::pm::PowerManager::new());
     let peripherals = static_init!(Sam4lDefaultPeripherals, Sam4lDefaultPeripherals::new(pm));

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -54,7 +54,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -54,7 +54,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
@@ -245,7 +245,12 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     let ccm = static_init!(imxrt1050::ccm::Ccm, imxrt1050::ccm::Ccm::new());
     let peripherals = static_init!(

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -245,12 +245,10 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     let ccm = static_init!(imxrt1050::ccm::Ccm, imxrt1050::ccm::Ccm::new());
     let peripherals = static_init!(

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -92,7 +92,7 @@ type SchedulerInUse = components::sched::mlfq::MLFQComponentType<AlarmHw>;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -220,12 +220,10 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread_unsafe::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     // Set up memory protection immediately after setting the trap handler, to
     // ensure that much of the board initialization routine runs with PMP kernel

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -92,7 +92,7 @@ type SchedulerInUse = components::sched::mlfq::MLFQComponentType<AlarmHw>;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
@@ -221,7 +221,11 @@ unsafe fn start() -> (
 
     // Bind global variables to this thread.
     PANIC_RESOURCES
-        .bind_to_thread_unsafe::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+        .bind_to_thread_unsafe::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     // Set up memory protection immediately after setting the trap handler, to
     // ensure that much of the board initialization routine runs with PMP kernel

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -97,7 +97,7 @@ type SchedulerInUse = components::sched::mlfq::MLFQComponentType<AlarmHw>;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -97,7 +97,7 @@ type SchedulerInUse = components::sched::mlfq::MLFQComponentType<AlarmHw>;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
@@ -233,7 +233,11 @@ unsafe fn start() -> (
 
     // Bind global variables to this thread.
     PANIC_RESOURCES
-        .bind_to_thread_unsafe::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+        .bind_to_thread_unsafe::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     // Set up memory protection immediately after setting the trap handler, to
     // ensure that much of the board initialization routine runs with PMP kernel

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -232,12 +232,10 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread_unsafe::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     // Set up memory protection immediately after setting the trap handler, to
     // ensure that much of the board initialization routine runs with PMP kernel

--- a/boards/lora_e5_mini/src/main.rs
+++ b/boards/lora_e5_mini/src/main.rs
@@ -213,6 +213,12 @@ pub unsafe fn main() {
         <ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider,
     >();
 
+    // Bind global variables to this thread.
+    let _ = PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        );
+
     stm32wle5jc::init();
 
     let peripherals = create_peripherals();
@@ -222,6 +228,9 @@ pub unsafe fn main() {
     // Create an array to hold process references.
     let processes = components::process_array::ProcessArrayComponent::new()
         .finalize(components::process_array_component_static!(NUM_PROCS));
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.processes.put(processes.as_slice());
+    });
 
     // Setup space to store the core kernel data structure.
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
@@ -230,6 +239,9 @@ pub unsafe fn main() {
         stm32wle5jc::chip::Stm32wle5xx<Stm32wle5jcDefaultPeripherals>,
         stm32wle5jc::chip::Stm32wle5xx::new(peripherals)
     );
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.chip.put(chip);
+    });
 
     setup_peripherals(&base_peripherals.tim2, &base_peripherals.subghz_spi);
 
@@ -302,6 +314,9 @@ pub unsafe fn main() {
 
     let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
         .finalize(components::process_printer_text_component_static!());
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.printer.put(process_printer);
+    });
 
     //--------------------------------------------------------------------
     // LED

--- a/boards/lora_e5_mini/src/main.rs
+++ b/boards/lora_e5_mini/src/main.rs
@@ -50,7 +50,7 @@ type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new();
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =

--- a/boards/lpc55s69-evk/src/main.rs
+++ b/boards/lpc55s69-evk/src/main.rs
@@ -127,12 +127,10 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     system_init();
 

--- a/boards/lpc55s69-evk/src/main.rs
+++ b/boards/lpc55s69-evk/src/main.rs
@@ -50,7 +50,7 @@ type ChipHw = Lpc55s69<'static, Lpc55s69DefaultPeripheral<'static>>;
 type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new();
 
 pub struct Lpc55s69evk {
     console: &'static capsules_core::console::Console<'static>,
@@ -127,7 +127,12 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     system_init();
 

--- a/boards/makepython-nrf52840/src/main.rs
+++ b/boards/makepython-nrf52840/src/main.rs
@@ -83,9 +83,9 @@ static mut CDC_REF_FOR_PANIC: Option<
 > = None;
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 static NRF52_POWER: SingleThreadValue<MapCell<&'static nrf52840::power::Power>> =
-    SingleThreadValue::new(MapCell::empty());
+    SingleThreadValue::new(MapCell::empty);
 
 kernel::stack_size! {0x1000}
 

--- a/boards/makepython-nrf52840/src/main.rs
+++ b/boards/makepython-nrf52840/src/main.rs
@@ -239,18 +239,14 @@ pub unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
-    NRF52_POWER
+        );
+    let _ = NRF52_POWER
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             MapCell::empty(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     let ieee802154_ack_buf = static_init!(
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],

--- a/boards/makepython-nrf52840/src/main.rs
+++ b/boards/makepython-nrf52840/src/main.rs
@@ -19,7 +19,6 @@ use kernel::hil::led::LedLow;
 use kernel::hil::time::Counter;
 use kernel::hil::usb::Client;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::utilities::cells::MapCell;
 use kernel::utilities::single_thread_value::SingleThreadValue;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
@@ -84,8 +83,7 @@ static mut CDC_REF_FOR_PANIC: Option<
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
     SingleThreadValue::new();
-static NRF52_POWER: SingleThreadValue<MapCell<&'static nrf52840::power::Power>> =
-    SingleThreadValue::new();
+static NRF52_POWER: SingleThreadValue<&'static nrf52840::power::Power> = SingleThreadValue::new();
 
 kernel::stack_size! {0x1000}
 
@@ -93,10 +91,8 @@ kernel::stack_size! {0x1000}
 fn baud_rate_reset_bootloader_enter() {
     unsafe {
         // 0x90 is the magic value the bootloader expects
-        NRF52_POWER.get().map(|power_cell| {
-            power_cell.map(|power| {
-                power.set_gpregret(0x90);
-            });
+        NRF52_POWER.get().map(|power| {
+            power.set_gpregret(0x90);
         });
         cortexm4::scb::reset();
     }
@@ -243,10 +239,6 @@ pub unsafe fn start() -> (
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
         );
-    let _ = NRF52_POWER
-        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
-            MapCell::empty(),
-        );
 
     let ieee802154_ack_buf = static_init!(
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
@@ -265,9 +257,10 @@ pub unsafe fn start() -> (
 
     // Save a reference to the power module for resetting the board into the
     // bootloader.
-    NRF52_POWER.get().map(|power_cell| {
-        power_cell.put(&base_peripherals.pwr_clk);
-    });
+    let _ = NRF52_POWER
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            &base_peripherals.pwr_clk,
+        );
 
     // Create an array to hold process references.
     let processes = components::process_array::ProcessArrayComponent::new()

--- a/boards/makepython-nrf52840/src/main.rs
+++ b/boards/makepython-nrf52840/src/main.rs
@@ -83,9 +83,9 @@ static mut CDC_REF_FOR_PANIC: Option<
 > = None;
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 static NRF52_POWER: SingleThreadValue<MapCell<&'static nrf52840::power::Power>> =
-    SingleThreadValue::new(MapCell::empty);
+    SingleThreadValue::new();
 
 kernel::stack_size! {0x1000}
 
@@ -239,8 +239,18 @@ pub unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
-    NRF52_POWER.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
+    NRF52_POWER
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            MapCell::empty(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     let ieee802154_ack_buf = static_init!(
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -75,7 +75,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 kernel::stack_size! {0x2000}
 

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -229,12 +229,10 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     let ieee802154_ack_buf = static_init!(
         [u8; nrf52833::ieee802154_radio::ACK_BUF_SIZE],

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -75,7 +75,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 kernel::stack_size! {0x2000}
 
@@ -229,7 +229,12 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     let ieee802154_ack_buf = static_init!(
         [u8; nrf52833::ieee802154_radio::ACK_BUF_SIZE],

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -30,7 +30,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 /// How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -30,7 +30,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 /// How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
@@ -197,7 +197,12 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     let peripherals = static_init!(
         msp432::chip::Msp432DefaultPeripherals,

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -197,12 +197,10 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     let peripherals = static_init!(
         msp432::chip::Msp432DefaultPeripherals,

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -100,9 +100,9 @@ static mut CDC_REF_FOR_PANIC: Option<
 > = None;
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 static NRF52_POWER: SingleThreadValue<MapCell<&'static nrf52840::power::Power>> =
-    SingleThreadValue::new(MapCell::empty());
+    SingleThreadValue::new(MapCell::empty);
 
 kernel::stack_size! {0x1000}
 

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -256,12 +256,10 @@ pub unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     let ieee802154_ack_buf = static_init!(
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -22,7 +22,6 @@ use kernel::hil::time::Counter;
 use kernel::hil::usb::Client;
 use kernel::platform::chip::Chip;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::utilities::cells::MapCell;
 use kernel::utilities::single_thread_value::SingleThreadValue;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
@@ -101,18 +100,15 @@ static mut CDC_REF_FOR_PANIC: Option<
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
     SingleThreadValue::new();
-static NRF52_POWER: SingleThreadValue<MapCell<&'static nrf52840::power::Power>> =
-    SingleThreadValue::new();
+static NRF52_POWER: SingleThreadValue<&'static nrf52840::power::Power> = SingleThreadValue::new();
 
 kernel::stack_size! {0x1000}
 
 // Function for the CDC/USB stack to use to enter the bootloader.
 fn baud_rate_reset_bootloader_enter() {
     // 0x90 is the magic value the bootloader expects
-    NRF52_POWER.get().map(|power_cell| {
-        power_cell.map(|power| {
-            power.set_gpregret(0x90);
-        });
+    NRF52_POWER.get().map(|power| {
+        power.set_gpregret(0x90);
     });
     unsafe {
         cortexm4::scb::reset();
@@ -278,9 +274,10 @@ pub unsafe fn start() -> (
 
     // Save a reference to the power module for resetting the board into the
     // bootloader.
-    NRF52_POWER.get().map(|power_cell| {
-        power_cell.put(&base_peripherals.pwr_clk);
-    });
+    let _ = NRF52_POWER
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            &base_peripherals.pwr_clk,
+        );
 
     // Create an array to hold process references.
     let processes = components::process_array::ProcessArrayComponent::new()

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -100,9 +100,9 @@ static mut CDC_REF_FOR_PANIC: Option<
 > = None;
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 static NRF52_POWER: SingleThreadValue<MapCell<&'static nrf52840::power::Power>> =
-    SingleThreadValue::new(MapCell::empty);
+    SingleThreadValue::new();
 
 kernel::stack_size! {0x1000}
 
@@ -256,7 +256,12 @@ pub unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     let ieee802154_ack_buf = static_init!(
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],

--- a/boards/nano33ble_rev2/src/main.rs
+++ b/boards/nano33ble_rev2/src/main.rs
@@ -97,9 +97,9 @@ static mut CDC_REF_FOR_PANIC: Option<
 > = None;
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 static NRF52_POWER: SingleThreadValue<MapCell<&'static nrf52840::power::Power>> =
-    SingleThreadValue::new(MapCell::empty());
+    SingleThreadValue::new(MapCell::empty);
 
 kernel::stack_size! {0x1000}
 

--- a/boards/nano33ble_rev2/src/main.rs
+++ b/boards/nano33ble_rev2/src/main.rs
@@ -97,9 +97,9 @@ static mut CDC_REF_FOR_PANIC: Option<
 > = None;
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 static NRF52_POWER: SingleThreadValue<MapCell<&'static nrf52840::power::Power>> =
-    SingleThreadValue::new(MapCell::empty);
+    SingleThreadValue::new();
 
 kernel::stack_size! {0x1000}
 

--- a/boards/nano33ble_rev2/src/main.rs
+++ b/boards/nano33ble_rev2/src/main.rs
@@ -22,7 +22,6 @@ use kernel::hil::time::Counter;
 use kernel::hil::usb::Client;
 use kernel::platform::chip::Chip;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::utilities::cells::MapCell;
 use kernel::utilities::single_thread_value::SingleThreadValue;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
@@ -98,18 +97,15 @@ static mut CDC_REF_FOR_PANIC: Option<
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
     SingleThreadValue::new();
-static NRF52_POWER: SingleThreadValue<MapCell<&'static nrf52840::power::Power>> =
-    SingleThreadValue::new();
+static NRF52_POWER: SingleThreadValue<&'static nrf52840::power::Power> = SingleThreadValue::new();
 
 kernel::stack_size! {0x1000}
 
 // Function for the CDC/USB stack to use to enter the bootloader.
 fn baud_rate_reset_bootloader_enter() {
     // 0x90 is the magic value the bootloader expects
-    NRF52_POWER.get().map(|power_cell| {
-        power_cell.map(|power| {
-            power.set_gpregret(0x90);
-        });
+    NRF52_POWER.get().map(|power| {
+        power.set_gpregret(0x90);
     });
 
     unsafe {
@@ -264,6 +260,12 @@ pub unsafe fn start() -> (
         <ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider,
     >();
 
+    // Bind global variables to this thread.
+    let _ = PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        );
+
     let ieee802154_ack_buf = static_init!(
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
@@ -281,9 +283,10 @@ pub unsafe fn start() -> (
 
     // Save a reference to the power module for resetting the board into the
     // bootloader.
-    NRF52_POWER.get().map(|power_cell| {
-        power_cell.put(&base_peripherals.pwr_clk);
-    });
+    let _ = NRF52_POWER
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            &base_peripherals.pwr_clk,
+        );
 
     // Create an array to hold process references.
     let processes = components::process_array::ProcessArrayComponent::new()

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -65,7 +65,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 type TemperatureRp2040Sensor = components::temperature_rp2040::TemperatureRp2040ComponentType<
     capsules_core::virtualizers::virtual_adc::AdcDevice<'static, rp2040::adc::Adc<'static>>,

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -264,12 +264,10 @@ pub unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread_unsafe::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     let peripherals = static_init!(Rp2040DefaultPeripherals, Rp2040DefaultPeripherals::new());
     peripherals.resolve_dependencies();

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -65,7 +65,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 type TemperatureRp2040Sensor = components::temperature_rp2040::TemperatureRp2040ComponentType<
     capsules_core::virtualizers::virtual_adc::AdcDevice<'static, rp2040::adc::Adc<'static>>,
@@ -265,7 +265,11 @@ pub unsafe fn start() -> (
 
     // Bind global variables to this thread.
     PANIC_RESOURCES
-        .bind_to_thread_unsafe::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+        .bind_to_thread_unsafe::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     let peripherals = static_init!(Rp2040DefaultPeripherals, Rp2040DefaultPeripherals::new());
     peripherals.resolve_dependencies();

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -71,7 +71,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 kernel::stack_size! {0x1000}
 

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -199,12 +199,10 @@ pub unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     let ieee802154_ack_buf = static_init!(
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -71,7 +71,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 kernel::stack_size! {0x1000}
 
@@ -199,7 +199,12 @@ pub unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     let ieee802154_ack_buf = static_init!(
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -421,18 +421,14 @@ pub unsafe fn start_no_pconsole() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
-    RTT_BUFFER
+        );
+    let _ = RTT_BUFFER
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             MapCell::empty(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     // Set up peripheral drivers. Called in separate function to reduce stack
     // usage.

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -148,11 +148,11 @@ use kernel::utilities::single_thread_value::SingleThreadValue;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 /// In-memory buffer used for the Segger Real Time Transfer (RTT) mechanism.
 static RTT_BUFFER: SingleThreadValue<MapCell<&'static segger::rtt::SeggerRttMemory<'static>>> =
-    SingleThreadValue::new(MapCell::empty());
+    SingleThreadValue::new();
 
 kernel::stack_size! {0x2000}
 
@@ -421,9 +421,12 @@ pub unsafe fn start_no_pconsole() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
-    RTT_BUFFER.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
-
+    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+        PanicResources::new(),
+    );
+    RTT_BUFFER.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+        MapCell::empty(),
+    );
     // Set up peripheral drivers. Called in separate function to reduce stack
     // usage.
     let ieee802154_ack_buf = static_init!(

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -148,7 +148,7 @@ use kernel::utilities::single_thread_value::SingleThreadValue;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 /// In-memory buffer used for the Segger Real Time Transfer (RTT) mechanism.
 static RTT_BUFFER: SingleThreadValue<MapCell<&'static segger::rtt::SeggerRttMemory<'static>>> =

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -421,12 +421,19 @@ pub unsafe fn start_no_pconsole() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
-        PanicResources::new(),
-    );
-    RTT_BUFFER.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
-        MapCell::empty(),
-    );
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
+    RTT_BUFFER
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            MapCell::empty(),
+        )
+        .map_err(|_| ())
+        .unwrap();
+
     // Set up peripheral drivers. Called in separate function to reduce stack
     // usage.
     let ieee802154_ack_buf = static_init!(

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -130,7 +130,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 kernel::stack_size! {0x1000}
 

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -251,12 +251,10 @@ pub unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     let nrf52832_peripherals = static_init!(
         Nrf52832DefaultPeripherals,

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -130,7 +130,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 kernel::stack_size! {0x1000}
 
@@ -251,7 +251,12 @@ pub unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     let nrf52832_peripherals = static_init!(
         Nrf52832DefaultPeripherals,

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -38,7 +38,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -38,7 +38,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
@@ -326,7 +326,12 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     // We use the default HSI 16Mhz clock
     let rcc = static_init!(stm32f429zi::rcc::Rcc, stm32f429zi::rcc::Rcc::new());

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -326,12 +326,10 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     // We use the default HSI 16Mhz clock
     let rcc = static_init!(stm32f429zi::rcc::Rcc, stm32f429zi::rcc::Rcc::new());

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -42,7 +42,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -42,7 +42,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
@@ -274,7 +274,12 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     // We use the default HSI 16Mhz clock
     let rcc = static_init!(stm32f446re::rcc::Rcc, stm32f446re::rcc::Rcc::new());

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -274,12 +274,10 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     // We use the default HSI 16Mhz clock
     let rcc = static_init!(stm32f446re::rcc::Rcc, stm32f446re::rcc::Rcc::new());

--- a/boards/opentitan/earlgrey-cw310/src/main.rs
+++ b/boards/opentitan/earlgrey-cw310/src/main.rs
@@ -112,7 +112,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 // Test access to the peripherals
 #[cfg(test)]

--- a/boards/opentitan/earlgrey-cw310/src/main.rs
+++ b/boards/opentitan/earlgrey-cw310/src/main.rs
@@ -112,7 +112,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 // Test access to the peripherals
 #[cfg(test)]
@@ -338,7 +338,11 @@ unsafe fn setup() -> (
 
     // Bind global variables to this thread.
     PANIC_RESOURCES
-        .bind_to_thread_unsafe::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+        .bind_to_thread_unsafe::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     // Set up memory protection immediately after setting the trap handler, to
     // ensure that much of the board initialization routine runs with ePMP

--- a/boards/opentitan/earlgrey-cw310/src/main.rs
+++ b/boards/opentitan/earlgrey-cw310/src/main.rs
@@ -337,12 +337,10 @@ unsafe fn setup() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread_unsafe::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     // Set up memory protection immediately after setting the trap handler, to
     // ensure that much of the board initialization routine runs with ePMP

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -79,7 +79,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 static mut NRF52_POWER: Option<&'static nrf52840::power::Power> = None;
 

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -79,7 +79,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 static mut NRF52_POWER: Option<&'static nrf52840::power::Power> = None;
 
@@ -223,7 +223,12 @@ pub unsafe fn start_particle_boron() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     let nrf52840_peripherals = create_peripherals();
 

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -81,8 +81,6 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
     SingleThreadValue::new();
 
-static mut NRF52_POWER: Option<&'static nrf52840::power::Power> = None;
-
 kernel::stack_size! {0x1000}
 
 type TemperatureDriver =
@@ -233,10 +231,6 @@ pub unsafe fn start_particle_boron() -> (
     // set up circular peripheral dependencies
     nrf52840_peripherals.init();
     let base_peripherals = &nrf52840_peripherals.nrf52;
-
-    // Save a reference to the power module for resetting the board into the
-    // bootloader.
-    NRF52_POWER = Some(&base_peripherals.pwr_clk);
 
     // Create an array to hold process references.
     let processes = components::process_array::ProcessArrayComponent::new()

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -223,12 +223,10 @@ pub unsafe fn start_particle_boron() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     let nrf52840_peripherals = create_peripherals();
 

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -68,7 +68,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 type TemperatureRp2040Sensor = components::temperature_rp2040::TemperatureRp2040ComponentType<
     capsules_core::virtualizers::virtual_adc::AdcDevice<'static, rp2040::adc::Adc<'static>>,

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -276,12 +276,10 @@ pub unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread_unsafe::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     let peripherals = static_init!(Rp2040DefaultPeripherals, Rp2040DefaultPeripherals::new());
     peripherals.resolve_dependencies();

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -68,7 +68,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 type TemperatureRp2040Sensor = components::temperature_rp2040::TemperatureRp2040ComponentType<
     capsules_core::virtualizers::virtual_adc::AdcDevice<'static, rp2040::adc::Adc<'static>>,
@@ -277,7 +277,11 @@ pub unsafe fn start() -> (
 
     // Bind global variables to this thread.
     PANIC_RESOURCES
-        .bind_to_thread_unsafe::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+        .bind_to_thread_unsafe::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     let peripherals = static_init!(Rp2040DefaultPeripherals, Rp2040DefaultPeripherals::new());
     peripherals.resolve_dependencies();

--- a/boards/qemu_i486_q35/src/main.rs
+++ b/boards/qemu_i486_q35/src/main.rs
@@ -61,7 +61,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =

--- a/boards/qemu_i486_q35/src/main.rs
+++ b/boards/qemu_i486_q35/src/main.rs
@@ -61,7 +61,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =

--- a/boards/qemu_i486_q35/src/main.rs
+++ b/boards/qemu_i486_q35/src/main.rs
@@ -231,6 +231,12 @@ unsafe extern "cdecl" fn main() {
         <ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider,
     >();
 
+    // Bind global variables to this thread.
+    let _ = PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        );
+
     // Basic setup of the i486 platform
     // Allocate statics for default peripherals and build them via the chip helper
     let default_peripherals = unsafe {

--- a/boards/qemu_rv32_virt/src/lib.rs
+++ b/boards/qemu_rv32_virt/src/lib.rs
@@ -39,7 +39,7 @@ type SchedulerInUse = components::sched::cooperative::CooperativeComponentType;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 kernel::stack_size! {0x8000}
 

--- a/boards/qemu_rv32_virt/src/lib.rs
+++ b/boards/qemu_rv32_virt/src/lib.rs
@@ -187,12 +187,10 @@ pub unsafe fn start() -> (
     }
     // ---------- BASIC INITIALIZATION -----------
 
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     // Basic setup of the RISC-V IMAC platform
     rv32i::configure_trap_handler();

--- a/boards/qemu_rv32_virt/src/lib.rs
+++ b/boards/qemu_rv32_virt/src/lib.rs
@@ -39,7 +39,7 @@ type SchedulerInUse = components::sched::cooperative::CooperativeComponentType;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 kernel::stack_size! {0x8000}
 
@@ -187,7 +187,12 @@ pub unsafe fn start() -> (
     }
     // ---------- BASIC INITIALIZATION -----------
 
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     // Basic setup of the RISC-V IMAC platform
     rv32i::configure_trap_handler();

--- a/boards/raspberry_pi_pico/src/lib.rs
+++ b/boards/raspberry_pi_pico/src/lib.rs
@@ -56,7 +56,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 pub static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 type TemperatureRp2040Sensor = components::temperature_rp2040::TemperatureRp2040ComponentType<
     capsules_core::virtualizers::virtual_adc::AdcDevice<'static, rp2040::adc::Adc<'static>>,

--- a/boards/raspberry_pi_pico/src/lib.rs
+++ b/boards/raspberry_pi_pico/src/lib.rs
@@ -252,6 +252,12 @@ pub unsafe fn setup(
     // Loads relocations and clears BSS
     rp2040::init();
 
+    // Bind global variables to this thread.
+    let _ = PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        );
+
     let peripherals = static_init!(Rp2040DefaultPeripherals, Rp2040DefaultPeripherals::new());
     peripherals.resolve_dependencies();
 

--- a/boards/raspberry_pi_pico/src/lib.rs
+++ b/boards/raspberry_pi_pico/src/lib.rs
@@ -56,7 +56,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 pub static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 type TemperatureRp2040Sensor = components::temperature_rp2040::TemperatureRp2040ComponentType<
     capsules_core::virtualizers::virtual_adc::AdcDevice<'static, rp2040::adc::Adc<'static>>,

--- a/boards/raspberry_pi_pico/src/lib.rs
+++ b/boards/raspberry_pi_pico/src/lib.rs
@@ -254,7 +254,7 @@ pub unsafe fn setup(
 
     // Bind global variables to this thread.
     let _ = PANIC_RESOURCES
-        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+        .bind_to_thread_unsafe::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
         );
 

--- a/boards/raspberry_pi_pico_2/src/main.rs
+++ b/boards/raspberry_pi_pico_2/src/main.rs
@@ -80,7 +80,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
 

--- a/boards/raspberry_pi_pico_2/src/main.rs
+++ b/boards/raspberry_pi_pico_2/src/main.rs
@@ -262,12 +262,10 @@ pub unsafe fn main() {
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     let peripherals = get_peripherals();
     peripherals.resolve_dependencies();

--- a/boards/raspberry_pi_pico_2/src/main.rs
+++ b/boards/raspberry_pi_pico_2/src/main.rs
@@ -80,7 +80,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
 
@@ -262,7 +262,12 @@ pub unsafe fn main() {
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     let peripherals = get_peripherals();
     peripherals.resolve_dependencies();

--- a/boards/redboard_redv/src/main.rs
+++ b/boards/redboard_redv/src/main.rs
@@ -39,7 +39,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =

--- a/boards/redboard_redv/src/main.rs
+++ b/boards/redboard_redv/src/main.rs
@@ -39,7 +39,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
@@ -138,7 +138,12 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     let peripherals = static_init!(
         E310G002DefaultPeripherals,

--- a/boards/redboard_redv/src/main.rs
+++ b/boards/redboard_redv/src/main.rs
@@ -138,12 +138,10 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     let peripherals = static_init!(
         E310G002DefaultPeripherals,

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -69,7 +69,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 kernel::stack_size! {0x1000}
 

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -69,7 +69,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 kernel::stack_size! {0x1000}
 
@@ -202,7 +202,12 @@ pub unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     let ieee802154_ack_buf = static_init!(
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -202,12 +202,10 @@ pub unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     let ieee802154_ack_buf = static_init!(
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -43,7 +43,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -43,7 +43,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
@@ -380,7 +380,12 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     // We use the default HSI 8Mhz clock
     let rcc = static_init!(stm32f303xc::rcc::Rcc, stm32f303xc::rcc::Rcc::new());

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -380,12 +380,10 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     // We use the default HSI 8Mhz clock
     let rcc = static_init!(stm32f303xc::rcc::Rcc, stm32f303xc::rcc::Rcc::new());

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -40,7 +40,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -406,12 +406,10 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     let rcc = static_init!(stm32f412g::rcc::Rcc, stm32f412g::rcc::Rcc::new());
     let clocks = static_init!(

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -40,7 +40,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
@@ -406,7 +406,12 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     let rcc = static_init!(stm32f412g::rcc::Rcc, stm32f412g::rcc::Rcc::new());
     let clocks = static_init!(

--- a/boards/stm32f429idiscovery/src/main.rs
+++ b/boards/stm32f429idiscovery/src/main.rs
@@ -38,7 +38,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =

--- a/boards/stm32f429idiscovery/src/main.rs
+++ b/boards/stm32f429idiscovery/src/main.rs
@@ -38,7 +38,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
@@ -287,7 +287,12 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     // We use the default HSI 16Mhz clock
     let rcc = static_init!(stm32f429zi::rcc::Rcc, stm32f429zi::rcc::Rcc::new());

--- a/boards/stm32f429idiscovery/src/main.rs
+++ b/boards/stm32f429idiscovery/src/main.rs
@@ -287,12 +287,10 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     // We use the default HSI 16Mhz clock
     let rcc = static_init!(stm32f429zi::rcc::Rcc, stm32f429zi::rcc::Rcc::new());

--- a/boards/teensy40/src/main.rs
+++ b/boards/teensy40/src/main.rs
@@ -36,7 +36,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 /// What should we do if a process faults?
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =

--- a/boards/teensy40/src/main.rs
+++ b/boards/teensy40/src/main.rs
@@ -187,12 +187,10 @@ unsafe fn start() -> (&'static kernel::Kernel, Teensy40, &'static ChipHw) {
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     let ccm = static_init!(imxrt1060::ccm::Ccm, imxrt1060::ccm::Ccm::new());
     let peripherals = static_init!(

--- a/boards/teensy40/src/main.rs
+++ b/boards/teensy40/src/main.rs
@@ -36,7 +36,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 /// What should we do if a process faults?
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
@@ -187,7 +187,12 @@ unsafe fn start() -> (&'static kernel::Kernel, Teensy40, &'static ChipHw) {
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     let ccm = static_init!(imxrt1060::ccm::Ccm, imxrt1060::ccm::Ccm::new());
     let peripherals = static_init!(

--- a/boards/veer_el2_sim/src/main.rs
+++ b/boards/veer_el2_sim/src/main.rs
@@ -36,7 +36,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =

--- a/boards/veer_el2_sim/src/main.rs
+++ b/boards/veer_el2_sim/src/main.rs
@@ -118,12 +118,10 @@ unsafe fn start() -> (&'static kernel::Kernel, VeeR, &'static VeeRChip) {
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread_unsafe::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     let peripherals = static_init!(VeeRDefaultPeripherals, VeeRDefaultPeripherals::new());
     peripherals.init();

--- a/boards/veer_el2_sim/src/main.rs
+++ b/boards/veer_el2_sim/src/main.rs
@@ -36,7 +36,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
@@ -119,7 +119,11 @@ unsafe fn start() -> (&'static kernel::Kernel, VeeR, &'static VeeRChip) {
 
     // Bind global variables to this thread.
     PANIC_RESOURCES
-        .bind_to_thread_unsafe::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+        .bind_to_thread_unsafe::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     let peripherals = static_init!(VeeRDefaultPeripherals, VeeRDefaultPeripherals::new());
     peripherals.init();

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -37,7 +37,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -37,7 +37,7 @@ type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
@@ -232,7 +232,12 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     // We use the default HSI 16Mhz clock
     let rcc = static_init!(stm32f401cc::rcc::Rcc, stm32f401cc::rcc::Rcc::new());

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -232,12 +232,10 @@ unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     // We use the default HSI 16Mhz clock
     let rcc = static_init!(stm32f401cc::rcc::Rcc, stm32f401cc::rcc::Rcc::new());

--- a/boards/wm1110dev/src/main.rs
+++ b/boards/wm1110dev/src/main.rs
@@ -80,7 +80,7 @@ type ProcessPrinter = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
-    SingleThreadValue::new(PanicResources::new());
+    SingleThreadValue::new(PanicResources::new);
 
 kernel::stack_size! {0x1000}
 

--- a/boards/wm1110dev/src/main.rs
+++ b/boards/wm1110dev/src/main.rs
@@ -80,7 +80,7 @@ type ProcessPrinter = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
-    SingleThreadValue::new(PanicResources::new);
+    SingleThreadValue::new();
 
 kernel::stack_size! {0x1000}
 
@@ -204,7 +204,12 @@ pub unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES.bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>();
+    PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        )
+        .map_err(|_| ())
+        .unwrap();
 
     let ieee802154_ack_buf = static_init!(
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],

--- a/boards/wm1110dev/src/main.rs
+++ b/boards/wm1110dev/src/main.rs
@@ -204,12 +204,10 @@ pub unsafe fn start() -> (
     >();
 
     // Bind global variables to this thread.
-    PANIC_RESOURCES
+    let _ = PANIC_RESOURCES
         .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
             PanicResources::new(),
-        )
-        .map_err(|_| ())
-        .unwrap();
+        );
 
     let ieee802154_ack_buf = static_init!(
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -396,14 +396,14 @@ pub fn panic_blink_forever<L: hil::led::Led>(leds: &mut [&L]) -> ! {
 
 /// Static variable that holds an array of debug GPIO references.
 pub static DEBUG_GPIOS: SingleThreadValue<MapCell<&'static [&'static dyn hil::gpio::Pin]>> =
-    SingleThreadValue::new(MapCell::empty);
+    SingleThreadValue::new();
 
 /// Initialize the static debug gpio variable.
 ///
 /// This ensures it can safely be used as a global variable.
 #[cfg(target_has_atomic = "ptr")]
 pub fn initialize_debug_gpio<P: ThreadIdProvider>() {
-    DEBUG_GPIOS.bind_to_thread::<P>();
+    DEBUG_GPIOS.bind_to_thread::<P>(MapCell::empty());
 }
 
 /// Initialize the static debug gpio variable.
@@ -415,7 +415,7 @@ pub fn initialize_debug_gpio<P: ThreadIdProvider>() {
 /// Callers of this function must ensure that this function is never called
 /// concurrently with other calls to [`initialize_debug_gpio_unsafe`].
 pub unsafe fn initialize_debug_gpio_unsafe<P: ThreadIdProvider>() {
-    DEBUG_GPIOS.bind_to_thread_unsafe::<P>();
+    DEBUG_GPIOS.bind_to_thread_unsafe::<P>(MapCell::empty());
 }
 
 /// Map an array of GPIO pins to use for debugging.
@@ -485,21 +485,21 @@ pub trait DebugWriter {
 /// This is needed so the `debug!()` macros have a reference to the object to
 /// use.
 static DEBUG_WRITER: SingleThreadValue<MapCell<&'static dyn DebugWriter>> =
-    SingleThreadValue::new(MapCell::empty);
+    SingleThreadValue::new();
 
 /// Static variable that holds how many times `debug!()` has been called.
 ///
 /// This enables printing a verbose header message that enumerates independent
 /// debug messages.
-static DEBUG_WRITER_COUNT: SingleThreadValue<Cell<usize>> = SingleThreadValue::new(|| Cell::new(0));
+static DEBUG_WRITER_COUNT: SingleThreadValue<Cell<usize>> = SingleThreadValue::new();
 
 /// Initialize the static debug writer.
 ///
 /// This ensures it can safely be used as a global variable.
 #[cfg(target_has_atomic = "ptr")]
 pub fn initialize_debug_writer_wrapper<P: ThreadIdProvider>() {
-    DEBUG_WRITER.bind_to_thread::<P>();
-    DEBUG_WRITER_COUNT.bind_to_thread::<P>();
+    DEBUG_WRITER.bind_to_thread::<P>(MapCell::empty());
+    DEBUG_WRITER_COUNT.bind_to_thread::<P>(Cell::new(0));
 }
 
 /// Initialize the static debug writer.
@@ -511,8 +511,8 @@ pub fn initialize_debug_writer_wrapper<P: ThreadIdProvider>() {
 /// Callers of this function must ensure that this function is never called
 /// concurrently with other calls to [`initialize_debug_writer_wrapper_unsafe`].
 pub unsafe fn initialize_debug_writer_wrapper_unsafe<P: ThreadIdProvider>() {
-    DEBUG_WRITER.bind_to_thread_unsafe::<P>();
-    DEBUG_WRITER_COUNT.bind_to_thread_unsafe::<P>();
+    DEBUG_WRITER.bind_to_thread_unsafe::<P>(MapCell::empty());
+    DEBUG_WRITER_COUNT.bind_to_thread_unsafe::<P>(Cell::new(0));
 }
 
 fn try_get_debug_writer<F, R>(closure: F) -> Option<R>

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -403,7 +403,10 @@ pub static DEBUG_GPIOS: SingleThreadValue<MapCell<&'static [&'static dyn hil::gp
 /// This ensures it can safely be used as a global variable.
 #[cfg(target_has_atomic = "ptr")]
 pub fn initialize_debug_gpio<P: ThreadIdProvider>() {
-    DEBUG_GPIOS.bind_to_thread::<P>(MapCell::empty());
+    DEBUG_GPIOS
+        .bind_to_thread::<P>(MapCell::empty())
+        .map_err(|_| ())
+        .unwrap();
 }
 
 /// Initialize the static debug gpio variable.
@@ -415,7 +418,10 @@ pub fn initialize_debug_gpio<P: ThreadIdProvider>() {
 /// Callers of this function must ensure that this function is never called
 /// concurrently with other calls to [`initialize_debug_gpio_unsafe`].
 pub unsafe fn initialize_debug_gpio_unsafe<P: ThreadIdProvider>() {
-    DEBUG_GPIOS.bind_to_thread_unsafe::<P>(MapCell::empty());
+    DEBUG_GPIOS
+        .bind_to_thread_unsafe::<P>(MapCell::empty())
+        .map_err(|_| ())
+        .unwrap();
 }
 
 /// Map an array of GPIO pins to use for debugging.
@@ -498,8 +504,14 @@ static DEBUG_WRITER_COUNT: SingleThreadValue<Cell<usize>> = SingleThreadValue::n
 /// This ensures it can safely be used as a global variable.
 #[cfg(target_has_atomic = "ptr")]
 pub fn initialize_debug_writer_wrapper<P: ThreadIdProvider>() {
-    DEBUG_WRITER.bind_to_thread::<P>(MapCell::empty());
-    DEBUG_WRITER_COUNT.bind_to_thread::<P>(Cell::new(0));
+    DEBUG_WRITER
+        .bind_to_thread::<P>(MapCell::empty())
+        .map_err(|_| ())
+        .unwrap();
+    DEBUG_WRITER_COUNT
+        .bind_to_thread::<P>(Cell::new(0))
+        .map_err(|_| ())
+        .unwrap();
 }
 
 /// Initialize the static debug writer.
@@ -511,8 +523,14 @@ pub fn initialize_debug_writer_wrapper<P: ThreadIdProvider>() {
 /// Callers of this function must ensure that this function is never called
 /// concurrently with other calls to [`initialize_debug_writer_wrapper_unsafe`].
 pub unsafe fn initialize_debug_writer_wrapper_unsafe<P: ThreadIdProvider>() {
-    DEBUG_WRITER.bind_to_thread_unsafe::<P>(MapCell::empty());
-    DEBUG_WRITER_COUNT.bind_to_thread_unsafe::<P>(Cell::new(0));
+    DEBUG_WRITER
+        .bind_to_thread_unsafe::<P>(MapCell::empty())
+        .map_err(|_| ())
+        .unwrap();
+    DEBUG_WRITER_COUNT
+        .bind_to_thread_unsafe::<P>(Cell::new(0))
+        .map_err(|_| ())
+        .unwrap();
 }
 
 fn try_get_debug_writer<F, R>(closure: F) -> Option<R>

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -396,7 +396,7 @@ pub fn panic_blink_forever<L: hil::led::Led>(leds: &mut [&L]) -> ! {
 
 /// Static variable that holds an array of debug GPIO references.
 pub static DEBUG_GPIOS: SingleThreadValue<MapCell<&'static [&'static dyn hil::gpio::Pin]>> =
-    SingleThreadValue::new(MapCell::empty());
+    SingleThreadValue::new(MapCell::empty);
 
 /// Initialize the static debug gpio variable.
 ///
@@ -485,13 +485,13 @@ pub trait DebugWriter {
 /// This is needed so the `debug!()` macros have a reference to the object to
 /// use.
 static DEBUG_WRITER: SingleThreadValue<MapCell<&'static dyn DebugWriter>> =
-    SingleThreadValue::new(MapCell::empty());
+    SingleThreadValue::new(MapCell::empty);
 
 /// Static variable that holds how many times `debug!()` has been called.
 ///
 /// This enables printing a verbose header message that enumerates independent
 /// debug messages.
-static DEBUG_WRITER_COUNT: SingleThreadValue<Cell<usize>> = SingleThreadValue::new(Cell::new(0));
+static DEBUG_WRITER_COUNT: SingleThreadValue<Cell<usize>> = SingleThreadValue::new(|| Cell::new(0));
 
 /// Initialize the static debug writer.
 ///

--- a/kernel/src/deferred_call.rs
+++ b/kernel/src/deferred_call.rs
@@ -166,12 +166,9 @@ static DEFCALLS: SingleThreadValue<[OptionalCell<DynDefCallRef<'static>>; 32]> =
 /// This ensures it can safely be used as a global variable.
 #[cfg(target_has_atomic = "ptr")]
 pub fn initialize_deferred_call_state<P: ThreadIdProvider>() {
-    CTR.bind_to_thread::<P>(Cell::new(0)).unwrap();
-    BITMASK.bind_to_thread::<P>(Cell::new(0)).unwrap();
-    DEFCALLS
-        .bind_to_thread::<P>([const { OptionalCell::empty() }; 32])
-        .map_err(|_| ())
-        .unwrap();
+    let _ = CTR.bind_to_thread::<P>(Cell::new(0));
+    let _ = BITMASK.bind_to_thread::<P>(Cell::new(0));
+    let _ = DEFCALLS.bind_to_thread::<P>([const { OptionalCell::empty() }; 32]);
 }
 
 /// Initialize the static state used by deferred calls.
@@ -184,12 +181,9 @@ pub fn initialize_deferred_call_state<P: ThreadIdProvider>() {
 /// concurrently with calls to [`initialize_deferred_call_state`] or other calls
 /// to [`initialize_deferred_call_state_unsafe`].
 pub unsafe fn initialize_deferred_call_state_unsafe<P: ThreadIdProvider>() {
-    CTR.bind_to_thread_unsafe::<P>(Cell::new(0)).unwrap();
-    BITMASK.bind_to_thread_unsafe::<P>(Cell::new(0)).unwrap();
-    DEFCALLS
-        .bind_to_thread_unsafe::<P>([const { OptionalCell::empty() }; 32])
-        .map_err(|_| ())
-        .unwrap();
+    let _ = CTR.bind_to_thread_unsafe::<P>(Cell::new(0));
+    let _ = BITMASK.bind_to_thread_unsafe::<P>(Cell::new(0));
+    let _ = DEFCALLS.bind_to_thread_unsafe::<P>([const { OptionalCell::empty() }; 32]);
 }
 
 pub struct DeferredCall {

--- a/kernel/src/deferred_call.rs
+++ b/kernel/src/deferred_call.rs
@@ -147,28 +147,28 @@ impl DynDefCallRef<'_> {
 // thread. TODO: Once Tock decides on an approach to replace `static mut` with
 // some sort of `SyncCell`, migrate all three of these to that approach
 // (https://github.com/tock/tock/issues/1545).
-static CTR: SingleThreadValue<Cell<usize>> = SingleThreadValue::new(|| Cell::new(0));
+static CTR: SingleThreadValue<Cell<usize>> = SingleThreadValue::new();
 
 /// This bitmask tracks which of the up to 32 existing deferred calls have been
 /// scheduled. Any bit that is set in that mask indicates the deferred call with
 /// its [`DeferredCall::idx`] field set to the index of that bit has been
 /// scheduled and not yet serviced.
-static BITMASK: SingleThreadValue<Cell<u32>> = SingleThreadValue::new(|| Cell::new(0));
+static BITMASK: SingleThreadValue<Cell<u32>> = SingleThreadValue::new();
 
 /// An array that stores references to up to 32 `DeferredCall`s via the low-cost
 /// [`DynDefCallRef`].
 // This is a 256 byte array, but at least resides in `.bss`.
 static DEFCALLS: SingleThreadValue<[OptionalCell<DynDefCallRef<'static>>; 32]> =
-    SingleThreadValue::new(|| [const { OptionalCell::empty() }; 32]);
+    SingleThreadValue::new();
 
 /// Initialize the static state used by deferred calls.
 ///
 /// This ensures it can safely be used as a global variable.
 #[cfg(target_has_atomic = "ptr")]
 pub fn initialize_deferred_call_state<P: ThreadIdProvider>() {
-    CTR.bind_to_thread::<P>();
-    BITMASK.bind_to_thread::<P>();
-    DEFCALLS.bind_to_thread::<P>();
+    CTR.bind_to_thread::<P>(Cell::new(0));
+    BITMASK.bind_to_thread::<P>(Cell::new(0));
+    DEFCALLS.bind_to_thread::<P>([const { OptionalCell::empty() }; 32]);
 }
 
 /// Initialize the static state used by deferred calls.
@@ -181,9 +181,9 @@ pub fn initialize_deferred_call_state<P: ThreadIdProvider>() {
 /// concurrently with calls to [`initialize_deferred_call_state`] or other calls
 /// to [`initialize_deferred_call_state_unsafe`].
 pub unsafe fn initialize_deferred_call_state_unsafe<P: ThreadIdProvider>() {
-    CTR.bind_to_thread_unsafe::<P>();
-    BITMASK.bind_to_thread_unsafe::<P>();
-    DEFCALLS.bind_to_thread_unsafe::<P>();
+    CTR.bind_to_thread_unsafe::<P>(Cell::new(0));
+    BITMASK.bind_to_thread_unsafe::<P>(Cell::new(0));
+    DEFCALLS.bind_to_thread_unsafe::<P>([const { OptionalCell::empty() }; 32]);
 }
 
 pub struct DeferredCall {

--- a/kernel/src/deferred_call.rs
+++ b/kernel/src/deferred_call.rs
@@ -147,19 +147,19 @@ impl DynDefCallRef<'_> {
 // thread. TODO: Once Tock decides on an approach to replace `static mut` with
 // some sort of `SyncCell`, migrate all three of these to that approach
 // (https://github.com/tock/tock/issues/1545).
-static CTR: SingleThreadValue<Cell<usize>> = SingleThreadValue::new(Cell::new(0));
+static CTR: SingleThreadValue<Cell<usize>> = SingleThreadValue::new(|| Cell::new(0));
 
 /// This bitmask tracks which of the up to 32 existing deferred calls have been
 /// scheduled. Any bit that is set in that mask indicates the deferred call with
 /// its [`DeferredCall::idx`] field set to the index of that bit has been
 /// scheduled and not yet serviced.
-static BITMASK: SingleThreadValue<Cell<u32>> = SingleThreadValue::new(Cell::new(0));
+static BITMASK: SingleThreadValue<Cell<u32>> = SingleThreadValue::new(|| Cell::new(0));
 
 /// An array that stores references to up to 32 `DeferredCall`s via the low-cost
 /// [`DynDefCallRef`].
 // This is a 256 byte array, but at least resides in `.bss`.
 static DEFCALLS: SingleThreadValue<[OptionalCell<DynDefCallRef<'static>>; 32]> =
-    SingleThreadValue::new([const { OptionalCell::empty() }; 32]);
+    SingleThreadValue::new(|| [const { OptionalCell::empty() }; 32]);
 
 /// Initialize the static state used by deferred calls.
 ///

--- a/kernel/src/deferred_call.rs
+++ b/kernel/src/deferred_call.rs
@@ -166,9 +166,12 @@ static DEFCALLS: SingleThreadValue<[OptionalCell<DynDefCallRef<'static>>; 32]> =
 /// This ensures it can safely be used as a global variable.
 #[cfg(target_has_atomic = "ptr")]
 pub fn initialize_deferred_call_state<P: ThreadIdProvider>() {
-    CTR.bind_to_thread::<P>(Cell::new(0));
-    BITMASK.bind_to_thread::<P>(Cell::new(0));
-    DEFCALLS.bind_to_thread::<P>([const { OptionalCell::empty() }; 32]);
+    CTR.bind_to_thread::<P>(Cell::new(0)).unwrap();
+    BITMASK.bind_to_thread::<P>(Cell::new(0)).unwrap();
+    DEFCALLS
+        .bind_to_thread::<P>([const { OptionalCell::empty() }; 32])
+        .map_err(|_| ())
+        .unwrap();
 }
 
 /// Initialize the static state used by deferred calls.
@@ -181,9 +184,12 @@ pub fn initialize_deferred_call_state<P: ThreadIdProvider>() {
 /// concurrently with calls to [`initialize_deferred_call_state`] or other calls
 /// to [`initialize_deferred_call_state_unsafe`].
 pub unsafe fn initialize_deferred_call_state_unsafe<P: ThreadIdProvider>() {
-    CTR.bind_to_thread_unsafe::<P>(Cell::new(0));
-    BITMASK.bind_to_thread_unsafe::<P>(Cell::new(0));
-    DEFCALLS.bind_to_thread_unsafe::<P>([const { OptionalCell::empty() }; 32]);
+    CTR.bind_to_thread_unsafe::<P>(Cell::new(0)).unwrap();
+    BITMASK.bind_to_thread_unsafe::<P>(Cell::new(0)).unwrap();
+    DEFCALLS
+        .bind_to_thread_unsafe::<P>([const { OptionalCell::empty() }; 32])
+        .map_err(|_| ())
+        .unwrap();
 }
 
 pub struct DeferredCall {

--- a/kernel/src/utilities/single_thread_value.rs
+++ b/kernel/src/utilities/single_thread_value.rs
@@ -14,24 +14,26 @@ use crate::platform::chip::ThreadIdProvider;
 /// Stages of binding a [`SingleThreadValue`] to a given thread.
 ///
 /// The [`SingleThreadValue`] starts out not being bound to, and thus not being
-/// usable by any thread. Only after its construction will it be bound to a
-/// particular thread, using either the [`SingleThreadValue::bind_to_thread`],
-/// or the [`SingleThreadValue::bind_to_thread_unsafe`] methods.
+/// usable by any thread. A `SingleThreadValue` instance is instead bound to
+/// particular thread using either the [`SingleThreadValue::bind_to_thread`], or
+/// the [`SingleThreadValue::bind_to_thread_unsafe`] methods. These methods can
+/// be used exactly once, after which the instance is permanently bound to the
+/// given thread that called these methods.
 ///
-/// For other these and other methods to know whether a [`SingleThreadValue`]
-/// has been bound to a thread already, and thus whether its `thread_id_and_fn`
-/// field is initialized and holds a stable, it contains an `AtomicUsize` type
-/// to indicate its current "binding stage". Over its lifetime, this stage value
-/// is strictly increasing, transitioning through its variants as per their
-/// documentation.
+/// For these and other methods to know whether a [`SingleThreadValue`] has been
+/// bound to a thread already, and thus whether its `thread_id_and_fn` field is
+/// initialized and holds a stable value, it contains an `AtomicUsize` type to
+/// indicate its current "binding stage". Over its lifetime, this stage value is
+/// strictly increasing, transitioning through the [`BoundToThreadStage`] enum
+/// variants as per their documentation.
 #[repr(usize)]
 enum BoundToThreadStage {
-    /// This state means that the [`SingleThreadValue`] has not been bound to a
+    /// This stage means that the [`SingleThreadValue`] has not been bound to a
     /// particular thread yet, and its `thread_id_and_fn` field is not
     /// initialized.
     ///
     /// For the `bind_to_thread` and `bind_to_thread_unsafe` methods, this value
-    /// further means that the value can be bound to the currently running
+    /// further means that the instance can be bound to the currently running
     /// thread.
     Unbound = 0,
 
@@ -39,24 +41,24 @@ enum BoundToThreadStage {
     /// `bind_to_thread` function atomically transitions it from the `Unbound`
     /// stage to the `Binding` stage, through a compare-exchange operation.
     ///
-    /// When this stage is active, the `thread_id_and_fn` are not initialized,
-    /// similar to `Unbound`. However, it guards other, concurrent calls to
-    /// `bind_to_thread` from attempting to bind the value to another thread
-    /// concurrently.
+    /// When this stage is active, the `thread_id_and_fn` field is not
+    /// initialized, similar to `Unbound`. However, it prevents other,
+    /// concurrent calls to `bind_to_thread` from attempting to bind the value
+    /// to another thread concurrently.
     ///
     /// Targets without support for compare-exchange atomic operations on
     /// `usize` types can utilize `bind_to_thread_unsafe` instead: this method
-    /// requires callers to guarantee that there are no concurrent calls to
-    /// either `bind_to_thread` OR `bind_to_thread_unsafe`. Thus, it can skip
-    /// this intermediate state: it can directly transition from `Unbound` into
-    /// `Bound`.
+    /// requires callers to externally guarantee that there are no concurrent
+    /// calls to either `bind_to_thread` OR `bind_to_thread_unsafe`. Thus, it
+    /// can skip this intermediate state: it can directly transition from
+    /// `Unbound` into `Bound`.
     #[allow(dead_code)]
     Binding = 1,
 
     /// This value indicates that the [`SingleThreadValue`] is bound to a
     /// particular thread. The `thread_id_and_fn` value is initialized and
-    /// sealed: it must not be modified any longer beyond this point, and no
-    /// mutable references may exist to it. The `Bound` state cannot be
+    /// sealed: it must not be modified beyond this point, and no mutable
+    /// references to it may exist. The `Bound` stage is final and cannot be
     /// transitioned out of.
     Bound = 2,
 }
@@ -91,12 +93,12 @@ enum BoundToThreadStage {
 ///     }
 /// }
 ///
-/// static FOO: SingleThreadValue<Cell<usize>> = SingleThreadValue::new(Cell::new(123));
+/// static FOO: SingleThreadValue<Cell<usize>> = SingleThreadValue::new();
 ///
 /// fn main() {
-///     // Bind the value contained in the `SingleThreadValue` to the currently
-///     // running thread:
-///     FOO.bind_to_thread::<DummyThreadIdProvider>();
+///     // Atomically move the value supplied in the constructor into the
+///     // `SingleThreadValue`, and bind it to the currently running thread:
+///     FOO.bind_to_thread::<DummyThreadIdProvider>(Cell::new(123));
 ///
 ///     // Attempt to access the value. Returns `Some(&T)` if running from the
 ///     // thread that the `SingleThreadValue` is bound to:
@@ -105,28 +107,30 @@ enum BoundToThreadStage {
 /// }
 /// ```
 ///
-/// After creating the [`SingleThreadValue`] and before trying to access the
-/// wrapped value, the [`SingleThreadValue`] must have its
-/// [`bind_to_thread`](SingleThreadValue::bind_to_thread) method called. Failing
-/// to bind it to a thread will prevent any access to the wrapped value.
+/// When creating a new [`SingleThreadValue`] instance, it is uninitialized
+/// until the [`bind_to_thread`](SingleThreadValue::bind_to_thread) or
+/// [`bind_to_thread_unsafe`](SingleThreadValue::bind_to_thread_unsafe) methods
+/// are called. Until it is initialized, all attempts to access the shared value
+/// using [`get`](SingleThreadValue::get) will return `None`.
 ///
 /// # Single-thread Synchronization
 ///
-/// It is possible for the same thread to get multiple, shared, references. As a
-/// result, users must use interior mutability (e.g.
+/// It is possible for the same thread to get multiple, shared, references to
+/// the wrapped value concurrently. Users can use interior mutability (e.g.
 /// [`Cell`](core::cell::Cell), [`MapCell`](tock_cells::map_cell::MapCell), or
 /// [`TakeCell`](tock_cells::take_cell::TakeCell)) to allow obtaining exclusive
 /// mutable access.
 ///
 /// # Guaranteeing Single-Thread Access
 ///
-/// [`SingleThreadValue`] is safe because it guarantees that the value is only
-/// ever accessed from a single thread. To do this, [`SingleThreadValue`]
-/// inspects the currently running thread on every access to the wrapped
-/// value. If the active thread is different than the original thread then the
+/// [`SingleThreadValue`] is safe because it guarantees that the contained value
+/// is only ever made accessible to the same thread from which it originated. To
+/// do this, [`SingleThreadValue`] inspects the currently running thread on
+/// every access to the wrapped value. If the active thread is different than
+/// the original thread to which the [`SingleThreadValue`] is bound, then the
 /// caller will not be able to access the value.
 ///
-/// This requires that the system provides a correct implementation of
+/// This requires that the system provide a correct implementation of
 /// [`ThreadIdProvider`] to identify the currently executing thread. Internally,
 /// [`SingleThreadValue`] uses the [`ThreadIdProvider::running_thread_id`]
 /// function to identify the current thread and compares it against the thread
@@ -172,15 +176,17 @@ enum BoundToThreadStage {
 pub struct SingleThreadValue<T> {
     /// The contained value, made accessible to a single thread only.
     ///
-    /// To avoid imposing a constraint of `T: Send`, the value is only stored
-    /// on the same thread that the `SingleThreadValue` is bound to within
-    /// the `bind_to_thread()` function.
+    /// To avoid imposing a constraint of `T: Send`, this value is not populated
+    /// when the [`SingleThreadValue`] is constructed. It is instead initialized
+    /// by moving a value originating from the same thread that the
+    /// `SingleThreadValue` is ultimately bound to, within the
+    /// `bind_to_thread()` function.
     value: UnsafeCell<MaybeUninit<T>>,
 
     /// Shared atomic state to indicate whether this type is already bound to a
     /// particular thread, or in the process of being bound to a particular
     /// thread. Assumes values of [`BoundToThreadStage`]. Consider that type's
-    /// documentation for how `bound_to_thread` is used.
+    /// documentation for how the `bound_to_thread` value is used.
     bound_to_thread: AtomicUsize,
 
     /// Context used to determine which thread ID this type is bound to, and how
@@ -198,16 +204,18 @@ pub struct SingleThreadValue<T> {
 /// # Safety
 ///
 /// This is safe because [`SingleThreadValue`] enforces that the shared value
-/// is only ever accessed from a single thread.
+/// is only ever accessed from the same thread it originated from.
 unsafe impl<T> Sync for SingleThreadValue<T> {}
 
 impl<T> SingleThreadValue<T> {
     /// Create a [`SingleThreadValue`].
     ///
-    /// Note, the value will not be accessible immediately after `new()` runs.
-    /// It must first be bound to a particular thread, using the
+    /// Note that the `SingleThreadValue` will initially be uninitialized. It
+    /// must first be bound to a particular thread, which will initialize with a
+    /// value originating from that thread, using the
     /// [`bind_to_thread`](SingleThreadValue::bind_to_thread) or
-    /// [`bind_to_thread_unsafe`](SingleThreadValue::bind_to_thread_unsafe) methods.
+    /// [`bind_to_thread_unsafe`](SingleThreadValue::bind_to_thread_unsafe)
+    /// methods.
     pub const fn new() -> Self {
         Self {
             value: UnsafeCell::new(MaybeUninit::uninit()),
@@ -216,7 +224,8 @@ impl<T> SingleThreadValue<T> {
         }
     }
 
-    /// Bind this [`SingleThreadValue`] to the currently running thread.
+    /// Initialize this [`SingleThreadValue`] and bind it the currently running
+    /// thread.
     ///
     /// If this [`SingleThreadValue`] is not already bound to a thread, or if it
     /// is not currently in the process of binding to a thread, then this binds
@@ -226,16 +235,16 @@ impl<T> SingleThreadValue<T> {
     /// reference, and uses this function to determine the currently running
     /// thread for any future queries.
     ///
-    /// Returns `true` if this invocation successfully bound the value to the
+    /// Returns `Ok(())` if this invocation successfully bound the value to the
     /// current thread. Otherwise, if the value was already bound to this same
     /// or another thread, or is concurrently being bound to a thread, it
-    /// returns `false`.
+    /// returns `Err(T)`, returning the supplied value.
     ///
     /// This method requires the target to support atomic operations
     /// (namely, `compare_exchange`) on `usize`-sized values, and thus
     /// relies on the `cfg(target_has_atomic = "ptr")` conditional.
     #[cfg(target_has_atomic = "ptr")]
-    pub fn bind_to_thread<P: ThreadIdProvider>(&self, value: T) -> bool {
+    pub fn bind_to_thread<P: ThreadIdProvider>(&self, value: T) -> Result<(), T> {
         // For the check whether we're already bound to a thread, `Relaxed`
         // ordering is fine: we don't actually care about the value in
         // `thread_id_and_fn`, and don't need previous writes to it to be
@@ -261,7 +270,7 @@ impl<T> SingleThreadValue<T> {
             )
             .is_err()
         {
-            return false;
+            return Err(value);
         }
 
         // Great, we have reserved the value for initialization!
@@ -339,10 +348,11 @@ impl<T> SingleThreadValue<T> {
 
         // We have successfully bound this `SingleThreadValue` to the
         // currently running thread:
-        true
+        Ok(())
     }
 
-    /// Bind this [`SingleThreadValue`] to the currently running thread.
+    /// Initialize this [`SingleThreadValue`] and bind it to the currently
+    /// running thread.
     ///
     /// If this [`SingleThreadValue`] is not already bound to a thread, or if it
     /// is not currently in the process of binding to a thread, then this binds
@@ -352,9 +362,9 @@ impl<T> SingleThreadValue<T> {
     /// reference, and uses this function to determine the currently running
     /// thread for any future queries.
     ///
-    /// Returns `true` if this invocation successfully bound the value to the
+    /// Returns `Ok(())` if this invocation successfully bound the value to the
     /// current thread. Otherwise, if the value was already bound to this same
-    /// or another thread, it returns `false`.
+    /// or another thread, it returns `Err(T)`, returning the supplied value.
     ///
     /// This method is `unsafe`, and does not require the target to support
     /// atomic operations (namely, `compare_exchange`) on `usize`-sized values.
@@ -366,14 +376,14 @@ impl<T> SingleThreadValue<T> {
     /// [`bind_to_thread`](SingleThreadValue::bind_to_thread) or
     /// [`bind_to_thread_unsafe`](SingleThreadValue::bind_to_thread_unsafe) on
     /// the same [`SingleThreadValue`] instance.
-    pub unsafe fn bind_to_thread_unsafe<P: ThreadIdProvider>(&self, value: T) -> bool {
+    pub unsafe fn bind_to_thread_unsafe<P: ThreadIdProvider>(&self, value: T) -> Result<(), T> {
         // For the check whether we're already bound to a thread, `Relaxed`
         // ordering is fine: we don't actually care about the value in
         // `thread_id_and_fn`, and don't need previous writes to it to be
         // visible to this thread.
         if self.bound_to_thread.load(Ordering::Relaxed) != BoundToThreadStage::Unbound as usize {
             // This value is already bound to a thread
-            return false;
+            return Err(value);
         }
 
         // Write the current thread ID, and the function symbol used to
@@ -432,7 +442,7 @@ impl<T> SingleThreadValue<T> {
 
         // We have successfully bound this `SingleThreadValue` to the
         // currently running thread:
-        true
+        Ok(())
     }
 
     /// Check whether this `SingleThreadValue` instance is bound to the

--- a/kernel/src/utilities/single_thread_value.rs
+++ b/kernel/src/utilities/single_thread_value.rs
@@ -333,7 +333,14 @@ impl<T> SingleThreadValue<T> {
 
         // Initialize the contained value, constructed on the same (currently
         // running) thread that we are binding the `SingleThreadValue` to. This
-        // avoids a requirement of `T: Send`:
+        // avoids a requirement of `T: Send`.
+        //
+        // # Safety
+        //
+        // We are the only thread with access to `self.value` going forward, and
+        // this is the first time that this value is being accessed (as we're
+        // initializing it). Therefore, we can safely dereference a mutable
+        // (unique) pointer to this value:
         unsafe {
             *self.value.get() = MaybeUninit::new(value);
         }
@@ -427,7 +434,14 @@ impl<T> SingleThreadValue<T> {
 
         // Initialize the contained value, constructed on the same (currently
         // running) thread that we are binding the `SingleThreadValue` to. This
-        // avoids a requirement of `T: Send`:
+        // avoids a requirement of `T: Send`.
+        //
+        // # Safety
+        //
+        // We are the only thread with access to `self.value` going forward, and
+        // this is the first time that this value is being accessed (as we're
+        // initializing it). Therefore, we can safely dereference a mutable
+        // (unique) pointer to this value:
         unsafe {
             *self.value.get() = MaybeUninit::new(value);
         }

--- a/kernel/src/utilities/single_thread_value.rs
+++ b/kernel/src/utilities/single_thread_value.rs
@@ -544,6 +544,12 @@ impl<T> SingleThreadValue<T> {
     /// reference to its contained value.
     pub fn get(&self) -> Option<&T> {
         if self.bound_to_current_thread() {
+            // # Safety
+            //
+            // When `self.bound_to_current_thread()` returns true, we know that
+            // `self.value` is initialized, and that the value belongs to and is
+            // accessible to the currently running thread. We can safely
+            // construct a reference to it.
             Some(unsafe { (&*self.value.get()).assume_init_ref() })
         } else {
             None

--- a/kernel/src/utilities/single_thread_value.rs
+++ b/kernel/src/utilities/single_thread_value.rs
@@ -172,14 +172,10 @@ enum BoundToThreadStage {
 pub struct SingleThreadValue<T> {
     /// The contained value, made accessible to a single thread only.
     ///
-    /// To avoid imposing a constraint of `T: Send`, the value is initialized on
-    /// the same thread that the `SingleThreadValue` is bound to, using the
-    /// `init_fn` function.
+    /// To avoid imposing a constraint of `T: Send`, the value is only stored
+    /// on the same thread that the `SingleThreadValue` is bound to within
+    /// the `bind_to_thread()` function.
     value: UnsafeCell<MaybeUninit<T>>,
-
-    /// A function to produce a new value of type `T`, used to initialize
-    /// `value` when binding to a thread.
-    init_fn: fn() -> T,
 
     /// Shared atomic state to indicate whether this type is already bound to a
     /// particular thread, or in the process of being bound to a particular
@@ -212,10 +208,9 @@ impl<T> SingleThreadValue<T> {
     /// It must first be bound to a particular thread, using the
     /// [`bind_to_thread`](SingleThreadValue::bind_to_thread) or
     /// [`bind_to_thread_unsafe`](SingleThreadValue::bind_to_thread_unsafe) methods.
-    pub const fn new(init_fn: fn() -> T) -> Self {
+    pub const fn new() -> Self {
         Self {
             value: UnsafeCell::new(MaybeUninit::uninit()),
-            init_fn,
             bound_to_thread: AtomicUsize::new(BoundToThreadStage::Unbound as usize),
             thread_id_and_fn: UnsafeCell::new(MaybeUninit::uninit()),
         }
@@ -240,7 +235,7 @@ impl<T> SingleThreadValue<T> {
     /// (namely, `compare_exchange`) on `usize`-sized values, and thus
     /// relies on the `cfg(target_has_atomic = "ptr")` conditional.
     #[cfg(target_has_atomic = "ptr")]
-    pub fn bind_to_thread<P: ThreadIdProvider>(&self) -> bool {
+    pub fn bind_to_thread<P: ThreadIdProvider>(&self, value: T) -> bool {
         // For the check whether we're already bound to a thread, `Relaxed`
         // ordering is fine: we don't actually care about the value in
         // `thread_id_and_fn`, and don't need previous writes to it to be
@@ -331,7 +326,7 @@ impl<T> SingleThreadValue<T> {
         // running) thread that we are binding the `SingleThreadValue` to. This
         // avoids a requirement of `T: Send`:
         unsafe {
-            *self.value.get() = MaybeUninit::new((self.init_fn)());
+            *self.value.get() = MaybeUninit::new(value);
         }
 
         // When initializing the `SingleThreadValue`, we must use `Release`
@@ -371,7 +366,7 @@ impl<T> SingleThreadValue<T> {
     /// [`bind_to_thread`](SingleThreadValue::bind_to_thread) or
     /// [`bind_to_thread_unsafe`](SingleThreadValue::bind_to_thread_unsafe) on
     /// the same [`SingleThreadValue`] instance.
-    pub unsafe fn bind_to_thread_unsafe<P: ThreadIdProvider>(&self) -> bool {
+    pub unsafe fn bind_to_thread_unsafe<P: ThreadIdProvider>(&self, value: T) -> bool {
         // For the check whether we're already bound to a thread, `Relaxed`
         // ordering is fine: we don't actually care about the value in
         // `thread_id_and_fn`, and don't need previous writes to it to be
@@ -424,7 +419,7 @@ impl<T> SingleThreadValue<T> {
         // running) thread that we are binding the `SingleThreadValue` to. This
         // avoids a requirement of `T: Send`:
         unsafe {
-            *self.value.get() = MaybeUninit::new((self.init_fn)());
+            *self.value.get() = MaybeUninit::new(value);
         }
 
         // When initializing the `SingleThreadValue`, we must use `Release`

--- a/kernel/src/utilities/single_thread_value.rs
+++ b/kernel/src/utilities/single_thread_value.rs
@@ -171,7 +171,15 @@ enum BoundToThreadStage {
 // necessary for certain use cases within Tock, this should not be used lightly.
 pub struct SingleThreadValue<T> {
     /// The contained value, made accessible to a single thread only.
-    value: T,
+    ///
+    /// To avoid imposing a constraint of `T: Send`, the value is initialized on
+    /// the same thread that the `SingleThreadValue` is bound to, using the
+    /// `init_fn` function.
+    value: UnsafeCell<MaybeUninit<T>>,
+
+    /// A function to produce a new value of type `T`, used to initialize
+    /// `value` when binding to a thread.
+    init_fn: fn() -> T,
 
     /// Shared atomic state to indicate whether this type is already bound to a
     /// particular thread, or in the process of being bound to a particular
@@ -204,9 +212,10 @@ impl<T> SingleThreadValue<T> {
     /// It must first be bound to a particular thread, using the
     /// [`bind_to_thread`](SingleThreadValue::bind_to_thread) or
     /// [`bind_to_thread_unsafe`](SingleThreadValue::bind_to_thread_unsafe) methods.
-    pub const fn new(value: T) -> Self {
+    pub const fn new(init_fn: fn() -> T) -> Self {
         Self {
-            value,
+            value: UnsafeCell::new(MaybeUninit::uninit()),
+            init_fn,
             bound_to_thread: AtomicUsize::new(BoundToThreadStage::Unbound as usize),
             thread_id_and_fn: UnsafeCell::new(MaybeUninit::uninit()),
         }
@@ -318,6 +327,13 @@ impl<T> SingleThreadValue<T> {
                 MaybeUninit::new((P::running_thread_id, P::running_thread_id()));
         }
 
+        // Initialize the contained value, constructed on the same (currently
+        // running) thread that we are binding the `SingleThreadValue` to. This
+        // avoids a requirement of `T: Send`:
+        unsafe {
+            *self.value.get() = MaybeUninit::new((self.init_fn)());
+        }
+
         // When initializing the `SingleThreadValue`, we must use `Release`
         // ordering on the `bound_to_thread` store. This ensures that any
         // subsequent atomic load of this value with at least `Acquire`
@@ -402,6 +418,13 @@ impl<T> SingleThreadValue<T> {
         unsafe {
             *ptr_thread_id_and_fn =
                 MaybeUninit::new((P::running_thread_id, P::running_thread_id()));
+        }
+
+        // Initialize the contained value, constructed on the same (currently
+        // running) thread that we are binding the `SingleThreadValue` to. This
+        // avoids a requirement of `T: Send`:
+        unsafe {
+            *self.value.get() = MaybeUninit::new((self.init_fn)());
         }
 
         // When initializing the `SingleThreadValue`, we must use `Release`
@@ -516,7 +539,7 @@ impl<T> SingleThreadValue<T> {
     /// reference to its contained value.
     pub fn get(&self) -> Option<&T> {
         if self.bound_to_current_thread() {
-            Some(&self.value)
+            Some(unsafe { (&*self.value.get()).assume_init_ref() })
         } else {
             None
         }


### PR DESCRIPTION
### Pull Request Overview

Currently, a value of type `T` can be moved into a `SingleThreadValue::new()` on a thread `A` (where thread `A` is the "thread" used when const-initializing the `static` holding the STV), then moved to a thread `B` (due to `SingleThreadValue: Sync`), bound that thread `B`, and finally retrieved in this other thread. This is unsound for `T: !Send`.

We can fix this issue by either requiring that `T: Send`, or by never moving values across thread boundaries. While conceptually simpler, the former approach causes issues in Tock. This is because we commonly store references to `T: !Sync` in `SingleThreadValue` containers. Unfortunately, `&T` is `Send` if and only if `T` is `Sync`.

Instead, this changes `SingleThreadValue` to accept and write the inner value in the `bind_to_thread` method itself. This moves an existing value of type `T` into the `SingleThreadValue`, stemming from the same thread that it is later made accessible to.

### Testing Strategy

This pull request has been subject to careful review.


### TODO or Help Wanted

~~This PR is a draft right now, to get early feedback on (1) whether this is actually a soundness bug and (2) if the solution is correct. (@jrvanwhy ?)~~

~~It needs a full pass over the `SingleThreadValue`'s documentation.~~

Man, this is tricky, eh?

### Documentation Updated

- [X] ~Updated the relevant files in `/docs`, or~ no updates are required.

### Formatting

- [X] Ran `make prepush`.
