### PR TITLE
chips/lowrisc/uart: fix rx timeout register writes

### DIFF
--- a/chips/lowrisc/src/uart.rs
+++ b/chips/lowrisc/src/uart.rs
@@ -132,15 +132,13 @@ impl<'a> Uart<'a> {
     fn enable_rx_timeout(&self, interbyte_timeout: u8) {
         let regs = self.registers;
 
-        // Program the timeout value
+        // Program the timeout value and enable the RX timeout feature in a
+        // single write, as a separate write to set EN would clear VAL.
         regs.timeout_ctrl
-            .write(TIMEOUT_CTRL::VAL.val(interbyte_timeout as u32));
-
-        // Enable RX timeout feature
-        regs.timeout_ctrl.write(TIMEOUT_CTRL::EN::SET);
+            .write(TIMEOUT_CTRL::VAL.val(interbyte_timeout as u32) + TIMEOUT_CTRL::EN::SET);
 
         // Enable RX timeout interrupt
-        regs.intr_enable.write(INTR::RX_TIMEOUT::SET);
+        regs.intr_enable.modify(INTR::RX_TIMEOUT::SET);
     }
 
     fn disable_rx_timeout(&self) {


### PR DESCRIPTION
### Pull Request Overview

Fixes #4006.

`enable_rx_timeout()` in the LowRISC UART driver programs `TIMEOUT_CTRL.VAL` and then sets `TIMEOUT_CTRL.EN` with a second `write()`. Since `write()` zeroes every field it does not mention, the second write clears the timeout value that was just programmed, and the hardware ends up with `EN=1, VAL=0` instead of the interbyte timeout requested through `receive_automatic()`.

This patch programs `VAL` and `EN` in a single `write()`.

The `INTR_ENABLE` write in the same function has the same problem: it clears every other interrupt enable bit, which would drop the `TX_EMPTY` enable if a transmit was in flight (`RX_WATERMARK` is masked too, though the only call site re-enables it immediately afterwards). This is switched to `modify()`, mirroring `disable_rx_timeout()` in the same file. The `intr_state` writes in the neighboring functions are intentionally left as `write()`, since that register is write-1-to-clear.

### Testing Strategy

- `make -C boards/opentitan/earlgrey-cw310` builds cleanly before and after the change, with identical section sizes (text 121900, data 28, bss 20528).
- `make prepush` passes.
- Applied the exact before/after write sequences to `InMemoryRegister`s with the same bitfield layout on the host (tock-registers 0.10.0, the version this workspace pins):

  <details>
  <summary>Host demonstration output</summary>

  ```text
  BEFORE fix:
    TIMEOUT_CTRL = 0x80000000  (EN=1, VAL=0)   <-- requested VAL=250
    INTR_ENABLE  = 0x00000040  (RX_TIMEOUT=1, TX_EMPTY=0)  <-- TX_EMPTY was 1
  AFTER fix:
    TIMEOUT_CTRL = 0x800000fa  (EN=1, VAL=250)
    INTR_ENABLE  = 0x00000044  (RX_TIMEOUT=1, TX_EMPTY=1)
  ```

  </details>

- Not tested on hardware: no in-tree earlgrey board exercises `receive_automatic()`, so this path is not reachable from CI.

### TODO or Help Wanted

This pull request may still need validation on OpenTitan hardware, if anyone has a setup that exercises `receive_automatic()`.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
