### PR TITLE
doc: update peripheral_management doc examples from VolatileCell to ReadWrite

### DIFF
--- a/kernel/src/utilities/peripheral_management.rs
+++ b/kernel/src/utilities/peripheral_management.rs
@@ -11,15 +11,15 @@
 //! Generally, Tock peripherals are modeled by two structures, such as:
 //!
 //! ```rust
-//! # use kernel::utilities::cells::VolatileCell;
 //! # use kernel::utilities::StaticRef;
+//! # use kernel::utilities::registers::ReadWrite;
 //! # struct ChipSpecificPeripheralClock {};
 //! /// The MMIO Structure.
 //! #[repr(C)]
 //! #[allow(dead_code)]
 //! pub struct PeripheralRegisters {
-//!     control: VolatileCell<u32>,
-//!     interrupt_mask: VolatileCell<u32>,
+//!     control: ReadWrite<u32>,
+//!     interrupt_mask: ReadWrite<u32>,
 //! }
 //!
 //! /// The Tock object that holds all information for this peripheral.
@@ -36,12 +36,13 @@
 //! MMIO pointer safely, Tock provides the PeripheralManager interface:
 //!
 //! ```rust
-//! # use kernel::utilities::cells::VolatileCell;
 //! # use kernel::utilities::peripheral_management::PeripheralManager;
 //! # use kernel::utilities::StaticRef;
+//! # use kernel::utilities::registers::ReadWrite;
+//! # use kernel::utilities::registers::interfaces::Writeable;
 //! # use kernel::ErrorCode;
 //! # use kernel::hil;
-//! # struct PeripheralRegisters { control: VolatileCell<u32> };
+//! # struct PeripheralRegisters { control: ReadWrite<u32> };
 //! # struct PeripheralHardware { mmio_address: StaticRef<PeripheralRegisters> };
 //! impl hil::uart::Configure for PeripheralHardware {
 //!     fn configure(&self, params: hil::uart::Parameters) -> Result<(), ErrorCode> {
@@ -186,10 +187,11 @@ where
 /// object.
 ///
 /// ```
-/// # use kernel::utilities::cells::VolatileCell;
 /// # use kernel::utilities::peripheral_management::PeripheralManager;
 /// # use kernel::utilities::StaticRef;
-/// # pub struct PeripheralRegisters { control: VolatileCell<u32> };
+/// # use kernel::utilities::registers::ReadWrite;
+/// # use kernel::utilities::registers::interfaces::Writeable;
+/// # pub struct PeripheralRegisters { control: ReadWrite<u32> };
 /// # pub struct PeripheralHardware { mmio_address: StaticRef<PeripheralRegisters> };
 /// impl PeripheralHardware {
 ///     fn example(&self) {


### PR DESCRIPTION
### Pull Request Overview

This is part of an effort triggered by https://github.com/tock/tock/pull/5002 to review our use of VolatileCell.

This is just updating a documentation example, no real code changes.

### Testing Strategy

Claude verified that `cargo test -p kernel --doc peripheral_management` passes all 5 doctests (the 3 unmodified plus the 2 touched here).

### TODO or Help Wanted

N/A

### Checklist

- [x] Ran `make prepush`.

### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

Claude authored the changes and commit; I cleaned the text up a little and verified them.
