### PR TITLE
chips: nrf5x: remove unsafe from gpio

### DIFF
--- a/boards/clue_nrf52840/src/io.rs
+++ b/boards/clue_nrf52840/src/io.rs
@@ -125,7 +125,11 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P1_01);
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
+        Pin::P1_01,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT1,
+    );
     let led = &mut led::LedHigh::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
     debug::panic_old(

--- a/boards/clue_nrf52840/src/io.rs
+++ b/boards/clue_nrf52840/src/io.rs
@@ -125,11 +125,7 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
-        Pin::P1_01,
-        nrf52840::gpio::GPIOTE_BASE,
-        nrf52840::gpio::GPIO_BASE_PORT1,
-    );
+    let led_kernel_pin = &nrf52840::gpio::nrf52840_gpio_create_pin(Pin::P1_01);
     let led = &mut led::LedHigh::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
     debug::panic_old(

--- a/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/io.rs
+++ b/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/io.rs
@@ -73,7 +73,11 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // MicroBit v2 has a microphone LED, use it for panic
 
     use core::ptr::addr_of_mut;
-    let led_kernel_pin = &nrf52833::gpio::GPIOPin::new(Pin::P0_20);
+    let led_kernel_pin = &nrf52833::gpio::GPIOPin::new(
+        Pin::P0_20,
+        nrf52833::gpio::GPIOTE_BASE,
+        nrf52833::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
     debug::panic_old(

--- a/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/io.rs
+++ b/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/io.rs
@@ -73,11 +73,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // MicroBit v2 has a microphone LED, use it for panic
 
     use core::ptr::addr_of_mut;
-    let led_kernel_pin = &nrf52833::gpio::GPIOPin::new(
-        Pin::P0_20,
-        nrf52833::gpio::GPIOTE_BASE,
-        nrf52833::gpio::GPIO_BASE_PORT0,
-    );
+    let led_kernel_pin = &nrf52833::gpio::nrf52833_gpio_create_pin(Pin::P0_20);
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
     debug::panic_old(

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/src/io.rs
@@ -10,7 +10,11 @@ use nrf52840::gpio::Pin;
 /// Panic handler
 pub unsafe fn panic_fmt(_pi: &PanicInfo) -> ! {
     // The nRF52840DK LEDs (see back of board)
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
+        Pin::P0_13,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut kernel::hil::led::LedLow::new(led_kernel_pin);
     kernel::debug::panic_blink_forever(&mut [led])
 }

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/src/io.rs
@@ -10,11 +10,7 @@ use nrf52840::gpio::Pin;
 /// Panic handler
 pub unsafe fn panic_fmt(_pi: &PanicInfo) -> ! {
     // The nRF52840DK LEDs (see back of board)
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
-        Pin::P0_13,
-        nrf52840::gpio::GPIOTE_BASE,
-        nrf52840::gpio::GPIO_BASE_PORT0,
-    );
+    let led_kernel_pin = &nrf52840::gpio::nrf52840_gpio_create_pin(Pin::P0_13);
     let led = &mut kernel::hil::led::LedLow::new(led_kernel_pin);
     kernel::debug::panic_blink_forever(&mut [led])
 }

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-sha256/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-sha256/src/io.rs
@@ -10,7 +10,11 @@ use nrf52840::gpio::Pin;
 /// Panic handler
 pub unsafe fn panic_fmt(_pi: &PanicInfo) -> ! {
     // The nRF52840DK LEDs (see back of board)
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
+        Pin::P0_13,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut kernel::hil::led::LedLow::new(led_kernel_pin);
     kernel::debug::panic_blink_forever(&mut [led])
 }

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-sha256/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-sha256/src/io.rs
@@ -10,11 +10,7 @@ use nrf52840::gpio::Pin;
 /// Panic handler
 pub unsafe fn panic_fmt(_pi: &PanicInfo) -> ! {
     // The nRF52840DK LEDs (see back of board)
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
-        Pin::P0_13,
-        nrf52840::gpio::GPIOTE_BASE,
-        nrf52840::gpio::GPIO_BASE_PORT0,
-    );
+    let led_kernel_pin = &nrf52840::gpio::nrf52840_gpio_create_pin(Pin::P0_13);
     let led = &mut kernel::hil::led::LedLow::new(led_kernel_pin);
     kernel::debug::panic_blink_forever(&mut [led])
 }

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/io.rs
@@ -10,7 +10,11 @@ use nrf52840::gpio::Pin;
 /// Panic handler
 pub unsafe fn panic_fmt(_pi: &PanicInfo) -> ! {
     // The nRF52840DK LEDs (see back of board)
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
+        Pin::P0_13,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut kernel::hil::led::LedLow::new(led_kernel_pin);
     kernel::debug::panic_blink_forever(&mut [led])
 }

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/io.rs
@@ -10,11 +10,7 @@ use nrf52840::gpio::Pin;
 /// Panic handler
 pub unsafe fn panic_fmt(_pi: &PanicInfo) -> ! {
     // The nRF52840DK LEDs (see back of board)
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
-        Pin::P0_13,
-        nrf52840::gpio::GPIOTE_BASE,
-        nrf52840::gpio::GPIO_BASE_PORT0,
-    );
+    let led_kernel_pin = &nrf52840::gpio::nrf52840_gpio_create_pin(Pin::P0_13);
     let led = &mut kernel::hil::led::LedLow::new(led_kernel_pin);
     kernel::debug::panic_blink_forever(&mut [led])
 }

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/io.rs
@@ -62,7 +62,11 @@ pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {
     use nrf52840::gpio::Pin;
 
     // The nRF52840DK LEDs (see back of board)
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
+        Pin::P0_13,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut led::LedLow::new(led_kernel_pin);
     let mut writer = Writer::new();
     debug::panic_old(

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/io.rs
@@ -62,11 +62,7 @@ pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {
     use nrf52840::gpio::Pin;
 
     // The nRF52840DK LEDs (see back of board)
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
-        Pin::P0_13,
-        nrf52840::gpio::GPIOTE_BASE,
-        nrf52840::gpio::GPIO_BASE_PORT0,
-    );
+    let led_kernel_pin = &nrf52840::gpio::nrf52840_gpio_create_pin(Pin::P0_13);
     let led = &mut led::LedLow::new(led_kernel_pin);
     let mut writer = Writer::new();
     debug::panic_old(

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-invs/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-invs/src/io.rs
@@ -10,7 +10,11 @@ use nrf52840::gpio::Pin;
 /// Panic handler
 pub unsafe fn panic_fmt(_pi: &PanicInfo) -> ! {
     // The nRF52840DK LEDs (see back of board)
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
+        Pin::P0_13,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut kernel::hil::led::LedLow::new(led_kernel_pin);
     kernel::debug::panic_blink_forever(&mut [led])
 }

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-invs/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-invs/src/io.rs
@@ -10,11 +10,7 @@ use nrf52840::gpio::Pin;
 /// Panic handler
 pub unsafe fn panic_fmt(_pi: &PanicInfo) -> ! {
     // The nRF52840DK LEDs (see back of board)
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
-        Pin::P0_13,
-        nrf52840::gpio::GPIOTE_BASE,
-        nrf52840::gpio::GPIO_BASE_PORT0,
-    );
+    let led_kernel_pin = &nrf52840::gpio::nrf52840_gpio_create_pin(Pin::P0_13);
     let led = &mut kernel::hil::led::LedLow::new(led_kernel_pin);
     kernel::debug::panic_blink_forever(&mut [led])
 }

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/io.rs
@@ -62,7 +62,11 @@ pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {
     use nrf52840::gpio::Pin;
 
     // The nRF52840DK LEDs (see back of board)
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
+        Pin::P0_13,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut led::LedLow::new(led_kernel_pin);
     let mut writer = Writer::new();
     debug::panic_old(

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/io.rs
@@ -62,11 +62,7 @@ pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {
     use nrf52840::gpio::Pin;
 
     // The nRF52840DK LEDs (see back of board)
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
-        Pin::P0_13,
-        nrf52840::gpio::GPIOTE_BASE,
-        nrf52840::gpio::GPIO_BASE_PORT0,
-    );
+    let led_kernel_pin = &nrf52840::gpio::nrf52840_gpio_create_pin(Pin::P0_13);
     let led = &mut led::LedLow::new(led_kernel_pin);
     let mut writer = Writer::new();
     debug::panic_old(

--- a/boards/makepython-nrf52840/src/io.rs
+++ b/boards/makepython-nrf52840/src/io.rs
@@ -123,7 +123,11 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P1_10);
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
+        Pin::P1_10,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
     debug::panic_old(

--- a/boards/makepython-nrf52840/src/io.rs
+++ b/boards/makepython-nrf52840/src/io.rs
@@ -123,11 +123,7 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
-        Pin::P1_10,
-        nrf52840::gpio::GPIOTE_BASE,
-        nrf52840::gpio::GPIO_BASE_PORT0,
-    );
+    let led_kernel_pin = &nrf52840::gpio::nrf52840_gpio_create_pin(Pin::P1_10);
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
     debug::panic_old(

--- a/boards/microbit_v2/src/io.rs
+++ b/boards/microbit_v2/src/io.rs
@@ -73,7 +73,11 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // MicroBit v2 has a microphone LED, use it for panic
 
     use core::ptr::addr_of_mut;
-    let led_kernel_pin = &nrf52833::gpio::GPIOPin::new(Pin::P0_20);
+    let led_kernel_pin = &nrf52833::gpio::GPIOPin::new(
+        Pin::P0_20,
+        nrf52833::gpio::GPIOTE_BASE,
+        nrf52833::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
     debug::panic_old(

--- a/boards/microbit_v2/src/io.rs
+++ b/boards/microbit_v2/src/io.rs
@@ -73,11 +73,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // MicroBit v2 has a microphone LED, use it for panic
 
     use core::ptr::addr_of_mut;
-    let led_kernel_pin = &nrf52833::gpio::GPIOPin::new(
-        Pin::P0_20,
-        nrf52833::gpio::GPIOTE_BASE,
-        nrf52833::gpio::GPIO_BASE_PORT0,
-    );
+    let led_kernel_pin = &nrf52833::gpio::nrf52833_gpio_create_pin(Pin::P0_20);
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
     debug::panic_old(

--- a/boards/nano33ble/src/io.rs
+++ b/boards/nano33ble/src/io.rs
@@ -125,7 +125,11 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
+        Pin::P0_13,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
     debug::panic_old(

--- a/boards/nano33ble/src/io.rs
+++ b/boards/nano33ble/src/io.rs
@@ -125,11 +125,7 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
-        Pin::P0_13,
-        nrf52840::gpio::GPIOTE_BASE,
-        nrf52840::gpio::GPIO_BASE_PORT0,
-    );
+    let led_kernel_pin = &nrf52840::gpio::nrf52840_gpio_create_pin(Pin::P0_13);
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
     debug::panic_old(

--- a/boards/nano33ble/src/test/log_test.rs
+++ b/boards/nano33ble/src/test/log_test.rs
@@ -84,7 +84,11 @@ pub unsafe fn run(mux_alarm: &'static MuxAlarm<'static, Rtc>, flash_controller: 
     test.alarm.set_alarm_client(test);
 
     // Configure GPIO pin P1.08 as the log erase pin.
-    let log_erase_pin = GPIOPin::new(Pin::P1_08);
+    let log_erase_pin = GPIOPin::new(
+        Pin::P1_08,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT1,
+    );
     log_erase_pin.enable_interrupts(InterruptEdge::RisingEdge);
     log_erase_pin.set_client(test);
 

--- a/boards/nano33ble/src/test/log_test.rs
+++ b/boards/nano33ble/src/test/log_test.rs
@@ -46,7 +46,7 @@ use kernel::storage_volume;
 use kernel::utilities::cells::{NumericCellExt, TakeCell};
 use kernel::ErrorCode;
 use nrf52840::{
-    gpio::{GPIOPin, Pin},
+    gpio::Pin,
     nvmc::{NrfPage, Nvmc},
     rtc::Rtc,
 };
@@ -84,11 +84,7 @@ pub unsafe fn run(mux_alarm: &'static MuxAlarm<'static, Rtc>, flash_controller: 
     test.alarm.set_alarm_client(test);
 
     // Configure GPIO pin P1.08 as the log erase pin.
-    let log_erase_pin = GPIOPin::new(
-        Pin::P1_08,
-        nrf52840::gpio::GPIOTE_BASE,
-        nrf52840::gpio::GPIO_BASE_PORT1,
-    );
+    let log_erase_pin = nrf52840::gpio::nrf52840_gpio_create_pin(Pin::P1_08);
     log_erase_pin.enable_interrupts(InterruptEdge::RisingEdge);
     log_erase_pin.set_client(test);
 

--- a/boards/nano33ble_rev2/src/io.rs
+++ b/boards/nano33ble_rev2/src/io.rs
@@ -126,7 +126,11 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
+        Pin::P0_13,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
     debug::panic_old(

--- a/boards/nano33ble_rev2/src/io.rs
+++ b/boards/nano33ble_rev2/src/io.rs
@@ -126,11 +126,7 @@ impl IoWrite for Writer {
 #[cfg(not(test))]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
-        Pin::P0_13,
-        nrf52840::gpio::GPIOTE_BASE,
-        nrf52840::gpio::GPIO_BASE_PORT0,
-    );
+    let led_kernel_pin = &nrf52840::gpio::nrf52840_gpio_create_pin(Pin::P0_13);
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
     debug::panic_old(

--- a/boards/nordic/nrf52840_dongle/src/io.rs
+++ b/boards/nordic/nrf52840_dongle/src/io.rs
@@ -57,7 +57,11 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // The nRF52840 Dongle LEDs (see back of board)
 
     use core::ptr::addr_of_mut;
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_06);
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
+        Pin::P0_06,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
     debug::panic_old(

--- a/boards/nordic/nrf52840_dongle/src/io.rs
+++ b/boards/nordic/nrf52840_dongle/src/io.rs
@@ -57,11 +57,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // The nRF52840 Dongle LEDs (see back of board)
 
     use core::ptr::addr_of_mut;
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
-        Pin::P0_06,
-        nrf52840::gpio::GPIOTE_BASE,
-        nrf52840::gpio::GPIO_BASE_PORT0,
-    );
+    let led_kernel_pin = &nrf52840::gpio::nrf52840_gpio_create_pin(Pin::P0_06);
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
     debug::panic_old(

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -13,7 +13,11 @@ use nrf52840::gpio::Pin;
 /// Panic handler
 pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {
     // The nRF52840DK LEDs (see back of board)
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
+        Pin::P0_13,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut led::LedLow::new(led_kernel_pin);
 
     if crate::USB_DEBUGGING {

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -13,11 +13,7 @@ use nrf52840::gpio::Pin;
 /// Panic handler
 pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {
     // The nRF52840DK LEDs (see back of board)
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
-        Pin::P0_13,
-        nrf52840::gpio::GPIOTE_BASE,
-        nrf52840::gpio::GPIO_BASE_PORT0,
-    );
+    let led_kernel_pin = &nrf52840::gpio::nrf52840_gpio_create_pin(Pin::P0_13);
     let led = &mut led::LedLow::new(led_kernel_pin);
 
     if crate::USB_DEBUGGING {

--- a/boards/nordic/nrf52dk/src/io.rs
+++ b/boards/nordic/nrf52dk/src/io.rs
@@ -13,7 +13,12 @@ use nrf52832::gpio::Pin;
 /// Panic handler
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // The nRF52 DK LEDs (see back of board)
-    let led_kernel_pin = &nrf52832::gpio::GPIOPin::new(Pin::P0_17);
+    let led_kernel_pin = &nrf52832::gpio::GPIOPin::new(
+        Pin::P0_17,
+        nrf52832::gpio::GPIOTE_BASE,
+        nrf52832::gpio::GPIO_BASE_PORT0,
+    );
+
     let led = &mut led::LedLow::new(led_kernel_pin);
 
     debug::panic::<_, nrf52832::uart::Uarte, _, _>(

--- a/boards/nordic/nrf52dk/src/io.rs
+++ b/boards/nordic/nrf52dk/src/io.rs
@@ -13,12 +13,7 @@ use nrf52832::gpio::Pin;
 /// Panic handler
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // The nRF52 DK LEDs (see back of board)
-    let led_kernel_pin = &nrf52832::gpio::GPIOPin::new(
-        Pin::P0_17,
-        nrf52832::gpio::GPIOTE_BASE,
-        nrf52832::gpio::GPIO_BASE_PORT0,
-    );
-
+    let led_kernel_pin = &nrf52832::gpio::nrf52832_gpio_create_pin(Pin::P0_17);
     let led = &mut led::LedLow::new(led_kernel_pin);
 
     debug::panic::<_, nrf52832::uart::Uarte, _, _>(

--- a/boards/particle_boron/src/io.rs
+++ b/boards/particle_boron/src/io.rs
@@ -63,7 +63,11 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // The nRF52840DK LEDs (see back of board)
 
     use core::ptr::addr_of_mut;
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(LED2_R_PIN);
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
+        LED2_R_PIN,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
     debug::panic_old(

--- a/boards/particle_boron/src/io.rs
+++ b/boards/particle_boron/src/io.rs
@@ -63,11 +63,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // The nRF52840DK LEDs (see back of board)
 
     use core::ptr::addr_of_mut;
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
-        LED2_R_PIN,
-        nrf52840::gpio::GPIOTE_BASE,
-        nrf52840::gpio::GPIO_BASE_PORT0,
-    );
+    let led_kernel_pin = &nrf52840::gpio::nrf52840_gpio_create_pin(LED2_R_PIN);
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
     debug::panic_old(

--- a/boards/sma_q3/src/io.rs
+++ b/boards/sma_q3/src/io.rs
@@ -45,7 +45,11 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // The display LEDs (see back of board)
 
     use core::ptr::addr_of_mut;
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
+        Pin::P0_13,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
     debug::panic_old(

--- a/boards/sma_q3/src/io.rs
+++ b/boards/sma_q3/src/io.rs
@@ -45,11 +45,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // The display LEDs (see back of board)
 
     use core::ptr::addr_of_mut;
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(
-        Pin::P0_13,
-        nrf52840::gpio::GPIOTE_BASE,
-        nrf52840::gpio::GPIO_BASE_PORT0,
-    );
+    let led_kernel_pin = &nrf52840::gpio::nrf52840_gpio_create_pin(Pin::P0_13);
     let led = &mut led::LedLow::new(led_kernel_pin);
     let writer = &mut *addr_of_mut!(WRITER);
     debug::panic_old(

--- a/boards/wm1110dev/src/io.rs
+++ b/boards/wm1110dev/src/io.rs
@@ -16,7 +16,11 @@ use nrf52840::gpio::Pin;
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // Red Led
-    let led_red_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_14);
+    let led_red_pin = &nrf52840::gpio::GPIOPin::new(
+        Pin::P0_14,
+        nrf52840::gpio::GPIOTE_BASE,
+        nrf52840::gpio::GPIO_BASE_PORT0,
+    );
     let led = &mut led::LedHigh::new(led_red_pin);
 
     debug::panic::<_, nrf52840::uart::Uarte, _, _>(

--- a/boards/wm1110dev/src/io.rs
+++ b/boards/wm1110dev/src/io.rs
@@ -16,11 +16,7 @@ use nrf52840::gpio::Pin;
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // Red Led
-    let led_red_pin = &nrf52840::gpio::GPIOPin::new(
-        Pin::P0_14,
-        nrf52840::gpio::GPIOTE_BASE,
-        nrf52840::gpio::GPIO_BASE_PORT0,
-    );
+    let led_red_pin = &nrf52840::gpio::nrf52840_gpio_create_pin(Pin::P0_14);
     let led = &mut led::LedHigh::new(led_red_pin);
 
     debug::panic::<_, nrf52840::uart::Uarte, _, _>(

--- a/chips/nrf52832/src/gpio.rs
+++ b/chips/nrf52832/src/gpio.rs
@@ -2,43 +2,51 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-pub use nrf52::gpio::{GPIOPin, Pin, Port};
+use kernel::utilities::StaticRef;
+pub use nrf52::gpio::{GPIOPin, Pin, Port, GPIO_BASE_ADDRESS, GPIO_SIZE};
+pub use nrf52::gpio::{GpioRegisters, GpioteRegisters};
 
 pub const NUM_PINS: usize = 32;
 
+pub const GPIOTE_BASE: StaticRef<GpioteRegisters> =
+    unsafe { StaticRef::new(0x40006000 as *const GpioteRegisters) };
+
+pub const GPIO_BASE_PORT0: StaticRef<GpioRegisters> =
+    unsafe { StaticRef::new((GPIO_BASE_ADDRESS) as *const GpioRegisters) };
+
 pub fn nrf52832_gpio_create<'a>() -> Port<'a, NUM_PINS> {
     Port::new([
-        GPIOPin::new(Pin::P0_00),
-        GPIOPin::new(Pin::P0_01),
-        GPIOPin::new(Pin::P0_02),
-        GPIOPin::new(Pin::P0_03),
-        GPIOPin::new(Pin::P0_04),
-        GPIOPin::new(Pin::P0_05),
-        GPIOPin::new(Pin::P0_06),
-        GPIOPin::new(Pin::P0_07),
-        GPIOPin::new(Pin::P0_08),
-        GPIOPin::new(Pin::P0_09),
-        GPIOPin::new(Pin::P0_10),
-        GPIOPin::new(Pin::P0_11),
-        GPIOPin::new(Pin::P0_12),
-        GPIOPin::new(Pin::P0_13),
-        GPIOPin::new(Pin::P0_14),
-        GPIOPin::new(Pin::P0_15),
-        GPIOPin::new(Pin::P0_16),
-        GPIOPin::new(Pin::P0_17),
-        GPIOPin::new(Pin::P0_18),
-        GPIOPin::new(Pin::P0_19),
-        GPIOPin::new(Pin::P0_20),
-        GPIOPin::new(Pin::P0_21),
-        GPIOPin::new(Pin::P0_22),
-        GPIOPin::new(Pin::P0_23),
-        GPIOPin::new(Pin::P0_24),
-        GPIOPin::new(Pin::P0_25),
-        GPIOPin::new(Pin::P0_26),
-        GPIOPin::new(Pin::P0_27),
-        GPIOPin::new(Pin::P0_28),
-        GPIOPin::new(Pin::P0_29),
-        GPIOPin::new(Pin::P0_30),
-        GPIOPin::new(Pin::P0_31),
+        GPIOPin::new(Pin::P0_00, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_01, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_02, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_03, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_04, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_05, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_06, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_07, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_08, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_09, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_10, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_11, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_12, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_13, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_14, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_15, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_16, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_17, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_18, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_19, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_20, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_21, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_22, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_23, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_24, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_25, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_26, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_27, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_28, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_29, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_30, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_31, GPIOTE_BASE, GPIO_BASE_PORT0),
     ])
 }

--- a/chips/nrf52832/src/gpio.rs
+++ b/chips/nrf52832/src/gpio.rs
@@ -14,6 +14,10 @@ pub const GPIOTE_BASE: StaticRef<GpioteRegisters> =
 pub const GPIO_BASE_PORT0: StaticRef<GpioRegisters> =
     unsafe { StaticRef::new((GPIO_BASE_ADDRESS) as *const GpioRegisters) };
 
+pub fn nrf52832_gpio_create_pin<'a>(pin: Pin) -> GPIOPin<'a> {
+    GPIOPin::new(pin, GPIOTE_BASE, GPIO_BASE_PORT0)
+}
+
 pub fn nrf52832_gpio_create<'a>() -> Port<'a, NUM_PINS> {
     Port::new([
         GPIOPin::new(Pin::P0_00, GPIOTE_BASE, GPIO_BASE_PORT0),

--- a/chips/nrf52833/src/gpio.rs
+++ b/chips/nrf52833/src/gpio.rs
@@ -2,59 +2,69 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-pub use nrf52::gpio::{GPIOPin, Pin, Port};
+use kernel::utilities::StaticRef;
+pub use nrf52::gpio::{GPIOPin, Pin, Port, GPIO_BASE_ADDRESS, GPIO_SIZE};
+pub use nrf52::gpio::{GpioRegisters, GpioteRegisters};
 
 pub const NUM_PINS: usize = 48;
 
+pub const GPIOTE_BASE: StaticRef<GpioteRegisters> =
+    unsafe { StaticRef::new(0x40006000 as *const GpioteRegisters) };
+
+pub const GPIO_BASE_PORT0: StaticRef<GpioRegisters> =
+    unsafe { StaticRef::new((GPIO_BASE_ADDRESS) as *const GpioRegisters) };
+pub const GPIO_BASE_PORT1: StaticRef<GpioRegisters> =
+    unsafe { StaticRef::new((GPIO_BASE_ADDRESS + GPIO_SIZE) as *const GpioRegisters) };
+
 pub fn nrf52833_gpio_create<'a>() -> Port<'a, NUM_PINS> {
     Port::new([
-        GPIOPin::new(Pin::P0_00),
-        GPIOPin::new(Pin::P0_01),
-        GPIOPin::new(Pin::P0_02),
-        GPIOPin::new(Pin::P0_03),
-        GPIOPin::new(Pin::P0_04),
-        GPIOPin::new(Pin::P0_05),
-        GPIOPin::new(Pin::P0_06),
-        GPIOPin::new(Pin::P0_07),
-        GPIOPin::new(Pin::P0_08),
-        GPIOPin::new(Pin::P0_09),
-        GPIOPin::new(Pin::P0_10),
-        GPIOPin::new(Pin::P0_11),
-        GPIOPin::new(Pin::P0_12),
-        GPIOPin::new(Pin::P0_13),
-        GPIOPin::new(Pin::P0_14),
-        GPIOPin::new(Pin::P0_15),
-        GPIOPin::new(Pin::P0_16),
-        GPIOPin::new(Pin::P0_17),
-        GPIOPin::new(Pin::P0_18),
-        GPIOPin::new(Pin::P0_19),
-        GPIOPin::new(Pin::P0_20),
-        GPIOPin::new(Pin::P0_21),
-        GPIOPin::new(Pin::P0_22),
-        GPIOPin::new(Pin::P0_23),
-        GPIOPin::new(Pin::P0_24),
-        GPIOPin::new(Pin::P0_25),
-        GPIOPin::new(Pin::P0_26),
-        GPIOPin::new(Pin::P0_27),
-        GPIOPin::new(Pin::P0_28),
-        GPIOPin::new(Pin::P0_29),
-        GPIOPin::new(Pin::P0_30),
-        GPIOPin::new(Pin::P0_31),
-        GPIOPin::new(Pin::P1_00),
-        GPIOPin::new(Pin::P1_01),
-        GPIOPin::new(Pin::P1_02),
-        GPIOPin::new(Pin::P1_03),
-        GPIOPin::new(Pin::P1_04),
-        GPIOPin::new(Pin::P1_05),
-        GPIOPin::new(Pin::P1_06),
-        GPIOPin::new(Pin::P1_07),
-        GPIOPin::new(Pin::P1_08),
-        GPIOPin::new(Pin::P1_09),
-        GPIOPin::new(Pin::P1_10),
-        GPIOPin::new(Pin::P1_11),
-        GPIOPin::new(Pin::P1_12),
-        GPIOPin::new(Pin::P1_13),
-        GPIOPin::new(Pin::P1_14),
-        GPIOPin::new(Pin::P1_15),
+        GPIOPin::new(Pin::P0_00, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_01, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_02, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_03, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_04, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_05, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_06, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_07, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_08, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_09, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_10, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_11, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_12, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_13, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_14, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_15, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_16, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_17, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_18, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_19, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_20, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_21, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_22, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_23, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_24, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_25, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_26, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_27, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_28, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_29, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_30, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_31, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P1_00, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_01, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_02, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_03, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_04, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_05, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_06, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_07, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_08, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_09, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_10, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_11, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_12, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_13, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_14, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_15, GPIOTE_BASE, GPIO_BASE_PORT1),
     ])
 }

--- a/chips/nrf52833/src/gpio.rs
+++ b/chips/nrf52833/src/gpio.rs
@@ -16,6 +16,60 @@ pub const GPIO_BASE_PORT0: StaticRef<GpioRegisters> =
 pub const GPIO_BASE_PORT1: StaticRef<GpioRegisters> =
     unsafe { StaticRef::new((GPIO_BASE_ADDRESS + GPIO_SIZE) as *const GpioRegisters) };
 
+pub fn nrf52833_gpio_create_pin<'a>(pin: Pin) -> GPIOPin<'a> {
+    let base_port = match pin {
+        Pin::P0_00
+        | Pin::P0_01
+        | Pin::P0_02
+        | Pin::P0_03
+        | Pin::P0_04
+        | Pin::P0_05
+        | Pin::P0_06
+        | Pin::P0_07
+        | Pin::P0_08
+        | Pin::P0_09
+        | Pin::P0_10
+        | Pin::P0_11
+        | Pin::P0_12
+        | Pin::P0_13
+        | Pin::P0_14
+        | Pin::P0_15
+        | Pin::P0_16
+        | Pin::P0_17
+        | Pin::P0_18
+        | Pin::P0_19
+        | Pin::P0_20
+        | Pin::P0_21
+        | Pin::P0_22
+        | Pin::P0_23
+        | Pin::P0_24
+        | Pin::P0_25
+        | Pin::P0_26
+        | Pin::P0_27
+        | Pin::P0_28
+        | Pin::P0_29
+        | Pin::P0_30
+        | Pin::P0_31 => GPIO_BASE_PORT0,
+        Pin::P1_00
+        | Pin::P1_01
+        | Pin::P1_02
+        | Pin::P1_03
+        | Pin::P1_04
+        | Pin::P1_05
+        | Pin::P1_06
+        | Pin::P1_07
+        | Pin::P1_08
+        | Pin::P1_09
+        | Pin::P1_10
+        | Pin::P1_11
+        | Pin::P1_12
+        | Pin::P1_13
+        | Pin::P1_14
+        | Pin::P1_15 => GPIO_BASE_PORT1,
+    };
+    GPIOPin::new(pin, GPIOTE_BASE, base_port)
+}
+
 pub fn nrf52833_gpio_create<'a>() -> Port<'a, NUM_PINS> {
     Port::new([
         GPIOPin::new(Pin::P0_00, GPIOTE_BASE, GPIO_BASE_PORT0),

--- a/chips/nrf52840/src/gpio.rs
+++ b/chips/nrf52840/src/gpio.rs
@@ -2,59 +2,69 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-pub use nrf52::gpio::{GPIOPin, Pin, Port};
+use kernel::utilities::StaticRef;
+pub use nrf52::gpio::{GPIOPin, Pin, Port, GPIO_BASE_ADDRESS, GPIO_SIZE};
+pub use nrf52::gpio::{GpioRegisters, GpioteRegisters};
 
 pub const NUM_PINS: usize = 48;
 
+pub const GPIOTE_BASE: StaticRef<GpioteRegisters> =
+    unsafe { StaticRef::new(0x40006000 as *const GpioteRegisters) };
+
+pub const GPIO_BASE_PORT0: StaticRef<GpioRegisters> =
+    unsafe { StaticRef::new((GPIO_BASE_ADDRESS) as *const GpioRegisters) };
+pub const GPIO_BASE_PORT1: StaticRef<GpioRegisters> =
+    unsafe { StaticRef::new((GPIO_BASE_ADDRESS + GPIO_SIZE) as *const GpioRegisters) };
+
 pub const fn nrf52840_gpio_create<'a>() -> Port<'a, NUM_PINS> {
     Port::new([
-        GPIOPin::new(Pin::P0_00),
-        GPIOPin::new(Pin::P0_01),
-        GPIOPin::new(Pin::P0_02),
-        GPIOPin::new(Pin::P0_03),
-        GPIOPin::new(Pin::P0_04),
-        GPIOPin::new(Pin::P0_05),
-        GPIOPin::new(Pin::P0_06),
-        GPIOPin::new(Pin::P0_07),
-        GPIOPin::new(Pin::P0_08),
-        GPIOPin::new(Pin::P0_09),
-        GPIOPin::new(Pin::P0_10),
-        GPIOPin::new(Pin::P0_11),
-        GPIOPin::new(Pin::P0_12),
-        GPIOPin::new(Pin::P0_13),
-        GPIOPin::new(Pin::P0_14),
-        GPIOPin::new(Pin::P0_15),
-        GPIOPin::new(Pin::P0_16),
-        GPIOPin::new(Pin::P0_17),
-        GPIOPin::new(Pin::P0_18),
-        GPIOPin::new(Pin::P0_19),
-        GPIOPin::new(Pin::P0_20),
-        GPIOPin::new(Pin::P0_21),
-        GPIOPin::new(Pin::P0_22),
-        GPIOPin::new(Pin::P0_23),
-        GPIOPin::new(Pin::P0_24),
-        GPIOPin::new(Pin::P0_25),
-        GPIOPin::new(Pin::P0_26),
-        GPIOPin::new(Pin::P0_27),
-        GPIOPin::new(Pin::P0_28),
-        GPIOPin::new(Pin::P0_29),
-        GPIOPin::new(Pin::P0_30),
-        GPIOPin::new(Pin::P0_31),
-        GPIOPin::new(Pin::P1_00),
-        GPIOPin::new(Pin::P1_01),
-        GPIOPin::new(Pin::P1_02),
-        GPIOPin::new(Pin::P1_03),
-        GPIOPin::new(Pin::P1_04),
-        GPIOPin::new(Pin::P1_05),
-        GPIOPin::new(Pin::P1_06),
-        GPIOPin::new(Pin::P1_07),
-        GPIOPin::new(Pin::P1_08),
-        GPIOPin::new(Pin::P1_09),
-        GPIOPin::new(Pin::P1_10),
-        GPIOPin::new(Pin::P1_11),
-        GPIOPin::new(Pin::P1_12),
-        GPIOPin::new(Pin::P1_13),
-        GPIOPin::new(Pin::P1_14),
-        GPIOPin::new(Pin::P1_15),
+        GPIOPin::new(Pin::P0_00, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_01, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_02, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_03, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_04, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_05, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_06, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_07, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_08, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_09, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_10, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_11, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_12, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_13, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_14, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_15, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_16, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_17, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_18, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_19, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_20, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_21, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_22, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_23, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_24, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_25, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_26, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_27, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_28, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_29, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_30, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P0_31, GPIOTE_BASE, GPIO_BASE_PORT0),
+        GPIOPin::new(Pin::P1_00, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_01, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_02, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_03, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_04, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_05, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_06, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_07, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_08, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_09, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_10, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_11, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_12, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_13, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_14, GPIOTE_BASE, GPIO_BASE_PORT1),
+        GPIOPin::new(Pin::P1_15, GPIOTE_BASE, GPIO_BASE_PORT1),
     ])
 }

--- a/chips/nrf52840/src/gpio.rs
+++ b/chips/nrf52840/src/gpio.rs
@@ -16,6 +16,60 @@ pub const GPIO_BASE_PORT0: StaticRef<GpioRegisters> =
 pub const GPIO_BASE_PORT1: StaticRef<GpioRegisters> =
     unsafe { StaticRef::new((GPIO_BASE_ADDRESS + GPIO_SIZE) as *const GpioRegisters) };
 
+pub fn nrf52840_gpio_create_pin<'a>(pin: Pin) -> GPIOPin<'a> {
+    let base_port = match pin {
+        Pin::P0_00
+        | Pin::P0_01
+        | Pin::P0_02
+        | Pin::P0_03
+        | Pin::P0_04
+        | Pin::P0_05
+        | Pin::P0_06
+        | Pin::P0_07
+        | Pin::P0_08
+        | Pin::P0_09
+        | Pin::P0_10
+        | Pin::P0_11
+        | Pin::P0_12
+        | Pin::P0_13
+        | Pin::P0_14
+        | Pin::P0_15
+        | Pin::P0_16
+        | Pin::P0_17
+        | Pin::P0_18
+        | Pin::P0_19
+        | Pin::P0_20
+        | Pin::P0_21
+        | Pin::P0_22
+        | Pin::P0_23
+        | Pin::P0_24
+        | Pin::P0_25
+        | Pin::P0_26
+        | Pin::P0_27
+        | Pin::P0_28
+        | Pin::P0_29
+        | Pin::P0_30
+        | Pin::P0_31 => GPIO_BASE_PORT0,
+        Pin::P1_00
+        | Pin::P1_01
+        | Pin::P1_02
+        | Pin::P1_03
+        | Pin::P1_04
+        | Pin::P1_05
+        | Pin::P1_06
+        | Pin::P1_07
+        | Pin::P1_08
+        | Pin::P1_09
+        | Pin::P1_10
+        | Pin::P1_11
+        | Pin::P1_12
+        | Pin::P1_13
+        | Pin::P1_14
+        | Pin::P1_15 => GPIO_BASE_PORT1,
+    };
+    GPIOPin::new(pin, GPIOTE_BASE, base_port)
+}
+
 pub const fn nrf52840_gpio_create<'a>() -> Port<'a, NUM_PINS> {
     Port::new([
         GPIOPin::new(Pin::P0_00, GPIOTE_BASE, GPIO_BASE_PORT0),

--- a/chips/nrf5x/src/gpio.rs
+++ b/chips/nrf5x/src/gpio.rs
@@ -32,19 +32,18 @@ const NUM_GPIOTE: usize = 4;
 
 const GPIO_PER_PORT: usize = 32;
 
-const GPIOTE_BASE: StaticRef<GpioteRegisters> =
-    unsafe { StaticRef::new(0x40006000 as *const GpioteRegisters) };
+pub const GPIO_BASE_ADDRESS: usize = 0x50000000;
+pub const GPIO_SIZE: usize = 0x300;
 
-const GPIO_BASE_ADDRESS: usize = 0x50000000;
-const GPIO_SIZE: usize = 0x300;
-
+/// nRF5x GPIOTE Registers
+///
 /// The nRF5x doesn't automatically provide GPIO interrupts. Instead, to receive
 /// interrupts from a GPIO line, you must allocate a GPIOTE (GPIO Task and
 /// Event) channel, and bind the channel to the desired pin. There are 4
 /// channels for the nrf51 and 8 channels for the nrf52. This means that
 /// requesting an interrupt can fail, if they are all already allocated.
 #[repr(C)]
-struct GpioteRegisters {
+pub struct GpioteRegisters {
     /// Task for writing to pin specified in CONFIG\[n\].PSEL.
     /// Action on pin is configured in CONFIG\[n\].POLARITY
     ///
@@ -84,7 +83,7 @@ struct GpioteRegisters {
 }
 
 #[repr(C)]
-struct GpioRegisters {
+pub struct GpioRegisters {
     /// Reserved
     _reserved1: [u32; 321],
     /// Write GPIO port
@@ -369,18 +368,17 @@ pub struct GPIOPin<'a> {
 }
 
 impl<'a> GPIOPin<'a> {
-    pub const fn new(pin: Pin) -> GPIOPin<'a> {
+    pub const fn new(
+        pin: Pin,
+        gpiote_registers: StaticRef<GpioteRegisters>,
+        gpio_registers: StaticRef<GpioRegisters>,
+    ) -> GPIOPin<'a> {
         GPIOPin {
             pin: ((pin as usize) % GPIO_PER_PORT) as u8,
             port: ((pin as usize) / GPIO_PER_PORT) as u8,
             client: OptionalCell::empty(),
-            gpio_registers: unsafe {
-                StaticRef::new(
-                    (GPIO_BASE_ADDRESS + ((pin as usize) / GPIO_PER_PORT) * GPIO_SIZE)
-                        as *const GpioRegisters,
-                )
-            },
-            gpiote_registers: GPIOTE_BASE,
+            gpio_registers,
+            gpiote_registers,
             allocated_channel: OptionalCell::empty(),
         }
     }


### PR DESCRIPTION
### Pull Request Overview

Remove unsafe from nrf5x gpio.

Extracted from https://github.com/tock/tock/pull/4626


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
