### PR TITLE
kernel: debug: print if panic resources not set; stm32u5: set panic resources

### DIFF
--- a/boards/nucleo_u545re_q/src/main.rs
+++ b/boards/nucleo_u545re_q/src/main.rs
@@ -6,13 +6,13 @@
 #![no_std]
 #![no_main]
 
-use kernel::capabilities;
 use kernel::component::Component;
 use kernel::debug::PanicResources;
 use kernel::deferred_call::DeferredCallClient;
 use kernel::platform::chip::Chip;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::{capabilities, debug};
 use kernel::{create_capability, static_init};
 
 use stm32u545::gpio::PinId;
@@ -177,6 +177,12 @@ unsafe fn start() -> (
         <ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider,
     >();
 
+    // Bind global variables to this thread.
+    let _ = PANIC_RESOURCES
+        .bind_to_thread::<<ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider>(
+            PanicResources::new(),
+        );
+
     // Create Individual Drivers
     let exti = static_init!(
         stm32u545::exti::Exti<'static>,
@@ -209,6 +215,10 @@ unsafe fn start() -> (
     // Kernel and Muxes
     let processes = components::process_array::ProcessArrayComponent::new()
         .finalize(components::process_array_component_static!(NUM_PROCS));
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.processes.put(processes.as_slice());
+    });
+
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
 
     let uart_mux = components::console::UartMuxComponent::new(periphs.usart1, 115200)
@@ -234,12 +244,17 @@ unsafe fn start() -> (
     )
     .finalize(components::debug_writer_component_static!());
 
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.printer.put(process_printer);
+    });
+
     let process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         alarm_mux,
-        components::process_printer::ProcessPrinterTextComponent::new()
-            .finalize(components::process_printer_text_component_static!()),
+        process_printer,
         None,
     )
     .finalize(components::process_console_component_static!(
@@ -327,13 +342,15 @@ unsafe fn start() -> (
             11 => periphs.gpio_a.pin(PinId::Pin07), // D11
             12 => periphs.gpio_a.pin(PinId::Pin06), // D12
             // 13 => D13/PA5 is used by the LD2 LED capsule
-            // D14-D15 require GPIOB
+            14 => periphs.gpio_b.pin(PinId::Pin07), // D14
+            15 => periphs.gpio_b.pin(PinId::Pin06), // D15
+
 
             // Analog pins exposed as GPIO
             16 => periphs.gpio_a.pin(PinId::Pin00), // A0
             17 => periphs.gpio_a.pin(PinId::Pin01), // A1
             18 => periphs.gpio_a.pin(PinId::Pin04), // A2
-            // 19 => A3 requires GPIOB
+            19 => periphs.gpio_b.pin(PinId::Pin00), // A3
             20 => periphs.gpio_c.pin(PinId::Pin01), // A4
             21 => periphs.gpio_c.pin(PinId::Pin00), // A5
 
@@ -368,6 +385,10 @@ unsafe fn start() -> (
         stm32u545::chip::Stm32u5xx<stm32u545::chip::Stm32u5xxDefaultPeripherals>,
         stm32u545::chip::Stm32u5xx::new(periphs)
     );
+
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.chip.put(chip);
+    });
 
     // Symbols for linker
     extern "C" {
@@ -409,6 +430,9 @@ pub unsafe fn main() {
     let main_loop_capability = create_capability!(capabilities::MainLoopCapability);
 
     let (board_kernel, platform, chip) = start();
+
+    debug!("Initialization complete. Entering main loop");
+
     // Hand over control to the Tock Kernel Loop
     board_kernel.kernel_loop::<NucleoU545RE, ChipHw, { NUM_PROCS as u8 }>(
         platform,

--- a/chips/stm32u5xx/src/chip.rs
+++ b/chips/stm32u5xx/src/chip.rs
@@ -21,6 +21,7 @@ use crate::usart;
 use crate::{dac, exti};
 
 use core::fmt::Write;
+use cortexm33::{CortexM33, CortexMVariant};
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
 
@@ -316,6 +317,6 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32u5xx<'a, I> {
     }
 
     unsafe fn print_state(_this: Option<&Self>, write: &mut dyn Write) {
-        let _ = write.write_str("Cortex-M33 state\n");
+        CortexM33::print_cortexm_state(write);
     }
 }

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -187,10 +187,10 @@ pub unsafe fn panic_print<PW: PanicWriter, C: Chip, PP: ProcessPrinter>(
             if let Some(p) = pr.processes.take() {
                 panic_process_info(p, pr.printer.take(), &mut writer);
             } else {
-                let _ = writer.write_str("Processes List is not available\r\n");
+                let _ = writer.write_str("\r\nProcesses List is not available\r\n");
             }
         } else {
-            let _ = writer.write_str("Panic Resources are not available\r\n");
+            let _ = writer.write_str("\r\nPanic Resources are not available\r\n");
         }
     }
 }
@@ -259,10 +259,10 @@ pub unsafe fn panic_print_old<W: Write + IoWrite, C: Chip, PP: ProcessPrinter>(
             if let Some(p) = pr.processes.take() {
                 panic_process_info(p, pr.printer.take(), writer);
             } else {
-                let _ = writer.write_str("Processes List is not available\r\n");
+                let _ = writer.write_str("\r\nProcesses List is not available\r\n");
             }
         } else {
-            let _ = writer.write_str("Panic Resources are not available\r\n");
+            let _ = writer.write_str("\r\nPanic Resources are not available\r\n");
         }
     }
 }

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -185,7 +185,11 @@ pub unsafe fn panic_print<PW: PanicWriter, C: Chip, PP: ProcessPrinter>(
                 c.mpu().disable_app_mpu()
             });
             if let Some(p) = pr.processes.take() {
-                panic_process_info(p, pr.printer.take(), &mut writer);
+                if let Some(process_printer) = pr.printer.take() {
+                    panic_process_info(p, process_printer, &mut writer);
+                } else {
+                    let _ = writer.write_str("\r\nProcess Printer is not available\r\n");
+                }
             } else {
                 let _ = writer.write_str("\r\nProcesses List is not available\r\n");
             }
@@ -257,7 +261,11 @@ pub unsafe fn panic_print_old<W: Write + IoWrite, C: Chip, PP: ProcessPrinter>(
                 c.mpu().disable_app_mpu()
             });
             if let Some(p) = pr.processes.take() {
-                panic_process_info(p, pr.printer.take(), writer);
+                if let Some(process_printer) = pr.printer.take() {
+                    panic_process_info(p, process_printer, writer);
+                } else {
+                    let _ = writer.write_str("\r\nProcess Printer is not available\r\n");
+                }
             } else {
                 let _ = writer.write_str("\r\nProcesses List is not available\r\n");
             }
@@ -350,10 +358,9 @@ pub unsafe fn panic_banner<W: Write>(writer: &mut W, panic_info: &PanicInfo) {
 pub unsafe fn panic_cpu_state<W: Write, C: Chip>(chip: Option<&'static C>, writer: &mut W) {
     if chip.is_none() {
         let _ = writer.write_str("\r\nChip Information is not available\r\n");
-    } else {
-        unsafe {
-            C::print_state(chip, writer);
-        }
+    }
+    unsafe {
+        C::print_state(chip, writer);
     }
 }
 
@@ -362,26 +369,26 @@ pub unsafe fn panic_cpu_state<W: Write, C: Chip>(chip: Option<&'static C>, write
 /// **NOTE:** The supplied `writer` must be synchronous.
 pub unsafe fn panic_process_info<PP: ProcessPrinter, W: Write>(
     processes: &'static [ProcessSlot],
-    process_printer: Option<&'static PP>,
+    process_printer: &'static PP,
     writer: &mut W,
 ) {
     if processes.iter().filter(|p| p.get().is_some()).count() > 0 {
-        if let Some(printer) = process_printer {
-            // print data about each process
-            let _ = writer.write_fmt(format_args!("\r\n---| App Status |---\r\n"));
-            for slot in processes {
-                slot.proc.get().map(|process| {
-                    // Print the memory map and basic process info.
-                    //
-                    // Because we are using a synchronous printer we do not need to
-                    // worry about looping on the print function.
-                    printer.print_overview(process, &mut BinaryToWriteWrapper::new(writer), None);
-                    // Print all of the process details.
-                    process.print_full_process(writer);
-                });
-            }
-        } else {
-            let _ = writer.write_str("\r\nProcess Printer is not available\r\n");
+        // print data about each process
+        let _ = writer.write_fmt(format_args!("\r\n---| App Status |---\r\n"));
+        for slot in processes {
+            slot.proc.get().map(|process| {
+                // Print the memory map and basic process info.
+                //
+                // Because we are using a synchronous printer we do not need to
+                // worry about looping on the print function.
+                process_printer.print_overview(
+                    process,
+                    &mut BinaryToWriteWrapper::new(writer),
+                    None,
+                );
+                // Print all of the process details.
+                process.print_full_process(writer);
+            });
         }
     } else {
         let _ = writer.write_str("\r\nNo loaded processes\r\n");

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -172,7 +172,7 @@ pub unsafe fn panic_print<PW: PanicWriter, C: Chip, PP: ProcessPrinter>(
         flush(&mut writer);
         panic_banner(&mut writer, panic_info);
 
-        panic_resources.map(|pr| {
+        if let Some(pr) = panic_resources {
             let chip = pr.chip.take();
             panic_cpu_state(chip, &mut writer);
 
@@ -184,10 +184,14 @@ pub unsafe fn panic_print<PW: PanicWriter, C: Chip, PP: ProcessPrinter>(
                 use crate::platform::mpu::MPU;
                 c.mpu().disable_app_mpu()
             });
-            pr.processes.take().map(|p| {
+            if let Some(p) = pr.processes.take() {
                 panic_process_info(p, pr.printer.take(), &mut writer);
-            });
-        });
+            } else {
+                let _ = writer.write_str("Processes List is not available\r\n");
+            }
+        } else {
+            let _ = writer.write_str("Panic Resources are not available\r\n");
+        }
     }
 }
 
@@ -240,7 +244,7 @@ pub unsafe fn panic_print_old<W: Write + IoWrite, C: Chip, PP: ProcessPrinter>(
         flush(writer);
         panic_banner(writer, panic_info);
 
-        panic_resources.map(|pr| {
+        if let Some(pr) = panic_resources {
             let chip = pr.chip.take();
             panic_cpu_state(chip, writer);
 
@@ -252,10 +256,14 @@ pub unsafe fn panic_print_old<W: Write + IoWrite, C: Chip, PP: ProcessPrinter>(
                 use crate::platform::mpu::MPU;
                 c.mpu().disable_app_mpu()
             });
-            pr.processes.take().map(|p| {
+            if let Some(p) = pr.processes.take() {
                 panic_process_info(p, pr.printer.take(), writer);
-            });
-        });
+            } else {
+                let _ = writer.write_str("Processes List is not available\r\n");
+            }
+        } else {
+            let _ = writer.write_str("Panic Resources are not available\r\n");
+        }
     }
 }
 
@@ -340,8 +348,12 @@ pub unsafe fn panic_banner<W: Write>(writer: &mut W, panic_info: &PanicInfo) {
 ///
 /// **NOTE:** The supplied `writer` must be synchronous.
 pub unsafe fn panic_cpu_state<W: Write, C: Chip>(chip: Option<&'static C>, writer: &mut W) {
-    unsafe {
-        C::print_state(chip, writer);
+    if chip.is_none() {
+        let _ = writer.write_str("\r\nChip Information is not available\r\n");
+    } else {
+        unsafe {
+            C::print_state(chip, writer);
+        }
     }
 }
 
@@ -353,21 +365,27 @@ pub unsafe fn panic_process_info<PP: ProcessPrinter, W: Write>(
     process_printer: Option<&'static PP>,
     writer: &mut W,
 ) {
-    process_printer.map(|printer| {
-        // print data about each process
-        let _ = writer.write_fmt(format_args!("\r\n---| App Status |---\r\n"));
-        for slot in processes {
-            slot.proc.get().map(|process| {
-                // Print the memory map and basic process info.
-                //
-                // Because we are using a synchronous printer we do not need to
-                // worry about looping on the print function.
-                printer.print_overview(process, &mut BinaryToWriteWrapper::new(writer), None);
-                // Print all of the process details.
-                process.print_full_process(writer);
-            });
+    if processes.iter().filter(|p| p.get().is_some()).count() > 0 {
+        if let Some(printer) = process_printer {
+            // print data about each process
+            let _ = writer.write_fmt(format_args!("\r\n---| App Status |---\r\n"));
+            for slot in processes {
+                slot.proc.get().map(|process| {
+                    // Print the memory map and basic process info.
+                    //
+                    // Because we are using a synchronous printer we do not need to
+                    // worry about looping on the print function.
+                    printer.print_overview(process, &mut BinaryToWriteWrapper::new(writer), None);
+                    // Print all of the process details.
+                    process.print_full_process(writer);
+                });
+            }
+        } else {
+            let _ = writer.write_str("\r\nProcess Printer is not available\r\n");
         }
-    });
+    } else {
+        let _ = writer.write_str("\r\nNo loaded processes\r\n");
+    }
 }
 
 /// Blinks a recognizable pattern forever.


### PR DESCRIPTION
### Pull Request Overview

This pull request:
  - fixes the setting of the panic resources for the stm32u5
  - adds some debug messages to the panic printers to print messages when information is not available
  - enables some of the missing GPIO pins
  - adds the printing of the kernel startup banner
  - fixes the Cortex M33 fault state printing function

We forgot to set the `PANIC_RESOURCES` fields for the stm32u5 board and the panic handler was not printing the correct information. Initially we thought it was a UART issue, just to figure out that we forgot to initialise the fields.

This PR adds some messages that clearly state of those fields are not available.

### Testing Strategy

This pull request was tested by @alexandruradovici.


### TODO or Help Wanted

N/A


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
