### PR TITLE
chips: qemu-virt: fix uart interrupt disable

### DIFF
--- a/chips/qemu_virt_chip/src/uart.rs
+++ b/chips/qemu_virt_chip/src/uart.rs
@@ -219,7 +219,12 @@ pub struct Uart16550<'a> {
 impl<'a> Uart16550<'a> {
     pub fn new(regs: StaticRef<Uart16550Registers>) -> Uart16550<'a> {
         // Disable all interrupts when constructing the UART
-        regs.ier.set(0xF);
+        regs.ier.write(
+            IER::ModemStatusRegisterChange::CLEAR
+                + IER::ReceiverLineStatusRegisterChange::CLEAR
+                + IER::TransmitterHoldingRegisterEmpty::CLEAR
+                + IER::ReceivedDataAvailable::CLEAR,
+        );
 
         regs.iir_fcr.write(FCR::Enable::CLEAR);
 


### PR DESCRIPTION


### Pull Request Overview

For the QEMU UART peripheral, setting IER to 0xF does not disable all interrupts. The RX interrupt is enabled by default, and causes a crash if a character is sent to the chip when nothing has setup UART RX.

Clear each interrupt explicitly.


### Testing Strategy

A test in QEMU (see #5026).


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
