### PR TITLE
clippy: Set config option "check-private-items"

### DIFF
--- a/arch/cortex-m/src/mpu.rs
+++ b/arch/cortex-m/src/mpu.rs
@@ -180,6 +180,7 @@ pub struct CortexMConfig<const NUM_REGIONS: usize> {
 }
 
 /// Records the index of the last region used for application RAM memory.
+///
 /// Regions 0-APP_MEMORY_REGION_MAX_NUM are used for application RAM. Regions
 /// with indices above APP_MEMORY_REGION_MAX_NUM can be used for other MPU
 /// needs.

--- a/arch/cortex-m/src/nvic.rs
+++ b/arch/cortex-m/src/nvic.rs
@@ -122,9 +122,11 @@ register_bitfields![u32,
 const NVIC: StaticRef<NvicRegisters> =
     unsafe { StaticRef::new(0xe000e000 as *const NvicRegisters) };
 
-/// Number of valid NVIC_XXXX registers. Note this is a ceiling on the number
-/// of available interrupts (as this is the number of banks of 32), but the
-/// actual number may be less. See NVIC and ICTR documentation for more detail.
+/// Number of valid NVIC_XXXX registers.
+///
+/// Note this is a ceiling on the number of available interrupts (as this is the
+/// number of banks of 32), but the actual number may be less. See NVIC and ICTR
+/// documentation for more detail.
 fn number_of_nvic_registers() -> usize {
     (NVIC.ictr.read(InterruptControllerType::INTLINESNUM) + 1) as usize
 }

--- a/arch/cortex-m0/src/lib.rs
+++ b/arch/cortex-m0/src/lib.rs
@@ -196,10 +196,9 @@ unsafe extern "C" fn systick_handler() {
 /// The `systick_handler` is called when the systick interrupt occurs, signaling
 /// that an application executed for longer than its timeslice.
 ///
-/// This interrupt
-/// handler is no longer responsible for signaling to the kernel thread that an
-/// interrupt has occurred, but is slightly more efficient than the
-/// `generic_isr` handler on account of not needing to mark the interrupt as
+/// This interrupt handler is no longer responsible for signaling to the kernel
+/// thread that an interrupt has occurred, but is slightly more efficient than
+/// the `generic_isr` handler on account of not needing to mark the interrupt as
 /// pending.
 ///
 /// # Safety

--- a/arch/cortex-m0/src/lib.rs
+++ b/arch/cortex-m0/src/lib.rs
@@ -194,7 +194,9 @@ unsafe extern "C" fn systick_handler() {
 }
 
 /// The `systick_handler` is called when the systick interrupt occurs, signaling
-/// that an application executed for longer than its timeslice. This interrupt
+/// that an application executed for longer than its timeslice.
+///
+/// This interrupt
 /// handler is no longer responsible for signaling to the kernel thread that an
 /// interrupt has occurred, but is slightly more efficient than the
 /// `generic_isr` handler on account of not needing to mark the interrupt as

--- a/arch/cortex-m33/src/mpu_v8m.rs
+++ b/arch/cortex-m33/src/mpu_v8m.rs
@@ -244,6 +244,7 @@ pub struct CortexMConfig<const NUM_REGIONS: usize> {
 }
 
 /// Records the index of the last region used for application RAM memory.
+///
 /// Regions 0-APP_MEMORY_REGION_MAX_NUM are used for application RAM. Regions
 /// with indices above APP_MEMORY_REGION_MAX_NUM can be used for other MPU
 /// needs.

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -118,6 +118,8 @@ impl KernelResources<e310_g002::chip::E310x<'static, E310G002DefaultPeripherals<
     }
 }
 
+/// Load processes in its own function.
+///
 /// For the HiFive1, if load_process is inlined, it leads to really large stack utilization in
 /// main. By wrapping it in a non-inlined function, this reduces the stack utilization once
 /// processes are running.

--- a/boards/imix/src/test/spi_loopback.rs
+++ b/boards/imix/src/test/spi_loopback.rs
@@ -3,7 +3,9 @@
 // Copyright Tock Contributors 2022.
 
 //! A SPI test which read/writes and expects MOSI to
-//! be loopbacked to MISO. It checks that what it writes
+//! be loopbacked to MISO.
+//!
+//! It checks that what it writes
 //! is what it reads. The values put in the buffer are
 //! a circular ring of 8-bit values, starting with an
 //! initial value and incrementing by 1 on each write.

--- a/boards/imix/src/test/spi_loopback.rs
+++ b/boards/imix/src/test/spi_loopback.rs
@@ -2,18 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-//! A SPI test which read/writes and expects MOSI to
-//! be loopbacked to MISO.
+//! A SPI test which read/writes and expects MOSI to be loopbacked to MISO.
 //!
-//! It checks that what it writes
-//! is what it reads. The values put in the buffer are
-//! a circular ring of 8-bit values, starting with an
-//! initial value and incrementing by 1 on each write.
-//! So if the first write is [33, 34, ... , 32],
-//! the next write will be [34, 35, ..., 34]. You can set
-//! the speed of the operation to check that configurations
-//! are being set correctly: running two tests in parallel
-//! with different bit rates should see different clock
+//! It checks that what it writes is what it reads. The values put in the buffer
+//! are a circular ring of 8-bit values, starting with an initial value and
+//! incrementing by 1 on each write. So if the first write is [33, 34, ...,
+//! 32], the next write will be [34, 35, ..., 34]. You can set the speed of the
+//! operation to check that configurations are being set correctly: running two
+//! tests in parallel with different bit rates should see different clock
 //! frequencies.
 
 use capsules_core::virtualizers::virtual_spi::MuxSpiMaster;

--- a/boards/imix/src/test/virtual_aes_ccm_test.rs
+++ b/boards/imix/src/test/virtual_aes_ccm_test.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
+//! Test AES CCM.
+//!
 //! notice that there will be 18 tests, 6 for each,
 //! and the test output will make the debug buffer full,
 //! please go to boards/components/src/debug_writer.rs and change

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -538,16 +538,16 @@ pub unsafe fn start() -> (
         systick: cortexm4::systick::SysTick::new_with_calibration(64000000),
     };
 
-    /// I split this out to be able to start applications with a delay
-    /// after the board is initialized.
-    /// The benefit to debugging is that if I want to print
-    /// some debug information while the board initalizes,
-    /// it won't be affected by an application that prints so much
-    /// that it overflows the output buffer.
-    ///
-    /// It's also useful for a future "fake off" functionality,
-    /// where if a button is pressed, processes are stopped,
-    /// but when pressed again, they are loaded anew.
+    // I split this out to be able to start applications with a delay
+    // after the board is initialized.
+    // The benefit to debugging is that if I want to print
+    // some debug information while the board initializes,
+    // it won't be affected by an application that prints so much
+    // that it overflows the output buffer.
+    //
+    // It's also useful for a future "fake off" functionality,
+    // where if a button is pressed, processes are stopped,
+    // but when pressed again, they are loaded anew.
     fn load_processes(
         board_kernel: &'static kernel::Kernel,
         chip: &'static nrf52840::chip::NRF52<'static, Nrf52840DefaultPeripherals<'static>>,

--- a/capsules/extra/src/cyw4343/bus/mod.rs
+++ b/capsules/extra/src/cyw4343/bus/mod.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright OxidOS Automotive 2025.
 
-//! Common interface for CYW4343x buses. The buses support 3 functions:
+//! Common interface for CYW4343x buses.
+//!
+//! The buses support 3 functions:
 //! F0: Standard bus function. These packets are used to write/read the chip's registers (e.g.
 //! disable overflow interrupts)
 //! F1: Backplane function. These packets are used to access the internal address space (e.g.

--- a/capsules/extra/src/cyw4343/driver.rs
+++ b/capsules/extra/src/cyw4343/driver.rs
@@ -805,6 +805,7 @@ impl<'a, P: hil::gpio::Pin, A: hil::time::Alarm<'a>, B: bus::CYW4343xBus<'a>> bu
 }
 
 /// Configuring a WiFi functionality requires a set of IOCTL commands to be sent to the chip.
+///
 /// This module defines lists of IOCTL operations needed
 /// for each functionality required by the WiFi device interface.
 mod ioctl {

--- a/capsules/extra/src/cyw4343/macros.rs
+++ b/capsules/extra/src/cyw4343/macros.rs
@@ -3,6 +3,7 @@
 // Copyright OxidOS Automotive 2025.
 
 /// Macro for parsing into/from bytes for structs that represent protocol packet headers.
+///
 /// This generates an `impl` block with `into_bytes` and `from_bytes` const methods and an
 /// associated `SIZE` constant for the struct size in bytes.
 ///

--- a/capsules/extra/src/date_time.rs
+++ b/capsules/extra/src/date_time.rs
@@ -158,7 +158,8 @@ fn date_from_u32_tuple(date: u32, time: u32) -> Result<date_time::DateTimeValues
     Ok(date_result)
 }
 
-/// Transforms DateTimeValues structure (year, month, dotm, dotw, hour, minute, seconds) into two u32 numbers
+/// Transforms DateTimeValues structure (year, month, dotm, dotw, hour, minute, seconds) into two u32 numbers.
+///
 /// Check file documentation for details on how the u32 numbers stores data
 /// The two u32 numbers are returned as a tuple
 fn date_as_u32_tuple(set_date: date_time::DateTimeValues) -> Result<(u32, u32), ErrorCode> {

--- a/capsules/extra/src/ieee802154/framer.rs
+++ b/capsules/extra/src/ieee802154/framer.rs
@@ -278,6 +278,7 @@ pub trait DeviceProcedure {
 }
 
 /// This state enum describes the state of the transmission pipeline.
+///
 /// Conditionally-present state is also included as fields in the enum variants.
 /// We can view the transmission process as a state machine driven by the
 /// following events:

--- a/capsules/extra/src/net/ipv6/ipv6.rs
+++ b/capsules/extra/src/net/ipv6/ipv6.rs
@@ -5,36 +5,36 @@
 //! This file contains structs, traits, and methods associated with the IP layer
 //! of the networking stack.
 //!
-//! This includes the declaration and methods for the
-//! IP6Header, IP6Packet, and IP6Payload structs. These methods implement the
-//! bulk of the functionality required for manipulating the fields of the
-//! IPv6 header. Additionally, the IP6Packet struct allows for multiple types
-//! of transport-level structures to be encapsulated within.
+//! This includes the declaration and methods for the IP6Header, IP6Packet, and
+//! IP6Payload structs. These methods implement the bulk of the functionality
+//! required for manipulating the fields of the IPv6 header. Additionally, the
+//! IP6Packet struct allows for multiple types of transport-level structures to
+//! be encapsulated within.
 //!
 //! An implementation for the structure of an IPv6 packet is provided by this
 //! file, and a rough outline is given below:
 //!
 //! ```txt
-//!            ----------------------------------------------
-//!            |                 IP6Packet                  |
-//!            |--------------------------------------------|
-//!            |                 |         IPPayload        |
-//!            |    IP6Header    |--------------------------|
-//!            |                 |TransportHeader | Payload |
-//!            ----------------------------------------------
+//! ----------------------------------------------
+//! |                 IP6Packet                  |
+//! |--------------------------------------------|
+//! |                 |         IPPayload        |
+//! |    IP6Header    |--------------------------|
+//! |                 |TransportHeader | Payload |
+//! ----------------------------------------------
 //! ```
 //!
 //! The [IP6Packet](struct.IP6Packet.html) struct contains an
 //! [IP6Header](struct.IP6Header.html) struct and an
-//! [IPPayload](struct.IPPayload.html) struct, with the `IPPayload` struct
-//! also containing a [TransportHeader](enum.TransportHeader.html) enum and
-//! a `Payload` buffer. Note that transport-level headers are contained inside
-//! the `TransportHeader`.
+//! [IPPayload](struct.IPPayload.html) struct, with the `IPPayload` struct also
+//! containing a [TransportHeader](enum.TransportHeader.html) enum and a
+//! `Payload` buffer. Note that transport-level headers are contained inside the
+//! `TransportHeader`.
 //!
 //! For a client interested in using this interface, they first statically
-//! allocate an `IP6Packet` struct, then set the appropriate headers and
-//! payload using the functions defined for the different structs. These
-//! methods are described in greater detail below.
+//! allocate an `IP6Packet` struct, then set the appropriate headers and payload
+//! using the functions defined for the different structs. These methods are
+//! described in greater detail below.
 
 // Discussion of Design Decisions
 // ------------------------------
@@ -44,7 +44,7 @@
 // for the IPv6 layer was the design of the `IP6Packet` struct. We noticed
 // that the mutable payload buffer should always be associated with some type
 // of headers; that is, we noticed that the payload for an IP packet should
-// be perminantly owned by an instance of an IPv6 packet. This avoids runtime
+// be permanently owned by an instance of an IPv6 packet. This avoids runtime
 // checks, as Rust can guarantee that the payload for an IPv6 packet is always
 // there, as it cannot be moved. In order to facilitate this design while still
 // allowing for (somewhat) arbitrary transport-level headers, we needed to
@@ -61,16 +61,16 @@
 // IPPayload design makes sense and is properly layered, and 2) figuring out
 // and implementing a receive path that uses this encapsulation.
 //
-// One of the primary problems with the current encapsulation design is that
-// it is impossible to encode recursive headers - any subsequent headers (IPv6
-// or transport) must be serialized and carried in the raw payload. This may
-// be avoided with references and allocation, but since we do not have
-// a memory allocator we could not allocate all possible headers at compile
-// time. Additionally, we couldn't just allocate headers "as-needed" on the
-// stack, as the network send interface is asynchronous, so anything allocated
-// on the stack would eventually be popped/disappear. Although this is not
-// a major problem in general, it makes handling encapsulated IPv6 packets
-// (as required by 6LoWPAN) difficult.
+// One of the primary problems with the current encapsulation design is that it
+// is impossible to encode recursive headers - any subsequent headers (IPv6 or
+// transport) must be serialized and carried in the raw payload. This may be
+// avoided with references and allocation, but since we do not have a memory
+// allocator we could not allocate all possible headers at compile time.
+// Additionally, we couldn't just allocate headers "as-needed" on the stack, as
+// the network send interface is asynchronous, so anything allocated on the
+// stack would eventually be popped/disappear. Although this is not a major
+// problem in general, it makes handling encapsulated IPv6 packets (as required
+// by 6LoWPAN) difficult.
 
 use crate::net::icmpv6::ICMP6Header;
 use crate::net::ipv6::ip_utils::{IPAddr, compute_icmp_checksum, compute_udp_checksum, ip6_nh};
@@ -126,12 +126,12 @@ impl IP6Header {
     ///
     /// # Arguments
     ///
-    /// `buf` - The serialized version of an IPv6 header
+    /// - `buf` - The serialized version of an IPv6 header
     ///
     /// # Return Value
     ///
-    /// `SResult<IP6Header>` - The resulting decoded IP6Header struct wrapped
-    /// in an SResult
+    /// - `SResult<IP6Header>` - The resulting decoded IP6Header struct wrapped
+    ///   in an SResult
     pub fn decode(buf: &[u8]) -> SResult<IP6Header> {
         // TODO: Let size of header be a constant
         stream_len_cond!(buf, 40);
@@ -151,17 +151,17 @@ impl IP6Header {
         stream_done!(off, ip6_header);
     }
 
-    /// This function transforms the `self` instance of an IP6Header into a
-    /// byte array
+    /// This function transforms the `self` instance of an IP6Header into a byte
+    /// array
     ///
     /// # Arguments
     ///
-    /// `buf` - A mutable array where the serialized version of the IP6Header
-    /// struct is written to
+    /// - `buf` - A mutable array where the serialized version of the IP6Header
+    ///   struct is written to
     ///
     /// # Return Value
     ///
-    /// `SResult<usize>` - The offset wrapped in an SResult
+    /// - `SResult<usize>` - The offset wrapped in an SResult
     pub fn encode(&self, buf: &mut [u8]) -> SResult<usize> {
         stream_len_cond!(buf, 40);
 
@@ -265,9 +265,9 @@ impl IP6Header {
         self.hop_limit = new_hl;
     }
 
-    /// Utility function for verifying whether a transport layer checksum of a received
-    /// packet is correct. Is called on the assocaite IPv6 Header, and passed the buffer
-    /// containing the remainder of the packet.
+    /// Utility function for verifying whether a transport layer checksum of a
+    /// received packet is correct. Is called on the associated IPv6 Header, and
+    /// passed the buffer containing the remainder of the packet.
     pub fn check_transport_checksum(&self, buf: &[u8]) -> Result<(), ErrorCode> {
         match self.next_header {
             ip6_nh::UDP => {
@@ -310,12 +310,11 @@ impl IP6Header {
 
 /// This defines the currently supported `TransportHeader` types.
 ///
-/// The contents of each header is encapsulated by the enum type. Note
-/// that this definition of `TransportHeader`s means that recursive
-/// headers are not supported.  As of now, there is no support for
-/// sending raw IP packets without a transport header.  Currently we
-/// accept the overhead of copying these structs in/out of an
-/// OptionalCell in `udp_send.rs`.
+/// The contents of each header is encapsulated by the enum type. Note that this
+/// definition of `TransportHeader`s means that recursive headers are not
+/// supported.  As of now, there is no support for sending raw IP packets
+/// without a transport header.  Currently we accept the overhead of copying
+/// these structs in/out of an OptionalCell in `udp_send.rs`.
 #[derive(Copy, Clone)]
 pub enum TransportHeader {
     UDP(UDPHeader),
@@ -335,8 +334,8 @@ impl<'a> IPPayload<'a> {
     ///
     /// # Arguments
     ///
-    /// `header` - A `TransportHeader` for the `IPPayload`
-    /// `payload` - A reference to a mutable buffer for the raw payload
+    /// - `header` - A `TransportHeader` for the `IPPayload`
+    /// - `payload` - A reference to a mutable buffer for the raw payload
     pub fn new(header: TransportHeader, payload: &'a mut [u8]) -> IPPayload<'a> {
         IPPayload { header, payload }
     }
@@ -346,14 +345,14 @@ impl<'a> IPPayload<'a> {
     ///
     /// # Arguments
     ///
-    /// `transport_header` - The new `TransportHeader` header for the payload
-    /// `payload` - The payload to be copied into the `IPPayload`
+    /// - `transport_header` - The new `TransportHeader` header for the payload
+    /// - `payload` - The payload to be copied into the `IPPayload`
     ///
     /// # Return Value
     ///
-    /// `(u8, u16)` - Returns a tuple of the `ip6_nh` type of the
-    /// `transport_header` and the total length of the `IPPayload`
-    /// (when serialized)
+    /// - `(u8, u16)` - Returns a tuple of the `ip6_nh` type of the
+    /// - `transport_header` and the total length of the `IPPayload` (when
+    ///   serialized)
     pub fn set_payload(
         &mut self,
         transport_header: TransportHeader,
@@ -383,13 +382,13 @@ impl<'a> IPPayload<'a> {
     ///
     /// # Arguments
     ///
-    /// `buf` - SubSliceMut to write the serialized `IPPayload` to
-    /// `offset` - Current offset into the buffer
+    /// - `buf` - SubSliceMut to write the serialized `IPPayload` to
+    /// - `offset` - Current offset into the buffer
     ///
     /// # Return Value
     ///
-    /// `SResult<usize>` - The final offset into the buffer `buf` is returned
-    /// wrapped in an SResult
+    /// - `SResult<usize>` - The final offset into the buffer `buf` is returned
+    ///   wrapped in an SResult
     pub fn encode(&self, buf: &mut [u8], offset: usize) -> SResult<usize> {
         let (offset, _) = match self.header {
             TransportHeader::UDP(udp_header) => udp_header.encode(buf, offset).done().unwrap(),
@@ -436,7 +435,7 @@ impl<'a> IP6Packet<'a> {
     ///
     /// # Arguments
     ///
-    /// `payload` - The `IPPayload` struct for the `IP6Packet`
+    /// - `payload` - The `IPPayload` struct for the `IP6Packet`
     pub fn new(payload: IPPayload<'a>) -> IP6Packet<'a> {
         IP6Packet {
             header: IP6Header::default(),
@@ -492,20 +491,21 @@ impl<'a> IP6Packet<'a> {
         }
     }
 
-    /// This function should be the function used to set the payload for a
-    /// given `IP6Packet` object. It first calls the `IPPayload::set_payload`
-    /// method to set the transport header and transport payload, which then
-    /// returns the `ip6_nh` value for the `TransportHeader` and the length of
-    /// the serialized `IPPayload` region. This function then sets the
-    /// `IP6Header` next header field correctly. **Without using this function,
-    /// the `IP6Header.next_header` field may not agree with the actual
-    /// next header (`IP6Header.payload.header`)**
+    /// This function should be the function used to set the payload for a given
+    /// `IP6Packet` object. It first calls the `IPPayload::set_payload` method
+    /// to set the transport header and transport payload, which then returns
+    /// the `ip6_nh` value for the `TransportHeader` and the length of the
+    /// serialized `IPPayload` region. This function then sets the `IP6Header`
+    /// next header field correctly. **Without using this function, the
+    /// `IP6Header.next_header` field may not agree with the actual next header
+    /// (`IP6Header.payload.header`)**
     ///
     /// # Arguments
     ///
-    /// `transport_header` - The `TransportHeader` to be set as the next header
-    /// `payload` - The transport payload to be copied into the `IPPayload`
-    /// transport payload
+    /// - `transport_header` - The `TransportHeader` to be set as the next
+    ///   header
+    /// - `payload` - The transport payload to be copied into the `IPPayload`
+    ///   transport payload
     pub fn set_payload(
         &mut self,
         transport_header: TransportHeader,

--- a/capsules/extra/src/net/ipv6/ipv6.rs
+++ b/capsules/extra/src/net/ipv6/ipv6.rs
@@ -3,7 +3,9 @@
 // Copyright Tock Contributors 2022.
 
 //! This file contains structs, traits, and methods associated with the IP layer
-//! of the networking stack. This includes the declaration and methods for the
+//! of the networking stack.
+//!
+//! This includes the declaration and methods for the
 //! IP6Header, IP6Packet, and IP6Payload structs. These methods implement the
 //! bulk of the functionality required for manipulating the fields of the
 //! IPv6 header. Additionally, the IP6Packet struct allows for multiple types

--- a/capsules/extra/src/net/udp/driver.rs
+++ b/capsules/extra/src/net/udp/driver.rs
@@ -5,10 +5,9 @@
 //! UDP userspace interface for transmit and receive.
 //!
 //! Implements a userspace interface for sending and receiving UDP messages.
-//! Processes use this driver to send UDP packets from a common interface
-//! and bind to UDP ports for receiving packets.
-//! Also exposes a list of interface addresses to the application (currently
-//! hard-coded).
+//! Processes use this driver to send UDP packets from a common interface and
+//! bind to UDP ports for receiving packets. Also exposes a list of interface
+//! addresses to the application (currently hard-coded).
 
 use crate::net::ipv6::ip_utils::IPAddr;
 use crate::net::network_capabilities::NetworkCapability;
@@ -44,10 +43,9 @@ mod upcall {
     pub const PACKET_RECEIVED: usize = 0;
     /// Callback for when packet is transmitted.
     ///
-    /// Notably, this callback receives
-    /// the result of the send_done callback from udp_send.rs, which does not
-    /// currently pass information regarding whether packets were acked at the
-    /// link layer.
+    /// Notably, this callback receives the result of the send_done callback
+    /// from udp_send.rs, which does not currently pass information regarding
+    /// whether packets were acked at the link layer.
     pub const PACKET_TRANSMITTED: usize = 1;
     /// Number of upcalls.
     pub const COUNT: u8 = 2;

--- a/capsules/extra/src/net/udp/driver.rs
+++ b/capsules/extra/src/net/udp/driver.rs
@@ -42,7 +42,9 @@ mod upcall {
     /// `RESERVE` to indicate that port binding is is a prerequisite to
     /// reception.
     pub const PACKET_RECEIVED: usize = 0;
-    /// Callback for when packet is transmitted. Notably, this callback receives
+    /// Callback for when packet is transmitted.
+    ///
+    /// Notably, this callback receives
     /// the result of the send_done callback from udp_send.rs, which does not
     /// currently pass information regarding whether packets were acked at the
     /// link layer.

--- a/capsules/extra/src/net/udp/udp.rs
+++ b/capsules/extra/src/net/udp/udp.rs
@@ -3,6 +3,7 @@
 // Copyright Tock Contributors 2022.
 
 //! This file contains the structs and methods associated with the UDP header.
+//!
 //! This includes getters and setters for the various header fields, as well
 //! as the standard encode/decode functionality required for serializing
 //! the struct for transmission.

--- a/capsules/extra/src/usb/ctap.rs
+++ b/capsules/extra/src/usb/ctap.rs
@@ -41,7 +41,8 @@ pub const MAX_CTRL_PACKET_SIZE: u8 = 64;
 
 const N_ENDPOINTS: usize = 2;
 
-/// The HID report descriptor for CTAP
+/// The HID report descriptor for CTAP.
+///
 /// This is a combination of:
 ///     - the CTAP spec, example 8
 ///     - USB HID spec examples

--- a/capsules/extra/src/usb/ctap.rs
+++ b/capsules/extra/src/usb/ctap.rs
@@ -42,7 +42,8 @@ pub const MAX_CTRL_PACKET_SIZE: u8 = 64;
 
 const N_ENDPOINTS: usize = 2;
 
-/// The HID report descriptor for CTAP
+/// The HID report descriptor for CTAP.
+///
 /// This is a combination of:
 ///     - the CTAP spec, example 8
 ///     - USB HID spec examples

--- a/chips/apollo3/src/flashctrl.rs
+++ b/chips/apollo3/src/flashctrl.rs
@@ -58,6 +58,8 @@ impl AsMut<[u8]> for Apollo3Page {
     }
 }
 
+/// FFI function to read a word from flash.
+///
 /// This function can be used to read / write arbitrary flash memory, and thus
 /// arbitrary program code. As such, they are unsafe operations. We also can't
 /// confirm that the functions are safe in the context of Rust.
@@ -79,6 +81,8 @@ unsafe fn flash_util_read_word(addr: *mut u32) -> u32 {
     flash_util_read_word(addr)
 }
 
+/// FFI function to program multiple words in flash.
+///
 /// This function can be used to read / write arbitrary flash memory, and thus
 /// arbitrary program code. As such, they are unsafe operations. We also can't
 /// confirm that the functions are safe in the context of Rust.
@@ -119,6 +123,8 @@ unsafe fn flash_program_main(
     flash_program_main(program_key, src_addr, dst_addr, num_words)
 }
 
+/// FFI function to erase flash.
+///
 /// This function can be used to read / write arbitrary flash memory, and thus
 /// arbitrary program code. As such, they are unsafe operations. We also can't
 /// confirm that the functions are safe in the context of Rust.

--- a/chips/msp432/src/dma.rs
+++ b/chips/msp432/src/dma.rs
@@ -36,10 +36,12 @@ static DMA_CONFIG: DmaConfigBlock = DmaConfigBlock([
     DmaChannelControl::const_default(),
 ]);
 
+/// Maximum usable DMA trigger sources.
+///
 /// Although there are 8bits reserved for selecting a source for the DMA trigger, the
 /// MSP432P4x family only supports numbers from 1 to 7. 0 doesn't cause an error, but it's
 /// marked as reserved. According to the device-specific datasheet 'reserved' can be used for
-/// transfering data from one location in the RAM to another one.
+/// transferring data from one location in the RAM to another one.
 const MAX_SRC_NR: u8 = 7;
 
 /// The MSP432 chips contain 8 DMA channels
@@ -482,6 +484,8 @@ register_bitfields![u32,
     ]
 ];
 
+/// DMA control structure in memory.
+///
 /// The uDMA of the MSP432 family don't offer own registers where the configuration of the
 /// individual DMA channels is stored, they require a pointer to a block of memory in the RAM
 /// where the actual configuration is stored. Within this block of memory the pointer to the

--- a/chips/nrf52/src/ieee802154_radio.rs
+++ b/chips/nrf52/src/ieee802154_radio.rs
@@ -95,8 +95,9 @@ const SEQ_NUM_LEN: usize = 1;
 pub const ACK_BUF_SIZE: usize =
     radio::SPI_HEADER_SIZE + radio::PHR_SIZE + radio::MHR_FC_SIZE + SEQ_NUM_LEN + radio::MFR_SIZE;
 
-/// Where the 15.4 packet from the radio is stored in the buffer. The HIL
-/// reserves one byte at the beginning of the buffer for use by the
+/// Where the 15.4 packet from the radio is stored in the buffer.
+///
+/// The HIL reserves one byte at the beginning of the buffer for use by the
 /// capsule/hardware. We have no use for this, but the upper layers expect it so
 /// we skip over it.
 // We can't just drop the byte from the buffer because then it would be lost

--- a/chips/nrf52/src/pwm.rs
+++ b/chips/nrf52/src/pwm.rs
@@ -169,6 +169,7 @@ const PWM0_BASE: StaticRef<PwmRegisters> =
     unsafe { StaticRef::new(0x4001C000 as *const PwmRegisters) };
 
 /// `DUTY_CYCLES` is a static array that must be passed to the PWM hardware.
+///
 /// The nRF52 hardware uses this static array in memory to enable switching
 /// between multiple duty cycles automatically while generating the PWM output.
 /// This isn't ideal from a Rust perspective, but the peripheral hardware must

--- a/chips/nrf52/src/pwm.rs
+++ b/chips/nrf52/src/pwm.rs
@@ -168,6 +168,7 @@ const PWM0_BASE: StaticRef<PwmRegisters> =
     unsafe { StaticRef::new(0x4001C000 as *const PwmRegisters) };
 
 /// `DUTY_CYCLES` is a static array that must be passed to the PWM hardware.
+///
 /// The nRF52 hardware uses this static array in memory to enable switching
 /// between multiple duty cycles automatically while generating the PWM output.
 /// This isn't ideal from a Rust perspective, but the peripheral hardware must

--- a/chips/stm32u5xx/src/crc.rs
+++ b/chips/stm32u5xx/src/crc.rs
@@ -35,6 +35,7 @@ pub const CRC_BASE: StaticRef<CrcRegisters> =
     unsafe { StaticRef::new(0x50023000 as *const CrcRegisters) };
 
 /// Byte-width alias into the CRC data register.
+///
 /// The STM32 CRC hardware supports sub-word writes.
 /// Byte-wide writes are required when input length isn't a multiple of 4,
 /// as writing full 32-bit words would pad with extra bytes and corrupt the

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,16 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2026.
+
+# We want our internal API documentation to be as good as our public
+# documentation. Enable `check-private-items` to apply lints from
+# https://rust-lang.github.io/rust-clippy/master/?search=check-private-items to
+# our internal APIs.
+# 
+# As of July 2026, this includes:
+# - clippy::missing_errors_doc (allowed in Tock)
+# - clippy::missing_panics_doc (allowed in Tock)
+# - clippy::missing_safety_doc (allowed in Tock, except kernel)
+# - clippy::unnecessary_safety_doc (denied in Tock)
+# - clippy::too_long_first_doc_paragraph (denied in Tock)
+check-private-items = true

--- a/kernel/src/config.rs
+++ b/kernel/src/config.rs
@@ -83,10 +83,11 @@ pub(crate) struct Config {
 }
 
 /// A unique instance of `Config` where compile-time configuration options are
-/// defined. These options are available in the kernel crate to be used for
-/// relevant configuration. Notably, this is the only location in the Tock
-/// kernel where we permit `#[cfg(x)]` to be used to configure code based on
-/// Cargo features.
+/// defined.
+///
+/// These options are available in the kernel crate to be used for relevant
+/// configuration. Notably, this is the only location in the Tock kernel where
+/// we permit `#[cfg(x)]` to be used to configure code based on Cargo features.
 pub(crate) const CONFIG: Config = Config {
     trace_syscalls: cfg!(feature = "trace_syscalls"),
     debug_load_processes: cfg!(feature = "debug_load_processes"),

--- a/kernel/src/deferred_call.rs
+++ b/kernel/src/deferred_call.rs
@@ -103,9 +103,11 @@ pub trait DeferredCallClient: Sized {
 }
 
 /// This struct serves as a lightweight alternative to the use of trait objects
-/// (e.g. `&dyn DeferredCall`). Using a trait object will include a 20 byte
-/// vtable per instance, but this alternative stores only the data and function
-/// pointers, 8 bytes per instance.
+/// (e.g. `&dyn DeferredCall`).
+///
+/// Using a trait object will include a 20 byte vtable per instance, but this
+/// alternative stores only the data and function pointers, 8 bytes per
+/// instance.
 #[derive(Copy, Clone)]
 struct DynDefCallRef<'a> {
     data: *const (),
@@ -152,9 +154,11 @@ impl DynDefCallRef<'_> {
 static CTR: SingleThreadValue<Cell<usize>> = SingleThreadValue::new();
 
 /// This bitmask tracks which of the up to 32 existing deferred calls have been
-/// scheduled. Any bit that is set in that mask indicates the deferred call with
-/// its [`DeferredCall::idx`] field set to the index of that bit has been
-/// scheduled and not yet serviced.
+/// scheduled.
+///
+/// Any bit that is set in that mask indicates the deferred call with its
+/// [`DeferredCall::idx`] field set to the index of that bit has been scheduled
+/// and not yet serviced.
 static BITMASK: SingleThreadValue<Cell<u32>> = SingleThreadValue::new();
 
 /// An array that stores references to up to 32 `DeferredCall`s via the low-cost

--- a/kernel/src/deferred_call.rs
+++ b/kernel/src/deferred_call.rs
@@ -103,9 +103,11 @@ pub trait DeferredCallClient: Sized {
 }
 
 /// This struct serves as a lightweight alternative to the use of trait objects
-/// (e.g. `&dyn DeferredCall`). Using a trait object will include a 20 byte
-/// vtable per instance, but this alternative stores only the data and function
-/// pointers, 8 bytes per instance.
+/// (e.g. `&dyn DeferredCall`).
+///
+/// Using a trait object will include a 20 byte vtable per instance, but this
+/// alternative stores only the data and function pointers, 8 bytes per
+/// instance.
 #[derive(Copy, Clone)]
 struct DynDefCallRef<'a> {
     data: *const (),
@@ -150,9 +152,11 @@ impl DynDefCallRef<'_> {
 static CTR: SingleThreadValue<Cell<usize>> = SingleThreadValue::new();
 
 /// This bitmask tracks which of the up to 32 existing deferred calls have been
-/// scheduled. Any bit that is set in that mask indicates the deferred call with
-/// its [`DeferredCall::idx`] field set to the index of that bit has been
-/// scheduled and not yet serviced.
+/// scheduled.
+///
+/// Any bit that is set in that mask indicates the deferred call with its
+/// [`DeferredCall::idx`] field set to the index of that bit has been scheduled
+/// and not yet serviced.
 static BITMASK: SingleThreadValue<Cell<u32>> = SingleThreadValue::new();
 
 /// An array that stores references to up to 32 `DeferredCall`s via the low-cost

--- a/kernel/src/process_loading.rs
+++ b/kernel/src/process_loading.rs
@@ -162,8 +162,10 @@ pub fn load_processes<C: Chip>(
 }
 
 /// Helper function to load processes from flash into an array of active
-/// processes. This is the default template for loading processes, but a board
-/// is able to create its own `load_processes()` function and use that instead.
+/// processes.
+///
+/// This is the default template for loading processes, but a board is able to
+/// create its own `load_processes()` function and use that instead.
 ///
 /// Processes are found in flash starting from the given address and iterating
 /// through Tock Binary Format (TBF) headers. Processes are given memory out of
@@ -353,9 +355,10 @@ fn discover_process_binary(
 }
 
 /// Load a process stored as a TBF process binary with `app_memory` as the RAM
-/// pool that its RAM should be allocated from. Returns `Ok` if the process
-/// object was created, `Err` with a relevant error if the process object could
-/// not be created.
+/// pool that its RAM should be allocated from.
+///
+/// Returns `Ok` if the process object was created, `Err` with a relevant error
+/// if the process object could not be created.
 fn load_process<C: Chip, D: ProcessStandardDebug>(
     kernel: &'static Kernel,
     chip: &'static C,


### PR DESCRIPTION


### Pull Request Overview

Ok. So. I'm not happy with this PR. I would like to apply the lints:

- clippy::missing_errors_doc (allowed in Tock)
- clippy::missing_panics_doc (allowed in Tock)
- **clippy::missing_safety_doc** (allowed in Tock, except kernel hopefully)
- clippy::unnecessary_safety_doc (denied in Tock)
- clippy::too_long_first_doc_paragraph (denied in Tock)

to all of our code, not just `pub`. Note: without this, even `pub(crate)` items are not checked.

HOWEVER, as far as I can tell, the only way to enable this is to add a `clippy.toml`, which is _yet another_ config file in the root. That is annoying. I've read the [docs](https://doc.rust-lang.org/clippy/configuration.html) and asked claude, and I don't see another way to do this.

Nearly all changes in this PR are to fix clippy::too_long_first_doc_paragraph.

More on the relevant lints: https://rust-lang.github.io/rust-clippy/master/?search=check-private-items






### Testing Strategy

`make clippy`


### TODO or Help Wanted

Is it worth it? I think so, just for ensuring we are doing the most to document unsafe. Still, annoying. Maybe I'm missing something and there is a way to enable this without another file.


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
