### PR TITLE
Doc/misc link fixes

### DIFF
--- a/capsules/extra/src/virtualizers/screen/virtual_screen_split.rs
+++ b/capsules/extra/src/virtualizers/screen/virtual_screen_split.rs
@@ -60,8 +60,8 @@ pub struct ScreenSplitUser<'a, S: hil::screen::Screen<'a>> {
     /// The frame inside of the split that is active. Defaults to the entire
     /// frame.
     write_frame: Cell<Frame>,
-    /// What operation this section would like to do.[`ScreenSplitSection`] sets
-    /// its intended operation here and then asks the [`ScreenSplit`] to
+    /// What operation this section would like to do.[`ScreenSplitUser`] sets
+    /// its intended operation here and then asks the [`ScreenSplitMux`] to
     /// execute it.
     pending: OptionalCell<ScreenSplitOperation>,
     /// Screen client.

--- a/kernel/src/deferred_call.rs
+++ b/kernel/src/deferred_call.rs
@@ -18,7 +18,7 @@
 //!
 //! Before any [`DeferredCall`]s are created, the internal state used by the
 //! implementation must be initialized. Boards must initialize deferred calls
-//! by calling either [`initialize_deferred_call_state`] or
+//! by calling either `initialize_deferred_call_state` or
 //! [`initialize_deferred_call_state_unsafe`]. Depending on the hardware state
 //! available (i.e., atomic support), boards will only have one initialization
 //! routine available.
@@ -178,7 +178,7 @@ pub fn initialize_deferred_call_state<P: ThreadIdProvider>() {
 /// # Safety
 ///
 /// Callers of this function must ensure that this function is never called
-/// concurrently with calls to [`initialize_deferred_call_state`] or other calls
+/// concurrently with calls to `initialize_deferred_call_state` or other calls
 /// to [`initialize_deferred_call_state_unsafe`].
 pub unsafe fn initialize_deferred_call_state_unsafe<P: ThreadIdProvider>() {
     let _ = CTR.bind_to_thread_unsafe::<P>(Cell::new(0));
@@ -286,7 +286,7 @@ impl DeferredCall {
     ///
     /// 1. That `DEFCALLS` and the other [`SingleThreadValue`] types have been
     ///    bound to a thread. This happens during
-    ///    [`initialize_deferred_call_state`] or
+    ///    `initialize_deferred_call_state` or
     ///    [`initialize_deferred_call_state_unsafe`].
     ///
     /// 2. That <= `DEFCALLS::len` deferred calls have been created, which is

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -301,8 +301,8 @@ impl Kernel {
         self.process_identifier_max.get_and_increment()
     }
 
-    /// Find the next slot that is available for storing a new [`&Process`]
-    /// (Process).
+    /// Find the next slot that is available for storing a new
+    /// [`&Process`](process::Process).
     ///
     /// Returns `Err(())` if there are no available slots.
     pub(crate) fn next_available_process_slot(&self) -> Result<(usize, &ProcessSlot), ()> {

--- a/kernel/src/upcall.rs
+++ b/kernel/src/upcall.rs
@@ -126,18 +126,17 @@ impl Upcall {
     ///
     /// # Note on Null upcalls
     ///
-    /// This function _does_ schedule [null upcalls][null_upcall]. This is
-    /// necessary to support the Yield-WaitFor system call which does not
-    /// require an upcall function to be registered.
-    ///
-    /// null_upcall: https://github.com/tock/tock/blob/master/doc/reference/trd104-syscalls.md#421-the-null-upcall
+    /// This function _does_ schedule
+    /// [null upcalls](https://github.com/tock/tock/blob/master/doc/reference/trd104-syscalls.md#421-the-null-upcall).
+    /// This is necessary to support the Yield-WaitFor system call which does
+    /// not require an upcall function to be registered.
     ///
     /// # Note on dropping upcalls and Yield-WaitFor
     ///
     /// If the per-process storage for upcalls is full the schedule operation
     /// may fail. The exact dynamics of what defines "full" is implementation
-    /// dependent based on the [`Process`] implementation. Also, what happens if
-    /// the storage for upcalls is full depends on the [`Process`]
+    /// dependent based on the [`Process`](process::Process) implementation. Also, what happens if
+    /// the storage for upcalls is full depends on the [`Process`](process::Process)
     /// implementation.
     ///
     /// It is likely, however, that the per-process storage is a queue, and when

--- a/kernel/src/utilities/single_thread_value.rs
+++ b/kernel/src/utilities/single_thread_value.rs
@@ -15,7 +15,7 @@ use crate::platform::chip::ThreadIdProvider;
 ///
 /// The [`SingleThreadValue`] starts out not being bound to, and thus not being
 /// usable by any thread. A `SingleThreadValue` instance is instead bound to
-/// particular thread using either the [`SingleThreadValue::bind_to_thread`], or
+/// particular thread using either the `SingleThreadValue::bind_to_thread`, or
 /// the [`SingleThreadValue::bind_to_thread_unsafe`] methods. These methods can
 /// be used exactly once, after which the instance is permanently bound to the
 /// given thread that called these methods.
@@ -74,7 +74,7 @@ enum BoundToThreadStage {
 /// similar to the standard library's `LocalKey`, and thus appropriate for
 /// static allocations of values that are not themselves [`Sync`]. However,
 /// unlike `LocalKey`, it only holds a value for a single thread, determined at
-/// runtime based on the first call to [`SingleThreadValue::bind_to_thread`].
+/// runtime based on the first call to `SingleThreadValue::bind_to_thread`.
 ///
 /// # Example
 ///
@@ -108,7 +108,7 @@ enum BoundToThreadStage {
 /// ```
 ///
 /// When creating a new [`SingleThreadValue`] instance, it is uninitialized
-/// until the [`bind_to_thread`](SingleThreadValue::bind_to_thread) or
+/// until the `bind_to_thread` or
 /// [`bind_to_thread_unsafe`](SingleThreadValue::bind_to_thread_unsafe) methods
 /// are called. Until it is initialized, all attempts to access the shared value
 /// using [`get`](SingleThreadValue::get) will return `None`.
@@ -213,7 +213,7 @@ impl<T> SingleThreadValue<T> {
     /// Note that the `SingleThreadValue` will initially be uninitialized. It
     /// must first be bound to a particular thread, which will initialize with a
     /// value originating from that thread, using the
-    /// [`bind_to_thread`](SingleThreadValue::bind_to_thread) or
+    /// `bind_to_thread` or
     /// [`bind_to_thread_unsafe`](SingleThreadValue::bind_to_thread_unsafe)
     /// methods.
     pub const fn new() -> Self {
@@ -380,7 +380,7 @@ impl<T> SingleThreadValue<T> {
     ///
     /// Callers of this function must ensure that this function is never called
     /// concurrently with other calls to
-    /// [`bind_to_thread`](SingleThreadValue::bind_to_thread) or
+    /// `bind_to_thread` or
     /// [`bind_to_thread_unsafe`](SingleThreadValue::bind_to_thread_unsafe) on
     /// the same [`SingleThreadValue`] instance.
     pub unsafe fn bind_to_thread_unsafe<P: ThreadIdProvider>(&self, value: T) -> Result<(), T> {
@@ -464,7 +464,7 @@ impl<T> SingleThreadValue<T> {
     ///
     /// Returns `true` if the value is bound to the thread that is currently
     /// running (as determined by the implementation of `ThreadIdProvider` used
-    /// in [`bind_to_thread`](SingleThreadValue::bind_to_thread) or
+    /// in `bind_to_thread` or
     /// [`bind_to_thread_unsafe`](SingleThreadValue::bind_to_thread_unsafe)).
     /// Returns `false` when a different thread is executing, when it is not
     /// bound to any thread yet, or currently in the process of being bound to a


### PR DESCRIPTION
### Pull Request Overview

I noticed these while working on something. Not sure why CI doesn't catch them.

Bummer that we can't link to functions not available on all boards.


### Testing Strategy

running `make doc` in a couple boards.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
