### PR TITLE
components: remove unsafe from debug_writer. kernel: add `mut_slice_as_maybeuninit()` function

### DIFF
--- a/boards/components/src/debug_writer.rs
+++ b/boards/components/src/debug_writer.rs
@@ -170,10 +170,7 @@ impl<const BUF_SIZE_BYTES: usize, C: SetDebugWriterCapability> Component
 
         let (output_buf, internal_buf) = buf.split_at_mut(DEBUG_BUFFER_SPLIT);
 
-        // SAFETY: MaybeUninit<u8> has the same size and alignment as u8.
-        let internal_buf: &mut [core::mem::MaybeUninit<u8>] = unsafe {
-            core::slice::from_raw_parts_mut(internal_buf.as_mut_ptr().cast(), internal_buf.len())
-        };
+        let internal_buf = kernel::utilities::slice_uninit::mut_slice_as_maybeuninit(internal_buf);
 
         // Create virtual device for kernel debug.
         let debugger_uart = s.0.write(UartDevice::new(self.uart_mux, false));
@@ -231,10 +228,7 @@ impl<
         let buf = s.1.write([0; BUF_SIZE_BYTES]);
         let (output_buf, internal_buf) = buf.split_at_mut(DEBUG_BUFFER_SPLIT);
 
-        // SAFETY: MaybeUninit<u8> has the same size and alignment as u8.
-        let internal_buf: &mut [core::mem::MaybeUninit<u8>] = unsafe {
-            core::slice::from_raw_parts_mut(internal_buf.as_mut_ptr().cast(), internal_buf.len())
-        };
+        let internal_buf = kernel::utilities::slice_uninit::mut_slice_as_maybeuninit(internal_buf);
 
         // Create virtual device for kernel debug.
         let ring_buffer = s.0.write(RingBuffer::new(internal_buf));

--- a/kernel/src/utilities/mod.rs
+++ b/kernel/src/utilities/mod.rs
@@ -18,6 +18,7 @@ pub mod math;
 pub mod mut_imut_buffer;
 pub mod peripheral_management;
 pub mod single_thread_value;
+pub mod slice_uninit;
 pub mod static_init;
 pub mod storage_volume;
 pub mod streaming_process_slice;

--- a/kernel/src/utilities/slice_uninit.rs
+++ b/kernel/src/utilities/slice_uninit.rs
@@ -1,0 +1,16 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+/// Convert a `&mut [T]` to a `&mut [MaybeUninit<T>]`.
+///
+/// This is a safe operation, but as of June 2026, there is no safe API in the
+/// standard library to do this. So, we provide our own.
+pub fn mut_slice_as_maybeuninit<T>(buffer: &mut [T]) -> &mut [core::mem::MaybeUninit<T>] {
+    // # Safety
+    //
+    // `MaybeUninit<T>` has the same size and alignment as `T`.
+    let maybeuninit_buf: &mut [core::mem::MaybeUninit<T>] =
+        unsafe { core::slice::from_raw_parts_mut(buffer.as_mut_ptr().cast(), buffer.len()) };
+    maybeuninit_buf
+}


### PR DESCRIPTION
### Pull Request Overview

Part of https://github.com/tock/tock/issues/4418

This removes the last non-capability-related `unsafe` from components.

It seems intuitive that converting a `[T]` to a `[MaybeUninit<T>]` is always a safe operation. This adds a helper function to do this in the kernel crate, because as far as I can tell this API does not exist in Rust.

We need this in our debug writer component because we use a RingBuffer which needs a `[MaybeUninit<u8>]`, not `[u8]`.

This gets us closer to forbid unsafe in components.


### Testing Strategy

travis


### TODO or Help Wanted

So I need help confirming that my safe API is in fact safe (claude says it is :) ).

I also wonder if there is a safe way to do this, I just couldn't find it.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.


I wrote all of the code. Claude told me that there is no safe API to do the conversion. I looked through API docs and unsafe  nightly features and couldn't find any even nightly API to do this conversion.