### PR TITLE
riscv syscall: cleaner register deconstruction

### DIFF
--- a/arch/riscv/src/syscall.rs
+++ b/arch/riscv/src/syscall.rs
@@ -157,29 +157,21 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
         // Encode the system call return value into registers,
         // available for when the process resumes
 
-        // We need to use a bunch of split_at_mut's to have multiple
-        // mutable borrows into the same slice at the same time.
-        //
-        // Since the compiler knows the size of this slice, and these
-        // calls will be optimized out, we use one to get to the first
-        // register (A0)
-        let (_, r) = state.regs.split_at_mut(R_A0);
-
-        // This comes with the assumption that the respective
-        // registers are stored at monotonically increasing indices
-        // in the register slice
-        let (a0slice, r) = r.split_at_mut(R_A1 - R_A0);
-        let (a1slice, r) = r.split_at_mut(R_A2 - R_A1);
-        let (a2slice, a3slice) = r.split_at_mut(R_A3 - R_A2);
+        // We know these indexes are valid and disjoint, the error
+        // case will never actually happen.
+        let [a0, a1, a2, a3] = state
+            .regs
+            .get_disjoint_mut([R_A0, R_A1, R_A2, R_A3])
+            .or(Err(()))?;
 
         kernel::utilities::arch_helpers::encode_syscall_return_trd104(
             &kernel::utilities::arch_helpers::TRD104SyscallReturn::from_syscall_return(
                 return_value,
             ),
-            &mut a0slice[0],
-            &mut a1slice[0],
-            &mut a2slice[0],
-            &mut a3slice[0],
+            a0,
+            a1,
+            a2,
+            a3,
         );
 
         // We do not use process memory, so this cannot fail.


### PR DESCRIPTION
### Pull Request Overview

This pull request switches to using `get_disjoint_mut`, rather than a series of `split_at_mut`s, in the RISC-V `set_syscall_return_value` to extract `&mut usize`s from the riscv register slice.

There is no semantic difference, but this:

- Makes it more clear which index each register is taken from
- Is fewer lines of code

### Testing Strategy

Tested by running some apps on the qemu_rv32_virt board.

### TODO or Help Wanted

N/A

### Checklist

- [X] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [X] No documentation updates are required.

#### AI Use

- [X] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
