### PR TITLE
Add `only_once!()` macro with `AtomicUsize` that panics if run a second time for most boards

### DIFF
--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -174,6 +174,12 @@ struct UarteRegistersManager {
 
 impl UarteRegistersManager {
     pub fn new(regs: StaticRef<UarteRegisters>) -> Self {
+        // We must ensure this register manager is only constructed once to make
+        // this constructor safe. If this is constructed multiple times then
+        // something could control DMA while the other UART register manager is
+        // active.
+        kernel::only_once!();
+
         Self {
             registers: regs,
             tx_dma_buf: MapCell::empty(),

--- a/kernel/src/utilities/mod.rs
+++ b/kernel/src/utilities/mod.rs
@@ -18,6 +18,7 @@ pub mod math;
 pub mod mut_imut_buffer;
 pub mod peripheral_management;
 pub mod single_thread_value;
+pub mod singleton;
 pub mod slice_uninit;
 pub mod static_init;
 pub mod storage_volume;

--- a/kernel/src/utilities/singleton.rs
+++ b/kernel/src/utilities/singleton.rs
@@ -1,0 +1,55 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+/// Internal helper function for [`only_once!()`](crate::only_once).
+///
+/// This must be public to work within the macro but should never be used
+/// directly.
+///
+/// This is a `#[inline(never)]` function that panics if the atomic flag has
+/// already been set. This function is intended for use within the
+/// [`only_once!()`](crate::only_once) macro to detect multiple uses of the
+/// macro on the same name.
+///
+/// This function is implemented separately without inlining to remove the size
+/// bloat of track_caller saving the location of every single call to
+/// [`only_once!()`](crate::only_once).
+#[cfg(target_has_atomic = "ptr")]
+#[inline(never)]
+pub fn only_once_check_used(used: &core::sync::atomic::AtomicUsize) {
+    // swap(1) returns the old value; if it was already 1, this is a second call.
+    if used.swap(1, core::sync::atomic::Ordering::Relaxed) != 0 {
+        panic!("Error! only_once!() called twice.");
+    }
+}
+
+/// Helper macro to ensure an object is only created once.
+///
+/// Panics if the same object is created twice.
+///
+/// This only exists for targets with atomic pointer-sized operations.
+/// Therefore, it can only be used in chip and board crates that can guarantee
+/// the atomic support exists.
+///
+/// ```ignore
+///
+/// /// This DMA-enabled peripheral manager MUST only be created once.
+/// struct PeripheralManagerWithDma;
+///
+/// impl PeripheralManagerWithDma {
+///     fn new() -> Self {
+///         // Ensure this will panic if constructed twice.
+///         kernel::only_once!();
+///         Self {}
+///     }
+/// }
+/// ```
+#[cfg(target_has_atomic = "ptr")]
+#[macro_export]
+macro_rules! only_once {
+    () => {{
+        static USED: core::sync::atomic::AtomicUsize = core::sync::atomic::AtomicUsize::new(0);
+        $crate::utilities::singleton::only_once_check_used(&USED);
+    }};
+}


### PR DESCRIPTION
### Pull Request Overview

Alternative to #4891.

Use `AtomicUsize` in the `only_once!()` macro for boards that support it. This makes it a took available for most boards, and other boards can implement their own or add more `unsafe` APIs.

Sorry I can't re-open the old PR because I force pushed, apparently.

### Testing Strategy

Well, putting `crate::only_once!()` in kernel.rs in handling `yield` seems to work pretty well to test this.


### TODO or Help Wanted

The major thing is: is this OK? There is no `unsafe`.

The second thing is: this breaks panicing on the nrf52 because we can't create the panic UART.

The third thing is: are we ok with an API that is mostly available but not everywhere? This seems much better than each board re-defining the same code.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.

I had claude write the AtomicUsize implementation of `only_once!()`.