### PR TITLE
chips: nrf5x: move unsafe `StaticRef` to nrf52 crate

### DIFF
--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -5,6 +5,29 @@
 use core::fmt::Write;
 use cortexm4f::{nvic, CortexM4F, CortexMVariant};
 use kernel::platform::chip::InterruptService;
+use kernel::utilities::StaticRef;
+
+//
+// Peripheral Registers Instantiations
+//
+
+const RTC1_BASE: StaticRef<crate::rtc::RtcRegisters> =
+    unsafe { StaticRef::new(0x40011000 as *const crate::rtc::RtcRegisters) };
+
+const TEMP_BASE: StaticRef<crate::temperature::TempRegisters> =
+    unsafe { StaticRef::new(0x4000C000 as *const crate::temperature::TempRegisters) };
+
+const TIMER0_BASE: StaticRef<crate::timer::TimerRegisters> =
+    unsafe { StaticRef::new(0x40008000 as *const crate::timer::TimerRegisters) };
+
+const TIMER1_BASE: StaticRef<crate::timer::TimerRegisters> =
+    unsafe { StaticRef::new(0x40009000 as *const crate::timer::TimerRegisters) };
+
+const TIMER2_BASE: StaticRef<crate::timer::TimerRegisters> =
+    unsafe { StaticRef::new(0x4000A000 as *const crate::timer::TimerRegisters) };
+
+const RNG_BASE: StaticRef<crate::trng::RngRegisters> =
+    unsafe { StaticRef::new(0x4000D000 as *const crate::trng::RngRegisters) };
 
 pub struct NRF52<'a, I: InterruptService + 'a> {
     mpu: cortexm4f::mpu::MPU,
@@ -55,12 +78,12 @@ impl Nrf52DefaultPeripherals<'_> {
             ecb: crate::aes::AesECB::new(),
             pwr_clk: crate::power::Power::new(),
             ble_radio: crate::ble_radio::Radio::new(),
-            trng: crate::trng::Trng::new(),
-            rtc: crate::rtc::Rtc::new(),
-            temp: crate::temperature::Temp::new(),
-            timer0: crate::timer::TimerAlarm::new(0),
-            timer1: crate::timer::TimerAlarm::new(1),
-            timer2: crate::timer::Timer::new(2),
+            trng: crate::trng::Trng::new(RNG_BASE),
+            rtc: crate::rtc::Rtc::new(RTC1_BASE),
+            temp: crate::temperature::Temp::new(TEMP_BASE),
+            timer0: crate::timer::TimerAlarm::new(TIMER0_BASE),
+            timer1: crate::timer::TimerAlarm::new(TIMER1_BASE),
+            timer2: crate::timer::Timer::new(TIMER2_BASE),
             uarte0: crate::uart::Uarte::new(crate::uart::UARTE0_BASE),
             spim0: crate::spi::SPIM::new(0),
             twi1: crate::i2c::TWI::new_twi1(),

--- a/chips/nrf5x/src/rtc.rs
+++ b/chips/nrf5x/src/rtc.rs
@@ -12,11 +12,8 @@ use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite, Writ
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 
-const RTC1_BASE: StaticRef<RtcRegisters> =
-    unsafe { StaticRef::new(0x40011000 as *const RtcRegisters) };
-
 #[repr(C)]
-struct RtcRegisters {
+pub struct RtcRegisters {
     /// Start RTC Counter.
     tasks_start: WriteOnly<u32, Task::Register>,
     /// Stop RTC Counter.
@@ -96,9 +93,9 @@ pub struct Rtc<'a> {
 }
 
 impl Rtc<'_> {
-    pub const fn new() -> Self {
+    pub const fn new(registers: StaticRef<RtcRegisters>) -> Self {
         Self {
-            registers: RTC1_BASE,
+            registers,
             overflow_client: OptionalCell::empty(),
             alarm_client: OptionalCell::empty(),
             enabled: Cell::new(false),

--- a/chips/nrf5x/src/temperature.rs
+++ b/chips/nrf5x/src/temperature.rs
@@ -18,11 +18,8 @@ use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite, Writ
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 
-const TEMP_BASE: StaticRef<TempRegisters> =
-    unsafe { StaticRef::new(0x4000C000 as *const TempRegisters) };
-
 #[repr(C)]
-struct TempRegisters {
+pub struct TempRegisters {
     /// Start temperature measurement
     /// Address: 0x000 - 0x004
     pub task_start: WriteOnly<u32, Task::Register>,
@@ -30,14 +27,14 @@ struct TempRegisters {
     /// Address: 0x004 - 0x008
     pub task_stop: WriteOnly<u32, Task::Register>,
     /// Reserved
-    pub _reserved1: [u32; 62],
+    _reserved1: [u32; 62],
     /// Temperature measurement complete, data ready
     /// Address: 0x100 - 0x104
     pub event_datardy: ReadWrite<u32, Event::Register>,
     /// Reserved
     // Note, `inten` register on nRF51 is ignored because it's not supported by nRF52
     // And intenset and intenclr provide the same functionality
-    pub _reserved2: [u32; 128],
+    _reserved2: [u32; 128],
     /// Enable interrupt
     /// Address: 0x304 - 0x308
     pub intenset: ReadWrite<u32, Intenset::Register>,
@@ -45,22 +42,22 @@ struct TempRegisters {
     /// Address: 0x308 - 0x30c
     pub intenclr: ReadWrite<u32, Intenclr::Register>,
     /// Reserved
-    pub _reserved3: [u32; 127],
+    _reserved3: [u32; 127],
     /// Temperature in °C (0.25° steps)
     /// Address: 0x508 - 0x50c
     pub temp: ReadOnly<u32, Temperature::Register>,
     /// Reserved
-    pub _reserved4: [u32; 5],
+    _reserved4: [u32; 5],
     /// Slope of piece wise linear function (nRF52 only)
     /// Address 0x520 - 0x534
     #[cfg(feature = "nrf52")]
     pub a: [ReadWrite<u32, A::Register>; 6],
-    pub _reserved5: [u32; 2],
+    _reserved5: [u32; 2],
     /// y-intercept of 5th piece wise linear function (nRF52 only)
     /// Address: 0x540 - 0x554
     #[cfg(feature = "nrf52")]
     pub b: [ReadWrite<u32, B::Register>; 6],
-    pub _reserved6: [u32; 2],
+    _reserved6: [u32; 2],
     /// End point of 1st piece wise linear function (nRF52 only)
     /// Address: 0x560 - 0x570
     #[cfg(feature = "nrf52")]
@@ -115,9 +112,9 @@ pub struct Temp<'a> {
 }
 
 impl<'a> Temp<'a> {
-    pub const fn new() -> Temp<'a> {
+    pub const fn new(registers: StaticRef<TempRegisters>) -> Temp<'a> {
         Temp {
-            registers: TEMP_BASE,
+            registers,
             client: OptionalCell::empty(),
         }
     }

--- a/chips/nrf5x/src/timer.rs
+++ b/chips/nrf5x/src/timer.rs
@@ -34,16 +34,8 @@ use kernel::utilities::registers::{register_bitfields, ReadWrite, WriteOnly};
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 
-const INSTANCES: [StaticRef<TimerRegisters>; 3] = unsafe {
-    [
-        StaticRef::new(0x40008000 as *const TimerRegisters),
-        StaticRef::new(0x40009000 as *const TimerRegisters),
-        StaticRef::new(0x4000A000 as *const TimerRegisters),
-    ]
-};
-
 #[repr(C)]
-struct TimerRegisters {
+pub struct TimerRegisters {
     /// Start Timer
     tasks_start: WriteOnly<u32, Task::Register>,
     /// Stop Timer
@@ -220,9 +212,9 @@ pub struct Timer {
 }
 
 impl Timer {
-    pub const fn new(instance: usize) -> Timer {
+    pub const fn new(registers: StaticRef<TimerRegisters>) -> Timer {
         Timer {
-            registers: INSTANCES[instance],
+            registers,
             client: OptionalCell::empty(),
         }
     }
@@ -271,9 +263,9 @@ const CC_CAPTURE: usize = 0;
 const CC_COMPARE: usize = 1;
 
 impl<'a> TimerAlarm<'a> {
-    pub const fn new(instance: usize) -> TimerAlarm<'a> {
+    pub const fn new(registers: StaticRef<TimerRegisters>) -> TimerAlarm<'a> {
         TimerAlarm {
-            registers: INSTANCES[instance],
+            registers,
             client: OptionalCell::empty(),
         }
     }

--- a/chips/nrf5x/src/trng.rs
+++ b/chips/nrf5x/src/trng.rs
@@ -32,9 +32,6 @@ use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite, Writ
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 
-const RNG_BASE: StaticRef<RngRegisters> =
-    unsafe { StaticRef::new(0x4000D000 as *const RngRegisters) };
-
 #[repr(C)]
 pub struct RngRegisters {
     /// Task starting the random number generator
@@ -117,9 +114,9 @@ pub struct Trng<'a> {
 }
 
 impl<'a> Trng<'a> {
-    pub const fn new() -> Trng<'a> {
+    pub const fn new(registers: StaticRef<RngRegisters>) -> Trng<'a> {
         Trng {
-            registers: RNG_BASE,
+            registers,
             client: OptionalCell::empty(),
             index: Cell::new(0),
             randomness: Cell::new(0),


### PR DESCRIPTION
### Pull Request Overview

Moves unsafe out of nrf5x, except for aes which is more involved.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
