### PR TITLE
Update Rust to Nightly 2026-07

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
     "editor.defaultFormatter": "rust-lang.rust-analyzer",
     "editor.formatOnSave": true,
     "rust-analyzer.server.extraEnv": {
-        "RUSTUP_TOOLCHAIN": "nightly-2026-04-21"
+        "RUSTUP_TOOLCHAIN": "nightly-2026-07-21"
     },
     "rust-analyzer.check.allTargets": false,
 }

--- a/arch/x86/src/registers/bits32/paging.rs
+++ b/arch/x86/src/registers/bits32/paging.rs
@@ -206,8 +206,8 @@ impl PDEntry {
             ADDRESS_MASK
         };
         let pt_val = pt & mask;
-        assert!(pt_val == pt.into());
-        assert!(pt % BASE_PAGE_SIZE == 0);
+        assert_eq!(pt_val, pt.into());
+        assert_eq!(pt % BASE_PAGE_SIZE, 0);
         PDEntry(pt_val | flags.get())
     }
 
@@ -246,8 +246,8 @@ impl PTEntry {
     ///  * `flags`- Additional flags for the entry.
     pub fn new(page: PAddr, flags: LocalRegisterCopy<u32, PTFLAGS::Register>) -> PTEntry {
         let page_val = page & ADDRESS_MASK;
-        assert!(page_val == page.into());
-        assert!(page % BASE_PAGE_SIZE == 0);
+        assert_eq!(page_val, page.into());
+        assert_eq!(page % BASE_PAGE_SIZE, 0);
         PTEntry(page_val | flags.get())
     }
 

--- a/boards/components/src/adc.rs
+++ b/boards/components/src/adc.rs
@@ -14,16 +14,12 @@ use kernel::hil::adc;
 
 #[macro_export]
 macro_rules! adc_mux_component_static {
-    ($A:ty $(,)?) => {{
-        kernel::static_buf!(capsules_core::virtualizers::virtual_adc::MuxAdc<'static, $A>)
-    };};
+    ($A:ty $(,)?) => {{ kernel::static_buf!(capsules_core::virtualizers::virtual_adc::MuxAdc<'static, $A>) }};
 }
 
 #[macro_export]
 macro_rules! adc_component_static {
-    ($A:ty $(,)?) => {{
-        kernel::static_buf!(capsules_core::virtualizers::virtual_adc::AdcDevice<'static, $A>)
-    };};
+    ($A:ty $(,)?) => {{ kernel::static_buf!(capsules_core::virtualizers::virtual_adc::AdcDevice<'static, $A>) }};
 }
 
 #[macro_export]
@@ -41,7 +37,7 @@ macro_rules! adc_syscall_component_helper {
         );
         let adc_virtualized = kernel::static_buf!(capsules_core::adc::AdcVirtualized<'static>);
         (adc_virtualized, drivers)
-    };};
+    }};
 }
 
 #[macro_export]
@@ -53,7 +49,7 @@ macro_rules! adc_dedicated_component_static {
         let buffer3 = kernel::static_buf!([u16; capsules_core::adc::BUF_LEN]);
 
         (adc, buffer1, buffer2, buffer3)
-    };};
+    }};
 }
 
 pub struct AdcMuxComponent<A: 'static + adc::Adc<'static>> {

--- a/boards/components/src/adc_microphone.rs
+++ b/boards/components/src/adc_microphone.rs
@@ -46,7 +46,7 @@ macro_rules! adc_microphone_component_static {
             kernel::static_buf!(capsules_extra::adc_microphone::AdcMicrophone<'static, $P>);
 
         (adc_device, buffer, adc_microphone)
-    };};
+    }};
 }
 
 pub struct AdcMicrophoneComponent<

--- a/boards/components/src/aes.rs
+++ b/boards/components/src/aes.rs
@@ -38,9 +38,7 @@ const CRYPT_SIZE: usize = 7 * hil::symmetric_encryption::AES_BLOCK_SIZE;
 
 #[macro_export]
 macro_rules! aes_mux_component_static {
-    ($A:ty $(,)?) => {{
-        kernel::static_buf!(capsules_core::virtualizers::virtual_aes_ccm::MuxAES128CCM<'static, $A>)
-    };};
+    ($A:ty $(,)?) => {{ kernel::static_buf!(capsules_core::virtualizers::virtual_aes_ccm::MuxAES128CCM<'static, $A>) }};
 }
 
 pub type AesMuxComponentType<A> =
@@ -85,7 +83,7 @@ macro_rules! aes_virtual_component_static {
         let crypt_buf = kernel::static_buf!([u8; CRYPT_SIZE]);
 
         (virtual_aes, crypt_buf)
-    };};
+    }};
 }
 
 #[macro_export]
@@ -99,7 +97,7 @@ macro_rules! aes_driver_component_static {
         );
 
         (aes_driver, aes_src_buffer, aes_dst_buffer)
-    };};
+    }};
 }
 
 pub struct AesVirtualComponent<A: 'static + AES<'static, AES128> + AESCtr + AESCBC + AESECB> {

--- a/boards/components/src/air_quality.rs
+++ b/boards/components/src/air_quality.rs
@@ -19,9 +19,7 @@ use kernel::hil;
 
 #[macro_export]
 macro_rules! air_quality_component_static {
-    () => {{
-        kernel::static_buf!(capsules_extra::air_quality::AirQualitySensor<'static>)
-    };};
+    () => {{ kernel::static_buf!(capsules_extra::air_quality::AirQualitySensor<'static>) }};
 }
 
 pub struct AirQualityComponent<

--- a/boards/components/src/alarm.rs
+++ b/boards/components/src/alarm.rs
@@ -33,9 +33,7 @@ use kernel::hil::time::{self, Alarm};
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! alarm_mux_component_static {
-    ($A:ty $(,)?) => {{
-        kernel::static_buf!(capsules_core::virtualizers::virtual_alarm::MuxAlarm<'static, $A>)
-    };};
+    ($A:ty $(,)?) => {{ kernel::static_buf!(capsules_core::virtualizers::virtual_alarm::MuxAlarm<'static, $A>) }};
 }
 
 // Setup static space for the objects.
@@ -53,7 +51,7 @@ macro_rules! alarm_component_static {
         );
 
         (mux_alarm, alarm_driver)
-    };};
+    }};
 }
 
 pub type AlarmDriverComponentType<A> = capsules_core::alarm::AlarmDriver<

--- a/boards/components/src/analog_comparator.rs
+++ b/boards/components/src/analog_comparator.rs
@@ -41,14 +41,12 @@ macro_rules! analog_comparator_component_helper {
                 $(static_init!($Channel, $P),)*
             ]
         )
-    };};
+    }};
 }
 
 #[macro_export]
 macro_rules! analog_comparator_component_static {
-    ($AC:ty $(,)?) => {{
-        kernel::static_buf!(capsules_extra::analog_comparator::AnalogComparator<'static, $AC>)
-    };};
+    ($AC:ty $(,)?) => {{ kernel::static_buf!(capsules_extra::analog_comparator::AnalogComparator<'static, $AC>) }};
 }
 
 pub type AnalogComparatorComponentType<AC> = AnalogComparator<'static, AC>;

--- a/boards/components/src/apds9960.rs
+++ b/boards/components/src/apds9960.rs
@@ -25,7 +25,7 @@ macro_rules! apds9960_component_static {
         let buffer = kernel::static_buf!([u8; capsules_extra::apds9960::BUF_LEN]);
 
         (i2c_device, apds9960, buffer)
-    };};
+    }};
 }
 
 pub struct Apds9960Component<I: 'static + i2c::I2CMaster<'static>> {

--- a/boards/components/src/app_flash_driver.rs
+++ b/boards/components/src/app_flash_driver.rs
@@ -33,7 +33,7 @@ macro_rules! app_flash_component_static {
         );
         let app_flash = kernel::static_buf!(capsules_extra::app_flash_driver::AppFlash<'static>);
         (buffer, page_buffer, nv_to_page, app_flash)
-    };};
+    }};
 }
 
 pub type AppFlashComponentType = capsules_extra::app_flash_driver::AppFlash<'static>;

--- a/boards/components/src/app_loader.rs
+++ b/boards/components/src/app_loader.rs
@@ -45,7 +45,7 @@ macro_rules! app_loader_component_static {
         let buffer = kernel::static_buf!([u8; capsules_extra::app_loader::BUF_LEN]);
 
         (al, buffer)
-    };};
+    }};
 }
 
 pub struct AppLoaderComponent<

--- a/boards/components/src/appid/assigner_name.rs
+++ b/boards/components/src/appid/assigner_name.rs
@@ -13,7 +13,7 @@ macro_rules! appid_assigner_names_component_static {
         kernel::static_buf!(
             capsules_system::process_checker::basic::AppIdAssignerNames<fn(&'static str) -> u32>
         )
-    };};
+    }};
 }
 
 pub struct AppIdAssignerNamesComponent {}

--- a/boards/components/src/appid/assigner_tbf.rs
+++ b/boards/components/src/appid/assigner_tbf.rs
@@ -9,9 +9,7 @@ use kernel::component::Component;
 
 #[macro_export]
 macro_rules! appid_assigner_tbf_header_component_static {
-    () => {{
-        kernel::static_buf!(capsules_system::process_checker::tbf::AppIdAssignerTbfHeader)
-    };};
+    () => {{ kernel::static_buf!(capsules_system::process_checker::tbf::AppIdAssignerTbfHeader) }};
 }
 
 pub struct AppIdAssignerTbfHeaderComponent {}

--- a/boards/components/src/appid/checker.rs
+++ b/boards/components/src/appid/checker.rs
@@ -9,9 +9,7 @@ use kernel::component::Component;
 
 #[macro_export]
 macro_rules! process_checker_machine_component_static {
-    () => {{
-        kernel::static_buf!(kernel::process::ProcessCheckerMachine)
-    };};
+    () => {{ kernel::static_buf!(kernel::process::ProcessCheckerMachine) }};
 }
 
 pub type ProcessCheckerMachineComponentType = kernel::process::ProcessCheckerMachine;

--- a/boards/components/src/appid/checker_null.rs
+++ b/boards/components/src/appid/checker_null.rs
@@ -10,9 +10,7 @@ use kernel::component::Component;
 
 #[macro_export]
 macro_rules! app_checker_null_component_static {
-    () => {{
-        kernel::static_buf!(capsules_system::process_checker::basic::AppCheckerNull)
-    };};
+    () => {{ kernel::static_buf!(capsules_system::process_checker::basic::AppCheckerNull) }};
 }
 
 pub type AppCheckerNullComponentType = capsules_system::process_checker::basic::AppCheckerNull;

--- a/boards/components/src/appid/checker_sha.rs
+++ b/boards/components/src/appid/checker_sha.rs
@@ -16,7 +16,7 @@ macro_rules! app_checker_sha256_component_static {
             kernel::static_buf!(capsules_system::process_checker::basic::AppCheckerSha256);
 
         (checker, buffer)
-    };};
+    }};
 }
 
 pub type AppCheckerSha256ComponentType = capsules_system::process_checker::basic::AppCheckerSha256;

--- a/boards/components/src/appid/checker_signature.rs
+++ b/boards/components/src/appid/checker_signature.rs
@@ -24,7 +24,7 @@ macro_rules! app_checker_signature_component_static {
         );
 
         (checker, hash_buffer, signature_buffer)
-    };};
+    }};
 }
 
 pub type AppCheckerSignatureComponentType<S, H, const HASH_LEN: usize, const SIGNATURE_LEN: usize> =

--- a/boards/components/src/atecc508a.rs
+++ b/boards/components/src/atecc508a.rs
@@ -37,7 +37,7 @@ macro_rules! atecc508a_component_static {
             verify_key_buffer,
             atecc508a,
         )
-    };};
+    }};
 }
 
 pub struct Atecc508aComponent<I: 'static + i2c::I2CMaster<'static>> {

--- a/boards/components/src/bme280.rs
+++ b/boards/components/src/bme280.rs
@@ -44,7 +44,7 @@ macro_rules! bme280_component_static {
         );
 
         (i2c_device, i2c_buffer, bme280)
-    };};
+    }};
 }
 
 pub type Bme280ComponentType<I> = capsules_extra::bme280::Bme280<'static, I>;

--- a/boards/components/src/bmm150.rs
+++ b/boards/components/src/bmm150.rs
@@ -35,7 +35,7 @@ macro_rules! bmm150_component_static {
         );
 
         (i2c_device, buffer, bmm150)
-    };};
+    }};
 }
 
 pub struct BMM150Component<I: 'static + i2c::I2CMaster<'static>> {

--- a/boards/components/src/bmp280.rs
+++ b/boards/components/src/bmp280.rs
@@ -53,7 +53,7 @@ macro_rules! bmp280_component_static {
         );
 
         (i2c_device, alarm, buffer, bmp280)
-    };};
+    }};
 }
 
 pub type Bmp280ComponentType<A, I> = capsules_extra::bmp280::Bmp280<'static, A, I>;

--- a/boards/components/src/bus.rs
+++ b/boards/components/src/bus.rs
@@ -37,9 +37,7 @@ use kernel::hil::spi::{self, ClockPhase, ClockPolarity, SpiMasterDevice};
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! bus8080_bus_component_static {
-    ($B:ty $(,)?) => {{
-        kernel::static_buf!(capsules_extra::bus::Bus8080Bus<'static, $B>)
-    };};
+    ($B:ty $(,)?) => {{ kernel::static_buf!(capsules_extra::bus::Bus8080Bus<'static, $B>) }};
 }
 
 #[macro_export]
@@ -57,7 +55,7 @@ macro_rules! spi_bus_component_static {
         );
 
         (spi, bus, address_buffer)
-    };};
+    }};
 }
 
 #[macro_export]
@@ -73,7 +71,7 @@ macro_rules! i2c_master_bus_component_static {
         );
 
         (bus, i2c_device, address_buffer)
-    };};
+    }};
 }
 
 pub struct Bus8080BusComponent<B: 'static + bus8080::Bus8080<'static>> {

--- a/boards/components/src/button.rs
+++ b/boards/components/src/button.rs
@@ -73,14 +73,12 @@ macro_rules! button_component_helper {
                 )*
             ]
         )
-    };};
+    }};
 }
 
 #[macro_export]
 macro_rules! button_component_static {
-    ($Pin:ty $(,)?) => {{
-        kernel::static_buf!(capsules_core::button::Button<'static, $Pin>)
-    };};
+    ($Pin:ty $(,)?) => {{ kernel::static_buf!(capsules_core::button::Button<'static, $Pin>) }};
 }
 
 pub type ButtonComponentType<IP> = capsules_core::button::Button<'static, IP>;

--- a/boards/components/src/button_keyboard.rs
+++ b/boards/components/src/button_keyboard.rs
@@ -15,9 +15,7 @@ use kernel::hil;
 
 #[macro_export]
 macro_rules! keyboard_button_component_static {
-    () => {{
-        kernel::static_buf!(capsules_extra::button_keyboard::ButtonKeyboard<'static>)
-    };};
+    () => {{ kernel::static_buf!(capsules_extra::button_keyboard::ButtonKeyboard<'static>) }};
 }
 
 pub type KeyboardButtonComponentType = capsules_extra::button_keyboard::ButtonKeyboard<'static>;

--- a/boards/components/src/buzzer.rs
+++ b/boards/components/src/buzzer.rs
@@ -47,7 +47,7 @@ macro_rules! buzzer_component_static {
             >
         );
         (alarm, pwm_buzzer, buzzer)
-    };};
+    }};
 }
 
 pub type BuzzerComponentType<A, P> = capsules_extra::buzzer_driver::Buzzer<

--- a/boards/components/src/can.rs
+++ b/boards/components/src/can.rs
@@ -41,7 +41,7 @@ macro_rules! can_component_static {
         let CAN_RX_BUF = static_buf!([u8; can::STANDARD_CAN_PACKET_SIZE]);
         let can = static_buf!(capsules_extra::can::CanCapsule<'static, $C>);
         (can, CAN_TX_BUF, CAN_RX_BUF)
-    };};
+    }};
 }
 
 pub struct CanComponent<A: 'static + can::Can, CAP: MemoryAllocationCapability + 'static> {

--- a/boards/components/src/ccs811.rs
+++ b/boards/components/src/ccs811.rs
@@ -39,7 +39,7 @@ macro_rules! ccs811_component_static {
         let ccs811 = kernel::static_buf!(capsules_extra::ccs811::Ccs811<'static>);
 
         (i2c_device, buffer, ccs811)
-    };};
+    }};
 }
 
 pub struct Ccs811Component<I: 'static + i2c::I2CMaster<'static>> {

--- a/boards/components/src/cdc.rs
+++ b/boards/components/src/cdc.rs
@@ -47,7 +47,7 @@ macro_rules! cdc_acm_component_static {
         );
 
         (alarm, cdc)
-    };};
+    }};
 }
 
 pub struct CdcAcmComponent<

--- a/boards/components/src/chirp_i2c_moisture.rs
+++ b/boards/components/src/chirp_i2c_moisture.rs
@@ -42,7 +42,7 @@ macro_rules! chirp_i2c_moisture_component_static {
         );
 
         (i2c_device, i2c_buffer, chirp_i2c_moisture)
-    };};
+    }};
 }
 
 pub type ChirpI2cMoistureComponentType<I> =

--- a/boards/components/src/console.rs
+++ b/boards/components/src/console.rs
@@ -60,10 +60,10 @@ macro_rules! uart_mux_component_static {
         (uart_mux, rx_buf)
     }};
     () => {
-        $crate::uart_mux_component_static!(capsules_core::virtualizers::virtual_uart::RX_BUF_LEN);
+        $crate::uart_mux_component_static!(capsules_core::virtualizers::virtual_uart::RX_BUF_LEN)
     };
     ($rx_buffer_len: literal) => {
-        $crate::uart_mux_component_static!($rx_buffer_len);
+        $crate::uart_mux_component_static!($rx_buffer_len)
     };
 }
 
@@ -116,10 +116,10 @@ macro_rules! console_component_static {
         (write_buf, read_buf, console_uart, console)
     }};
     () => {
-        $crate::console_component_static!(DEFAULT_BUF_SIZE, DEFAULT_BUF_SIZE);
+        $crate::console_component_static!(DEFAULT_BUF_SIZE, DEFAULT_BUF_SIZE)
     };
     ($rx_buffer_len: literal, $tx_buffer_len: literal) => {
-        $crate::console_component_static!($rx_buffer_len, $tx_buffer_len);
+        $crate::console_component_static!($rx_buffer_len, $tx_buffer_len)
     };
 }
 
@@ -195,7 +195,7 @@ macro_rules! console_ordered_component_static {
             kernel::static_buf!(capsules_core::virtualizers::virtual_uart::UartDevice);
         let console = kernel::static_buf!(ConsoleOrdered<'static, VirtualMuxAlarm<'static, $A>>);
         (mux_alarm, read_buf, console_uart, console)
-    };};
+    }};
 }
 
 pub struct ConsoleOrderedComponent<

--- a/boards/components/src/crc.rs
+++ b/boards/components/src/crc.rs
@@ -32,7 +32,7 @@ macro_rules! crc_component_static {
         let crc = kernel::static_buf!(capsules_extra::crc::CrcDriver<'static, $C>);
 
         (crc, buffer)
-    };};
+    }};
 }
 
 pub struct CrcComponent<C: 'static + Crc<'static>, CAP: MemoryAllocationCapability + 'static> {

--- a/boards/components/src/ctap.rs
+++ b/boards/components/src/ctap.rs
@@ -51,7 +51,7 @@ macro_rules! ctap_component_static {
         let recv_buffer = kernel::static_buf!([u8; 64]);
 
         (hid, driver, send_buffer, recv_buffer)
-    };};
+    }};
 }
 
 pub struct CtapComponent<

--- a/boards/components/src/dac.rs
+++ b/boards/components/src/dac.rs
@@ -18,9 +18,7 @@ use kernel::hil;
 
 #[macro_export]
 macro_rules! dac_component_static {
-    () => {{
-        kernel::static_buf!(capsules_extra::dac::Dac<'static>)
-    };};
+    () => {{ kernel::static_buf!(capsules_extra::dac::Dac<'static>) }};
 }
 
 pub struct DacComponent {

--- a/boards/components/src/date_time.rs
+++ b/boards/components/src/date_time.rs
@@ -31,7 +31,7 @@ macro_rules! date_time_component_static {
     ($R:ty $(,)?) => {{
         let rtc = kernel::static_buf!(capsules_extra::date_time::DateTimeCapsule<'static, $R>);
         (rtc)
-    };};
+    }};
 }
 
 pub struct DateTimeComponent<

--- a/boards/components/src/debug_writer.rs
+++ b/boards/components/src/debug_writer.rs
@@ -62,10 +62,8 @@ macro_rules! debug_writer_component_static {
             kernel::static_buf!(capsules_system::debug_writer::uart_debug_writer::UartDebugWriter);
 
         (uart, ring, buffer, debug)
-    };};
-    () => {{
-        $crate::debug_writer_component_static!($crate::debug_writer::DEFAULT_DEBUG_BUFFER_KBYTE)
-    };};
+    }};
+    () => {{ $crate::debug_writer_component_static!($crate::debug_writer::DEFAULT_DEBUG_BUFFER_KBYTE) }};
 }
 
 /// The optional argument to this macro allows boards to specify the size of the in-RAM
@@ -82,11 +80,11 @@ macro_rules! debug_writer_no_mux_component_static {
             kernel::static_buf!(capsules_system::debug_writer::uart_debug_writer::UartDebugWriter);
 
         (ring, buffer, debug)
-    };};
+    }};
     () => {{
         use $crate::debug_writer::DEFAULT_DEBUG_BUFFER_KBYTE;
         $crate::debug_writer_no_mux_component_static!(DEFAULT_DEBUG_BUFFER_KBYTE)
-    };};
+    }};
 }
 
 // Allow dead code because we need the `Chip` type but don't use `chip`.

--- a/boards/components/src/dfrobot_rainfall_sensor.rs
+++ b/boards/components/src/dfrobot_rainfall_sensor.rs
@@ -45,7 +45,7 @@ macro_rules! dfrobot_rainfall_sensor_component_static {
         );
 
         (i2c_device, i2c_buffer, dfrobot_rainfall_sensor, alarm)
-    };};
+    }};
 }
 
 pub type DFRobotRainFallSensorComponentType<A, I> =

--- a/boards/components/src/dynamic_binary_storage.rs
+++ b/boards/components/src/dynamic_binary_storage.rs
@@ -53,7 +53,7 @@ macro_rules! sequential_binary_storage_component_static {
         let buffer = kernel::static_buf!([u8; kernel::dynamic_binary_storage::BUF_LEN]);
 
         (page, ntp, pl, buffer)
-    };};
+    }};
 }
 
 pub struct SequentialBinaryStorageComponent<

--- a/boards/components/src/eui64.rs
+++ b/boards/components/src/eui64.rs
@@ -17,9 +17,7 @@ use kernel::component::Component;
 
 #[macro_export]
 macro_rules! eui64_component_static {
-    () => {{
-        kernel::static_buf!(capsules_extra::eui64::Eui64)
-    };};
+    () => {{ kernel::static_buf!(capsules_extra::eui64::Eui64) }};
 }
 
 pub type Eui64ComponentType = capsules_extra::eui64::Eui64;

--- a/boards/components/src/flash.rs
+++ b/boards/components/src/flash.rs
@@ -27,16 +27,12 @@ use kernel::hil::flash::{Flash, HasClient};
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! flash_user_component_static {
-    ($F:ty) => {{
-        kernel::static_buf!(capsules_core::virtualizers::virtual_flash::FlashUser<'static, $F>)
-    };};
+    ($F:ty) => {{ kernel::static_buf!(capsules_core::virtualizers::virtual_flash::FlashUser<'static, $F>) }};
 }
 
 #[macro_export]
 macro_rules! flash_mux_component_static {
-    ($F:ty) => {{
-        kernel::static_buf!(capsules_core::virtualizers::virtual_flash::MuxFlash<'static, $F>)
-    };};
+    ($F:ty) => {{ kernel::static_buf!(capsules_core::virtualizers::virtual_flash::MuxFlash<'static, $F>) }};
 }
 
 pub struct FlashMuxComponent<F: 'static + Flash + HasClient<'static, MuxFlash<'static, F>>> {

--- a/boards/components/src/fm25cl.rs
+++ b/boards/components/src/fm25cl.rs
@@ -37,7 +37,7 @@ macro_rules! fm25cl_component_static {
         );
 
         (spi, fm25cl, txbuffer, rxbuffer)
-    };};
+    }};
 }
 
 pub struct Fm25clComponent<

--- a/boards/components/src/ft6x06.rs
+++ b/boards/components/src/ft6x06.rs
@@ -39,7 +39,7 @@ macro_rules! ft6x06_component_static {
         );
 
         (i2c_device, ft6x06, buffer, events_buffer)
-    };};
+    }};
 }
 
 pub struct Ft6x06Component<I: 'static + i2c::I2CMaster<'static>> {

--- a/boards/components/src/fxos8700.rs
+++ b/boards/components/src/fxos8700.rs
@@ -39,7 +39,7 @@ macro_rules! fxos8700_component_static {
         let fxo = kernel::static_buf!(capsules_extra::fxos8700cq::Fxos8700cq<'static>);
 
         (i2c_device, buffer, fxo)
-    };};
+    }};
 }
 
 pub struct Fxos8700Component<I: 'static + i2c::I2CMaster<'static>> {

--- a/boards/components/src/gpio.rs
+++ b/boards/components/src/gpio.rs
@@ -108,14 +108,12 @@ macro_rules! gpio_component_helper {
         )*
 
         pins
-    };};
+    }};
 }
 
 #[macro_export]
 macro_rules! gpio_component_static {
-    ($Pin:ty $(,)?) => {{
-        kernel::static_buf!(capsules_core::gpio::GPIO<'static, $Pin>)
-    };};
+    ($Pin:ty $(,)?) => {{ kernel::static_buf!(capsules_core::gpio::GPIO<'static, $Pin>) }};
 }
 
 pub type GpioComponentType<IP> = GPIO<'static, IP>;

--- a/boards/components/src/hd44780.rs
+++ b/boards/components/src/hd44780.rs
@@ -56,7 +56,7 @@ macro_rules! hd44780_component_static {
         let buffer = kernel::static_buf!([u8; capsules_extra::hd44780::BUF_LEN]);
 
         (alarm, hd44780, buffer)
-    };};
+    }};
 }
 
 pub struct HD44780Component<A: 'static + time::Alarm<'static>> {

--- a/boards/components/src/hmac.rs
+++ b/boards/components/src/hmac.rs
@@ -32,7 +32,7 @@ macro_rules! hmac_component_static {
         let dest_buffer = kernel::static_buf!([u8; $L]);
 
         (hmac, data_buffer, dest_buffer)
-    };};
+    }};
 }
 
 pub type HmacComponentType<H, const L: usize> = capsules_extra::hmac::HmacDriver<'static, H, L>;
@@ -117,7 +117,7 @@ macro_rules! hmac_sha256_software_component_static {
         let verify_buffer = kernel::static_buf!([u8; 32]);
 
         (hmac_sha256, data_buffer, verify_buffer)
-    };};
+    }};
 }
 
 pub type HmacSha256SoftwareComponentType<S> =

--- a/boards/components/src/hs3003.rs
+++ b/boards/components/src/hs3003.rs
@@ -34,7 +34,7 @@ macro_rules! hs3003_component_static {
         );
 
         (i2c_device, buffer, hs3003)
-    };};
+    }};
 }
 
 pub type Hs3003ComponentType<I> = Hs3003<'static, I>;

--- a/boards/components/src/hts221.rs
+++ b/boards/components/src/hts221.rs
@@ -34,7 +34,7 @@ macro_rules! hts221_component_static {
         );
 
         (i2c_device, buffer, hts221)
-    };};
+    }};
 }
 
 pub type Hts221ComponentType<I> = capsules_extra::hts221::Hts221<'static, I>;

--- a/boards/components/src/humidity.rs
+++ b/boards/components/src/humidity.rs
@@ -19,9 +19,7 @@ use kernel::hil;
 
 #[macro_export]
 macro_rules! humidity_component_static {
-    ($H: ty $(,)?) => {{
-        kernel::static_buf!(capsules_extra::humidity::HumiditySensor<'static, $H>)
-    };};
+    ($H: ty $(,)?) => {{ kernel::static_buf!(capsules_extra::humidity::HumiditySensor<'static, $H>) }};
 }
 
 pub type HumidityComponentType<H> = capsules_extra::humidity::HumiditySensor<'static, H>;

--- a/boards/components/src/i2c.rs
+++ b/boards/components/src/i2c.rs
@@ -30,19 +30,13 @@ use kernel::hil::i2c::{self, NoSMBus};
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! i2c_mux_component_static {
-    ($I:ty $(,)?) => {{
-        kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::MuxI2C<'static, $I>)
-    };};
-    ($I:ty, $S:ty $(,)?) => {{
-        kernel::static_buf!(capsules::virtual_i2c::MuxI2C<'static, $I, $S>)
-    };};
+    ($I:ty $(,)?) => {{ kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::MuxI2C<'static, $I>) }};
+    ($I:ty, $S:ty $(,)?) => {{ kernel::static_buf!(capsules::virtual_i2c::MuxI2C<'static, $I, $S>) }};
 }
 
 #[macro_export]
 macro_rules! i2c_component_static {
-    ($I:ty $(,)?) => {{
-        kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, $I>)
-    };};
+    ($I:ty $(,)?) => {{ kernel::static_buf!(capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, $I>) }};
 }
 
 #[macro_export]
@@ -62,7 +56,7 @@ macro_rules! i2c_master_slave_component_static {
             i2c_slave_buffer1,
             i2c_slave_buffer2,
         )
-    };};
+    }};
 }
 
 #[macro_export]
@@ -73,7 +67,7 @@ macro_rules! i2c_master_driver_component_static {
         let driver = kernel::static_buf!(capsules_core::i2c_master::I2CMasterDriver<'static, $I>);
 
         (driver, i2c_master_buffer)
-    };};
+    }};
 }
 
 pub struct I2CMuxComponent<

--- a/boards/components/src/ieee802154.rs
+++ b/boards/components/src/ieee802154.rs
@@ -48,9 +48,7 @@ pub const CRYPT_SIZE: usize = 3 * symmetric_encryption::AES_BLOCK_SIZE + radio::
 
 #[macro_export]
 macro_rules! mux_aes128ccm_component_static {
-    ($A:ty $(,)?) => {{
-        kernel::static_buf!(capsules_core::virtualizers::virtual_aes_ccm::MuxAES128CCM<'static, $A>)
-    };};
+    ($A:ty $(,)?) => {{ kernel::static_buf!(capsules_core::virtualizers::virtual_aes_ccm::MuxAES128CCM<'static, $A>) }};
 }
 
 pub type MuxAes128ccmComponentType<A> = MuxAES128CCM<'static, A>;
@@ -147,7 +145,7 @@ macro_rules! ieee802154_component_static {
             crypt_buf,
             radio_rx_crypt_buf,
         )
-    };};
+    }};
 }
 
 pub type Ieee802154ComponentType<R, A> = capsules_extra::ieee802154::RadioDriver<
@@ -372,7 +370,7 @@ macro_rules! ieee802154_raw_component_static {
         let rx_buffer = kernel::static_buf!([u8; kernel::hil::radio::MAX_BUF_SIZE]);
 
         (radio_driver, tx_buffer, rx_buffer)
-    };};
+    }};
 }
 
 pub type Ieee802154RawComponentType<R> =

--- a/boards/components/src/isl29035.rs
+++ b/boards/components/src/isl29035.rs
@@ -55,14 +55,12 @@ macro_rules! isl29035_component_static {
         );
 
         (alarm, i2c_device, i2c_buffer, isl29035)
-    };};
+    }};
 }
 
 #[macro_export]
 macro_rules! ambient_light_component_static {
-    () => {{
-        kernel::static_buf!(capsules_extra::ambient_light::AmbientLight<'static>)
-    };};
+    () => {{ kernel::static_buf!(capsules_extra::ambient_light::AmbientLight<'static>) }};
 }
 
 pub struct Isl29035Component<

--- a/boards/components/src/isolated_nonvolatile_storage.rs
+++ b/boards/components/src/isolated_nonvolatile_storage.rs
@@ -55,7 +55,7 @@ macro_rules! isolated_nonvolatile_storage_component_static {
             kernel::static_buf!([u8; capsules_extra::isolated_nonvolatile_storage_driver::BUF_LEN]);
 
         (page, ntp, ns, buffer)
-    };};
+    }};
 }
 
 pub type IsolatedNonvolatileStorageComponentType<const APP_REGION_SIZE: usize> =

--- a/boards/components/src/keyboard_hid.rs
+++ b/boards/components/src/keyboard_hid.rs
@@ -53,7 +53,7 @@ macro_rules! keyboard_hid_component_static {
         let recv_buffer = kernel::static_buf!([u8; 64]);
 
         (hid, driver, send_buffer, recv_buffer)
-    };};
+    }};
 }
 
 pub type KeyboardHidComponentType<U> = capsules_extra::usb_hid_driver::UsbHidDriver<

--- a/boards/components/src/kv.rs
+++ b/boards/components/src/kv.rs
@@ -26,7 +26,7 @@ macro_rules! kv_driver_component_static {
         let value_buffer = kernel::static_buf!([u8; 512]);
 
         (kv, key_buffer, value_buffer)
-    };};
+    }};
 }
 
 pub type KVDriverComponentType<V> = capsules_extra::kv_driver::KVStoreDriver<'static, V>;
@@ -97,7 +97,7 @@ macro_rules! kv_permissions_mux_component_static {
         );
 
         mux
-    };};
+    }};
 }
 
 pub type KVPermissionsMuxComponentType<V> =
@@ -136,7 +136,7 @@ macro_rules! virtual_kv_permissions_component_static {
         );
 
         virtual_kv
-    };};
+    }};
 }
 
 pub type VirtualKVPermissionsComponentType<V> =
@@ -176,7 +176,7 @@ macro_rules! kv_store_permissions_component_static {
         );
 
         (kv_store, buffer)
-    };};
+    }};
 }
 
 pub type KVStorePermissionsComponentType<V> =
@@ -226,7 +226,7 @@ macro_rules! tickv_kv_store_component_static {
             kernel::static_buf!(capsules_extra::tickv_kv_store::TicKVKVStore<'static, $K, $T>);
 
         (kv_store, key)
-    };};
+    }};
 }
 
 pub type TicKVKVStoreComponentType<K, T> =

--- a/boards/components/src/l3gd20.rs
+++ b/boards/components/src/l3gd20.rs
@@ -39,7 +39,7 @@ macro_rules! l3gd20_component_static {
         );
 
         (spi, l3gd20spi, txbuffer, rxbuffer)
-    };};
+    }};
 }
 
 pub type L3gd20ComponentType<S> = capsules_extra::l3gd20::L3gd20Spi<'static, S>;

--- a/boards/components/src/led.rs
+++ b/boards/components/src/led.rs
@@ -41,7 +41,7 @@ macro_rules! led_component_static {
 
         let led = kernel::static_buf!( capsules_core::led::LedDriver<'static, $Led, NUM_LEDS>);
         (led, arr)
-    };};
+    }};
 }
 
 pub type LedsComponentType<L, const NUMLEDS: usize> = LedDriver<'static, L, NUMLEDS>;

--- a/boards/components/src/led_matrix.rs
+++ b/boards/components/src/led_matrix.rs
@@ -92,7 +92,7 @@ macro_rules! led_matrix_component_static {
         );
 
         (alarm, led, buffer)
-    };};
+    }};
 }
 
 #[macro_export]
@@ -113,7 +113,7 @@ macro_rules! led_line_component_static {
                 ),+
             ]
         )
-    };};
+    }};
 }
 
 #[macro_export]
@@ -124,7 +124,7 @@ macro_rules! led_matrix_led {
             LedMatrixLed<'static, $Pin, $A>,
             LedMatrixLed::new($led_matrix, $col, $row)
         )
-    };};
+    }};
 }
 
 #[macro_export]
@@ -141,7 +141,7 @@ macro_rules! led_matrix_leds {
             ),+]
         );
         leds
-    };};
+    }};
 }
 
 pub struct LedMatrixComponent<

--- a/boards/components/src/lldb.rs
+++ b/boards/components/src/lldb.rs
@@ -41,7 +41,7 @@ macro_rules! low_level_debug_component_static {
         );
 
         (uart, buffer, lldb)
-    };};
+    }};
 }
 
 pub struct LowLevelDebugComponent<CAP: MemoryAllocationCapability + 'static> {

--- a/boards/components/src/loader/sequential.rs
+++ b/boards/components/src/loader/sequential.rs
@@ -27,7 +27,7 @@ macro_rules! process_loader_sequential_component_static {
         );
 
        (loader, process_binary_array)
-    };};
+    }};
 }
 
 pub type ProcessLoaderSequentialComponentType<C, D> =

--- a/boards/components/src/lps22hb.rs
+++ b/boards/components/src/lps22hb.rs
@@ -24,7 +24,7 @@ macro_rules! lps22hb_component_static {
         let buffer = kernel::static_buf!([u8; 4]);
 
         (i2c_device, lps22hb, buffer)
-    };};
+    }};
 }
 
 pub struct Lps22hbComponent<I: 'static + i2c::I2CMaster<'static>> {

--- a/boards/components/src/lps25hb.rs
+++ b/boards/components/src/lps25hb.rs
@@ -26,7 +26,7 @@ macro_rules! lps25hb_component_static {
         let buffer = kernel::static_buf!([u8; capsules_extra::lps25hb::BUF_LEN]);
 
         (i2c_device, lps25hb, buffer)
-    };};
+    }};
 }
 
 pub struct Lps25hbComponent<

--- a/boards/components/src/lsm303agr.rs
+++ b/boards/components/src/lsm303agr.rs
@@ -48,7 +48,7 @@ macro_rules! lsm303agr_component_static {
         );
 
         (accelerometer_i2c, magnetometer_i2c, buffer, lsm303agr)
-    };};
+    }};
 }
 
 pub struct Lsm303agrI2CComponent<

--- a/boards/components/src/lsm303dlhc.rs
+++ b/boards/components/src/lsm303dlhc.rs
@@ -47,7 +47,7 @@ macro_rules! lsm303dlhc_component_static {
         );
 
         (accelerometer_i2c, magnetometer_i2c, buffer, lsm303dlhc)
-    };};
+    }};
 }
 
 pub struct Lsm303dlhcI2CComponent<

--- a/boards/components/src/lsm6dsox.rs
+++ b/boards/components/src/lsm6dsox.rs
@@ -50,7 +50,7 @@ macro_rules! lsm6ds_i2c_component_static {
         );
 
         (i2c_device, buffer, lsm6dsoxtr)
-    };};
+    }};
 }
 
 pub struct Lsm6dsoxtrI2CComponent<

--- a/boards/components/src/ltc294x.rs
+++ b/boards/components/src/ltc294x.rs
@@ -37,14 +37,12 @@ macro_rules! ltc294x_component_static {
         let buffer = kernel::static_buf!([u8; capsules_extra::ltc294x::BUF_LEN]);
 
         (i2c_device, ltc294x, buffer)
-    };};
+    }};
 }
 
 #[macro_export]
 macro_rules! ltc294x_driver_component_static {
-    () => {{
-        kernel::static_buf!(capsules_extra::ltc294x::LTC294XDriver<'static>)
-    };};
+    () => {{ kernel::static_buf!(capsules_extra::ltc294x::LTC294XDriver<'static>) }};
 }
 
 pub struct Ltc294xComponent<I: 'static + i2c::I2CMaster<'static>> {

--- a/boards/components/src/mlx90614.rs
+++ b/boards/components/src/mlx90614.rs
@@ -34,7 +34,7 @@ macro_rules! mlx90614_component_static {
         let mlx90614 = kernel::static_buf!(capsules_extra::mlx90614::Mlx90614SMBus<'static>);
 
         (i2c_device, buffer, mlx90614)
-    };};
+    }};
 }
 
 pub struct Mlx90614SMBusComponent<

--- a/boards/components/src/moisture.rs
+++ b/boards/components/src/moisture.rs
@@ -23,9 +23,7 @@ use kernel::hil;
 
 #[macro_export]
 macro_rules! moisture_component_static {
-    ($H: ty $(,)?) => {{
-        kernel::static_buf!(capsules_extra::moisture::MoistureSensor<'static, $H>)
-    };};
+    ($H: ty $(,)?) => {{ kernel::static_buf!(capsules_extra::moisture::MoistureSensor<'static, $H>) }};
 }
 
 pub type MoistureComponentType<H> = capsules_extra::moisture::MoistureSensor<'static, H>;

--- a/boards/components/src/mx25r6435f.rs
+++ b/boards/components/src/mx25r6435f.rs
@@ -53,7 +53,7 @@ macro_rules! mx25r6435f_component_static {
         let rx_buf = kernel::static_buf!([u8; capsules_extra::mx25r6435f::RX_BUF_LEN]);
 
         (spi_device, alarm, mx25r6435f, tx_buf, rx_buf)
-    };};
+    }};
 }
 
 pub type Mx25r6435fComponentType<S, P, A> = capsules_extra::mx25r6435f::MX25R6435F<

--- a/boards/components/src/ninedof.rs
+++ b/boards/components/src/ninedof.rs
@@ -32,7 +32,7 @@ macro_rules! ninedof_component_static {
         );
         let ninedof = kernel::static_buf!(capsules_extra::ninedof::NineDof<'static>);
         (ninedof, drivers)
-    };};
+    }};
 }
 
 pub type NineDofComponentType = capsules_extra::ninedof::NineDof<'static>;

--- a/boards/components/src/nonvolatile_storage.rs
+++ b/boards/components/src/nonvolatile_storage.rs
@@ -44,7 +44,7 @@ macro_rules! nonvolatile_storage_component_static {
         let buffer = kernel::static_buf!([u8; capsules_extra::nonvolatile_storage_driver::BUF_LEN]);
 
         (page, ntp, ns, buffer)
-    };};
+    }};
 }
 
 pub type NonvolatileStorageComponentType = NonvolatileStorage<'static>;

--- a/boards/components/src/nrf51822.rs
+++ b/boards/components/src/nrf51822.rs
@@ -36,7 +36,7 @@ macro_rules! nrf51822_component_static {
             kernel::static_buf!([u8; capsules_extra::nrf51822_serialization::READ_BUF_LEN]);
 
         (nrf, write_buffer, read_buffer)
-    };};
+    }};
 }
 
 pub struct Nrf51822Component<

--- a/boards/components/src/panic_button.rs
+++ b/boards/components/src/panic_button.rs
@@ -29,9 +29,7 @@ use kernel::hil::gpio;
 
 #[macro_export]
 macro_rules! panic_button_component_static {
-    ($Pin:ty $(,)?) => {{
-        kernel::static_buf!(capsules_core::button::PanicButton<'static, $Pin>)
-    };};
+    ($Pin:ty $(,)?) => {{ kernel::static_buf!(capsules_core::button::PanicButton<'static, $Pin>) }};
 }
 
 pub struct PanicButtonComponent<'a, IP: gpio::InterruptPin<'a>> {

--- a/boards/components/src/pressure.rs
+++ b/boards/components/src/pressure.rs
@@ -19,9 +19,7 @@ use kernel::hil;
 
 #[macro_export]
 macro_rules! pressure_component_static {
-    ($T:ty $(,)?) => {{
-        kernel::static_buf!(capsules_extra::pressure::PressureSensor<'static, $T>)
-    };};
+    ($T:ty $(,)?) => {{ kernel::static_buf!(capsules_extra::pressure::PressureSensor<'static, $T>) }};
 }
 
 pub struct PressureComponent<

--- a/boards/components/src/process_array.rs
+++ b/boards/components/src/process_array.rs
@@ -9,9 +9,7 @@ use kernel::component::Component;
 
 #[macro_export]
 macro_rules! process_array_component_static {
-    ($NUM_PROCS:ty $(,)?) => {{
-        kernel::static_buf!(kernel::process::ProcessArray<$NUM_PROCS>)
-    };};
+    ($NUM_PROCS:ty $(,)?) => {{ kernel::static_buf!(kernel::process::ProcessArray<$NUM_PROCS>) }};
 }
 
 pub struct ProcessArrayComponent<const NUM_PROCS: usize> {}

--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -70,10 +70,10 @@ macro_rules! process_console_component_static {
             command_history_buffer,
             pconsole,
         )
-    };};
+    }};
     ($A: ty, $C: ty $(,)?) => {{
         $crate::process_console_component_static!($A, $C, { capsules_core::process_console::DEFAULT_COMMAND_HISTORY_LEN })
-    };};
+    }};
 }
 
 pub type ProcessConsoleComponentType<A, C> = process_console::ProcessConsole<

--- a/boards/components/src/process_info_driver.rs
+++ b/boards/components/src/process_info_driver.rs
@@ -20,7 +20,7 @@ macro_rules! process_info_component_static {
         );
 
         process_info
-    };};
+    }};
 }
 
 pub struct ProcessInfoComponent<

--- a/boards/components/src/process_printer.rs
+++ b/boards/components/src/process_printer.rs
@@ -16,9 +16,7 @@ use kernel::component::Component;
 
 #[macro_export]
 macro_rules! process_printer_text_component_static {
-    () => {{
-        kernel::static_buf!(capsules_system::process_printer::ProcessPrinterText)
-    };};
+    () => {{ kernel::static_buf!(capsules_system::process_printer::ProcessPrinterText) }};
 }
 
 pub struct ProcessPrinterTextComponent {}

--- a/boards/components/src/proximity.rs
+++ b/boards/components/src/proximity.rs
@@ -19,9 +19,7 @@ use kernel::hil;
 
 #[macro_export]
 macro_rules! proximity_component_static {
-    () => {{
-        kernel::static_buf!(capsules_extra::proximity::ProximitySensor<'static>)
-    };};
+    () => {{ kernel::static_buf!(capsules_extra::proximity::ProximitySensor<'static>) }};
 }
 
 pub type ProximityComponentType = capsules_extra::proximity::ProximitySensor<'static>;

--- a/boards/components/src/pwm.rs
+++ b/boards/components/src/pwm.rs
@@ -13,16 +13,12 @@ use kernel::hil::pwm;
 
 #[macro_export]
 macro_rules! pwm_mux_component_static {
-    ($A:ty $(,)?) => {{
-        kernel::static_buf!(capsules_core::virtualizers::virtual_pwm::MuxPwm<'static, $A>)
-    };};
+    ($A:ty $(,)?) => {{ kernel::static_buf!(capsules_core::virtualizers::virtual_pwm::MuxPwm<'static, $A>) }};
 }
 
 #[macro_export]
 macro_rules! pwm_pin_user_component_static {
-    ($A:ty $(,)?) => {{
-        kernel::static_buf!(capsules_core::virtualizers::virtual_pwm::PwmPinUser<'static, $A>)
-    };};
+    ($A:ty $(,)?) => {{ kernel::static_buf!(capsules_core::virtualizers::virtual_pwm::PwmPinUser<'static, $A>) }};
 }
 
 #[macro_export]
@@ -40,7 +36,7 @@ macro_rules! pwm_driver_component_helper {
         );
         let pwm = kernel::static_buf!(capsules_extra::pwm::Pwm<'static, NUM_DRIVERS>);
         (pwm, drivers)
-    };};
+    }};
 }
 
 pub struct PwmMuxComponent<P: 'static + pwm::Pwm> {

--- a/boards/components/src/rainfall.rs
+++ b/boards/components/src/rainfall.rs
@@ -23,9 +23,7 @@ use kernel::hil;
 
 #[macro_export]
 macro_rules! rainfall_component_static {
-    ($H: ty $(,)?) => {{
-        kernel::static_buf!(capsules_extra::rainfall::RainFallSensor<'static, $H>)
-    };};
+    ($H: ty $(,)?) => {{ kernel::static_buf!(capsules_extra::rainfall::RainFallSensor<'static, $H>) }};
 }
 
 pub type RainFallComponentType<H> = capsules_extra::rainfall::RainFallSensor<'static, H>;

--- a/boards/components/src/rf233.rs
+++ b/boards/components/src/rf233.rs
@@ -54,7 +54,7 @@ macro_rules! rf233_component_static {
             kernel::static_buf!([u8; capsules_extra::rf233::SPI_REGISTER_TRANSACTION_LENGTH]);
 
         (spi_device, rf233_buf, rf233_reg_write, rf233_reg_read)
-    };};
+    }};
 }
 
 pub struct RF233Component<S: SpiMaster<'static> + 'static> {

--- a/boards/components/src/rng.rs
+++ b/boards/components/src/rng.rs
@@ -49,7 +49,7 @@ macro_rules! rng_component_static {
         );
 
         (etr, rng)
-    };};
+    }};
 }
 
 pub type RngComponentType<E> =
@@ -116,7 +116,7 @@ macro_rules! rng_random_component_static {
         let rng = kernel::static_buf!(capsules_core::rng::RngDriver<'static, $R>);
 
         rng
-    };};
+    }};
 }
 
 pub type RngRandomComponentType<R> = rng::RngDriver<'static, R>;

--- a/boards/components/src/sched/cooperative.rs
+++ b/boards/components/src/sched/cooperative.rs
@@ -32,7 +32,7 @@ macro_rules! cooperative_component_static {
         );
 
         (coop_sched, coop_nodes)
-    };};
+    }};
 }
 
 pub type CooperativeComponentType =

--- a/boards/components/src/sched/mlfq.rs
+++ b/boards/components/src/sched/mlfq.rs
@@ -35,7 +35,7 @@ macro_rules! mlfq_component_static {
         );
 
         (alarm, mlfq_sched, mlfq_node)
-    };};
+    }};
 }
 
 pub type MLFQComponentType<A> =

--- a/boards/components/src/sched/priority.rs
+++ b/boards/components/src/sched/priority.rs
@@ -21,9 +21,7 @@ use kernel::component::Component;
 
 #[macro_export]
 macro_rules! priority_component_static {
-    ($CAP:ty $(,)?) => {{
-        kernel::static_buf!(capsules_system::scheduler::priority::PrioritySched<$CAP>)
-    };};
+    ($CAP:ty $(,)?) => {{ kernel::static_buf!(capsules_system::scheduler::priority::PrioritySched<$CAP>) }};
 }
 
 pub type PriorityComponentType<CAP> = capsules_system::scheduler::priority::PrioritySched<CAP>;

--- a/boards/components/src/sched/round_robin.rs
+++ b/boards/components/src/sched/round_robin.rs
@@ -33,7 +33,7 @@ macro_rules! round_robin_component_static {
         );
 
         (rr_sched, rr_nodes)
-    };};
+    }};
 }
 
 pub type RoundRobinComponentType =

--- a/boards/components/src/screen.rs
+++ b/boards/components/src/screen.rs
@@ -44,7 +44,7 @@ macro_rules! screen_split_mux_component_static {
         kernel::static_buf!(
             capsules_extra::virtualizers::screen::virtual_screen_split::ScreenSplitMux<'static, $S>
         )
-    };};
+    }};
 }
 
 #[macro_export]
@@ -56,7 +56,7 @@ macro_rules! screen_split_user_component_static {
                 $S,
             >
         )
-    };};
+    }};
 }
 
 pub type ScreenSplitMuxComponentType<S> = virtual_screen_split::ScreenSplitMux<'static, S>;
@@ -139,7 +139,7 @@ macro_rules! screen_component_static {
         let screen = kernel::static_buf!(capsules_extra::screen::screen::Screen);
 
         (buffer, screen)
-    };};
+    }};
 }
 
 pub type ScreenComponentType = capsules_extra::screen::screen::Screen<'static>;
@@ -211,7 +211,7 @@ macro_rules! screen_shared_component_static {
         let screen = kernel::static_buf!(capsules_extra::screen::screen_shared::ScreenShared<$S>);
 
         (buffer, screen)
-    };};
+    }};
 }
 
 pub type ScreenSharedComponentType<S> =

--- a/boards/components/src/screen_adapters.rs
+++ b/boards/components/src/screen_adapters.rs
@@ -22,7 +22,7 @@ macro_rules! screen_adapter_argb8888_to_mono8bitpage_component_static {
             kernel::static_buf!([u8; $SCREEN_WIDTH * $SCREEN_HEIGHT * $PIXEL_STRIDE]);
 
         (adapter, frame_buffer)
-    };};
+    }};
 }
 
 pub type ScreenAdapterARGB8888ToMono8BitPageComponentType<S> =

--- a/boards/components/src/screen_on.rs
+++ b/boards/components/src/screen_on.rs
@@ -27,7 +27,7 @@ macro_rules! screen_on_led_component_static {
         );
 
         (buffer, screen_on_led)
-    };};
+    }};
 }
 
 pub type ScreenOnLedComponentType<

--- a/boards/components/src/segger_rtt.rs
+++ b/boards/components/src/segger_rtt.rs
@@ -41,7 +41,7 @@ macro_rules! segger_rtt_memory_component_static {
         );
 
         (rtt_memory, up_buffer, down_buffer)
-    };};
+    }};
 }
 
 #[macro_export]
@@ -58,7 +58,7 @@ macro_rules! segger_rtt_component_static {
         );
 
         (alarm, rtt)
-    };};
+    }};
 }
 
 pub struct SeggerRttMemoryRefs<'a> {

--- a/boards/components/src/servo.rs
+++ b/boards/components/src/servo.rs
@@ -34,7 +34,7 @@ macro_rules! servo_component_static {
 
         let servo = kernel::static_buf!( capsules_extra::servo::Servo<'static, SERVO_COUNT>);
         (servo, arr)
-    };};
+    }};
 }
 
 pub type ServosComponentType<const SERVO_COUNT: usize> = ServoDriver<'static, SERVO_COUNT>;

--- a/boards/components/src/sh1106.rs
+++ b/boards/components/src/sh1106.rs
@@ -32,7 +32,7 @@ macro_rules! sh1106_component_static {
         );
 
         (buffer, sh1106)
-    };};
+    }};
 }
 
 pub type Sh1106ComponentType<I> = capsules_extra::sh1106::Sh1106<

--- a/boards/components/src/sha.rs
+++ b/boards/components/src/sha.rs
@@ -39,7 +39,7 @@ macro_rules! sha_driver_component_static {
         let dest_buffer = kernel::static_buf!([u8; $L]);
 
         (sha_driver, data_buffer, dest_buffer)
-    };};
+    }};
 }
 
 pub type ShaDriverComponentType<A, const L: usize> = ShaDriver<'static, A, L>;
@@ -110,9 +110,7 @@ impl<
 
 #[macro_export]
 macro_rules! sha_software_256_component_static {
-    ($(,)?) => {{
-        kernel::static_buf!(capsules_extra::sha256::Sha256Software<'static>)
-    };};
+    ($(,)?) => {{ kernel::static_buf!(capsules_extra::sha256::Sha256Software<'static>) }};
 }
 
 pub type ShaSoftware256ComponentType = capsules_extra::sha256::Sha256Software<'static>;

--- a/boards/components/src/sht3x.rs
+++ b/boards/components/src/sht3x.rs
@@ -43,7 +43,7 @@ macro_rules! sht3x_component_static {
         );
 
         (sht3x_alarm, i2c_device, sht3x, buffer)
-    };};
+    }};
 }
 
 pub type SHT3xComponentType<A, I> = capsules_extra::sht3x::SHT3x<'static, A, I>;

--- a/boards/components/src/sht4x.rs
+++ b/boards/components/src/sht4x.rs
@@ -43,7 +43,7 @@ macro_rules! sht4x_component_static {
         );
 
         (sht4x_alarm, i2c_device, sht4x, buffer)
-    };};
+    }};
 }
 
 pub type SHT4xComponentType<A, I> = capsules_extra::sht4x::SHT4x<'static, A, I>;

--- a/boards/components/src/si7021.rs
+++ b/boards/components/src/si7021.rs
@@ -45,7 +45,7 @@ macro_rules! si7021_component_static {
         let buffer = kernel::static_buf!([u8; 14]);
 
         (alarm, i2c_device, si7021, buffer)
-    };};
+    }};
 }
 
 pub type SI7021ComponentType<A, I> = capsules_extra::si7021::SI7021<'static, A, I>;

--- a/boards/components/src/signature_verify_in_memory_keys.rs
+++ b/boards/components/src/signature_verify_in_memory_keys.rs
@@ -23,7 +23,7 @@ macro_rules! signature_verify_in_memory_keys_component_static {
         );
 
         verifier
-    };};
+    }};
 }
 
 pub type SignatureVerifyInMemoryKeysComponentType<

--- a/boards/components/src/siphash.rs
+++ b/boards/components/src/siphash.rs
@@ -11,9 +11,7 @@ use kernel::deferred_call::DeferredCallClient;
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! siphasher24_component_static {
-    ($(,)?) => {{
-        kernel::static_buf!(capsules_extra::sip_hash::SipHasher24)
-    };};
+    ($(,)?) => {{ kernel::static_buf!(capsules_extra::sip_hash::SipHasher24) }};
 }
 
 pub type Siphasher24ComponentType = capsules_extra::sip_hash::SipHasher24<'static>;

--- a/boards/components/src/sound_pressure.rs
+++ b/boards/components/src/sound_pressure.rs
@@ -19,9 +19,7 @@ use kernel::hil;
 
 #[macro_export]
 macro_rules! sound_pressure_component_static {
-    () => {{
-        kernel::static_buf!(capsules_extra::sound_pressure::SoundPressureSensor<'static>)
-    };};
+    () => {{ kernel::static_buf!(capsules_extra::sound_pressure::SoundPressureSensor<'static>) }};
 }
 
 pub type SoundPressureComponentType = capsules_extra::sound_pressure::SoundPressureSensor<'static>;

--- a/boards/components/src/spi.rs
+++ b/boards/components/src/spi.rs
@@ -43,9 +43,7 @@ use kernel::hil::spi::{SpiMasterDevice, SpiSlaveDevice};
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! spi_mux_component_static {
-    ($S:ty $(,)?) => {{
-        kernel::static_buf!(capsules_core::virtualizers::virtual_spi::MuxSpiMaster<'static, $S>)
-    };};
+    ($S:ty $(,)?) => {{ kernel::static_buf!(capsules_core::virtualizers::virtual_spi::MuxSpiMaster<'static, $S>) }};
 }
 
 #[macro_export]
@@ -67,7 +65,7 @@ macro_rules! spi_syscall_component_static {
             kernel::static_buf!([u8; capsules_core::spi_controller::DEFAULT_WRITE_BUF_LENGTH]);
 
         (virtual_spi, spi, spi_read_buf, spi_write_buf)
-    };};
+    }};
 }
 
 #[macro_export]
@@ -89,7 +87,7 @@ macro_rules! spi_syscallp_component_static {
             kernel::static_buf!([u8; capsules_core::spi_controller::DEFAULT_WRITE_BUF_LENGTH]);
 
         (spi_slave, spi_peripheral, spi_read_buf, spi_write_buf)
-    };};
+    }};
 }
 
 #[macro_export]
@@ -98,14 +96,12 @@ macro_rules! spi_component_static {
         kernel::static_buf!(
             capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<'static, $S>
         )
-    };};
+    }};
 }
 
 #[macro_export]
 macro_rules! spi_peripheral_component_static {
-    ($S:ty $(,)?) => {{
-        kernel::static_buf!(capsules_core::spi_peripheral::SpiPeripheral<'static, $S>)
-    };};
+    ($S:ty $(,)?) => {{ kernel::static_buf!(capsules_core::spi_peripheral::SpiPeripheral<'static, $S>) }};
 }
 
 pub struct SpiMuxComponent<S: 'static + spi::SpiMaster<'static>> {

--- a/boards/components/src/ssd1306.rs
+++ b/boards/components/src/ssd1306.rs
@@ -32,7 +32,7 @@ macro_rules! ssd1306_component_static {
         );
 
         (buffer, ssd1306)
-    };};
+    }};
 }
 
 pub type Ssd1306ComponentType<I> = capsules_extra::ssd1306::Ssd1306<

--- a/boards/components/src/st77xx.rs
+++ b/boards/components/src/st77xx.rs
@@ -67,7 +67,7 @@ macro_rules! st77xx_component_static {
         );
 
         (st77xx_alarm, st77xx, buffer, sequence_buffer)
-    };};
+    }};
 }
 
 pub struct ST77XXComponent<

--- a/boards/components/src/storage_permissions/individual.rs
+++ b/boards/components/src/storage_permissions/individual.rs
@@ -36,7 +36,7 @@ macro_rules! storage_permissions_individual_component_static {
                 $CAP,
             >
         )
-    };};
+    }};
 }
 
 pub type StoragePermissionsIndividualComponentType<C, D, CAP> =

--- a/boards/components/src/storage_permissions/null.rs
+++ b/boards/components/src/storage_permissions/null.rs
@@ -14,7 +14,7 @@ use kernel::process::ProcessStandardDebug;
 macro_rules! storage_permissions_null_component_static {
     ($C:ty, $D:ty $(,)?) => {{
         kernel::static_buf!(capsules_system::storage_permissions::null::NullStoragePermissions<$C, $D>)
-    };};
+    }};
 }
 
 pub type StoragePermissionsNullComponentType<C, D> =

--- a/boards/components/src/storage_permissions/tbf_header.rs
+++ b/boards/components/src/storage_permissions/tbf_header.rs
@@ -36,7 +36,7 @@ macro_rules! storage_permissions_tbf_header_component_static {
                 $CAP,
             >
         )
-    };};
+    }};
 }
 
 pub type StoragePermissionsTbfHeaderComponentType<C, D, CAP> =

--- a/boards/components/src/temperature.rs
+++ b/boards/components/src/temperature.rs
@@ -19,9 +19,7 @@ use kernel::hil;
 
 #[macro_export]
 macro_rules! temperature_component_static {
-    ($T:ty $(,)?) => {{
-        kernel::static_buf!(capsules_extra::temperature::TemperatureSensor<'static, $T>)
-    };};
+    ($T:ty $(,)?) => {{ kernel::static_buf!(capsules_extra::temperature::TemperatureSensor<'static, $T>) }};
 }
 
 pub type TemperatureComponentType<T> = capsules_extra::temperature::TemperatureSensor<'static, T>;

--- a/boards/components/src/temperature_rp2040.rs
+++ b/boards/components/src/temperature_rp2040.rs
@@ -23,7 +23,7 @@ macro_rules! temperature_rp2040_adc_component_static {
         );
 
         (adc_device, temperature_rp2040)
-    };};
+    }};
 }
 
 pub type TemperatureRp2040ComponentType<A> =

--- a/boards/components/src/temperature_stm.rs
+++ b/boards/components/src/temperature_stm.rs
@@ -23,7 +23,7 @@ macro_rules! temperature_stm_adc_component_static {
         );
 
         (adc_device, temperature_stm)
-    };};
+    }};
 }
 
 pub type TemperatureSTMComponentType<A> =

--- a/boards/components/src/test/multi_alarm_test.rs
+++ b/boards/components/src/test/multi_alarm_test.rs
@@ -23,7 +23,7 @@ macro_rules! multi_alarm_test_component_buf {
         let buf21 = kernel::static_buf!(TestRandomAlarm<'static, VirtualMuxAlarm<'static, $A>>);
 
         ((buf00, buf01)(buf10, buf11)(buf20, buf21))
-    };};
+    }};
 }
 
 pub struct MultiAlarmTestComponent<A: 'static + time::Alarm<'static>> {

--- a/boards/components/src/text_screen.rs
+++ b/boards/components/src/text_screen.rs
@@ -35,7 +35,7 @@ macro_rules! text_screen_component_static {
         let screen = kernel::static_buf!(capsules_extra::text_screen::TextScreen);
 
         (buffer, screen)
-    };};
+    }};
 }
 
 pub struct TextScreenComponent<

--- a/boards/components/src/thread_network.rs
+++ b/boards/components/src/thread_network.rs
@@ -100,7 +100,7 @@ macro_rules! thread_network_component_static {
             alarm,
             driver_cap,
         )
-    };};
+    }};
 }
 pub struct ThreadNetworkComponent<
     A: Alarm<'static> + 'static,

--- a/boards/components/src/tickv.rs
+++ b/boards/components/src/tickv.rs
@@ -70,7 +70,7 @@ macro_rules! tickv_component_static {
         );
 
         (flash, tickv)
-    };};
+    }};
 }
 
 #[macro_export]
@@ -81,7 +81,7 @@ macro_rules! tickv_dedicated_flash_component_static {
             kernel::static_buf!(capsules_extra::tickv::TicKVSystem<'static, $F, $H, $PAGE_SIZE>);
 
         (tickv, tickfs_read_buffer)
-    };};
+    }};
 }
 
 pub struct TicKVComponent<

--- a/boards/components/src/touch.rs
+++ b/boards/components/src/touch.rs
@@ -41,9 +41,7 @@ use kernel::component::Component;
 
 #[macro_export]
 macro_rules! touch_component_static {
-    () => {{
-        kernel::static_buf!(capsules_extra::touch::Touch<'static>)
-    };};
+    () => {{ kernel::static_buf!(capsules_extra::touch::Touch<'static>) }};
 }
 
 pub struct TouchComponent<CAP: MemoryAllocationCapability + 'static> {

--- a/boards/components/src/udp_driver.rs
+++ b/boards/components/src/udp_driver.rs
@@ -76,7 +76,7 @@ macro_rules! udp_driver_component_static {
             udp_recv,
             driver_cap,
         )
-    };};
+    }};
 }
 
 pub type UDPDriverComponentType = capsules_extra::net::udp::UDPDriver<'static>;

--- a/boards/components/src/udp_mux.rs
+++ b/boards/components/src/udp_mux.rs
@@ -150,7 +150,7 @@ macro_rules! udp_mux_component_static {
             udp_vis_cap,
             ip_vis_cap,
         )
-    };};
+    }};
 }
 
 pub struct UDPMuxComponent<

--- a/boards/components/src/virtual_scheduler_timer.rs
+++ b/boards/components/src/virtual_scheduler_timer.rs
@@ -25,7 +25,7 @@ macro_rules! virtual_scheduler_timer_component_static {
         );
 
         (alarm, scheduler_timer)
-    };};
+    }};
 }
 
 pub type VirtualSchedulerTimerComponentType<A> = VirtualSchedulerTimer<VirtualMuxAlarm<'static, A>>;
@@ -67,7 +67,7 @@ macro_rules! virtual_scheduler_timer_no_mux_component_static {
         );
 
         scheduler_timer
-    };};
+    }};
 }
 
 pub type VirtualSchedulerTimerNoMuxComponentType<A> = VirtualSchedulerTimer<A>;

--- a/boards/imix/src/test/udp_lowpan_test.rs
+++ b/boards/imix/src/test/udp_lowpan_test.rs
@@ -431,7 +431,7 @@ impl<'a, A: time::Alarm<'a>> LowpanTest<'a, A> {
 
     fn capsule_send_fail(&self) {
         let ret = self.mock_udp1.send(0);
-        assert!(ret != Ok(())); //trying to send while not bound should fail!
+        assert_ne!(ret, Ok(())); //trying to send while not bound should fail!
 
         debug!("send_fail test passed")
     }

--- a/boards/nordic/nrf52_components/src/startup.rs
+++ b/boards/nordic/nrf52_components/src/startup.rs
@@ -158,9 +158,7 @@ impl Component for NrfClockComponent<'_> {
 
 #[macro_export]
 macro_rules! uart_channel_component_static {
-    ($A:ty $(,)?) => {{
-        components::segger_rtt_component_static!($A)
-    };};
+    ($A:ty $(,)?) => {{ components::segger_rtt_component_static!($A) }};
 }
 
 /// Pins for the UART

--- a/capsules/core/src/adc.rs
+++ b/capsules/core/src/adc.rs
@@ -372,18 +372,13 @@ impl<'a, A: hil::adc::Adc<'a> + hil::adc::AdcHighSpeed<'a>> AdcDedicated<'a, A> 
                             .map_or(Err(ErrorCode::BUSY), move |buf2| {
                                 // determine request length
                                 let request_len = app_buf_length / 2;
-                                let len1;
-                                let len2;
-                                if request_len <= buf1.len() {
-                                    len1 = app_buf_length / 2;
-                                    len2 = 0;
+                                let (len1, len2) = if request_len <= buf1.len() {
+                                    (app_buf_length / 2, 0)
                                 } else if request_len <= (buf1.len() + buf2.len()) {
-                                    len1 = buf1.len();
-                                    len2 = request_len - buf1.len();
+                                    (buf1.len(), request_len - buf1.len())
                                 } else {
-                                    len1 = buf1.len();
-                                    len2 = buf2.len();
-                                }
+                                    (buf1.len(), buf2.len())
+                                };
 
                                 // begin sampling
                                 app.using_app_buf0.set(true);
@@ -873,15 +868,11 @@ impl<'a, A: hil::adc::Adc<'a> + hil::adc::AdcHighSpeed<'a>> hil::adc::HighSpeedC
                         // determine which app buffer to copy data into and which is
                         // next up if we're in continuous mode
                         let use0 = app.using_app_buf0.get();
-                        let next_app_buf;
-                        let app_buf_ref;
-                        if use0 {
-                            app_buf_ref = &app_buf0;
-                            next_app_buf = &app_buf1;
+                        let (app_buf_ref, next_app_buf) = if use0 {
+                            (&app_buf0, &app_buf1)
                         } else {
-                            app_buf_ref = &app_buf1;
-                            next_app_buf = &app_buf0;
-                        }
+                            (&app_buf1, &app_buf0)
+                        };
 
                         // update count of outstanding sample requests
                         app.samples_outstanding

--- a/capsules/core/src/console_ordered.rs
+++ b/capsules/core/src/console_ordered.rs
@@ -210,10 +210,10 @@ impl<'a, A: Alarm<'a>> ConsoleOrdered<'a, A> {
             app.pending_write = true;
         } else if app.write_len <= debug_space_avail {
             // Space for the full write, make it
-            app.write_position = self.send(app, kernel_data).map_or(0, |len| len);
+            app.write_position = self.send(app, kernel_data).unwrap_or(0);
         } else if self.atomic_size.get() <= debug_space_avail {
             // Space for a partial write, make it
-            app.write_position = self.send(app, kernel_data).map_or(0, |len| len);
+            app.write_position = self.send(app, kernel_data).unwrap_or(0);
         } else {
             // No space even for a partial, minimum size write: enqueue
             app.pending_write = true;
@@ -345,8 +345,7 @@ impl<'a, A: Alarm<'a>> AlarmClient for ConsoleOrdered<'a, A> {
 
                             // Write, or if there isn't space for a minimum write, retry later
                             if minimum_write <= debug_space_avail {
-                                app.write_position +=
-                                    self.send(app, kernel_data).map_or(0, |len| len);
+                                app.write_position += self.send(app, kernel_data).unwrap_or(0);
                             } else {
                                 self.alarm.set_alarm(
                                     self.alarm.now(),

--- a/capsules/extra/src/lpm013m126.rs
+++ b/capsules/extra/src/lpm013m126.rs
@@ -155,7 +155,7 @@ impl<'a> FrameBuffer<'a> {
             for (frame_pixel, buf_pixel) in frame_row
                 .iter_mut()
                 .skip(buffer.frame.column as usize)
-                .zip(buf_row.data.chunks_exact(2))
+                .zip(buf_row.data.as_chunks::<2>().0.iter())
             {
                 let buf_pixel = [buf_pixel[0], buf_pixel[1]];
                 let buf_p = u16::from_le_bytes(buf_pixel);

--- a/capsules/extra/src/net/ipv6/ipv6_send.rs
+++ b/capsules/extra/src/net/ipv6/ipv6_send.rs
@@ -150,17 +150,16 @@ impl<'a, A: time::Alarm<'a>> IP6Sender<'a> for IP6SendStruct<'a, A> {
         // with the manner in which Thread addresses packets,
         // but may conflict with some other or future protocol
         // that sits above and uses IPV6
-        let dst_mac_addr;
-        if dst == MULTICAST_IPV6 {
+        let dst_mac_addr = if dst == MULTICAST_IPV6 {
             // use short multicast ipv6 for dst mac address
-            dst_mac_addr = MacAddress::Short(0xFFFF)
+            MacAddress::Short(0xFFFF)
         } else if dst.0[0..8] == [0xfe, 0x80, 0, 0, 0, 0, 0, 0] {
             // ipv6 address is of form fe80::MAC; use mac_from_ipv6
             // helper function to determine ipv6 to send to
-            dst_mac_addr = MacAddress::Long(mac_from_ipv6(dst))
+            MacAddress::Long(mac_from_ipv6(dst))
         } else {
-            dst_mac_addr = self.dst_mac_addr;
-        }
+            self.dst_mac_addr
+        };
 
         // TODO: add error handling here
         let _ = self

--- a/capsules/extra/src/screen/screen_adapters/mono_vlsb.rs
+++ b/capsules/extra/src/screen/screen_adapters/mono_vlsb.rs
@@ -131,9 +131,9 @@ fn convert_mvlsb_sub_rect(src: &[u8], dst: &mut [u8], sub_cols: usize) {
             // Extract the row of source pixels
             let src_row_pixels = src_page.iter().map(|b| (b >> bit) & 1 != 0);
             // Within a row, each source byte fills one 4-byte pixel.
-            let dst_row_pixels = dst_row.chunks_exact_mut(4);
+            let dst_row_pixels = dst_row.as_chunks_mut::<4>().0;
 
-            for (src_pixel, dst_pixel) in src_row_pixels.zip(dst_row_pixels) {
+            for (src_pixel, dst_pixel) in src_row_pixels.zip(dst_row_pixels.iter_mut()) {
                 // Yellow foreground, black background.
                 let color = if src_pixel {
                     [0, 0xFF, 0xFF, 0xFF]

--- a/capsules/extra/src/test/aes.rs
+++ b/capsules/extra/src/test/aes.rs
@@ -95,7 +95,7 @@ impl<'a, A: AES<'a, AES128> + AESECB> TestAes128Ecb<'a, A> {
                 key[i] = *b;
             }
 
-            assert!(self.aes.set_key(key) == Ok(()));
+            assert_eq!(self.aes.set_key(key), Ok(()));
         });
 
         // Copy mode-appropriate source into source buffer
@@ -196,7 +196,7 @@ impl<'a, A: AES<'a, AES128> + AESCtr> TestAes128Ctr<'a, A> {
                 key[i] = *b;
             }
 
-            assert!(self.aes.set_key(key) == Ok(()));
+            assert_eq!(self.aes.set_key(key), Ok(()));
         });
 
         // Copy mode-appropriate IV into IV buffer and configure it in the hardware
@@ -206,7 +206,7 @@ impl<'a, A: AES<'a, AES128> + AESCtr> TestAes128Ctr<'a, A> {
                 iv[i] = *b;
             }
 
-            assert!(self.aes.set_iv(iv) == Ok(()));
+            assert_eq!(self.aes.set_iv(iv), Ok(()));
         });
 
         // Copy mode-appropriate source into source buffer
@@ -370,7 +370,7 @@ impl<'a, A: AES<'a, AES128> + AESCBC> TestAes128Cbc<'a, A> {
                 key[i] = *b;
             }
 
-            assert!(self.aes.set_key(key) == Ok(()));
+            assert_eq!(self.aes.set_key(key), Ok(()));
         });
 
         // Copy mode-appropriate IV into IV buffer and configure it in the hardware
@@ -381,7 +381,7 @@ impl<'a, A: AES<'a, AES128> + AESCBC> TestAes128Cbc<'a, A> {
                 iv[i] = *b;
             }
 
-            assert!(self.aes.set_iv(iv) == Ok(()));
+            assert_eq!(self.aes.set_iv(iv), Ok(()));
         });
 
         // Copy mode-appropriate source into source buffer

--- a/chips/apollo3/src/lib.rs
+++ b/chips/apollo3/src/lib.rs
@@ -5,6 +5,15 @@
 //! Peripheral implementations for the Apollo3 MCU.
 
 #![no_std]
+// Fixes this error introduced in nightly-2026-07:
+//
+// ```
+// error: queries overflow the depth limit!
+//   |
+//   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`apollo3`)
+//   = note: query depth increased by 130 when simplifying constant for the type system `mcuctrl::_`
+// ```
+#![recursion_limit = "256"]
 
 // Peripherals
 pub mod ble;

--- a/chips/earlgrey/src/epmp.rs
+++ b/chips/earlgrey/src/epmp.rs
@@ -987,7 +987,7 @@ impl<const HANDOVER_CONFIG_CHECK: bool, DBG: EPMPDebugConfig>
         // Currently, this code requires the TOR regions to start at an even PMP
         // region index. Assert that this is indeed the case:
         #[allow(clippy::let_unit_value)]
-        let _: () = assert!(DBG::TOR_USER_ENTRIES_OFFSET % 2 == 0);
+        let _: () = assert_eq!(DBG::TOR_USER_ENTRIES_OFFSET % 2, 0);
 
         // We store the "enabled" PMPCFG octets of user regions in the
         // `shadow_user_pmpcfg` field, such that we can re-enable the PMP

--- a/chips/litex/src/timer.rs
+++ b/chips/litex/src/timer.rs
@@ -202,7 +202,7 @@ impl<R: LiteXSoCRegisterConfiguration, F: Frequency> LiteXTimer<'_, R, F> {
                 // If the timer really is a oneshot, the remaining time must be 0
                 WriteRegWrapper::wrap(&self.registers.update_value)
                     .write(update_value::latch_value::SET);
-                assert!(self.registers.value.get() == 0);
+                assert_eq!(self.registers.value.get(), 0);
 
                 // Completely disable and make sure it doesn't generate
                 // more interrupts until it is started again

--- a/chips/litex/src/uart.rs
+++ b/chips/litex/src/uart.rs
@@ -395,7 +395,7 @@ impl<'a, R: LiteXSoCRegisterConfiguration> uart::Transmit<'a> for LiteXUart<'a, 
         // and reading txfull. Hence, if an event is pending, rely on
         // the fact that an interrupt will be generated.
         if !(fifo_full || self.uart_regs.ev().event_pending(EVENT_MANAGER_INDEX_TX)) {
-            assert!(progress == tx_len);
+            assert_eq!(progress, tx_len);
 
             self.tx_deferred_call.set(true);
             self.deferred_call.set();

--- a/chips/sam4l/src/acifc.rs
+++ b/chips/sam4l/src/acifc.rs
@@ -458,20 +458,19 @@ impl<'a> analog_comparator::AnalogComparator<'a> for Acifc<'a> {
     fn comparison(&self, channel: &Self::Channel) -> bool {
         self.enable();
         let regs = ACIFC_BASE;
-        let result;
-        if channel.chan_num == 0 {
-            result = regs.sr.is_set(Status::ACCS0);
+        let result = if channel.chan_num == 0 {
+            regs.sr.is_set(Status::ACCS0)
         } else if channel.chan_num == 1 {
-            result = regs.sr.is_set(Status::ACCS1);
+            regs.sr.is_set(Status::ACCS1)
         } else if channel.chan_num == 2 {
-            result = regs.sr.is_set(Status::ACCS2);
+            regs.sr.is_set(Status::ACCS2)
         } else if channel.chan_num == 3 {
-            result = regs.sr.is_set(Status::ACCS3);
+            regs.sr.is_set(Status::ACCS3)
         } else {
             // Should never get here, just making sure
             self.disable();
             panic!("PANIC! Please choose a comparator (value of ac) that this chip supports");
-        }
+        };
         result
     }
 

--- a/chips/stm32wle5xx/src/chip.rs
+++ b/chips/stm32wle5xx/src/chip.rs
@@ -148,7 +148,7 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32wle5xx<'a, I> {
                         !(1u128 << crate::nvic::RADIO_IRQ),
                     )) {
                         // check to confirm we masked properly
-                        assert!(radio_interrupt == crate::nvic::RADIO_IRQ);
+                        assert_eq!(radio_interrupt, crate::nvic::RADIO_IRQ);
                         self.interrupt_service.service_interrupt(radio_interrupt);
                         let n = cortexm4::nvic::Nvic::new(radio_interrupt);
                         n.clear_pending();

--- a/chips/stm32wle5xx/src/pwr.rs
+++ b/chips/stm32wle5xx/src/pwr.rs
@@ -62,7 +62,7 @@ pub struct Pwr {
 
 impl Pwr {
     pub fn new() -> Pwr {
-        assert!(core::mem::size_of::<PwrRegisters>() == 0x94);
+        assert_eq!(core::mem::size_of::<PwrRegisters>(), 0x94);
         Pwr { registers: PWR }
     }
 

--- a/chips/virtio/src/devices/virtio_gpu/mod.rs
+++ b/chips/virtio/src/devices/virtio_gpu/mod.rs
@@ -397,7 +397,7 @@ impl<'a, 'b, F: DmaFence> VirtIOGPU<'a, 'b, F> {
             .len()
             .checked_sub(write_buffer_offset)
             .unwrap();
-        assert!(write_buffer_remaining_bytes % PIXEL_STRIDE == 0);
+        assert_eq!(write_buffer_remaining_bytes % PIXEL_STRIDE, 0);
         let write_buffer_remaining_pixels = write_buffer_remaining_bytes / PIXEL_STRIDE;
         assert!(write_buffer_remaining_pixels <= remaining_pixels);
 

--- a/chips/virtio/src/queues/split_queue.rs
+++ b/chips/virtio/src/queues/split_queue.rs
@@ -761,7 +761,10 @@ impl<'a, 'b, const MAX_QUEUE_SIZE: usize, F: DmaFence> SplitVirtqueue<'a, 'b, MA
             let dma_virtqueue_buffer = self.descriptor_buffers[current_index]
                 .take()
                 .expect("Virtqueue descriptors and slices out of sync");
-            assert!(dma_virtqueue_buffer.as_ptr() as u64 == current_desc.addr.get());
+            assert_eq!(
+                dma_virtqueue_buffer.as_ptr() as u64,
+                current_desc.addr.get()
+            );
 
             // Return the original VirtqueueBuffer (which we obtain from the DMA
             // buffer, now that the operation is over), and hand it back with

--- a/chips/x86_q35/src/vga.rs
+++ b/chips/x86_q35/src/vga.rs
@@ -178,8 +178,8 @@ impl TextBuf {
 
     /// Iterate rows as fixed-size chunks.
     #[inline(always)]
-    fn rows(&self) -> core::slice::ChunksExact<'_, VolatileCell<u16>> {
-        self.cells[..].chunks_exact(TEXT_BUFFER_WIDTH)
+    fn rows(&self) -> &[[VolatileCell<u16>; 80]] {
+        self.cells[..].as_chunks::<TEXT_BUFFER_WIDTH>().0
     }
 
     /// Expose an Option for row, col for the user
@@ -344,7 +344,7 @@ impl Vga {
 
         // move rows 1..H up by one
         let rows = VgaDevice::TEXT.rows();
-        let src_rows = rows.clone().skip(1);
+        let src_rows = rows.iter().clone().skip(1);
         let dst_rows = rows;
         for (src_row, dst_row) in src_rows.zip(dst_rows) {
             for (src, dst) in src_row.iter().zip(dst_row.iter()) {

--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -73,7 +73,7 @@ of installing some of these tools, but you can also install them yourself.
 
 #### Rust (nightly)
 
-We are using `nightly-2026-04-21`. We require
+We are using `nightly-2026-07-21`. We require
 installing it with [rustup](http://www.rustup.rs) so you can manage multiple
 versions of Rust and continue using stable versions for other Rust code:
 
@@ -88,7 +88,7 @@ to your `$PATH`.
 Then install the correct nightly version of Rust:
 
 ```bash
-$ rustup install nightly-2026-04-21
+$ rustup install nightly-2026-07-21
 ```
 
 ### Compiling the Kernel

--- a/libraries/tock-tbf/src/parse.rs
+++ b/libraries/tock-tbf/src/parse.rs
@@ -83,11 +83,11 @@ pub fn parse_tbf_header(
             let mut checksum: u32 = 0;
 
             // Get an iterator across 4 byte fields in the header.
-            let header_iter = header.chunks_exact(4);
+            let (header_chunks, _remainder) = header.as_chunks::<4>();
 
             // Iterate all chunks and XOR the chunks to compute the checksum.
-            for (i, chunk) in header_iter.enumerate() {
-                let word = u32::from_le_bytes(chunk.try_into()?);
+            for (i, chunk) in header_chunks.iter().enumerate() {
+                let word = u32::from_le_bytes(*chunk);
                 if i == 3 {
                     // Skip the checksum field.
                 } else {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,6 +3,6 @@
 # Copyright Tock Contributors 2023.
 
 [toolchain]
-channel = "nightly-2026-04-21"
+channel = "nightly-2026-07-21"
 components = ["miri", "llvm-tools", "rust-src", "rustfmt", "clippy", "rust-analyzer"]
 targets = ["thumbv6m-none-eabi", "thumbv7em-none-eabi", "thumbv7em-none-eabihf", "thumbv8m.main-none-eabi", "riscv32imc-unknown-none-elf", "riscv32imac-unknown-none-elf"]


### PR DESCRIPTION
### Pull Request Overview

It has been three months since our last nightly update. This updates to July 2026 nightly.

This has the normal clippy updates that come with a newer nightly.

The main change from the updated Rust version is a change in how macros can use semicolons. This is an example error that we now get:

```
error: trailing semicolon in macro used in expression position
   --> boards/nucleo_u545re_q/src/main.rs:215:19
    |
215 |         .finalize(components::uart_mux_component_static!());
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: `#[deny(semicolon_in_expressions_from_macros)]` (part of `#[deny(future_incompatible)]`) on by default
    = note: this error originates in the macro `components::uart_mux_component_static` (in Nightly builds, run with -Z macro-backtrace for more info)
```

The fix is just to remove the semi colon from after the inner `{}` block in our component macros. I did this with just a find-and-replace.


### Testing Strategy

travis


### TODO or Help Wanted

I'm not sure about the [chunks-exact-to-as-chunks](https://github.com/tock/tock/commit/9d904829ccaa36060bf5f4e0c7e46e68b844ebc3) clippy lint. The clippy page makes it seem reasonable, but I feel like the actual code changes are just worse. However, maybe if you were writing the code from scratch it would guide you in the right direction, and trying to create a minimal patch on existing code isn't ideal. Thoughts on this lint? Should we just allow it instead of fixing the couple cases?


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [x] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [ ] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

I had claude fix all of the assertion changes from that clippy lint.
