### PR TITLE
Dev/rv64/ci roundtrip

### DIFF
--- a/.github/workflows/qemu_rv64_virt.yml
+++ b/.github/workflows/qemu_rv64_virt.yml
@@ -33,7 +33,7 @@ jobs:
       # that other steps (such as the Rust toolchain) depend on files
       # in this repo.
       - name: Checkout the current repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # Install qemu-system-riscv64 (provided by qemu-system-misc) and the
       # RISC-V userspace toolchain. ubuntu-24.04 ships QEMU 8.2.x, which is new
@@ -41,21 +41,20 @@ jobs:
       - name: Update packages and install dependencies
         run: |
           sudo apt update
-          sudo apt-get install -y qemu-system-misc gcc-riscv64-unknown-elf unzip
+          sudo apt-get install -y qemu-system-misc gcc-riscv64-unknown-elf
 
       # Install elf2tab, required to build libtock-c userspace apps.
       - name: Install elf2tab
         run: |
-          cargo install elf2tab@0.12.0
+          cargo install elf2tab@0.13.0
 
       # Check out libtock-c to build a real userspace app.
       - name: Checkout libtock-c
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: tock/libtock-c
-          # Pinned to the branch pending tock/libtock-c#572; switch to a pinned
-          # SHA once #572 merges.
-          ref: dev/riscv-medany
+          # Pinned to the libtock-c commit that added rv64 support (tock/libtock-c#572).
+          ref: 32c7099ffaba54e9f847da8009ef74ade8442314
           path: libtock-c
 
       # Build the qemu_rv64_virt board kernel.

--- a/.github/workflows/qemu_rv64_virt.yml
+++ b/.github/workflows/qemu_rv64_virt.yml
@@ -41,7 +41,19 @@ jobs:
       - name: Update packages and install dependencies
         run: |
           sudo apt update
-          sudo apt-get install -y qemu-system-misc gcc-riscv64-unknown-elf
+          sudo apt-get install -y qemu-system-misc
+
+      # libtock-c drops all rv64 targets when the rv64 compiler is older than
+      # GCC 15 (see libtock-c Configuration.mk). ubuntu-24.04's apt
+      # gcc-riscv64-unknown-elf is 13.2, so install the same GCC-15 xPack
+      # toolchain that libtock-c's own CI uses for rv64.
+      - name: Install RISC-V toolchain (GCC 15, xPack)
+        run: |
+          npm install --location=global xpm@latest
+          xpm install --global @xpack-dev-tools/riscv-none-elf-gcc@latest
+          RISCV_DIR="$(find "$HOME/.local/xPacks/@xpack-dev-tools/riscv-none-elf-gcc" -maxdepth 1 -type d -name '[0-9]*' | sort -V | tail -n 1)"
+          echo "$RISCV_DIR/.content/bin" >> "$GITHUB_PATH"
+          "$RISCV_DIR/.content/bin/riscv-none-elf-gcc" --version
 
       # Install elf2tab, required to build libtock-c userspace apps.
       - name: Install elf2tab

--- a/.github/workflows/qemu_rv64_virt.yml
+++ b/.github/workflows/qemu_rv64_virt.yml
@@ -1,0 +1,84 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2026.
+
+# This workflow builds a real libtock-c example app, boots the qemu_rv64_virt
+# board kernel under qemu-system-riscv64 with that app loaded, and asserts that
+# the app actually ran. This exercises the rv64 userspace round-trip
+# (switch_to_process -> mret -> ecall -> kernel -> UART), which nothing else in
+# CI currently covers.
+
+name: qemu-rv64-virt-ci
+env:
+  TERM: xterm # Makes tput work in actions output
+
+# Controls when the action will run. Triggers the workflow on push or pull
+# request events but only for the master branch
+on:
+  push: # Run CI for all branches except GitHub merge queue tmp branches
+    branches-ignore:
+    - "gh-readonly-queue/**"
+  pull_request: # Run CI for PRs on any branch
+  merge_group: # Run CI for the GitHub merge queue
+
+permissions:
+  contents: read
+
+jobs:
+  qemu-rv64-virt-ci:
+    runs-on: ubuntu-24.04
+
+    steps:
+      # Checkout the Tock repo, needs to happen at the beginning given
+      # that other steps (such as the Rust toolchain) depend on files
+      # in this repo.
+      - name: Checkout the current repository
+        uses: actions/checkout@v4
+
+      # Install qemu-system-riscv64 (provided by qemu-system-misc) and the
+      # RISC-V userspace toolchain. ubuntu-24.04 ships QEMU 8.2.x, which is new
+      # enough for the qemu_rv64_virt board (known broken: <= 8.1.5).
+      - name: Update packages and install dependencies
+        run: |
+          sudo apt update
+          sudo apt-get install -y qemu-system-misc gcc-riscv64-unknown-elf unzip
+
+      # Install elf2tab, required to build libtock-c userspace apps.
+      - name: Install elf2tab
+        run: |
+          cargo install elf2tab@0.12.0
+
+      # Check out libtock-c to build a real userspace app.
+      - name: Checkout libtock-c
+        uses: actions/checkout@v4
+        with:
+          repository: tock/libtock-c
+          # Pinned to the branch pending tock/libtock-c#572; switch to a pinned
+          # SHA once #572 merges.
+          ref: dev/riscv-medany
+          path: libtock-c
+
+      # Build the qemu_rv64_virt board kernel.
+      - name: Build the qemu_rv64_virt kernel
+        run: |
+          make -C boards/qemu_rv64_virt
+
+      # Build the c_hello example app for the qemu_rv64_virt memory map. A single
+      # rv64imac target fixed-linked at the board's app flash/RAM addresses is
+      # sufficient; the kernel loads it at 0x80100000 (the start of its `prog`
+      # region).
+      - name: Build the c_hello app
+        run: |
+          make -C libtock-c/examples/c_hello \
+            TOCK_TARGETS="rv64imac|rv64imac.0x80100080.0x80300000|0x80100080|0x80300000"
+
+      # Boot the kernel with the app loaded and assert that it ran. QEMU does not
+      # exit on its own (the kernel keeps running after the app yields), so bound
+      # the run with `timeout` and then grep the captured serial output.
+      - name: Run the app on qemu_rv64_virt and assert output
+        run: |
+          set -o pipefail
+          timeout --foreground 60 make run-app -C boards/qemu_rv64_virt \
+            APP=$GITHUB_WORKSPACE/libtock-c/examples/c_hello/build/rv64imac/rv64imac.0x80100080.0x80300000.tbf \
+            2>&1 | tee qemu.log || true
+          grep -q "Hello World!" qemu.log

--- a/.github/workflows/qemu_rv64_virt.yml
+++ b/.github/workflows/qemu_rv64_virt.yml
@@ -57,15 +57,13 @@ jobs:
       # Install elf2tab, required to build libtock-c userspace apps.
       - name: Install elf2tab
         run: |
-          cargo install elf2tab@0.13.0
+          cargo install elf2tab
 
       # Check out libtock-c to build a real userspace app.
       - name: Checkout libtock-c
         uses: actions/checkout@v7
         with:
           repository: tock/libtock-c
-          # Pinned to the libtock-c commit that added rv64 support (tock/libtock-c#572).
-          ref: 32c7099ffaba54e9f847da8009ef74ade8442314
           path: libtock-c
 
       # Build the qemu_rv64_virt board kernel.

--- a/.github/workflows/qemu_rv64_virt.yml
+++ b/.github/workflows/qemu_rv64_virt.yml
@@ -5,8 +5,7 @@
 # This workflow builds a real libtock-c example app, boots the qemu_rv64_virt
 # board kernel under qemu-system-riscv64 with that app loaded, and asserts that
 # the app actually ran. This exercises the rv64 userspace round-trip
-# (switch_to_process -> mret -> ecall -> kernel -> UART), which nothing else in
-# CI currently covers.
+# (switch_to_process -> mret -> ecall -> kernel -> UART).
 
 name: qemu-rv64-virt-ci
 env:


### PR DESCRIPTION
### Pull Request Overview

**This is PR #4880 by @siju-felsite that we already merged, but to the wrong branch. This PR just repurposes that PR for master. See original discussion in #4880. Original description follows**

#4878 enabled `switch_to_process` on rv64, but nothing in CI exercises the rv64 userspace path, so it could silently regress. This adds a CI test that boots a real process on `qemu_rv64_virt` and asserts it runs.

Per the discussion below, this uses a real **libtock-c** app rather than a committed hand-asm `.tbf`. A new standalone `.github/workflows/qemu_rv64_virt.yml` (modeled on `litex_sim.yml`) builds the `qemu_rv64_virt` kernel and a real libtock-c `c_hello` app (from @bradjc's `dev/riscv-medany` branch, tock/libtock-c#572), boots it on `qemu-system-riscv64` (ubuntu-24.04's QEMU 8.2.2 — no from-source build), and asserts `Hello World!`, which only prints if `switch_to_process` -> mret-to-user -> `ecall` -> kernel -> UART all run. re #2332.

Note: the libtock-c ref is pinned to the `dev/riscv-medany` branch pending tock/libtock-c#572; it should switch to a pinned commit (like litex_sim's `.libtock_c_ci_rev`) once #572 merges.

### Testing Strategy

Validated locally end-to-end with `qemu-system-riscv64` 8.2.2: the kernel + `c_hello` build, the app loads at the board's prog region (`0x80100000`), and the run prints `Hello World!`. `make prepush` passes.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.
### Formatting

- [x] Ran `make prepush`.
### AI Use

This change was developed with the assistance of an AI coding assistant (Claude / Claude Code) and reviewed before submission.

- [x] The PR description details my use of AI in the production of the code in this PR, if any, and I have manually checked and personally certify the entire contents of this PR.
