### PR TITLE
libraries: volatile cell: add safety comments

### DIFF
--- a/libraries/tock-cells/src/volatile_cell.rs
+++ b/libraries/tock-cells/src/volatile_cell.rs
@@ -66,6 +66,10 @@ impl<T> VolatileCell<T> {
     where
         T: Copy,
     {
+        // SAFETY:
+        // - `self.value` is valid to read, as it is an allocated Rust type.
+        // - `self.value` is properly aligned as a normal type in an UnsafeCell.
+        // - The `VolatileCell` constructor ensures `self.value` is initialized.
         unsafe { ptr::read_volatile(self.value.get()) }
     }
 
@@ -90,6 +94,9 @@ impl<T> VolatileCell<T> {
     where
         T: Copy,
     {
+        // SAFETY:
+        // - `self.value` is valid to read, as it is an allocated Rust type.
+        // - `self.value` is properly aligned as a normal type in an UnsafeCell.
         unsafe { ptr::write_volatile(self.value.get(), value) }
     }
 }


### PR DESCRIPTION
### Pull Request Overview

Ok...so this one. Unfortunately, to run 

```
cargo clippy -p kernel -- -A clippy::all -W clippy::undocumented_unsafe_blocks
```

we have to address the missing safety docs in libraries/cells first. However, I don't know if `VolatileCell`[ _is_ safe](https://lokathor.github.io/volatile/). Or if it depends on how it is used. But, we have it, so...I tried to document it based on the safety requirements of [read_volatile](https://doc.rust-lang.org/core/ptr/fn.read_volatile.html#safety) and [write_volatile](https://doc.rust-lang.org/core/ptr/fn.write_volatile.html).

It seems pretty straightforward since we are starting with a `T` in an `UnsafeCell`.


### Testing Strategy

Just docs


### TODO or Help Wanted

Any thoughts on if these safety comments are OK?


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
