### PR TITLE
nucleo_u545re_q: enable GPIO syscall driver

### DIFF
--- a/boards/nucleo_u545re_q/src/main.rs
+++ b/boards/nucleo_u545re_q/src/main.rs
@@ -26,9 +26,12 @@ extern "C" {
 
 const NUM_PROCS: usize = 4;
 
+type GpioHw = stm32u545::gpio::Pin<'static>;
 type ChipHw =
     stm32u545::chip::Stm32u5xx<'static, stm32u545::chip::Stm32u5xxDefaultPeripherals<'static>>;
 type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
+
+type GpioDriver = components::gpio::GpioComponentType<GpioHw>;
 
 static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
     SingleThreadValue::new();
@@ -52,6 +55,7 @@ struct NucleoU545RE {
             stm32u545::tim::Tim2<'static>,
         >,
     >,
+    gpio: &'static GpioDriver,
 }
 
 impl SyscallDriverLookup for NucleoU545RE {
@@ -64,6 +68,7 @@ impl SyscallDriverLookup for NucleoU545RE {
             capsules_core::led::DRIVER_NUM => f(Some(self.led)),
             capsules_core::button::DRIVER_NUM => f(Some(self.button)),
             capsules_core::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules_core::gpio::DRIVER_NUM => f(Some(self.gpio)),
             _ => f(None),
         }
     }
@@ -233,6 +238,37 @@ unsafe fn start() -> (
     )
     .finalize(components::button_component_static!(stm32u545::gpio::Pin));
 
+    let gpio = components::gpio::GpioComponent::new(
+        board_kernel,
+        capsules_core::gpio::DRIVER_NUM,
+        components::gpio_component_helper_owned!(
+            GpioHw,
+            // CN7
+            0 => periphs.gpio_c.pin(PinId::Pin10),
+            1 => periphs.gpio_c.pin(PinId::Pin11),
+            2 => periphs.gpio_c.pin(PinId::Pin12),
+            3 => periphs.gpio_a.pin(PinId::Pin15),
+            4 => periphs.gpio_a.pin(PinId::Pin00),
+            5 => periphs.gpio_a.pin(PinId::Pin01),
+            6 => periphs.gpio_a.pin(PinId::Pin04),
+            7 => periphs.gpio_c.pin(PinId::Pin02),
+            8 => periphs.gpio_c.pin(PinId::Pin01),
+            9 => periphs.gpio_c.pin(PinId::Pin03),
+            10 => periphs.gpio_c.pin(PinId::Pin00),
+            // CN10
+            11 => periphs.gpio_a.pin(PinId::Pin06),
+            12 => periphs.gpio_a.pin(PinId::Pin07),
+            13 => periphs.gpio_c.pin(PinId::Pin09),
+            14 => periphs.gpio_c.pin(PinId::Pin06),
+            15 => periphs.gpio_c.pin(PinId::Pin07),
+            16 => periphs.gpio_a.pin(PinId::Pin08),
+            17 => periphs.gpio_c.pin(PinId::Pin08),
+            18 => periphs.gpio_a.pin(PinId::Pin02),
+            19 => periphs.gpio_a.pin(PinId::Pin03),
+        ),
+    )
+    .finalize(components::gpio_component_static!(GpioHw));
+
     // Platform and Interrupts
     let platform = static_init!(
         NucleoU545RE,
@@ -244,6 +280,7 @@ unsafe fn start() -> (
             led,
             button,
             alarm,
+            gpio,
         }
     );
 

--- a/boards/nucleo_u545re_q/src/main.rs
+++ b/boards/nucleo_u545re_q/src/main.rs
@@ -243,28 +243,34 @@ unsafe fn start() -> (
         capsules_core::gpio::DRIVER_NUM,
         components::gpio_component_helper_owned!(
             GpioHw,
-            // CN7
-            0 => periphs.gpio_c.pin(PinId::Pin10),
-            1 => periphs.gpio_c.pin(PinId::Pin11),
-            2 => periphs.gpio_c.pin(PinId::Pin12),
-            3 => periphs.gpio_a.pin(PinId::Pin15),
-            4 => periphs.gpio_a.pin(PinId::Pin00),
-            5 => periphs.gpio_a.pin(PinId::Pin01),
-            6 => periphs.gpio_a.pin(PinId::Pin04),
-            7 => periphs.gpio_c.pin(PinId::Pin02),
-            8 => periphs.gpio_c.pin(PinId::Pin01),
-            9 => periphs.gpio_c.pin(PinId::Pin03),
-            10 => periphs.gpio_c.pin(PinId::Pin00),
-            // CN10
-            11 => periphs.gpio_a.pin(PinId::Pin06),
-            12 => periphs.gpio_a.pin(PinId::Pin07),
-            13 => periphs.gpio_c.pin(PinId::Pin09),
-            14 => periphs.gpio_c.pin(PinId::Pin06),
-            15 => periphs.gpio_c.pin(PinId::Pin07),
-            16 => periphs.gpio_a.pin(PinId::Pin08),
-            17 => periphs.gpio_c.pin(PinId::Pin08),
-            18 => periphs.gpio_a.pin(PinId::Pin02),
-            19 => periphs.gpio_a.pin(PinId::Pin03),
+            // Digital pins
+            0 => periphs.gpio_a.pin(PinId::Pin03), // D0
+            1 => periphs.gpio_a.pin(PinId::Pin02), // D1
+            2 => periphs.gpio_c.pin(PinId::Pin08), // D2
+            // D3-D6 require GPIOB
+            7 => periphs.gpio_a.pin(PinId::Pin08), // D7
+            8 => periphs.gpio_c.pin(PinId::Pin07), // D8
+            9 => periphs.gpio_c.pin(PinId::Pin06), // D9
+            10 => periphs.gpio_c.pin(PinId::Pin09), // D10
+            11 => periphs.gpio_a.pin(PinId::Pin07), // D11
+            12 => periphs.gpio_a.pin(PinId::Pin06), // D12
+            // 13 => D13/PA5 is used by the LD2 LED capsule
+            // D14-D15 require GPIOB
+
+            // Analog pins exposed as GPIO
+            16 => periphs.gpio_a.pin(PinId::Pin00), // A0
+            17 => periphs.gpio_a.pin(PinId::Pin01), // A1
+            18 => periphs.gpio_a.pin(PinId::Pin04), // A2
+            // 19 => A3 requires GPIOB
+            20 => periphs.gpio_c.pin(PinId::Pin01), // A4
+            21 => periphs.gpio_c.pin(PinId::Pin00), // A5
+
+            // ST Morpho-only GPIO pins (no D/A aliases)
+            22 => periphs.gpio_c.pin(PinId::Pin10), // CN7 pin 1
+            23 => periphs.gpio_c.pin(PinId::Pin11), // CN7 pin 2
+            24 => periphs.gpio_c.pin(PinId::Pin12), // CN7 pin 3
+            25 => periphs.gpio_a.pin(PinId::Pin15), // CN7 pin 17
+            26 => periphs.gpio_c.pin(PinId::Pin03), // CN7 pin 37
         ),
     )
     .finalize(components::gpio_component_static!(GpioHw));


### PR DESCRIPTION
### Pull Request Overview

Closes #4909 

The driver exposes 19 currently supported and unreserved GPIOA/GPIOC pins. Userspace GPIO identifiers follow the board-visible connector names where available:

- GPIO IDs 0–15 correspond to D0–D15.
- GPIO IDs 16–21 correspond to A0–A5.
- GPIO IDs 22–26 expose additional GPIOs available only through the Morpho connector. These pins do not have D/A aliases.

Unavailable identifiers remain holes in the mapping:

- D3–D6, D14–D15, and A3 require GPIOB support.
- D13/PA5 remains owned by the LD2 LED capsule.

### Testing Strategy

- `make -C boards/nucleo_u545re_q`
- `make prepush`

Both completed successfully. The pin assignments were also checked
against Table 14, 15, and 16 of the STM32U3/U5 Nucleo-64 board user manual.

This table can be found on page 34-35 of [the user manual](https://www.st.com/resource/en/user_manual/um3062-stm32u3u5-nucleo64-boards-mb1841-stmicroelectronics.pdf).

### TODO or Help Wanted

This PR would be best paired if someone could do a hardware smoketest for GPIO input/output on a real nucleo_u545re_q board.

Furthermore, the STM32U5 interrupt dispatcher currently routes only EXTI13. This means userspace GPIO interrupt upcalls require follow-up work. This should most likely be a separate issue. 

We should also later add support on the rest of the pins, right now we only support GPIOA and GPIOC. It would be nice to add support for GPIOH and GPIOB. You can find details on page 34-35 of [the user manual](https://www.st.com/resource/en/user_manual/um3062-stm32u3u5-nucleo64-boards-mb1841-stmicroelectronics.pdf)

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.

Codex was used mainly for learning the repo and helping me understand the schematics from STM as well as mapping out the pins. The actual code itself was written by hand and verified.