### PR TITLE
Refactor to remove `VolatileCell` "MMIO" with non-primitive types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1556,6 +1556,7 @@ name = "sam4l"
 version = "0.2.3-dev"
 dependencies = [
  "cortexm4",
+ "enum_primitive",
  "kernel",
 ]
 

--- a/chips/nrf52/src/adc.rs
+++ b/chips/nrf52/src/adc.rs
@@ -10,7 +10,7 @@ use core::ptr::addr_of;
 use kernel::ErrorCode;
 use kernel::hil;
 use kernel::utilities::StaticRef;
-use kernel::utilities::cells::{OptionalCell, TakeCell, VolatileCell};
+use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 use kernel::utilities::registers::{ReadOnly, ReadWrite, WriteOnly, register_bitfields};
 
@@ -63,7 +63,7 @@ struct AdcRegisters {
     samplerate: ReadWrite<u32, SAMPLERATE::Register>,
     _reserved6: [u8; 48],
     /// Pointer to store samples to
-    result_ptr: VolatileCell<*const u16>,
+    result_ptr: ReadWrite<u32>,
     /// Number of 16 bit samples to save in RAM
     result_maxcnt: ReadWrite<u32, RESULT_MAXCNT::Register>,
     /// Number of 16 bit samples recorded to RAM
@@ -401,7 +401,7 @@ impl Adc<'_> {
                     // Where to put the reading.
                     let sample: *const [u16; 1] = addr_of!(SAMPLE);
                     let sample: *const u16 = sample.cast();
-                    self.registers.result_ptr.set(sample);
+                    self.registers.result_ptr.set(sample as u32);
 
                     // No automatic sampling, will trigger manually.
                     self.registers.samplerate.write(SAMPLERATE::MODE::Task);
@@ -484,7 +484,7 @@ impl Adc<'_> {
                         // First determine the buffer's length in samples.
                         let dma_len = cmp::min(buf.len(), self.next_length.get());
                         if dma_len > 0 {
-                            self.registers.result_ptr.set(buf.as_ptr());
+                            self.registers.result_ptr.set(buf.as_ptr() as u32);
                         }
                     });
 
@@ -584,7 +584,7 @@ impl<'a> hil::adc::Adc<'a> for Adc<'a> {
         // Where to put the reading.
         let sample: *const [u16; 1] = addr_of!(SAMPLE);
         let sample: *const u16 = sample.cast();
-        self.registers.result_ptr.set(sample);
+        self.registers.result_ptr.set(sample as u32);
 
         // No automatic sampling, will trigger manually.
         self.registers.samplerate.write(SAMPLERATE::MODE::Task);
@@ -653,7 +653,7 @@ impl<'a> hil::adc::AdcHighSpeed<'a> for Adc<'a> {
             self.setup_resolution();
 
             // Use EasyDMA to save the samples to our buffer.
-            self.registers.result_ptr.set(buffer1.as_ptr());
+            self.registers.result_ptr.set(buffer1.as_ptr() as u32);
 
             // Also need to save these to return to the caller.
             self.buffer.replace(buffer1);

--- a/chips/nrf52/src/i2c.rs
+++ b/chips/nrf52/src/i2c.rs
@@ -11,7 +11,6 @@ use kernel::hil;
 use kernel::utilities::StaticRef;
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::cells::TakeCell;
-use kernel::utilities::cells::VolatileCell;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{ReadWrite, WriteOnly, register_bitfields, register_structs};
 use nrf5x::pinmux::Pinmux;
@@ -65,8 +64,8 @@ impl TWI<'_> {
 
     /// Configures an already constructed `TWI`.
     pub fn configure(&self, scl: Pinmux, sda: Pinmux) {
-        self.registers.psel_scl.set(scl);
-        self.registers.psel_sda.set(sda);
+        self.registers.psel_scl.set(scl.into());
+        self.registers.psel_sda.set(sda.into());
     }
 
     /// Sets the I2C bus speed to one of three possible values
@@ -469,9 +468,9 @@ register_structs! {
         (0x500 => enable: ReadWrite<u32, ENABLE::Register>),
         (0x504 => _reserved13),
         /// Pin select for SCL signal
-        (0x508 => psel_scl: VolatileCell<Pinmux>),
+        (0x508 => psel_scl: ReadWrite<u32>),
         /// Pin select for SDA signal
-        (0x50C => psel_sda: VolatileCell<Pinmux>),
+        (0x50C => psel_sda: ReadWrite<u32>),
         (0x510 => _reserved_14),
         /// TWI frequency
         (0x524 => frequency: ReadWrite<u32>),

--- a/chips/nrf52/src/pwm.rs
+++ b/chips/nrf52/src/pwm.rs
@@ -7,7 +7,6 @@
 use kernel::ErrorCode;
 use kernel::hil;
 use kernel::utilities::StaticRef;
-use kernel::utilities::cells::VolatileCell;
 use kernel::utilities::registers::interfaces::Writeable;
 use kernel::utilities::registers::{ReadWrite, WriteOnly, register_bitfields};
 
@@ -65,7 +64,7 @@ struct PwmRegisters {
 
 #[repr(C)]
 struct PwmSeqRegisters {
-    seq_ptr: VolatileCell<*const u16>,
+    seq_ptr: ReadWrite<u32>,
     seq_cnt: ReadWrite<u32, SEQ_CNT::Register>,
     seq_refresh: ReadWrite<u32, SEQ_REFRESH::Register>,
     seq_enddelay: ReadWrite<u32, SEQ_ENDDELAY::Register>,
@@ -235,7 +234,7 @@ impl Pwm {
         }
         let duty_cycles: *const [u16; 4] = core::ptr::addr_of!(DUTY_CYCLES);
         let duty_cycles: *const u16 = duty_cycles.cast();
-        self.registers.seq0.seq_ptr.set(duty_cycles);
+        self.registers.seq0.seq_ptr.set(duty_cycles as u32);
         self.registers.seq0.seq_cnt.write(SEQ_CNT::CNT.val(1));
         self.registers
             .seq0

--- a/chips/nrf52/src/pwm.rs
+++ b/chips/nrf52/src/pwm.rs
@@ -60,7 +60,7 @@ struct PwmRegisters {
     _reserved6: [u8; 16],
     seq1: PwmSeqRegisters,
     _reserved7: [u8; 16],
-    psel_out: [VolatileCell<nrf5x::pinmux::Pinmux>; 4],
+    psel_out: [ReadWrite<u32>; 4],
 }
 
 #[repr(C)]
@@ -210,7 +210,7 @@ impl Pwm {
         let dc_out = counter_top - ((3 * duty_cycle) / frequency_hz);
 
         // Configure the pin
-        self.registers.psel_out[0].set(*pin);
+        self.registers.psel_out[0].set((*pin).into());
 
         // Start by enabling the peripheral.
         self.registers.enable.write(ENABLE::ENABLE::SET);

--- a/chips/nrf52/src/spi.rs
+++ b/chips/nrf52/src/spi.rs
@@ -34,13 +34,13 @@
 //! * Date: Sep 10, 2017
 
 use core::cell::Cell;
-use core::{cmp, ptr};
+use core::cmp;
 use kernel::ErrorCode;
 use kernel::hil;
 use kernel::hil::gpio::Configure;
 use kernel::hil::spi::cs::ChipSelectPolar;
 use kernel::utilities::StaticRef;
-use kernel::utilities::cells::{MapCell, OptionalCell, VolatileCell};
+use kernel::utilities::cells::{MapCell, OptionalCell};
 use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{ReadWrite, WriteOnly, register_bitfields};
@@ -80,17 +80,17 @@ struct SpimRegisters {
     _reserved9: [u8; 500],                           // reserved
     enable: ReadWrite<u32, ENABLE::Register>,        // Enable SPIM
     _reserved10: [u8; 4],                            // reserved
-    psel_sck: VolatileCell<Pinmux>,                  // Pin select for SCK
-    psel_mosi: VolatileCell<Pinmux>,                 // Pin select for MOSI signal
-    psel_miso: VolatileCell<Pinmux>,                 // Pin select for MISO signal
+    psel_sck: ReadWrite<u32>,                        // Pin select for SCK
+    psel_mosi: ReadWrite<u32>,                       // Pin select for MOSI signal
+    psel_miso: ReadWrite<u32>,                       // Pin select for MISO signal
     _reserved11: [u8; 16],                           // reserved
     frequency: ReadWrite<u32>,                       // SPI frequency
     _reserved12: [u8; 12],                           // reserved
-    rxd_ptr: VolatileCell<*mut u8>,                  // Data pointer
+    rxd_ptr: ReadWrite<u32>,                         // Data pointer
     rxd_maxcnt: ReadWrite<u32, MAXCNT::Register>,    // Maximum number of bytes in receive buffer
     rxd_amount: ReadWrite<u32>,                      // Number of bytes transferred
     rxd_list: ReadWrite<u32>,                        // EasyDMA list type
-    txd_ptr: VolatileCell<*const u8>,                // Data pointer
+    txd_ptr: ReadWrite<u32>,                         // Data pointer
     txd_maxcnt: ReadWrite<u32, MAXCNT::Register>,    // Maximum number of bytes in transmit buffer
     txd_amount: ReadWrite<u32>,                      // Number of bytes transferred
     txd_list: ReadWrite<u32>,                        // EasyDMA list type
@@ -316,9 +316,9 @@ impl<'a> SPIM<'a> {
 
     /// Configures an already constructed `SPIM`.
     pub fn configure(&self, mosi: Pinmux, miso: Pinmux, sck: Pinmux) {
-        self.registers.psel_mosi.set(mosi);
-        self.registers.psel_miso.set(miso);
-        self.registers.psel_sck.set(sck);
+        self.registers.psel_mosi.set(mosi.into());
+        self.registers.psel_miso.set(miso.into());
+        self.registers.psel_sck.set(sck.into());
     }
 
     /// Enables `SPIM` peripheral.
@@ -375,20 +375,20 @@ impl<'a> hil::spi::SpiMaster<'a> for SPIM<'a> {
 
         // Setup transmit data registers
         let tx_len: u32 = tx_buf.len() as u32;
-        self.registers.txd_ptr.set(tx_buf.as_ptr());
+        self.registers.txd_ptr.set(tx_buf.as_ptr() as u32);
         self.registers.txd_maxcnt.write(MAXCNT::MAXCNT.val(tx_len));
         self.tx_buf.replace(tx_buf);
 
         // Setup receive data registers
         match rx_buf {
             None => {
-                self.registers.rxd_ptr.set(ptr::null_mut());
+                self.registers.rxd_ptr.set(0);
                 self.registers.rxd_maxcnt.write(MAXCNT::MAXCNT.val(0));
                 self.transfer_len.set(tx_len as usize);
                 self.rx_buf.take();
             }
             Some(mut buf) => {
-                self.registers.rxd_ptr.set(buf.as_mut_ptr());
+                self.registers.rxd_ptr.set(buf.as_mut_ptr() as u32);
                 let rx_len: u32 = buf.len() as u32;
                 self.registers.rxd_maxcnt.write(MAXCNT::MAXCNT.val(rx_len));
                 self.transfer_len.set(cmp::min(tx_len, rx_len) as usize);

--- a/chips/nrf52/src/usbd.rs
+++ b/chips/nrf52/src/usbd.rs
@@ -315,7 +315,7 @@ mod detail {
 
     #[repr(C)]
     pub struct EndpointRegisters<'a> {
-        ptr: VolatileCell<*const u8>,
+        ptr: ReadWrite<u32>,
         maxcnt: ReadWrite<u32, Count::Register>,
         amount: ReadOnly<u32, Amount::Register>,
         // padding
@@ -326,7 +326,7 @@ mod detail {
 
     impl<'a> EndpointRegisters<'a> {
         pub fn set_buffer(&self, slice: &'a [VolatileCell<u8>]) {
-            self.ptr.set(slice.as_ptr().cast::<u8>());
+            self.ptr.set(slice.as_ptr().cast::<u8>() as u32);
             self.maxcnt.write(Count::MAXCNT.val(slice.len() as u32));
         }
     }

--- a/chips/sam4l/Cargo.toml
+++ b/chips/sam4l/Cargo.toml
@@ -10,6 +10,7 @@ edition.workspace = true
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }
+enum_primitive = { path = "../../libraries/enum_primitive" }
 kernel = { path = "../../kernel" }
 
 [lints]

--- a/chips/sam4l/src/dma.rs
+++ b/chips/sam4l/src/dma.rs
@@ -8,8 +8,9 @@ use crate::pm;
 use core::cell::Cell;
 use core::cmp;
 use core::sync::atomic;
+use enum_primitive::cast::FromPrimitive;
+use kernel::debug;
 use kernel::utilities::StaticRef;
-use kernel::utilities::cells::VolatileCell;
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 use kernel::utilities::registers::{ReadOnly, ReadWrite, WriteOnly, register_bitfields};
@@ -19,7 +20,7 @@ use kernel::utilities::registers::{ReadOnly, ReadWrite, WriteOnly, register_bitf
 #[allow(dead_code)]
 struct DMARegisters {
     mar: ReadWrite<u32, MemoryAddress::Register>,
-    psr: VolatileCell<DMAPeripheral>,
+    psr: ReadWrite<u8>,
     _psr_padding: [u8; 3],
     tcr: ReadWrite<u32, TransferCounter::Register>,
     marr: ReadWrite<u32, MemoryAddressReload::Register>,
@@ -126,6 +127,7 @@ pub enum DMAChannelNum {
     DMAChannel15 = 15,
 }
 
+enum_primitive::enum_from_primitive! {
 /// The peripheral function a channel is assigned to (Section 16.7). `*_RX`
 /// means transfer data from peripheral to memory, `*_TX` means transfer data
 /// from memory to peripheral.
@@ -171,6 +173,7 @@ pub enum DMAPeripheral {
     AESA_TX = 36,
     LCDCA_ACMDR_TX = 37,
     LCDCA_ABMDR_TX = 38,
+}
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -254,9 +257,19 @@ impl DMAChannel {
             .write(Interrupt::TERR::SET + Interrupt::TRC::SET + Interrupt::RCZ::SET);
         let channel = self.registers.psr.get();
 
-        self.client.map(|client| {
-            client.transfer_done(channel);
-        });
+        match DMAPeripheral::from_u8(channel) {
+            Some(channel) => {
+                self.client.map(|client| {
+                    client.transfer_done(channel);
+                });
+            }
+            None => {
+                debug!(
+                    "sam4l dma: psr read back invalid DMAPeripheral value {}",
+                    channel
+                );
+            }
+        }
     }
 
     pub fn start_transfer(&self) {
@@ -277,7 +290,7 @@ impl DMAChannel {
             .mr
             .write(Mode::SIZE.val(self.width.get() as u32));
 
-        self.registers.psr.set(pid);
+        self.registers.psr.set(pid as u8);
         self.registers
             .marr
             .write(MemoryAddressReload::MARV.val(core::ptr::from_ref::<u8>(&buf[0]) as u32));

--- a/chips/sam4l/src/usbc/mod.rs
+++ b/chips/sam4l/src/usbc/mod.rs
@@ -12,7 +12,6 @@ use crate::pm;
 use crate::pm::{Clock, HSBClock, PBBClock, disable_clock, enable_clock};
 use crate::scif;
 use core::cell::Cell;
-use core::ptr;
 use core::slice;
 use kernel::debug as debugln;
 use kernel::hil;
@@ -380,7 +379,7 @@ pub const fn new_endpoint() -> Endpoint {
 
 #[repr(C)]
 pub struct Bank {
-    addr: VolatileCell<*mut u8>,
+    addr: InMemoryRegister<u32>,
 
     // The following fields are not actually registers
     // (they may be placed anywhere in memory),
@@ -395,7 +394,7 @@ pub struct Bank {
 impl Bank {
     pub const fn new() -> Bank {
         Bank {
-            addr: VolatileCell::new(ptr::null_mut()),
+            addr: InMemoryRegister::new(0),
             packet_size: InMemoryRegister::new(0),
             control_status: InMemoryRegister::new(0),
             _reserved: 0,
@@ -403,7 +402,7 @@ impl Bank {
     }
 
     pub fn set_addr(&self, addr: *mut u8) {
-        self.addr.set(addr);
+        self.addr.set(addr as u32);
     }
 }
 
@@ -1379,7 +1378,7 @@ impl<'a> Usbc<'a> {
     fn debug_show_d0(&self) {
         for bi in 0..1 {
             let b = &self.descriptors[0][bi];
-            let addr = b.addr.get();
+            let addr = b.addr.get() as *const u8;
             let _buf = if addr.is_null() {
                 None
             } else {


### PR DESCRIPTION
### Pull Request Overview

This pull request is the last in a series inspired by #5002 , and removes the remaining uses of `VolatileCell` as MMIO.

Here, we were still using `VolatileCell` because the type "in" hardware wasn't `[U]IntLike`. This was really not a great thing to be doing, however, the reality of hardware is that the MMIO interface really only provides primitive types — indeed, the last commit in this series fixes a (unlikely to happen in practice) soundness bug, where the `VolatileCell` blindly casted the `u8` that hardware gives us to an `enum` type with only ~30 variants.

Instead, all of the `register_struct!` definitions now use actual hardware types, s.t. the peripheral memory map honestly reflects how the hardware interface views types, and any type conversion occurs where we call the MMIO getters and setters.

I think we didn't do this originally because we feared the type conversions would end up everywhere and be annoying—but in practice they're mostly `repr(u8|u32)` types that convert effortlessly [the diffs here really aren't big].

### Testing Strategy

This pull request was tested by compiling. Claude even went so far as to ensure the binaries were unchanged (with the exception of the sam4l-based boards, where the binary images changed because of line refs in panic strings but were otherwise unchanged).

### TODO or Help Wanted

N/A

### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

Claude wrote the implementation and commits, with some heavier iteration from me. I've verified all diffs.
