### PR TITLE
components: document forbid unsafe policy

### DIFF
--- a/boards/components/README.md
+++ b/boards/components/README.md
@@ -29,6 +29,17 @@ the chance for errors. Components also reduce the burden when changes are made
 to capsules, as the change can likely be reflected in the single component and
 not in every board's main.rs file.
 
+### No `unsafe` Code in Components
+
+Tock includes the `#![forbid(unsafe_code)]` directive in the components crate.
+This ensures that components cannot encapsulate any unsafe operations that
+would otherwise be hidden from the main board configuration. All unsafe
+operations (for example providing a capability) must be handled in the
+board's main setup function and then provided to the component. This makes
+any sensitive or potentially unsafe operations visible in the board's main
+function, helping anyone audit what the kernel configuration is actually
+doing.
+
 Adding Components
 -----------------
 


### PR DESCRIPTION


### Pull Request Overview

Issue #4418 outlined that we should explain why components are forbid unsafe. I think the crate readme is probably one of the best places to do that, because I don't think we have other documents specifically related to components.


### Testing Strategy

doc


### TODO or Help Wanted

Needs #4937


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [x] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).

    https://github.com/tock/book/pull/90

- [ ] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
