### PR TITLE
kernel: process std: document UKB unsafe blocks

### DIFF
--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -1417,21 +1417,25 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
     }
 
     fn set_syscall_return_value(&self, return_value: SyscallReturn) {
-        match self.stored_state.map(|stored_state| unsafe {
+        match self.stored_state.map(|stored_state| {
             // Actually set the return value for a particular process.
             //
-            // The UKB implementation uses the bounds of process-accessible
-            // memory to verify that any memory changes are valid. Here, the
-            // unsafe promise we are making is that the bounds passed to the UKB
-            // are correct.
-            self.chip
-                .userspace_kernel_boundary()
-                .set_syscall_return_value(
-                    self.mem_start(),
-                    self.app_break.get(),
-                    stored_state,
-                    return_value,
-                )
+            // SAFETY: The UKB implementation uses the bounds of
+            // process-accessible memory to verify that any memory changes are
+            // valid. Here, the unsafe promise we are making is that the bounds
+            // passed to the UKB are correct. Because we use the start of the
+            // process's memory, and the current `app_break`, we know that the
+            // memory in that range is accessible to the process.
+            unsafe {
+                self.chip
+                    .userspace_kernel_boundary()
+                    .set_syscall_return_value(
+                        self.mem_start(),
+                        self.app_break.get(),
+                        stored_state,
+                        return_value,
+                    )
+            }
         }) {
             Some(Ok(())) => {
                 // If we get an `Ok` we are all set.
@@ -1472,9 +1476,13 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
         // remaining.
         match self.stored_state.map(|stored_state| {
             // Let the UKB implementation handle setting the process's PC so
-            // that the process executes the upcall function. We encapsulate
-            // unsafe here because we are guaranteeing that the memory bounds
-            // passed to `set_process_function` are correct.
+            // that the process executes the upcall function.
+            //
+            // SAFETY: We encapsulate unsafe here because we are guaranteeing
+            // that the memory bounds passed to `set_process_function` are
+            // correct. We know this because we use the start of process memory
+            // and the current `app_break`, and that range is accessible to the
+            // process.
             unsafe {
                 self.chip.userspace_kernel_boundary().set_process_function(
                     self.mem_start(),
@@ -1518,9 +1526,13 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
 
         let (switch_reason, stack_pointer) =
             self.stored_state.map_or((None, None), |stored_state| {
-                // Switch to the process. We guarantee that the memory pointers
-                // we pass are valid, ensuring this context switch is safe.
-                // Therefore we encapsulate the `unsafe`.
+                // Switch to the process.
+                //
+                // SAFETY: We guarantee that the memory pointers we pass are valid,
+                // ensuring this context switch is safe. We know this because we use
+                // the start of process memory and the current `app_break`, and that
+                // range is accessible to the process. Therefore we encapsulate the
+                // `unsafe`.
                 unsafe {
                     let (switch_reason, optional_stack_pointer) = self
                         .chip
@@ -1597,8 +1609,10 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
         }
 
         self.stored_state.map(|stored_state| {
-            // We guarantee the memory bounds pointers provided to the UKB are
-            // correct.
+            // SAFETY: We guarantee the memory bounds pointers provided to the
+            // UKB are correct. We know this because we use the start of process
+            // memory and the current `app_break`, and that range is accessible
+            // to the process.
             unsafe {
                 self.chip.userspace_kernel_boundary().print_context(
                     self.mem_start(),
@@ -2426,12 +2440,18 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
 
         // Handle any architecture-specific requirements for a process when it
         // first starts (as it would when it is new).
-        let ukb_init_process = self.stored_state.map_or(Err(()), |stored_state| unsafe {
-            self.chip.userspace_kernel_boundary().initialize_process(
-                app_mpu_mem_start,
-                app_brk,
-                stored_state,
-            )
+        let ukb_init_process = self.stored_state.map_or(Err(()), |stored_state| {
+            // SAFETY: The memory bounds must be valid for this process. We know
+            // this is true here because we use the start of process memory and
+            // the current `app_brk`, and that range is accessible to the
+            // process.
+            unsafe {
+                self.chip.userspace_kernel_boundary().initialize_process(
+                    app_mpu_mem_start,
+                    app_brk,
+                    stored_state,
+                )
+            }
         });
         match ukb_init_process {
             Ok(()) => {}


### PR DESCRIPTION
### Pull Request Overview
We have to ensure the range we are giving to the MPU is valid memory for the process. We always confirm that in the code, this just documents that we do that.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
