### PR TITLE
kernel: helpers: fix doc comment rust syntax

### DIFF
--- a/kernel/src/utilities/helpers.rs
+++ b/kernel/src/utilities/helpers.rs
@@ -193,7 +193,7 @@ macro_rules! stack_size {
 ///         kernel: kernel,
 ///         chip: chip,
 ///         ...
-///     )};
+///     });
 /// }
 /// ```
 ///


### PR DESCRIPTION
### Pull Request Overview

Fix this warning:

```
❯ cargo doc
 Documenting kernel v0.2.3-dev (/Users/bradjc/git/tock/kernel)
warning: could not parse code block as Rust code
   --> kernel/src/utilities/helpers.rs:187:5
    |
187 |   /// ```rust,ignore
    |  _____^
188 | | /// let process_uninit: &mut MaybeUninit<ProcessStandard<C, D>> =
189 | | ///     unsafe { &mut *process_struct_memory_location };
190 | | ///
...   |
196 | | /// }
197 | | /// ```
    | |_______^
    |
help: `ignore` code blocks require valid Rust code for syntax highlighting; mark blocks that do not contain Rust code as text: ```text
   --> kernel/src/utilities/helpers.rs:187:5
    |
187 | /// ```rust,ignore
    |     ^^^
    = note: error from rustc: unexpected closing delimiter: `}`
    = note: `#[warn(rustdoc::invalid_rust_codeblocks)]` on by default

warning: `kernel` (lib doc) generated 1 warning
    Finished `dev` profile [optimized + debuginfo] target(s) in 1.11s
   Generated /Users/bradjc/git/tock/target/doc/kernel/index.html
```


### Testing Strategy

`cargo doc` in the kernel crate.


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
