### PR TITLE
capsules: sha256: support all clients

### DIFF
--- a/capsules/extra/src/sha256.rs
+++ b/capsules/extra/src/sha256.rs
@@ -8,23 +8,6 @@
 //! algorithm. It performs the hash using 32-bit native values,
 //! translating the input data into the endianness of the processor
 //! and translating the output into big endian format.
-//!
-//! # Callbacks
-//!
-//! The digest traits support different clients for data, hashing, and
-//! verifying, and all combinations. This capsule is implemented such that the
-//! "highest priority" client that is registered will be triggered. The priority
-//! order is as follows:
-//!
-//! 1. [`Client`]
-//! 2. [`ClientDataHash`]
-//! 3. [`ClientDataVerify`]
-//! 4. [`ClientData`]
-//! 5. [`ClientHash`]
-//! 6. [`ClientVerify`]
-//!
-//! That is, if a [`ClientDataHash`] and a [`ClientHash`] are both registered,
-//! then only the [`ClientDataHash`] will be invoked when a hash completes.
 
 use core::cell::Cell;
 use kernel::deferred_call::{DeferredCall, DeferredCallClient};
@@ -68,12 +51,9 @@ const ROUND_CONSTANTS: [u32; NUM_ROUND_CONSTANTS] = [
 pub struct Sha256Software<'a> {
     state: Cell<State>,
 
-    client: OptionalCell<&'a dyn Client<SHA_256_OUTPUT_LEN_BYTES>>,
     client_data: OptionalCell<&'a dyn ClientData<SHA_256_OUTPUT_LEN_BYTES>>,
     client_hash: OptionalCell<&'a dyn ClientHash<SHA_256_OUTPUT_LEN_BYTES>>,
     client_verify: OptionalCell<&'a dyn ClientVerify<SHA_256_OUTPUT_LEN_BYTES>>,
-    client_data_hash: OptionalCell<&'a dyn ClientDataHash<SHA_256_OUTPUT_LEN_BYTES>>,
-    client_data_verify: OptionalCell<&'a dyn ClientDataVerify<SHA_256_OUTPUT_LEN_BYTES>>,
 
     input_data: OptionalCell<SubSliceMutImmut<'static, u8>>,
     data_buffer: MapCell<[u8; SHA_BLOCK_LEN_BYTES]>,
@@ -91,12 +71,9 @@ impl Sha256Software<'_> {
     pub fn new() -> Self {
         let s = Self {
             state: Cell::new(State::Idle),
-            client: OptionalCell::empty(),
             client_data: OptionalCell::empty(),
             client_hash: OptionalCell::empty(),
             client_verify: OptionalCell::empty(),
-            client_data_hash: OptionalCell::empty(),
-            client_data_verify: OptionalCell::empty(),
             input_data: OptionalCell::empty(),
             data_buffer: MapCell::new([0; SHA_BLOCK_LEN_BYTES]),
             buffered_length: Cell::new(0),
@@ -322,101 +299,6 @@ impl Sha256Software<'_> {
         }
         self.hash_values.set(new_hashes);
     }
-
-    fn callback_data(&self, result: Result<(), ErrorCode>, data: SubSliceMutImmut<'static, u8>) {
-        match data {
-            SubSliceMutImmut::Mutable(buffer) => {
-                if self.client.is_some() {
-                    self.client.map(|client| {
-                        client.add_mut_data_done(result, buffer);
-                    });
-                } else {
-                    if self.client_data_hash.is_some() {
-                        self.client_data_hash.map(|client| {
-                            client.add_mut_data_done(result, buffer);
-                        });
-                    } else {
-                        if self.client_data_verify.is_some() {
-                            self.client_data_verify.map(|client| {
-                                client.add_mut_data_done(result, buffer);
-                            });
-                        } else {
-                            self.client_data.map(|client| {
-                                client.add_mut_data_done(result, buffer);
-                            });
-                        }
-                    }
-                }
-            }
-            SubSliceMutImmut::Immutable(buffer) => {
-                if self.client.is_some() {
-                    self.client.map(|client| {
-                        client.add_data_done(result, buffer);
-                    });
-                } else {
-                    if self.client_data_hash.is_some() {
-                        self.client_data_hash.map(|client| {
-                            client.add_data_done(result, buffer);
-                        });
-                    } else {
-                        if self.client_data_verify.is_some() {
-                            self.client_data_verify.map(|client| {
-                                client.add_data_done(result, buffer);
-                            });
-                        } else {
-                            self.client_data.map(|client| {
-                                client.add_data_done(result, buffer);
-                            });
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    fn callback_hash(
-        &self,
-        result: Result<(), ErrorCode>,
-        digest: &'static mut [u8; SHA_256_OUTPUT_LEN_BYTES],
-    ) {
-        if self.client.is_some() {
-            self.client.map(|c| {
-                c.hash_done(result, digest);
-            });
-        } else {
-            if self.client_data_hash.is_some() {
-                self.client_data_hash.map(|client| {
-                    client.hash_done(result, digest);
-                });
-            } else {
-                self.client_hash.map(|client| {
-                    client.hash_done(result, digest);
-                });
-            }
-        }
-    }
-
-    fn callback_verify(
-        &self,
-        result: Result<bool, ErrorCode>,
-        compare: &'static mut [u8; SHA_256_OUTPUT_LEN_BYTES],
-    ) {
-        if self.client.is_some() {
-            self.client.map(|client| {
-                client.verification_done(result, compare);
-            });
-        } else {
-            if self.client_data_verify.is_some() {
-                self.client_data_verify.map(|client| {
-                    client.verification_done(result, compare);
-                });
-            } else {
-                self.client_verify.map(|client| {
-                    client.verification_done(result, compare);
-                });
-            }
-        }
-    }
 }
 
 impl<'a> DigestData<'a, 32> for Sha256Software<'a> {
@@ -510,7 +392,9 @@ impl<'a> DigestVerify<'a, 32> for Sha256Software<'a> {
 
 impl<'a> Digest<'a, 32> for Sha256Software<'a> {
     fn set_client(&'a self, client: &'a dyn Client<32>) {
-        self.client.set(client);
+        self.client_data.set(client);
+        self.client_hash.set(client);
+        self.client_verify.set(client);
     }
 }
 
@@ -538,38 +422,68 @@ impl DeferredCallClient for Sha256Software<'_> {
                 }
                 self.state.set(State::Idle);
                 self.clear_data();
-                self.callback_verify(Ok(pass), output);
+                self.client_verify.map(|client| {
+                    client.verification_done(Ok(pass), output);
+                });
             }
             State::Data => {
                 // Data already computed in method call
                 let data = self.input_data.take().unwrap();
                 self.state.set(State::Idle);
-                self.callback_data(Ok(()), data);
+                match data {
+                    SubSliceMutImmut::Mutable(buffer) => {
+                        self.client_data.map(|client| {
+                            client.add_mut_data_done(Ok(()), buffer);
+                        });
+                    }
+                    SubSliceMutImmut::Immutable(buffer) => {
+                        self.client_data.map(|client| {
+                            client.add_data_done(Ok(()), buffer);
+                        });
+                    }
+                }
             }
             State::Hash => {
                 // Hash already copied in method call.
                 let output = self.output_data.replace(None).unwrap();
                 self.state.set(State::Idle);
                 self.clear_data();
-                self.callback_hash(Ok(()), output);
+                self.client_hash.map(|client| {
+                    client.hash_done(Ok(()), output);
+                });
             }
             State::CancelData => {
                 self.state.set(State::Idle);
                 self.clear_data();
                 let data = self.input_data.take().unwrap();
-                self.callback_data(Err(ErrorCode::CANCEL), data);
+                match data {
+                    SubSliceMutImmut::Mutable(buffer) => {
+                        self.client_data.map(|client| {
+                            client.add_mut_data_done(Err(ErrorCode::CANCEL), buffer);
+                        });
+                    }
+                    SubSliceMutImmut::Immutable(buffer) => {
+                        self.client_data.map(|client| {
+                            client.add_data_done(Err(ErrorCode::CANCEL), buffer);
+                        });
+                    }
+                }
             }
             State::CancelVerify => {
                 self.state.set(State::Idle);
                 self.clear_data();
                 let output = self.output_data.replace(None).unwrap();
-                self.callback_verify(Err(ErrorCode::CANCEL), output);
+                self.client_verify.map(|client| {
+                    client.verification_done(Err(ErrorCode::CANCEL), output);
+                });
             }
             State::CancelHash => {
                 self.state.set(State::Idle);
                 self.clear_data();
                 let output = self.output_data.replace(None).unwrap();
-                self.callback_hash(Err(ErrorCode::CANCEL), output);
+                self.client_hash.map(|client| {
+                    client.hash_done(Err(ErrorCode::CANCEL), output);
+                });
             }
         }
     }
@@ -588,12 +502,14 @@ impl Sha256 for Sha256Software<'_> {
 
 impl<'a> DigestDataHash<'a, 32> for Sha256Software<'a> {
     fn set_client(&'a self, client: &'a dyn ClientDataHash<32>) {
-        self.client_data_hash.set(client);
+        self.client_data.set(client);
+        self.client_hash.set(client);
     }
 }
 
 impl<'a> DigestDataVerify<'a, 32> for Sha256Software<'a> {
     fn set_client(&'a self, client: &'a dyn ClientDataVerify<32>) {
-        self.client_data_verify.set(client);
+        self.client_data.set(client);
+        self.client_verify.set(client);
     }
 }

--- a/capsules/extra/src/sha256.rs
+++ b/capsules/extra/src/sha256.rs
@@ -8,6 +8,23 @@
 //! algorithm. It performs the hash using 32-bit native values,
 //! translating the input data into the endianness of the processor
 //! and translating the output into big endian format.
+//!
+//! # Callbacks
+//!
+//! The digest traits support different clients for data, hashing, and
+//! verifying, and all combinations. This capsule is implemented such that the
+//! "highest priority" client that is registered will be triggered. The priority
+//! order is as follows:
+//!
+//! 1. [`Client`]
+//! 2. [`ClientDataHash`]
+//! 3. [`ClientDataVerify`]
+//! 4. [`ClientData`]
+//! 5. [`ClientHash`]
+//! 6. [`ClientVerify`]
+//!
+//! That is, if a [`ClientDataHash`] and a [`ClientHash`] are both registered,
+//! then only the [`ClientDataHash`] will be invoked when a hash completes.
 
 use core::cell::Cell;
 use kernel::deferred_call::{DeferredCall, DeferredCallClient};
@@ -52,6 +69,12 @@ pub struct Sha256Software<'a> {
     state: Cell<State>,
 
     client: OptionalCell<&'a dyn Client<SHA_256_OUTPUT_LEN_BYTES>>,
+    client_data: OptionalCell<&'a dyn ClientData<SHA_256_OUTPUT_LEN_BYTES>>,
+    client_hash: OptionalCell<&'a dyn ClientHash<SHA_256_OUTPUT_LEN_BYTES>>,
+    client_verify: OptionalCell<&'a dyn ClientVerify<SHA_256_OUTPUT_LEN_BYTES>>,
+    client_data_hash: OptionalCell<&'a dyn ClientDataHash<SHA_256_OUTPUT_LEN_BYTES>>,
+    client_data_verify: OptionalCell<&'a dyn ClientDataVerify<SHA_256_OUTPUT_LEN_BYTES>>,
+
     input_data: OptionalCell<SubSliceMutImmut<'static, u8>>,
     data_buffer: MapCell<[u8; SHA_BLOCK_LEN_BYTES]>,
     buffered_length: Cell<usize>,
@@ -69,6 +92,11 @@ impl Sha256Software<'_> {
         let s = Self {
             state: Cell::new(State::Idle),
             client: OptionalCell::empty(),
+            client_data: OptionalCell::empty(),
+            client_hash: OptionalCell::empty(),
+            client_verify: OptionalCell::empty(),
+            client_data_hash: OptionalCell::empty(),
+            client_data_verify: OptionalCell::empty(),
             input_data: OptionalCell::empty(),
             data_buffer: MapCell::new([0; SHA_BLOCK_LEN_BYTES]),
             buffered_length: Cell::new(0),
@@ -294,6 +322,101 @@ impl Sha256Software<'_> {
         }
         self.hash_values.set(new_hashes);
     }
+
+    fn callback_data(&self, result: Result<(), ErrorCode>, data: SubSliceMutImmut<'static, u8>) {
+        match data {
+            SubSliceMutImmut::Mutable(buffer) => {
+                if self.client.is_some() {
+                    self.client.map(|client| {
+                        client.add_mut_data_done(result, buffer);
+                    });
+                } else {
+                    if self.client_data_hash.is_some() {
+                        self.client_data_hash.map(|client| {
+                            client.add_mut_data_done(result, buffer);
+                        });
+                    } else {
+                        if self.client_data_verify.is_some() {
+                            self.client_data_verify.map(|client| {
+                                client.add_mut_data_done(result, buffer);
+                            });
+                        } else {
+                            self.client_data.map(|client| {
+                                client.add_mut_data_done(result, buffer);
+                            });
+                        }
+                    }
+                }
+            }
+            SubSliceMutImmut::Immutable(buffer) => {
+                if self.client.is_some() {
+                    self.client.map(|client| {
+                        client.add_data_done(result, buffer);
+                    });
+                } else {
+                    if self.client_data_hash.is_some() {
+                        self.client_data_hash.map(|client| {
+                            client.add_data_done(result, buffer);
+                        });
+                    } else {
+                        if self.client_data_verify.is_some() {
+                            self.client_data_verify.map(|client| {
+                                client.add_data_done(result, buffer);
+                            });
+                        } else {
+                            self.client_data.map(|client| {
+                                client.add_data_done(result, buffer);
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn callback_hash(
+        &self,
+        result: Result<(), ErrorCode>,
+        digest: &'static mut [u8; SHA_256_OUTPUT_LEN_BYTES],
+    ) {
+        if self.client.is_some() {
+            self.client.map(|c| {
+                c.hash_done(result, digest);
+            });
+        } else {
+            if self.client_data_hash.is_some() {
+                self.client_data_hash.map(|client| {
+                    client.hash_done(result, digest);
+                });
+            } else {
+                self.client_hash.map(|client| {
+                    client.hash_done(result, digest);
+                });
+            }
+        }
+    }
+
+    fn callback_verify(
+        &self,
+        result: Result<bool, ErrorCode>,
+        compare: &'static mut [u8; SHA_256_OUTPUT_LEN_BYTES],
+    ) {
+        if self.client.is_some() {
+            self.client.map(|client| {
+                client.verification_done(result, compare);
+            });
+        } else {
+            if self.client_data_verify.is_some() {
+                self.client_data_verify.map(|client| {
+                    client.verification_done(result, compare);
+                });
+            } else {
+                self.client_verify.map(|client| {
+                    client.verification_done(result, compare);
+                });
+            }
+        }
+    }
 }
 
 impl<'a> DigestData<'a, 32> for Sha256Software<'a> {
@@ -331,8 +454,8 @@ impl<'a> DigestData<'a, 32> for Sha256Software<'a> {
         self.initialize();
     }
 
-    fn set_data_client(&'a self, _client: &'a (dyn ClientData<32> + 'a)) {
-        unimplemented!()
+    fn set_data_client(&'a self, client: &'a (dyn ClientData<32> + 'a)) {
+        self.client_data.set(client);
     }
 }
 
@@ -359,8 +482,8 @@ impl<'a> DigestHash<'a, 32> for Sha256Software<'a> {
         }
     }
 
-    fn set_hash_client(&'a self, _client: &'a (dyn ClientHash<32> + 'a)) {
-        unimplemented!()
+    fn set_hash_client(&'a self, client: &'a (dyn ClientHash<32> + 'a)) {
+        self.client_hash.set(client);
     }
 }
 
@@ -380,8 +503,8 @@ impl<'a> DigestVerify<'a, 32> for Sha256Software<'a> {
         }
     }
 
-    fn set_verify_client(&'a self, _client: &'a (dyn ClientVerify<32> + 'a)) {
-        unimplemented!()
+    fn set_verify_client(&'a self, client: &'a (dyn ClientVerify<32> + 'a)) {
+        self.client_verify.set(client);
     }
 }
 
@@ -415,68 +538,38 @@ impl DeferredCallClient for Sha256Software<'_> {
                 }
                 self.state.set(State::Idle);
                 self.clear_data();
-                self.client.map(|c| {
-                    c.verification_done(Ok(pass), output);
-                });
+                self.callback_verify(Ok(pass), output);
             }
             State::Data => {
                 // Data already computed in method call
                 let data = self.input_data.take().unwrap();
                 self.state.set(State::Idle);
-                match data {
-                    SubSliceMutImmut::Mutable(buffer) => {
-                        self.client.map(|client| {
-                            client.add_mut_data_done(Ok(()), buffer);
-                        });
-                    }
-                    SubSliceMutImmut::Immutable(buffer) => {
-                        self.client.map(|client| {
-                            client.add_data_done(Ok(()), buffer);
-                        });
-                    }
-                }
+                self.callback_data(Ok(()), data);
             }
             State::Hash => {
                 // Hash already copied in method call.
                 let output = self.output_data.replace(None).unwrap();
                 self.state.set(State::Idle);
                 self.clear_data();
-                self.client.map(|c| {
-                    c.hash_done(Ok(()), output);
-                });
+                self.callback_hash(Ok(()), output);
             }
             State::CancelData => {
                 self.state.set(State::Idle);
                 self.clear_data();
                 let data = self.input_data.take().unwrap();
-                match data {
-                    SubSliceMutImmut::Mutable(buffer) => {
-                        self.client.map(|client| {
-                            client.add_mut_data_done(Err(ErrorCode::CANCEL), buffer);
-                        });
-                    }
-                    SubSliceMutImmut::Immutable(buffer) => {
-                        self.client.map(|client| {
-                            client.add_data_done(Err(ErrorCode::CANCEL), buffer);
-                        });
-                    }
-                }
+                self.callback_data(Err(ErrorCode::CANCEL), data);
             }
             State::CancelVerify => {
                 self.state.set(State::Idle);
                 self.clear_data();
                 let output = self.output_data.replace(None).unwrap();
-                self.client.map(|client| {
-                    client.verification_done(Err(ErrorCode::CANCEL), output);
-                });
+                self.callback_verify(Err(ErrorCode::CANCEL), output);
             }
             State::CancelHash => {
                 self.state.set(State::Idle);
                 self.clear_data();
                 let output = self.output_data.replace(None).unwrap();
-                self.client.map(|client| {
-                    client.hash_done(Err(ErrorCode::CANCEL), output);
-                });
+                self.callback_hash(Err(ErrorCode::CANCEL), output);
             }
         }
     }
@@ -494,13 +587,13 @@ impl Sha256 for Sha256Software<'_> {
 }
 
 impl<'a> DigestDataHash<'a, 32> for Sha256Software<'a> {
-    fn set_client(&'a self, _client: &'a dyn ClientDataHash<32>) {
-        unimplemented!()
+    fn set_client(&'a self, client: &'a dyn ClientDataHash<32>) {
+        self.client_data_hash.set(client);
     }
 }
 
 impl<'a> DigestDataVerify<'a, 32> for Sha256Software<'a> {
-    fn set_client(&'a self, _client: &'a dyn ClientDataVerify<32>) {
-        unimplemented!()
+    fn set_client(&'a self, client: &'a dyn ClientDataVerify<32>) {
+        self.client_data_verify.set(client);
     }
 }

--- a/capsules/extra/src/sha256.rs
+++ b/capsules/extra/src/sha256.rs
@@ -338,6 +338,8 @@ impl<'a> DigestData<'a, 32> for Sha256Software<'a> {
 
     fn set_data_client(&'a self, client: &'a (dyn ClientData<32> + 'a)) {
         self.client_data.set(client);
+        self.client_hash.clear();
+        self.client_verify.clear();
     }
 }
 
@@ -365,7 +367,9 @@ impl<'a> DigestHash<'a, 32> for Sha256Software<'a> {
     }
 
     fn set_hash_client(&'a self, client: &'a (dyn ClientHash<32> + 'a)) {
+        self.client_data.clear();
         self.client_hash.set(client);
+        self.client_verify.clear();
     }
 }
 
@@ -386,6 +390,8 @@ impl<'a> DigestVerify<'a, 32> for Sha256Software<'a> {
     }
 
     fn set_verify_client(&'a self, client: &'a (dyn ClientVerify<32> + 'a)) {
+        self.client_data.clear();
+        self.client_hash.clear();
         self.client_verify.set(client);
     }
 }
@@ -504,12 +510,14 @@ impl<'a> DigestDataHash<'a, 32> for Sha256Software<'a> {
     fn set_client(&'a self, client: &'a dyn ClientDataHash<32>) {
         self.client_data.set(client);
         self.client_hash.set(client);
+        self.client_verify.clear();
     }
 }
 
 impl<'a> DigestDataVerify<'a, 32> for Sha256Software<'a> {
     fn set_client(&'a self, client: &'a dyn ClientDataVerify<32>) {
         self.client_data.set(client);
+        self.client_hash.clear();
         self.client_verify.set(client);
     }
 }


### PR DESCRIPTION
### Pull Request Overview

Our current SHA256 software implementation assumed all users would only use the combined `Client` trait. However, since we removed verify from the driver capsule, we are now _not_ using the `Client` trait, and using this capsule causes an `unimplemented!()` panic.

~~This adds helper functions to choose the callback client to use based on what has been registered.~~

EDIT: After an update, this adds separate clients for all three operations (data, hash, verify) and calls the operations-specific client. Whichever set_client is called most recently will set the relevant client.


### Testing Strategy

Running the SHA configuration board with a libtock-c test.


### TODO or Help Wanted

I know that even this is clumsy code. However, we have never found a better way to handle fine-grained clients and this is the best option we know of.


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

Much simpler change now from the original version.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

~~I forgot that `.map_or_else()` does not work (the borrow checker doesn't understand we are not using returned buffers twice), but that `if {} else {}` does. Claude helped me with that.~~

AI was used in the original version (first commit), but the new version is much simpler and doesn't require any additional ifs.
