### PR TITLE
arch/riscv: elide `link_section` attrs when targeting macOS

### DIFF
--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -65,10 +65,18 @@ extern "C" {
 ///    information.
 /// 3. Finally it calls `main()`, the main entry point for Tock boards.
 #[cfg(any(doc, any(target_arch = "riscv32", target_arch = "riscv64")))]
-// When compiling for a macOS host, the `link_section` attribute is elided as
-// it yields the following error: `mach-o section specifier requires a segment
-// and section separated by a comma`.
-#[cfg_attr(not(target_os = "macos"), link_section = ".riscv.start")]
+// Only apply the `link_section` attribute when actually targeting bare-metal
+// RISC-V. Host builds (e.g. `doc`, tests, clippy on macOS, Windows, Linux,
+// ...) use object formats (Mach-O, PE, ...) that reject a bare section name
+// like this, yielding errors such as: `mach-o section specifier requires a
+// segment and section separated by a comma`.
+#[cfg_attr(
+    all(
+        target_os = "none",
+        any(target_arch = "riscv32", target_arch = "riscv64")
+    ),
+    link_section = ".riscv.start"
+)]
 #[unsafe(naked)]
 // We don't want the function name symbol to be mangled in order to be able to refer to
 // it the linker script. It is not currently being used in the provided linker script
@@ -309,10 +317,18 @@ pub extern "C" fn _start_trap() -> ! {
     all(target_arch = "riscv32", target_os = "none"),
     all(target_arch = "riscv64", target_os = "none")
 ))]
-// When compiling for a macOS host, the `link_section` attribute is elided as
-// it yields the following error: `mach-o section specifier requires a segment
-// and section separated by a comma`.
-#[cfg_attr(not(target_os = "macos"), link_section = ".riscv.trap")]
+// Only apply the `link_section` attribute when actually targeting bare-metal
+// RISC-V. Host builds (e.g. `doc`, tests, clippy on macOS, Windows, Linux,
+// ...) use object formats (Mach-O, PE, ...) that reject a bare section name
+// like this, yielding errors such as: `mach-o section specifier requires a
+// segment and section separated by a comma`.
+#[cfg_attr(
+    all(
+        target_os = "none",
+        any(target_arch = "riscv32", target_arch = "riscv64")
+    ),
+    link_section = ".riscv.trap"
+)]
 // We need the `_start_trap` function to be 256 byte aligned. The linker script
 // includes a check for whether a symbol named `_start_trap` exists. If it does,
 // it makes sure to align the `.riscv.trap` section on a 256 byte

--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -71,9 +71,9 @@ extern "C" {
 // like this, yielding errors such as: `mach-o section specifier requires a
 // segment and section separated by a comma`.
 #[cfg_attr(
-    all(
-        target_os = "none",
-        any(target_arch = "riscv32", target_arch = "riscv64")
+    any(
+        all(target_arch = "riscv32", target_os = "none"),
+        all(target_arch = "riscv64", target_os = "none")
     ),
     link_section = ".riscv.start"
 )]
@@ -323,9 +323,9 @@ pub extern "C" fn _start_trap() -> ! {
 // like this, yielding errors such as: `mach-o section specifier requires a
 // segment and section separated by a comma`.
 #[cfg_attr(
-    all(
-        target_os = "none",
-        any(target_arch = "riscv32", target_arch = "riscv64")
+    any(
+        all(target_arch = "riscv32", target_os = "none"),
+        all(target_arch = "riscv64", target_os = "none")
     ),
     link_section = ".riscv.trap"
 )]

--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -65,7 +65,10 @@ extern "C" {
 ///    information.
 /// 3. Finally it calls `main()`, the main entry point for Tock boards.
 #[cfg(any(doc, any(target_arch = "riscv32", target_arch = "riscv64")))]
-#[link_section = ".riscv.start"]
+// When compiling for a macOS host, the `link_section` attribute is elided as
+// it yields the following error: `mach-o section specifier requires a segment
+// and section separated by a comma`.
+#[cfg_attr(not(target_os = "macos"), link_section = ".riscv.start")]
 #[unsafe(naked)]
 // We don't want the function name symbol to be mangled in order to be able to refer to
 // it the linker script. It is not currently being used in the provided linker script
@@ -306,7 +309,10 @@ pub extern "C" fn _start_trap() -> ! {
     all(target_arch = "riscv32", target_os = "none"),
     all(target_arch = "riscv64", target_os = "none")
 ))]
-#[link_section = ".riscv.trap"]
+// When compiling for a macOS host, the `link_section` attribute is elided as
+// it yields the following error: `mach-o section specifier requires a segment
+// and section separated by a comma`.
+#[cfg_attr(not(target_os = "macos"), link_section = ".riscv.trap")]
 // We need the `_start_trap` function to be 256 byte aligned. The linker script
 // includes a check for whether a symbol named `_start_trap` exists. If it does,
 // it makes sure to align the `.riscv.trap` section on a 256 byte

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -60,10 +60,12 @@ const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
 
 // Manually setting the boot header section that contains the FCB header
 //
-// When compiling for a macOS host, the `link_section` attribute is elided as it
-// yields the following error: `mach-o section specifier requires a segment and
+// This section attribute is only applied when targeting bare-metal
+// (`target_os = "none"`). Host builds (e.g. tests, clippy, doc) use object
+// formats (Mach-O, PE, ...) that reject a bare section name like this,
+// yielding errors such as: `mach-o section specifier requires a segment and
 // section separated by a comma`.
-#[cfg_attr(not(target_os = "macos"), link_section = ".boot_hdr")]
+#[cfg_attr(target_os = "none", link_section = ".boot_hdr")]
 #[used]
 static BOOT_HDR: [u8; 8192] = boot_header::BOOT_HDR;
 

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -46,10 +46,12 @@ kernel::stack_size! {0x1500}
 
 // Manually setting the boot header section that contains the FCB header
 //
-// When compiling for a macOS host, the `link_section` attribute is elided as it
-// yields the following error: `mach-o section specifier requires a segment and
+// This section attribute is only applied when targeting bare-metal
+// (`target_os = "none"`). Host builds (e.g. tests, clippy, doc) use object
+// formats (Mach-O, PE, ...) that reject a bare section name like this,
+// yielding errors such as: `mach-o section specifier requires a segment and
 // section separated by a comma`.
-#[cfg_attr(not(target_os = "macos"), link_section = ".flash_bootloader")]
+#[cfg_attr(target_os = "none", link_section = ".flash_bootloader")]
 #[used]
 static FLASH_BOOTLOADER: [u8; 256] = flash_bootloader::FLASH_BOOTLOADER;
 

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -49,10 +49,12 @@ kernel::stack_size! {0x1500}
 
 // Manually setting the boot header section that contains the FCB header
 //
-// When compiling for a macOS host, the `link_section` attribute is elided as it
-// yields the following error: `mach-o section specifier requires a segment and
+// This section attribute is only applied when targeting bare-metal
+// (`target_os = "none"`). Host builds (e.g. tests, clippy, doc) use object
+// formats (Mach-O, PE, ...) that reject a bare section name like this,
+// yielding errors such as: `mach-o section specifier requires a segment and
 // section separated by a comma`.
-#[cfg_attr(not(target_os = "macos"), link_section = ".flash_bootloader")]
+#[cfg_attr(target_os = "none", link_section = ".flash_bootloader")]
 #[used]
 static FLASH_BOOTLOADER: [u8; 256] = flash_bootloader::FLASH_BOOTLOADER;
 

--- a/boards/qemu_i486_q35/src/main.rs
+++ b/boards/qemu_i486_q35/src/main.rs
@@ -46,10 +46,12 @@ mod io;
 
 /// Multiboot V1 header, allowing this kernel to be booted directly by QEMU
 ///
-/// When compiling for a macOS host, the `link_section` attribute is elided as
-/// it yields the following error: `mach-o section specifier requires a segment
-/// and section separated by a comma`.
-#[cfg_attr(not(target_os = "macos"), link_section = ".multiboot")]
+/// This section attribute is only applied when targeting bare-metal
+/// (`target_os = "none"`). Host builds (e.g. tests, clippy, doc) use object
+/// formats (Mach-O, PE, ...) that reject a bare section name like this,
+/// yielding errors such as: `mach-o section specifier requires a segment and
+/// section separated by a comma`.
+#[cfg_attr(target_os = "none", link_section = ".multiboot")]
 #[used]
 static MULTIBOOT_V1_HEADER: MultibootV1Header = MultibootV1Header::new(0);
 
@@ -76,11 +78,17 @@ type SchedulerInUse = components::sched::cooperative::CooperativeComponentType;
 // Static allocations used for page tables
 //
 // These are placed into custom sections so they can be properly aligned and padded in layout.ld
+//
+// The section attributes are only applied when targeting bare-metal
+// (`target_os = "none"`). Host builds (e.g. tests, clippy, doc) use object
+// formats (Mach-O, PE, ...) that reject a bare section name like this,
+// yielding errors such as: `mach-o section specifier requires a segment and
+// section separated by a comma`.
 #[no_mangle]
-#[cfg_attr(not(target_os = "macos"), link_section = ".pde")]
+#[cfg_attr(target_os = "none", link_section = ".pde")]
 pub static mut PAGE_DIR: PD = [PDEntry(0); 1024];
 #[no_mangle]
-#[cfg_attr(not(target_os = "macos"), link_section = ".pte")]
+#[cfg_attr(target_os = "none", link_section = ".pte")]
 pub static mut PAGE_TABLE: PT = [PTEntry(0); 1024];
 
 /// Initializes a Virtio transport driver for the given PCI device.

--- a/boards/raspberry_pi_pico/src/lib.rs
+++ b/boards/raspberry_pi_pico/src/lib.rs
@@ -43,10 +43,12 @@ mod flash_bootloader;
 
 // Manually setting the boot header section that contains the FCB header
 //
-// When compiling for a macOS host, the `link_section` attribute is elided as
-// it yields the following error: `mach-o section specifier requires a segment
-// and section separated by a comma`.
-#[cfg_attr(not(target_os = "macos"), link_section = ".flash_bootloader")]
+// This section attribute is only applied when targeting bare-metal
+// (`target_os = "none"`). Host builds (e.g. tests, clippy, doc) use object
+// formats (Mach-O, PE, ...) that reject a bare section name like this,
+// yielding errors such as: `mach-o section specifier requires a segment and
+// section separated by a comma`.
+#[cfg_attr(target_os = "none", link_section = ".flash_bootloader")]
 #[used]
 static FLASH_BOOTLOADER: [u8; 256] = flash_bootloader::FLASH_BOOTLOADER;
 

--- a/boards/raspberry_pi_pico_2/src/main.rs
+++ b/boards/raspberry_pi_pico_2/src/main.rs
@@ -48,17 +48,21 @@ kernel::stack_size! {0x3000}
 
 // Manually setting the boot header section that contains the FCB header
 //
-// When compiling for a macOS host, the `link_section` attribute is elided as
-// it yields the following error: `mach-o section specifier requires a segment
-// and section separated by a comma`.
-#[cfg_attr(not(target_os = "macos"), link_section = ".flash_bootloader")]
+// This section attribute is only applied when targeting bare-metal
+// (`target_os = "none"`). Host builds (e.g. tests, clippy, doc) use object
+// formats (Mach-O, PE, ...) that reject a bare section name like this,
+// yielding errors such as: `mach-o section specifier requires a segment and
+// section separated by a comma`.
+#[cfg_attr(target_os = "none", link_section = ".flash_bootloader")]
 #[used]
 static FLASH_BOOTLOADER: [u8; 256] = flash_bootloader::FLASH_BOOTLOADER;
 
-// When compiling for a macOS host, the `link_section` attribute is elided as
-// it yields the following error: `mach-o section specifier requires a segment
-// and section separated by a comma`.
-#[cfg_attr(not(target_os = "macos"), link_section = ".metadata_block")]
+// This section attribute is only applied when targeting bare-metal
+// (`target_os = "none"`). Host builds (e.g. tests, clippy, doc) use object
+// formats (Mach-O, PE, ...) that reject a bare section name like this,
+// yielding errors such as: `mach-o section specifier requires a segment and
+// section separated by a comma`.
+#[cfg_attr(target_os = "none", link_section = ".metadata_block")]
 #[used]
 static METADATA_BLOCK: [u8; 28] = flash_bootloader::METADATA_BLOCK;
 

--- a/boards/teensy40/src/fcb.rs
+++ b/boards/teensy40/src/fcb.rs
@@ -15,10 +15,12 @@
 
 pub type FCB = [u8; 512];
 
-// When compiling for a macOS host, the `link_section` attribute is elided as
-// it yields the following error: `mach-o section specifier requires a segment
-// and section separated by a comma`.
-#[cfg_attr(not(target_os = "macos"), link_section = ".fcb")]
+// This section attribute is only applied when targeting bare-metal
+// (`target_os = "none"`). Host builds (e.g. tests, clippy, doc) use object
+// formats (Mach-O, PE, ...) that reject a bare section name like this,
+// yielding errors such as: `mach-o section specifier requires a segment and
+// section separated by a comma`.
+#[cfg_attr(target_os = "none", link_section = ".fcb")]
 #[no_mangle]
 #[used]
 static FLEXSPI_CONFIGURATION_BLOCK: FCB = [

--- a/boards/teensy40/src/main.rs
+++ b/boards/teensy40/src/main.rs
@@ -411,10 +411,12 @@ const FCB_SIZE: usize = core::mem::size_of::<fcb::FCB>();
 /// See justification for the `".stack_buffer"` section to understand why we need
 /// explicit padding for the FCB.
 ///
-/// When compiling for a macOS host, the `link_section` attribute is elided as
-/// it yields the following error: `mach-o section specifier requires a segment
-/// and section separated by a comma`.
-#[cfg_attr(not(target_os = "macos"), link_section = ".fcb_buffer")]
+/// This section attribute is only applied when targeting bare-metal
+/// (`target_os = "none"`). Host builds (e.g. tests, clippy, doc) use object
+/// formats (Mach-O, PE, ...) that reject a bare section name like this,
+/// yielding errors such as: `mach-o section specifier requires a segment and
+/// section separated by a comma`.
+#[cfg_attr(target_os = "none", link_section = ".fcb_buffer")]
 #[no_mangle]
 #[used]
 static mut FCB_BUFFER: [u8; 0x1000 - FCB_SIZE] = [0xFF; 0x1000 - FCB_SIZE];

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -141,13 +141,12 @@ struct TockAttributesKernelVersion {
 /// the linker script includes at the correct location to be included in the
 /// attributes.
 ///
-/// When compiling for a macOS host, this section attribute is elided as it is
-/// incompatible with Mach-O objects and yields the following error: `mach-o
-/// section specifier requires a segment and section separated by a comma`.
-#[cfg_attr(
-    not(target_os = "macos"),
-    unsafe(link_section = ".tock.attr.kernel_version")
-)]
+/// This section attribute is only applied when targeting bare-metal
+/// (`target_os = "none"`). Host builds (e.g. tests, clippy, doc) use object
+/// formats (Mach-O, PE, ...) that reject a bare section name like this,
+/// yielding errors such as: `mach-o section specifier requires a segment and
+/// section separated by a comma`.
+#[cfg_attr(target_os = "none", unsafe(link_section = ".tock.attr.kernel_version"))]
 #[used]
 static TOCK_ATTRIBUTES_KERNEL_VERSION: TockAttributesKernelVersion = TockAttributesKernelVersion {
     major: KERNEL_MAJOR_VERSION,

--- a/kernel/src/utilities/helpers.rs
+++ b/kernel/src/utilities/helpers.rs
@@ -151,11 +151,12 @@ macro_rules! stack_size {
         /// section that the linker script picks up and places at the correct
         /// location in RAM.
         ///
-        /// When compiling for a macOS host, this section attribute is elided as
-        /// it is incompatible with Mach-O objects and yields the following
-        /// error: `mach-o section specifier requires a segment and section
-        /// separated by a comma`.
-        #[cfg_attr(not(target_os = "macos"), unsafe(link_section = ".stack_buffer"))]
+        /// This section attribute is only applied when targeting bare-metal
+        /// (`target_os = "none"`). Host builds (e.g. tests, clippy, doc) use
+        /// object formats (Mach-O, PE, ...) that reject a bare section name
+        /// like this, yielding errors such as: `mach-o section specifier
+        /// requires a segment and section separated by a comma`.
+        #[cfg_attr(target_os = "none", unsafe(link_section = ".stack_buffer"))]
         #[unsafe(no_mangle)]
         static mut STACK_MEMORY: [u8; $size] = [0; $size];
     }

--- a/kernel/src/utilities/storage_volume.rs
+++ b/kernel/src/utilities/storage_volume.rs
@@ -25,10 +25,12 @@
 #[macro_export]
 macro_rules! storage_volume {
     ($N:ident, $kB:expr $(,)?) => {
-        // When compiling for a macOS host, the `link_section` attribute is
-        // elided as it yields the following error: `mach-o section specifier
+        // This section attribute is only applied when targeting bare-metal
+        // (`target_os = "none"`). Host builds (e.g. tests, clippy, doc) use
+        // object formats (Mach-O, PE, ...) that reject a bare section name
+        // like this, yielding errors such as: `mach-o section specifier
         // requires a segment and section separated by a comma`.
-        #[cfg_attr(not(target_os = "macos"), unsafe(link_section = ".storage"))]
+        #[cfg_attr(target_os = "none", unsafe(link_section = ".storage"))]
         #[used]
         #[unsafe(no_mangle)]
         pub static $N: [u8; $kB * 1024] = [0x00; $kB * 1024];


### PR DESCRIPTION
### Pull Request Overview

Compiling riscv doctests on a macOS host yields:

    error: invalid Mach-O section specifier
     --> arch/riscv/src/lib.rs:68:18
    |
    68 | #[link_section = ".riscv.start"]
    |                  ^^^^^^^^^^^^^^ not a valid Mach-O section specifier

because `cfg(doc)` is active during doctest compilation, which enables these link_section attrs even on a macOS host. Same issue and fix as #4653.

Fixes #4998.

### Testing Strategy

This pull request was tested by compiling.

### TODO or Help Wanted

N/A

### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

This fix was fully authored by Claude using the following prompt:
    
      ❯ The CI job `make ci-job-archs` is failing
      
      It looks like it is a similar problem we have had before: https://github.com/tock/tock/pull/4653/
      
      Can you:
       1. Create a new branch `dev/mach-o-section-fix` to work on
       2. Fix the `cfgs` so that `make ci-job-archs` works?
       3. Commit the changes when you're done

I have manually reviewed the diff before opening this PR.