### PR TITLE
[RFC] kernel/process: switch ProcessId to use u64 unique identifier

### DIFF
--- a/capsules/core/src/low_level_debug/fmt.rs
+++ b/capsules/core/src/low_level_debug/fmt.rs
@@ -19,7 +19,7 @@ pub const BUF_LEN: usize = max(45 + 2 * USIZE_DIGITS, 35 + 3 * USIZE_DIGITS);
 
 // Formats the given DebugEntry using the provided buffer. Returns the length of
 // the message.
-pub(crate) fn format_entry(app_num: usize, entry: DebugEntry, buffer: &mut [u8]) -> usize {
+pub(crate) fn format_entry(app_num: u64, entry: DebugEntry, buffer: &mut [u8]) -> usize {
     use core::fmt::write;
     use DebugEntry::{AlertCode, Dropped, Print1, Print2};
     let mut adapter = WriteAdapter::new(buffer);

--- a/capsules/core/src/low_level_debug/mod.rs
+++ b/capsules/core/src/low_level_debug/mod.rs
@@ -152,7 +152,7 @@ impl<'u, U: Transmit<'u>> LowLevelDebug<'u, U> {
     }
 
     // Immediately prints the provided entry to the UART.
-    fn transmit_entry(&self, buffer: &'static mut [u8], app_num: usize, entry: DebugEntry) {
+    fn transmit_entry(&self, buffer: &'static mut [u8], app_num: u64, entry: DebugEntry) {
         let msg_len = fmt::format_entry(app_num, entry, buffer);
         // The uart's error message is ignored because we cannot do anything if
         // it fails anyway.

--- a/capsules/extra/src/process_info_driver.rs
+++ b/capsules/extra/src/process_info_driver.rs
@@ -111,6 +111,11 @@ impl<C: ProcessManagementCapability + ProcessStartCapability> SyscallDriver for 
         data2: usize,
         process_id: ProcessId,
     ) -> CommandReturn {
+        // If the data arugments contain a 64-bit ProcessId, then data1 contains
+        // the low-half (in native endianness) and data2 contains the high-half
+        // (in native endianness):
+        let data_process_id = (data2 as u64) << 32 | data1 as u64;
+
         match command_num {
             // Driver existence check
             0 => CommandReturn::success(),
@@ -151,7 +156,7 @@ impl<C: ProcessManagementCapability + ProcessStartCapability> SyscallDriver for 
 
                                 self.kernel
                                     .process_each_capability(&self.capability, |process| {
-                                        if process.processid().id() == data1 {
+                                        if process.processid().id() == data_process_id {
                                             let n = process.get_process_name().as_bytes();
 
                                             let name_len = n.len();
@@ -193,7 +198,7 @@ impl<C: ProcessManagementCapability + ProcessStartCapability> SyscallDriver for 
                                 let mut chunks = s.chunks(size_of::<u32>());
                                 self.kernel
                                     .process_each_capability(&self.capability, |process| {
-                                        if process.processid().id() == data1 {
+                                        if process.processid().id() == data_process_id {
                                             if let Some(chunk) = chunks.next() {
                                                 let _ = chunk.copy_from_slice_or_err(
                                                     &process
@@ -235,34 +240,34 @@ impl<C: ProcessManagementCapability + ProcessStartCapability> SyscallDriver for 
                 })
                 .unwrap_or_else(|err| CommandReturn::failure(err.into())),
 
-            6 => {
+            6..=10 => {
                 let mut matched = false;
                 self.kernel
                     .process_each_capability(&self.capability, |process| {
-                        if process.processid().id() == data1 {
+                        if process.processid().id() == data_process_id {
                             matched = true;
 
-                            match data2 {
-                                1 => {
+                            match command_num - 6 {
+                                0 => {
                                     // START
                                     process.resume();
                                 }
-                                2 => {
+                                1 => {
                                     // STOP
                                     process.stop();
                                 }
 
-                                3 => {
+                                2 => {
                                     // FAULT
                                     process.set_fault_state();
                                 }
 
-                                4 => {
+                                3 => {
                                     // TERMINATE
                                     process.terminate(None);
                                 }
 
-                                5 => {
+                                4 => {
                                     // BOOT
                                     if process.get_state() == process::State::Terminated {
                                         process.start(&self.capability);

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -48,7 +48,7 @@ pub struct Kernel {
 
     /// A counter which keeps track of how many process identifiers have been
     /// created. This is used to create new unique identifiers for processes.
-    process_identifier_max: Cell<usize>,
+    process_identifier_max: Cell<u64>,
 
     /// How many grant regions have been setup. This is incremented on every
     /// call to `create_grant()`. We need to explicitly track this so that when
@@ -295,10 +295,29 @@ impl Kernel {
 
     /// Create a new unique identifier for a process and return the identifier.
     ///
-    /// Typically we just choose a larger number than we have used for any
-    /// process before which ensures that the identifier is unique.
-    pub(crate) fn create_process_identifier(&self) -> usize {
-        self.process_identifier_max.get_and_increment()
+    /// The kernel internally tracks the highest previously created process
+    /// identifier, and hands out the next not-yet-assigned identifier.
+    ///
+    /// # Panics
+    ///
+    /// This underlying counter is not allowed to wrap around to guarantee
+    /// uniqueness of all created identifiers across a kernel instance's
+    /// lifetime. This function will panic in case the underlying u64 counter
+    /// will overflow.
+    ///
+    ///  In practice, this case should never be encountered. Even on a 1GHz with
+    /// 1 instruction per cycle, where this value is incremented in every cycle,
+    /// it would still take 584 years for this number to wrap around. It's
+    /// highly unlikely a Tock kernel instance will be running for this amount
+    /// of time.
+    pub(crate) fn create_process_identifier(&self) -> u64 {
+        let id = self.process_identifier_max.get();
+
+        // We increment the maximum processes identifier by 1, panicing in case
+        // of a u64 integer overflow.
+        self.process_identifier_max.set(id.checked_add(1).unwrap());
+
+        id
     }
 
     /// Find the next slot that is available for storing a new [`&Process`]

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -91,7 +91,7 @@ pub struct ProcessId {
     /// process at the given index does not match the value saved here, then the
     /// process moved or otherwise ended, and this `ProcessId` is no longer
     /// valid.
-    identifier: usize,
+    identifier: u64,
 }
 
 impl PartialEq for ProcessId {
@@ -128,7 +128,7 @@ impl fmt::Debug for ProcessId {
 impl ProcessId {
     /// Create a new `ProcessId` object based on the app identifier and its
     /// index in the processes array.
-    pub(crate) fn new(kernel: &'static Kernel, identifier: usize, index: usize) -> ProcessId {
+    pub(crate) fn new(kernel: &'static Kernel, identifier: u64, index: usize) -> ProcessId {
         ProcessId {
             kernel,
             index,
@@ -143,7 +143,7 @@ impl ProcessId {
     /// external implementations of `Process` can use it.
     pub fn new_external(
         kernel: &'static Kernel,
-        identifier: usize,
+        identifier: u64,
         index: usize,
         _capability: &dyn capabilities::ExternalProcessCapability,
     ) -> ProcessId {
@@ -168,7 +168,7 @@ impl ProcessId {
         }
     }
 
-    /// Get a `usize` unique identifier for the app this `ProcessId` refers to.
+    /// Get a `u64` unique identifier for the app this `ProcessId` refers to.
     ///
     /// This function should not generally be used, instead code should just use
     /// the `ProcessId` object itself to refer to various apps on the system.
@@ -182,7 +182,7 @@ impl ProcessId {
     /// the app may have restarted, or may have been ended or removed by the
     /// kernel. Therefore, calling `id()` is _not_ a valid way to check that an
     /// application still exists.
-    pub fn id(&self) -> usize {
+    pub fn id(&self) -> u64 {
         self.identifier
     }
 

--- a/kernel/src/process_array.rs
+++ b/kernel/src/process_array.rs
@@ -67,7 +67,7 @@ impl ProcessSlot {
     }
 
     /// Check if the slot contains a process with a matching process ID.
-    pub fn contains_process_with_id(&self, identifier: usize) -> bool {
+    pub fn contains_process_with_id(&self, identifier: u64) -> bool {
         match self.proc.get() {
             Some(process) => process.processid().id() == identifier,
             None => false,


### PR DESCRIPTION
### Pull Request Overview

This switches the unique numeric identifier of a process instance within the ProcessId type (colloquially also called process ID) to be an 8-byte unsigned integer, instead of usize. Additionally, it changes the kernel to panic on the offchance that the counter used for assigning new process IDs rolls over.

This change is motivated by recent discussions around new IPC mechanisms. These mechanisms consist of a "discovery" phase, where applications search for, and potentially authenticate a given process, and a "communication" phase, where they actually exchange data between processes. The discovery phase emits a unique process handle that a subsequent communication phase will use to uniquely identify a previously discovered and authenticated process. Virtually the only good candidate for such a handle on a Tock system is the numeric process ID, as it refers to a particular instance of an application, and does not require us to keep track of extra state or mappings.

However, depending on which architecture we are running on, this numeric process ID will be generated based on a counter that is either 4 or 8 byte wide (`usize`). While Tock systems generally are limited in the number of applications they can concurrently run, this identifier instead refers to an _instance_ of a process. As such, this counter can be controlled and increased by processes themselves. If this counter is based on a 4 byte value it is unlikely, but not impossible, that malicious or colluding processes could force it to overflow to a known, previous assigned value within a somewhat reasonable timeframe (multiple days).

We should not prevent such overflows by panicing the kernel, or preventing process restarts, as that endangers availability of the system, esp. when deployed in critical and long running scenarios.

At the same time, while unlikely, explicitly permitting counter overflows forces us to think about, model, and either handle or explicitly ignore many types of attacks (e.g., confused deputy) that could arise from such a forced counter overflow. This is not just affecting IPC, but any kernel or userspace subsystem that explicitly or implicitly relies on process ID uniqueness.

This PR instead proposes to make this numeric counter consistent across platforms and debug/release builds: it is always an 8 byte unsigned integer, and in contrast to the previous implementation (which only panics on debug builds) an overflow of this counter always panics the kernel. However, given the astronomical size of this counter, it is virtually impossible that a correct kernel implementation will ever reach this case.

This does come with some drawbacks: I don't believe performance will be impacted significantly (comparsion and increments of 64 bit numbers is decently efficient even on 32 bit systems). However, it does add a single word of memory everywhere that a Process ID is used. It also forces backwards-incompatible changes to a few userspace APIs (legacy IPC being a notable example, although we're in the process of removing that).

I want to open this RFC to start a discussion about this change, whether or not it is a good idea, and what a possible pathway for integrating it into the kernel could be. This does not actively block any IPC development, but we might design our interfaces to expect that we will be passing around `u64` instead of `usize` values.

### Testing Strategy

This PR is not tested.


### TODO or Help Wanted

The PR needs
1. consensus of whether this is a good change we want to (eventually) make
2. careful review of which existing capsule APIs this would break
3. evaluation of performance and memory overhead impacts
4. actual testing

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.

### AI Use

- [X] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.

Wrote this myself.
