### PR TITLE
x86: Add PS2 and Keyboard Support

### DIFF
--- a/boards/qemu_i486_q35/src/main.rs
+++ b/boards/qemu_i486_q35/src/main.rs
@@ -22,6 +22,7 @@ use kernel::debug;
 use kernel::debug::PanicResources;
 use kernel::deferred_call::DeferredCallClient;
 use kernel::hil;
+use kernel::hil::keyboard::Keyboard;
 use kernel::ipc::IPC;
 use kernel::platform::chip::InterruptService;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
@@ -224,6 +225,19 @@ impl<C: kernel::platform::chip::Chip> KernelResources<C> for QemuI386Q35Platform
         &()
     }
 }
+
+impl kernel::hil::keyboard::KeyboardClient for QemuI386Q35Platform {
+    fn keys_pressed(&self, keys: &[(u16, bool)], result: Result<(), kernel::ErrorCode>) {
+        if result.is_ok() {
+            for (key, pressed) in keys {
+                if *pressed {
+                    kernel::debug!("Keyboard Key Pressed: {}", key);
+                }
+            }
+        }
+    }
+}
+
 // `allow(unsupported_calling_conventions)`: cdecl is not valid when testing
 // this code on an x86_64 machine. This avoids a warning until a more permanent
 // fix is decided. See: https://github.com/tock/tock/pull/4662
@@ -256,7 +270,7 @@ unsafe extern "cdecl" fn main() {
                     (kernel::static_buf!(x86_q35::serial::SerialPort<'static>),),
                     kernel::static_buf!(x86_q35::vga_uart_driver::VgaText<'static>),
                     kernel::static_buf!(x86_q35::ps2::Ps2Controller),
-                    kernel::static_buf!(x86_q35::keyboard::Keyboard<'static>),
+                    kernel::static_buf!(x86_q35::keyboard::Ps2Keyboard<'static>),
                 ),
                 &mut *ptr::addr_of_mut!(PAGE_DIR),
             )
@@ -525,23 +539,29 @@ unsafe extern "cdecl" fn main() {
                 AlarmHw
             ));
 
-    let platform = QemuI386Q35Platform {
-        pconsole,
-        console,
-        alarm,
-        lldb,
-        scheduler,
-        scheduler_timer,
-        rng: rng_driver,
-        ipc: kernel::ipc::IPC::new(
-            board_kernel,
-            kernel::ipc::DRIVER_NUM,
-            &memory_allocation_cap,
-        ),
-    };
+    let platform = static_init!(
+        QemuI386Q35Platform,
+        QemuI386Q35Platform {
+            pconsole,
+            console,
+            alarm,
+            lldb,
+            scheduler,
+            scheduler_timer,
+            rng: rng_driver,
+            ipc: kernel::ipc::IPC::new(
+                board_kernel,
+                kernel::ipc::DRIVER_NUM,
+                &memory_allocation_cap,
+            ),
+        }
+    );
 
     // Start the process console:
     let _ = platform.pconsole.start();
+
+    // Attach the keyboard button press callback to ourself.
+    default_peripherals.keyboard.set_client(platform);
 
     debug!("QEMU i486 \"Q35\" machine, initialization complete.");
     debug!("Entering main loop.");
@@ -579,5 +599,5 @@ unsafe extern "cdecl" fn main() {
         debug!("{:?}", err);
     });
 
-    board_kernel.kernel_loop(&platform, chip, Some(&platform.ipc), &main_loop_cap);
+    board_kernel.kernel_loop(platform, chip, Some(&platform.ipc), &main_loop_cap);
 }

--- a/boards/qemu_i486_q35/src/main.rs
+++ b/boards/qemu_i486_q35/src/main.rs
@@ -256,6 +256,7 @@ unsafe extern "cdecl" fn main() {
                     (kernel::static_buf!(x86_q35::serial::SerialPort<'static>),),
                     kernel::static_buf!(x86_q35::vga_uart_driver::VgaText<'static>),
                     kernel::static_buf!(x86_q35::ps2::Ps2Controller),
+                    kernel::static_buf!(x86_q35::keyboard::Keyboard<'static>),
                 ),
                 &mut *ptr::addr_of_mut!(PAGE_DIR),
             )

--- a/boards/qemu_i486_q35/src/main.rs
+++ b/boards/qemu_i486_q35/src/main.rs
@@ -255,6 +255,7 @@ unsafe extern "cdecl" fn main() {
                     (kernel::static_buf!(x86_q35::serial::SerialPort<'static>),),
                     (kernel::static_buf!(x86_q35::serial::SerialPort<'static>),),
                     kernel::static_buf!(x86_q35::vga_uart_driver::VgaText<'static>),
+                    kernel::static_buf!(x86_q35::ps2::Ps2Controller),
                 ),
                 &mut *ptr::addr_of_mut!(PAGE_DIR),
             )

--- a/chips/x86_q35/src/chip.rs
+++ b/chips/x86_q35/src/chip.rs
@@ -11,6 +11,7 @@ use x86::registers::bits32::paging::{PD, PT};
 use x86::support;
 use x86::{Boundary, InterruptPoller};
 
+use crate::keyboard::Ps2Keyboard;
 use crate::pic::PIC1_OFFSET;
 use crate::pit::{Pit, RELOAD_1KHZ};
 use crate::ps2::Ps2Controller;
@@ -81,6 +82,9 @@ pub struct Pc<'a, I1: InterruptService + 'a, I2: InterruptService + 'a, const PR
     /// PS/2 Controller
     pub ps2: &'a Ps2Controller,
 
+    /// Keyboard device
+    pub keyboard: &'a Ps2Keyboard<'a>,
+
     /// System call context
     syscall: Boundary,
     paging: PagingMPU<'a>,
@@ -122,6 +126,7 @@ impl<I2: InterruptService, const PR: u16> Pc<'static, PcDefaultPeripherals<PR>, 
             pit: &default_peripherals.pit,
             vga: default_peripherals.vga,
             ps2: default_peripherals.ps2,
+            keyboard: default_peripherals.keyboard,
             syscall,
             paging,
             default_peripherals,
@@ -256,6 +261,7 @@ pub struct PcDefaultPeripherals<const PR: u16 = RELOAD_1KHZ> {
     pub pit: Pit<'static, PR>,
     pub vga: &'static VgaText<'static>,
     pub ps2: &'static Ps2Controller,
+    pub keyboard: &'static Ps2Keyboard<'static>,
 }
 
 impl<const PR: u16> PcDefaultPeripherals<PR> {
@@ -273,6 +279,7 @@ impl<const PR: u16> PcDefaultPeripherals<PR> {
             (&'static mut core::mem::MaybeUninit<SerialPort<'static>>,),
             &'static mut core::mem::MaybeUninit<VgaText<'static>>,
             &'static mut core::mem::MaybeUninit<Ps2Controller>,
+            &'static mut core::mem::MaybeUninit<Ps2Keyboard<'static>>,
         ),
         page_dir: &mut PD,
     ) -> Self {
@@ -308,6 +315,12 @@ impl<const PR: u16> PcDefaultPeripherals<PR> {
         // controller bring-up owned by the chip
         let _ = ps2.init_early();
 
+        // keyboard device
+        let keyboard = s.6.write(Ps2Keyboard::new(ps2));
+        // connect keyboard as the ps/2 client, controller will call `receive_scancode`
+        ps2.set_client(keyboard);
+        keyboard.init_device();
+
         Self {
             com1,
             com2,
@@ -316,6 +329,7 @@ impl<const PR: u16> PcDefaultPeripherals<PR> {
             pit,
             vga,
             ps2,
+            keyboard,
         }
     }
 

--- a/chips/x86_q35/src/chip.rs
+++ b/chips/x86_q35/src/chip.rs
@@ -13,6 +13,7 @@ use x86::{Boundary, InterruptPoller};
 
 use crate::pic::PIC1_OFFSET;
 use crate::pit::{Pit, RELOAD_1KHZ};
+use crate::ps2::Ps2Controller;
 use crate::serial::{COM1_BASE, COM2_BASE, COM3_BASE, COM4_BASE, SerialPort, SerialPortComponent};
 use crate::vga_uart_driver::VgaText;
 
@@ -28,6 +29,10 @@ mod interrupt {
 
     /// Interrupt number shared by COM1 and COM3 serial devices
     pub(super) const COM1_COM3: u32 = (PIC1_OFFSET as u32) + 4;
+
+    /// Interrupt number used by the PS/2 keyboard (i8042, IRQ1).
+    /// Raised when the controller’s output buffer has data ready (OB=1).
+    pub(super) const KEYBOARD: u32 = (PIC1_OFFSET as u32) + 1;
 }
 
 /// Representation of a generic PC platform.
@@ -73,6 +78,9 @@ pub struct Pc<'a, I1: InterruptService + 'a, I2: InterruptService + 'a, const PR
     /// Vga
     pub vga: &'a VgaText<'a>,
 
+    /// PS/2 Controller
+    pub ps2: &'a Ps2Controller,
+
     /// System call context
     syscall: Boundary,
     paging: PagingMPU<'a>,
@@ -113,6 +121,7 @@ impl<I2: InterruptService, const PR: u16> Pc<'static, PcDefaultPeripherals<PR>, 
             com4: default_peripherals.com4,
             pit: &default_peripherals.pit,
             vga: default_peripherals.vga,
+            ps2: default_peripherals.ps2,
             syscall,
             paging,
             default_peripherals,
@@ -246,6 +255,7 @@ pub struct PcDefaultPeripherals<const PR: u16 = RELOAD_1KHZ> {
     pub com4: &'static SerialPort<'static>,
     pub pit: Pit<'static, PR>,
     pub vga: &'static VgaText<'static>,
+    pub ps2: &'static Ps2Controller,
 }
 
 impl<const PR: u16> PcDefaultPeripherals<PR> {
@@ -262,6 +272,7 @@ impl<const PR: u16> PcDefaultPeripherals<PR> {
             (&'static mut core::mem::MaybeUninit<SerialPort<'static>>,),
             (&'static mut core::mem::MaybeUninit<SerialPort<'static>>,),
             &'static mut core::mem::MaybeUninit<VgaText<'static>>,
+            &'static mut core::mem::MaybeUninit<Ps2Controller>,
         ),
         page_dir: &mut PD,
     ) -> Self {
@@ -291,6 +302,12 @@ impl<const PR: u16> PcDefaultPeripherals<PR> {
 
         let vga = s.4.write(VgaText::new());
 
+        // PS/2 inside the component
+        let ps2 = s.5.write(Ps2Controller::new());
+
+        // controller bring-up owned by the chip
+        let _ = ps2.init_early();
+
         Self {
             com1,
             com2,
@@ -298,12 +315,14 @@ impl<const PR: u16> PcDefaultPeripherals<PR> {
             com4,
             pit,
             vga,
+            ps2,
         }
     }
 
     /// Finalize deferred-call registrations and any circular deps.
     pub fn setup_circular_deps(&self) {
         kernel::deferred_call::DeferredCallClient::register(self.vga);
+        kernel::deferred_call::DeferredCallClient::register(self.ps2);
     }
 }
 
@@ -322,6 +341,10 @@ impl<const PR: u16> InterruptService for PcDefaultPeripherals<PR> {
             interrupt::COM1_COM3 => {
                 self.com1.handle_interrupt();
                 self.com3.handle_interrupt();
+                true
+            }
+            interrupt::KEYBOARD => {
+                self.ps2.handle_interrupt();
                 true
             }
             _ => false,

--- a/chips/x86_q35/src/cmd_fifo.rs
+++ b/chips/x86_q35/src/cmd_fifo.rs
@@ -1,0 +1,97 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+//! Minimal, non-alloc ring FIFO for small fixed-size queues.
+
+// Why `FifoItem::EMPTY` and const init?
+// We need to create the FIFO in static memory (no heap). That means the backing
+// array `[T; N]` must be initialized in a `const` context. I believe we can't  directly
+// call `T::default()` in `const fn`, so `[T::default(); N]` won’t work.
+// By requiring `T: FifoItem` with a `const EMPTY`, we can do `[T::EMPTY; N]`
+// and safely build the FIFO at compile time
+
+use core::cell::Cell;
+
+pub(crate) trait FifoItem: Copy {
+    /// Const zero/empty value used to initialize the backing array.
+    const EMPTY: Self;
+}
+
+pub struct Fifo<T: Copy + FifoItem, const N: usize> {
+    buf: [Cell<T>; N],
+    head: Cell<usize>,
+    tail: Cell<usize>,
+    len: Cell<usize>,
+}
+
+impl<T: Copy + FifoItem, const N: usize> Fifo<T, N> {
+    pub(crate) const fn new() -> Self {
+        Self {
+            buf: [const { Cell::new(T::EMPTY) }; N],
+            head: Cell::new(0),
+            tail: Cell::new(0),
+            len: Cell::new(0),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.len.get() == 0
+    }
+
+    #[inline]
+    pub(crate) fn is_full(&self) -> bool {
+        self.len.get() == N
+    }
+
+    /// Push at head; returns Err(item) if full
+    #[inline]
+    pub(crate) fn push(&self, item: T) -> Result<(), T> {
+        if self.is_full() {
+            return Err(item);
+        }
+        let h = self.head.get();
+        self.buf[h].set(item);
+        self.head.set((h + 1) % N);
+        self.len.set(self.len.get() + 1);
+        Ok(())
+    }
+
+    /// Copy the current head entry (None if empty).
+    #[inline]
+    pub(crate) fn peek_copy(&self) -> Option<T> {
+        if self.is_empty() {
+            None
+        } else {
+            Some(self.buf[self.tail.get()].get())
+        }
+    }
+
+    /// Read-modify-write the current head entry; returns closure result.
+    #[inline]
+    pub(crate) fn peek_update<R>(&self, f: impl FnOnce(&mut T) -> R) -> Option<R> {
+        if self.is_empty() {
+            None
+        } else {
+            let t = self.tail.get();
+            let mut v = self.buf[t].get();
+            let r = f(&mut v);
+            self.buf[t].set(v);
+            Some(r)
+        }
+    }
+
+    /// Pop from tail; returns a copy of the removed item.
+    #[inline]
+    pub(crate) fn pop(&self) -> Option<T> {
+        if self.is_empty() {
+            return None;
+        }
+        let t = self.tail.get();
+        let item = self.buf[t].get();
+        self.tail.set((t + 1) % N);
+        self.len.set(self.len.get() - 1);
+        Some(item)
+    }
+}

--- a/chips/x86_q35/src/keyboard.rs
+++ b/chips/x86_q35/src/keyboard.rs
@@ -1,0 +1,408 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+//! PS/2 keyboard device over the i8042 controller.
+//!
+//! How it works (overview)
+//! - I8042 (ports available on 0X60/0X64) delivers keyboard bytes via IRQ1
+//! - We use scan Code set 2 (no translation). 0xE0/0xE1 are prefixes; 0xF0 marks BREAK
+//! - Keyboard speaks simple command/ACK (0xFA) / RESEND (0xFE) protocol
+//!
+//! References:
+//! - OSDev: i8042 PS/2 Controller — https://wiki.osdev.org/I8042_PS/2_Controller
+//! - OSDev: PS/2 Keyboard — https://wiki.osdev.org/PS/2_Keyboard
+//! - OSDev: Keyboard / Scan Code Set 2 — https://wiki.osdev.org/Keyboard#Scan_Code_Set_2
+
+use crate::cmd_fifo::Fifo as CmdFifo;
+use crate::ps2::Ps2Client;
+use crate::ps2::Ps2Controller;
+use core::cell::Cell;
+use kernel::hil::keyboard::{Keyboard, KeyboardClient};
+use kernel::utilities::cells::OptionalCell;
+
+/// Set-2 - Linux keycode mapper
+#[inline(always)]
+fn linux_key_for(extended: bool, code: u8) -> Option<u16> {
+    match (extended, code) {
+        // basics
+        (false, 0x76) => Some(1),  // KEY_ESC
+        (false, 0x5A) => Some(28), // KEY_ENTER
+        (false, 0x66) => Some(14), // KEY_BACKSPACE
+        (false, 0x0D) => Some(15), // KEY_TAB
+        (false, 0x29) => Some(57), // KEY_SPACE
+
+        // modifiers
+        (false, 0x12) => Some(42), // KEY_LEFTSHIFT
+        (false, 0x59) => Some(54), // KEY_RIGHTSHIFT
+        (false, 0x14) => Some(29), // KEY_LEFTCTRL
+        (true, 0x14) => Some(97),  // KEY_RIGHTCTRL
+        (false, 0x11) => Some(56), // KEY_LEFTALT
+        (true, 0x11) => Some(100), // KEY_RIGHTALT (AltGr)
+        (false, 0x58) => Some(58), // KEY_CAPSLOCK
+
+        // arrows (E0)
+        (true, 0x75) => Some(103), // KEY_UP
+        (true, 0x72) => Some(108), // KEY_DOWN
+        (true, 0x6B) => Some(105), // KEY_LEFT
+        (true, 0x74) => Some(106), // KEY_RIGHT
+
+        // letters (US)
+        (false, 0x1C) => Some(30), // A
+        (false, 0x32) => Some(48), // B
+        (false, 0x21) => Some(46), // C
+        (false, 0x23) => Some(32), // D
+        (false, 0x24) => Some(18), // E
+        (false, 0x2B) => Some(33), // F
+        (false, 0x34) => Some(34), // G
+        (false, 0x33) => Some(35), // H
+        (false, 0x43) => Some(23), // I
+        (false, 0x3B) => Some(36), // J
+        (false, 0x42) => Some(37), // K
+        (false, 0x4B) => Some(38), // L
+        (false, 0x3A) => Some(50), // M
+        (false, 0x31) => Some(49), // N
+        (false, 0x44) => Some(24), // O
+        (false, 0x4D) => Some(25), // P
+        (false, 0x15) => Some(16), // Q
+        (false, 0x2D) => Some(19), // R
+        (false, 0x1B) => Some(31), // S
+        (false, 0x2C) => Some(20), // T
+        (false, 0x3C) => Some(22), // U
+        (false, 0x2A) => Some(47), // V
+        (false, 0x1D) => Some(17), // W
+        (false, 0x22) => Some(45), // X
+        (false, 0x35) => Some(21), // Y
+        (false, 0x1A) => Some(44), // Z
+
+        // digits row (US)
+        (false, 0x16) => Some(2),  // 1
+        (false, 0x1E) => Some(3),  // 2
+        (false, 0x26) => Some(4),  // 3
+        (false, 0x25) => Some(5),  // 4
+        (false, 0x2E) => Some(6),  // 5
+        (false, 0x36) => Some(7),  // 6
+        (false, 0x3D) => Some(8),  // 7
+        (false, 0x3E) => Some(9),  // 8
+        (false, 0x46) => Some(10), // 9
+        (false, 0x45) => Some(11), // 0
+
+        _ => None,
+    }
+}
+
+// Set-2 scancode constants used for decoding
+
+const SC_LSHIFT: u8 = 0x12;
+const SC_RSHIFT: u8 = 0x59;
+const SC_CAPS: u8 = 0x58;
+const RESP_ACK: u8 = 0xFA;
+const RESP_RESEND: u8 = 0xFE;
+const RESP_BAT_OK: u8 = 0xAA; // BAT after reset
+
+// We will add a small "command engine" (command/response state machine)
+// with ACK/RESEND handling.
+// A fixed-size FIFO holds short command sequences (e.g., F0 02, F4).
+// One byte is in flight at a time; 0xFA ACK advances, 0xFE RESEND retries.
+
+const CMDQ_LEN: usize = 8;
+const CMD_MAX_LEN: usize = 3;
+const MAX_RETRIES: u8 = 3; // to not be confused with the deff call "good bytes" we do for telemetry on controller
+
+#[derive(Copy, Clone)]
+struct CmdEntry {
+    bytes: [u8; CMD_MAX_LEN],
+    len: u8,
+    idx: u8, //next byte to send
+}
+
+impl CmdEntry {
+    const fn empty() -> Self {
+        Self {
+            bytes: [0; CMD_MAX_LEN],
+            len: 0,
+            idx: 0,
+        }
+    }
+
+    fn is_done(&self) -> bool {
+        (self.idx as usize) >= (self.len as usize)
+    }
+
+    // helper to avoid duplicating the “turn a byte slice into a queued command” logic
+    fn try_from_bytes(seq: &[u8]) -> Option<Self> {
+        if seq.is_empty() || seq.len() > CMD_MAX_LEN {
+            return None;
+        }
+        let mut e = CmdEntry::empty();
+        e.bytes[..seq.len()].copy_from_slice(seq);
+        e.len = seq.len() as u8;
+        Some(e)
+    }
+}
+
+// this is needed so CmdEntry expects a FifoItem, and not a const default
+impl crate::cmd_fifo::FifoItem for CmdEntry {
+    const EMPTY: Self = Self::empty();
+}
+
+impl Default for CmdEntry {
+    fn default() -> Self {
+        CmdEntry::empty()
+    }
+}
+
+/// We capture bytes and will later add:
+///
+/// 1) Command FIFO with ACK/RESEND handling
+/// 2) Set-2 decoder state machine (e0/f0/e1)
+///
+/// Modifier tracking and ASCII/layout mapping in upper layers
+pub struct Ps2Keyboard<'a> {
+    ps2: &'a Ps2Controller,
+    client: OptionalCell<&'a dyn KeyboardClient>,
+
+    // decoder state
+    got_e0: Cell<bool>,   // sau 0xE0: next code is extended
+    got_f0: Cell<bool>,   // saw 0xF0: next code is a break
+    swallow_e1: Cell<u8>, // > 0 means we are swallowing remaining Pause seq bytes
+
+    // modifiers
+    shift_l: Cell<bool>,
+    shift_r: Cell<bool>,
+    caps: Cell<bool>,
+
+    // command engine queue (ring FIFO) - interior mutable via Cells inside
+    cmd_q: CmdFifo<CmdEntry, CMDQ_LEN>,
+
+    in_flight: Cell<bool>,      // waiting for ACK/RESEND to the last sent byte
+    retries_left: Cell<u8>,     // remaining entries for the current byte
+    cmd_sent_bytes: Cell<u32>,  //bytes attempted to send
+    cmd_acks: Cell<u32>,        // ACKs observed
+    cmd_resends: Cell<u32>,     // RESENDs observed
+    cmd_drops: Cell<u32>,       //commands dropped after retry execution
+    cmd_send_errors: Cell<u32>, // controller TX errors/timeouts
+}
+
+impl<'a> Keyboard<'a> for Ps2Keyboard<'a> {
+    fn set_client(&self, client: &'a dyn KeyboardClient) {
+        self.client.set(client);
+    }
+}
+
+impl<'a> Ps2Keyboard<'a> {
+    pub const fn new(ps2: &'a Ps2Controller) -> Self {
+        Self {
+            ps2,
+            client: OptionalCell::empty(),
+
+            // decoder state
+            got_e0: Cell::new(false),
+            got_f0: Cell::new(false),
+            swallow_e1: Cell::new(0),
+            shift_l: Cell::new(false),
+            shift_r: Cell::new(false),
+            caps: Cell::new(false),
+
+            cmd_q: CmdFifo::new(),
+
+            in_flight: Cell::new(false),
+            retries_left: Cell::new(0),
+
+            cmd_sent_bytes: Cell::new(0),
+            cmd_acks: Cell::new(0),
+            cmd_resends: Cell::new(0),
+            cmd_drops: Cell::new(0),
+            cmd_send_errors: Cell::new(0),
+        }
+    }
+
+    /// Device-level init hook. No-op for now since the `init_early()`
+    /// already runs in the controller. After capsule lands, we will enqueue:
+    ///  F5 (disable scan) -> FF (reset; expect FA then AA) - F0 02 (Set-2) - F4 (enable).
+    /// This will use the command engine (ACK/RESEND) and can run with IRQ1 enabled.
+    pub fn init_device(&self) {
+        // TODO
+    }
+
+    /// Command engine public API
+    ///
+    /// Queue a short PS/2 device command (e.g. `&[0xF0, 0x02]`, `&[0xF4]`).
+    ///
+    ///  Runs in the keyboard’s deferred/bottom-half context;
+    ///  Bytes are sent one-by-one; `ACK (0xFA)` advances; `RESEND (0xFE)` retries with a bounded budget.
+    ///  Returns `false` if the queue is full or the sequence length exceeds `CMD_MAX_LEN`.
+    ///  No completion callback; failures are tracked internally (telemetry counters).
+    pub fn enqueue_command(&self, seq: &[u8]) -> bool {
+        let Some(entry) = CmdEntry::try_from_bytes(seq) else {
+            return false;
+        };
+        if self.cmd_q.is_full() {
+            return false;
+        }
+        let _ = self.cmd_q.push(entry);
+        self.drive_tx();
+        true
+    }
+
+    /// Try to transmit the next byte of the current command
+    fn drive_tx(&self) {
+        if self.in_flight.get() {
+            return;
+        }
+
+        // Peek current command
+        let (byte_opt, done_opt) = match self.cmd_q.peek_copy() {
+            None => (None, None),
+            Some(e) if e.is_done() => (None, Some(true)),
+            Some(e) => (Some(e.bytes[e.idx as usize]), Some(false)),
+        };
+
+        match done_opt {
+            None => return, // queue empty
+            Some(true) => {
+                // finished entry => pop and try next
+                self.cmd_q.pop();
+                self.drive_tx();
+                return;
+            }
+            Some(false) => {}
+        }
+
+        if let Some(b) = byte_opt {
+            match self.ps2.send_port1(b) {
+                Ok(()) => {
+                    self.in_flight.set(true);
+                    if self.retries_left.get() == 0 {
+                        self.retries_left.set(MAX_RETRIES);
+                    }
+                    self.cmd_sent_bytes
+                        .set(self.cmd_sent_bytes.get().wrapping_add(1));
+                }
+                Err(_e) => {
+                    self.cmd_send_errors
+                        .set(self.cmd_send_errors.get().wrapping_add(1));
+                }
+            }
+        }
+    }
+
+    fn advance_idx_after_ack(&self) {
+        let finished = self
+            .cmd_q
+            .peek_update(|e| {
+                if !e.is_done() {
+                    e.idx = e.idx.saturating_add(1);
+                }
+                e.is_done()
+            })
+            .unwrap_or(false);
+        if finished {
+            self.cmd_q.pop();
+        }
+        // New byte will get a fresh retry budget on first send
+        self.retries_left.set(0);
+    }
+
+    /// Core set-2 decoder. Consumes one non-command byte
+    #[inline(always)]
+    fn decode_byte(&self, byte: u8) {
+        // handle E1 (pause) long sequence
+        if self.swallow_e1.get() > 0 {
+            self.swallow_e1.set(self.swallow_e1.get() - 1);
+            return;
+        }
+        if byte == 0xE1 {
+            // start swallowing the remaining 7 bytes
+            self.swallow_e1.set(7);
+            return;
+        }
+
+        // Prefix events (caps, shifts)
+        if byte == 0xE0 {
+            self.got_e0.set(true);
+            return;
+        }
+
+        if byte == 0xF0 {
+            self.got_f0.set(true);
+            return;
+        }
+
+        // resolve latched prefixes
+        let extended = self.got_e0.replace(false);
+        let breaking = self.got_f0.replace(false);
+        let pressed = !breaking;
+
+        // // log the final key event (after prefixes are applied)
+        // debug!(
+        // "ps2kbd: {} {}{:02X}",
+        // if pressed { "MAKE " } else { "BREAK" },
+        // if extended { "E0 " } else { "" },
+        // byte
+        // );
+
+        // Emit Linux keycode to the HIL client
+        if let Some(code) = linux_key_for(extended, byte) {
+            self.client.map(|c| {
+                let one = [(code, pressed)];
+                c.keys_pressed(&one, Ok(()));
+            });
+        }
+
+        // Update local modifier state (we still emit events for them)
+        // consumers can ignore
+        match (byte, extended) {
+            (SC_LSHIFT, false) => self.shift_l.set(pressed),
+            (SC_RSHIFT, false) => self.shift_r.set(pressed),
+            (SC_CAPS, _) if pressed => self.caps.set(!self.caps.get()), // toggle on make; ignore break
+            _ => {}
+        }
+    }
+}
+impl Ps2Client for Ps2Keyboard<'_> {
+    /// Called by the controller (in def context) for each byte)
+    fn receive_scancode(&self, byte: u8) {
+        // First, if a command byte is in flight, interpret 0XFA/0XFE
+        if self.in_flight.get() {
+            match byte {
+                RESP_ACK => {
+                    // ACK
+                    self.cmd_acks.set(self.cmd_acks.get().wrapping_add(1));
+                    self.in_flight.set(false);
+                    self.advance_idx_after_ack();
+                    // Immediately try to send the next byte/command
+                    self.drive_tx();
+                    return;
+                }
+                RESP_RESEND => {
+                    // RESEND - bounded retry of the same byte
+                    self.cmd_resends.set(self.cmd_resends.get().wrapping_add(1));
+                    let left = self.retries_left.get();
+                    if left > 1 {
+                        self.retries_left.set(left - 1);
+                        self.in_flight.set(false);
+                        self.drive_tx(); // resend same byte, don't reset retries
+                    } else {
+                        // Give up on this command
+                        self.cmd_drops.set(self.cmd_drops.get().wrapping_add(1));
+                        self.in_flight.set(false);
+                        self.cmd_q.pop();
+                        self.retries_left.set(0); // clear for the next new byte
+                        self.drive_tx();
+                    }
+                    return;
+                }
+                _ => {
+                    // Not an ACK/RESEND while waiting = ignore (do NOT decode as a key).
+                    return;
+                }
+            }
+        }
+        // No command in flight: ignore device-only responses that aren’t keystrokes.
+        if byte == RESP_ACK || byte == RESP_RESEND || byte == RESP_BAT_OK {
+            return;
+        }
+        self.decode_byte(byte);
+    }
+}

--- a/chips/x86_q35/src/lib.rs
+++ b/chips/x86_q35/src/lib.rs
@@ -23,6 +23,7 @@ pub mod pic;
 
 pub mod pit;
 
+pub mod ps2;
 pub mod serial;
 
 pub mod vga;

--- a/chips/x86_q35/src/lib.rs
+++ b/chips/x86_q35/src/lib.rs
@@ -17,6 +17,7 @@
 mod chip;
 pub use chip::{Pc, PcDefaultPeripherals};
 
+mod cmd_fifo;
 mod interrupts;
 
 pub mod pic;
@@ -26,5 +27,6 @@ pub mod pit;
 pub mod ps2;
 pub mod serial;
 
+pub mod keyboard;
 pub mod vga;
 pub mod vga_uart_driver;

--- a/chips/x86_q35/src/ps2.rs
+++ b/chips/x86_q35/src/ps2.rs
@@ -1,0 +1,483 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+//! i8042 PS/2 controller for x86_q35
+//!
+//! Init policy (chip owns bring-up -> `init_early_with()`):
+//!  - Disable ports, flush OB, self-test
+//!  - Config: translation OFF (Set-2), IRQ bits off during tests
+//!  - Port1 test + enable; device: F5, FF -> AA, F0 02 (Set-2), enable IRQ1, F4
+//!
+//! ISR/BH split:
+//!  - ISR reads OB, drops on parity/timeout, queues bytes, schedules deferred call
+//!  - Deferred call drains ring; for now it logs; and attempts to send data to a present client
+
+use core::cell::Cell;
+use kernel::debug;
+use kernel::deferred_call::{DeferredCall, DeferredCallClient};
+use kernel::utilities::cells::{MapCell, OptionalCell};
+use kernel::utilities::registers::register_bitfields;
+use tock_registers::LocalRegisterCopy;
+use x86::registers::io;
+
+/// PS/2 controller ports
+const PS2_DATA_PORT: u16 = 0x60;
+const PS2_STATUS_PORT: u16 = 0x64;
+
+/// Depth of the scan-code ring buffer
+const BUFFER_SIZE: usize = 32;
+
+// This is not time-based. We repeatedly read the controller status (0x64)
+// and check the relevant bit; if we’ve spun this many iterations without the
+// condition becoming true, we return a Timeout error.
+
+/// Big spin budget used during controller/device bring-up
+const SPINS_INIT: usize = 32768;
+
+/// Small budget for non-init use
+const SPINS_RUNTIME: usize = 256;
+
+// Status-register bits returned by inb(0x64)
+register_bitfields![u8,
+    pub STATUS [
+        OUTPUT_FULL OFFSET(0) NUMBITS(1), // OB has data
+        INPUT_FULL  OFFSET(1) NUMBITS(1), // IB is full (busy)
+        // (bit2 SYSFLAG and bit3 CMD/DATA not used here)
+        AUX_OBF     OFFSET(5) NUMBITS(1), // 1 = from mouse/port2
+        TIMEOUT_ERR OFFSET(6) NUMBITS(1),
+        PARITY_ERR  OFFSET(7) NUMBITS(1),
+    ]
+];
+
+register_bitfields![u8,
+pub CONFIG [
+        IRQ1 OFFSET(0) NUMBITS(1),
+        IRQ12 OFFSET(1) NUMBITS(1),
+        SYSFLAG OFFSET(2) NUMBITS(1),
+        RESERVED3 OFFSET(3) NUMBITS(1),
+        DISABLE_KBD OFFSET(4) NUMBITS(1),
+        DISABLE_AUX OFFSET(5) NUMBITS(1),
+        TRANSLATION OFFSET(6) NUMBITS(1),
+        RESERVED7 OFFSET(7) NUMBITS(1),
+    ]
+];
+
+/// Raw byte sink for PS/2 controller clients (keyboard, mouse).
+pub trait Ps2Client {
+    /// Called in deferred context for each byte pulled from the ring.
+    fn receive_scancode(&self, byte: u8);
+}
+
+/// Error types that  the controller can return
+/// so we don't bring the whole kernel down
+/// if something breaks in a peripheral
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Ps2Error {
+    TimeoutIB,
+    TimeoutOB,
+    SelfTestFailed,
+    Port1TestFailed,
+    AckError,
+    ControllerTimeout,
+    UnexpectedResponse(u8),
+}
+
+/// Lightweight health snapshot for observability.
+#[derive(Debug, Clone, Copy)]
+pub struct Ps2Health {
+    pub bytes_rx: u32,
+    pub overruns: u32,
+    pub parity_err: u32,
+    pub timeout_err: u32,
+    pub timeouts: u32, // controller wait timeouts (IB/OB)
+    pub resends: u32,  // times device asked us to resend (0xFE)
+}
+
+// Since we really want to minimise the risk of the controller
+// bringing the whole kernel down if a device (or even the controller itself)
+// breaks, we will add this simple display and its struct,
+impl core::fmt::Display for Ps2Health {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "rx={} overruns={} parity_err={} timeout_err={} ctrl_timeouts={} resends={}",
+            self.bytes_rx,
+            self.overruns,
+            self.parity_err,
+            self.timeout_err,
+            self.timeouts,
+            self.resends
+        )
+    }
+}
+
+/// Note: There is no hardware interrupt when the input buffer empties, so we must poll bit 1.
+/// See OSDev documentation:
+/// https://wiki.osdev.org/I8042_PS/2_Controller#Status_Register
+///
+/// Block until the controller’s input buffer is empty (ready for a command).
+#[inline(always)]
+fn wait_ib_empty_with_timeout(limit: usize) -> Result<(), Ps2Error> {
+    let mut spins = 0usize;
+    while read_status().is_set(STATUS::INPUT_FULL) {
+        spins += 1;
+        if spins >= limit {
+            return Err(Ps2Error::TimeoutIB);
+        }
+    }
+    Ok(())
+}
+
+/// Data-ready events trigger IRQ1, handled asynchronously in `handle_interrupt()`.
+/// See OSDev documentation:
+/// https://wiki.osdev.org/I8042_PS/2_Controller#Status_Register
+///
+/// Block until there is data ready to read in the output buffer.
+#[inline(always)]
+fn wait_ob_full_with_timeout(limit: usize) -> Result<(), Ps2Error> {
+    let mut spins = 0usize;
+    while !read_status().is_set(STATUS::OUTPUT_FULL) {
+        spins += 1;
+        if spins >= limit {
+            return Err(Ps2Error::TimeoutOB);
+        }
+    }
+    Ok(())
+}
+
+/// Read one byte from the data port (0x60).
+#[inline(always)]
+fn read_data_with(limit: usize) -> Result<u8, Ps2Error> {
+    wait_ob_full_with_timeout(limit)?;
+    Ok(unsafe { io::inb(PS2_DATA_PORT) })
+}
+
+/// Send a command byte to the controller (port 0x64).
+#[inline(always)]
+fn write_command_with(c: u8, limit: usize) -> Result<(), Ps2Error> {
+    wait_ib_empty_with_timeout(limit)?;
+    unsafe { io::outb(PS2_STATUS_PORT, c) }
+    Ok(())
+}
+
+/// Write a data byte to the data port (0x60).
+#[inline(always)]
+fn write_data_with(d: u8, limit: usize) -> Result<(), Ps2Error> {
+    wait_ib_empty_with_timeout(limit)?;
+    unsafe { io::outb(PS2_DATA_PORT, d) }
+    Ok(())
+}
+#[inline(always)]
+fn read_status() -> LocalRegisterCopy<u8, STATUS::Register> {
+    LocalRegisterCopy::new(unsafe { io::inb(PS2_STATUS_PORT) })
+}
+
+#[inline(always)]
+fn read_config_reg_with(limit: usize) -> Result<LocalRegisterCopy<u8, CONFIG::Register>, Ps2Error> {
+    write_command_with(0x20, limit)?; // Read Controller Configuration Byte
+    Ok(LocalRegisterCopy::new(read_data_with(limit)?))
+}
+
+#[inline(always)]
+fn write_config_reg_with(
+    cfg: LocalRegisterCopy<u8, CONFIG::Register>,
+    limit: usize,
+) -> Result<(), Ps2Error> {
+    write_command_with(0x60, limit)?; // Write Controller Configuration Byte
+    write_data_with(cfg.get(), limit)
+}
+
+fn update_config_with<F>(limit: usize, f: F) -> Result<u8, Ps2Error>
+where
+    F: FnOnce(LocalRegisterCopy<u8, CONFIG::Register>) -> LocalRegisterCopy<u8, CONFIG::Register>,
+{
+    let cur = read_config_reg_with(limit)?;
+    let new = f(cur);
+    write_config_reg_with(new, limit)?;
+    Ok(new.get())
+}
+
+fn flush_output_buffer() -> Result<(), Ps2Error> {
+    // Poll status; if OB has data, read once and loop.
+    // Use the small runtime budget for the read.
+    while read_status().is_set(STATUS::OUTPUT_FULL) {
+        let _ = read_data_with(SPINS_RUNTIME)?;
+    }
+    Ok(())
+}
+
+/// PS/2 controller driver (the “8042” peripheral)
+pub struct Ps2Controller {
+    buffer: MapCell<[u8; BUFFER_SIZE]>,
+    head: Cell<usize>,
+    tail: Cell<usize>,
+    count: Cell<usize>, // new field to track number of valid entries
+
+    // "health" counters
+    parity_drops: Cell<u32>,
+    timeout_drops: Cell<u32>,
+    overruns: Cell<u32>,
+    bytes_rx: Cell<u32>,
+    resends: Cell<u32>,
+    timeouts: Cell<u32>,
+    // deferred call handle (bottom-half scheduling)
+    deferred_call: DeferredCall,
+
+    // actually count health logs in board
+    prev_log_bytes: Cell<u32>,
+
+    // raw byte client (keyboard device)
+    client: OptionalCell<&'static dyn Ps2Client>,
+}
+
+impl Ps2Controller {
+    pub fn new() -> Self {
+        Self {
+            buffer: MapCell::new([0; BUFFER_SIZE]),
+            head: Cell::new(0),
+            tail: Cell::new(0),
+            count: Cell::new(0),
+
+            parity_drops: Cell::new(0),
+            timeout_drops: Cell::new(0),
+            overruns: Cell::new(0),
+            bytes_rx: Cell::new(0),
+            resends: Cell::new(0),
+            timeouts: Cell::new(0),
+
+            deferred_call: DeferredCall::new(),
+            prev_log_bytes: Cell::new(0),
+            client: OptionalCell::empty(),
+        }
+    }
+
+    /// telemetry debugging for future devices
+    pub fn health_snapshot(&self) -> Ps2Health {
+        Ps2Health {
+            bytes_rx: self.bytes_rx.get(),
+            overruns: self.overruns.get(),
+            parity_err: self.parity_drops.get(),
+            timeout_err: self.timeout_drops.get(),
+            timeouts: self.timeouts.get(),
+            resends: self.resends.get(),
+        }
+    }
+    pub fn set_client(&self, client: &'static dyn Ps2Client) {
+        self.client.set(client);
+    }
+
+    #[inline(always)]
+    fn drain_and_deliver(&self) {
+        while let Some(b) = self.pop_scan_code() {
+            self.client.map(|c| c.receive_scancode(b));
+        }
+    }
+
+    /// Count controller wait timeouts
+    #[inline(always)]
+    fn tally_timeout<T>(&self, r: Result<T, Ps2Error>) -> Result<T, Ps2Error> {
+        if matches!(r, Err(Ps2Error::TimeoutIB) | Err(Ps2Error::TimeoutOB)) {
+            self.timeouts.set(self.timeouts.get().wrapping_add(1));
+        }
+        r
+    }
+
+    // Keyboard device commands (port 0x60)
+    // Thin wrappers over `send_with_ack`. Kept as methods so they can use the
+    // controller’s counters/state.
+
+    /// Send a device command and wait for ACK (0xFA).
+    /// Retries on RESEND (0xFE) up to `tries - 1` times and increments `self.resends`.
+    /// Returns:
+    /// `Ok(())` on ACK
+    /// `Err(Ps2Error::AckError)` if RESEND persists after all retries
+    /// `Err(Ps2Error::UnexpectedResponse(_))` for any other response byte
+    fn send_with_ack_limit(&self, byte: u8, tries: u8, limit: usize) -> Result<(), Ps2Error> {
+        let mut attempts = 0;
+        loop {
+            attempts += 1;
+            write_data_with(byte, limit)?;
+            match read_data_with(limit)? {
+                0xFA => return Ok(()),
+                0xFE if attempts < tries => {
+                    self.resends.set(self.resends.get().wrapping_add(1));
+                    continue;
+                }
+                0xFE => {
+                    self.resends.set(self.resends.get().wrapping_add(1));
+                    return Err(Ps2Error::AckError);
+                }
+                other => return Err(Ps2Error::UnexpectedResponse(other)),
+            }
+        }
+    }
+
+    /// Pure controller + device bring-up.
+    /// No logging, no PIC masking/unmasking, no CPU-IRQ enabling. (hopefully)
+    /// Called by PcComponent::finalize() (chip layer).
+    ///
+    /// Whole goal of this change is to stop nagging the memory directly
+    /// We created tiny wrappers and helpers, so we can configure the init
+    /// much easier
+    ///
+    /// For testing and health of the controller, we'll wrap each call with
+    /// tally_timeout helper
+    pub fn init_early_with_spins(&self, spins: usize) -> Result<(), Ps2Error> {
+        // disable ports; flush OB
+        self.tally_timeout(write_command_with(0xAD, spins))?;
+        self.tally_timeout(write_command_with(0xA7, spins))?;
+        self.tally_timeout(flush_output_buffer())?;
+
+        // controller self-test
+        self.tally_timeout({
+            write_command_with(0xAA, spins)?;
+            match read_data_with(spins)? {
+                0x55 => Ok(()),
+                other => Err(Ps2Error::UnexpectedResponse(other)),
+            }
+        })?;
+
+        // config policy (do not generate IRQs during tests)
+        self.tally_timeout(update_config_with(spins, |mut c| {
+            c.modify(CONFIG::IRQ1::CLEAR);
+            c
+        }))?;
+        self.tally_timeout(update_config_with(spins, |mut c| {
+            c.modify(CONFIG::IRQ12::CLEAR);
+            c
+        }))?;
+        self.tally_timeout(update_config_with(spins, |mut c| {
+            c.modify(CONFIG::TRANSLATION::CLEAR);
+            c
+        }))?;
+        self.tally_timeout(update_config_with(spins, |mut c| {
+            c.modify(CONFIG::DISABLE_KBD::CLEAR);
+            c
+        }))?;
+        self.tally_timeout(update_config_with(spins, |mut c| {
+            c.modify(CONFIG::DISABLE_AUX::SET);
+            c
+        }))?;
+
+        // port1 test then enable keyboard clock at the controller command level
+        self.tally_timeout({
+            write_command_with(0xAB, spins)?;
+            match read_data_with(spins)? {
+                0x00 => Ok(()),
+                other => Err(Ps2Error::UnexpectedResponse(other)),
+            }
+        })?;
+        self.tally_timeout(write_command_with(0xAE, spins))?;
+
+        // device sequence (keyboard)
+        self.tally_timeout(self.send_with_ack_limit(0xF5, 3, spins))?; // F5 disable scan
+        self.tally_timeout(self.send_with_ack_limit(0xFF, 3, spins))?; // FF reset
+        self.tally_timeout({
+            match read_data_with(spins)? {
+                0xAA => Ok(()), // BAT passed
+                other => Err(Ps2Error::UnexpectedResponse(other)),
+            }
+        })?;
+        self.tally_timeout(self.send_with_ack_limit(0xF0, 3, spins))?; // select set
+        self.tally_timeout(self.send_with_ack_limit(0x02, 3, spins))?; // set-2
+        self.tally_timeout(update_config_with(spins, |mut c| {
+            c.modify(CONFIG::IRQ1::SET);
+            c
+        }))?;
+        self.tally_timeout(self.send_with_ack_limit(0xF4, 3, spins))?; // enable scan
+
+        Ok(())
+    }
+
+    /// Back-compat wrapper: long spin budget during bring-up.
+    pub fn init_early(&self) -> Result<(), Ps2Error> {
+        self.init_early_with_spins(SPINS_INIT)
+    }
+    pub fn handle_interrupt(&self) {
+        let mut scheduled = false;
+
+        loop {
+            let status = read_status();
+            if !status.is_set(STATUS::OUTPUT_FULL) {
+                break;
+            }
+
+            let b = unsafe { io::inb(PS2_DATA_PORT) };
+
+            if status.is_set(STATUS::PARITY_ERR) {
+                self.parity_drops
+                    .set(self.parity_drops.get().wrapping_add(1));
+                continue;
+            }
+            if status.is_set(STATUS::TIMEOUT_ERR) {
+                self.timeout_drops
+                    .set(self.timeout_drops.get().wrapping_add(1));
+                continue;
+            }
+
+            self.push_code(b);
+            scheduled = true;
+        }
+
+        if scheduled {
+            self.deferred_call.set();
+        }
+    }
+
+    /// Producer-side enqueue: push one scan-code byte into the ring buffer.
+    /// Safe without masking on x86_q35: both `handle_interrupt()` and
+    /// deferred calls run on the kernel main loop (no preemption).
+    #[inline(always)]
+    fn push_code(&self, b: u8) {
+        let h = self.head.get();
+        self.buffer.map(|buf| {
+            buf[h] = b;
+        });
+        self.head.set((h + 1) % BUFFER_SIZE);
+        if self.count.get() < BUFFER_SIZE {
+            self.count.set(self.count.get() + 1);
+        } else {
+            self.tail.set((self.tail.get() + 1) % BUFFER_SIZE);
+            self.overruns.set(self.overruns.get().wrapping_add(1));
+        }
+        self.bytes_rx.set(self.bytes_rx.get().wrapping_add(1));
+    }
+
+    /// Consumer-side dequeue. Also safe without masking for the same reason.
+    pub fn pop_scan_code(&self) -> Option<u8> {
+        if self.count.get() == 0 {
+            None
+        } else {
+            let t = self.tail.get();
+            // without `const` buffer type, the
+            // old declaration MapCell::new([0; BUFFER_SIZE]) was fine for initialization,
+            // but it broke when we tried to write through the .map closure
+            //
+            // since MapCell::map returns Option<R> to prevent nested borrows
+            // our closure returns an `u8`, so the whole call is Option<u8>,
+            // wrap it (or use a temp Cell) so we hand back a `u8`
+            let b = self.buffer.map(|buf| buf[t]).unwrap();
+            self.tail.set((t + 1) % BUFFER_SIZE);
+            self.count.set(self.count.get() - 1);
+            Some(b)
+        }
+    }
+}
+impl DeferredCallClient for Ps2Controller {
+    fn handle_deferred_call(&self) {
+        // drain ring and deliver raw bytes to the client
+        self.drain_and_deliver();
+
+        // log health only when bytes_rx advanced
+        let cur = self.bytes_rx.get();
+        // print every N bytes so we don't spam the console
+        if cur.wrapping_sub(self.prev_log_bytes.get()) >= 16 {
+            self.prev_log_bytes.set(cur);
+            debug!("ps/2 health: {}", self.health_snapshot());
+        }
+    }
+    fn register(&'static self) {
+        self.deferred_call.register(self);
+    }
+}

--- a/chips/x86_q35/src/ps2.rs
+++ b/chips/x86_q35/src/ps2.rs
@@ -267,6 +267,12 @@ impl Ps2Controller {
         self.client.set(client);
     }
 
+    /// Send one byte to port 0x60 (device), small runtime spin budget.
+    #[inline(always)]
+    pub(crate) fn send_port1(&self, byte: u8) -> Result<(), Ps2Error> {
+        write_data_with(byte, SPINS_RUNTIME)
+    }
+
     #[inline(always)]
     fn drain_and_deliver(&self) {
         while let Some(b) = self.pop_scan_code() {


### PR DESCRIPTION
### Pull Request Overview

This rebases and combines two PRs:
- #4595
- #4594 

Even without the full VGA text screen, these are useful drivers for the x86 platform and it would be nice to not lose them.

I did add a demo by just printing keyboard presses.

I also did some more minor cleanup to the original PRs to fix clippy issues, avoid `as` imports, and remove comment deletions.

### Testing Strategy

Verifying I see keyboard presses when I run `make run` on the x86 board, selecting the QEMU window, and pressing keys.


### TODO or Help Wanted

This pull request still needs...


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
