### PR TITLE
cortex-m: fix syscall return register values

### DIFF
--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -326,7 +326,6 @@ impl<A: CortexMVariant> kernel::syscall::UserspaceKernelBoundary for SysCall<A> 
         // To offset the pointer there must be valid memory pointed to by `sp`.
         // We verified that there is space for four u32s on the stack before
         // hitting the `app_brk`.
-        let (r0, r1, r2, r3) = unsafe { (sp.add(0), sp.add(1), sp.add(2), sp.add(3)) };
 
         // # Safety
         //
@@ -348,18 +347,19 @@ impl<A: CortexMVariant> kernel::syscall::UserspaceKernelBoundary for SysCall<A> 
         //
         // Refer to
         // https://doc.rust-lang.org/std/primitive.pointer.html#safety-13
-        let (mut r0_val, mut r1_val, mut r2_val, mut r3_val) = unsafe { (*r0, *r1, *r2, *r3) };
+        unsafe {
+            let (r0, r1, r2, r3) = (sp.add(0), sp.add(1), sp.add(2), sp.add(3));
 
-        kernel::utilities::arch_helpers::encode_syscall_return_trd104(
-            &kernel::utilities::arch_helpers::TRD104SyscallReturn::from_syscall_return(
-                return_value,
-            ),
-            &mut r0_val,
-            &mut r1_val,
-            &mut r2_val,
-            &mut r3_val,
-        );
-
+            kernel::utilities::arch_helpers::encode_syscall_return_trd104(
+                &kernel::utilities::arch_helpers::TRD104SyscallReturn::from_syscall_return(
+                    return_value,
+                ),
+                &mut *r0,
+                &mut *r1,
+                &mut *r2,
+                &mut *r3,
+            );
+        }
         Ok(())
     }
 

--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -326,6 +326,7 @@ impl<A: CortexMVariant> kernel::syscall::UserspaceKernelBoundary for SysCall<A> 
         // To offset the pointer there must be valid memory pointed to by `sp`.
         // We verified that there is space for four u32s on the stack before
         // hitting the `app_brk`.
+        let (r0, r1, r2, r3) = unsafe { (sp.add(0), sp.add(1), sp.add(2), sp.add(3)) };
 
         // # Safety
         //
@@ -347,19 +348,18 @@ impl<A: CortexMVariant> kernel::syscall::UserspaceKernelBoundary for SysCall<A> 
         //
         // Refer to
         // https://doc.rust-lang.org/std/primitive.pointer.html#safety-13
-        unsafe {
-            let (r0, r1, r2, r3) = (sp.add(0), sp.add(1), sp.add(2), sp.add(3));
+        let (r0_ref, r1_ref, r2_ref, r3_ref) = unsafe { (&mut *r0, &mut *r1, &mut *r2, &mut *r3) };
 
-            kernel::utilities::arch_helpers::encode_syscall_return_trd104(
-                &kernel::utilities::arch_helpers::TRD104SyscallReturn::from_syscall_return(
-                    return_value,
-                ),
-                &mut *r0,
-                &mut *r1,
-                &mut *r2,
-                &mut *r3,
-            );
-        }
+        kernel::utilities::arch_helpers::encode_syscall_return_trd104(
+            &kernel::utilities::arch_helpers::TRD104SyscallReturn::from_syscall_return(
+                return_value,
+            ),
+            r0_ref,
+            r1_ref,
+            r2_ref,
+            r3_ref,
+        );
+
         Ok(())
     }
 


### PR DESCRIPTION
### Pull Request Overview

We need to fix this so this is a commit on top of #4979.


### Testing Strategy

Running these apps on the nrf52840dk:

```
┌──────────────────────────────────────────────────┐
│ App 0                                            |
└──────────────────────────────────────────────────┘
  Name:                  sha
  Version:               0
  Enabled:               True
  Sticky:                False
  Total Size in Flash:   16384 bytes


┌──────────────────────────────────────────────────┐
│ App 1                                            |
└──────────────────────────────────────────────────┘
  Name:                  blink
  Version:               0
  Enabled:               True
  Sticky:                False
  Total Size in Flash:   16384 bytes


┌──────────────────────────────────────────────────┐
│ App 2                                            |
└──────────────────────────────────────────────────┘
  Name:                  rot13_client
  Version:               0
  Enabled:               True
  Sticky:                False
  Total Size in Flash:   16384 bytes


┌──────────────────────────────────────────────────┐
│ App 3                                            |
└──────────────────────────────────────────────────┘
  Name:                  sensors
  Version:               0
  Enabled:               True
  Sticky:                False
  Total Size in Flash:   16384 bytes


┌──────────────────────────────────────────────────┐
│ App 4                                            |
└──────────────────────────────────────────────────┘
  Name:                  org.tockos.examples.rot13
  Version:               0
  Enabled:               True
  Sticky:                False
  Total Size in Flash:   8192 bytes
```

And they output what I expect.


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
