### PR TITLE
Updates to CONTRIBUTING guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -244,16 +244,16 @@ updated sort][lru] is good for finding issues like this.
 
 All contributions to Tock are expected to be dual-licensed under the
 [Apache 2.0](../LICENSE-APACHE) and [MIT](../LICENSE-MIT) licenses. Copyrights
-in Tock projects are retained by their contributors. For full details, see the
-[Tock Reference Document on Licensing and Copyrights](../doc/reference/trd4-legal.md)
-
-Whenever possible, files should begin with a license header stating its license status. CI
-enforces this.
+in Tock projects are retained by their contributors. Whenever possible, files
+should begin with a license header stating its license status. CI enforces
+this.
 
     // Licensed under the Apache License, Version 2.0 or the MIT License.
     // SPDX-License-Identifier: Apache-2.0 OR MIT
     // Copyright Tock Contributors 2026.
 
+For full details, see the
+[Tock Reference Document on Licensing and Copyrights](../doc/reference/trd4-legal.md).
 
 ## AI Policy
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,13 +12,14 @@ contribute, and we appreciate all of them.
 * [Notes](#notes)
 
 If you have questions, please make a post on the [mailing list][listserv] or
-join us on [Slack][slack].
+join us on [Matrix][matrix] or [Slack][slack].
 
 As a reminder, all contributors are expected to follow the Rust [Code of
 Conduct][coc].
 
+[matrix]: https://matrix.to/#/#tock:tockos.org
 [slack]: https://join.slack.com/t/tockos/shared_invite/enQtNDE5ODQyNDU4NTE1LWVjNTgzMTMwYzA1NDI1MjExZjljMjFmOTMxMGIwOGJlMjk0ZTI4YzY0NTYzNWM0ZmJmZGFjYmY5MTJiMDBlOTk
-[listserv]: https://groups.google.com/forum/#!forum/tock-dev
+[listserv]: https://lists.tockos.org
 [coc]: https://www.rust-lang.org/conduct.html
 
 ## What Goes Where?
@@ -217,16 +218,13 @@ and make any required changes. PRs must pass the formatting checks before landin
 ### Step 8: Landing
 
 In order to land, a Pull Request needs to be reviewed and
-[approved](#getting-approvals-for-your-pull-request) by at least one person with
+approved by at least one person with
 commit access to the Tock repository and pass the continuous integration tests.
-After that, as long as there are no objections, the Pull Request can be merged.
-
-We use the bors-ng bot to merge PRs. In short, when someone replies `bors r+`,
-your PR has been scheduled for final tests and will be automatically merged. If
-a maintainer replies `bors delegate+`, then you have been granted the authority
-to merge your own PR (usually this will happen if there are some trivial
-changes required). For more on bors,
-[see the bors documentation](https://bors.tech/documentation/).
+[Depending on the significance of the
+PR](https://github.com/tock/tock/blob/master/doc/CodeReview.md#pull-requests),
+it may require review by multiple Core team members. Generally, trivial fixes
+should be easy to merge, and complex updates touching sensitive code may require
+consideration by several people.
 
 
 ## Issue Triage

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -240,6 +240,20 @@ updated sort][lru] is good for finding issues like this.
 
 [lru]: https://github.com/tock/tock/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-asc
 
+## Licensing
+
+All contributions to Tock are expected to be dual-licensed under the
+[Apache 2.0](../LICENSE-APACHE) and [MIT](../LICENSE-MIT) licenses. Copyrights
+in Tock projects are retained by their contributors. For full details, see the
+[Tock Reference Document on Licensing and Copyrights](../doc/reference/trd4-legal.md)
+
+Whenever possible, files should begin with a license header stating its license status. CI
+enforces this.
+
+    // Licensed under the Apache License, Version 2.0 or the MIT License.
+    // SPDX-License-Identifier: Apache-2.0 OR MIT
+    // Copyright Tock Contributors 2026.
+
 
 ## AI Policy
 
@@ -249,6 +263,10 @@ AI-generated code themselves for correctness and compatibility with Tock's
 code expectations. All AI use must be disclosed in the pull request
 description, including which AI tool was used, what portion of the patch was
 created by AI, and how the AI-generated code was reviewed.
+
+Contributors remain responsible for ensuring that their contributions are
+compatible with the applicable licenses, do not infringe on any copyright
+claims, and maintain proper attribution.
 
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ![TockOS](http://www.tockos.org/assets/img/tock.svg "TockOS Logo")
 
 [![tock-ci](https://github.com/tock/tock/actions/workflows/ci.yml/badge.svg)][tock-ci]
+[![matrix](https://img.shields.io/badge/matrix-tockos-informational)][matrix]
 [![slack](https://img.shields.io/badge/slack-tockos-informational)][slack]
 [![book](https://img.shields.io/badge/book-Tock_Book-green)][tock-book]
 
@@ -39,10 +40,13 @@ project, and getting help.
   - [Contributing Guide](.github/CONTRIBUTING.md)
   - [Code Review Guidelines](doc/CodeReview.md)
 - Getting Help
+  - [Matrix Channel][matrix]
   - [Slack Channel][slack]
   - [Email List](https://lists.tockos.org)
   - [Tock Blog](https://www.tockos.org/blog/)
   - [@talkingtock](https://twitter.com/talkingtock)
+
+[matrix]: https://matrix.to/#/#tock:tockos.org
 
 [slack]: https://join.slack.com/t/tockos/shared_invite/enQtNDE5ODQyNDU4NTE1LWVjNTgzMTMwYzA1NDI1MjExZjljMjFmOTMxMGIwOGJlMjk0ZTI4YzY0NTYzNWM0ZmJmZGFjYmY5MTJiMDBlOTk
 


### PR DESCRIPTION
### Pull Request Overview

Our CONTRIBUTING guidelines are quite out of date. I made some trivial updates (such as removing `bors` from them...). I also added references to the Matrix channel we now use to both the CONTRIBUTING guidelines and the README.

Also, this was a good chance to add licensing and copyright information to the CONTRIBUTING guidelines, as previously discussed in #4838

* [Rendered README](https://github.com/tock/tock/blob/dev/contributing-updates/README.md)
* [Rendered CONTRIBUTING](https://github.com/tock/tock/blob/dev/contributing-updates/.github/CONTRIBUTING.md)


### Testing Strategy

Documentation


### TODO or Help Wanted

I think this is good to go. Presumably someone is going to care strongly about very specific wording choices. I do not, so please feel free to suggest changes.


### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [N/A] Ran `make prepush`.

### AI Use

- [X] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.

No one to blame but me.