### PR TITLE
chips: veer (riscv): store interrupts global bitmap

### DIFF
--- a/chips/veer_el2/src/chip.rs
+++ b/chips/veer_el2/src/chip.rs
@@ -7,7 +7,6 @@
 
 use crate::machine_timer::Clint;
 use core::fmt::Write;
-use core::ptr::addr_of;
 use kernel::platform::chip::{Chip, InterruptService};
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 use kernel::utilities::StaticRef;
@@ -21,11 +20,8 @@ use crate::pic::PicRegisters;
 pub const PIC_BASE: StaticRef<PicRegisters> =
     unsafe { StaticRef::new(0xf00c_0000 as *const PicRegisters) };
 
-pub static mut PIC: Pic = Pic::new(PIC_BASE);
-
 pub struct VeeR<'a, I: InterruptService + 'a> {
     userspace_kernel_boundary: SysCall,
-    pic: &'a Pic,
     mtimer: &'static Clint<'static>,
     pic_interrupt_service: &'a I,
     pmp: PMPUserMPU<4, SimplePMP<8>>,
@@ -65,7 +61,6 @@ impl<'a, I: InterruptService + 'a> VeeR<'a, I> {
     pub unsafe fn new(pic_interrupt_service: &'a I, mtimer: &'static Clint) -> Self {
         Self {
             userspace_kernel_boundary: SysCall::new(),
-            pic: &*addr_of!(PIC),
             mtimer,
             pic_interrupt_service,
             pmp: PMPUserMPU::new(SimplePMP::new().unwrap()),
@@ -73,17 +68,19 @@ impl<'a, I: InterruptService + 'a> VeeR<'a, I> {
     }
 
     pub fn enable_pic_interrupts(&self) {
-        self.pic.enable_all();
+        let pic = Pic::new(PIC_BASE);
+        pic.enable_all();
     }
 
-    unsafe fn handle_pic_interrupts(&self) {
-        while let Some(interrupt) = self.pic.get_saved_interrupts() {
+    unsafe fn handle_pic_interrupts(&self, pic: &Pic) {
+        while let Some(interrupt) = pic.get_saved_interrupts() {
             if !self.pic_interrupt_service.service_interrupt(interrupt) {
                 panic!("Unhandled interrupt {}", interrupt);
             }
+
             self.with_interrupts_disabled(|| {
                 // Safe as interrupts are disabled
-                self.pic.complete(interrupt);
+                pic.complete(interrupt);
             });
         }
     }
@@ -103,6 +100,9 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for VeeR<'a, I> 
     }
 
     fn service_pending_interrupts(&self) {
+        // Need to create a PIC object to use
+        let pic = Pic::new(PIC_BASE);
+
         loop {
             let mip = CSR.mip.extract();
 
@@ -110,14 +110,13 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for VeeR<'a, I> 
             if mip.is_set(mip::mtimer) {
                 self.mtimer.handle_interrupt();
             }
-            if self.pic.get_saved_interrupts().is_some() {
+            if pic.get_saved_interrupts().is_some() {
                 unsafe {
-                    self.handle_pic_interrupts();
+                    self.handle_pic_interrupts(&pic);
                 }
             }
 
-            if !mip.any_matching_bits_set(mip::mtimer::SET)
-                && self.pic.get_saved_interrupts().is_none()
+            if !mip.any_matching_bits_set(mip::mtimer::SET) && pic.get_saved_interrupts().is_none()
             {
                 break;
             }
@@ -129,8 +128,9 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for VeeR<'a, I> 
     }
 
     fn has_pending_interrupts(&self) -> bool {
+        let pic = Pic::new(PIC_BASE);
         let mip = CSR.mip.extract();
-        self.pic.get_saved_interrupts().is_some() || mip.any_matching_bits_set(mip::mtimer::SET)
+        pic.get_saved_interrupts().is_some() || mip.any_matching_bits_set(mip::mtimer::SET)
     }
 
     fn sleep(&self) {
@@ -196,16 +196,19 @@ unsafe fn handle_interrupt(intr: mcause::Interrupt) {
             // We received an interrupt, disable interrupts while we handle them
             CSR.mie.modify(mie::mext::CLEAR);
 
+            // Need to create a PIC object to use
+            let pic = Pic::new(PIC_BASE);
+
             // Claim the interrupt, unwrap() as we know an interrupt exists
             // Once claimed this interrupt won't fire until it's completed
             // NOTE: The interrupt is no longer pending in the PIC
             loop {
-                let interrupt = (*addr_of!(PIC)).next_pending();
+                let interrupt = pic.next_pending();
 
                 match interrupt {
                     Some(irq) => {
                         // Safe as interrupts are disabled
-                        (*addr_of!(PIC)).save_interrupt(irq);
+                        pic.save_interrupt(irq);
                     }
                     None => {
                         // Enable generic interrupts

--- a/chips/veer_el2/src/chip.rs
+++ b/chips/veer_el2/src/chip.rs
@@ -7,7 +7,6 @@
 
 use crate::machine_timer::Clint;
 use core::fmt::Write;
-use core::ptr::addr_of;
 use kernel::platform::chip::{Chip, InterruptService};
 use kernel::utilities::StaticRef;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
@@ -21,11 +20,8 @@ use crate::pic::PicRegisters;
 pub const PIC_BASE: StaticRef<PicRegisters> =
     unsafe { StaticRef::new(0xf00c_0000 as *const PicRegisters) };
 
-pub static mut PIC: Pic = Pic::new(PIC_BASE);
-
 pub struct VeeR<'a, I: InterruptService + 'a> {
     userspace_kernel_boundary: SysCall,
-    pic: &'a Pic,
     mtimer: &'static Clint<'static>,
     pic_interrupt_service: &'a I,
     pmp: PMPUserMPU<4, SimplePMP<8>>,
@@ -65,7 +61,6 @@ impl<'a, I: InterruptService + 'a> VeeR<'a, I> {
     pub unsafe fn new(pic_interrupt_service: &'a I, mtimer: &'static Clint) -> Self {
         Self {
             userspace_kernel_boundary: SysCall::new(),
-            pic: &*addr_of!(PIC),
             mtimer,
             pic_interrupt_service,
             pmp: PMPUserMPU::new(SimplePMP::new().unwrap()),
@@ -73,17 +68,19 @@ impl<'a, I: InterruptService + 'a> VeeR<'a, I> {
     }
 
     pub fn enable_pic_interrupts(&self) {
-        self.pic.enable_all();
+        let pic = Pic::new(PIC_BASE);
+        pic.enable_all();
     }
 
-    unsafe fn handle_pic_interrupts(&self) {
-        while let Some(interrupt) = self.pic.get_saved_interrupts() {
+    unsafe fn handle_pic_interrupts(&self, pic: &Pic) {
+        while let Some(interrupt) = pic.get_saved_interrupts() {
             if !self.pic_interrupt_service.service_interrupt(interrupt) {
                 panic!("Unhandled interrupt {}", interrupt);
             }
+
             self.with_interrupts_disabled(|| {
                 // Safe as interrupts are disabled
-                self.pic.complete(interrupt);
+                pic.complete(interrupt);
             });
         }
     }
@@ -105,6 +102,9 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for VeeR<'a, I> 
     }
 
     fn service_pending_interrupts(&self) {
+        // Need to create a PIC object to use
+        let pic = Pic::new(PIC_BASE);
+
         loop {
             let mip = CSR.mip.extract();
 
@@ -112,14 +112,13 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for VeeR<'a, I> 
             if mip.is_set(mip::mtimer) {
                 self.mtimer.handle_interrupt();
             }
-            if self.pic.get_saved_interrupts().is_some() {
+            if pic.get_saved_interrupts().is_some() {
                 unsafe {
-                    self.handle_pic_interrupts();
+                    self.handle_pic_interrupts(&pic);
                 }
             }
 
-            if !mip.any_matching_bits_set(mip::mtimer::SET)
-                && self.pic.get_saved_interrupts().is_none()
+            if !mip.any_matching_bits_set(mip::mtimer::SET) && pic.get_saved_interrupts().is_none()
             {
                 break;
             }
@@ -131,8 +130,9 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for VeeR<'a, I> 
     }
 
     fn has_pending_interrupts(&self) -> bool {
+        let pic = Pic::new(PIC_BASE);
         let mip = CSR.mip.extract();
-        self.pic.get_saved_interrupts().is_some() || mip.any_matching_bits_set(mip::mtimer::SET)
+        pic.get_saved_interrupts().is_some() || mip.any_matching_bits_set(mip::mtimer::SET)
     }
 
     fn sleep(&self) {
@@ -198,16 +198,19 @@ unsafe fn handle_interrupt(intr: mcause::Interrupt) {
             // We received an interrupt, disable interrupts while we handle them
             CSR.mie.modify(mie::mext::CLEAR);
 
+            // Need to create a PIC object to use
+            let pic = Pic::new(PIC_BASE);
+
             // Claim the interrupt, unwrap() as we know an interrupt exists
             // Once claimed this interrupt won't fire until it's completed
             // NOTE: The interrupt is no longer pending in the PIC
             loop {
-                let interrupt = (*addr_of!(PIC)).next_pending();
+                let interrupt = pic.next_pending();
 
                 match interrupt {
                     Some(irq) => {
                         // Safe as interrupts are disabled
-                        (*addr_of!(PIC)).save_interrupt(irq);
+                        pic.save_interrupt(irq);
                     }
                     None => {
                         // Enable generic interrupts

--- a/chips/veer_el2/src/pic.rs
+++ b/chips/veer_el2/src/pic.rs
@@ -3,16 +3,27 @@
 // Copyright Tock Contributors 2022.
 
 //! Platform Level Interrupt Control peripheral driver for VeeR.
-/* Currently no peripheral that would generate interupts is defined in the reference
+/* Currently no peripheral that would generate interrupts is defined in the reference
 testbench for VeeR EL2, so the Pic is not expected to handle any interrupts. */
 
-use kernel::utilities::cells::VolatileCell;
+use core::sync::atomic::{AtomicU32, Ordering};
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
-use kernel::utilities::registers::{
-    register_bitfields, register_structs, LocalRegisterCopy, ReadWrite,
-};
+use kernel::utilities::registers::{register_bitfields, register_structs, ReadWrite};
 use kernel::utilities::StaticRef;
 use riscv_csr::csr::ReadWriteRiscvCsr;
+
+/// Bitmap data structure to hold the interrupt number of pending interrupts.
+///
+/// Holds interrupts numbers 0-31.
+pub static INTERRUPT_BITMAP1: AtomicU32 = AtomicU32::new(0);
+/// Bitmap data structure to hold the interrupt number of pending interrupts.
+///
+/// Holds interrupts numbers 32-63.
+pub static INTERRUPT_BITMAP2: AtomicU32 = AtomicU32::new(0);
+/// Bitmap data structure to hold the interrupt number of pending interrupts.
+///
+/// Holds interrupts numbers 64-95.
+pub static INTERRUPT_BITMAP3: AtomicU32 = AtomicU32::new(0);
 
 register_structs! {
     pub PicRegisters {
@@ -94,7 +105,6 @@ register_bitfields![usize,
 #[allow(dead_code)]
 pub struct Pic {
     registers: StaticRef<PicRegisters>,
-    saved: [VolatileCell<LocalRegisterCopy<u32>>; 3],
     meivt: ReadWriteRiscvCsr<usize, MEIVT::Register, 0xBC8>,
     meipt: ReadWriteRiscvCsr<usize, MEIPT::Register, 0xBC9>,
     meicpct: ReadWriteRiscvCsr<usize, MEICPCT::Register, 0xBCA>,
@@ -107,11 +117,6 @@ impl Pic {
     pub const fn new(base: StaticRef<PicRegisters>) -> Self {
         Pic {
             registers: base,
-            saved: [
-                VolatileCell::new(LocalRegisterCopy::new(0)),
-                VolatileCell::new(LocalRegisterCopy::new(0)),
-                VolatileCell::new(LocalRegisterCopy::new(0)),
-            ],
             meivt: ReadWriteRiscvCsr::new(),
             meipt: ReadWriteRiscvCsr::new(),
             meicpct: ReadWriteRiscvCsr::new(),
@@ -185,33 +190,38 @@ impl Pic {
     /// Saved interrupts can be retrieved by calling `get_saved_interrupts()`.
     /// Saved interrupts are cleared when `'complete()` is called.
     pub fn save_interrupt(&self, index: u32) {
-        let offset = if index < 32 {
-            0
+        let irq = index % 32;
+        if index < 32 {
+            let bitmap = INTERRUPT_BITMAP1.load(Ordering::Relaxed);
+            INTERRUPT_BITMAP1.store(bitmap | (1 << irq), Ordering::Relaxed);
         } else if index < 64 {
-            1
+            let bitmap = INTERRUPT_BITMAP2.load(Ordering::Relaxed);
+            INTERRUPT_BITMAP2.store(bitmap | (1 << irq), Ordering::Relaxed);
         } else if index < 96 {
-            2
+            let bitmap = INTERRUPT_BITMAP3.load(Ordering::Relaxed);
+            INTERRUPT_BITMAP3.store(bitmap | (1 << irq), Ordering::Relaxed);
         } else {
             panic!("Unsupported index {}", index);
-        };
-        let irq = index % 32;
-
-        // OR the current saved state with the new value
-        let new_saved = self.saved[offset].get().get() | 1 << irq;
-
-        // Set the new state
-        self.saved[offset].set(LocalRegisterCopy::new(new_saved));
+        }
     }
 
     /// The `next_pending()` function will only return enabled interrupts.
     /// This function will return a pending interrupt that has been disabled by
     /// `save_interrupt()`.
     pub fn get_saved_interrupts(&self) -> Option<u32> {
-        for (i, pending) in self.saved.iter().enumerate() {
-            let saved = pending.get().get();
-            if saved != 0 {
-                return Some(saved.trailing_zeros() + (i as u32 * 32));
-            }
+        let bitmap = INTERRUPT_BITMAP1.load(Ordering::Relaxed);
+        if bitmap != 0 {
+            return Some(bitmap.trailing_zeros());
+        }
+
+        let bitmap = INTERRUPT_BITMAP2.load(Ordering::Relaxed);
+        if bitmap != 0 {
+            return Some(bitmap.trailing_zeros() + 32);
+        }
+
+        let bitmap = INTERRUPT_BITMAP3.load(Ordering::Relaxed);
+        if bitmap != 0 {
+            return Some(bitmap.trailing_zeros() + 64);
         }
 
         None
@@ -230,19 +240,16 @@ impl Pic {
         // Enable the interrupt
         self.registers.meie[index as usize - 1].write(MEIE::INTEN::ENABLE);
 
-        let offset = if index < 32 {
-            0
-        } else if index < 64 {
-            1
-        } else {
-            2
-        };
         let irq = index % 32;
-
-        // OR the current saved state with the new value
-        let new_saved = self.saved[offset].get().get() & !(1 << irq);
-
-        // Set the new state
-        self.saved[offset].set(LocalRegisterCopy::new(new_saved));
+        if index < 32 {
+            let bitmap = INTERRUPT_BITMAP1.load(Ordering::Relaxed);
+            INTERRUPT_BITMAP1.store(bitmap & !(1 << irq), Ordering::Relaxed);
+        } else if index < 64 {
+            let bitmap = INTERRUPT_BITMAP2.load(Ordering::Relaxed);
+            INTERRUPT_BITMAP2.store(bitmap & !(1 << irq), Ordering::Relaxed);
+        } else if index < 96 {
+            let bitmap = INTERRUPT_BITMAP3.load(Ordering::Relaxed);
+            INTERRUPT_BITMAP3.store(bitmap & !(1 << irq), Ordering::Relaxed);
+        }
     }
 }

--- a/chips/veer_el2/src/pic.rs
+++ b/chips/veer_el2/src/pic.rs
@@ -3,17 +3,27 @@
 // Copyright Tock Contributors 2022.
 
 //! Platform Level Interrupt Control peripheral driver for VeeR.
-/* Currently no peripheral that would generate interupts is defined in the reference
+/* Currently no peripheral that would generate interrupts is defined in the reference
 testbench for VeeR EL2, so the Pic is not expected to handle any interrupts. */
 
-use core::cell::Cell;
-
+use core::sync::atomic::{AtomicU32, Ordering};
 use kernel::utilities::StaticRef;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
-use kernel::utilities::registers::{
-    LocalRegisterCopy, ReadWrite, register_bitfields, register_structs,
-};
+use kernel::utilities::registers::{ReadWrite, register_bitfields, register_structs};
 use riscv_csr::csr::ReadWriteRiscvCsr;
+
+/// Bitmap data structure to hold the interrupt number of pending interrupts.
+///
+/// Holds interrupts numbers 0-31.
+pub static INTERRUPT_BITMAP1: AtomicU32 = AtomicU32::new(0);
+/// Bitmap data structure to hold the interrupt number of pending interrupts.
+///
+/// Holds interrupts numbers 32-63.
+pub static INTERRUPT_BITMAP2: AtomicU32 = AtomicU32::new(0);
+/// Bitmap data structure to hold the interrupt number of pending interrupts.
+///
+/// Holds interrupts numbers 64-95.
+pub static INTERRUPT_BITMAP3: AtomicU32 = AtomicU32::new(0);
 
 register_structs! {
     pub PicRegisters {
@@ -95,7 +105,6 @@ register_bitfields![usize,
 #[allow(dead_code)]
 pub struct Pic {
     registers: StaticRef<PicRegisters>,
-    saved: [Cell<LocalRegisterCopy<u32>>; 3],
     meivt: ReadWriteRiscvCsr<usize, MEIVT::Register, 0xBC8>,
     meipt: ReadWriteRiscvCsr<usize, MEIPT::Register, 0xBC9>,
     meicpct: ReadWriteRiscvCsr<usize, MEICPCT::Register, 0xBCA>,
@@ -108,11 +117,6 @@ impl Pic {
     pub const fn new(base: StaticRef<PicRegisters>) -> Self {
         Pic {
             registers: base,
-            saved: [
-                Cell::new(LocalRegisterCopy::new(0)),
-                Cell::new(LocalRegisterCopy::new(0)),
-                Cell::new(LocalRegisterCopy::new(0)),
-            ],
             meivt: ReadWriteRiscvCsr::new(),
             meipt: ReadWriteRiscvCsr::new(),
             meicpct: ReadWriteRiscvCsr::new(),
@@ -186,33 +190,38 @@ impl Pic {
     /// Saved interrupts can be retrieved by calling `get_saved_interrupts()`.
     /// Saved interrupts are cleared when `'complete()` is called.
     pub fn save_interrupt(&self, index: u32) {
-        let offset = if index < 32 {
-            0
+        let irq = index % 32;
+        if index < 32 {
+            let bitmap = INTERRUPT_BITMAP1.load(Ordering::Relaxed);
+            INTERRUPT_BITMAP1.store(bitmap | (1 << irq), Ordering::Relaxed);
         } else if index < 64 {
-            1
+            let bitmap = INTERRUPT_BITMAP2.load(Ordering::Relaxed);
+            INTERRUPT_BITMAP2.store(bitmap | (1 << irq), Ordering::Relaxed);
         } else if index < 96 {
-            2
+            let bitmap = INTERRUPT_BITMAP3.load(Ordering::Relaxed);
+            INTERRUPT_BITMAP3.store(bitmap | (1 << irq), Ordering::Relaxed);
         } else {
             panic!("Unsupported index {}", index);
-        };
-        let irq = index % 32;
-
-        // OR the current saved state with the new value
-        let new_saved = self.saved[offset].get().get() | 1 << irq;
-
-        // Set the new state
-        self.saved[offset].set(LocalRegisterCopy::new(new_saved));
+        }
     }
 
     /// The `next_pending()` function will only return enabled interrupts.
     /// This function will return a pending interrupt that has been disabled by
     /// `save_interrupt()`.
     pub fn get_saved_interrupts(&self) -> Option<u32> {
-        for (i, pending) in self.saved.iter().enumerate() {
-            let saved = pending.get().get();
-            if saved != 0 {
-                return Some(saved.trailing_zeros() + (i as u32 * 32));
-            }
+        let bitmap = INTERRUPT_BITMAP1.load(Ordering::Relaxed);
+        if bitmap != 0 {
+            return Some(bitmap.trailing_zeros());
+        }
+
+        let bitmap = INTERRUPT_BITMAP2.load(Ordering::Relaxed);
+        if bitmap != 0 {
+            return Some(bitmap.trailing_zeros() + 32);
+        }
+
+        let bitmap = INTERRUPT_BITMAP3.load(Ordering::Relaxed);
+        if bitmap != 0 {
+            return Some(bitmap.trailing_zeros() + 64);
         }
 
         None
@@ -231,19 +240,16 @@ impl Pic {
         // Enable the interrupt
         self.registers.meie[index as usize - 1].write(MEIE::INTEN::ENABLE);
 
-        let offset = if index < 32 {
-            0
-        } else if index < 64 {
-            1
-        } else {
-            2
-        };
         let irq = index % 32;
-
-        // OR the current saved state with the new value
-        let new_saved = self.saved[offset].get().get() & !(1 << irq);
-
-        // Set the new state
-        self.saved[offset].set(LocalRegisterCopy::new(new_saved));
+        if index < 32 {
+            let bitmap = INTERRUPT_BITMAP1.load(Ordering::Relaxed);
+            INTERRUPT_BITMAP1.store(bitmap & !(1 << irq), Ordering::Relaxed);
+        } else if index < 64 {
+            let bitmap = INTERRUPT_BITMAP2.load(Ordering::Relaxed);
+            INTERRUPT_BITMAP2.store(bitmap & !(1 << irq), Ordering::Relaxed);
+        } else if index < 96 {
+            let bitmap = INTERRUPT_BITMAP3.load(Ordering::Relaxed);
+            INTERRUPT_BITMAP3.store(bitmap & !(1 << irq), Ordering::Relaxed);
+        }
     }
 }

--- a/chips/veer_el2/src/pic.rs
+++ b/chips/veer_el2/src/pic.rs
@@ -14,16 +14,11 @@ use riscv_csr::csr::ReadWriteRiscvCsr;
 
 /// Bitmap data structure to hold the interrupt number of pending interrupts.
 ///
-/// Holds interrupts numbers 0-31.
-pub static INTERRUPT_BITMAP1: AtomicU32 = AtomicU32::new(0);
-/// Bitmap data structure to hold the interrupt number of pending interrupts.
-///
-/// Holds interrupts numbers 32-63.
-pub static INTERRUPT_BITMAP2: AtomicU32 = AtomicU32::new(0);
-/// Bitmap data structure to hold the interrupt number of pending interrupts.
-///
-/// Holds interrupts numbers 64-95.
-pub static INTERRUPT_BITMAP3: AtomicU32 = AtomicU32::new(0);
+/// `INTERRUPT_BITMAPS[i]` holds interrupt numbers `[i*32, i*32+32)`. Interrupt
+/// numbers are claim IDs from `next_pending()`, which are 1-based (0 means no
+/// interrupt), so bit 0 of `INTERRUPT_BITMAPS[0]` is never set.
+static INTERRUPT_BITMAPS: [AtomicU32; 3] =
+    [AtomicU32::new(0), AtomicU32::new(0), AtomicU32::new(0)];
 
 register_structs! {
     pub PicRegisters {
@@ -190,40 +185,24 @@ impl Pic {
     /// Saved interrupts can be retrieved by calling `get_saved_interrupts()`.
     /// Saved interrupts are cleared when `'complete()` is called.
     pub fn save_interrupt(&self, index: u32) {
-        let irq = index % 32;
-        if index < 32 {
-            let bitmap = INTERRUPT_BITMAP1.load(Ordering::Relaxed);
-            INTERRUPT_BITMAP1.store(bitmap | (1 << irq), Ordering::Relaxed);
-        } else if index < 64 {
-            let bitmap = INTERRUPT_BITMAP2.load(Ordering::Relaxed);
-            INTERRUPT_BITMAP2.store(bitmap | (1 << irq), Ordering::Relaxed);
-        } else if index < 96 {
-            let bitmap = INTERRUPT_BITMAP3.load(Ordering::Relaxed);
-            INTERRUPT_BITMAP3.store(bitmap | (1 << irq), Ordering::Relaxed);
-        } else {
-            panic!("Unsupported index {}", index);
-        }
+        assert!(index < 96, "Unsupported index {}", index);
+        let bitmap = &INTERRUPT_BITMAPS[(index / 32) as usize];
+        bitmap.store(
+            bitmap.load(Ordering::Relaxed) | 1 << (index % 32),
+            Ordering::Relaxed,
+        );
     }
 
     /// The `next_pending()` function will only return enabled interrupts.
     /// This function will return a pending interrupt that has been disabled by
     /// `save_interrupt()`.
     pub fn get_saved_interrupts(&self) -> Option<u32> {
-        let bitmap = INTERRUPT_BITMAP1.load(Ordering::Relaxed);
-        if bitmap != 0 {
-            return Some(bitmap.trailing_zeros());
+        for (i, bitmap) in INTERRUPT_BITMAPS.iter().enumerate() {
+            let bitmap = bitmap.load(Ordering::Relaxed);
+            if bitmap != 0 {
+                return Some(bitmap.trailing_zeros() + ((i * 32) as u32));
+            }
         }
-
-        let bitmap = INTERRUPT_BITMAP2.load(Ordering::Relaxed);
-        if bitmap != 0 {
-            return Some(bitmap.trailing_zeros() + 32);
-        }
-
-        let bitmap = INTERRUPT_BITMAP3.load(Ordering::Relaxed);
-        if bitmap != 0 {
-            return Some(bitmap.trailing_zeros() + 64);
-        }
-
         None
     }
 
@@ -240,16 +219,11 @@ impl Pic {
         // Enable the interrupt
         self.registers.meie[index as usize - 1].write(MEIE::INTEN::ENABLE);
 
-        let irq = index % 32;
-        if index < 32 {
-            let bitmap = INTERRUPT_BITMAP1.load(Ordering::Relaxed);
-            INTERRUPT_BITMAP1.store(bitmap & !(1 << irq), Ordering::Relaxed);
-        } else if index < 64 {
-            let bitmap = INTERRUPT_BITMAP2.load(Ordering::Relaxed);
-            INTERRUPT_BITMAP2.store(bitmap & !(1 << irq), Ordering::Relaxed);
-        } else if index < 96 {
-            let bitmap = INTERRUPT_BITMAP3.load(Ordering::Relaxed);
-            INTERRUPT_BITMAP3.store(bitmap & !(1 << irq), Ordering::Relaxed);
-        }
+        assert!(index < 96, "Unsupported index {}", index);
+        let bitmap = &INTERRUPT_BITMAPS[(index / 32) as usize];
+        bitmap.store(
+            bitmap.load(Ordering::Relaxed) & !(1 << (index % 32)),
+            Ordering::Relaxed,
+        );
     }
 }


### PR DESCRIPTION


### Pull Request Overview

Rather than using a Rust struct to store interrupts, and having to declare it static mut and shared between main thread and interrupt handler, store pending interrupts in a static atomicu64 bitmap.

Removes a `static mut`.


### Testing Strategy

travis


### TODO or Help Wanted

Is this a reasonable approach?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
