### PR TITLE
kernel: Deny `clippy::missing_safety_doc` for the kernel crate

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -89,6 +89,9 @@
 //!    this use case. It is likely we will have to create new interfaces as new
 //!    use cases are discovered.
 
+// `clippy::missing_safety_doc`: Our goal is to apply this in all of Tock,
+// but as of September 2026 we are starting with the kernel crate.
+#![deny(clippy::missing_safety_doc)]
 #![warn(unreachable_pub)]
 #![no_std]
 


### PR DESCRIPTION
### Pull Request Overview

We should have safety docs! This starts with the kernel crate. We have a _long_ way to go to make this Tock-wide, but this is a start.


### Testing Strategy

`make clippy`


### TODO or Help Wanted

This needs some other recent PRs to actually pass.

Also, if we enable `check-private-items`, there are a couple more functions we need to document.


### Checklist

- [ ] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [ ] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
