### PR TITLE
components: `forbid(unsafe_code)`. Require all capabilities to be passed in rather than created in the component.

### DIFF
--- a/boards/apollo3/lora_things_plus/src/main.rs
+++ b/boards/apollo3/lora_things_plus/src/main.rs
@@ -944,14 +944,18 @@ unsafe fn setup() -> (
     let checker = components::appid::checker::ProcessCheckerMachineComponent::new(checking_policy)
         .finalize(components::process_checker_machine_component_static!());
 
+    kernel::declare_capability!(AppStoreCap: kernel::capabilities::ApplicationStorageCapability);
     let storage_permissions_policy =
-        components::storage_permissions::tbf_header::StoragePermissionsTbfHeaderComponent::new()
-            .finalize(
-                components::storage_permissions_tbf_header_component_static!(
-                    apollo3::chip::Apollo3<Apollo3DefaultPeripherals>,
-                    kernel::process::ProcessStandardDebugFull,
-                ),
-            );
+        components::storage_permissions::tbf_header::StoragePermissionsTbfHeaderComponent::new(
+            AppStoreCap,
+        )
+        .finalize(
+            components::storage_permissions_tbf_header_component_static!(
+                apollo3::chip::Apollo3<Apollo3DefaultPeripherals>,
+                kernel::process::ProcessStandardDebugFull,
+                AppStoreCap,
+            ),
+        );
 
     let app_flash = core::slice::from_raw_parts(
         core::ptr::addr_of!(_sapps),

--- a/boards/apollo3/lora_things_plus/src/main.rs
+++ b/boards/apollo3/lora_things_plus/src/main.rs
@@ -295,6 +295,7 @@ unsafe fn setup_chirp_i2c_moisture(
         board_kernel,
         capsules_extra::moisture::DRIVER_NUM,
         chirp_moisture,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::moisture_component_static!(ChirpI2cMoistureType));
 
@@ -321,6 +322,7 @@ unsafe fn setup_dfrobot_i2c_rainfall(
         board_kernel,
         capsules_extra::rainfall::DRIVER_NUM,
         dfrobot_rainfall,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::rainfall_component_static!(DFRobotRainFallType));
 
@@ -491,6 +493,7 @@ unsafe fn setup() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
@@ -521,6 +524,7 @@ unsafe fn setup() -> (
             3 => &peripherals.gpio_port[35],  // A3
             4 => &peripherals.gpio_port[34],  // A4
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(apollo3::gpio::GpioPin));
 
@@ -534,6 +538,7 @@ unsafe fn setup() -> (
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(apollo3::stimer::STimer));
     ALARM = Some(mux_alarm);
@@ -581,12 +586,14 @@ unsafe fn setup() -> (
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,
         bme280,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::temperature_component_static!(BME280Sensor));
     let humidity = components::humidity::HumidityComponent::new(
         board_kernel,
         capsules_extra::humidity::DRIVER_NUM,
         bme280,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::humidity_component_static!(BME280Sensor));
     BME280 = Some(bme280);
@@ -598,6 +605,7 @@ unsafe fn setup() -> (
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,
         ccs811,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::air_quality_component_static!());
     CCS811 = Some(ccs811);
@@ -642,6 +650,7 @@ unsafe fn setup() -> (
             &peripherals.gpio_port[11], // A5
         ),
         capsules_core::spi_controller::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::spi_syscall_component_static!(
         apollo3::iom::Iom<'static>
@@ -659,6 +668,7 @@ unsafe fn setup() -> (
             &peripherals.gpio_port[36], // H6 - SX1262 Slave Select
         ),
         LORA_SPI_DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::spi_syscall_component_static!(
         apollo3::iom::Iom<'static>
@@ -684,6 +694,7 @@ unsafe fn setup() -> (
             3 => &peripherals.gpio_port[47], // H9 - SX1262 Multipurpose digital I/O (DIO3)
             4 => &peripherals.gpio_port[44], // J7 - SX1262 Reset
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(apollo3::gpio::GpioPin));
 
@@ -795,6 +806,7 @@ unsafe fn setup() -> (
         virtual_kv_driver,
         board_kernel,
         capsules_extra::kv_driver::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::kv_driver_component_static!(
         capsules_extra::virtualizers::virtual_kv::VirtualKVPermissions<
@@ -976,6 +988,7 @@ unsafe fn setup() -> (
         storage_permissions_policy,
         app_flash,
         app_memory,
+        create_capability!(capabilities::ProcessManagementCapability),
     )
     .finalize(components::process_loader_sequential_component_static!(
         apollo3::chip::Apollo3<Apollo3DefaultPeripherals>,

--- a/boards/apollo3/redboard_artemis_atp/src/main.rs
+++ b/boards/apollo3/redboard_artemis_atp/src/main.rs
@@ -248,6 +248,7 @@ unsafe fn setup() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
@@ -275,6 +276,7 @@ unsafe fn setup() -> (
             0 => &peripherals.gpio_port[2],  // D2
             1 => &peripherals.gpio_port[8],  // D8
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(apollo3::gpio::GpioPin));
 
@@ -288,6 +290,7 @@ unsafe fn setup() -> (
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(apollo3::stimer::STimer));
     ALARM = Some(mux_alarm);
@@ -355,6 +358,7 @@ unsafe fn setup() -> (
             &peripherals.gpio_port[13], // A13
         ),
         capsules_core::spi_controller::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::spi_syscall_component_static!(
         apollo3::iom::Iom<'static>
@@ -374,6 +378,7 @@ unsafe fn setup() -> (
         capsules_extra::ble_advertising_driver::DRIVER_NUM,
         &peripherals.ble,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::ble_component_static!(
         apollo3::stimer::STimer,

--- a/boards/apollo3/redboard_artemis_nano/src/main.rs
+++ b/boards/apollo3/redboard_artemis_nano/src/main.rs
@@ -261,6 +261,7 @@ unsafe fn setup() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
@@ -291,6 +292,7 @@ unsafe fn setup() -> (
             3 => &peripherals.gpio_port[29],  // A3
             5 => &peripherals.gpio_port[31]  // A5
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(apollo3::gpio::GpioPin));
 
@@ -304,6 +306,7 @@ unsafe fn setup() -> (
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(apollo3::stimer::STimer));
     ALARM = Some(mux_alarm);
@@ -344,12 +347,14 @@ unsafe fn setup() -> (
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,
         bme280,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::temperature_component_static!(BME280Sensor));
     let humidity = components::humidity::HumidityComponent::new(
         board_kernel,
         capsules_extra::humidity::DRIVER_NUM,
         bme280,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::humidity_component_static!(BME280Sensor));
     BME280 = Some(bme280);
@@ -360,6 +365,7 @@ unsafe fn setup() -> (
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,
         ccs811,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::air_quality_component_static!());
     CCS811 = Some(ccs811);
@@ -378,6 +384,7 @@ unsafe fn setup() -> (
             &peripherals.gpio_port[35], // A14
         ),
         capsules_core::spi_controller::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::spi_syscall_component_static!(
         apollo3::iom::Iom<'static>
@@ -397,6 +404,7 @@ unsafe fn setup() -> (
         capsules_extra::ble_advertising_driver::DRIVER_NUM,
         &peripherals.ble,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::ble_component_static!(
         apollo3::stimer::STimer,

--- a/boards/arty_e21/src/main.rs
+++ b/boards/arty_e21/src/main.rs
@@ -195,6 +195,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
 
@@ -211,6 +212,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(
         arty_e21_chip::chip::ArtyExxClint
@@ -248,6 +250,7 @@ unsafe fn start() -> (
                 kernel::hil::gpio::FloatingState::PullNone
             )
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::button_component_static!(
         arty_e21_chip::gpio::GpioPin
@@ -263,6 +266,7 @@ unsafe fn start() -> (
             1 => &peripherals.gpio_port[5],
             2 => &peripherals.gpio_port[6]
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(
         arty_e21_chip::gpio::GpioPin

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -705,14 +705,22 @@ unsafe fn start() -> (
         resources.printer.put(process_printer);
     });
 
+    kernel::declare_capability!(ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
+        ProcessConsoleCap,
     )
-    .finalize(components::process_console_component_static!(AlarmHw));
+    .finalize(components::process_console_component_static!(
+        nrf52840::rtc::Rtc,
+        ProcessConsoleCap
+    ));
     let _ = pconsole.start();
 
     //--------------------------------------------------------------------------

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -367,6 +367,7 @@ unsafe fn start() -> (
             15 => &nrf52840_peripherals.gpio_port[GPIO_D15],
             16 => &nrf52840_peripherals.gpio_port[GPIO_D16]
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(nrf52840::gpio::GPIOPin));
 
@@ -399,6 +400,7 @@ unsafe fn start() -> (
                 kernel::hil::gpio::FloatingState::PullUp
             ) // Right
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::button_component_static!(
         nrf52840::gpio::GPIOPin
@@ -417,6 +419,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(nrf52::rtc::Rtc));
 
@@ -438,6 +441,7 @@ unsafe fn start() -> (
         capsules_extra::buzzer_driver::DRIVER_NUM,
         mux_alarm,
         virtual_pwm_buzzer,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::buzzer_component_static!(AlarmHw, PwmHw));
 
@@ -485,6 +489,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
@@ -504,6 +509,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::rng::DRIVER_NUM,
         &base_peripherals.trng,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::rng_component_static!(nrf52840::trng::Trng));
 
@@ -515,52 +521,55 @@ unsafe fn start() -> (
     let adc_mux = components::adc::AdcMuxComponent::new(&base_peripherals.adc)
         .finalize(components::adc_mux_component_static!(nrf52840::adc::Adc));
 
-    let adc_syscall =
-        components::adc::AdcVirtualComponent::new(board_kernel, capsules_core::adc::DRIVER_NUM)
-            .finalize(components::adc_syscall_component_helper!(
-                // A0
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput7)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // A1
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput5)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // A2
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput2)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // A3
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput3)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // A4
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput1)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // A5
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput4)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // A6
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput0)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-            ));
+    let adc_syscall = components::adc::AdcVirtualComponent::new(
+        board_kernel,
+        capsules_core::adc::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
+    )
+    .finalize(components::adc_syscall_component_helper!(
+        // A0
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput7)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // A1
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput5)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // A2
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput2)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // A3
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput3)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // A4
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput1)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // A5
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput4)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // A6
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput0)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+    ));
 
     //--------------------------------------------------------------------------
     // SENSORS
@@ -583,6 +592,7 @@ unsafe fn start() -> (
         apds9960,
         board_kernel,
         capsules_extra::proximity::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::proximity_component_static!());
 
@@ -600,6 +610,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,
         sht3x,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::temperature_component_static!(SHT3xSensor));
 
@@ -607,6 +618,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_extra::humidity::DRIVER_NUM,
         sht3x,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::humidity_component_static!(SHT3xSensor));
 
@@ -663,6 +675,7 @@ unsafe fn start() -> (
         capsules_extra::screen::screen::DRIVER_NUM,
         tft,
         Some(tft),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::screen_component_static!(57600));
 
@@ -675,6 +688,7 @@ unsafe fn start() -> (
         capsules_extra::ble_advertising_driver::DRIVER_NUM,
         &base_peripherals.ble_radio,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::ble_component_static!(AlarmHw, BleHw));
 
@@ -693,6 +707,7 @@ unsafe fn start() -> (
         PAN_ID,
         device_id_bottom_16,
         device_id,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::ieee802154_component_static!(
         nrf52840::ieee802154_radio::Radio,

--- a/boards/components/src/adc.rs
+++ b/boards/components/src/adc.rs
@@ -165,9 +165,9 @@ pub struct AdcDedicatedComponent<
 }
 
 impl<
-        A: kernel::hil::adc::Adc<'static> + kernel::hil::adc::AdcHighSpeed<'static> + 'static,
-        CAP: MemoryAllocationCapability + 'static,
-    > AdcDedicatedComponent<A, CAP>
+    A: kernel::hil::adc::Adc<'static> + kernel::hil::adc::AdcHighSpeed<'static> + 'static,
+    CAP: MemoryAllocationCapability + 'static,
+> AdcDedicatedComponent<A, CAP>
 {
     pub fn new(
         adc: &'static A,
@@ -187,9 +187,9 @@ impl<
 }
 
 impl<
-        A: kernel::hil::adc::Adc<'static> + kernel::hil::adc::AdcHighSpeed<'static> + 'static,
-        CAP: MemoryAllocationCapability + 'static,
-    > Component for AdcDedicatedComponent<A, CAP>
+    A: kernel::hil::adc::Adc<'static> + kernel::hil::adc::AdcHighSpeed<'static> + 'static,
+    CAP: MemoryAllocationCapability + 'static,
+> Component for AdcDedicatedComponent<A, CAP>
 {
     type StaticInput = (
         &'static mut MaybeUninit<AdcDedicated<'static, A>>,

--- a/boards/components/src/adc.rs
+++ b/boards/components/src/adc.rs
@@ -8,9 +8,8 @@ use capsules_core::adc::AdcDedicated;
 use capsules_core::adc::AdcVirtualized;
 use capsules_core::virtualizers::virtual_adc::{AdcDevice, MuxAdc};
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil::adc;
 
 #[macro_export]
@@ -109,21 +108,23 @@ impl<A: 'static + adc::Adc<'static>> Component for AdcComponent<A> {
 
 pub type AdcVirtualComponentType = capsules_core::adc::AdcVirtualized<'static>;
 
-pub struct AdcVirtualComponent {
+pub struct AdcVirtualComponent<CAP: MemoryAllocationCapability + 'static> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
+    mem_cap: CAP,
 }
 
-impl AdcVirtualComponent {
-    pub fn new(board_kernel: &'static kernel::Kernel, driver_num: usize) -> AdcVirtualComponent {
+impl<CAP: MemoryAllocationCapability + 'static> AdcVirtualComponent<CAP> {
+    pub fn new(board_kernel: &'static kernel::Kernel, driver_num: usize, mem_cap: CAP) -> Self {
         AdcVirtualComponent {
             board_kernel,
             driver_num,
+            mem_cap,
         }
     }
 }
 
-impl Component for AdcVirtualComponent {
+impl<CAP: MemoryAllocationCapability + 'static> Component for AdcVirtualComponent<CAP> {
     type StaticInput = (
         &'static mut MaybeUninit<AdcVirtualized<'static>>,
         &'static [&'static dyn kernel::hil::adc::AdcChannel<'static>],
@@ -131,8 +132,9 @@ impl Component for AdcVirtualComponent {
     type Output = &'static capsules_core::adc::AdcVirtualized<'static>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-        let grant_adc = self.board_kernel.create_grant(self.driver_num, &grant_cap);
+        let grant_adc = self
+            .board_kernel
+            .create_grant(self.driver_num, &self.mem_cap);
 
         let adc = static_buffer
             .0
@@ -153,33 +155,41 @@ pub type AdcDedicatedComponentType<A> = capsules_core::adc::AdcDedicated<'static
 
 pub struct AdcDedicatedComponent<
     A: kernel::hil::adc::Adc<'static> + kernel::hil::adc::AdcHighSpeed<'static> + 'static,
+    CAP: MemoryAllocationCapability + 'static,
 > {
     adc: &'static A,
     channels: &'static [A::Channel],
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
+    mem_cap: CAP,
 }
 
-impl<A: kernel::hil::adc::Adc<'static> + kernel::hil::adc::AdcHighSpeed<'static> + 'static>
-    AdcDedicatedComponent<A>
+impl<
+        A: kernel::hil::adc::Adc<'static> + kernel::hil::adc::AdcHighSpeed<'static> + 'static,
+        CAP: MemoryAllocationCapability + 'static,
+    > AdcDedicatedComponent<A, CAP>
 {
     pub fn new(
         adc: &'static A,
         channels: &'static [A::Channel],
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
-    ) -> AdcDedicatedComponent<A> {
+        mem_cap: CAP,
+    ) -> AdcDedicatedComponent<A, CAP> {
         AdcDedicatedComponent {
             adc,
             channels,
             board_kernel,
             driver_num,
+            mem_cap,
         }
     }
 }
 
-impl<A: kernel::hil::adc::Adc<'static> + kernel::hil::adc::AdcHighSpeed<'static> + 'static>
-    Component for AdcDedicatedComponent<A>
+impl<
+        A: kernel::hil::adc::Adc<'static> + kernel::hil::adc::AdcHighSpeed<'static> + 'static,
+        CAP: MemoryAllocationCapability + 'static,
+    > Component for AdcDedicatedComponent<A, CAP>
 {
     type StaticInput = (
         &'static mut MaybeUninit<AdcDedicated<'static, A>>,
@@ -190,15 +200,14 @@ impl<A: kernel::hil::adc::Adc<'static> + kernel::hil::adc::AdcHighSpeed<'static>
     type Output = &'static AdcDedicated<'static, A>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let buffer1 = s.1.write([0; capsules_core::adc::BUF_LEN]);
         let buffer2 = s.2.write([0; capsules_core::adc::BUF_LEN]);
         let buffer3 = s.3.write([0; capsules_core::adc::BUF_LEN]);
 
         let adc = s.0.write(AdcDedicated::new(
             self.adc,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
             self.channels,
             buffer1,
             buffer2,

--- a/boards/components/src/aes.rs
+++ b/boards/components/src/aes.rs
@@ -26,9 +26,8 @@
 
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::deferred_call::DeferredCallClient;
 use kernel::hil;
 use kernel::hil::symmetric_encryption::{
@@ -141,26 +140,36 @@ impl<A: 'static + AES<'static, AES128> + AESCtr + AESCBC + AESECB> Component
     }
 }
 
-pub struct AesDriverComponent<K: AESKeySize, A: AES<'static, K> + AESCCM<'static, K> + 'static> {
+pub struct AesDriverComponent<
+    K: AESKeySize,
+    A: AES<'static, K> + AESCCM<'static, K> + 'static,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     aes: &'static A,
-
+    mem_cap: CAP,
     _phantom: PhantomData<K>,
 }
 
-impl<K: AESKeySize, A: AES<'static, K> + AESCtr + AESCBC + AESECB + AESCCM<'static, K>>
-    AesDriverComponent<K, A>
+impl<
+    K: AESKeySize,
+    A: AES<'static, K> + AESCCM<'static, K> + 'static,
+    CAP: MemoryAllocationCapability + 'static,
+> AesDriverComponent<K, A, CAP>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         aes: &'static A,
-    ) -> AesDriverComponent<K, A> {
+
+        mem_cap: CAP,
+    ) -> AesDriverComponent<K, A, CAP> {
         AesDriverComponent {
             board_kernel,
             driver_num,
             aes,
+            mem_cap,
 
             _phantom: PhantomData::<K>,
         }
@@ -170,7 +179,8 @@ impl<K: AESKeySize, A: AES<'static, K> + AESCtr + AESCBC + AESECB + AESCCM<'stat
 impl<
     K: AESKeySize + 'static,
     A: AES<'static, K> + AESCtr + AESCBC + AESECB + AESCCM<'static, K> + AESGCM<'static, K>,
-> Component for AesDriverComponent<K, A>
+    CAP: MemoryAllocationCapability + 'static,
+> Component for AesDriverComponent<K, A, CAP>
 {
     type StaticInput = (
         &'static mut MaybeUninit<
@@ -182,7 +192,6 @@ impl<
     type Output = &'static capsules_extra::symmetric_encryption::aes::AesDriver<'static, A, K>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
         let aes_src_buf = static_buffer.1.write([0; 32]);
         let aes_dst_buf = static_buffer.2.write([0; CRYPT_SIZE]);
 
@@ -193,7 +202,8 @@ impl<
                     self.aes,
                     aes_src_buf,
                     aes_dst_buf,
-                    self.board_kernel.create_grant(self.driver_num, &grant_cap),
+                    self.board_kernel
+                        .create_grant(self.driver_num, &self.mem_cap),
                 ));
 
         hil::symmetric_encryption::AESCCM::set_client(self.aes, aes_driver);

--- a/boards/components/src/air_quality.rs
+++ b/boards/components/src/air_quality.rs
@@ -13,9 +13,8 @@
 
 use capsules_extra::air_quality::AirQualitySensor;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil;
 
 #[macro_export]
@@ -25,36 +24,49 @@ macro_rules! air_quality_component_static {
     };};
 }
 
-pub struct AirQualityComponent<T: 'static + hil::sensors::AirQualityDriver<'static>> {
+pub struct AirQualityComponent<
+    T: 'static + hil::sensors::AirQualityDriver<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     temp_sensor: &'static T,
+    mem_cap: CAP,
 }
 
-impl<T: 'static + hil::sensors::AirQualityDriver<'static>> AirQualityComponent<T> {
+impl<
+        T: 'static + hil::sensors::AirQualityDriver<'static>,
+        CAP: MemoryAllocationCapability + 'static,
+    > AirQualityComponent<T, CAP>
+{
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         temp_sensor: &'static T,
-    ) -> AirQualityComponent<T> {
+        mem_cap: CAP,
+    ) -> AirQualityComponent<T, CAP> {
         AirQualityComponent {
             board_kernel,
             driver_num,
             temp_sensor,
+            mem_cap,
         }
     }
 }
 
-impl<T: 'static + hil::sensors::AirQualityDriver<'static>> Component for AirQualityComponent<T> {
+impl<
+        T: 'static + hil::sensors::AirQualityDriver<'static>,
+        CAP: MemoryAllocationCapability + 'static,
+    > Component for AirQualityComponent<T, CAP>
+{
     type StaticInput = &'static mut MaybeUninit<AirQualitySensor<'static>>;
     type Output = &'static AirQualitySensor<'static>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let air_quality = s.write(AirQualitySensor::new(
             self.temp_sensor,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
         ));
 
         hil::sensors::AirQualityDriver::set_client(self.temp_sensor, air_quality);

--- a/boards/components/src/air_quality.rs
+++ b/boards/components/src/air_quality.rs
@@ -35,9 +35,9 @@ pub struct AirQualityComponent<
 }
 
 impl<
-        T: 'static + hil::sensors::AirQualityDriver<'static>,
-        CAP: MemoryAllocationCapability + 'static,
-    > AirQualityComponent<T, CAP>
+    T: 'static + hil::sensors::AirQualityDriver<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> AirQualityComponent<T, CAP>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
@@ -55,9 +55,9 @@ impl<
 }
 
 impl<
-        T: 'static + hil::sensors::AirQualityDriver<'static>,
-        CAP: MemoryAllocationCapability + 'static,
-    > Component for AirQualityComponent<T, CAP>
+    T: 'static + hil::sensors::AirQualityDriver<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> Component for AirQualityComponent<T, CAP>
 {
     type StaticInput = &'static mut MaybeUninit<AirQualitySensor<'static>>;
     type Output = &'static AirQualitySensor<'static>;

--- a/boards/components/src/alarm.rs
+++ b/boards/components/src/alarm.rs
@@ -26,9 +26,8 @@ use core::mem::MaybeUninit;
 
 use capsules_core::alarm::AlarmDriver;
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil::time::{self, Alarm};
 
 // Setup static space for the objects.
@@ -84,27 +83,37 @@ impl<A: 'static + time::Alarm<'static>> Component for AlarmMuxComponent<A> {
     }
 }
 
-pub struct AlarmDriverComponent<A: 'static + time::Alarm<'static>> {
+pub struct AlarmDriverComponent<
+    A: 'static + time::Alarm<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     alarm_mux: &'static MuxAlarm<'static, A>,
+    mem_cap: CAP,
 }
 
-impl<A: 'static + time::Alarm<'static>> AlarmDriverComponent<A> {
+impl<A: 'static + time::Alarm<'static>, CAP: MemoryAllocationCapability + 'static>
+    AlarmDriverComponent<A, CAP>
+{
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         mux: &'static MuxAlarm<'static, A>,
-    ) -> AlarmDriverComponent<A> {
+        mem_cap: CAP,
+    ) -> AlarmDriverComponent<A, CAP> {
         AlarmDriverComponent {
             board_kernel,
             driver_num,
             alarm_mux: mux,
+            mem_cap,
         }
     }
 }
 
-impl<A: 'static + time::Alarm<'static>> Component for AlarmDriverComponent<A> {
+impl<A: 'static + time::Alarm<'static>, CAP: MemoryAllocationCapability + 'static> Component
+    for AlarmDriverComponent<A, CAP>
+{
     type StaticInput = (
         &'static mut MaybeUninit<VirtualMuxAlarm<'static, A>>,
         &'static mut MaybeUninit<AlarmDriver<'static, VirtualMuxAlarm<'static, A>>>,
@@ -112,14 +121,13 @@ impl<A: 'static + time::Alarm<'static>> Component for AlarmDriverComponent<A> {
     type Output = &'static AlarmDriver<'static, VirtualMuxAlarm<'static, A>>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let virtual_alarm1 = static_buffer.0.write(VirtualMuxAlarm::new(self.alarm_mux));
         virtual_alarm1.setup();
 
         let alarm = static_buffer.1.write(AlarmDriver::new(
             virtual_alarm1,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
         ));
 
         virtual_alarm1.set_alarm_client(alarm);

--- a/boards/components/src/analog_comparator.rs
+++ b/boards/components/src/analog_comparator.rs
@@ -25,9 +25,8 @@
 
 use capsules_extra::analog_comparator::AnalogComparator;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 
 #[macro_export]
 macro_rules! analog_comparator_component_helper {
@@ -56,40 +55,49 @@ pub type AnalogComparatorComponentType<AC> = AnalogComparator<'static, AC>;
 
 pub struct AnalogComparatorComponent<
     AC: 'static + kernel::hil::analog_comparator::AnalogComparator<'static>,
+    CAP: MemoryAllocationCapability + 'static,
 > {
     comp: &'static AC,
     ac_channels: &'static [&'static AC::Channel],
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
+    mem_cap: CAP,
 }
 
-impl<AC: 'static + kernel::hil::analog_comparator::AnalogComparator<'static>>
-    AnalogComparatorComponent<AC>
+impl<
+        AC: 'static + kernel::hil::analog_comparator::AnalogComparator<'static>,
+        CAP: MemoryAllocationCapability + 'static,
+    > AnalogComparatorComponent<AC, CAP>
 {
     pub fn new(
         comp: &'static AC,
         ac_channels: &'static [&'static AC::Channel],
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
+        mem_cap: CAP,
     ) -> Self {
         Self {
             comp,
             ac_channels,
             board_kernel,
             driver_num,
+            mem_cap,
         }
     }
 }
 
-impl<AC: 'static + kernel::hil::analog_comparator::AnalogComparator<'static>> Component
-    for AnalogComparatorComponent<AC>
+impl<
+        AC: 'static + kernel::hil::analog_comparator::AnalogComparator<'static>,
+        CAP: MemoryAllocationCapability + 'static,
+    > Component for AnalogComparatorComponent<AC, CAP>
 {
     type StaticInput = &'static mut MaybeUninit<AnalogComparator<'static, AC>>;
     type Output = &'static AnalogComparator<'static, AC>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-        let grant_ac = self.board_kernel.create_grant(self.driver_num, &grant_cap);
+        let grant_ac = self
+            .board_kernel
+            .create_grant(self.driver_num, &self.mem_cap);
 
         let analog_comparator =
             static_buffer.write(AnalogComparator::new(self.comp, self.ac_channels, grant_ac));

--- a/boards/components/src/analog_comparator.rs
+++ b/boards/components/src/analog_comparator.rs
@@ -65,9 +65,9 @@ pub struct AnalogComparatorComponent<
 }
 
 impl<
-        AC: 'static + kernel::hil::analog_comparator::AnalogComparator<'static>,
-        CAP: MemoryAllocationCapability + 'static,
-    > AnalogComparatorComponent<AC, CAP>
+    AC: 'static + kernel::hil::analog_comparator::AnalogComparator<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> AnalogComparatorComponent<AC, CAP>
 {
     pub fn new(
         comp: &'static AC,
@@ -87,9 +87,9 @@ impl<
 }
 
 impl<
-        AC: 'static + kernel::hil::analog_comparator::AnalogComparator<'static>,
-        CAP: MemoryAllocationCapability + 'static,
-    > Component for AnalogComparatorComponent<AC, CAP>
+    AC: 'static + kernel::hil::analog_comparator::AnalogComparator<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> Component for AnalogComparatorComponent<AC, CAP>
 {
     type StaticInput = &'static mut MaybeUninit<AnalogComparator<'static, AC>>;
     type Output = &'static AnalogComparator<'static, AC>;

--- a/boards/components/src/app_flash_driver.rs
+++ b/boards/components/src/app_flash_driver.rs
@@ -18,9 +18,8 @@
 use capsules_extra::app_flash_driver::AppFlash;
 use capsules_extra::nonvolatile_to_pages::NonvolatileToPages;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil;
 use kernel::hil::nonvolatile_storage::NonvolatileStorage;
 
@@ -42,26 +41,31 @@ pub type AppFlashComponentType = capsules_extra::app_flash_driver::AppFlash<'sta
 pub struct AppFlashComponent<
     F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, NonvolatileToPages<'static, F>>,
     const BUF_LEN: usize,
+    CAP: MemoryAllocationCapability + 'static,
 > {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     storage: &'static F,
+    mem_cap: CAP,
 }
 
 impl<
     F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, NonvolatileToPages<'static, F>>,
     const BUF_LEN: usize,
-> AppFlashComponent<F, BUF_LEN>
+    CAP: MemoryAllocationCapability + 'static,
+> AppFlashComponent<F, BUF_LEN, CAP>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         storage: &'static F,
-    ) -> AppFlashComponent<F, BUF_LEN> {
+        mem_cap: CAP,
+    ) -> AppFlashComponent<F, BUF_LEN, CAP> {
         AppFlashComponent {
             board_kernel,
             driver_num,
             storage,
+            mem_cap,
         }
     }
 }
@@ -69,7 +73,8 @@ impl<
 impl<
     F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, NonvolatileToPages<'static, F>>,
     const BUF_LEN: usize,
-> Component for AppFlashComponent<F, BUF_LEN>
+    CAP: MemoryAllocationCapability + 'static,
+> Component for AppFlashComponent<F, BUF_LEN, CAP>
 {
     type StaticInput = (
         &'static mut MaybeUninit<[u8; BUF_LEN]>,
@@ -80,8 +85,6 @@ impl<
     type Output = &'static AppFlash<'static>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let buffer = static_buffer.0.write([0; BUF_LEN]);
 
         let flash_pagebuffer = static_buffer
@@ -97,7 +100,8 @@ impl<
             .3
             .write(capsules_extra::app_flash_driver::AppFlash::new(
                 nv_to_page,
-                self.board_kernel.create_grant(self.driver_num, &grant_cap),
+                self.board_kernel
+                    .create_grant(self.driver_num, &self.mem_cap),
                 buffer,
             ));
 

--- a/boards/components/src/app_loader.rs
+++ b/boards/components/src/app_loader.rs
@@ -33,9 +33,8 @@
 
 use capsules_extra::app_loader::AppLoader;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::dynamic_binary_storage;
 
 // Setup static space for the objects.
@@ -52,29 +51,34 @@ macro_rules! app_loader_component_static {
 pub struct AppLoaderComponent<
     S: dynamic_binary_storage::DynamicBinaryStore + 'static,
     L: dynamic_binary_storage::DynamicProcessLoad + 'static,
+    CAP: MemoryAllocationCapability + 'static,
 > {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     storage_driver: &'static S,
     load_driver: &'static L,
+    mem_cap: CAP,
 }
 
 impl<
     S: dynamic_binary_storage::DynamicBinaryStore + 'static,
     L: dynamic_binary_storage::DynamicProcessLoad + 'static,
-> AppLoaderComponent<S, L>
+    CAP: MemoryAllocationCapability + 'static,
+> AppLoaderComponent<S, L, CAP>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         storage_driver: &'static S,
         load_driver: &'static L,
+        mem_cap: CAP,
     ) -> Self {
         Self {
             board_kernel,
             driver_num,
             storage_driver,
             load_driver,
+            mem_cap,
         }
     }
 }
@@ -82,7 +86,8 @@ impl<
 impl<
     S: dynamic_binary_storage::DynamicBinaryStore + 'static,
     L: dynamic_binary_storage::DynamicProcessLoad + 'static,
-> Component for AppLoaderComponent<S, L>
+    CAP: MemoryAllocationCapability + 'static,
+> Component for AppLoaderComponent<S, L, CAP>
 {
     type StaticInput = (
         &'static mut MaybeUninit<AppLoader<S, L>>,
@@ -91,14 +96,13 @@ impl<
     type Output = &'static AppLoader<S, L>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let buffer = static_buffer
             .1
             .write([0; capsules_extra::app_loader::BUF_LEN]);
 
         let dynamic_app_loader = static_buffer.0.write(AppLoader::new(
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
             self.storage_driver,
             self.load_driver,
             buffer,

--- a/boards/components/src/ble.rs
+++ b/boards/components/src/ble.rs
@@ -12,9 +12,8 @@
 
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil::ble_advertising::BleConfig;
 use kernel::hil::time::Alarm;
 
@@ -43,29 +42,34 @@ pub type BLEComponentType<B, A> =
 pub struct BLEComponent<
     A: kernel::hil::time::Alarm<'static> + 'static,
     B: kernel::hil::ble_advertising::BleAdvertisementDriver<'static> + BleConfig + 'static,
+    CAP: MemoryAllocationCapability + 'static,
 > {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     radio: &'static B,
     mux_alarm: &'static capsules_core::virtualizers::virtual_alarm::MuxAlarm<'static, A>,
+    mem_cap: CAP,
 }
 
 impl<
     A: kernel::hil::time::Alarm<'static> + 'static,
     B: kernel::hil::ble_advertising::BleAdvertisementDriver<'static> + BleConfig + 'static,
-> BLEComponent<A, B>
+    CAP: MemoryAllocationCapability + 'static,
+> BLEComponent<A, B, CAP>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         radio: &'static B,
         mux_alarm: &'static capsules_core::virtualizers::virtual_alarm::MuxAlarm<'static, A>,
+        mem_cap: CAP,
     ) -> Self {
         Self {
             board_kernel,
             driver_num,
             radio,
             mux_alarm,
+            mem_cap,
         }
     }
 }
@@ -73,7 +77,8 @@ impl<
 impl<
     A: kernel::hil::time::Alarm<'static> + 'static,
     B: kernel::hil::ble_advertising::BleAdvertisementDriver<'static> + BleConfig + 'static,
-> Component for BLEComponent<A, B>
+    CAP: MemoryAllocationCapability + 'static,
+> Component for BLEComponent<A, B, CAP>
 {
     type StaticInput = (
         &'static mut MaybeUninit<
@@ -91,8 +96,6 @@ impl<
     >;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let ble_radio_virtual_alarm = s.0.write(
             capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm::new(self.mux_alarm),
         );
@@ -102,7 +105,8 @@ impl<
 
         let ble_radio = s.1.write(capsules_extra::ble_advertising_driver::BLE::new(
             self.radio,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
             buffer,
             ble_radio_virtual_alarm,
         ));

--- a/boards/components/src/button.rs
+++ b/boards/components/src/button.rs
@@ -34,9 +34,8 @@
 
 use capsules_core::button::Button;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil::gpio;
 use kernel::hil::gpio::InterruptWithValue;
 
@@ -86,7 +85,10 @@ macro_rules! button_component_static {
 
 pub type ButtonComponentType<IP> = capsules_core::button::Button<'static, IP>;
 
-pub struct ButtonComponent<IP: 'static + gpio::InterruptPin<'static>> {
+pub struct ButtonComponent<
+    IP: 'static + gpio::InterruptPin<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     button_pins: &'static [(
@@ -94,9 +96,12 @@ pub struct ButtonComponent<IP: 'static + gpio::InterruptPin<'static>> {
         gpio::ActivationMode,
         gpio::FloatingState,
     )],
+    mem_cap: CAP,
 }
 
-impl<IP: 'static + gpio::InterruptPin<'static>> ButtonComponent<IP> {
+impl<IP: 'static + gpio::InterruptPin<'static>, CAP: MemoryAllocationCapability + 'static>
+    ButtonComponent<IP, CAP>
+{
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
@@ -105,24 +110,28 @@ impl<IP: 'static + gpio::InterruptPin<'static>> ButtonComponent<IP> {
             gpio::ActivationMode,
             gpio::FloatingState,
         )],
+        mem_cap: CAP,
     ) -> Self {
         Self {
             board_kernel,
             driver_num,
             button_pins,
+            mem_cap,
         }
     }
 }
 
-impl<IP: 'static + gpio::InterruptPin<'static>> Component for ButtonComponent<IP> {
+impl<IP: 'static + gpio::InterruptPin<'static>, CAP: MemoryAllocationCapability + 'static> Component
+    for ButtonComponent<IP, CAP>
+{
     type StaticInput = &'static mut MaybeUninit<Button<'static, IP>>;
     type Output = &'static Button<'static, IP>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
         let button = static_buffer.write(capsules_core::button::Button::new(
             self.button_pins,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
         ));
         for (pin, _, _) in self.button_pins.iter() {
             pin.set_client(button);

--- a/boards/components/src/button_keyboard.rs
+++ b/boards/components/src/button_keyboard.rs
@@ -9,9 +9,8 @@
 //! Implements the button system call with keyboard inputs.
 
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil;
 
 #[macro_export]
@@ -23,40 +22,49 @@ macro_rules! keyboard_button_component_static {
 
 pub type KeyboardButtonComponentType = capsules_extra::button_keyboard::ButtonKeyboard<'static>;
 
-pub struct KeyboardButtonComponent<K: 'static + hil::keyboard::Keyboard<'static>> {
+pub struct KeyboardButtonComponent<
+    K: 'static + hil::keyboard::Keyboard<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     keyboard: &'static K,
     key_codes: &'static [u16],
+    mem_cap: CAP,
 }
 
-impl<K: 'static + hil::keyboard::Keyboard<'static>> KeyboardButtonComponent<K> {
+impl<K: 'static + hil::keyboard::Keyboard<'static>, CAP: MemoryAllocationCapability + 'static>
+    KeyboardButtonComponent<K, CAP>
+{
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         keyboard: &'static K,
         key_codes: &'static [u16],
+        mem_cap: CAP,
     ) -> Self {
         Self {
             board_kernel,
             driver_num,
             keyboard,
             key_codes,
+            mem_cap,
         }
     }
 }
 
-impl<K: 'static + hil::keyboard::Keyboard<'static>> Component for KeyboardButtonComponent<K> {
+impl<K: 'static + hil::keyboard::Keyboard<'static>, CAP: MemoryAllocationCapability + 'static>
+    Component for KeyboardButtonComponent<K, CAP>
+{
     type StaticInput =
         &'static mut MaybeUninit<capsules_extra::button_keyboard::ButtonKeyboard<'static>>;
     type Output = &'static capsules_extra::button_keyboard::ButtonKeyboard<'static>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let button_keyboard = s.write(capsules_extra::button_keyboard::ButtonKeyboard::new(
             self.key_codes,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
         ));
         self.keyboard.set_client(button_keyboard);
 

--- a/boards/components/src/buzzer.rs
+++ b/boards/components/src/buzzer.rs
@@ -72,10 +72,10 @@ pub struct BuzzerComponent<
 }
 
 impl<
-        A: 'static + hil::time::Alarm<'static>,
-        P: 'static + hil::pwm::Pwm,
-        CAP: MemoryAllocationCapability + 'static,
-    > BuzzerComponent<A, P, CAP>
+    A: 'static + hil::time::Alarm<'static>,
+    P: 'static + hil::pwm::Pwm,
+    CAP: MemoryAllocationCapability + 'static,
+> BuzzerComponent<A, P, CAP>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
@@ -95,10 +95,10 @@ impl<
 }
 
 impl<
-        A: 'static + hil::time::Alarm<'static>,
-        P: 'static + hil::pwm::Pwm,
-        CAP: MemoryAllocationCapability + 'static,
-    > Component for BuzzerComponent<A, P, CAP>
+    A: 'static + hil::time::Alarm<'static>,
+    P: 'static + hil::pwm::Pwm,
+    CAP: MemoryAllocationCapability + 'static,
+> Component for BuzzerComponent<A, P, CAP>
 {
     type StaticInput = (
         &'static mut MaybeUninit<VirtualMuxAlarm<'static, A>>,

--- a/boards/components/src/buzzer.rs
+++ b/boards/components/src/buzzer.rs
@@ -25,9 +25,8 @@ use capsules_core::virtualizers::virtual_pwm::PwmPinUser;
 use capsules_extra::buzzer_driver::Buzzer;
 use capsules_extra::buzzer_pwm::PwmBuzzer;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil;
 
 #[macro_export]
@@ -60,31 +59,46 @@ pub type BuzzerComponentType<A, P> = capsules_extra::buzzer_driver::Buzzer<
     >,
 >;
 
-pub struct BuzzerComponent<A: 'static + hil::time::Alarm<'static>, P: 'static + hil::pwm::Pwm> {
+pub struct BuzzerComponent<
+    A: 'static + hil::time::Alarm<'static>,
+    P: 'static + hil::pwm::Pwm,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     mux_alarm: &'static MuxAlarm<'static, A>,
     pwm_pin: &'static PwmPinUser<'static, P>,
+    mem_cap: CAP,
 }
 
-impl<A: 'static + hil::time::Alarm<'static>, P: 'static + hil::pwm::Pwm> BuzzerComponent<A, P> {
+impl<
+        A: 'static + hil::time::Alarm<'static>,
+        P: 'static + hil::pwm::Pwm,
+        CAP: MemoryAllocationCapability + 'static,
+    > BuzzerComponent<A, P, CAP>
+{
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         mux_alarm: &'static MuxAlarm<'static, A>,
         pwm_pin: &'static PwmPinUser<'static, P>,
+        mem_cap: CAP,
     ) -> Self {
         Self {
             board_kernel,
             driver_num,
             mux_alarm,
             pwm_pin,
+            mem_cap,
         }
     }
 }
 
-impl<A: 'static + hil::time::Alarm<'static>, P: 'static + hil::pwm::Pwm> Component
-    for BuzzerComponent<A, P>
+impl<
+        A: 'static + hil::time::Alarm<'static>,
+        P: 'static + hil::pwm::Pwm,
+        CAP: MemoryAllocationCapability + 'static,
+    > Component for BuzzerComponent<A, P, CAP>
 {
     type StaticInput = (
         &'static mut MaybeUninit<VirtualMuxAlarm<'static, A>>,
@@ -104,8 +118,6 @@ impl<A: 'static + hil::time::Alarm<'static>, P: 'static + hil::pwm::Pwm> Compone
     >;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let virtual_alarm_buzzer = static_buffer.0.write(VirtualMuxAlarm::new(self.mux_alarm));
         virtual_alarm_buzzer.setup();
 
@@ -118,7 +130,8 @@ impl<A: 'static + hil::time::Alarm<'static>, P: 'static + hil::pwm::Pwm> Compone
         let buzzer = static_buffer.2.write(Buzzer::new(
             pwm_buzzer,
             capsules_extra::buzzer_driver::DEFAULT_MAX_BUZZ_TIME_MS,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
         ));
 
         hil::buzzer::Buzzer::set_client(pwm_buzzer, buzzer);

--- a/boards/components/src/can.rs
+++ b/boards/components/src/can.rs
@@ -25,9 +25,9 @@
 
 use capsules_extra::can::CanCapsule;
 use core::mem::MaybeUninit;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
 use kernel::hil::can;
-use kernel::{capabilities, create_capability};
 
 #[macro_export]
 macro_rules! can_component_static {
@@ -44,27 +44,32 @@ macro_rules! can_component_static {
     };};
 }
 
-pub struct CanComponent<A: 'static + can::Can> {
+pub struct CanComponent<A: 'static + can::Can, CAP: MemoryAllocationCapability + 'static> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     can: &'static A,
+    mem_cap: CAP,
 }
 
-impl<A: 'static + can::Can> CanComponent<A> {
+impl<A: 'static + can::Can, CAP: MemoryAllocationCapability + 'static> CanComponent<A, CAP> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         can: &'static A,
-    ) -> CanComponent<A> {
+        mem_cap: CAP,
+    ) -> CanComponent<A, CAP> {
         CanComponent {
             board_kernel,
             driver_num,
             can,
+            mem_cap,
         }
     }
 }
 
-impl<A: 'static + can::Can> Component for CanComponent<A> {
+impl<A: 'static + can::Can, CAP: MemoryAllocationCapability + 'static> Component
+    for CanComponent<A, CAP>
+{
     type StaticInput = (
         &'static mut MaybeUninit<CanCapsule<'static, A>>,
         &'static mut MaybeUninit<[u8; can::STANDARD_CAN_PACKET_SIZE]>,
@@ -73,8 +78,9 @@ impl<A: 'static + can::Can> Component for CanComponent<A> {
     type Output = &'static CanCapsule<'static, A>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-        let grant_can = self.board_kernel.create_grant(self.driver_num, &grant_cap);
+        let grant_can = self
+            .board_kernel
+            .create_grant(self.driver_num, &self.mem_cap);
 
         let can = static_buffer.0.write(capsules_extra::can::CanCapsule::new(
             self.can,

--- a/boards/components/src/console.rs
+++ b/boards/components/src/console.rs
@@ -136,11 +136,8 @@ pub struct ConsoleComponent<
     mem_cap: CAP,
 }
 
-impl<
-        const RX_BUF_LEN: usize,
-        const TX_BUF_LEN: usize,
-        CAP: MemoryAllocationCapability + 'static,
-    > ConsoleComponent<RX_BUF_LEN, TX_BUF_LEN, CAP>
+impl<const RX_BUF_LEN: usize, const TX_BUF_LEN: usize, CAP: MemoryAllocationCapability + 'static>
+    ConsoleComponent<RX_BUF_LEN, TX_BUF_LEN, CAP>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
@@ -157,11 +154,8 @@ impl<
     }
 }
 
-impl<
-        const RX_BUF_LEN: usize,
-        const TX_BUF_LEN: usize,
-        CAP: MemoryAllocationCapability + 'static,
-    > Component for ConsoleComponent<RX_BUF_LEN, TX_BUF_LEN, CAP>
+impl<const RX_BUF_LEN: usize, const TX_BUF_LEN: usize, CAP: MemoryAllocationCapability + 'static>
+    Component for ConsoleComponent<RX_BUF_LEN, TX_BUF_LEN, CAP>
 {
     type StaticInput = (
         &'static mut MaybeUninit<[u8; TX_BUF_LEN]>,

--- a/boards/components/src/console.rs
+++ b/boards/components/src/console.rs
@@ -41,9 +41,8 @@ use capsules_core::console_ordered::ConsoleOrdered;
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules_core::virtualizers::virtual_uart::{MuxUart, UartDevice};
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil;
 use kernel::hil::time::{self, Alarm};
 use kernel::hil::uart;
@@ -126,28 +125,43 @@ macro_rules! console_component_static {
 
 pub type ConsoleComponentType = console::Console<'static>;
 
-pub struct ConsoleComponent<const RX_BUF_LEN: usize, const TX_BUF_LEN: usize> {
+pub struct ConsoleComponent<
+    const RX_BUF_LEN: usize,
+    const TX_BUF_LEN: usize,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     uart_mux: &'static MuxUart<'static>,
+    mem_cap: CAP,
 }
 
-impl<const RX_BUF_LEN: usize, const TX_BUF_LEN: usize> ConsoleComponent<RX_BUF_LEN, TX_BUF_LEN> {
+impl<
+        const RX_BUF_LEN: usize,
+        const TX_BUF_LEN: usize,
+        CAP: MemoryAllocationCapability + 'static,
+    > ConsoleComponent<RX_BUF_LEN, TX_BUF_LEN, CAP>
+{
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         uart_mux: &'static MuxUart,
-    ) -> ConsoleComponent<RX_BUF_LEN, TX_BUF_LEN> {
+        mem_cap: CAP,
+    ) -> ConsoleComponent<RX_BUF_LEN, TX_BUF_LEN, CAP> {
         ConsoleComponent {
             board_kernel,
             driver_num,
             uart_mux,
+            mem_cap,
         }
     }
 }
 
-impl<const RX_BUF_LEN: usize, const TX_BUF_LEN: usize> Component
-    for ConsoleComponent<RX_BUF_LEN, TX_BUF_LEN>
+impl<
+        const RX_BUF_LEN: usize,
+        const TX_BUF_LEN: usize,
+        CAP: MemoryAllocationCapability + 'static,
+    > Component for ConsoleComponent<RX_BUF_LEN, TX_BUF_LEN, CAP>
 {
     type StaticInput = (
         &'static mut MaybeUninit<[u8; TX_BUF_LEN]>,
@@ -158,8 +172,6 @@ impl<const RX_BUF_LEN: usize, const TX_BUF_LEN: usize> Component
     type Output = &'static console::Console<'static>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let write_buffer = s.0.write([0; TX_BUF_LEN]);
 
         let read_buffer = s.1.write([0; RX_BUF_LEN]);
@@ -171,7 +183,8 @@ impl<const RX_BUF_LEN: usize, const TX_BUF_LEN: usize> Component
             console_uart,
             write_buffer,
             read_buffer,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
         ));
         hil::uart::Transmit::set_transmit_client(console_uart, console);
         hil::uart::Receive::set_receive_client(console_uart, console);
@@ -191,7 +204,10 @@ macro_rules! console_ordered_component_static {
     };};
 }
 
-pub struct ConsoleOrderedComponent<A: 'static + time::Alarm<'static>> {
+pub struct ConsoleOrderedComponent<
+    A: 'static + time::Alarm<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     uart_mux: &'static MuxUart<'static>,
@@ -199,9 +215,12 @@ pub struct ConsoleOrderedComponent<A: 'static + time::Alarm<'static>> {
     atomic_size: usize,
     retry_timer: u32,
     write_timer: u32,
+    mem_cap: CAP,
 }
 
-impl<A: 'static + time::Alarm<'static>> ConsoleOrderedComponent<A> {
+impl<A: 'static + time::Alarm<'static>, CAP: MemoryAllocationCapability + 'static>
+    ConsoleOrderedComponent<A, CAP>
+{
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
@@ -210,7 +229,8 @@ impl<A: 'static + time::Alarm<'static>> ConsoleOrderedComponent<A> {
         atomic_size: usize,
         retry_timer: u32,
         write_timer: u32,
-    ) -> ConsoleOrderedComponent<A> {
+        mem_cap: CAP,
+    ) -> ConsoleOrderedComponent<A, CAP> {
         ConsoleOrderedComponent {
             board_kernel,
             driver_num,
@@ -219,11 +239,14 @@ impl<A: 'static + time::Alarm<'static>> ConsoleOrderedComponent<A> {
             atomic_size,
             retry_timer,
             write_timer,
+            mem_cap,
         }
     }
 }
 
-impl<A: 'static + time::Alarm<'static>> Component for ConsoleOrderedComponent<A> {
+impl<A: 'static + time::Alarm<'static>, CAP: MemoryAllocationCapability + 'static> Component
+    for ConsoleOrderedComponent<A, CAP>
+{
     type StaticInput = (
         &'static mut MaybeUninit<VirtualMuxAlarm<'static, A>>,
         &'static mut MaybeUninit<[u8; DEFAULT_BUF_SIZE]>,
@@ -233,8 +256,6 @@ impl<A: 'static + time::Alarm<'static>> Component for ConsoleOrderedComponent<A>
     type Output = &'static ConsoleOrdered<'static, VirtualMuxAlarm<'static, A>>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let virtual_alarm1 = static_buffer.0.write(VirtualMuxAlarm::new(self.alarm_mux));
         virtual_alarm1.setup();
 
@@ -247,7 +268,8 @@ impl<A: 'static + time::Alarm<'static>> Component for ConsoleOrderedComponent<A>
             console_uart,
             virtual_alarm1,
             read_buffer,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
             self.atomic_size,
             self.retry_timer,
             self.write_timer,

--- a/boards/components/src/crc.rs
+++ b/boards/components/src/crc.rs
@@ -20,9 +20,8 @@
 
 use capsules_extra::crc::CrcDriver;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil::crc::Crc;
 
 // Setup static space for the objects.
@@ -36,27 +35,32 @@ macro_rules! crc_component_static {
     };};
 }
 
-pub struct CrcComponent<C: 'static + Crc<'static>> {
+pub struct CrcComponent<C: 'static + Crc<'static>, CAP: MemoryAllocationCapability + 'static> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     crc: &'static C,
+    mem_cap: CAP,
 }
 
-impl<C: 'static + Crc<'static>> CrcComponent<C> {
+impl<C: 'static + Crc<'static>, CAP: MemoryAllocationCapability + 'static> CrcComponent<C, CAP> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         crc: &'static C,
-    ) -> CrcComponent<C> {
+        mem_cap: CAP,
+    ) -> CrcComponent<C, CAP> {
         CrcComponent {
             board_kernel,
             driver_num,
             crc,
+            mem_cap,
         }
     }
 }
 
-impl<C: 'static + Crc<'static>> Component for CrcComponent<C> {
+impl<C: 'static + Crc<'static>, CAP: MemoryAllocationCapability + 'static> Component
+    for CrcComponent<C, CAP>
+{
     type StaticInput = (
         &'static mut MaybeUninit<CrcDriver<'static, C>>,
         &'static mut MaybeUninit<[u8; capsules_extra::crc::DEFAULT_CRC_BUF_LENGTH]>,
@@ -64,7 +68,6 @@ impl<C: 'static + Crc<'static>> Component for CrcComponent<C> {
     type Output = &'static CrcDriver<'static, C>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
         let crc_buf = static_buffer
             .1
             .write([0; capsules_extra::crc::DEFAULT_CRC_BUF_LENGTH]);
@@ -72,7 +75,8 @@ impl<C: 'static + Crc<'static>> Component for CrcComponent<C> {
         let crc = static_buffer.0.write(CrcDriver::new(
             self.crc,
             crc_buf,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
         ));
 
         self.crc.set_client(crc);

--- a/boards/components/src/ctap.rs
+++ b/boards/components/src/ctap.rs
@@ -32,9 +32,8 @@
 //! ```
 
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil;
 
 // Setup static space for the objects.
@@ -55,16 +54,22 @@ macro_rules! ctap_component_static {
     };};
 }
 
-pub struct CtapComponent<U: 'static + hil::usb::UsbController<'static>> {
+pub struct CtapComponent<
+    U: 'static + hil::usb::UsbController<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     usb: &'static U,
     vendor_id: u16,
     product_id: u16,
     strings: &'static [&'static str; 3],
+    mem_cap: CAP,
 }
 
-impl<U: 'static + hil::usb::UsbController<'static>> CtapComponent<U> {
+impl<U: 'static + hil::usb::UsbController<'static>, CAP: MemoryAllocationCapability + 'static>
+    CtapComponent<U, CAP>
+{
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
@@ -72,7 +77,8 @@ impl<U: 'static + hil::usb::UsbController<'static>> CtapComponent<U> {
         vendor_id: u16,
         product_id: u16,
         strings: &'static [&'static str; 3],
-    ) -> CtapComponent<U> {
+        mem_cap: CAP,
+    ) -> CtapComponent<U, CAP> {
         CtapComponent {
             board_kernel,
             driver_num,
@@ -80,11 +86,14 @@ impl<U: 'static + hil::usb::UsbController<'static>> CtapComponent<U> {
             vendor_id,
             product_id,
             strings,
+            mem_cap,
         }
     }
 }
 
-impl<U: 'static + hil::usb::UsbController<'static>> Component for CtapComponent<U> {
+impl<U: 'static + hil::usb::UsbController<'static>, CAP: MemoryAllocationCapability + 'static>
+    Component for CtapComponent<U, CAP>
+{
     type StaticInput = (
         &'static mut MaybeUninit<capsules_extra::usb::ctap::CtapHid<'static, U>>,
         &'static mut MaybeUninit<
@@ -113,8 +122,6 @@ impl<U: 'static + hil::usb::UsbController<'static>> Component for CtapComponent<
         ));
         self.usb.set_client(ctap);
 
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let send_buffer = s.2.write([0; 64]);
         let recv_buffer = s.3.write([0; 64]);
 
@@ -122,7 +129,8 @@ impl<U: 'static + hil::usb::UsbController<'static>> Component for CtapComponent<
             ctap,
             send_buffer,
             recv_buffer,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
         ));
 
         ctap.set_client(ctap_driver);

--- a/boards/components/src/date_time.rs
+++ b/boards/components/src/date_time.rs
@@ -22,9 +22,8 @@
 use core::mem::MaybeUninit;
 
 use capsules_extra::date_time::DateTimeCapsule;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil::date_time;
 
 #[macro_export]
@@ -35,36 +34,47 @@ macro_rules! date_time_component_static {
     };};
 }
 
-pub struct DateTimeComponent<D: 'static + date_time::DateTime<'static>> {
+pub struct DateTimeComponent<
+    D: 'static + date_time::DateTime<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     rtc: &'static D,
+    mem_cap: CAP,
 }
 
-impl<D: 'static + date_time::DateTime<'static>> DateTimeComponent<D> {
+impl<D: 'static + date_time::DateTime<'static>, CAP: MemoryAllocationCapability + 'static>
+    DateTimeComponent<D, CAP>
+{
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         rtc: &'static D,
-    ) -> DateTimeComponent<D> {
+        mem_cap: CAP,
+    ) -> DateTimeComponent<D, CAP> {
         DateTimeComponent {
             board_kernel,
             driver_num,
             rtc,
+            mem_cap,
         }
     }
 }
 
-impl<D: 'static + date_time::DateTime<'static> + kernel::deferred_call::DeferredCallClient>
-    Component for DateTimeComponent<D>
+impl<
+        D: 'static + date_time::DateTime<'static> + kernel::deferred_call::DeferredCallClient,
+        CAP: MemoryAllocationCapability + 'static,
+    > Component for DateTimeComponent<D, CAP>
 {
     type StaticInput = &'static mut MaybeUninit<DateTimeCapsule<'static, D>>;
 
     type Output = &'static DateTimeCapsule<'static, D>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let grant_dt = create_capability!(capabilities::MemoryAllocationCapability);
-        let grant_date_time = self.board_kernel.create_grant(self.driver_num, &grant_dt);
+        let grant_date_time = self
+            .board_kernel
+            .create_grant(self.driver_num, &self.mem_cap);
 
         let date_time = s.write(DateTimeCapsule::new(self.rtc, grant_date_time));
         date_time::DateTime::set_client(self.rtc, date_time);

--- a/boards/components/src/date_time.rs
+++ b/boards/components/src/date_time.rs
@@ -63,9 +63,9 @@ impl<D: 'static + date_time::DateTime<'static>, CAP: MemoryAllocationCapability 
 }
 
 impl<
-        D: 'static + date_time::DateTime<'static> + kernel::deferred_call::DeferredCallClient,
-        CAP: MemoryAllocationCapability + 'static,
-    > Component for DateTimeComponent<D, CAP>
+    D: 'static + date_time::DateTime<'static> + kernel::deferred_call::DeferredCallClient,
+    CAP: MemoryAllocationCapability + 'static,
+> Component for DateTimeComponent<D, CAP>
 {
     type StaticInput = &'static mut MaybeUninit<DateTimeCapsule<'static, D>>;
 

--- a/boards/components/src/gpio.rs
+++ b/boards/components/src/gpio.rs
@@ -50,9 +50,8 @@
 
 use capsules_core::gpio::GPIO;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil::gpio;
 use kernel::hil::gpio::InterruptWithValue;
 
@@ -121,35 +120,45 @@ macro_rules! gpio_component_static {
 
 pub type GpioComponentType<IP> = GPIO<'static, IP>;
 
-pub struct GpioComponent<IP: 'static + gpio::InterruptPin<'static>> {
+pub struct GpioComponent<
+    IP: 'static + gpio::InterruptPin<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     gpio_pins: &'static [Option<&'static gpio::InterruptValueWrapper<'static, IP>>],
+    mem_cap: CAP,
 }
 
-impl<IP: 'static + gpio::InterruptPin<'static>> GpioComponent<IP> {
+impl<IP: 'static + gpio::InterruptPin<'static>, CAP: MemoryAllocationCapability + 'static>
+    GpioComponent<IP, CAP>
+{
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         gpio_pins: &'static [Option<&'static gpio::InterruptValueWrapper<'static, IP>>],
+        mem_cap: CAP,
     ) -> Self {
         Self {
             board_kernel,
             driver_num,
             gpio_pins,
+            mem_cap,
         }
     }
 }
 
-impl<IP: 'static + gpio::InterruptPin<'static>> Component for GpioComponent<IP> {
+impl<IP: 'static + gpio::InterruptPin<'static>, CAP: MemoryAllocationCapability + 'static> Component
+    for GpioComponent<IP, CAP>
+{
     type StaticInput = &'static mut MaybeUninit<GPIO<'static, IP>>;
     type Output = &'static GPIO<'static, IP>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
         let gpio = static_buffer.write(GPIO::new(
             self.gpio_pins,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
         ));
         for maybe_pin in self.gpio_pins.iter() {
             if let Some(pin) = maybe_pin {

--- a/boards/components/src/hmac.rs
+++ b/boards/components/src/hmac.rs
@@ -19,9 +19,8 @@
 
 use capsules_extra::hmac::HmacDriver;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil::digest;
 
 #[macro_export]
@@ -38,22 +37,34 @@ macro_rules! hmac_component_static {
 
 pub type HmacComponentType<H, const L: usize> = capsules_extra::hmac::HmacDriver<'static, H, L>;
 
-pub struct HmacComponent<A: 'static + digest::Digest<'static, L>, const L: usize> {
+pub struct HmacComponent<
+    A: 'static + digest::Digest<'static, L>,
+    const L: usize,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     hmac: &'static A,
+    mem_cap: CAP,
 }
 
-impl<A: 'static + digest::Digest<'static, L>, const L: usize> HmacComponent<A, L> {
+impl<
+    A: 'static + digest::Digest<'static, L>,
+    const L: usize,
+    CAP: MemoryAllocationCapability + 'static,
+> HmacComponent<A, L, CAP>
+{
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         hmac: &'static A,
-    ) -> HmacComponent<A, L> {
+        mem_cap: CAP,
+    ) -> HmacComponent<A, L, CAP> {
         HmacComponent {
             board_kernel,
             driver_num,
             hmac,
+            mem_cap,
         }
     }
 }
@@ -65,7 +76,8 @@ impl<
         + 'static
         + digest::Digest<'static, L>,
     const L: usize,
-> Component for HmacComponent<A, L>
+    CAP: MemoryAllocationCapability + 'static,
+> Component for HmacComponent<A, L, CAP>
 {
     type StaticInput = (
         &'static mut MaybeUninit<HmacDriver<'static, A, L>>,
@@ -75,8 +87,6 @@ impl<
     type Output = &'static HmacDriver<'static, A, L>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let data_buffer = s.1.write([0; 64]);
         let dest_buffer = s.2.write([0; L]);
 
@@ -84,7 +94,8 @@ impl<
             self.hmac,
             data_buffer,
             dest_buffer,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
         ));
 
         self.hmac.set_client(hmac);

--- a/boards/components/src/humidity.rs
+++ b/boards/components/src/humidity.rs
@@ -13,9 +13,8 @@
 
 use capsules_extra::humidity::HumiditySensor;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil;
 
 #[macro_export]
@@ -27,36 +26,49 @@ macro_rules! humidity_component_static {
 
 pub type HumidityComponentType<H> = capsules_extra::humidity::HumiditySensor<'static, H>;
 
-pub struct HumidityComponent<T: 'static + hil::sensors::HumidityDriver<'static>> {
+pub struct HumidityComponent<
+    T: 'static + hil::sensors::HumidityDriver<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     sensor: &'static T,
+    mem_cap: CAP,
 }
 
-impl<T: 'static + hil::sensors::HumidityDriver<'static>> HumidityComponent<T> {
+impl<
+        T: 'static + hil::sensors::HumidityDriver<'static>,
+        CAP: MemoryAllocationCapability + 'static,
+    > HumidityComponent<T, CAP>
+{
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         sensor: &'static T,
-    ) -> HumidityComponent<T> {
+        mem_cap: CAP,
+    ) -> HumidityComponent<T, CAP> {
         HumidityComponent {
             board_kernel,
             driver_num,
             sensor,
+            mem_cap,
         }
     }
 }
 
-impl<T: 'static + hil::sensors::HumidityDriver<'static>> Component for HumidityComponent<T> {
+impl<
+        T: 'static + hil::sensors::HumidityDriver<'static>,
+        CAP: MemoryAllocationCapability + 'static,
+    > Component for HumidityComponent<T, CAP>
+{
     type StaticInput = &'static mut MaybeUninit<HumiditySensor<'static, T>>;
     type Output = &'static HumiditySensor<'static, T>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let humidity = s.write(HumiditySensor::new(
             self.sensor,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
         ));
 
         hil::sensors::HumidityDriver::set_client(self.sensor, humidity);

--- a/boards/components/src/humidity.rs
+++ b/boards/components/src/humidity.rs
@@ -36,10 +36,8 @@ pub struct HumidityComponent<
     mem_cap: CAP,
 }
 
-impl<
-        T: 'static + hil::sensors::HumidityDriver<'static>,
-        CAP: MemoryAllocationCapability + 'static,
-    > HumidityComponent<T, CAP>
+impl<T: 'static + hil::sensors::HumidityDriver<'static>, CAP: MemoryAllocationCapability + 'static>
+    HumidityComponent<T, CAP>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
@@ -56,10 +54,8 @@ impl<
     }
 }
 
-impl<
-        T: 'static + hil::sensors::HumidityDriver<'static>,
-        CAP: MemoryAllocationCapability + 'static,
-    > Component for HumidityComponent<T, CAP>
+impl<T: 'static + hil::sensors::HumidityDriver<'static>, CAP: MemoryAllocationCapability + 'static>
+    Component for HumidityComponent<T, CAP>
 {
     type StaticInput = &'static mut MaybeUninit<HumiditySensor<'static, T>>;
     type Output = &'static HumiditySensor<'static, T>;

--- a/boards/components/src/i2c.rs
+++ b/boards/components/src/i2c.rs
@@ -23,9 +23,8 @@
 
 use capsules_core::virtualizers::virtual_i2c::{I2CDevice, MuxI2C};
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil::i2c::{self, NoSMBus};
 
 // Setup static space for the objects.
@@ -137,23 +136,37 @@ impl<I: 'static + i2c::I2CMaster<'static>> Component for I2CComponent<I> {
 pub type I2CMasterSlaveDriverComponentType<I> =
     capsules_core::i2c_master_slave_driver::I2CMasterSlaveDriver<'static, I>;
 
-pub struct I2CMasterSlaveDriverComponent<I: 'static + i2c::I2CMasterSlave<'static>> {
+pub struct I2CMasterSlaveDriverComponent<
+    I: 'static + i2c::I2CMasterSlave<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     i2c: &'static I,
+    mem_cap: CAP,
 }
 
-impl<I: 'static + i2c::I2CMasterSlave<'static>> I2CMasterSlaveDriverComponent<I> {
-    pub fn new(board_kernel: &'static kernel::Kernel, driver_num: usize, i2c: &'static I) -> Self {
+impl<I: 'static + i2c::I2CMasterSlave<'static>, CAP: MemoryAllocationCapability + 'static>
+    I2CMasterSlaveDriverComponent<I, CAP>
+{
+    pub fn new(
+        board_kernel: &'static kernel::Kernel,
+        driver_num: usize,
+        i2c: &'static I,
+        mem_cap: CAP,
+    ) -> Self {
         I2CMasterSlaveDriverComponent {
             board_kernel,
             driver_num,
             i2c,
+            mem_cap,
         }
     }
 }
 
-impl<I: 'static + i2c::I2CMasterSlave<'static>> Component for I2CMasterSlaveDriverComponent<I> {
+impl<I: 'static + i2c::I2CMasterSlave<'static>, CAP: MemoryAllocationCapability + 'static> Component
+    for I2CMasterSlaveDriverComponent<I, CAP>
+{
     type StaticInput = (
         &'static mut MaybeUninit<
             capsules_core::i2c_master_slave_driver::I2CMasterSlaveDriver<'static, I>,
@@ -165,8 +178,6 @@ impl<I: 'static + i2c::I2CMasterSlave<'static>> Component for I2CMasterSlaveDriv
     type Output = &'static capsules_core::i2c_master_slave_driver::I2CMasterSlaveDriver<'static, I>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let i2c_master_buffer = static_buffer.1.write([0; 32]);
         let i2c_slave_buffer1 = static_buffer.2.write([0; 32]);
         let i2c_slave_buffer2 = static_buffer.3.write([0; 32]);
@@ -177,7 +188,8 @@ impl<I: 'static + i2c::I2CMasterSlave<'static>> Component for I2CMasterSlaveDriv
                 i2c_master_buffer,
                 i2c_slave_buffer1,
                 i2c_slave_buffer2,
-                self.board_kernel.create_grant(self.driver_num, &grant_cap),
+                self.board_kernel
+                    .create_grant(self.driver_num, &self.mem_cap),
             ),
         );
 
@@ -188,22 +200,36 @@ impl<I: 'static + i2c::I2CMasterSlave<'static>> Component for I2CMasterSlaveDriv
     }
 }
 
-pub struct I2CMasterDriverComponent<I: 'static + i2c::I2CMaster<'static>> {
+pub struct I2CMasterDriverComponent<
+    I: 'static + i2c::I2CMaster<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     i2c: &'static I,
+    mem_cap: CAP,
 }
 
-impl<I: 'static + i2c::I2CMaster<'static>> I2CMasterDriverComponent<I> {
-    pub fn new(board_kernel: &'static kernel::Kernel, driver_num: usize, i2c: &'static I) -> Self {
+impl<I: 'static + i2c::I2CMaster<'static>, CAP: MemoryAllocationCapability + 'static>
+    I2CMasterDriverComponent<I, CAP>
+{
+    pub fn new(
+        board_kernel: &'static kernel::Kernel,
+        driver_num: usize,
+        i2c: &'static I,
+        mem_cap: CAP,
+    ) -> Self {
         I2CMasterDriverComponent {
             board_kernel,
             driver_num,
             i2c,
+            mem_cap,
         }
     }
 }
-impl<I: 'static + i2c::I2CMaster<'static>> Component for I2CMasterDriverComponent<I> {
+impl<I: 'static + i2c::I2CMaster<'static>, CAP: MemoryAllocationCapability + 'static> Component
+    for I2CMasterDriverComponent<I, CAP>
+{
     type StaticInput = (
         &'static mut MaybeUninit<capsules_core::i2c_master::I2CMasterDriver<'static, I>>,
         &'static mut MaybeUninit<[u8; 32]>,
@@ -211,8 +237,6 @@ impl<I: 'static + i2c::I2CMaster<'static>> Component for I2CMasterDriverComponen
     type Output = &'static capsules_core::i2c_master::I2CMasterDriver<'static, I>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let i2c_master_buffer = static_buffer.1.write([0; 32]);
 
         let i2c_master_driver =
@@ -221,7 +245,8 @@ impl<I: 'static + i2c::I2CMaster<'static>> Component for I2CMasterDriverComponen
                 .write(capsules_core::i2c_master::I2CMasterDriver::new(
                     self.i2c,
                     i2c_master_buffer,
-                    self.board_kernel.create_grant(self.driver_num, &grant_cap),
+                    self.board_kernel
+                        .create_grant(self.driver_num, &self.mem_cap),
                 ));
 
         self.i2c.set_master_client(i2c_master_driver);

--- a/boards/components/src/ieee802154.rs
+++ b/boards/components/src/ieee802154.rs
@@ -37,9 +37,8 @@ use capsules_core::virtualizers::virtual_aes_ccm::MuxAES128CCM;
 use capsules_extra::ieee802154::device::MacDevice;
 use capsules_extra::ieee802154::mac::{AwakeMac, Mac};
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil::radio::{self, MAX_BUF_SIZE};
 use kernel::hil::symmetric_encryption::{self, AES, AES128, AESCBC, AESCCM, AESCtr, AESECB};
 
@@ -172,6 +171,7 @@ pub type Ieee802154ComponentMacDeviceType<R, A> = capsules_extra::ieee802154::fr
 pub struct Ieee802154Component<
     R: 'static + kernel::hil::radio::Radio<'static>,
     A: 'static + AES<'static, AES128> + AESCtr + AESCBC + AESECB,
+    CAP: MemoryAllocationCapability + 'static,
 > {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
@@ -180,12 +180,14 @@ pub struct Ieee802154Component<
     pan_id: capsules_extra::net::ieee802154::PanID,
     short_addr: u16,
     long_addr: [u8; 8],
+    mem_cap: CAP,
 }
 
 impl<
     R: 'static + kernel::hil::radio::Radio<'static>,
     A: 'static + AES<'static, AES128> + AESCtr + AESCBC + AESECB,
-> Ieee802154Component<R, A>
+    CAP: MemoryAllocationCapability + 'static,
+> Ieee802154Component<R, A, CAP>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
@@ -195,6 +197,7 @@ impl<
         pan_id: capsules_extra::net::ieee802154::PanID,
         short_addr: u16,
         long_addr: [u8; 8],
+        mem_cap: CAP,
     ) -> Self {
         Self {
             board_kernel,
@@ -204,6 +207,7 @@ impl<
             pan_id,
             short_addr,
             long_addr,
+            mem_cap,
         }
     }
 }
@@ -211,7 +215,8 @@ impl<
 impl<
     R: 'static + kernel::hil::radio::Radio<'static>,
     A: 'static + AES<'static, AES128> + AESCtr + AESCBC + AESECB,
-> Component for Ieee802154Component<R, A>
+    CAP: MemoryAllocationCapability + 'static,
+> Component for Ieee802154Component<R, A, CAP>
 {
     type StaticInput = (
         &'static mut MaybeUninit<
@@ -286,8 +291,6 @@ impl<
     );
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let crypt_buf = static_buffer.8.write([0; CRYPT_SIZE]);
         let aes_ccm = static_buffer.0.write(
             capsules_core::virtualizers::virtual_aes_ccm::VirtualAES128CCM::new(
@@ -339,7 +342,8 @@ impl<
             .5
             .write(capsules_extra::ieee802154::RadioDriver::new(
                 userspace_mac,
-                self.board_kernel.create_grant(self.driver_num, &grant_cap),
+                self.board_kernel
+                    .create_grant(self.driver_num, &self.mem_cap),
                 radio_buffer,
             ));
         kernel::deferred_call::DeferredCallClient::register(radio_driver);
@@ -374,27 +378,37 @@ macro_rules! ieee802154_raw_component_static {
 pub type Ieee802154RawComponentType<R> =
     capsules_extra::ieee802154::phy_driver::RadioDriver<'static, R>;
 
-pub struct Ieee802154RawComponent<R: 'static + kernel::hil::radio::Radio<'static>> {
+pub struct Ieee802154RawComponent<
+    R: 'static + kernel::hil::radio::Radio<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     radio: &'static R,
+    mem_cap: CAP,
 }
 
-impl<R: 'static + kernel::hil::radio::Radio<'static>> Ieee802154RawComponent<R> {
+impl<R: 'static + kernel::hil::radio::Radio<'static>, CAP: MemoryAllocationCapability + 'static>
+    Ieee802154RawComponent<R, CAP>
+{
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         radio: &'static R,
+        mem_cap: CAP,
     ) -> Self {
         Self {
             board_kernel,
             driver_num,
             radio,
+            mem_cap,
         }
     }
 }
 
-impl<R: 'static + kernel::hil::radio::Radio<'static>> Component for Ieee802154RawComponent<R> {
+impl<R: 'static + kernel::hil::radio::Radio<'static>, CAP: MemoryAllocationCapability + 'static>
+    Component for Ieee802154RawComponent<R, CAP>
+{
     type StaticInput = (
         &'static mut MaybeUninit<capsules_extra::ieee802154::phy_driver::RadioDriver<'static, R>>,
         &'static mut MaybeUninit<[u8; radio::MAX_BUF_SIZE]>,
@@ -403,8 +417,6 @@ impl<R: 'static + kernel::hil::radio::Radio<'static>> Component for Ieee802154Ra
     type Output = &'static capsules_extra::ieee802154::phy_driver::RadioDriver<'static, R>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let tx_buffer = static_buffer.1.write([0; MAX_BUF_SIZE]);
         let radio_rx_buf = static_buffer.2.write([0; radio::MAX_BUF_SIZE]);
 
@@ -413,7 +425,8 @@ impl<R: 'static + kernel::hil::radio::Radio<'static>> Component for Ieee802154Ra
                 .0
                 .write(capsules_extra::ieee802154::phy_driver::RadioDriver::new(
                     self.radio,
-                    self.board_kernel.create_grant(self.driver_num, &grant_cap),
+                    self.board_kernel
+                        .create_grant(self.driver_num, &self.mem_cap),
                     tx_buffer,
                 ));
 

--- a/boards/components/src/isl29035.rs
+++ b/boards/components/src/isl29035.rs
@@ -31,9 +31,8 @@ use capsules_core::virtualizers::virtual_i2c::{I2CDevice, MuxI2C};
 use capsules_extra::ambient_light::AmbientLight;
 use capsules_extra::isl29035::Isl29035;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil;
 use kernel::hil::i2c;
 use kernel::hil::time::{self, Alarm};
@@ -115,36 +114,49 @@ impl<A: 'static + time::Alarm<'static>, I: 'static + i2c::I2CMaster<'static>> Co
     }
 }
 
-pub struct AmbientLightComponent<L: 'static + hil::sensors::AmbientLight<'static>> {
+pub struct AmbientLightComponent<
+    L: 'static + hil::sensors::AmbientLight<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     light_sensor: &'static L,
+    mem_cap: CAP,
 }
 
-impl<L: 'static + hil::sensors::AmbientLight<'static>> AmbientLightComponent<L> {
+impl<
+        L: 'static + hil::sensors::AmbientLight<'static>,
+        CAP: MemoryAllocationCapability + 'static,
+    > AmbientLightComponent<L, CAP>
+{
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         light_sensor: &'static L,
+        mem_cap: CAP,
     ) -> Self {
         AmbientLightComponent {
             board_kernel,
             driver_num,
             light_sensor,
+            mem_cap,
         }
     }
 }
 
-impl<L: 'static + hil::sensors::AmbientLight<'static>> Component for AmbientLightComponent<L> {
+impl<
+        L: 'static + hil::sensors::AmbientLight<'static>,
+        CAP: MemoryAllocationCapability + 'static,
+    > Component for AmbientLightComponent<L, CAP>
+{
     type StaticInput = &'static mut MaybeUninit<AmbientLight<'static>>;
     type Output = &'static AmbientLight<'static>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let ambient_light = static_buffer.write(AmbientLight::new(
             self.light_sensor,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
         ));
         hil::sensors::AmbientLight::set_client(self.light_sensor, ambient_light);
         ambient_light

--- a/boards/components/src/isl29035.rs
+++ b/boards/components/src/isl29035.rs
@@ -124,10 +124,8 @@ pub struct AmbientLightComponent<
     mem_cap: CAP,
 }
 
-impl<
-        L: 'static + hil::sensors::AmbientLight<'static>,
-        CAP: MemoryAllocationCapability + 'static,
-    > AmbientLightComponent<L, CAP>
+impl<L: 'static + hil::sensors::AmbientLight<'static>, CAP: MemoryAllocationCapability + 'static>
+    AmbientLightComponent<L, CAP>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
@@ -144,10 +142,8 @@ impl<
     }
 }
 
-impl<
-        L: 'static + hil::sensors::AmbientLight<'static>,
-        CAP: MemoryAllocationCapability + 'static,
-    > Component for AmbientLightComponent<L, CAP>
+impl<L: 'static + hil::sensors::AmbientLight<'static>, CAP: MemoryAllocationCapability + 'static>
+    Component for AmbientLightComponent<L, CAP>
 {
     type StaticInput = &'static mut MaybeUninit<AmbientLight<'static>>;
     type Output = &'static AmbientLight<'static>;

--- a/boards/components/src/isolated_nonvolatile_storage.rs
+++ b/boards/components/src/isolated_nonvolatile_storage.rs
@@ -28,9 +28,8 @@
 use capsules_extra::isolated_nonvolatile_storage_driver::IsolatedNonvolatileStorage;
 use capsules_extra::nonvolatile_to_pages::NonvolatileToPages;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil;
 
 // How much storage space to allocate per-app. Currently, regions are not
@@ -65,18 +64,21 @@ pub type IsolatedNonvolatileStorageComponentType<const APP_REGION_SIZE: usize> =
 pub struct IsolatedNonvolatileStorageComponent<
     F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, NonvolatileToPages<'static, F>>,
     const APP_REGION_SIZE: usize,
+    CAP: MemoryAllocationCapability + 'static,
 > {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     flash: &'static F,
     userspace_start: usize,
     userspace_length: usize,
+    mem_cap: CAP,
 }
 
 impl<
     F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, NonvolatileToPages<'static, F>>,
     const APP_REGION_SIZE: usize,
-> IsolatedNonvolatileStorageComponent<F, APP_REGION_SIZE>
+    CAP: MemoryAllocationCapability + 'static,
+> IsolatedNonvolatileStorageComponent<F, APP_REGION_SIZE, CAP>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
@@ -84,6 +86,7 @@ impl<
         flash: &'static F,
         userspace_start: usize,
         userspace_length: usize,
+        mem_cap: CAP,
     ) -> Self {
         Self {
             board_kernel,
@@ -91,6 +94,7 @@ impl<
             flash,
             userspace_start,
             userspace_length,
+            mem_cap,
         }
     }
 }
@@ -98,7 +102,8 @@ impl<
 impl<
     F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, NonvolatileToPages<'static, F>>,
     const APP_REGION_SIZE: usize,
-> Component for IsolatedNonvolatileStorageComponent<F, APP_REGION_SIZE>
+    CAP: MemoryAllocationCapability + 'static,
+> Component for IsolatedNonvolatileStorageComponent<F, APP_REGION_SIZE, CAP>
 {
     type StaticInput = (
         &'static mut MaybeUninit<<F as hil::flash::Flash>::Page>,
@@ -111,8 +116,6 @@ impl<
     type Output = &'static IsolatedNonvolatileStorage<'static, APP_REGION_SIZE>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let buffer = static_buffer
             .3
             .write([0; capsules_extra::isolated_nonvolatile_storage_driver::BUF_LEN]);
@@ -128,7 +131,8 @@ impl<
 
         let nonvolatile_storage = static_buffer.2.write(IsolatedNonvolatileStorage::new(
             nv_to_page,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
             self.userspace_start, // Start address for userspace accessible region
             self.userspace_length, // Length of userspace accessible region
             buffer,

--- a/boards/components/src/keyboard_hid.rs
+++ b/boards/components/src/keyboard_hid.rs
@@ -34,9 +34,8 @@
 //! ```
 
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil;
 
 // Setup static space for the objects.
@@ -62,16 +61,22 @@ pub type KeyboardHidComponentType<U> = capsules_extra::usb_hid_driver::UsbHidDri
     capsules_extra::usb::keyboard_hid::KeyboardHid<'static, U>,
 >;
 
-pub struct KeyboardHidComponent<U: 'static + hil::usb::UsbController<'static>> {
+pub struct KeyboardHidComponent<
+    U: 'static + hil::usb::UsbController<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     usb: &'static U,
     vendor_id: u16,
     product_id: u16,
     strings: &'static [&'static str; 3],
+    mem_cap: CAP,
 }
 
-impl<U: 'static + hil::usb::UsbController<'static>> KeyboardHidComponent<U> {
+impl<U: 'static + hil::usb::UsbController<'static>, CAP: MemoryAllocationCapability + 'static>
+    KeyboardHidComponent<U, CAP>
+{
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
@@ -79,7 +84,8 @@ impl<U: 'static + hil::usb::UsbController<'static>> KeyboardHidComponent<U> {
         vendor_id: u16,
         product_id: u16,
         strings: &'static [&'static str; 3],
-    ) -> KeyboardHidComponent<U> {
+        mem_cap: CAP,
+    ) -> KeyboardHidComponent<U, CAP> {
         KeyboardHidComponent {
             board_kernel,
             driver_num,
@@ -87,11 +93,14 @@ impl<U: 'static + hil::usb::UsbController<'static>> KeyboardHidComponent<U> {
             vendor_id,
             product_id,
             strings,
+            mem_cap,
         }
     }
 }
 
-impl<U: 'static + hil::usb::UsbController<'static>> Component for KeyboardHidComponent<U> {
+impl<U: 'static + hil::usb::UsbController<'static>, CAP: MemoryAllocationCapability + 'static>
+    Component for KeyboardHidComponent<U, CAP>
+{
     type StaticInput = (
         &'static mut MaybeUninit<capsules_extra::usb::keyboard_hid::KeyboardHid<'static, U>>,
         &'static mut MaybeUninit<
@@ -121,8 +130,6 @@ impl<U: 'static + hil::usb::UsbController<'static>> Component for KeyboardHidCom
             ));
         self.usb.set_client(keyboard_hid);
 
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let send_buffer = s.2.write([0; 64]);
         let recv_buffer = s.3.write([0; 64]);
 
@@ -130,7 +137,8 @@ impl<U: 'static + hil::usb::UsbController<'static>> Component for KeyboardHidCom
             keyboard_hid,
             send_buffer,
             recv_buffer,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
         ));
 
         keyboard_hid.set_client(usb_hid_driver);

--- a/boards/components/src/kv.rs
+++ b/boards/components/src/kv.rs
@@ -10,9 +10,8 @@ use capsules_extra::tickv::{KVSystem, KeyType};
 use capsules_extra::tickv_kv_store::TicKVKVStore;
 use capsules_extra::virtualizers::virtual_kv::{MuxKVPermissions, VirtualKVPermissions};
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil;
 
 ///////////////////////
@@ -32,23 +31,37 @@ macro_rules! kv_driver_component_static {
 
 pub type KVDriverComponentType<V> = capsules_extra::kv_driver::KVStoreDriver<'static, V>;
 
-pub struct KVDriverComponent<V: hil::kv::KVPermissions<'static> + 'static> {
+pub struct KVDriverComponent<
+    V: hil::kv::KVPermissions<'static> + 'static,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     kv: &'static V,
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
+    mem_cap: CAP,
 }
 
-impl<V: hil::kv::KVPermissions<'static>> KVDriverComponent<V> {
-    pub fn new(kv: &'static V, board_kernel: &'static kernel::Kernel, driver_num: usize) -> Self {
+impl<V: hil::kv::KVPermissions<'static>, CAP: MemoryAllocationCapability + 'static>
+    KVDriverComponent<V, CAP>
+{
+    pub fn new(
+        kv: &'static V,
+        board_kernel: &'static kernel::Kernel,
+        driver_num: usize,
+        mem_cap: CAP,
+    ) -> Self {
         Self {
             kv,
             board_kernel,
             driver_num,
+            mem_cap,
         }
     }
 }
 
-impl<V: hil::kv::KVPermissions<'static>> Component for KVDriverComponent<V> {
+impl<V: hil::kv::KVPermissions<'static>, CAP: MemoryAllocationCapability + 'static> Component
+    for KVDriverComponent<V, CAP>
+{
     type StaticInput = (
         &'static mut MaybeUninit<KVStoreDriver<'static, V>>,
         &'static mut MaybeUninit<[u8; 64]>,
@@ -57,8 +70,6 @@ impl<V: hil::kv::KVPermissions<'static>> Component for KVDriverComponent<V> {
     type Output = &'static KVStoreDriver<'static, V>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let key_buffer = static_buffer.1.write([0; 64]);
         let value_buffer = static_buffer.2.write([0; 512]);
 
@@ -66,7 +77,8 @@ impl<V: hil::kv::KVPermissions<'static>> Component for KVDriverComponent<V> {
             self.kv,
             key_buffer,
             value_buffer,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
         ));
         self.kv.set_client(driver);
         driver

--- a/boards/components/src/l3gd20.rs
+++ b/boards/components/src/l3gd20.rs
@@ -16,9 +16,8 @@
 use capsules_core::virtualizers::virtual_spi::{MuxSpiMaster, VirtualSpiMasterDevice};
 use capsules_extra::l3gd20::L3gd20Spi;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil::spi;
 use kernel::hil::spi::SpiMasterDevice;
 
@@ -48,29 +47,34 @@ pub type L3gd20ComponentType<S> = capsules_extra::l3gd20::L3gd20Spi<'static, S>;
 pub struct L3gd20Component<
     S: 'static + spi::SpiMaster<'static>,
     CS: spi::cs::IntoChipSelect<S::ChipSelect, spi::cs::ActiveLow>,
+    CAP: MemoryAllocationCapability + 'static,
 > {
     spi_mux: &'static MuxSpiMaster<'static, S>,
     chip_select: CS,
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
+    mem_cap: CAP,
 }
 
 impl<
     S: 'static + spi::SpiMaster<'static>,
     CS: spi::cs::IntoChipSelect<S::ChipSelect, spi::cs::ActiveLow>,
-> L3gd20Component<S, CS>
+    CAP: MemoryAllocationCapability + 'static,
+> L3gd20Component<S, CS, CAP>
 {
     pub fn new(
         spi_mux: &'static MuxSpiMaster<'static, S>,
         chip_select: CS,
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
+        mem_cap: CAP,
     ) -> Self {
         Self {
             spi_mux,
             chip_select,
             board_kernel,
             driver_num,
+            mem_cap,
         }
     }
 }
@@ -78,7 +82,8 @@ impl<
 impl<
     S: 'static + spi::SpiMaster<'static>,
     CS: spi::cs::IntoChipSelect<S::ChipSelect, spi::cs::ActiveLow>,
-> Component for L3gd20Component<S, CS>
+    CAP: MemoryAllocationCapability + 'static,
+> Component for L3gd20Component<S, CS, CAP>
 {
     type StaticInput = (
         &'static mut MaybeUninit<VirtualSpiMasterDevice<'static, S>>,
@@ -89,8 +94,9 @@ impl<
     type Output = &'static L3gd20Spi<'static, VirtualSpiMasterDevice<'static, S>>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-        let grant = self.board_kernel.create_grant(self.driver_num, &grant_cap);
+        let grant = self
+            .board_kernel
+            .create_grant(self.driver_num, &self.mem_cap);
 
         let spi_device = static_buffer.0.write(VirtualSpiMasterDevice::new(
             self.spi_mux,

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
+#![forbid(unsafe_code)]
 #![no_std]
 
 pub mod adc;

--- a/boards/components/src/lldb.rs
+++ b/boards/components/src/lldb.rs
@@ -23,9 +23,8 @@
 use capsules_core::low_level_debug::LowLevelDebug;
 use capsules_core::virtualizers::virtual_uart::{MuxUart, UartDevice};
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil;
 
 #[macro_export]
@@ -45,27 +44,30 @@ macro_rules! low_level_debug_component_static {
     };};
 }
 
-pub struct LowLevelDebugComponent {
+pub struct LowLevelDebugComponent<CAP: MemoryAllocationCapability + 'static> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     uart_mux: &'static MuxUart<'static>,
+    mem_cap: CAP,
 }
 
-impl LowLevelDebugComponent {
+impl<CAP: MemoryAllocationCapability + 'static> LowLevelDebugComponent<CAP> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         uart_mux: &'static MuxUart,
-    ) -> LowLevelDebugComponent {
+        mem_cap: CAP,
+    ) -> LowLevelDebugComponent<CAP> {
         LowLevelDebugComponent {
             board_kernel,
             driver_num,
             uart_mux,
+            mem_cap,
         }
     }
 }
 
-impl Component for LowLevelDebugComponent {
+impl<CAP: MemoryAllocationCapability + 'static> Component for LowLevelDebugComponent<CAP> {
     type StaticInput = (
         &'static mut MaybeUninit<UartDevice<'static>>,
         &'static mut MaybeUninit<[u8; capsules_core::low_level_debug::BUF_LEN]>,
@@ -74,8 +76,6 @@ impl Component for LowLevelDebugComponent {
     type Output = &'static LowLevelDebug<'static, UartDevice<'static>>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let lldb_uart = s.0.write(UartDevice::new(self.uart_mux, true));
         lldb_uart.setup();
 
@@ -84,7 +84,8 @@ impl Component for LowLevelDebugComponent {
         let lldb = s.2.write(LowLevelDebug::new(
             buffer,
             lldb_uart,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
         ));
         hil::uart::Transmit::set_transmit_client(lldb_uart, lldb);
 

--- a/boards/components/src/loader/sequential.rs
+++ b/boards/components/src/loader/sequential.rs
@@ -51,11 +51,11 @@ pub struct ProcessLoaderSequentialComponent<
 }
 
 impl<
-        C: Chip,
-        D: ProcessStandardDebug,
-        CAP: ProcessManagementCapability + 'static,
-        const NUM_PROCS: usize,
-    > ProcessLoaderSequentialComponent<C, D, CAP, NUM_PROCS>
+    C: Chip,
+    D: ProcessStandardDebug,
+    CAP: ProcessManagementCapability + 'static,
+    const NUM_PROCS: usize,
+> ProcessLoaderSequentialComponent<C, D, CAP, NUM_PROCS>
 {
     pub fn new(
         checker: &'static kernel::process::ProcessCheckerMachine,
@@ -83,11 +83,11 @@ impl<
 }
 
 impl<
-        C: Chip,
-        D: ProcessStandardDebug,
-        CAP: ProcessManagementCapability + 'static,
-        const NUM_PROCS: usize,
-    > Component for ProcessLoaderSequentialComponent<C, D, CAP, NUM_PROCS>
+    C: Chip,
+    D: ProcessStandardDebug,
+    CAP: ProcessManagementCapability + 'static,
+    const NUM_PROCS: usize,
+> Component for ProcessLoaderSequentialComponent<C, D, CAP, NUM_PROCS>
 {
     type StaticInput = (
         &'static mut MaybeUninit<kernel::process::SequentialProcessLoaderMachine<'static, C, D>>,

--- a/boards/components/src/loader/sequential.rs
+++ b/boards/components/src/loader/sequential.rs
@@ -9,6 +9,7 @@
 //! use.
 
 use core::mem::MaybeUninit;
+use kernel::capabilities::ProcessManagementCapability;
 use kernel::component::Component;
 use kernel::deferred_call::DeferredCallClient;
 use kernel::platform::chip::Chip;
@@ -35,6 +36,7 @@ pub type ProcessLoaderSequentialComponentType<C, D> =
 pub struct ProcessLoaderSequentialComponent<
     C: Chip + 'static,
     D: ProcessStandardDebug + 'static,
+    CAP: ProcessManagementCapability + 'static,
     const NUM_PROCS: usize,
 > {
     checker: &'static kernel::process::ProcessCheckerMachine,
@@ -45,10 +47,15 @@ pub struct ProcessLoaderSequentialComponent<
     storage_policy: &'static dyn kernel::process::ProcessStandardStoragePermissionsPolicy<C, D>,
     app_flash: &'static [u8],
     app_memory: &'static mut [u8],
+    proc_manage_cap: CAP,
 }
 
-impl<C: Chip, D: ProcessStandardDebug, const NUM_PROCS: usize>
-    ProcessLoaderSequentialComponent<C, D, NUM_PROCS>
+impl<
+        C: Chip,
+        D: ProcessStandardDebug,
+        CAP: ProcessManagementCapability + 'static,
+        const NUM_PROCS: usize,
+    > ProcessLoaderSequentialComponent<C, D, CAP, NUM_PROCS>
 {
     pub fn new(
         checker: &'static kernel::process::ProcessCheckerMachine,
@@ -59,6 +66,7 @@ impl<C: Chip, D: ProcessStandardDebug, const NUM_PROCS: usize>
         storage_policy: &'static dyn kernel::process::ProcessStandardStoragePermissionsPolicy<C, D>,
         app_flash: &'static [u8],
         app_memory: &'static mut [u8],
+        proc_manage_cap: CAP,
     ) -> Self {
         Self {
             checker,
@@ -69,12 +77,17 @@ impl<C: Chip, D: ProcessStandardDebug, const NUM_PROCS: usize>
             storage_policy,
             app_flash,
             app_memory,
+            proc_manage_cap,
         }
     }
 }
 
-impl<C: Chip, D: ProcessStandardDebug, const NUM_PROCS: usize> Component
-    for ProcessLoaderSequentialComponent<C, D, NUM_PROCS>
+impl<
+        C: Chip,
+        D: ProcessStandardDebug,
+        CAP: ProcessManagementCapability + 'static,
+        const NUM_PROCS: usize,
+    > Component for ProcessLoaderSequentialComponent<C, D, CAP, NUM_PROCS>
 {
     type StaticInput = (
         &'static mut MaybeUninit<kernel::process::SequentialProcessLoaderMachine<'static, C, D>>,
@@ -84,9 +97,6 @@ impl<C: Chip, D: ProcessStandardDebug, const NUM_PROCS: usize> Component
     type Output = &'static kernel::process::SequentialProcessLoaderMachine<'static, C, D>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let proc_manage_cap =
-            kernel::create_capability!(kernel::capabilities::ProcessManagementCapability);
-
         const ARRAY_REPEAT_VALUE: Option<kernel::process::ProcessBinary> = None;
         let process_binary_array = s.1.write([ARRAY_REPEAT_VALUE; NUM_PROCS]);
 
@@ -101,7 +111,7 @@ impl<C: Chip, D: ProcessStandardDebug, const NUM_PROCS: usize> Component
                 self.fault_policy,
                 self.storage_policy,
                 self.appid_policy,
-                &proc_manage_cap,
+                &self.proc_manage_cap,
             ));
         self.checker.set_client(loader);
         loader.register();

--- a/boards/components/src/lps25hb.rs
+++ b/boards/components/src/lps25hb.rs
@@ -7,9 +7,8 @@
 use capsules_core::virtualizers::virtual_i2c::{I2CDevice, MuxI2C};
 use capsules_extra::lps25hb::LPS25HB;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil::gpio;
 use kernel::hil::i2c;
 
@@ -30,21 +29,28 @@ macro_rules! lps25hb_component_static {
     };};
 }
 
-pub struct Lps25hbComponent<I: 'static + i2c::I2CMaster<'static>> {
+pub struct Lps25hbComponent<
+    I: 'static + i2c::I2CMaster<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     i2c_mux: &'static MuxI2C<'static, I>,
     i2c_address: u8,
     interrupt_pin: &'static dyn gpio::InterruptPin<'static>,
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
+    mem_cap: CAP,
 }
 
-impl<I: 'static + i2c::I2CMaster<'static>> Lps25hbComponent<I> {
+impl<I: 'static + i2c::I2CMaster<'static>, CAP: MemoryAllocationCapability + 'static>
+    Lps25hbComponent<I, CAP>
+{
     pub fn new(
         i2c_mux: &'static MuxI2C<'static, I>,
         i2c_address: u8,
         interrupt_pin: &'static dyn gpio::InterruptPin<'static>,
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
+        mem_cap: CAP,
     ) -> Self {
         Lps25hbComponent {
             i2c_mux,
@@ -52,11 +58,14 @@ impl<I: 'static + i2c::I2CMaster<'static>> Lps25hbComponent<I> {
             interrupt_pin,
             board_kernel,
             driver_num,
+            mem_cap,
         }
     }
 }
 
-impl<I: 'static + i2c::I2CMaster<'static>> Component for Lps25hbComponent<I> {
+impl<I: 'static + i2c::I2CMaster<'static>, CAP: MemoryAllocationCapability + 'static> Component
+    for Lps25hbComponent<I, CAP>
+{
     type StaticInput = (
         &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<LPS25HB<'static, I2CDevice<'static, I>>>,
@@ -65,8 +74,9 @@ impl<I: 'static + i2c::I2CMaster<'static>> Component for Lps25hbComponent<I> {
     type Output = &'static LPS25HB<'static, I2CDevice<'static, I>>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-        let grant = self.board_kernel.create_grant(self.driver_num, &grant_cap);
+        let grant = self
+            .board_kernel
+            .create_grant(self.driver_num, &self.mem_cap);
 
         let lps25hb_i2c = s.0.write(I2CDevice::new(self.i2c_mux, self.i2c_address));
 

--- a/boards/components/src/lsm303agr.rs
+++ b/boards/components/src/lsm303agr.rs
@@ -27,9 +27,8 @@ use capsules_core::virtualizers::virtual_i2c::{I2CDevice, MuxI2C};
 use capsules_extra::lsm303agr::Lsm303agrI2C;
 use capsules_extra::lsm303xx;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil::i2c;
 
 // Setup static space for the objects.
@@ -52,22 +51,29 @@ macro_rules! lsm303agr_component_static {
     };};
 }
 
-pub struct Lsm303agrI2CComponent<I: 'static + i2c::I2CMaster<'static>> {
+pub struct Lsm303agrI2CComponent<
+    I: 'static + i2c::I2CMaster<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     i2c_mux: &'static MuxI2C<'static, I>,
     accelerometer_i2c_address: u8,
     magnetometer_i2c_address: u8,
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
+    mem_cap: CAP,
 }
 
-impl<I: 'static + i2c::I2CMaster<'static>> Lsm303agrI2CComponent<I> {
+impl<I: 'static + i2c::I2CMaster<'static>, CAP: MemoryAllocationCapability + 'static>
+    Lsm303agrI2CComponent<I, CAP>
+{
     pub fn new(
         i2c_mux: &'static MuxI2C<'static, I>,
         accelerometer_i2c_address: Option<u8>,
         magnetometer_i2c_address: Option<u8>,
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
-    ) -> Lsm303agrI2CComponent<I> {
+        mem_cap: CAP,
+    ) -> Lsm303agrI2CComponent<I, CAP> {
         Lsm303agrI2CComponent {
             i2c_mux,
             accelerometer_i2c_address: accelerometer_i2c_address
@@ -76,11 +82,14 @@ impl<I: 'static + i2c::I2CMaster<'static>> Lsm303agrI2CComponent<I> {
                 .unwrap_or(lsm303xx::MAGNETOMETER_BASE_ADDRESS),
             board_kernel,
             driver_num,
+            mem_cap,
         }
     }
 }
 
-impl<I: 'static + i2c::I2CMaster<'static>> Component for Lsm303agrI2CComponent<I> {
+impl<I: 'static + i2c::I2CMaster<'static>, CAP: MemoryAllocationCapability + 'static> Component
+    for Lsm303agrI2CComponent<I, CAP>
+{
     type StaticInput = (
         &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<I2CDevice<'static, I>>,
@@ -90,8 +99,6 @@ impl<I: 'static + i2c::I2CMaster<'static>> Component for Lsm303agrI2CComponent<I
     type Output = &'static Lsm303agrI2C<'static, I2CDevice<'static, I>>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let buffer = static_buffer.2.write([0; 8]);
 
         let accelerometer_i2c = static_buffer
@@ -101,7 +108,9 @@ impl<I: 'static + i2c::I2CMaster<'static>> Component for Lsm303agrI2CComponent<I
             .1
             .write(I2CDevice::new(self.i2c_mux, self.magnetometer_i2c_address));
 
-        let grant = self.board_kernel.create_grant(self.driver_num, &grant_cap);
+        let grant = self
+            .board_kernel
+            .create_grant(self.driver_num, &self.mem_cap);
         let lsm303agr = static_buffer.3.write(Lsm303agrI2C::new(
             accelerometer_i2c,
             magnetometer_i2c,

--- a/boards/components/src/lsm303dlhc.rs
+++ b/boards/components/src/lsm303dlhc.rs
@@ -26,6 +26,7 @@ use capsules_core::virtualizers::virtual_i2c::{I2CDevice, MuxI2C};
 use capsules_extra::lsm303dlhc::Lsm303dlhcI2C;
 use capsules_extra::lsm303xx;
 use core::mem::MaybeUninit;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
 use kernel::hil::i2c;
 
@@ -49,22 +50,29 @@ macro_rules! lsm303dlhc_component_static {
     };};
 }
 
-pub struct Lsm303dlhcI2CComponent<I: 'static + i2c::I2CMaster<'static>> {
+pub struct Lsm303dlhcI2CComponent<
+    I: 'static + i2c::I2CMaster<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     i2c_mux: &'static MuxI2C<'static, I>,
     accelerometer_i2c_address: u8,
     magnetometer_i2c_address: u8,
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
+    mem_cap: CAP,
 }
 
-impl<I: 'static + i2c::I2CMaster<'static>> Lsm303dlhcI2CComponent<I> {
+impl<I: 'static + i2c::I2CMaster<'static>, CAP: MemoryAllocationCapability + 'static>
+    Lsm303dlhcI2CComponent<I, CAP>
+{
     pub fn new(
         i2c_mux: &'static MuxI2C<'static, I>,
         accelerometer_i2c_address: Option<u8>,
         magnetometer_i2c_address: Option<u8>,
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
-    ) -> Lsm303dlhcI2CComponent<I> {
+        mem_cap: CAP,
+    ) -> Lsm303dlhcI2CComponent<I, CAP> {
         Lsm303dlhcI2CComponent {
             i2c_mux,
             accelerometer_i2c_address: accelerometer_i2c_address
@@ -73,11 +81,14 @@ impl<I: 'static + i2c::I2CMaster<'static>> Lsm303dlhcI2CComponent<I> {
                 .unwrap_or(lsm303xx::MAGNETOMETER_BASE_ADDRESS),
             board_kernel,
             driver_num,
+            mem_cap,
         }
     }
 }
 
-impl<I: 'static + i2c::I2CMaster<'static>> Component for Lsm303dlhcI2CComponent<I> {
+impl<I: 'static + i2c::I2CMaster<'static>, CAP: MemoryAllocationCapability + 'static> Component
+    for Lsm303dlhcI2CComponent<I, CAP>
+{
     type StaticInput = (
         &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<I2CDevice<'static, I>>,
@@ -87,9 +98,6 @@ impl<I: 'static + i2c::I2CMaster<'static>> Component for Lsm303dlhcI2CComponent<
     type Output = &'static Lsm303dlhcI2C<'static, I2CDevice<'static, I>>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap =
-            kernel::create_capability!(kernel::capabilities::MemoryAllocationCapability);
-
         let buffer = static_buffer.2.write([0; 8]);
 
         let accelerometer_i2c = static_buffer
@@ -103,7 +111,8 @@ impl<I: 'static + i2c::I2CMaster<'static>> Component for Lsm303dlhcI2CComponent<
             accelerometer_i2c,
             magnetometer_i2c,
             buffer,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
         ));
         accelerometer_i2c.set_client(lsm303dlhc);
         magnetometer_i2c.set_client(lsm303dlhc);

--- a/boards/components/src/lsm6dsox.rs
+++ b/boards/components/src/lsm6dsox.rs
@@ -31,9 +31,8 @@
 use capsules_core::virtualizers::virtual_i2c::{I2CDevice, MuxI2C};
 use capsules_extra::lsm6dsoxtr::Lsm6dsoxtrI2C;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil::i2c;
 
 // Setup static space for the objects.
@@ -54,30 +53,40 @@ macro_rules! lsm6ds_i2c_component_static {
     };};
 }
 
-pub struct Lsm6dsoxtrI2CComponent<I: 'static + i2c::I2CMaster<'static>> {
+pub struct Lsm6dsoxtrI2CComponent<
+    I: 'static + i2c::I2CMaster<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     i2c_mux: &'static MuxI2C<'static, I>,
     i2c_address: u8,
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
+    mem_cap: CAP,
 }
 
-impl<I: 'static + i2c::I2CMaster<'static>> Lsm6dsoxtrI2CComponent<I> {
+impl<I: 'static + i2c::I2CMaster<'static>, CAP: MemoryAllocationCapability + 'static>
+    Lsm6dsoxtrI2CComponent<I, CAP>
+{
     pub fn new(
         i2c_mux: &'static MuxI2C<'static, I>,
         i2c_address: u8,
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
-    ) -> Lsm6dsoxtrI2CComponent<I> {
+        mem_cap: CAP,
+    ) -> Lsm6dsoxtrI2CComponent<I, CAP> {
         Lsm6dsoxtrI2CComponent {
             i2c_mux,
             i2c_address,
             board_kernel,
             driver_num,
+            mem_cap,
         }
     }
 }
 
-impl<I: 'static + i2c::I2CMaster<'static>> Component for Lsm6dsoxtrI2CComponent<I> {
+impl<I: 'static + i2c::I2CMaster<'static>, CAP: MemoryAllocationCapability + 'static> Component
+    for Lsm6dsoxtrI2CComponent<I, CAP>
+{
     type StaticInput = (
         &'static mut MaybeUninit<I2CDevice<'static, I>>,
         &'static mut MaybeUninit<[u8; 8]>,
@@ -86,8 +95,9 @@ impl<I: 'static + i2c::I2CMaster<'static>> Component for Lsm6dsoxtrI2CComponent<
     type Output = &'static Lsm6dsoxtrI2C<'static, I2CDevice<'static, I>>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-        let grant = self.board_kernel.create_grant(self.driver_num, &grant_cap);
+        let grant = self
+            .board_kernel
+            .create_grant(self.driver_num, &self.mem_cap);
 
         let lsm6dsox_i2c = static_buffer
             .0

--- a/boards/components/src/ltc294x.rs
+++ b/boards/components/src/ltc294x.rs
@@ -18,9 +18,8 @@ use capsules_core::virtualizers::virtual_i2c::{I2CDevice, MuxI2C};
 use capsules_extra::ltc294x::LTC294X;
 use capsules_extra::ltc294x::LTC294XDriver;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil::gpio;
 use kernel::hil::i2c;
 
@@ -92,33 +91,44 @@ impl<I: 'static + i2c::I2CMaster<'static>> Component for Ltc294xComponent<I> {
     }
 }
 
-pub struct Ltc294xDriverComponent<I: 'static + i2c::I2CMaster<'static>> {
+pub struct Ltc294xDriverComponent<
+    I: 'static + i2c::I2CMaster<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     ltc294x: &'static LTC294X<'static, I2CDevice<'static, I>>,
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
+    mem_cap: CAP,
 }
 
-impl<I: 'static + i2c::I2CMaster<'static>> Ltc294xDriverComponent<I> {
+impl<I: 'static + i2c::I2CMaster<'static>, CAP: MemoryAllocationCapability + 'static>
+    Ltc294xDriverComponent<I, CAP>
+{
     pub fn new(
         ltc294x: &'static LTC294X<'static, I2CDevice<'static, I>>,
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
+        mem_cap: CAP,
     ) -> Self {
         Ltc294xDriverComponent {
             ltc294x,
             board_kernel,
             driver_num,
+            mem_cap,
         }
     }
 }
 
-impl<I: 'static + i2c::I2CMaster<'static>> Component for Ltc294xDriverComponent<I> {
+impl<I: 'static + i2c::I2CMaster<'static>, CAP: MemoryAllocationCapability + 'static> Component
+    for Ltc294xDriverComponent<I, CAP>
+{
     type StaticInput = &'static mut MaybeUninit<LTC294XDriver<'static, I2CDevice<'static, I>>>;
     type Output = &'static LTC294XDriver<'static, I2CDevice<'static, I>>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-        let grant = self.board_kernel.create_grant(self.driver_num, &grant_cap);
+        let grant = self
+            .board_kernel
+            .create_grant(self.driver_num, &self.mem_cap);
 
         let ltc294x_driver = s.write(LTC294XDriver::new(self.ltc294x, grant));
         self.ltc294x.set_client(ltc294x_driver);

--- a/boards/components/src/mlx90614.rs
+++ b/boards/components/src/mlx90614.rs
@@ -21,9 +21,8 @@
 use capsules_core::virtualizers::virtual_i2c::{MuxI2C, SMBusDevice};
 use capsules_extra::mlx90614::Mlx90614SMBus;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil::i2c::{self, NoSMBus};
 
 // Setup static space for the objects.
@@ -40,34 +39,44 @@ macro_rules! mlx90614_component_static {
 
 pub struct Mlx90614SMBusComponent<
     I: 'static + i2c::I2CMaster<'static>,
+    CAP: MemoryAllocationCapability + 'static,
     S: 'static + i2c::SMBusMaster<'static> = NoSMBus,
 > {
     i2c_mux: &'static MuxI2C<'static, I, S>,
     i2c_address: u8,
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
+    mem_cap: CAP,
 }
 
-impl<I: 'static + i2c::I2CMaster<'static>, S: 'static + i2c::SMBusMaster<'static>>
-    Mlx90614SMBusComponent<I, S>
+impl<
+        I: 'static + i2c::I2CMaster<'static>,
+        CAP: MemoryAllocationCapability + 'static,
+        S: 'static + i2c::SMBusMaster<'static>,
+    > Mlx90614SMBusComponent<I, CAP, S>
 {
     pub fn new(
         i2c: &'static MuxI2C<'static, I, S>,
         i2c_address: u8,
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
+        mem_cap: CAP,
     ) -> Self {
         Mlx90614SMBusComponent {
             i2c_mux: i2c,
             i2c_address,
             board_kernel,
             driver_num,
+            mem_cap,
         }
     }
 }
 
-impl<I: 'static + i2c::I2CMaster<'static>, S: 'static + i2c::SMBusMaster<'static>> Component
-    for Mlx90614SMBusComponent<I, S>
+impl<
+        I: 'static + i2c::I2CMaster<'static>,
+        CAP: MemoryAllocationCapability + 'static,
+        S: 'static + i2c::SMBusMaster<'static>,
+    > Component for Mlx90614SMBusComponent<I, CAP, S>
 {
     type StaticInput = (
         &'static mut MaybeUninit<SMBusDevice<'static, I, S>>,
@@ -81,11 +90,11 @@ impl<I: 'static + i2c::I2CMaster<'static>, S: 'static + i2c::SMBusMaster<'static
             .0
             .write(SMBusDevice::new(self.i2c_mux, self.i2c_address));
         let buffer = static_buffer.1.write([0; 14]);
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
         let mlx90614 = static_buffer.2.write(Mlx90614SMBus::new(
             mlx90614_smbus,
             buffer,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
         ));
 
         mlx90614_smbus.set_client(mlx90614);

--- a/boards/components/src/mlx90614.rs
+++ b/boards/components/src/mlx90614.rs
@@ -50,10 +50,10 @@ pub struct Mlx90614SMBusComponent<
 }
 
 impl<
-        I: 'static + i2c::I2CMaster<'static>,
-        CAP: MemoryAllocationCapability + 'static,
-        S: 'static + i2c::SMBusMaster<'static>,
-    > Mlx90614SMBusComponent<I, CAP, S>
+    I: 'static + i2c::I2CMaster<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+    S: 'static + i2c::SMBusMaster<'static>,
+> Mlx90614SMBusComponent<I, CAP, S>
 {
     pub fn new(
         i2c: &'static MuxI2C<'static, I, S>,
@@ -73,10 +73,10 @@ impl<
 }
 
 impl<
-        I: 'static + i2c::I2CMaster<'static>,
-        CAP: MemoryAllocationCapability + 'static,
-        S: 'static + i2c::SMBusMaster<'static>,
-    > Component for Mlx90614SMBusComponent<I, CAP, S>
+    I: 'static + i2c::I2CMaster<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+    S: 'static + i2c::SMBusMaster<'static>,
+> Component for Mlx90614SMBusComponent<I, CAP, S>
 {
     type StaticInput = (
         &'static mut MaybeUninit<SMBusDevice<'static, I, S>>,

--- a/boards/components/src/moisture.rs
+++ b/boards/components/src/moisture.rs
@@ -17,9 +17,8 @@
 
 use capsules_extra::moisture::MoistureSensor;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil;
 
 #[macro_export]
@@ -31,36 +30,49 @@ macro_rules! moisture_component_static {
 
 pub type MoistureComponentType<H> = capsules_extra::moisture::MoistureSensor<'static, H>;
 
-pub struct MoistureComponent<T: 'static + hil::sensors::MoistureDriver<'static>> {
+pub struct MoistureComponent<
+    T: 'static + hil::sensors::MoistureDriver<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     sensor: &'static T,
+    mem_cap: CAP,
 }
 
-impl<T: 'static + hil::sensors::MoistureDriver<'static>> MoistureComponent<T> {
+impl<
+        T: 'static + hil::sensors::MoistureDriver<'static>,
+        CAP: MemoryAllocationCapability + 'static,
+    > MoistureComponent<T, CAP>
+{
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         sensor: &'static T,
-    ) -> MoistureComponent<T> {
+        mem_cap: CAP,
+    ) -> MoistureComponent<T, CAP> {
         MoistureComponent {
             board_kernel,
             driver_num,
             sensor,
+            mem_cap,
         }
     }
 }
 
-impl<T: 'static + hil::sensors::MoistureDriver<'static>> Component for MoistureComponent<T> {
+impl<
+        T: 'static + hil::sensors::MoistureDriver<'static>,
+        CAP: MemoryAllocationCapability + 'static,
+    > Component for MoistureComponent<T, CAP>
+{
     type StaticInput = &'static mut MaybeUninit<MoistureSensor<'static, T>>;
     type Output = &'static MoistureSensor<'static, T>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let moisture = s.write(MoistureSensor::new(
             self.sensor,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
         ));
 
         hil::sensors::MoistureDriver::set_client(self.sensor, moisture);

--- a/boards/components/src/moisture.rs
+++ b/boards/components/src/moisture.rs
@@ -40,10 +40,8 @@ pub struct MoistureComponent<
     mem_cap: CAP,
 }
 
-impl<
-        T: 'static + hil::sensors::MoistureDriver<'static>,
-        CAP: MemoryAllocationCapability + 'static,
-    > MoistureComponent<T, CAP>
+impl<T: 'static + hil::sensors::MoistureDriver<'static>, CAP: MemoryAllocationCapability + 'static>
+    MoistureComponent<T, CAP>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
@@ -60,10 +58,8 @@ impl<
     }
 }
 
-impl<
-        T: 'static + hil::sensors::MoistureDriver<'static>,
-        CAP: MemoryAllocationCapability + 'static,
-    > Component for MoistureComponent<T, CAP>
+impl<T: 'static + hil::sensors::MoistureDriver<'static>, CAP: MemoryAllocationCapability + 'static>
+    Component for MoistureComponent<T, CAP>
 {
     type StaticInput = &'static mut MaybeUninit<MoistureSensor<'static, T>>;
     type Output = &'static MoistureSensor<'static, T>;

--- a/boards/components/src/ninedof.rs
+++ b/boards/components/src/ninedof.rs
@@ -14,9 +14,8 @@
 
 use capsules_extra::ninedof::NineDof;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 
 #[macro_export]
 macro_rules! ninedof_component_static {
@@ -38,21 +37,27 @@ macro_rules! ninedof_component_static {
 
 pub type NineDofComponentType = capsules_extra::ninedof::NineDof<'static>;
 
-pub struct NineDofComponent {
+pub struct NineDofComponent<CAP: MemoryAllocationCapability + 'static> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
+    mem_cap: CAP,
 }
 
-impl NineDofComponent {
-    pub fn new(board_kernel: &'static kernel::Kernel, driver_num: usize) -> NineDofComponent {
+impl<CAP: MemoryAllocationCapability + 'static> NineDofComponent<CAP> {
+    pub fn new(
+        board_kernel: &'static kernel::Kernel,
+        driver_num: usize,
+        mem_cap: CAP,
+    ) -> NineDofComponent<CAP> {
         NineDofComponent {
             board_kernel,
             driver_num,
+            mem_cap,
         }
     }
 }
 
-impl Component for NineDofComponent {
+impl<CAP: MemoryAllocationCapability + 'static> Component for NineDofComponent<CAP> {
     type StaticInput = (
         &'static mut MaybeUninit<NineDof<'static>>,
         &'static [&'static dyn kernel::hil::sensors::NineDof<'static>],
@@ -60,8 +65,9 @@ impl Component for NineDofComponent {
     type Output = &'static capsules_extra::ninedof::NineDof<'static>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-        let grant_ninedof = self.board_kernel.create_grant(self.driver_num, &grant_cap);
+        let grant_ninedof = self
+            .board_kernel
+            .create_grant(self.driver_num, &self.mem_cap);
 
         let ninedof = static_buffer.0.write(capsules_extra::ninedof::NineDof::new(
             static_buffer.1,

--- a/boards/components/src/nonvolatile_storage.rs
+++ b/boards/components/src/nonvolatile_storage.rs
@@ -26,9 +26,8 @@
 use capsules_extra::nonvolatile_storage_driver::NonvolatileStorage;
 use capsules_extra::nonvolatile_to_pages::NonvolatileToPages;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil;
 
 // Setup static space for the objects.
@@ -52,6 +51,7 @@ pub type NonvolatileStorageComponentType = NonvolatileStorage<'static>;
 
 pub struct NonvolatileStorageComponent<
     F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, NonvolatileToPages<'static, F>>,
+    CAP: MemoryAllocationCapability + 'static,
 > {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
@@ -60,11 +60,13 @@ pub struct NonvolatileStorageComponent<
     userspace_length: usize,
     kernel_start: usize,
     kernel_length: usize,
+    mem_cap: CAP,
 }
 
 impl<
     F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, NonvolatileToPages<'static, F>>,
-> NonvolatileStorageComponent<F>
+    CAP: MemoryAllocationCapability + 'static,
+> NonvolatileStorageComponent<F, CAP>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
@@ -74,6 +76,7 @@ impl<
         userspace_length: usize,
         kernel_start: usize,
         kernel_length: usize,
+        mem_cap: CAP,
     ) -> Self {
         Self {
             board_kernel,
@@ -83,13 +86,15 @@ impl<
             userspace_length,
             kernel_start,
             kernel_length,
+            mem_cap,
         }
     }
 }
 
 impl<
     F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, NonvolatileToPages<'static, F>>,
-> Component for NonvolatileStorageComponent<F>
+    CAP: MemoryAllocationCapability + 'static,
+> Component for NonvolatileStorageComponent<F, CAP>
 {
     type StaticInput = (
         &'static mut MaybeUninit<<F as hil::flash::Flash>::Page>,
@@ -100,8 +105,6 @@ impl<
     type Output = &'static NonvolatileStorage<'static>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let buffer = static_buffer
             .3
             .write([0; capsules_extra::nonvolatile_storage_driver::BUF_LEN]);
@@ -117,7 +120,8 @@ impl<
 
         let nonvolatile_storage = static_buffer.2.write(NonvolatileStorage::new(
             nv_to_page,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
             self.userspace_start, // Start address for userspace accessible region
             self.userspace_length, // Length of userspace accessible region
             self.kernel_start,    // Start address of kernel region

--- a/boards/components/src/nrf51822.rs
+++ b/boards/components/src/nrf51822.rs
@@ -52,10 +52,10 @@ pub struct Nrf51822Component<
 }
 
 impl<
-        U: 'static + hil::uart::UartAdvanced<'static>,
-        G: 'static + hil::gpio::Pin,
-        CAP: MemoryAllocationCapability + 'static,
-    > Nrf51822Component<U, G, CAP>
+    U: 'static + hil::uart::UartAdvanced<'static>,
+    G: 'static + hil::gpio::Pin,
+    CAP: MemoryAllocationCapability + 'static,
+> Nrf51822Component<U, G, CAP>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
@@ -75,10 +75,10 @@ impl<
 }
 
 impl<
-        U: 'static + hil::uart::UartAdvanced<'static>,
-        G: 'static + hil::gpio::Pin,
-        CAP: MemoryAllocationCapability + 'static,
-    > Component for Nrf51822Component<U, G, CAP>
+    U: 'static + hil::uart::UartAdvanced<'static>,
+    G: 'static + hil::gpio::Pin,
+    CAP: MemoryAllocationCapability + 'static,
+> Component for Nrf51822Component<U, G, CAP>
 {
     type StaticInput = (
         &'static mut MaybeUninit<Nrf51822Serialization<'static>>,

--- a/boards/components/src/nrf51822.rs
+++ b/boards/components/src/nrf51822.rs
@@ -20,9 +20,8 @@
 
 use capsules_extra::nrf51822_serialization::Nrf51822Serialization;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil;
 
 #[macro_export]
@@ -43,33 +42,43 @@ macro_rules! nrf51822_component_static {
 pub struct Nrf51822Component<
     U: 'static + hil::uart::UartAdvanced<'static>,
     G: 'static + hil::gpio::Pin,
+    CAP: MemoryAllocationCapability + 'static,
 > {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     uart: &'static U,
     reset_pin: &'static G,
+    mem_cap: CAP,
 }
 
-impl<U: 'static + hil::uart::UartAdvanced<'static>, G: 'static + hil::gpio::Pin>
-    Nrf51822Component<U, G>
+impl<
+        U: 'static + hil::uart::UartAdvanced<'static>,
+        G: 'static + hil::gpio::Pin,
+        CAP: MemoryAllocationCapability + 'static,
+    > Nrf51822Component<U, G, CAP>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         uart: &'static U,
         reset_pin: &'static G,
-    ) -> Nrf51822Component<U, G> {
+        mem_cap: CAP,
+    ) -> Nrf51822Component<U, G, CAP> {
         Nrf51822Component {
             board_kernel,
             driver_num,
             uart,
             reset_pin,
+            mem_cap,
         }
     }
 }
 
-impl<U: 'static + hil::uart::UartAdvanced<'static>, G: 'static + hil::gpio::Pin> Component
-    for Nrf51822Component<U, G>
+impl<
+        U: 'static + hil::uart::UartAdvanced<'static>,
+        G: 'static + hil::gpio::Pin,
+        CAP: MemoryAllocationCapability + 'static,
+    > Component for Nrf51822Component<U, G, CAP>
 {
     type StaticInput = (
         &'static mut MaybeUninit<Nrf51822Serialization<'static>>,
@@ -79,8 +88,6 @@ impl<U: 'static + hil::uart::UartAdvanced<'static>, G: 'static + hil::gpio::Pin>
     type Output = &'static Nrf51822Serialization<'static>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let write_buffer =
             s.1.write([0; capsules_extra::nrf51822_serialization::WRITE_BUF_LEN]);
         let read_buffer =
@@ -88,7 +95,8 @@ impl<U: 'static + hil::uart::UartAdvanced<'static>, G: 'static + hil::gpio::Pin>
 
         let nrf_serialization = s.0.write(Nrf51822Serialization::new(
             self.uart,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
             self.reset_pin,
             write_buffer,
             read_buffer,

--- a/boards/components/src/pressure.rs
+++ b/boards/components/src/pressure.rs
@@ -34,10 +34,8 @@ pub struct PressureComponent<
     mem_cap: CAP,
 }
 
-impl<
-        T: 'static + hil::sensors::PressureDriver<'static>,
-        CAP: MemoryAllocationCapability + 'static,
-    > PressureComponent<T, CAP>
+impl<T: 'static + hil::sensors::PressureDriver<'static>, CAP: MemoryAllocationCapability + 'static>
+    PressureComponent<T, CAP>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
@@ -54,10 +52,8 @@ impl<
     }
 }
 
-impl<
-        T: 'static + hil::sensors::PressureDriver<'static>,
-        CAP: MemoryAllocationCapability + 'static,
-    > Component for PressureComponent<T, CAP>
+impl<T: 'static + hil::sensors::PressureDriver<'static>, CAP: MemoryAllocationCapability + 'static>
+    Component for PressureComponent<T, CAP>
 {
     type StaticInput = &'static mut MaybeUninit<PressureSensor<'static, T>>;
     type Output = &'static PressureSensor<'static, T>;

--- a/boards/components/src/pressure.rs
+++ b/boards/components/src/pressure.rs
@@ -13,9 +13,8 @@
 
 use capsules_extra::pressure::PressureSensor;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil;
 
 #[macro_export]
@@ -25,36 +24,49 @@ macro_rules! pressure_component_static {
     };};
 }
 
-pub struct PressureComponent<T: 'static + hil::sensors::PressureDriver<'static>> {
+pub struct PressureComponent<
+    T: 'static + hil::sensors::PressureDriver<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     pressure_sensor: &'static T,
+    mem_cap: CAP,
 }
 
-impl<T: 'static + hil::sensors::PressureDriver<'static>> PressureComponent<T> {
+impl<
+        T: 'static + hil::sensors::PressureDriver<'static>,
+        CAP: MemoryAllocationCapability + 'static,
+    > PressureComponent<T, CAP>
+{
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         pressure_sensor: &'static T,
-    ) -> PressureComponent<T> {
+        mem_cap: CAP,
+    ) -> PressureComponent<T, CAP> {
         PressureComponent {
             board_kernel,
             driver_num,
             pressure_sensor,
+            mem_cap,
         }
     }
 }
 
-impl<T: 'static + hil::sensors::PressureDriver<'static>> Component for PressureComponent<T> {
+impl<
+        T: 'static + hil::sensors::PressureDriver<'static>,
+        CAP: MemoryAllocationCapability + 'static,
+    > Component for PressureComponent<T, CAP>
+{
     type StaticInput = &'static mut MaybeUninit<PressureSensor<'static, T>>;
     type Output = &'static PressureSensor<'static, T>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let pressure = static_buffer.write(PressureSensor::new(
             self.pressure_sensor,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
         ));
 
         hil::sensors::PressureDriver::set_client(self.pressure_sensor, pressure);

--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -97,10 +97,10 @@ pub struct ProcessConsoleComponent<
 }
 
 impl<
-        const COMMAND_HISTORY_LEN: usize,
-        A: 'static + Alarm<'static>,
-        C: ProcessManagementCapability + ProcessStartCapability + 'static,
-    > ProcessConsoleComponent<COMMAND_HISTORY_LEN, A, C>
+    const COMMAND_HISTORY_LEN: usize,
+    A: 'static + Alarm<'static>,
+    C: ProcessManagementCapability + ProcessStartCapability + 'static,
+> ProcessConsoleComponent<COMMAND_HISTORY_LEN, A, C>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
@@ -136,10 +136,10 @@ extern "C" {
 }
 
 impl<
-        const COMMAND_HISTORY_LEN: usize,
-        A: 'static + Alarm<'static>,
-        C: ProcessManagementCapability + ProcessStartCapability + 'static,
-    > Component for ProcessConsoleComponent<COMMAND_HISTORY_LEN, A, C>
+    const COMMAND_HISTORY_LEN: usize,
+    A: 'static + Alarm<'static>,
+    C: ProcessManagementCapability + ProcessStartCapability + 'static,
+> Component for ProcessConsoleComponent<COMMAND_HISTORY_LEN, A, C>
 {
     type StaticInput = (
         &'static mut MaybeUninit<VirtualMuxAlarm<'static, A>>,

--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -11,8 +11,19 @@
 //! Usage
 //! -----
 //! ```rust
-//! let pconsole = ProcessConsoleComponent::new(board_kernel, uart_mux, alarm_mux, process_printer, Some(reset_function))
-//!     .finalize(process_console_component_static!());
+//! kernel::declare_capability!(ProcessConsoleCap:
+//!     kernel::capabilities::ProcessManagementCapability,
+//!     kernel::capabilities::ProcessStartCapability
+//! );
+//! let pconsole = ProcessConsoleComponent::new(
+//!     board_kernel,
+//!     uart_mux,
+//!     alarm_mux,
+//!     process_printer,
+//!     Some(reset_function),
+//!     ProcessConsoleCap,
+//! )
+//! .finalize(process_console_component_static!(AlarmType, ProcessConsoleCap));
 //! ```
 
 // Author: Philip Levis <pal@cs.stanford.edu>
@@ -22,7 +33,7 @@ use capsules_core::process_console::{self, ProcessConsole};
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules_core::virtualizers::virtual_uart::{MuxUart, UartDevice};
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::{ProcessManagementCapability, ProcessStartCapability};
 use kernel::component::Component;
 use kernel::hil;
 use kernel::hil::time::Alarm;
@@ -30,14 +41,14 @@ use kernel::process::ProcessPrinter;
 
 #[macro_export]
 macro_rules! process_console_component_static {
-    ($A: ty, $COMMAND_HISTORY_LEN: expr $(,)?) => {{
+    ($A: ty, $C: ty, $COMMAND_HISTORY_LEN: expr $(,)?) => {{
         let alarm = kernel::static_buf!(capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, $A>);
         let uart = kernel::static_buf!(capsules_core::virtualizers::virtual_uart::UartDevice);
         let pconsole = kernel::static_buf!(
             capsules_core::process_console::ProcessConsole<
                 $COMMAND_HISTORY_LEN,
                 capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, $A>,
-                components::process_console::Capability,
+                $C,
             >
         );
 
@@ -60,28 +71,36 @@ macro_rules! process_console_component_static {
             pconsole,
         )
     };};
-    ($A: ty $(,)?) => {{
-        $crate::process_console_component_static!($A, { capsules_core::process_console::DEFAULT_COMMAND_HISTORY_LEN })
+    ($A: ty, $C: ty $(,)?) => {{
+        $crate::process_console_component_static!($A, $C, { capsules_core::process_console::DEFAULT_COMMAND_HISTORY_LEN })
     };};
 }
 
-pub type ProcessConsoleComponentType<A> = process_console::ProcessConsole<
+pub type ProcessConsoleComponentType<A, C> = process_console::ProcessConsole<
     'static,
     { capsules_core::process_console::DEFAULT_COMMAND_HISTORY_LEN },
     VirtualMuxAlarm<'static, A>,
-    Capability,
+    C,
 >;
 
-pub struct ProcessConsoleComponent<const COMMAND_HISTORY_LEN: usize, A: 'static + Alarm<'static>> {
+pub struct ProcessConsoleComponent<
+    const COMMAND_HISTORY_LEN: usize,
+    A: 'static + Alarm<'static>,
+    C: ProcessManagementCapability + ProcessStartCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     uart_mux: &'static MuxUart<'static>,
     alarm_mux: &'static MuxAlarm<'static, A>,
     process_printer: &'static dyn ProcessPrinter,
     reset_function: Option<fn() -> !>,
+    capability: C,
 }
 
-impl<const COMMAND_HISTORY_LEN: usize, A: 'static + Alarm<'static>>
-    ProcessConsoleComponent<COMMAND_HISTORY_LEN, A>
+impl<
+        const COMMAND_HISTORY_LEN: usize,
+        A: 'static + Alarm<'static>,
+        C: ProcessManagementCapability + ProcessStartCapability + 'static,
+    > ProcessConsoleComponent<COMMAND_HISTORY_LEN, A, C>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
@@ -89,13 +108,15 @@ impl<const COMMAND_HISTORY_LEN: usize, A: 'static + Alarm<'static>>
         alarm_mux: &'static MuxAlarm<'static, A>,
         process_printer: &'static dyn ProcessPrinter,
         reset_function: Option<fn() -> !>,
-    ) -> ProcessConsoleComponent<COMMAND_HISTORY_LEN, A> {
+        capability: C,
+    ) -> ProcessConsoleComponent<COMMAND_HISTORY_LEN, A, C> {
         ProcessConsoleComponent {
             board_kernel,
             uart_mux,
             alarm_mux,
             process_printer,
             reset_function,
+            capability,
         }
     }
 }
@@ -114,12 +135,11 @@ extern "C" {
     static _ezero: u8;
 }
 
-pub struct Capability;
-unsafe impl capabilities::ProcessManagementCapability for Capability {}
-unsafe impl capabilities::ProcessStartCapability for Capability {}
-
-impl<const COMMAND_HISTORY_LEN: usize, A: 'static + Alarm<'static>> Component
-    for ProcessConsoleComponent<COMMAND_HISTORY_LEN, A>
+impl<
+        const COMMAND_HISTORY_LEN: usize,
+        A: 'static + Alarm<'static>,
+        C: ProcessManagementCapability + ProcessStartCapability + 'static,
+    > Component for ProcessConsoleComponent<COMMAND_HISTORY_LEN, A, C>
 {
     type StaticInput = (
         &'static mut MaybeUninit<VirtualMuxAlarm<'static, A>>,
@@ -130,14 +150,14 @@ impl<const COMMAND_HISTORY_LEN: usize, A: 'static + Alarm<'static>> Component
         &'static mut MaybeUninit<[u8; capsules_core::process_console::COMMAND_BUF_LEN]>,
         &'static mut MaybeUninit<[capsules_core::process_console::Command; COMMAND_HISTORY_LEN]>,
         &'static mut MaybeUninit<
-            ProcessConsole<'static, COMMAND_HISTORY_LEN, VirtualMuxAlarm<'static, A>, Capability>,
+            ProcessConsole<'static, COMMAND_HISTORY_LEN, VirtualMuxAlarm<'static, A>, C>,
         >,
     );
     type Output = &'static process_console::ProcessConsole<
         'static,
         COMMAND_HISTORY_LEN,
         VirtualMuxAlarm<'static, A>,
-        Capability,
+        C,
     >;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
@@ -190,7 +210,7 @@ impl<const COMMAND_HISTORY_LEN: usize, A: 'static + Alarm<'static>> Component
             self.board_kernel,
             kernel_addresses,
             self.reset_function,
-            Capability,
+            self.capability,
         ));
         hil::uart::Transmit::set_transmit_client(console_uart, console);
         hil::uart::Receive::set_receive_client(console_uart, console);

--- a/boards/components/src/process_info_driver.rs
+++ b/boards/components/src/process_info_driver.rs
@@ -6,10 +6,9 @@
 
 use capsules_extra::process_info_driver::{self, ProcessInfo};
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::capabilities::{ProcessManagementCapability, ProcessStartCapability};
 use kernel::component::Component;
-use kernel::create_capability;
 
 #[macro_export]
 macro_rules! process_info_component_static {
@@ -24,34 +23,49 @@ macro_rules! process_info_component_static {
     };};
 }
 
-pub struct ProcessInfoComponent<C: ProcessManagementCapability + ProcessStartCapability> {
+pub struct ProcessInfoComponent<
+    C: ProcessManagementCapability + ProcessStartCapability,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     capability: C,
+    mem_cap: CAP,
 }
 
-impl<C: ProcessManagementCapability + ProcessStartCapability> ProcessInfoComponent<C> {
-    pub fn new(board_kernel: &'static kernel::Kernel, driver_num: usize, capability: C) -> Self {
+impl<
+        C: ProcessManagementCapability + ProcessStartCapability,
+        CAP: MemoryAllocationCapability + 'static,
+    > ProcessInfoComponent<C, CAP>
+{
+    pub fn new(
+        board_kernel: &'static kernel::Kernel,
+        driver_num: usize,
+        capability: C,
+        mem_cap: CAP,
+    ) -> Self {
         Self {
             board_kernel,
             driver_num,
             capability,
+            mem_cap,
         }
     }
 }
 
-impl<C: ProcessManagementCapability + ProcessStartCapability + 'static> Component
-    for ProcessInfoComponent<C>
+impl<
+        C: ProcessManagementCapability + ProcessStartCapability + 'static,
+        CAP: MemoryAllocationCapability + 'static,
+    > Component for ProcessInfoComponent<C, CAP>
 {
     type StaticInput = &'static mut MaybeUninit<ProcessInfo<C>>;
     type Output = &'static process_info_driver::ProcessInfo<C>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let process_info = static_buffer.write(ProcessInfo::new(
             self.board_kernel,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
             self.capability,
         ));
 

--- a/boards/components/src/process_info_driver.rs
+++ b/boards/components/src/process_info_driver.rs
@@ -34,9 +34,9 @@ pub struct ProcessInfoComponent<
 }
 
 impl<
-        C: ProcessManagementCapability + ProcessStartCapability,
-        CAP: MemoryAllocationCapability + 'static,
-    > ProcessInfoComponent<C, CAP>
+    C: ProcessManagementCapability + ProcessStartCapability,
+    CAP: MemoryAllocationCapability + 'static,
+> ProcessInfoComponent<C, CAP>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
@@ -54,9 +54,9 @@ impl<
 }
 
 impl<
-        C: ProcessManagementCapability + ProcessStartCapability + 'static,
-        CAP: MemoryAllocationCapability + 'static,
-    > Component for ProcessInfoComponent<C, CAP>
+    C: ProcessManagementCapability + ProcessStartCapability + 'static,
+    CAP: MemoryAllocationCapability + 'static,
+> Component for ProcessInfoComponent<C, CAP>
 {
     type StaticInput = &'static mut MaybeUninit<ProcessInfo<C>>;
     type Output = &'static process_info_driver::ProcessInfo<C>;

--- a/boards/components/src/proximity.rs
+++ b/boards/components/src/proximity.rs
@@ -13,9 +13,8 @@
 
 use capsules_extra::proximity::ProximitySensor;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil;
 
 #[macro_export]
@@ -27,33 +26,44 @@ macro_rules! proximity_component_static {
 
 pub type ProximityComponentType = capsules_extra::proximity::ProximitySensor<'static>;
 
-pub struct ProximityComponent<P: hil::sensors::ProximityDriver<'static> + 'static> {
+pub struct ProximityComponent<
+    P: hil::sensors::ProximityDriver<'static> + 'static,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     sensor: &'static P,
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
+    mem_cap: CAP,
 }
 
-impl<P: hil::sensors::ProximityDriver<'static>> ProximityComponent<P> {
+impl<P: hil::sensors::ProximityDriver<'static>, CAP: MemoryAllocationCapability + 'static>
+    ProximityComponent<P, CAP>
+{
     pub fn new(
         sensor: &'static P,
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
-    ) -> ProximityComponent<P> {
+        mem_cap: CAP,
+    ) -> ProximityComponent<P, CAP> {
         ProximityComponent {
             sensor,
             board_kernel,
             driver_num,
+            mem_cap,
         }
     }
 }
 
-impl<P: hil::sensors::ProximityDriver<'static>> Component for ProximityComponent<P> {
+impl<P: hil::sensors::ProximityDriver<'static>, CAP: MemoryAllocationCapability + 'static> Component
+    for ProximityComponent<P, CAP>
+{
     type StaticInput = &'static mut MaybeUninit<ProximitySensor<'static>>;
     type Output = &'static ProximitySensor<'static>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-        let grant = self.board_kernel.create_grant(self.driver_num, &grant_cap);
+        let grant = self
+            .board_kernel
+            .create_grant(self.driver_num, &self.mem_cap);
 
         let proximity = s.write(ProximitySensor::new(self.sensor, grant));
 

--- a/boards/components/src/pwm.rs
+++ b/boards/components/src/pwm.rs
@@ -7,9 +7,8 @@
 use capsules_core::virtualizers::virtual_pwm::{MuxPwm, PwmPinUser};
 use capsules_extra::pwm::Pwm;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil::pwm;
 
 #[macro_export]
@@ -95,24 +94,31 @@ impl<P: 'static + pwm::Pwm> Component for PwmPinUserComponent<P> {
 pub type PwmDriverComponentType<const NUM_PINS: usize> =
     capsules_extra::pwm::Pwm<'static, NUM_PINS>;
 
-pub struct PwmDriverComponent<const NUM_PINS: usize> {
+pub struct PwmDriverComponent<const NUM_PINS: usize, CAP: MemoryAllocationCapability + 'static> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
+    mem_cap: CAP,
 }
 
-impl<const NUM_PINS: usize> PwmDriverComponent<NUM_PINS> {
+impl<const NUM_PINS: usize, CAP: MemoryAllocationCapability + 'static>
+    PwmDriverComponent<NUM_PINS, CAP>
+{
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
-    ) -> PwmDriverComponent<NUM_PINS> {
+        mem_cap: CAP,
+    ) -> PwmDriverComponent<NUM_PINS, CAP> {
         PwmDriverComponent {
             board_kernel,
             driver_num,
+            mem_cap,
         }
     }
 }
 
-impl<const NUM_PINS: usize> Component for PwmDriverComponent<NUM_PINS> {
+impl<const NUM_PINS: usize, CAP: MemoryAllocationCapability + 'static> Component
+    for PwmDriverComponent<NUM_PINS, CAP>
+{
     type StaticInput = (
         &'static mut MaybeUninit<Pwm<'static, NUM_PINS>>,
         &'static [&'static dyn kernel::hil::pwm::PwmPin; NUM_PINS],
@@ -120,8 +126,9 @@ impl<const NUM_PINS: usize> Component for PwmDriverComponent<NUM_PINS> {
     type Output = &'static capsules_extra::pwm::Pwm<'static, NUM_PINS>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-        let grant_adc = self.board_kernel.create_grant(self.driver_num, &grant_cap);
+        let grant_adc = self
+            .board_kernel
+            .create_grant(self.driver_num, &self.mem_cap);
 
         let pwm = static_buffer
             .0

--- a/boards/components/src/rainfall.rs
+++ b/boards/components/src/rainfall.rs
@@ -17,9 +17,8 @@
 
 use capsules_extra::rainfall::RainFallSensor;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil;
 
 #[macro_export]
@@ -31,36 +30,49 @@ macro_rules! rainfall_component_static {
 
 pub type RainFallComponentType<H> = capsules_extra::rainfall::RainFallSensor<'static, H>;
 
-pub struct RainFallComponent<T: 'static + hil::sensors::RainFallDriver<'static>> {
+pub struct RainFallComponent<
+    T: 'static + hil::sensors::RainFallDriver<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     sensor: &'static T,
+    mem_cap: CAP,
 }
 
-impl<T: 'static + hil::sensors::RainFallDriver<'static>> RainFallComponent<T> {
+impl<
+        T: 'static + hil::sensors::RainFallDriver<'static>,
+        CAP: MemoryAllocationCapability + 'static,
+    > RainFallComponent<T, CAP>
+{
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         sensor: &'static T,
-    ) -> RainFallComponent<T> {
+        mem_cap: CAP,
+    ) -> RainFallComponent<T, CAP> {
         RainFallComponent {
             board_kernel,
             driver_num,
             sensor,
+            mem_cap,
         }
     }
 }
 
-impl<T: 'static + hil::sensors::RainFallDriver<'static>> Component for RainFallComponent<T> {
+impl<
+        T: 'static + hil::sensors::RainFallDriver<'static>,
+        CAP: MemoryAllocationCapability + 'static,
+    > Component for RainFallComponent<T, CAP>
+{
     type StaticInput = &'static mut MaybeUninit<RainFallSensor<'static, T>>;
     type Output = &'static RainFallSensor<'static, T>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let rainfall = s.write(RainFallSensor::new(
             self.sensor,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
         ));
 
         hil::sensors::RainFallDriver::set_client(self.sensor, rainfall);

--- a/boards/components/src/rainfall.rs
+++ b/boards/components/src/rainfall.rs
@@ -40,10 +40,8 @@ pub struct RainFallComponent<
     mem_cap: CAP,
 }
 
-impl<
-        T: 'static + hil::sensors::RainFallDriver<'static>,
-        CAP: MemoryAllocationCapability + 'static,
-    > RainFallComponent<T, CAP>
+impl<T: 'static + hil::sensors::RainFallDriver<'static>, CAP: MemoryAllocationCapability + 'static>
+    RainFallComponent<T, CAP>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
@@ -60,10 +58,8 @@ impl<
     }
 }
 
-impl<
-        T: 'static + hil::sensors::RainFallDriver<'static>,
-        CAP: MemoryAllocationCapability + 'static,
-    > Component for RainFallComponent<T, CAP>
+impl<T: 'static + hil::sensors::RainFallDriver<'static>, CAP: MemoryAllocationCapability + 'static>
+    Component for RainFallComponent<T, CAP>
 {
     type StaticInput = &'static mut MaybeUninit<RainFallSensor<'static, T>>;
     type Output = &'static RainFallSensor<'static, T>;

--- a/boards/components/src/rng.rs
+++ b/boards/components/src/rng.rs
@@ -32,9 +32,8 @@
 
 use capsules_core::rng;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil::entropy::Entropy32;
 use kernel::hil::rng::Rng;
 
@@ -56,23 +55,33 @@ macro_rules! rng_component_static {
 pub type RngComponentType<E> =
     rng::RngDriver<'static, capsules_core::rng::Entropy32ToRandom<'static, E>>;
 
-pub struct RngComponent<E: Entropy32<'static> + 'static> {
+pub struct RngComponent<E: Entropy32<'static> + 'static, CAP: MemoryAllocationCapability + 'static>
+{
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     trng: &'static E,
+    mem_cap: CAP,
 }
 
-impl<E: Entropy32<'static>> RngComponent<E> {
-    pub fn new(board_kernel: &'static kernel::Kernel, driver_num: usize, trng: &'static E) -> Self {
+impl<E: Entropy32<'static>, CAP: MemoryAllocationCapability + 'static> RngComponent<E, CAP> {
+    pub fn new(
+        board_kernel: &'static kernel::Kernel,
+        driver_num: usize,
+        trng: &'static E,
+        mem_cap: CAP,
+    ) -> Self {
         Self {
             board_kernel,
             driver_num,
             trng,
+            mem_cap,
         }
     }
 }
 
-impl<E: Entropy32<'static>> Component for RngComponent<E> {
+impl<E: Entropy32<'static>, CAP: MemoryAllocationCapability + 'static> Component
+    for RngComponent<E, CAP>
+{
     type StaticInput = (
         &'static mut MaybeUninit<capsules_core::rng::Entropy32ToRandom<'static, E>>,
         &'static mut MaybeUninit<
@@ -86,14 +95,13 @@ impl<E: Entropy32<'static>> Component for RngComponent<E> {
         &'static rng::RngDriver<'static, capsules_core::rng::Entropy32ToRandom<'static, E>>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let entropy_to_random = static_buffer
             .0
             .write(rng::Entropy32ToRandom::new(self.trng));
         let rng = static_buffer.1.write(rng::RngDriver::new(
             entropy_to_random,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
         ));
         self.trng.set_client(entropy_to_random);
         entropy_to_random.set_client(rng);
@@ -113,32 +121,41 @@ macro_rules! rng_random_component_static {
 
 pub type RngRandomComponentType<R> = rng::RngDriver<'static, R>;
 
-pub struct RngRandomComponent<R: Rng<'static> + 'static> {
+pub struct RngRandomComponent<R: Rng<'static> + 'static, CAP: MemoryAllocationCapability + 'static>
+{
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     rng: &'static R,
+    mem_cap: CAP,
 }
 
-impl<R: Rng<'static>> RngRandomComponent<R> {
-    pub fn new(board_kernel: &'static kernel::Kernel, driver_num: usize, rng: &'static R) -> Self {
+impl<R: Rng<'static>, CAP: MemoryAllocationCapability + 'static> RngRandomComponent<R, CAP> {
+    pub fn new(
+        board_kernel: &'static kernel::Kernel,
+        driver_num: usize,
+        rng: &'static R,
+        mem_cap: CAP,
+    ) -> Self {
         Self {
             board_kernel,
             driver_num,
             rng,
+            mem_cap,
         }
     }
 }
 
-impl<R: Rng<'static>> Component for RngRandomComponent<R> {
+impl<R: Rng<'static>, CAP: MemoryAllocationCapability + 'static> Component
+    for RngRandomComponent<R, CAP>
+{
     type StaticInput = &'static mut MaybeUninit<capsules_core::rng::RngDriver<'static, R>>;
     type Output = &'static rng::RngDriver<'static, R>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let rng_driver = static_buffer.write(rng::RngDriver::new(
             self.rng,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
         ));
         self.rng.set_client(rng_driver);
 

--- a/boards/components/src/screen.rs
+++ b/boards/components/src/screen.rs
@@ -34,9 +34,8 @@ use capsules_extra::screen::screen::Screen;
 use capsules_extra::screen::screen_shared::ScreenShared;
 use capsules_extra::virtualizers::screen::virtual_screen_split;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil;
 
 #[macro_export]
@@ -145,30 +144,37 @@ macro_rules! screen_component_static {
 
 pub type ScreenComponentType = capsules_extra::screen::screen::Screen<'static>;
 
-pub struct ScreenComponent<const SCREEN_BUF_LEN: usize> {
+pub struct ScreenComponent<const SCREEN_BUF_LEN: usize, CAP: MemoryAllocationCapability + 'static> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     screen: &'static dyn kernel::hil::screen::Screen<'static>,
     screen_setup: Option<&'static dyn kernel::hil::screen::ScreenSetup<'static>>,
+    mem_cap: CAP,
 }
 
-impl<const SCREEN_BUF_LEN: usize> ScreenComponent<SCREEN_BUF_LEN> {
+impl<const SCREEN_BUF_LEN: usize, CAP: MemoryAllocationCapability + 'static>
+    ScreenComponent<SCREEN_BUF_LEN, CAP>
+{
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         screen: &'static dyn kernel::hil::screen::Screen,
         screen_setup: Option<&'static dyn kernel::hil::screen::ScreenSetup>,
-    ) -> ScreenComponent<SCREEN_BUF_LEN> {
+        mem_cap: CAP,
+    ) -> ScreenComponent<SCREEN_BUF_LEN, CAP> {
         ScreenComponent {
             board_kernel,
             driver_num,
             screen,
             screen_setup,
+            mem_cap,
         }
     }
 }
 
-impl<const SCREEN_BUF_LEN: usize> Component for ScreenComponent<SCREEN_BUF_LEN> {
+impl<const SCREEN_BUF_LEN: usize, CAP: MemoryAllocationCapability + 'static> Component
+    for ScreenComponent<SCREEN_BUF_LEN, CAP>
+{
     type StaticInput = (
         &'static mut MaybeUninit<[u8; SCREEN_BUF_LEN]>,
         &'static mut MaybeUninit<Screen<'static>>,
@@ -176,8 +182,9 @@ impl<const SCREEN_BUF_LEN: usize> Component for ScreenComponent<SCREEN_BUF_LEN> 
     type Output = &'static Screen<'static>;
 
     fn finalize(self, static_input: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-        let grant_screen = self.board_kernel.create_grant(self.driver_num, &grant_cap);
+        let grant_screen = self
+            .board_kernel
+            .create_grant(self.driver_num, &self.mem_cap);
 
         let buffer = static_input.0.write([0; SCREEN_BUF_LEN]);
 
@@ -213,33 +220,43 @@ pub type ScreenSharedComponentType<S> =
 pub struct ScreenSharedComponent<
     const SCREEN_BUF_LEN: usize,
     S: hil::screen::Screen<'static> + 'static,
+    CAP: MemoryAllocationCapability + 'static,
 > {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     screen: &'static S,
     apps_regions: &'static [capsules_extra::screen::screen_shared::AppScreenRegion],
+    mem_cap: CAP,
 }
 
-impl<const SCREEN_BUF_LEN: usize, S: hil::screen::Screen<'static>>
-    ScreenSharedComponent<SCREEN_BUF_LEN, S>
+impl<
+        const SCREEN_BUF_LEN: usize,
+        S: hil::screen::Screen<'static>,
+        CAP: MemoryAllocationCapability + 'static,
+    > ScreenSharedComponent<SCREEN_BUF_LEN, S, CAP>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         screen: &'static S,
         apps_regions: &'static [capsules_extra::screen::screen_shared::AppScreenRegion],
-    ) -> ScreenSharedComponent<SCREEN_BUF_LEN, S> {
+        mem_cap: CAP,
+    ) -> ScreenSharedComponent<SCREEN_BUF_LEN, S, CAP> {
         ScreenSharedComponent {
             board_kernel,
             driver_num,
             screen,
             apps_regions,
+            mem_cap,
         }
     }
 }
 
-impl<const SCREEN_BUF_LEN: usize, S: hil::screen::Screen<'static>> Component
-    for ScreenSharedComponent<SCREEN_BUF_LEN, S>
+impl<
+        const SCREEN_BUF_LEN: usize,
+        S: hil::screen::Screen<'static>,
+        CAP: MemoryAllocationCapability + 'static,
+    > Component for ScreenSharedComponent<SCREEN_BUF_LEN, S, CAP>
 {
     type StaticInput = (
         &'static mut MaybeUninit<[u8; SCREEN_BUF_LEN]>,
@@ -248,8 +265,9 @@ impl<const SCREEN_BUF_LEN: usize, S: hil::screen::Screen<'static>> Component
     type Output = &'static ScreenShared<'static, S>;
 
     fn finalize(self, static_input: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-        let grant_screen = self.board_kernel.create_grant(self.driver_num, &grant_cap);
+        let grant_screen = self
+            .board_kernel
+            .create_grant(self.driver_num, &self.mem_cap);
 
         let buffer = static_input.0.write([0; SCREEN_BUF_LEN]);
 

--- a/boards/components/src/screen.rs
+++ b/boards/components/src/screen.rs
@@ -230,10 +230,10 @@ pub struct ScreenSharedComponent<
 }
 
 impl<
-        const SCREEN_BUF_LEN: usize,
-        S: hil::screen::Screen<'static>,
-        CAP: MemoryAllocationCapability + 'static,
-    > ScreenSharedComponent<SCREEN_BUF_LEN, S, CAP>
+    const SCREEN_BUF_LEN: usize,
+    S: hil::screen::Screen<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> ScreenSharedComponent<SCREEN_BUF_LEN, S, CAP>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
@@ -253,10 +253,10 @@ impl<
 }
 
 impl<
-        const SCREEN_BUF_LEN: usize,
-        S: hil::screen::Screen<'static>,
-        CAP: MemoryAllocationCapability + 'static,
-    > Component for ScreenSharedComponent<SCREEN_BUF_LEN, S, CAP>
+    const SCREEN_BUF_LEN: usize,
+    S: hil::screen::Screen<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> Component for ScreenSharedComponent<SCREEN_BUF_LEN, S, CAP>
 {
     type StaticInput = (
         &'static mut MaybeUninit<[u8; SCREEN_BUF_LEN]>,

--- a/boards/components/src/sha.rs
+++ b/boards/components/src/sha.rs
@@ -24,9 +24,8 @@
 
 use capsules_extra::sha256_driver::ShaDriver;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil::digest;
 
 // Setup static space for the objects.
@@ -45,24 +44,43 @@ macro_rules! sha_driver_component_static {
 
 pub type ShaDriverComponentType<A, const L: usize> = ShaDriver<'static, A, L>;
 
-pub struct ShaDriverComponent<A: 'static + digest::DigestDataHash<'static, L>, const L: usize> {
+pub struct ShaDriverComponent<
+    A: 'static + digest::DigestDataHash<'static, L>,
+    const L: usize,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     sha: &'static A,
+    mem_cap: CAP,
 }
 
-impl<A: 'static + digest::DigestDataHash<'static, L>, const L: usize> ShaDriverComponent<A, L> {
-    pub fn new(board_kernel: &'static kernel::Kernel, driver_num: usize, sha: &'static A) -> Self {
+impl<
+    A: 'static + digest::DigestDataHash<'static, L>,
+    const L: usize,
+    CAP: MemoryAllocationCapability + 'static,
+> ShaDriverComponent<A, L, CAP>
+{
+    pub fn new(
+        board_kernel: &'static kernel::Kernel,
+        driver_num: usize,
+        sha: &'static A,
+        mem_cap: CAP,
+    ) -> Self {
         Self {
             board_kernel,
             driver_num,
             sha,
+            mem_cap,
         }
     }
 }
 
-impl<A: kernel::hil::digest::Sha256 + 'static + digest::DigestDataHash<'static, L>, const L: usize>
-    Component for ShaDriverComponent<A, L>
+impl<
+    A: kernel::hil::digest::Sha256 + 'static + digest::DigestDataHash<'static, L>,
+    const L: usize,
+    CAP: MemoryAllocationCapability + 'static,
+> Component for ShaDriverComponent<A, L, CAP>
 {
     type StaticInput = (
         &'static mut MaybeUninit<ShaDriver<'static, A, L>>,
@@ -73,8 +91,6 @@ impl<A: kernel::hil::digest::Sha256 + 'static + digest::DigestDataHash<'static, 
     type Output = &'static ShaDriver<'static, A, L>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let data_buffer = s.1.write([0; 64]);
         let dest_buffer = s.2.write([0; L]);
 
@@ -82,7 +98,8 @@ impl<A: kernel::hil::digest::Sha256 + 'static + digest::DigestDataHash<'static, 
             self.sha,
             data_buffer,
             dest_buffer,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
         ));
 
         self.sha.set_client(sha);

--- a/boards/components/src/sound_pressure.rs
+++ b/boards/components/src/sound_pressure.rs
@@ -13,9 +13,8 @@
 
 use capsules_extra::sound_pressure::SoundPressureSensor;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil;
 
 #[macro_export]
@@ -27,36 +26,49 @@ macro_rules! sound_pressure_component_static {
 
 pub type SoundPressureComponentType = capsules_extra::sound_pressure::SoundPressureSensor<'static>;
 
-pub struct SoundPressureComponent<S: 'static + hil::sensors::SoundPressure<'static>> {
+pub struct SoundPressureComponent<
+    S: 'static + hil::sensors::SoundPressure<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     sound_sensor: &'static S,
+    mem_cap: CAP,
 }
 
-impl<S: 'static + hil::sensors::SoundPressure<'static>> SoundPressureComponent<S> {
+impl<
+        S: 'static + hil::sensors::SoundPressure<'static>,
+        CAP: MemoryAllocationCapability + 'static,
+    > SoundPressureComponent<S, CAP>
+{
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         sound_sensor: &'static S,
-    ) -> SoundPressureComponent<S> {
+        mem_cap: CAP,
+    ) -> SoundPressureComponent<S, CAP> {
         SoundPressureComponent {
             board_kernel,
             driver_num,
             sound_sensor,
+            mem_cap,
         }
     }
 }
 
-impl<S: 'static + hil::sensors::SoundPressure<'static>> Component for SoundPressureComponent<S> {
+impl<
+        S: 'static + hil::sensors::SoundPressure<'static>,
+        CAP: MemoryAllocationCapability + 'static,
+    > Component for SoundPressureComponent<S, CAP>
+{
     type StaticInput = &'static mut MaybeUninit<SoundPressureSensor<'static>>;
     type Output = &'static SoundPressureSensor<'static>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let sound_pressure = s.write(SoundPressureSensor::new(
             self.sound_sensor,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
         ));
 
         hil::sensors::SoundPressure::set_client(self.sound_sensor, sound_pressure);

--- a/boards/components/src/sound_pressure.rs
+++ b/boards/components/src/sound_pressure.rs
@@ -36,10 +36,8 @@ pub struct SoundPressureComponent<
     mem_cap: CAP,
 }
 
-impl<
-        S: 'static + hil::sensors::SoundPressure<'static>,
-        CAP: MemoryAllocationCapability + 'static,
-    > SoundPressureComponent<S, CAP>
+impl<S: 'static + hil::sensors::SoundPressure<'static>, CAP: MemoryAllocationCapability + 'static>
+    SoundPressureComponent<S, CAP>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
@@ -56,10 +54,8 @@ impl<
     }
 }
 
-impl<
-        S: 'static + hil::sensors::SoundPressure<'static>,
-        CAP: MemoryAllocationCapability + 'static,
-    > Component for SoundPressureComponent<S, CAP>
+impl<S: 'static + hil::sensors::SoundPressure<'static>, CAP: MemoryAllocationCapability + 'static>
+    Component for SoundPressureComponent<S, CAP>
 {
     type StaticInput = &'static mut MaybeUninit<SoundPressureSensor<'static>>;
     type Output = &'static SoundPressureSensor<'static>;

--- a/boards/components/src/spi.rs
+++ b/boards/components/src/spi.rs
@@ -35,9 +35,8 @@ use capsules_core::spi_controller::{DEFAULT_READ_BUF_LENGTH, DEFAULT_WRITE_BUF_L
 use capsules_core::spi_peripheral::SpiPeripheral;
 use capsules_core::virtualizers::virtual_spi;
 use capsules_core::virtualizers::virtual_spi::{MuxSpiMaster, VirtualSpiMasterDevice};
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil::spi;
 use kernel::hil::spi::{SpiMasterDevice, SpiSlaveDevice};
 
@@ -115,17 +114,25 @@ pub struct SpiMuxComponent<S: 'static + spi::SpiMaster<'static>> {
 
 pub type SpiSyscallComponentType<S> = Spi<'static, VirtualSpiMasterDevice<'static, S>>;
 
-pub struct SpiSyscallComponent<S: 'static + spi::SpiMaster<'static>> {
+pub struct SpiSyscallComponent<
+    S: 'static + spi::SpiMaster<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     spi_mux: &'static MuxSpiMaster<'static, S>,
     chip_select: S::ChipSelect,
     driver_num: usize,
+    mem_cap: CAP,
 }
 
-pub struct SpiSyscallPComponent<S: 'static + spi::SpiSlave<'static>> {
+pub struct SpiSyscallPComponent<
+    S: 'static + spi::SpiSlave<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     spi_slave: &'static S,
     driver_num: usize,
+    mem_cap: CAP,
 }
 
 pub struct SpiComponent<
@@ -162,23 +169,29 @@ impl<S: 'static + spi::SpiMaster<'static>> Component for SpiMuxComponent<S> {
     }
 }
 
-impl<S: 'static + spi::SpiMaster<'static>> SpiSyscallComponent<S> {
+impl<S: 'static + spi::SpiMaster<'static>, CAP: MemoryAllocationCapability + 'static>
+    SpiSyscallComponent<S, CAP>
+{
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         mux: &'static MuxSpiMaster<'static, S>,
         chip_select: S::ChipSelect,
         driver_num: usize,
+        mem_cap: CAP,
     ) -> Self {
         SpiSyscallComponent {
             board_kernel,
             spi_mux: mux,
             chip_select,
             driver_num,
+            mem_cap,
         }
     }
 }
 
-impl<S: 'static + spi::SpiMaster<'static>> Component for SpiSyscallComponent<S> {
+impl<S: 'static + spi::SpiMaster<'static>, CAP: MemoryAllocationCapability + 'static> Component
+    for SpiSyscallComponent<S, CAP>
+{
     type StaticInput = (
         &'static mut MaybeUninit<VirtualSpiMasterDevice<'static, S>>,
         &'static mut MaybeUninit<Spi<'static, VirtualSpiMasterDevice<'static, S>>>,
@@ -188,15 +201,14 @@ impl<S: 'static + spi::SpiMaster<'static>> Component for SpiSyscallComponent<S> 
     type Output = &'static Spi<'static, VirtualSpiMasterDevice<'static, S>>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let syscall_spi_device = static_buffer
             .0
             .write(VirtualSpiMasterDevice::new(self.spi_mux, self.chip_select));
 
         let spi_syscalls = static_buffer.1.write(Spi::new(
             syscall_spi_device,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
         ));
 
         let spi_read_buf = static_buffer.2.write([0; DEFAULT_READ_BUF_LENGTH]);
@@ -209,21 +221,27 @@ impl<S: 'static + spi::SpiMaster<'static>> Component for SpiSyscallComponent<S> 
     }
 }
 
-impl<S: 'static + spi::SpiSlave<'static>> SpiSyscallPComponent<S> {
+impl<S: 'static + spi::SpiSlave<'static>, CAP: MemoryAllocationCapability + 'static>
+    SpiSyscallPComponent<S, CAP>
+{
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         slave: &'static S,
         driver_num: usize,
+        mem_cap: CAP,
     ) -> Self {
         SpiSyscallPComponent {
             board_kernel,
             spi_slave: slave,
             driver_num,
+            mem_cap,
         }
     }
 }
 
-impl<S: 'static + spi::SpiSlave<'static>> Component for SpiSyscallPComponent<S> {
+impl<S: 'static + spi::SpiSlave<'static>, CAP: MemoryAllocationCapability + 'static> Component
+    for SpiSyscallPComponent<S, CAP>
+{
     type StaticInput = (
         &'static mut MaybeUninit<virtual_spi::SpiSlaveDevice<'static, S>>,
         &'static mut MaybeUninit<SpiPeripheral<'static, virtual_spi::SpiSlaveDevice<'static, S>>>,
@@ -233,15 +251,14 @@ impl<S: 'static + spi::SpiSlave<'static>> Component for SpiSyscallPComponent<S> 
     type Output = &'static SpiPeripheral<'static, virtual_spi::SpiSlaveDevice<'static, S>>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let syscallp_spi_device = static_buffer
             .0
             .write(virtual_spi::SpiSlaveDevice::new(self.spi_slave));
 
         let spi_syscallsp = static_buffer.1.write(SpiPeripheral::new(
             syscallp_spi_device,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
         ));
 
         let spi_read_buf = static_buffer.2.write([0; DEFAULT_READ_BUF_LENGTH]);
@@ -288,38 +305,47 @@ impl<
     }
 }
 
-pub struct SpiPeripheralComponent<S: 'static + spi::SpiSlave<'static>> {
+pub struct SpiPeripheralComponent<
+    S: 'static + spi::SpiSlave<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     device: &'static S,
     driver_num: usize,
+    mem_cap: CAP,
 }
 
-impl<S: 'static + spi::SpiSlave<'static>> SpiPeripheralComponent<S> {
+impl<S: 'static + spi::SpiSlave<'static>, CAP: MemoryAllocationCapability + 'static>
+    SpiPeripheralComponent<S, CAP>
+{
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         device: &'static S,
         driver_num: usize,
+        mem_cap: CAP,
     ) -> Self {
         SpiPeripheralComponent {
             board_kernel,
             device,
             driver_num,
+            mem_cap,
         }
     }
 }
 
-impl<S: 'static + spi::SpiSlave<'static> + kernel::hil::spi::SpiSlaveDevice<'static>> Component
-    for SpiPeripheralComponent<S>
+impl<
+        S: 'static + spi::SpiSlave<'static> + kernel::hil::spi::SpiSlaveDevice<'static>,
+        CAP: MemoryAllocationCapability + 'static,
+    > Component for SpiPeripheralComponent<S, CAP>
 {
     type StaticInput = &'static mut MaybeUninit<SpiPeripheral<'static, S>>;
     type Output = &'static SpiPeripheral<'static, S>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let spi_device = static_buffer.write(SpiPeripheral::new(
             self.device,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
         ));
 
         spi_device

--- a/boards/components/src/spi.rs
+++ b/boards/components/src/spi.rs
@@ -334,9 +334,9 @@ impl<S: 'static + spi::SpiSlave<'static>, CAP: MemoryAllocationCapability + 'sta
 }
 
 impl<
-        S: 'static + spi::SpiSlave<'static> + kernel::hil::spi::SpiSlaveDevice<'static>,
-        CAP: MemoryAllocationCapability + 'static,
-    > Component for SpiPeripheralComponent<S, CAP>
+    S: 'static + spi::SpiSlave<'static> + kernel::hil::spi::SpiSlaveDevice<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> Component for SpiPeripheralComponent<S, CAP>
 {
     type StaticInput = &'static mut MaybeUninit<SpiPeripheral<'static, S>>;
     type Output = &'static SpiPeripheral<'static, S>;

--- a/boards/components/src/storage_permissions/individual.rs
+++ b/boards/components/src/storage_permissions/individual.rs
@@ -65,10 +65,10 @@ impl<C: Chip, D: ProcessStandardDebug, CAP: ApplicationStorageCapability>
 }
 
 impl<
-        C: Chip + 'static,
-        D: ProcessStandardDebug + 'static,
-        CAP: ApplicationStorageCapability + 'static,
-    > Component for StoragePermissionsIndividualComponent<C, D, CAP>
+    C: Chip + 'static,
+    D: ProcessStandardDebug + 'static,
+    CAP: ApplicationStorageCapability + 'static,
+> Component for StoragePermissionsIndividualComponent<C, D, CAP>
 {
     type StaticInput = &'static mut MaybeUninit<
         capsules_system::storage_permissions::individual::IndividualStoragePermissions<C, D, CAP>,

--- a/boards/components/src/storage_permissions/individual.rs
+++ b/boards/components/src/storage_permissions/individual.rs
@@ -6,77 +6,84 @@
 //! access to their own stored state.
 //!
 //! ```rust
+//! kernel::declare_capability!(AppStoreCap: kernel::capabilities::ApplicationStorageCapability);
 //! let storage_permissions_policy =
-//!     components::storage_permissions::individual::StoragePermissionsIndividualComponent::new()
-//!         .finalize(
-//!             components::storage_permissions_individual_component_static!(nrf52840dk_lib::Chip),
-//!         );
+//!     components::storage_permissions::individual::StoragePermissionsIndividualComponent::new(
+//!         AppStoreCap,
+//!     )
+//!     .finalize(
+//!         components::storage_permissions_individual_component_static!(
+//!             nrf52840dk_lib::Chip,
+//!             kernel::process::ProcessStandardDebugFull,
+//!             AppStoreCap,
+//!         ),
+//!     );
 //! ```
 
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::ApplicationStorageCapability;
 use kernel::component::Component;
 use kernel::platform::chip::Chip;
 use kernel::process::ProcessStandardDebug;
 
 #[macro_export]
 macro_rules! storage_permissions_individual_component_static {
-    ($C:ty, $D:ty $(,)?) => {{
+    ($C:ty, $D:ty, $CAP:ty $(,)?) => {{
         kernel::static_buf!(
             capsules_system::storage_permissions::individual::IndividualStoragePermissions<
                 $C,
                 $D,
-                components::storage_permissions::individual::AppStoreCapability
+                $CAP,
             >
         )
     };};
 }
 
-pub struct AppStoreCapability;
-unsafe impl capabilities::ApplicationStorageCapability for AppStoreCapability {}
+pub type StoragePermissionsIndividualComponentType<C, D, CAP> =
+    capsules_system::storage_permissions::individual::IndividualStoragePermissions<C, D, CAP>;
 
-pub type StoragePermissionsIndividualComponentType<C, D> =
-    capsules_system::storage_permissions::individual::IndividualStoragePermissions<
-        C,
-        D,
-        AppStoreCapability,
-    >;
-
-pub struct StoragePermissionsIndividualComponent<C: Chip, D: ProcessStandardDebug> {
+pub struct StoragePermissionsIndividualComponent<
+    C: Chip,
+    D: ProcessStandardDebug,
+    CAP: ApplicationStorageCapability + 'static,
+> {
+    cap: CAP,
     _chip: core::marker::PhantomData<C>,
     _debug: core::marker::PhantomData<D>,
 }
 
-impl<C: Chip, D: ProcessStandardDebug> StoragePermissionsIndividualComponent<C, D> {
-    pub fn new() -> Self {
+impl<C: Chip, D: ProcessStandardDebug, CAP: ApplicationStorageCapability>
+    StoragePermissionsIndividualComponent<C, D, CAP>
+{
+    pub fn new(cap: CAP) -> Self {
         Self {
+            cap,
             _chip: core::marker::PhantomData,
             _debug: core::marker::PhantomData,
         }
     }
 }
 
-impl<C: Chip + 'static, D: ProcessStandardDebug + 'static> Component
-    for StoragePermissionsIndividualComponent<C, D>
+impl<
+        C: Chip + 'static,
+        D: ProcessStandardDebug + 'static,
+        CAP: ApplicationStorageCapability + 'static,
+    > Component for StoragePermissionsIndividualComponent<C, D, CAP>
 {
     type StaticInput = &'static mut MaybeUninit<
-        capsules_system::storage_permissions::individual::IndividualStoragePermissions<
-            C,
-            D,
-            AppStoreCapability,
-        >,
+        capsules_system::storage_permissions::individual::IndividualStoragePermissions<C, D, CAP>,
     >;
     type Output =
         &'static capsules_system::storage_permissions::individual::IndividualStoragePermissions<
             C,
             D,
-            AppStoreCapability,
+            CAP,
         >;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
         s.write(
             capsules_system::storage_permissions::individual::IndividualStoragePermissions::new(
-                AppStoreCapability,
+                self.cap,
             ),
         )
     }

--- a/boards/components/src/storage_permissions/tbf_header.rs
+++ b/boards/components/src/storage_permissions/tbf_header.rs
@@ -4,70 +4,86 @@
 
 //! Component for creating a storage permissions policy that grants applications
 //! storage permissions based on TBF headers.
+//!
+//! ```rust
+//! kernel::declare_capability!(AppStoreCap: kernel::capabilities::ApplicationStorageCapability);
+//! let storage_permissions_policy =
+//!     components::storage_permissions::tbf_header::StoragePermissionsTbfHeaderComponent::new(
+//!         AppStoreCap,
+//!     )
+//!     .finalize(
+//!         components::storage_permissions_tbf_header_component_static!(
+//!             nrf52840dk_lib::Chip,
+//!             kernel::process::ProcessStandardDebugFull,
+//!             AppStoreCap,
+//!         ),
+//!     );
+//! ```
 
 use core::mem::MaybeUninit;
+use kernel::capabilities::ApplicationStorageCapability;
 use kernel::component::Component;
 use kernel::platform::chip::Chip;
 use kernel::process::ProcessStandardDebug;
 
 #[macro_export]
 macro_rules! storage_permissions_tbf_header_component_static {
-    ($C:ty, $D:ty $(,)?) => {{
+    ($C:ty, $D:ty, $CAP:ty $(,)?) => {{
         kernel::static_buf!(
             capsules_system::storage_permissions::tbf_header::TbfHeaderStoragePermissions<
                 $C,
                 $D,
-                components::storage_permissions::tbf_header::AppStoreCapability
+                $CAP,
             >
         )
     };};
 }
 
-pub struct AppStoreCapability;
-unsafe impl kernel::capabilities::ApplicationStorageCapability for AppStoreCapability {}
+pub type StoragePermissionsTbfHeaderComponentType<C, D, CAP> =
+    capsules_system::storage_permissions::tbf_header::TbfHeaderStoragePermissions<C, D, CAP>;
 
-pub type StoragePermissionsTbfHeaderComponentType<C, D> =
-    capsules_system::storage_permissions::tbf_header::TbfHeaderStoragePermissions<
-        C,
-        D,
-        AppStoreCapability,
-    >;
-
-pub struct StoragePermissionsTbfHeaderComponent<C: Chip, D: ProcessStandardDebug> {
+pub struct StoragePermissionsTbfHeaderComponent<
+    C: Chip,
+    D: ProcessStandardDebug,
+    CAP: ApplicationStorageCapability + 'static,
+> {
+    cap: CAP,
     _chip: core::marker::PhantomData<C>,
     _debug: core::marker::PhantomData<D>,
 }
 
-impl<C: Chip, D: ProcessStandardDebug> StoragePermissionsTbfHeaderComponent<C, D> {
-    pub fn new() -> Self {
+impl<C: Chip, D: ProcessStandardDebug, CAP: ApplicationStorageCapability>
+    StoragePermissionsTbfHeaderComponent<C, D, CAP>
+{
+    pub fn new(cap: CAP) -> Self {
         Self {
+            cap,
             _chip: core::marker::PhantomData,
             _debug: core::marker::PhantomData,
         }
     }
 }
 
-impl<C: Chip + 'static, D: ProcessStandardDebug + 'static> Component
-    for StoragePermissionsTbfHeaderComponent<C, D>
+impl<
+        C: Chip + 'static,
+        D: ProcessStandardDebug + 'static,
+        CAP: ApplicationStorageCapability + 'static,
+    > Component for StoragePermissionsTbfHeaderComponent<C, D, CAP>
 {
     type StaticInput = &'static mut MaybeUninit<
-        capsules_system::storage_permissions::tbf_header::TbfHeaderStoragePermissions<
-            C,
-            D,
-            AppStoreCapability,
-        >,
+        capsules_system::storage_permissions::tbf_header::TbfHeaderStoragePermissions<C, D, CAP>,
     >;
     type Output =
         &'static capsules_system::storage_permissions::tbf_header::TbfHeaderStoragePermissions<
             C,
             D,
-            AppStoreCapability,
+            CAP,
         >;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
         s.write(
             capsules_system::storage_permissions::tbf_header::TbfHeaderStoragePermissions::new(
-                AppStoreCapability,
+                self.cap,
             ),
         )
     }

--- a/boards/components/src/storage_permissions/tbf_header.rs
+++ b/boards/components/src/storage_permissions/tbf_header.rs
@@ -65,10 +65,10 @@ impl<C: Chip, D: ProcessStandardDebug, CAP: ApplicationStorageCapability>
 }
 
 impl<
-        C: Chip + 'static,
-        D: ProcessStandardDebug + 'static,
-        CAP: ApplicationStorageCapability + 'static,
-    > Component for StoragePermissionsTbfHeaderComponent<C, D, CAP>
+    C: Chip + 'static,
+    D: ProcessStandardDebug + 'static,
+    CAP: ApplicationStorageCapability + 'static,
+> Component for StoragePermissionsTbfHeaderComponent<C, D, CAP>
 {
     type StaticInput = &'static mut MaybeUninit<
         capsules_system::storage_permissions::tbf_header::TbfHeaderStoragePermissions<C, D, CAP>,

--- a/boards/components/src/temperature.rs
+++ b/boards/components/src/temperature.rs
@@ -37,9 +37,9 @@ pub struct TemperatureComponent<
 }
 
 impl<
-        T: 'static + hil::sensors::TemperatureDriver<'static>,
-        CAP: MemoryAllocationCapability + 'static,
-    > TemperatureComponent<T, CAP>
+    T: 'static + hil::sensors::TemperatureDriver<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> TemperatureComponent<T, CAP>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
@@ -57,9 +57,9 @@ impl<
 }
 
 impl<
-        T: 'static + hil::sensors::TemperatureDriver<'static>,
-        CAP: MemoryAllocationCapability + 'static,
-    > Component for TemperatureComponent<T, CAP>
+    T: 'static + hil::sensors::TemperatureDriver<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> Component for TemperatureComponent<T, CAP>
 {
     type StaticInput = &'static mut MaybeUninit<TemperatureSensor<'static, T>>;
     type Output = &'static TemperatureSensor<'static, T>;

--- a/boards/components/src/temperature.rs
+++ b/boards/components/src/temperature.rs
@@ -13,9 +13,8 @@
 
 use capsules_extra::temperature::TemperatureSensor;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil;
 
 #[macro_export]
@@ -27,36 +26,49 @@ macro_rules! temperature_component_static {
 
 pub type TemperatureComponentType<T> = capsules_extra::temperature::TemperatureSensor<'static, T>;
 
-pub struct TemperatureComponent<T: 'static + hil::sensors::TemperatureDriver<'static>> {
+pub struct TemperatureComponent<
+    T: 'static + hil::sensors::TemperatureDriver<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     temp_sensor: &'static T,
+    mem_cap: CAP,
 }
 
-impl<T: 'static + hil::sensors::TemperatureDriver<'static>> TemperatureComponent<T> {
+impl<
+        T: 'static + hil::sensors::TemperatureDriver<'static>,
+        CAP: MemoryAllocationCapability + 'static,
+    > TemperatureComponent<T, CAP>
+{
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         temp_sensor: &'static T,
-    ) -> TemperatureComponent<T> {
+        mem_cap: CAP,
+    ) -> TemperatureComponent<T, CAP> {
         TemperatureComponent {
             board_kernel,
             driver_num,
             temp_sensor,
+            mem_cap,
         }
     }
 }
 
-impl<T: 'static + hil::sensors::TemperatureDriver<'static>> Component for TemperatureComponent<T> {
+impl<
+        T: 'static + hil::sensors::TemperatureDriver<'static>,
+        CAP: MemoryAllocationCapability + 'static,
+    > Component for TemperatureComponent<T, CAP>
+{
     type StaticInput = &'static mut MaybeUninit<TemperatureSensor<'static, T>>;
     type Output = &'static TemperatureSensor<'static, T>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let temp = s.write(TemperatureSensor::new(
             self.temp_sensor,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
         ));
 
         hil::sensors::TemperatureDriver::set_client(self.temp_sensor, temp);

--- a/boards/components/src/text_screen.rs
+++ b/boards/components/src/text_screen.rs
@@ -25,9 +25,8 @@
 
 use capsules_extra::text_screen::TextScreen;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 
 #[macro_export]
 macro_rules! text_screen_component_static {
@@ -39,27 +38,37 @@ macro_rules! text_screen_component_static {
     };};
 }
 
-pub struct TextScreenComponent<const SCREEN_BUF_LEN: usize> {
+pub struct TextScreenComponent<
+    const SCREEN_BUF_LEN: usize,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     text_screen: &'static dyn kernel::hil::text_screen::TextScreen<'static>,
+    mem_cap: CAP,
 }
 
-impl<const SCREEN_BUF_LEN: usize> TextScreenComponent<SCREEN_BUF_LEN> {
+impl<const SCREEN_BUF_LEN: usize, CAP: MemoryAllocationCapability + 'static>
+    TextScreenComponent<SCREEN_BUF_LEN, CAP>
+{
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         text_screen: &'static dyn kernel::hil::text_screen::TextScreen<'static>,
-    ) -> TextScreenComponent<SCREEN_BUF_LEN> {
+        mem_cap: CAP,
+    ) -> TextScreenComponent<SCREEN_BUF_LEN, CAP> {
         TextScreenComponent {
             board_kernel,
             driver_num,
             text_screen,
+            mem_cap,
         }
     }
 }
 
-impl<const SCREEN_BUF_LEN: usize> Component for TextScreenComponent<SCREEN_BUF_LEN> {
+impl<const SCREEN_BUF_LEN: usize, CAP: MemoryAllocationCapability + 'static> Component
+    for TextScreenComponent<SCREEN_BUF_LEN, CAP>
+{
     type StaticInput = (
         &'static mut MaybeUninit<[u8; SCREEN_BUF_LEN]>,
         &'static mut MaybeUninit<TextScreen<'static>>,
@@ -67,8 +76,9 @@ impl<const SCREEN_BUF_LEN: usize> Component for TextScreenComponent<SCREEN_BUF_L
     type Output = &'static TextScreen<'static>;
 
     fn finalize(self, static_input: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-        let grant_text_screen = self.board_kernel.create_grant(self.driver_num, &grant_cap);
+        let grant_text_screen = self
+            .board_kernel
+            .create_grant(self.driver_num, &self.mem_cap);
 
         let buffer = static_input.0.write([0; SCREEN_BUF_LEN]);
 

--- a/boards/components/src/thread_network.rs
+++ b/boards/components/src/thread_network.rs
@@ -42,7 +42,7 @@ use capsules_extra::net::udp::udp_recv::UDPReceiver;
 use capsules_extra::net::udp::udp_send::{MuxUdpSender, UDPSendStruct, UDPSender};
 use core::mem::MaybeUninit;
 use kernel::capabilities;
-use kernel::capabilities::NetworkCapabilityCreationCapability;
+use kernel::capabilities::{NetworkCapabilityCreationCapability, UdpDriverCapability};
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::radio;
@@ -54,7 +54,7 @@ pub const CRYPT_SIZE: usize = 3 * symmetric_encryption::AES_BLOCK_SIZE + radio::
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! thread_network_component_static {
-    ($A:ty, $B:ty $(,)?) => {{
+    ($A:ty, $B:ty, $C:ty $(,)?) => {{
         use components::udp_mux::MAX_PAYLOAD_LEN;
 
         let udp_send = kernel::static_buf!(
@@ -85,6 +85,7 @@ macro_rules! thread_network_component_static {
             capsules_core::virtualizers::virtual_aes_ccm::VirtualAES128CCM<'static, $B>,
         );
         let alarm = kernel::static_buf!(VirtualMuxAlarm<'static, $A>);
+        let driver_cap = kernel::static_buf!($C);
 
         (
             udp_send,
@@ -97,12 +98,14 @@ macro_rules! thread_network_component_static {
             crypt_buf,
             crypt,
             alarm,
+            driver_cap,
         )
     };};
 }
 pub struct ThreadNetworkComponent<
     A: Alarm<'static> + 'static,
     B: AES<'static, AES128> + AESCtr + AESCBC + AESECB + 'static,
+    C: UdpDriverCapability + 'static,
 > {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
@@ -113,10 +116,14 @@ pub struct ThreadNetworkComponent<
     aes_mux: &'static MuxAES128CCM<'static, B>,
     serial_num: [u8; 8],
     alarm_mux: &'static MuxAlarm<'static, A>,
+    driver_cap: C,
 }
 
-impl<A: Alarm<'static> + 'static, B: AES<'static, AES128> + AESCtr + AESCBC + AESECB + 'static>
-    ThreadNetworkComponent<A, B>
+impl<
+    A: Alarm<'static> + 'static,
+    B: AES<'static, AES128> + AESCtr + AESCBC + AESECB + 'static,
+    C: UdpDriverCapability + 'static,
+> ThreadNetworkComponent<A, B, C>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
@@ -130,6 +137,7 @@ impl<A: Alarm<'static> + 'static, B: AES<'static, AES128> + AESCtr + AESCBC + AE
         aes_mux: &'static MuxAES128CCM<'static, B>,
         serial_num: [u8; 8],
         alarm_mux: &'static MuxAlarm<'static, A>,
+        driver_cap: C,
     ) -> Self {
         Self {
             board_kernel,
@@ -140,12 +148,16 @@ impl<A: Alarm<'static> + 'static, B: AES<'static, AES128> + AESCtr + AESCBC + AE
             aes_mux,
             serial_num,
             alarm_mux,
+            driver_cap,
         }
     }
 }
 
-impl<A: Alarm<'static> + 'static, B: AES<'static, AES128> + AESCtr + AESCBC + AESECB + 'static>
-    Component for ThreadNetworkComponent<A, B>
+impl<
+    A: Alarm<'static> + 'static,
+    B: AES<'static, AES128> + AESCtr + AESCBC + AESECB + 'static,
+    C: UdpDriverCapability + 'static,
+> Component for ThreadNetworkComponent<A, B, C>
 {
     type StaticInput = (
         &'static mut MaybeUninit<
@@ -175,6 +187,7 @@ impl<A: Alarm<'static> + 'static, B: AES<'static, AES128> + AESCtr + AESCBC + AE
             capsules_core::virtualizers::virtual_aes_ccm::VirtualAES128CCM<'static, B>,
         >,
         &'static mut MaybeUninit<VirtualMuxAlarm<'static, A>>,
+        &'static mut MaybeUninit<C>,
     );
     type Output = &'static capsules_extra::net::thread::driver::ThreadNetworkDriver<
         'static,
@@ -202,11 +215,7 @@ impl<A: Alarm<'static> + 'static, B: AES<'static, AES128> + AESCtr + AESCBC + AE
         let udp_vis = s.1.write(UdpVisibilityCapability::new(&create_cap));
         let udp_send = s.0.write(UDPSendStruct::new(self.udp_send_mux, udp_vis));
 
-        // Can't use create_capability bc need capability to have a static lifetime
-        // so that Thread driver can use it as needed
-        struct DriverCap;
-        unsafe impl capabilities::UdpDriverCapability for DriverCap {}
-        static DRIVER_CAP: DriverCap = DriverCap;
+        let driver_cap: &'static C = s.10.write(self.driver_cap);
 
         let net_cap = s.2.write(NetworkCapability::new(
             AddrRange::Any,
@@ -229,7 +238,7 @@ impl<A: Alarm<'static> + 'static, B: AES<'static, AES128> + AESCtr + AESCBC + AE
                 self.port_table,
                 kernel::utilities::leasable_buffer::SubSliceMut::new(send_buffer),
                 kernel::utilities::leasable_buffer::SubSliceMut::new(recv_buffer),
-                &DRIVER_CAP,
+                driver_cap,
                 net_cap,
             ),
         );

--- a/boards/components/src/thread_network.rs
+++ b/boards/components/src/thread_network.rs
@@ -41,10 +41,10 @@ use capsules_extra::net::udp::udp_recv::MuxUdpReceiver;
 use capsules_extra::net::udp::udp_recv::UDPReceiver;
 use capsules_extra::net::udp::udp_send::{MuxUdpSender, UDPSendStruct, UDPSender};
 use core::mem::MaybeUninit;
-use kernel::capabilities;
-use kernel::capabilities::{NetworkCapabilityCreationCapability, UdpDriverCapability};
+use kernel::capabilities::{
+    MemoryAllocationCapability, NetworkCapabilityCreationCapability, UdpDriverCapability,
+};
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil::radio;
 use kernel::hil::time::Alarm;
 
@@ -106,6 +106,8 @@ pub struct ThreadNetworkComponent<
     A: Alarm<'static> + 'static,
     B: AES<'static, AES128> + AESCtr + AESCBC + AESECB + 'static,
     C: UdpDriverCapability + 'static,
+    MEM: MemoryAllocationCapability + 'static,
+    NET: NetworkCapabilityCreationCapability + 'static,
 > {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
@@ -117,13 +119,17 @@ pub struct ThreadNetworkComponent<
     serial_num: [u8; 8],
     alarm_mux: &'static MuxAlarm<'static, A>,
     driver_cap: C,
+    mem_cap: MEM,
+    create_cap: NET,
 }
 
 impl<
     A: Alarm<'static> + 'static,
     B: AES<'static, AES128> + AESCtr + AESCBC + AESECB + 'static,
     C: UdpDriverCapability + 'static,
-> ThreadNetworkComponent<A, B, C>
+    MEM: MemoryAllocationCapability + 'static,
+    NET: NetworkCapabilityCreationCapability + 'static,
+> ThreadNetworkComponent<A, B, C, MEM, NET>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
@@ -138,6 +144,8 @@ impl<
         serial_num: [u8; 8],
         alarm_mux: &'static MuxAlarm<'static, A>,
         driver_cap: C,
+        mem_cap: MEM,
+        create_cap: NET,
     ) -> Self {
         Self {
             board_kernel,
@@ -149,6 +157,8 @@ impl<
             serial_num,
             alarm_mux,
             driver_cap,
+            mem_cap,
+            create_cap,
         }
     }
 }
@@ -157,7 +167,9 @@ impl<
     A: Alarm<'static> + 'static,
     B: AES<'static, AES128> + AESCtr + AESCBC + AESECB + 'static,
     C: UdpDriverCapability + 'static,
-> Component for ThreadNetworkComponent<A, B, C>
+    MEM: MemoryAllocationCapability + 'static,
+    NET: NetworkCapabilityCreationCapability + 'static,
+> Component for ThreadNetworkComponent<A, B, C, MEM, NET>
 {
     type StaticInput = (
         &'static mut MaybeUninit<
@@ -199,8 +211,6 @@ impl<
             s.9.write(VirtualMuxAlarm::new(self.alarm_mux));
         thread_virtual_alarm.setup();
 
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         // AES-128CCM setup
         let crypt_buf = s.7.write([0; CRYPT_SIZE]);
         let aes_ccm = s.8.write(
@@ -211,8 +221,7 @@ impl<
         );
         aes_ccm.setup();
 
-        let create_cap = create_capability!(NetworkCapabilityCreationCapability);
-        let udp_vis = s.1.write(UdpVisibilityCapability::new(&create_cap));
+        let udp_vis = s.1.write(UdpVisibilityCapability::new(&self.create_cap));
         let udp_send = s.0.write(UDPSendStruct::new(self.udp_send_mux, udp_vis));
 
         let driver_cap: &'static C = s.10.write(self.driver_cap);
@@ -221,7 +230,7 @@ impl<
             AddrRange::Any,
             PortRange::Any,
             PortRange::Any,
-            &create_cap,
+            &self.create_cap,
         ));
 
         let send_buffer = s.4.write([0; MAX_PAYLOAD_LEN]);
@@ -232,7 +241,8 @@ impl<
                 udp_send,
                 aes_ccm,
                 thread_virtual_alarm,
-                self.board_kernel.create_grant(self.driver_num, &grant_cap),
+                self.board_kernel
+                    .create_grant(self.driver_num, &self.mem_cap),
                 self.serial_num,
                 MAX_PAYLOAD_LEN,
                 self.port_table,

--- a/boards/components/src/tickv.rs
+++ b/boards/components/src/tickv.rs
@@ -49,9 +49,7 @@ use capsules_core::virtualizers::virtual_flash::FlashUser;
 use capsules_core::virtualizers::virtual_flash::MuxFlash;
 use capsules_extra::tickv::TicKVSystem;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil;
 use kernel::hil::flash::HasClient;
 use kernel::hil::hasher::Hasher;
@@ -137,8 +135,6 @@ impl<
     type Output = &'static TicKVSystem<'static, FlashUser<'static, F>, H, PAGE_SIZE>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let _grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let virtual_flash = static_buffer.0.write(FlashUser::new(self.mux_flash));
 
         let driver = static_buffer.1.write(TicKVSystem::new(
@@ -212,8 +208,6 @@ impl<
     type Output = &'static TicKVSystem<'static, F, H, PAGE_SIZE>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let _grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         let tickfs_read_buf = static_buffer.1.write([0; PAGE_SIZE]);
 
         let tickv = static_buffer.0.write(TicKVSystem::new(

--- a/boards/components/src/touch.rs
+++ b/boards/components/src/touch.rs
@@ -36,9 +36,8 @@
 //! ```
 use capsules_extra::touch::Touch;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 
 #[macro_export]
 macro_rules! touch_component_static {
@@ -47,39 +46,43 @@ macro_rules! touch_component_static {
     };};
 }
 
-pub struct TouchComponent {
+pub struct TouchComponent<CAP: MemoryAllocationCapability + 'static> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     touch: &'static dyn kernel::hil::touch::Touch<'static>,
     gesture: Option<&'static dyn kernel::hil::touch::Gesture<'static>>,
     screen: Option<&'static dyn kernel::hil::screen::Screen<'static>>,
+    mem_cap: CAP,
 }
 
-impl TouchComponent {
+impl<CAP: MemoryAllocationCapability + 'static> TouchComponent<CAP> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         touch: &'static dyn kernel::hil::touch::Touch<'static>,
         gesture: Option<&'static dyn kernel::hil::touch::Gesture<'static>>,
         screen: Option<&'static dyn kernel::hil::screen::Screen<'static>>,
-    ) -> TouchComponent {
+        mem_cap: CAP,
+    ) -> TouchComponent<CAP> {
         TouchComponent {
             board_kernel,
             driver_num,
             touch,
             gesture,
             screen,
+            mem_cap,
         }
     }
 }
 
-impl Component for TouchComponent {
+impl<CAP: MemoryAllocationCapability + 'static> Component for TouchComponent<CAP> {
     type StaticInput = &'static mut MaybeUninit<Touch<'static>>;
     type Output = &'static capsules_extra::touch::Touch<'static>;
 
     fn finalize(self, static_input: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-        let grant_touch = self.board_kernel.create_grant(self.driver_num, &grant_cap);
+        let grant_touch = self
+            .board_kernel
+            .create_grant(self.driver_num, &self.mem_cap);
 
         let touch = static_input.write(capsules_extra::touch::Touch::new(
             Some(self.touch),
@@ -97,39 +100,43 @@ impl Component for TouchComponent {
     }
 }
 
-pub struct MultiTouchComponent {
+pub struct MultiTouchComponent<CAP: MemoryAllocationCapability + 'static> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     multi_touch: &'static dyn kernel::hil::touch::MultiTouch<'static>,
     gesture: Option<&'static dyn kernel::hil::touch::Gesture<'static>>,
     screen: Option<&'static dyn kernel::hil::screen::Screen<'static>>,
+    mem_cap: CAP,
 }
 
-impl MultiTouchComponent {
+impl<CAP: MemoryAllocationCapability + 'static> MultiTouchComponent<CAP> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         multi_touch: &'static dyn kernel::hil::touch::MultiTouch<'static>,
         gesture: Option<&'static dyn kernel::hil::touch::Gesture<'static>>,
         screen: Option<&'static dyn kernel::hil::screen::Screen>,
-    ) -> MultiTouchComponent {
+        mem_cap: CAP,
+    ) -> MultiTouchComponent<CAP> {
         MultiTouchComponent {
             board_kernel,
             driver_num,
             multi_touch,
             gesture,
             screen,
+            mem_cap,
         }
     }
 }
 
-impl Component for MultiTouchComponent {
+impl<CAP: MemoryAllocationCapability + 'static> Component for MultiTouchComponent<CAP> {
     type StaticInput = &'static mut MaybeUninit<Touch<'static>>;
     type Output = &'static capsules_extra::touch::Touch<'static>;
 
     fn finalize(self, static_input: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-        let grant_touch = self.board_kernel.create_grant(self.driver_num, &grant_cap);
+        let grant_touch = self
+            .board_kernel
+            .create_grant(self.driver_num, &self.mem_cap);
 
         let touch = static_input.write(capsules_extra::touch::Touch::new(
             None,

--- a/boards/components/src/udp_driver.rs
+++ b/boards/components/src/udp_driver.rs
@@ -10,15 +10,17 @@
 //! Usage
 //! -----
 //! ```rust
-//!    let udp_driver = UDPDriverComponent::new(
-//!        board_kernel,
-//!        udp_send_mux,
-//!        udp_recv_mux,
-//!        udp_port_table,
-//!        local_ip_ifaces,
-//!        PAYLOAD_LEN,
-//!     )
-//!     .finalize(components::udp_driver_component_static!());
+//! kernel::declare_capability!(UdpDriverCap: kernel::capabilities::UdpDriverCapability);
+//! let udp_driver = UDPDriverComponent::new(
+//!     board_kernel,
+//!     udp_send_mux,
+//!     udp_recv_mux,
+//!     udp_port_table,
+//!     local_ip_ifaces,
+//!     PAYLOAD_LEN,
+//!     UdpDriverCap,
+//! )
+//! .finalize(components::udp_driver_component_static!(AlarmType, UdpDriverCap));
 //! ```
 
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
@@ -33,7 +35,7 @@ use capsules_extra::net::udp::udp_recv::UDPReceiver;
 use capsules_extra::net::udp::udp_send::{MuxUdpSender, UDPSendStruct, UDPSender};
 use core::mem::MaybeUninit;
 use kernel::capabilities;
-use kernel::capabilities::NetworkCapabilityCreationCapability;
+use kernel::capabilities::{NetworkCapabilityCreationCapability, UdpDriverCapability};
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::time::Alarm;
@@ -43,7 +45,7 @@ const MAX_PAYLOAD_LEN: usize = super::udp_mux::MAX_PAYLOAD_LEN;
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! udp_driver_component_static {
-    ($A:ty $(,)?) => {{
+    ($A:ty, $C:ty $(,)?) => {{
         use components::udp_mux::MAX_PAYLOAD_LEN;
 
         let udp_send = kernel::static_buf!(
@@ -63,14 +65,23 @@ macro_rules! udp_driver_component_static {
         let buffer = kernel::static_buf!([u8; MAX_PAYLOAD_LEN]);
         let udp_recv =
             kernel::static_buf!(capsules_extra::net::udp::udp_recv::UDPReceiver<'static>);
+        let driver_cap = kernel::static_buf!($C);
 
-        (udp_send, udp_vis_cap, net_cap, udp_driver, buffer, udp_recv)
+        (
+            udp_send,
+            udp_vis_cap,
+            net_cap,
+            udp_driver,
+            buffer,
+            udp_recv,
+            driver_cap,
+        )
     };};
 }
 
 pub type UDPDriverComponentType = capsules_extra::net::udp::UDPDriver<'static>;
 
-pub struct UDPDriverComponent<A: Alarm<'static> + 'static> {
+pub struct UDPDriverComponent<A: Alarm<'static> + 'static, C: UdpDriverCapability + 'static> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     udp_send_mux:
@@ -78,9 +89,10 @@ pub struct UDPDriverComponent<A: Alarm<'static> + 'static> {
     udp_recv_mux: &'static MuxUdpReceiver<'static>,
     port_table: &'static UdpPortManager,
     interface_list: &'static [IPAddr],
+    driver_cap: C,
 }
 
-impl<A: Alarm<'static>> UDPDriverComponent<A> {
+impl<A: Alarm<'static>, C: UdpDriverCapability + 'static> UDPDriverComponent<A, C> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
@@ -91,6 +103,7 @@ impl<A: Alarm<'static>> UDPDriverComponent<A> {
         udp_recv_mux: &'static MuxUdpReceiver<'static>,
         port_table: &'static UdpPortManager,
         interface_list: &'static [IPAddr],
+        driver_cap: C,
     ) -> Self {
         Self {
             board_kernel,
@@ -99,11 +112,12 @@ impl<A: Alarm<'static>> UDPDriverComponent<A> {
             udp_recv_mux,
             port_table,
             interface_list,
+            driver_cap,
         }
     }
 }
 
-impl<A: Alarm<'static>> Component for UDPDriverComponent<A> {
+impl<A: Alarm<'static>, C: UdpDriverCapability + 'static> Component for UDPDriverComponent<A, C> {
     type StaticInput = (
         &'static mut MaybeUninit<
             UDPSendStruct<
@@ -121,21 +135,17 @@ impl<A: Alarm<'static>> Component for UDPDriverComponent<A> {
         &'static mut MaybeUninit<capsules_extra::net::udp::UDPDriver<'static>>,
         &'static mut MaybeUninit<[u8; MAX_PAYLOAD_LEN]>,
         &'static mut MaybeUninit<UDPReceiver<'static>>,
+        &'static mut MaybeUninit<C>,
     );
     type Output = &'static capsules_extra::net::udp::UDPDriver<'static>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-        // TODO: change initialization below
         let create_cap = create_capability!(NetworkCapabilityCreationCapability);
         let udp_vis = s.1.write(UdpVisibilityCapability::new(&create_cap));
         let udp_send = s.0.write(UDPSendStruct::new(self.udp_send_mux, udp_vis));
 
-        // Can't use create_capability bc need capability to have a static lifetime
-        // so that UDP driver can use it as needed
-        struct DriverCap;
-        unsafe impl capabilities::UdpDriverCapability for DriverCap {}
-        static DRIVER_CAP: DriverCap = DriverCap;
+        let driver_cap: &'static C = s.6.write(self.driver_cap);
 
         let net_cap = s.2.write(NetworkCapability::new(
             AddrRange::Any,
@@ -153,11 +163,11 @@ impl<A: Alarm<'static>> Component for UDPDriverComponent<A> {
             MAX_PAYLOAD_LEN,
             self.port_table,
             kernel::utilities::leasable_buffer::SubSliceMut::new(buffer),
-            &DRIVER_CAP,
+            driver_cap,
             net_cap,
         ));
         udp_send.set_client(udp_driver);
-        self.port_table.set_user_ports(udp_driver, &DRIVER_CAP);
+        self.port_table.set_user_ports(udp_driver, driver_cap);
 
         let udp_driver_rcvr = s.5.write(UDPReceiver::new());
         self.udp_recv_mux.set_driver(udp_driver);

--- a/boards/components/src/udp_driver.rs
+++ b/boards/components/src/udp_driver.rs
@@ -34,10 +34,10 @@ use capsules_extra::net::udp::udp_recv::MuxUdpReceiver;
 use capsules_extra::net::udp::udp_recv::UDPReceiver;
 use capsules_extra::net::udp::udp_send::{MuxUdpSender, UDPSendStruct, UDPSender};
 use core::mem::MaybeUninit;
-use kernel::capabilities;
-use kernel::capabilities::{NetworkCapabilityCreationCapability, UdpDriverCapability};
+use kernel::capabilities::{
+    MemoryAllocationCapability, NetworkCapabilityCreationCapability, UdpDriverCapability,
+};
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil::time::Alarm;
 
 const MAX_PAYLOAD_LEN: usize = super::udp_mux::MAX_PAYLOAD_LEN;
@@ -81,7 +81,12 @@ macro_rules! udp_driver_component_static {
 
 pub type UDPDriverComponentType = capsules_extra::net::udp::UDPDriver<'static>;
 
-pub struct UDPDriverComponent<A: Alarm<'static> + 'static, C: UdpDriverCapability + 'static> {
+pub struct UDPDriverComponent<
+    A: Alarm<'static> + 'static,
+    C: UdpDriverCapability + 'static,
+    MEM: MemoryAllocationCapability + 'static,
+    NET: NetworkCapabilityCreationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     udp_send_mux:
@@ -90,9 +95,17 @@ pub struct UDPDriverComponent<A: Alarm<'static> + 'static, C: UdpDriverCapabilit
     port_table: &'static UdpPortManager,
     interface_list: &'static [IPAddr],
     driver_cap: C,
+    mem_cap: MEM,
+    create_cap: NET,
 }
 
-impl<A: Alarm<'static>, C: UdpDriverCapability + 'static> UDPDriverComponent<A, C> {
+impl<
+        A: Alarm<'static>,
+        C: UdpDriverCapability + 'static,
+        MEM: MemoryAllocationCapability + 'static,
+        NET: NetworkCapabilityCreationCapability + 'static,
+    > UDPDriverComponent<A, C, MEM, NET>
+{
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
@@ -104,6 +117,8 @@ impl<A: Alarm<'static>, C: UdpDriverCapability + 'static> UDPDriverComponent<A, 
         port_table: &'static UdpPortManager,
         interface_list: &'static [IPAddr],
         driver_cap: C,
+        mem_cap: MEM,
+        create_cap: NET,
     ) -> Self {
         Self {
             board_kernel,
@@ -113,11 +128,19 @@ impl<A: Alarm<'static>, C: UdpDriverCapability + 'static> UDPDriverComponent<A, 
             port_table,
             interface_list,
             driver_cap,
+            mem_cap,
+            create_cap,
         }
     }
 }
 
-impl<A: Alarm<'static>, C: UdpDriverCapability + 'static> Component for UDPDriverComponent<A, C> {
+impl<
+        A: Alarm<'static>,
+        C: UdpDriverCapability + 'static,
+        MEM: MemoryAllocationCapability + 'static,
+        NET: NetworkCapabilityCreationCapability + 'static,
+    > Component for UDPDriverComponent<A, C, MEM, NET>
+{
     type StaticInput = (
         &'static mut MaybeUninit<
             UDPSendStruct<
@@ -140,9 +163,7 @@ impl<A: Alarm<'static>, C: UdpDriverCapability + 'static> Component for UDPDrive
     type Output = &'static capsules_extra::net::udp::UDPDriver<'static>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-        let create_cap = create_capability!(NetworkCapabilityCreationCapability);
-        let udp_vis = s.1.write(UdpVisibilityCapability::new(&create_cap));
+        let udp_vis = s.1.write(UdpVisibilityCapability::new(&self.create_cap));
         let udp_send = s.0.write(UDPSendStruct::new(self.udp_send_mux, udp_vis));
 
         let driver_cap: &'static C = s.6.write(self.driver_cap);
@@ -151,14 +172,15 @@ impl<A: Alarm<'static>, C: UdpDriverCapability + 'static> Component for UDPDrive
             AddrRange::Any,
             PortRange::Any,
             PortRange::Any,
-            &create_cap,
+            &self.create_cap,
         ));
 
         let buffer = s.4.write([0; MAX_PAYLOAD_LEN]);
 
         let udp_driver = s.3.write(capsules_extra::net::udp::UDPDriver::new(
             udp_send,
-            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
             self.interface_list,
             MAX_PAYLOAD_LEN,
             self.port_table,

--- a/boards/components/src/udp_driver.rs
+++ b/boards/components/src/udp_driver.rs
@@ -100,11 +100,11 @@ pub struct UDPDriverComponent<
 }
 
 impl<
-        A: Alarm<'static>,
-        C: UdpDriverCapability + 'static,
-        MEM: MemoryAllocationCapability + 'static,
-        NET: NetworkCapabilityCreationCapability + 'static,
-    > UDPDriverComponent<A, C, MEM, NET>
+    A: Alarm<'static>,
+    C: UdpDriverCapability + 'static,
+    MEM: MemoryAllocationCapability + 'static,
+    NET: NetworkCapabilityCreationCapability + 'static,
+> UDPDriverComponent<A, C, MEM, NET>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
@@ -135,11 +135,11 @@ impl<
 }
 
 impl<
-        A: Alarm<'static>,
-        C: UdpDriverCapability + 'static,
-        MEM: MemoryAllocationCapability + 'static,
-        NET: NetworkCapabilityCreationCapability + 'static,
-    > Component for UDPDriverComponent<A, C, MEM, NET>
+    A: Alarm<'static>,
+    C: UdpDriverCapability + 'static,
+    MEM: MemoryAllocationCapability + 'static,
+    NET: NetworkCapabilityCreationCapability + 'static,
+> Component for UDPDriverComponent<A, C, MEM, NET>
 {
     type StaticInput = (
         &'static mut MaybeUninit<

--- a/boards/components/src/udp_mux.rs
+++ b/boards/components/src/udp_mux.rs
@@ -171,11 +171,11 @@ pub struct UDPMuxComponent<
 }
 
 impl<
-        A: Alarm<'static> + 'static,
-        M: MacDevice<'static>,
-        NET: NetworkCapabilityCreationCapability + 'static,
-        TABLE: CreatePortTableCapability + 'static,
-    > UDPMuxComponent<A, M, NET, TABLE>
+    A: Alarm<'static> + 'static,
+    M: MacDevice<'static>,
+    NET: NetworkCapabilityCreationCapability + 'static,
+    TABLE: CreatePortTableCapability + 'static,
+> UDPMuxComponent<A, M, NET, TABLE>
 {
     pub fn new(
         mux_mac: &'static capsules_extra::ieee802154::virtual_mac::MuxMac<'static, M>,
@@ -203,11 +203,11 @@ impl<
 }
 
 impl<
-        A: Alarm<'static> + 'static,
-        M: MacDevice<'static>,
-        NET: NetworkCapabilityCreationCapability + 'static,
-        TABLE: CreatePortTableCapability + 'static,
-    > Component for UDPMuxComponent<A, M, NET, TABLE>
+    A: Alarm<'static> + 'static,
+    M: MacDevice<'static>,
+    NET: NetworkCapabilityCreationCapability + 'static,
+    TABLE: CreatePortTableCapability + 'static,
+> Component for UDPMuxComponent<A, M, NET, TABLE>
 {
     type StaticInput = (
         &'static mut MaybeUninit<VirtualMuxAlarm<'static, A>>,

--- a/boards/components/src/udp_mux.rs
+++ b/boards/components/src/udp_mux.rs
@@ -45,9 +45,8 @@ use capsules_extra::net::udp::udp_port_table::{
 use capsules_extra::net::udp::udp_recv::MuxUdpReceiver;
 use capsules_extra::net::udp::udp_send::MuxUdpSender;
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::{CreatePortTableCapability, NetworkCapabilityCreationCapability};
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil::radio;
 use kernel::hil::time::Alarm;
 
@@ -154,7 +153,12 @@ macro_rules! udp_mux_component_static {
     };};
 }
 
-pub struct UDPMuxComponent<A: Alarm<'static> + 'static, M: MacDevice<'static> + 'static> {
+pub struct UDPMuxComponent<
+    A: Alarm<'static> + 'static,
+    M: MacDevice<'static> + 'static,
+    NET: NetworkCapabilityCreationCapability + 'static,
+    TABLE: CreatePortTableCapability + 'static,
+> {
     mux_mac: &'static capsules_extra::ieee802154::virtual_mac::MuxMac<'static, M>,
     ctx_pfix_len: u8,
     ctx_pfix: [u8; 16],
@@ -162,9 +166,17 @@ pub struct UDPMuxComponent<A: Alarm<'static> + 'static, M: MacDevice<'static> + 
     src_mac_addr: MacAddress,
     interface_list: &'static [IPAddr],
     alarm_mux: &'static MuxAlarm<'static, A>,
+    create_cap: NET,
+    create_table_cap: TABLE,
 }
 
-impl<A: Alarm<'static> + 'static, M: MacDevice<'static>> UDPMuxComponent<A, M> {
+impl<
+        A: Alarm<'static> + 'static,
+        M: MacDevice<'static>,
+        NET: NetworkCapabilityCreationCapability + 'static,
+        TABLE: CreatePortTableCapability + 'static,
+    > UDPMuxComponent<A, M, NET, TABLE>
+{
     pub fn new(
         mux_mac: &'static capsules_extra::ieee802154::virtual_mac::MuxMac<'static, M>,
         ctx_pfix_len: u8,
@@ -173,6 +185,8 @@ impl<A: Alarm<'static> + 'static, M: MacDevice<'static>> UDPMuxComponent<A, M> {
         src_mac_addr: MacAddress,
         interface_list: &'static [IPAddr],
         alarm_mux: &'static MuxAlarm<'static, A>,
+        create_cap: NET,
+        create_table_cap: TABLE,
     ) -> Self {
         Self {
             mux_mac,
@@ -182,11 +196,19 @@ impl<A: Alarm<'static> + 'static, M: MacDevice<'static>> UDPMuxComponent<A, M> {
             src_mac_addr,
             interface_list,
             alarm_mux,
+            create_cap,
+            create_table_cap,
         }
     }
 }
 
-impl<A: Alarm<'static> + 'static, M: MacDevice<'static>> Component for UDPMuxComponent<A, M> {
+impl<
+        A: Alarm<'static> + 'static,
+        M: MacDevice<'static>,
+        NET: NetworkCapabilityCreationCapability + 'static,
+        TABLE: CreatePortTableCapability + 'static,
+    > Component for UDPMuxComponent<A, M, NET, TABLE>
+{
     type StaticInput = (
         &'static mut MaybeUninit<VirtualMuxAlarm<'static, A>>,
         &'static mut MaybeUninit<capsules_extra::ieee802154::virtual_mac::MacUser<'static, M>>,
@@ -239,9 +261,8 @@ impl<A: Alarm<'static> + 'static, M: MacDevice<'static>> Component for UDPMuxCom
                 self.mux_mac,
             ));
         self.mux_mac.add_user(udp_mac);
-        let create_cap = create_capability!(capabilities::NetworkCapabilityCreationCapability);
-        let udp_vis = s.14.write(UdpVisibilityCapability::new(&create_cap));
-        let ip_vis = s.15.write(IpVisibilityCapability::new(&create_cap));
+        let udp_vis = s.14.write(UdpVisibilityCapability::new(&self.create_cap));
+        let ip_vis = s.15.write(IpVisibilityCapability::new(&self.create_cap));
 
         let sixlowpan = s.2.write(sixlowpan_state::Sixlowpan::new(
             sixlowpan_compression::Context {
@@ -308,9 +329,8 @@ impl<A: Alarm<'static> + 'static, M: MacDevice<'static>> Component for UDPMuxCom
         ip_send.set_client(udp_send_mux);
 
         let kernel_ports = s.10.write([None; MAX_NUM_BOUND_PORTS]);
-        let create_table_cap = create_capability!(capabilities::CreatePortTableCapability);
         let udp_port_table = s.7.write(UdpPortManager::new(
-            &create_table_cap,
+            &self.create_table_cap,
             kernel_ports,
             udp_vis,
         ));

--- a/boards/components/src/usb.rs
+++ b/boards/components/src/usb.rs
@@ -19,9 +19,8 @@
 //! ```
 
 use core::mem::MaybeUninit;
-use kernel::capabilities;
+use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil::usb::UsbController;
 
 #[macro_export]
@@ -38,23 +37,37 @@ macro_rules! usb_component_static {
     }};
 }
 
-pub struct UsbComponent<U: UsbController<'static> + 'static> {
+pub struct UsbComponent<
+    U: UsbController<'static> + 'static,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     usbc: &'static U,
+    mem_cap: CAP,
 }
 
-impl<U: UsbController<'static> + 'static> UsbComponent<U> {
-    pub fn new(board_kernel: &'static kernel::Kernel, driver_num: usize, usbc: &'static U) -> Self {
+impl<U: UsbController<'static> + 'static, CAP: MemoryAllocationCapability + 'static>
+    UsbComponent<U, CAP>
+{
+    pub fn new(
+        board_kernel: &'static kernel::Kernel,
+        driver_num: usize,
+        usbc: &'static U,
+        mem_cap: CAP,
+    ) -> Self {
         Self {
             board_kernel,
             driver_num,
             usbc,
+            mem_cap,
         }
     }
 }
 
-impl<U: UsbController<'static> + 'static> Component for UsbComponent<U> {
+impl<U: UsbController<'static> + 'static, CAP: MemoryAllocationCapability + 'static> Component
+    for UsbComponent<U, CAP>
+{
     type StaticInput = (
         &'static mut MaybeUninit<capsules_extra::usb::usbc_client::Client<'static, U>>,
         &'static mut MaybeUninit<
@@ -70,8 +83,6 @@ impl<U: UsbController<'static> + 'static> Component for UsbComponent<U> {
     >;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
         // Configure the USB controller
         let usb_client = s.0.write(capsules_extra::usb::usbc_client::Client::new(
             self.usbc,
@@ -83,7 +94,8 @@ impl<U: UsbController<'static> + 'static> Component for UsbComponent<U> {
         let usb_driver =
             s.1.write(capsules_extra::usb::usb_user::UsbSyscallDriver::new(
                 usb_client,
-                self.board_kernel.create_grant(self.driver_num, &grant_cap),
+                self.board_kernel
+                    .create_grant(self.driver_num, &self.mem_cap),
             ));
 
         usb_driver

--- a/boards/components/src/wifi.rs
+++ b/boards/components/src/wifi.rs
@@ -4,42 +4,52 @@
 
 use capsules_extra::wifi;
 use core::mem::MaybeUninit;
-use kernel::{capabilities, component::Component, create_capability};
+use kernel::capabilities::MemoryAllocationCapability;
+use kernel::component::Component;
 
 #[macro_export]
 macro_rules! wifi_component_static {
     ($D:ty $(,)?) => {{ kernel::static_buf!(capsules_extra::wifi::WifiDriver<'static, $D>) }};
 }
 
-pub struct WifiComponent<D: 'static + wifi::Device<'static>> {
+pub struct WifiComponent<
+    D: 'static + wifi::Device<'static>,
+    CAP: MemoryAllocationCapability + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     device: &'static D,
+    mem_cap: CAP,
 }
 
-impl<D: 'static + wifi::Device<'static>> WifiComponent<D> {
+impl<D: 'static + wifi::Device<'static>, CAP: MemoryAllocationCapability + 'static>
+    WifiComponent<D, CAP>
+{
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         device: &'static D,
+        mem_cap: CAP,
     ) -> Self {
         Self {
             board_kernel,
             driver_num,
             device,
+            mem_cap,
         }
     }
 }
 
-impl<D: 'static + wifi::Device<'static>> Component for WifiComponent<D> {
+impl<D: 'static + wifi::Device<'static>, CAP: MemoryAllocationCapability + 'static> Component
+    for WifiComponent<D, CAP>
+{
     type StaticInput = &'static mut MaybeUninit<wifi::WifiDriver<'static, D>>;
     type Output = &'static wifi::WifiDriver<'static, D>;
     fn finalize(self, static_memory: Self::StaticInput) -> Self::Output {
-        let capability = create_capability!(capabilities::MemoryAllocationCapability);
-
         let wifi = static_memory.write(wifi::WifiDriver::new(
             self.device,
-            self.board_kernel.create_grant(self.driver_num, &capability),
+            self.board_kernel
+                .create_grant(self.driver_num, &self.mem_cap),
         ));
         self.device.set_client(wifi);
 

--- a/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
@@ -287,6 +287,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_extra::ieee802154::DRIVER_NUM,
         &nrf52833_peripherals.ieee802154_radio,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::ieee802154_raw_component_static!(
         nrf52833::ieee802154_radio::Radio,
@@ -333,6 +334,7 @@ unsafe fn start() -> (
             9 => &nrf52833_peripherals.gpio_port[GPIO_P9],
             16 => &nrf52833_peripherals.gpio_port[GPIO_P16],
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(nrf52833::gpio::GPIOPin));
 
@@ -360,6 +362,7 @@ unsafe fn start() -> (
                 kernel::hil::gpio::FloatingState::PullNone
             ), // Touch Logo
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::button_component_static!(
         nrf52833::gpio::GPIOPin
@@ -378,6 +381,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(nrf52::rtc::Rtc));
 
@@ -453,9 +457,12 @@ unsafe fn start() -> (
                 nrf52833::pwm::Pwm
             ));
 
-    let pwm =
-        components::pwm::PwmDriverComponent::new(board_kernel, capsules_extra::pwm::DRIVER_NUM)
-            .finalize(components::pwm_driver_component_helper!(virtual_pwm_driver));
+    let pwm = components::pwm::PwmDriverComponent::new(
+        board_kernel,
+        capsules_extra::pwm::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
+    )
+    .finalize(components::pwm_driver_component_helper!(virtual_pwm_driver));
 
     //--------------------------------------------------------------------------
     // UART & CONSOLE & DEBUG
@@ -477,6 +484,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
@@ -496,6 +504,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::rng::DRIVER_NUM,
         &base_peripherals.trng,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::rng_component_static!(nrf52833::trng::Trng));
 
@@ -521,6 +530,7 @@ unsafe fn start() -> (
         None,
         board_kernel,
         capsules_extra::lsm303agr::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::lsm303agr_component_static!(
         nrf52833::i2c::TWI<'static>
@@ -541,6 +551,7 @@ unsafe fn start() -> (
     let ninedof = components::ninedof::NineDofComponent::new(
         board_kernel,
         capsules_extra::ninedof::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::ninedof_component_static!(lsm303agr));
 
@@ -550,6 +561,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,
         &base_peripherals.temp,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::temperature_component_static!(
         nrf52833::temperature::Temp
@@ -564,28 +576,31 @@ unsafe fn start() -> (
         .finalize(components::adc_mux_component_static!(nrf52833::adc::Adc));
 
     // Comment out the following to use P0, P1 and P2 as GPIO
-    let adc_syscall =
-        components::adc::AdcVirtualComponent::new(board_kernel, capsules_core::adc::DRIVER_NUM)
-            .finalize(components::adc_syscall_component_helper!(
-                // ADC Ring 0 (P0)
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52833::adc::AdcChannelSetup::new(nrf52833::adc::AdcChannel::AnalogInput0)
-                )
-                .finalize(components::adc_component_static!(nrf52833::adc::Adc)),
-                // ADC Ring 1 (P1)
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52833::adc::AdcChannelSetup::new(nrf52833::adc::AdcChannel::AnalogInput1)
-                )
-                .finalize(components::adc_component_static!(nrf52833::adc::Adc)),
-                // ADC Ring 2 (P2)
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52833::adc::AdcChannelSetup::new(nrf52833::adc::AdcChannel::AnalogInput2)
-                )
-                .finalize(components::adc_component_static!(nrf52833::adc::Adc))
-            ));
+    let adc_syscall = components::adc::AdcVirtualComponent::new(
+        board_kernel,
+        capsules_core::adc::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
+    )
+    .finalize(components::adc_syscall_component_helper!(
+        // ADC Ring 0 (P0)
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52833::adc::AdcChannelSetup::new(nrf52833::adc::AdcChannel::AnalogInput0)
+        )
+        .finalize(components::adc_component_static!(nrf52833::adc::Adc)),
+        // ADC Ring 1 (P1)
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52833::adc::AdcChannelSetup::new(nrf52833::adc::AdcChannel::AnalogInput1)
+        )
+        .finalize(components::adc_component_static!(nrf52833::adc::Adc)),
+        // ADC Ring 2 (P2)
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52833::adc::AdcChannelSetup::new(nrf52833::adc::AdcChannel::AnalogInput2)
+        )
+        .finalize(components::adc_component_static!(nrf52833::adc::Adc))
+    ));
 
     // Microphone
 
@@ -615,6 +630,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_extra::sound_pressure::DRIVER_NUM,
         adc_microphone,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::sound_pressure_component_static!());
 
@@ -636,6 +652,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_extra::app_flash_driver::DRIVER_NUM,
         virtual_app_flash,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::app_flash_component_static!(
         capsules_core::virtualizers::virtual_flash::FlashUser<'static, nrf52833::nvmc::Nvmc>,
@@ -651,6 +668,7 @@ unsafe fn start() -> (
         capsules_extra::ble_advertising_driver::DRIVER_NUM,
         &base_peripherals.ble_radio,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::ble_component_static!(
         nrf52833::rtc::Rtc,
@@ -832,6 +850,7 @@ unsafe fn start() -> (
         storage_permissions_policy,
         app_flash_slice,
         app_memory_slice,
+        create_capability!(capabilities::ProcessManagementCapability),
     )
     .finalize(components::process_loader_sequential_component_static!(
         nrf52833::chip::NRF52<Nrf52833DefaultPeripherals>,
@@ -861,6 +880,7 @@ unsafe fn start() -> (
         capsules_extra::app_loader::DRIVER_NUM,
         dynamic_binary_storage,
         dynamic_binary_storage,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::app_loader_component_static!(
         DynamicBinaryStorage<'static>,

--- a/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
@@ -747,15 +747,21 @@ unsafe fn start() -> (
         resources.printer.put(process_printer);
     });
 
+    kernel::declare_capability!(ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let _process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
+        ProcessConsoleCap,
     )
     .finalize(components::process_console_component_static!(
-        nrf52833::rtc::Rtc
+        nrf52833::rtc::Rtc,
+        ProcessConsoleCap
     ));
     let _ = _process_console.start();
 

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-ecdsap256/src/main.rs
@@ -8,6 +8,7 @@
 #![no_main]
 #![deny(missing_docs)]
 
+use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::deferred_call::DeferredCallClient;
@@ -188,6 +189,7 @@ pub unsafe fn main() {
         storage_permissions_policy,
         app_flash,
         app_memory,
+        create_capability!(capabilities::ProcessManagementCapability),
     )
     .finalize(components::process_loader_sequential_component_static!(
         nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-sha256/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-sha256/src/main.rs
@@ -8,6 +8,7 @@
 #![no_main]
 #![deny(missing_docs)]
 
+use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
@@ -85,6 +86,7 @@ pub unsafe fn main() {
         storage_permissions_policy,
         app_flash,
         app_memory,
+        create_capability!(capabilities::ProcessManagementCapability),
     )
     .finalize(components::process_loader_sequential_component_static!(
         nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/main.rs
@@ -58,15 +58,21 @@ pub unsafe fn main() {
 
     // Create the process console, an interactive terminal for managing
     // processes.
+    kernel::declare_capability!(ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         mux_uart,
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
+        ProcessConsoleCap,
     )
     .finalize(components::process_console_component_static!(
-        nrf52840::rtc::Rtc<'static>
+        nrf52840::rtc::Rtc<'static>,
+        ProcessConsoleCap
     ));
 
     // Create the debugger object that handles calls to `debug!()`.

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/main.rs
@@ -147,6 +147,7 @@ pub unsafe fn main() {
         storage_permissions_policy,
         app_flash,
         app_memory,
+        create_capability!(capabilities::ProcessManagementCapability),
     )
     .finalize(components::process_loader_sequential_component_static!(
         nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-base/src/lib.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-base/src/lib.rs
@@ -15,6 +15,7 @@ use kernel::hil::time::Counter;
 use kernel::platform::chip::Chip;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::static_init;
+use kernel::{capabilities, create_capability};
 use nrf52_components::{UartChannel, UartPins};
 use nrf52840::gpio::Pin;
 use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
@@ -219,6 +220,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(nrf52840::rtc::Rtc));
 
@@ -244,6 +246,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         mux_uart,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
 

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
@@ -315,15 +315,21 @@ pub unsafe fn main() {
 
     // Create the process console, an interactive terminal for managing
     // processes.
+    kernel::declare_capability!(ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
+        ProcessConsoleCap,
     )
     .finalize(components::process_console_component_static!(
-        nrf52840::rtc::Rtc<'static>
+        nrf52840::rtc::Rtc<'static>,
+        ProcessConsoleCap
     ));
 
     // Create the debugger object that handles calls to `debug!()`.

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
@@ -278,6 +278,7 @@ pub unsafe fn main() {
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(nrf52840::rtc::Rtc));
 
@@ -303,6 +304,7 @@ pub unsafe fn main() {
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
 
@@ -371,6 +373,7 @@ pub unsafe fn main() {
                 kernel::hil::gpio::FloatingState::PullUp
             )
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::button_component_static!(
         nrf52840::gpio::GPIOPin
@@ -396,6 +399,7 @@ pub unsafe fn main() {
         adc_channels,
         board_kernel,
         capsules_core::adc::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::adc_dedicated_component_static!(
         nrf52840::adc::Adc
@@ -466,6 +470,7 @@ pub unsafe fn main() {
         storage_permissions_policy,
         app_flash,
         app_memory,
+        create_capability!(capabilities::ProcessManagementCapability),
     )
     .finalize(components::process_loader_sequential_component_static!(
         nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
@@ -495,6 +500,7 @@ pub unsafe fn main() {
         capsules_extra::app_loader::DRIVER_NUM,
         dynamic_binary_storage,
         dynamic_binary_storage,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::app_loader_component_static!(
         DynamicBinaryStorage<'static>,

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-invs/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-invs/src/main.rs
@@ -138,6 +138,7 @@ pub unsafe fn main() {
         mx25r6435f,
         0x40000,  // start address
         0x100000, // length
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::isolated_nonvolatile_storage_component_static!(
         Mx25r6435f,
@@ -220,6 +221,7 @@ pub unsafe fn main() {
         storage_permissions_policy,
         app_flash,
         app_memory,
+        create_capability!(capabilities::ProcessManagementCapability),
     )
     .finalize(components::process_loader_sequential_component_static!(
         nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-sha256/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-sha256/src/main.rs
@@ -90,6 +90,7 @@ pub unsafe fn main() {
         board_kernel,
         capsules_extra::sha256_driver::DRIVER_NUM,
         sha,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::sha_driver_component_static!(
         Sha,

--- a/boards/cy8cproto_62_4343_w/src/main.rs
+++ b/boards/cy8cproto_62_4343_w/src/main.rs
@@ -221,14 +221,22 @@ pub unsafe fn main() {
         resources.printer.put(process_printer);
     });
 
+    kernel::declare_capability!(ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         Some(cortexm0p::support::reset),
+        ProcessConsoleCap,
     )
-    .finalize(components::process_console_component_static!(Tcpwm0));
+    .finalize(components::process_console_component_static!(
+        Tcpwm0,
+        ProcessConsoleCap
+    ));
     let _ = process_console.start();
 
     let led_pin = peripherals.gpio.get_pin(psoc62xa::gpio::PsocPin::P13_7);

--- a/boards/cy8cproto_62_4343_w/src/main.rs
+++ b/boards/cy8cproto_62_4343_w/src/main.rs
@@ -184,6 +184,7 @@ pub unsafe fn main() {
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     components::debug_writer::DebugWriterComponent::new_unsafe(
@@ -209,6 +210,7 @@ pub unsafe fn main() {
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(Tcpwm0));
 
@@ -278,6 +280,7 @@ pub unsafe fn main() {
             108 => peripherals.gpio.get_pin(psoc62xa::gpio::PsocPin::P13_4),
             110 => peripherals.gpio.get_pin(psoc62xa::gpio::PsocPin::P13_6),
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(psoc62xa::gpio::GpioPin));
 
@@ -298,6 +301,7 @@ pub unsafe fn main() {
                 kernel::hil::gpio::FloatingState::PullNone
             ),
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::button_component_static!(GpioPin));
 

--- a/boards/esp32-c3-devkitM-1/src/main.rs
+++ b/boards/esp32-c3-devkitM-1/src/main.rs
@@ -215,6 +215,7 @@ unsafe fn setup() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
@@ -255,6 +256,7 @@ unsafe fn setup() -> (
             7 => &peripherals.gpio[7],
             8 => &peripherals.gpio[15]
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(esp32::gpio::GpioPin));
 
@@ -319,6 +321,7 @@ unsafe fn setup() -> (
                 kernel::hil::gpio::FloatingState::PullUp
             )
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::button_component_static!(GpioHw));
 
@@ -371,6 +374,7 @@ unsafe fn setup() -> (
         board_kernel,
         capsules_core::rng::DRIVER_NUM,
         &peripherals.rng,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::rng_component_static!(esp32_c3::rng::Rng));
 

--- a/boards/esp32-c3-devkitM-1/src/main.rs
+++ b/boards/esp32-c3-devkitM-1/src/main.rs
@@ -345,15 +345,21 @@ unsafe fn setup() -> (
     // PROCESS CONSOLE
     //
 
+    kernel::declare_capability!(ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         None,
+        ProcessConsoleCap,
     )
     .finalize(components::process_console_component_static!(
-        esp32_c3::timg::TimG
+        esp32_c3::timg::TimG,
+        ProcessConsoleCap
     ));
     let _ = process_console.start();
 

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -322,6 +322,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     kernel::declare_capability!(ProcessConsoleCap:
@@ -357,6 +358,7 @@ unsafe fn start() -> (
         capsules_extra::nrf51822_serialization::DRIVER_NUM,
         &peripherals.usart3,
         &peripherals.pa[17],
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::nrf51822_component_static!());
 
@@ -371,12 +373,14 @@ unsafe fn start() -> (
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,
         si7021,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::temperature_component_static!(SI7021Sensor));
     let humidity = components::humidity::HumidityComponent::new(
         board_kernel,
         capsules_extra::humidity::DRIVER_NUM,
         si7021,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::humidity_component_static!(SI7021Sensor));
 
@@ -388,6 +392,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_extra::ambient_light::DRIVER_NUM,
         isl29035,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::ambient_light_component_static!());
 
@@ -396,6 +401,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(sam4l::ast::Ast));
 
@@ -407,6 +413,7 @@ unsafe fn start() -> (
     let ninedof = components::ninedof::NineDofComponent::new(
         board_kernel,
         capsules_extra::ninedof::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::ninedof_component_static!(fxos8700));
 
@@ -420,6 +427,7 @@ unsafe fn start() -> (
         mux_spi,
         sam4l::spi::Peripheral::Peripheral0,
         capsules_core::spi_controller::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::spi_syscall_component_static!(sam4l::spi::SpiHw));
 
@@ -443,6 +451,7 @@ unsafe fn start() -> (
                 kernel::hil::gpio::FloatingState::PullNone
             )
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::button_component_static!(sam4l::gpio::GPIOPin));
 
@@ -463,6 +472,7 @@ unsafe fn start() -> (
         adc_channels,
         board_kernel,
         capsules_core::adc::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::adc_dedicated_component_static!(sam4l::adc::Adc));
 
@@ -471,6 +481,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::rng::DRIVER_NUM,
         &peripherals.trng,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::rng_component_static!(sam4l::trng::Trng));
 
@@ -485,6 +496,7 @@ unsafe fn start() -> (
             2 => &peripherals.pb[11], // D6
             3 => &peripherals.pb[12]  // D7
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(sam4l::gpio::GPIOPin));
 
@@ -493,6 +505,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_extra::crc::DRIVER_NUM,
         &peripherals.crccu,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::crc_component_static!(sam4l::crccu::Crccu));
 

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -324,15 +324,21 @@ unsafe fn start() -> (
         uart_mux,
     )
     .finalize(components::console_component_static!());
+    kernel::declare_capability!(ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
+        ProcessConsoleCap,
     )
     .finalize(components::process_console_component_static!(
-        sam4l::ast::Ast<'static>
+        sam4l::ast::Ast<'static>,
+        ProcessConsoleCap
     ));
     components::debug_writer::DebugWriterComponent::new::<
         <ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider,

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -296,15 +296,21 @@ unsafe fn start() -> (
         resources.printer.put(process_printer);
     });
 
+    kernel::declare_capability!(ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         None,
+        ProcessConsoleCap,
     )
     .finalize(components::process_console_component_static!(
-        e310_g002::chip::E310xClint
+        e310_g002::chip::E310xClint,
+        ProcessConsoleCap
     ));
     let _ = process_console.start();
 

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -328,6 +328,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
@@ -344,6 +345,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::low_level_debug::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::low_level_debug_component_static!());
 

--- a/boards/hifive_inventor/src/main.rs
+++ b/boards/hifive_inventor/src/main.rs
@@ -256,6 +256,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
@@ -271,6 +272,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::low_level_debug::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::low_level_debug_component_static!());
 

--- a/boards/hifive_inventor/src/main.rs
+++ b/boards/hifive_inventor/src/main.rs
@@ -224,15 +224,21 @@ unsafe fn start() -> (
         resources.printer.put(process_printer);
     });
 
+    kernel::declare_capability!(ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         None,
+        ProcessConsoleCap,
     )
     .finalize(components::process_console_component_static!(
-        e310_g003::chip::E310xClint
+        e310_g003::chip::E310xClint,
+        ProcessConsoleCap
     ));
     let _ = process_console.start();
 

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -404,9 +404,13 @@ unsafe fn start() -> (
         .finalize(components::alarm_mux_component_static!(sam4l::ast::Ast));
     peripherals.ast.configure(mux_alarm);
 
-    let alarm =
-        AlarmDriverComponent::new(board_kernel, capsules_core::alarm::DRIVER_NUM, mux_alarm)
-            .finalize(components::alarm_component_static!(sam4l::ast::Ast));
+    let alarm = AlarmDriverComponent::new(
+        board_kernel,
+        capsules_core::alarm::DRIVER_NUM,
+        mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
+    )
+    .finalize(components::alarm_component_static!(sam4l::ast::Ast));
 
     let pconsole = ProcessConsoleComponent::new(
         board_kernel,
@@ -429,6 +433,7 @@ unsafe fn start() -> (
         200,
         5,
         5,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_ordered_component_static!(
         sam4l::ast::Ast
@@ -446,6 +451,7 @@ unsafe fn start() -> (
         capsules_extra::nrf51822_serialization::DRIVER_NUM,
         &peripherals.usart2,
         &peripherals.pb[07],
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::nrf51822_component_static!());
 
@@ -464,6 +470,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_extra::ambient_light::DRIVER_NUM,
         isl29035,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::ambient_light_component_static!());
 
@@ -474,12 +481,14 @@ unsafe fn start() -> (
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,
         si7021,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::temperature_component_static!(SI7021Sensor));
     let humidity = components::humidity::HumidityComponent::new(
         board_kernel,
         capsules_extra::humidity::DRIVER_NUM,
         si7021,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::humidity_component_static!(SI7021Sensor));
 
@@ -491,6 +500,7 @@ unsafe fn start() -> (
     let ninedof = components::ninedof::NineDofComponent::new(
         board_kernel,
         capsules_extra::ninedof::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::ninedof_component_static!(fxos8700));
 
@@ -504,6 +514,7 @@ unsafe fn start() -> (
         mux_spi,
         sam4l::spi::Peripheral::Peripheral2,
         capsules_core::spi_controller::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::spi_syscall_component_static!(
         sam4l::spi::SpiHw<'static>
@@ -540,6 +551,7 @@ unsafe fn start() -> (
         adc_channels,
         board_kernel,
         capsules_core::adc::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::adc_dedicated_component_static!(sam4l::adc::Adc));
 
@@ -556,6 +568,7 @@ unsafe fn start() -> (
             5 => &peripherals.pc[26],
             6 => &peripherals.pa[20]
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(sam4l::gpio::GPIOPin));
 
@@ -575,6 +588,7 @@ unsafe fn start() -> (
                 kernel::hil::gpio::FloatingState::PullNone
             )
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::button_component_static!(sam4l::gpio::GPIOPin));
 
@@ -582,6 +596,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_extra::crc::DRIVER_NUM,
         &peripherals.crccu,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::crc_component_static!(sam4l::crccu::Crccu));
 
@@ -596,6 +611,7 @@ unsafe fn start() -> (
         ),
         board_kernel,
         capsules_extra::analog_comparator::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::analog_comparator_component_static!(
         sam4l::acifc::Acifc
@@ -604,6 +620,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::rng::DRIVER_NUM,
         &peripherals.trng,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::rng_component_static!(sam4l::trng::Trng));
 
@@ -632,6 +649,7 @@ unsafe fn start() -> (
         PAN_ID,
         serial_num_bottom_16,
         DEFAULT_EXT_SRC_MAC,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::ieee802154_component_static!(
         capsules_extra::rf233::RF233<
@@ -645,6 +663,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_extra::usb::usb_user::DRIVER_NUM,
         &peripherals.usbc,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::usb_component_static!(sam4l::usbc::Usbc));
 
@@ -664,6 +683,7 @@ unsafe fn start() -> (
         0x20000, // Length of userspace accessible region
         core::ptr::addr_of!(_sstorage) as usize, //start address of kernel region
         core::ptr::addr_of!(_estorage) as usize - core::ptr::addr_of!(_sstorage) as usize, // length of kernel region
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::nonvolatile_storage_component_static!(
         sam4l::flashcalw::FLASHCALW
@@ -693,6 +713,8 @@ unsafe fn start() -> (
         //MacAddress::Short(49138), //comment in for dual rx test only
         local_ip_ifaces,
         mux_alarm,
+        create_capability!(capabilities::NetworkCapabilityCreationCapability),
+        create_capability!(capabilities::CreatePortTableCapability),
     )
     .finalize(components::udp_mux_component_static!(
         sam4l::ast::Ast,
@@ -709,6 +731,8 @@ unsafe fn start() -> (
         udp_port_table,
         local_ip_ifaces,
         UdpDriverCap,
+        create_capability!(capabilities::MemoryAllocationCapability),
+        create_capability!(capabilities::NetworkCapabilityCreationCapability),
     )
     .finalize(components::udp_driver_component_static!(
         sam4l::ast::Ast,
@@ -786,6 +810,7 @@ unsafe fn start() -> (
         storage_permissions_policy,
         app_flash,
         app_memory,
+        create_capability!(capabilities::ProcessManagementCapability),
     )
     .finalize(components::process_loader_sequential_component_static!(
         sam4l::chip::Sam4l<Sam4lDefaultPeripherals>,

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -124,6 +124,11 @@ type Ieee802154MacDevice =
 
 type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
 
+kernel::declare_capability!(ProcessConsoleCap:
+    kernel::capabilities::ProcessManagementCapability,
+    kernel::capabilities::ProcessStartCapability
+);
+
 struct Imix {
     pconsole: &'static capsules_core::process_console::ProcessConsole<
         'static,
@@ -132,7 +137,7 @@ struct Imix {
             'static,
             sam4l::ast::Ast<'static>,
         >,
-        components::process_console::Capability,
+        ProcessConsoleCap,
     >,
     console: &'static capsules_core::console_ordered::ConsoleOrdered<
         'static,
@@ -409,9 +414,11 @@ unsafe fn start() -> (
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
+        ProcessConsoleCap,
     )
     .finalize(components::process_console_component_static!(
-        sam4l::ast::Ast
+        sam4l::ast::Ast,
+        ProcessConsoleCap
     ));
 
     let console = ConsoleOrderedComponent::new(
@@ -693,6 +700,7 @@ unsafe fn start() -> (
     ));
 
     // UDP driver initialization happens here
+    kernel::declare_capability!(UdpDriverCap: kernel::capabilities::UdpDriverCapability);
     let udp_driver = components::udp_driver::UDPDriverComponent::new(
         board_kernel,
         capsules_extra::net::udp::driver::DRIVER_NUM,
@@ -700,8 +708,12 @@ unsafe fn start() -> (
         udp_recv_mux,
         udp_port_table,
         local_ip_ifaces,
+        UdpDriverCap,
     )
-    .finalize(components::udp_driver_component_static!(sam4l::ast::Ast));
+    .finalize(components::udp_driver_component_static!(
+        sam4l::ast::Ast,
+        UdpDriverCap
+    ));
 
     let scheduler = components::sched::round_robin::RoundRobinComponent::new(processes)
         .finalize(components::round_robin_component_static!(NUM_PROCS));
@@ -726,14 +738,18 @@ unsafe fn start() -> (
     // STORAGE PERMISSIONS
     //--------------------------------------------------------------------------
 
+    kernel::declare_capability!(AppStoreCap: kernel::capabilities::ApplicationStorageCapability);
     let storage_permissions_policy =
-        components::storage_permissions::individual::StoragePermissionsIndividualComponent::new()
-            .finalize(
-                components::storage_permissions_individual_component_static!(
-                    sam4l::chip::Sam4l<Sam4lDefaultPeripherals>,
-                    kernel::process::ProcessStandardDebugFull,
-                ),
-            );
+        components::storage_permissions::individual::StoragePermissionsIndividualComponent::new(
+            AppStoreCap,
+        )
+        .finalize(
+            components::storage_permissions_individual_component_static!(
+                sam4l::chip::Sam4l<Sam4lDefaultPeripherals>,
+                kernel::process::ProcessStandardDebugFull,
+                AppStoreCap,
+            ),
+        );
 
     //--------------------------------------------------------------------------
     // PROCESS LOADING

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -508,15 +508,21 @@ unsafe fn start() -> (
         resources.printer.put(process_printer);
     });
 
+    kernel::declare_capability!(ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         lpuart_mux,
         mux_alarm,
         process_printer,
         None,
+        ProcessConsoleCap,
     )
     .finalize(components::process_console_component_static!(
-        imxrt10xx::gpt::Gpt1
+        imxrt10xx::gpt::Gpt1,
+        ProcessConsoleCap
     ));
     let _ = process_console.start();
 

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -337,6 +337,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         lpuart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
@@ -368,6 +369,7 @@ unsafe fn start() -> (
                 kernel::hil::gpio::FloatingState::PullDown
             )
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::button_component_static!(imxrt10xx::gpio::Pin));
 
@@ -381,6 +383,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(imxrt10xx::gpt::Gpt1));
 
@@ -394,6 +397,7 @@ unsafe fn start() -> (
             // The User Led
             0 => peripherals.ports.pin(imxrt10xx::gpio::PinId::AdB0_09)
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(
         imxrt10xx::gpio::Pin<'static>
@@ -471,6 +475,7 @@ unsafe fn start() -> (
     let ninedof = components::ninedof::NineDofComponent::new(
         board_kernel,
         capsules_extra::ninedof::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::ninedof_component_static!(fxos8700));
 

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -32,13 +32,18 @@ mod litex_generated_constants;
 // short name.
 use litex_generated_constants as socc;
 
-/// Structure for dynamic interrupt mapping, depending on the SoC
-/// configuration
-///
-/// This struct is deliberately kept in the board crate. Because of
-/// the configurable nature of LiteX, it does not make sense to define
-/// a default interrupt mapping, as the interrupt numbers are
-/// generated sequentially for all softcores.
+// Structure for dynamic interrupt mapping, depending on the SoC
+// configuration
+//
+// This struct is deliberately kept in the board crate. Because of
+// the configurable nature of LiteX, it does not make sense to define
+// a default interrupt mapping, as the interrupt numbers are
+// generated sequentially for all softcores.
+kernel::declare_capability!(ProcessConsoleCap:
+    kernel::capabilities::ProcessManagementCapability,
+    kernel::capabilities::ProcessStartCapability
+);
+
 struct LiteXArtyInterruptablePeripherals {
     uart0: &'static litex_vexriscv::uart::LiteXUart<'static, socc::SoCRegisterFmt>,
     timer0: &'static litex_vexriscv::timer::LiteXTimer<
@@ -113,7 +118,7 @@ struct LiteXArty {
         'static,
         { capsules_core::process_console::DEFAULT_COMMAND_HISTORY_LEN },
         VirtualMuxAlarm<'static, AlarmHw>,
-        components::process_console::Capability,
+        ProcessConsoleCap,
     >,
     lldb: &'static capsules_core::low_level_debug::LowLevelDebug<
         'static,
@@ -452,8 +457,12 @@ unsafe fn start() -> (
         mux_alarm,
         process_printer,
         None,
+        ProcessConsoleCap,
     )
-    .finalize(components::process_console_component_static!(AlarmHw));
+    .finalize(components::process_console_component_static!(
+        AlarmHw,
+        ProcessConsoleCap
+    ));
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -32,18 +32,18 @@ mod litex_generated_constants;
 // short name.
 use litex_generated_constants as socc;
 
-// Structure for dynamic interrupt mapping, depending on the SoC
-// configuration
-//
-// This struct is deliberately kept in the board crate. Because of
-// the configurable nature of LiteX, it does not make sense to define
-// a default interrupt mapping, as the interrupt numbers are
-// generated sequentially for all softcores.
 kernel::declare_capability!(ProcessConsoleCap:
     kernel::capabilities::ProcessManagementCapability,
     kernel::capabilities::ProcessStartCapability
 );
 
+/// Structure for dynamic interrupt mapping, depending on the SoC
+/// configuration
+///
+/// This struct is deliberately kept in the board crate. Because of
+/// the configurable nature of LiteX, it does not make sense to define
+/// a default interrupt mapping, as the interrupt numbers are
+/// generated sequentially for all softcores.
 struct LiteXArtyInterruptablePeripherals {
     uart0: &'static litex_vexriscv::uart::LiteXUart<'static, socc::SoCRegisterFmt>,
     timer0: &'static litex_vexriscv::timer::LiteXTimer<
@@ -469,6 +469,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
 
@@ -488,6 +489,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::low_level_debug::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::low_level_debug_component_static!());
 

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -426,6 +426,7 @@ unsafe fn start() -> (
             30 => gpio0.get_gpio_pin(30).unwrap(),
             31 => gpio0.get_gpio_pin(31).unwrap(),
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(GPIOPin));
 
@@ -506,6 +507,7 @@ unsafe fn start() -> (
                 kernel::hil::gpio::FloatingState::PullNone
             ),
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::button_component_static!(GPIOPin));
 
@@ -556,6 +558,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
@@ -574,6 +577,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::low_level_debug::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::low_level_debug_component_static!());
 

--- a/boards/lora_e5_mini/src/main.rs
+++ b/boards/lora_e5_mini/src/main.rs
@@ -288,6 +288,7 @@ pub unsafe fn main() {
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(stm32wle5jc::tim2::Tim2));
 
@@ -298,6 +299,7 @@ pub unsafe fn main() {
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
 
@@ -344,6 +346,7 @@ pub unsafe fn main() {
         lora_spi_mux,
         chip_select,
         LORA_SPI_DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::spi_syscall_component_static!(
         stm32wle5jc::spi::Spi<'static>
@@ -379,6 +382,7 @@ pub unsafe fn main() {
             1 => lora_busy_pin,
             2 => lora_interrupt_pin,
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(
         stm32wle5jc::subghz_radio::SubGhzRadioVirtualGpio
@@ -402,6 +406,7 @@ pub unsafe fn main() {
         board_kernel,
         capsules_core::i2c_master::DRIVER_NUM,
         &base_peripherals.i2c2,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::i2c_master_driver_component_static!(
         stm32wle5jc::i2c::I2C

--- a/boards/lora_e5_mini/src/main.rs
+++ b/boards/lora_e5_mini/src/main.rs
@@ -413,15 +413,21 @@ pub unsafe fn main() {
     //--------------------------------------------------------------------
     // PROCESS CONSOLE
     //--------------------------------------------------------------------
+    kernel::declare_capability!(ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
+        ProcessConsoleCap,
     )
     .finalize(components::process_console_component_static!(
-        stm32wle5jc::tim2::Tim2
+        stm32wle5jc::tim2::Tim2,
+        ProcessConsoleCap
     ));
     let _ = process_console.start();
 

--- a/boards/lpc55s69-evk/src/main.rs
+++ b/boards/lpc55s69-evk/src/main.rs
@@ -363,15 +363,21 @@ unsafe fn start() -> (
         resources.printer.put(process_printer);
     });
 
+    kernel::declare_capability!(ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         None,
+        ProcessConsoleCap,
     )
     .finalize(components::process_console_component_static!(
-        lpc55s6x::ctimer0::LPCTimer
+        lpc55s6x::ctimer0::LPCTimer,
+        ProcessConsoleCap
     ));
     let _ = process_console.start();
 

--- a/boards/lpc55s69-evk/src/main.rs
+++ b/boards/lpc55s69-evk/src/main.rs
@@ -178,6 +178,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(
         lpc55s6x::ctimer0::LPCTimer
@@ -254,6 +255,7 @@ unsafe fn start() -> (
             63 => peripherals.pins.get_pin(lpc55s6x::gpio::LPCPin::P1_30),
             64 => peripherals.pins.get_pin(lpc55s6x::gpio::LPCPin::P1_31),
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(lpc55s6x::gpio::GpioPin));
 
@@ -270,6 +272,7 @@ unsafe fn start() -> (
                 kernel::hil::gpio::FloatingState::PullUp
             ),
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::button_component_static!(
         lpc55s6x::gpio::GpioPin
@@ -345,6 +348,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
 

--- a/boards/makepython-nrf52840/src/main.rs
+++ b/boards/makepython-nrf52840/src/main.rs
@@ -105,8 +105,7 @@ fn crc(s: &'static str) -> u32 {
 // SYSCALL DRIVER TYPE DEFINITIONS
 //------------------------------------------------------------------------------
 
-type AlarmHw = nrf52840::rtc::Rtc<'static>;
-type AlarmDriver = components::alarm::AlarmDriverComponentType<AlarmHw>;
+type AlarmDriver = components::alarm::AlarmDriverComponentType<nrf52840::rtc::Rtc<'static>>;
 
 type Screen = components::ssd1306::Ssd1306ComponentType<nrf52840::i2c::TWI<'static>>;
 type ScreenDriver = components::screen::ScreenSharedComponentType<Screen>;
@@ -121,13 +120,8 @@ type Ieee802154Driver = components::ieee802154::Ieee802154ComponentType<
 >;
 type RngDriver = components::rng::RngComponentType<nrf52840::trng::Trng<'static>>;
 
-type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
-
-//------------------------------------------------------------------------------
-// SYSCALL DRIVER TYPE DEFINITIONS
-//------------------------------------------------------------------------------
-
 type BleHw = nrf52840::ble_radio::Radio<'static>;
+type AlarmHw = nrf52840::rtc::Rtc<'static>;
 type GpioHw = nrf52::gpio::GPIOPin<'static>;
 type Nrf52840GpioHw = nrf52840::gpio::GPIOPin<'static>;
 type LedHw = kernel::hil::led::LedLow<'static, nrf52::gpio::GPIOPin<'static>>;
@@ -138,8 +132,16 @@ type LedDriver = components::led::LedsComponentType<LedHw, 1>;
 type ButtonDriver = components::button::ButtonComponentType<Nrf52840GpioHw>;
 type ConsoleDriver = components::console::ConsoleComponentType;
 type AdcDriver = components::adc::AdcVirtualComponentType;
-type ProcessConsoleDriver = components::process_console::ProcessConsoleComponentType<AlarmHw>;
+type ProcessConsoleDriver =
+    components::process_console::ProcessConsoleComponentType<AlarmHw, ProcessConsoleCap>;
 type UdpDriver = components::udp_driver::UDPDriverComponentType;
+
+type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
+
+kernel::declare_capability!(ProcessConsoleCap:
+    kernel::capabilities::ProcessManagementCapability,
+    kernel::capabilities::ProcessStartCapability
+);
 
 /// Supported drivers by the platform
 pub struct Platform {
@@ -325,21 +327,21 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::gpio::DRIVER_NUM,
         components::gpio_component_helper!(
-            Nrf52840GpioHw,
+            nrf52840::gpio::GPIOPin,
             0 => &nrf52840_peripherals.gpio_port[GPIO_D0],
             1 => &nrf52840_peripherals.gpio_port[GPIO_D1],
             2 => &nrf52840_peripherals.gpio_port[GPIO_D2],
             3 => &nrf52840_peripherals.gpio_port[GPIO_D3],
         ),
     )
-    .finalize(components::gpio_component_static!(Nrf52840GpioHw));
+    .finalize(components::gpio_component_static!(nrf52840::gpio::GPIOPin));
 
     //--------------------------------------------------------------------------
     // LEDs
     //--------------------------------------------------------------------------
 
     let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
-        LedLow<'static, Nrf52840GpioHw>,
+        LedLow<'static, nrf52840::gpio::GPIOPin>,
         LedLow::new(&nrf52840_peripherals.gpio_port[LED_PIN]),
     ));
 
@@ -351,7 +353,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::button::DRIVER_NUM,
         components::button_component_helper!(
-            Nrf52840GpioHw,
+            nrf52840::gpio::GPIOPin,
             (
                 &nrf52840_peripherals.gpio_port[BUTTON_PIN],
                 kernel::hil::gpio::ActivationMode::ActiveLow,
@@ -359,7 +361,9 @@ pub unsafe fn start() -> (
             )
         ),
     )
-    .finalize(components::button_component_static!(Nrf52840GpioHw));
+    .finalize(components::button_component_static!(
+        nrf52840::gpio::GPIOPin
+    ));
 
     //--------------------------------------------------------------------------
     // ALARM & TIMER
@@ -429,9 +433,11 @@ pub unsafe fn start() -> (
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
+        ProcessConsoleCap,
     )
     .finalize(components::process_console_component_static!(
-        nrf52::rtc::Rtc<'static>
+        nrf52::rtc::Rtc<'static>,
+        ProcessConsoleCap
     ));
 
     // Setup the console.
@@ -597,7 +603,10 @@ pub unsafe fn start() -> (
         &base_peripherals.ble_radio,
         mux_alarm,
     )
-    .finalize(components::ble_component_static!(AlarmHw, BleHw));
+    .finalize(components::ble_component_static!(
+        nrf52840::rtc::Rtc,
+        nrf52840::ble_radio::Radio
+    ));
 
     use capsules_extra::net::ieee802154::MacAddress;
 
@@ -650,11 +659,12 @@ pub unsafe fn start() -> (
         mux_alarm,
     )
     .finalize(components::udp_mux_component_static!(
-        AlarmHw,
+        nrf52840::rtc::Rtc,
         Ieee802154MacDevice
     ));
 
     // UDP driver initialization happens here
+    kernel::declare_capability!(UdpDriverCap: kernel::capabilities::UdpDriverCapability);
     let udp_driver = components::udp_driver::UDPDriverComponent::new(
         board_kernel,
         capsules_extra::net::udp::DRIVER_NUM,
@@ -662,8 +672,12 @@ pub unsafe fn start() -> (
         udp_recv_mux,
         udp_port_table,
         local_ip_ifaces,
+        UdpDriverCap,
     )
-    .finalize(components::udp_driver_component_static!(AlarmHw));
+    .finalize(components::udp_driver_component_static!(
+        nrf52840::rtc::Rtc,
+        UdpDriverCap
+    ));
 
     //--------------------------------------------------------------------------
     // APP ID CHECKING
@@ -689,14 +703,18 @@ pub unsafe fn start() -> (
     // STORAGE PERMISSIONS
     //--------------------------------------------------------------------------
 
+    kernel::declare_capability!(AppStoreCap: kernel::capabilities::ApplicationStorageCapability);
     let storage_permissions_policy =
-        components::storage_permissions::individual::StoragePermissionsIndividualComponent::new()
-            .finalize(
-                components::storage_permissions_individual_component_static!(
-                    nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
-                    kernel::process::ProcessStandardDebugFull,
-                ),
-            );
+        components::storage_permissions::individual::StoragePermissionsIndividualComponent::new(
+            AppStoreCap,
+        )
+        .finalize(
+            components::storage_permissions_individual_component_static!(
+                nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
+                kernel::process::ProcessStandardDebugFull,
+                AppStoreCap,
+            ),
+        );
 
     //--------------------------------------------------------------------------
     // PROCESS LOADING

--- a/boards/makepython-nrf52840/src/main.rs
+++ b/boards/makepython-nrf52840/src/main.rs
@@ -105,7 +105,8 @@ fn crc(s: &'static str) -> u32 {
 // SYSCALL DRIVER TYPE DEFINITIONS
 //------------------------------------------------------------------------------
 
-type AlarmDriver = components::alarm::AlarmDriverComponentType<nrf52840::rtc::Rtc<'static>>;
+type AlarmHw = nrf52840::rtc::Rtc<'static>;
+type AlarmDriver = components::alarm::AlarmDriverComponentType<AlarmHw>;
 
 type Screen = components::ssd1306::Ssd1306ComponentType<nrf52840::i2c::TWI<'static>>;
 type ScreenDriver = components::screen::ScreenSharedComponentType<Screen>;
@@ -120,8 +121,13 @@ type Ieee802154Driver = components::ieee802154::Ieee802154ComponentType<
 >;
 type RngDriver = components::rng::RngComponentType<nrf52840::trng::Trng<'static>>;
 
+type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
+
+//------------------------------------------------------------------------------
+// SYSCALL DRIVER TYPE DEFINITIONS
+//------------------------------------------------------------------------------
+
 type BleHw = nrf52840::ble_radio::Radio<'static>;
-type AlarmHw = nrf52840::rtc::Rtc<'static>;
 type GpioHw = nrf52::gpio::GPIOPin<'static>;
 type Nrf52840GpioHw = nrf52840::gpio::GPIOPin<'static>;
 type LedHw = kernel::hil::led::LedLow<'static, nrf52::gpio::GPIOPin<'static>>;
@@ -135,8 +141,6 @@ type AdcDriver = components::adc::AdcVirtualComponentType;
 type ProcessConsoleDriver =
     components::process_console::ProcessConsoleComponentType<AlarmHw, ProcessConsoleCap>;
 type UdpDriver = components::udp_driver::UDPDriverComponentType;
-
-type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
 
 kernel::declare_capability!(ProcessConsoleCap:
     kernel::capabilities::ProcessManagementCapability,
@@ -327,21 +331,22 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::gpio::DRIVER_NUM,
         components::gpio_component_helper!(
-            nrf52840::gpio::GPIOPin,
+            Nrf52840GpioHw,
             0 => &nrf52840_peripherals.gpio_port[GPIO_D0],
             1 => &nrf52840_peripherals.gpio_port[GPIO_D1],
             2 => &nrf52840_peripherals.gpio_port[GPIO_D2],
             3 => &nrf52840_peripherals.gpio_port[GPIO_D3],
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
-    .finalize(components::gpio_component_static!(nrf52840::gpio::GPIOPin));
+    .finalize(components::gpio_component_static!(Nrf52840GpioHw));
 
     //--------------------------------------------------------------------------
     // LEDs
     //--------------------------------------------------------------------------
 
     let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
-        LedLow<'static, nrf52840::gpio::GPIOPin>,
+        LedLow<'static, Nrf52840GpioHw>,
         LedLow::new(&nrf52840_peripherals.gpio_port[LED_PIN]),
     ));
 
@@ -353,17 +358,16 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::button::DRIVER_NUM,
         components::button_component_helper!(
-            nrf52840::gpio::GPIOPin,
+            Nrf52840GpioHw,
             (
                 &nrf52840_peripherals.gpio_port[BUTTON_PIN],
                 kernel::hil::gpio::ActivationMode::ActiveLow,
                 kernel::hil::gpio::FloatingState::PullUp
             )
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
-    .finalize(components::button_component_static!(
-        nrf52840::gpio::GPIOPin
-    ));
+    .finalize(components::button_component_static!(Nrf52840GpioHw));
 
     //--------------------------------------------------------------------------
     // ALARM & TIMER
@@ -378,6 +382,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(nrf52::rtc::Rtc));
 
@@ -445,6 +450,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
@@ -464,6 +470,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::rng::DRIVER_NUM,
         &base_peripherals.trng,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::rng_component_static!(nrf52840::trng::Trng));
 
@@ -475,58 +482,61 @@ pub unsafe fn start() -> (
     let adc_mux = components::adc::AdcMuxComponent::new(&base_peripherals.adc)
         .finalize(components::adc_mux_component_static!(nrf52840::adc::Adc));
 
-    let adc_syscall =
-        components::adc::AdcVirtualComponent::new(board_kernel, capsules_core::adc::DRIVER_NUM)
-            .finalize(components::adc_syscall_component_helper!(
-                // A0
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput2)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // A1
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput3)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // A2
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput6)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // A3
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput5)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // A4
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput7)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // A5
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput0)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // A6
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput4)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // A7
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput1)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-            ));
+    let adc_syscall = components::adc::AdcVirtualComponent::new(
+        board_kernel,
+        capsules_core::adc::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
+    )
+    .finalize(components::adc_syscall_component_helper!(
+        // A0
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput2)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // A1
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput3)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // A2
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput6)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // A3
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput5)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // A4
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput7)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // A5
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput0)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // A6
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput4)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // A7
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput1)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+    ));
 
     //--------------------------------------------------------------------------
     // SCREEN
@@ -590,6 +600,7 @@ pub unsafe fn start() -> (
         capsules_extra::screen::screen::DRIVER_NUM,
         ssd1306,
         apps_regions,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::screen_shared_component_static!(1032, Screen));
 
@@ -602,11 +613,9 @@ pub unsafe fn start() -> (
         capsules_extra::ble_advertising_driver::DRIVER_NUM,
         &base_peripherals.ble_radio,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
-    .finalize(components::ble_component_static!(
-        nrf52840::rtc::Rtc,
-        nrf52840::ble_radio::Radio
-    ));
+    .finalize(components::ble_component_static!(AlarmHw, BleHw));
 
     use capsules_extra::net::ieee802154::MacAddress;
 
@@ -625,6 +634,7 @@ pub unsafe fn start() -> (
         PAN_ID,
         device_id_bottom_16,
         device_id,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::ieee802154_component_static!(
         nrf52840::ieee802154_radio::Radio,
@@ -657,9 +667,11 @@ pub unsafe fn start() -> (
         MacAddress::Short(device_id_bottom_16),
         local_ip_ifaces,
         mux_alarm,
+        create_capability!(capabilities::NetworkCapabilityCreationCapability),
+        create_capability!(capabilities::CreatePortTableCapability),
     )
     .finalize(components::udp_mux_component_static!(
-        nrf52840::rtc::Rtc,
+        AlarmHw,
         Ieee802154MacDevice
     ));
 
@@ -673,9 +685,11 @@ pub unsafe fn start() -> (
         udp_port_table,
         local_ip_ifaces,
         UdpDriverCap,
+        create_capability!(capabilities::MemoryAllocationCapability),
+        create_capability!(capabilities::NetworkCapabilityCreationCapability),
     )
     .finalize(components::udp_driver_component_static!(
-        nrf52840::rtc::Rtc,
+        AlarmHw,
         UdpDriverCap
     ));
 
@@ -751,6 +765,7 @@ pub unsafe fn start() -> (
         storage_permissions_policy,
         app_flash,
         app_memory,
+        create_capability!(capabilities::ProcessManagementCapability),
     )
     .finalize(components::process_loader_sequential_component_static!(
         nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -671,14 +671,22 @@ unsafe fn start() -> (
         resources.printer.put(process_printer);
     });
 
+    kernel::declare_capability!(ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let _process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
+        ProcessConsoleCap,
     )
-    .finalize(components::process_console_component_static!(AlarmHw));
+    .finalize(components::process_console_component_static!(
+        nrf52833::rtc::Rtc,
+        ProcessConsoleCap
+    ));
     let _ = _process_console.start();
 
     //--------------------------------------------------------------------------

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -271,6 +271,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_extra::ieee802154::DRIVER_NUM,
         &nrf52833_peripherals.ieee802154_radio,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::ieee802154_raw_component_static!(
         nrf52833::ieee802154_radio::Radio,
@@ -319,6 +320,7 @@ unsafe fn start() -> (
             9 => &nrf52833_peripherals.gpio_port[GPIO_P9],
             16 => &nrf52833_peripherals.gpio_port[GPIO_P16],
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(nrf52833::gpio::GPIOPin));
 
@@ -346,6 +348,7 @@ unsafe fn start() -> (
                 kernel::hil::gpio::FloatingState::PullNone
             ), // Touch Logo
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::button_component_static!(
         nrf52833::gpio::GPIOPin
@@ -364,6 +367,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(nrf52::rtc::Rtc));
 
@@ -385,6 +389,7 @@ unsafe fn start() -> (
         capsules_extra::buzzer_driver::DRIVER_NUM,
         mux_alarm,
         virtual_pwm_buzzer,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::buzzer_component_static!(AlarmHw, PwmHw));
 
@@ -392,9 +397,12 @@ unsafe fn start() -> (
         components::pwm::PwmPinUserComponent::new(mux_pwm, nrf52833::pinmux::Pinmux::new(GPIO_P8))
             .finalize(components::pwm_pin_user_component_static!(PwmHw));
 
-    let pwm =
-        components::pwm::PwmDriverComponent::new(board_kernel, capsules_extra::pwm::DRIVER_NUM)
-            .finalize(components::pwm_driver_component_helper!(virtual_pwm_driver));
+    let pwm = components::pwm::PwmDriverComponent::new(
+        board_kernel,
+        capsules_extra::pwm::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
+    )
+    .finalize(components::pwm_driver_component_helper!(virtual_pwm_driver));
 
     //--------------------------------------------------------------------------
     // UART & CONSOLE & DEBUG
@@ -416,6 +424,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
@@ -435,6 +444,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::rng::DRIVER_NUM,
         &base_peripherals.trng,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::rng_component_static!(nrf52833::trng::Trng));
 
@@ -458,6 +468,7 @@ unsafe fn start() -> (
         None,
         board_kernel,
         capsules_extra::lsm303agr::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::lsm303agr_component_static!(I2cHw));
 
@@ -476,6 +487,7 @@ unsafe fn start() -> (
     let ninedof = components::ninedof::NineDofComponent::new(
         board_kernel,
         capsules_extra::ninedof::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::ninedof_component_static!(lsm303agr));
 
@@ -485,6 +497,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,
         &base_peripherals.temp,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::temperature_component_static!(
         nrf52833::temperature::Temp
@@ -499,28 +512,31 @@ unsafe fn start() -> (
         .finalize(components::adc_mux_component_static!(nrf52833::adc::Adc));
 
     // Comment out the following to use P0, P1 and P2 as GPIO
-    let adc_syscall =
-        components::adc::AdcVirtualComponent::new(board_kernel, capsules_core::adc::DRIVER_NUM)
-            .finalize(components::adc_syscall_component_helper!(
-                // ADC Ring 0 (P0)
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52833::adc::AdcChannelSetup::new(nrf52833::adc::AdcChannel::AnalogInput0)
-                )
-                .finalize(components::adc_component_static!(nrf52833::adc::Adc)),
-                // ADC Ring 1 (P1)
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52833::adc::AdcChannelSetup::new(nrf52833::adc::AdcChannel::AnalogInput1)
-                )
-                .finalize(components::adc_component_static!(nrf52833::adc::Adc)),
-                // ADC Ring 2 (P2)
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52833::adc::AdcChannelSetup::new(nrf52833::adc::AdcChannel::AnalogInput2)
-                )
-                .finalize(components::adc_component_static!(nrf52833::adc::Adc))
-            ));
+    let adc_syscall = components::adc::AdcVirtualComponent::new(
+        board_kernel,
+        capsules_core::adc::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
+    )
+    .finalize(components::adc_syscall_component_helper!(
+        // ADC Ring 0 (P0)
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52833::adc::AdcChannelSetup::new(nrf52833::adc::AdcChannel::AnalogInput0)
+        )
+        .finalize(components::adc_component_static!(nrf52833::adc::Adc)),
+        // ADC Ring 1 (P1)
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52833::adc::AdcChannelSetup::new(nrf52833::adc::AdcChannel::AnalogInput1)
+        )
+        .finalize(components::adc_component_static!(nrf52833::adc::Adc)),
+        // ADC Ring 2 (P2)
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52833::adc::AdcChannelSetup::new(nrf52833::adc::AdcChannel::AnalogInput2)
+        )
+        .finalize(components::adc_component_static!(nrf52833::adc::Adc))
+    ));
 
     // Microphone
 
@@ -550,6 +566,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_extra::sound_pressure::DRIVER_NUM,
         adc_microphone,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::sound_pressure_component_static!());
 
@@ -571,6 +588,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_extra::app_flash_driver::DRIVER_NUM,
         virtual_app_flash,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::app_flash_component_static!(
         capsules_core::virtualizers::virtual_flash::FlashUser<'static, nrf52833::nvmc::Nvmc>,
@@ -586,6 +604,7 @@ unsafe fn start() -> (
         capsules_extra::ble_advertising_driver::DRIVER_NUM,
         &base_peripherals.ble_radio,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::ble_component_static!(
         AlarmHw,
@@ -684,7 +703,7 @@ unsafe fn start() -> (
         ProcessConsoleCap,
     )
     .finalize(components::process_console_component_static!(
-        nrf52833::rtc::Rtc,
+        AlarmHw,
         ProcessConsoleCap
     ));
     let _ = _process_console.start();

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -278,6 +278,7 @@ unsafe fn start() -> (
                 kernel::hil::gpio::FloatingState::PullUp
             )
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::button_component_static!(msp432::gpio::IntPin));
 
@@ -341,6 +342,7 @@ unsafe fn start() -> (
             // 33 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P05_2 as usize], // A3
             34 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P03_6 as usize]
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(
         msp432::gpio::IntPin<'static>
@@ -359,6 +361,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
@@ -379,6 +382,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(msp432::timer::TimerA));
 
@@ -419,6 +423,7 @@ unsafe fn start() -> (
         adc_channels,
         board_kernel,
         capsules_core::adc::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::adc_dedicated_component_static!(
         msp432::adc::Adc

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -128,6 +128,12 @@ type Ieee802154Driver = components::ieee802154::Ieee802154ComponentType<
 >;
 type RngDriver = components::rng::RngComponentType<nrf52840::trng::Trng<'static>>;
 
+type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
+
+//------------------------------------------------------------------------------
+// SYSCALL DRIVER TYPE DEFINITIONS
+//------------------------------------------------------------------------------
+
 type BleHw = nrf52840::ble_radio::Radio<'static>;
 type AlarmHw = nrf52840::rtc::Rtc<'static>;
 type GpioHw = nrf52::gpio::GPIOPin<'static>;
@@ -143,8 +149,6 @@ type AdcDriver = components::adc::AdcVirtualComponentType;
 type ProcessConsoleDriver =
     components::process_console::ProcessConsoleComponentType<AlarmHw, ProcessConsoleCap>;
 type UdpDriver = components::udp_driver::UDPDriverComponentType;
-
-type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
 
 kernel::declare_capability!(ProcessConsoleCap:
     kernel::capabilities::ProcessManagementCapability,
@@ -332,6 +336,7 @@ pub unsafe fn start() -> (
             9 => &nrf52840_peripherals.gpio_port[GPIO_D9],
             10 => &nrf52840_peripherals.gpio_port[GPIO_D10]
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(nrf52840::gpio::GPIOPin));
 
@@ -359,6 +364,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(nrf52::rtc::Rtc));
 
@@ -426,6 +432,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
@@ -445,6 +452,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::rng::DRIVER_NUM,
         &base_peripherals.trng,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::rng_component_static!(nrf52840::trng::Trng));
 
@@ -456,58 +464,61 @@ pub unsafe fn start() -> (
     let adc_mux = components::adc::AdcMuxComponent::new(&base_peripherals.adc)
         .finalize(components::adc_mux_component_static!(nrf52840::adc::Adc));
 
-    let adc_syscall =
-        components::adc::AdcVirtualComponent::new(board_kernel, capsules_core::adc::DRIVER_NUM)
-            .finalize(components::adc_syscall_component_helper!(
-                // A0
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput2)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // A1
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput3)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // A2
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput6)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // A3
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput5)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // A4
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput7)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // A5
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput0)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // A6
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput4)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // A7
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput1)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-            ));
+    let adc_syscall = components::adc::AdcVirtualComponent::new(
+        board_kernel,
+        capsules_core::adc::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
+    )
+    .finalize(components::adc_syscall_component_helper!(
+        // A0
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput2)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // A1
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput3)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // A2
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput6)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // A3
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput5)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // A4
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput7)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // A5
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput0)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // A6
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput4)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // A7
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput1)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+    ));
 
     //--------------------------------------------------------------------------
     // SENSORS
@@ -533,6 +544,7 @@ pub unsafe fn start() -> (
         apds9960,
         board_kernel,
         capsules_extra::proximity::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::proximity_component_static!());
 
@@ -542,12 +554,14 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,
         hts221,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::temperature_component_static!(HTS221Sensor));
     let humidity = components::humidity::HumidityComponent::new(
         board_kernel,
         capsules_extra::humidity::DRIVER_NUM,
         hts221,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::humidity_component_static!(HTS221Sensor));
 
@@ -560,11 +574,9 @@ pub unsafe fn start() -> (
         capsules_extra::ble_advertising_driver::DRIVER_NUM,
         &base_peripherals.ble_radio,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
-    .finalize(components::ble_component_static!(
-        nrf52840::rtc::Rtc,
-        nrf52840::ble_radio::Radio
-    ));
+    .finalize(components::ble_component_static!(AlarmHw, BleHw));
 
     use capsules_extra::net::ieee802154::MacAddress;
 
@@ -583,6 +595,7 @@ pub unsafe fn start() -> (
         PAN_ID,
         device_id_bottom_16,
         device_id,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::ieee802154_component_static!(
         nrf52840::ieee802154_radio::Radio,
@@ -615,9 +628,11 @@ pub unsafe fn start() -> (
         MacAddress::Short(device_id_bottom_16),
         local_ip_ifaces,
         mux_alarm,
+        create_capability!(capabilities::NetworkCapabilityCreationCapability),
+        create_capability!(capabilities::CreatePortTableCapability),
     )
     .finalize(components::udp_mux_component_static!(
-        nrf52840::rtc::Rtc,
+        AlarmHw,
         Ieee802154MacDevice
     ));
 
@@ -631,9 +646,11 @@ pub unsafe fn start() -> (
         udp_port_table,
         local_ip_ifaces,
         UdpDriverCap,
+        create_capability!(capabilities::MemoryAllocationCapability),
+        create_capability!(capabilities::NetworkCapabilityCreationCapability),
     )
     .finalize(components::udp_driver_component_static!(
-        nrf52840::rtc::Rtc,
+        AlarmHw,
         UdpDriverCap
     ));
 

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -128,12 +128,6 @@ type Ieee802154Driver = components::ieee802154::Ieee802154ComponentType<
 >;
 type RngDriver = components::rng::RngComponentType<nrf52840::trng::Trng<'static>>;
 
-type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
-
-//------------------------------------------------------------------------------
-// SYSCALL DRIVER TYPE DEFINITIONS
-//------------------------------------------------------------------------------
-
 type BleHw = nrf52840::ble_radio::Radio<'static>;
 type AlarmHw = nrf52840::rtc::Rtc<'static>;
 type GpioHw = nrf52::gpio::GPIOPin<'static>;
@@ -146,8 +140,16 @@ type LedDriver = components::led::LedsComponentType<LedHw, 3>;
 type ConsoleDriver = components::console::ConsoleComponentType;
 type ProximityDriver = components::proximity::ProximityComponentType;
 type AdcDriver = components::adc::AdcVirtualComponentType;
-type ProcessConsoleDriver = components::process_console::ProcessConsoleComponentType<AlarmHw>;
+type ProcessConsoleDriver =
+    components::process_console::ProcessConsoleComponentType<AlarmHw, ProcessConsoleCap>;
 type UdpDriver = components::udp_driver::UDPDriverComponentType;
+
+type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
+
+kernel::declare_capability!(ProcessConsoleCap:
+    kernel::capabilities::ProcessManagementCapability,
+    kernel::capabilities::ProcessStartCapability
+);
 
 /// Supported drivers by the platform
 pub struct Platform {
@@ -412,9 +414,11 @@ pub unsafe fn start() -> (
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
+        ProcessConsoleCap,
     )
     .finalize(components::process_console_component_static!(
-        nrf52::rtc::Rtc<'static>
+        nrf52::rtc::Rtc<'static>,
+        ProcessConsoleCap
     ));
 
     // Setup the console.
@@ -557,7 +561,10 @@ pub unsafe fn start() -> (
         &base_peripherals.ble_radio,
         mux_alarm,
     )
-    .finalize(components::ble_component_static!(AlarmHw, BleHw));
+    .finalize(components::ble_component_static!(
+        nrf52840::rtc::Rtc,
+        nrf52840::ble_radio::Radio
+    ));
 
     use capsules_extra::net::ieee802154::MacAddress;
 
@@ -610,11 +617,12 @@ pub unsafe fn start() -> (
         mux_alarm,
     )
     .finalize(components::udp_mux_component_static!(
-        AlarmHw,
+        nrf52840::rtc::Rtc,
         Ieee802154MacDevice
     ));
 
     // UDP driver initialization happens here
+    kernel::declare_capability!(UdpDriverCap: kernel::capabilities::UdpDriverCapability);
     let udp_driver = components::udp_driver::UDPDriverComponent::new(
         board_kernel,
         capsules_extra::net::udp::DRIVER_NUM,
@@ -622,8 +630,12 @@ pub unsafe fn start() -> (
         udp_recv_mux,
         udp_port_table,
         local_ip_ifaces,
+        UdpDriverCap,
     )
-    .finalize(components::udp_driver_component_static!(AlarmHw));
+    .finalize(components::udp_driver_component_static!(
+        nrf52840::rtc::Rtc,
+        UdpDriverCap
+    ));
 
     //--------------------------------------------------------------------------
     // FINAL SETUP AND BOARD BOOT

--- a/boards/nano33ble_rev2/src/main.rs
+++ b/boards/nano33ble_rev2/src/main.rs
@@ -111,16 +111,6 @@ fn baud_rate_reset_bootloader_enter() {
     }
 }
 
-type BleHw = nrf52840::ble_radio::Radio<'static>;
-type AlarmHw = nrf52840::rtc::Rtc<'static>;
-type GpioHw = nrf52::gpio::GPIOPin<'static>;
-type LedHw = kernel::hil::led::LedLow<'static, nrf52::gpio::GPIOPin<'static>>;
-type I2cHw = nrf52840::i2c::TWI<'static>;
-type Lps22hbSensor = capsules_extra::lps22hb::Lps22hb<
-    'static,
-    capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, I2cHw>,
->;
-
 type HS3003Sensor = components::hs3003::Hs3003ComponentType<
     capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, I2cHw>,
 >;
@@ -136,6 +126,22 @@ type Ieee802154Driver = components::ieee802154::Ieee802154ComponentType<
 >;
 type RngDriver = components::rng::RngComponentType<nrf52840::trng::Trng<'static>>;
 
+type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
+
+//------------------------------------------------------------------------------
+// SYSCALL DRIVER TYPE DEFINITIONS
+//------------------------------------------------------------------------------
+
+type BleHw = nrf52840::ble_radio::Radio<'static>;
+type AlarmHw = nrf52840::rtc::Rtc<'static>;
+type GpioHw = nrf52::gpio::GPIOPin<'static>;
+type LedHw = kernel::hil::led::LedLow<'static, nrf52::gpio::GPIOPin<'static>>;
+type I2cHw = nrf52840::i2c::TWI<'static>;
+type Lps22hbSensor = capsules_extra::lps22hb::Lps22hb<
+    'static,
+    capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, I2cHw>,
+>;
+
 type BleDriver = components::ble::BLEComponentType<BleHw, AlarmHw>;
 type AlarmDriver = components::alarm::AlarmDriverComponentType<AlarmHw>;
 type GpioDriver = components::gpio::GpioComponentType<GpioHw>;
@@ -147,8 +153,6 @@ type ProcessConsoleDriver =
     components::process_console::ProcessConsoleComponentType<AlarmHw, ProcessConsoleCap>;
 type PressureDriver = capsules_extra::pressure::PressureSensor<'static, Lps22hbSensor>;
 type UdpDriver = components::udp_driver::UDPDriverComponentType;
-
-type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
 
 kernel::declare_capability!(ProcessConsoleCap:
     kernel::capabilities::ProcessManagementCapability,
@@ -338,6 +342,7 @@ pub unsafe fn start() -> (
             9 => &nrf52840_peripherals.gpio_port[GPIO_D9],
             10 => &nrf52840_peripherals.gpio_port[GPIO_D10]
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(nrf52840::gpio::GPIOPin));
 
@@ -365,6 +370,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(nrf52::rtc::Rtc));
 
@@ -432,6 +438,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
@@ -451,6 +458,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::rng::DRIVER_NUM,
         &base_peripherals.trng,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::rng_component_static!(nrf52840::trng::Trng));
 
@@ -462,65 +470,68 @@ pub unsafe fn start() -> (
     let adc_mux = components::adc::AdcMuxComponent::new(&base_peripherals.adc)
         .finalize(components::adc_mux_component_static!(nrf52840::adc::Adc));
 
-    let adc_syscall =
-        components::adc::AdcVirtualComponent::new(board_kernel, capsules_core::adc::DRIVER_NUM)
-            .finalize(components::adc_syscall_component_helper!(
-                // A0
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput2)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // A1
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput3)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // A2
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput6)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // A3
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput5)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // A4
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput7)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // A5
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput0)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // A6
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput4)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // A7
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput1)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-            ));
+    let adc_syscall = components::adc::AdcVirtualComponent::new(
+        board_kernel,
+        capsules_core::adc::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
+    )
+    .finalize(components::adc_syscall_component_helper!(
+        // A0
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput2)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // A1
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput3)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // A2
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput6)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // A3
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput5)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // A4
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput7)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // A5
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput0)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // A6
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput4)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // A7
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput1)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+    ));
 
     //--------------------------------------------------------------------------
     // SENSORS
     //--------------------------------------------------------------------------
 
     let sensors_i2c_bus = components::i2c::I2CMuxComponent::new(&base_peripherals.twi1, None)
-        .finalize(components::i2c_mux_component_static!(nrf52840::i2c::TWI));
+        .finalize(components::i2c_mux_component_static!(I2cHw));
     base_peripherals.twi1.configure(
         nrf52840::pinmux::Pinmux::new(I2C_SCL_PIN),
         nrf52840::pinmux::Pinmux::new(I2C_SDA_PIN),
@@ -534,40 +545,44 @@ pub unsafe fn start() -> (
         0x39,
         &nrf52840_peripherals.gpio_port[APDS9960_PIN],
     )
-    .finalize(components::apds9960_component_static!(nrf52840::i2c::TWI));
+    .finalize(components::apds9960_component_static!(I2cHw));
     let proximity = components::proximity::ProximityComponent::new(
         apds9960,
         board_kernel,
         capsules_extra::proximity::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::proximity_component_static!());
 
     let lps22hb = components::lps22hb::Lps22hbComponent::new(sensors_i2c_bus, 0x5C)
-        .finalize(components::lps22hb_component_static!(nrf52840::i2c::TWI));
+        .finalize(components::lps22hb_component_static!(I2cHw));
     let pressure = components::pressure::PressureComponent::new(
         board_kernel,
         capsules_extra::pressure::DRIVER_NUM,
         lps22hb,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::pressure_component_static!(
         capsules_extra::lps22hb::Lps22hb<
             'static,
-            capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, nrf52840::i2c::TWI>,
+            capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, I2cHw>,
         >
     ));
 
     let hs3003 = components::hs3003::Hs3003Component::new(sensors_i2c_bus, 0x44)
-        .finalize(components::hs3003_component_static!(nrf52840::i2c::TWI));
+        .finalize(components::hs3003_component_static!(I2cHw));
     let temperature = components::temperature::TemperatureComponent::new(
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,
         hs3003,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::temperature_component_static!(HS3003Sensor));
     let humidity = components::humidity::HumidityComponent::new(
         board_kernel,
         capsules_extra::humidity::DRIVER_NUM,
         hs3003,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::humidity_component_static!(HS3003Sensor));
 
@@ -580,11 +595,9 @@ pub unsafe fn start() -> (
         capsules_extra::ble_advertising_driver::DRIVER_NUM,
         &base_peripherals.ble_radio,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
-    .finalize(components::ble_component_static!(
-        nrf52840::rtc::Rtc,
-        nrf52840::ble_radio::Radio
-    ));
+    .finalize(components::ble_component_static!(AlarmHw, BleHw));
 
     use capsules_extra::net::ieee802154::MacAddress;
 
@@ -603,6 +616,7 @@ pub unsafe fn start() -> (
         PAN_ID,
         device_id_bottom_16,
         device_id,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::ieee802154_component_static!(
         nrf52840::ieee802154_radio::Radio,
@@ -635,9 +649,11 @@ pub unsafe fn start() -> (
         MacAddress::Short(device_id_bottom_16),
         local_ip_ifaces,
         mux_alarm,
+        create_capability!(capabilities::NetworkCapabilityCreationCapability),
+        create_capability!(capabilities::CreatePortTableCapability),
     )
     .finalize(components::udp_mux_component_static!(
-        nrf52840::rtc::Rtc,
+        AlarmHw,
         Ieee802154MacDevice
     ));
 
@@ -651,9 +667,11 @@ pub unsafe fn start() -> (
         udp_port_table,
         local_ip_ifaces,
         UdpDriverCap,
+        create_capability!(capabilities::MemoryAllocationCapability),
+        create_capability!(capabilities::NetworkCapabilityCreationCapability),
     )
     .finalize(components::udp_driver_component_static!(
-        nrf52840::rtc::Rtc,
+        AlarmHw,
         UdpDriverCap
     ));
 

--- a/boards/nano33ble_rev2/src/main.rs
+++ b/boards/nano33ble_rev2/src/main.rs
@@ -111,6 +111,16 @@ fn baud_rate_reset_bootloader_enter() {
     }
 }
 
+type BleHw = nrf52840::ble_radio::Radio<'static>;
+type AlarmHw = nrf52840::rtc::Rtc<'static>;
+type GpioHw = nrf52::gpio::GPIOPin<'static>;
+type LedHw = kernel::hil::led::LedLow<'static, nrf52::gpio::GPIOPin<'static>>;
+type I2cHw = nrf52840::i2c::TWI<'static>;
+type Lps22hbSensor = capsules_extra::lps22hb::Lps22hb<
+    'static,
+    capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, I2cHw>,
+>;
+
 type HS3003Sensor = components::hs3003::Hs3003ComponentType<
     capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, I2cHw>,
 >;
@@ -126,22 +136,6 @@ type Ieee802154Driver = components::ieee802154::Ieee802154ComponentType<
 >;
 type RngDriver = components::rng::RngComponentType<nrf52840::trng::Trng<'static>>;
 
-type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
-
-//------------------------------------------------------------------------------
-// SYSCALL DRIVER TYPE DEFINITIONS
-//------------------------------------------------------------------------------
-
-type BleHw = nrf52840::ble_radio::Radio<'static>;
-type AlarmHw = nrf52840::rtc::Rtc<'static>;
-type GpioHw = nrf52::gpio::GPIOPin<'static>;
-type LedHw = kernel::hil::led::LedLow<'static, nrf52::gpio::GPIOPin<'static>>;
-type I2cHw = nrf52840::i2c::TWI<'static>;
-type Lps22hbSensor = capsules_extra::lps22hb::Lps22hb<
-    'static,
-    capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, I2cHw>,
->;
-
 type BleDriver = components::ble::BLEComponentType<BleHw, AlarmHw>;
 type AlarmDriver = components::alarm::AlarmDriverComponentType<AlarmHw>;
 type GpioDriver = components::gpio::GpioComponentType<GpioHw>;
@@ -149,9 +143,17 @@ type LedDriver = components::led::LedsComponentType<LedHw, 3>;
 type ConsoleDriver = components::console::ConsoleComponentType;
 type ProximityDriver = components::proximity::ProximityComponentType;
 type AdcDriver = components::adc::AdcVirtualComponentType;
-type ProcessConsoleDriver = components::process_console::ProcessConsoleComponentType<AlarmHw>;
+type ProcessConsoleDriver =
+    components::process_console::ProcessConsoleComponentType<AlarmHw, ProcessConsoleCap>;
 type PressureDriver = capsules_extra::pressure::PressureSensor<'static, Lps22hbSensor>;
 type UdpDriver = components::udp_driver::UDPDriverComponentType;
+
+type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
+
+kernel::declare_capability!(ProcessConsoleCap:
+    kernel::capabilities::ProcessManagementCapability,
+    kernel::capabilities::ProcessStartCapability
+);
 
 /// Supported drivers by the platform
 pub struct Platform {
@@ -418,9 +420,11 @@ pub unsafe fn start() -> (
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
+        ProcessConsoleCap,
     )
     .finalize(components::process_console_component_static!(
-        nrf52::rtc::Rtc<'static>
+        nrf52::rtc::Rtc<'static>,
+        ProcessConsoleCap
     ));
 
     // Setup the console.
@@ -516,7 +520,7 @@ pub unsafe fn start() -> (
     //--------------------------------------------------------------------------
 
     let sensors_i2c_bus = components::i2c::I2CMuxComponent::new(&base_peripherals.twi1, None)
-        .finalize(components::i2c_mux_component_static!(I2cHw));
+        .finalize(components::i2c_mux_component_static!(nrf52840::i2c::TWI));
     base_peripherals.twi1.configure(
         nrf52840::pinmux::Pinmux::new(I2C_SCL_PIN),
         nrf52840::pinmux::Pinmux::new(I2C_SDA_PIN),
@@ -530,7 +534,7 @@ pub unsafe fn start() -> (
         0x39,
         &nrf52840_peripherals.gpio_port[APDS9960_PIN],
     )
-    .finalize(components::apds9960_component_static!(I2cHw));
+    .finalize(components::apds9960_component_static!(nrf52840::i2c::TWI));
     let proximity = components::proximity::ProximityComponent::new(
         apds9960,
         board_kernel,
@@ -539,7 +543,7 @@ pub unsafe fn start() -> (
     .finalize(components::proximity_component_static!());
 
     let lps22hb = components::lps22hb::Lps22hbComponent::new(sensors_i2c_bus, 0x5C)
-        .finalize(components::lps22hb_component_static!(I2cHw));
+        .finalize(components::lps22hb_component_static!(nrf52840::i2c::TWI));
     let pressure = components::pressure::PressureComponent::new(
         board_kernel,
         capsules_extra::pressure::DRIVER_NUM,
@@ -548,12 +552,12 @@ pub unsafe fn start() -> (
     .finalize(components::pressure_component_static!(
         capsules_extra::lps22hb::Lps22hb<
             'static,
-            capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, I2cHw>,
+            capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, nrf52840::i2c::TWI>,
         >
     ));
 
     let hs3003 = components::hs3003::Hs3003Component::new(sensors_i2c_bus, 0x44)
-        .finalize(components::hs3003_component_static!(I2cHw));
+        .finalize(components::hs3003_component_static!(nrf52840::i2c::TWI));
     let temperature = components::temperature::TemperatureComponent::new(
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,
@@ -577,7 +581,10 @@ pub unsafe fn start() -> (
         &base_peripherals.ble_radio,
         mux_alarm,
     )
-    .finalize(components::ble_component_static!(AlarmHw, BleHw));
+    .finalize(components::ble_component_static!(
+        nrf52840::rtc::Rtc,
+        nrf52840::ble_radio::Radio
+    ));
 
     use capsules_extra::net::ieee802154::MacAddress;
 
@@ -630,11 +637,12 @@ pub unsafe fn start() -> (
         mux_alarm,
     )
     .finalize(components::udp_mux_component_static!(
-        AlarmHw,
+        nrf52840::rtc::Rtc,
         Ieee802154MacDevice
     ));
 
     // UDP driver initialization happens here
+    kernel::declare_capability!(UdpDriverCap: kernel::capabilities::UdpDriverCapability);
     let udp_driver = components::udp_driver::UDPDriverComponent::new(
         board_kernel,
         capsules_extra::net::udp::DRIVER_NUM,
@@ -642,8 +650,12 @@ pub unsafe fn start() -> (
         udp_recv_mux,
         udp_port_table,
         local_ip_ifaces,
+        UdpDriverCap,
     )
-    .finalize(components::udp_driver_component_static!(AlarmHw));
+    .finalize(components::udp_driver_component_static!(
+        nrf52840::rtc::Rtc,
+        UdpDriverCap
+    ));
 
     //--------------------------------------------------------------------------
     // FINAL SETUP AND BOARD BOOT

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -340,6 +340,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(RPTimer));
 
@@ -385,6 +386,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
@@ -442,6 +444,7 @@ pub unsafe fn start() -> (
             // 28 => peripherals.pins.get_pin(RPGpio::GPIO28),
             // 29 => peripherals.pins.get_pin(RPGpio::GPIO29)
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(RPGpioPin<'static>));
 
@@ -480,6 +483,7 @@ pub unsafe fn start() -> (
         capsules_extra::lsm6dsoxtr::ACCELEROMETER_BASE_ADDRESS,
         board_kernel,
         capsules_extra::lsm6dsoxtr::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::lsm6ds_i2c_component_static!(
         rp2040::i2c::I2c<'static, 'static>
@@ -488,6 +492,7 @@ pub unsafe fn start() -> (
     let ninedof = components::ninedof::NineDofComponent::new(
         board_kernel,
         capsules_extra::ninedof::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::ninedof_component_static!(lsm6dsoxtr));
 
@@ -495,6 +500,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,
         temp_sensor,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::temperature_component_static!(
         TemperatureRp2040Sensor
@@ -538,14 +544,17 @@ pub unsafe fn start() -> (
     let adc_channel_3 = components::adc::AdcComponent::new(adc_mux, Channel::Channel3)
         .finalize(components::adc_component_static!(Adc));
 
-    let adc_syscall =
-        components::adc::AdcVirtualComponent::new(board_kernel, capsules_core::adc::DRIVER_NUM)
-            .finalize(components::adc_syscall_component_helper!(
-                adc_channel_0,
-                adc_channel_1,
-                adc_channel_2,
-                adc_channel_3,
-            ));
+    let adc_syscall = components::adc::AdcVirtualComponent::new(
+        board_kernel,
+        capsules_core::adc::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
+    )
+    .finalize(components::adc_syscall_component_helper!(
+        adc_channel_0,
+        adc_channel_1,
+        adc_channel_2,
+        adc_channel_3,
+    ));
 
     let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
         .finalize(components::process_printer_text_component_static!());

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -554,14 +554,22 @@ pub unsafe fn start() -> (
     });
 
     // PROCESS CONSOLE
+    kernel::declare_capability!(ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         Some(cortexm0p::support::reset),
+        ProcessConsoleCap,
     )
-    .finalize(components::process_console_component_static!(RPTimer));
+    .finalize(components::process_console_component_static!(
+        RPTimer,
+        ProcessConsoleCap
+    ));
     let _ = process_console.start();
 
     let scheduler = components::sched::round_robin::RoundRobinComponent::new(processes)

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -11,12 +11,9 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use capsules_core::virtualizers::virtual_aes_ccm::MuxAES128CCM;
 use kernel::component::Component;
 use kernel::debug::PanicResources;
-use kernel::deferred_call::DeferredCallClient;
 use kernel::hil::led::LedLow;
-use kernel::hil::symmetric_encryption::AES128;
 use kernel::hil::time::Counter;
 use kernel::platform::chip::Chip;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
@@ -82,6 +79,12 @@ type Ieee802154Driver = components::ieee802154::Ieee802154ComponentType<
     nrf52840::aes::AesECB<'static>,
 >;
 
+type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
+
+//------------------------------------------------------------------------------
+// SYSCALL DRIVER TYPE DEFINITIONS
+//------------------------------------------------------------------------------
+
 type BleHw = nrf52840::ble_radio::Radio<'static>;
 type AlarmHw = nrf52840::rtc::Rtc<'static>;
 type GpioHw = nrf52840::gpio::GPIOPin<'static>;
@@ -96,15 +99,12 @@ type ButtonDriver = components::button::ButtonComponentType<GpioHw>;
 type ConsoleDriver = components::console::ConsoleComponentType;
 type AnalogComparatorDriver =
     components::analog_comparator::AnalogComparatorComponentType<AnalogComparatorHw>;
-type ProcessConsoleDriver =
-    components::process_console::ProcessConsoleComponentType<AlarmHw, ProcessConsoleCap>;
-
-type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
-
 kernel::declare_capability!(ProcessConsoleCap:
     kernel::capabilities::ProcessManagementCapability,
     kernel::capabilities::ProcessStartCapability
 );
+type ProcessConsoleDriver =
+    components::process_console::ProcessConsoleComponentType<AlarmHw, ProcessConsoleCap>;
 
 /// Supported drivers by the platform
 pub struct Platform {
@@ -232,7 +232,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::gpio::DRIVER_NUM,
         components::gpio_component_helper!(
-            nrf52840::gpio::GPIOPin,
+            GpioHw,
             // left side of the USB plug
             0 => &nrf52840_peripherals.gpio_port[Pin::P0_13],
             1 => &nrf52840_peripherals.gpio_port[Pin::P0_15],
@@ -261,27 +261,27 @@ pub unsafe fn start() -> (
             22 => &nrf52840_peripherals.gpio_port[Pin::P1_04],
             23 => &nrf52840_peripherals.gpio_port[Pin::P1_02]
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
-    .finalize(components::gpio_component_static!(nrf52840::gpio::GPIOPin));
+    .finalize(components::gpio_component_static!(GpioHw));
 
     let button = components::button::ButtonComponent::new(
         board_kernel,
         capsules_core::button::DRIVER_NUM,
         components::button_component_helper!(
-            nrf52840::gpio::GPIOPin,
+            GpioHw,
             (
                 &nrf52840_peripherals.gpio_port[BUTTON_PIN],
                 kernel::hil::gpio::ActivationMode::ActiveLow,
                 kernel::hil::gpio::FloatingState::PullUp
             )
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
-    .finalize(components::button_component_static!(
-        nrf52840::gpio::GPIOPin
-    ));
+    .finalize(components::button_component_static!(GpioHw));
 
     let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
-        LedLow<'static, nrf52840::gpio::GPIOPin>,
+        LedLow<'static, GpioHw>,
         LedLow::new(&nrf52840_peripherals.gpio_port[LED1_PIN]),
         LedLow::new(&nrf52840_peripherals.gpio_port[LED2_R_PIN]),
         LedLow::new(&nrf52840_peripherals.gpio_port[LED2_G_PIN]),
@@ -332,22 +332,21 @@ pub unsafe fn start() -> (
     let rtc = &base_peripherals.rtc;
     let _ = rtc.start();
     let mux_alarm = components::alarm::AlarmMuxComponent::new(rtc)
-        .finalize(components::alarm_mux_component_static!(nrf52840::rtc::Rtc));
+        .finalize(components::alarm_mux_component_static!(AlarmHw));
     let alarm = components::alarm::AlarmDriverComponent::new(
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
-    .finalize(components::alarm_component_static!(nrf52840::rtc::Rtc));
+    .finalize(components::alarm_component_static!(AlarmHw));
     let uart_channel = UartChannel::Pins(UartPins::new(UART_RTS, UART_TXD, UART_CTS, UART_RXD));
     let channel = nrf52_components::UartChannelComponent::new(
         uart_channel,
         mux_alarm,
         &base_peripherals.uarte0,
     )
-    .finalize(nrf52_components::uart_channel_component_static!(
-        nrf52840::rtc::Rtc
-    ));
+    .finalize(nrf52_components::uart_channel_component_static!(AlarmHw));
 
     let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
         .finalize(components::process_printer_text_component_static!());
@@ -368,8 +367,8 @@ pub unsafe fn start() -> (
         ProcessConsoleCap,
     )
     .finalize(components::process_console_component_static!(
-        nrf52840::rtc::Rtc<'static>,
-        ProcessConsoleCap
+        AlarmHw,
+        ProcessConsoleCap,
     ));
 
     // Setup the console.
@@ -377,6 +376,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
@@ -393,18 +393,12 @@ pub unsafe fn start() -> (
         capsules_extra::ble_advertising_driver::DRIVER_NUM,
         &base_peripherals.ble_radio,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
-    .finalize(components::ble_component_static!(
-        nrf52840::rtc::Rtc,
-        nrf52840::ble_radio::Radio
-    ));
+    .finalize(components::ble_component_static!(AlarmHw, BleHw));
 
-    let aes_mux = static_init!(
-        MuxAES128CCM<'static, nrf52840::aes::AesECB>,
-        MuxAES128CCM::new(&base_peripherals.ecb,)
-    );
-    aes_mux.register();
-    base_peripherals.ecb.set_client(aes_mux);
+    let aes_mux = components::aes::AesMuxComponent::new(&base_peripherals.ecb)
+        .finalize(components::aes_mux_component_static!(nrf52840::aes::AesECB));
 
     let (ieee802154_radio, _mux_mac) = components::ieee802154::Ieee802154Component::new(
         board_kernel,
@@ -414,6 +408,7 @@ pub unsafe fn start() -> (
         PAN_ID,
         SRC_MAC,
         DEFAULT_EXT_SRC_MAC,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::ieee802154_component_static!(
         nrf52840::ieee802154_radio::Radio,
@@ -424,6 +419,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,
         &base_peripherals.temp,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::temperature_component_static!(
         nrf52840::temperature::Temp
@@ -433,6 +429,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::rng::DRIVER_NUM,
         &base_peripherals.trng,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::rng_component_static!(nrf52840::trng::Trng));
 
@@ -446,9 +443,10 @@ pub unsafe fn start() -> (
         ),
         board_kernel,
         capsules_extra::analog_comparator::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::analog_comparator_component_static!(
-        nrf52840::acomp::Comparator
+        AnalogComparatorHw
     ));
 
     nrf52_components::NrfClockComponent::new(&base_peripherals.clock).finalize(());

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -11,9 +11,12 @@
 #![no_main]
 #![deny(missing_docs)]
 
+use capsules_core::virtualizers::virtual_aes_ccm::MuxAES128CCM;
 use kernel::component::Component;
 use kernel::debug::PanicResources;
+use kernel::deferred_call::DeferredCallClient;
 use kernel::hil::led::LedLow;
+use kernel::hil::symmetric_encryption::AES128;
 use kernel::hil::time::Counter;
 use kernel::platform::chip::Chip;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
@@ -79,12 +82,6 @@ type Ieee802154Driver = components::ieee802154::Ieee802154ComponentType<
     nrf52840::aes::AesECB<'static>,
 >;
 
-type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
-
-//------------------------------------------------------------------------------
-// SYSCALL DRIVER TYPE DEFINITIONS
-//------------------------------------------------------------------------------
-
 type BleHw = nrf52840::ble_radio::Radio<'static>;
 type AlarmHw = nrf52840::rtc::Rtc<'static>;
 type GpioHw = nrf52840::gpio::GPIOPin<'static>;
@@ -99,7 +96,15 @@ type ButtonDriver = components::button::ButtonComponentType<GpioHw>;
 type ConsoleDriver = components::console::ConsoleComponentType;
 type AnalogComparatorDriver =
     components::analog_comparator::AnalogComparatorComponentType<AnalogComparatorHw>;
-type ProcessConsoleDriver = components::process_console::ProcessConsoleComponentType<AlarmHw>;
+type ProcessConsoleDriver =
+    components::process_console::ProcessConsoleComponentType<AlarmHw, ProcessConsoleCap>;
+
+type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
+
+kernel::declare_capability!(ProcessConsoleCap:
+    kernel::capabilities::ProcessManagementCapability,
+    kernel::capabilities::ProcessStartCapability
+);
 
 /// Supported drivers by the platform
 pub struct Platform {
@@ -227,7 +232,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::gpio::DRIVER_NUM,
         components::gpio_component_helper!(
-            GpioHw,
+            nrf52840::gpio::GPIOPin,
             // left side of the USB plug
             0 => &nrf52840_peripherals.gpio_port[Pin::P0_13],
             1 => &nrf52840_peripherals.gpio_port[Pin::P0_15],
@@ -257,13 +262,13 @@ pub unsafe fn start() -> (
             23 => &nrf52840_peripherals.gpio_port[Pin::P1_02]
         ),
     )
-    .finalize(components::gpio_component_static!(GpioHw));
+    .finalize(components::gpio_component_static!(nrf52840::gpio::GPIOPin));
 
     let button = components::button::ButtonComponent::new(
         board_kernel,
         capsules_core::button::DRIVER_NUM,
         components::button_component_helper!(
-            GpioHw,
+            nrf52840::gpio::GPIOPin,
             (
                 &nrf52840_peripherals.gpio_port[BUTTON_PIN],
                 kernel::hil::gpio::ActivationMode::ActiveLow,
@@ -271,10 +276,12 @@ pub unsafe fn start() -> (
             )
         ),
     )
-    .finalize(components::button_component_static!(GpioHw));
+    .finalize(components::button_component_static!(
+        nrf52840::gpio::GPIOPin
+    ));
 
     let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
-        LedLow<'static, GpioHw>,
+        LedLow<'static, nrf52840::gpio::GPIOPin>,
         LedLow::new(&nrf52840_peripherals.gpio_port[LED1_PIN]),
         LedLow::new(&nrf52840_peripherals.gpio_port[LED2_R_PIN]),
         LedLow::new(&nrf52840_peripherals.gpio_port[LED2_G_PIN]),
@@ -325,20 +332,22 @@ pub unsafe fn start() -> (
     let rtc = &base_peripherals.rtc;
     let _ = rtc.start();
     let mux_alarm = components::alarm::AlarmMuxComponent::new(rtc)
-        .finalize(components::alarm_mux_component_static!(AlarmHw));
+        .finalize(components::alarm_mux_component_static!(nrf52840::rtc::Rtc));
     let alarm = components::alarm::AlarmDriverComponent::new(
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
     )
-    .finalize(components::alarm_component_static!(AlarmHw));
+    .finalize(components::alarm_component_static!(nrf52840::rtc::Rtc));
     let uart_channel = UartChannel::Pins(UartPins::new(UART_RTS, UART_TXD, UART_CTS, UART_RXD));
     let channel = nrf52_components::UartChannelComponent::new(
         uart_channel,
         mux_alarm,
         &base_peripherals.uarte0,
     )
-    .finalize(nrf52_components::uart_channel_component_static!(AlarmHw));
+    .finalize(nrf52_components::uart_channel_component_static!(
+        nrf52840::rtc::Rtc
+    ));
 
     let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
         .finalize(components::process_printer_text_component_static!());
@@ -356,8 +365,12 @@ pub unsafe fn start() -> (
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
+        ProcessConsoleCap,
     )
-    .finalize(components::process_console_component_static!(AlarmHw));
+    .finalize(components::process_console_component_static!(
+        nrf52840::rtc::Rtc<'static>,
+        ProcessConsoleCap
+    ));
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(
@@ -381,10 +394,17 @@ pub unsafe fn start() -> (
         &base_peripherals.ble_radio,
         mux_alarm,
     )
-    .finalize(components::ble_component_static!(AlarmHw, BleHw));
+    .finalize(components::ble_component_static!(
+        nrf52840::rtc::Rtc,
+        nrf52840::ble_radio::Radio
+    ));
 
-    let aes_mux = components::aes::AesMuxComponent::new(&base_peripherals.ecb)
-        .finalize(components::aes_mux_component_static!(nrf52840::aes::AesECB));
+    let aes_mux = static_init!(
+        MuxAES128CCM<'static, nrf52840::aes::AesECB>,
+        MuxAES128CCM::new(&base_peripherals.ecb,)
+    );
+    aes_mux.register();
+    base_peripherals.ecb.set_client(aes_mux);
 
     let (ieee802154_radio, _mux_mac) = components::ieee802154::Ieee802154Component::new(
         board_kernel,
@@ -428,7 +448,7 @@ pub unsafe fn start() -> (
         capsules_extra::analog_comparator::DRIVER_NUM,
     )
     .finalize(components::analog_comparator_component_static!(
-        AnalogComparatorHw
+        nrf52840::acomp::Comparator
     ));
 
     nrf52_components::NrfClockComponent::new(&base_peripherals.clock).finalize(());

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -185,7 +185,12 @@ type AnalogComparatorDriver =
     components::analog_comparator::AnalogComparatorComponentType<AnalogComparatorHw>;
 type I2CMasterSlaveDriver = components::i2c::I2CMasterSlaveDriverComponentType<I2cHw>;
 type SpiControllerDriver = components::spi::SpiSyscallComponentType<SpiHw>;
-type ProcessConsoleDriver = components::process_console::ProcessConsoleComponentType<AlarmHw>;
+kernel::declare_capability!(ProcessConsoleCap:
+    kernel::capabilities::ProcessManagementCapability,
+    kernel::capabilities::ProcessStartCapability
+);
+type ProcessConsoleDriver =
+    components::process_console::ProcessConsoleComponentType<AlarmHw, ProcessConsoleCap>;
 type TemperatureDriver = components::temperature::TemperatureComponentType<TemperatureHw>;
 type IpcDriver = kernel::ipc::IPC<{ NUM_PROCS as u8 }>;
 
@@ -211,6 +216,8 @@ pub type Ieee802154Driver = components::ieee802154::Ieee802154ComponentType<Radi
 
 /// Userspace EUI64 driver.
 pub type Eui64Driver = components::eui64::Eui64ComponentType;
+
+kernel::declare_capability!(UdpDriverCap: kernel::capabilities::UdpDriverCapability);
 
 /// Userspace UDP driver.
 pub type UdpDriver = components::udp_driver::UDPDriverComponentType;
@@ -377,8 +384,12 @@ pub unsafe fn ieee802154_udp(
         udp_recv_mux,
         udp_port_table,
         local_ip_ifaces,
+        UdpDriverCap,
     )
-    .finalize(components::udp_driver_component_static!(AlarmHw));
+    .finalize(components::udp_driver_component_static!(
+        AlarmHw,
+        UdpDriverCap
+    ));
 
     (eui64_driver, ieee802154_driver, udp_driver)
 }
@@ -627,8 +638,12 @@ pub unsafe fn start_no_pconsole() -> (
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
+        ProcessConsoleCap,
     )
-    .finalize(components::process_console_component_static!(AlarmHw));
+    .finalize(components::process_console_component_static!(
+        AlarmHw,
+        ProcessConsoleCap
+    ));
 
     // Setup the serial console for userspace.
     let console = components::console::ConsoleComponent::new(

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -341,6 +341,7 @@ pub unsafe fn ieee802154_udp(
         PAN_ID,
         device_id_bottom_16,
         device_id,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::ieee802154_component_static!(RadioHw, AesHw));
 
@@ -370,6 +371,8 @@ pub unsafe fn ieee802154_udp(
         MacAddress::Long(device_id),
         local_ip_ifaces,
         mux_alarm,
+        create_capability!(capabilities::NetworkCapabilityCreationCapability),
+        create_capability!(capabilities::CreatePortTableCapability),
     )
     .finalize(components::udp_mux_component_static!(
         AlarmHw,
@@ -385,6 +388,8 @@ pub unsafe fn ieee802154_udp(
         udp_port_table,
         local_ip_ifaces,
         UdpDriverCap,
+        create_capability!(capabilities::MemoryAllocationCapability),
+        create_capability!(capabilities::NetworkCapabilityCreationCapability),
     )
     .finalize(components::udp_driver_component_static!(
         AlarmHw,
@@ -545,6 +550,7 @@ pub unsafe fn start_no_pconsole() -> (
             12 => &nrf52840_peripherals.gpio_port[Pin::P1_14],
             13 => &nrf52840_peripherals.gpio_port[Pin::P1_15],
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(GpioHw));
 
@@ -578,6 +584,7 @@ pub unsafe fn start_no_pconsole() -> (
                 kernel::hil::gpio::FloatingState::PullUp
             )
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::button_component_static!(ButtonHw));
 
@@ -605,6 +612,7 @@ pub unsafe fn start_no_pconsole() -> (
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(AlarmHw));
 
@@ -650,6 +658,7 @@ pub unsafe fn start_no_pconsole() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
 
@@ -671,6 +680,7 @@ pub unsafe fn start_no_pconsole() -> (
         capsules_extra::ble_advertising_driver::DRIVER_NUM,
         &base_peripherals.ble_radio,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::ble_component_static!(AlarmHw, BleHw));
 
@@ -682,6 +692,7 @@ pub unsafe fn start_no_pconsole() -> (
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,
         &base_peripherals.temp,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::temperature_component_static!(TemperatureHw));
 
@@ -693,6 +704,7 @@ pub unsafe fn start_no_pconsole() -> (
         board_kernel,
         capsules_core::rng::DRIVER_NUM,
         &base_peripherals.trng,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::rng_component_static!(RngHw));
 
@@ -716,6 +728,7 @@ pub unsafe fn start_no_pconsole() -> (
         adc_channels,
         board_kernel,
         capsules_core::adc::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::adc_dedicated_component_static!(AdcHw));
 
@@ -734,6 +747,7 @@ pub unsafe fn start_no_pconsole() -> (
             &gpio_port[SPI_CS],
         ),
         capsules_core::spi_controller::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::spi_syscall_component_static!(SpiHw));
 
@@ -814,6 +828,7 @@ pub unsafe fn start_no_pconsole() -> (
         virtual_kv_driver,
         board_kernel,
         capsules_extra::kv_driver::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::kv_driver_component_static!(
         VirtualKVPermissions
@@ -827,6 +842,7 @@ pub unsafe fn start_no_pconsole() -> (
         board_kernel,
         capsules_core::i2c_master_slave_driver::DRIVER_NUM,
         &base_peripherals.twi1,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::i2c_master_slave_component_static!(I2cHw));
 
@@ -850,6 +866,7 @@ pub unsafe fn start_no_pconsole() -> (
         ),
         board_kernel,
         capsules_extra::analog_comparator::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::analog_comparator_component_static!(
         AnalogComparatorHw

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -81,6 +81,7 @@ use kernel::{capabilities, create_capability, debug, debug_gpio, debug_verbose, 
 use nrf52_components::{UartChannel, UartPins};
 use nrf52832::gpio::Pin;
 use nrf52832::interrupt_service::Nrf52832DefaultPeripherals;
+use nrf52832::rtc::Rtc;
 
 // The nRF52 DK LEDs (see back of board)
 const LED1_PIN: Pin = Pin::P0_17;
@@ -135,12 +136,6 @@ type TemperatureDriver =
     components::temperature::TemperatureComponentType<nrf52832::temperature::Temp<'static>>;
 type RngDriver = components::rng::RngComponentType<nrf52832::trng::Trng<'static>>;
 
-type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
-
-//------------------------------------------------------------------------------
-// SYSCALL DRIVER TYPE DEFINITIONS
-//------------------------------------------------------------------------------
-
 type BleHw = nrf52832::ble_radio::Radio<'static>;
 type AlarmHw = nrf52832::rtc::Rtc<'static>;
 type GpioHw = nrf52832::gpio::GPIOPin<'static>;
@@ -155,7 +150,15 @@ type ButtonDriver = components::button::ButtonComponentType<GpioHw>;
 type ConsoleDriver = components::console::ConsoleComponentType;
 type AnalogComparatorDriver =
     components::analog_comparator::AnalogComparatorComponentType<AnalogComparatorHw>;
-type ProcessConsoleDriver = components::process_console::ProcessConsoleComponentType<AlarmHw>;
+type ProcessConsoleDriver =
+    components::process_console::ProcessConsoleComponentType<AlarmHw, ProcessConsoleCap>;
+
+type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
+
+kernel::declare_capability!(ProcessConsoleCap:
+    kernel::capabilities::ProcessManagementCapability,
+    kernel::capabilities::ProcessStartCapability
+);
 
 /// Supported drivers by the platform
 pub struct Platform {
@@ -278,7 +281,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::gpio::DRIVER_NUM,
         components::gpio_component_helper!(
-            GpioHw,
+            nrf52832::gpio::GPIOPin,
             // Bottom right header on DK board
             0 => &nrf52832_peripherals.gpio_port[Pin::P0_03],
             1 => &nrf52832_peripherals.gpio_port[Pin::P0_04],
@@ -296,13 +299,13 @@ pub unsafe fn start() -> (
             11 => &nrf52832_peripherals.gpio_port[Pin::P0_25]
         ),
     )
-    .finalize(components::gpio_component_static!(GpioHw));
+    .finalize(components::gpio_component_static!(nrf52832::gpio::GPIOPin));
 
     let button = components::button::ButtonComponent::new(
         board_kernel,
         capsules_core::button::DRIVER_NUM,
         components::button_component_helper!(
-            GpioHw,
+            nrf52832::gpio::GPIOPin,
             (
                 &nrf52832_peripherals.gpio_port[BUTTON1_PIN],
                 kernel::hil::gpio::ActivationMode::ActiveLow,
@@ -325,10 +328,12 @@ pub unsafe fn start() -> (
             ) //16
         ),
     )
-    .finalize(components::button_component_static!(GpioHw));
+    .finalize(components::button_component_static!(
+        nrf52832::gpio::GPIOPin
+    ));
 
     let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
-        LedLow<'static, GpioHw>,
+        LedLow<'static, nrf52832::gpio::GPIOPin>,
         LedLow::new(&nrf52832_peripherals.gpio_port[LED1_PIN]),
         LedLow::new(&nrf52832_peripherals.gpio_port[LED2_PIN]),
         LedLow::new(&nrf52832_peripherals.gpio_port[LED3_PIN]),
@@ -375,20 +380,22 @@ pub unsafe fn start() -> (
     let rtc = &base_peripherals.rtc;
     let _ = rtc.start();
     let mux_alarm = components::alarm::AlarmMuxComponent::new(rtc)
-        .finalize(components::alarm_mux_component_static!(AlarmHw));
+        .finalize(components::alarm_mux_component_static!(nrf52832::rtc::Rtc));
     let alarm = components::alarm::AlarmDriverComponent::new(
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
     )
-    .finalize(components::alarm_component_static!(AlarmHw));
+    .finalize(components::alarm_component_static!(nrf52832::rtc::Rtc));
     let uart_channel = UartChannel::Pins(UartPins::new(UART_RTS, UART_TXD, UART_CTS, UART_RXD));
     let channel = nrf52_components::UartChannelComponent::new(
         uart_channel,
         mux_alarm,
         &base_peripherals.uarte0,
     )
-    .finalize(nrf52_components::uart_channel_component_static!(AlarmHw));
+    .finalize(nrf52_components::uart_channel_component_static!(
+        nrf52832::rtc::Rtc
+    ));
 
     let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
         .finalize(components::process_printer_text_component_static!());
@@ -406,8 +413,12 @@ pub unsafe fn start() -> (
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
+        ProcessConsoleCap,
     )
-    .finalize(components::process_console_component_static!(AlarmHw));
+    .finalize(components::process_console_component_static!(
+        Rtc<'static>,
+        ProcessConsoleCap
+    ));
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(
@@ -431,7 +442,10 @@ pub unsafe fn start() -> (
         &base_peripherals.ble_radio,
         mux_alarm,
     )
-    .finalize(components::ble_component_static!(AlarmHw, BleHw));
+    .finalize(components::ble_component_static!(
+        nrf52832::rtc::Rtc,
+        nrf52832::ble_radio::Radio
+    ));
 
     let temp = components::temperature::TemperatureComponent::new(
         board_kernel,
@@ -461,7 +475,7 @@ pub unsafe fn start() -> (
         capsules_extra::analog_comparator::DRIVER_NUM,
     )
     .finalize(components::analog_comparator_component_static!(
-        AnalogComparatorHw
+        nrf52832::acomp::Comparator
     ));
 
     nrf52_components::NrfClockComponent::new(&base_peripherals.clock).finalize(());

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -81,7 +81,6 @@ use kernel::{capabilities, create_capability, debug, debug_gpio, debug_verbose, 
 use nrf52_components::{UartChannel, UartPins};
 use nrf52832::gpio::Pin;
 use nrf52832::interrupt_service::Nrf52832DefaultPeripherals;
-use nrf52832::rtc::Rtc;
 
 // The nRF52 DK LEDs (see back of board)
 const LED1_PIN: Pin = Pin::P0_17;
@@ -136,6 +135,12 @@ type TemperatureDriver =
     components::temperature::TemperatureComponentType<nrf52832::temperature::Temp<'static>>;
 type RngDriver = components::rng::RngComponentType<nrf52832::trng::Trng<'static>>;
 
+type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
+
+//------------------------------------------------------------------------------
+// SYSCALL DRIVER TYPE DEFINITIONS
+//------------------------------------------------------------------------------
+
 type BleHw = nrf52832::ble_radio::Radio<'static>;
 type AlarmHw = nrf52832::rtc::Rtc<'static>;
 type GpioHw = nrf52832::gpio::GPIOPin<'static>;
@@ -150,15 +155,12 @@ type ButtonDriver = components::button::ButtonComponentType<GpioHw>;
 type ConsoleDriver = components::console::ConsoleComponentType;
 type AnalogComparatorDriver =
     components::analog_comparator::AnalogComparatorComponentType<AnalogComparatorHw>;
-type ProcessConsoleDriver =
-    components::process_console::ProcessConsoleComponentType<AlarmHw, ProcessConsoleCap>;
-
-type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
-
 kernel::declare_capability!(ProcessConsoleCap:
     kernel::capabilities::ProcessManagementCapability,
     kernel::capabilities::ProcessStartCapability
 );
+type ProcessConsoleDriver =
+    components::process_console::ProcessConsoleComponentType<AlarmHw, ProcessConsoleCap>;
 
 /// Supported drivers by the platform
 pub struct Platform {
@@ -281,7 +283,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::gpio::DRIVER_NUM,
         components::gpio_component_helper!(
-            nrf52832::gpio::GPIOPin,
+            GpioHw,
             // Bottom right header on DK board
             0 => &nrf52832_peripherals.gpio_port[Pin::P0_03],
             1 => &nrf52832_peripherals.gpio_port[Pin::P0_04],
@@ -298,14 +300,15 @@ pub unsafe fn start() -> (
             10 => &nrf52832_peripherals.gpio_port[Pin::P0_02],
             11 => &nrf52832_peripherals.gpio_port[Pin::P0_25]
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
-    .finalize(components::gpio_component_static!(nrf52832::gpio::GPIOPin));
+    .finalize(components::gpio_component_static!(GpioHw));
 
     let button = components::button::ButtonComponent::new(
         board_kernel,
         capsules_core::button::DRIVER_NUM,
         components::button_component_helper!(
-            nrf52832::gpio::GPIOPin,
+            GpioHw,
             (
                 &nrf52832_peripherals.gpio_port[BUTTON1_PIN],
                 kernel::hil::gpio::ActivationMode::ActiveLow,
@@ -327,13 +330,12 @@ pub unsafe fn start() -> (
                 kernel::hil::gpio::FloatingState::PullUp
             ) //16
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
-    .finalize(components::button_component_static!(
-        nrf52832::gpio::GPIOPin
-    ));
+    .finalize(components::button_component_static!(GpioHw));
 
     let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
-        LedLow<'static, nrf52832::gpio::GPIOPin>,
+        LedLow<'static, GpioHw>,
         LedLow::new(&nrf52832_peripherals.gpio_port[LED1_PIN]),
         LedLow::new(&nrf52832_peripherals.gpio_port[LED2_PIN]),
         LedLow::new(&nrf52832_peripherals.gpio_port[LED3_PIN]),
@@ -380,22 +382,21 @@ pub unsafe fn start() -> (
     let rtc = &base_peripherals.rtc;
     let _ = rtc.start();
     let mux_alarm = components::alarm::AlarmMuxComponent::new(rtc)
-        .finalize(components::alarm_mux_component_static!(nrf52832::rtc::Rtc));
+        .finalize(components::alarm_mux_component_static!(AlarmHw));
     let alarm = components::alarm::AlarmDriverComponent::new(
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
-    .finalize(components::alarm_component_static!(nrf52832::rtc::Rtc));
+    .finalize(components::alarm_component_static!(AlarmHw));
     let uart_channel = UartChannel::Pins(UartPins::new(UART_RTS, UART_TXD, UART_CTS, UART_RXD));
     let channel = nrf52_components::UartChannelComponent::new(
         uart_channel,
         mux_alarm,
         &base_peripherals.uarte0,
     )
-    .finalize(nrf52_components::uart_channel_component_static!(
-        nrf52832::rtc::Rtc
-    ));
+    .finalize(nrf52_components::uart_channel_component_static!(AlarmHw));
 
     let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
         .finalize(components::process_printer_text_component_static!());
@@ -416,8 +417,8 @@ pub unsafe fn start() -> (
         ProcessConsoleCap,
     )
     .finalize(components::process_console_component_static!(
-        Rtc<'static>,
-        ProcessConsoleCap
+        AlarmHw,
+        ProcessConsoleCap,
     ));
 
     // Setup the console.
@@ -425,6 +426,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
@@ -441,16 +443,15 @@ pub unsafe fn start() -> (
         capsules_extra::ble_advertising_driver::DRIVER_NUM,
         &base_peripherals.ble_radio,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
-    .finalize(components::ble_component_static!(
-        nrf52832::rtc::Rtc,
-        nrf52832::ble_radio::Radio
-    ));
+    .finalize(components::ble_component_static!(AlarmHw, BleHw));
 
     let temp = components::temperature::TemperatureComponent::new(
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,
         &base_peripherals.temp,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::temperature_component_static!(
         nrf52832::temperature::Temp
@@ -460,6 +461,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::rng::DRIVER_NUM,
         &base_peripherals.trng,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::rng_component_static!(nrf52832::trng::Trng));
 
@@ -473,9 +475,10 @@ pub unsafe fn start() -> (
         ),
         board_kernel,
         capsules_extra::analog_comparator::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::analog_comparator_component_static!(
-        nrf52832::acomp::Comparator
+        AnalogComparatorHw
     ));
 
     nrf52_components::NrfClockComponent::new(&base_peripherals.clock).finalize(());

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -660,15 +660,21 @@ unsafe fn start() -> (
     ));
 
     // PROCESS CONSOLE
+    kernel::declare_capability!(ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
+        ProcessConsoleCap,
     )
     .finalize(components::process_console_component_static!(
-        stm32f429zi::tim2::Tim2
+        stm32f429zi::tim2::Tim2,
+        ProcessConsoleCap
     ));
     let _ = process_console.start();
 

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -410,6 +410,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
@@ -445,6 +446,7 @@ unsafe fn start() -> (
                 kernel::hil::gpio::FloatingState::PullNone
             )
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::button_component_static!(stm32f429zi::gpio::Pin));
 
@@ -459,6 +461,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(stm32f429zi::tim2::Tim2));
 
@@ -561,6 +564,7 @@ unsafe fn start() -> (
             // 79 => gpio_ports.pins[2][2].as_ref().unwrap(), //A7
             80 => gpio_ports.pins[5][4].as_ref().unwrap()  //A8
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(stm32f429zi::gpio::Pin));
 
@@ -582,6 +586,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,
         temp_sensor,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::temperature_component_static!(
         TemperatureSTMSensor
@@ -607,15 +612,18 @@ unsafe fn start() -> (
         components::adc::AdcComponent::new(adc_mux, stm32f429zi::adc::Channel::Channel12)
             .finalize(components::adc_component_static!(stm32f429zi::adc::Adc));
 
-    let adc_syscall =
-        components::adc::AdcVirtualComponent::new(board_kernel, capsules_core::adc::DRIVER_NUM)
-            .finalize(components::adc_syscall_component_helper!(
-                adc_channel_0,
-                adc_channel_1,
-                adc_channel_2,
-                adc_channel_3,
-                adc_channel_4,
-            ));
+    let adc_syscall = components::adc::AdcVirtualComponent::new(
+        board_kernel,
+        capsules_core::adc::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
+    )
+    .finalize(components::adc_syscall_component_helper!(
+        adc_channel_0,
+        adc_channel_1,
+        adc_channel_2,
+        adc_channel_3,
+        adc_channel_4,
+    ));
 
     let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
         .finalize(components::process_printer_text_component_static!());
@@ -632,6 +640,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::rng::DRIVER_NUM,
         &peripherals.trng,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::rng_component_static!(stm32f429zi::trng::Trng));
 
@@ -640,6 +649,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_extra::can::DRIVER_NUM,
         &peripherals.can1,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::can_component_static!(
         stm32f429zi::can::Can<'static>
@@ -654,6 +664,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_extra::date_time::DRIVER_NUM,
         &peripherals.rtc,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::date_time_component_static!(
         stm32f429zi::rtc::Rtc<'static>

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -504,15 +504,21 @@ unsafe fn start() -> (
     .finalize(components::gpio_component_static!(stm32f446re::gpio::Pin));
 
     // PROCESS CONSOLE
+    kernel::declare_capability!(ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
+        ProcessConsoleCap,
     )
     .finalize(components::process_console_component_static!(
-        stm32f446re::tim2::Tim2
+        stm32f446re::tim2::Tim2,
+        ProcessConsoleCap
     ));
     let _ = process_console.start();
 

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -355,6 +355,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
@@ -387,6 +388,7 @@ unsafe fn start() -> (
                 kernel::hil::gpio::FloatingState::PullNone
             )
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::button_component_static!(stm32f446re::gpio::Pin));
 
@@ -400,6 +402,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(stm32f446re::tim2::Tim2));
 
@@ -421,6 +424,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,
         temp_sensor,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::temperature_component_static!(
         TemperatureSTMSensor
@@ -450,16 +454,19 @@ unsafe fn start() -> (
         components::adc::AdcComponent::new(adc_mux, stm32f446re::adc::Channel::Channel10)
             .finalize(components::adc_component_static!(stm32f446re::adc::Adc));
 
-    let adc_syscall =
-        components::adc::AdcVirtualComponent::new(board_kernel, capsules_core::adc::DRIVER_NUM)
-            .finalize(components::adc_syscall_component_helper!(
-                adc_channel_0,
-                adc_channel_1,
-                adc_channel_2,
-                adc_channel_3,
-                adc_channel_4,
-                adc_channel_5
-            ));
+    let adc_syscall = components::adc::AdcVirtualComponent::new(
+        board_kernel,
+        capsules_core::adc::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
+    )
+    .finalize(components::adc_syscall_component_helper!(
+        adc_channel_0,
+        adc_channel_1,
+        adc_channel_2,
+        adc_channel_3,
+        adc_channel_4,
+        adc_channel_5
+    ));
 
     let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
         .finalize(components::process_printer_text_component_static!());
@@ -500,6 +507,7 @@ unsafe fn start() -> (
             // 20 => gpio_ports.get_pin(PinId::PC01).unwrap(), //A4
             // 21 => gpio_ports.get_pin(PinId::PC00).unwrap(), //A5
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(stm32f446re::gpio::Pin));
 

--- a/boards/nucleo_u545re_q/src/main.rs
+++ b/boards/nucleo_u545re_q/src/main.rs
@@ -225,6 +225,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
 
@@ -259,6 +260,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         alarm_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(stm32u545::tim::Tim2));
 
@@ -279,6 +281,7 @@ unsafe fn start() -> (
                 kernel::hil::gpio::FloatingState::PullDown
             )
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::button_component_static!(stm32u545::gpio::Pin));
 
@@ -289,9 +292,12 @@ unsafe fn start() -> (
         stm32u545::tim::PwmPin::new(&periphs.tim3, pwm_pin),
     );
 
-    let pwm =
-        components::pwm::PwmDriverComponent::new(board_kernel, capsules_extra::pwm::DRIVER_NUM)
-            .finalize(components::pwm_driver_component_helper!(tim3_pwm_pin));
+    let pwm = components::pwm::PwmDriverComponent::new(
+        board_kernel,
+        capsules_extra::pwm::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
+    )
+    .finalize(components::pwm_driver_component_helper!(tim3_pwm_pin));
     let adc_mux = components::adc::AdcMuxComponent::new(&periphs.adc1)
         .finalize(components::adc_mux_component_static!(stm32u545::adc::Adc));
 
@@ -316,16 +322,19 @@ unsafe fn start() -> (
             .finalize(components::adc_component_static!(stm32u545::adc::Adc));
 
     // Applications will see 6 ADC channels available, with index 0-5 corresponding directly to Arduino pins A0-A5
-    let adc_syscall =
-        components::adc::AdcVirtualComponent::new(board_kernel, capsules_core::adc::DRIVER_NUM)
-            .finalize(components::adc_syscall_component_helper!(
-                adc1_channel_5,
-                adc1_channel_6,
-                adc1_channel_9,
-                adc1_channel_15,
-                adc1_channel_2,
-                adc1_channel_1,
-            ));
+    let adc_syscall = components::adc::AdcVirtualComponent::new(
+        board_kernel,
+        capsules_core::adc::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
+    )
+    .finalize(components::adc_syscall_component_helper!(
+        adc1_channel_5,
+        adc1_channel_6,
+        adc1_channel_9,
+        adc1_channel_15,
+        adc1_channel_2,
+        adc1_channel_1,
+    ));
     let dac = components::dac::DacComponent::new(&periphs.dac)
         .finalize(components::dac_component_static!());
     let gpio = components::gpio::GpioComponent::new(
@@ -362,6 +371,7 @@ unsafe fn start() -> (
             25 => periphs.gpio_a.pin(PinId::Pin15), // CN7 pin 17
             26 => periphs.gpio_c.pin(PinId::Pin03), // CN7 pin 37
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(GpioHw));
 

--- a/boards/nucleo_u545re_q/src/main.rs
+++ b/boards/nucleo_u545re_q/src/main.rs
@@ -236,6 +236,10 @@ unsafe fn start() -> (
     )
     .finalize(components::debug_writer_component_static!());
 
+    kernel::declare_capability!(ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
@@ -243,9 +247,11 @@ unsafe fn start() -> (
         components::process_printer::ProcessPrinterTextComponent::new()
             .finalize(components::process_printer_text_component_static!()),
         None,
+        ProcessConsoleCap,
     )
     .finalize(components::process_console_component_static!(
-        stm32u545::tim::Tim2
+        stm32u545::tim::Tim2,
+        ProcessConsoleCap
     ));
     let _ = process_console.start();
 

--- a/boards/opentitan/earlgrey-cw310/src/main.rs
+++ b/boards/opentitan/earlgrey-cw310/src/main.rs
@@ -457,6 +457,7 @@ unsafe fn setup() -> (
             6 => &peripherals.gpio_port[6],
             7 => &peripherals.gpio_port[15]
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(
         earlgrey::gpio::GpioPin<earlgrey::pinmux::PadConfig>
@@ -524,6 +525,7 @@ unsafe fn setup() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
@@ -542,6 +544,7 @@ unsafe fn setup() -> (
         board_kernel,
         capsules_core::low_level_debug::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::low_level_debug_component_static!());
 
@@ -549,6 +552,7 @@ unsafe fn setup() -> (
         board_kernel,
         capsules_extra::hmac::DRIVER_NUM,
         &peripherals.hmac,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::hmac_component_static!(lowrisc::hmac::Hmac, 32));
 
@@ -580,6 +584,7 @@ unsafe fn setup() -> (
         mux_spi,
         lowrisc::spi_host::CS(0),
         capsules_core::spi_controller::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::spi_syscall_component_static!(
         lowrisc::spi_host::SpiHost
@@ -664,7 +669,7 @@ unsafe fn setup() -> (
         // Region Size
         lowrisc::flash_ctrl::FLASH_PAGES_PER_BANK * lowrisc::flash_ctrl::PAGE_SIZE,
         flash_ctrl_read_buf, // Buffer used internally in TicKV
-        page_buffer,         // Buffer used with the flash controller
+        page_buffer,         // Buffer used with the flash controller,
     )
     .finalize(components::tickv_component_static!(
         lowrisc::flash_ctrl::FlashCtrl,
@@ -741,6 +746,7 @@ unsafe fn setup() -> (
         virtual_kv_driver,
         board_kernel,
         capsules_extra::kv_driver::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::kv_driver_component_static!(
         capsules_extra::virtualizers::virtual_kv::VirtualKVPermissions<
@@ -841,6 +847,7 @@ unsafe fn setup() -> (
         board_kernel,
         capsules_extra::symmetric_encryption::aes::DRIVER_NUM,
         gcm_client,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::aes_driver_component_static!(
         aes_gcm::Aes128Gcm<

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -322,6 +322,7 @@ pub unsafe fn start_particle_boron() -> (
             //D0
             19 => &nrf52840_peripherals.gpio_port[Pin::P0_26],
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(GpioHw));
 
@@ -340,6 +341,7 @@ pub unsafe fn start_particle_boron() -> (
                 kernel::hil::gpio::FloatingState::PullUp
             )
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::button_component_static!(GpioHw));
 
@@ -375,6 +377,7 @@ pub unsafe fn start_particle_boron() -> (
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(AlarmHw));
 
@@ -405,6 +408,7 @@ pub unsafe fn start_particle_boron() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!(132, 132));
     // Create the debugger object that handles calls to `debug!()`.
@@ -425,6 +429,7 @@ pub unsafe fn start_particle_boron() -> (
         capsules_extra::ble_advertising_driver::DRIVER_NUM,
         &base_peripherals.ble_radio,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::ble_component_static!(AlarmHw, BleHw));
 
@@ -439,6 +444,7 @@ pub unsafe fn start_particle_boron() -> (
         PAN_ID,
         SRC_MAC,
         DEFAULT_EXT_SRC_MAC,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::ieee802154_component_static!(
         nrf52840::ieee802154_radio::Radio,
@@ -453,6 +459,7 @@ pub unsafe fn start_particle_boron() -> (
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,
         &base_peripherals.temp,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::temperature_component_static!(
         nrf52840::temperature::Temp
@@ -466,6 +473,7 @@ pub unsafe fn start_particle_boron() -> (
         board_kernel,
         capsules_core::rng::DRIVER_NUM,
         &base_peripherals.trng,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::rng_component_static!(nrf52840::trng::Trng));
 
@@ -478,46 +486,49 @@ pub unsafe fn start_particle_boron() -> (
     let adc_mux = components::adc::AdcMuxComponent::new(&base_peripherals.adc)
         .finalize(components::adc_mux_component_static!(nrf52840::adc::Adc));
 
-    let adc_syscall =
-        components::adc::AdcVirtualComponent::new(board_kernel, capsules_core::adc::DRIVER_NUM)
-            .finalize(components::adc_syscall_component_helper!(
-                // BRD_A0
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput1)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // BRD_A1
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput2)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // BRD_A2
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput4)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // BRD_A3
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput5)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // BRD_A4
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput6)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-                // BRD_A5
-                components::adc::AdcComponent::new(
-                    adc_mux,
-                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput7)
-                )
-                .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
-            ));
+    let adc_syscall = components::adc::AdcVirtualComponent::new(
+        board_kernel,
+        capsules_core::adc::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
+    )
+    .finalize(components::adc_syscall_component_helper!(
+        // BRD_A0
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput1)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // BRD_A1
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput2)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // BRD_A2
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput4)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // BRD_A3
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput5)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // BRD_A4
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput6)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+        // BRD_A5
+        components::adc::AdcComponent::new(
+            adc_mux,
+            nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput7)
+        )
+        .finalize(components::adc_component_static!(nrf52840::adc::Adc)),
+    ));
 
     //--------------------------------------------------------------------------
     // I2C Master/Slave

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -352,6 +352,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(RPTimer));
 
@@ -394,6 +395,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
@@ -430,6 +432,7 @@ pub unsafe fn start() -> (
             21 => peripherals.pins.get_pin(RPGpio::GPIO21),
             22 => peripherals.pins.get_pin(RPGpio::GPIO22),
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(RPGpioPin<'static>));
 
@@ -463,6 +466,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,
         temp_sensor,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::temperature_component_static!(
         TemperatureRp2040Sensor
@@ -536,6 +540,7 @@ pub unsafe fn start() -> (
                 kernel::hil::gpio::FloatingState::PullUp
             ), // Y
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::button_component_static!(RPGpioPin));
 
@@ -544,6 +549,7 @@ pub unsafe fn start() -> (
         capsules_extra::screen::screen::DRIVER_NUM,
         tft,
         Some(tft),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::screen_component_static!(57600));
 
@@ -556,13 +562,16 @@ pub unsafe fn start() -> (
     let adc_channel_2 = components::adc::AdcComponent::new(adc_mux, Channel::Channel2)
         .finalize(components::adc_component_static!(Adc));
 
-    let adc_syscall =
-        components::adc::AdcVirtualComponent::new(board_kernel, capsules_core::adc::DRIVER_NUM)
-            .finalize(components::adc_syscall_component_helper!(
-                adc_channel_0,
-                adc_channel_1,
-                adc_channel_2,
-            ));
+    let adc_syscall = components::adc::AdcVirtualComponent::new(
+        board_kernel,
+        capsules_core::adc::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
+    )
+    .finalize(components::adc_syscall_component_helper!(
+        adc_channel_0,
+        adc_channel_1,
+        adc_channel_2,
+    ));
 
     let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
         .finalize(components::process_printer_text_component_static!());

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -571,14 +571,22 @@ pub unsafe fn start() -> (
     });
 
     // PROCESS CONSOLE
+    kernel::declare_capability!(ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         Some(cortexm0p::support::reset),
+        ProcessConsoleCap,
     )
-    .finalize(components::process_console_component_static!(RPTimer));
+    .finalize(components::process_console_component_static!(
+        RPTimer,
+        ProcessConsoleCap
+    ));
     let _ = process_console.start();
 
     let scheduler = components::sched::round_robin::RoundRobinComponent::new(processes)

--- a/boards/psc3m5_evk/src/main.rs
+++ b/boards/psc3m5_evk/src/main.rs
@@ -237,14 +237,22 @@ pub unsafe fn start() -> (
         resources.printer.put(process_printer);
     });
 
+    kernel::declare_capability!(ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         Some(cortexm33::support::reset),
+        ProcessConsoleCap,
     )
-    .finalize(components::process_console_component_static!(Tcpwm0));
+    .finalize(components::process_console_component_static!(
+        Tcpwm0,
+        ProcessConsoleCap
+    ));
     let _ = process_console.start();
 
     let led_pin = peripherals.gpio.get_pin(gpio::PsocPin::P8_4);

--- a/boards/psc3m5_evk/src/main.rs
+++ b/boards/psc3m5_evk/src/main.rs
@@ -207,6 +207,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(Tcpwm0));
 
@@ -218,6 +219,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
 
@@ -306,6 +308,7 @@ pub unsafe fn start() -> (
             91 => peripherals.gpio.get_pin(gpio::PsocPin::P9_1), // Header J5.25
             93 => peripherals.gpio.get_pin(gpio::PsocPin::P9_3), // Header J24.3
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(gpio::GpioPin));
 
@@ -327,6 +330,7 @@ pub unsafe fn start() -> (
                 kernel::hil::gpio::FloatingState::PullNone
             ),
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::button_component_static!(gpio::GpioPin));
 

--- a/boards/qemu_i486_q35/src/main.rs
+++ b/boards/qemu_i486_q35/src/main.rs
@@ -118,8 +118,13 @@ fn init_virtio_dev(
     Some((int_line, dev))
 }
 
-/// Provides interrupt servicing logic for Virtio devices which may or may not be present at
-/// runtime.
+// Provides interrupt servicing logic for Virtio devices which may or may not be present at
+// runtime.
+kernel::declare_capability!(ProcessConsoleCap:
+    kernel::capabilities::ProcessManagementCapability,
+    kernel::capabilities::ProcessStartCapability
+);
+
 struct VirtioDevices {
     rng: OptionalCell<(u8, &'static VirtIOPCIDevice)>,
 }
@@ -144,7 +149,7 @@ pub struct QemuI386Q35Platform {
         'static,
         { capsules_core::process_console::DEFAULT_COMMAND_HISTORY_LEN },
         VirtualMuxAlarm<'static, Pit<'static, RELOAD_1KHZ>>,
-        components::process_console::Capability,
+        ProcessConsoleCap,
     >,
     console: &'static Console<'static>,
     lldb: &'static capsules_core::low_level_debug::LowLevelDebug<
@@ -463,9 +468,11 @@ unsafe extern "cdecl" fn main() {
         mux_alarm,
         process_printer,
         None,
+        ProcessConsoleCap,
     )
     .finalize(components::process_console_component_static!(
-        Pit<'static, RELOAD_1KHZ>
+        Pit<'static, RELOAD_1KHZ>,
+        ProcessConsoleCap,
     ));
 
     // Setup the console.

--- a/boards/qemu_i486_q35/src/main.rs
+++ b/boards/qemu_i486_q35/src/main.rs
@@ -118,13 +118,13 @@ fn init_virtio_dev(
     Some((int_line, dev))
 }
 
-// Provides interrupt servicing logic for Virtio devices which may or may not be present at
-// runtime.
 kernel::declare_capability!(ProcessConsoleCap:
     kernel::capabilities::ProcessManagementCapability,
     kernel::capabilities::ProcessStartCapability
 );
 
+/// Provides interrupt servicing logic for Virtio devices which may or may not be present at
+/// runtime.
 struct VirtioDevices {
     rng: OptionalCell<(u8, &'static VirtIOPCIDevice)>,
 }
@@ -476,8 +476,13 @@ unsafe extern "cdecl" fn main() {
     ));
 
     // Setup the console.
-    let console = ConsoleComponent::new(board_kernel, console::DRIVER_NUM, console_uart_device)
-        .finalize(components::console_component_static!());
+    let console = ConsoleComponent::new(
+        board_kernel,
+        console::DRIVER_NUM,
+        console_uart_device,
+        create_capability!(capabilities::MemoryAllocationCapability),
+    )
+    .finalize(components::console_component_static!());
 
     // Create the debugger object that handles calls to `debug!()`.
     DebugWriterComponent::new::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
@@ -490,6 +495,7 @@ unsafe extern "cdecl" fn main() {
         board_kernel,
         capsules_core::low_level_debug::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::low_level_debug_component_static!());
 
@@ -497,10 +503,15 @@ unsafe extern "cdecl" fn main() {
 
     // Userspace RNG driver over the VirtIO EntropySource
     let rng_driver = virtio_rng.map(|rng| {
-        components::rng::RngRandomComponent::new(board_kernel, capsules_core::rng::DRIVER_NUM, rng)
-            .finalize(components::rng_random_component_static!(
-                VirtIORng<X86DmaFence>
-            ))
+        components::rng::RngRandomComponent::new(
+            board_kernel,
+            capsules_core::rng::DRIVER_NUM,
+            rng,
+            create_capability!(capabilities::MemoryAllocationCapability),
+        )
+        .finalize(components::rng_random_component_static!(
+            VirtIORng<X86DmaFence>
+        ))
     });
 
     let scheduler = components::sched::cooperative::CooperativeComponent::new(processes)

--- a/boards/qemu_rv32_virt/src/lib.rs
+++ b/boards/qemu_rv32_virt/src/lib.rs
@@ -702,6 +702,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
@@ -717,6 +718,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::low_level_debug::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::low_level_debug_component_static!());
 
@@ -724,10 +726,15 @@ pub unsafe fn start() -> (
 
     // Userspace RNG driver over the VirtIO EntropySource
     let rng_driver = virtio_rng.map(|rng| {
-        components::rng::RngRandomComponent::new(board_kernel, capsules_core::rng::DRIVER_NUM, rng)
-            .finalize(components::rng_random_component_static!(
-                qemu_rv32_virt_chip::virtio::devices::virtio_rng::VirtIORng<RiscvCoherentDmaFence>
-            ))
+        components::rng::RngRandomComponent::new(
+            board_kernel,
+            capsules_core::rng::DRIVER_NUM,
+            rng,
+            create_capability!(capabilities::MemoryAllocationCapability),
+        )
+        .finalize(components::rng_random_component_static!(
+            qemu_rv32_virt_chip::virtio::devices::virtio_rng::VirtIORng<RiscvCoherentDmaFence>
+        ))
     });
 
     // ---------- SCHEDULER ----------

--- a/boards/qemu_rv32_virt/src/lib.rs
+++ b/boards/qemu_rv32_virt/src/lib.rs
@@ -52,6 +52,11 @@ static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>
 
 kernel::stack_size! {0x8000}
 
+kernel::declare_capability!(pub ProcessConsoleCap:
+    kernel::capabilities::ProcessManagementCapability,
+    kernel::capabilities::ProcessStartCapability
+);
+
 /// A structure representing this platform that holds references to all
 /// capsules for this platform. We've included an alarm and console.
 pub struct QemuRv32VirtPlatform {
@@ -62,7 +67,7 @@ pub struct QemuRv32VirtPlatform {
             'static,
             qemu_rv32_virt_chip::chip::QemuRv32VirtClint<'static>,
         >,
-        components::process_console::Capability,
+        ProcessConsoleCap,
     >,
     console: &'static capsules_core::console::Console<'static>,
     lldb: &'static capsules_core::low_level_debug::LowLevelDebug<
@@ -685,9 +690,11 @@ pub unsafe fn start() -> (
         mux_alarm,
         process_printer,
         None,
+        ProcessConsoleCap,
     )
     .finalize(components::process_console_component_static!(
-        qemu_rv32_virt_chip::chip::QemuRv32VirtClint
+        qemu_rv32_virt_chip::chip::QemuRv32VirtClint,
+        ProcessConsoleCap
     ));
 
     // Setup the console.

--- a/boards/qemu_rv32_virt/src/lib.rs
+++ b/boards/qemu_rv32_virt/src/lib.rs
@@ -8,6 +8,7 @@
 #![no_main]
 
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use kernel::ErrorCode;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::debug::PanicResources;
@@ -52,7 +53,7 @@ static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>
 
 kernel::stack_size! {0x8000}
 
-kernel::declare_capability!(pub ProcessConsoleCap:
+kernel::declare_capability!(ProcessConsoleCap:
     kernel::capabilities::ProcessManagementCapability,
     kernel::capabilities::ProcessStartCapability
 );
@@ -60,7 +61,7 @@ kernel::declare_capability!(pub ProcessConsoleCap:
 /// A structure representing this platform that holds references to all
 /// capsules for this platform. We've included an alarm and console.
 pub struct QemuRv32VirtPlatform {
-    pub pconsole: &'static capsules_core::process_console::ProcessConsole<
+    pconsole: &'static capsules_core::process_console::ProcessConsole<
         'static,
         { capsules_core::process_console::DEFAULT_COMMAND_HISTORY_LEN },
         capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<
@@ -103,6 +104,12 @@ pub struct QemuRv32VirtPlatform {
             RiscvCoherentDmaFence,
         >,
     >,
+}
+
+impl QemuRv32VirtPlatform {
+    pub fn process_console_start(&self) -> Result<(), ErrorCode> {
+        self.pconsole.start()
+    }
 }
 
 /// Mapping of integer syscalls to objects that implement syscalls.

--- a/boards/qemu_rv32_virt/src/main.rs
+++ b/boards/qemu_rv32_virt/src/main.rs
@@ -100,6 +100,7 @@ pub unsafe fn main() {
             capsules_extra::screen::screen::DRIVER_NUM,
             screen,
             None,
+            create_capability!(capabilities::MemoryAllocationCapability),
         )
         .finalize(components::screen_component_static!(1032))
     });

--- a/boards/qemu_rv32_virt/src/main.rs
+++ b/boards/qemu_rv32_virt/src/main.rs
@@ -111,7 +111,7 @@ pub unsafe fn main() {
     };
 
     // Start the process console:
-    let _ = platform.base.pconsole.start();
+    let _ = platform.base.process_console_start();
 
     // These symbols are defined in the linker script.
     extern "C" {

--- a/boards/raspberry_pi_pico/src/lib.rs
+++ b/boards/raspberry_pi_pico/src/lib.rs
@@ -324,6 +324,7 @@ pub unsafe fn setup(
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(RPTimer));
 
@@ -370,6 +371,7 @@ pub unsafe fn setup(
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
@@ -425,6 +427,7 @@ pub unsafe fn setup(
             // 28 => peripherals.pins.get_pin(RPGpio::GPIO28),
             // 29 => peripherals.pins.get_pin(RPGpio::GPIO29)
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(RPGpioPin<'static>));
 
@@ -454,6 +457,7 @@ pub unsafe fn setup(
         board_kernel,
         capsules_extra::date_time::DRIVER_NUM,
         &peripherals.rtc,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::date_time_component_static!(
         rp2040::rtc::Rtc<'static>
@@ -463,6 +467,7 @@ pub unsafe fn setup(
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,
         temp_sensor,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::temperature_component_static!(
         TemperatureRp2040Sensor
@@ -480,14 +485,17 @@ pub unsafe fn setup(
     let adc_channel_3 = components::adc::AdcComponent::new(adc_mux, adc::Channel::Channel3)
         .finalize(components::adc_component_static!(Adc));
 
-    let adc =
-        components::adc::AdcVirtualComponent::new(board_kernel, capsules_core::adc::DRIVER_NUM)
-            .finalize(components::adc_syscall_component_helper!(
-                adc_channel_0,
-                adc_channel_1,
-                adc_channel_2,
-                adc_channel_3,
-            ));
+    let adc = components::adc::AdcVirtualComponent::new(
+        board_kernel,
+        capsules_core::adc::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
+    )
+    .finalize(components::adc_syscall_component_helper!(
+        adc_channel_0,
+        adc_channel_1,
+        adc_channel_2,
+        adc_channel_3,
+    ));
 
     // PROCESS CONSOLE
     let process_printer = components::process_printer::ProcessPrinterTextComponent::new()

--- a/boards/raspberry_pi_pico/src/lib.rs
+++ b/boards/raspberry_pi_pico/src/lib.rs
@@ -496,14 +496,22 @@ pub unsafe fn setup(
         resources.printer.put(process_printer);
     });
 
+    kernel::declare_capability!(ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         Some(cortexm0p::support::reset),
+        ProcessConsoleCap,
     )
-    .finalize(components::process_console_component_static!(RPTimer));
+    .finalize(components::process_console_component_static!(
+        RPTimer,
+        ProcessConsoleCap
+    ));
     let _ = process_console.start();
 
     let sda_pin = peripherals.pins.get_pin(RPGpio::GPIO4);

--- a/boards/raspberry_pi_pico_2/src/main.rs
+++ b/boards/raspberry_pi_pico_2/src/main.rs
@@ -318,6 +318,7 @@ pub unsafe fn main() {
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(RPTimer));
 
@@ -329,6 +330,7 @@ pub unsafe fn main() {
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
 
@@ -370,6 +372,7 @@ pub unsafe fn main() {
             28 => peripherals.pins.get_pin(RPGpio::GPIO28),
             29 => peripherals.pins.get_pin(RPGpio::GPIO29)
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(RPGpioPin<'static>));
 

--- a/boards/raspberry_pi_pico_2/src/main.rs
+++ b/boards/raspberry_pi_pico_2/src/main.rs
@@ -394,14 +394,22 @@ pub unsafe fn main() {
         resources.printer.put(process_printer);
     });
 
+    kernel::declare_capability!(ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         Some(cortexm33::support::reset),
+        ProcessConsoleCap,
     )
-    .finalize(components::process_console_component_static!(RPTimer));
+    .finalize(components::process_console_component_static!(
+        RPTimer,
+        ProcessConsoleCap
+    ));
     let _ = process_console.start();
 
     let scheduler = components::sched::round_robin::RoundRobinComponent::new(processes)

--- a/boards/raspberry_pi_pico_w/src/main.rs
+++ b/boards/raspberry_pi_pico_w/src/main.rs
@@ -161,6 +161,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_extra::wifi::DRIVER_NUM,
         cyw4343_device,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::wifi_component_static!(CYW4343xHw));
 

--- a/boards/redboard_redv/src/main.rs
+++ b/boards/redboard_redv/src/main.rs
@@ -257,15 +257,21 @@ unsafe fn start() -> (
         resources.printer.put(process_printer);
     });
 
+    kernel::declare_capability!(ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         None,
+        ProcessConsoleCap,
     )
     .finalize(components::process_console_component_static!(
-        e310_g002::chip::E310xClint
+        e310_g002::chip::E310xClint,
+        ProcessConsoleCap
     ));
     let _ = process_console.start();
 

--- a/boards/redboard_redv/src/main.rs
+++ b/boards/redboard_redv/src/main.rs
@@ -289,6 +289,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
@@ -304,6 +305,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::low_level_debug::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::low_level_debug_component_static!());
 

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -14,16 +14,12 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use capsules_core::virtualizers::virtual_aes_ccm::MuxAES128CCM;
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice;
 use kernel::component::Component;
 use kernel::debug::PanicResources;
-use kernel::deferred_call::DeferredCallClient;
-use kernel::hil::i2c::I2CMaster;
 use kernel::hil::led::LedHigh;
 use kernel::hil::screen::Screen;
-use kernel::hil::symmetric_encryption::AES128;
 use kernel::hil::time::Counter;
 use kernel::platform::chip::Chip;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
@@ -73,7 +69,7 @@ static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterI
 kernel::stack_size! {0x1000}
 
 type Bmp280Sensor = components::bmp280::Bmp280ComponentType<
-    VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
+    VirtualMuxAlarm<'static, AlarmHw>,
     capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, nrf52840::i2c::TWI<'static>>,
 >;
 type TemperatureDriver = components::temperature::TemperatureComponentType<Bmp280Sensor>;
@@ -83,6 +79,12 @@ type Ieee802154Driver = components::ieee802154::Ieee802154ComponentType<
     nrf52840::ieee802154_radio::Radio<'static>,
     nrf52840::aes::AesECB<'static>,
 >;
+
+type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
+
+//------------------------------------------------------------------------------
+// SYSCALL DRIVER TYPE DEFINITIONS
+//------------------------------------------------------------------------------
 
 type BleHw = nrf52840::ble_radio::Radio<'static>;
 type AlarmHw = nrf52840::rtc::Rtc<'static>;
@@ -98,16 +100,15 @@ type ButtonDriver = components::button::ButtonComponentType<GpioHw>;
 type ConsoleDriver = components::console::ConsoleComponentType;
 type AnalogComparatorDriver =
     components::analog_comparator::AnalogComparatorComponentType<AnalogComparatorHw>;
-type ProcessConsoleDriver =
-    components::process_console::ProcessConsoleComponentType<AlarmHw, ProcessConsoleCap>;
 type ScreenDriver = components::screen::ScreenComponentType;
-
-type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
 
 kernel::declare_capability!(ProcessConsoleCap:
     kernel::capabilities::ProcessManagementCapability,
     kernel::capabilities::ProcessStartCapability
 );
+
+type ProcessConsoleDriver =
+    components::process_console::ProcessConsoleComponentType<AlarmHw, ProcessConsoleCap>;
 
 /// Supported drivers by the platform
 pub struct Platform {
@@ -240,30 +241,30 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::gpio::DRIVER_NUM,
         components::gpio_component_helper!(
-            nrf52840::gpio::GPIOPin,
+            GpioHw,
             0 => &nrf52840_peripherals.gpio_port[Pin::P0_29],
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
-    .finalize(components::gpio_component_static!(nrf52840::gpio::GPIOPin));
+    .finalize(components::gpio_component_static!(GpioHw));
 
     let button = components::button::ButtonComponent::new(
         board_kernel,
         capsules_core::button::DRIVER_NUM,
         components::button_component_helper!(
-            nrf52840::gpio::GPIOPin,
+            GpioHw,
             (
                 &nrf52840_peripherals.gpio_port[BUTTON_PIN],
                 kernel::hil::gpio::ActivationMode::ActiveLow,
                 kernel::hil::gpio::FloatingState::PullUp
             )
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
-    .finalize(components::button_component_static!(
-        nrf52840::gpio::GPIOPin
-    ));
+    .finalize(components::button_component_static!(GpioHw));
 
     let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
-        LedHigh<'static, nrf52840::gpio::GPIOPin>,
+        LedHigh<'static, GpioHw>,
         LedHigh::new(&nrf52840_peripherals.gpio_port[LED1_PIN]),
         LedHigh::new(&nrf52840_peripherals.gpio_port[VIBRA1_PIN]),
     ));
@@ -307,13 +308,14 @@ pub unsafe fn start() -> (
     let rtc = &base_peripherals.rtc;
     let _ = rtc.start();
     let mux_alarm = components::alarm::AlarmMuxComponent::new(rtc)
-        .finalize(components::alarm_mux_component_static!(nrf52840::rtc::Rtc));
+        .finalize(components::alarm_mux_component_static!(AlarmHw));
     let alarm = components::alarm::AlarmDriverComponent::new(
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
-    .finalize(components::alarm_component_static!(nrf52840::rtc::Rtc));
+    .finalize(components::alarm_component_static!(AlarmHw));
 
     let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
         .finalize(components::process_printer_text_component_static!());
@@ -333,7 +335,7 @@ pub unsafe fn start() -> (
         self::io::set_rtt_memory(&*core::ptr::from_mut(rtt_memory.rtt_memory));
 
         components::segger_rtt::SeggerRttComponent::new(mux_alarm, rtt_memory)
-            .finalize(components::segger_rtt_component_static!(nrf52840::rtc::Rtc))
+            .finalize(components::segger_rtt_component_static!(AlarmHw))
     };
 
     // Create a shared UART channel for the console and for kernel debug.
@@ -350,7 +352,7 @@ pub unsafe fn start() -> (
     )
     .finalize(components::process_console_component_static!(
         nrf52840::rtc::Rtc<'static>,
-        ProcessConsoleCap
+        ProcessConsoleCap,
     ));
 
     // Setup the console.
@@ -358,6 +360,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
@@ -374,18 +377,12 @@ pub unsafe fn start() -> (
         capsules_extra::ble_advertising_driver::DRIVER_NUM,
         &base_peripherals.ble_radio,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
-    .finalize(components::ble_component_static!(
-        nrf52840::rtc::Rtc,
-        nrf52840::ble_radio::Radio
-    ));
+    .finalize(components::ble_component_static!(AlarmHw, BleHw));
 
-    let aes_mux = static_init!(
-        MuxAES128CCM<'static, nrf52840::aes::AesECB>,
-        MuxAES128CCM::new(&base_peripherals.ecb,)
-    );
-    base_peripherals.ecb.set_client(aes_mux);
-    aes_mux.register();
+    let aes_mux = components::aes::AesMuxComponent::new(&base_peripherals.ecb)
+        .finalize(components::aes_mux_component_static!(nrf52840::aes::AesECB));
 
     let (ieee802154_radio, _mux_mac) = components::ieee802154::Ieee802154Component::new(
         board_kernel,
@@ -395,6 +392,7 @@ pub unsafe fn start() -> (
         PAN_ID,
         SRC_MAC,
         DEFAULT_EXT_SRC_MAC,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::ieee802154_component_static!(
         nrf52840::ieee802154_radio::Radio,
@@ -407,22 +405,18 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,
         &base_peripherals.temp,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::temperature_component_static!(
         nrf52840::temperature::Temp
     ));
 
-    let sensors_i2c_bus = static_init!(
-        capsules_core::virtualizers::virtual_i2c::MuxI2C<'static, nrf52840::i2c::TWI>,
-        capsules_core::virtualizers::virtual_i2c::MuxI2C::new(&base_peripherals.twi1, None,)
-    );
-    sensors_i2c_bus.register();
-
     base_peripherals.twi1.configure(
         nrf52840::pinmux::Pinmux::new(I2C_TEMP_SCL_PIN),
         nrf52840::pinmux::Pinmux::new(I2C_TEMP_SDA_PIN),
     );
-    base_peripherals.twi1.set_master_client(sensors_i2c_bus);
+    let sensors_i2c_bus = components::i2c::I2CMuxComponent::new(&base_peripherals.twi1, None)
+        .finalize(components::i2c_mux_component_static!(nrf52840::i2c::TWI));
 
     let bmp280 = components::bmp280::Bmp280Component::new(
         sensors_i2c_bus,
@@ -430,7 +424,7 @@ pub unsafe fn start() -> (
         mux_alarm,
     )
     .finalize(components::bmp280_component_static!(
-        nrf52840::rtc::Rtc<'static>,
+        AlarmHw,
         nrf52840::i2c::TWI
     ));
 
@@ -438,6 +432,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,
         bmp280,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::temperature_component_static!(Bmp280Sensor));
 
@@ -445,6 +440,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::rng::DRIVER_NUM,
         &base_peripherals.trng,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::rng_component_static!(nrf52840::trng::Trng));
 
@@ -458,9 +454,10 @@ pub unsafe fn start() -> (
         ),
         board_kernel,
         capsules_extra::analog_comparator::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::analog_comparator_component_static!(
-        nrf52840::acomp::Comparator
+        AnalogComparatorHw
     ));
 
     nrf52_components::NrfClockComponent::new(&base_peripherals.clock).finalize(());
@@ -469,7 +466,7 @@ pub unsafe fn start() -> (
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let periodic_virtual_alarm = static_init!(
-        capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, nrf52840::rtc::Rtc>,
+        capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, AlarmHw>,
         capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm::new(mux_alarm)
     );
     periodic_virtual_alarm.setup();
@@ -501,8 +498,8 @@ pub unsafe fn start() -> (
             mux_alarm,
         )
         .finalize(components::lpm013m126_component_static!(
-            nrf52840::rtc::Rtc<'static>,
-            nrf52840::gpio::GPIOPin,
+            AlarmHw,
+            GpioHw,
             nrf52840::spi::SPIM
         ));
 
@@ -511,6 +508,7 @@ pub unsafe fn start() -> (
             capsules_extra::screen::screen::DRIVER_NUM,
             display,
             None,
+            create_capability!(capabilities::MemoryAllocationCapability),
         )
         .finalize(components::screen_component_static!(4096));
         // Power on screen if not already powered

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -14,12 +14,16 @@
 #![no_main]
 #![deny(missing_docs)]
 
+use capsules_core::virtualizers::virtual_aes_ccm::MuxAES128CCM;
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
 use capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice;
 use kernel::component::Component;
 use kernel::debug::PanicResources;
+use kernel::deferred_call::DeferredCallClient;
+use kernel::hil::i2c::I2CMaster;
 use kernel::hil::led::LedHigh;
 use kernel::hil::screen::Screen;
+use kernel::hil::symmetric_encryption::AES128;
 use kernel::hil::time::Counter;
 use kernel::platform::chip::Chip;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
@@ -69,7 +73,7 @@ static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterI
 kernel::stack_size! {0x1000}
 
 type Bmp280Sensor = components::bmp280::Bmp280ComponentType<
-    VirtualMuxAlarm<'static, AlarmHw>,
+    VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
     capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, nrf52840::i2c::TWI<'static>>,
 >;
 type TemperatureDriver = components::temperature::TemperatureComponentType<Bmp280Sensor>;
@@ -79,12 +83,6 @@ type Ieee802154Driver = components::ieee802154::Ieee802154ComponentType<
     nrf52840::ieee802154_radio::Radio<'static>,
     nrf52840::aes::AesECB<'static>,
 >;
-
-type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
-
-//------------------------------------------------------------------------------
-// SYSCALL DRIVER TYPE DEFINITIONS
-//------------------------------------------------------------------------------
 
 type BleHw = nrf52840::ble_radio::Radio<'static>;
 type AlarmHw = nrf52840::rtc::Rtc<'static>;
@@ -100,8 +98,16 @@ type ButtonDriver = components::button::ButtonComponentType<GpioHw>;
 type ConsoleDriver = components::console::ConsoleComponentType;
 type AnalogComparatorDriver =
     components::analog_comparator::AnalogComparatorComponentType<AnalogComparatorHw>;
-type ProcessConsoleDriver = components::process_console::ProcessConsoleComponentType<AlarmHw>;
+type ProcessConsoleDriver =
+    components::process_console::ProcessConsoleComponentType<AlarmHw, ProcessConsoleCap>;
 type ScreenDriver = components::screen::ScreenComponentType;
+
+type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
+
+kernel::declare_capability!(ProcessConsoleCap:
+    kernel::capabilities::ProcessManagementCapability,
+    kernel::capabilities::ProcessStartCapability
+);
 
 /// Supported drivers by the platform
 pub struct Platform {
@@ -234,17 +240,17 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::gpio::DRIVER_NUM,
         components::gpio_component_helper!(
-            GpioHw,
+            nrf52840::gpio::GPIOPin,
             0 => &nrf52840_peripherals.gpio_port[Pin::P0_29],
         ),
     )
-    .finalize(components::gpio_component_static!(GpioHw));
+    .finalize(components::gpio_component_static!(nrf52840::gpio::GPIOPin));
 
     let button = components::button::ButtonComponent::new(
         board_kernel,
         capsules_core::button::DRIVER_NUM,
         components::button_component_helper!(
-            GpioHw,
+            nrf52840::gpio::GPIOPin,
             (
                 &nrf52840_peripherals.gpio_port[BUTTON_PIN],
                 kernel::hil::gpio::ActivationMode::ActiveLow,
@@ -252,10 +258,12 @@ pub unsafe fn start() -> (
             )
         ),
     )
-    .finalize(components::button_component_static!(GpioHw));
+    .finalize(components::button_component_static!(
+        nrf52840::gpio::GPIOPin
+    ));
 
     let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
-        LedHigh<'static, GpioHw>,
+        LedHigh<'static, nrf52840::gpio::GPIOPin>,
         LedHigh::new(&nrf52840_peripherals.gpio_port[LED1_PIN]),
         LedHigh::new(&nrf52840_peripherals.gpio_port[VIBRA1_PIN]),
     ));
@@ -299,13 +307,13 @@ pub unsafe fn start() -> (
     let rtc = &base_peripherals.rtc;
     let _ = rtc.start();
     let mux_alarm = components::alarm::AlarmMuxComponent::new(rtc)
-        .finalize(components::alarm_mux_component_static!(AlarmHw));
+        .finalize(components::alarm_mux_component_static!(nrf52840::rtc::Rtc));
     let alarm = components::alarm::AlarmDriverComponent::new(
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
     )
-    .finalize(components::alarm_component_static!(AlarmHw));
+    .finalize(components::alarm_component_static!(nrf52840::rtc::Rtc));
 
     let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
         .finalize(components::process_printer_text_component_static!());
@@ -325,7 +333,7 @@ pub unsafe fn start() -> (
         self::io::set_rtt_memory(&*core::ptr::from_mut(rtt_memory.rtt_memory));
 
         components::segger_rtt::SeggerRttComponent::new(mux_alarm, rtt_memory)
-            .finalize(components::segger_rtt_component_static!(AlarmHw))
+            .finalize(components::segger_rtt_component_static!(nrf52840::rtc::Rtc))
     };
 
     // Create a shared UART channel for the console and for kernel debug.
@@ -338,8 +346,12 @@ pub unsafe fn start() -> (
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
+        ProcessConsoleCap,
     )
-    .finalize(components::process_console_component_static!(AlarmHw));
+    .finalize(components::process_console_component_static!(
+        nrf52840::rtc::Rtc<'static>,
+        ProcessConsoleCap
+    ));
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(
@@ -363,10 +375,17 @@ pub unsafe fn start() -> (
         &base_peripherals.ble_radio,
         mux_alarm,
     )
-    .finalize(components::ble_component_static!(AlarmHw, BleHw));
+    .finalize(components::ble_component_static!(
+        nrf52840::rtc::Rtc,
+        nrf52840::ble_radio::Radio
+    ));
 
-    let aes_mux = components::aes::AesMuxComponent::new(&base_peripherals.ecb)
-        .finalize(components::aes_mux_component_static!(nrf52840::aes::AesECB));
+    let aes_mux = static_init!(
+        MuxAES128CCM<'static, nrf52840::aes::AesECB>,
+        MuxAES128CCM::new(&base_peripherals.ecb,)
+    );
+    base_peripherals.ecb.set_client(aes_mux);
+    aes_mux.register();
 
     let (ieee802154_radio, _mux_mac) = components::ieee802154::Ieee802154Component::new(
         board_kernel,
@@ -393,12 +412,17 @@ pub unsafe fn start() -> (
         nrf52840::temperature::Temp
     ));
 
+    let sensors_i2c_bus = static_init!(
+        capsules_core::virtualizers::virtual_i2c::MuxI2C<'static, nrf52840::i2c::TWI>,
+        capsules_core::virtualizers::virtual_i2c::MuxI2C::new(&base_peripherals.twi1, None,)
+    );
+    sensors_i2c_bus.register();
+
     base_peripherals.twi1.configure(
         nrf52840::pinmux::Pinmux::new(I2C_TEMP_SCL_PIN),
         nrf52840::pinmux::Pinmux::new(I2C_TEMP_SDA_PIN),
     );
-    let sensors_i2c_bus = components::i2c::I2CMuxComponent::new(&base_peripherals.twi1, None)
-        .finalize(components::i2c_mux_component_static!(nrf52840::i2c::TWI));
+    base_peripherals.twi1.set_master_client(sensors_i2c_bus);
 
     let bmp280 = components::bmp280::Bmp280Component::new(
         sensors_i2c_bus,
@@ -406,7 +430,7 @@ pub unsafe fn start() -> (
         mux_alarm,
     )
     .finalize(components::bmp280_component_static!(
-        AlarmHw,
+        nrf52840::rtc::Rtc<'static>,
         nrf52840::i2c::TWI
     ));
 
@@ -436,7 +460,7 @@ pub unsafe fn start() -> (
         capsules_extra::analog_comparator::DRIVER_NUM,
     )
     .finalize(components::analog_comparator_component_static!(
-        AnalogComparatorHw
+        nrf52840::acomp::Comparator
     ));
 
     nrf52_components::NrfClockComponent::new(&base_peripherals.clock).finalize(());
@@ -445,7 +469,7 @@ pub unsafe fn start() -> (
         .finalize(components::round_robin_component_static!(NUM_PROCS));
 
     let periodic_virtual_alarm = static_init!(
-        capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, AlarmHw>,
+        capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, nrf52840::rtc::Rtc>,
         capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm::new(mux_alarm)
     );
     periodic_virtual_alarm.setup();
@@ -477,8 +501,8 @@ pub unsafe fn start() -> (
             mux_alarm,
         )
         .finalize(components::lpm013m126_component_static!(
-            AlarmHw,
-            GpioHw,
+            nrf52840::rtc::Rtc<'static>,
+            nrf52840::gpio::GPIOPin,
             nrf52840::spi::SPIM
         ));
 

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -799,15 +799,21 @@ unsafe fn start() -> (
     });
 
     // PROCESS CONSOLE
+    kernel::declare_capability!(ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
+        ProcessConsoleCap,
     )
     .finalize(components::process_console_component_static!(
-        stm32f303xc::tim2::Tim2
+        stm32f303xc::tim2::Tim2,
+        ProcessConsoleCap
     ));
     let _ = process_console.start();
 

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -455,6 +455,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
@@ -537,9 +538,10 @@ unsafe fn start() -> (
                 kernel::hil::gpio::FloatingState::PullNone
             )
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::button_component_static!(
-        stm32f303xc::gpio::Pin<'static>
+        stm32f303xc::gpio::Pin<'static>,
     ));
 
     // ALARM
@@ -553,6 +555,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(stm32f303xc::tim2::Tim2));
 
@@ -655,9 +658,10 @@ unsafe fn start() -> (
             85 => gpio_ports.get_pin(stm32f303xc::gpio::PinId::PA09).unwrap(),
             86 => gpio_ports.get_pin(stm32f303xc::gpio::PinId::PC09).unwrap()
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(
-        stm32f303xc::gpio::Pin<'static>
+        stm32f303xc::gpio::Pin<'static>,
     ));
 
     // L3GD20 sensor
@@ -669,6 +673,7 @@ unsafe fn start() -> (
         gpio_ports.get_pin(stm32f303xc::gpio::PinId::PE03).unwrap(),
         board_kernel,
         capsules_extra::l3gd20::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::l3gd20_component_static!(
         // spi type
@@ -682,6 +687,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,
         l3gd20,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::temperature_component_static!(L3GD20Sensor));
 
@@ -696,6 +702,7 @@ unsafe fn start() -> (
         None,
         board_kernel,
         capsules_extra::lsm303dlhc::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::lsm303dlhc_component_static!(
         stm32f303xc::i2c::I2C
@@ -716,6 +723,7 @@ unsafe fn start() -> (
     let ninedof = components::ninedof::NineDofComponent::new(
         board_kernel,
         capsules_extra::ninedof::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::ninedof_component_static!(l3gd20, lsm303dlhc));
 
@@ -762,14 +770,17 @@ unsafe fn start() -> (
         components::adc::AdcComponent::new(adc_mux, stm32f303xc::adc::Channel::Channel5)
             .finalize(components::adc_component_static!(stm32f303xc::adc::Adc));
 
-    let adc_syscall =
-        components::adc::AdcVirtualComponent::new(board_kernel, capsules_core::adc::DRIVER_NUM)
-            .finalize(components::adc_syscall_component_helper!(
-                adc_channel_2,
-                adc_channel_3,
-                adc_channel_4,
-                adc_channel_5,
-            ));
+    let adc_syscall = components::adc::AdcVirtualComponent::new(
+        board_kernel,
+        capsules_core::adc::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
+    )
+    .finalize(components::adc_syscall_component_helper!(
+        adc_channel_2,
+        adc_channel_3,
+        adc_channel_4,
+        adc_channel_5,
+    ));
 
     // Kernel storage region, allocated with the storage_volume!
     // macro in common/utils.rs
@@ -787,6 +798,7 @@ unsafe fn start() -> (
         0x8000,     // Length of userspace accesible region (16 pages)
         core::ptr::addr_of!(_sstorage) as usize,
         core::ptr::addr_of!(_estorage) as usize - core::ptr::addr_of!(_sstorage) as usize,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::nonvolatile_storage_component_static!(
         stm32f303xc::flash::Flash

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -500,6 +500,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
@@ -595,6 +596,7 @@ unsafe fn start() -> (
                 kernel::hil::gpio::FloatingState::PullNone
             )
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::button_component_static!(stm32f412g::gpio::Pin));
 
@@ -609,6 +611,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(stm32f412g::tim2::Tim2));
 
@@ -644,6 +647,7 @@ unsafe fn start() -> (
             // 19 => base_peripherals.gpio_ports.get_pin(stm32f412g::gpio::PinId::PC05).unwrap(), //A4
             // 20 => base_peripherals.gpio_ports.get_pin(stm32f412g::gpio::PinId::PB00).unwrap() //A5
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(stm32f412g::gpio::Pin));
 
@@ -652,6 +656,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::rng::DRIVER_NUM,
         &peripherals.trng,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::rng_component_static!(stm32f412g::trng::Trng));
 
@@ -699,6 +704,7 @@ unsafe fn start() -> (
         capsules_extra::screen::screen::DRIVER_NUM,
         tft,
         Some(tft),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::screen_component_static!(1024));
 
@@ -708,6 +714,7 @@ unsafe fn start() -> (
         ft6x06,
         Some(ft6x06),
         Some(tft),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::touch_component_static!());
 
@@ -736,6 +743,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,
         temp_sensor,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::temperature_component_static!(
         TemperatureSTMSensor
@@ -765,16 +773,19 @@ unsafe fn start() -> (
         components::adc::AdcComponent::new(adc_mux, stm32f412g::adc::Channel::Channel8)
             .finalize(components::adc_component_static!(stm32f412g::adc::Adc));
 
-    let adc_syscall =
-        components::adc::AdcVirtualComponent::new(board_kernel, capsules_core::adc::DRIVER_NUM)
-            .finalize(components::adc_syscall_component_helper!(
-                adc_channel_0,
-                adc_channel_1,
-                adc_channel_2,
-                adc_channel_3,
-                adc_channel_4,
-                adc_channel_5
-            ));
+    let adc_syscall = components::adc::AdcVirtualComponent::new(
+        board_kernel,
+        capsules_core::adc::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
+    )
+    .finalize(components::adc_syscall_component_helper!(
+        adc_channel_0,
+        adc_channel_1,
+        adc_channel_2,
+        adc_channel_3,
+        adc_channel_4,
+        adc_channel_5
+    ));
 
     let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
         .finalize(components::process_printer_text_component_static!());

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -783,15 +783,21 @@ unsafe fn start() -> (
     });
 
     // PROCESS CONSOLE
+    kernel::declare_capability!(ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
+        ProcessConsoleCap,
     )
     .finalize(components::process_console_component_static!(
-        stm32f412g::tim2::Tim2
+        stm32f412g::tim2::Tim2,
+        ProcessConsoleCap
     ));
     let _ = process_console.start();
 

--- a/boards/stm32f429idiscovery/src/main.rs
+++ b/boards/stm32f429idiscovery/src/main.rs
@@ -591,15 +591,21 @@ unsafe fn start() -> (
     });
 
     // PROCESS CONSOLE
+    kernel::declare_capability!(ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
+        ProcessConsoleCap,
     )
     .finalize(components::process_console_component_static!(
-        stm32f429zi::tim2::Tim2
+        stm32f429zi::tim2::Tim2,
+        ProcessConsoleCap
     ));
     let _ = process_console.start();
 

--- a/boards/stm32f429idiscovery/src/main.rs
+++ b/boards/stm32f429idiscovery/src/main.rs
@@ -368,6 +368,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
@@ -404,6 +405,7 @@ unsafe fn start() -> (
                 kernel::hil::gpio::FloatingState::PullNone
             )
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::button_component_static!(stm32f429zi::gpio::Pin));
 
@@ -418,6 +420,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(stm32f429zi::tim2::Tim2));
 
@@ -523,6 +526,7 @@ unsafe fn start() -> (
             // 79 gpio_ports.pins::PIN[2][2].as_ref().unwrap(), //A7
             // 80 gpio_ports.pins::PIN[5][4].as_ref().unwrap()  //A8
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(stm32f429zi::gpio::Pin));
 
@@ -544,6 +548,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,
         temp_sensor,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::temperature_component_static!(
         TemperatureSTMSensor
@@ -573,16 +578,19 @@ unsafe fn start() -> (
         components::adc::AdcComponent::new(adc_mux, stm32f429zi::adc::Channel::Channel8)
             .finalize(components::adc_component_static!(stm32f429zi::adc::Adc));
 
-    let adc_syscall =
-        components::adc::AdcVirtualComponent::new(board_kernel, capsules_core::adc::DRIVER_NUM)
-            .finalize(components::adc_syscall_component_helper!(
-                adc_channel_0,
-                adc_channel_1,
-                adc_channel_2,
-                adc_channel_3,
-                adc_channel_4,
-                adc_channel_5
-            ));
+    let adc_syscall = components::adc::AdcVirtualComponent::new(
+        board_kernel,
+        capsules_core::adc::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
+    )
+    .finalize(components::adc_syscall_component_helper!(
+        adc_channel_0,
+        adc_channel_1,
+        adc_channel_2,
+        adc_channel_3,
+        adc_channel_4,
+        adc_channel_5
+    ));
 
     let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
         .finalize(components::process_printer_text_component_static!());

--- a/boards/teensy40/src/main.rs
+++ b/boards/teensy40/src/main.rs
@@ -296,6 +296,7 @@ unsafe fn start() -> (&'static kernel::Kernel, Teensy40, &'static ChipHw) {
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
 
@@ -313,6 +314,7 @@ unsafe fn start() -> (&'static kernel::Kernel, Teensy40, &'static ChipHw) {
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(imxrt1060::gpt::Gpt1));
 

--- a/boards/tutorials/nrf52840dk-dynamic-apps-and-policies/src/main.rs
+++ b/boards/tutorials/nrf52840dk-dynamic-apps-and-policies/src/main.rs
@@ -272,6 +272,7 @@ pub unsafe fn main() {
         capsules_extra::screen::screen::DRIVER_NUM,
         ssd1306_sh1106,
         apps_regions,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::screen_shared_component_static!(1032, Screen));
 
@@ -308,7 +309,8 @@ pub unsafe fn main() {
         capsules_extra::isolated_nonvolatile_storage_driver::DRIVER_NUM,
         virtual_flash_nvm,
         core::ptr::addr_of!(APP_STORAGE) as usize,
-        APP_STORAGE.len()
+        APP_STORAGE.len(),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::isolated_nonvolatile_storage_component_static!(
         capsules_core::virtualizers::virtual_flash::FlashUser<'static, nrf52840::nvmc::Nvmc>,
@@ -323,6 +325,7 @@ pub unsafe fn main() {
         board_kernel,
         capsules_extra::process_info_driver::DRIVER_NUM,
         PMCapability,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::process_info_component_static!(PMCapability));
 
@@ -492,6 +495,7 @@ pub unsafe fn main() {
         storage_permissions_policy,
         app_flash,
         app_memory,
+        create_capability!(capabilities::ProcessManagementCapability),
     )
     .finalize(components::process_loader_sequential_component_static!(
         nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
@@ -521,6 +525,7 @@ pub unsafe fn main() {
         capsules_extra::app_loader::DRIVER_NUM,
         dynamic_binary_storage,
         dynamic_binary_storage,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::app_loader_component_static!(
         DynamicBinaryStorage<'static>,

--- a/boards/tutorials/nrf52840dk-hotp-tutorial/src/main.rs
+++ b/boards/tutorials/nrf52840dk-hotp-tutorial/src/main.rs
@@ -217,14 +217,18 @@ pub unsafe fn main() {
     // STORAGE PERMISSIONS
     //--------------------------------------------------------------------------
 
+    kernel::declare_capability!(AppStoreCap: kernel::capabilities::ApplicationStorageCapability);
     let storage_permissions_policy =
-        components::storage_permissions::tbf_header::StoragePermissionsTbfHeaderComponent::new()
-            .finalize(
-                components::storage_permissions_tbf_header_component_static!(
-                    nrf52840dk_lib::ChipHw,
-                    kernel::process::ProcessStandardDebugFull,
-                ),
-            );
+        components::storage_permissions::tbf_header::StoragePermissionsTbfHeaderComponent::new(
+            AppStoreCap,
+        )
+        .finalize(
+            components::storage_permissions_tbf_header_component_static!(
+                nrf52840dk_lib::ChipHw,
+                kernel::process::ProcessStandardDebugFull,
+                AppStoreCap,
+            ),
+        );
 
     //--------------------------------------------------------------------------
     // PROCESS LOADING

--- a/boards/tutorials/nrf52840dk-hotp-tutorial/src/main.rs
+++ b/boards/tutorials/nrf52840dk-hotp-tutorial/src/main.rs
@@ -123,6 +123,7 @@ pub unsafe fn main() {
         board_kernel,
         capsules_extra::hmac::DRIVER_NUM,
         hmac_sha256_sw,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::hmac_component_static!(HmacSha256Software, 32));
 
@@ -178,6 +179,7 @@ pub unsafe fn main() {
         capsules_extra::screen::screen::DRIVER_NUM,
         ssd1306_sh1106,
         None,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::screen_component_static!(1032));
 
@@ -207,6 +209,7 @@ pub unsafe fn main() {
         0x1915, // Nordic Semiconductor
         0x503a,
         strings,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::keyboard_hid_component_static!(UsbHw));
 
@@ -265,6 +268,7 @@ pub unsafe fn main() {
         storage_permissions_policy,
         app_flash,
         app_memory,
+        create_capability!(capabilities::ProcessManagementCapability),
     )
     .finalize(components::process_loader_sequential_component_static!(
         nrf52840dk_lib::ChipHw,

--- a/boards/tutorials/nrf52840dk-root-of-trust-tutorial/src/main.rs
+++ b/boards/tutorials/nrf52840dk-root-of-trust-tutorial/src/main.rs
@@ -127,6 +127,7 @@ pub unsafe fn main() {
         capsules_extra::screen::screen::DRIVER_NUM,
         ssd1306_sh1106,
         None,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::screen_component_static!(1032));
 

--- a/boards/tutorials/nrf52840dk-thread-tutorial/src/main.rs
+++ b/boards/tutorials/nrf52840dk-thread-tutorial/src/main.rs
@@ -248,14 +248,18 @@ pub unsafe fn main() {
     // STORAGE PERMISSIONS
     //--------------------------------------------------------------------------
 
+    kernel::declare_capability!(AppStoreCap: kernel::capabilities::ApplicationStorageCapability);
     let storage_permissions_policy =
-        components::storage_permissions::individual::StoragePermissionsIndividualComponent::new()
-            .finalize(
-                components::storage_permissions_individual_component_static!(
-                    nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
-                    kernel::process::ProcessStandardDebugFull,
-                ),
-            );
+        components::storage_permissions::individual::StoragePermissionsIndividualComponent::new(
+            AppStoreCap,
+        )
+        .finalize(
+            components::storage_permissions_individual_component_static!(
+                nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
+                kernel::process::ProcessStandardDebugFull,
+                AppStoreCap,
+            ),
+        );
 
     //--------------------------------------------------------------------------
     // PROCESS LOADING

--- a/boards/tutorials/nrf52840dk-thread-tutorial/src/main.rs
+++ b/boards/tutorials/nrf52840dk-thread-tutorial/src/main.rs
@@ -126,6 +126,7 @@ pub unsafe fn main() {
         board_kernel,
         capsules_extra::ieee802154::DRIVER_NUM,
         &nrf52840_peripherals.ieee802154_radio,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::ieee802154_raw_component_static!(
         nrf52840::ieee802154_radio::Radio,
@@ -191,6 +192,7 @@ pub unsafe fn main() {
         capsules_extra::screen::screen::DRIVER_NUM,
         ssd1306_sh1106,
         None,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::screen_component_static!(1032));
 
@@ -208,7 +210,8 @@ pub unsafe fn main() {
         capsules_extra::isolated_nonvolatile_storage_driver::DRIVER_NUM,
         &nrf52840_peripherals.nrf52.nvmc,
         core::ptr::addr_of!(APP_STORAGE) as usize,
-        APP_STORAGE.len()
+        APP_STORAGE.len(),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::isolated_nonvolatile_storage_component_static!(
         nrf52840::nvmc::Nvmc,
@@ -296,6 +299,7 @@ pub unsafe fn main() {
         storage_permissions_policy,
         app_flash,
         app_memory,
+        create_capability!(capabilities::ProcessManagementCapability),
     )
     .finalize(components::process_loader_sequential_component_static!(
         nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,

--- a/boards/tutorials/qemu_rv32_virt-tutorial/src/main.rs
+++ b/boards/tutorials/qemu_rv32_virt-tutorial/src/main.rs
@@ -192,6 +192,7 @@ pub unsafe fn main() {
                 capsules_extra::screen::screen::DRIVER_NUM,
                 screen_split_userspace,
                 None,
+                create_capability!(capabilities::MemoryAllocationCapability),
             )
             .finalize(components::screen_component_static!(1032));
 
@@ -244,6 +245,7 @@ pub unsafe fn main() {
             capsules_extra::button_keyboard::DRIVER_NUM,
             keyboard,
             key_mappings,
+            create_capability!(capabilities::MemoryAllocationCapability),
         )
         .finalize(components::keyboard_button_component_static!())
     });
@@ -413,6 +415,7 @@ pub unsafe fn main() {
         storage_permissions_policy,
         app_flash,
         app_memory,
+        create_capability!(capabilities::ProcessManagementCapability),
     )
     .finalize(components::process_loader_sequential_component_static!(
         qemu_rv32_virt_lib::ChipHw,

--- a/boards/tutorials/qemu_rv32_virt-tutorial/src/main.rs
+++ b/boards/tutorials/qemu_rv32_virt-tutorial/src/main.rs
@@ -258,7 +258,7 @@ pub unsafe fn main() {
     };
 
     // Start the process console:
-    let _ = platform.base.pconsole.start();
+    let _ = platform.base.process_console_start();
 
     //--------------------------------------------------------------------------
     // CREDENTIAL CHECKING

--- a/boards/veer_el2_sim/src/main.rs
+++ b/boards/veer_el2_sim/src/main.rs
@@ -179,14 +179,22 @@ unsafe fn start() -> (&'static kernel::Kernel, VeeR, &'static VeeRChip) {
         resources.printer.put(process_printer);
     });
 
+    kernel::declare_capability!(ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         None,
+        ProcessConsoleCap,
     )
-    .finalize(components::process_console_component_static!(Clint));
+    .finalize(components::process_console_component_static!(
+        Clint,
+        ProcessConsoleCap
+    ));
     let _ = process_console.start();
 
     // Need to enable all interrupts for Tock Kernel

--- a/boards/veer_el2_sim/src/main.rs
+++ b/boards/veer_el2_sim/src/main.rs
@@ -211,6 +211,7 @@ unsafe fn start() -> (&'static kernel::Kernel, VeeR, &'static VeeRChip) {
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -311,6 +311,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
@@ -343,6 +344,7 @@ unsafe fn start() -> (
                 kernel::hil::gpio::FloatingState::PullUp
             )
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::button_component_static!(stm32f401cc::gpio::Pin));
 
@@ -357,6 +359,7 @@ unsafe fn start() -> (
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(stm32f401cc::tim2::Tim2));
 
@@ -401,6 +404,7 @@ unsafe fn start() -> (
             45 => gpio_ports.pins[1][8].as_ref().unwrap(), // B8
             46 => gpio_ports.pins[1][9].as_ref().unwrap(), // B9
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(stm32f401cc::gpio::Pin));
 
@@ -432,16 +436,19 @@ unsafe fn start() -> (
         components::adc::AdcComponent::new(adc_mux, stm32f401cc::adc::Channel::Channel8)
             .finalize(components::adc_component_static!(stm32f401cc::adc::Adc));
 
-    let adc_syscall =
-        components::adc::AdcVirtualComponent::new(board_kernel, capsules_core::adc::DRIVER_NUM)
-            .finalize(components::adc_syscall_component_helper!(
-                adc_channel_0,
-                adc_channel_1,
-                adc_channel_2,
-                adc_channel_3,
-                adc_channel_4,
-                adc_channel_5
-            ));
+    let adc_syscall = components::adc::AdcVirtualComponent::new(
+        board_kernel,
+        capsules_core::adc::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
+    )
+    .finalize(components::adc_syscall_component_helper!(
+        adc_channel_0,
+        adc_channel_1,
+        adc_channel_2,
+        adc_channel_3,
+        adc_channel_4,
+        adc_channel_5
+    ));
 
     let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
         .finalize(components::process_printer_text_component_static!());

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -450,15 +450,21 @@ unsafe fn start() -> (
     });
 
     // PROCESS CONSOLE
+    kernel::declare_capability!(ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
+        ProcessConsoleCap,
     )
     .finalize(components::process_console_component_static!(
-        stm32f401cc::tim2::Tim2
+        stm32f401cc::tim2::Tim2,
+        ProcessConsoleCap
     ));
     let _ = process_console.start();
 

--- a/boards/wm1110dev/src/main.rs
+++ b/boards/wm1110dev/src/main.rs
@@ -290,6 +290,7 @@ pub unsafe fn start() -> (
             6 => &nrf52840_peripherals.gpio_port[GPIO_D6],
             7 => &nrf52840_peripherals.gpio_port[GPIO_D7],
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(Nrf52840GpioHw));
 
@@ -316,6 +317,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::alarm::DRIVER_NUM,
         mux_alarm,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::alarm_component_static!(nrf52::rtc::Rtc));
 
@@ -339,6 +341,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::console::DRIVER_NUM,
         uart_mux,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
 
@@ -380,6 +383,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_extra::temperature::DRIVER_NUM,
         sht4x,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::temperature_component_static!(SHT4xSensor));
 
@@ -387,6 +391,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_extra::humidity::DRIVER_NUM,
         sht4x,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::humidity_component_static!(SHT4xSensor));
 
@@ -405,6 +410,7 @@ pub unsafe fn start() -> (
             &nrf52840_peripherals.gpio_port[SPI_CS_PIN],
         ),
         LORA_SPI_DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::spi_syscall_component_static!(SpiHw));
 
@@ -433,6 +439,7 @@ pub unsafe fn start() -> (
             42 => &nrf52840_peripherals.gpio_port[RADIO_RESET_PIN],
             43 => &nrf52840_peripherals.gpio_port[RADIO_BUSY_PIN],
         ),
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::gpio_component_static!(Nrf52840GpioHw));
 
@@ -471,6 +478,7 @@ pub unsafe fn start() -> (
         board_kernel,
         capsules_core::rng::DRIVER_NUM,
         &base_peripherals.trng,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::rng_component_static!(nrf52840::trng::Trng));
 
@@ -486,6 +494,7 @@ pub unsafe fn start() -> (
         4096 * 4, // Length of userspace accessible region (16 pages)
         0,        // No kernel access
         0,
+        create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::nonvolatile_storage_component_static!(
         nrf52840::nvmc::Nvmc

--- a/boards/wm1110dev/src/main.rs
+++ b/boards/wm1110dev/src/main.rs
@@ -446,14 +446,22 @@ pub unsafe fn start() -> (
         resources.printer.put(process_printer);
     });
 
+    kernel::declare_capability!(ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let _process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
+        ProcessConsoleCap,
     )
-    .finalize(components::process_console_component_static!(AlarmHw));
+    .finalize(components::process_console_component_static!(
+        nrf52840::rtc::Rtc,
+        ProcessConsoleCap
+    ));
 
     //--------------------------------------------------------------------------
     // RANDOM NUMBERS

--- a/kernel/src/utilities/helpers.rs
+++ b/kernel/src/utilities/helpers.rs
@@ -49,6 +49,47 @@ macro_rules! create_capability {
     }};
 }
 
+/// Declare a named struct that implements the given capability traits.
+///
+/// Unlike [`create_capability!`], this macro creates a named type that can be
+/// used as a generic parameter (e.g., in component static macros). Use this
+/// when you need to name the capability type, such as when passing it to a
+/// component's static buffer macro.
+///
+/// ```
+/// # use kernel::capabilities::ProcessManagementCapability;
+/// # use kernel::declare_capability;
+/// declare_capability!(MyCapability: ProcessManagementCapability);
+/// let cap = MyCapability;
+/// ```
+///
+/// This helper macro cannot be called from `#![forbid(unsafe_code)]` crates,
+/// and is used by trusted code to generate a capability type.
+///
+/// # Safety
+///
+/// This macro can only be used in a context that is allowed to use
+/// `unsafe`. Specifically, an internal `allow(unsafe_code)` directive
+/// will conflict with any `forbid(unsafe_code)` at the crate or block
+/// level.
+#[macro_export]
+macro_rules! declare_capability {
+    (pub $name:ident: $($T:ty),+) => {
+        pub struct $name;
+        $(
+            #[allow(unsafe_code)]
+            unsafe impl $T for $name {}
+        )*
+    };
+    ($name:ident: $($T:ty),+) => {
+        struct $name;
+        $(
+            #[allow(unsafe_code)]
+            unsafe impl $T for $name {}
+        )*
+    };
+}
+
 /// Count the number of passed expressions.
 ///
 /// Useful for constructing variable sized arrays in other macros.

--- a/kernel/src/utilities/helpers.rs
+++ b/kernel/src/utilities/helpers.rs
@@ -74,13 +74,6 @@ macro_rules! create_capability {
 /// level.
 #[macro_export]
 macro_rules! declare_capability {
-    (pub $name:ident: $($T:ty),+) => {
-        pub struct $name;
-        $(
-            #[allow(unsafe_code)]
-            unsafe impl $T for $name {}
-        )*
-    };
     ($name:ident: $($T:ty),+) => {
         struct $name;
         $(

--- a/kernel/src/utilities/helpers.rs
+++ b/kernel/src/utilities/helpers.rs
@@ -56,22 +56,55 @@ macro_rules! create_capability {
 /// when you need to name the capability type, such as when passing it to a
 /// component's static buffer macro.
 ///
-/// ```
+/// # Usage Example
+///
+/// ```ignore
 /// # use kernel::capabilities::ProcessManagementCapability;
 /// # use kernel::declare_capability;
+///
 /// declare_capability!(MyCapability: ProcessManagementCapability);
-/// let cap = MyCapability;
+///
+/// let manager = components::manager::ManagerComponent::new(
+///     board_kernel,
+///     mux_alarm,
+///     MyCapability,
+/// )
+/// .finalize(components::manager_component_static!(
+///     AlarmHw,
+///     MyCapability,
+/// ));
 /// ```
+///
+/// # Difference from `create_capability!()`
+///
+/// `declare_capability!()` creates a named type, whereas [`create_capability!`]
+/// does not. If possible, use [`create_capability!`]. However, for components
+/// that need the capability struct named in the static constructor macro, use
+/// `declare_capability!()` to create the named struct that is used in the macro
+/// expansion and in the component `finalize()` method.
+///
+/// # Supporting Multiple Capabilities
+///
+/// Some type signatures require multiple capabilities. This macro supports
+/// declaring multiple capabilities. For example:
+///
+/// ```
+/// kernel::declare_capability!(ProcessConsoleCap:
+///     kernel::capabilities::ProcessManagementCapability,
+///     kernel::capabilities::ProcessStartCapability
+/// );
+/// ```
+///
+/// # Restrictions
 ///
 /// This helper macro cannot be called from `#![forbid(unsafe_code)]` crates,
 /// and is used by trusted code to generate a capability type.
 ///
 /// # Safety
 ///
-/// This macro can only be used in a context that is allowed to use
-/// `unsafe`. Specifically, an internal `allow(unsafe_code)` directive
-/// will conflict with any `forbid(unsafe_code)` at the crate or block
-/// level.
+/// This macro can only be used in a context that is allowed to use `unsafe`.
+/// Specifically, an internal `allow(unsafe_code)` directive will conflict with
+/// any `forbid(unsafe_code)` at the crate or block level.
 #[macro_export]
 macro_rules! declare_capability {
     ($name:ident: $($T:ty),+) => {


### PR DESCRIPTION
### Pull Request Overview

This is part of #4418.

This was nearly entirely done by Claude.

This removes all capability creation in components, and instead requires that call component users pass in the capability. This allows us to remove unsafe from components.

The one wrinkle is that some capabilities struct need to be named so they can be used both in the type and as an argument. Claude came up with the `declare_capability!()` macro to enable this.


### Testing Strategy

travis


### TODO or Help Wanted

This does need #4916.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.

Claude did nearly all of this because the changes are so mechanical.