### PR TITLE
kernel: ProcessStandard: fix undefined behavior in `enter_grant()`

### DIFF
--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -1307,30 +1307,24 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
                         // Check if this is entering a valid grant that has been created and
                         // initialized. If the grant is not valid then the `grant_ptr` will
                         // be null.
-                        match NonNull::new(grant_entry.grant_ptr) {
-                            Some(grant_ptr_nonnull) => {
-                                // Check if the grant pointer is marked that the grant
-                                // has already been entered. If so, return an error.
-                                if (usize::from(grant_ptr_nonnull.addr())) & 0x1 == 0x1 {
-                                    // Lowest bit is one, meaning this grant has been
-                                    // entered.
-                                    Err(Error::AlreadyInUse)
-                                } else {
-                                    // Now, to mark that the grant has been entered, we
-                                    // set the lowest bit to one and save this as the
-                                    // grant pointer.
-                                    grant_entry.grant_ptr =
-                                        (usize::from(grant_ptr_nonnull.addr()) | 0x1) as *mut u8;
+                        if let Some(grant_ptr_nonnull) = NonNull::new(grant_entry.grant_ptr) {
+                            // Check if the grant pointer is marked that the grant has already
+                            // been entered. If so, return an error.
+                            if (usize::from(grant_ptr_nonnull.addr())) & 0x1 == 0x1 {
+                                // Lowest bit is one, meaning this grant has been entered.
+                                Err(Error::AlreadyInUse)
+                            } else {
+                                // Now, to mark that the grant has been entered, we set the lowest
+                                // bit to one and save this as the grant pointer.
+                                grant_entry.grant_ptr =
+                                    (usize::from(grant_ptr_nonnull.addr()) | 0x1) as *mut u8;
 
-                                    // And we return the grant pointer to the entered
-                                    // grant.
-                                    Ok(grant_ptr_nonnull)
-                                }
+                                // And we return the grant pointer to the entered grant.
+                                Ok(grant_ptr_nonnull)
                             }
-                            None => {
-                                // The grant has not been created and is not valid to enter.
-                                Err(Error::OutOfMemory)
-                            }
+                        } else {
+                            // The grant has not been created and is not valid to enter.
+                            Err(Error::OutOfMemory)
                         }
                     }
                     None => Err(Error::AddressOutOfBounds),

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -1304,24 +1304,33 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
                 // panic.
                 match grant_pointers.get_mut(grant_num) {
                     Some(grant_entry) => {
-                        // Get a copy of the actual grant pointer.
-                        let grant_ptr = grant_entry.grant_ptr;
+                        // Check if this is entering a valid grant that has been created and
+                        // initialized. If the grant is not valid then the `grant_ptr` will
+                        // be null.
+                        match NonNull::new(grant_entry.grant_ptr) {
+                            Some(grant_ptr_nonnull) => {
+                                // Check if the grant pointer is marked that the grant
+                                // has already been entered. If so, return an error.
+                                if (usize::from(grant_ptr_nonnull.addr())) & 0x1 == 0x1 {
+                                    // Lowest bit is one, meaning this grant has been
+                                    // entered.
+                                    Err(Error::AlreadyInUse)
+                                } else {
+                                    // Now, to mark that the grant has been entered, we
+                                    // set the lowest bit to one and save this as the
+                                    // grant pointer.
+                                    grant_entry.grant_ptr =
+                                        (usize::from(grant_ptr_nonnull.addr()) | 0x1) as *mut u8;
 
-                        // Check if the grant pointer is marked that the grant
-                        // has already been entered. If so, return an error.
-                        if (grant_ptr as usize) & 0x1 == 0x1 {
-                            // Lowest bit is one, meaning this grant has been
-                            // entered.
-                            Err(Error::AlreadyInUse)
-                        } else {
-                            // Now, to mark that the grant has been entered, we
-                            // set the lowest bit to one and save this as the
-                            // grant pointer.
-                            grant_entry.grant_ptr = (grant_ptr as usize | 0x1) as *mut u8;
-
-                            // And we return the grant pointer to the entered
-                            // grant.
-                            Ok(unsafe { NonNull::new_unchecked(grant_ptr) })
+                                    // And we return the grant pointer to the entered
+                                    // grant.
+                                    Ok(grant_ptr_nonnull)
+                                }
+                            }
+                            None => {
+                                // The grant has not been created and is not valid to enter.
+                                Err(Error::OutOfMemory)
+                            }
                         }
                     }
                     None => Err(Error::AddressOutOfBounds),


### PR DESCRIPTION


### Pull Request Overview

The enter_grant function used `NonNull::new_unchecked()` without first checking that the pointer was in fact not null. In practice we only call this `enter_grant()` on allocated grants. However, the API is public and marked safe.

This fixes the issue by using creating a NonNull as the check, and return `OutOfMemory` if the grant is not allocated.


### Testing Strategy

I used the process console to verify I could in fact call this function and get a NonNull to address 0x0. With this I get the error instead.


### TODO or Help Wanted

I used the `OutOfMemory` because it kind of matches another grant-related function. We don't have a specific obvious error for this. Should I create one?


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
