### PR TITLE
feat: round robin selection in virtualizers

### DIFF
--- a/capsules/core/src/virtualizers/virtual_adc.rs
+++ b/capsules/core/src/virtualizers/virtual_adc.rs
@@ -6,6 +6,8 @@
 //!
 //! Support Single Sample for now.
 
+use core::cell::Cell;
+
 use kernel::collections::list::{List, ListLink, ListNode};
 use kernel::hil;
 use kernel::utilities::cells::OptionalCell;
@@ -15,6 +17,7 @@ use kernel::ErrorCode;
 pub struct MuxAdc<'a, A: hil::adc::Adc<'a>> {
     adc: &'a A,
     devices: List<'a, AdcDevice<'a, A>>,
+    last_access_position: Cell<usize>,
     inflight: OptionalCell<&'a AdcDevice<'a, A>>,
 }
 
@@ -40,13 +43,29 @@ impl<'a, A: hil::adc::Adc<'a>> MuxAdc<'a, A> {
         MuxAdc {
             adc,
             devices: List::new(),
+            last_access_position: Cell::new(0),
             inflight: OptionalCell::empty(),
         }
     }
 
     fn do_next_op(&self) {
         if self.inflight.is_none() {
-            let mnode = self.devices.iter().find(|node| node.operation.is_some());
+            let mnode = self
+                .devices
+                .iter()
+                .enumerate()
+                .skip(self.last_access_position.get() + 1)
+                .chain(
+                    self.devices
+                        .iter()
+                        .enumerate()
+                        .take(self.last_access_position.get()),
+                )
+                .find(|(_, node)| node.operation.is_some())
+                .map(|(index, node)| {
+                    self.last_access_position.set(index);
+                    node
+                });
             mnode.map(|node| {
                 let started = node.operation.map_or(false, |operation| match operation {
                     Operation::OneSample => {

--- a/capsules/core/src/virtualizers/virtual_aes_ccm.rs
+++ b/capsules/core/src/virtualizers/virtual_aes_ccm.rs
@@ -139,6 +139,7 @@ pub struct MuxAES128CCM<'a, A: AES128<'a> + AES128Ctr + AES128CBC + AES128ECB> {
     aes: &'a A,
     client: OptionalCell<&'a dyn symmetric_encryption::Client<'a>>,
     ccm_clients: List<'a, VirtualAES128CCM<'a, A>>,
+    last_access_position: Cell<usize>,
     inflight: OptionalCell<&'a VirtualAES128CCM<'a, A>>,
     deferred_call: DeferredCall,
 }
@@ -150,6 +151,7 @@ impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC + AES128ECB> MuxAES128CCM<'a, A> 
             aes,
             client: OptionalCell::empty(),
             ccm_clients: List::new(),
+            last_access_position: Cell::new(0),
             inflight: OptionalCell::empty(),
             deferred_call: DeferredCall::new(),
         }
@@ -168,7 +170,19 @@ impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC + AES128ECB> MuxAES128CCM<'a, A> 
             let mnode = self
                 .ccm_clients
                 .iter()
-                .find(|node| node.queued_up.is_some());
+                .enumerate()
+                .skip(self.last_access_position.get() + 1)
+                .chain(
+                    self.ccm_clients
+                        .iter()
+                        .enumerate()
+                        .take(self.last_access_position.get()),
+                )
+                .find(|(_, node)| node.queued_up.is_some())
+                .map(|(index, node)| {
+                    self.last_access_position.set(index);
+                    node
+                });
             mnode.map(|node| {
                 self.inflight.set(node);
                 let parameters: CryptFunctionParameters = node.queued_up.take().unwrap();

--- a/capsules/core/src/virtualizers/virtual_flash.rs
+++ b/capsules/core/src/virtualizers/virtual_flash.rs
@@ -46,6 +46,7 @@ use kernel::ErrorCode;
 pub struct MuxFlash<'a, F: hil::flash::Flash + 'static> {
     flash: &'a F,
     users: List<'a, FlashUser<'a, F>>,
+    last_access_position: Cell<usize>,
     inflight: OptionalCell<&'a FlashUser<'a, F>>,
 }
 
@@ -85,6 +86,7 @@ impl<'a, F: hil::flash::Flash> MuxFlash<'a, F> {
         MuxFlash {
             flash,
             users: List::new(),
+            last_access_position: Cell::new(0),
             inflight: OptionalCell::empty(),
         }
     }
@@ -96,7 +98,19 @@ impl<'a, F: hil::flash::Flash> MuxFlash<'a, F> {
             let mnode = self
                 .users
                 .iter()
-                .find(|node| node.operation.get() != Op::Idle);
+                .enumerate()
+                .skip(self.last_access_position.get() + 1)
+                .chain(
+                    self.users
+                        .iter()
+                        .enumerate()
+                        .take(self.last_access_position.get()),
+                )
+                .find(|(_, node)| node.operation.get() != Op::Idle)
+                .map(|(index, node)| {
+                    self.last_access_position.set(index);
+                    node
+                });
             mnode.map(|node| {
                 node.buffer.take().map_or_else(
                     || {

--- a/capsules/core/src/virtualizers/virtual_i2c.rs
+++ b/capsules/core/src/virtualizers/virtual_i2c.rs
@@ -22,6 +22,7 @@ pub struct MuxI2C<'a, I: i2c::I2CMaster<'a>, S: i2c::SMBusMaster<'a> = NoSMBus> 
     enabled: Cell<usize>,
     i2c_inflight: OptionalCell<&'a I2CDevice<'a, I, S>>,
     smbus_inflight: OptionalCell<&'a SMBusDevice<'a, I, S>>,
+    last_access_position: Cell<usize>,
     deferred_call: DeferredCall,
 }
 
@@ -50,6 +51,7 @@ impl<'a, I: i2c::I2CMaster<'a>, S: i2c::SMBusMaster<'a>> MuxI2C<'a, I, S> {
             enabled: Cell::new(0),
             i2c_inflight: OptionalCell::empty(),
             smbus_inflight: OptionalCell::empty(),
+            last_access_position: Cell::new(0),
             deferred_call: DeferredCall::new(),
         }
     }
@@ -78,7 +80,19 @@ impl<'a, I: i2c::I2CMaster<'a>, S: i2c::SMBusMaster<'a>> MuxI2C<'a, I, S> {
             let mnode = self
                 .i2c_devices
                 .iter()
-                .find(|node| node.operation.get() != Op::Idle);
+                .enumerate()
+                .skip(self.last_access_position.get() + 1)
+                .chain(
+                    self.i2c_devices
+                        .iter()
+                        .enumerate()
+                        .take(self.last_access_position.get()),
+                )
+                .find(|(_, node)| node.operation.get() != Op::Idle)
+                .map(|(index, node)| {
+                    self.last_access_position.set(index);
+                    node
+                });
             mnode.map(|node| {
                 node.buffer.take().map(|buf| {
                     match node.operation.get() {

--- a/capsules/core/src/virtualizers/virtual_pwm.rs
+++ b/capsules/core/src/virtualizers/virtual_pwm.rs
@@ -23,6 +23,7 @@
 //! );
 //! virtual_pwm_buzzer.add_to_mux();
 //! ```
+use core::cell::Cell;
 
 use kernel::collections::list::{List, ListLink, ListNode};
 use kernel::hil;
@@ -32,6 +33,7 @@ use kernel::ErrorCode;
 pub struct MuxPwm<'a, P: hil::pwm::Pwm> {
     pwm: &'a P,
     devices: List<'a, PwmPinUser<'a, P>>,
+    last_access_position: Cell<usize>,
     inflight: OptionalCell<&'a PwmPinUser<'a, P>>,
 }
 
@@ -40,6 +42,7 @@ impl<'a, P: hil::pwm::Pwm> MuxPwm<'a, P> {
         MuxPwm {
             pwm,
             devices: List::new(),
+            last_access_position: Cell::new(0),
             inflight: OptionalCell::empty(),
         }
     }
@@ -48,7 +51,22 @@ impl<'a, P: hil::pwm::Pwm> MuxPwm<'a, P> {
     /// one with an outstanding operation and run that.
     fn do_next_op(&self) {
         if self.inflight.is_none() {
-            let mnode = self.devices.iter().find(|node| node.operation.is_some());
+            let mnode = self
+                .devices
+                .iter()
+                .enumerate()
+                .skip(self.last_access_position.get() + 1)
+                .chain(
+                    self.devices
+                        .iter()
+                        .enumerate()
+                        .take(self.last_access_position.get()),
+                )
+                .find(|(_, node)| node.operation.is_some())
+                .map(|(index, node)| {
+                    self.last_access_position.set(index);
+                    node
+                });
             mnode.map(|node| {
                 let started = node.operation.take().is_some_and(|operation| {
                     match operation {

--- a/capsules/core/src/virtualizers/virtual_rng.rs
+++ b/capsules/core/src/virtualizers/virtual_rng.rs
@@ -19,6 +19,7 @@ enum Op {
 pub struct MuxRngMaster<'a> {
     rng: &'a dyn Rng<'a>,
     devices: List<'a, VirtualRngMasterDevice<'a>>,
+    last_access_position: Cell<usize>,
     inflight: OptionalCell<&'a VirtualRngMasterDevice<'a>>,
 }
 
@@ -27,6 +28,7 @@ impl<'a> MuxRngMaster<'a> {
         MuxRngMaster {
             rng,
             devices: List::new(),
+            last_access_position: Cell::new(0),
             inflight: OptionalCell::empty(),
         }
     }
@@ -36,7 +38,19 @@ impl<'a> MuxRngMaster<'a> {
             let mnode = self
                 .devices
                 .iter()
-                .find(|node| node.operation.get() != Op::Idle);
+                .enumerate()
+                .skip(self.last_access_position.get() + 1)
+                .chain(
+                    self.devices
+                        .iter()
+                        .enumerate()
+                        .take(self.last_access_position.get()),
+                )
+                .find(|(_, node)| node.operation.get() != Op::Idle)
+                .map(|(index, node)| {
+                    self.last_access_position.set(index);
+                    node
+                });
 
             let return_code = mnode.map(|node| {
                 let op = node.operation.get();

--- a/capsules/core/src/virtualizers/virtual_spi.rs
+++ b/capsules/core/src/virtualizers/virtual_spi.rs
@@ -19,6 +19,7 @@ pub struct MuxSpiMaster<'a, Spi: hil::spi::SpiMaster<'a>> {
     spi: &'a Spi,
     devices: List<'a, VirtualSpiMasterDevice<'a, Spi>>,
     inflight: OptionalCell<&'a VirtualSpiMasterDevice<'a, Spi>>,
+    last_access_position: Cell<usize>,
     deferred_call: DeferredCall,
 }
 
@@ -47,6 +48,7 @@ impl<'a, Spi: hil::spi::SpiMaster<'a>> MuxSpiMaster<'a, Spi> {
             spi,
             devices: List::new(),
             inflight: OptionalCell::empty(),
+            last_access_position: Cell::new(0),
             deferred_call: DeferredCall::new(),
         }
     }
@@ -56,7 +58,19 @@ impl<'a, Spi: hil::spi::SpiMaster<'a>> MuxSpiMaster<'a, Spi> {
             let mnode = self
                 .devices
                 .iter()
-                .find(|node| node.operation.get() != Op::Idle);
+                .enumerate()
+                .skip(self.last_access_position.get() + 1)
+                .chain(
+                    self.devices
+                        .iter()
+                        .enumerate()
+                        .take(self.last_access_position.get()),
+                )
+                .find(|(_, node)| node.operation.get() != Op::Idle)
+                .map(|(index, node)| {
+                    self.last_access_position.set(index);
+                    node
+                });
             mnode.map(|node| {
                 let configuration = node.configuration.get();
                 let cs = configuration.chip_select;

--- a/capsules/core/src/virtualizers/virtual_uart.rs
+++ b/capsules/core/src/virtualizers/virtual_uart.rs
@@ -63,6 +63,7 @@ pub struct MuxUart<'a> {
     inflight: OptionalCell<&'a UartDevice<'a>>,
     buffer: TakeCell<'static, [u8]>,
     completing_read: Cell<bool>,
+    last_access_position: Cell<usize>,
     deferred_call: DeferredCall,
 }
 
@@ -219,6 +220,7 @@ impl<'a> MuxUart<'a> {
             inflight: OptionalCell::empty(),
             buffer: TakeCell::new(buffer),
             completing_read: Cell::new(false),
+            last_access_position: Cell::new(0),
             deferred_call: DeferredCall::new(),
         }
     }
@@ -235,7 +237,22 @@ impl<'a> MuxUart<'a> {
 
     fn do_next_op(&self) {
         if self.inflight.is_none() {
-            let mnode = self.devices.iter().find(|node| node.operation.is_some());
+            let mnode = self
+                .devices
+                .iter()
+                .enumerate()
+                .skip(self.last_access_position.get() + 1)
+                .chain(
+                    self.devices
+                        .iter()
+                        .enumerate()
+                        .take(self.last_access_position.get()),
+                )
+                .find(|(_, node)| node.operation.is_some())
+                .map(|(index, node)| {
+                    self.last_access_position.set(index);
+                    node
+                });
             mnode.map(|node| {
                 node.tx_buffer.take().map(|buf| {
                     node.operation.take().map(move |op| match op {


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the fairness problem of virtual devices. The solution iterates the devices list in a round robin manner and is introduced at every multiplexer (except `VirtualTimer` and `VirtualMuxAlarm` which have different implementation). For more details, please refer to #4802. 


### Testing Strategy

This pull request was tested by using a custom kernel of qemu_rv32_virt with UART peripheral, and three equivalent applications that try to use printf() simultaneously.


### TODO or Help Wanted

Feedback


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.

No AI was used in this PR.