### PR TITLE
tools/license-checker: skip .git in worktrees

### DIFF
--- a/.lcignore
+++ b/.lcignore
@@ -3,7 +3,7 @@
 # Copyright Tock Contributors 2022.
 # Copyright Google LLC 2022.
 
-/.git/
+/.git
 /COPYRIGHT
 /LICENSE-APACHE
 /LICENSE-MIT


### PR DESCRIPTION
### Pull Request Overview

In a git worktree, .git is a file rather than a directory. With hidden(false), the walker would attempt to check it for a license header, causing spurious failures. Filter out .git entries entirely so the checker works correctly in both normal repos and worktrees.

### Testing Strategy

This pull request was tested by running license checker in a worktree.

### TODO or Help Wanted

N/A

### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

Claude wrote the fix here.
