### PR TITLE
boards: libs: leave pconsole in platform struct

### DIFF
--- a/boards/apollo3/lora_things_plus/src/main.rs
+++ b/boards/apollo3/lora_things_plus/src/main.rs
@@ -956,10 +956,10 @@ unsafe fn setup() -> (
     let checker = components::appid::checker::ProcessCheckerMachineComponent::new(checking_policy)
         .finalize(components::process_checker_machine_component_static!());
 
-    kernel::declare_capability!(AppStoreCap: kernel::capabilities::ApplicationStorageCapability);
+    kernel::create_typed_capability!(app_store_cap, AppStoreCap: kernel::capabilities::ApplicationStorageCapability);
     let storage_permissions_policy =
         components::storage_permissions::tbf_header::StoragePermissionsTbfHeaderComponent::new(
-            AppStoreCap,
+            app_store_cap,
         )
         .finalize(
             components::storage_permissions_tbf_header_component_static!(

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -720,7 +720,7 @@ unsafe fn start() -> (
         resources.printer.put(process_printer);
     });
 
-    kernel::declare_capability!(ProcessConsoleCap:
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
         kernel::capabilities::ProcessManagementCapability,
         kernel::capabilities::ProcessStartCapability
     );
@@ -730,7 +730,7 @@ unsafe fn start() -> (
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         nrf52840::rtc::Rtc,

--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -11,7 +11,7 @@
 //! Usage
 //! -----
 //! ```rust
-//! kernel::declare_capability!(ProcessConsoleCap:
+//! kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
 //!     kernel::capabilities::ProcessManagementCapability,
 //!     kernel::capabilities::ProcessStartCapability
 //! );
@@ -21,7 +21,7 @@
 //!     alarm_mux,
 //!     process_printer,
 //!     Some(reset_function),
-//!     ProcessConsoleCap,
+//!     process_console_cap,
 //! )
 //! .finalize(process_console_component_static!(AlarmType, ProcessConsoleCap));
 //! ```

--- a/boards/components/src/storage_permissions/individual.rs
+++ b/boards/components/src/storage_permissions/individual.rs
@@ -6,10 +6,10 @@
 //! access to their own stored state.
 //!
 //! ```rust
-//! kernel::declare_capability!(AppStoreCap: kernel::capabilities::ApplicationStorageCapability);
+//! kernel::create_typed_capability!(app_store_cap, AppStoreCap: kernel::capabilities::ApplicationStorageCapability);
 //! let storage_permissions_policy =
 //!     components::storage_permissions::individual::StoragePermissionsIndividualComponent::new(
-//!         AppStoreCap,
+//!         app_store_cap,
 //!     )
 //!     .finalize(
 //!         components::storage_permissions_individual_component_static!(

--- a/boards/components/src/storage_permissions/tbf_header.rs
+++ b/boards/components/src/storage_permissions/tbf_header.rs
@@ -6,10 +6,10 @@
 //! storage permissions based on TBF headers.
 //!
 //! ```rust
-//! kernel::declare_capability!(AppStoreCap: kernel::capabilities::ApplicationStorageCapability);
+//! kernel::create_typed_capability!(app_store_cap, AppStoreCap: kernel::capabilities::ApplicationStorageCapability);
 //! let storage_permissions_policy =
 //!     components::storage_permissions::tbf_header::StoragePermissionsTbfHeaderComponent::new(
-//!         AppStoreCap,
+//!         app_store_cap,
 //!     )
 //!     .finalize(
 //!         components::storage_permissions_tbf_header_component_static!(

--- a/boards/components/src/udp_driver.rs
+++ b/boards/components/src/udp_driver.rs
@@ -10,7 +10,7 @@
 //! Usage
 //! -----
 //! ```rust
-//! kernel::declare_capability!(UdpDriverCap: kernel::capabilities::UdpDriverCapability);
+//! kernel::create_typed_capability!(udp_driver_cap, UdpDriverCap: kernel::capabilities::UdpDriverCapability);
 //! let udp_driver = UDPDriverComponent::new(
 //!     board_kernel,
 //!     udp_send_mux,
@@ -18,7 +18,7 @@
 //!     udp_port_table,
 //!     local_ip_ifaces,
 //!     PAYLOAD_LEN,
-//!     UdpDriverCap,
+//!     udp_driver_cap,
 //! )
 //! .finalize(components::udp_driver_component_static!(AlarmType, UdpDriverCap));
 //! ```

--- a/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
@@ -767,7 +767,7 @@ unsafe fn start() -> (
         resources.printer.put(process_printer);
     });
 
-    kernel::declare_capability!(ProcessConsoleCap:
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
         kernel::capabilities::ProcessManagementCapability,
         kernel::capabilities::ProcessStartCapability
     );
@@ -777,7 +777,7 @@ unsafe fn start() -> (
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         nrf52833::rtc::Rtc,

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-appid-tbf/src/main.rs
@@ -58,7 +58,7 @@ pub unsafe fn main() {
 
     // Create the process console, an interactive terminal for managing
     // processes.
-    kernel::declare_capability!(ProcessConsoleCap:
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
         kernel::capabilities::ProcessManagementCapability,
         kernel::capabilities::ProcessStartCapability
     );
@@ -68,7 +68,7 @@ pub unsafe fn main() {
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         nrf52840::rtc::Rtc<'static>,

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
@@ -321,7 +321,7 @@ pub unsafe fn main() {
 
     // Create the process console, an interactive terminal for managing
     // processes.
-    kernel::declare_capability!(ProcessConsoleCap:
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
         kernel::capabilities::ProcessManagementCapability,
         kernel::capabilities::ProcessStartCapability
     );
@@ -331,7 +331,7 @@ pub unsafe fn main() {
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         nrf52840::rtc::Rtc<'static>,

--- a/boards/cy8cproto_62_4343_w/src/main.rs
+++ b/boards/cy8cproto_62_4343_w/src/main.rs
@@ -223,7 +223,7 @@ pub unsafe fn main() {
         resources.printer.put(process_printer);
     });
 
-    kernel::declare_capability!(ProcessConsoleCap:
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
         kernel::capabilities::ProcessManagementCapability,
         kernel::capabilities::ProcessStartCapability
     );
@@ -233,7 +233,7 @@ pub unsafe fn main() {
         mux_alarm,
         process_printer,
         Some(cortexm0p::support::reset),
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         Tcpwm0,

--- a/boards/esp32-c3-devkitM-1/src/main.rs
+++ b/boards/esp32-c3-devkitM-1/src/main.rs
@@ -348,7 +348,7 @@ unsafe fn setup() -> (
     // PROCESS CONSOLE
     //
 
-    kernel::declare_capability!(ProcessConsoleCap:
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
         kernel::capabilities::ProcessManagementCapability,
         kernel::capabilities::ProcessStartCapability
     );
@@ -358,7 +358,7 @@ unsafe fn setup() -> (
         mux_alarm,
         process_printer,
         None,
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         esp32_c3::timg::TimG,

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -325,7 +325,7 @@ unsafe fn start() -> (
         create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::console_component_static!());
-    kernel::declare_capability!(ProcessConsoleCap:
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
         kernel::capabilities::ProcessManagementCapability,
         kernel::capabilities::ProcessStartCapability
     );
@@ -335,7 +335,7 @@ unsafe fn start() -> (
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         sam4l::ast::Ast<'static>,

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -296,7 +296,7 @@ unsafe fn start() -> (
         resources.printer.put(process_printer);
     });
 
-    kernel::declare_capability!(ProcessConsoleCap:
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
         kernel::capabilities::ProcessManagementCapability,
         kernel::capabilities::ProcessStartCapability
     );
@@ -306,7 +306,7 @@ unsafe fn start() -> (
         mux_alarm,
         process_printer,
         None,
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         e310_g002::chip::E310xClint,

--- a/boards/hifive_inventor/src/main.rs
+++ b/boards/hifive_inventor/src/main.rs
@@ -224,7 +224,7 @@ unsafe fn start() -> (
         resources.printer.put(process_printer);
     });
 
-    kernel::declare_capability!(ProcessConsoleCap:
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
         kernel::capabilities::ProcessManagementCapability,
         kernel::capabilities::ProcessStartCapability
     );
@@ -234,7 +234,7 @@ unsafe fn start() -> (
         mux_alarm,
         process_printer,
         None,
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         e310_g003::chip::E310xClint,

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -722,7 +722,7 @@ unsafe fn start() -> (
     ));
 
     // UDP driver initialization happens here
-    kernel::declare_capability!(UdpDriverCap: kernel::capabilities::UdpDriverCapability);
+    kernel::create_typed_capability!(udp_driver_cap, UdpDriverCap: kernel::capabilities::UdpDriverCapability);
     let udp_driver = components::udp_driver::UDPDriverComponent::new(
         board_kernel,
         capsules_extra::net::udp::driver::DRIVER_NUM,
@@ -730,7 +730,7 @@ unsafe fn start() -> (
         udp_recv_mux,
         udp_port_table,
         local_ip_ifaces,
-        UdpDriverCap,
+        udp_driver_cap,
         create_capability!(capabilities::MemoryAllocationCapability),
         create_capability!(capabilities::NetworkCapabilityCreationCapability),
     )
@@ -762,10 +762,10 @@ unsafe fn start() -> (
     // STORAGE PERMISSIONS
     //--------------------------------------------------------------------------
 
-    kernel::declare_capability!(AppStoreCap: kernel::capabilities::ApplicationStorageCapability);
+    kernel::create_typed_capability!(app_store_cap, AppStoreCap: kernel::capabilities::ApplicationStorageCapability);
     let storage_permissions_policy =
         components::storage_permissions::individual::StoragePermissionsIndividualComponent::new(
-            AppStoreCap,
+            app_store_cap,
         )
         .finalize(
             components::storage_permissions_individual_component_static!(

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -124,21 +124,7 @@ type Ieee802154MacDevice =
 
 type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
 
-kernel::declare_capability!(ProcessConsoleCap:
-    kernel::capabilities::ProcessManagementCapability,
-    kernel::capabilities::ProcessStartCapability
-);
-
 struct Imix {
-    pconsole: &'static capsules_core::process_console::ProcessConsole<
-        'static,
-        { capsules_core::process_console::DEFAULT_COMMAND_HISTORY_LEN },
-        capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<
-            'static,
-            sam4l::ast::Ast<'static>,
-        >,
-        ProcessConsoleCap,
-    >,
     console: &'static capsules_core::console_ordered::ConsoleOrdered<
         'static,
         VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>,
@@ -412,13 +398,17 @@ unsafe fn start() -> (
     )
     .finalize(components::alarm_component_static!(sam4l::ast::Ast));
 
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let pconsole = ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         sam4l::ast::Ast,
@@ -819,7 +809,6 @@ unsafe fn start() -> (
     ));
 
     let imix = Imix {
-        pconsole,
         console,
         alarm,
         gpio,
@@ -851,7 +840,7 @@ unsafe fn start() -> (
     let _ = rf233.reset();
     let _ = rf233.start();
 
-    let _ = imix.pconsole.start();
+    let _ = pconsole.start();
 
     // Optional kernel tests. Note that these might conflict
     // with normal operation (e.g., steal callbacks from drivers, etc.),

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -513,7 +513,7 @@ unsafe fn start() -> (
         resources.printer.put(process_printer);
     });
 
-    kernel::declare_capability!(ProcessConsoleCap:
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
         kernel::capabilities::ProcessManagementCapability,
         kernel::capabilities::ProcessStartCapability
     );
@@ -523,7 +523,7 @@ unsafe fn start() -> (
         mux_alarm,
         process_printer,
         None,
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         imxrt10xx::gpt::Gpt1,

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -32,11 +32,6 @@ mod litex_generated_constants;
 // short name.
 use litex_generated_constants as socc;
 
-kernel::declare_capability!(ProcessConsoleCap:
-    kernel::capabilities::ProcessManagementCapability,
-    kernel::capabilities::ProcessStartCapability
-);
-
 /// Structure for dynamic interrupt mapping, depending on the SoC
 /// configuration
 ///
@@ -114,12 +109,6 @@ struct LiteXArty {
         4,
     >,
     console: &'static capsules_core::console::Console<'static>,
-    pconsole: &'static capsules_core::process_console::ProcessConsole<
-        'static,
-        { capsules_core::process_console::DEFAULT_COMMAND_HISTORY_LEN },
-        VirtualMuxAlarm<'static, AlarmHw>,
-        ProcessConsoleCap,
-    >,
     lldb: &'static capsules_core::low_level_debug::LowLevelDebug<
         'static,
         capsules_core::virtualizers::virtual_uart::UartDevice<'static>,
@@ -451,13 +440,17 @@ unsafe fn start() -> (
     chip.unmask_interrupts();
 
     // Setup the process console.
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         None,
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         AlarmHw,
@@ -498,7 +491,6 @@ unsafe fn start() -> (
 
     let litex_arty = LiteXArty {
         console,
-        pconsole,
         alarm,
         lldb,
         led_driver,
@@ -512,7 +504,7 @@ unsafe fn start() -> (
     };
 
     debug!("LiteX+VexRiscv on ArtyA7: initialization complete, entering main loop.");
-    let _ = litex_arty.pconsole.start();
+    let _ = pconsole.start();
 
     kernel::process::load_processes(
         board_kernel,

--- a/boards/lora_e5_mini/src/main.rs
+++ b/boards/lora_e5_mini/src/main.rs
@@ -418,7 +418,7 @@ pub unsafe fn main() {
     //--------------------------------------------------------------------
     // PROCESS CONSOLE
     //--------------------------------------------------------------------
-    kernel::declare_capability!(ProcessConsoleCap:
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
         kernel::capabilities::ProcessManagementCapability,
         kernel::capabilities::ProcessStartCapability
     );
@@ -428,7 +428,7 @@ pub unsafe fn main() {
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         stm32wle5jc::tim2::Tim2,

--- a/boards/lpc55s69-evk/src/main.rs
+++ b/boards/lpc55s69-evk/src/main.rs
@@ -367,7 +367,7 @@ unsafe fn start() -> (
         resources.printer.put(process_printer);
     });
 
-    kernel::declare_capability!(ProcessConsoleCap:
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
         kernel::capabilities::ProcessManagementCapability,
         kernel::capabilities::ProcessStartCapability
     );
@@ -377,7 +377,7 @@ unsafe fn start() -> (
         mux_alarm,
         process_printer,
         None,
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         lpc55s6x::ctimer0::LPCTimer,

--- a/boards/makepython-nrf52840/src/main.rs
+++ b/boards/makepython-nrf52840/src/main.rs
@@ -138,21 +138,13 @@ type LedDriver = components::led::LedsComponentType<LedHw, 1>;
 type ButtonDriver = components::button::ButtonComponentType<Nrf52840GpioHw>;
 type ConsoleDriver = components::console::ConsoleComponentType;
 type AdcDriver = components::adc::AdcVirtualComponentType;
-type ProcessConsoleDriver =
-    components::process_console::ProcessConsoleComponentType<AlarmHw, ProcessConsoleCap>;
 type UdpDriver = components::udp_driver::UDPDriverComponentType;
-
-kernel::declare_capability!(ProcessConsoleCap:
-    kernel::capabilities::ProcessManagementCapability,
-    kernel::capabilities::ProcessStartCapability
-);
 
 /// Supported drivers by the platform
 pub struct Platform {
     ble_radio: &'static BleDriver,
     ieee802154_radio: &'static Ieee802154Driver,
     console: &'static ConsoleDriver,
-    pconsole: &'static ProcessConsoleDriver,
     gpio: &'static GpioDriver,
     led: &'static LedDriver,
     adc: &'static AdcDriver,
@@ -432,13 +424,17 @@ pub unsafe fn start() -> (
     let uart_mux = components::console::UartMuxComponent::new(cdc, 115200)
         .finalize(components::uart_mux_component_static!());
 
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         nrf52::rtc::Rtc<'static>,
@@ -788,7 +784,6 @@ pub unsafe fn start() -> (
         ble_radio,
         ieee802154_radio,
         console,
-        pconsole,
         adc: adc_syscall,
         led,
         button,
@@ -823,7 +818,7 @@ pub unsafe fn start() -> (
     // );
 
     debug!("Initialization complete. Entering main loop.");
-    let _ = platform.pconsole.start();
+    let _ = pconsole.start();
 
     ssd1306.init_screen();
 

--- a/boards/makepython-nrf52840/src/main.rs
+++ b/boards/makepython-nrf52840/src/main.rs
@@ -676,7 +676,7 @@ pub unsafe fn start() -> (
     ));
 
     // UDP driver initialization happens here
-    kernel::declare_capability!(UdpDriverCap: kernel::capabilities::UdpDriverCapability);
+    kernel::create_typed_capability!(udp_driver_cap, UdpDriverCap: kernel::capabilities::UdpDriverCapability);
     let udp_driver = components::udp_driver::UDPDriverComponent::new(
         board_kernel,
         capsules_extra::net::udp::DRIVER_NUM,
@@ -684,7 +684,7 @@ pub unsafe fn start() -> (
         udp_recv_mux,
         udp_port_table,
         local_ip_ifaces,
-        UdpDriverCap,
+        udp_driver_cap,
         create_capability!(capabilities::MemoryAllocationCapability),
         create_capability!(capabilities::NetworkCapabilityCreationCapability),
     )
@@ -717,10 +717,10 @@ pub unsafe fn start() -> (
     // STORAGE PERMISSIONS
     //--------------------------------------------------------------------------
 
-    kernel::declare_capability!(AppStoreCap: kernel::capabilities::ApplicationStorageCapability);
+    kernel::create_typed_capability!(app_store_cap, AppStoreCap: kernel::capabilities::ApplicationStorageCapability);
     let storage_permissions_policy =
         components::storage_permissions::individual::StoragePermissionsIndividualComponent::new(
-            AppStoreCap,
+            app_store_cap,
         )
         .finalize(
             components::storage_permissions_individual_component_static!(

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -692,7 +692,7 @@ unsafe fn start() -> (
         resources.printer.put(process_printer);
     });
 
-    kernel::declare_capability!(ProcessConsoleCap:
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
         kernel::capabilities::ProcessManagementCapability,
         kernel::capabilities::ProcessStartCapability
     );
@@ -702,7 +702,7 @@ unsafe fn start() -> (
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         AlarmHw,

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -146,21 +146,13 @@ type LedDriver = components::led::LedsComponentType<LedHw, 3>;
 type ConsoleDriver = components::console::ConsoleComponentType;
 type ProximityDriver = components::proximity::ProximityComponentType;
 type AdcDriver = components::adc::AdcVirtualComponentType;
-type ProcessConsoleDriver =
-    components::process_console::ProcessConsoleComponentType<AlarmHw, ProcessConsoleCap>;
 type UdpDriver = components::udp_driver::UDPDriverComponentType;
-
-kernel::declare_capability!(ProcessConsoleCap:
-    kernel::capabilities::ProcessManagementCapability,
-    kernel::capabilities::ProcessStartCapability
-);
 
 /// Supported drivers by the platform
 pub struct Platform {
     ble_radio: &'static BleDriver,
     ieee802154_radio: &'static Ieee802154Driver,
     console: &'static ConsoleDriver,
-    pconsole: &'static ProcessConsoleDriver,
     proximity: &'static ProximityDriver,
     temperature: &'static TemperatureDriver,
     humidity: &'static HumidityDriver,
@@ -414,13 +406,17 @@ pub unsafe fn start() -> (
     let uart_mux = components::console::UartMuxComponent::new(cdc, 115200)
         .finalize(components::uart_mux_component_static!());
 
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         nrf52::rtc::Rtc<'static>,
@@ -669,7 +665,6 @@ pub unsafe fn start() -> (
         ble_radio,
         ieee802154_radio,
         console,
-        pconsole,
         proximity,
         temperature,
         humidity,
@@ -716,7 +711,7 @@ pub unsafe fn start() -> (
     // );
 
     debug!("Initialization complete. Entering main loop.");
-    let _ = platform.pconsole.start();
+    let _ = pconsole.start();
 
     //--------------------------------------------------------------------------
     // PROCESSES AND MAIN LOOP

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -637,7 +637,7 @@ pub unsafe fn start() -> (
     ));
 
     // UDP driver initialization happens here
-    kernel::declare_capability!(UdpDriverCap: kernel::capabilities::UdpDriverCapability);
+    kernel::create_typed_capability!(udp_driver_cap, UdpDriverCap: kernel::capabilities::UdpDriverCapability);
     let udp_driver = components::udp_driver::UDPDriverComponent::new(
         board_kernel,
         capsules_extra::net::udp::DRIVER_NUM,
@@ -645,7 +645,7 @@ pub unsafe fn start() -> (
         udp_recv_mux,
         udp_port_table,
         local_ip_ifaces,
-        UdpDriverCap,
+        udp_driver_cap,
         create_capability!(capabilities::MemoryAllocationCapability),
         create_capability!(capabilities::NetworkCapabilityCreationCapability),
     )

--- a/boards/nano33ble_rev2/src/main.rs
+++ b/boards/nano33ble_rev2/src/main.rs
@@ -149,22 +149,14 @@ type LedDriver = components::led::LedsComponentType<LedHw, 3>;
 type ConsoleDriver = components::console::ConsoleComponentType;
 type ProximityDriver = components::proximity::ProximityComponentType;
 type AdcDriver = components::adc::AdcVirtualComponentType;
-type ProcessConsoleDriver =
-    components::process_console::ProcessConsoleComponentType<AlarmHw, ProcessConsoleCap>;
 type PressureDriver = capsules_extra::pressure::PressureSensor<'static, Lps22hbSensor>;
 type UdpDriver = components::udp_driver::UDPDriverComponentType;
-
-kernel::declare_capability!(ProcessConsoleCap:
-    kernel::capabilities::ProcessManagementCapability,
-    kernel::capabilities::ProcessStartCapability
-);
 
 /// Supported drivers by the platform
 pub struct Platform {
     ble_radio: &'static BleDriver,
     ieee802154_radio: &'static Ieee802154Driver,
     console: &'static ConsoleDriver,
-    pconsole: &'static ProcessConsoleDriver,
     proximity: &'static ProximityDriver,
     pressure: &'static PressureDriver,
     temperature: &'static TemperatureDriver,
@@ -420,13 +412,17 @@ pub unsafe fn start() -> (
     let uart_mux = components::console::UartMuxComponent::new(cdc, 115200)
         .finalize(components::uart_mux_component_static!());
 
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         nrf52::rtc::Rtc<'static>,
@@ -690,7 +686,6 @@ pub unsafe fn start() -> (
         ble_radio,
         ieee802154_radio,
         console,
-        pconsole,
         proximity,
         pressure,
         temperature,
@@ -738,7 +733,7 @@ pub unsafe fn start() -> (
     // );
 
     debug!("Initialization complete. Entering main loop.");
-    let _ = platform.pconsole.start();
+    let _ = pconsole.start();
 
     //--------------------------------------------------------------------------
     // PROCESSES AND MAIN LOOP

--- a/boards/nano33ble_rev2/src/main.rs
+++ b/boards/nano33ble_rev2/src/main.rs
@@ -658,7 +658,7 @@ pub unsafe fn start() -> (
     ));
 
     // UDP driver initialization happens here
-    kernel::declare_capability!(UdpDriverCap: kernel::capabilities::UdpDriverCapability);
+    kernel::create_typed_capability!(udp_driver_cap, UdpDriverCap: kernel::capabilities::UdpDriverCapability);
     let udp_driver = components::udp_driver::UDPDriverComponent::new(
         board_kernel,
         capsules_extra::net::udp::DRIVER_NUM,
@@ -666,7 +666,7 @@ pub unsafe fn start() -> (
         udp_recv_mux,
         udp_port_table,
         local_ip_ifaces,
-        UdpDriverCap,
+        udp_driver_cap,
         create_capability!(capabilities::MemoryAllocationCapability),
         create_capability!(capabilities::NetworkCapabilityCreationCapability),
     )

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -563,7 +563,7 @@ pub unsafe fn start() -> (
     });
 
     // PROCESS CONSOLE
-    kernel::declare_capability!(ProcessConsoleCap:
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
         kernel::capabilities::ProcessManagementCapability,
         kernel::capabilities::ProcessStartCapability
     );
@@ -573,7 +573,7 @@ pub unsafe fn start() -> (
         mux_alarm,
         process_printer,
         Some(cortexm0p::support::reset),
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         RPTimer,

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -103,19 +103,11 @@ type ButtonDriver = components::button::ButtonComponentType<GpioHw>;
 type ConsoleDriver = components::console::ConsoleComponentType;
 type AnalogComparatorDriver =
     components::analog_comparator::AnalogComparatorComponentType<AnalogComparatorHw>;
-kernel::declare_capability!(ProcessConsoleCap:
-    kernel::capabilities::ProcessManagementCapability,
-    kernel::capabilities::ProcessStartCapability
-);
-type ProcessConsoleDriver =
-    components::process_console::ProcessConsoleComponentType<AlarmHw, ProcessConsoleCap>;
-
 /// Supported drivers by the platform
 pub struct Platform {
     ble_radio: &'static BleDriver,
     ieee802154_radio: &'static Ieee802154Driver,
     button: &'static ButtonDriver,
-    pconsole: &'static ProcessConsoleDriver,
     console: &'static ConsoleDriver,
     gpio: &'static GpioDriver,
     led: &'static LedDriver,
@@ -362,13 +354,17 @@ pub unsafe fn start() -> (
     let uart_mux = components::console::UartMuxComponent::new(channel, 115200)
         .finalize(components::uart_mux_component_static!());
 
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         AlarmHw,
@@ -462,7 +458,6 @@ pub unsafe fn start() -> (
         button,
         ble_radio,
         ieee802154_radio,
-        pconsole,
         console,
         led,
         gpio,
@@ -479,7 +474,7 @@ pub unsafe fn start() -> (
         systick: cortexm4::systick::SysTick::new_with_calibration(64000000),
     };
 
-    let _ = platform.pconsole.start();
+    let _ = pconsole.start();
     debug!("Initialization complete. Entering main loop\r");
     debug!("{}", ficr);
 

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -228,6 +228,7 @@ type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
 pub struct Platform {
     ble_radio: &'static BleDriver,
     button: &'static ButtonDriver,
+    pconsole: &'static ProcessConsoleDriver,
     console: &'static capsules_core::console::Console<'static>,
     gpio: &'static GpioDriver,
     led: &'static LedDriver,
@@ -403,15 +404,12 @@ pub unsafe fn ieee802154_udp(
 /// removed when this function returns. Otherwise, the stack space used for
 /// these static_inits is wasted.
 #[inline(never)]
-pub unsafe fn start_pconsole_optional(
-    start_pconsole: bool,
-) -> (
+pub unsafe fn start_no_pconsole() -> (
     &'static kernel::Kernel,
     Platform,
     &'static ChipHw,
     &'static Nrf52840DefaultPeripherals<'static>,
     &'static MuxAlarm<'static, AlarmHw>,
-    Option<&'static ProcessConsoleDriver>,
 ) {
     //--------------------------------------------------------------------------
     // INITIAL SETUP
@@ -658,6 +656,22 @@ pub unsafe fn start_pconsole_optional(
         create_capability!(capabilities::SetDebugWriterCapability),
     )
     .finalize(components::debug_writer_component_static!());
+
+    // Create the process console, an interactive terminal for managing
+    // processes.
+    let process_console_cap = unsafe { mint_defined_capability!(ProcessConsoleCap) };
+    let pconsole = components::process_console::ProcessConsoleComponent::new(
+        board_kernel,
+        uart_mux,
+        mux_alarm,
+        process_printer,
+        Some(cortexm4::support::reset),
+        process_console_cap,
+    )
+    .finalize(components::process_console_component_static!(
+        AlarmHw,
+        ProcessConsoleCap
+    ));
 
     //--------------------------------------------------------------------------
     // BLE
@@ -923,6 +937,7 @@ pub unsafe fn start_pconsole_optional(
     let platform = Platform {
         button,
         ble_radio,
+        pconsole,
         console,
         led,
         gpio,
@@ -948,36 +963,12 @@ pub unsafe fn start_pconsole_optional(
     debug!("Initialization complete. Entering main loop\r");
     debug!("{}", ficr);
 
-    // Create the process console, an interactive terminal for managing
-    // processes. This is left unstarted; it is up to the caller to start it
-    // (or start it hibernated) once the rest of initialization, including
-    // the debug prints above, has completed. Starting the console arms an
-    // alarm that will (asynchronously) print its prompt and begin accepting
-    // input, so starting it too early could interleave its output with or
-    // precede the initialization messages above.
-    let pconsole = start_pconsole.then(|| {
-        let process_console_cap = unsafe { mint_defined_capability!(ProcessConsoleCap) };
-        components::process_console::ProcessConsoleComponent::new(
-            board_kernel,
-            uart_mux,
-            mux_alarm,
-            process_printer,
-            Some(cortexm4::support::reset),
-            process_console_cap,
-        )
-        .finalize(components::process_console_component_static!(
-            AlarmHw,
-            ProcessConsoleCap
-        ))
-    });
-
     (
         board_kernel,
         platform,
         chip,
         nrf52840_peripherals,
         mux_alarm,
-        pconsole,
     )
 }
 
@@ -992,7 +983,7 @@ pub unsafe fn start() -> (
     &'static Nrf52840DefaultPeripherals<'static>,
     &'static MuxAlarm<'static, AlarmHw>,
 ) {
-    let (kernel, platform, chip, peripherals, mux_alarm, pconsole) = start_pconsole_optional(true);
-    let _ = pconsole.unwrap().start();
+    let (kernel, platform, chip, peripherals, mux_alarm) = start_no_pconsole();
+    let _ = platform.pconsole.start();
     (kernel, platform, chip, peripherals, mux_alarm)
 }

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -185,12 +185,6 @@ type AnalogComparatorDriver =
     components::analog_comparator::AnalogComparatorComponentType<AnalogComparatorHw>;
 type I2CMasterSlaveDriver = components::i2c::I2CMasterSlaveDriverComponentType<I2cHw>;
 type SpiControllerDriver = components::spi::SpiSyscallComponentType<SpiHw>;
-kernel::declare_capability!(ProcessConsoleCap:
-    kernel::capabilities::ProcessManagementCapability,
-    kernel::capabilities::ProcessStartCapability
-);
-type ProcessConsoleDriver =
-    components::process_console::ProcessConsoleComponentType<AlarmHw, ProcessConsoleCap>;
 type TemperatureDriver = components::temperature::TemperatureComponentType<TemperatureHw>;
 type IpcDriver = kernel::ipc::IPC<{ NUM_PROCS as u8 }>;
 
@@ -226,7 +220,6 @@ type SchedulerInUse = components::sched::round_robin::RoundRobinComponentType;
 pub struct Platform {
     ble_radio: &'static BleDriver,
     button: &'static ButtonDriver,
-    pconsole: &'static ProcessConsoleDriver,
     console: &'static capsules_core::console::Console<'static>,
     gpio: &'static GpioDriver,
     led: &'static LedDriver,
@@ -402,7 +395,9 @@ pub unsafe fn ieee802154_udp(
 /// removed when this function returns. Otherwise, the stack space used for
 /// these static_inits is wasted.
 #[inline(never)]
-pub unsafe fn start_no_pconsole() -> (
+pub unsafe fn start_pconsole_optional(
+    start_pconsole: bool,
+) -> (
     &'static kernel::Kernel,
     Platform,
     &'static ChipHw,
@@ -636,21 +631,6 @@ pub unsafe fn start_no_pconsole() -> (
     // Virtualize the UART channel for the console and for kernel debug.
     let uart_mux = components::console::UartMuxComponent::new(uart_channel, 115200)
         .finalize(components::uart_mux_component_static!());
-
-    // Create the process console, an interactive terminal for managing
-    // processes.
-    let pconsole = components::process_console::ProcessConsoleComponent::new(
-        board_kernel,
-        uart_mux,
-        mux_alarm,
-        process_printer,
-        Some(cortexm4::support::reset),
-        ProcessConsoleCap,
-    )
-    .finalize(components::process_console_component_static!(
-        AlarmHw,
-        ProcessConsoleCap
-    ));
 
     // Setup the serial console for userspace.
     let console = components::console::ConsoleComponent::new(
@@ -934,7 +914,6 @@ pub unsafe fn start_no_pconsole() -> (
     let platform = Platform {
         button,
         ble_radio,
-        pconsole,
         console,
         led,
         gpio,
@@ -960,6 +939,33 @@ pub unsafe fn start_no_pconsole() -> (
     debug!("Initialization complete. Entering main loop\r");
     debug!("{}", ficr);
 
+    if start_pconsole {
+        // Create the process console, an interactive terminal for managing
+        // processes. This is done last, after the debug prints above,
+        // because starting the console arms an alarm that will
+        // (asynchronously) print its prompt and begin accepting input; if it
+        // were started earlier, its output could interleave with or precede
+        // the initialization messages above.
+        kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
+            kernel::capabilities::ProcessManagementCapability,
+            kernel::capabilities::ProcessStartCapability
+        );
+        let pconsole = components::process_console::ProcessConsoleComponent::new(
+            board_kernel,
+            uart_mux,
+            mux_alarm,
+            process_printer,
+            Some(cortexm4::support::reset),
+            process_console_cap,
+        )
+        .finalize(components::process_console_component_static!(
+            AlarmHw,
+            ProcessConsoleCap
+        ));
+
+        let _ = pconsole.start();
+    }
+
     (
         board_kernel,
         platform,
@@ -980,7 +986,6 @@ pub unsafe fn start() -> (
     &'static Nrf52840DefaultPeripherals<'static>,
     &'static MuxAlarm<'static, AlarmHw>,
 ) {
-    let (kernel, platform, chip, peripherals, mux_alarm) = start_no_pconsole();
-    let _ = platform.pconsole.start();
+    let (kernel, platform, chip, peripherals, mux_alarm) = start_pconsole_optional(true);
     (kernel, platform, chip, peripherals, mux_alarm)
 }

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -217,8 +217,6 @@ pub type Ieee802154Driver = components::ieee802154::Ieee802154ComponentType<Radi
 /// Userspace EUI64 driver.
 pub type Eui64Driver = components::eui64::Eui64ComponentType;
 
-kernel::declare_capability!(UdpDriverCap: kernel::capabilities::UdpDriverCapability);
-
 /// Userspace UDP driver.
 pub type UdpDriver = components::udp_driver::UDPDriverComponentType;
 
@@ -380,6 +378,7 @@ pub unsafe fn ieee802154_udp(
     ));
 
     // UDP driver initialization happens here
+    kernel::create_typed_capability!(udp_driver_cap, UdpDriverCap: kernel::capabilities::UdpDriverCapability);
     let udp_driver = components::udp_driver::UDPDriverComponent::new(
         board_kernel,
         capsules_extra::net::udp::driver::DRIVER_NUM,
@@ -387,7 +386,7 @@ pub unsafe fn ieee802154_udp(
         udp_recv_mux,
         udp_port_table,
         local_ip_ifaces,
-        UdpDriverCap,
+        udp_driver_cap,
         create_capability!(capabilities::MemoryAllocationCapability),
         create_capability!(capabilities::NetworkCapabilityCreationCapability),
     )

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -83,7 +83,10 @@ use kernel::platform::chip::Chip;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::utilities::cells::MapCell;
 #[allow(unused_imports)]
-use kernel::{capabilities, create_capability, debug, debug_gpio, debug_verbose, static_init};
+use kernel::{
+    capabilities, create_capability, debug, debug_gpio, debug_verbose, define_capability_type,
+    mint_defined_capability, static_init,
+};
 use nrf52_components::{UartChannel, UartPins};
 use nrf52840::gpio::Pin;
 use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
@@ -186,29 +189,10 @@ type AnalogComparatorDriver =
 type I2CMasterSlaveDriver = components::i2c::I2CMasterSlaveDriverComponentType<I2cHw>;
 type SpiControllerDriver = components::spi::SpiSyscallComponentType<SpiHw>;
 
-/// Capability type used to construct the process console.
-///
-/// Unlike most capabilities in this file, this one is declared by hand
-/// (rather than with [`kernel::create_typed_capability!`]) because it must
-/// be nameable both in [`start_pconsole_optional`] and in its return type,
-/// so that callers in other crates (board `main.rs` files) can decide
-/// whether and how to start the returned [`ProcessConsoleDriver`]. Its
-/// private tuple field prevents construction from outside this module, and
-/// [`ProcessConsoleCap::new`] additionally requires an `unsafe` block,
-/// matching the convention used for capability creation elsewhere.
-pub struct ProcessConsoleCap(());
-
-unsafe impl kernel::capabilities::ProcessManagementCapability for ProcessConsoleCap {}
-unsafe impl kernel::capabilities::ProcessStartCapability for ProcessConsoleCap {}
-
-impl ProcessConsoleCap {
-    unsafe fn new() -> Self {
-        ProcessConsoleCap(())
-    }
-}
-
+define_capability_type!(ProcessConsoleCap: capabilities::ProcessManagementCapability, capabilities::ProcessStartCapability);
 type ProcessConsoleDriver =
     components::process_console::ProcessConsoleComponentType<AlarmHw, ProcessConsoleCap>;
+
 type TemperatureDriver = components::temperature::TemperatureComponentType<TemperatureHw>;
 type IpcDriver = kernel::ipc::IPC<{ NUM_PROCS as u8 }>;
 
@@ -972,7 +956,7 @@ pub unsafe fn start_pconsole_optional(
     // input, so starting it too early could interleave its output with or
     // precede the initialization messages above.
     let pconsole = start_pconsole.then(|| {
-        let process_console_cap = unsafe { ProcessConsoleCap::new() };
+        let process_console_cap = unsafe { mint_defined_capability!(ProcessConsoleCap) };
         components::process_console::ProcessConsoleComponent::new(
             board_kernel,
             uart_mux,

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -185,6 +185,30 @@ type AnalogComparatorDriver =
     components::analog_comparator::AnalogComparatorComponentType<AnalogComparatorHw>;
 type I2CMasterSlaveDriver = components::i2c::I2CMasterSlaveDriverComponentType<I2cHw>;
 type SpiControllerDriver = components::spi::SpiSyscallComponentType<SpiHw>;
+
+/// Capability type used to construct the process console.
+///
+/// Unlike most capabilities in this file, this one is declared by hand
+/// (rather than with [`kernel::create_typed_capability!`]) because it must
+/// be nameable both in [`start_pconsole_optional`] and in its return type,
+/// so that callers in other crates (board `main.rs` files) can decide
+/// whether and how to start the returned [`ProcessConsoleDriver`]. Its
+/// private tuple field prevents construction from outside this module, and
+/// [`ProcessConsoleCap::new`] additionally requires an `unsafe` block,
+/// matching the convention used for capability creation elsewhere.
+pub struct ProcessConsoleCap(());
+
+unsafe impl kernel::capabilities::ProcessManagementCapability for ProcessConsoleCap {}
+unsafe impl kernel::capabilities::ProcessStartCapability for ProcessConsoleCap {}
+
+impl ProcessConsoleCap {
+    unsafe fn new() -> Self {
+        ProcessConsoleCap(())
+    }
+}
+
+type ProcessConsoleDriver =
+    components::process_console::ProcessConsoleComponentType<AlarmHw, ProcessConsoleCap>;
 type TemperatureDriver = components::temperature::TemperatureComponentType<TemperatureHw>;
 type IpcDriver = kernel::ipc::IPC<{ NUM_PROCS as u8 }>;
 
@@ -403,6 +427,7 @@ pub unsafe fn start_pconsole_optional(
     &'static ChipHw,
     &'static Nrf52840DefaultPeripherals<'static>,
     &'static MuxAlarm<'static, AlarmHw>,
+    Option<&'static ProcessConsoleDriver>,
 ) {
     //--------------------------------------------------------------------------
     // INITIAL SETUP
@@ -939,18 +964,16 @@ pub unsafe fn start_pconsole_optional(
     debug!("Initialization complete. Entering main loop\r");
     debug!("{}", ficr);
 
-    if start_pconsole {
-        // Create the process console, an interactive terminal for managing
-        // processes. This is done last, after the debug prints above,
-        // because starting the console arms an alarm that will
-        // (asynchronously) print its prompt and begin accepting input; if it
-        // were started earlier, its output could interleave with or precede
-        // the initialization messages above.
-        kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
-            kernel::capabilities::ProcessManagementCapability,
-            kernel::capabilities::ProcessStartCapability
-        );
-        let pconsole = components::process_console::ProcessConsoleComponent::new(
+    // Create the process console, an interactive terminal for managing
+    // processes. This is left unstarted; it is up to the caller to start it
+    // (or start it hibernated) once the rest of initialization, including
+    // the debug prints above, has completed. Starting the console arms an
+    // alarm that will (asynchronously) print its prompt and begin accepting
+    // input, so starting it too early could interleave its output with or
+    // precede the initialization messages above.
+    let pconsole = start_pconsole.then(|| {
+        let process_console_cap = unsafe { ProcessConsoleCap::new() };
+        components::process_console::ProcessConsoleComponent::new(
             board_kernel,
             uart_mux,
             mux_alarm,
@@ -961,10 +984,8 @@ pub unsafe fn start_pconsole_optional(
         .finalize(components::process_console_component_static!(
             AlarmHw,
             ProcessConsoleCap
-        ));
-
-        let _ = pconsole.start();
-    }
+        ))
+    });
 
     (
         board_kernel,
@@ -972,6 +993,7 @@ pub unsafe fn start_pconsole_optional(
         chip,
         nrf52840_peripherals,
         mux_alarm,
+        pconsole,
     )
 }
 
@@ -986,6 +1008,7 @@ pub unsafe fn start() -> (
     &'static Nrf52840DefaultPeripherals<'static>,
     &'static MuxAlarm<'static, AlarmHw>,
 ) {
-    let (kernel, platform, chip, peripherals, mux_alarm) = start_pconsole_optional(true);
+    let (kernel, platform, chip, peripherals, mux_alarm, pconsole) = start_pconsole_optional(true);
+    let _ = pconsole.unwrap().start();
     (kernel, platform, chip, peripherals, mux_alarm)
 }

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -155,18 +155,10 @@ type ButtonDriver = components::button::ButtonComponentType<GpioHw>;
 type ConsoleDriver = components::console::ConsoleComponentType;
 type AnalogComparatorDriver =
     components::analog_comparator::AnalogComparatorComponentType<AnalogComparatorHw>;
-kernel::declare_capability!(ProcessConsoleCap:
-    kernel::capabilities::ProcessManagementCapability,
-    kernel::capabilities::ProcessStartCapability
-);
-type ProcessConsoleDriver =
-    components::process_console::ProcessConsoleComponentType<AlarmHw, ProcessConsoleCap>;
-
 /// Supported drivers by the platform
 pub struct Platform {
     ble_radio: &'static BleDriver,
     button: &'static ButtonDriver,
-    pconsole: &'static ProcessConsoleDriver,
     console: &'static ConsoleDriver,
     gpio: &'static GpioDriver,
     led: &'static LedDriver,
@@ -408,13 +400,17 @@ pub unsafe fn start() -> (
     let uart_mux = components::console::UartMuxComponent::new(channel, 115200)
         .finalize(components::uart_mux_component_static!());
 
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         AlarmHw,
@@ -489,7 +485,6 @@ pub unsafe fn start() -> (
     let platform = Platform {
         button,
         ble_radio,
-        pconsole,
         console,
         led,
         gpio,
@@ -506,7 +501,7 @@ pub unsafe fn start() -> (
         systick: cortexm4::systick::SysTick::new_with_calibration(64000000),
     };
 
-    let _ = platform.pconsole.start();
+    let _ = pconsole.start();
     debug!("Initialization complete. Entering main loop\r");
     debug!("{}", ficr);
 

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -671,7 +671,7 @@ unsafe fn start() -> (
     ));
 
     // PROCESS CONSOLE
-    kernel::declare_capability!(ProcessConsoleCap:
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
         kernel::capabilities::ProcessManagementCapability,
         kernel::capabilities::ProcessStartCapability
     );
@@ -681,7 +681,7 @@ unsafe fn start() -> (
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         stm32f429zi::tim2::Tim2,

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -512,7 +512,7 @@ unsafe fn start() -> (
     .finalize(components::gpio_component_static!(stm32f446re::gpio::Pin));
 
     // PROCESS CONSOLE
-    kernel::declare_capability!(ProcessConsoleCap:
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
         kernel::capabilities::ProcessManagementCapability,
         kernel::capabilities::ProcessStartCapability
     );
@@ -522,7 +522,7 @@ unsafe fn start() -> (
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         stm32f446re::tim2::Tim2,

--- a/boards/nucleo_u545re_q/src/main.rs
+++ b/boards/nucleo_u545re_q/src/main.rs
@@ -247,7 +247,7 @@ unsafe fn start() -> (
     )
     .finalize(components::debug_writer_component_static!());
 
-    kernel::declare_capability!(ProcessConsoleCap:
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
         kernel::capabilities::ProcessManagementCapability,
         kernel::capabilities::ProcessStartCapability
     );
@@ -258,7 +258,7 @@ unsafe fn start() -> (
         components::process_printer::ProcessPrinterTextComponent::new()
             .finalize(components::process_printer_text_component_static!()),
         None,
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         stm32u545::tim::Tim2,

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -580,7 +580,7 @@ pub unsafe fn start() -> (
     });
 
     // PROCESS CONSOLE
-    kernel::declare_capability!(ProcessConsoleCap:
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
         kernel::capabilities::ProcessManagementCapability,
         kernel::capabilities::ProcessStartCapability
     );
@@ -590,7 +590,7 @@ pub unsafe fn start() -> (
         mux_alarm,
         process_printer,
         Some(cortexm0p::support::reset),
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         RPTimer,

--- a/boards/psc3m5_evk/src/main.rs
+++ b/boards/psc3m5_evk/src/main.rs
@@ -239,7 +239,7 @@ pub unsafe fn start() -> (
         resources.printer.put(process_printer);
     });
 
-    kernel::declare_capability!(ProcessConsoleCap:
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
         kernel::capabilities::ProcessManagementCapability,
         kernel::capabilities::ProcessStartCapability
     );
@@ -249,7 +249,7 @@ pub unsafe fn start() -> (
         mux_alarm,
         process_printer,
         Some(cortexm33::support::reset),
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         Tcpwm0,

--- a/boards/qemu_i486_q35/src/main.rs
+++ b/boards/qemu_i486_q35/src/main.rs
@@ -119,11 +119,6 @@ fn init_virtio_dev(
     Some((int_line, dev))
 }
 
-kernel::declare_capability!(ProcessConsoleCap:
-    kernel::capabilities::ProcessManagementCapability,
-    kernel::capabilities::ProcessStartCapability
-);
-
 /// Provides interrupt servicing logic for Virtio devices which may or may not be present at
 /// runtime.
 struct VirtioDevices {
@@ -146,12 +141,6 @@ impl InterruptService for VirtioDevices {
 }
 
 pub struct QemuI386Q35Platform {
-    pconsole: &'static capsules_core::process_console::ProcessConsole<
-        'static,
-        { capsules_core::process_console::DEFAULT_COMMAND_HISTORY_LEN },
-        VirtualMuxAlarm<'static, Pit<'static, RELOAD_1KHZ>>,
-        ProcessConsoleCap,
-    >,
     console: &'static Console<'static>,
     lldb: &'static capsules_core::low_level_debug::LowLevelDebug<
         'static,
@@ -478,13 +467,17 @@ unsafe extern "cdecl" fn main() {
     let console_uart_device = uart_mux;
 
     // Initialize the kernel's process console.
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         console_uart_device,
         mux_alarm,
         process_printer,
         None,
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         Pit<'static, RELOAD_1KHZ>,
@@ -542,7 +535,6 @@ unsafe extern "cdecl" fn main() {
     let platform = static_init!(
         QemuI386Q35Platform,
         QemuI386Q35Platform {
-            pconsole,
             console,
             alarm,
             lldb,
@@ -558,7 +550,7 @@ unsafe extern "cdecl" fn main() {
     );
 
     // Start the process console:
-    let _ = platform.pconsole.start();
+    let _ = pconsole.start();
 
     // Attach the keyboard button press callback to ourself.
     default_peripherals.keyboard.set_client(platform);

--- a/boards/qemu_rv32_virt/src/lib.rs
+++ b/boards/qemu_rv32_virt/src/lib.rs
@@ -8,6 +8,7 @@
 #![no_main]
 
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use kernel::ErrorCode;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::debug::PanicResources;
@@ -61,6 +62,7 @@ type ProcessConsoleDriver =
 /// A structure representing this platform that holds references to all
 /// capsules for this platform. We've included an alarm and console.
 pub struct QemuRv32VirtPlatform {
+    pconsole: &'static ProcessConsoleDriver,
     console: &'static capsules_core::console::Console<'static>,
     lldb: &'static capsules_core::low_level_debug::LowLevelDebug<
         'static,
@@ -95,6 +97,12 @@ pub struct QemuRv32VirtPlatform {
             RiscvCoherentDmaFence,
         >,
     >,
+}
+
+impl QemuRv32VirtPlatform {
+    pub fn process_console_start(&self) -> Result<(), ErrorCode> {
+        self.pconsole.start()
+    }
 }
 
 /// Mapping of integer syscalls to objects that implement syscalls.
@@ -182,7 +190,6 @@ pub unsafe fn start() -> (
         'static,
         QemuRv32VirtDefaultPeripherals<'static>,
     >,
-    &'static ProcessConsoleDriver,
 ) {
     // These symbols are defined in the linker script.
     extern "C" {
@@ -676,6 +683,21 @@ pub unsafe fn start() -> (
         resources.printer.put(process_printer);
     });
 
+    // Initialize the kernel's process console.
+    let process_console_cap = unsafe { mint_defined_capability!(ProcessConsoleCap) };
+    let pconsole = components::process_console::ProcessConsoleComponent::new(
+        board_kernel,
+        uart_mux,
+        mux_alarm,
+        process_printer,
+        None,
+        process_console_cap,
+    )
+    .finalize(components::process_console_component_static!(
+        qemu_rv32_virt_chip::chip::QemuRv32VirtClint,
+        ProcessConsoleCap
+    ));
+
     // Setup the console.
     let console = components::console::ConsoleComponent::new(
         board_kernel,
@@ -728,6 +750,7 @@ pub unsafe fn start() -> (
             ));
 
     let platform = QemuRv32VirtPlatform {
+        pconsole,
         console,
         alarm,
         lldb,
@@ -770,26 +793,5 @@ pub unsafe fn start() -> (
         debug!("- VirtIO Input device not found, disabling Input");
     }
 
-    // Create the process console, an interactive terminal for managing
-    // processes. This is left unstarted; it is up to the caller to start it
-    // once the rest of initialization, including the debug prints above,
-    // has completed. Starting the console arms an alarm that will
-    // (asynchronously) print its prompt and begin accepting input, so
-    // starting it too early could interleave its output with or precede the
-    // initialization messages above.
-    let process_console_cap = unsafe { mint_defined_capability!(ProcessConsoleCap) };
-    let pconsole = components::process_console::ProcessConsoleComponent::new(
-        board_kernel,
-        uart_mux,
-        mux_alarm,
-        process_printer,
-        None,
-        process_console_cap,
-    )
-    .finalize(components::process_console_component_static!(
-        qemu_rv32_virt_chip::chip::QemuRv32VirtClint,
-        ProcessConsoleCap
-    ));
-
-    (board_kernel, platform, chip, pconsole)
+    (board_kernel, platform, chip)
 }

--- a/boards/qemu_rv32_virt/src/lib.rs
+++ b/boards/qemu_rv32_virt/src/lib.rs
@@ -52,6 +52,30 @@ static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>
 
 kernel::stack_size! {0x8000}
 
+/// Capability type used to construct the process console.
+///
+/// Unlike most capabilities in this file, this one is declared by hand
+/// (rather than with [`kernel::create_typed_capability!`]) because it must
+/// be nameable both in [`start`] and in its return type, so that callers in
+/// other crates (board `main.rs` files) can decide whether and how to
+/// start the returned [`ProcessConsoleDriver`]. Its private tuple field
+/// prevents construction from outside this module, and
+/// [`ProcessConsoleCap::new`] additionally requires an `unsafe` block,
+/// matching the convention used for capability creation elsewhere.
+pub struct ProcessConsoleCap(());
+
+unsafe impl kernel::capabilities::ProcessManagementCapability for ProcessConsoleCap {}
+unsafe impl kernel::capabilities::ProcessStartCapability for ProcessConsoleCap {}
+
+impl ProcessConsoleCap {
+    unsafe fn new() -> Self {
+        ProcessConsoleCap(())
+    }
+}
+
+type ProcessConsoleDriver =
+    components::process_console::ProcessConsoleComponentType<AlarmHw, ProcessConsoleCap>;
+
 /// A structure representing this platform that holds references to all
 /// capsules for this platform. We've included an alarm and console.
 pub struct QemuRv32VirtPlatform {
@@ -176,6 +200,7 @@ pub unsafe fn start() -> (
         'static,
         QemuRv32VirtDefaultPeripherals<'static>,
     >,
+    &'static ProcessConsoleDriver,
 ) {
     // These symbols are defined in the linker script.
     extern "C" {
@@ -763,15 +788,14 @@ pub unsafe fn start() -> (
         debug!("- VirtIO Input device not found, disabling Input");
     }
 
-    // Initialize the kernel's process console. This is done last, after the
-    // debug prints above, because starting the console arms an alarm that
-    // will (asynchronously) print its prompt and begin accepting input; if
-    // it were started earlier, its output could interleave with or precede
-    // the initialization messages above.
-    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
-        kernel::capabilities::ProcessManagementCapability,
-        kernel::capabilities::ProcessStartCapability
-    );
+    // Create the process console, an interactive terminal for managing
+    // processes. This is left unstarted; it is up to the caller to start it
+    // once the rest of initialization, including the debug prints above,
+    // has completed. Starting the console arms an alarm that will
+    // (asynchronously) print its prompt and begin accepting input, so
+    // starting it too early could interleave its output with or precede the
+    // initialization messages above.
+    let process_console_cap = unsafe { ProcessConsoleCap::new() };
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
@@ -785,7 +809,5 @@ pub unsafe fn start() -> (
         ProcessConsoleCap
     ));
 
-    let _ = pconsole.start();
-
-    (board_kernel, platform, chip)
+    (board_kernel, platform, chip, pconsole)
 }

--- a/boards/qemu_rv32_virt/src/lib.rs
+++ b/boards/qemu_rv32_virt/src/lib.rs
@@ -8,7 +8,6 @@
 #![no_main]
 
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
-use kernel::ErrorCode;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::debug::PanicResources;
@@ -53,23 +52,9 @@ static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>
 
 kernel::stack_size! {0x8000}
 
-kernel::declare_capability!(ProcessConsoleCap:
-    kernel::capabilities::ProcessManagementCapability,
-    kernel::capabilities::ProcessStartCapability
-);
-
 /// A structure representing this platform that holds references to all
 /// capsules for this platform. We've included an alarm and console.
 pub struct QemuRv32VirtPlatform {
-    pconsole: &'static capsules_core::process_console::ProcessConsole<
-        'static,
-        { capsules_core::process_console::DEFAULT_COMMAND_HISTORY_LEN },
-        capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<
-            'static,
-            qemu_rv32_virt_chip::chip::QemuRv32VirtClint<'static>,
-        >,
-        ProcessConsoleCap,
-    >,
     console: &'static capsules_core::console::Console<'static>,
     lldb: &'static capsules_core::low_level_debug::LowLevelDebug<
         'static,
@@ -104,12 +89,6 @@ pub struct QemuRv32VirtPlatform {
             RiscvCoherentDmaFence,
         >,
     >,
-}
-
-impl QemuRv32VirtPlatform {
-    pub fn process_console_start(&self) -> Result<(), ErrorCode> {
-        self.pconsole.start()
-    }
 }
 
 /// Mapping of integer syscalls to objects that implement syscalls.
@@ -690,20 +669,6 @@ pub unsafe fn start() -> (
         resources.printer.put(process_printer);
     });
 
-    // Initialize the kernel's process console.
-    let pconsole = components::process_console::ProcessConsoleComponent::new(
-        board_kernel,
-        uart_mux,
-        mux_alarm,
-        process_printer,
-        None,
-        ProcessConsoleCap,
-    )
-    .finalize(components::process_console_component_static!(
-        qemu_rv32_virt_chip::chip::QemuRv32VirtClint,
-        ProcessConsoleCap
-    ));
-
     // Setup the console.
     let console = components::console::ConsoleComponent::new(
         board_kernel,
@@ -756,7 +721,6 @@ pub unsafe fn start() -> (
             ));
 
     let platform = QemuRv32VirtPlatform {
-        pconsole,
         console,
         alarm,
         lldb,
@@ -798,6 +762,30 @@ pub unsafe fn start() -> (
     } else {
         debug!("- VirtIO Input device not found, disabling Input");
     }
+
+    // Initialize the kernel's process console. This is done last, after the
+    // debug prints above, because starting the console arms an alarm that
+    // will (asynchronously) print its prompt and begin accepting input; if
+    // it were started earlier, its output could interleave with or precede
+    // the initialization messages above.
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
+    let pconsole = components::process_console::ProcessConsoleComponent::new(
+        board_kernel,
+        uart_mux,
+        mux_alarm,
+        process_printer,
+        None,
+        process_console_cap,
+    )
+    .finalize(components::process_console_component_static!(
+        qemu_rv32_virt_chip::chip::QemuRv32VirtClint,
+        ProcessConsoleCap
+    ));
+
+    let _ = pconsole.start();
 
     (board_kernel, platform, chip)
 }

--- a/boards/qemu_rv32_virt/src/lib.rs
+++ b/boards/qemu_rv32_virt/src/lib.rs
@@ -16,7 +16,9 @@ use kernel::platform::KernelResources;
 use kernel::platform::SyscallDriverLookup;
 use kernel::utilities::registers::interfaces::ReadWriteable;
 use kernel::utilities::single_thread_value::SingleThreadValue;
-use kernel::{create_capability, debug, static_init};
+use kernel::{
+    create_capability, debug, define_capability_type, mint_defined_capability, static_init,
+};
 use qemu_rv32_virt_chip::chip::{QemuRv32VirtChip, QemuRv32VirtDefaultPeripherals};
 use rv32i::csr;
 use rv32i::dma_fence::RiscvCoherentDmaFence;
@@ -52,27 +54,7 @@ static PANIC_RESOURCES: SingleThreadValue<PanicResources<ChipHw, ProcessPrinter>
 
 kernel::stack_size! {0x8000}
 
-/// Capability type used to construct the process console.
-///
-/// Unlike most capabilities in this file, this one is declared by hand
-/// (rather than with [`kernel::create_typed_capability!`]) because it must
-/// be nameable both in [`start`] and in its return type, so that callers in
-/// other crates (board `main.rs` files) can decide whether and how to
-/// start the returned [`ProcessConsoleDriver`]. Its private tuple field
-/// prevents construction from outside this module, and
-/// [`ProcessConsoleCap::new`] additionally requires an `unsafe` block,
-/// matching the convention used for capability creation elsewhere.
-pub struct ProcessConsoleCap(());
-
-unsafe impl kernel::capabilities::ProcessManagementCapability for ProcessConsoleCap {}
-unsafe impl kernel::capabilities::ProcessStartCapability for ProcessConsoleCap {}
-
-impl ProcessConsoleCap {
-    unsafe fn new() -> Self {
-        ProcessConsoleCap(())
-    }
-}
-
+define_capability_type!(ProcessConsoleCap: capabilities::ProcessManagementCapability, capabilities::ProcessStartCapability);
 type ProcessConsoleDriver =
     components::process_console::ProcessConsoleComponentType<AlarmHw, ProcessConsoleCap>;
 
@@ -795,7 +777,7 @@ pub unsafe fn start() -> (
     // (asynchronously) print its prompt and begin accepting input, so
     // starting it too early could interleave its output with or precede the
     // initialization messages above.
-    let process_console_cap = unsafe { ProcessConsoleCap::new() };
+    let process_console_cap = unsafe { mint_defined_capability!(ProcessConsoleCap) };
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,

--- a/boards/qemu_rv32_virt/src/main.rs
+++ b/boards/qemu_rv32_virt/src/main.rs
@@ -110,9 +110,6 @@ pub unsafe fn main() {
         screen,
     };
 
-    // Start the process console:
-    let _ = platform.base.process_console_start();
-
     // These symbols are defined in the linker script.
     extern "C" {
         /// Beginning of the ROM region containing app images.

--- a/boards/qemu_rv32_virt/src/main.rs
+++ b/boards/qemu_rv32_virt/src/main.rs
@@ -92,7 +92,7 @@ impl KernelResources<qemu_rv32_virt_lib::ChipHw> for Platform {
 pub unsafe fn main() {
     let main_loop_capability = create_capability!(capabilities::MainLoopCapability);
 
-    let (board_kernel, base_platform, chip, pconsole) = qemu_rv32_virt_lib::start();
+    let (board_kernel, base_platform, chip) = qemu_rv32_virt_lib::start();
 
     let screen = base_platform.virtio_gpu_screen.map(|screen| {
         components::screen::ScreenComponent::new(
@@ -111,7 +111,7 @@ pub unsafe fn main() {
     };
 
     // Start the process console:
-    let _ = pconsole.start();
+    let _ = platform.base.process_console_start();
 
     // These symbols are defined in the linker script.
     extern "C" {

--- a/boards/qemu_rv32_virt/src/main.rs
+++ b/boards/qemu_rv32_virt/src/main.rs
@@ -92,7 +92,7 @@ impl KernelResources<qemu_rv32_virt_lib::ChipHw> for Platform {
 pub unsafe fn main() {
     let main_loop_capability = create_capability!(capabilities::MainLoopCapability);
 
-    let (board_kernel, base_platform, chip) = qemu_rv32_virt_lib::start();
+    let (board_kernel, base_platform, chip, pconsole) = qemu_rv32_virt_lib::start();
 
     let screen = base_platform.virtio_gpu_screen.map(|screen| {
         components::screen::ScreenComponent::new(
@@ -109,6 +109,9 @@ pub unsafe fn main() {
         base: base_platform,
         screen,
     };
+
+    // Start the process console:
+    let _ = pconsole.start();
 
     // These symbols are defined in the linker script.
     extern "C" {

--- a/boards/raspberry_pi_pico/src/lib.rs
+++ b/boards/raspberry_pi_pico/src/lib.rs
@@ -511,7 +511,7 @@ pub unsafe fn setup(
         resources.printer.put(process_printer);
     });
 
-    kernel::declare_capability!(ProcessConsoleCap:
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
         kernel::capabilities::ProcessManagementCapability,
         kernel::capabilities::ProcessStartCapability
     );
@@ -521,7 +521,7 @@ pub unsafe fn setup(
         mux_alarm,
         process_printer,
         Some(cortexm0p::support::reset),
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         RPTimer,

--- a/boards/raspberry_pi_pico_2/src/main.rs
+++ b/boards/raspberry_pi_pico_2/src/main.rs
@@ -397,7 +397,7 @@ pub unsafe fn main() {
         resources.printer.put(process_printer);
     });
 
-    kernel::declare_capability!(ProcessConsoleCap:
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
         kernel::capabilities::ProcessManagementCapability,
         kernel::capabilities::ProcessStartCapability
     );
@@ -407,7 +407,7 @@ pub unsafe fn main() {
         mux_alarm,
         process_printer,
         Some(cortexm33::support::reset),
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         RPTimer,

--- a/boards/redboard_redv/src/main.rs
+++ b/boards/redboard_redv/src/main.rs
@@ -257,7 +257,7 @@ unsafe fn start() -> (
         resources.printer.put(process_printer);
     });
 
-    kernel::declare_capability!(ProcessConsoleCap:
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
         kernel::capabilities::ProcessManagementCapability,
         kernel::capabilities::ProcessStartCapability
     );
@@ -267,7 +267,7 @@ unsafe fn start() -> (
         mux_alarm,
         process_printer,
         None,
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         e310_g002::chip::E310xClint,

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -102,21 +102,12 @@ type AnalogComparatorDriver =
     components::analog_comparator::AnalogComparatorComponentType<AnalogComparatorHw>;
 type ScreenDriver = components::screen::ScreenComponentType;
 
-kernel::declare_capability!(ProcessConsoleCap:
-    kernel::capabilities::ProcessManagementCapability,
-    kernel::capabilities::ProcessStartCapability
-);
-
-type ProcessConsoleDriver =
-    components::process_console::ProcessConsoleComponentType<AlarmHw, ProcessConsoleCap>;
-
 /// Supported drivers by the platform
 pub struct Platform {
     temperature: &'static TemperatureDriver,
     ble_radio: &'static BleDriver,
     ieee802154_radio: &'static Ieee802154Driver,
     button: &'static ButtonDriver,
-    pconsole: &'static ProcessConsoleDriver,
     console: &'static ConsoleDriver,
     gpio: &'static GpioDriver,
     led: &'static LedDriver,
@@ -342,13 +333,17 @@ pub unsafe fn start() -> (
     let uart_mux = components::console::UartMuxComponent::new(uart_channel, 115200)
         .finalize(components::uart_mux_component_static!());
 
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
+        kernel::capabilities::ProcessManagementCapability,
+        kernel::capabilities::ProcessStartCapability
+    );
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         nrf52840::rtc::Rtc<'static>,
@@ -521,7 +516,6 @@ pub unsafe fn start() -> (
         button,
         ble_radio,
         ieee802154_radio,
-        pconsole,
         console,
         led,
         gpio,
@@ -576,7 +570,7 @@ pub unsafe fn start() -> (
         }
     }
 
-    let _ = platform.pconsole.start();
+    let _ = pconsole.start();
     debug!("Initialization complete. Entering main loop\r");
     debug!("{}", ficr);
 

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -811,7 +811,7 @@ unsafe fn start() -> (
     });
 
     // PROCESS CONSOLE
-    kernel::declare_capability!(ProcessConsoleCap:
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
         kernel::capabilities::ProcessManagementCapability,
         kernel::capabilities::ProcessStartCapability
     );
@@ -821,7 +821,7 @@ unsafe fn start() -> (
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         stm32f303xc::tim2::Tim2,

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -794,7 +794,7 @@ unsafe fn start() -> (
     });
 
     // PROCESS CONSOLE
-    kernel::declare_capability!(ProcessConsoleCap:
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
         kernel::capabilities::ProcessManagementCapability,
         kernel::capabilities::ProcessStartCapability
     );
@@ -804,7 +804,7 @@ unsafe fn start() -> (
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         stm32f412g::tim2::Tim2,

--- a/boards/stm32f429idiscovery/src/main.rs
+++ b/boards/stm32f429idiscovery/src/main.rs
@@ -599,7 +599,7 @@ unsafe fn start() -> (
     });
 
     // PROCESS CONSOLE
-    kernel::declare_capability!(ProcessConsoleCap:
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
         kernel::capabilities::ProcessManagementCapability,
         kernel::capabilities::ProcessStartCapability
     );
@@ -609,7 +609,7 @@ unsafe fn start() -> (
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         stm32f429zi::tim2::Tim2,

--- a/boards/tutorials/nrf52840dk-hotp-tutorial/src/main.rs
+++ b/boards/tutorials/nrf52840dk-hotp-tutorial/src/main.rs
@@ -220,10 +220,10 @@ pub unsafe fn main() {
     // STORAGE PERMISSIONS
     //--------------------------------------------------------------------------
 
-    kernel::declare_capability!(AppStoreCap: kernel::capabilities::ApplicationStorageCapability);
+    kernel::create_typed_capability!(app_store_cap, AppStoreCap: kernel::capabilities::ApplicationStorageCapability);
     let storage_permissions_policy =
         components::storage_permissions::tbf_header::StoragePermissionsTbfHeaderComponent::new(
-            AppStoreCap,
+            app_store_cap,
         )
         .finalize(
             components::storage_permissions_tbf_header_component_static!(

--- a/boards/tutorials/nrf52840dk-root-of-trust-tutorial/src/main.rs
+++ b/boards/tutorials/nrf52840dk-root-of-trust-tutorial/src/main.rs
@@ -88,7 +88,7 @@ pub unsafe fn main() {
     let main_loop_capability = create_capability!(capabilities::MainLoopCapability);
 
     // Create the base board:
-    let (board_kernel, base_platform, chip, nrf52840_peripherals, _mux_alarm) =
+    let (board_kernel, base_platform, chip, nrf52840_peripherals, _mux_alarm, _pconsole) =
         nrf52840dk_lib::start_pconsole_optional(false);
 
     //--------------------------------------------------------------------------

--- a/boards/tutorials/nrf52840dk-root-of-trust-tutorial/src/main.rs
+++ b/boards/tutorials/nrf52840dk-root-of-trust-tutorial/src/main.rs
@@ -89,7 +89,7 @@ pub unsafe fn main() {
 
     // Create the base board:
     let (board_kernel, base_platform, chip, nrf52840_peripherals, _mux_alarm) =
-        nrf52840dk_lib::start_no_pconsole();
+        nrf52840dk_lib::start_pconsole_optional(false);
 
     //--------------------------------------------------------------------------
     // SCREEN

--- a/boards/tutorials/nrf52840dk-thread-tutorial/src/main.rs
+++ b/boards/tutorials/nrf52840dk-thread-tutorial/src/main.rs
@@ -251,10 +251,10 @@ pub unsafe fn main() {
     // STORAGE PERMISSIONS
     //--------------------------------------------------------------------------
 
-    kernel::declare_capability!(AppStoreCap: kernel::capabilities::ApplicationStorageCapability);
+    kernel::create_typed_capability!(app_store_cap, AppStoreCap: kernel::capabilities::ApplicationStorageCapability);
     let storage_permissions_policy =
         components::storage_permissions::individual::StoragePermissionsIndividualComponent::new(
-            AppStoreCap,
+            app_store_cap,
         )
         .finalize(
             components::storage_permissions_individual_component_static!(

--- a/boards/tutorials/qemu_rv32_virt-tutorial/src/main.rs
+++ b/boards/tutorials/qemu_rv32_virt-tutorial/src/main.rs
@@ -162,7 +162,7 @@ impl KernelResources<qemu_rv32_virt_lib::ChipHw> for Platform {
 pub unsafe fn main() {
     let main_loop_capability = create_capability!(capabilities::MainLoopCapability);
 
-    let (board_kernel, base_platform, chip) = qemu_rv32_virt_lib::start();
+    let (board_kernel, base_platform, chip, pconsole) = qemu_rv32_virt_lib::start();
 
     //--------------------------------------------------------------------------
     // SCREEN
@@ -256,6 +256,9 @@ pub unsafe fn main() {
         led,
         buttons,
     };
+
+    // Start the process console:
+    let _ = pconsole.start();
 
     //--------------------------------------------------------------------------
     // CREDENTIAL CHECKING

--- a/boards/tutorials/qemu_rv32_virt-tutorial/src/main.rs
+++ b/boards/tutorials/qemu_rv32_virt-tutorial/src/main.rs
@@ -257,9 +257,6 @@ pub unsafe fn main() {
         buttons,
     };
 
-    // Start the process console:
-    let _ = platform.base.process_console_start();
-
     //--------------------------------------------------------------------------
     // CREDENTIAL CHECKING
     //--------------------------------------------------------------------------

--- a/boards/veer_el2_sim/src/main.rs
+++ b/boards/veer_el2_sim/src/main.rs
@@ -179,7 +179,7 @@ unsafe fn start() -> (&'static kernel::Kernel, VeeR, &'static VeeRChip) {
         resources.printer.put(process_printer);
     });
 
-    kernel::declare_capability!(ProcessConsoleCap:
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
         kernel::capabilities::ProcessManagementCapability,
         kernel::capabilities::ProcessStartCapability
     );
@@ -189,7 +189,7 @@ unsafe fn start() -> (&'static kernel::Kernel, VeeR, &'static VeeRChip) {
         mux_alarm,
         process_printer,
         None,
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         Clint,

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -457,7 +457,7 @@ unsafe fn start() -> (
     });
 
     // PROCESS CONSOLE
-    kernel::declare_capability!(ProcessConsoleCap:
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
         kernel::capabilities::ProcessManagementCapability,
         kernel::capabilities::ProcessStartCapability
     );
@@ -467,7 +467,7 @@ unsafe fn start() -> (
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         stm32f401cc::tim2::Tim2,

--- a/boards/wm1110dev/src/main.rs
+++ b/boards/wm1110dev/src/main.rs
@@ -453,7 +453,7 @@ pub unsafe fn start() -> (
         resources.printer.put(process_printer);
     });
 
-    kernel::declare_capability!(ProcessConsoleCap:
+    kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
         kernel::capabilities::ProcessManagementCapability,
         kernel::capabilities::ProcessStartCapability
     );
@@ -463,7 +463,7 @@ pub unsafe fn start() -> (
         mux_alarm,
         process_printer,
         Some(cortexm4::support::reset),
-        ProcessConsoleCap,
+        process_console_cap,
     )
     .finalize(components::process_console_component_static!(
         nrf52840::rtc::Rtc,

--- a/kernel/src/utilities/helpers.rs
+++ b/kernel/src/utilities/helpers.rs
@@ -130,6 +130,7 @@ macro_rules! create_typed_capability {
 
             impl $type {
                 // Mark the constructor unsafe to prevent non-obvious use.
+                #[doc(hidden)]
                 pub unsafe fn new_only_for_use_in_macro() -> Self {
                     $type(())
                 }
@@ -140,6 +141,93 @@ macro_rules! create_typed_capability {
 
         // Create one instance of the capability.
         let $var = unsafe { $type::new_only_for_use_in_macro() };
+    };
+}
+
+/// Define a struct type that implements the given capability traits.
+///
+/// Unlike [`create_capability!`] or [`create_typed_capability!`], this macro
+/// only defines a visibly named type, it does not create any instances.
+/// Use this when you need to name the capability type across scope boundaries.
+///
+/// Use [`mint_defined_capability!`] to create an instance. Note: You can only
+/// mint capabilities in the same module that defines this type.
+///
+/// This macro must be used at module level scope (i.e. not in a code block).
+///
+/// # Usage Example
+///
+/// ```ignore
+/// # use kernel::capabilities::ProcessManagementCapability;
+/// # use kernel::define_capability_type;
+///
+/// define_capability_type!(ProcCapForManager: ProcessManagementCapability);
+/// ```
+///
+/// # Restrictions
+///
+/// This helper macro cannot be called from `#![forbid(unsafe_code)]` crates,
+/// and is used by trusted code to define a capability type.
+///
+/// # Safety
+///
+/// This macro can only be used in a context that is allowed to use `unsafe`.
+/// Specifically, an internal `allow(unsafe_code)` directive will conflict with
+/// any `forbid(unsafe_code)` at the crate or block level.
+#[macro_export]
+macro_rules! define_capability_type {
+    ($type:ident: $($T:path),+ $(,)?) => {
+        /// Publicly nameable type for capabilities.
+        pub struct $type {
+            // Make it obvious that this should not be directly constructed.
+            _not_for_public_construction: (),
+        }
+
+        // Implement specified capabilities.
+        $(
+            #[allow(unsafe_code)]
+            unsafe impl $T for $type {}
+        )*
+
+        impl $type {
+            // Mark the constructor unsafe to prevent non-obvious use.
+            //
+            // Must not be `pub` to prevent external users.
+            #[doc(hidden)]
+            unsafe fn __macro_only_capability_creator() -> Self {
+                Self { _not_for_public_construction: () }
+            }
+        }
+    };
+}
+
+/// Create an instance of a capability type defined by [`define_capability_type!`].
+///
+/// Use this to create one instance of a capability previously declared via
+/// [`define_capability_type`]. Note: You can only mint capabilities in the
+/// same module that defines this type.
+///
+/// # Usage Example
+///
+/// ```ignore
+/// # use kernel::mint_defined_capability;
+///
+/// let proc_cap = unsafe { mint_defined_capability!(ProcCapForManager) };
+/// ```
+///
+/// # Restrictions
+///
+/// This macro invokes an `unsafe` function. Callers must wrap use of this
+/// macro in `unsafe` to assert they are trusted to mint a capability.
+// Note: Ultimately, this is just a wrapper around a function call, and does
+// not _need_ to be in a macro per se. However, minting capabilities is a
+// highly sensitive operation, and encapsulating this in a macro helps code
+// review spot this directly as the creation of a capability, which may be less
+// apparent when just constructing an arbitrarily named struct.
+#[macro_export]
+macro_rules! mint_defined_capability {
+    ($type:ident) => {
+        $type::__macro_only_capability_creator()
     };
 }
 

--- a/kernel/src/utilities/helpers.rs
+++ b/kernel/src/utilities/helpers.rs
@@ -49,39 +49,38 @@ macro_rules! create_capability {
     }};
 }
 
-/// Declare a named struct that implements the given capability traits.
+/// Create a struct that implements the given capability traits.
 ///
-/// Unlike [`create_capability!`], this macro creates a named type that can be
-/// used as a generic parameter (e.g., in component static macros). Use this
-/// when you need to name the capability type, such as when passing it to a
-/// component's static buffer macro.
+/// Unlike [`create_capability!`], this macro creates an instance of a struct
+/// with a visibly named type. Use this when you need to name the capability
+/// type, such as when passing it to a component's static buffer macro.
 ///
 /// # Usage Example
 ///
 /// ```ignore
 /// # use kernel::capabilities::ProcessManagementCapability;
-/// # use kernel::declare_capability;
+/// # use kernel::create_typed_capability;
 ///
-/// declare_capability!(MyCapability: ProcessManagementCapability);
+/// create_typed_capability!(proc_cap, ProcCapForManager: ProcessManagementCapability);
 ///
 /// let manager = components::manager::ManagerComponent::new(
 ///     board_kernel,
 ///     mux_alarm,
-///     MyCapability,
+///     proc_cap,
 /// )
 /// .finalize(components::manager_component_static!(
 ///     AlarmHw,
-///     MyCapability,
+///     ProcCapForManager,
 /// ));
 /// ```
 ///
 /// # Difference from `create_capability!()`
 ///
-/// `declare_capability!()` creates a named type, whereas [`create_capability!`]
-/// does not. If possible, use [`create_capability!`]. However, for components
-/// that need the capability struct named in the static constructor macro, use
-/// `declare_capability!()` to create the named struct that is used in the macro
-/// expansion and in the component `finalize()` method.
+/// `create_typed_capability!()` creates a visibly named type, whereas
+/// [`create_capability!`] does not. If possible, use [`create_capability!`].
+/// However, for components that need to name the type for static constructors,
+/// use `create_typed_capability!()` to create the struct that is used in that
+/// macro expansion and in the component `finalize()` method.
 ///
 /// # Supporting Multiple Capabilities
 ///
@@ -89,7 +88,7 @@ macro_rules! create_capability {
 /// declaring multiple capabilities. For example:
 ///
 /// ```
-/// kernel::declare_capability!(ProcessConsoleCap:
+/// kernel::create_typed_capability!(process_console_cap, ProcessConsoleCap:
 ///     kernel::capabilities::ProcessManagementCapability,
 ///     kernel::capabilities::ProcessStartCapability
 /// );
@@ -106,13 +105,41 @@ macro_rules! create_capability {
 /// Specifically, an internal `allow(unsafe_code)` directive will conflict with
 /// any `forbid(unsafe_code)` at the crate or block level.
 #[macro_export]
-macro_rules! declare_capability {
-    ($name:ident: $($T:ty),+) => {
-        struct $name;
-        $(
-            #[allow(unsafe_code)]
-            unsafe impl $T for $name {}
-        )*
+macro_rules! create_typed_capability {
+    ($var:ident, $type:ident: $($T:path),+ $(,)?) => {
+        // In plain macros, there's not an ergonomic way to construct a new
+        // identifier for the module name, but we do need unique module name.
+        // Modules and structs share the same namespace, so we can't use
+        // `mod $type` here, but _variables_ exist in a separate namespace,
+        // so we can use the variable name as a module name.
+        //
+        // The implication of this design is that something in the same scope
+        // of this macro _could_ write
+        //     unsafe { $type::new_only_for_use_in_macro() }
+        // to mint another capability, but doing so requires both an unsafe
+        // block and use of an obviously wrong method name.
+        mod $var {
+            // Prevent creation by anything external.
+            pub struct $type(());
+
+            // Implement specified capabilities.
+            $(
+                #[allow(unsafe_code)]
+                unsafe impl $T for $type {}
+            )*
+
+            impl $type {
+                // Mark the constructor unsafe to prevent non-obvious use.
+                pub unsafe fn new_only_for_use_in_macro() -> Self {
+                    $type(())
+                }
+            }
+        }
+        // Import the type name to the current scope
+        use $var::$type;
+
+        // Create one instance of the capability.
+        let $var = unsafe { $type::new_only_for_use_in_macro() };
     };
 }
 


### PR DESCRIPTION
### Pull Request Overview

This targets #4983. For boards which are libraries, this leaves the pconsole in the platform struct (basically just shrinks the size of the patch in #4983).


### Testing Strategy

travis


### TODO or Help Wanted

Note: CI doesn't pass because the rv64 board still needs to be updated in the original PR.


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
