### PR TITLE
PR template: Update V3, add yes/no for AI and docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,4 +28,6 @@ This pull request still needs...
 #### AI Use
 
 - [ ] No AI was used in this PR.
-- [ ] I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.
+- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.
+
+<!-- Include details of AI use here, if you used any --!>

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,16 +13,19 @@ This pull request was tested by...
 This pull request still needs...
 
 
-### Documentation Updated
-
-- [ ] Updated the relevant files in `/docs`, or no updates are required.
-
-### Formatting
+### Checklist
 
 - [ ] Ran `make prepush`.
 
-### AI Use
 
-- [ ] The PR description details my use of AI in the production of the
-      code in this PR, if any, and I have manually checked and
-      personally certify the entire contents of this PR.
+### PR Contents
+
+#### Documentation
+
+- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
+- [ ] No documentation updates are required.
+
+#### AI Use
+
+- [ ] No AI was used in this PR.
+- [ ] I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.


### PR DESCRIPTION
### Pull Request Overview

This is an alternative to #4792 and #4834.

Based on the discussion about the AI disclosure, this does add two checkboxes (which should be thought of as radio buttons) for used AI vs. did not.

Since that gives up using the checkboxes as a github-tracked checklist, this also splits the documentation disclosure into two checkboxes. Since we have two (AI and doc), this groups them in a category I called "PR Contents".

What we had as "formatting" now becomes checklist, to clearly indicate that this checkbox needs to be checked. Also, `make prepush` does more than format, so I dropped that heading.







### Testing Strategy

n/a


### TODO or Help Wanted

Thoughts?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
