### PR TITLE
arch: cortex-m: Remove static mut global variables

### DIFF
--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -195,35 +195,7 @@ pub unsafe extern "C" fn initialize_ram_jump_to_main() {
 }
 
 pub unsafe fn print_cortexm_state(writer: &mut dyn Write) {
-    let _ccr: u32;
-    let cfsr: u32;
-    let hfsr: u32;
-    let mmfar: u32;
-    let bfar: u32;
-
-    // Retrieve the stored SCB register values using assembly.
-    unsafe {
-        core::arch::asm!(
-                "
-    ldr r0, =SCB_REGISTERS            // r0 = &SCB_REGISTERS
-    ldr r1, [r0]                      // r1 = _ccr = SCB_REGISTERS[0]
-    add r0, r0, #4                    // r0 = &SCB_REGISTERS[1]
-    ldr r2, [r0]                      // r2 = cfsr = SCB_REGISTERS[1]
-    add r0, r0, #4                    // r0 = &SCB_REGISTERS[2]
-    ldr r3, [r0]                      // r3 = hfsr = SCB_REGISTERS[2]
-    add r0, r0, #4                    // r0 = &SCB_REGISTERS[3]
-    ldr r4, [r0]                      // r4 = mmfar = SCB_REGISTERS[3]
-    add r0, r0, #4                    // r0 = &SCB_REGISTERS[4]
-    ldr r5, [r0]                      // r5 = bfar = SCB_REGISTERS[4]
-                    ",
-                out("r0") _,
-                out("r1") _ccr,
-                out("r2") cfsr,
-                out("r3") hfsr,
-                out("r4") mmfar,
-                out("r5") bfar,
-        );
-    }
+    let (_ccr, cfsr, hfsr, mmfar, bfar) = crate::syscall::get_global_scb_registers();
 
     let iaccviol = (cfsr & 0x01) == 0x01;
     let daccviol = (cfsr & 0x02) == 0x02;

--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -195,11 +195,35 @@ pub unsafe extern "C" fn initialize_ram_jump_to_main() {
 }
 
 pub unsafe fn print_cortexm_state(writer: &mut dyn Write) {
-    let _ccr = syscall::SCB_REGISTERS[0];
-    let cfsr = syscall::SCB_REGISTERS[1];
-    let hfsr = syscall::SCB_REGISTERS[2];
-    let mmfar = syscall::SCB_REGISTERS[3];
-    let bfar = syscall::SCB_REGISTERS[4];
+    let _ccr: u32;
+    let cfsr: u32;
+    let hfsr: u32;
+    let mmfar: u32;
+    let bfar: u32;
+
+    // Retrieve the stored SCB register values using assembly.
+    unsafe {
+        core::arch::asm!(
+                "
+    ldr r0, =SCB_REGISTERS            // r0 = &SCB_REGISTERS
+    ldr r1, [r0]                      // r1 = _ccr = SCB_REGISTERS[0]
+    add r0, r0, #4                    // r0 = &SCB_REGISTERS[1]
+    ldr r2, [r0]                      // r2 = cfsr = SCB_REGISTERS[1]
+    add r0, r0, #4                    // r0 = &SCB_REGISTERS[2]
+    ldr r3, [r0]                      // r3 = hfsr = SCB_REGISTERS[2]
+    add r0, r0, #4                    // r0 = &SCB_REGISTERS[3]
+    ldr r4, [r0]                      // r4 = mmfar = SCB_REGISTERS[3]
+    add r0, r0, #4                    // r0 = &SCB_REGISTERS[4]
+    ldr r5, [r0]                      // r5 = bfar = SCB_REGISTERS[4]
+                    ",
+                out("r0") _,
+                out("r1") _ccr,
+                out("r2") cfsr,
+                out("r3") hfsr,
+                out("r4") mmfar,
+                out("r5") bfar,
+        );
+    }
 
     let iaccviol = (cfsr & 0x01) == 0x01;
     let daccviol = (cfsr & 0x02) == 0x02;

--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -7,6 +7,7 @@
 //! Implementation of the architecture-specific portions of the kernel-userland
 //! system call interface.
 
+use core::cell::UnsafeCell;
 use core::fmt::Write;
 use core::marker::PhantomData;
 use core::mem::{self, size_of};
@@ -21,7 +22,7 @@ use crate::CortexMVariant;
 /// specific handler.
 #[no_mangle]
 #[used]
-pub static mut SYSCALL_FIRED: usize = 0;
+pub static mut SYSCALL_FIRED: UnsafeCell<usize> = UnsafeCell::new(0);
 
 /// This is called in the hard fault handler. When set to 1 this means the hard
 /// fault handler was called. Marked `pub` because it is used in the cortex-m*
@@ -31,7 +32,7 @@ pub static mut SYSCALL_FIRED: usize = 0;
 /// for handling application hard faults.
 #[no_mangle]
 #[used]
-pub static mut APP_HARD_FAULT: usize = 0;
+pub static mut APP_HARD_FAULT: UnsafeCell<usize> = UnsafeCell::new(0);
 
 /// This is used in the hardfault handler.
 ///
@@ -40,7 +41,7 @@ pub static mut APP_HARD_FAULT: usize = 0;
 /// be displayed in a diagnostic fault message.
 #[no_mangle]
 #[used]
-pub static mut SCB_REGISTERS: [u32; 5] = [0; 5];
+pub static mut SCB_REGISTERS: UnsafeCell<[u32; 5]> = UnsafeCell::new([0; 5]);
 
 /// Get the `APP_HARD_FAULT` flag.
 ///

--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -20,6 +20,9 @@ use crate::CortexMVariant;
 /// This is used in the syscall handler. When set to 1 this means the
 /// svc_handler was called. Marked `pub` because it is used in the cortex-m*
 /// specific handler.
+///
+/// Because this is a global `static mut` variable, we can only access it from
+/// inline assembly.
 #[no_mangle]
 #[used]
 pub static mut SYSCALL_FIRED: UnsafeCell<usize> = UnsafeCell::new(0);
@@ -30,6 +33,9 @@ pub static mut SYSCALL_FIRED: UnsafeCell<usize> = UnsafeCell::new(0);
 ///
 /// n.b. If the kernel hard faults, it immediately panic's. This flag is only
 /// for handling application hard faults.
+///
+/// Because this is a global `static mut` variable, we can only access it from
+/// inline assembly.
 #[no_mangle]
 #[used]
 pub static mut APP_HARD_FAULT: UnsafeCell<usize> = UnsafeCell::new(0);
@@ -39,6 +45,9 @@ pub static mut APP_HARD_FAULT: UnsafeCell<usize> = UnsafeCell::new(0);
 /// When an app faults, the hardfault handler stores the value of the
 /// SCB registers in this static array. This makes them available to
 /// be displayed in a diagnostic fault message.
+///
+/// Because this is a global `static mut` variable, we can only access it from
+/// inline assembly.
 #[no_mangle]
 #[used]
 pub static mut SCB_REGISTERS: UnsafeCell<[u32; 5]> = UnsafeCell::new([0; 5]);

--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -65,8 +65,8 @@ pub fn get_global_app_hard_fault() -> usize {
     // # Safety
     //
     // This is safe as long as the static memory is defined, of the correct
-    // size, and aligned correctly. We ensure these conditions are met by the
-    // assembly that defines these global variables.
+    // size, and aligned correctly. We ensure these conditions are met by
+    // creating the variable as an Rust type in an `UnsafeCell`.
     unsafe {
         core::arch::asm!(
             "
@@ -97,8 +97,8 @@ pub fn get_global_syscall_fired() -> usize {
     // # Safety
     //
     // This is safe as long as the static memory is defined, of the correct
-    // size, and aligned correctly. We ensure these conditions are met by the
-    // assembly that defines these global variables.
+    // size, and aligned correctly. We ensure these conditions are met by
+    // creating the variable as an Rust type in an `UnsafeCell`.
     unsafe {
         core::arch::asm!(
             "
@@ -145,8 +145,8 @@ pub fn get_global_scb_registers() -> (u32, u32, u32, u32, u32) {
     // # Safety
     //
     // This is safe as long as the static memory is defined, of the correct
-    // size, and aligned correctly. We ensure these conditions are met by the
-    // assembly that defines these global variables.
+    // size, and aligned correctly. We ensure these conditions are met by
+    // creating the variable as an Rust type in an `UnsafeCell`.
     unsafe {
         core::arch::asm!(
             "

--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -11,36 +11,55 @@ use core::fmt::Write;
 use core::marker::PhantomData;
 use core::mem::{self, size_of};
 use core::ops::Range;
-use core::ptr::{self, addr_of, addr_of_mut, read_volatile, write_volatile};
+use core::ptr;
 use kernel::errorcode::ErrorCode;
 
 use crate::CortexMVariant;
 
-/// This is used in the syscall handler. When set to 1 this means the
-/// svc_handler was called. Marked `pub` because it is used in the cortex-m*
-/// specific handler.
-#[no_mangle]
-#[used]
-pub static mut SYSCALL_FIRED: usize = 0;
+// Global variables used by the cortex-m arch implementation.
+//
+// These track state between exception handlers and the syscall context
+// switching code.
+core::arch::global_asm!(
+    "
+    // This is used in the syscall handler. When set to 1 this means the
+    // svc_handler was called.
+    //
+    // pub static mut SYSCALL_FIRED: usize = 0;
+.section .data
+.global SYSCALL_FIRED
+.align 4
+SYSCALL_FIRED:
+    .word 0x00000000                  // SYSCALL_FIRED = 0
 
-/// This is called in the hard fault handler. When set to 1 this means the hard
-/// fault handler was called. Marked `pub` because it is used in the cortex-m*
-/// specific handler.
-///
-/// n.b. If the kernel hard faults, it immediately panic's. This flag is only
-/// for handling application hard faults.
-#[no_mangle]
-#[used]
-pub static mut APP_HARD_FAULT: usize = 0;
+    // This is called in the hard fault handler. When set to 1 this means the
+    // hard fault handler was called.
+    //
+    // pub static mut APP_HARD_FAULT: usize = 0;
+.section .data
+.global APP_HARD_FAULT
+.align 4
+APP_HARD_FAULT:
+    .word 0x00000000                  // APP_HARD_FAULT = 0
 
-/// This is used in the hardfault handler.
-///
-/// When an app faults, the hardfault handler stores the value of the
-/// SCB registers in this static array. This makes them available to
-/// be displayed in a diagnostic fault message.
-#[no_mangle]
-#[used]
-pub static mut SCB_REGISTERS: [u32; 5] = [0; 5];
+    // This is used in the hardfault handler.
+    //
+    // When an app faults, the hardfault handler stores the value of the
+    // SCB registers in this static array. This makes them available to
+    // be displayed in a diagnostic fault message.
+    //
+    // pub static mut SCB_REGISTERS: [u32; 5] = [0; 5];
+.section .data
+.global SCB_REGISTERS
+.align 4
+SCB_REGISTERS:
+    .word 0x00000000                  // SCB_REGISTERS[0] = 0
+    .word 0x00000000                  // SCB_REGISTERS[1] = 0
+    .word 0x00000000                  // SCB_REGISTERS[2] = 0
+    .word 0x00000000                  // SCB_REGISTERS[3] = 0
+    .word 0x00000000                  // SCB_REGISTERS[4] = 0
+    "
+);
 
 /// This holds all of the state that the kernel must keep for the process when
 /// the process is not executing.
@@ -278,13 +297,43 @@ impl<A: CortexMVariant> kernel::syscall::UserspaceKernelBoundary for SysCall<A> 
 
         // Check to see if the fault handler was called while the process was
         // running.
-        let app_fault = read_volatile(&*addr_of!(APP_HARD_FAULT));
-        write_volatile(&mut *addr_of_mut!(APP_HARD_FAULT), 0);
+        //
+        // We need to do this in assembly because we cannot have Rust access
+        // the global variable.
+        let app_fault: usize;
+        unsafe {
+            core::arch::asm!(
+                    "
+    ldr r0, =APP_HARD_FAULT           // r0 = &APP_HARD_FAULT
+    mov r1, #0                        // r1 = 0
+    ldr r2, [r0]                      // r2 = *APP_HARD_FAULT
+    str r1, [r0]                      // *APP_HARD_FAULT = 0
+                    ",
+                    out("r0") _,
+                    out("r1") _,
+                    out("r2") app_fault,
+            );
+        }
 
         // Check to see if the svc_handler was called and the process called a
         // syscall.
-        let syscall_fired = read_volatile(&*addr_of!(SYSCALL_FIRED));
-        write_volatile(&mut *addr_of_mut!(SYSCALL_FIRED), 0);
+        //
+        // We need to do this in assembly because we cannot have Rust access
+        // the global variable.
+        let syscall_fired: usize;
+        unsafe {
+            core::arch::asm!(
+                    "
+    ldr r0, =SYSCALL_FIRED            // r0 = &SYSCALL_FIRED
+    mov r1, #0                        // r1 = 0
+    ldr r2, [r0]                      // r2 = *SYSCALL_FIRED
+    str r1, [r0]                      // *SYSCALL_FIRED = 0
+                    ",
+                    out("r0") _,
+                    out("r1") _,
+                    out("r2") syscall_fired,
+            );
+        }
 
         // Now decide the reason based on which flags were set.
         let switch_reason = if app_fault == 1 || invalid_stack_pointer {

--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -42,6 +42,142 @@ pub static mut APP_HARD_FAULT: usize = 0;
 #[used]
 pub static mut SCB_REGISTERS: [u32; 5] = [0; 5];
 
+/// Get the `APP_HARD_FAULT` flag.
+///
+/// This indicates that the app triggered the hard fault handler.
+///
+/// We need to do this in assembly because we cannot have Rust access
+/// the global variable.
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+pub fn get_global_app_hard_fault() -> usize {
+    let app_fault: usize;
+
+    // # Safety
+    //
+    // This is safe as long as the static memory is defined, of the correct
+    // size, and aligned correctly. We ensure these conditions are met by the
+    // assembly that defines these global variables.
+    unsafe {
+        core::arch::asm!(
+            "
+    ldr  r0, =APP_HARD_FAULT          // r0 = &APP_HARD_FAULT
+    movs r1, #0                       // r1 = 0
+    ldr  r2, [r0]                     // r2 = *APP_HARD_FAULT
+    str  r1, [r0]                     // *APP_HARD_FAULT = 0
+            ",
+            out("r0") _,
+            out("r1") _,
+            out("r2") app_fault,
+            // clobbers flags
+        );
+    }
+    app_fault
+}
+
+/// Get the `SYSCALL_FIRED` flag.
+///
+/// This indicates that the app called a syscall.
+///
+/// We need to do this in assembly because we cannot have Rust access
+/// the global variable.
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+pub fn get_global_syscall_fired() -> usize {
+    let syscall_fired: usize;
+
+    // # Safety
+    //
+    // This is safe as long as the static memory is defined, of the correct
+    // size, and aligned correctly. We ensure these conditions are met by the
+    // assembly that defines these global variables.
+    unsafe {
+        core::arch::asm!(
+            "
+    ldr  r0, =SYSCALL_FIRED           // r0 = &SYSCALL_FIRED
+    movs r1, #0                       // r1 = 0
+    ldr  r2, [r0]                     // r2 = *SYSCALL_FIRED
+    str  r1, [r0]                     // *SYSCALL_FIRED = 0
+            ",
+            out("r0") _,
+            out("r1") _,
+            out("r2") syscall_fired,
+            // clobbers flags
+        )
+    }
+    syscall_fired
+}
+
+/// Get the stored System Control Block register values.
+///
+/// These are recorded during the fault, and then stored in the global
+/// `SCB_REGISTERS` array for use later during debugging.
+///
+/// We need to do this in assembly because we cannot have Rust access
+/// the global variable.
+#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+pub fn get_global_scb_registers() -> (u32, u32, u32, u32, u32) {
+    let _ccr: u32;
+    let cfsr: u32;
+    let hfsr: u32;
+    let mmfar: u32;
+    let bfar: u32;
+
+    // Need this for compatibility with armv6.
+    //
+    // Using the normal `ldr  r0, =SCB_REGISTERS` gives
+    // "error: out of range pc-relative fixup value". So, instead, we pass in a
+    // pointer based on the symbol.
+    extern "C" {
+        static SCB_REGISTERS: u32;
+    }
+
+    // Retrieve the stored SCB register values using assembly.
+    //
+    // # Safety
+    //
+    // This is safe as long as the static memory is defined, of the correct
+    // size, and aligned correctly. We ensure these conditions are met by the
+    // assembly that defines these global variables.
+    unsafe {
+        core::arch::asm!(
+            "
+    // Load all values of the SCB_REGISTERS array. Avoid ldm because
+    // it is not compatible with armv6.
+    ldr r1, [{addr}, #0]              // r1 = _ccr = SCB_REGISTERS[0]
+    ldr r2, [{addr}, #4]              // r2 = cfsr = SCB_REGISTERS[1]
+    ldr r3, [{addr}, #8]              // r3 = hfsr = SCB_REGISTERS[2]
+    ldr r4, [{addr}, #12]             // r4 = mmfar = SCB_REGISTERS[3]
+    ldr r5, [{addr}, #16]             // r5 = bfar = SCB_REGISTERS[4]
+            ",
+            addr = in(reg) core::ptr::from_ref::<u32>(&SCB_REGISTERS),
+            out("r1") _ccr,
+            out("r2") cfsr,
+            out("r3") hfsr,
+            out("r4") mmfar,
+            out("r5") bfar,
+        );
+    }
+
+    (_ccr, cfsr, hfsr, mmfar, bfar)
+}
+
+/// Dummy
+#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+pub fn get_global_app_hard_fault() -> usize {
+    0
+}
+
+/// Dummy
+#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+pub fn get_global_syscall_fired() -> usize {
+    0
+}
+
+/// Dummy
+#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+pub fn get_global_scb_registers() -> (u32, u32, u32, u32, u32) {
+    (0, 0, 0, 0, 0)
+}
+
 /// This holds all of the state that the kernel must keep for the process when
 /// the process is not executing.
 #[derive(Default)]
@@ -278,43 +414,11 @@ impl<A: CortexMVariant> kernel::syscall::UserspaceKernelBoundary for SysCall<A> 
 
         // Check to see if the fault handler was called while the process was
         // running.
-        //
-        // We need to do this in assembly because we cannot have Rust access
-        // the global variable.
-        let app_fault: usize;
-        unsafe {
-            core::arch::asm!(
-                    "
-    ldr r0, =APP_HARD_FAULT           // r0 = &APP_HARD_FAULT
-    mov r1, #0                        // r1 = 0
-    ldr r2, [r0]                      // r2 = *APP_HARD_FAULT
-    str r1, [r0]                      // *APP_HARD_FAULT = 0
-                    ",
-                    out("r0") _,
-                    out("r1") _,
-                    out("r2") app_fault,
-            );
-        }
+        let app_fault = get_global_app_hard_fault();
 
         // Check to see if the svc_handler was called and the process called a
         // syscall.
-        //
-        // We need to do this in assembly because we cannot have Rust access
-        // the global variable.
-        let syscall_fired: usize;
-        unsafe {
-            core::arch::asm!(
-                    "
-    ldr r0, =SYSCALL_FIRED            // r0 = &SYSCALL_FIRED
-    mov r1, #0                        // r1 = 0
-    ldr r2, [r0]                      // r2 = *SYSCALL_FIRED
-    str r1, [r0]                      // *SYSCALL_FIRED = 0
-                    ",
-                    out("r0") _,
-                    out("r1") _,
-                    out("r2") syscall_fired,
-            );
-        }
+        let syscall_fired = get_global_syscall_fired();
 
         // Now decide the reason based on which flags were set.
         let switch_reason = if app_fault == 1 || invalid_stack_pointer {

--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -16,50 +16,31 @@ use kernel::errorcode::ErrorCode;
 
 use crate::CortexMVariant;
 
-// Global variables used by the cortex-m arch implementation.
-//
-// These track state between exception handlers and the syscall context
-// switching code.
-core::arch::global_asm!(
-    "
-    // This is used in the syscall handler. When set to 1 this means the
-    // svc_handler was called.
-    //
-    // pub static mut SYSCALL_FIRED: usize = 0;
-.section .data
-.global SYSCALL_FIRED
-.align 4
-SYSCALL_FIRED:
-    .word 0x00000000                  // SYSCALL_FIRED = 0
+/// This is used in the syscall handler. When set to 1 this means the
+/// svc_handler was called. Marked `pub` because it is used in the cortex-m*
+/// specific handler.
+#[no_mangle]
+#[used]
+pub static mut SYSCALL_FIRED: usize = 0;
 
-    // This is called in the hard fault handler. When set to 1 this means the
-    // hard fault handler was called.
-    //
-    // pub static mut APP_HARD_FAULT: usize = 0;
-.section .data
-.global APP_HARD_FAULT
-.align 4
-APP_HARD_FAULT:
-    .word 0x00000000                  // APP_HARD_FAULT = 0
+/// This is called in the hard fault handler. When set to 1 this means the hard
+/// fault handler was called. Marked `pub` because it is used in the cortex-m*
+/// specific handler.
+///
+/// n.b. If the kernel hard faults, it immediately panic's. This flag is only
+/// for handling application hard faults.
+#[no_mangle]
+#[used]
+pub static mut APP_HARD_FAULT: usize = 0;
 
-    // This is used in the hardfault handler.
-    //
-    // When an app faults, the hardfault handler stores the value of the
-    // SCB registers in this static array. This makes them available to
-    // be displayed in a diagnostic fault message.
-    //
-    // pub static mut SCB_REGISTERS: [u32; 5] = [0; 5];
-.section .data
-.global SCB_REGISTERS
-.align 4
-SCB_REGISTERS:
-    .word 0x00000000                  // SCB_REGISTERS[0] = 0
-    .word 0x00000000                  // SCB_REGISTERS[1] = 0
-    .word 0x00000000                  // SCB_REGISTERS[2] = 0
-    .word 0x00000000                  // SCB_REGISTERS[3] = 0
-    .word 0x00000000                  // SCB_REGISTERS[4] = 0
-    "
-);
+/// This is used in the hardfault handler.
+///
+/// When an app faults, the hardfault handler stores the value of the
+/// SCB registers in this static array. This makes them available to
+/// be displayed in a diagnostic fault message.
+#[no_mangle]
+#[used]
+pub static mut SCB_REGISTERS: [u32; 5] = [0; 5];
 
 /// This holds all of the state that the kernel must keep for the process when
 /// the process is not executing.


### PR DESCRIPTION


### Pull Request Overview

Part of #3841.

This removes the `static mut` Rust globals we use to track state between the exception handlers and the main syscall context switch code. All variables are now created as `static mut UnsafeCell`s, and only accessed using assembly. ~~There are no types in Rust.~~

This is my attempt based on discussions on element and on the core call. ~~It's possible this is not actually what we want.~~ It seems like this is a valid solution.


### Testing Strategy

I ran a handful of apps on the nRF52840dk, including the crash_dummy app to see that panics print the same.


### TODO or Help Wanted

Is this sound/correct?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.

I asked claude some questions about asm but I wrote all code.