### PR TITLE
kernel/arch-riscv: fix unsound usize->u32/u64 syscall register reinterpretation

### DIFF
--- a/arch/riscv/src/syscall.rs
+++ b/arch/riscv/src/syscall.rs
@@ -125,17 +125,10 @@ fn encode_syscall_return_helper(
     a3: &mut usize,
 ) {
     // Convert the `&mut usize` references to `&mut u32`s.
-    //
-    // SAFETY: We are guaranteed to be on a 32-bit platform, and converting a
-    // `&mut usize` to a `&mut u32` will be safe. The pointer will always be
-    // aligned and the values will always be initialized to something.
-    let (a0_u32, a1_u32, a2_u32, a3_u32) = unsafe {
-        let a0_u32: &mut u32 = &mut *core::ptr::from_mut::<usize>(a0).cast::<u32>();
-        let a1_u32: &mut u32 = &mut *core::ptr::from_mut::<usize>(a1).cast::<u32>();
-        let a2_u32: &mut u32 = &mut *core::ptr::from_mut::<usize>(a2).cast::<u32>();
-        let a3_u32: &mut u32 = &mut *core::ptr::from_mut::<usize>(a3).cast::<u32>();
-        (a0_u32, a1_u32, a2_u32, a3_u32)
-    };
+    let a0_u32 = kernel::utilities::helpers::usize_as_native_mut(a0);
+    let a1_u32 = kernel::utilities::helpers::usize_as_native_mut(a1);
+    let a2_u32 = kernel::utilities::helpers::usize_as_native_mut(a2);
+    let a3_u32 = kernel::utilities::helpers::usize_as_native_mut(a3);
 
     kernel::utilities::arch_helpers::encode_syscall_return_trd104(
         &kernel::utilities::arch_helpers::TRD104SyscallReturn::from_syscall_return(return_value),
@@ -155,17 +148,10 @@ fn encode_syscall_return_helper(
     a3: &mut usize,
 ) {
     // Convert the `&mut usize` references to `&mut u64`s.
-    //
-    // SAFETY: We are guaranteed to be on a 64-bit platform, and converting a
-    // `&mut usize` to a `&mut u64` will be safe. The pointer will always be
-    // aligned and the values will always be initialized to something.
-    let (a0_u64, a1_u64, a2_u64, a3_u64) = unsafe {
-        let a0_u64: &mut u64 = &mut *core::ptr::from_mut::<usize>(a0).cast::<u64>();
-        let a1_u64: &mut u64 = &mut *core::ptr::from_mut::<usize>(a1).cast::<u64>();
-        let a2_u64: &mut u64 = &mut *core::ptr::from_mut::<usize>(a2).cast::<u64>();
-        let a3_u64: &mut u64 = &mut *core::ptr::from_mut::<usize>(a3).cast::<u64>();
-        (a0_u64, a1_u64, a2_u64, a3_u64)
-    };
+    let a0_u64 = kernel::utilities::helpers::usize_as_native_mut(a0);
+    let a1_u64 = kernel::utilities::helpers::usize_as_native_mut(a1);
+    let a2_u64 = kernel::utilities::helpers::usize_as_native_mut(a2);
+    let a3_u64 = kernel::utilities::helpers::usize_as_native_mut(a3);
 
     kernel::utilities::arch_helpers::encode_syscall_return_trd64bit(
         &kernel::utilities::arch_helpers::TRD104SyscallReturn::from_syscall_return(return_value),
@@ -236,17 +222,10 @@ fn encode_upcall_helper(
     a3: &mut usize,
 ) {
     // Convert the `&mut usize` references to `&mut u32`s.
-    //
-    // SAFETY: We are guaranteed to be on a 32-bit platform, and converting a
-    // `&mut usize` to a `&mut u32` will be safe. The pointer will always be
-    // aligned and the values will always be initialized to something.
-    let (a0_u32, a1_u32, a2_u32, a3_u32) = unsafe {
-        let a0_u32: &mut u32 = &mut *core::ptr::from_mut::<usize>(a0).cast::<u32>();
-        let a1_u32: &mut u32 = &mut *core::ptr::from_mut::<usize>(a1).cast::<u32>();
-        let a2_u32: &mut u32 = &mut *core::ptr::from_mut::<usize>(a2).cast::<u32>();
-        let a3_u32: &mut u32 = &mut *core::ptr::from_mut::<usize>(a3).cast::<u32>();
-        (a0_u32, a1_u32, a2_u32, a3_u32)
-    };
+    let a0_u32 = kernel::utilities::helpers::usize_as_native_mut(a0);
+    let a1_u32 = kernel::utilities::helpers::usize_as_native_mut(a1);
+    let a2_u32 = kernel::utilities::helpers::usize_as_native_mut(a2);
+    let a3_u32 = kernel::utilities::helpers::usize_as_native_mut(a3);
 
     kernel::utilities::arch_helpers::encode_upcall_trd104(upcall, a0_u32, a1_u32, a2_u32, a3_u32);
 }
@@ -260,17 +239,10 @@ fn encode_upcall_helper(
     a3: &mut usize,
 ) {
     // Convert the `&mut usize` references to `&mut u64`s.
-    //
-    // SAFETY: We are guaranteed to be on a 64-bit platform, and converting a
-    // `&mut usize` to a `&mut u64` will be safe. The pointer will always be
-    // aligned and the values will always be initialized to something.
-    let (a0_u64, a1_u64, a2_u64, a3_u64) = unsafe {
-        let a0_u64: &mut u64 = &mut *core::ptr::from_mut::<usize>(a0).cast::<u64>();
-        let a1_u64: &mut u64 = &mut *core::ptr::from_mut::<usize>(a1).cast::<u64>();
-        let a2_u64: &mut u64 = &mut *core::ptr::from_mut::<usize>(a2).cast::<u64>();
-        let a3_u64: &mut u64 = &mut *core::ptr::from_mut::<usize>(a3).cast::<u64>();
-        (a0_u64, a1_u64, a2_u64, a3_u64)
-    };
+    let a0_u64 = kernel::utilities::helpers::usize_as_native_mut(a0);
+    let a1_u64 = kernel::utilities::helpers::usize_as_native_mut(a1);
+    let a2_u64 = kernel::utilities::helpers::usize_as_native_mut(a2);
+    let a3_u64 = kernel::utilities::helpers::usize_as_native_mut(a3);
 
     kernel::utilities::arch_helpers::encode_upcall_trd64bit(upcall, a0_u64, a1_u64, a2_u64, a3_u64);
 }

--- a/kernel/src/utilities/helpers.rs
+++ b/kernel/src/utilities/helpers.rs
@@ -253,6 +253,39 @@ macro_rules! init_uninit_struct {
     };
 }
 
+/// Reinterpret a `&mut usize` as a `&mut u32` (32-bit targets) or `&mut u64`
+/// (64-bit targets).
+///
+/// This is useful for architectures (e.g. RISC-V) that store syscall/upcall
+/// register arguments as `usize` so that a single struct definition can serve
+/// both 32-bit and 64-bit targets, but need to pass register-width-specific
+/// (`u32`/`u64`) references into TRD-defined encode/decode functions.
+///
+/// This is a plain function, not a macro, on purpose: the conversion is only
+/// sound behind a real function-call boundary.
+#[cfg(target_pointer_width = "32")]
+pub fn usize_as_native_mut(val: &mut usize) -> &mut u32 {
+    let ptr = core::ptr::from_mut::<usize>(val);
+    // SAFETY: We are guaranteed to be on a 32-bit platform, so a `usize` is
+    // the same size and alignment as a `u32`, and `val` is guaranteed to be
+    // initialized to some value.
+    unsafe { &mut *ptr.cast::<u32>() }
+}
+
+/// Reinterpret a `&mut usize` as a `&mut u32` (32-bit targets) or `&mut u64`
+/// (64-bit targets).
+///
+/// This is a plain function, not a macro, on purpose: the conversion is only
+/// sound behind a real function-call boundary.
+#[cfg(target_pointer_width = "64")]
+pub fn usize_as_native_mut(val: &mut usize) -> &mut u64 {
+    let ptr = core::ptr::from_mut::<usize>(val);
+    // SAFETY: We are guaranteed to be on a 64-bit platform, so a `usize` is
+    // the same size and alignment as a `u64`, and `val` is guaranteed to be
+    // initialized to some value.
+    unsafe { &mut *ptr.cast::<u64>() }
+}
+
 /// Compute a POSIX-style CRC32 checksum of a slice.
 ///
 /// Online calculator: <https://crccalc.com/>


### PR DESCRIPTION
### Pull Request Overview

Our current pointer casts are unsound. The conjured `&mut u32` has no lifetime tied back to `a0`, so the compiler still allows using `a0` again while `a0_u32` is alive:

```rust
let a0_u32 = &mut *core::ptr::from_mut::<usize>(a0).cast::<u32>();
*a0 = 1;   // compiles today; a0_u32 still holds a live reference into the same slot
```

This PR extracts the cast into `kernel::utilities::helpers::usize_as_native_mut`, a plain function. A function's lifetime elision (`fn usize_as_native_mut<'a>(val: &'a mut usize) -> &'a mut u32`) ties the output to the input at every call site — neither an inline block nor a macro provides this, since neither introduces a real function-call boundary.

With the fix, the `*a0 = 1;` above (correctly) fails to compile with a lifetime violation.

### Testing Strategy

- `make -C boards/qemu_rv32_virt` — full board build, riscv32 path.
- `cargo check --target riscv64imac-unknown-none-elf` against `kernel` and `arch/riscv` directly — riscv64 path (no riscv64 board in-tree yet).
- Verified the repro: `*a0 = 1;` inserted after the conversion compiles on unpatched code, fails with `E0506` after this fix.

### TODO or Help Wanted

N/A

### Checklist

- [x] Ran `make prepush`.

### PR Contents

#### Documentation

- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<details>
<summary>Prompts used across this PR (review, fix, and this update)</summary>

    ❯ Perform a code review on PR 4964. Pay particular attention to (1) the
      soundness of the new macros, (2) whether there is overlap / redundancy
      with existing Rust primitives that should be used instead, (3) whether
      there are other places in the codebase that should be converted to use
      these macros not covered by the current PR

    ❯ Fix #1, but pause before committing for me to review

    ❯ create a new branch, based off of PR 4964 tip; we will open a new PR
      that targets current PR 4964 as the merge base
      [...]

    ❯ Brad closed PR 4964 as the macros did not fix the soundness issue. But
      there is a real soundness concern it flagged. Review the conversation
      on PR 5070 [sic, 5057]. Then make a plan to update PR 5070 based on my
      most recent comment in the thread.

    ❯ Plan changes:
      1. target origin/master not local master
      2. good as-is
      3. good as-is
      NEW STEP HERE: Search for other places in the existing codebase where
      these helpers should be used. Pause to discuss findings.
      4. The proposed work is good. Plan to pause and iterate with me on the
         exact text.
      5. The proposed work is good. Plan to pause and iterate with me on the
         exact text.
      6. The should move before step 4, verify everything before we author
         PR and comment text

    ❯ Go ahead and draft the PR body

</details>

I have manually reviewed the diff.
