### PR TITLE
nrf52: Create a single `UarteRegistersManager` and share it with the panic handler; add a `custom` field in `PanicResources` to help; add `only_once!()` to enforce uniqueness

### DIFF
--- a/boards/arty_e21/src/io.rs
+++ b/boards/arty_e21/src/io.rs
@@ -39,7 +39,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
 
     let led_red = &mut led::LedHigh::new(led_red_pin);
 
-    debug::panic::<_, sifive::uart::Uart, _, _>(
+    debug::panic::<_, sifive::uart::Uart, _, _, _>(
         &mut [led_red],
         sifive::uart::UartPanicWriterConfig {
             registers: arty_e21_chip::uart::UART0_BASE,

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -111,7 +111,7 @@ static mut CDC_REF_FOR_PANIC: Option<
     >,
 > = None;
 /// Resources for when a board panics used by io.rs.
-static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
+static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter, ()>> =
     SingleThreadValue::new();
 static NRF52_POWER: SingleThreadValue<&'static nrf52840::power::Power> = SingleThreadValue::new();
 
@@ -277,10 +277,14 @@ unsafe fn start() -> (
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let uarte0_registers_manager = static_init!(
+        nrf52840::uart::UarteRegistersManager,
+        nrf52840::uart::UarteRegistersManager::new_uarte0()
+    );
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf, uarte0_registers_manager)
     );
 
     // set up circular peripheral dependencies

--- a/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/io.rs
+++ b/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/io.rs
@@ -23,23 +23,33 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
 
     let led_kernel_pin = &nrf52833::gpio::nrf52833_gpio_create_pin(Pin::P0_20);
     let led = &mut led::LedLow::new(led_kernel_pin);
-    debug::panic::<_, Uarte, _, _>(
-        &mut [led],
-        UartPanicWriterConfig {
-            params: uart::Parameters {
-                baud_rate: 115200,
-                stop_bits: uart::StopBits::One,
-                parity: uart::Parity::None,
-                hw_flow_control: false,
-                width: uart::Width::Eight,
+
+    crate::PANIC_RESOURCES
+        .get()
+        .and_then(|r| r.custom.take())
+        .map_or_else(
+            || debug::panic_blink_forever(&mut [led]),
+            |uarte0_register_manager| {
+                debug::panic::<_, Uarte, _, _, _>(
+                    &mut [led],
+                    UartPanicWriterConfig {
+                        registers_manager: uarte0_register_manager,
+                        params: uart::Parameters {
+                            baud_rate: 115200,
+                            stop_bits: uart::StopBits::One,
+                            parity: uart::Parity::None,
+                            hw_flow_control: false,
+                            width: uart::Width::Eight,
+                        },
+                        txd: crate::UART_TX_PIN,
+                        rxd: crate::UART_RX_PIN,
+                        cts: None,
+                        rts: None,
+                    },
+                    pi,
+                    &cortexm4::support::nop,
+                    crate::PANIC_RESOURCES.get(),
+                )
             },
-            txd: crate::UART_TX_PIN,
-            rxd: crate::UART_RX_PIN,
-            cts: None,
-            rts: None,
-        },
-        pi,
-        &cortexm4::support::nop,
-        crate::PANIC_RESOURCES.get(),
-    )
+        )
 }

--- a/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
@@ -75,8 +75,9 @@ type ChipHw = nrf52833::chip::NRF52<'static, Nrf52833DefaultPeripherals<'static>
 type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
-static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new();
+static PANIC_RESOURCES: SingleThreadValue<
+    PanicResources<ChipHw, ProcessPrinterInUse, &nrf52833::uart::UarteRegistersManager>,
+> = SingleThreadValue::new();
 
 kernel::stack_size! {0x2000}
 
@@ -252,10 +253,17 @@ unsafe fn start() -> (
         [0; nrf52833::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let uarte0_registers_manager = static_init!(
+        nrf52833::uart::UarteRegistersManager,
+        nrf52833::uart::UarteRegistersManager::new_uarte0()
+    );
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.custom.put(uarte0_registers_manager);
+    });
     // Initialize chip peripheral drivers
     let nrf52833_peripherals = static_init!(
         Nrf52833DefaultPeripherals,
-        Nrf52833DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52833DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf, uarte0_registers_manager)
     );
 
     // set up circular peripheral dependencies

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-base/src/lib.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-base/src/lib.rs
@@ -94,10 +94,14 @@ unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'stati
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let uarte0_registers_manager = static_init!(
+        nrf52840::uart::UarteRegistersManager,
+        nrf52840::uart::UarteRegistersManager::new_uarte0()
+    );
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf, uarte0_registers_manager)
     );
 
     nrf52840_peripherals

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/io.rs
@@ -16,23 +16,33 @@ pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {
     // The nRF52840DK LEDs (see back of board)
     let led_kernel_pin = &nrf52840::gpio::nrf52840_gpio_create_pin(Pin::P0_13);
     let led = &mut led::LedLow::new(led_kernel_pin);
-    debug::panic::<_, Uarte, _, _>(
-        &mut [led],
-        UartPanicWriterConfig {
-            params: uart::Parameters {
-                baud_rate: 115200,
-                stop_bits: uart::StopBits::One,
-                parity: uart::Parity::None,
-                hw_flow_control: false,
-                width: uart::Width::Eight,
+
+    crate::PANIC_RESOURCES
+        .get()
+        .and_then(|r| r.custom.take())
+        .map_or_else(
+            || debug::panic_blink_forever(&mut [led]),
+            |uarte0_register_manager| {
+                debug::panic::<_, Uarte, _, _, _>(
+                    &mut [led],
+                    UartPanicWriterConfig {
+                        registers_manager: uarte0_register_manager,
+                        params: uart::Parameters {
+                            baud_rate: 115200,
+                            stop_bits: uart::StopBits::One,
+                            parity: uart::Parity::None,
+                            hw_flow_control: false,
+                            width: uart::Width::Eight,
+                        },
+                        txd: crate::UART_TXD,
+                        rxd: crate::UART_RXD,
+                        cts: crate::UART_CTS,
+                        rts: crate::UART_RTS,
+                    },
+                    pi,
+                    &cortexm4::support::nop,
+                    crate::PANIC_RESOURCES.get(),
+                )
             },
-            txd: crate::UART_TXD,
-            rxd: crate::UART_RXD,
-            cts: crate::UART_CTS,
-            rts: crate::UART_RTS,
-        },
-        pi,
-        &cortexm4::support::nop,
-        crate::PANIC_RESOURCES.get(),
-    )
+        )
 }

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
@@ -59,8 +59,9 @@ type ChipHw = nrf52840::chip::NRF52<'static, Nrf52840DefaultPeripherals<'static>
 type ProcessPrinter = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
-static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
-    SingleThreadValue::new();
+static PANIC_RESOURCES: SingleThreadValue<
+    PanicResources<ChipHw, ProcessPrinter, &nrf52840::uart::UarteRegistersManager>,
+> = SingleThreadValue::new();
 
 kernel::stack_size! {0x2000}
 
@@ -128,10 +129,17 @@ unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'stati
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let uarte0_registers_manager = static_init!(
+        nrf52840::uart::UarteRegistersManager,
+        nrf52840::uart::UarteRegistersManager::new_uarte0()
+    );
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.custom.put(uarte0_registers_manager);
+    });
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf, uarte0_registers_manager)
     );
 
     nrf52840_peripherals

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/io.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/io.rs
@@ -16,23 +16,33 @@ pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {
     // The nRF52840DK LEDs (see back of board)
     let led_kernel_pin = &nrf52840::gpio::nrf52840_gpio_create_pin(Pin::P0_13);
     let led = &mut led::LedLow::new(led_kernel_pin);
-    debug::panic::<_, Uarte, _, _>(
-        &mut [led],
-        UartPanicWriterConfig {
-            params: uart::Parameters {
-                baud_rate: 115200,
-                stop_bits: uart::StopBits::One,
-                parity: uart::Parity::None,
-                hw_flow_control: false,
-                width: uart::Width::Eight,
+
+    crate::PANIC_RESOURCES
+        .get()
+        .and_then(|r| r.custom.take())
+        .map_or_else(
+            || debug::panic_blink_forever(&mut [led]),
+            |uarte0_register_manager| {
+                debug::panic::<_, Uarte, _, _, _>(
+                    &mut [led],
+                    UartPanicWriterConfig {
+                        registers_manager: uarte0_register_manager,
+                        params: uart::Parameters {
+                            baud_rate: 115200,
+                            stop_bits: uart::StopBits::One,
+                            parity: uart::Parity::None,
+                            hw_flow_control: false,
+                            width: uart::Width::Eight,
+                        },
+                        txd: crate::UART_TXD,
+                        rxd: crate::UART_RXD,
+                        cts: crate::UART_CTS,
+                        rts: crate::UART_RTS,
+                    },
+                    pi,
+                    &cortexm4::support::nop,
+                    crate::PANIC_RESOURCES.get(),
+                )
             },
-            txd: crate::UART_TXD,
-            rxd: crate::UART_RXD,
-            cts: crate::UART_CTS,
-            rts: crate::UART_RTS,
-        },
-        pi,
-        &cortexm4::support::nop,
-        crate::PANIC_RESOURCES.get(),
-    )
+        )
 }

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/main.rs
@@ -46,8 +46,9 @@ type ChipHw = nrf52840::chip::NRF52<'static, Nrf52840DefaultPeripherals<'static>
 type ProcessPrinter = capsules_system::process_printer::ProcessPrinterNull;
 
 /// Resources for when a board panics used by io.rs.
-static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
-    SingleThreadValue::new();
+static PANIC_RESOURCES: SingleThreadValue<
+    PanicResources<ChipHw, ProcessPrinter, &nrf52840::uart::UarteRegistersManager>,
+> = SingleThreadValue::new();
 
 kernel::stack_size! {0x2000}
 
@@ -119,10 +120,17 @@ unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'stati
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let uarte0_registers_manager = static_init!(
+        nrf52840::uart::UarteRegistersManager,
+        nrf52840::uart::UarteRegistersManager::new_uarte0()
+    );
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.custom.put(uarte0_registers_manager);
+    });
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf, uarte0_registers_manager)
     );
 
     nrf52840_peripherals

--- a/boards/esp32-c3-devkitM-1/src/io.rs
+++ b/boards/esp32-c3-devkitM-1/src/io.rs
@@ -9,7 +9,7 @@ use kernel::debug;
 #[cfg(not(test))]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    debug::panic_print::<esp32::uart::Uart, _, _>(
+    debug::panic_print::<esp32::uart::Uart, _, _, _>(
         esp32::uart::UartPanicWriterConfig {
             registers: esp32::uart::UART0_BASE,
             params: kernel::hil::uart::Parameters {
@@ -33,7 +33,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
 #[cfg(test)]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    debug::panic_print::<esp32::uart::Uart, _, _>(
+    debug::panic_print::<esp32::uart::Uart, _, _, _>(
         esp32::uart::UartPanicWriterConfig {
             registers: esp32::uart::UART0_BASE,
             params: kernel::hil::uart::Parameters {

--- a/boards/makepython-nrf52840/src/main.rs
+++ b/boards/makepython-nrf52840/src/main.rs
@@ -80,7 +80,7 @@ static mut CDC_REF_FOR_PANIC: Option<
     >,
 > = None;
 /// Resources for when a board panics used by io.rs.
-static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
+static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter, ()>> =
     SingleThreadValue::new();
 static NRF52_POWER: SingleThreadValue<&'static nrf52840::power::Power> = SingleThreadValue::new();
 
@@ -250,11 +250,15 @@ pub unsafe fn start() -> (
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let uarte0_registers_manager = static_init!(
+        nrf52840::uart::UarteRegistersManager,
+        nrf52840::uart::UarteRegistersManager::new_uarte0()
+    );
 
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf, uarte0_registers_manager)
     );
 
     // set up circular peripheral dependencies

--- a/boards/microbit_v2/src/io.rs
+++ b/boards/microbit_v2/src/io.rs
@@ -20,26 +20,35 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     // let mut led = Led (&gpio::PORT[Pin::P0_28], );
 
     // MicroBit v2 has a microphone LED, use it for panic
-
     let led_kernel_pin = &nrf52833::gpio::nrf52833_gpio_create_pin(Pin::P0_20);
     let led = &mut led::LedLow::new(led_kernel_pin);
-    debug::panic::<_, Uarte, _, _>(
-        &mut [led],
-        UartPanicWriterConfig {
-            params: uart::Parameters {
-                baud_rate: 115200,
-                stop_bits: uart::StopBits::One,
-                parity: uart::Parity::None,
-                hw_flow_control: false,
-                width: uart::Width::Eight,
+
+    crate::PANIC_RESOURCES
+        .get()
+        .and_then(|r| r.custom.take())
+        .map_or_else(
+            || debug::panic_blink_forever(&mut [led]),
+            |uarte0_register_manager| {
+                debug::panic::<_, Uarte, _, _, _>(
+                    &mut [led],
+                    UartPanicWriterConfig {
+                        registers_manager: uarte0_register_manager,
+                        params: uart::Parameters {
+                            baud_rate: 115200,
+                            stop_bits: uart::StopBits::One,
+                            parity: uart::Parity::None,
+                            hw_flow_control: false,
+                            width: uart::Width::Eight,
+                        },
+                        txd: crate::UART_TX_PIN,
+                        rxd: crate::UART_RX_PIN,
+                        cts: None,
+                        rts: None,
+                    },
+                    pi,
+                    &cortexm4::support::nop,
+                    crate::PANIC_RESOURCES.get(),
+                )
             },
-            txd: crate::UART_TX_PIN,
-            rxd: crate::UART_RX_PIN,
-            cts: None,
-            rts: None,
-        },
-        pi,
-        &cortexm4::support::nop,
-        crate::PANIC_RESOURCES.get(),
-    )
+        )
 }

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -75,8 +75,9 @@ type ChipHw = nrf52833::chip::NRF52<'static, Nrf52833DefaultPeripherals<'static>
 type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
-static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new();
+static PANIC_RESOURCES: SingleThreadValue<
+    PanicResources<ChipHw, ProcessPrinterInUse, &nrf52833::uart::UarteRegistersManager>,
+> = SingleThreadValue::new();
 
 kernel::stack_size! {0x2000}
 
@@ -236,10 +237,17 @@ unsafe fn start() -> (
         [0; nrf52833::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let uarte0_registers_manager = static_init!(
+        nrf52833::uart::UarteRegistersManager,
+        nrf52833::uart::UarteRegistersManager::new_uarte0()
+    );
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.custom.put(uarte0_registers_manager);
+    });
     // Initialize chip peripheral drivers
     let nrf52833_peripherals = static_init!(
         Nrf52833DefaultPeripherals,
-        Nrf52833DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52833DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf, uarte0_registers_manager)
     );
 
     // set up circular peripheral dependencies

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -96,7 +96,7 @@ static mut CDC_REF_FOR_PANIC: Option<
     >,
 > = None;
 /// Resources for when a board panics used by io.rs.
-static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
+static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter, ()>> =
     SingleThreadValue::new();
 static NRF52_POWER: SingleThreadValue<&'static nrf52840::power::Power> = SingleThreadValue::new();
 
@@ -260,11 +260,15 @@ pub unsafe fn start() -> (
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let uarte0_registers_manager = static_init!(
+        nrf52840::uart::UarteRegistersManager,
+        nrf52840::uart::UarteRegistersManager::new_uarte0()
+    );
 
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf, uarte0_registers_manager)
     );
 
     // set up circular peripheral dependencies

--- a/boards/nano33ble_rev2/src/main.rs
+++ b/boards/nano33ble_rev2/src/main.rs
@@ -93,7 +93,7 @@ static mut CDC_REF_FOR_PANIC: Option<
     >,
 > = None;
 /// Resources for when a board panics used by io.rs.
-static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
+static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter, ()>> =
     SingleThreadValue::new();
 static NRF52_POWER: SingleThreadValue<&'static nrf52840::power::Power> = SingleThreadValue::new();
 
@@ -266,11 +266,15 @@ pub unsafe fn start() -> (
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let uarte0_registers_manager = static_init!(
+        nrf52840::uart::UarteRegistersManager,
+        nrf52840::uart::UarteRegistersManager::new_uarte0()
+    );
 
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf, uarte0_registers_manager)
     );
 
     // set up circular peripheral dependencies

--- a/boards/nordic/nrf52840_dongle/src/io.rs
+++ b/boards/nordic/nrf52840_dongle/src/io.rs
@@ -17,23 +17,33 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
 
     let led_kernel_pin = &nrf52840::gpio::nrf52840_gpio_create_pin(Pin::P0_06);
     let led = &mut led::LedLow::new(led_kernel_pin);
-    debug::panic::<_, Uarte, _, _>(
-        &mut [led],
-        UartPanicWriterConfig {
-            params: uart::Parameters {
-                baud_rate: 115200,
-                stop_bits: uart::StopBits::One,
-                parity: uart::Parity::None,
-                hw_flow_control: false,
-                width: uart::Width::Eight,
+
+    crate::PANIC_RESOURCES
+        .get()
+        .and_then(|r| r.custom.take())
+        .map_or_else(
+            || debug::panic_blink_forever(&mut [led]),
+            |uarte0_register_manager| {
+                debug::panic::<_, Uarte, _, _, _>(
+                    &mut [led],
+                    UartPanicWriterConfig {
+                        registers_manager: uarte0_register_manager,
+                        params: uart::Parameters {
+                            baud_rate: 115200,
+                            stop_bits: uart::StopBits::One,
+                            parity: uart::Parity::None,
+                            hw_flow_control: false,
+                            width: uart::Width::Eight,
+                        },
+                        txd: crate::UART_TXD,
+                        rxd: crate::UART_RXD,
+                        cts: crate::UART_CTS,
+                        rts: crate::UART_RTS,
+                    },
+                    pi,
+                    &cortexm4::support::nop,
+                    crate::PANIC_RESOURCES.get(),
+                )
             },
-            txd: crate::UART_TXD,
-            rxd: crate::UART_RXD,
-            cts: crate::UART_CTS,
-            rts: crate::UART_RTS,
-        },
-        pi,
-        &cortexm4::support::nop,
-        crate::PANIC_RESOURCES.get(),
-    )
+        )
 }

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -69,8 +69,9 @@ type ChipHw = nrf52840::chip::NRF52<'static, Nrf52840DefaultPeripherals<'static>
 type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
-static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new();
+static PANIC_RESOURCES: SingleThreadValue<
+    PanicResources<ChipHw, ProcessPrinterInUse, &nrf52840::uart::UarteRegistersManager>,
+> = SingleThreadValue::new();
 
 kernel::stack_size! {0x1000}
 
@@ -211,10 +212,17 @@ pub unsafe fn start() -> (
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let uarte0_registers_manager = static_init!(
+        nrf52840::uart::UarteRegistersManager,
+        nrf52840::uart::UarteRegistersManager::new_uarte0()
+    );
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.custom.put(uarte0_registers_manager);
+    });
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf, uarte0_registers_manager)
     );
 
     // set up circular peripheral dependencies

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -22,7 +22,7 @@ pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {
         crate::RTT_BUFFER.get().and_then(MapCell::take).map_or_else(
             || debug::panic_blink_forever(&mut [led]),
             |rtt| {
-                debug::panic::<_, segger::rtt::SeggerRttMemory, _, _>(
+                debug::panic::<_, segger::rtt::SeggerRttMemory, _, _, _>(
                     &mut [led],
                     rtt,
                     pi,
@@ -34,24 +34,33 @@ pub unsafe fn panic_fmt(pi: &core::panic::PanicInfo) -> ! {
     } else {
         // Use the nRF52 UART for panic output.
 
-        debug::panic::<_, nrf52840::uart::Uarte, _, _>(
-            &mut [led],
-            nrf52840::uart::UartPanicWriterConfig {
-                params: uart::Parameters {
-                    baud_rate: 115200,
-                    stop_bits: uart::StopBits::One,
-                    parity: uart::Parity::None,
-                    hw_flow_control: false,
-                    width: uart::Width::Eight,
+        crate::PANIC_RESOURCES
+            .get()
+            .and_then(|r| r.custom.take())
+            .map_or_else(
+                || debug::panic_blink_forever(&mut [led]),
+                |uarte0_register_manager| {
+                    debug::panic::<_, nrf52840::uart::Uarte, _, _, _>(
+                        &mut [led],
+                        nrf52840::uart::UartPanicWriterConfig {
+                            registers_manager: uarte0_register_manager,
+                            params: uart::Parameters {
+                                baud_rate: 115200,
+                                stop_bits: uart::StopBits::One,
+                                parity: uart::Parity::None,
+                                hw_flow_control: false,
+                                width: uart::Width::Eight,
+                            },
+                            txd: crate::UART_TXD,
+                            rxd: crate::UART_RXD,
+                            cts: crate::UART_CTS,
+                            rts: crate::UART_CTS,
+                        },
+                        pi,
+                        &cortexm4::support::nop,
+                        crate::PANIC_RESOURCES.get(),
+                    )
                 },
-                txd: crate::UART_TXD,
-                rxd: crate::UART_RXD,
-                cts: crate::UART_CTS,
-                rts: crate::UART_CTS,
-            },
-            pi,
-            &cortexm4::support::nop,
-            crate::PANIC_RESOURCES.get(),
-        )
+            )
     }
 }

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -146,8 +146,9 @@ pub const NUM_PROCS: usize = 8;
 use kernel::utilities::single_thread_value::SingleThreadValue;
 
 /// Resources for when a board panics used by io.rs.
-static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
-    SingleThreadValue::new();
+static PANIC_RESOURCES: SingleThreadValue<
+    PanicResources<ChipHw, ProcessPrinter, &nrf52840::uart::UarteRegistersManager>,
+> = SingleThreadValue::new();
 
 /// In-memory buffer used for the Segger Real Time Transfer (RTT) mechanism.
 static RTT_BUFFER: SingleThreadValue<MapCell<&'static segger::rtt::SeggerRttMemory<'static>>> =
@@ -439,10 +440,17 @@ pub unsafe fn start_no_pconsole() -> (
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let uarte0_registers_manager = static_init!(
+        nrf52840::uart::UarteRegistersManager,
+        nrf52840::uart::UarteRegistersManager::new_uarte0()
+    );
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.custom.put(uarte0_registers_manager);
+    });
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf, uarte0_registers_manager)
     );
 
     // Set up circular peripheral dependencies.

--- a/boards/nordic/nrf52dk/src/io.rs
+++ b/boards/nordic/nrf52dk/src/io.rs
@@ -16,23 +16,32 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_kernel_pin = &nrf52832::gpio::nrf52832_gpio_create_pin(Pin::P0_17);
     let led = &mut led::LedLow::new(led_kernel_pin);
 
-    debug::panic::<_, nrf52832::uart::Uarte, _, _>(
-        &mut [led],
-        nrf52832::uart::UartPanicWriterConfig {
-            params: uart::Parameters {
-                baud_rate: 115200,
-                stop_bits: uart::StopBits::One,
-                parity: uart::Parity::None,
-                hw_flow_control: false,
-                width: uart::Width::Eight,
+    crate::PANIC_RESOURCES
+        .get()
+        .and_then(|r| r.custom.take())
+        .map_or_else(
+            || debug::panic_blink_forever(&mut [led]),
+            |uarte0_register_manager| {
+                debug::panic::<_, nrf52832::uart::Uarte, _, _, _>(
+                    &mut [led],
+                    nrf52832::uart::UartPanicWriterConfig {
+                        registers_manager: uarte0_register_manager,
+                        params: uart::Parameters {
+                            baud_rate: 115200,
+                            stop_bits: uart::StopBits::One,
+                            parity: uart::Parity::None,
+                            hw_flow_control: false,
+                            width: uart::Width::Eight,
+                        },
+                        txd: crate::UART_TXD,
+                        rxd: crate::UART_RXD,
+                        cts: crate::UART_CTS,
+                        rts: crate::UART_CTS,
+                    },
+                    pi,
+                    &cortexm4::support::nop,
+                    crate::PANIC_RESOURCES.get(),
+                )
             },
-            txd: crate::UART_TXD,
-            rxd: crate::UART_RXD,
-            cts: crate::UART_CTS,
-            rts: crate::UART_CTS,
-        },
-        pi,
-        &cortexm4::support::nop,
-        crate::PANIC_RESOURCES.get(),
-    )
+        )
 }

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -126,8 +126,9 @@ type ChipHw = nrf52832::chip::NRF52<'static, Nrf52832DefaultPeripherals<'static>
 type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
-static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new();
+static PANIC_RESOURCES: SingleThreadValue<
+    PanicResources<ChipHw, ProcessPrinterInUse, &nrf52832::uart::UarteRegistersManager>,
+> = SingleThreadValue::new();
 
 kernel::stack_size! {0x1000}
 
@@ -257,9 +258,16 @@ pub unsafe fn start() -> (
         );
 
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let uarte0_registers_manager = static_init!(
+        nrf52832::uart::UarteRegistersManager,
+        nrf52832::uart::UarteRegistersManager::new_uarte0()
+    );
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.custom.put(uarte0_registers_manager);
+    });
     let nrf52832_peripherals = static_init!(
         Nrf52832DefaultPeripherals,
-        Nrf52832DefaultPeripherals::new(aes_ecb_buf)
+        Nrf52832DefaultPeripherals::new(aes_ecb_buf, uarte0_registers_manager)
     );
 
     // set up circular peripheral dependencies

--- a/boards/nucleo_u545re_q/src/io.rs
+++ b/boards/nucleo_u545re_q/src/io.rs
@@ -13,7 +13,7 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
         base: stm32u545::usart::USART1_BASE,
     };
 
-    debug::panic_print::<stm32u545::usart::Usart, crate::ChipHw, crate::ProcessPrinterInUse>(
+    debug::panic_print::<stm32u545::usart::Usart, crate::ChipHw, crate::ProcessPrinterInUse, ()>(
         writer_config,
         info,
         &cortexm33::support::nop,

--- a/boards/particle_boron/src/io.rs
+++ b/boards/particle_boron/src/io.rs
@@ -19,23 +19,33 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
 
     let led_kernel_pin = &nrf52840::gpio::nrf52840_gpio_create_pin(LED2_R_PIN);
     let led = &mut led::LedLow::new(led_kernel_pin);
-    debug::panic::<_, Uarte, _, _>(
-        &mut [led],
-        UartPanicWriterConfig {
-            params: uart::Parameters {
-                baud_rate: 115200,
-                stop_bits: uart::StopBits::One,
-                parity: uart::Parity::None,
-                hw_flow_control: false,
-                width: uart::Width::Eight,
+
+    crate::PANIC_RESOURCES
+        .get()
+        .and_then(|r| r.custom.take())
+        .map_or_else(
+            || debug::panic_blink_forever(&mut [led]),
+            |uarte0_register_manager| {
+                debug::panic::<_, Uarte, _, _, _>(
+                    &mut [led],
+                    UartPanicWriterConfig {
+                        registers_manager: uarte0_register_manager,
+                        params: uart::Parameters {
+                            baud_rate: 115200,
+                            stop_bits: uart::StopBits::One,
+                            parity: uart::Parity::None,
+                            hw_flow_control: false,
+                            width: uart::Width::Eight,
+                        },
+                        txd: crate::UART_TXD,
+                        rxd: crate::UART_RXD,
+                        cts: None,
+                        rts: None,
+                    },
+                    pi,
+                    &cortexm4::support::nop,
+                    crate::PANIC_RESOURCES.get(),
+                )
             },
-            txd: crate::UART_TXD,
-            rxd: crate::UART_RXD,
-            cts: None,
-            rts: None,
-        },
-        pi,
-        &cortexm4::support::nop,
-        crate::PANIC_RESOURCES.get(),
-    )
+        )
 }

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -76,8 +76,9 @@ type ChipHw = nrf52840::chip::NRF52<'static, Nrf52840DefaultPeripherals<'static>
 type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
-static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
-    SingleThreadValue::new();
+static PANIC_RESOURCES: SingleThreadValue<
+    PanicResources<ChipHw, ProcessPrinterInUse, &nrf52840::uart::UarteRegistersManager>,
+> = SingleThreadValue::new();
 
 kernel::stack_size! {0x1000}
 
@@ -196,10 +197,17 @@ unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'stati
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let uarte0_registers_manager = static_init!(
+        nrf52840::uart::UarteRegistersManager,
+        nrf52840::uart::UarteRegistersManager::new_uarte0()
+    );
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.custom.put(uarte0_registers_manager);
+    });
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf, uarte0_registers_manager)
     );
 
     nrf52840_peripherals

--- a/boards/psc3m5_evk/src/io.rs
+++ b/boards/psc3m5_evk/src/io.rs
@@ -18,7 +18,7 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_kernel_pin = &GpioPin::new(gpio::PsocPin::P8_5);
     let led = &mut LedHigh::new(led_kernel_pin);
 
-    debug::panic::<_, psc3::scb::Scb, _, _>(
+    debug::panic::<_, psc3::scb::Scb, _, _, _>(
         &mut [led],
         psc3::scb::ScbPanicWriterConfig {
             params: kernel::hil::uart::Parameters {

--- a/boards/qemu_rv32_virt/src/io.rs
+++ b/boards/qemu_rv32_virt/src/io.rs
@@ -11,7 +11,7 @@ use kernel::hil::uart;
 #[cfg(not(test))]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    debug::panic_print::<qemu_rv32_virt_chip::uart::UartPanicWriter, _, _>(
+    debug::panic_print::<qemu_rv32_virt_chip::uart::UartPanicWriter, _, _, _>(
         qemu_rv32_virt_chip::uart::UartPanicWriterConfig {
             params: uart::Parameters {
                 baud_rate: 115200,

--- a/boards/qemu_rv32_virt/src/lib.rs
+++ b/boards/qemu_rv32_virt/src/lib.rs
@@ -48,7 +48,7 @@ type SchedulerTimerHw =
 type SchedulerInUse = components::sched::cooperative::CooperativeComponentType;
 
 /// Resources for when a board panics used by io.rs.
-static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
+static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter, ()>> =
     SingleThreadValue::new();
 
 kernel::stack_size! {0x8000}

--- a/boards/qemu_rv64_virt/src/io.rs
+++ b/boards/qemu_rv64_virt/src/io.rs
@@ -11,7 +11,7 @@ use kernel::hil::uart;
 #[cfg(not(test))]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
-    debug::panic_print::<qemu_rv64_virt_chip::uart::UartPanicWriter, _, _>(
+    debug::panic_print::<qemu_rv64_virt_chip::uart::UartPanicWriter, _, _, _>(
         qemu_rv64_virt_chip::uart::UartPanicWriterConfig {
             params: uart::Parameters {
                 baud_rate: 115200,

--- a/boards/raspberry_pi_pico/src/lib.rs
+++ b/boards/raspberry_pi_pico/src/lib.rs
@@ -59,7 +59,7 @@ pub type ChipHw = Rp2040<'static, Rp2040DefaultPeripherals<'static>>;
 type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
-pub static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
+pub static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse, ()>> =
     SingleThreadValue::new();
 
 type TemperatureRp2040Sensor = components::temperature_rp2040::TemperatureRp2040ComponentType<

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -63,7 +63,7 @@ type ChipHw = nrf52840::chip::NRF52<'static, Nrf52840DefaultPeripherals<'static>
 type ProcessPrinterInUse = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
-static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse>> =
+static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinterInUse, ()>> =
     SingleThreadValue::new();
 
 kernel::stack_size! {0x1000}
@@ -213,10 +213,14 @@ pub unsafe fn start() -> (
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let uarte0_registers_manager = static_init!(
+        nrf52840::uart::UarteRegistersManager,
+        nrf52840::uart::UarteRegistersManager::new_uarte0()
+    );
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf, uarte0_registers_manager)
     );
 
     // set up circular peripheral dependencies

--- a/boards/wm1110dev/src/io.rs
+++ b/boards/wm1110dev/src/io.rs
@@ -19,23 +19,32 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let led_red_pin = &nrf52840::gpio::nrf52840_gpio_create_pin(Pin::P0_14);
     let led = &mut led::LedHigh::new(led_red_pin);
 
-    debug::panic::<_, nrf52840::uart::Uarte, _, _>(
-        &mut [led],
-        nrf52840::uart::UartPanicWriterConfig {
-            params: uart::Parameters {
-                baud_rate: 115200,
-                stop_bits: uart::StopBits::One,
-                parity: uart::Parity::None,
-                hw_flow_control: false,
-                width: uart::Width::Eight,
+    crate::PANIC_RESOURCES
+        .get()
+        .and_then(|r| r.custom.take())
+        .map_or_else(
+            || debug::panic_blink_forever(&mut [led]),
+            |uarte0_register_manager| {
+                debug::panic::<_, nrf52840::uart::Uarte, _, _, _>(
+                    &mut [led],
+                    nrf52840::uart::UartPanicWriterConfig {
+                        registers_manager: uarte0_register_manager,
+                        params: uart::Parameters {
+                            baud_rate: 115200,
+                            stop_bits: uart::StopBits::One,
+                            parity: uart::Parity::None,
+                            hw_flow_control: false,
+                            width: uart::Width::Eight,
+                        },
+                        txd: crate::UART_TX_PIN,
+                        rxd: crate::UART_RX_PIN,
+                        cts: None,
+                        rts: None,
+                    },
+                    pi,
+                    &cortexm4::support::nop,
+                    crate::PANIC_RESOURCES.get(),
+                )
             },
-            txd: crate::UART_TX_PIN,
-            rxd: crate::UART_RX_PIN,
-            cts: None,
-            rts: None,
-        },
-        pi,
-        &cortexm4::support::nop,
-        crate::PANIC_RESOURCES.get(),
-    )
+        )
 }

--- a/boards/wm1110dev/src/main.rs
+++ b/boards/wm1110dev/src/main.rs
@@ -80,8 +80,9 @@ pub type ChipHw = nrf52840::chip::NRF52<'static, Nrf52840DefaultPeripherals<'sta
 type ProcessPrinter = capsules_system::process_printer::ProcessPrinterText;
 
 /// Resources for when a board panics used by io.rs.
-static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>> =
-    SingleThreadValue::new();
+static PANIC_RESOURCES: SingleThreadValue<
+    PanicResources<ChipHw, ProcessPrinter, &nrf52840::uart::UarteRegistersManager>,
+> = SingleThreadValue::new();
 
 kernel::stack_size! {0x1000}
 
@@ -216,11 +217,18 @@ pub unsafe fn start() -> (
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let uarte0_registers_manager = static_init!(
+        nrf52840::uart::UarteRegistersManager,
+        nrf52840::uart::UarteRegistersManager::new_uarte0()
+    );
+    PANIC_RESOURCES.get().map(|resources| {
+        resources.custom.put(uarte0_registers_manager);
+    });
 
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf, uarte0_registers_manager)
     );
 
     // set up circular peripheral dependencies

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -76,8 +76,11 @@ pub struct Nrf52DefaultPeripherals<'a> {
     pub pwm0: crate::pwm::Pwm,
 }
 
-impl Nrf52DefaultPeripherals<'_> {
-    pub fn new(aes_ecb_buffer: &'static mut [u8; 48]) -> Self {
+impl<'a> Nrf52DefaultPeripherals<'a> {
+    pub fn new(
+        aes_ecb_buffer: &'static mut [u8; 48],
+        uarte0_registers_manager: &'a crate::uart::UarteRegistersManager,
+    ) -> Self {
         // # Safety
         //
         // This must only get constructed once.
@@ -100,7 +103,7 @@ impl Nrf52DefaultPeripherals<'_> {
             timer0: crate::timer::TimerAlarm::new(TIMER0_BASE),
             timer1: crate::timer::TimerAlarm::new(TIMER1_BASE),
             timer2: crate::timer::Timer::new(TIMER2_BASE),
-            uarte0: crate::uart::Uarte::new(crate::uart::UARTE0_BASE),
+            uarte0: crate::uart::Uarte::new(uarte0_registers_manager),
             spim0: crate::spi::SPIM::new(0),
             twi1: crate::i2c::TWI::new_twi1(),
             spim2: crate::spi::SPIM::new(2),

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -184,6 +184,12 @@ impl UarteRegistersManager {
     /// we must ensure there is only one register manager in existence. Trying
     /// to call this constructor twice will result in a board panic.
     pub fn new_uarte0() -> Self {
+        // We must ensure this register manager is only constructed once to make
+        // this constructor safe. If this is constructed multiple times then
+        // something could control DMA while the other UART register manager is
+        // active.
+        kernel::only_once!();
+
         Self {
             registers: UARTE0_BASE,
             tx_dma_buf: MapCell::empty(),

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -27,7 +27,7 @@ const UARTE_MAX_BUFFER_SIZE: usize = 0xff;
 
 static mut BYTE: u8 = 0;
 
-pub const UARTE0_BASE: StaticRef<UarteRegisters> =
+const UARTE0_BASE: StaticRef<UarteRegisters> =
     unsafe { StaticRef::new(0x40002000 as *const UarteRegisters) };
 
 #[repr(C)]
@@ -163,7 +163,7 @@ register_bitfields! [u32,
 ];
 
 /// Wrapper for managing MMIO for UARTE.
-struct UarteRegistersManager {
+pub struct UarteRegistersManager {
     /// MMIO registers for the UARTE peripheral.
     registers: StaticRef<UarteRegisters>,
     /// Holding place for the TX DMA buffer while DMA in progress.
@@ -173,9 +173,19 @@ struct UarteRegistersManager {
 }
 
 impl UarteRegistersManager {
-    pub fn new(regs: StaticRef<UarteRegisters>) -> Self {
+    /// Create the register manager for the UARTE0 peripheral.
+    ///
+    /// This wraps the StaticRef for the UARTE0 memory location and owns the
+    /// registers, particularly the DMA registers.
+    ///
+    /// # Panics
+    ///
+    /// This can _only be called once_. Because the UARTE peripheral uses DMA,
+    /// we must ensure there is only one register manager in existence. Trying
+    /// to call this constructor twice will result in a board panic.
+    pub fn new_uarte0() -> Self {
         Self {
-            registers: regs,
+            registers: UARTE0_BASE,
             tx_dma_buf: MapCell::empty(),
             rx_dma_buf: MapCell::empty(),
         }
@@ -322,7 +332,7 @@ impl UarteRegistersManager {
 // It should never be instanced outside this module but because a static mutable reference to it
 // is exported outside this module it must be `pub`
 pub struct Uarte<'a> {
-    registers: UarteRegistersManager,
+    registers: &'a UarteRegistersManager,
     tx_client: OptionalCell<&'a dyn uart::TransmitClient>,
     tx_len: Cell<usize>,
     rx_client: OptionalCell<&'a dyn uart::ReceiveClient>,
@@ -336,11 +346,9 @@ pub struct UARTParams {
 }
 
 impl<'a> Uarte<'a> {
-    /// Constructor
-    // This should only be constructed once
-    pub fn new(regs: StaticRef<UarteRegisters>) -> Uarte<'a> {
+    pub fn new(registers: &'a UarteRegistersManager) -> Uarte<'a> {
         Uarte {
-            registers: UarteRegistersManager::new(regs),
+            registers,
             tx_client: OptionalCell::empty(),
             // tx_buffer: kernel::utilities::cells::TakeCell::empty(),
             tx_len: Cell::new(0),
@@ -827,6 +835,7 @@ impl core::fmt::Write for UartPanicWriter<'_> {
 /// This captures everything needed to setup the UART for panic display, even
 /// if the normal kernel had initialized it differently.
 pub struct UartPanicWriterConfig {
+    pub registers_manager: &'static UarteRegistersManager,
     pub params: uart::Parameters,
     pub txd: Pin,
     pub rxd: Pin,
@@ -840,7 +849,7 @@ impl kernel::platform::chip::PanicWriter for Uarte<'_> {
     unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write {
         use uart::Configure as _;
 
-        let inner = Uarte::new(UARTE0_BASE);
+        let inner = Uarte::new(config.registers_manager);
         inner.initialize(
             pinmux::Pinmux::new(config.txd),
             pinmux::Pinmux::new(config.rxd),
@@ -858,7 +867,8 @@ mod tests {
 
     #[test]
     fn baud_rate_divider_calculation() {
-        let u = super::Uarte::new(super::UARTE0_BASE);
+        let registers_manager = super::UarteRegistersManager::new_uarte0();
+        let u = super::Uarte::new(&registers_manager);
         assert_eq!(u.get_divider_for_baud(0), Err(ErrorCode::INVAL));
         assert_eq!(u.get_divider_for_baud(4_000_000), Err(ErrorCode::INVAL));
 

--- a/chips/nrf52832/src/interrupt_service.rs
+++ b/chips/nrf52832/src/interrupt_service.rs
@@ -13,10 +13,13 @@ pub struct Nrf52832DefaultPeripherals<'a> {
     pub nrf52: Nrf52DefaultPeripherals<'a>,
     pub gpio_port: crate::gpio::Port<'a, { crate::gpio::NUM_PINS }>,
 }
-impl Nrf52832DefaultPeripherals<'_> {
-    pub unsafe fn new(aes_ecb_buf: &'static mut [u8; 48]) -> Self {
+impl<'a> Nrf52832DefaultPeripherals<'a> {
+    pub unsafe fn new(
+        aes_ecb_buf: &'static mut [u8; 48],
+        uarte0_registers_manager: &'a nrf52::uart::UarteRegistersManager,
+    ) -> Self {
         Self {
-            nrf52: Nrf52DefaultPeripherals::new(aes_ecb_buf),
+            nrf52: Nrf52DefaultPeripherals::new(aes_ecb_buf, uarte0_registers_manager),
             gpio_port: crate::gpio::nrf52832_gpio_create(),
         }
     }

--- a/chips/nrf52833/src/interrupt_service.rs
+++ b/chips/nrf52833/src/interrupt_service.rs
@@ -15,13 +15,14 @@ pub struct Nrf52833DefaultPeripherals<'a> {
     pub ieee802154_radio: crate::ieee802154_radio::Radio<'a>,
     pub gpio_port: crate::gpio::Port<'a, { crate::gpio::NUM_PINS }>,
 }
-impl Nrf52833DefaultPeripherals<'_> {
+impl<'a> Nrf52833DefaultPeripherals<'a> {
     pub unsafe fn new(
         ieee802154_radio_ack_buf: &'static mut [u8; crate::ieee802154_radio::ACK_BUF_SIZE],
         aes_ecb_buf: &'static mut [u8; 48],
+        uarte0_registers_manager: &'a nrf52::uart::UarteRegistersManager,
     ) -> Self {
         Self {
-            nrf52: Nrf52DefaultPeripherals::new(aes_ecb_buf),
+            nrf52: Nrf52DefaultPeripherals::new(aes_ecb_buf, uarte0_registers_manager),
             ieee802154_radio: crate::ieee802154_radio::Radio::new(ieee802154_radio_ack_buf),
             gpio_port: crate::gpio::nrf52833_gpio_create(),
         }

--- a/chips/nrf52840/src/interrupt_service.rs
+++ b/chips/nrf52840/src/interrupt_service.rs
@@ -20,13 +20,14 @@ pub struct Nrf52840DefaultPeripherals<'a> {
     pub gpio_port: crate::gpio::Port<'a, { crate::gpio::NUM_PINS }>,
 }
 
-impl Nrf52840DefaultPeripherals<'_> {
+impl<'a> Nrf52840DefaultPeripherals<'a> {
     pub unsafe fn new(
         ieee802154_radio_ack_buf: &'static mut [u8; crate::ieee802154_radio::ACK_BUF_SIZE],
         aes_ecb_buf: &'static mut [u8; 48],
+        uarte0_registers_manager: &'a nrf52::uart::UarteRegistersManager,
     ) -> Self {
         Self {
-            nrf52: Nrf52DefaultPeripherals::new(aes_ecb_buf),
+            nrf52: Nrf52DefaultPeripherals::new(aes_ecb_buf, uarte0_registers_manager),
             ieee802154_radio: crate::ieee802154_radio::Radio::new(ieee802154_radio_ack_buf),
             usbd: crate::usbd::Usbd::new(),
             gpio_port: crate::gpio::nrf52840_gpio_create(),

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -126,22 +126,30 @@ use crate::utilities::single_thread_value::SingleThreadValue;
 // panic! support routines
 
 /// Resources needed by the main panic routines.
-pub struct PanicResources<C: Chip + 'static, PP: ProcessPrinter + 'static> {
+pub struct PanicResources<C: Chip + 'static, PP: ProcessPrinter + 'static, T = ()> {
     /// The array of process slots.
     pub processes: MapCell<&'static [ProcessSlot]>,
     /// The board-specific chip object.
     pub chip: MapCell<&'static C>,
     /// The tool for printing process details.
     pub printer: MapCell<&'static PP>,
+    /// Board-specific resource to use during panic.
+    ///
+    /// This type is configured entirely by the board and can be used to store
+    /// anything that the board needs in its panic handler. This simplifies
+    /// creating multiple `SingleThreadValue`s in the board main.rs and
+    /// logically groups resources which are all used by the panic handler.
+    pub custom: MapCell<T>,
 }
 
-impl<C: Chip, PP: ProcessPrinter> PanicResources<C, PP> {
+impl<T, C: Chip, PP: ProcessPrinter> PanicResources<C, PP, T> {
     /// Create a new [`PanicResources`] with nothing stored.
     pub const fn new() -> Self {
         Self {
             processes: MapCell::empty(),
             chip: MapCell::empty(),
             printer: MapCell::empty(),
+            custom: MapCell::empty(),
         }
     }
 }
@@ -157,11 +165,11 @@ impl<C: Chip, PP: ProcessPrinter> PanicResources<C, PP> {
 /// returns.
 ///
 /// **NOTE:** The supplied `writer` must be synchronous.
-pub unsafe fn panic_print<PW: PanicWriter, C: Chip, PP: ProcessPrinter>(
+pub unsafe fn panic_print<PW: PanicWriter, C: Chip, PP: ProcessPrinter, T>(
     writer_config: PW::Config,
     panic_info: &PanicInfo,
     nop: &dyn Fn(),
-    panic_resources: Option<&PanicResources<C, PP>>,
+    panic_resources: Option<&PanicResources<C, PP, T>>,
 ) {
     unsafe {
         // Create the synchronous writer we can use to output the panic message.
@@ -197,17 +205,17 @@ pub unsafe fn panic_print<PW: PanicWriter, C: Chip, PP: ProcessPrinter>(
 ///
 /// This will print a detailed debugging message and then loop forever while
 /// blinking an LED in a recognizable pattern.
-pub unsafe fn panic<L: hil::led::Led, PW: PanicWriter, C: Chip, PP: ProcessPrinter>(
+pub unsafe fn panic<L: hil::led::Led, PW: PanicWriter, C: Chip, PP: ProcessPrinter, T>(
     leds: &mut [&L],
     writer_config: PW::Config,
     panic_info: &PanicInfo,
     nop: &dyn Fn(),
-    panic_resources: Option<&PanicResources<C, PP>>,
+    panic_resources: Option<&PanicResources<C, PP, T>>,
 ) -> ! {
     unsafe {
         // Call `panic_print` first which will print out the panic information and
         // return
-        panic_print::<PW, C, PP>(writer_config, panic_info, nop, panic_resources);
+        panic_print::<PW, C, PP, T>(writer_config, panic_info, nop, panic_resources);
 
         // The system is no longer in a well-defined state, we cannot
         // allow this function to return
@@ -228,11 +236,11 @@ pub unsafe fn panic<L: hil::led::Led, PW: PanicWriter, C: Chip, PP: ProcessPrint
 /// returns.
 ///
 /// **NOTE:** The supplied `writer` must be synchronous.
-pub unsafe fn panic_print_old<W: Write + IoWrite, C: Chip, PP: ProcessPrinter>(
+pub unsafe fn panic_print_old<W: Write + IoWrite, C: Chip, PP: ProcessPrinter, T>(
     writer: &mut W,
     panic_info: &PanicInfo,
     nop: &dyn Fn(),
-    panic_resources: Option<&PanicResources<C, PP>>,
+    panic_resources: Option<&PanicResources<C, PP, T>>,
 ) {
     unsafe {
         panic_begin(nop);
@@ -265,12 +273,12 @@ pub unsafe fn panic_print_old<W: Write + IoWrite, C: Chip, PP: ProcessPrinter>(
 ///
 /// This will print a detailed debugging message and then loop forever while
 /// blinking an LED in a recognizable pattern.
-pub unsafe fn panic_old<L: hil::led::Led, W: Write + IoWrite, C: Chip, PP: ProcessPrinter>(
+pub unsafe fn panic_old<L: hil::led::Led, W: Write + IoWrite, C: Chip, PP: ProcessPrinter, T>(
     leds: &mut [&L],
     writer: &mut W,
     panic_info: &PanicInfo,
     nop: &dyn Fn(),
-    panic_resources: Option<&PanicResources<C, PP>>,
+    panic_resources: Option<&PanicResources<C, PP, T>>,
 ) -> ! {
     unsafe {
         // Call `panic_print` first which will print out the panic information and

--- a/kernel/src/utilities/mod.rs
+++ b/kernel/src/utilities/mod.rs
@@ -18,6 +18,7 @@ pub mod math;
 pub mod mut_imut_buffer;
 pub mod peripheral_management;
 pub mod single_thread_value;
+pub mod singleton;
 pub mod slice_uninit;
 pub mod static_init;
 pub mod storage_volume;

--- a/kernel/src/utilities/singleton.rs
+++ b/kernel/src/utilities/singleton.rs
@@ -1,0 +1,55 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+/// Internal helper function for [`only_once!()`](crate::only_once).
+///
+/// This must be public to work within the macro but should never be used
+/// directly.
+///
+/// This is a `#[inline(never)]` function that panics if the atomic flag has
+/// already been set. This function is intended for use within the
+/// [`only_once!()`](crate::only_once) macro to detect multiple uses of the
+/// macro on the same name.
+///
+/// This function is implemented separately without inlining to remove the size
+/// bloat of track_caller saving the location of every single call to
+/// [`only_once!()`](crate::only_once).
+#[cfg(target_has_atomic = "ptr")]
+#[inline(never)]
+pub fn only_once_check_used(used: &core::sync::atomic::AtomicUsize) {
+    // swap(1) returns the old value; if it was already 1, this is a second call.
+    if used.swap(1, core::sync::atomic::Ordering::Relaxed) != 0 {
+        panic!("Error! only_once!() called twice.");
+    }
+}
+
+/// Helper macro to ensure an object is only created once.
+///
+/// Panics if the same object is created twice.
+///
+/// This only exists for targets with atomic pointer-sized operations.
+/// Therefore, it can only be used in chip and board crates that can guarantee
+/// the atomic support exists.
+///
+/// ```ignore
+///
+/// /// This DMA-enabled peripheral manager MUST only be created once.
+/// struct PeripheralManagerWithDma;
+///
+/// impl PeripheralManagerWithDma {
+///     fn new() -> Self {
+///         // Ensure this will panic if constructed twice.
+///         kernel::only_once!();
+///         Self {}
+///     }
+/// }
+/// ```
+#[cfg(target_has_atomic = "ptr")]
+#[macro_export]
+macro_rules! only_once {
+    () => {{
+        static USED: core::sync::atomic::AtomicUsize = core::sync::atomic::AtomicUsize::new(0);
+        $crate::utilities::singleton::only_once_check_used(&USED);
+    }};
+}


### PR DESCRIPTION
### Pull Request Overview

The goal of this PR is to follow through on the safety requirement that the `UarteRegistersManager` struct for the nRF52 uart driver is only created once. This safety invariant is because the register manager controls DMA registers, and those need to be only managed by one thing. That is, `UarteRegistersManager::new()` must only be called once.

This is problematic because we call `UarteRegistersManager::new()` in two places: when the board boots, and when it panics.

To remedy this, this PR does the following:

1. It makes the register manager passed in to the UARTE driver. This allows the same register manager to be used for normal operation and for panic.
2. It adds a `custom` field to the `kernel::debug::PanicResources` struct to make it easier to save the register manager for use in the panic handler (it is a panic resource).
3. It adds a `only_once!()` macro to enforce that the `UarteRegistersManager` constructor tied to UARTE0 is only every constructed once.


### Testing Strategy

I used the crash_dummy app on the nRF52840dk. Whereas without this change but with `only_once!()` nothing prints (the board panics while handling the panic), with this refactor it does print the panic dump.


### TODO or Help Wanted

This is not the only way to address this problem. I started with just adding a new `SingleThreadValue` in the board's main.rs. However, we probably want to encourage more state to be shared with the panic handler for other platforms to address the same problem, and this makes it a bit easier.

We could just share the entire UART driver with the panic handler. Maybe the `PanicWriter` interface actually isn't that useful. Haven't thought a lot about this.


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [ ] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

Claude did the copy and paste work to apply the io.rs changes to all of the nrf boards. This is based on #4989.
