### PR TITLE
boards: convert panic-handler `DummyUsbClient` spin-loop flag from `VolatileCell` to `Cell`

### DIFF
--- a/boards/clue_nrf52840/src/io.rs
+++ b/boards/clue_nrf52840/src/io.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
+use core::cell::Cell;
 use core::fmt::Write;
 use core::panic::PanicInfo;
 use core::ptr::addr_of;
@@ -12,7 +13,6 @@ use kernel::debug;
 use kernel::hil::led;
 use kernel::hil::uart::Transmit;
 use kernel::hil::uart::{self};
-use kernel::utilities::cells::VolatileCell;
 use kernel::utilities::io_write::IoWrite;
 use nrf52840::gpio::Pin;
 
@@ -33,11 +33,11 @@ const BUF_LEN: usize = 512;
 static mut STATIC_PANIC_BUF: [u8; BUF_LEN] = [0; BUF_LEN];
 
 static mut DUMMY: DummyUsbClient = DummyUsbClient {
-    fired: VolatileCell::new(false),
+    fired: Cell::new(false),
 };
 
 struct DummyUsbClient {
-    fired: VolatileCell<bool>,
+    fired: Cell<bool>,
 }
 
 impl uart::TransmitClient for DummyUsbClient {

--- a/boards/makepython-nrf52840/src/io.rs
+++ b/boards/makepython-nrf52840/src/io.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
+use core::cell::Cell;
 use core::fmt::Write;
 use core::panic::PanicInfo;
 use core::ptr::{addr_of, addr_of_mut};
@@ -14,7 +15,6 @@ use kernel::utilities::io_write::IoWrite;
 use nrf52840::gpio::Pin;
 
 use kernel::hil::uart::Transmit;
-use kernel::utilities::cells::VolatileCell;
 
 struct Writer {
     initialized: bool,
@@ -33,11 +33,11 @@ const BUF_LEN: usize = 512;
 static mut STATIC_PANIC_BUF: [u8; BUF_LEN] = [0; BUF_LEN];
 
 static mut DUMMY: DummyUsbClient = DummyUsbClient {
-    fired: VolatileCell::new(false),
+    fired: Cell::new(false),
 };
 
 struct DummyUsbClient {
-    fired: VolatileCell<bool>,
+    fired: Cell<bool>,
 }
 
 impl uart::TransmitClient for DummyUsbClient {

--- a/boards/nano33ble/src/io.rs
+++ b/boards/nano33ble/src/io.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
+use core::cell::Cell;
 use core::fmt::Write;
 use core::panic::PanicInfo;
 use core::ptr::{addr_of, addr_of_mut};
@@ -14,7 +15,6 @@ use kernel::utilities::io_write::IoWrite;
 use nrf52840::gpio::Pin;
 
 use kernel::hil::uart::Transmit;
-use kernel::utilities::cells::VolatileCell;
 
 struct Writer {
     initialized: bool,
@@ -33,11 +33,11 @@ const BUF_LEN: usize = 512;
 static mut STATIC_PANIC_BUF: [u8; BUF_LEN] = [0; BUF_LEN];
 
 static mut DUMMY: DummyUsbClient = DummyUsbClient {
-    fired: VolatileCell::new(false),
+    fired: Cell::new(false),
 };
 
 struct DummyUsbClient {
-    fired: VolatileCell<bool>,
+    fired: Cell<bool>,
 }
 
 impl uart::TransmitClient for DummyUsbClient {

--- a/boards/nano33ble_rev2/src/io.rs
+++ b/boards/nano33ble_rev2/src/io.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2023.
 
+use core::cell::Cell;
 use core::fmt::Write;
 use core::panic::PanicInfo;
 use core::ptr::{addr_of, addr_of_mut};
@@ -15,7 +16,6 @@ use kernel::utilities::io_write::IoWrite;
 use nrf52840::gpio::Pin;
 
 use kernel::hil::uart::Transmit;
-use kernel::utilities::cells::VolatileCell;
 
 struct Writer {
     initialized: bool,
@@ -34,11 +34,11 @@ const BUF_LEN: usize = 512;
 static mut STATIC_PANIC_BUF: [u8; BUF_LEN] = [0; BUF_LEN];
 
 static mut DUMMY: DummyUsbClient = DummyUsbClient {
-    fired: VolatileCell::new(false),
+    fired: Cell::new(false),
 };
 
 struct DummyUsbClient {
-    fired: VolatileCell<bool>,
+    fired: Cell<bool>,
 }
 
 impl uart::TransmitClient for DummyUsbClient {


### PR DESCRIPTION
### Pull Request Overview

This is part of an effort triggered by https://github.com/tock/tock/pull/5002 to review our use of VolatileCell.

This is another example much like #5007 and #5008 , where this is ultimately something always called from the main thread, and were that ever to change, we'd (1) catch it because `Cell` isn't `Sync` and (2) need to build a proper synchronization primitive anyway.

### Testing Strategy

Claude said it verified: clue_nrf52840, makepython-nrf52840, nano33ble, and nano33ble_rev2 (all four boards using this pattern) build successfully with make prepush passing.

### TODO or Help Wanted

N/A

### Checklist

- [x] Ran `make prepush`.

### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

Claude authored the changes and commit; I verified the diff and reasoning.
