### PR TITLE
issue #4894: fixed end address for mpu v8m

### DIFF
--- a/arch/cortex-m33/src/mpu_v8m.rs
+++ b/arch/cortex-m33/src/mpu_v8m.rs
@@ -356,7 +356,7 @@ impl CortexMRegion {
 
         // Limit Address register
         let rlar_value = MPU_RLAR::ENABLE::SET
-            + MPU_RLAR::LIMIT.val((logical_end as u32) >> 5)
+            + MPU_RLAR::LIMIT.val(((logical_end - 1) as u32) >> 5)  // shift the logical_end value by one byte, because v8m architechture expects inclusive limit
             + MPU_RLAR::PXN::Disable
             + MPU_RLAR::ATTRINDX.val(0);
 


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the misconfigured (off by 1 byte) end address for MPU v8m architecture. The logical_end was set as exclusive boundary, while hardware registers were expecting inclusive boundary


### Testing Strategy

This pull request was tested by compiling the kernel and installing several apps on nucleo u545re_q board. Even though the original bug occured on musca b1 board, both boards use Cortex M33 architechture. Since the apps were successfule installed the code updates did not cause any memory breaks.


### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [ ] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
