### PR TITLE
kernel: process std: brk safety comment

### DIFF
--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -1012,6 +1012,14 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
                     //    process-accessible memory region through the process
                     //    buffer infrastructure.
                     let old_break_mut_ptr: *mut u8 = old_break.cast_mut();
+                    // SAFETY: We know this will write to only process-accessible memory
+                    // that has never been used to create any kernel data structures
+                    // because of the checks at the beginning of this function. We also
+                    // know this is valid memory to write to. Because we are using `u8`,
+                    // we know `old_break_mut_ptr` is aligned. Since the process will
+                    // have access to this memory we know the kernel will not try to use
+                    // it for any data structures, avoiding any potential future memory
+                    // initialization error.
                     unsafe {
                         core::ptr::write_bytes(
                             old_break_mut_ptr,

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -1015,10 +1015,11 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
                     // SAFETY: We know this will write to only process-accessible memory
                     // that has never been used to create any kernel data structures
                     // because of the checks at the beginning of this function. We also
-                    // know this is valid memory to write to. Because we are using `u8`,
-                    // we know `old_break_mut_ptr` is aligned. Since the process will
-                    // have access to this memory we know the kernel will not try to use
-                    // it for any data structures, avoiding any potential future memory
+                    // know this is valid memory to write to because we checked the
+                    // new_break is within process memory. Because we are using `u8`, we
+                    // know `old_break_mut_ptr` is aligned. Since the process will have
+                    // access to this memory we know the kernel will not try to use it
+                    // for any data structures, avoiding any potential future memory
                     // initialization error.
                     unsafe {
                         core::ptr::write_bytes(


### PR DESCRIPTION
### Pull Request Overview

Write a safety comment for the unsafe zeroing write when a process calls sbrk.


### Testing Strategy

doc


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
