### PR TITLE
bug-fixes: Virtio GPU brightness and framed-write correctness

### DIFF
--- a/chips/virtio/src/devices/virtio_gpu/mod.rs
+++ b/chips/virtio/src/devices/virtio_gpu/mod.rs
@@ -580,7 +580,9 @@ impl<'a, 'b, F: DmaFence> VirtIOGPU<'a, 'b, F> {
 
         // We always draw left -> right, top -> bottom, so we can simply set the
         // current `x` and `y` coordinates to the bottom-right most coordinates
-        // we've just drawn (while wrapping and carrying the one):
+        // we've just drawn (while wrapping and carrying the one). `y` is the
+        // last row we drew (relative to `draw_rect`); the wrap below advances
+        // it to the next row when we've finished the row's rightmost column.
         current_draw_offset.0 = drawn_area
             .x
             .checked_add(drawn_area.width)
@@ -589,7 +591,8 @@ impl<'a, 'b, F: DmaFence> VirtIOGPU<'a, 'b, F> {
         current_draw_offset.1 = drawn_area
             .y
             .checked_add(drawn_area.height)
-            .and_then(|drawn_y1| drawn_y1.checked_sub(draw_rect.y))
+            .and_then(|drawn_y1| drawn_y1.checked_sub(1))
+            .and_then(|last_row| last_row.checked_sub(draw_rect.y))
             .unwrap();
 
         // Wrap to the next line when we've finished writing the column of our

--- a/chips/virtio/src/devices/virtio_gpu/mod.rs
+++ b/chips/virtio/src/devices/virtio_gpu/mod.rs
@@ -412,14 +412,23 @@ impl<'a, 'b, F: DmaFence> VirtIOGPU<'a, 'b, F> {
             // We're at the start of a row. If the client buffer holds less than
             // a full row, copy just those pixels as a partial trailing row.
             // Otherwise, copy as many full rows as fit in the buffer (leaving
-            // any remainder to a subsequent iteration, which will then hit the
-            // partial-row branch above):
+            // any remainder to a subsequent iteration).
+            //
+            // However, batching multiple rows into a single
+            // `TRANSFER_TO_HOST_2D` is only safe when `draw_rect.width` matches
+            // the resource's width: the device reads row `h` of the transfer
+            // rectangle from backing offset `t2d.offset + h * (resource_width *
+            // bpp)`, but our backing is a compact `draw_rect.width * bpp`
+            // per-row buffer. When the widths don't match, cap to a single row
+            // so the strided read collapses to a single contiguous copy:
             assert!(current_draw_offset.1 <= draw_rect.height || remaining_pixels == 0);
             if write_buffer_remaining_pixels < draw_rect.width as usize {
                 write_buffer_remaining_pixels
-            } else {
+            } else if draw_rect.width == self.width {
                 (write_buffer_remaining_pixels / draw_rect.width as usize)
                     * draw_rect.width as usize
+            } else {
+                draw_rect.width as usize
             }
         } else {
             // Our current draw offset is not zero. This means we must copy

--- a/chips/virtio/src/devices/virtio_gpu/mod.rs
+++ b/chips/virtio/src/devices/virtio_gpu/mod.rs
@@ -409,25 +409,17 @@ impl<'a, 'b, F: DmaFence> VirtIOGPU<'a, 'b, F> {
             // areas when using `rect.width` or `rect.height` as a divisor:
             0
         } else if current_draw_offset.0 == 0 {
-            // Okay, we can start drawing the full rectangle. We want to try
-            // drawing any full rows, if there are any left, and if not the
-            // last partial row:
+            // We're at the start of a row. If the client buffer holds less than
+            // a full row, copy just those pixels as a partial trailing row.
+            // Otherwise, copy as many full rows as fit in the buffer (leaving
+            // any remainder to a subsequent iteration, which will then hit the
+            // partial-row branch above):
             assert!(current_draw_offset.1 <= draw_rect.height || remaining_pixels == 0);
-            if current_draw_offset.1 >= draw_rect.height {
-                // Just one row left to draw, and we start from `x ==
-                // 0`. This means we can just copy however much more data
-                // the client buffer holds. We've previously checked that
-                // the client buffer fully fits into the draw area, but
-                // re-check that assertion here:
-                assert!(draw_rect.width as usize >= write_buffer_remaining_pixels);
+            if write_buffer_remaining_pixels < draw_rect.width as usize {
                 write_buffer_remaining_pixels
             } else {
-                // There is more than one row left to copy, and we start
-                // from `x == 0`. If the client buffer lines up with the end
-                // of a row, we can copy them as a single
-                // rectangle. Otherwise, we need two copies:
-                write_buffer_remaining_pixels / (draw_rect.width as usize)
-                    * (draw_rect.width as usize)
+                (write_buffer_remaining_pixels / draw_rect.width as usize)
+                    * draw_rect.width as usize
             }
         } else {
             // Our current draw offset is not zero. This means we must copy

--- a/chips/virtio/src/devices/virtio_gpu/mod.rs
+++ b/chips/virtio/src/devices/virtio_gpu/mod.rs
@@ -1016,7 +1016,7 @@ impl<'a, F: DmaFence> Screen<'a> for VirtIOGPU<'a, '_, F> {
 
     fn set_brightness(&self, _brightness: u16) -> Result<(), ErrorCode> {
         // nop, not supported
-        Ok(())
+        Err(ErrorCode::NOSUPPORT)
     }
 
     fn set_power(&self, enabled: bool) -> Result<(), ErrorCode> {


### PR DESCRIPTION
### Pull Request Overview

This pull requests fixes a number of related bugs in the Virtio GPU driver. The driver worked for applications using the u8g2 library because they happen not to exercise these paths. But graphics applications in general (LVGL-based, for example) do hit these paths:

* **`set_brightness` not supported** VirtIO GPU does not support setting the brightness, but the appropriate response from the HIL is `Err(NOSUPPORT)` not a dummy `Ok(())`.
* **y-offset after full-row draws** The Y-offset after a full row write was incremented by both a direct row-increment _and_ overflowing a column increment, so skipped a row.
* **partial trailing row draw** skipped partial row draws.
* **multi-non-full-row writes** multi-row writes worked correctly only if the write frame match the native display width. The fix in this PR is to write one-row-at-a-time iff the frame width is less than the native display width, which can be expensive, but the alternative requires manually adding padding scatter-gather buffers which is a tad complex and costs static memory, so I chose to defer that for now.

### Testing Strategy

Testing these bugs exist and are fixed required a modified QEMU board without a screen adapter, along with a modified LVGL app that uses the `ARGB8888` color scheme. I did that extensively, and they work very nicely, whereas before they just don't work at all, with various degrees of brokenness as commits are applied.

I also tested that previously working apps to make sure they still work. Those are the `u8g2`-based app from the qemu tutorials as well as the embedded graphics demo in libtock-rs, on the qemu tutorial board.

### TODO or Help Wanted

N/A


### Checklist

- [X] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [X] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [X] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

I used Claude Code systematically to help diagnose all issues except the `set_brightness` one. In particular, I used it to summarize the existing logic of the VirtIO GPU driver, to identify why asserts were being violated, and to summarize the behavior of the host-side VirtIO GPU device in QEMU. In my workflow it also proposed fixes, which were simple and I adopted with review but little changes. Finally, I used it to help summarize bugs and fixes in commit messages, which I then edited.
