### PR TITLE
chips: update already compatible chips to Rust 2024

### DIFF
--- a/chips/esp32/Cargo.toml
+++ b/chips/esp32/Cargo.toml
@@ -6,7 +6,7 @@
 name = "esp32"
 version.workspace = true
 authors.workspace = true
-edition.workspace = true
+edition = "2024"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/chips/lowrisc/Cargo.toml
+++ b/chips/lowrisc/Cargo.toml
@@ -6,7 +6,7 @@
 name = "lowrisc"
 version.workspace = true
 authors.workspace = true
-edition.workspace = true
+edition = "2024"
 
 [dependencies]
 rv32i = { path = "../../arch/rv32i" }

--- a/chips/lowrisc/src/spi_host.rs
+++ b/chips/lowrisc/src/spi_host.rs
@@ -242,7 +242,7 @@ impl SpiHost<'_> {
     //Determine if transfer complete or if we need to keep
     //writing from an offset.
     fn continue_transfer(&self) -> Result<SpiHostStatus, ErrorCode> {
-        let rc = self.rx_buf.take().map_or(
+        self.rx_buf.take().map_or(
             Err(ErrorCode::FAIL),
             |mut rx_buf| -> Result<SpiHostStatus, ErrorCode> {
                 let regs = self.registers;
@@ -281,9 +281,7 @@ impl SpiHost<'_> {
                     self.spi_transfer_progress()
                 }
             },
-        );
-
-        rc
+        )
     }
 
     /// Continue SPI transfer from offset point

--- a/chips/nrf5x-unsafe/Cargo.toml
+++ b/chips/nrf5x-unsafe/Cargo.toml
@@ -6,7 +6,7 @@
 name = "nrf5x-unsafe"
 version.workspace = true
 authors.workspace = true
-edition.workspace = true
+edition = "2024"
 
 [dependencies]
 cortexm4f = { path = "../../arch/cortex-m4f" }

--- a/chips/nrf5x/Cargo.toml
+++ b/chips/nrf5x/Cargo.toml
@@ -6,7 +6,7 @@
 name = "nrf5x"
 version.workspace = true
 authors.workspace = true
-edition.workspace = true
+edition = "2024"
 
 [dependencies]
 nrf5x-unsafe = { path = "../nrf5x-unsafe" }

--- a/chips/pci-x86/Cargo.toml
+++ b/chips/pci-x86/Cargo.toml
@@ -6,7 +6,7 @@
 name = "pci-x86"
 version.workspace = true
 authors.workspace = true
-edition.workspace = true
+edition = "2024"
 
 [dependencies]
 tock-registers.workspace = true

--- a/chips/segger/Cargo.toml
+++ b/chips/segger/Cargo.toml
@@ -6,7 +6,7 @@
 name = "segger"
 version.workspace = true
 authors.workspace = true
-edition.workspace = true
+edition = "2024"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/chips/sifive/Cargo.toml
+++ b/chips/sifive/Cargo.toml
@@ -6,7 +6,7 @@
 name = "sifive"
 version.workspace = true
 authors.workspace = true
-edition.workspace = true
+edition = "2024"
 
 [dependencies]
 rv32i = { path = "../../arch/rv32i" }


### PR DESCRIPTION


### Pull Request Overview

These are all already compatible with Rust 2024 and just updates the edition.

EDIT: There was one clippy lint issue in the lowrisc chip.

### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
