### PR TITLE
convert USB EasyDMA buffer ecosystem from VolatileCell to InMemoryRegister

### DIFF
--- a/capsules/extra/src/usb/cdc.rs
+++ b/capsules/extra/src/usb/cdc.rs
@@ -26,7 +26,8 @@ use kernel::hil::uart;
 use kernel::hil::usb::TransferType;
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::cells::TakeCell;
-use kernel::utilities::cells::VolatileCell;
+use kernel::utilities::registers::InMemoryRegister;
+use kernel::utilities::registers::interfaces::{Readable, Writeable};
 
 /// Identifying number for the endpoint when transferring data from us to the
 /// host.
@@ -319,7 +320,7 @@ impl<'a, U: hil::usb::UsbController<'a>, A: 'a + Alarm<'a>> CdcAcm<'a, U, A> {
     }
 
     #[inline]
-    fn buffer(&'a self, i: usize) -> &'a [VolatileCell<u8>; 64] {
+    fn buffer(&'a self, i: usize) -> &'a [InMemoryRegister<u8>; 64] {
         &self.buffers[i - 1].buf
     }
 

--- a/capsules/extra/src/usb/ctap.rs
+++ b/capsules/extra/src/usb/ctap.rs
@@ -26,6 +26,7 @@ use kernel::hil;
 use kernel::hil::usb::TransferType;
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::cells::TakeCell;
+use kernel::utilities::registers::interfaces::{Readable, Writeable};
 
 /// Use 1 Interrupt transfer IN/OUT endpoint
 const ENDPOINT_NUM: usize = 1;

--- a/capsules/extra/src/usb/descriptors.rs
+++ b/capsules/extra/src/usb/descriptors.rs
@@ -11,25 +11,33 @@ use core::cmp::min;
 use core::fmt;
 
 use kernel::hil::usb::TransferType;
-use kernel::utilities::cells::VolatileCell;
+use kernel::utilities::registers::InMemoryRegister;
+use kernel::utilities::registers::interfaces::Readable;
 
 // On Nordic, USB buffers must be 32-bit aligned, with a power-of-2 size. For
 // now we apply these constraints on all platforms.
-#[derive(Default)]
 #[repr(align(4))]
 pub struct Buffer8 {
-    pub buf: [VolatileCell<u8>; 8],
+    pub buf: [InMemoryRegister<u8>; 8],
+}
+
+impl Default for Buffer8 {
+    fn default() -> Self {
+        Self {
+            buf: [const { InMemoryRegister::new(0) }; 8],
+        }
+    }
 }
 
 #[repr(align(4))]
 pub struct Buffer64 {
-    pub buf: [VolatileCell<u8>; 64],
+    pub buf: [InMemoryRegister<u8>; 64],
 }
 
 impl Default for Buffer64 {
     fn default() -> Self {
         Self {
-            buf: [(); 64].map(|()| VolatileCell::default()),
+            buf: [const { InMemoryRegister::new(0) }; 64],
         }
     }
 }
@@ -46,7 +54,7 @@ pub struct SetupData {
 
 impl SetupData {
     /// Create a `SetupData` structure from a packet received from the wire
-    pub fn get(p: &[VolatileCell<u8>]) -> Option<Self> {
+    pub fn get(p: &[InMemoryRegister<u8>]) -> Option<Self> {
         if p.len() < 8 {
             return None;
         }
@@ -877,7 +885,7 @@ pub struct CdcAcmSetLineCodingData {
 impl CdcAcmSetLineCodingData {
     /// Create a `CdcAcmSetLineCodingData` structure from a packet received
     /// after the ctrl endpoint setup.
-    pub fn get(p: &[VolatileCell<u8>]) -> Option<Self> {
+    pub fn get(p: &[InMemoryRegister<u8>]) -> Option<Self> {
         if p.len() < 7 {
             return None;
         }

--- a/capsules/extra/src/usb/keyboard_hid.rs
+++ b/capsules/extra/src/usb/keyboard_hid.rs
@@ -22,6 +22,7 @@ use kernel::hil;
 use kernel::hil::usb::TransferType;
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::cells::TakeCell;
+use kernel::utilities::registers::interfaces::Writeable;
 
 /// Use 1 Interrupt transfer IN/OUT endpoint
 const ENDPOINT_NUM: usize = 1;

--- a/capsules/extra/src/usb/usbc_client.rs
+++ b/capsules/extra/src/usb/usbc_client.rs
@@ -16,7 +16,8 @@ use super::usbc_client_ctrl::ClientCtrl;
 use kernel::debug;
 use kernel::hil;
 use kernel::hil::usb::TransferType;
-use kernel::utilities::cells::VolatileCell;
+use kernel::utilities::registers::InMemoryRegister;
+use kernel::utilities::registers::interfaces::{Readable, Writeable};
 
 const VENDOR_ID: u16 = 0x6667;
 const PRODUCT_ID: u16 = 0xabcd;
@@ -135,7 +136,7 @@ impl<'a, C: hil::usb::UsbController<'a>> Client<'a, C> {
     }
 
     #[inline]
-    fn buffer(&'a self, i: usize) -> &'a [VolatileCell<u8>; 8] {
+    fn buffer(&'a self, i: usize) -> &'a [InMemoryRegister<u8>; 8] {
         &self.buffers[i - 1].buf
     }
 }

--- a/capsules/extra/src/usb/usbc_client_ctrl.rs
+++ b/capsules/extra/src/usb/usbc_client_ctrl.rs
@@ -39,6 +39,7 @@ use core::cmp::min;
 
 use kernel::hil;
 use kernel::hil::usb::TransferType;
+use kernel::utilities::registers::interfaces::Writeable;
 
 const DESCRIPTOR_BUFLEN: usize = 128;
 

--- a/chips/lowrisc/src/usbdev.rs
+++ b/chips/lowrisc/src/usbdev.rs
@@ -11,10 +11,11 @@ use core::cell::Cell;
 use kernel::hil;
 use kernel::hil::usb::TransferType;
 use kernel::utilities::StaticRef;
-use kernel::utilities::cells::{OptionalCell, VolatileCell};
+use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{
-    LocalRegisterCopy, ReadOnly, ReadWrite, WriteOnly, register_bitfields, register_structs,
+    InMemoryRegister, LocalRegisterCopy, ReadOnly, ReadWrite, WriteOnly, register_bitfields,
+    register_structs,
 };
 
 pub const N_ENDPOINTS: usize = 12;
@@ -305,8 +306,8 @@ impl From<BankIndex> for usize {
 
 #[repr(C)]
 pub struct Endpoint<'a> {
-    slice_in: OptionalCell<&'a [VolatileCell<u8>]>,
-    slice_out: OptionalCell<&'a [VolatileCell<u8>]>,
+    slice_in: OptionalCell<&'a [InMemoryRegister<u8>]>,
+    slice_out: OptionalCell<&'a [InMemoryRegister<u8>]>,
     state: Cell<EndpointState>,
 
     _reserved: u32,
@@ -965,7 +966,7 @@ impl<'a> Usb<'a> {
 
     /// Provide a buffer for transfers in and out of the given endpoint
     /// (The controller need not be enabled before calling this method.)
-    fn endpoint_bank_set_buffer(&self, endpoint: usize, buf: &'a [VolatileCell<u8>]) {
+    fn endpoint_bank_set_buffer(&self, endpoint: usize, buf: &'a [InMemoryRegister<u8>]) {
         self.descriptors[endpoint].slice_in.set(buf);
         self.descriptors[endpoint].slice_out.set(buf);
     }
@@ -976,15 +977,15 @@ impl<'a> hil::usb::UsbController<'a> for Usb<'a> {
         self.client.set(client);
     }
 
-    fn endpoint_set_ctrl_buffer(&self, buf: &'a [VolatileCell<u8>]) {
+    fn endpoint_set_ctrl_buffer(&self, buf: &'a [InMemoryRegister<u8>]) {
         self.endpoint_bank_set_buffer(0, buf);
     }
 
-    fn endpoint_set_in_buffer(&self, endpoint: usize, buf: &'a [VolatileCell<u8>]) {
+    fn endpoint_set_in_buffer(&self, endpoint: usize, buf: &'a [InMemoryRegister<u8>]) {
         self.endpoint_bank_set_buffer(endpoint, buf);
     }
 
-    fn endpoint_set_out_buffer(&self, endpoint: usize, buf: &'a [VolatileCell<u8>]) {
+    fn endpoint_set_out_buffer(&self, endpoint: usize, buf: &'a [InMemoryRegister<u8>]) {
         self.endpoint_bank_set_buffer(endpoint, buf);
     }
 

--- a/chips/nrf52/src/usbd.rs
+++ b/chips/nrf52/src/usbd.rs
@@ -9,7 +9,7 @@ use cortexm4f::support::with_interrupts_disabled;
 use kernel::hil;
 use kernel::hil::usb::TransferType;
 use kernel::utilities::StaticRef;
-use kernel::utilities::cells::{OptionalCell, VolatileCell};
+use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{
     Field, InMemoryRegister, LocalRegisterCopy, ReadOnly, ReadWrite, WriteOnly, register_bitfields,
@@ -309,7 +309,7 @@ struct UsbdRegisters<'a> {
 mod detail {
     use super::{Amount, Count};
     use core::marker::PhantomData;
-    use kernel::utilities::cells::VolatileCell;
+    use kernel::utilities::registers::InMemoryRegister;
     use kernel::utilities::registers::interfaces::Writeable;
     use kernel::utilities::registers::{ReadOnly, ReadWrite};
 
@@ -325,7 +325,7 @@ mod detail {
     }
 
     impl<'a> EndpointRegisters<'a> {
-        pub fn set_buffer(&self, slice: &'a [VolatileCell<u8>]) {
+        pub fn set_buffer(&self, slice: &'a [InMemoryRegister<u8>]) {
             self.ptr.set(slice.as_ptr().cast::<u8>() as u32);
             self.maxcnt.write(Count::MAXCNT.val(slice.len() as u32));
         }
@@ -688,8 +688,8 @@ pub enum BulkOutState {
 }
 
 pub struct Endpoint<'a> {
-    slice_in: OptionalCell<&'a [VolatileCell<u8>]>,
-    slice_out: OptionalCell<&'a [VolatileCell<u8>]>,
+    slice_in: OptionalCell<&'a [InMemoryRegister<u8>]>,
+    slice_out: OptionalCell<&'a [InMemoryRegister<u8>]>,
     state: Cell<EndpointState>,
     // The USB controller can only process one DMA transfer at a time (over all endpoints). The
     // request_transmit_* bits allow to queue transfers until the DMA becomes available again.
@@ -1935,7 +1935,7 @@ impl<'a> hil::usb::UsbController<'a> for Usbd<'a> {
         self.client.set(client);
     }
 
-    fn endpoint_set_ctrl_buffer(&self, buf: &'a [VolatileCell<u8>]) {
+    fn endpoint_set_ctrl_buffer(&self, buf: &'a [InMemoryRegister<u8>]) {
         if buf.len() < 8 {
             panic!("Endpoint buffer must be at least 8 bytes");
         }
@@ -1946,7 +1946,7 @@ impl<'a> hil::usb::UsbController<'a> for Usbd<'a> {
         self.descriptors[0].slice_out.set(buf);
     }
 
-    fn endpoint_set_in_buffer(&self, endpoint: usize, buf: &'a [VolatileCell<u8>]) {
+    fn endpoint_set_in_buffer(&self, endpoint: usize, buf: &'a [InMemoryRegister<u8>]) {
         if buf.len() < 8 {
             panic!("Endpoint buffer must be at least 8 bytes");
         }
@@ -1959,7 +1959,7 @@ impl<'a> hil::usb::UsbController<'a> for Usbd<'a> {
         self.descriptors[endpoint].slice_in.set(buf);
     }
 
-    fn endpoint_set_out_buffer(&self, endpoint: usize, buf: &'a [VolatileCell<u8>]) {
+    fn endpoint_set_out_buffer(&self, endpoint: usize, buf: &'a [InMemoryRegister<u8>]) {
         if buf.len() < 8 {
             panic!("Endpoint buffer must be at least 8 bytes");
         }
@@ -2175,7 +2175,7 @@ fn inter_endepout(ep: usize) -> Field<u32, Interrupt::Register> {
 }
 
 // Debugging functions.
-fn packet_to_hex(packet: &[VolatileCell<u8>], packet_hex: &mut [u8]) {
+fn packet_to_hex(packet: &[InMemoryRegister<u8>], packet_hex: &mut [u8]) {
     let hex_char = |x: u8| {
         if x < 10 { b'0' + x } else { b'a' + x - 10 }
     };

--- a/chips/rp2040/src/usb.rs
+++ b/chips/rp2040/src/usb.rs
@@ -12,9 +12,11 @@ use core::cell::Cell;
 use kernel::hil;
 use kernel::hil::usb::TransferType;
 use kernel::utilities::StaticRef;
-use kernel::utilities::cells::{OptionalCell, VolatileCell};
+use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
-use kernel::utilities::registers::{ReadWrite, register_bitfields, register_structs};
+use kernel::utilities::registers::{
+    InMemoryRegister, ReadWrite, register_bitfields, register_structs,
+};
 
 macro_rules! internal_err {
     [ $( $arg:expr ),+ ] => {
@@ -1279,8 +1281,8 @@ pub enum EndpointType {
 }
 
 pub struct Endpoint<'a> {
-    slice_in: OptionalCell<&'a [VolatileCell<u8>]>,
-    slice_out: OptionalCell<&'a [VolatileCell<u8>]>,
+    slice_in: OptionalCell<&'a [InMemoryRegister<u8>]>,
+    slice_out: OptionalCell<&'a [InMemoryRegister<u8>]>,
     state: Cell<EndpointState>,
     // Whether a transfer is requested on this IN endpoint.
     request_transmit_in: Cell<bool>,
@@ -2324,7 +2326,7 @@ impl<'a> hil::usb::UsbController<'a> for UsbCtrl<'a> {
         self.client.set(client);
     }
 
-    fn endpoint_set_ctrl_buffer(&self, buf: &'a [VolatileCell<u8>]) {
+    fn endpoint_set_ctrl_buffer(&self, buf: &'a [InMemoryRegister<u8>]) {
         if buf.len() < 8 {
             panic!("Endpoint buffer must be at least 8 bytes");
         }
@@ -2335,7 +2337,7 @@ impl<'a> hil::usb::UsbController<'a> for UsbCtrl<'a> {
         self.descriptors[0].slice_out.set(buf);
     }
 
-    fn endpoint_set_in_buffer(&self, endpoint: usize, buf: &'a [VolatileCell<u8>]) {
+    fn endpoint_set_in_buffer(&self, endpoint: usize, buf: &'a [InMemoryRegister<u8>]) {
         if buf.len() < 8 {
             panic!("Endpoint buffer must be at least 8 bytes");
         }
@@ -2348,7 +2350,7 @@ impl<'a> hil::usb::UsbController<'a> for UsbCtrl<'a> {
         self.descriptors[endpoint].slice_in.set(buf);
     }
 
-    fn endpoint_set_out_buffer(&self, endpoint: usize, buf: &'a [VolatileCell<u8>]) {
+    fn endpoint_set_out_buffer(&self, endpoint: usize, buf: &'a [InMemoryRegister<u8>]) {
         if buf.len() < 8 {
             panic!("Endpoint buffer must be at least 8 bytes");
         }

--- a/chips/sam4l/src/usbc/mod.rs
+++ b/chips/sam4l/src/usbc/mod.rs
@@ -17,7 +17,7 @@ use kernel::debug as debugln;
 use kernel::hil;
 use kernel::hil::usb::TransferType;
 use kernel::utilities::StaticRef;
-use kernel::utilities::cells::{OptionalCell, VolatileCell};
+use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{
     FieldValue, InMemoryRegister, LocalRegisterCopy, ReadOnly, ReadWrite, WriteOnly,
@@ -476,11 +476,11 @@ impl<'a> Usbc<'a> {
         &self,
         endpoint: EndpointIndex,
         bank: BankIndex,
-        buf: &[VolatileCell<u8>],
+        buf: &[InMemoryRegister<u8>],
     ) {
         let e: usize = From::from(endpoint);
         let b: usize = From::from(bank);
-        let p: *const VolatileCell<u8> = buf.as_ptr();
+        let p: *const InMemoryRegister<u8> = buf.as_ptr();
         let p: *mut u8 = p.cast_mut().cast();
 
         debug1!("Set Endpoint{}/Bank{} addr={:8?}", e, b, p);
@@ -1443,7 +1443,7 @@ impl<'a> hil::usb::UsbController<'a> for Usbc<'a> {
         self.client.set(client);
     }
 
-    fn endpoint_set_ctrl_buffer(&self, buf: &'a [VolatileCell<u8>]) {
+    fn endpoint_set_ctrl_buffer(&self, buf: &'a [InMemoryRegister<u8>]) {
         if buf.len() < 8 {
             client_err!("Bad endpoint buffer size");
         }
@@ -1451,7 +1451,7 @@ impl<'a> hil::usb::UsbController<'a> for Usbc<'a> {
         self.endpoint_bank_set_buffer(EndpointIndex::new(0), BankIndex::Bank0, buf);
     }
 
-    fn endpoint_set_in_buffer(&self, endpoint: usize, buf: &'a [VolatileCell<u8>]) {
+    fn endpoint_set_in_buffer(&self, endpoint: usize, buf: &'a [InMemoryRegister<u8>]) {
         if buf.len() < 8 {
             client_err!("Bad endpoint buffer size");
         }
@@ -1459,7 +1459,7 @@ impl<'a> hil::usb::UsbController<'a> for Usbc<'a> {
         self.endpoint_bank_set_buffer(EndpointIndex::new(endpoint), BankIndex::Bank0, buf);
     }
 
-    fn endpoint_set_out_buffer(&self, endpoint: usize, buf: &'a [VolatileCell<u8>]) {
+    fn endpoint_set_out_buffer(&self, endpoint: usize, buf: &'a [InMemoryRegister<u8>]) {
         if buf.len() < 8 {
             client_err!("Bad endpoint buffer size");
         }

--- a/kernel/src/hil/usb.rs
+++ b/kernel/src/hil/usb.rs
@@ -4,16 +4,16 @@
 
 //! Interface to USB controller hardware
 
-use crate::utilities::cells::VolatileCell;
+use crate::utilities::registers::InMemoryRegister;
 
 /// USB controller interface
 pub trait UsbController<'a> {
     fn set_client(&self, client: &'a dyn Client<'a>);
 
     // Should be called before `enable_as_device()`
-    fn endpoint_set_ctrl_buffer(&self, buf: &'a [VolatileCell<u8>]);
-    fn endpoint_set_in_buffer(&self, endpoint: usize, buf: &'a [VolatileCell<u8>]);
-    fn endpoint_set_out_buffer(&self, endpoint: usize, buf: &'a [VolatileCell<u8>]);
+    fn endpoint_set_ctrl_buffer(&self, buf: &'a [InMemoryRegister<u8>]);
+    fn endpoint_set_in_buffer(&self, endpoint: usize, buf: &'a [InMemoryRegister<u8>]);
+    fn endpoint_set_out_buffer(&self, endpoint: usize, buf: &'a [InMemoryRegister<u8>]);
 
     // Must be called before `attach()`
     fn enable_as_device(&self, speed: DeviceSpeed);


### PR DESCRIPTION
### Pull Request Overview

~~***This is a Draft PR as (1) I'd like to discuss the staging of the more substantial work, and (2) I have NOT yet fully reviewed Claude's work here.***~~

This is the last in a series of PRs inspired by #5002, with all of the related PRs and this merged, we can remove `VolatileCell`.

This one demands more attention for two reasons:

  1. It touches a HIL, albeit the more scoped USB HIL.
  2. The issue I was pondering in #5029 is indeed real—the as-is `VolatileCell`s here are almost certainly wrong since correct code very likely needs memory fences too.

Converting to `InMemoryRegister` would be an as-is change that removes the last use of `VolatileCell`. However, we really _should_ convert things to the new `DmaFence` abstraction, and likely update the HIL to do that too.

That said, I lean slightly towards moving forward with this changeset as-is and merging it, and then separately doing a more thorough investigation of all uses of `InMemoryRegister`, as I strongly suspect this is not the only place where we have missing memory fences, and I am starting to strongly suspect that `InMemoryRegister` is an abstraction that invites this subtle error.

---

What follows after this is Claude's reasoning for the current changeset:

kernel::hil::usb::UsbController's endpoint_set_{ctrl,in,out}_buffer methods took &'a [VolatileCell<u8>], and every implementer/consumer had to match that exact type. Since a trait and all its impls must agree simultaneously, this change had to land as a single atomic commit across:

- kernel/src/hil/usb.rs - the trait signature itself
- capsules/extra/src/usb/descriptors.rs - Buffer8/Buffer64, the actual owned buffer types
- capsules/extra/src/usb/{cdc,ctap,keyboard_hid,usbc_client, usbc_client_ctrl}.rs - consumers. The latter three don't spell VolatileCell directly - they only call .get()/.set() on values returned from buffer() via type inference, so a plain grep for the type name misses them; only a full build surfaces the dependency.
- chips/{lowrisc/usbdev,nrf52/usbd,rp2040/usb,sam4l/usbc/mod}.rs - the four chip implementers

InMemoryRegister (not ReadWrite) because these buffers are genuinely owned RAM - allocated as normal static buffers, then either DMA'd into directly by hardware (nRF52, SAM4L) or manually copied to/from the chip's own internal buffer registers (rp2040, lowrisc) - the same shape as the sam4l USBC Bank descriptor and segger RTT buffers already converted. ReadWrite has no ::new() (only for casting over an existing StaticRef address), so it can't represent owned memory.

This forced one real change beyond a type rename: Buffer8's #[derive(Default)] doesn't work anymore (neither ReadWrite nor InMemoryRegister implement Default), so it now has a manual impl matching Buffer64's existing pattern, using the same `[const { InMemoryRegister::new(0) }; N]` array-repeat construction introduced for the segger RTT buffers.

Left untouched: each of the 4 chip files' *other* VolatileCell usage (rp2040's next_pid_in/out, sam4l's Bank.addr, nrf52's EasyDMA ptr register) is handled by separate commits on other branches - this commit only touches the buffer-sharing fields/methods.

### (Claude's) Testing Strategy

Verified: `make prepush` passes; built one board per chip implementer (nrf52840dk, raspberry_pi_pico, imix, hail, earlgrey-cw310), all succeed with unchanged text/data/bss sizes. Did a byte-level diff on raspberry_pi_pico specifically (not just a size comparison), since this touches far more code than a typical single-field rename: ~22% of bytes differ, but the symbol table diff (565 vs 564 symbols) shows exactly why - one generic instantiation's mangled name changes (expected, different type parameter), one mangled name shifts from an unrelated internal index renumbering, and Buffer64::default() is fully inlined away since the new const-block initialization is trivially const-foldable where the old runtime .map() closure wasn't. No functions were unexpectedly added or removed.

### TODO or Help Wanted

TODO: (see above)

### Checklist

- [x] Ran `make prepush`.

### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

Claude authored the existing changset and commit; I've only lightly reviewed it so far (see above).
