### PR TITLE
Replace trivial `VolatileCell` MMIO uses with `tock-registers::ReadWrite`

### DIFF
--- a/chips/nrf52/src/nvmc.rs
+++ b/chips/nrf52/src/nvmc.rs
@@ -14,7 +14,6 @@ use kernel::hil;
 use kernel::utilities::StaticRef;
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::cells::TakeCell;
-use kernel::utilities::cells::VolatileCell;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 use kernel::utilities::registers::{ReadOnly, ReadWrite, register_bitfields};
 
@@ -341,7 +340,7 @@ impl Nvmc {
                 | (data[i + 3] as u32) << 24;
 
             let address = ((page_number * PAGE_SIZE) + i) as u32;
-            let location = unsafe { &*(address as *const VolatileCell<u32>) };
+            let location = unsafe { &*(address as *const ReadWrite<u32>) };
             location.set(word);
             while !self.registers.ready.is_set(Ready::READY) {}
         }

--- a/chips/rp2040/src/usb.rs
+++ b/chips/rp2040/src/usb.rs
@@ -46,9 +46,9 @@ register_structs! {
         (0x04 => setup_l: ReadWrite<u32, SETUP_L::Register>),
         (0x08 => ep_ctrl: [Ep_ctrl; 15]),
         (0x80 => ep_buf_ctrl: [Ep_buf_ctrl; 16]),
-        (0x100 => ep0_buffer0: [VolatileCell<u8>; 0x40]),
-        (0x140 => optional_ep0_buffer0: [VolatileCell<u8>; 0x40]),
-        (0x180 => buffers: [VolatileCell<u8>; 4096-0x180]),
+        (0x100 => ep0_buffer0: [ReadWrite<u8>; 0x40]),
+        (0x140 => optional_ep0_buffer0: [ReadWrite<u8>; 0x40]),
+        (0x180 => buffers: [ReadWrite<u8>; 4096-0x180]),
         (0x1000 => @END),
     }
 }

--- a/chips/stm32f303xc/src/flash.rs
+++ b/chips/stm32f303xc/src/flash.rs
@@ -21,7 +21,6 @@ use kernel::hil;
 use kernel::utilities::StaticRef;
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::cells::TakeCell;
-use kernel::utilities::cells::VolatileCell;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::register_bitfields;
 use kernel::utilities::registers::{ReadOnly, ReadWrite, WriteOnly};
@@ -466,7 +465,7 @@ impl Flash {
             let halfword: u16 = (buffer[i] as u16) << 0 | (buffer[i + 1] as u16) << 8;
             let page_addr = PAGE_START + self.page_number.get() * PAGE_SIZE;
             let address = page_addr + i;
-            let location = unsafe { &*(address as *const VolatileCell<u16>) };
+            let location = unsafe { &*(address as *const ReadWrite<u16>) };
             location.set(halfword);
 
             self.buffer.replace(buffer);
@@ -579,7 +578,7 @@ impl Flash {
         self.registers.cr.modify(Control::OPTPG::SET);
 
         let address = OPT_START + byte_number * 2;
-        let location = unsafe { &*(address as *const VolatileCell<u16>) };
+        let location = unsafe { &*(address as *const ReadWrite<u16>) };
         let halfword: u16 = value as u16;
         location.set(halfword);
 


### PR DESCRIPTION
### Pull Request Overview

We had a few places where we were still using `VolatileCell` for MMIO access, where the tock-registers `ReadWrite` is a drop-in replacement. This makes the swap.

### Testing Strategy

This pull request was tested by compiling.

### TODO or Help Wanted

N/A

### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

Claude authored the changes and the commits, with feedback, iteration, and review by me.