### PR TITLE
kernel: Update how Yield and Yield variants are constructed

### DIFF
--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -765,11 +765,7 @@ impl Kernel {
         // immediately (assuming the process has not already exhausted its
         // timeslice) allowing the process to decide how to handle the error.
         match syscall {
-            Syscall::Yield {
-                which: _,
-                param_a: _,
-                param_b: _,
-            } => {} // Yield is not filterable.
+            Syscall::Yield { yield_type: _ } => {} // Yield is not filterable.
             Syscall::Exit {
                 which: _,
                 completion_code: _,
@@ -813,16 +809,12 @@ impl Kernel {
                 }
                 process.set_syscall_return_value(rval);
             }
-            Syscall::Yield {
-                which,
-                param_a,
-                param_b,
-            } => {
+            Syscall::Yield { yield_type } => {
                 if config::CONFIG.trace_syscalls {
-                    debug!("[{:?}] yield. which: {}", process.processid(), which);
+                    debug!("[{:?}] yield. which: {}", process.processid(), yield_type);
                 }
-                match which.try_into() {
-                    Ok(YieldCall::NoWait) => {
+                match yield_type {
+                    YieldCall::NoWait { ptr } => {
                         // If this is a `Yield-WaitFor` AND there are no pending
                         // tasks, then return immediately. Otherwise, go into
                         // the yielded state and execute tasks now or when they
@@ -838,8 +830,7 @@ impl Kernel {
                         // process's memory exist. We do not have a reference,
                         // so we can safely call `set_byte()`.
                         unsafe {
-                            let address = param_a as *mut u8;
-                            process.set_byte(address, has_tasks as u8);
+                            process.set_byte(ptr, has_tasks as u8);
                         }
 
                         if has_tasks {
@@ -847,23 +838,19 @@ impl Kernel {
                         }
                     }
 
-                    Ok(YieldCall::Wait) => {
+                    YieldCall::Wait => {
                         process.set_yielded_state();
                     }
 
-                    Ok(YieldCall::WaitFor) => {
+                    YieldCall::WaitFor {
+                        driver_number,
+                        subdriver_number,
+                    } => {
                         let upcall_id = UpcallId {
-                            driver_num: param_a,
-                            subscribe_num: param_b,
+                            driver_num: driver_number,
+                            subscribe_num: subdriver_number,
                         };
                         process.set_yielded_for_state(upcall_id);
-                    }
-
-                    _ => {
-                        // Only 0, 1, and 2 are valid, so this is not a valid
-                        // yield system call, Yield does not have a return value
-                        // because it can push a function call onto the stack;
-                        // just return control to the process.
                     }
                 }
             }

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -31,7 +31,7 @@ use crate::process::{self, ProcessId, Task};
 use crate::scheduler::{Scheduler, SchedulingDecision};
 use crate::syscall::SyscallDriver;
 use crate::syscall::{ContextSwitchReason, SyscallReturn};
-use crate::syscall::{Syscall, YieldCall};
+use crate::syscall::{Syscall, YieldVariant};
 use crate::syscall_driver::CommandReturn;
 use crate::upcall::{Upcall, UpcallId};
 use crate::utilities::cells::NumericCellExt;
@@ -814,7 +814,7 @@ impl Kernel {
                     debug!("[{:?}] yield. which: {}", process.processid(), yield_type);
                 }
                 match yield_type {
-                    YieldCall::NoWait { ptr } => {
+                    YieldVariant::NoWait { ptr } => {
                         // If this is a `Yield-NoWait` AND there are no pending
                         // tasks, then return immediately. Otherwise, go into
                         // the yielded state and execute tasks now or when they
@@ -838,11 +838,11 @@ impl Kernel {
                         }
                     }
 
-                    YieldCall::Wait => {
+                    YieldVariant::Wait => {
                         process.set_yielded_state();
                     }
 
-                    YieldCall::WaitFor {
+                    YieldVariant::WaitFor {
                         driver_number,
                         subdriver_number,
                     } => {

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -815,7 +815,7 @@ impl Kernel {
                 }
                 match yield_type {
                     YieldCall::NoWait { ptr } => {
-                        // If this is a `Yield-WaitFor` AND there are no pending
+                        // If this is a `Yield-NoWait` AND there are no pending
                         // tasks, then return immediately. Otherwise, go into
                         // the yielded state and execute tasks now or when they
                         // arrive.

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -119,7 +119,7 @@ impl TryFrom<u8> for SyscallClass {
 /// Enumeration of the yield system calls based on the Yield identifier
 /// values specified in the Tock ABI.
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub enum YieldCall {
+pub enum YieldVariant {
     NoWait {
         ptr: *mut u8,
     },
@@ -130,12 +130,12 @@ pub enum YieldCall {
     },
 }
 
-impl core::fmt::Display for YieldCall {
+impl core::fmt::Display for YieldVariant {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let name = match self {
-            YieldCall::NoWait { ptr: _ } => "NoWait",
-            YieldCall::Wait => "Wait",
-            YieldCall::WaitFor {
+            YieldVariant::NoWait { ptr: _ } => "NoWait",
+            YieldVariant::Wait => "Wait",
+            YieldVariant::WaitFor {
                 driver_number: _,
                 subdriver_number: _,
             } => "WaitFor",
@@ -152,7 +152,7 @@ pub enum Syscall {
     /// system call class.
     Yield {
         /// The yield variant.
-        yield_type: YieldCall,
+        yield_type: YieldVariant,
     },
 
     /// Structure representing an invocation of the Subscribe system call class.
@@ -254,15 +254,15 @@ impl Syscall {
         match SyscallClass::try_from(syscall_number) {
             Ok(SyscallClass::Yield) => match r0 {
                 0 => Some(Syscall::Yield {
-                    yield_type: YieldCall::NoWait {
+                    yield_type: YieldVariant::NoWait {
                         ptr: r1.as_capability_ptr().as_ptr::<u8>().cast_mut(),
                     },
                 }),
                 1 => Some(Syscall::Yield {
-                    yield_type: YieldCall::Wait,
+                    yield_type: YieldVariant::Wait,
                 }),
                 2 => Some(Syscall::Yield {
-                    yield_type: YieldCall::WaitFor {
+                    yield_type: YieldVariant::WaitFor {
                         driver_number: r1.as_usize(),
                         subdriver_number: r2.as_usize(),
                     },

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -95,28 +95,6 @@ pub enum SyscallClass {
     UserspaceReadableAllow = 7,
 }
 
-/// Enumeration of the yield system calls based on the Yield identifier
-/// values specified in the Tock ABI.
-#[derive(Copy, Clone, Debug)]
-pub enum YieldCall {
-    NoWait = 0,
-    Wait = 1,
-    WaitFor = 2,
-}
-
-impl TryFrom<usize> for YieldCall {
-    type Error = usize;
-
-    fn try_from(yield_variant: usize) -> Result<YieldCall, usize> {
-        match yield_variant {
-            0 => Ok(YieldCall::NoWait),
-            1 => Ok(YieldCall::Wait),
-            2 => Ok(YieldCall::WaitFor),
-            i => Err(i),
-        }
-    }
-}
-
 // Required as long as no solution to
 // https://github.com/rust-lang/rfcs/issues/2783 is integrated into
 // the standard library.
@@ -138,16 +116,43 @@ impl TryFrom<u8> for SyscallClass {
     }
 }
 
+/// Enumeration of the yield system calls based on the Yield identifier
+/// values specified in the Tock ABI.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum YieldCall {
+    NoWait {
+        ptr: *mut u8,
+    },
+    Wait,
+    WaitFor {
+        driver_number: usize,
+        subdriver_number: usize,
+    },
+}
+
+impl core::fmt::Display for YieldCall {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let name = match self {
+            YieldCall::NoWait { ptr: _ } => "NoWait",
+            YieldCall::Wait => "Wait",
+            YieldCall::WaitFor {
+                driver_number: _,
+                subdriver_number: _,
+            } => "WaitFor",
+        };
+
+        write!(f, "{}", name)
+    }
+}
+
 /// Decoded system calls as defined in TRD104.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Syscall {
     /// Structure representing an invocation of the [`SyscallClass::Yield`]
-    /// system call class. `which` is the Yield identifier value and `address`
-    /// is the no wait field.
+    /// system call class.
     Yield {
-        which: usize,
-        param_a: usize,
-        param_b: usize,
+        /// The yield variant.
+        yield_type: YieldCall,
     },
 
     /// Structure representing an invocation of the Subscribe system call class.
@@ -247,11 +252,23 @@ impl Syscall {
         r3: MachineRegister,
     ) -> Option<Syscall> {
         match SyscallClass::try_from(syscall_number) {
-            Ok(SyscallClass::Yield) => Some(Syscall::Yield {
-                which: r0,
-                param_a: r1.as_usize(),
-                param_b: r2.as_usize(),
-            }),
+            Ok(SyscallClass::Yield) => match r0 {
+                0 => Some(Syscall::Yield {
+                    yield_type: YieldCall::NoWait {
+                        ptr: r1.as_capability_ptr().as_ptr::<u8>().cast_mut(),
+                    },
+                }),
+                1 => Some(Syscall::Yield {
+                    yield_type: YieldCall::Wait,
+                }),
+                2 => Some(Syscall::Yield {
+                    yield_type: YieldCall::WaitFor {
+                        driver_number: r1.as_usize(),
+                        subdriver_number: r2.as_usize(),
+                    },
+                }),
+                _ => None,
+            },
             Ok(SyscallClass::Subscribe) => Some(Syscall::Subscribe {
                 driver_number: r0,
                 subdriver_number: r1.as_usize(),


### PR DESCRIPTION


### Pull Request Overview

We currently handle r1 (param_a) in yield as a usize. However, in variant Yield-NoWait, we use r1 (param_a) as a ptr. To correctly capture that, this re-works the yield handling to convert directly to a `*mut u8` for Yield-NoWait, and the correct parameters for other yield variants.

This is in preparation for handling a 64-bit system call interface, where what exactly is a pointer vs. usize is going to matter.

This also removes an `as` ptr cast!

This also renames `YieldCall` to `YieldVariant`.

### Testing Strategy

Just in CI


### TODO or Help Wanted

This is just one step in making it possible to fully define different ABI interfaces.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.

Just me