### PR TITLE
chips: stm32u5xx: refactor: initialization function changed for CRC DeferredCallClient

### DIFF
--- a/chips/stm32u5xx/src/chip.rs
+++ b/chips/stm32u5xx/src/chip.rs
@@ -117,14 +117,12 @@ impl<'a> Stm32u5xxDefaultPeripherals<'a> {
         // As explained in the driver, an application can't change the samplling time, so it's hardcoded here
         self.adc1.enable(AdcSamplingTime::ClockCycles20);
 
-        // Registering the CRC deferred call
-        kernel::deferred_call::DeferredCallClient::register(&self.crc);
-
         self.rcc.enable_dac1();
         self.rcc.enable_crc();
 
         // Deferred Calls
         self.usart1.register();
+        self.crc.register();
 
         // Link DMA to USART1
         let usart1_channel_tx = self.dma1.request_channel();

--- a/chips/stm32u5xx/src/crc.rs
+++ b/chips/stm32u5xx/src/crc.rs
@@ -264,6 +264,10 @@ impl<'a> Crc<'a> for CRC<'a> {
 }
 
 impl DeferredCallClient for CRC<'_> {
+    fn register(&'static self) {
+        self.deferred_call.register(self);
+    }
+
     fn handle_deferred_call(&self) {
         let current_request = self.request.get();
         self.request.set(Request::None);
@@ -296,9 +300,5 @@ impl DeferredCallClient for CRC<'_> {
 
             Request::None => {}
         });
-    }
-
-    fn register(&'static self) {
-        self.deferred_call.register(self);
     }
 }

--- a/chips/stm32u5xx/src/crc.rs
+++ b/chips/stm32u5xx/src/crc.rs
@@ -264,10 +264,6 @@ impl<'a> Crc<'a> for CRC<'a> {
 }
 
 impl DeferredCallClient for CRC<'_> {
-    fn register(&'static self) {
-        self.deferred_call.register(self);
-    }
-
     fn handle_deferred_call(&self) {
         let current_request = self.request.get();
         self.request.set(Request::None);
@@ -300,5 +296,9 @@ impl DeferredCallClient for CRC<'_> {
 
             Request::None => {}
         });
+    }
+
+    fn register(&'static self) {
+        self.deferred_call.register(self);
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request aligns the `impl DeferredCallClient` for the CRC driver with the already existent implementation for USART.


### Testing Strategy

The changes in this PR are purely esthetic.


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.
