### PR TITLE
Make `Scheduler::execute_kernel_work()` safe

### DIFF
--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -358,51 +358,48 @@ impl Kernel {
         let scheduler = resources.scheduler();
 
         resources.watchdog().tickle();
-        unsafe {
-            // Ask the scheduler if we should do tasks inside of the kernel,
-            // such as handle interrupts. A scheduler may want to prioritize
-            // processes instead, or there may be no kernel work to do.
-            match scheduler.do_kernel_work_now(chip) {
-                true => {
-                    // Execute kernel work. This includes handling
-                    // interrupts and is how code in the chips/ and capsules
-                    // crates is able to execute.
-                    scheduler.execute_kernel_work(chip);
-                }
-                false => {
-                    // No kernel work ready, so ask scheduler for a process.
-                    match scheduler.next() {
-                        SchedulingDecision::RunProcess((processid, timeslice_us)) => {
-                            self.process_map_or((), processid, |process| {
-                                let (reason, time_executed) =
-                                    self.do_process(resources, chip, process, ipc, timeslice_us);
-                                scheduler.result(reason, time_executed);
+        // Ask the scheduler if we should do tasks inside of the kernel,
+        // such as handle interrupts. A scheduler may want to prioritize
+        // processes instead, or there may be no kernel work to do.
+        match scheduler.do_kernel_work_now(chip) {
+            true => {
+                // Execute kernel work. This includes handling
+                // interrupts and is how code in the chips/ and capsules
+                // crates is able to execute.
+                scheduler.execute_kernel_work(chip);
+            }
+            false => {
+                // No kernel work ready, so ask scheduler for a process.
+                match scheduler.next() {
+                    SchedulingDecision::RunProcess((processid, timeslice_us)) => {
+                        self.process_map_or((), processid, |process| {
+                            let (reason, time_executed) =
+                                self.do_process(resources, chip, process, ipc, timeslice_us);
+                            scheduler.result(reason, time_executed);
+                        });
+                    }
+                    SchedulingDecision::TrySleep => {
+                        // For testing, it may be helpful to
+                        // disable sleeping the chip in case
+                        // the running test does not generate
+                        // any interrupts.
+                        if !no_sleep {
+                            chip.with_interrupts_disabled(|| {
+                                // Cannot sleep if interrupts are pending,
+                                // as on most platforms unhandled interrupts
+                                // will wake the device. Also, if the only
+                                // pending interrupt occurred after the
+                                // scheduler decided to put the chip to
+                                // sleep, but before this atomic section
+                                // starts, the interrupt will not be
+                                // serviced and the chip will never wake
+                                // from sleep.
+                                if !chip.has_pending_interrupts() && !DeferredCall::has_tasks() {
+                                    resources.watchdog().suspend();
+                                    chip.sleep();
+                                    resources.watchdog().resume();
+                                }
                             });
-                        }
-                        SchedulingDecision::TrySleep => {
-                            // For testing, it may be helpful to
-                            // disable sleeping the chip in case
-                            // the running test does not generate
-                            // any interrupts.
-                            if !no_sleep {
-                                chip.with_interrupts_disabled(|| {
-                                    // Cannot sleep if interrupts are pending,
-                                    // as on most platforms unhandled interrupts
-                                    // will wake the device. Also, if the only
-                                    // pending interrupt occurred after the
-                                    // scheduler decided to put the chip to
-                                    // sleep, but before this atomic section
-                                    // starts, the interrupt will not be
-                                    // serviced and the chip will never wake
-                                    // from sleep.
-                                    if !chip.has_pending_interrupts() && !DeferredCall::has_tasks()
-                                    {
-                                        resources.watchdog().suspend();
-                                        chip.sleep();
-                                        resources.watchdog().resume();
-                                    }
-                                });
-                            }
                         }
                     }
                 }

--- a/kernel/src/scheduler.rs
+++ b/kernel/src/scheduler.rs
@@ -45,7 +45,7 @@ pub trait Scheduler<C: Chip> {
     ///
     /// Custom implementations of this function must be very careful, however,
     /// as this function is called in the core kernel loop.
-    unsafe fn execute_kernel_work(&self, chip: &C) {
+    fn execute_kernel_work(&self, chip: &C) {
         chip.service_pending_interrupts();
         while DeferredCall::has_tasks() && !chip.has_pending_interrupts() {
             DeferredCall::service_next_pending();


### PR DESCRIPTION


### Pull Request Overview

It doesn't seem like having the scheduler do kernel work is an unsafe operation. I wonder if this was marked as unsafe because `service_pending_interrupts` has been marked as unsafe, and we just carried that through.

There is no safety doc for how to correctly call execute_kernel_work().


### Testing Strategy

travis


### TODO or Help Wanted

This needs #4993 to compile.

Anyone think this is an unsafe operation, and if so, what the safety docs might be?


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

Claude did the mechanics. Just one change.
