### PR TITLE
arch: cortex-m: v7m: fix incorrect naked_asm behavior in hard fault handler

### DIFF
--- a/arch/cortex-v7m/src/lib.rs
+++ b/arch/cortex-v7m/src/lib.rs
@@ -460,9 +460,9 @@ pub unsafe extern "C" fn hard_fault_handler_arm_v7m() {
     ite   ne               // check if the result of that bitwise AND was not 0
     movne r1, #1           // BFSR & 0b00110000 != 0; r1 = 1
     moveq r1, #0           // BFSR & 0b00110000 == 0; r1 = 0
-    and r5, r2, r1         // bitwise and r1 and r2, store in r5
-    cmp  r5, #1            //  update condition codes to reflect if r1 == 1 && r2 == 1
-    itt  eq                // if r5==1 run the next 2 instructions, else skip to branch
+    and r3, r2, r1         // bitwise and r1 and r2, store in r3
+    cmp  r3, #1            //  update condition codes to reflect if r1 == 1 && r2 == 1
+    itt  eq                // if r3==1 run the next 2 instructions, else skip to branch
     // if true, The hardware couldn't use the stack, so we have no saved data and
     // we cannot use the kernel stack as is. We just want to report that
     // the kernel's stack overflowed, since that is essential for
@@ -472,8 +472,8 @@ pub unsafe extern "C" fn hard_fault_handler_arm_v7m() {
     // kernel's original stack. This should in theory leave the bottom
     // of the stack where the problem occurred untouched should one want
     // to further debug.
-    ldreq  r4, ={estack} // load _estack into r4
-    moveq  sp, r4        // Set the stack pointer to _estack
+    ldreq  r3, ={estack} // load _estack into r3
+    moveq  sp, r3        // Set the stack pointer to _estack
     // finally, if the fault occurred in privileged mode (r2 == 1), branch
     // to non-naked handler.
     cmp r2, #0


### PR DESCRIPTION
### Pull Request Overview

Registers `r4` and `r5` are not caller-saved. So, if we write them, we have to restore their values to avoid [incorrect behavior](https://doc.rust-lang.org/nightly/reference/inline-assembly.html#r-asm.naked-rules.callee-saved-registers). To avoid doing that, use a caller-saved register instead (in this case `r3`). After checking `BFSR`, `r3` isn't used again, so we can use it as a scratch register.

This avoids incorrect behavior in this assembly block, since it is invalid to change the value of a callee-saved register (in this case r4 and r5) and not restore it.






### Testing Strategy

Running crash_dummy test app with manually setting register values (specifically r5) and showing that the output sees the correct values. For example, I added this assembly:

```diff
diff --git a/examples/tests/crash_dummy/main.c b/examples/tests/crash_dummy/main.c
index df4371cf..59ac7de7 100644
--- a/examples/tests/crash_dummy/main.c
+++ b/examples/tests/crash_dummy/main.c
@@ -7,6 +7,13 @@ volatile int* zeroptr = 0;
 static void button_callback(__attribute__ ((unused)) returncode_t ret,
                             __attribute__ ((unused)) int          btn_num,
                             __attribute__ ((unused)) bool         val) {
+asm volatile ("ldr r0, =0xabc4320");
+asm volatile ("ldr r1, =0xabc4321");
+asm volatile ("ldr r2, =0xabc4322");
+asm volatile ("ldr r3, =0xabc4323");
+asm volatile ("ldr r4, =0xabc4324");
+asm volatile ("ldr r5, =0xabc4325");
+asm volatile ("ldr r6, =0xabc4326");
   __attribute__ ((unused)) volatile int k = *zeroptr;
 }
```
and I see:
```
---| App Status |---
𝐀𝐩𝐩: crash_dummy   -   [Faulted]
 Events Queued: 1   Syscall Count: 6   Dropped Upcall Count: 0
 Restart Count: 0
 Last Syscall: Yield { which: 1, param_a: 0, param_b: 0 }
 Completion Code: None


 ╔═══════════╤══════════════════════════════════════════╗
 ║  Address  │ Region Name    Used | Allocated (bytes)  ║
 ╚0x2000B000═╪══════════════════════════════════════════╝
             │ Grant Ptrs      120
             │ Upcalls         320
             │ Process         772
  0x2000AB44 ┼───────────────────────────────────────────
             │ ▼ Grant          16
  0x2000AB34 ┼───────────────────────────────────────────
             │ Unused
  0x200099D8 ┼───────────────────────────────────────────
             │ ▲ Heap            0 |   4444               S
  0x200099D8 ┼─────────────────────────────────────────── R
             │ Data            472 |    472               A
  0x20009800 ┼─────────────────────────────────────────── M
             │ ▼ Stack          96 |   2048
  0x200097A0 ┼───────────────────────────────────────────
             │ Unused
  0x20009000 ┴───────────────────────────────────────────
             .....
  0x00041000 ┬─────────────────────────────────────────── F
             │ App Flash      4016                        L
  0x00040050 ┼─────────────────────────────────────────── A
             │ Protected        80                        S
  0x00040000 ┴─────────────────────────────────────────── H

  R0 : 0x0ABC4320    R6 : 0x0ABC4326
  R1 : 0x0ABC4321    R7 : 0x20009000
  R2 : 0x0ABC4322    R8 : 0x00000000
  R3 : 0x00000000    R10: 0x00000000
  R4 : 0x0ABC4324    R11: 0x00000000
  R5 : 0x0ABC4325    R12: 0x00000000
  R9 : 0x20009800 (Static Base Register)
  SP : 0x200097C0 (Process Stack Pointer)
  LR : 0x000401E5
  PC : 0x000400D4
 YPC : 0x000401E4
```
Note, r3 is what the compiler used for the zero pointer access, hence it is 0.


### TODO or Help Wanted

It would be good for someone to double check that clobbering r3 at that point is in fact fine.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
