### PR TITLE
clippy: deny unused_peekable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -273,7 +273,6 @@ option_if_let_else = "allow"
 cognitive_complexity = "allow"
 
 
-unused_peekable = "allow"
 branches_sharing_code = "allow"
 
 

--- a/chips/virtio/src/queues/split_queue.rs
+++ b/chips/virtio/src/queues/split_queue.rs
@@ -643,7 +643,7 @@ impl<'a, 'b, const MAX_QUEUE_SIZE: usize, F: DmaFence> SplitVirtqueue<'a, 'b, MA
         let mut i = 0;
         let mut previous_descriptor: Option<usize> = None;
         let mut head = None;
-        let queuebuf_iter = buffer_chain.iter_mut().peekable();
+        let queuebuf_iter = buffer_chain.iter_mut();
         for queuebuf in queuebuf_iter.take_while(|queuebuf| queuebuf.is_some()) {
             // Take the queuebuf out of the caller array
             let taken_queuebuf = queuebuf.take().expect("queuebuf is None");


### PR DESCRIPTION
### Pull Request Overview

Pretty simple deny `unused_peekable` clippy lint.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
