### PR TITLE
hil: pub key: add metadata to select key done

### DIFF
--- a/capsules/extra/src/signature_verify_in_memory_keys.rs
+++ b/capsules/extra/src/signature_verify_in_memory_keys.rs
@@ -186,7 +186,8 @@ impl<
         }
 
         self.client_key_select.map(|client| {
-            client.select_key_done(self.active_key.get().unwrap_or(0), error);
+            let key_index = self.active_key.get().unwrap_or(0);
+            client.select_key_done(key_index, key_index, error);
         });
     }
 }

--- a/capsules/system/src/process_checker/signature.rs
+++ b/capsules/system/src/process_checker/signature.rs
@@ -39,7 +39,7 @@ pub struct AppCheckerSignature<
     credential_type: TbfFooterV2CredentialsType,
     credentials: OptionalCell<TbfFooterV2Credentials>,
     binary: OptionalCell<&'static [u8]>,
-    active_key_index: Cell<(usize, usize)>,
+    active_key_index: Cell<(usize, usize, usize)>,
 }
 
 impl<
@@ -67,7 +67,7 @@ impl<
             credential_type,
             credentials: OptionalCell::empty(),
             binary: OptionalCell::empty(),
-            active_key_index: Cell::new((0, 0)),
+            active_key_index: Cell::new((0, 0, 0)),
         }
     }
 
@@ -154,7 +154,7 @@ impl<
     fn get_key_count_done(&self, count: usize) {
         // We have the hash, we know how many keys, now we need to select the
         // first key to check. Activate the first key.
-        self.active_key_index.set((0, count));
+        self.active_key_index.set((0, 0, count));
         if let Err(_e) = self.verifier.select_key(0) {
             self.client.map(|c| {
                 let binary = self.binary.take().unwrap();
@@ -164,7 +164,7 @@ impl<
         }
     }
 
-    fn select_key_done(&self, _index: usize, error: Result<(), ErrorCode>) {
+    fn select_key_done(&self, _index: usize, metadata: usize, error: Result<(), ErrorCode>) {
         match error {
             Err(e) => {
                 // Could not switch to the requested key.
@@ -174,7 +174,14 @@ impl<
                     c.check_done(Err(e), cred, binary)
                 });
             }
-            Ok(()) => self.do_verify(),
+            Ok(()) => {
+                // Save the metadata for the newly selected key.
+                let (current_key, _, number_keys) = self.active_key_index.get();
+                self.active_key_index
+                    .set((current_key, metadata, number_keys));
+
+                self.do_verify()
+            }
         }
     }
 }
@@ -257,7 +264,7 @@ impl<
         self.hash.replace(hash);
         self.signature.replace(signature);
 
-        let (current_key, number_keys) = self.active_key_index.get();
+        let (current_key, key_metadata, number_keys) = self.active_key_index.get();
 
         // Check if the verification was successful. If so, we can issue the
         // callback.
@@ -268,7 +275,7 @@ impl<
                 c.check_done(
                     Ok(CheckResult::Accept(Some(
                         kernel::process_checker::CheckResultAcceptMetadata {
-                            metadata: current_key,
+                            metadata: key_metadata,
                         },
                     ))),
                     cred,
@@ -290,7 +297,7 @@ impl<
                 });
             } else {
                 // Activate the next key.
-                self.active_key_index.set((next_key, number_keys));
+                self.active_key_index.set((next_key, 0, number_keys));
                 if self.verifier.select_key(next_key).is_err() {
                     self.client.map(|c| {
                         let binary = self.binary.take().unwrap();

--- a/kernel/src/hil/public_key_crypto/keys.rs
+++ b/kernel/src/hil/public_key_crypto/keys.rs
@@ -292,13 +292,21 @@ pub trait SelectKeyClient {
     /// Called when the specified key is active and ready to use for the next
     /// cryptographic operation.
     ///
+    /// ### Arguments
+    ///
+    /// - `index`: The index of the key that was selected.
+    /// - `metadata`: An opaque usize of metadata associated with the key. This
+    ///   can be used with
+    ///   [`CheckResultAcceptMetadata`](crate::process_checker::CheckResultAcceptMetadata)
+    ///   to assign metadata with the accepted credential.
+    ///
     /// ### `error`:
     ///
     /// - `Ok(())`: The key was selected successfully.
     /// - `Err(())`: The key was selected set successfully.
     ///   - `ErrorCode::INVAL`: The index was not valid.
     ///   - `ErrorCode::FAIL`: The key could not be set.
-    fn select_key_done(&self, index: usize, error: Result<(), ErrorCode>);
+    fn select_key_done(&self, index: usize, metadata: usize, error: Result<(), ErrorCode>);
 }
 
 /// Interface for selecting an active key among the number of available keys.


### PR DESCRIPTION
### Pull Request Overview

Add a `metadata` field to the `select_key_done()` callback.

This allows for the layer that handles selecting keys to provide an opaque usize metadata that can later be used as part of appid.

The idea is this: the key selector might not want to use index as the metadata. For example, keys stored in flash or in some hardware chip might be set in any order, and instead might have some other way to assign metadata. This allows the key selection layer to decide.

For in_memory_keys, we just use the index because the array of keys is well known.

This is part of work to be able to store public keys for app credential checking in the kernel attributes rather than in buffers defined in main.rs.


### Testing Strategy

Trying the dynamic apps and policies tutorial board with signed apps.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
