### PR TITLE
arch/riscv: enable switch_to_process on rv64

### DIFF
--- a/arch/riscv/src/syscall.rs
+++ b/arch/riscv/src/syscall.rs
@@ -222,7 +222,11 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
     }
 
     // Mock implementation for tests on Travis-CI.
-    #[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
+    #[cfg(not(any(
+        doc,
+        all(target_arch = "riscv32", target_os = "none"),
+        all(target_arch = "riscv64", target_os = "none")
+    )))]
     unsafe fn switch_to_process(
         &self,
         _accessible_memory_start: *const u8,
@@ -235,7 +239,11 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
         unimplemented!()
     }
 
-    #[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
+    #[cfg(any(
+        doc,
+        all(target_arch = "riscv32", target_os = "none"),
+        all(target_arch = "riscv64", target_os = "none")
+    ))]
     unsafe fn switch_to_process(
         &self,
         _accessible_memory_start: *const u8,


### PR DESCRIPTION
### Pull Request Overview

The rv64 syscall-support work converted `switch_to_process` to the generic `sx`/`lx`/`{XLEN}` form, but its `cfg` gate stayed `riscv32`-only — so on rv64 the syscall boundary still resolved to the `unimplemented!()` mock and no process could run (the board boots to the process console but can't run userspace). This widens the gate to also cover `riscv64` (mirroring the pattern already used for `_start_trap` in `lib.rs`), so rv64 uses the real, already-generic context-switch body. **The body itself is unchanged** — this is purely an enablement flip.

Part of the RV64 userspace work discussed in #4873; re #2332. The 64-bit syscall ABI itself is being settled separately in @jrvanwhy's forthcoming TRD — this PR only enables the existing context switch and does not change the return encoding.

### Testing Strategy

Builds clean and warning-free for `riscv64imac` (`qemu_rv64_virt`), `riscv32imac` (regression), and host; `make prepush` passes. Validated end-to-end by booting `qemu_rv64_virt` (qemu-system-riscv64 8.2.2) and running a minimal hand-written rv64 process — it loads (process count 1) and reaches `Yielded`, exercising `switch_to_process` -> mret-to-user -> `ecall` -> `_start_app_trap` -> `_return_to_kernel`. The generic body was also cross-checked against an independent, separately-proven rv64 `switch_to_process` implementation (frame size, slot assignments, PC-at-31xXLEN, and 100/200/300 trap labels all identical).

<details><summary>Reproduce the round-trip</summary>

```
# app.S: li a4,0; li a0,1; ecall; j _start   (Yield-wait, pure PIC)
riscv64-unknown-elf-gcc -march=rv64imac -mabi=lp64 -mcmodel=medany \
  -nostdlib -ffreestanding -Wl,--build-id=none -T app.ld -o app.elf app.S
#   app.ld: ". = 0x80000000;"   (PIC sentinel -> elf2tab omits FixedAddresses TLV)
elf2tab -n rv64yield -o app.tab --stack 1024 --kernel-major 2 --kernel-minor 2 app.elf
make -C boards/qemu_rv64_virt run-app APP=app.tbf
```
</details>

### TODO or Help Wanted

None blocking. A small in-tree userspace test for `qemu_rv64_virt` could follow if useful — happy to add one.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

This change was developed with the assistance of an AI coding assistant (Claude / Claude Code) and reviewed before submission.

- [x] The PR description details my use of AI in the production of the code in this PR, if any, and I have manually checked and personally certify the entire contents of this PR.