### PR TITLE
flux-ci-runner: pin fixpoint's version

### DIFF
--- a/tools/ci/flux-ci-runner/deps.sh
+++ b/tools/ci/flux-ci-runner/deps.sh
@@ -11,7 +11,7 @@
 # Author: Pat Pannuto <ppannuto@ucsd.edu>
 
 DESIRED_FIXPOINT_VERSION="0.9.6.3.3"
-DESIRED_FIXPOINT_RELEASE_TAG="nightly"
+DESIRED_FIXPOINT_RELEASE_TAG="nightly-01-14-2026"
 
 ########################################################
 


### PR DESCRIPTION
### Pull Request Overview

fixpoint's CLI changed recently (probably due to https://github.com/ucsd-progsys/liquid-fixpoint/pull/842), which broke our CI. We currently have flux's version pinned, but were using the latest nightly build of fixpoint. This changes our script to use a pinned build of fixpoint from just before the CLI breakage. This should prevent any sudden breakage from hitting in the future.

### Testing Strategy

`make prepush` plus CI.

### TODO or Help Wanted

None

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.

### AI Use

- [X] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.