### PR TITLE
kernel: use From for TRD syscall-return conversions

### DIFF
--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -351,9 +351,7 @@ impl<A: CortexMVariant> kernel::syscall::UserspaceKernelBoundary for SysCall<A> 
         let (r0_ref, r1_ref, r2_ref, r3_ref) = unsafe { (&mut *r0, &mut *r1, &mut *r2, &mut *r3) };
 
         kernel::utilities::arch_helpers::encode_syscall_return_trd104(
-            &kernel::utilities::arch_helpers::TRD104SyscallReturn::from_syscall_return(
-                return_value,
-            ),
+            &return_value.into(),
             r0_ref,
             r1_ref,
             r2_ref,

--- a/arch/riscv/src/syscall.rs
+++ b/arch/riscv/src/syscall.rs
@@ -138,7 +138,7 @@ fn encode_syscall_return_helper(
     };
 
     kernel::utilities::arch_helpers::encode_syscall_return_trd104(
-        &kernel::utilities::arch_helpers::TRD104SyscallReturn::from_syscall_return(return_value),
+        &return_value.into(),
         a0_u32,
         a1_u32,
         a2_u32,
@@ -168,9 +168,7 @@ fn encode_syscall_return_helper(
     };
 
     kernel::utilities::arch_helpers::encode_syscall_return_trd64bit(
-        &kernel::utilities::arch_helpers::TRDRiscv64bitSyscallReturn::from_syscall_return(
-            return_value,
-        ),
+        &return_value.into(),
         a0_u64,
         a1_u64,
         a2_u64,

--- a/arch/x86/src/boundary/boundary_impl.rs
+++ b/arch/x86/src/boundary/boundary_impl.rs
@@ -114,9 +114,7 @@ impl UserspaceKernelBoundary for Boundary {
         // Refer to
         // https://doc.rust-lang.org/std/primitive.pointer.html#safety-13
         kernel::utilities::arch_helpers::encode_syscall_return_trd104(
-            &kernel::utilities::arch_helpers::TRD104SyscallReturn::from_syscall_return(
-                return_value,
-            ),
+            &return_value.into(),
             &mut ret0,
             &mut ret1,
             &mut ret2,

--- a/kernel/src/utilities/arch_helpers.rs
+++ b/kernel/src/utilities/arch_helpers.rs
@@ -225,11 +225,11 @@ pub enum TRD104SyscallReturn {
     YieldWaitFor(u32, u32, u32),
 }
 
-impl TRD104SyscallReturn {
+impl From<SyscallReturn> for TRD104SyscallReturn {
     /// Map from the kernel's [`SyscallReturn`] enum to the subset of return
     /// values specified in TRD104. This ensures backwards compatibility with
     /// architectures implementing the ABI as specified in TRD104.
-    pub fn from_syscall_return(syscall_return: SyscallReturn) -> Self {
+    fn from(syscall_return: SyscallReturn) -> Self {
         match syscall_return {
             // Identical variants:
             SyscallReturn::Failure(a) => TRD104SyscallReturn::Failure(a),
@@ -453,11 +453,11 @@ pub enum TRDRiscv64bitSyscallReturn {
     SuccessPtr(CapabilityPtr),
 }
 
-impl TRDRiscv64bitSyscallReturn {
+impl From<SyscallReturn> for TRDRiscv64bitSyscallReturn {
     /// Map from the kernel's [`SyscallReturn`] enum to the subset of return
     /// values specified in TRD-Riscv64bit. This ensures backwards compatibility with
     /// architectures implementing the ABI as specified in the TRD.
-    pub fn from_syscall_return(syscall_return: SyscallReturn) -> Self {
+    fn from(syscall_return: SyscallReturn) -> Self {
         match syscall_return {
             SyscallReturn::Failure(a) => TRDRiscv64bitSyscallReturn::Failure(a),
             SyscallReturn::FailureU32(a, b) => TRDRiscv64bitSyscallReturn::FailureU32(a, b),


### PR DESCRIPTION
### Pull Request Overview

While reviewing #5036, I wondered whether it made sense to use the standard `From` trait rather than a custom function name. I think it does, but it's a bit orthogonal to that PR, and we should really update the TRD104 variant as well, so I separated this out as a stacked PR on #5036 to change both to standard `From`.

### Testing Strategy

This pull request was tested by compiling.

### TODO or Help Wanted

N/A

### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

Claude wrote the actual code changes and commit message here; it's pretty mechanical / small.
