### PR TITLE
hil: time: move Counter::set_overflow_client to new `CounterOverflow` trait

### DIFF
--- a/chips/apollo3/src/stimer.rs
+++ b/chips/apollo3/src/stimer.rs
@@ -4,9 +4,7 @@
 
 //! STimer driver for the Apollo3
 
-use kernel::hil::time::{
-    Alarm, AlarmClient, Counter, Freq16KHz, OverflowClient, Ticks, Ticks32, Time,
-};
+use kernel::hil::time::{Alarm, AlarmClient, Counter, Freq16KHz, Ticks, Ticks32, Time};
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{register_bitfields, register_structs, ReadWrite};
@@ -143,10 +141,6 @@ impl Time for STimer<'_> {
 }
 
 impl<'a> Counter<'a> for STimer<'a> {
-    fn set_overflow_client(&self, _client: &'a dyn OverflowClient) -> Result<(), ErrorCode> {
-        Err(ErrorCode::NOSUPPORT)
-    }
-
     fn start(&self) -> Result<(), ErrorCode> {
         // Set the clock source
         self.registers.stcfg.write(STCFG::CLKSEL::XTAL_DIV2);

--- a/chips/apollo3/src/stimer.rs
+++ b/chips/apollo3/src/stimer.rs
@@ -143,8 +143,8 @@ impl Time for STimer<'_> {
 }
 
 impl<'a> Counter<'a> for STimer<'a> {
-    fn set_overflow_client(&self, _client: &'a dyn OverflowClient) {
-        //self.overflow_client.set(client);
+    fn set_overflow_client(&self, _client: &'a dyn OverflowClient) -> Result<(), ErrorCode> {
+        Err(ErrorCode::NOSUPPORT)
     }
 
     fn start(&self) -> Result<(), ErrorCode> {

--- a/chips/earlgrey/src/timer.rs
+++ b/chips/earlgrey/src/timer.rs
@@ -111,8 +111,9 @@ impl<CFG: EarlGreyConfig> time::Time for RvTimer<'_, CFG> {
 }
 
 impl<'a, CFG: EarlGreyConfig> time::Counter<'a> for RvTimer<'a, CFG> {
-    fn set_overflow_client(&self, client: &'a dyn time::OverflowClient) {
+    fn set_overflow_client(&self, client: &'a dyn time::OverflowClient) -> Result<(), ErrorCode> {
         self.overflow_client.set(client);
+        Ok(())
     }
 
     fn start(&self) -> Result<(), ErrorCode> {

--- a/chips/earlgrey/src/timer.rs
+++ b/chips/earlgrey/src/timer.rs
@@ -109,11 +109,6 @@ impl<CFG: EarlGreyConfig> time::Time for RvTimer<'_, CFG> {
 }
 
 impl<'a, CFG: EarlGreyConfig> time::Counter<'a> for RvTimer<'a, CFG> {
-    fn set_overflow_client(&self, _client: &'a dyn time::OverflowClient) -> Result<(), ErrorCode> {
-        // Hardware counter overflow interrupts are not currently implemented for Earlgrey.
-        Err(ErrorCode::NOSUPPORT)
-    }
-
     fn start(&self) -> Result<(), ErrorCode> {
         Ok(())
     }

--- a/chips/earlgrey/src/timer.rs
+++ b/chips/earlgrey/src/timer.rs
@@ -57,7 +57,6 @@ register_bitfields![u32,
 pub struct RvTimer<'a, CFG: EarlGreyConfig> {
     registers: StaticRef<TimerRegisters>,
     alarm_client: OptionalCell<&'a dyn time::AlarmClient>,
-    overflow_client: OptionalCell<&'a dyn time::OverflowClient>,
     mtimer: MachineTimer<'a>,
     _cfg: PhantomData<CFG>,
 }
@@ -67,7 +66,6 @@ impl<CFG: EarlGreyConfig> RvTimer<'_, CFG> {
         Self {
             registers: TIMER_BASE,
             alarm_client: OptionalCell::empty(),
-            overflow_client: OptionalCell::empty(),
             mtimer: MachineTimer::new(
                 &TIMER_BASE.compare_low,
                 &TIMER_BASE.compare_high,
@@ -111,9 +109,9 @@ impl<CFG: EarlGreyConfig> time::Time for RvTimer<'_, CFG> {
 }
 
 impl<'a, CFG: EarlGreyConfig> time::Counter<'a> for RvTimer<'a, CFG> {
-    fn set_overflow_client(&self, client: &'a dyn time::OverflowClient) -> Result<(), ErrorCode> {
-        self.overflow_client.set(client);
-        Ok(())
+    fn set_overflow_client(&self, _client: &'a dyn time::OverflowClient) -> Result<(), ErrorCode> {
+        // Hardware counter overflow interrupts are not currently implemented for Earlgrey.
+        Err(ErrorCode::NOSUPPORT)
     }
 
     fn start(&self) -> Result<(), ErrorCode> {

--- a/chips/esp32/src/timg.rs
+++ b/chips/esp32/src/timg.rs
@@ -206,8 +206,9 @@ impl<F: time::Frequency, const C3: bool> time::Time for TimG<'_, F, C3> {
 }
 
 impl<'a, F: time::Frequency, const C3: bool> Counter<'a> for TimG<'a, F, C3> {
-    fn set_overflow_client(&self, _client: &'a dyn time::OverflowClient) {
+    fn set_overflow_client(&self, _client: &'a dyn time::OverflowClient) -> Result<(), ErrorCode> {
         // We have no way to know when this happens
+        Err(ErrorCode::NOSUPPORT)
     }
 
     fn start(&self) -> Result<(), ErrorCode> {

--- a/chips/esp32/src/timg.rs
+++ b/chips/esp32/src/timg.rs
@@ -206,11 +206,6 @@ impl<F: time::Frequency, const C3: bool> time::Time for TimG<'_, F, C3> {
 }
 
 impl<'a, F: time::Frequency, const C3: bool> Counter<'a> for TimG<'a, F, C3> {
-    fn set_overflow_client(&self, _client: &'a dyn time::OverflowClient) -> Result<(), ErrorCode> {
-        // We have no way to know when this happens
-        Err(ErrorCode::NOSUPPORT)
-    }
-
     fn start(&self) -> Result<(), ErrorCode> {
         self.registers.t0config.write(CONFIG::EN::SET);
 

--- a/chips/msp432/src/timer.rs
+++ b/chips/msp432/src/timer.rs
@@ -5,9 +5,7 @@
 //! Timer (TIMER_Ax)
 
 use core::cell::Cell;
-use kernel::hil::time::{
-    Alarm, AlarmClient, Counter, Frequency, OverflowClient, Ticks, Ticks16, Time,
-};
+use kernel::hil::time::{Alarm, AlarmClient, Counter, Frequency, Ticks, Ticks16, Time};
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{register_bitfields, register_structs, ReadWrite};
@@ -345,10 +343,6 @@ impl Time for TimerA<'_> {
 }
 
 impl<'a> Counter<'a> for TimerA<'a> {
-    fn set_overflow_client(&self, _client: &'a dyn OverflowClient) -> Result<(), ErrorCode> {
-        Err(ErrorCode::NOSUPPORT)
-    }
-
     fn start(&self) -> Result<(), ErrorCode> {
         self.setup_for_alarm();
         Ok(())

--- a/chips/msp432/src/timer.rs
+++ b/chips/msp432/src/timer.rs
@@ -345,7 +345,9 @@ impl Time for TimerA<'_> {
 }
 
 impl<'a> Counter<'a> for TimerA<'a> {
-    fn set_overflow_client(&self, _client: &'a dyn OverflowClient) {}
+    fn set_overflow_client(&self, _client: &'a dyn OverflowClient) -> Result<(), ErrorCode> {
+        Err(ErrorCode::NOSUPPORT)
+    }
 
     fn start(&self) -> Result<(), ErrorCode> {
         self.setup_for_alarm();

--- a/chips/nrf5x/src/rtc.rs
+++ b/chips/nrf5x/src/rtc.rs
@@ -127,9 +127,10 @@ impl Time for Rtc<'_> {
 }
 
 impl<'a> time::Counter<'a> for Rtc<'a> {
-    fn set_overflow_client(&self, client: &'a dyn time::OverflowClient) {
+    fn set_overflow_client(&self, client: &'a dyn time::OverflowClient) -> Result<(), ErrorCode> {
         self.overflow_client.set(client);
         self.registers.intenset.write(Inte::OVRFLW::SET);
+        Ok(())
     }
 
     fn start(&self) -> Result<(), ErrorCode> {

--- a/chips/nrf5x/src/rtc.rs
+++ b/chips/nrf5x/src/rtc.rs
@@ -127,12 +127,6 @@ impl Time for Rtc<'_> {
 }
 
 impl<'a> time::Counter<'a> for Rtc<'a> {
-    fn set_overflow_client(&self, client: &'a dyn time::OverflowClient) -> Result<(), ErrorCode> {
-        self.overflow_client.set(client);
-        self.registers.intenset.write(Inte::OVRFLW::SET);
-        Ok(())
-    }
-
     fn start(&self) -> Result<(), ErrorCode> {
         self.registers.prescaler.write(Prescaler::PRESCALER.val(0));
         self.registers.tasks_start.write(Task::ENABLE::SET);
@@ -154,6 +148,13 @@ impl<'a> time::Counter<'a> for Rtc<'a> {
 
     fn is_running(&self) -> bool {
         self.enabled.get()
+    }
+}
+
+impl<'a> time::CounterOverflow<'a> for Rtc<'a> {
+    fn set_overflow_client(&self, client: &'a dyn time::OverflowClient) {
+        self.overflow_client.set(client);
+        self.registers.intenset.write(Inte::OVRFLW::SET);
     }
 }
 

--- a/chips/nrf5x/src/rtc.rs
+++ b/chips/nrf5x/src/rtc.rs
@@ -151,6 +151,7 @@ impl<'a> time::Counter<'a> for Rtc<'a> {
     }
 }
 
+#[allow(deprecated)]
 impl<'a> time::CounterOverflow<'a> for Rtc<'a> {
     fn set_overflow_client(&self, client: &'a dyn time::OverflowClient) {
         self.overflow_client.set(client);

--- a/chips/sam4l/src/ast.rs
+++ b/chips/sam4l/src/ast.rs
@@ -321,10 +321,6 @@ impl time::Time for Ast<'_> {
 }
 
 impl<'a> time::Counter<'a> for Ast<'a> {
-    fn set_overflow_client(&self, _client: &'a dyn time::OverflowClient) -> Result<(), ErrorCode> {
-        Err(ErrorCode::NOSUPPORT)
-    }
-
     fn start(&self) -> Result<(), ErrorCode> {
         self.enable();
         Ok(())

--- a/chips/sam4l/src/ast.rs
+++ b/chips/sam4l/src/ast.rs
@@ -321,7 +321,9 @@ impl time::Time for Ast<'_> {
 }
 
 impl<'a> time::Counter<'a> for Ast<'a> {
-    fn set_overflow_client(&self, _client: &'a dyn time::OverflowClient) {}
+    fn set_overflow_client(&self, _client: &'a dyn time::OverflowClient) -> Result<(), ErrorCode> {
+        Err(ErrorCode::NOSUPPORT)
+    }
 
     fn start(&self) -> Result<(), ErrorCode> {
         self.enable();

--- a/chips/stm32f303xc/src/tim2.rs
+++ b/chips/stm32f303xc/src/tim2.rs
@@ -376,7 +376,9 @@ impl Time for Tim2<'_> {
 }
 
 impl<'a> Counter<'a> for Tim2<'a> {
-    fn set_overflow_client(&self, _client: &'a dyn OverflowClient) {}
+    fn set_overflow_client(&self, _client: &'a dyn OverflowClient) -> Result<(), ErrorCode> {
+        Err(ErrorCode::NOSUPPORT)
+    }
 
     // starts the timer
     fn start(&self) -> Result<(), ErrorCode> {

--- a/chips/stm32f303xc/src/tim2.rs
+++ b/chips/stm32f303xc/src/tim2.rs
@@ -3,9 +3,7 @@
 // Copyright Tock Contributors 2022.
 
 use cortexm4f::support::with_interrupts_disabled;
-use kernel::hil::time::{
-    Alarm, AlarmClient, Counter, Freq16KHz, OverflowClient, Ticks, Ticks32, Time,
-};
+use kernel::hil::time::{Alarm, AlarmClient, Counter, Freq16KHz, Ticks, Ticks32, Time};
 use kernel::platform::chip::ClockInterface;
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
@@ -376,10 +374,6 @@ impl Time for Tim2<'_> {
 }
 
 impl<'a> Counter<'a> for Tim2<'a> {
-    fn set_overflow_client(&self, _client: &'a dyn OverflowClient) -> Result<(), ErrorCode> {
-        Err(ErrorCode::NOSUPPORT)
-    }
-
     // starts the timer
     fn start(&self) -> Result<(), ErrorCode> {
         self.start_counter();

--- a/chips/stm32f4xx/src/tim2.rs
+++ b/chips/stm32f4xx/src/tim2.rs
@@ -3,9 +3,7 @@
 // Copyright Tock Contributors 2022.
 
 use cortexm4f::support::with_interrupts_disabled;
-use kernel::hil::time::{
-    Alarm, AlarmClient, Counter, Freq16KHz, Frequency, OverflowClient, Ticks, Ticks32, Time,
-};
+use kernel::hil::time::{Alarm, AlarmClient, Counter, Freq16KHz, Frequency, Ticks, Ticks32, Time};
 use kernel::platform::chip::ClockInterface;
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
@@ -397,10 +395,6 @@ impl Time for Tim2<'_> {
 }
 
 impl<'a> Counter<'a> for Tim2<'a> {
-    fn set_overflow_client(&self, _client: &'a dyn OverflowClient) -> Result<(), ErrorCode> {
-        Err(ErrorCode::NOSUPPORT)
-    }
-
     // starts the timer
     fn start(&self) -> Result<(), ErrorCode> {
         self.start();

--- a/chips/stm32f4xx/src/tim2.rs
+++ b/chips/stm32f4xx/src/tim2.rs
@@ -397,7 +397,9 @@ impl Time for Tim2<'_> {
 }
 
 impl<'a> Counter<'a> for Tim2<'a> {
-    fn set_overflow_client(&self, _client: &'a dyn OverflowClient) {}
+    fn set_overflow_client(&self, _client: &'a dyn OverflowClient) -> Result<(), ErrorCode> {
+        Err(ErrorCode::NOSUPPORT)
+    }
 
     // starts the timer
     fn start(&self) -> Result<(), ErrorCode> {

--- a/chips/stm32wle5xx/src/tim2.rs
+++ b/chips/stm32wle5xx/src/tim2.rs
@@ -3,9 +3,7 @@
 // Copyright Tock Contributors 2025.
 
 use cortexm4::support::with_interrupts_disabled;
-use kernel::hil::time::{
-    Alarm, AlarmClient, Counter, Freq16KHz, OverflowClient, Ticks, Ticks32, Time,
-};
+use kernel::hil::time::{Alarm, AlarmClient, Counter, Freq16KHz, Ticks, Ticks32, Time};
 use kernel::platform::chip::ClockInterface;
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
@@ -378,10 +376,6 @@ impl Time for Tim2<'_> {
 }
 
 impl<'a> Counter<'a> for Tim2<'a> {
-    fn set_overflow_client(&self, _client: &'a dyn OverflowClient) -> Result<(), ErrorCode> {
-        Err(ErrorCode::NOSUPPORT)
-    }
-
     // starts the timer
     fn start(&self) -> Result<(), ErrorCode> {
         self.start_counter();

--- a/chips/stm32wle5xx/src/tim2.rs
+++ b/chips/stm32wle5xx/src/tim2.rs
@@ -378,7 +378,9 @@ impl Time for Tim2<'_> {
 }
 
 impl<'a> Counter<'a> for Tim2<'a> {
-    fn set_overflow_client(&self, _client: &'a dyn OverflowClient) {}
+    fn set_overflow_client(&self, _client: &'a dyn OverflowClient) -> Result<(), ErrorCode> {
+        Err(ErrorCode::NOSUPPORT)
+    }
 
     // starts the timer
     fn start(&self) -> Result<(), ErrorCode> {

--- a/doc/reference/trd101-time.md
+++ b/doc/reference/trd101-time.md
@@ -161,7 +161,7 @@ pub trait Counter<'a>: Time {
   fn stop(&self) -> Result<(), ErrorCode>;
   fn reset(&self) -> Result<(), ErrorCode>;
   fn is_running(&self) -> bool;
-  fn set_overflow_client(&'a self, &'a dyn OverflowClient);
+  fn set_overflow_client(&self, client: &'a dyn OverflowClient) -> Result<(), ErrorCode>;
 }
 ```
 

--- a/doc/reference/trd101-time.md
+++ b/doc/reference/trd101-time.md
@@ -161,7 +161,7 @@ pub trait Counter<'a>: Time {
   fn stop(&self) -> Result<(), ErrorCode>;
   fn reset(&self) -> Result<(), ErrorCode>;
   fn is_running(&self) -> bool;
-  fn set_overflow_client(&self, client: &'a dyn OverflowClient) -> Result<(), ErrorCode>;
+  fn set_overflow_client(&'a self, &'a dyn OverflowClient);
 }
 ```
 

--- a/doc/reference/trd105-time.md
+++ b/doc/reference/trd105-time.md
@@ -4,13 +4,9 @@ Kernel Time HIL
 **TRD:** 105<br/>
 **Working Group:** Kernel<br/>
 **Type:** Documentary<br/>
-**Status:** Draft <br/>
-**Obsoletes:** 101 <br/>
+**Status:** Obsolete<br/>
+**Obsoleted By:** xxx <br/>
 **Author:** Guillaume Endignoux, Amit Levy, Philip Levis, and Jett Rink <br/>
-**Draft-Created:** 2021/07/23 <br/>
-**Draft-Modified:** 2021/07/23 <br/>
-**Draft-Version:** 1.0 <br/>
-**Draft-Discuss:** Github PR <br/>
 
 Abstract
 -------------------------------

--- a/doc/reference/trd105-time.md
+++ b/doc/reference/trd105-time.md
@@ -30,15 +30,16 @@ broad categories: alarms and timers. Alarms continuously increment a clock and
 can fire an event when the clock reaches a specific value. Timers can fire an
 event after a certain number of clock ticks have elapsed.
 
-The time HIL is in the kernel crate, in module `hil::time`. It provides six
+The time HIL is in the kernel crate, in module `hil::time`. It provides several
 main traits:
 
 
   * `kernel::hil::time::Time`: provides an abstraction of a moment in time. It has two associated types. One describes the width and maximum value of a time value. The other specifies the frequency of the ticks of the time value.
   * `kernel::hil::time::Counter`: derives from `Time` and provides an abstraction of a free-running counter that can be started or stopped. A `Counter`'s moment in time is the current value of the counter.
+  * `kernel::hil::time::CounterOverflow`: derives from `Counter`, and provides an abstraction for hardware counters that can generate overflow notifications.
   * `kernel::hil::time::Alarm`: derives from `Time`, and provides an abstraction of being able to receive a callback at a future moment in time.
   * `kernel::hil::time::Timer`: derives from `Time`, and provides an abstraction of being able to receive a callback at some amount of time in the future, or a series of callbacks at a given period.
-  * `kernel::hil::time::OverflowClient`: handles an overflow callback from a `Counter`.
+  * `kernel::hil::time::OverflowClient`: handles an overflow callback from a `CounterOverflow`.
   * `kernel::hil::time::AlarmClient`: handles the callback from an `Alarm`.
   * `kernel::hil::time::TimerClient`: handles the callback from a `Timer`.
 
@@ -170,13 +171,17 @@ is 30.5 microseconds.
 [associated_type]: https://doc.rust-lang.org/book/ch19-03-advanced-traits.html#specifying-placeholder-types-in-trait-definitions-with-associated-types
 
 
-3 `Counter` and `OverflowClient` traits
+3 `Counter`, `CounterOverflow`, and `OverflowClient` traits
 ===============================
 
 The `Counter` trait is the abstraction of a free-running counter that
 can be started and stopped. This trait derives from the `Time` trait, so
-it has associated `Frequency` and `Tick` types. The `Counter` trait
-allows a client to register for callbacks when the counter overflows.
+it has associated `Frequency` and `Tick` types.
+
+To support hardware that can explicitly notify the system when the timer
+wraps around, the `CounterOverflow` trait extends `Counter`. This is provided
+as a separate extension trait so that support is explicit at compile-time,
+and unsupported boards do not carry dead API surface.
 
 ```rust
 pub trait OverflowClient {
@@ -188,7 +193,10 @@ pub trait Counter<'a>: Time {
   fn stop(&self) -> Result<(), ErrorCode>;
   fn reset(&self) -> Result<(), ErrorCode>;
   fn is_running(&self) -> bool;
-  fn set_overflow_client(&self, client: &'a dyn OverflowClient) -> Result<(), ErrorCode>;
+}
+
+pub trait CounterOverflow<'a>: Counter<'a> {
+  fn set_overflow_client(&self, client: &'a dyn OverflowClient);
 }
 ```
 
@@ -446,6 +454,7 @@ This TRD obsoletes TRD 101, and the changes include:
       generic parameters when there is only a single concrete type.
   * Added `ticks_to_` helper methods on `ConvertTicks`
   * Added a few more support methods on `Ticks` trait.
+  * Extracted overflow management from `Counter` into a separate `CounterOverflow` trait to provide compile-time guarantees for hardware support.
 
 12 Authors' Address
 =================================

--- a/doc/reference/trd105-time.md
+++ b/doc/reference/trd105-time.md
@@ -188,7 +188,7 @@ pub trait Counter<'a>: Time {
   fn stop(&self) -> Result<(), ErrorCode>;
   fn reset(&self) -> Result<(), ErrorCode>;
   fn is_running(&self) -> bool;
-  fn set_overflow_client(&self, &'a dyn OverflowClient);
+  fn set_overflow_client(&self, client: &'a dyn OverflowClient) -> Result<(), ErrorCode>;
 }
 ```
 

--- a/doc/reference/trdxxx-time.md
+++ b/doc/reference/trdxxx-time.md
@@ -1,14 +1,13 @@
 Kernel Time HIL
 ========================================
 
-**TRD:** 105<br/>
+**TRD:** xxx<br/>
 **Working Group:** Kernel<br/>
 **Type:** Documentary<br/>
 **Status:** Draft <br/>
-**Obsoletes:** 101 <br/>
-**Author:** Guillaume Endignoux, Amit Levy, Philip Levis, and Jett Rink <br/>
-**Draft-Created:** 2021/07/23 <br/>
-**Draft-Modified:** 2021/07/23 <br/>
+**Obsoletes:** 105 <br/>
+**Author:** Guillaume Endignoux, Amit Levy, Philip Levis, Jett Rink and Gabriel Stanciu<br/>
+**Draft-Created:** 2026/06/09 <br/>
 **Draft-Version:** 1.0 <br/>
 **Draft-Discuss:** Github PR <br/>
 
@@ -30,15 +29,16 @@ broad categories: alarms and timers. Alarms continuously increment a clock and
 can fire an event when the clock reaches a specific value. Timers can fire an
 event after a certain number of clock ticks have elapsed.
 
-The time HIL is in the kernel crate, in module `hil::time`. It provides six
+The time HIL is in the kernel crate, in module `hil::time`. It provides several
 main traits:
 
 
   * `kernel::hil::time::Time`: provides an abstraction of a moment in time. It has two associated types. One describes the width and maximum value of a time value. The other specifies the frequency of the ticks of the time value.
   * `kernel::hil::time::Counter`: derives from `Time` and provides an abstraction of a free-running counter that can be started or stopped. A `Counter`'s moment in time is the current value of the counter.
+  * `kernel::hil::time::CounterOverflow`: derives from `Counter`, and provides an abstraction for hardware counters that can generate overflow notifications.
   * `kernel::hil::time::Alarm`: derives from `Time`, and provides an abstraction of being able to receive a callback at a future moment in time.
   * `kernel::hil::time::Timer`: derives from `Time`, and provides an abstraction of being able to receive a callback at some amount of time in the future, or a series of callbacks at a given period.
-  * `kernel::hil::time::OverflowClient`: handles an overflow callback from a `Counter`.
+  * `kernel::hil::time::OverflowClient`: handles an overflow callback from a `CounterOverflow`.
   * `kernel::hil::time::AlarmClient`: handles the callback from an `Alarm`.
   * `kernel::hil::time::TimerClient`: handles the callback from a `Timer`.
 
@@ -170,13 +170,16 @@ is 30.5 microseconds.
 [associated_type]: https://doc.rust-lang.org/book/ch19-03-advanced-traits.html#specifying-placeholder-types-in-trait-definitions-with-associated-types
 
 
-3 `Counter` and `OverflowClient` traits
+3 `Counter`, `CounterOverflow`, and `OverflowClient` traits
 ===============================
 
 The `Counter` trait is the abstraction of a free-running counter that
 can be started and stopped. This trait derives from the `Time` trait, so
-it has associated `Frequency` and `Tick` types. The `Counter` trait
-allows a client to register for callbacks when the counter overflows.
+it has associated `Frequency` and `Tick` types.
+
+To support hardware that can explicitly notify the system when the timer
+wraps around, the `CounterOverflow` trait extends `Counter`. This is provided
+as a separate extension trait so that support is explicit at compile-time.
 
 ```rust
 pub trait OverflowClient {
@@ -188,7 +191,10 @@ pub trait Counter<'a>: Time {
   fn stop(&self) -> Result<(), ErrorCode>;
   fn reset(&self) -> Result<(), ErrorCode>;
   fn is_running(&self) -> bool;
-  fn set_overflow_client(&self, &'a dyn OverflowClient);
+}
+
+pub trait CounterOverflow<'a>: Counter<'a> {
+  fn set_overflow_client(&self, client: &'a dyn OverflowClient);
 }
 ```
 
@@ -433,19 +439,12 @@ The traits and abstractions in this document draw from contributions
 and ideas from Patrick Mooney and Guillaume Endignoux as well as
 others.
 
-11 Modification After TRD 101
+11 Modification After TRD 105
 ===============================
 
-This TRD obsoletes TRD 101, and the changes include:
+This TRD obsoletes TRD 105, and the changes include:
 
-  * The `tick_from_` helper methods moved from `Time` trait to `ConvertTicks`
-    trait
-    * This allow downstream clients to use trait objects (i.e. `dyn`) with the
-      `Time`, `Alarm`, and `Timer` traits. Even though it is possible to use
-      trait objects with `Time` and sub traits, it is still beneficial to use
-      generic parameters when there is only a single concrete type.
-  * Added `ticks_to_` helper methods on `ConvertTicks`
-  * Added a few more support methods on `Ticks` trait.
+  * Extracted overflow management from `Counter` into a separate `CounterOverflow` trait to provide compile-time guarantees for hardware support.
 
 12 Authors' Address
 =================================
@@ -465,4 +464,7 @@ guillaumee@google.com
 
 Jett Rink
 jettrink@google.com
+
+Gabriel Stanciu
+github.com/stanciugabriel
 ```

--- a/kernel/src/hil/time.rs
+++ b/kernel/src/hil/time.rs
@@ -234,16 +234,6 @@ pub trait OverflowClient {
 
 /// Represents a free-running hardware counter that can be started and stopped.
 pub trait Counter<'a>: Time {
-    /// Specify the callback for when the counter overflows its maximum
-    /// value (defined by `Ticks`). If there was a previously registered
-    /// callback this call replaces it.
-    ///
-    /// Valid `Result<(), ErrorCode>` values are:
-    ///   - `Ok(())`: The client was successfully registered.
-    ///   - `Err(ErrorCode::NOSUPPORT)`: The underlying hardware does not support
-    ///     generating interrupts or notifications on counter overflow.
-    fn set_overflow_client(&self, client: &'a dyn OverflowClient) -> Result<(), ErrorCode>;
-
     /// Starts the free-running hardware counter. Valid `Result<(), ErrorCode>` values are:
     ///   - `Ok(())`: the counter is now running
     ///   - `Err(ErrorCode::OFF)`: underlying clocks or other hardware resources
@@ -272,6 +262,11 @@ pub trait Counter<'a>: Time {
 
     /// Returns whether the counter is currently running.
     fn is_running(&self) -> bool;
+}
+
+/// Extension trait for counters that support hardware overflow notifications.
+pub trait CounterOverflow<'a>: Counter<'a> {
+    fn set_overflow_client(&self, client: &'a dyn OverflowClient);
 }
 
 /// Callback handler for when an Alarm fires (a `Counter` reaches a specific

--- a/kernel/src/hil/time.rs
+++ b/kernel/src/hil/time.rs
@@ -265,6 +265,9 @@ pub trait Counter<'a>: Time {
 }
 
 /// Extension trait for counters that support hardware overflow notifications.
+#[deprecated(
+    note = "set_overflow_client never used so moved to an independent trait. Set to be removed in future releases unless a concrete use case is raised."
+)]
 pub trait CounterOverflow<'a>: Counter<'a> {
     fn set_overflow_client(&self, client: &'a dyn OverflowClient);
 }

--- a/kernel/src/hil/time.rs
+++ b/kernel/src/hil/time.rs
@@ -237,7 +237,12 @@ pub trait Counter<'a>: Time {
     /// Specify the callback for when the counter overflows its maximum
     /// value (defined by `Ticks`). If there was a previously registered
     /// callback this call replaces it.
-    fn set_overflow_client(&self, client: &'a dyn OverflowClient);
+    ///
+    /// Valid `Result<(), ErrorCode>` values are:
+    ///   - `Ok(())`: The client was successfully registered.
+    ///   - `Err(ErrorCode::NOSUPPORT)`: The underlying hardware does not support
+    ///     generating interrupts or notifications on counter overflow.
+    fn set_overflow_client(&self, client: &'a dyn OverflowClient) -> Result<(), ErrorCode>;
 
     /// Starts the free-running hardware counter. Valid `Result<(), ErrorCode>` values are:
     ///   - `Ok(())`: the counter is now running


### PR DESCRIPTION
### Pull Request Overview

This pull request resolves issue #4866 by moving hardware timer overflow support into a separate extension trait called CounterOverflow.

Previously, the main Counter trait forced unsupported hardware to include dummy overflow functions that could fail silently, like we saw in the earlgrey chip. Instead of using a runtime Result to patch this, we are now using the type system to guarantee support at compile time.

The main Counter trait is now completely free of overflow logic. The nrf5x chip explicitly implements the new CounterOverflow trait to preserve its hardware support. Also, all the dummy overflow code has been completely deleted from unsupported chips like esp32, apollo3, sam4l, msp432, stm32, and earlgrey. Finally, the trd105 documentation has been updated to reflect this new design.

### Testing Strategy

Verified multiple boards using `make check`(including hail, apollo3, esp32-c3, earlgrey-cw310, and other relevant boards).


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
~No AI was used.~ AI was used for the documentation changes and commit message(wanted something more explicit because of the breaking changes).