### PR TITLE
Add `only_once!()` macro that panics if run a second time

### DIFF
--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -174,6 +174,12 @@ struct UarteRegistersManager {
 
 impl UarteRegistersManager {
     pub fn new(regs: StaticRef<UarteRegisters>) -> Self {
+        // We must ensure this register manager is only constructed once to make
+        // this constructor safe. If this is constructed multiple times then
+        // something could control DMA while the other UART register manager is
+        // active.
+        kernel::only_once!(NRF52_UART_ONLY_ONCE);
+
         Self {
             registers: regs,
             tx_dma_buf: MapCell::empty(),

--- a/kernel/src/utilities/mod.rs
+++ b/kernel/src/utilities/mod.rs
@@ -18,6 +18,7 @@ pub mod math;
 pub mod mut_imut_buffer;
 pub mod peripheral_management;
 pub mod single_thread_value;
+pub mod singleton;
 pub mod static_init;
 pub mod storage_volume;
 pub mod streaming_process_slice;
@@ -38,8 +39,8 @@ pub mod registers {
     pub use tock_registers::interfaces;
     pub use tock_registers::registers::InMemoryRegister;
     pub use tock_registers::registers::{Aliased, ReadOnly, ReadWrite, WriteOnly};
-    pub use tock_registers::{LocalRegisterCopy, RegisterLongName};
     pub use tock_registers::{register_bitfields, register_structs};
+    pub use tock_registers::{LocalRegisterCopy, RegisterLongName};
 }
 
 /// The Tock `Cell` types.

--- a/kernel/src/utilities/singleton.rs
+++ b/kernel/src/utilities/singleton.rs
@@ -1,0 +1,65 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+/// Internal helper function for [`only_once!()`](crate::only_once).
+///
+/// This must be public to work within the macro but should never be used
+/// directly.
+///
+/// This is a `#[inline(never)]` function that panics internally if the passed
+/// reference is `true`. This function is intended for use within the
+/// [`only_once!()`](crate::only_once) macro to detect multiple uses of the
+/// macro on the same name.
+///
+/// This function is implemented separately without inlining to removes the size
+/// bloat of track_caller saving the location of every single call to
+/// [`only_once!()`](crate::only_once).
+#[inline(never)]
+pub unsafe fn only_once_check_used(used: &mut bool) {
+    // Check if this bool has already been declared and initialized. If it
+    // has, then this is a call which is an error.
+    if *used {
+        // panic, this buf has already been declared and initialized.
+        // NOTE: To save 144 bytes of code size, use loop {} instead of this
+        // panic.
+        panic!("Error! only_once!() called twice.");
+    } else {
+        // Otherwise, mark our uninitialized buffer as used.
+        *used = true;
+    }
+}
+
+/// Helper macro to ensure an object is only created once.
+///
+/// Panics if the same object is created twice.
+///
+/// ```ignore
+///
+/// /// This DMA-enabled peripheral manager MUST only be created once.
+/// struct PeripheralManagerWithDma;
+///
+/// impl PeripheralManagerWithDma {
+///     fn new() -> Self {
+///     	// Ensure this will panic if constructed twice.
+///     	kernel::only_once!(PERIPHERAL_MANAGER_WITH_DMA);
+///     	Self {}
+///     }
+/// }
+/// ```
+#[macro_export]
+macro_rules! only_once {
+    ($N:ident $(,)?) => {{
+        // Statically allocate a read-write buffer for the value without
+        // actually writing anything, as well as a flag to track if
+        // this memory has been initialized yet.
+        static mut $N: bool = false;
+
+        // To minimize the amount of code duplicated across every invocation
+        // of this macro, all of the logic for checking if the buffer has been
+        // used is contained within the static_buf_check_used function,
+        // which panics if the passed boolean has been used and sets the
+        // boolean to true otherwise.
+        unsafe { $crate::utilities::singleton::only_once_check_used(&mut $N) };
+    }};
+}


### PR DESCRIPTION
### Pull Request Overview

This allows us to do something like this:

```rust
struct MyDMAStructMustBeUnique {}

impl MyDMAStructMustBeUnique {
    pub fn new() -> Self {
        kernel::only_once!(MY_DMA_ONLY_ONCE);

        Self {}
    }
}
```

This is useful for DMA managers that must only be created once so that two different DMA managers can't conflict when trying to ensure memory is safely shared with DMA hardware.

This works much like `static_init!()` macro.


### Testing Strategy

I tried this by putting this in a capsule constructor and creating a capsule twice in a board. This caused a panic.


### TODO or Help Wanted

I just kinda made this up as a way to avoid needing to mark DMA manager constructors as unsafe. Is there a better way? Does this actually solve the safety issue?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

Maybe we could document this somewhere, but I'm not sure where.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.

Just me.
