### PR TITLE
arch: RISC-V: Redo and standardize how we include code for cross-compiling and `cargo test`

### DIFF
--- a/arch/riscv/build.rs
+++ b/arch/riscv/build.rs
@@ -74,6 +74,8 @@ fn main() {
     // Get build variables to determine how we are building the crate.
     let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
     let os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    println!("cargo::rerun-if-env-changed=CARGO_CFG_TARGET_ARCH");
+    println!("cargo::rerun-if-env-changed=CARGO_CFG_TARGET_OS");
 
     // `riscv_bare_metal`
     println!("cargo::rustc-check-cfg=cfg(riscv_bare_metal)");

--- a/arch/riscv/build.rs
+++ b/arch/riscv/build.rs
@@ -1,0 +1,89 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+//! Defines two cfg aliases for gating RISC-V specific code.
+//!
+//! 1. `riscv_bare_metal`: True when building for bare metal RISC-V platforms,
+//!    32 or 64 bit.
+//! 2. `riscv`: True when building for any RISC-V platform, 32 or 64 bit.
+//!
+//! `riscv_bare_metal` can be used to gate code that is only valid on bare metal
+//! systems where there is no other OS present. `riscv` can be used to gate code
+//! that is valid on any RISC-V platform, with or without an OS.
+//!
+//! Commonly, code that is Tock-specific and only makes sense on bare-metal
+//! platforms will be gated by the logic or of `riscv_bare_metal` and `doc`. For
+//! example:
+//!
+//! ```
+//! #[cfg(any(riscv_bare_metal, doc))]
+//! pub extern "C" fn _start_trap() -> ! {
+//!     // trap handler code...
+//! }
+//! ```
+//!
+//! This ensures that this code is only compiled and tested when the target is
+//! bare metal RISC-V, or when building documentation so that any function
+//! comments will be included in the rustdocs. However, cargo often builds Tock
+//! code targeted for the host machine (which is likely not RISC-V), for example
+//! when running tests. Therefore, we also need to include a mock implementation
+//! so the symbol still exists:
+//!
+//! ```
+//! #[cfg(not(any(riscv_bare_metal, doc)))]
+//! pub extern "C" fn _start_trap() -> ! {
+//!     unimplemented!()
+//! }
+//! ```
+//!
+//! By convention we just negate the check for the actual code.
+//!
+//! There may also be code that RISC-V specific, but is valid on bare metal or
+//! if targeting a platform with an OS. That can be gated with `riscv`. For
+//! example, a simple NOP instruction:
+//!
+//! ```
+//! #[cfg(any(riscv, doc))]
+//! pub fn nop() {
+//!     unsafe { asm!("nop"); }
+//! }
+//! ```
+//!
+//! Finally, there is some code that is rv32i- or rv64i-specific.
+//!
+//! That can be gated on the specific `target_arch` like this:
+//!
+//! ```
+//! #[cfg(all(target_arch = "riscv32", not(doc)))]
+//! pub const XLEN: usize = 32;
+//! #[cfg(all(target_arch = "riscv64", not(doc)))]
+//! pub const XLEN: usize = 64;
+//! ```
+//!
+//! However, to make non-cross-compiled compilations still work (like `cargo
+//! test`), and for documentation, we still need the mock implementation:
+//!
+//! ```
+//! #[cfg(any(not(riscv), doc))]
+//! pub const XLEN: usize = 32;
+//! ```
+//!
+
+fn main() {
+    // Get build variables to determine how we are building the crate.
+    let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    let os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+
+    // `riscv_bare_metal`
+    println!("cargo::rustc-check-cfg=cfg(riscv_bare_metal)");
+    if (arch == "riscv32" || arch == "riscv64") && os == "none" {
+        println!("cargo::rustc-cfg=riscv_bare_metal");
+    }
+
+    // `riscv`
+    println!("cargo::rustc-check-cfg=cfg(riscv)");
+    if arch == "riscv32" || arch == "riscv64" {
+        println!("cargo::rustc-cfg=riscv");
+    }
+}

--- a/arch/riscv/build.rs
+++ b/arch/riscv/build.rs
@@ -13,8 +13,8 @@
 //! that is valid on any RISC-V platform, with or without an OS.
 //!
 //! Commonly, code that is Tock-specific and only makes sense on bare-metal
-//! platforms will be gated by the logic or of `riscv_bare_metal` and `doc`. For
-//! example:
+//! platforms will be gated by the logical OR of `riscv_bare_metal` and `doc`.
+//! For example:
 //!
 //! ```
 //! #[cfg(any(riscv_bare_metal, doc))]

--- a/arch/riscv/src/dma_fence.rs
+++ b/arch/riscv/src/dma_fence.rs
@@ -44,7 +44,7 @@ impl RiscvCoherentDmaFence {
     }
 }
 
-#[cfg(any(doc, target_arch = "riscv32", target_arch = "riscv64"))]
+#[cfg(any(riscv_bare_metal, doc))]
 unsafe impl DmaFence for RiscvCoherentDmaFence {
     /// Expose prior writes to in-memory buffers to subsequent DMA operations.
     ///
@@ -156,7 +156,7 @@ unsafe impl DmaFence for RiscvCoherentDmaFence {
     }
 }
 
-#[cfg(not(any(doc, target_arch = "riscv32", target_arch = "riscv64")))]
+#[cfg(not(any(riscv_bare_metal, doc)))]
 unsafe impl DmaFence for RiscvCoherentDmaFence {
     fn release<T>(self, _slice_ptr: *mut [T]) {
         // When building for another architecture, such as for tests or CI:

--- a/arch/riscv/src/dma_fence.rs
+++ b/arch/riscv/src/dma_fence.rs
@@ -44,7 +44,7 @@ impl RiscvCoherentDmaFence {
     }
 }
 
-#[cfg(any(riscv_bare_metal, doc))]
+#[cfg(any(riscv, doc))]
 unsafe impl DmaFence for RiscvCoherentDmaFence {
     /// Expose prior writes to in-memory buffers to subsequent DMA operations.
     ///

--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -22,15 +22,16 @@ pub mod thread_id;
 /// `XLEN` is the width of an integer register in bits (either 32 or 64).
 pub const XLEN: usize = 1 << XLEN_LOG2;
 
-/// `XLEN_LOG2` is the log base 2 of XLEN.
-#[cfg(target_arch = "riscv32")]
+/// `XLEN_LOG2` is the log base 2 of [`XLEN`].
+///
+/// Actual value varies based on RISCV-32 vs. RISCV-64.
+// Use << operator to (somewhat) hide value in rustdocs.
+#[cfg(any(not(riscv), doc))]
+pub const XLEN_LOG2: usize = 3 << 1;
+#[cfg(all(target_arch = "riscv32", not(doc)))]
 pub const XLEN_LOG2: usize = 5;
-#[cfg(target_arch = "riscv64")]
+#[cfg(all(target_arch = "riscv64", not(doc)))]
 pub const XLEN_LOG2: usize = 6;
-// Default to 32 bit if no architecture is specified of if this is being
-// compiled for docs or testing on a different architecture.
-#[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
-pub const XLEN_LOG2: usize = 5;
 
 extern "C" {
     // Where the end of the stack region is (and hence where the stack should
@@ -64,19 +65,13 @@ extern "C" {
 ///    any Rust code runs. See <https://github.com/tock/tock/issues/2222> for more
 ///    information.
 /// 3. Finally it calls `main()`, the main entry point for Tock boards.
-#[cfg(any(doc, any(target_arch = "riscv32", target_arch = "riscv64")))]
+#[cfg(any(riscv_bare_metal, doc))]
 // Only apply the `link_section` attribute when actually targeting bare-metal
 // RISC-V. Host builds (e.g. `doc`, tests, clippy on macOS, Windows, Linux,
 // ...) use object formats (Mach-O, PE, ...) that reject a bare section name
 // like this, yielding errors such as: `mach-o section specifier requires a
 // segment and section separated by a comma`.
-#[cfg_attr(
-    any(
-        all(target_arch = "riscv32", target_os = "none"),
-        all(target_arch = "riscv64", target_os = "none")
-    ),
-    link_section = ".riscv.start"
-)]
+#[cfg_attr(riscv_bare_metal, link_section = ".riscv.start")]
 #[unsafe(naked)]
 // We don't want the function name symbol to be mangled in order to be able to refer to
 // it the linker script. It is not currently being used in the provided linker script
@@ -167,7 +162,7 @@ pub unsafe extern "C" fn initialize_ram_jump_to_main() {
 }
 
 // Mock implementation for tests on Travis-CI.
-#[cfg(not(any(doc, any(target_arch = "riscv32", target_arch = "riscv64"))))]
+#[cfg(not(any(riscv_bare_metal, doc)))]
 pub unsafe extern "C" fn initialize_ram_jump_to_main() {
     unimplemented!()
 }
@@ -198,16 +193,6 @@ pub unsafe fn configure_trap_handler() {
         csr::mtvec::mtvec::trap_addr.val(_start_trap as extern "C" fn() -> ! as usize >> 2)
             + csr::mtvec::mtvec::mode::CLEAR,
     );
-}
-
-// Mock implementation for tests on Travis-CI.
-#[cfg(not(any(
-    doc,
-    all(target_arch = "riscv32", target_os = "none"),
-    all(target_arch = "riscv64", target_os = "none")
-)))]
-pub extern "C" fn _start_trap() -> ! {
-    unimplemented!()
 }
 
 /// This is the trap handler function. This code is called on all traps,
@@ -312,23 +297,13 @@ pub extern "C" fn _start_trap() -> ! {
 /// invoked, it may, for instance, choose to ignore a certain trap, access
 /// global state (subject to synchronization), etc. It must still abide to
 /// the contract as stated above.
-#[cfg(any(
-    doc,
-    all(target_arch = "riscv32", target_os = "none"),
-    all(target_arch = "riscv64", target_os = "none")
-))]
+#[cfg(any(riscv_bare_metal, doc))]
 // Only apply the `link_section` attribute when actually targeting bare-metal
 // RISC-V. Host builds (e.g. `doc`, tests, clippy on macOS, Windows, Linux,
 // ...) use object formats (Mach-O, PE, ...) that reject a bare section name
 // like this, yielding errors such as: `mach-o section specifier requires a
 // segment and section separated by a comma`.
-#[cfg_attr(
-    any(
-        all(target_arch = "riscv32", target_os = "none"),
-        all(target_arch = "riscv64", target_os = "none")
-    ),
-    link_section = ".riscv.trap"
-)]
+#[cfg_attr(riscv_bare_metal, link_section = ".riscv.trap")]
 // We need the `_start_trap` function to be 256 byte aligned. The linker script
 // includes a check for whether a symbol named `_start_trap` exists. If it does,
 // it makes sure to align the `.riscv.trap` section on a 256 byte
@@ -480,6 +455,12 @@ pub extern "C" fn _start_trap() -> ! {
     );
 }
 
+// Mock implementation for tests on Travis-CI.
+#[cfg(not(any(riscv_bare_metal, doc)))]
+pub extern "C" fn _start_trap() -> ! {
+    unimplemented!()
+}
+
 /// RISC-V semihosting needs three exact instructions in uncompressed form.
 ///
 /// See <https://github.com/riscv/riscv-semihosting-spec/blob/main/riscv-semihosting-spec.adoc#11-semihosting-trap-instruction-sequence>
@@ -491,7 +472,7 @@ pub extern "C" fn _start_trap() -> ! {
 /// <https://elixir.bootlin.com/linux/v5.12.10/source/arch/riscv/include/asm/jump_label.h#L21>
 /// as suggested by the RISC-V developers:
 /// <https://groups.google.com/a/groups.riscv.org/g/isa-dev/c/XKkYacERM04/m/CdpOcqtRAgAJ>
-#[cfg(any(doc, any(target_arch = "riscv32", target_arch = "riscv64")))]
+#[cfg(any(riscv_bare_metal, doc))]
 pub unsafe fn semihost_command(command: usize, arg0: usize, arg1: usize) -> usize {
     use core::arch::asm;
     let res;
@@ -515,7 +496,7 @@ pub unsafe fn semihost_command(command: usize, arg0: usize, arg1: usize) -> usiz
 }
 
 // Mock implementation for tests on Travis-CI.
-#[cfg(not(any(doc, any(target_arch = "riscv32", target_arch = "riscv64"),)))]
+#[cfg(not(any(riscv_bare_metal, doc)))]
 pub unsafe fn semihost_command(_command: usize, _arg0: usize, _arg1: usize) -> usize {
     unimplemented!()
 }

--- a/arch/riscv/src/pseudo_instructions.rs
+++ b/arch/riscv/src/pseudo_instructions.rs
@@ -13,7 +13,35 @@
 //! `xlen_macros!` defines macros `lx` and `sx`, which function as
 //! pseudoinstructions for loading and storing XLEN-sized values.
 
-#[cfg(any(doc, target_arch = "riscv32"))]
+/// Generate `asm!()` macros to create register-sized load and store
+/// instructions.
+///
+/// On RISCV-32 this creates two psuedoinstructions:
+/// 1. `sx` -> `sw`
+/// 2. `lx` -> `lw`
+///
+/// On RISCV-64 this creates two psuedoinstructions:
+/// 1. `sx` -> `sd`
+/// 2. `lx` -> `ld`
+///
+/// These apply globally, and so only need to be included once in the project.
+/// For example:
+///
+/// ```rust,ignore
+/// use core::arch::naked_asm;
+/// use riscv::xlen_macros;
+/// naked_asm!(
+///     xlen_macros!(),
+///     "
+///     ...asm code here...
+///     "
+/// );
+/// ```
+#[cfg(any(not(riscv), doc))]
+#[macro_export]
+macro_rules! xlen_macros[() => [r""]];
+
+#[cfg(all(target_arch = "riscv32", not(doc)))]
 #[macro_export]
 macro_rules! xlen_macros[() => [r"
     .macro sx src, dest
@@ -24,7 +52,7 @@ macro_rules! xlen_macros[() => [r"
     .endm
 "]];
 
-#[cfg(target_arch = "riscv64")]
+#[cfg(all(target_arch = "riscv64", not(doc)))]
 #[macro_export]
 macro_rules! xlen_macros[() => [r"
     .macro sx src, dest

--- a/arch/riscv/src/support.rs
+++ b/arch/riscv/src/support.rs
@@ -6,7 +6,7 @@
 
 use crate::csr::{CSR, mstatus::mstatus};
 
-#[cfg(any(doc, target_arch = "riscv32", target_arch = "riscv64"))]
+#[cfg(any(riscv, doc))]
 #[inline(always)]
 /// NOP instruction
 pub fn nop() {
@@ -16,7 +16,7 @@ pub fn nop() {
     }
 }
 
-#[cfg(any(doc, target_arch = "riscv32", target_arch = "riscv64"))]
+#[cfg(any(riscv, doc))]
 #[inline(always)]
 /// Wait For Interrupt (WFI) instruction.
 pub unsafe fn wfi() {
@@ -51,14 +51,12 @@ where
 }
 
 // Mock implementations for tests on Travis-CI.
-#[cfg(not(any(doc, target_arch = "riscv32", target_arch = "riscv64")))]
-/// NOP instruction (mock)
+#[cfg(not(any(riscv, doc)))]
 pub fn nop() {
     unimplemented!()
 }
 
-#[cfg(not(any(doc, target_arch = "riscv32", target_arch = "riscv64")))]
-/// WFI instruction (mock)
+#[cfg(not(any(riscv, doc)))]
 pub unsafe fn wfi() {
     unimplemented!()
 }

--- a/arch/riscv/src/syscall.rs
+++ b/arch/riscv/src/syscall.rs
@@ -55,7 +55,7 @@ const STORED_STATE_SIZE: usize = size_of::<RiscvStoredState>();
 const TAG: [u8; 4] = *b"rv5i";
 #[cfg(target_arch = "riscv64")]
 const TAG: [u8; 8] = *b"rv64i___";
-#[cfg(not(any(doc, target_arch = "riscv32", target_arch = "riscv64")))]
+#[cfg(not(riscv))]
 const TAG: [u8; 8] = *b"noopnoop";
 const METADATA_LEN: usize = 3;
 
@@ -116,7 +116,7 @@ impl core::convert::TryFrom<&[u8]> for RiscvStoredState {
 /// Helper function for encoding a syscall return into registers.
 ///
 /// This is a helper function to wrap the differences between rv32i and rv64i.
-#[cfg(any(doc, target_arch = "riscv32"))]
+#[cfg(target_arch = "riscv32")]
 fn encode_syscall_return_helper(
     return_value: kernel::syscall::SyscallReturn,
     a0: &mut usize,
@@ -176,7 +176,7 @@ fn encode_syscall_return_helper(
     );
 }
 
-#[cfg(not(any(doc, any(target_arch = "riscv32", target_arch = "riscv64"))))]
+#[cfg(not(riscv))]
 fn encode_syscall_return_helper(
     _return_value: kernel::syscall::SyscallReturn,
     _a0: &mut usize,
@@ -190,7 +190,7 @@ fn encode_syscall_return_helper(
 /// Helper to convert registers to a [`Syscall`](kernel::syscall::Syscall).
 ///
 /// The helper wraps both rv32i and rv64i support.
-#[cfg(any(doc, target_arch = "riscv32"))]
+#[cfg(target_arch = "riscv32")]
 fn syscall_from_register_arguments_helper(
     syscall_number: usize,
     r0: usize,
@@ -227,7 +227,7 @@ fn syscall_from_register_arguments_helper(
 /// Helper to put upcall arguments into registers.
 ///
 /// The helper wraps both rv32i and rv64i support.
-#[cfg(any(doc, target_arch = "riscv32"))]
+#[cfg(target_arch = "riscv32")]
 fn encode_upcall_helper(
     upcall: &kernel::process::FunctionCall,
     a0: &mut usize,
@@ -275,7 +275,7 @@ fn encode_upcall_helper(
     kernel::utilities::arch_helpers::encode_upcall_trd64bit(upcall, a0_u64, a1_u64, a2_u64, a3_u64);
 }
 
-#[cfg(not(any(doc, any(target_arch = "riscv32", target_arch = "riscv64"))))]
+#[cfg(not(riscv))]
 fn encode_upcall_helper(
     _upcall: &kernel::process::FunctionCall,
     _a0: &mut usize,
@@ -383,29 +383,7 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
         Ok(())
     }
 
-    // Mock implementation for tests on Travis-CI.
-    #[cfg(not(any(
-        doc,
-        all(target_arch = "riscv32", target_os = "none"),
-        all(target_arch = "riscv64", target_os = "none")
-    )))]
-    unsafe fn switch_to_process(
-        &self,
-        _accessible_memory_start: *const u8,
-        _app_brk: *const u8,
-        _state: &mut RiscvStoredState,
-    ) -> (ContextSwitchReason, Option<*const u8>) {
-        // Convince lint that 'mcause' and 'R_A4' are used during test build
-        let _cause = mcause::Trap::from(_state.mcause);
-        let _arg4 = _state.regs[R_A4];
-        unimplemented!()
-    }
-
-    #[cfg(any(
-        doc,
-        all(target_arch = "riscv32", target_os = "none"),
-        all(target_arch = "riscv64", target_os = "none")
-    ))]
+    #[cfg(any(riscv_bare_metal, doc))]
     unsafe fn switch_to_process(
         &self,
         _accessible_memory_start: *const u8,
@@ -856,6 +834,20 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
         };
         let new_stack_pointer = state.regs[R_SP];
         (ret, Some(new_stack_pointer as *const u8))
+    }
+
+    // Mock implementation for tests on Travis-CI.
+    #[cfg(not(any(riscv_bare_metal, doc)))]
+    unsafe fn switch_to_process(
+        &self,
+        _accessible_memory_start: *const u8,
+        _app_brk: *const u8,
+        _state: &mut RiscvStoredState,
+    ) -> (ContextSwitchReason, Option<*const u8>) {
+        // Convince lint that 'mcause' and 'R_A4' are used during test build
+        let _cause = mcause::Trap::from(_state.mcause);
+        let _arg4 = _state.regs[R_A4];
+        unimplemented!()
     }
 
     unsafe fn print_context(

--- a/arch/riscv/src/thread_id.rs
+++ b/arch/riscv/src/thread_id.rs
@@ -18,10 +18,7 @@ pub enum RiscvThreadIdProvider {}
 //
 // The assembly (read `mhartid`, load the `_trap_handler_active` symbol address,
 // read a `usize`) is XLEN-agnostic, so the same code serves both rv32 and rv64.
-#[cfg(all(
-    any(target_arch = "riscv32", target_arch = "riscv64"),
-    target_os = "none"
-))]
+#[cfg(any(riscv_bare_metal, doc))]
 unsafe impl ThreadIdProvider for RiscvThreadIdProvider {
     /// Return the current thread ID, computed using the `mhartid` (hardware thread
     /// ID), and a flag indicating whether the current hart is currently in a trap
@@ -86,10 +83,7 @@ unsafe impl ThreadIdProvider for RiscvThreadIdProvider {
 }
 
 // Mock implementation for non-RISC-V (host / doc) target builds
-#[cfg(not(all(
-    any(target_arch = "riscv32", target_arch = "riscv64"),
-    target_os = "none"
-)))]
+#[cfg(not(any(riscv_bare_metal, doc)))]
 unsafe impl ThreadIdProvider for RiscvThreadIdProvider {
     fn running_thread_id() -> usize {
         unimplemented!()

--- a/arch/riscv/src/thread_id.rs
+++ b/arch/riscv/src/thread_id.rs
@@ -82,7 +82,7 @@ unsafe impl ThreadIdProvider for RiscvThreadIdProvider {
     }
 }
 
-// Mock implementation for non-RISC-V (host / doc) target builds
+// Mock implementation for non-RISC-V (host) target builds
 #[cfg(not(any(riscv_bare_metal, doc)))]
 unsafe impl ThreadIdProvider for RiscvThreadIdProvider {
     fn running_thread_id() -> usize {


### PR DESCRIPTION


### Pull Request Overview

The main change here is adding two flags we can use in `cfg`s via build.rs for the `riscv` crate:

- `riscv_bare_metal`: We are building for bare metal RISC-V with `target_os = none`.
- `riscv`: We are building for any RISC-V platform.

These add another indirection layer, but, they do simplify the code and avoid long wrapping `cfg` statements that are easy to make inconsistent.

This PR makes an opinion on documentation with 32-bit vs. 64-bit code. Since the `riscv` crate supports both, I don't think it is correct to document one or the other. So, `target_arch = "riscv32"` is always coupled with `not(doc)` (same with `target_arch = "riscv64"`). Then the separate item to be documented is `#[cfg(any(not(riscv), doc))]` to build on non-RISC-V and for doc.

This also standardizes on arch first, doc second, in the cfg.

There are many cases we need to consider when `cfg`-ing code in arch:

1. Tock-specific code with asm: `#[cfg(any(riscv_bare_metal, doc))]`. Only build if targeting riscv bare metal, OR generating docs. Ideally get the docs from what is likely the most documented function.
2. RISC-V-specific code with asm: `#[cfg(any(riscv, doc))]`.
3. Public 32-bit RISC-V code: `#[cfg(all(target_arch = "riscv32", not(doc)))]`.
4. Public 64-bit RISC-V code: `#[cfg(all(target_arch = "riscv64", not(doc)))]`.
5. RISC-V code with differences between 32-bit and 64-bit for documentation and non-riscv compiling: `#[cfg(any(not(riscv), doc))]`.
6. Private 32-bit RISC-V code: `#[cfg(target_arch = "riscv32")]`.
7. Private 64-bit RISC-V code: `#[cfg(target_arch = "riscv64")]`.
8. Private RISC-V code for compiling: `#[cfg(not(riscv))]`.

---

This is the promised followup to https://github.com/tock/tock/pull/4873#discussion_r3616781918



### Testing Strategy

Running various board builds and `cargo doc` and `cargo test`.


### TODO or Help Wanted

Well, we need to decide we are ok with build.rs-defined configs. I would rather _not_ add them, but this is so messy the indirection layer not only makes for a single place to comment, but makes reading them in the actual riscv source so much easier. It is also easier to reason about bare metal vs not, and what should be documented.


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
