### PR TITLE
riscv: convert `_start_trap` to support both rv32 and rv64

### DIFF
--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -13,6 +13,7 @@ use kernel::utilities::registers::interfaces::{Readable, Writeable};
 pub mod csr;
 pub mod dma_fence;
 pub mod pmp;
+pub mod pseudo_instructions;
 pub mod support;
 pub mod syscall;
 pub mod thread_id;

--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -208,7 +208,16 @@ pub extern "C" fn _start_trap() -> ! {
 /// assume that the hart is currently executing kernel code.
 ///
 /// If it contains any other value, we interpret it to be a memory address
-/// pointing to a particular data structure:
+/// pointing to a particular data structure (`custom_trap_handler`):
+///
+/// ```text
+/// custom_trap_handler: [usize; 2];
+///
+/// mscratch = &custom_trap_handler;
+/// ```
+///
+/// or in memory:
+///
 ///
 /// ```text
 /// mscratch           0               1               2               3
@@ -302,19 +311,21 @@ pub extern "C" fn _start_trap() -> ! {
     //
     // For documentation of its behavior, and how process
     // implementations can hook their own trap handler code, see the
-    // comment on the `extern C _start_trap` symbol above.
+    // comment on the `_start_trap` function.
 
-    // Atomically swap s0 and mscratch:
+    // Atomically swap s0 and mscratch. This puts `&custom_trap_handler`
+    // in s0.
     csrrw s0, mscratch, s0        // s0 = mscratch; mscratch = s0
 
     // If mscratch contained 0, invoke the kernel trap handler.
-    beq   s0, x0, 100f      // if s0==x0: goto 100
+    beq   s0, x0, 100f            // if s0==x0: goto 100
 
-    // Else, save the current value of s1 to `0*4(s0)`, load `1*4(s0)`
-    // into s1 and jump to it (invoking a custom trap handler).
-    sw    s1, 0*4(s0)       // *s0 = s1
-    lw    s1, 1*4(s0)       // s1 = *(s0+4)
-    jr    s1                // goto s1
+    // Else, save the current value of s1 to `custom_trap_handler[0]`,
+    // load `custom_trap_handler[1]` into s1 and jump to it (invoking
+    // a custom trap handler).
+    sw    s1, 0*4(s0)             // custom_trap_handler[0] = s1
+    lw    s1, 1*4(s0)             // s1 = custom_trap_handler[1]
+    jr    s1                      // goto s1
 
   100: // _start_kernel_trap
 
@@ -328,50 +339,50 @@ pub extern "C" fn _start_trap() -> ! {
 
     // Load the address of the bottom of the stack (`_sstack`) into our
     // newly freed-up s0 register.
-    la s0, {sstack}                     // s0 = _sstack
+    la s0, {sstack}               // s0 = _sstack
 
     // Compare the kernel stack pointer to the bottom of the stack. If
     // the stack pointer is above the bottom of the stack, then continue
     // handling the fault as normal.
-    bgtu sp, s0, 200f                   // branch if sp > s0
+    bgtu sp, s0, 200f             // branch if sp > s0
 
     // If we get here, then we did encounter a stack overflow. We are
     // going to panic at this point, but for that to work we need a
     // valid stack to run the panic code. We do this by just starting
     // over with the kernel stack and placing the stack pointer at the
     // top of the original stack.
-    la sp, {estack}                     // sp = _estack
+    la sp, {estack}               // sp = _estack
 
 200: // _start_kernel_trap_continue
 
     // Restore s0. We reset mscratch to 0 (kernel trap handler mode)
-    csrrw s0, mscratch, zero    // s0 = mscratch; mscratch = 0
+    csrrw s0, mscratch, zero      // s0 = mscratch; mscratch = 0
 
     // Make room for the caller saved registers we need to restore after running
     // any trap handler code.
-    addi sp, sp, -20*4
+    addi sp, sp, -20*4            // riscv32: sp = sp - (20*4)
 
     // Save all of the caller saved registers.
-    sw   ra, 0*4(sp)
-    sw   t0, 1*4(sp)
-    sw   t1, 2*4(sp)
-    sw   t2, 3*4(sp)
-    sw   t3, 4*4(sp)
-    sw   t4, 5*4(sp)
-    sw   t5, 6*4(sp)
-    sw   t6, 7*4(sp)
-    sw   a0, 8*4(sp)
-    sw   a1, 9*4(sp)
-    sw   a2, 10*4(sp)
-    sw   a3, 11*4(sp)
-    sw   a4, 12*4(sp)
-    sw   a5, 13*4(sp)
-    sw   a6, 14*4(sp)
-    sw   a7, 15*4(sp)
+    sw   ra,  0*4(sp)             // riscv32: *(stackptr +  (0*4)) = ra
+    sw   t0,  1*4(sp)             // riscv32: *(stackptr +  (1*4)) = t0
+    sw   t1,  2*4(sp)             // riscv32: *(stackptr +  (2*4)) = t1
+    sw   t2,  3*4(sp)             // riscv32: *(stackptr +  (3*4)) = t2
+    sw   t3,  4*4(sp)             // riscv32: *(stackptr +  (4*4)) = t3
+    sw   t4,  5*4(sp)             // riscv32: *(stackptr +  (5*4)) = t4
+    sw   t5,  6*4(sp)             // riscv32: *(stackptr +  (6*4)) = t5
+    sw   t6,  7*4(sp)             // riscv32: *(stackptr +  (7*4)) = t6
+    sw   a0,  8*4(sp)             // riscv32: *(stackptr +  (8*4)) = a0
+    sw   a1,  9*4(sp)             // riscv32: *(stackptr +  (9*4)) = a1
+    sw   a2, 10*4(sp)             // riscv32: *(stackptr + (10*4)) = a2
+    sw   a3, 11*4(sp)             // riscv32: *(stackptr + (11*4)) = a3
+    sw   a4, 12*4(sp)             // riscv32: *(stackptr + (12*4)) = a4
+    sw   a5, 13*4(sp)             // riscv32: *(stackptr + (13*4)) = a5
+    sw   a6, 14*4(sp)             // riscv32: *(stackptr + (14*4)) = a6
+    sw   a7, 15*4(sp)             // riscv32: *(stackptr + (15*4)) = a7
 
     // Save one callee-saved register (s0), which we place the address of
     // the hart-specific 'are we in a trap handler' flag in:
-    sw   s0, 16*4(sp)
+    sw   s0, 16*4(sp)             // riscv32: *(stackptr + (16*4)) = s0
 
     // Determine the address of the hart-specific 'are we in a trap handler'
     // flag as an offset to the _trap_handler_active symbol. The chip crate
@@ -379,12 +390,12 @@ pub extern "C" fn _start_trap() -> ! {
     // enough to fit `max(mhartid) * MXLEN` bytes.
     la   s0, _trap_handler_active // s0 = addr(_trap_handler_active)
     csrr t0, mhartid              // t0 = hartid
-    slli t0, t0, 2                // t0 = t0 * 4
+    slli t0, t0, 2                // t0 = t0 * sizeof(u32)
     add  s0, s0, t0               // s0 = addr(_trap_handler_active[hartid])
 
     // Indicate that we are in a trap handler on this hart:
-    li   t0, 1
-    sw   t0, 0(s0)
+    li   t0, 1                    // t0 = 1
+    sw   t0, 0(s0)                // _trap_handler_active[hartid] = 1
 
     // Jump to board-specific trap handler code. Likely this was an
     // interrupt and we want to disable a particular interrupt, but each
@@ -393,32 +404,32 @@ pub extern "C" fn _start_trap() -> ! {
 
     // Indicate that we are no longer going to be in a trap handler on this
     // hart:
-    sw   x0, 0(s0)
+    sw   x0, 0(s0)                // _trap_handler_active[hartid] = 0
 
     // Restore the caller saved registers from the stack.
-    lw   ra, 0*4(sp)
-    lw   t0, 1*4(sp)
-    lw   t1, 2*4(sp)
-    lw   t2, 3*4(sp)
-    lw   t3, 4*4(sp)
-    lw   t4, 5*4(sp)
-    lw   t5, 6*4(sp)
-    lw   t6, 7*4(sp)
-    lw   a0, 8*4(sp)
-    lw   a1, 9*4(sp)
-    lw   a2, 10*4(sp)
-    lw   a3, 11*4(sp)
-    lw   a4, 12*4(sp)
-    lw   a5, 13*4(sp)
-    lw   a6, 14*4(sp)
-    lw   a7, 15*4(sp)
+    lw   ra,  0*4(sp)             // riscv32: ra = *(stackptr +  (0*4))
+    lw   t0,  1*4(sp)             // riscv32: t0 = *(stackptr +  (1*4))
+    lw   t1,  2*4(sp)             // riscv32: t1 = *(stackptr +  (2*4))
+    lw   t2,  3*4(sp)             // riscv32: t2 = *(stackptr +  (3*4))
+    lw   t3,  4*4(sp)             // riscv32: t3 = *(stackptr +  (4*4))
+    lw   t4,  5*4(sp)             // riscv32: t4 = *(stackptr +  (5*4))
+    lw   t5,  6*4(sp)             // riscv32: t5 = *(stackptr +  (6*4))
+    lw   t6,  7*4(sp)             // riscv32: t6 = *(stackptr +  (7*4))
+    lw   a0,  8*4(sp)             // riscv32: a0 = *(stackptr +  (8*4))
+    lw   a1,  9*4(sp)             // riscv32: a1 = *(stackptr +  (9*4))
+    lw   a2, 10*4(sp)             // riscv32: a2 = *(stackptr + (10*4))
+    lw   a3, 11*4(sp)             // riscv32: a3 = *(stackptr + (11*4))
+    lw   a4, 12*4(sp)             // riscv32: a4 = *(stackptr + (12*4))
+    lw   a5, 13*4(sp)             // riscv32: a5 = *(stackptr + (13*4))
+    lw   a6, 14*4(sp)             // riscv32: a6 = *(stackptr + (14*4))
+    lw   a7, 15*4(sp)             // riscv32: a7 = *(stackptr + (15*4))
 
     // Restore the one callee-saved register (s0), which used to hold the
     // address of the hart-specific 'are we in a trap handler flag':
-    lw   s0, 16*4(sp)
+    lw   s0, 16*4(sp)             // riscv32: s0 = *(stackptr + (16*4))
 
     // Reset the stack pointer.
-    addi sp, sp, 20*4
+    addi sp, sp, 20*4             // sp = sp + (20*4)
 
     // mret returns from the trap handler. The PC is set to what is in
     // mepc and execution proceeds from there. Since we did not modify

--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -18,13 +18,25 @@ pub mod support;
 pub mod syscall;
 pub mod thread_id;
 
+/// `XLEN` is the width of an integer register in bits (either 32 or 64).
+#[cfg(target_arch = "riscv32")]
+pub const XLEN: usize = 32;
+#[cfg(target_arch = "riscv64")]
+pub const XLEN: usize = 64;
 // Default to 32 bit if no architecture is specified of if this is being
 // compiled for docs or testing on a different architecture.
-pub const XLEN: usize = if cfg!(target_arch = "riscv64") {
-    64
-} else {
-    32
-};
+#[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
+pub const XLEN: usize = 32;
+
+/// `XLEN_LOG2` is the log base 2 of XLEN.
+#[cfg(target_arch = "riscv32")]
+pub const XLEN_LOG2: usize = 5;
+#[cfg(target_arch = "riscv64")]
+pub const XLEN_LOG2: usize = 6;
+// Default to 32 bit if no architecture is specified of if this is being
+// compiled for docs or testing on a different architecture.
+#[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
+pub const XLEN_LOG2: usize = 5;
 
 extern "C" {
     // Where the end of the stack region is (and hence where the stack should
@@ -184,7 +196,11 @@ pub unsafe fn configure_trap_handler() {
 }
 
 // Mock implementation for tests on Travis-CI.
-#[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
+#[cfg(not(any(
+    doc,
+    all(target_arch = "riscv32", target_os = "none"),
+    all(target_arch = "riscv64", target_os = "none")
+)))]
 pub extern "C" fn _start_trap() -> ! {
     unimplemented!()
 }
@@ -219,9 +235,8 @@ pub extern "C" fn _start_trap() -> ! {
 ///
 /// or in memory:
 ///
-///
 /// ```text
-/// mscratch           0               1               2               3
+/// mscratch
 ///  \->|--------------------------------------------------------------|
 ///     | scratch word, overwritten with s1 register contents          |
 ///     |--------------------------------------------------------------|
@@ -238,9 +253,9 @@ pub extern "C" fn _start_trap() -> ! {
 /// 2. execute the default kernel trap handler if s0 now contains `0` (meaning
 ///    that the mscratch CSR contained `0` before entering this trap handler),
 ///
-/// 3. otherwise, save s1 to `0*4(s0)`, and finally
+/// 3. otherwise, save s1 to `0*(XLEN/8)(s0)`, and finally
 ///
-/// 4. load the address at `1*4(s0)` into s1, and jump to it.
+/// 4. load the address at `1*(XLEN/8)(s0)` into s1, and jump to it.
 ///
 /// No registers other than s0, s1 and the mscratch CSR are to be clobbered
 /// before continuing execution at the address loaded into the mscratch CSR
@@ -292,7 +307,11 @@ pub extern "C" fn _start_trap() -> ! {
 /// invoked, it may, for instance, choose to ignore a certain trap, access
 /// global state (subject to synchronization), etc. It must still abide to
 /// the contract as stated above.
-#[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
+#[cfg(any(
+    doc,
+    all(target_arch = "riscv32", target_os = "none"),
+    all(target_arch = "riscv64", target_os = "none")
+))]
 #[link_section = ".riscv.trap"]
 // We need the `_start_trap` function to be 256 byte aligned. The linker script
 // includes a check for whether a symbol named `_start_trap` exists. If it does,
@@ -303,7 +322,7 @@ pub extern "C" fn _start_trap() -> ! {
 #[unsafe(naked)]
 pub extern "C" fn _start_trap() -> ! {
     use core::arch::naked_asm;
-    naked_asm!(
+    naked_asm!(concat!(
         "
     // This is the global trap handler. By default, Tock expects this
     // trap handler to be registered at all times, and that all traps
@@ -324,8 +343,8 @@ pub extern "C" fn _start_trap() -> ! {
     // Else, save the current value of s1 to `custom_trap_handler[0]`,
     // load `custom_trap_handler[1]` into s1 and jump to it (invoking
     // a custom trap handler).
-    sw    s1, 0*({XLEN}/8)(s0)    // custom_trap_handler[0] = s1
-    lw    s1, 1*({XLEN}/8)(s0)    // s1 = custom_trap_handler[1]
+",sx!()," s1, 0*({XLEN}/8)(s0)    // custom_trap_handler[0] = s1
+",lx!()," s1, 1*({XLEN}/8)(s0)    // s1 = custom_trap_handler[1]
     jr    s1                      // goto s1
 
   100: // _start_kernel_trap
@@ -361,29 +380,29 @@ pub extern "C" fn _start_trap() -> ! {
 
     // Make room for the caller saved registers we need to restore after running
     // any trap handler code.
-    addi sp, sp, -20*({XLEN}/8)   // riscv32: sp = sp - (20*4)
+    addi sp, sp, -20*({XLEN}/8)   // riscv32: sp = sp - (20*4), riscv64: sp = sp - (20*8)
 
     // Save all of the caller saved registers.
-    sw   ra,  0*({XLEN}/8)(sp)    // riscv32: *(stackptr +  (0*4)) = ra
-    sw   t0,  1*({XLEN}/8)(sp)    // riscv32: *(stackptr +  (1*4)) = t0
-    sw   t1,  2*({XLEN}/8)(sp)    // riscv32: *(stackptr +  (2*4)) = t1
-    sw   t2,  3*({XLEN}/8)(sp)    // riscv32: *(stackptr +  (3*4)) = t2
-    sw   t3,  4*({XLEN}/8)(sp)    // riscv32: *(stackptr +  (4*4)) = t3
-    sw   t4,  5*({XLEN}/8)(sp)    // riscv32: *(stackptr +  (5*4)) = t4
-    sw   t5,  6*({XLEN}/8)(sp)    // riscv32: *(stackptr +  (6*4)) = t5
-    sw   t6,  7*({XLEN}/8)(sp)    // riscv32: *(stackptr +  (7*4)) = t6
-    sw   a0,  8*({XLEN}/8)(sp)    // riscv32: *(stackptr +  (8*4)) = a0
-    sw   a1,  9*({XLEN}/8)(sp)    // riscv32: *(stackptr +  (9*4)) = a1
-    sw   a2, 10*({XLEN}/8)(sp)    // riscv32: *(stackptr + (10*4)) = a2
-    sw   a3, 11*({XLEN}/8)(sp)    // riscv32: *(stackptr + (11*4)) = a3
-    sw   a4, 12*({XLEN}/8)(sp)    // riscv32: *(stackptr + (12*4)) = a4
-    sw   a5, 13*({XLEN}/8)(sp)    // riscv32: *(stackptr + (13*4)) = a5
-    sw   a6, 14*({XLEN}/8)(sp)    // riscv32: *(stackptr + (14*4)) = a6
-    sw   a7, 15*({XLEN}/8)(sp)    // riscv32: *(stackptr + (15*4)) = a7
+",sx!()," ra,  0*({XLEN}/8)(sp)   // riscv32: *(stackptr +  (0*4)) = ra, riscv64: *(stackptr +  (0*8)) = ra
+",sx!()," t0,  1*({XLEN}/8)(sp)   // riscv32: *(stackptr +  (1*4)) = t0, riscv64: *(stackptr +  (1*8)) = t0
+",sx!()," t1,  2*({XLEN}/8)(sp)   // riscv32: *(stackptr +  (2*4)) = t1, riscv64: *(stackptr +  (2*8)) = t1
+",sx!()," t2,  3*({XLEN}/8)(sp)   // riscv32: *(stackptr +  (3*4)) = t2, riscv64: *(stackptr +  (3*8)) = t2
+",sx!()," t3,  4*({XLEN}/8)(sp)   // riscv32: *(stackptr +  (4*4)) = t3, riscv64: *(stackptr +  (4*8)) = t3
+",sx!()," t4,  5*({XLEN}/8)(sp)   // riscv32: *(stackptr +  (5*4)) = t4, riscv64: *(stackptr +  (5*8)) = t4
+",sx!()," t5,  6*({XLEN}/8)(sp)   // riscv32: *(stackptr +  (6*4)) = t5, riscv64: *(stackptr +  (6*8)) = t5
+",sx!()," t6,  7*({XLEN}/8)(sp)   // riscv32: *(stackptr +  (7*4)) = t6, riscv64: *(stackptr +  (7*8)) = t6
+",sx!()," a0,  8*({XLEN}/8)(sp)   // riscv32: *(stackptr +  (8*4)) = a0, riscv64: *(stackptr +  (8*8)) = a0
+",sx!()," a1,  9*({XLEN}/8)(sp)   // riscv32: *(stackptr +  (9*4)) = a1, riscv64: *(stackptr +  (9*8)) = a1
+",sx!()," a2, 10*({XLEN}/8)(sp)   // riscv32: *(stackptr + (10*4)) = a2, riscv64: *(stackptr + (10*8)) = a2
+",sx!()," a3, 11*({XLEN}/8)(sp)   // riscv32: *(stackptr + (11*4)) = a3, riscv64: *(stackptr + (11*8)) = a3
+",sx!()," a4, 12*({XLEN}/8)(sp)   // riscv32: *(stackptr + (12*4)) = a4, riscv64: *(stackptr + (12*8)) = a4
+",sx!()," a5, 13*({XLEN}/8)(sp)   // riscv32: *(stackptr + (13*4)) = a5, riscv64: *(stackptr + (13*8)) = a5
+",sx!()," a6, 14*({XLEN}/8)(sp)   // riscv32: *(stackptr + (14*4)) = a6, riscv64: *(stackptr + (14*8)) = a6
+",sx!()," a7, 15*({XLEN}/8)(sp)   // riscv32: *(stackptr + (15*4)) = a7, riscv64: *(stackptr + (15*8)) = a7
 
     // Save one callee-saved register (s0), which we place the address of
     // the hart-specific 'are we in a trap handler' flag in:
-    sw   s0, 16*({XLEN}/8)(sp)    // riscv32: *(stackptr + (16*4)) = s0
+",sx!()," s0, 16*({XLEN}/8)(sp)    // riscv32: *(stackptr + (16*4)) = s0, riscv64: *(stackptr + (16*8)) = s0
 
     // Determine the address of the hart-specific 'are we in a trap handler'
     // flag as an offset to the _trap_handler_active symbol. The chip crate
@@ -391,7 +410,7 @@ pub extern "C" fn _start_trap() -> ! {
     // enough to fit `max(mhartid) * MXLEN` bytes.
     la   s0, _trap_handler_active // s0 = addr(_trap_handler_active)
     csrr t0, mhartid              // t0 = hartid
-    slli t0, t0, 2                // t0 = t0 * sizeof(u32)
+    slli t0, t0, ({XLEN_LOG2}-3)  // t0 = t0 * sizeof(usize)
     add  s0, s0, t0               // s0 = addr(_trap_handler_active[hartid])
 
     // Indicate that we are in a trap handler on this hart:
@@ -408,38 +427,39 @@ pub extern "C" fn _start_trap() -> ! {
     sw   x0, 0(s0)                // _trap_handler_active[hartid] = 0
 
     // Restore the caller saved registers from the stack.
-    lw   ra,  0*({XLEN}/8)(sp)    // riscv32: ra = *(stackptr +  (0*4))
-    lw   t0,  1*({XLEN}/8)(sp)    // riscv32: t0 = *(stackptr +  (1*4))
-    lw   t1,  2*({XLEN}/8)(sp)    // riscv32: t1 = *(stackptr +  (2*4))
-    lw   t2,  3*({XLEN}/8)(sp)    // riscv32: t2 = *(stackptr +  (3*4))
-    lw   t3,  4*({XLEN}/8)(sp)    // riscv32: t3 = *(stackptr +  (4*4))
-    lw   t4,  5*({XLEN}/8)(sp)    // riscv32: t4 = *(stackptr +  (5*4))
-    lw   t5,  6*({XLEN}/8)(sp)    // riscv32: t5 = *(stackptr +  (6*4))
-    lw   t6,  7*({XLEN}/8)(sp)    // riscv32: t6 = *(stackptr +  (7*4))
-    lw   a0,  8*({XLEN}/8)(sp)    // riscv32: a0 = *(stackptr +  (8*4))
-    lw   a1,  9*({XLEN}/8)(sp)    // riscv32: a1 = *(stackptr +  (9*4))
-    lw   a2, 10*({XLEN}/8)(sp)    // riscv32: a2 = *(stackptr + (10*4))
-    lw   a3, 11*({XLEN}/8)(sp)    // riscv32: a3 = *(stackptr + (11*4))
-    lw   a4, 12*({XLEN}/8)(sp)    // riscv32: a4 = *(stackptr + (12*4))
-    lw   a5, 13*({XLEN}/8)(sp)    // riscv32: a5 = *(stackptr + (13*4))
-    lw   a6, 14*({XLEN}/8)(sp)    // riscv32: a6 = *(stackptr + (14*4))
-    lw   a7, 15*({XLEN}/8)(sp)    // riscv32: a7 = *(stackptr + (15*4))
+",lx!()," ra,  0*({XLEN}/8)(sp)   // riscv32: ra = *(stackptr +  (0*4)), riscv64: ra = *(stackptr +  (0*8))
+",lx!()," t0,  1*({XLEN}/8)(sp)   // riscv32: t0 = *(stackptr +  (1*4)), riscv64: t0 = *(stackptr +  (1*8))
+",lx!()," t1,  2*({XLEN}/8)(sp)   // riscv32: t1 = *(stackptr +  (2*4)), riscv64: t1 = *(stackptr +  (2*8))
+",lx!()," t2,  3*({XLEN}/8)(sp)   // riscv32: t2 = *(stackptr +  (3*4)), riscv64: t2 = *(stackptr +  (3*8))
+",lx!()," t3,  4*({XLEN}/8)(sp)   // riscv32: t3 = *(stackptr +  (4*4)), riscv64: t3 = *(stackptr +  (4*8))
+",lx!()," t4,  5*({XLEN}/8)(sp)   // riscv32: t4 = *(stackptr +  (5*4)), riscv64: t4 = *(stackptr +  (5*8))
+",lx!()," t5,  6*({XLEN}/8)(sp)   // riscv32: t5 = *(stackptr +  (6*4)), riscv64: t5 = *(stackptr +  (6*8))
+",lx!()," t6,  7*({XLEN}/8)(sp)   // riscv32: t6 = *(stackptr +  (7*4)), riscv64: t6 = *(stackptr +  (7*8))
+",lx!()," a0,  8*({XLEN}/8)(sp)   // riscv32: a0 = *(stackptr +  (8*4)), riscv64: a0 = *(stackptr +  (8*8))
+",lx!()," a1,  9*({XLEN}/8)(sp)   // riscv32: a1 = *(stackptr +  (9*4)), riscv64: a1 = *(stackptr +  (9*8))
+",lx!()," a2, 10*({XLEN}/8)(sp)   // riscv32: a2 = *(stackptr + (10*4)), riscv64: a2 = *(stackptr + (10*8))
+",lx!()," a3, 11*({XLEN}/8)(sp)   // riscv32: a3 = *(stackptr + (11*4)), riscv64: a3 = *(stackptr + (11*8))
+",lx!()," a4, 12*({XLEN}/8)(sp)   // riscv32: a4 = *(stackptr + (12*4)), riscv64: a4 = *(stackptr + (12*8))
+",lx!()," a5, 13*({XLEN}/8)(sp)   // riscv32: a5 = *(stackptr + (13*4)), riscv64: a5 = *(stackptr + (13*8))
+",lx!()," a6, 14*({XLEN}/8)(sp)   // riscv32: a6 = *(stackptr + (14*4)), riscv64: a6 = *(stackptr + (14*8))
+",lx!()," a7, 15*({XLEN}/8)(sp)   // riscv32: a7 = *(stackptr + (15*4)), riscv64: a7 = *(stackptr + (15*8))
 
     // Restore the one callee-saved register (s0), which used to hold the
     // address of the hart-specific 'are we in a trap handler flag':
-    lw   s0, 16*({XLEN}/8)(sp)    // riscv32: s0 = *(stackptr + (16*4))
+",lx!()," s0, 16*({XLEN}/8)(sp)   // riscv32: s0 = *(stackptr + (16*4)), riscv64: s0 = *(stackptr + (16*8))
 
     // Reset the stack pointer.
-    addi sp, sp, 20*({XLEN}/8)    // sp = sp + (20*4)
+    addi sp, sp, 20*({XLEN}/8)    // riscv32: sp = sp + (20*4), riscv32: sp = sp + (20*8)
 
     // mret returns from the trap handler. The PC is set to what is in
     // mepc and execution proceeds from there. Since we did not modify
     // mepc we will return to where the exception occurred.
     mret
-        ",
+        "),
         estack = sym _estack,
         sstack = sym _sstack,
         XLEN = const XLEN,
+        XLEN_LOG2 = const XLEN_LOG2,
     );
 }
 

--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -323,8 +323,8 @@ pub extern "C" fn _start_trap() -> ! {
     // Else, save the current value of s1 to `custom_trap_handler[0]`,
     // load `custom_trap_handler[1]` into s1 and jump to it (invoking
     // a custom trap handler).
-    sw    s1, 0*4(s0)             // custom_trap_handler[0] = s1
-    lw    s1, 1*4(s0)             // s1 = custom_trap_handler[1]
+    sw    s1, 0*({XLEN}/8)(s0)    // custom_trap_handler[0] = s1
+    lw    s1, 1*({XLEN}/8)(s0)    // s1 = custom_trap_handler[1]
     jr    s1                      // goto s1
 
   100: // _start_kernel_trap
@@ -360,29 +360,29 @@ pub extern "C" fn _start_trap() -> ! {
 
     // Make room for the caller saved registers we need to restore after running
     // any trap handler code.
-    addi sp, sp, -20*4            // riscv32: sp = sp - (20*4)
+    addi sp, sp, -20*({XLEN}/8)   // riscv32: sp = sp - (20*4)
 
     // Save all of the caller saved registers.
-    sw   ra,  0*4(sp)             // riscv32: *(stackptr +  (0*4)) = ra
-    sw   t0,  1*4(sp)             // riscv32: *(stackptr +  (1*4)) = t0
-    sw   t1,  2*4(sp)             // riscv32: *(stackptr +  (2*4)) = t1
-    sw   t2,  3*4(sp)             // riscv32: *(stackptr +  (3*4)) = t2
-    sw   t3,  4*4(sp)             // riscv32: *(stackptr +  (4*4)) = t3
-    sw   t4,  5*4(sp)             // riscv32: *(stackptr +  (5*4)) = t4
-    sw   t5,  6*4(sp)             // riscv32: *(stackptr +  (6*4)) = t5
-    sw   t6,  7*4(sp)             // riscv32: *(stackptr +  (7*4)) = t6
-    sw   a0,  8*4(sp)             // riscv32: *(stackptr +  (8*4)) = a0
-    sw   a1,  9*4(sp)             // riscv32: *(stackptr +  (9*4)) = a1
-    sw   a2, 10*4(sp)             // riscv32: *(stackptr + (10*4)) = a2
-    sw   a3, 11*4(sp)             // riscv32: *(stackptr + (11*4)) = a3
-    sw   a4, 12*4(sp)             // riscv32: *(stackptr + (12*4)) = a4
-    sw   a5, 13*4(sp)             // riscv32: *(stackptr + (13*4)) = a5
-    sw   a6, 14*4(sp)             // riscv32: *(stackptr + (14*4)) = a6
-    sw   a7, 15*4(sp)             // riscv32: *(stackptr + (15*4)) = a7
+    sw   ra,  0*({XLEN}/8)(sp)    // riscv32: *(stackptr +  (0*4)) = ra
+    sw   t0,  1*({XLEN}/8)(sp)    // riscv32: *(stackptr +  (1*4)) = t0
+    sw   t1,  2*({XLEN}/8)(sp)    // riscv32: *(stackptr +  (2*4)) = t1
+    sw   t2,  3*({XLEN}/8)(sp)    // riscv32: *(stackptr +  (3*4)) = t2
+    sw   t3,  4*({XLEN}/8)(sp)    // riscv32: *(stackptr +  (4*4)) = t3
+    sw   t4,  5*({XLEN}/8)(sp)    // riscv32: *(stackptr +  (5*4)) = t4
+    sw   t5,  6*({XLEN}/8)(sp)    // riscv32: *(stackptr +  (6*4)) = t5
+    sw   t6,  7*({XLEN}/8)(sp)    // riscv32: *(stackptr +  (7*4)) = t6
+    sw   a0,  8*({XLEN}/8)(sp)    // riscv32: *(stackptr +  (8*4)) = a0
+    sw   a1,  9*({XLEN}/8)(sp)    // riscv32: *(stackptr +  (9*4)) = a1
+    sw   a2, 10*({XLEN}/8)(sp)    // riscv32: *(stackptr + (10*4)) = a2
+    sw   a3, 11*({XLEN}/8)(sp)    // riscv32: *(stackptr + (11*4)) = a3
+    sw   a4, 12*({XLEN}/8)(sp)    // riscv32: *(stackptr + (12*4)) = a4
+    sw   a5, 13*({XLEN}/8)(sp)    // riscv32: *(stackptr + (13*4)) = a5
+    sw   a6, 14*({XLEN}/8)(sp)    // riscv32: *(stackptr + (14*4)) = a6
+    sw   a7, 15*({XLEN}/8)(sp)    // riscv32: *(stackptr + (15*4)) = a7
 
     // Save one callee-saved register (s0), which we place the address of
     // the hart-specific 'are we in a trap handler' flag in:
-    sw   s0, 16*4(sp)             // riscv32: *(stackptr + (16*4)) = s0
+    sw   s0, 16*({XLEN}/8)(sp)    // riscv32: *(stackptr + (16*4)) = s0
 
     // Determine the address of the hart-specific 'are we in a trap handler'
     // flag as an offset to the _trap_handler_active symbol. The chip crate
@@ -407,29 +407,29 @@ pub extern "C" fn _start_trap() -> ! {
     sw   x0, 0(s0)                // _trap_handler_active[hartid] = 0
 
     // Restore the caller saved registers from the stack.
-    lw   ra,  0*4(sp)             // riscv32: ra = *(stackptr +  (0*4))
-    lw   t0,  1*4(sp)             // riscv32: t0 = *(stackptr +  (1*4))
-    lw   t1,  2*4(sp)             // riscv32: t1 = *(stackptr +  (2*4))
-    lw   t2,  3*4(sp)             // riscv32: t2 = *(stackptr +  (3*4))
-    lw   t3,  4*4(sp)             // riscv32: t3 = *(stackptr +  (4*4))
-    lw   t4,  5*4(sp)             // riscv32: t4 = *(stackptr +  (5*4))
-    lw   t5,  6*4(sp)             // riscv32: t5 = *(stackptr +  (6*4))
-    lw   t6,  7*4(sp)             // riscv32: t6 = *(stackptr +  (7*4))
-    lw   a0,  8*4(sp)             // riscv32: a0 = *(stackptr +  (8*4))
-    lw   a1,  9*4(sp)             // riscv32: a1 = *(stackptr +  (9*4))
-    lw   a2, 10*4(sp)             // riscv32: a2 = *(stackptr + (10*4))
-    lw   a3, 11*4(sp)             // riscv32: a3 = *(stackptr + (11*4))
-    lw   a4, 12*4(sp)             // riscv32: a4 = *(stackptr + (12*4))
-    lw   a5, 13*4(sp)             // riscv32: a5 = *(stackptr + (13*4))
-    lw   a6, 14*4(sp)             // riscv32: a6 = *(stackptr + (14*4))
-    lw   a7, 15*4(sp)             // riscv32: a7 = *(stackptr + (15*4))
+    lw   ra,  0*({XLEN}/8)(sp)    // riscv32: ra = *(stackptr +  (0*4))
+    lw   t0,  1*({XLEN}/8)(sp)    // riscv32: t0 = *(stackptr +  (1*4))
+    lw   t1,  2*({XLEN}/8)(sp)    // riscv32: t1 = *(stackptr +  (2*4))
+    lw   t2,  3*({XLEN}/8)(sp)    // riscv32: t2 = *(stackptr +  (3*4))
+    lw   t3,  4*({XLEN}/8)(sp)    // riscv32: t3 = *(stackptr +  (4*4))
+    lw   t4,  5*({XLEN}/8)(sp)    // riscv32: t4 = *(stackptr +  (5*4))
+    lw   t5,  6*({XLEN}/8)(sp)    // riscv32: t5 = *(stackptr +  (6*4))
+    lw   t6,  7*({XLEN}/8)(sp)    // riscv32: t6 = *(stackptr +  (7*4))
+    lw   a0,  8*({XLEN}/8)(sp)    // riscv32: a0 = *(stackptr +  (8*4))
+    lw   a1,  9*({XLEN}/8)(sp)    // riscv32: a1 = *(stackptr +  (9*4))
+    lw   a2, 10*({XLEN}/8)(sp)    // riscv32: a2 = *(stackptr + (10*4))
+    lw   a3, 11*({XLEN}/8)(sp)    // riscv32: a3 = *(stackptr + (11*4))
+    lw   a4, 12*({XLEN}/8)(sp)    // riscv32: a4 = *(stackptr + (12*4))
+    lw   a5, 13*({XLEN}/8)(sp)    // riscv32: a5 = *(stackptr + (13*4))
+    lw   a6, 14*({XLEN}/8)(sp)    // riscv32: a6 = *(stackptr + (14*4))
+    lw   a7, 15*({XLEN}/8)(sp)    // riscv32: a7 = *(stackptr + (15*4))
 
     // Restore the one callee-saved register (s0), which used to hold the
     // address of the hart-specific 'are we in a trap handler flag':
-    lw   s0, 16*4(sp)             // riscv32: s0 = *(stackptr + (16*4))
+    lw   s0, 16*({XLEN}/8)(sp)    // riscv32: s0 = *(stackptr + (16*4))
 
     // Reset the stack pointer.
-    addi sp, sp, 20*4             // sp = sp + (20*4)
+    addi sp, sp, 20*({XLEN}/8)    // sp = sp + (20*4)
 
     // mret returns from the trap handler. The PC is set to what is in
     // mepc and execution proceeds from there. Since we did not modify
@@ -438,6 +438,7 @@ pub extern "C" fn _start_trap() -> ! {
         ",
         estack = sym _estack,
         sstack = sym _sstack,
+        XLEN = const XLEN,
     );
 }
 

--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -315,7 +315,8 @@ pub extern "C" fn _start_trap() -> ! {
 #[unsafe(naked)]
 pub extern "C" fn _start_trap() -> ! {
     use core::arch::naked_asm;
-    naked_asm!(concat!(
+    naked_asm!(
+        xlen_macros!(),
         "
     // This is the global trap handler. By default, Tock expects this
     // trap handler to be registered at all times, and that all traps
@@ -336,8 +337,8 @@ pub extern "C" fn _start_trap() -> ! {
     // Else, save the current value of s1 to `custom_trap_handler[0]`,
     // load `custom_trap_handler[1]` into s1 and jump to it (invoking
     // a custom trap handler).
-",sx!()," s1, 0*({XLEN}/8)(s0)    // custom_trap_handler[0] = s1
-",lx!()," s1, 1*({XLEN}/8)(s0)    // s1 = custom_trap_handler[1]
+    sx    s1, 0*({XLEN}/8)(s0)    // custom_trap_handler[0] = s1
+    lx    s1, 1*({XLEN}/8)(s0)    // s1 = custom_trap_handler[1]
     jr    s1                      // goto s1
 
   100: // _start_kernel_trap
@@ -376,26 +377,26 @@ pub extern "C" fn _start_trap() -> ! {
     addi sp, sp, -20*({XLEN}/8)   // riscv32: sp = sp - (20*4), riscv64: sp = sp - (20*8)
 
     // Save all of the caller saved registers.
-",sx!()," ra,  0*({XLEN}/8)(sp)   // riscv32: *(stackptr +  (0*4)) = ra, riscv64: *(stackptr +  (0*8)) = ra
-",sx!()," t0,  1*({XLEN}/8)(sp)   // riscv32: *(stackptr +  (1*4)) = t0, riscv64: *(stackptr +  (1*8)) = t0
-",sx!()," t1,  2*({XLEN}/8)(sp)   // riscv32: *(stackptr +  (2*4)) = t1, riscv64: *(stackptr +  (2*8)) = t1
-",sx!()," t2,  3*({XLEN}/8)(sp)   // riscv32: *(stackptr +  (3*4)) = t2, riscv64: *(stackptr +  (3*8)) = t2
-",sx!()," t3,  4*({XLEN}/8)(sp)   // riscv32: *(stackptr +  (4*4)) = t3, riscv64: *(stackptr +  (4*8)) = t3
-",sx!()," t4,  5*({XLEN}/8)(sp)   // riscv32: *(stackptr +  (5*4)) = t4, riscv64: *(stackptr +  (5*8)) = t4
-",sx!()," t5,  6*({XLEN}/8)(sp)   // riscv32: *(stackptr +  (6*4)) = t5, riscv64: *(stackptr +  (6*8)) = t5
-",sx!()," t6,  7*({XLEN}/8)(sp)   // riscv32: *(stackptr +  (7*4)) = t6, riscv64: *(stackptr +  (7*8)) = t6
-",sx!()," a0,  8*({XLEN}/8)(sp)   // riscv32: *(stackptr +  (8*4)) = a0, riscv64: *(stackptr +  (8*8)) = a0
-",sx!()," a1,  9*({XLEN}/8)(sp)   // riscv32: *(stackptr +  (9*4)) = a1, riscv64: *(stackptr +  (9*8)) = a1
-",sx!()," a2, 10*({XLEN}/8)(sp)   // riscv32: *(stackptr + (10*4)) = a2, riscv64: *(stackptr + (10*8)) = a2
-",sx!()," a3, 11*({XLEN}/8)(sp)   // riscv32: *(stackptr + (11*4)) = a3, riscv64: *(stackptr + (11*8)) = a3
-",sx!()," a4, 12*({XLEN}/8)(sp)   // riscv32: *(stackptr + (12*4)) = a4, riscv64: *(stackptr + (12*8)) = a4
-",sx!()," a5, 13*({XLEN}/8)(sp)   // riscv32: *(stackptr + (13*4)) = a5, riscv64: *(stackptr + (13*8)) = a5
-",sx!()," a6, 14*({XLEN}/8)(sp)   // riscv32: *(stackptr + (14*4)) = a6, riscv64: *(stackptr + (14*8)) = a6
-",sx!()," a7, 15*({XLEN}/8)(sp)   // riscv32: *(stackptr + (15*4)) = a7, riscv64: *(stackptr + (15*8)) = a7
+    sx    ra,  0*({XLEN}/8)(sp)   // riscv32: *(stackptr +  (0*4)) = ra, riscv64: *(stackptr +  (0*8)) = ra
+    sx    t0,  1*({XLEN}/8)(sp)   // riscv32: *(stackptr +  (1*4)) = t0, riscv64: *(stackptr +  (1*8)) = t0
+    sx    t1,  2*({XLEN}/8)(sp)   // riscv32: *(stackptr +  (2*4)) = t1, riscv64: *(stackptr +  (2*8)) = t1
+    sx    t2,  3*({XLEN}/8)(sp)   // riscv32: *(stackptr +  (3*4)) = t2, riscv64: *(stackptr +  (3*8)) = t2
+    sx    t3,  4*({XLEN}/8)(sp)   // riscv32: *(stackptr +  (4*4)) = t3, riscv64: *(stackptr +  (4*8)) = t3
+    sx    t4,  5*({XLEN}/8)(sp)   // riscv32: *(stackptr +  (5*4)) = t4, riscv64: *(stackptr +  (5*8)) = t4
+    sx    t5,  6*({XLEN}/8)(sp)   // riscv32: *(stackptr +  (6*4)) = t5, riscv64: *(stackptr +  (6*8)) = t5
+    sx    t6,  7*({XLEN}/8)(sp)   // riscv32: *(stackptr +  (7*4)) = t6, riscv64: *(stackptr +  (7*8)) = t6
+    sx    a0,  8*({XLEN}/8)(sp)   // riscv32: *(stackptr +  (8*4)) = a0, riscv64: *(stackptr +  (8*8)) = a0
+    sx    a1,  9*({XLEN}/8)(sp)   // riscv32: *(stackptr +  (9*4)) = a1, riscv64: *(stackptr +  (9*8)) = a1
+    sx    a2, 10*({XLEN}/8)(sp)   // riscv32: *(stackptr + (10*4)) = a2, riscv64: *(stackptr + (10*8)) = a2
+    sx    a3, 11*({XLEN}/8)(sp)   // riscv32: *(stackptr + (11*4)) = a3, riscv64: *(stackptr + (11*8)) = a3
+    sx    a4, 12*({XLEN}/8)(sp)   // riscv32: *(stackptr + (12*4)) = a4, riscv64: *(stackptr + (12*8)) = a4
+    sx    a5, 13*({XLEN}/8)(sp)   // riscv32: *(stackptr + (13*4)) = a5, riscv64: *(stackptr + (13*8)) = a5
+    sx    a6, 14*({XLEN}/8)(sp)   // riscv32: *(stackptr + (14*4)) = a6, riscv64: *(stackptr + (14*8)) = a6
+    sx    a7, 15*({XLEN}/8)(sp)   // riscv32: *(stackptr + (15*4)) = a7, riscv64: *(stackptr + (15*8)) = a7
 
     // Save one callee-saved register (s0), which we place the address of
     // the hart-specific 'are we in a trap handler' flag in:
-",sx!()," s0, 16*({XLEN}/8)(sp)    // riscv32: *(stackptr + (16*4)) = s0, riscv64: *(stackptr + (16*8)) = s0
+    sx    s0, 16*({XLEN}/8)(sp)   // riscv32: *(stackptr + (16*4)) = s0, riscv64: *(stackptr + (16*8)) = s0
 
     // Determine the address of the hart-specific 'are we in a trap handler'
     // flag as an offset to the _trap_handler_active symbol. The chip crate
@@ -420,26 +421,26 @@ pub extern "C" fn _start_trap() -> ! {
     sw   x0, 0(s0)                // _trap_handler_active[hartid] = 0
 
     // Restore the caller saved registers from the stack.
-",lx!()," ra,  0*({XLEN}/8)(sp)   // riscv32: ra = *(stackptr +  (0*4)), riscv64: ra = *(stackptr +  (0*8))
-",lx!()," t0,  1*({XLEN}/8)(sp)   // riscv32: t0 = *(stackptr +  (1*4)), riscv64: t0 = *(stackptr +  (1*8))
-",lx!()," t1,  2*({XLEN}/8)(sp)   // riscv32: t1 = *(stackptr +  (2*4)), riscv64: t1 = *(stackptr +  (2*8))
-",lx!()," t2,  3*({XLEN}/8)(sp)   // riscv32: t2 = *(stackptr +  (3*4)), riscv64: t2 = *(stackptr +  (3*8))
-",lx!()," t3,  4*({XLEN}/8)(sp)   // riscv32: t3 = *(stackptr +  (4*4)), riscv64: t3 = *(stackptr +  (4*8))
-",lx!()," t4,  5*({XLEN}/8)(sp)   // riscv32: t4 = *(stackptr +  (5*4)), riscv64: t4 = *(stackptr +  (5*8))
-",lx!()," t5,  6*({XLEN}/8)(sp)   // riscv32: t5 = *(stackptr +  (6*4)), riscv64: t5 = *(stackptr +  (6*8))
-",lx!()," t6,  7*({XLEN}/8)(sp)   // riscv32: t6 = *(stackptr +  (7*4)), riscv64: t6 = *(stackptr +  (7*8))
-",lx!()," a0,  8*({XLEN}/8)(sp)   // riscv32: a0 = *(stackptr +  (8*4)), riscv64: a0 = *(stackptr +  (8*8))
-",lx!()," a1,  9*({XLEN}/8)(sp)   // riscv32: a1 = *(stackptr +  (9*4)), riscv64: a1 = *(stackptr +  (9*8))
-",lx!()," a2, 10*({XLEN}/8)(sp)   // riscv32: a2 = *(stackptr + (10*4)), riscv64: a2 = *(stackptr + (10*8))
-",lx!()," a3, 11*({XLEN}/8)(sp)   // riscv32: a3 = *(stackptr + (11*4)), riscv64: a3 = *(stackptr + (11*8))
-",lx!()," a4, 12*({XLEN}/8)(sp)   // riscv32: a4 = *(stackptr + (12*4)), riscv64: a4 = *(stackptr + (12*8))
-",lx!()," a5, 13*({XLEN}/8)(sp)   // riscv32: a5 = *(stackptr + (13*4)), riscv64: a5 = *(stackptr + (13*8))
-",lx!()," a6, 14*({XLEN}/8)(sp)   // riscv32: a6 = *(stackptr + (14*4)), riscv64: a6 = *(stackptr + (14*8))
-",lx!()," a7, 15*({XLEN}/8)(sp)   // riscv32: a7 = *(stackptr + (15*4)), riscv64: a7 = *(stackptr + (15*8))
+    lx    ra,  0*({XLEN}/8)(sp)   // riscv32: ra = *(stackptr +  (0*4)), riscv64: ra = *(stackptr +  (0*8))
+    lx    t0,  1*({XLEN}/8)(sp)   // riscv32: t0 = *(stackptr +  (1*4)), riscv64: t0 = *(stackptr +  (1*8))
+    lx    t1,  2*({XLEN}/8)(sp)   // riscv32: t1 = *(stackptr +  (2*4)), riscv64: t1 = *(stackptr +  (2*8))
+    lx    t2,  3*({XLEN}/8)(sp)   // riscv32: t2 = *(stackptr +  (3*4)), riscv64: t2 = *(stackptr +  (3*8))
+    lx    t3,  4*({XLEN}/8)(sp)   // riscv32: t3 = *(stackptr +  (4*4)), riscv64: t3 = *(stackptr +  (4*8))
+    lx    t4,  5*({XLEN}/8)(sp)   // riscv32: t4 = *(stackptr +  (5*4)), riscv64: t4 = *(stackptr +  (5*8))
+    lx    t5,  6*({XLEN}/8)(sp)   // riscv32: t5 = *(stackptr +  (6*4)), riscv64: t5 = *(stackptr +  (6*8))
+    lx    t6,  7*({XLEN}/8)(sp)   // riscv32: t6 = *(stackptr +  (7*4)), riscv64: t6 = *(stackptr +  (7*8))
+    lx    a0,  8*({XLEN}/8)(sp)   // riscv32: a0 = *(stackptr +  (8*4)), riscv64: a0 = *(stackptr +  (8*8))
+    lx    a1,  9*({XLEN}/8)(sp)   // riscv32: a1 = *(stackptr +  (9*4)), riscv64: a1 = *(stackptr +  (9*8))
+    lx    a2, 10*({XLEN}/8)(sp)   // riscv32: a2 = *(stackptr + (10*4)), riscv64: a2 = *(stackptr + (10*8))
+    lx    a3, 11*({XLEN}/8)(sp)   // riscv32: a3 = *(stackptr + (11*4)), riscv64: a3 = *(stackptr + (11*8))
+    lx    a4, 12*({XLEN}/8)(sp)   // riscv32: a4 = *(stackptr + (12*4)), riscv64: a4 = *(stackptr + (12*8))
+    lx    a5, 13*({XLEN}/8)(sp)   // riscv32: a5 = *(stackptr + (13*4)), riscv64: a5 = *(stackptr + (13*8))
+    lx    a6, 14*({XLEN}/8)(sp)   // riscv32: a6 = *(stackptr + (14*4)), riscv64: a6 = *(stackptr + (14*8))
+    lx    a7, 15*({XLEN}/8)(sp)   // riscv32: a7 = *(stackptr + (15*4)), riscv64: a7 = *(stackptr + (15*8))
 
     // Restore the one callee-saved register (s0), which used to hold the
     // address of the hart-specific 'are we in a trap handler flag':
-",lx!()," s0, 16*({XLEN}/8)(sp)   // riscv32: s0 = *(stackptr + (16*4)), riscv64: s0 = *(stackptr + (16*8))
+    lx    s0, 16*({XLEN}/8)(sp)   // riscv32: s0 = *(stackptr + (16*4)), riscv64: s0 = *(stackptr + (16*8))
 
     // Reset the stack pointer.
     addi sp, sp, 20*({XLEN}/8)    // riscv32: sp = sp + (20*4), riscv32: sp = sp + (20*8)
@@ -448,7 +449,7 @@ pub extern "C" fn _start_trap() -> ! {
     // mepc and execution proceeds from there. Since we did not modify
     // mepc we will return to where the exception occurred.
     mret
-        "),
+        ",
         estack = sym _estack,
         sstack = sym _sstack,
         XLEN = const XLEN,

--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -19,14 +19,7 @@ pub mod syscall;
 pub mod thread_id;
 
 /// `XLEN` is the width of an integer register in bits (either 32 or 64).
-#[cfg(target_arch = "riscv32")]
-pub const XLEN: usize = 32;
-#[cfg(target_arch = "riscv64")]
-pub const XLEN: usize = 64;
-// Default to 32 bit if no architecture is specified of if this is being
-// compiled for docs or testing on a different architecture.
-#[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
-pub const XLEN: usize = 32;
+pub const XLEN: usize = 1 << XLEN_LOG2;
 
 /// `XLEN_LOG2` is the log base 2 of XLEN.
 #[cfg(target_arch = "riscv32")]

--- a/arch/riscv/src/pseudo_instructions.rs
+++ b/arch/riscv/src/pseudo_instructions.rs
@@ -1,0 +1,49 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+//! Define missing RISC-V pseudo instructions using macros.
+//!
+//! The RISC-V spec includes numerous pseudo instructions to help with writing
+//! RISC-V assembly. However, somewhat bafflingly, there are no pseudo
+//! instructions for making operations XLEN bits long. This makes it difficult
+//! to write general assembly code that works on both RV32 and RV64 systems,
+//! where the assembly only needs to operate on different register sizes.
+//!
+//! We use the pseudo instructions `lx` and `sx` for loading and storing an
+//! entire register, respectively.
+
+/// Loads an XLEN size register.
+#[cfg(any(doc, target_arch = "riscv32"))]
+#[macro_export]
+macro_rules! lx {
+    () => {
+        "lw "
+    };
+}
+
+/// Loads an XLEN size register.
+#[cfg(target_arch = "riscv64")]
+#[macro_export]
+macro_rules! lx {
+    () => {
+        "ld "
+    };
+}
+
+/// Stores a XLEN size register.
+#[cfg(any(doc, target_arch = "riscv32"))]
+#[macro_export]
+macro_rules! sx {
+    () => {
+        "sw "
+    };
+}
+/// Stores a XLEN size register.
+#[cfg(target_arch = "riscv64")]
+#[macro_export]
+macro_rules! sx {
+    () => {
+        "sd "
+    };
+}

--- a/arch/riscv/src/pseudo_instructions.rs
+++ b/arch/riscv/src/pseudo_instructions.rs
@@ -13,7 +13,7 @@
 //! `xlen_macros!` defines macros `lx` and `sx`, which function as
 //! pseudoinstructions for loading and storing XLEN-sized values.
 
-#[cfg(target_arch = "riscv32")]
+#[cfg(any(doc, target_arch = "riscv32"))]
 #[macro_export]
 macro_rules! xlen_macros[() => [r"
     .macro sx src, dest

--- a/arch/riscv/src/pseudo_instructions.rs
+++ b/arch/riscv/src/pseudo_instructions.rs
@@ -2,48 +2,35 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2026.
 
-//! Define missing RISC-V pseudo instructions using macros.
+//! Define missing RISC-V pseudo instructions using assembly macros.
 //!
 //! The RISC-V spec includes numerous pseudo instructions to help with writing
 //! RISC-V assembly. However, somewhat bafflingly, there are no pseudo
 //! instructions for making operations XLEN bits long. This makes it difficult
 //! to write general assembly code that works on both RV32 and RV64 systems,
-//! where the assembly only needs to operate on different register sizes.
+//! where the assembly only needs to operate on different XLENs.
 //!
-//! We use the pseudo instructions `lx` and `sx` for loading and storing an
-//! entire register, respectively.
+//! `xlen_macros!` defines macros `lx` and `sx`, which function as
+//! pseudoinstructions for loading and storing XLEN-sized values.
 
-/// Loads an XLEN size register.
-#[cfg(any(doc, target_arch = "riscv32"))]
+#[cfg(target_arch = "riscv32")]
 #[macro_export]
-macro_rules! lx {
-    () => {
-        "lw "
-    };
-}
+macro_rules! xlen_macros[() => [r"
+    .macro sx src, dest
+        sw \src, \dest
+    .endm
+    .macro lx dest, src
+        lw \dest, \src
+    .endm
+"]];
 
-/// Loads an XLEN size register.
 #[cfg(target_arch = "riscv64")]
 #[macro_export]
-macro_rules! lx {
-    () => {
-        "ld "
-    };
-}
-
-/// Stores a XLEN size register.
-#[cfg(any(doc, target_arch = "riscv32"))]
-#[macro_export]
-macro_rules! sx {
-    () => {
-        "sw "
-    };
-}
-/// Stores a XLEN size register.
-#[cfg(target_arch = "riscv64")]
-#[macro_export]
-macro_rules! sx {
-    () => {
-        "sd "
-    };
-}
+macro_rules! xlen_macros[() => [r"
+    .macro sx src, dest
+        sd \src, \dest
+    .endm
+    .macro lx dest, src
+        ld \dest, \src
+    .endm
+"]];


### PR DESCRIPTION
### Pull Request Overview
This is one small part of #4365.

In the year since #4365 was opened, no one has proposed a better option for supporting "load/store an entire register" in RISCV than using macros that we define to different instructions based on which arch (32 bit or 64 bit) we are compiling for. These _should_ be pseudo instructions provided by the assembler, but, they aren't. So we make our own.

This is a little clumsy in the source code:

```
sw
```
becomes:
```
",sx!(),"
```
but...I don't know that we have a choice other than just not supporting rv64 upstream ever.

Then instead of `4` I am using `XLEN/8` for the number of bytes to offset on the stack to store a register.

I also added the missing comments.

Note, this does not make the crate fully rv32/rv64 compliant, but is a test to see if we like this approach.


### Testing Strategy

todo


### TODO or Help Wanted

Thoughts?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
