### PR TITLE
arch: riscv 64-bit: pmp: claude's fix

### DIFF
--- a/arch/riscv/src/pmp.rs
+++ b/arch/riscv/src/pmp.rs
@@ -2060,10 +2060,6 @@ pub mod kernel_protection {
 
                         pmpcfg
                     })
-                    .chain(core::iter::repeat_n(
-                        TORUserPMPCFG::OFF,
-                        AVAILABLE_ENTRIES - (MPU_REGIONS * 2),
-                    ))
                     .map(TORUserPMPCFG::get_reg),
             );
 


### PR DESCRIPTION


### Pull Request Overview

PR #4874 fails litex CI. I asked Claude and this was its suggested fix.

This is Claude's analysis:

> What changed: The old (pre-commit) code only ever wrote pmpcfg octets for the MPU_REGIONS * 2 user-region physical PMP entries (indices 0..MPU_REGIONS*2) — it never touched anything beyond that. The new code pads the write-back iterator with TORUserPMPCFG::OFF all the way up to AVAILABLE_ENTRIES, so configure_pmp now unconditionally writes OFF into every entry from MPU_REGIONS*2 through AVAILABLE_ENTRIES - 1 — which includes the kernel-protection region block (n-7 .. n-1) that KernelProtectionPMP::new() sets up and is documented as "never modified" (see the comment at pmp.rs:1998-2001).
>
> Why it breaks specifically on RV32: KernelProtectionPMP is the implementation used by litex/arty (a vexriscv/RV32 board — chips/litex_vexriscv/src/chip.rs:29 instantiates KernelProtectionPMP<16> with MPU_REGIONS = 4). Most of the 7 kernel-protection entries (.text, flash, RAM, MMIO, deny-all-machine) have the lock bit set, so hardware silently ignores writes to them — those survive. But entry n-7 (index 9 with AVAILABLE_ENTRIES=16) is the user-mode "deny-all" rule, deliberately left unlocked (l::CLEAR, pmp.rs:2002-2012) so the hardware actually accepts the write. Since MPU_REGIONS*2 = 8 <= 9, this entry falls inside the padding range and gets clobbered to OFF on every single call to configure_pmp — which happens routinely (e.g. on process context switches). That disables the fallback rule that's supposed to prohibit user-mode access to anything not explicitly granted, silently weakening the kernel/user memory isolation on that board.
>
> The fix is to not pad KernelProtectionPMP::configure_pmp's write-back beyond MPU_REGIONS * 2 entries (i.e. drop that .chain(...), matching the old behavior) — the fixed kernel-protection region indices must never be touched by configure_pmp.


### Testing Strategy

CI


### TODO or Help Wanted

@lschuermann 


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

This was entirely done by Claude.
