### PR TITLE
Update `append_key` guard to reject `object_length == 0xFFF`

### DIFF
--- a/libraries/tickv/src/tickv.rs
+++ b/libraries/tickv/src/tickv.rs
@@ -394,7 +394,7 @@ impl<'a, C: FlashController<S>, const S: usize> TicKV<'a, C, S> {
         let package_length = HEADER_LENGTH + value.len();
         let object_length = HEADER_LENGTH + value.len() + CHECK_SUM_LEN;
 
-        if object_length > 0xFFF {
+        if object_length >= 0xFFF {
             return Err(ErrorCode::ObjectTooLarge);
         }
 


### PR DESCRIPTION
### Pull Request Overview

Fixes #4847, which mentioned that a guard in `append_key` could allow for the assertion within `ObjectHeader::new` to fail. Do advise if my patch is in the wrong direction, i.e., if we should relax the assertion to allow for `object_length`s of exactly `0xFFF` in size.

### Testing Strategy

Claude pointed me toward `make ci-job-libraries` and used that for testing; will use CI as another signal of correctness.

### TODO or Help Wanted

None needed!

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
