### PR TITLE
DMA Slice: export cortex-m dma_fence, continue renames

### DIFF
--- a/arch/cortex-m4f/src/lib.rs
+++ b/arch/cortex-m4f/src/lib.rs
@@ -21,6 +21,7 @@ pub mod mpu {
     }
 }
 
+pub use cortexm::dma_fence;
 pub use cortexm::dwt;
 pub use cortexm::initialize_ram_jump_to_main;
 pub use cortexm::nvic;

--- a/chips/virtio/src/queues/split_queue.rs
+++ b/chips/virtio/src/queues/split_queue.rs
@@ -356,13 +356,13 @@ impl<'b> VirtqueueDmaBuffer<'b> {
     ) -> Self {
         match virtqueue_buffer {
             VirtqueueBuffer::DeviceReadable(sub_slice_mut_immut) => {
-                VirtqueueDmaBuffer::DeviceReadable(DmaSubSliceMutImmut::from_sub_slice_mut_immut(
+                VirtqueueDmaBuffer::DeviceReadable(DmaSubSliceMutImmut::new(
                     sub_slice_mut_immut,
                     fence,
                 ))
             }
             VirtqueueBuffer::DeviceWriteable(sub_slice_mut) => VirtqueueDmaBuffer::DeviceWriteable(
-                DmaSubSliceMut::from_sub_slice_mut(sub_slice_mut, fence),
+                DmaSubSliceMut::new_unsafe(sub_slice_mut, fence),
             ),
         }
     }
@@ -370,14 +370,10 @@ impl<'b> VirtqueueDmaBuffer<'b> {
     unsafe fn into_virtqueue_buffer(self, fence: impl DmaFence) -> VirtqueueBuffer<'b> {
         match self {
             VirtqueueDmaBuffer::DeviceReadable(dma_sub_slice_mut_immut) => {
-                VirtqueueBuffer::DeviceReadable(
-                    dma_sub_slice_mut_immut.restore_sub_slice_mut_immut(),
-                )
+                VirtqueueBuffer::DeviceReadable(dma_sub_slice_mut_immut.take())
             }
             VirtqueueDmaBuffer::DeviceWriteable(dma_sub_slice_mut) => {
-                VirtqueueBuffer::DeviceWriteable(unsafe {
-                    dma_sub_slice_mut.restore_sub_slice_mut(fence)
-                })
+                VirtqueueBuffer::DeviceWriteable(unsafe { dma_sub_slice_mut.take(fence) })
             }
         }
     }

--- a/kernel/src/utilities/dma_slice.rs
+++ b/kernel/src/utilities/dma_slice.rs
@@ -514,7 +514,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMut<'a
     /// [`restore_sub_slice_mut`](Self::restore_sub_slice_mut) to retrieve the
     /// underlying buffer.
     #[must_use]
-    pub unsafe fn from_sub_slice_mut(
+    pub unsafe fn new_unsafe(
         sub_slice_mut: SubSliceMut<'_, T>,
         fence: impl DmaFence,
     ) -> DmaSubSliceMut<'_, T> {
@@ -554,11 +554,11 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMut<'a
     /// In contrast to [`from_sub_slice_mut`] this function is safe, as dropping
     /// or forgetting its return value is safe, it would merely leak memory and
     /// make the underlying slice inaccessible.
-    pub fn from_static_sub_slice_mut(
+    pub fn new(
         sub_slice: SubSliceMut<'static, T>,
         fence: impl DmaFence,
     ) -> DmaSubSliceMut<'static, T> {
-        unsafe { Self::from_sub_slice_mut(sub_slice, fence) }
+        unsafe { Self::new_unsafe(sub_slice, fence) }
     }
 
     /// Returns the pointer to the first element of the active range of the
@@ -606,7 +606,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMut<'a
     /// that the hardware will not perform any further writes to the buffer at
     /// the point where [`restore_sub_slice_mut`](Self::restore_sub_slice_mut)
     /// is called.
-    pub unsafe fn restore_sub_slice_mut(mut self, fence: impl DmaFence) -> SubSliceMut<'a, T> {
+    pub unsafe fn take(mut self, fence: impl DmaFence) -> SubSliceMut<'a, T> {
         // Ensure that any reads from Rust to the active range of the buffer
         // (described by `self.as_mut_ptr()` and `self.len()`) _after_ this
         // function returns reflect all writes made by DMA operations finished
@@ -671,7 +671,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMutImm
     /// writes to `slice` are exposed to any DMA operations initiated by an MMIO
     /// read or write operation after this function returns, and which finish
     /// before the resulting [`DmaSubSlice`] is dropped.
-    pub fn from_sub_slice_mut_immut(
+    pub fn new(
         sub_slice: SubSliceMutImmut<'_, T>,
         fence: impl DmaFence,
     ) -> DmaSubSliceMutImmut<'_, T> {
@@ -690,7 +690,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMutImm
                 // Rust. However, this struct does not permit DMA operations
                 // which write to the slice, and hence it can be safely dropped
                 // without risk of concurrent modifications or incoherence.
-                DmaSubSliceMut::from_sub_slice_mut(sub_slice_mut, fence)
+                DmaSubSliceMut::new_unsafe(sub_slice_mut, fence)
             }),
         }
     }
@@ -721,7 +721,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMutImm
     /// that the DMA operation over the buffer is complete (such as by reading a
     /// status bit in memory or an MMIO register). Otherwise, any future reads
     /// by the DMA peripheral may not be consistent with the buffer contents.
-    pub fn restore_sub_slice_mut_immut(self) -> SubSliceMutImmut<'a, T> {
+    pub fn take(self) -> SubSliceMutImmut<'a, T> {
         // We don't need to perform an `acquire` fence, as any DMA operation on
         // the underlying slice must not have changed its contents:
         match self {


### PR DESCRIPTION
### Pull Request Overview

This pull requests continues my changes towards getting nrf52840dk uart to work with dmaslice.


### Testing Strategy

Running libtock-c uart tests with the nrf52840dk.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
