### PR TITLE
kernel: chip: make `PanicWriter::create_panic_writer()` safe

### DIFF
--- a/chips/esp32/src/uart.rs
+++ b/chips/esp32/src/uart.rs
@@ -513,7 +513,10 @@ pub struct UartPanicWriterConfig {
 impl kernel::platform::chip::PanicWriter for Uart<'_> {
     type Config = UartPanicWriterConfig;
 
-    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write {
+    fn create_panic_writer(
+        config: Self::Config,
+        _panic: &core::panic::PanicInfo,
+    ) -> impl IoWrite + core::fmt::Write {
         use kernel::hil::uart::Configure as _;
 
         let uart = Uart::new(config.registers);

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -846,7 +846,10 @@ pub struct UartPanicWriterConfig {
 impl kernel::platform::chip::PanicWriter for Uarte<'_> {
     type Config = UartPanicWriterConfig;
 
-    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write {
+    fn create_panic_writer(
+        config: Self::Config,
+        _panic: &core::panic::PanicInfo,
+    ) -> impl IoWrite + core::fmt::Write {
         use uart::Configure as _;
 
         let registers = UarteRegistersManager::new_uarte0();

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -852,7 +852,13 @@ impl kernel::platform::chip::PanicWriter for Uarte<'_> {
     ) -> impl IoWrite + core::fmt::Write {
         use uart::Configure as _;
 
-        let registers = UarteRegistersManager::new_uarte0();
+        // SAFETY: This must be unique and the only owner of the UARTE0 register
+        // manager. We are generally VIOLATING this safety requirement. See
+        // <https://github.com/tock/tock/pull/5091> and
+        // <https://github.com/tock/tock/pull/4990> for more context and some
+        // paths forward to resolve this existing safety violation about
+        // multiple managers of the UARTE0 DMA registers.
+        let registers = unsafe { UarteRegistersManager::new_uarte0() };
 
         let inner = Uarte::new(registers);
         inner.initialize(

--- a/chips/psc3/src/scb.rs
+++ b/chips/psc3/src/scb.rs
@@ -429,7 +429,10 @@ pub struct ScbPanicWriterConfig {
 impl kernel::platform::chip::PanicWriter for Scb<'_> {
     type Config = ScbPanicWriterConfig;
 
-    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write {
+    fn create_panic_writer(
+        config: Self::Config,
+        _panic: &core::panic::PanicInfo,
+    ) -> impl IoWrite + core::fmt::Write {
         use kernel::hil::uart::Configure as _;
 
         let scb = Scb::new();

--- a/chips/qemu_rv32_virt_chip/src/uart.rs
+++ b/chips/qemu_rv32_virt_chip/src/uart.rs
@@ -53,7 +53,10 @@ pub struct UartPanicWriterConfig {
 impl kernel::platform::chip::PanicWriter for UartPanicWriter<'_> {
     type Config = UartPanicWriterConfig;
 
-    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write {
+    fn create_panic_writer(
+        config: Self::Config,
+        _panic: &core::panic::PanicInfo,
+    ) -> impl IoWrite + core::fmt::Write {
         use hil::uart::Configure as _;
 
         let inner = Uart16550::new(UART0_BASE);

--- a/chips/qemu_rv64_virt_chip/src/uart.rs
+++ b/chips/qemu_rv64_virt_chip/src/uart.rs
@@ -53,7 +53,10 @@ pub struct UartPanicWriterConfig {
 impl kernel::platform::chip::PanicWriter for UartPanicWriter<'_> {
     type Config = UartPanicWriterConfig;
 
-    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write {
+    fn create_panic_writer(
+        config: Self::Config,
+        _panic: &core::panic::PanicInfo,
+    ) -> impl IoWrite + core::fmt::Write {
         use hil::uart::Configure as _;
 
         let inner = Uart16550::new(UART0_BASE);

--- a/chips/segger/src/rtt.rs
+++ b/chips/segger/src/rtt.rs
@@ -404,7 +404,10 @@ impl core::fmt::Write for RttPanicWriter<'_> {
 impl<'a> kernel::platform::chip::PanicWriter for SeggerRttMemory<'a> {
     type Config = &'a SeggerRttMemory<'a>;
 
-    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write {
+    fn create_panic_writer(
+        config: Self::Config,
+        _panic: &core::panic::PanicInfo,
+    ) -> impl IoWrite + core::fmt::Write {
         RttPanicWriter { inner: config }
     }
 }

--- a/chips/sifive/src/uart.rs
+++ b/chips/sifive/src/uart.rs
@@ -491,7 +491,10 @@ pub struct UartPanicWriterConfig {
 impl kernel::platform::chip::PanicWriter for Uart<'_> {
     type Config = UartPanicWriterConfig;
 
-    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write {
+    fn create_panic_writer(
+        config: Self::Config,
+        _panic: &core::panic::PanicInfo,
+    ) -> impl IoWrite + core::fmt::Write {
         use kernel::hil::uart::Configure as _;
 
         let uart = Uart::new(config.registers, config.clock_frequency);

--- a/chips/stm32u5xx/src/usart.rs
+++ b/chips/stm32u5xx/src/usart.rs
@@ -519,7 +519,10 @@ pub struct UsartPanicWriterConfig {
 
 impl PanicWriter for Usart<'_> {
     type Config = UsartPanicWriterConfig;
-    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write {
+    fn create_panic_writer(
+        config: Self::Config,
+        _panic: &core::panic::PanicInfo,
+    ) -> impl IoWrite + core::fmt::Write {
         let writer = UsartPanicWriter {
             registers: config.base,
         };

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -165,7 +165,7 @@ pub unsafe fn panic_print<PW: PanicWriter, C: Chip, PP: ProcessPrinter>(
 ) {
     unsafe {
         // Create the synchronous writer we can use to output the panic message.
-        let mut writer = PW::create_panic_writer(writer_config);
+        let mut writer = PW::create_panic_writer(writer_config, panic_info);
 
         panic_begin(nop);
         // Flush debug buffer if needed

--- a/kernel/src/platform/chip.rs
+++ b/kernel/src/platform/chip.rs
@@ -8,6 +8,7 @@ use crate::platform::mpu;
 use crate::syscall;
 use crate::utilities::io_write::IoWrite;
 use core::fmt::Write;
+use core::panic::PanicInfo;
 
 /// Interface for individual MCUs.
 ///
@@ -218,5 +219,12 @@ pub trait PanicWriter {
     ///
     /// The writer must implement [`IoWrite`] (which is just `std:io::Write`
     /// implemented for no_std).
-    unsafe fn create_panic_writer(config: Self::Config) -> impl IoWrite + core::fmt::Write;
+    ///
+    /// This function requires a [`PanicInfo`] reference, but the implementation
+    /// should not use it. This only enforces that this function is only called
+    /// from a panic context and not during normal operation.
+    fn create_panic_writer(
+        config: Self::Config,
+        _panic: &PanicInfo,
+    ) -> impl IoWrite + core::fmt::Write;
 }


### PR DESCRIPTION


### Pull Request Overview

Rather than have the requirement that the `create_panic_writer()` constructor is only called in a panic context be a safety requirement, enforce that invariant by requiring the function to need a `PanicInfo` reference. The `PanicInfo` type has no public constructor and can only be created by the language at panic, enforcing that invariant.

This updates the type signature and removes `unsafe` for the implementations of this trait.


### Testing Strategy

CI


### TODO or Help Wanted

This assumes that "only called in a panic context" is the safety requirement for the `unsafe` on this function.


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
