### PR TITLE
kernel: add `symbol_defined_slice!()` macro to create slices from linker symbols

### DIFF
--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -95,25 +95,25 @@ pub unsafe fn main() {
 
     // These symbols are defined in the linker script.
     extern "C" {
-        /// Beginning of the ROM region containing app images.
-        static _sapps: u8;
-        /// End of the ROM region containing app images.
-        static _eapps: u8;
         /// Beginning of the RAM region for app memory.
         static mut _sappmem: u8;
         /// End of the RAM region for app memory.
         static _eappmem: u8;
     }
 
+    // SAFETY: The linker script ensures the symbols are valid and refer to a
+    // memory region entirely used to store TBFs. `_sapps` starts after the
+    // kernel text region and therefore is not null. We never create a mutable
+    // reference to the same memory region.
+    #[allow(unused_unsafe)]
+    let app_flash = unsafe { kernel::symbol_defined_slice!(_sapps, _eapps) };
+
     let process_management_capability =
         create_capability!(capabilities::ProcessManagementCapability);
     kernel::process::load_processes(
         board_kernel,
         chip,
-        core::slice::from_raw_parts(
-            core::ptr::addr_of!(_sapps),
-            core::ptr::addr_of!(_eapps) as usize - core::ptr::addr_of!(_sapps) as usize,
-        ),
+        app_flash,
         core::slice::from_raw_parts_mut(
             core::ptr::addr_of_mut!(_sappmem),
             core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,

--- a/kernel/src/utilities/helpers.rs
+++ b/kernel/src/utilities/helpers.rs
@@ -96,10 +96,11 @@ macro_rules! stack_size {
 
 /// Create a slice from memory defined by start and end linker symbols.
 ///
-/// This is designed to help get a slice for the region of flash used to store
-/// TBFs. The actual addresses of the region are determined by the linker and
-/// the linker script, and this macro encapsulates safely using linker symbols
-/// to create a Rust slice representing that memory region.
+/// This is designed to help convert linker-defined buffers, such
+/// as TBF ranges in flash, into native Rust types. Linker symbols
+/// are not expressable with the Rust type system, which makes
+/// converting linker symbols subtle, so we encapsulate this in a
+/// helper macro here.
 ///
 /// This macro ensures that the slice is only a `u8` slice, which ensures that
 /// every element in the slice is a valid `u8` (as a `u8` is always valid for

--- a/kernel/src/utilities/helpers.rs
+++ b/kernel/src/utilities/helpers.rs
@@ -94,6 +94,82 @@ macro_rules! stack_size {
     }
 }
 
+/// Create a slice from memory defined by start and end linker symbols.
+///
+/// This is designed to help get a slice for the region of flash used to store
+/// TBFs. The actual addresses of the region are determined by the linker and
+/// the linker script, and this macro encapsulates safely using linker symbols
+/// to create a Rust slice representing that memory region.
+///
+/// This macro ensures that the slice is only a `u8` slice, which ensures that
+/// every element in the slice is a valid `u8` (as a `u8` is always valid for
+/// any series of bits).
+///
+/// # Usage
+///
+/// ```rust
+/// // Get a slice over the region of flash containing TBFs.
+/// //
+/// // The `_sapps` and `_eapps` symbols are defined by the linker.
+/// //
+/// // SAFETY: The linker script ensures the symbols are valid and
+/// // refer to a memory region entirely used to store TBFs. `_sapps` starts
+/// // after the kernel text region and therefore is not null. We never
+/// // create a mutable reference to the same memory region.
+/// let app_flash = kernel::symbol_defined_slice!(_sapps, _eapps);
+/// ```
+///
+/// # Safety
+///
+/// - `$sym_start` and `$sym_end` must be linker-defined symbols with valid
+///   addresses.
+/// - `$sym_start` must not be at address 0 (null).
+/// - `$sym_start` must refer to a contiguous region of memory that is at least
+///   `addr!($sym_end) - addr!($sym_start)` bytes long and is within a single
+///   allocation.
+/// - The memory referenced by the returned slice must not be mutated.
+#[macro_export]
+macro_rules! symbol_defined_slice {
+    ($sym_start:ident, $sym_end:ident $(,)?) => {{
+        // Ensure this requires `unsafe`.
+        #[allow(unsafe_code)]
+
+        // SAFETY: The user of this macro must ensure these are both valid
+        // symbols defined by the linker.
+        unsafe extern "C" {
+            static $sym_start: u8;
+            static $sym_end: [u8; 0];
+        }
+
+        // Create a raw pointer at the address of the linker symbol.
+        let start = &raw const $sym_start;
+        // Get the raw pointer address as a usize to calculate the region
+        // length.
+        let start_address = start as usize;
+        // Get the address of the end by using a raw pointer to a zero-sized
+        // slice and then converting the pointer to a usize.
+        let end_address = &raw const $sym_end as usize;
+
+        // Compute the length. Handle the case if `$sym_start` is after
+        // `$sym_end`.
+        let length = end_address.saturating_sub(start_address);
+
+        // Create the slice from the region defined by the linker symbols.
+        //
+        // SAFETY: This meets the safety requirements because:
+        // - `start is non-null and valid for reads of `length` bytes because of
+        //   the macro-level requirement. `start` is aligned because we use
+        //   `u8`s.
+        // - There are `length` bytes of initialized values because `u8`s are
+        //   valid for any bits and the macro-level requirement ensures the
+        //   provided symbols represent a valid region of memory.
+        // - The memory is not mutated because of the macro-level requirement.
+        // - This does not exceed `isize::MAX` or wrap around because of the
+        //   `saturating_sub()` to calculate the length.
+        unsafe { core::slice::from_raw_parts(start, length) }
+    }};
+}
+
 /// Initialize all fields of a `MaybeUninit<T>` struct.
 ///
 /// Use this macro to guarantee that all fields in `T` are initialized.


### PR DESCRIPTION
### Pull Request Overview

Creating Rust slices from linker symbols is confusing for a couple reasons:

1. The `extern` block must ["ensure that the signatures are correct"](https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-extern.html). However, linker symbols don't really have types.
2. Linker symbols are variables, that can (but MUST NOT) be accessed directly. We actually want the address of the variables.
3. Creating a slice from memory addresses has a series of safety requirements.

The purpose of this macro is to encapsulate all of this complexity in one place, and then boards have specific safety requirements to meet that can be documented with an unsafe block. The macro also gives us a single place to document everything we need to to ensure using linker symbols is safe.

I just demonstrated this with a single board. We can expand this to more boards if we think this is a good direction.

### Testing Strategy

todo


### TODO or Help Wanted

- Do these safety requirements look correct?
- This is only for the const slice (eg for app TBFs). The mutable version is easy to create, but the safety requirements are a lot more difficult to meet since nothing else can read or write the same memory in the slice for the lifetime of the slice. So, I'm not sure what to do about that. This may not be useful without the matching `mut` version.


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

Claude wrote an early version of the macro, but I mostly rewrote it and documented it.
