### PR TITLE
Create SPI interface (only Controller ) for boards/raspberry_pi_pico #4780

### DIFF
--- a/boards/raspberry_pi_pico/src/lib.rs
+++ b/boards/raspberry_pi_pico/src/lib.rs
@@ -592,6 +592,7 @@ pub unsafe fn setup(
             spi_chip_select,
         ),
         capsules_core::spi_controller::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::spi_syscall_component_static!(Spi));
 

--- a/boards/raspberry_pi_pico/src/lib.rs
+++ b/boards/raspberry_pi_pico/src/lib.rs
@@ -34,6 +34,7 @@ use rp2040::clocks::{SystemAuxiliaryClockSource, SystemClockSource, UsbAuxiliary
 use rp2040::gpio::{GpioFunction, RPGpio, RPGpioPin};
 use rp2040::i2c::I2c;
 use rp2040::resets::Peripheral;
+use rp2040::spi::Spi;
 use rp2040::sysinfo;
 use rp2040::timer::RPTimer;
 use rp2040::usb::UsbCtrl;
@@ -79,6 +80,10 @@ pub struct Platform {
     adc: &'static capsules_core::adc::AdcVirtualized<'static>,
     temperature: &'static TemperatureDriver,
     i2c: &'static capsules_core::i2c_master::I2CMasterDriver<'static, I2c<'static, 'static>>,
+    spi_controller: &'static capsules_core::spi_controller::Spi<
+        'static,
+        capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<'static, Spi<'static>>,
+    >,
     date_time:
         &'static capsules_extra::date_time::DateTimeCapsule<'static, rp2040::rtc::Rtc<'static>>,
     console: &'static capsules_core::console::Console<'static>,
@@ -97,6 +102,7 @@ impl SyscallDriverLookup for Platform {
             capsules_core::adc::DRIVER_NUM => f(Some(self.adc)),
             capsules_extra::temperature::DRIVER_NUM => f(Some(self.temperature)),
             capsules_core::i2c_master::DRIVER_NUM => f(Some(self.i2c)),
+            capsules_core::spi_controller::DRIVER_NUM => f(Some(self.spi_controller)),
             capsules_extra::date_time::DRIVER_NUM => f(Some(self.date_time)),
             _ => f(None),
         }
@@ -409,10 +415,11 @@ pub unsafe fn setup(
             13 => peripherals.pins.get_pin(RPGpio::GPIO13),
             14 => peripherals.pins.get_pin(RPGpio::GPIO14),
             15 => peripherals.pins.get_pin(RPGpio::GPIO15),
-            16 => peripherals.pins.get_pin(RPGpio::GPIO16),
-            17 => peripherals.pins.get_pin(RPGpio::GPIO17),
-            18 => peripherals.pins.get_pin(RPGpio::GPIO18),
-            19 => peripherals.pins.get_pin(RPGpio::GPIO19),
+            // Pins 16(RX), 17(CSn), 18(SCK) 19(TX) used for SPI0. Comment them in if you don't use SPI.
+            // 16 => peripherals.pins.get_pin(RPGpio::GPIO16),
+            // 17 => peripherals.pins.get_pin(RPGpio::GPIO17),
+            // 18 => peripherals.pins.get_pin(RPGpio::GPIO18),
+            // 19 => peripherals.pins.get_pin(RPGpio::GPIO19),
             20 => peripherals.pins.get_pin(RPGpio::GPIO20),
             21 => peripherals.pins.get_pin(RPGpio::GPIO21),
             22 => peripherals.pins.get_pin(RPGpio::GPIO22),
@@ -550,6 +557,44 @@ pub unsafe fn setup(
     i2c0.init(10 * 1000);
     i2c0.set_master_client(i2c);
 
+    // Set SPI0 bus pins to SPI function (SCK, MOSI, MISO).
+    peripherals
+        .pins
+        .get_pin(RPGpio::GPIO18)
+        .set_function(GpioFunction::SPI);
+    peripherals
+        .pins
+        .get_pin(RPGpio::GPIO19)
+        .set_function(GpioFunction::SPI);
+    peripherals
+        .pins
+        .get_pin(RPGpio::GPIO16)
+        .set_function(GpioFunction::SPI);
+    peripherals
+        .pins
+        .get_pin(RPGpio::GPIO17)
+        .set_function(GpioFunction::SPI);
+    let spi_chip_select = peripherals.pins.get_pin(RPGpio::GPIO17);
+
+    // If instead hold_low and release_low
+    // The RP2040 SPI peripheral toggles its hardware CS between data frames.
+    // Keep CS as a GPIO so the SPI HIL can hold it active for the full buffer.
+    // spi_chip_select.make_output();
+    // spi_chip_select.set();
+
+    let mux_spi = components::spi::SpiMuxComponent::new(&peripherals.spi0)
+        .finalize(components::spi_mux_component_static!(Spi));
+
+    let spi_controller = components::spi::SpiSyscallComponent::new(
+        board_kernel,
+        mux_spi,
+        kernel::hil::spi::cs::IntoChipSelect::<_, kernel::hil::spi::cs::ActiveLow>::into_cs(
+            spi_chip_select,
+        ),
+        capsules_core::spi_controller::DRIVER_NUM,
+    )
+    .finalize(components::spi_syscall_component_static!(Spi));
+
     let platform_type = match peripherals.sysinfo.get_platform() {
         sysinfo::Platform::Asic => "ASIC",
         sysinfo::Platform::Fpga => "FPGA",
@@ -571,6 +616,7 @@ pub unsafe fn setup(
         adc,
         temperature,
         i2c,
+        spi_controller,
         date_time,
         systick: cortexm0p::systick::SysTick::new_with_calibration(125_000_000),
         ipc: kernel::ipc::IPC::new(

--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -95,7 +95,7 @@ pub unsafe fn start() -> (
 
     let output = raspberry_pi_pico::Output::Cdc;
 
-    // Uncomment this to use UART0 as output for console caspule/debug writer/process console
+    // Uncomment this to use UART0 as output for console capsule/debug writer/process console
     // let output = raspberry_pi_pico::Output::Uart;
 
     let (board_kernel, base, peripherals, _, chip) = raspberry_pi_pico::setup(output);

--- a/chips/rp2040/src/spi.rs
+++ b/chips/rp2040/src/spi.rs
@@ -478,16 +478,16 @@ impl<'a> Spi<'a> {
         }
     }
 
-    // Currently the format is set to Motorola SPI frame format, 8 bit mode (octets), MSSPCLKOUT polarity and phase on 0 SPO=1, SPH=0
+    // Currently the format is set to Motorola SPI frame format, 8 bit mode (octets), MSSPCLKOUT polarity and phase on 0 SPO=0, SPH=0
     // This means that in the case of continuous back-to-back transmissions of octets, the SSPFSSOUT signal will be pulsed HIGH between the octets.
     // If your slave device requires the SSPFSSOUT signal to be held LOW for the entire transmission, you will need to either:
     // 1. Set the chip select pin as a GPIO and hold it low for the duration of the octets
-    // 2. In Motorola SPI frame format set SPO=1, SPH=1 and make sure the buffer is continuous
+    // 2. In Motorola SPI frame format set SPO=0, SPH=1 and make sure the buffer is continuous
     // Ref: 4.4.3.13. Motorola SPI Format in the RP2040 Datasheet
     fn set_format(&self) {
         self.registers.sspcr0.modify(SSPCR0::DSS::DATA_8_BIT);
         self.registers.sspcr0.modify(SSPCR0::SPO::CLEAR);
-        self.registers.sspcr0.modify(SSPCR0::SPH::SET);
+        self.registers.sspcr0.modify(SSPCR0::SPH::CLEAR);
         self.registers.sspcr0.modify(SSPCR0::FRF::MOTOROLA_SPI);
     }
 }

--- a/chips/rp2040/src/spi.rs
+++ b/chips/rp2040/src/spi.rs
@@ -18,6 +18,7 @@ use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{ReadOnly, ReadWrite, register_bitfields, register_structs};
 
+// It is assumed that the state values are represented uniquely by a single bit
 const SPI_READ_IN_PROGRESS: u8 = 0b001;
 const SPI_WRITE_IN_PROGRESS: u8 = 0b010;
 const SPI_IN_PROGRESS: u8 = 0b100;
@@ -325,23 +326,27 @@ impl<'a> Spi<'a> {
                 self.registers.sspimsc.modify(SSPIMSC::TXIM::CLEAR);
             }
         }
-
+        // if still recieving data (receive fifo not empty) store to the buffer until full
         while self.registers.sspsr.is_set(SSPSR::RNE) {
             let byte = self.registers.sspdr.read(SSPDR::DATA) as u8;
-            if self.rx_buffer.is_some() {
-                if self.rx_position.get() < self.len.get() {
-                    self.rx_buffer.map(|buf| {
-                        buf[self.rx_position.get()] = byte;
-                    });
-                    self.rx_position.set(self.rx_position.get() + 1);
-                } else {
-                    self.transfers
-                        .set(self.transfers.get() & !SPI_READ_IN_PROGRESS);
-                }
+            if self.rx_buffer.is_some() && self.rx_position.get() < self.len.get() {
+                self.rx_buffer.map(|buf| {
+                    buf[self.rx_position.get()] = byte;
+                });
+                self.rx_position.set(self.rx_position.get() + 1);
             }
         }
+        // if the buffer is full, clear the read in progress flag so the client callback can fire
+        if self.rx_position.get() >= self.len.get() {
+            self.transfers
+                .set(self.transfers.get() & !SPI_READ_IN_PROGRESS);
+        }
 
-        if self.transfers.get() == SPI_IN_PROGRESS {
+        // The SPI state should be changed to IDLE if the transmit FIFO is empty (TFE) and the SPI is not busy (BSY))
+        if self.transfers.get() == SPI_IN_PROGRESS
+            && self.registers.sspsr.is_set(SSPSR::TFE)
+            && !self.registers.sspsr.is_set(SSPSR::BSY)
+        {
             if !self.active_after.get() {
                 self.active_slave.map(|p| {
                     p.deactivate();
@@ -473,10 +478,17 @@ impl<'a> Spi<'a> {
         }
     }
 
+    // Currently the format is set to Motorola SPI frame format, 8 bit mode (octets), MSSPCLKOUT polarity and phase on 0 SPO=1, SPH=0
+    // This means that in the case of continuous back-to-back transmissions of octets, the SSPFSSOUT signal will be pulsed HIGH between the octets.
+    // If your slave device requires the SSPFSSOUT signal to be held LOW for the entire transmission, you will need to either:
+    // 1. Set the chip select pin as a GPIO and hold it low for the duration of the octets
+    // 2. In Motorola SPI frame format set SPO=1, SPH=1 and make sure the buffer is continuous
+    // Ref: 4.4.3.13. Motorola SPI Format in the RP2040 Datasheet
     fn set_format(&self) {
         self.registers.sspcr0.modify(SSPCR0::DSS::DATA_8_BIT);
         self.registers.sspcr0.modify(SSPCR0::SPO::CLEAR);
-        self.registers.sspcr0.modify(SSPCR0::SPH::CLEAR);
+        self.registers.sspcr0.modify(SSPCR0::SPH::SET);
+        self.registers.sspcr0.modify(SSPCR0::FRF::MOTOROLA_SPI);
     }
 }
 
@@ -492,7 +504,7 @@ impl<'a> SpiMaster<'a> for Spi<'a> {
             Err(error) => Err(error),
             Ok(_) => Ok(()),
         }?;
-        // set format: 8 bit mode, SSPCLKOUT polarity and phase on 0
+        // This sets the default format for the SPI bus
         self.set_format();
 
         // Always enable DREQ signals -- harmless if DMA is not listening


### PR DESCRIPTION
### Pull Request Overview

The Raspberry Pi Pico is a popular chip with many low-cost development boards such as from [AdaFruit](https://www.adafruit.com/product/5525). Adding capsule level controller access for the RP2040 chip's SPI interface would allow user processes to communicate with devices exposing a SPI peripheral interface. Currently the SPI interface is exposed in chips/rp2040/src/lib.rs but not in boards/raspberry_pi_pico/src/lib.rs. The code to add the capsule capability capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice and to verify its operation with the example code examples/spi_controller_write_read.rs from libtock-rs. I will use the [Digital Discovery](https://digilent.com/reference/test-and-measurement/digital-discovery/start) to act as the SPI peripheral to test.

The underlying driver controls the chip select line in hardware toggling for every octet and does not expect the application to explicitly set/unset the chip select. This prevents the use of the functions `hold_low` and `release_low` which expect GPIO control.

This will close issue https://github.com/tock/tock/issues/4780 .

The AI tooling I used was Microsoft Copilot (GPT 5.X models) and Codex for issue analysis, code generation, and code review.

### Testing Strategy

This pull request was tested sending spi data using the program https://github.com/tock/libtock-rs/examples/spi_controller_write_read.rs. Both the MOSI and MISO were tested between the program and a Digilent Digital Discovery. The program sent 0x12 and the Digital Discovery replied with 0x08 (below)
<img width="2000" height="676" alt="image" src="https://github.com/user-attachments/assets/d62e2bb2-9d6b-4faa-ade2-aef1342a4080" />

The program output is below (note I moved the write-read code below the write and read to simplify initial testing)
```
RP2040 Revision 2 ASIC
tock$ Initialization complete. Enter main loop
spi-controller: write
spi-controller: wrote [12, 12, 12, 12, 12, 12, 12, 12]
spi-controller: read
spi-controller: read [8, 8, 8, 8, 8, 8, 8, 8]
spi-controller: write-read
spi-controller: write-read: wrote [12, 12, 12, 12, 12, 12, 12, 12]: read [8, 8, 8, 8, 8, 8, 8, 8]
spi-controller: inplace write-read
spi-controller: inplace write-read: wrote [12, 12, 12, 12, 12, 12, 12, 12]: read [8, 8, 8, 8, 8, 8, 8, 8]
```

### TODO or Help Wanted

I followed the conventions for the RP2040 specific code of setting the default SPI format in `chips/rp2040/src/spi.rs` function `fn set_format(&self)`. However it appears no other boards in the Tock repo follow this convention and most set the default values in main.rs. Should this be refactored?

Also, I think somewhere in the docs it needs to be made clear that while the default SPI of Motorola SPI Format with SPO=0 and SPH=0 simplifies initial development because the chip select will toggle every octet by hardware, if the peripheral device expects that the chip select is held low the entire "command" or "data" sequence the peripheral device will not work. I'm not sure where I should put this.

### Documentation Updated

- [ X] Updated the relevant files in `/docs`, or no updates are required. No updates required.


### Formatting

- [X ] Ran `make prepush`.

### AI Use

- [ X] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
