### PR TITLE
kernel: arch_helpers: fix YWF TRD104 syscall return

### DIFF
--- a/kernel/src/utilities/arch_helpers.rs
+++ b/kernel/src/utilities/arch_helpers.rs
@@ -221,7 +221,7 @@ pub enum TRD104SyscallReturn {
     AllowReadOnlyFailure(ErrorCode, *const u8, usize),
     SubscribeSuccess(*const (), usize),
     SubscribeFailure(ErrorCode, *const (), usize),
-    YieldWaitFor(usize, usize, usize),
+    YieldWaitFor(u32, u32, u32),
 }
 
 impl TRD104SyscallReturn {
@@ -265,7 +265,9 @@ impl TRD104SyscallReturn {
             SyscallReturn::SubscribeFailure(a, b, c) => {
                 TRD104SyscallReturn::SubscribeFailure(a, b, c)
             }
-            SyscallReturn::YieldWaitFor(a, b, c) => TRD104SyscallReturn::YieldWaitFor(a, b, c),
+            SyscallReturn::YieldWaitFor(a, b, c) => {
+                TRD104SyscallReturn::YieldWaitFor(a as u32, b as u32, c as u32)
+            }
 
             // Compatibility mapping:
             SyscallReturn::SuccessAddr(a) => TRD104SyscallReturn::SuccessU32(a as u32),
@@ -387,9 +389,9 @@ pub fn encode_syscall_return_trd104(
             *a3 = data as u32;
         }
         TRD104SyscallReturn::YieldWaitFor(data0, data1, data2) => {
-            *a0 = data0 as u32;
-            *a1 = data1 as u32;
-            *a2 = data2 as u32;
+            *a0 = data0;
+            *a1 = data1;
+            *a2 = data2;
         }
     }
 }


### PR DESCRIPTION


### Pull Request Overview

The YWF arguments, at the TRD104 syscall layer, are `u32`s, not `usize`s. The in-kernel `SyscallReturn::YieldWaitFor` correctly uses usize, but the TRD104-specific return type should be `u32`s. `usize` is only used to mean "opaque", not a value passed from the capsule to the app. This now matches `encode_upcall_trd104`.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
