### PR TITLE
chips/lpc55s6x: convert ctimer0 armed flag from VolatileCell to Cell

### DIFF
--- a/chips/lpc55s6x/src/ctimer0.rs
+++ b/chips/lpc55s6x/src/ctimer0.rs
@@ -12,11 +12,13 @@
 //!
 //! Reference: *LPC55S6x/LPC55S2x/LPC552x User Manual* (NXP).
 
+use core::cell::Cell;
+
 use cortexm33::support::with_interrupts_disabled;
 use kernel::hil;
 use kernel::hil::time::{Alarm, Ticks, Ticks32, Time};
 use kernel::utilities::StaticRef;
-use kernel::utilities::cells::{OptionalCell, VolatileCell};
+use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{ReadOnly, ReadWrite, register_bitfields, register_structs};
 
@@ -340,7 +342,7 @@ const CTIMER0_BASE: StaticRef<Ctimer0Registers> =
 pub struct LPCTimer<'a> {
     registers: StaticRef<Ctimer0Registers>,
     client: OptionalCell<&'a dyn hil::time::AlarmClient>,
-    armed: VolatileCell<bool>,
+    armed: Cell<bool>,
 }
 
 impl<'a> LPCTimer<'a> {
@@ -348,7 +350,7 @@ impl<'a> LPCTimer<'a> {
         LPCTimer {
             registers: CTIMER0_BASE,
             client: OptionalCell::empty(),
-            armed: VolatileCell::new(false),
+            armed: Cell::new(false),
         }
     }
 


### PR DESCRIPTION
### Pull Request Overview

Apologies for the extra PR here; I'm learning a lot about coding with agents in this `VolatileCell` cleanup, and this commit didn't get rolled up with the other "this is a 'synchronization' that isn't needed". My fault :/.

Claude's full justification:

> `armed` is a plain software flag toggled from ordinary calls (`set_alarm`/`disarm`) and from `handle_interrupt`, which Tock's cooperative model runs from the kernel main loop rather than a preemptive nested ISR. There's no real concurrent/reentrant access here, so `VolatileCell` wasn't buying any synchronization guarantee.
>
> This is a different justification than the PLIC-family commit: it's not about an explicit "interrupts must be disabled" API contract, just Tock's general single-threaded execution model, and the fact that this same driver already uses `OptionalCell` for equivalent state (`client`). Plain `Cell` has identical single-threaded semantics.


### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

N/A

### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

Claude wrote and tested this; I verified it.
