### PR TITLE
Make `with_interrupts_disabled()` safe

### DIFF
--- a/arch/cortex-m/src/support.rs
+++ b/arch/cortex-m/src/support.rs
@@ -58,7 +58,7 @@ pub unsafe fn wfi() {
 
 /// Single-core critical section operation
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
-pub unsafe fn with_interrupts_disabled<F, R>(f: F) -> R
+pub fn with_interrupts_disabled<F, R>(f: F) -> R
 where
     F: FnOnce() -> R,
 {
@@ -122,7 +122,7 @@ pub unsafe fn wfi() {
 
 /// Single-core critical section operation (mock)
 #[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
-pub unsafe fn with_interrupts_disabled<F, R>(_f: F) -> R
+pub fn with_interrupts_disabled<F, R>(_f: F) -> R
 where
     F: FnOnce() -> R,
 {

--- a/arch/riscv/src/support.rs
+++ b/arch/riscv/src/support.rs
@@ -25,7 +25,7 @@ pub unsafe fn wfi() {
 }
 
 /// Single-core critical section operation
-pub unsafe fn with_interrupts_disabled<F, R>(f: F) -> R
+pub fn with_interrupts_disabled<F, R>(f: F) -> R
 where
     F: FnOnce() -> R,
 {

--- a/chips/apollo3/src/chip.rs
+++ b/chips/apollo3/src/chip.rs
@@ -159,7 +159,7 @@ impl<I: InterruptService + 'static> Chip for Apollo3<I> {
         }
     }
 
-    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
+    fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {

--- a/chips/arty_e21_chip/src/chip.rs
+++ b/chips/arty_e21_chip/src/chip.rs
@@ -141,7 +141,7 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for ArtyExx<'a, 
         }
     }
 
-    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
+    fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {

--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -170,7 +170,7 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for E310x<'a, I>
         }
     }
 
-    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
+    fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -307,7 +307,7 @@ impl<
         }
     }
 
-    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
+    fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {

--- a/chips/esp32-c3/src/chip.rs
+++ b/chips/esp32-c3/src/chip.rs
@@ -149,7 +149,7 @@ impl<'a, I: InterruptService + 'a> Chip for Esp32C3<'a, I> {
         }
     }
 
-    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
+    fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {

--- a/chips/imxrt10xx/src/chip.rs
+++ b/chips/imxrt10xx/src/chip.rs
@@ -148,7 +148,7 @@ impl<I: InterruptService + 'static> Chip for Imxrt10xx<I> {
         }
     }
 
-    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
+    fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {

--- a/chips/imxrt10xx/src/gpio.rs
+++ b/chips/imxrt10xx/src/gpio.rs
@@ -332,13 +332,11 @@ impl<'a, const N: usize> Port<'a, N> {
         // changed due to an external interrupt. `ISR` is a read/clear write
         // 1 register (`rc_w1`). So, we only clear bits whose value has been
         // transferred to `isr`.
-        let isr_val = unsafe {
-            with_interrupts_disabled(|| {
-                let isr_val = self.registers.isr.get();
-                self.registers.isr.set(isr_val);
-                isr_val
-            })
-        };
+        let isr_val = with_interrupts_disabled(|| {
+            let isr_val = self.registers.isr.get();
+            self.registers.isr.set(isr_val);
+            isr_val
+        });
 
         BitOffsets(isr_val)
             // Did we enable this interrupt?
@@ -746,25 +744,21 @@ impl hil::gpio::Input for Pin<'_> {
 
 impl<'a> hil::gpio::Interrupt<'a> for Pin<'a> {
     fn enable_interrupts(&self, mode: hil::gpio::InterruptEdge) {
-        unsafe {
-            with_interrupts_disabled(|| {
-                // disable the interrupt
-                self.mask_interrupt();
-                self.clear_pending();
-                self.set_edge_sensitive(mode);
+        with_interrupts_disabled(|| {
+            // disable the interrupt
+            self.mask_interrupt();
+            self.clear_pending();
+            self.set_edge_sensitive(mode);
 
-                self.unmask_interrupt();
-            });
-        }
+            self.unmask_interrupt();
+        });
     }
 
     fn disable_interrupts(&self) {
-        unsafe {
-            with_interrupts_disabled(|| {
-                self.mask_interrupt();
-                self.clear_pending();
-            });
-        }
+        with_interrupts_disabled(|| {
+            self.mask_interrupt();
+            self.clear_pending();
+        });
     }
 
     fn set_client(&self, client: &'a dyn hil::gpio::Client) {

--- a/chips/imxrt10xx/src/gpt.rs
+++ b/chips/imxrt10xx/src/gpt.rs
@@ -392,13 +392,11 @@ impl<'a, F: hil::time::Frequency> hil::time::Alarm<'a> for Gpt<'a, F> {
     }
 
     fn disarm(&self) -> Result<(), ErrorCode> {
-        unsafe {
-            with_interrupts_disabled(|| {
-                // Disable counter
-                self.registers.ir.modify(IR::OF1IE::CLEAR);
-                cortexm7::nvic::Nvic::new(self.irqn).clear_pending();
-            });
-        }
+        with_interrupts_disabled(|| {
+            // Disable counter
+            self.registers.ir.modify(IR::OF1IE::CLEAR);
+            cortexm7::nvic::Nvic::new(self.irqn).clear_pending();
+        });
         Ok(())
     }
 

--- a/chips/litex_vexriscv/src/chip.rs
+++ b/chips/litex_vexriscv/src/chip.rs
@@ -97,7 +97,7 @@ impl<I: 'static + InterruptService> kernel::platform::chip::Chip for LiteXVexRis
         }
     }
 
-    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
+    fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {

--- a/chips/lpc55s6x/src/chip.rs
+++ b/chips/lpc55s6x/src/chip.rs
@@ -92,7 +92,7 @@ impl<I: InterruptService> Chip for Lpc55s69<'_, I> {
         }
     }
 
-    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
+    fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {

--- a/chips/lpc55s6x/src/ctimer0.rs
+++ b/chips/lpc55s6x/src/ctimer0.rs
@@ -386,12 +386,10 @@ impl<'a> LPCTimer<'a> {
     }
 
     fn enable_timer_interrupt(&self) {
-        unsafe {
-            with_interrupts_disabled(|| {
-                let n = cortexm33::nvic::Nvic::new(CTIMER0);
-                n.enable();
-            })
-        }
+        with_interrupts_disabled(|| {
+            let n = cortexm33::nvic::Nvic::new(CTIMER0);
+            n.enable();
+        })
     }
 
     #[allow(dead_code)]
@@ -459,11 +457,9 @@ impl<'a> Alarm<'a> for LPCTimer<'a> {
         self.disable_interrupt();
         self.armed.set(false);
 
-        unsafe {
-            with_interrupts_disabled(|| {
-                cortexm33::nvic::Nvic::new(CTIMER0).clear_pending();
-            });
-        }
+        with_interrupts_disabled(|| {
+            cortexm33::nvic::Nvic::new(CTIMER0).clear_pending();
+        });
 
         Ok(())
     }

--- a/chips/msp432/src/chip.rs
+++ b/chips/msp432/src/chip.rs
@@ -147,7 +147,7 @@ impl<'a, I: InterruptService + 'a> Chip for Msp432<'a, I> {
         }
     }
 
-    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
+    fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -195,7 +195,7 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for NRF52<'a, I>
         }
     }
 
-    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
+    fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {

--- a/chips/nrf52/src/usbd.rs
+++ b/chips/nrf52/src/usbd.rs
@@ -791,34 +791,30 @@ impl<'a> Usbd<'a> {
     /// USBD might not reach its active state.
     fn apply_errata_171(&self, val: u32) {
         if self.has_errata_171() {
-            unsafe {
-                with_interrupts_disabled(|| {
-                    if USBERRATA_BASE.reg_c00.get() == 0 {
-                        USBERRATA_BASE.reg_c00.set(0x9375);
-                        USBERRATA_BASE.reg_c14.set(val);
-                        USBERRATA_BASE.reg_c00.set(0x9375);
-                    } else {
-                        USBERRATA_BASE.reg_c14.set(val);
-                    }
-                });
-            }
+            with_interrupts_disabled(|| {
+                if USBERRATA_BASE.reg_c00.get() == 0 {
+                    USBERRATA_BASE.reg_c00.set(0x9375);
+                    USBERRATA_BASE.reg_c14.set(val);
+                    USBERRATA_BASE.reg_c00.set(0x9375);
+                } else {
+                    USBERRATA_BASE.reg_c14.set(val);
+                }
+            });
         }
     }
 
     /// USB cannot be enabled
     fn apply_errata_187(&self, val: u32) {
         if self.has_errata_187() {
-            unsafe {
-                with_interrupts_disabled(|| {
-                    if USBERRATA_BASE.reg_c00.get() == 0 {
-                        USBERRATA_BASE.reg_c00.set(0x9375);
-                        USBERRATA_BASE.reg_d14.set(val);
-                        USBERRATA_BASE.reg_c00.set(0x9375);
-                    } else {
-                        USBERRATA_BASE.reg_d14.set(val);
-                    }
-                });
-            }
+            with_interrupts_disabled(|| {
+                if USBERRATA_BASE.reg_c00.get() == 0 {
+                    USBERRATA_BASE.reg_c00.set(0x9375);
+                    USBERRATA_BASE.reg_d14.set(val);
+                    USBERRATA_BASE.reg_c00.set(0x9375);
+                } else {
+                    USBERRATA_BASE.reg_d14.set(val);
+                }
+            });
         }
     }
 

--- a/chips/psc3/src/chip.rs
+++ b/chips/psc3/src/chip.rs
@@ -149,7 +149,7 @@ impl<I: InterruptService> Chip for Psc3<'_, I> {
         }
     }
 
-    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
+    fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {

--- a/chips/psoc62xa/src/chip.rs
+++ b/chips/psoc62xa/src/chip.rs
@@ -44,7 +44,7 @@ impl<I: InterruptService> Chip for Psoc62xa<'_, I> {
         }
     }
 
-    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
+    fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {

--- a/chips/qemu_rv32_virt_chip/src/chip.rs
+++ b/chips/qemu_rv32_virt_chip/src/chip.rs
@@ -169,7 +169,7 @@ impl<'a, I: InterruptService + 'a> Chip for QemuRv32VirtChip<'a, I> {
         }
     }
 
-    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
+    fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {

--- a/chips/qemu_rv64_virt_chip/src/chip.rs
+++ b/chips/qemu_rv64_virt_chip/src/chip.rs
@@ -166,7 +166,7 @@ impl<'a, I: InterruptService + 'a> Chip for QemuRv64VirtChip<'a, I> {
         }
     }
 
-    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
+    fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {

--- a/chips/rp2040/src/chip.rs
+++ b/chips/rp2040/src/chip.rs
@@ -120,7 +120,7 @@ impl<I: InterruptService> Chip for Rp2040<'_, I> {
         }
     }
 
-    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
+    fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {

--- a/chips/rp2040/src/timer.rs
+++ b/chips/rp2040/src/timer.rs
@@ -199,12 +199,10 @@ impl<'a> RPTimer<'a> {
         // Failing to do so results in the interrupt being set as pending but
         // not fired. This means that the interrupt will be handled whenever the
         // next kernel tasks are processed.
-        unsafe {
-            with_interrupts_disabled(|| {
-                let n = cortexm0p::nvic::Nvic::new(TIMER_IRQ_0);
-                n.enable();
-            })
-        }
+        with_interrupts_disabled(|| {
+            let n = cortexm0p::nvic::Nvic::new(TIMER_IRQ_0);
+            n.enable();
+        })
     }
 
     fn disable_timer_interrupt(&self) {
@@ -256,12 +254,10 @@ impl<'a> Alarm<'a> for RPTimer<'a> {
 
     fn disarm(&self) -> Result<(), ErrorCode> {
         self.registers.armed.set(1);
-        unsafe {
-            with_interrupts_disabled(|| {
-                // Clear pending interrupts
-                cortexm0p::nvic::Nvic::new(TIMER_IRQ_0).clear_pending();
-            });
-        }
+        with_interrupts_disabled(|| {
+            // Clear pending interrupts
+            cortexm0p::nvic::Nvic::new(TIMER_IRQ_0).clear_pending();
+        });
         self.disable_interrupt();
         self.disable_timer_interrupt();
         Ok(())

--- a/chips/rp2350/src/chip.rs
+++ b/chips/rp2350/src/chip.rs
@@ -106,7 +106,7 @@ impl<I: InterruptService> Chip for Rp2350<'_, I> {
         }
     }
 
-    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
+    fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {

--- a/chips/rp2350/src/timer.rs
+++ b/chips/rp2350/src/timer.rs
@@ -197,11 +197,9 @@ impl<'a> RPTimer<'a> {
         // Failing to do so results in the interrupt being set as pending but
         // not fired. This means that the interrupt will be handled whenever the
         // next kernel tasks are processed.
-        unsafe {
-            with_interrupts_disabled(|| {
-                cortexm33::nvic::Nvic::new(TIMER0_IRQ_0).enable();
-            })
-        }
+        with_interrupts_disabled(|| {
+            cortexm33::nvic::Nvic::new(TIMER0_IRQ_0).enable();
+        })
     }
 
     fn disable_timer_interrupt0(&self) {
@@ -253,12 +251,10 @@ impl<'a> Alarm<'a> for RPTimer<'a> {
 
     fn disarm(&self) -> Result<(), ErrorCode> {
         self.registers.armed.set(1);
-        unsafe {
-            with_interrupts_disabled(|| {
-                // Clear pending interrupts
-                cortexm33::nvic::Nvic::new(TIMER0_IRQ_0).clear_pending();
-            });
-        }
+        with_interrupts_disabled(|| {
+            // Clear pending interrupts
+            cortexm33::nvic::Nvic::new(TIMER0_IRQ_0).clear_pending();
+        });
         self.disable_interrupt0();
         self.disable_timer_interrupt0();
         Ok(())

--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -288,7 +288,7 @@ impl<I: InterruptService + 'static> Chip for Sam4l<I> {
         }
     }
 
-    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
+    fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {

--- a/chips/stm32f303xc/src/chip.rs
+++ b/chips/stm32f303xc/src/chip.rs
@@ -144,7 +144,7 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32f3xx<'a, I> {
         }
     }
 
-    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
+    fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {

--- a/chips/stm32f303xc/src/exti.rs
+++ b/chips/stm32f303xc/src/exti.rs
@@ -701,12 +701,10 @@ impl<'a> Exti<'a> {
         // changed due to an external interrupt. `EXTI_PR` is a read/clear write
         // 1 register (`rc_w1`). So, we only clear bits whose value has been
         // transferred to `exti_pr`.
-        unsafe {
-            with_interrupts_disabled(|| {
-                exti_pr = self.registers.pr1.get();
-                self.registers.pr1.set(exti_pr);
-            });
-        }
+        with_interrupts_disabled(|| {
+            exti_pr = self.registers.pr1.get();
+            self.registers.pr1.set(exti_pr);
+        });
 
         // ignore the "reserved" EXTI bits. Use bits [22:0]. See `EXTI_PR` for
         // details.

--- a/chips/stm32f303xc/src/gpio.rs
+++ b/chips/stm32f303xc/src/gpio.rs
@@ -1114,46 +1114,42 @@ impl hil::gpio::Input for Pin<'_> {
 
 impl<'a> hil::gpio::Interrupt<'a> for Pin<'a> {
     fn enable_interrupts(&self, mode: hil::gpio::InterruptEdge) {
-        unsafe {
-            with_interrupts_disabled(|| {
-                self.exti_lineid.map(|lineid| {
-                    let l = lineid;
+        with_interrupts_disabled(|| {
+            self.exti_lineid.map(|lineid| {
+                let l = lineid;
 
-                    // disable the interrupt
-                    self.exti.mask_interrupt(l);
-                    self.exti.clear_pending(l);
+                // disable the interrupt
+                self.exti.mask_interrupt(l);
+                self.exti.clear_pending(l);
 
-                    match mode {
-                        hil::gpio::InterruptEdge::EitherEdge => {
-                            self.exti.select_rising_trigger(l);
-                            self.exti.select_falling_trigger(l);
-                        }
-                        hil::gpio::InterruptEdge::RisingEdge => {
-                            self.exti.select_rising_trigger(l);
-                            self.exti.deselect_falling_trigger(l);
-                        }
-                        hil::gpio::InterruptEdge::FallingEdge => {
-                            self.exti.deselect_rising_trigger(l);
-                            self.exti.select_falling_trigger(l);
-                        }
+                match mode {
+                    hil::gpio::InterruptEdge::EitherEdge => {
+                        self.exti.select_rising_trigger(l);
+                        self.exti.select_falling_trigger(l);
                     }
+                    hil::gpio::InterruptEdge::RisingEdge => {
+                        self.exti.select_rising_trigger(l);
+                        self.exti.deselect_falling_trigger(l);
+                    }
+                    hil::gpio::InterruptEdge::FallingEdge => {
+                        self.exti.deselect_rising_trigger(l);
+                        self.exti.select_falling_trigger(l);
+                    }
+                }
 
-                    self.exti.unmask_interrupt(l);
-                });
+                self.exti.unmask_interrupt(l);
             });
-        }
+        });
     }
 
     fn disable_interrupts(&self) {
-        unsafe {
-            with_interrupts_disabled(|| {
-                self.exti_lineid.map(|lineid| {
-                    let l = lineid;
-                    self.exti.mask_interrupt(l);
-                    self.exti.clear_pending(l);
-                });
+        with_interrupts_disabled(|| {
+            self.exti_lineid.map(|lineid| {
+                let l = lineid;
+                self.exti.mask_interrupt(l);
+                self.exti.clear_pending(l);
             });
-        }
+        });
     }
 
     fn set_client(&self, client: &'a dyn hil::gpio::Client) {

--- a/chips/stm32f303xc/src/tim2.rs
+++ b/chips/stm32f303xc/src/tim2.rs
@@ -423,13 +423,11 @@ impl<'a> Alarm<'a> for Tim2<'a> {
     }
 
     fn disarm(&self) -> Result<(), ErrorCode> {
-        unsafe {
-            with_interrupts_disabled(|| {
-                // Disable counter
-                self.registers.dier.modify(DIER::CC1IE::CLEAR);
-                cortexm4f::nvic::Nvic::new(self.irqn).clear_pending();
-            });
-        }
+        with_interrupts_disabled(|| {
+            // Disable counter
+            self.registers.dier.modify(DIER::CC1IE::CLEAR);
+            cortexm4f::nvic::Nvic::new(self.irqn).clear_pending();
+        });
         Ok(())
     }
 

--- a/chips/stm32f4xx/src/chip.rs
+++ b/chips/stm32f4xx/src/chip.rs
@@ -206,7 +206,7 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32f4xx<'a, I> {
         }
     }
 
-    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
+    fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {

--- a/chips/stm32f4xx/src/exti.rs
+++ b/chips/stm32f4xx/src/exti.rs
@@ -584,12 +584,10 @@ impl<'a> Exti<'a> {
         // changed due to an external interrupt. `EXTI_PR` is a read/clear write
         // 1 register (`rc_w1`). So, we only clear bits whose value has been
         // transferred to `exti_pr`.
-        unsafe {
-            with_interrupts_disabled(|| {
-                exti_pr = self.registers.pr.get();
-                self.registers.pr.set(exti_pr);
-            });
-        }
+        with_interrupts_disabled(|| {
+            exti_pr = self.registers.pr.get();
+            self.registers.pr.set(exti_pr);
+        });
 
         // ignore the "reserved" EXTI bits. Use bits [22:0]. See `EXTI_PR` for
         // details.

--- a/chips/stm32f4xx/src/gpio.rs
+++ b/chips/stm32f4xx/src/gpio.rs
@@ -1201,46 +1201,42 @@ impl hil::gpio::Input for Pin<'_> {
 
 impl<'a> hil::gpio::Interrupt<'a> for Pin<'a> {
     fn enable_interrupts(&self, mode: hil::gpio::InterruptEdge) {
-        unsafe {
-            with_interrupts_disabled(|| {
-                self.exti_lineid.map(|lineid| {
-                    let l = lineid;
+        with_interrupts_disabled(|| {
+            self.exti_lineid.map(|lineid| {
+                let l = lineid;
 
-                    // disable the interrupt
-                    self.exti.mask_interrupt(l);
-                    self.exti.clear_pending(l);
+                // disable the interrupt
+                self.exti.mask_interrupt(l);
+                self.exti.clear_pending(l);
 
-                    match mode {
-                        hil::gpio::InterruptEdge::EitherEdge => {
-                            self.exti.select_rising_trigger(l);
-                            self.exti.select_falling_trigger(l);
-                        }
-                        hil::gpio::InterruptEdge::RisingEdge => {
-                            self.exti.select_rising_trigger(l);
-                            self.exti.deselect_falling_trigger(l);
-                        }
-                        hil::gpio::InterruptEdge::FallingEdge => {
-                            self.exti.deselect_rising_trigger(l);
-                            self.exti.select_falling_trigger(l);
-                        }
+                match mode {
+                    hil::gpio::InterruptEdge::EitherEdge => {
+                        self.exti.select_rising_trigger(l);
+                        self.exti.select_falling_trigger(l);
                     }
+                    hil::gpio::InterruptEdge::RisingEdge => {
+                        self.exti.select_rising_trigger(l);
+                        self.exti.deselect_falling_trigger(l);
+                    }
+                    hil::gpio::InterruptEdge::FallingEdge => {
+                        self.exti.deselect_rising_trigger(l);
+                        self.exti.select_falling_trigger(l);
+                    }
+                }
 
-                    self.exti.unmask_interrupt(l);
-                });
+                self.exti.unmask_interrupt(l);
             });
-        }
+        });
     }
 
     fn disable_interrupts(&self) {
-        unsafe {
-            with_interrupts_disabled(|| {
-                self.exti_lineid.map(|lineid| {
-                    let l = lineid;
-                    self.exti.mask_interrupt(l);
-                    self.exti.clear_pending(l);
-                });
+        with_interrupts_disabled(|| {
+            self.exti_lineid.map(|lineid| {
+                let l = lineid;
+                self.exti.mask_interrupt(l);
+                self.exti.clear_pending(l);
             });
-        }
+        });
     }
 
     fn set_client(&self, client: &'a dyn hil::gpio::Client) {

--- a/chips/stm32f4xx/src/tim2.rs
+++ b/chips/stm32f4xx/src/tim2.rs
@@ -443,13 +443,11 @@ impl<'a> Alarm<'a> for Tim2<'a> {
     }
 
     fn disarm(&self) -> Result<(), ErrorCode> {
-        unsafe {
-            with_interrupts_disabled(|| {
-                // Disable counter
-                self.registers.dier.modify(DIER::CC1IE::CLEAR);
-                cortexm4f::nvic::Nvic::new(self.irqn).clear_pending();
-            });
-        }
+        with_interrupts_disabled(|| {
+            // Disable counter
+            self.registers.dier.modify(DIER::CC1IE::CLEAR);
+            cortexm4f::nvic::Nvic::new(self.irqn).clear_pending();
+        });
         Ok(())
     }
 

--- a/chips/stm32u5xx/src/chip.rs
+++ b/chips/stm32u5xx/src/chip.rs
@@ -341,7 +341,7 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32u5xx<'a, I> {
         }
     }
 
-    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
+    fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {

--- a/chips/stm32wle5xx/src/chip.rs
+++ b/chips/stm32wle5xx/src/chip.rs
@@ -172,7 +172,7 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32wle5xx<'a, I> {
         &self.userspace_kernel_boundary
     }
 
-    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
+    fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {

--- a/chips/stm32wle5xx/src/exti.rs
+++ b/chips/stm32wle5xx/src/exti.rs
@@ -620,12 +620,10 @@ impl<'a> Exti<'a> {
         // changed due to an external interrupt. `EXTI_PR` is a read/clear write
         // 1 register (`rc_w1`). So, we only clear bits whose value has been
         // transferred to `exti_pr`.
-        unsafe {
-            with_interrupts_disabled(|| {
-                exti_pr = self.registers.pr1.get();
-                self.registers.pr1.set(exti_pr);
-            });
-        }
+        with_interrupts_disabled(|| {
+            exti_pr = self.registers.pr1.get();
+            self.registers.pr1.set(exti_pr);
+        });
 
         // ignore the "reserved" EXTI bits. Use bits [22:0]. See `EXTI_PR` for
         // details.

--- a/chips/stm32wle5xx/src/gpio.rs
+++ b/chips/stm32wle5xx/src/gpio.rs
@@ -1105,46 +1105,42 @@ impl hil::gpio::Input for Pin<'_> {
 
 impl<'a> hil::gpio::Interrupt<'a> for Pin<'a> {
     fn enable_interrupts(&self, mode: hil::gpio::InterruptEdge) {
-        unsafe {
-            with_interrupts_disabled(|| {
-                self.exti_lineid.map(|lineid| {
-                    let l = lineid;
+        with_interrupts_disabled(|| {
+            self.exti_lineid.map(|lineid| {
+                let l = lineid;
 
-                    // disable the interrupt
-                    self.exti.mask_interrupt(l);
-                    self.exti.clear_pending(l);
+                // disable the interrupt
+                self.exti.mask_interrupt(l);
+                self.exti.clear_pending(l);
 
-                    match mode {
-                        hil::gpio::InterruptEdge::EitherEdge => {
-                            self.exti.select_rising_trigger(l);
-                            self.exti.select_falling_trigger(l);
-                        }
-                        hil::gpio::InterruptEdge::RisingEdge => {
-                            self.exti.select_rising_trigger(l);
-                            self.exti.deselect_falling_trigger(l);
-                        }
-                        hil::gpio::InterruptEdge::FallingEdge => {
-                            self.exti.deselect_rising_trigger(l);
-                            self.exti.select_falling_trigger(l);
-                        }
+                match mode {
+                    hil::gpio::InterruptEdge::EitherEdge => {
+                        self.exti.select_rising_trigger(l);
+                        self.exti.select_falling_trigger(l);
                     }
+                    hil::gpio::InterruptEdge::RisingEdge => {
+                        self.exti.select_rising_trigger(l);
+                        self.exti.deselect_falling_trigger(l);
+                    }
+                    hil::gpio::InterruptEdge::FallingEdge => {
+                        self.exti.deselect_rising_trigger(l);
+                        self.exti.select_falling_trigger(l);
+                    }
+                }
 
-                    self.exti.unmask_interrupt(l);
-                });
+                self.exti.unmask_interrupt(l);
             });
-        }
+        });
     }
 
     fn disable_interrupts(&self) {
-        unsafe {
-            with_interrupts_disabled(|| {
-                self.exti_lineid.map(|lineid| {
-                    let l = lineid;
-                    self.exti.mask_interrupt(l);
-                    self.exti.clear_pending(l);
-                });
+        with_interrupts_disabled(|| {
+            self.exti_lineid.map(|lineid| {
+                let l = lineid;
+                self.exti.mask_interrupt(l);
+                self.exti.clear_pending(l);
             });
-        }
+        });
     }
 
     fn set_client(&self, client: &'a dyn hil::gpio::Client) {

--- a/chips/stm32wle5xx/src/tim2.rs
+++ b/chips/stm32wle5xx/src/tim2.rs
@@ -425,13 +425,11 @@ impl<'a> Alarm<'a> for Tim2<'a> {
     }
 
     fn disarm(&self) -> Result<(), ErrorCode> {
-        unsafe {
-            with_interrupts_disabled(|| {
-                // Disable counter
-                self.registers.dier.modify(DIER::CC1IE::CLEAR);
-                cortexm4::nvic::Nvic::new(self.irqn).clear_pending();
-            });
-        }
+        with_interrupts_disabled(|| {
+            // Disable counter
+            self.registers.dier.modify(DIER::CC1IE::CLEAR);
+            cortexm4::nvic::Nvic::new(self.irqn).clear_pending();
+        });
         Ok(())
     }
 

--- a/chips/veer_el2/src/chip.rs
+++ b/chips/veer_el2/src/chip.rs
@@ -141,7 +141,7 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for VeeR<'a, I> 
         }
     }
 
-    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
+    fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {

--- a/chips/x86_q35/src/chip.rs
+++ b/chips/x86_q35/src/chip.rs
@@ -220,7 +220,7 @@ impl<'a, I1: InterruptService, I2: InterruptService, const PR: u16> Chip for Pc<
         unimplemented!()
     }
 
-    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
+    fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,
     {

--- a/kernel/src/platform/chip.rs
+++ b/kernel/src/platform/chip.rs
@@ -79,7 +79,7 @@ pub trait Chip {
     /// means that interrupts are disabled so that an interrupt will not fire
     /// during the passed in function's execution, but *does not* make any
     /// guarantees about memory consistency on a multi-core system.
-    unsafe fn with_interrupts_disabled<F, R>(&self, f: F) -> R
+    fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R;
 


### PR DESCRIPTION


### Pull Request Overview

This starts with changing `Chip::with_interrupts_disabled()` to be safe. From there, this changes all arch with_interrupts_disabled() functions to be safe (arm and riscv, x86 is already safe). 

I can't think of why running code without interrupts enabled would violate any Rust memory safety requirements. Notably, no one has, as far as I can tell, tried to document any safety issues with `with_interrupts_disabled()` in code that uses the function.

For what it is worth, this code also has the function as safe: https://docs.rs/interrupts/latest/interrupts/fn.without.html. It is also safe here: https://docs.rs/x86_64/0.15.5/x86_64/instructions/interrupts/fn.without_interrupts.html

I'm guessing ours is marked unsafe because the first implementation (ie, arm) used assembly.

### Testing Strategy

travis


### TODO or Help Wanted

If anyone believes this _should_ be unsafe, it would be helpful to have at least a draft on what the safety comment should say.


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

Claude did all of the mechanical work here. I did look at all the changes to see if there were any old safety docs that would no longer be needed, but I couldn't find any.
