### PR TITLE
hil/digest: add preset message function

### DIFF
--- a/capsules/extra/src/atecc508a.rs
+++ b/capsules/extra/src/atecc508a.rs
@@ -1313,6 +1313,10 @@ impl<'a> digest::DigestData<'a, 32> for Atecc508a<'a> {
 
         self.reset();
     }
+
+    fn preset_message_length(&self, _len: usize) -> Result<(), ErrorCode> {
+        Ok(())
+    }
 }
 
 impl<'a> digest::DigestHash<'a, 32> for Atecc508a<'a> {

--- a/capsules/extra/src/hmac.rs
+++ b/capsules/extra/src/hmac.rs
@@ -790,6 +790,21 @@ impl<
                             CommandReturn::failure(ErrorCode::OFF)
                         }
                     }
+                    // preset the message length
+                    // it is an optional operation.
+                    6 => {
+                        let res = self.apps.enter(processid, |app, _kernel_data| {
+                            if app.op.get().is_none() {
+                                self.hmac.preset_message_length(data1)
+                            } else {
+                                Err(ErrorCode::BUSY)
+                            }
+                        });
+                        match res {
+                            Ok(_) => CommandReturn::success(),
+                            Err(e) => e.into(),
+                        }
+                    }
 
                     // default
                     _ => CommandReturn::failure(ErrorCode::NOSUPPORT),

--- a/capsules/extra/src/hmac_sha256.rs
+++ b/capsules/extra/src/hmac_sha256.rs
@@ -221,6 +221,10 @@ impl<'a, S: hil::digest::Sha256 + hil::digest::DigestDataHash<'a, 32>>
         self.sha256.clear_data();
     }
 
+    fn preset_message_length(&self, _len: usize) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+
     fn set_data_client(&'a self, _client: &'a dyn hil::digest::ClientData<32>) {
         // self.data_client.set(client);
         unimplemented!()

--- a/capsules/extra/src/sha256.rs
+++ b/capsules/extra/src/sha256.rs
@@ -336,6 +336,10 @@ impl<'a> DigestData<'a, 32> for Sha256Software<'a> {
         self.initialize();
     }
 
+    fn preset_message_length(&self, _len: usize) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+
     fn set_data_client(&'a self, client: &'a (dyn ClientData<32> + 'a)) {
         self.client_data.set(client);
         self.client_hash.clear();

--- a/capsules/extra/src/sha256_driver.rs
+++ b/capsules/extra/src/sha256_driver.rs
@@ -373,6 +373,7 @@ impl<'a, H: digest::DigestDataHash<'a, DIGEST_LEN> + digest::Sha256, const DIGES
     /// - `0`: driver check
     /// - `1`: set_algorithm
     /// - `2`: hash
+    /// - `3`: preset the length
     fn command(
         &self,
         command_num: usize,
@@ -436,6 +437,20 @@ impl<'a, H: digest::DigestDataHash<'a, DIGEST_LEN> + digest::Sha256, const DIGES
                             })
                             .into()
                     }
+                    Err(e) => e.into(),
+                }
+            }
+
+            3 => {
+                let res = self.apps.enter(processid, |app, _kernel_data| {
+                    if app.operation.is_none() {
+                        self.sha.preset_message_length(data1)
+                    } else {
+                        Err(ErrorCode::BUSY)
+                    }
+                });
+                match res {
+                    Ok(_) => CommandReturn::success(),
                     Err(e) => e.into(),
                 }
             }

--- a/capsules/extra/src/test/hmac_md5.rs
+++ b/capsules/extra/src/test/hmac_md5.rs
@@ -52,6 +52,10 @@ impl<'a, H: digest::Digest<'a, HMAC_MD5_DIGEST_LEN> + HmacMd5> TestHmacMd5<'a, H
             panic!("HmacMd5Test: failed to set key: {:?}", r);
         }
         let data = self.data.take().unwrap();
+        let r = self.hmac.preset_message_length(data.len());
+        if r.is_err() {
+            panic!("HmacMd5Test: failed to preset the length: {:?}", r);
+        }
         let buffer = SubSliceMut::new(data);
         let r = self.hmac.add_mut_data(buffer);
         if r.is_err() {

--- a/capsules/extra/src/test/hmac_sha1.rs
+++ b/capsules/extra/src/test/hmac_sha1.rs
@@ -52,6 +52,10 @@ impl<'a, H: digest::Digest<'a, HMAC_SHA1_DIGEST_LEN> + HmacSha1> TestHmacSha1<'a
             panic!("HmacSha1Test: failed to set key: {:?}", r);
         }
         let data = self.data.take().unwrap();
+        let r = self.hmac.preset_message_length(data.len());
+        if r.is_err() {
+            panic!("HmacSha1Test: failed to preset the length: {:?}", r);
+        }
         let buffer = SubSliceMut::new(data);
         let r = self.hmac.add_mut_data(buffer);
         if r.is_err() {

--- a/capsules/extra/src/test/hmac_sha224.rs
+++ b/capsules/extra/src/test/hmac_sha224.rs
@@ -52,6 +52,10 @@ impl<'a, H: digest::Digest<'a, HMAC_SHA224_DIGEST_LEN> + HmacSha224> TestHmacSha
             panic!("HmacSha224Test: failed to set key: {:?}", r);
         }
         let data = self.data.take().unwrap();
+        let r = self.hmac.preset_message_length(data.len());
+        if r.is_err() {
+            panic!("HmacSha224Test: failed to preset the length: {:?}", r);
+        }
         let buffer = SubSliceMut::new(data);
         let r = self.hmac.add_mut_data(buffer);
         if r.is_err() {

--- a/capsules/extra/src/test/hmac_sha256.rs
+++ b/capsules/extra/src/test/hmac_sha256.rs
@@ -52,6 +52,10 @@ impl<'a, H: digest::Digest<'a, HMAC_SHA256_DIGEST_LEN> + HmacSha256> TestHmacSha
             panic!("HmacSha256Test: failed to set key: {:?}", r);
         }
         let data = self.data.take().unwrap();
+        let r = self.hmac.preset_message_length(data.len());
+        if r.is_err() {
+            panic!("HmacSha256Test: failed to preset the length: {:?}", r);
+        }
         let buffer = SubSliceMut::new(data);
         let r = self.hmac.add_mut_data(buffer);
         if r.is_err() {

--- a/capsules/extra/src/test/hmac_sha512.rs
+++ b/capsules/extra/src/test/hmac_sha512.rs
@@ -51,6 +51,10 @@ impl<'a, H: digest::Digest<'a, HMAC_SHA512_DIGEST_LEN> + HmacSha512> TestHmacSha
             panic!("HmacSha512Test: failed to set key: {:?}", r);
         }
         let data = self.data.take().unwrap();
+        let r = self.hmac.preset_message_length(data.len());
+        if r.is_err() {
+            panic!("HmacSha512Test: failed to preset the length: {:?}", r);
+        }
         let buffer = SubSliceMut::new(data);
         let r = self.hmac.add_mut_data(buffer);
         if r.is_err() {

--- a/capsules/extra/src/test/md5.rs
+++ b/capsules/extra/src/test/md5.rs
@@ -56,6 +56,10 @@ impl<'a, H: digest::Digest<'a, 16> + digest::Md5> TestMd5<'a, H> {
         }
         self.sha.set_client(self);
         let data = self.data.take().unwrap();
+        let r = self.sha.preset_message_length(data.len());
+        if r.is_err() {
+            panic!("Md5Test: failed to preset the length: {:?}", r);
+        }
         let chunk_size = cmp::min(CHUNK_SIZE, data.len());
         self.position.set(chunk_size);
         let mut buffer = SubSliceMut::new(data);

--- a/capsules/extra/src/test/sha1.rs
+++ b/capsules/extra/src/test/sha1.rs
@@ -58,6 +58,10 @@ impl<'a, H: digest::Digest<'a, SHA1_DIGEST_LEN> + digest::Sha1> TestSha1<'a, H> 
         }
         self.sha.set_client(self);
         let data = self.data.take().unwrap();
+        let r = self.sha.preset_message_length(data.len());
+        if r.is_err() {
+            panic!("Sha1Test: failed to preset the length: {:?}", r);
+        }
         let chunk_size = cmp::min(CHUNK_SIZE, data.len());
         self.position.set(chunk_size);
         let mut buffer = SubSliceMut::new(data);

--- a/capsules/extra/src/test/sha224.rs
+++ b/capsules/extra/src/test/sha224.rs
@@ -58,6 +58,10 @@ impl<'a, H: digest::Digest<'a, SHA224_DIGEST_LEN> + digest::Sha224> TestSha224<'
         }
         self.sha.set_client(self);
         let data = self.data.take().unwrap();
+        let r = self.sha.preset_message_length(data.len());
+        if r.is_err() {
+            panic!("Sha224Test: failed to preset the length: {:?}", r);
+        }
         let chunk_size = cmp::min(CHUNK_SIZE, data.len());
         self.position.set(chunk_size);
         let mut buffer = SubSliceMut::new(data);

--- a/capsules/extra/src/test/sha256.rs
+++ b/capsules/extra/src/test/sha256.rs
@@ -59,6 +59,10 @@ impl<'a, H: digest::Digest<'a, SHA256_DIGEST_LEN> + digest::Sha256> TestSha256<'
         }
         self.sha.set_client(self);
         let data = self.data.take().unwrap();
+        let r = self.sha.preset_message_length(data.len());
+        if r.is_err() {
+            panic!("Sha256Test: failed to preset the length: {:?}", r);
+        }
         let chunk_size = cmp::min(CHUNK_SIZE, data.len());
         self.position.set(chunk_size);
         let mut buffer = SubSliceMut::new(data);

--- a/capsules/extra/src/test/sha512.rs
+++ b/capsules/extra/src/test/sha512.rs
@@ -58,6 +58,10 @@ impl<'a, H: digest::Digest<'a, SHA512_DIGEST_LEN> + digest::Sha512> TestSha512<'
         }
         self.sha.set_client(self);
         let data = self.data.take().unwrap();
+        let r = self.sha.preset_message_length(data.len());
+        if r.is_err() {
+            panic!("Sha512Test: failed to preset the length: {:?}", r);
+        }
         let chunk_size = cmp::min(CHUNK_SIZE, data.len());
         self.position.set(chunk_size);
         let mut buffer = SubSliceMut::new(data);

--- a/chips/lowrisc/src/hmac.rs
+++ b/chips/lowrisc/src/hmac.rs
@@ -320,6 +320,10 @@ impl<'a> hil::digest::DigestData<'a, 32> for Hmac<'a> {
         self.cancelled.set(true);
     }
 
+    fn preset_message_length(&self, _len: usize) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+
     fn set_data_client(&'a self, _client: &'a (dyn digest::ClientData<32> + 'a)) {
         unimplemented!()
     }

--- a/chips/stm32u5xx/src/hash/md5.rs
+++ b/chips/stm32u5xx/src/hash/md5.rs
@@ -108,6 +108,10 @@ impl<'a> digest::DigestData<'a, MD5_DIGEST_LEN> for Md5Adapter<'a> {
         self.hash.add_mut_data(data)
     }
 
+    fn preset_message_length(&self, _len: usize) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+
     fn clear_data(&self) {
         self.hash.clear_data();
     }

--- a/chips/stm32u5xx/src/hash/sha1.rs
+++ b/chips/stm32u5xx/src/hash/sha1.rs
@@ -108,6 +108,10 @@ impl<'a> digest::DigestData<'a, SHA1_DIGEST_LEN> for Sha1Adapter<'a> {
         self.hash.add_mut_data(data)
     }
 
+    fn preset_message_length(&self, _len: usize) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+
     fn clear_data(&self) {
         self.hash.clear_data();
     }

--- a/chips/stm32u5xx/src/hash/sha224.rs
+++ b/chips/stm32u5xx/src/hash/sha224.rs
@@ -109,6 +109,10 @@ impl<'a> digest::DigestData<'a, SHA224_DIGEST_LEN> for Sha224Adapter<'a> {
         self.hash.add_mut_data(data)
     }
 
+    fn preset_message_length(&self, _len: usize) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+
     fn clear_data(&self) {
         self.hash.clear_data();
     }

--- a/chips/stm32u5xx/src/hash/sha256.rs
+++ b/chips/stm32u5xx/src/hash/sha256.rs
@@ -111,6 +111,10 @@ impl<'a> digest::DigestData<'a, SHA256_DIGEST_LEN> for Sha256Adapter<'a> {
         self.hash.add_mut_data(data)
     }
 
+    fn preset_message_length(&self, _len: usize) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+
     fn clear_data(&self) {
         self.hash.clear_data();
     }

--- a/kernel/src/hil/digest.rs
+++ b/kernel/src/hil/digest.rs
@@ -192,6 +192,19 @@ pub trait DigestData<'a, const DIGEST_LEN: usize> {
     /// [`ErrorCode::CANCEL`]. This call does not clear buffers passed through
     /// `add_mut_data`, those are up to the client clear.
     fn clear_data(&self);
+
+    /// Preset the message length to validate message integrity.
+    ///
+    /// `Ok` indicates the message length is pushed to the digest engine
+    /// and the transaction can be started.
+    ///
+    /// Note: This function is optional and don't have to be invoked during the transaction.
+    /// For peripherals that have no hardware support for this function `Ok` is returned.
+    ///
+    /// Valid `ErrorCode` value is:
+    /// - `BUSY`: there is an outstanding transaction, so the digest engine is busy
+    ///   and cannot reset current message length.
+    fn preset_message_length(&self, len: usize) -> Result<(), ErrorCode>;
 }
 
 /// Computes a digest (cryptographic hash) over data provided through a


### PR DESCRIPTION
### Pull Request Overview

This pull request adds an optional function for the Digest HIL that will preset the message length. The following function is optional and should not disrupt any functionality of capsules and chips.


### Testing Strategy

This pull request was tested by the HMAC-SHA512 capsule


### TODO or Help Wanted

This pull request still needs review


### Checklist

- [X] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [X] No documentation updates are required.

#### AI Use

- [X] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
