### PR TITLE
kernel: proc std: safety doc for `init_fn` capability ptr

### DIFF
--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -2457,16 +2457,20 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
         let init_addr =
             flash_start.wrapping_add(self.header.get_init_function_offset() as usize) as usize;
 
-        // We need to construct a capability with sufficient authority to cover all of a user's
-        // code, with permissions to execute it. The entirety of flash is sufficient.
-
-        // SAFETY: It must be safe for a process to use the a pointer in the
-        // given memory range for the given permission. We use the process's
-        // flash region as the bounds, ensuring the pointer is contained to this
-        // new process. The capability pointer is only specified with execute
-        // permissions, and it is safe for the process to execute anywhere in
-        // its flash region. If `init_addr` is not actually within the range
-        // then this does not provide authority to dereference the pointer.
+        // We need to construct a capability with sufficient authority to cover
+        // all of a user's code, with permissions to execute it. The entirety
+        // of this process's flash is sufficient.
+        //
+        // SAFETY: It must be safe for this process to access the
+        // bounds+permission expressed here while assuming no other protection
+        // mechanism is active.
+        //  - It is valid under Tock's threat model for a process to try to
+        //  execute anything within process-owned flash.
+        //  - `self.flash` which we use to derive the bounds is defined as
+        //  process-owned flash for a well-formed process, which we trust is
+        //  the case here.
+        //  - We grant only execute permission.
+        //  - We only pass this pointer to this process.
         let init_fn = unsafe {
             CapabilityPtr::new_with_authority(
                 init_addr as *const (),

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -2460,6 +2460,13 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
         // We need to construct a capability with sufficient authority to cover all of a user's
         // code, with permissions to execute it. The entirety of flash is sufficient.
 
+        // SAFETY: It must be safe for a process to use the a pointer in the
+        // given memory range for the given permission. We use the process's
+        // flash region as the bounds, ensuring the pointer is contained to this
+        // new process. The capability pointer is only specified with execute
+        // permissions, and it is safe for the process to execute anywhere in
+        // its flash region. If `init_addr` is not actually within the range
+        // then this does not provide authority to dereference the pointer.
         let init_fn = unsafe {
             CapabilityPtr::new_with_authority(
                 init_addr as *const (),

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -1024,8 +1024,14 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
 
                 let base = self.mem_start() as usize;
                 let old_break_unit_ptr: *const () = old_break.cast();
-                // SAFETY: The passed range [base, new_break) exactly matches the process' memory range,
-                // and a process should have RW access to its own memory.
+                // SAFETY: It must be safe for this process to access the
+                // bounds+permission expressed here while assuming no other
+                // protection mechanism is active.
+                //  - A process should have Read+Write access to its memory.
+                //  - The function has established [base, new_break) as the
+                //    (new) valid bounds for process memory.
+                //  - We grant only Read+Write permissions.
+                //  - We only pass this pointer to this process.
                 let break_result = unsafe {
                     CapabilityPtr::new_with_authority(
                         old_break_unit_ptr,
@@ -2276,11 +2282,19 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
         let fn_len = process.flash.len();
 
         // We need to construct a capability with sufficient authority to cover
-        // all of a user's code, with permissions to execute it. The entirety of
-        // flash is sufficient.
+        // all of a user's code, with permissions to execute it. The entirety
+        // of this process's flash is sufficient.
         //
-        // SAFETY: TODO? I don't understand the `new_with_authority()` safety block as
-        // it doesn't define what the caller must do.
+        // SAFETY: It must be safe for this process to access the
+        // bounds+permission expressed here while assuming no other protection
+        // mechanism is active.
+        //  - It is valid under Tock's threat model for a process to try to
+        //  execute anything within process-owned flash.
+        //  - `process.flash` which we use to derive the bounds is defined as
+        //  process-owned flash for a well-formed process, which we trust is
+        //  the case here.
+        //  - We grant only execute permission.
+        //  - We only pass this pointer to this process.
         let init_fn = unsafe {
             CapabilityPtr::new_with_authority(
                 init_addr as *const (),

--- a/kernel/src/utilities/capability_ptr.rs
+++ b/kernel/src/utilities/capability_ptr.rs
@@ -108,23 +108,38 @@ impl CapabilityPtr {
         self.ptr.cast()
     }
 
-    /// Construct a [`CapabilityPtr`] from a raw pointer, with authority ranging over
-    /// [`base`, `base + length`) and permissions `perms`.
+    /// Construct a [`CapabilityPtr`] from a raw pointer, with authority
+    /// ranging over [`base`, `base + length`) and permissions `perms`.
     ///
-    /// Provenance note: may derive from a pointer other than the input to provide something with
-    /// valid provenance to justify the other arguments.
+    /// [`CapabilityPtr`]s can be the sole memory isolation primitive in the
+    /// system, thus great care must be taken with this method, as errors can
+    /// break Tock's isolation model.
+    ///
+    /// Provenance note: may derive from a pointer other than the input to
+    /// provide something with valid provenance to justify the other arguments.
     ///
     /// # Safety
     ///
-    /// Constructing a [`CapabilityPtr`] with metadata may convey authority to
-    /// dereference this pointer, such as in userspace. When these pointers
-    /// serve as the only memory isolation primitive in the system, this method
-    /// can thus break Tock's isolation model. As semi-trusted kernel code can
-    /// name this type and method, it is thus marked as `unsafe`.
+    /// NOTE: Hardware capability support is **experimental** in Tock. The
+    /// intent of this type is to capture semantics general to any hardware
+    /// capability implementation, however, there is no upstream support for
+    /// any such hardware today. As such, the exact safety conditions may
+    /// change in the future.
     ///
-    // TODO: Once Tock supports hardware that uses the [`CapabilityPtr`]'s
-    // metdata to convey authority, this comment should incorporate the exact
-    // safety conditions of this function.
+    /// Callers are responsible for ensuring that the authority conveyed by this
+    /// pointer does not violate Tock's isolation model, under an assumption
+    /// that hardware capabilities are the sole memory isolation mechanism.
+    ///
+    /// Authority is conveyed solely by the `base`, `length`, and `perms`.
+    /// The value in `ptr` may be freely changed by untrusted code. When
+    /// executing on a platform with hardware capability enforcement, callers
+    /// may assume that on any attempt to use `ptr`, hardware will verify that:
+    ///   - `ptr` is within the bounds [`base`, `base + length`).
+    ///   - The access type is allowed by `perms`.
+    ///
+    /// Callers are responsible for restricting access to this pointer, i.e.,
+    /// ensuring that a pointer which allows access to process memory is only
+    /// given to the *correct* process.
     #[inline]
     pub unsafe fn new_with_authority(
         ptr: *const (),


### PR DESCRIPTION
### Pull Request Overview

I did my best to document why this is safe, which basically boils down to the range given to the `new_with_authority()` call matches the process's flash region. However, the capability pointer documentation is very sparse, and I'm just inferring that is what makes this safe in all cases. In the normal case we have the MPU that ensures this is safe.


### Testing Strategy

CI


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
