### PR TITLE
kernel: add faulting state to process lifecycle

### DIFF
--- a/capsules/core/src/process_console.rs
+++ b/capsules/core/src/process_console.rs
@@ -24,7 +24,7 @@ use kernel::debug;
 use kernel::hil::time::{Alarm, AlarmClient};
 use kernel::hil::uart;
 use kernel::introspection::KernelInfo;
-use kernel::process::{ProcessPrinter, ProcessPrinterContext, State};
+use kernel::process::{FaultReason, ProcessPrinter, ProcessPrinterContext, State};
 use kernel::utilities::binary_write::BinaryWrite;
 
 /// Buffer to hold outgoing data that is passed to the UART hardware.
@@ -840,7 +840,7 @@ impl<
                                     .process_each_capability(&self.capability, |proc| {
                                         let proc_name = proc.get_process_name();
                                         if proc_name == name {
-                                            proc.set_fault_state();
+                                            proc.set_faulting_state(FaultReason::ForcedRestart);
                                             let mut console_writer = ConsoleWriter::new();
                                             let _ = write(
                                                 &mut console_writer,

--- a/capsules/extra/src/process_info_driver.rs
+++ b/capsules/extra/src/process_info_driver.rs
@@ -220,6 +220,7 @@ impl<C: ProcessManagementCapability + ProcessStartCapability> SyscallDriver for 
                                                         process::State::Stopped(_) => 3,
                                                         process::State::Faulted => 4,
                                                         process::State::Terminated => 5,
+                                                        process::State::Faulting(_) => 6,
                                                     };
 
                                                 let _ = chunk.copy_from_slice_or_err(
@@ -254,7 +255,9 @@ impl<C: ProcessManagementCapability + ProcessStartCapability> SyscallDriver for 
 
                                 3 => {
                                     // FAULT
-                                    process.set_fault_state();
+                                    process.set_faulting_state(
+                                        kernel::process::FaultReason::ForcedRestart,
+                                    );
                                 }
 
                                 4 => {

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -326,7 +326,7 @@ impl Kernel {
     /// apps.
     pub fn hardfault_all_apps<C: capabilities::ProcessManagementCapability>(&self, _c: &C) {
         for process in self.get_process_iter() {
-            process.set_faulting_state(FaultReason::Unknown);
+            process.set_faulting_state(FaultReason::AppError);
         }
     }
 
@@ -589,7 +589,7 @@ impl Kernel {
                                 .is_err()
                             {
                                 // Let process deal with it as appropriate.
-                                process.set_faulting_state(FaultReason::Unknown);
+                                process.set_faulting_state(FaultReason::AppError);
                             }
                         }
                         Some(ContextSwitchReason::SyscallFired { syscall }) => {
@@ -609,10 +609,12 @@ impl Kernel {
                             continue;
                         }
                         None => {
-                            // Something went wrong when switching to this
-                            // process. Indicate this by putting it in a fault
-                            // state.
-                            process.set_faulting_state(FaultReason::Unknown);
+                            // Attempt to switch to an invalid process; this
+                            // should not happen since process liveness was
+                            // established when we matched `State::Running`.
+                            if process.is_running() {
+                                process.set_faulting_state(FaultReason::KernelError);
+                            }
                         }
                     }
                 }

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -27,7 +27,7 @@ use crate::platform::platform::{ProcessFault, SyscallDriverLookup, SyscallFilter
 use crate::platform::scheduler_timer::SchedulerTimer;
 use crate::platform::watchdog::WatchDog;
 use crate::process::ProcessSlot;
-use crate::process::{self, ProcessId, Task};
+use crate::process::{self, FaultReason, ProcessId, Task};
 use crate::scheduler::{Scheduler, SchedulingDecision};
 use crate::syscall::SyscallDriver;
 use crate::syscall::{ContextSwitchReason, SyscallReturn};
@@ -316,7 +316,7 @@ impl Kernel {
 
     /// Cause all apps to fault.
     ///
-    /// This will call `set_fault_state()` on each app, causing the app to enter
+    /// This will call `set_faulting_state()` on each app, causing the app to enter
     /// the state as if it had crashed (for example with an MPU violation). If
     /// the process is configured to be restarted it will be.
     ///
@@ -326,7 +326,7 @@ impl Kernel {
     /// apps.
     pub fn hardfault_all_apps<C: capabilities::ProcessManagementCapability>(&self, _c: &C) {
         for process in self.get_process_iter() {
-            process.set_fault_state();
+            process.set_faulting_state(FaultReason::Unknown);
         }
     }
 
@@ -525,6 +525,17 @@ impl Kernel {
                 break;
             }
 
+            // CAUTION: With the current architecture, once this selection is
+            // made, code must take caution to avoid any destructive operations
+            // to a process; e.g., the body of a syscall may change the state of
+            // a process to `Faulting(ForcedTerminate)`, but must not actually
+            // terminate the process, since the process object is within a code
+            // path that has matched to `State::Running`, and other code may
+            // assume that the process is still running since this state has
+            // already been checked (e.g., trying to set a process return value).
+            //
+            // This is a bit brittle, but is a limitation of the way that process
+            // state is managed and the executor loop runs currently.
             match process.get_state() {
                 process::State::Running => {
                     // Running means that this process expects to be running, so
@@ -578,7 +589,7 @@ impl Kernel {
                                 .is_err()
                             {
                                 // Let process deal with it as appropriate.
-                                process.set_fault_state();
+                                process.set_faulting_state(FaultReason::Unknown);
                             }
                         }
                         Some(ContextSwitchReason::SyscallFired { syscall }) => {
@@ -601,7 +612,7 @@ impl Kernel {
                             // Something went wrong when switching to this
                             // process. Indicate this by putting it in a fault
                             // state.
-                            process.set_fault_state();
+                            process.set_faulting_state(FaultReason::Unknown);
                         }
                     }
                 }
@@ -700,6 +711,11 @@ impl Kernel {
                                 .set_syscall_return_value(SyscallReturn::YieldWaitFor(a0, a1, a2));
                         }
                     }
+                }
+                process::State::Faulting(reason) => {
+                    return_reason = process::StoppedExecutingReason::StoppedFaulted;
+                    process.resolve_faulting_state(reason);
+                    break;
                 }
                 process::State::Faulted | process::State::Terminated => {
                     // We should never be scheduling an unrunnable process.

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -450,11 +450,15 @@ pub trait Process {
     /// This will fail (i.e. not do anything) if the process was not stopped.
     fn resume(&self);
 
-    /// Put this process in the fault state.
+    /// Put this process in the faulting state.
+    fn set_faulting_state(&self, reason: FaultReason);
+
+    /// Resolve the fault in a process.
     ///
-    /// The kernel will use the process's fault policy to decide what action to
+    /// Do something, most likely restart or terminate, to resolve the fault in a process.
+    /// For unknown faults, use the process's fault policy to decide what action to
     /// take in regards to the faulted process.
-    fn set_fault_state(&self);
+    fn resolve_faulting_state(&self, reason: FaultReason);
 
     /// Start a terminated process. This function can only be called on a
     /// terminated process.
@@ -985,7 +989,13 @@ pub enum State {
     /// state so it will execute correctly.
     Stopped(StoppedState),
 
-    /// The process ran, faulted while running, and is no longer runnable. For a
+    /// The process is in a transition state. Some fault has occurred, and the
+    /// process should not be run without handling it, but its resources are
+    /// not yet ready to be reaped.
+    Faulting(FaultReason),
+
+    /// The process is not running: it exited uncleanly in some way and has been
+    /// left in a faulted state, most likely for debugging or analytics.  For a
     /// faulted process to be made runnable, it must first be terminated (to
     /// clean up its state).
     Faulted,
@@ -994,6 +1004,25 @@ pub enum State {
     /// call or was terminated for some other reason (e.g., by the process
     /// console). Processes in the `Terminated` state can be run again.
     Terminated,
+}
+
+/// Reasons that a process could have faulted.
+///
+/// This is public so external implementations of `Process` can re-use these
+/// process fault states.
+///
+/// These are recorded so that the kernel can decide what response to take to a
+/// fault, and to provide debugging information on why a process faulted.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum FaultReason {
+    /// Something (e.g. exit syscall, process manager) forced process restart.
+    ForcedRestart,
+
+    /// Something (e.g. exit syscall, process manager) forced process termination.
+    ForcedTerminate,
+
+    /// Catch-all for unknown faults.
+    Unknown,
 }
 
 /// States a process could previously have been in when stopped.
@@ -1035,8 +1064,12 @@ pub enum FaultAction {
     /// and schedules the process to run again from its init function.
     Restart,
 
-    /// Stop the process by no longer scheduling it to run.
+    /// Stop the process by no longer scheduling it to run. This leaves process
+    /// resources intact and available for inspection.
     Stop,
+
+    /// Stop the process and free all of its resources.
+    Terminate,
 }
 
 /// Tasks that can be enqueued for a process.

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -1021,8 +1021,11 @@ pub enum FaultReason {
     /// Something (e.g. exit syscall, process manager) forced process termination.
     ForcedTerminate,
 
-    /// Catch-all for unknown faults.
-    Unknown,
+    /// While executing, the app had a userspace fault (e.g. DivZero, OOM).
+    AppError,
+
+    /// Some kernel invariant was violated and the process can no longer execute.
+    KernelError,
 }
 
 /// States a process could previously have been in when stopped.

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -744,7 +744,11 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
     }
 
     fn set_faulting_state(&self, reason: FaultReason) {
-        self.state.set(State::Faulting(reason))
+        // Once a process starts faulting, a few things might go wrong before
+        // that is actually handled. We preserve the original fault cause here.
+        if !matches!(self.get_state(), State::Faulting(_)) {
+            self.state.set(State::Faulting(reason));
+        }
     }
 
     fn resolve_faulting_state(&self, reason: FaultReason) {
@@ -753,7 +757,7 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
         let action = match reason {
             FaultReason::ForcedTerminate => FaultAction::Terminate,
             FaultReason::ForcedRestart => FaultAction::Restart,
-            FaultReason::Unknown => self.fault_policy.action(self),
+            FaultReason::AppError | FaultReason::KernelError => self.fault_policy.action(self),
         };
         match action {
             FaultAction::Panic => {
@@ -1472,14 +1476,16 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
             Some(Err(())) => {
                 // If we get an `Err`, then the UKB implementation could not set
                 // the return value, likely because the process's stack is no
-                // longer accessible to it. All we can do is fault.
-                self.set_faulting_state(FaultReason::Unknown);
+                // longer accessible to it. In spirit, this is the app
+                // attempting to write to memory it does not own, so we mark it
+                // as an AppError.
+                self.set_faulting_state(FaultReason::AppError);
             }
 
             None => {
                 // We should never be here since `stored_state` should always be
                 // occupied.
-                self.set_faulting_state(FaultReason::Unknown);
+                self.set_faulting_state(FaultReason::KernelError);
             }
         }
     }
@@ -1518,15 +1524,15 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
                 // If we got an Error, then there was likely not enough room on
                 // the stack to allow the process to execute this function given
                 // the details of the particular architecture this is running
-                // on. This process has essentially faulted, so we mark it as
-                // such.
-                self.set_faulting_state(FaultReason::Unknown);
+                // on. In spirit, this is the app attempting to write to memory
+                // it does not own, so we mark it as an AppError.
+                self.set_faulting_state(FaultReason::AppError);
             }
 
             None => {
                 // We should never be here since `stored_state` should always be
                 // occupied.
-                self.set_faulting_state(FaultReason::Unknown);
+                self.set_faulting_state(FaultReason::KernelError);
             }
         }
     }

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -27,7 +27,7 @@ use crate::platform::mpu::{self, MPU};
 use crate::process::ProcessBinary;
 use crate::process::{BinaryVersion, ReturnArguments};
 use crate::process::{Error, FunctionCall, FunctionCallSource, Process, Task};
-use crate::process::{FaultAction, ProcessCustomGrantIdentifier, ProcessId};
+use crate::process::{FaultAction, FaultReason, ProcessCustomGrantIdentifier, ProcessId};
 use crate::process::{ProcessAddresses, ProcessSizes, ShortId};
 use crate::process::{State, StoppedState};
 use crate::process_checker::AcceptedCredential;
@@ -644,7 +644,7 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
             State::Running => true,
             State::YieldedFor(_) => self.is_yield_wait_for_ready.get(),
             State::Yielded => self.tasks.map_or(false, |ring_buf| ring_buf.has_elements()),
-            _ => false,
+            State::Stopped(_) | State::Faulting(_) | State::Faulted | State::Terminated => false,
         }
     }
 
@@ -677,7 +677,10 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
     fn is_running(&self) -> bool {
         match self.state.get() {
             State::Running | State::Yielded | State::YieldedFor(_) | State::Stopped(_) => true,
-            _ => false,
+            // Note: Semantically a process that is Faulting is still running,
+            // it stops running when the fault is resolved.
+            State::Faulting(_) => true,
+            State::Faulted | State::Terminated => false,
         }
     }
 
@@ -724,7 +727,7 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
             State::Stopped(_stopped_state) => {
                 // Already stopped, nothing to do.
             }
-            State::Faulted | State::Terminated => {
+            State::Faulting(_) | State::Faulted | State::Terminated => {
                 // Stop has no meaning on a inactive process.
             }
         }
@@ -740,27 +743,35 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
         }
     }
 
-    fn set_fault_state(&self) {
+    fn set_faulting_state(&self, reason: FaultReason) {
+        self.state.set(State::Faulting(reason))
+    }
+
+    fn resolve_faulting_state(&self, reason: FaultReason) {
         // Use the per-process fault policy to determine what action the kernel
         // should take since the process faulted.
-        let action = self.fault_policy.action(self);
+        let action = match reason {
+            FaultReason::ForcedTerminate => FaultAction::Terminate,
+            FaultReason::ForcedRestart => FaultAction::Restart,
+            FaultReason::Unknown => self.fault_policy.action(self),
+        };
         match action {
             FaultAction::Panic => {
                 // process faulted. Panic and print status
-                self.state.set(State::Faulted);
                 panic!("Process {} had a fault", self.get_process_name());
             }
             FaultAction::Restart => {
                 self.try_restart(None);
             }
             FaultAction::Stop => {
-                // This looks a lot like restart, except we just leave the app
-                // how it faulted and mark it as `Faulted`. By clearing
-                // all of the app's todo work it will not be scheduled, and
-                // clearing all of the grant regions will cause capsules to drop
-                // this app as well.
-                self.terminate(None);
+                // A `Faulted` app will return false for `ready()` and thus
+                // will not be scheduled.
+                // Similarly, `enter_grant()` will fail for `is_running()`
+                // false, thus capsules will ignore this app as well.
                 self.state.set(State::Faulted);
+            }
+            FaultAction::Terminate => {
+                self.terminate(None);
             }
         }
     }
@@ -790,26 +801,23 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
 
         // If there is a kernel policy that controls restarts, it should be
         // implemented here. For now, always restart.
-        if let Ok(()) = self.reset() {
-            self.state.set(State::Yielded);
-        }
+        //
+        // n.b., `reset()` sets process state to `State::Yielded` internally.
+        let _ = self.reset();
 
         // Decide what to do with res later. E.g., if we can't restart
         // want to reclaim the process resources.
     }
 
     fn terminate(&self, completion_code: Option<u32>) {
-        // A process can be terminated if it is running or in the `Faulted`
-        // state. Otherwise, you cannot terminate it and this method return
-        // early.
-        //
-        // The kernel can terminate in the `Faulted` state to return the process
-        // to a state in which it can run again (e.g., reset it).
-        if !self.is_running() && self.get_state() != State::Faulted {
+        // A process can only be terminated if it is not running or it is
+        // faulting and we are resolving the fault by terminating.
+        // Otherwise, you cannot terminate it and this method returns early.
+        if self.is_running() && !matches!(self.get_state(), State::Faulting(_)) {
             return;
         }
 
-        // And remove those tasks
+        // Clear the tasks for the defunct process.
         self.tasks.map(|tasks| {
             tasks.empty();
         });
@@ -1465,13 +1473,13 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
                 // If we get an `Err`, then the UKB implementation could not set
                 // the return value, likely because the process's stack is no
                 // longer accessible to it. All we can do is fault.
-                self.set_fault_state();
+                self.set_faulting_state(FaultReason::Unknown);
             }
 
             None => {
                 // We should never be here since `stored_state` should always be
                 // occupied.
-                self.set_fault_state();
+                self.set_faulting_state(FaultReason::Unknown);
             }
         }
     }
@@ -1512,13 +1520,13 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
                 // the details of the particular architecture this is running
                 // on. This process has essentially faulted, so we mark it as
                 // such.
-                self.set_fault_state();
+                self.set_faulting_state(FaultReason::Unknown);
             }
 
             None => {
                 // We should never be here since `stored_state` should always be
                 // occupied.
-                self.set_fault_state();
+                self.set_faulting_state(FaultReason::Unknown);
             }
         }
     }


### PR DESCRIPTION
### Pull Request Overview

The monolithic process object doesn't check process state every time it is accessed. Rather, we check process state at the beginning of the process event loop and operate assuming the process remains in that state until the next loop.

This means a process can't safely transition out of a runnable state in the middle of the loop (e.g., a command cannot directly restart or terminate a process, see #4872).

Instead, we mark a running process as `Faulting` while within an execution such that the next iteration through the loop the fault and its response can be safely handled.

This implements "path #2" from https://github.com/tock/tock/pull/4872#issuecomment-4846619442

### Testing Strategy

This pull request was tested by compiling.

### TODO or Help Wanted

Is this an agreeable solution to the problem?

### Checklist

- [ ] Ran `make prepush`.


### PR Contents

#### Documentation

- [x] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
