### PR TITLE
RFC: Add a `StaticRef`-like type that requires an "unlock" step before being used

### DIFF
--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -13,6 +13,8 @@
 use core::cell::Cell;
 use kernel::ErrorCode;
 use kernel::hil::uart;
+use kernel::utilities::MmioWithDmaRef;
+use kernel::utilities::MmioWithDmaRefUnlocked;
 use kernel::utilities::StaticRef;
 use kernel::utilities::cells::{MapCell, OptionalCell};
 use kernel::utilities::dma_slice::DmaSubSliceMut;
@@ -27,8 +29,13 @@ const UARTE_MAX_BUFFER_SIZE: usize = 0xff;
 
 static mut BYTE: u8 = 0;
 
-pub const UARTE0_BASE: StaticRef<UarteRegisters> =
-    unsafe { StaticRef::new(0x40002000 as *const UarteRegisters) };
+/// UARTE0 registers.
+///
+/// # Safety
+///
+/// This is the correct address on this MCU for this peripheral.
+pub const UARTE0_BASE: MmioWithDmaRef<UarteRegisters> =
+    unsafe { MmioWithDmaRef::new(0x40002000 as *const UarteRegisters) };
 
 #[repr(C)]
 pub struct UarteRegisters {
@@ -165,7 +172,7 @@ register_bitfields! [u32,
 /// Wrapper for managing MMIO for UARTE.
 struct UarteRegistersManager {
     /// MMIO registers for the UARTE peripheral.
-    registers: StaticRef<UarteRegisters>,
+    registers: MmioWithDmaRefUnlocked<UarteRegisters>,
     /// Holding place for the TX DMA buffer while DMA in progress.
     tx_dma_buf: MapCell<DmaSubSliceMut<'static, u8>>,
     /// Holding place for the RX DMA buffer while DMA in progress.
@@ -173,9 +180,12 @@ struct UarteRegistersManager {
 }
 
 impl UarteRegistersManager {
-    pub fn new(regs: StaticRef<UarteRegisters>) -> Self {
+    pub fn new(regs: MmioWithDmaRef<UarteRegisters>) -> Self {
+        // SAFETY: This register manager must only be constructed once.
+        // Therefore, we will only unlock the MMIO DMA registers at most once.
+        let registers = unsafe { regs.unlock() };
         Self {
-            registers: regs,
+            registers,
             tx_dma_buf: MapCell::empty(),
             rx_dma_buf: MapCell::empty(),
         }
@@ -338,7 +348,7 @@ pub struct UARTParams {
 impl<'a> Uarte<'a> {
     /// Constructor
     // This should only be constructed once
-    pub fn new(regs: StaticRef<UarteRegisters>) -> Uarte<'a> {
+    pub fn new(regs: MmioWithDmaRef<UarteRegisters>) -> Uarte<'a> {
         Uarte {
             registers: UarteRegistersManager::new(regs),
             tx_client: OptionalCell::empty(),

--- a/kernel/src/utilities/mod.rs
+++ b/kernel/src/utilities/mod.rs
@@ -24,6 +24,8 @@ pub mod storage_volume;
 pub mod streaming_process_slice;
 
 mod static_ref;
+pub use self::static_ref::MmioWithDmaRef;
+pub use self::static_ref::MmioWithDmaRefUnlocked;
 pub use self::static_ref::StaticRef;
 
 /// The Tock Register Interface.

--- a/kernel/src/utilities/static_ref.rs
+++ b/kernel/src/utilities/static_ref.rs
@@ -58,3 +58,61 @@ impl<T> Deref for StaticRef<T> {
         unsafe { self.ptr.as_ref() }
     }
 }
+
+#[derive(Debug)]
+pub struct MmioWithDmaRefUnlocked<T> {
+    ptr: NonNull<T>,
+}
+
+impl<T> MmioWithDmaRefUnlocked<T> {
+    /// Create a new [`MmioWithDmaRefUnlocked`].
+    ///
+    /// Internal use only.
+    const fn new(ptr: NonNull<T>) -> Self {
+        Self { ptr }
+    }
+}
+
+impl<T> Deref for MmioWithDmaRefUnlocked<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        // SAFETY: `ptr` is aligned and dereferencable for the program duration
+        // as promised by the caller of `StaticRef::new`.
+        unsafe { self.ptr.as_ref() }
+    }
+}
+
+#[derive(Debug)]
+pub struct MmioWithDmaRef<T> {
+    ptr: NonNull<T>,
+}
+
+impl<T> MmioWithDmaRef<T> {
+    /// Create a new [`MmioWithDmaRef`] from a raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// - `ptr` must be aligned, non-null, and dereferencable as `T`.
+    /// - `*ptr` must be valid for the program duration.
+    pub const unsafe fn new(ptr: *const T) -> Self {
+        // SAFETY: `ptr` is non-null as promised by the caller.
+        unsafe {
+            Self {
+                ptr: NonNull::new_unchecked(ptr.cast_mut()),
+            }
+        }
+    }
+
+    /// Get access to the internal `StaticRef`.
+    ///
+    /// This must only be called once! It is only valid to have a single
+    /// `MmioWithDmaRefUnlocked` for a given MMIO register map that has DMA
+    /// registers.
+    ///
+    /// # Safety
+    ///
+    /// This must only be called once.
+    pub unsafe fn unlock(&self) -> MmioWithDmaRefUnlocked<T> {
+        MmioWithDmaRefUnlocked::new(self.ptr)
+    }
+}


### PR DESCRIPTION
### Pull Request Overview

This PR is a sketch on how we might have an additional `StaticRef`-esque type for DMA-enabled peripherals. The key idea is this type requires _two_ unsafe operations:

1. The ref is created at a particular address. This requires the creator to attest that the MMIO register map actually matches the hardware at this exact address.
2. The ref is "unlocked". This requires the creator to attest that the unlock step has never happened before, and there is no other reference to the DMA registers anywhere. This ensures there is only a single owner of the DMA MMIO registers and there is no safe way to get a second reference to those registers.

These are two separate unsafe operations so they can be documented separately and executed at different places in code as needed. 


### Testing Strategy

RFC


### TODO or Help Wanted

It seems at least for DMA we need some way to reason about what can be done in safe code. Accessing the registers is OK as long as there is a single manager. There may be better ways to handle this. But this is an approach we can consider.


### Checklist

- [ ] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [ ] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
