### PR TITLE
chips: nrf5x: remove unsafe from pinmux

### DIFF
--- a/boards/nordic/nrf52_components/src/startup.rs
+++ b/boards/nordic/nrf52_components/src/startup.rs
@@ -217,14 +217,12 @@ impl Component for UartChannelComponent {
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
         match self.uart_channel {
             UartChannel::Pins(uart_pins) => {
-                unsafe {
-                    self.uarte0.initialize(
-                        nrf52::pinmux::Pinmux::new(uart_pins.txd),
-                        nrf52::pinmux::Pinmux::new(uart_pins.rxd),
-                        uart_pins.cts.map(|x| nrf52::pinmux::Pinmux::new(x)),
-                        uart_pins.rts.map(|x| nrf52::pinmux::Pinmux::new(x)),
-                    )
-                };
+                self.uarte0.initialize(
+                    nrf52::pinmux::Pinmux::new(uart_pins.txd),
+                    nrf52::pinmux::Pinmux::new(uart_pins.rxd),
+                    uart_pins.cts.map(nrf52::pinmux::Pinmux::new),
+                    uart_pins.rts.map(nrf52::pinmux::Pinmux::new),
+                );
                 self.uarte0
             }
             UartChannel::Rtt(rtt_memory) => {

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -842,10 +842,10 @@ impl kernel::platform::chip::PanicWriter for Uarte<'_> {
 
         let inner = Uarte::new(UARTE0_BASE);
         inner.initialize(
-            pinmux::Pinmux::from_pin(config.txd),
-            pinmux::Pinmux::from_pin(config.rxd),
-            config.cts.map(|c| unsafe { pinmux::Pinmux::from_pin(c) }),
-            config.rts.map(|r| unsafe { pinmux::Pinmux::from_pin(r) }),
+            pinmux::Pinmux::new(config.txd),
+            pinmux::Pinmux::new(config.rxd),
+            config.cts.map(pinmux::Pinmux::new),
+            config.rts.map(pinmux::Pinmux::new),
         );
         let _ = inner.configure(config.params);
         UartPanicWriter { inner }

--- a/chips/nrf5x/src/pinmux.rs
+++ b/chips/nrf5x/src/pinmux.rs
@@ -9,18 +9,7 @@
 //! configuration should create `Pinmux`s and pass them into controller drivers
 //! during initialization.
 
-use kernel::utilities::cells::VolatileCell;
-
 use crate::gpio::Pin;
-
-// Note: only the nrf52840 has two ports, but we create two ports to avoid
-// gating this code by a feature.
-const NUM_PORTS: usize = 2;
-
-const PIN_PER_PORT: usize = 32;
-
-// Keep track of which pins has a `Pinmux` been created for.
-static mut USED_PINS: [VolatileCell<u32>; NUM_PORTS] = [VolatileCell::new(0), VolatileCell::new(0)];
 
 /// An opaque wrapper around a configurable pin.
 #[derive(Copy, Clone)]
@@ -34,19 +23,7 @@ impl Pinmux {
     /// If a `Pinmux` for this pin has already
     /// been created.
     ///
-    pub unsafe fn new(pin: Pin) -> Pinmux {
-        let port: usize = (pin as usize) / PIN_PER_PORT;
-        let pin_idx: usize = (pin as usize) % PIN_PER_PORT;
-        let used_pins = USED_PINS[port].get();
-        if used_pins & (1 << pin_idx) != 0 {
-            panic!("Pin {:?} is already in use!", pin);
-        } else {
-            USED_PINS[port].set(used_pins | 1 << pin_idx);
-            Pinmux(pin)
-        }
-    }
-
-    pub unsafe fn from_pin(pin: crate::gpio::Pin) -> Pinmux {
+    pub fn new(pin: Pin) -> Pinmux {
         Pinmux(pin)
     }
 }

--- a/chips/nrf5x/src/pinmux.rs
+++ b/chips/nrf5x/src/pinmux.rs
@@ -17,12 +17,6 @@ pub struct Pinmux(Pin);
 
 impl Pinmux {
     /// Creates a new `Pinmux` wrapping the numbered pin.
-    ///
-    /// # Panics
-    ///
-    /// If a `Pinmux` for this pin has already
-    /// been created.
-    ///
     pub fn new(pin: Pin) -> Pinmux {
         Pinmux(pin)
     }


### PR DESCRIPTION
### Pull Request Overview

Remove unsafe from nrf5x/pinmux.

Extracted from https://github.com/tock/tock/pull/4626.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
