### PR TITLE
fix: stop stripping kernel attributes when flashing nucleo_u545re_q

### DIFF
--- a/boards/nucleo_u545re_q/Makefile
+++ b/boards/nucleo_u545re_q/Makefile
@@ -29,18 +29,14 @@ install: flash
 
 .PHONY: flash-debug
 flash-debug: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf
-	@echo "--- Preparing Clean Debug Kernel ELF ---"
-	$(OBJCOPY) -j .text -j .ARM.exidx -j .storage -j .relocate $< $<.clean
 	@echo "--- Flashing Debug Kernel via probe-rs ---"
-	$(PROBE_RS) download --chip $(CHIP) --allow-erase-all $<.clean
+	$(PROBE_RS) download --chip $(CHIP) --allow-erase-all $<
 	$(PROBE_RS) reset --chip $(CHIP)
 
 .PHONY: flash
 flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	@echo "--- Preparing Clean Release Kernel ELF ---"
-	$(OBJCOPY) -j .text -j .ARM.exidx -j .storage -j .relocate $< $<.clean
 	@echo "--- Flashing Release Kernel via probe-rs ---"
-	$(PROBE_RS) download --chip $(CHIP) --allow-erase-all $<.clean
+	$(PROBE_RS) download --chip $(CHIP) --allow-erase-all $<
 	$(PROBE_RS) reset --chip $(CHIP)
 
 .PHONY: program


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the stripping of kernel attributes when flashing the board.
Flash and flash-debug used objcopy to strip the ELF down to a few sections before flashing, to avoid a crash caused by one section ".ARM.attributes".But that strip list also deleted .attributes, a different section that Tock uses to store the kernel version and a sentinel("TOCK) on the chip. 


### Testing Strategy

Flashed the board with both flash and flash-debug, kernel boots well. Dumped the chip's flash before and after: the "TOCK" marker/metadata was missing before the fix and present after.


### TODO or Help Wanted
N/A


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
