### PR TITLE
kernel: process standard: create() safety doc

### DIFF
--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -1728,6 +1728,12 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
     const PROCESS_STRUCT_ALIGNMENT: usize = mem::align_of::<ProcessStandard<C, D>>();
 
     /// Create a `ProcessStandard` object based on the found `ProcessBinary`.
+    ///
+    /// # Safety
+    ///
+    /// This function allocates memory from `remaining_memory` for use by the
+    /// process. There must not be any references to or other uses of
+    /// `remaining_memory` when calling this function.
     pub(crate) unsafe fn create(
         kernel: &'static Kernel,
         chip: &'static C,


### PR DESCRIPTION
### Pull Request Overview

Add the safety doc for our process create function.

There isn't much that I think we need. However, I do think we need to ensure the memory we are allocating the PCB in isn't used elsewhere. Otherwise, I think we are ok.


### Testing Strategy

n/a


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
