### PR TITLE
fix: update the registers instead of local values in `set_syscall_return_value`

### DIFF
--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -326,7 +326,6 @@ impl<A: CortexMVariant> kernel::syscall::UserspaceKernelBoundary for SysCall<A> 
         // To offset the pointer there must be valid memory pointed to by `sp`.
         // We verified that there is space for four u32s on the stack before
         // hitting the `app_brk`.
-        let (r0, r1, r2, r3) = unsafe { (sp.add(0), sp.add(1), sp.add(2), sp.add(3)) };
 
         // # Safety
         //
@@ -348,18 +347,19 @@ impl<A: CortexMVariant> kernel::syscall::UserspaceKernelBoundary for SysCall<A> 
         //
         // Refer to
         // https://doc.rust-lang.org/std/primitive.pointer.html#safety-13
-        let (mut r0_val, mut r1_val, mut r2_val, mut r3_val) = unsafe { (*r0, *r1, *r2, *r3) };
+        unsafe {
+            let (r0, r1, r2, r3) = (sp.add(0), sp.add(1), sp.add(2), sp.add(3));
 
-        kernel::utilities::arch_helpers::encode_syscall_return_trd104(
-            &kernel::utilities::arch_helpers::TRD104SyscallReturn::from_syscall_return(
-                return_value,
-            ),
-            &mut r0_val,
-            &mut r1_val,
-            &mut r2_val,
-            &mut r3_val,
-        );
-
+            kernel::utilities::arch_helpers::encode_syscall_return_trd104(
+                &kernel::utilities::arch_helpers::TRD104SyscallReturn::from_syscall_return(
+                    return_value,
+                ),
+                &mut *r0,
+                &mut *r1,
+                &mut *r2,
+                &mut *r3,
+            );
+        }
         Ok(())
     }
 


### PR DESCRIPTION
### Pull Request Overview

This pull request resolves the issue related to the refactoring of the function in PR #4900. The refactoring of the `set_syscall_return_value` function consists solely of updating local variables instead of the registers themselves, and the register values are not actually updated, which causes applications to stop working.


### Testing Strategy

This pull request was tested by @genan2003 by loading the applications onto the board and verifying that they worked.


### TODO or Help Wanted

This pull request still needs review.


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
