### PR TITLE
kernel: Format `SAFETY:` docs to match `clippy::undocumented_unsafe_block`

### DIFF
--- a/kernel/src/collections/ring_buffer.rs
+++ b/kernel/src/collections/ring_buffer.rs
@@ -51,10 +51,10 @@ impl<'a, T: Copy> RingBuffer<'a, T> {
     ///   (although physically the "left" slice is stored after the "right"
     ///   slice).
     pub fn as_slices(&'a self) -> (Option<&'a [T]>, Option<&'a [T]>) {
-        // SAFETY: Reinterprets &[MaybeUninit<T>] as &[T]. MaybeUninit<T> has the same layout as
-        // T, and every element in the returned slice falls within [head, tail) which has been
-        // written by enqueue/push, so reading those elements as T is valid.
         let assume_init = |s: &[MaybeUninit<T>]| -> &[T] {
+            // SAFETY: Reinterprets &[MaybeUninit<T>] as &[T]. MaybeUninit<T> has the same layout as
+            // T, and every element in the returned slice falls within [head, tail) which has been
+            // written by enqueue/push, so reading those elements as T is valid.
             unsafe { core::slice::from_raw_parts(s.as_ptr().cast::<T>(), s.len()) }
         };
 
@@ -98,9 +98,7 @@ impl<'a, T: Copy> RingBuffer<'a, T> {
         } else {
             let element = self.ring.get(index);
             element.map(|e| {
-                // # Safety
-                //
-                // It is safe to read the element from this location in the ring and
+                // SAFETY: It is safe to read the element from this location in the ring and
                 // assume it is initialized because we verified that the index is
                 // within the populated elements of the ring. Our invariant is that
                 // any index with head and tail _must_ be initialized.
@@ -120,9 +118,7 @@ impl<'a, T: Copy> RingBuffer<'a, T> {
         } else {
             let element = self.ring.get(index);
             element.map(|e| {
-                // # Safety
-                //
-                // It is safe to read the element from this location in the ring and
+                // SAFETY: It is safe to read the element from this location in the ring and
                 // assume it is initialized because we verified that the index is
                 // within the populated elements of the ring. Our invariant is that
                 // any index with head and tail _must_ be initialized.

--- a/kernel/src/deferred_call.rs
+++ b/kernel/src/deferred_call.rs
@@ -114,18 +114,20 @@ struct DynDefCallRef<'a> {
 }
 
 impl<'a> DynDefCallRef<'a> {
-    // SAFETY: We define the callback function as being a closure which casts
-    // the passed pointer to be the appropriate type (a pointer to `T`) and then
-    // calls `T::handle_deferred_call()`. In practice, the closure is optimized
-    // away by LLVM when the ABI of the closure and the underlying function are
-    // identical, making this zero-cost, but saving us from having to trust that
-    // `fn(*const ())` and `fn handle_deferred_call(&self)` will always have the
-    // same calling convention for any type.
     fn new<T: DeferredCallClient>(x: &'a T) -> Self {
         let data: *const () = core::ptr::from_ref(x).cast();
         Self {
             data,
-            callback: |p| unsafe { T::handle_deferred_call(&*p.cast()) },
+            callback: |p| {
+                // SAFETY: We define the callback function as being a closure which casts
+                // the passed pointer to be the appropriate type (a pointer to `T`) and then
+                // calls `T::handle_deferred_call()`. In practice, the closure is optimized
+                // away by LLVM when the ABI of the closure and the underlying function are
+                // identical, making this zero-cost, but saving us from having to trust that
+                // `fn(*const ())` and `fn handle_deferred_call(&self)` will always have the
+                // same calling convention for any type.
+                unsafe { T::handle_deferred_call(&*p.cast()) }
+            },
             _lifetime: PhantomData,
         }
     }
@@ -181,9 +183,7 @@ pub fn initialize_deferred_call_state<P: ThreadIdProvider>() {
 /// concurrently with calls to `initialize_deferred_call_state` or other calls
 /// to [`initialize_deferred_call_state_unsafe`].
 pub unsafe fn initialize_deferred_call_state_unsafe<P: ThreadIdProvider>() {
-    // # Safety
-    //
-    // See function safety description.
+    // SAFETY: See function safety description.
     unsafe {
         let _ = CTR.bind_to_thread_unsafe::<P>(Cell::new(0));
         let _ = BITMASK.bind_to_thread_unsafe::<P>(Cell::new(0));

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -281,9 +281,7 @@ impl<'a> EnteredGrantKernelManagedLayout<'a> {
     ) -> Self {
         let counters_ptr: *mut usize = base_ptr.as_ptr().cast();
 
-        // # Safety
-        //
-        // The safety requirement for the function ensures that `base_ptr` is
+        // SAFETY: The safety requirement for the function ensures that `base_ptr` is
         // well aligned and there is an initialized counters structure there.
         let counters_val = unsafe { counters_ptr.read() };
 
@@ -293,9 +291,7 @@ impl<'a> EnteredGrantKernelManagedLayout<'a> {
         // Skip over the counter usize, then the stored array of `SavedAllowRo`
         // items and `SavedAllowRw` items.
         //
-        // # Safety
-        //
-        // The safety requirement for the function ensures that `base_ptr` is
+        // SAFETY: The safety requirement for the function ensures that `base_ptr` is
         // well aligned and there are initialized arrays of saved upcalls and
         // allows above the counters.
         let (upcalls_array, allow_ro_array, allow_rw_array) = unsafe {
@@ -342,9 +338,7 @@ impl<'a> EnteredGrantKernelManagedLayout<'a> {
             u32::from_be_bytes([0, allow_rw_num_val.0, allow_ro_num_val.0, upcalls_num_val.0])
                 as usize;
 
-        // # Safety
-        //
-        // Callers guarantee that the `base_ptr` is well aligned to the kernel
+        // SAFETY: Callers guarantee that the `base_ptr` is well aligned to the kernel
         // managed grant structure and these pointers reconstruct that grant
         // structure.
         let (upcalls_array, allow_ro_array, allow_rw_array) = unsafe {
@@ -356,9 +350,7 @@ impl<'a> EnteredGrantKernelManagedLayout<'a> {
             (upcalls_array, allow_ro_array, allow_rw_array)
         };
 
-        // # Safety
-        //
-        // Callers guarantee that the `base_ptr` is well aligned to the kernel
+        // SAFETY: Callers guarantee that the `base_ptr` is well aligned to the kernel
         // managed grant structure and there is enough memory to hold the entire
         // grant structure. That ensures writing the grant structure is safe.
         unsafe {
@@ -424,9 +416,7 @@ impl<'a> EnteredGrantKernelManagedLayout<'a> {
         grant_size: usize,
         grant_t_size: GrantDataSize,
     ) -> NonNull<u8> {
-        // # Safety
-        //
-        // The location of the grant data T is the last element in the entire
+        // SAFETY: The location of the grant data T is the last element in the entire
         // grant region. Caller must verify that memory is accessible and well
         // aligned to T.
         unsafe {
@@ -438,9 +428,7 @@ impl<'a> EnteredGrantKernelManagedLayout<'a> {
     /// Read an 8 bit value from the counter field offset by the specified
     /// number of bits. This is a helper function for reading the counter field.
     fn get_counter_offset(&self, offset_bits: usize) -> usize {
-        // # Safety
-        //
-        // Creating a `EnteredGrantKernelManagedLayout` object requires that the
+        // SAFETY: Creating a `EnteredGrantKernelManagedLayout` object requires that the
         // pointers are well aligned and point to valid memory.
         let counters_val = unsafe { self.counters_ptr.read() };
         (counters_val >> offset_bits) & 0xFF
@@ -466,9 +454,7 @@ impl<'a> EnteredGrantKernelManagedLayout<'a> {
     /// Return mutable access to the slice of stored upcalls for this grant.
     /// This is necessary for storing a new upcall.
     fn get_upcalls_slice(&mut self) -> &mut [SavedUpcall] {
-        // # Safety
-        //
-        // Creating a `EnteredGrantKernelManagedLayout` object ensures that the
+        // SAFETY: Creating a `EnteredGrantKernelManagedLayout` object ensures that the
         // pointer to the upcall array is valid.
         unsafe { slice::from_raw_parts_mut(self.upcalls_array, self.get_upcalls_number()) }
     }
@@ -476,9 +462,7 @@ impl<'a> EnteredGrantKernelManagedLayout<'a> {
     /// Return mutable access to the slice of stored read-only allow buffers for
     /// this grant. This is necessary for storing a new read-only allow.
     fn get_allow_ro_slice(&mut self) -> &mut [SavedAllowRo] {
-        // # Safety
-        //
-        // Creating a `EnteredGrantKernelManagedLayout` object ensures that the
+        // SAFETY: Creating a `EnteredGrantKernelManagedLayout` object ensures that the
         // pointer to the RO allow array is valid.
         unsafe { slice::from_raw_parts_mut(self.allow_ro_array, self.get_allow_ro_number()) }
     }
@@ -486,9 +470,7 @@ impl<'a> EnteredGrantKernelManagedLayout<'a> {
     /// Return mutable access to the slice of stored read-write allow buffers
     /// for this grant. This is necessary for storing a new read-write allow.
     fn get_allow_rw_slice(&mut self) -> &mut [SavedAllowRw] {
-        // # Safety
-        //
-        // Creating a `EnteredGrantKernelManagedLayout` object ensures that the
+        // SAFETY: Creating a `EnteredGrantKernelManagedLayout` object ensures that the
         // pointer to the RW allow array is valid.
         unsafe { slice::from_raw_parts_mut(self.allow_rw_array, self.get_allow_rw_number()) }
     }
@@ -497,23 +479,17 @@ impl<'a> EnteredGrantKernelManagedLayout<'a> {
     /// permits using upcalls and allow buffers when a capsule is accessing a
     /// grant.
     fn get_resource_slices(&self) -> (&[SavedUpcall], &[SavedAllowRo], &[SavedAllowRw]) {
-        // # Safety
-        //
-        // Creating a `EnteredGrantKernelManagedLayout` object ensures that the
+        // SAFETY: Creating a `EnteredGrantKernelManagedLayout` object ensures that the
         // pointer to the upcall array is valid.
         let upcall_slice =
             unsafe { slice::from_raw_parts(self.upcalls_array, self.get_upcalls_number()) };
 
-        // # Safety
-        //
-        // Creating a `EnteredGrantKernelManagedLayout` object ensures that the
+        // SAFETY: Creating a `EnteredGrantKernelManagedLayout` object ensures that the
         // pointer to the RO allow array is valid.
         let allow_ro_slice =
             unsafe { slice::from_raw_parts(self.allow_ro_array, self.get_allow_ro_number()) };
 
-        // # Safety
-        //
-        // Creating a `KernelManagedLayout` object ensures that the pointer to
+        // SAFETY: Creating a `KernelManagedLayout` object ensures that the pointer to
         // the RW allow array is valid.
         let allow_rw_slice =
             unsafe { slice::from_raw_parts(self.allow_rw_array, self.get_allow_rw_number()) };
@@ -525,9 +501,7 @@ impl<'a> EnteredGrantKernelManagedLayout<'a> {
 // Ensure that we leave the grant once this goes out of scope.
 impl Drop for EnteredGrantKernelManagedLayout<'_> {
     fn drop(&mut self) {
-        // ### Safety
-        //
-        // To safely call this function we must ensure that no references will
+        // SAFETY: To safely call this function we must ensure that no references will
         // exist to the grant once `leave_grant()` returns. Because using a
         // `EnteredGrantKernelManagedLayout` object is the only only way we
         // access the actual memory of a grant, and we are calling
@@ -716,9 +690,7 @@ impl<'a> GrantKernelData<'a> {
         self.allow_ro.get(allow_ro_num).map_or(
             Err(crate::process::Error::AddressOutOfBounds),
             |saved_ro| {
-                // # Safety
-                //
-                // This is the saved process buffer data has been validated to
+                // SAFETY: This is the saved process buffer data has been validated to
                 // be wholly contained within this process before it was stored.
                 // The lifetime of the ReadOnlyProcessBuffer is bound to the
                 // lifetime of self, which correctly limits dereferencing this
@@ -757,9 +729,7 @@ impl<'a> GrantKernelData<'a> {
         self.allow_rw.get(allow_rw_num).map_or(
             Err(crate::process::Error::AddressOutOfBounds),
             |saved_rw| {
-                // # Safety
-                //
-                // This is the saved process buffer data has been validated to
+                // SAFETY: This is the saved process buffer data has been validated to
                 // be wholly contained within this process before it was stored.
                 // The lifetime of the ReadWriteProcessBuffer is bound to the
                 // lifetime of self, which correctly limits dereferencing this
@@ -841,9 +811,7 @@ impl Default for SavedAllowRw {
 /// already does contain initialized memory, then those contents will be
 /// overwritten without being `Drop`ed first.
 unsafe fn write_default_array<T: Default>(base: *mut T, num: usize) {
-    // # Safety
-    //
-    // See function description.
+    // SAFETY: See function description.
     unsafe {
         for i in 0..num {
             base.add(i).write(T::default());
@@ -870,9 +838,7 @@ fn enter_grant_kernel_managed(
 
     // Return early if no grant.
     let grant_base_ptr = process.enter_grant(grant_num).or(Err(ErrorCode::NOMEM))?;
-    // # Safety
-    //
-    // We know that this pointer is well aligned and initialized with meaningful
+    // SAFETY: We know that this pointer is well aligned and initialized with meaningful
     // data when the grant region was allocated.
     let layout = unsafe {
         EnteredGrantKernelManagedLayout::read_from_base(grant_base_ptr, process, grant_num)
@@ -954,9 +920,7 @@ pub(crate) fn allow_ro(
     // userspace passed us a bad allow number.
     match saved_allow_ro_slice.get_mut(allow_num) {
         Some(saved) => {
-            // # Safety
-            //
-            // The pointer has already been validated to be within application
+            // SAFETY: The pointer has already been validated to be within application
             // memory before storing the values in the saved slice.
             let old_allow =
                 unsafe { ReadOnlyProcessBuffer::new(saved.ptr, saved.len, process.processid()) };
@@ -1002,9 +966,7 @@ pub(crate) fn allow_rw(
     // userspace passed us a bad allow number.
     match saved_allow_rw_slice.get_mut(allow_num) {
         Some(saved) => {
-            // # Safety
-            //
-            // The pointer has already been validated to be within application
+            // SAFETY: The pointer has already been validated to be within application
             // memory before storing the values in the saved slice.
             let old_allow =
                 unsafe { ReadWriteProcessBuffer::new(saved.ptr, saved.len, process.processid()) };
@@ -1152,8 +1114,7 @@ impl<'a, T: Default, Upcalls: UpcallSize, AllowROs: AllowRoSize, AllowRWs: Allow
                     // all memory so it is valid in the future to read as a
                     // reference.
                     //
-                    // # Safety
-                    //
+                    // SAFETY:
                     // - The grant base pointer is well aligned, yet does not
                     //   have initialized data.
                     // - The pointer points to a large enough space to correctly
@@ -1172,9 +1133,7 @@ impl<'a, T: Default, Upcalls: UpcallSize, AllowROs: AllowRoSize, AllowRWs: Allow
                         );
                     }
 
-                    // # Safety
-                    //
-                    // The grant pointer points to an alloc that is alloc_size
+                    // SAFETY: The grant pointer points to an alloc that is alloc_size
                     // large and is at least as aligned as grant_t_align.
                     unsafe {
                         Ok((
@@ -1214,9 +1173,7 @@ impl<'a, T: Default, Upcalls: UpcallSize, AllowROs: AllowRoSize, AllowRWs: Allow
         if let Some(allocated_ptr) = opt_raw_grant_ptr_nn {
             // Grant type T
             //
-            // # Safety
-            //
-            // This is safe because:
+            // SAFETY: This is safe because:
             //
             // 1. The pointer address is valid. The pointer is allocated
             //    statically in process memory, and will exist for as long
@@ -1490,17 +1447,14 @@ impl<'a, T: Default, Upcalls: UpcallSize, AllowROs: AllowRoSize, AllowRWs: Allow
 
         // Parse layout of entire grant allocation using the known base pointer.
         //
-        // # Safety
-        //
-        // Grant pointer is well aligned and points to initialized data.
+        // SAFETY: Grant pointer is well aligned and points to initialized data.
         let layout = unsafe {
             EnteredGrantKernelManagedLayout::read_from_base(grant_ptr, self.process, self.grant_num)
         };
 
         // Get references to all of the saved upcall data.
         //
-        // # Safety
-        //
+        // SAFETY:
         // - Pointer is well aligned and initialized with data from Self::new()
         //   call.
         // - Data will not be modified externally while this immutable reference
@@ -1602,9 +1556,7 @@ impl<T> CustomGrant<T> {
                 let grant_ptr: *mut u8 = process.enter_custom_grant(self.identifier)?;
                 let grant_ptr: *mut T = grant_ptr.cast();
 
-                // # Safety
-                //
-                // `grant_ptr` must be a valid pointer and there must not exist
+                // SAFETY: `grant_ptr` must be a valid pointer and there must not exist
                 // any other references to the same memory. We verify the
                 // pointer is valid and aligned when the memory is allocated and
                 // `CustomGrant` is created. We are sure that there are no
@@ -1646,9 +1598,7 @@ impl GrantRegionAllocator {
     {
         let (custom_grant_identifier, typed_ptr) = self.alloc_raw::<T>()?;
 
-        // # Safety
-        //
-        // Writing to this pointer is safe as long as the pointer is valid
+        // SAFETY: Writing to this pointer is safe as long as the pointer is valid
         // and aligned. `alloc_raw()` guarantees these constraints are met.
         unsafe {
             // We use `ptr::write` to avoid `Drop`ping the uninitialized memory
@@ -1679,9 +1629,7 @@ impl GrantRegionAllocator {
         let (custom_grant_identifier, typed_ptr) = self.alloc_n_raw::<T>(NUM_ITEMS)?;
 
         for i in 0..NUM_ITEMS {
-            // # Safety
-            //
-            // The allocate function guarantees that `ptr` points to memory
+            // SAFETY: The allocate function guarantees that `ptr` points to memory
             // large enough to allocate `num_items` copies of the object.
             unsafe {
                 write(typed_ptr.as_ptr().add(i), init(i));

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -554,9 +554,7 @@ impl Kernel {
                     // inaccessible to kernel mode if memory protection is
                     // active.
                     //
-                    // # Safety
-                    //
-                    // This function is unsafe, as calling it before switching
+                    // SAFETY: This function is unsafe, as calling it before switching
                     // to a process, without first re-enabling memory
                     // protection, could allow an application to access
                     // kernel-private memory. Invoking this function is safe
@@ -824,9 +822,7 @@ impl Kernel {
                         // Set the "did I trigger upcalls" flag.
                         // If address is invalid does nothing.
                         //
-                        // # Safety
-                        //
-                        // This is fine as long as no references to the
+                        // SAFETY: This is fine as long as no references to the
                         // process's memory exist. We do not have a reference,
                         // so we can safely call `set_byte()`.
                         unsafe {

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -888,16 +888,14 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
 
     fn setup_mpu(&self) {
         self.mpu_config.map(|config| {
-            // # Safety
-            //
-            // `configure_mpu` is unsafe, as invoking it with an incorrect
+            // SAFETY: `configure_mpu` is unsafe, as invoking it with an incorrect
             // configuration can allow an untrusted application to access
             // kernel-private memory.
             //
             // This call is safe given we trust that the implementation of
             // `ProcessStandard` correctly provisions a set of MPU regions that
             // does not grant access to any kernel-private memory, and
-            // `ProcessStandard` does not provide safe, publically accessible
+            // `ProcessStandard` does not provide safe, publicly accessible
             // APIs to add other arbitrary MPU regions to this configuration.
             unsafe {
                 self.chip.mpu().configure_mpu(config);
@@ -983,16 +981,14 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
                 let old_break: *const u8 = self.app_break.get();
                 self.app_break.set(new_break);
 
-                // # Safety
-                //
-                // `configure_mpu` is unsafe, as invoking it with an incorrect
+                // SAFETY: `configure_mpu` is unsafe, as invoking it with an incorrect
                 // configuration can allow an untrusted application to access
                 // kernel-private memory.
                 //
                 // This call is safe given we trust that the implementation of
                 // `ProcessStandard` correctly provisions a set of MPU regions
                 // that does not grant access to any kernel-private memory, and
-                // `ProcessStandard` does not provide safe, publically
+                // `ProcessStandard` does not provide safe, publicly
                 // accessible APIs to add other arbitrary MPU regions to this
                 // configuration.
                 unsafe {
@@ -1026,8 +1022,7 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
 
                 let base = self.mem_start() as usize;
                 let old_break_unit_ptr: *const () = old_break.cast();
-                // # Safety
-                // The passed range [base, new_break) exactly matches the process' memory range,
+                // SAFETY: The passed range [base, new_break) exactly matches the process' memory range,
                 // and a process should have RW access to its own memory.
                 let break_result = unsafe {
                     CapabilityPtr::new_with_authority(
@@ -1069,9 +1064,7 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
             // It should be fine to ignore the lint here, as a buffer of length
             // 0 will never allow dereferencing any memory in a safe manner.
             //
-            // ### Safety
-            //
-            // We specify a zero-length buffer, so the implementation of
+            // SAFETY: We specify a zero-length buffer, so the implementation of
             // `ReadWriteProcessBuffer` will handle any safety issues.
             // Therefore, we can encapsulate the unsafe.
             Ok(unsafe { ReadWriteProcessBuffer::new(buf_start_addr, 0, self.processid()) })
@@ -1098,9 +1091,7 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
             // constraints of the Rust references created by
             // `ReadWriteProcessBuffer`.
             //
-            // ### Safety
-            //
-            // We encapsulate the unsafe here on the condition in the TODO
+            // SAFETY: We encapsulate the unsafe here on the condition in the TODO
             // above, as we must ensure that this `ReadWriteProcessBuffer` will
             // be the only reference to this memory.
             Ok(unsafe { ReadWriteProcessBuffer::new(buf_start_addr, size, self.processid()) })
@@ -1135,9 +1126,7 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
             // It should be fine to ignore the lint here, as a buffer of length
             // 0 will never allow dereferencing any memory in a safe manner.
             //
-            // ### Safety
-            //
-            // We specify a zero-length buffer, so the implementation of
+            // SAFETY: We specify a zero-length buffer, so the implementation of
             // `ReadOnlyProcessBuffer` will handle any safety issues. Therefore,
             // we can encapsulate the unsafe.
             Ok(unsafe { ReadOnlyProcessBuffer::new(buf_start_addr, 0, self.processid()) })
@@ -1169,9 +1158,7 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
             // alignment and other constraints of the Rust references created by
             // `ReadWriteProcessBuffer`.
             //
-            // ### Safety
-            //
-            // We encapsulate the unsafe here on the condition in the TODO
+            // SAFETY: We encapsulate the unsafe here on the condition in the TODO
             // above, as we must ensure that this `ReadOnlyProcessBuffer` will
             // be the only reference to this memory.
             Ok(unsafe { ReadOnlyProcessBuffer::new(buf_start_addr, size, self.processid()) })
@@ -1182,9 +1169,7 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
 
     unsafe fn set_byte(&self, addr: *mut u8, value: u8) -> bool {
         if self.in_app_owned_memory(addr, 1) {
-            // # Safety
-            //
-            // We verify that this will only write process-accessible memory,
+            // SAFETY: We verify that this will only write process-accessible memory,
             // but this can still be undefined behavior if something else holds
             // a reference to this memory. The caller must ensure nothing else
             // holds a reference to this memory.
@@ -1873,9 +1858,7 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
                     // it more cleanly would be good but was a bit beyond my borrow ken;
                     // calling get_mut has a mutable borrow.-pal
                     //
-                    // # Safety
-                    //
-                    // `diff` must be within the `remaining_memory` slice. Because we
+                    // SAFETY: `diff` must be within the `remaining_memory` slice. Because we
                     // check that `diff` is less than the length of `remaining_memory`
                     // we know diff will be within  `remaining_memory`.
                     let (_, sliced) = unsafe { raw_slice_split_at_mut(remaining_memory, diff) };
@@ -2010,18 +1993,14 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
         // 2. `unused_memory`: the rest of the `remaining_memory`, not assigned
         //    to this app.
         //
-        // # Safety
-        //
-        // `app_memory_start_offset + allocation_size` must be within `remaining_memory`.
+        // SAFETY: `app_memory_start_offset + allocation_size` must be within `remaining_memory`.
         let (allocated_padded_memory, unused_memory) = unsafe {
             raw_slice_split_at_mut(remaining_memory, app_memory_start_offset + allocation_size)
         };
 
         // Now, slice off the (optional) padding at the start:
         //
-        // # Safety
-        //
-        // `app_memory_start_offset` must be within `allocated_padded_memory`.
+        // SAFETY: `app_memory_start_offset` must be within `allocated_padded_memory`.
         let (_padding, allocated_memory) =
             unsafe { raw_slice_split_at_mut(allocated_padded_memory, app_memory_start_offset) };
 
@@ -2033,9 +2012,7 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
 
         // Slice off the process-accessible memory:
         //
-        // # Safety
-        //
-        // `min_process_memory_size` must be within `allocated_memory`.
+        // SAFETY: `min_process_memory_size` must be within `allocated_memory`.
         let (app_accessible_memory, allocated_kernel_memory) =
             unsafe { raw_slice_split_at_mut(allocated_memory, min_process_memory_size) };
 
@@ -2050,9 +2027,7 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
         //    references into this process-accessible memory region through the
         //    process buffer infrastructure.
         let app_accessible_memory_bytes: *mut u8 = app_accessible_memory.cast();
-        // # Safety
-        //
-        // `app_accessible_memory_bytes` is from a slice, and we use that
+        // SAFETY: `app_accessible_memory_bytes` is from a slice, and we use that
         // slice's length, so we know that there is enough memory and that the
         // pointer is aligned.
         unsafe {
@@ -2066,9 +2041,7 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
 
         // Set the initial process-accessible memory.
         //
-        // # Safety
-        //
-        // By using the slice `app_accessible_memory` and getting a pointer to
+        // SAFETY: By using the slice `app_accessible_memory` and getting a pointer to
         // the byte after the slice, we are ensured that the memory between the
         // start of the allocation and the new pointer (at the end of the slice)
         // is valid because of the existing slice.
@@ -2113,9 +2086,7 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
             kernel_memory_break.cast();
         // Get a reference to the slice of `GrantPointerEntry`s.
         //
-        // # Safety
-        //
-        // This is safe, as `grant_pointers_memory_location` is aligned to a
+        // SAFETY: This is safe, as `grant_pointers_memory_location` is aligned to a
         // `GrantPointerEntry`, and we ensured there is space for
         // `grant_ptrs_num` of `GrantPointerEntry`s allocated.
         let grant_pointers_uninit: &mut [MaybeUninit<GrantPointerEntry>] =
@@ -2127,9 +2098,7 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
                 grant_ptr: core::ptr::null_mut(),
             });
         }
-        // # Safety
-        //
-        // All values in this slice have been properly initialized.
+        // SAFETY: All values in this slice have been properly initialized.
         let grant_pointers = unsafe { maybe_uninit_slice_assume_init_mut(grant_pointers_uninit) };
 
         ////////////////////////
@@ -2151,9 +2120,7 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
 
         // Get a reference `&mut [Task; Self:CALLBACK_LEN]`
         //
-        // # Safety
-        //
-        // This needs to be aligned and have allocated space for
+        // SAFETY: This needs to be aligned and have allocated space for
         // `Self::CALLBACK_LEN` instances of `Task`. We ensured there is enough
         // space when we allocated `allocated_kernel_memory` and we moved
         // kernel_memory_break up to fit the callbacks. We ensured this is
@@ -2186,9 +2153,7 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
         // just transforming a pointer into a structure. Because the
         // `ProcessStandard` is not initialized we mark it with `MaybeUninit`.
         //
-        // # Safety
-        //
-        // This must have sufficient allocated space and proper alignment. When
+        // SAFETY: This must have sufficient allocated space and proper alignment. When
         // we sized `allocated_kernel_memory` we ensured there was room for the
         // entire `ProcessStandard` struct. We also allocated space for
         // potential alignment issues, and ensured `kernel_memory_break` was
@@ -2198,9 +2163,7 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
 
         // Initialize ALL fields of `ProcessStandard`.
         //
-        // # Safety
-        //
-        // These need to be valid and aligned writes. When we create the `MaybeUnint`
+        // SAFETY: These need to be valid and aligned writes. When we create the `MaybeUnint`
         // ProcessStandard struct we ensure there is valid memory for the object and
         // that it is aligned.
         unsafe {
@@ -2252,9 +2215,7 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
         // Convert the originally uninitialized `ProcessStandard` to a proper
         // `ProcessStandard` struct reference.
         //
-        // # Safety
-        //
-        // All fields in `ProcessStandard` must be initialized. We guaranteed
+        // SAFETY: All fields in `ProcessStandard` must be initialized. We guaranteed
         // this by using the `init_uninit_struct!()` macro, which causes a
         // compiler error if there is a missing field.
         let process = unsafe { process_uninit.assume_init_mut() };
@@ -2272,9 +2233,7 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
 
         // Handle any architecture-specific requirements for a new process.
         match process.stored_state.map(|stored_state| {
-            // # Safety
-            //
-            // NOTE! We have to ensure that the start of process-accessible memory
+            // SAFETY: NOTE! We have to ensure that the start of process-accessible memory
             // (`app_memory_start`) is word-aligned. Since we currently start
             // process-accessible memory at the beginning of the allocated memory
             // region, we trust the MPU to give us a word-aligned starting address.
@@ -2318,9 +2277,7 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
         // all of a user's code, with permissions to execute it. The entirety of
         // flash is sufficient.
         //
-        // # Safety
-        //
-        // TODO? I don't understand the `new_with_authority()` safety block as
+        // SAFETY: TODO? I don't understand the `new_with_authority()` safety block as
         // it doesn't define what the caller must do.
         let init_fn = unsafe {
             CapabilityPtr::new_with_authority(
@@ -2617,9 +2574,7 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
                 // We need `grant_ptr` as a mutable pointer.
                 let grant_ptr: *mut u8 = new_break.cast_mut();
 
-                // ### Safety
-                //
-                // Here we are guaranteeing that `grant_ptr` is not null. We can
+                // SAFETY: Here we are guaranteeing that `grant_ptr` is not null. We can
                 // ensure this because we just created `grant_ptr` based on the
                 // process's allocated memory, and we know it cannot be null.
                 unsafe { Some(NonNull::new_unchecked(grant_ptr)) }

--- a/kernel/src/processbuffer.rs
+++ b/kernel/src/processbuffer.rs
@@ -67,9 +67,7 @@ unsafe fn raw_processbuf_to_roprocessslice<'a>(
     // Transmute a slice reference over readable (read-only or read-write, and
     // potentially aliased) bytes into a `ReadableProcessSlice` reference.
     //
-    // # Safety
-    //
-    // This is sound, as `ReadableProcessSlice` is merely a
+    // SAFETY: This is sound, as `ReadableProcessSlice` is merely a
     // `#[repr(transparent)]` wrapper around `[ReadableProcessByte]`. However,
     // we cannot build this struct safely from an intermediate
     // `[ReadableProcessByte]` slice reference, as we cannot dereference this
@@ -138,9 +136,7 @@ unsafe fn raw_processbuf_to_rwprocessslice<'a>(
     // Transmute a slice reference over writeable and potentially aliased bytes
     // into a `WriteableProcessSlice` reference.
     //
-    // # Safety
-    //
-    // This is sound, as `WriteableProcessSlice` is merely a
+    // SAFETY: This is sound, as `WriteableProcessSlice` is merely a
     // `#[repr(transparent)]` wrapper around `[Cell<u8>]`. However, we cannot
     // build this struct safely from an intermediate `[WriteableProcessByte]`
     // slice reference, as we cannot dereference this unsized type.
@@ -395,9 +391,7 @@ impl ReadOnlyProcessBuffer {
         process_id: ProcessId,
         _cap: &dyn capabilities::ExternalProcessCapability,
     ) -> Self {
-        // # Safety
-        //
-        // See function description.
+        // SAFETY: See function description.
         unsafe { Self::new(ptr, len, process_id) }
     }
 
@@ -443,7 +437,7 @@ unsafe impl ReadableProcessBuffer for ReadOnlyProcessBuffer {
             Some(pid) => pid
                 .kernel
                 .process_map_or(Err(process::Error::NoSuchApp), pid, |_| {
-                    // Safety: `kernel.process_map_or()` validates that
+                    // SAFETY: `kernel.process_map_or()` validates that
                     // the process still exists and its memory is still
                     // valid. In particular, `Process` tracks the "high water
                     // mark" of memory that the process has `allow`ed to the
@@ -495,9 +489,7 @@ impl ReadOnlyProcessBufferRef<'_> {
     /// help enforce the invariant that this incoming pointer may only
     /// be access for a certain duration.
     pub(crate) unsafe fn new(ptr: *const u8, len: usize, process_id: ProcessId) -> Self {
-        // # Safety
-        //
-        // See function description.
+        // SAFETY: See function description.
         unsafe {
             Self {
                 buf: ReadOnlyProcessBuffer::new(ptr, len, process_id),
@@ -589,9 +581,7 @@ impl ReadWriteProcessBuffer {
         process_id: ProcessId,
         _cap: &dyn capabilities::ExternalProcessCapability,
     ) -> Self {
-        // # Safety
-        //
-        // See function description.
+        // SAFETY: See function description.
         unsafe { Self::new(ptr, len, process_id) }
     }
 
@@ -658,7 +648,7 @@ unsafe impl ReadableProcessBuffer for ReadWriteProcessBuffer {
             Some(pid) => pid
                 .kernel
                 .process_map_or(Err(process::Error::NoSuchApp), pid, |_| {
-                    // Safety: `kernel.process_map_or()` validates that
+                    // SAFETY: `kernel.process_map_or()` validates that
                     // the process still exists and its memory is still
                     // valid. In particular, `Process` tracks the "high water
                     // mark" of memory that the process has `allow`ed to the
@@ -692,7 +682,7 @@ unsafe impl WriteableProcessBuffer for ReadWriteProcessBuffer {
             Some(pid) => pid
                 .kernel
                 .process_map_or(Err(process::Error::NoSuchApp), pid, |_| {
-                    // Safety: `kernel.process_map_or()` validates that
+                    // SAFETY: `kernel.process_map_or()` validates that
                     // the process still exists and its memory is still
                     // valid. In particular, `Process` tracks the "high water
                     // mark" of memory that the process has `allow`ed to the
@@ -740,9 +730,7 @@ impl ReadWriteProcessBufferRef<'_> {
     /// help enforce the invariant that this incoming pointer may only
     /// be access for a certain duration.
     pub(crate) unsafe fn new(ptr: *mut u8, len: usize, process_id: ProcessId) -> Self {
-        // # Safety
-        //
-        // See function description.
+        // SAFETY: See function description.
         unsafe {
             Self {
                 buf: ReadWriteProcessBuffer::new(ptr, len, process_id),
@@ -855,9 +843,7 @@ fn cast_byte_slice_to_process_slice(byte_slice: &[ReadableProcessByte]) -> &Read
 // to be authored once and accept either [u8] or ReadableProcessSlice.
 impl<'a> From<&'a [u8]> for &'a ReadableProcessSlice {
     fn from(val: &'a [u8]) -> Self {
-        // # Safety
-        //
-        // The layout of a [u8] and ReadableProcessSlice are guaranteed to be
+        // SAFETY: The layout of a [u8] and ReadableProcessSlice are guaranteed to be
         // the same. This also extends the lifetime of the buffer, so aliasing
         // rules are thus maintained properly.
         unsafe { core::mem::transmute(val) }
@@ -869,9 +855,7 @@ impl<'a> From<&'a [u8]> for &'a ReadableProcessSlice {
 // ReadableProcessSlice.
 impl<'a> From<&'a mut [u8]> for &'a ReadableProcessSlice {
     fn from(val: &'a mut [u8]) -> Self {
-        // # Safety
-        //
-        // The layout of a [u8] and ReadableProcessSlice are guaranteed to be
+        // SAFETY: The layout of a [u8] and ReadableProcessSlice are guaranteed to be
         // the same. This also extends the mutable lifetime of the buffer, so
         // aliasing rules are thus maintained properly.
         unsafe { core::mem::transmute(val) }
@@ -1047,9 +1031,7 @@ pub struct WriteableProcessSlice {
 }
 
 fn cast_cell_slice_to_process_slice(cell_slice: &[Cell<u8>]) -> &WriteableProcessSlice {
-    // # Safety
-    //
-    // As WriteableProcessSlice is a transparent wrapper around its inner type,
+    // SAFETY: As WriteableProcessSlice is a transparent wrapper around its inner type,
     // [Cell<u8>], we can safely transmute a reference to the inner type as the
     // outer type with the same lifetime.
     unsafe { core::mem::transmute(cell_slice) }
@@ -1060,9 +1042,7 @@ fn cast_cell_slice_to_process_slice(cell_slice: &[Cell<u8>]) -> &WriteableProces
 // WriteableProcessSlice.
 impl<'a> From<&'a mut [u8]> for &'a WriteableProcessSlice {
     fn from(val: &'a mut [u8]) -> Self {
-        // # Safety
-        //
-        // The layout of a [u8] and WriteableProcessSlice are guaranteed to be
+        // SAFETY: The layout of a [u8] and WriteableProcessSlice are guaranteed to be
         // the same. This also extends the mutable lifetime of the buffer, so
         // aliasing rules are thus maintained properly.
         unsafe { core::mem::transmute(val) }

--- a/kernel/src/utilities/arch_helpers.rs
+++ b/kernel/src/utilities/arch_helpers.rs
@@ -533,9 +533,7 @@ pub unsafe fn encode_upcall_trd104_ptr(
     a2: *mut u32,
     a3: *mut u32,
 ) {
-    // # Safety
-    //
-    // All safety invariants must be upheld by the function caller.
+    // SAFETY: All safety invariants must be upheld by the function caller.
     unsafe {
         core::ptr::write(a0, upcall.argument0 as u32);
         core::ptr::write(a1, upcall.argument1 as u32);

--- a/kernel/src/utilities/dma_slice.rs
+++ b/kernel/src/utilities/dma_slice.rs
@@ -222,9 +222,7 @@ pub struct DmaSliceMut<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes>
 impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSliceMut<'a, T> {
     /// Create a [`DmaSliceMut`] from a static mutable slice.
     pub fn new_static(slice: &'static mut [T], fence: impl DmaFence) -> DmaSliceMut<'static, T> {
-        // # Safety
-        //
-        // This operation is safe, as dropping or forgetting its return value is
+        // SAFETY: This operation is safe, as dropping or forgetting its return value is
         // safe. This would merely leak memory and make the underlying slice
         // inaccessible.
         unsafe { Self::new(slice, fence) }
@@ -337,9 +335,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSliceMutImmut<
     /// Even though this method takes a unique, mutable Rust slice, DMA
     /// operations must not modify the buffers contents.
     pub fn new_mut(slice: &mut [T], fence: impl DmaFence) -> DmaSliceMutImmut<'_, T> {
-        // # Safety
-        //
-        // `DmaSliceMut::from_mut_slice_ref` is unsafe, as dropping its return
+        // SAFETY: `DmaSliceMut::from_mut_slice_ref` is unsafe, as dropping its return
         // value without calling `take` may make the underlying buffer
         // accessible as a Rust slice, potentially before the DMA operation is
         // complete, and without using `fence.acquire` to make DMA writes
@@ -378,21 +374,21 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSliceMutImmut<
     pub fn get(&self) -> &'a [T] {
         match self {
             DmaSliceMutImmut::Immutable(dma_slice) => dma_slice.get(),
-            DmaSliceMutImmut::Mutable(dma_slice_mut) => unsafe {
-                // # Safety
-                //
-                // Over the duration that [`DmaSliceMutImmut`] the user
+            DmaSliceMutImmut::Mutable(dma_slice_mut) => {
+                // SAFETY: Over the duration that [`DmaSliceMutImmut`] the user
                 // guarantees that no DMA operation modifies the buffer (and
                 // doing so would require an MMIO write, which is itself
                 // unsafe). The `dma_slice_mut` is capturing a unique, mutable
                 // borrow of the underlying slice over its lifetime `'a`. As
                 // such, we can safely hand out immutable references over this
                 // slice, which are also bound to the lifetime `'a`.
-                core::slice::from_raw_parts(
-                    dma_slice_mut.as_mut_ptr().cast_const(),
-                    dma_slice_mut.len(),
-                )
-            },
+                unsafe {
+                    core::slice::from_raw_parts(
+                        dma_slice_mut.as_mut_ptr().cast_const(),
+                        dma_slice_mut.len(),
+                    )
+                }
+            }
         }
     }
 }
@@ -533,9 +529,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMut<'a
         sub_slice: SubSliceMut<'static, T>,
         fence: impl DmaFence,
     ) -> DmaSubSliceMut<'static, T> {
-        // # Safety
-        //
-        // This operation is safe, as dropping or forgetting its return value is
+        // SAFETY: This operation is safe, as dropping or forgetting its return value is
         // safe. This would merely leak memory and make the underlying slice
         // inaccessible.
         unsafe { Self::new(sub_slice, fence) }
@@ -688,10 +682,8 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMutImm
             SubSliceMutImmut::Immutable(sub_slice) => {
                 DmaSubSliceMutImmut::Immutable(DmaSubSlice::new(sub_slice, fence))
             }
-            SubSliceMutImmut::Mutable(sub_slice_mut) => DmaSubSliceMutImmut::Mutable(unsafe {
-                // # Safety
-                //
-                // `DmaSubSliceMut::new` is unsafe, as dropping its return value
+            SubSliceMutImmut::Mutable(sub_slice_mut) => DmaSubSliceMutImmut::Mutable(
+                // SAFETY: `DmaSubSliceMut::new` is unsafe, as dropping its return value
                 // without calling `take` may make the underlying buffer
                 // accessible as a Rust slice, potentially before the DMA
                 // operation is complete, and without using `fence.acquire` to
@@ -699,8 +691,8 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMutImm
                 // not permit DMA operations which write to the slice, and hence
                 // it can be safely dropped without risk of concurrent
                 // modifications or incoherence.
-                DmaSubSliceMut::new(sub_slice_mut, fence)
-            }),
+                unsafe { DmaSubSliceMut::new(sub_slice_mut, fence) },
+            ),
         }
     }
 
@@ -742,16 +734,14 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMutImm
             DmaSubSliceMutImmut::Immutable(dma_sub_slice) => {
                 SubSliceMutImmut::Immutable(dma_sub_slice.as_sub_slice())
             }
-            DmaSubSliceMutImmut::Mutable(dma_sub_slice_mut) => SubSliceMutImmut::Mutable(unsafe {
-                // # Safety
-                //
-                // The user guarantees that there has not been any DMA operation
+            DmaSubSliceMutImmut::Mutable(dma_sub_slice_mut) => SubSliceMutImmut::Mutable(
+                // SAFETY: The user guarantees that there has not been any DMA operation
                 // that changed the buffers contents while the
                 // `DmaSubSliceMutImmut` existed, and hence restoring a unique
                 // Rust slice through `take` is safe. No acquire-fence is
                 // needed, given the bufer contents have not been modified.
-                dma_sub_slice_mut.take_no_acquire()
-            }),
+                unsafe { dma_sub_slice_mut.take_no_acquire() },
+            ),
         }
     }
 }

--- a/kernel/src/utilities/single_thread_value.rs
+++ b/kernel/src/utilities/single_thread_value.rs
@@ -201,9 +201,7 @@ pub struct SingleThreadValue<T> {
 
 /// Mark that [`SingleThreadValue`] is [`Sync`] to enable multiple accesses.
 ///
-/// # Safety
-///
-/// This is safe because [`SingleThreadValue`] enforces that the shared value
+/// SAFETY: This is safe because [`SingleThreadValue`] enforces that the shared value
 /// is only ever accessed from the same thread it originated from.
 unsafe impl<T> Sync for SingleThreadValue<T> {}
 
@@ -279,9 +277,7 @@ impl<T> SingleThreadValue<T> {
         // the currently running thread ID.
         let ptr_thread_id_and_fn = self.thread_id_and_fn.get();
 
-        // # Safety
-        //
-        // We must ensure that there are no (mutable) aliases or concurrent
+        // SAFETY: We must ensure that there are no (mutable) aliases or concurrent
         // reads or writes of the thread_id_and_fn value.
         //
         // This value is accessed in three functions: `bind_to_thread_unsafe`,
@@ -335,9 +331,7 @@ impl<T> SingleThreadValue<T> {
         // running) thread that we are binding the `SingleThreadValue` to. This
         // avoids a requirement of `T: Send`.
         //
-        // # Safety
-        //
-        // We are the only thread with access to `self.value` going forward, and
+        // SAFETY: We are the only thread with access to `self.value` going forward, and
         // this is the first time that this value is being accessed (as we're
         // initializing it). Therefore, we can safely dereference a mutable
         // (unique) pointer to this value:
@@ -397,9 +391,7 @@ impl<T> SingleThreadValue<T> {
         // query the currently running thread ID.
         let ptr_thread_id_and_fn = self.thread_id_and_fn.get();
 
-        // # Safety
-        //
-        // We must ensure that there are no (mutable) aliases or concurrent
+        // SAFETY: We must ensure that there are no (mutable) aliases or concurrent
         // reads or writes of the `thread_id_and_fn` value.
         //
         // This value is accessed in three functions: `bind_to_thread`,
@@ -436,9 +428,7 @@ impl<T> SingleThreadValue<T> {
         // running) thread that we are binding the `SingleThreadValue` to. This
         // avoids a requirement of `T: Send`.
         //
-        // # Safety
-        //
-        // We are the only thread with access to `self.value` going forward, and
+        // SAFETY: We are the only thread with access to `self.value` going forward, and
         // this is the first time that this value is being accessed (as we're
         // initializing it). Therefore, we can safely dereference a mutable
         // (unique) pointer to this value:
@@ -485,9 +475,9 @@ impl<T> SingleThreadValue<T> {
         let ptr_thread_id_and_fn: *mut MaybeUninit<(fn() -> usize, usize)> =
             self.thread_id_and_fn.get();
 
-        // # Safety
-        //
-        // We must ensure that there are no (mutable) aliases or concurrent
+        let maybe_thread_id_and_fn: *const MaybeUninit<(fn() -> usize, usize)> =
+            ptr_thread_id_and_fn.cast_const();
+        // SAFETY: We must ensure that there are no (mutable) aliases or concurrent
         // reads or writes of the thread_id_and_fn value.
         //
         // This value is accessed in three functions: `bind_to_thread`,
@@ -525,14 +515,10 @@ impl<T> SingleThreadValue<T> {
         //   have ceased to exist.
         //
         // Thus, this operation is sound.
-        let maybe_thread_id_and_fn: *const MaybeUninit<(fn() -> usize, usize)> =
-            ptr_thread_id_and_fn.cast_const();
         let maybe_thread_id_and_fn: &MaybeUninit<(fn() -> usize, usize)> =
             unsafe { &*maybe_thread_id_and_fn };
 
-        // # Safety
-        //
-        // Both `bind_to_thread` and `bind_to_thread_unsafe` are guaranteed to
+        // SAFETY: Both `bind_to_thread` and `bind_to_thread_unsafe` are guaranteed to
         // have initialized `thread_id_and_fn` *before* setting
         // `bound_to_thread` to `Bound` with `Release` ordering constraints.
         //
@@ -558,9 +544,7 @@ impl<T> SingleThreadValue<T> {
     /// reference to its contained value.
     pub fn get(&self) -> Option<&T> {
         if self.bound_to_current_thread() {
-            // # Safety
-            //
-            // When `self.bound_to_current_thread()` returns true, we know that
+            // SAFETY: When `self.bound_to_current_thread()` returns true, we know that
             // `self.value` is initialized, and that the value belongs to and is
             // accessible to the currently running thread. We can safely
             // construct a reference to it.

--- a/kernel/src/utilities/slice_uninit.rs
+++ b/kernel/src/utilities/slice_uninit.rs
@@ -7,9 +7,7 @@
 /// This is a safe operation, but as of June 2026, there is no safe API in the
 /// standard library to do this. So, we provide our own.
 pub fn mut_slice_as_maybeuninit<T>(buffer: &mut [T]) -> &mut [core::mem::MaybeUninit<T>] {
-    // # Safety
-    //
-    // `MaybeUninit<T>` has the same size and alignment as `T`.
+    // SAFETY: `MaybeUninit<T>` has the same size and alignment as `T`.
     let maybeuninit_buf: &mut [core::mem::MaybeUninit<T>] =
         unsafe { core::slice::from_raw_parts_mut(buffer.as_mut_ptr().cast(), buffer.len()) };
     maybeuninit_buf


### PR DESCRIPTION
### Pull Request Overview

We have a bunch of safety docs in the kernel that are formatted in different ways. This reformats them to match the clippy lint [`clippy::undocumented_unsafe_block`](https://rust-lang.github.io/rust-clippy/master/?search=clippy%3A%3Aundocumented_unsafe_block#undocumented_unsafe_blocks).

That is, comments look like

```rust
fn () {
  // SAFETY: Docs for unsafe code here...
  unsafe {
    ...
  }
}
```

This does not add or change any safety docs. Just formatting.

I am definitely responsible for a lot of the formatting here, so I think it is good to clean this up and be consistent.


### Testing Strategy

```
cargo clippy -p kernel -- -A clippy::all -W clippy::undocumented_unsafe_blocks
```


### TODO or Help Wanted

Nothing


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
