### PR TITLE
Revised IPC Implementation: Fair Iteration of Grants

### DIFF
--- a/capsules/core/src/ipc/ipc_relay_request.rs
+++ b/capsules/core/src/ipc/ipc_relay_request.rs
@@ -385,10 +385,8 @@ impl IpcRelayRequest {
         // processes. Each time this function is called by a server it continues
         // searching the process list from where it last left off.
         let mut client: Option<ProcessId> = None;
-        let mut end_offset = IterOffset::default();
-        for (offset, cntr) in self.apps.rotated_iter(start_offset) {
-            end_offset = offset;
-
+        let mut app_iterator = self.apps.rotated_iter(start_offset);
+        for cntr in app_iterator.by_ref() {
             // skip this process
             if cntr.processid() != processid {
                 self.apps.enter(cntr.processid(), |client_app, _| {
@@ -410,9 +408,10 @@ impl IpcRelayRequest {
 
         // Save iteration location for next time
         self.apps.enter(processid, |app, _| {
-            app.iteration_offset = end_offset;
+            app.iteration_offset = app_iterator.offset();
         })?;
 
+        // Check if we found a waiting request
         if let Some(client_processid) = client {
             // Found request. Attempt the data copy
             self.handle_request_copy(processid, client_processid)

--- a/capsules/core/src/ipc/ipc_relay_request.rs
+++ b/capsules/core/src/ipc/ipc_relay_request.rs
@@ -32,7 +32,7 @@
 //! ```
 
 use crate::ipc::ipc_identifier::IpcIdentifier;
-use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
+use kernel::grant::{AllowRoCount, AllowRwCount, Grant, IterOffset, UpcallCount};
 use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::{ErrorCode, ProcessId};
@@ -76,8 +76,16 @@ enum TransactionState {
 /// Per-process metadata
 #[derive(Default)]
 pub struct App {
+    /// For clients and servers, holds the current state of any ongoing IPC
+    /// Relay Request transaction
     transaction: TransactionState,
+
+    /// For servers, tracks whether requests destined for this app are allowed
     requests_enabled: bool,
+
+    /// For servers, tracks offset in the process list for round-robin iteration
+    /// when getting the next response
+    iteration_offset: IterOffset,
 }
 
 /// IPC Relay Request capsule
@@ -363,17 +371,24 @@ impl IpcRelayRequest {
         processid: ProcessId,
     ) -> Result<Result<(u32, u64), (ErrorCode, u64)>, ErrorCode> {
         // Check if any transaction is active, and fail if so
-        self.apps
+        let start_offset = self
+            .apps
             .enter(processid, |app, _| match app.transaction {
-                TransactionState::None => Ok(()),
+                TransactionState::None => Ok(app.iteration_offset),
                 _ => Err(ErrorCode::ALREADY),
             })??;
 
         // Iterate client apps looking for a transaction in progress with this
-        // app as a server destination
-        // TODO: this should really be a round-robin iteration of clients for fairness... I have a design for that
+        // app as a server destination.
+        //
+        // This uses the rotated_iter function to fairly round-robin through
+        // processes. Each time this function is called by a server it continues
+        // searching the process list from where it last left off.
         let mut client: Option<ProcessId> = None;
-        for cntr in self.apps.iter() {
+        let mut end_offset = IterOffset::default();
+        for (offset, cntr) in self.apps.rotated_iter(start_offset) {
+            end_offset = offset;
+
             // skip this process
             if cntr.processid() != processid {
                 self.apps.enter(cntr.processid(), |client_app, _| {
@@ -385,8 +400,18 @@ impl IpcRelayRequest {
                         client = Some(cntr.processid());
                     }
                 })?;
+
+                // Stop looking if we found a client
+                if client.is_some() {
+                    break;
+                }
             }
         }
+
+        // Save iteration location for next time
+        self.apps.enter(processid, |app, _| {
+            app.iteration_offset = end_offset;
+        })?;
 
         if let Some(client_processid) = client {
             // Found request. Attempt the data copy

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -1807,6 +1807,42 @@ impl<T: Default, Upcalls: UpcallSize, AllowROs: AllowRoSize, AllowRWs: AllowRwSi
             subiter: self.kernel.get_process_iter(),
         }
     }
+
+    /// Get a rotated iterator over all processes and their active grant regions
+    /// for this particular grant.
+    ///
+    /// This is useful for implementing round-robin behavior where process
+    /// iteration can start wherever the prior iteration operation left off. To
+    /// do so, save the most-recently-returned "offset" value during iteration
+    /// and use it to call this function the next time an iterator is needed.
+    ///
+    /// This rotates the iterated contents such that the iterator starts at the
+    /// specified offset into the contents and continues, wrapping around, until
+    /// it reaches the item before the specified offset. For example, [a, b, c]
+    /// rotated with an offset of 1 becomes [b, c, a]. The offset does not have
+    /// to be less than the length of the contents. In the prior example,
+    /// offsets of 4 and 7 also produce [b, c, a].
+    ///
+    /// Calling this function when an [`ProcessGrant`] for a process is
+    /// currently entered will result in a panic.
+    pub fn rotated_iter(
+        &self,
+        offset: IterOffset,
+    ) -> RotatedIter<'_, T, Upcalls, AllowROs, AllowRWs> {
+        // Generates an enumerated iterator, with identical length and elements
+        // to the original iterator, except that a rotation has been applied by
+        // the offset.value amount modulus the array length.
+        RotatedIter {
+            grant: self,
+            subiter: self
+                .kernel
+                .get_process_iter()
+                .enumerate()
+                .cycle()
+                .skip(offset.value)
+                .take(self.kernel.get_process_iter().count()),
+        }
+    }
 }
 
 /// Type to iterate [`ProcessGrant`]s across processes.
@@ -1839,5 +1875,65 @@ impl<'a, T: Default, Upcalls: UpcallSize, AllowROs: AllowRoSize, AllowRWs: Allow
         // this function again will start where we left off.
         self.subiter
             .find_map(|process| ProcessGrant::new_if_allocated(grant, process))
+    }
+}
+
+/// Type to encapsulate iteration offset for creating a RotatedIter.
+#[derive(Default, Clone, Copy)]
+pub struct IterOffset {
+    value: usize,
+}
+
+/// Type to iterate [`ProcessGrant`]s across processes, but with the iterator
+/// rotated by a fixed amount.
+pub struct RotatedIter<
+    'a,
+    T: 'a + Default,
+    Upcalls: UpcallSize,
+    AllowROs: AllowRoSize,
+    AllowRWs: AllowRwSize,
+> {
+    /// The grant type to use.
+    grant: &'a Grant<T, Upcalls, AllowROs, AllowRWs>,
+
+    /// Iterator over valid processes, already rotated.
+    subiter: core::iter::Take<
+        core::iter::Skip<
+            core::iter::Cycle<
+                core::iter::Enumerate<
+                    core::iter::FilterMap<
+                        core::slice::Iter<'a, ProcessSlot>,
+                        fn(&ProcessSlot) -> Option<&'static dyn Process>,
+                    >,
+                >,
+            >,
+        >,
+    >,
+}
+
+impl<'a, T: Default, Upcalls: UpcallSize, AllowROs: AllowRoSize, AllowRWs: AllowRwSize> Iterator
+    for RotatedIter<'a, T, Upcalls, AllowROs, AllowRWs>
+{
+    type Item = (IterOffset, ProcessGrant<'a, T, Upcalls, AllowROs, AllowRWs>);
+
+    /// Get the next item from the iterator.
+    ///
+    /// Returns a tuple of "offset" and the current grant space. The "offset"
+    /// can be fed into future calls to `rotated_iter()` when creating a new
+    /// iterator to start off where this iterator ended.
+    fn next(&mut self) -> Option<Self::Item> {
+        let grant = self.grant;
+        // Get the next `ProcessId` from the kernel processes array that is
+        // setup to use this grant. Since the iterator itself is saved calling
+        // this function again will start where we left off.
+        self.subiter.find_map(|(index, process)| {
+            if let Some(value) = ProcessGrant::new_if_allocated(grant, process) {
+                // Provide the index incremented by one so it always represents
+                // the next offset in the process array
+                Some((IterOffset { value: index + 1 }, value))
+            } else {
+                None
+            }
+        })
     }
 }

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -1813,8 +1813,10 @@ impl<T: Default, Upcalls: UpcallSize, AllowROs: AllowRoSize, AllowRWs: AllowRwSi
     ///
     /// This is useful for implementing round-robin behavior where process
     /// iteration can start wherever the prior iteration operation left off. To
-    /// do so, save the most-recently-returned "offset" value during iteration
-    /// and use it to call this function the next time an iterator is needed.
+    /// do so, save the "offset" value when you've completed iteration and then
+    /// use it to call this function the next time an iterator is needed.
+    /// Initially, this can be called with an `IterOffset::default()` to start
+    /// at the beginning.
     ///
     /// This rotates the iterated contents such that the iterator starts at the
     /// specified offset into the contents and continues, wrapping around, until
@@ -1841,6 +1843,7 @@ impl<T: Default, Upcalls: UpcallSize, AllowROs: AllowRoSize, AllowRWs: AllowRwSi
                 .cycle()
                 .skip(offset.value)
                 .take(self.kernel.get_process_iter().count()),
+            offset: offset.value,
         }
     }
 }
@@ -1909,18 +1912,32 @@ pub struct RotatedIter<
             >,
         >,
     >,
+
+    /// Track the current location within the iterator. This is the offset of
+    /// the _next_ element in the iterator, i.e. the first element that hasn't
+    /// been returned yet.
+    offset: usize,
+}
+
+impl<T: Default, Upcalls: UpcallSize, AllowROs: AllowRoSize, AllowRWs: AllowRwSize>
+    RotatedIter<'_, T, Upcalls, AllowROs, AllowRWs>
+{
+    /// Get the current "offset" within the process list.
+    ///
+    /// This offset value can be fed into future calls to `rotated_iter()` when
+    /// creating a new iterator to start the new one off where this iterator
+    /// ended.
+    pub fn offset(&self) -> IterOffset {
+        IterOffset { value: self.offset }
+    }
 }
 
 impl<'a, T: Default, Upcalls: UpcallSize, AllowROs: AllowRoSize, AllowRWs: AllowRwSize> Iterator
     for RotatedIter<'a, T, Upcalls, AllowROs, AllowRWs>
 {
-    type Item = (IterOffset, ProcessGrant<'a, T, Upcalls, AllowROs, AllowRWs>);
+    type Item = ProcessGrant<'a, T, Upcalls, AllowROs, AllowRWs>;
 
-    /// Get the next item from the iterator.
-    ///
-    /// Returns a tuple of "offset" and the current grant space. The "offset"
-    /// can be fed into future calls to `rotated_iter()` when creating a new
-    /// iterator to start off where this iterator ended.
+    /// Get the next process's grant space from the iterator.
     fn next(&mut self) -> Option<Self::Item> {
         let grant = self.grant;
         // Get the next `ProcessId` from the kernel processes array that is
@@ -1928,9 +1945,10 @@ impl<'a, T: Default, Upcalls: UpcallSize, AllowROs: AllowRoSize, AllowRWs: Allow
         // this function again will start where we left off.
         self.subiter.find_map(|(index, process)| {
             if let Some(value) = ProcessGrant::new_if_allocated(grant, process) {
-                // Provide the index incremented by one so it always represents
-                // the next offset in the process array
-                Some((IterOffset { value: index + 1 }, value))
+                // Save the index incremented by one so it always represents the
+                // next offset in the process array
+                self.offset = index + 1;
+                Some(value)
             } else {
                 None
             }


### PR DESCRIPTION
### Pull Request Overview

This pull request adds functionality for fairly iterating through process grants and uses it for the IPC Relay Request to ensure that getting requests does not suffer from possible starvation.

This is a "stacked PR" on top of https://github.com/tock/tock/pull/5015

To implement this, instead of starting with the first process, we now track where we left off and start from that point the next time we search for any available requests. The location where we left off is saved in grant space for the server so it can be accessed again on next call.

This is added as new functionality to the grant type, with the `RotatedIter` struct being a rotated iterator to the process grant. For example, if the processes were `[a, b, c]` then after rotating them by 1 the iterator will instead go through processes in the order `[b, c, a]`. Any offset provided has a modulus operation implicitly performed on it, so rotating by 4 or 7 would also result in `[b, c, a]`. The offset is just a `usize`, but I wrapped it in an `IterOffset` type to make it clear that it's an opaque marker for position in the process list and should not be directly modified by capsules.

### Testing Strategy

This pull request was tested with the libtock-c IPC Relay Request server and client apps. Three clients were loaded on to the board along with the server. Before this change, only the last and second-to-last were ever served. The first app starved. After this change, service is given to each of the three in order. No starvation.


### TODO or Help Wanted

**Fairness:** If the number or ordering of processes changes within the process array, this new mechanism does NOT account for that. For example, if the process array is `[a, b, c, d]` and we iterate to item `b`, we'd normally start off again with item `c`. But if item `a` is removed, we will start iteration with item `d` instead. So, this only really guarantees total fairness if processes are stable. It will still iterate all processes in either case though. I think this is acceptable, but I'll take opinions on it.

**Overhead:** There are multiple different methods by which a rotated iterator could be constructed. For example `a.iter().enumerate().skip(k).chain(a.iter().enumerate().take(k)` or `a.iter().enumerate().cycle().skip(k).take(a.len())`. I wrote a test to compare these two with `cargo bench`, but found no difference in them. I'm not entirely confident my test was valid though. https://gist.github.com/brghena/5f00cd1cbfb66dc353436a3986ae7488


### Checklist

- [X] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [X] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [X] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
I asked for guidance on wrangling types, but all code was written by me.