### PR TITLE
kernel: process std: remove `grant_ptrs_reset()` API (which was unsafe)

### DIFF
--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -816,8 +816,14 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
             tasks.empty();
         });
 
-        // Clear any grant regions this app has setup with any capsules.
-        self.grant_ptrs_reset();
+        // Clear any grant regions this app has setup with any capsules by
+        // setting all `grant_ptr`s to NULL.
+        self.grant_pointers.map(|grant_pointers| {
+            for grant_entry in grant_pointers.iter_mut() {
+                grant_entry.driver_num = 0;
+                grant_entry.grant_ptr = ptr::null_mut();
+            }
+        });
 
         // Save the completion code.
         self.completion_code.set(completion_code);
@@ -2510,16 +2516,6 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
         buf_end_addr >= buf_start_addr
             && buf_start_addr >= self.flash_non_protected_start()
             && buf_end_addr <= self.flash_end()
-    }
-
-    /// Reset all `grant_ptr`s to NULL.
-    fn grant_ptrs_reset(&self) {
-        self.grant_pointers.map(|grant_pointers| {
-            for grant_entry in grant_pointers.iter_mut() {
-                grant_entry.driver_num = 0;
-                grant_entry.grant_ptr = ptr::null_mut();
-            }
-        });
     }
 
     /// Allocate memory in a process's grant region.

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -817,9 +817,7 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
         });
 
         // Clear any grant regions this app has setup with any capsules.
-        unsafe {
-            self.grant_ptrs_reset();
-        }
+        self.grant_ptrs_reset();
 
         // Save the completion code.
         self.completion_code.set(completion_code);
@@ -2515,7 +2513,7 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
     }
 
     /// Reset all `grant_ptr`s to NULL.
-    unsafe fn grant_ptrs_reset(&self) {
+    fn grant_ptrs_reset(&self) {
         self.grant_pointers.map(|grant_pointers| {
             for grant_entry in grant_pointers.iter_mut() {
                 grant_entry.driver_num = 0;


### PR DESCRIPTION


### Pull Request Overview

This does not require any unsafe operations, and all it does is iterate a slice and reset a number and pointer.

I can't think of any reason this would be memory unsafe.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
