### PR TITLE
DMA Slice: format regular vs doc/test code in arch the same as all other crates, format assembly

### DIFF
--- a/arch/riscv/src/dma_fence.rs
+++ b/arch/riscv/src/dma_fence.rs
@@ -87,15 +87,15 @@ unsafe impl DmaFence for RiscvCoherentDmaFence {
         unsafe {
             core::arch::asm!(
                 "
-                        // This block is opaque to the compiler; it must assume
-                        // that it could read the entire buffer from which the
-                        // pointer stored in {dma_buffer_ptr_reg} was derived.
+    // This block is opaque to the compiler; it must assume
+    // that it could read the entire buffer from which the
+    // pointer stored in {dma_buffer_ptr_reg} was derived.
 
-                        // Do not reorder prior memory writes over subsequent
-                        // I/O or memory reads or writes; see above Rust source
-                        // comment for explanation.
-                        fence w, iorw
-                    ",
+    // Do not reorder prior memory writes over subsequent
+    // I/O or memory reads or writes; see above Rust source
+    // comment for explanation.
+    fence w, iorw
+                ",
                 dma_buffer_ptr_reg = in(reg) slice_start_ptr,
             );
         }
@@ -140,16 +140,16 @@ unsafe impl DmaFence for RiscvCoherentDmaFence {
         unsafe {
             core::arch::asm!(
                 "
-                        // This block is opaque to the compiler; it must assume
-                        // that it could write to the entire buffer from which
-                        // the pointer stored in {dma_buffer_ptr_reg} was
-                        // derived.
+    // This block is opaque to the compiler; it must assume
+    // that it could write to the entire buffer from which
+    // the pointer stored in {dma_buffer_ptr_reg} was
+    // derived.
 
-                        // Do not reorder subsequent memory reads over prior I/O
-                        // or memory reads; see above Rust source comment for
-                        // explanation.
-                        fence ir, r
-                    ",
+    // Do not reorder subsequent memory reads over prior I/O
+    // or memory reads; see above Rust source comment for
+    // explanation.
+    fence ir, r
+                ",
                 dma_buffer_ptr_reg = in(reg) slice_start_ptr,
             );
         }

--- a/arch/riscv/src/dma_fence.rs
+++ b/arch/riscv/src/dma_fence.rs
@@ -44,7 +44,7 @@ impl RiscvCoherentDmaFence {
     }
 }
 
-#[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
+#[cfg(any(doc, target_arch = "riscv32", target_arch = "riscv64"))]
 unsafe impl DmaFence for RiscvCoherentDmaFence {
     /// Expose prior writes to in-memory buffers to subsequent DMA operations.
     ///
@@ -156,7 +156,7 @@ unsafe impl DmaFence for RiscvCoherentDmaFence {
     }
 }
 
-#[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
+#[cfg(not(any(doc, target_arch = "riscv32", target_arch = "riscv64")))]
 unsafe impl DmaFence for RiscvCoherentDmaFence {
     fn release<T>(self, _slice_ptr: *mut [T]) {
         // When building for another architecture, such as for tests or CI:

--- a/arch/riscv/src/dma_fence.rs
+++ b/arch/riscv/src/dma_fence.rs
@@ -44,6 +44,7 @@ impl RiscvCoherentDmaFence {
     }
 }
 
+#[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
 unsafe impl DmaFence for RiscvCoherentDmaFence {
     /// Expose prior writes to in-memory buffers to subsequent DMA operations.
     ///
@@ -82,11 +83,10 @@ unsafe impl DmaFence for RiscvCoherentDmaFence {
     /// [1]: https://docs.riscv.org/reference/isa/_attachments/riscv-unprivileged.pdf
     #[inline(always)]
     fn release<T>(self, slice_ptr: *mut [T]) {
-        if cfg!(any(target_arch = "riscv32", target_arch = "riscv64")) {
-            let slice_start_ptr: *mut T = slice_ptr.cast();
-            unsafe {
-                core::arch::asm!(
-                    "
+        let slice_start_ptr: *mut T = slice_ptr.cast();
+        unsafe {
+            core::arch::asm!(
+                "
                         // This block is opaque to the compiler; it must assume
                         // that it could read the entire buffer from which the
                         // pointer stored in {dma_buffer_ptr_reg} was derived.
@@ -96,12 +96,8 @@ unsafe impl DmaFence for RiscvCoherentDmaFence {
                         // comment for explanation.
                         fence w, iorw
                     ",
-                    dma_buffer_ptr_reg = in(reg) slice_start_ptr,
-                );
-            }
-        } else {
-            // When building for another architecture, such as for tests or CI:
-            unimplemented!("RiscvCoherentDmaFence can only be used on RISC-V targets");
+                dma_buffer_ptr_reg = in(reg) slice_start_ptr,
+            );
         }
     }
 
@@ -140,11 +136,10 @@ unsafe impl DmaFence for RiscvCoherentDmaFence {
     /// [1]: https://docs.riscv.org/reference/isa/_attachments/riscv-unprivileged.pdf
     #[inline(always)]
     fn acquire<T>(self, slice_ptr: *mut [T]) {
-        if cfg!(any(target_arch = "riscv32", target_arch = "riscv64")) {
-            let slice_start_ptr: *mut T = slice_ptr.cast();
-            unsafe {
-                core::arch::asm!(
-                    "
+        let slice_start_ptr: *mut T = slice_ptr.cast();
+        unsafe {
+            core::arch::asm!(
+                "
                         // This block is opaque to the compiler; it must assume
                         // that it could write to the entire buffer from which
                         // the pointer stored in {dma_buffer_ptr_reg} was
@@ -155,12 +150,20 @@ unsafe impl DmaFence for RiscvCoherentDmaFence {
                         // explanation.
                         fence ir, r
                     ",
-                    dma_buffer_ptr_reg = in(reg) slice_start_ptr,
-                );
-            }
-        } else {
-            // When building for another architecture, such as for tests or CI:
-            unimplemented!("RiscvCoherentDmaFence can only be used on RISC-V targets");
+                dma_buffer_ptr_reg = in(reg) slice_start_ptr,
+            );
         }
+    }
+}
+
+#[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
+unsafe impl DmaFence for RiscvCoherentDmaFence {
+    fn release<T>(self, _slice_ptr: *mut [T]) {
+        // When building for another architecture, such as for tests or CI:
+        unimplemented!("RiscvCoherentDmaFence can only be used on RISC-V targets");
+    }
+    fn acquire<T>(self, _slice_ptr: *mut [T]) {
+        // When building for another architecture, such as for tests or CI:
+        unimplemented!("RiscvCoherentDmaFence can only be used on RISC-V targets");
     }
 }

--- a/arch/x86/src/dma_fence.rs
+++ b/arch/x86/src/dma_fence.rs
@@ -40,6 +40,7 @@ impl X86DmaFence {
     }
 }
 
+#[cfg(any(doc, target_arch = "x86"))]
 unsafe impl DmaFence for X86DmaFence {
     /// Expose prior writes to in-memory buffers to subsequent DMA operations.
     ///
@@ -64,21 +65,16 @@ unsafe impl DmaFence for X86DmaFence {
     /// accessing memory.
     #[inline(always)]
     fn release<T>(self, slice_ptr: *mut [T]) {
-        if cfg!(any(target_arch = "x86", target_arch = "x86_64")) {
-            let slice_start_ptr: *mut T = slice_ptr.cast();
-            unsafe {
-                core::arch::asm!(
-                    "
+        let slice_start_ptr: *mut T = slice_ptr.cast();
+        unsafe {
+            core::arch::asm!(
+                "
                         // This block is opaque to the compiler; it must assume
                         // that it could read the entire buffer from which the
                         // pointer stored in {dma_buffer_ptr_reg} was derived.
                     ",
-                    dma_buffer_ptr_reg = in(reg) slice_start_ptr,
-                );
-            }
-        } else {
-            // When building for another architecture, such as for tests or CI:
-            unimplemented!("X86DmaFence can only be used on x86 targets");
+                dma_buffer_ptr_reg = in(reg) slice_start_ptr,
+            );
         }
     }
 
@@ -105,22 +101,29 @@ unsafe impl DmaFence for X86DmaFence {
     /// accessing memory.
     #[inline(always)]
     fn acquire<T>(self, slice_ptr: *mut [T]) {
-        if cfg!(any(target_arch = "x86", target_arch = "x86_64")) {
-            let slice_start_ptr: *mut T = slice_ptr.cast();
-            unsafe {
-                core::arch::asm!(
-                    "
+        let slice_start_ptr: *mut T = slice_ptr.cast();
+        unsafe {
+            core::arch::asm!(
+                "
                         // This block is opaque to the compiler; it must assume
                         // that it could write to the entire buffer from which
                         // the pointer stored in {dma_buffer_ptr_reg} was
                         // derived.
                     ",
-                    dma_buffer_ptr_reg = in(reg) slice_start_ptr,
-                );
-            }
-        } else {
-            // When building for another architecture, such as for tests or CI:
-            unimplemented!("X86DmaFence can only be used on x86 targets");
+                dma_buffer_ptr_reg = in(reg) slice_start_ptr,
+            );
         }
+    }
+}
+
+#[cfg(not(any(doc, target_arch = "x86")))]
+unsafe impl DmaFence for X86DmaFence {
+    fn release<T>(self, _slice_ptr: *mut [T]) {
+        // When building for another architecture, such as for tests or CI:
+        unimplemented!("X86DmaFence can only be used on x86 targets");
+    }
+    fn acquire<T>(self, _slice_ptr: *mut [T]) {
+        // When building for another architecture, such as for tests or CI:
+        unimplemented!("X86DmaFence can only be used on x86 targets");
     }
 }

--- a/arch/x86/src/dma_fence.rs
+++ b/arch/x86/src/dma_fence.rs
@@ -69,10 +69,10 @@ unsafe impl DmaFence for X86DmaFence {
         unsafe {
             core::arch::asm!(
                 "
-                        // This block is opaque to the compiler; it must assume
-                        // that it could read the entire buffer from which the
-                        // pointer stored in {dma_buffer_ptr_reg} was derived.
-                    ",
+    // This block is opaque to the compiler; it must assume
+    // that it could read the entire buffer from which the
+    // pointer stored in {dma_buffer_ptr_reg} was derived.
+                ",
                 dma_buffer_ptr_reg = in(reg) slice_start_ptr,
             );
         }
@@ -105,11 +105,11 @@ unsafe impl DmaFence for X86DmaFence {
         unsafe {
             core::arch::asm!(
                 "
-                        // This block is opaque to the compiler; it must assume
-                        // that it could write to the entire buffer from which
-                        // the pointer stored in {dma_buffer_ptr_reg} was
-                        // derived.
-                    ",
+    // This block is opaque to the compiler; it must assume
+    // that it could write to the entire buffer from which
+    // the pointer stored in {dma_buffer_ptr_reg} was
+    // derived.
+                ",
                 dma_buffer_ptr_reg = in(reg) slice_start_ptr,
             );
         }


### PR DESCRIPTION
### Pull Request Overview

This change how cfgs are done to give dummy code to cargo for dma_slice on riscv and x86. This matches how we do this everywhere else.

This also changes the guards to be the same as the rest of the crate. I'm not sure why we would want to have some be different, particularly with no explanation.

And, since I was there, this also formats the assembly according the unofficial style guide.

### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.

Did myself.