### PR TITLE
Make `service_interrupt()` safe

### DIFF
--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -66,7 +66,7 @@ impl LiteXArtyInterruptablePeripherals {
 }
 
 impl InterruptService for LiteXArtyInterruptablePeripherals {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt as usize {
             socc::UART_INTERRUPT => {
                 self.uart0.service_interrupt();

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -62,7 +62,7 @@ impl LiteXSimInterruptablePeripherals {
 }
 
 impl InterruptService for LiteXSimInterruptablePeripherals {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt as usize {
             socc::UART_INTERRUPT => {
                 self.uart0.service_interrupt();

--- a/boards/qemu_i486_q35/src/main.rs
+++ b/boards/qemu_i486_q35/src/main.rs
@@ -130,7 +130,7 @@ struct VirtioDevices {
 }
 
 impl InterruptService for VirtioDevices {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         let mut handled = false;
 
         self.rng.map(|(int_line, dev)| {

--- a/chips/apollo3/src/chip.rs
+++ b/chips/apollo3/src/chip.rs
@@ -71,7 +71,7 @@ impl Apollo3DefaultPeripherals {
 }
 
 impl kernel::platform::chip::InterruptService for Apollo3DefaultPeripherals {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         use crate::nvic;
         match interrupt {
             nvic::STIMER..=nvic::STIMER_CMPR7 => self.stimer.handle_interrupt(),
@@ -127,16 +127,14 @@ impl<I: InterruptService + 'static> Chip for Apollo3<I> {
     }
 
     fn service_pending_interrupts(&self) {
-        unsafe {
-            while let Some(interrupt) = cortexm4f::nvic::next_pending() {
-                if !self.interrupt_service.service_interrupt(interrupt) {
-                    panic!("unhandled interrupt, {}", interrupt);
-                }
-
-                let n = cortexm4f::nvic::Nvic::new(interrupt);
-                n.clear_pending();
-                n.enable();
+        while let Some(interrupt) = cortexm4f::nvic::next_pending() {
+            if !self.interrupt_service.service_interrupt(interrupt) {
+                panic!("unhandled interrupt, {}", interrupt);
             }
+
+            let n = cortexm4f::nvic::Nvic::new(interrupt);
+            n.clear_pending();
+            n.enable();
         }
     }
 

--- a/chips/arty_e21_chip/src/chip.rs
+++ b/chips/arty_e21_chip/src/chip.rs
@@ -49,7 +49,7 @@ impl ArtyExxDefaultPeripherals<'_> {
 }
 
 impl InterruptService for ArtyExxDefaultPeripherals<'_> {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
             interrupts::MTIP => self.machinetimer.handle_interrupt(),
 
@@ -118,16 +118,14 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for ArtyExx<'a, 
     }
 
     fn service_pending_interrupts(&self) {
-        unsafe {
-            while let Some(interrupt) = self.clic.next_pending() {
-                if !self.interrupt_service.service_interrupt(interrupt) {
-                    debug!("unhandled interrupt: {:?}", interrupt);
-                }
-
-                // Mark that we are done with this interrupt and the hardware
-                // can clear it.
-                self.clic.complete(interrupt);
+        while let Some(interrupt) = self.clic.next_pending() {
+            if !self.interrupt_service.service_interrupt(interrupt) {
+                debug!("unhandled interrupt: {:?}", interrupt);
             }
+
+            // Mark that we are done with this interrupt and the hardware
+            // can clear it.
+            self.clic.complete(interrupt);
         }
     }
 

--- a/chips/e310_g002/src/interrupt_service.rs
+++ b/chips/e310_g002/src/interrupt_service.rs
@@ -22,7 +22,7 @@ impl E310G002DefaultPeripherals<'_> {
     }
 }
 impl kernel::platform::chip::InterruptService for E310G002DefaultPeripherals<'_> {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
             interrupts::UART0 => self.e310x.uart0.handle_interrupt(),
             interrupts::UART1 => self.e310x.uart1.handle_interrupt(),

--- a/chips/e310_g003/src/interrupt_service.rs
+++ b/chips/e310_g003/src/interrupt_service.rs
@@ -22,7 +22,7 @@ impl E310G003DefaultPeripherals<'_> {
     }
 }
 impl kernel::platform::chip::InterruptService for E310G003DefaultPeripherals<'_> {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
             interrupts::UART0 => self.e310x.uart0.handle_interrupt(),
             interrupts::UART1 => self.e310x.uart1.handle_interrupt(),

--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -63,7 +63,7 @@ impl E310xDefaultPeripherals<'_> {
 }
 
 impl InterruptService for E310xDefaultPeripherals<'_> {
-    unsafe fn service_interrupt(&self, _interrupt: u32) -> bool {
+    fn service_interrupt(&self, _interrupt: u32) -> bool {
         false
     }
 }

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -98,7 +98,7 @@ impl<CFG: EarlGreyConfig, PINMUX: EarlGreyPinmuxConfig>
 impl<CFG: EarlGreyConfig, PINMUX: EarlGreyPinmuxConfig> InterruptService
     for EarlGreyDefaultPeripherals<'_, CFG, PINMUX>
 {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
             interrupts::UART0_TX_WATERMARK..=interrupts::UART0_RX_PARITYERR => {
                 self.uart0.handle_interrupt();

--- a/chips/esp32-c3/src/chip.rs
+++ b/chips/esp32-c3/src/chip.rs
@@ -62,7 +62,7 @@ impl Esp32C3DefaultPeripherals<'_> {
 }
 
 impl InterruptService for Esp32C3DefaultPeripherals<'_> {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
             interrupts::IRQ_UART0 => self.uart0.handle_interrupt(),
 

--- a/chips/imxrt10xx/src/chip.rs
+++ b/chips/imxrt10xx/src/chip.rs
@@ -62,7 +62,7 @@ impl Imxrt10xxDefaultPeripherals {
 }
 
 impl InterruptService for Imxrt10xxDefaultPeripherals {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
             nvic::LPUART1 => self.lpuart1.handle_interrupt(),
             nvic::LPUART2 => self.lpuart2.handle_interrupt(),
@@ -118,14 +118,12 @@ impl<I: InterruptService + 'static> Chip for Imxrt10xx<I> {
     }
 
     fn service_pending_interrupts(&self) {
-        unsafe {
-            while let Some(interrupt) = cortexm7::nvic::next_pending() {
-                let handled = self.interrupt_service.service_interrupt(interrupt);
-                assert!(handled, "Unhandled interrupt number {}", interrupt);
-                let n = cortexm7::nvic::Nvic::new(interrupt);
-                n.clear_pending();
-                n.enable();
-            }
+        while let Some(interrupt) = cortexm7::nvic::next_pending() {
+            let handled = self.interrupt_service.service_interrupt(interrupt);
+            assert!(handled, "Unhandled interrupt number {}", interrupt);
+            let n = cortexm7::nvic::Nvic::new(interrupt);
+            n.clear_pending();
+            n.enable();
         }
     }
 

--- a/chips/lpc55s6x/src/chip.rs
+++ b/chips/lpc55s6x/src/chip.rs
@@ -61,16 +61,14 @@ impl<I: InterruptService> Chip for Lpc55s69<'_, I> {
     }
 
     fn service_pending_interrupts(&self) {
-        unsafe {
-            while let Some(interrupt) = cortexm33::nvic::next_pending() {
-                if !self.interrupt_service.service_interrupt(interrupt) {
-                    panic!("unhandled interrupt {}", interrupt);
-                }
-
-                let n = cortexm33::nvic::Nvic::new(interrupt);
-                n.clear_pending();
-                n.enable();
+        while let Some(interrupt) = cortexm33::nvic::next_pending() {
+            if !self.interrupt_service.service_interrupt(interrupt) {
+                panic!("unhandled interrupt {}", interrupt);
             }
+
+            let n = cortexm33::nvic::Nvic::new(interrupt);
+            n.clear_pending();
+            n.enable();
         }
     }
 
@@ -121,7 +119,7 @@ impl Lpc55s69DefaultPeripheral<'_> {
 }
 
 impl InterruptService for Lpc55s69DefaultPeripheral<'_> {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
             interrupts::GPIO_INT0_IRQ0 => {
                 self.pins.handle_interrupt();

--- a/chips/msp432/src/chip.rs
+++ b/chips/msp432/src/chip.rs
@@ -69,7 +69,7 @@ impl<'a> Msp432DefaultPeripherals<'a> {
 }
 
 impl kernel::platform::chip::InterruptService for Msp432DefaultPeripherals<'_> {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
             nvic::ADC => self.adc.handle_interrupt(),
             nvic::DMA_INT0 => self.dma_channels.handle_interrupt(0),
@@ -117,10 +117,8 @@ impl<'a, I: InterruptService + 'a> Chip for Msp432<'a, I> {
 
     fn service_pending_interrupts(&self) {
         while let Some(interrupt) = cortexm4::nvic::next_pending() {
-            unsafe {
-                if !self.interrupt_service.service_interrupt(interrupt) {
-                    panic!("unhandled interrupt {}", interrupt);
-                }
+            if !self.interrupt_service.service_interrupt(interrupt) {
+                panic!("unhandled interrupt {}", interrupt);
             }
 
             let n = cortexm4::nvic::Nvic::new(interrupt);

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -117,7 +117,7 @@ impl Nrf52DefaultPeripherals<'_> {
     }
 }
 impl kernel::platform::chip::InterruptService for Nrf52DefaultPeripherals<'_> {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
             crate::peripheral_interrupts::COMP => self.acomp.handle_interrupt(),
             crate::peripheral_interrupts::ECB => self.ecb.handle_interrupt(),
@@ -173,15 +173,13 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for NRF52<'a, I>
     }
 
     fn service_pending_interrupts(&self) {
-        unsafe {
-            while let Some(interrupt) = nvic::next_pending() {
-                if !self.interrupt_service.service_interrupt(interrupt) {
-                    panic!("unhandled interrupt {}", interrupt);
-                }
-                let n = nvic::Nvic::new(interrupt);
-                n.clear_pending();
-                n.enable();
+        while let Some(interrupt) = nvic::next_pending() {
+            if !self.interrupt_service.service_interrupt(interrupt) {
+                panic!("unhandled interrupt {}", interrupt);
             }
+            let n = nvic::Nvic::new(interrupt);
+            n.clear_pending();
+            n.enable();
         }
     }
 

--- a/chips/nrf52832/src/interrupt_service.rs
+++ b/chips/nrf52832/src/interrupt_service.rs
@@ -26,7 +26,7 @@ impl Nrf52832DefaultPeripherals<'_> {
     }
 }
 impl kernel::platform::chip::InterruptService for Nrf52832DefaultPeripherals<'_> {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
             nrf52::peripheral_interrupts::GPIOTE => self.gpio_port.handle_interrupt(),
             _ => return self.nrf52.service_interrupt(interrupt),

--- a/chips/nrf52833/src/interrupt_service.rs
+++ b/chips/nrf52833/src/interrupt_service.rs
@@ -35,7 +35,7 @@ impl Nrf52833DefaultPeripherals<'_> {
     }
 }
 impl kernel::platform::chip::InterruptService for Nrf52833DefaultPeripherals<'_> {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
             nrf52::peripheral_interrupts::GPIOTE => self.gpio_port.handle_interrupt(),
             nrf52::peripheral_interrupts::RADIO => {

--- a/chips/nrf52840/src/interrupt_service.rs
+++ b/chips/nrf52840/src/interrupt_service.rs
@@ -43,7 +43,7 @@ impl Nrf52840DefaultPeripherals<'_> {
     }
 }
 impl kernel::platform::chip::InterruptService for Nrf52840DefaultPeripherals<'_> {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
             crate::peripheral_interrupts::USBD => self.usbd.handle_interrupt(),
             nrf52::peripheral_interrupts::GPIOTE => self.gpio_port.handle_interrupt(),

--- a/chips/psc3/src/chip.rs
+++ b/chips/psc3/src/chip.rs
@@ -112,15 +112,13 @@ impl<I: InterruptService> Chip for Psc3<'_, I> {
     type ThreadIdProvider = cortexm33::thread_id::CortexMThreadIdProvider;
 
     fn service_pending_interrupts(&self) {
-        unsafe {
-            while let Some(interrupt) = cortexm33::nvic::next_pending() {
-                if !self.interrupt_service.service_interrupt(interrupt) {
-                    panic!("unhandled interrupt {}", interrupt);
-                }
-                let n = cortexm33::nvic::Nvic::new(interrupt);
-                n.clear_pending();
-                n.enable();
+        while let Some(interrupt) = cortexm33::nvic::next_pending() {
+            if !self.interrupt_service.service_interrupt(interrupt) {
+                panic!("unhandled interrupt {}", interrupt);
             }
+            let n = cortexm33::nvic::Nvic::new(interrupt);
+            n.clear_pending();
+            n.enable();
         }
     }
 
@@ -265,7 +263,7 @@ impl Psc3DefaultPeripherals<'_> {
 }
 
 impl InterruptService for Psc3DefaultPeripherals<'_> {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         // handle all GPIO interrupts
         if interrupt <= interrupts::IOSS_INTERRUPTS_SEC_GPIO_9 {
             self.gpio.handle_interrupt();

--- a/chips/psoc62xa/src/chip.rs
+++ b/chips/psoc62xa/src/chip.rs
@@ -65,10 +65,8 @@ impl<I: InterruptService> Chip for Psoc62xa<'_, I> {
 
     fn service_pending_interrupts(&self) {
         while let Some(interrupt) = cortexm0p::nvic::next_pending() {
-            unsafe {
-                if !self.interrupt_service.service_interrupt(interrupt) {
-                    panic!("unhandled interrupt {}", interrupt);
-                }
+            if !self.interrupt_service.service_interrupt(interrupt) {
+                panic!("unhandled interrupt {}", interrupt);
             }
             let n = cortexm0p::nvic::Nvic::new(interrupt);
             n.clear_pending();
@@ -107,7 +105,7 @@ impl PsoC62xaDefaultPeripherals<'_> {
 }
 
 impl InterruptService for PsoC62xaDefaultPeripherals<'_> {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
             0 => {
                 self.scb.handle_interrupt();

--- a/chips/qemu_rv32_virt_chip/src/chip.rs
+++ b/chips/qemu_rv32_virt_chip/src/chip.rs
@@ -61,7 +61,7 @@ impl QemuRv32VirtDefaultPeripherals<'_> {
 }
 
 impl InterruptService for QemuRv32VirtDefaultPeripherals<'_> {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
             interrupts::UART0 => self.uart0.handle_interrupt(),
             interrupts::VIRTIO_MMIO_0 => self.virtio_mmio[0].handle_interrupt(),

--- a/chips/qemu_rv64_virt_chip/src/chip.rs
+++ b/chips/qemu_rv64_virt_chip/src/chip.rs
@@ -58,7 +58,7 @@ impl QemuRv64VirtDefaultPeripherals<'_> {
 }
 
 impl InterruptService for QemuRv64VirtDefaultPeripherals<'_> {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
             interrupts::UART0 => self.uart0.handle_interrupt(),
             interrupts::VIRTIO_MMIO_0 => self.virtio_mmio[0].handle_interrupt(),

--- a/chips/rp2040/src/chip.rs
+++ b/chips/rp2040/src/chip.rs
@@ -76,22 +76,20 @@ impl<I: InterruptService> Chip for Rp2040<'_, I> {
     }
 
     fn service_pending_interrupts(&self) {
-        unsafe {
-            let mask = match self.sio.get_processor() {
-                Processor::Processor0 => self.processor0_interrupt_mask,
-                Processor::Processor1 => self.processor1_interrupt_mask,
-            };
-            while let Some(interrupt) = cortexm0p::nvic::next_pending_with_mask(mask) {
-                // ignore SIO_IRQ_PROC1 as it is intended for processor 1
-                // not able to unset its pending status
-                // probably only processor 1 can unset the pending by reading the fifo
-                if !self.interrupt_service.service_interrupt(interrupt) {
-                    panic!("unhandled interrupt {}", interrupt);
-                }
-                let n = cortexm0p::nvic::Nvic::new(interrupt);
-                n.clear_pending();
-                n.enable();
+        let mask = match self.sio.get_processor() {
+            Processor::Processor0 => self.processor0_interrupt_mask,
+            Processor::Processor1 => self.processor1_interrupt_mask,
+        };
+        while let Some(interrupt) = cortexm0p::nvic::next_pending_with_mask(mask) {
+            // ignore SIO_IRQ_PROC1 as it is intended for processor 1
+            // not able to unset its pending status
+            // probably only processor 1 can unset the pending by reading the fifo
+            if !self.interrupt_service.service_interrupt(interrupt) {
+                panic!("unhandled interrupt {}", interrupt);
             }
+            let n = cortexm0p::nvic::Nvic::new(interrupt);
+            n.clear_pending();
+            n.enable();
         }
     }
 
@@ -184,7 +182,7 @@ impl Rp2040DefaultPeripherals<'_> {
 }
 
 impl InterruptService for Rp2040DefaultPeripherals<'_> {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
             interrupts::PIO0_IRQ_0 => {
                 self.pio0.handle_interrupt();

--- a/chips/rp2350/src/chip.rs
+++ b/chips/rp2350/src/chip.rs
@@ -65,22 +65,20 @@ impl<I: InterruptService> Chip for Rp2350<'_, I> {
     }
 
     fn service_pending_interrupts(&self) {
-        unsafe {
-            let mask = match self.sio.get_processor() {
-                Processor::Processor0 => self.processor0_interrupt_mask,
-                Processor::Processor1 => self.processor1_interrupt_mask,
-            };
-            while let Some(interrupt) = cortexm33::nvic::next_pending_with_mask(mask) {
-                // ignore PROC1_IRQ_CTI as it is intended for processor 1
-                // not able to unset its pending status
-                // probably only processor 1 can unset the pending by reading the fifo
-                if !self.interrupt_service.service_interrupt(interrupt) {
-                    panic!("unhandled interrupt {}", interrupt);
-                }
-                let n = cortexm33::nvic::Nvic::new(interrupt);
-                n.clear_pending();
-                n.enable();
+        let mask = match self.sio.get_processor() {
+            Processor::Processor0 => self.processor0_interrupt_mask,
+            Processor::Processor1 => self.processor1_interrupt_mask,
+        };
+        while let Some(interrupt) = cortexm33::nvic::next_pending_with_mask(mask) {
+            // ignore PROC1_IRQ_CTI as it is intended for processor 1
+            // not able to unset its pending status
+            // probably only processor 1 can unset the pending by reading the fifo
+            if !self.interrupt_service.service_interrupt(interrupt) {
+                panic!("unhandled interrupt {}", interrupt);
             }
+            let n = cortexm33::nvic::Nvic::new(interrupt);
+            n.clear_pending();
+            n.enable();
         }
     }
 
@@ -150,7 +148,7 @@ impl Rp2350DefaultPeripherals<'_> {
 }
 
 impl InterruptService for Rp2350DefaultPeripherals<'_> {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
             interrupts::TIMER0_IRQ_0 => {
                 self.timer0.handle_interrupt();

--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -161,7 +161,7 @@ impl Sam4lDefaultPeripherals {
     }
 }
 impl InterruptService for Sam4lDefaultPeripherals {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         use crate::nvic;
         match interrupt {
             nvic::ASTALARM => self.ast.handle_interrupt(),
@@ -247,16 +247,14 @@ impl<I: InterruptService + 'static> Chip for Sam4l<I> {
     }
 
     fn service_pending_interrupts(&self) {
-        unsafe {
-            while let Some(interrupt) = cortexm4::nvic::next_pending() {
-                match self.interrupt_service.service_interrupt(interrupt) {
-                    true => {}
-                    false => panic!("unhandled interrupt"),
-                }
-                let n = cortexm4::nvic::Nvic::new(interrupt);
-                n.clear_pending();
-                n.enable();
+        while let Some(interrupt) = cortexm4::nvic::next_pending() {
+            match self.interrupt_service.service_interrupt(interrupt) {
+                true => {}
+                false => panic!("unhandled interrupt"),
             }
+            let n = cortexm4::nvic::Nvic::new(interrupt);
+            n.clear_pending();
+            n.enable();
         }
     }
 

--- a/chips/stm32f303xc/src/chip.rs
+++ b/chips/stm32f303xc/src/chip.rs
@@ -62,7 +62,7 @@ impl<'a> Stm32f3xxDefaultPeripherals<'a> {
 }
 
 impl InterruptService for Stm32f3xxDefaultPeripherals<'_> {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
             nvic::USART1 => self.usart1.handle_interrupt(),
             nvic::USART2 => self.usart2.handle_interrupt(),
@@ -113,15 +113,13 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32f3xx<'a, I> {
     }
 
     fn service_pending_interrupts(&self) {
-        unsafe {
-            while let Some(interrupt) = cortexm4f::nvic::next_pending() {
-                if !self.interrupt_service.service_interrupt(interrupt) {
-                    panic!("unhandled interrupt {}", interrupt);
-                }
-                let n = cortexm4f::nvic::Nvic::new(interrupt);
-                n.clear_pending();
-                n.enable();
+        while let Some(interrupt) = cortexm4f::nvic::next_pending() {
+            if !self.interrupt_service.service_interrupt(interrupt) {
+                panic!("unhandled interrupt {}", interrupt);
             }
+            let n = cortexm4f::nvic::Nvic::new(interrupt);
+            n.clear_pending();
+            n.enable();
         }
     }
 

--- a/chips/stm32f401cc/src/interrupt_service.rs
+++ b/chips/stm32f401cc/src/interrupt_service.rs
@@ -28,7 +28,7 @@ impl<'a> Stm32f401ccDefaultPeripherals<'a> {
     }
 }
 impl kernel::platform::chip::InterruptService for Stm32f401ccDefaultPeripherals<'_> {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         #[allow(clippy::match_single_binding)]
         match interrupt {
             // put Stm32f401cc specific interrupts here

--- a/chips/stm32f412g/src/interrupt_service.rs
+++ b/chips/stm32f412g/src/interrupt_service.rs
@@ -31,7 +31,7 @@ impl<'a> Stm32f412gDefaultPeripherals<'a> {
     }
 }
 impl kernel::platform::chip::InterruptService for Stm32f412gDefaultPeripherals<'_> {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
             // put Stm32f412g specific interrupts here
             stm32f412g_nvic::RNG => {

--- a/chips/stm32f429zi/src/interrupt_service.rs
+++ b/chips/stm32f429zi/src/interrupt_service.rs
@@ -37,7 +37,7 @@ impl<'a> Stm32f429ziDefaultPeripherals<'a> {
     }
 }
 impl kernel::platform::chip::InterruptService for Stm32f429ziDefaultPeripherals<'_> {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
             // put Stm32f429zi specific interrupts here
             stm32f429zi_nvic::HASH_RNG => {

--- a/chips/stm32f446re/src/interrupt_service.rs
+++ b/chips/stm32f446re/src/interrupt_service.rs
@@ -28,7 +28,7 @@ impl<'a> Stm32f446reDefaultPeripherals<'a> {
     }
 }
 impl kernel::platform::chip::InterruptService for Stm32f446reDefaultPeripherals<'_> {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         #[allow(clippy::match_single_binding)]
         match interrupt {
             // put Stm32f446re specific interrupts here

--- a/chips/stm32f4xx/src/chip.rs
+++ b/chips/stm32f4xx/src/chip.rs
@@ -97,7 +97,7 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Stm32f4xxDefaultPeripherals<'a, ChipSpecs> {
 }
 
 impl<ChipSpecs: ChipSpecsTrait> InterruptService for Stm32f4xxDefaultPeripherals<'_, ChipSpecs> {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
             nvic::DMA1_Stream1 => self.dma1_streams
                 [dma::Dma1Peripheral::USART3_RX.get_stream_idx()]
@@ -174,16 +174,14 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32f4xx<'a, I> {
     }
 
     fn service_pending_interrupts(&self) {
-        unsafe {
-            while let Some(interrupt) = cortexm4f::nvic::next_pending() {
-                if !self.interrupt_service.service_interrupt(interrupt) {
-                    panic!("unhandled interrupt {}", interrupt);
-                }
-
-                let n = cortexm4f::nvic::Nvic::new(interrupt);
-                n.clear_pending();
-                n.enable();
+        while let Some(interrupt) = cortexm4f::nvic::next_pending() {
+            if !self.interrupt_service.service_interrupt(interrupt) {
+                panic!("unhandled interrupt {}", interrupt);
             }
+
+            let n = cortexm4f::nvic::Nvic::new(interrupt);
+            n.clear_pending();
+            n.enable();
         }
     }
 

--- a/chips/stm32u5xx/src/chip.rs
+++ b/chips/stm32u5xx/src/chip.rs
@@ -131,7 +131,7 @@ impl<'a> Stm32u5xxDefaultPeripherals<'a> {
 }
 
 impl InterruptService for Stm32u5xxDefaultPeripherals<'_> {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
             ADC1_2_IRQ => {
                 // ADC1
@@ -309,16 +309,14 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32u5xx<'a, I> {
     }
 
     fn service_pending_interrupts(&self) {
-        unsafe {
-            while let Some(interrupt) = cortexm33::nvic::next_pending() {
-                if !self.interrupt_service.service_interrupt(interrupt) {
-                    panic!("unhandled interrupt {}", interrupt);
-                }
-
-                let n = cortexm33::nvic::Nvic::new(interrupt);
-                n.clear_pending();
-                n.enable();
+        while let Some(interrupt) = cortexm33::nvic::next_pending() {
+            if !self.interrupt_service.service_interrupt(interrupt) {
+                panic!("unhandled interrupt {}", interrupt);
             }
+
+            let n = cortexm33::nvic::Nvic::new(interrupt);
+            n.clear_pending();
+            n.enable();
         }
     }
 

--- a/chips/stm32wle5jc/src/interrupt_service.rs
+++ b/chips/stm32wle5jc/src/interrupt_service.rs
@@ -26,7 +26,7 @@ impl<'a> Stm32wle5jcDefaultPeripherals<'a> {
     }
 }
 impl kernel::platform::chip::InterruptService for Stm32wle5jcDefaultPeripherals<'_> {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         #[allow(clippy::match_single_binding)]
         match interrupt {
             // put Stm32wle5jc specific interrupts here

--- a/chips/stm32wle5xx/src/chip.rs
+++ b/chips/stm32wle5xx/src/chip.rs
@@ -66,7 +66,7 @@ impl<'a, ChipSpecs: ChipSpecsTrait> Stm32wle5xxDefaultPeripherals<'a, ChipSpecs>
 }
 
 impl<ChipSpecs: ChipSpecsTrait> InterruptService for Stm32wle5xxDefaultPeripherals<'_, ChipSpecs> {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+    fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
             nvic::USART1 => self.usart1.handle_interrupt(),
             nvic::USART2 => self.usart2.handle_interrupt(),
@@ -130,32 +130,30 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32wle5xx<'a, I> {
         // After servicing all other pending interrupts, we then check if the subghz
         // radio interrupt is asserted (see comments in subghz_radio.rs for details
         // of handling).
-        unsafe {
-            loop {
-                if let Some(interrupt) =
-                    cortexm4::nvic::next_pending_with_mask((0, 1u128 << crate::nvic::RADIO_IRQ))
-                {
-                    if !self.interrupt_service.service_interrupt(interrupt) {
-                        panic!("unhandled interrupt {}", interrupt);
-                    }
+        loop {
+            if let Some(interrupt) =
+                cortexm4::nvic::next_pending_with_mask((0, 1u128 << crate::nvic::RADIO_IRQ))
+            {
+                if !self.interrupt_service.service_interrupt(interrupt) {
+                    panic!("unhandled interrupt {}", interrupt);
+                }
 
-                    let n = cortexm4::nvic::Nvic::new(interrupt);
+                let n = cortexm4::nvic::Nvic::new(interrupt);
+                n.clear_pending();
+                n.enable();
+            } else {
+                if let Some(radio_interrupt) = cortexm4::nvic::next_pending_with_mask((
+                    u128::MAX,
+                    !(1u128 << crate::nvic::RADIO_IRQ),
+                )) {
+                    // check to confirm we masked properly
+                    assert_eq!(radio_interrupt, crate::nvic::RADIO_IRQ);
+                    self.interrupt_service.service_interrupt(radio_interrupt);
+                    let n = cortexm4::nvic::Nvic::new(radio_interrupt);
                     n.clear_pending();
                     n.enable();
-                } else {
-                    if let Some(radio_interrupt) = cortexm4::nvic::next_pending_with_mask((
-                        u128::MAX,
-                        !(1u128 << crate::nvic::RADIO_IRQ),
-                    )) {
-                        // check to confirm we masked properly
-                        assert_eq!(radio_interrupt, crate::nvic::RADIO_IRQ);
-                        self.interrupt_service.service_interrupt(radio_interrupt);
-                        let n = cortexm4::nvic::Nvic::new(radio_interrupt);
-                        n.clear_pending();
-                        n.enable();
-                    }
-                    break;
                 }
+                break;
             }
         }
     }

--- a/chips/veer_el2/src/chip.rs
+++ b/chips/veer_el2/src/chip.rs
@@ -54,7 +54,7 @@ impl Default for VeeRDefaultPeripherals {
 }
 
 impl InterruptService for VeeRDefaultPeripherals {
-    unsafe fn service_interrupt(&self, _interrupt: u32) -> bool {
+    fn service_interrupt(&self, _interrupt: u32) -> bool {
         true
     }
 }

--- a/chips/x86_q35/src/chip.rs
+++ b/chips/x86_q35/src/chip.rs
@@ -150,13 +150,13 @@ impl<'a, I1: InterruptService, I2: InterruptService, const PR: u16> Chip for Pc<
         InterruptPoller::access(|poller| {
             while let Some(num) = poller.next_pending() {
                 let mut handled = true;
-                match unsafe { self.default_peripherals.service_interrupt(num) } {
+                match self.default_peripherals.service_interrupt(num) {
                     true => {}
                     false => {
                         // Convert back to physical interrupt line number before passing to
                         // board-specific handler
                         let phys_num = num - PIC1_OFFSET as u32;
-                        handled = unsafe { self.board_peripherals.service_interrupt(phys_num) };
+                        handled = self.board_peripherals.service_interrupt(phys_num);
                     }
                 }
                 poller.clear_pending(num);
@@ -308,7 +308,7 @@ impl<const PR: u16> PcDefaultPeripherals<PR> {
 }
 
 impl<const PR: u16> InterruptService for PcDefaultPeripherals<PR> {
-    unsafe fn service_interrupt(&self, num: u32) -> bool {
+    fn service_interrupt(&self, num: u32) -> bool {
         match num {
             interrupt::PIT => {
                 self.pit.handle_interrupt();

--- a/kernel/src/platform/chip.rs
+++ b/kernel/src/platform/chip.rs
@@ -168,12 +168,12 @@ pub unsafe trait ThreadIdProvider {
 pub trait InterruptService {
     /// Service an interrupt, if supported by this chip. If this interrupt
     /// number is not supported, return false.
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool;
+    fn service_interrupt(&self, interrupt: u32) -> bool;
 }
 
 /// A default implementation of `InterruptService` that handles nothing and returns `false`.
 impl InterruptService for () {
-    unsafe fn service_interrupt(&self, _interrupt: u32) -> bool {
+    fn service_interrupt(&self, _interrupt: u32) -> bool {
         false
     }
 }


### PR DESCRIPTION


### Pull Request Overview

Remove `unsafe` from `InterruptService::service_interrupt()`. I do not think that servicing an interrupt violates Rust memory safety.

I looked through all of the changes needed, and I don't see any safety docs.


### Testing Strategy

travis


### TODO or Help Wanted

If someone has a sense as to why this needs to be unsafe, an idea about what the safety doc would say would be helpful.


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [ ] No documentation updates are required.

It is possible some examples show this and use unsafe {} blocks.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

Claude did all the mechanical work. I looked at each change for the safety doc and everything is a pretty straightforward change.
