### PR TITLE
kernel: chip: add safety doc for chip debug print

### DIFF
--- a/kernel/src/platform/chip.rs
+++ b/kernel/src/platform/chip.rs
@@ -95,6 +95,12 @@ pub trait Chip {
     /// `None`. The implementation of `print_state` may not print certain
     /// information if it depends on runtime-accessible state in `Self`, but
     /// that reference is not provided.
+    ///
+    /// # Safety
+    ///
+    /// Implementations may need to access low-level chip-specific hardware that
+    /// isn't safe to access during the normal operation of the chip. This
+    /// function may only be called from a panic context.
     unsafe fn print_state(this: Option<&Self>, writer: &mut dyn Write);
 }
 


### PR DESCRIPTION
### Pull Request Overview

I took a stab at writing safety docs for `Chip::print_state()`. This one isn't clear why printing is unsafe, but here is my attempt.


### Testing Strategy

comments


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
