### PR TITLE
debug: Add messages if resources for printing unavailable

### DIFF
--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -175,7 +175,7 @@ pub fn panic_print<PW: PanicWriter, C: Chip, PP: ProcessPrinter>(
     // Display general information about the kernel.
     panic_banner(&mut writer, panic_info);
 
-    panic_resources.map(|pr| {
+    if let Some(pr) = panic_resources {
         let chip = pr.chip.take();
 
         // SAFETY: This may only be called during a panic, and we are guaranteed
@@ -197,13 +197,25 @@ pub fn panic_print<PW: PanicWriter, C: Chip, PP: ProcessPrinter>(
             // run processes.
             unsafe { c.mpu().disable_app_mpu() }
         });
-        pr.processes.take().map(|p| {
-            // SAFETY: We are guaranteed to be in a panic context.
-            unsafe {
-                panic_process_info(p, pr.printer.take(), &mut writer);
+        if let Some(p) = pr.processes.take() {
+            if let Some(process_printer) = pr.printer.take() {
+                if p.iter().filter(|p| p.get().is_some()).count() > 0 {
+                    // SAFETY: We are guaranteed to be in a panic context.
+                    unsafe {
+                        panic_process_info(p, process_printer, &mut writer);
+                    }
+                } else {
+                    let _ = writer.write_str("\r\nNo loaded processes\r\n");
+                }
+            } else {
+                let _ = writer.write_str("\r\nProcess Printer is not available\r\n");
             }
-        });
-    });
+        } else {
+            let _ = writer.write_str("\r\nProcesses List is not available\r\n");
+        }
+    } else {
+        let _ = writer.write_str("\r\nPanic Resources are not available\r\n");
+    }
 }
 
 /// Tock default panic routine.
@@ -276,7 +288,9 @@ pub unsafe fn panic_print_old<W: Write + IoWrite, C: Chip, PP: ProcessPrinter>(
                 c.mpu().disable_app_mpu()
             });
             pr.processes.take().map(|p| {
-                panic_process_info(p, pr.printer.take(), writer);
+                if let Some(process_printer) = pr.printer.take() {
+                    panic_process_info(p, process_printer, writer);
+                }
             });
         });
     }
@@ -392,24 +406,22 @@ pub unsafe fn panic_cpu_state<W: Write, C: Chip>(chip: Option<&'static C>, write
 /// This must only be called from a panic context.
 pub unsafe fn panic_process_info<PP: ProcessPrinter, W: Write>(
     processes: &'static [ProcessSlot],
-    process_printer: Option<&'static PP>,
+    process_printer: &'static PP,
     writer: &mut W,
 ) {
-    process_printer.map(|printer| {
-        // print data about each process
-        let _ = writer.write_fmt(format_args!("\r\n---| App Status |---\r\n"));
-        for slot in processes {
-            slot.proc.get().map(|process| {
-                // Print the memory map and basic process info.
-                //
-                // Because we are using a synchronous printer we do not need to
-                // worry about looping on the print function.
-                printer.print_overview(process, &mut BinaryToWriteWrapper::new(writer), None);
-                // Print all of the process details.
-                process.print_full_process(writer);
-            });
-        }
-    });
+    // print data about each process
+    let _ = writer.write_fmt(format_args!("\r\n---| App Status |---\r\n"));
+    for slot in processes {
+        slot.proc.get().map(|process| {
+            // Print the memory map and basic process info.
+            //
+            // Because we are using a synchronous printer we do not need to
+            // worry about looping on the print function.
+            process_printer.print_overview(process, &mut BinaryToWriteWrapper::new(writer), None);
+            // Print all of the process details.
+            process.print_full_process(writer);
+        });
+    }
 }
 
 /// Blinks a recognizable pattern forever.

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -205,16 +205,16 @@ pub fn panic_print<PW: PanicWriter, C: Chip, PP: ProcessPrinter>(
                         panic_process_info(p, process_printer, &mut writer);
                     }
                 } else {
-                    let _ = writer.write_str("\r\nNo loaded processes\r\n");
+                    let _ = writer.write_str("\r\nNo loaded processes.\r\n");
                 }
             } else {
-                let _ = writer.write_str("\r\nProcess Printer is not available\r\n");
+                let _ = writer.write_str("\r\nProcess Printer is not available.\r\n");
             }
         } else {
-            let _ = writer.write_str("\r\nProcesses List is not available\r\n");
+            let _ = writer.write_str("\r\nProcesses List is not available.\r\n");
         }
     } else {
-        let _ = writer.write_str("\r\nPanic Resources are not available\r\n");
+        let _ = writer.write_str("\r\nPanic Resources are not available.\r\n");
     }
 }
 


### PR DESCRIPTION
### Pull Request Overview

This is my take on half of #4972, specifically, changes to kernel/debug that show messages rather than just silently not doing anything if the board doesn't configure the panic resources correctly.

This differs from the existing PR in that the caller to print_process_info checks if there are actually any processes to print info about, and doesn't print anything if Chip is none, as most chips either print the same thing either way, or will still print nearly everything when chip is None.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
