### PR TITLE
qemu: help quickstart by putting app memory range in readme

### DIFF
--- a/boards/qemu_rv32_virt/README.md
+++ b/boards/qemu_rv32_virt/README.md
@@ -59,6 +59,14 @@ QEMU standalone, or with a single app. These can be executed through the
   tock/boards/qemu_rv32_virt $ make run-app APP=$PATH_TO_APP.tbf
   ```
 
+With default configuration, this QEMU board will attempt to load processes from
+flash=0x80100000-0x801FFFFF into sram=0x8021ACE0-0x803FFFFF. With fixed-slot
+apps, you will need to select something within this range, e.g.,
+
+  ```
+  APP=$PATH_TO_LIBTOCK_C/examples/blink/build/rv32imac/rv32imac.0x80100080.0x80300000.tbf
+  ```
+
 Through the **`NETDEV`** environment variable, QEMU can be instructed to attach
 a VirtIO-based network adapter to the target. The following options are available:
 


### PR DESCRIPTION
### Pull Request Overview

This adds the default app memory ranges to the README for the QEMU board to make quickstart a little easier.

### Testing Strategy

This pull request was tested by running apps on qemu.

### TODO or Help Wanted

N/A

### Checklist

- [ ] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
