### PR TITLE
Capsule SPI-Controller: fix the length check for read operation

### DIFF
--- a/capsules/core/src/spi_controller.rs
+++ b/capsules/core/src/spi_controller.rs
@@ -369,7 +369,7 @@ impl<'a, S: SpiMasterDevice<'a>> SyscallDriver for Spi<'a, S> {
                             .get_readwrite_processbuffer(rw_allow::READ)
                             .map_or(0, |read| read.len());
 
-                        if rlen >= arg1 && rlen > 0 {
+                        if rlen >= arg1 && arg1 > 0 {
                             app.len = arg1;
                             app.index = 0;
                             self.busy.set(true);


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the request data length check for the SPI-controller read operation


### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

This pull request is ready to be reviewed and merged


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
