### PR TITLE
arch: cortex-m crates: Update to Rust 2024

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,7 @@ dependencies = [
 name = "cortexv7m"
 version = "0.2.3-dev"
 dependencies = [
+ "cortexm",
  "kernel",
 ]
 

--- a/arch/cortex-m/Cargo.toml
+++ b/arch/cortex-m/Cargo.toml
@@ -6,7 +6,7 @@
 name = "cortexm"
 version.workspace = true
 authors.workspace = true
-edition.workspace = true
+edition = "2024"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -20,12 +20,19 @@ pub mod systick;
 pub mod thread_id;
 
 // These constants are defined in the linker script.
+//
+// # Safety
+//
+// All symbols must have the correct signatures. These symbols are values in the
+// program and we conservatively treat them as single bytes. In practice we do
+// not care or use the value of any of these static `u8`s. We are only
+// interested in the address of these static `u8`s.
 unsafe extern "C" {
-    static _szero: *const u32;
-    static _ezero: *const u32;
-    static _etext: *const u32;
-    static _srelocate: *const u32;
-    static _erelocate: *const u32;
+    static _szero: u8;
+    static _ezero: u8;
+    static _etext: u8;
+    static _srelocate: u8;
+    static _erelocate: u8;
 }
 
 /// Trait to encapsulate differences in between Cortex-M variants

--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -20,7 +20,7 @@ pub mod systick;
 pub mod thread_id;
 
 // These constants are defined in the linker script.
-extern "C" {
+unsafe extern "C" {
     static _szero: *const u32;
     static _ezero: *const u32;
     static _etext: *const u32;

--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -19,22 +19,6 @@ pub mod syscall;
 pub mod systick;
 pub mod thread_id;
 
-// These constants are defined in the linker script.
-//
-// # Safety
-//
-// All symbols must have the correct signatures. These symbols are values in the
-// program and we conservatively treat them as single bytes. In practice we do
-// not care or use the value of any of these static `u8`s. We are only
-// interested in the address of these static `u8`s.
-unsafe extern "C" {
-    static _szero: u8;
-    static _ezero: u8;
-    static _etext: u8;
-    static _srelocate: u8;
-    static _erelocate: u8;
-}
-
 /// Trait to encapsulate differences in between Cortex-M variants
 ///
 /// This trait contains functions and other associated data (constants) which
@@ -181,6 +165,24 @@ pub unsafe extern "C" fn unhandled_interrupt() {
 #[unsafe(naked)]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn initialize_ram_jump_to_main() {
+    // These constants are defined in the linker script.
+    //
+    // # Safety
+    //
+    // Linker script symbols are value-less entities, a concept that does not
+    // map onto any actual Rust type (as of July 2026).  This method only uses
+    // these declarations to pass their address to the assembly. By declaring
+    // these variables within this naked fn, we ensure that no Rust code
+    // attempts to access them, and assert that the assembly will take only the
+    // address, which is well-defined.
+    unsafe extern "C" {
+        static _szero: u8;
+        static _ezero: u8;
+        static _etext: u8;
+        static _srelocate: u8;
+        static _erelocate: u8;
+    }
+
     use core::arch::naked_asm;
     naked_asm!(
         "

--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -171,7 +171,6 @@ pub unsafe extern "C" fn unhandled_interrupt() {
 /// - This does not fall-through, it branches at the end.
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 #[unsafe(naked)]
-#[unsafe(no_mangle)]
 pub unsafe extern "C" fn initialize_ram_jump_to_main() {
     use core::arch::naked_asm;
     naked_asm!(

--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -119,13 +119,30 @@ pub unsafe extern "C" fn unhandled_interrupt() {
     let mut interrupt_number: u32;
 
     // IPSR[8:0] holds the currently active interrupt
-    asm!(
-        "
+    //
+    // # Safety
+    //
+    // - INPUTS: This does not use the existing value of any registers.
+    // - OUTPUTS: This only writes `r0` which is marked as an output.
+    // - Options set:
+    //   - nomem: We do not read or write memory.
+    //   - nostack: This does not use the stack.
+    //   - preserves_flags: This does not change flags.
+    // - Options not set:
+    //   - pure: not required
+    //   - readonly: implied by nomem
+    //   - noreturn: we do fall-through
+    //   - att_syntax: not on arm
+    //   - raw: not required
+    unsafe {
+        asm!(
+            "
     mrs r0, ipsr
-        ",
-        out("r0") interrupt_number,
-        options(nomem, nostack, preserves_flags),
-    );
+            ",
+            out("r0") interrupt_number,
+            options(nomem, nostack, preserves_flags),
+        );
+    }
 
     interrupt_number &= 0x1ff;
 
@@ -138,6 +155,13 @@ pub unsafe extern "C" fn unhandled_interrupt() {
 /// not valid to run Rust code without RAM initialized.
 ///
 /// See <https://github.com/tock/tock/issues/2222> for more information.
+///
+/// # Safety
+///
+/// - INPUTS: This does not use the existing value of any registers.
+/// - OUTPUTS: This does not write any callee-saved registers, and only uses
+///   caller-saved registers.
+/// - This does not fall-through, it branches at the end.
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 #[unsafe(naked)]
 #[unsafe(no_mangle)]

--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -165,12 +165,21 @@ pub unsafe extern "C" fn unhandled_interrupt() {
 ///
 /// # Safety
 ///
+/// ## `naked`
+///
 /// - INPUTS: This does not use the existing value of any registers.
 /// - OUTPUTS: This does not write any callee-saved registers, and only uses
 ///   caller-saved registers.
 /// - This does not fall-through, it branches at the end.
+///
+/// ## `no_mangle`
+///
+/// We use `initialize_ram_jump_to_main` as a symbol in the linker file. This is
+/// the only user of the name `initialize_ram_jump_to_main` and no other symbol
+/// may use the same name.
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 #[unsafe(naked)]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn initialize_ram_jump_to_main() {
     use core::arch::naked_asm;
     naked_asm!(

--- a/arch/cortex-m/src/scb.rs
+++ b/arch/cortex-m/src/scb.rs
@@ -281,7 +281,29 @@ pub unsafe fn set_sleepdeep() {
 
     SCB.scr.modify(SystemControl::SLEEPDEEP::SET);
 
-    asm!("dsb", "isb", options(nomem, nostack, preserves_flags));
+    // # Safety
+    //
+    // - INPUTS: This does not use the existing value of any registers.
+    // - OUTPUTS: This does not write any registers.
+    // - Options set:
+    //   - nomem: We do not read or write memory.
+    //   - nostack: This does not use the stack.
+    //   - preserves_flags: This does not change flags.
+    // - Options not set:
+    //   - pure: not required
+    //   - readonly: implied by nomem
+    //   - noreturn: we do fall-through
+    //   - att_syntax: not on arm
+    //   - raw: not required
+    unsafe {
+        asm!(
+            "
+    dsb                 // Data Synchronization Barrier
+    isb                 // Instruction Synchronization Barrier
+            ",
+            options(nomem, nostack, preserves_flags)
+        );
+    }
 }
 
 // Mock implementation for tests on Travis-CI.
@@ -322,7 +344,29 @@ pub unsafe fn disable_fpca() {
     SCB.cpacr
         .modify(CoprocessorAccessControl::CP10::CLEAR + CoprocessorAccessControl::CP11::CLEAR);
 
-    asm!("dsb", "isb", options(nomem, nostack, preserves_flags));
+    // # Safety
+    //
+    // - INPUTS: This does not use the existing value of any registers.
+    // - OUTPUTS: This does not write any registers.
+    // - Options set:
+    //   - nomem: We do not read or write memory.
+    //   - nostack: This does not use the stack.
+    //   - preserves_flags: This does not change flags.
+    // - Options not set:
+    //   - pure: not required
+    //   - readonly: implied by nomem
+    //   - noreturn: we do fall-through
+    //   - att_syntax: not on arm
+    //   - raw: not required
+    unsafe {
+        asm!(
+            "
+    dsb                 // Data Synchronization Barrier
+    isb                 // Instruction Synchronization Barrier
+            ",
+            options(nomem, nostack, preserves_flags)
+        );
+    }
 
     if SCB.cpacr.read(CoprocessorAccessControl::CP10) != 0
         || SCB.cpacr.read(CoprocessorAccessControl::CP11) != 0

--- a/arch/cortex-m/src/support.rs
+++ b/arch/cortex-m/src/support.rs
@@ -11,6 +11,21 @@ use crate::scb;
 #[inline(always)]
 pub fn nop() {
     use core::arch::asm;
+
+    // # Safety
+    //
+    // - INPUTS: This does not use the existing value of any registers.
+    // - OUTPUTS: This does not write any registers.
+    // - Options set:
+    //   - nomem: We do not read or write memory.
+    //   - nostack: This does not use the stack.
+    //   - preserves_flags: This does not change flags.
+    // - Options not set:
+    //   - pure: not required
+    //   - readonly: implied by nomem
+    //   - noreturn: we do fall-through
+    //   - att_syntax: not on arm
+    //   - raw: not required
     unsafe {
         asm!("nop", options(nomem, nostack, preserves_flags));
     }
@@ -21,7 +36,24 @@ pub fn nop() {
 #[inline(always)]
 pub unsafe fn wfi() {
     use core::arch::asm;
-    asm!("wfi", options(nomem, preserves_flags));
+
+    // # Safety
+    //
+    // - INPUTS: This does not use the existing value of any registers.
+    // - OUTPUTS: This does not write any registers.
+    // - Options set:
+    //   - nomem: We do not read or write memory.
+    //   - nostack: This does not use the stack.
+    //   - preserves_flags: This does not change flags.
+    // - Options not set:
+    //   - pure: not required
+    //   - readonly: implied by nomem
+    //   - noreturn: we do fall-through
+    //   - att_syntax: not on arm
+    //   - raw: not required
+    unsafe {
+        asm!("wfi", options(nomem, nostack, preserves_flags));
+    }
 }
 
 /// Single-core critical section operation
@@ -31,13 +63,47 @@ where
     F: FnOnce() -> R,
 {
     use core::arch::asm;
-    // Set PRIMASK
-    asm!("cpsid i", options(nomem, nostack));
+    // Set PRIMASK to disable interrupts.
+    //
+    // # Safety
+    //
+    // - INPUTS: This does not use the existing value of any registers.
+    // - OUTPUTS: This does not write any registers.
+    // - Options set:
+    //   - nomem: We do not read or write memory.
+    //   - nostack: This does not use the stack.
+    //   - preserves_flags: This does not change flags.
+    // - Options not set:
+    //   - pure: not required
+    //   - readonly: implied by nomem
+    //   - noreturn: we do fall-through
+    //   - att_syntax: not on arm
+    //   - raw: not required
+    unsafe {
+        asm!("cpsid i", options(nomem, nostack, preserves_flags));
+    }
 
     let res = f();
 
-    // Unset PRIMASK
-    asm!("cpsie i", options(nomem, nostack));
+    // Unset PRIMASK to re-enable interrupts.
+    //
+    // # Safety
+    //
+    // - INPUTS: This does not use the existing value of any registers.
+    // - OUTPUTS: This does not write any registers.
+    // - Options set:
+    //   - nomem: We do not read or write memory.
+    //   - nostack: This does not use the stack.
+    //   - preserves_flags: This does not change flags.
+    // - Options not set:
+    //   - pure: not required
+    //   - readonly: implied by nomem
+    //   - noreturn: we do fall-through
+    //   - att_syntax: not on arm
+    //   - raw: not required
+    unsafe {
+        asm!("cpsie i", options(nomem, nostack, preserves_flags));
+    }
     res
 }
 
@@ -86,11 +152,24 @@ pub fn is_interrupt_context() -> bool {
 
     // # Safety
     //
-    // This only reads a register and has no effects.
+    // - INPUTS: This does not use the existing value of any registers.
+    // - OUTPUTS: This writes `r0` which is specified as an output.
+    // - Options set:
+    //   - nomem: We do not read or write memory.
+    //   - nostack: This does not use the stack.
+    //   - preserves_flags: This does not change flags.
+    // - Options not set:
+    //   - pure: not required
+    //   - readonly: implied by nomem
+    //   - noreturn: we do fall-through
+    //   - att_syntax: not on arm
+    //   - raw: not required
     unsafe {
         // IPSR[8:0] holds the currently active interrupt
         asm!(
-            "mrs r0, ipsr",
+            "
+    mrs r0, ipsr
+            ",
             out("r0") interrupt_number,
             options(nomem, nostack, preserves_flags)
         );

--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -136,8 +136,12 @@ pub fn get_global_scb_registers() -> (u32, u32, u32, u32, u32) {
     // Using the normal `ldr  r0, =SCB_REGISTERS` gives
     // "error: out of range pc-relative fixup value". So, instead, we pass in a
     // pointer based on the symbol.
-    extern "C" {
-        static SCB_REGISTERS: u32;
+    //
+    // # Safety
+    //
+    // `SCB_REGISTERS` is the name of an allocated array of five `u32`s.
+    unsafe extern "C" {
+        static SCB_REGISTERS: [u32; 5];
     }
 
     // Retrieve the stored SCB register values using assembly.
@@ -158,7 +162,7 @@ pub fn get_global_scb_registers() -> (u32, u32, u32, u32, u32) {
     ldr r4, [{addr}, #12]             // r4 = mmfar = SCB_REGISTERS[3]
     ldr r5, [{addr}, #16]             // r5 = bfar = SCB_REGISTERS[4]
             ",
-            addr = in(reg) core::ptr::from_ref::<u32>(&SCB_REGISTERS),
+            addr = in(reg) core::ptr::from_ref::<[u32; 5]>(&SCB_REGISTERS),
             out("r1") _ccr,
             out("r2") cfsr,
             out("r3") hfsr,

--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -23,7 +23,6 @@ use crate::CortexMVariant;
 ///
 /// Because this is a global `static mut` variable, we can only access it from
 /// inline assembly.
-#[unsafe(no_mangle)]
 #[used]
 pub static mut SYSCALL_FIRED: UnsafeCell<usize> = UnsafeCell::new(0);
 
@@ -36,7 +35,6 @@ pub static mut SYSCALL_FIRED: UnsafeCell<usize> = UnsafeCell::new(0);
 ///
 /// Because this is a global `static mut` variable, we can only access it from
 /// inline assembly.
-#[unsafe(no_mangle)]
 #[used]
 pub static mut APP_HARD_FAULT: UnsafeCell<usize> = UnsafeCell::new(0);
 
@@ -48,7 +46,6 @@ pub static mut APP_HARD_FAULT: UnsafeCell<usize> = UnsafeCell::new(0);
 ///
 /// Because this is a global `static mut` variable, we can only access it from
 /// inline assembly.
-#[unsafe(no_mangle)]
 #[used]
 pub static mut SCB_REGISTERS: UnsafeCell<[u32; 5]> = UnsafeCell::new([0; 5]);
 
@@ -70,11 +67,12 @@ pub fn get_global_app_hard_fault() -> usize {
     unsafe {
         core::arch::asm!(
             "
-    ldr  r0, =APP_HARD_FAULT          // r0 = &APP_HARD_FAULT
+    ldr  r0, ={app_hard_fault}        // r0 = &APP_HARD_FAULT
     movs r1, #0                       // r1 = 0
     ldr  r2, [r0]                     // r2 = *APP_HARD_FAULT
     str  r1, [r0]                     // *APP_HARD_FAULT = 0
             ",
+            app_hard_fault = sym APP_HARD_FAULT,
             out("r0") _,
             out("r1") _,
             out("r2") app_fault,
@@ -102,11 +100,12 @@ pub fn get_global_syscall_fired() -> usize {
     unsafe {
         core::arch::asm!(
             "
-    ldr  r0, =SYSCALL_FIRED           // r0 = &SYSCALL_FIRED
+    ldr  r0, ={syscall_fired}         // r0 = &SYSCALL_FIRED
     movs r1, #0                       // r1 = 0
     ldr  r2, [r0]                     // r2 = *SYSCALL_FIRED
     str  r1, [r0]                     // *SYSCALL_FIRED = 0
             ",
+            syscall_fired = sym SYSCALL_FIRED,
             out("r0") _,
             out("r1") _,
             out("r2") syscall_fired,
@@ -131,20 +130,11 @@ pub fn get_global_scb_registers() -> (u32, u32, u32, u32, u32) {
     let mmfar: u32;
     let bfar: u32;
 
-    // Need this for compatibility with armv6.
+    // Retrieve the stored SCB register values using assembly.
     //
     // Using the normal `ldr  r0, =SCB_REGISTERS` gives
     // "error: out of range pc-relative fixup value". So, instead, we pass in a
     // pointer based on the symbol.
-    //
-    // # Safety
-    //
-    // `SCB_REGISTERS` is the name of an allocated array of five `u32`s.
-    unsafe extern "C" {
-        static SCB_REGISTERS: [u32; 5];
-    }
-
-    // Retrieve the stored SCB register values using assembly.
     //
     // # Safety
     //
@@ -162,7 +152,7 @@ pub fn get_global_scb_registers() -> (u32, u32, u32, u32, u32) {
     ldr r4, [{addr}, #12]             // r4 = mmfar = SCB_REGISTERS[3]
     ldr r5, [{addr}, #16]             // r5 = bfar = SCB_REGISTERS[4]
             ",
-            addr = in(reg) core::ptr::from_ref::<[u32; 5]>(&SCB_REGISTERS),
+            addr = in(reg) core::ptr::addr_of!(SCB_REGISTERS),
             out("r1") _ccr,
             out("r2") cfsr,
             out("r3") hfsr,

--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -395,38 +395,24 @@ impl<A: CortexMVariant> kernel::syscall::UserspaceKernelBoundary for SysCall<A> 
         //  - Stack offset 4 is R12, which the syscall interface ignores
         let stack_bottom = state.psp as *mut usize;
 
-        // # Safety
-        //
-        // We ensured there is `SVC_FRAME_SIZE` of memory at `stack_bottom` so
-        // we can create pointers to u32s in that memory.
-        let (ptr_apsr, ptr_pc, ptr_lr, ptr_r3, ptr_r2, ptr_r1, ptr_r0) = unsafe {
-            (
-                stack_bottom.add(7),
-                stack_bottom.add(6),
-                stack_bottom.add(5),
-                stack_bottom.add(3),
-                stack_bottom.add(2),
-                stack_bottom.add(1),
-                stack_bottom.add(0),
-            )
-        };
-
-        // # Safety
-        //
-        // The pointers are valid memory in the process's memory space and
-        // well-aligned to a u32.
+        // SAFETY: We both offset the pointer (`add()`) and then write using the
+        // pointer. Both of these require the pointers remain valid, there is
+        // allocated memory, and the pointers are aligned. We ensured there is
+        // `SVC_FRAME_SIZE` of memory at `stack_bottom` so we can create
+        // pointers to u32s in that memory. The pointers are valid memory in the
+        // process's memory space and well-aligned to a u32.
         unsafe {
-            ptr::write(ptr_apsr, state.psr); // ................. -> APSR
-            ptr::write(ptr_pc, callback.pc.addr() | 1); // ...... -> PC
-            ptr::write(ptr_lr, state.yield_pc | 1); // .......... -> LR
+            ptr::write(stack_bottom.add(7), state.psr); // ............ -> APSR
+            ptr::write(stack_bottom.add(6), callback.pc.addr() | 1); // -> PC
+            ptr::write(stack_bottom.add(5), state.yield_pc | 1); // ... -> LR
 
             // Write upcall arguments to the proper stack locations.
             kernel::utilities::arch_helpers::encode_upcall_trd104_ptr(
                 &callback,
-                ptr_r0.cast::<u32>(), // -> R0
-                ptr_r1.cast::<u32>(), // -> R1
-                ptr_r2.cast::<u32>(), // -> R2
-                ptr_r3.cast::<u32>(), // -> R3
+                stack_bottom.add(0).cast::<u32>(), // -> R0
+                stack_bottom.add(1).cast::<u32>(), // -> R1
+                stack_bottom.add(2).cast::<u32>(), // -> R2
+                stack_bottom.add(3).cast::<u32>(), // -> R3
             );
         }
 
@@ -468,40 +454,25 @@ impl<A: CortexMVariant> kernel::syscall::UserspaceKernelBoundary for SysCall<A> 
             // handler and this process faulted.
             kernel::syscall::ContextSwitchReason::Fault
         } else if syscall_fired == 1 {
-            // # Safety
-            //
-            // We verified that there is room on the stack for the service frame
-            // so we can safely create pointers to that memory on the process
-            // stack.
-            let (yield_pc_ptr, psr_ptr, r0_ptr, r1_ptr, r2_ptr, r3_ptr) = unsafe {
-                (
-                    new_stack_pointer.add(6),
-                    new_stack_pointer.add(7),
-                    new_stack_pointer.add(0),
-                    new_stack_pointer.add(1),
-                    new_stack_pointer.add(2),
-                    new_stack_pointer.add(3),
-                )
-            };
-
-            // # Safety
-            //
-            // The pointers are to valid memory in the process stack.
+            // SAFETY: We verified that there is room on the stack for the
+            // service frame so we can safely create pointers to that memory on
+            // the process stack. The pointers are to valid memory in the
+            // process stack.
             let (r0, r1, r2, r3) = unsafe {
                 // Save these fields after a syscall. If this is a synchronous
                 // syscall (i.e. we return a value to the app immediately) then this
                 // will have no effect. If we are doing something like `yield()`,
                 // however, then we need to have this state.
-                state.yield_pc = ptr::read(yield_pc_ptr);
-                state.psr = ptr::read(psr_ptr);
+                state.yield_pc = ptr::read(new_stack_pointer.add(6));
+                state.psr = ptr::read(new_stack_pointer.add(7));
 
                 // Get the syscall arguments and return them along with the syscall.
                 // It's possible the app did something invalid, in which case we put
                 // the app in the fault state.
-                let r0 = ptr::read(r0_ptr);
-                let r1 = ptr::read(r1_ptr);
-                let r2 = ptr::read(r2_ptr);
-                let r3 = ptr::read(r3_ptr);
+                let r0 = ptr::read(new_stack_pointer.add(0));
+                let r1 = ptr::read(new_stack_pointer.add(1));
+                let r2 = ptr::read(new_stack_pointer.add(2));
+                let r3 = ptr::read(new_stack_pointer.add(3));
 
                 (r0, r1, r2, r3)
             };
@@ -568,36 +539,19 @@ impl<A: CortexMVariant> kernel::syscall::UserspaceKernelBoundary for SysCall<A> 
                 0xBAD00BAD,
             )
         } else {
-            // # Safety
-            //
-            // We ensured there is enough valid process memory on the stack to store
-            // these values we are creating pointers to.
-            let (r0_ptr, r1_ptr, r2_ptr, r3_ptr, r12_ptr, lr_ptr, pc_ptr, xpsr_ptr) = unsafe {
-                (
-                    stack_pointer.add(0),
-                    stack_pointer.add(1),
-                    stack_pointer.add(2),
-                    stack_pointer.add(3),
-                    stack_pointer.add(4),
-                    stack_pointer.add(5),
-                    stack_pointer.add(6),
-                    stack_pointer.add(7),
-                )
-            };
-
-            // # Safety
-            //
-            // We ensured the pointers point to valid stack memory we can read
+            // SAFETY: We ensured there is enough valid process memory on the
+            // stack to store these values we are creating pointers to. We
+            // ensured the pointers point to valid stack memory we can read
             // from.
             unsafe {
-                let r0 = ptr::read(r0_ptr);
-                let r1 = ptr::read(r1_ptr);
-                let r2 = ptr::read(r2_ptr);
-                let r3 = ptr::read(r3_ptr);
-                let r12 = ptr::read(r12_ptr);
-                let lr = ptr::read(lr_ptr);
-                let pc = ptr::read(pc_ptr);
-                let xpsr = ptr::read(xpsr_ptr);
+                let r0 = ptr::read(stack_pointer.add(0));
+                let r1 = ptr::read(stack_pointer.add(1));
+                let r2 = ptr::read(stack_pointer.add(2));
+                let r3 = ptr::read(stack_pointer.add(3));
+                let r12 = ptr::read(stack_pointer.add(4));
+                let lr = ptr::read(stack_pointer.add(5));
+                let pc = ptr::read(stack_pointer.add(6));
+                let xpsr = ptr::read(stack_pointer.add(7));
                 (r0, r1, r2, r3, r12, lr, pc, xpsr)
             }
         };

--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -474,30 +474,55 @@ impl<A: CortexMVariant> kernel::syscall::UserspaceKernelBoundary for SysCall<A> 
             // handler and this process faulted.
             kernel::syscall::ContextSwitchReason::Fault
         } else if syscall_fired == 1 {
-            // Save these fields after a syscall. If this is a synchronous
-            // syscall (i.e. we return a value to the app immediately) then this
-            // will have no effect. If we are doing something like `yield()`,
-            // however, then we need to have this state.
-            state.yield_pc = ptr::read(new_stack_pointer.add(6));
-            state.psr = ptr::read(new_stack_pointer.add(7));
+            // # Safety
+            //
+            // We verified that there is room on the stack for the service frame
+            // so we can safely create pointers to that memory on the process
+            // stack.
+            let (yield_pc_ptr, psr_ptr, r0_ptr, r1_ptr, r2_ptr, r3_ptr) = unsafe {
+                (
+                    new_stack_pointer.add(6),
+                    new_stack_pointer.add(7),
+                    new_stack_pointer.add(0),
+                    new_stack_pointer.add(1),
+                    new_stack_pointer.add(2),
+                    new_stack_pointer.add(3),
+                )
+            };
 
-            // Get the syscall arguments and return them along with the syscall.
-            // It's possible the app did something invalid, in which case we put
-            // the app in the fault state.
-            let r0 = ptr::read(new_stack_pointer.add(0));
-            let r1 = ptr::read(new_stack_pointer.add(1));
-            let r2 = ptr::read(new_stack_pointer.add(2));
-            let r3 = ptr::read(new_stack_pointer.add(3));
+            // # Safety
+            //
+            // The pointers are to valid memory in the process stack.
+            let (r0, r1, r2, r3) = unsafe {
+                // Save these fields after a syscall. If this is a synchronous
+                // syscall (i.e. we return a value to the app immediately) then this
+                // will have no effect. If we are doing something like `yield()`,
+                // however, then we need to have this state.
+                state.yield_pc = ptr::read(yield_pc_ptr);
+                state.psr = ptr::read(psr_ptr);
+
+                // Get the syscall arguments and return them along with the syscall.
+                // It's possible the app did something invalid, in which case we put
+                // the app in the fault state.
+                let r0 = ptr::read(r0_ptr);
+                let r1 = ptr::read(r1_ptr);
+                let r2 = ptr::read(r2_ptr);
+                let r3 = ptr::read(r3_ptr);
+
+                (r0, r1, r2, r3)
+            };
 
             // Get the actual SVC number.
-            // Read the PC from the stack as a *const u16 (i.e. we're treating instructions as
+            // Use the PC from the stack as a *const u16 (i.e. we're treating instructions as
             // u16).
-            let pcptr_ptr: *const usize = new_stack_pointer;
-            let pcptr_ptr: *const *const u16 = pcptr_ptr.cast();
-            let pcptr = ptr::read(pcptr_ptr.add(6));
+            let pcptr: *const u16 = state.yield_pc as *const u16;
+
+            // Get a pointer to the instruction before the PC value.
+            let pcprev_ptr = unsafe { pcptr.sub(1) };
+
             // The svc instruction is the last instruction before the PC, and should be 16 bits.
             // Read it by offsetting the PC.
-            let svc_instr = ptr::read(pcptr.sub(1));
+            let svc_instr = unsafe { ptr::read(pcprev_ptr) };
             let svc_num = (svc_instr & 0xff) as u8;
 
             // Use the helper function to convert these raw values into a Tock
@@ -549,15 +574,38 @@ impl<A: CortexMVariant> kernel::syscall::UserspaceKernelBoundary for SysCall<A> 
                 0xBAD00BAD,
             )
         } else {
-            let r0 = ptr::read(stack_pointer.add(0));
-            let r1 = ptr::read(stack_pointer.add(1));
-            let r2 = ptr::read(stack_pointer.add(2));
-            let r3 = ptr::read(stack_pointer.add(3));
-            let r12 = ptr::read(stack_pointer.add(4));
-            let lr = ptr::read(stack_pointer.add(5));
-            let pc = ptr::read(stack_pointer.add(6));
-            let xpsr = ptr::read(stack_pointer.add(7));
-            (r0, r1, r2, r3, r12, lr, pc, xpsr)
+            // # Safety
+            //
+            // We ensured there is enough valid process memory on the stack to store
+            // these values we are creating pointers to.
+            let (r0_ptr, r1_ptr, r2_ptr, r3_ptr, r12_ptr, lr_ptr, pc_ptr, xpsr_ptr) = unsafe {
+                (
+                    stack_pointer.add(0),
+                    stack_pointer.add(1),
+                    stack_pointer.add(2),
+                    stack_pointer.add(3),
+                    stack_pointer.add(4),
+                    stack_pointer.add(5),
+                    stack_pointer.add(6),
+                    stack_pointer.add(7),
+                )
+            };
+
+            // # Safety
+            //
+            // We ensured the pointers point to valid stack memory we can read
+            // from.
+            unsafe {
+                let r0 = ptr::read(r0_ptr);
+                let r1 = ptr::read(r1_ptr);
+                let r2 = ptr::read(r2_ptr);
+                let r3 = ptr::read(r3_ptr);
+                let r12 = ptr::read(r12_ptr);
+                let lr = ptr::read(lr_ptr);
+                let pc = ptr::read(pc_ptr);
+                let xpsr = ptr::read(xpsr_ptr);
+                (r0, r1, r2, r3, r12, lr, pc, xpsr)
+            }
         };
 
         let _ = writer.write_fmt(format_args!(

--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -23,7 +23,7 @@ use crate::CortexMVariant;
 ///
 /// Because this is a global `static mut` variable, we can only access it from
 /// inline assembly.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[used]
 pub static mut SYSCALL_FIRED: UnsafeCell<usize> = UnsafeCell::new(0);
 
@@ -36,7 +36,7 @@ pub static mut SYSCALL_FIRED: UnsafeCell<usize> = UnsafeCell::new(0);
 ///
 /// Because this is a global `static mut` variable, we can only access it from
 /// inline assembly.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[used]
 pub static mut APP_HARD_FAULT: UnsafeCell<usize> = UnsafeCell::new(0);
 
@@ -48,7 +48,7 @@ pub static mut APP_HARD_FAULT: UnsafeCell<usize> = UnsafeCell::new(0);
 ///
 /// Because this is a global `static mut` variable, we can only access it from
 /// inline assembly.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[used]
 pub static mut SCB_REGISTERS: UnsafeCell<[u32; 5]> = UnsafeCell::new([0; 5]);
 
@@ -327,8 +327,15 @@ impl<A: CortexMVariant> kernel::syscall::UserspaceKernelBoundary for SysCall<A> 
         }
 
         let sp = state.psp as *mut u32;
-        let (r0, r1, r2, r3) = (sp.add(0), sp.add(1), sp.add(2), sp.add(3));
+        // # Safety
+        //
+        // To offset the pointer there must be valid memory pointed to by `sp`.
+        // We verified that there is space for four u32s on the stack before
+        // hitting the `app_brk`.
+        let (r0, r1, r2, r3) = unsafe { (sp.add(0), sp.add(1), sp.add(2), sp.add(3)) };
 
+        // # Safety
+        //
         // These operations are only safe so long as
         // - the pointers are properly aligned. This is guaranteed because the
         //   pointers are all offset multiples of 4 bytes from the stack
@@ -347,14 +354,16 @@ impl<A: CortexMVariant> kernel::syscall::UserspaceKernelBoundary for SysCall<A> 
         //
         // Refer to
         // https://doc.rust-lang.org/std/primitive.pointer.html#safety-13
+        let (mut r0_val, mut r1_val, mut r2_val, mut r3_val) = unsafe { (*r0, *r1, *r2, *r3) };
+
         kernel::utilities::arch_helpers::encode_syscall_return_trd104(
             &kernel::utilities::arch_helpers::TRD104SyscallReturn::from_syscall_return(
                 return_value,
             ),
-            &mut *r0,
-            &mut *r1,
-            &mut *r2,
-            &mut *r3,
+            &mut r0_val,
+            &mut r1_val,
+            &mut r2_val,
+            &mut r3_val,
         );
 
         Ok(())
@@ -391,18 +400,41 @@ impl<A: CortexMVariant> kernel::syscall::UserspaceKernelBoundary for SysCall<A> 
         //  - Instruction addresses require `|1` to indicate thumb code
         //  - Stack offset 4 is R12, which the syscall interface ignores
         let stack_bottom = state.psp as *mut usize;
-        ptr::write(stack_bottom.add(7), state.psr); //......... -> APSR
-        ptr::write(stack_bottom.add(6), callback.pc.addr() | 1); //... -> PC
-        ptr::write(stack_bottom.add(5), state.yield_pc | 1); // -> LR
 
-        // Write upcall arguments to the proper stack locations.
-        kernel::utilities::arch_helpers::encode_upcall_trd104_ptr(
-            &callback,
-            stack_bottom.add(0).cast::<u32>(), // -> R0
-            stack_bottom.add(1).cast::<u32>(), // -> R1
-            stack_bottom.add(2).cast::<u32>(), // -> R2
-            stack_bottom.add(3).cast::<u32>(), // -> R3
-        );
+        // # Safety
+        //
+        // We ensured there is `SVC_FRAME_SIZE` of memory at `stack_bottom` so
+        // we can create pointers to u32s in that memory.
+        let (ptr_apsr, ptr_pc, ptr_lr, ptr_r3, ptr_r2, ptr_r1, ptr_r0) = unsafe {
+            (
+                stack_bottom.add(7),
+                stack_bottom.add(6),
+                stack_bottom.add(5),
+                stack_bottom.add(3),
+                stack_bottom.add(2),
+                stack_bottom.add(1),
+                stack_bottom.add(0),
+            )
+        };
+
+        // # Safety
+        //
+        // The pointers are valid memory in the process's memory space and
+        // well-aligned to a u32.
+        unsafe {
+            ptr::write(ptr_apsr, state.psr); // ................. -> APSR
+            ptr::write(ptr_pc, callback.pc.addr() | 1); // ...... -> PC
+            ptr::write(ptr_lr, state.yield_pc | 1); // .......... -> LR
+
+            // Write upcall arguments to the proper stack locations.
+            kernel::utilities::arch_helpers::encode_upcall_trd104_ptr(
+                &callback,
+                ptr_r0.cast::<u32>(), // -> R0
+                ptr_r1.cast::<u32>(), // -> R1
+                ptr_r2.cast::<u32>(), // -> R2
+                ptr_r3.cast::<u32>(), // -> R3
+            );
+        }
 
         Ok(())
     }
@@ -413,7 +445,8 @@ impl<A: CortexMVariant> kernel::syscall::UserspaceKernelBoundary for SysCall<A> 
         app_brk: *const u8,
         state: &mut CortexMStoredState,
     ) -> (kernel::syscall::ContextSwitchReason, Option<*const u8>) {
-        let new_stack_pointer = A::switch_to_user(state.psp as *const usize, &mut state.regs);
+        let new_stack_pointer =
+            unsafe { A::switch_to_user(state.psp as *const usize, &mut state.regs) };
 
         // We need to keep track of the current stack pointer.
         state.psp = new_stack_pointer as usize;

--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -482,12 +482,20 @@ impl<A: CortexMVariant> kernel::syscall::UserspaceKernelBoundary for SysCall<A> 
             // u16).
             let pcptr: *const u16 = state.yield_pc as *const u16;
 
-            // Get a pointer to the instruction before the PC value.
-            let pcprev_ptr = unsafe { pcptr.sub(1) };
+            // SAFETY: ARM architecture specifications dictate that the PC we
+            // see is one past the instruction that caused the SVC entry, so
+            // decrementing the PC as a pointer and reading that memory will be
+            // valid per the architecture rules.
+            let svc_instr = unsafe {
+                // The svc instruction is the last instruction before the PC, and
+                // should be 16 bits. Get a pointer to the instruction before the PC
+                // value.
+                let pcprev_ptr = pcptr.sub(1);
+                // Read the instruction by with the PC-minus-one pointer.
+                ptr::read(pcprev_ptr)
+            };
 
-            // The svc instruction is the last instruction before the PC, and should be 16 bits.
-            // Read it by offsetting the PC.
-            let svc_instr = unsafe { ptr::read(pcprev_ptr) };
+            // The SVC num is the lower 8 bits of the instruction.
             let svc_num = (svc_instr & 0xff) as u8;
 
             // Use the helper function to convert these raw values into a Tock

--- a/arch/cortex-m/src/systick.rs
+++ b/arch/cortex-m/src/systick.rs
@@ -92,9 +92,10 @@ impl SysTick {
     ///   if the SysTick is driven by the CPU clock, it is simply the CPU
     ///   speed.
     pub fn new_with_calibration(clock_speed: u32) -> SysTick {
-        let res = SysTick::new();
-        res.hertz.set(clock_speed);
-        res
+        Self {
+            hertz: Cell::new(clock_speed),
+            external_clock: false,
+        }
     }
 
     /// Initialize the `SysTick` with an explicit clock speed and external

--- a/arch/cortex-m0/Cargo.toml
+++ b/arch/cortex-m0/Cargo.toml
@@ -6,7 +6,7 @@
 name = "cortexm0"
 version.workspace = true
 authors.workspace = true
-edition.workspace = true
+edition = "2024"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/arch/cortex-m0/src/lib.rs
+++ b/arch/cortex-m0/src/lib.rs
@@ -269,7 +269,7 @@ unsafe extern "C" fn svc_handler() {
     // CONTROL writes must be followed by ISB
     // https://developer.arm.com/documentation/dui0662/b/The-Cortex-M0--Processor/Programmers-model/Core-registers
     isb
-    ldr r0, =SYSCALL_FIRED
+    ldr r0, ={syscall_fired}
     movs r1, #1
     str r1, [r0, #0]
     ldr r1, 200f
@@ -280,7 +280,8 @@ unsafe extern "C" fn svc_handler() {
     .word 0xFFFFFFF9
 300: // EXC_RETURN_PSP
     .word 0xFFFFFFFD
-        "
+        ",
+        syscall_fired = sym cortexm::syscall::SYSCALL_FIRED,
     );
 }
 
@@ -340,7 +341,7 @@ unsafe extern "C" fn hard_fault_handler() {
 400: // _hardfault_app
     // Otherwise, store that a hardfault occurred in an app, store some CPU
     // state and finally return to the kernel stack:
-    ldr r0, =APP_HARD_FAULT
+    ldr r0, ={app_hard_fault}
     movs r1, #1 // Fault
     str r1, [r0, #0]
 
@@ -355,7 +356,7 @@ unsafe extern "C" fn hard_fault_handler() {
     // ARMv6-M however has no _privileged_ mode.
 
     // Read the SCB registers.
-    ldr r0, =SCB_REGISTERS
+    ldr r0, ={scb_registers}
     ldr r1, =0xE000ED14
     ldr r2, [r1, #0] // CCR
     str r2, [r0, #0]
@@ -385,6 +386,8 @@ unsafe extern "C" fn hard_fault_handler() {
     .word 0xFFFFFFF9
         ",
         kernel_hard_fault_handler = sym hard_fault_handler_kernel,
+        app_hard_fault = sym cortexm::syscall::APP_HARD_FAULT,
+        scb_registers = sym cortexm::syscall::SCB_REGISTERS,
     );
 }
 

--- a/arch/cortex-m0/src/lib.rs
+++ b/arch/cortex-m0/src/lib.rs
@@ -32,15 +32,21 @@ struct HardFaultStackedRegisters {
 /// Handle a hard fault that occurred in the kernel. This function is invoked
 /// by the naked hard_fault_handler function.
 unsafe extern "C" fn hard_fault_handler_kernel(faulting_stack: *mut u32) -> ! {
-    let hardfault_stacked_registers = HardFaultStackedRegisters {
-        r0: *faulting_stack.add(0),
-        r1: *faulting_stack.add(1),
-        r2: *faulting_stack.add(2),
-        r3: *faulting_stack.add(3),
-        r12: *faulting_stack.add(4),
-        lr: *faulting_stack.add(5),
-        pc: *faulting_stack.add(6),
-        xpsr: *faulting_stack.add(7),
+    // # Safety
+    //
+    // The hardware pushed the register and status values to the stack so
+    // we access them from the stack.
+    let hardfault_stacked_registers = unsafe {
+        HardFaultStackedRegisters {
+            r0: *faulting_stack.add(0),
+            r1: *faulting_stack.add(1),
+            r2: *faulting_stack.add(2),
+            r3: *faulting_stack.add(3),
+            r12: *faulting_stack.add(4),
+            lr: *faulting_stack.add(5),
+            pc: *faulting_stack.add(6),
+            xpsr: *faulting_stack.add(7),
+        }
     };
 
     panic!(
@@ -71,9 +77,28 @@ unsafe extern "C" fn generic_isr() {
     unimplemented!()
 }
 
+/// All ISRs are caught by this handler which disables the NVIC and switches to the kernel.
+///
+/// # Safety
+///
+/// - INPUTS:
+///   - This reads the `lr`, which is part of the calling convention.
+/// - OUTPUTS:
+///   - This writes to `r0`, a caller-saved register.
+///   - This writes to `r1`, a caller-saved register.
+///   - This writes to `r2`, a caller-saved register.
+///   - This writes to `r3`, a caller-saved register.
+///   - This writes to `r4`, a callee-saved register, but it is pushed and
+///     popped to/from the stack to return to its original value.
+///   - This writes to `r5`, a callee-saved register, but it is pushed and
+///     popped to/from the stack to return to its original value.
+///   - This writes to `r6`, a callee-saved register, but it is pushed and
+///     popped to/from the stack to return to its original value.
+///   - This writes to `r7`, a callee-saved register, but it is pushed and
+///     popped to/from the stack to return to its original value.
+/// - This does not fall-through, it branches at the end.
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 #[unsafe(naked)]
-/// All ISRs are caught by this handler which disables the NVIC and switches to the kernel.
 unsafe extern "C" fn generic_isr() {
     use core::arch::naked_asm;
     naked_asm!(
@@ -174,6 +199,14 @@ unsafe extern "C" fn systick_handler() {
 /// interrupt has occurred, but is slightly more efficient than the
 /// `generic_isr` handler on account of not needing to mark the interrupt as
 /// pending.
+///
+/// # Safety
+///
+/// - INPUTS:
+///   - This reads the `lr`, which is part of the calling convention.
+/// - OUTPUTS:
+///   - This writes to `r0`, a caller-saved register.
+/// - This does not fall-through, it branches at the end.
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 #[unsafe(naked)]
 unsafe extern "C" fn systick_handler() {
@@ -205,6 +238,14 @@ unsafe extern "C" fn svc_handler() {
     unimplemented!()
 }
 
+/// # Safety
+///
+/// - INPUTS:
+///   - This reads the `lr`, which is part of the calling convention.
+/// - OUTPUTS:
+///   - This writes to `r0`, a caller-saved register.
+///   - This writes to `r1`, a caller-saved register.
+/// - This does not fall-through, it branches in both branches.
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 #[unsafe(naked)]
 unsafe extern "C" fn svc_handler() {
@@ -249,6 +290,16 @@ unsafe extern "C" fn hard_fault_handler() {
     unimplemented!()
 }
 
+/// # Safety
+///
+/// - INPUTS:
+///   - This reads the `lr`, which is part of the calling convention.
+/// - OUTPUTS:
+///   - This writes to `r0`, a caller-saved register.
+///   - This writes to `r1`, a caller-saved register.
+///   - This writes to `r2`, a caller-saved register.
+///   - This writes to `r3`, a caller-saved register.
+/// - This does not fall-through, it branches at the end.
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 #[unsafe(naked)]
 unsafe extern "C" fn hard_fault_handler() {
@@ -363,8 +414,40 @@ impl cortexm::CortexMVariant for CortexM0 {
         process_regs: &mut [usize; 8],
     ) -> *const usize {
         use core::arch::asm;
-        asm!(
-            "
+        unsafe {
+            // # Safety
+            //
+            // - INPUTS:
+            //   - This uses `r0`, which is specified as an input from `user_stack`.
+            //   - This uses `r1`, which is specified as an input from `process_regs`.
+            // - CALLER-SAVED registers:
+            //   - This uses `r6`, which is replaced before exiting asm.
+            //   - This uses `r7`, which is replaced before exiting asm.
+            //   - This uses `r9`, which is replaced before exiting asm.
+            // - OUTPUTS:
+            //   - This writes `r0` which is specified as an output.
+            //   - This writes `r1` which is NOT specified as an output. However,
+            //     the original value is restored before exiting the asm block.
+            //   - This writes `r2` which is specified as an output.
+            //   - This writes `r3` which is specified as an output.
+            //   - This writes `r4` which is specified as an output.
+            //   - This writes `r5` which is specified as an output.
+            //   - This writes `r8` which is specified as an output.
+            //   - This writes `r10` which is specified as an output.
+            //   - This writes `r11` which is specified as an output.
+            //   - This writes `r12` which is specified as an output.
+            // - Options set:
+            // - Options not set:
+            //   - nomem: We read and write memory.
+            //   - nostack: We use the stack.
+            //   - preserves_flags: This likely change flags in userspace.
+            //   - pure: not required
+            //   - readonly: implied by nomem
+            //   - noreturn: we do fall-through
+            //   - att_syntax: not on arm
+            //   - raw: not required
+            asm!(
+                "
     // Rust `asm!()` macro (as of May 2021) will not let us mark r6, r7 and r9
     // as clobbers. r6 and r9 is used internally by LLVM, and r7 is used for
     // the frame pointer. However, in the process of restoring and saving the
@@ -415,18 +498,19 @@ impl cortexm::CortexMVariant for CortexM0 {
     mov r6, r2
     mov r7, r3
     mov r9, r12
-            ",
-            inout("r0") user_stack,
-            in("r1") process_regs,
-            out("r2") _,
-            out("r3") _,
-            out("r4") _,
-            out("r5") _,
-            out("r8") _,
-            out("r10") _,
-            out("r11") _,
-            out("r12") _,
-        );
+                ",
+                inout("r0") user_stack,
+                in("r1") process_regs,
+                out("r2") _,
+                out("r3") _,
+                out("r4") _,
+                out("r5") _,
+                out("r8") _,
+                out("r10") _,
+                out("r11") _,
+                out("r12") _,
+            );
+        }
 
         user_stack
     }

--- a/arch/cortex-m0p/Cargo.toml
+++ b/arch/cortex-m0p/Cargo.toml
@@ -6,7 +6,7 @@
 name = "cortexm0p"
 version.workspace = true
 authors.workspace = true
-edition.workspace = true
+edition = "2024"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/arch/cortex-m0p/src/lib.rs
+++ b/arch/cortex-m0p/src/lib.rs
@@ -17,7 +17,7 @@ pub mod mpu {
         unsafe { StaticRef::new(0xE000ED90 as *const cortexm::mpu::MpuRegisters) };
 
     pub unsafe fn new() -> MPU {
-        MPU::new(MPU_BASE_ADDRESS)
+        unsafe { MPU::new(MPU_BASE_ADDRESS) }
     }
 }
 

--- a/arch/cortex-m0p/src/lib.rs
+++ b/arch/cortex-m0p/src/lib.rs
@@ -93,7 +93,7 @@ impl cortexm::CortexMVariant for CortexM0P {
         user_stack: *const usize,
         process_regs: &mut [usize; 8],
     ) -> *const usize {
-        CortexM0::switch_to_user(user_stack, process_regs)
+        unsafe { CortexM0::switch_to_user(user_stack, process_regs) }
     }
 
     #[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]

--- a/arch/cortex-m0p/src/lib.rs
+++ b/arch/cortex-m0p/src/lib.rs
@@ -41,6 +41,14 @@ pub unsafe extern "C" fn svc_handler() {
     unimplemented!()
 }
 
+/// # Safety
+///
+/// - INPUTS:
+///   - This reads the `lr`, which is part of the calling convention.
+/// - OUTPUTS:
+///   - This writes to `r0`, a caller-saved register.
+///   - This writes to `r1`, a caller-saved register.
+/// - This does not fall-through, it branches in both branches.
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 #[unsafe(naked)]
 pub unsafe extern "C" fn svc_handler() {

--- a/arch/cortex-m0p/src/lib.rs
+++ b/arch/cortex-m0p/src/lib.rs
@@ -59,7 +59,7 @@ pub unsafe extern "C" fn svc_handler() {
     bx r1
 
 300: // to_kernel
-    ldr r0, =SYSCALL_FIRED
+    ldr r0, ={syscall_fired}
     movs r1, #1
     str r1, [r0, #0]
     // Set thread mode to privileged as we switch back to the kernel.
@@ -73,7 +73,8 @@ pub unsafe extern "C" fn svc_handler() {
     .word 0xFFFFFFF9
 200: // EXC_RETURN_PSP
     .word 0xFFFFFFFD
-        "
+        ",
+        syscall_fired = sym cortexm::syscall::SYSCALL_FIRED,
     );
 }
 

--- a/arch/cortex-m3/Cargo.toml
+++ b/arch/cortex-m3/Cargo.toml
@@ -6,7 +6,7 @@
 name = "cortexm3"
 version.workspace = true
 authors.workspace = true
-edition.workspace = true
+edition = "2024"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/arch/cortex-m3/src/lib.rs
+++ b/arch/cortex-m3/src/lib.rs
@@ -17,7 +17,7 @@ pub mod mpu {
         unsafe { StaticRef::new(0xE000ED90 as *const cortexm::mpu::MpuRegisters) };
 
     pub unsafe fn new() -> MPU {
-        MPU::new(MPU_BASE_ADDRESS)
+        unsafe { MPU::new(MPU_BASE_ADDRESS) }
     }
 }
 

--- a/arch/cortex-m3/src/lib.rs
+++ b/arch/cortex-m3/src/lib.rs
@@ -47,7 +47,7 @@ impl cortexm::CortexMVariant for CortexM3 {
         user_stack: *const usize,
         process_regs: &mut [usize; 8],
     ) -> *const usize {
-        cortexv7m::switch_to_user_arm_v7m(user_stack, process_regs)
+        unsafe { cortexv7m::switch_to_user_arm_v7m(user_stack, process_regs) }
     }
 
     #[cfg(not(all(target_arch = "arm", target_os = "none")))]

--- a/arch/cortex-m33/Cargo.toml
+++ b/arch/cortex-m33/Cargo.toml
@@ -6,7 +6,7 @@
 name = "cortexm33"
 version.workspace = true
 authors.workspace = true
-edition.workspace = true
+edition = "2024"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/arch/cortex-m33/src/lib.rs
+++ b/arch/cortex-m33/src/lib.rs
@@ -52,7 +52,7 @@ impl cortexm::CortexMVariant for CortexM33 {
         user_stack: *const usize,
         process_regs: &mut [usize; 8],
     ) -> *const usize {
-        cortexv7m::switch_to_user_arm_v7m(user_stack, process_regs)
+        unsafe { cortexv7m::switch_to_user_arm_v7m(user_stack, process_regs) }
     }
 
     #[cfg(not(all(target_arch = "arm", target_os = "none")))]

--- a/arch/cortex-m33/src/lib.rs
+++ b/arch/cortex-m33/src/lib.rs
@@ -21,7 +21,7 @@ pub mod mpu {
         unsafe { StaticRef::new(0xE000ED90 as *const crate::mpu_v8m::MpuRegisters) };
 
     pub unsafe fn new<const NUM_REGIONS: usize>() -> mpu_v8m::MPU<NUM_REGIONS> {
-        mpu_v8m::MPU::new(MPU_BASE_ADDRESS)
+        unsafe { mpu_v8m::MPU::new(MPU_BASE_ADDRESS) }
     }
 }
 

--- a/arch/cortex-m4/Cargo.toml
+++ b/arch/cortex-m4/Cargo.toml
@@ -6,7 +6,7 @@
 name = "cortexm4"
 version.workspace = true
 authors.workspace = true
-edition.workspace = true
+edition = "2024"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -17,7 +17,7 @@ pub mod mpu {
         unsafe { StaticRef::new(0xE000ED90 as *const cortexm::mpu::MpuRegisters) };
 
     pub unsafe fn new() -> MPU {
-        MPU::new(MPU_BASE_ADDRESS)
+        unsafe { MPU::new(MPU_BASE_ADDRESS) }
     }
 }
 

--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -47,7 +47,7 @@ impl cortexm::CortexMVariant for CortexM4 {
         user_stack: *const usize,
         process_regs: &mut [usize; 8],
     ) -> *const usize {
-        cortexv7m::switch_to_user_arm_v7m(user_stack, process_regs)
+        unsafe { cortexv7m::switch_to_user_arm_v7m(user_stack, process_regs) }
     }
 
     #[cfg(not(all(target_arch = "arm", target_os = "none")))]

--- a/arch/cortex-m4f/Cargo.toml
+++ b/arch/cortex-m4f/Cargo.toml
@@ -6,7 +6,7 @@
 name = "cortexm4f"
 version.workspace = true
 authors.workspace = true
-edition.workspace = true
+edition = "2024"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/arch/cortex-m4f/src/lib.rs
+++ b/arch/cortex-m4f/src/lib.rs
@@ -17,7 +17,7 @@ pub mod mpu {
         unsafe { StaticRef::new(0xE000ED90 as *const cortexm::mpu::MpuRegisters) };
 
     pub unsafe fn new() -> MPU {
-        MPU::new(MPU_BASE_ADDRESS)
+        unsafe { MPU::new(MPU_BASE_ADDRESS) }
     }
 }
 

--- a/arch/cortex-m4f/src/lib.rs
+++ b/arch/cortex-m4f/src/lib.rs
@@ -48,7 +48,7 @@ impl cortexm::CortexMVariant for CortexM4F {
         user_stack: *const usize,
         process_regs: &mut [usize; 8],
     ) -> *const usize {
-        cortexv7m::switch_to_user_arm_v7m(user_stack, process_regs)
+        unsafe { cortexv7m::switch_to_user_arm_v7m(user_stack, process_regs) }
     }
 
     #[cfg(not(all(target_arch = "arm", target_os = "none")))]

--- a/arch/cortex-m7/Cargo.toml
+++ b/arch/cortex-m7/Cargo.toml
@@ -6,7 +6,7 @@
 name = "cortexm7"
 version.workspace = true
 authors.workspace = true
-edition.workspace = true
+edition = "2024"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/arch/cortex-m7/src/lib.rs
+++ b/arch/cortex-m7/src/lib.rs
@@ -17,7 +17,7 @@ pub mod mpu {
         unsafe { StaticRef::new(0xE000ED90 as *const cortexm::mpu::MpuRegisters) };
 
     pub unsafe fn new() -> MPU {
-        MPU::new(MPU_BASE_ADDRESS)
+        unsafe { MPU::new(MPU_BASE_ADDRESS) }
     }
 }
 

--- a/arch/cortex-v7m/Cargo.toml
+++ b/arch/cortex-v7m/Cargo.toml
@@ -6,7 +6,7 @@
 name = "cortexv7m"
 version.workspace = true
 authors.workspace = true
-edition.workspace = true
+edition = "2024"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/arch/cortex-v7m/Cargo.toml
+++ b/arch/cortex-v7m/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2024"
 
 [dependencies]
 kernel = { path = "../../kernel" }
+cortexm = { path = "../cortex-m" }
 
 [lints]
 workspace = true

--- a/arch/cortex-v7m/src/lib.rs
+++ b/arch/cortex-v7m/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 
 // These constants are defined in the linker script.
-extern "C" {
+unsafe extern "C" {
     static _estack: u8;
     static _sstack: u8;
 }

--- a/arch/cortex-v7m/src/lib.rs
+++ b/arch/cortex-v7m/src/lib.rs
@@ -16,6 +16,14 @@ unsafe extern "C" {
 ///
 /// For documentation of this function, please see
 /// `CortexMVariant::SYSTICK_HANDLER`.
+///
+/// # Safety
+///
+/// - INPUTS:
+///   - This reads the `lr`, which is part of the calling convention.
+/// - OUTPUTS:
+///   - This writes to `r0`, a caller-saved register.
+/// - This does not fall-through, it branches at the end.
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 #[unsafe(naked)]
 pub unsafe extern "C" fn systick_handler_arm_v7m() {
@@ -53,6 +61,16 @@ pub unsafe extern "C" fn systick_handler_arm_v7m() {
 ///
 /// For documentation of this function, please see
 /// `CortexMVariant::SVC_HANDLER`.
+///
+/// # Safety
+///
+/// - INPUTS:
+///   - This reads the `lr`, which is part of the calling convention.
+/// - OUTPUTS:
+///   - This writes to `r0`, a caller-saved register.
+///   - This writes to `r2`, a caller-saved register.
+///   - This writes to `r3`, a caller-saved register.
+/// - This does not fall-through, it branches in both arms of the branch.
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 #[unsafe(naked)]
 pub unsafe extern "C" fn svc_handler_arm_v7m() {
@@ -129,6 +147,16 @@ pub unsafe extern "C" fn svc_handler_arm_v7m() {
 /// Generic interrupt handler for ARMv7-M instruction sets.
 ///
 /// For documentation of this function, see `CortexMVariant::GENERIC_ISR`.
+///
+/// # Safety
+///
+/// - INPUTS:
+///   - This reads the `lr`, which is part of the calling convention.
+/// - OUTPUTS:
+///   - This writes to `r0`, a caller-saved register.
+///   - This writes to `r2`, a caller-saved register.
+///   - This writes to `r3`, a caller-saved register.
+/// - This does not fall-through, it branches at the end.
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 #[unsafe(naked)]
 pub unsafe extern "C" fn generic_isr_arm_v7m() {
@@ -214,8 +242,38 @@ pub unsafe fn switch_to_user_arm_v7m(
     process_regs: &mut [usize; 8],
 ) -> *const usize {
     use core::arch::asm;
-    asm!(
-        "
+    // # Safety
+    //
+    // - INPUTS:
+    //   - This uses `r0`, which is specified as an input from `user_stack`.
+    //   - This uses `r1`, which is specified as an input from `process_regs`.
+    // - CALLER-SAVED registers:
+    //   - This uses `r6`, which is replaced before exiting asm.
+    //   - This uses `r7`, which is replaced before exiting asm.
+    //   - This uses `r9`, which is replaced before exiting asm.
+    // - OUTPUTS:
+    //   - This writes `r0` which is specified as an output.
+    //   - This writes `r2` which is specified as an output.
+    //   - This writes `r3` which is specified as an output.
+    //   - This writes `r4` which is specified as an output.
+    //   - This writes `r5` which is specified as an output.
+    //   - This writes `r8` which is specified as an output.
+    //   - This writes `r10` which is specified as an output.
+    //   - This writes `r11` which is specified as an output.
+    //   - This writes `r12` which is specified as an output.
+    // - Options set:
+    // - Options not set:
+    //   - nomem: We read and write memory.
+    //   - nostack: We use the stack.
+    //   - preserves_flags: This likely change flags in userspace.
+    //   - pure: not required
+    //   - readonly: implied by nomem
+    //   - noreturn: we do fall-through
+    //   - att_syntax: not on arm
+    //   - raw: not required
+    unsafe {
+        asm!(
+            "
     // Rust `asm!()` macro (as of May 2021) will not let us mark r6, r7 and r9
     // as clobbers. r6 and r9 is used internally by LLVM, and r7 is used for
     // the frame pointer. However, in the process of restoring and saving the
@@ -260,20 +318,21 @@ pub unsafe fn switch_to_user_arm_v7m(
     mov r6, r2                        // r6 = r2
     mov r7, r3                        // r7 = r3
     mov r9, r12                       // r9 = r12
-        ",
-        inout("r0") user_stack,
-        in("r1") process_regs,
-        out("r2") _,
-        out("r3") _,
-        out("r4") _,
-        out("r5") _,
-        out("r8") _,
-        out("r10") _,
-        out("r11") _,
-        out("r12") _,
-    );
+            ",
+            inout("r0") user_stack,
+            in("r1") process_regs,
+            out("r2") _,
+            out("r3") _,
+            out("r4") _,
+            out("r5") _,
+            out("r8") _,
+            out("r10") _,
+            out("r11") _,
+            out("r12") _,
+        );
 
-    user_stack
+        user_stack
+    }
 }
 
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
@@ -431,6 +490,17 @@ unsafe extern "C" fn hard_fault_handler_arm_v7m_kernel(
 ///
 /// For documentation of this function, please see
 /// `CortexMVariant::HARD_FAULT_HANDLER_HANDLER`.
+///
+/// # Safety
+///
+/// - INPUTS:
+///   - This reads the `lr`, which is part of the calling convention.
+/// - OUTPUTS:
+///   - This writes to `r0`, a caller-saved register.
+///   - This writes to `r1`, a caller-saved register.
+///   - This writes to `r2`, a caller-saved register.
+///   - This writes to `r3`, a caller-saved register.
+/// - This does not fall-through, it branches at the end.
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 #[unsafe(naked)]
 pub unsafe extern "C" fn hard_fault_handler_arm_v7m() {

--- a/arch/cortex-v7m/src/lib.rs
+++ b/arch/cortex-v7m/src/lib.rs
@@ -6,19 +6,6 @@
 
 #![no_std]
 
-// These constants are defined in the linker script.
-//
-// # Safety
-//
-// All symbols must have the correct signatures. These symbols are values in the
-// program and we conservatively treat them as single bytes. In practice we do
-// not care or use the value of any of these static `u8`s. We are only
-// interested in the address of these static `u8`s.
-unsafe extern "C" {
-    static _estack: u8;
-    static _sstack: u8;
-}
-
 /// ARMv7-M systick handler function.
 ///
 /// For documentation of this function, please see
@@ -387,6 +374,24 @@ unsafe extern "C" fn hard_fault_handler_arm_v7m_kernel(
 
         let mode_str = "Kernel";
 
+        // Extract symbols from the linker script
+        let (estack, sstack) = {
+            // # Safety
+            //
+            // Linker script symbols are value-less entities, a concept that
+            // does not map onto any actual Rust type (as of July 2026). The
+            // only valid operation on these "types" is taking their address.
+            // We scope the declaration to a dedicated block here to ensure no
+            // invalid access attempts.
+            unsafe extern "C" {
+                static _estack: u8;
+                static _sstack: u8;
+            }
+            let estack: u32 = core::ptr::addr_of!(_estack) as u32;
+            let sstack: u32 = core::ptr::addr_of!(_sstack) as u32;
+            (estack, sstack)
+        };
+
         // Read system status registers.
         //
         // # Safety
@@ -491,8 +496,8 @@ unsafe extern "C" fn hard_fault_handler_arm_v7m_kernel(
             exception_number,
             ipsr_isr_number_to_str(exception_number),
             faulting_stack as u32,
-            core::ptr::addr_of!(_estack) as u32,
-            core::ptr::addr_of!(_sstack) as u32,
+            estack,
+            sstack,
             shcsr,
             cfsr,
             hfsr,
@@ -541,6 +546,21 @@ unsafe extern "C" fn hard_fault_handler_arm_v7m_kernel(
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 #[unsafe(naked)]
 pub unsafe extern "C" fn hard_fault_handler_arm_v7m() {
+    // These constants are defined in the linker script.
+    //
+    // # Safety
+    //
+    // Linker script symbols are value-less entities, a concept that does not
+    // map onto any actual Rust type (as of July 2026).  This method only uses
+    // these declarations to pass their address to the assembly. By declaring
+    // these variables within this naked fn, we ensure that no Rust code
+    // attempts to access them, and assert that the assembly will take only the
+    // address, which is well-defined.
+    unsafe extern "C" {
+        static _estack: u8;
+        static _sstack: u8;
+    }
+
     use core::arch::naked_asm;
     // First need to determine if this a kernel fault or a userspace fault, and store
     // the unmodified stack pointer. Place these values in registers, then call

--- a/arch/cortex-v7m/src/lib.rs
+++ b/arch/cortex-v7m/src/lib.rs
@@ -347,22 +347,51 @@ unsafe extern "C" fn hard_fault_handler_arm_v7m_kernel(
         panic!("kernel stack overflow");
     } else {
         // Show the normal kernel hardfault message.
-        let stacked_r0: u32 = *faulting_stack.add(0);
-        let stacked_r1: u32 = *faulting_stack.add(1);
-        let stacked_r2: u32 = *faulting_stack.add(2);
-        let stacked_r3: u32 = *faulting_stack.add(3);
-        let stacked_r12: u32 = *faulting_stack.add(4);
-        let stacked_lr: u32 = *faulting_stack.add(5);
-        let stacked_pc: u32 = *faulting_stack.add(6);
-        let stacked_xpsr: u32 = *faulting_stack.add(7);
+
+        // Get the stacked copies of caller-saved registers and other state.
+        //
+        // # Safety
+        //
+        // Because we verified there was not a stack overflow when the hardware
+        // pushed these values to the stack, these are valid pointers to
+        // allocated memory.
+        let (
+            stacked_r0,
+            stacked_r1,
+            stacked_r2,
+            stacked_r3,
+            stacked_r12,
+            stacked_lr,
+            stacked_pc,
+            stacked_xpsr,
+        ) = unsafe {
+            let r0: u32 = *faulting_stack.add(0);
+            let r1: u32 = *faulting_stack.add(1);
+            let r2: u32 = *faulting_stack.add(2);
+            let r3: u32 = *faulting_stack.add(3);
+            let r12: u32 = *faulting_stack.add(4);
+            let lr: u32 = *faulting_stack.add(5);
+            let pc: u32 = *faulting_stack.add(6);
+            let xpsr: u32 = *faulting_stack.add(7);
+
+            (r0, r1, r2, r3, r12, lr, pc, xpsr)
+        };
 
         let mode_str = "Kernel";
 
-        let shcsr: u32 = core::ptr::read_volatile(0xE000ED24 as *const u32);
-        let cfsr: u32 = core::ptr::read_volatile(0xE000ED28 as *const u32);
-        let hfsr: u32 = core::ptr::read_volatile(0xE000ED2C as *const u32);
-        let mmfar: u32 = core::ptr::read_volatile(0xE000ED34 as *const u32);
-        let bfar: u32 = core::ptr::read_volatile(0xE000ED38 as *const u32);
+        // Read system status registers.
+        //
+        // # Safety
+        //
+        // These are the valid locations of 32-bit registers.
+        let (shcsr, cfsr, hfsr, mmfar, bfar) = unsafe {
+            let shcsr: u32 = core::ptr::read_volatile(0xE000ED24 as *const u32);
+            let cfsr: u32 = core::ptr::read_volatile(0xE000ED28 as *const u32);
+            let hfsr: u32 = core::ptr::read_volatile(0xE000ED2C as *const u32);
+            let mmfar: u32 = core::ptr::read_volatile(0xE000ED34 as *const u32);
+            let bfar: u32 = core::ptr::read_volatile(0xE000ED38 as *const u32);
+            (shcsr, cfsr, hfsr, mmfar, bfar)
+        };
 
         let iaccviol = (cfsr & 0x01) == 0x01;
         let daccviol = (cfsr & 0x02) == 0x02;

--- a/arch/cortex-v7m/src/lib.rs
+++ b/arch/cortex-v7m/src/lib.rs
@@ -121,7 +121,7 @@ pub unsafe extern "C" fn svc_handler_arm_v7m() {
     // `SYSCALL_FIRED` which is stored in the syscall file.
     // `UserspaceKernelBoundary` will use this variable to decide why the app
     // stopped executing.
-    ldr r0, =SYSCALL_FIRED            // r0 = &SYSCALL_FIRED
+    ldr r0, ={syscall_fired}          // r0 = &SYSCALL_FIRED
     mov r1, #1                        // r1 = 1
     str r1, [r0]                      // *SYSCALL_FIRED = 1
 
@@ -147,7 +147,8 @@ pub unsafe extern "C" fn svc_handler_arm_v7m() {
 
     // Return to the kernel.
     bx lr
-        "
+        ",
+        syscall_fired = sym cortexm::syscall::SYSCALL_FIRED,
     );
 }
 
@@ -588,7 +589,7 @@ pub unsafe extern "C" fn hard_fault_handler_arm_v7m() {
     bne {kernel_hard_fault_handler} // branch to kernel hard fault handler
     // Otherwise, the hard fault occurred in userspace. In this case, read
     // the relevant SCB registers:
-    ldr r0, =SCB_REGISTERS    // Global variable address
+    ldr r0, ={scb_registers}  // Global variable address
     ldr r1, =0xE000ED14       // SCB CCR register address
     ldr r2, [r1, #0]          // CCR
     str r2, [r0, #0]
@@ -601,7 +602,7 @@ pub unsafe extern "C" fn hard_fault_handler_arm_v7m() {
     ldr r2, [r1, #36]         // BFAR
     str r2, [r0, #16]
 
-    ldr r0, =APP_HARD_FAULT  // Global variable address
+    ldr r0, ={app_hard_fault}// Global variable address
     mov r1, #1               // r1 = 1
     str r1, [r0, #0]         // APP_HARD_FAULT = 1
 
@@ -621,6 +622,8 @@ pub unsafe extern "C" fn hard_fault_handler_arm_v7m() {
         ",
         estack = sym _estack,
         kernel_hard_fault_handler = sym hard_fault_handler_arm_v7m_kernel,
+        app_hard_fault = sym cortexm::syscall::APP_HARD_FAULT,
+        scb_registers = sym cortexm::syscall::SCB_REGISTERS,
     );
 }
 

--- a/arch/cortex-v7m/src/lib.rs
+++ b/arch/cortex-v7m/src/lib.rs
@@ -7,6 +7,13 @@
 #![no_std]
 
 // These constants are defined in the linker script.
+//
+// # Safety
+//
+// All symbols must have the correct signatures. These symbols are values in the
+// program and we conservatively treat them as single bytes. In practice we do
+// not care or use the value of any of these static `u8`s. We are only
+// interested in the address of these static `u8`s.
 unsafe extern "C" {
     static _estack: u8;
     static _sstack: u8;


### PR DESCRIPTION
### Pull Request Overview

With various changes to how cortex-m functions use unsafe, we are pretty close to being able to update the cortex-m crates to Rust 2024.

This changes all crates to Rust 2024.

It adds documentation for the various unsafe operations within the architecture functions.

MPU construction is unsafe, and this propagates that unsafe to the call site.

Mangle and extern are unsafe.

This also fixes the SCB_REGISTERS type.

#### `asm!()` documentation

I don't think we've ever written safety documentation for asm before, so I made up a format. For asm!(), I did something like:

```rust
    // # Safety
    //
    // - INPUTS: This does not use the existing value of any registers.
    // - OUTPUTS: This only writes `r0` which is marked as an output.
    // - Options set:
    //   - nomem: We do not read or write memory.
    //   - nostack: This does not use the stack.
    //   - preserves_flags: This does not change flags.
    // - Options not set:
    //   - pure: not required
    //   - readonly: implied by nomem
    //   - noreturn: we do fall-through
    //   - att_syntax: not on arm
    //   - raw: not required
```

For naked_asm, which is not marked unsafe, I documented the function something like:

```rust
/// # Safety
///
/// - INPUTS:
///   - This reads the `lr`, which is part of the calling convention.
/// - OUTPUTS:
///   - This writes to `r0`, a caller-saved register.
///   - This writes to `r2`, a caller-saved register.
///   - This writes to `r3`, a caller-saved register.
/// - This does not fall-through, it branches at the end.
```
And hey, I found a bug that has been there for 6 years because we were violating the `naked_asm!()` rules. #4899

### Testing Strategy

Travis. There shouldn't be any functional changes in this PR.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
