### PR TITLE
kernel: Add TRD104 helper function for upcalls

### DIFF
--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -394,10 +394,15 @@ impl<A: CortexMVariant> kernel::syscall::UserspaceKernelBoundary for SysCall<A> 
         ptr::write(stack_bottom.add(7), state.psr); //......... -> APSR
         ptr::write(stack_bottom.add(6), callback.pc.addr() | 1); //... -> PC
         ptr::write(stack_bottom.add(5), state.yield_pc | 1); // -> LR
-        ptr::write(stack_bottom.add(3), callback.argument3.as_usize()); // -> R3
-        ptr::write(stack_bottom.add(2), callback.argument2); // -> R2
-        ptr::write(stack_bottom.add(1), callback.argument1); // -> R1
-        ptr::write(stack_bottom.add(0), callback.argument0); // -> R0
+
+        // Write upcall arguments to the proper stack locations.
+        kernel::utilities::arch_helpers::encode_upcall_trd104_ptr(
+            &callback,
+            stack_bottom.add(0).cast::<u32>(), // -> R0
+            stack_bottom.add(1).cast::<u32>(), // -> R1
+            stack_bottom.add(2).cast::<u32>(), // -> R2
+            stack_bottom.add(3).cast::<u32>(), // -> R3
+        );
 
         Ok(())
     }

--- a/arch/riscv/src/syscall.rs
+++ b/arch/riscv/src/syscall.rs
@@ -195,10 +195,29 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
     ) -> Result<(), ()> {
         // Set the register state for the application when it starts
         // executing. These are the argument registers.
-        state.regs[R_A0] = callback.argument0 as u32;
-        state.regs[R_A1] = callback.argument1 as u32;
-        state.regs[R_A2] = callback.argument2 as u32;
-        state.regs[R_A3] = callback.argument3.as_usize() as u32;
+
+        // We need to use a bunch of split_at_mut's to have multiple
+        // mutable borrows into the same slice at the same time.
+        //
+        // Since the compiler knows the size of this slice, and these
+        // calls will be optimized out, we use one to get to the first
+        // register (A0)
+        let (_, r) = state.regs.split_at_mut(R_A0);
+
+        // This comes with the assumption that the respective
+        // registers are stored at monotonically increasing indices
+        // in the register slice
+        let (a0slice, r) = r.split_at_mut(R_A1 - R_A0);
+        let (a1slice, r) = r.split_at_mut(R_A2 - R_A1);
+        let (a2slice, a3slice) = r.split_at_mut(R_A3 - R_A2);
+
+        kernel::utilities::arch_helpers::encode_upcall_trd104(
+            &callback,
+            &mut a0slice[0],
+            &mut a1slice[0],
+            &mut a2slice[0],
+            &mut a3slice[0],
+        );
 
         // We also need to set the return address (ra) register so that the new
         // function that the process is running returns to the correct location.

--- a/kernel/src/utilities/arch_helpers.rs
+++ b/kernel/src/utilities/arch_helpers.rs
@@ -10,6 +10,7 @@
 //! `kernel` crate as all `arch` crates already depend on it.
 
 use crate::ErrorCode;
+use crate::process::FunctionCall;
 use crate::syscall::SyscallReturn;
 
 /// Helper function to split a [`u64`] into a higher and lower [`u32`].
@@ -240,5 +241,45 @@ pub fn encode_syscall_return_trd104(
             *a1 = data1 as u32;
             *a2 = data2 as u32;
         }
+    }
+}
+
+/// Encode the upcall arguments into 4 registers compatible with TRD104.
+pub fn encode_upcall_trd104(
+    upcall: &FunctionCall,
+    a0: &mut u32,
+    a1: &mut u32,
+    a2: &mut u32,
+    a3: &mut u32,
+) {
+    *a0 = upcall.argument0 as u32;
+    *a1 = upcall.argument1 as u32;
+    *a2 = upcall.argument2 as u32;
+    *a3 = upcall.argument3.as_usize() as u32;
+}
+
+/// Encode the upcall arguments into 4 registers compatible with TRD104.
+///
+/// Use pointer writes.
+///
+/// # Safety
+///
+/// All pointers `a0`, `a1`, `a2`, `a3` must point to valid, aligned, and
+/// writable memory locations.
+pub unsafe fn encode_upcall_trd104_ptr(
+    upcall: &FunctionCall,
+    a0: *mut u32,
+    a1: *mut u32,
+    a2: *mut u32,
+    a3: *mut u32,
+) {
+    // # Safety
+    //
+    // All safety invariants must be upheld by the function caller.
+    unsafe {
+        core::ptr::write(a0, upcall.argument0 as u32);
+        core::ptr::write(a1, upcall.argument1 as u32);
+        core::ptr::write(a2, upcall.argument2 as u32);
+        core::ptr::write(a3, upcall.argument3.as_usize() as u32);
     }
 }


### PR DESCRIPTION
### Pull Request Overview

The mapping of upcall arguments to registers is ABI-specific. We should use TRD104 functions to ensure the mapping is done correctly on all platforms.

This implements the function for both mutable references and pointers, and updates the arm and rv32 implementations to use it.

This is a step towards rv64i support. 




### Testing Strategy

todo


### TODO or Help Wanted

This one is pretty small, as our arguments map pretty directly to registers. Is the reason we haven't really given this mapping much attention (it isn't really specified in the TRD104) just because it is relatively simple? Or is there some reason not to have a helper function like this?

I want to have this for rv64 to provide a clear place to ensure only the lowest 32 bits are passed to userspace. The prevents an issue where a capsule sets the entire `usize`, and an app using the same capsule syscall driver on a 64 bit platform ends up with more data than one on a 32 bit platform.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
