### PR TITLE
doc: trd104: add note about YWF race condition avoidance

### DIFF
--- a/doc/reference/trd104-syscalls.md
+++ b/doc/reference/trd104-syscalls.md
@@ -517,6 +517,10 @@ function will invoked by the kernel. Instead, the contents of r0-r2 will
 be set to the Upcall Arguments provided by the driver when the upcall is
 scheduled.
 
+To avoid a race condition between the event being waited on and the
+Yield-WaitFor call, the kernel will queue upcalls for the process even if
+there is no userspace callback function registered.
+
 `yield-param-C` is unused and reserved.
 
 


### PR DESCRIPTION


### Pull Request Overview

Add a brief note to TRD104 about how the kernel avoids an issue where an upcall is lost between an app asking for an event and calling YWF.


### Testing Strategy

doc


### TODO or Help Wanted

Is this the place to add this?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
