### PR TITLE
chips/segger, boards/components: convert RTT buffers from VolatileCell to InMemoryRegister

### DIFF
--- a/boards/components/src/segger_rtt.rs
+++ b/boards/components/src/segger_rtt.rs
@@ -25,7 +25,7 @@ use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::hil::time::{self, Alarm};
-use kernel::utilities::cells::VolatileCell;
+use kernel::utilities::registers::InMemoryRegister;
 use segger::rtt::{SeggerRtt, SeggerRttMemory};
 
 // Setup static space for the objects.
@@ -34,10 +34,12 @@ macro_rules! segger_rtt_memory_component_static {
     () => {{
         let rtt_memory = kernel::static_named_buf!(segger::rtt::SeggerRttMemory, "_SEGGER_RTT");
         let up_buffer = kernel::static_buf!(
-            [kernel::utilities::cells::VolatileCell<u8>; segger::rtt::DEFAULT_UP_BUFFER_LENGTH]
+            [kernel::utilities::registers::InMemoryRegister<u8>;
+                segger::rtt::DEFAULT_UP_BUFFER_LENGTH]
         );
         let down_buffer = kernel::static_buf!(
-            [kernel::utilities::cells::VolatileCell<u8>; segger::rtt::DEFAULT_DOWN_BUFFER_LENGTH]
+            [kernel::utilities::registers::InMemoryRegister<u8>;
+                segger::rtt::DEFAULT_DOWN_BUFFER_LENGTH]
         );
 
         (rtt_memory, up_buffer, down_buffer)
@@ -76,8 +78,8 @@ impl SeggerRttMemoryComponent {
 impl Component for SeggerRttMemoryComponent {
     type StaticInput = (
         &'static mut MaybeUninit<SeggerRttMemory<'static>>,
-        &'static mut MaybeUninit<[VolatileCell<u8>; segger::rtt::DEFAULT_UP_BUFFER_LENGTH]>,
-        &'static mut MaybeUninit<[VolatileCell<u8>; segger::rtt::DEFAULT_DOWN_BUFFER_LENGTH]>,
+        &'static mut MaybeUninit<[InMemoryRegister<u8>; segger::rtt::DEFAULT_UP_BUFFER_LENGTH]>,
+        &'static mut MaybeUninit<[InMemoryRegister<u8>; segger::rtt::DEFAULT_DOWN_BUFFER_LENGTH]>,
     );
     type Output = SeggerRttMemoryRefs<'static>;
 
@@ -86,9 +88,10 @@ impl Component for SeggerRttMemoryComponent {
         let up_buffer_name = name;
         let down_buffer_name = name;
         let up_buffer =
-            s.1.write([const { VolatileCell::new(0) }; segger::rtt::DEFAULT_UP_BUFFER_LENGTH]);
-        let down_buffer =
-            s.2.write([const { VolatileCell::new(0) }; segger::rtt::DEFAULT_DOWN_BUFFER_LENGTH]);
+            s.1.write([const { InMemoryRegister::new(0) }; segger::rtt::DEFAULT_UP_BUFFER_LENGTH]);
+        let down_buffer = s
+            .2
+            .write([const { InMemoryRegister::new(0) }; segger::rtt::DEFAULT_DOWN_BUFFER_LENGTH]);
 
         let rtt_memory = s.0.write(SeggerRttMemory::new_raw(
             up_buffer_name,

--- a/chips/segger/src/rtt.rs
+++ b/chips/segger/src/rtt.rs
@@ -90,8 +90,10 @@ use kernel::ErrorCode;
 use kernel::hil;
 use kernel::hil::time::ConvertTicks;
 use kernel::hil::uart;
-use kernel::utilities::cells::{OptionalCell, TakeCell, VolatileCell};
+use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::utilities::io_write::IoWrite;
+use kernel::utilities::registers::InMemoryRegister;
+use kernel::utilities::registers::interfaces::{Readable, Writeable};
 
 /// Suggested length for the up buffer to pass to the Segger RTT capsule.
 pub const DEFAULT_UP_BUFFER_LENGTH: usize = 1024;
@@ -123,16 +125,16 @@ pub struct SeggerRttMemory<'a> {
 pub struct SeggerRttBuffer<'a> {
     name: *const u8, // Pointer to the name of this channel. Must be a 4 byte thin pointer.
     // These fields are marked as `pub` to allow access in the panic handler.
-    pub buffer: *const VolatileCell<u8>, // Pointer to the buffer for this channel.
+    pub buffer: *const InMemoryRegister<u8>, // Pointer to the buffer for this channel.
     pub length: u32,
-    pub write_position: VolatileCell<u32>,
-    read_position: VolatileCell<u32>,
+    pub write_position: InMemoryRegister<u32>,
+    read_position: InMemoryRegister<u32>,
     flags: u32,
     _lifetime: PhantomData<&'a ()>,
 }
 
 impl Index<usize> for SeggerRttBuffer<'_> {
-    type Output = VolatileCell<u8>;
+    type Output = InMemoryRegister<u8>;
 
     fn index(&self, index: usize) -> &Self::Output {
         let index = index as isize;
@@ -147,9 +149,9 @@ impl Index<usize> for SeggerRttBuffer<'_> {
 impl<'a> SeggerRttMemory<'a> {
     pub fn new_raw(
         up_buffer_name: &'a [u8],
-        up_buffer: &'a [VolatileCell<u8>],
+        up_buffer: &'a [InMemoryRegister<u8>],
         down_buffer_name: &'a [u8],
-        down_buffer: &'a [VolatileCell<u8>],
+        down_buffer: &'a [InMemoryRegister<u8>],
     ) -> SeggerRttMemory<'a> {
         SeggerRttMemory {
             // This field is a magic value that must be set to "SEGGER RTT" for the debugger to
@@ -166,8 +168,8 @@ impl<'a> SeggerRttMemory<'a> {
                 name: up_buffer_name.as_ptr(),
                 buffer: up_buffer.as_ptr(),
                 length: up_buffer.len() as u32,
-                write_position: VolatileCell::new(0),
-                read_position: VolatileCell::new(0),
+                write_position: InMemoryRegister::new(0),
+                read_position: InMemoryRegister::new(0),
                 flags: 0,
                 _lifetime: PhantomData,
             },
@@ -175,8 +177,8 @@ impl<'a> SeggerRttMemory<'a> {
                 name: down_buffer_name.as_ptr(),
                 buffer: down_buffer.as_ptr(),
                 length: down_buffer.len() as u32,
-                write_position: VolatileCell::new(0),
-                read_position: VolatileCell::new(0),
+                write_position: InMemoryRegister::new(0),
+                read_position: InMemoryRegister::new(0),
                 flags: 0,
                 _lifetime: PhantomData,
             },


### PR DESCRIPTION
### Pull Request Overview

This is part of an effort triggered by https://github.com/tock/tock/pull/5002 to review our use of VolatileCell.

This is ultimately another case where's it's just a swap to an existing "in memory register" abstraction; very similar to the MMIO PRs.

After reviewing this, I _suspect_ it's the case that we should consider reviewing all our use `InMemoryRegister`: The RTT code correctly adds memory fences where they are needed; I'm not certain that everything does currently, and I'm wary that it's something that's hard to get right. _But_, that's a separate concern from this PR, which is a minimally invasive change.

### Testing Strategy

Claude claimed it did the following:

>Verified with an objdump diff: lpc55s69-evk's binary differs by exactly 2 bytes across the whole image, both a +2 shift in embedded core::panic::Location line numbers, matching the two net new `use` lines added to rtt.rs's import block. No .text changed and no .data/.bss size changed. sma_q3 (the other board exercising this component) also builds successfully.

### TODO or Help Wanted

N/A

### Checklist

- [x] Ran `make prepush`.

### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

Claude authored the changes and the commit; I verified the diff and explanation.
