### PR TITLE
doc: trd-102: remove `static mut`

### DIFF
--- a/doc/reference/trd102-adc.md
+++ b/doc/reference/trd102-adc.md
@@ -7,7 +7,7 @@ Kernel Analog-to-Digital Conversion HIL
 **Status:** Draft <br/>
 **Author:** Philip Levis and Branden Ghena<br/>
 **Draft-Created:** Dec 18, 2016<br/>
-**Draft-Modified:** June 12, 2017<br/>
+**Draft-Modified:** May 15, 2026<br/>
 **Draft-Version:** 2<br/>
 **Draft-Discuss:** devel@lists.tockos.org</br>
 
@@ -312,13 +312,6 @@ impl AdcChannel {
         }
     }
 }
-
-/// Statically allocated ADC channels. Used in board configurations to specify
-/// which channels are used on the platform.
-pub static mut CHANNEL_AD0: AdcChannel = AdcChannel::new(Channel::AD0);
-pub static mut CHANNEL_AD1: AdcChannel = AdcChannel::new(Channel::AD1);
-...
-pub static mut CHANNEL_REFERENCE_GROUND: AdcChannel = AdcChannel::new(Channel::ReferenceGround);
 ```
 
 6.2 Client Handling


### PR DESCRIPTION


### Pull Request Overview

We shouldn't recommend this, and I don't think the removed code is actually used anywhere.


### Testing Strategy

doc


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
