### PR TITLE
arch/riscv/pmp: make rv64i compatible

### DIFF
--- a/arch/riscv/src/pmp.rs
+++ b/arch/riscv/src/pmp.rs
@@ -2060,10 +2060,6 @@ pub mod kernel_protection {
 
                         pmpcfg
                     })
-                    .chain(core::iter::repeat_n(
-                        TORUserPMPCFG::OFF,
-                        AVAILABLE_ENTRIES - (MPU_REGIONS * 2),
-                    ))
                     .map(TORUserPMPCFG::get_reg),
             );
 

--- a/arch/riscv/src/pmp.rs
+++ b/arch/riscv/src/pmp.rs
@@ -48,6 +48,163 @@ register_bitfields![u8,
 /// `0xFFFFFFFF` on RV32 platforms.
 const PMPADDR_MASK: usize = (0x003F_FFFF_FFFF_FFFFu64 & usize::MAX as u64) as usize;
 
+/// The number of bytes, which is also the number of PMP entries, in a PMP
+/// configuration CSR. This is 4 on rv32i, and 8 on rv64i. So, we use the size
+/// of `usize` to make this easy to set.
+const OCTETS_PER_PMPCFG_CSR: usize = core::mem::size_of::<usize>();
+
+pub struct PmpConfigCSRIter {
+    // The pmpcfg octet returned on the next call to next():
+    current_entry: usize,
+    // The current pmpcfg value, containing the pmpcfg octet addressed by
+    // `current_entry`:
+    pmpcfg_csr_value: Option<usize>,
+}
+
+impl PmpConfigCSRIter {
+    pub fn from_pmpcfg_entry_offset(start_entry: usize) -> Self {
+        PmpConfigCSRIter {
+            current_entry: start_entry,
+            pmpcfg_csr_value: None,
+        }
+    }
+
+    pub fn write_back(
+        start_entry: usize,
+        mut iter: impl Iterator<Item = LocalRegisterCopy<u8, pmpcfg_octet::Register>>,
+    ) {
+        let mut current_entry = start_entry;
+        let mut iterator_exhausted = false;
+
+        // RISC-V only supports up to 64 PMP entries. We don't need to check for
+        // `current_entry < 64` in the inner loop, as 64 is evenly divisible by
+        // `OCTETS_PER_PMPCFG_CSR` for both rv32i and rv64i.
+        while !iterator_exhausted && current_entry < 64 {
+            // We use an intermediate `usize` value to collect all of the pmpcfg
+            // CSRs being written. It's possible that the `start_entry` does not
+            // align with the bounds of a CSR, or that we don't have sufficient
+            // entries to fill a CSR. We handle both of these cases below by lazily
+            // perfoming read-modify-write and issuing a CSR read:
+            let mut new_pmpcfg_csr: usize = 0;
+
+            // Determine the pmpcfg CSR address.
+            //
+            // Multiply by `OCTETS_PER_PMPCFG_CSR / 4` (= 1 on rv32i, = 2 on rv64i) to
+            // skip every other PMPCFG CSR on rv64i.
+            let pmpcfg_csr = (current_entry / OCTETS_PER_PMPCFG_CSR) * (OCTETS_PER_PMPCFG_CSR / 4);
+
+            // Determine the byte offset into the `new_pmpcfg_csr`:
+            let start_csr_byte_offset: usize = current_entry % OCTETS_PER_PMPCFG_CSR;
+            let mut current_csr_byte_offset: usize = start_csr_byte_offset;
+
+            // Current pmpcfg_octet, to be read from the iterator in the loop
+            // conditional and used in the loop body:
+            let mut pmpcfg_octet: u8 = 0;
+            while {
+                // First, check that we have more space in the current CSR:
+                if current_csr_byte_offset >= OCTETS_PER_PMPCFG_CSR {
+                    false
+                } else {
+                    // If we have more space, try to pull a new octet out of the
+                    // iterator, and remember if we've exhausted it:
+                    if let Some(o) = iter.next() {
+                        pmpcfg_octet = o.get();
+                        true
+                    } else {
+                        iterator_exhausted = true;
+                        false
+                    }
+                }
+            } {
+                new_pmpcfg_csr |= (pmpcfg_octet as usize) << (current_csr_byte_offset * 8);
+                current_csr_byte_offset += 1;
+                current_entry += 1;
+            }
+
+            // If we haven't written any octets, skip to the next loop iteration
+            // and don't issue any CSR writes:
+            if start_csr_byte_offset == current_csr_byte_offset {
+                continue;
+            }
+
+            // We issue a read to the CSR only if we have any octets that have
+            // not been populated above:
+            if start_csr_byte_offset > 0 || current_csr_byte_offset < OCTETS_PER_PMPCFG_CSR {
+                let prev_pmpcfg_csr = csr::CSR.pmpconfig_get(pmpcfg_csr);
+
+                // Build a mask selecting bits that we're want to replace.
+                //
+                // First, define a mask excluding bits from the most significant
+                // octet to the current_csr_byte_offset, e.g.: 0x00FFFFFF.
+                //
+                // We use checked_shl, as `current_csr_byte_offset * 8` might
+                // exceed 32/64 bits, resulting in an overflow and potentially
+                // panic. We don't need to do so for `start_csr_byte_offset`, as
+                // that one was obtained through a modulo operation with
+                // OCTETS_PER_PMPCFG_CSR, which in turn is equals to the number of
+                // bytes in a usize.
+                let mut pmpcfg_csr_mask = 1_usize
+                    .checked_shl((current_csr_byte_offset * 8) as u32)
+                    .map_or(usize::MAX, |v| v - 1);
+                // Now, remove bits between the least significant octet to the
+                // start_csr_byte_offset, e.g.: 0x00FFFF00.
+                pmpcfg_csr_mask ^= (1_usize << (start_csr_byte_offset * 8)) - 1;
+
+                // Merge the unchanged octets from the previous CSR value into
+                // the new one:
+                new_pmpcfg_csr |= prev_pmpcfg_csr & !pmpcfg_csr_mask;
+            }
+
+            // Finally, write the new pmpcfg CSR:
+            csr::CSR.pmpconfig_set(pmpcfg_csr, new_pmpcfg_csr);
+        }
+    }
+}
+
+impl Iterator for PmpConfigCSRIter {
+    type Item = LocalRegisterCopy<u8, pmpcfg_octet::Register>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current_entry >= 64 {
+            // RISC-V only supports up to 64 PMP entries:
+            return None;
+        }
+
+        // Get the current pmpcfg CSR that contains the `current_entry` octet:
+        let pmpcfg_csr_value = if let Some(v) = self.pmpcfg_csr_value {
+            v
+        } else {
+            // Multiply by `OCTETS_PER_PMPCFG_CSR / 4` (= 1 on rv32i, = 2 on rv64i) to
+            // skip every other PMPCFG CSR on rv64i.
+            let v = csr::CSR.pmpconfig_get(
+                (self.current_entry / OCTETS_PER_PMPCFG_CSR) * (OCTETS_PER_PMPCFG_CSR / 4),
+            );
+            self.pmpcfg_csr_value = Some(v);
+            v
+        };
+
+        // Extract the particular CSR octet we want to return:
+        let csr_byte_offset = self.current_entry % OCTETS_PER_PMPCFG_CSR;
+        let csr_octet = LocalRegisterCopy::new((pmpcfg_csr_value >> (csr_byte_offset * 8)) as u8);
+
+        // Increment the next entry. We use `checked_add` to avoid overflows. As
+        // the maximum number of PMP entries is capped to 64 in practice, it's
+        // fine for us to keep returning none when our `current_entry ==
+        // usize::MAX`:
+        self.current_entry = self.current_entry.checked_add(1)?;
+
+        // If we've just flowed over into a new CSR, set our cached CSR value to
+        // None. This will force it to be fetched again on the next call to
+        // `next()`:
+        if self.current_entry.is_multiple_of(OCTETS_PER_PMPCFG_CSR) {
+            self.pmpcfg_csr_value = None;
+        }
+
+        // Return the CSR octet:
+        Some(csr_octet)
+    }
+}
+
 /// A `pmpcfg` octet for a user-mode (non-locked) TOR-addressed PMP region.
 ///
 /// This is a wrapper around a [`pmpcfg_octet`] (`u8`) register type, which
@@ -65,12 +222,12 @@ impl TORUserPMPCFG {
     pub const OFF: TORUserPMPCFG = TORUserPMPCFG(LocalRegisterCopy::new(0));
 
     /// Extract the `u8` representation of the [`pmpcfg_octet`] register.
-    pub fn get(&self) -> u8 {
+    pub fn get(self) -> u8 {
         self.0.get()
     }
 
     /// Extract a copy of the contained [`pmpcfg_octet`] register.
-    pub fn get_reg(&self) -> LocalRegisterCopy<u8, pmpcfg_octet::Register> {
+    pub fn get_reg(self) -> LocalRegisterCopy<u8, pmpcfg_octet::Register> {
         self.0
     }
 }
@@ -571,7 +728,7 @@ pub mod misc_pmp_test {
     }
 }
 
-/// Print a table of the configured PMP regions, read from  the HW CSRs.
+/// Print a table of the configured PMP regions, read from the HW CSRs.
 ///
 /// # Safety
 ///
@@ -582,19 +739,10 @@ pub mod misc_pmp_test {
 pub unsafe fn format_pmp_entries<const PHYSICAL_ENTRIES: usize>(
     f: &mut fmt::Formatter<'_>,
 ) -> fmt::Result {
-    for i in 0..PHYSICAL_ENTRIES {
-        // Extract the entry's pmpcfgX register value. The pmpcfgX CSRs are
-        // tightly packed and contain 4 octets beloging to individual
-        // entries. Convert this into a u8-wide LocalRegisterCopy<u8,
-        // pmpcfg_octet> as a generic register type, independent of the entry's
-        // offset.
-        let pmpcfg: LocalRegisterCopy<u8, pmpcfg_octet::Register> = LocalRegisterCopy::new(
-            csr::CSR
-                .pmpconfig_get(i / 4)
-                .overflowing_shr(((i % 4) * 8) as u32)
-                .0 as u8,
-        );
-
+    for (i, pmpcfg) in PmpConfigCSRIter::from_pmpcfg_entry_offset(0)
+        .take(PHYSICAL_ENTRIES)
+        .enumerate()
+    {
         // The address interpretation is different for every mode. Return both a
         // string indicating the PMP entry's mode, as well as the effective
         // start and end address (inclusive) affected by the region. For regions
@@ -659,11 +807,11 @@ pub unsafe fn format_pmp_entries<const PHYSICAL_ENTRIES: usize>(
 
         write!(
             f,
-            "  [{:02}]: {}={:#010X}, end={:#010X}, cfg={:#04X} ({}) ({}{}{}{})\r\n",
+            "  [{:02}]: {}={:p}, end={:p}, cfg={:#04X} ({}) ({}{}{}{})\r\n",
             i,
             start_label,
-            start,
-            end,
+            start as *const (),
+            end as *const (),
             pmpcfg.get(),
             mode,
             t(pmpcfg.is_set(pmpcfg_octet::l), "l", "-"),
@@ -836,10 +984,10 @@ impl<const MAX_REGIONS: usize> fmt::Display for PMPUserMPUConfig<MAX_REGIONS> {
             let pmpcfg = tor_user_pmpcfg.get_reg();
             write!(
                 f,
-                "     #{:02}: start={:p}, end={:p}, cfg={:#04X} ({}) (-{}{}{})\r\n",
+                "     #{:02}: start={:#010X}, end={:#010X}, cfg={:#04X} ({}) (-{}{}{})\r\n",
                 i,
-                *start,
-                *end,
+                *start as usize,
+                *end as usize,
                 pmpcfg.get(),
                 t(pmpcfg.is_set(pmpcfg_octet::a), "TOR", "OFF"),
                 t(pmpcfg.is_set(pmpcfg_octet::r), "r", "-"),
@@ -1441,10 +1589,10 @@ pub mod tor_user_pmp_test {
 }
 
 pub mod simple {
-    use super::{TORUserPMP, TORUserPMPCFG, pmpcfg_octet};
+    use super::{OCTETS_PER_PMPCFG_CSR, PmpConfigCSRIter, TORUserPMP, TORUserPMPCFG, pmpcfg_octet};
     use crate::csr;
     use core::fmt;
-    use kernel::utilities::registers::{FieldValue, LocalRegisterCopy};
+    use kernel::utilities::registers::LocalRegisterCopy;
 
     /// A "simple" RISC-V PMP implementation.
     ///
@@ -1484,12 +1632,18 @@ pub mod simple {
             // right now. Thus, never try to touch a locked region, as we might
             // well revoke access to a kernel region!
             for i in 0..AVAILABLE_ENTRIES {
+                // Multiply by `OCTETS_PER_PMPCFG_CSR / 4` (= 1 on rv32i, = 2 on rv64i) to
+                // skip every other PMPCFG CSR on rv64i.
+                let pmpcfg_csr_idx = (i / OCTETS_PER_PMPCFG_CSR) * (OCTETS_PER_PMPCFG_CSR / 4);
+
                 // Read the entry's CSR:
-                let pmpcfg_csr = csr::CSR.pmpconfig_get(i / 4);
+                let pmpcfg_csr = csr::CSR.pmpconfig_get(pmpcfg_csr_idx);
 
                 // Extract the entry's pmpcfg octet:
                 let pmpcfg: LocalRegisterCopy<u8, pmpcfg_octet::Register> = LocalRegisterCopy::new(
-                    pmpcfg_csr.overflowing_shr(((i % 4) * 8) as u32).0 as u8,
+                    pmpcfg_csr
+                        .overflowing_shr(((i % OCTETS_PER_PMPCFG_CSR) * 8) as u32)
+                        .0 as u8,
                 );
 
                 // As outlined above, we never touch a locked region. Thus, bail
@@ -1503,10 +1657,13 @@ pub mod simple {
                 // denied for machine-mode access. Hence, we can change it in
                 // arbitrary ways without breaking our own memory access. Try to
                 // flip the R/W/X bits:
-                csr::CSR.pmpconfig_set(i / 4, pmpcfg_csr ^ (7 << ((i % 4) * 8)));
+                csr::CSR.pmpconfig_set(
+                    pmpcfg_csr_idx,
+                    pmpcfg_csr ^ (7 << ((i % OCTETS_PER_PMPCFG_CSR) * 8)),
+                );
 
                 // Check if the CSR changed:
-                if pmpcfg_csr == csr::CSR.pmpconfig_get(i / 4) {
+                if pmpcfg_csr == csr::CSR.pmpconfig_get(pmpcfg_csr_idx) {
                     // Didn't change! This means that this region is not backed
                     // by HW. Return an error as `AVAILABLE_ENTRIES` is
                     // incorrect:
@@ -1514,7 +1671,10 @@ pub mod simple {
                 }
 
                 // Finally, turn the region off:
-                csr::CSR.pmpconfig_set(i / 4, pmpcfg_csr & !(0x18 << ((i % 4) * 8)));
+                csr::CSR.pmpconfig_set(
+                    pmpcfg_csr_idx,
+                    pmpcfg_csr & !(0x18 << ((i % OCTETS_PER_PMPCFG_CSR) * 8)),
+                );
             }
 
             // Hardware PMP is verified to be in a compatible mode / state, and
@@ -1536,80 +1696,38 @@ pub mod simple {
             MPU_REGIONS
         }
 
-        // This implementation is specific for 32-bit systems. We use
-        // `u32::from_be_bytes` and then cast to usize, as it manages to compile
-        // on 64-bit systems as well. However, this implementation will not work
-        // on RV64I systems, due to the changed pmpcfgX CSR layout.
         fn configure_pmp(
             &self,
             regions: &[(TORUserPMPCFG, *const u8, *const u8); MPU_REGIONS],
         ) -> Result<(), ()> {
-            // Could use `iter_array_chunks` once that's stable.
-            let mut regions_iter = regions.iter();
-            let mut i = 0;
+            PmpConfigCSRIter::write_back(
+                0,
+                &mut regions
+                    .iter()
+                    .flat_map(|(region_pmpcfg, region_start, region_end)| {
+                        if *region_pmpcfg == TORUserPMPCFG::OFF {
+                            [(TORUserPMPCFG::OFF, None), (TORUserPMPCFG::OFF, None)]
+                        } else {
+                            [
+                                (TORUserPMPCFG::OFF, Some(region_start)),
+                                (*region_pmpcfg, Some(region_end)),
+                            ]
+                        }
+                    })
+                    .enumerate()
+                    .map(|(i, (pmpcfg, opt_addr))| {
+                        if let Some(addr) = opt_addr {
+                            csr::CSR.pmpaddr_set(i, (*addr as usize).overflowing_shr(2).0);
+                        }
 
-            while let Some(even_region) = regions_iter.next() {
-                let odd_region_opt = regions_iter.next();
-
-                if let Some(odd_region) = odd_region_opt {
-                    // We can configure two regions at once which, given that we
-                    // start at index 0 (an even offset), translates to a single
-                    // CSR write for the pmpcfgX register:
-                    csr::CSR.pmpconfig_set(
-                        i / 2,
-                        u32::from_be_bytes([
-                            odd_region.0.get(),
-                            TORUserPMPCFG::OFF.get(),
-                            even_region.0.get(),
-                            TORUserPMPCFG::OFF.get(),
-                        ]) as usize,
-                    );
-
-                    // Now, set the addresses of the respective regions, if they
-                    // are enabled, respectively:
-                    if even_region.0 != TORUserPMPCFG::OFF {
-                        csr::CSR
-                            .pmpaddr_set(i * 2 + 0, (even_region.1 as usize).overflowing_shr(2).0);
-                        csr::CSR
-                            .pmpaddr_set(i * 2 + 1, (even_region.2 as usize).overflowing_shr(2).0);
-                    }
-
-                    if odd_region.0 != TORUserPMPCFG::OFF {
-                        csr::CSR
-                            .pmpaddr_set(i * 2 + 2, (odd_region.1 as usize).overflowing_shr(2).0);
-                        csr::CSR
-                            .pmpaddr_set(i * 2 + 3, (odd_region.2 as usize).overflowing_shr(2).0);
-                    }
-
-                    i += 2;
-                } else {
-                    // TODO: check overhead of code
-                    // Modify the first two pmpcfgX octets for this region:
-                    csr::CSR.pmpconfig_modify(
-                        i / 2,
-                        FieldValue::<usize, csr::pmpconfig::pmpcfg::Register>::new(
-                            0x0000FFFF,
-                            0,
-                            u32::from_be_bytes([
-                                0,
-                                0,
-                                even_region.0.get(),
-                                TORUserPMPCFG::OFF.get(),
-                            ]) as usize,
-                        ),
-                    );
-
-                    // Set the addresses if the region is enabled:
-                    if even_region.0 != TORUserPMPCFG::OFF {
-                        csr::CSR
-                            .pmpaddr_set(i * 2 + 0, (even_region.1 as usize).overflowing_shr(2).0);
-                        csr::CSR
-                            .pmpaddr_set(i * 2 + 1, (even_region.2 as usize).overflowing_shr(2).0);
-                    }
-
-                    i += 1;
-                }
-            }
+                        pmpcfg
+                    })
+                    .chain(core::iter::repeat_n(
+                        TORUserPMPCFG::OFF,
+                        AVAILABLE_ENTRIES - (MPU_REGIONS * 2),
+                    ))
+                    .map(TORUserPMPCFG::get_reg),
+            );
 
             Ok(())
         }
@@ -1633,7 +1751,9 @@ pub mod simple {
 }
 
 pub mod kernel_protection {
-    use super::{NAPOTRegionSpec, TORRegionSpec, TORUserPMP, TORUserPMPCFG, pmpcfg_octet};
+    use super::{
+        NAPOTRegionSpec, PmpConfigCSRIter, TORRegionSpec, TORUserPMP, TORUserPMPCFG, pmpcfg_octet,
+    };
     use crate::csr;
     use core::fmt;
     use kernel::utilities::registers::{FieldValue, LocalRegisterCopy};
@@ -1918,71 +2038,34 @@ pub mod kernel_protection {
             &self,
             regions: &[(TORUserPMPCFG, *const u8, *const u8); MPU_REGIONS],
         ) -> Result<(), ()> {
-            // Could use `iter_array_chunks` once that's stable.
-            let mut regions_iter = regions.iter();
-            let mut i = 0;
+            PmpConfigCSRIter::write_back(
+                0,
+                &mut regions
+                    .iter()
+                    .flat_map(|(region_pmpcfg, region_start, region_end)| {
+                        if *region_pmpcfg == TORUserPMPCFG::OFF {
+                            [(TORUserPMPCFG::OFF, None), (TORUserPMPCFG::OFF, None)]
+                        } else {
+                            [
+                                (TORUserPMPCFG::OFF, Some(region_start)),
+                                (*region_pmpcfg, Some(region_end)),
+                            ]
+                        }
+                    })
+                    .enumerate()
+                    .map(|(i, (pmpcfg, opt_addr))| {
+                        if let Some(addr) = opt_addr {
+                            csr::CSR.pmpaddr_set(i, (*addr as usize).overflowing_shr(2).0);
+                        }
 
-            while let Some(even_region) = regions_iter.next() {
-                let odd_region_opt = regions_iter.next();
-
-                if let Some(odd_region) = odd_region_opt {
-                    // We can configure two regions at once which, given that we
-                    // start at index 0 (an even offset), translates to a single
-                    // CSR write for the pmpcfgX register:
-                    csr::CSR.pmpconfig_set(
-                        i / 2,
-                        u32::from_be_bytes([
-                            odd_region.0.get(),
-                            TORUserPMPCFG::OFF.get(),
-                            even_region.0.get(),
-                            TORUserPMPCFG::OFF.get(),
-                        ]) as usize,
-                    );
-
-                    // Now, set the addresses of the respective regions, if they
-                    // are enabled, respectively:
-                    if even_region.0 != TORUserPMPCFG::OFF {
-                        csr::CSR
-                            .pmpaddr_set(i * 2 + 0, (even_region.1 as usize).overflowing_shr(2).0);
-                        csr::CSR
-                            .pmpaddr_set(i * 2 + 1, (even_region.2 as usize).overflowing_shr(2).0);
-                    }
-
-                    if odd_region.0 != TORUserPMPCFG::OFF {
-                        csr::CSR
-                            .pmpaddr_set(i * 2 + 2, (odd_region.1 as usize).overflowing_shr(2).0);
-                        csr::CSR
-                            .pmpaddr_set(i * 2 + 3, (odd_region.2 as usize).overflowing_shr(2).0);
-                    }
-
-                    i += 2;
-                } else {
-                    // Modify the first two pmpcfgX octets for this region:
-                    csr::CSR.pmpconfig_modify(
-                        i / 2,
-                        FieldValue::<usize, csr::pmpconfig::pmpcfg::Register>::new(
-                            0x0000FFFF,
-                            0,
-                            u32::from_be_bytes([
-                                0,
-                                0,
-                                even_region.0.get(),
-                                TORUserPMPCFG::OFF.get(),
-                            ]) as usize,
-                        ),
-                    );
-
-                    // Set the addresses if the region is enabled:
-                    if even_region.0 != TORUserPMPCFG::OFF {
-                        csr::CSR
-                            .pmpaddr_set(i * 2 + 0, (even_region.1 as usize).overflowing_shr(2).0);
-                        csr::CSR
-                            .pmpaddr_set(i * 2 + 1, (even_region.2 as usize).overflowing_shr(2).0);
-                    }
-
-                    i += 1;
-                }
-            }
+                        pmpcfg
+                    })
+                    .chain(core::iter::repeat_n(
+                        TORUserPMPCFG::OFF,
+                        AVAILABLE_ENTRIES - (MPU_REGIONS * 2),
+                    ))
+                    .map(TORUserPMPCFG::get_reg),
+            );
 
             Ok(())
         }
@@ -2010,7 +2093,9 @@ pub mod kernel_protection {
 }
 
 pub mod kernel_protection_mml_epmp {
-    use super::{NAPOTRegionSpec, TORRegionSpec, TORUserPMP, TORUserPMPCFG, pmpcfg_octet};
+    use super::{
+        NAPOTRegionSpec, PmpConfigCSRIter, TORRegionSpec, TORUserPMP, TORUserPMPCFG, pmpcfg_octet,
+    };
     use crate::csr;
     use core::cell::Cell;
     use core::fmt;
@@ -2346,74 +2431,15 @@ pub mod kernel_protection_mml_epmp {
             // `shadow_user_pmpcfg` field, such that we can re-enable the PMP
             // without a call to `configure_pmp` (where the `TORUserPMPCFG`s are
             // provided by the caller).
-
-            // Could use `iter_array_chunks` once that's stable.
-            let mut shadow_user_pmpcfgs_iter = self.shadow_user_pmpcfgs.iter();
-            let mut i = Self::TOR_REGIONS_OFFSET;
-
-            while let Some(first_region_pmpcfg) = shadow_user_pmpcfgs_iter.next() {
-                // If we're at a "region" offset divisible by two (where "region" =
-                // 2 PMP "entries"), then we can configure an entire `pmpcfgX` CSR
-                // in one operation. As CSR writes are expensive, this is an
-                // operation worth making:
-                let second_region_opt = if i % 2 == 0 {
-                    shadow_user_pmpcfgs_iter.next()
-                } else {
-                    None
-                };
-
-                if let Some(second_region_pmpcfg) = second_region_opt {
-                    // We're at an even index and have two regions to configure, so
-                    // do that with a single CSR write:
-                    csr::CSR.pmpconfig_set(
-                        i / 2,
-                        u32::from_be_bytes([
-                            second_region_pmpcfg.get().get(),
-                            TORUserPMPCFG::OFF.get(),
-                            first_region_pmpcfg.get().get(),
-                            TORUserPMPCFG::OFF.get(),
-                        ]) as usize,
-                    );
-
-                    i += 2;
-                } else if i % 2 == 0 {
-                    // This is a single region at an even index. Thus, modify the
-                    // first two pmpcfgX octets for this region.
-                    csr::CSR.pmpconfig_modify(
-                        i / 2,
-                        FieldValue::<usize, csr::pmpconfig::pmpcfg::Register>::new(
-                            0x0000FFFF,
-                            0, // lower two octets
-                            u32::from_be_bytes([
-                                0,
-                                0,
-                                first_region_pmpcfg.get().get(),
-                                TORUserPMPCFG::OFF.get(),
-                            ]) as usize,
-                        ),
-                    );
-
-                    i += 1;
-                } else {
-                    // This is a single region at an odd index. Thus, modify the
-                    // latter two pmpcfgX octets for this region.
-                    csr::CSR.pmpconfig_modify(
-                        i / 2,
-                        FieldValue::<usize, csr::pmpconfig::pmpcfg::Register>::new(
-                            0x0000FFFF,
-                            16, // higher two octets
-                            u32::from_be_bytes([
-                                0,
-                                0,
-                                first_region_pmpcfg.get().get(),
-                                TORUserPMPCFG::OFF.get(),
-                            ]) as usize,
-                        ),
-                    );
-
-                    i += 1;
-                }
-            }
+            PmpConfigCSRIter::write_back(
+                Self::TOR_REGIONS_OFFSET * 2,
+                &mut self.shadow_user_pmpcfgs.iter().flat_map(|octet| {
+                    [
+                        TORUserPMPCFG::get_reg(TORUserPMPCFG::OFF),
+                        TORUserPMPCFG::get_reg(octet.get()),
+                    ]
+                }),
+            );
 
             self.user_pmp_enabled.set(true);
 
@@ -2422,62 +2448,18 @@ pub mod kernel_protection_mml_epmp {
 
         fn disable_user_pmp(&self) {
             // Simply set all of the user-region pmpcfg octets to OFF:
-
-            let mut user_region_pmpcfg_octet_pairs =
-                (Self::TOR_REGIONS_OFFSET)..(Self::TOR_REGIONS_OFFSET + MPU_REGIONS);
-            while let Some(first_region_idx) = user_region_pmpcfg_octet_pairs.next() {
-                let second_region_opt = if first_region_idx % 2 == 0 {
-                    user_region_pmpcfg_octet_pairs.next()
-                } else {
-                    None
-                };
-
-                if let Some(_second_region_idx) = second_region_opt {
-                    // We're at an even index and have two regions to configure, so
-                    // do that with a single CSR write:
-                    csr::CSR.pmpconfig_set(
-                        first_region_idx / 2,
-                        u32::from_be_bytes([
-                            TORUserPMPCFG::OFF.get(),
-                            TORUserPMPCFG::OFF.get(),
-                            TORUserPMPCFG::OFF.get(),
-                            TORUserPMPCFG::OFF.get(),
-                        ]) as usize,
-                    );
-                } else if first_region_idx % 2 == 0 {
-                    // This is a single region at an even index. Thus, modify the
-                    // first two pmpcfgX octets for this region.
-                    csr::CSR.pmpconfig_modify(
-                        first_region_idx / 2,
-                        FieldValue::<usize, csr::pmpconfig::pmpcfg::Register>::new(
-                            0x0000FFFF,
-                            0, // lower two octets
-                            u32::from_be_bytes([
-                                0,
-                                0,
-                                TORUserPMPCFG::OFF.get(),
-                                TORUserPMPCFG::OFF.get(),
-                            ]) as usize,
-                        ),
-                    );
-                } else {
-                    // This is a single region at an odd index. Thus, modify the
-                    // latter two pmpcfgX octets for this region.
-                    csr::CSR.pmpconfig_modify(
-                        first_region_idx / 2,
-                        FieldValue::<usize, csr::pmpconfig::pmpcfg::Register>::new(
-                            0x0000FFFF,
-                            16, // higher two octets
-                            u32::from_be_bytes([
-                                0,
-                                0,
-                                TORUserPMPCFG::OFF.get(),
-                                TORUserPMPCFG::OFF.get(),
-                            ]) as usize,
-                        ),
-                    );
-                }
-            }
+            PmpConfigCSRIter::write_back(
+                Self::TOR_REGIONS_OFFSET * 2,
+                // We don't actually read these elements, and are only
+                // interested in the array length. We use `.iter()` for the code
+                // to be symmetrical with `enable_user_pmp`.
+                &mut self.shadow_user_pmpcfgs.iter().flat_map(|_| {
+                    [
+                        TORUserPMPCFG::get_reg(TORUserPMPCFG::OFF),
+                        TORUserPMPCFG::get_reg(TORUserPMPCFG::OFF),
+                    ]
+                }),
+            );
 
             self.user_pmp_enabled.set(false);
         }
@@ -2523,11 +2505,11 @@ pub mod kernel_protection_mml_epmp {
 
                 write!(
                     f,
-                    "  [{:02}]: {}={:p}, end={:p}, cfg={:#04X} ({}  ) ({}{}{}{})\r\n",
+                    "  [{:02}]: {}={:#010X}, end={:#010X}, cfg={:#04X} ({}  ) ({}{}{}{})\r\n",
                     (i + Self::TOR_REGIONS_OFFSET) * 2 + 1,
                     start_pmpaddr_label,
-                    startaddr_pmpaddr as *const (),
-                    endaddr as *const (),
+                    startaddr_pmpaddr,
+                    endaddr,
                     shadowed_pmpcfg.get().get(),
                     mode,
                     if shadowed_pmpcfg.get().get_reg().is_set(pmpcfg_octet::l) {

--- a/arch/riscv/src/pmp.rs
+++ b/arch/riscv/src/pmp.rs
@@ -1704,6 +1704,12 @@ pub mod simple {
                 0,
                 &mut regions
                     .iter()
+                    // Each region occupies two physical PMP entries: a
+                    // "start" entry (always OFF, only its pmpaddr matters as
+                    // the lower TOR bound) and an "end" entry (carries the
+                    // actual permissions and the upper TOR bound). An OFF
+                    // region contributes two OFF entries with no address to
+                    // write, since its old address, if any, is irrelevant:
                     .flat_map(|(region_pmpcfg, region_start, region_end)| {
                         if *region_pmpcfg == TORUserPMPCFG::OFF {
                             [(TORUserPMPCFG::OFF, None), (TORUserPMPCFG::OFF, None)]
@@ -1715,6 +1721,9 @@ pub mod simple {
                         }
                     })
                     .enumerate()
+                    // Write each entry's pmpaddr (if it has one), and pass its
+                    // pmpcfg octet through to be written to the pmpcfgX CSRs
+                    // by `write_back` below:
                     .map(|(i, (pmpcfg, opt_addr))| {
                         if let Some(addr) = opt_addr {
                             csr::CSR.pmpaddr_set(i, (*addr as usize).overflowing_shr(2).0);
@@ -1722,6 +1731,11 @@ pub mod simple {
 
                         pmpcfg
                     })
+                    // Since SimplePMP keeps no record of which entries were
+                    // previously enabled, explicitly turn off every remaining
+                    // hardware entry beyond the `MPU_REGIONS * 2` entries
+                    // above, so that a region disabled since the last call is
+                    // actually cleared in hardware:
                     .chain(core::iter::repeat_n(
                         TORUserPMPCFG::OFF,
                         AVAILABLE_ENTRIES - (MPU_REGIONS * 2),
@@ -2030,10 +2044,6 @@ pub mod kernel_protection {
             MPU_REGIONS
         }
 
-        // This implementation is specific for 32-bit systems. We use
-        // `u32::from_be_bytes` and then cast to usize, as it manages to compile
-        // on 64-bit systems as well. However, this implementation will not work
-        // on RV64I systems, due to the changed pmpcfgX CSR layout.
         fn configure_pmp(
             &self,
             regions: &[(TORUserPMPCFG, *const u8, *const u8); MPU_REGIONS],
@@ -2042,6 +2052,12 @@ pub mod kernel_protection {
                 0,
                 &mut regions
                     .iter()
+                    // Each region occupies two physical PMP entries: a
+                    // "start" entry (always OFF, only its pmpaddr matters as
+                    // the lower TOR bound) and an "end" entry (carries the
+                    // actual permissions and the upper TOR bound). An OFF
+                    // region contributes two OFF entries with no address to
+                    // write, since its old address, if any, is irrelevant:
                     .flat_map(|(region_pmpcfg, region_start, region_end)| {
                         if *region_pmpcfg == TORUserPMPCFG::OFF {
                             [(TORUserPMPCFG::OFF, None), (TORUserPMPCFG::OFF, None)]
@@ -2053,6 +2069,9 @@ pub mod kernel_protection {
                         }
                     })
                     .enumerate()
+                    // Write each entry's pmpaddr (if it has one), and pass its
+                    // pmpcfg octet through to be written to the pmpcfgX CSRs
+                    // by `write_back` below:
                     .map(|(i, (pmpcfg, opt_addr))| {
                         if let Some(addr) = opt_addr {
                             csr::CSR.pmpaddr_set(i, (*addr as usize).overflowing_shr(2).0);

--- a/arch/riscv/src/pmp.rs
+++ b/arch/riscv/src/pmp.rs
@@ -1731,11 +1731,22 @@ pub mod simple {
 
                         pmpcfg
                     })
-                    // Since SimplePMP keeps no record of which entries were
-                    // previously enabled, explicitly turn off every remaining
-                    // hardware entry beyond the `MPU_REGIONS * 2` entries
-                    // above, so that a region disabled since the last call is
-                    // actually cleared in hardware:
+                    // Explicitly turn off every remaining hardware entry beyond
+                    // the `MPU_REGIONS * 2` entries above, so that any stale
+                    // entry left enabled is actually cleared in hardware. While
+                    // `MPU_REGIONS` is constant for a given trait impl they may
+                    // nonetheless be enabled, as a single `SimplePMP`
+                    // implements `TORUserPMP<MPU_REGIONS>` for *multiple*
+                    // values of `MPU_REGIONS` (every value permitted by
+                    // `CONST_ASSERT_CHECK`, i.e. `MPU_REGIONS <=
+                    // AVAILABLE_ENTRIES / 2`). A prior call may thus have gone
+                    // through a different monomorphization with a larger
+                    // `MPU_REGIONS`, enabling entries that this impl would
+                    // otherwise leave untouched.
+                    //
+                    // Because SimplePMP keeps no record of which entries were
+                    // previously enabled, we must unconditionally clear all
+                    // remaining entries on every call:
                     .chain(core::iter::repeat_n(
                         TORUserPMPCFG::OFF,
                         AVAILABLE_ENTRIES - (MPU_REGIONS * 2),


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the RISC-V PMP implementation to make it compatible with `rv64i` systems.


### Testing Strategy

Done: This pull request was tested by running it with the QEMU board. Needs more testing.


### TODO or Help Wanted

This pull request still needs porting of more low-level `TORUserPMP` implementations.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.

I have experimented with using Gemini Pro 3 to review some of this code. No substantial parts of the LLM's output have been incorprated into this patch.
