### PR TITLE
riscv: remove unneeded unsafe from core state prints

### DIFF
--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -521,7 +521,7 @@ pub unsafe fn semihost_command(_command: usize, _arg0: usize, _arg1: usize) -> u
 }
 
 /// Print a readable string for an mcause reason.
-pub unsafe fn print_mcause(mcval: csr::mcause::Trap, writer: &mut dyn Write) {
+pub fn print_mcause(mcval: csr::mcause::Trap, writer: &mut dyn Write) {
     let s = match mcval {
         csr::mcause::Trap::Interrupt(interrupt) => match interrupt {
             csr::mcause::Interrupt::UserSoft => "User software interrupt",
@@ -558,7 +558,7 @@ pub unsafe fn print_mcause(mcval: csr::mcause::Trap, writer: &mut dyn Write) {
 
 /// Prints out RISCV machine state, including basic system registers
 /// (mcause, mstatus, mtvec, mepc, mtval, interrupt status).
-pub unsafe fn print_riscv_state(writer: &mut dyn Write) {
+pub fn print_riscv_state(writer: &mut dyn Write) {
     let mcval: csr::mcause::Trap = core::convert::From::from(csr::CSR.mcause.extract());
     let _ = writer.write_fmt(format_args!("\r\n---| RISC-V Machine State |---\r\n"));
     let _ = writer.write_fmt(format_args!("Last cause (mcause): "));


### PR DESCRIPTION
### Pull Request Overview

This removes two unneeded `unsafe` qualifiers; the functions are completely safe AFAICT.

There's nothing `unsafe` about reading some status registers or mapping statuses to strings.

### Testing Strategy

This pull request was tested by compiling.

### TODO or Help Wanted

N/A


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
