### PR TITLE
DMA Slice: Port nrf52 uart to DmaSlice

### DIFF
--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -179,7 +179,17 @@ impl UarteRegistersManager {
         }
     }
 
-    pub fn start_tx_dma(&self, buf: SubSliceMut<'static, u8>) {
+    /// Start a UART transmission with DMA.
+    ///
+    /// # Return
+    ///
+    /// `Ok(())` on successfully starting the DMA operation. `Err(())` if the
+    /// DMA is busy and the operation could not be started.
+    pub fn start_tx_dma(&self, buf: SubSliceMut<'static, u8>) -> Result<(), ()> {
+        if self.tx_dma_pending() {
+            return Err(());
+        }
+
         // To create a DmaFence we must trust the implementation.
         //
         // # Safety
@@ -204,6 +214,8 @@ impl UarteRegistersManager {
 
         // Start the TX DMA operation
         self.registers.task_starttx.write(Task::ENABLE::SET);
+
+        Ok(())
     }
 
     pub fn finish_tx_dma(&self) -> Option<(SubSliceMut<'static, u8>, usize)> {
@@ -235,7 +247,17 @@ impl UarteRegistersManager {
         self.tx_dma_buf.is_some()
     }
 
-    pub fn start_rx_dma(&self, buf: SubSliceMut<'static, u8>) {
+    /// Start a UART reception with DMA.
+    ///
+    /// # Return
+    ///
+    /// `Ok(())` on successfully starting the DMA operation. `Err(())` if the
+    /// DMA is busy and the operation could not be started.
+    pub fn start_rx_dma(&self, buf: SubSliceMut<'static, u8>) -> Result<(), ()> {
+        if self.rx_dma_pending() {
+            return Err(());
+        }
+
         // To create a DmaFence we must trust the implementation.
         //
         // # Safety
@@ -260,6 +282,8 @@ impl UarteRegistersManager {
 
         // Start the RX DMA operation
         self.registers.task_startrx.write(Task::ENABLE::SET);
+
+        Ok(())
     }
 
     pub fn finish_rx_dma(&self) -> Option<(SubSliceMut<'static, u8>, usize)> {
@@ -489,7 +513,7 @@ impl<'a> Uarte<'a> {
                     // Limit to at most the `UARTE_MAX_BUFFER_SIZE` bytes.
                     buf.slice(0..UARTE_MAX_BUFFER_SIZE);
                     // Send via DMA.
-                    self.registers.start_tx_dma(buf);
+                    let _ = self.registers.start_tx_dma(buf);
                     // Re-enable interrupts.
                     self.enable_tx_interrupts();
                 }
@@ -565,7 +589,7 @@ impl<'a> Uarte<'a> {
                         // Limit to at most the `UARTE_MAX_BUFFER_SIZE` bytes.
                         buf.slice(0..UARTE_MAX_BUFFER_SIZE);
                         // Receive via DMA.
-                        self.registers.start_rx_dma(buf);
+                        let _ = self.registers.start_rx_dma(buf);
                         // Re-enable interrupts.
                         self.enable_rx_interrupts();
                     }
@@ -622,7 +646,7 @@ impl<'a> Uarte<'a> {
 
         // Send the buffer using DMA. This is managed by the register manager to
         // ensure we are safely using DMA.
-        self.registers.start_tx_dma(slice_to_send);
+        let _ = self.registers.start_tx_dma(slice_to_send);
 
         // Enable interrupts so we get a interrupt when the transmission has
         // finished.
@@ -640,7 +664,7 @@ impl<'a> Uarte<'a> {
 
         // Use the buffer with DMA. This is managed by the register manager to
         // ensure we are safely using DMA.
-        self.registers.start_rx_dma(slice_to_receive);
+        let _ = self.registers.start_rx_dma(slice_to_receive);
 
         // Enable interrupts so we get a interrupt when the receive has
         // finished.

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -298,9 +298,7 @@ impl UarteRegistersManager {
 pub struct Uarte<'a> {
     registers: UarteRegistersManager,
     tx_client: OptionalCell<&'a dyn uart::TransmitClient>,
-    // tx_buffer: kernel::utilities::cells::TakeCell<'static, [u8]>,
     tx_len: Cell<usize>,
-    // tx_remaining_bytes: Cell<usize>,
     rx_client: OptionalCell<&'a dyn uart::ReceiveClient>,
     rx_len: Cell<usize>,
     rx_abort_in_progress: Cell<bool>,

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -11,16 +11,17 @@
 //! * Date: March 10 2018
 
 use core::cell::Cell;
-use core::cmp::min;
 use kernel::hil::uart;
-use kernel::utilities::cells::OptionalCell;
+use kernel::utilities::cells::{MapCell, OptionalCell};
+use kernel::utilities::dma_slice::DmaSubSliceMut;
+use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 use nrf5x::pinmux;
 
-const UARTE_MAX_BUFFER_SIZE: u32 = 0xff;
+const UARTE_MAX_BUFFER_SIZE: usize = 0xff;
 
 static mut BYTE: u8 = 0;
 
@@ -159,20 +160,150 @@ register_bitfields! [u32,
     ]
 ];
 
+/// Wrapper for managing MMIO for UARTE.
+struct UarteRegistersManager {
+    /// MMIO registers for the UARTE peripheral.
+    registers: StaticRef<UarteRegisters>,
+    /// Holding place for the TX DMA buffer while DMA in progress.
+    tx_dma_buf: MapCell<DmaSubSliceMut<'static, u8>>,
+    /// Holding place for the RX DMA buffer while DMA in progress.
+    rx_dma_buf: MapCell<DmaSubSliceMut<'static, u8>>,
+}
+
+impl UarteRegistersManager {
+    pub fn new(regs: StaticRef<UarteRegisters>) -> Self {
+        Self {
+            registers: regs,
+            tx_dma_buf: MapCell::empty(),
+            rx_dma_buf: MapCell::empty(),
+        }
+    }
+
+    pub fn start_tx_dma(&self, buf: SubSliceMut<'static, u8>) {
+        // To create a DmaFence we must trust the implementation.
+        //
+        // # Safety
+        //
+        // The architecture-provided version is correct for the nRF52.
+        let fence = unsafe { cortexm4f::dma_fence::CortexMDmaFence::new() };
+
+        // Create DmaSlice for the TX buffer. This ensures that we can soundly
+        // share it with the DMA hardware.
+        let tx_dma_slice = DmaSubSliceMut::new_static(buf, fence);
+
+        // Provide the DmaSlice buffer to the hardware DMA engine.
+        self.registers.txd_ptr.set(tx_dma_slice.as_mut_ptr() as u32);
+
+        // Specify the length to transmit.
+        self.registers
+            .txd_maxcnt
+            .write(Counter::COUNTER.val(tx_dma_slice.len() as u32));
+
+        // Save the DmaSlice while the DMA operation executes.
+        self.tx_dma_buf.replace(tx_dma_slice);
+
+        // Start the TX DMA operation
+        self.registers.task_starttx.write(Task::ENABLE::SET);
+    }
+
+    pub fn finish_tx_dma(&self) -> Option<(SubSliceMut<'static, u8>, usize)> {
+        // End the DMA operation so it is safe to retrieve the buffer.
+        self.registers.event_endtx.write(Event::READY::CLEAR);
+
+        self.tx_dma_buf.take().map(|dma_slice| {
+            // To create a DmaFence we must trust the implementation.
+            //
+            // # Safety
+            //
+            // The architecture-provided version is correct for the nRF52.
+            let fence = unsafe { cortexm4f::dma_fence::CortexMDmaFence::new() };
+
+            // # Safety
+            //
+            // We must ensure that the DMA hardware no longer has any access
+            // to this buffer. We ensure that by setting the `event_endtx`
+            // event before taking the dma slice back.
+            let buf = unsafe { dma_slice.take(fence) };
+
+            let tx_bytes = self.registers.txd_amount.get() as usize;
+
+            (buf, tx_bytes)
+        })
+    }
+
+    pub fn tx_dma_pending(&self) -> bool {
+        self.tx_dma_buf.is_some()
+    }
+
+    pub fn start_rx_dma(&self, buf: SubSliceMut<'static, u8>) {
+        // To create a DmaFence we must trust the implementation.
+        //
+        // # Safety
+        //
+        // The architecture-provided version is correct for the nRF52.
+        let fence = unsafe { cortexm4f::dma_fence::CortexMDmaFence::new() };
+
+        // Create DmaSlice for the RX buffer. This ensures that we can soundly
+        // share it with the DMA hardware.
+        let rx_dma_slice = DmaSubSliceMut::new_static(buf, fence);
+
+        // Provide the DmaSlice buffer to the hardware DMA engine.
+        self.registers.rxd_ptr.set(rx_dma_slice.as_mut_ptr() as u32);
+
+        // Specify the length to transmit.
+        self.registers
+            .rxd_maxcnt
+            .write(Counter::COUNTER.val(rx_dma_slice.len() as u32));
+
+        // Save the DmaSlice while the DMA operation executes.
+        self.rx_dma_buf.replace(rx_dma_slice);
+
+        // Start the RX DMA operation
+        self.registers.task_startrx.write(Task::ENABLE::SET);
+    }
+
+    pub fn finish_rx_dma(&self) -> Option<(SubSliceMut<'static, u8>, usize)> {
+        // End the DMA operation so it is safe to retrieve the buffer.
+        self.registers.event_endrx.write(Event::READY::CLEAR);
+
+        self.rx_dma_buf.take().map(|dma_slice| {
+            // To create a DmaFence we must trust the implementation.
+            //
+            // # Safety
+            //
+            // The architecture-provided version is correct for the nRF52.
+            let fence = unsafe { cortexm4f::dma_fence::CortexMDmaFence::new() };
+
+            // # Safety
+            //
+            // We must ensure that the DMA hardware no longer has any access
+            // to this buffer. We ensure that by setting the `event_endrx`
+            // event before taking the dma slice back.
+            let buf = unsafe { dma_slice.take(fence) };
+
+            let rx_bytes = self.registers.rxd_amount.get() as usize;
+
+            (buf, rx_bytes)
+        })
+    }
+
+    pub fn rx_dma_pending(&self) -> bool {
+        self.rx_dma_buf.is_some()
+    }
+}
+
 /// UARTE
 // It should never be instanced outside this module but because a static mutable reference to it
 // is exported outside this module it must be `pub`
 pub struct Uarte<'a> {
-    registers: StaticRef<UarteRegisters>,
+    registers: UarteRegistersManager,
     tx_client: OptionalCell<&'a dyn uart::TransmitClient>,
-    tx_buffer: kernel::utilities::cells::TakeCell<'static, [u8]>,
+    // tx_buffer: kernel::utilities::cells::TakeCell<'static, [u8]>,
     tx_len: Cell<usize>,
-    tx_remaining_bytes: Cell<usize>,
+    // tx_remaining_bytes: Cell<usize>,
     rx_client: OptionalCell<&'a dyn uart::ReceiveClient>,
-    rx_buffer: kernel::utilities::cells::TakeCell<'static, [u8]>,
-    rx_remaining_bytes: Cell<usize>,
+    rx_len: Cell<usize>,
     rx_abort_in_progress: Cell<bool>,
-    offset: Cell<usize>,
 }
 
 #[derive(Copy, Clone)]
@@ -183,18 +314,16 @@ pub struct UARTParams {
 impl<'a> Uarte<'a> {
     /// Constructor
     // This should only be constructed once
-    pub const fn new(regs: StaticRef<UarteRegisters>) -> Uarte<'a> {
+    pub fn new(regs: StaticRef<UarteRegisters>) -> Uarte<'a> {
         Uarte {
-            registers: regs,
+            registers: UarteRegistersManager::new(regs),
             tx_client: OptionalCell::empty(),
-            tx_buffer: kernel::utilities::cells::TakeCell::empty(),
+            // tx_buffer: kernel::utilities::cells::TakeCell::empty(),
             tx_len: Cell::new(0),
-            tx_remaining_bytes: Cell::new(0),
+            // tx_remaining_bytes: Cell::new(0),
             rx_client: OptionalCell::empty(),
-            rx_buffer: kernel::utilities::cells::TakeCell::empty(),
-            rx_remaining_bytes: Cell::new(0),
+            rx_len: Cell::new(0),
             rx_abort_in_progress: Cell::new(false),
-            offset: Cell::new(0),
         }
     }
 
@@ -206,26 +335,38 @@ impl<'a> Uarte<'a> {
         cts: Option<pinmux::Pinmux>,
         rts: Option<pinmux::Pinmux>,
     ) {
-        self.registers.pseltxd.write(Psel::PIN.val(txd.into()));
-        self.registers.pselrxd.write(Psel::PIN.val(rxd.into()));
+        self.registers
+            .registers
+            .pseltxd
+            .write(Psel::PIN.val(txd.into()));
+        self.registers
+            .registers
+            .pselrxd
+            .write(Psel::PIN.val(rxd.into()));
         cts.map_or_else(
             || {
                 // If no CTS pin is provided, then we need to mark it as
                 // disconnected in the register.
-                self.registers.pselcts.write(Psel::CONNECT::SET);
+                self.registers.registers.pselcts.write(Psel::CONNECT::SET);
             },
             |c| {
-                self.registers.pselcts.write(Psel::PIN.val(c.into()));
+                self.registers
+                    .registers
+                    .pselcts
+                    .write(Psel::PIN.val(c.into()));
             },
         );
         rts.map_or_else(
             || {
                 // If no RTS pin is provided, then we need to mark it as
                 // disconnected in the register.
-                self.registers.pselrts.write(Psel::CONNECT::SET);
+                self.registers.registers.pselrts.write(Psel::CONNECT::SET);
             },
             |r| {
-                self.registers.pselrts.write(Psel::PIN.val(r.into()));
+                self.registers
+                    .registers
+                    .pselrts
+                    .write(Psel::PIN.val(r.into()));
             },
         );
 
@@ -234,7 +375,10 @@ impl<'a> Uarte<'a> {
         // as we handle it, so this is not necessary. However, a bootloader (or
         // some other startup code) may have setup TX interrupts, and there may
         // be one pending. We clear it to be safe.
-        self.registers.event_endtx.write(Event::READY::CLEAR);
+        self.registers
+            .registers
+            .event_endtx
+            .write(Event::READY::CLEAR);
 
         self.enable_uart();
     }
@@ -265,35 +409,47 @@ impl<'a> Uarte<'a> {
 
     fn set_baud_rate(&self, baud_rate: u32) -> Result<(), ErrorCode> {
         let divider = self.get_divider_for_baud(baud_rate)?;
-        self.registers.baudrate.set(divider);
+        self.registers.registers.baudrate.set(divider);
 
         Ok(())
     }
 
     // Enable UART peripheral, this need to disabled for low power applications
     fn enable_uart(&self) {
-        self.registers.enable.write(Uart::ENABLE::ON);
+        self.registers.registers.enable.write(Uart::ENABLE::ON);
     }
 
     #[allow(dead_code)]
     fn disable_uart(&self) {
-        self.registers.enable.write(Uart::ENABLE::OFF);
+        self.registers.registers.enable.write(Uart::ENABLE::OFF);
     }
 
     fn enable_rx_interrupts(&self) {
-        self.registers.intenset.write(Interrupt::ENDRX::SET);
+        self.registers
+            .registers
+            .intenset
+            .write(Interrupt::ENDRX::SET);
     }
 
     fn enable_tx_interrupts(&self) {
-        self.registers.intenset.write(Interrupt::ENDTX::SET);
+        self.registers
+            .registers
+            .intenset
+            .write(Interrupt::ENDTX::SET);
     }
 
     fn disable_rx_interrupts(&self) {
-        self.registers.intenclr.write(Interrupt::ENDRX::SET);
+        self.registers
+            .registers
+            .intenclr
+            .write(Interrupt::ENDRX::SET);
     }
 
     fn disable_tx_interrupts(&self) {
-        self.registers.intenclr.write(Interrupt::ENDTX::SET);
+        self.registers
+            .registers
+            .intenclr
+            .write(Interrupt::ENDTX::SET);
     }
 
     /// UART interrupt handler that listens for both tx_end and rx_end events
@@ -301,32 +457,44 @@ impl<'a> Uarte<'a> {
     pub fn handle_interrupt(&self) {
         if self.tx_ready() {
             self.disable_tx_interrupts();
-            self.registers.event_endtx.write(Event::READY::CLEAR);
-            let tx_bytes = self.registers.txd_amount.get() as usize;
 
-            let rem = match self.tx_remaining_bytes.get().checked_sub(tx_bytes) {
-                None => return,
-                Some(r) => r,
-            };
+            if let Some((mut buf, transmitted_length)) = self.registers.finish_tx_dma() {
+                let active_range = buf.active_range();
 
-            // All bytes have been transmitted
-            if rem == 0 {
-                // Signal client write done
-                self.tx_client.map(|client| {
-                    self.tx_buffer.take().map(|tx_buffer| {
-                        client.transmitted_buffer(tx_buffer, self.tx_len.get(), Ok(()));
+                // Calculate the remaining bytes to transmit based on the length to
+                // transmit, the window we just tried to transmit, and how many
+                // bytes we actually did transmit.
+                //
+                // <-----buffer------------------->
+                //          <-active range->
+                // [        [              ]      ]
+                let remaining_bytes = self
+                    .tx_len
+                    .get()
+                    .saturating_sub(active_range.start)
+                    .saturating_sub(transmitted_length);
+
+                if remaining_bytes == 0 {
+                    // We sent everything.
+                    self.tx_client.map(|client| {
+                        client.transmitted_buffer(buf.take(), self.tx_len.get(), Ok(()));
                     });
-                });
-            } else {
-                // Not all bytes have been transmitted then update offset and continue transmitting
-                self.offset.set(self.offset.get() + tx_bytes);
-                self.tx_remaining_bytes.set(rem);
-                self.set_tx_dma_pointer_to_buffer();
-                self.registers
-                    .txd_maxcnt
-                    .write(Counter::COUNTER.val(min(rem as u32, UARTE_MAX_BUFFER_SIZE)));
-                self.registers.task_starttx.write(Task::ENABLE::SET);
-                self.enable_tx_interrupts();
+                } else {
+                    // Send the next portion of the buffer.
+
+                    // Reset back to the original slice.
+                    buf.reset();
+                    // Limit to just the portion of the buffer we are transmitting from.
+                    buf.slice(0..self.tx_len.get());
+                    // Skip what has already been transmitted.
+                    buf.slice((self.tx_len.get() - remaining_bytes)..);
+                    // Limit to at most the `UARTE_MAX_BUFFER_SIZE` bytes.
+                    buf.slice(0..UARTE_MAX_BUFFER_SIZE);
+                    // Send via DMA.
+                    self.registers.start_tx_dma(buf);
+                    // Re-enable interrupts.
+                    self.enable_tx_interrupts();
+                }
             }
         }
 
@@ -334,60 +502,75 @@ impl<'a> Uarte<'a> {
             self.disable_rx_interrupts();
 
             // Clear the ENDRX event
-            self.registers.event_endrx.write(Event::READY::CLEAR);
+            self.registers
+                .registers
+                .event_endrx
+                .write(Event::READY::CLEAR);
 
-            // Get the number of bytes in the buffer that was received this time
-            let rx_bytes = self.registers.rxd_amount.get() as usize;
+            if let Some((mut buf, received_length)) = self.registers.finish_rx_dma() {
+                let active_range = buf.active_range();
 
-            // Check if this ENDRX is due to an abort. If so, we want to
-            // do the receive callback immediately.
-            if self.rx_abort_in_progress.get() {
-                self.rx_abort_in_progress.set(false);
-                self.rx_client.map(|client| {
-                    self.rx_buffer.take().map(|rx_buffer| {
+                // Check if this ENDRX is due to an abort. If so, we want to
+                // do the receive callback immediately.
+                if self.rx_abort_in_progress.get() {
+                    self.rx_abort_in_progress.set(false);
+
+                    // Calculate how many bytes we actually received.
+                    let received_bytes = active_range.start + received_length;
+
+                    // Notify the client.
+                    self.rx_client.map(|client| {
                         client.received_buffer(
-                            rx_buffer,
-                            self.offset.get() + rx_bytes,
+                            buf.take(),
+                            received_bytes,
                             Err(ErrorCode::CANCEL),
                             uart::Error::None,
                         );
                     });
-                });
-            } else {
-                // In the normal case, we need to either pass call the callback
-                // or do another read to get more bytes.
+                } else {
+                    // In the normal case, we need to either pass call the callback
+                    // or do another read to get more bytes.
 
-                // Update how many bytes we still need to receive and
-                // where we are storing in the buffer.
-                self.rx_remaining_bytes
-                    .set(self.rx_remaining_bytes.get().saturating_sub(rx_bytes));
-                self.offset.set(self.offset.get() + rx_bytes);
+                    // Calculate the remaining bytes to receive based on the length to
+                    // receive, the window we just tried to receive into, and how many
+                    // bytes we actually did receive.
+                    //
+                    //
+                    // <-----buffer------------------->
+                    //          <-active range->
+                    // [        [              ]      ]
+                    let remaining_bytes = self
+                        .rx_len
+                        .get()
+                        .saturating_sub(active_range.start)
+                        .saturating_sub(received_length);
 
-                let rem = self.rx_remaining_bytes.get();
-                if rem == 0 {
-                    // Signal client that the read is done
-                    self.rx_client.map(|client| {
-                        self.rx_buffer.take().map(|rx_buffer| {
+                    if remaining_bytes == 0 {
+                        // Signal client that the read is done
+                        self.rx_client.map(|client| {
                             client.received_buffer(
-                                rx_buffer,
-                                self.offset.get(),
+                                buf.take(),
+                                self.rx_len.get(),
                                 Ok(()),
                                 uart::Error::None,
                             );
                         });
-                    });
-                } else {
-                    // Setup how much we can read. We already made sure that
-                    // this will fit in the buffer.
-                    let to_read = core::cmp::min(rem, 255);
-                    self.registers
-                        .rxd_maxcnt
-                        .write(Counter::COUNTER.val(to_read as u32));
+                    } else {
+                        // Receive into the next portion of the buffer.
 
-                    // Actually do the receive.
-                    self.set_rx_dma_pointer_to_buffer();
-                    self.registers.task_startrx.write(Task::ENABLE::SET);
-                    self.enable_rx_interrupts();
+                        // Reset back to the original slice.
+                        buf.reset();
+                        // Limit to just the portion of the buffer we are receiving into.
+                        buf.slice(0..self.rx_len.get());
+                        // Skip what has already been received.
+                        buf.slice((self.rx_len.get() - remaining_bytes)..);
+                        // Limit to at most the `UARTE_MAX_BUFFER_SIZE` bytes.
+                        buf.slice(0..UARTE_MAX_BUFFER_SIZE);
+                        // Receive via DMA.
+                        self.registers.start_rx_dma(buf);
+                        // Re-enable interrupts.
+                        self.enable_rx_interrupts();
+                    }
                 }
             }
         }
@@ -396,55 +579,74 @@ impl<'a> Uarte<'a> {
     /// Transmit one byte at the time and the client is responsible for polling
     /// This is used by the panic handler
     pub unsafe fn send_byte(&self, byte: u8) {
-        self.tx_remaining_bytes.set(1);
-        self.registers.event_endtx.write(Event::READY::CLEAR);
+        // self.tx_remaining_bytes.set(1);
+        self.registers
+            .registers
+            .event_endtx
+            .write(Event::READY::CLEAR);
         // precaution: copy value into variable with static lifetime
         BYTE = byte;
-        self.registers.txd_ptr.set(core::ptr::addr_of!(BYTE) as u32);
-        self.registers.txd_maxcnt.write(Counter::COUNTER.val(1));
-        self.registers.task_starttx.write(Task::ENABLE::SET);
+        self.registers
+            .registers
+            .txd_ptr
+            .set(core::ptr::addr_of!(BYTE) as u32);
+        self.registers
+            .registers
+            .txd_maxcnt
+            .write(Counter::COUNTER.val(1));
+        self.registers
+            .registers
+            .task_starttx
+            .write(Task::ENABLE::SET);
     }
 
     /// Check if the UART transmission is done
     pub fn tx_ready(&self) -> bool {
-        self.registers.event_endtx.is_set(Event::READY)
+        self.registers.registers.event_endtx.is_set(Event::READY)
     }
 
     /// Check if either the rx_buffer is full or the UART has timed out
     pub fn rx_ready(&self) -> bool {
-        self.registers.event_endrx.is_set(Event::READY)
-    }
-
-    fn set_tx_dma_pointer_to_buffer(&self) {
-        self.tx_buffer.map(|tx_buffer| {
-            self.registers
-                .txd_ptr
-                .set(tx_buffer[self.offset.get()..].as_ptr() as u32);
-        });
-    }
-
-    fn set_rx_dma_pointer_to_buffer(&self) {
-        self.rx_buffer.map(|rx_buffer| {
-            self.registers
-                .rxd_ptr
-                .set(rx_buffer[self.offset.get()..].as_ptr() as u32);
-        });
+        self.registers.registers.event_endrx.is_set(Event::READY)
     }
 
     // Helper function used by both transmit_word and transmit_buffer
     fn setup_buffer_transmit(&self, buf: &'static mut [u8], tx_len: usize) {
-        self.tx_remaining_bytes.set(tx_len);
+        // Save the total length to transmit as we may need to send over
+        // multiple iterations.
         self.tx_len.set(tx_len);
-        self.offset.set(0);
-        self.tx_buffer.replace(buf);
-        self.set_tx_dma_pointer_to_buffer();
 
-        self.registers
-            .txd_maxcnt
-            .write(Counter::COUNTER.val(min(tx_len as u32, UARTE_MAX_BUFFER_SIZE)));
-        self.registers.task_starttx.write(Task::ENABLE::SET);
+        // Create a `SubSlice` to simplify tracking which part we are sending,
+        // and slice the sub slice to either the total buffer to send or what
+        // fits in one send buffer.
+        let mut slice_to_send = SubSliceMut::new(buf);
+        slice_to_send.slice(0..core::cmp::min(tx_len, UARTE_MAX_BUFFER_SIZE));
 
+        // Send the buffer using DMA. This is managed by the register manager to
+        // ensure we are safely using DMA.
+        self.registers.start_tx_dma(slice_to_send);
+
+        // Enable interrupts so we get a interrupt when the transmission has
+        // finished.
         self.enable_tx_interrupts();
+    }
+
+    fn setup_buffer_receive(&self, buf: &'static mut [u8], rx_len: usize) {
+        // Save the total length to receive.
+        self.rx_len.set(rx_len);
+
+        // Create a `SubSlice` to simplify tracking which part we have received
+        // into.
+        let mut slice_to_receive = SubSliceMut::new(buf);
+        slice_to_receive.slice(0..core::cmp::min(rx_len, UARTE_MAX_BUFFER_SIZE));
+
+        // Use the buffer with DMA. This is managed by the register manager to
+        // ensure we are safely using DMA.
+        self.registers.start_rx_dma(slice_to_receive);
+
+        // Enable interrupts so we get a interrupt when the receive has
+        // finished.
+        self.enable_rx_interrupts();
     }
 }
 
@@ -460,7 +662,7 @@ impl<'a> uart::Transmit<'a> for Uarte<'a> {
     ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         if tx_len == 0 || tx_len > tx_data.len() {
             Err((ErrorCode::SIZE, tx_data))
-        } else if self.tx_buffer.is_some() {
+        } else if self.registers.tx_dma_pending() {
             Err((ErrorCode::BUSY, tx_data))
         } else {
             self.setup_buffer_transmit(tx_data, tx_len);
@@ -507,27 +709,14 @@ impl<'a> uart::Receive<'a> for Uarte<'a> {
         rx_buf: &'static mut [u8],
         rx_len: usize,
     ) -> Result<(), (ErrorCode, &'static mut [u8])> {
-        if self.rx_buffer.is_some() {
-            return Err((ErrorCode::BUSY, rx_buf));
+        if rx_len > rx_buf.len() {
+            Err((ErrorCode::SIZE, rx_buf))
+        } else if self.registers.rx_dma_pending() {
+            Err((ErrorCode::BUSY, rx_buf))
+        } else {
+            self.setup_buffer_receive(rx_buf, rx_len);
+            Ok(())
         }
-        // truncate rx_len if necessary
-        let truncated_length = core::cmp::min(rx_len, rx_buf.len());
-
-        self.rx_remaining_bytes.set(truncated_length);
-        self.offset.set(0);
-        self.rx_buffer.replace(rx_buf);
-        self.set_rx_dma_pointer_to_buffer();
-
-        let truncated_uart_max_length = core::cmp::min(truncated_length, 255);
-
-        self.registers
-            .rxd_maxcnt
-            .write(Counter::COUNTER.val(truncated_uart_max_length as u32));
-        self.registers.task_stoprx.write(Task::ENABLE::SET);
-        self.registers.task_startrx.write(Task::ENABLE::SET);
-
-        self.enable_rx_interrupts();
-        Ok(())
     }
 
     fn receive_word(&self) -> Result<(), ErrorCode> {
@@ -536,11 +725,14 @@ impl<'a> uart::Receive<'a> for Uarte<'a> {
 
     fn receive_abort(&self) -> Result<(), ErrorCode> {
         // Trigger the STOPRX event to cancel the current receive call.
-        if self.rx_buffer.is_none() {
+        if !self.registers.rx_dma_pending() {
             Ok(())
         } else {
             self.rx_abort_in_progress.set(true);
-            self.registers.task_stoprx.write(Task::ENABLE::SET);
+            self.registers
+                .registers
+                .task_stoprx
+                .write(Task::ENABLE::SET);
             Err(ErrorCode::BUSY)
         }
     }


### PR DESCRIPTION
### Pull Request Overview

This reworks the nrf52 uart driver to use the dma slice with the register manager struct idea. All unsafe is encapsulated in the register manager. I used subslices to make all of the buffer indexing much more straightforward.


### Testing Strategy

Running several libtock-c tests with the nrf52840dk and adjusting the max uarte buffer length to force TX messages to be done in multiple iterations.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
