### PR TITLE
Standardize on the safety comments with `# Safety` headers

### DIFF
--- a/arch/x86/src/boundary/context.rs
+++ b/arch/x86/src/boundary/context.rs
@@ -49,7 +49,7 @@ impl UserContext {
     ///
     /// Returns an `Err` if the new stack value would fall outside of valid memory.
     ///
-    /// ## Safety
+    /// # Safety
     ///
     /// The memory region described by `accessible_memory_start` and `app_brk` must point to memory
     /// of the user process. This function will write to that memory.
@@ -84,7 +84,7 @@ impl UserContext {
     ///
     /// Returns an `Err` if the specified location falls outside of valid memory.
     ///
-    /// ## Safety
+    /// # Safety
     ///
     /// The memory region described by `accessible_memory_start` and `app_brk` must point to memory
     /// of the user process. This function will read from that memory.
@@ -117,7 +117,7 @@ impl UserContext {
     ///
     /// Returns an `Err` if the specified location falls outside of valid memory.
     ///
-    /// ## Safety
+    /// # Safety
     ///
     /// The memory region described by `accessible_memory_start` and `app_brk` must point to memory
     /// of the user process. This function will write to that memory.

--- a/arch/x86/src/interrupts/idt.rs
+++ b/arch/x86/src/interrupts/idt.rs
@@ -57,7 +57,7 @@ const USER_ACCESSIBLE_INTERRUPTS: &[u8] = &[
 /// entry for every possible interrupt vector (see [`NUM_VECTORS`]) referencing the corresponding
 /// handler stub.
 ///
-/// ## Safety
+/// # Safety
 ///
 /// Must not be called more than once, or the IDT created by this function may become corrupted.
 ///

--- a/arch/x86/src/interrupts/mod.rs
+++ b/arch/x86/src/interrupts/mod.rs
@@ -30,7 +30,7 @@ pub const IDT_RESERVED_EXCEPTIONS: u8 = 32;
 ///
 /// After calling this function, [`InterruptPoller`] can be used to poll for and handle interrupts.
 ///
-/// ## Safety
+/// # Safety
 ///
 /// This function must never be executed more than once.
 ///

--- a/arch/x86/src/interrupts/poller.rs
+++ b/arch/x86/src/interrupts/poller.rs
@@ -40,7 +40,7 @@ pub struct InterruptPoller {
 /// We use a `static mut` singleton so that the instance can be accessed directly from interrupt
 /// handler routines.
 ///
-/// ## Safety
+/// # Safety
 ///
 /// As with any `static mut` item, the poller singleton must not be accessed concurrently. To
 /// enforce this restriction, this module exposes two constrained methods for accessing the
@@ -79,7 +79,7 @@ impl InterruptPoller {
 
     /// Marks that the specified interrupt as pending.
     ///
-    /// ## Safety
+    /// # Safety
     ///
     /// Interrupts must be disabled when this function is called. This function is _intended_ to be
     /// called from within an ISR, so hopefully this is already true.

--- a/arch/x86/src/lib.rs
+++ b/arch/x86/src/lib.rs
@@ -25,7 +25,7 @@
 //! Apart from external interrupts, all other interrupt categories such as CPU exceptions or system
 //! calls are handled internally by this crate.
 //!
-//! ## Safety
+//! # Safety
 //!
 //! Some of the `unsafe` code in this crate relies on the blanket assumption that this code is being
 //! compiled into a Tock kernel for an x86 system. When calling code from this crate, the following
@@ -61,7 +61,7 @@ mod start;
 /// This function installs new segmentation and interrupt handling regimes which the rest of this
 /// crate needs to function properly.
 ///
-/// ## Safety
+/// # Safety
 ///
 /// This function must never be executed more than once.
 ///

--- a/arch/x86/src/segmentation.rs
+++ b/arch/x86/src/segmentation.rs
@@ -74,7 +74,7 @@ static mut TSS_INSTANCE: TaskStateSegment = TaskStateSegment::new();
 
 /// Initializes the global TSS instance and returns a descriptor for it.
 ///
-/// ## Safety
+/// # Safety
 ///
 /// Must never be called more than once, as this would cause the TSS to be reinitialized
 /// unexpectedly.
@@ -95,7 +95,7 @@ unsafe fn init_tss() -> Descriptor {
 
 /// Sets the stack pointer to use for handling interrupts from user mode.
 ///
-/// ## Safety
+/// # Safety
 ///
 /// When handling interrupts that occur during user mode, the context switching logic has very
 /// specific expectations about the layout of the kernel's stack frame. See _return_from_user.rs_ for
@@ -115,7 +115,7 @@ pub unsafe extern "cdecl" fn set_tss_esp0(esp: u32) {
 
 /// Performs global initialization of memory segmentation.
 ///
-/// ## Safety
+/// # Safety
 ///
 /// Memory must be identity-mapped before this function is called. Otherwise the kernel's code/data
 /// will suddenly be re-mapped to different addresses, likely resulting in a spectacular crash.

--- a/chips/msp432/src/adc.rs
+++ b/chips/msp432/src/adc.rs
@@ -577,7 +577,7 @@ enum AdcMode {
 /// This function converts a `&'static mut [u8]` slice reference to a
 /// `&'static mut [u16]` slice.
 ///
-/// ## Safety
+/// # Safety
 ///
 /// It is a necessary condition for the passed buffer to have an even
 /// length, otherwise the function will panic because the conversion

--- a/chips/rp2040/src/pwm.rs
+++ b/chips/rp2040/src/pwm.rs
@@ -744,7 +744,7 @@ impl hil::pwm::Pwm for Pwm<'_> {
     /// + 100% duty cycle demand for low frequencies (close to or below threshold_freq)
     /// + very low frequencies
     ///
-    /// ## Safety
+    /// # Safety
     ///
     /// It is safe to call multiples times this method with different values while the pin is
     /// running.
@@ -766,7 +766,7 @@ impl hil::pwm::Pwm for Pwm<'_> {
     ///
     /// This method may never fail.
     ///
-    /// ## Safety
+    /// # Safety
     ///
     /// It is safe to call this method multiple times on the same pin. If the pin is already
     /// stopped, then it does nothing.

--- a/chips/stm32u5xx-unsafe/src/aes.rs
+++ b/chips/stm32u5xx-unsafe/src/aes.rs
@@ -169,7 +169,7 @@ pub struct AesRegistersManager {
 }
 
 impl AesRegistersManager {
-    /// ### Safety
+    /// # Safety
     ///
     /// The caller must ensure that the provided `StaticRef` points to a valid
     /// memory-mapped AES peripheral and that no other part of the system is
@@ -327,7 +327,7 @@ impl AesDmaBuffers {
             reg.cr.modify(Control::DMAINEN::CLEAR);
         }
         self.dma_in_buf.take().map(|s| {
-            // ### Safety
+            // # Safety
             //
             // This creates a new DMA fence to ensure that all previous DMA
             // transfers have completed and memory is consistent before the
@@ -348,7 +348,7 @@ impl AesDmaBuffers {
             reg.cr.modify(Control::DMAINEN::CLEAR);
         }
         self.dma_out_buf.take().map(|s| {
-            // ### Safety
+            // # Safety
             //
             // This creates a new DMA fence to ensure that all previous DMA
             // transfers have completed and memory is consistent before the

--- a/chips/x86_q35/src/chip.rs
+++ b/chips/x86_q35/src/chip.rs
@@ -99,7 +99,7 @@ pub struct Pc<'a, I1: InterruptService + 'a, I2: InterruptService + 'a, const PR
 impl<I2: InterruptService, const PR: u16> Pc<'static, PcDefaultPeripherals<PR>, I2, PR> {
     /// Construct `Pc` using a standard set of peripherals plus page tables.
     ///
-    /// ## Safety
+    /// # Safety
     /// - Must be called only once for the lifetime of the kernel.
     /// - `pd` and `pt` must be identity-mapped and unique.
     pub unsafe fn new(
@@ -269,7 +269,7 @@ impl<const PR: u16> PcDefaultPeripherals<PR> {
     ///
     /// The caller must provide statics through `x86_q35_peripherals_static!()`.
     ///
-    /// ## Safety
+    /// # Safety
     /// - Must be called only once per kernel lifetime.
     pub unsafe fn new(
         s: (

--- a/chips/x86_q35/src/interrupts.rs
+++ b/chips/x86_q35/src/interrupts.rs
@@ -13,7 +13,7 @@ use super::pic;
 /// interrupt, then issues an EOI message to the system interrupt controller so that subsequent
 /// interrupts can be delivered.
 ///
-/// ## Safety
+/// # Safety
 ///
 /// This function must only be called when handling an interrupt. It should _never_ be called by
 /// other Rust code.

--- a/chips/x86_q35/src/lib.rs
+++ b/chips/x86_q35/src/lib.rs
@@ -4,7 +4,7 @@
 
 //! Support for traditional x86 PC hardware.
 //!
-//! ## Safety
+//! # Safety
 //!
 //! This crate inherits all of the same safety hazards as outlined by [`x86`].
 //!

--- a/chips/x86_q35/src/pic.rs
+++ b/chips/x86_q35/src/pic.rs
@@ -52,7 +52,7 @@ const POST_PORT: u16 = 0x80;
 /// Initializes the system's primary and secondary PICs in a chained configuration and unmasks all
 /// interrupts.
 ///
-/// ## Safety
+/// # Safety
 ///
 /// Calling this function will cause interrupts to start firing. This means the IDT must already be
 /// initialized with valid handlers for all possible interrupt numbers (i.e. by a call to
@@ -95,7 +95,7 @@ pub unsafe fn init() {
 ///
 /// If `num` does not correspond to either the primary or secondary PIC, then no action is taken.
 ///
-/// ## Safety
+/// # Safety
 ///
 /// This function must _only_ be called from an interrupt servicing routine. Calling this function
 /// from the normal kernel loop could interfere with this crate's interrupt handling logic.
@@ -114,7 +114,7 @@ pub(crate) unsafe fn eoi(num: u32) {
 ///
 /// If `num` does not correspond to either the primary or secondary PIC, then no action is taken.
 ///
-/// ## Safety
+/// # Safety
 ///
 /// Must be called with interrupts disabled or from within an interrupt handler to avoid race
 /// conditions updating the IMR.
@@ -136,7 +136,7 @@ pub(crate) unsafe fn mask(num: u32) {
 ///
 /// If `num` does not correspond to either the primary or secondary PIC, then no action is taken.
 ///
-/// ## Safety
+/// # Safety
 ///
 /// Must be called with interrupts disabled or from within an interrupt handler to avoid race
 /// conditions updating the IMR.

--- a/chips/x86_q35/src/pit.rs
+++ b/chips/x86_q35/src/pit.rs
@@ -119,7 +119,7 @@ pub struct Pit<'a, const R: u16> {
 impl<const R: u16> Pit<'_, R> {
     /// Creates a new PIT timer object.
     ///
-    /// ## Safety
+    /// # Safety
     ///
     /// There must never be more than a single instance of `Pit` alive at any given time.
     pub unsafe fn new() -> Self {

--- a/chips/x86_q35/src/serial.rs
+++ b/chips/x86_q35/src/serial.rs
@@ -432,7 +432,7 @@ pub struct SerialPortComponent {
 impl SerialPortComponent {
     /// Constructs and returns a new instance of `SerialPortComponent`.
     ///
-    /// ## Safety
+    /// # Safety
     ///
     /// An 8250-compatible serial port must exist at the specified address. Otherwise we could end
     /// up spamming some unknown device with I/O operations.
@@ -481,7 +481,7 @@ pub struct BlockingSerialPort(u16);
 impl BlockingSerialPort {
     /// Creates and returns a new `BlockingSerialPort` instance.
     ///
-    /// ## Safety
+    /// # Safety
     ///
     /// An 8250-compatible serial port must exist at the specified address. Otherwise we could end
     /// up spamming some unknown device with I/O operations.

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -645,7 +645,7 @@ pub trait Process {
     /// process (thereby writable by the process itself) and the value was set,
     /// false otherwise.
     ///
-    /// ### Safety
+    /// # Safety
     ///
     /// This function verifies that the byte to be written is in the process's
     /// accessible memory. However, to avoid undefined behavior the caller needs
@@ -770,7 +770,7 @@ pub trait Process {
     /// grants are invalid and are not entered or not entered, and this function
     /// will do nothing.
     ///
-    /// ### Safety
+    /// # Safety
     ///
     /// The caller must ensure that no references to the memory inside the grant
     /// exist after calling `leave_grant()`. Otherwise, it would be possible to

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -532,7 +532,7 @@ pub trait UserspaceKernelBoundary {
     /// example, if a process crashes and is to be restarted, this must be
     /// called. Or if the process is moved this may need to be called.
     ///
-    /// ### Safety
+    /// # Safety
     ///
     /// This function guarantees that it if needs to change process memory, it
     /// will only change memory starting at `accessible_memory_start` and before
@@ -554,7 +554,7 @@ pub trait UserspaceKernelBoundary {
     /// process so that when it resumes executing it knows the return value of
     /// the syscall it called.
     ///
-    /// ### Safety
+    /// # Safety
     ///
     /// This function guarantees that it if needs to change process memory, it
     /// will only change memory starting at `accessible_memory_start` and before
@@ -596,7 +596,7 @@ pub trait UserspaceKernelBoundary {
     /// process. Returns `Err(())` if the function was not, likely because there
     /// is insufficient memory available to do so.
     ///
-    /// ### Safety
+    /// # Safety
     ///
     /// This function guarantees that it if needs to change process memory, it
     /// will only change memory starting at `accessible_memory_start` and before
@@ -621,7 +621,7 @@ pub trait UserspaceKernelBoundary {
     ///    the process's stack pointer with process.rs users can inspect the
     ///    state and see the stack depth, which might be useful for debugging.
     ///
-    /// ### Safety
+    /// # Safety
     ///
     /// This function guarantees that it if needs to change process memory, it
     /// will only change memory starting at `accessible_memory_start` and before
@@ -637,7 +637,7 @@ pub trait UserspaceKernelBoundary {
     /// Display architecture specific (e.g. CPU registers or status flags) data
     /// for a process identified by the stored state for that process.
     ///
-    /// ### Safety
+    /// # Safety
     ///
     /// This function guarantees that it if needs to change process memory, it
     /// will only change memory starting at `accessible_memory_start` and before

--- a/kernel/src/utilities/capability_ptr.rs
+++ b/kernel/src/utilities/capability_ptr.rs
@@ -114,7 +114,7 @@ impl CapabilityPtr {
     /// Provenance note: may derive from a pointer other than the input to provide something with
     /// valid provenance to justify the other arguments.
     ///
-    /// ## Safety
+    /// # Safety
     ///
     /// Constructing a [`CapabilityPtr`] with metadata may convey authority to
     /// dereference this pointer, such as in userspace. When these pointers

--- a/kernel/src/utilities/static_ref.rs
+++ b/kernel/src/utilities/static_ref.rs
@@ -28,7 +28,7 @@ pub struct StaticRef<T> {
 impl<T> StaticRef<T> {
     /// Create a new [`StaticRef`] from a raw pointer
     ///
-    /// ## Safety
+    /// # Safety
     ///
     /// - `ptr` must be aligned, non-null, and dereferencable as `T`.
     /// - `*ptr` must be valid for the program duration.

--- a/libraries/tock-tbf/src/parse.rs
+++ b/libraries/tock-tbf/src/parse.rs
@@ -29,7 +29,7 @@ pub fn parse_tbf_header_lengths(
     // Version is the first 16 bits of the app TBF contents. We need this to
     // correctly parse the other lengths.
     //
-    // ## Safety
+    // # Safety
     // We trust that the version number has been checked prior to running this
     // parsing code. That is, whatever loaded this application has verified that
     // the version is valid and therefore we can trust it.


### PR DESCRIPTION
### Pull Request Overview

Change all `## Safety` and `### Safety` to just `# Safety`.


### Testing Strategy

comments


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

I had claude write the sed command I ran.
