### PR TITLE
arch: riscv: format printing 32v64

### DIFF
--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -543,22 +543,25 @@ pub unsafe fn print_riscv_state(writer: &mut dyn Write) {
     let interrupt = csr::CSR.mcause.read(csr::mcause::mcause::is_interrupt);
     let code = csr::CSR.mcause.read(csr::mcause::mcause::reason);
     let _ = writer.write_fmt(format_args!(
-        " (interrupt={}, exception code={:#010X})",
-        interrupt, code
+        " (interrupt={}, exception code={:#0width$X})",
+        interrupt,
+        code,
+        width = (XLEN / 4) + 2,
     ));
     let _ = writer.write_fmt(format_args!(
-        "\r\nLast value (mtval):  {:#010X}\
+        "\r\nLast value (mtval):  {:#0width$X}\
          \r\n\
          \r\nSystem register dump:\
-         \r\n mepc:    {:#010X}    mstatus:     {:#010X}\
-         \r\n mcycle:  {:#010X}    minstret:    {:#010X}\
-         \r\n mtvec:   {:#010X}",
+         \r\n mepc:    {:#0width$X}    mstatus:     {:#0width$X}\
+         \r\n mcycle:  {:#0width$X}    minstret:    {:#0width$X}\
+         \r\n mtvec:   {:#0width$X}",
         csr::CSR.mtval.get(),
         csr::CSR.mepc.get(),
         csr::CSR.mstatus.get(),
         csr::CSR.mcycle.get(),
         csr::CSR.minstret.get(),
-        csr::CSR.mtvec.get()
+        csr::CSR.mtvec.get(),
+        width = (XLEN / 4) + 2,
     ));
     let mstatus = csr::CSR.mstatus.extract();
     let uie = mstatus.is_set(csr::mstatus::mstatus::uie);
@@ -569,11 +572,11 @@ pub unsafe fn print_riscv_state(writer: &mut dyn Write) {
     let mpie = mstatus.is_set(csr::mstatus::mstatus::mpie);
     let spp = mstatus.is_set(csr::mstatus::mstatus::spp);
     let _ = writer.write_fmt(format_args!(
-        "\r\n mstatus: {:#010X}\
-         \r\n  uie:    {:5}  upie:   {}\
-         \r\n  sie:    {:5}  spie:   {}\
-         \r\n  mie:    {:5}  mpie:   {}\
-         \r\n  spp:    {}",
+        "\r\n mstatus: {:#0width$X}\
+         \r\n  uie:    {:5}    upie:   {:5}\
+         \r\n  sie:    {:5}    spie:   {:5}\
+         \r\n  mie:    {:5}    mpie:   {:5}\
+         \r\n  spp:    {:5}",
         mstatus.get(),
         uie,
         upie,
@@ -581,7 +584,8 @@ pub unsafe fn print_riscv_state(writer: &mut dyn Write) {
         spie,
         mie,
         mpie,
-        spp
+        spp,
+        width = (XLEN / 4) + 2,
     ));
     let e_usoft = csr::CSR.mie.is_set(csr::mie::mie::usoft);
     let e_ssoft = csr::CSR.mie.is_set(csr::mie::mie::ssoft);
@@ -603,16 +607,16 @@ pub unsafe fn print_riscv_state(writer: &mut dyn Write) {
     let p_sext = csr::CSR.mip.is_set(csr::mip::mip::sext);
     let p_mext = csr::CSR.mip.is_set(csr::mip::mip::mext);
     let _ = writer.write_fmt(format_args!(
-        "\r\n mie:   {:#010X}   mip:   {:#010X}\
-         \r\n  usoft:  {:6}              {:6}\
-         \r\n  ssoft:  {:6}              {:6}\
-         \r\n  msoft:  {:6}              {:6}\
-         \r\n  utimer: {:6}              {:6}\
-         \r\n  stimer: {:6}              {:6}\
-         \r\n  mtimer: {:6}              {:6}\
-         \r\n  uext:   {:6}              {:6}\
-         \r\n  sext:   {:6}              {:6}\
-         \r\n  mext:   {:6}              {:6}\r\n",
+        "\r\n mie:     {:#0width$X}    mip:         {:#0width$X}\
+         \r\n  usoft:  {:5}        {space:>swidth$} {:5}\
+         \r\n  ssoft:  {:5}        {space:>swidth$} {:5}\
+         \r\n  msoft:  {:5}        {space:>swidth$} {:5}\
+         \r\n  utimer: {:5}        {space:>swidth$} {:5}\
+         \r\n  stimer: {:5}        {space:>swidth$} {:5}\
+         \r\n  mtimer: {:5}        {space:>swidth$} {:5}\
+         \r\n  uext:   {:5}        {space:>swidth$} {:5}\
+         \r\n  sext:   {:5}        {space:>swidth$} {:5}\
+         \r\n  mext:   {:5}        {space:>swidth$} {:5}\r\n",
         csr::CSR.mie.get(),
         csr::CSR.mip.get(),
         e_usoft,
@@ -632,6 +636,9 @@ pub unsafe fn print_riscv_state(writer: &mut dyn Write) {
         e_sext,
         p_sext,
         e_mext,
-        p_mext
+        p_mext,
+        space = "",
+        width = (XLEN / 4) + 2,
+        swidth = (XLEN / 4) - 8 + 13,
     ));
 }

--- a/arch/riscv/src/pmp.rs
+++ b/arch/riscv/src/pmp.rs
@@ -844,10 +844,10 @@ impl<const MAX_REGIONS: usize> fmt::Display for PMPUserMPUConfig<MAX_REGIONS> {
             let pmpcfg = tor_user_pmpcfg.get_reg();
             write!(
                 f,
-                "     #{:02}: start={:#010X}, end={:#010X}, cfg={:#04X} ({}) (-{}{}{})\r\n",
+                "     #{:02}: start={:p}, end={:p}, cfg={:#04X} ({}) (-{}{}{})\r\n",
                 i,
-                *start as usize,
-                *end as usize,
+                *start,
+                *end,
                 pmpcfg.get(),
                 t(pmpcfg.is_set(pmpcfg_octet::a), "TOR", "OFF"),
                 t(pmpcfg.is_set(pmpcfg_octet::r), "r", "-"),
@@ -2527,11 +2527,11 @@ pub mod kernel_protection_mml_epmp {
 
                 write!(
                     f,
-                    "  [{:02}]: {}={:#010X}, end={:#010X}, cfg={:#04X} ({}  ) ({}{}{}{})\r\n",
+                    "  [{:02}]: {}={:p}, end={:p}, cfg={:#04X} ({}  ) ({}{}{}{})\r\n",
                     (i + Self::TOR_REGIONS_OFFSET) * 2 + 1,
                     start_pmpaddr_label,
-                    startaddr_pmpaddr,
-                    endaddr,
+                    startaddr_pmpaddr as *const (),
+                    endaddr as *const (),
                     shadowed_pmpcfg.get().get(),
                     mode,
                     if shadowed_pmpcfg.get().get_reg().is_set(pmpcfg_octet::l) {

--- a/arch/riscv/src/syscall.rs
+++ b/arch/riscv/src/syscall.rs
@@ -687,25 +687,25 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
     ) {
         let _ = writer.write_fmt(format_args!(
             "\
-             \r\n R0 : {:#010X}    R16: {:#010X}\
-             \r\n R1 : {:#010X}    R17: {:#010X}\
-             \r\n R2 : {:#010X}    R18: {:#010X}\
-             \r\n R3 : {:#010X}    R19: {:#010X}\
-             \r\n R4 : {:#010X}    R20: {:#010X}\
-             \r\n R5 : {:#010X}    R21: {:#010X}\
-             \r\n R6 : {:#010X}    R22: {:#010X}\
-             \r\n R7 : {:#010X}    R23: {:#010X}\
-             \r\n R8 : {:#010X}    R24: {:#010X}\
-             \r\n R9 : {:#010X}    R25: {:#010X}\
-             \r\n R10: {:#010X}    R26: {:#010X}\
-             \r\n R11: {:#010X}    R27: {:#010X}\
-             \r\n R12: {:#010X}    R28: {:#010X}\
-             \r\n R13: {:#010X}    R29: {:#010X}\
-             \r\n R14: {:#010X}    R30: {:#010X}\
-             \r\n R15: {:#010X}    R31: {:#010X}\
-             \r\n PC : {:#010X}\
+             \r\n R0 : {:#0width$X}    R16: {:#0width$X}\
+             \r\n R1 : {:#0width$X}    R17: {:#0width$X}\
+             \r\n R2 : {:#0width$X}    R18: {:#0width$X}\
+             \r\n R3 : {:#0width$X}    R19: {:#0width$X}\
+             \r\n R4 : {:#0width$X}    R20: {:#0width$X}\
+             \r\n R5 : {:#0width$X}    R21: {:#0width$X}\
+             \r\n R6 : {:#0width$X}    R22: {:#0width$X}\
+             \r\n R7 : {:#0width$X}    R23: {:#0width$X}\
+             \r\n R8 : {:#0width$X}    R24: {:#0width$X}\
+             \r\n R9 : {:#0width$X}    R25: {:#0width$X}\
+             \r\n R10: {:#0width$X}    R26: {:#0width$X}\
+             \r\n R11: {:#0width$X}    R27: {:#0width$X}\
+             \r\n R12: {:#0width$X}    R28: {:#0width$X}\
+             \r\n R13: {:#0width$X}    R29: {:#0width$X}\
+             \r\n R14: {:#0width$X}    R30: {:#0width$X}\
+             \r\n R15: {:#0width$X}    R31: {:#0width$X}\
+             \r\n PC : {:#0width$X}\
              \r\n\
-             \r\n mcause: {:#010X} (",
+             \r\n mcause: {:#0width$X} (",
             0,
             state.regs[15],
             state.regs[0],
@@ -740,13 +740,15 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
             state.regs[30],
             state.pc,
             state.mcause,
+            width = (crate::XLEN / 4) + 2,
         ));
         crate::print_mcause(mcause::Trap::from(state.mcause as usize), writer);
         let _ = writer.write_fmt(format_args!(
             ")\
-             \r\n mtval:  {:#010X}\
+             \r\n mtval:  {:#0width$X}\
              \r\n\r\n",
             state.mtval,
+            width = (crate::XLEN / 4) + 2,
         ));
     }
 


### PR DESCRIPTION


### Pull Request Overview

With rv64i we need longer prints for debugging. This uses Rusts `width$` syntax to dynamically size prints based on XLEN.

This also format padding a little more nicely. PMP uses `{:p}` consistently.

32 bit:

```
Starting main kernel loop.

panicked at kernel/src/process_standard.rs:744:17:
Process register-debug had a fault
	Kernel version 2.3.0-dev1

---| RISC-V Machine State |---
Last cause (mcause): Machine external interrupt (interrupt=1, exception code=0x0000000B)
Last value (mtval):  0x00000000

System register dump:
 mepc:    0x800170F4    mstatus:     0x00000088
 mcycle:  0x28DD5668    minstret:    0x28DD5E38
 mtvec:   0x80000100
 mstatus: 0x00000088
  uie:    false    upie:   false
  sie:    false    spie:   false
  mie:    true     mpie:   true
  spp:    false
 mie:     0x00000888    mip:         0x00000000
  usoft:  false                      false
  ssoft:  false                      false
  msoft:  true                       false
  utimer: false                      false
  stimer: false                      false
  mtimer: true                       false
  uext:   false                      false
  sext:   false                      false
  mext:   true                       false
 ePMP configuration:
  mseccfg: 0x000003, user-mode PMP active: false, entries:
  [00]: pmpaddr=0x20000000, end=0x0, cfg=0x80 (OFF  ) (l---)
  [01]:   start=0x80000000, end=0x80020dff, cfg=0x8D (TOR  ) (lr-x)
  [02]: pmpaddr=0x20040000, end=0x0, cfg=0x00 (OFF  ) (----)
  [03]: pmpaddr=0x200403b6, end=0x0, cfg=0x00 (OFF  ) (----)
  [04]: pmpaddr=0x200c0000, end=0x0, cfg=0x00 (OFF  ) (----)
  [05]: pmpaddr=0x200c026d, end=0x0, cfg=0x00 (OFF  ) (----)
  [06]: pmpaddr=0x0, end=0x0, cfg=0x00 (OFF  ) (----)
  [07]: pmpaddr=0x0, end=0x0, cfg=0x00 (OFF  ) (----)
  [08]: pmpaddr=0x0, end=0x0, cfg=0x00 (OFF  ) (----)
  [09]: pmpaddr=0x0, end=0x0, cfg=0x00 (OFF  ) (----)
  [10]: pmpaddr=0x0, end=0x0, cfg=0x00 (OFF  ) (----)
  [11]: pmpaddr=0x0, end=0x0, cfg=0x00 (OFF  ) (----)
  [12]: pmpaddr=0x0, end=0x0, cfg=0x00 (OFF  ) (----)
  [13]:   start=0x80000000, end=0x801fffff, cfg=0x99 (NAPOT) (lr--)
  [14]:   start=0x80200000, end=0x803fffff, cfg=0x9B (NAPOT) (lrw-)
  [15]:   start=0x0, end=0x1fffffff, cfg=0x9B (NAPOT) (lrw-)
  Shadow PMP entries for user-mode:
  [03]:   start=0x80100000, end=0x80100edb, cfg=0x0D (TOR  ) (-r-x)
  [05]:   start=0x80300000, end=0x803009b7, cfg=0x0B (TOR  ) (-rw-)
  [07]: pmpaddr=0x0, end=0x0, cfg=0x00 (OFF  ) (----)
  [09]: pmpaddr=0x0, end=0x0, cfg=0x00 (OFF  ) (----)
  [11]: pmpaddr=0x0, end=0x0, cfg=0x00 (OFF  ) (----)

---| App Status |---
𝐀𝐩𝐩: register-debug   -   [Faulted]
 Events Queued: 0   Syscall Count: 3   Dropped Upcall Count: 0
 Restart Count: 0
 Last Syscall: Memop { operand: 11, arg0: 2150631860 }
 Completion Code: None


 ╔═══════════╤══════════════════════════════════════════╗
 ║  Address  │ Region Name    Used | Allocated (bytes)  ║
 ╚0x803015F4═╪══════════════════════════════════════════╝
             │ Grant Ptrs       56
             │ Upcalls         320
             │ Process         708
  0x803011B8 ┼───────────────────────────────────────────
             │ ▼ Grant           0
  0x803011B8 ┼───────────────────────────────────────────
             │ Unused
  0x803009B4 ┼───────────────────────────────────────────
             │ ▲ Heap            0 |   2052               S
  0x803009B4 ┼─────────────────────────────────────────── R
             │ Data            436 |    436               A
  0x80300800 ┼─────────────────────────────────────────── M
             │ ▼ Stack           0 |   2048
  0x80300800 ┼───────────────────────────────────────────
             │ Unused
  0x80300000 ┴───────────────────────────────────────────
             .....
  0x80100ED8 ┬─────────────────────────────────────────── F
             │ App Flash      3672                        L
  0x80100080 ┼─────────────────────────────────────────── A
             │ Protected       128                        S
  0x80100000 ┴─────────────────────────────────────────── H

 R0 : 0x00000000    R16: 0xABC04330
 R1 : 0xABC04321    R17: 0xABC04331
 R2 : 0xABC04322    R18: 0xABC04332
 R3 : 0xABC04323    R19: 0xABC04333
 R4 : 0xABC04324    R20: 0xABC04334
 R5 : 0xABC04325    R21: 0xABC04335
 R6 : 0xABC04326    R22: 0xABC04336
 R7 : 0xABC04327    R23: 0xABC04337
 R8 : 0xABC04328    R24: 0xABC04338
 R9 : 0xABC04329    R25: 0xABC04339
 R10: 0xABC0432A    R26: 0xABC0433A
 R11: 0xABC0432B    R27: 0xABC0433B
 R12: 0xABC0432C    R28: 0xABC0433C
 R13: 0xABC0432D    R29: 0xABC0433D
 R14: 0xABC0432E    R30: 0xABC0433E
 R15: 0xABC0432F    R31: 0xABC0433F
 PC : 0x801001F4

 mcause: 0x00000007 (Store/AMO access fault)
 mtval:  0xABC04321


 Total number of grant regions defined: 7
  Grant  0 : --          Grant  3 : --          Grant  6 : --
  Grant  1 : --          Grant  4 : --
  Grant  2 : --          Grant  5 : --
 PMPUserMPUConfig {
  id: 1,
  is_dirty: false,
  app_memory_region: Some(1),
  regions:
     #00: start=0x80100000, end=0x80100ed8, cfg=0x0D (TOR) (-r-x)
     #01: start=0x80300000, end=0x803009b4, cfg=0x0B (TOR) (-rw-)
     #02: start=0x0, end=0x0, cfg=0x00 (OFF) (----)
     #03: start=0x0, end=0x0, cfg=0x00 (OFF) (----)
     #04: start=0x0, end=0x0, cfg=0x00 (OFF) (----)
 }

To debug libtock-c apps, run `make lst` in the app's
folder and open the arch.0x80100080.0x80300000.lst file.
```

64 bit:

```
Entering main loop.
Hello World!
tock$
panicked at kernel/src/process_standard.rs:744:17:
Process crash_dummy had a fault
	Kernel version 2.3.0-dev1

---| RISC-V Machine State |---
Last cause (mcause): Machine external interrupt (interrupt=1, exception code=0x000000000000000B)
Last value (mtval):  0x0000000000000000

System register dump:
 mepc:    0x0000000080012238    mstatus:     0x0000000A00000088
 mcycle:  0x000630D7E58989D0    minstret:    0x000630D7E5899D58
 mtvec:   0x0000000080000100
 mstatus: 0x0000000A00000088
  uie:    false    upie:   false
  sie:    false    spie:   false
  mie:    true     mpie:   true
  spp:    false
 mie:     0x0000000000000888    mip:         0x0000000000000000
  usoft:  false                              false
  ssoft:  false                              false
  msoft:  true                               false
  utimer: false                              false
  stimer: false                              false
  mtimer: true                               false
  uext:   false                              false
  sext:   false                              false
  mext:   true                               false
 PMP hardware configuration -- entries:
  [00]: pmpaddr=0x2004c000, end=0x0, cfg=0x00 (OFF  ) (----)
  [01]:   start=0x80130000, end=0x80130fbf, cfg=0x0D (TOR  ) (-r-x)
  [02]: pmpaddr=0x200cc000, end=0x0, cfg=0x00 (OFF  ) (----)
  [03]:   start=0x80330000, end=0x80330aff, cfg=0x0B (TOR  ) (-rw-)
  [04]: pmpaddr=0x0, end=0x0, cfg=0x00 (OFF  ) (----)
  [05]: pmpaddr=0x0, end=0x0, cfg=0x00 (OFF  ) (----)
  [06]: pmpaddr=0x0, end=0x0, cfg=0x00 (OFF  ) (----)
  [07]: pmpaddr=0x0, end=0x0, cfg=0x00 (OFF  ) (----)
  [08]: pmpaddr=0x0, end=0x0, cfg=0x00 (OFF  ) (----)
  [09]: pmpaddr=0x0, end=0x0, cfg=0x00 (OFF  ) (----)
  [10]: pmpaddr=0x0, end=0x0, cfg=0x00 (OFF  ) (----)
  [11]: pmpaddr=0x0, end=0x0, cfg=0x00 (OFF  ) (----)
  [12]: pmpaddr=0x0, end=0x0, cfg=0x00 (OFF  ) (----)
  [13]: pmpaddr=0x0, end=0x0, cfg=0x00 (OFF  ) (----)
  [14]: pmpaddr=0x0, end=0x0, cfg=0x00 (OFF  ) (----)
  [15]: pmpaddr=0x0, end=0x0, cfg=0x00 (OFF  ) (----)

---| App Status |---
𝐀𝐩𝐩: led-odd   -   [Terminated]
 Events Queued: 0   Syscall Count: 9   Dropped Upcall Count: 0
 Restart Count: 0
 Last Syscall: Exit { which: 0, completion_code: 0 }
 Completion Code: 0


 ╔═══════════╤══════════════════════════════════════════╗
 ║  Address  │ Region Name    Used | Allocated (bytes)  ║
 ╚0x80301B10═╪══════════════════════════════════════════╝
             │ Grant Ptrs      112
             │ Upcalls         640
             │ Process        1312
  0x80301300 ┼───────────────────────────────────────────
             │ ▼ Grant           0
  0x80301300 ┼───────────────────────────────────────────
             │ Unused
  0x80300AF8 ┼───────────────────────────────────────────
             │ ▲ Heap            0 |   2056               S
  0x80300AF8 ┼─────────────────────────────────────────── R
             │ Data            760 |    760               A
  0x80300800 ┼─────────────────────────────────────────── M
             │ ▼ Stack         112 |   2048
  0x80300790 ┼───────────────────────────────────────────
             │ Unused
  0x80300000 ┴───────────────────────────────────────────
             .....
  0x80100F68 ┬─────────────────────────────────────────── F
             │ App Flash      3816                        L
  0x80100080 ┼─────────────────────────────────────────── A
             │ Protected       128                        S
  0x80100000 ┴─────────────────────────────────────────── H

 R0 : 0x0000000000000000    R16: 0x0000000000000000
 R1 : 0x00000000801002FC    R17: 0x0000000000000000
 R2 : 0x00000000803007C0    R18: 0x0000000080300000
 R3 : 0x0000000000000000    R19: 0x0000000000000000
 R4 : 0x0000000000000000    R20: 0x0000000000000000
 R5 : 0x0000000080300800    R21: 0x0000000000000000
 R6 : 0x0000000080100200    R22: 0x0000000000000000
 R7 : 0x0000000000000248    R23: 0x0000000000000000
 R8 : 0x0000000000000000    R24: 0x0000000000000000
 R9 : 0x0000000080300000    R25: 0x0000000000000000
 R10: 0x0000000000000000    R26: 0x0000000000000000
 R11: 0x0000000000000000    R27: 0x0000000000000000
 R12: 0x0000000000000003    R28: 0x0000000000000000
 R13: 0x0000000000000000    R29: 0x0000000000000000
 R14: 0x0000000000000006    R30: 0x0000000000000000
 R15: 0x0000000000000000    R31: 0x0000000000000000
 PC : 0x000000008010027A

 mcause: 0x0000000000000008 (Environment call from U-mode)
 mtval:  0x0000000000000000


 Total number of grant regions defined: 7
  Grant  0 : --          Grant  3 : --          Grant  6 : --
  Grant  1 : --          Grant  4 : --
  Grant  2 : --          Grant  5 : --
 PMPUserMPUConfig {
  id: 1,
  is_dirty: false,
  app_memory_region: Some(1),
  regions:
     #00: start=0x80100000, end=0x80100f68, cfg=0x0D (TOR) (-r-x)
     #01: start=0x80300000, end=0x80300af8, cfg=0x0B (TOR) (-rw-)
     #02: start=0x0, end=0x0, cfg=0x00 (OFF) (----)
     #03: start=0x0, end=0x0, cfg=0x00 (OFF) (----)
     #04: start=0x0, end=0x0, cfg=0x00 (OFF) (----)
     #05: start=0x0, end=0x0, cfg=0x00 (OFF) (----)
     #06: start=0x0, end=0x0, cfg=0x00 (OFF) (----)
     #07: start=0x0, end=0x0, cfg=0x00 (OFF) (----)
 }

To debug libtock-c apps, run `make lst` in the app's
folder and open the arch.0x80100080.0x80300000.lst file.

𝐀𝐩𝐩: c_hello   -   [Terminated]
 Events Queued: 0   Syscall Count: 8   Dropped Upcall Count: 0
 Restart Count: 0
 Last Syscall: Exit { which: 0, completion_code: 0 }
 Completion Code: 0


 ╔═══════════╤══════════════════════════════════════════╗
 ║  Address  │ Region Name    Used | Allocated (bytes)  ║
 ╚0x80311B20═╪══════════════════════════════════════════╝
             │ Grant Ptrs      112
             │ Upcalls         640
             │ Process        1312
  0x80311310 ┼───────────────────────────────────────────
             │ ▼ Grant         152
  0x80311278 ┼───────────────────────────────────────────
             │ Unused
  0x80310B08 ┼───────────────────────────────────────────
             │ ▲ Heap            0 |   1904               S
  0x80310B08 ┼─────────────────────────────────────────── R
             │ Data            776 |    776               A
  0x80310800 ┼─────────────────────────────────────────── M
             │ ▼ Stack         160 |   2048
  0x80310760 ┼───────────────────────────────────────────
             │ Unused
  0x80310000 ┴───────────────────────────────────────────
             .....
  0x801110C0 ┬─────────────────────────────────────────── F
             │ App Flash      4160                        L
  0x80110080 ┼─────────────────────────────────────────── A
             │ Protected       128                        S
  0x80110000 ┴─────────────────────────────────────────── H

 R0 : 0x0000000000000000    R16: 0x0000000080310780
 R1 : 0x0000000080110442    R17: 0x0000000000000000
 R2 : 0x00000000803107C0    R18: 0x0000000080310000
 R3 : 0x0000000000000000    R19: 0x0000000000000000
 R4 : 0x0000000000000000    R20: 0x0000000000000000
 R5 : 0x0000000080310800    R21: 0x0000000000000000
 R6 : 0x00000000801103C4    R22: 0x0000000000000000
 R7 : 0x0000000000000248    R23: 0x0000000000000000
 R8 : 0x0000000000000000    R24: 0x0000000000000000
 R9 : 0x0000000080310000    R25: 0x0000000000000000
 R10: 0x0000000000000000    R26: 0x0000000000000000
 R11: 0x0000000000000000    R27: 0x0000000000000000
 R12: 0x0000000000000000    R28: 0x0000000000000000
 R13: 0x00000000801100FC    R29: 0x0000000000000000
 R14: 0x0000000000000006    R30: 0x0000000000000000
 R15: 0x0000000000000000    R31: 0x0000000000000000
 PC : 0x000000008011020C

 mcause: 0x0000000000000008 (Environment call from U-mode)
 mtval:  0x0000000000000000


 Total number of grant regions defined: 7
  Grant  0 : --          Grant  3 : --          Grant  6 : --
  Grant  1 : --          Grant  4 : --
  Grant  2 : --          Grant  5 : --
 PMPUserMPUConfig {
  id: 2,
  is_dirty: false,
  app_memory_region: Some(1),
  regions:
     #00: start=0x80110000, end=0x801110c0, cfg=0x0D (TOR) (-r-x)
     #01: start=0x80310000, end=0x80310b08, cfg=0x0B (TOR) (-rw-)
     #02: start=0x0, end=0x0, cfg=0x00 (OFF) (----)
     #03: start=0x0, end=0x0, cfg=0x00 (OFF) (----)
     #04: start=0x0, end=0x0, cfg=0x00 (OFF) (----)
     #05: start=0x0, end=0x0, cfg=0x00 (OFF) (----)
     #06: start=0x0, end=0x0, cfg=0x00 (OFF) (----)
     #07: start=0x0, end=0x0, cfg=0x00 (OFF) (----)
 }

To debug libtock-c apps, run `make lst` in the app's
folder and open the arch.0x80110080.0x80310000.lst file.

𝐀𝐩𝐩: crash_dummy   -   [Faulted]
 Events Queued: 0   Syscall Count: 6   Dropped Upcall Count: 0
 Restart Count: 0
 Last Syscall: Yield { yield_type: Wait }
 Completion Code: None


 ╔═══════════╤══════════════════════════════════════════╗
 ║  Address  │ Region Name    Used | Allocated (bytes)  ║
 ╚0x80331B18═╪══════════════════════════════════════════╝
             │ Grant Ptrs      112
             │ Upcalls         640
             │ Process        1312
  0x80331308 ┼───────────────────────────────────────────
             │ ▼ Grant          32
  0x803312E8 ┼───────────────────────────────────────────
             │ Unused
  0x80330B00 ┼───────────────────────────────────────────
             │ ▲ Heap            0 |   2024               S
  0x80330B00 ┼─────────────────────────────────────────── R
             │ Data            768 |    768               A
  0x80330800 ┼─────────────────────────────────────────── M
             │ ▼ Stack         144 |   2048
  0x80330770 ┼───────────────────────────────────────────
             │ Unused
  0x80330000 ┴───────────────────────────────────────────
             .....
  0x80130FC0 ┬─────────────────────────────────────────── F
             │ App Flash      3904                        L
  0x80130080 ┼─────────────────────────────────────────── A
             │ Protected       128                        S
  0x80130000 ┴─────────────────────────────────────────── H

 R0 : 0x0000000000000000    R16: 0x0000000080330790
 R1 : 0x00000000801301D6    R17: 0x0000000000000000
 R2 : 0x00000000803307B0    R18: 0x0000000080330000
 R3 : 0x0000000000000000    R19: 0x0000000000000000
 R4 : 0x0000000000000000    R20: 0x0000000000000000
 R5 : 0x0000000080330800    R21: 0x0000000000000000
 R6 : 0x00000000801302E6    R22: 0x0000000000000000
 R7 : 0x0000000000000250    R23: 0x0000000000000000
 R8 : 0x0000000080130080    R24: 0x0000000000000000
 R9 : 0x0000000080330000    R25: 0x0000000000000000
 R10: 0x0000000000000000    R26: 0x0000000000000000
 R11: 0x0000000000000000    R27: 0x0000000000000000
 R12: 0x0000000000000001    R28: 0x0000000000000000
 R13: 0x00000000801300FC    R29: 0x0000000000000000
 R14: 0x0000000000000000    R30: 0x0000000000000000
 R15: 0x0000000000000000    R31: 0x0000000000000000
 PC : 0x0000000080130106

 mcause: 0x0000000000000005 (Load access fault)
 mtval:  0x0000000000000000


 Total number of grant regions defined: 7
  Grant  0 : --          Grant  3 : --          Grant  6 0x3: 0x803312e8
  Grant  1 : --          Grant  4 : --
  Grant  2 : --          Grant  5 : --
 PMPUserMPUConfig {
  id: 3,
  is_dirty: false,
  app_memory_region: Some(1),
  regions:
     #00: start=0x80130000, end=0x80130fc0, cfg=0x0D (TOR) (-r-x)
     #01: start=0x80330000, end=0x80330b00, cfg=0x0B (TOR) (-rw-)
     #02: start=0x0, end=0x0, cfg=0x00 (OFF) (----)
     #03: start=0x0, end=0x0, cfg=0x00 (OFF) (----)
     #04: start=0x0, end=0x0, cfg=0x00 (OFF) (----)
     #05: start=0x0, end=0x0, cfg=0x00 (OFF) (----)
     #06: start=0x0, end=0x0, cfg=0x00 (OFF) (----)
     #07: start=0x0, end=0x0, cfg=0x00 (OFF) (----)
 }

To debug libtock-c apps, run `make lst` in the app's
folder and open the arch.0x80130080.0x80330000.lst file.
```



### Testing Strategy

Triggering various panics on the qemu boards and looking at the output.


### TODO or Help Wanted

Nothing for now. We will need to decide what to do for process memory map printing in process_standard at some point.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
