### PR TITLE
arch: cortex-m: systick constructors safe

### DIFF
--- a/arch/cortex-m/src/systick.rs
+++ b/arch/cortex-m/src/systick.rs
@@ -76,7 +76,7 @@ impl SysTick {
     ///
     /// Use this constructor if the core implementation has a pre-calibration
     /// value in hardware.
-    pub unsafe fn new() -> SysTick {
+    pub fn new() -> SysTick {
         SysTick {
             hertz: Cell::new(0),
             external_clock: false,
@@ -91,7 +91,7 @@ impl SysTick {
     /// * `clock_speed` - the frequency of SysTick tics in Hertz. For example,
     ///   if the SysTick is driven by the CPU clock, it is simply the CPU
     ///   speed.
-    pub unsafe fn new_with_calibration(clock_speed: u32) -> SysTick {
+    pub fn new_with_calibration(clock_speed: u32) -> SysTick {
         let res = SysTick::new();
         res.hertz.set(clock_speed);
         res
@@ -107,7 +107,7 @@ impl SysTick {
     /// * `clock_speed` - the frequency of SysTick tics in Hertz. For example,
     ///   if the SysTick is driven by the CPU clock, it is simply the CPU
     ///   speed.
-    pub unsafe fn new_with_calibration_and_external_clock(clock_speed: u32) -> SysTick {
+    pub fn new_with_calibration_and_external_clock(clock_speed: u32) -> SysTick {
         let mut res = SysTick::new();
         res.hertz.set(clock_speed);
         res.external_clock = true;


### PR DESCRIPTION


### Pull Request Overview

Creating a simple systick struct doesn't violate any Rust safety requirements. Also, only code that has an arch crate a dependency can call this, and those can all use unsafe anyway, so this doesn't restrict anything from creating a systick either.


### Testing Strategy

travis


### TODO or Help Wanted

nothing


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
