### PR TITLE
boards: add shakti_c_sim — SHAKTI C-Class RV64 userspace round-trip b…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,6 +1527,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "shakti_c"
+version = "0.2.3-dev"
+dependencies = [
+ "kernel",
+ "rv64i",
+]
+
+[[package]]
+name = "shakti_c_sim"
+version = "0.2.3-dev"
+dependencies = [
+ "capsules-core",
+ "capsules-system",
+ "components",
+ "kernel",
+ "rv64i",
+ "shakti_c",
+ "tock_build_scripts",
+]
+
+[[package]]
 name = "sifive"
 version = "0.2.3-dev"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,8 @@
 
 [workspace]
 members = [
+    "chips/shakti_c",
+    "boards/shakti_c_sim",
     "arch/cortex-m",
     "arch/cortex-v7m",
     "arch/cortex-m0",

--- a/boards/README.md
+++ b/boards/README.md
@@ -39,6 +39,7 @@ but the approximate definitions:
 >    under active development to move to Tier 2 support.
 > 1. For a fully virtual platform on QEMU you can use the
 >    [QEMU RISC-V 32 bit `virt` platform](qemu_rv32_virt/README.md) board. This
+| [SHAKTI C-Class Simulation](shakti_c_sim/README.md)              | RISC-V RV64IMAC  | SHAKTI C-Class | custom     | custom                      | No            |
 >    can be quickly started and run on a host computer.
 > 1. For a simulation environment you can use Verilator with
 >    [OpenTitan Earlgrey on CW310](opentitan/earlgrey-cw310/README.md) or
@@ -115,6 +116,7 @@ Virtual hardware platforms that are regularly tested as part of the CI.
 | Board                                                             | Architecture     | MCU            | Interface  | App deployment              | QEMU Support? |
 |-------------------------------------------------------------------|------------------|----------------|------------|-----------------------------|---------------|
 | [QEMU RISC-V 32 bit `virt` platform](qemu_rv32_virt/README.md)    | RISC-V RV32IMAC  | QEMU           | custom     | custom                      | Yes (7.2.0)   |
+| [SHAKTI C-Class Simulation](shakti_c_sim/README.md)              | RISC-V RV64IMAC  | SHAKTI C-Class | custom     | custom                      | No            |
 | [QEMU RISC-V 64 bit `virt` platform](qemu_rv64_virt/README.md)    | RISC-V RV64IMAC  | QEMU           | custom     | custom                      | Yes (8.2.7)   |
 | [LiteX on Digilent Arty A-7](litex/arty/README.md)                | RISC-V RV32IMC   | LiteX+VexRiscV | custom     | tockloader (flash-file)[^1] | No            |
 | [Verilated LiteX Simulation](litex/sim/README.md)                 | RISC-V RV32IMC   | LiteX+VexRiscv | custom     | tockloader (flash-file)[^1] | No            |

--- a/boards/shakti_c_sim/.cargo/config.toml
+++ b/boards/shakti_c_sim/.cargo/config.toml
@@ -1,0 +1,12 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2026.
+
+include = [
+  "../../cargo/tock_flags.toml",
+  "../../cargo/unstable_flags.toml",
+  "../../cargo/riscv_flags.toml",
+]
+
+[build]
+target = "riscv64imac-unknown-none-elf"

--- a/boards/shakti_c_sim/Cargo.toml
+++ b/boards/shakti_c_sim/Cargo.toml
@@ -1,0 +1,24 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2026.
+
+[package]
+name = "shakti_c_sim"
+version.workspace = true
+authors.workspace = true
+build = "../build.rs"
+edition.workspace = true
+
+[dependencies]
+rv64i = { path = "../../arch/rv64i" }
+shakti_c = { path = "../../chips/shakti_c" }
+kernel = { path = "../../kernel" }
+components = { path = "../components" }
+capsules-core = { path = "../../capsules/core" }
+capsules-system = { path = "../../capsules/system" }
+
+[build-dependencies]
+tock_build_scripts = { path = "../build_scripts" }
+
+[lints]
+workspace = true

--- a/boards/shakti_c_sim/Makefile
+++ b/boards/shakti_c_sim/Makefile
@@ -1,0 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2026.
+
+# Makefile for building the Tock kernel for the SHAKTI C-Class Verilator sim.
+
+include ../Makefile.common

--- a/boards/shakti_c_sim/README.md
+++ b/boards/shakti_c_sim/README.md
@@ -1,0 +1,83 @@
+# SHAKTI C-Class Simulation
+
+This board runs Tock on the open-source
+[SHAKTI C-Class](https://gitlab.com/shaktiproject/cores/c-class) (RV64IMAC) core
+under a Verilator simulation. It boots a single process and exercises the full
+RV64 userspace round-trip (context switch, `ecall`, upcalls) driving the Alarm
+capsule for a time-based syscall.
+
+Test-SoC memory map: RAM at `0x8000_0000`, CLINT at `0x0200_0000`, UART at
+`0x0001_1300`, and a simulation-control register at `0x0002_000C` (writing `1`
+ends the sim). The CLINT `mtime` is accessed as a single 64-bit register (see
+`chips/shakti_c`).
+
+Kernel boot progress and the process/panic dumps are emitted with the standard
+Tock `debug!()` mechanism over the SoC UART; the board self-terminates the
+simulation once the test process completes.
+
+## Building
+
+Build the kernel from this directory:
+
+```
+cd boards/shakti_c_sim
+make
+```
+
+This produces the kernel ELF and a raw binary:
+
+- ELF: `target/riscv64imac-unknown-none-elf/release/shakti_c_sim`
+- BIN: `target/riscv64imac-unknown-none-elf/release/shakti_c_sim.bin`
+
+The board loads exactly one process. The app image is a hand-written RV64
+assembly TBF (there is no libtock-rs RV64 target yet) spliced into the flash
+region at `_sapps` (`0x8010_0000`). Concatenate the kernel and the app TBF into
+the image the simulator loads:
+
+```
+make
+cat target/riscv64imac-unknown-none-elf/release/shakti_c_sim.bin app.tbf > shakti_c_sim_with_app.bin
+```
+
+## Running
+
+1. Build the SHAKTI C-Class Verilator model (from the
+   [c-class](https://gitlab.com/shaktiproject/cores/c-class) project) for the
+   Test-SoC configuration used here (RAM `0x8000_0000`, UART `0x0001_1300`,
+   CLINT `0x0200_0000`).
+
+2. Load the combined kernel+app binary at the boot address `0x8000_0000` and
+   start the simulation, pointing the harness's boot memory image at
+   `shakti_c_sim_with_app.bin`.
+
+3. Watch the UART output. The testbench captures each byte written to the UART TX
+   register and writes it to `app_log`/stdout. Expected output is approximately:
+
+   ```
+   === Tock OS on SHAKTI C-Class (RV64IMAC) ===
+   [shakti_c_sim] real TBF process, time-based syscall via Alarm
+   calling load_processes from _sapps=0x0000000080100000
+   load_processes Ok
+   processes loaded = 1
+   alarm wired (driver 0); mtimer IRQ enabled; entering kernel_loop
+   t_before  mtime=0x00000000........
+   process resumed after alarm-fired upcall
+   t_after   mtime=0x00000000........
+   elapsed ticks (10 MHz) = 0x00000000........
+   *** STAGE 5 PASS ***
+   ```
+
+4. On `*** STAGE 5 PASS ***` the board writes `1` to the sim-control register at
+   `0x0002_000C`, which ends the Verilator run and flushes `app_log`. The board
+   self-exits; you do not need to kill the simulator manually.
+
+If a process faults or the kernel panics, the standard Tock panic handler prints
+the panic banner, kernel version, RISC-V CPU register state, and a per-process
+dump over the same UART, then ends the simulation the same way.
+
+## Notes
+
+- The SoC UART is polled (no interrupt line in the sim), so kernel output is
+  synchronous.
+- There is no PLIC in this Test-SoC; the only interrupt source is the CLINT
+  (machine timer / machine software), which drives the Alarm capsule.

--- a/boards/shakti_c_sim/layout.ld
+++ b/boards/shakti_c_sim/layout.ld
@@ -1,0 +1,18 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2026.                                  */
+
+/*
+ * SHAKTI C-Class test SoC: 2 GiB of RAM starting at 0x80000000. The
+ * boot ROM jumps to 0x80000000, so the kernel is placed at the start of DRAM
+ * (same convention as the the bare-metal bring-up program).
+ */
+
+MEMORY
+{
+  rom  (rx)  : ORIGIN = 0x80000000, LENGTH = 0x00100000
+  prog (rx)  : ORIGIN = 0x80100000, LENGTH = 0x00100000
+  ram  (rwx) : ORIGIN = 0x80200000, LENGTH = 0x01000000
+}
+
+INCLUDE tock_kernel_layout.ld

--- a/boards/shakti_c_sim/src/io.rs
+++ b/boards/shakti_c_sim/src/io.rs
@@ -1,0 +1,59 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+use core::fmt::Write;
+use core::panic::PanicInfo;
+use core::ptr::addr_of_mut;
+
+use kernel::debug;
+use kernel::utilities::io_write::IoWrite;
+
+/// Sim-finish MMIO register: writing 1 ends the Verilator simulation cleanly so
+/// the testbench flushes `app_log`. This is the one raw write the panic path
+/// keeps, since it must run after the (now standard) panic dump.
+const SIM_FINISH: *mut u32 = 0x0002_000C as *mut u32;
+
+/// Synchronous writer used by the panic handler. Drives the SHAKTI UART through
+/// the chip driver's blocking `transmit_sync`, which cannot recurse into the
+/// async driver path and waits for the last byte to serialize.
+struct Writer {}
+
+static mut WRITER: Writer = Writer {};
+
+impl Write for Writer {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+impl IoWrite for Writer {
+    fn write(&mut self, buf: &[u8]) -> usize {
+        let uart = shakti_c::uart::Uart::new(shakti_c::uart::UART0_BASE);
+        uart.transmit_sync(buf);
+        buf.len()
+    }
+}
+
+/// Panic handler: standard `debug::panic_print_old` (banner, kernel version,
+/// RISC-V CPU state, per-process fault dump), then end the Verilator sim (no
+/// LEDs on this SoC) so `app_log` is flushed.
+#[cfg(not(test))]
+#[panic_handler]
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
+    let writer = &mut *addr_of_mut!(WRITER);
+
+    debug::panic_print_old(
+        writer,
+        pi,
+        &rv64i::support::nop,
+        crate::PANIC_RESOURCES.get(),
+    );
+
+    core::ptr::write_volatile(SIM_FINISH, 1);
+
+    loop {
+        core::hint::spin_loop();
+    }
+}

--- a/boards/shakti_c_sim/src/main.rs
+++ b/boards/shakti_c_sim/src/main.rs
@@ -1,0 +1,342 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+//! Board file for the SHAKTI C-Class (RV64) Verilator simulation.
+//!
+//! Boots a single real TBF process under `kernel_loop` and exercises the full
+//! RV64 userspace round-trip: the process performs a time-based syscall via the
+//! Alarm capsule (Subscribe -> Command(set-alarm) -> Yield), is resumed by the
+//! machine-timer interrupt through `_start_trap`, and reads back the elapsed
+//! time, proving switch_to_process -> mret-to-user -> ecall -> kernel -> UART
+//! end-to-end on rv64. The test app is hand-written assembly (raw `ecall`s; no
+//! libtock-rs rv64 target yet). A board-local SimControl driver times the alarm
+//! and prints the delta; boot progress is logged with `debug!()` over the SoC
+//! UART.
+
+#![no_std]
+#![no_main]
+
+use core::cell::Cell;
+
+use kernel::capabilities;
+use kernel::component::Component;
+use kernel::create_capability;
+use kernel::debug::PanicResources;
+use kernel::hil::time::{Alarm, Time};
+use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::syscall::{CommandReturn, SyscallDriver};
+use kernel::utilities::registers::interfaces::ReadWriteable;
+use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::{debug, static_init, ProcessId};
+
+use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use shakti_c::chip::{ShaktiC, ShaktiCClint};
+
+mod io;
+
+/// Process capacity. loads exactly one app.
+pub const NUM_PROCS: usize = 1;
+
+/// Board-local "SimControl" syscall driver number (board-private range).
+const SIMCTL_DRIVER_NUM: usize = 0x9000;
+
+type ShaktiCChip = ShaktiC<'static>;
+type SchedulerInUse = capsules_system::scheduler::round_robin::RoundRobinSched<'static>;
+type AlarmDriverInUse =
+    capsules_core::alarm::AlarmDriver<'static, VirtualMuxAlarm<'static, ShaktiCClint<'static>>>;
+type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
+
+/// Resources the panic handler in `io.rs` needs to print CPU + process state.
+static PANIC_RESOURCES: SingleThreadValue<PanicResources<ShaktiCChip, ProcessPrinterInUse>> =
+    SingleThreadValue::new();
+
+/// How the kernel responds when a process faults: panic, which the standard
+/// panic handler (`io.rs`) turns into a UART dump + clean sim exit.
+static FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
+    capsules_system::process_policies::PanicFaultPolicy {};
+
+// Reserve the kernel stack (referenced by the linker script).
+kernel::stack_size! {0x2000}
+
+const SIM_FINISH: *mut u32 = 0x0002_000C as *mut u32;
+
+/// End the Verilator simulation cleanly (so the testbench flushes `app_log`).
+///
+/// `debug!()` output is buffered twice over, and both buffers must be drained
+/// before the machine is halted or the last lines are lost:
+///
+/// 1. The debug writer hands a single output buffer to the UART mux at a time
+///    and only refills it from the deferred call that completes the previous
+///    transmission, so back-to-back `debug!()` calls leave bytes in the debug
+///    ring buffer. Servicing the pending deferred calls drains it; each chip
+///    transmit is synchronous, so this terminates once the ring is empty.
+/// 2. The async `transmit_buffer` path only waits for `tx_full` to clear before
+///    each write, so the last bytes are still in the UART's hardware FIFO when
+///    it returns. `transmit_sync` additionally waits on `transmission_done`;
+///    calling it with an empty slice waits without emitting anything.
+unsafe fn sim_finish() -> ! {
+    while kernel::deferred_call::DeferredCall::has_tasks() {
+        let _ = kernel::deferred_call::DeferredCall::service_next_pending();
+    }
+    shakti_c::uart::Uart::new(shakti_c::uart::UART0_BASE).transmit_sync(&[]);
+
+    core::ptr::write_volatile(SIM_FINISH, 1);
+    loop {
+        core::hint::spin_loop();
+    }
+}
+
+// --- SimControl syscall driver (timestamps + sim exit) ------------------------
+
+/// Board-local driver used to expose the CLINT time around the alarm and to end
+/// the sim. Command 2 captures `t_before` (when the app arms the alarm, just
+/// before it yields); command 1 captures `t_after` (when the fired upcall has
+/// resumed the app) and prints the elapsed delta + the Stage-5 pass marker.
+struct SimControl {
+    timer: &'static ShaktiCClint<'static>,
+    t_before: Cell<u64>,
+}
+
+impl SyscallDriver for SimControl {
+    fn command(&self, command_num: usize, _r2: usize, _r3: usize, _id: ProcessId) -> CommandReturn {
+        match command_num {
+            0 => CommandReturn::success(),
+            2 => {
+                // t_before: the app has armed the alarm and is about to yield.
+                let t = self.timer.now().into_u64();
+                self.t_before.set(t);
+                debug!("t_before  mtime={:#018x}", t);
+                CommandReturn::success()
+            }
+            1 => {
+                // t_after: the fired upcall has resumed the app after the delay.
+                let t = self.timer.now().into_u64();
+                let dt = t.wrapping_sub(self.t_before.get());
+                debug!("process resumed after alarm-fired upcall");
+                debug!("t_after   mtime={:#018x}", t);
+                debug!("elapsed ticks (10 MHz) = {:#018x}", dt);
+                debug!("*** STAGE 5 PASS ***");
+                unsafe { sim_finish() };
+            }
+            _ => CommandReturn::failure(kernel::ErrorCode::NOSUPPORT),
+        }
+    }
+
+    fn allocate_grant(&self, _process_id: ProcessId) -> Result<(), kernel::process::Error> {
+        Ok(())
+    }
+}
+
+// --- Board / KernelResources --------------------------------------------------
+
+struct ShaktiCSim {
+    scheduler: &'static SchedulerInUse,
+    alarm: &'static AlarmDriverInUse,
+    simctl: &'static SimControl,
+}
+
+impl SyscallDriverLookup for ShaktiCSim {
+    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    where
+        F: FnOnce(Option<&dyn SyscallDriver>) -> R,
+    {
+        match driver_num {
+            capsules_core::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            SIMCTL_DRIVER_NUM => f(Some(self.simctl)),
+            _ => f(None),
+        }
+    }
+}
+
+impl KernelResources<ShaktiCChip> for ShaktiCSim {
+    type SyscallDriverLookup = Self;
+    type SyscallFilter = ();
+    type ProcessFault = ();
+    type Scheduler = SchedulerInUse;
+    type SchedulerTimer = ();
+    type WatchDog = ();
+    type ContextSwitchCallback = ();
+
+    fn syscall_driver_lookup(&self) -> &Self::SyscallDriverLookup {
+        self
+    }
+    fn syscall_filter(&self) -> &Self::SyscallFilter {
+        &()
+    }
+    fn process_fault(&self) -> &Self::ProcessFault {
+        &()
+    }
+    fn scheduler(&self) -> &Self::Scheduler {
+        self.scheduler
+    }
+    fn scheduler_timer(&self) -> &Self::SchedulerTimer {
+        &()
+    }
+    fn watchdog(&self) -> &Self::WatchDog {
+        &()
+    }
+    fn context_switch_callback(&self) -> &Self::ContextSwitchCallback {
+        &()
+    }
+}
+
+/// Entry point, reached from the RV64 startup assembly once RAM is initialized.
+///
+/// # Safety
+/// Accesses memory-mapped registers and CSRs, and performs one-time static init.
+#[no_mangle]
+pub unsafe fn main() {
+    use rv64i::csr;
+
+    // Point mtvec at _start_trap and mark mscratch = 0 (kernel mode).
+    rv64i::configure_trap_handler();
+
+    // Deferred calls may be created during bring-up (the virtual-alarm layer can
+    // use one for already-expired alarms); init the state first.
+    kernel::deferred_call::initialize_deferred_call_state::<rv64i::thread_id::RiscvThreadIdProvider>(
+    );
+
+    let _ = PANIC_RESOURCES
+        .bind_to_thread::<<ShaktiCChip as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        );
+
+    let uart0 = static_init!(
+        shakti_c::uart::Uart,
+        shakti_c::uart::Uart::new(shakti_c::uart::UART0_BASE)
+    );
+    kernel::deferred_call::DeferredCallClient::register(uart0);
+
+    let uart_mux = components::console::UartMuxComponent::new(uart0, 115200)
+        .finalize(components::uart_mux_component_static!());
+
+    components::debug_writer::DebugWriterComponent::new::<
+        <ShaktiCChip as kernel::platform::chip::Chip>::ThreadIdProvider,
+    >(
+        uart_mux,
+        create_capability!(capabilities::SetDebugWriterCapability),
+    )
+    .finalize(components::debug_writer_component_static!());
+
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
+    PANIC_RESOURCES
+        .get()
+        .map(|r| r.printer.put(process_printer));
+
+    debug!("=== Tock OS on SHAKTI C-Class (RV64IMAC) ===");
+    debug!("[shakti_c_sim] real TBF process, time-based syscall via Alarm");
+
+    // Core kernel + process array.
+    let processes = components::process_array::ProcessArrayComponent::new()
+        .finalize(components::process_array_component_static!(NUM_PROCS));
+    PANIC_RESOURCES
+        .get()
+        .map(|r| r.processes.put(processes.as_slice()));
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
+
+    // The 64-bit CLINT timer, shared by the chip (for service_pending_interrupts)
+    // and the alarm mux.
+    let timer = static_init!(
+        ShaktiCClint,
+        ShaktiCClint::new(&shakti_c::clint::CLINT_BASE)
+    );
+    let chip = static_init!(ShaktiCChip, ShaktiC::new(timer));
+    PANIC_RESOURCES.get().map(|r| r.chip.put(chip));
+
+    // Alarm stack: MuxAlarm over the CLINT, a user VirtualMuxAlarm, and the
+    // AlarmDriver (driver 0).
+    let mux_alarm = static_init!(MuxAlarm<ShaktiCClint>, MuxAlarm::new(timer));
+    Alarm::set_alarm_client(timer, mux_alarm);
+
+    let virtual_alarm_user = static_init!(
+        VirtualMuxAlarm<ShaktiCClint>,
+        VirtualMuxAlarm::new(mux_alarm)
+    );
+    virtual_alarm_user.setup();
+
+    let memory_allocation_cap = create_capability!(capabilities::MemoryAllocationCapability);
+    let alarm = static_init!(
+        AlarmDriverInUse,
+        capsules_core::alarm::AlarmDriver::new(
+            virtual_alarm_user,
+            board_kernel.create_grant(capsules_core::alarm::DRIVER_NUM, &memory_allocation_cap)
+        )
+    );
+    Alarm::set_alarm_client(virtual_alarm_user, alarm);
+
+    let simctl = static_init!(
+        SimControl,
+        SimControl {
+            timer,
+            t_before: Cell::new(0),
+        }
+    );
+
+    // Linker symbols bracketing the app flash region (TBF spliced at _sapps =
+    // 0x80100000) and the RAM available for app memory.
+    extern "C" {
+        static _sapps: u8;
+        static _eapps: u8;
+        static mut _sappmem: u8;
+        static _eappmem: u8;
+    }
+
+    let process_mgmt_cap = create_capability!(capabilities::ProcessManagementCapability);
+
+    // Load the TBF app image through the standard process loader.
+    debug!(
+        "calling load_processes from _sapps={:#018x}",
+        core::ptr::addr_of!(_sapps) as u64
+    );
+
+    let load_result = kernel::process::load_processes(
+        board_kernel,
+        chip,
+        core::slice::from_raw_parts(
+            core::ptr::addr_of!(_sapps),
+            core::ptr::addr_of!(_eapps) as usize - core::ptr::addr_of!(_sapps) as usize,
+        ),
+        core::slice::from_raw_parts_mut(
+            core::ptr::addr_of_mut!(_sappmem),
+            core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
+        ),
+        &FAULT_RESPONSE,
+        &process_mgmt_cap,
+    );
+
+    match load_result {
+        Ok(()) => debug!("load_processes Ok"),
+        Err(e) => {
+            debug!("FAIL: load_processes returned Err (TBF rejected): {:?}", e);
+            sim_finish();
+        }
+    }
+
+    let mut found = 0usize;
+    board_kernel.process_each_capability(&process_mgmt_cap, |_p| found += 1);
+    debug!("processes loaded = {}", found);
+    if found == 0 {
+        debug!("FAIL: no process in any slot");
+        sim_finish();
+    }
+
+    // Enable machine-timer interrupts and enter the kernel loop.
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(processes)
+        .finalize(components::round_robin_component_static!(NUM_PROCS));
+    let board = ShaktiCSim {
+        scheduler,
+        alarm,
+        simctl,
+    };
+
+    // Enable the machine-timer interrupt source + global machine interrupts so
+    // the CLINT alarm can wake the kernel from `wfi` (as during timer bring-up).
+    csr::CSR.mie.modify(csr::mie::mie::mtimer::SET);
+    csr::CSR.mstatus.modify(csr::mstatus::mstatus::mie::SET);
+
+    debug!("alarm wired (driver 0); mtimer IRQ enabled; entering kernel_loop");
+    let main_loop_cap = create_capability!(capabilities::MainLoopCapability);
+    board_kernel.kernel_loop(&board, chip, None::<&kernel::ipc::IPC<0>>, &main_loop_cap);
+}

--- a/chips/shakti_c/Cargo.toml
+++ b/chips/shakti_c/Cargo.toml
@@ -1,0 +1,16 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2026.
+
+[package]
+name = "shakti_c"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+
+[dependencies]
+rv64i = { path = "../../arch/rv64i" }
+kernel = { path = "../../kernel" }
+
+[lints]
+workspace = true

--- a/chips/shakti_c/README.md
+++ b/chips/shakti_c/README.md
@@ -1,0 +1,11 @@
+# SHAKTI C-Class Chip
+
+Chip crate for the open-source
+[SHAKTI C-Class](https://gitlab.com/shaktiproject/cores/c-class) (RV64IMAC) test
+SoC, targeting the Verilator simulation used by the `shakti_c_sim` board.
+
+Provides a 64-bit-access CLINT machine-timer / alarm driver (the SoC's CLINT
+mishandles 32-bit reads of the 64-bit `mtime`, so it is accessed as a single
+64-bit register), a polled UART driver, and chip setup and interrupt handling.
+
+Built on the shared `riscv` / `rv64i` architecture crates.

--- a/chips/shakti_c/src/chip.rs
+++ b/chips/shakti_c/src/chip.rs
@@ -1,0 +1,169 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+//! High-level setup and interrupt mapping for the SHAKTI C-Class test SoC.
+//!
+//! The simulation SoC has no external interrupt controller (the PLIC inputs are
+//! tied to zero), so the only interrupt source is the CLINT (machine timer and
+//! machine software). The trap handler therefore only ever has to service those.
+
+use core::fmt::Write;
+
+use kernel::platform::chip::Chip;
+use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
+
+use rv64i::csr::{mcause, mie::mie, mip::mip, CSR};
+use rv64i::pmp::{simple::SimplePMP, PMPUserMPU};
+
+use crate::clint;
+
+/// CLINT machine timer, clocked at the SoC's 10 MHz `timebase-frequency`.
+///
+/// This is the SHAKTI-specific 64-bit-access CLINT driver, not `sifive::clint`:
+/// the SHAKTI `mkclint_axi4` mis-handles 32-bit reads of the 64-bit `mtime`
+/// register (see [`crate::clint`]).
+pub type ShaktiCClint<'a> = crate::clint::Clint<'a>;
+
+/// The default peripherals available on the SHAKTI C-Class test SoC.
+pub struct ShaktiCDefaultPeripherals<'a> {
+    pub uart0: crate::uart::Uart<'a>,
+    pub timer: ShaktiCClint<'a>,
+}
+
+impl Default for ShaktiCDefaultPeripherals<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ShaktiCDefaultPeripherals<'_> {
+    pub fn new() -> Self {
+        Self {
+            uart0: crate::uart::Uart::new(crate::uart::UART0_BASE),
+            timer: ShaktiCClint::new(&clint::CLINT_BASE),
+        }
+    }
+
+    /// Register deferred-call clients. Must be called once the peripherals have
+    /// a `'static` lifetime.
+    pub fn init(&'static self) {
+        kernel::deferred_call::DeferredCallClient::register(&self.uart0);
+    }
+}
+
+pub struct ShaktiC<'a> {
+    userspace_kernel_boundary: rv64i::syscall::SysCall,
+    pmp: PMPUserMPU<2, SimplePMP<4>>,
+    timer: &'a ShaktiCClint<'a>,
+}
+
+impl<'a> ShaktiC<'a> {
+    /// # Safety
+    ///
+    /// Reads the number of implemented PMP entries from the hardware; must be
+    /// called on the SHAKTI C-Class (which implements 4 PMP entries).
+    pub unsafe fn new(timer: &'a ShaktiCClint<'a>) -> Self {
+        Self {
+            userspace_kernel_boundary: rv64i::syscall::SysCall::new(),
+            pmp: PMPUserMPU::new(SimplePMP::new().unwrap()),
+            timer,
+        }
+    }
+}
+
+impl Chip for ShaktiC<'_> {
+    type MPU = PMPUserMPU<2, SimplePMP<4>>;
+    type UserspaceKernelBoundary = rv64i::syscall::SysCall;
+    type ThreadIdProvider = rv64i::thread_id::RiscvThreadIdProvider;
+
+    fn mpu(&self) -> &Self::MPU {
+        &self.pmp
+    }
+
+    fn userspace_kernel_boundary(&self) -> &rv64i::syscall::SysCall {
+        &self.userspace_kernel_boundary
+    }
+
+    fn service_pending_interrupts(&self) {
+        loop {
+            let mip = CSR.mip.extract();
+
+            if mip.is_set(mip::mtimer) {
+                self.timer.handle_interrupt();
+            }
+
+            if !mip.any_matching_bits_set(mip::mtimer::SET) {
+                break;
+            }
+        }
+
+        // Re-enable the machine timer interrupt now that it has been serviced.
+        CSR.mie.modify(mie::mtimer::SET);
+    }
+
+    fn has_pending_interrupts(&self) -> bool {
+        CSR.mip.is_set(mip::mtimer)
+    }
+
+    fn sleep(&self) {
+        unsafe {
+            rv64i::support::wfi();
+        }
+    }
+
+    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        rv64i::support::with_interrupts_disabled(f)
+    }
+
+    unsafe fn print_state(_this: Option<&Self>, writer: &mut dyn Write) {
+        rv64i::print_riscv_state(writer);
+    }
+}
+
+fn handle_exception(exception: mcause::Exception) {
+    match exception {
+        mcause::Exception::UserEnvCall | mcause::Exception::SupervisorEnvCall => (),
+        _ => panic!("fatal exception"),
+    }
+}
+
+unsafe fn handle_interrupt(intr: mcause::Interrupt) {
+    match intr {
+        // Disable the source that fired; the kernel re-enables it after
+        // servicing in `service_pending_interrupts`.
+        mcause::Interrupt::MachineSoft => CSR.mie.modify(mie::msoft::CLEAR),
+        mcause::Interrupt::MachineTimer => CSR.mie.modify(mie::mtimer::CLEAR),
+        // No PLIC in this SoC, so no machine-external interrupts are expected;
+        // ignore any other (e.g. spurious lower-privilege) interrupt.
+        _ => {}
+    }
+}
+
+/// Trap handler for chip-specific code, called from the shared `riscv` trap
+/// assembly when an interrupt/exception occurs while the chip is in kernel mode.
+#[export_name = "_start_trap_rust_from_kernel"]
+pub unsafe extern "C" fn start_trap_rust() {
+    match mcause::Trap::from(CSR.mcause.extract()) {
+        mcause::Trap::Interrupt(interrupt) => handle_interrupt(interrupt),
+        mcause::Trap::Exception(exception) => handle_exception(exception),
+    }
+}
+
+/// Called if an interrupt occurs while an app was running. `mcause` is passed
+/// in; this disables the interrupt that fired so it does not immediately refire.
+#[export_name = "_disable_interrupt_trap_rust_from_app"]
+pub unsafe extern "C" fn disable_interrupt_trap_handler(mcause_val: usize) {
+    match mcause::Trap::from(mcause_val) {
+        mcause::Trap::Interrupt(interrupt) => handle_interrupt(interrupt),
+        _ => panic!("unexpected non-interrupt"),
+    }
+}
+
+/// Per-hart "trap handler active" tracking array required by the `riscv` crate.
+/// The SHAKTI C-Class test SoC runs a single hart (id 0).
+#[export_name = "_trap_handler_active"]
+static mut TRAP_HANDLER_ACTIVE: [usize; 1] = [0; 1];

--- a/chips/shakti_c/src/clint.rs
+++ b/chips/shakti_c/src/clint.rs
@@ -1,0 +1,123 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+//! 64-bit CLINT (core-local interruptor) machine-timer driver for the SHAKTI
+//! C-Class SoC.
+//!
+//! The SHAKTI `clint@2000000` is *almost* `riscv,clint0`-compatible, but its
+//! `mkclint_axi4` does **not** honour the intra-register byte offset for
+//! sub-64-bit reads of the `mtime` / `mtimecmp` region: the address shift in the
+//! read path is commented out in RTL (`devices/clint/clint.bsv`), so a 32-bit
+//! read of `mtime+4` (`0xBFFC`) returns `mtime[31:0]` — the *low* word — instead
+//! of `mtime[63:32]`. The reusable `sifive::clint` driver assembles the 64-bit
+//! counter from two separate 32-bit reads, so on this SoC it computes a corrupt
+//! `now()` (high word mirrors the low word) and any alarm it programs is
+//! unreachable.
+//!
+//! This driver instead accesses `mtime` and `mtimecmp` as single **64-bit**
+//! (`ld`/`sd`) operations, which the SHAKTI CLINT services correctly (a 64-bit
+//! access returns/sets the full counter).
+
+use kernel::hil::time::{self, Alarm, Freq10MHz, Ticks, Ticks64, Time};
+use kernel::utilities::cells::OptionalCell;
+use kernel::utilities::registers::interfaces::{Readable, Writeable};
+use kernel::utilities::registers::{register_structs, ReadWrite};
+use kernel::utilities::StaticRef;
+use kernel::ErrorCode;
+
+register_structs! {
+    pub ClintRegisters {
+        /// Machine-software-interrupt-pending (hart 0). Writing 1 raises a
+        /// machine software interrupt; writing 0 clears it.
+        (0x0000 => msip: ReadWrite<u32>),
+        (0x0004 => _reserved0),
+        /// Machine time-compare (hart 0). The machine timer interrupt is pending
+        /// while `mtime >= mtimecmp`. Accessed as a single 64-bit register.
+        (0x4000 => mtimecmp: ReadWrite<u64>),
+        (0x4008 => _reserved1),
+        /// Free-running machine time counter. Accessed as a single 64-bit
+        /// register (a 32-bit read of `0xBFFC` does not return the high word on
+        /// this SoC; see the module docs).
+        (0xBFF8 => mtime: ReadWrite<u64>),
+        (0xC000 => @END),
+    }
+}
+
+pub const CLINT_BASE: StaticRef<ClintRegisters> =
+    unsafe { StaticRef::new(0x0200_0000 as *const ClintRegisters) };
+
+/// SHAKTI C-Class CLINT machine timer / alarm, clocked at the SoC's 10 MHz
+/// `timebase-frequency`.
+pub struct Clint<'a> {
+    registers: StaticRef<ClintRegisters>,
+    client: OptionalCell<&'a dyn time::AlarmClient>,
+}
+
+impl Clint<'_> {
+    pub fn new(base: &StaticRef<ClintRegisters>) -> Self {
+        Self {
+            registers: *base,
+            client: OptionalCell::empty(),
+        }
+    }
+
+    /// Service a machine timer interrupt: disarm the comparator (so it does not
+    /// immediately re-fire) and notify the alarm client.
+    pub fn handle_interrupt(&self) {
+        self.disable_timer();
+        self.client.map(|client| client.alarm());
+    }
+
+    /// Disarm the comparator by setting it to its maximum value.
+    fn disable_timer(&self) {
+        self.registers.mtimecmp.set(u64::MAX);
+    }
+}
+
+impl Time for Clint<'_> {
+    type Frequency = Freq10MHz;
+    type Ticks = Ticks64;
+
+    fn now(&self) -> Ticks64 {
+        // Single 64-bit read: atomic, so unlike the 32-bit-halves path there is
+        // no low/high tearing to compensate for.
+        Ticks64::from(self.registers.mtime.get())
+    }
+}
+
+impl<'a> Alarm<'a> for Clint<'a> {
+    fn set_alarm_client(&self, client: &'a dyn time::AlarmClient) {
+        self.client.set(client);
+    }
+
+    fn set_alarm(&self, reference: Ticks64, dt: Ticks64) {
+        let now = self.now();
+        let mut expire = reference.wrapping_add(dt);
+        if !now.within_range(reference, expire) {
+            // The requested expiration is already in the past; fire ASAP.
+            expire = now;
+        }
+        // Single 64-bit write: atomic, so there is no spurious early fire while
+        // the comparator is half-updated (the reason the 32-bit-halves driver
+        // needs its two-step compare_low/high write dance).
+        self.registers.mtimecmp.set(expire.into_u64());
+    }
+
+    fn get_alarm(&self) -> Ticks64 {
+        Ticks64::from(self.registers.mtimecmp.get())
+    }
+
+    fn disarm(&self) -> Result<(), ErrorCode> {
+        self.disable_timer();
+        Ok(())
+    }
+
+    fn is_armed(&self) -> bool {
+        self.registers.mtimecmp.get() != u64::MAX
+    }
+
+    fn minimum_dt(&self) -> Ticks64 {
+        Ticks64::from(1u64)
+    }
+}

--- a/chips/shakti_c/src/lib.rs
+++ b/chips/shakti_c/src/lib.rs
@@ -1,0 +1,23 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+//! Chip support for the SHAKTI C-Class (RV64) test SoC.
+//!
+//! Targets the open-source SHAKTI C-Class core (IIT Madras) test SoC
+//! as simulated under Verilator. Memory map (from the
+//! the bare-metal bring-up path):
+//!
+//! - RAM   `0x8000_0000` (2 GiB)
+//! - CLINT `0x0200_0000` (SiFive-*like*, but needs 64-bit `mtime` accesses; see [`clint`])
+//! - UART  `0x0001_1300` (custom SHAKTI UART; see [`uart`])
+//!
+//! The test SoC ties the PLIC `meip`/`seip` inputs to zero, so there is no
+//! external interrupt controller: peripherals are polled and only the CLINT
+//! (machine timer / software) interrupts are used.
+
+#![no_std]
+
+pub mod chip;
+pub mod clint;
+pub mod uart;

--- a/chips/shakti_c/src/uart.rs
+++ b/chips/shakti_c/src/uart.rs
@@ -1,0 +1,195 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+//! UART driver for the SHAKTI C-Class test SoC.
+//!
+//! The SHAKTI test-SoC UART (`mkuart_axi4`, MMIO base `0x0001_1300`) has no
+//! interrupt line wired in the simulation SoC (the PLIC `meip`/`seip` inputs are
+//! tied to zero), so this driver is fully **polled**. Transmit completion is
+//! signalled to the client from a [`DeferredCall`].
+//!
+//! The register layout and the transmit handshake are taken from the proven
+//! the bare-metal bring-up path: poll the status
+//! register at offset `0xC` and wait while `tx_full` (bit 1) is set, then write
+//! the byte to the TX register at offset `0x4`.
+
+use core::cell::Cell;
+
+use kernel::deferred_call::{DeferredCall, DeferredCallClient};
+use kernel::hil;
+use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::utilities::registers::interfaces::{Readable, Writeable};
+use kernel::utilities::registers::{register_bitfields, register_structs, ReadOnly, ReadWrite};
+use kernel::utilities::StaticRef;
+use kernel::ErrorCode;
+
+pub const UART0_BASE: StaticRef<ShaktiUartRegisters> =
+    unsafe { StaticRef::new(0x0001_1300 as *const ShaktiUartRegisters) };
+
+register_structs! {
+    pub ShaktiUartRegisters {
+        /// Baud divisor.
+        (0x00 => baud: ReadWrite<u16>),
+        (0x02 => _reserved0),
+        /// Transmit byte: writing a byte here enqueues it for transmission.
+        (0x04 => tx: ReadWrite<u8>),
+        (0x05 => _reserved1),
+        /// Receive byte.
+        (0x08 => rx: ReadOnly<u8>),
+        (0x09 => _reserved2),
+        /// Status register (see [`status`]).
+        (0x0C => status: ReadOnly<u16, status::Register>),
+        (0x0E => _reserved3),
+        (0x10 => @END),
+    }
+}
+
+register_bitfields![u16,
+    status [
+        /// Set when the transmitter has fully drained (no byte in flight).
+        /// Validated against the the bare-metal bring-up `exit()` drain.
+        transmission_done OFFSET(0) NUMBITS(1) [],
+        /// TX FIFO full: while set, the TX register cannot accept a new byte.
+        /// Validated against the the bare-metal bring-up hello.
+        tx_full OFFSET(1) NUMBITS(1) [],
+        /// RX data available. NOTE: tentative — the SoC UART's exact RX status
+        /// bit was not exercised by the bare-metal bring-up; validate before relying on RX.
+        rx_not_empty OFFSET(3) NUMBITS(1) [],
+    ],
+];
+
+pub struct Uart<'a> {
+    registers: StaticRef<ShaktiUartRegisters>,
+    tx_client: OptionalCell<&'a dyn hil::uart::TransmitClient>,
+    rx_client: OptionalCell<&'a dyn hil::uart::ReceiveClient>,
+    tx_buffer: TakeCell<'static, [u8]>,
+    tx_len: Cell<usize>,
+    rx_buffer: TakeCell<'static, [u8]>,
+    rx_len: Cell<usize>,
+    deferred_call: DeferredCall,
+}
+
+impl<'a> Uart<'a> {
+    pub fn new(base: StaticRef<ShaktiUartRegisters>) -> Uart<'a> {
+        Uart {
+            registers: base,
+            tx_client: OptionalCell::empty(),
+            rx_client: OptionalCell::empty(),
+            tx_buffer: TakeCell::empty(),
+            tx_len: Cell::new(0),
+            rx_buffer: TakeCell::empty(),
+            rx_len: Cell::new(0),
+            deferred_call: DeferredCall::new(),
+        }
+    }
+
+    /// Blocking single-byte transmit using the proven status handshake.
+    fn send_byte(&self, byte: u8) {
+        while self.registers.status.is_set(status::tx_full) {}
+        self.registers.tx.set(byte);
+    }
+
+    /// Blocking transmit of a slice. Used for panic / synchronous debug output.
+    pub fn transmit_sync(&self, bytes: &[u8]) {
+        for &b in bytes {
+            self.send_byte(b);
+        }
+        // Wait for the last byte to fully serialize (status.transmission_done,
+        // bit 0) so callers that immediately stop the machine don't truncate it.
+        while !self.registers.status.is_set(status::transmission_done) {}
+    }
+}
+
+impl DeferredCallClient for Uart<'_> {
+    fn register(&'static self) {
+        self.deferred_call.register(self);
+    }
+
+    fn handle_deferred_call(&self) {
+        // The whole TX buffer is written synchronously in `transmit_buffer`, so
+        // here we simply return it to the client, off the original call stack.
+        if let Some(buffer) = self.tx_buffer.take() {
+            let len = self.tx_len.get();
+            self.tx_client.map(|client| {
+                client.transmitted_buffer(buffer, len, Ok(()));
+            });
+        }
+    }
+}
+
+impl hil::uart::Configure for Uart<'_> {
+    fn configure(&self, _params: hil::uart::Parameters) -> Result<(), ErrorCode> {
+        // The Verilator testbench captures characters regardless of the divisor,
+        // so configuration is a no-op in simulation. The reset divisor is left
+        // in place. (A real board would program `baud` from the core clock.)
+        Ok(())
+    }
+}
+
+impl<'a> hil::uart::Transmit<'a> for Uart<'a> {
+    fn set_transmit_client(&self, client: &'a dyn hil::uart::TransmitClient) {
+        self.tx_client.set(client);
+    }
+
+    fn transmit_buffer(
+        &self,
+        tx_buffer: &'static mut [u8],
+        tx_len: usize,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+        if tx_len > tx_buffer.len() {
+            return Err((ErrorCode::SIZE, tx_buffer));
+        }
+        if self.tx_buffer.is_some() {
+            return Err((ErrorCode::BUSY, tx_buffer));
+        }
+
+        // Polled UART: write the whole buffer synchronously, then notify the
+        // client from a deferred call (no TX interrupt is available).
+        for &b in tx_buffer[..tx_len].iter() {
+            self.send_byte(b);
+        }
+        self.tx_len.set(tx_len);
+        self.tx_buffer.replace(tx_buffer);
+        self.deferred_call.set();
+        Ok(())
+    }
+
+    fn transmit_abort(&self) -> Result<(), ErrorCode> {
+        Err(ErrorCode::FAIL)
+    }
+
+    fn transmit_word(&self, _word: u32) -> Result<(), ErrorCode> {
+        Err(ErrorCode::FAIL)
+    }
+}
+
+impl<'a> hil::uart::Receive<'a> for Uart<'a> {
+    fn set_receive_client(&self, client: &'a dyn hil::uart::ReceiveClient) {
+        self.rx_client.set(client);
+    }
+
+    fn receive_buffer(
+        &self,
+        rx_buffer: &'static mut [u8],
+        rx_len: usize,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+        // RX is not yet validated on this SoC UART (see module docs / the
+        // `rx_not_empty` status bit note). For now accept and hold the buffer;
+        // a later revision will poll the RX path once it is exercised in sim.
+        if rx_len > rx_buffer.len() {
+            return Err((ErrorCode::SIZE, rx_buffer));
+        }
+        self.rx_len.set(rx_len);
+        self.rx_buffer.replace(rx_buffer);
+        Ok(())
+    }
+
+    fn receive_abort(&self) -> Result<(), ErrorCode> {
+        Err(ErrorCode::FAIL)
+    }
+
+    fn receive_word(&self) -> Result<(), ErrorCode> {
+        Err(ErrorCode::FAIL)
+    }
+}


### PR DESCRIPTION
### Pull Request Overview

Follow-up to #4873 / #4878, per @bradjc's suggestion to open the userspace path as a separate PR. This adds a SHAKTI C-Class (RV64IMAC) Verilator-sim board that boots a real process and completes the full split-phase syscall round-trip on rv64, plus the thin chip crate it needs.

`chips/shakti_c` is an RV64 chip crate for the SHAKTI C-Class test SoC: a 64-bit-access CLINT machine-timer driver (the SoC's CLINT mishandles 32-bit reads of the 64-bit `mtime`, so this accesses it as a single 64-bit register), a polled UART, and the chip/interrupt wiring, built on the shared `riscv`/`rv64i` crates.

`boards/shakti_c_sim` boots one real TBF process under `kernel_loop` and has it perform a time-based syscall via the Alarm capsule (Subscribe -> Command(set-alarm) -> Yield), resumed by the machine-timer interrupt, exercising the rv64 userspace round-trip (switch_to_process -> mret-to-user -> ecall -> kernel -> UART) end-to-end.

Targets `dev/riscv-rv64i` and uses the shared `arch/rv64i` from that branch. Per the #4873 discussion, this is offered as an additional RV64 test vehicle alongside qemu_rv64_virt: it runs on the open-source SHAKTI C-Class core and exercises a real-core CLINT quirk qemu does not have.

### Testing Strategy

Runtime-proven end-to-end on the SHAKTI C-Class (RV64IMAC) under Verilator: boots the TBF process, completes subscribe/command/yield over an Alarm capsule with per-process PMP isolation, kernel + app linked at the 0x8000_0000 (2 GiB) base (rustc's riscv64 medany code model). `make prepush` passes.

### TODO or Help Wanted

Offered as an additional board per #4873; happy to adjust scope or fold pieces toward qemu_rv64_virt if maintainers prefer.

### Checklist

- [x] Ran `make prepush`.

### PR Contents

#### Documentation

- [x] No documentation updates are required.

#### AI Use

- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

This change was developed with the assistance of an AI coding assistant (Claude / Claude Code); I reviewed and tested the entire change and personally certify its contents.