### PR TITLE
chips: nRF52: Make `Nrf52DefaultPeripherals::new()` unsafe

### DIFF
--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -440,10 +440,14 @@ pub unsafe fn start_no_pconsole() -> (
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
     // Initialize chip peripheral drivers
-    let nrf52840_peripherals = static_init!(
-        Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
-    );
+    //
+    // SAFETY: We believe this is unique and uniquely controls DMA.
+    let nrf52840_peripherals = unsafe {
+        static_init!(
+            Nrf52840DefaultPeripherals,
+            Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
+        )
+    };
 
     // Set up circular peripheral dependencies.
     nrf52840_peripherals.init();

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -77,18 +77,23 @@ pub struct Nrf52DefaultPeripherals<'a> {
 }
 
 impl Nrf52DefaultPeripherals<'_> {
-    pub fn new(aes_ecb_buffer: &'static mut [u8; 48]) -> Self {
-        // # Safety
-        //
-        // This must only get constructed once.
-        //
-        // TODO: As of June 2026, we just assume peripherals are only created
-        // once and this is the only call to the AES manager constructor.
-        // However, once we have a strategy for enforcing the only-once
-        // constraint, we need to update this to use that so we can properly
-        // enforce this safety requirement.
+    /// Create default peripherals for an nRF52-based microcontroller.
+    ///
+    /// # Safety
+    ///
+    /// Some of these peripherals use DMA. As such, the default peripherals must
+    /// be unique. This requires:
+    ///
+    /// - This constructor must be called at most once.
+    /// - There must not be additional instances of the DMA-enabled peripheral
+    ///   drivers.
+    /// - There must not be any other code that accesses the DMA buffer and
+    ///   length registers of the DMA-enabled peripherals.
+    pub unsafe fn new(aes_ecb_buffer: &'static mut [u8; 48]) -> Self {
+        // SAFETY: See function-level doc.
         let aes_registers = unsafe { crate::aes::AesEcbRegistersManager::new(AESECB_BASE) };
 
+        // SAFETY: See function-level doc.
         let uarte0_registers = unsafe { crate::uart::UarteRegistersManager::new_uarte0() };
 
         Self {

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -89,6 +89,8 @@ impl Nrf52DefaultPeripherals<'_> {
         // enforce this safety requirement.
         let aes_registers = unsafe { crate::aes::AesEcbRegistersManager::new(AESECB_BASE) };
 
+        let uarte0_registers = unsafe { crate::uart::UarteRegistersManager::new_uarte0() };
+
         Self {
             acomp: crate::acomp::Comparator::new(),
             ecb: crate::aes::AesECB::new(aes_registers, aes_ecb_buffer),
@@ -100,7 +102,7 @@ impl Nrf52DefaultPeripherals<'_> {
             timer0: crate::timer::TimerAlarm::new(TIMER0_BASE),
             timer1: crate::timer::TimerAlarm::new(TIMER1_BASE),
             timer2: crate::timer::Timer::new(TIMER2_BASE),
-            uarte0: crate::uart::Uarte::new(crate::uart::UARTE0_BASE),
+            uarte0: crate::uart::Uarte::new(uarte0_registers),
             spim0: crate::spi::SPIM::new(0),
             twi1: crate::i2c::TWI::new_twi1(),
             spim2: crate::spi::SPIM::new(2),

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -27,8 +27,8 @@ const UARTE_MAX_BUFFER_SIZE: usize = 0xff;
 
 static mut BYTE: u8 = 0;
 
-pub const UARTE0_BASE: StaticRef<UarteRegisters> =
-    unsafe { StaticRef::new(0x40002000 as *const UarteRegisters) };
+const UARTE0_BASE: StaticRef<crate::uart::UarteRegisters> =
+    unsafe { StaticRef::new(0x40002000 as *const crate::uart::UarteRegisters) };
 
 #[repr(C)]
 pub struct UarteRegisters {
@@ -163,7 +163,7 @@ register_bitfields! [u32,
 ];
 
 /// Wrapper for managing MMIO for UARTE.
-struct UarteRegistersManager {
+pub struct UarteRegistersManager {
     /// MMIO registers for the UARTE peripheral.
     registers: StaticRef<UarteRegisters>,
     /// Holding place for the TX DMA buffer while DMA in progress.
@@ -173,9 +173,18 @@ struct UarteRegistersManager {
 }
 
 impl UarteRegistersManager {
-    pub fn new(regs: StaticRef<UarteRegisters>) -> Self {
+    /// Create a DMA-enabled register manager for UARTE.
+    ///
+    /// # Safety
+    ///
+    /// This controls DMA hardware. As such, it must be unique. This requires:
+    ///
+    /// - This constructor must be called at most once.
+    /// - There must not be any other code that accesses the DMA buffer and
+    ///   length registers.
+    pub unsafe fn new_uarte0() -> Self {
         Self {
-            registers: regs,
+            registers: UARTE0_BASE,
             tx_dma_buf: MapCell::empty(),
             rx_dma_buf: MapCell::empty(),
         }
@@ -338,9 +347,9 @@ pub struct UARTParams {
 impl<'a> Uarte<'a> {
     /// Constructor
     // This should only be constructed once
-    pub fn new(regs: StaticRef<UarteRegisters>) -> Uarte<'a> {
+    pub fn new(registers: UarteRegistersManager) -> Uarte<'a> {
         Uarte {
-            registers: UarteRegistersManager::new(regs),
+            registers,
             tx_client: OptionalCell::empty(),
             // tx_buffer: kernel::utilities::cells::TakeCell::empty(),
             tx_len: Cell::new(0),
@@ -840,7 +849,9 @@ impl kernel::platform::chip::PanicWriter for Uarte<'_> {
     unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write {
         use uart::Configure as _;
 
-        let inner = Uarte::new(UARTE0_BASE);
+        let registers = UarteRegistersManager::new_uarte0();
+
+        let inner = Uarte::new(registers);
         inner.initialize(
             pinmux::Pinmux::new(config.txd),
             pinmux::Pinmux::new(config.rxd),
@@ -858,7 +869,8 @@ mod tests {
 
     #[test]
     fn baud_rate_divider_calculation() {
-        let u = super::Uarte::new(super::UARTE0_BASE);
+        let registers_manager = super::UarteRegistersManager::new_uarte0();
+        let u = super::Uarte::new(&registers_manager);
         assert_eq!(u.get_divider_for_baud(0), Err(ErrorCode::INVAL));
         assert_eq!(u.get_divider_for_baud(4_000_000), Err(ErrorCode::INVAL));
 

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -869,8 +869,8 @@ mod tests {
 
     #[test]
     fn baud_rate_divider_calculation() {
-        let registers_manager = super::UarteRegistersManager::new_uarte0();
-        let u = super::Uarte::new(&registers_manager);
+        let registers_manager = unsafe { super::UarteRegistersManager::new_uarte0() };
+        let u = super::Uarte::new(registers_manager);
         assert_eq!(u.get_divider_for_baud(0), Err(ErrorCode::INVAL));
         assert_eq!(u.get_divider_for_baud(4_000_000), Err(ErrorCode::INVAL));
 

--- a/chips/nrf52840/src/interrupt_service.rs
+++ b/chips/nrf52840/src/interrupt_service.rs
@@ -21,12 +21,27 @@ pub struct Nrf52840DefaultPeripherals<'a> {
 }
 
 impl Nrf52840DefaultPeripherals<'_> {
+    /// Create default peripherals for the nRF52840 microcontroller.
+    ///
+    /// # Safety
+    ///
+    /// Some of these peripherals use DMA. As such, the default peripherals must
+    /// be unique. This requires:
+    ///
+    /// - This constructor must be called at most once.
+    /// - There must not be additional instances of the DMA-enabled peripheral
+    ///   drivers.
+    /// - There must not be any other code that accesses the DMA buffer and
+    ///   length registers of the DMA-enabled peripherals.
     pub unsafe fn new(
         ieee802154_radio_ack_buf: &'static mut [u8; crate::ieee802154_radio::ACK_BUF_SIZE],
         aes_ecb_buf: &'static mut [u8; 48],
     ) -> Self {
+        // SAFETY: See function-level doc.
+        let nrf52_peripherals = unsafe { Nrf52DefaultPeripherals::new(aes_ecb_buf) };
+
         Self {
-            nrf52: Nrf52DefaultPeripherals::new(aes_ecb_buf),
+            nrf52: nrf52_peripherals,
             ieee802154_radio: crate::ieee802154_radio::Radio::new(ieee802154_radio_ack_buf),
             usbd: crate::usbd::Usbd::new(),
             gpio_port: crate::gpio::nrf52840_gpio_create(),

--- a/chips/nrf5x-unsafe/src/aes.rs
+++ b/chips/nrf5x-unsafe/src/aes.rs
@@ -83,9 +83,11 @@ impl AesEcbRegistersManager {
     ///
     /// # Safety
     ///
-    /// This is only valid on an nrf5x-based MCU. This must only be called once
-    /// as having multiple interfaces to DMA registers is not safe. This must
-    /// be the only way the AES DMA registers are controlled.
+    /// This controls DMA hardware. As such, it must be unique. This requires:
+    ///
+    /// - This constructor must be called at most once.
+    /// - There must not be any other code that accesses the DMA buffer and
+    ///   length registers.
     pub unsafe fn new(regs: StaticRef<AesEcbRegisters>) -> Self {
         Self {
             registers: regs,


### PR DESCRIPTION
### Pull Request Overview

By popular demand, this marks the public constructor for the nRF52 default peripherals as unsafe.

I think this is completely broken, and that all safety requirements are already handled by Tock's policies, the cargo build system, the existence of `only_once!()`, and common sense. The situation required to violate this is implausible (a Tock board re-writes its interrupt handlers to include non-Tock code that activates DMA peripherals during an interrupt handler). Worse, the presence of one line of "SAFETY: ..." in lib.rs isn't going to stop someone who wants to do that implausible setup from doing do. However, it seems the consensus of the Tock project is to mark these constructors unsafe to make this requirement visible in the public API. So, here it is.

This is one step towards making the nrf52 chip crates mostly safe code (with separate `-unsafe` crates), and on edition 2024.

Note: this does not fix our current violation of the safety requirements. There is an ongoing thread about switching panic handlers to use UART and not UARTE. Also, it's in a panic, so...who cares.

-----
PS: Instead of marking the constructor unsafe, I propose we have a blanket Tock-wide safety policy around DMA since Rust has abdicated their responsibility to do so. It would state that to use the Tock Rust crates you can't call DMA from interrupts and you can't create safe APIs that expose the DMA address and length setters separately. Otherwise, your use of Tock is unsafe and that is on you. Same effect, still not checked by anything, but doesn't add more unsafe APIs to our codebase.




### Testing Strategy

Travis. This just slightly modifies some constructors.


### TODO or Help Wanted

Suggested changes on the safety docs? I would like to keep them agnostic of the actual peripheral so we can just copy-and-paste them without re-writing per peripheral.


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
