### PR TITLE
nrf5x: Re-write AES driver to use DmaSlice, create nrf5x-unsafe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1082,6 +1082,15 @@ version = "0.2.3-dev"
 dependencies = [
  "enum_primitive",
  "kernel",
+ "nrf5x-unsafe",
+]
+
+[[package]]
+name = "nrf5x-unsafe"
+version = "0.2.3-dev"
+dependencies = [
+ "cortexm4f",
+ "kernel",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ members = [
     "chips/nrf52833",
     "chips/nrf52840",
     "chips/nrf5x",
+    "chips/nrf5x-unsafe",
     "chips/pci-x86",
     "chips/x86_q35",
     "chips/qemu_rv32_virt_chip",

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -276,10 +276,11 @@ unsafe fn start() -> (
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
     );
 
     // set up circular peripheral dependencies

--- a/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
@@ -249,10 +249,11 @@ unsafe fn start() -> (
         [u8; nrf52833::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52833::ieee802154_radio::ACK_BUF_SIZE]
     );
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
     // Initialize chip peripheral drivers
     let nrf52833_peripherals = static_init!(
         Nrf52833DefaultPeripherals,
-        Nrf52833DefaultPeripherals::new(ieee802154_ack_buf)
+        Nrf52833DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
     );
 
     // set up circular peripheral dependencies

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-base/src/lib.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-base/src/lib.rs
@@ -92,10 +92,11 @@ unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'stati
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
     );
 
     nrf52840_peripherals

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
@@ -123,10 +123,11 @@ unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'stati
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
     );
 
     nrf52840_peripherals

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/main.rs
@@ -114,10 +114,11 @@ unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'stati
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
     );
 
     nrf52840_peripherals

--- a/boards/makepython-nrf52840/src/main.rs
+++ b/boards/makepython-nrf52840/src/main.rs
@@ -243,11 +243,12 @@ pub unsafe fn start() -> (
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
 
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
     );
 
     // set up circular peripheral dependencies

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -233,10 +233,11 @@ unsafe fn start() -> (
         [u8; nrf52833::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52833::ieee802154_radio::ACK_BUF_SIZE]
     );
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
     // Initialize chip peripheral drivers
     let nrf52833_peripherals = static_init!(
         Nrf52833DefaultPeripherals,
-        Nrf52833DefaultPeripherals::new(ieee802154_ack_buf)
+        Nrf52833DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
     );
 
     // set up circular peripheral dependencies

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -253,11 +253,12 @@ pub unsafe fn start() -> (
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
 
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
     );
 
     // set up circular peripheral dependencies

--- a/boards/nano33ble_rev2/src/main.rs
+++ b/boards/nano33ble_rev2/src/main.rs
@@ -259,11 +259,12 @@ pub unsafe fn start() -> (
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
 
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
     );
 
     // set up circular peripheral dependencies

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -201,10 +201,11 @@ pub unsafe fn start() -> (
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
     );
 
     // set up circular peripheral dependencies

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -422,10 +422,11 @@ pub unsafe fn start_no_pconsole() -> (
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
     );
 
     // Set up circular peripheral dependencies.

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -251,9 +251,10 @@ pub unsafe fn start() -> (
             PanicResources::new(),
         );
 
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
     let nrf52832_peripherals = static_init!(
         Nrf52832DefaultPeripherals,
-        Nrf52832DefaultPeripherals::new()
+        Nrf52832DefaultPeripherals::new(aes_ecb_buf)
     );
 
     // set up circular peripheral dependencies

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -193,10 +193,11 @@ unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'stati
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
     );
 
     nrf52840_peripherals

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -205,10 +205,11 @@ pub unsafe fn start() -> (
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
     );
 
     // set up circular peripheral dependencies

--- a/boards/wm1110dev/src/main.rs
+++ b/boards/wm1110dev/src/main.rs
@@ -215,11 +215,12 @@ pub unsafe fn start() -> (
         [u8; nrf52840::ieee802154_radio::ACK_BUF_SIZE],
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
+    let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
 
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
     );
 
     // set up circular peripheral dependencies

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -81,6 +81,12 @@ impl Nrf52DefaultPeripherals<'_> {
         // # Safety
         //
         // This must only get constructed once.
+        //
+        // TODO: As of June 2026, we just assume peripherals are only created
+        // once and this is the only call to the AES manager constructor.
+        // However, once we have a strategy for enforcing the only-once
+        // constraint, we need to update this to use that so we can properly
+        // enforce this safety requirement.
         let aes_registers = unsafe { crate::aes::AesEcbRegistersManager::new(AESECB_BASE) };
 
         Self {

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -13,6 +13,9 @@ use kernel::utilities::StaticRef;
 // Peripheral Registers Instantiations
 //
 
+const AESECB_BASE: StaticRef<crate::aes::AesEcbRegisters> =
+    unsafe { StaticRef::new(0x4000E000 as *const crate::aes::AesEcbRegisters) };
+
 const RTC1_BASE: StaticRef<crate::rtc::RtcRegisters> =
     unsafe { StaticRef::new(0x40011000 as *const crate::rtc::RtcRegisters) };
 
@@ -74,10 +77,15 @@ pub struct Nrf52DefaultPeripherals<'a> {
 }
 
 impl Nrf52DefaultPeripherals<'_> {
-    pub fn new() -> Self {
+    pub fn new(aes_ecb_buffer: &'static mut [u8; 48]) -> Self {
+        // # Safety
+        //
+        // This must only get constructed once.
+        let aes_registers = unsafe { crate::aes::AesEcbRegistersManager::new(AESECB_BASE) };
+
         Self {
             acomp: crate::acomp::Comparator::new(),
-            ecb: crate::aes::AesECB::new(),
+            ecb: crate::aes::AesECB::new(aes_registers, aes_ecb_buffer),
             pwr_clk: crate::power::Power::new(),
             ble_radio: crate::ble_radio::Radio::new(),
             trng: crate::trng::Trng::new(RNG_BASE),

--- a/chips/nrf52832/src/interrupt_service.rs
+++ b/chips/nrf52832/src/interrupt_service.rs
@@ -14,9 +14,9 @@ pub struct Nrf52832DefaultPeripherals<'a> {
     pub gpio_port: crate::gpio::Port<'a, { crate::gpio::NUM_PINS }>,
 }
 impl Nrf52832DefaultPeripherals<'_> {
-    pub unsafe fn new() -> Self {
+    pub unsafe fn new(aes_ecb_buf: &'static mut [u8; 48]) -> Self {
         Self {
-            nrf52: Nrf52DefaultPeripherals::new(),
+            nrf52: Nrf52DefaultPeripherals::new(aes_ecb_buf),
             gpio_port: crate::gpio::nrf52832_gpio_create(),
         }
     }

--- a/chips/nrf52833/src/interrupt_service.rs
+++ b/chips/nrf52833/src/interrupt_service.rs
@@ -18,9 +18,10 @@ pub struct Nrf52833DefaultPeripherals<'a> {
 impl Nrf52833DefaultPeripherals<'_> {
     pub unsafe fn new(
         ieee802154_radio_ack_buf: &'static mut [u8; crate::ieee802154_radio::ACK_BUF_SIZE],
+        aes_ecb_buf: &'static mut [u8; 48],
     ) -> Self {
         Self {
-            nrf52: Nrf52DefaultPeripherals::new(),
+            nrf52: Nrf52DefaultPeripherals::new(aes_ecb_buf),
             ieee802154_radio: crate::ieee802154_radio::Radio::new(ieee802154_radio_ack_buf),
             gpio_port: crate::gpio::nrf52833_gpio_create(),
         }

--- a/chips/nrf52840/src/interrupt_service.rs
+++ b/chips/nrf52840/src/interrupt_service.rs
@@ -23,9 +23,10 @@ pub struct Nrf52840DefaultPeripherals<'a> {
 impl Nrf52840DefaultPeripherals<'_> {
     pub unsafe fn new(
         ieee802154_radio_ack_buf: &'static mut [u8; crate::ieee802154_radio::ACK_BUF_SIZE],
+        aes_ecb_buf: &'static mut [u8; 48],
     ) -> Self {
         Self {
-            nrf52: Nrf52DefaultPeripherals::new(),
+            nrf52: Nrf52DefaultPeripherals::new(aes_ecb_buf),
             ieee802154_radio: crate::ieee802154_radio::Radio::new(ieee802154_radio_ack_buf),
             usbd: crate::usbd::Usbd::new(),
             gpio_port: crate::gpio::nrf52840_gpio_create(),

--- a/chips/nrf5x-unsafe/Cargo.toml
+++ b/chips/nrf5x-unsafe/Cargo.toml
@@ -1,23 +1,16 @@
 # Licensed under the Apache License, Version 2.0 or the MIT License.
 # SPDX-License-Identifier: Apache-2.0 OR MIT
-# Copyright Tock Contributors 2022.
+# Copyright Tock Contributors 2026.
 
 [package]
-name = "nrf5x"
+name = "nrf5x-unsafe"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-nrf5x-unsafe = { path = "../nrf5x-unsafe" }
+cortexm4f = { path = "../../arch/cortex-m4f" }
 kernel = { path = "../../kernel" }
-enum_primitive = { path = "../../libraries/enum_primitive" }
-
-[features]
-default = []
-
-nrf51 = []
-nrf52 = []
 
 [lints]
 workspace = true

--- a/chips/nrf5x-unsafe/README.md
+++ b/chips/nrf5x-unsafe/README.md
@@ -1,0 +1,3 @@
+# Nordic Semiconductor nRF5X Series SoC - Unsafe
+
+This contains the `unsafe` code for the nrf5x chip.

--- a/chips/nrf5x-unsafe/src/aes.rs
+++ b/chips/nrf5x-unsafe/src/aes.rs
@@ -79,6 +79,13 @@ pub struct AesEcbRegistersManager {
 }
 
 impl AesEcbRegistersManager {
+    /// Create a new AES registers manager.
+    ///
+    /// # Safety
+    ///
+    /// This is only valid on an nrf5x-based MCU. This must only be called once
+    /// as having multiple interfaces to DMA registers is not safe. This must
+    /// be the only way the AES DMA registers are controlled.
     pub unsafe fn new(regs: StaticRef<AesEcbRegisters>) -> Self {
         Self {
             registers: regs,

--- a/chips/nrf5x-unsafe/src/aes.rs
+++ b/chips/nrf5x-unsafe/src/aes.rs
@@ -1,0 +1,156 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+
+//! AES128 driver, nRF5X-family, unsafe code
+
+use kernel::utilities::StaticRef;
+use kernel::utilities::cells::MapCell;
+use kernel::utilities::dma_slice::DmaSliceMut;
+use kernel::utilities::registers::interfaces::Writeable;
+use kernel::utilities::registers::{ReadWrite, WriteOnly, register_bitfields};
+
+#[repr(C)]
+pub struct AesEcbRegisters {
+    /// Start ECB block encrypt
+    /// - Address 0x000 - 0x004
+    task_startecb: WriteOnly<u32, Task::Register>,
+    /// Abort a possible executing ECB operation
+    /// - Address: 0x004 - 0x008
+    task_stopecb: WriteOnly<u32, Task::Register>,
+    /// Reserved
+    _reserved1: [u32; 62],
+    /// ECB block encrypt complete
+    /// - Address: 0x100 - 0x104
+    pub event_endecb: ReadWrite<u32, Event::Register>,
+    /// ECB block encrypt aborted because of a STOPECB task or due to an error
+    /// - Address: 0x104 - 0x108
+    pub event_errorecb: ReadWrite<u32, Event::Register>,
+    /// Reserved
+    _reserved2: [u32; 127],
+    /// Enable interrupt
+    /// - Address: 0x304 - 0x308
+    pub intenset: ReadWrite<u32, Intenset::Register>,
+    /// Disable interrupt
+    /// - Address: 0x308 - 0x30c
+    pub intenclr: ReadWrite<u32, Intenclr::Register>,
+    /// Reserved
+    _reserved3: [u32; 126],
+    /// ECB block encrypt memory pointers
+    /// - Address: 0x504 - 0x508
+    ecbdataptr: ReadWrite<u32, EcbDataPointer::Register>,
+}
+
+register_bitfields! [u32,
+    /// Start task
+    pub Task [
+        ENABLE OFFSET(0) NUMBITS(1)
+    ],
+
+    /// Read event
+    pub Event [
+        READY OFFSET(0) NUMBITS(1)
+    ],
+
+    /// Enabled interrupt
+    pub Intenset [
+        ENDECB OFFSET(0) NUMBITS(1),
+        ERRORECB OFFSET(1) NUMBITS(1)
+    ],
+
+    /// Disable interrupt
+    pub Intenclr [
+        ENDECB OFFSET(0) NUMBITS(1),
+        ERRORECB OFFSET(1) NUMBITS(1)
+    ],
+
+    /// ECB block encrypt memory pointers
+    EcbDataPointer [
+        POINTER OFFSET(0) NUMBITS(32)
+    ]
+];
+
+/// Wrapper for managing MMIO for the AES ECB peripheral.
+pub struct AesEcbRegistersManager {
+    /// MMIO registers for the AES ECB peripheral.
+    pub registers: StaticRef<AesEcbRegisters>,
+    /// Holding place for the DMA buffer while DMA is in progress.
+    dma_buf: MapCell<DmaSliceMut<'static, u8>>,
+}
+
+impl AesEcbRegistersManager {
+    pub unsafe fn new(regs: StaticRef<AesEcbRegisters>) -> Self {
+        Self {
+            registers: regs,
+            dma_buf: MapCell::empty(),
+        }
+    }
+
+    /// Start an ECB encryption with DMA.
+    ///
+    /// The buffer must cover the full 48-byte ECB data block:
+    /// bytes 0–15 = key, bytes 16–31 = plaintext/counter, bytes 32–47 = ciphertext output.
+    ///
+    /// # Return
+    ///
+    /// `Ok(())` on successfully starting the DMA operation. `Err(())` if DMA
+    /// is already busy.
+    pub fn start_ecb_dma(&self, buf: &'static mut [u8]) -> Result<(), ()> {
+        if self.dma_pending() {
+            return Err(());
+        }
+
+        // To create a DmaFence we must trust the implementation.
+        //
+        // # Safety
+        //
+        // The architecture-provided version is correct for the nRF52.
+        let fence = unsafe { cortexm4f::dma_fence::CortexMDmaFence::new() };
+
+        // Create DmaSubSliceMut for the ECB data buffer. This ensures that we
+        // can soundly share it with the DMA hardware.
+        let ecb_dma_slice = DmaSliceMut::new_static(buf, fence);
+
+        // Provide the buffer pointer to the ECB hardware. The hardware expects
+        // the pointer to point at byte 0 of the 48-byte data block (the key).
+        // The SubSliceMut covers the full ecb_data buffer (never sliced), so
+        // as_mut_ptr() correctly points to byte 0.
+        self.registers
+            .ecbdataptr
+            .write(EcbDataPointer::POINTER.val(ecb_dma_slice.as_mut_ptr() as u32));
+
+        // Save the DmaSubSliceMut while the DMA operation executes.
+        self.dma_buf.replace(ecb_dma_slice);
+
+        // Clear the end event and start the ECB task.
+        self.registers.event_endecb.write(Event::READY::CLEAR);
+        self.registers.task_startecb.write(Task::ENABLE::SET);
+
+        Ok(())
+    }
+
+    pub fn finish_ecb_dma(&self) -> Option<&'static mut [u8]> {
+        // Clear the end event before releasing the buffer.
+        self.registers.event_endecb.write(Event::READY::CLEAR);
+
+        self.dma_buf.take().map(|dma_slice| {
+            // To create a DmaFence we must trust the implementation.
+            //
+            // # Safety
+            //
+            // The architecture-provided version is correct for the nRF52.
+            let fence = unsafe { cortexm4f::dma_fence::CortexMDmaFence::new() };
+
+            // # Safety
+            //
+            // We must ensure that the DMA hardware no longer has any access to
+            // this buffer. We ensure that by clearing `event_endecb` above;
+            // the hardware sets this event only after completing the operation.
+            unsafe { dma_slice.take(fence) }
+        })
+    }
+
+    pub fn dma_pending(&self) -> bool {
+        self.dma_buf.is_some()
+    }
+}

--- a/chips/nrf5x-unsafe/src/lib.rs
+++ b/chips/nrf5x-unsafe/src/lib.rs
@@ -1,0 +1,7 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+#![no_std]
+
+pub mod aes;

--- a/chips/nrf5x/src/aes.rs
+++ b/chips/nrf5x/src/aes.rs
@@ -24,11 +24,6 @@
 //! ### Payload
 //! Data to be encrypted or decrypted it is XOR:ed with the generated keystream
 //!
-//! ### Things to highlight that can be improved:
-//!
-//! * ECB_DATA must be a static mut \[u8\] and can't be located in the struct
-//! * PAYLOAD size is restricted to 128 bytes
-//!
 //! Authors
 //! --------
 //! * Niklas Adolfsson <niklasadolfsson1@gmail.com>
@@ -36,94 +31,17 @@
 //! * Date: April 21, 2017
 
 use core::cell::Cell;
-use core::ptr::addr_of;
 use kernel::ErrorCode;
 use kernel::hil::symmetric_encryption;
-use kernel::utilities::StaticRef;
-use kernel::utilities::cells::OptionalCell;
-use kernel::utilities::cells::TakeCell;
+use kernel::utilities::cells::{MapCell, OptionalCell};
+use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
-use kernel::utilities::registers::{ReadWrite, WriteOnly, register_bitfields};
+pub use nrf5x_unsafe::aes::AesEcbRegisters;
+pub use nrf5x_unsafe::aes::AesEcbRegistersManager;
 
-// DMA buffer that the aes chip will mutate during encryption
-// Byte 0-15   - Key
-// Byte 16-32  - Payload
-// Byte 33-47  - Ciphertext
-static mut ECB_DATA: [u8; 48] = [0; 48];
-
-#[allow(dead_code)]
 const KEY_START: usize = 0;
-#[allow(dead_code)]
-const KEY_END: usize = 15;
 const PLAINTEXT_START: usize = 16;
 const PLAINTEXT_END: usize = 32;
-#[allow(dead_code)]
-const CIPHERTEXT_START: usize = 33;
-#[allow(dead_code)]
-const CIPHERTEXT_END: usize = 47;
-
-const AESECB_BASE: StaticRef<AesEcbRegisters> =
-    unsafe { StaticRef::new(0x4000E000 as *const AesEcbRegisters) };
-
-#[repr(C)]
-struct AesEcbRegisters {
-    /// Start ECB block encrypt
-    /// - Address 0x000 - 0x004
-    task_startecb: WriteOnly<u32, Task::Register>,
-    /// Abort a possible executing ECB operation
-    /// - Address: 0x004 - 0x008
-    task_stopecb: WriteOnly<u32, Task::Register>,
-    /// Reserved
-    _reserved1: [u32; 62],
-    /// ECB block encrypt complete
-    /// - Address: 0x100 - 0x104
-    event_endecb: ReadWrite<u32, Event::Register>,
-    /// ECB block encrypt aborted because of a STOPECB task or due to an error
-    /// - Address: 0x104 - 0x108
-    event_errorecb: ReadWrite<u32, Event::Register>,
-    /// Reserved
-    _reserved2: [u32; 127],
-    /// Enable interrupt
-    /// - Address: 0x304 - 0x308
-    intenset: ReadWrite<u32, Intenset::Register>,
-    /// Disable interrupt
-    /// - Address: 0x308 - 0x30c
-    intenclr: ReadWrite<u32, Intenclr::Register>,
-    /// Reserved
-    _reserved3: [u32; 126],
-    /// ECB block encrypt memory pointers
-    /// - Address: 0x504 - 0x508
-    ecbdataptr: ReadWrite<u32, EcbDataPointer::Register>,
-}
-
-register_bitfields! [u32,
-    /// Start task
-    Task [
-        ENABLE OFFSET(0) NUMBITS(1)
-    ],
-
-    /// Read event
-    Event [
-        READY OFFSET(0) NUMBITS(1)
-    ],
-
-    /// Enabled interrupt
-    Intenset [
-        ENDECB OFFSET(0) NUMBITS(1),
-        ERRORECB OFFSET(1) NUMBITS(1)
-    ],
-
-    /// Disable interrupt
-    Intenclr [
-        ENDECB OFFSET(0) NUMBITS(1),
-        ERRORECB OFFSET(1) NUMBITS(1)
-    ],
-
-    /// ECB block encrypt memory pointers
-    EcbDataPointer [
-        POINTER OFFSET(0) NUMBITS(32)
-    ]
-];
 
 #[derive(Copy, Clone, Debug)]
 enum AESMode {
@@ -133,311 +51,241 @@ enum AESMode {
 }
 
 pub struct AesECB<'a> {
-    registers: StaticRef<AesEcbRegisters>,
+    registers: AesEcbRegistersManager,
     mode: Cell<AESMode>,
+    /// DMA buffer for the ECB engine. Needed because we need to set the key and
+    /// payload in specific bytes, and then read the ciphertext from the same
+    /// buffer.
+    ///
+    /// - Byte 0-15   - Key
+    /// - Byte 16-32  - Payload
+    /// - Byte 33-47  - Ciphertext
+    ecb_data: MapCell<&'static mut [u8]>,
+    /// Input plaintext or ciphertext. SubSliceMut window advances one block at
+    /// a time as encryption proceeds. Empty when using in-place (dest-only) mode.
+    input: MapCell<SubSliceMut<'static, u8>>,
+    /// Output buffer, pre-sliced to the requested start..stop range. Window
+    /// advances one block at a time as encryption proceeds.
+    output: MapCell<SubSliceMut<'static, u8>>,
     client: OptionalCell<&'a dyn kernel::hil::symmetric_encryption::Client<'a>>,
-    /// Input either plaintext or ciphertext to be encrypted or decrypted.
-    input: TakeCell<'static, [u8]>,
-    output: TakeCell<'static, [u8]>,
-    current_idx: Cell<usize>,
-    start_idx: Cell<usize>,
-    end_idx: Cell<usize>,
 }
 
-impl<'a> AesECB<'a> {
-    pub const fn new() -> AesECB<'a> {
-        AesECB {
-            registers: AESECB_BASE,
+impl AesECB<'_> {
+    pub fn new(registers: AesEcbRegistersManager, ecb_data: &'static mut [u8; 48]) -> Self {
+        Self {
+            registers,
             mode: Cell::new(AESMode::CTR),
+            ecb_data: MapCell::new(ecb_data),
+            input: MapCell::empty(),
+            output: MapCell::empty(),
             client: OptionalCell::empty(),
-            input: TakeCell::empty(),
-            output: TakeCell::empty(),
-            current_idx: Cell::new(0),
-            start_idx: Cell::new(0),
-            end_idx: Cell::new(0),
         }
     }
 
-    fn set_dma(&self) {
-        self.registers.ecbdataptr.set(addr_of!(ECB_DATA) as u32);
+    /// Returns the number of bytes remaining in the current operation.
+    fn remaining_len(&self) -> usize {
+        self.input
+            .map_or(self.output.map_or(0, |o| o.len()), |i| i.len())
     }
 
-    /// Verify that the provided start and stop indices work with the given
-    /// buffers.
-    fn try_set_indices(&self, start_index: usize, stop_index: usize) -> bool {
-        stop_index.checked_sub(start_index).is_some_and(|sublen| {
-            sublen % symmetric_encryption::AES128_BLOCK_SIZE == 0 && {
-                self.input.map_or_else(
-                    || {
-                        // The destination buffer is also the input
-                        if self.output.map_or(false, |dest| stop_index <= dest.len()) {
-                            self.current_idx.set(0);
-                            self.start_idx.set(start_index);
-                            self.end_idx.set(stop_index);
-                            true
-                        } else {
-                            false
-                        }
-                    },
-                    |source| {
-                        if sublen == source.len()
-                            && self.output.map_or(false, |dest| stop_index <= dest.len())
-                        {
-                            // We will start writing to the AES from the
-                            // beginning of `source`, and end at its end
-                            self.current_idx.set(0);
+    fn copy_plaintext(&self) {
+        fn copy_to_ecb(
+            ecb: &MapCell<&'static mut [u8]>,
+            buf: &MapCell<SubSliceMut<'static, u8>>,
+            len: usize,
+        ) {
+            ecb.map(|ecb| {
+                buf.map(|buf| {
+                    ecb[PLAINTEXT_START..PLAINTEXT_START + len].copy_from_slice(&buf[0..len]);
+                });
+            });
+        }
 
-                            // We will start reading from the AES into `dest` at
-                            // `start_index`, and continue until `stop_index`
-                            self.start_idx.set(start_index);
-                            self.end_idx.set(stop_index);
-                            true
-                        } else {
-                            false
-                        }
-                    },
-                )
+        fn xor_to_ecb(
+            ecb: &MapCell<&'static mut [u8]>,
+            buf: &MapCell<SubSliceMut<'static, u8>>,
+            len: usize,
+        ) {
+            ecb.map(|ecb| {
+                buf.map(|buf| {
+                    for i in 0..len {
+                        ecb[PLAINTEXT_START + i] ^= buf[i];
+                    }
+                });
+            });
+        }
+
+        let take = core::cmp::min(
+            symmetric_encryption::AES128_BLOCK_SIZE,
+            self.remaining_len(),
+        );
+
+        match self.mode.get() {
+            AESMode::ECB => {
+                // Copy the current plaintext block into the ECB data buffer.
+                if self.input.is_some() {
+                    copy_to_ecb(&self.ecb_data, &self.input, take);
+                } else {
+                    copy_to_ecb(&self.ecb_data, &self.output, take);
+                }
             }
-        })
+
+            AESMode::CBC => {
+                // XOR the existing ECB plaintext slot (IV or previous ciphertext)
+                // with the current plaintext block.
+                if self.input.is_some() {
+                    xor_to_ecb(&self.ecb_data, &self.input, take);
+                } else {
+                    xor_to_ecb(&self.ecb_data, &self.output, take);
+                }
+            }
+
+            AESMode::CTR => {
+                // The counter is already in the ECB plaintext slot; no copy needed.
+            }
+        }
+    }
+
+    /// Start a single ECB encryption block via DMA, preparing the ECB data
+    /// buffer with the current plaintext block if needed.
+    fn do_crypt(&self) {
+        self.copy_plaintext();
+
+        if let Some(ecb_data) = self.ecb_data.take() {
+            let _ = self.registers.start_ecb_dma(ecb_data);
+        }
+
+        self.enable_interrupts();
     }
 
     // FIXME: should this be performed in constant time i.e. skip the break part
     // and always loop 16 times?
     fn update_ctr(&self) {
-        for i in (PLAINTEXT_START..PLAINTEXT_END).rev() {
-            unsafe {
-                ECB_DATA[i] += 1;
-                if ECB_DATA[i] != 0 {
+        self.ecb_data.map(|buf| {
+            for i in (PLAINTEXT_START..PLAINTEXT_END).rev() {
+                buf[i] = buf[i].wrapping_add(1);
+                if buf[i] != 0 {
                     break;
                 }
             }
-        }
-    }
-
-    /// Get the relevant positions of our input data whether we are using a
-    /// source buffer or overwriting the destination buffer.
-    fn get_start_end_take(&self) -> (usize, usize, usize) {
-        let current_idx = self.current_idx.get();
-
-        // Location in the appropriate source buffer we are currently working
-        // on.
-        let start = current_idx + self.input.map_or(self.start_idx.get(), |_| 0);
-        // Last index in the appropriate source buffer we need to work on.
-        let end = self.end_idx.get() - self.input.map_or(0, |_| self.start_idx.get());
-
-        // Get the number of bytes that were used in the keystream/block.
-        let take = match end.checked_sub(start) {
-            Some(v) if v > symmetric_encryption::AES128_BLOCK_SIZE => {
-                symmetric_encryption::AES128_BLOCK_SIZE
-            }
-            Some(v) => v,
-            None => 0,
-        };
-
-        (start, end, take)
-    }
-
-    fn copy_plaintext(&self) {
-        let (start, _end, take) = self.get_start_end_take();
-
-        // Copy the plaintext either from the source if it exists or from the
-        // destination buffer.
-        if take > 0 {
-            match self.mode.get() {
-                AESMode::ECB => {
-                    self.input.map_or_else(
-                        || {
-                            self.output.map(|output| {
-                                for i in 0..take {
-                                    // Copy into static mut DMA buffer
-                                    unsafe {
-                                        ECB_DATA[i + PLAINTEXT_START] = output[i + start];
-                                    }
-                                }
-                            });
-                        },
-                        |input| {
-                            for i in 0..take {
-                                // Copy into static mut DMA buffer
-                                unsafe {
-                                    ECB_DATA[i + PLAINTEXT_START] = input[i + start];
-                                }
-                            }
-                        },
-                    );
-                }
-
-                AESMode::CBC => {
-                    self.input.map_or_else(
-                        || {
-                            self.output.map(|output| {
-                                for i in 0..take {
-                                    let ecb_idx = i + PLAINTEXT_START;
-
-                                    // Copy into static mut DMA buffer
-                                    unsafe {
-                                        ECB_DATA[ecb_idx] ^= output[i + start];
-                                    }
-                                }
-                            });
-                        },
-                        |input| {
-                            for i in 0..take {
-                                let ecb_idx = i + PLAINTEXT_START;
-                                // Copy into static mut DMA buffer
-                                unsafe {
-                                    ECB_DATA[ecb_idx] ^= input[i + start];
-                                }
-                            }
-                        },
-                    );
-                }
-
-                AESMode::CTR => {
-                    // no copying plaintext in ctr mode
-                }
-            }
-        }
-    }
-
-    fn crypt(&self) {
-        match self.mode.get() {
-            AESMode::CTR => {}
-            AESMode::ECB => {
-                // Need to copy the plaintext to the ECB buffer.
-                self.copy_plaintext();
-            }
-            AESMode::CBC => {
-                self.copy_plaintext();
-            }
-        }
-
-        self.registers.event_endecb.write(Event::READY::CLEAR);
-        self.registers.task_startecb.set(1);
-
-        self.enable_interrupts();
+        });
     }
 
     /// AesEcb Interrupt handler
     pub fn handle_interrupt(&self) {
-        // disable interrupts
         self.disable_interrupts();
 
-        if self.registers.event_endecb.get() == 1 {
-            let (start, end, take) = self.get_start_end_take();
-            let start_idx = self.start_idx.get();
-            let current_idx = self.current_idx.get();
+        if self
+            .registers
+            .registers
+            .event_endecb
+            .is_set(nrf5x_unsafe::aes::Event::READY)
+        {
+            // Recover the ECB data buffer from the DMA manager.
+            if let Some(ecb_data) = self.registers.finish_ecb_dma() {
+                self.ecb_data.replace(ecb_data);
+            }
 
-            match self.mode.get() {
-                AESMode::CTR => {
-                    // Fill in the ciphertext in the output buffer.
-                    if take > 0 {
-                        self.input.map_or_else(
-                            || {
-                                // No input buffer, so source data comes from
-                                // output buffer.
+            let take = core::cmp::min(
+                symmetric_encryption::AES128_BLOCK_SIZE,
+                self.remaining_len(),
+            );
+
+            if take > 0 {
+                match self.mode.get() {
+                    AESMode::ECB => {
+                        // Copy ciphertext from the ECB output slot to the output buffer.
+                        self.ecb_data.map(|ecb| {
+                            self.output.map(|output| {
+                                output[0..take]
+                                    .copy_from_slice(&ecb[PLAINTEXT_END..PLAINTEXT_END + take]);
+                            });
+                        });
+                    }
+
+                    AESMode::CBC => {
+                        // Copy ciphertext to output and save it in the ECB plaintext
+                        // slot for CBC chaining on the next block.
+                        self.ecb_data.map(|ecb| {
+                            self.output.map(|output| {
+                                for i in 0..take {
+                                    let byte = ecb[PLAINTEXT_END + i];
+                                    output[i] = byte;
+                                    ecb[PLAINTEXT_START + i] = byte;
+                                }
+                            });
+                        });
+                    }
+
+                    AESMode::CTR => {
+                        // XOR keystream output with plaintext to produce ciphertext.
+                        if self.input.is_some() {
+                            self.ecb_data.map(|ecb| {
+                                self.input.map(|input| {
+                                    self.output.map(|output| {
+                                        for i in 0..take {
+                                            output[i] = input[i] ^ ecb[PLAINTEXT_END + i];
+                                        }
+                                    });
+                                });
+                            });
+                        } else {
+                            self.ecb_data.map(|ecb| {
                                 self.output.map(|output| {
                                     for i in 0..take {
-                                        let in_byte = output[start + i];
-                                        let keystream_byte = unsafe { ECB_DATA[i + PLAINTEXT_END] };
-
-                                        output[start + i] = keystream_byte ^ in_byte;
+                                        output[i] ^= ecb[PLAINTEXT_END + i];
                                     }
                                 });
-                            },
-                            |input| {
-                                self.output.map(|output| {
-                                    let start_idx = self.start_idx.get();
-
-                                    for i in 0..take {
-                                        let in_byte = input[start + i];
-                                        let keystream_byte = unsafe { ECB_DATA[i + PLAINTEXT_END] };
-
-                                        output[start_idx + current_idx + i] =
-                                            keystream_byte ^ in_byte;
-                                    }
-                                });
-                            },
-                        );
-
+                            });
+                        }
                         self.update_ctr();
                     }
                 }
 
-                AESMode::ECB => {
-                    // Copy ciphertext to output.
-                    if take > 0 {
-                        self.output.map(|output| {
-                            for i in 0..take {
-                                // We write to the buffer starting at the
-                                // originally provided start index, plus our
-                                // offset at current_idx.
-                                let dest_idx = start_idx + current_idx + i;
-                                // Copy out of static mut DMA buffer
-                                unsafe {
-                                    output[dest_idx] = ECB_DATA[i + PLAINTEXT_END];
-                                }
-                            }
-                        });
-                    }
-                }
-                AESMode::CBC => {
-                    // Copy ciphertext to both output AND the ECB payload to use
-                    // on the next iteration.
-                    if take > 0 {
-                        self.output.map(|output| {
-                            for i in 0..take {
-                                // We write to the buffer starting at the
-                                // originally provided start index, plus our
-                                // offset at current_idx.
-                                let dest_idx = start_idx + current_idx + i;
-                                // Copy out of static mut DMA buffer
-                                unsafe {
-                                    output[dest_idx] = ECB_DATA[i + PLAINTEXT_END];
-                                    ECB_DATA[i + PLAINTEXT_START] = ECB_DATA[i + PLAINTEXT_END];
-                                }
-                            }
-                        });
-                    }
-                }
+                // Advance both SubSliceMut windows past the block just processed.
+                self.output.map(|buf| {
+                    buf.slice(take..);
+                });
+                self.input.map(|buf| {
+                    buf.slice(take..);
+                });
             }
 
-            // Advance through the buffer.
-            self.current_idx.set(current_idx + take);
-
-            // Check if we are done or if we need to crypt another block.
-            if start + take < end {
-                // More to do.
-                self.crypt();
+            if self.remaining_len() > 0 {
+                self.do_crypt();
             } else {
-                self.output.take().map(|output| {
-                    self.client
-                        .map(move |client| client.crypt_done(self.input.take(), output));
-                });
+                // Recover the original buffers (SubSliceMut::take returns the
+                // full underlying &'static mut [u8] regardless of the current
+                // window position) and notify the client.
+                let input_buf = self.input.take().map(|s| s.take());
+                if let Some(output_sub) = self.output.take() {
+                    let output = output_sub.take();
+                    self.client.map(move |client| {
+                        client.crypt_done(input_buf, output);
+                    });
+                }
             }
         }
     }
 
     fn enable_interrupts(&self) {
-        self.registers
-            .intenset
-            .write(Intenset::ENDECB::SET + Intenset::ERRORECB::SET);
+        self.registers.registers.intenset.write(
+            nrf5x_unsafe::aes::Intenset::ENDECB::SET + nrf5x_unsafe::aes::Intenset::ERRORECB::SET,
+        );
     }
 
     fn disable_interrupts(&self) {
-        self.registers
-            .intenclr
-            .write(Intenclr::ENDECB::SET + Intenclr::ERRORECB::SET);
+        self.registers.registers.intenclr.write(
+            nrf5x_unsafe::aes::Intenclr::ENDECB::SET + nrf5x_unsafe::aes::Intenclr::ERRORECB::SET,
+        );
     }
 }
 
 impl<'a> kernel::hil::symmetric_encryption::AES128<'a> for AesECB<'a> {
-    fn enable(&self) {
-        self.set_dma();
-    }
+    fn enable(&self) {}
 
     fn disable(&self) {
-        self.registers.task_stopecb.write(Task::ENABLE::CLEAR);
+        self.registers.finish_ecb_dma();
         self.disable_interrupts();
     }
 
@@ -449,11 +297,10 @@ impl<'a> kernel::hil::symmetric_encryption::AES128<'a> for AesECB<'a> {
         if key.len() != symmetric_encryption::AES128_KEY_SIZE {
             Err(ErrorCode::INVAL)
         } else {
-            for (i, c) in key.iter().enumerate() {
-                unsafe {
-                    ECB_DATA[i] = *c;
-                }
-            }
+            self.ecb_data.map(|buf| {
+                buf[KEY_START..KEY_START + symmetric_encryption::AES128_KEY_SIZE]
+                    .copy_from_slice(key);
+            });
             Ok(())
         }
     }
@@ -462,11 +309,9 @@ impl<'a> kernel::hil::symmetric_encryption::AES128<'a> for AesECB<'a> {
         if iv.len() != symmetric_encryption::AES128_BLOCK_SIZE {
             Err(ErrorCode::INVAL)
         } else {
-            for (i, c) in iv.iter().enumerate() {
-                unsafe {
-                    ECB_DATA[i + PLAINTEXT_START] = *c;
-                }
-            }
+            self.ecb_data.map(|buf| {
+                buf[PLAINTEXT_START..PLAINTEXT_END].copy_from_slice(iv);
+            });
             Ok(())
         }
     }
@@ -485,18 +330,32 @@ impl<'a> kernel::hil::symmetric_encryption::AES128<'a> for AesECB<'a> {
         Option<&'static mut [u8]>,
         &'static mut [u8],
     )> {
-        self.input.put(source);
-        self.output.replace(dest);
-        if self.try_set_indices(start_index, stop_index) {
-            self.crypt();
-            None
-        } else {
-            Some((
-                Err(ErrorCode::INVAL),
-                self.input.take(),
-                self.output.take().unwrap(),
-            ))
+        // Validate indices and buffer sizes before consuming any buffers.
+        let len = match stop_index.checked_sub(start_index) {
+            Some(l) if l % symmetric_encryption::AES128_BLOCK_SIZE == 0 => l,
+            _ => return Some((Err(ErrorCode::INVAL), source, dest)),
+        };
+
+        if stop_index > dest.len() {
+            return Some((Err(ErrorCode::INVAL), source, dest));
         }
+
+        if let Some(ref src) = source {
+            if src.len() != len {
+                return Some((Err(ErrorCode::INVAL), source, dest));
+            }
+        }
+
+        if let Some(src) = source {
+            self.input.replace(SubSliceMut::new(src));
+        }
+
+        let mut output_slice = SubSliceMut::new(dest);
+        output_slice.slice(start_index..stop_index);
+        self.output.replace(output_slice);
+
+        self.do_crypt();
+        None
     }
 }
 

--- a/chips/nrf5x/src/aes.rs
+++ b/chips/nrf5x/src/aes.rs
@@ -332,7 +332,7 @@ impl<'a> kernel::hil::symmetric_encryption::AES128<'a> for AesECB<'a> {
     )> {
         // Validate indices and buffer sizes before consuming any buffers.
         let len = match stop_index.checked_sub(start_index) {
-            Some(l) if l % symmetric_encryption::AES128_BLOCK_SIZE == 0 => l,
+            Some(l) if l.is_multiple_of(symmetric_encryption::AES128_BLOCK_SIZE) => l,
             _ => return Some((Err(ErrorCode::INVAL), source, dest)),
         };
 


### PR DESCRIPTION
### Pull Request Overview

This replaces #4626.

It does two things to improve the safety of the AES driver:

1. Removes the static mut buffer that is shared with DMA.
2. Uses DmaSlice to safely share memory with the DMA hardware.

Because this is the last step in removing unsafe from the nrf5x crate, this also moves the unsafe AES DMA code into a new crate called `nrf5x-unsafe`. `nrf5x` is now forbid unsafe.


### Testing Strategy

I ran the `boards/configurations/nrf52840dk/nrf52840dk-test-kernel` kernel. Output:

```
Sha256Test: Setting slice to 12..24
Sha256Test: Setting slice to 24..36
Sha256Test: Setting slice to 36..48
Sha256Test: Setting slice to 48..60
Sha256Test: Setting slice to 60..72
Sha256Test: Verification result: Ok(true)
HMAC-SHA256 matches!
TestSipHash24: incorrect hash output!
TestSipHash24 matches!
aes_test CTR passed: (CTR Enc Ctr Src/Dst)
aes_test CTR passed: (CTR Enc Ctr In-place)
aes_test CTR passed: (CTR Dec Ctr Src/Dst)
aes_test CTR passed: (CTR Dec Ctr In-place)
aes_test passed (CBC Enc Src/Dst)
aes_test passed (CBC Enc In-place)
aes_test passed (ECB Enc Src/Dst)
aes_test passed (ECB Enc In-place)
EcdsaP256SignTest passed (signatures match)
All tests finished.
```


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
