### PR TITLE
hotp tutorial: storage permission fix

### DIFF
--- a/boards/tutorials/nrf52840dk-hotp-tutorial/src/main.rs
+++ b/boards/tutorials/nrf52840dk-hotp-tutorial/src/main.rs
@@ -9,9 +9,9 @@
 #![deny(missing_docs)]
 
 use kernel::component::Component;
-use kernel::debug;
 use kernel::hil::usb::Client;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::process::ProcessLoadingAsync;
 use kernel::static_init;
 use kernel::{capabilities, create_capability};
 use nrf52840::gpio::Pin;
@@ -55,6 +55,13 @@ impl SyscallDriverLookup for Platform {
             _ => self.base.with_driver(driver_num, f),
         }
     }
+}
+
+// Called by the process loader when the board boots.
+impl kernel::process::ProcessLoadingAsyncClient for Platform {
+    fn process_loaded(&self, _result: Result<(), kernel::process::ProcessLoadError>) {}
+
+    fn process_loading_finished(&self) {}
 }
 
 type ChipHw = nrf52840dk_lib::ChipHw;
@@ -118,6 +125,22 @@ pub unsafe fn main() {
         hmac_sha256_sw,
     )
     .finalize(components::hmac_component_static!(HmacSha256Software, 32));
+
+    //--------------------------------------------------------------------------
+    // CREDENTIALS CHECKING POLICY
+    //--------------------------------------------------------------------------
+
+    // Create the credential checker.
+    let checking_policy = components::appid::checker_null::AppCheckerNullComponent::new()
+        .finalize(components::app_checker_null_component_static!());
+
+    // Create the AppID assigner.
+    let assigner = components::appid::assigner_tbf::AppIdAssignerTbfHeaderComponent::new()
+        .finalize(components::appid_assigner_tbf_header_component_static!());
+
+    // Create the process checking machine.
+    let checker = components::appid::checker::ProcessCheckerMachineComponent::new(checking_policy)
+        .finalize(components::process_checker_machine_component_static!());
 
     //--------------------------------------------------------------------------
     // SCREEN
@@ -191,17 +214,23 @@ pub unsafe fn main() {
     keyboard_hid.attach();
 
     //--------------------------------------------------------------------------
-    // PLATFORM SETUP, SCHEDULER, AND START KERNEL LOOP
+    // STORAGE PERMISSIONS
     //--------------------------------------------------------------------------
 
-    let platform = Platform {
-        base: base_platform,
-        keyboard_hid_driver,
-        hmac,
-        screen,
-    };
+    let storage_permissions_policy =
+        components::storage_permissions::tbf_header::StoragePermissionsTbfHeaderComponent::new()
+            .finalize(
+                components::storage_permissions_tbf_header_component_static!(
+                    nrf52840dk_lib::ChipHw,
+                    kernel::process::ProcessStandardDebugFull,
+                ),
+            );
 
-    // These symbols are defined in the linker script.
+    //--------------------------------------------------------------------------
+    // PROCESS LOADING
+    //--------------------------------------------------------------------------
+
+    // These symbols are defined in the standard Tock linker script.
     extern "C" {
         /// Beginning of the ROM region containing app images.
         static _sapps: u8;
@@ -213,30 +242,50 @@ pub unsafe fn main() {
         static _eappmem: u8;
     }
 
-    let process_management_capability =
-        create_capability!(capabilities::ProcessManagementCapability);
+    let app_flash = core::slice::from_raw_parts(
+        core::ptr::addr_of!(_sapps),
+        core::ptr::addr_of!(_eapps) as usize - core::ptr::addr_of!(_sapps) as usize,
+    );
+    let app_memory = core::slice::from_raw_parts_mut(
+        core::ptr::addr_of_mut!(_sappmem),
+        core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
+    );
 
-    kernel::process::load_processes(
+    // Create and start the asynchronous process loader.
+    let loader = components::loader::sequential::ProcessLoaderSequentialComponent::new(
+        checker,
         board_kernel,
         chip,
-        core::slice::from_raw_parts(
-            core::ptr::addr_of!(_sapps),
-            core::ptr::addr_of!(_eapps) as usize - core::ptr::addr_of!(_sapps) as usize,
-        ),
-        core::slice::from_raw_parts_mut(
-            core::ptr::addr_of_mut!(_sappmem),
-            core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
-        ),
         &FAULT_RESPONSE,
-        &process_management_capability,
+        assigner,
+        storage_permissions_policy,
+        app_flash,
+        app_memory,
     )
-    .unwrap_or_else(|err| {
-        debug!("Error loading processes!");
-        debug!("{:?}", err);
-    });
+    .finalize(components::process_loader_sequential_component_static!(
+        nrf52840dk_lib::ChipHw,
+        kernel::process::ProcessStandardDebugFull,
+        nrf52840dk_lib::NUM_PROCS
+    ));
+
+    //--------------------------------------------------------------------------
+    // PLATFORM SETUP, SCHEDULER, AND START KERNEL LOOP
+    //--------------------------------------------------------------------------
+
+    let platform = static_init!(
+        Platform,
+        Platform {
+            base: base_platform,
+            keyboard_hid_driver,
+            hmac,
+            screen,
+        }
+    );
+
+    loader.set_client(platform);
 
     board_kernel.kernel_loop(
-        &platform,
+        platform,
         chip,
         Some(&platform.base.ipc),
         &main_loop_capability,


### PR DESCRIPTION
### Pull Request Overview

Access to write/read/modify storage requires an application to possess the necessary permissions. The hotp tutorial, in its current form, does not populate a process' permissions from the app's tbf, defaults to the process not having read/write/modify permissions, and results in the hotp tutorial application not working. This pull request updates the tutorial board file to load a process' storage permissions from the provided tbf.

### Testing Strategy

This pull request was tested by the tutorial checkpoints.

### TODO or Help Wanted

- Confirmation from @bradjc on if these changes are all needed. We really only care about populating the storage permission from the tbf header.
- We will also need to update the libtock-c Makefiles (add `--short-id <ID>` to `elf2tab` args) and update the book's tutorial. I will open PRs for both soon.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

No AI was used for this PR.

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
