### PR TITLE
kernel: process: error: support any Ok type

### DIFF
--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -917,8 +917,8 @@ pub enum Error {
     AlreadyInUse,
 }
 
-impl From<Error> for Result<(), ErrorCode> {
-    fn from(err: Error) -> Result<(), ErrorCode> {
+impl<T> From<Error> for Result<T, ErrorCode> {
+    fn from(err: Error) -> Result<T, ErrorCode> {
         match err {
             Error::OutOfMemory => Err(ErrorCode::NOMEM),
             Error::AddressOutOfBounds => Err(ErrorCode::INVAL),


### PR DESCRIPTION
### Pull Request Overview

I was writing a capsule and wanted to use a `Result<bool, ErrorCode>` from within a grant. Since a grant failure returns `Process::Error`, without this more general conversion, the `.unwrap_or_else(|err| err.into())` trick doesn't work.


### Testing Strategy

Compiling.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
