### PR TITLE
arch/x86: convert InterruptPoller pending array from VolatileCell to Cell

### DIFF
--- a/arch/x86/src/interrupts/poller.rs
+++ b/arch/x86/src/interrupts/poller.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2024.
 
+use core::cell::Cell;
 use core::ptr;
 
-use tock_cells::volatile_cell::VolatileCell;
 use tock_registers::LocalRegisterCopy;
 
 use crate::support;
@@ -32,7 +32,7 @@ use super::NUM_VECTORS;
 /// directly. Instead, you must access the singleton instance using `InterruptPoller::access`.
 pub struct InterruptPoller {
     /// Tracks the pending status of each interrupt
-    pending: [VolatileCell<LocalRegisterCopy<u32>>; NUM_VECTORS / 32],
+    pending: [Cell<LocalRegisterCopy<u32>>; NUM_VECTORS / 32],
 }
 
 /// The singleton poller instance
@@ -47,14 +47,14 @@ pub struct InterruptPoller {
 /// instance: `InterruptPoller::access` and `InterruptPoller::save`.
 static mut SINGLETON: InterruptPoller = InterruptPoller {
     pending: [
-        VolatileCell::new(LocalRegisterCopy::new(0)),
-        VolatileCell::new(LocalRegisterCopy::new(0)),
-        VolatileCell::new(LocalRegisterCopy::new(0)),
-        VolatileCell::new(LocalRegisterCopy::new(0)),
-        VolatileCell::new(LocalRegisterCopy::new(0)),
-        VolatileCell::new(LocalRegisterCopy::new(0)),
-        VolatileCell::new(LocalRegisterCopy::new(0)),
-        VolatileCell::new(LocalRegisterCopy::new(0)),
+        Cell::new(LocalRegisterCopy::new(0)),
+        Cell::new(LocalRegisterCopy::new(0)),
+        Cell::new(LocalRegisterCopy::new(0)),
+        Cell::new(LocalRegisterCopy::new(0)),
+        Cell::new(LocalRegisterCopy::new(0)),
+        Cell::new(LocalRegisterCopy::new(0)),
+        Cell::new(LocalRegisterCopy::new(0)),
+        Cell::new(LocalRegisterCopy::new(0)),
     ],
 };
 


### PR DESCRIPTION
### Pull Request Overview

This is part of an effort triggered by #5002 to review our use of `VolatileCell`.

***The following explanation was written by Claude. I am not enough of an x86 expert to validate these claims and this rationale needs review.***

VolatileCell was never providing concurrency safety here: the `pending` array is written from `set_pending()`, called only from `handle_external_interrupt`, which is only ever reached via an IDT *interrupt gate* (arch/x86/src/interrupts/idt.rs uses `DescriptorBuilder::interrupt_descriptor` for every vector). Entering through an interrupt gate clears the CPU's IF flag automatically, and nothing in the handler path re-enables it, so `set_pending()` always runs with interrupts masked on this core.

The reader side (`next_pending`/`clear_pending`) is only ever called through `InterruptPoller::access()`, which wraps the closure in `support::with_interrupts_disabled` for exactly this reason (see its doc comment: "This allows you to safely perform single-core operations which would otherwise race against interrupt handlers.").

Since every access to `pending` therefore happens with IF=0 on this single core, the writer and reader can never physically interleave. `VolatileCell`'s only remaining effect was forcing a real memory access and blocking some compiler reordering, neither of which is needed once genuine concurrent access is ruled out. Plain `Cell` is sound and lighter weight.

### Testing Strategy

This pull request was tested by compiling.

### TODO or Help Wanted

Someone who knows x86 better to validate the correctness here.

### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

I asked Claude whether these needed to be `VolatileCell`s, and Claude said no, proposed these changes to `Cell` and gave the rationale here.