### PR TITLE
Rust 2024: Convert most libraries, all capsules, and chips/virtio

### DIFF
--- a/capsules/aes_gcm/Cargo.toml
+++ b/capsules/aes_gcm/Cargo.toml
@@ -6,7 +6,7 @@
 name = "capsules-aes-gcm"
 version.workspace = true
 authors.workspace = true
-edition.workspace = true
+edition = "2024"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/capsules/core/Cargo.toml
+++ b/capsules/core/Cargo.toml
@@ -6,7 +6,7 @@
 name = "capsules-core"
 version.workspace = true
 authors.workspace = true
-edition.workspace = true
+edition = "2024"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/capsules/core/src/adc.rs
+++ b/capsules/core/src/adc.rs
@@ -366,7 +366,7 @@ impl<'a, A: hil::adc::Adc<'a> + hil::adc::AdcHighSpeed<'a>> AdcDedicated<'a, A> 
                     app.app_buf_offset.set(0);
                     self.channel.set(channel);
                     // start a continuous sample
-                    let res = self.adc_buf1.take().map_or(Err(ErrorCode::BUSY), |buf1| {
+                    self.adc_buf1.take().map_or(Err(ErrorCode::BUSY), |buf1| {
                         self.adc_buf2
                             .take()
                             .map_or(Err(ErrorCode::BUSY), move |buf2| {
@@ -401,8 +401,7 @@ impl<'a, A: hil::adc::Adc<'a> + hil::adc::AdcHighSpeed<'a>> AdcDedicated<'a, A> 
                                         |()| Ok(()),
                                     )
                             })
-                    });
-                    res
+                    })
                 })
                 .map_err(|err| {
                     if err == kernel::process::Error::NoSuchApp

--- a/capsules/core/src/virtualizers/virtual_adc.rs
+++ b/capsules/core/src/virtualizers/virtual_adc.rs
@@ -88,14 +88,13 @@ pub struct AdcDevice<'a, A: hil::adc::Adc<'a>> {
 
 impl<'a, A: hil::adc::Adc<'a>> AdcDevice<'a, A> {
     pub const fn new(mux: &'a MuxAdc<'a, A>, channel: A::Channel) -> AdcDevice<'a, A> {
-        let adc_user = AdcDevice {
+        AdcDevice {
             mux,
             channel,
             operation: OptionalCell::empty(),
             next: ListLink::empty(),
             client: OptionalCell::empty(),
-        };
-        adc_user
+        }
     }
 
     pub fn add_to_mux(&'a self) {

--- a/capsules/core/src/virtualizers/virtual_timer.rs
+++ b/capsules/core/src/virtualizers/virtual_timer.rs
@@ -48,15 +48,14 @@ impl<'a, A: Alarm<'a>> VirtualTimer<'a, A> {
     /// After calling new, always call setup()
     pub fn new(mux_timer: &'a MuxTimer<'a, A>) -> VirtualTimer<'a, A> {
         let zero = A::Ticks::from(0);
-        let v = VirtualTimer {
+        VirtualTimer {
             mux: mux_timer,
             when: Cell::new(zero),
             interval: Cell::new(zero),
             mode: Cell::new(Mode::Disabled),
             next: ListLink::empty(),
             client: OptionalCell::empty(),
-        };
-        v
+        }
     }
 
     /// Call this method immediately after new() to link this to the mux, otherwise timers won't

--- a/capsules/ecdsa_sw/Cargo.toml
+++ b/capsules/ecdsa_sw/Cargo.toml
@@ -6,7 +6,7 @@
 name = "ecdsa-sw"
 version.workspace = true
 authors.workspace = true
-edition.workspace = true
+edition = "2024"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/capsules/ecdsa_sw/src/p256_signer.rs
+++ b/capsules/ecdsa_sw/src/p256_signer.rs
@@ -113,10 +113,10 @@ impl kernel::deferred_call::DeferredCallClient for EcdsaP256SignatureSigner<'_> 
             match s {
                 State::Signing => {
                     self.client.map(|client| {
-                        if let Some(h) = self.hash_storage.take() {
-                            if let Some(s) = self.signature_storage.take() {
-                                client.signing_done(Ok(()), h, s);
-                            }
+                        if let Some(h) = self.hash_storage.take()
+                            && let Some(s) = self.signature_storage.take()
+                        {
+                            client.signing_done(Ok(()), h, s);
                         }
                     });
                 }

--- a/capsules/ecdsa_sw/src/p256_verifier.rs
+++ b/capsules/ecdsa_sw/src/p256_verifier.rs
@@ -117,10 +117,10 @@ impl kernel::deferred_call::DeferredCallClient for EcdsaP256SignatureVerifier<'_
             match s {
                 State::Verifying => {
                     self.client.map(|client| {
-                        if let Some(h) = self.hash_storage.take() {
-                            if let Some(s) = self.signature_storage.take() {
-                                client.verification_done(Ok(self.verified.get()), h, s);
-                            }
+                        if let Some(h) = self.hash_storage.take()
+                            && let Some(s) = self.signature_storage.take()
+                        {
+                            client.verification_done(Ok(self.verified.get()), h, s);
                         }
                     });
                 }

--- a/capsules/extra/Cargo.toml
+++ b/capsules/extra/Cargo.toml
@@ -6,7 +6,7 @@
 name = "capsules-extra"
 version.workspace = true
 authors.workspace = true
-edition.workspace = true
+edition = "2024"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/capsules/extra/src/adc_microphone.rs
+++ b/capsules/extra/src/adc_microphone.rs
@@ -44,7 +44,7 @@ impl<'a, P: gpio::Pin> AdcMicrophone<'a, P> {
     }
 
     fn compute_spl(&self) -> u8 {
-        let max = self.spl_buffer.map_or(0, |buffer| {
+        self.spl_buffer.map_or(0, |buffer| {
             let avg = (buffer.iter().fold(0usize, |a, v| a + *v as usize) / buffer.len()) as u16;
             let max = buffer
                 .iter()
@@ -53,8 +53,7 @@ impl<'a, P: gpio::Pin> AdcMicrophone<'a, P> {
             let mut conv = (max as f32) / (((1 << 15) - 1) as f32) * 9_f32;
             conv = 20f32 * math::log10(conv / 0.00002f32);
             conv as u8
-        });
-        max
+        })
     }
 }
 

--- a/capsules/extra/src/app_loader.rs
+++ b/capsules/extra/src/app_loader.rs
@@ -454,15 +454,14 @@ impl<
                 match res {
                     Ok(()) => CommandReturn::success(),
                     Err(e) => {
-                        let command_result = if let Some(buffer) = self.buffer.take() {
+                        if let Some(buffer) = self.buffer.take() {
                             self.buffer.replace(buffer);
                             self.new_app_length.set(0);
                             self.current_process.take();
                             CommandReturn::failure(e)
                         } else {
                             CommandReturn::failure(ErrorCode::RESERVE)
-                        };
-                        command_result
+                        }
                     }
                 }
             }

--- a/capsules/extra/src/crc.rs
+++ b/capsules/extra/src/crc.rs
@@ -150,7 +150,7 @@ impl<'a, C: Crc<'a>> CrcDriver<'a, C> {
     }
 
     fn do_next_input(&self, data: &ReadableProcessSlice, len: usize) -> usize {
-        let count = self.crc_buffer.take().map_or(0, |kbuffer| {
+        self.crc_buffer.take().map_or(0, |kbuffer| {
             let copy_len = cmp::min(len, kbuffer.len());
             for i in 0..copy_len {
                 kbuffer[i] = data[i].get();
@@ -169,8 +169,7 @@ impl<'a, C: Crc<'a>> CrcDriver<'a, C> {
             } else {
                 0
             }
-        });
-        count
+        })
     }
 
     // Start a new request. Return Ok(()) if one started, Err(FAIL) if not.

--- a/capsules/system/Cargo.toml
+++ b/capsules/system/Cargo.toml
@@ -6,7 +6,7 @@
 name = "capsules-system"
 version.workspace = true
 authors.workspace = true
-edition.workspace = true
+edition = "2024"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/chips/virtio-pci-x86/Cargo.toml
+++ b/chips/virtio-pci-x86/Cargo.toml
@@ -6,7 +6,7 @@
 name = "virtio-pci-x86"
 version.workspace = true
 authors.workspace = true
-edition.workspace = true
+edition = "2024"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/chips/virtio/Cargo.toml
+++ b/chips/virtio/Cargo.toml
@@ -6,7 +6,7 @@
 name = "virtio"
 version.workspace = true
 authors.workspace = true
-edition.workspace = true
+edition = "2024"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/chips/virtio/src/queues/split_queue.rs
+++ b/chips/virtio/src/queues/split_queue.rs
@@ -350,6 +350,11 @@ enum VirtqueueDmaBuffer<'b> {
 }
 
 impl<'b> VirtqueueDmaBuffer<'b> {
+    /// Create a DMA-safe buffer from a `VirtqueueBuffer`.
+    ///
+    /// # Safety
+    ///
+    /// Callers must ensure they do not drop the created `VirtqueueDmaBuffer`.
     unsafe fn from_virtqueue_buffer(
         virtqueue_buffer: VirtqueueBuffer<'b>,
         fence: impl DmaFence,
@@ -362,7 +367,14 @@ impl<'b> VirtqueueDmaBuffer<'b> {
                 ))
             }
             VirtqueueBuffer::DeviceWriteable(sub_slice_mut) => {
-                VirtqueueDmaBuffer::DeviceWriteable(DmaSubSliceMut::new(sub_slice_mut, fence))
+                // Wrap the queue buffer in a DmaSlice.
+                //
+                // # Safety
+                //
+                // Because our buffer isn't static, we must ensure to never drop the
+                // buffer. The function-level safety requirements ensure this.
+                let dma_slice = unsafe { DmaSubSliceMut::new(sub_slice_mut, fence) };
+                VirtqueueDmaBuffer::DeviceWriteable(dma_slice)
             }
         }
     }

--- a/libraries/enum_primitive/Cargo.toml
+++ b/libraries/enum_primitive/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "enum_primitive"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lints]
 workspace = true

--- a/libraries/riscv-csr/Cargo.toml
+++ b/libraries/riscv-csr/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 keywords = ["tock", "embedded", "riscv", "bare-metal"]
 categories = ["data-structures", "embedded", "no-std"]
 license = "MIT/Apache-2.0"
-edition = "2021"
+edition = "2024"
 
 [badges]
 travis-ci = { repository = "tock/tock", branch = "master" }

--- a/libraries/tock-cells/Cargo.toml
+++ b/libraries/tock-cells/Cargo.toml
@@ -6,7 +6,7 @@
 name = "tock-cells"
 version = "0.1.0"
 authors = ["Tock Project Developers <devel@lists.tockos.org>"]
-edition = "2021"
+edition = "2024"
 
 
 [lints]

--- a/libraries/tock-tbf/Cargo.toml
+++ b/libraries/tock-tbf/Cargo.toml
@@ -6,7 +6,7 @@
 name = "tock-tbf"
 version = "0.1.0"
 authors = ["Tock Project Developers <devel@lists.tockos.org>"]
-edition = "2021"
+edition = "2024"
 
 [lints]
 workspace = true

--- a/libraries/tock-tbf/src/types.rs
+++ b/libraries/tock-tbf/src/types.rs
@@ -927,11 +927,10 @@ impl<'a> TbfHeader<'a> {
         match self {
             TbfHeader::TbfHeaderV2(hd) => match hd.storage_permissions {
                 Some(storage_permissions_tlv_slice) => {
-                    let write_id = core::num::NonZeroU32::new(u32::from_le_bytes(
+                    // write_id
+                    core::num::NonZeroU32::new(u32::from_le_bytes(
                         storage_permissions_tlv_slice.get(0..4)?.try_into().ok()?,
-                    ));
-
-                    write_id
+                    ))
                 }
                 _ => None,
             },


### PR DESCRIPTION
### Pull Request Overview

As we push towards using the 2024 edition of Rust, there are a few crates that are pretty easy to switch. This converts capsules, most libraries, and chips/virtio.

The required changes are pretty minimal:
- Add safety comments in virtio
- Uses a if let chain
- Fix a clippy lint related to assigning a new struct to a variable to then just return the variable

This does not convert the tickv library. That library uses `static mut` in its tests and is more involved to update to 2024.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
