### PR TITLE
arch: cortex-m: make `print_cortexm_state` safe

### DIFF
--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -194,7 +194,7 @@ pub unsafe extern "C" fn initialize_ram_jump_to_main() {
     );
 }
 
-pub unsafe fn print_cortexm_state(writer: &mut dyn Write) {
+pub fn print_cortexm_state(writer: &mut dyn Write) {
     let (_ccr, cfsr, hfsr, mmfar, bfar) = crate::syscall::get_global_scb_registers();
 
     let iaccviol = (cfsr & 0x01) == 0x01;


### PR DESCRIPTION


### Pull Request Overview

I think the `unsafe` on this function is carried over from older implementations. It just reads a variable and prints. I think that should be safe.

This is part of updating arch/cortex-m* crates to Rust 2024.

### Testing Strategy

travis


### TODO or Help Wanted

The function doesn't include any unsafe code. Any reason this shouldn't be marked safe?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
