### PR TITLE
chips: stm32u5xx: Implemented SPI Master driver

### DIFF
--- a/boards/nucleo_u545re_q/src/main.rs
+++ b/boards/nucleo_u545re_q/src/main.rs
@@ -6,16 +6,22 @@
 #![no_std]
 #![no_main]
 
+use core::arch::asm;
+
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::debug::PanicResources;
 use kernel::deferred_call::DeferredCallClient;
+use kernel::hil::gpio::Output;
+use kernel::hil::spi::SpiMaster;
+use kernel::hil::time::{Ticks, Timer};
 use kernel::platform::chip::Chip;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::utilities::single_thread_value::SingleThreadValue;
 use kernel::{create_capability, static_init};
 
 use stm32u545::gpio::PinId;
+use stm32u545::spi;
 
 pub mod io;
 
@@ -39,17 +45,24 @@ struct NucleoU545RE {
     console: &'static capsules_core::console::Console<'static>,
     scheduler: &'static components::sched::round_robin::RoundRobinComponentType,
     systick: cortexm33::systick::SysTick,
-    led: &'static capsules_core::led::LedDriver<
-        'static,
-        kernel::hil::led::LedHigh<'static, stm32u545::gpio::Pin<'static>>,
-        1,
-    >,
+    // led: &'static capsules_core::led::LedDriver<
+    //     'static,
+    //     kernel::hil::led::LedHigh<'static, stm32u545::gpio::Pin<'static>>,
+    //     1,
+    // >,
     button: &'static capsules_core::button::Button<'static, stm32u545::gpio::Pin<'static>>,
     alarm: &'static capsules_core::alarm::AlarmDriver<
         'static,
         capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<
             'static,
             stm32u545::tim::Tim2<'static>,
+        >,
+    >,
+    spi: &'static capsules_core::spi_controller::Spi<
+        'static,
+        capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<
+            'static,
+            stm32u545::spi::Spi<'static>,
         >,
     >,
 }
@@ -61,9 +74,10 @@ impl SyscallDriverLookup for NucleoU545RE {
     {
         match driver_num {
             capsules_core::console::DRIVER_NUM => f(Some(self.console)),
-            capsules_core::led::DRIVER_NUM => f(Some(self.led)),
+            // capsules_core::led::DRIVER_NUM => f(Some(self.led)),
             capsules_core::button::DRIVER_NUM => f(Some(self.button)),
             capsules_core::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules_core::spi_controller::DRIVER_NUM => f(Some(self.spi)),
             _ => f(None),
         }
     }
@@ -115,8 +129,30 @@ unsafe fn set_pin_primary_functions(periphs: &stm32u545::chip::Stm32u5xxDefaultP
     pin10.set_alternate_function(7);
     pin10.set_speed_high();
 
-    // LED Pin (PA5)
-    periphs.gpio_a.pin(PinId::Pin05).make_output();
+    // SPI1 Pins
+    // SPI_CLOCK + LED Pin (PA5)
+    let spi1_sck = periphs.gpio_a.pin(PinId::Pin05);
+    spi1_sck.set_mode(stm32u545::gpio::Mode::AlternateFunction);
+    spi1_sck.set_alternate_function(5);
+    spi1_sck.set_speed_high();
+
+    // SPI_MISO (PA6)
+    let spi1_miso = periphs.gpio_a.pin(PinId::Pin06);
+    spi1_miso.set_mode(stm32u545::gpio::Mode::AlternateFunction);
+    spi1_miso.set_alternate_function(5);
+    spi1_miso.set_speed_high();
+
+    // SPI_MOSI (PA7)
+    let spi1_mosi = periphs.gpio_a.pin(PinId::Pin07);
+    spi1_mosi.set_mode(stm32u545::gpio::Mode::AlternateFunction);
+    spi1_mosi.set_alternate_function(5);
+    spi1_mosi.set_speed_high();
+
+    // SPI1_CS (PC9)
+    let spi1_cs = periphs.gpio_c.pin(PinId::Pin09);
+    spi1_cs.set_mode(stm32u545::gpio::Mode::AlternateFunction);
+    spi1_cs.set_alternate_function(5);
+    spi1_cs.set_speed_high();
 
     // Button Pin (PC13) - Hardware is Active High
     let btn = periphs.gpio_c.pin(PinId::Pin13);
@@ -152,10 +188,15 @@ unsafe fn start() -> (
     );
     usart1.register();
 
+    let spi1 = static_init!(
+        stm32u545::spi::Spi<'static>,
+        stm32u545::spi::Spi::new(stm32u545::spi::SPI1_BASE)
+    );
+
     // Load Peripherals Bundle
     let periphs = static_init!(
         stm32u545::chip::Stm32u5xxDefaultPeripherals<'static>,
-        stm32u545::chip::Stm32u5xxDefaultPeripherals::new(usart1, exti, dma1)
+        stm32u545::chip::Stm32u5xxDefaultPeripherals::new(usart1, spi1, exti, dma1)
     );
 
     // Initialize wiring (DMA, clocks)
@@ -172,6 +213,9 @@ unsafe fn start() -> (
 
     let uart_mux = components::console::UartMuxComponent::new(periphs.usart1, 115200)
         .finalize(components::uart_mux_component_static!());
+
+    let spi_mux = components::spi::SpiMuxComponent::new(periphs.spi1)
+        .finalize(components::spi_mux_component_static!(stm32u545::spi::Spi));
 
     let alarm_mux = components::alarm::AlarmMuxComponent::new(&periphs.tim2).finalize(
         components::alarm_mux_component_static!(stm32u545::tim::Tim2),
@@ -213,10 +257,28 @@ unsafe fn start() -> (
     )
     .finalize(components::alarm_component_static!(stm32u545::tim::Tim2));
 
-    let led_pin = static_init!(stm32u545::gpio::Pin, periphs.gpio_a.pin(PinId::Pin05));
-    let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
-        kernel::hil::led::LedHigh<'static, stm32u545::gpio::Pin>,
-        kernel::hil::led::LedHigh::new(led_pin)
+    // let led_pin = static_init!(stm32u545::gpio::Pin, periphs.gpio_a.pin(PinId::Pin05));
+    // let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
+    //     kernel::hil::led::LedHigh<'static, stm32u545::gpio::Pin>,
+    //     kernel::hil::led::LedHigh::new(led_pin)
+    // ));
+
+    let spi_cs = static_init!(
+        stm32u545::gpio::Pin<'static>,
+        periphs.gpio_c.pin(PinId::Pin09)
+    );
+
+    kernel::hil::gpio::Configure::make_output(spi_cs);
+    kernel::hil::gpio::Output::set(spi_cs);
+
+    let spi_syscalls = components::spi::SpiSyscallComponent::new(
+        board_kernel,
+        spi_mux,
+        spi_cs,
+        capsules_core::spi_controller::DRIVER_NUM,
+    )
+    .finalize(components::spi_syscall_component_static!(
+        stm32u545::spi::Spi<'static>
     ));
 
     let button = components::button::ButtonComponent::new(
@@ -241,9 +303,10 @@ unsafe fn start() -> (
             scheduler: components::sched::round_robin::RoundRobinComponent::new(processes)
                 .finalize(components::round_robin_component_static!(NUM_PROCS)),
             systick: cortexm33::systick::SysTick::new(),
-            led,
+            // led,
             button,
             alarm,
+            spi: spi_syscalls,
         }
     );
 
@@ -251,6 +314,22 @@ unsafe fn start() -> (
         stm32u545::chip::Stm32u5xx<stm32u545::chip::Stm32u5xxDefaultPeripherals>,
         stm32u545::chip::Stm32u5xx::new(periphs)
     );
+
+    // let _ = spi1.init();
+    // let spi1_cs_test = periphs.gpio_a.pin(PinId::Pin08);
+    // spi1_cs_test.set_mode(stm32u545::gpio::Mode::Output);
+
+    // while true {
+    //     spi1_cs_test.clear();
+    //     spi1.write_byte(250);
+    //     spi1_cs_test.set();
+    //     for _ in 0..80000 {
+    //         // The compiler will keep this loop because of the assembly instruction
+    //         unsafe {
+    //             asm!("nop");
+    //         }
+    //     }
+    // }
 
     // Symbols for linker
     extern "C" {

--- a/boards/nucleo_u545re_q/src/main.rs
+++ b/boards/nucleo_u545re_q/src/main.rs
@@ -40,11 +40,11 @@ struct NucleoU545RE {
     console: &'static capsules_core::console::Console<'static>,
     scheduler: &'static components::sched::round_robin::RoundRobinComponentType,
     systick: cortexm33::systick::SysTick,
-    // led: &'static capsules_core::led::LedDriver<
-    //     'static,
-    //     kernel::hil::led::LedHigh<'static, stm32u545::gpio::Pin<'static>>,
-    //     1,
-    // >,
+    led: &'static capsules_core::led::LedDriver<
+        'static,
+        kernel::hil::led::LedHigh<'static, stm32u545::gpio::Pin<'static>>,
+        1,
+    >,
     button: &'static capsules_core::button::Button<'static, stm32u545::gpio::Pin<'static>>,
     alarm: &'static capsules_core::alarm::AlarmDriver<
         'static,
@@ -69,7 +69,7 @@ impl SyscallDriverLookup for NucleoU545RE {
     {
         match driver_num {
             capsules_core::console::DRIVER_NUM => f(Some(self.console)),
-            // capsules_core::led::DRIVER_NUM => f(Some(self.led)),
+            capsules_core::led::DRIVER_NUM => f(Some(self.led)),
             capsules_core::button::DRIVER_NUM => f(Some(self.button)),
             capsules_core::alarm::DRIVER_NUM => f(Some(self.alarm)),
             capsules_core::spi_controller::DRIVER_NUM => f(Some(self.spi)),
@@ -124,9 +124,13 @@ unsafe fn set_pin_primary_functions(periphs: &stm32u545::chip::Stm32u5xxDefaultP
     pin10.set_alternate_function(7);
     pin10.set_speed_high();
 
+    // LED Pin (PA5)
+    periphs.gpio_a.pin(PinId::Pin05).make_output();
+
     // SPI1 Pins
-    // SPI_CLOCK + LED Pin (PA5)
-    let spi1_sck = periphs.gpio_a.pin(PinId::Pin05);
+    // SPI_CLOCK (PB3)
+    // Warning: SCLK used PB3 instead of PA5 because it would conflict with the on-board LED
+    let spi1_sck = periphs.gpio_b.pin(PinId::Pin03);
     spi1_sck.set_mode(stm32u545::gpio::Mode::AlternateFunction);
     spi1_sck.set_alternate_function(5);
     spi1_sck.set_speed_high();
@@ -252,11 +256,11 @@ unsafe fn start() -> (
     )
     .finalize(components::alarm_component_static!(stm32u545::tim::Tim2));
 
-    // let led_pin = static_init!(stm32u545::gpio::Pin, periphs.gpio_a.pin(PinId::Pin05));
-    // let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
-    //     kernel::hil::led::LedHigh<'static, stm32u545::gpio::Pin>,
-    //     kernel::hil::led::LedHigh::new(led_pin)
-    // ));
+    let led_pin = static_init!(stm32u545::gpio::Pin, periphs.gpio_a.pin(PinId::Pin05));
+    let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
+        kernel::hil::led::LedHigh<'static, stm32u545::gpio::Pin>,
+        kernel::hil::led::LedHigh::new(led_pin)
+    ));
 
     let spi_cs = static_init!(
         stm32u545::gpio::Pin<'static>,
@@ -298,7 +302,7 @@ unsafe fn start() -> (
             scheduler: components::sched::round_robin::RoundRobinComponent::new(processes)
                 .finalize(components::round_robin_component_static!(NUM_PROCS)),
             systick: cortexm33::systick::SysTick::new(),
-            // led,
+            led,
             button,
             alarm,
             spi: spi_syscalls,
@@ -311,36 +315,6 @@ unsafe fn start() -> (
     );
 
     let _ = spi1.init();
-    // let spi1_cs_test = periphs.gpio_a.pin(PinId::Pin08);
-    // spi1_cs_test.set_mode(stm32u545::gpio::Mode::Output);
-
-    // spi1_cs_test.set();
-    // let tx_buf = static_init!([u8; 4], [0x00, 0x69, 0x42, 0xFF]);
-    // let rx_buf = static_init!([u8; 4], [0x00; 4]);
-
-    // let write_buffer = SubSliceMut::new(tx_buf);
-    // let read_buffer = SubSliceMut::new(rx_buf);
-
-    // spi1_cs_test.clear();
-    // spi1.read_write_bytes(write_buffer, Some(read_buffer));
-    // for _ in 0..80000 {
-    //     unsafe {
-    //         asm!("nop");
-    //     }
-    // }
-    // spi1_cs_test.set();
-
-    // while true {
-    //     spi1_cs_test.clear();
-    //     spi1.write_byte(250);
-    //     spi1_cs_test.set();
-    //     for _ in 0..80000 {
-    //         // The compiler will keep this loop because of the assembly instruction
-    //         unsafe {
-    //             asm!("nop");
-    //         }
-    //     }
-    // }
 
     // Symbols for linker
     extern "C" {

--- a/boards/nucleo_u545re_q/src/main.rs
+++ b/boards/nucleo_u545re_q/src/main.rs
@@ -6,22 +6,17 @@
 #![no_std]
 #![no_main]
 
-use core::arch::asm;
-
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::debug::PanicResources;
 use kernel::deferred_call::DeferredCallClient;
-use kernel::hil::gpio::Output;
 use kernel::hil::spi::SpiMaster;
-use kernel::hil::time::{Ticks, Timer};
 use kernel::platform::chip::Chip;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::utilities::single_thread_value::SingleThreadValue;
 use kernel::{create_capability, static_init};
 
 use stm32u545::gpio::PinId;
-use stm32u545::spi;
 
 pub mod io;
 
@@ -315,9 +310,25 @@ unsafe fn start() -> (
         stm32u545::chip::Stm32u5xx::new(periphs)
     );
 
-    // let _ = spi1.init();
+    let _ = spi1.init();
     // let spi1_cs_test = periphs.gpio_a.pin(PinId::Pin08);
     // spi1_cs_test.set_mode(stm32u545::gpio::Mode::Output);
+
+    // spi1_cs_test.set();
+    // let tx_buf = static_init!([u8; 4], [0x00, 0x69, 0x42, 0xFF]);
+    // let rx_buf = static_init!([u8; 4], [0x00; 4]);
+
+    // let write_buffer = SubSliceMut::new(tx_buf);
+    // let read_buffer = SubSliceMut::new(rx_buf);
+
+    // spi1_cs_test.clear();
+    // spi1.read_write_bytes(write_buffer, Some(read_buffer));
+    // for _ in 0..80000 {
+    //     unsafe {
+    //         asm!("nop");
+    //     }
+    // }
+    // spi1_cs_test.set();
 
     // while true {
     //     spi1_cs_test.clear();

--- a/chips/stm32f4xx/src/spi.rs
+++ b/chips/stm32f4xx/src/spi.rs
@@ -423,8 +423,6 @@ impl<'a> spi::SpiMaster<'a> for Spi<'a> {
         Ok(rate)
     }
 
-    /// We *only* support 1Mhz and 4MHz. If we need to return any other value
-    /// than `1_000_000` or `4_000_000`, then this function panics.
     fn get_rate(&self) -> u32 {
         // HSI is 16Mhz and Fpclk is also 16Mhz
         match self.registers.cr1.read(CR1::BR) {

--- a/chips/stm32u545/src/lib.rs
+++ b/chips/stm32u545/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![no_std]
 
-pub use stm32u5xx::{chip, dma, exti, gpio, rcc, tim, usart};
+pub use stm32u5xx::{chip, dma, exti, gpio, rcc, spi, tim, usart};
 
 use cortexm33::{CortexM33, CortexMVariant};
 

--- a/chips/stm32u5xx/src/chip.rs
+++ b/chips/stm32u5xx/src/chip.rs
@@ -10,9 +10,10 @@ use crate::nvic::{
     EXTI13_IRQ, GPDMA1_CH0_IRQ, GPDMA1_CH10_IRQ, GPDMA1_CH11_IRQ, GPDMA1_CH12_IRQ, GPDMA1_CH13_IRQ,
     GPDMA1_CH14_IRQ, GPDMA1_CH15_IRQ, GPDMA1_CH1_IRQ, GPDMA1_CH2_IRQ, GPDMA1_CH3_IRQ,
     GPDMA1_CH4_IRQ, GPDMA1_CH5_IRQ, GPDMA1_CH6_IRQ, GPDMA1_CH7_IRQ, GPDMA1_CH8_IRQ, GPDMA1_CH9_IRQ,
-    TIM2_IRQ, USART1_IRQ,
+    SPI1_IRQ, TIM2_IRQ, USART1_IRQ,
 };
 use crate::rcc;
+use crate::spi;
 use crate::tim;
 use crate::usart;
 
@@ -30,6 +31,7 @@ pub struct Stm32u5xxDefaultPeripherals<'a> {
     pub rcc: rcc::Rcc,
     pub tim2: tim::Tim2<'a>,
     pub usart1: &'a usart::Usart<'a>,
+    pub spi1: &'a spi::Spi<'a>,
     pub exti: &'a exti::Exti<'a>,
     pub dma1: &'a Dma,
     pub gpio_a: gpio::Port<'a>,
@@ -42,11 +44,17 @@ fn enable_tim2_clock() {
 }
 
 impl<'a> Stm32u5xxDefaultPeripherals<'a> {
-    pub fn new(usart1: &'a usart::Usart<'a>, exti: &'a exti::Exti<'a>, dma1: &'a Dma) -> Self {
+    pub fn new(
+        usart1: &'a usart::Usart<'a>,
+        spi1: &'a spi::Spi<'a>,
+        exti: &'a exti::Exti<'a>,
+        dma1: &'a Dma,
+    ) -> Self {
         Self {
             rcc: rcc::Rcc::new(rcc::RCC_BASE),
             tim2: tim::Tim2::new(tim::TIM2_BASE, enable_tim2_clock),
             usart1,
+            spi1,
             exti,
             dma1,
             gpio_a: gpio::Port::new(gpio::GPIO_A_BASE, exti, gpio::GpioPort::PortA),
@@ -60,6 +68,7 @@ impl<'a> Stm32u5xxDefaultPeripherals<'a> {
         self.rcc.enable_gpioa();
         self.rcc.enable_gpioc();
         self.rcc.enable_usart1();
+        self.rcc.enable_spi1();
         self.rcc.enable_syscfg();
         self.rcc.set_usart1_source_pclk();
         // Link DMA to USART1
@@ -68,6 +77,14 @@ impl<'a> Stm32u5xxDefaultPeripherals<'a> {
 
         if let (Some(tx), Some(rx)) = (usart1_channel_tx, usart1_channel_rx) {
             usart::Usart::set_dma(self.usart1, self.dma1, tx, rx);
+        }
+
+        // Link DMA to SPI1
+        let spi1_channel_tx = self.dma1.request_channel();
+        let spi1_channel_rx = self.dma1.request_channel();
+
+        if let (Some(tx), Some(rx)) = (spi1_channel_tx, spi1_channel_rx) {
+            spi::Spi::set_dma(self.spi1, self.dma1, tx, rx);
         }
     }
 }
@@ -83,6 +100,11 @@ impl InterruptService for Stm32u5xxDefaultPeripherals<'_> {
             USART1_IRQ => {
                 // USART1
                 self.usart1.handle_interrupt();
+                true
+            }
+            SPI1_IRQ => {
+                // SPI1
+                self.spi1.handle_interrupt();
                 true
             }
             EXTI13_IRQ => {

--- a/chips/stm32u5xx/src/chip.rs
+++ b/chips/stm32u5xx/src/chip.rs
@@ -35,6 +35,7 @@ pub struct Stm32u5xxDefaultPeripherals<'a> {
     pub exti: &'a exti::Exti<'a>,
     pub dma1: &'a Dma,
     pub gpio_a: gpio::Port<'a>,
+    pub gpio_b: gpio::Port<'a>,
     pub gpio_c: gpio::Port<'a>,
 }
 
@@ -58,6 +59,7 @@ impl<'a> Stm32u5xxDefaultPeripherals<'a> {
             exti,
             dma1,
             gpio_a: gpio::Port::new(gpio::GPIO_A_BASE, exti, gpio::GpioPort::PortA),
+            gpio_b: gpio::Port::new(gpio::GPIO_B_BASE, exti, gpio::GpioPort::PortB),
             gpio_c: gpio::Port::new(gpio::GPIO_C_BASE, exti, gpio::GpioPort::PortC),
         }
     }
@@ -66,6 +68,7 @@ impl<'a> Stm32u5xxDefaultPeripherals<'a> {
         // Power and Wires
         self.rcc.enable_dma1();
         self.rcc.enable_gpioa();
+        self.rcc.enable_gpiob();
         self.rcc.enable_gpioc();
         self.rcc.enable_usart1();
         self.rcc.enable_spi1();

--- a/chips/stm32u5xx/src/dma.rs
+++ b/chips/stm32u5xx/src/dma.rs
@@ -11,16 +11,23 @@ use kernel::utilities::registers::{
 use kernel::utilities::StaticRef;
 
 /// Base address for USART1 in Secure Alias mode.
-const USART1_BASE_ADDR: u32 = 0x50013800;
+const USART1_BASE_ADDR: u32 = 0x5001_3800;
 /// USART1 Receive Data Register (RDR) address.
 const USART1_RDR: u32 = USART1_BASE_ADDR + 0x24;
 /// USART1 Transmit Data Register (TDR) address.
 const USART1_TDR: u32 = USART1_BASE_ADDR + 0x28;
 
+/// Base address for SPI1 in Secure Alias mode.
+const SPI1_BASE_ADDR: u32 = 0x5001_3000;
+const SPI1_RXDR: u32 = SPI1_BASE_ADDR + 0x030;
+const SPI1_TXDR: u32 = SPI1_BASE_ADDR + 0x020;
+
 /// GPDMA Request Selection IDs (REQSEL)
 /// Found in the GPDMA request multiplexer table of the STM32U5 reference manual.
 const GPDMA_REQ_USART1_RX: u32 = 24;
 const GPDMA_REQ_USART1_TX: u32 = 25;
+const GPDMA_REQ_SPI1_RX: u32 = 6;
+const GPDMA_REQ_SPI1_TX: u32 = 7;
 
 register_bitfields! [
     u32,
@@ -205,6 +212,8 @@ pub enum DmaDirection {
 pub enum DmaPeripheral {
     Usart1Tx,
     Usart1Rx,
+    Spi1Tx,
+    Spi1Rx,
 }
 
 impl DmaPeripheral {
@@ -218,6 +227,16 @@ impl DmaPeripheral {
             DmaPeripheral::Usart1Rx => (
                 USART1_RDR,
                 GPDMA_REQ_USART1_RX,
+                DmaDirection::PeripheralToMemory,
+            ),
+            DmaPeripheral::Spi1Tx => (
+                SPI1_TXDR,
+                GPDMA_REQ_SPI1_TX,
+                DmaDirection::MemoryToPeripheral,
+            ),
+            DmaPeripheral::Spi1Rx => (
+                SPI1_RXDR,
+                GPDMA_REQ_SPI1_RX,
                 DmaDirection::PeripheralToMemory,
             ),
         }

--- a/chips/stm32u5xx/src/gpio.rs
+++ b/chips/stm32u5xx/src/gpio.rs
@@ -351,6 +351,9 @@ register_bitfields![u32,
 pub const GPIO_A_BASE: StaticRef<GpioRegisters> =
     unsafe { StaticRef::new(0x52020000 as *const GpioRegisters) };
 
+pub const GPIO_B_BASE: StaticRef<GpioRegisters> =
+    unsafe { StaticRef::new(0x52020400 as *const GpioRegisters) };
+
 pub const GPIO_C_BASE: StaticRef<GpioRegisters> =
     unsafe { StaticRef::new(0x52020800 as *const GpioRegisters) };
 

--- a/chips/stm32u5xx/src/lib.rs
+++ b/chips/stm32u5xx/src/lib.rs
@@ -10,6 +10,7 @@ pub mod exti;
 pub mod gpio;
 pub mod nvic;
 pub mod rcc;
+pub mod spi;
 pub mod tim;
 pub mod usart;
 

--- a/chips/stm32u5xx/src/rcc.rs
+++ b/chips/stm32u5xx/src/rcc.rs
@@ -51,7 +51,8 @@ register_bitfields![u32,
         TIM2EN OFFSET(0) NUMBITS(1) []
     ],
     pub APB2ENR [
-        USART1EN OFFSET(14) NUMBITS(1) []
+        USART1EN OFFSET(14) NUMBITS(1) [],
+        SPI1EN OFFSET(12) NUMBITS(1) []
     ],
     pub APB3ENR [
         SYSCFGEN OFFSET(1) NUMBITS(1) []
@@ -89,6 +90,10 @@ impl Rcc {
 
     pub fn enable_gpioc(&self) {
         self.registers.ahb2enr1.modify(AHB2ENR1::GPIOCEN::SET);
+    }
+
+    pub fn enable_spi1(&self) {
+        self.registers.apb2enr.modify(APB2ENR::SPI1EN::SET);
     }
 
     pub fn enable_usart1(&self) {

--- a/chips/stm32u5xx/src/rcc.rs
+++ b/chips/stm32u5xx/src/rcc.rs
@@ -88,6 +88,10 @@ impl Rcc {
         self.registers.ahb2enr1.modify(AHB2ENR1::GPIOAEN::SET);
     }
 
+    pub fn enable_gpiob(&self) {
+        self.registers.ahb2enr1.modify(AHB2ENR1::GPIOBEN::SET);
+    }
+
     pub fn enable_gpioc(&self) {
         self.registers.ahb2enr1.modify(AHB2ENR1::GPIOCEN::SET);
     }

--- a/chips/stm32u5xx/src/spi.rs
+++ b/chips/stm32u5xx/src/spi.rs
@@ -2,11 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2026.
 
-use crate::dma::{self, ChannelId, Dma, DmaPeripheral};
-use crate::dma::{Dma1, Dma1Peripheral};
-
+use crate::dma::{ChannelId, Dma};
 use core::cell::Cell;
 use core::cmp;
+use cortexm33::dma_fence::CortexMDmaFence;
 use kernel::hil::gpio::Output;
 use kernel::hil::spi::{self, ClockPhase, ClockPolarity};
 use kernel::utilities::cells::{MapCell, OptionalCell};
@@ -425,8 +424,8 @@ pub struct Spi<'a> {
     dma: OptionalCell<&'a Dma>,
     dma_channel_tx: Cell<Option<ChannelId>>,
     dma_channel_rx: Cell<Option<ChannelId>>,
-    tx_dma_peripheral: Cell<Option<DmaPeripheral>>,
-    rx_dma_peripheral: Cell<Option<DmaPeripheral>>,
+    // tx_dma_peripheral: Cell<Option<DmaPeripheral>>,
+    // rx_dma_peripheral: Cell<Option<DmaPeripheral>>,
     tx_dma_buf: MapCell<DmaSubSliceMut<'static, u8>>,
     rx_dma_buf: MapCell<DmaSubSliceMut<'static, u8>>,
     dma_len: Cell<usize>,
@@ -443,8 +442,8 @@ impl<'a> Spi<'a> {
             dma: OptionalCell::empty(),
             dma_channel_tx: Cell::new(None),
             dma_channel_rx: Cell::new(None),
-            tx_dma_peripheral: Cell::new(None),
-            rx_dma_peripheral: Cell::new(None),
+            // tx_dma_peripheral: Cell::new(None),
+            // rx_dma_peripheral: Cell::new(None),
             tx_dma_buf: MapCell::empty(),
             rx_dma_buf: MapCell::empty(),
             dma_len: Cell::new(0),
@@ -454,149 +453,98 @@ impl<'a> Spi<'a> {
         }
     }
 
-    /// Associates a DMA controller and channels with the USART driver.
+    /// associates a DMA controller and channels with the SPI driver.
     pub fn set_dma(
         spi: &'static Self,
         dma: &'a Dma,
-        tx_peripheral: DmaPeripheral,
+        // tx_peripheral: DmaPeripheral,
         tx_channel: ChannelId,
-        rx_peripheral: DmaPeripheral,
+        // rx_peripheral: DmaPeripheral,
         rx_channel: ChannelId,
     ) {
         spi.dma.set(dma);
-        spi.tx_dma_peripheral.set(Some(tx_peripheral));
+        // spi.tx_dma_peripheral.set(Some(tx_peripheral));
         spi.dma_channel_tx.set(Some(tx_channel));
-        spi.rx_dma_peripheral.set(Some(rx_peripheral));
+        // spi.rx_dma_peripheral.set(Some(rx_peripheral));
         spi.dma_channel_rx.set(Some(rx_channel));
-        dma.set_client(tx_channel, spi);
-        dma.set_client(rx_channel, spi);
+        // dma.set_client(tx_channel, spi);
+        // dma.set_client(rx_channel, spi);
     }
 
-    /// 0: SCK signal is at 0 when idle
-    /// 1: SCK signal is at 1 when idle
-    fn set_polarity(&self, polarity: ClockPolarity) {
-        self.set_cr(|| match polarity {
-            ClockPolarity::IdleLow => self.registers.cfg2.modify(CFG2::CPOL::CLEAR),
-            ClockPolarity::IdleHigh => self.registers.cfg2.modify(CFG2::CPOL::SET),
-        });
-    }
-
-    fn get_polarity(&self) -> ClockPolarity {
-        if !self.registers.cfg2.is_set(CFG2::CPOL) {
-            ClockPolarity::IdleLow
-        } else {
-            ClockPolarity::IdleHigh
-        }
-    }
-
-    /// SampleLeading  = CPHA = 0
-    /// SampleTrailing = CPHA = 1
-    fn set_phase(&self, phase: ClockPhase) {
-        self.set_cr(|| match phase {
-            ClockPhase::SampleLeading => self.registers.cfg2.modify(CFG2::CPHA::CLEAR),
-            ClockPhase::SampleTrailing => self.registers.cfg2.modify(CFG2::CPHA::SET),
-        });
-    }
-
-    fn get_phase(&self) -> ClockPhase {
-        if !self.registers.cfg2.is_set(CFG2::CPHA) {
-            ClockPhase::SampleLeading
-        } else {
-            ClockPhase::SampleTrailing
-        }
-    }
-
-    fn set_cr<F>(&self, f: F)
-    where
-        F: FnOnce(),
-    {
-        self.registers.cr1.modify(CR1::SPE::CLEAR);
-        f();
-        self.registers.cr1.modify(CR1::SPE::SET);
-    }
-
-    fn enable_tx(&self) {
-        self.registers.cfg1.modify(CFG1::TXDMAEN::SET);
-    }
-
-    fn disable_tx(&self) {
-        self.registers.cfg1.modify(CFG1::TXDMAEN::CLEAR);
-    }
-
-    fn enable_rx(&self) {
-        self.registers.cfg1.modify(CFG1::RXDMAEN::SET);
-    }
-
-    fn disable_rx(&self) {
-        self.registers.cfg1.modify(CFG1::RXDMAEN::CLEAR);
-    }
-
-    ///*******************  Implemented above this line  *************************
+    // pub fn handle_dma_interrupt(&self, is_tx: bool) {
+    //     if is_tx {
+    //         self.dma.map(|dma| {
+    //             if let Some(ch) = self.dma_channel_tx.get() {
+    //                 dma.clear_interrupt(ch);
+    //             }
+    //         });
+    //         self.registers.cr3.modify(CR3::DMAT::CLEAR);
+    //         self.tx_deferred.set(false);
+    //         if let Some(dma_slice) = self.tx_dma_buf.take() {
+    //             let fence = unsafe { CortexMDmaFence::new() };
+    //             let mut subslice = unsafe { dma_slice.take(fence) };
+    //             subslice.reset();
+    //             let buf = subslice.take();
+    //             let len = self.tx_len.get();
+    //             self.tx_client.map(move |client| {
+    //                 client.transmitted_buffer(buf, len, Ok(()));
+    //             });
+    //         }
+    //     } else {
+    //         self.dma.map(|dma| {
+    //             if let Some(ch) = self.dma_channel_rx.get() {
+    //                 dma.clear_interrupt(ch);
+    //             }
+    //         });
+    //         self.registers.cr3.modify(CR3::DMAR::CLEAR);
+    //         self.rx_deferred.set(false);
+    //         if let Some(dma_slice) = self.rx_dma_buf.take() {
+    //             let fence = unsafe { CortexMDmaFence::new() };
+    //             let mut subslice = unsafe { dma_slice.take(fence) };
+    //             subslice.reset();
+    //             let buf = subslice.take();
+    //             let len = self.rx_len.get();
+    //             self.rx_client.map(move |client| {
+    //                 client.received_buffer(buf, len, Ok(()), uart::Error::None);
+    //             });
+    //         }
+    //     }
+    // }
 
     pub fn handle_interrupt(&self) {
         // Used only during debugging. Since we use DMA, we do not enable SPI
         // interrupts during normal operations
     }
 
-    fn set_active_slave(&self, slave_pin: &'a crate::gpio::Pin<'a>) {
-        self.active_slave.set(slave_pin);
+    fn enable_tx(&self) {
+        self.registers.cfg1.modify(CFG1::TXDMAEN::SET);
     }
 
-    fn read_write_bytes(
-        &self,
-        write_buffer: SubSliceMut<'static, u8>,
-        read_buffer: Option<SubSliceMut<'static, u8>>,
-    ) -> Result<
-        (),
-        (
-            ErrorCode,
-            SubSliceMut<'static, u8>,
-            Option<SubSliceMut<'static, u8>>,
-        ),
-    > {
-        self.active_slave.map(|p| {
-            p.clear();
-        });
+    // fn disable_tx(&self) {
+    //     self.registers.cfg1.modify(CFG1::TXDMAEN::CLEAR);
+    // }
 
-        let mut count: usize = write_buffer.len();
-        read_buffer
-            .as_ref()
-            .map(|buf| count = cmp::min(count, buf.len()));
-
-        self.dma_len.set(count);
-
-        self.transfers_in_progress.set(0);
-
-        read_buffer.map(|rx_buffer| {
-            self.transfers_in_progress
-                .set(self.transfers_in_progress.get() + 1);
-            self.rx_dma.map(move |dma| {
-                dma.do_transfer(rx_buffer);
-            });
-            self.enable_rx();
-        });
-
-        self.transfers_in_progress
-            .set(self.transfers_in_progress.get() + 1);
-        self.tx_dma.map(move |dma| {
-            dma.do_transfer(write_buffer);
-        });
-        self.enable_tx();
-
-        Ok(())
+    fn enable_rx(&self) {
+        self.registers.cfg1.modify(CFG1::RXDMAEN::SET);
     }
+
+    // fn disable_rx(&self) {
+    //     self.registers.cfg1.modify(CFG1::RXDMAEN::CLEAR);
+    // }
 }
 
 impl<'a> spi::SpiMaster<'a> for Spi<'a> {
+    type ChipSelect = &'a crate::gpio::Pin<'a>;
+
     fn set_phase(&self, phase: ClockPhase) -> Result<(), kernel::ErrorCode> {
         let regs = &*self.registers;
 
         match phase {
             ClockPhase::SampleLeading => {
-                regs.cfg2.modify(CFG2::CPOL::CLEAR);
+                regs.cfg2.modify(CFG2::CPHA::CLEAR);
             }
             ClockPhase::SampleTrailing => {
-                regs.cfg2.modify(CFG2::CPOL::SET);
+                regs.cfg2.modify(CFG2::CPHA::SET);
             }
         }
         Ok(())
@@ -607,10 +555,10 @@ impl<'a> spi::SpiMaster<'a> for Spi<'a> {
 
         match polarity {
             ClockPolarity::IdleLow => {
-                regs.cfg2.modify(CFG2::CPHA::CLEAR);
+                regs.cfg2.modify(CFG2::CPOL::CLEAR);
             }
             ClockPolarity::IdleHigh => {
-                regs.cfg2.modify(CFG2::CPHA::SET);
+                regs.cfg2.modify(CFG2::CPOL::SET);
             }
         }
 
@@ -619,25 +567,54 @@ impl<'a> spi::SpiMaster<'a> for Spi<'a> {
 
     fn set_rate(&self, rate: u32) -> Result<u32, kernel::ErrorCode> {
         let regs = &*self.registers;
+        let spi_clock_freq: u32 = 4_000_000;
 
-        regs.cfg1.modify(CFG1::MBR::Div8);
+        let divider = spi_clock_freq / rate;
 
-        // match rate {
-        //     1_000_000 => self.set_cr(|| {
-        //         // HSI is 16Mhz and Fpclk is also 16Mhz. 0b011 is Fpclk / 16
-        //         self.registers.cr1.modify(CR1::BR.val(0b011));
-        //     }),
-        //     4_000_000 => self.set_cr(|| {
-        //         // HSI is 16Mhz and Fpclk is also 16Mhz. 0b001 is Fpclk / 4
-        //         self.registers.cr1.modify(CR1::BR.val(0b001));
-        //     }),
-        //     _ => panic!("SPI rate must be 1_000_000 or 4_000_000"),
-        // }
-        Ok(rate)
+        let (mbr_val, actual_rate) = if divider <= 2 {
+            (CFG1::MBR::Div2, spi_clock_freq / 2)
+        } else if divider <= 4 {
+            (CFG1::MBR::Div4, spi_clock_freq / 4)
+        } else if divider <= 8 {
+            (CFG1::MBR::Div8, spi_clock_freq / 8)
+        } else if divider <= 16 {
+            (CFG1::MBR::Div16, spi_clock_freq / 16)
+        } else if divider <= 32 {
+            (CFG1::MBR::Div32, spi_clock_freq / 32)
+        } else if divider <= 64 {
+            (CFG1::MBR::Div64, spi_clock_freq / 64)
+        } else if divider <= 128 {
+            (CFG1::MBR::Div128, spi_clock_freq / 128)
+        } else {
+            (CFG1::MBR::Div256, spi_clock_freq / 256)
+        };
+
+        if regs.cr1.is_set(CR1::SPE) {
+            regs.cr1.modify(CR1::SPE::CLEAR);
+        }
+
+        self.registers.cfg1.modify(mbr_val);
+
+        if regs.cr1.is_set(CR1::SPE) {
+            regs.cr1.modify(CR1::SPE::SET);
+        }
+
+        Ok(actual_rate)
     }
 
     fn get_rate(&self) -> u32 {
-        69
+        let spi_clock_freq: u32 = 4_000_000;
+
+        match self.registers.cfg1.read(CFG1::MBR) {
+            0b000 => spi_clock_freq / 2,
+            0b001 => spi_clock_freq / 4,
+            0b010 => spi_clock_freq / 8,
+            0b011 => spi_clock_freq / 16,
+            0b100 => spi_clock_freq / 32,
+            0b101 => spi_clock_freq / 64,
+            0b110 => spi_clock_freq / 128,
+            _ => spi_clock_freq / 256,
+        }
     }
 
     fn get_phase(&self) -> ClockPhase {
@@ -681,7 +658,7 @@ impl<'a> spi::SpiMaster<'a> for Spi<'a> {
         regs.cr1.modify(CR1::SPE::CLEAR);
 
         //set baudrate
-        regs.cfg1.modify(CFG1::MBR::Div8);
+        regs.cfg1.modify(CFG1::MBR::Div2);
 
         //sets spi in master mode, full-duplex, with slave-select managed by software
         regs.cfg2
@@ -705,6 +682,7 @@ impl<'a> spi::SpiMaster<'a> for Spi<'a> {
         self.read_write_byte(0)
     }
 
+    // checked with logic analyzer and works
     fn write_byte(&self, val: u8) -> Result<(), kernel::ErrorCode> {
         let regs = &*self.registers;
 
@@ -717,18 +695,50 @@ impl<'a> spi::SpiMaster<'a> for Spi<'a> {
         // start transfer
         regs.cr1.modify(CR1::CSTART::SET);
 
+        //wait for transfer
+        while !regs.sr.is_set(SR::TXC) {}
+
         Ok(())
     }
 
-    //********* good impl above **********
-
-    fn read_write_byte(&self, val: u8) -> Result<u8, kernel::ErrorCode> {
-        Ok(0)
+    fn specify_chip_select(&self, cs: Self::ChipSelect) -> Result<(), kernel::ErrorCode> {
+        self.active_slave.set(cs);
+        Ok(())
     }
 
+    // have to check with logic analyzer
+    fn read_write_byte(&self, val: u8) -> Result<u8, kernel::ErrorCode> {
+        let regs = &*self.registers;
+
+        // set the transfer size
+        regs.cr2.modify(CR2::TSIZE.val(1));
+
+        // start the transfer
+        regs.cr1.modify(CR1::CSTART::SET);
+
+        // wait until the tx fifo actually has space then write the byte
+        while !regs.sr.is_set(SR::TXP) {}
+        regs.txdr.write(TXDR::TXDR.val(val as u32));
+
+        // wait for the incoming byte to arrive in the rx fifo
+        while !regs.sr.is_set(SR::RXP) {}
+
+        // retrieve the byte
+        let byte = regs.rxdr.get() as u8;
+
+        // clear the completion flags
+        regs.ifcr.write(IFCR::EOTC::SET + IFCR::TXTFC::SET);
+
+        // wait for the transfer to finish
+        while !regs.sr.is_set(SR::EOT) {}
+
+        Ok(byte)
+    }
+
+    // have to check with logic analyzer
     fn read_write_bytes(
         &self,
-        write_buffer: kernel::utilities::leasable_buffer::SubSliceMut<'static, u8>,
+        mut write_buffer: kernel::utilities::leasable_buffer::SubSliceMut<'static, u8>,
         read_buffer: Option<kernel::utilities::leasable_buffer::SubSliceMut<'static, u8>>,
     ) -> Result<
         (),
@@ -738,10 +748,153 @@ impl<'a> spi::SpiMaster<'a> for Spi<'a> {
             Option<kernel::utilities::leasable_buffer::SubSliceMut<'static, u8>>,
         ),
     > {
+        let regs = &*self.registers;
+
+        // check if there is another transaction pending
+        if self.is_busy() {
+            return Err((kernel::ErrorCode::BUSY, write_buffer, read_buffer));
+        }
+
+        // verify if the dma is associated with this spi instance
+        if self.dma.is_none() {
+            return Err((kernel::ErrorCode::OFF, write_buffer, read_buffer));
+        }
+
+        self.active_slave.map(|p| {
+            p.clear();
+        });
+
+        // we default to the len of the write buf but we pick the minimum of write/ read buf
+        let mut count: usize = write_buffer.len();
+        read_buffer
+            .as_ref()
+            .map(|buf| count = cmp::min(count, buf.len()));
+
+        self.dma_len.set(count);
+        // send the transfer size to hardware
+        regs.cr2.modify(CR2::TSIZE.val(count as u32));
+        self.transfers_in_progress.set(0);
+
+        // rx transfer
+        read_buffer.map(|mut rx_buffer| {
+            self.transfers_in_progress
+                .set(self.transfers_in_progress.get() + 1);
+
+            rx_buffer.slice(0..count);
+            let fence = unsafe { CortexMDmaFence::new() };
+            let dma_slice = DmaSubSliceMut::new_static(rx_buffer, fence);
+
+            let ptr = dma_slice.as_mut_ptr() as u32;
+            let len = dma_slice.len() as u32;
+
+            self.rx_dma_buf.replace(dma_slice);
+
+            self.dma.map(move |dma| {
+                if let Some(ch) = self.dma_channel_rx.get() {
+                    dma.setup(ch, crate::dma::DmaPeripheral::Spi1Rx, ptr, len);
+                    self.enable_rx();
+                }
+            });
+        });
+
+        // tx transfer
+        self.transfers_in_progress
+            .set(self.transfers_in_progress.get() + 1);
+
+        write_buffer.slice(0..count);
+        let fence = unsafe { CortexMDmaFence::new() };
+        let dma_slice = DmaSubSliceMut::new_static(write_buffer, fence);
+
+        let ptr = dma_slice.as_mut_ptr() as u32;
+        let len = dma_slice.len() as u32;
+
+        self.tx_dma_buf.replace(dma_slice);
+
+        self.dma.map(move |dma| {
+            if let Some(ch) = self.dma_channel_tx.get() {
+                dma.setup(ch, crate::dma::DmaPeripheral::Spi1Tx, ptr, len);
+                self.enable_tx();
+            }
+        });
+
+        //start the transfer
+        regs.cr1.modify(CR1::CSTART::SET);
+
         Ok(())
     }
+}
 
-    fn specify_chip_select(&self, cs: Self::ChipSelect) -> Result<(), kernel::ErrorCode> {
-        Ok(())
+// impl crate::dma::DmaClient for Spi<'_> {
+//     fn transfer_done(&self, channel: ChannelId) {
+//         if let Some(tx_ch) = self.dma_channel_tx.get() {
+//             if channel == tx_ch {
+//                 self.handle_dma_interrupt(true);
+//                 return;
+//             }
+//         }
+//         if let Some(rx_ch) = self.dma_channel_rx.get() {
+//             if channel == rx_ch {
+//                 self.handle_dma_interrupt(false);
+//             }
+//         }
+//     }
+// }
+
+impl crate::dma::DmaClient for Spi<'_> {
+    fn transfer_done(&self, channel: ChannelId) {
+        let regs = &*self.registers;
+
+        if let Some(tx_ch) = self.dma_channel_tx.get() {
+            if channel == tx_ch {
+                regs.cfg1.modify(CFG1::TXDMAEN::CLEAR);
+                self.dma.map(|dma| dma.clear_interrupt(tx_ch));
+                self.transfers_in_progress
+                    .set(self.transfers_in_progress.get() - 1);
+            }
+        }
+
+        if let Some(rx_ch) = self.dma_channel_rx.get() {
+            if channel == rx_ch {
+                regs.cfg1.modify(CFG1::RXDMAEN::CLEAR);
+                self.dma.map(|dma| dma.clear_interrupt(rx_ch));
+                self.transfers_in_progress
+                    .set(self.transfers_in_progress.get() - 1);
+            }
+        }
+
+        if self.transfers_in_progress.get() == 0 {
+            // clear flags
+            regs.ifcr
+                .write(IFCR::EOTC::SET + IFCR::TXTFC::SET + IFCR::OVRC::SET);
+
+            if !self.active_after.get() {
+                self.active_slave.map(|p| {
+                    p.set();
+                });
+            }
+
+            let tx_buffer = self.tx_dma_buf.take().map(|dma_slice| {
+                let fence = unsafe { CortexMDmaFence::new() };
+                let mut subslice = unsafe { dma_slice.take(fence) };
+                subslice.reset();
+                subslice
+            });
+
+            let rx_buffer = self.rx_dma_buf.take().map(|dma_slice| {
+                let fence = unsafe { CortexMDmaFence::new() };
+                let mut subslice = unsafe { dma_slice.take(fence) };
+                subslice.reset();
+                subslice
+            });
+
+            let length = self.dma_len.get();
+            self.dma_len.set(0);
+
+            self.client.map(|client| {
+                tx_buffer.map(|t| {
+                    client.read_write_done(t, rx_buffer, Ok(length));
+                });
+            });
+        }
     }
 }

--- a/chips/stm32u5xx/src/spi.rs
+++ b/chips/stm32u5xx/src/spi.rs
@@ -2,6 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2026.
 
+use crate::dma::{self, ChannelId, Dma, DmaPeripheral};
+use crate::dma::{Dma1, Dma1Peripheral};
+
+use core::cell::Cell;
+use core::cmp;
+use kernel::hil::gpio::Output;
+use kernel::hil::spi::{self, ClockPhase, ClockPolarity};
+use kernel::utilities::cells::{MapCell, OptionalCell};
+use kernel::utilities::dma_slice::DmaSubSliceMut;
+use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{
     register_bitfields, register_structs, ReadOnly, ReadWrite, WriteOnly,
 };
@@ -199,34 +209,34 @@ register_bitfields![u32,
         // 1: SCK signal is at 1 when idle
         CPOL OFFSET(25) NUMBITS(1) [],
 
-        // clock phase
-        // 0: the first clock transition is the first data capture edge
-        // 1: the second clock transition is the first data capture edge
+        /// Clock Phase
+        /// 0: the first clock transition is the first data capture edge
+        /// 1: the second clock transition is the first data capture edge
         CPHA OFFSET(24) NUMBITS(1) [],
 
-        // data frame format
-        // 0: MSB transmitted first
-        // 1: LSB transmitted first
+        /// data frame format
+        /// 0: MSB transmitted first
+        /// 1: LSB transmitted first
         LSBFRST OFFSET(23) NUMBITS(1) [],
 
-        // SPI master
-        // 0: SPI slave
-        // 1: SPI master
+        /// SPI master
+        /// 0: SPI slave
+        /// 1: SPI master
         MASTER OFFSET(22) NUMBITS(1) [],
 
-        // Serial protocol
-        // 000: SPI Motorola
-        // 001: SPI TI
+        /// Serial protocol
+        /// 000: SPI Motorola
+        /// 001: SPI TI
         SP OFFSET(19) NUMBITS(3) [
             Motorola = 0b000,
             Ti = 0b001
         ],
 
-        // SPI Communication Mode
-        // 00: full-duplex
-        // 01: simplex transmitter
-        // 10: simplex receiver
-        // 11: half-duplex
+        /// SPI Communication Mode
+        /// 00: full-duplex
+        /// 01: simplex transmitter
+        /// 10: simplex receiver
+        /// 11: half-duplex
         COMM OFFSET(17) NUMBITS(2) [
             FullDuplex = 0b00,
             SimplexTx = 0b01,
@@ -234,147 +244,147 @@ register_bitfields![u32,
             HalfDuplex = 0b11
         ],
 
-        // Swap functionality of MISO and MOSI pins
-        // 0: no swap
-        // 1: MOSI and MISO are swapped
+        /// Swap functionality of MISO and MOSI pins
+        /// 0: no swap
+        /// 1: MOSI and MISO are swapped
         IOSWP OFFSET(15) NUMBITS(1) [],
 
-        // RDY signal input/output polarity
-        // 0: high level of the signal means the slave is ready for communication
-        // 1: low level of the signal means the slave is ready for communication
+        /// RDY signal input/output polarity
+        /// 0: high level of the signal means the slave is ready for communication
+        /// 1: low level of the signal means the slave is ready for communication
         RDIOP OFFSET(14) NUMBITS(1) [],
 
-        // RDY signal input/output management
-        // 0: RDY signal is defined internally fixed as permanently active (RDIOP setting has no effect)
-        // 1: RDY signal is overtaken from alternate function input (at master case) or output (at slave case)
+        /// RDY signal input/output management
+        /// 0: RDY signal is defined internally fixed as permanently active (RDIOP setting has no effect)
+        /// 1: RDY signal is overtaken from alternate function input (at master case) or output (at slave case)
         RDIOM OFFSET(13) NUMBITS(1) [],
 
-        // Master Inter-Data Idleness
-        // Specifies minimum time delay (expressed in SPI clock cycles periods) inserted between two
-        // consecutive data frames in master mode.
+        /// Master Inter-Data Idleness
+        /// Specifies minimum time delay (expressed in SPI clock cycles periods) inserted between two
+        /// consecutive data frames in master mode.
         MIDI OFFSET(4) NUMBITS(4) [],
 
-        // Master NSS Idleness
-        // Specifies an extra delay, expressed in number of SPI clock cycle periods, inserted
-        // additionally between active edge of NSS opening a session and the beginning of the first
-        // data frame of the session in master mode when SSOE is enabled.
+        /// Master NSS Idleness
+        /// Specifies an extra delay, expressed in number of SPI clock cycle periods, inserted
+        /// additionally between active edge of NSS opening a session and the beginning of the first
+        /// data frame of the session in master mode when SSOE is enabled.
         MSSI OFFSET(0) NUMBITS(4) []
     ],
 
-    // SPI interrupt enable register
+    /// SPI interrupt enable register
     pub IER [
-        // Mode Fault interrupt enable
+        /// Mode Fault interrupt enable
         MODFIE OFFSET(9) NUMBITS(1) [],
 
-        // TIFRE interrupt enable
+        /// TIFRE interrupt enable
         TIFREIE OFFSET(8) NUMBITS(1) [],
 
-        // CRC error interrupt enable
+        /// CRC error interrupt enable
         CRCEIE OFFSET(7) NUMBITS(1) [],
 
-        // OVR interrupt enable
+        /// OVR interrupt enable
         OVRIE OFFSET(6) NUMBITS(1) [],
 
-        // UDR interrupt enable
+        /// UDR interrupt enable
         UDRIE OFFSET(5) NUMBITS(1) [],
 
-        // TXTF interrupt enable
+        /// TXTF interrupt enable
         TXTFIE OFFSET(4) NUMBITS(1) [],
 
-        // EOT, SUSP and TXC interrupt enable
+        /// EOT, SUSP and TXC interrupt enable
         EOTIE OFFSET(3) NUMBITS(1) [],
 
-        // DXP interrupt enabled
+        /// DXP interrupt enabled
         DXPIE OFFSET(2) NUMBITS(1) [],
 
-        // TXP interrupt enabled
+        /// TXP interrupt enabled
         TXPIE OFFSET(1) NUMBITS(1) [],
 
-        // RXP interrupt enabled
+        /// RXP interrupt enabled
         RXPIE OFFSET(0) NUMBITS(1) []
     ],
 
-    // SPI status register
+    /// SPI status register
     pub SR [
-        // number of data frames remaining in current TSIZE session
+        /// number of data frames remaining in current TSIZE session
         CTSIZE OFFSET(16) NUMBITS(16) [],
 
-        // RxFIFO word not empty
+        /// RxFIFO word not empty
         RXWNE OFFSET(15) NUMBITS(1) [],
 
-        // RxFIFO packing level
+        /// RxFIFO packing level
         RXPLVL OFFSET(13) NUMBITS(2) [],
 
-        // TxFIFO transmission complete
+        /// TxFIFO transmission complete
         TXC OFFSET(12) NUMBITS(1) [],
 
-        // Suspension status
+        /// Suspension status
         SUSP OFFSET(11) NUMBITS(1) [],
 
-        // Mode fault
+        /// Mode fault
         MODF OFFSET(9) NUMBITS(1) [],
 
-        // TI frame format error
+        /// TI frame format error
         TIFRE OFFSET(8) NUMBITS(1) [],
 
-        // CRC error
+        /// CRC error
         CRCE OFFSET(7) NUMBITS(1) [],
 
-        // Overrun
+        /// Overrun
         OVR OFFSET(6) NUMBITS(1) [],
 
-        // Underrun
+        /// Underrun
         UDR OFFSET(5) NUMBITS(1) [],
 
-        // Transmission transfer filled
+        /// Transmission transfer filled
         TXTF OFFSET(4) NUMBITS(1) [],
 
-        // End of transfer
+        /// End of transfer
         EOT OFFSET(3) NUMBITS(1) [],
 
-        // Duplex packet
+        /// Duplex packet
         DXP OFFSET(2) NUMBITS(1) [],
 
-        // Tx-packet space available
+        /// Tx-packet space available
         TXP OFFSET(1) NUMBITS(1) [],
 
-        // RXP: Rx-packet available
+        /// RXP: Rx-packet available
         RXP OFFSET(0) NUMBITS(1) []
     ],
 
     /// SPI interrupt/status flags clear register
     pub IFCR [
-        // Suspend flag clear
+        /// Suspend flag clear
         SUSPC OFFSET(11) NUMBITS(1) [],
-        // Mode fault flag clear
+        /// Mode fault flag clear
         MODFC OFFSET(9) NUMBITS(1) [],
-        // TI frame format error flag clear
+        /// TI frame format error flag clear
         TIFREC OFFSET(8) NUMBITS(1) [],
-        // CRC error flag clear
+        /// CRC error flag clear
         CRCEC OFFSET(7) NUMBITS(1) [],
-        // Overrun flag clear
+        /// Overrun flag clear
         OVRC OFFSET(6) NUMBITS(1) [],
-        // Underrun flag clear
+        /// Underrun flag clear
         UDRC OFFSET(5) NUMBITS(1) [],
-        // Transmission transfer filled flag clear
+        /// Transmission transfer filled flag clear
         TXTFC OFFSET(4) NUMBITS(1) [],
-        // End of transfer flag clear
+        /// End of transfer flag clear
         EOTC OFFSET(3) NUMBITS(1) []
     ],
 
     /// SPI autonomous mode control register
     pub AUTOCR [
-        // Hardware control of CSTART triggering enable
+        /// Hardware control of CSTART triggering enable
         TRIGEN OFFSET(21) NUMBITS(1) [],
-        // Trigger polarity
+        /// Trigger polarity
         TRIGPOL OFFSET(20) NUMBITS(1) [],
-        // Trigger selection
+        /// Trigger selection
         TRIGSEL OFFSET(16) NUMBITS(4) []
     ],
 
     /// SPI transmit data register
     pub TXDR[
-        // Transmit data register
+        /// Transmit data register
         TXDR OFFSET(0) NUMBITS(32) []
     ],
 
@@ -384,27 +394,354 @@ register_bitfields![u32,
         RXDR OFFSET(0) NUMBITS(32) []
     ],
 
-    // SPI polynomial register
+    /// SPI polynomial register
     pub CRCPOLY [
-        // CRC polynomial register
+        /// CRC polynomial register
         CRCPOLY OFFSET(0) NUMBITS(32) []
     ],
 
-    // SPI transmitter CRC register
+    /// SPI transmitter CRC register
     pub TXCRC [
-        // CRC register for transmitter
+        /// CRC register for transmitter
         TXCRC OFFSET(0) NUMBITS(32) []
     ],
 
-    // SPI receiver CRC register
+    /// SPI receiver CRC register
     pub RXCRC [
-        // CRC register for receiver
+        /// CRC register for receiver
         RXCRC OFFSET(0) NUMBITS(32) []
     ],
 
-    // SPI underrun data register
+    /// SPI underrun data register
     pub UDRDR [
-        // Data at slave underrun condition
+        /// Data at slave underrun condition
         UDRDR OFFSET(0) NUMBITS(32) []
     ]
 ];
+
+pub struct Spi<'a> {
+    pub registers: StaticRef<SpiRegisters>,
+    client: OptionalCell<&'a dyn spi::SpiMasterClient>,
+    dma: OptionalCell<&'a Dma>,
+    dma_channel_tx: Cell<Option<ChannelId>>,
+    dma_channel_rx: Cell<Option<ChannelId>>,
+    tx_dma_peripheral: Cell<Option<DmaPeripheral>>,
+    rx_dma_peripheral: Cell<Option<DmaPeripheral>>,
+    tx_dma_buf: MapCell<DmaSubSliceMut<'static, u8>>,
+    rx_dma_buf: MapCell<DmaSubSliceMut<'static, u8>>,
+    dma_len: Cell<usize>,
+    transfers_in_progress: Cell<u8>,
+    active_slave: OptionalCell<&'a crate::gpio::Pin<'a>>,
+    active_after: Cell<bool>,
+}
+
+impl<'a> Spi<'a> {
+    pub fn new(base: StaticRef<SpiRegisters>) -> Self {
+        Self {
+            registers: base,
+            client: OptionalCell::empty(),
+            dma: OptionalCell::empty(),
+            dma_channel_tx: Cell::new(None),
+            dma_channel_rx: Cell::new(None),
+            tx_dma_peripheral: Cell::new(None),
+            rx_dma_peripheral: Cell::new(None),
+            tx_dma_buf: MapCell::empty(),
+            rx_dma_buf: MapCell::empty(),
+            dma_len: Cell::new(0),
+            transfers_in_progress: Cell::new(0),
+            active_slave: OptionalCell::empty(),
+            active_after: Cell::new(false),
+        }
+    }
+
+    /// Associates a DMA controller and channels with the USART driver.
+    pub fn set_dma(
+        spi: &'static Self,
+        dma: &'a Dma,
+        tx_peripheral: DmaPeripheral,
+        tx_channel: ChannelId,
+        rx_peripheral: DmaPeripheral,
+        rx_channel: ChannelId,
+    ) {
+        spi.dma.set(dma);
+        spi.tx_dma_peripheral.set(Some(tx_peripheral));
+        spi.dma_channel_tx.set(Some(tx_channel));
+        spi.rx_dma_peripheral.set(Some(rx_peripheral));
+        spi.dma_channel_rx.set(Some(rx_channel));
+        dma.set_client(tx_channel, spi);
+        dma.set_client(rx_channel, spi);
+    }
+
+    /// 0: SCK signal is at 0 when idle
+    /// 1: SCK signal is at 1 when idle
+    fn set_polarity(&self, polarity: ClockPolarity) {
+        self.set_cr(|| match polarity {
+            ClockPolarity::IdleLow => self.registers.cfg2.modify(CFG2::CPOL::CLEAR),
+            ClockPolarity::IdleHigh => self.registers.cfg2.modify(CFG2::CPOL::SET),
+        });
+    }
+
+    fn get_polarity(&self) -> ClockPolarity {
+        if !self.registers.cfg2.is_set(CFG2::CPOL) {
+            ClockPolarity::IdleLow
+        } else {
+            ClockPolarity::IdleHigh
+        }
+    }
+
+    /// SampleLeading  = CPHA = 0
+    /// SampleTrailing = CPHA = 1
+    fn set_phase(&self, phase: ClockPhase) {
+        self.set_cr(|| match phase {
+            ClockPhase::SampleLeading => self.registers.cfg2.modify(CFG2::CPHA::CLEAR),
+            ClockPhase::SampleTrailing => self.registers.cfg2.modify(CFG2::CPHA::SET),
+        });
+    }
+
+    fn get_phase(&self) -> ClockPhase {
+        if !self.registers.cfg2.is_set(CFG2::CPHA) {
+            ClockPhase::SampleLeading
+        } else {
+            ClockPhase::SampleTrailing
+        }
+    }
+
+    fn set_cr<F>(&self, f: F)
+    where
+        F: FnOnce(),
+    {
+        self.registers.cr1.modify(CR1::SPE::CLEAR);
+        f();
+        self.registers.cr1.modify(CR1::SPE::SET);
+    }
+
+    fn enable_tx(&self) {
+        self.registers.cfg1.modify(CFG1::TXDMAEN::SET);
+    }
+
+    fn disable_tx(&self) {
+        self.registers.cfg1.modify(CFG1::TXDMAEN::CLEAR);
+    }
+
+    fn enable_rx(&self) {
+        self.registers.cfg1.modify(CFG1::RXDMAEN::SET);
+    }
+
+    fn disable_rx(&self) {
+        self.registers.cfg1.modify(CFG1::RXDMAEN::CLEAR);
+    }
+
+    ///*******************  Implemented above this line  *************************
+
+    pub fn handle_interrupt(&self) {
+        // Used only during debugging. Since we use DMA, we do not enable SPI
+        // interrupts during normal operations
+    }
+
+    fn set_active_slave(&self, slave_pin: &'a crate::gpio::Pin<'a>) {
+        self.active_slave.set(slave_pin);
+    }
+
+    fn read_write_bytes(
+        &self,
+        write_buffer: SubSliceMut<'static, u8>,
+        read_buffer: Option<SubSliceMut<'static, u8>>,
+    ) -> Result<
+        (),
+        (
+            ErrorCode,
+            SubSliceMut<'static, u8>,
+            Option<SubSliceMut<'static, u8>>,
+        ),
+    > {
+        self.active_slave.map(|p| {
+            p.clear();
+        });
+
+        let mut count: usize = write_buffer.len();
+        read_buffer
+            .as_ref()
+            .map(|buf| count = cmp::min(count, buf.len()));
+
+        self.dma_len.set(count);
+
+        self.transfers_in_progress.set(0);
+
+        read_buffer.map(|rx_buffer| {
+            self.transfers_in_progress
+                .set(self.transfers_in_progress.get() + 1);
+            self.rx_dma.map(move |dma| {
+                dma.do_transfer(rx_buffer);
+            });
+            self.enable_rx();
+        });
+
+        self.transfers_in_progress
+            .set(self.transfers_in_progress.get() + 1);
+        self.tx_dma.map(move |dma| {
+            dma.do_transfer(write_buffer);
+        });
+        self.enable_tx();
+
+        Ok(())
+    }
+}
+
+impl<'a> spi::SpiMaster<'a> for Spi<'a> {
+    fn set_phase(&self, phase: ClockPhase) -> Result<(), kernel::ErrorCode> {
+        let regs = &*self.registers;
+
+        match phase {
+            ClockPhase::SampleLeading => {
+                regs.cfg2.modify(CFG2::CPOL::CLEAR);
+            }
+            ClockPhase::SampleTrailing => {
+                regs.cfg2.modify(CFG2::CPOL::SET);
+            }
+        }
+        Ok(())
+    }
+
+    fn set_polarity(&self, polarity: ClockPolarity) -> Result<(), kernel::ErrorCode> {
+        let regs = &*self.registers;
+
+        match polarity {
+            ClockPolarity::IdleLow => {
+                regs.cfg2.modify(CFG2::CPHA::CLEAR);
+            }
+            ClockPolarity::IdleHigh => {
+                regs.cfg2.modify(CFG2::CPHA::SET);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn set_rate(&self, rate: u32) -> Result<u32, kernel::ErrorCode> {
+        let regs = &*self.registers;
+
+        regs.cfg1.modify(CFG1::MBR::Div8);
+
+        // match rate {
+        //     1_000_000 => self.set_cr(|| {
+        //         // HSI is 16Mhz and Fpclk is also 16Mhz. 0b011 is Fpclk / 16
+        //         self.registers.cr1.modify(CR1::BR.val(0b011));
+        //     }),
+        //     4_000_000 => self.set_cr(|| {
+        //         // HSI is 16Mhz and Fpclk is also 16Mhz. 0b001 is Fpclk / 4
+        //         self.registers.cr1.modify(CR1::BR.val(0b001));
+        //     }),
+        //     _ => panic!("SPI rate must be 1_000_000 or 4_000_000"),
+        // }
+        Ok(rate)
+    }
+
+    fn get_rate(&self) -> u32 {
+        69
+    }
+
+    fn get_phase(&self) -> ClockPhase {
+        let regs = &*self.registers;
+
+        if !regs.cfg2.is_set(CFG2::CPHA) {
+            ClockPhase::SampleLeading
+        } else {
+            ClockPhase::SampleTrailing
+        }
+    }
+
+    fn get_polarity(&self) -> ClockPolarity {
+        let regs = &*self.registers;
+
+        if !regs.cfg2.is_set(CFG2::CPOL) {
+            ClockPolarity::IdleLow
+        } else {
+            ClockPolarity::IdleHigh
+        }
+    }
+
+    fn is_busy(&self) -> bool {
+        let regs = &*self.registers;
+
+        regs.cr1.is_set(CR1::CSTART) || !regs.sr.is_set(SR::TXC)
+    }
+
+    fn hold_low(&self) {
+        self.active_after.set(true);
+    }
+
+    fn release_low(&self) {
+        self.active_after.set(false);
+    }
+
+    fn init(&self) -> Result<(), kernel::ErrorCode> {
+        let regs = &*self.registers;
+
+        //need to disable spi in order to change config
+        regs.cr1.modify(CR1::SPE::CLEAR);
+
+        //set baudrate
+        regs.cfg1.modify(CFG1::MBR::Div8);
+
+        //sets spi in master mode, full-duplex, with slave-select managed by software
+        regs.cfg2
+            .modify(CFG2::MASTER::SET + CFG2::SSM::SET + CFG2::COMM::FullDuplex);
+
+        regs.cr1.modify(CR1::SSI::SET);
+
+        // clear any pending mode faults
+        regs.ifcr.write(IFCR::MODFC::SET);
+
+        //enable spi
+        regs.cr1.modify(CR1::SPE::SET);
+        Ok(())
+    }
+
+    fn set_client(&self, client: &'a dyn spi::SpiMasterClient) {
+        self.client.set(client);
+    }
+
+    fn read_byte(&self) -> Result<u8, kernel::ErrorCode> {
+        self.read_write_byte(0)
+    }
+
+    fn write_byte(&self, val: u8) -> Result<(), kernel::ErrorCode> {
+        let regs = &*self.registers;
+
+        // wait until the FIFO has space for at least one packet
+        while !regs.sr.is_set(SR::TXP) {}
+
+        // write byte into TXDR
+        regs.txdr.write(TXDR::TXDR.val(val as u32));
+
+        // start transfer
+        regs.cr1.modify(CR1::CSTART::SET);
+
+        Ok(())
+    }
+
+    //********* good impl above **********
+
+    fn read_write_byte(&self, val: u8) -> Result<u8, kernel::ErrorCode> {
+        Ok(0)
+    }
+
+    fn read_write_bytes(
+        &self,
+        write_buffer: kernel::utilities::leasable_buffer::SubSliceMut<'static, u8>,
+        read_buffer: Option<kernel::utilities::leasable_buffer::SubSliceMut<'static, u8>>,
+    ) -> Result<
+        (),
+        (
+            kernel::ErrorCode,
+            kernel::utilities::leasable_buffer::SubSliceMut<'static, u8>,
+            Option<kernel::utilities::leasable_buffer::SubSliceMut<'static, u8>>,
+        ),
+    > {
+        Ok(())
+    }
+
+    fn specify_chip_select(&self, cs: Self::ChipSelect) -> Result<(), kernel::ErrorCode> {
+        Ok(())
+    }
+}

--- a/chips/stm32u5xx/src/spi.rs
+++ b/chips/stm32u5xx/src/spi.rs
@@ -1,0 +1,410 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+use kernel::utilities::registers::{
+    register_bitfields, register_structs, ReadOnly, ReadWrite, WriteOnly,
+};
+use kernel::utilities::StaticRef;
+
+register_structs! {
+    pub SpiRegisters {
+        //Control register 1
+        (0x000 => cr1: ReadWrite<u32, CR1::Register>),
+        //Control register 2
+        (0x004 => cr2: ReadWrite<u32, CR2::Register>),
+        //Configuration register 1
+        (0x008 => cfg1: ReadWrite<u32, CFG1::Register>),
+        //Configuration register 2
+        (0x00C => cfg2: ReadWrite<u32, CFG2::Register>),
+        //Interrupt enable register
+        (0x010 => ier: ReadWrite<u32, IER::Register>),
+        //Status register
+        (0x014 => sr: ReadOnly<u32, SR::Register>),
+        //Interrupt/status flags clear register
+        (0x018 => ifcr: WriteOnly<u32, IFCR::Register>),
+        //Autonomous mode control register
+        (0x01C => autocr: ReadWrite<u32, AUTOCR::Register>),
+        //Transmit data register
+        (0x020 => txdr: WriteOnly<u32, TXDR::Register>),
+        (0x024 => _reserved0),
+        //Receive data register
+        (0x030 => rxdr: ReadOnly<u32, RXDR::Register>),
+        (0x034 => _reserved1),
+        //Polynomial register
+        (0x040 => crcpoly: ReadWrite<u32, CRCPOLY::Register>),
+        //Transmitter CRC register
+        (0x044 => txcrc: ReadOnly<u32, TXCRC::Register>),
+        //Receiver CRC register
+        (0x048 => rxcrc: ReadOnly<u32, RXCRC::Register>),
+        //Underrun data register
+        (0x04C => udrdr: ReadWrite<u32, UDRDR::Register>),
+        (0x050 => @END),
+    }
+}
+
+// Base addresses for SPI1, 2 and 3 in Secure Alias mode
+pub const SPI1_BASE: StaticRef<SpiRegisters> =
+    unsafe { StaticRef::new(0x5001_3000 as *const SpiRegisters) };
+// pub const SPI2_BASE: StaticRef<SpiRegisters> =
+//     unsafe { StaticRef::new(0x5000_3800 as *const SpiRegisters) }; //not used
+// pub const SPI3_BASE: StaticRef<SpiRegisters> =
+//     unsafe { StaticRef::new(0x5600_2000 as *const SpiRegisters) }; //not used
+
+register_bitfields![u32,
+    // Control Register 1
+    pub CR1 [
+        /// Locking the AF configuration of associated I/Os
+        /// 0: AF configuration is not locked
+        /// 1: AF configuration is locked
+        IOLOCK OFFSET(16) NUMBITS(1) [],
+
+        /// CRC calculation initialization pattern control for transmitter
+        /// 0: all zero pattern is applied
+        /// 1: all ones pattern is applied
+        TCRCINI OFFSET(15) NUMBITS(1) [],
+
+        /// CRC calculation initialization pattern control for receiver
+        /// 0: All zero pattern is applied
+        /// 1: All ones pattern is applied
+        RCRCINI OFFSET(14) NUMBITS(1) [],
+
+        /// Full size (33-bit or 17-bit) CRC polynomial configuration
+        /// 0: Full size (33-bit or 17-bit) CRC polynomial is not used
+        /// 1: Full size (33-bit or 17-bit) CRC polynomial is used
+        CRC33_17 OFFSET(13) NUMBITS(1) [],
+
+        /// Internal slave select signal input level
+        /// This bit has an effect only when the SSM bit is set. The value of this bit
+        /// is forced onto the peripheral NSS input internally.
+        SSI OFFSET(12) NUMBITS(1) [],
+
+        /// Rx/Tx direction at half-duplex mode
+        /// 0: SPI is receiver
+        /// 1: SPI is transmitter
+        HDDIR OFFSET(11) NUMBITS(1) [],
+
+        /// Master suspend request
+        /// In master mode, when this bit is set by software, the CSTART bit is reset
+        /// at the end of the current frame and communication is suspended.
+        CSUSP OFFSET(10) NUMBITS(1) [],
+
+        /// Master transfer start
+        /// 0: master transfer is at idle
+        /// 1: master transfer is ongoing or temporary suspended by automatic suspend
+        CSTART OFFSET(9) NUMBITS(1) [],
+
+        /// Master automatic suspension in Receive mode
+        /// 0: SPI flow/clock generation is continuous, regardless of overrun condition
+        /// 1: SPI flow is suspended temporary on RxFIFO full condition
+        MASRX OFFSET(8) NUMBITS(1) [],
+
+        /// Serial peripheral enable
+        /// 0: Serial peripheral disabled
+        /// 1: Serial peripheral enabled
+        SPE OFFSET(0) NUMBITS(1) []
+    ],
+
+    // Control Register 2
+    pub CR2 [
+        ///Number of data at current transfer
+        TSIZE OFFSET(0)  NUMBITS(16) []
+    ],
+
+    // SPI configuration register 1
+    pub CFG1 [
+        /// Bypass of the prescaler at master baud rate clock generator
+        /// 0: bypass is disabled
+        /// 1: bypass is enabled
+        BPASS OFFSET(31) NUMBITS(1) [],
+
+        /// Master baud rate prescaler setting
+        /// 000: SPI master clock/2
+        /// 001: SPI master clock/4
+        /// ...
+        /// 111: SPI master clock/256
+        MBR OFFSET(28) NUMBITS(3) [
+            Div2 = 0b000,
+            Div4 = 0b001,
+            Div8 = 0b010,
+            Div16 = 0b011,
+            Div32 = 0b100,
+            Div64 = 0b101,
+            Div128 = 0b110,
+            Div256 = 0b111
+        ],
+
+        /// Hardware CRC computation enable
+        /// 0: CRC calculation disabled
+        /// 1: CRC calculation enabled
+        CRCEN OFFSET(22) NUMBITS(1) [],
+
+        /// Length of CRC frame to be transferred and compared
+        CRCSIZE OFFSET(16) NUMBITS(5) [],
+
+        /// Tx DMA stream enable
+        /// 0: Tx DMA disabled
+        /// 1: Tx DMA enabled
+        TXDMAEN OFFSET(15) NUMBITS(1) [],
+
+        /// Rx DMA stream enable
+        /// 0: Rx-DMA disabled
+        /// 1: Rx-DMA enabled
+        RXDMAEN OFFSET(14) NUMBITS(1) [],
+
+        /// Behavior of slave transmitter at underrun condition
+        /// 0: slave sends a constant pattern defined by the user in the SPI_UDRDR register
+        /// 1: Slave repeats the last received data from master.
+        UDRCFG OFFSET(9) NUMBITS(1) [],
+
+        /// FIFO threshold level
+        /// Defines number of data frames in a single data packet.
+        FTHLV OFFSET(5) NUMBITS(4) [],
+
+        /// Number of bits in a single SPI data frame
+        DSIZE OFFSET(0) NUMBITS(5) []
+    ],
+
+    // SPI configuration register 2
+    pub CFG2 [
+        /// Alternate function GPIOs control
+        /// This bit is taken into account when SPE = 0 only.
+        /// 0: The peripheral takes no control of GPIOs while it is disabled
+        /// 1: The peripheral keeps always control of all associated GPIOs
+        AFCNTR OFFSET(31) NUMBITS(1) [],
+
+        /// NSS output management in master mode
+        /// 0: NSS is kept at active level until data transfer is complete, it becomes inactive with EOT flag
+        /// 1: SPI data frames are interleaved with NSS nonactive pulses when MIDI[3:0] > 1
+        SSOM OFFSET(30) NUMBITS(1) [],
+
+        /// NSS output enable
+        /// This bit is taken into account in master mode only
+        /// 0: NSS output is disabled and the SPI can work in multimaster configuration
+        /// 1: NSS output is enabled. The SPI cannot work in a multimaster environment.
+        SSOE OFFSET(29) NUMBITS(1) [],
+
+        /// NSS input/output polarity
+        /// 0: low level is active for NSS signal
+        /// 1: high level is active for NSS signal
+        SSIOP OFFSET(28) NUMBITS(1) [],
+
+        /// Software management of internal slave select signal input
+        /// 0: Input value of the internal slave select signal is determined by the external NSS hardware pin
+        /// 1: Input value of the internal slave select signal is determined by the SSI bit controlled by software
+        SSM OFFSET(26) NUMBITS(1) [],
+
+        // Clock polarity
+        // 0: SCK signal is at 0 when idle
+        // 1: SCK signal is at 1 when idle
+        CPOL OFFSET(25) NUMBITS(1) [],
+
+        // clock phase
+        // 0: the first clock transition is the first data capture edge
+        // 1: the second clock transition is the first data capture edge
+        CPHA OFFSET(24) NUMBITS(1) [],
+
+        // data frame format
+        // 0: MSB transmitted first
+        // 1: LSB transmitted first
+        LSBFRST OFFSET(23) NUMBITS(1) [],
+
+        // SPI master
+        // 0: SPI slave
+        // 1: SPI master
+        MASTER OFFSET(22) NUMBITS(1) [],
+
+        // Serial protocol
+        // 000: SPI Motorola
+        // 001: SPI TI
+        SP OFFSET(19) NUMBITS(3) [
+            Motorola = 0b000,
+            Ti = 0b001
+        ],
+
+        // SPI Communication Mode
+        // 00: full-duplex
+        // 01: simplex transmitter
+        // 10: simplex receiver
+        // 11: half-duplex
+        COMM OFFSET(17) NUMBITS(2) [
+            FullDuplex = 0b00,
+            SimplexTx = 0b01,
+            SimplexRx = 0b10,
+            HalfDuplex = 0b11
+        ],
+
+        // Swap functionality of MISO and MOSI pins
+        // 0: no swap
+        // 1: MOSI and MISO are swapped
+        IOSWP OFFSET(15) NUMBITS(1) [],
+
+        // RDY signal input/output polarity
+        // 0: high level of the signal means the slave is ready for communication
+        // 1: low level of the signal means the slave is ready for communication
+        RDIOP OFFSET(14) NUMBITS(1) [],
+
+        // RDY signal input/output management
+        // 0: RDY signal is defined internally fixed as permanently active (RDIOP setting has no effect)
+        // 1: RDY signal is overtaken from alternate function input (at master case) or output (at slave case)
+        RDIOM OFFSET(13) NUMBITS(1) [],
+
+        // Master Inter-Data Idleness
+        // Specifies minimum time delay (expressed in SPI clock cycles periods) inserted between two
+        // consecutive data frames in master mode.
+        MIDI OFFSET(4) NUMBITS(4) [],
+
+        // Master NSS Idleness
+        // Specifies an extra delay, expressed in number of SPI clock cycle periods, inserted
+        // additionally between active edge of NSS opening a session and the beginning of the first
+        // data frame of the session in master mode when SSOE is enabled.
+        MSSI OFFSET(0) NUMBITS(4) []
+    ],
+
+    // SPI interrupt enable register
+    pub IER [
+        // Mode Fault interrupt enable
+        MODFIE OFFSET(9) NUMBITS(1) [],
+
+        // TIFRE interrupt enable
+        TIFREIE OFFSET(8) NUMBITS(1) [],
+
+        // CRC error interrupt enable
+        CRCEIE OFFSET(7) NUMBITS(1) [],
+
+        // OVR interrupt enable
+        OVRIE OFFSET(6) NUMBITS(1) [],
+
+        // UDR interrupt enable
+        UDRIE OFFSET(5) NUMBITS(1) [],
+
+        // TXTF interrupt enable
+        TXTFIE OFFSET(4) NUMBITS(1) [],
+
+        // EOT, SUSP and TXC interrupt enable
+        EOTIE OFFSET(3) NUMBITS(1) [],
+
+        // DXP interrupt enabled
+        DXPIE OFFSET(2) NUMBITS(1) [],
+
+        // TXP interrupt enabled
+        TXPIE OFFSET(1) NUMBITS(1) [],
+
+        // RXP interrupt enabled
+        RXPIE OFFSET(0) NUMBITS(1) []
+    ],
+
+    // SPI status register
+    pub SR [
+        // number of data frames remaining in current TSIZE session
+        CTSIZE OFFSET(16) NUMBITS(16) [],
+
+        // RxFIFO word not empty
+        RXWNE OFFSET(15) NUMBITS(1) [],
+
+        // RxFIFO packing level
+        RXPLVL OFFSET(13) NUMBITS(2) [],
+
+        // TxFIFO transmission complete
+        TXC OFFSET(12) NUMBITS(1) [],
+
+        // Suspension status
+        SUSP OFFSET(11) NUMBITS(1) [],
+
+        // Mode fault
+        MODF OFFSET(9) NUMBITS(1) [],
+
+        // TI frame format error
+        TIFRE OFFSET(8) NUMBITS(1) [],
+
+        // CRC error
+        CRCE OFFSET(7) NUMBITS(1) [],
+
+        // Overrun
+        OVR OFFSET(6) NUMBITS(1) [],
+
+        // Underrun
+        UDR OFFSET(5) NUMBITS(1) [],
+
+        // Transmission transfer filled
+        TXTF OFFSET(4) NUMBITS(1) [],
+
+        // End of transfer
+        EOT OFFSET(3) NUMBITS(1) [],
+
+        // Duplex packet
+        DXP OFFSET(2) NUMBITS(1) [],
+
+        // Tx-packet space available
+        TXP OFFSET(1) NUMBITS(1) [],
+
+        // RXP: Rx-packet available
+        RXP OFFSET(0) NUMBITS(1) []
+    ],
+
+    /// SPI interrupt/status flags clear register
+    pub IFCR [
+        // Suspend flag clear
+        SUSPC OFFSET(11) NUMBITS(1) [],
+        // Mode fault flag clear
+        MODFC OFFSET(9) NUMBITS(1) [],
+        // TI frame format error flag clear
+        TIFREC OFFSET(8) NUMBITS(1) [],
+        // CRC error flag clear
+        CRCEC OFFSET(7) NUMBITS(1) [],
+        // Overrun flag clear
+        OVRC OFFSET(6) NUMBITS(1) [],
+        // Underrun flag clear
+        UDRC OFFSET(5) NUMBITS(1) [],
+        // Transmission transfer filled flag clear
+        TXTFC OFFSET(4) NUMBITS(1) [],
+        // End of transfer flag clear
+        EOTC OFFSET(3) NUMBITS(1) []
+    ],
+
+    /// SPI autonomous mode control register
+    pub AUTOCR [
+        // Hardware control of CSTART triggering enable
+        TRIGEN OFFSET(21) NUMBITS(1) [],
+        // Trigger polarity
+        TRIGPOL OFFSET(20) NUMBITS(1) [],
+        // Trigger selection
+        TRIGSEL OFFSET(16) NUMBITS(4) []
+    ],
+
+    /// SPI transmit data register
+    pub TXDR[
+        // Transmit data register
+        TXDR OFFSET(0) NUMBITS(32) []
+    ],
+
+    /// SPI receive data register
+    pub RXDR [
+        // Receive data register
+        RXDR OFFSET(0) NUMBITS(32) []
+    ],
+
+    // SPI polynomial register
+    pub CRCPOLY [
+        // CRC polynomial register
+        CRCPOLY OFFSET(0) NUMBITS(32) []
+    ],
+
+    // SPI transmitter CRC register
+    pub TXCRC [
+        // CRC register for transmitter
+        TXCRC OFFSET(0) NUMBITS(32) []
+    ],
+
+    // SPI receiver CRC register
+    pub RXCRC [
+        // CRC register for receiver
+        RXCRC OFFSET(0) NUMBITS(32) []
+    ],
+
+    // SPI underrun data register
+    pub UDRDR [
+        // Data at slave underrun condition
+        UDRDR OFFSET(0) NUMBITS(32) []
+    ]
+];

--- a/chips/stm32u5xx/src/spi.rs
+++ b/chips/stm32u5xx/src/spi.rs
@@ -424,8 +424,6 @@ pub struct Spi<'a> {
     dma: OptionalCell<&'a Dma>,
     dma_channel_tx: Cell<Option<ChannelId>>,
     dma_channel_rx: Cell<Option<ChannelId>>,
-    // tx_dma_peripheral: Cell<Option<DmaPeripheral>>,
-    // rx_dma_peripheral: Cell<Option<DmaPeripheral>>,
     tx_dma_buf: MapCell<DmaSubSliceMut<'static, u8>>,
     rx_dma_buf: MapCell<DmaSubSliceMut<'static, u8>>,
     dma_len: Cell<usize>,
@@ -442,8 +440,6 @@ impl<'a> Spi<'a> {
             dma: OptionalCell::empty(),
             dma_channel_tx: Cell::new(None),
             dma_channel_rx: Cell::new(None),
-            // tx_dma_peripheral: Cell::new(None),
-            // rx_dma_peripheral: Cell::new(None),
             tx_dma_buf: MapCell::empty(),
             rx_dma_buf: MapCell::empty(),
             dma_len: Cell::new(0),
@@ -454,62 +450,11 @@ impl<'a> Spi<'a> {
     }
 
     /// associates a DMA controller and channels with the SPI driver.
-    pub fn set_dma(
-        spi: &'static Self,
-        dma: &'a Dma,
-        // tx_peripheral: DmaPeripheral,
-        tx_channel: ChannelId,
-        // rx_peripheral: DmaPeripheral,
-        rx_channel: ChannelId,
-    ) {
+    pub fn set_dma(spi: &'static Self, dma: &'a Dma, tx_channel: ChannelId, rx_channel: ChannelId) {
         spi.dma.set(dma);
-        // spi.tx_dma_peripheral.set(Some(tx_peripheral));
         spi.dma_channel_tx.set(Some(tx_channel));
-        // spi.rx_dma_peripheral.set(Some(rx_peripheral));
         spi.dma_channel_rx.set(Some(rx_channel));
-        // dma.set_client(tx_channel, spi);
-        // dma.set_client(rx_channel, spi);
     }
-
-    // pub fn handle_dma_interrupt(&self, is_tx: bool) {
-    //     if is_tx {
-    //         self.dma.map(|dma| {
-    //             if let Some(ch) = self.dma_channel_tx.get() {
-    //                 dma.clear_interrupt(ch);
-    //             }
-    //         });
-    //         self.registers.cr3.modify(CR3::DMAT::CLEAR);
-    //         self.tx_deferred.set(false);
-    //         if let Some(dma_slice) = self.tx_dma_buf.take() {
-    //             let fence = unsafe { CortexMDmaFence::new() };
-    //             let mut subslice = unsafe { dma_slice.take(fence) };
-    //             subslice.reset();
-    //             let buf = subslice.take();
-    //             let len = self.tx_len.get();
-    //             self.tx_client.map(move |client| {
-    //                 client.transmitted_buffer(buf, len, Ok(()));
-    //             });
-    //         }
-    //     } else {
-    //         self.dma.map(|dma| {
-    //             if let Some(ch) = self.dma_channel_rx.get() {
-    //                 dma.clear_interrupt(ch);
-    //             }
-    //         });
-    //         self.registers.cr3.modify(CR3::DMAR::CLEAR);
-    //         self.rx_deferred.set(false);
-    //         if let Some(dma_slice) = self.rx_dma_buf.take() {
-    //             let fence = unsafe { CortexMDmaFence::new() };
-    //             let mut subslice = unsafe { dma_slice.take(fence) };
-    //             subslice.reset();
-    //             let buf = subslice.take();
-    //             let len = self.rx_len.get();
-    //             self.rx_client.map(move |client| {
-    //                 client.received_buffer(buf, len, Ok(()), uart::Error::None);
-    //             });
-    //         }
-    //     }
-    // }
 
     pub fn handle_interrupt(&self) {
         // Used only during debugging. Since we use DMA, we do not enable SPI
@@ -520,17 +465,9 @@ impl<'a> Spi<'a> {
         self.registers.cfg1.modify(CFG1::TXDMAEN::SET);
     }
 
-    // fn disable_tx(&self) {
-    //     self.registers.cfg1.modify(CFG1::TXDMAEN::CLEAR);
-    // }
-
     fn enable_rx(&self) {
         self.registers.cfg1.modify(CFG1::RXDMAEN::SET);
     }
-
-    // fn disable_rx(&self) {
-    //     self.registers.cfg1.modify(CFG1::RXDMAEN::CLEAR);
-    // }
 }
 
 impl<'a> spi::SpiMaster<'a> for Spi<'a> {
@@ -823,22 +760,6 @@ impl<'a> spi::SpiMaster<'a> for Spi<'a> {
         Ok(())
     }
 }
-
-// impl crate::dma::DmaClient for Spi<'_> {
-//     fn transfer_done(&self, channel: ChannelId) {
-//         if let Some(tx_ch) = self.dma_channel_tx.get() {
-//             if channel == tx_ch {
-//                 self.handle_dma_interrupt(true);
-//                 return;
-//             }
-//         }
-//         if let Some(rx_ch) = self.dma_channel_rx.get() {
-//             if channel == rx_ch {
-//                 self.handle_dma_interrupt(false);
-//             }
-//         }
-//     }
-// }
 
 impl crate::dma::DmaClient for Spi<'_> {
     fn transfer_done(&self, channel: ChannelId) {


### PR DESCRIPTION
### Pull Request Overview

This pull request adds the spi master driver for the stm32u5xx chip as well as adding support for the Nucleo u545re_q board.


### Testing Strategy

There is no libtock-c example, so I couldn't test it from userspace, but I tested it in the kernel and used a logic analyzer to check for any bugs.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR. No AI was used in making of 
      this code. Most of it was just copied from other chips.
