### PR TITLE
arch: riscv: csr: simplify cfgs

### DIFF
--- a/arch/riscv/src/csr/mseccfg.rs
+++ b/arch/riscv/src/csr/mseccfg.rs
@@ -4,8 +4,6 @@
 
 use kernel::utilities::registers::register_bitfields;
 
-// Default to 32 bit if compiling for debug/testing.
-#[cfg(not(target_arch = "riscv64"))]
 register_bitfields![usize,
     pub mseccfg [
         mml OFFSET(0) NUMBITS(1) [],
@@ -19,14 +17,5 @@ register_bitfields![usize,
     pub mseccfgh [
         // This isn't a real entry, it just avoids compilation errors
         none OFFSET(0) NUMBITS(1) [],
-    ]
-];
-
-#[cfg(target_arch = "riscv64")]
-register_bitfields![usize,
-    pub mseccfg [
-        mml OFFSET(0) NUMBITS(1) [],
-        mmwp OFFSET(1) NUMBITS(1) [],
-        rlb OFFSET(2) NUMBITS(1) [],
     ]
 ];

--- a/arch/riscv/src/csr/pmpconfig.rs
+++ b/arch/riscv/src/csr/pmpconfig.rs
@@ -5,10 +5,7 @@
 use kernel::utilities::registers::register_bitfields;
 
 // Default to 32 bit if compiling for debug/testing.
-#[cfg(any(
-    target_arch = "riscv32",
-    all(not(target_arch = "riscv32"), not(target_arch = "riscv64"))
-))]
+#[cfg(not(target_arch = "riscv64"))]
 register_bitfields![usize,
     pub pmpcfg [
         r0 OFFSET(0) NUMBITS(1) [],


### PR DESCRIPTION


### Pull Request Overview

There were a couple CSR cfgs that I think are pretty superfluous. Note, the CSR module widely uses `#[cfg(not(target_arch = "riscv64"))]`.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

I checked with claude that my understanding that

```
#[cfg(any(
    target_arch = "riscv32",
    all(not(target_arch = "riscv32"), not(target_arch = "riscv64"))
))]
```
and
```
#[cfg(not(target_arch = "riscv64"))]
```
are the same.
