### PR TITLE
fix: stm32u5xx cnt register offset

### DIFF
--- a/chips/stm32u5xx/src/tim.rs
+++ b/chips/stm32u5xx/src/tim.rs
@@ -321,7 +321,7 @@ register_bitfields![u32,
         CC1E OFFSET(0) NUMBITS(1) []
     ],
     CNT [
-        CNT OFFSET(16) NUMBITS(32) []
+        CNT OFFSET(0) NUMBITS(32) []
     ],
     PSC [
         /// Prescaler value


### PR DESCRIPTION
### Pull Request Overview

This pull request reverts the `CNT` register offset to `0` which was changed in the PR #4951. This change to the register broke the `TIM` component of the board.


### Testing Strategy

This pull request was tested by @genan2003 by flashing the boardd with the modified `TIM` component and observe that the `process_console` is working.


### TODO or Help Wanted

This pull request still needs review.


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
