### PR TITLE
kernel: debug: make panic functions safe and add safety comments

### DIFF
--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -156,39 +156,54 @@ impl<C: Chip, PP: ProcessPrinter> PanicResources<C, PP> {
 /// Care must be taken on how one interacts with the system once this function
 /// returns.
 ///
-/// **NOTE:** The supplied `writer` must be synchronous.
-pub unsafe fn panic_print<PW: PanicWriter, C: Chip, PP: ProcessPrinter>(
+/// Because this requires a [`PanicInfo`] reference, this can only be called
+/// from a panic context.
+pub fn panic_print<PW: PanicWriter, C: Chip, PP: ProcessPrinter>(
     writer_config: PW::Config,
     panic_info: &PanicInfo,
     nop: &dyn Fn(),
     panic_resources: Option<&PanicResources<C, PP>>,
 ) {
-    unsafe {
-        // Create the synchronous writer we can use to output the panic message.
-        let mut writer = PW::create_panic_writer(writer_config, panic_info);
+    // Create the synchronous writer we can use to output the panic message.
+    let mut writer = PW::create_panic_writer(writer_config, panic_info);
 
-        panic_begin(nop);
-        // Flush debug buffer if needed
-        flush(&mut writer);
-        panic_banner(&mut writer, panic_info);
+    panic_begin(nop);
 
-        panic_resources.map(|pr| {
-            let chip = pr.chip.take();
+    // Flush debug buffer if needed
+    flush(&mut writer);
+
+    // Display general information about the kernel.
+    panic_banner(&mut writer, panic_info);
+
+    panic_resources.map(|pr| {
+        let chip = pr.chip.take();
+
+        // SAFETY: This may only be called during a panic, and we are guaranteed
+        // to be in a panic when running this function.
+        unsafe {
             panic_cpu_state(chip, &mut writer);
+        }
 
-            chip.map(|c| {
-                // Some systems may enforce memory protection regions for the kernel,
-                // making application memory inaccessible. However, printing process
-                // information will attempt to access memory. If we are provided a chip
-                // reference, attempt to disable userspace memory protection first:
-                use crate::platform::mpu::MPU;
-                c.mpu().disable_app_mpu()
-            });
-            pr.processes.take().map(|p| {
-                panic_process_info(p, pr.printer.take(), &mut writer);
-            });
+        chip.map(|c| {
+            use crate::platform::mpu::MPU;
+            // Some systems may enforce memory protection regions for the kernel,
+            // making application memory inaccessible. However, printing process
+            // information will attempt to access memory. If we are provided a chip
+            // reference, attempt to disable userspace memory protection first.
+            //
+            // SAFETY: This is safe because we are in a panic handler and we
+            // will never run processes again. We do not guarantee we will
+            // re-enable the MPU, but that is ok because in a panic we do not
+            // run processes.
+            unsafe { c.mpu().disable_app_mpu() }
         });
-    }
+        pr.processes.take().map(|p| {
+            // SAFETY: We are guaranteed to be in a panic context.
+            unsafe {
+                panic_process_info(p, pr.printer.take(), &mut writer);
+            }
+        });
+    });
 }
 
 /// Tock default panic routine.
@@ -197,24 +212,25 @@ pub unsafe fn panic_print<PW: PanicWriter, C: Chip, PP: ProcessPrinter>(
 ///
 /// This will print a detailed debugging message and then loop forever while
 /// blinking an LED in a recognizable pattern.
-pub unsafe fn panic<L: hil::led::Led, PW: PanicWriter, C: Chip, PP: ProcessPrinter>(
+///
+/// Because this requires a [`PanicInfo`] reference, this can only be called
+/// from a panic context.
+pub fn panic<L: hil::led::Led, PW: PanicWriter, C: Chip, PP: ProcessPrinter>(
     leds: &mut [&L],
     writer_config: PW::Config,
     panic_info: &PanicInfo,
     nop: &dyn Fn(),
     panic_resources: Option<&PanicResources<C, PP>>,
 ) -> ! {
-    unsafe {
-        // Call `panic_print` first which will print out the panic information and
-        // return
-        panic_print::<PW, C, PP>(writer_config, panic_info, nop, panic_resources);
+    // Call `panic_print` first which will print out the panic information and
+    // return
+    panic_print::<PW, C, PP>(writer_config, panic_info, nop, panic_resources);
 
-        // The system is no longer in a well-defined state, we cannot
-        // allow this function to return
-        //
-        // Forever blink LEDs in an infinite loop
-        panic_blink_forever(leds)
-    }
+    // The system is no longer in a well-defined state, we cannot
+    // allow this function to return
+    //
+    // Forever blink LEDs in an infinite loop
+    panic_blink_forever(leds)
 }
 
 /// Tock panic routine, without the infinite LED-blinking loop.
@@ -228,12 +244,19 @@ pub unsafe fn panic<L: hil::led::Led, PW: PanicWriter, C: Chip, PP: ProcessPrint
 /// returns.
 ///
 /// **NOTE:** The supplied `writer` must be synchronous.
+///
+/// # Safety
+///
+/// - This must ONLY be called during a panic.
 pub unsafe fn panic_print_old<W: Write + IoWrite, C: Chip, PP: ProcessPrinter>(
     writer: &mut W,
     panic_info: &PanicInfo,
     nop: &dyn Fn(),
     panic_resources: Option<&PanicResources<C, PP>>,
 ) {
+    // SAFETY: This has the same safety reasoning as `panic_print()`. This
+    // implementation is deprecated. When all callers are updated it will be
+    // removed.
     unsafe {
         panic_begin(nop);
         // Flush debug buffer if needed
@@ -265,6 +288,10 @@ pub unsafe fn panic_print_old<W: Write + IoWrite, C: Chip, PP: ProcessPrinter>(
 ///
 /// This will print a detailed debugging message and then loop forever while
 /// blinking an LED in a recognizable pattern.
+///
+/// # Safety
+///
+/// - This must ONLY be called during a panic.
 pub unsafe fn panic_old<L: hil::led::Led, W: Write + IoWrite, C: Chip, PP: ProcessPrinter>(
     leds: &mut [&L],
     writer: &mut W,
@@ -272,17 +299,19 @@ pub unsafe fn panic_old<L: hil::led::Led, W: Write + IoWrite, C: Chip, PP: Proce
     nop: &dyn Fn(),
     panic_resources: Option<&PanicResources<C, PP>>,
 ) -> ! {
+    // Call `panic_print` first which will print out the panic information and
+    // return.
+    //
+    // SAFETY: The requirements match this function.
     unsafe {
-        // Call `panic_print` first which will print out the panic information and
-        // return
         panic_print_old(writer, panic_info, nop, panic_resources);
-
-        // The system is no longer in a well-defined state, we cannot
-        // allow this function to return
-        //
-        // Forever blink LEDs in an infinite loop
-        panic_blink_forever(leds)
     }
+
+    // The system is no longer in a well-defined state, we cannot
+    // allow this function to return
+    //
+    // Forever blink LEDs in an infinite loop
+    panic_blink_forever(leds)
 }
 
 /// Generic panic entry.
@@ -290,7 +319,7 @@ pub unsafe fn panic_old<L: hil::led::Led, W: Write + IoWrite, C: Chip, PP: Proce
 /// This opaque method should always be called at the beginning of a board's
 /// panic method to allow hooks for any core kernel cleanups that may be
 /// appropriate.
-pub unsafe fn panic_begin(nop: &dyn Fn()) {
+pub fn panic_begin(nop: &dyn Fn()) {
     // Let any outstanding uart DMA's finish
     for _ in 0..200000 {
         nop();
@@ -300,7 +329,10 @@ pub unsafe fn panic_begin(nop: &dyn Fn()) {
 /// Lightweight prints about the current panic and kernel version.
 ///
 /// **NOTE:** The supplied `writer` must be synchronous.
-pub unsafe fn panic_banner<W: Write>(writer: &mut W, panic_info: &PanicInfo) {
+///
+/// Because this requires a [`PanicInfo`] reference, this can only be called
+/// from a panic context.
+pub fn panic_banner<W: Write>(writer: &mut W, panic_info: &PanicInfo) {
     // Expand `PanicInfo` manually rather than using its `Display`
     // implementation. The `Display` implementation inserts bare LFs
     // between the location line and the message body, rather than a
@@ -339,7 +371,13 @@ pub unsafe fn panic_banner<W: Write>(writer: &mut W, panic_info: &PanicInfo) {
 /// Print current machine (CPU) state.
 ///
 /// **NOTE:** The supplied `writer` must be synchronous.
+///
+/// # Safety
+///
+/// This may only be called during a panic.
 pub unsafe fn panic_cpu_state<W: Write, C: Chip>(chip: Option<&'static C>, writer: &mut W) {
+    // SAFETY: The function-level safety doc requires this only be called during
+    // a panic, matching the requirement for `print_state()`.
     unsafe {
         C::print_state(chip, writer);
     }
@@ -348,6 +386,10 @@ pub unsafe fn panic_cpu_state<W: Write, C: Chip>(chip: Option<&'static C>, write
 /// More detailed prints about all processes.
 ///
 /// **NOTE:** The supplied `writer` must be synchronous.
+///
+/// # Safety
+///
+/// This must only be called from a panic context.
 pub unsafe fn panic_process_info<PP: ProcessPrinter, W: Write>(
     processes: &'static [ProcessSlot],
     process_printer: Option<&'static PP>,


### PR DESCRIPTION
### Pull Request Overview

This fills in safety docs for our debug panic utilities and removes unsafe in favor of requiring a `PanicInfo`. Because there is no `PanicInfo` constructor, this ensures these functions can only be called from a panic context. The functions that do not require a `PanicInfo` argument remain unsafe (likely those will be changed to use the PanicContextTicket in the future).

We talked a bit when I proposed switching to capabilities that we don't know what the safety requirements actually are. Here is my attempt to define them.


### Testing Strategy

comments


### TODO or Help Wanted

It does seem like a stretch these are all memory safety issues. Thoughts?


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
