### PR TITLE
Make riscv's, earlgrey's, and esp32-c3's start trap functions consistent.

### DIFF
--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -176,14 +176,14 @@ pub unsafe fn configure_trap_handler() {
     // trap handler, this should ensure that all traps are handled by the M-mode
     // handler.
     csr::CSR.mtvec.write(
-        csr::mtvec::mtvec::trap_addr.val(_start_trap as extern "C" fn() as usize >> 2)
+        csr::mtvec::mtvec::trap_addr.val(_start_trap as extern "C" fn() -> ! as usize >> 2)
             + csr::mtvec::mtvec::mode::CLEAR,
     );
 }
 
 // Mock implementation for tests on Travis-CI.
 #[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
-pub extern "C" fn _start_trap() {
+pub extern "C" fn _start_trap() -> ! {
     unimplemented!()
 }
 
@@ -290,7 +290,7 @@ pub extern "C" fn _start_trap() {
 // symbol name.
 #[export_name = "_start_trap"]
 #[unsafe(naked)]
-pub extern "C" fn _start_trap() {
+pub extern "C" fn _start_trap() -> ! {
     use core::arch::naked_asm;
     naked_asm!(
         "

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -186,11 +186,6 @@ OBJDUMP_FLAGS ?= --disassemble-all --source --section-headers --demangle
 # Set default flags for size.
 SIZE_FLAGS ?=
 
-# Need an extra flag for OBJDUMP if we are on a thumb platform.
-ifneq (,$(findstring thumb,$(TARGET)))
-  OBJDUMP_FLAGS += --arch-name=thumb
-endif
-
 # Additional flags that can be passed to print_tock_memory_usage.py via an
 # environment variable. By default, pass an empty string.
 PTMU_ARGS ?=

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -458,7 +458,7 @@ pub extern "C" fn _earlgrey_start_trap_vectored() {
 #[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
 #[link_section = ".riscv.trap_vectored"]
 #[unsafe(naked)]
-pub extern "C" fn _earlgrey_start_trap_vectored() -> ! {
+pub extern "C" fn _earlgrey_start_trap_vectored() {
     use core::arch::naked_asm;
     // According to the Ibex user manual:
     // [NMI] has interrupt ID 31, i.e., it has the highest priority of all

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -439,7 +439,7 @@ pub unsafe fn configure_trap_handler() {
 
     // The Ibex CPU does not support non-vectored trap entries.
     CSR.mtvec.write(
-        mtvec::trap_addr.val(_earlgrey_start_trap_vectored as extern "C" fn() as usize >> 2)
+        mtvec::trap_addr.val(_earlgrey_start_trap_vectored as extern "C" fn() -> ! as usize >> 2)
             + mtvec::mode::Vectored,
     );
 }
@@ -448,7 +448,7 @@ pub unsafe fn configure_trap_handler() {
 // specifier, as the test will not use our linker script, and the host
 // compilation environment may not allow the section name.
 #[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
-pub extern "C" fn _earlgrey_start_trap_vectored() {
+pub extern "C" fn _earlgrey_start_trap_vectored() -> ! {
     use core::hint::unreachable_unchecked;
     unsafe {
         unreachable_unchecked();
@@ -458,7 +458,7 @@ pub extern "C" fn _earlgrey_start_trap_vectored() {
 #[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
 #[link_section = ".riscv.trap_vectored"]
 #[unsafe(naked)]
-pub extern "C" fn _earlgrey_start_trap_vectored() {
+pub extern "C" fn _earlgrey_start_trap_vectored() -> ! {
     use core::arch::naked_asm;
     // According to the Ibex user manual:
     // [NMI] has interrupt ID 31, i.e., it has the highest priority of all

--- a/chips/esp32-c3/src/chip.rs
+++ b/chips/esp32-c3/src/chip.rs
@@ -303,7 +303,7 @@ pub extern "C" fn _start_trap_vectored() {
 #[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
 #[link_section = ".riscv.trap_vectored"]
 #[unsafe(naked)]
-pub extern "C" fn _start_trap_vectored() -> ! {
+pub extern "C" fn _start_trap_vectored() {
     use core::arch::naked_asm;
     // Below are 32 (non-compressed) jumps to cover the entire possible
     // range of vectored traps.

--- a/chips/esp32-c3/src/chip.rs
+++ b/chips/esp32-c3/src/chip.rs
@@ -284,7 +284,7 @@ pub unsafe extern "C" fn disable_interrupt_trap_handler(mcause_val: u32) {
 /// vectored interrupts seem more reliable so let's use that.
 pub unsafe fn configure_trap_handler() {
     CSR.mtvec.write(
-        mtvec::trap_addr.val(_start_trap_vectored as extern "C" fn() as usize >> 2)
+        mtvec::trap_addr.val(_start_trap_vectored as extern "C" fn() -> ! as usize >> 2)
             + mtvec::mode::Vectored,
     )
 }
@@ -293,7 +293,7 @@ pub unsafe fn configure_trap_handler() {
 // specifier, as the test will not use our linker script, and the host
 // compilation environment may not allow the section name.
 #[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
-pub extern "C" fn _start_trap_vectored() {
+pub extern "C" fn _start_trap_vectored() -> ! {
     use core::hint::unreachable_unchecked;
     unsafe {
         unreachable_unchecked();
@@ -303,7 +303,7 @@ pub extern "C" fn _start_trap_vectored() {
 #[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
 #[link_section = ".riscv.trap_vectored"]
 #[unsafe(naked)]
-pub extern "C" fn _start_trap_vectored() {
+pub extern "C" fn _start_trap_vectored() -> ! {
     use core::arch::naked_asm;
     // Below are 32 (non-compressed) jumps to cover the entire possible
     // range of vectored traps.


### PR DESCRIPTION
### Pull Request Overview

These crates define their start trap functions twice:

1. Once `#[cfg]`'d to only show up when compiled for their devices, implemented as a naked function that jumps to `rv32i::_start_trap`.
2. Once `#[cfg]`'d to show up in all other cases, so e.g. `cargo check` passes without `--target`.

`rv32i::_start_trap` (in both compilation modes) and the group 2 definitions have return type `()`, while the group 1 definitions have return type `!`. This makes the function cast from PR #4801 fail.

This changes all of the functions to have return type `()`. Ultimately, I don't believe the return type matters here -- for the naked implementatinos the return type doesn't really matter, and for the non-naked implementation both are fine. But they should be consistent.

### Testing Strategy

Manual `cargo check` runs without `--target`, with `--target=riscv32imc-unknown-none-elf`, and with `--target=riscv32imac-unknown-none-elf` (except for EarlGrey, where I skipped riscv32imac), plus I'll wait for CI to finish.

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.

### AI Use

- [X] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.

No AI