### PR TITLE
capsules: gpio: ensure the grant is allocated

### DIFF
--- a/capsules/core/src/gpio.rs
+++ b/capsules/core/src/gpio.rs
@@ -197,7 +197,7 @@ impl<'a, IP: gpio::InterruptPin<'a>> SyscallDriver for GPIO<'a, IP> {
 
         // This app did anything with the GPIO driver. We mark it as enabled
         // by allocating the grant region. This allows for upcalls.
-        let _ = self.apps.enter(processid, |_, _| {});
+        let grant_ret = self.apps.enter(processid, |_, _| {});
 
         match command_num {
             // Check existence.
@@ -292,6 +292,14 @@ impl<'a, IP: gpio::InterruptPin<'a>> SyscallDriver for GPIO<'a, IP> {
             // configure interrupts on pin
             // (no affect or reliance on registered callback)
             7 => {
+                // If the grant entry failed, meaning we could not allocate the
+                // grant, we want to ensure the app does not try to wait on an
+                // interrupt upcall using Yield-WaitFor which will never return. So,
+                // we return an error for this operation.
+                if grant_ret.is_err() {
+                    return CommandReturn::failure(ErrorCode::NOMEM);
+                }
+
                 let irq_config = data2;
                 if pin_index >= pins.len() {
                     /* impossible pin */
@@ -304,6 +312,14 @@ impl<'a, IP: gpio::InterruptPin<'a>> SyscallDriver for GPIO<'a, IP> {
             // disable interrupts on pin, also disables pin
             // (no affect or reliance on registered callback)
             8 => {
+                // If the grant entry failed, meaning we could not allocate the
+                // grant, we want to ensure the app does not try to wait on an
+                // interrupt upcall using Yield-WaitFor which will never return. So,
+                // we return an error for this operation.
+                if grant_ret.is_err() {
+                    return CommandReturn::failure(ErrorCode::NOMEM);
+                }
+
                 if pin_index >= pins.len() {
                     /* impossible pin */
                     CommandReturn::failure(ErrorCode::INVAL)

--- a/capsules/core/src/gpio.rs
+++ b/capsules/core/src/gpio.rs
@@ -190,10 +190,15 @@ impl<'a, IP: gpio::InterruptPin<'a>> SyscallDriver for GPIO<'a, IP> {
         command_num: usize,
         data1: usize,
         data2: usize,
-        _: ProcessId,
+        processid: ProcessId,
     ) -> CommandReturn {
         let pins = self.pins;
         let pin_index = data1;
+
+        // This app did anything with the GPIO driver. We mark it as enabled
+        // by allocating the grant region. This allows for upcalls.
+        let _ = self.apps.enter(processid, |_, _| {});
+
         match command_num {
             // Check existence.
             0 => CommandReturn::success(),

--- a/doc/syscalls/00004_gpio.md
+++ b/doc/syscalls/00004_gpio.md
@@ -117,9 +117,33 @@ actual hardware pins. This mapping is currently subject to change.
     undefined.
 
     **Returns**: `Ok(())` if the pin identifier is valid, `INVAL` if it is
-    invalid, and `ENOSUPPORT` if an invalid interrupt mode is passed in the
+    invalid, `NOMEM` if the grant region could not be allocated, and
+    `ENOSUPPORT` if an invalid interrupt mode is passed in the
     configuration field of the argument. If any error is returned, no state
     will be changed.
+
+  * ### Command number: `8`
+
+    **Description**: Disable interrupts on a GPIO pin.
+
+    **Argument 1**: The identifier of the GPIO pin to read.
+
+    **Argument 2**: unused
+
+    **Returns**: `Ok(())` if the pin identifier is valid, `INVAL` if it is
+    invalid, or `NOMEM` if the grant region could not be allocated. If any
+    error is returned, no state will be changed.
+
+  * ### Command number: `9`
+
+    **Description**: Disable a GPIO pin.
+
+    **Argument 1**: The identifier of the GPIO pin to read.
+
+    **Argument 2**: unused
+
+    **Returns**: `Ok(())` if the pin identifier is valid, or `INVAL` if it is
+    invalid. If any error is returned, no state will be changed.
 
   * ### Command number: `10`
 


### PR DESCRIPTION


### Pull Request Overview

This ensures the grant region is created for the app whenever it uses the GPIO driver. This in turn ensures that upcalls work, even if the app uses Yield-WaitFor.

This is an alternative to #4769, and takes the approach of "the GPIO driver is wrong".


### Testing Strategy

Trying to lose an upcall between when a command is called and calling YWF.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
