### PR TITLE
kernel: chip: add create_panic_writer safety doc

### DIFF
--- a/kernel/src/platform/chip.rs
+++ b/kernel/src/platform/chip.rs
@@ -218,5 +218,18 @@ pub trait PanicWriter {
     ///
     /// The writer must implement [`IoWrite`] (which is just `std:io::Write`
     /// implemented for no_std).
+    ///
+    /// # Safety
+    ///
+    /// Implementors must ensure that the created writer is safe to construct,
+    /// particularly if the writer is based on using a hardware peripheral. The
+    /// panic writer may need to use the same hardware resources that the normal
+    /// kernel used, and the implementation must ensure that constructing a new
+    /// writer does not alias any memory or otherwise violate memory safety
+    /// requirements.
+    ///
+    /// A particular issue is with writers that use DMA. Implementors must
+    /// ensure a second object that manages the same DMA hardware is not
+    /// created.
     unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write;
 }

--- a/kernel/src/platform/chip.rs
+++ b/kernel/src/platform/chip.rs
@@ -221,15 +221,8 @@ pub trait PanicWriter {
     ///
     /// # Safety
     ///
-    /// Implementors must ensure that the created writer is safe to construct,
-    /// particularly if the writer is based on using a hardware peripheral. The
-    /// panic writer may need to use the same hardware resources that the normal
-    /// kernel used, and the implementation must ensure that constructing a new
-    /// writer does not alias any memory or otherwise violate memory safety
-    /// requirements.
+    /// - This must ONLY be called from a panic context.
     ///
-    /// A particular issue is with writers that use DMA. Implementors must
-    /// ensure a second object that manages the same DMA hardware is not
-    /// created.
+    /// Implementations must not require more strict safety requirements.
     unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write;
 }


### PR DESCRIPTION
### Pull Request Overview

I made an attempt at writing the safety docs for `create_panic_writer`. I was never too confident on why this needs to be unsafe, but here is my attempt.

@lschuermann 


### Testing Strategy

comments


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
