### PR TITLE
Replace `InMemoryRegister` with `LocalRegisterCopy` where appropriate

### DIFF
--- a/chips/nrf52/src/usbd.rs
+++ b/chips/nrf52/src/usbd.rs
@@ -12,8 +12,7 @@ use kernel::utilities::StaticRef;
 use kernel::utilities::cells::{OptionalCell, VolatileCell};
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{
-    Field, InMemoryRegister, LocalRegisterCopy, ReadOnly, ReadWrite, WriteOnly, register_bitfields,
-    register_structs,
+    Field, LocalRegisterCopy, ReadOnly, ReadWrite, WriteOnly, register_bitfields, register_structs,
 };
 
 use crate::power;
@@ -1205,8 +1204,8 @@ impl<'a> Usbd<'a> {
     fn active_events(
         &self,
         _saved_inter: &LocalRegisterCopy<u32, Interrupt::Register>,
-    ) -> InMemoryRegister<u32, Interrupt::Register> {
-        let result = InMemoryRegister::new(0);
+    ) -> LocalRegisterCopy<u32, Interrupt::Register> {
+        let mut result = LocalRegisterCopy::new(0);
         if Usbd::take_event(&self.registers.event_usbreset) {
             debug_events!(
                 "- event: usbreset{}",

--- a/chips/nrf52/src/usbd.rs
+++ b/chips/nrf52/src/usbd.rs
@@ -1205,8 +1205,8 @@ impl<'a> Usbd<'a> {
     fn active_events(
         &self,
         _saved_inter: &LocalRegisterCopy<u32, Interrupt::Register>,
-    ) -> InMemoryRegister<u32, Interrupt::Register> {
-        let result = InMemoryRegister::new(0);
+    ) -> LocalRegisterCopy<u32, Interrupt::Register> {
+        let mut result = LocalRegisterCopy::new(0);
         if Usbd::take_event(&self.registers.event_usbreset) {
             debug_events!(
                 "- event: usbreset{}",

--- a/chips/qemu_virt_chip/src/uart.rs
+++ b/chips/qemu_virt_chip/src/uart.rs
@@ -12,7 +12,7 @@ use kernel::utilities::StaticRef;
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{
-    Aliased, Field, InMemoryRegister, ReadOnly, ReadWrite, register_bitfields,
+    Aliased, Field, LocalRegisterCopy, ReadOnly, ReadWrite, register_bitfields,
 };
 
 pub const UART_16550_BAUD_BASE: usize = 399193;
@@ -69,7 +69,7 @@ impl Uart16550Registers {
     /// registers.
     fn divisor_latch_reg<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&InMemoryRegister<u16, DLR::Register>) -> R,
+        F: FnOnce(&mut LocalRegisterCopy<u16, DLR::Register>) -> R,
     {
         let dlab_field = Field::<Uart16550RegshiftInt, LCR::Register>::new(1, 7);
 
@@ -83,8 +83,8 @@ impl Uart16550Registers {
         // Set DLAB = 0 prior to handing back to the caller
         self.lcr.modify(dlab_field.val(0));
 
-        let dlr = InMemoryRegister::<u16, DLR::Register>::new(old_val);
-        let ret = f(&dlr);
+        let mut dlr = LocalRegisterCopy::<u16, DLR::Register>::new(old_val);
+        let ret = f(&mut dlr);
 
         // Get the bytes from the modified value
         let [new_ier, new_rbr_thr] = u16::to_be_bytes(dlr.get());

--- a/chips/virtio/src/transports/mmio.rs
+++ b/chips/virtio/src/transports/mmio.rs
@@ -8,7 +8,7 @@ use kernel::utilities::StaticRef;
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{
-    InMemoryRegister, ReadOnly, ReadWrite, WriteOnly, register_bitfields,
+    LocalRegisterCopy, ReadOnly, ReadWrite, WriteOnly, register_bitfields,
 };
 
 use super::super::devices::{VirtIODeviceDriver, VirtIODeviceType};
@@ -262,10 +262,10 @@ impl VirtIOTransport for VirtIOMMIODevice {
         device_features_reg |= (self.regs.device_features.get() as u64) << 32;
 
         // Negotiate the transport features
-        let offered_transport_features: InMemoryRegister<u64, TransportFeatures::Register> =
-            InMemoryRegister::new(device_features_reg);
-        let selected_transport_features: InMemoryRegister<u64, TransportFeatures::Register> =
-            InMemoryRegister::new(0x0000000000000000);
+        let offered_transport_features: LocalRegisterCopy<u64, TransportFeatures::Register> =
+            LocalRegisterCopy::new(device_features_reg);
+        let mut selected_transport_features: LocalRegisterCopy<u64, TransportFeatures::Register> =
+            LocalRegisterCopy::new(0x0000000000000000);
 
         // Sanity check: Version1 must be offered AND accepted
         if !offered_transport_features.is_set(TransportFeatures::Version1) {


### PR DESCRIPTION
### Pull Request Overview

We had a few places where we were using `InMemoryRegister` where `LocalRegisterCopy` is actually the appropriate abstraction, i.e., where code just wants to use the bitfields API to manipulate a copy of a register. There's nothing _behaviorally wrong_ with using `InMemoryRegister`, the underlying volatile accesses just force the emission of a few extra reads and writes, it's just unnecessary and not actually the right abstraction for what the code is doing.

### Testing Strategy

This pull request was tested by compiling.

### TODO or Help Wanted

N/A


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

I'm working with Claude to review our use of `InMemoryRegister`. I prompted Claude to look for cases where `InMemoryRegister` was in use but was not the right abstraction, and these we all the cases it identified where `LocalRegisterCopy` should be used instead. I verified the reasoning and code diff for each of these cases.