### PR TITLE
clippy: Deny `doc_lazy_continuation`, various doc/comment fixes/improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,7 +235,6 @@ upper_case_acronyms = "allow"
 collapsible-match = "allow"
 
 missing_safety_doc = "allow"
-doc_lazy_continuation = "allow"
 
 
 # PERF

--- a/boards/raspberry_pi_pico_2/src/flash_bootloader.rs
+++ b/boards/raspberry_pi_pico_2/src/flash_bootloader.rs
@@ -28,9 +28,9 @@ pub const FLASH_BOOTLOADER: [u8; 256] = [
 /// The RP2350 chip requires a metadata block.
 /// As per section 5.9 from the RP2350 manual, the block contains 2 items:
 /// - An IMAGE_DEF item that declares that the Tock image is executable,
-/// runs in Secure mode, for the ARM architecture, for the RP2350 chip.
+///   runs in Secure mode, for the ARM architecture, for the RP2350 chip.
 /// - A VECTOR_TABLE item that specifies that the vector table is loaded
-/// at memory address 0x10000400.
+///   at memory address 0x10000400.
 pub const METADATA_BLOCK: [u8; 28] = [
     0xd3, 0xde, 0xff, 0xff, 0x42, 0x01, 0x21, 0x10, 0x03, 0x02, 0x00, 0x00, 0x00, 0x04, 0x00, 0x10,
     0xff, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x79, 0x35, 0x12, 0xab,

--- a/capsules/core/src/led.rs
+++ b/capsules/core/src/led.rs
@@ -56,7 +56,7 @@
 //! - `4`: Read the current state of the LED.
 //!   - `data`: The index of the LED. Starts at 0.
 //!   - Return: `INVAL` if the LED index was invalid, `Ok(0u32)` if the LED is
-//!   off, `Ok(1u32)` if the LED is on.
+//!     off, `Ok(1u32)` if the LED is on.
 
 use kernel::hil::led;
 use kernel::syscall::{CommandReturn, SyscallDriver};

--- a/capsules/extra/src/app_loader.rs
+++ b/capsules/extra/src/app_loader.rs
@@ -353,8 +353,8 @@ impl<
     /// Command interface.
     ///
     /// The driver returns ErrorCode::BUSY if:
-    ///    - The kernel has already dedicated this driver to another process.
-    ///    - The kernel is busy executing another command for this process.
+    /// - The kernel has already dedicated this driver to another process.
+    /// - The kernel is busy executing another command for this process.
     ///
     /// Currently, this capsule is not virtualized and can only be used by one
     /// application at a time.
@@ -366,30 +366,32 @@ impl<
     /// - `0`: Return Ok(()) if this driver is included on the platform.
     /// - `1`: Request kernel to setup for loading app.
     ///  - Returns appsize if the kernel has available space
-    ///  - Returns ErrorCode::FAIL if the kernel is unable to allocate space for the new app
+    ///  - Returns ErrorCode::FAIL if the kernel is unable to allocate space for
+    ///    the new app
     /// - `2`: Request kernel to write app data to the nonvolatile_storage
     ///  - Returns Ok(()) when write is successful
     ///  - Returns ErrorCode::INVAL when the app is violating bounds
     ///  - Returns ErrorCode::FAIL when the write fails
     /// - `3`: Signal to the kernel that the writing is done.
     ///  - Returns Ok(()) if the kernel successfully verified it and
-    ///  set the stage for `load()`.
+    ///    set the stage for `load()`.
     ///  - Returns ErrorCode::FAIL if:
-    ///  a. The kernel needs to write a leading padding app but is unable to.
-    ///  b. The command is called during setup or load phases.
+    ///    a. The kernel needs to write a leading padding app but is unable to.
+    ///    b. The command is called during setup or load phases.
     /// - `4`: Request kernel to load app.
     ///  - Returns Ok(()) when the process is successfully loaded
     ///  - Returns ErrorCode::FAIL if:
-    ///  a. The kernel is unable to create a process object for the application
+    ///    a. The kernel is unable to create a process object for the application
     /// - `5`: Request kernel to abort setup/write operation.
     ///  - Returns Ok(()) when the operation is cancelled successfully
-    ///  - Returns ErrorCode::BUSY when the abort fails
-    ///  (due to padding app being unable to be written, so try again)
+    ///  - Returns ErrorCode::BUSY when the abort fails(due to padding app being
+    ///    unable to be written, so try again)
     ///  - Returns ErrorCode::FAIL if the driver is not dedicated to this process
     ///
-    /// The driver returns ErrorCode::INVAL if any operation is called before the
-    /// preceeding operation was invoked. For example, `write()` cannot be called before
-    /// `setup()`, and `load()` cannot be called before `write()` (for this implementation).
+    /// The driver returns ErrorCode::INVAL if any operation is called before
+    /// the preceding operation was invoked. For example, `write()` cannot be
+    /// called before `setup()`, and `load()` cannot be called before `write()`
+    /// (for this implementation).
     fn command(
         &self,
         command_num: usize,

--- a/capsules/extra/src/crc.rs
+++ b/capsules/extra/src/crc.rs
@@ -264,12 +264,11 @@ impl<'a, C: Crc<'a>> SyscallDriver for CrcDriver<'a, C> {
     //
     // where
     //
-    //   * `status` is indicates whether the computation
-    //     succeeded. The status `BUSY` indicates the unit is already
-    //     busy. The status `SIZE` indicates the provided buffer is
-    //     too large for the unit to handle.
+    // * `status` is indicates whether the computation succeeded. The status
+    //   `BUSY` indicates the unit is already busy. The status `SIZE` indicates
+    //   the provided buffer is too large for the unit to handle.
     //
-    //   * `result` is the result of the Crc computation when `status == BUSY`.
+    // * `result` is the result of the Crc computation when `status == BUSY`.
     //
 
     /// The command system call for this driver return meta-data about the driver and kicks off
@@ -277,27 +276,25 @@ impl<'a, C: Crc<'a>> SyscallDriver for CrcDriver<'a, C> {
     ///
     /// ### Command Numbers
     ///
-    ///   *   `0`: Returns non-zero to indicate the driver is present.
+    /// * `0`: Returns non-zero to indicate the driver is present.
     ///
-    ///   *   `1`: Requests that a Crc be computed over the buffer
-    ///       previously provided by `allow`.  If none was provided,
-    ///       this command will return `INVAL`.
+    /// * `1`: Requests that a Crc be computed over the buffer previously
+    ///   provided by `allow`.  If none was provided, this command will return
+    ///   `INVAL`.
     ///
-    ///       This command's driver-specific argument indicates what Crc
-    ///       algorithm to perform, as listed below.  If an invalid
-    ///       algorithm specifier is provided, this command will return
-    ///       `INVAL`.
+    ///   This command's driver-specific argument indicates what Crc algorithm
+    ///   to perform, as listed below.  If an invalid algorithm specifier is
+    ///   provided, this command will return `INVAL`.
     ///
-    ///       If a callback was not previously registered with
-    ///       `subscribe`, this command will return `INVAL`.
+    ///   If a callback was not previously registered with `subscribe`, this
+    ///   command will return `INVAL`.
     ///
-    ///       If a computation has already been requested by this
-    ///       application but the callback has not yet been invoked to
-    ///       receive the result, this command will return `BUSY`.
+    ///   If a computation has already been requested by this application but
+    ///   the callback has not yet been invoked to receive the result, this
+    ///   command will return `BUSY`.
     ///
-    ///       When `Ok(())` is returned, this means the request has been
-    ///       queued and the callback will be invoked when the Crc
-    ///       computation is complete.
+    ///   When `Ok(())` is returned, this means the request has been queued and
+    ///   the callback will be invoked when the Crc computation is complete.
     ///
     /// ### Algorithm
     ///
@@ -308,16 +305,16 @@ impl<'a, C: Crc<'a>> SyscallDriver for CrcDriver<'a, C> {
     /// consume each input byte from most-significant bit to
     /// least-significant.
     ///
-    ///   * `0: Crc-32`  This algorithm is used in Ethernet and many other
+    /// * `0: Crc-32`  This algorithm is used in Ethernet and many other
     ///   applications.  It uses polynomial 0x04C11DB7 and it bit-reverses
     ///   and then bit-inverts the output.
     ///
-    ///   * `1: Crc-32C`  This algorithm uses polynomial 0x1EDC6F41 (due
+    /// * `1: Crc-32C`  This algorithm uses polynomial 0x1EDC6F41 (due
     ///   to Castagnoli) and it bit-reverses and then bit-inverts the
     ///   output.  It *may* be equivalent to various Crc functions using
     ///   the same name.
     ///
-    ///   * `2: Crc-16CCITT`  This algorithm uses polynomial 0x1021 and does
+    /// * `2: Crc-16CCITT`  This algorithm uses polynomial 0x1021 and does
     ///   no post-processing on the output value. The sixteen-bit Crc
     ///   result is placed in the low-order bits of the returned result
     ///   value. That is, result values will always be of the form `0x0000xxxx`
@@ -394,9 +391,9 @@ impl<'a, C: Crc<'a>> Client for CrcDriver<'a, C> {
         // SubSliceMut window and pass it in again.
         let mut computing = false;
         // There are three outcomes to this match:
-        //   - crc_buffer is not put back: input is ongoing
-        //   - crc_buffer is put back and computing is true: compute is ongoing
-        //   - crc_buffer is put back and computing is false: something failed, start a new request
+        // - crc_buffer is not put back: input is ongoing
+        // - crc_buffer is put back and computing is true: compute is ongoing
+        // - crc_buffer is put back and computing is false: something failed, start a new request
         match result {
             Ok(()) => {
                 // Completed leasable buffer, either refill it or compute

--- a/capsules/extra/src/ieee802154/device.rs
+++ b/capsules/extra/src/ieee802154/device.rs
@@ -69,8 +69,8 @@ pub trait MacDevice<'a> {
     /// - `src_pan`: The source PAN ID
     /// - `src_addr`: The source MAC address
     /// - `security_needed`: Whether or not this frame should be secured. This
-    /// needs to be specified beforehand so that the auxiliary security header
-    /// can be pre-inserted.
+    ///   needs to be specified beforehand so that the auxiliary security
+    ///   header can be pre-inserted.
     ///
     /// Returns either a Frame that is ready to have payload appended to it, or
     /// the mutable buffer if the frame cannot be prepared for any reason
@@ -99,10 +99,10 @@ pub trait TxClient {
     /// the transmission was successful.
     ///
     /// - `spi_buf`: The buffer used to contain the transmitted frame is
-    /// returned to the client here.
+    ///   returned to the client here.
     /// - `acked`: Whether the transmission was acknowledged.
     /// - `result`: This is `Ok(())` if the frame was transmitted,
-    /// otherwise an error occurred in the transmission pipeline.
+    ///   otherwise an error occurred in the transmission pipeline.
     fn send_done(&self, spi_buf: &'static mut [u8], acked: bool, result: Result<(), ErrorCode>);
 }
 
@@ -119,14 +119,14 @@ pub trait RxClient {
     /// exposed to the client.
     ///
     /// - `buf`: The entire buffer containing the frame, including extra bytes
-    /// in front used for the physical layer.
+    ///   in front used for the physical layer.
     /// - `header`: A fully-parsed representation of the MAC header, with the
-    /// caveat that the auxiliary security header is still included if the frame
-    /// was previously secured.
+    ///   caveat that the auxiliary security header is still included if the
+    ///   frame was previously secured.
     /// - `lqi`: The link quality indicator of the received frame.
-    /// - `data_offset`: Offset of the data payload relative to
-    /// `buf`, so that the payload of the frame is contained in
-    /// `buf[data_offset..data_offset + data_len]`.
+    /// - `data_offset`: Offset of the data payload relative to `buf`, so that
+    ///   the payload of the frame is contained in
+    ///   `buf[data_offset..data_offset + data_len]`.
     /// - `data_len`: Length of the data payload
     fn receive<'a>(
         &self,

--- a/capsules/extra/src/isolated_nonvolatile_storage_driver.rs
+++ b/capsules/extra/src/isolated_nonvolatile_storage_driver.rs
@@ -57,11 +57,12 @@
 //! 1. App engages with the capsule by making any syscall.
 //! 2. Capsule searches through storage to see if that app has an existing
 //!    region.
-//! 3. a. If the capsule finds a matching region:
-//!    - Cache the app's region information in its grant.
-//!    b. If the capsule DOESN'T find a matching region:
-//!    - Allocate a new region for that app.
-//!    - Erase the region's usable area.
+//! 3. After the search:
+//!    - If the capsule finds a matching region:
+//!      - Cache the app's region information in its grant.
+//!    - If the capsule DOESN'T find a matching region:
+//!      - Allocate a new region for that app.
+//!      - Erase the region's usable area.
 //! 4. Handle the syscall that the app originally made.
 //! 5. When the syscall finishes, notify the app via upcall.
 //!

--- a/capsules/extra/src/net/sixlowpan/sixlowpan_compression.rs
+++ b/capsules/extra/src/net/sixlowpan/sixlowpan_compression.rs
@@ -589,10 +589,10 @@ fn compress_udp_checksum(udp_header: &UDPHeader, buf: &mut [u8], written: &mut u
 /// * `dst_mac_addr` - the 16-bit MAC address of the frame receiver.
 ///
 /// * `out_buf` - A buffer to write the output to. Must be at least large enough
-/// to store an IPv6 header (XX bytes).
+///   to store an IPv6 header (XX bytes).
 ///
 /// * `dgram_size` - If `is_fragment` is `true`, this is used as the IPv6
-/// packets total payload size. Otherwise, this is ignored.
+///   packets total payload size. Otherwise, this is ignored.
 ///
 /// * `is_fragment` - ???
 ///
@@ -603,7 +603,7 @@ fn compress_udp_checksum(udp_header: &UDPHeader, buf: &mut [u8], written: &mut u
 /// * `consumed` is the number of header bytes consumed from the 6LoWPAN header
 ///
 /// * `written` is the number of uncompressed header bytes written into
-/// `out_buf`.
+///   `out_buf`.
 pub fn decompress(
     ctx_store: &dyn ContextStore,
     buf: &[u8],

--- a/capsules/extra/src/net/sixlowpan/sixlowpan_state.rs
+++ b/capsules/extra/src/net/sixlowpan/sixlowpan_state.rs
@@ -875,12 +875,12 @@ impl<'a, A: time::Alarm<'a>, C: ContextStore> Sixlowpan<'a, A, C> {
     /// * `ctx_store` - Stores IPv6 address nextwork context mappings
     ///
     /// * `tx_buf` - A buffer used for storing individual fragments of a packet
-    /// in transmission. This buffer must be at least the length of an 802.15.4
-    /// frame.
+    ///   in transmission. This buffer must be at least the length of an
+    ///   802.15.4 frame.
     ///
     /// * `clock` - A implementation of `Alarm` used for tracking the timing of
-    /// frame arrival. The clock should be continue running during sleep and
-    /// have an accuracy of at least 60 seconds.
+    ///   frame arrival. The clock should be continue running during sleep and
+    ///   have an accuracy of at least 60 seconds.
     pub fn new(ctx_store: C, clock: &'a A) -> Sixlowpan<'a, A, C> {
         Sixlowpan {
             ctx_store,

--- a/capsules/extra/src/net/util.rs
+++ b/capsules/extra/src/net/util.rs
@@ -8,7 +8,7 @@
 /// respect to its length in bits (prefix_len):
 ///
 /// - The byte array slice must contain enough bytes to cover the prefix length
-/// (no implicit zero-padding)
+///   (no implicit zero-padding)
 /// - The rest of the prefix array slice is zero-padded
 pub fn verify_prefix_len(prefix: &[u8], prefix_len: u8) -> bool {
     let full_bytes = (prefix_len / 8) as usize;

--- a/capsules/extra/src/servo.rs
+++ b/capsules/extra/src/servo.rs
@@ -61,9 +61,9 @@ impl<const SERVO_COUNT: usize> SyscallDriver for Servo<'_, SERVO_COUNT> {
     ///
     /// - `0`: Return Ok(()) if this driver is included on the platform.
     /// - `1`: Returns an u32 representing the number of available servomotors.
-    /// - `2`: Changing the angle immediatelly.`servo_index` receives the index
-    /// corresponding to the servo whose angle we want to adjust
-    /// `angle` is used to receive a value between 0 and 180.
+    /// - `2`: Changing the angle immediately.`servo_index` receives the index
+    ///   corresponding to the servo whose angle we want to adjust `angle` is
+    ///   used to receive a value between 0 and 180.
     /// - `3`: Returning the current angle for a specific index.
     fn command(
         &self,

--- a/capsules/extra/src/wifi/device.rs
+++ b/capsules/extra/src/wifi/device.rs
@@ -64,8 +64,8 @@ pub trait Client {
     /// ## Arguments
     ///
     /// - `rval`: Status of the command. `Ok(())` means that it has been completed
-    /// successfully. If the command has failed, it will provide an `ErrorCode` to
-    /// signal the motive.
+    ///   successfully. If the command has failed, it will provide an `ErrorCode` to
+    ///   signal the motive.
     ///
     /// TODO: This maybe should be split between commands. I haven't figured it out yet
     /// on the CYW4343x but we might be able to retrieve from the event status code

--- a/chips/nrf52/src/ble_radio.rs
+++ b/chips/nrf52/src/ble_radio.rs
@@ -4,11 +4,12 @@
 
 //! Radio driver, Bluetooth Low Energy, NRF52
 //!
-//! The generic radio configuration i.e., not specific to Bluetooth are functions and similar which
-//! do not start with `ble`. Moreover, Bluetooth Low Energy specific radio configuration
-//! starts with `ble`
+//! The generic radio configuration i.e., not specific to Bluetooth are
+//! functions and similar which do not start with `ble`. Moreover, Bluetooth
+//! Low Energy specific radio configuration starts with `ble`
 //!
-//! For more readability the Bluetooth specific configuration may be moved to separate trait
+//! For more readability the Bluetooth specific configuration may be moved to
+//! separate trait
 //!
 //! ### Author
 //! * Niklas Adolfsson <niklasadolfsson1@gmail.com>
@@ -26,10 +27,10 @@
 //! * Base and prefix forms together the access address
 //!
 //! * S0, an optional parameter that is configured to indicate how many bytes of
-//! the payload is the PDU Type. Configured as 1 byte!
+//!   the payload is the PDU Type. Configured as 1 byte!
 //!
-//! * Length, an optional parameter that is configured to indicate how many bits of the
-//! payload is the length field. Configured as 8 bits!
+//! * Length, an optional parameter that is configured to indicate how many bits
+//!   of the payload is the length field. Configured as 8 bits!
 //!
 //! * S1, Not used
 //!

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
+//! Top-level chip definition for the nRF52 microcontroller.
+
 use core::fmt::Write;
 use cortexm4f::{nvic, CortexM4F, CortexMVariant};
 use kernel::platform::chip::InterruptService;

--- a/chips/nrf52840/src/interrupt_service.rs
+++ b/chips/nrf52840/src/interrupt_service.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
+//! Handle interrupts for nRF52840-specific peripherals
+
 use kernel::hil::time::Alarm;
 use nrf52::chip::Nrf52DefaultPeripherals;
 

--- a/chips/nrf52840/src/lib.rs
+++ b/chips/nrf52840/src/lib.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
+//! Chip implementation for the nRF52840 microcontroller
+
 #![no_std]
 pub use nrf52::{
     acomp, adc, aes, ble_radio, chip, clock, constants, crt1, ficr, i2c, ieee802154_radio, nvmc,

--- a/chips/nrf52840/src/peripheral_interrupts.rs
+++ b/chips/nrf52840/src/peripheral_interrupts.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
+//! Interrupt numbers for nRF52840 peripherals
+
 pub const USBD: u32 = 39;
 #[allow(dead_code)]
 pub const UART1: u32 = 40;

--- a/chips/nrf5x/src/constants.rs
+++ b/chips/nrf5x/src/constants.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
+//! Fixed constants for the nRF5x family
+
 // PCNF0
 pub const RADIO_PCNF0_LFLEN_POS: u32 = 0;
 pub const RADIO_PCNF0_S0LEN_POS: u32 = 8;

--- a/chips/nrf5x/src/peripheral_interrupts.rs
+++ b/chips/nrf5x/src/peripheral_interrupts.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
+//! nRF5x interrupt numbers
+
 pub const POWER_CLOCK: u32 = 0;
 pub const RADIO: u32 = 1;
 pub const UART0: u32 = 2;

--- a/chips/rp2040/src/pwm.rs
+++ b/chips/rp2040/src/pwm.rs
@@ -150,13 +150,13 @@ register_structs! {
 /// Each channel can be configured to run in four different ways:
 ///
 /// + Free running: The fractional clock divider is always enabled. In this mode,
-/// pins A and B are configured as output pins. In other modes, pin B becomes
-/// an input pin.
+///   pins A and B are configured as output pins. In other modes, pin B becomes
+///   an input pin.
 /// + High: The fractional clock divider is enabled when pin B is high.
 /// + Rising: The fractional clock divider is enabled when a rising-edge is
-/// detected on pin B.
+///   detected on pin B.
 /// + Falling: The fractional clock divider is enabled when a falling-edge
-/// is detected on pin B.
+///   is detected on pin B.
 pub enum DivMode {
     FreeRunning,
     High,
@@ -229,9 +229,9 @@ const CHANNEL_NUMBERS: [ChannelNumber; NUMBER_CHANNELS] = [
 /// **Note**:
 ///
 /// + The same PWM output can be selected on two GPIO pins. The same signal will appear on each
-/// GPIO.
+///   GPIO.
 /// + If a PWM B pin is used as an input, and is selected on multiple GPIO pins, then the PWM
-/// channel will see the logical OR of those two GPIO inputs
+///   channel will see the logical OR of those two GPIO inputs
 impl From<RPGpio> for ChannelNumber {
     fn from(gpio: RPGpio) -> Self {
         match gpio as u8 >> 1 & 0b111 {
@@ -328,7 +328,7 @@ impl<'a> Pwm<'a> {
     /// + This method must be called only once when setting up the kernel peripherals.
     /// + This peripheral depends on the chip's clocks.
     /// + Also, if interrupts are required, then an interrupt handler must be set. Otherwise, all
-    /// the interrupts will be ignored.
+    ///   the interrupts will be ignored.
     pub fn new(clocks: &'a clocks::Clocks) -> Self {
         let pwm = Self {
             registers: PWM_BASE,

--- a/chips/sifive/src/plic.rs
+++ b/chips/sifive/src/plic.rs
@@ -125,8 +125,8 @@ impl<const TOTAL_INTS: usize> Plic<TOTAL_INTS> {
 
     /// Clear all pending interrupts. The [`PLIC specification`] section 7:
     /// > A successful claim will also atomically clear the corresponding pending bit on the interrupt source..
-    /// Note that this function will only clear the enabled interrupt sources, as only those can be claimed.
-    /// [`PLIC specification`]: <https://github.com/riscv/riscv-plic-spec/blob/master/riscv-plic.adoc>
+    /// > Note that this function will only clear the enabled interrupt sources, as only those can be claimed.
+    /// > [`PLIC specification`]: <https://github.com/riscv/riscv-plic-spec/blob/master/riscv-plic.adoc>
     pub fn clear_all_pending(&self) {
         let claim = self.registers.get_claim_reg();
         loop {

--- a/chips/stm32f4xx/src/clocks/clocks.rs
+++ b/chips/stm32f4xx/src/clocks/clocks.rs
@@ -6,9 +6,10 @@
 
 //! STM32F4xx clock driver
 //!
-//! This crate provides drivers for various clocks: HSI, PLL, system, AHB, APB1 and APB2.
-//! This documentation applies to the system clock, AHB, APB1 and APB2. For in-detail documentation
-//! for HSI and PLL, check their documentation.
+//! This crate provides drivers for various clocks: HSI, PLL, system, AHB, APB1
+//! and APB2. This documentation applies to the system clock, AHB, APB1 and
+//! APB2. For in-detail documentation for HSI and PLL, check their
+//! documentation.
 //!
 //! # Features
 //!
@@ -72,8 +73,8 @@
 //!
 //! ## APB1 and APB2 prescalers
 //!
-//! APB1 and APB2 prescalers are configured in a similar way as AHB prescaler, except that the
-//! corresponding enum is APBPrescaler.
+//! APB1 and APB2 prescalers are configured in a similar way as AHB prescaler,
+//! except that the corresponding enum is APBPrescaler.
 //!
 //! ## Retrieve the system clock frequency:
 //!
@@ -91,8 +92,9 @@
 //!
 //! ## Change the system clock source to PLL:
 //!
-//! Changing the system clock source is a fastidious task because of AHB, APB1 and APB2 limits,
-//! which are chip-dependent. This example assumes a STM32F429 chip.
+//! Changing the system clock source is a fastidious task because of AHB, APB1
+//! and APB2 limits, which are chip-dependent. This example assumes a STM32F429
+//! chip.
 //!
 //! First, get a reference to the PLL
 //!
@@ -107,15 +109,16 @@
 //! ```
 //!
 //! STM32F429 maximum APB1 frequency is 45MHz, which is computed as following:
-//! freq_APB1 = freq_sys / AHB_prescaler / APB1_prescaler
-//! Default prescaler values are 1, which gives an frequency of 50MHz without modifying the
-//! APB1 prescaler. As such, the APB1 prescaler must be changed.
+//! freq_APB1 = freq_sys / AHB_prescaler / APB1_prescaler Default prescaler
+//! values are 1, which gives an frequency of 50MHz without modifying the APB1
+//! prescaler. As such, the APB1 prescaler must be changed.
 //!
 //! ```rust,ignore
 //! clocks.set_apb1_prescaler(APBPrescaler::DivideBy2);
 //! ```
 //!
-//! Since the APB1 frequency limit is satisfied now, the system clock source can be safely changed.
+//! Since the APB1 frequency limit is satisfied now, the system clock source can
+//! be safely changed.
 //!
 //! ```rust,ignore
 //! clocks.set_sys_clock_source(SysClockSource::PLL);
@@ -130,16 +133,16 @@
 //! pll.enable();
 //! ```
 //!
-//! Because of the high frequency of the PLL clock, both APB1 and APB2 prescalers must be
-//! configured.
+//! Because of the high frequency of the PLL clock, both APB1 and APB2
+//! prescalers must be configured.
 //!
 //! ```rust,ignore
 //! clocks.set_apb1_prescaler(APBPrescaler::DivideBy4);
 //! clocks.set_apb2_prescaler(APBPrescaler::DivideBy2);
 //! ```
 //!
-//! As an alternative, the AHB prescaler could be configured to change both APB1 and APB2
-//! frequencies.
+//! As an alternative, the AHB prescaler could be configured to change both APB1
+//! and APB2 frequencies.
 //!
 //! ```rust,ignore
 //! // Changing it to 2 wouldn't work, because it would give a frequency of 50MHz for the APB1.
@@ -208,9 +211,10 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
     ///
     /// # Errors:
     ///
-    /// + [Err]\([ErrorCode::FAIL]\) if changing the AHB prescaler doesn't preserve APB frequency
-    /// constraints
-    /// + [Err]\([ErrorCode::BUSY]\) if changing the AHB prescaler took too long. Retry.
+    /// + [Err]\([ErrorCode::FAIL]\) if changing the AHB prescaler doesn't
+    ///   preserve APB frequency constraints
+    /// + [Err]\([ErrorCode::BUSY]\) if changing the AHB prescaler took too
+    ///   long. Retry.
     pub fn set_ahb_prescaler(&self, prescaler: AHBPrescaler) -> Result<(), ErrorCode> {
         // Changing the AHB prescaler affects the APB frequencies. A check must be done to ensure
         // that the constraints are still valid
@@ -255,13 +259,15 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
 
     /// Set the APB1 prescaler.
     ///
-    /// The APB1 peripheral clock frequency is equal to the AHB frequency divided by the APB1
-    /// prescaler.
+    /// The APB1 peripheral clock frequency is equal to the AHB frequency
+    /// divided by the APB1 prescaler.
     ///
     /// # Errors:
     ///
-    /// + [Err]\([ErrorCode::FAIL]\) if the desired prescaler would break the APB1 frequency limit
-    /// + [Err]\([ErrorCode::BUSY]\) if setting the prescaler took too long. Retry.
+    /// + [Err]\([ErrorCode::FAIL]\) if the desired prescaler would break the
+    ///   APB1 frequency limit
+    /// + [Err]\([ErrorCode::BUSY]\) if setting the prescaler took too long.
+    ///   Retry.
     pub fn set_apb1_prescaler(&self, prescaler: APBPrescaler) -> Result<(), ErrorCode> {
         let ahb_frequency = self.get_ahb_frequency_mhz();
         let divider: usize = prescaler.into();
@@ -292,7 +298,8 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
         self.get_ahb_frequency_mhz() / divider
     }
 
-    // Same as for APB1, APB2 has a frequency limit that must be enforced by software
+    // Same as for APB1, APB2 has a frequency limit that must be enforced by
+    // software
     fn check_apb2_frequency_limit(&self, ahb_frequency_mhz: usize) -> bool {
         ahb_frequency_mhz
             <= ChipSpecs::APB2_FREQUENCY_LIMIT_MHZ
@@ -301,13 +308,15 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
 
     /// Set the APB2 prescaler.
     ///
-    /// The APB2 peripheral clock frequency is equal to the AHB frequency divided by the APB2
-    /// prescaler.
+    /// The APB2 peripheral clock frequency is equal to the AHB frequency
+    /// divided by the APB2 prescaler.
     ///
     /// # Errors:
     ///
-    /// + [Err]\([ErrorCode::FAIL]\) if the desired prescaler would break the APB2 frequency limit
-    /// + [Err]\([ErrorCode::BUSY]\) if setting the prescaler took too long. Retry.
+    /// + [Err]\([ErrorCode::FAIL]\) if the desired prescaler would break the
+    ///   APB2 frequency limit
+    /// + [Err]\([ErrorCode::BUSY]\) if setting the prescaler took too long.
+    ///   Retry.
     pub fn set_apb2_prescaler(&self, prescaler: APBPrescaler) -> Result<(), ErrorCode> {
         let current_ahb_frequency = self.get_ahb_frequency_mhz();
         let divider: usize = prescaler.into();
@@ -343,9 +352,11 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
     /// # Errors:
     ///
     /// + [Err]\([ErrorCode::FAIL]\) if the source is not enabled.
-    /// + [Err]\([ErrorCode::SIZE]\) if the source frequency surpasses the system clock frequency
-    /// limit, or the APB1 and APB2 limits are not satisfied.
-    /// + [Err]\([ErrorCode::BUSY]\) if the source switching took too long. Retry.
+    /// + [Err]\([ErrorCode::SIZE]\) if the source frequency surpasses the
+    ///   system clock frequency limit, or the APB1 and APB2 limits are not
+    ///   satisfied.
+    /// + [Err]\([ErrorCode::BUSY]\) if the source switching took too long.
+    ///   Retry.
     pub fn set_sys_clock_source(&self, source: SysClockSource) -> Result<(), ErrorCode> {
         // Immediately return if the required source is already configured as the system clock
         // source. Should this maybe be Err(ErrorCode::ALREADY)?
@@ -432,8 +443,8 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
         }
     }
 
-    /// Get the current system clock frequency in MHz from RCC registers instead of the cached
-    /// value. Used for debug only.
+    /// Get the current system clock frequency in MHz from RCC registers instead
+    /// of the cached value. Used for debug only.
     pub fn _get_sys_clock_frequency_mhz_no_cache(&self) -> usize {
         match self.get_sys_clock_source() {
             // These unwraps can't panic because set_sys_clock_frequency ensures that the source is
@@ -459,13 +470,15 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
     ///
     /// + pll_source: PLL source clock (HSI or HSE)
     ///
-    /// + desired_frequency_mhz: the desired frequency in MHz. Supported values: 24-216MHz for
-    /// STM32F401 and 13-216MHz for all the other chips
+    /// + desired_frequency_mhz: the desired frequency in MHz. Supported values:
+    ///   24-216MHz for STM32F401 and 13-216MHz for all the other chips
     ///
     /// # Errors
     ///
-    /// + [Err]\([ErrorCode::INVAL]\): if the desired frequency can't be achieved
-    /// + [Err]\([ErrorCode::FAIL]\): if the PLL clock is already enabled. It must be disabled before
+    /// + [Err]\([ErrorCode::INVAL]\): if the desired frequency can't be
+    ///   achieved
+    /// + [Err]\([ErrorCode::FAIL]\): if the PLL clock is already enabled. It
+    ///   must be disabled before
     pub fn set_pll_frequency_mhz(
         &self,
         pll_source: PllSource,
@@ -483,7 +496,8 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
     ///
     /// # Errors:
     ///
-    /// + [Err]\([ErrorCode::FAIL]\) if the source apart from HSI is already enabled.
+    /// + [Err]\([ErrorCode::FAIL]\) if the source apart from HSI is already
+    ///   enabled.
     pub fn set_mco1_clock_source(&self, source: MCO1Source) -> Result<(), ErrorCode> {
         match source {
             MCO1Source::HSE => {
@@ -513,7 +527,8 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
     ///
     /// # Errors:
     ///
-    /// + [Err]\([ErrorCode::FAIL]\) if the configured source apart from HSI is already enabled.
+    /// + [Err]\([ErrorCode::FAIL]\) if the configured source apart from HSI is
+    ///   already enabled.
     pub fn set_mco1_clock_divider(&self, divider: MCO1Divider) -> Result<(), ErrorCode> {
         match self.get_mco1_clock_source() {
             MCO1Source::PLL => {
@@ -538,8 +553,8 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
 
 /// Stm32f4Clocks trait
 ///
-/// This can be used to control clocks without the need to keep a reference of the chip specific
-/// Clocks struct, for instance by peripherals
+/// This can be used to control clocks without the need to keep a reference of
+/// the chip specific Clocks struct, for instance by peripherals
 pub trait Stm32f4Clocks {
     /// Get RCC instance
     fn get_rcc(&self) -> &Rcc;
@@ -562,8 +577,8 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Stm32f4Clocks for Clocks<'a, ChipSpecs> {
 
 /// Tests for clocks functionalities
 ///
-/// These tests ensure the clocks are properly working. If any changes are made to the clock
-/// module, make sure to run these tests.
+/// These tests ensure the clocks are properly working. If any changes are made
+/// to the clock module, make sure to run these tests.
 ///
 /// # Usage
 ///
@@ -574,13 +589,15 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Stm32f4Clocks for Clocks<'a, ChipSpecs> {
 /// use stm32f429zi::clocks;
 /// ```
 ///
-/// To run all the available tests, add this line before **kernel::process::load_processes()**:
+/// To run all the available tests, add this line before
+/// `kernel::process::load_processes()`:
 ///
 /// ```rust,ignore
 /// clocks::tests::run_all(&peripherals.stm32f4.clocks);
 /// ```
 ///
-/// If everything works as expected, the following message should be printed on the kernel console:
+/// If everything works as expected, the following message should be printed on
+/// the kernel console:
 ///
 /// ```text
 /// ===============================================
@@ -614,13 +631,14 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Stm32f4Clocks for Clocks<'a, ChipSpecs> {
 /// ===============================================
 /// ```
 ///
-/// There is also the possibility to run a part of the test suite. Check the functions present in
-/// this module for more details.
+/// There is also the possibility to run a part of the test suite. Check the
+/// functions present in this module for more details.
 ///
 /// # Errors
 ///
-/// If there are any errors, open an issue ticket at <https://github.com/tock/tock>. Please provide the
-/// output of the test execution.
+/// If there are any errors, open an issue ticket at
+/// <https://github.com/tock/tock>. Please provide the output of the test
+/// execution.
 pub mod tests {
     use super::{
         debug, AHBPrescaler, APBPrescaler, ChipSpecsTrait, Clocks, ErrorCode, MCO1Divider,

--- a/chips/stm32f4xx/src/clocks/hse.rs
+++ b/chips/stm32f4xx/src/clocks/hse.rs
@@ -104,7 +104,7 @@ impl<'a> Hse<'a> {
     ///
     /// + [Err]\([ErrorCode::FAIL]\): if the HSE clock is configured as the system clock.
     /// + [Err]\([ErrorCode::BUSY]\): disabling the HSE clock took to long. Retry to ensure it is
-    /// not running.
+    ///   not running.
     pub fn disable(&self) -> Result<(), ErrorCode> {
         if self.rcc.is_hse_clock_system_clock() {
             return Err(ErrorCode::FAIL);

--- a/chips/stm32f4xx/src/clocks/hsi.rs
+++ b/chips/stm32f4xx/src/clocks/hsi.rs
@@ -8,8 +8,8 @@
 //!
 //! # Usage
 //!
-//! For the purposes of brevity, any error checking has been removed. In real applications, always
-//! check the return values of the [Hsi] methods.
+//! For the purposes of brevity, any error checking has been removed. In real
+//! applications, always check the return values of the [Hsi] methods.
 //!
 //! First, get a reference to the [Hsi] struct:
 //! ```rust,ignore
@@ -75,8 +75,8 @@ impl<'a> Hsi<'a> {
     ///
     /// # Errors
     ///
-    /// + [Err]\([ErrorCode::BUSY]\): if enabling the HSI clock took too long. Recall this method to
-    /// ensure the HSI clock is running.
+    /// + [Err]\([ErrorCode::BUSY]\): if enabling the HSI clock took too long.
+    ///   Recall this method to ensure the HSI clock is running.
     pub fn enable(&self) -> Result<(), ErrorCode> {
         self.rcc.enable_hsi_clock();
 
@@ -94,8 +94,8 @@ impl<'a> Hsi<'a> {
     /// # Errors
     ///
     /// + [Err]\([ErrorCode::FAIL]\): if the HSI clock is configured as the system clock.
-    /// + [Err]\([ErrorCode::BUSY]\): disabling the HSI clock took to long. Retry to ensure it is
-    /// not running.
+    /// + [Err]\([ErrorCode::BUSY]\): disabling the HSI clock took to long.
+    ///   Retry to ensure it is not running.
     pub fn disable(&self) -> Result<(), ErrorCode> {
         if self.rcc.is_hsi_clock_system_clock() {
             return Err(ErrorCode::FAIL);

--- a/chips/stm32f4xx/src/clocks/phclk.rs
+++ b/chips/stm32f4xx/src/clocks/phclk.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
+//! Peripheral clock driver for the STM32F4xx family.
+
 use crate::clocks::Stm32f4Clocks;
 use crate::rcc::{APBPrescaler, Rcc, RtcClockSource};
 use kernel::platform::chip::ClockInterface;

--- a/chips/stm32f4xx/src/clocks/pll.rs
+++ b/chips/stm32f4xx/src/clocks/pll.rs
@@ -30,8 +30,8 @@
 //!
 //! # Usage
 //!
-//! For the purposes of brevity, any error checking has been removed. In real applications, always
-//! check the return values of the [Pll] methods.
+//! For the purposes of brevity, any error checking has been removed. In real
+//! applications, always check the return values of the [Pll] methods.
 //!
 //! First, get a reference to the [Pll] struct:
 //! ```rust,ignore
@@ -281,30 +281,33 @@ impl<'a, PllConstants: clock_constants::PllConstants> Pll<'a, PllConstants> {
     /// The PLL clock has two outputs:
     ///
     /// + main output used for configuring the system clock
-    /// + a second output called PLL48CLK used by OTG USB FS (48MHz), the random number generator
-    /// (≤ 48MHz) and the SDIO (≤ 48MHz) clocks.
+    /// + a second output called PLL48CLK used by OTG USB FS (48MHz), the random
+    ///   number generator(≤ 48MHz) and the SDIO (≤ 48MHz) clocks.
     ///
-    /// When calling this method, the given frequency is set for the main output. The method will
-    /// attempt to configure the PLL48CLK output to 48MHz, or to the highest value less than 48MHz
-    /// if it is not possible to get a precise 48MHz. In order to obtain a precise 48MHz frequency
-    /// (for the OTG USB FS peripheral), one should call this method with a frequency of 1, 1.5, 2,
-    /// 2.5 ... 4 x 48MHz.
+    /// When calling this method, the given frequency is set for the main
+    /// output. The method will attempt to configure the PLL48CLK output to
+    /// 48MHz, or to the highest value less than 48MHz if it is not possible to
+    /// get a precise 48MHz. In order to obtain a precise 48MHz frequency
+    /// (for the OTG USB FS peripheral), one should call this method with a
+    /// frequency of 1, 1.5, 2, 2.5 ... 4 x 48MHz.
     ///
     /// # Parameters
     ///
     /// + pll_source: PLL source clock (HSI or HSE)
     ///
-    /// + source_frequency: the frequency of the PLL source clock in MHz. For the HSI the frequency
-    /// is fixed to 16MHz. For the HSE, the frequency is hardware-dependent
+    /// + source_frequency: the frequency of the PLL source clock in MHz. For
+    ///   the HSI the frequency is fixed to 16MHz. For the HSE, the frequency
+    ///   is hardware-dependent
     ///
-    /// + desired_frequency_mhz: the desired frequency in MHz. Supported values: 24-216MHz for
-    /// STM32F401 and 13-216MHz for all the other chips
+    /// + desired_frequency_mhz: the desired frequency in MHz. Supported values:
+    ///   24-216MHz for STM32F401 and 13-216MHz for all the other chips
     ///
     /// # Errors
     ///
-    /// + [Err]\([ErrorCode::INVAL]\): if the desired frequency can't be achieved
-    /// + [Err]\([ErrorCode::FAIL]\): if the PLL clock is already enabled. It must be disabled before
-    /// configuring it.
+    /// + [Err]\([ErrorCode::INVAL]\): if the desired frequency can't be
+    ///   achieved
+    /// + [Err]\([ErrorCode::FAIL]\): if the PLL clock is already enabled. It
+    ///   must be disabled before configuring it.
     pub(super) fn set_frequency_mhz(
         &self,
         pll_source: PllSource,

--- a/chips/stm32f4xx/src/clocks/pll.rs
+++ b/chips/stm32f4xx/src/clocks/pll.rs
@@ -6,9 +6,9 @@
 
 //! Main phase-locked loop (PLL) clock driver for the STM32F4xx family. [^doc_ref]
 //!
-//! Many boards of the STM32F4xx family provide several PLL clocks. However, all of them have a
-//! main PLL clock. This driver is designed for the main PLL clock. It will be simply referred as
-//! the PLL clock.
+//! Many boards of the STM32F4xx family provide several PLL clocks. However, all
+//! of them have a main PLL clock. This driver is designed for the main PLL
+//! clock. It will be simply referred as the PLL clock.
 //!
 //! The PLL clock is composed of two outputs:
 //!
@@ -130,18 +130,18 @@ pub struct Pll<'a, PllConstants> {
 }
 
 impl<'a, PllConstants: clock_constants::PllConstants> Pll<'a, PllConstants> {
-    // Create a new instance of the PLL clock.
-    //
-    // The instance of the PLL clock is configured to run at 96MHz and with minimal PLL jitter
-    // effects.
-    //
-    // # Parameters
-    //
-    // + rcc: an instance of [crate::rcc]
-    //
-    // # Returns
-    //
-    // An instance of the PLL clock.
+    /// Create a new instance of the PLL clock.
+    ///
+    /// The instance of the PLL clock is configured to run at 96MHz and with
+    /// minimal PLL jitter effects.
+    ///
+    /// # Parameters
+    ///
+    /// + rcc: an instance of [crate::rcc]
+    ///
+    /// # Returns
+    ///
+    /// An instance of the PLL clock.
     pub(in crate::clocks) fn new(rcc: &'a Rcc) -> Self {
         const PLLP: usize = match DEFAULT_PLLP_VALUE {
             PLLP::DivideBy2 => 2,
@@ -162,8 +162,8 @@ impl<'a, PllConstants: clock_constants::PllConstants> Pll<'a, PllConstants> {
         }
     }
 
-    // The caller must ensure the desired frequency lies between MIN_FREQ_MHZ and
-    // MAX_FREQ_MHZ.  Otherwise, the return value makes no sense.
+    /// The caller must ensure the desired frequency lies between MIN_FREQ_MHZ
+    /// and MAX_FREQ_MHZ. Otherwise, the return value makes no sense.
     fn compute_pllp(desired_frequency_mhz: usize) -> PLLP {
         if desired_frequency_mhz < 55 {
             PLLP::DivideBy8
@@ -176,8 +176,8 @@ impl<'a, PllConstants: clock_constants::PllConstants> Pll<'a, PllConstants> {
         }
     }
 
-    // The caller must ensure the desired frequency lies between MIN_FREQ_MHZ and
-    // MAX_FREQ_MHZ. Otherwise, the return value makes no sense.
+    /// The caller must ensure the desired frequency lies between MIN_FREQ_MHZ
+    /// and MAX_FREQ_MHZ. Otherwise, the return value makes no sense.
     fn compute_plln(
         desired_frequency_mhz: usize,
         pll_source_clock_freq: usize,
@@ -187,8 +187,8 @@ impl<'a, PllConstants: clock_constants::PllConstants> Pll<'a, PllConstants> {
         desired_frequency_mhz * Into::<usize>::into(pllp) / vco_input_frequency
     }
 
-    // The caller must ensure the VCO output frequency lies between 100 and 432MHz. Otherwise, the
-    // return value makes no sense.
+    /// The caller must ensure the VCO output frequency lies between 100 and
+    /// 432MHz. Otherwise, the return value makes no sense.
     fn compute_pllq(vco_output_frequency_mhz: usize) -> PLLQ {
         for pllq in 3..10 {
             if 48 * pllq >= vco_output_frequency_mhz {
@@ -220,8 +220,8 @@ impl<'a, PllConstants: clock_constants::PllConstants> Pll<'a, PllConstants> {
     ///
     /// # Errors
     ///
-    /// + [Err]\([ErrorCode::BUSY]\): if enabling the PLL clock took too long. Recall this method to
-    /// ensure the PLL clock is running.
+    /// + [Err]\([ErrorCode::BUSY]\): if enabling the PLL clock took too long.
+    ///   Recall this method to ensure the PLL clock is running.
     pub fn enable(&self) -> Result<(), ErrorCode> {
         // Enable the PLL clock
         self.rcc.enable_pll_clock();
@@ -242,9 +242,10 @@ impl<'a, PllConstants: clock_constants::PllConstants> Pll<'a, PllConstants> {
     ///
     /// # Errors
     ///
-    /// + [Err]\([ErrorCode::FAIL]\): if the PLL clock is configured as the system clock.
-    /// + [Err]\([ErrorCode::BUSY]\): disabling the PLL clock took to long. Retry to ensure it is
-    /// not running.
+    /// + [Err]\([ErrorCode::FAIL]\): if the PLL clock is configured as the
+    ///   system clock.
+    /// + [Err]\([ErrorCode::BUSY]\): disabling the PLL clock took to long.
+    ///   Retry to ensure it is not running.
     pub fn disable(&self) -> Result<(), ErrorCode> {
         // Can't disable the PLL clock when it is used as the system clock
         if self.rcc.get_sys_clock_source() == SysClockSource::PLL {
@@ -304,10 +305,9 @@ impl<'a, PllConstants: clock_constants::PllConstants> Pll<'a, PllConstants> {
     ///
     /// # Errors
     ///
-    /// + [Err]\([ErrorCode::INVAL]\): if the desired frequency can't be
-    ///   achieved
-    /// + [Err]\([ErrorCode::FAIL]\): if the PLL clock is already enabled. It
-    ///   must be disabled before configuring it.
+    /// + [Err]\([ErrorCode::INVAL]\): if the desired frequency can't be achieved
+    /// + [Err]\([ErrorCode::FAIL]\): if the PLL clock is already enabled. It must be
+    ///   disabled before configuring it.
     pub(super) fn set_frequency_mhz(
         &self,
         pll_source: PllSource,
@@ -375,8 +375,8 @@ impl<'a, PllConstants: clock_constants::PllConstants> Pll<'a, PllConstants> {
         }
     }
 
-    /// Get the frequency in MHz of the PLL clock from RCC registers instead of using the cached
-    /// value.
+    /// Get the frequency in MHz of the PLL clock from RCC registers instead of
+    /// using the cached value.
     ///
     /// # Returns
     ///
@@ -395,8 +395,8 @@ impl<'a, PllConstants: clock_constants::PllConstants> Pll<'a, PllConstants> {
 
     /// Get the frequency in MHz of the PLL48 clock.
     ///
-    /// **NOTE:** If the PLL clock was not configured with a frequency multiple of 48MHz, the
-    /// returned value is inaccurate.
+    /// **NOTE:** If the PLL clock was not configured with a frequency multiple
+    /// of 48MHz, the returned value is inaccurate.
     ///
     /// # Returns
     ///
@@ -425,8 +425,9 @@ impl<'a, PllConstants: clock_constants::PllConstants> Pll<'a, PllConstants> {
 
 /// Tests for the PLL clock
 ///
-/// This module ensures that the PLL clock works as expected. If changes are brought to the PLL
-/// clock, ensure to run all the tests to see if anything is broken.
+/// This module ensures that the PLL clock works as expected. If changes are
+/// brought to the PLL clock, ensure to run all the tests to see if anything is
+/// broken.
 ///
 /// # Usage
 ///
@@ -435,13 +436,16 @@ impl<'a, PllConstants: clock_constants::PllConstants> Pll<'a, PllConstants> {
 /// ```rust,ignore
 /// use stm32f429zi::pll;
 /// ```
-/// To run all the available tests, add this line before **kernel::process::load_processes()**:
+///
+/// To run all the available tests, add this line before
+/// `kernel::process::load_processes()`:
 ///
 /// ```rust,ignore
 /// pll::tests::run(&peripherals.stm32f4.clocks.pll);
 /// ```
 ///
-/// If everything works as expected, the following message should be printed on the kernel console:
+/// If everything works as expected, the following message should be printed on
+/// the kernel console:
 ///
 /// ```text
 /// ===============================================
@@ -457,13 +461,14 @@ impl<'a, PllConstants: clock_constants::PllConstants> Pll<'a, PllConstants> {
 /// ===============================================
 /// ```
 ///
-/// There is also the possibility to run a part of the test suite. Check the functions present in
-/// this module for more details.
+/// There is also the possibility to run a part of the test suite. Check the
+/// functions present in this module for more details.
 ///
 /// # Errors
 ///
-/// If there are any errors, open an issue ticket at <https://github.com/tock/tock>. Please provide the
-/// output of the test execution.
+/// If there are any errors, open an issue ticket at
+/// <https://github.com/tock/tock>. Please provide the output of the test
+/// execution.
 pub mod tests {
     use super::{
         clock_constants, debug, ErrorCode, Pll, PllSource, DEFAULT_PLLM_VALUE, HSI_FREQUENCY_MHZ,

--- a/chips/stm32wle5xx/src/clocks/clocks.rs
+++ b/chips/stm32wle5xx/src/clocks/clocks.rs
@@ -66,7 +66,7 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
     /// # Errors:
     ///
     /// + [Err]\([ErrorCode::FAIL]\) if changing the AHB prescaler doesn't preserve APB frequency
-    /// constraints
+    ///   constraints
     /// + [Err]\([ErrorCode::BUSY]\) if changing the AHB prescaler took too long. Retry.
     pub fn set_ahb_prescaler(&self, prescaler: AHBPrescaler) -> Result<(), ErrorCode> {
         // Changing the AHB prescaler affects the APB frequencies. A check must be done to ensure
@@ -205,7 +205,7 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Clocks<'a, ChipSpecs> {
     ///
     /// + [Err]\([ErrorCode::FAIL]\) if the source is not enabled.
     /// + [Err]\([ErrorCode::SIZE]\) if the source frequency surpasses the system clock frequency
-    /// limit, or the APB1 and APB2 limits are not satisfied.
+    ///   limit, or the APB1 and APB2 limits are not satisfied.
     /// + [Err]\([ErrorCode::BUSY]\) if the source switching took too long. Retry.
     pub fn set_sys_clock_source(&self, source: SysClockSource) -> Result<(), ErrorCode> {
         // Immediately return if the required source is already configured as the system clock

--- a/chips/stm32wle5xx/src/clocks/hse.rs
+++ b/chips/stm32wle5xx/src/clocks/hse.rs
@@ -67,7 +67,7 @@ impl<'a> Hse<'a> {
     ///
     /// + [Err]\([ErrorCode::FAIL]\): if the HSE clock is configured as the system clock.
     /// + [Err]\([ErrorCode::BUSY]\): disabling the HSE clock took to long. Retry to ensure it is
-    /// not running.
+    ///   not running.
     pub fn disable(&self) -> Result<(), ErrorCode> {
         if self.rcc.is_hse_clock_system_clock() {
             return Err(ErrorCode::FAIL);

--- a/chips/stm32wle5xx/src/clocks/hsi.rs
+++ b/chips/stm32wle5xx/src/clocks/hsi.rs
@@ -42,7 +42,7 @@ impl<'a> Hsi<'a> {
     /// # Errors
     ///
     /// + [Err]\([ErrorCode::BUSY]\): if enabling the HSI clock took too long. Recall this method to
-    /// ensure the HSI clock is running.
+    ///   ensure the HSI clock is running.
     pub fn enable(&self) -> Result<(), ErrorCode> {
         self.rcc.enable_hsi_clock();
 
@@ -61,7 +61,7 @@ impl<'a> Hsi<'a> {
     ///
     /// + [Err]\([ErrorCode::FAIL]\): if the HSI clock is configured as the system clock.
     /// + [Err]\([ErrorCode::BUSY]\): disabling the HSI clock took to long. Retry to ensure it is
-    /// not running.
+    ///   not running.
     pub fn disable(&self) -> Result<(), ErrorCode> {
         if self.rcc.is_hsi_clock_system_clock() {
             return Err(ErrorCode::FAIL);

--- a/chips/stm32wle5xx/src/clocks/msi.rs
+++ b/chips/stm32wle5xx/src/clocks/msi.rs
@@ -42,7 +42,7 @@ impl<'a> Msi<'a> {
     /// # Errors
     ///
     /// + [Err]\([ErrorCode::BUSY]\): if enabling the MSI clock took too long. Recall this method to
-    /// ensure the MSI clock is running.
+    ///   ensure the MSI clock is running.
     pub fn enable(&self) -> Result<(), ErrorCode> {
         self.rcc.enable_msi_clock();
 
@@ -61,7 +61,7 @@ impl<'a> Msi<'a> {
     ///
     /// + [Err]\([ErrorCode::FAIL]\): if the MSI clock is configured as the system clock.
     /// + [Err]\([ErrorCode::BUSY]\): disabling the MSI clock took to long. Retry to ensure it is
-    /// not running.
+    ///   not running.
     pub fn disable(&self) -> Result<(), ErrorCode> {
         if self.rcc.is_msi_clock_system_clock() {
             return Err(ErrorCode::FAIL);

--- a/chips/stm32wle5xx/src/clocks/pll.rs
+++ b/chips/stm32wle5xx/src/clocks/pll.rs
@@ -126,7 +126,7 @@ impl<'a, PllConstants: clock_constants::PllConstants> Pll<'a, PllConstants> {
     /// # Errors
     ///
     /// + [Err]\([ErrorCode::BUSY]\): if enabling the PLL clock took too long. Recall this method to
-    /// ensure the PLL clock is running.
+    ///   ensure the PLL clock is running.
     pub fn enable(&self) -> Result<(), ErrorCode> {
         // Enable the PLL clock
         self.rcc.enable_pll_clock();
@@ -149,7 +149,7 @@ impl<'a, PllConstants: clock_constants::PllConstants> Pll<'a, PllConstants> {
     ///
     /// + [Err]\([ErrorCode::FAIL]\): if the PLL clock is configured as the system clock.
     /// + [Err]\([ErrorCode::BUSY]\): disabling the PLL clock took to long. Retry to ensure it is
-    /// not running.
+    ///   not running.
     pub fn disable(&self) -> Result<(), ErrorCode> {
         // Can't disable the PLL clock when it is used as the system clock
         if self.rcc.get_sys_clock_source() == SysClockSource::PLLR {
@@ -187,7 +187,7 @@ impl<'a, PllConstants: clock_constants::PllConstants> Pll<'a, PllConstants> {
     ///
     /// + main output used for configuring the system clock
     /// + a second output called PLL48CLK used by OTG USB FS (48MHz), the random number generator
-    /// (≤ 48MHz) and the SDIO (≤ 48MHz) clocks.
+    ///   (≤ 48MHz) and the SDIO (≤ 48MHz) clocks.
     ///
     /// When calling this method, the given frequency is set for the main output. The method will
     /// attempt to configure the PLL48CLK output to 48MHz, or to the highest value less than 48MHz
@@ -200,7 +200,7 @@ impl<'a, PllConstants: clock_constants::PllConstants> Pll<'a, PllConstants> {
     /// + pll_source: PLL source clock (HSI or HSE)
     ///
     /// + source_frequency: the frequency of the PLL source clock in MHz. For the HSI the frequency
-    /// is fixed to 16MHz. For the HSE, the frequency is hardware-dependent
+    ///   is fixed to 16MHz. For the HSE, the frequency is hardware-dependent
     ///
     /// + desired_frequency_mhz: the desired frequency in MHz.
     ///
@@ -208,7 +208,7 @@ impl<'a, PllConstants: clock_constants::PllConstants> Pll<'a, PllConstants> {
     ///
     /// + [Err]\([ErrorCode::INVAL]\): if the desired frequency can't be achieved
     /// + [Err]\([ErrorCode::FAIL]\): if the PLL clock is already enabled. It must be disabled before
-    /// configuring it.
+    ///   configuring it.
     pub(super) fn set_frequency_mhz(
         &self,
         pll_source: PllSource,

--- a/kernel/src/collections/ring_buffer.rs
+++ b/kernel/src/collections/ring_buffer.rs
@@ -44,11 +44,12 @@ impl<'a, T: Copy> RingBuffer<'a, T> {
     ///
     /// Returns:
     /// - `(None, None)` if the buffer is empty.
-    /// - `(Some(slice), None)` if the head is before the tail (therefore all the contents is
-    /// contiguous).
-    /// - `(Some(left), Some(right))` if the head is after the tail. In that case, the logical
-    /// contents of the buffer is `[left, right].concat()` (although physically the "left" slice is
-    /// stored after the "right" slice).
+    /// - `(Some(slice), None)` if the head is before the tail (therefore all
+    ///   the contents is contiguous).
+    /// - `(Some(left), Some(right))` if the head is after the tail. In that
+    ///   case, the logical contents of the buffer is `[left, right].concat()`
+    ///   (although physically the "left" slice is stored after the "right"
+    ///   slice).
     pub fn as_slices(&'a self) -> (Option<&'a [T]>, Option<&'a [T]>) {
         // SAFETY: Reinterprets &[MaybeUninit<T>] as &[T]. MaybeUninit<T> has the same layout as
         // T, and every element in the returned slice falls within [head, tail) which has been

--- a/kernel/src/hil/digest.rs
+++ b/kernel/src/hil/digest.rs
@@ -14,78 +14,88 @@ use crate::utilities::leasable_buffer::SubSliceMut;
 ///
 /// 'DIGEST_LEN' is the length of the 'u8' array to store the digest output.
 pub trait ClientData<const DIGEST_LEN: usize> {
-    /// Called when the data has been added to the digest. `data` is
-    /// the `SubSlice` passed in the call to `add_data`, whose
-    /// active slice contains the data that was not added. On `Ok`,
-    /// `data` has an active slice of size zero (all data was added).
+    /// Called when the data has been added to the digest.
+    ///
+    /// `data` is the `SubSlice` passed in the call to `add_data`, whose active
+    /// slice contains the data that was not added. On `Ok`, `data` has an
+    /// active slice of size zero (all data was added).
+    ///
     /// Valid `ErrorCode` values are:
-    ///  - OFF: the underlying digest engine is powered down and
-    ///  cannot be used.
-    ///  - BUSY: there is an outstanding `add_data`, `add_data_mut`,
-    ///  `run`, or `verify` operation, so the digest engine is busy
-    ///  and cannot accept more data.
-    ///  - SIZE: the active slice of the SubSlice has zero size.
-    ///  - CANCEL: the operation was cancelled by a call to `clear_data`.
-    ///  - FAIL: an internal failure.
+    /// - `OFF`: the underlying digest engine is powered down and cannot be
+    ///   used.
+    /// - `BUSY`: there is an outstanding `add_data`, `add_data_mut`, `run`, or
+    ///   `verify` operation, so the digest engine is busy and cannot accept
+    ///   more data.
+    /// - `SIZE`: the active slice of the SubSlice has zero size.
+    /// - `CANCEL`: the operation was cancelled by a call to `clear_data`.
+    /// - `FAIL`: an internal failure.
     fn add_data_done(&self, result: Result<(), ErrorCode>, data: SubSlice<'static, u8>);
 
-    /// Called when the data has been added to the digest. `data` is
-    /// the `SubSliceMut` passed in the call to
-    /// `add_mut_data`, whose active slice contains the data that was
-    /// not added. On `Ok`, `data` has an active slice of size zero
-    /// (all data was added). Valid `ErrorCode` values are:
-    ///  - OFF: the underlying digest engine is powered down and
-    ///  cannot be used.
-    ///  - BUSY: there is an outstanding `add_data`, `add_data_mut`,
-    ///  `run`, or `verify` operation, so the digest engine is busy
-    ///  and cannot accept more data.
-    ///  - SIZE: the active slice of the SubSlice has zero size.
-    ///  - CANCEL: the operation was cancelled by a call to `clear_data`.
-    ///  - FAIL: an internal failure.
+    /// Called when the data has been added to the digest.
+    ///
+    /// `data` is the `SubSliceMut` passed in the call to `add_mut_data`, whose
+    /// active slice contains the data that was not added. On `Ok`, `data` has
+    /// an active slice of size zero(all data was added).
+    ///
+    /// Valid `ErrorCode` values are:
+    /// - `OFF`: the underlying digest engine is powered down and cannot be
+    ///   used.
+    /// - `BUSY`: there is an outstanding `add_data`, `add_data_mut`, `run`, or
+    ///   `verify` operation, so the digest engine is busy and cannot accept
+    ///   more data.
+    /// - `SIZE`: the active slice of the SubSlice has zero size.
+    /// - `CANCEL`: the operation was cancelled by a call to `clear_data`.
+    /// - `FAIL`: an internal failure.
     fn add_mut_data_done(&self, result: Result<(), ErrorCode>, data: SubSliceMut<'static, u8>);
 }
 
-/// Implement this trait and use `set_client()` in order to receive callbacks when
-/// a digest is completed.
+/// Implement this trait and use `set_client()` in order to receive callbacks
+/// when a digest is completed.
 ///
 /// 'DIGEST_LEN' is the length of the 'u8' array to store the digest output.
 pub trait ClientHash<const DIGEST_LEN: usize> {
-    /// Called when a digest is computed. `digest` is the same
+    /// Called when a digest is computed.
+    ///
+    /// `digest` is the same
     /// reference passed to `run()` to store the hash value. If
     /// `result` is `Ok`, `digest` stores the computed hash. If
     /// `result` is `Err`, the data stored in `digest` is undefined
-    /// and may have any value. Valid `ErrorCode` values are:
-    ///  - OFF: the underlying digest engine is powered down and
-    ///  cannot be used.
-    ///  - BUSY: there is an outstanding `add_data`, `add_data_mut`,
-    ///  `run`, or `verify` operation, so the digest engine is busy
-    ///  and cannot perform a hash.
-    ///  - CANCEL: the operation was cancelled by a call to `clear_data`.
-    ///  - NOSUPPORT: the requested digest algorithm is not supported,
-    ///  or one was not requested.
-    ///  - FAIL: an internal failure.
+    /// and may have any value.
+    ///
+    /// Valid `ErrorCode` values are:
+    /// - `OFF`: the underlying digest engine is powered down and cannot be
+    ///   used.
+    /// - `BUSY`: there is an outstanding `add_data`, `add_data_mut`, `run`, or
+    ///   `verify` operation, so the digest engine is busy and cannot perform a
+    ///   hash.
+    /// - `CANCEL`: the operation was cancelled by a call to `clear_data`.
+    /// - `NOSUPPORT`: the requested digest algorithm is not supported, or one
+    ///   was not requested.
+    /// - `FAIL`: an internal failure.
     fn hash_done(&self, result: Result<(), ErrorCode>, digest: &'static mut [u8; DIGEST_LEN]);
 }
 
-/// Implement this trait and use `set_client()` in order to receive callbacks when
-/// digest verification is complete.
+/// Implement this trait and use `set_client()` in order to receive callbacks
+/// when digest verification is complete.
 ///
 /// 'DIGEST_LEN' is the length of the 'u8' array to store the digest output.
 pub trait ClientVerify<const DIGEST_LEN: usize> {
-    /// Called when a verification is computed.  `compare` is the
-    /// reference supplied to `verify()` and the data stored in
-    /// `compare` is unchanged.  On `Ok` the `bool` indicates if the
-    /// computed hash matches the value in `compare`. Valid
-    /// `ErrorCode` values are:
-    ///  - OFF: the underlying digest engine is powered down and
-    ///  cannot be used.
-    ///  - BUSY: there is an outstanding `add_data`, `add_data_mut`,
-    ///  `run`, or `verify` operation, so the digest engine is busy
-    ///  and cannot verify a hash.
-    ///  - CANCEL: the operation was cancelled by a call to `clear_data`.
-    ///  - NOSUPPORT: the requested digest algorithm is not supported,
-    ///  or one was not requested.
-    ///  - FAIL: an internal failure.
+    /// Called when a verification is computed.
+    ///
+    /// `compare` is the reference supplied to `verify()` and the data stored in
+    /// `compare` is unchanged.  On `Ok` the `bool` indicates if the computed
+    /// hash matches the value in `compare`.
+    ///
+    /// Valid `ErrorCode` values are:
+    /// - `OFF`: the underlying digest engine is powered down and cannot be
+    ///   used.
+    /// - `BUSY`: there is an outstanding `add_data`, `add_data_mut`, `run`, or
+    ///   `verify` operation, so the digest engine is busy and cannot verify a
+    ///   hash.
+    /// - `CANCEL`: the operation was cancelled by a call to `clear_data`.
+    /// - `NOSUPPORT`: the requested digest algorithm is not supported, or one
+    ///   was not requested.
+    /// - `FAIL`: an internal failure.
     fn verification_done(
         &self,
         result: Result<bool, ErrorCode>,
@@ -136,46 +146,51 @@ pub trait DigestData<'a, const DIGEST_LEN: usize> {
     /// and `add_mut_data_done` callbacks.
     fn set_data_client(&'a self, client: &'a dyn ClientData<DIGEST_LEN>);
 
-    /// Add data to the input of the hash function/digest. `Ok`
-    /// indicates all of the active bytes in `data` will be added.
-    /// There is no guarantee the data has been added to the digest
-    /// until the `add_data_done()` callback is called.  On error the
-    /// cause of the error is returned along with the SubSlice
-    /// unchanged (it has the same range of active bytes as the call).
+    /// Add data to the input of the hash function/digest.
+    ///
+    /// `Ok` indicates all of the active bytes in `data` will be added. There is
+    /// no guarantee the data has been added to the digest until the
+    /// `add_data_done()` callback is called.  On error the cause of the error
+    /// is returned along with the SubSlice unchanged (it has the same range of
+    /// active bytes as the call).
+    ///
     /// Valid `ErrorCode` values are:
-    ///  - OFF: the underlying digest engine is powered down and
-    ///  cannot be used.
-    ///  - BUSY: there is an outstanding `add_data`, `add_data_mut`,
-    ///  `run`, or `verify` operation, so the digest engine is busy
-    ///  and cannot accept more data.
-    ///  - SIZE: the active slice of the SubSlice has zero size.
+    /// - `OFF`: the underlying digest engine is powered down and cannot be
+    ///   used.
+    /// - `BUSY`: there is an outstanding `add_data`, `add_data_mut`, `run`, or
+    ///   `verify` operation, so the digest engine is busy and cannot accept
+    ///   more data.
+    /// - `SIZE`: the active slice of the SubSlice has zero size.
     fn add_data(
         &self,
         data: SubSlice<'static, u8>,
     ) -> Result<(), (ErrorCode, SubSlice<'static, u8>)>;
 
-    /// Add data to the input of the hash function/digest. `Ok`
-    /// indicates all of the active bytes in `data` will be added.
-    /// There is no guarantee the data has been added to the digest
-    /// until the `add_mut_data_done()` callback is called.  On error
-    /// the cause of the error is returned along with the
-    /// SubSlice unchanged (it has the same range of active
-    /// bytes as the call).  Valid `ErrorCode` values are:
-    ///  - OFF: the underlying digest engine is powered down and
-    ///  cannot be used.
-    ///  - BUSY: there is an outstanding `add_data`, `add_data_mut`,
-    ///  `run`, or `verify` operation, so the digest engine is busy
-    ///  and cannot accept more data.
-    ///  - SIZE: the active slice of the SubSlice has zero size.
+    /// Add data to the input of the hash function/digest.
+    ///
+    /// `Ok` indicates all of the active bytes in `data` will be added. There is
+    /// no guarantee the data has been added to the digest until the
+    /// `add_mut_data_done()` callback is called.  On error the cause of the
+    /// error is returned along with the SubSlice unchanged (it has the same
+    /// range of active bytes as the call).
+    ///
+    /// Valid `ErrorCode` values are:
+    /// - `OFF`: the underlying digest engine is powered down and cannot be
+    ///   used.
+    /// - `BUSY`: there is an outstanding `add_data`, `add_data_mut`, `run`, or
+    ///   `verify` operation, so the digest engine is busy and cannot accept
+    ///   more data.
+    /// - `SIZE`: the active slice of the SubSlice has zero size.
     fn add_mut_data(
         &self,
         data: SubSliceMut<'static, u8>,
     ) -> Result<(), (ErrorCode, SubSliceMut<'static, u8>)>;
 
-    /// Clear the keys and any other internal state. Any pending
-    /// operations terminate and issue a callback with an
-    /// `ErrorCode::CANCEL`. This call does not clear buffers passed
-    /// through `add_mut_data`, those are up to the client clear.
+    /// Clear the keys and any other internal state.
+    ///
+    /// Any pending operations terminate and issue a callback with an
+    /// [`ErrorCode::CANCEL`]. This call does not clear buffers passed through
+    /// `add_mut_data`, those are up to the client clear.
     fn clear_data(&self);
 }
 
@@ -189,24 +204,27 @@ pub trait DigestHash<'a, const DIGEST_LEN: usize> {
     fn set_hash_client(&'a self, client: &'a dyn ClientHash<DIGEST_LEN>);
 
     /// Compute a digest of all of the data added with `add_data` and
-    /// `add_data_mut`, storing the computed value in `digest`.  The
-    /// computed value is returned in a `hash_done` callback.  On
-    /// error the return value will contain a return code and the
-    /// slice passed in `digest`. Valid `ErrorCode` values are:
-    ///  - OFF: the underlying digest engine is powered down and
-    ///  cannot be used.
-    ///  - BUSY: there is an outstanding `add_data`, `add_data_mut`,
-    ///  `run`, or `verify` operation, so the digest engine is busy
-    ///  and cannot accept more data.
-    ///  - SIZE: the active slice of the SubSlice has zero size.
-    ///  - NOSUPPORT: the currently selected digest algorithm is not
-    ///  supported.
+    /// `add_data_mut`, storing the computed value in `digest`.
+    ///
+    /// The computed value is returned in a `hash_done` callback.  On error the
+    /// return value will contain a return code and the slice passed in
+    /// `digest`.
+    ///
+    /// Valid `ErrorCode` values are:
+    /// - `OFF`: the underlying digest engine is powered down and cannot be
+    ///   used.
+    /// - `BUSY`: there is an outstanding `add_data`, `add_data_mut`, `run`, or
+    ///   `verify` operation, so the digest engine is busy and cannot accept
+    ///   more data.
+    /// - `SIZE`: the active slice of the SubSlice has zero size.
+    /// - `NOSUPPORT`: the currently selected digest algorithm is not
+    ///   supported.
     ///
     /// If an appropriate `set_mode*()` wasn't called before this function the
     /// implementation should try to use a default option. In the case where
     /// there is only one digest supported this should be used. If there is no
     /// suitable or obvious default option, the implementation can return
-    /// `ErrorCode::NOSUPPORT`.
+    /// [`ErrorCode::NOSUPPORT`].
     fn run(
         &'a self,
         digest: &'static mut [u8; DIGEST_LEN],
@@ -223,25 +241,28 @@ pub trait DigestVerify<'a, const DIGEST_LEN: usize> {
     fn set_verify_client(&'a self, client: &'a dyn ClientVerify<DIGEST_LEN>);
 
     /// Compute a digest of all of the data added with `add_data` and
-    /// `add_data_mut` then compare it with value in `compare`.  The
-    /// compare value is returned in a `verification_done` callback, along with
-    /// a boolean indicating whether it matches the computed value. On
-    /// error the return value will contain a return code and the
-    /// slice passed in `compare`. Valid `ErrorCode` values are:
-    ///  - OFF: the underlying digest engine is powered down and
-    ///  cannot be used.
-    ///  - BUSY: there is an outstanding `add_data`, `add_data_mut`,
-    ///  `run`, or `verify` operation, so the digest engine is busy
-    ///  and cannot accept more data.
-    ///  - SIZE: the active slice of the SubSlice has zero size.
-    ///  - NOSUPPORT: the currently selected digest algorithm is not
-    ///  supported.
+    /// `add_data_mut` then compare it with value in `compare`.
+    ///
+    /// The compare value is returned in a `verification_done` callback, along
+    /// with a boolean indicating whether it matches the computed value. On
+    /// error the return value will contain a return code and the slice passed
+    /// in `compare`.
+    ///
+    /// Valid `ErrorCode` values are:
+    /// - `OFF`: the underlying digest engine is powered down and cannot be
+    ///   used.
+    /// - `BUSY`: there is an outstanding `add_data`, `add_data_mut`, `run`, or
+    ///   `verify` operation, so the digest engine is busy and cannot accept
+    ///   more data.
+    /// - `SIZE`: the active slice of the SubSlice has zero size.
+    /// - `NOSUPPORT`: the currently selected digest algorithm is not
+    ///   supported.
     ///
     /// If an appropriate `set_mode*()` wasn't called before this function the
     /// implementation should try to use a default option. In the case where
     /// there is only one digest supported this should be used. If there is no
     /// suitable or obvious default option, the implementation can return
-    /// `ErrorCode::NOSUPPORT`.
+    /// [`ErrorCode::NOSUPPORT`].
     fn verify(
         &'a self,
         compare: &'static mut [u8; DIGEST_LEN],

--- a/kernel/src/hil/sensors.rs
+++ b/kernel/src/hil/sensors.rs
@@ -17,7 +17,7 @@ pub trait TemperatureClient {
     /// Called when a temperature reading has completed.
     ///
     /// - `value`: the most recently read temperature in hundredths of degrees
-    /// centigrade (centiCelsius), or Err on failure.
+    ///   centigrade (centiCelsius), or Err on failure.
     fn callback(&self, value: Result<i32, ErrorCode>);
 }
 
@@ -53,8 +53,8 @@ pub trait MoistureDriver<'a> {
 pub trait MoistureClient {
     /// Called when a moisture reading has completed.
     ///
-    /// - `value`: the most recently read moisture in hundredths of
-    /// percent, or Err on failure.
+    /// - `value`: the most recently read moisture in hundredths of percent, or
+    ///   Err on failure.
     ///
     /// This function might return the following errors:
     /// - `BUSY`: Indicates that the hardware is busy with an existing operation
@@ -129,15 +129,23 @@ pub trait AirQualityClient {
 /// A basic interface for a proximity sensor
 pub trait ProximityDriver<'a> {
     fn set_client(&self, client: &'a dyn ProximityClient);
+
     /// Callback issued after sensor reads proximity value
     fn read_proximity(&self) -> Result<(), ErrorCode>;
-    /// Callback issued after sensor reads proximity value greater than 'high_threshold' or less than 'low_threshold'
+
+    /// Callback issued after sensor reads proximity value greater
+    /// than 'high_threshold' or less than 'low_threshold'
     ///
-    /// To elaborate, the callback is not issued by the driver until (prox_reading >= high_threshold || prox_reading <= low_threshold).
-    /// When (prox_reading >= high_threshold || prox_reading <= low_threshold) is read by the sensor, an I2C interrupt is generated and sent to the kernel
-    /// which prompts the driver to collect the proximity reading from the sensor and perform the callback.
-    /// Any apps issuing this command will have to wait for the proximity reading to fall within the aforementioned ranges in order to received a callback.
-    /// Threshold: A value of range [0 , 255] which represents at what proximity reading ranges an interrupt will occur.
+    /// To elaborate, the callback is not issued by the driver until
+    /// (prox_reading >= high_threshold || prox_reading <= low_threshold).
+    /// When (prox_reading >= high_threshold || prox_reading <= low_threshold)
+    /// is read by the sensor, an I2C interrupt is generated and sent to the
+    /// kernel which prompts the driver to collect the proximity reading from
+    /// the sensor and perform the callback. Any apps issuing this command will
+    /// have to wait for the proximity reading to fall within the
+    /// aforementioned ranges in order to received a callback. Threshold: A
+    /// value of range [0 , 255] which represents at what proximity reading
+    /// ranges an interrupt will occur.
     fn read_proximity_on_interrupt(
         &self,
         low_threshold: u8,
@@ -148,8 +156,9 @@ pub trait ProximityDriver<'a> {
 pub trait ProximityClient {
     /// Called when a proximity reading has completed.
     ///
-    /// - `value`: the most recently read proximity value which ranges [0 , 255]...
-    /// where 255 -> object is closest readable distance, 0 -> object is farthest readable distance.
+    /// - `value`: the most recently read proximity value which ranges
+    ///   [0 , 255]... where 255 -> object is closest readable distance, 0 ->
+    ///   object is farthest readable distance.
     fn callback(&self, value: u8);
 }
 

--- a/kernel/src/hil/servo.rs
+++ b/kernel/src/hil/servo.rs
@@ -3,25 +3,27 @@
 // Copyright Tock Contributors 2024.
 
 use crate::ErrorCode;
+
 pub trait Servo<'a> {
     /// Changes the angle of the servo.
-    /// Return values:
     ///
+    /// Return values:
     /// - `Ok(())`: The attempt at changing the angle was successful.
     /// - `FAIL`: Cannot change the angle.
     /// - `INVAL`: The value exceeds u16, indicating it's incorrect
-    /// since servomotors can only have a maximum of 360 degrees.
+    ///   since servomotors can only have a maximum of 360 degrees.
     /// - `NODEVICE`: The index exceeds the number of servomotors provided.
-    ///  # Arguments
-    /// - `angle` - the variable that receives the angle
-    /// (in degrees from 0 to 180) from the servo driver.
+    ///
+    /// # Arguments
+    /// - `angle`: the variable that receives the angle(in degrees from 0 to
+    ///   180) from the servo driver.
     fn set_angle(&self, angle: u16) -> Result<(), ErrorCode>;
 
     /// Returns the angle of the servo.
-    /// Return values:
     ///
-    /// - `angle`: The value, in angles from 0 to 360, of the servo.
-    /// - `NOSUPPORT`:  The servo cannot return its angle.
+    /// Return values:
+    /// - `Ok(angle)`: The value, in angles from 0 to 360, of the servo.
+    /// - `NOSUPPORT`: The servo cannot return its angle.
     /// - `NODEVICE`: The index exceeds the number of servomotors provided.
     fn get_angle(&self) -> Result<usize, ErrorCode>;
 }

--- a/kernel/src/hil/time.rs
+++ b/kernel/src/hil/time.rs
@@ -234,34 +234,21 @@ pub trait OverflowClient {
 
 /// Represents a free-running hardware counter that can be started and stopped.
 pub trait Counter<'a>: Time {
-<<<<<<< HEAD
     /// Starts the free-running hardware counter. Valid `Result<(), ErrorCode>` values are:
     ///   - `Ok(())`: the counter is now running
     ///   - `Err(ErrorCode::OFF)`: underlying clocks or other hardware resources
-=======
-    /// Specify the callback for when the counter overflows its maximum
-    /// value (defined by `Ticks`). If there was a previously registered
-    /// callback this call replaces it.
-    fn set_overflow_client(&self, client: &'a dyn OverflowClient);
-
-    /// Starts the free-running hardware counter. Valid `Result<(), ErrorCode>`
-    /// values are:
-    /// - `Ok(())`: the counter is now running
-    /// - `Err(ErrorCode::OFF)`: underlying clocks or other hardware resources
->>>>>>> c86cab10c (clippy: deny doc_lazy_continuation)
-    ///   are not on, such that the counter cannot start.
-    /// - `Err(ErrorCode::FAIL)`: unidentified failure, counter is not running.
+    ///     are not on, such that the counter cannot start.
+    ///   - `Err(ErrorCode::FAIL)`: unidentified failure, counter is not running.
     ///
     /// After a successful call to `start`, `is_running` MUST return true.
     fn start(&self) -> Result<(), ErrorCode>;
 
-    /// Stops the free-running hardware counter. Valid `Result<(), ErrorCode>`
-    /// values are:
-    /// - `Ok(())`: the counter is now stopped. No further
-    ///   overflow callbacks will be invoked.
-    /// - `Err(ErrorCode::BUSY)`: the counter is in use in a way that means it
-    ///   cannot be stopped and is busy.
-    /// - `Err(ErrorCode::FAIL)`: unidentified failure, counter is running.
+    /// Stops the free-running hardware counter. Valid `Result<(), ErrorCode>` values are:
+    ///   - `Ok(())`: the counter is now stopped. No further
+    ///     overflow callbacks will be invoked.
+    ///   - `Err(ErrorCode::BUSY)`: the counter is in use in a way that means it
+    ///     cannot be stopped and is busy.
+    ///   - `Err(ErrorCode::FAIL)`: unidentified failure, counter is running.
     ///
     /// After a successful call to `stop`, `is_running` MUST return false.
     fn stop(&self) -> Result<(), ErrorCode>;
@@ -271,8 +258,8 @@ pub trait Counter<'a>: Time {
     /// If a client needs to reset and clear pending callbacks it should
     /// call `stop` before `reset`.
     /// Valid `Result<(), ErrorCode>` values are:
-    /// - `Ok(())`: the counter was reset to 0.
-    /// - `Err(ErrorCode::FAIL)`: the counter was not reset to 0.
+    ///   - `Ok(())`: the counter was reset to 0.
+    ///   - `Err(ErrorCode::FAIL)`: the counter was not reset to 0.
     fn reset(&self) -> Result<(), ErrorCode>;
 
     /// Returns whether the counter is currently running.
@@ -327,10 +314,10 @@ pub trait Alarm<'a>: Time {
 
     /// Disable the alarm and stop it from firing in the future.
     /// Valid `Result<(), ErrorCode>` codes are:
-    /// - `Ok(())` the alarm has been disarmed and will not invoke
-    ///   the callback in the future
-    /// - `Err(ErrorCode::FAIL)` the alarm could not be disarmed and will invoke
-    ///   the callback in the future
+    ///   - `Ok(())` the alarm has been disarmed and will not invoke
+    ///     the callback in the future
+    ///   - `Err(ErrorCode::FAIL)` the alarm could not be disarmed and will invoke
+    ///     the callback in the future
     fn disarm(&self) -> Result<(), ErrorCode>;
 
     /// Returns whether the alarm is currently armed. Note that this
@@ -403,11 +390,10 @@ pub trait Timer<'a>: Time {
     /// or `repeating` restarts the timer.
     fn is_enabled(&self) -> bool;
 
-    /// Cancel the current timer, if any. Value `Result<(), ErrorCode>` values
-    /// are:
-    /// - `Ok(())`: no callback will be invoked in the future.
-    /// - `Err(ErrorCode::FAIL)`: the timer could not be cancelled and a
-    ///   callback will be invoked in the future.
+    /// Cancel the current timer, if any. Value `Result<(), ErrorCode>` values are:
+    ///  - `Ok(())`: no callback will be invoked in the future.
+    ///  - `Err(ErrorCode::FAIL)`: the timer could not be cancelled and a callback
+    ///    will be invoked in the future.
     fn cancel(&self) -> Result<(), ErrorCode>;
 }
 

--- a/kernel/src/hil/time.rs
+++ b/kernel/src/hil/time.rs
@@ -234,20 +234,35 @@ pub trait OverflowClient {
 
 /// Represents a free-running hardware counter that can be started and stopped.
 pub trait Counter<'a>: Time {
+<<<<<<< HEAD
     /// Starts the free-running hardware counter. Valid `Result<(), ErrorCode>` values are:
     ///   - `Ok(())`: the counter is now running
     ///   - `Err(ErrorCode::OFF)`: underlying clocks or other hardware resources
+=======
+    /// Specify the callback for when the counter overflows its maximum
+    /// value (defined by `Ticks`). If there was a previously registered
+    /// callback this call replaces it.
+    fn set_overflow_client(&self, client: &'a dyn OverflowClient);
+
+    /// Starts the free-running hardware counter. Valid `Result<(), ErrorCode>`
+    /// values are:
+    /// - `Ok(())`: the counter is now running
+    /// - `Err(ErrorCode::OFF)`: underlying clocks or other hardware resources
+>>>>>>> c86cab10c (clippy: deny doc_lazy_continuation)
     ///   are not on, such that the counter cannot start.
-    ///   - `Err(ErrorCode::FAIL)`: unidentified failure, counter is not running.
+    /// - `Err(ErrorCode::FAIL)`: unidentified failure, counter is not running.
+    ///
     /// After a successful call to `start`, `is_running` MUST return true.
     fn start(&self) -> Result<(), ErrorCode>;
 
-    /// Stops the free-running hardware counter. Valid `Result<(), ErrorCode>` values are:
-    ///   - `Ok(())`: the counter is now stopped. No further
+    /// Stops the free-running hardware counter. Valid `Result<(), ErrorCode>`
+    /// values are:
+    /// - `Ok(())`: the counter is now stopped. No further
     ///   overflow callbacks will be invoked.
-    ///   - `Err(ErrorCode::BUSY)`: the counter is in use in a way that means it
+    /// - `Err(ErrorCode::BUSY)`: the counter is in use in a way that means it
     ///   cannot be stopped and is busy.
-    ///   - `Err(ErrorCode::FAIL)`: unidentified failure, counter is running.
+    /// - `Err(ErrorCode::FAIL)`: unidentified failure, counter is running.
+    ///
     /// After a successful call to `stop`, `is_running` MUST return false.
     fn stop(&self) -> Result<(), ErrorCode>;
 
@@ -256,8 +271,8 @@ pub trait Counter<'a>: Time {
     /// If a client needs to reset and clear pending callbacks it should
     /// call `stop` before `reset`.
     /// Valid `Result<(), ErrorCode>` values are:
-    ///    - `Ok(())`: the counter was reset to 0.
-    ///    - `Err(ErrorCode::FAIL)`: the counter was not reset to 0.
+    /// - `Ok(())`: the counter was reset to 0.
+    /// - `Err(ErrorCode::FAIL)`: the counter was not reset to 0.
     fn reset(&self) -> Result<(), ErrorCode>;
 
     /// Returns whether the counter is currently running.
@@ -312,9 +327,9 @@ pub trait Alarm<'a>: Time {
 
     /// Disable the alarm and stop it from firing in the future.
     /// Valid `Result<(), ErrorCode>` codes are:
-    ///   - `Ok(())` the alarm has been disarmed and will not invoke
+    /// - `Ok(())` the alarm has been disarmed and will not invoke
     ///   the callback in the future
-    ///   - `Err(ErrorCode::FAIL)` the alarm could not be disarmed and will invoke
+    /// - `Err(ErrorCode::FAIL)` the alarm could not be disarmed and will invoke
     ///   the callback in the future
     fn disarm(&self) -> Result<(), ErrorCode>;
 
@@ -388,10 +403,11 @@ pub trait Timer<'a>: Time {
     /// or `repeating` restarts the timer.
     fn is_enabled(&self) -> bool;
 
-    /// Cancel the current timer, if any. Value `Result<(), ErrorCode>` values are:
-    ///  - `Ok(())`: no callback will be invoked in the future.
-    ///  - `Err(ErrorCode::FAIL)`: the timer could not be cancelled and a callback
-    ///  will be invoked in the future.
+    /// Cancel the current timer, if any. Value `Result<(), ErrorCode>` values
+    /// are:
+    /// - `Ok(())`: no callback will be invoked in the future.
+    /// - `Err(ErrorCode::FAIL)`: the timer could not be cancelled and a
+    ///   callback will be invoked in the future.
     fn cancel(&self) -> Result<(), ErrorCode>;
 }
 


### PR DESCRIPTION
### Pull Request Overview

In markdown, text like this is unclear:

```text
Consider a list:
- My first list element says something.
- My second list element is good.
Good list elements are helpful to put second.
```

Should the sentence `Good list elements are helpful to put second.` be part of the list (it will be) or a new paragraph?

This lint ensures that if it is part of the list element it is indented:

```text
Consider a list:
- My first list element says something.
- My second list element is good.
  Good list elements are helpful to put second.
```

or if it is a new paragraph there is a space:

```text
Consider a list:
- My first list element says something.
- My second list element is good.

Good list elements are helpful to put second.
```


### Testing Strategy

Running `cargo clippy`


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.

All me.