### PR TITLE
arch: rv64: machine timer for 64-bit

### DIFF
--- a/arch/rv64i/src/machine_timer.rs
+++ b/arch/rv64i/src/machine_timer.rs
@@ -9,6 +9,26 @@ use kernel::hil::time::{Ticks, Ticks64};
 use kernel::utilities::registers::ReadWrite;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 
+/// A RISC-V machine timer, read/written as a single 64-bit MMIO access.
+///
+/// # Atomicity assumption
+///
+/// This driver assumes `compare` and `value` are backed by a genuinely
+/// 64-bit-wide MMIO register — i.e. that a single `u64` load/store to
+/// them is an atomic bus transaction, per RISC-V Privileged Architectures
+/// §3.1.15 ("Attempts to read the mtime register while an update is
+/// in progress do not cause the read to stall ... implementations must
+/// provide the appearance that writes to mtimecmp ... are atomic when
+/// naturally aligned").
+///
+/// This holds for a standard/reference CLINT (e.g. SiFive-style), which is
+/// what every RV64 board Tock currently supports uses. It is NOT universal:
+/// at least one shipping RV64 core (T-Head C9xx, used in Allwinner D1 /
+/// Sipeed Lichee RV / Nezha) only supports 32-bit-wide mtime/mtimecmp
+/// accesses and requires split reads/writes
+/// (see <https://github.com/riscv/riscv-isa-manual/issues/639> and the
+/// upstream Linux `timer-clint` T-Head quirk driver). If a board ever targets
+/// such a core, it must use the 32-bit driver instead for correctness.
 pub struct MachineTimer<'a> {
     compare: &'a ReadWrite<u64>,
     value: &'a ReadWrite<u64>,

--- a/arch/rv64i/src/machine_timer.rs
+++ b/arch/rv64i/src/machine_timer.rs
@@ -10,43 +10,21 @@ use kernel::utilities::registers::ReadWrite;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 
 pub struct MachineTimer<'a> {
-    compare_low: &'a ReadWrite<u32>,
-    compare_high: &'a ReadWrite<u32>,
-    value_low: &'a ReadWrite<u32>,
-    value_high: &'a ReadWrite<u32>,
+    compare: &'a ReadWrite<u64>,
+    value: &'a ReadWrite<u64>,
 }
 
 impl<'a> MachineTimer<'a> {
-    pub const fn new(
-        compare_low: &'a ReadWrite<u32>,
-        compare_high: &'a ReadWrite<u32>,
-        value_low: &'a ReadWrite<u32>,
-        value_high: &'a ReadWrite<u32>,
-    ) -> Self {
-        MachineTimer {
-            compare_low,
-            compare_high,
-            value_low,
-            value_high,
-        }
+    pub const fn new(compare: &'a ReadWrite<u64>, value: &'a ReadWrite<u64>) -> Self {
+        MachineTimer { compare, value }
     }
 
     pub fn disable_machine_timer(&self) {
-        self.compare_high.set(0xFFFF_FFFF);
-        self.compare_low.set(0xFFFF_FFFF);
+        self.compare.set(0xFFFF_FFFF_FFFF_FFFF);
     }
 
     pub fn now(&self) -> Ticks64 {
-        let first_low: u32 = self.value_low.get();
-        let mut high: u32 = self.value_high.get();
-        let second_low: u32 = self.value_low.get();
-
-        if second_low < first_low {
-            // Wraparound
-            high = self.value_high.get();
-        }
-
-        Ticks64::from(((high as u64) << 32) | second_low as u64)
+        Ticks64::from(self.value.get())
     }
 
     pub fn set_alarm(&self, reference: Ticks64, dt: Ticks64) {
@@ -56,7 +34,6 @@ impl<'a> MachineTimer<'a> {
         // maximum value, issuing a callback on the overflow client
         // if there is one, spinning until it wraps around to 0, then
         // setting the compare to the correct value.
-        let regs = self;
         let now = self.now();
         let mut expire = reference.wrapping_add(dt);
 
@@ -64,22 +41,11 @@ impl<'a> MachineTimer<'a> {
             expire = now;
         }
 
-        let val = expire.into_u64();
-
-        let high = (val >> 32) as u32;
-        let low = (val & 0xffffffff) as u32;
-
-        // Recommended approach for setting the two compare registers
-        // (RISC-V Privileged Architectures 3.1.15) -pal 8/6/20
-        regs.compare_low.set(0xFFFF_FFFF);
-        regs.compare_high.set(high);
-        regs.compare_low.set(low);
+        self.compare.set(expire.into_u64());
     }
 
     pub fn get_alarm(&self) -> Ticks64 {
-        let mut val: u64 = (self.compare_high.get() as u64) << 32;
-        val |= self.compare_low.get() as u64;
-        Ticks64::from(val)
+        Ticks64::from(self.compare.get())
     }
 
     pub fn disarm(&self) -> Result<(), ErrorCode> {
@@ -90,7 +56,7 @@ impl<'a> MachineTimer<'a> {
     pub fn is_armed(&self) -> bool {
         // Check if mtimecmp is the max value. If it is, then we are not armed,
         // otherwise we assume we have a value set.
-        self.compare_high.get() != 0xFFFF_FFFF || self.compare_low.get() != 0xFFFF_FFFF
+        self.compare.get() != 0xFFFF_FFFF_FFFF_FFFF
     }
 
     pub fn minimum_dt(&self) -> Ticks64 {


### PR DESCRIPTION


### Pull Request Overview

In #4976, we decided to only make CLIC shared, and not machine timer, as our understanding was that machine timer could be optimized for 64-bit machines.

This is Claude's optimization of the machine timer file on known 64-bit hardware.


### Testing Strategy

This is not tested, and I don't know how to test it.


### TODO or Help Wanted

Does this look ok?


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

I asked claude to optimize this file for 64-bit machines. The changes look very reasonable, basically removing all of the high and low registers in favor of just directly 64 bit registers.
