### PR TITLE
arch/riscv: implement running_thread_id() for RV64

### DIFF
--- a/arch/riscv/src/thread_id.rs
+++ b/arch/riscv/src/thread_id.rs
@@ -15,7 +15,13 @@ pub enum RiscvThreadIdProvider {}
 // return the thread ID. On single-core platforms the thread ID only depends on
 // whether execution is in an interrupt service routine or not, which is what
 // this implementation checks for.
-#[cfg(all(target_arch = "riscv32", target_os = "none"))]
+//
+// The assembly (read `mhartid`, load the `_trap_handler_active` symbol address,
+// read a `usize`) is XLEN-agnostic, so the same code serves both rv32 and rv64.
+#[cfg(all(
+    any(target_arch = "riscv32", target_arch = "riscv64"),
+    target_os = "none"
+))]
 unsafe impl ThreadIdProvider for RiscvThreadIdProvider {
     /// Return the current thread ID, computed using the `mhartid` (hardware thread
     /// ID), and a flag indicating whether the current hart is currently in a trap
@@ -79,8 +85,11 @@ unsafe impl ThreadIdProvider for RiscvThreadIdProvider {
     }
 }
 
-// Mock implementation for non-rv32 target builds
-#[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
+// Mock implementation for non-RISC-V (host / doc) target builds
+#[cfg(not(all(
+    any(target_arch = "riscv32", target_arch = "riscv64"),
+    target_os = "none"
+)))]
 unsafe impl ThreadIdProvider for RiscvThreadIdProvider {
     fn running_thread_id() -> usize {
         unimplemented!()


### PR DESCRIPTION
## Pull Request Overview

`running_thread_id()` in `arch/riscv/src/thread_id.rs` was `unimplemented!()` for any target other than riscv32. Like the CSR paths fixed in #4865, this RV64 path had simply never been compiled or exercised (no RV64 board existed). The implementation — read `mhartid`, load the `_trap_handler_active` symbol address, read a `usize` — is XLEN-agnostic, so this widens the `cfg` to also cover `riscv64` (the non-RISC-V host/doc build keeps the `unimplemented!()` mock). Without it, any use of `DeferredCall` / `SingleThreadValue` panics on RV64 (a UART driver, for example, builds a `DeferredCall`).

The rv32 path is unchanged. Groundwork toward #2332 (64-bit RISC-V support), independent of any board.

## Testing Strategy

Builds clean and warning-free for `riscv64imac-unknown-none-elf`; rv32 and host are unchanged. `make prepush` (format-check, clippy, syntax, licensecheck) passes clean.

## TODO or Help Wanted

None — this is a standalone RV64 enablement fix.

## Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

## Formatting

- [x] Ran `make prepush`.

## AI Use

This change was developed with the assistance of an AI coding assistant (Claude / Claude Code) and reviewed before submission.

- [x] The PR description details my use of AI in the production of the code in this PR, if any, and I have manually checked and personally certify the entire contents of this PR.