### PR TITLE
arm-v8m: fix mpu wrong end address

### DIFF
--- a/arch/cortex-m33/src/mpu_v8m.rs
+++ b/arch/cortex-m33/src/mpu_v8m.rs
@@ -356,7 +356,8 @@ impl CortexMRegion {
 
         // Limit Address register
         let rlar_value = MPU_RLAR::ENABLE::SET
-            + MPU_RLAR::LIMIT.val((logical_end as u32) >> 5)
+            // RLAR::LIMIT is inclusive so `- 1` here to not have the region 32 bytes further.
+            + MPU_RLAR::LIMIT.val(((logical_end - 1) as u32) >> 5)
             + MPU_RLAR::PXN::Disable
             + MPU_RLAR::ATTRINDX.val(0);
 


### PR DESCRIPTION
### Pull Request Overview

The RLAR LIMIT is inclusive. See [here](https://developer.arm.com/documentation/100235/0100/The-Cortex-M33-Peripherals/Security-Attribution-and--Memory-Protection/MPU-Region-Limit-Address-Register?lang=en#:~:text=upper%20inclusive%20limit%20of%20the%20selected%20MPU%20memory%20region)

Fixes #4894 

### Testing Strategy

This pull request was tested by...
me


### TODO or Help Wanted

This pull request still needs...


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

- actually during debugging a LLM found the bug :)

<!-- Include details of AI use here, if you used any --!>
