### PR TITLE
Update Tockbot Requirements

### DIFF
--- a/tools/ci/tockbot/requirements.txt
+++ b/tools/ci/tockbot/requirements.txt
@@ -14,6 +14,7 @@ platformdirs==4.2.0
 pycparser==2.21
 PyGithub==2.1.1
 PyJWT==2.13.0
+pyOpenSSL==26.4.0
 PyNaCl==1.6.2
 python-dateutil==2.8.2
 PyYAML==6.0.1


### PR DESCRIPTION
### Pull Request Overview

Tockbot is broken again. There's some conflict between library versions which is causing the error. Github copilot suggests we add pyOpenSSL as an explicit dependency with versioning to fix it. From their release notes pyOpenSSL version 26.4.0 says it supports up to cryptography 50.0.0.


### Testing Strategy

I'm not at all sure how to test this


### TODO or Help Wanted

Testing


### Checklist

- [X] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [X] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [X] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
Github copilot told me to add this dependency. I did make sure it seemed plausible and supported the version of cryptography we're using.