### PR TITLE
Convert most boards to PanicWriter

### DIFF
--- a/boards/apollo3/lora_things_plus/src/io.rs
+++ b/boards/apollo3/lora_things_plus/src/io.rs
@@ -2,34 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::ptr::addr_of_mut;
 
 use kernel::debug;
 use kernel::hil::led;
-use kernel::utilities::io_write::IoWrite;
+use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
 
-/// Writer is used by kernel::debug to panic message to the serial port.
-pub struct Writer {}
-
-/// Global static for debug writer
-pub static mut WRITER: Writer = Writer {};
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        let uart = apollo3::uart::Uart::new_uart_0(); // Aliases memory for uart0. Okay bc we are panicking.
-        uart.transmit_sync(buf);
-        buf.len()
-    }
-}
+use apollo3::uart::{Uart, UartPanicWriterConfig, UART0_BASE};
 
 /// Panic handler.
 #[panic_handler]
@@ -42,11 +21,19 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
         apollo3::gpio::Pin::Pin26,
     );
     let led = &mut led::LedLow::new(led_pin);
-    let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic_old(
+    debug::panic::<_, Uart, _, _>(
         &mut [led],
-        writer,
+        UartPanicWriterConfig {
+            registers: UART0_BASE,
+            params: Parameters {
+                baud_rate: 115200,
+                width: Width::Eight,
+                stop_bits: StopBits::One,
+                parity: Parity::None,
+                hw_flow_control: false,
+            },
+        },
         info,
         &cortexm4::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/apollo3/redboard_artemis_atp/src/io.rs
+++ b/boards/apollo3/redboard_artemis_atp/src/io.rs
@@ -2,34 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::ptr::addr_of_mut;
 
 use kernel::debug;
 use kernel::hil::led;
-use kernel::utilities::io_write::IoWrite;
+use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
 
-/// Writer is used by kernel::debug to panic message to the serial port.
-pub struct Writer {}
-
-/// Global static for debug writer
-pub static mut WRITER: Writer = Writer {};
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        let uart = apollo3::uart::Uart::new_uart_0(); // Aliases memory for uart0. Okay bc we are panicking.
-        uart.transmit_sync(buf);
-        buf.len()
-    }
-}
+use apollo3::uart::{Uart, UartPanicWriterConfig, UART0_BASE};
 
 /// Panic handler.
 #[panic_handler]
@@ -42,11 +21,19 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
         apollo3::gpio::Pin::Pin19,
     );
     let led = &mut led::LedLow::new(led_pin);
-    let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic_old(
+    debug::panic::<_, Uart, _, _>(
         &mut [led],
-        writer,
+        UartPanicWriterConfig {
+            registers: UART0_BASE,
+            params: Parameters {
+                baud_rate: 115200,
+                width: Width::Eight,
+                stop_bits: StopBits::One,
+                parity: Parity::None,
+                hw_flow_control: false,
+            },
+        },
         info,
         &cortexm4::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/apollo3/redboard_artemis_nano/src/io.rs
+++ b/boards/apollo3/redboard_artemis_nano/src/io.rs
@@ -2,34 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::ptr::addr_of_mut;
 
 use kernel::debug;
 use kernel::hil::led;
-use kernel::utilities::io_write::IoWrite;
+use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
 
-/// Writer is used by kernel::debug to panic message to the serial port.
-pub struct Writer {}
-
-/// Global static for debug writer
-pub static mut WRITER: Writer = Writer {};
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        let uart = apollo3::uart::Uart::new_uart_0(); // Aliases memory for uart0. Okay bc we are panicking.
-        uart.transmit_sync(buf);
-        buf.len()
-    }
-}
+use apollo3::uart::{Uart, UartPanicWriterConfig, UART0_BASE};
 
 /// Panic handler.
 #[panic_handler]
@@ -42,11 +21,19 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
         apollo3::gpio::Pin::Pin19,
     );
     let led = &mut led::LedLow::new(led_pin);
-    let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic_old(
+    debug::panic::<_, Uart, _, _>(
         &mut [led],
-        writer,
+        UartPanicWriterConfig {
+            registers: UART0_BASE,
+            params: Parameters {
+                baud_rate: 115200,
+                width: Width::Eight,
+                stop_bits: StopBits::One,
+                parity: Parity::None,
+                hw_flow_control: false,
+            },
+        },
         info,
         &cortexm4::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/io.rs
+++ b/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/io.rs
@@ -2,64 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
 
 use kernel::debug;
 use kernel::hil::led;
-use kernel::hil::uart;
-use kernel::utilities::io_write::IoWrite;
+use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
 use nrf52833::gpio::Pin;
-use nrf52833::uart::{Uarte, UARTE0_BASE};
-
-/// Writer is used by kernel::debug to panic message to the serial port.
-pub struct Writer {
-    initialized: bool,
-}
-
-impl Writer {
-    /// Indicate that USART has already been initialized.
-    pub fn set_initialized(&mut self) {
-        self.initialized = true;
-    }
-}
-
-/// Global static for debug writer
-pub static mut WRITER: Writer = Writer { initialized: false };
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        let uart = Uarte::new(UARTE0_BASE);
-
-        use kernel::hil::uart::Configure;
-
-        if !self.initialized {
-            self.initialized = true;
-            let _ = uart.configure(uart::Parameters {
-                baud_rate: 115200,
-                stop_bits: uart::StopBits::One,
-                parity: uart::Parity::None,
-                hw_flow_control: false,
-                width: uart::Width::Eight,
-            });
-        }
-
-        unsafe {
-            for &c in buf {
-                uart.send_byte(c);
-                while !uart.tx_ready() {}
-            }
-        }
-        buf.len()
-    }
-}
+use nrf52833::uart::{UartPanicWriterConfig, Uarte};
 
 /// Default panic handler for the microbit board.
 ///
@@ -67,18 +16,25 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    // MicroBit v2 has an LED matrix, use the upper left LED
-    // let mut led = Led (&gpio::PORT[Pin::P0_28], );
-
     // MicroBit v2 has a microphone LED, use it for panic
-
-    use core::ptr::addr_of_mut;
     let led_kernel_pin = &nrf52833::gpio::nrf52833_gpio_create_pin(Pin::P0_20);
     let led = &mut led::LedLow::new(led_kernel_pin);
-    let writer = &mut *addr_of_mut!(WRITER);
-    debug::panic_old(
+
+    debug::panic::<_, Uarte, _, _>(
         &mut [led],
-        writer,
+        UartPanicWriterConfig {
+            params: Parameters {
+                baud_rate: 115200,
+                stop_bits: StopBits::One,
+                parity: Parity::None,
+                hw_flow_control: false,
+                width: Width::Eight,
+            },
+            txd: Pin::P0_06,
+            rxd: Pin::P1_08,
+            cts: None,
+            rts: None,
+        },
         pi,
         &cortexm4::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/io.rs
@@ -2,72 +2,39 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2024.
 
-use core::fmt::Write;
-use kernel::hil::uart;
-use kernel::hil::uart::Configure;
-use kernel::utilities::io_write::IoWrite;
+use core::panic::PanicInfo;
 
-use nrf52840::uart::{Uarte, UARTE0_BASE};
+use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
 
-struct Writer {
-    initialized: bool,
-}
-
-impl Writer {
-    fn new() -> Self {
-        Self { initialized: false }
-    }
-}
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        // Here, we create a second instance of the Uarte struct.
-        // This is okay because we only call this during a panic, and
-        // we will never actually process the interrupts
-        let uart = Uarte::new(UARTE0_BASE);
-        if !self.initialized {
-            self.initialized = true;
-            let _ = uart.configure(uart::Parameters {
-                baud_rate: 115200,
-                stop_bits: uart::StopBits::One,
-                parity: uart::Parity::None,
-                hw_flow_control: false,
-                width: uart::Width::Eight,
-            });
-        }
-        for &c in buf {
-            unsafe {
-                uart.send_byte(c);
-            }
-            while !uart.tx_ready() {}
-        }
-
-        buf.len()
-    }
-}
+use nrf52840::gpio::Pin;
+use nrf52840::uart::{Uarte, UartPanicWriterConfig};
 
 #[cfg(not(test))]
 #[panic_handler]
 /// Panic handler
-pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     use kernel::debug;
     use kernel::hil::led;
-    use nrf52840::gpio::Pin;
 
     // The nRF52840DK LEDs (see back of board)
     let led_kernel_pin = &nrf52840::gpio::nrf52840_gpio_create_pin(Pin::P0_13);
     let led = &mut led::LedLow::new(led_kernel_pin);
-    let mut writer = Writer::new();
-    debug::panic_old(
+
+    debug::panic::<_, Uarte, _, _>(
         &mut [led],
-        &mut writer,
+        UartPanicWriterConfig {
+            params: Parameters {
+                baud_rate: 115200,
+                stop_bits: StopBits::One,
+                parity: Parity::None,
+                hw_flow_control: false,
+                width: Width::Eight,
+            },
+            txd: Pin::P0_06,
+            rxd: Pin::P0_08,
+            cts: Some(Pin::P0_07),
+            rts: Some(Pin::P0_05),
+        },
         pi,
         &cortexm4::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/io.rs
@@ -7,7 +7,7 @@ use core::panic::PanicInfo;
 use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
 
 use nrf52840::gpio::Pin;
-use nrf52840::uart::{Uarte, UartPanicWriterConfig};
+use nrf52840::uart::{UartPanicWriterConfig, Uarte};
 
 #[cfg(not(test))]
 #[panic_handler]

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/io.rs
@@ -2,72 +2,39 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2024.
 
-use core::fmt::Write;
-use kernel::hil::uart;
-use kernel::hil::uart::Configure;
-use kernel::utilities::io_write::IoWrite;
+use core::panic::PanicInfo;
 
-use nrf52840::uart::{Uarte, UARTE0_BASE};
+use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
 
-struct Writer {
-    initialized: bool,
-}
-
-impl Writer {
-    fn new() -> Self {
-        Self { initialized: false }
-    }
-}
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        // Here, we create a second instance of the Uarte struct.
-        // This is okay because we only call this during a panic, and
-        // we will never actually process the interrupts
-        let uart = Uarte::new(UARTE0_BASE);
-        if !self.initialized {
-            self.initialized = true;
-            let _ = uart.configure(uart::Parameters {
-                baud_rate: 115200,
-                stop_bits: uart::StopBits::One,
-                parity: uart::Parity::None,
-                hw_flow_control: false,
-                width: uart::Width::Eight,
-            });
-        }
-        for &c in buf {
-            unsafe {
-                uart.send_byte(c);
-            }
-            while !uart.tx_ready() {}
-        }
-
-        buf.len()
-    }
-}
+use nrf52840::gpio::Pin;
+use nrf52840::uart::{Uarte, UartPanicWriterConfig};
 
 #[cfg(not(test))]
 #[panic_handler]
 /// Panic handler
-pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     use kernel::debug;
     use kernel::hil::led;
-    use nrf52840::gpio::Pin;
 
     // The nRF52840DK LEDs (see back of board)
     let led_kernel_pin = &nrf52840::gpio::nrf52840_gpio_create_pin(Pin::P0_13);
     let led = &mut led::LedLow::new(led_kernel_pin);
-    let mut writer = Writer::new();
-    debug::panic_old(
+
+    debug::panic::<_, Uarte, _, _>(
         &mut [led],
-        &mut writer,
+        UartPanicWriterConfig {
+            params: Parameters {
+                baud_rate: 115200,
+                stop_bits: StopBits::One,
+                parity: Parity::None,
+                hw_flow_control: false,
+                width: Width::Eight,
+            },
+            txd: Pin::P0_06,
+            rxd: Pin::P0_08,
+            cts: Some(Pin::P0_07),
+            rts: Some(Pin::P0_05),
+        },
         pi,
         &cortexm4::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/io.rs
@@ -7,7 +7,7 @@ use core::panic::PanicInfo;
 use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
 
 use nrf52840::gpio::Pin;
-use nrf52840::uart::{Uarte, UartPanicWriterConfig};
+use nrf52840::uart::{UartPanicWriterConfig, Uarte};
 
 #[cfg(not(test))]
 #[panic_handler]

--- a/boards/cy8cproto_62_4343_w/src/io.rs
+++ b/boards/cy8cproto_62_4343_w/src/io.rs
@@ -3,57 +3,24 @@
 // Copyright OxidOS Automotive 2025 SRL.
 
 use core::panic::PanicInfo;
-use kernel::utilities::cells::OptionalCell;
 
 use psoc62xa::gpio::GpioPin;
-use psoc62xa::scb::Scb;
+use psoc62xa::scb::{Scb, ScbPanicWriterConfig};
 
 use kernel::debug;
 use kernel::hil::led::LedHigh;
-use kernel::utilities::io_write::IoWrite;
-
-/// Writer is used by kernel::debug to panic message to the serial port.
-pub struct Writer {
-    scb: OptionalCell<&'static Scb<'static>>,
-}
-
-impl Writer {
-    pub fn set_scb(&self, scb: &'static Scb) {
-        self.scb.set(scb);
-    }
-}
-
-impl core::fmt::Write for Writer {
-    fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        self.scb.map(|scb| scb.transmit_uart_sync(s.as_bytes()));
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        self.scb.map(|scb| scb.transmit_uart_sync(buf));
-        buf.len()
-    }
-}
-
-pub static mut WRITER: Writer = Writer {
-    scb: OptionalCell::empty(),
-};
 
 /// Panic handler for the CY8CPROTO-062-4343 board.
 #[panic_handler]
 pub unsafe fn panic_fmt(panic_info: &PanicInfo) -> ! {
-    use core::ptr::addr_of_mut;
-    let writer = &mut *addr_of_mut!(WRITER);
     let led_kernel_pin = &GpioPin::new(psoc62xa::gpio::PsocPin::P13_7);
     let led = &mut LedHigh::new(led_kernel_pin);
 
-    debug::panic_old(
+    debug::panic::<_, Scb, _, _>(
         &mut [led],
-        writer,
+        ScbPanicWriterConfig,
         panic_info,
         &cortexm0p::support::nop,
         crate::PANIC_RESOURCES.get(),
-    );
+    )
 }

--- a/boards/cy8cproto_62_4343_w/src/main.rs
+++ b/boards/cy8cproto_62_4343_w/src/main.rs
@@ -316,8 +316,6 @@ pub unsafe fn main() {
     PANIC_RESOURCES.get().map(|resources| {
         resources.chip.put(chip);
     });
-    (*addr_of_mut!(io::WRITER)).set_scb(&peripherals.scb);
-
     kernel::debug!("Initialization complete. Entering main loop.");
 
     //--------------------------------------------------------------------------

--- a/boards/cy8cproto_62_4343_w/src/main.rs
+++ b/boards/cy8cproto_62_4343_w/src/main.rs
@@ -12,8 +12,6 @@ mod io;
 
 kernel::stack_size! {0x2000}
 
-use core::ptr::addr_of_mut;
-
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::led::LedsComponent;
 use kernel::component::Component;

--- a/boards/hail/src/io.rs
+++ b/boards/hail/src/io.rs
@@ -2,64 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::str;
 use kernel::debug;
 use kernel::hil::led;
-use kernel::hil::uart::{self, Configure};
-use kernel::utilities::io_write::IoWrite;
-
-struct Writer {
-    initialized: bool,
-}
-
-static mut WRITER: Writer = Writer { initialized: false };
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        // Here, we create a second instance of the USART0 struct.
-        // This is okay because we only call this during a panic, and
-        // we will never actually process the interrupts
-        let pm = unsafe {
-            kernel::static_init!(sam4l::pm::PowerManager, sam4l::pm::PowerManager::new())
-        };
-        let uart = sam4l::usart::USART::new_usart0(pm);
-        let regs_manager = &sam4l::usart::USARTRegManager::panic_new(&uart);
-        if !self.initialized {
-            self.initialized = true;
-            let _ = uart.configure(uart::Parameters {
-                baud_rate: 115200,
-                width: uart::Width::Eight,
-                stop_bits: uart::StopBits::One,
-                parity: uart::Parity::None,
-                hw_flow_control: false,
-            });
-            uart.enable_tx(regs_manager);
-        }
-        // XXX: I'd like to get this working the "right" way, but I'm not sure how
-        for &c in buf {
-            uart.send_byte(regs_manager, c);
-            while !uart.tx_ready(regs_manager) {}
-        }
-        buf.len()
-    }
-}
+use sam4l::usart::{UsartId, UsartPanicWriterConfig, USART};
 
 /// Panic handler.
 #[cfg(not(test))]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // turn off the non panic leds, just in case
-
-    use core::ptr::addr_of_mut;
     let led_green = sam4l::gpio::GPIOPin::new(sam4l::gpio::Pin::PA14);
     led_green.enable_output();
     led_green.set();
@@ -69,10 +21,12 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
 
     let red_pin = sam4l::gpio::GPIOPin::new(sam4l::gpio::Pin::PA13);
     let led_red = &mut led::LedLow::new(&red_pin);
-    let writer = &mut *addr_of_mut!(WRITER);
-    debug::panic_old(
+
+    debug::panic::<_, USART, _, _>(
         &mut [led_red],
-        writer,
+        UsartPanicWriterConfig {
+            id: UsartId::Usart0,
+        },
         pi,
         &cortexm4::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/hifive1/src/io.rs
+++ b/boards/hifive1/src/io.rs
@@ -2,33 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
 use core::ptr::addr_of_mut;
-use core::str;
 use kernel::debug;
 use kernel::hil::gpio;
 use kernel::hil::led;
-use kernel::utilities::io_write::IoWrite;
+use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
 
-struct Writer {}
-
-static mut WRITER: Writer = Writer {};
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        let uart = sifive::uart::Uart::new(e310_g002::uart::UART0_BASE, 16_000_000);
-        uart.transmit_sync(buf);
-        buf.len()
-    }
-}
+use sifive::uart::{Uart, UartPanicWriterConfig};
 
 /// Panic handler.
 #[cfg(not(test))]
@@ -60,11 +41,20 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         sifive::gpio::pins::pin22::CLEAR,
     );
     let led_red = &mut led::LedLow::new(&led_red_pin);
-    let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic_old(
+    debug::panic::<_, Uart, _, _>(
         &mut [led_red],
-        writer,
+        UartPanicWriterConfig {
+            registers: e310_g002::uart::UART0_BASE,
+            clock_frequency: 16_000_000,
+            params: Parameters {
+                baud_rate: 115200,
+                width: Width::Eight,
+                stop_bits: StopBits::One,
+                parity: Parity::None,
+                hw_flow_control: false,
+            },
+        },
         pi,
         &rv32i::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/hifive1/src/io.rs
+++ b/boards/hifive1/src/io.rs
@@ -3,7 +3,6 @@
 // Copyright Tock Contributors 2022.
 
 use core::panic::PanicInfo;
-use core::ptr::addr_of_mut;
 use kernel::debug;
 use kernel::hil::gpio;
 use kernel::hil::led;

--- a/boards/hifive_inventor/src/io.rs
+++ b/boards/hifive_inventor/src/io.rs
@@ -2,31 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::str;
 use kernel::debug;
 use kernel::hil::led;
-use kernel::utilities::io_write::IoWrite;
+use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
 
-struct Writer {}
-
-static mut WRITER: Writer = Writer {};
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        let uart = sifive::uart::Uart::new(e310_g003::uart::UART0_BASE, 16_000_000);
-        uart.transmit_sync(buf);
-        buf.len()
-    }
-}
+use sifive::uart::{Uart, UartPanicWriterConfig};
 
 /// Panic handler.
 #[cfg(not(test))]
@@ -41,11 +22,20 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         sifive::gpio::pins::pin22::CLEAR,
     );
     let led = &mut led::LedLow::new(&led);
-    let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic_old(
+    debug::panic::<_, Uart, _, _>(
         &mut [led],
-        writer,
+        UartPanicWriterConfig {
+            registers: e310_g003::uart::UART0_BASE,
+            clock_frequency: 16_000_000,
+            params: Parameters {
+                baud_rate: 115200,
+                width: Width::Eight,
+                stop_bits: StopBits::One,
+                parity: Parity::None,
+                hw_flow_control: false,
+            },
+        },
         pi,
         &rv32i::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/hifive_inventor/src/io.rs
+++ b/boards/hifive_inventor/src/io.rs
@@ -13,8 +13,6 @@ use sifive::uart::{Uart, UartPanicWriterConfig};
 #[cfg(not(test))]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    use core::ptr::addr_of_mut;
-
     let led = sifive::gpio::GpioPin::new(
         e310_g003::gpio::GPIO0_BASE,
         sifive::gpio::pins::pin22,

--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -2,67 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
 use kernel::debug;
 use kernel::hil::led;
-use kernel::hil::uart::{self, Configure};
-use kernel::utilities::io_write::IoWrite;
-
-struct Writer {
-    initialized: bool,
-}
-
-static mut WRITER: Writer = Writer { initialized: false };
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        // Here, we create a second instance of the USART3 struct.
-        // This is okay because we only call this during a panic, and
-        // we will never actually process the interrupts
-        let uart = unsafe { sam4l::usart::USART::new_usart3(crate::CHIP.unwrap().pm) };
-        let regs_manager = &sam4l::usart::USARTRegManager::panic_new(&uart);
-        if !self.initialized {
-            self.initialized = true;
-            let _ = uart.configure(uart::Parameters {
-                baud_rate: 115200,
-                width: uart::Width::Eight,
-                stop_bits: uart::StopBits::One,
-                parity: uart::Parity::None,
-                hw_flow_control: false,
-            });
-            uart.enable_tx(regs_manager);
-        }
-        // XXX: I'd like to get this working the "right" way, but I'm not sure how
-        let mut total = 0;
-        for &c in buf {
-            uart.send_byte(regs_manager, c);
-            while !uart.tx_ready(regs_manager) {}
-            total += 1;
-        }
-        total
-    }
-}
+use sam4l::usart::{UsartId, UsartPanicWriterConfig, USART};
 
 /// Panic handler.
 #[cfg(not(test))]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    use core::ptr::addr_of_mut;
-
     let led_pin = sam4l::gpio::GPIOPin::new(sam4l::gpio::Pin::PC22);
     let led = &mut led::LedLow::new(&led_pin);
-    let writer = &mut *addr_of_mut!(WRITER);
-    debug::panic_old(
+
+    debug::panic::<_, USART, _, _>(
         &mut [led],
-        writer,
+        UsartPanicWriterConfig {
+            id: UsartId::Usart3,
+        },
         pi,
         &cortexm4::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/imxrt1050-evkb/src/io.rs
+++ b/boards/imxrt1050-evkb/src/io.rs
@@ -2,63 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::ptr::addr_of_mut;
 
 use kernel::debug;
 use kernel::hil::led;
-use kernel::hil::uart;
-use kernel::hil::uart::Configure;
-use kernel::utilities::io_write::IoWrite;
 
 use imxrt10xx::gpio::PinId;
-
-/// Writer is used by kernel::debug to panic message to the serial port.
-pub struct Writer {
-    initialized: bool,
-}
-
-/// Global static for debug writer
-pub static mut WRITER: Writer = Writer { initialized: false };
-
-impl Writer {
-    /// Indicate that LPUART has already been initialized.
-    pub fn set_initialized(&mut self) {
-        self.initialized = true;
-    }
-}
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        let ccm = imxrt10xx::ccm::Ccm::new();
-        let uart = imxrt10xx::lpuart::Lpuart::new_lpuart1(&ccm);
-
-        if !self.initialized {
-            self.initialized = true;
-
-            let _ = uart.configure(uart::Parameters {
-                baud_rate: 115200,
-                stop_bits: uart::StopBits::One,
-                parity: uart::Parity::None,
-                hw_flow_control: false,
-                width: uart::Width::Eight,
-            });
-        }
-
-        for &c in buf {
-            uart.send_byte(c);
-        }
-        buf.len()
-    }
-}
 
 /// Panic handler.
 #[panic_handler]
@@ -66,11 +15,22 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     // User Led is connected to AdB0_09
     let pin = imxrt10xx::gpio::Pin::from_pin_id(PinId::AdB0_09);
     let led = &mut led::LedLow::new(&pin);
-    let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic_old(
+    let ccm = kernel::static_init!(imxrt10xx::ccm::Ccm, imxrt10xx::ccm::Ccm::new());
+
+    debug::panic::<_, imxrt10xx::lpuart::Lpuart, _, _>(
         &mut [led],
-        writer,
+        imxrt10xx::lpuart::LpuartPanicWriterConfig {
+            ccm,
+            id: imxrt10xx::lpuart::LpuartId::Lpuart1,
+            params: kernel::hil::uart::Parameters {
+                baud_rate: 115200,
+                stop_bits: kernel::hil::uart::StopBits::One,
+                parity: kernel::hil::uart::Parity::None,
+                hw_flow_control: false,
+                width: kernel::hil::uart::Width::Eight,
+            },
+        },
         info,
         &cortexm7::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -10,8 +10,6 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use core::ptr::addr_of_mut;
-
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
 use kernel::capabilities;
@@ -323,7 +321,6 @@ unsafe fn start() -> (
 
     let lpuart_mux = components::console::UartMuxComponent::new(&peripherals.lpuart1, 115200)
         .finalize(components::uart_mux_component_static!());
-    (*addr_of_mut!(io::WRITER)).set_initialized();
 
     // Create capabilities that the board needs to call certain protected kernel
     // functions.

--- a/boards/litex/arty/src/io.rs
+++ b/boards/litex/arty/src/io.rs
@@ -2,29 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::str;
 use kernel::debug;
-use kernel::utilities::io_write::IoWrite;
-
-struct Writer {
-    uart: litex_vexriscv::uart::LiteXUart<'static, crate::socc::SoCRegisterFmt>,
-}
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        self.uart.transmit_sync(buf);
-        buf.len()
-    }
-}
+use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
+use kernel::utilities::StaticRef;
+use litex_vexriscv::led_controller::{LiteXLedController, LiteXLedRegisters};
+use litex_vexriscv::uart::{LiteXUart, LiteXUartPanicWriterConfig, LiteXUartRegisters};
 
 /// Panic handler.
 #[cfg(not(test))]
@@ -35,34 +18,36 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // operation with the hardware in any arbitrary state, and where the caller
     // guarantees that the regular UART driver will not run following any call
     // to `transmit_sync`)
-    let mut writer = Writer {
-        uart: litex_vexriscv::uart::LiteXUart::new(
-            kernel::utilities::StaticRef::new(
-                crate::socc::CSR_UART_BASE
-                    as *const litex_vexriscv::uart::LiteXUartRegisters<crate::socc::SoCRegisterFmt>,
-            ),
-            None, // LiteX simulator has no UART phy
-        ),
-    };
 
     // TODO: this double-initializes the LED controller. Similar to the UART
     // above, this should have the `panic_led` function be static and unsafe,
     // with a guarantee that the rest of the controller will not run after this
     // function is called once:
-    let led0 = litex_vexriscv::led_controller::LiteXLedController::new(
-        kernel::utilities::StaticRef::new(
+    let led0 = LiteXLedController::new(
+        StaticRef::new(
             crate::socc::CSR_LEDS_BASE
-                as *const litex_vexriscv::led_controller::LiteXLedRegisters<
-                    crate::socc::SoCRegisterFmt,
-                >,
+                as *const LiteXLedRegisters<crate::socc::SoCRegisterFmt>,
         ),
         4, // 4 LEDs on this board
     );
-    let panic_led = led0.panic_led(0);
+    let panic_led = led0.panic_led(0).unwrap();
 
-    debug::panic_old(
-        &mut [&mut panic_led.unwrap()],
-        &mut writer,
+    debug::panic::<_, LiteXUart<crate::socc::SoCRegisterFmt>, _, _>(
+        &mut [&panic_led],
+        LiteXUartPanicWriterConfig {
+            uart_base: StaticRef::new(
+                crate::socc::CSR_UART_BASE
+                    as *const LiteXUartRegisters<crate::socc::SoCRegisterFmt>,
+            ),
+            phy_args: None, // LiteX simulator has no UART phy
+            params: Parameters {
+                baud_rate: 115200,
+                stop_bits: StopBits::One,
+                parity: Parity::None,
+                hw_flow_control: false,
+                width: Width::Eight,
+            },
+        },
         pi,
         &rv32i::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/litex/arty/src/io.rs
+++ b/boards/litex/arty/src/io.rs
@@ -25,8 +25,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // function is called once:
     let led0 = LiteXLedController::new(
         StaticRef::new(
-            crate::socc::CSR_LEDS_BASE
-                as *const LiteXLedRegisters<crate::socc::SoCRegisterFmt>,
+            crate::socc::CSR_LEDS_BASE as *const LiteXLedRegisters<crate::socc::SoCRegisterFmt>,
         ),
         4, // 4 LEDs on this board
     );

--- a/boards/litex/sim/src/io.rs
+++ b/boards/litex/sim/src/io.rs
@@ -2,29 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::str;
 use kernel::debug;
-use kernel::utilities::io_write::IoWrite;
-
-struct Writer {
-    uart: litex_vexriscv::uart::LiteXUart<'static, crate::socc::SoCRegisterFmt>,
-}
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        self.uart.transmit_sync(buf);
-        buf.len()
-    }
-}
+use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
+use kernel::utilities::StaticRef;
+use litex_vexriscv::uart::{LiteXUart, LiteXUartPanicWriterConfig, LiteXUartRegisters};
 
 /// Panic handler.
 #[cfg(not(test))]
@@ -35,18 +17,21 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // operation with the hardware in any arbitrary state, and where the caller
     // guarantees that the regular UART driver will not run following any call
     // to `transmit_sync`)
-    let mut writer = Writer {
-        uart: litex_vexriscv::uart::LiteXUart::new(
-            kernel::utilities::StaticRef::new(
+    debug::panic_print::<LiteXUart<crate::socc::SoCRegisterFmt>, _, _>(
+        LiteXUartPanicWriterConfig {
+            uart_base: StaticRef::new(
                 crate::socc::CSR_UART_BASE
-                    as *const litex_vexriscv::uart::LiteXUartRegisters<crate::socc::SoCRegisterFmt>,
+                    as *const LiteXUartRegisters<crate::socc::SoCRegisterFmt>,
             ),
-            None, // LiteX simulator has no UART phy
-        ),
-    };
-
-    debug::panic_print_old(
-        &mut writer,
+            phy_args: None, // LiteX simulator has no UART phy
+            params: Parameters {
+                baud_rate: 115200,
+                stop_bits: StopBits::One,
+                parity: Parity::None,
+                hw_flow_control: false,
+                width: Width::Eight,
+            },
+        },
         pi,
         &rv32i::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/lora_e5_mini/src/io.rs
+++ b/boards/lora_e5_mini/src/io.rs
@@ -2,68 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2025.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::ptr::addr_of_mut;
 
 use kernel::hil::led;
-use kernel::utilities::io_write::IoWrite;
-
 use kernel::hil::led::Led;
-use kernel::hil::uart;
-use kernel::hil::uart::Configure;
+use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
+
 use stm32wle5jc::chip_specs::Stm32wle5jcSpecs;
-use stm32wle5jc::clocks;
 use stm32wle5jc::gpio::PinId;
-/// Writer is used by kernel::debug to panic message to the serial port.
-pub struct Writer {
-    initialized: bool,
-}
-
-/// Global static for debug writer
-pub static mut WRITER: Writer = Writer { initialized: false };
-
-impl Writer {
-    /// Indicate that USART has already been initialized. Trying to double
-    /// initialize USART1 causes stm32f429zi to go into in in-deterministic state.
-    pub fn set_initialized(&mut self) {
-        self.initialized = true;
-    }
-}
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        let rcc = stm32wle5jc::rcc::Rcc::new();
-        let clocks: clocks::Clocks<Stm32wle5jcSpecs> = clocks::Clocks::new(&rcc);
-        let usart = stm32wle5jc::usart::Usart::new_usart1(&clocks);
-
-        if !self.initialized {
-            self.initialized = true;
-
-            let _ = usart.configure(uart::Parameters {
-                baud_rate: 115200,
-                stop_bits: uart::StopBits::One,
-                parity: uart::Parity::None,
-                hw_flow_control: false,
-                width: uart::Width::Eight,
-            });
-        }
-
-        let mut written = 0;
-        for byte in buf {
-            usart.send_byte(*byte);
-            written += 1;
-        }
-        written
-    }
-}
+use stm32wle5jc::usart::{Usart, UsartId, UsartPanicWriterConfig};
 
 /// Panic handler.
 #[panic_handler]
@@ -74,13 +21,15 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     //
     // Relying on `main.rs` to initialize clocks/gpios may result in the gpio
     // not being properly configured if the panic occurs early in `main.rs`.
-    let rcc = stm32wle5jc::rcc::Rcc::new();
-    let clocks: stm32wle5jc::clocks::Clocks<Stm32wle5jcSpecs> =
-        stm32wle5jc::clocks::Clocks::new(&rcc);
+    let rcc = kernel::static_init!(stm32wle5jc::rcc::Rcc, stm32wle5jc::rcc::Rcc::new());
+    let clocks = kernel::static_init!(
+        stm32wle5jc::clocks::Clocks<'static, Stm32wle5jcSpecs>,
+        stm32wle5jc::clocks::Clocks::new(rcc)
+    );
     let syscfg = stm32wle5jc::syscfg::Syscfg::new();
     let exti = stm32wle5jc::exti::Exti::new(&syscfg);
 
-    let gpio_ports = stm32wle5jc::gpio::GpioPorts::new(&clocks, &exti);
+    let gpio_ports = stm32wle5jc::gpio::GpioPorts::new(clocks, &exti);
     gpio_ports.setup_circular_deps();
     gpio_ports
         .get_port_from_port_id(stm32wle5jc::gpio::PortId::B)
@@ -101,18 +50,18 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
         pin.set_alternate_function(stm32wle5jc::gpio::AlternateFunction::AF7);
     });
 
-    let usart = stm32wle5jc::usart::Usart::new_usart1(&clocks);
-    usart.enable_clock();
-    let _ = usart.configure(uart::Parameters {
-        baud_rate: 115200,
-        stop_bits: uart::StopBits::One,
-        parity: uart::Parity::None,
-        hw_flow_control: false,
-        width: uart::Width::Eight,
-    });
-
-    kernel::debug::panic_print_old(
-        &mut *addr_of_mut!(WRITER),
+    kernel::debug::panic_print::<Usart, _, _>(
+        UsartPanicWriterConfig {
+            id: UsartId::Usart1,
+            clocks,
+            params: Parameters {
+                baud_rate: 115200,
+                stop_bits: StopBits::One,
+                parity: Parity::None,
+                hw_flow_control: false,
+                width: Width::Eight,
+            },
+        },
         info,
         &cortexm4::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/lora_e5_mini/src/main.rs
+++ b/boards/lora_e5_mini/src/main.rs
@@ -12,8 +12,6 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
-use core::ptr::addr_of_mut;
-
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use kernel::capabilities;
 use kernel::component::Component;

--- a/boards/lora_e5_mini/src/main.rs
+++ b/boards/lora_e5_mini/src/main.rs
@@ -273,8 +273,6 @@ pub unsafe fn main() {
     let uart_mux = components::console::UartMuxComponent::new(&base_peripherals.usart1, 115200)
         .finalize(components::uart_mux_component_static!());
 
-    (*addr_of_mut!(io::WRITER)).set_initialized();
-
     //--------------------------------------------------------------------
     // Alarm
     //--------------------------------------------------------------------

--- a/boards/lpc55s69-evk/src/io.rs
+++ b/boards/lpc55s69-evk/src/io.rs
@@ -19,116 +19,15 @@
 //!
 //! Reference: *LPC55S6x/LPC55S2x/LPC552x User Manual* (NXP).
 
-use crate::LPCPin;
-use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::ptr::addr_of_mut;
 use kernel::debug;
 use kernel::hil::gpio::Configure;
 use kernel::hil::led::LedHigh;
-use kernel::hil::uart::{Configure as UARTconfig, Parameters, Parity, StopBits, Width};
-use kernel::utilities::cells::OptionalCell;
-use kernel::utilities::io_write::IoWrite;
-use lpc55s6x::gpio::GpioPin;
+use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
+use lpc55s6x::gpio::{GpioPin, LPCPin};
 use lpc55s6x::iocon::{Config, Function, Iocon, Pull, Slew};
-use lpc55s6x::uart::Uart;
 
-pub struct Writer {
-    uart: OptionalCell<&'static Uart<'static>>,
-    rtt: OptionalCell<&'static segger::rtt::SeggerRttMemory<'static>>,
-}
-
-impl Writer {
-    pub fn set_uart(&self, uart: &'static Uart) {
-        self.uart.set(uart);
-    }
-
-    pub fn set_rtt_memory(&self, rtt: &'static segger::rtt::SeggerRttMemory<'static>) {
-        self.rtt.set(rtt);
-    }
-
-    fn configure_uart(&self, uart: &Uart) {
-        if !uart.is_configured() {
-            let params = Parameters {
-                // USART initial configuration, using default settings
-                baud_rate: 115200,
-                width: Width::Eight,
-                stop_bits: StopBits::One,
-                parity: Parity::None,
-                hw_flow_control: false,
-            };
-
-            let _ = uart.configure(params);
-
-            let iocon = Iocon::new();
-
-            iocon.configure_pin(
-                LPCPin::P0_29,
-                Config {
-                    function: Function::Alt1,
-                    pull: Pull::None,
-                    digital_mode: true,
-                    slew: Slew::Standard,
-                    invert: false,
-                    open_drain: false,
-                },
-            );
-            iocon.configure_pin(
-                LPCPin::P0_30,
-                Config {
-                    function: Function::Alt1,
-                    pull: Pull::None,
-                    digital_mode: true,
-                    slew: Slew::Standard,
-                    invert: false,
-                    open_drain: false,
-                },
-            );
-        }
-    }
-
-    fn write_to_uart(&self, uart: &Uart, buf: &[u8]) {
-        for &c in buf {
-            uart.send_byte(c);
-            while !uart.uart_is_writable() {}
-        }
-    }
-}
-
-pub static mut WRITER: Writer = Writer {
-    uart: OptionalCell::empty(),
-    rtt: OptionalCell::empty(),
-};
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        self.uart.map_or_else(
-            || {
-                let clocks = lpc55s6x::clocks::Clock::new();
-                let flexcomm = lpc55s6x::flexcomm::Flexcomm::new(0);
-
-                let uart = Uart::new_uart0(&clocks, &flexcomm);
-                self.configure_uart(&uart);
-                self.write_to_uart(&uart, buf);
-            },
-            |uart| {
-                self.configure_uart(uart);
-                self.write_to_uart(uart, buf);
-            },
-        );
-        self.rtt.map(|rtt| {
-            rtt.write_sync(buf);
-        });
-        buf.len()
-    }
-}
+use lpc55s6x::uart::{Uart, UartPanicWriterConfig};
 
 #[panic_handler]
 pub unsafe fn panic_fmt(panic_info: &PanicInfo) -> ! {
@@ -145,13 +44,45 @@ pub unsafe fn panic_fmt(panic_info: &PanicInfo) -> ! {
     let red_led = GpioPin::new(LPCPin::P1_6);
     red_led.make_output();
     let led = &mut LedHigh::new(&red_led);
-    let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic_old(
-        &mut [led],
-        writer,
-        panic_info,
-        &cortexm33::support::nop,
-        crate::PANIC_RESOURCES.get(),
-    )
+    if crate::USB_DEBUGGING {
+        // Use the RTT output that needs to be setup in main.rs.
+
+        crate::RTT_BUFFER.get().map_or_else(
+            || debug::panic_blink_forever(&mut [led]),
+            |rtt| {
+                debug::panic::<_, segger::rtt::SeggerRttMemory, _, _>(
+                    &mut [led],
+                    rtt,
+                    panic_info,
+                    &cortexm33::support::nop,
+                    crate::PANIC_RESOURCES.get(),
+                )
+            },
+        )
+    } else {
+        // Use the LPC55 UART for panic output.
+
+        debug::panic::<_, Uart, _, _>(
+            &mut [led],
+            UartPanicWriterConfig {
+                params: Parameters {
+                    baud_rate: 115200,
+                    stop_bits: StopBits::One,
+                    parity: Parity::None,
+                    hw_flow_control: false,
+                    width: Width::Eight,
+                },
+                id: lpc55s6x::uart::UartId::Uart0,
+                clocks: &lpc55s6x::clocks::Clock::new(),
+                flexcomm: &lpc55s6x::flexcomm::Flexcomm::new(0),
+                iocon: &iocon_ctrl,
+                pin1: LPCPin::P0_29,
+                pin2: LPCPin::P0_30,
+            },
+            panic_info,
+            &cortexm33::support::nop,
+            crate::PANIC_RESOURCES.get(),
+        )
+    }
 }

--- a/boards/lpc55s69-evk/src/main.rs
+++ b/boards/lpc55s69-evk/src/main.rs
@@ -7,8 +7,6 @@
 
 mod io;
 
-use core::ptr::addr_of_mut;
-
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use capsules_system::scheduler::round_robin::RoundRobinSched;
 use components::led::LedsComponent;
@@ -44,6 +42,12 @@ unsafe fn get_peripherals(
     )
 }
 
+/// Whether to use UART debugging or Segger RTT (USB) debugging.
+///
+/// - Set to false to use UART.
+/// - Set to true to use Segger RTT over USB.
+pub const USB_DEBUGGING: bool = false;
+
 const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
     capsules_system::process_policies::PanicFaultPolicy {};
 
@@ -56,6 +60,10 @@ type ChipHw = Lpc55s69<'static, Lpc55s69DefaultPeripheral<'static>>;
 type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
+    SingleThreadValue::new();
+
+/// In-memory buffer used for the Segger Real Time Transfer (RTT) mechanism.
+static RTT_BUFFER: SingleThreadValue<&'static segger::rtt::SeggerRttMemory<'static>> =
     SingleThreadValue::new();
 
 pub struct Lpc55s69evk {
@@ -329,12 +337,12 @@ unsafe fn start() -> (
     };
     uart.configure(params).unwrap();
 
-    (*addr_of_mut!(io::WRITER)).set_uart(&peripherals.uart);
-
-    let rtt_memory = components::segger_rtt::SeggerRttMemoryComponent::new()
+    let rtt_memory_refs = components::segger_rtt::SeggerRttMemoryComponent::new()
         .finalize(components::segger_rtt_memory_component_static!());
-
-    (*addr_of_mut!(io::WRITER)).set_rtt_memory(rtt_memory.rtt_memory);
+    let _ = RTT_BUFFER
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            *core::ptr::addr_of!(rtt_memory_refs.rtt_memory),
+        );
 
     let uart_mux = components::console::UartMuxComponent::new(uart, 115200)
         .finalize(components::uart_mux_component_static!());

--- a/boards/microbit_v2/src/io.rs
+++ b/boards/microbit_v2/src/io.rs
@@ -8,7 +8,7 @@ use kernel::debug;
 use kernel::hil::led;
 use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
 use nrf52833::gpio::Pin;
-use nrf52833::uart::{Uarte, UartPanicWriterConfig};
+use nrf52833::uart::{UartPanicWriterConfig, Uarte};
 
 /// Default panic handler for the microbit board.
 ///
@@ -17,7 +17,6 @@ use nrf52833::uart::{Uarte, UartPanicWriterConfig};
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // MicroBit v2 has a microphone LED, use it for panic
-    use core::ptr::addr_of_mut;
     let led_kernel_pin = &nrf52833::gpio::nrf52833_gpio_create_pin(Pin::P0_20);
     let led = &mut led::LedLow::new(led_kernel_pin);
 

--- a/boards/microbit_v2/src/io.rs
+++ b/boards/microbit_v2/src/io.rs
@@ -2,64 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
 
 use kernel::debug;
 use kernel::hil::led;
-use kernel::hil::uart;
-use kernel::utilities::io_write::IoWrite;
+use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
 use nrf52833::gpio::Pin;
-use nrf52833::uart::{Uarte, UARTE0_BASE};
-
-/// Writer is used by kernel::debug to panic message to the serial port.
-pub struct Writer {
-    initialized: bool,
-}
-
-impl Writer {
-    /// Indicate that USART has already been initialized.
-    pub fn set_initialized(&mut self) {
-        self.initialized = true;
-    }
-}
-
-/// Global static for debug writer
-pub static mut WRITER: Writer = Writer { initialized: false };
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        let uart = Uarte::new(UARTE0_BASE);
-
-        use kernel::hil::uart::Configure;
-
-        if !self.initialized {
-            self.initialized = true;
-            let _ = uart.configure(uart::Parameters {
-                baud_rate: 115200,
-                stop_bits: uart::StopBits::One,
-                parity: uart::Parity::None,
-                hw_flow_control: false,
-                width: uart::Width::Eight,
-            });
-        }
-
-        unsafe {
-            for &c in buf {
-                uart.send_byte(c);
-                while !uart.tx_ready() {}
-            }
-        }
-        buf.len()
-    }
-}
+use nrf52833::uart::{Uarte, UartPanicWriterConfig};
 
 /// Default panic handler for the microbit board.
 ///
@@ -67,18 +16,26 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    // MicroBit v2 has an LED matrix, use the upper left LED
-    // let mut led = Led (&gpio::PORT[Pin::P0_28], );
-
     // MicroBit v2 has a microphone LED, use it for panic
-
     use core::ptr::addr_of_mut;
     let led_kernel_pin = &nrf52833::gpio::nrf52833_gpio_create_pin(Pin::P0_20);
     let led = &mut led::LedLow::new(led_kernel_pin);
-    let writer = &mut *addr_of_mut!(WRITER);
-    debug::panic_old(
+
+    debug::panic::<_, Uarte, _, _>(
         &mut [led],
-        writer,
+        UartPanicWriterConfig {
+            params: Parameters {
+                baud_rate: 115200,
+                stop_bits: StopBits::One,
+                parity: Parity::None,
+                hw_flow_control: false,
+                width: Width::Eight,
+            },
+            txd: Pin::P0_06,
+            rxd: Pin::P1_08,
+            cts: None,
+            rts: None,
+        },
         pi,
         &cortexm4::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/msp_exp432p401r/src/io.rs
+++ b/boards/msp_exp432p401r/src/io.rs
@@ -2,35 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::ptr::addr_of_mut;
 use kernel::debug;
 use kernel::hil::led;
-use kernel::utilities::io_write::IoWrite;
+use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
 use msp432::gpio::IntPinNr;
+use msp432::uart::{Uart, UartId, UartPanicWriterConfig};
 use msp432::wdt::Wdt;
-
-/// Uart is used by kernel::debug to panic message to the serial port.
-pub struct Uart {}
-
-/// Global static for debug writer
-pub static mut UART: Uart = Uart {};
-
-impl Write for Uart {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Uart {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        let uart0 = msp432::uart::Uart::new(msp432::usci::USCI_A0_BASE, 0, 1, 1, 1);
-        uart0.transmit_sync(buf);
-        buf.len()
-    }
-}
 
 /// Panic handler
 #[panic_handler]
@@ -38,13 +16,22 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     const LED1_PIN: IntPinNr = IntPinNr::P01_0;
     let gpio_pin = msp432::gpio::IntPin::new(LED1_PIN);
     let led = &mut led::LedHigh::new(&gpio_pin);
-    let writer = &mut *addr_of_mut!(UART);
-    let wdt = Wdt::new();
 
+    let wdt = Wdt::new();
     wdt.disable();
-    debug::panic_old(
+
+    debug::panic::<_, Uart, _, _>(
         &mut [led],
-        writer,
+        UartPanicWriterConfig {
+            id: UartId::UcA0,
+            params: Parameters {
+                baud_rate: 115200,
+                stop_bits: StopBits::One,
+                parity: Parity::None,
+                hw_flow_control: false,
+                width: Width::Eight,
+            },
+        },
         info,
         &cortexm4::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/nano_rp2040_connect/src/io.rs
+++ b/boards/nano_rp2040_connect/src/io.rs
@@ -8,6 +8,7 @@ use kernel::debug;
 use kernel::hil::led::LedHigh;
 use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
 
+use rp2040::clocks::Clocks;
 use rp2040::gpio::{RPGpio, RPGpioPin};
 use rp2040::uart::{Uart, UartId, UartPanicWriterConfig};
 
@@ -21,6 +22,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_kernel_pin = &RPGpioPin::new(RPGpio::GPIO25);
     let led = &mut LedHigh::new(led_kernel_pin);
 
+    let clocks = Clocks::new();
     debug::panic::<_, Uart, _, _>(
         &mut [led],
         UartPanicWriterConfig {
@@ -32,6 +34,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
                 stop_bits: StopBits::One,
                 hw_flow_control: false,
             },
+            clocks: &clocks,
         },
         pi,
         &cortexm0p::support::nop,

--- a/boards/nano_rp2040_connect/src/io.rs
+++ b/boards/nano_rp2040_connect/src/io.rs
@@ -2,82 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
 
 use kernel::debug;
 use kernel::hil::led::LedHigh;
-use kernel::hil::uart::{Configure, Parameters, Parity, StopBits, Width};
-use kernel::utilities::cells::OptionalCell;
-use kernel::utilities::io_write::IoWrite;
+use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
 
-use rp2040::clocks::Clocks;
-use rp2040::gpio::{GpioFunction, RPGpio, RPGpioPin};
-use rp2040::uart::Uart;
-
-/// Writer is used by kernel::debug to panic message to the serial port.
-pub struct Writer {
-    uart: OptionalCell<&'static Uart<'static>>,
-}
-
-impl Writer {
-    pub fn set_uart(&self, uart: &'static Uart) {
-        self.uart.set(uart);
-    }
-
-    fn write_to_uart(&self, uart: &Uart, buf: &[u8]) {
-        for &c in buf {
-            uart.send_byte(c);
-        }
-    }
-}
-
-/// Global static for debug writer
-pub static mut WRITER: Writer = Writer {
-    uart: OptionalCell::empty(),
-};
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        self.uart.map_or_else(
-            || {
-                // If no UART is configured for panic print, use UART0
-                let clocks = &Clocks::new();
-                let uart0 = &Uart::new_uart0(clocks);
-
-                if !uart0.is_configured() {
-                    let parameters = Parameters {
-                        baud_rate: 115200,
-                        width: Width::Eight,
-                        parity: Parity::None,
-                        stop_bits: StopBits::One,
-                        hw_flow_control: false,
-                    };
-                    //configure parameters of uart for sending bytes
-                    let _result = uart0.configure(parameters);
-                    //set RX and TX pins in UART mode
-                    let gpio_tx = RPGpioPin::new(RPGpio::GPIO0);
-                    let gpio_rx = RPGpioPin::new(RPGpio::GPIO1);
-                    gpio_rx.set_function(GpioFunction::UART);
-                    gpio_tx.set_function(GpioFunction::UART);
-                }
-
-                self.write_to_uart(uart0, buf);
-            },
-            |uart| {
-                self.write_to_uart(uart, buf);
-            },
-        );
-        buf.len()
-    }
-}
+use rp2040::gpio::{RPGpio, RPGpioPin};
+use rp2040::uart::{Uart, UartId, UartPanicWriterConfig};
 
 /// Default panic handler for the Arduino Nano RP2040 Connect board.
 ///
@@ -86,15 +18,21 @@ impl IoWrite for Writer {
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // LED is connected to GPIO 25
-
-    use core::ptr::addr_of_mut;
     let led_kernel_pin = &RPGpioPin::new(RPGpio::GPIO25);
     let led = &mut LedHigh::new(led_kernel_pin);
-    let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic_old(
+    debug::panic::<_, Uart, _, _>(
         &mut [led],
-        writer,
+        UartPanicWriterConfig {
+            id: UartId::Uart0,
+            params: Parameters {
+                baud_rate: 115200,
+                width: Width::Eight,
+                parity: Parity::None,
+                stop_bits: StopBits::One,
+                hw_flow_control: false,
+            },
+        },
         pi,
         &cortexm0p::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -10,8 +10,6 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use core::ptr::addr_of_mut;
-
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
 use components::led::LedsComponent;

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -293,9 +293,6 @@ pub unsafe fn start() -> (
     // Unreset all peripherals
     resets.unreset_all_except(&[], true);
 
-    // Set the UART used for panic
-    (*addr_of_mut!(io::WRITER)).set_uart(&peripherals.uart0);
-
     //set RX and TX pins in UART mode
     let gpio_tx = peripherals.pins.get_pin(RPGpio::GPIO0);
     let gpio_rx = peripherals.pins.get_pin(RPGpio::GPIO1);

--- a/boards/nordic/nrf52840_dongle/src/io.rs
+++ b/boards/nordic/nrf52840_dongle/src/io.rs
@@ -2,67 +2,39 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
-use kernel::debug;
-use kernel::hil::led;
-use kernel::hil::uart::{self, Configure};
-use kernel::utilities::io_write::IoWrite;
+
+use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
+
 use nrf52840::gpio::Pin;
-use nrf52840::uart::{Uarte, UARTE0_BASE};
-
-struct Writer {
-    initialized: bool,
-}
-
-static mut WRITER: Writer = Writer { initialized: false };
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        // Here, we create a second instance of the Uarte struct.
-        // This is okay because we only call this during a panic, and
-        // we will never actually process the interrupts
-        let uart = Uarte::new(UARTE0_BASE);
-        if !self.initialized {
-            self.initialized = true;
-            let _ = uart.configure(uart::Parameters {
-                baud_rate: 115200,
-                stop_bits: uart::StopBits::One,
-                parity: uart::Parity::None,
-                hw_flow_control: false,
-                width: uart::Width::Eight,
-            });
-        }
-        for &c in buf {
-            unsafe {
-                uart.send_byte(c);
-            }
-            while !uart.tx_ready() {}
-        }
-        buf.len()
-    }
-}
+use nrf52840::uart::{UartPanicWriterConfig, Uarte};
 
 #[cfg(not(test))]
 #[panic_handler]
 /// Panic handler
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    // The nRF52840 Dongle LEDs (see back of board)
+    use kernel::debug;
+    use kernel::hil::led;
 
-    use core::ptr::addr_of_mut;
+    // The nRF52840 Dongle LEDs (see back of board)
     let led_kernel_pin = &nrf52840::gpio::nrf52840_gpio_create_pin(Pin::P0_06);
     let led = &mut led::LedLow::new(led_kernel_pin);
-    let writer = &mut *addr_of_mut!(WRITER);
-    debug::panic_old(
+
+    debug::panic::<_, Uarte, _, _>(
         &mut [led],
-        writer,
+        UartPanicWriterConfig {
+            params: Parameters {
+                baud_rate: 115200,
+                stop_bits: StopBits::One,
+                parity: Parity::None,
+                hw_flow_control: false,
+                width: Width::Eight,
+            },
+            txd: Pin::P0_15,
+            rxd: Pin::P0_20,
+            cts: Some(Pin::P0_17),
+            rts: Some(Pin::P0_13),
+        },
         pi,
         &cortexm4::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/nucleo_f429zi/src/io.rs
+++ b/boards/nucleo_f429zi/src/io.rs
@@ -2,88 +2,43 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::ptr::addr_of_mut;
 
 use kernel::debug;
 use kernel::hil::led;
-use kernel::hil::uart;
-use kernel::hil::uart::Configure;
-use kernel::utilities::io_write::IoWrite;
 
 use stm32f429zi::chip_specs::Stm32f429Specs;
 use stm32f429zi::gpio::PinId;
-
-/// Writer is used by kernel::debug to panic message to the serial port.
-pub struct Writer {
-    initialized: bool,
-}
-
-/// Global static for debug writer
-pub static mut WRITER: Writer = Writer { initialized: false };
-
-impl Writer {
-    /// Indicate that USART has already been initialized. Trying to double
-    /// initialize USART2 causes STM32F446RE to go into in in-deterministic state.
-    pub fn set_initialized(&mut self) {
-        self.initialized = true;
-    }
-}
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        let rcc = stm32f429zi::rcc::Rcc::new();
-        let clocks: stm32f429zi::clocks::Clocks<Stm32f429Specs> =
-            stm32f429zi::clocks::Clocks::new(&rcc);
-        let uart = stm32f429zi::usart::Usart::new_usart3(&clocks);
-
-        if !self.initialized {
-            self.initialized = true;
-
-            let _ = uart.configure(uart::Parameters {
-                baud_rate: 115200,
-                stop_bits: uart::StopBits::One,
-                parity: uart::Parity::None,
-                hw_flow_control: false,
-                width: uart::Width::Eight,
-            });
-        }
-
-        for &c in buf {
-            uart.send_byte(c);
-        }
-        buf.len()
-    }
-}
 
 /// Panic handler.
 #[panic_handler]
 pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     // User LD2 is connected to PB07
-    // Have to reinitialize several peripherals because otherwise can't access them here.
-    let rcc = stm32f429zi::rcc::Rcc::new();
-    let clocks: stm32f429zi::clocks::Clocks<Stm32f429Specs> =
-        stm32f429zi::clocks::Clocks::new(&rcc);
-    let syscfg = stm32f429zi::syscfg::Syscfg::new(&clocks);
+    let rcc = kernel::static_init!(stm32f429zi::rcc::Rcc, stm32f429zi::rcc::Rcc::new());
+    let clocks = kernel::static_init!(
+        stm32f429zi::clocks::Clocks<Stm32f429Specs>,
+        stm32f429zi::clocks::Clocks::new(rcc)
+    );
+    let syscfg = stm32f429zi::syscfg::Syscfg::new(clocks);
     let exti = stm32f429zi::exti::Exti::new(&syscfg);
     let pin = stm32f429zi::gpio::Pin::new(PinId::PB07, &exti);
-    let gpio_ports = stm32f429zi::gpio::GpioPorts::new(&clocks, &exti);
+    let gpio_ports = stm32f429zi::gpio::GpioPorts::new(clocks, &exti);
     pin.set_ports_ref(&gpio_ports);
     let led = &mut led::LedHigh::new(&pin);
 
-    let writer = &mut *addr_of_mut!(WRITER);
-
-    debug::panic_old(
+    debug::panic::<_, stm32f429zi::usart::Usart<'static, stm32f429zi::dma::Dma1<'static>>, _, _>(
         &mut [led],
-        writer,
+        stm32f429zi::usart::UsartPanicWriterConfig {
+            id: stm32f429zi::usart::UsartId::Usart3,
+            clocks,
+            params: kernel::hil::uart::Parameters {
+                baud_rate: 115200,
+                stop_bits: kernel::hil::uart::StopBits::One,
+                parity: kernel::hil::uart::Parity::None,
+                hw_flow_control: false,
+                width: kernel::hil::uart::Width::Eight,
+            },
+        },
         info,
         &cortexm4::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -10,7 +10,6 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use core::ptr::addr_of_mut;
 
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
@@ -395,8 +394,6 @@ unsafe fn start() -> (
     base_peripherals.usart3.enable_clock();
     let uart_mux = components::console::UartMuxComponent::new(&base_peripherals.usart3, 115200)
         .finalize(components::uart_mux_component_static!());
-
-    (*addr_of_mut!(io::WRITER)).set_initialized();
 
     // Create capabilities that the board needs to call certain protected kernel
     // functions.

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -10,7 +10,6 @@
 #![no_main]
 #![deny(missing_docs)]
 
-
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
 use kernel::capabilities;

--- a/boards/nucleo_f446re/src/io.rs
+++ b/boards/nucleo_f446re/src/io.rs
@@ -2,88 +2,43 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::ptr::addr_of_mut;
 
 use kernel::debug;
 use kernel::hil::led;
-use kernel::hil::uart;
-use kernel::hil::uart::Configure;
-use kernel::utilities::io_write::IoWrite;
 
 use stm32f446re::chip_specs::Stm32f446Specs;
 use stm32f446re::gpio::PinId;
-
-/// Writer is used by kernel::debug to panic message to the serial port.
-pub struct Writer {
-    initialized: bool,
-}
-
-/// Global static for debug writer
-pub static mut WRITER: Writer = Writer { initialized: false };
-
-impl Writer {
-    /// Indicate that USART has already been initialized. Trying to double
-    /// initialize USART2 causes STM32F446RE to go into in in-deterministic state.
-    pub fn set_initialized(&mut self) {
-        self.initialized = true;
-    }
-}
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        let rcc = stm32f446re::rcc::Rcc::new();
-        let clocks: stm32f446re::clocks::Clocks<Stm32f446Specs> =
-            stm32f446re::clocks::Clocks::new(&rcc);
-        let uart = stm32f446re::usart::Usart::new_usart2(&clocks);
-
-        if !self.initialized {
-            self.initialized = true;
-
-            let _ = uart.configure(uart::Parameters {
-                baud_rate: 115200,
-                stop_bits: uart::StopBits::One,
-                parity: uart::Parity::None,
-                hw_flow_control: false,
-                width: uart::Width::Eight,
-            });
-        }
-
-        for &c in buf {
-            uart.send_byte(c);
-        }
-        buf.len()
-    }
-}
 
 /// Panic handler.
 #[panic_handler]
 pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     // User LD2 is connected to PA05
-    // Have to reinitialize several peripherals because otherwise can't access them here.
-    let rcc = stm32f446re::rcc::Rcc::new();
-    let clocks: stm32f446re::clocks::Clocks<Stm32f446Specs> =
-        stm32f446re::clocks::Clocks::new(&rcc);
-    let syscfg = stm32f446re::syscfg::Syscfg::new(&clocks);
+    let rcc = kernel::static_init!(stm32f446re::rcc::Rcc, stm32f446re::rcc::Rcc::new());
+    let clocks = kernel::static_init!(
+        stm32f446re::clocks::Clocks<Stm32f446Specs>,
+        stm32f446re::clocks::Clocks::new(rcc)
+    );
+    let syscfg = stm32f446re::syscfg::Syscfg::new(clocks);
     let exti = stm32f446re::exti::Exti::new(&syscfg);
     let pin = stm32f446re::gpio::Pin::new(PinId::PA05, &exti);
-    let gpio_ports = stm32f446re::gpio::GpioPorts::new(&clocks, &exti);
+    let gpio_ports = stm32f446re::gpio::GpioPorts::new(clocks, &exti);
     pin.set_ports_ref(&gpio_ports);
     let led = &mut led::LedHigh::new(&pin);
 
-    let writer = &mut *addr_of_mut!(WRITER);
-
-    debug::panic_old(
+    debug::panic::<_, stm32f446re::usart::Usart<'static, stm32f446re::dma::Dma1<'static>>, _, _>(
         &mut [led],
-        writer,
+        stm32f446re::usart::UsartPanicWriterConfig {
+            id: stm32f446re::usart::UsartId::Usart2,
+            clocks,
+            params: kernel::hil::uart::Parameters {
+                baud_rate: 115200,
+                stop_bits: kernel::hil::uart::StopBits::One,
+                parity: kernel::hil::uart::Parity::None,
+                hw_flow_control: false,
+                width: kernel::hil::uart::Width::Eight,
+            },
+        },
         info,
         &cortexm4::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -10,7 +10,6 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use core::ptr::addr_of_mut;
 
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
@@ -338,10 +337,6 @@ unsafe fn start() -> (
     base_peripherals.usart2.enable_clock();
     let uart_mux = components::console::UartMuxComponent::new(&base_peripherals.usart2, 115200)
         .finalize(components::uart_mux_component_static!());
-
-    // `finalize()` configures the underlying USART, so we need to
-    // tell `send_byte()` not to configure the USART again.
-    (*addr_of_mut!(io::WRITER)).set_initialized();
 
     // Create capabilities that the board needs to call certain protected kernel
     // functions.

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -10,7 +10,6 @@
 #![no_main]
 #![deny(missing_docs)]
 
-
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
 use kernel::capabilities;

--- a/boards/opentitan/earlgrey-cw310/src/io.rs
+++ b/boards/opentitan/earlgrey-cw310/src/io.rs
@@ -2,34 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::str;
 use earlgrey::chip_config::EarlGreyConfig;
 use kernel::debug;
-use kernel::utilities::io_write::IoWrite;
+use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
+use lowrisc::uart::{Uart, UartPanicWriterConfig};
 
-struct Writer {}
-
-static mut WRITER: Writer = Writer {};
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        // This creates a second instance of the UART peripheral, and should only be used
-        // during panic.
-        earlgrey::uart::Uart::new(
-            earlgrey::uart::UART0_BASE,
-            crate::ChipConfig::PERIPHERAL_FREQ,
-        )
-        .transmit_sync(buf);
-        buf.len()
+fn make_uart_config() -> UartPanicWriterConfig {
+    UartPanicWriterConfig {
+        registers: earlgrey::uart::UART0_BASE,
+        clock_frequency: crate::ChipConfig::PERIPHERAL_FREQ,
+        params: Parameters {
+            baud_rate: 115200,
+            stop_bits: StopBits::One,
+            parity: Parity::None,
+            hw_flow_control: false,
+            width: Width::Eight,
+        },
     }
 }
 
@@ -42,7 +31,6 @@ use kernel::hil::led;
 #[cfg(not(test))]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    use core::ptr::addr_of_mut;
     let first_led_pin = &mut earlgrey::gpio::GpioPin::new(
         earlgrey::gpio::GPIO_BASE,
         earlgrey::pinmux::PadConfig::Output(
@@ -53,21 +41,20 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     );
     first_led_pin.make_output();
     let first_led = &mut led::LedLow::new(first_led_pin);
-    let writer = &mut *addr_of_mut!(WRITER);
 
     #[cfg(feature = "sim_verilator")]
-    debug::panic_old(
+    debug::panic::<_, Uart, _, _>(
         &mut [first_led],
-        writer,
+        make_uart_config(),
         pi,
         &|| {},
         crate::PANIC_RESOURCES.get(),
     );
 
     #[cfg(not(feature = "sim_verilator"))]
-    debug::panic_old(
+    debug::panic::<_, Uart, _, _>(
         &mut [first_led],
-        writer,
+        make_uart_config(),
         pi,
         &rv32i::support::nop,
         crate::PANIC_RESOURCES.get(),
@@ -77,19 +64,16 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
 #[cfg(test)]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    let writer = &mut WRITER;
-
     #[cfg(feature = "sim_verilator")]
-    debug::panic_print_old(writer, pi, &|| {}, crate::PANIC_RESOURCES.get());
+    debug::panic_print::<Uart, _, _>(make_uart_config(), pi, &|| {}, crate::PANIC_RESOURCES.get());
     #[cfg(not(feature = "sim_verilator"))]
-    debug::panic_print_old(
-        writer,
+    debug::panic_print::<Uart, _, _>(
+        make_uart_config(),
         pi,
         &rv32i::support::nop,
         crate::PANIC_RESOURCES.get(),
     );
 
-    let _ = writeln!(writer, "{}", pi);
     // Exit QEMU with a return code of 1
     crate::tests::semihost_command_exit_failure();
 }

--- a/boards/particle_boron/src/io.rs
+++ b/boards/particle_boron/src/io.rs
@@ -2,57 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
-use kernel::debug;
-use kernel::hil::led;
-use kernel::hil::uart;
-use kernel::hil::uart::Configure;
-use kernel::utilities::io_write::IoWrite;
+
+use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
+
 use nrf52840::gpio::Pin;
-use nrf52840::uart::{Uarte, UARTE0_BASE};
-
-// Expand here with more writing methods as required (rtt/cdc etc...)
-enum Writer {
-    WriterUart(/* initialized */ bool),
-}
-
-static mut WRITER: Writer = Writer::WriterUart(false);
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        match self {
-            Writer::WriterUart(ref mut initialized) => {
-                // Here, we create a second instance of the Uarte struct.
-                // This is okay because we only call this during a panic, and
-                // we will never actually process the interrupts
-                let uart = Uarte::new(UARTE0_BASE);
-                if !*initialized {
-                    *initialized = true;
-                    let _ = uart.configure(uart::Parameters {
-                        baud_rate: 115200,
-                        stop_bits: uart::StopBits::One,
-                        parity: uart::Parity::None,
-                        hw_flow_control: false,
-                        width: uart::Width::Eight,
-                    });
-                }
-                for &c in buf {
-                    unsafe { uart.send_byte(c) }
-                    while !uart.tx_ready() {}
-                }
-            }
-        }
-        buf.len()
-    }
-}
+use nrf52840::uart::{UartPanicWriterConfig, Uarte};
 
 const LED2_R_PIN: Pin = Pin::P0_13;
 
@@ -60,15 +15,27 @@ const LED2_R_PIN: Pin = Pin::P0_13;
 #[panic_handler]
 /// Panic handler
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    // The nRF52840DK LEDs (see back of board)
+    use kernel::debug;
+    use kernel::hil::led;
 
-    use core::ptr::addr_of_mut;
     let led_kernel_pin = &nrf52840::gpio::nrf52840_gpio_create_pin(LED2_R_PIN);
     let led = &mut led::LedLow::new(led_kernel_pin);
-    let writer = &mut *addr_of_mut!(WRITER);
-    debug::panic_old(
+
+    debug::panic::<_, Uarte, _, _>(
         &mut [led],
-        writer,
+        UartPanicWriterConfig {
+            params: Parameters {
+                baud_rate: 115200,
+                stop_bits: StopBits::One,
+                parity: Parity::None,
+                hw_flow_control: false,
+                width: Width::Eight,
+            },
+            txd: Pin::P0_06,
+            rxd: Pin::P0_08,
+            cts: None,
+            rts: None,
+        },
         pi,
         &cortexm4::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/pico_explorer_base/src/io.rs
+++ b/boards/pico_explorer_base/src/io.rs
@@ -8,6 +8,7 @@ use kernel::debug;
 use kernel::hil::led::LedHigh;
 use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
 
+use rp2040::clocks::Clocks;
 use rp2040::gpio::{RPGpio, RPGpioPin};
 use rp2040::uart::{Uart, UartId, UartPanicWriterConfig};
 
@@ -21,6 +22,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_kernel_pin = &RPGpioPin::new(RPGpio::GPIO25);
     let led = &mut LedHigh::new(led_kernel_pin);
 
+    let clocks = Clocks::new();
     debug::panic::<_, Uart, _, _>(
         &mut [led],
         UartPanicWriterConfig {
@@ -32,6 +34,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
                 stop_bits: StopBits::One,
                 hw_flow_control: false,
             },
+            clocks: &clocks,
         },
         pi,
         &cortexm0p::support::nop,

--- a/boards/pico_explorer_base/src/io.rs
+++ b/boards/pico_explorer_base/src/io.rs
@@ -2,84 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
 
 use kernel::debug;
 use kernel::hil::led::LedHigh;
-use kernel::hil::uart::{Configure, Parameters, Parity, StopBits, Width};
-use kernel::utilities::cells::OptionalCell;
-use kernel::utilities::io_write::IoWrite;
+use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
 
-use rp2040::clocks::Clocks;
-use rp2040::gpio::{GpioFunction, RPGpio, RPGpioPin};
-use rp2040::uart::Uart;
-
-/// Writer is used by kernel::debug to panic message to the serial port.
-pub struct Writer {
-    uart: OptionalCell<&'static Uart<'static>>,
-}
-
-impl Writer {
-    pub fn set_uart(&self, uart: &'static Uart) {
-        self.uart.set(uart);
-    }
-
-    fn configure_uart(&self, uart: &Uart) {
-        if !uart.is_configured() {
-            let parameters = Parameters {
-                baud_rate: 115200,
-                width: Width::Eight,
-                parity: Parity::None,
-                stop_bits: StopBits::One,
-                hw_flow_control: false,
-            };
-            //configure parameters of uart for sending bytes
-            let _ = uart.configure(parameters);
-            //set RX and TX pins in UART mode
-            let gpio_tx = RPGpioPin::new(RPGpio::GPIO0);
-            let gpio_rx = RPGpioPin::new(RPGpio::GPIO1);
-            gpio_rx.set_function(GpioFunction::UART);
-            gpio_tx.set_function(GpioFunction::UART);
-        }
-    }
-
-    fn write_to_uart(&self, uart: &Uart, buf: &[u8]) {
-        for &c in buf {
-            uart.send_byte(c);
-        }
-    }
-}
-
-/// Global static for debug writer
-pub static mut WRITER: Writer = Writer {
-    uart: OptionalCell::empty(),
-};
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        self.uart.map_or_else(
-            || {
-                let clocks = Clocks::new();
-                let uart = Uart::new_uart0(&clocks);
-                self.configure_uart(&uart);
-                self.write_to_uart(&uart, buf);
-            },
-            |uart| {
-                self.configure_uart(uart);
-                self.write_to_uart(uart, buf);
-            },
-        );
-        buf.len()
-    }
-}
+use rp2040::gpio::{RPGpio, RPGpioPin};
+use rp2040::uart::{Uart, UartId, UartPanicWriterConfig};
 
 /// Default panic handler for the pico explorer base board.
 ///
@@ -88,15 +18,21 @@ impl IoWrite for Writer {
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // LED is connected to GPIO 25
-
-    use core::ptr::addr_of_mut;
     let led_kernel_pin = &RPGpioPin::new(RPGpio::GPIO25);
     let led = &mut LedHigh::new(led_kernel_pin);
-    let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic_old(
+    debug::panic::<_, Uart, _, _>(
         &mut [led],
-        writer,
+        UartPanicWriterConfig {
+            id: UartId::Uart0,
+            params: Parameters {
+                baud_rate: 115200,
+                width: Width::Eight,
+                parity: Parity::None,
+                stop_bits: StopBits::One,
+                hw_flow_control: false,
+            },
+        },
         pi,
         &cortexm0p::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -10,8 +10,6 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use core::ptr::addr_of_mut;
-
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
 use components::led::LedsComponent;

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -311,9 +311,6 @@ pub unsafe fn start() -> (
     gpio_rx.set_function(GpioFunction::UART);
     gpio_tx.set_function(GpioFunction::UART);
 
-    // Set the UART used for panic
-    (*addr_of_mut!(io::WRITER)).set_uart(&peripherals.uart0);
-
     // Disable IE for pads 26-29 (the Pico SDK runtime does this, not sure why)
     for pin in 26..30 {
         peripherals

--- a/boards/qemu_i486_q35/src/io.rs
+++ b/boards/qemu_i486_q35/src/io.rs
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2024.
 
-use core::fmt::Write;
 use core::{arch::asm, panic::PanicInfo};
+use core::fmt::Write;
 
 use kernel::debug;
 
-use x86_q35::serial::{BlockingSerialPort, COM1_BASE};
+use x86_q35::serial::{BlockingSerialPort, BlockingSerialPortConfig, COM1_BASE};
 
-/// Exists QEMU
+/// Exits QEMU
 ///
 /// This function requires the `-device isa-debug-exit,iobase=0xf4,iosize=0x04`
 /// device enabled.
@@ -37,7 +37,7 @@ fn exit_qemu() -> ! {
         \r\n"
     ));
 
-    // We use the `htl` instruction in the infinite loop to prevent high CPU usage
+    // We use the `hlt` instruction in the infinite loop to prevent high CPU usage
     // if QEMU did not exit.
     loop {
         unsafe { asm!("hlt") }
@@ -48,10 +48,8 @@ fn exit_qemu() -> ! {
 #[cfg(not(test))]
 #[panic_handler]
 unsafe fn panic_handler(pi: &PanicInfo) -> ! {
-    let mut com1 = BlockingSerialPort::new(COM1_BASE);
-
-    debug::panic_print_old(
-        &mut com1,
+    debug::panic_print::<BlockingSerialPort, _, _>(
+        BlockingSerialPortConfig { base: COM1_BASE },
         pi,
         &x86::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/qemu_i486_q35/src/io.rs
+++ b/boards/qemu_i486_q35/src/io.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2024.
 
-use core::{arch::asm, panic::PanicInfo};
 use core::fmt::Write;
+use core::{arch::asm, panic::PanicInfo};
 
 use kernel::debug;
 

--- a/boards/raspberry_pi_pico/src/io.rs
+++ b/boards/raspberry_pi_pico/src/io.rs
@@ -8,6 +8,7 @@ use kernel::debug;
 use kernel::hil::led::LedHigh;
 use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
 
+use rp2040::clocks::Clocks;
 use rp2040::gpio::{RPGpio, RPGpioPin};
 use rp2040::uart::{Uart, UartId, UartPanicWriterConfig};
 
@@ -21,6 +22,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_kernel_pin = &RPGpioPin::new(RPGpio::GPIO25);
     let led = &mut LedHigh::new(led_kernel_pin);
 
+    let clocks = Clocks::new();
     debug::panic::<_, Uart, _, _>(
         &mut [led],
         UartPanicWriterConfig {
@@ -32,6 +34,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
                 stop_bits: StopBits::One,
                 hw_flow_control: false,
             },
+            clocks: &clocks,
         },
         pi,
         &cortexm0p::support::nop,

--- a/boards/raspberry_pi_pico/src/io.rs
+++ b/boards/raspberry_pi_pico/src/io.rs
@@ -2,84 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
 
 use kernel::debug;
 use kernel::hil::led::LedHigh;
-use kernel::hil::uart::{Configure, Parameters, Parity, StopBits, Width};
-use kernel::utilities::cells::OptionalCell;
-use kernel::utilities::io_write::IoWrite;
+use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
 
-use rp2040::clocks::Clocks;
-use rp2040::gpio::{GpioFunction, RPGpio, RPGpioPin};
-use rp2040::uart::Uart;
-
-/// Writer is used by kernel::debug to panic message to the serial port.
-pub struct Writer {
-    uart: OptionalCell<&'static Uart<'static>>,
-}
-
-impl Writer {
-    pub fn set_uart(&self, uart: &'static Uart) {
-        self.uart.set(uart);
-    }
-
-    fn configure_uart(&self, uart: &Uart) {
-        if !uart.is_configured() {
-            let parameters = Parameters {
-                baud_rate: 115200,
-                width: Width::Eight,
-                parity: Parity::None,
-                stop_bits: StopBits::One,
-                hw_flow_control: false,
-            };
-            //configure parameters of uart for sending bytes
-            let _ = uart.configure(parameters);
-            //set RX and TX pins in UART mode
-            let gpio_tx = RPGpioPin::new(RPGpio::GPIO0);
-            let gpio_rx = RPGpioPin::new(RPGpio::GPIO1);
-            gpio_rx.set_function(GpioFunction::UART);
-            gpio_tx.set_function(GpioFunction::UART);
-        }
-    }
-
-    fn write_to_uart(&self, uart: &Uart, buf: &[u8]) {
-        for &c in buf {
-            uart.send_byte(c);
-        }
-    }
-}
-
-/// Global static for debug writer
-pub static mut WRITER: Writer = Writer {
-    uart: OptionalCell::empty(),
-};
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        self.uart.map_or_else(
-            || {
-                let clocks = Clocks::new();
-                let uart = Uart::new_uart0(&clocks);
-                self.configure_uart(&uart);
-                self.write_to_uart(&uart, buf);
-            },
-            |uart| {
-                self.configure_uart(uart);
-                self.write_to_uart(uart, buf);
-            },
-        );
-        buf.len()
-    }
-}
+use rp2040::gpio::{RPGpio, RPGpioPin};
+use rp2040::uart::{Uart, UartId, UartPanicWriterConfig};
 
 /// Default panic handler for the Raspberry Pi Pico board.
 ///
@@ -88,15 +18,21 @@ impl IoWrite for Writer {
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // LED is connected to GPIO 25
-
-    use core::ptr::addr_of_mut;
     let led_kernel_pin = &RPGpioPin::new(RPGpio::GPIO25);
     let led = &mut LedHigh::new(led_kernel_pin);
-    let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic_old(
+    debug::panic::<_, Uart, _, _>(
         &mut [led],
-        writer,
+        UartPanicWriterConfig {
+            id: UartId::Uart0,
+            params: Parameters {
+                baud_rate: 115200,
+                width: Width::Eight,
+                parity: Parity::None,
+                stop_bits: StopBits::One,
+                hw_flow_control: false,
+            },
+        },
         pi,
         &cortexm0p::support::nop,
         raspberry_pi_pico::PANIC_RESOURCES.get(),

--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -100,9 +100,6 @@ pub unsafe fn start() -> (
 
     let (board_kernel, base, peripherals, _, chip) = raspberry_pi_pico::setup(output);
 
-    // Set the UART used for panic
-    (*core::ptr::addr_of_mut!(io::WRITER)).set_uart(&peripherals.uart0);
-
     // LED
     let led = LedsComponent::new().finalize(components::led_component_static!(
         LedHigh<'static, RPGpioPin<'static>>,

--- a/boards/raspberry_pi_pico_2/src/io.rs
+++ b/boards/raspberry_pi_pico_2/src/io.rs
@@ -8,6 +8,7 @@ use kernel::debug;
 use kernel::hil::led::LedHigh;
 use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
 
+use rp2350::clocks::Clocks;
 use rp2350::gpio::{RPGpio, RPGpioPin};
 use rp2350::uart::{Uart, UartId, UartPanicWriterConfig};
 
@@ -21,6 +22,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_kernel_pin = &RPGpioPin::new(RPGpio::GPIO25);
     let led = &mut LedHigh::new(led_kernel_pin);
 
+    let clocks = Clocks::new();
     debug::panic::<_, Uart, _, _>(
         &mut [led],
         UartPanicWriterConfig {
@@ -32,6 +34,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
                 stop_bits: StopBits::One,
                 hw_flow_control: false,
             },
+            clocks: &clocks,
         },
         pi,
         &cortexm33::support::nop,

--- a/boards/raspberry_pi_pico_2/src/io.rs
+++ b/boards/raspberry_pi_pico_2/src/io.rs
@@ -2,84 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright OxidOS Automotive 2025.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
 
 use kernel::debug;
 use kernel::hil::led::LedHigh;
-use kernel::hil::uart::{Configure, Parameters, Parity, StopBits, Width};
-use kernel::utilities::cells::OptionalCell;
-use kernel::utilities::io_write::IoWrite;
+use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
 
-use rp2350::clocks::Clocks;
-use rp2350::gpio::{GpioFunction, RPGpio, RPGpioPin};
-use rp2350::uart::Uart;
-
-/// Writer is used by kernel::debug to panic message to the serial port.
-pub struct Writer {
-    uart: OptionalCell<&'static Uart<'static>>,
-}
-
-impl Writer {
-    pub fn set_uart(&self, uart: &'static Uart) {
-        self.uart.set(uart);
-    }
-
-    fn configure_uart(&self, uart: &Uart) {
-        if !uart.is_configured() {
-            let parameters = Parameters {
-                baud_rate: 115200,
-                width: Width::Eight,
-                parity: Parity::None,
-                stop_bits: StopBits::One,
-                hw_flow_control: false,
-            };
-            //configure parameters of uart for sending bytes
-            let _ = uart.configure(parameters);
-            //set RX and TX pins in UART mode
-            let gpio_tx = RPGpioPin::new(RPGpio::GPIO0);
-            let gpio_rx = RPGpioPin::new(RPGpio::GPIO1);
-            gpio_rx.set_function(GpioFunction::UART);
-            gpio_tx.set_function(GpioFunction::UART);
-        }
-    }
-
-    fn write_to_uart(&self, uart: &Uart, buf: &[u8]) {
-        for &c in buf {
-            uart.send_byte(c);
-        }
-    }
-}
-
-/// Global static for debug writer
-pub static mut WRITER: Writer = Writer {
-    uart: OptionalCell::empty(),
-};
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        self.uart.map_or_else(
-            || {
-                let clocks = &Clocks::new();
-                let uart = Uart::new_uart0(clocks);
-                self.configure_uart(&uart);
-                self.write_to_uart(&uart, buf);
-            },
-            |uart| {
-                self.configure_uart(uart);
-                self.write_to_uart(uart, buf);
-            },
-        );
-        buf.len()
-    }
-}
+use rp2350::gpio::{RPGpio, RPGpioPin};
+use rp2350::uart::{Uart, UartId, UartPanicWriterConfig};
 
 /// Default panic handler for the Raspberry Pi Pico 2 board.
 ///
@@ -88,15 +18,21 @@ impl IoWrite for Writer {
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // LED is connected to GPIO 25
-
-    use core::ptr::addr_of_mut;
     let led_kernel_pin = &RPGpioPin::new(RPGpio::GPIO25);
     let led = &mut LedHigh::new(led_kernel_pin);
-    let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic_old(
+    debug::panic::<_, Uart, _, _>(
         &mut [led],
-        writer,
+        UartPanicWriterConfig {
+            id: UartId::Uart0,
+            params: Parameters {
+                baud_rate: 115200,
+                width: Width::Eight,
+                parity: Parity::None,
+                stop_bits: StopBits::One,
+                hw_flow_control: false,
+            },
+        },
         pi,
         &cortexm33::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/raspberry_pi_pico_2/src/main.rs
+++ b/boards/raspberry_pi_pico_2/src/main.rs
@@ -273,9 +273,6 @@ pub unsafe fn main() {
 
     resets.unreset_all_except(&[], true);
 
-    // Set the UART used for panic
-    (*addr_of_mut!(io::WRITER)).set_uart(&peripherals.uart0);
-
     let gpio_tx = peripherals.pins.get_pin(RPGpio::GPIO0);
     let gpio_rx = peripherals.pins.get_pin(RPGpio::GPIO1);
     gpio_rx.set_function(GpioFunction::UART);

--- a/boards/raspberry_pi_pico_2/src/main.rs
+++ b/boards/raspberry_pi_pico_2/src/main.rs
@@ -12,8 +12,6 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
-use core::ptr::addr_of_mut;
-
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
 use components::led::LedsComponent;

--- a/boards/raspberry_pi_pico_w/src/io.rs
+++ b/boards/raspberry_pi_pico_w/src/io.rs
@@ -3,83 +3,12 @@
 // Copyright Tock Contributors 2022.
 // Copyright OxidOS Automotive 2025.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
 
 use kernel::debug;
-use kernel::hil::uart::{Configure, Parameters, Parity, StopBits, Width};
-use kernel::utilities::cells::OptionalCell;
-use kernel::utilities::io_write::IoWrite;
+use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
 
-use rp2040::clocks::Clocks;
-use rp2040::gpio::{GpioFunction, RPGpio, RPGpioPin};
-use rp2040::uart::Uart;
-
-/// Writer is used by kernel::debug to panic message to the serial port.
-pub struct Writer {
-    uart: OptionalCell<&'static Uart<'static>>,
-}
-
-impl Writer {
-    pub fn set_uart(&self, uart: &'static Uart) {
-        self.uart.set(uart);
-    }
-
-    fn configure_uart(&self, uart: &Uart) {
-        if !uart.is_configured() {
-            let parameters = Parameters {
-                baud_rate: 115200,
-                width: Width::Eight,
-                parity: Parity::None,
-                stop_bits: StopBits::One,
-                hw_flow_control: false,
-            };
-            //configure parameters of uart for sending bytes
-            let _ = uart.configure(parameters);
-            //set RX and TX pins in UART mode
-            let gpio_tx = RPGpioPin::new(RPGpio::GPIO0);
-            let gpio_rx = RPGpioPin::new(RPGpio::GPIO1);
-            gpio_rx.set_function(GpioFunction::UART);
-            gpio_tx.set_function(GpioFunction::UART);
-        }
-    }
-
-    fn write_to_uart(&self, uart: &Uart, buf: &[u8]) {
-        for &c in buf {
-            uart.send_byte(c);
-        }
-    }
-}
-
-/// Global static for debug writer
-pub static mut WRITER: Writer = Writer {
-    uart: OptionalCell::empty(),
-};
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        self.uart.map_or_else(
-            || {
-                let clocks = Clocks::new();
-                let uart = Uart::new_uart0(&clocks);
-                self.configure_uart(&uart);
-                self.write_to_uart(&uart, buf);
-            },
-            |uart| {
-                self.configure_uart(uart);
-                self.write_to_uart(uart, buf);
-            },
-        );
-        buf.len()
-    }
-}
+use rp2040::uart::{Uart, UartId, UartPanicWriterConfig};
 
 /// Default panic handler for the Raspberry Pi Pico board.
 ///
@@ -87,11 +16,17 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    use core::ptr::addr_of_mut;
-    let writer = &mut *addr_of_mut!(WRITER);
-
-    debug::panic_print_old(
-        writer,
+    debug::panic_print::<Uart, _, _>(
+        UartPanicWriterConfig {
+            id: UartId::Uart0,
+            params: Parameters {
+                baud_rate: 115200,
+                width: Width::Eight,
+                parity: Parity::None,
+                stop_bits: StopBits::One,
+                hw_flow_control: false,
+            },
+        },
         pi,
         &cortexm0p::support::nop,
         raspberry_pi_pico::PANIC_RESOURCES.get(),

--- a/boards/raspberry_pi_pico_w/src/io.rs
+++ b/boards/raspberry_pi_pico_w/src/io.rs
@@ -8,6 +8,7 @@ use core::panic::PanicInfo;
 use kernel::debug;
 use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
 
+use rp2040::clocks::Clocks;
 use rp2040::uart::{Uart, UartId, UartPanicWriterConfig};
 
 /// Default panic handler for the Raspberry Pi Pico board.
@@ -16,6 +17,7 @@ use rp2040::uart::{Uart, UartId, UartPanicWriterConfig};
 #[cfg(not(test))]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
+    let clocks = Clocks::new();
     debug::panic_print::<Uart, _, _>(
         UartPanicWriterConfig {
             id: UartId::Uart0,
@@ -26,6 +28,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
                 stop_bits: StopBits::One,
                 hw_flow_control: false,
             },
+            clocks: &clocks,
         },
         pi,
         &cortexm0p::support::nop,

--- a/boards/raspberry_pi_pico_w/src/main.rs
+++ b/boards/raspberry_pi_pico_w/src/main.rs
@@ -118,9 +118,6 @@ pub unsafe fn start() -> (
 
     let (board_kernel, base, peripherals, mux_alarm, chip) = raspberry_pi_pico::setup(output);
 
-    // Set the UART used for panic
-    (*core::ptr::addr_of_mut!(io::WRITER)).set_uart(&peripherals.uart0);
-
     // WIFI
 
     let cs = peripherals.pins.get_pin(RPGpio::GPIO25);

--- a/boards/redboard_redv/src/io.rs
+++ b/boards/redboard_redv/src/io.rs
@@ -16,7 +16,6 @@ use sifive::uart::{Uart, UartPanicWriterConfig};
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // turn off the non panic leds, just in case
 
-    use core::ptr::addr_of_mut;
     let led_green = sifive::gpio::GpioPin::new(
         e310_g002::gpio::GPIO0_BASE,
         sifive::gpio::pins::pin19,

--- a/boards/redboard_redv/src/io.rs
+++ b/boards/redboard_redv/src/io.rs
@@ -2,32 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::str;
 use kernel::debug;
 use kernel::hil::gpio;
 use kernel::hil::led;
-use kernel::utilities::io_write::IoWrite;
+use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
 
-struct Writer {}
-
-static mut WRITER: Writer = Writer {};
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        let uart = sifive::uart::Uart::new(e310_g002::uart::UART0_BASE, 16_000_000);
-        uart.transmit_sync(buf);
-        buf.len()
-    }
-}
+use sifive::uart::{Uart, UartPanicWriterConfig};
 
 /// Panic handler.
 #[cfg(not(test))]
@@ -61,11 +42,20 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         sifive::gpio::pins::pin22::CLEAR,
     );
     let led_red = &mut led::LedLow::new(&led_red_pin);
-    let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic_old(
+    debug::panic::<_, Uart, _, _>(
         &mut [led_red],
-        writer,
+        UartPanicWriterConfig {
+            registers: e310_g002::uart::UART0_BASE,
+            clock_frequency: 16_000_000,
+            params: Parameters {
+                baud_rate: 115200,
+                width: Width::Eight,
+                stop_bits: StopBits::One,
+                parity: Parity::None,
+                hw_flow_control: false,
+            },
+        },
         pi,
         &rv32i::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/stm32f3discovery/src/io.rs
+++ b/boards/stm32f3discovery/src/io.rs
@@ -2,82 +2,38 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::ptr::addr_of_mut;
 
 use kernel::debug;
 use kernel::hil::led;
-use kernel::hil::uart;
-use kernel::hil::uart::Configure;
-use kernel::utilities::io_write::IoWrite;
 
 use stm32f303xc::gpio::PinId;
-
-/// Writer is used by kernel::debug to panic message to the serial port.
-pub struct Writer {
-    initialized: bool,
-}
-
-/// Global static for debug writer
-pub static mut WRITER: Writer = Writer { initialized: false };
-
-impl Writer {
-    /// Indicate that USART has already been initialized. Trying to double
-    /// initialize USART2 causes STM32F446RE to go into in in-deterministic state.
-    pub fn set_initialized(&mut self) {
-        self.initialized = true;
-    }
-}
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        let rcc = stm32f303xc::rcc::Rcc::new();
-        let uart = stm32f303xc::usart::Usart::new_usart1(&rcc);
-
-        if !self.initialized {
-            self.initialized = true;
-
-            let _ = uart.configure(uart::Parameters {
-                baud_rate: 115200,
-                stop_bits: uart::StopBits::One,
-                parity: uart::Parity::None,
-                hw_flow_control: false,
-                width: uart::Width::Eight,
-            });
-        }
-
-        for &c in buf {
-            uart.send_byte(c);
-        }
-        buf.len()
-    }
-}
 
 /// Panic handler.
 #[panic_handler]
 pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     // User LD3 is connected to PE09
-    // Have to reinitialize several peripherals because otherwise can't access them here.
-    let rcc = stm32f303xc::rcc::Rcc::new();
-    let syscfg = stm32f303xc::syscfg::Syscfg::new(&rcc);
+    let rcc = kernel::static_init!(stm32f303xc::rcc::Rcc, stm32f303xc::rcc::Rcc::new());
+    let syscfg = stm32f303xc::syscfg::Syscfg::new(rcc);
     let exti = stm32f303xc::exti::Exti::new(&syscfg);
     let pin = stm32f303xc::gpio::Pin::new(PinId::PE09, &exti);
-    let gpio_ports = stm32f303xc::gpio::GpioPorts::new(&rcc, &exti);
+    let gpio_ports = stm32f303xc::gpio::GpioPorts::new(rcc, &exti);
     pin.set_ports_ref(&gpio_ports);
     let led = &mut led::LedHigh::new(&pin);
-    let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic_old(
+    debug::panic::<_, stm32f303xc::usart::Usart, _, _>(
         &mut [led],
-        writer,
+        stm32f303xc::usart::UsartPanicWriterConfig {
+            id: stm32f303xc::usart::UsartId::Usart1,
+            rcc,
+            params: kernel::hil::uart::Parameters {
+                baud_rate: 115200,
+                stop_bits: kernel::hil::uart::StopBits::One,
+                parity: kernel::hil::uart::Parity::None,
+                hw_flow_control: false,
+                width: kernel::hil::uart::Width::Eight,
+            },
+        },
         info,
         &cortexm4::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -10,7 +10,6 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use core::ptr::addr_of_mut;
 
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use capsules_extra::lsm303xx;
@@ -438,10 +437,6 @@ unsafe fn start() -> (
 
     let uart_mux = components::console::UartMuxComponent::new(&peripherals.usart1, 115200)
         .finalize(components::uart_mux_component_static!());
-
-    // `finalize()` configures the underlying USART, so we need to
-    // tell `send_byte()` not to configure the USART again.
-    (*addr_of_mut!(io::WRITER)).set_initialized();
 
     // Create capabilities that the board needs to call certain protected kernel
     // functions.

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -10,7 +10,6 @@
 #![no_main]
 #![deny(missing_docs)]
 
-
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use capsules_extra::lsm303xx;
 use components::gpio::GpioComponent;

--- a/boards/stm32f412gdiscovery/src/io.rs
+++ b/boards/stm32f412gdiscovery/src/io.rs
@@ -2,87 +2,43 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::ptr::addr_of_mut;
 
 use kernel::debug;
 use kernel::hil::led;
-use kernel::hil::uart;
-use kernel::hil::uart::Configure;
-use kernel::utilities::io_write::IoWrite;
 
 use stm32f412g::chip_specs::Stm32f412Specs;
 use stm32f412g::gpio::PinId;
 
-/// Writer is used by kernel::debug to panic message to the serial port.
-pub struct Writer {
-    initialized: bool,
-}
-
-/// Global static for debug writer
-pub static mut WRITER: Writer = Writer { initialized: false };
-
-impl Writer {
-    /// Indicate that USART has already been initialized. Trying to double
-    /// initialize USART2 causes STM32F412G to go into in in-deterministic state.
-    pub fn set_initialized(&mut self) {
-        self.initialized = true;
-    }
-}
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        let rcc = stm32f412g::rcc::Rcc::new();
-        let clocks: stm32f412g::clocks::Clocks<Stm32f412Specs> =
-            stm32f412g::clocks::Clocks::new(&rcc);
-        let uart = stm32f412g::usart::Usart::new_usart2(&clocks);
-
-        if !self.initialized {
-            self.initialized = true;
-
-            let _ = uart.configure(uart::Parameters {
-                baud_rate: 115200,
-                stop_bits: uart::StopBits::One,
-                parity: uart::Parity::None,
-                hw_flow_control: false,
-                width: uart::Width::Eight,
-            });
-        }
-
-        for &c in buf {
-            uart.send_byte(c);
-        }
-
-        buf.len()
-    }
-}
-
 /// Panic handler.
 #[panic_handler]
 pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
-    // User LD2 is connected to PB07
-    // Have to reinitialize several peripherals because otherwise can't access them here.
-    let rcc = stm32f412g::rcc::Rcc::new();
-    let clocks: stm32f412g::clocks::Clocks<Stm32f412Specs> = stm32f412g::clocks::Clocks::new(&rcc);
-    let syscfg = stm32f412g::syscfg::Syscfg::new(&clocks);
+    // User LD2 is connected to PE02
+    let rcc = kernel::static_init!(stm32f412g::rcc::Rcc, stm32f412g::rcc::Rcc::new());
+    let clocks = kernel::static_init!(
+        stm32f412g::clocks::Clocks<Stm32f412Specs>,
+        stm32f412g::clocks::Clocks::new(rcc)
+    );
+    let syscfg = stm32f412g::syscfg::Syscfg::new(clocks);
     let exti = stm32f412g::exti::Exti::new(&syscfg);
     let pin = stm32f412g::gpio::Pin::new(PinId::PE02, &exti);
-    let gpio_ports = stm32f412g::gpio::GpioPorts::new(&clocks, &exti);
+    let gpio_ports = stm32f412g::gpio::GpioPorts::new(clocks, &exti);
     pin.set_ports_ref(&gpio_ports);
     let led = &mut led::LedHigh::new(&pin);
-    let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic_old(
+    debug::panic::<_, stm32f412g::usart::Usart<'static, stm32f412g::dma::Dma1<'static>>, _, _>(
         &mut [led],
-        writer,
+        stm32f412g::usart::UsartPanicWriterConfig {
+            id: stm32f412g::usart::UsartId::Usart2,
+            clocks,
+            params: kernel::hil::uart::Parameters {
+                baud_rate: 115200,
+                stop_bits: kernel::hil::uart::StopBits::One,
+                parity: kernel::hil::uart::Parity::None,
+                hw_flow_control: false,
+                width: kernel::hil::uart::Width::Eight,
+            },
+        },
         info,
         &cortexm4::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -10,7 +10,6 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use core::ptr::addr_of_mut;
 
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
@@ -485,8 +484,6 @@ unsafe fn start() -> (
     base_peripherals.usart2.enable_clock();
     let uart_mux = components::console::UartMuxComponent::new(&base_peripherals.usart2, 115200)
         .finalize(components::uart_mux_component_static!());
-
-    (*addr_of_mut!(io::WRITER)).set_initialized();
 
     // Create capabilities that the board needs to call certain protected kernel
     // functions.

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -10,7 +10,6 @@
 #![no_main]
 #![deny(missing_docs)]
 
-
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
 use components::rng::RngComponent;

--- a/boards/stm32f429idiscovery/src/io.rs
+++ b/boards/stm32f429idiscovery/src/io.rs
@@ -2,89 +2,43 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::ptr::addr_of_mut;
 
 use kernel::debug;
 use kernel::hil::led;
-use kernel::hil::uart;
-use kernel::hil::uart::Configure;
-use kernel::utilities::io_write::IoWrite;
 
 use stm32f429zi::chip_specs::Stm32f429Specs;
 use stm32f429zi::gpio::PinId;
-
-/// Writer is used by kernel::debug to panic message to the serial port.
-pub struct Writer {
-    initialized: bool,
-}
-
-/// Global static for debug writer
-pub static mut WRITER: Writer = Writer { initialized: false };
-
-impl Writer {
-    /// Indicate that USART has already been initialized. Trying to double
-    /// initialize USART1 causes stm32f429zi to go into in in-deterministic state.
-    pub fn set_initialized(&mut self) {
-        self.initialized = true;
-    }
-}
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        let rcc = stm32f429zi::rcc::Rcc::new();
-        let clocks: stm32f429zi::clocks::Clocks<Stm32f429Specs> =
-            stm32f429zi::clocks::Clocks::new(&rcc);
-        let uart = stm32f429zi::usart::Usart::new_usart1(&clocks);
-
-        if !self.initialized {
-            self.initialized = true;
-
-            let _ = uart.configure(uart::Parameters {
-                baud_rate: 115200,
-                stop_bits: uart::StopBits::One,
-                parity: uart::Parity::None,
-                hw_flow_control: false,
-                width: uart::Width::Eight,
-            });
-        }
-
-        for &c in buf {
-            uart.send_byte(c);
-        }
-
-        buf.len()
-    }
-}
 
 /// Panic handler.
 #[panic_handler]
 pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     // User LD4 is connected to PG14
-    // Have to reinitialize several peripherals because otherwise can't access them here.
-    let rcc = stm32f429zi::rcc::Rcc::new();
-    let clocks: stm32f429zi::clocks::Clocks<Stm32f429Specs> =
-        stm32f429zi::clocks::Clocks::new(&rcc);
-    let syscfg = stm32f429zi::syscfg::Syscfg::new(&clocks);
+    let rcc = kernel::static_init!(stm32f429zi::rcc::Rcc, stm32f429zi::rcc::Rcc::new());
+    let clocks = kernel::static_init!(
+        stm32f429zi::clocks::Clocks<Stm32f429Specs>,
+        stm32f429zi::clocks::Clocks::new(rcc)
+    );
+    let syscfg = stm32f429zi::syscfg::Syscfg::new(clocks);
     let exti = stm32f429zi::exti::Exti::new(&syscfg);
     let pin = stm32f429zi::gpio::Pin::new(PinId::PG14, &exti);
-    let gpio_ports = stm32f429zi::gpio::GpioPorts::new(&clocks, &exti);
+    let gpio_ports = stm32f429zi::gpio::GpioPorts::new(clocks, &exti);
     pin.set_ports_ref(&gpio_ports);
     let led = &mut led::LedHigh::new(&pin);
 
-    let writer = &mut *addr_of_mut!(WRITER);
-
-    debug::panic_old(
+    debug::panic::<_, stm32f429zi::usart::Usart<'static, stm32f429zi::dma::Dma2<'static>>, _, _>(
         &mut [led],
-        writer,
+        stm32f429zi::usart::UsartPanicWriterConfig {
+            id: stm32f429zi::usart::UsartId::Usart1,
+            clocks,
+            params: kernel::hil::uart::Parameters {
+                baud_rate: 115200,
+                stop_bits: kernel::hil::uart::StopBits::One,
+                parity: kernel::hil::uart::Parity::None,
+                hw_flow_control: false,
+                width: kernel::hil::uart::Width::Eight,
+            },
+        },
         info,
         &cortexm4::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/stm32f429idiscovery/src/main.rs
+++ b/boards/stm32f429idiscovery/src/main.rs
@@ -10,7 +10,6 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use core::ptr::addr_of_mut;
 
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
@@ -353,8 +352,6 @@ unsafe fn start() -> (
     base_peripherals.usart1.enable_clock();
     let uart_mux = components::console::UartMuxComponent::new(&base_peripherals.usart1, 115200)
         .finalize(components::uart_mux_component_static!());
-
-    (*addr_of_mut!(io::WRITER)).set_initialized();
 
     // Create capabilities that the board needs to call certain protected kernel
     // functions.

--- a/boards/stm32f429idiscovery/src/main.rs
+++ b/boards/stm32f429idiscovery/src/main.rs
@@ -10,7 +10,6 @@
 #![no_main]
 #![deny(missing_docs)]
 
-
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
 use kernel::capabilities;

--- a/boards/teensy40/src/io.rs
+++ b/boards/teensy40/src/io.rs
@@ -10,7 +10,10 @@ use crate::imxrt1060::lpuart::{Lpuart, LpuartId, LpuartPanicWriterConfig};
 
 #[panic_handler]
 unsafe fn panic_handler(panic_info: &core::panic::PanicInfo) -> ! {
-    let ccm = kernel::static_init!(crate::imxrt1060::ccm::Ccm, crate::imxrt1060::ccm::Ccm::new());
+    let ccm = kernel::static_init!(
+        crate::imxrt1060::ccm::Ccm,
+        crate::imxrt1060::ccm::Ccm::new()
+    );
     let pin = crate::imxrt1060::gpio::Pin::from_pin_id(PinId::B0_03);
     let led = &mut led::LedHigh::new(&pin);
 

--- a/boards/teensy40/src/io.rs
+++ b/boards/teensy40/src/io.rs
@@ -2,64 +2,31 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::{self, Write};
-
 use kernel::debug;
-use kernel::hil::{
-    led,
-    uart::{self, Configure},
-};
-use kernel::utilities::io_write::IoWrite;
+use kernel::hil::{led, uart::Parameters, uart::Parity, uart::StopBits, uart::Width};
 
-use crate::imxrt1060::gpio;
-use crate::imxrt1060::lpuart;
-
-struct Writer<'a> {
-    output: &'a mut lpuart::Lpuart<'a>,
-}
-
-const BAUD_RATE: u32 = 115_200;
-
-impl<'a> Writer<'a> {
-    pub unsafe fn new(output: &'a mut lpuart::Lpuart<'a>) -> Self {
-        let _ = output.configure(uart::Parameters {
-            baud_rate: BAUD_RATE,
-            stop_bits: uart::StopBits::One,
-            parity: uart::Parity::None,
-            hw_flow_control: false,
-            width: uart::Width::Eight,
-        });
-
-        Writer { output }
-    }
-}
-
-impl IoWrite for Writer<'_> {
-    fn write(&mut self, bytes: &[u8]) -> usize {
-        for byte in bytes {
-            self.output.send_byte(*byte);
-        }
-        bytes.len()
-    }
-}
-
-impl Write for Writer<'_> {
-    fn write_str(&mut self, s: &str) -> fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
+use crate::imxrt1060::gpio::PinId;
+use crate::imxrt1060::lpuart::{Lpuart, LpuartId, LpuartPanicWriterConfig};
 
 #[panic_handler]
 unsafe fn panic_handler(panic_info: &core::panic::PanicInfo) -> ! {
-    let ccm = crate::imxrt1060::ccm::Ccm::new();
-    let pin = crate::imxrt1060::gpio::Pin::from_pin_id(gpio::PinId::B0_03);
+    let ccm = kernel::static_init!(crate::imxrt1060::ccm::Ccm, crate::imxrt1060::ccm::Ccm::new());
+    let pin = crate::imxrt1060::gpio::Pin::from_pin_id(PinId::B0_03);
     let led = &mut led::LedHigh::new(&pin);
-    let mut lpuart2 = lpuart::Lpuart::new_lpuart2(&ccm);
-    let mut writer = Writer::new(&mut lpuart2);
-    debug::panic_old(
+
+    debug::panic::<_, Lpuart, _, _>(
         &mut [led],
-        &mut writer,
+        LpuartPanicWriterConfig {
+            ccm,
+            id: LpuartId::Lpuart2,
+            params: Parameters {
+                baud_rate: 115_200,
+                stop_bits: StopBits::One,
+                parity: Parity::None,
+                hw_flow_control: false,
+                width: Width::Eight,
+            },
+        },
         panic_info,
         &cortexm7::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/veer_el2_sim/src/io.rs
+++ b/boards/veer_el2_sim/src/io.rs
@@ -43,12 +43,7 @@ impl kernel::platform::chip::PanicWriter for Writer {
 #[cfg(not(test))]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    debug::panic_print::<Writer, _, _>(
-        (),
-        pi,
-        &rv32i::support::nop,
-        crate::PANIC_RESOURCES.get(),
-    );
+    debug::panic_print::<Writer, _, _>((), pi, &rv32i::support::nop, crate::PANIC_RESOURCES.get());
 
     // By writing 0xff to this address we can exit the simulation.
     // So instead of blinking in a loop let's exit the simulation.

--- a/boards/veer_el2_sim/src/io.rs
+++ b/boards/veer_el2_sim/src/io.rs
@@ -4,14 +4,11 @@
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::ptr::addr_of_mut;
 use core::ptr::write_volatile;
 use kernel::debug;
 use kernel::utilities::io_write::IoWrite;
 
 struct Writer {}
-
-static mut WRITER: Writer = Writer {};
 
 impl Write for Writer {
     fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
@@ -32,6 +29,13 @@ impl IoWrite for Writer {
     }
 }
 
+impl kernel::platform::chip::PanicWriter for Writer {
+    type Config = ();
+    unsafe fn create_panic_writer(_config: Self::Config) -> impl IoWrite + core::fmt::Write {
+        Writer {}
+    }
+}
+
 /// Panic handler.
 ///
 /// # Safety
@@ -39,10 +43,8 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    let writer = &mut *addr_of_mut!(WRITER);
-
-    debug::panic_print_old(
-        writer,
+    debug::panic_print::<Writer, _, _>(
+        (),
         pi,
         &rv32i::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/weact_f401ccu6/src/io.rs
+++ b/boards/weact_f401ccu6/src/io.rs
@@ -2,88 +2,43 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::ptr::addr_of_mut;
 
 use kernel::debug;
 use kernel::hil::led;
-use kernel::hil::uart;
-use kernel::hil::uart::Configure;
-use kernel::utilities::io_write::IoWrite;
 
 use stm32f401cc::chip_specs::Stm32f401Specs;
 use stm32f401cc::gpio::PinId;
-
-/// Writer is used by kernel::debug to panic message to the serial port.
-pub struct Writer {
-    initialized: bool,
-}
-
-/// Global static for debug writer
-pub static mut WRITER: Writer = Writer { initialized: false };
-
-impl Writer {
-    /// Indicate that USART has already been initialized. Trying to double
-    /// initialize USART2 causes STM32F401CC to go into in in-deterministic state.
-    pub fn set_initialized(&mut self) {
-        self.initialized = true;
-    }
-}
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        let rcc = stm32f401cc::rcc::Rcc::new();
-        let clocks: stm32f401cc::clocks::Clocks<Stm32f401Specs> =
-            stm32f401cc::clocks::Clocks::new(&rcc);
-        let uart = stm32f401cc::usart::Usart::new_usart2(&clocks);
-
-        if !self.initialized {
-            self.initialized = true;
-
-            let _ = uart.configure(uart::Parameters {
-                baud_rate: 115200,
-                stop_bits: uart::StopBits::One,
-                parity: uart::Parity::None,
-                hw_flow_control: false,
-                width: uart::Width::Eight,
-            });
-        }
-
-        for &c in buf {
-            uart.send_byte(c);
-        }
-        buf.len()
-    }
-}
 
 /// Panic handler.
 #[panic_handler]
 pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
     // On-board LED C13 is connected to PC13
-    // Have to reinitialize several peripherals because otherwise can't access them here.
-    let rcc = stm32f401cc::rcc::Rcc::new();
-    let clocks: stm32f401cc::clocks::Clocks<Stm32f401Specs> =
-        stm32f401cc::clocks::Clocks::new(&rcc);
-    let syscfg = stm32f401cc::syscfg::Syscfg::new(&clocks);
+    let rcc = kernel::static_init!(stm32f401cc::rcc::Rcc, stm32f401cc::rcc::Rcc::new());
+    let clocks = kernel::static_init!(
+        stm32f401cc::clocks::Clocks<Stm32f401Specs>,
+        stm32f401cc::clocks::Clocks::new(rcc)
+    );
+    let syscfg = stm32f401cc::syscfg::Syscfg::new(clocks);
     let exti = stm32f401cc::exti::Exti::new(&syscfg);
     let pin = stm32f401cc::gpio::Pin::new(PinId::PC13, &exti);
-    let gpio_ports = stm32f401cc::gpio::GpioPorts::new(&clocks, &exti);
+    let gpio_ports = stm32f401cc::gpio::GpioPorts::new(clocks, &exti);
     pin.set_ports_ref(&gpio_ports);
     let led = &mut led::LedLow::new(&pin);
 
-    let writer = &mut *addr_of_mut!(WRITER);
-
-    debug::panic_old(
+    debug::panic::<_, stm32f401cc::usart::Usart<'static, stm32f401cc::dma::Dma1<'static>>, _, _>(
         &mut [led],
-        writer,
+        stm32f401cc::usart::UsartPanicWriterConfig {
+            id: stm32f401cc::usart::UsartId::Usart2,
+            clocks,
+            params: kernel::hil::uart::Parameters {
+                baud_rate: 115200,
+                stop_bits: kernel::hil::uart::StopBits::One,
+                parity: kernel::hil::uart::Parity::None,
+                hw_flow_control: false,
+                width: kernel::hil::uart::Width::Eight,
+            },
+        },
         info,
         &cortexm4::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -10,7 +10,6 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use core::ptr::addr_of_mut;
 
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
@@ -296,8 +295,6 @@ unsafe fn start() -> (
     base_peripherals.usart2.enable_clock();
     let uart_mux = components::console::UartMuxComponent::new(&base_peripherals.usart2, 115200)
         .finalize(components::uart_mux_component_static!());
-
-    (*addr_of_mut!(io::WRITER)).set_initialized();
 
     // Create capabilities that the board needs to call certain protected kernel
     // functions.

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -10,7 +10,6 @@
 #![no_main]
 #![deny(missing_docs)]
 
-
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
 use kernel::capabilities;

--- a/chips/apollo3/src/uart.rs
+++ b/chips/apollo3/src/uart.rs
@@ -16,7 +16,7 @@ use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeabl
 use kernel::utilities::registers::{register_bitfields, register_structs, ReadWrite};
 use kernel::utilities::StaticRef;
 
-const UART0_BASE: StaticRef<UartRegisters> =
+pub const UART0_BASE: StaticRef<UartRegisters> =
     unsafe { StaticRef::new(0x4001_C000 as *const UartRegisters) };
 
 pub const UART1_BASE: StaticRef<UartRegisters> =

--- a/chips/apollo3/src/uart.rs
+++ b/chips/apollo3/src/uart.rs
@@ -11,6 +11,7 @@ use kernel::hil;
 use kernel::hil::uart;
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::cells::TakeCell;
+use kernel::utilities::io_write::IoWrite;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{register_bitfields, register_structs, ReadWrite};
 use kernel::utilities::StaticRef;
@@ -185,6 +186,21 @@ pub struct UartParams {
 }
 
 impl Uart<'_> {
+    pub fn new(base: StaticRef<UartRegisters>) -> Self {
+        Self {
+            registers: base,
+            clock_frequency: 24_000_000,
+            tx_client: OptionalCell::empty(),
+            rx_client: OptionalCell::empty(),
+            tx_buffer: TakeCell::empty(),
+            tx_len: Cell::new(0),
+            tx_index: Cell::new(0),
+            rx_buffer: TakeCell::empty(),
+            rx_len: Cell::new(0),
+            rx_index: Cell::new(0),
+        }
+    }
+
     // unsafe bc of UART0_BASE usage, called twice would alias location
     pub fn new_uart_0() -> Self {
         Self {
@@ -484,5 +500,61 @@ impl<'a> hil::uart::Receive<'a> for Uart<'a> {
 
     fn receive_word(&self) -> Result<(), ErrorCode> {
         Err(ErrorCode::FAIL)
+    }
+}
+
+/// A synchronous writer for the apollo3 useful for panics.
+///
+/// For boards that want to use the UART to display panic messages, this
+/// provides an implementation of
+/// [`PanicWriter`](kernel::platform::chip::PanicWriter) with synchronous
+/// output.
+///
+/// This is only to be used by panic messages and is not used within the normal
+/// operation of the Tock kernel.
+///
+/// TODO: Validate this [`UartPanicWriter`] is always sound to create.
+struct UartPanicWriter<'a> {
+    uart: Uart<'a>,
+}
+
+impl IoWrite for UartPanicWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> usize {
+        self.uart.transmit_sync(buf);
+        buf.len()
+    }
+}
+
+impl core::fmt::Write for UartPanicWriter<'_> {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+/// Configuration for the synchronous UART panic writer.
+///
+/// This captures everything needed to setup the UART for panic display, even
+/// if the normal kernel had initialized it differently.
+pub struct UartPanicWriterConfig {
+    pub registers: StaticRef<UartRegisters>,
+    pub params: hil::uart::Parameters,
+}
+
+impl kernel::platform::chip::PanicWriter for Uart<'_> {
+    type Config = UartPanicWriterConfig;
+
+    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write {
+        use hil::uart::Configure as _;
+
+        let uart = Uart::new(config.registers);
+
+        // Configure the UART correctly for panics.
+        let _ = uart.configure(config.params);
+
+        // Enable the UART for transmission.
+        uart.registers.cr.modify(CR::UARTEN::SET + CR::TXE::SET);
+
+        UartPanicWriter { uart }
     }
 }

--- a/chips/imxrt10xx/src/lpuart.rs
+++ b/chips/imxrt10xx/src/lpuart.rs
@@ -4,6 +4,7 @@
 
 use core::cell::Cell;
 use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::utilities::io_write::IoWrite;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite};
 
@@ -774,6 +775,12 @@ impl<'a> Lpuart<'a> {
         });
         Ok(())
     }
+
+    fn transmit_sync(&self, bytes: &[u8]) {
+        for &b in bytes {
+            self.send_byte(b);
+        }
+    }
 }
 
 impl<'a> hil::uart::Transmit<'a> for Lpuart<'a> {
@@ -986,3 +993,66 @@ impl dma::DmaClient for Lpuart<'_> {
         }
     }
 }
+
+/// A synchronous writer for the imxrt10xx useful for panics.
+///
+/// For boards that want to use the LPUART to display panic messages, this
+/// provides an implementation of
+/// [`PanicWriter`](kernel::platform::chip::PanicWriter) with synchronous
+/// output.
+///
+/// This is only to be used by panic messages and is not used within the normal
+/// operation of the Tock kernel.
+///
+/// TODO: Validate this [`LpuartPanicWriter`] is always sound to create.
+struct LpuartPanicWriter {
+    uart: Lpuart<'static>,
+}
+
+impl IoWrite for LpuartPanicWriter {
+    fn write(&mut self, buf: &[u8]) -> usize {
+        self.uart.transmit_sync(buf);
+        buf.len()
+    }
+}
+
+impl core::fmt::Write for LpuartPanicWriter {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+/// Selects which LPUART instance to use for panic output.
+pub enum LpuartId {
+    Lpuart1,
+    Lpuart2,
+}
+
+/// Configuration for the synchronous LPUART panic writer.
+///
+/// This captures everything needed to setup the LPUART for panic display, even
+/// if the normal kernel had initialized it differently.
+pub struct LpuartPanicWriterConfig {
+    pub ccm: &'static ccm::Ccm,
+    pub id: LpuartId,
+    pub params: hil::uart::Parameters,
+}
+
+impl kernel::platform::chip::PanicWriter for Lpuart<'_> {
+    type Config = LpuartPanicWriterConfig;
+
+    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write {
+        use hil::uart::Configure as _;
+
+        let uart = match config.id {
+            LpuartId::Lpuart1 => Lpuart::new_lpuart1(config.ccm),
+            LpuartId::Lpuart2 => Lpuart::new_lpuart2(config.ccm),
+        };
+        let _ = uart.configure(config.params);
+
+        LpuartPanicWriter { uart }
+    }
+}
+
+impl Lpuart<'_> {}

--- a/chips/litex/src/uart.rs
+++ b/chips/litex/src/uart.rs
@@ -11,6 +11,7 @@ use core::cell::Cell;
 use kernel::deferred_call::{DeferredCall, DeferredCallClient};
 use kernel::hil::uart;
 use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::utilities::io_write::IoWrite;
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 
@@ -558,5 +559,58 @@ impl<R: LiteXSoCRegisterConfiguration> DeferredCallClient for LiteXUart<'_, R> {
                 self.rx_data();
             }
         }
+    }
+}
+
+/// A synchronous writer for the litex useful for panics.
+///
+/// For boards that want to use the UART to display panic messages, this
+/// provides an implementation of
+/// [`PanicWriter`](kernel::platform::chip::PanicWriter) with synchronous
+/// output.
+///
+/// This is only to be used by panic messages and is not used within the normal
+/// operation of the Tock kernel.
+///
+/// TODO: Validate this [`LiteXUartPanicWriter`] is always sound to create.
+struct LiteXUartPanicWriter<R: LiteXSoCRegisterConfiguration> {
+    uart: LiteXUart<'static, R>,
+}
+
+impl<R: LiteXSoCRegisterConfiguration> IoWrite for LiteXUartPanicWriter<R> {
+    fn write(&mut self, buf: &[u8]) -> usize {
+        self.uart.transmit_sync(buf);
+        buf.len()
+    }
+}
+
+impl<R: LiteXSoCRegisterConfiguration> core::fmt::Write for LiteXUartPanicWriter<R> {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+/// Configuration for the synchronous LiteX UART panic writer.
+///
+/// This captures everything needed to setup the UART for panic display, even
+/// if the normal kernel had initialized it differently.
+pub struct LiteXUartPanicWriterConfig<R: LiteXSoCRegisterConfiguration> {
+    pub uart_base: StaticRef<LiteXUartRegisters<R>>,
+    pub phy_args: Option<(StaticRef<LiteXUartPhyRegisters<R>>, u32)>,
+    pub params: uart::Parameters,
+}
+
+impl<R: LiteXSoCRegisterConfiguration> kernel::platform::chip::PanicWriter for LiteXUart<'_, R> {
+    type Config = LiteXUartPanicWriterConfig<R>;
+
+    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write {
+        use uart::Configure as _;
+
+        let uart = LiteXUart::new(config.uart_base, config.phy_args);
+        uart.initialize();
+        let _ = uart.configure(config.params);
+
+        LiteXUartPanicWriter { uart }
     }
 }

--- a/chips/lowrisc/src/uart.rs
+++ b/chips/lowrisc/src/uart.rs
@@ -13,6 +13,7 @@ use kernel::hil::uart;
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::cells::TakeCell;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
+use kernel::utilities::io_write::IoWrite;
 use kernel::utilities::StaticRef;
 
 use crate::registers::uart_regs::UartRegisters;
@@ -442,6 +443,58 @@ impl DeferredCallClient for Uart<'_> {
 
     fn register(&'static self) {
         self.rx_deferred_call.register(self);
+    }
+}
+
+/// A synchronous writer for the lowrisc useful for panics.
+///
+/// For boards that want to use the UART to display panic messages, this
+/// provides an implementation of
+/// [`PanicWriter`](kernel::platform::chip::PanicWriter) with synchronous
+/// output.
+///
+/// This is only to be used by panic messages and is not used within the normal
+/// operation of the Tock kernel.
+///
+/// TODO: Validate this [`UartPanicWriter`] is always sound to create.
+struct UartPanicWriter<'a> {
+    uart: Uart<'a>,
+}
+
+impl IoWrite for UartPanicWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> usize {
+        self.uart.transmit_sync(buf);
+        buf.len()
+    }
+}
+
+impl core::fmt::Write for UartPanicWriter<'_> {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+/// Configuration for the synchronous UART panic writer.
+///
+/// This captures everything needed to setup the UART for panic display, even
+/// if the normal kernel had initialized it differently.
+pub struct UartPanicWriterConfig {
+    pub registers: StaticRef<UartRegisters>,
+    pub clock_frequency: u32,
+    pub params: hil::uart::Parameters,
+}
+
+impl kernel::platform::chip::PanicWriter for Uart<'_> {
+    type Config = UartPanicWriterConfig;
+
+    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write {
+        use hil::uart::Configure as _;
+
+        let uart = Uart::new(config.registers, config.clock_frequency);
+        let _ = uart.configure(config.params);
+
+        UartPanicWriter { uart }
     }
 }
 

--- a/chips/lowrisc/src/uart.rs
+++ b/chips/lowrisc/src/uart.rs
@@ -12,8 +12,8 @@ use kernel::hil;
 use kernel::hil::uart;
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::cells::TakeCell;
-use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::io_write::IoWrite;
+use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::StaticRef;
 
 use crate::registers::uart_regs::UartRegisters;

--- a/chips/lpc55s6x/src/uart.rs
+++ b/chips/lpc55s6x/src/uart.rs
@@ -24,17 +24,19 @@ use kernel::hil::uart::{
     Configure, Parameters, Parity, Receive, StopBits, Transmit, TransmitClient, Width,
 };
 use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::utilities::io_write::IoWrite;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{
     register_bitfields, register_structs, ReadOnly, ReadWrite, WriteOnly,
 };
-use kernel::utilities::io_write::IoWrite;
 use kernel::utilities::StaticRef;
 use kernel::{hil, ErrorCode};
 
 use crate::clocks::FrgId;
 use crate::clocks::{Clock, FrgClockSource};
 use crate::flexcomm::Flexcomm;
+use crate::gpio::LPCPin;
+use crate::iocon::{self, Iocon};
 
 register_structs! {
     /// USARTs
@@ -1049,18 +1051,49 @@ pub enum UartId {
 /// that lpc55s6x UART configuration requires chip-specific clock and flexcomm
 /// setup; the panic writer relies on the UART having already been initialized
 /// by the kernel before the panic occurred.
-pub struct UartPanicWriterConfig {
+pub struct UartPanicWriterConfig<'a> {
+    pub params: Parameters,
     pub id: UartId,
+    pub clocks: &'a Clock,
+    pub flexcomm: &'a Flexcomm,
+    pub iocon: &'a Iocon,
+    pub pin1: LPCPin,
+    pub pin2: LPCPin,
 }
 
-impl kernel::platform::chip::PanicWriter for Uart<'_> {
-    type Config = UartPanicWriterConfig;
+impl<'a> kernel::platform::chip::PanicWriter for Uart<'a> {
+    type Config = UartPanicWriterConfig<'a>;
 
     unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write {
         let uart = match config.id {
-            UartId::Uart0 => Uart::new_uart0(),
-            UartId::Uart4 => Uart::new_uart4(),
+            UartId::Uart0 => Uart::new_uart0(config.clocks, config.flexcomm),
+            UartId::Uart4 => Uart::new_uart4(config.clocks, config.flexcomm),
         };
+        let _ = uart.configure(config.params);
+
+        config.iocon.configure_pin(
+            config.pin1,
+            iocon::Config {
+                function: iocon::Function::Alt1,
+                pull: iocon::Pull::None,
+                digital_mode: true,
+                slew: iocon::Slew::Standard,
+                invert: false,
+                open_drain: false,
+            },
+        );
+
+        config.iocon.configure_pin(
+            config.pin2,
+            iocon::Config {
+                function: iocon::Function::Alt1,
+                pull: iocon::Pull::None,
+                digital_mode: true,
+                slew: iocon::Slew::Standard,
+                invert: false,
+                open_drain: false,
+            },
+        );
 
         UartPanicWriter { uart }
     }

--- a/chips/lpc55s6x/src/uart.rs
+++ b/chips/lpc55s6x/src/uart.rs
@@ -28,6 +28,7 @@ use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeabl
 use kernel::utilities::registers::{
     register_bitfields, register_structs, ReadOnly, ReadWrite, WriteOnly,
 };
+use kernel::utilities::io_write::IoWrite;
 use kernel::utilities::StaticRef;
 use kernel::{hil, ErrorCode};
 
@@ -689,6 +690,13 @@ impl<'a> Uart<'a> {
         self.registers.fifowr.set(data as u32);
     }
 
+    pub fn transmit_sync(&self, bytes: &[u8]) {
+        for &b in bytes {
+            while !self.uart_is_writable() {}
+            self.send_byte(b);
+        }
+    }
+
     pub fn receive_byte(&self) -> u8 {
         (self.registers.fiford.get() & 0xFF) as u8
     }
@@ -997,5 +1005,63 @@ impl<'a> Receive<'a> for Uart<'a> {
         } else {
             Ok(())
         }
+    }
+}
+
+/// A synchronous writer for the lpc55s6x useful for panics.
+///
+/// For boards that want to use the UART to display panic messages, this
+/// provides an implementation of
+/// [`PanicWriter`](kernel::platform::chip::PanicWriter) with synchronous
+/// output.
+///
+/// This is only to be used by panic messages and is not used within the normal
+/// operation of the Tock kernel.
+///
+/// TODO: Validate this [`UartPanicWriter`] is always sound to create.
+struct UartPanicWriter<'a> {
+    uart: Uart<'a>,
+}
+
+impl IoWrite for UartPanicWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> usize {
+        self.uart.transmit_sync(buf);
+        buf.len()
+    }
+}
+
+impl core::fmt::Write for UartPanicWriter<'_> {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+/// Selects which USART instance to use for panic output.
+pub enum UartId {
+    Uart0,
+    Uart4,
+}
+
+/// Configuration for the synchronous UART panic writer.
+///
+/// This captures everything needed to setup the UART for panic display. Note
+/// that lpc55s6x UART configuration requires chip-specific clock and flexcomm
+/// setup; the panic writer relies on the UART having already been initialized
+/// by the kernel before the panic occurred.
+pub struct UartPanicWriterConfig {
+    pub id: UartId,
+}
+
+impl kernel::platform::chip::PanicWriter for Uart<'_> {
+    type Config = UartPanicWriterConfig;
+
+    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write {
+        let uart = match config.id {
+            UartId::Uart0 => Uart::new_uart0(),
+            UartId::Uart4 => Uart::new_uart4(),
+        };
+
+        UartPanicWriter { uart }
     }
 }

--- a/chips/msp432/src/uart.rs
+++ b/chips/msp432/src/uart.rs
@@ -9,6 +9,7 @@ use crate::usci::{self, UsciARegisters};
 use core::cell::Cell;
 use kernel::hil;
 use kernel::utilities::cells::OptionalCell;
+use kernel::utilities::io_write::IoWrite;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
@@ -330,5 +331,70 @@ impl<'a> hil::uart::Receive<'a> for Uart<'a> {
         });
 
         Err(ErrorCode::BUSY)
+    }
+}
+
+/// A synchronous writer for the msp432 useful for panics.
+///
+/// For boards that want to use the UART to display panic messages, this
+/// provides an implementation of
+/// [`PanicWriter`](kernel::platform::chip::PanicWriter) with synchronous
+/// output.
+///
+/// This is only to be used by panic messages and is not used within the normal
+/// operation of the Tock kernel.
+///
+/// TODO: Validate this [`UartPanicWriter`] is always sound to create.
+struct UartPanicWriter<'a> {
+    uart: Uart<'a>,
+}
+
+impl IoWrite for UartPanicWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> usize {
+        self.uart.transmit_sync(buf);
+        buf.len()
+    }
+}
+
+impl core::fmt::Write for UartPanicWriter<'_> {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+/// Selects which USCI_A UART instance to use for panic output.
+pub enum UartId {
+    UcA0,
+    UcA1,
+    UcA2,
+    UcA3,
+}
+
+/// Configuration for the synchronous UART panic writer.
+///
+/// This captures everything needed to setup the UART for panic display, even
+/// if the normal kernel had initialized it differently.
+pub struct UartPanicWriterConfig {
+    pub id: UartId,
+    pub params: hil::uart::Parameters,
+}
+
+impl kernel::platform::chip::PanicWriter for Uart<'_> {
+    type Config = UartPanicWriterConfig;
+
+    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write {
+        use hil::uart::Configure as _;
+
+        let registers = match config.id {
+            UartId::UcA0 => usci::USCI_A0_BASE,
+            UartId::UcA1 => usci::USCI_A1_BASE,
+            UartId::UcA2 => usci::USCI_A2_BASE,
+            UartId::UcA3 => usci::USCI_A3_BASE,
+        };
+        let uart = Uart::new(registers, 0, 0, 0, 0);
+        let _ = uart.configure(config.params);
+
+        UartPanicWriter { uart }
     }
 }

--- a/chips/psoc62xa/src/scb.rs
+++ b/chips/psoc62xa/src/scb.rs
@@ -7,8 +7,8 @@ use core::fmt;
 use core::num::NonZeroUsize;
 use kernel::errorcode::ErrorCode;
 use kernel::hil::uart::{self, Configure, Receive, ReceiveClient, Transmit, TransmitClient};
-use kernel::utilities::StaticRef;
 use kernel::utilities::io_write::IoWrite;
+use kernel::utilities::StaticRef;
 use kernel::utilities::{
     cells::{OptionalCell, TakeCell},
     registers::{

--- a/chips/psoc62xa/src/scb.rs
+++ b/chips/psoc62xa/src/scb.rs
@@ -3,10 +3,12 @@
 // Copyright OxidOS Automotive 2025 SRL.
 
 use core::cell::Cell;
+use core::fmt;
 use core::num::NonZeroUsize;
 use kernel::errorcode::ErrorCode;
 use kernel::hil::uart::{self, Configure, Receive, ReceiveClient, Transmit, TransmitClient};
 use kernel::utilities::StaticRef;
+use kernel::utilities::io_write::IoWrite;
 use kernel::utilities::{
     cells::{OptionalCell, TakeCell},
     registers::{
@@ -852,5 +854,41 @@ impl Configure for Scb<'_> {
             }
             Ok(())
         }
+    }
+}
+
+/// [`PanicWriter`](kernel::platform::chip::PanicWriter) with synchronous
+/// output.
+///
+/// This is only to be used by panic messages and is not used within the normal
+/// operation of the Tock kernel.
+///
+/// TODO: Validate this [`ScbPanicWriter`] is always sound to create.
+struct ScbPanicWriter;
+
+impl IoWrite for ScbPanicWriter {
+    fn write(&mut self, buf: &[u8]) -> usize {
+        // Create a fresh Scb instance to access the fixed SCB5 hardware registers.
+        // The SCB is assumed to have been configured by the normal kernel startup.
+        Scb::new().transmit_uart_sync(buf);
+        buf.len()
+    }
+}
+
+impl fmt::Write for ScbPanicWriter {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+/// Configuration for the synchronous SCB UART panic writer.
+pub struct ScbPanicWriterConfig;
+
+impl kernel::platform::chip::PanicWriter for Scb<'static> {
+    type Config = ScbPanicWriterConfig;
+
+    unsafe fn create_panic_writer(_config: Self::Config) -> impl IoWrite + fmt::Write {
+        ScbPanicWriter
     }
 }

--- a/chips/rp2040/src/uart.rs
+++ b/chips/rp2040/src/uart.rs
@@ -806,20 +806,21 @@ pub enum UartId {
 ///
 /// This captures everything needed to setup the UART for panic display, even
 /// if the normal kernel had initialized it differently.
-pub struct UartPanicWriterConfig {
+pub struct UartPanicWriterConfig<'a> {
     pub id: UartId,
     pub params: hil::uart::Parameters,
+    pub clocks: &'a clocks::Clocks,
 }
 
-impl kernel::platform::chip::PanicWriter for Uart<'_> {
-    type Config = UartPanicWriterConfig;
+impl<'a> kernel::platform::chip::PanicWriter for Uart<'a> {
+    type Config = UartPanicWriterConfig<'a>;
 
     unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write {
         use hil::uart::Configure as _;
 
         let uart = match config.id {
-            UartId::Uart0 => Uart::new_uart0(),
-            UartId::Uart1 => Uart::new_uart1(),
+            UartId::Uart0 => Uart::new_uart0(config.clocks),
+            UartId::Uart1 => Uart::new_uart1(config.clocks),
         };
         let _ = uart.configure(config.params);
 

--- a/chips/rp2040/src/uart.rs
+++ b/chips/rp2040/src/uart.rs
@@ -10,9 +10,9 @@ use kernel::hil::uart::{
     Configure, Parameters, Parity, Receive, StopBits, Transmit, TransmitClient, Width,
 };
 use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::utilities::io_write::IoWrite;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{register_bitfields, register_structs, ReadOnly, ReadWrite};
-use kernel::utilities::io_write::IoWrite;
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 

--- a/chips/rp2040/src/uart.rs
+++ b/chips/rp2040/src/uart.rs
@@ -12,6 +12,7 @@ use kernel::hil::uart::{
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{register_bitfields, register_structs, ReadOnly, ReadWrite};
+use kernel::utilities::io_write::IoWrite;
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 
@@ -476,6 +477,12 @@ impl<'a> Uart<'a> {
         self.registers.uartdr.write(UARTDR::DATA.val(data as u32));
     }
 
+    pub fn transmit_sync(&self, bytes: &[u8]) {
+        for &b in bytes {
+            self.send_byte(b);
+        }
+    }
+
     pub fn handle_interrupt(&self) {
         if self.registers.uartimsc.is_set(UARTIMSC::TXIM) {
             if self.registers.uartfr.is_set(UARTFR::TXFE) {
@@ -757,5 +764,65 @@ impl<'a> Receive<'a> for Uart<'a> {
         } else {
             Ok(())
         }
+    }
+}
+
+/// A synchronous writer for the rp2040 useful for panics.
+///
+/// For boards that want to use the UART to display panic messages, this
+/// provides an implementation of
+/// [`PanicWriter`](kernel::platform::chip::PanicWriter) with synchronous
+/// output.
+///
+/// This is only to be used by panic messages and is not used within the normal
+/// operation of the Tock kernel.
+///
+/// TODO: Validate this [`UartPanicWriter`] is always sound to create.
+struct UartPanicWriter<'a> {
+    uart: Uart<'a>,
+}
+
+impl IoWrite for UartPanicWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> usize {
+        self.uart.transmit_sync(buf);
+        buf.len()
+    }
+}
+
+impl core::fmt::Write for UartPanicWriter<'_> {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+/// Selects which UART instance to use for panic output.
+pub enum UartId {
+    Uart0,
+    Uart1,
+}
+
+/// Configuration for the synchronous UART panic writer.
+///
+/// This captures everything needed to setup the UART for panic display, even
+/// if the normal kernel had initialized it differently.
+pub struct UartPanicWriterConfig {
+    pub id: UartId,
+    pub params: hil::uart::Parameters,
+}
+
+impl kernel::platform::chip::PanicWriter for Uart<'_> {
+    type Config = UartPanicWriterConfig;
+
+    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write {
+        use hil::uart::Configure as _;
+
+        let uart = match config.id {
+            UartId::Uart0 => Uart::new_uart0(),
+            UartId::Uart1 => Uart::new_uart1(),
+        };
+        let _ = uart.configure(config.params);
+
+        UartPanicWriter { uart }
     }
 }

--- a/chips/rp2350/src/uart.rs
+++ b/chips/rp2350/src/uart.rs
@@ -10,6 +10,7 @@ use kernel::hil::uart::{
     Configure, Parameters, Parity, Receive, StopBits, Transmit, TransmitClient, Width,
 };
 use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::utilities::io_write::IoWrite;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{register_bitfields, register_structs, ReadWrite};
 use kernel::utilities::StaticRef;
@@ -444,6 +445,12 @@ impl<'a> Uart<'a> {
         self.registers.uartdr.write(UARTDR::DATA.val(data as u32));
     }
 
+    pub fn transmit_sync(&self, bytes: &[u8]) {
+        for &b in bytes {
+            self.send_byte(b);
+        }
+    }
+
     pub fn handle_interrupt(&self) {
         if self.registers.uartimsc.is_set(UARTIMSC::TXIM) {
             if self.registers.uartfr.is_set(UARTFR::TXFE) {
@@ -807,5 +814,65 @@ impl<'a> Receive<'a> for Uart<'a> {
         } else {
             Ok(())
         }
+    }
+}
+
+/// A synchronous writer for the rp2350 useful for panics.
+///
+/// For boards that want to use the UART to display panic messages, this
+/// provides an implementation of
+/// [`PanicWriter`](kernel::platform::chip::PanicWriter) with synchronous
+/// output.
+///
+/// This is only to be used by panic messages and is not used within the normal
+/// operation of the Tock kernel.
+///
+/// TODO: Validate this [`UartPanicWriter`] is always sound to create.
+struct UartPanicWriter<'a> {
+    uart: Uart<'a>,
+}
+
+impl IoWrite for UartPanicWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> usize {
+        self.uart.transmit_sync(buf);
+        buf.len()
+    }
+}
+
+impl core::fmt::Write for UartPanicWriter<'_> {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+/// Selects which UART instance to use for panic output.
+pub enum UartId {
+    Uart0,
+    Uart1,
+}
+
+/// Configuration for the synchronous UART panic writer.
+///
+/// This captures everything needed to setup the UART for panic display, even
+/// if the normal kernel had initialized it differently.
+pub struct UartPanicWriterConfig {
+    pub id: UartId,
+    pub params: hil::uart::Parameters,
+}
+
+impl kernel::platform::chip::PanicWriter for Uart<'_> {
+    type Config = UartPanicWriterConfig;
+
+    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write {
+        use hil::uart::Configure as _;
+
+        let uart = match config.id {
+            UartId::Uart0 => Uart::new_uart0(),
+            UartId::Uart1 => Uart::new_uart1(),
+        };
+        let _ = uart.configure(config.params);
+
+        UartPanicWriter { uart }
     }
 }

--- a/chips/rp2350/src/uart.rs
+++ b/chips/rp2350/src/uart.rs
@@ -856,20 +856,21 @@ pub enum UartId {
 ///
 /// This captures everything needed to setup the UART for panic display, even
 /// if the normal kernel had initialized it differently.
-pub struct UartPanicWriterConfig {
+pub struct UartPanicWriterConfig<'a> {
     pub id: UartId,
     pub params: hil::uart::Parameters,
+    pub clocks: &'a clocks::Clocks,
 }
 
-impl kernel::platform::chip::PanicWriter for Uart<'_> {
-    type Config = UartPanicWriterConfig;
+impl<'a> kernel::platform::chip::PanicWriter for Uart<'a> {
+    type Config = UartPanicWriterConfig<'a>;
 
     unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write {
         use hil::uart::Configure as _;
 
         let uart = match config.id {
-            UartId::Uart0 => Uart::new_uart0(),
-            UartId::Uart1 => Uart::new_uart1(),
+            UartId::Uart0 => Uart::new_uart0(config.clocks),
+            UartId::Uart1 => Uart::new_uart1(config.clocks),
         };
         let _ = uart.configure(config.params);
 

--- a/chips/sam4l/src/usart.rs
+++ b/chips/sam4l/src/usart.rs
@@ -1285,3 +1285,83 @@ impl<'a> spi::SpiMaster<'a> for USART<'a> {
         unimplemented!("USART: SPI: Use `read_write_bytes()` instead.");
     }
 }
+
+/// Selects which USART instance to use for panic output.
+pub enum UsartId {
+    Usart0,
+    Usart1,
+    Usart2,
+    Usart3,
+}
+
+/// Configuration for the synchronous USART panic writer.
+///
+/// This captures everything needed to set up the USART for panic output.
+pub struct UsartPanicWriterConfig {
+    pub id: UsartId,
+}
+
+/// [`PanicWriter`](kernel::platform::chip::PanicWriter) with synchronous
+/// output.
+///
+/// This is only to be used by panic messages and is not used within the normal
+/// operation of the Tock kernel.
+///
+/// TODO: Validate this [`UsartPanicWriter`] is always sound to create.
+struct UsartPanicWriter {
+    id: UsartId,
+    initialized: bool,
+}
+
+impl kernel::utilities::io_write::IoWrite for UsartPanicWriter {
+    fn write(&mut self, buf: &[u8]) -> usize {
+        // Create a fresh PowerManager for panic output using static allocation.
+        // This mirrors the pattern used in board-level panic handlers for sam4l.
+        let pm = unsafe {
+            kernel::static_init!(pm::PowerManager, pm::PowerManager::new())
+        };
+        let usart = match self.id {
+            UsartId::Usart0 => USART::new_usart0(pm),
+            UsartId::Usart1 => USART::new_usart1(pm),
+            UsartId::Usart2 => USART::new_usart2(pm),
+            UsartId::Usart3 => USART::new_usart3(pm),
+        };
+        let regs_manager = &USARTRegManager::panic_new(&usart);
+        if !self.initialized {
+            self.initialized = true;
+            let _ = usart.configure(uart::Parameters {
+                baud_rate: 115200,
+                width: uart::Width::Eight,
+                stop_bits: uart::StopBits::One,
+                parity: uart::Parity::None,
+                hw_flow_control: false,
+            });
+            usart.enable_tx(regs_manager);
+        }
+        for &c in buf {
+            usart.send_byte(regs_manager, c);
+            while !usart.tx_ready(regs_manager) {}
+        }
+        buf.len()
+    }
+}
+
+impl core::fmt::Write for UsartPanicWriter {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        kernel::utilities::io_write::IoWrite::write(self, s.as_bytes());
+        Ok(())
+    }
+}
+
+impl kernel::platform::chip::PanicWriter for USART<'static> {
+    type Config = UsartPanicWriterConfig;
+
+    unsafe fn create_panic_writer(
+        config: Self::Config,
+    ) -> impl kernel::utilities::io_write::IoWrite + core::fmt::Write {
+        UsartPanicWriter {
+            id: config.id,
+            initialized: false,
+        }
+    }
+}

--- a/chips/sam4l/src/usart.rs
+++ b/chips/sam4l/src/usart.rs
@@ -13,6 +13,7 @@ use kernel::deferred_call::{DeferredCall, DeferredCallClient};
 use kernel::hil::spi;
 use kernel::hil::spi::cs::ChipSelectPolar;
 use kernel::hil::uart;
+use kernel::hil::uart::Configure;
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
@@ -1317,9 +1318,7 @@ impl kernel::utilities::io_write::IoWrite for UsartPanicWriter {
     fn write(&mut self, buf: &[u8]) -> usize {
         // Create a fresh PowerManager for panic output using static allocation.
         // This mirrors the pattern used in board-level panic handlers for sam4l.
-        let pm = unsafe {
-            kernel::static_init!(pm::PowerManager, pm::PowerManager::new())
-        };
+        let pm = unsafe { kernel::static_init!(pm::PowerManager, pm::PowerManager::new()) };
         let usart = match self.id {
             UsartId::Usart0 => USART::new_usart0(pm),
             UsartId::Usart1 => USART::new_usart1(pm),

--- a/chips/stm32f303xc/src/usart.rs
+++ b/chips/stm32f303xc/src/usart.rs
@@ -8,9 +8,9 @@ use kernel::deferred_call::{DeferredCall, DeferredCallClient};
 use kernel::hil;
 use kernel::platform::chip::ClockInterface;
 use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::utilities::io_write::IoWrite;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite};
-use kernel::utilities::io_write::IoWrite;
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 

--- a/chips/stm32f303xc/src/usart.rs
+++ b/chips/stm32f303xc/src/usart.rs
@@ -10,6 +10,7 @@ use kernel::platform::chip::ClockInterface;
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite};
+use kernel::utilities::io_write::IoWrite;
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 
@@ -386,6 +387,12 @@ impl<'a> Usart<'a> {
         self.registers.tdr.set(byte.into());
     }
 
+    pub fn transmit_sync(&self, bytes: &[u8]) {
+        for &b in bytes {
+            self.send_byte(b);
+        }
+    }
+
     fn enable_transmit_interrupt(&self) {
         self.registers.cr1.modify(CR1::TXEIE::SET);
     }
@@ -648,6 +655,51 @@ impl<'a> hil::uart::Receive<'a> for Usart<'a> {
         } else {
             Ok(())
         }
+    }
+}
+
+pub enum UsartId {
+    Usart1,
+    Usart2,
+    Usart3,
+}
+
+pub struct UsartPanicWriterConfig {
+    pub id: UsartId,
+    pub rcc: &'static rcc::Rcc,
+    pub params: hil::uart::Parameters,
+}
+
+struct UsartPanicWriter {
+    uart: Usart<'static>,
+}
+
+impl IoWrite for UsartPanicWriter {
+    fn write(&mut self, buf: &[u8]) -> usize {
+        self.uart.transmit_sync(buf);
+        buf.len()
+    }
+}
+
+impl core::fmt::Write for UsartPanicWriter {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+impl kernel::platform::chip::PanicWriter for Usart<'_> {
+    type Config = UsartPanicWriterConfig;
+    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write {
+        use hil::uart::Configure as _;
+        let UsartPanicWriterConfig { id, rcc, params } = config;
+        let uart = match id {
+            UsartId::Usart1 => Usart::new_usart1(rcc),
+            UsartId::Usart2 => Usart::new_usart2(rcc),
+            UsartId::Usart3 => Usart::new_usart3(rcc),
+        };
+        let _ = uart.configure(params);
+        UsartPanicWriter { uart }
     }
 }
 

--- a/chips/stm32f4xx/src/usart.rs
+++ b/chips/stm32f4xx/src/usart.rs
@@ -7,10 +7,10 @@ use kernel::deferred_call::{DeferredCall, DeferredCallClient};
 use kernel::hil;
 use kernel::platform::chip::ClockInterface;
 use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::utilities::io_write::IoWrite;
 use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{register_bitfields, ReadWrite};
-use kernel::utilities::io_write::IoWrite;
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 

--- a/chips/stm32f4xx/src/usart.rs
+++ b/chips/stm32f4xx/src/usart.rs
@@ -10,6 +10,7 @@ use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{register_bitfields, ReadWrite};
+use kernel::utilities::io_write::IoWrite;
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 
@@ -373,6 +374,12 @@ impl<'a, DMA: dma::StreamServer<'a>> Usart<'a, DMA> {
         while !self.registers.sr.is_set(SR::TXE) {}
 
         self.registers.dr.set(byte.into());
+    }
+
+    pub fn transmit_sync(&self, bytes: &[u8]) {
+        for &b in bytes {
+            self.send_byte(b);
+        }
     }
 
     // enable DMA TX from the peripheral side
@@ -753,6 +760,65 @@ impl<'a> dma::StreamClient<'a, dma::Dma1<'a>> for Usart<'a, dma::Dma1<'a>> {
 impl<'a> dma::StreamClient<'a, dma::Dma2<'a>> for Usart<'a, dma::Dma2<'a>> {
     fn transfer_done(&self, pid: dma::Dma2Peripheral) {
         self.transfer_done(pid);
+    }
+}
+
+pub enum UsartId {
+    Usart1,
+    Usart2,
+    Usart3,
+}
+
+pub struct UsartPanicWriterConfig {
+    pub id: UsartId,
+    pub clocks: &'static dyn Stm32f4Clocks,
+    pub params: hil::uart::Parameters,
+}
+
+struct UsartPanicWriter {
+    registers: StaticRef<UsartRegisters>,
+}
+
+impl IoWrite for UsartPanicWriter {
+    fn write(&mut self, buf: &[u8]) -> usize {
+        for &b in buf {
+            while !self.registers.sr.is_set(SR::TXE) {}
+            self.registers.dr.set(b.into());
+        }
+        buf.len()
+    }
+}
+
+impl core::fmt::Write for UsartPanicWriter {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+impl<'a, DMA: dma::StreamServer<'a>> kernel::platform::chip::PanicWriter for Usart<'a, DMA> {
+    type Config = UsartPanicWriterConfig;
+    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write {
+        use hil::uart::Configure as _;
+        let UsartPanicWriterConfig { id, clocks, params } = config;
+        let base = match id {
+            UsartId::Usart1 => {
+                let uart = Usart::new_usart1(clocks);
+                let _ = uart.configure(params);
+                USART1_BASE
+            }
+            UsartId::Usart2 => {
+                let uart = Usart::new_usart2(clocks);
+                let _ = uart.configure(params);
+                USART2_BASE
+            }
+            UsartId::Usart3 => {
+                let uart = Usart::new_usart3(clocks);
+                let _ = uart.configure(params);
+                USART3_BASE
+            }
+        };
+        UsartPanicWriter { registers: base }
     }
 }
 

--- a/chips/stm32wle5xx/src/usart.rs
+++ b/chips/stm32wle5xx/src/usart.rs
@@ -722,6 +722,7 @@ impl kernel::platform::chip::PanicWriter for Usart<'_> {
             UsartId::Usart1 => Usart::new_usart1(clocks),
             UsartId::Usart2 => Usart::new_usart2(clocks),
         };
+        uart.enable_clock();
         let _ = uart.configure(params);
         UsartPanicWriter { uart }
     }

--- a/chips/stm32wle5xx/src/usart.rs
+++ b/chips/stm32wle5xx/src/usart.rs
@@ -9,6 +9,7 @@ use kernel::platform::chip::ClockInterface;
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite};
+use kernel::utilities::io_write::IoWrite;
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 
@@ -413,6 +414,12 @@ impl<'a> Usart<'a> {
         self.registers.tdr.set(byte.into());
     }
 
+    pub fn transmit_sync(&self, bytes: &[u8]) {
+        for &b in bytes {
+            self.send_byte(b);
+        }
+    }
+
     fn enable_transmit_interrupt(&self) {
         self.registers.cr1.modify(CR1::TXEIE::SET);
     }
@@ -674,6 +681,49 @@ impl<'a> hil::uart::Receive<'a> for Usart<'a> {
         } else {
             Ok(())
         }
+    }
+}
+
+pub enum UsartId {
+    Usart1,
+    Usart2,
+}
+
+pub struct UsartPanicWriterConfig {
+    pub id: UsartId,
+    pub clocks: &'static dyn Stm32wle5xxClocks,
+    pub params: hil::uart::Parameters,
+}
+
+struct UsartPanicWriter {
+    uart: Usart<'static>,
+}
+
+impl IoWrite for UsartPanicWriter {
+    fn write(&mut self, buf: &[u8]) -> usize {
+        self.uart.transmit_sync(buf);
+        buf.len()
+    }
+}
+
+impl core::fmt::Write for UsartPanicWriter {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+impl kernel::platform::chip::PanicWriter for Usart<'_> {
+    type Config = UsartPanicWriterConfig;
+    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write {
+        use hil::uart::Configure as _;
+        let UsartPanicWriterConfig { id, clocks, params } = config;
+        let uart = match id {
+            UsartId::Usart1 => Usart::new_usart1(clocks),
+            UsartId::Usart2 => Usart::new_usart2(clocks),
+        };
+        let _ = uart.configure(params);
+        UsartPanicWriter { uart }
     }
 }
 

--- a/chips/stm32wle5xx/src/usart.rs
+++ b/chips/stm32wle5xx/src/usart.rs
@@ -7,9 +7,9 @@ use kernel::deferred_call::{DeferredCall, DeferredCallClient};
 use kernel::hil;
 use kernel::platform::chip::ClockInterface;
 use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::utilities::io_write::IoWrite;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite};
-use kernel::utilities::io_write::IoWrite;
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 

--- a/chips/x86_q35/src/serial.rs
+++ b/chips/x86_q35/src/serial.rs
@@ -521,3 +521,18 @@ impl IoWrite for BlockingSerialPort {
         buf.len()
     }
 }
+
+/// Configuration for the synchronous serial port panic writer.
+///
+/// This captures everything needed to set up the serial port for panic output.
+pub struct BlockingSerialPortConfig {
+    pub base: u16,
+}
+
+impl kernel::platform::chip::PanicWriter for BlockingSerialPort {
+    type Config = BlockingSerialPortConfig;
+
+    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write {
+        BlockingSerialPort::new(config.base)
+    }
+}

--- a/chips/x86_q35/src/serial.rs
+++ b/chips/x86_q35/src/serial.rs
@@ -533,6 +533,6 @@ impl kernel::platform::chip::PanicWriter for BlockingSerialPort {
     type Config = BlockingSerialPortConfig;
 
     unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write {
-        BlockingSerialPort::new(config.base)
+        unsafe { BlockingSerialPort::new(config.base) }
     }
 }


### PR DESCRIPTION
### Pull Request Overview

Convert all boards to use PanicWriter ~, and remove panic_old in debug~ .

I had my robot claude do all of this.

This allows us to remove many `static mut`s in io.rs files.


### Testing Strategy

Yeah...this is tricky.  I need to go through the changes, but I obviously cannot test probably any of these changes because I don't have the boards.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.

This was entirely done by claude.