### PR TITLE
kernel: dma_slice: Add `ImmutFromIntoBytes` safety doc

### DIFF
--- a/kernel/src/utilities/dma_slice.rs
+++ b/kernel/src/utilities/dma_slice.rs
@@ -780,6 +780,23 @@ pub mod immutable_from_into_bytes {
     /// [zerocopy-frombytes]: https://docs.rs/zerocopy/0.8.42/zerocopy/trait.FromBytes.html
     /// [zerocopy-intobytes]: https://docs.rs/zerocopy/0.8.42/zerocopy/trait.IntoBytes.html
     /// [zerocopy-immutable]: https://docs.rs/zerocopy/0.8.42/zerocopy/trait.Immutable.html
+    ///
+    /// # Safety
+    ///
+    /// If `T: ImmutableFromIntoBytes`, then unsafe code may assume that it is
+    /// sound to produce a `T` whose bytes are initialized to any sequence of
+    /// valid u8s (in other words, any byte value which is not uninitialized).
+    /// Additionally, unsafe code may assume that it is sound to treat any `t:
+    /// T` as an immutable `[u8]` of length `size_of_val(t)`. If a type is
+    /// marked as `ImmutableFromIntoBytes` which violates this contract, it may
+    /// cause undefined behavior.
+    ///
+    /// Unsafe code outside of this crate must not make any assumptions about
+    /// `T` based on `T` not featuring interior mutability. We reserve the right
+    /// to relax the requirements for `ImmutableFromIntoBytes` in the future,
+    /// and if unsafe code outside of this crate makes assumptions based on not
+    /// featuring interior mutability, future relaxations may cause that code to
+    /// become unsound.
     pub unsafe trait ImmutableFromIntoBytes: private::Sealed {}
 
     impl private::Sealed for u8 {}

--- a/kernel/src/utilities/dma_slice.rs
+++ b/kernel/src/utilities/dma_slice.rs
@@ -783,20 +783,16 @@ pub mod immutable_from_into_bytes {
     ///
     /// # Safety
     ///
-    /// If `T: ImmutableFromIntoBytes`, then unsafe code may assume that it is
-    /// sound to produce a `T` whose bytes are initialized to any sequence of
-    /// valid u8s (in other words, any byte value which is not uninitialized).
-    /// Additionally, unsafe code may assume that it is sound to treat any `t:
-    /// T` as an immutable `[u8]` of length `size_of_val(t)`. If a type is
-    /// marked as `ImmutableFromIntoBytes` which violates this contract, it may
-    /// cause undefined behavior.
+    /// Types that implement `ImmutableFromIntoBytes` must:
     ///
-    /// Unsafe code outside of this crate must not make any assumptions about
-    /// `T` based on `T` not featuring interior mutability. We reserve the right
-    /// to relax the requirements for `ImmutableFromIntoBytes` in the future,
-    /// and if unsafe code outside of this crate makes assumptions based on not
-    /// featuring interior mutability, future relaxations may cause that code to
-    /// become unsound.
+    /// 1. no_uninit: Not contain any uninitialized bytes (such as padding)
+    /// 2. no_interior_mut: Not have any interior mutability
+    /// 3. any_init_pattern: Be valid for all initialized byte patterns of the
+    ///    correct length and alignment.
+    ///
+    /// These guarantees effectively allow `&mut [T]` references to be converted
+    /// into `&mut [u8]` references, mutated, and then converted back into `&mut
+    /// [T]` references.
     pub unsafe trait ImmutableFromIntoBytes: private::Sealed {}
 
     impl private::Sealed for u8 {}


### PR DESCRIPTION
### Pull Request Overview

I wrote this based on the referenced docs from zero copy:

- https://docs.rs/zerocopy/0.8.42/zerocopy/trait.FromBytes.html
- https://docs.rs/zerocopy/0.8.42/zerocopy/trait.IntoBytes.html
- https://docs.rs/zerocopy/0.8.42/zerocopy/trait.Immutable.html

I think the safety docs for `FromBytes` and `IntoBytes` are reasonably understandable.

However, the safety doc for `Immutable` seems useless. I don't know if that is supposed to cover the case where someone looks at how the derive is implemented and do something based on it, but, it should go without saying that code can't make assumptions not specified by the meaning of the trait. But, I included it anyway in case it matters to us.


### Testing Strategy

docs


### TODO or Help Wanted

@lschuermann to review


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
