### PR TITLE
arch/riscv: elide more link_section attrs when targeting macOS

### DIFF
--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -458,7 +458,15 @@ pub extern "C" fn _earlgrey_start_trap_vectored() -> ! {
 }
 
 #[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
-#[link_section = ".riscv.trap_vectored"]
+// Only apply the `link_section` attribute when actually targeting bare-metal
+// RISC-V. Host builds (e.g. `doc`, tests, clippy on macOS, Windows, Linux,
+// ...) use object formats (Mach-O, PE, ...) that reject a bare section name
+// like this, yielding errors such as: `mach-o section specifier requires a
+// segment and section separated by a comma`.
+#[cfg_attr(
+    all(target_arch = "riscv32", target_os = "none"),
+    link_section = ".riscv.trap_vectored"
+)]
 #[unsafe(naked)]
 pub extern "C" fn _earlgrey_start_trap_vectored() -> ! {
     use core::arch::naked_asm;

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -459,7 +459,7 @@ pub extern "C" fn _earlgrey_start_trap_vectored() -> ! {
 
 #[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
 // Only apply the `link_section` attribute when actually targeting bare-metal
-// RISC-V. Host builds (e.g. `doc`, tests, clippy on macOS, Windows, Linux,
+// RISC-V. Some host builds (e.g. `doc`, tests, clippy on macOS, Windows,
 // ...) use object formats (Mach-O, PE, ...) that reject a bare section name
 // like this, yielding errors such as: `mach-o section specifier requires a
 // segment and section separated by a comma`.

--- a/chips/esp32-c3/src/chip.rs
+++ b/chips/esp32-c3/src/chip.rs
@@ -303,7 +303,15 @@ pub extern "C" fn _start_trap_vectored() -> ! {
 }
 
 #[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
-#[link_section = ".riscv.trap_vectored"]
+// Only apply the `link_section` attribute when actually targeting bare-metal
+// RISC-V. Host builds (e.g. `doc`, tests, clippy on macOS, Windows, Linux,
+// ...) use object formats (Mach-O, PE, ...) that reject a bare section name
+// like this, yielding errors such as: `mach-o section specifier requires a
+// segment and section separated by a comma`.
+#[cfg_attr(
+    all(target_arch = "riscv32", target_os = "none"),
+    link_section = ".riscv.trap_vectored"
+)]
 #[unsafe(naked)]
 pub extern "C" fn _start_trap_vectored() -> ! {
     use core::arch::naked_asm;

--- a/chips/esp32-c3/src/chip.rs
+++ b/chips/esp32-c3/src/chip.rs
@@ -304,7 +304,7 @@ pub extern "C" fn _start_trap_vectored() -> ! {
 
 #[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
 // Only apply the `link_section` attribute when actually targeting bare-metal
-// RISC-V. Host builds (e.g. `doc`, tests, clippy on macOS, Windows, Linux,
+// RISC-V. Some host builds (e.g. `doc`, tests, clippy on macOS, Windows,
 // ...) use object formats (Mach-O, PE, ...) that reject a bare section name
 // like this, yielding errors such as: `mach-o section specifier requires a
 // segment and section separated by a comma`.


### PR DESCRIPTION
### Pull Request Overview

Follow-on to #5006 fixing two things we missed.

Fixes #5012 


### Testing Strategy

I ran `make ci-job-chips` to test it.


### TODO or Help Wanted

I made these two only generate riscv32 since they're specific to a 32-bit chip.


### Checklist

- [X] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [X] No documentation updates are required.

#### AI Use

- [X] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
