### PR TITLE
chips: convert PLIC-family "saved interrupts" arrays from VolatileCell to Cell

### DIFF
--- a/chips/earlgrey/src/plic.rs
+++ b/chips/earlgrey/src/plic.rs
@@ -4,9 +4,10 @@
 
 //! Platform Level Interrupt Control peripheral driver.
 
+use core::cell::Cell;
+
 use crate::registers::top_earlgrey::RV_PLIC_BASE_ADDR;
 use kernel::utilities::StaticRef;
-use kernel::utilities::cells::VolatileCell;
 use kernel::utilities::registers::LocalRegisterCopy;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 use kernel::utilities::registers::{ReadOnly, ReadWrite, register_bitfields, register_structs};
@@ -51,7 +52,7 @@ register_bitfields![u32,
 
 pub struct Plic {
     registers: StaticRef<PlicRegisters>,
-    saved: [VolatileCell<LocalRegisterCopy<u32>>; PLIC_REGS],
+    saved: [Cell<LocalRegisterCopy<u32>>; PLIC_REGS],
 }
 
 impl Plic {
@@ -59,12 +60,12 @@ impl Plic {
         Plic {
             registers: base,
             saved: [
-                VolatileCell::new(LocalRegisterCopy::new(0)),
-                VolatileCell::new(LocalRegisterCopy::new(0)),
-                VolatileCell::new(LocalRegisterCopy::new(0)),
-                VolatileCell::new(LocalRegisterCopy::new(0)),
-                VolatileCell::new(LocalRegisterCopy::new(0)),
-                VolatileCell::new(LocalRegisterCopy::new(0)),
+                Cell::new(LocalRegisterCopy::new(0)),
+                Cell::new(LocalRegisterCopy::new(0)),
+                Cell::new(LocalRegisterCopy::new(0)),
+                Cell::new(LocalRegisterCopy::new(0)),
+                Cell::new(LocalRegisterCopy::new(0)),
+                Cell::new(LocalRegisterCopy::new(0)),
             ],
         }
     }

--- a/chips/esp32-c3/src/intc.rs
+++ b/chips/esp32-c3/src/intc.rs
@@ -4,9 +4,10 @@
 
 //! Platform Level Interrupt Control peripheral driver.
 
+use core::cell::Cell;
+
 use crate::interrupts;
 use kernel::utilities::StaticRef;
-use kernel::utilities::cells::VolatileCell;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 use kernel::utilities::registers::{
     LocalRegisterCopy, ReadWrite, register_bitfields, register_structs,
@@ -57,14 +58,14 @@ register_bitfields![u32,
 
 pub struct Intc {
     registers: StaticRef<IntcRegisters>,
-    saved: VolatileCell<LocalRegisterCopy<u32>>,
+    saved: Cell<LocalRegisterCopy<u32>>,
 }
 
 impl Intc {
     pub const fn new(base: StaticRef<IntcRegisters>) -> Self {
         Intc {
             registers: base,
-            saved: VolatileCell::new(LocalRegisterCopy::new(0)),
+            saved: Cell::new(LocalRegisterCopy::new(0)),
         }
     }
 

--- a/chips/sifive/src/plic.rs
+++ b/chips/sifive/src/plic.rs
@@ -4,8 +4,9 @@
 
 //! Platform Level Interrupt Control peripheral driver.
 
+use core::cell::Cell;
+
 use kernel::utilities::StaticRef;
-use kernel::utilities::cells::VolatileCell;
 use kernel::utilities::registers::LocalRegisterCopy;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 use kernel::utilities::registers::{ReadOnly, ReadWrite, register_bitfields};
@@ -109,7 +110,7 @@ register_bitfields![u32,
 /// platforms implemented without the generic parameter.
 pub struct Plic<const TOTAL_INTS: usize = 51> {
     registers: RegsWrapper,
-    saved: [VolatileCell<LocalRegisterCopy<u32>>; 2],
+    saved: [Cell<LocalRegisterCopy<u32>>; 2],
 }
 
 impl<const TOTAL_INTS: usize> Plic<TOTAL_INTS> {
@@ -117,8 +118,8 @@ impl<const TOTAL_INTS: usize> Plic<TOTAL_INTS> {
         Plic {
             registers: RegsWrapper::new(base, TOTAL_INTS),
             saved: [
-                VolatileCell::new(LocalRegisterCopy::new(0)),
-                VolatileCell::new(LocalRegisterCopy::new(0)),
+                Cell::new(LocalRegisterCopy::new(0)),
+                Cell::new(LocalRegisterCopy::new(0)),
             ],
         }
     }

--- a/chips/veer_el2/src/pic.rs
+++ b/chips/veer_el2/src/pic.rs
@@ -6,8 +6,9 @@
 /* Currently no peripheral that would generate interupts is defined in the reference
 testbench for VeeR EL2, so the Pic is not expected to handle any interrupts. */
 
+use core::cell::Cell;
+
 use kernel::utilities::StaticRef;
-use kernel::utilities::cells::VolatileCell;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 use kernel::utilities::registers::{
     LocalRegisterCopy, ReadWrite, register_bitfields, register_structs,
@@ -94,7 +95,7 @@ register_bitfields![usize,
 #[allow(dead_code)]
 pub struct Pic {
     registers: StaticRef<PicRegisters>,
-    saved: [VolatileCell<LocalRegisterCopy<u32>>; 3],
+    saved: [Cell<LocalRegisterCopy<u32>>; 3],
     meivt: ReadWriteRiscvCsr<usize, MEIVT::Register, 0xBC8>,
     meipt: ReadWriteRiscvCsr<usize, MEIPT::Register, 0xBC9>,
     meicpct: ReadWriteRiscvCsr<usize, MEICPCT::Register, 0xBCA>,
@@ -108,9 +109,9 @@ impl Pic {
         Pic {
             registers: base,
             saved: [
-                VolatileCell::new(LocalRegisterCopy::new(0)),
-                VolatileCell::new(LocalRegisterCopy::new(0)),
-                VolatileCell::new(LocalRegisterCopy::new(0)),
+                Cell::new(LocalRegisterCopy::new(0)),
+                Cell::new(LocalRegisterCopy::new(0)),
+                Cell::new(LocalRegisterCopy::new(0)),
             ],
             meivt: ReadWriteRiscvCsr::new(),
             meipt: ReadWriteRiscvCsr::new(),


### PR DESCRIPTION
### Pull Request Overview

This is part of an effort triggered by https://github.com/tock/tock/pull/5002 to review our use of VolatileCell.

***This commit and its explanation here was authored by Claude. I agree with the explanation provided, but I am not a risc-v expert and may have misssed some nuance.***

Affects sifive::Plic, veer_el2::Pic, earlgrey::Plic, and esp32-c3::Intc.

Each of these interrupt controllers keeps a software-only `saved` array of interrupt sources that were pending-but-disabled, distinct from the hardware pending/enable registers. It's mutated by `save_interrupt()` and `complete()`, and read by `get_saved_interrupts()`. Both mutating methods are explicitly documented "interrupts must be disabled before this is called," and the only reader (`get_saved_interrupts()`) is called exclusively from the single-threaded bottom-half interrupt loop (e.g. `chips/e310x/src/chip.rs`'s `handle_plic_interrupts`, which loops `while let Some(interrupt) = self.plic.get_saved_interrupts() { ...; self.plic.complete(interrupt) }`).

Tock's cooperative model runs `handle_interrupt` from the kernel main loop rather than a preemptive nested ISR, so with that documented interrupt-disabled contract honored by callers, there is no genuine concurrent access to `saved`. `VolatileCell` was not providing any synchronization guarantee here; plain `Cell` has identical single-threaded semantics.

These four are bundled in one commit because they're the same pattern copied across four chips with the same justification, rather than four near-identical diffs each needing to be independently re-verified.

### Testing Strategy

This pull request was tested by compiling.

### TODO or Help Wanted

This pull request still needs confirmation by a risc-v expert.

### Checklist

- [ ] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [ ] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use above.
