### PR TITLE
Expand `PanicInfo` manually rather than using its `Display`

### DIFF
--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -301,7 +301,21 @@ pub unsafe fn panic_begin(nop: &dyn Fn()) {
 ///
 /// **NOTE:** The supplied `writer` must be synchronous.
 pub unsafe fn panic_banner<W: Write>(writer: &mut W, panic_info: &PanicInfo) {
-    let _ = writer.write_fmt(format_args!("\r\n{}\r\n", panic_info));
+    // Expand `PanicInfo` manually rather than using its `Display`
+    // implementation. The `Display` implementation inserts bare LFs
+    // between the location line and the message body, rather than a
+    // CRLF.
+    if let Some(location) = panic_info.location() {
+        let _ = writer.write_fmt(format_args!(
+            "\r\npanicked at {}:{}:{}:\r\n{}\r\n",
+            location.file(),
+            location.line(),
+            location.column(),
+            panic_info.message(),
+        ));
+    } else {
+        let _ = writer.write_fmt(format_args!("\r\n{}\r\n", panic_info.message()));
+    }
 
     // Print version of the kernel
     if crate::KERNEL_PRERELEASE_VERSION != 0 {


### PR DESCRIPTION
### Pull Request Overview

`PanicInfo`'s `Display` implementation in Rust core emits bare line-feeds, not CRLF, between the location line and the message body. This results in output that is counter to manually formatted panic messages in the default implementation, and breaks terminals expecting CRLF (most other than `tockloader` by default).

This PR simply implements the same `Display` logic manually but with `\r\n`.


### Testing Strategy

TODO

### TODO or Help Wanted

Testing

### Checklist

- [X] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [X] No documentation updates are required.

#### AI Use

- [X] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
