### PR TITLE
Apploader unload

### DIFF
--- a/boards/components/src/app_loader.rs
+++ b/boards/components/src/app_loader.rs
@@ -26,6 +26,7 @@
 //!     dynamic_binary_storage,
 //!     dynamic_binary_storage,
 //!     dynamic_binary_storage,
+//!     create_capability!(capabilities::MemoryAllocationCapability),
 //!     ).finalize(components::app_loader_component_static!(
 //!     DynamicBinaryStorage<'static>,
 //!     DynamicBinaryStorage<'static>,
@@ -53,39 +54,39 @@ macro_rules! app_loader_component_static {
 pub struct AppLoaderComponent<
     S: dynamic_binary_storage::DynamicBinaryStore + 'static,
     L: dynamic_binary_storage::DynamicProcessLoad + 'static,
-    CAP: MemoryAllocationCapability + 'static,
     T: dynamic_binary_storage::DynamicProcessUnload + 'static,
+    CAP: MemoryAllocationCapability + 'static,
 > {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     storage_driver: &'static S,
     load_driver: &'static L,
-    mem_cap: CAP,
     unload_driver: &'static T,
+    mem_cap: CAP,
 }
 
 impl<
     S: dynamic_binary_storage::DynamicBinaryStore + 'static,
     L: dynamic_binary_storage::DynamicProcessLoad + 'static,
-    CAP: MemoryAllocationCapability + 'static,
     T: dynamic_binary_storage::DynamicProcessUnload + 'static,
-> AppLoaderComponent<S, L, CAP, T>
+    CAP: MemoryAllocationCapability + 'static,
+> AppLoaderComponent<S, L, T, CAP>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         storage_driver: &'static S,
         load_driver: &'static L,
-        mem_cap: CAP,
         unload_driver: &'static T,
+        mem_cap: CAP,
     ) -> Self {
         Self {
             board_kernel,
             driver_num,
             storage_driver,
             load_driver,
-            mem_cap,
             unload_driver,
+            mem_cap,
         }
     }
 }
@@ -93,9 +94,9 @@ impl<
 impl<
     S: dynamic_binary_storage::DynamicBinaryStore + 'static,
     L: dynamic_binary_storage::DynamicProcessLoad + 'static,
-    CAP: MemoryAllocationCapability + 'static,
     T: dynamic_binary_storage::DynamicProcessUnload + 'static,
-> Component for AppLoaderComponent<S, L, CAP, T>
+    CAP: MemoryAllocationCapability + 'static,
+> Component for AppLoaderComponent<S, L, T, CAP>
 {
     type StaticInput = (
         &'static mut MaybeUninit<AppLoader<S, L, T>>,

--- a/boards/components/src/app_loader.rs
+++ b/boards/components/src/app_loader.rs
@@ -26,12 +26,10 @@
 //!     dynamic_binary_storage,
 //!     dynamic_binary_storage,
 //!     dynamic_binary_storage,
-//!     PMCapability,
 //!     ).finalize(components::app_loader_component_static!(
 //!     DynamicBinaryStorage<'static>,
 //!     DynamicBinaryStorage<'static>,
 //!     DynamicBinaryStorage<'static>,
-//!     PMCapability,
 //!     ));
 //! ```
 
@@ -44,8 +42,8 @@ use kernel::dynamic_binary_storage;
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! app_loader_component_static {
-    ($S:ty, $L:ty, $T:ty, $P:ty $(,)?) => {{
-        let al = kernel::static_buf!(capsules_extra::app_loader::AppLoader<$S, $L, $T, $P>);
+    ($S:ty, $L:ty, $T:ty $(,)?) => {{
+        let al = kernel::static_buf!(capsules_extra::app_loader::AppLoader<$S, $L, $T>);
         let buffer = kernel::static_buf!([u8; capsules_extra::app_loader::BUF_LEN]);
 
         (al, buffer)
@@ -57,7 +55,6 @@ pub struct AppLoaderComponent<
     L: dynamic_binary_storage::DynamicProcessLoad + 'static,
     CAP: MemoryAllocationCapability + 'static,
     T: dynamic_binary_storage::DynamicProcessUnload + 'static,
-    P: capabilities::ProcessManagementCapability + 'static,
 > {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
@@ -65,7 +62,6 @@ pub struct AppLoaderComponent<
     load_driver: &'static L,
     mem_cap: CAP,
     unload_driver: &'static T,
-    capability: P,
 }
 
 impl<
@@ -73,8 +69,7 @@ impl<
     L: dynamic_binary_storage::DynamicProcessLoad + 'static,
     CAP: MemoryAllocationCapability + 'static,
     T: dynamic_binary_storage::DynamicProcessUnload + 'static,
-    P: capabilities::ProcessManagementCapability + 'static,
-> AppLoaderComponent<S, L, CAP, T, P>
+> AppLoaderComponent<S, L, CAP, T>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
@@ -83,7 +78,6 @@ impl<
         load_driver: &'static L,
         mem_cap: CAP,
         unload_driver: &'static T,
-        capability: P,
     ) -> Self {
         Self {
             board_kernel,
@@ -92,7 +86,6 @@ impl<
             load_driver,
             mem_cap,
             unload_driver,
-            capability,
         }
     }
 }
@@ -102,14 +95,13 @@ impl<
     L: dynamic_binary_storage::DynamicProcessLoad + 'static,
     CAP: MemoryAllocationCapability + 'static,
     T: dynamic_binary_storage::DynamicProcessUnload + 'static,
-    P: capabilities::ProcessManagementCapability + 'static,
-> Component for AppLoaderComponent<S, L, CAP, T, P>
+> Component for AppLoaderComponent<S, L, CAP, T>
 {
     type StaticInput = (
-        &'static mut MaybeUninit<AppLoader<S, L, T, P>>,
+        &'static mut MaybeUninit<AppLoader<S, L, T>>,
         &'static mut MaybeUninit<[u8; capsules_extra::app_loader::BUF_LEN]>,
     );
-    type Output = &'static AppLoader<S, L, T, P>;
+    type Output = &'static AppLoader<S, L, T>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let buffer = static_buffer
@@ -122,7 +114,6 @@ impl<
             self.storage_driver,
             self.load_driver,
             self.unload_driver,
-            self.capability,
             buffer,
         ));
         dynamic_binary_storage::DynamicBinaryStore::set_storage_client(

--- a/boards/components/src/app_loader.rs
+++ b/boards/components/src/app_loader.rs
@@ -25,9 +25,13 @@
 //!     capsules_extra::app_loader::DRIVER_NUM,
 //!     dynamic_binary_storage,
 //!     dynamic_binary_storage,
+//!     dynamic_binary_storage,
+//!     PMCapability,
 //!     ).finalize(components::app_loader_component_static!(
 //!     DynamicBinaryStorage<'static>,
 //!     DynamicBinaryStorage<'static>,
+//!     DynamicBinaryStorage<'static>,
+//!     PMCapability,
 //!     ));
 //! ```
 
@@ -40,8 +44,8 @@ use kernel::dynamic_binary_storage;
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! app_loader_component_static {
-    ($S:ty, $L:ty, $T:ty $(,)?) => {{
-        let al = kernel::static_buf!(capsules_extra::app_loader::AppLoader<$S, $L, $T>);
+    ($S:ty, $L:ty, $T:ty, $P:ty $(,)?) => {{
+        let al = kernel::static_buf!(capsules_extra::app_loader::AppLoader<$S, $L, $T, $P>);
         let buffer = kernel::static_buf!([u8; capsules_extra::app_loader::BUF_LEN]);
 
         (al, buffer)
@@ -53,6 +57,7 @@ pub struct AppLoaderComponent<
     L: dynamic_binary_storage::DynamicProcessLoad + 'static,
     CAP: MemoryAllocationCapability + 'static,
     T: dynamic_binary_storage::DynamicProcessUnload + 'static,
+    P: capabilities::ProcessManagementCapability + 'static,
 > {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
@@ -60,6 +65,7 @@ pub struct AppLoaderComponent<
     load_driver: &'static L,
     mem_cap: CAP,
     unload_driver: &'static T,
+    capability: P,
 }
 
 impl<
@@ -67,7 +73,8 @@ impl<
     L: dynamic_binary_storage::DynamicProcessLoad + 'static,
     CAP: MemoryAllocationCapability + 'static,
     T: dynamic_binary_storage::DynamicProcessUnload + 'static,
-> AppLoaderComponent<S, L, CAP, T>
+    P: capabilities::ProcessManagementCapability + 'static,
+> AppLoaderComponent<S, L, CAP, T, P>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
@@ -76,6 +83,7 @@ impl<
         load_driver: &'static L,
         mem_cap: CAP,
         unload_driver: &'static T,
+        capability: P,
     ) -> Self {
         Self {
             board_kernel,
@@ -84,6 +92,7 @@ impl<
             load_driver,
             mem_cap,
             unload_driver,
+            capability,
         }
     }
 }
@@ -93,13 +102,14 @@ impl<
     L: dynamic_binary_storage::DynamicProcessLoad + 'static,
     CAP: MemoryAllocationCapability + 'static,
     T: dynamic_binary_storage::DynamicProcessUnload + 'static,
-> Component for AppLoaderComponent<S, L, CAP, T>
+    P: capabilities::ProcessManagementCapability + 'static,
+> Component for AppLoaderComponent<S, L, CAP, T, P>
 {
     type StaticInput = (
-        &'static mut MaybeUninit<AppLoader<S, L, T>>,
+        &'static mut MaybeUninit<AppLoader<S, L, T, P>>,
         &'static mut MaybeUninit<[u8; capsules_extra::app_loader::BUF_LEN]>,
     );
-    type Output = &'static AppLoader<S, L, T>;
+    type Output = &'static AppLoader<S, L, T, P>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let buffer = static_buffer
@@ -112,6 +122,7 @@ impl<
             self.storage_driver,
             self.load_driver,
             self.unload_driver,
+            self.capability,
             buffer,
         ));
         dynamic_binary_storage::DynamicBinaryStore::set_storage_client(

--- a/boards/components/src/app_loader.rs
+++ b/boards/components/src/app_loader.rs
@@ -40,8 +40,8 @@ use kernel::dynamic_binary_storage;
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! app_loader_component_static {
-    ($S:ty, $L:ty $(,)?) => {{
-        let al = kernel::static_buf!(capsules_extra::app_loader::AppLoader<$S, $L>);
+    ($S:ty, $L:ty, $T:ty $(,)?) => {{
+        let al = kernel::static_buf!(capsules_extra::app_loader::AppLoader<$S, $L, $T>);
         let buffer = kernel::static_buf!([u8; capsules_extra::app_loader::BUF_LEN]);
 
         (al, buffer)
@@ -52,19 +52,22 @@ pub struct AppLoaderComponent<
     S: dynamic_binary_storage::DynamicBinaryStore + 'static,
     L: dynamic_binary_storage::DynamicProcessLoad + 'static,
     CAP: MemoryAllocationCapability + 'static,
+    T: dynamic_binary_storage::DynamicProcessUnload + 'static,
 > {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     storage_driver: &'static S,
     load_driver: &'static L,
     mem_cap: CAP,
+    unload_driver: &'static T,
 }
 
 impl<
     S: dynamic_binary_storage::DynamicBinaryStore + 'static,
     L: dynamic_binary_storage::DynamicProcessLoad + 'static,
     CAP: MemoryAllocationCapability + 'static,
-> AppLoaderComponent<S, L, CAP>
+    T: dynamic_binary_storage::DynamicProcessUnload + 'static,
+> AppLoaderComponent<S, L, CAP, T>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
@@ -72,6 +75,7 @@ impl<
         storage_driver: &'static S,
         load_driver: &'static L,
         mem_cap: CAP,
+        unload_driver: &'static T,
     ) -> Self {
         Self {
             board_kernel,
@@ -79,6 +83,7 @@ impl<
             storage_driver,
             load_driver,
             mem_cap,
+            unload_driver,
         }
     }
 }
@@ -87,13 +92,14 @@ impl<
     S: dynamic_binary_storage::DynamicBinaryStore + 'static,
     L: dynamic_binary_storage::DynamicProcessLoad + 'static,
     CAP: MemoryAllocationCapability + 'static,
-> Component for AppLoaderComponent<S, L, CAP>
+    T: dynamic_binary_storage::DynamicProcessUnload + 'static,
+> Component for AppLoaderComponent<S, L, CAP, T>
 {
     type StaticInput = (
-        &'static mut MaybeUninit<AppLoader<S, L>>,
+        &'static mut MaybeUninit<AppLoader<S, L, T>>,
         &'static mut MaybeUninit<[u8; capsules_extra::app_loader::BUF_LEN]>,
     );
-    type Output = &'static AppLoader<S, L>;
+    type Output = &'static AppLoader<S, L, T>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let buffer = static_buffer
@@ -105,6 +111,7 @@ impl<
                 .create_grant(self.driver_num, &self.mem_cap),
             self.storage_driver,
             self.load_driver,
+            self.unload_driver,
             buffer,
         ));
         dynamic_binary_storage::DynamicBinaryStore::set_storage_client(
@@ -113,6 +120,10 @@ impl<
         );
         dynamic_binary_storage::DynamicProcessLoad::set_load_client(
             self.load_driver,
+            dynamic_app_loader,
+        );
+        dynamic_binary_storage::DynamicProcessUnload::set_unload_client(
+            self.unload_driver,
             dynamic_app_loader,
         );
         dynamic_app_loader

--- a/boards/components/src/dynamic_binary_storage.rs
+++ b/boards/components/src/dynamic_binary_storage.rs
@@ -23,7 +23,6 @@
 
 use capsules_extra::nonvolatile_to_pages::NonvolatileToPages;
 use core::mem::MaybeUninit;
-use kernel::capabilities::ProcessManagementCapability;
 use kernel::component::Component;
 use kernel::deferred_call::DeferredCallClient;
 use kernel::dynamic_binary_storage::SequentialDynamicBinaryStorage;
@@ -37,7 +36,7 @@ pub type NVPages<F> = capsules_extra::nonvolatile_to_pages::NonvolatileToPages<'
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! sequential_binary_storage_component_static {
-    ($F:ty, $C:ty, $D:ty, $P:ty $(,)?) => {{
+    ($F:ty, $C:ty, $D:ty $(,)?) => {{
         let page = kernel::static_buf!(<$F as kernel::hil::flash::Flash>::Page);
         let ntp = kernel::static_buf!(
             capsules_extra::nonvolatile_to_pages::NonvolatileToPages<'static, $F>
@@ -49,7 +48,6 @@ macro_rules! sequential_binary_storage_component_static {
                 $C,
                 $D,
                 capsules_extra::nonvolatile_to_pages::NonvolatileToPages<'static, $F>,
-                $P,
             >
         );
         let buffer = kernel::static_buf!([u8; kernel::dynamic_binary_storage::BUF_LEN]);
@@ -62,12 +60,10 @@ pub struct SequentialBinaryStorageComponent<
     F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, NonvolatileToPages<'static, F>>,
     C: Chip + 'static,
     D: ProcessStandardDebug + 'static,
-    P: 'static + ProcessManagementCapability,
 > {
     board_kernel: &'static kernel::Kernel,
     nv_flash: &'static F,
     loader_driver: &'static SequentialProcessLoaderMachine<'static, C, D>,
-    capability: P,
 }
 
 impl<
@@ -76,20 +72,17 @@ impl<
             + hil::flash::HasClient<'static, NonvolatileToPages<'static, F>>,
         C: 'static + Chip,
         D: 'static + ProcessStandardDebug,
-        P: 'static + ProcessManagementCapability,
-    > SequentialBinaryStorageComponent<F, C, D, P>
+    > SequentialBinaryStorageComponent<F, C, D>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         nv_flash: &'static F,
         loader_driver: &'static SequentialProcessLoaderMachine<'static, C, D>,
-        capability: P,
     ) -> Self {
         Self {
             board_kernel,
             nv_flash,
             loader_driver,
-            capability,
         }
     }
 }
@@ -100,21 +93,13 @@ impl<
             + hil::flash::HasClient<'static, NonvolatileToPages<'static, F>>,
         C: 'static + Chip,
         D: 'static + ProcessStandardDebug,
-        P: 'static + ProcessManagementCapability,
-    > Component for SequentialBinaryStorageComponent<F, C, D, P>
+    > Component for SequentialBinaryStorageComponent<F, C, D>
 {
     type StaticInput = (
         &'static mut MaybeUninit<<F as hil::flash::Flash>::Page>,
         &'static mut MaybeUninit<NonvolatileToPages<'static, F>>,
         &'static mut MaybeUninit<
-            SequentialDynamicBinaryStorage<
-                'static,
-                'static,
-                C,
-                D,
-                NonvolatileToPages<'static, F>,
-                P,
-            >,
+            SequentialDynamicBinaryStorage<'static, 'static, C, D, NonvolatileToPages<'static, F>>,
         >,
         &'static mut MaybeUninit<[u8; kernel::dynamic_binary_storage::BUF_LEN]>,
     );
@@ -124,7 +109,6 @@ impl<
         C,
         D,
         NonvolatileToPages<'static, F>,
-        P,
     >;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
@@ -146,7 +130,6 @@ impl<
             nv_to_page,
             self.loader_driver,
             buffer,
-            self.capability,
         ));
         hil::nonvolatile_storage::NonvolatileStorage::set_client(
             nv_to_page,

--- a/boards/components/src/dynamic_binary_storage.rs
+++ b/boards/components/src/dynamic_binary_storage.rs
@@ -23,6 +23,7 @@
 
 use capsules_extra::nonvolatile_to_pages::NonvolatileToPages;
 use core::mem::MaybeUninit;
+use kernel::capabilities::ProcessManagementCapability;
 use kernel::component::Component;
 use kernel::deferred_call::DeferredCallClient;
 use kernel::dynamic_binary_storage::SequentialDynamicBinaryStorage;
@@ -36,7 +37,7 @@ pub type NVPages<F> = capsules_extra::nonvolatile_to_pages::NonvolatileToPages<'
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! sequential_binary_storage_component_static {
-    ($F:ty, $C:ty, $D:ty $(,)?) => {{
+    ($F:ty, $C:ty, $D:ty, $P:ty $(,)?) => {{
         let page = kernel::static_buf!(<$F as kernel::hil::flash::Flash>::Page);
         let ntp = kernel::static_buf!(
             capsules_extra::nonvolatile_to_pages::NonvolatileToPages<'static, $F>
@@ -48,6 +49,7 @@ macro_rules! sequential_binary_storage_component_static {
                 $C,
                 $D,
                 capsules_extra::nonvolatile_to_pages::NonvolatileToPages<'static, $F>,
+                $P,
             >
         );
         let buffer = kernel::static_buf!([u8; kernel::dynamic_binary_storage::BUF_LEN]);
@@ -60,10 +62,12 @@ pub struct SequentialBinaryStorageComponent<
     F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, NonvolatileToPages<'static, F>>,
     C: Chip + 'static,
     D: ProcessStandardDebug + 'static,
+    P: 'static + ProcessManagementCapability,
 > {
     board_kernel: &'static kernel::Kernel,
     nv_flash: &'static F,
     loader_driver: &'static SequentialProcessLoaderMachine<'static, C, D>,
+    capability: P,
 }
 
 impl<
@@ -72,17 +76,20 @@ impl<
             + hil::flash::HasClient<'static, NonvolatileToPages<'static, F>>,
         C: 'static + Chip,
         D: 'static + ProcessStandardDebug,
-    > SequentialBinaryStorageComponent<F, C, D>
+        P: 'static + ProcessManagementCapability,
+    > SequentialBinaryStorageComponent<F, C, D, P>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         nv_flash: &'static F,
         loader_driver: &'static SequentialProcessLoaderMachine<'static, C, D>,
+        capability: P,
     ) -> Self {
         Self {
             board_kernel,
             nv_flash,
             loader_driver,
+            capability,
         }
     }
 }
@@ -93,13 +100,21 @@ impl<
             + hil::flash::HasClient<'static, NonvolatileToPages<'static, F>>,
         C: 'static + Chip,
         D: 'static + ProcessStandardDebug,
-    > Component for SequentialBinaryStorageComponent<F, C, D>
+        P: 'static + ProcessManagementCapability,
+    > Component for SequentialBinaryStorageComponent<F, C, D, P>
 {
     type StaticInput = (
         &'static mut MaybeUninit<<F as hil::flash::Flash>::Page>,
         &'static mut MaybeUninit<NonvolatileToPages<'static, F>>,
         &'static mut MaybeUninit<
-            SequentialDynamicBinaryStorage<'static, 'static, C, D, NonvolatileToPages<'static, F>>,
+            SequentialDynamicBinaryStorage<
+                'static,
+                'static,
+                C,
+                D,
+                NonvolatileToPages<'static, F>,
+                P,
+            >,
         >,
         &'static mut MaybeUninit<[u8; kernel::dynamic_binary_storage::BUF_LEN]>,
     );
@@ -109,6 +124,7 @@ impl<
         C,
         D,
         NonvolatileToPages<'static, F>,
+        P,
     >;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
@@ -130,6 +146,7 @@ impl<
             nv_to_page,
             self.loader_driver,
             buffer,
+            self.capability,
         ));
         hil::nonvolatile_storage::NonvolatileStorage::set_client(
             nv_to_page,

--- a/boards/components/src/dynamic_binary_storage.rs
+++ b/boards/components/src/dynamic_binary_storage.rs
@@ -23,6 +23,7 @@
 
 use capsules_extra::nonvolatile_to_pages::NonvolatileToPages;
 use core::mem::MaybeUninit;
+use kernel::capabilities::ProcessManagementCapability;
 use kernel::component::Component;
 use kernel::deferred_call::DeferredCallClient;
 use kernel::dynamic_binary_storage::SequentialDynamicBinaryStorage;
@@ -36,7 +37,7 @@ pub type NVPages<F> = capsules_extra::nonvolatile_to_pages::NonvolatileToPages<'
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! sequential_binary_storage_component_static {
-    ($F:ty, $C:ty, $D:ty $(,)?) => {{
+    ($F:ty, $C:ty, $D:ty, $P:ty $(,)?) => {{
         let page = kernel::static_buf!(<$F as kernel::hil::flash::Flash>::Page);
         let ntp = kernel::static_buf!(
             capsules_extra::nonvolatile_to_pages::NonvolatileToPages<'static, $F>
@@ -48,6 +49,7 @@ macro_rules! sequential_binary_storage_component_static {
                 $C,
                 $D,
                 capsules_extra::nonvolatile_to_pages::NonvolatileToPages<'static, $F>,
+                $P,
             >
         );
         let buffer = kernel::static_buf!([u8; kernel::dynamic_binary_storage::BUF_LEN]);
@@ -60,39 +62,59 @@ pub struct SequentialBinaryStorageComponent<
     F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, NonvolatileToPages<'static, F>>,
     C: Chip + 'static,
     D: ProcessStandardDebug + 'static,
+    P: 'static + ProcessManagementCapability,
 > {
+    board_kernel: &'static kernel::Kernel,
     nv_flash: &'static F,
     loader_driver: &'static SequentialProcessLoaderMachine<'static, C, D>,
+    capability: P,
 }
 
 impl<
-    F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, NonvolatileToPages<'static, F>>,
-    C: 'static + Chip,
-    D: 'static + ProcessStandardDebug,
-> SequentialBinaryStorageComponent<F, C, D>
+        F: 'static
+            + hil::flash::Flash
+            + hil::flash::HasClient<'static, NonvolatileToPages<'static, F>>,
+        C: 'static + Chip,
+        D: 'static + ProcessStandardDebug,
+        P: 'static + ProcessManagementCapability,
+    > SequentialBinaryStorageComponent<F, C, D, P>
 {
     pub fn new(
+        board_kernel: &'static kernel::Kernel,
         nv_flash: &'static F,
         loader_driver: &'static SequentialProcessLoaderMachine<'static, C, D>,
+        capability: P,
     ) -> Self {
         Self {
+            board_kernel,
             nv_flash,
             loader_driver,
+            capability,
         }
     }
 }
 
 impl<
-    F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, NonvolatileToPages<'static, F>>,
-    C: 'static + Chip,
-    D: 'static + ProcessStandardDebug,
-> Component for SequentialBinaryStorageComponent<F, C, D>
+        F: 'static
+            + hil::flash::Flash
+            + hil::flash::HasClient<'static, NonvolatileToPages<'static, F>>,
+        C: 'static + Chip,
+        D: 'static + ProcessStandardDebug,
+        P: 'static + ProcessManagementCapability,
+    > Component for SequentialBinaryStorageComponent<F, C, D, P>
 {
     type StaticInput = (
         &'static mut MaybeUninit<<F as hil::flash::Flash>::Page>,
         &'static mut MaybeUninit<NonvolatileToPages<'static, F>>,
         &'static mut MaybeUninit<
-            SequentialDynamicBinaryStorage<'static, 'static, C, D, NonvolatileToPages<'static, F>>,
+            SequentialDynamicBinaryStorage<
+                'static,
+                'static,
+                C,
+                D,
+                NonvolatileToPages<'static, F>,
+                P,
+            >,
         >,
         &'static mut MaybeUninit<[u8; kernel::dynamic_binary_storage::BUF_LEN]>,
     );
@@ -102,6 +124,7 @@ impl<
         C,
         D,
         NonvolatileToPages<'static, F>,
+        P,
     >;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
@@ -119,9 +142,11 @@ impl<
         hil::flash::HasClient::set_client(self.nv_flash, nv_to_page);
 
         let dynamic_binary_storage = static_buffer.2.write(SequentialDynamicBinaryStorage::new(
+            self.board_kernel,
             nv_to_page,
             self.loader_driver,
             buffer,
+            self.capability,
         ));
         hil::nonvolatile_storage::NonvolatileStorage::set_client(
             nv_to_page,

--- a/boards/components/src/dynamic_binary_storage.rs
+++ b/boards/components/src/dynamic_binary_storage.rs
@@ -11,6 +11,7 @@
 //! # use kernel::static_init;
 //!
 //! let dynamic_binary_storage = components::dyn_binary_storage::SequentialBinaryStorageComponent::new(
+//!     board_kernel,
 //!     &base_peripherals.nvmc,
 //!     &loader,
 //! )

--- a/boards/components/src/dynamic_binary_storage.rs
+++ b/boards/components/src/dynamic_binary_storage.rs
@@ -68,12 +68,10 @@ pub struct SequentialBinaryStorageComponent<
 }
 
 impl<
-        F: 'static
-            + hil::flash::Flash
-            + hil::flash::HasClient<'static, NonvolatileToPages<'static, F>>,
-        C: 'static + Chip,
-        D: 'static + ProcessStandardDebug,
-    > SequentialBinaryStorageComponent<F, C, D>
+    F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, NonvolatileToPages<'static, F>>,
+    C: 'static + Chip,
+    D: 'static + ProcessStandardDebug,
+> SequentialBinaryStorageComponent<F, C, D>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
@@ -89,12 +87,10 @@ impl<
 }
 
 impl<
-        F: 'static
-            + hil::flash::Flash
-            + hil::flash::HasClient<'static, NonvolatileToPages<'static, F>>,
-        C: 'static + Chip,
-        D: 'static + ProcessStandardDebug,
-    > Component for SequentialBinaryStorageComponent<F, C, D>
+    F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, NonvolatileToPages<'static, F>>,
+    C: 'static + Chip,
+    D: 'static + ProcessStandardDebug,
+> Component for SequentialBinaryStorageComponent<F, C, D>
 {
     type StaticInput = (
         &'static mut MaybeUninit<<F as hil::flash::Flash>::Page>,

--- a/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
@@ -86,12 +86,16 @@ type RngDriver = components::rng::RngComponentType<nrf52833::trng::Trng<'static>
 type Ieee802154RawDriver =
     components::ieee802154::Ieee802154RawComponentType<nrf52833::ieee802154_radio::Radio<'static>>;
 type NonVolatilePages = components::dynamic_binary_storage::NVPages<nrf52833::nvmc::Nvmc>;
+/// Needed for dynamic binary storage capsule.
+pub struct PMCap;
+unsafe impl capabilities::ProcessManagementCapability for PMCap {}
 type DynamicBinaryStorage<'a> = kernel::dynamic_binary_storage::SequentialDynamicBinaryStorage<
     'static,
     'static,
     nrf52833::chip::NRF52<'a, Nrf52833DefaultPeripherals<'a>>,
     kernel::process::ProcessStandardDebugFull,
     NonVolatilePages,
+    PMCap,
 >;
 type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
 
@@ -871,11 +875,13 @@ unsafe fn start() -> (
             board_kernel,
             &base_peripherals.nvmc,
             loader,
+            PMCap,
         )
         .finalize(components::sequential_binary_storage_component_static!(
             nrf52833::nvmc::Nvmc,
             nrf52833::chip::NRF52<Nrf52833DefaultPeripherals>,
             kernel::process::ProcessStandardDebugFull,
+            PMCap,
         ));
 
     // Create the dynamic app loader capsule.

--- a/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
@@ -884,8 +884,8 @@ unsafe fn start() -> (
         capsules_extra::app_loader::DRIVER_NUM,
         dynamic_binary_storage,
         dynamic_binary_storage,
-        create_capability!(capabilities::MemoryAllocationCapability),
         dynamic_binary_storage,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::app_loader_component_static!(
         DynamicBinaryStorage<'static>,

--- a/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
@@ -86,7 +86,7 @@ type RngDriver = components::rng::RngComponentType<nrf52833::trng::Trng<'static>
 type Ieee802154RawDriver =
     components::ieee802154::Ieee802154RawComponentType<nrf52833::ieee802154_radio::Radio<'static>>;
 type NonVolatilePages = components::dynamic_binary_storage::NVPages<nrf52833::nvmc::Nvmc>;
-/// Needed for dynamic binary storage capsule.
+/// Needed for apploader capsule.
 pub struct PMCap;
 unsafe impl capabilities::ProcessManagementCapability for PMCap {}
 type DynamicBinaryStorage<'a> = kernel::dynamic_binary_storage::SequentialDynamicBinaryStorage<
@@ -95,7 +95,6 @@ type DynamicBinaryStorage<'a> = kernel::dynamic_binary_storage::SequentialDynami
     nrf52833::chip::NRF52<'a, Nrf52833DefaultPeripherals<'a>>,
     kernel::process::ProcessStandardDebugFull,
     NonVolatilePages,
-    PMCap,
 >;
 type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
 
@@ -160,6 +159,7 @@ pub struct MicroBit {
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
+        PMCap,
     >,
 
     scheduler: &'static SchedulerInUse,
@@ -875,13 +875,11 @@ unsafe fn start() -> (
             board_kernel,
             &base_peripherals.nvmc,
             loader,
-            PMCap,
         )
         .finalize(components::sequential_binary_storage_component_static!(
             nrf52833::nvmc::Nvmc,
             nrf52833::chip::NRF52<Nrf52833DefaultPeripherals>,
             kernel::process::ProcessStandardDebugFull,
-            PMCap,
         ));
 
     // Create the dynamic app loader capsule.
@@ -892,11 +890,13 @@ unsafe fn start() -> (
         dynamic_binary_storage,
         create_capability!(capabilities::MemoryAllocationCapability),
         dynamic_binary_storage,
+        PMCap,
     )
     .finalize(components::app_loader_component_static!(
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
+        PMCap,
     ));
 
     //--------------------------------------------------------------------------

--- a/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
@@ -86,16 +86,12 @@ type RngDriver = components::rng::RngComponentType<nrf52833::trng::Trng<'static>
 type Ieee802154RawDriver =
     components::ieee802154::Ieee802154RawComponentType<nrf52833::ieee802154_radio::Radio<'static>>;
 type NonVolatilePages = components::dynamic_binary_storage::NVPages<nrf52833::nvmc::Nvmc>;
-/// Needed for dynamic binary storage capsule.
-pub struct PMCap;
-unsafe impl capabilities::ProcessManagementCapability for PMCap {}
 type DynamicBinaryStorage<'a> = kernel::dynamic_binary_storage::SequentialDynamicBinaryStorage<
     'static,
     'static,
     nrf52833::chip::NRF52<'a, Nrf52833DefaultPeripherals<'a>>,
     kernel::process::ProcessStandardDebugFull,
     NonVolatilePages,
-    PMCap,
 >;
 type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
 
@@ -157,6 +153,7 @@ pub struct MicroBit {
     app_flash: &'static capsules_extra::app_flash_driver::AppFlash<'static>,
     sound_pressure: &'static capsules_extra::sound_pressure::SoundPressureSensor<'static>,
     dynamic_app_loader: &'static capsules_extra::app_loader::AppLoader<
+        DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
     >,
@@ -874,13 +871,11 @@ unsafe fn start() -> (
             board_kernel,
             &base_peripherals.nvmc,
             loader,
-            PMCap,
         )
         .finalize(components::sequential_binary_storage_component_static!(
             nrf52833::nvmc::Nvmc,
             nrf52833::chip::NRF52<Nrf52833DefaultPeripherals>,
             kernel::process::ProcessStandardDebugFull,
-            PMCap,
         ));
 
     // Create the dynamic app loader capsule.
@@ -890,8 +885,10 @@ unsafe fn start() -> (
         dynamic_binary_storage,
         dynamic_binary_storage,
         create_capability!(capabilities::MemoryAllocationCapability),
+        dynamic_binary_storage,
     )
     .finalize(components::app_loader_component_static!(
+        DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
     ));

--- a/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
@@ -86,9 +86,6 @@ type RngDriver = components::rng::RngComponentType<nrf52833::trng::Trng<'static>
 type Ieee802154RawDriver =
     components::ieee802154::Ieee802154RawComponentType<nrf52833::ieee802154_radio::Radio<'static>>;
 type NonVolatilePages = components::dynamic_binary_storage::NVPages<nrf52833::nvmc::Nvmc>;
-/// Needed for apploader capsule.
-pub struct PMCap;
-unsafe impl capabilities::ProcessManagementCapability for PMCap {}
 type DynamicBinaryStorage<'a> = kernel::dynamic_binary_storage::SequentialDynamicBinaryStorage<
     'static,
     'static,
@@ -159,7 +156,6 @@ pub struct MicroBit {
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
-        PMCap,
     >,
 
     scheduler: &'static SchedulerInUse,
@@ -890,13 +886,11 @@ unsafe fn start() -> (
         dynamic_binary_storage,
         create_capability!(capabilities::MemoryAllocationCapability),
         dynamic_binary_storage,
-        PMCap,
     )
     .finalize(components::app_loader_component_static!(
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
-        PMCap,
     ));
 
     //--------------------------------------------------------------------------

--- a/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
@@ -86,12 +86,16 @@ type RngDriver = components::rng::RngComponentType<nrf52833::trng::Trng<'static>
 type Ieee802154RawDriver =
     components::ieee802154::Ieee802154RawComponentType<nrf52833::ieee802154_radio::Radio<'static>>;
 type NonVolatilePages = components::dynamic_binary_storage::NVPages<nrf52833::nvmc::Nvmc>;
+/// Needed for dynamic binary storage capsule.
+pub struct PMCap;
+unsafe impl capabilities::ProcessManagementCapability for PMCap {}
 type DynamicBinaryStorage<'a> = kernel::dynamic_binary_storage::SequentialDynamicBinaryStorage<
     'static,
     'static,
     nrf52833::chip::NRF52<'a, Nrf52833DefaultPeripherals<'a>>,
     kernel::process::ProcessStandardDebugFull,
     NonVolatilePages,
+    PMCap,
 >;
 type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
 
@@ -867,13 +871,16 @@ unsafe fn start() -> (
     // Create the dynamic binary flasher.
     let dynamic_binary_storage =
         components::dynamic_binary_storage::SequentialBinaryStorageComponent::new(
+            board_kernel,
             &base_peripherals.nvmc,
             loader,
+            PMCap,
         )
         .finalize(components::sequential_binary_storage_component_static!(
             nrf52833::nvmc::Nvmc,
             nrf52833::chip::NRF52<Nrf52833DefaultPeripherals>,
             kernel::process::ProcessStandardDebugFull,
+            PMCap,
         ));
 
     // Create the dynamic app loader capsule.

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
@@ -71,12 +71,17 @@ kernel::stack_size! {0x2000}
 type AlarmDriver = components::alarm::AlarmDriverComponentType<nrf52840::rtc::Rtc<'static>>;
 
 type NonVolatilePages = components::dynamic_binary_storage::NVPages<nrf52840::nvmc::Nvmc>;
+
+/// Needed for dynamic binary storage capsule.
+pub struct PMCap;
+unsafe impl kernel::capabilities::ProcessManagementCapability for PMCap {}
 type DynamicBinaryStorage<'a> = kernel::dynamic_binary_storage::SequentialDynamicBinaryStorage<
     'static,
     'static,
     nrf52840::chip::NRF52<'a, Nrf52840DefaultPeripherals<'a>>,
     kernel::process::ProcessStandardDebugFull,
     NonVolatilePages,
+    PMCap,
 >;
 
 type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
@@ -493,11 +498,13 @@ pub unsafe fn main() {
             board_kernel,
             &base_peripherals.nvmc,
             loader,
+            PMCap,
         )
         .finalize(components::sequential_binary_storage_component_static!(
             nrf52840::nvmc::Nvmc,
             nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
             kernel::process::ProcessStandardDebugFull,
+            PMCap,
         ));
 
     // Create the dynamic app loader capsule.

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
@@ -72,7 +72,7 @@ type AlarmDriver = components::alarm::AlarmDriverComponentType<nrf52840::rtc::Rt
 
 type NonVolatilePages = components::dynamic_binary_storage::NVPages<nrf52840::nvmc::Nvmc>;
 
-/// Needed for dynamic binary storage capsule.
+/// Needed for apploader capsule.
 pub struct PMCap;
 unsafe impl kernel::capabilities::ProcessManagementCapability for PMCap {}
 type DynamicBinaryStorage<'a> = kernel::dynamic_binary_storage::SequentialDynamicBinaryStorage<
@@ -81,7 +81,6 @@ type DynamicBinaryStorage<'a> = kernel::dynamic_binary_storage::SequentialDynami
     nrf52840::chip::NRF52<'a, Nrf52840DefaultPeripherals<'a>>,
     kernel::process::ProcessStandardDebugFull,
     NonVolatilePages,
-    PMCap,
 >;
 
 type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
@@ -104,6 +103,7 @@ pub struct Platform {
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
+        PMCap,
     >,
 }
 
@@ -498,13 +498,11 @@ pub unsafe fn main() {
             board_kernel,
             &base_peripherals.nvmc,
             loader,
-            PMCap,
         )
         .finalize(components::sequential_binary_storage_component_static!(
             nrf52840::nvmc::Nvmc,
             nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
             kernel::process::ProcessStandardDebugFull,
-            PMCap,
         ));
 
     // Create the dynamic app loader capsule.
@@ -515,11 +513,13 @@ pub unsafe fn main() {
         dynamic_binary_storage,
         create_capability!(capabilities::MemoryAllocationCapability),
         dynamic_binary_storage,
+        PMCap,
     )
     .finalize(components::app_loader_component_static!(
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
+        PMCap,
     ));
 
     //--------------------------------------------------------------------------

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
@@ -71,12 +71,16 @@ kernel::stack_size! {0x2000}
 type AlarmDriver = components::alarm::AlarmDriverComponentType<nrf52840::rtc::Rtc<'static>>;
 
 type NonVolatilePages = components::dynamic_binary_storage::NVPages<nrf52840::nvmc::Nvmc>;
+/// Needed for dynamic binary storage capsule.
+pub struct PMCap;
+unsafe impl kernel::capabilities::ProcessManagementCapability for PMCap {}
 type DynamicBinaryStorage<'a> = kernel::dynamic_binary_storage::SequentialDynamicBinaryStorage<
     'static,
     'static,
     nrf52840::chip::NRF52<'a, Nrf52840DefaultPeripherals<'a>>,
     kernel::process::ProcessStandardDebugFull,
     NonVolatilePages,
+    PMCap,
 >;
 
 type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
@@ -489,13 +493,16 @@ pub unsafe fn main() {
     // Create the dynamic binary flasher.
     let dynamic_binary_storage =
         components::dynamic_binary_storage::SequentialBinaryStorageComponent::new(
+            board_kernel,
             &base_peripherals.nvmc,
             loader,
+            PMCap,
         )
         .finalize(components::sequential_binary_storage_component_static!(
             nrf52840::nvmc::Nvmc,
             nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
             kernel::process::ProcessStandardDebugFull,
+            PMCap,
         ));
 
     // Create the dynamic app loader capsule.

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
@@ -72,9 +72,6 @@ type AlarmDriver = components::alarm::AlarmDriverComponentType<nrf52840::rtc::Rt
 
 type NonVolatilePages = components::dynamic_binary_storage::NVPages<nrf52840::nvmc::Nvmc>;
 
-/// Needed for apploader capsule.
-pub struct PMCap;
-unsafe impl kernel::capabilities::ProcessManagementCapability for PMCap {}
 type DynamicBinaryStorage<'a> = kernel::dynamic_binary_storage::SequentialDynamicBinaryStorage<
     'static,
     'static,
@@ -103,7 +100,6 @@ pub struct Platform {
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
-        PMCap,
     >,
 }
 
@@ -513,13 +509,11 @@ pub unsafe fn main() {
         dynamic_binary_storage,
         create_capability!(capabilities::MemoryAllocationCapability),
         dynamic_binary_storage,
-        PMCap,
     )
     .finalize(components::app_loader_component_static!(
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
-        PMCap,
     ));
 
     //--------------------------------------------------------------------------

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
@@ -71,16 +71,12 @@ kernel::stack_size! {0x2000}
 type AlarmDriver = components::alarm::AlarmDriverComponentType<nrf52840::rtc::Rtc<'static>>;
 
 type NonVolatilePages = components::dynamic_binary_storage::NVPages<nrf52840::nvmc::Nvmc>;
-/// Needed for dynamic binary storage capsule.
-pub struct PMCap;
-unsafe impl kernel::capabilities::ProcessManagementCapability for PMCap {}
 type DynamicBinaryStorage<'a> = kernel::dynamic_binary_storage::SequentialDynamicBinaryStorage<
     'static,
     'static,
     nrf52840::chip::NRF52<'a, Nrf52840DefaultPeripherals<'a>>,
     kernel::process::ProcessStandardDebugFull,
     NonVolatilePages,
-    PMCap,
 >;
 
 type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
@@ -100,6 +96,7 @@ pub struct Platform {
     systick: cortexm4::systick::SysTick,
     processes: &'static ProcessArray<NUM_PROCS>,
     dynamic_app_loader: &'static capsules_extra::app_loader::AppLoader<
+        DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
     >,
@@ -496,13 +493,11 @@ pub unsafe fn main() {
             board_kernel,
             &base_peripherals.nvmc,
             loader,
-            PMCap,
         )
         .finalize(components::sequential_binary_storage_component_static!(
             nrf52840::nvmc::Nvmc,
             nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
             kernel::process::ProcessStandardDebugFull,
-            PMCap,
         ));
 
     // Create the dynamic app loader capsule.
@@ -512,8 +507,10 @@ pub unsafe fn main() {
         dynamic_binary_storage,
         dynamic_binary_storage,
         create_capability!(capabilities::MemoryAllocationCapability),
+        dynamic_binary_storage,
     )
     .finalize(components::app_loader_component_static!(
+        DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
     ));

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
@@ -507,8 +507,8 @@ pub unsafe fn main() {
         capsules_extra::app_loader::DRIVER_NUM,
         dynamic_binary_storage,
         dynamic_binary_storage,
-        create_capability!(capabilities::MemoryAllocationCapability),
         dynamic_binary_storage,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::app_loader_component_static!(
         DynamicBinaryStorage<'static>,

--- a/boards/tutorials/nrf52840dk-dynamic-apps-and-policies/src/main.rs
+++ b/boards/tutorials/nrf52840dk-dynamic-apps-and-policies/src/main.rs
@@ -78,9 +78,9 @@ type DynamicBinaryStorage<'a> = kernel::dynamic_binary_storage::SequentialDynami
     nrf52840::chip::NRF52<'a, Nrf52840DefaultPeripherals<'a>>,
     kernel::process::ProcessStandardDebugFull,
     NonVolatilePages,
-    PMCapability,
 >;
 type AppLoaderDriver = capsules_extra::app_loader::AppLoader<
+    DynamicBinaryStorage<'static>,
     DynamicBinaryStorage<'static>,
     DynamicBinaryStorage<'static>,
 >;
@@ -514,13 +514,11 @@ pub unsafe fn main() {
             board_kernel,
             virtual_flash_dbs,
             loader,
-            PMCapability,
         )
         .finalize(components::sequential_binary_storage_component_static!(
             FlashUser,
             nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
             kernel::process::ProcessStandardDebugFull,
-            PMCapability,
         ));
 
     // Create the dynamic app loader capsule.
@@ -530,8 +528,10 @@ pub unsafe fn main() {
         dynamic_binary_storage,
         dynamic_binary_storage,
         create_capability!(capabilities::MemoryAllocationCapability),
+        dynamic_binary_storage,
     )
     .finalize(components::app_loader_component_static!(
+        DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
     ));

--- a/boards/tutorials/nrf52840dk-dynamic-apps-and-policies/src/main.rs
+++ b/boards/tutorials/nrf52840dk-dynamic-apps-and-policies/src/main.rs
@@ -527,8 +527,8 @@ pub unsafe fn main() {
         capsules_extra::app_loader::DRIVER_NUM,
         dynamic_binary_storage,
         dynamic_binary_storage,
-        create_capability!(capabilities::MemoryAllocationCapability),
         dynamic_binary_storage,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::app_loader_component_static!(
         DynamicBinaryStorage<'static>,

--- a/boards/tutorials/nrf52840dk-dynamic-apps-and-policies/src/main.rs
+++ b/boards/tutorials/nrf52840dk-dynamic-apps-and-policies/src/main.rs
@@ -47,7 +47,7 @@ const SIGNATURE_SIG_LEN: usize = 64;
 // SYSCALL DRIVER TYPE DEFINITIONS
 //------------------------------------------------------------------------------
 
-/// Needed for process info capsule.
+/// Needed for process info and apploader capsules.
 pub struct PMCapability;
 unsafe impl capabilities::ProcessManagementCapability for PMCapability {}
 unsafe impl capabilities::ProcessStartCapability for PMCapability {}
@@ -78,12 +78,12 @@ type DynamicBinaryStorage<'a> = kernel::dynamic_binary_storage::SequentialDynami
     nrf52840::chip::NRF52<'a, Nrf52840DefaultPeripherals<'a>>,
     kernel::process::ProcessStandardDebugFull,
     NonVolatilePages,
-    PMCapability,
 >;
 type AppLoaderDriver = capsules_extra::app_loader::AppLoader<
     DynamicBinaryStorage<'static>,
     DynamicBinaryStorage<'static>,
     DynamicBinaryStorage<'static>,
+    PMCapability,
 >;
 
 type Verifier = ecdsa_sw::p256_verifier::EcdsaP256SignatureVerifier<'static>;
@@ -515,13 +515,11 @@ pub unsafe fn main() {
             board_kernel,
             virtual_flash_dbs,
             loader,
-            PMCapability,
         )
         .finalize(components::sequential_binary_storage_component_static!(
             FlashUser,
             nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
             kernel::process::ProcessStandardDebugFull,
-            PMCapability,
         ));
 
     // Create the dynamic app loader capsule.
@@ -532,11 +530,13 @@ pub unsafe fn main() {
         dynamic_binary_storage,
         create_capability!(capabilities::MemoryAllocationCapability),
         dynamic_binary_storage,
+        PMCapability,
     )
     .finalize(components::app_loader_component_static!(
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
+        PMCapability,
     ));
 
     //--------------------------------------------------------------------------

--- a/boards/tutorials/nrf52840dk-dynamic-apps-and-policies/src/main.rs
+++ b/boards/tutorials/nrf52840dk-dynamic-apps-and-policies/src/main.rs
@@ -47,7 +47,7 @@ const SIGNATURE_SIG_LEN: usize = 64;
 // SYSCALL DRIVER TYPE DEFINITIONS
 //------------------------------------------------------------------------------
 
-/// Needed for process info and apploader capsules.
+/// Needed for process info capsule.
 pub struct PMCapability;
 unsafe impl capabilities::ProcessManagementCapability for PMCapability {}
 unsafe impl capabilities::ProcessStartCapability for PMCapability {}
@@ -83,7 +83,6 @@ type AppLoaderDriver = capsules_extra::app_loader::AppLoader<
     DynamicBinaryStorage<'static>,
     DynamicBinaryStorage<'static>,
     DynamicBinaryStorage<'static>,
-    PMCapability,
 >;
 
 type Verifier = ecdsa_sw::p256_verifier::EcdsaP256SignatureVerifier<'static>;
@@ -530,13 +529,11 @@ pub unsafe fn main() {
         dynamic_binary_storage,
         create_capability!(capabilities::MemoryAllocationCapability),
         dynamic_binary_storage,
-        PMCapability,
     )
     .finalize(components::app_loader_component_static!(
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
-        PMCapability,
     ));
 
     //--------------------------------------------------------------------------

--- a/boards/tutorials/nrf52840dk-dynamic-apps-and-policies/src/main.rs
+++ b/boards/tutorials/nrf52840dk-dynamic-apps-and-policies/src/main.rs
@@ -78,6 +78,7 @@ type DynamicBinaryStorage<'a> = kernel::dynamic_binary_storage::SequentialDynami
     nrf52840::chip::NRF52<'a, Nrf52840DefaultPeripherals<'a>>,
     kernel::process::ProcessStandardDebugFull,
     NonVolatilePages,
+    PMCapability,
 >;
 type AppLoaderDriver = capsules_extra::app_loader::AppLoader<
     DynamicBinaryStorage<'static>,
@@ -510,13 +511,16 @@ pub unsafe fn main() {
     // Create the dynamic binary flasher.
     let dynamic_binary_storage =
         components::dynamic_binary_storage::SequentialBinaryStorageComponent::new(
+            board_kernel,
             virtual_flash_dbs,
             loader,
+            PMCapability,
         )
         .finalize(components::sequential_binary_storage_component_static!(
             FlashUser,
             nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
             kernel::process::ProcessStandardDebugFull,
+            PMCapability,
         ));
 
     // Create the dynamic app loader capsule.

--- a/boards/tutorials/nrf52840dk-dynamic-apps-and-policies/src/main.rs
+++ b/boards/tutorials/nrf52840dk-dynamic-apps-and-policies/src/main.rs
@@ -78,6 +78,7 @@ type DynamicBinaryStorage<'a> = kernel::dynamic_binary_storage::SequentialDynami
     nrf52840::chip::NRF52<'a, Nrf52840DefaultPeripherals<'a>>,
     kernel::process::ProcessStandardDebugFull,
     NonVolatilePages,
+    PMCapability,
 >;
 type AppLoaderDriver = capsules_extra::app_loader::AppLoader<
     DynamicBinaryStorage<'static>,
@@ -514,11 +515,13 @@ pub unsafe fn main() {
             board_kernel,
             virtual_flash_dbs,
             loader,
+            PMCapability,
         )
         .finalize(components::sequential_binary_storage_component_static!(
             FlashUser,
             nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
             kernel::process::ProcessStandardDebugFull,
+            PMCapability,
         ));
 
     // Create the dynamic app loader capsule.

--- a/capsules/extra/src/app_loader.rs
+++ b/capsules/extra/src/app_loader.rs
@@ -362,7 +362,7 @@ impl<
 {
     /// Let the app know we have unloaded the target process
     /// and return an opaque identifier for the process binary
-    fn unload_done(&self, result: Result<(), ErrorCode>, app_identifier: Option<usize>) {
+    fn unload_done(&self, result: Result<(), ErrorCode>, app_handle: usize) {
         self.current_process.map(|processid| {
             let _ = self.apps.enter(processid, move |app, kernel_data| {
                 // And then signal the app.
@@ -372,7 +372,7 @@ impl<
                 let _ = kernel_data
                     .schedule_upcall(
                         upcall::UNLOAD_DONE,
-                        (into_statuscode(result), app_identifier.unwrap_or(0), 0),
+                        (into_statuscode(result), app_handle, 0),
                     )
                     .ok();
             });

--- a/capsules/extra/src/app_loader.rs
+++ b/capsules/extra/src/app_loader.rs
@@ -425,7 +425,7 @@ impl<
     ///    unable to be written, so try again)
     ///  - Returns ErrorCode::FAIL if the driver is not dedicated to this process
     /// - `6`: Request kernel to unload a processs
-    ///  - Returns Ok(identifier) when the application is successfully scheduled for unload
+    ///  - Returns Ok(()) when the application is successfully scheduled for unload
     ///  - Returns ErrorCode::FAIL when the unload fails
     /// The driver returns ErrorCode::INVAL if any operation is called before the
     /// preceeding operation was invoked. For example, `write()` cannot be called before

--- a/capsules/extra/src/app_loader.rs
+++ b/capsules/extra/src/app_loader.rs
@@ -427,6 +427,7 @@ impl<
     /// - `6`: Request kernel to unload a processs
     ///  - Returns Ok(()) when the application is successfully scheduled for unload
     ///  - Returns ErrorCode::FAIL when the unload fails
+    ///
     /// The driver returns ErrorCode::INVAL if any operation is called before the
     /// preceeding operation was invoked. For example, `write()` cannot be called before
     /// `setup()`, and `load()` cannot be called before `write()` (for this implementation).

--- a/capsules/extra/src/app_loader.rs
+++ b/capsules/extra/src/app_loader.rs
@@ -121,10 +121,12 @@ pub struct App {
 pub struct AppLoader<
     S: dynamic_binary_storage::DynamicBinaryStore + 'static,
     L: dynamic_binary_storage::DynamicProcessLoad + 'static,
+    T: dynamic_binary_storage::DynamicProcessUnload + 'static,
 > {
     // The underlying driver for the process flashing and loading.
     storage_driver: &'static S,
     load_driver: &'static L,
+    unload_driver: &'static T,
     // Per-app state.
     apps: Grant<
         App,
@@ -141,9 +143,10 @@ pub struct AppLoader<
 }
 
 impl<
-    S: dynamic_binary_storage::DynamicBinaryStore + 'static,
-    L: dynamic_binary_storage::DynamicProcessLoad + 'static,
-> AppLoader<S, L>
+        S: dynamic_binary_storage::DynamicBinaryStore + 'static,
+        L: dynamic_binary_storage::DynamicProcessLoad + 'static,
+        T: dynamic_binary_storage::DynamicProcessUnload + 'static,
+    > AppLoader<S, L, T>
 {
     pub fn new(
         grant: Grant<
@@ -154,12 +157,14 @@ impl<
         >,
         storage_driver: &'static S,
         load_driver: &'static L,
+        unload_driver: &'static T,
         buffer: &'static mut [u8],
-    ) -> AppLoader<S, L> {
+    ) -> AppLoader<S, L, T> {
         AppLoader {
             apps: grant,
             storage_driver,
             load_driver,
+            unload_driver,
             buffer: TakeCell::new(buffer),
             current_process: OptionalCell::empty(),
             new_app_length: Cell::new(0),
@@ -239,9 +244,10 @@ impl<
 }
 
 impl<
-    S: dynamic_binary_storage::DynamicBinaryStore + 'static,
-    L: dynamic_binary_storage::DynamicProcessLoad + 'static,
-> dynamic_binary_storage::DynamicBinaryStoreClient for AppLoader<S, L>
+        S: dynamic_binary_storage::DynamicBinaryStore + 'static,
+        L: dynamic_binary_storage::DynamicProcessLoad + 'static,
+        T: dynamic_binary_storage::DynamicProcessUnload + 'static,
+    > dynamic_binary_storage::DynamicBinaryStoreClient for AppLoader<S, L, T>
 {
     /// Let the requesting app know we are done setting up for the new app
     fn setup_done(&self, result: Result<(), ErrorCode>) {
@@ -302,9 +308,10 @@ impl<
 }
 
 impl<
-    S: dynamic_binary_storage::DynamicBinaryStore + 'static,
-    L: dynamic_binary_storage::DynamicProcessLoad + 'static,
-> dynamic_binary_storage::DynamicProcessLoadClient for AppLoader<S, L>
+        S: dynamic_binary_storage::DynamicBinaryStore + 'static,
+        L: dynamic_binary_storage::DynamicProcessLoad + 'static,
+        T: dynamic_binary_storage::DynamicProcessUnload + 'static,
+    > dynamic_binary_storage::DynamicProcessLoadClient for AppLoader<S, L, T>
 {
     /// Let the requesting app know we are done loading the new process
     ///
@@ -345,7 +352,14 @@ impl<
             });
         });
     }
+}
 
+impl<
+        S: dynamic_binary_storage::DynamicBinaryStore + 'static,
+        L: dynamic_binary_storage::DynamicProcessLoad + 'static,
+        T: dynamic_binary_storage::DynamicProcessUnload + 'static,
+    > dynamic_binary_storage::DynamicProcessUnloadClient for AppLoader<S, L, T>
+{
     /// Let the app know we have unloaded the target process
     /// and return an opaque identifier for the process binary
     fn unload_done(&self, result: Result<(), ErrorCode>, app_identifier: Option<usize>) {
@@ -368,9 +382,10 @@ impl<
 
 /// Provide an interface for userland.
 impl<
-    S: dynamic_binary_storage::DynamicBinaryStore + 'static,
-    L: dynamic_binary_storage::DynamicProcessLoad + 'static,
-> SyscallDriver for AppLoader<S, L>
+        S: dynamic_binary_storage::DynamicBinaryStore + 'static,
+        L: dynamic_binary_storage::DynamicProcessLoad + 'static,
+        T: dynamic_binary_storage::DynamicProcessUnload + 'static,
+    > SyscallDriver for AppLoader<S, L, T>
 {
     /// Command interface.
     ///
@@ -542,16 +557,14 @@ impl<
                     Some(id) => ShortId::Fixed(id),
                     None => return CommandReturn::failure(ErrorCode::INVAL),
                 };
-                self.load_driver.unload(shortid);
-                CommandReturn::success()
-                // let result = self.storage_driver.unload(shortid);
-                // match result {
-                //     Ok(()) => CommandReturn::success(),
-                //     Err(e) => {
-                //         self.current_process.take();
-                //         CommandReturn::failure(e)
-                //     }
-                // }
+                let res = self.unload_driver.unload(shortid);
+                match res {
+                    Ok(()) => CommandReturn::success(),
+                    Err(e) => {
+                        self.current_process.take();
+                        CommandReturn::failure(e)
+                    }
+                }
             }
             // Unsupported command numbers.
             _ => CommandReturn::failure(ErrorCode::NOSUPPORT),

--- a/capsules/extra/src/app_loader.rs
+++ b/capsules/extra/src/app_loader.rs
@@ -55,9 +55,13 @@
 //!     capsules_extra::app_loader::DRIVER_NUM,
 //!     dynamic_binary_storage,
 //!     dynamic_binary_storage,
+//!     dynamic_binary_storage,
+//!     PMCapability,
 //!     ).finalize(components::app_loader_component_static!(
 //!     DynamicBinaryStorage<'static>,
 //!     DynamicBinaryStorage<'static>,
+//!     DynamicBinaryStorage<'static>,
+//!     PMCapability,
 //!     ));
 //!
 //! NOTE:
@@ -69,6 +73,7 @@ use core::cell::Cell;
 use core::cmp;
 use core::num::NonZeroU32;
 
+use kernel::capabilities::ProcessManagementCapability;
 use kernel::dynamic_binary_storage;
 use kernel::errorcode::into_statuscode;
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
@@ -122,11 +127,13 @@ pub struct AppLoader<
     S: dynamic_binary_storage::DynamicBinaryStore + 'static,
     L: dynamic_binary_storage::DynamicProcessLoad + 'static,
     T: dynamic_binary_storage::DynamicProcessUnload + 'static,
+    P: ProcessManagementCapability + 'static,
 > {
     // The underlying driver for the process flashing and loading.
     storage_driver: &'static S,
     load_driver: &'static L,
     unload_driver: &'static T,
+    capability: P,
     // Per-app state.
     apps: Grant<
         App,
@@ -146,7 +153,8 @@ impl<
         S: dynamic_binary_storage::DynamicBinaryStore + 'static,
         L: dynamic_binary_storage::DynamicProcessLoad + 'static,
         T: dynamic_binary_storage::DynamicProcessUnload + 'static,
-    > AppLoader<S, L, T>
+        P: ProcessManagementCapability + 'static,
+    > AppLoader<S, L, T, P>
 {
     pub fn new(
         grant: Grant<
@@ -158,13 +166,15 @@ impl<
         storage_driver: &'static S,
         load_driver: &'static L,
         unload_driver: &'static T,
+        capability: P,
         buffer: &'static mut [u8],
-    ) -> AppLoader<S, L, T> {
+    ) -> AppLoader<S, L, T, P> {
         AppLoader {
             apps: grant,
             storage_driver,
             load_driver,
             unload_driver,
+            capability,
             buffer: TakeCell::new(buffer),
             current_process: OptionalCell::empty(),
             new_app_length: Cell::new(0),
@@ -247,7 +257,8 @@ impl<
         S: dynamic_binary_storage::DynamicBinaryStore + 'static,
         L: dynamic_binary_storage::DynamicProcessLoad + 'static,
         T: dynamic_binary_storage::DynamicProcessUnload + 'static,
-    > dynamic_binary_storage::DynamicBinaryStoreClient for AppLoader<S, L, T>
+        P: ProcessManagementCapability + 'static,
+    > dynamic_binary_storage::DynamicBinaryStoreClient for AppLoader<S, L, T, P>
 {
     /// Let the requesting app know we are done setting up for the new app
     fn setup_done(&self, result: Result<(), ErrorCode>) {
@@ -311,7 +322,8 @@ impl<
         S: dynamic_binary_storage::DynamicBinaryStore + 'static,
         L: dynamic_binary_storage::DynamicProcessLoad + 'static,
         T: dynamic_binary_storage::DynamicProcessUnload + 'static,
-    > dynamic_binary_storage::DynamicProcessLoadClient for AppLoader<S, L, T>
+        P: ProcessManagementCapability + 'static,
+    > dynamic_binary_storage::DynamicProcessLoadClient for AppLoader<S, L, T, P>
 {
     /// Let the requesting app know we are done loading the new process
     ///
@@ -358,7 +370,8 @@ impl<
         S: dynamic_binary_storage::DynamicBinaryStore + 'static,
         L: dynamic_binary_storage::DynamicProcessLoad + 'static,
         T: dynamic_binary_storage::DynamicProcessUnload + 'static,
-    > dynamic_binary_storage::DynamicProcessUnloadClient for AppLoader<S, L, T>
+        P: ProcessManagementCapability + 'static,
+    > dynamic_binary_storage::DynamicProcessUnloadClient for AppLoader<S, L, T, P>
 {
     /// Let the app know we have unloaded the target process
     /// and return an opaque identifier for the process binary
@@ -369,12 +382,10 @@ impl<
                 app.pending_command = false;
 
                 self.current_process.take();
-                let _ = kernel_data
-                    .schedule_upcall(
-                        upcall::UNLOAD_DONE,
-                        (into_statuscode(result), app_handle, 0),
-                    )
-                    .ok();
+                let _ = kernel_data.schedule_upcall(
+                    upcall::UNLOAD_DONE,
+                    (into_statuscode(result), app_handle, 0),
+                );
             });
         });
     }
@@ -385,7 +396,8 @@ impl<
         S: dynamic_binary_storage::DynamicBinaryStore + 'static,
         L: dynamic_binary_storage::DynamicProcessLoad + 'static,
         T: dynamic_binary_storage::DynamicProcessUnload + 'static,
-    > SyscallDriver for AppLoader<S, L, T>
+        P: ProcessManagementCapability + 'static,
+    > SyscallDriver for AppLoader<S, L, T, P>
 {
     /// Command interface.
     ///
@@ -427,6 +439,7 @@ impl<
     /// - `6`: Request kernel to unload a processs
     ///  - Returns Ok(()) when the application is successfully scheduled for unload
     ///  - Returns ErrorCode::FAIL when the unload fails
+    ///  - This operation requires a process management capability
     ///
     /// The driver returns ErrorCode::INVAL if any operation is called before the
     /// preceeding operation was invoked. For example, `write()` cannot be called before
@@ -553,12 +566,12 @@ impl<
                 // Request the kernel to unload a process
                 // by specifying its ShortId
 
-                // returns only the address of the active process (which is the latest version). we need to be able to uninstall any version
+                // Returns only the address of the active process (which is the latest version). we need to be able to uninstall any version
                 let shortid = match NonZeroU32::new(arg1 as u32) {
                     Some(id) => ShortId::Fixed(id),
                     None => return CommandReturn::failure(ErrorCode::INVAL),
                 };
-                let res = self.unload_driver.unload(shortid);
+                let res = self.unload_driver.unload(shortid, &self.capability);
                 match res {
                     Ok(()) => CommandReturn::success(),
                     Err(e) => {

--- a/capsules/extra/src/app_loader.rs
+++ b/capsules/extra/src/app_loader.rs
@@ -56,12 +56,10 @@
 //!     dynamic_binary_storage,
 //!     dynamic_binary_storage,
 //!     dynamic_binary_storage,
-//!     PMCapability,
 //!     ).finalize(components::app_loader_component_static!(
 //!     DynamicBinaryStorage<'static>,
 //!     DynamicBinaryStorage<'static>,
 //!     DynamicBinaryStorage<'static>,
-//!     PMCapability,
 //!     ));
 //!
 //! NOTE:
@@ -73,7 +71,6 @@ use core::cell::Cell;
 use core::cmp;
 use core::num::NonZeroU32;
 
-use kernel::capabilities::ProcessManagementCapability;
 use kernel::dynamic_binary_storage;
 use kernel::errorcode::into_statuscode;
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
@@ -127,13 +124,11 @@ pub struct AppLoader<
     S: dynamic_binary_storage::DynamicBinaryStore + 'static,
     L: dynamic_binary_storage::DynamicProcessLoad + 'static,
     T: dynamic_binary_storage::DynamicProcessUnload + 'static,
-    P: ProcessManagementCapability + 'static,
 > {
     // The underlying driver for the process flashing and loading.
     storage_driver: &'static S,
     load_driver: &'static L,
     unload_driver: &'static T,
-    capability: P,
     // Per-app state.
     apps: Grant<
         App,
@@ -153,8 +148,7 @@ impl<
         S: dynamic_binary_storage::DynamicBinaryStore + 'static,
         L: dynamic_binary_storage::DynamicProcessLoad + 'static,
         T: dynamic_binary_storage::DynamicProcessUnload + 'static,
-        P: ProcessManagementCapability + 'static,
-    > AppLoader<S, L, T, P>
+    > AppLoader<S, L, T>
 {
     pub fn new(
         grant: Grant<
@@ -166,15 +160,13 @@ impl<
         storage_driver: &'static S,
         load_driver: &'static L,
         unload_driver: &'static T,
-        capability: P,
         buffer: &'static mut [u8],
-    ) -> AppLoader<S, L, T, P> {
+    ) -> AppLoader<S, L, T> {
         AppLoader {
             apps: grant,
             storage_driver,
             load_driver,
             unload_driver,
-            capability,
             buffer: TakeCell::new(buffer),
             current_process: OptionalCell::empty(),
             new_app_length: Cell::new(0),
@@ -257,8 +249,7 @@ impl<
         S: dynamic_binary_storage::DynamicBinaryStore + 'static,
         L: dynamic_binary_storage::DynamicProcessLoad + 'static,
         T: dynamic_binary_storage::DynamicProcessUnload + 'static,
-        P: ProcessManagementCapability + 'static,
-    > dynamic_binary_storage::DynamicBinaryStoreClient for AppLoader<S, L, T, P>
+    > dynamic_binary_storage::DynamicBinaryStoreClient for AppLoader<S, L, T>
 {
     /// Let the requesting app know we are done setting up for the new app
     fn setup_done(&self, result: Result<(), ErrorCode>) {
@@ -322,8 +313,7 @@ impl<
         S: dynamic_binary_storage::DynamicBinaryStore + 'static,
         L: dynamic_binary_storage::DynamicProcessLoad + 'static,
         T: dynamic_binary_storage::DynamicProcessUnload + 'static,
-        P: ProcessManagementCapability + 'static,
-    > dynamic_binary_storage::DynamicProcessLoadClient for AppLoader<S, L, T, P>
+    > dynamic_binary_storage::DynamicProcessLoadClient for AppLoader<S, L, T>
 {
     /// Let the requesting app know we are done loading the new process
     ///
@@ -370,8 +360,7 @@ impl<
         S: dynamic_binary_storage::DynamicBinaryStore + 'static,
         L: dynamic_binary_storage::DynamicProcessLoad + 'static,
         T: dynamic_binary_storage::DynamicProcessUnload + 'static,
-        P: ProcessManagementCapability + 'static,
-    > dynamic_binary_storage::DynamicProcessUnloadClient for AppLoader<S, L, T, P>
+    > dynamic_binary_storage::DynamicProcessUnloadClient for AppLoader<S, L, T>
 {
     /// Let the app know we have unloaded the target process
     /// and return an opaque identifier for the process binary
@@ -396,8 +385,7 @@ impl<
         S: dynamic_binary_storage::DynamicBinaryStore + 'static,
         L: dynamic_binary_storage::DynamicProcessLoad + 'static,
         T: dynamic_binary_storage::DynamicProcessUnload + 'static,
-        P: ProcessManagementCapability + 'static,
-    > SyscallDriver for AppLoader<S, L, T, P>
+    > SyscallDriver for AppLoader<S, L, T>
 {
     /// Command interface.
     ///
@@ -439,7 +427,6 @@ impl<
     /// - `6`: Request kernel to unload a processs
     ///  - Returns Ok(()) when the application is successfully scheduled for unload
     ///  - Returns ErrorCode::FAIL when the unload fails
-    ///  - This operation requires a process management capability
     ///
     /// The driver returns ErrorCode::INVAL if any operation is called before the
     /// preceeding operation was invoked. For example, `write()` cannot be called before
@@ -566,12 +553,12 @@ impl<
                 // Request the kernel to unload a process
                 // by specifying its ShortId
 
-                // Returns only the address of the active process (which is the latest version). we need to be able to uninstall any version
+                // returns only the address of the active process (which is the latest version). we need to be able to uninstall any version
                 let shortid = match NonZeroU32::new(arg1 as u32) {
                     Some(id) => ShortId::Fixed(id),
                     None => return CommandReturn::failure(ErrorCode::INVAL),
                 };
-                let res = self.unload_driver.unload(shortid, &self.capability);
+                let res = self.unload_driver.unload(shortid);
                 match res {
                     Ok(()) => CommandReturn::success(),
                     Err(e) => {

--- a/capsules/extra/src/app_loader.rs
+++ b/capsules/extra/src/app_loader.rs
@@ -67,11 +67,12 @@
 
 use core::cell::Cell;
 use core::cmp;
+use core::num::NonZeroU32;
 
 use kernel::dynamic_binary_storage;
 use kernel::errorcode::into_statuscode;
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::process::ProcessLoadError;
+use kernel::process::{ProcessLoadError, ShortId};
 use kernel::processbuffer::ReadableProcessBuffer;
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
@@ -94,8 +95,10 @@ mod upcall {
     pub const LOAD_DONE: usize = 3;
     /// Abort done callback.
     pub const ABORT_DONE: usize = 4;
+    /// Unload done callback.
+    pub const UNLOAD_DONE: usize = 5;
     /// Number of upcalls.
-    pub const COUNT: u8 = 5;
+    pub const COUNT: u8 = 6;
 }
 
 // Ids for read-only allow buffers
@@ -342,6 +345,25 @@ impl<
             });
         });
     }
+
+    /// Let the app know we have unloaded the target process
+    /// and return an opaque identifier for the process binary
+    fn unload_done(&self, result: Result<(), ErrorCode>, app_identifier: Option<usize>) {
+        self.current_process.map(|processid| {
+            let _ = self.apps.enter(processid, move |app, kernel_data| {
+                // And then signal the app.
+                app.pending_command = false;
+
+                self.current_process.take();
+                let _ = kernel_data
+                    .schedule_upcall(
+                        upcall::UNLOAD_DONE,
+                        (into_statuscode(result), app_identifier.unwrap_or(0), 0),
+                    )
+                    .ok();
+            });
+        });
+    }
 }
 
 /// Provide an interface for userland.
@@ -387,11 +409,12 @@ impl<
     ///  - Returns ErrorCode::BUSY when the abort fails(due to padding app being
     ///    unable to be written, so try again)
     ///  - Returns ErrorCode::FAIL if the driver is not dedicated to this process
-    ///
-    /// The driver returns ErrorCode::INVAL if any operation is called before
-    /// the preceding operation was invoked. For example, `write()` cannot be
-    /// called before `setup()`, and `load()` cannot be called before `write()`
-    /// (for this implementation).
+    /// - `6`: Request kernel to unload a processs
+    ///  - Returns Ok(identifier) when the application is successfully scheduled for unload
+    ///  - Returns ErrorCode::FAIL when the unload fails
+    /// The driver returns ErrorCode::INVAL if any operation is called before the
+    /// preceeding operation was invoked. For example, `write()` cannot be called before
+    /// `setup()`, and `load()` cannot be called before `write()` (for this implementation).
     fn command(
         &self,
         command_num: usize,
@@ -509,6 +532,26 @@ impl<
                         CommandReturn::failure(e)
                     }
                 }
+            }
+            6 => {
+                // Request the kernel to unload a process
+                // by specifying its ShortId
+
+                // returns only the address of the active process (which is the latest version). we need to be able to uninstall any version
+                let shortid = match NonZeroU32::new(arg1 as u32) {
+                    Some(id) => ShortId::Fixed(id),
+                    None => return CommandReturn::failure(ErrorCode::INVAL),
+                };
+                self.load_driver.unload(shortid);
+                CommandReturn::success()
+                // let result = self.storage_driver.unload(shortid);
+                // match result {
+                //     Ok(()) => CommandReturn::success(),
+                //     Err(e) => {
+                //         self.current_process.take();
+                //         CommandReturn::failure(e)
+                //     }
+                // }
             }
             // Unsupported command numbers.
             _ => CommandReturn::failure(ErrorCode::NOSUPPORT),

--- a/capsules/extra/src/app_loader.rs
+++ b/capsules/extra/src/app_loader.rs
@@ -56,6 +56,7 @@
 //!     dynamic_binary_storage,
 //!     dynamic_binary_storage,
 //!     dynamic_binary_storage,
+//!     create_capability!(capabilities::MemoryAllocationCapability),
 //!     ).finalize(components::app_loader_component_static!(
 //!     DynamicBinaryStorage<'static>,
 //!     DynamicBinaryStorage<'static>,
@@ -145,10 +146,10 @@ pub struct AppLoader<
 }
 
 impl<
-        S: dynamic_binary_storage::DynamicBinaryStore + 'static,
-        L: dynamic_binary_storage::DynamicProcessLoad + 'static,
-        T: dynamic_binary_storage::DynamicProcessUnload + 'static,
-    > AppLoader<S, L, T>
+    S: dynamic_binary_storage::DynamicBinaryStore + 'static,
+    L: dynamic_binary_storage::DynamicProcessLoad + 'static,
+    T: dynamic_binary_storage::DynamicProcessUnload + 'static,
+> AppLoader<S, L, T>
 {
     pub fn new(
         grant: Grant<
@@ -246,10 +247,10 @@ impl<
 }
 
 impl<
-        S: dynamic_binary_storage::DynamicBinaryStore + 'static,
-        L: dynamic_binary_storage::DynamicProcessLoad + 'static,
-        T: dynamic_binary_storage::DynamicProcessUnload + 'static,
-    > dynamic_binary_storage::DynamicBinaryStoreClient for AppLoader<S, L, T>
+    S: dynamic_binary_storage::DynamicBinaryStore + 'static,
+    L: dynamic_binary_storage::DynamicProcessLoad + 'static,
+    T: dynamic_binary_storage::DynamicProcessUnload + 'static,
+> dynamic_binary_storage::DynamicBinaryStoreClient for AppLoader<S, L, T>
 {
     /// Let the requesting app know we are done setting up for the new app
     fn setup_done(&self, result: Result<(), ErrorCode>) {
@@ -310,10 +311,10 @@ impl<
 }
 
 impl<
-        S: dynamic_binary_storage::DynamicBinaryStore + 'static,
-        L: dynamic_binary_storage::DynamicProcessLoad + 'static,
-        T: dynamic_binary_storage::DynamicProcessUnload + 'static,
-    > dynamic_binary_storage::DynamicProcessLoadClient for AppLoader<S, L, T>
+    S: dynamic_binary_storage::DynamicBinaryStore + 'static,
+    L: dynamic_binary_storage::DynamicProcessLoad + 'static,
+    T: dynamic_binary_storage::DynamicProcessUnload + 'static,
+> dynamic_binary_storage::DynamicProcessLoadClient for AppLoader<S, L, T>
 {
     /// Let the requesting app know we are done loading the new process
     ///
@@ -357,10 +358,10 @@ impl<
 }
 
 impl<
-        S: dynamic_binary_storage::DynamicBinaryStore + 'static,
-        L: dynamic_binary_storage::DynamicProcessLoad + 'static,
-        T: dynamic_binary_storage::DynamicProcessUnload + 'static,
-    > dynamic_binary_storage::DynamicProcessUnloadClient for AppLoader<S, L, T>
+    S: dynamic_binary_storage::DynamicBinaryStore + 'static,
+    L: dynamic_binary_storage::DynamicProcessLoad + 'static,
+    T: dynamic_binary_storage::DynamicProcessUnload + 'static,
+> dynamic_binary_storage::DynamicProcessUnloadClient for AppLoader<S, L, T>
 {
     /// Let the app know we have unloaded the target process
     /// and return an opaque identifier for the process binary
@@ -382,10 +383,10 @@ impl<
 
 /// Provide an interface for userland.
 impl<
-        S: dynamic_binary_storage::DynamicBinaryStore + 'static,
-        L: dynamic_binary_storage::DynamicProcessLoad + 'static,
-        T: dynamic_binary_storage::DynamicProcessUnload + 'static,
-    > SyscallDriver for AppLoader<S, L, T>
+    S: dynamic_binary_storage::DynamicBinaryStore + 'static,
+    L: dynamic_binary_storage::DynamicProcessLoad + 'static,
+    T: dynamic_binary_storage::DynamicProcessUnload + 'static,
+> SyscallDriver for AppLoader<S, L, T>
 {
     /// Command interface.
     ///

--- a/kernel/src/capabilities.rs
+++ b/kernel/src/capabilities.rs
@@ -70,10 +70,6 @@ pub unsafe trait ProcessManagementCapability {}
 /// Capabilities can only be created in trusted crates that can use `unsafe`.
 pub unsafe trait ProcessStartCapability {}
 
-/// `RemoveProcessFromActiveProcessesCapability` allows the holder to remove
-///  process from the `Processes` struct.
-pub unsafe trait RemoveProcessFromActiveProcessesCapability {}
-
 /// The `MainLoopCapability` capability allows the holder to start executing as
 /// well as manage the main scheduler loop in Tock.
 ///

--- a/kernel/src/capabilities.rs
+++ b/kernel/src/capabilities.rs
@@ -70,6 +70,10 @@ pub unsafe trait ProcessManagementCapability {}
 /// Capabilities can only be created in trusted crates that can use `unsafe`.
 pub unsafe trait ProcessStartCapability {}
 
+/// `RemoveProcessFromActiveProcessesCapability` allows the holder to remove
+///  process from the `Processes` struct.
+pub unsafe trait RemoveProcessFromActiveProcessesCapability {}
+
 /// The `MainLoopCapability` capability allows the holder to start executing as
 /// well as manage the main scheduler loop in Tock.
 ///

--- a/kernel/src/dynamic_binary_storage.rs
+++ b/kernel/src/dynamic_binary_storage.rs
@@ -37,7 +37,7 @@ pub enum State {
     AppWrite,
     Load,
     Abort,
-    Unload,
+    Unload(Result<(), ErrorCode>, Option<usize>),
     PaddingWrite,
     Fail,
 }
@@ -117,9 +117,6 @@ pub trait DynamicProcessLoad {
     /// Call to request kernel to load a new process.
     fn load(&self) -> Result<(), ErrorCode>;
 
-    /// Call to unload a process with given ShortId.
-    fn unload(&self, app: ShortId); // -> Result<(), ErrorCode>;
-
     /// Sets a client for the SequentialDynamicProcessLoading Object
     ///
     /// When the client operation is done, it calls the `load_done()`
@@ -127,11 +124,26 @@ pub trait DynamicProcessLoad {
     fn set_load_client(&self, client: &'static dyn DynamicProcessLoadClient);
 }
 
-/// The callback for dynamic binary flashing.
+/// The callback for dynamic process loading.
 pub trait DynamicProcessLoadClient {
     /// The new app has been loaded.
     fn load_done(&self, result: Result<(), ProcessLoadError>);
+}
 
+/// This interface supports unloading processes at runtime.
+pub trait DynamicProcessUnload {
+    /// Call to terminate a process with given ShortId.
+    fn unload(&self, app: ShortId) -> Result<(), ErrorCode>;
+
+    /// Sets a client for the SequentialDynamicProcessUnload Object
+    ///
+    /// When the client operation is done, it calls the `unload_done()`
+    /// function.
+    fn set_unload_client(&self, client: &'static dyn DynamicProcessUnloadClient);
+}
+
+/// The callback for dynamic process unloading.
+pub trait DynamicProcessUnloadClient {
     /// Terminated app (if running).
     fn unload_done(&self, result: Result<(), ErrorCode>, app_identifier: Option<usize>);
 }
@@ -143,7 +155,6 @@ pub struct SequentialDynamicBinaryStorage<
     C: Chip + 'static,
     D: ProcessStandardDebug + 'static,
     F: NonvolatileStorage<'b>,
-    P: ProcessManagementCapability + 'static,
 > {
     kernel: &'static Kernel,
     flash_driver: &'b F,
@@ -151,27 +162,20 @@ pub struct SequentialDynamicBinaryStorage<
     buffer: TakeCell<'static, [u8]>,
     storage_client: OptionalCell<&'static dyn DynamicBinaryStoreClient>,
     load_client: OptionalCell<&'static dyn DynamicProcessLoadClient>,
+    unload_client: OptionalCell<&'static dyn DynamicProcessUnloadClient>,
     process_metadata: OptionalCell<ProcessLoadMetadata>,
     state: Cell<State>,
     deferred_call: DeferredCall,
-    capability: P,
 }
 
-impl<
-        'a,
-        'b,
-        C: Chip + 'static,
-        D: ProcessStandardDebug + 'static,
-        F: NonvolatileStorage<'b>,
-        P: ProcessManagementCapability + 'static,
-    > SequentialDynamicBinaryStorage<'a, 'b, C, D, F, P>
+impl<'a, 'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileStorage<'b>>
+    SequentialDynamicBinaryStorage<'a, 'b, C, D, F>
 {
     pub fn new(
         kernel: &'static Kernel,
         flash_driver: &'b F,
         loader_driver: &'a SequentialProcessLoaderMachine<'a, C, D>,
         buffer: &'static mut [u8],
-        capability: P,
     ) -> Self {
         Self {
             kernel,
@@ -180,10 +184,10 @@ impl<
             buffer: TakeCell::new(buffer),
             storage_client: OptionalCell::empty(),
             load_client: OptionalCell::empty(),
+            unload_client: OptionalCell::empty(),
             process_metadata: OptionalCell::empty(),
             state: Cell::new(State::Idle),
             deferred_call: DeferredCall::new(),
-            capability,
         }
     }
 
@@ -357,19 +361,28 @@ impl<
     }
 }
 
-impl<
-        'b,
-        C: Chip,
-        D: ProcessStandardDebug,
-        F: NonvolatileStorage<'b>,
-        P: ProcessManagementCapability + 'static,
-    > DeferredCallClient for SequentialDynamicBinaryStorage<'_, 'b, C, D, F, P>
+impl<'b, C: Chip, D: ProcessStandardDebug, F: NonvolatileStorage<'b>> DeferredCallClient
+    for SequentialDynamicBinaryStorage<'_, 'b, C, D, F>
 {
     fn handle_deferred_call(&self) {
-        // We use deferred call to signal the completion of finalize
-        self.storage_client.map(|client| {
-            client.finalize_done(Ok(()));
-        });
+        // We use deferred call to signal the completion of finalize or unload
+        match self.state.get() {
+            State::Load => {
+                self.storage_client.map(|client| {
+                    client.finalize_done(Ok(()));
+                });
+            }
+            State::Unload(result, Some(app_id)) => {
+                let res = result;
+                let id = app_id;
+                self.reset_process_loading_metadata();
+
+                self.unload_client.map(|client| {
+                    client.unload_done(res, Some(id));
+                });
+            }
+            _ => {}
+        }
     }
 
     fn register(&'static self) {
@@ -378,13 +391,8 @@ impl<
 }
 
 /// This is the callback client for the underlying physical storage driver.
-impl<
-        'b,
-        C: Chip + 'static,
-        D: ProcessStandardDebug + 'static,
-        F: NonvolatileStorage<'b>,
-        P: ProcessManagementCapability + 'static,
-    > NonvolatileStorageClient for SequentialDynamicBinaryStorage<'_, 'b, C, D, F, P>
+impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileStorage<'b>>
+    NonvolatileStorageClient for SequentialDynamicBinaryStorage<'_, 'b, C, D, F>
 {
     fn read_done(&self, _buffer: &'static mut [u8], _length: usize) {
         // We will never use this, but we need to implement this anyway.
@@ -457,9 +465,8 @@ impl<
                     client.abort_done(Ok(()));
                 });
             }
-            State::Unload => {
+            State::Unload(_, _) => {
                 self.buffer.replace(buffer);
-                self.reset_process_loading_metadata();
             }
             State::Idle => {
                 self.buffer.replace(buffer);
@@ -469,13 +476,8 @@ impl<
 }
 
 /// Callback client for the async process loader
-impl<
-        'b,
-        C: Chip + 'static,
-        D: ProcessStandardDebug + 'static,
-        F: NonvolatileStorage<'b>,
-        P: ProcessManagementCapability + 'static,
-    > ProcessLoadingAsyncClient for SequentialDynamicBinaryStorage<'_, 'b, C, D, F, P>
+impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileStorage<'b>>
+    ProcessLoadingAsyncClient for SequentialDynamicBinaryStorage<'_, 'b, C, D, F>
 {
     fn process_loaded(&self, result: Result<(), ProcessLoadError>) {
         self.load_client.map(|client| {
@@ -491,13 +493,8 @@ impl<
 }
 
 /// Storage interface exposed to the app_loader capsule
-impl<
-        'b,
-        C: Chip + 'static,
-        D: ProcessStandardDebug + 'static,
-        F: NonvolatileStorage<'b>,
-        P: ProcessManagementCapability + 'static,
-    > DynamicBinaryStore for SequentialDynamicBinaryStorage<'_, 'b, C, D, F, P>
+impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileStorage<'b>>
+    DynamicBinaryStore for SequentialDynamicBinaryStorage<'_, 'b, C, D, F>
 {
     fn set_storage_client(&self, client: &'static dyn DynamicBinaryStoreClient) {
         self.storage_client.set(client);
@@ -683,13 +680,8 @@ impl<
 }
 
 /// Loading interface exposed to the app_loader capsule
-impl<
-        'b,
-        C: Chip + 'static,
-        D: ProcessStandardDebug + 'static,
-        F: NonvolatileStorage<'b>,
-        P: ProcessManagementCapability + 'static,
-    > DynamicProcessLoad for SequentialDynamicBinaryStorage<'_, 'b, C, D, F, P>
+impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileStorage<'b>>
+    DynamicProcessLoad for SequentialDynamicBinaryStorage<'_, 'b, C, D, F>
 {
     fn set_load_client(&self, client: &'static dyn DynamicProcessLoadClient) {
         self.load_client.set(client);
@@ -721,32 +713,41 @@ impl<
             _ => Err(ErrorCode::INVAL),
         }
     }
+}
 
-    fn unload(&self, app: ShortId) {
+/// Loading interface exposed to the app_loader capsule
+impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileStorage<'b>>
+    DynamicProcessUnload for SequentialDynamicBinaryStorage<'_, 'b, C, D, F>
+{
+    fn set_unload_client(&self, client: &'static dyn DynamicProcessUnloadClient) {
+        self.unload_client.set(client);
+    }
+
+    fn unload(&self, app: ShortId) -> Result<(), ErrorCode> {
         match self.state.get() {
             State::Idle => {
-                self.process_metadata.set(ProcessLoadMetadata::default());
-                self.state.set(State::Unload);
+                self.state.set(State::Unload(Err(ErrorCode::BUSY), None)); // To ensure the state machine knows not to service other apps
 
                 let (result, app_identifier) = match self
                     .kernel
-                    .remove_process_from_active_processes(app, &self.capability)
-                {
+                    .remove_process_from_active_processes(app, |proc| {
+                        proc.get_addresses().flash_start
+                    }) {
                     Ok(id) => (Ok(()), Some(id)),
                     Err(()) => (Err(ErrorCode::INVAL), None),
                 };
 
-                self.load_client.map(|client| {
-                    client.unload_done(result, app_identifier);
-                });
+                self.state.set(State::Unload(result, app_identifier));
 
-                self.reset_process_loading_metadata();
+                self.deferred_call.set();
+
+                result
             }
             _ => {
                 // We are in the wrong mode of operation. Ideally we should never reach
                 // here, but this error exists as a failsafe. The capsule should send
                 // a busy error out to the userland app.
-                // Err(ErrorCode::INVAL)
+                Err(ErrorCode::INVAL)
             }
         }
     }

--- a/kernel/src/dynamic_binary_storage.rs
+++ b/kernel/src/dynamic_binary_storage.rs
@@ -11,6 +11,7 @@ use core::cell::Cell;
 
 use crate::ErrorCode;
 use crate::Kernel;
+use crate::capabilities::ProcessManagementCapability;
 use crate::config;
 use crate::debug;
 use crate::deferred_call::{DeferredCall, DeferredCallClient};
@@ -155,6 +156,7 @@ pub struct SequentialDynamicBinaryStorage<
     C: Chip + 'static,
     D: ProcessStandardDebug + 'static,
     F: NonvolatileStorage<'b>,
+    P: ProcessManagementCapability + 'static,
 > {
     kernel: &'static Kernel,
     flash_driver: &'b F,
@@ -166,16 +168,24 @@ pub struct SequentialDynamicBinaryStorage<
     process_metadata: OptionalCell<ProcessLoadMetadata>,
     state: Cell<State>,
     deferred_call: DeferredCall,
+    capability: P,
 }
 
-impl<'a, 'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileStorage<'b>>
-    SequentialDynamicBinaryStorage<'a, 'b, C, D, F>
+impl<
+    'a,
+    'b,
+    C: Chip + 'static,
+    D: ProcessStandardDebug + 'static,
+    F: NonvolatileStorage<'b>,
+    P: ProcessManagementCapability + 'static,
+> SequentialDynamicBinaryStorage<'a, 'b, C, D, F, P>
 {
     pub fn new(
         kernel: &'static Kernel,
         flash_driver: &'b F,
         loader_driver: &'a SequentialProcessLoaderMachine<'a, C, D>,
         buffer: &'static mut [u8],
+        capability: P,
     ) -> Self {
         Self {
             kernel,
@@ -188,6 +198,7 @@ impl<'a, 'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: Nonvolatil
             process_metadata: OptionalCell::empty(),
             state: Cell::new(State::Idle),
             deferred_call: DeferredCall::new(),
+            capability,
         }
     }
 
@@ -361,8 +372,13 @@ impl<'a, 'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: Nonvolatil
     }
 }
 
-impl<'b, C: Chip, D: ProcessStandardDebug, F: NonvolatileStorage<'b>> DeferredCallClient
-    for SequentialDynamicBinaryStorage<'_, 'b, C, D, F>
+impl<
+    'b,
+    C: Chip,
+    D: ProcessStandardDebug,
+    F: NonvolatileStorage<'b>,
+    P: ProcessManagementCapability + 'static,
+> DeferredCallClient for SequentialDynamicBinaryStorage<'_, 'b, C, D, F, P>
 {
     fn handle_deferred_call(&self) {
         // We use deferred call to signal the completion of finalize or unload
@@ -373,10 +389,13 @@ impl<'b, C: Chip, D: ProcessStandardDebug, F: NonvolatileStorage<'b>> DeferredCa
                 });
             }
             State::Unload(result, app_id) => {
-                
                 // let id = app_id;
                 let id = app_id;
-                let res = if id == 0 {Err(ErrorCode::FAIL)} else {result};
+                let res = if id == 0 {
+                    Err(ErrorCode::FAIL)
+                } else {
+                    result
+                };
                 self.reset_process_loading_metadata();
 
                 self.unload_client.map(|client| {
@@ -393,8 +412,13 @@ impl<'b, C: Chip, D: ProcessStandardDebug, F: NonvolatileStorage<'b>> DeferredCa
 }
 
 /// This is the callback client for the underlying physical storage driver.
-impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileStorage<'b>>
-    NonvolatileStorageClient for SequentialDynamicBinaryStorage<'_, 'b, C, D, F>
+impl<
+    'b,
+    C: Chip + 'static,
+    D: ProcessStandardDebug + 'static,
+    F: NonvolatileStorage<'b>,
+    P: ProcessManagementCapability + 'static,
+> NonvolatileStorageClient for SequentialDynamicBinaryStorage<'_, 'b, C, D, F, P>
 {
     fn read_done(&self, _buffer: &'static mut [u8], _length: usize) {
         // We will never use this, but we need to implement this anyway.
@@ -478,8 +502,13 @@ impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileSto
 }
 
 /// Callback client for the async process loader
-impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileStorage<'b>>
-    ProcessLoadingAsyncClient for SequentialDynamicBinaryStorage<'_, 'b, C, D, F>
+impl<
+    'b,
+    C: Chip + 'static,
+    D: ProcessStandardDebug + 'static,
+    F: NonvolatileStorage<'b>,
+    P: ProcessManagementCapability + 'static,
+> ProcessLoadingAsyncClient for SequentialDynamicBinaryStorage<'_, 'b, C, D, F, P>
 {
     fn process_loaded(&self, result: Result<(), ProcessLoadError>) {
         self.load_client.map(|client| {
@@ -495,8 +524,13 @@ impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileSto
 }
 
 /// Storage interface exposed to the app_loader capsule
-impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileStorage<'b>>
-    DynamicBinaryStore for SequentialDynamicBinaryStorage<'_, 'b, C, D, F>
+impl<
+    'b,
+    C: Chip + 'static,
+    D: ProcessStandardDebug + 'static,
+    F: NonvolatileStorage<'b>,
+    P: ProcessManagementCapability + 'static,
+> DynamicBinaryStore for SequentialDynamicBinaryStorage<'_, 'b, C, D, F, P>
 {
     fn set_storage_client(&self, client: &'static dyn DynamicBinaryStoreClient) {
         self.storage_client.set(client);
@@ -682,8 +716,13 @@ impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileSto
 }
 
 /// Loading interface exposed to the app_loader capsule
-impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileStorage<'b>>
-    DynamicProcessLoad for SequentialDynamicBinaryStorage<'_, 'b, C, D, F>
+impl<
+    'b,
+    C: Chip + 'static,
+    D: ProcessStandardDebug + 'static,
+    F: NonvolatileStorage<'b>,
+    P: ProcessManagementCapability + 'static,
+> DynamicProcessLoad for SequentialDynamicBinaryStorage<'_, 'b, C, D, F, P>
 {
     fn set_load_client(&self, client: &'static dyn DynamicProcessLoadClient) {
         self.load_client.set(client);
@@ -718,8 +757,13 @@ impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileSto
 }
 
 /// Loading interface exposed to the app_loader capsule
-impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileStorage<'b>>
-    DynamicProcessUnload for SequentialDynamicBinaryStorage<'_, 'b, C, D, F>
+impl<
+    'b,
+    C: Chip + 'static,
+    D: ProcessStandardDebug + 'static,
+    F: NonvolatileStorage<'b>,
+    P: ProcessManagementCapability + 'static,
+> DynamicProcessUnload for SequentialDynamicBinaryStorage<'_, 'b, C, D, F, P>
 {
     fn set_unload_client(&self, client: &'static dyn DynamicProcessUnloadClient) {
         self.unload_client.set(client);
@@ -730,20 +774,21 @@ impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileSto
             State::Idle => {
                 self.state.set(State::Unload(Err(ErrorCode::BUSY), 0)); // To ensure the state machine knows not to service other apps
 
-                let (result, _app_handle) = match self.kernel.remove_process_from_active_processes(app, |proc| {
-                        proc.get_addresses().flash_start
-                    }) 
-                {
+                let (result, _app_handle) = match self.kernel.remove_process_from_active_processes(
+                    app,
+                    |proc| proc.get_addresses().flash_start,
+                    &self.capability,
+                ) {
                     Ok(id) => {
                         let res = Ok(());
                         let handle = id;
-                        
+
                         self.state.set(State::Unload(res, handle));
                         self.deferred_call.set();
-                        
+
                         (res, handle)
                     }
-                    Err(()) => (Err(ErrorCode::INVAL), 0)
+                    Err(()) => (Err(ErrorCode::INVAL), 0),
                 };
 
                 result

--- a/kernel/src/dynamic_binary_storage.rs
+++ b/kernel/src/dynamic_binary_storage.rs
@@ -37,7 +37,7 @@ pub enum State {
     AppWrite,
     Load,
     Abort,
-    Unload(Result<(), ErrorCode>, Option<usize>),
+    Unload(Result<(), ErrorCode>, usize),
     PaddingWrite,
     Fail,
 }
@@ -145,7 +145,7 @@ pub trait DynamicProcessUnload {
 /// The callback for dynamic process unloading.
 pub trait DynamicProcessUnloadClient {
     /// Terminated app (if running).
-    fn unload_done(&self, result: Result<(), ErrorCode>, app_identifier: Option<usize>);
+    fn unload_done(&self, result: Result<(), ErrorCode>, app_handle: usize);
 }
 
 /// Dynamic process loading machine.
@@ -372,13 +372,15 @@ impl<'b, C: Chip, D: ProcessStandardDebug, F: NonvolatileStorage<'b>> DeferredCa
                     client.finalize_done(Ok(()));
                 });
             }
-            State::Unload(result, Some(app_id)) => {
-                let res = result;
+            State::Unload(result, app_id) => {
+                
+                // let id = app_id;
                 let id = app_id;
+                let res = if id == 0 {Err(ErrorCode::FAIL)} else {result};
                 self.reset_process_loading_metadata();
 
                 self.unload_client.map(|client| {
-                    client.unload_done(res, Some(id));
+                    client.unload_done(res, id);
                 });
             }
             _ => {}
@@ -726,20 +728,23 @@ impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileSto
     fn unload(&self, app: ShortId) -> Result<(), ErrorCode> {
         match self.state.get() {
             State::Idle => {
-                self.state.set(State::Unload(Err(ErrorCode::BUSY), None)); // To ensure the state machine knows not to service other apps
+                self.state.set(State::Unload(Err(ErrorCode::BUSY), 0)); // To ensure the state machine knows not to service other apps
 
-                let (result, app_identifier) = match self
-                    .kernel
-                    .remove_process_from_active_processes(app, |proc| {
+                let (result, _app_handle) = match self.kernel.remove_process_from_active_processes(app, |proc| {
                         proc.get_addresses().flash_start
-                    }) {
-                    Ok(id) => (Ok(()), Some(id)),
-                    Err(()) => (Err(ErrorCode::INVAL), None),
+                    }) 
+                {
+                    Ok(id) => {
+                        let res = Ok(());
+                        let handle = id;
+                        
+                        self.state.set(State::Unload(res, handle));
+                        self.deferred_call.set();
+                        
+                        (res, handle)
+                    }
+                    Err(()) => (Err(ErrorCode::INVAL), 0)
                 };
-
-                self.state.set(State::Unload(result, app_identifier));
-
-                self.deferred_call.set();
 
                 result
             }

--- a/kernel/src/dynamic_binary_storage.rs
+++ b/kernel/src/dynamic_binary_storage.rs
@@ -9,6 +9,8 @@
 
 use core::cell::Cell;
 
+use crate::ErrorCode;
+use crate::Kernel;
 use crate::config;
 use crate::debug;
 use crate::deferred_call::{DeferredCall, DeferredCallClient};
@@ -21,8 +23,6 @@ use crate::process_loading::{
 use crate::process_standard::ProcessStandardDebug;
 use crate::utilities::cells::{OptionalCell, TakeCell};
 use crate::utilities::leasable_buffer::SubSliceMut;
-use crate::ErrorCode;
-use crate::Kernel;
 
 /// Expected buffer length for storing application binaries.
 pub const BUF_LEN: usize = 512;

--- a/kernel/src/dynamic_binary_storage.rs
+++ b/kernel/src/dynamic_binary_storage.rs
@@ -9,19 +9,20 @@
 
 use core::cell::Cell;
 
-use crate::ErrorCode;
 use crate::config;
 use crate::debug;
 use crate::deferred_call::{DeferredCall, DeferredCallClient};
 use crate::hil::nonvolatile_storage::{NonvolatileStorage, NonvolatileStorageClient};
 use crate::platform::chip::Chip;
-use crate::process::ProcessLoadingAsyncClient;
+use crate::process::{ProcessLoadingAsyncClient, ShortId};
 use crate::process_loading::{
     PaddingRequirement, ProcessLoadError, SequentialProcessLoaderMachine,
 };
 use crate::process_standard::ProcessStandardDebug;
 use crate::utilities::cells::{OptionalCell, TakeCell};
 use crate::utilities::leasable_buffer::SubSliceMut;
+use crate::ErrorCode;
+use crate::Kernel;
 
 /// Expected buffer length for storing application binaries.
 pub const BUF_LEN: usize = 512;
@@ -36,6 +37,7 @@ pub enum State {
     AppWrite,
     Load,
     Abort,
+    Unload,
     PaddingWrite,
     Fail,
 }
@@ -115,6 +117,9 @@ pub trait DynamicProcessLoad {
     /// Call to request kernel to load a new process.
     fn load(&self) -> Result<(), ErrorCode>;
 
+    /// Call to unload a process with given ShortId.
+    fn unload(&self, app: ShortId); // -> Result<(), ErrorCode>;
+
     /// Sets a client for the SequentialDynamicProcessLoading Object
     ///
     /// When the client operation is done, it calls the `load_done()`
@@ -126,6 +131,9 @@ pub trait DynamicProcessLoad {
 pub trait DynamicProcessLoadClient {
     /// The new app has been loaded.
     fn load_done(&self, result: Result<(), ProcessLoadError>);
+
+    /// Terminated app (if running).
+    fn unload_done(&self, result: Result<(), ErrorCode>, app_identifier: Option<usize>);
 }
 
 /// Dynamic process loading machine.
@@ -135,7 +143,9 @@ pub struct SequentialDynamicBinaryStorage<
     C: Chip + 'static,
     D: ProcessStandardDebug + 'static,
     F: NonvolatileStorage<'b>,
+    P: ProcessManagementCapability + 'static,
 > {
+    kernel: &'static Kernel,
     flash_driver: &'b F,
     loader_driver: &'a SequentialProcessLoaderMachine<'a, C, D>,
     buffer: TakeCell<'static, [u8]>,
@@ -144,17 +154,27 @@ pub struct SequentialDynamicBinaryStorage<
     process_metadata: OptionalCell<ProcessLoadMetadata>,
     state: Cell<State>,
     deferred_call: DeferredCall,
+    capability: P,
 }
 
-impl<'a, 'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileStorage<'b>>
-    SequentialDynamicBinaryStorage<'a, 'b, C, D, F>
+impl<
+        'a,
+        'b,
+        C: Chip + 'static,
+        D: ProcessStandardDebug + 'static,
+        F: NonvolatileStorage<'b>,
+        P: ProcessManagementCapability + 'static,
+    > SequentialDynamicBinaryStorage<'a, 'b, C, D, F, P>
 {
     pub fn new(
+        kernel: &'static Kernel,
         flash_driver: &'b F,
         loader_driver: &'a SequentialProcessLoaderMachine<'a, C, D>,
         buffer: &'static mut [u8],
+        capability: P,
     ) -> Self {
         Self {
+            kernel,
             flash_driver,
             loader_driver,
             buffer: TakeCell::new(buffer),
@@ -163,6 +183,7 @@ impl<'a, 'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: Nonvolatil
             process_metadata: OptionalCell::empty(),
             state: Cell::new(State::Idle),
             deferred_call: DeferredCall::new(),
+            capability,
         }
     }
 
@@ -336,8 +357,13 @@ impl<'a, 'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: Nonvolatil
     }
 }
 
-impl<'b, C: Chip, D: ProcessStandardDebug, F: NonvolatileStorage<'b>> DeferredCallClient
-    for SequentialDynamicBinaryStorage<'_, 'b, C, D, F>
+impl<
+        'b,
+        C: Chip,
+        D: ProcessStandardDebug,
+        F: NonvolatileStorage<'b>,
+        P: ProcessManagementCapability + 'static,
+    > DeferredCallClient for SequentialDynamicBinaryStorage<'_, 'b, C, D, F, P>
 {
     fn handle_deferred_call(&self) {
         // We use deferred call to signal the completion of finalize
@@ -352,8 +378,13 @@ impl<'b, C: Chip, D: ProcessStandardDebug, F: NonvolatileStorage<'b>> DeferredCa
 }
 
 /// This is the callback client for the underlying physical storage driver.
-impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileStorage<'b>>
-    NonvolatileStorageClient for SequentialDynamicBinaryStorage<'_, 'b, C, D, F>
+impl<
+        'b,
+        C: Chip + 'static,
+        D: ProcessStandardDebug + 'static,
+        F: NonvolatileStorage<'b>,
+        P: ProcessManagementCapability + 'static,
+    > NonvolatileStorageClient for SequentialDynamicBinaryStorage<'_, 'b, C, D, F, P>
 {
     fn read_done(&self, _buffer: &'static mut [u8], _length: usize) {
         // We will never use this, but we need to implement this anyway.
@@ -426,6 +457,10 @@ impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileSto
                     client.abort_done(Ok(()));
                 });
             }
+            State::Unload => {
+                self.buffer.replace(buffer);
+                self.reset_process_loading_metadata();
+            }
             State::Idle => {
                 self.buffer.replace(buffer);
             }
@@ -434,8 +469,13 @@ impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileSto
 }
 
 /// Callback client for the async process loader
-impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileStorage<'b>>
-    ProcessLoadingAsyncClient for SequentialDynamicBinaryStorage<'_, 'b, C, D, F>
+impl<
+        'b,
+        C: Chip + 'static,
+        D: ProcessStandardDebug + 'static,
+        F: NonvolatileStorage<'b>,
+        P: ProcessManagementCapability + 'static,
+    > ProcessLoadingAsyncClient for SequentialDynamicBinaryStorage<'_, 'b, C, D, F, P>
 {
     fn process_loaded(&self, result: Result<(), ProcessLoadError>) {
         self.load_client.map(|client| {
@@ -451,8 +491,13 @@ impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileSto
 }
 
 /// Storage interface exposed to the app_loader capsule
-impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileStorage<'b>>
-    DynamicBinaryStore for SequentialDynamicBinaryStorage<'_, 'b, C, D, F>
+impl<
+        'b,
+        C: Chip + 'static,
+        D: ProcessStandardDebug + 'static,
+        F: NonvolatileStorage<'b>,
+        P: ProcessManagementCapability + 'static,
+    > DynamicBinaryStore for SequentialDynamicBinaryStorage<'_, 'b, C, D, F, P>
 {
     fn set_storage_client(&self, client: &'static dyn DynamicBinaryStoreClient) {
         self.storage_client.set(client);
@@ -638,8 +683,13 @@ impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileSto
 }
 
 /// Loading interface exposed to the app_loader capsule
-impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileStorage<'b>>
-    DynamicProcessLoad for SequentialDynamicBinaryStorage<'_, 'b, C, D, F>
+impl<
+        'b,
+        C: Chip + 'static,
+        D: ProcessStandardDebug + 'static,
+        F: NonvolatileStorage<'b>,
+        P: ProcessManagementCapability + 'static,
+    > DynamicProcessLoad for SequentialDynamicBinaryStorage<'_, 'b, C, D, F, P>
 {
     fn set_load_client(&self, client: &'static dyn DynamicProcessLoadClient) {
         self.load_client.set(client);
@@ -669,6 +719,35 @@ impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileSto
                 Ok(())
             }
             _ => Err(ErrorCode::INVAL),
+        }
+    }
+
+    fn unload(&self, app: ShortId) {
+        match self.state.get() {
+            State::Idle => {
+                self.process_metadata.set(ProcessLoadMetadata::default());
+                self.state.set(State::Unload);
+
+                let (result, app_identifier) = match self
+                    .kernel
+                    .remove_process_from_active_processes(app, &self.capability)
+                {
+                    Ok(id) => (Ok(()), Some(id)),
+                    Err(()) => (Err(ErrorCode::INVAL), None),
+                };
+
+                self.load_client.map(|client| {
+                    client.unload_done(result, app_identifier);
+                });
+
+                self.reset_process_loading_metadata();
+            }
+            _ => {
+                // We are in the wrong mode of operation. Ideally we should never reach
+                // here, but this error exists as a failsafe. The capsule should send
+                // a busy error out to the userland app.
+                // Err(ErrorCode::INVAL)
+            }
         }
     }
 }

--- a/kernel/src/dynamic_binary_storage.rs
+++ b/kernel/src/dynamic_binary_storage.rs
@@ -11,7 +11,6 @@ use core::cell::Cell;
 
 use crate::ErrorCode;
 use crate::Kernel;
-use crate::capabilities::ProcessManagementCapability;
 use crate::config;
 use crate::debug;
 use crate::deferred_call::{DeferredCall, DeferredCallClient};
@@ -134,11 +133,7 @@ pub trait DynamicProcessLoadClient {
 /// This interface supports unloading processes at runtime.
 pub trait DynamicProcessUnload {
     /// Call to terminate a process with given ShortId.
-    fn unload(
-        &self,
-        app: ShortId,
-        _capability: &dyn ProcessManagementCapability,
-    ) -> Result<(), ErrorCode>;
+    fn unload(&self, app: ShortId) -> Result<(), ErrorCode>;
 
     /// Sets a client for the SequentialDynamicProcessUnload Object
     ///
@@ -377,18 +372,11 @@ impl<'b, C: Chip, D: ProcessStandardDebug, F: NonvolatileStorage<'b>> DeferredCa
                     client.finalize_done(Ok(()));
                 });
             }
-            State::Unload(result, app_id) => {
-                // let id = app_id;
-                let id = app_id;
-                let res = if id == 0 {
-                    Err(ErrorCode::FAIL)
-                } else {
-                    result
-                };
+            State::Unload(result, app_handle) => {
                 self.reset_process_loading_metadata();
 
                 self.unload_client.map(|client| {
-                    client.unload_done(res, id);
+                    client.unload_done(result, app_handle);
                 });
             }
             _ => {}
@@ -733,11 +721,7 @@ impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileSto
         self.unload_client.set(client);
     }
 
-    fn unload(
-        &self,
-        app: ShortId,
-        _capability: &dyn ProcessManagementCapability,
-    ) -> Result<(), ErrorCode> {
+    fn unload(&self, app: ShortId) -> Result<(), ErrorCode> {
         match self.state.get() {
             State::Idle => {
                 self.state.set(State::Unload(Err(ErrorCode::BUSY), 0)); // To ensure the state machine knows not to service other apps
@@ -765,7 +749,7 @@ impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileSto
                 // We are in the wrong mode of operation. Ideally we should never reach
                 // here, but this error exists as a failsafe. The capsule should send
                 // a busy error out to the userland app.
-                Err(ErrorCode::INVAL)
+                Err(ErrorCode::BUSY)
             }
         }
     }

--- a/kernel/src/dynamic_binary_storage.rs
+++ b/kernel/src/dynamic_binary_storage.rs
@@ -134,7 +134,11 @@ pub trait DynamicProcessLoadClient {
 /// This interface supports unloading processes at runtime.
 pub trait DynamicProcessUnload {
     /// Call to terminate a process with given ShortId.
-    fn unload(&self, app: ShortId) -> Result<(), ErrorCode>;
+    fn unload(
+        &self,
+        app: ShortId,
+        _capability: &dyn ProcessManagementCapability,
+    ) -> Result<(), ErrorCode>;
 
     /// Sets a client for the SequentialDynamicProcessUnload Object
     ///
@@ -156,7 +160,6 @@ pub struct SequentialDynamicBinaryStorage<
     C: Chip + 'static,
     D: ProcessStandardDebug + 'static,
     F: NonvolatileStorage<'b>,
-    P: ProcessManagementCapability + 'static,
 > {
     kernel: &'static Kernel,
     flash_driver: &'b F,
@@ -168,24 +171,16 @@ pub struct SequentialDynamicBinaryStorage<
     process_metadata: OptionalCell<ProcessLoadMetadata>,
     state: Cell<State>,
     deferred_call: DeferredCall,
-    capability: P,
 }
 
-impl<
-    'a,
-    'b,
-    C: Chip + 'static,
-    D: ProcessStandardDebug + 'static,
-    F: NonvolatileStorage<'b>,
-    P: ProcessManagementCapability + 'static,
-> SequentialDynamicBinaryStorage<'a, 'b, C, D, F, P>
+impl<'a, 'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileStorage<'b>>
+    SequentialDynamicBinaryStorage<'a, 'b, C, D, F>
 {
     pub fn new(
         kernel: &'static Kernel,
         flash_driver: &'b F,
         loader_driver: &'a SequentialProcessLoaderMachine<'a, C, D>,
         buffer: &'static mut [u8],
-        capability: P,
     ) -> Self {
         Self {
             kernel,
@@ -198,7 +193,6 @@ impl<
             process_metadata: OptionalCell::empty(),
             state: Cell::new(State::Idle),
             deferred_call: DeferredCall::new(),
-            capability,
         }
     }
 
@@ -372,13 +366,8 @@ impl<
     }
 }
 
-impl<
-    'b,
-    C: Chip,
-    D: ProcessStandardDebug,
-    F: NonvolatileStorage<'b>,
-    P: ProcessManagementCapability + 'static,
-> DeferredCallClient for SequentialDynamicBinaryStorage<'_, 'b, C, D, F, P>
+impl<'b, C: Chip, D: ProcessStandardDebug, F: NonvolatileStorage<'b>> DeferredCallClient
+    for SequentialDynamicBinaryStorage<'_, 'b, C, D, F>
 {
     fn handle_deferred_call(&self) {
         // We use deferred call to signal the completion of finalize or unload
@@ -412,13 +401,8 @@ impl<
 }
 
 /// This is the callback client for the underlying physical storage driver.
-impl<
-    'b,
-    C: Chip + 'static,
-    D: ProcessStandardDebug + 'static,
-    F: NonvolatileStorage<'b>,
-    P: ProcessManagementCapability + 'static,
-> NonvolatileStorageClient for SequentialDynamicBinaryStorage<'_, 'b, C, D, F, P>
+impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileStorage<'b>>
+    NonvolatileStorageClient for SequentialDynamicBinaryStorage<'_, 'b, C, D, F>
 {
     fn read_done(&self, _buffer: &'static mut [u8], _length: usize) {
         // We will never use this, but we need to implement this anyway.
@@ -502,13 +486,8 @@ impl<
 }
 
 /// Callback client for the async process loader
-impl<
-    'b,
-    C: Chip + 'static,
-    D: ProcessStandardDebug + 'static,
-    F: NonvolatileStorage<'b>,
-    P: ProcessManagementCapability + 'static,
-> ProcessLoadingAsyncClient for SequentialDynamicBinaryStorage<'_, 'b, C, D, F, P>
+impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileStorage<'b>>
+    ProcessLoadingAsyncClient for SequentialDynamicBinaryStorage<'_, 'b, C, D, F>
 {
     fn process_loaded(&self, result: Result<(), ProcessLoadError>) {
         self.load_client.map(|client| {
@@ -524,13 +503,8 @@ impl<
 }
 
 /// Storage interface exposed to the app_loader capsule
-impl<
-    'b,
-    C: Chip + 'static,
-    D: ProcessStandardDebug + 'static,
-    F: NonvolatileStorage<'b>,
-    P: ProcessManagementCapability + 'static,
-> DynamicBinaryStore for SequentialDynamicBinaryStorage<'_, 'b, C, D, F, P>
+impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileStorage<'b>>
+    DynamicBinaryStore for SequentialDynamicBinaryStorage<'_, 'b, C, D, F>
 {
     fn set_storage_client(&self, client: &'static dyn DynamicBinaryStoreClient) {
         self.storage_client.set(client);
@@ -716,13 +690,8 @@ impl<
 }
 
 /// Loading interface exposed to the app_loader capsule
-impl<
-    'b,
-    C: Chip + 'static,
-    D: ProcessStandardDebug + 'static,
-    F: NonvolatileStorage<'b>,
-    P: ProcessManagementCapability + 'static,
-> DynamicProcessLoad for SequentialDynamicBinaryStorage<'_, 'b, C, D, F, P>
+impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileStorage<'b>>
+    DynamicProcessLoad for SequentialDynamicBinaryStorage<'_, 'b, C, D, F>
 {
     fn set_load_client(&self, client: &'static dyn DynamicProcessLoadClient) {
         self.load_client.set(client);
@@ -757,28 +726,27 @@ impl<
 }
 
 /// Loading interface exposed to the app_loader capsule
-impl<
-    'b,
-    C: Chip + 'static,
-    D: ProcessStandardDebug + 'static,
-    F: NonvolatileStorage<'b>,
-    P: ProcessManagementCapability + 'static,
-> DynamicProcessUnload for SequentialDynamicBinaryStorage<'_, 'b, C, D, F, P>
+impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileStorage<'b>>
+    DynamicProcessUnload for SequentialDynamicBinaryStorage<'_, 'b, C, D, F>
 {
     fn set_unload_client(&self, client: &'static dyn DynamicProcessUnloadClient) {
         self.unload_client.set(client);
     }
 
-    fn unload(&self, app: ShortId) -> Result<(), ErrorCode> {
+    fn unload(
+        &self,
+        app: ShortId,
+        _capability: &dyn ProcessManagementCapability,
+    ) -> Result<(), ErrorCode> {
         match self.state.get() {
             State::Idle => {
                 self.state.set(State::Unload(Err(ErrorCode::BUSY), 0)); // To ensure the state machine knows not to service other apps
 
-                let (result, _app_handle) = match self.kernel.remove_process_from_active_processes(
-                    app,
-                    |proc| proc.get_addresses().flash_start,
-                    &self.capability,
-                ) {
+                let (result, _app_handle) = match self
+                    .kernel
+                    .remove_process_from_active_processes(app, |proc| {
+                        proc.get_addresses().flash_start
+                    }) {
                     Ok(id) => {
                         let res = Ok(());
                         let handle = id;

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -314,6 +314,23 @@ impl Kernel {
         Err(())
     }
 
+    /// Terminate a process if it exists, and remove it from ProcessArray.
+    pub(crate) fn remove_process_from_active_processes(
+        &self,
+        shortid: process::ShortId,
+        _capability: &dyn capabilities::ProcessManagementCapability,
+    ) {
+        for slot in self.processes.iter() {
+            if let Some(process) = slot.get() {
+                if process.short_app_id() == shortid {
+                    process.terminate(None);
+                    slot.proc.set(None);
+                    break;
+                }
+            }
+        }
+    }
+
     /// Cause all apps to fault.
     ///
     /// This will call `set_fault_state()` on each app, causing the app to enter

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -319,7 +319,7 @@ impl Kernel {
         &self,
         shortid: process::ShortId,
         f: F,
-        // _capability: &dyn capabilities::ProcessManagementCapability,
+        _capability: &dyn capabilities::ProcessManagementCapability,
     ) -> Result<usize, ()>
     where
         F: FnOnce(&'static dyn process::Process) -> usize,

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -319,16 +319,17 @@ impl Kernel {
         &self,
         shortid: process::ShortId,
         _capability: &dyn capabilities::ProcessManagementCapability,
-    ) {
+    ) -> Result<usize, ()> {
         for slot in self.processes.iter() {
             if let Some(process) = slot.get() {
                 if process.short_app_id() == shortid {
                     process.terminate(None);
                     slot.proc.set(None);
-                    break;
+                    return Ok(process.get_addresses().flash_start);
                 }
             }
         }
+        Err(())
     }
 
     /// Cause all apps to fault.

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -315,17 +315,22 @@ impl Kernel {
     }
 
     /// Terminate a process if it exists, and remove it from ProcessArray.
-    pub(crate) fn remove_process_from_active_processes(
+    pub fn remove_process_from_active_processes<F>(
         &self,
         shortid: process::ShortId,
-        _capability: &dyn capabilities::ProcessManagementCapability,
-    ) -> Result<usize, ()> {
+        f: F,
+        // _capability: &dyn capabilities::ProcessManagementCapability,
+    ) -> Result<usize, ()>
+    where
+        F: FnOnce(&'static dyn process::Process) -> usize,
+    {
         for slot in self.processes.iter() {
             if let Some(process) = slot.get() {
                 if process.short_app_id() == shortid {
                     process.terminate(None);
+                    let result = f(process);
                     slot.proc.set(None);
-                    return Ok(process.get_addresses().flash_start);
+                    return Ok(result);
                 }
             }
         }

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -315,10 +315,12 @@ impl Kernel {
     }
 
     /// Terminate a process if it exists, and remove it from ProcessArray.
+    /// `extract_app_handle` is the caller-passed operation which is used
+    /// to determine the `app_handle` which is returned as a usize value.
     pub(crate) fn remove_process_from_active_processes<F>(
         &self,
         shortid: process::ShortId,
-        f: F,
+        extract_app_handle: F,
     ) -> Result<usize, ()>
     where
         F: FnOnce(&'static dyn process::Process) -> usize,
@@ -327,7 +329,7 @@ impl Kernel {
             if let Some(process) = slot.get() {
                 if process.short_app_id() == shortid {
                     process.terminate(None);
-                    let result = f(process);
+                    let result = extract_app_handle(process);
                     slot.proc.set(None);
                     return Ok(result);
                 }

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -315,11 +315,10 @@ impl Kernel {
     }
 
     /// Terminate a process if it exists, and remove it from ProcessArray.
-    pub fn remove_process_from_active_processes<F>(
+    pub(crate) fn remove_process_from_active_processes<F>(
         &self,
         shortid: process::ShortId,
         f: F,
-        _capability: &dyn capabilities::ProcessManagementCapability,
     ) -> Result<usize, ()>
     where
         F: FnOnce(&'static dyn process::Process) -> usize,


### PR DESCRIPTION
### Pull Request Overview

This pull request adds the unload functionality (opposite of loading a process) to the app_loader. This function returns an opaque value that can be used to uninstall an app in the future. Did not use AI in this PR.


### Testing Strategy

This pull request was tested with libtock-c apps (`blink,` `adc`, `process-manager`).


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
