### PR TITLE
rp2040, rp2350: Remove `resolve_dependencies()`

### DIFF
--- a/boards/nano_rp2040_connect/src/io.rs
+++ b/boards/nano_rp2040_connect/src/io.rs
@@ -11,6 +11,7 @@ use kernel::hil::uart::{Configure, Parameters, Parity, StopBits, Width};
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::io_write::IoWrite;
 
+use rp2040::clocks::Clocks;
 use rp2040::gpio::{GpioFunction, RPGpio, RPGpioPin};
 use rp2040::uart::Uart;
 
@@ -48,7 +49,8 @@ impl IoWrite for Writer {
         self.uart.map_or_else(
             || {
                 // If no UART is configured for panic print, use UART0
-                let uart0 = &Uart::new_uart0();
+                let clocks = &Clocks::new();
+                let uart0 = &Uart::new_uart0(clocks);
 
                 if !uart0.is_configured() {
                     let parameters = Parameters {

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -263,7 +263,7 @@ pub unsafe fn start() -> (
         Rp2040DefaultPeripherals,
         Rp2040DefaultPeripherals::new(clocks, resets)
     );
-    peripherals.resolve_dependencies();
+    peripherals.init();
 
     // Reset all peripherals except QSPI (we might be booting from Flash), PLL USB and PLL SYS
     resets.reset_all_except(&[

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -177,26 +177,26 @@ pub unsafe extern "C" fn jump_to_bootloader() {
     );
 }
 
-fn init_clocks(peripherals: &Rp2040DefaultPeripherals) {
+fn init_clocks(
+    peripherals: &Rp2040DefaultPeripherals,
+    clocks: &'static rp2040::clocks::Clocks,
+    resets: &'static rp2040::resets::Resets,
+) {
     // Start tick in watchdog
     peripherals.watchdog.start_tick(12);
 
     // Disable the Resus clock
-    peripherals.clocks.disable_resus();
+    clocks.disable_resus();
 
     // Setup the external Osciallator
     peripherals.xosc.init();
 
     // disable ref and sys clock aux sources
-    peripherals.clocks.disable_sys_aux();
-    peripherals.clocks.disable_ref_aux();
+    clocks.disable_sys_aux();
+    clocks.disable_ref_aux();
 
-    peripherals
-        .resets
-        .reset(&[Peripheral::PllSys, Peripheral::PllUsb]);
-    peripherals
-        .resets
-        .unreset(&[Peripheral::PllSys, Peripheral::PllUsb], true);
+    resets.reset(&[Peripheral::PllSys, Peripheral::PllUsb]);
+    resets.unreset(&[Peripheral::PllSys, Peripheral::PllUsb], true);
 
     // Configure PLLs (from Pico SDK)
     //                   REF     FBDIV VCO            POSTDIV
@@ -205,45 +205,33 @@ fn init_clocks(peripherals: &Rp2040DefaultPeripherals) {
 
     // It seems that the external osciallator is clocked at 12 MHz
 
-    peripherals
-        .clocks
-        .pll_init(PllClock::Sys, 12, 1, 1500 * 1000000, 6, 2);
-    peripherals
-        .clocks
-        .pll_init(PllClock::Usb, 12, 1, 480 * 1000000, 5, 2);
+    clocks.pll_init(PllClock::Sys, 12, 1, 1500 * 1000000, 6, 2);
+    clocks.pll_init(PllClock::Usb, 12, 1, 480 * 1000000, 5, 2);
 
     // pico-sdk: // CLK_REF = XOSC (12MHz) / 1 = 12MHz
-    peripherals.clocks.configure_reference(
+    clocks.configure_reference(
         ReferenceClockSource::Xosc,
         ReferenceAuxiliaryClockSource::PllUsb,
         12000000,
         12000000,
     );
     // pico-sdk: CLK SYS = PLL SYS (125MHz) / 1 = 125MHz
-    peripherals.clocks.configure_system(
+    clocks.configure_system(
         SystemClockSource::Auxiliary,
         SystemAuxiliaryClockSource::PllSys,
         125000000,
         125000000,
     );
     // pico-sdk: CLK USB = PLL USB (48MHz) / 1 = 48MHz
-    peripherals
-        .clocks
-        .configure_usb(UsbAuxiliaryClockSource::PllSys, 48000000, 48000000);
+    clocks.configure_usb(UsbAuxiliaryClockSource::PllSys, 48000000, 48000000);
     // pico-sdk: CLK ADC = PLL USB (48MHZ) / 1 = 48MHz
-    peripherals
-        .clocks
-        .configure_adc(AdcAuxiliaryClockSource::PllUsb, 48000000, 48000000);
+    clocks.configure_adc(AdcAuxiliaryClockSource::PllUsb, 48000000, 48000000);
     // pico-sdk: CLK RTC = PLL USB (48MHz) / 1024 = 46875Hz
-    peripherals
-        .clocks
-        .configure_rtc(RtcAuxiliaryClockSource::PllSys, 48000000, 46875);
+    clocks.configure_rtc(RtcAuxiliaryClockSource::PllSys, 48000000, 46875);
     // pico-sdk:
     // CLK PERI = clk_sys. Used as reference clock for Peripherals. No dividers so just select and enable
     // Normally choose clk_sys or clk_usb
-    peripherals
-        .clocks
-        .configure_peripheral(PeripheralAuxiliaryClockSource::System, 125000000);
+    clocks.configure_peripheral(PeripheralAuxiliaryClockSource::System, 125000000);
 }
 
 /// This is in a separate, inline(never) function so that its stack frame is
@@ -269,11 +257,16 @@ pub unsafe fn start() -> (
             PanicResources::new(),
         );
 
-    let peripherals = static_init!(Rp2040DefaultPeripherals, Rp2040DefaultPeripherals::new());
+    let clocks = static_init!(rp2040::clocks::Clocks, rp2040::clocks::Clocks::new());
+    let resets = static_init!(rp2040::resets::Resets, rp2040::resets::Resets::new());
+    let peripherals = static_init!(
+        Rp2040DefaultPeripherals,
+        Rp2040DefaultPeripherals::new(clocks, resets)
+    );
     peripherals.resolve_dependencies();
 
     // Reset all peripherals except QSPI (we might be booting from Flash), PLL USB and PLL SYS
-    peripherals.resets.reset_all_except(&[
+    resets.reset_all_except(&[
         Peripheral::IOQSpi,
         Peripheral::PadsQSpi,
         Peripheral::PllUsb,
@@ -282,7 +275,7 @@ pub unsafe fn start() -> (
 
     // Unreset all the peripherals that do not require clock setup as they run using the sys_clk or ref_clk
     // Wait for the peripherals to reset
-    peripherals.resets.unreset_all_except(
+    resets.unreset_all_except(
         &[
             Peripheral::Adc,
             Peripheral::Rtc,
@@ -295,10 +288,10 @@ pub unsafe fn start() -> (
         true,
     );
 
-    init_clocks(peripherals);
+    init_clocks(peripherals, clocks, resets);
 
     // Unreset all peripherals
-    peripherals.resets.unreset_all_except(&[], true);
+    resets.unreset_all_except(&[], true);
 
     // Set the UART used for panic
     (*addr_of_mut!(io::WRITER)).set_uart(&peripherals.uart0);

--- a/boards/pico_explorer_base/src/io.rs
+++ b/boards/pico_explorer_base/src/io.rs
@@ -11,6 +11,7 @@ use kernel::hil::uart::{Configure, Parameters, Parity, StopBits, Width};
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::io_write::IoWrite;
 
+use rp2040::clocks::Clocks;
 use rp2040::gpio::{GpioFunction, RPGpio, RPGpioPin};
 use rp2040::uart::Uart;
 
@@ -66,7 +67,8 @@ impl IoWrite for Writer {
     fn write(&mut self, buf: &[u8]) -> usize {
         self.uart.map_or_else(
             || {
-                let uart = Uart::new_uart0();
+                let clocks = Clocks::new();
+                let uart = Uart::new_uart0(&clocks);
                 self.configure_uart(&uart);
                 self.write_to_uart(&uart, buf);
             },

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -275,7 +275,7 @@ pub unsafe fn start() -> (
         Rp2040DefaultPeripherals,
         Rp2040DefaultPeripherals::new(clocks, resets)
     );
-    peripherals.resolve_dependencies();
+    peripherals.init();
 
     // Reset all peripherals except QSPI (we might be booting from Flash), PLL USB and PLL SYS
     resets.reset_all_except(&[

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -189,26 +189,26 @@ pub unsafe extern "C" fn jump_to_bootloader() {
     );
 }
 
-fn init_clocks(peripherals: &Rp2040DefaultPeripherals) {
+fn init_clocks(
+    peripherals: &Rp2040DefaultPeripherals,
+    clocks: &'static rp2040::clocks::Clocks,
+    resets: &'static rp2040::resets::Resets,
+) {
     // Start tick in watchdog
     peripherals.watchdog.start_tick(12);
 
     // Disable the Resus clock
-    peripherals.clocks.disable_resus();
+    clocks.disable_resus();
 
     // Setup the external Oscillator
     peripherals.xosc.init();
 
     // disable ref and sys clock aux sources
-    peripherals.clocks.disable_sys_aux();
-    peripherals.clocks.disable_ref_aux();
+    clocks.disable_sys_aux();
+    clocks.disable_ref_aux();
 
-    peripherals
-        .resets
-        .reset(&[Peripheral::PllSys, Peripheral::PllUsb]);
-    peripherals
-        .resets
-        .unreset(&[Peripheral::PllSys, Peripheral::PllUsb], true);
+    resets.reset(&[Peripheral::PllSys, Peripheral::PllUsb]);
+    resets.unreset(&[Peripheral::PllSys, Peripheral::PllUsb], true);
 
     // Configure PLLs (from Pico SDK)
     //                   REF     FBDIV VCO            POSTDIV
@@ -217,45 +217,33 @@ fn init_clocks(peripherals: &Rp2040DefaultPeripherals) {
 
     // It seems that the external osciallator is clocked at 12 MHz
 
-    peripherals
-        .clocks
-        .pll_init(PllClock::Sys, 12, 1, 1500 * 1000000, 6, 2);
-    peripherals
-        .clocks
-        .pll_init(PllClock::Usb, 12, 1, 480 * 1000000, 5, 2);
+    clocks.pll_init(PllClock::Sys, 12, 1, 1500 * 1000000, 6, 2);
+    clocks.pll_init(PllClock::Usb, 12, 1, 480 * 1000000, 5, 2);
 
     // pico-sdk: // CLK_REF = XOSC (12MHz) / 1 = 12MHz
-    peripherals.clocks.configure_reference(
+    clocks.configure_reference(
         ReferenceClockSource::Xosc,
         ReferenceAuxiliaryClockSource::PllUsb,
         12000000,
         12000000,
     );
     // pico-sdk: CLK SYS = PLL SYS (125MHz) / 1 = 125MHz
-    peripherals.clocks.configure_system(
+    clocks.configure_system(
         SystemClockSource::Auxiliary,
         SystemAuxiliaryClockSource::PllSys,
         125000000,
         125000000,
     );
     // pico-sdk: CLK USB = PLL USB (48MHz) / 1 = 48MHz
-    peripherals
-        .clocks
-        .configure_usb(UsbAuxiliaryClockSource::PllSys, 48000000, 48000000);
+    clocks.configure_usb(UsbAuxiliaryClockSource::PllSys, 48000000, 48000000);
     // pico-sdk: CLK ADC = PLL USB (48MHZ) / 1 = 48MHz
-    peripherals
-        .clocks
-        .configure_adc(AdcAuxiliaryClockSource::PllUsb, 48000000, 48000000);
+    clocks.configure_adc(AdcAuxiliaryClockSource::PllUsb, 48000000, 48000000);
     // pico-sdk: CLK RTC = PLL USB (48MHz) / 1024 = 46875Hz
-    peripherals
-        .clocks
-        .configure_rtc(RtcAuxiliaryClockSource::PllSys, 48000000, 46875);
+    clocks.configure_rtc(RtcAuxiliaryClockSource::PllSys, 48000000, 46875);
     // pico-sdk:
     // CLK PERI = clk_sys. Used as reference clock for Peripherals. No dividers so just select and enable
     // Normally choose clk_sys or clk_usb
-    peripherals
-        .clocks
-        .configure_peripheral(PeripheralAuxiliaryClockSource::System, 125000000);
+    clocks.configure_peripheral(PeripheralAuxiliaryClockSource::System, 125000000);
 }
 
 /// This is in a separate, inline(never) function so that its stack frame is
@@ -281,11 +269,16 @@ pub unsafe fn start() -> (
             PanicResources::new(),
         );
 
-    let peripherals = static_init!(Rp2040DefaultPeripherals, Rp2040DefaultPeripherals::new());
+    let clocks = static_init!(rp2040::clocks::Clocks, rp2040::clocks::Clocks::new());
+    let resets = static_init!(rp2040::resets::Resets, rp2040::resets::Resets::new());
+    let peripherals = static_init!(
+        Rp2040DefaultPeripherals,
+        Rp2040DefaultPeripherals::new(clocks, resets)
+    );
     peripherals.resolve_dependencies();
 
     // Reset all peripherals except QSPI (we might be booting from Flash), PLL USB and PLL SYS
-    peripherals.resets.reset_all_except(&[
+    resets.reset_all_except(&[
         Peripheral::IOQSpi,
         Peripheral::PadsQSpi,
         Peripheral::PllUsb,
@@ -294,7 +287,7 @@ pub unsafe fn start() -> (
 
     // Unreset all the peripherals that do not require clock setup as they run using the sys_clk or ref_clk
     // Wait for the peripherals to reset
-    peripherals.resets.unreset_all_except(
+    resets.unreset_all_except(
         &[
             Peripheral::Adc,
             Peripheral::Rtc,
@@ -307,10 +300,10 @@ pub unsafe fn start() -> (
         true,
     );
 
-    init_clocks(peripherals);
+    init_clocks(peripherals, clocks, resets);
 
     // Unreset all peripherals
-    peripherals.resets.unreset_all_except(&[], true);
+    resets.unreset_all_except(&[], true);
 
     //set RX and TX pins in UART mode
     let gpio_tx = peripherals.pins.get_pin(RPGpio::GPIO0);
@@ -723,7 +716,7 @@ pub unsafe fn start() -> (
 
     let mut pio: Pio = Pio::new_pio0();
 
-    let _pio_pwm = PioPwm::new(&mut pio, &peripherals.clocks);
+    let _pio_pwm = PioPwm::new(&mut pio, clocks);
     // This will start a PWM with PIO with the set frequency and duty cycle on the specified pin.
     // pio_pwm
     //     .start(

--- a/boards/raspberry_pi_pico/src/io.rs
+++ b/boards/raspberry_pi_pico/src/io.rs
@@ -11,6 +11,7 @@ use kernel::hil::uart::{Configure, Parameters, Parity, StopBits, Width};
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::io_write::IoWrite;
 
+use rp2040::clocks::Clocks;
 use rp2040::gpio::{GpioFunction, RPGpio, RPGpioPin};
 use rp2040::uart::Uart;
 
@@ -66,7 +67,8 @@ impl IoWrite for Writer {
     fn write(&mut self, buf: &[u8]) -> usize {
         self.uart.map_or_else(
             || {
-                let uart = Uart::new_uart0();
+                let clocks = Clocks::new();
+                let uart = Uart::new_uart0(&clocks);
                 self.configure_uart(&uart);
                 self.write_to_uart(&uart, buf);
             },

--- a/boards/raspberry_pi_pico/src/lib.rs
+++ b/boards/raspberry_pi_pico/src/lib.rs
@@ -128,26 +128,26 @@ pub unsafe extern "C" fn jump_to_bootloader() {
     );
 }
 
-fn init_clocks(peripherals: &Rp2040DefaultPeripherals) {
+fn init_clocks(
+    peripherals: &Rp2040DefaultPeripherals,
+    clocks: &'static rp2040::clocks::Clocks,
+    resets: &'static rp2040::resets::Resets,
+) {
     // Start tick in watchdog
     peripherals.watchdog.start_tick(12);
 
     // Disable the Resus clock
-    peripherals.clocks.disable_resus();
+    clocks.disable_resus();
 
     // Setup the external Oscillator
     peripherals.xosc.init();
 
     // disable ref and sys clock aux sources
-    peripherals.clocks.disable_sys_aux();
-    peripherals.clocks.disable_ref_aux();
+    clocks.disable_sys_aux();
+    clocks.disable_ref_aux();
 
-    peripherals
-        .resets
-        .reset(&[Peripheral::PllSys, Peripheral::PllUsb]);
-    peripherals
-        .resets
-        .unreset(&[Peripheral::PllSys, Peripheral::PllUsb], true);
+    resets.reset(&[Peripheral::PllSys, Peripheral::PllUsb]);
+    resets.unreset(&[Peripheral::PllSys, Peripheral::PllUsb], true);
 
     // Configure PLLs (from Pico SDK)
     //                   REF     FBDIV VCO            POSTDIV
@@ -156,45 +156,33 @@ fn init_clocks(peripherals: &Rp2040DefaultPeripherals) {
 
     // It seems that the external oscillator is clocked at 12 MHz
 
-    peripherals
-        .clocks
-        .pll_init(PllClock::Sys, 12, 1, 1500 * 1000000, 6, 2);
-    peripherals
-        .clocks
-        .pll_init(PllClock::Usb, 12, 1, 480 * 1000000, 5, 2);
+    clocks.pll_init(PllClock::Sys, 12, 1, 1500 * 1000000, 6, 2);
+    clocks.pll_init(PllClock::Usb, 12, 1, 480 * 1000000, 5, 2);
 
     // pico-sdk: // CLK_REF = XOSC (12MHz) / 1 = 12MHz
-    peripherals.clocks.configure_reference(
+    clocks.configure_reference(
         ReferenceClockSource::Xosc,
         ReferenceAuxiliaryClockSource::PllUsb,
         12000000,
         12000000,
     );
     // pico-sdk: CLK SYS = PLL SYS (125MHz) / 1 = 125MHz
-    peripherals.clocks.configure_system(
+    clocks.configure_system(
         SystemClockSource::Auxiliary,
         SystemAuxiliaryClockSource::PllSys,
         125000000,
         125000000,
     );
     // pico-sdk: CLK USB = PLL USB (48MHz) / 1 = 48MHz
-    peripherals
-        .clocks
-        .configure_usb(UsbAuxiliaryClockSource::PllSys, 48000000, 48000000);
+    clocks.configure_usb(UsbAuxiliaryClockSource::PllSys, 48000000, 48000000);
     // pico-sdk: CLK ADC = PLL USB (48MHZ) / 1 = 48MHz
-    peripherals
-        .clocks
-        .configure_adc(AdcAuxiliaryClockSource::PllUsb, 48000000, 48000000);
+    clocks.configure_adc(AdcAuxiliaryClockSource::PllUsb, 48000000, 48000000);
     // pico-sdk: CLK RTC = PLL USB (48MHz) / 1024 = 46875Hz
-    peripherals
-        .clocks
-        .configure_rtc(RtcAuxiliaryClockSource::PllSys, 48000000, 46875);
+    clocks.configure_rtc(RtcAuxiliaryClockSource::PllSys, 48000000, 46875);
     // pico-sdk:
     // CLK PERI = clk_sys. Used as reference clock for Peripherals. No dividers so just select and enable
     // Normally choose clk_sys or clk_usb
-    peripherals
-        .clocks
-        .configure_peripheral(PeripheralAuxiliaryClockSource::System, 125000000);
+    clocks.configure_peripheral(PeripheralAuxiliaryClockSource::System, 125000000);
 }
 
 /// Setup the CDC capsule
@@ -258,11 +246,16 @@ pub unsafe fn setup(
             PanicResources::new(),
         );
 
-    let peripherals = static_init!(Rp2040DefaultPeripherals, Rp2040DefaultPeripherals::new());
+    let clocks = static_init!(rp2040::clocks::Clocks, rp2040::clocks::Clocks::new());
+    let resets = static_init!(rp2040::resets::Resets, rp2040::resets::Resets::new());
+    let peripherals = static_init!(
+        Rp2040DefaultPeripherals,
+        Rp2040DefaultPeripherals::new(clocks, resets)
+    );
     peripherals.resolve_dependencies();
 
     // Reset all peripherals except QSPI (we might be booting from Flash), PLL USB and PLL SYS
-    peripherals.resets.reset_all_except(&[
+    resets.reset_all_except(&[
         Peripheral::IOQSpi,
         Peripheral::PadsQSpi,
         Peripheral::PllUsb,
@@ -271,7 +264,7 @@ pub unsafe fn setup(
 
     // Unreset all the peripherals that do not require clock setup as they run using the sys_clk or ref_clk
     // Wait for the peripherals to reset
-    peripherals.resets.unreset_all_except(
+    resets.unreset_all_except(
         &[
             Peripheral::Adc,
             Peripheral::Rtc,
@@ -284,10 +277,10 @@ pub unsafe fn setup(
         true,
     );
 
-    init_clocks(peripherals);
+    init_clocks(peripherals, clocks, resets);
 
     // Unreset all peripherals
-    peripherals.resets.unreset_all_except(&[], true);
+    resets.unreset_all_except(&[], true);
 
     //set RX and TX pins in UART mode
     let gpio_tx = peripherals.pins.get_pin(RPGpio::GPIO0);

--- a/boards/raspberry_pi_pico/src/lib.rs
+++ b/boards/raspberry_pi_pico/src/lib.rs
@@ -252,7 +252,7 @@ pub unsafe fn setup(
         Rp2040DefaultPeripherals,
         Rp2040DefaultPeripherals::new(clocks, resets)
     );
-    peripherals.resolve_dependencies();
+    peripherals.init();
 
     // Reset all peripherals except QSPI (we might be booting from Flash), PLL USB and PLL SYS
     resets.reset_all_except(&[

--- a/boards/raspberry_pi_pico_2/src/io.rs
+++ b/boards/raspberry_pi_pico_2/src/io.rs
@@ -11,6 +11,7 @@ use kernel::hil::uart::{Configure, Parameters, Parity, StopBits, Width};
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::io_write::IoWrite;
 
+use rp2350::clocks::Clocks;
 use rp2350::gpio::{GpioFunction, RPGpio, RPGpioPin};
 use rp2350::uart::Uart;
 
@@ -66,7 +67,8 @@ impl IoWrite for Writer {
     fn write(&mut self, buf: &[u8]) -> usize {
         self.uart.map_or_else(
             || {
-                let uart = Uart::new_uart0();
+                let clocks = &Clocks::new();
+                let uart = Uart::new_uart0(clocks);
                 self.configure_uart(&uart);
                 self.write_to_uart(&uart, buf);
             },

--- a/boards/raspberry_pi_pico_2/src/main.rs
+++ b/boards/raspberry_pi_pico_2/src/main.rs
@@ -177,26 +177,26 @@ core::arch::global_asm!(
     "
 );
 
-fn init_clocks(peripherals: &Rp2350DefaultPeripherals) {
+fn init_clocks(
+    peripherals: &Rp2350DefaultPeripherals,
+    clocks: &'static rp2350::clocks::Clocks,
+    resets: &'static rp2350::resets::Resets,
+) {
     // // Start tick in watchdog
     // peripherals.watchdog.start_tick(12);
     //
     // Disable the Resus clock
-    peripherals.clocks.disable_resus();
+    clocks.disable_resus();
 
     // Setup the external Oscillator
     peripherals.xosc.init();
 
     // disable ref and sys clock aux sources
-    peripherals.clocks.disable_sys_aux();
-    peripherals.clocks.disable_ref_aux();
+    clocks.disable_sys_aux();
+    clocks.disable_ref_aux();
 
-    peripherals
-        .resets
-        .reset(&[Peripheral::PllSys, Peripheral::PllUsb]);
-    peripherals
-        .resets
-        .unreset(&[Peripheral::PllSys, Peripheral::PllUsb], true);
+    resets.reset(&[Peripheral::PllSys, Peripheral::PllUsb]);
+    resets.unreset(&[Peripheral::PllSys, Peripheral::PllUsb], true);
 
     // Configure PLLs (from Pico SDK)
     //                   REF     FBDIV VCO            POSTDIV
@@ -205,22 +205,18 @@ fn init_clocks(peripherals: &Rp2350DefaultPeripherals) {
 
     // It seems that the external oscillator is clocked at 12 MHz
 
-    peripherals
-        .clocks
-        .pll_init(PllClock::Sys, 12, 1, 1500 * 1000000, 6, 2);
-    peripherals
-        .clocks
-        .pll_init(PllClock::Usb, 12, 1, 480 * 1000000, 5, 2);
+    clocks.pll_init(PllClock::Sys, 12, 1, 1500 * 1000000, 6, 2);
+    clocks.pll_init(PllClock::Usb, 12, 1, 480 * 1000000, 5, 2);
 
     // pico-sdk: // CLK_REF = XOSC (12MHz) / 1 = 12MHz
-    peripherals.clocks.configure_reference(
+    clocks.configure_reference(
         ReferenceClockSource::Xosc,
         ReferenceAuxiliaryClockSource::PllUsb,
         12000000,
         12000000,
     );
     // pico-sdk: CLK SYS = PLL SYS (125MHz) / 1 = 125MHz
-    peripherals.clocks.configure_system(
+    clocks.configure_system(
         SystemClockSource::Auxiliary,
         SystemAuxiliaryClockSource::PllSys,
         125000000,
@@ -228,27 +224,29 @@ fn init_clocks(peripherals: &Rp2350DefaultPeripherals) {
     );
 
     // pico-sdk: CLK USB = PLL USB (48MHz) / 1 = 48MHz
-    peripherals
-        .clocks
-        .configure_usb(UsbAuxiliaryClockSource::PllSys, 48000000, 48000000);
+    clocks.configure_usb(UsbAuxiliaryClockSource::PllSys, 48000000, 48000000);
     // pico-sdk: CLK ADC = PLL USB (48MHZ) / 1 = 48MHz
-    peripherals
-        .clocks
-        .configure_adc(AdcAuxiliaryClockSource::PllUsb, 48000000, 48000000);
+    clocks.configure_adc(AdcAuxiliaryClockSource::PllUsb, 48000000, 48000000);
     // pico-sdk: CLK HSTX = PLL USB (48MHz) / 1024 = 46875Hz
-    peripherals
-        .clocks
-        .configure_hstx(HstxAuxiliaryClockSource::PllSys, 48000000, 46875);
+    clocks.configure_hstx(HstxAuxiliaryClockSource::PllSys, 48000000, 46875);
     // pico-sdk:
     // CLK PERI = clk_sys. Used as reference clock for Peripherals. No dividers so just select and enable
     // Normally choose clk_sys or clk_usb
-    peripherals
-        .clocks
-        .configure_peripheral(PeripheralAuxiliaryClockSource::System, 125000000);
+    clocks.configure_peripheral(PeripheralAuxiliaryClockSource::System, 125000000);
 }
 
-unsafe fn get_peripherals() -> &'static mut Rp2350DefaultPeripherals<'static> {
-    static_init!(Rp2350DefaultPeripherals, Rp2350DefaultPeripherals::new())
+unsafe fn get_peripherals() -> (
+    &'static mut Rp2350DefaultPeripherals<'static>,
+    &'static rp2350::clocks::Clocks,
+    &'static rp2350::resets::Resets,
+) {
+    let clocks = static_init!(rp2350::clocks::Clocks, rp2350::clocks::Clocks::new());
+    let resets = static_init!(rp2350::resets::Resets, rp2350::resets::Resets::new());
+    let peripherals = static_init!(
+        Rp2350DefaultPeripherals,
+        Rp2350DefaultPeripherals::new(clocks)
+    );
+    (peripherals, clocks, resets)
 }
 
 /// Main function called after RAM initialized.
@@ -267,19 +265,19 @@ pub unsafe fn main() {
             PanicResources::new(),
         );
 
-    let peripherals = get_peripherals();
-    peripherals.resolve_dependencies();
+    let (peripherals, clocks, resets) = get_peripherals();
+    peripherals.init();
 
-    peripherals.resets.reset_all_except(&[
+    resets.reset_all_except(&[
         Peripheral::IOQSpi,
         Peripheral::PadsQSpi,
         Peripheral::PllUsb,
         Peripheral::PllSys,
     ]);
 
-    init_clocks(peripherals);
+    init_clocks(peripherals, clocks, resets);
 
-    peripherals.resets.unreset_all_except(&[], true);
+    resets.unreset_all_except(&[], true);
 
     // Set the UART used for panic
     (*addr_of_mut!(io::WRITER)).set_uart(&peripherals.uart0);

--- a/boards/raspberry_pi_pico_w/src/io.rs
+++ b/boards/raspberry_pi_pico_w/src/io.rs
@@ -11,6 +11,7 @@ use kernel::hil::uart::{Configure, Parameters, Parity, StopBits, Width};
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::io_write::IoWrite;
 
+use rp2040::clocks::Clocks;
 use rp2040::gpio::{GpioFunction, RPGpio, RPGpioPin};
 use rp2040::uart::Uart;
 
@@ -66,7 +67,8 @@ impl IoWrite for Writer {
     fn write(&mut self, buf: &[u8]) -> usize {
         self.uart.map_or_else(
             || {
-                let uart = Uart::new_uart0();
+                let clocks = Clocks::new();
+                let uart = Uart::new_uart0(&clocks);
                 self.configure_uart(&uart);
                 self.write_to_uart(&uart, buf);
             },

--- a/chips/rp2040/src/chip.rs
+++ b/chips/rp2040/src/chip.rs
@@ -160,7 +160,7 @@ impl Rp2040DefaultPeripherals<'_> {
         }
     }
 
-    pub fn resolve_dependencies(&'static self) {
+    pub fn init(&'static self) {
         kernel::deferred_call::DeferredCallClient::register(&self.uart0);
         kernel::deferred_call::DeferredCallClient::register(&self.uart1);
         kernel::deferred_call::DeferredCallClient::register(&self.rtc);

--- a/chips/rp2040/src/chip.rs
+++ b/chips/rp2040/src/chip.rs
@@ -120,13 +120,11 @@ impl<I: InterruptService> Chip for Rp2040<'_, I> {
 pub struct Rp2040DefaultPeripherals<'a> {
     pub adc: adc::Adc<'a>,
     pub dma: dma::Dma<'a>,
-    pub clocks: Clocks,
     pub i2c0: i2c::I2c<'a, 'a>,
     pub pins: RPPins<'a>,
     pub pio0: Pio,
     pub pio1: Pio,
     pub pwm: pwm::Pwm<'a>,
-    pub resets: Resets,
     pub sio: SIO,
     pub spi0: spi::Spi<'a>,
     pub sysinfo: sysinfo::SysInfo,
@@ -140,41 +138,33 @@ pub struct Rp2040DefaultPeripherals<'a> {
 }
 
 impl Rp2040DefaultPeripherals<'_> {
-    pub fn new() -> Self {
+    pub fn new(clocks: &'static Clocks, resets: &'static Resets) -> Self {
         Self {
             adc: adc::Adc::new(),
             dma: dma::Dma::new(),
-            clocks: Clocks::new(),
-            i2c0: i2c::I2c::new_i2c0(),
+            i2c0: i2c::I2c::new_i2c0(clocks, resets),
             pins: RPPins::new(),
             pio0: Pio::new_pio0(),
             pio1: Pio::new_pio1(),
-            pwm: pwm::Pwm::new(),
-            resets: Resets::new(),
+            pwm: pwm::Pwm::new(clocks),
             sio: SIO::new(),
-            spi0: spi::Spi::new_spi0(),
+            spi0: spi::Spi::new_spi0(clocks),
             sysinfo: sysinfo::SysInfo::new(),
             timer: RPTimer::new(),
-            uart0: Uart::new_uart0(),
-            uart1: Uart::new_uart1(),
+            uart0: Uart::new_uart0(clocks),
+            uart1: Uart::new_uart1(clocks),
             usb: usb::UsbCtrl::new(),
-            watchdog: Watchdog::new(),
+            watchdog: Watchdog::new(resets),
             xosc: Xosc::new(),
-            rtc: rtc::Rtc::new(),
+            rtc: rtc::Rtc::new(clocks),
         }
     }
 
     pub fn resolve_dependencies(&'static self) {
-        self.pwm.set_clocks(&self.clocks);
-        self.watchdog.resolve_dependencies(&self.resets);
-        self.spi0.set_clocks(&self.clocks);
-        self.uart0.set_clocks(&self.clocks);
         kernel::deferred_call::DeferredCallClient::register(&self.uart0);
         kernel::deferred_call::DeferredCallClient::register(&self.uart1);
         kernel::deferred_call::DeferredCallClient::register(&self.rtc);
-        self.i2c0.resolve_dependencies(&self.clocks, &self.resets);
         self.usb.set_gpio(self.pins.get_pin(RPGpio::GPIO15));
-        self.rtc.set_clocks(&self.clocks);
     }
 }
 

--- a/chips/rp2350/src/chip.rs
+++ b/chips/rp2350/src/chip.rs
@@ -11,7 +11,6 @@ use kernel::platform::chip::InterruptService;
 use crate::clocks::Clocks;
 use crate::gpio::{RPPins, SIO};
 use crate::interrupts;
-use crate::resets::Resets;
 use crate::ticks::Ticks;
 use crate::timer::RPTimer;
 use crate::uart::Uart;
@@ -106,9 +105,7 @@ impl<I: InterruptService> Chip for Rp2350<'_, I> {
 }
 
 pub struct Rp2350DefaultPeripherals<'a> {
-    pub clocks: Clocks,
     pub pins: RPPins<'a>,
-    pub resets: Resets,
     pub sio: SIO,
     pub ticks: Ticks,
     pub timer0: RPTimer<'a>,
@@ -118,22 +115,19 @@ pub struct Rp2350DefaultPeripherals<'a> {
 }
 
 impl Rp2350DefaultPeripherals<'_> {
-    pub fn new() -> Self {
+    pub fn new(clocks: &'static Clocks) -> Self {
         Self {
-            clocks: Clocks::new(),
             pins: RPPins::new(),
-            resets: Resets::new(),
             sio: SIO::new(),
             ticks: Ticks::new(),
             timer0: RPTimer::new_timer0(),
-            uart0: Uart::new_uart0(),
-            uart1: Uart::new_uart1(),
+            uart0: Uart::new_uart0(clocks),
+            uart1: Uart::new_uart1(clocks),
             xosc: Xosc::new(),
         }
     }
 
-    pub fn resolve_dependencies(&'static self) {
-        self.uart0.set_clocks(&self.clocks);
+    pub fn init(&'static self) {
         self.ticks.set_timer0_generator();
         self.ticks.set_timer1_generator();
         kernel::deferred_call::DeferredCallClient::register(&self.uart0);

--- a/chips/rp2350/src/uart.rs
+++ b/chips/rp2350/src/uart.rs
@@ -348,7 +348,7 @@ const UART1_BASE: StaticRef<UartRegisters> =
 
 pub struct Uart<'a> {
     registers: StaticRef<UartRegisters>,
-    clocks: OptionalCell<&'a clocks::Clocks>,
+    clocks: &'a clocks::Clocks,
 
     tx_client: OptionalCell<&'a dyn TransmitClient>,
     rx_client: OptionalCell<&'a dyn ReceiveClient>,
@@ -367,10 +367,10 @@ pub struct Uart<'a> {
 }
 
 impl<'a> Uart<'a> {
-    pub fn new_uart0() -> Self {
+    pub fn new_uart0(clocks: &'a clocks::Clocks) -> Self {
         Self {
             registers: UART0_BASE,
-            clocks: OptionalCell::empty(),
+            clocks,
 
             tx_client: OptionalCell::empty(),
             rx_client: OptionalCell::empty(),
@@ -388,10 +388,10 @@ impl<'a> Uart<'a> {
             deferred_call: DeferredCall::new(),
         }
     }
-    pub fn new_uart1() -> Self {
+    pub fn new_uart1(clocks: &'a clocks::Clocks) -> Self {
         Self {
             registers: UART1_BASE,
-            clocks: OptionalCell::empty(),
+            clocks,
 
             tx_client: OptionalCell::empty(),
             rx_client: OptionalCell::empty(),
@@ -407,10 +407,6 @@ impl<'a> Uart<'a> {
 
             deferred_call: DeferredCall::new(),
         }
-    }
-
-    pub(crate) fn set_clocks(&self, clocks: &'a clocks::Clocks) {
-        self.clocks.set(clocks);
     }
 
     pub fn enable(&self) {
@@ -529,9 +525,7 @@ impl<'a> Uart<'a> {
         self.disable();
         self.registers.uartlcr_h.modify(UARTLCR_H::FEN::CLEAR);
 
-        let clk = self.clocks.map_or(125_000_000, |clocks| {
-            clocks.get_frequency(clocks::Clock::Peripheral)
-        });
+        let clk = self.clocks.get_frequency(clocks::Clock::Peripheral);
 
         // Calculate baud rate
         let baud_rate_div = 8 * clk / params.baud_rate;
@@ -648,9 +642,7 @@ impl Configure for Uart<'_> {
         self.disable();
         self.registers.uartlcr_h.modify(UARTLCR_H::FEN::CLEAR);
 
-        let clk = self.clocks.map_or(125_000_000, |clocks| {
-            clocks.get_frequency(clocks::Clock::Peripheral)
-        });
+        let clk = self.clocks.get_frequency(clocks::Clock::Peripheral);
 
         // Calculate baud rate
         let baud_rate_div = 8 * clk / params.baud_rate;


### PR DESCRIPTION
### Pull Request Overview

This fixes #4543.

Rather than have optional cells in chip drivers, just statically init the needed shared peripherals and hold references directly.


### Testing Strategy

Only CI.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.

I used claude to copy the rp2040 implementation over to the rp2350.