### PR TITLE
riscv: handful of style, consistency, and minor simplification changes, plus nop+wfi are rv64 compatible

### DIFF
--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -503,7 +503,7 @@ pub unsafe fn print_mcause(mcval: csr::mcause::Trap, writer: &mut dyn Write) {
             csr::mcause::Exception::Unknown => "Reserved",
         },
     };
-    let _ = writer.write_fmt(format_args!("{}", s));
+    let _ = writer.write_str(s);
 }
 
 /// Prints out RISCV machine state, including basic system registers

--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -447,19 +447,19 @@ pub unsafe fn semihost_command(command: usize, arg0: usize, arg1: usize) -> usiz
     let res;
     asm!(
         "
-    .balign 16
-    .option push
-    .option norelax
-    .option norvc
-    slli x0, x0, 0x1f
-    ebreak
-    srai x0, x0, 7
+    .balign 16                    // ensure 16 byte alignment
+    .option push                  // enable the following options:
+    .option norelax               // - norelax: do not replace these instructions
+    .option norvc                 // - norvc: force full 32 bit instructions
+    slli x0, x0, 0x1f             // useless instruction (writes to x0), but serves as sentinel for semihosting
+    ebreak                        // trap to debugger
+    srai x0, x0, 7                // useless instruction (writes to x0), but serves as second sentinel
     .option pop
         ",
-        in("a0") command,
-        in("a1") arg0,
-        in("a2") arg1,
-        lateout("a0") res,
+        in("a0") command,         // a0 holds command (and return code)
+        in("a1") arg0,            // a1 holds first argument
+        in("a2") arg1,            // a2 holds second argument
+        lateout("a0") res,        // semihosting replaces a0 with return code
     );
     res
 }

--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -472,87 +472,38 @@ pub unsafe fn semihost_command(_command: usize, _arg0: usize, _arg1: usize) -> u
 
 /// Print a readable string for an mcause reason.
 pub unsafe fn print_mcause(mcval: csr::mcause::Trap, writer: &mut dyn Write) {
-    match mcval {
+    let s = match mcval {
         csr::mcause::Trap::Interrupt(interrupt) => match interrupt {
-            csr::mcause::Interrupt::UserSoft => {
-                let _ = writer.write_fmt(format_args!("User software interrupt"));
-            }
-            csr::mcause::Interrupt::SupervisorSoft => {
-                let _ = writer.write_fmt(format_args!("Supervisor software interrupt"));
-            }
-            csr::mcause::Interrupt::MachineSoft => {
-                let _ = writer.write_fmt(format_args!("Machine software interrupt"));
-            }
-            csr::mcause::Interrupt::UserTimer => {
-                let _ = writer.write_fmt(format_args!("User timer interrupt"));
-            }
-            csr::mcause::Interrupt::SupervisorTimer => {
-                let _ = writer.write_fmt(format_args!("Supervisor timer interrupt"));
-            }
-            csr::mcause::Interrupt::MachineTimer => {
-                let _ = writer.write_fmt(format_args!("Machine timer interrupt"));
-            }
-            csr::mcause::Interrupt::UserExternal => {
-                let _ = writer.write_fmt(format_args!("User external interrupt"));
-            }
-            csr::mcause::Interrupt::SupervisorExternal => {
-                let _ = writer.write_fmt(format_args!("Supervisor external interrupt"));
-            }
-            csr::mcause::Interrupt::MachineExternal => {
-                let _ = writer.write_fmt(format_args!("Machine external interrupt"));
-            }
-            csr::mcause::Interrupt::Unknown(_) => {
-                let _ = writer.write_fmt(format_args!("Reserved/Unknown"));
-            }
+            csr::mcause::Interrupt::UserSoft => "User software interrupt",
+            csr::mcause::Interrupt::SupervisorSoft => "Supervisor software interrupt",
+            csr::mcause::Interrupt::MachineSoft => "Machine software interrupt",
+            csr::mcause::Interrupt::UserTimer => "User timer interrupt",
+            csr::mcause::Interrupt::SupervisorTimer => "Supervisor timer interrupt",
+            csr::mcause::Interrupt::MachineTimer => "Machine timer interrupt",
+            csr::mcause::Interrupt::UserExternal => "User external interrupt",
+            csr::mcause::Interrupt::SupervisorExternal => "Supervisor external interrupt",
+            csr::mcause::Interrupt::MachineExternal => "Machine external interrupt",
+            csr::mcause::Interrupt::Unknown(_) => "Reserved/Unknown",
         },
         csr::mcause::Trap::Exception(exception) => match exception {
-            csr::mcause::Exception::InstructionMisaligned => {
-                let _ = writer.write_fmt(format_args!("Instruction access misaligned"));
-            }
-            csr::mcause::Exception::InstructionFault => {
-                let _ = writer.write_fmt(format_args!("Instruction access fault"));
-            }
-            csr::mcause::Exception::IllegalInstruction => {
-                let _ = writer.write_fmt(format_args!("Illegal instruction"));
-            }
-            csr::mcause::Exception::Breakpoint => {
-                let _ = writer.write_fmt(format_args!("Breakpoint"));
-            }
-            csr::mcause::Exception::LoadMisaligned => {
-                let _ = writer.write_fmt(format_args!("Load address misaligned"));
-            }
-            csr::mcause::Exception::LoadFault => {
-                let _ = writer.write_fmt(format_args!("Load access fault"));
-            }
-            csr::mcause::Exception::StoreMisaligned => {
-                let _ = writer.write_fmt(format_args!("Store/AMO address misaligned"));
-            }
-            csr::mcause::Exception::StoreFault => {
-                let _ = writer.write_fmt(format_args!("Store/AMO access fault"));
-            }
-            csr::mcause::Exception::UserEnvCall => {
-                let _ = writer.write_fmt(format_args!("Environment call from U-mode"));
-            }
-            csr::mcause::Exception::SupervisorEnvCall => {
-                let _ = writer.write_fmt(format_args!("Environment call from S-mode"));
-            }
-            csr::mcause::Exception::MachineEnvCall => {
-                let _ = writer.write_fmt(format_args!("Environment call from M-mode"));
-            }
-            csr::mcause::Exception::InstructionPageFault => {
-                let _ = writer.write_fmt(format_args!("Instruction page fault"));
-            }
-            csr::mcause::Exception::LoadPageFault => {
-                let _ = writer.write_fmt(format_args!("Load page fault"));
-            }
-            csr::mcause::Exception::StorePageFault => {
-                let _ = writer.write_fmt(format_args!("Store/AMO page fault"));
-            }
-            csr::mcause::Exception::Unknown => {
-                let _ = writer.write_fmt(format_args!("Reserved"));
-            }
+            csr::mcause::Exception::InstructionMisaligned => "Instruction access misaligned",
+            csr::mcause::Exception::InstructionFault => "Instruction access fault",
+            csr::mcause::Exception::IllegalInstruction => "Illegal instruction",
+            csr::mcause::Exception::Breakpoint => "Breakpoint",
+            csr::mcause::Exception::LoadMisaligned => "Load address misaligned",
+            csr::mcause::Exception::LoadFault => "Load access fault",
+            csr::mcause::Exception::StoreMisaligned => "Store/AMO address misaligned",
+            csr::mcause::Exception::StoreFault => "Store/AMO access fault",
+            csr::mcause::Exception::UserEnvCall => "Environment call from U-mode",
+            csr::mcause::Exception::SupervisorEnvCall => "Environment call from S-mode",
+            csr::mcause::Exception::MachineEnvCall => "Environment call from M-mode",
+            csr::mcause::Exception::InstructionPageFault => "Instruction page fault",
+            csr::mcause::Exception::LoadPageFault => "Load page fault",
+            csr::mcause::Exception::StorePageFault => "Store/AMO page fault",
+            csr::mcause::Exception::Unknown => "Reserved",
         },
-    }
+    };
+    let _ = writer.write_fmt(format_args!("{}", s));
 }
 
 /// Prints out RISCV machine state, including basic system registers

--- a/arch/riscv/src/pmp.rs
+++ b/arch/riscv/src/pmp.rs
@@ -327,7 +327,7 @@ pub mod misc_pmp_test {
     fn test_napot_region_spec_from_pmpaddr_csr() {
         use super::NAPOTRegionSpec;
 
-        // Unfortunatly, we can't run these unit tests for different platforms,
+        // Unfortunately, we can't run these unit tests for different platforms,
         // with arbitrary bit-widths (at least when using `usize` in the
         // `TORRegionSpec` internally.
         //
@@ -419,7 +419,7 @@ pub mod misc_pmp_test {
     #[test]
     fn test_tor_region_spec_from_pmpaddr_csrs() {
         use super::TORRegionSpec;
-        // Unfortunatly, we can't run these unit tests for different platforms,
+        // Unfortunately, we can't run these unit tests for different platforms,
         // with arbitrary bit-widths (at least when using `usize` in the
         // `TORRegionSpec` internally.
         //
@@ -577,7 +577,7 @@ pub mod misc_pmp_test {
 ///
 /// This function is unsafe, as it relies on the PMP CSRs to be accessible, and
 /// the hardware to feature `PHYSICAL_ENTRIES` PMP CSR entries. If these
-/// conditions are not met, calling this function can result in undefinied
+/// conditions are not met, calling this function can result in undefined
 /// behavior (e.g., cause a system trap).
 pub unsafe fn format_pmp_entries<const PHYSICAL_ENTRIES: usize>(
     f: &mut fmt::Formatter<'_>,
@@ -763,11 +763,11 @@ pub trait TORUserPMP<const MAX_REGIONS: usize> {
     ///   configured either as a TOR region (`A = 0b01`), or disabled (all bits
     ///   set to `0`).
     ///
-    /// - second value (`*const u8`): the region's start addres. As a PMP TOR
+    /// - second value (`*const u8`): the region's start address. As a PMP TOR
     ///   region has a 4-byte address granularity, this address is rounded down
     ///   to the next 4-byte boundary.
     ///
-    /// - third value (`*const u8`): the region's end addres. As a PMP TOR
+    /// - third value (`*const u8`): the region's end address. As a PMP TOR
     ///   region has a 4-byte address granularity, this address is rounded down
     ///   to the next 4-byte boundary.
     ///
@@ -795,7 +795,7 @@ pub trait TORUserPMP<const MAX_REGIONS: usize> {
     /// Disable the user-mode memory protection.
     ///
     /// Disables the memory protection for user-mode. If enabling the user-mode
-    /// memory protetion made user-mode accessible regions inaccessible to
+    /// memory protection made user-mode accessible regions inaccessible to
     /// machine-mode, this method should make these regions accessible again.
     ///
     /// For PMP implementations where configured regions are only enforced in
@@ -995,7 +995,7 @@ unsafe impl<const MAX_REGIONS: usize, P: TORUserPMP<MAX_REGIONS> + 'static>
             // that performed this check before adjusting the requested region
             // size to meet PMP region layout constraints (4 byte alignment for
             // start and end address). Existing applications whose end-address
-            // is aligned on a less than 4-byte bondary would thus be given
+            // is aligned on a less than 4-byte boundary would thus be given
             // access to additional memory which should be inaccessible.
             // Unfortunately, we can't fix this without breaking existing
             // applications. Thus, we perform the same insecure hack here, and
@@ -1458,12 +1458,12 @@ pub mod simple {
     /// expected to be set to the number of available entries.
     ///
     /// [`SimplePMP`] implements [`TORUserPMP`] to expose all of its regions as
-    /// "top of range" (TOR) regions (each taking up two physical PMP entires)
+    /// "top of range" (TOR) regions (each taking up two physical PMP entries)
     /// for use as a user-mode memory protection mechanism.
     ///
     /// Notably, [`SimplePMP`] implements `TORUserPMP<MPU_REGIONS>` over a
     /// generic `MPU_REGIONS` where `MPU_REGIONS <= (AVAILABLE_ENTRIES / 2)`. As
-    /// PMP re-configuration can have a significiant runtime overhead, users are
+    /// PMP re-configuration can have a significant runtime overhead, users are
     /// free to specify a small `MPU_REGIONS` const-generic parameter to reduce
     /// the runtime overhead induced through PMP configuration, at the cost of
     /// having less PMP regions available to use for userspace memory
@@ -2278,7 +2278,7 @@ pub mod kernel_protection_mml_epmp {
         for KernelProtectionMMLEPMP<AVAILABLE_ENTRIES, MPU_REGIONS>
     {
         // Ensure that the MPU_REGIONS (starting at entry, and occupying two
-        // entries per region) don't overflow the available entires, excluding
+        // entries per region) don't overflow the available entries, excluding
         // the 7 entries used for implementing the kernel memory protection:
         const CONST_ASSERT_CHECK: () = assert!(MPU_REGIONS <= ((AVAILABLE_ENTRIES - 5) / 2));
 

--- a/arch/riscv/src/support.rs
+++ b/arch/riscv/src/support.rs
@@ -6,7 +6,7 @@
 
 use crate::csr::{mstatus::mstatus, CSR};
 
-#[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
+#[cfg(any(doc, target_arch = "riscv32", target_arch = "riscv64"))]
 #[inline(always)]
 /// NOP instruction
 pub fn nop() {
@@ -16,9 +16,9 @@ pub fn nop() {
     }
 }
 
-#[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
+#[cfg(any(doc, target_arch = "riscv32", target_arch = "riscv64"))]
 #[inline(always)]
-/// WFI instruction
+/// Wait For Interrupt (WFI) instruction.
 pub unsafe fn wfi() {
     use core::arch::asm;
     asm!("wfi", options(nomem, nostack));
@@ -51,13 +51,13 @@ where
 }
 
 // Mock implementations for tests on Travis-CI.
-#[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
+#[cfg(not(any(doc, target_arch = "riscv32", target_arch = "riscv64")))]
 /// NOP instruction (mock)
 pub fn nop() {
     unimplemented!()
 }
 
-#[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
+#[cfg(not(any(doc, target_arch = "riscv32", target_arch = "riscv64")))]
 /// WFI instruction (mock)
 pub unsafe fn wfi() {
     unimplemented!()

--- a/arch/riscv/src/syscall.rs
+++ b/arch/riscv/src/syscall.rs
@@ -246,382 +246,383 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
         // is not set, hence the compiler has to assume the assembly
         // will issue arbitrary memory accesses (acting as a compiler
         // fence).
-        asm!("
-          // Before switching to the app we need to save some kernel registers
-          // to the kernel stack, specifically ones which we can't mark as
-          // clobbered in the asm!() block. We then save the stack pointer in
-          // the mscratch CSR so we can retrieve it after returning to the
-          // kernel from the app.
-          //
-          // A few values get saved to the kernel stack, including an app
-          // register temporarily after entering the trap handler. Here is a
-          // memory map to make it easier to keep track:
-          //
-          // ```
-          //  8*4(sp):          <- original stack pointer
-          //  7*4(sp):
-          //  6*4(sp): x9  / s1
-          //  5*4(sp): x8  / s0 / fp
-          //  4*4(sp): x4  / tp
-          //  3*4(sp): x3  / gp
-          //  2*4(sp): x10 / a0 (*state, Per-process StoredState struct)
-          //  1*4(sp): custom trap handler address
-          //  0*4(sp): scratch space, having s1 written to by the trap handler
-          //                    <- new stack pointer
-          // ```
+        asm!(
+            "
+    // Before switching to the app we need to save some kernel registers
+    // to the kernel stack, specifically ones which we can't mark as
+    // clobbered in the asm!() block. We then save the stack pointer in
+    // the mscratch CSR so we can retrieve it after returning to the
+    // kernel from the app.
+    //
+    // A few values get saved to the kernel stack, including an app
+    // register temporarily after entering the trap handler. Here is a
+    // memory map to make it easier to keep track:
+    //
+    // ```
+    //  8*4(sp):          <- original stack pointer
+    //  7*4(sp):
+    //  6*4(sp): x9  / s1
+    //  5*4(sp): x8  / s0 / fp
+    //  4*4(sp): x4  / tp
+    //  3*4(sp): x3  / gp
+    //  2*4(sp): x10 / a0 (*state, Per-process StoredState struct)
+    //  1*4(sp): custom trap handler address
+    //  0*4(sp): scratch space, having s1 written to by the trap handler
+    //                    <- new stack pointer
+    // ```
 
-          addi sp, sp, -8*4  // Move the stack pointer down to make room.
+    addi sp, sp, -8*4             // Move the stack pointer down to make room.
 
-          // Save all registers on the kernel stack which cannot be clobbered
-          // by an asm!() block. These are mostly registers which have a
-          // designated purpose (e.g. stack pointer) or are used internally
-          // by LLVM.
-          sw   x9,  6*4(sp)   // s1 (used internally by LLVM)
-          sw   x8,  5*4(sp)   // fp (can't be clobbered / used as an operand)
-          sw   x4,  4*4(sp)   // tp (can't be clobbered / used as an operand)
-          sw   x3,  3*4(sp)   // gp (can't be clobbered / used as an operand)
+    // Save all registers on the kernel stack which cannot be clobbered
+    // by an asm!() block. These are mostly registers which have a
+    // designated purpose (e.g. stack pointer) or are used internally
+    // by LLVM.
+    sw   x9,  6*4(sp)             // s1 (used internally by LLVM)
+    sw   x8,  5*4(sp)             // fp (can't be clobbered / used as an operand)
+    sw   x4,  4*4(sp)             // tp (can't be clobbered / used as an operand)
+    sw   x3,  3*4(sp)             // gp (can't be clobbered / used as an operand)
 
-          sw   x10, 2*4(sp)   // Store process state pointer on stack as well.
-                              // We need to have this available for after the
-                              // app returns to the kernel so we can store its
-                              // registers.
+    sw   x10, 2*4(sp)             // Store process state pointer on stack as well.
+                                  // We need to have this available for after the
+                                  // app returns to the kernel so we can store its
+                                  // registers.
 
-          // Load the address of `_start_app_trap` into `1*4(sp)`. We swap our
-          // stack pointer into the mscratch CSR and the trap handler will load
-          // and jump to the address at this offset.
-          la    t0, 100f      // t0 = _start_app_trap
-          sw    t0, 1*4(sp)   // 1*4(sp) = t0
+    // Load the address of `_start_app_trap` into `1*4(sp)`. We swap our
+    // stack pointer into the mscratch CSR and the trap handler will load
+    // and jump to the address at this offset.
+    la    t0, 100f                // t0 = _start_app_trap
+    sw    t0, 1*4(sp)             // 1*4(sp) = t0
 
-          // sw x0, 0*4(sp)   // Reserved as scratch space for the trap handler
+    // sw x0, 0*4(sp)             // Reserved as scratch space for the trap handler
 
-          // -----> All required registers saved to the stack.
-          //        sp holds the updated stack pointer, a0 the per-process state
+    // -----> All required registers saved to the stack.
+    //        sp holds the updated stack pointer, a0 the per-process state
 
-          // From here on we can't allow the CPU to take interrupts anymore, as
-          // we re-route traps to `_start_app_trap` below (by writing our stack
-          // pointer into the mscratch CSR), and we rely on certain CSRs to not
-          // be modified or used in their intermediate states (e.g., mepc).
-          //
-          // We atomically switch to user-mode and re-enable interrupts using
-          // the `mret` instruction below.
-          //
-          // If interrupts are disabled _after_ setting mscratch, this result in
-          // the race condition of [PR 2308](https://github.com/tock/tock/pull/2308)
+    // From here on we can't allow the CPU to take interrupts anymore, as
+    // we re-route traps to `_start_app_trap` below (by writing our stack
+    // pointer into the mscratch CSR), and we rely on certain CSRs to not
+    // be modified or used in their intermediate states (e.g., mepc).
+    //
+    // We atomically switch to user-mode and re-enable interrupts using
+    // the `mret` instruction below.
+    //
+    // If interrupts are disabled _after_ setting mscratch, this result in
+    // the race condition of [PR 2308](https://github.com/tock/tock/pull/2308)
 
-          // Therefore, clear the following bits in mstatus first:
-          //   0x00000008 -> bit 3 -> MIE (disabling interrupts here)
-          // + 0x00001800 -> bits 11,12 -> MPP (switch to usermode on mret)
-          li    t0, 0x00001808
-          csrc  mstatus, t0         // clear bits in mstatus
+    // Therefore, clear the following bits in mstatus first:
+    //   0x00000008 -> bit 3 -> MIE (disabling interrupts here)
+    // + 0x00001800 -> bits 11,12 -> MPP (switch to usermode on mret)
+    li    t0, 0x00001808
+    csrc  mstatus, t0             // clear bits in mstatus
 
-          // Afterwards, set the following bits in mstatus:
-          //   0x00000080 -> bit 7 -> MPIE (enable interrupts on mret)
-          li    t0, 0x00000080
-          csrs  mstatus, t0         // set bits in mstatus
+    // Afterwards, set the following bits in mstatus:
+    //   0x00000080 -> bit 7 -> MPIE (enable interrupts on mret)
+    li    t0, 0x00000080
+    csrs  mstatus, t0             // set bits in mstatus
 
-          // Execute `_start_app_trap` on a trap by setting the mscratch trap
-          // handler address to our current stack pointer. This stack pointer,
-          // at `1*4(sp)`, holds the address of `_start_app_trap`.
-          //
-          // Upon a trap, the global trap handler (_start_trap) will swap `s0`
-          // with the `mscratch` CSR and, if it contains a non-zero address,
-          // jump to the address that is now at `1*4(s0)`. This allows us to
-          // hook a custom trap handler that saves all userspace state:
-          //
-          csrw  mscratch, sp        // Store `sp` in mscratch CSR. Discard the
-                                    // prior value, must have been set to zero.
+    // Execute `_start_app_trap` on a trap by setting the mscratch trap
+    // handler address to our current stack pointer. This stack pointer,
+    // at `1*4(sp)`, holds the address of `_start_app_trap`.
+    //
+    // Upon a trap, the global trap handler (_start_trap) will swap `s0`
+    // with the `mscratch` CSR and, if it contains a non-zero address,
+    // jump to the address that is now at `1*4(s0)`. This allows us to
+    // hook a custom trap handler that saves all userspace state:
+    //
+    csrw  mscratch, sp            // Store `sp` in mscratch CSR. Discard the
+                                  // prior value, must have been set to zero.
 
-          // We have to set the mepc CSR with the PC we want the app to start
-          // executing at. This has been saved in Riscv32iStoredState for us
-          // (either when the app returned back to the kernel or in the
-          // `set_process_function()` function).
-          lw    t0, 31*4(a0)        // Retrieve the PC from Riscv32iStoredState
-          csrw  mepc, t0            // Set mepc CSR to the app's PC.
+    // We have to set the mepc CSR with the PC we want the app to start
+    // executing at. This has been saved in Riscv32iStoredState for us
+    // (either when the app returned back to the kernel or in the
+    // `set_process_function()` function).
+    lw    t0, 31*4(a0)            // Retrieve the PC from Riscv32iStoredState
+    csrw  mepc, t0                // Set mepc CSR to the app's PC.
 
-          // Restore all of the app registers from what we saved. If this is the
-          // first time running the app then most of these values are
-          // irrelevant, However we do need to set the four arguments to the
-          // `_start_ function in the app. If the app has been executing then
-          // this allows the app to correctly resume.
+    // Restore all of the app registers from what we saved. If this is the
+    // first time running the app then most of these values are
+    // irrelevant, However we do need to set the four arguments to the
+    // `_start_ function in the app. If the app has been executing then
+    // this allows the app to correctly resume.
 
-          // We do a little switcheroo here, and place the per-process stored
-          // state pointer into the `sp` register instead of `a0`. Doing so
-          // allows us to use compressed instructions for all of these loads:
-          mv    sp,  a0             // sp <- a0 (per-process stored state)
+    // We do a little switcheroo here, and place the per-process stored
+    // state pointer into the `sp` register instead of `a0`. Doing so
+    // allows us to use compressed instructions for all of these loads:
+    mv    sp,  a0                 // sp <- a0 (per-process stored state)
 
-          lw    x1,  0*4(sp)        // ra
-          // ------------------------> sp, do last since we overwrite our pointer
-          lw    x3,  2*4(sp)        // gp
-          lw    x4,  3*4(sp)        // tp
-          lw    x5,  4*4(sp)        // t0
-          lw    x6,  5*4(sp)        // t1
-          lw    x7,  6*4(sp)        // t2
-          lw    x8,  7*4(sp)        // s0,fp
-          lw    x9,  8*4(sp)        // s1
-          lw   x10,  9*4(sp)        // a0
-          lw   x11, 10*4(sp)        // a1
-          lw   x12, 11*4(sp)        // a2
-          lw   x13, 12*4(sp)        // a3
-          lw   x14, 13*4(sp)        // a4
-          lw   x15, 14*4(sp)        // a5
-          lw   x16, 15*4(sp)        // a6
-          lw   x17, 16*4(sp)        // a7
-          lw   x18, 17*4(sp)        // s2
-          lw   x19, 18*4(sp)        // s3
-          lw   x20, 19*4(sp)        // s4
-          lw   x21, 20*4(sp)        // s5
-          lw   x22, 21*4(sp)        // s6
-          lw   x23, 22*4(sp)        // s7
-          lw   x24, 23*4(sp)        // s8
-          lw   x25, 24*4(sp)        // s9
-          lw   x26, 25*4(sp)        // s10
-          lw   x27, 26*4(sp)        // s11
-          lw   x28, 27*4(sp)        // t3
-          lw   x29, 28*4(sp)        // t4
-          lw   x30, 29*4(sp)        // t5
-          lw   x31, 30*4(sp)        // t6
-          lw    x2,  1*4(sp)        // sp, overwriting our pointer
+    lw    x1,  0*4(sp)            // ra
+    // ------------------------> sp, do last since we overwrite our pointer
+    lw    x3,  2*4(sp)            // gp
+    lw    x4,  3*4(sp)            // tp
+    lw    x5,  4*4(sp)            // t0
+    lw    x6,  5*4(sp)            // t1
+    lw    x7,  6*4(sp)            // t2
+    lw    x8,  7*4(sp)            // s0,fp
+    lw    x9,  8*4(sp)            // s1
+    lw   x10,  9*4(sp)            // a0
+    lw   x11, 10*4(sp)            // a1
+    lw   x12, 11*4(sp)            // a2
+    lw   x13, 12*4(sp)            // a3
+    lw   x14, 13*4(sp)            // a4
+    lw   x15, 14*4(sp)            // a5
+    lw   x16, 15*4(sp)            // a6
+    lw   x17, 16*4(sp)            // a7
+    lw   x18, 17*4(sp)            // s2
+    lw   x19, 18*4(sp)            // s3
+    lw   x20, 19*4(sp)            // s4
+    lw   x21, 20*4(sp)            // s5
+    lw   x22, 21*4(sp)            // s6
+    lw   x23, 22*4(sp)            // s7
+    lw   x24, 23*4(sp)            // s8
+    lw   x25, 24*4(sp)            // s9
+    lw   x26, 25*4(sp)            // s10
+    lw   x27, 26*4(sp)            // s11
+    lw   x28, 27*4(sp)            // t3
+    lw   x29, 28*4(sp)            // t4
+    lw   x30, 29*4(sp)            // t5
+    lw   x31, 30*4(sp)            // t6
+    lw    x2,  1*4(sp)            // sp, overwriting our pointer
 
-          // Call mret to jump to where mepc points, switch to user mode, and
-          // start running the app.
-          mret
+    // Call mret to jump to where mepc points, switch to user mode, and
+    // start running the app.
+    mret
 
-          // The global trap handler will jump to this address when catching a
-          // trap while the app is executing (address loaded into the mscratch
-          // CSR).
-          //
-          // This custom trap handler is responsible for saving application
-          // state, clearing the custom trap handler (mscratch = 0), and
-          // restoring the kernel context.
-        100: // _start_app_trap
+    // The global trap handler will jump to this address when catching a
+    // trap while the app is executing (address loaded into the mscratch
+    // CSR).
+    //
+    // This custom trap handler is responsible for saving application
+    // state, clearing the custom trap handler (mscratch = 0), and
+    // restoring the kernel context.
+100: // _start_app_trap
 
-          // At this point all we know is that we entered the trap handler from
-          // an app. We don't know _why_ we got a trap, it could be from an
-          // interrupt, syscall, or fault (or maybe something else). Therefore
-          // we have to be very careful not to overwrite any registers before we
-          // have saved them.
-          //
-          // The global trap handler has swapped the app's `s0` into the
-          // mscratch CSR, which now contains the address of our stack pointer.
-          // The global trap handler further clobbered `s1`, which now contains
-          // the address of `_start_app_trap`. The app's `s1` is saved at
-          // `0*4(s0)`.
-          //
-          // Thus we can clobber `s1` and load the address of the per-process
-          // stored state:
-          //
-          lw   s1, 2*4(s0)
+    // At this point all we know is that we entered the trap handler from
+    // an app. We don't know _why_ we got a trap, it could be from an
+    // interrupt, syscall, or fault (or maybe something else). Therefore
+    // we have to be very careful not to overwrite any registers before we
+    // have saved them.
+    //
+    // The global trap handler has swapped the app's `s0` into the
+    // mscratch CSR, which now contains the address of our stack pointer.
+    // The global trap handler further clobbered `s1`, which now contains
+    // the address of `_start_app_trap`. The app's `s1` is saved at
+    // `0*4(s0)`.
+    //
+    // Thus we can clobber `s1` and load the address of the per-process
+    // stored state:
+    //
+    lw   s1, 2*4(s0)
 
-          // With the per-process stored state address in `t1`, save all
-          // non-clobbered registers. Save the `sp` first, then do the same
-          // switcheroo as above, moving the per-process stored state pointer
-          // into `sp`. This allows us to use compressed instructions for all
-          // these stores:
-          sw    x2,  1*4(s1)        // Save app's sp
-          mv    sp,  s1             // sp <- s1 (per-process stored state)
+    // With the per-process stored state address in `t1`, save all
+    // non-clobbered registers. Save the `sp` first, then do the same
+    // switcheroo as above, moving the per-process stored state pointer
+    // into `sp`. This allows us to use compressed instructions for all
+    // these stores:
+    sw    x2,  1*4(s1)            // Save app's sp
+    mv    sp,  s1                 // sp <- s1 (per-process stored state)
 
-          // Now, store relative to `sp` (per-process stored state) with
-          // compressed instructions:
-          sw    x1,  0*4(sp)        // ra
-          // ------------------------> sp, saved above
-          sw    x3,  2*4(sp)        // gp
-          sw    x4,  3*4(sp)        // tp
-          sw    x5,  4*4(sp)        // t0
-          sw    x6,  5*4(sp)        // t1
-          sw    x7,  6*4(sp)        // t2
-          // ------------------------> s0, in mscratch right now
-          // ------------------------> s1, stored at 0*4(s0) right now
-          sw   x10,  9*4(sp)        // a0
-          sw   x11, 10*4(sp)        // a1
-          sw   x12, 11*4(sp)        // a2
-          sw   x13, 12*4(sp)        // a3
-          sw   x14, 13*4(sp)        // a4
-          sw   x15, 14*4(sp)        // a5
-          sw   x16, 15*4(sp)        // a6
-          sw   x17, 16*4(sp)        // a7
-          sw   x18, 17*4(sp)        // s2
-          sw   x19, 18*4(sp)        // s3
-          sw   x20, 19*4(sp)        // s4
-          sw   x21, 20*4(sp)        // s5
-          sw   x22, 21*4(sp)        // s6
-          sw   x23, 22*4(sp)        // s7
-          sw   x24, 23*4(sp)        // s8
-          sw   x25, 24*4(sp)        // s9
-          sw   x26, 25*4(sp)        // s10
-          sw   x27, 26*4(sp)        // s11
-          sw   x28, 27*4(sp)        // t3
-          sw   x29, 28*4(sp)        // t4
-          sw   x30, 29*4(sp)        // t5
-          sw   x31, 30*4(sp)        // t6
+    // Now, store relative to `sp` (per-process stored state) with
+    // compressed instructions:
+    sw    x1,  0*4(sp)            // ra
+    // ------------------------> sp, saved above
+    sw    x3,  2*4(sp)            // gp
+    sw    x4,  3*4(sp)            // tp
+    sw    x5,  4*4(sp)            // t0
+    sw    x6,  5*4(sp)            // t1
+    sw    x7,  6*4(sp)            // t2
+    // ------------------------> s0, in mscratch right now
+    // ------------------------> s1, stored at 0*4(s0) right now
+    sw   x10,  9*4(sp)            // a0
+    sw   x11, 10*4(sp)            // a1
+    sw   x12, 11*4(sp)            // a2
+    sw   x13, 12*4(sp)            // a3
+    sw   x14, 13*4(sp)            // a4
+    sw   x15, 14*4(sp)            // a5
+    sw   x16, 15*4(sp)            // a6
+    sw   x17, 16*4(sp)            // a7
+    sw   x18, 17*4(sp)            // s2
+    sw   x19, 18*4(sp)            // s3
+    sw   x20, 19*4(sp)            // s4
+    sw   x21, 20*4(sp)            // s5
+    sw   x22, 21*4(sp)            // s6
+    sw   x23, 22*4(sp)            // s7
+    sw   x24, 23*4(sp)            // s8
+    sw   x25, 24*4(sp)            // s9
+    sw   x26, 25*4(sp)            // s10
+    sw   x27, 26*4(sp)            // s11
+    sw   x28, 27*4(sp)            // t3
+    sw   x29, 28*4(sp)            // t4
+    sw   x30, 29*4(sp)            // t5
+    sw   x31, 30*4(sp)            // t6
 
-          // At this point, we can restore s0 into our stack pointer:
-          mv   sp, s0
+    // At this point, we can restore s0 into our stack pointer:
+    mv   sp, s0
 
-          // Now retrieve the original value of s1 and save that as well. We
-          // must not clobber s1, our per-process stored state pointer.
-          lw   s0,  0*4(sp)         // s0 = app s1 (from trap handler scratch space)
-          sw   s0,  8*4(s1)         // Save app s1 to per-process state
+    // Now retrieve the original value of s1 and save that as well. We
+    // must not clobber s1, our per-process stored state pointer.
+    lw   s0,  0*4(sp)             // s0 = app s1 (from trap handler scratch space)
+    sw   s0,  8*4(s1)             // Save app s1 to per-process state
 
-          // Retrieve the original value of s0 from the mscratch CSR, save it.
-          //
-          // This will also restore the kernel trap handler by writing zero to
-          // the CSR. `csrrw` allows us to read and write the CSR in a single
-          // instruction:
-          csrrw s0, mscratch, zero  // s0 <- mscratch[app s0] <- zero
-          sw    s0, 7*4(s1)         // Save app s0 to per-process state
+    // Retrieve the original value of s0 from the mscratch CSR, save it.
+    //
+    // This will also restore the kernel trap handler by writing zero to
+    // the CSR. `csrrw` allows us to read and write the CSR in a single
+    // instruction:
+    csrrw s0, mscratch, zero      // s0 <- mscratch[app s0] <- zero
+    sw    s0, 7*4(s1)             // Save app s0 to per-process state
 
-          // -------------------------------------------------------------------
-          // At this point, the entire app register file is saved. We also
-          // restored the kernel trap handler. We have restored the following
-          // kernel registers:
-          //
-          // - sp: kernel stack pointer
-          // - s1: per-process stored state pointer
-          //
-          // We avoid clobbering those registers from this point onward.
-          // -------------------------------------------------------------------
+    // -------------------------------------------------------------------
+    // At this point, the entire app register file is saved. We also
+    // restored the kernel trap handler. We have restored the following
+    // kernel registers:
+    //
+    // - sp: kernel stack pointer
+    // - s1: per-process stored state pointer
+    //
+    // We avoid clobbering those registers from this point onward.
+    // -------------------------------------------------------------------
 
-          // We also need to store some other information about the trap reason,
-          // present in CSRs:
-          //
-          // - the app's PC (mepc),
-          // - the trap reason (mcause),
-          // - the trap 'value' (mtval, e.g., faulting address).
-          //
-          // We need to store mcause because we use that to determine why the
-          // app stopped executing and returned to the kernel. We store mepc
-          // because it is where we need to return to in the app at some
-          // point. We need to store mtval in case the app faulted and we need
-          // mtval to help with debugging.
-          //
-          // We use `s0` as a scratch register, as it fits into the 3-bit
-          // register argument of RISC-V compressed loads / stores:
+    // We also need to store some other information about the trap reason,
+    // present in CSRs:
+    //
+    // - the app's PC (mepc),
+    // - the trap reason (mcause),
+    // - the trap 'value' (mtval, e.g., faulting address).
+    //
+    // We need to store mcause because we use that to determine why the
+    // app stopped executing and returned to the kernel. We store mepc
+    // because it is where we need to return to in the app at some
+    // point. We need to store mtval in case the app faulted and we need
+    // mtval to help with debugging.
+    //
+    // We use `s0` as a scratch register, as it fits into the 3-bit
+    // register argument of RISC-V compressed loads / stores:
 
-          // Save the PC to the stored state struct. We also load the address
-          // of _return_to_kernel into it, as this will be where we jump on
-          // the mret instruction, which leaves the trap handler.
-          la    s0, 300f            // Load _return_to_kernel into t0.
-          csrrw s0, mepc, s0        // s0 <- mepc[app pc] <- _return_to_kernel
-          sw    s0, 31*4(s1)        // Store app's pc in stored state struct.
+    // Save the PC to the stored state struct. We also load the address
+    // of _return_to_kernel into it, as this will be where we jump on
+    // the mret instruction, which leaves the trap handler.
+    la    s0, 300f                // Load _return_to_kernel into t0.
+    csrrw s0, mepc, s0            // s0 <- mepc[app pc] <- _return_to_kernel
+    sw    s0, 31*4(s1)            // Store app's pc in stored state struct.
 
-          // Save mtval to the stored state struct
-          csrr  s0, mtval
-          sw    s0, 33*4(s1)
+    // Save mtval to the stored state struct
+    csrr  s0, mtval
+    sw    s0, 33*4(s1)
 
-          // Save mcause and leave it loaded into a0, as we call a function
-          // with it below:
-          csrr  a0, mcause
-          sw    a0, 32*4(s1)
+    // Save mcause and leave it loaded into a0, as we call a function
+    // with it below:
+    csrr  a0, mcause
+    sw    a0, 32*4(s1)
 
-          // Depending on the value of a0, we might be calling into a function
-          // while still in the trap handler. The callee may rely on the `gp`,
-          // `tp`, and `fp` (s0) registers to be set correctly. Thus we restore
-          // them here, as we need to do anyways. They are saved registers,
-          // and so we avoid clobbering them beyond this point.
-          //
-          // We do not restore `s1`, as we need to move it back into `a0`
-          // _after_ potentially invoking the _disable_interrupt_... function.
-          // LLVM relies on it to not be clobbered internally, but it is not
-          // part of the RISC-V C ABI, which we need to follow here.
-          //
-          lw    x8, 5*4(sp)         // fp/s0: Restore the frame pointer
-          lw    x4, 4*4(sp)         // tp: Restore the thread pointer
-          lw    x3, 3*4(sp)         // gp: Restore the global pointer
+    // Depending on the value of a0, we might be calling into a function
+    // while still in the trap handler. The callee may rely on the `gp`,
+    // `tp`, and `fp` (s0) registers to be set correctly. Thus we restore
+    // them here, as we need to do anyways. They are saved registers,
+    // and so we avoid clobbering them beyond this point.
+    //
+    // We do not restore `s1`, as we need to move it back into `a0`
+    // _after_ potentially invoking the _disable_interrupt_... function.
+    // LLVM relies on it to not be clobbered internally, but it is not
+    // part of the RISC-V C ABI, which we need to follow here.
+    //
+    lw    x8, 5*4(sp)             // fp/s0: Restore the frame pointer
+    lw    x4, 4*4(sp)             // tp: Restore the thread pointer
+    lw    x3, 3*4(sp)             // gp: Restore the global pointer
 
-          // --------------------------------------------------------------------
-          // From this point onward, avoid clobbering the following registers:
-          //
-          // - x2 / sp: kernel stack pointer
-          // - x3 / gp: kernel global pointer
-          // - x4 / tp: kernel thread pointer
-          // - x8 / s0 / fp: kernel frame pointer
-          // - x9 / s1: per-process stored state pointer
-          //
-          // --------------------------------------------------------------------
+    // --------------------------------------------------------------------
+    // From this point onward, avoid clobbering the following registers:
+    //
+    // - x2 / sp: kernel stack pointer
+    // - x3 / gp: kernel global pointer
+    // - x4 / tp: kernel thread pointer
+    // - x8 / s0 / fp: kernel frame pointer
+    // - x9 / s1: per-process stored state pointer
+    //
+    // --------------------------------------------------------------------
 
-          // Now we need to check if this was an interrupt, and if it was,
-          // then we need to disable the interrupt before returning from this
-          // trap handler so that it does not fire again.
-          //
-          // If mcause is greater than or equal to zero this was not an
-          // interrupt (i.e. the most significant bit is not 1). In this case,
-          // jump to _start_app_trap_continue.
-          bge   a0, zero, 200f
+    // Now we need to check if this was an interrupt, and if it was,
+    // then we need to disable the interrupt before returning from this
+    // trap handler so that it does not fire again.
+    //
+    // If mcause is greater than or equal to zero this was not an
+    // interrupt (i.e. the most significant bit is not 1). In this case,
+    // jump to _start_app_trap_continue.
+    bge   a0, zero, 200f
 
-          // This was an interrupt. Call the interrupt disable function, with
-          // mcause already loaded in a0.
-          //
-          // This may clobber all caller-saved registers. However, at this
-          // stage, we only restored `sp`, `s1`, and the registers above, all of
-          // which are saved. Thus we don't have to worry about the function
-          // call clobbering these registers.
-          //
-          // However, before we can execute any Rust code within a trap handler
-          // context, we must set the hart-specific 'are we in a trap handler'
-          // flag as an offset to the `_trap_handler_active` symbol. The chip
-          // crate is responsible for defining this symbol, and ensuring it is
-          // large enough to fit `max(mhartid) * MXLEN` bytes.
-          //
-          // First, calculate its address and save it in a callee-saved
-          // register. We use `s2`: the app's `s2` has already been saved, and
-          // its not one of the register's we've already restored:
-          la   s2, _trap_handler_active // s2 = addr(_trap_handler_active)
-          csrr t0, mhartid              // t0 = hartid
-          slli t0, t0, 2                // t0 = t0 * 4
-          add  s2, s2, t0               // s2 = addr(_trap_handler_active[hartid])
+    // This was an interrupt. Call the interrupt disable function, with
+    // mcause already loaded in a0.
+    //
+    // This may clobber all caller-saved registers. However, at this
+    // stage, we only restored `sp`, `s1`, and the registers above, all of
+    // which are saved. Thus we don't have to worry about the function
+    // call clobbering these registers.
+    //
+    // However, before we can execute any Rust code within a trap handler
+    // context, we must set the hart-specific 'are we in a trap handler'
+    // flag as an offset to the `_trap_handler_active` symbol. The chip
+    // crate is responsible for defining this symbol, and ensuring it is
+    // large enough to fit `max(mhartid) * MXLEN` bytes.
+    //
+    // First, calculate its address and save it in a callee-saved
+    // register. We use `s2`: the app's `s2` has already been saved, and
+    // its not one of the register's we've already restored:
+    la   s2, _trap_handler_active // s2 = addr(_trap_handler_active)
+    csrr t0, mhartid              // t0 = hartid
+    slli t0, t0, 2                // t0 = t0 * 4
+    add  s2, s2, t0               // s2 = addr(_trap_handler_active[hartid])
 
-          // Indicate that we are in a trap handler on this hart:
-          li   t0, 1
-          sw   t0, 0(s2)
+    // Indicate that we are in a trap handler on this hart:
+    li   t0, 1
+    sw   t0, 0(s2)
 
-          jal  ra, _disable_interrupt_trap_rust_from_app
+    jal  ra, _disable_interrupt_trap_rust_from_app
 
-          // Indicate that we are no longer going to be in a trap handler on
-          // this hart:
-          sw   x0, 0(s2)
+    // Indicate that we are no longer going to be in a trap handler on
+    // this hart:
+    sw   x0, 0(s2)
 
-        200: // _start_app_trap_continue
+200: // _start_app_trap_continue
 
-          // Need to set mstatus.MPP to 0b11 so that we stay in machine mode.
-          //
-          // We use `a0` as a scratch register, as we are allowed to clobber it
-          // here, and it fits into a compressed load instruction. We must avoid
-          // using restored saved registers like `s0`, etc.
-          //
-          li    a0, 0x1800          // Load 0b11 to the MPP bits location in a0
-          csrs  mstatus, a0         // mstatus |= a0
+    // Need to set mstatus.MPP to 0b11 so that we stay in machine mode.
+    //
+    // We use `a0` as a scratch register, as we are allowed to clobber it
+    // here, and it fits into a compressed load instruction. We must avoid
+    // using restored saved registers like `s0`, etc.
+    //
+    li    a0, 0x1800              // Load 0b11 to the MPP bits location in a0
+    csrs  mstatus, a0             // mstatus |= a0
 
-          // Use mret to exit the trap handler and return to the context
-          // switching code. We loaded the address of _return_to_kernel
-          // into mepc above.
-          mret
+    // Use mret to exit the trap handler and return to the context
+    // switching code. We loaded the address of _return_to_kernel
+    // into mepc above.
+    mret
 
-          // This is where the trap handler jumps back to after the app stops
-          // executing.
-        300: // _return_to_kernel
+    // This is where the trap handler jumps back to after the app stops
+    // executing.
+300: // _return_to_kernel
 
-          // We have already stored the app registers in the trap handler. We
-          // have further restored `gp`, `tp`, `fp`/`s0` and the stack pointer.
-          //
-          // The only other non-clobbered registers are `s1` and `a0`, where
-          // `a0` needs to hold the per-process state pointer currently stored
-          // in `s1`, and the original value of `s1` is saved on the stack.
-          // Restore them:
-          //
-          mv    a0, s1              // a0 = per-process stored state
-          lw    s1, 6*4(sp)         // restore s1 (used by LLVM internally)
+    // We have already stored the app registers in the trap handler. We
+    // have further restored `gp`, `tp`, `fp`/`s0` and the stack pointer.
+    //
+    // The only other non-clobbered registers are `s1` and `a0`, where
+    // `a0` needs to hold the per-process state pointer currently stored
+    // in `s1`, and the original value of `s1` is saved on the stack.
+    // Restore them:
+    //
+    mv    a0, s1                  // a0 = per-process stored state
+    lw    s1, 6*4(sp)             // restore s1 (used by LLVM internally)
 
-          // We need thus need to mark all registers as clobbered, except:
-          //
-          // - x2  (sp)
-          // - x3  (gp)
-          // - x4  (tp)
-          // - x8  (fp)
-          // - x9  (s1)
-          // - x10 (a0)
+    // We need thus need to mark all registers as clobbered, except:
+    //
+    // - x2  (sp)
+    // - x3  (gp)
+    // - x4  (tp)
+    // - x8  (fp)
+    // - x9  (s1)
+    // - x10 (a0)
 
-          addi sp, sp, 8*4   // Reset kernel stack pointer
-        ",
+    addi sp, sp, 8*4              // Reset kernel stack pointer
+            ",
 
             // We pass the per-process state struct in a register we are allowed
             // to clobber (not s0 or s1), but still fits into 3-bit register

--- a/arch/riscv/src/thread_id.rs
+++ b/arch/riscv/src/thread_id.rs
@@ -15,74 +15,74 @@ pub enum RiscvThreadIdProvider {}
 // return the thread ID. On single-core platforms the thread ID only depends on
 // whether execution is in an interrupt service routine or not, which is what
 // this implementation checks for.
+#[cfg(all(target_arch = "riscv32", target_os = "none"))]
 unsafe impl ThreadIdProvider for RiscvThreadIdProvider {
     /// Return the current thread ID, computed using the `mhartid` (hardware thread
     /// ID), and a flag indicating whether the current hart is currently in a trap
     /// handler context.
     fn running_thread_id() -> usize {
-        // Mock implementation for non-rv32 target builds:
-        #[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
-        {
-            unimplemented!()
+        let hartid: usize;
+        let trap_handler_active_addr: *mut usize;
+
+        // # Safety
+        //
+        // This does not read any memory by itself, it merely loads a symbol
+        // address and reads the `mhartid` CSR:
+        unsafe {
+            core::arch::asm!(
+                "
+    // Determine the hart id and save in the appropriate output register.
+    csrr {hartid_reg}, mhartid    // hartid_reg = hartid
+    // Load the `_trap_handler_active` symbol address.
+    la {trap_handler_active_addr_reg}, _trap_handler_active // trap_handler_active_addr = &_trap_handler_active
+                ",
+                hartid_reg = out(reg) hartid,
+                trap_handler_active_addr_reg = out(reg) trap_handler_active_addr,
+                options(
+                // The assembly code has no side effects, must eventually
+                // return, and its outputs depend only on its direct inputs
+                // (i.e. the values themselves, not what they point to) or
+                // values read from memory (unless the nomem options is also
+                // set).
+                pure,
+                // The assembly code does not read from or write to any memory
+                // accessible outside of the assembly code.
+                nomem,
+                // The assembly code does not modify the flags register (for
+                // RISC-V: `fflags`, `vtype`, `vl`, or `vcsr`).
+                preserves_flags,
+                // The assembly code does not push data to the stack, or write
+                // to the stack red-zone (if supported by the target).
+                nostack,
+                ),
+            );
         }
 
-        // Proper rv32i-specific implementation:
-        #[cfg(all(target_arch = "riscv32", target_os = "none"))]
-        {
-            let hartid: usize;
-            let trap_handler_active_addr: *mut usize;
+        // Load the hart's trap_handler_active value.
+        //
+        // # Safety
+        //
+        // `hartid` * core::mem::size_of::<usize>() must fit into an `isize`. By
+        // allocating the `_trap_handler_active` array, the chip crate ensures
+        // that this array can fit all hart IDs for all harts on the target
+        // machine. The maximum size of any Rust allocation is `isize::MAX`
+        // bytes, and as such, by allocating this array in the first place, the
+        // chip crate maintains that indexing into it with `hartid` must stay in
+        // this object, and an index of `hartid` elements will not produce an
+        // offset larger than `isize::MAX` bytes.
+        let hart_trap_handler_active =
+            unsafe { core::ptr::read(trap_handler_active_addr.add(hartid)) };
 
-            // Safety:
-            //
-            // This does not read any memory by itself, it merely loads a symbol
-            // address and reads the `mhartid` CSR:
-            unsafe {
-                core::arch::asm!(
-                    // Determine the hart id and save in the appropriate output
-                    // register:
-                    "csrr {hartid_reg}, mhartid",
-                    // Load the `_trap_handler_active` symbol address:
-                    "la {trap_handler_active_addr_reg}, _trap_handler_active",
-                    hartid_reg = out(reg) hartid,
-                    trap_handler_active_addr_reg = out(reg) trap_handler_active_addr,
-                    options(
-                    // The assembly code has no side effects, must eventually
-                    // return, and its outputs depend only on its direct inputs
-                    // (i.e. the values themselves, not what they point to) or
-                    // values read from memory (unless the nomem options is also
-                    // set).
-                    pure,
-                    // The assembly code does not read from or write to any memory
-                    // accessible outside of the assembly code.
-                    nomem,
-                    // The assembly code does not modify the flags register (for
-                    // RISC-V: `fflags`, `vtype`, `vl`, or `vcsr`).
-                    preserves_flags,
-                    // The assembly code does not push data to the stack, or write
-                    // to the stack red-zone (if supported by the target).
-                    nostack,
-                    ),
-                );
-            }
+        // Determine the thread ID as a combination of the hart id, and whether
+        // it is currently in a trap handler context:
+        hartid.overflowing_shl(1).0 | ((hart_trap_handler_active != 0) as usize)
+    }
+}
 
-            // Load the hart's trap_handler_active value.
-            //
-            // Safety:
-            //
-            // `hartid` * core::mem::size_of::<usize>() must fit into an `isize`. By
-            // allocating the `_trap_handler_active` array, the chip crate ensures
-            // that this array can fit all hart IDs for all harts on the target
-            // machine. The maximum size of any Rust allocation is `isize::MAX`
-            // bytes, and as such, by allocating this arrary in the first place, the
-            // chip crate maintains that indexing into it with `hartid` must stay in
-            // this object, and an index of `hartid` elements will not produce an
-            // offset larger than `isize::MAX` bytes.
-            let hart_trap_handler_active =
-                unsafe { core::ptr::read(trap_handler_active_addr.add(hartid)) };
-
-            // Determine the thread ID as a combination of the hart id, and whether
-            // it is currently in a trap handler context:
-            hartid.overflowing_shl(1).0 | ((hart_trap_handler_active != 0) as usize)
-        }
+// Mock implementation for non-rv32 target builds
+#[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
+unsafe impl ThreadIdProvider for RiscvThreadIdProvider {
+    fn running_thread_id() -> usize {
+        unimplemented!()
     }
 }


### PR DESCRIPTION
### Pull Request Overview

Looking at the riscv crate for an effort to make it rv32 and rv64 has inspired an update pass.

Each commit should be self contained.

The changes should be ALMOST entirely stylistic:

- Adding comments
- Formatting assembly and comments
- Fixing spelling
- Simplifying code
- Making cfg structure the same in the crate

I made no changes to the syscall assembly or assembly comments, other than whitespace movements. This prepares it for the lx/sx conversion.

The actual operative change is to support.rs to make `wfi()` and `nop()` available on rv64.

### Testing Strategy

n/a


### TODO or Help Wanted

If someone knows that nop/wfi are not correct on rv64 then we need to revisit that.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.

Claude explained the semihosting asm code to me. I wrote the comments.