### PR TITLE
rtc driver for the stm32u5xx and instantiation on the nucleo_u545re_q board.

### DIFF
--- a/boards/nucleo_u545re_q/src/main.rs
+++ b/boards/nucleo_u545re_q/src/main.rs
@@ -6,13 +6,13 @@
 #![no_std]
 #![no_main]
 
-use kernel::capabilities;
 use kernel::component::Component;
 use kernel::debug::PanicResources;
 use kernel::deferred_call::DeferredCallClient;
 use kernel::platform::chip::Chip;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::{capabilities, debug};
 use kernel::{create_capability, static_init};
 
 use stm32u545::gpio::PinId;
@@ -58,6 +58,8 @@ struct NucleoU545RE {
     adc: &'static capsules_core::adc::AdcVirtualized<'static>,
     dac: &'static capsules_extra::dac::Dac<'static>,
     gpio: &'static GpioDriver,
+    date_time:
+        &'static capsules_extra::date_time::DateTimeCapsule<'static, stm32u545::rtc::Rtc<'static>>,
 }
 
 impl SyscallDriverLookup for NucleoU545RE {
@@ -73,6 +75,7 @@ impl SyscallDriverLookup for NucleoU545RE {
             capsules_core::adc::DRIVER_NUM => f(Some(self.adc)),
             capsules_extra::dac::DRIVER_NUM => f(Some(self.dac)),
             capsules_core::gpio::DRIVER_NUM => f(Some(self.gpio)),
+            capsules_extra::date_time::DRIVER_NUM => f(Some(self.date_time)),
             _ => f(None),
         }
     }
@@ -192,11 +195,25 @@ unsafe fn start() -> (
     );
 
     usart1.register();
+    let rtc = static_init!(stm32u545::rtc::Rtc<'static>, stm32u545::rtc::Rtc::new());
+    rtc.register();
+
+    // Turn on the RTC clock and unlock the backup domain.
+    // We handle errors here such that a failure doesn't halt the kernel.
+    if let Err(e) = rtc.initialize_clock() {
+        debug!("{:?}", e)
+    }
+
+    // Set up the RTC mode. (configure prescalers, 24h format, default date/time)
+    // This requires the previous step, the clock and bckup domain to have been sucessfully initialized.
+    if let Err(e) = rtc.init_mode() {
+        debug!("{:?}", e)
+    }
 
     // Load Peripherals Bundle
     let periphs = static_init!(
         stm32u545::chip::Stm32u5xxDefaultPeripherals<'static>,
-        stm32u545::chip::Stm32u5xxDefaultPeripherals::new(usart1, exti, dma1)
+        stm32u545::chip::Stm32u5xxDefaultPeripherals::new(usart1, exti, dma1, rtc)
     );
 
     // Initialize wiring (DMA, clocks)
@@ -253,6 +270,15 @@ unsafe fn start() -> (
         alarm_mux,
     )
     .finalize(components::alarm_component_static!(stm32u545::tim::Tim2));
+
+    let date_time = components::date_time::DateTimeComponent::new(
+        board_kernel,
+        capsules_extra::date_time::DRIVER_NUM,
+        rtc,
+    )
+    .finalize(components::date_time_component_static!(
+        stm32u545::rtc::Rtc<'static>
+    ));
 
     let led_pin = static_init!(stm32u545::gpio::Pin, periphs.gpio_a.pin(PinId::Pin05));
     let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
@@ -361,6 +387,7 @@ unsafe fn start() -> (
             adc: adc_syscall,
             dac,
             gpio,
+            date_time,
         }
     );
 

--- a/boards/nucleo_u545re_q/src/main.rs
+++ b/boards/nucleo_u545re_q/src/main.rs
@@ -200,17 +200,18 @@ unsafe fn start() -> (
         stm32u545::rcc::Rcc,
         stm32u545::rcc::Rcc::new(stm32u545::rcc::RCC_BASE)
     );
-    let rtc = static_init!(stm32u545::rtc::Rtc<'static>, stm32u545::rtc::Rtc::new(rcc));
-    rtc.register();
 
     // Load Peripherals Bundle
     let periphs = static_init!(
         stm32u545::chip::Stm32u5xxDefaultPeripherals<'static>,
-        stm32u545::chip::Stm32u5xxDefaultPeripherals::new(usart1, exti, dma1, rtc)
+        stm32u545::chip::Stm32u5xxDefaultPeripherals::new(usart1, exti, dma1, rcc)
     );
 
     // Initialize wiring (DMA, clocks)
     periphs.init();
+
+    // Register the RTC to the deferred call client
+    periphs.rtc.register();
 
     // Board specific wiring
     periphs.tim2.start();
@@ -267,7 +268,7 @@ unsafe fn start() -> (
     let date_time = components::date_time::DateTimeComponent::new(
         board_kernel,
         capsules_extra::date_time::DRIVER_NUM,
-        rtc,
+        &periphs.rtc,
     )
     .finalize(components::date_time_component_static!(
         stm32u545::rtc::Rtc<'static>

--- a/boards/nucleo_u545re_q/src/main.rs
+++ b/boards/nucleo_u545re_q/src/main.rs
@@ -6,13 +6,13 @@
 #![no_std]
 #![no_main]
 
+use kernel::capabilities;
 use kernel::component::Component;
 use kernel::debug::PanicResources;
 use kernel::deferred_call::DeferredCallClient;
 use kernel::platform::chip::Chip;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::utilities::single_thread_value::SingleThreadValue;
-use kernel::{capabilities, debug};
 use kernel::{create_capability, static_init};
 
 use stm32u545::gpio::PinId;
@@ -202,18 +202,6 @@ unsafe fn start() -> (
     );
     let rtc = static_init!(stm32u545::rtc::Rtc<'static>, stm32u545::rtc::Rtc::new(rcc));
     rtc.register();
-
-    // Turn on the RTC clock and unlock the backup domain.
-    // We handle errors here such that a failure doesn't halt the kernel.
-    if let Err(e) = rtc.initialize_clock() {
-        debug!("{:?}", e)
-    }
-
-    // Set up the RTC mode. (configure prescalers, 24h format, default date/time)
-    // This requires the previous step, the clock and bckup domain to have been sucessfully initialized.
-    if let Err(e) = rtc.init_mode() {
-        debug!("{:?}", e)
-    }
 
     // Load Peripherals Bundle
     let periphs = static_init!(

--- a/boards/nucleo_u545re_q/src/main.rs
+++ b/boards/nucleo_u545re_q/src/main.rs
@@ -195,7 +195,12 @@ unsafe fn start() -> (
     );
 
     usart1.register();
-    let rtc = static_init!(stm32u545::rtc::Rtc<'static>, stm32u545::rtc::Rtc::new());
+
+    let rcc = static_init!(
+        stm32u545::rcc::Rcc,
+        stm32u545::rcc::Rcc::new(stm32u545::rcc::RCC_BASE)
+    );
+    let rtc = static_init!(stm32u545::rtc::Rtc<'static>, stm32u545::rtc::Rtc::new(rcc));
     rtc.register();
 
     // Turn on the RTC clock and unlock the backup domain.

--- a/boards/nucleo_u545re_q/src/main.rs
+++ b/boards/nucleo_u545re_q/src/main.rs
@@ -81,6 +81,8 @@ struct NucleoU545RE {
         >,
     >,
     i2c: &'static capsules_core::i2c_master::I2CMasterDriver<'static, stm32u545::i2c::I2c<'static>>,
+    date_time:
+        &'static capsules_extra::date_time::DateTimeCapsule<'static, stm32u545::rtc::Rtc<'static>>,
 }
 
 impl SyscallDriverLookup for NucleoU545RE {
@@ -102,6 +104,7 @@ impl SyscallDriverLookup for NucleoU545RE {
             capsules_extra::symmetric_encryption::aes::DRIVER_NUM => f(Some(self.aes)),
             capsules_core::spi_controller::DRIVER_NUM => f(Some(self.spi)),
             capsules_core::i2c_master::DRIVER_NUM => f(Some(self.i2c)),
+            capsules_extra::date_time::DRIVER_NUM => f(Some(self.date_time)),
             _ => f(None),
         }
     }
@@ -380,6 +383,16 @@ unsafe fn start() -> (
     )
     .finalize(components::alarm_component_static!(stm32u545::tim::Tim2));
 
+    let date_time = components::date_time::DateTimeComponent::new(
+        board_kernel,
+        capsules_extra::date_time::DRIVER_NUM,
+        &periphs.rtc,
+        create_capability!(capabilities::MemoryAllocationCapability),
+    )
+    .finalize(components::date_time_component_static!(
+        stm32u545::rtc::Rtc<'static>
+    ));
+
     let led_pin = static_init!(stm32u545::gpio::Pin, periphs.gpio_a.pin(PinId::Pin05));
     let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
         kernel::hil::led::LedHigh<'static, stm32u545::gpio::Pin>,
@@ -564,6 +577,7 @@ unsafe fn start() -> (
             hmac,
             aes: aes_driver,
             spi,
+            date_time,
         }
     );
 

--- a/boards/nucleo_u545re_q/src/main.rs
+++ b/boards/nucleo_u545re_q/src/main.rs
@@ -210,9 +210,6 @@ unsafe fn start() -> (
     // Initialize wiring (DMA, clocks)
     periphs.init();
 
-    // Register the RTC to the deferred call client
-    periphs.rtc.register();
-
     // Board specific wiring
     periphs.tim2.start();
     set_pin_primary_functions(periphs);

--- a/chips/stm32u545/src/lib.rs
+++ b/chips/stm32u545/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![no_std]
 
-pub use stm32u5xx::{adc, chip, dma, exti, gpio, pwr, rcc, tim, usart};
+pub use stm32u5xx::{adc, chip, dma, exti, gpio, pwr, rcc, rtc, tim, usart};
 
 use cortexm33::{CortexM33, CortexMVariant};
 

--- a/chips/stm32u545/src/lib.rs
+++ b/chips/stm32u545/src/lib.rs
@@ -4,7 +4,9 @@
 
 #![no_std]
 
-pub use stm32u5xx::{adc, aes, chip, crc, dma, exti, gpio, hash, i2c, pwr, rcc, spi, tim, usart};
+pub use stm32u5xx::{
+    adc, aes, chip, crc, dma, exti, gpio, hash, i2c, pwr, rcc, rtc, spi, tim, usart,
+};
 
 use cortexm33::{CortexM33, CortexMVariant};
 

--- a/chips/stm32u5xx/README.md
+++ b/chips/stm32u5xx/README.md
@@ -7,6 +7,7 @@ microcontrollers from STMicroelectronics.
 
 Currently supported peripherals:
 - RCC (Reset and Clock Control)
+- RTC (Real Time Clock)
 - GPIO (General Purpose I/O)
 - EXTI (External Interrupts)
 - USART (Universal Synchronous/Asynchronous Receiver Transmitter)

--- a/chips/stm32u5xx/README.md
+++ b/chips/stm32u5xx/README.md
@@ -8,6 +8,7 @@ microcontrollers from STMicroelectronics.
 Currently supported peripherals:
 
 - RCC (Reset and Clock Control)
+- RTC (Real Time Clock)
 - GPIO (General Purpose I/O)
 - EXTI (External Interrupts)
 - USART (Universal Synchronous/Asynchronous Receiver Transmitter)

--- a/chips/stm32u5xx/src/chip.rs
+++ b/chips/stm32u5xx/src/chip.rs
@@ -22,6 +22,7 @@ use crate::usart;
 use crate::{dac, exti};
 
 use core::fmt::Write;
+use kernel::debug;
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
 
@@ -105,6 +106,17 @@ impl<'a> Stm32u5xxDefaultPeripherals<'a> {
         let usart1_channel_rx = self.dma1.request_channel();
         if let (Some(tx), Some(rx)) = (usart1_channel_tx, usart1_channel_rx) {
             usart::Usart::set_dma(self.usart1, self.dma1, tx, rx);
+        }
+
+        // Turn on the RTC clock and unlock the backup domain.
+        // We handle errors here such that a failure doesn't halt the kernel.
+        if let Err(e) = self.rtc.initialize_clock() {
+            debug!("{:?}", e)
+        }
+        // Set up the RTC mode. (configure prescalers, 24h format, default date/time)
+        // This requires the previous step, the clock and bckup domain to have been sucessfully initialized.
+        if let Err(e) = self.rtc.init_mode() {
+            debug!("{:?}", e)
         }
     }
 }

--- a/chips/stm32u5xx/src/chip.rs
+++ b/chips/stm32u5xx/src/chip.rs
@@ -16,6 +16,7 @@ use crate::nvic::{
 };
 use crate::pwr;
 use crate::rcc;
+use crate::rtc;
 use crate::tim;
 use crate::usart;
 use crate::{dac, exti};
@@ -32,6 +33,7 @@ pub struct Stm32u5xx<'a, I: InterruptService + 'a> {
 
 pub struct Stm32u5xxDefaultPeripherals<'a> {
     pub rcc: rcc::Rcc,
+    pub rtc: &'a rtc::Rtc<'a>,
     pub tim2: tim::Tim2<'a>,
     pub usart1: &'a usart::Usart<'a>,
     pub exti: &'a exti::Exti<'a>,
@@ -55,9 +57,15 @@ fn enable_dac1_clock() {
 }
 
 impl<'a> Stm32u5xxDefaultPeripherals<'a> {
-    pub fn new(usart1: &'a usart::Usart<'a>, exti: &'a exti::Exti<'a>, dma1: &'a Dma) -> Self {
+    pub fn new(
+        usart1: &'a usart::Usart<'a>,
+        exti: &'a exti::Exti<'a>,
+        dma1: &'a Dma,
+        rtc: &'a rtc::Rtc<'a>,
+    ) -> Self {
         Self {
             rcc: rcc::Rcc::new(rcc::RCC_BASE),
+            rtc,
             tim2: tim::Tim2::new(tim::TIM2_BASE, enable_tim2_clock),
             usart1,
             exti,

--- a/chips/stm32u5xx/src/chip.rs
+++ b/chips/stm32u5xx/src/chip.rs
@@ -33,8 +33,8 @@ pub struct Stm32u5xx<'a, I: InterruptService + 'a> {
 }
 
 pub struct Stm32u5xxDefaultPeripherals<'a> {
-    pub rcc: rcc::Rcc,
-    pub rtc: &'a rtc::Rtc<'a>,
+    pub rcc: &'a rcc::Rcc,
+    pub rtc: rtc::Rtc<'a>,
     pub tim2: tim::Tim2<'a>,
     pub usart1: &'a usart::Usart<'a>,
     pub exti: &'a exti::Exti<'a>,
@@ -62,11 +62,11 @@ impl<'a> Stm32u5xxDefaultPeripherals<'a> {
         usart1: &'a usart::Usart<'a>,
         exti: &'a exti::Exti<'a>,
         dma1: &'a Dma,
-        rtc: &'a rtc::Rtc<'a>,
+        rcc: &'a rcc::Rcc,
     ) -> Self {
         Self {
-            rcc: rcc::Rcc::new(rcc::RCC_BASE),
-            rtc,
+            rcc,
+            rtc: rtc::Rtc::new(rcc),
             tim2: tim::Tim2::new(tim::TIM2_BASE, enable_tim2_clock),
             usart1,
             exti,

--- a/chips/stm32u5xx/src/chip.rs
+++ b/chips/stm32u5xx/src/chip.rs
@@ -23,6 +23,7 @@ use crate::{dac, exti};
 
 use core::fmt::Write;
 use kernel::debug;
+use kernel::deferred_call::DeferredCallClient;
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
 
@@ -101,6 +102,10 @@ impl<'a> Stm32u5xxDefaultPeripherals<'a> {
         self.adc1.enable(AdcSamplingTime::ClockCycles20);
 
         self.rcc.enable_dac1();
+
+        // Deferred Calls
+        self.rtc.register();
+
         // Link DMA to USART1
         let usart1_channel_tx = self.dma1.request_channel();
         let usart1_channel_rx = self.dma1.request_channel();

--- a/chips/stm32u5xx/src/chip.rs
+++ b/chips/stm32u5xx/src/chip.rs
@@ -20,6 +20,7 @@ use crate::nvic::{
 };
 use crate::pwr;
 use crate::rcc;
+use crate::rtc;
 use crate::spi;
 use crate::tim;
 use crate::usart;
@@ -41,6 +42,7 @@ pub struct Stm32u5xx<'a, I: InterruptService + 'a> {
 
 pub struct Stm32u5xxDefaultPeripherals<'a> {
     pub rcc: rcc::Rcc,
+    pub rtc: rtc::Rtc<'a>,
     pub tim2: tim::Tim2<'a>,
     pub tim3: tim::Pwm<'a>,
     pub usart1: usart::Usart<'a>,
@@ -78,6 +80,7 @@ impl<'a> Stm32u5xxDefaultPeripherals<'a> {
     pub fn new(exti: &'a exti::Exti<'a>, dma1: &'a Dma) -> Self {
         Self {
             rcc: rcc::Rcc::new(rcc::RCC_BASE),
+            rtc: rtc::Rtc::new(rtc::RTC_BASE),
             tim2: tim::Tim2::new(tim::TIM2_BASE, enable_tim2_clock),
             tim3: tim::Pwm::new(
                 tim::TIM3_BASE,
@@ -121,6 +124,17 @@ impl<'a> Stm32u5xxDefaultPeripherals<'a> {
         self.rcc.enable_hash();
         self.rcc.set_usart1_source_pclk();
 
+        // RTC
+        // The RTC lives in the backup domain, which is write protected on every start
+        self.pwr.disable_backup_domain();
+        // Clock the RTC registers so we can write to them.
+        self.rcc.enable_apb3_bus_clk();
+        self.rcc.enable_lsi();
+        // Only use the LSI once it is stable, but don't hang the kernel if it never is.
+        self.rcc.wait_for_lsi_ready();
+        self.rcc.select_rtc_source_lsi();
+        self.rcc.enable_rtc();
+
         let _ = self.spi1.init();
 
         // ADC
@@ -138,6 +152,7 @@ impl<'a> Stm32u5xxDefaultPeripherals<'a> {
         // Deferred Calls
         self.usart1.register();
         self.crc.register();
+        self.rtc.register();
 
         // I2C
         self.rcc.enable_i2c1();
@@ -179,6 +194,11 @@ impl<'a> Stm32u5xxDefaultPeripherals<'a> {
         if let (Some(tx), Some(rx)) = (i2c1_channel_tx, i2c1_channel_rx) {
             i2c::I2c::set_dma(&self.i2c1, self.dma1, tx, rx);
         }
+
+        // Set up the RTC mode. (configure prescalers, 24h format, default date/time)
+        // This requires the RTC clock and backup domain to have been sucessfully
+        // initialized in the "Power and Wires" section above.
+        let _ = self.rtc.init_mode();
     }
 }
 

--- a/chips/stm32u5xx/src/lib.rs
+++ b/chips/stm32u5xx/src/lib.rs
@@ -13,6 +13,7 @@ pub mod gpio;
 pub mod nvic;
 pub mod pwr;
 pub mod rcc;
+pub mod rtc;
 pub mod tim;
 pub mod usart;
 

--- a/chips/stm32u5xx/src/lib.rs
+++ b/chips/stm32u5xx/src/lib.rs
@@ -19,6 +19,7 @@ pub mod pwr;
 pub mod rcc;
 pub mod rng;
 pub mod rsa;
+pub mod rtc;
 pub mod spi;
 pub mod tim;
 pub mod usart;

--- a/chips/stm32u5xx/src/pwr.rs
+++ b/chips/stm32u5xx/src/pwr.rs
@@ -12,7 +12,10 @@ register_structs! {
         (0x000 => _reserved),
         /// PWR supply voltage monitoring control register
         (0x010 => pwr_svmcr: ReadWrite<u32, PWR_SVMCR::Register>),
-        (0x014 => @END),
+        (0x014 => _reserved1: [u32; 5]),
+        /// PWR disable backup domain register
+        (0x028 => pwr_dbpr: ReadWrite<u32, PWR_DBPR::Register>),
+        (0x02C => @END),
     }
 }
 register_bitfields![u32,
@@ -22,6 +25,10 @@ register_bitfields![u32,
         // If VDDA is not always present in the application, the VDDA voltage monitor can be used to determine whether this supply is ready or not.
         /// VDDA independent analog supply valid
         ASV OFFSET(30) NUMBITS(1) []
+    ],
+    PWR_DBPR [
+        /// Disable backup domain write protection
+        DBP OFFSET(0) NUMBITS(1) []
     ],
 ];
 const PWR_BASE: StaticRef<PwrRegisters> =
@@ -40,5 +47,10 @@ impl Pwr {
 
     pub fn validate_vdda(&self) {
         self.registers.pwr_svmcr.modify(PWR_SVMCR::ASV::SET);
+    }
+
+    /// Disable Backup Domain Write Protection
+    pub fn disable_backup_domain(&self) {
+        self.registers.pwr_dbpr.modify(PWR_DBPR::DBP::SET);
     }
 }

--- a/chips/stm32u5xx/src/pwr.rs
+++ b/chips/stm32u5xx/src/pwr.rs
@@ -3,7 +3,7 @@
 // Copyright Tock Contributors 2026.
 
 use kernel::utilities::StaticRef;
-use kernel::utilities::registers::interfaces::ReadWriteable;
+use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 use kernel::utilities::registers::{ReadWrite, register_bitfields, register_structs};
 
 register_structs! {
@@ -12,7 +12,10 @@ register_structs! {
         (0x000 => _reserved),
         /// PWR supply voltage monitoring control register
         (0x010 => pwr_svmcr: ReadWrite<u32, PWR_SVMCR::Register>),
-        (0x014 => @END),
+        (0x014 => _reserved1: [u32; 5]),
+        /// PWR disable backup domain register
+        (0x028 => pwr_dbpr: ReadWrite<u32, PWR_DBPR::Register>),
+        (0x02C => @END),
     }
 }
 register_bitfields![u32,
@@ -22,6 +25,10 @@ register_bitfields![u32,
         // If VDDA is not always present in the application, the VDDA voltage monitor can be used to determine whether this supply is ready or not.
         /// VDDA independent analog supply valid
         ASV OFFSET(30) NUMBITS(1) []
+    ],
+    PWR_DBPR [
+        /// Disable backup domain write protection
+        DBP OFFSET(0) NUMBITS(1) []
     ],
 ];
 const PWR_BASE: StaticRef<PwrRegisters> =
@@ -40,5 +47,20 @@ impl Pwr {
 
     pub fn validate_vdda(&self) {
         self.registers.pwr_svmcr.modify(PWR_SVMCR::ASV::SET);
+    }
+
+    /// Disable Backup Domain Write Protection
+    pub fn disable_backup_domain(&self) {
+        self.registers.pwr_dbpr.modify(PWR_DBPR::DBP::SET);
+        // Since the backup domain is behind a clock domain crossing the write
+        // takes a few cycles to take effect. Registers in that domain silently drop
+        // writes until it takes effect so we just poll for the bit to be activated before
+        // returning
+
+        // Magic number large enough to prevent kernel hanging if the write never takes effect
+        let mut cycle_counter = 100000;
+        while !self.registers.pwr_dbpr.is_set(PWR_DBPR::DBP) && cycle_counter > 0 {
+            cycle_counter -= 1;
+        }
     }
 }

--- a/chips/stm32u5xx/src/rcc.rs
+++ b/chips/stm32u5xx/src/rcc.rs
@@ -33,7 +33,10 @@ register_structs! {
         (0x0E4 => ccipr2: ReadWrite<u32, CCIPR1::Register>),
         /// Peripherals independent clock configuration register 3
         (0x0E8 => ccipr3: ReadWrite<u32, CCIPR3::Register>),
-        (0x0EC => @END),
+        (0x0EC => _reserved5: [u32; 1]),
+        /// RCC backup domain control register
+        (0x0F0 => bdcr: ReadWrite<u32, BDCR::Register>),
+        (0x0F4 => @END),
     }
 }
 
@@ -69,7 +72,9 @@ register_bitfields![u32,
         USART1EN OFFSET(14) NUMBITS(1) []
     ],
     pub APB3ENR [
-        SYSCFGEN OFFSET(1) NUMBITS(1) []
+        SYSCFGEN OFFSET(1) NUMBITS(1) [],
+        PWREN OFFSET(2) NUMBITS(1) [],
+        RTCAPBEN OFFSET(21) NUMBITS(1) [],
     ],
     pub CCIPR1 [
         USART1SEL OFFSET(0) NUMBITS(2) [
@@ -93,6 +98,21 @@ register_bitfields![u32,
             LSI = 1
         ]
     ],
+    pub BDCR [
+        /// LSI oscillator enable
+        LSION OFFSET(26) NUMBITS(1) [],
+        /// LSI oscillator ready
+        LSIRDY OFFSET(27) NUMBITS(1) [],
+        /// RTC and TAMP clock enable
+        RTCEN OFFSET(15) NUMBITS(1) [],
+        /// RTC and TAMP clock source selection
+        RTCSEL OFFSET(8) NUMBITS(2) [
+            NO_CLK = 0,
+            LSE = 1,
+            LSI = 2,
+            HSE = 3,
+        ]
+    ]
 ];
 
 /// Base address for RCC in Nonsecure mode
@@ -157,5 +177,29 @@ impl Rcc {
 
     pub fn enable_dac1(&self) {
         self.registers.ahb3enr.modify(AHB3ENR::DAC1EN::SET);
+    }
+    // Enable the power clock on the 3rd bus, used by RTC peripheral
+    pub fn enable_ahb3_pwrclk(&self) {
+        self.registers.ahb3enr.modify(AHB3ENR::PWREN::SET);
+    }
+    // Enable the APB3 bus clock for the RTC and TAMP peripherals
+    pub fn enable_apb3_bus_clk(&self) {
+        self.registers.apb3enr.modify(APB3ENR::RTCAPBEN::SET);
+    }
+    // Enabling the LSI oscillator
+    pub fn enable_lsi(&self) {
+        self.registers.bdcr.modify(BDCR::LSION::SET);
+    }
+    // Check if LSI is ready
+    pub fn is_lsi_ready(&self) -> bool {
+        self.registers.bdcr.is_set(BDCR::LSIRDY)
+    }
+    // Select LSI (2) as the RTC clock source
+    pub fn select_rtc_source_lsi(&self) {
+        self.registers.bdcr.modify(BDCR::RTCSEL::LSI);
+    }
+    // Enable the RTC clock
+    pub fn enable_rtc(&self) {
+        self.registers.bdcr.modify(BDCR::RTCEN::SET);
     }
 }

--- a/chips/stm32u5xx/src/rcc.rs
+++ b/chips/stm32u5xx/src/rcc.rs
@@ -58,7 +58,10 @@ register_structs! {
         (0x0E4 => ccipr2: ReadWrite<u32, CCIPR1::Register>),
         /// Peripherals independent clock configuration register 3
         (0x0E8 => ccipr3: ReadWrite<u32, CCIPR3::Register>),
-        (0x0EC => @END),
+        (0x0EC => _reserved5: [u32; 1]),
+        /// RCC backup domain control register
+        (0x0F0 => bdcr: ReadWrite<u32, BDCR::Register>),
+        (0x0F4 => @END),
     }
 }
 
@@ -102,7 +105,9 @@ register_bitfields![u32,
         SPI1EN OFFSET(12) NUMBITS(1) []
     ],
     pub APB3ENR [
-        SYSCFGEN OFFSET(1) NUMBITS(1) []
+        SYSCFGEN OFFSET(1) NUMBITS(1) [],
+        PWREN OFFSET(2) NUMBITS(1) [],
+        RTCAPBEN OFFSET(21) NUMBITS(1) [],
     ],
     pub CCIPR1 [
         USART1SEL OFFSET(0) NUMBITS(2) [
@@ -133,6 +138,21 @@ register_bitfields![u32,
             LSI = 1
         ]
     ],
+    pub BDCR [
+        /// LSI oscillator enable
+        LSION OFFSET(26) NUMBITS(1) [],
+        /// LSI oscillator ready
+        LSIRDY OFFSET(27) NUMBITS(1) [],
+        /// RTC and TAMP clock enable
+        RTCEN OFFSET(15) NUMBITS(1) [],
+        /// RTC and TAMP clock source selection
+        RTCSEL OFFSET(8) NUMBITS(2) [
+            NO_CLK = 0,
+            LSE = 1,
+            LSI = 2,
+            HSE = 3,
+        ]
+    ]
 ];
 
 /// Base address for RCC in Nonsecure mode
@@ -239,5 +259,34 @@ impl Rcc {
     // I belive it is better to be explicit
     pub fn set_i2c1_source_pclk(&self) {
         self.registers.ccipr1.modify(CCIPR1::I2C1SEL::PCLK);
+    }
+
+    // Enable the APB3 bus clock for the RTC and TAMP peripherals
+    pub fn enable_apb3_bus_clk(&self) {
+        self.registers.apb3enr.modify(APB3ENR::RTCAPBEN::SET);
+    }
+    // Enabling the LSI oscillator
+    pub fn enable_lsi(&self) {
+        self.registers.bdcr.modify(BDCR::LSION::SET);
+    }
+    // Check if LSI is ready
+    fn is_lsi_ready(&self) -> bool {
+        self.registers.bdcr.is_set(BDCR::LSIRDY)
+    }
+    // Wait for the LSI oscillator to stabilize before it is used as a clock source
+    pub fn wait_for_lsi_ready(&self) {
+        // Magic number large enough to prevent kernel hanging if the oscillator fails to stabilize
+        let mut cycle_counter = 100000;
+        while !self.is_lsi_ready() && cycle_counter > 0 {
+            cycle_counter -= 1;
+        }
+    }
+    // Select LSI as the RTC clock source
+    pub fn select_rtc_source_lsi(&self) {
+        self.registers.bdcr.modify(BDCR::RTCSEL::LSI);
+    }
+    // Enable the RTC clock
+    pub fn enable_rtc(&self) {
+        self.registers.bdcr.modify(BDCR::RTCEN::SET);
     }
 }

--- a/chips/stm32u5xx/src/rtc.rs
+++ b/chips/stm32u5xx/src/rtc.rs
@@ -508,6 +508,7 @@ enum DeferredCallTask {
 
 pub struct Rtc<'a> {
     registers: StaticRef<RtcRegisters>,
+    rcc: &'a rcc::Rcc,
     client: OptionalCell<&'a dyn date_time::DateTimeClient>,
     time: Cell<DateTimeValues>,
 
@@ -529,46 +530,11 @@ impl DeferredCallClient for Rtc<'_> {
     }
 }
 
-fn init_rtc_clock() -> Result<(), ErrorCode> {
-    // Initialize the RTC clock source and enables peripheral access.
-    // Why this specific sequence:
-    // 1. Enable the PWR clock: The Power controller manages access to the backup domain
-    // 2. We need to disable the Backup Domain's Write Protection since the write
-    //    protection resets to default state every time we boot up the board. We
-    //    want no write protection on the Backup Domain so we can access the RTC config
-    //    registers and time registers.
-    // 3. Enable the APB3 bus clock so our code can send commands to the RTC registers
-    // 4. Turn on the LSI Oscillator, which is a slow internal clock we use for low power consumption.
-    //    In ultra low power mode the HSE/HSI are disabled. We use LSI to keep track of time regardless
-    //    if the board is in stand-by, lower power mode or not.
-    // 5. After the LSI Oscillator stabilizes we select it as the RTC clock source. There can be
-    //    a situation where the oscillator doesn't stabilize, in that case my approach is to not hang the kernel
-    //    and just timeout.
-    let rcc = rcc::Rcc::new(rcc::RCC_BASE);
-    let pwr = PWR_BASE;
-    rcc.enable_ahb3_pwrclk();
-    pwr.pwr_dbpr.modify(PWR_DBPR::DBP::SET);
-    rcc.enable_apb3_bus_clk();
-
-    // Enable LSI oscillator.
-    rcc.enable_lsi();
-    // Magic number large enough to prevent kernel hanging if the oscillator fails to stabilize
-    let mut cycle_counter = 100000;
-    while !rcc.is_lsi_ready() && cycle_counter > 0 {
-        cycle_counter -= 1;
-    }
-    if cycle_counter <= 0 {
-        return Err(ErrorCode::FAIL);
-    }
-    rcc.select_rtc_source_lsi();
-    rcc.enable_rtc();
-    Ok(())
-}
-
 impl<'a> Rtc<'a> {
-    pub fn new() -> Rtc<'a> {
+    pub fn new(rcc: &'a rcc::Rcc) -> Rtc<'a> {
         Rtc {
             registers: RTC_BASE,
+            rcc,
             client: OptionalCell::empty(),
             time: Cell::new(DateTimeValues {
                 year: 0,
@@ -584,7 +550,38 @@ impl<'a> Rtc<'a> {
         }
     }
     pub fn initialize_clock(&self) -> Result<(), ErrorCode> {
-        init_rtc_clock()
+        // Initialize the RTC clock source and enables peripheral access.
+        // Why this specific sequence:
+        // 1. Enable the PWR clock: The Power controller manages access to the backup domain
+        // 2. We need to disable the Backup Domain's Write Protection since the write
+        //    protection resets to default state every time we boot up the board. We
+        //    want no write protection on the Backup Domain so we can access the RTC config
+        //    registers and time registers.
+        // 3. Enable the APB3 bus clock so our code can send commands to the RTC registers
+        // 4. Turn on the LSI Oscillator, which is a slow internal clock we use for low power consumption.
+        //    In ultra low power mode the HSE/HSI are disabled. We use LSI to keep track of time regardless
+        //    if the board is in stand-by, lower power mode or not.
+        // 5. After the LSI Oscillator stabilizes we select it as the RTC clock source. There can be
+        //    a situation where the oscillator doesn't stabilize, in that case my approach is to not hang the kernel
+        //    and just timeout.
+        let pwr = PWR_BASE;
+        self.rcc.enable_ahb3_pwrclk();
+        pwr.pwr_dbpr.modify(PWR_DBPR::DBP::SET);
+        self.rcc.enable_apb3_bus_clk();
+
+        // Enable LSI oscillator.
+        self.rcc.enable_lsi();
+        // Magic number large enough to prevent kernel hanging if the oscillator fails to stabilize
+        let mut cycle_counter = 100000;
+        while !self.rcc.is_lsi_ready() && cycle_counter > 0 {
+            cycle_counter -= 1;
+        }
+        if cycle_counter <= 0 {
+            return Err(ErrorCode::FAIL);
+        }
+        self.rcc.select_rtc_source_lsi();
+        self.rcc.enable_rtc();
+        Ok(())
     }
     #[inline(never)]
     // This function is marked as #[inline(never)] in order to aid with the debugging process when

--- a/chips/stm32u5xx/src/rtc.rs
+++ b/chips/stm32u5xx/src/rtc.rs
@@ -6,6 +6,8 @@
 // Referance Document:
 // RM0456 Reference Manual: https://www.st.com/resource/en/reference_manual/rm0456-stm32u5-series-armbased-32bit-mcus-stmicroelectronics.pdf
 
+use crate::pwr;
+
 use super::rcc;
 use core::cell::Cell;
 use kernel::ErrorCode;
@@ -476,29 +478,10 @@ RTC_ALRBBINR[
 ],
 ];
 
-register_structs! {
-pub PwrRegisters {
-    (0x00 => _padding),
-    /// PWR disable backup domain register
-    (0x28 => pwr_dbpr: ReadWrite<u32, PWR_DBPR::Register>),
-    (0x2C => @END),
-}
-}
-register_bitfields![u32,
-    PWR_DBPR [
-        /// Disable backup domain write protection
-        DBP OFFSET(0) NUMBITS(1) []
-    ],
-];
-
 // Real Time Clock
 // RM0456, Table 6. Memoy map and peripheral register boundary addresses - Page 145
 const RTC_BASE: StaticRef<RtcRegisters> =
     unsafe { StaticRef::new(0x46007800 as *const RtcRegisters) };
-// Power Control
-// RM0456, Table 6. Memoy map and peripheral register boundary addresses - Page 145
-const PWR_BASE: StaticRef<PwrRegisters> =
-    unsafe { StaticRef::new(0x46020800 as *const PwrRegisters) };
 
 #[derive(Clone, Copy)]
 enum DeferredCallTask {
@@ -564,9 +547,9 @@ impl<'a> Rtc<'a> {
         // 5. After the LSI Oscillator stabilizes we select it as the RTC clock source. There can be
         //    a situation where the oscillator doesn't stabilize, in that case my approach is to not hang the kernel
         //    and just timeout.
-        let pwr = PWR_BASE;
+        let pwr = pwr::Pwr::new();
         self.rcc.enable_ahb3_pwrclk();
-        pwr.pwr_dbpr.modify(PWR_DBPR::DBP::SET);
+        pwr.disable_backup_domain();
         self.rcc.enable_apb3_bus_clk();
 
         // Enable LSI oscillator.

--- a/chips/stm32u5xx/src/rtc.rs
+++ b/chips/stm32u5xx/src/rtc.rs
@@ -1,0 +1,858 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright OxidOS Automotive 2026.
+
+// RTC Driver for the STM32U545RE-Q
+// Referance Document:
+// RM0456 Reference Manual: https://www.st.com/resource/en/reference_manual/rm0456-stm32u5-series-armbased-32bit-mcus-stmicroelectronics.pdf
+
+use super::rcc;
+use core::cell::Cell;
+use kernel::ErrorCode;
+use kernel::deferred_call::{DeferredCall, DeferredCallClient};
+use kernel::hil::date_time;
+use kernel::hil::date_time::{DateTimeClient, DateTimeValues, DayOfWeek, Month};
+use kernel::utilities::StaticRef;
+use kernel::utilities::cells::OptionalCell;
+use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
+use kernel::utilities::registers::{ReadOnly, WriteOnly, interfaces::Writeable, register_structs};
+use kernel::utilities::registers::{ReadWrite, register_bitfields};
+
+register_structs! {
+pub  RtcRegisters{
+
+    /// The RTC_TR is the calendar time shadow register. This register must be written in initialization mode only.
+    (0x00 => rtc_tr: ReadWrite<u32, RTC_TR::Register>),
+
+    /// The RTC_DR is the calendar date shadow register. This register must be written in initialization mode only.
+    (0x04 => rtc_dr: ReadWrite<u32, RTC_DR::Register>),
+
+    /// RTC subsecond register
+    (0x08 => rtc_ssr: ReadOnly<u32, RTC_SSR::Register>),
+
+    /// RTC initialization control and status regiter.
+    (0x0C => rtc_icsr: ReadWrite<u32, RTC_ICSR::Register>),
+
+    /// RTC prescaler register
+    (0x10 => rtc_prer: ReadWrite<u32,RTC_PRER::Register>),
+
+    /// RTC wake-up timer register
+    (0x14 => rtc_wutr: ReadWrite<u32,RTC_WUTR::Register>),
+
+    /// RTC control register
+    (0x18 => rtc_cr: ReadWrite<u32,RTC_CR::Register>),
+
+    /// RTC privilege mode control register. This register can be written only when the APB access is privileged.
+    (0x1C => rtc_privcfgr: ReadWrite<u32,RTC_PRIVCFGR::Register>),
+
+    /// RTC secure configuration register. This register can be written only when the APB access is secure.
+    (0x20 => rtc_seccfgr: ReadWrite<u32, RTC_SECCFGR::Register>),
+
+    /// RTC write protection register
+    (0x24 => rtc_wpr: WriteOnly<u32,RTC_WPR::Register>),
+
+    /// RTC calibration register
+    (0x28 => rtc_calr: ReadWrite<u32, RTC_CALR::Register>),
+
+    /// RTC shift control register
+    (0x2C => rtc_shiftr: WriteOnly<u32,RTC_SHIFTR::Register>),
+
+    /// RTC timestamp time register
+    (0x30 => rtc_tstr: ReadOnly<u32, RTC_TSTR::Register>),
+
+    /// RTC timestamp data register
+    (0x34 => rtc_tsdr: ReadOnly<u32,RTC_TSDR::Register>),
+
+    /// RTC timestamp subsecond register
+    (0x38 => rtc_tsssr: ReadOnly<u32,RTC_TSSSR::Register>),
+
+    (0x3C => _padding),
+
+    /// RTC alarm A register.This register can be written only when ALRAE is reset in RTC_CR register.
+    (0x40 => rtc_alrmar: ReadWrite<u32,RTC_ALRMAR::Register>),
+
+    /// RTC alarm A subsecond register.
+    (0x44 => rtc_alrmassr: ReadWrite<u32,RTC_ALRMASSR::Register>),
+
+    /// RTC alarm B register
+    (0x48 => rtc_alrmbr: ReadWrite<u32,RTC_ALRMBR::Register>),
+
+    /// RTC alarm B subsecond register
+    (0x4C => rtc_alrmbssr: ReadWrite<u32,RTC_ALRMBSSR::Register>),
+
+    /// RTC status register
+    (0x50 => rtc_sr: ReadOnly<u32, RTC_SR::Register>),
+
+    /// RTC nonsecure masked interrupt status register
+    (0x54 => rtc_misr: ReadOnly<u32,RTC_MISR::Register>),
+
+    /// RTC secure masked interrupt status register
+    (0x58 => rtc_smisr: ReadOnly<u32,RTC_SMISR::Register>),
+
+    /// RTC status clear register
+    (0x5C => rtc_scr: WriteOnly<u32,RTC_SCR::Register>),
+
+    (0x60 => _padding1),
+    (0x64 => _padding2),
+    (0x68 => _padding3),
+    (0x6C => _padding4),
+
+    /// RTC alarm A binary mode register.This register can be written only when ALRAE is reset in RTC_CR register.
+    (0x70 => rtc_alrabinr: ReadWrite<u32,RTC_ALRABINR::Register>),
+
+    /// RTC alarm B binary mode register.This register can be written only when ALRBE is reset in RTC_CR register.
+    (0x74 => rtc_alrbbinr: ReadWrite<u32,RTC_ALRBBINR::Register>),
+
+    (0x78 => @END),
+}
+}
+register_bitfields![u32,
+RTC_TR[
+    /// AM/PM notation. 0: AM or 24-hour format, 1: PM
+    PM OFFSET(22) NUMBITS(1) [],
+    /// Hour tens in BCD format
+    HT OFFSET(20) NUMBITS(2) [],
+    /// Hour units in BCD format
+    HU OFFSET(16) NUMBITS(4) [],
+    /// Minute tens in BCD format
+    MNT OFFSET(12) NUMBITS(3) [],
+    /// Minute units in BCD format
+    MNU OFFSET(8) NUMBITS(4) [],
+    /// Second tens in BCD format
+    ST OFFSET(4) NUMBITS(3) [],
+    /// Second units in BCD format
+    SU OFFSET(0) NUMBITS(4) [],
+],
+RTC_DR[
+    /// Year tens in BCD format
+    YT OFFSET(20) NUMBITS(4) [],
+    /// Year units in BCD format
+    YU OFFSET(16) NUMBITS(4) [],
+    /// Week day units
+    WDU OFFSET(13) NUMBITS(3) [],
+    /// Month tens in BCD format
+    MT OFFSET(12) NUMBITS(1) [],
+    /// Month units in BCD format
+    MU OFFSET(8) NUMBITS(4) [],
+    /// Date tens in BCD format
+    DT OFFSET(4) NUMBITS(1) [],
+    /// Date units in BCD format
+    DU OFFSET(0) NUMBITS(4) [],
+],
+
+RTC_SSR[
+    /// Sub second value / synchronous binary counter LSB values
+    SS OFFSET(0) NUMBITS(16) [],
+],
+
+RTC_ICSR[
+    /// Wake-up timer write flag
+    WUTWF OFFSET(2) NUMBITS(1) [],
+    /// Shift operation pending
+    SHPF OFFSET(3) NUMBITS(1) [],
+    /// Initalization status flag
+    INITS OFFSET(4) NUMBITS(1) [],
+    /// Registers synchronization flag
+    RSF OFFSET(5) NUMBITS(1) [],
+    /// Initialization flag
+    INITF OFFSET(6) NUMBITS(1) [],
+    /// Initialization mode
+    INIT OFFSET(7) NUMBITS(1) [],
+    /// Binary mode
+    BIN OFFSET(8) NUMBITS(2) [],
+    /// BCD update
+    BCDU OFFSET(10) NUMBITS(3) [],
+    /// Recalibration pending flag
+    RECALPF OFFSET(16) NUMBITS(1) [],
+],
+
+RTC_PRER[
+    /// Synchronous prescaler factor
+    PREDIV_S OFFSET(0) NUMBITS(15) [],
+    /// Asynchronous prescaler factor
+    PREDIV_A OFFSET(16) NUMBITS(7) [],
+],
+RTC_WUTR[
+    /// Wake-up auto-reload output clear value
+    WUTOCLR OFFSET(16) NUMBITS(16) [],
+    /// Wake-up auto-reload value bits
+    WUT OFFSET(0) NUMBITS(16) [],
+],
+RTC_CR[
+    /// RTC_OUT2 output enalbe
+    OUT2EN OFFSET(31) NUMBITS(1) [],
+    /// TAMPALRM output type
+    TAMPALRM_TYPE OFFSET(30) NUMBITS(1) [],
+    /// TAMPALRM pull-up enable
+    TAMPALRM_PU OFFSET(29) NUMBITS(1) [],
+    /// Alarm B flag automatic clear
+    ALRBFCLR OFFSET(28) NUMBITS(1) [],
+    /// Alarm A flag automatic clear
+    ALRAFCLR OFFSET(27) NUMBITS(1) [],
+    ///Tamper detection output enable on TAMPALRM
+    TAMPOE OFFSET(26) NUMBITS(1) [],
+    /// Activate timestamp on tamper detection event
+    TAMPTS OFFSET(25) NUMBITS(1) [],
+    /// Timestamp on internal event enable
+    ITSE OFFSET(24) NUMBITS(1) [],
+    /// Calibration output enable
+    COE OFFSET(23) NUMBITS(1) [],
+    /// Output selection
+    OSEL OFFSET(21) NUMBITS(2) [],
+    /// Output polarity
+    POL OFFSET(20) NUMBITS(1) [],
+    /// Calibration output selection
+    COSEL OFFSET(19) NUMBITS(1) [],
+    /// Backup
+    BKP OFFSET(18) NUMBITS(1) [],
+    /// Subtract 1 hour (winter time change)
+    SUB1H OFFSET(17) NUMBITS(1) [],
+    /// Add 1 hour (sumer time change)
+    AD1H OFFSET(16)  NUMBITS(1) [],
+    /// Timestampt interrupt enable
+    TSIE OFFSET(15) NUMBITS(1) [],
+    /// Wake-up timer interrupt enable
+    WUTIE OFFSET(14) NUMBITS(1) [],
+    /// Alarm B interrupt enable
+    ALRBIE OFFSET(13) NUMBITS(1) [],
+    /// Alarm A interrupt enable
+    ALRAIE OFFSET(12) NUMBITS(1) [],
+    /// Timestamp enable
+    TSE OFFSET(11) NUMBITS(1) [],
+    /// Wake-up timer enable
+    WUTE OFFSET(10) NUMBITS(1) [],
+    /// Alarm B enable
+    ALRBE OFFSET(9) NUMBITS(1) [],
+    /// Alarm A enable
+    ALRAE OFFSET(8) NUMBITS(1) [],
+    /// SSR underflow interrupt enable
+    SSRUIE OFFSET(7) NUMBITS(1) [],
+    /// Hour Format ( 0 -> 24h , 1 -> AM/PM)
+    FMT OFFSET(6) NUMBITS(1) [],
+    /// Bypas the shadow registers
+    BYPSHAD OFFSET(5) NUMBITS(1) [],
+    /// RTC_REFIN reference clock detection enable (50 or 60 Hz)
+    REFCKON OFFSET(4) NUMBITS(1) [],
+    /// Timestamp event active edge
+    TSEDGE OFFSET(3) NUMBITS(1) [],
+    /// ck_wut wake-up clock selection
+    WUCKSEL OFFSET(0) NUMBITS(2) [],
+
+],
+RTC_PRIVCFGR[
+    /// RTC privilege protecction
+    PRIV OFFSET(15) NUMBITS(1) [],
+    /// Initialization privilege protection
+    INITPRIV OFFSET(14) NUMBITS(1) [],
+    /// Shift register, daylight saving, calibration and reference clock privilege protection
+    CALPRIV OFFSET(13) NUMBITS(1) [],
+    /// Timestamp privilege protection
+    TSPRIV OFFSET(3) NUMBITS(1) [],
+    /// Wake-up timer privilege protection
+    WUTPRIV OFFSET(2) NUMBITS(1) [],
+    /// Alarm B privilege protection
+    ALRBPRIV OFFSET(1) NUMBITS(1) [],
+    /// Alarm A and SSR underflow privilege protection
+    ALRAPRIV OFFSET(0) NUMBITS(1) [],
+],
+RTC_SECCFGR[
+    /// RTC global protection
+    SEC OFFSET(15) NUMBITS(1) [],
+    /// Initialization protection
+    INITSEC OFFSET(14) NUMBITS(1) [],
+    /// Shift register, daylight saving, calibration and reference clock protection
+    CALSEC OFFSET(13) NUMBITS(1) [],
+    /// Timestamp protection
+    TSSEC OFFSET(3) NUMBITS(1) [],
+    /// Wake-up timer protection
+    WUTSEC OFFSET(2) NUMBITS(1) [],
+    /// Alarm B protection
+    ALRBSEC OFFSET(1) NUMBITS(1) [],
+    /// Alarm A and SSR underflow protection
+    ALRASEC OFFSET(0) NUMBITS(1) [],
+],
+RTC_WPR[
+    /// Write protection key
+    KEY OFFSET(0) NUMBITS(8) [],
+],
+RTC_CALR[
+    /// Increase frequenccey of RTC by 488.5 ppm
+    CALP OFFSET(15)  NUMBITS(1) [],
+    /// use an 8-second calibration cycle period
+    CALW8 OFFSET(14) NUMBITS(1) [],
+    /// Use a 16-second calibration cycle period
+    CALW16 OFFSET(13) NUMBITS(1) [],
+    /// RTC low-power mode
+    LPCAL OFFSET(12) NUMBITS(1) [],
+    /// Calibration minus
+    CALM OFFSET(0) NUMBITS(9) [],
+],
+RTC_SHIFTR[
+    /// Add one second
+    ADD1S OFFSET(31) NUMBITS(1) [],
+    /// Subtract a fraction of a second  = SUBFS / (PREDIV_S + 1)
+    SUBFS OFFSET(0) NUMBITS(15)[],
+],
+RTC_TSTR[
+    /// AM/PM notation (0 is 24h)
+    PM OFFSET(22) NUMBITS(1) [],
+    /// Hour tens in BCD format
+    HT OFFSET(20) NUMBITS(2)[],
+    /// Hour units in BCD format
+    HU OFFSET(16) NUMBITS(4)[],
+    /// Minute tens in BCD format
+    MNT OFFSET(12) NUMBITS(3)[],
+    /// Minute units in BCD format
+    MNU OFFSET(8) NUMBITS(4)[],
+    /// Second tens in BCD format
+    ST OFFSET(4) NUMBITS(3) [],
+    /// Second units in BCD format
+    SU OFFSET(0) NUMBITS(4) [],
+],
+
+RTC_TSDR[
+    /// Week day units
+    WDU OFFSET(13) NUMBITS(3) [],
+    /// Month tens in BCD format
+    MT OFFSET(12) NUMBITS(1) [],
+    /// Month units in BCD format
+    MU OFFSET(8) NUMBITS(4) [],
+    /// Day tens in BCD format
+    DT OFFSET(4) NUMBITS(2)[],
+    /// Day units in BCD format
+    DU OFFSET(0) NUMBITS(4)[],
+],
+RTC_TSSSR[
+    /// Subsecond value/synchronous binary counter values
+    SS OFFSET(0) NUMBITS(32) []
+],
+RTC_ALRMAR[
+    /// Alarm A date mask
+    MSK4 OFFSET(31) NUMBITS(1) [],
+    /// Week day selection
+    WDSEL OFFSET(30) NUMBITS(1) [],
+    /// Date tens in BCD format
+    DT OFFSET(28) NUMBITS(2) [],
+    /// Date units or day in BCD format
+    DU OFFSET(24) NUMBITS(4) [],
+    /// Alarm A hours mask
+    MSK3 OFFSET(23) NUMBITS(1) [],
+    /// AM/PM notation
+    PM OFFSET(22) NUMBITS(1) [],
+    /// Hour tens in BCD format
+    HT OFFSET(20) NUMBITS(2) [],
+    /// Hour units in BCD format
+    HU OFFSET(16) NUMBITS(4) [],
+    /// Alarm A minutes mask
+    MSK2 OFFSET(15) NUMBITS(1) [],
+    /// Minute tens in BCD format
+    MNT OFFSET(12) NUMBITS(3) [],
+    ///Minute units in BCD format
+    MNU OFFSET(8) NUMBITS(4) [],
+    /// Alarm A seconds mask
+    MSK1 OFFSET(7) NUMBITS(1) [],
+    /// Second tens in BCD format
+    ST OFFSET(4) NUMBITS(3) [],
+    /// Second units in BCD format
+    SU OFFSET(0) NUMBITS(4) [],
+],
+RTC_ALRMASSR[
+    /// Clear synchronous counter on alarm
+    SSCLR OFFSET(31) NUMBITS(1) [],
+    /// Mask the MSBs starting at this bit
+    MASKSS OFFSET(24) NUMBITS(5)[],
+    /// Subseconds value
+    SS OFFSET(0) NUMBITS(15)[],
+],
+RTC_ALRMBR[
+    /// Alarm B date mask
+    MSK4 OFFSET(31) NUMBITS(1) [],
+    /// Week day selection
+    WDSEL OFFSET(30) NUMBITS(1)[],
+    /// Data tens in BCD format
+    DT OFFSET(28) NUMBITS(2) [],
+    /// Date units or day in BCD format
+    DU OFFSET(24) NUMBITS(4) [],
+    /// Alarm B hours mask
+    MSK3 OFFSET(23) NUMBITS(1) [],
+    /// AM/PM notation
+    PM OFFSET(22) NUMBITS(1) [],
+    /// Hour tens in BCD format
+    HT OFFSET(20) NUMBITS(2) [],
+    /// Hour units in BCD foramt
+    HU OFFSET(16) NUMBITS(4) [],
+    /// Alarm B minutes mask
+    MSK2 OFFSET(15) NUMBITS(1) [],
+    /// Minute tens in BCD fomrmat
+    MNT OFFSET(12) NUMBITS(3) [],
+    /// Minute units in BCD format
+    MNU OFFSET(8) NUMBITS(4)  [],
+    /// Alarm B seconds mask
+    MSK1 OFFSET(7) NUMBITS(1) [],
+    /// Second tens in BCD format
+    ST OFFSET(4) NUMBITS(3) [],
+    /// Second units in BCD format
+    SU OFFSET(0) NUMBITS(4) [],
+],
+RTC_ALRMBSSR[
+    /// Clear synchronous counter on alarm
+    SSCLR OFFSET(31) NUMBITS(1) [],
+    /// Mask the MSBs starting at this bit
+    MASKSS OFFSET(24) NUMBITS(5) [],
+    /// Subseconds value
+    SS OFFSET(0) NUMBITS(15) [],
+],
+RTC_SR [
+    /// SSR underflow flag
+    SSRUF OFFSET(6) NUMBITS(1) [],
+    /// Internal timestamp flag
+    ITSF OFFSET(5) NUMBITS(1) [],
+    /// Timestamp overflow flag
+    TSOVF OFFSET(4) NUMBITS(1) [],
+    /// Timestamp flag
+    TSF OFFSET(3) NUMBITS(1) [],
+    ///Wake-up timer flag
+    WUTF OFFSET(2) NUMBITS(1) [],
+    /// Alarm B flag
+    ALRBF OFFSET(1) NUMBITS(1) [],
+    /// Alarm A flag
+    ALRAF OFFSET(0) NUMBITS(1) [],
+],
+RTC_MISR [
+    /// SSR underflow nonsecure masked flag
+    SSRUMF OFFSET(6) NUMBITS(1) [],
+    /// Internal timestamp nonsecure masked flag
+    ITSMF OFFSET(5) NUMBITS(1) [],
+    /// Timestamp overflow nonsecure masked flag
+    TSOVMF OFFSET(4) NUMBITS(1) [],
+    /// Timestamp nonsecure masked flag
+    TSMF OFFSET(3) NUMBITS(1) [],
+    /// Wake-up timer nonsecure masked flag
+    WUTMF OFFSET(2) NUMBITS(1) [],
+    /// Alarm B nonsecure masked flag
+    ALRBMF OFFSET(1) NUMBITS(1) [],
+    /// Alarm A masked flag
+    ALRAMF OFFSET(0) NUMBITS(1) [],
+],
+RTC_SMISR [
+    /// SSR underflow secure masked flag
+    SSRUMF OFFSET(6) NUMBITS(1) [],
+    /// Internal timestamp interrupt secure masked flag
+    ITSMF OFFSET(5) NUMBITS(1) [],
+    /// Timestamp overflow interrupt secure masked flag
+    TSOVMF OFFSET(4) NUMBITS(1) [],
+    /// Timestamp interrupt secure masked flag
+    TSMF OFFSET(3) NUMBITS(1) [],
+    /// Wake-up timer interrupt secure masked flag
+    WUTMF OFFSET(2) NUMBITS(1) [],
+    /// Alarm B interrupt secure masked flag
+    ALRBMF OFFSET(1) NUMBITS(1) [],
+    /// Alarm A interrupt secure masked flag
+    ALRAMF OFFSET(0) NUMBITS(1) [],
+],
+RTC_SCR [
+    /// Clear SSR underflow flag
+    CSSRUF OFFSET(6) NUMBITS(1) [],
+    /// Clear internal timestamp flag
+    CITSF OFFSET(5) NUMBITS(1) [],
+    /// Clear timestamp overflow flag
+    CTSOVF OFFSET(4) NUMBITS(1) [],
+    /// Clear timestamp overflow flag
+    CTSF OFFSET(3)  NUMBITS(1) [],
+    /// Clear wake-up timer flag
+    CWUTF OFFSET(2) NUMBITS(1) [],
+    /// Clear alarm B flag
+    CALRBF OFFSET(1) NUMBITS(1) [],
+    /// Clear alarm A flag
+    CALRAF OFFSET(0) NUMBITS(1) [],
+],
+RTC_ALRABINR[
+    /// Synchronous counter alarm value
+    SS OFFSET(0) NUMBITS(32) [],
+],
+RTC_ALRBBINR[
+    /// Synchronous counter alarm value
+    SS OFFSET(0) NUMBITS(32) [],
+],
+];
+
+register_structs! {
+pub PwrRegisters {
+    (0x00 => _padding),
+    /// PWR disable backup domain register
+    (0x28 => pwr_dbpr: ReadWrite<u32, PWR_DBPR::Register>),
+    (0x2C => @END),
+}
+}
+register_bitfields![u32,
+    PWR_DBPR [
+        /// Disable backup domain write protection
+        DBP OFFSET(0) NUMBITS(1) []
+    ],
+];
+
+// Real Time Clock
+// RM0456, Table 6. Memoy map and peripheral register boundary addresses - Page 145
+const RTC_BASE: StaticRef<RtcRegisters> =
+    unsafe { StaticRef::new(0x46007800 as *const RtcRegisters) };
+// Power Control
+// RM0456, Table 6. Memoy map and peripheral register boundary addresses - Page 145
+const PWR_BASE: StaticRef<PwrRegisters> =
+    unsafe { StaticRef::new(0x46020800 as *const PwrRegisters) };
+
+#[derive(Clone, Copy)]
+enum DeferredCallTask {
+    Get,
+    Set,
+}
+
+pub struct Rtc<'a> {
+    registers: StaticRef<RtcRegisters>,
+    client: OptionalCell<&'a dyn date_time::DateTimeClient>,
+    time: Cell<DateTimeValues>,
+
+    deferred_call: DeferredCall,
+    deferred_call_task: OptionalCell<DeferredCallTask>,
+}
+
+impl DeferredCallClient for Rtc<'_> {
+    fn handle_deferred_call(&self) {
+        self.deferred_call_task.take().map(|value| match value {
+            DeferredCallTask::Get => self
+                .client
+                .map(|client| client.get_date_time_done(Ok(self.time.get()))),
+            DeferredCallTask::Set => self.client.map(|client| client.set_date_time_done(Ok(()))),
+        });
+    }
+    fn register(&'static self) {
+        self.deferred_call.register(self);
+    }
+}
+
+fn init_rtc_clock() -> Result<(), ErrorCode> {
+    // Initialize the RTC clock source and enables peripheral access.
+    // Why this specific sequence:
+    // 1. Enable the PWR clock: The Power controller manages access to the backup domain
+    // 2. We need to disable the Backup Domain's Write Protection since the write
+    //    protection resets to default state every time we boot up the board. We
+    //    want no write protection on the Backup Domain so we can access the RTC config
+    //    registers and time registers.
+    // 3. Enable the APB3 bus clock so our code can send commands to the RTC registers
+    // 4. Turn on the LSI Oscillator, which is a slow internal clock we use for low power consumption.
+    //    In ultra low power mode the HSE/HSI are disabled. We use LSI to keep track of time regardless
+    //    if the board is in stand-by, lower power mode or not.
+    // 5. After the LSI Oscillator stabilizes we select it as the RTC clock source. There can be
+    //    a situation where the oscillator doesn't stabilize, in that case my approach is to not hang the kernel
+    //    and just timeout.
+    let rcc = rcc::Rcc::new(rcc::RCC_BASE);
+    let pwr = PWR_BASE;
+    rcc.enable_ahb3_pwrclk();
+    pwr.pwr_dbpr.modify(PWR_DBPR::DBP::SET);
+    rcc.enable_apb3_bus_clk();
+
+    // Enable LSI oscillator.
+    rcc.enable_lsi();
+    // Magic number large enough to prevent kernel hanging if the oscillator fails to stabilize
+    let mut cycle_counter = 100000;
+    while !rcc.is_lsi_ready() && cycle_counter > 0 {
+        cycle_counter -= 1;
+    }
+    if cycle_counter <= 0 {
+        return Err(ErrorCode::FAIL);
+    }
+    rcc.select_rtc_source_lsi();
+    rcc.enable_rtc();
+    Ok(())
+}
+
+impl<'a> Rtc<'a> {
+    pub fn new() -> Rtc<'a> {
+        Rtc {
+            registers: RTC_BASE,
+            client: OptionalCell::empty(),
+            time: Cell::new(DateTimeValues {
+                year: 0,
+                month: Month::January,
+                day: 1,
+                day_of_week: DayOfWeek::Sunday,
+                hour: 0,
+                minute: 0,
+                seconds: 0,
+            }),
+            deferred_call: DeferredCall::new(),
+            deferred_call_task: OptionalCell::empty(),
+        }
+    }
+    pub fn initialize_clock(&self) -> Result<(), ErrorCode> {
+        init_rtc_clock()
+    }
+    #[inline(never)]
+    // This function is marked as #[inline(never)] in order to aid with the debugging process when
+    // disabling board memory protection
+    /// Bypass write protection.
+    fn bypass_write_protection(&self) {
+        // Unlock write acces to RTC_WPR to be able to access RTC calibration and initialization registers
+        // Writing an incorrect key reactivated the write protection
+        // RM0456 - Section 63.3.11, Page 2596
+        self.registers.rtc_wpr.write(RTC_WPR::KEY.val(0xCA));
+        self.registers.rtc_wpr.write(RTC_WPR::KEY.val(0x53));
+    }
+    #[inline(never)]
+    // This function is marked as #[inline(never)] in order to aid with the debugging process when
+    // enabling board memory protection
+    /// Reactivate write protection.
+    fn enable_write_protection(&self) {
+        // Just write a random value to activate write protection.
+        self.registers.rtc_wpr.write(RTC_WPR::KEY.val(0x42));
+    }
+
+    pub fn enter_init_mode(&self) -> Result<(), ErrorCode> {
+        // We need to bypass the hardware write protection before we can modify
+        // any of the RTC control registers.
+        // We then request the RTC to enter initialization mode.
+        self.bypass_write_protection();
+        self.registers.rtc_icsr.modify(RTC_ICSR::INIT::SET);
+        let mut cycle_counter = 100000;
+        while self.registers.rtc_icsr.read(RTC_ICSR::INITF) != 1 && cycle_counter > 0 {
+            cycle_counter -= 1;
+        }
+        if cycle_counter <= 0 {
+            return Err(ErrorCode::FAIL);
+        }
+
+        Ok(())
+    }
+    pub fn init_mode(&self) -> Result<(), ErrorCode> {
+        self.enter_init_mode()?;
+        // Run clock at 1 Hz
+        // The formula is f_RTC = f_CLK / ((PREDIV_A + 1) * (PREDIV_S + 1))
+        // 32.768 kHz / (128 * 256) = 1 Hz.
+        // It is recommended to max out PREDIV_A which is an asynchronous prescaler.
+        // Doing this reduces the power consumption since we minimize the frequency of the clock
+        // that goes into the synchronous part of the RTC.
+        self.registers.rtc_prer.modify(RTC_PRER::PREDIV_A.val(127));
+        self.registers.rtc_prer.modify(RTC_PRER::PREDIV_S.val(255));
+
+        // Enter BCD mode.
+        self.registers.rtc_icsr.modify(RTC_ICSR::BIN::CLEAR);
+
+        // Set time format to 24h. We first clear the AM/PM notation bit.
+        self.registers.rtc_tr.write(RTC_TR::PM::CLEAR);
+        self.registers.rtc_cr.modify(RTC_CR::FMT::CLEAR);
+
+        let datetime = date_time::DateTimeValues {
+            year: 0,
+            month: Month::January,
+            day: 1,
+            day_of_week: DayOfWeek::Monday,
+
+            hour: 0,
+            minute: 0,
+            seconds: 0,
+        };
+        self.date_time_setup(datetime)?;
+
+        self.exit_init_mode()?;
+        Ok(())
+    }
+    pub fn exit_init_mode(&self) -> Result<(), ErrorCode> {
+        // To exit initialization mode we first need to request exiting it
+        // and then re-enable write protection so we don't accidentaly change anything.
+        self.registers.rtc_icsr.modify(RTC_ICSR::INIT::CLEAR);
+        let mut cycle_counter = 100000;
+        while self.registers.rtc_icsr.read(RTC_ICSR::INITF) != 0 && cycle_counter > 0 {
+            cycle_counter -= 1;
+        }
+        if cycle_counter <= 0 {
+            return Err(ErrorCode::FAIL);
+        }
+
+        self.enable_write_protection();
+        Ok(())
+    }
+
+    fn date_time_setup(&self, datetime: date_time::DateTimeValues) -> Result<(), ErrorCode> {
+        // The hardware RTC registers store time and date values in BCD format, not integers.
+        // Since the digits are represented in BCD format we divide by 10 to get the tens digit and
+        // use modulo the get the units digits for the respective bitfield.
+        let month_num = Rtc::month_into_u32(datetime.month);
+        let dotw_num = Rtc::dotw_into_u32(datetime.day_of_week);
+
+        if !(datetime.day >= 1 && datetime.day <= 31) {
+            return Err(ErrorCode::INVAL);
+        }
+        if !(datetime.hour <= 23) {
+            return Err(ErrorCode::INVAL);
+        }
+        if !(datetime.minute <= 59) {
+            return Err(ErrorCode::INVAL);
+        }
+        if !(datetime.seconds <= 59) {
+            return Err(ErrorCode::INVAL);
+        }
+        self.registers.rtc_dr.modify(
+            RTC_DR::YT.val((datetime.year % 100) as u32 / 10)
+                + RTC_DR::YU.val((datetime.year % 100) as u32 % 10)
+                + RTC_DR::MT.val(month_num / 10)
+                + RTC_DR::MU.val(month_num % 10)
+                + RTC_DR::DT.val(datetime.day as u32 / 10)
+                + RTC_DR::DU.val(datetime.day as u32 % 10)
+                + RTC_DR::WDU.val(dotw_num),
+        );
+
+        self.registers.rtc_tr.modify(
+            RTC_TR::HT.val(datetime.hour as u32 / 10)
+                + RTC_TR::HU.val(datetime.hour as u32 % 10)
+                + RTC_TR::MNT.val(datetime.minute as u32 / 10)
+                + RTC_TR::MNU.val(datetime.minute as u32 % 10)
+                + RTC_TR::ST.val(datetime.seconds as u32 / 10)
+                + RTC_TR::SU.val(datetime.seconds as u32 % 10),
+        );
+
+        Ok(())
+    }
+
+    fn dotw_try_from_u32(dotw: u32) -> Result<DayOfWeek, ErrorCode> {
+        match dotw {
+            1 => Ok(DayOfWeek::Monday),
+            2 => Ok(DayOfWeek::Tuesday),
+            3 => Ok(DayOfWeek::Wednesday),
+            4 => Ok(DayOfWeek::Thursday),
+            5 => Ok(DayOfWeek::Friday),
+            6 => Ok(DayOfWeek::Saturday),
+            7 => Ok(DayOfWeek::Sunday),
+            _ => Err(ErrorCode::INVAL),
+        }
+    }
+
+    fn dotw_into_u32(dotw: DayOfWeek) -> u32 {
+        match dotw {
+            DayOfWeek::Monday => 1,
+            DayOfWeek::Tuesday => 2,
+            DayOfWeek::Wednesday => 3,
+            DayOfWeek::Thursday => 4,
+            DayOfWeek::Friday => 5,
+            DayOfWeek::Saturday => 6,
+            DayOfWeek::Sunday => 7,
+        }
+    }
+
+    fn month_try_from_u32(month_num: u32) -> Result<Month, ErrorCode> {
+        match month_num {
+            1 => Ok(Month::January),
+            2 => Ok(Month::February),
+            3 => Ok(Month::March),
+            4 => Ok(Month::April),
+            5 => Ok(Month::May),
+            6 => Ok(Month::June),
+            7 => Ok(Month::July),
+            8 => Ok(Month::August),
+            9 => Ok(Month::September),
+            10 => Ok(Month::October),
+            11 => Ok(Month::November),
+            12 => Ok(Month::December),
+            _ => Err(ErrorCode::INVAL),
+        }
+    }
+
+    fn month_into_u32(month: Month) -> u32 {
+        match month {
+            Month::January => 1,
+            Month::February => 2,
+            Month::March => 3,
+            Month::April => 4,
+            Month::May => 5,
+            Month::June => 6,
+            Month::July => 7,
+            Month::August => 8,
+            Month::September => 9,
+            Month::October => 10,
+            Month::November => 11,
+            Month::December => 12,
+        }
+    }
+}
+
+impl<'a> date_time::DateTime<'a> for Rtc<'a> {
+    fn get_date_time(&self) -> Result<(), ErrorCode> {
+        // Start an async read of current date and time:
+        // 1. Verify if the driver isn't busy.
+        // 2. Read the calendar registers (TR and DR) and converts their BCD values into integers.
+        // 3. The time and date are then stored in the time cell and it is later retrieved via the deferred call
+        //    handler and passed to the client.
+        // 4. Set a deferred call task and schedules it to notify client.
+        match self.deferred_call_task.take() {
+            Some(DeferredCallTask::Set) => {
+                self.deferred_call_task.insert(Some(DeferredCallTask::Set));
+                return Err(ErrorCode::BUSY);
+            }
+            Some(DeferredCallTask::Get) => {
+                self.deferred_call_task.insert(Some(DeferredCallTask::Get));
+                return Err(ErrorCode::ALREADY);
+            }
+            _ => (),
+        }
+
+        let month_num =
+            self.registers.rtc_dr.read(RTC_DR::MT) * 10 + self.registers.rtc_dr.read(RTC_DR::MU);
+        let month_name = Rtc::month_try_from_u32(month_num)?;
+
+        let dotw_num = self.registers.rtc_dr.read(RTC_DR::WDU);
+        let dotw_name = Rtc::dotw_try_from_u32(dotw_num)?;
+
+        let datetime = date_time::DateTimeValues {
+            hour: (self.registers.rtc_tr.read(RTC_TR::HT) * 10
+                + self.registers.rtc_tr.read(RTC_TR::HU)) as u8,
+            minute: (self.registers.rtc_tr.read(RTC_TR::MNT) * 10
+                + self.registers.rtc_tr.read(RTC_TR::MNU)) as u8,
+            seconds: (self.registers.rtc_tr.read(RTC_TR::ST) * 10
+                + self.registers.rtc_tr.read(RTC_TR::SU)) as u8,
+
+            year: (self.registers.rtc_dr.read(RTC_DR::YT) * 10
+                + self.registers.rtc_dr.read(RTC_DR::YU)) as u16,
+            month: month_name,
+            day: (self.registers.rtc_dr.read(RTC_DR::DT) * 10
+                + self.registers.rtc_dr.read(RTC_DR::DU)) as u8,
+            day_of_week: dotw_name,
+        };
+
+        self.time.replace(datetime);
+
+        self.deferred_call_task.insert(Some(DeferredCallTask::Get));
+        self.deferred_call.set();
+
+        Ok(())
+    }
+
+    fn set_date_time(&self, date_time: date_time::DateTimeValues) -> Result<(), ErrorCode> {
+        // Start an async write to update RTC date and time registers:
+        // 1. Verify if the driver isn't busy.
+        // 2. Unlock the wp and enters init mode (which is necessary for writing to RTC date/time registers).
+        // 3. Convert the provided date and time values to BCD format and writes them to the registers (TR and DR).
+        // 4. Exit initialization mode, resume clk and reactivate wp.
+        // 5. Set a deferred call task and schedule it to notify client.
+        match self.deferred_call_task.take() {
+            Some(DeferredCallTask::Set) => {
+                self.deferred_call_task.insert(Some(DeferredCallTask::Set));
+                return Err(ErrorCode::ALREADY);
+            }
+            Some(DeferredCallTask::Get) => {
+                self.deferred_call_task.insert(Some(DeferredCallTask::Get));
+                return Err(ErrorCode::BUSY);
+            }
+            _ => (),
+        }
+
+        self.enter_init_mode()?;
+        self.date_time_setup(date_time)?;
+        self.exit_init_mode()?;
+
+        self.deferred_call_task.insert(Some(DeferredCallTask::Set));
+        self.deferred_call.set();
+        Ok(())
+    }
+
+    fn set_client(&self, client: &'a dyn DateTimeClient) {
+        self.client.set(client);
+    }
+}

--- a/chips/stm32u5xx/src/rtc.rs
+++ b/chips/stm32u5xx/src/rtc.rs
@@ -1,0 +1,813 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright OxidOS Automotive 2026.
+
+// RTC Driver for the STM32U545RE-Q
+// Referance Document:
+// RM0456 Reference Manual: https://www.st.com/resource/en/reference_manual/rm0456-stm32u5-series-armbased-32bit-mcus-stmicroelectronics.pdf
+
+use core::cell::Cell;
+use kernel::ErrorCode;
+use kernel::deferred_call::{DeferredCall, DeferredCallClient};
+use kernel::hil::date_time;
+use kernel::hil::date_time::{DateTimeClient, DateTimeValues, DayOfWeek, Month};
+use kernel::utilities::StaticRef;
+use kernel::utilities::cells::OptionalCell;
+use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
+use kernel::utilities::registers::{ReadOnly, WriteOnly, interfaces::Writeable, register_structs};
+use kernel::utilities::registers::{ReadWrite, register_bitfields};
+
+register_structs! {
+pub  RtcRegisters{
+
+    /// The RTC_TR is the calendar time shadow register. This register must be written in initialization mode only.
+    (0x00 => rtc_tr: ReadWrite<u32, RTC_TR::Register>),
+
+    /// The RTC_DR is the calendar date shadow register. This register must be written in initialization mode only.
+    (0x04 => rtc_dr: ReadWrite<u32, RTC_DR::Register>),
+
+    /// RTC subsecond register
+    (0x08 => rtc_ssr: ReadOnly<u32, RTC_SSR::Register>),
+
+    /// RTC initialization control and status regiter.
+    (0x0C => rtc_icsr: ReadWrite<u32, RTC_ICSR::Register>),
+
+    /// RTC prescaler register
+    (0x10 => rtc_prer: ReadWrite<u32,RTC_PRER::Register>),
+
+    /// RTC wake-up timer register
+    (0x14 => rtc_wutr: ReadWrite<u32,RTC_WUTR::Register>),
+
+    /// RTC control register
+    (0x18 => rtc_cr: ReadWrite<u32,RTC_CR::Register>),
+
+    /// RTC privilege mode control register. This register can be written only when the APB access is privileged.
+    (0x1C => rtc_privcfgr: ReadWrite<u32,RTC_PRIVCFGR::Register>),
+
+    /// RTC secure configuration register. This register can be written only when the APB access is secure.
+    (0x20 => rtc_seccfgr: ReadWrite<u32, RTC_SECCFGR::Register>),
+
+    /// RTC write protection register
+    (0x24 => rtc_wpr: WriteOnly<u32,RTC_WPR::Register>),
+
+    /// RTC calibration register
+    (0x28 => rtc_calr: ReadWrite<u32, RTC_CALR::Register>),
+
+    /// RTC shift control register
+    (0x2C => rtc_shiftr: WriteOnly<u32,RTC_SHIFTR::Register>),
+
+    /// RTC timestamp time register
+    (0x30 => rtc_tstr: ReadOnly<u32, RTC_TSTR::Register>),
+
+    /// RTC timestamp data register
+    (0x34 => rtc_tsdr: ReadOnly<u32,RTC_TSDR::Register>),
+
+    /// RTC timestamp subsecond register
+    (0x38 => rtc_tsssr: ReadOnly<u32,RTC_TSSSR::Register>),
+
+    (0x3C => _padding),
+
+    /// RTC alarm A register.This register can be written only when ALRAE is reset in RTC_CR register.
+    (0x40 => rtc_alrmar: ReadWrite<u32,RTC_ALRMAR::Register>),
+
+    /// RTC alarm A subsecond register.
+    (0x44 => rtc_alrmassr: ReadWrite<u32,RTC_ALRMASSR::Register>),
+
+    /// RTC alarm B register
+    (0x48 => rtc_alrmbr: ReadWrite<u32,RTC_ALRMBR::Register>),
+
+    /// RTC alarm B subsecond register
+    (0x4C => rtc_alrmbssr: ReadWrite<u32,RTC_ALRMBSSR::Register>),
+
+    /// RTC status register
+    (0x50 => rtc_sr: ReadOnly<u32, RTC_SR::Register>),
+
+    /// RTC nonsecure masked interrupt status register
+    (0x54 => rtc_misr: ReadOnly<u32,RTC_MISR::Register>),
+
+    /// RTC secure masked interrupt status register
+    (0x58 => rtc_smisr: ReadOnly<u32,RTC_SMISR::Register>),
+
+    /// RTC status clear register
+    (0x5C => rtc_scr: WriteOnly<u32,RTC_SCR::Register>),
+
+    (0x60 => _padding1),
+    (0x64 => _padding2),
+    (0x68 => _padding3),
+    (0x6C => _padding4),
+
+    /// RTC alarm A binary mode register.This register can be written only when ALRAE is reset in RTC_CR register.
+    (0x70 => rtc_alrabinr: ReadWrite<u32,RTC_ALRABINR::Register>),
+
+    /// RTC alarm B binary mode register.This register can be written only when ALRBE is reset in RTC_CR register.
+    (0x74 => rtc_alrbbinr: ReadWrite<u32,RTC_ALRBBINR::Register>),
+
+    (0x78 => @END),
+}
+}
+register_bitfields![u32,
+RTC_TR[
+    /// AM/PM notation. 0: AM or 24-hour format, 1: PM
+    PM OFFSET(22) NUMBITS(1) [],
+    /// Hour tens in BCD format
+    HT OFFSET(20) NUMBITS(2) [],
+    /// Hour units in BCD format
+    HU OFFSET(16) NUMBITS(4) [],
+    /// Minute tens in BCD format
+    MNT OFFSET(12) NUMBITS(3) [],
+    /// Minute units in BCD format
+    MNU OFFSET(8) NUMBITS(4) [],
+    /// Second tens in BCD format
+    ST OFFSET(4) NUMBITS(3) [],
+    /// Second units in BCD format
+    SU OFFSET(0) NUMBITS(4) [],
+],
+RTC_DR[
+    /// Year tens in BCD format
+    YT OFFSET(20) NUMBITS(4) [],
+    /// Year units in BCD format
+    YU OFFSET(16) NUMBITS(4) [],
+    /// Week day units
+    WDU OFFSET(13) NUMBITS(3) [],
+    /// Month tens in BCD format
+    MT OFFSET(12) NUMBITS(1) [],
+    /// Month units in BCD format
+    MU OFFSET(8) NUMBITS(4) [],
+    /// Date tens in BCD format
+    DT OFFSET(4) NUMBITS(1) [],
+    /// Date units in BCD format
+    DU OFFSET(0) NUMBITS(4) [],
+],
+
+RTC_SSR[
+    /// Sub second value / synchronous binary counter LSB values
+    SS OFFSET(0) NUMBITS(16) [],
+],
+
+RTC_ICSR[
+    /// Wake-up timer write flag
+    WUTWF OFFSET(2) NUMBITS(1) [],
+    /// Shift operation pending
+    SHPF OFFSET(3) NUMBITS(1) [],
+    /// Initalization status flag
+    INITS OFFSET(4) NUMBITS(1) [],
+    /// Registers synchronization flag
+    RSF OFFSET(5) NUMBITS(1) [],
+    /// Initialization flag
+    INITF OFFSET(6) NUMBITS(1) [],
+    /// Initialization mode
+    INIT OFFSET(7) NUMBITS(1) [],
+    /// Binary mode
+    BIN OFFSET(8) NUMBITS(2) [],
+    /// BCD update
+    BCDU OFFSET(10) NUMBITS(3) [],
+    /// Recalibration pending flag
+    RECALPF OFFSET(16) NUMBITS(1) [],
+],
+
+RTC_PRER[
+    /// Synchronous prescaler factor
+    PREDIV_S OFFSET(0) NUMBITS(15) [],
+    /// Asynchronous prescaler factor
+    PREDIV_A OFFSET(16) NUMBITS(7) [],
+],
+RTC_WUTR[
+    /// Wake-up auto-reload output clear value
+    WUTOCLR OFFSET(16) NUMBITS(16) [],
+    /// Wake-up auto-reload value bits
+    WUT OFFSET(0) NUMBITS(16) [],
+],
+RTC_CR[
+    /// RTC_OUT2 output enalbe
+    OUT2EN OFFSET(31) NUMBITS(1) [],
+    /// TAMPALRM output type
+    TAMPALRM_TYPE OFFSET(30) NUMBITS(1) [],
+    /// TAMPALRM pull-up enable
+    TAMPALRM_PU OFFSET(29) NUMBITS(1) [],
+    /// Alarm B flag automatic clear
+    ALRBFCLR OFFSET(28) NUMBITS(1) [],
+    /// Alarm A flag automatic clear
+    ALRAFCLR OFFSET(27) NUMBITS(1) [],
+    ///Tamper detection output enable on TAMPALRM
+    TAMPOE OFFSET(26) NUMBITS(1) [],
+    /// Activate timestamp on tamper detection event
+    TAMPTS OFFSET(25) NUMBITS(1) [],
+    /// Timestamp on internal event enable
+    ITSE OFFSET(24) NUMBITS(1) [],
+    /// Calibration output enable
+    COE OFFSET(23) NUMBITS(1) [],
+    /// Output selection
+    OSEL OFFSET(21) NUMBITS(2) [],
+    /// Output polarity
+    POL OFFSET(20) NUMBITS(1) [],
+    /// Calibration output selection
+    COSEL OFFSET(19) NUMBITS(1) [],
+    /// Backup
+    BKP OFFSET(18) NUMBITS(1) [],
+    /// Subtract 1 hour (winter time change)
+    SUB1H OFFSET(17) NUMBITS(1) [],
+    /// Add 1 hour (sumer time change)
+    AD1H OFFSET(16)  NUMBITS(1) [],
+    /// Timestampt interrupt enable
+    TSIE OFFSET(15) NUMBITS(1) [],
+    /// Wake-up timer interrupt enable
+    WUTIE OFFSET(14) NUMBITS(1) [],
+    /// Alarm B interrupt enable
+    ALRBIE OFFSET(13) NUMBITS(1) [],
+    /// Alarm A interrupt enable
+    ALRAIE OFFSET(12) NUMBITS(1) [],
+    /// Timestamp enable
+    TSE OFFSET(11) NUMBITS(1) [],
+    /// Wake-up timer enable
+    WUTE OFFSET(10) NUMBITS(1) [],
+    /// Alarm B enable
+    ALRBE OFFSET(9) NUMBITS(1) [],
+    /// Alarm A enable
+    ALRAE OFFSET(8) NUMBITS(1) [],
+    /// SSR underflow interrupt enable
+    SSRUIE OFFSET(7) NUMBITS(1) [],
+    /// Hour Format ( 0 -> 24h , 1 -> AM/PM)
+    FMT OFFSET(6) NUMBITS(1) [],
+    /// Bypas the shadow registers
+    BYPSHAD OFFSET(5) NUMBITS(1) [],
+    /// RTC_REFIN reference clock detection enable (50 or 60 Hz)
+    REFCKON OFFSET(4) NUMBITS(1) [],
+    /// Timestamp event active edge
+    TSEDGE OFFSET(3) NUMBITS(1) [],
+    /// ck_wut wake-up clock selection
+    WUCKSEL OFFSET(0) NUMBITS(2) [],
+
+],
+RTC_PRIVCFGR[
+    /// RTC privilege protecction
+    PRIV OFFSET(15) NUMBITS(1) [],
+    /// Initialization privilege protection
+    INITPRIV OFFSET(14) NUMBITS(1) [],
+    /// Shift register, daylight saving, calibration and reference clock privilege protection
+    CALPRIV OFFSET(13) NUMBITS(1) [],
+    /// Timestamp privilege protection
+    TSPRIV OFFSET(3) NUMBITS(1) [],
+    /// Wake-up timer privilege protection
+    WUTPRIV OFFSET(2) NUMBITS(1) [],
+    /// Alarm B privilege protection
+    ALRBPRIV OFFSET(1) NUMBITS(1) [],
+    /// Alarm A and SSR underflow privilege protection
+    ALRAPRIV OFFSET(0) NUMBITS(1) [],
+],
+RTC_SECCFGR[
+    /// RTC global protection
+    SEC OFFSET(15) NUMBITS(1) [],
+    /// Initialization protection
+    INITSEC OFFSET(14) NUMBITS(1) [],
+    /// Shift register, daylight saving, calibration and reference clock protection
+    CALSEC OFFSET(13) NUMBITS(1) [],
+    /// Timestamp protection
+    TSSEC OFFSET(3) NUMBITS(1) [],
+    /// Wake-up timer protection
+    WUTSEC OFFSET(2) NUMBITS(1) [],
+    /// Alarm B protection
+    ALRBSEC OFFSET(1) NUMBITS(1) [],
+    /// Alarm A and SSR underflow protection
+    ALRASEC OFFSET(0) NUMBITS(1) [],
+],
+RTC_WPR[
+    /// Write protection key
+    KEY OFFSET(0) NUMBITS(8) [],
+],
+RTC_CALR[
+    /// Increase frequenccey of RTC by 488.5 ppm
+    CALP OFFSET(15)  NUMBITS(1) [],
+    /// use an 8-second calibration cycle period
+    CALW8 OFFSET(14) NUMBITS(1) [],
+    /// Use a 16-second calibration cycle period
+    CALW16 OFFSET(13) NUMBITS(1) [],
+    /// RTC low-power mode
+    LPCAL OFFSET(12) NUMBITS(1) [],
+    /// Calibration minus
+    CALM OFFSET(0) NUMBITS(9) [],
+],
+RTC_SHIFTR[
+    /// Add one second
+    ADD1S OFFSET(31) NUMBITS(1) [],
+    /// Subtract a fraction of a second  = SUBFS / (PREDIV_S + 1)
+    SUBFS OFFSET(0) NUMBITS(15)[],
+],
+RTC_TSTR[
+    /// AM/PM notation (0 is 24h)
+    PM OFFSET(22) NUMBITS(1) [],
+    /// Hour tens in BCD format
+    HT OFFSET(20) NUMBITS(2)[],
+    /// Hour units in BCD format
+    HU OFFSET(16) NUMBITS(4)[],
+    /// Minute tens in BCD format
+    MNT OFFSET(12) NUMBITS(3)[],
+    /// Minute units in BCD format
+    MNU OFFSET(8) NUMBITS(4)[],
+    /// Second tens in BCD format
+    ST OFFSET(4) NUMBITS(3) [],
+    /// Second units in BCD format
+    SU OFFSET(0) NUMBITS(4) [],
+],
+
+RTC_TSDR[
+    /// Week day units
+    WDU OFFSET(13) NUMBITS(3) [],
+    /// Month tens in BCD format
+    MT OFFSET(12) NUMBITS(1) [],
+    /// Month units in BCD format
+    MU OFFSET(8) NUMBITS(4) [],
+    /// Day tens in BCD format
+    DT OFFSET(4) NUMBITS(2)[],
+    /// Day units in BCD format
+    DU OFFSET(0) NUMBITS(4)[],
+],
+RTC_TSSSR[
+    /// Subsecond value/synchronous binary counter values
+    SS OFFSET(0) NUMBITS(32) []
+],
+RTC_ALRMAR[
+    /// Alarm A date mask
+    MSK4 OFFSET(31) NUMBITS(1) [],
+    /// Week day selection
+    WDSEL OFFSET(30) NUMBITS(1) [],
+    /// Date tens in BCD format
+    DT OFFSET(28) NUMBITS(2) [],
+    /// Date units or day in BCD format
+    DU OFFSET(24) NUMBITS(4) [],
+    /// Alarm A hours mask
+    MSK3 OFFSET(23) NUMBITS(1) [],
+    /// AM/PM notation
+    PM OFFSET(22) NUMBITS(1) [],
+    /// Hour tens in BCD format
+    HT OFFSET(20) NUMBITS(2) [],
+    /// Hour units in BCD format
+    HU OFFSET(16) NUMBITS(4) [],
+    /// Alarm A minutes mask
+    MSK2 OFFSET(15) NUMBITS(1) [],
+    /// Minute tens in BCD format
+    MNT OFFSET(12) NUMBITS(3) [],
+    ///Minute units in BCD format
+    MNU OFFSET(8) NUMBITS(4) [],
+    /// Alarm A seconds mask
+    MSK1 OFFSET(7) NUMBITS(1) [],
+    /// Second tens in BCD format
+    ST OFFSET(4) NUMBITS(3) [],
+    /// Second units in BCD format
+    SU OFFSET(0) NUMBITS(4) [],
+],
+RTC_ALRMASSR[
+    /// Clear synchronous counter on alarm
+    SSCLR OFFSET(31) NUMBITS(1) [],
+    /// Mask the MSBs starting at this bit
+    MASKSS OFFSET(24) NUMBITS(5)[],
+    /// Subseconds value
+    SS OFFSET(0) NUMBITS(15)[],
+],
+RTC_ALRMBR[
+    /// Alarm B date mask
+    MSK4 OFFSET(31) NUMBITS(1) [],
+    /// Week day selection
+    WDSEL OFFSET(30) NUMBITS(1)[],
+    /// Data tens in BCD format
+    DT OFFSET(28) NUMBITS(2) [],
+    /// Date units or day in BCD format
+    DU OFFSET(24) NUMBITS(4) [],
+    /// Alarm B hours mask
+    MSK3 OFFSET(23) NUMBITS(1) [],
+    /// AM/PM notation
+    PM OFFSET(22) NUMBITS(1) [],
+    /// Hour tens in BCD format
+    HT OFFSET(20) NUMBITS(2) [],
+    /// Hour units in BCD foramt
+    HU OFFSET(16) NUMBITS(4) [],
+    /// Alarm B minutes mask
+    MSK2 OFFSET(15) NUMBITS(1) [],
+    /// Minute tens in BCD fomrmat
+    MNT OFFSET(12) NUMBITS(3) [],
+    /// Minute units in BCD format
+    MNU OFFSET(8) NUMBITS(4)  [],
+    /// Alarm B seconds mask
+    MSK1 OFFSET(7) NUMBITS(1) [],
+    /// Second tens in BCD format
+    ST OFFSET(4) NUMBITS(3) [],
+    /// Second units in BCD format
+    SU OFFSET(0) NUMBITS(4) [],
+],
+RTC_ALRMBSSR[
+    /// Clear synchronous counter on alarm
+    SSCLR OFFSET(31) NUMBITS(1) [],
+    /// Mask the MSBs starting at this bit
+    MASKSS OFFSET(24) NUMBITS(5) [],
+    /// Subseconds value
+    SS OFFSET(0) NUMBITS(15) [],
+],
+RTC_SR [
+    /// SSR underflow flag
+    SSRUF OFFSET(6) NUMBITS(1) [],
+    /// Internal timestamp flag
+    ITSF OFFSET(5) NUMBITS(1) [],
+    /// Timestamp overflow flag
+    TSOVF OFFSET(4) NUMBITS(1) [],
+    /// Timestamp flag
+    TSF OFFSET(3) NUMBITS(1) [],
+    ///Wake-up timer flag
+    WUTF OFFSET(2) NUMBITS(1) [],
+    /// Alarm B flag
+    ALRBF OFFSET(1) NUMBITS(1) [],
+    /// Alarm A flag
+    ALRAF OFFSET(0) NUMBITS(1) [],
+],
+RTC_MISR [
+    /// SSR underflow nonsecure masked flag
+    SSRUMF OFFSET(6) NUMBITS(1) [],
+    /// Internal timestamp nonsecure masked flag
+    ITSMF OFFSET(5) NUMBITS(1) [],
+    /// Timestamp overflow nonsecure masked flag
+    TSOVMF OFFSET(4) NUMBITS(1) [],
+    /// Timestamp nonsecure masked flag
+    TSMF OFFSET(3) NUMBITS(1) [],
+    /// Wake-up timer nonsecure masked flag
+    WUTMF OFFSET(2) NUMBITS(1) [],
+    /// Alarm B nonsecure masked flag
+    ALRBMF OFFSET(1) NUMBITS(1) [],
+    /// Alarm A masked flag
+    ALRAMF OFFSET(0) NUMBITS(1) [],
+],
+RTC_SMISR [
+    /// SSR underflow secure masked flag
+    SSRUMF OFFSET(6) NUMBITS(1) [],
+    /// Internal timestamp interrupt secure masked flag
+    ITSMF OFFSET(5) NUMBITS(1) [],
+    /// Timestamp overflow interrupt secure masked flag
+    TSOVMF OFFSET(4) NUMBITS(1) [],
+    /// Timestamp interrupt secure masked flag
+    TSMF OFFSET(3) NUMBITS(1) [],
+    /// Wake-up timer interrupt secure masked flag
+    WUTMF OFFSET(2) NUMBITS(1) [],
+    /// Alarm B interrupt secure masked flag
+    ALRBMF OFFSET(1) NUMBITS(1) [],
+    /// Alarm A interrupt secure masked flag
+    ALRAMF OFFSET(0) NUMBITS(1) [],
+],
+RTC_SCR [
+    /// Clear SSR underflow flag
+    CSSRUF OFFSET(6) NUMBITS(1) [],
+    /// Clear internal timestamp flag
+    CITSF OFFSET(5) NUMBITS(1) [],
+    /// Clear timestamp overflow flag
+    CTSOVF OFFSET(4) NUMBITS(1) [],
+    /// Clear timestamp overflow flag
+    CTSF OFFSET(3)  NUMBITS(1) [],
+    /// Clear wake-up timer flag
+    CWUTF OFFSET(2) NUMBITS(1) [],
+    /// Clear alarm B flag
+    CALRBF OFFSET(1) NUMBITS(1) [],
+    /// Clear alarm A flag
+    CALRAF OFFSET(0) NUMBITS(1) [],
+],
+RTC_ALRABINR[
+    /// Synchronous counter alarm value
+    SS OFFSET(0) NUMBITS(32) [],
+],
+RTC_ALRBBINR[
+    /// Synchronous counter alarm value
+    SS OFFSET(0) NUMBITS(32) [],
+],
+];
+
+// Real Time Clock
+// RM0456, Table 6. Memoy map and peripheral register boundary addresses - Page 145
+pub const RTC_BASE: StaticRef<RtcRegisters> =
+    unsafe { StaticRef::new(0x46007800 as *const RtcRegisters) };
+
+#[derive(Clone, Copy)]
+enum DeferredCallTask {
+    Get,
+    Set,
+}
+
+pub struct Rtc<'a> {
+    registers: StaticRef<RtcRegisters>,
+    client: OptionalCell<&'a dyn date_time::DateTimeClient>,
+    time: Cell<DateTimeValues>,
+
+    deferred_call: DeferredCall,
+    deferred_call_task: OptionalCell<DeferredCallTask>,
+}
+
+impl DeferredCallClient for Rtc<'_> {
+    fn handle_deferred_call(&self) {
+        self.deferred_call_task.take().map(|value| match value {
+            DeferredCallTask::Get => self
+                .client
+                .map(|client| client.get_date_time_done(Ok(self.time.get()))),
+            DeferredCallTask::Set => self.client.map(|client| client.set_date_time_done(Ok(()))),
+        });
+    }
+    fn register(&'static self) {
+        self.deferred_call.register(self);
+    }
+}
+
+impl<'a> Rtc<'a> {
+    pub fn new(base: StaticRef<RtcRegisters>) -> Rtc<'a> {
+        Rtc {
+            registers: base,
+            client: OptionalCell::empty(),
+            time: Cell::new(DateTimeValues {
+                year: 0,
+                month: Month::January,
+                day: 1,
+                day_of_week: DayOfWeek::Sunday,
+                hour: 0,
+                minute: 0,
+                seconds: 0,
+            }),
+            deferred_call: DeferredCall::new(),
+            deferred_call_task: OptionalCell::empty(),
+        }
+    }
+    /// Bypass write protection.
+    fn bypass_write_protection(&self) {
+        // Unlock write acces to RTC_WPR to be able to access RTC calibration and initialization registers
+        // Writing an incorrect key reactivated the write protection
+        // RM0456 - Section 63.3.11, Page 2596
+        self.registers.rtc_wpr.write(RTC_WPR::KEY.val(0xCA));
+        self.registers.rtc_wpr.write(RTC_WPR::KEY.val(0x53));
+    }
+    /// Reactivate write protection.
+    fn enable_write_protection(&self) {
+        // Just write a random value to activate write protection.
+        self.registers.rtc_wpr.write(RTC_WPR::KEY.val(0x42));
+    }
+
+    fn enter_init_mode(&self) -> Result<(), ErrorCode> {
+        // We need to bypass the hardware write protection before we can modify
+        // any of the RTC control registers.
+        // We then request the RTC to enter initialization mode.
+        self.bypass_write_protection();
+        self.registers.rtc_icsr.modify(RTC_ICSR::INIT::SET);
+        let mut cycle_counter = 100000;
+        while self.registers.rtc_icsr.read(RTC_ICSR::INITF) != 1 && cycle_counter > 0 {
+            cycle_counter -= 1;
+        }
+        if cycle_counter <= 0 {
+            // Restore the protection we bypassed above, otherwise the RTC would
+            // be left writable for the rest of the boot.
+            self.enable_write_protection();
+            return Err(ErrorCode::FAIL);
+        }
+
+        Ok(())
+    }
+    pub fn init_mode(&self) -> Result<(), ErrorCode> {
+        // The calendar lives in the backup domain, so it keeps running across a
+        // system reset (and across power loss when VBAT is present).
+        // INITS is set by hardware once the calendar has been programmed and is reset
+        // only with the backup domain, so it tells us whether a previous boot already
+        // configured the RTC. We do this so the the RTC won't reset every boot.
+        if self.registers.rtc_icsr.is_set(RTC_ICSR::INITS) {
+            return Ok(());
+        }
+
+        self.enter_init_mode()?;
+        // Run clock at 1 Hz
+        // The formula is f_RTC = f_CLK / ((PREDIV_A + 1) * (PREDIV_S + 1))
+        // The RTC is clocked by the LSI, which runs at 32 kHz
+        // 32 kHz / (128 * 250) = 1 Hz.
+        // It is recommended to max out PREDIV_A which is an asynchronous prescaler.
+        // Doing this reduces the power consumption since we minimize the frequency of the clock
+        // that goes into the synchronous part of the RTC.
+        self.registers.rtc_prer.modify(RTC_PRER::PREDIV_A.val(127));
+        self.registers.rtc_prer.modify(RTC_PRER::PREDIV_S.val(249));
+
+        // Enter BCD mode.
+        self.registers.rtc_icsr.modify(RTC_ICSR::BIN::CLEAR);
+
+        // Set time format to 24h. We first clear the AM/PM notation bit.
+        self.registers.rtc_tr.write(RTC_TR::PM::CLEAR);
+        self.registers.rtc_cr.modify(RTC_CR::FMT::CLEAR);
+
+        let datetime = date_time::DateTimeValues {
+            year: 0,
+            month: Month::January,
+            day: 1,
+            day_of_week: DayOfWeek::Monday,
+
+            hour: 0,
+            minute: 0,
+            seconds: 0,
+        };
+        self.date_time_setup(datetime);
+
+        self.exit_init_mode()?;
+        Ok(())
+    }
+    fn exit_init_mode(&self) -> Result<(), ErrorCode> {
+        // To exit initialization mode we first need to request exiting it
+        // and then re-enable write protection so we don't accidentaly change anything.
+        self.registers.rtc_icsr.modify(RTC_ICSR::INIT::CLEAR);
+        let mut cycle_counter = 100000;
+        while self.registers.rtc_icsr.read(RTC_ICSR::INITF) != 0 && cycle_counter > 0 {
+            cycle_counter -= 1;
+        }
+        if cycle_counter <= 0 {
+            // We are leaving the critical section anyway, so the protection
+            // has to go back on even when the RTC did not acknowledge the exit.
+            self.enable_write_protection();
+            return Err(ErrorCode::FAIL);
+        }
+
+        self.enable_write_protection();
+        Ok(())
+    }
+
+    /// Check that a date and time can be represented by the calendar registers.
+    ///
+    /// This is kept separate from the register writes so that caller can reject
+    /// invalid values before bypassing the write protection. Otherwise an
+    /// invalid date returns early and that will leave the RTC unlocked.
+    fn validate_date_time(datetime: &date_time::DateTimeValues) -> Result<(), ErrorCode> {
+        if !(datetime.day >= 1 && datetime.day <= 31) {
+            return Err(ErrorCode::INVAL);
+        }
+        if !(datetime.hour <= 23) {
+            return Err(ErrorCode::INVAL);
+        }
+        if !(datetime.minute <= 59) {
+            return Err(ErrorCode::INVAL);
+        }
+        if !(datetime.seconds <= 59) {
+            return Err(ErrorCode::INVAL);
+        }
+        Ok(())
+    }
+
+    /// Write a date and time into the calendar registers.
+    ///
+    /// The values already have been checked with validate_date_time.
+    /// This results in this function only writing registers, so it cannot fail
+    /// and cannot return early while the write protection is bypassed.
+    fn date_time_setup(&self, datetime: date_time::DateTimeValues) {
+        // The hardware RTC registers store time and date values in BCD format, not integers.
+        // Since the digits are represented in BCD format we divide by 10 to get the tens digit and
+        // use modulo the get the units digits for the respective bitfield.
+        let month_num = Rtc::month_into_u32(datetime.month);
+        let dotw_num = Rtc::dotw_into_u32(datetime.day_of_week);
+
+        self.registers.rtc_dr.modify(
+            RTC_DR::YT.val((datetime.year % 100) as u32 / 10)
+                + RTC_DR::YU.val((datetime.year % 100) as u32 % 10)
+                + RTC_DR::MT.val(month_num / 10)
+                + RTC_DR::MU.val(month_num % 10)
+                + RTC_DR::DT.val(datetime.day as u32 / 10)
+                + RTC_DR::DU.val(datetime.day as u32 % 10)
+                + RTC_DR::WDU.val(dotw_num),
+        );
+
+        self.registers.rtc_tr.modify(
+            RTC_TR::HT.val(datetime.hour as u32 / 10)
+                + RTC_TR::HU.val(datetime.hour as u32 % 10)
+                + RTC_TR::MNT.val(datetime.minute as u32 / 10)
+                + RTC_TR::MNU.val(datetime.minute as u32 % 10)
+                + RTC_TR::ST.val(datetime.seconds as u32 / 10)
+                + RTC_TR::SU.val(datetime.seconds as u32 % 10),
+        );
+    }
+
+    fn dotw_try_from_u32(dotw: u32) -> Result<DayOfWeek, ErrorCode> {
+        match dotw {
+            1 => Ok(DayOfWeek::Monday),
+            2 => Ok(DayOfWeek::Tuesday),
+            3 => Ok(DayOfWeek::Wednesday),
+            4 => Ok(DayOfWeek::Thursday),
+            5 => Ok(DayOfWeek::Friday),
+            6 => Ok(DayOfWeek::Saturday),
+            7 => Ok(DayOfWeek::Sunday),
+            _ => Err(ErrorCode::INVAL),
+        }
+    }
+
+    fn dotw_into_u32(dotw: DayOfWeek) -> u32 {
+        match dotw {
+            DayOfWeek::Monday => 1,
+            DayOfWeek::Tuesday => 2,
+            DayOfWeek::Wednesday => 3,
+            DayOfWeek::Thursday => 4,
+            DayOfWeek::Friday => 5,
+            DayOfWeek::Saturday => 6,
+            DayOfWeek::Sunday => 7,
+        }
+    }
+
+    fn month_try_from_u32(month_num: u32) -> Result<Month, ErrorCode> {
+        match month_num {
+            1 => Ok(Month::January),
+            2 => Ok(Month::February),
+            3 => Ok(Month::March),
+            4 => Ok(Month::April),
+            5 => Ok(Month::May),
+            6 => Ok(Month::June),
+            7 => Ok(Month::July),
+            8 => Ok(Month::August),
+            9 => Ok(Month::September),
+            10 => Ok(Month::October),
+            11 => Ok(Month::November),
+            12 => Ok(Month::December),
+            _ => Err(ErrorCode::INVAL),
+        }
+    }
+
+    fn month_into_u32(month: Month) -> u32 {
+        match month {
+            Month::January => 1,
+            Month::February => 2,
+            Month::March => 3,
+            Month::April => 4,
+            Month::May => 5,
+            Month::June => 6,
+            Month::July => 7,
+            Month::August => 8,
+            Month::September => 9,
+            Month::October => 10,
+            Month::November => 11,
+            Month::December => 12,
+        }
+    }
+}
+
+impl<'a> date_time::DateTime<'a> for Rtc<'a> {
+    fn get_date_time(&self) -> Result<(), ErrorCode> {
+        // Start an async read of current date and time:
+        // 1. Verify if the driver isn't busy.
+        // 2. Read the calendar registers (TR and DR) and converts their BCD values into integers.
+        // 3. The time and date are then stored in the time cell and it is later retrieved via the deferred call
+        //    handler and passed to the client.
+        // 4. Set a deferred call task and schedules it to notify client.
+        match self.deferred_call_task.get() {
+            Some(DeferredCallTask::Set) => return Err(ErrorCode::BUSY),
+            Some(DeferredCallTask::Get) => return Err(ErrorCode::ALREADY),
+            None => (),
+        }
+
+        let month_num =
+            self.registers.rtc_dr.read(RTC_DR::MT) * 10 + self.registers.rtc_dr.read(RTC_DR::MU);
+        let month_name = Rtc::month_try_from_u32(month_num)?;
+
+        let dotw_num = self.registers.rtc_dr.read(RTC_DR::WDU);
+        let dotw_name = Rtc::dotw_try_from_u32(dotw_num)?;
+
+        let datetime = date_time::DateTimeValues {
+            hour: (self.registers.rtc_tr.read(RTC_TR::HT) * 10
+                + self.registers.rtc_tr.read(RTC_TR::HU)) as u8,
+            minute: (self.registers.rtc_tr.read(RTC_TR::MNT) * 10
+                + self.registers.rtc_tr.read(RTC_TR::MNU)) as u8,
+            seconds: (self.registers.rtc_tr.read(RTC_TR::ST) * 10
+                + self.registers.rtc_tr.read(RTC_TR::SU)) as u8,
+
+            year: (self.registers.rtc_dr.read(RTC_DR::YT) * 10
+                + self.registers.rtc_dr.read(RTC_DR::YU)) as u16,
+            month: month_name,
+            day: (self.registers.rtc_dr.read(RTC_DR::DT) * 10
+                + self.registers.rtc_dr.read(RTC_DR::DU)) as u8,
+            day_of_week: dotw_name,
+        };
+
+        self.time.replace(datetime);
+
+        self.deferred_call_task.insert(Some(DeferredCallTask::Get));
+        self.deferred_call.set();
+
+        Ok(())
+    }
+
+    fn set_date_time(&self, date_time: date_time::DateTimeValues) -> Result<(), ErrorCode> {
+        // Start an async write to update RTC date and time registers:
+        // 1. Verify if the driver isn't busy.
+        // 2. Unlock the wp and enters init mode (which is necessary for writing to RTC date/time registers).
+        // 3. Convert the provided date and time values to BCD format and writes them to the registers (TR and DR).
+        // 4. Exit initialization mode, resume clk and reactivate wp.
+        // 5. Set a deferred call task and schedule it to notify client.
+        match self.deferred_call_task.get() {
+            Some(DeferredCallTask::Set) => return Err(ErrorCode::ALREADY),
+            Some(DeferredCallTask::Get) => return Err(ErrorCode::BUSY),
+            None => (),
+        }
+
+        // Reject invalid values before the write protection is bypassed, so a
+        // bad date given cannot leave the RTC unlocked.
+        Self::validate_date_time(&date_time)?;
+
+        self.enter_init_mode()?;
+        self.date_time_setup(date_time);
+        self.exit_init_mode()?;
+
+        self.deferred_call_task.insert(Some(DeferredCallTask::Set));
+        self.deferred_call.set();
+        Ok(())
+    }
+
+    fn set_client(&self, client: &'a dyn DateTimeClient) {
+        self.client.set(client);
+    }
+}

--- a/chips/stm32u5xx/src/rtc.rs
+++ b/chips/stm32u5xx/src/rtc.rs
@@ -761,16 +761,10 @@ impl<'a> date_time::DateTime<'a> for Rtc<'a> {
         // 3. The time and date are then stored in the time cell and it is later retrieved via the deferred call
         //    handler and passed to the client.
         // 4. Set a deferred call task and schedules it to notify client.
-        match self.deferred_call_task.take() {
-            Some(DeferredCallTask::Set) => {
-                self.deferred_call_task.insert(Some(DeferredCallTask::Set));
-                return Err(ErrorCode::BUSY);
-            }
-            Some(DeferredCallTask::Get) => {
-                self.deferred_call_task.insert(Some(DeferredCallTask::Get));
-                return Err(ErrorCode::ALREADY);
-            }
-            _ => (),
+        match self.deferred_call_task.get() {
+            Some(DeferredCallTask::Set) => return Err(ErrorCode::BUSY),
+            Some(DeferredCallTask::Get) => return Err(ErrorCode::ALREADY),
+            None => (),
         }
 
         let month_num =
@@ -811,16 +805,10 @@ impl<'a> date_time::DateTime<'a> for Rtc<'a> {
         // 3. Convert the provided date and time values to BCD format and writes them to the registers (TR and DR).
         // 4. Exit initialization mode, resume clk and reactivate wp.
         // 5. Set a deferred call task and schedule it to notify client.
-        match self.deferred_call_task.take() {
-            Some(DeferredCallTask::Set) => {
-                self.deferred_call_task.insert(Some(DeferredCallTask::Set));
-                return Err(ErrorCode::ALREADY);
-            }
-            Some(DeferredCallTask::Get) => {
-                self.deferred_call_task.insert(Some(DeferredCallTask::Get));
-                return Err(ErrorCode::BUSY);
-            }
-            _ => (),
+        match self.deferred_call_task.get() {
+            Some(DeferredCallTask::Set) => return Err(ErrorCode::ALREADY),
+            Some(DeferredCallTask::Get) => return Err(ErrorCode::BUSY),
+            None => (),
         }
 
         self.enter_init_mode()?;


### PR DESCRIPTION
### Pull Request Overview

This pull request adds RTC driver for stm32u5xx and instantiates it in `boards/nucleo_u545re_q`.

### Testing Strategy

This pull request was tested by uploading tock on the Nucleo U545RE-Q board and running a userspace RTC application. The application can be found in `libtock-c/examples/tests/rtc`.


### TODO or Help Wanted
N/A
### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
      
My AI use: Although AI didn't write any lines of code in this PR, I have used Gemini for asking questions about the RTC driver for the F429ZI to understand it better and to have the same approach for my driver. 
