### PR TITLE
kernel: DMA Slice: add `ptr_addr()` method

### DIFF
--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -204,7 +204,7 @@ impl UarteRegistersManager {
         let tx_dma_slice = DmaSubSliceMut::new_static(buf, fence);
 
         // Provide the DmaSlice buffer to the hardware DMA engine.
-        self.registers.txd_ptr.set(tx_dma_slice.as_mut_ptr() as u32);
+        self.registers.txd_ptr.set(tx_dma_slice.ptr_addr() as u32);
 
         // Specify the length to transmit.
         self.registers
@@ -272,7 +272,7 @@ impl UarteRegistersManager {
         let rx_dma_slice = DmaSubSliceMut::new_static(buf, fence);
 
         // Provide the DmaSlice buffer to the hardware DMA engine.
-        self.registers.rxd_ptr.set(rx_dma_slice.as_mut_ptr() as u32);
+        self.registers.rxd_ptr.set(rx_dma_slice.ptr_addr() as u32);
 
         // Specify the length to transmit.
         self.registers

--- a/kernel/src/utilities/dma_slice.rs
+++ b/kernel/src/utilities/dma_slice.rs
@@ -145,6 +145,11 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSlice<'a, T> {
         self.slice.as_ptr()
     }
 
+    // Returns the address of the slice to pass to DMA hardware.
+    pub fn ptr_addr(&self) -> usize {
+        self.as_ptr().addr()
+    }
+
     /// Returns the length of the slice.
     pub fn len(&self) -> usize {
         self.slice.len()
@@ -256,6 +261,11 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSliceMut<'a, T
         self.slice_ptr.as_ptr().cast()
     }
 
+    // Returns the address of the slice to pass to DMA hardware.
+    pub fn ptr_addr(&self) -> usize {
+        self.as_mut_ptr().addr()
+    }
+
     /// Returns the length of the slice.
     pub fn len(&self) -> usize {
         self.slice_ptr.len()
@@ -347,6 +357,11 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSliceMutImmut<
         }
     }
 
+    // Returns the address of the slice to pass to DMA hardware.
+    pub fn ptr_addr(&self) -> usize {
+        self.as_ptr().addr()
+    }
+
     /// Returns the length of the wrapped slice reference.
     pub fn len(&self) -> usize {
         match self {
@@ -436,6 +451,11 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSlice<'a, T
     /// portion of the wrapped `SubSlice`.
     pub fn as_ptr(&self) -> *const T {
         self.sub_slice.as_ptr()
+    }
+
+    // Returns the address of the slice to pass to DMA hardware.
+    pub fn ptr_addr(&self) -> usize {
+        self.as_ptr().addr()
     }
 
     /// Returns the length of the currently accessible range of the wrapped
@@ -573,6 +593,11 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMut<'a
         )
     }
 
+    // Returns the address of the slice to pass to DMA hardware.
+    pub fn ptr_addr(&self) -> usize {
+        self.as_mut_ptr().addr()
+    }
+
     /// Returns the length of the active range of the wrapped [`SubSliceMut`].
     pub fn len(&self) -> usize {
         core::cmp::min(
@@ -688,6 +713,11 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMutImm
                 dma_sub_slice_mut.as_mut_ptr().cast_const()
             }
         }
+    }
+
+    // Returns the address of the slice to pass to DMA hardware.
+    pub fn ptr_addr(&self) -> usize {
+        self.as_ptr().addr()
     }
 
     /// Returns the length of the currently accessible range of the wrapped

--- a/kernel/src/utilities/dma_slice.rs
+++ b/kernel/src/utilities/dma_slice.rs
@@ -145,7 +145,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSlice<'a, T> {
         self.slice.as_ptr()
     }
 
-    // Returns the address of the slice to pass to DMA hardware.
+    /// Returns the address of the slice to pass to DMA hardware, without exposing provenance.
     pub fn ptr_addr(&self) -> usize {
         self.as_ptr().addr()
     }
@@ -261,7 +261,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSliceMut<'a, T
         self.slice_ptr.as_ptr().cast()
     }
 
-    // Returns the address of the slice to pass to DMA hardware.
+    /// Returns the address of the slice to pass to DMA hardware, without exposing provenance.
     pub fn ptr_addr(&self) -> usize {
         self.as_mut_ptr().addr()
     }
@@ -357,7 +357,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSliceMutImmut<
         }
     }
 
-    // Returns the address of the slice to pass to DMA hardware.
+    /// Returns the address of the slice to pass to DMA hardware, without exposing provenance.
     pub fn ptr_addr(&self) -> usize {
         self.as_ptr().addr()
     }
@@ -453,7 +453,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSlice<'a, T
         self.sub_slice.as_ptr()
     }
 
-    // Returns the address of the slice to pass to DMA hardware.
+    /// Returns the address of the slice to pass to DMA hardware, without exposing provenance.
     pub fn ptr_addr(&self) -> usize {
         self.as_ptr().addr()
     }
@@ -593,7 +593,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMut<'a
         )
     }
 
-    // Returns the address of the slice to pass to DMA hardware.
+    /// Returns the address of the slice to pass to DMA hardware, without exposing provenance.
     pub fn ptr_addr(&self) -> usize {
         self.as_mut_ptr().addr()
     }
@@ -715,7 +715,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMutImm
         }
     }
 
-    // Returns the address of the slice to pass to DMA hardware.
+    /// Returns the address of the slice to pass to DMA hardware, without exposing provenance.
     pub fn ptr_addr(&self) -> usize {
         self.as_ptr().addr()
     }


### PR DESCRIPTION
### Pull Request Overview

Per a comment in https://github.com/tock/tock/pull/4856, this adds a method to DMA slices that gets the address without exposing provenance.

Then update the nRF52 UART dma manger to use the new API.


### Testing Strategy

travis


### TODO or Help Wanted

Should be good? I don't think Rust provides this API already directly, so I made up the name `ptr_addr()`.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
