### PR TITLE
lpc55s6x: use static refs, not optionalcells

### DIFF
--- a/boards/lpc55s69-evk/src/io.rs
+++ b/boards/lpc55s69-evk/src/io.rs
@@ -111,7 +111,10 @@ impl IoWrite for Writer {
     fn write(&mut self, buf: &[u8]) -> usize {
         self.uart.map_or_else(
             || {
-                let uart = Uart::new_uart0();
+                let clocks = lpc55s6x::clocks::Clock::new();
+                let flexcomm = lpc55s6x::flexcomm::Flexcomm::new(0);
+
+                let uart = Uart::new_uart0(&clocks, &flexcomm);
                 self.configure_uart(&uart);
                 self.write_to_uart(&uart, buf);
             },

--- a/boards/lpc55s69-evk/src/main.rs
+++ b/boards/lpc55s69-evk/src/main.rs
@@ -34,8 +34,14 @@ fn system_init() {
     clocks.start_timer_clocks();
 }
 
-unsafe fn get_peripherals() -> &'static mut Lpc55s69DefaultPeripheral<'static> {
-    static_init!(Lpc55s69DefaultPeripheral, Lpc55s69DefaultPeripheral::new())
+unsafe fn get_peripherals(
+    clocks: &'static Clock,
+    flexcomm: &'static flexcomm::Flexcomm,
+) -> &'static Lpc55s69DefaultPeripheral<'static> {
+    static_init!(
+        Lpc55s69DefaultPeripheral,
+        Lpc55s69DefaultPeripheral::new(clocks, flexcomm)
+    )
 }
 
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
@@ -134,7 +140,9 @@ unsafe fn start() -> (
 
     system_init();
 
-    let peripherals = get_peripherals();
+    let clock = static_init!(clocks::Clock, clocks::Clock::new());
+    let flexcomm0 = static_init!(flexcomm::Flexcomm, flexcomm::Flexcomm::new_id(0).unwrap());
+    let peripherals = get_peripherals(clock, flexcomm0);
 
     peripherals.pins.init();
 
@@ -282,16 +290,11 @@ unsafe fn start() -> (
 
     peripherals.pins.pint.configure_interrupt(0, Edge::Rising);
 
-    let clock = static_init!(clocks::Clock, clocks::Clock::new());
-    let flexcomm0 = static_init!(flexcomm::Flexcomm, flexcomm::Flexcomm::new_id(0).unwrap());
-
     clock.setup_uart_clock(FrgId::Frg0, FrgClockSource::Fro96Mhz);
 
     let uart = &peripherals.uart;
 
     uart.set_clock_source(FrgClockSource::Fro96Mhz);
-    uart.set_clocks(clock);
-    uart.set_flexcomm(flexcomm0);
 
     peripherals.pins.iocon.configure_pin(
         LPCPin::P0_29,

--- a/chips/lpc55s6x/src/chip.rs
+++ b/chips/lpc55s6x/src/chip.rs
@@ -10,7 +10,9 @@ use cortexm33::{CortexM33, CortexMVariant};
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
 
+use crate::clocks::Clock;
 use crate::ctimer0::LPCTimer;
+use crate::flexcomm::Flexcomm;
 use crate::gpio::Pins;
 use crate::interrupts;
 use crate::uart::Uart;
@@ -93,11 +95,11 @@ pub struct Lpc55s69DefaultPeripheral<'a> {
 }
 
 impl Lpc55s69DefaultPeripheral<'_> {
-    pub fn new() -> Self {
+    pub fn new(clocks: &'static Clock, flexcomm: &'static Flexcomm) -> Self {
         Self {
             pins: Pins::new(),
             ctimer0: LPCTimer::new(),
-            uart: Uart::new_uart0(),
+            uart: Uart::new_uart0(clocks, flexcomm),
         }
     }
 }

--- a/chips/lpc55s6x/src/uart.rs
+++ b/chips/lpc55s6x/src/uart.rs
@@ -562,8 +562,8 @@ const USART4_BASE: StaticRef<UsartRegisters> =
 pub struct Uart<'a> {
     registers: StaticRef<UsartRegisters>,
     instance: u8,
-    clocks: OptionalCell<&'a Clock>,
-    flexcomm: OptionalCell<&'a Flexcomm>,
+    clocks: &'a Clock,
+    flexcomm: &'a Flexcomm,
 
     uart_clock_source: Cell<FrgClockSource>,
 
@@ -582,12 +582,17 @@ pub struct Uart<'a> {
 }
 
 impl<'a> Uart<'a> {
-    pub fn new(registers: StaticRef<UsartRegisters>, instance: u8) -> Self {
+    pub fn new(
+        registers: StaticRef<UsartRegisters>,
+        instance: u8,
+        clocks: &'a Clock,
+        flexcomm: &'a Flexcomm,
+    ) -> Self {
         Self {
             registers,
             instance,
-            clocks: OptionalCell::empty(),
-            flexcomm: OptionalCell::empty(),
+            clocks,
+            flexcomm,
 
             uart_clock_source: Cell::new(FrgClockSource::Fro12Mhz),
 
@@ -605,20 +610,12 @@ impl<'a> Uart<'a> {
             rx_status: Cell::new(UARTStateRX::Idle),
         }
     }
-    pub fn new_uart0() -> Self {
-        Self::new(USART0_BASE, 0)
+    pub fn new_uart0(clocks: &'a Clock, flexcomm: &'a Flexcomm) -> Self {
+        Self::new(USART0_BASE, 0, clocks, flexcomm)
     }
 
-    pub fn new_uart4() -> Self {
-        Self::new(USART4_BASE, 4)
-    }
-
-    pub fn set_clocks(&self, clocks: &'a Clock) {
-        self.clocks.set(clocks);
-    }
-
-    pub fn set_flexcomm(&self, flexcomm: &'a Flexcomm) {
-        self.flexcomm.set(flexcomm);
+    pub fn new_uart4(clocks: &'a Clock, flexcomm: &'a Flexcomm) -> Self {
+        Self::new(USART4_BASE, 4, clocks, flexcomm)
     }
 
     pub fn set_clock_source(&self, source: FrgClockSource) {
@@ -836,17 +833,15 @@ impl<'a> Uart<'a> {
 
 impl Configure for Uart<'_> {
     fn configure(&self, params: Parameters) -> Result<(), ErrorCode> {
-        let clocks = self.clocks.get().ok_or(ErrorCode::OFF)?;
-        let flexcomm = self.flexcomm.get().ok_or(ErrorCode::OFF)?;
         let clock_source = self.uart_clock_source.get();
         let frg_id = FrgId::from_u32(self.instance.into()).ok_or(ErrorCode::INVAL)?;
-        clocks.setup_uart_clock(frg_id, clock_source);
-        flexcomm.configure_for_uart();
+        self.clocks.setup_uart_clock(frg_id, clock_source);
+        self.flexcomm.configure_for_uart();
 
         // --- Disable USART before configuration ---
         self.registers.cfg.modify(CFG::ENABLE::CLEAR);
 
-        let clk = clocks.get_frg_clock_frequency(clock_source);
+        let clk = self.clocks.get_frg_clock_frequency(clock_source);
         let brg_val = (clk / (16 * params.baud_rate)).saturating_sub(1);
         if brg_val > 0xFFFF {
             return Err(ErrorCode::INVAL); // Baud rate not possible


### PR DESCRIPTION
### Pull Request Overview

This pull request is similar to #4811 in that it removes chip peripheral references stored in cells in favor of static references.


### Testing Strategy

Travis only


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
