### PR TITLE
libraries: map_cell: add/update safety comments

### DIFF
--- a/libraries/tock-cells/src/map_cell.rs
+++ b/libraries/tock-cells/src/map_cell.rs
@@ -223,24 +223,26 @@ impl<T> MapCell<T> {
     /// # Panics
     /// If debug assertions are enabled, this panics if the `MapCell`'s contents are already borrowed.
     pub fn replace(&self, val: T) -> Option<T> {
-        let was_occupied = self.occupied.get();
         debug_assert_not_borrowed!(self);
-        if was_occupied == MapCellState::Borrowed {
-            return None;
+        let was_occupied = self.occupied.get();
+        match was_occupied {
+            MapCellState::Borrowed => None,
+            MapCellState::Uninit | MapCellState::Init => {
+                self.occupied.set(MapCellState::Init);
+
+                let new_contents = MaybeUninit::new(val);
+                // SAFETY:
+                // - Since `was_occupied` is `Init` or `Uninit`, no `&mut` to the `val`
+                //   exists, meaning it is safe to mutate the `get` pointer.
+                let old_contents_maybe_uninit = unsafe { self.val.get().replace(new_contents) };
+
+                (was_occupied == MapCellState::Init).then(|| {
+                    // SAFETY:
+                    // - If was_occupied is `Init`, `old_contents_maybe_uninit` must be initialized.
+                    unsafe { old_contents_maybe_uninit.assume_init() }
+                })
+            }
         }
-        self.occupied.set(MapCellState::Init);
-
-        let new_contents = MaybeUninit::new(val);
-        // SAFETY:
-        // - Since `was_occupied` is `Init` or `Uninit`, no `&mut` to the `val`
-        //   exists, meaning it is safe to mutate the `get` pointer.
-        let old_contents_maybe_uninit = unsafe { self.val.get().replace(new_contents) };
-
-        (was_occupied == MapCellState::Init).then(|| {
-            // SAFETY:
-            // - If was_occupied is `Init`, `old_contents_maybe_uninit` must be initialized.
-            unsafe { old_contents_maybe_uninit.assume_init() }
-        })
     }
 
     /// Calls `closure` with a `&mut` of the contents of the `MapCell`, if available.

--- a/libraries/tock-cells/src/map_cell.rs
+++ b/libraries/tock-cells/src/map_cell.rs
@@ -233,8 +233,9 @@ impl<T> MapCell<T> {
         // SAFETY:
         // - Since `occupied` is `Init` or `Uninit`, no `&mut` to the `val` exists, meaning it
         //   is safe to mutate the `get` pointer.
-        // - If occupied is `Init`, `maybe_uninit_val` must be initialized.
         let maybe_uninit_val = unsafe { self.val.get().replace(MaybeUninit::new(val)) };
+        // SAFETY:
+        // - If occupied is `Init`, `maybe_uninit_val` must be initialized.
         (occupied == MapCellState::Init).then(|| unsafe { maybe_uninit_val.assume_init() })
     }
 
@@ -288,7 +289,12 @@ impl<T> MapCell<T> {
                 }
             }
             let _reset_to_init = ResetToInit(&self.occupied);
-            unsafe { closure(&mut *self.val.get().cast::<T>()) }
+            let val_ptr_mut: *mut T = self.val.get().cast::<T>();
+            // SAFETY: The pointer points to memory for a `T`. Creating the
+            // reference is only sound if the value is initialized, which we
+            // ensured by checking that the state is `MapCell::Init`.
+            let val_ref_mut = unsafe { &mut *val_ptr_mut };
+            closure(val_ref_mut)
         })
     }
 

--- a/libraries/tock-cells/src/map_cell.rs
+++ b/libraries/tock-cells/src/map_cell.rs
@@ -65,7 +65,7 @@ pub struct MapCell<T> {
     val: UnsafeCell<MaybeUninit<T>>,
 
     // Safety invariants:
-    // - The contents of `val` must be initialized if this is `Init` or `InsideMap`.
+    // - The contents of `val` must be initialized if this is `Init` or `Borrowed`.
     // - It must be sound to mutate `val` behind a shared reference if this is `Uninit` or `Init`.
     //   No outside mutation can occur while a `&mut` to the contents of `val` exist.
     occupied: Cell<MapCellState>,

--- a/libraries/tock-cells/src/map_cell.rs
+++ b/libraries/tock-cells/src/map_cell.rs
@@ -223,20 +223,24 @@ impl<T> MapCell<T> {
     /// # Panics
     /// If debug assertions are enabled, this panics if the `MapCell`'s contents are already borrowed.
     pub fn replace(&self, val: T) -> Option<T> {
-        let occupied = self.occupied.get();
+        let was_occupied = self.occupied.get();
         debug_assert_not_borrowed!(self);
-        if occupied == MapCellState::Borrowed {
+        if was_occupied == MapCellState::Borrowed {
             return None;
         }
         self.occupied.set(MapCellState::Init);
 
+        let new_contents = MaybeUninit::new(val);
         // SAFETY:
-        // - Since `occupied` is `Init` or `Uninit`, no `&mut` to the `val` exists, meaning it
-        //   is safe to mutate the `get` pointer.
-        let maybe_uninit_val = unsafe { self.val.get().replace(MaybeUninit::new(val)) };
-        // SAFETY:
-        // - If occupied is `Init`, `maybe_uninit_val` must be initialized.
-        (occupied == MapCellState::Init).then(|| unsafe { maybe_uninit_val.assume_init() })
+        // - Since `was_occupied` is `Init` or `Uninit`, no `&mut` to the `val`
+        //   exists, meaning it is safe to mutate the `get` pointer.
+        let old_contents_maybe_uninit = unsafe { self.val.get().replace(new_contents) };
+
+        (was_occupied == MapCellState::Init).then(|| {
+            // SAFETY:
+            // - If was_occupied is `Init`, `old_contents_maybe_uninit` must be initialized.
+            unsafe { old_contents_maybe_uninit.assume_init() }
+        })
     }
 
     /// Calls `closure` with a `&mut` of the contents of the `MapCell`, if available.


### PR DESCRIPTION
### Pull Request Overview

This modifies and adds safety comments in map cell. In particular, there are two unsafe blocks which I believe map to two unsafe comments, so I split those comments. Then, I wrote a comment for the unsafe use in `map()`.


### Testing Strategy

Just docs


### TODO or Help Wanted

I believe these are reasonable changes to update the safety docs. Particularly, getting the reference in map is safe because we know the pointer points to a `T` and must be initialized from an earlier if check.


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
