### PR TITLE
Make tock-registers an inherited workspace dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,9 @@ version = "0.2.3-dev"
 authors = ["Tock Project Developers <devel@lists.tockos.org>"]
 edition = "2021"
 
+[workspace.dependencies]
+tock-registers = { version = "0.10.0", default-features = false }
+
 [profile.dev]
 panic = "abort"
 lto = true

--- a/arch/riscv/Cargo.toml
+++ b/arch/riscv/Cargo.toml
@@ -10,7 +10,7 @@ edition.workspace = true
 
 [dependencies]
 kernel = { path = "../../kernel" }
-tock-registers = "0.10.0"
+tock-registers.workspace = true
 riscv-csr = { path = "../../libraries/riscv-csr" }
 
 

--- a/arch/rv32i/Cargo.toml
+++ b/arch/rv32i/Cargo.toml
@@ -10,7 +10,7 @@ edition.workspace = true
 
 [dependencies]
 kernel = { path = "../../kernel" }
-tock-registers = "0.10.0"
+tock-registers.workspace = true
 riscv-csr = { path = "../../libraries/riscv-csr" }
 riscv = { path = "../riscv" }
 

--- a/arch/x86/Cargo.toml
+++ b/arch/x86/Cargo.toml
@@ -11,7 +11,7 @@ edition.workspace = true
 [dependencies]
 kernel = { path = "../../kernel" }
 tock-cells = { path = "../../libraries/tock-cells" }
-tock-registers = "0.10.0"
+tock-registers.workspace = true
 
 [lints]
 workspace = true

--- a/chips/litex/Cargo.toml
+++ b/chips/litex/Cargo.toml
@@ -9,7 +9,7 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-tock-registers = "0.10.0"
+tock-registers.workspace = true
 kernel = { path = "../../kernel" }
 
 [lints]

--- a/chips/pci-x86/Cargo.toml
+++ b/chips/pci-x86/Cargo.toml
@@ -9,7 +9,7 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-tock-registers = "0.10.0"
+tock-registers.workspace = true
 x86 = { path = "../../arch/x86" }
 
 [lints]

--- a/chips/x86_q35/Cargo.toml
+++ b/chips/x86_q35/Cargo.toml
@@ -11,7 +11,7 @@ edition.workspace = true
 [dependencies]
 kernel = { path = "../../kernel" }
 x86 = { path = "../../arch/x86" }
-tock-registers = "0.10.0"
+tock-registers.workspace = true
 tock-cells = { path = "../../libraries/tock-cells" }
 
 [lints]

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -16,7 +16,7 @@ check_overflow = "lazy"
 include = [ "src/collections{*.rs}" ]
 
 [dependencies]
-tock-registers = "0.10.0"
+tock-registers = { features = ["register_types"], workspace = true }
 tock-cells = { path = "../libraries/tock-cells" }
 tock-tbf = { path = "../libraries/tock-tbf" }
 flux-rs = { git  = "https://github.com/flux-rs/flux.git", rev = "8256bd03c72f4ba4633ff969fac6c53928969edc", optional = true }

--- a/libraries/riscv-csr/Cargo.toml
+++ b/libraries/riscv-csr/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2021"
 travis-ci = { repository = "tock/tock", branch = "master" }
 
 [dependencies]
-tock-registers = {version = "0.10.0", default-features = false }
+tock-registers.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
### Pull Request Overview

This moves the dependency specification into the root Cargo.toml. With this change, anyone working on tock-registers only needs to change one Cargo.toml to test Tock with their tock-registers changes.

### Testing Strategy

1. `make boards`
1. `make check` with `path = "../registers"` added to the tock-registers dependency.

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.

### AI Use

- [X] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
