### PR TITLE
kernel: debug: remove `pub unsafe` from `flush()`

### DIFF
--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -714,7 +714,7 @@ macro_rules! debug_expr {
 }
 
 /// Flush any stored messages to the output writer.
-pub unsafe fn flush<W: Write + IoWrite>(writer: &mut W) {
+fn flush<W: Write + IoWrite>(writer: &mut W) {
     try_get_debug_writer(|debug_writer|{
         if debug_writer.to_write_len() > 0 {
             let _ = writer.write_str(


### PR DESCRIPTION
### Pull Request Overview

I'm not sure what would make this unsafe or why this needs to be public.



This helps us be able to document all unsafe in the kernel.


### Testing Strategy

n/a


### TODO or Help Wanted

Any idea why this should be unsafe?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
