### PR TITLE
chips/apollo3: align flash page buffers to words

### DIFF
--- a/chips/apollo3/src/flashctrl.rs
+++ b/chips/apollo3/src/flashctrl.rs
@@ -26,7 +26,10 @@ enum FlashInstance {
     MAIN0 = 0,
     MAIN1 = 1,
 }
-
+/// A flash page aligned for use with the Apollo3 ROM flash programming API.
+///
+/// `flash_program_main` requires its source buffer to be word-aligned.
+#[repr(C, align(4))]
 pub struct Apollo3Page(pub [u8; PAGE_SIZE]);
 
 impl Default for Apollo3Page {


### PR DESCRIPTION
### Pull Request Overview

Give `Apollo3Page` four-byte alignment so it satisfies the source-buffer
alignment requirement of the Apollo3 ROM flash programming API.

Fixes #4751.

### Testing Strategy

- `make -C boards/apollo3/redboard_artemis_nano`
- `make prepush`

### TODO or Help Wanted

None.

### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [x] No documentation updates are required.

#### AI Use

- [ x] No AI was used in this PR.

