### PR TITLE
arch: cortex-m: nvic functions safe

### DIFF
--- a/arch/cortex-m/src/nvic.rs
+++ b/arch/cortex-m/src/nvic.rs
@@ -130,21 +130,21 @@ fn number_of_nvic_registers() -> usize {
 }
 
 /// Clear all pending interrupts
-pub unsafe fn clear_all_pending() {
+pub fn clear_all_pending() {
     for icpr in NVIC.icpr.iter().take(number_of_nvic_registers()) {
         icpr.set(!0)
     }
 }
 
 /// Enable all interrupts
-pub unsafe fn enable_all() {
+pub fn enable_all() {
     for icer in NVIC.iser.iter().take(number_of_nvic_registers()) {
         icer.set(!0)
     }
 }
 
 /// Disable all interrupts
-pub unsafe fn disable_all() {
+pub fn disable_all() {
     for icer in NVIC.icer.iter().take(number_of_nvic_registers()) {
         icer.set(!0)
     }
@@ -152,7 +152,7 @@ pub unsafe fn disable_all() {
 
 /// Get the index (0-240) the lowest number pending interrupt, or `None` if none
 /// are pending.
-pub unsafe fn next_pending() -> Option<u32> {
+pub fn next_pending() -> Option<u32> {
     for (block, ispr) in NVIC
         .ispr
         .iter()
@@ -178,7 +178,7 @@ pub unsafe fn next_pending() -> Option<u32> {
 /// Mask is defined as two `u128` fields,
 ///   `mask.0` has the bits corresponding to interrupts from 128 to 240.
 ///   `mask.1` has the bits corresponding to interrupts from 0 to 127.
-pub unsafe fn next_pending_with_mask(mask: (u128, u128)) -> Option<u32> {
+pub fn next_pending_with_mask(mask: (u128, u128)) -> Option<u32> {
     for (block, ispr) in NVIC
         .ispr
         .iter()
@@ -198,7 +198,7 @@ pub unsafe fn next_pending_with_mask(mask: (u128, u128)) -> Option<u32> {
     None
 }
 
-pub unsafe fn has_pending() -> bool {
+pub fn has_pending() -> bool {
     NVIC.ispr
         .iter()
         .take(number_of_nvic_registers())
@@ -212,7 +212,7 @@ pub unsafe fn has_pending() -> bool {
 /// Mask is defined as two `u128` fields,
 ///   `mask.0` has the bits corresponding to interrupts from 128 to 240.
 ///   `mask.1` has the bits corresponding to interrupts from 0 to 127.
-pub unsafe fn has_pending_with_mask(mask: (u128, u128)) -> bool {
+pub fn has_pending_with_mask(mask: (u128, u128)) -> bool {
     NVIC.ispr
         .iter()
         .take(number_of_nvic_registers())
@@ -232,10 +232,7 @@ pub struct Nvic(u32);
 
 impl Nvic {
     /// Creates a new `Nvic`.
-    ///
-    /// Marked unsafe because only chip/platform configuration code should be
-    /// able to create these.
-    pub const unsafe fn new(idx: u32) -> Nvic {
+    pub const fn new(idx: u32) -> Nvic {
         Nvic(idx)
     }
 

--- a/boards/teensy40/src/main.rs
+++ b/boards/teensy40/src/main.rs
@@ -136,7 +136,7 @@ mod dma_config {
             .iter()
             .copied()
             // Safety: creating NVIC vector in platform code. Vector is valid.
-            .map(|vector| unsafe { cortexm7::nvic::Nvic::new(vector) })
+            .map(cortexm7::nvic::Nvic::new)
             .for_each(|intr| intr.enable());
     }
 }

--- a/chips/apollo3/src/chip.rs
+++ b/chips/apollo3/src/chip.rs
@@ -121,11 +121,9 @@ impl<I: InterruptService + 'static> Chip for Apollo3<I> {
             crate::actually_disable_fpu();
         }
 
-        unsafe {
-            cortexm4f::nvic::disable_all();
-            cortexm4f::nvic::clear_all_pending();
-            cortexm4f::nvic::enable_all();
-        }
+        cortexm4f::nvic::disable_all();
+        cortexm4f::nvic::clear_all_pending();
+        cortexm4f::nvic::enable_all();
     }
 
     fn service_pending_interrupts(&self) {
@@ -143,7 +141,7 @@ impl<I: InterruptService + 'static> Chip for Apollo3<I> {
     }
 
     fn has_pending_interrupts(&self) -> bool {
-        unsafe { cortexm4f::nvic::has_pending() }
+        cortexm4f::nvic::has_pending()
     }
 
     fn mpu(&self) -> &cortexm4f::mpu::MPU {

--- a/chips/imxrt10xx/src/chip.rs
+++ b/chips/imxrt10xx/src/chip.rs
@@ -108,17 +108,13 @@ impl<I: InterruptService + 'static> Chip for Imxrt10xx<I> {
     type ThreadIdProvider = cortexm7::thread_id::CortexMThreadIdProvider;
 
     fn init() {
-        unsafe {
-            cortexm7::nvic::disable_all();
-            cortexm7::nvic::clear_all_pending();
-        }
+        cortexm7::nvic::disable_all();
+        cortexm7::nvic::clear_all_pending();
 
         // Set the vector table offset.
         crate::initialize_vector_table();
 
-        unsafe {
-            cortexm7::nvic::enable_all();
-        }
+        cortexm7::nvic::enable_all();
     }
 
     fn service_pending_interrupts(&self) {
@@ -134,7 +130,7 @@ impl<I: InterruptService + 'static> Chip for Imxrt10xx<I> {
     }
 
     fn has_pending_interrupts(&self) -> bool {
-        unsafe { cortexm7::nvic::has_pending() }
+        cortexm7::nvic::has_pending()
     }
 
     fn mpu(&self) -> &cortexm7::mpu::MPU {

--- a/chips/lpc55s6x/src/chip.rs
+++ b/chips/lpc55s6x/src/chip.rs
@@ -45,19 +45,19 @@ impl<I: InterruptService> Chip for Lpc55s69<'_, I> {
     type ThreadIdProvider = cortexm33::thread_id::CortexMThreadIdProvider;
 
     fn init() {
-        unsafe {
-            cortexm33::nvic::disable_all();
-            cortexm33::nvic::clear_all_pending();
+        cortexm33::nvic::disable_all();
+        cortexm33::nvic::clear_all_pending();
 
+        unsafe {
             // Set the vector table offset, which requires casting from a BASE_VECTORS to a *const ()
             // pointer.
             let vector_table: *const [unsafe extern "C" fn(); 16] =
                 core::ptr::addr_of!(crate::BASE_VECTORS);
             let vector_table: *const () = vector_table.cast();
             cortexm33::scb::set_vector_table_offset(vector_table);
-
-            cortexm33::nvic::enable_all();
         }
+
+        cortexm33::nvic::enable_all();
     }
 
     fn service_pending_interrupts(&self) {
@@ -75,7 +75,7 @@ impl<I: InterruptService> Chip for Lpc55s69<'_, I> {
     }
 
     fn has_pending_interrupts(&self) -> bool {
-        unsafe { cortexm33::nvic::has_pending() }
+        cortexm33::nvic::has_pending()
     }
 
     fn mpu(&self) -> &Self::MPU {

--- a/chips/lpc55s6x/src/ctimer0.rs
+++ b/chips/lpc55s6x/src/ctimer0.rs
@@ -396,9 +396,7 @@ impl<'a> LPCTimer<'a> {
 
     #[allow(dead_code)]
     fn disable_timer_interrupt(&self) {
-        unsafe {
-            cortexm33::nvic::Nvic::new(CTIMER0).disable();
-        }
+        cortexm33::nvic::Nvic::new(CTIMER0).disable();
     }
 
     pub fn handle_interrupt(&self) {

--- a/chips/msp432/src/chip.rs
+++ b/chips/msp432/src/chip.rs
@@ -110,29 +110,27 @@ impl<'a, I: InterruptService + 'a> Chip for Msp432<'a, I> {
     type ThreadIdProvider = cortexm4::thread_id::CortexMThreadIdProvider;
 
     fn init() {
-        unsafe {
-            cortexm4::nvic::disable_all();
-            cortexm4::nvic::clear_all_pending();
-            cortexm4::nvic::enable_all();
-        }
+        cortexm4::nvic::disable_all();
+        cortexm4::nvic::clear_all_pending();
+        cortexm4::nvic::enable_all();
     }
 
     fn service_pending_interrupts(&self) {
-        unsafe {
-            while let Some(interrupt) = cortexm4::nvic::next_pending() {
+        while let Some(interrupt) = cortexm4::nvic::next_pending() {
+            unsafe {
                 if !self.interrupt_service.service_interrupt(interrupt) {
                     panic!("unhandled interrupt {}", interrupt);
                 }
-
-                let n = cortexm4::nvic::Nvic::new(interrupt);
-                n.clear_pending();
-                n.enable();
             }
+
+            let n = cortexm4::nvic::Nvic::new(interrupt);
+            n.clear_pending();
+            n.enable();
         }
     }
 
     fn has_pending_interrupts(&self) -> bool {
-        unsafe { cortexm4::nvic::has_pending() }
+        cortexm4::nvic::has_pending()
     }
 
     fn mpu(&self) -> &cortexm4::mpu::MPU {

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -147,9 +147,7 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for NRF52<'a, I>
         // # Safety
         //
         // Need to enable interrupts.
-        unsafe {
-            nvic::enable_all();
-        }
+        nvic::enable_all();
     }
 
     fn mpu(&self) -> &Self::MPU {
@@ -174,7 +172,7 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for NRF52<'a, I>
     }
 
     fn has_pending_interrupts(&self) -> bool {
-        unsafe { nvic::has_pending() }
+        nvic::has_pending()
     }
 
     fn sleep(&self) {

--- a/chips/psc3/src/chip.rs
+++ b/chips/psc3/src/chip.rs
@@ -126,15 +126,13 @@ impl<I: InterruptService> Chip for Psc3<'_, I> {
 
     fn init() {
         icache::sys_init_enable_cache();
-        unsafe {
-            cortexm33::nvic::disable_all();
-            cortexm33::nvic::clear_all_pending();
-            cortexm33::nvic::enable_all();
-        }
+        cortexm33::nvic::disable_all();
+        cortexm33::nvic::clear_all_pending();
+        cortexm33::nvic::enable_all();
     }
 
     fn has_pending_interrupts(&self) -> bool {
-        unsafe { cortexm33::nvic::has_pending() }
+        cortexm33::nvic::has_pending()
     }
 
     fn mpu(&self) -> &Self::MPU {

--- a/chips/psoc62xa/src/chip.rs
+++ b/chips/psoc62xa/src/chip.rs
@@ -60,24 +60,24 @@ impl<I: InterruptService> Chip for Psoc62xa<'_, I> {
     }
 
     fn has_pending_interrupts(&self) -> bool {
-        unsafe { cortexm0p::nvic::has_pending() }
+        cortexm0p::nvic::has_pending()
     }
 
     fn service_pending_interrupts(&self) {
-        unsafe {
-            while let Some(interrupt) = cortexm0p::nvic::next_pending() {
+        while let Some(interrupt) = cortexm0p::nvic::next_pending() {
+            unsafe {
                 if !self.interrupt_service.service_interrupt(interrupt) {
                     panic!("unhandled interrupt {}", interrupt);
                 }
-                let n = cortexm0p::nvic::Nvic::new(interrupt);
-                n.clear_pending();
-                n.enable();
             }
-            while let Some(interrupt) = cortexm0p::nvic::next_pending() {
-                let nvic = cortexm0p::nvic::Nvic::new(interrupt);
-                nvic.clear_pending();
-                nvic.enable();
-            }
+            let n = cortexm0p::nvic::Nvic::new(interrupt);
+            n.clear_pending();
+            n.enable();
+        }
+        while let Some(interrupt) = cortexm0p::nvic::next_pending() {
+            let nvic = cortexm0p::nvic::Nvic::new(interrupt);
+            nvic.clear_pending();
+            nvic.enable();
         }
     }
 }

--- a/chips/rp2040/src/chip.rs
+++ b/chips/rp2040/src/chip.rs
@@ -61,10 +61,8 @@ impl<I: InterruptService> Chip for Rp2040<'_, I> {
     type ThreadIdProvider = cortexm0p::thread_id::CortexMThreadIdProvider;
 
     fn init() {
-        unsafe {
-            cortexm0p::nvic::disable_all();
-            cortexm0p::nvic::clear_all_pending();
-        }
+        cortexm0p::nvic::disable_all();
+        cortexm0p::nvic::clear_all_pending();
 
         let sio = crate::gpio::SIO::new();
         let processor = sio.get_processor();
@@ -105,7 +103,7 @@ impl<I: InterruptService> Chip for Rp2040<'_, I> {
             Processor::Processor0 => self.processor0_interrupt_mask,
             Processor::Processor1 => self.processor1_interrupt_mask,
         };
-        unsafe { cortexm0p::nvic::has_pending_with_mask(mask) }
+        cortexm0p::nvic::has_pending_with_mask(mask)
     }
 
     fn mpu(&self) -> &Self::MPU {

--- a/chips/rp2040/src/timer.rs
+++ b/chips/rp2040/src/timer.rs
@@ -211,9 +211,7 @@ impl<'a> RPTimer<'a> {
         // Even though clearing the INTE::ALARM_0 bit should be enough to disable
         // the interrupt firing, it seems that RP2040 requires manual NVIC
         // disabling of the interrupt.
-        unsafe {
-            cortexm0p::nvic::Nvic::new(TIMER_IRQ_0).disable();
-        }
+        cortexm0p::nvic::Nvic::new(TIMER_IRQ_0).disable();
     }
 
     pub fn handle_interrupt(&self) {

--- a/chips/rp2350/src/chip.rs
+++ b/chips/rp2350/src/chip.rs
@@ -51,10 +51,8 @@ impl<I: InterruptService> Chip for Rp2350<'_, I> {
     type ThreadIdProvider = cortexm33::thread_id::CortexMThreadIdProvider;
 
     fn init() {
-        unsafe {
-            cortexm33::nvic::disable_all();
-            cortexm33::nvic::clear_all_pending();
-        }
+        cortexm33::nvic::disable_all();
+        cortexm33::nvic::clear_all_pending();
         let sio = crate::gpio::SIO::new();
         let processor = sio.get_processor();
         match processor {
@@ -91,7 +89,7 @@ impl<I: InterruptService> Chip for Rp2350<'_, I> {
             Processor::Processor0 => self.processor0_interrupt_mask,
             Processor::Processor1 => self.processor1_interrupt_mask,
         };
-        unsafe { cortexm33::nvic::has_pending_with_mask(mask) }
+        cortexm33::nvic::has_pending_with_mask(mask)
     }
 
     fn mpu(&self) -> &Self::MPU {

--- a/chips/rp2350/src/timer.rs
+++ b/chips/rp2350/src/timer.rs
@@ -208,9 +208,7 @@ impl<'a> RPTimer<'a> {
         // Even though clearing the INTE::ALARM_0 bit should be enough to disable
         // the interrupt firing, it seems that RP2040 requires manual NVIC
         // disabling of the interrupt.
-        unsafe {
-            cortexm33::nvic::Nvic::new(TIMER0_IRQ_0).disable();
-        }
+        cortexm33::nvic::Nvic::new(TIMER0_IRQ_0).disable();
     }
 
     pub fn handle_interrupt(&self) {

--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -241,11 +241,9 @@ impl<I: InterruptService + 'static> Chip for Sam4l<I> {
     type ThreadIdProvider = cortexm4::thread_id::CortexMThreadIdProvider;
 
     fn init() {
-        unsafe {
-            cortexm4::nvic::disable_all();
-            cortexm4::nvic::clear_all_pending();
-            cortexm4::nvic::enable_all();
-        }
+        cortexm4::nvic::disable_all();
+        cortexm4::nvic::clear_all_pending();
+        cortexm4::nvic::enable_all();
     }
 
     fn service_pending_interrupts(&self) {
@@ -263,7 +261,7 @@ impl<I: InterruptService + 'static> Chip for Sam4l<I> {
     }
 
     fn has_pending_interrupts(&self) -> bool {
-        unsafe { cortexm4::nvic::has_pending() }
+        cortexm4::nvic::has_pending()
     }
 
     fn mpu(&self) -> &cortexm4::mpu::MPU {

--- a/chips/stm32f303xc/src/chip.rs
+++ b/chips/stm32f303xc/src/chip.rs
@@ -107,11 +107,9 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32f3xx<'a, I> {
     type ThreadIdProvider = cortexm4f::thread_id::CortexMThreadIdProvider;
 
     fn init() {
-        unsafe {
-            cortexm4f::nvic::disable_all();
-            cortexm4f::nvic::clear_all_pending();
-            cortexm4f::nvic::enable_all();
-        }
+        cortexm4f::nvic::disable_all();
+        cortexm4f::nvic::clear_all_pending();
+        cortexm4f::nvic::enable_all();
     }
 
     fn service_pending_interrupts(&self) {
@@ -128,7 +126,7 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32f3xx<'a, I> {
     }
 
     fn has_pending_interrupts(&self) -> bool {
-        unsafe { cortexm4f::nvic::has_pending() }
+        cortexm4f::nvic::has_pending()
     }
 
     fn mpu(&self) -> &cortexm4f::mpu::MPU {

--- a/chips/stm32f4xx/src/chip.rs
+++ b/chips/stm32f4xx/src/chip.rs
@@ -168,11 +168,9 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32f4xx<'a, I> {
     type ThreadIdProvider = cortexm4f::thread_id::CortexMThreadIdProvider;
 
     fn init() {
-        unsafe {
-            cortexm4f::nvic::disable_all();
-            cortexm4f::nvic::clear_all_pending();
-            cortexm4f::nvic::enable_all();
-        }
+        cortexm4f::nvic::disable_all();
+        cortexm4f::nvic::clear_all_pending();
+        cortexm4f::nvic::enable_all();
     }
 
     fn service_pending_interrupts(&self) {
@@ -190,7 +188,7 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32f4xx<'a, I> {
     }
 
     fn has_pending_interrupts(&self) -> bool {
-        unsafe { cortexm4f::nvic::has_pending() }
+        cortexm4f::nvic::has_pending()
     }
 
     fn mpu(&self) -> &cortexm4f::mpu::MPU {

--- a/chips/stm32u5xx/src/chip.rs
+++ b/chips/stm32u5xx/src/chip.rs
@@ -176,11 +176,9 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32u5xx<'a, I> {
     type ThreadIdProvider = cortexm33::thread_id::CortexMThreadIdProvider;
 
     fn init() {
-        unsafe {
-            cortexm33::nvic::disable_all();
-            cortexm33::nvic::clear_all_pending();
-            cortexm33::nvic::enable_all();
-        }
+        cortexm33::nvic::disable_all();
+        cortexm33::nvic::clear_all_pending();
+        cortexm33::nvic::enable_all();
     }
 
     fn service_pending_interrupts(&self) {
@@ -198,7 +196,7 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32u5xx<'a, I> {
     }
 
     fn has_pending_interrupts(&self) -> bool {
-        unsafe { cortexm33::nvic::has_pending() }
+        cortexm33::nvic::has_pending()
     }
 
     fn mpu(&self) -> &cortexm33::mpu::MPU<8> {

--- a/chips/stm32wle5xx/src/chip.rs
+++ b/chips/stm32wle5xx/src/chip.rs
@@ -114,25 +114,23 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32wle5xx<'a, I> {
     type ThreadIdProvider = cortexm4::thread_id::CortexMThreadIdProvider;
 
     fn init() {
-        unsafe {
-            cortexm4::nvic::disable_all();
-            cortexm4::nvic::clear_all_pending();
-            cortexm4::nvic::enable_all();
-        }
+        cortexm4::nvic::disable_all();
+        cortexm4::nvic::clear_all_pending();
+        cortexm4::nvic::enable_all();
     }
 
     fn service_pending_interrupts(&self) {
+        // We have a bit of a hacky solution here to deal with a peculiarity of the
+        // stm32wle5xx's built in subghz radio (SX126x). The subghz radio
+        // feeds directly into nvic which means we cannot configure it to
+        // be rising edge triggered. To clear this interrupt, we must clear
+        // the interrupt source on the internal SX126x radio via a SPI write
+        // over the internal spi bus. This means that we need to mask this interrupt
+        // here to prevent being stuck in the `service_pending_interrupts` loop.
+        // After servicing all other pending interrupts, we then check if the subghz
+        // radio interrupt is asserted (see comments in subghz_radio.rs for details
+        // of handling).
         unsafe {
-            // We have a bit of a hacky solution here to deal with a peculiarity of the
-            // stm32wle5xx's built in subghz radio (SX126x). The subghz radio
-            // feeds directly into nvic which means we cannot configure it to
-            // be rising edge triggered. To clear this interrupt, we must clear
-            // the interrupt source on the internal SX126x radio via a SPI write
-            // over the internal spi bus. This means that we need to mask this interrupt
-            // here to prevent being stuck in the `service_pending_interrupts` loop.
-            // After servicing all other pending interrupts, we then check if the subghz
-            // radio interrupt is asserted (see comments in subghz_radio.rs for details
-            // of handling).
             loop {
                 if let Some(interrupt) =
                     cortexm4::nvic::next_pending_with_mask((0, 1u128 << crate::nvic::RADIO_IRQ))
@@ -163,7 +161,7 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32wle5xx<'a, I> {
     }
 
     fn has_pending_interrupts(&self) -> bool {
-        unsafe { cortexm4::nvic::has_pending_with_mask((0, 1u128 << crate::nvic::RADIO_IRQ)) }
+        cortexm4::nvic::has_pending_with_mask((0, 1u128 << crate::nvic::RADIO_IRQ))
     }
 
     fn mpu(&self) -> &cortexm4::mpu::MPU {

--- a/chips/stm32wle5xx/src/subghz_radio.rs
+++ b/chips/stm32wle5xx/src/subghz_radio.rs
@@ -98,10 +98,8 @@ impl<'a> VirtualGpio<'a> for SubGhzRadioInterrupt<'a> {
         // command to the subghz radio. Because of this, we mask
         // the interrupt in the interrupt handler and perform the
         // check here to see if any other interrupts are pending.
-        unsafe {
-            cortexm4::nvic::next_pending_with_mask((u128::MAX, !(1 << crate::nvic::RADIO_IRQ)))
-                .is_some_and(|_| true)
-        }
+        cortexm4::nvic::next_pending_with_mask((u128::MAX, !(1 << crate::nvic::RADIO_IRQ)))
+            .is_some_and(|_| true)
     }
     fn write(&self, _val: u32) {
         // Read-only, write does nothing.
@@ -186,10 +184,8 @@ impl<'a> Interrupt<'a> for SubGhzRadioVirtualGpio<'a> {
     }
 
     fn is_pending(&self) -> bool {
-        unsafe {
-            cortexm4::nvic::next_pending_with_mask((u128::MAX, !(1 << crate::nvic::RADIO_IRQ)))
-                .is_some_and(|_| true)
-        }
+        cortexm4::nvic::next_pending_with_mask((u128::MAX, !(1 << crate::nvic::RADIO_IRQ)))
+            .is_some_and(|_| true)
     }
 
     fn set_client(&self, client: &'a dyn kernel::hil::gpio::Client) {


### PR DESCRIPTION
### Pull Request Overview

The cortex-m nvic functions date back a long time, and, I'm guessing, felt unsafe at the time, and have been marked unsafe ever since. But all they do is set registers. Also, this does enable/disable interrupts, just individual interrupts.

One comment mentioned using this for visibility, which we no longer want to do.


### Testing Strategy

travis


### TODO or Help Wanted

Anyone want to make the case these are in fact unsafe? Even better, what should the safety comment be?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.

claude helped me fix all of the created unnecessary unsafe block warnings.