### PR TITLE
chips: stm32: remove static mut `EXTI_EVENTS`

### DIFF
--- a/chips/stm32f303xc/src/exti.rs
+++ b/chips/stm32f303xc/src/exti.rs
@@ -466,23 +466,6 @@ const EXTI_BASE: StaticRef<ExtiRegisters> =
 // ///  - EXTI22 -> RTC_WKUP (3)
 // ///
 
-/// The EXTI_PR (pending) register when set, generates a level-triggered
-/// interrupt on the NVIC.
-///
-/// This means, that its the responsibility of the IRQ handler to
-/// clear the interrupt source (pending bit), in order to prevent
-/// multiple interrupts from occurring.
-///
-/// `EXTI_EVENTS` is modeled to capture information from `EXTI_PR` register. In
-/// the top half IRQ handler, prior to clearing the pending bit, we set the
-/// corresponding bit in `EXTI_EVENTS`. Once the bit is set, in `EXTI_EVENTS`,
-/// we clear the pending bit and exit the ISR.
-///
-/// [^1]: Section 10.2.2, EXTI block diagram, page 243 of reference manual.
-#[no_mangle]
-#[used]
-pub static mut EXTI_EVENTS: u32 = 0;
-
 enum_from_primitive! {
     #[repr(u8)]
     #[derive(Copy, Clone)]

--- a/chips/stm32f303xc/src/exti.rs
+++ b/chips/stm32f303xc/src/exti.rs
@@ -442,30 +442,6 @@ register_bitfields![u32,
 const EXTI_BASE: StaticRef<ExtiRegisters> =
     unsafe { StaticRef::new(0x4001_0400 as *const ExtiRegisters) };
 
-// /// EXTI block has 23 lines going into NVIC. This arrangement is described here
-// /// [^1].
-// ///
-// /// The 23 lines going into NVIC, are mapped to the following NVIC IRQs. Note
-// /// there is *no* one-to-one mapping between the 23 lines to NVIC IRQs. The 23
-// /// lines going into NVIC translates to 14 IRQs on NVIC.
-// ///
-// ///  - EXTI0 (6)
-// ///  - EXTI1 (7)
-// ///  - EXTI2 (8)
-// ///  - EXTI3 (9)
-// ///  - EXTI4 (10)
-// ///  - EXTI9_5 (23)
-// ///  - EXTI15_10 (40)
-// ///
-// ///  - EXTI16 -> PVD (1)
-// ///  - EXTI17 -> RTC_Alarm (41)
-// ///  - EXTI18 -> OTG_FS_WKUP (42)
-// ///  - EXTI19 -> <UNKNOWN>
-// ///  - EXTI20 -> OTG_FS (67)
-// ///  - EXTI21 -> TAMP_STAMP (2)
-// ///  - EXTI22 -> RTC_WKUP (3)
-// ///
-
 enum_from_primitive! {
     #[repr(u8)]
     #[derive(Copy, Clone)]

--- a/chips/stm32f4xx/src/exti.rs
+++ b/chips/stm32f4xx/src/exti.rs
@@ -325,29 +325,6 @@ register_bitfields![u32,
 const EXTI_BASE: StaticRef<ExtiRegisters> =
     unsafe { StaticRef::new(0x40013C00 as *const ExtiRegisters) };
 
-// /// EXTI block has 23 lines going into NVIC. This arrangement is described here
-// /// [^1].
-// ///
-// /// The 23 lines going into NVIC, are mapped to the following NVIC IRQs. Note
-// /// there is *no* one-to-one mapping between the 23 lines to NVIC IRQs. The 23
-// /// lines going into NVIC translates to 14 IRQs on NVIC.
-// ///
-// ///  - `EXTI0` (6)
-// ///  - `EXTI1` (7)
-// ///  - `EXTI2` (8)
-// ///  - `EXTI3` (9)
-// ///  - `EXTI4` (10)
-// ///  - `EXTI9_5` (23)
-// ///  - `EXTI15_10` (40)
-// ///
-// ///  - `EXTI16` -> `PVD` (1)
-// ///  - `EXTI17` -> `RTC_Alarm` (41)
-// ///  - `EXTI18` -> `OTG_FS_WKUP` (42)
-// ///  - `EXTI19` -> `<UNKNOWN>`
-// ///  - `EXTI20` -> `OTG_FS` (67)
-// ///  - `EXTI21` -> `TAMP_STAMP` (2)
-// ///  - `EXTI22` -> `RTC_WKUP` (3)
-
 enum_from_primitive! {
     #[repr(u8)]
     #[derive(Copy, Clone)]

--- a/chips/stm32f4xx/src/exti.rs
+++ b/chips/stm32f4xx/src/exti.rs
@@ -325,43 +325,28 @@ register_bitfields![u32,
 const EXTI_BASE: StaticRef<ExtiRegisters> =
     unsafe { StaticRef::new(0x40013C00 as *const ExtiRegisters) };
 
-/// EXTI block has 23 lines going into NVIC. This arrangement is described here
-/// [^1].
-///
-/// The 23 lines going into NVIC, are mapped to the following NVIC IRQs. Note
-/// there is *no* one-to-one mapping between the 23 lines to NVIC IRQs. The 23
-/// lines going into NVIC translates to 14 IRQs on NVIC.
-///
-///  - `EXTI0` (6)
-///  - `EXTI1` (7)
-///  - `EXTI2` (8)
-///  - `EXTI3` (9)
-///  - `EXTI4` (10)
-///  - `EXTI9_5` (23)
-///  - `EXTI15_10` (40)
-///
-///  - `EXTI16` -> `PVD` (1)
-///  - `EXTI17` -> `RTC_Alarm` (41)
-///  - `EXTI18` -> `OTG_FS_WKUP` (42)
-///  - `EXTI19` -> `<UNKNOWN>`
-///  - `EXTI20` -> `OTG_FS` (67)
-///  - `EXTI21` -> `TAMP_STAMP` (2)
-///  - `EXTI22` -> `RTC_WKUP` (3)
-///
-/// The EXTI_PR (pending) register when set, generates a level-triggered
-/// interrupt on the NVIC. This means, that its the responsibility of the IRQ
-/// handler to clear the interrupt source (pending bit), in order to prevent
-/// multiple interrupts from occurring.
-///
-/// `EXTI_EVENTS` is modeled to capture information from `EXTI_PR` register. In
-/// the top half IRQ handler, prior to clearing the pending bit, we set the
-/// corresponding bit in `EXTI_EVENTS`. Once the bit is set, in `EXTI_EVENTS`,
-/// we clear the pending bit and exit the ISR.
-///
-/// [^1]: Section 10.2.2, EXTI block diagram, page 243 of reference manual.
-#[no_mangle]
-#[used]
-pub static mut EXTI_EVENTS: u32 = 0;
+// /// EXTI block has 23 lines going into NVIC. This arrangement is described here
+// /// [^1].
+// ///
+// /// The 23 lines going into NVIC, are mapped to the following NVIC IRQs. Note
+// /// there is *no* one-to-one mapping between the 23 lines to NVIC IRQs. The 23
+// /// lines going into NVIC translates to 14 IRQs on NVIC.
+// ///
+// ///  - `EXTI0` (6)
+// ///  - `EXTI1` (7)
+// ///  - `EXTI2` (8)
+// ///  - `EXTI3` (9)
+// ///  - `EXTI4` (10)
+// ///  - `EXTI9_5` (23)
+// ///  - `EXTI15_10` (40)
+// ///
+// ///  - `EXTI16` -> `PVD` (1)
+// ///  - `EXTI17` -> `RTC_Alarm` (41)
+// ///  - `EXTI18` -> `OTG_FS_WKUP` (42)
+// ///  - `EXTI19` -> `<UNKNOWN>`
+// ///  - `EXTI20` -> `OTG_FS` (67)
+// ///  - `EXTI21` -> `TAMP_STAMP` (2)
+// ///  - `EXTI22` -> `RTC_WKUP` (3)
 
 enum_from_primitive! {
     #[repr(u8)]

--- a/chips/stm32wle5xx/src/exti.rs
+++ b/chips/stm32wle5xx/src/exti.rs
@@ -375,23 +375,6 @@ register_bitfields![u32,
 const EXTI_BASE: StaticRef<ExtiRegisters> =
     unsafe { StaticRef::new(0x5800_0800 as *const ExtiRegisters) };
 
-/// The EXTI_PR (pending) register when set, generates a level-triggered
-/// interrupt on the NVIC.
-///
-/// This means, that its the responsibility of the IRQ handler to
-/// clear the interrupt source (pending bit), in order to prevent
-/// multiple interrupts from occurring.
-///
-/// `EXTI_EVENTS` is modeled to capture information from `EXTI_PR` register. In
-/// the top half IRQ handler, prior to clearing the pending bit, we set the
-/// corresponding bit in `EXTI_EVENTS`. Once the bit is set, in `EXTI_EVENTS`,
-/// we clear the pending bit and exit the ISR.
-///
-/// [^1]: Section 10.2.2, EXTI block diagram, page 243 of reference manual.
-#[no_mangle]
-#[used]
-pub static mut EXTI_EVENTS: u32 = 0;
-
 enum_from_primitive! {
     #[repr(u8)]
     #[derive(Copy, Clone)]


### PR DESCRIPTION


### Pull Request Overview

`EXTI_EVENTS` doesn't seem to be used anywhere?


### Testing Strategy

travis


### TODO or Help Wanted

Is this old and just never removed?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
