### PR TITLE
Fix tock_kernel_layout Size Assertion Error

### DIFF
--- a/boards/build_scripts/tock_kernel_layout.ld
+++ b/boards/build_scripts/tock_kernel_layout.ld
@@ -466,8 +466,13 @@ ENTRY(_stext);
  */
 ASSERT((_eattributes == _erom) || (_eattributes == _erom + SIZEOF(.attributes)), "Kernel attributes are not at the end of ROM.")
 
-/* This assert works out because even though some of the relative positions are
- * off, the sizes are sane in each pass.
+/* Another dirty, not-fully-understood, hack. See previous comment.
+ * Only enforce the ROM-budget check on the converged lld pass, where
+ * `_eattributes == _erom`. On the other passes the symbol values are
+ * unreliable, so we skip the check by short-circuiting the OR. If the kernel
+ * genuinely overflows ROM the linker still emits its own "section will not fit
+ * in region `rom'" error.
  */
-ASSERT((_etext - _stext) + (_erelocate - _srelocate) + (_eattributes - _sattributes) < LENGTH(rom),
+ASSERT((_eattributes != _erom) ||
+       (((_etext - _stext) + (_erelocate - _srelocate) + (_eattributes - _sattributes)) < LENGTH(rom)),
 "Text plus relocations plus attributes exceeds the available ROM space.");


### PR DESCRIPTION
Fix a size assertion bug where multiple passes against tock_kernel_layout.ld file would give sizes that were not consistent with the actual sizes of sections. This would result in a bloated ROM size.

### Pull Request Overview

This PR fixes an issue where during multiple passes of rust lld, section sizes (text, relocate, and attributes) would change during the passes. This was previously assumed to be the same over multiple passes, but upon investigation this is not the case. This assertion was being tripped, but when examining the resulting elf the assertion should not have been tripped. In some of the passes, one (or more) of the sections must have been larger, and therefore tripping the assertion.

This PR fixes the issue by taking advantage of some behavior highlighted in the previous assertion. With passes that have `_eattributes != _erom`, these size differences seem to be present. So we skip these passes, and only check the sizes when they seem to be consistent.

AI was not used to generate the code nor the PR.

### Testing Strategy

This pull request was tested by compiling against internal Microsoft software and running on Microsoft hardware. I also tested this by compiling with the imix board.


### TODO or Help Wanted

This pull request still needs to be reviewed by project owners.


### Documentation Updated

- [✅ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ✅] Ran `make prepush`.

### AI Use

- [✅ ] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
