### PR TITLE
doc: refactor comment to fix rustfmt issue

### DIFF
--- a/arch/cortex-m33/src/mpu_v8m.rs
+++ b/arch/cortex-m33/src/mpu_v8m.rs
@@ -354,9 +354,11 @@ impl CortexMRegion {
             return None;
         }
 
-        // Limit Address register
+        // Limit Address register.
+        //
+        // RLAR::LIMIT is inclusive so `logical_end - 1` here to not have the
+        // region 32 bytes further.
         let rlar_value = MPU_RLAR::ENABLE::SET
-            // RLAR::LIMIT is inclusive so `- 1` here to not have the region 32 bytes further.
             + MPU_RLAR::LIMIT.val(((logical_end - 1) as u32) >> 5)
             + MPU_RLAR::PXN::Disable
             + MPU_RLAR::ATTRINDX.val(0);


### PR DESCRIPTION
### Pull Request Overview

Rustfmt can't move the comment around the broken `+` line, so refactor the comment manually.

Prior to this change, `fmt` failed with:

    cargo fmt
    error[internal]: not formatted because a comment would be lost
       --> /Users/ppannuto/code/helena-project/tock/arch/cortex-m33/src/mpu_v8m.rs:358
        |
    358 |         let rlar_value = MPU_RLAR::ENABLE::SET
        |
        = note: set `error_on_unformatted = false` to suppress the warning against comments or string literals

    error[internal]: not formatted because a comment would be lost
       --> /Users/ppannuto/code/helena-project/tock/arch/cortex-m33/src/mpu_v8m.rs:358
        |
    358 |         let rlar_value = MPU_RLAR::ENABLE::SET
        |
        = note: set `error_on_unformatted = false` to suppress the warning against comments or string literals

    warning: rustfmt has failed to format. See previous 2 errors.


### Testing Strategy

This pull request was tested by `make fmt`


### TODO or Help Wanted

N/A

### Checklist

- [ ] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [X] No documentation updates are required.

#### AI Use

- [X] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
