### PR TITLE
cargo: rust mangling v0 now default

### DIFF
--- a/boards/cargo/tock_flags.toml
+++ b/boards/cargo/tock_flags.toml
@@ -24,12 +24,6 @@ rustflags = [
   # the same address in the binary. However, it can save a fair bit of code
   # size.
   "-C", "link-arg=-icf=all",
-  # Opt-in to Rust v0 symbol mangling scheme.  See
-  # https://github.com/rust-lang/rust/issues/60705 and
-  # https://github.com/tock/tock/issues/3529.
-  # https://github.com/rust-lang/rust/pull/89917 tracks this becoming the
-  # default, then we can remove this.
-  "-C", "symbol-mangling-version=v0",
   # Enable link-time-optimization
   "-C", "lto",
   # Have rustc generate stack sizes for analyzing the size of stack frames.


### PR DESCRIPTION
### Pull Request Overview

No longer need the option in cargo config file.






### Testing Strategy

Building objects and seeing the symbols have the same name.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
