### PR TITLE
kernel: app restarting dirty state leakage fix

### DIFF
--- a/kernel/src/capabilities.rs
+++ b/kernel/src/capabilities.rs
@@ -62,6 +62,14 @@ pub unsafe trait ProcessManagementCapability {}
 /// so only modules which check this may do so.
 pub unsafe trait ProcessStartCapability {}
 
+/// The `ProcessRestartCapability` allows the holder to restart a process.
+///
+/// This is separate from and a subset of the functionality the
+/// `ProcessManagementCapability` possesses. This provides a
+/// finer grained permission for restarting a process without granting
+/// all process management functionality.
+pub unsafe trait ProcessRestartCapability {}
+
 /// The `MainLoopCapability` capability allows the holder to start executing as
 /// well as manage the main scheduler loop in Tock.
 ///

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -330,6 +330,24 @@ impl Kernel {
         }
     }
 
+    /// Attempt to restart the process identified by `pid`.
+    ///
+    /// Has no effect if `pid` does not match a currently loaded process, or
+    /// if the kernel policy declines to restart it.
+    ///
+    /// Restarting a process is a privileged operation and therefore requires
+    /// the [`ProcessRestartCapability`](crate::capabilities::ProcessRestartCapability)
+    /// to call this method.
+    pub fn restart_process<C: capabilities::ProcessRestartCapability>(
+        &self,
+        pid: ProcessId,
+        _capability: &C,
+    ) {
+        self.get_process(pid).map(|process| {
+            process.enqueue_process_restart();
+        });
+    }
+
     /// Perform one iteration of the core Tock kernel loop.
     ///
     /// This function is responsible for three main operations:
@@ -468,6 +486,16 @@ impl Kernel {
         ipc: Option<&crate::ipc::IPC<NUM_PROCS>>,
         timeslice_us: Option<NonZeroU32>,
     ) -> (process::StoppedExecutingReason, Option<u32>) {
+        // Before performing any process work, first see if this application
+        // has a pending restart enqueued.
+        if process.has_pending_restart() {
+            // Restarting the process is unsafe if performed in the context of
+            // handling certain syscalls. Because this is handled here and all
+            // kernel functionality to handle syscalls runs to completion, we can
+            // safely call `try_restart` here.
+            unsafe { process.try_restart(None) };
+        }
+
         // We must use a dummy scheduler timer if the process should be executed
         // without any timeslice restrictions. Note, a chip may not provide a
         // real scheduler timer implementation even if a timeslice is requested.
@@ -1425,7 +1453,11 @@ impl Kernel {
                     }
                     // The process called the `exit-restart` system call.
                     1 => {
-                        process.try_restart(Some(completion_code as u32));
+                        // This is safe so long as we do not call `set_syscall_return_value`
+                        // after calling `try_restart` (occurs in `_` branch).
+                        unsafe {
+                            process.try_restart(Some(completion_code as u32));
+                        }
                         None
                     }
                     // The process called an invalid variant of the Exit

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -494,7 +494,18 @@ pub trait Process {
     /// with `Some(u32)`. If the kernel is trying to restart the process and the
     /// process did not provide a completion code, then this should be called
     /// with `None`.
-    fn try_restart(&self, completion_code: Option<u32>);
+    ///
+    /// ### Safety
+    ///
+    /// This function must not be called from the context of handling a
+    /// command syscall or any instance where the kernel implicitly expects
+    /// the process to still be alive (e.g., calling `set_syscall_return_val`).
+    /// Violating these conditions will result in the kernel writing the
+    /// command syscall return value to the now invalid/freed UKB.
+    ///
+    /// The implementation must clear any Process state (e.g., via the
+    /// `Process` `terminate` method).
+    unsafe fn try_restart(&self, completion_code: Option<u32>);
 
     /// Stop and clear a process's state and put it into the
     /// [`Terminated`](State::Terminated) state.
@@ -853,6 +864,14 @@ pub trait Process {
     /// Print out the full state of the process: its memory map, its context,
     /// and the state of the memory protection unit (MPU).
     fn print_full_process(&self, writer: &mut dyn Write);
+
+    /// Reqest the kernel to restart this process.
+    ///
+    /// This is executed at the kernel's discretion and may result in a noop.
+    fn enqueue_process_restart(&self);
+
+    /// Read the current pending restart state.
+    fn has_pending_restart(&self) -> bool;
 
     // debug
 

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -563,6 +563,9 @@ pub struct ProcessStandard<'a, C: 'static + Chip, D: 'static + ProcessStandardDe
     /// the process is in the [`State::YieldedFor`] state.
     is_yield_wait_for_ready: Cell<bool>,
 
+    /// Track if the process has pending request to be restarted.
+    pending_restart: Cell<bool>,
+
     /// Values kept so that we can print useful debug messages when apps fault.
     debug: D,
 }
@@ -744,7 +747,7 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
                 panic!("Process {} had a fault", self.get_process_name());
             }
             FaultAction::Restart => {
-                self.try_restart(None);
+                self.enqueue_process_restart();
             }
             FaultAction::Stop => {
                 // This looks a lot like restart, except we just leave the app
@@ -770,7 +773,7 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
         }
     }
 
-    fn try_restart(&self, completion_code: Option<u32>) {
+    unsafe fn try_restart(&self, completion_code: Option<u32>) {
         // `try_restart()` cannot be called if the process is terminated. Only
         // `start()` can start a terminated process.
         if self.get_state() == State::Terminated {
@@ -1543,6 +1546,14 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
         }
 
         switch_reason
+    }
+
+    fn enqueue_process_restart(&self) {
+        self.pending_restart.set(true)
+    }
+
+    fn has_pending_restart(&self) -> bool {
+        self.pending_restart.get()
     }
 
     fn debug_syscall_count(&self) -> usize {
@@ -2446,6 +2457,8 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
                 CapabilityPtrPermissions::Execute,
             )
         };
+
+        self.pending_restart.set(false);
 
         self.enqueue_task(Task::FunctionCall(FunctionCall {
             source: FunctionCallSource::Kernel,


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes a bug that results in an app being corrupted across restarts due to state leakage. When restarting an application, we use the `reset()` function to clear the app's state (e.g., cancelling pending upcalls) and enqueue the app's init function. 

The current implementation allows state to leak across app restarts for a specific corner case with Command Syscalls:

1. App issues command syscall.
2. Kernel handles command syscall, delegates to respective capsule.
3. Capsule initiates app restart (which in turn clears state etc).
4. Command returns to kernel syscall handler, writes into the UKB the command return value.
5. New app runs and immediately faults as the app's memory is corrupted by the UKB write.

The fix in the PR is fairly simple and uses the fact that processes get a new PID to check if the process was restarted during the command handling. As an alternative, we could also prevent this bug by specifying by documentation/convention that it is not valid for a capsule to restart an application while handling a command.

### Testing Strategy

This pull request was tested on the nrf52840dk with restarting apps. I am working on a "software watchdog" capsule that restarts applications if they miss an agreed upon checkin (PR coming soon for this). 

In testing the new capsule I'm working on, I uncovered this bug.

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

No AI used.

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
