### PR TITLE
ExternalDependencies: allow procedural macro ecosystem crates in tock-registers.

### DIFF
--- a/doc/ExternalDependencies.md
+++ b/doc/ExternalDependencies.md
@@ -17,7 +17,7 @@ External Dependencies
   * [Capsule Crate-Specific External Dependencies](#capsule-crate-specific-external-dependencies)
   * [Core Kernel External Dependencies](#core-kernel-external-dependencies)
     + [Approved Exceptions for Core Kernel External Dependencies](#approved-exceptions-for-core-kernel-external-dependencies)
-      - [**tock-registers**](#tock-registers)
+      - [**tock-registers** and **tock-registers-macros**](#tock-registers)
       - [**flux-rs**](#flux-rs)
 - [Including the Dependency](#including-the-dependency)
   * [Including Capsule Crate-Specific External Dependencies](#including-capsule-crate-specific-external-dependencies)

--- a/doc/ExternalDependencies.md
+++ b/doc/ExternalDependencies.md
@@ -17,7 +17,7 @@ External Dependencies
   * [Capsule Crate-Specific External Dependencies](#capsule-crate-specific-external-dependencies)
   * [Core Kernel External Dependencies](#core-kernel-external-dependencies)
     + [Approved Exceptions for Core Kernel External Dependencies](#approved-exceptions-for-core-kernel-external-dependencies)
-      - [**tock-registers** and **tock-registers-macros**](#tock-registers)
+      - [**tock-registers** and **tock-registers-macros**](#tock-registers-and-tock-registers-macros)
       - [**flux-rs**](#flux-rs)
 - [Including the Dependency](#including-the-dependency)
   * [Including Capsule Crate-Specific External Dependencies](#including-capsule-crate-specific-external-dependencies)

--- a/doc/ExternalDependencies.md
+++ b/doc/ExternalDependencies.md
@@ -17,7 +17,7 @@ External Dependencies
   * [Capsule Crate-Specific External Dependencies](#capsule-crate-specific-external-dependencies)
   * [Core Kernel External Dependencies](#core-kernel-external-dependencies)
     + [Approved Exceptions for Core Kernel External Dependencies](#approved-exceptions-for-core-kernel-external-dependencies)
-      - [**tock-registers** and **tock-registers-macros**](#tock-registers-and-tock-registers-macros)
+      - [**tock-registers**](#tock-registers)
       - [**flux-rs**](#flux-rs)
 - [Including the Dependency](#including-the-dependency)
   * [Including Capsule Crate-Specific External Dependencies](#including-capsule-crate-specific-external-dependencies)
@@ -210,12 +210,12 @@ crates. All exceptions will be considered independently.
 
 #### Approved Exceptions for Core Kernel External Dependencies
 
-##### **tock-registers** and **tock-registers-macros**
-`tock-registers` provides an interface for using MMIO registers which is
-extensively used in `chips/` crates.
+##### **tock-registers**
+The `tock-registers` crates provide an interface for using MMIO registers which
+is extensively used in `chips/` crates.
 
 - **Repository:** https://github.com/tock/tock-registers
-- **Justification:** This crate has moved to an external dependency to
+- **Justification:** This project has moved to an external dependency to
   encourage its development and use in projects beyond Tock. Specifically, the
   benefits of development in a separate repository include:
   1. Encouraging more rigorous backwards compatibility considerations for
@@ -234,17 +234,17 @@ extensively used in `chips/` crates.
      repository makes it clear it is a standalone project and can be developed
      independently of Tock. This should help contributions that benefit
      tock-registers but not necessarily Tock as well.
-- **Dependencies:** `tock-registers-macros` may have dev-dependencies on
+- **Dependencies:** `tock-registers` crates may have dev-dependencies on
   external crates to support unit testing, as those dev-dependencies are not
-  included in a Tock kernel build. Additionally, `tock-registers-macros` may
+  included in a Tock kernel build. Additionally, `tock-registers` crates may
   depend on the `syn`, `quote`, and `proc-macro2` crates for the following
   reasons:
   1. **Important functionality:** Procedural macros need to parse nontrivial
      Rust code and generate nontrivial Rust code, and `syn` and `quote` provide
-     that functionality. For us to implement that ourself — and maintain it as
-     the Rust language evolves — would require considerable effort. `quote` has
-     a hard dependency on `proc-macro2`, which is also useful to support
-     `tock-registers-macros`' unit tests, so that is included as well.
+     that functionality. It would require considerable effort for us to
+     implement and maintain that ourselves. `quote` has a hard dependency on
+     `proc-macro2`, which is also useful to support the procedural macros' unit
+     tests, so that is included as well.
   2. **Project maturity:** These crates are core Rust ecosystem mechanisms, and
      have been stable for years. All three crates are in the top 10
      all-time-most-downloaded crates on crates.io.

--- a/doc/ExternalDependencies.md
+++ b/doc/ExternalDependencies.md
@@ -115,6 +115,12 @@ Such functionality includes:
   correct and resistant to attacks is challenging. Leveraging validated,
   high-quality cryptographic libraries instead of Tock-specific cryptographic
   code increases the security of the Tock kernel.
+* Procedural macro support. The `syn`, `quote`, and `proc-macro2` crates are
+  effectively a core part of the Rust language, despite being distributed
+  separately from the Rust toolchain. They enable tock-registers to expose
+  sound, highly-testable interfaces to hardware peripherals. Unit- and
+  integration-testing code increases the reliability and security of the Tock
+  kernel.
 
 #### Project Understandability
 
@@ -196,7 +202,7 @@ development in a standalone repository is necessary for the continued
 development, improvement, and impact of the crate.
 
 All crates permitted by this exception MUST NOT have any external dependencies
-themselves.
+themselves unless explicitly permitted by this document.
 
 Any crates included in this exception list, with their associated justification,
 do not imply any predisposition to allowing an exception for any future
@@ -204,15 +210,14 @@ crates. All exceptions will be considered independently.
 
 #### Approved Exceptions for Core Kernel External Dependencies
 
-##### **tock-registers**
-This crate provides an interface for using MMIO registers which are extensively
-used in `chips/` crates.
+##### **tock-registers** and **tock-registers-macros**
+`tock-registers` provides an interface for using MMIO registers which is
+extensively used in `chips/` crates.
 
 - **Repository:** https://github.com/tock/tock-registers
 - **Justification:** This crate has moved to an external dependency to
   encourage its development and use in projects beyond Tock. Specifically, the
   benefits of development in a separate repository include:
-
   1. Encouraging more rigorous backwards compatibility considerations for
      external users. The close interplay of Tock and tock-registers means
      breaking changes for external users can be hidden in Tock-specific pull
@@ -229,6 +234,24 @@ used in `chips/` crates.
      repository makes it clear it is a standalone project and can be developed
      independently of Tock. This should help contributions that benefit
      tock-registers but not necessarily Tock as well.
+- **Dependencies:** `tock-registers-macros` may have dev-dependencies on
+  external crates to support unit testing, as those dev-dependencies are not
+  included in a Tock kernel build. Additionally, `tock-registers-macros` may
+  depend on the `syn`, `quote`, and `proc-macro2` crates for the following
+  reasons:
+  1. **Important functionality:** Procedural macros need to parse nontrivial
+     Rust code and generate nontrivial Rust code, and `syn` and `quote` provide
+     that functionality. For us to implement that ourself — and maintain it as
+     the Rust language evolves — would require considerable effort. `quote` has
+     a hard dependency on `proc-macro2`, which is also useful to support
+     `tock-registers-macros`' unit tests, so that is included as well.
+  2. **Project maturity:** These crates are core Rust ecosystem mechanisms, and
+     have been stable for years. All three crates are in the top 10
+     all-time-most-downloaded crates on crates.io.
+  3. **Limited sub-dependencies:** The only additional dependency these crates
+     bring in is `unicode-ident`, which has no dependencies. `unicode-ident` is
+     relatively small and simple, and is a top 30 all-time-most-downloaded crate
+     on crates.io.
 
 ##### **flux-rs**
 This crate provides support for formal verification of Rust code via


### PR DESCRIPTION
### Pull Request Overview

When I started working to make tock-registers sound and to support unit testing Tock drivers, it quickly became clear than tock-registers will need to use a procedural macro. Unfortunately, Rust all-but-requires procedural macros to use the `syn`, `quote`, and `proc-macro2` crates. This PR modifies the external dependencies policy to allow `tock-registers` to have a procedural macro, and to allow that procedural macro to depend on those three ecosystem crates.

Vendoring these crates is not a great solution, as they update frequently to track Rust language changes. Also, most nontrivial uses of Tock will have these crates in their dependency tree anyway, and if we vendor them then users who care to audit their dependency tree will have to audit both the vendored and non-vendored versions of these crates.

While it may be technically feasible for us to implement the subset of these crates' functionality that we need, doing so would likely be a larger project than the entire tock-registers project (including the changes I'm still building). I'm not sure it's possible to do that in a reasonable timeframe, and it would add a considerable maintenance burden to tock-registers.

The `cargo tree` output for my work-in-progress procedural macro at https://github.com/tock/tock-registers/pull/11 is:

```
~/tock/registers$ cargo tree
tock-registers v0.10.1 (/home/ryan/tock/registers)
└── tock-registers-macros v0.10.1 (proc-macro) (/home/ryan/tock/registers/macros)
    ├── proc-macro2 v1.0.106
    │   └── unicode-ident v1.0.24
    └── tock-registers-codegen v0.10.1 (/home/ryan/tock/registers/codegen)
        ├── proc-macro2 v1.0.106 (*)
        ├── quote v1.0.45
        │   └── proc-macro2 v1.0.106 (*)
        └── syn v2.0.117
            ├── proc-macro2 v1.0.106 (*)
            ├── quote v1.0.45 (*)
            └── unicode-ident v1.0.24
```

This change also allows `tock-registers` crates to have dev-dependencies for the purpose of unit testing. This doesn't impact the Tock kernel, as those dependencies are only used when those crates are tested directly. The `cargo tree` output for unit testing the `tock-registers` crate and its dependencies is:

```
~/tock/registers$ cargo tree -e normal,dev -p tock-registers -p tock-registers-macros -p tock-registers-codegen
tock-registers v0.10.1 (/home/ryan/tock/registers)
└── tock-registers-macros v0.10.1 (proc-macro) (/home/ryan/tock/registers/macros)
    ├── proc-macro2 v1.0.106
    │   └── unicode-ident v1.0.24
    └── tock-registers-codegen v0.10.1 (/home/ryan/tock/registers/codegen)
        ├── proc-macro2 v1.0.106 (*)
        ├── quote v1.0.45
        │   └── proc-macro2 v1.0.106 (*)
        └── syn v2.0.117
            ├── proc-macro2 v1.0.106 (*)
            ├── quote v1.0.45 (*)
            └── unicode-ident v1.0.24
        [dev-dependencies]
        ├── pretty_assertions v1.4.1
        │   ├── diff v0.1.13
        │   └── yansi v1.0.1
        ├── prettyplease v0.2.37
        │   ├── proc-macro2 v1.0.106 (*)
        │   └── syn v2.0.117 (*)
        ├── syn v2.0.117 (*)
        └── tock-registers v0.10.1 (/home/ryan/tock/registers) (*)

tock-registers-codegen v0.10.1 (/home/ryan/tock/registers/codegen) (*)

tock-registers-macros v0.10.1 (proc-macro) (/home/ryan/tock/registers/macros) (*)
```

### Testing Strategy

`make prepush`

At this point, I'm fairly confident that we will not need any other dependencies for the procedural macro.

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.

### AI Use

- [X] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.

No AI use.