### PR TITLE
x86: format asm code

### DIFF
--- a/arch/x86/src/boundary/return_from_user.rs
+++ b/arch/x86/src/boundary/return_from_user.rs
@@ -40,62 +40,62 @@ use core::arch::naked_asm;
 pub extern "C" fn return_from_user() {
     naked_asm!(
         "
-        mov     ecx, dword ptr [esp+76]       # UserContext
+    mov     ecx, dword ptr [esp+76]       # UserContext
 
-        # First switch back to the kernel's data segment. Once this is done, we are safe to start
-        # storing things in UserContext.
-        mov     eax, ds
-        mov     edx, [esp+52]
-        mov     ds, edx
-        mov     dword ptr [ecx+48], eax
+    # First switch back to the kernel's data segment. Once this is done, we are safe to start
+    # storing things in UserContext.
+    mov     eax, ds
+    mov     edx, [esp+52]
+    mov     ds, edx
+    mov     dword ptr [ecx+48], eax
 
-        # Store the remaining general purpose registers
-        mov     dword ptr [ecx+4], ebx
-        mov     dword ptr [ecx+16], esi
-        mov     dword ptr [ecx+20], edi
-        mov     dword ptr [ecx+24], ebp
+    # Store the remaining general purpose registers
+    mov     dword ptr [ecx+4], ebx
+    mov     dword ptr [ecx+16], esi
+    mov     dword ptr [ecx+20], edi
+    mov     dword ptr [ecx+24], ebp
 
-        # Store segment selectors
-        mov     eax, es
-        mov     dword ptr [ecx+52], eax
-        mov     eax, fs
-        mov     dword ptr [ecx+56], eax
-        mov     eax, gs
-        mov     dword ptr [ecx+60], eax
+    # Store segment selectors
+    mov     eax, es
+    mov     dword ptr [ecx+52], eax
+    mov     eax, fs
+    mov     dword ptr [ecx+56], eax
+    mov     eax, gs
+    mov     dword ptr [ecx+60], eax
 
-        mov     edx, dword ptr [esp+80]       # Load error code pointer
+    mov     edx, dword ptr [esp+80]       # Load error code pointer
 
-        # Then unwind the stack
-        pop     dword ptr [ecx+12]             # EDX
-        pop     dword ptr [ecx+8]              # ECX
-        pop     dword ptr [ecx]                # EAX
-        pop     eax                            # Interrupt number (returned in EAX)
-        pop     dword ptr [edx]                # Error code
-        pop     dword ptr [ecx+32]             # EIP
-        pop     dword ptr [ecx+40]             # CS
-        pop     dword ptr [ecx+36]             # EFLAGS
-        pop     dword ptr [ecx+28]             # ESP
-        pop     dword ptr [ecx+44]             # SS
+    # Then unwind the stack
+    pop     dword ptr [ecx+12]             # EDX
+    pop     dword ptr [ecx+8]              # ECX
+    pop     dword ptr [ecx]                # EAX
+    pop     eax                            # Interrupt number (returned in EAX)
+    pop     dword ptr [edx]                # Error code
+    pop     dword ptr [ecx+32]             # EIP
+    pop     dword ptr [ecx+40]             # CS
+    pop     dword ptr [ecx+36]             # EFLAGS
+    pop     dword ptr [ecx+28]             # ESP
+    pop     dword ptr [ecx+44]             # SS
 
-        # Manually pop 16-bit segment registers. Using a real pop instruction seems to have
-        # inconsistent behavior (some of the registers move the stack by 2 bytes, others by 4).
-        mov     gs, [esp]
-        add     esp, 4
-        mov     fs, [esp]
-        add     esp, 4
-        mov     es, [esp]
-        add     esp, 4
-        # Already restored DS above, so we only need to increment ESP
-        add     esp, 4
+    # Manually pop 16-bit segment registers. Using a real pop instruction seems to have
+    # inconsistent behavior (some of the registers move the stack by 2 bytes, others by 4).
+    mov     gs, [esp]
+    add     esp, 4
+    mov     fs, [esp]
+    add     esp, 4
+    mov     es, [esp]
+    add     esp, 4
+    # Already restored DS above, so we only need to increment ESP
+    add     esp, 4
 
-        # Restore remaining kernel-mode CPU state
-        pop     ebx
-        pop     ebp
-        pop     esi
-        pop     edi
+    # Restore remaining kernel-mode CPU state
+    pop     ebx
+    pop     ebp
+    pop     esi
+    pop     edi
 
-        # Return to whoever called switch_to_user
-        ret
-"
+    # Return to whoever called switch_to_user
+    ret
+        "
     );
 }

--- a/arch/x86/src/boundary/switch_to_user.rs
+++ b/arch/x86/src/boundary/switch_to_user.rs
@@ -92,6 +92,7 @@ pub extern "C" fn switch_to_user() {
     # Now restore EAX from the stack
     pop     eax
 
-    iretd"
+    iretd
+        "
     );
 }

--- a/arch/x86/src/interrupts/handler_entry.rs
+++ b/arch/x86/src/interrupts/handler_entry.rs
@@ -83,7 +83,6 @@ pub extern "C" fn handler_entry() {
     # handle_kernel_exception should never return, but just in case...
 3:
     jmp     3b
-
-"
+        "
     );
 }

--- a/arch/x86/src/interrupts/handler_stubs.rs
+++ b/arch/x86/src/interrupts/handler_stubs.rs
@@ -15,1277 +15,1277 @@ global_asm!(
 .align 16
 .global handler_stub_0
 handler_stub_0:
-  push 0
-  push 0
-  jmp handler_entry
+    push 0
+    push 0
+    jmp handler_entry
 
 .align 16
 .global handler_stub_1
 handler_stub_1:
-  push 0
-  push 1
-  jmp handler_entry
+    push 0
+    push 1
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 2
-  jmp handler_entry
+    push 0
+    push 2
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 3
-  jmp handler_entry
+    push 0
+    push 3
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 4
-  jmp handler_entry
+    push 0
+    push 4
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 5
-  jmp handler_entry
+    push 0
+    push 5
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 6
-  jmp handler_entry
+    push 0
+    push 6
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 7
-  jmp handler_entry
+    push 0
+    push 7
+    jmp handler_entry
 
 .align 16
-  push 8
-  jmp handler_entry
+    push 8
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 9
-  jmp handler_entry
+    push 0
+    push 9
+    jmp handler_entry
 
 .align 16
-  push 10
-  jmp handler_entry
+    push 10
+    jmp handler_entry
 
 .align 16
-  push 11
-  jmp handler_entry
+    push 11
+    jmp handler_entry
 
 .align 16
-  push 12
-  jmp handler_entry
+    push 12
+    jmp handler_entry
 
 .align 16
-  push 13
-  jmp handler_entry
+    push 13
+    jmp handler_entry
 
 .align 16
-  push 14
-  jmp handler_entry
+    push 14
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 15
-  jmp handler_entry
+    push 0
+    push 15
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 16
-  jmp handler_entry
+    push 0
+    push 16
+    jmp handler_entry
 
 .align 16
-  push 17
-  jmp handler_entry
+    push 17
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 18
-  jmp handler_entry
+    push 0
+    push 18
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 19
-  jmp handler_entry
+    push 0
+    push 19
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 20
-  jmp handler_entry
+    push 0
+    push 20
+    jmp handler_entry
 
 .align 16
-  push 21
-  jmp handler_entry
+    push 21
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 22
-  jmp handler_entry
+    push 0
+    push 22
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 23
-  jmp handler_entry
+    push 0
+    push 23
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 24
-  jmp handler_entry
+    push 0
+    push 24
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 25
-  jmp handler_entry
+    push 0
+    push 25
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 26
-  jmp handler_entry
+    push 0
+    push 26
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 27
-  jmp handler_entry
+    push 0
+    push 27
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 28
-  jmp handler_entry
+    push 0
+    push 28
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 29
-  jmp handler_entry
+    push 0
+    push 29
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 30
-  jmp handler_entry
+    push 0
+    push 30
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 31
-  jmp handler_entry
+    push 0
+    push 31
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 32
-  jmp handler_entry
+    push 0
+    push 32
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 33
-  jmp handler_entry
+    push 0
+    push 33
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 34
-  jmp handler_entry
+    push 0
+    push 34
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 35
-  jmp handler_entry
+    push 0
+    push 35
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 36
-  jmp handler_entry
+    push 0
+    push 36
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 37
-  jmp handler_entry
+    push 0
+    push 37
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 38
-  jmp handler_entry
+    push 0
+    push 38
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 39
-  jmp handler_entry
+    push 0
+    push 39
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 40
-  jmp handler_entry
+    push 0
+    push 40
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 41
-  jmp handler_entry
+    push 0
+    push 41
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 42
-  jmp handler_entry
+    push 0
+    push 42
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 43
-  jmp handler_entry
+    push 0
+    push 43
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 44
-  jmp handler_entry
+    push 0
+    push 44
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 45
-  jmp handler_entry
+    push 0
+    push 45
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 46
-  jmp handler_entry
+    push 0
+    push 46
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 47
-  jmp handler_entry
+    push 0
+    push 47
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 48
-  jmp handler_entry
+    push 0
+    push 48
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 49
-  jmp handler_entry
+    push 0
+    push 49
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 50
-  jmp handler_entry
+    push 0
+    push 50
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 51
-  jmp handler_entry
+    push 0
+    push 51
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 52
-  jmp handler_entry
+    push 0
+    push 52
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 53
-  jmp handler_entry
+    push 0
+    push 53
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 54
-  jmp handler_entry
+    push 0
+    push 54
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 55
-  jmp handler_entry
+    push 0
+    push 55
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 56
-  jmp handler_entry
+    push 0
+    push 56
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 57
-  jmp handler_entry
+    push 0
+    push 57
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 58
-  jmp handler_entry
+    push 0
+    push 58
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 59
-  jmp handler_entry
+    push 0
+    push 59
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 60
-  jmp handler_entry
+    push 0
+    push 60
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 61
-  jmp handler_entry
+    push 0
+    push 61
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 62
-  jmp handler_entry
+    push 0
+    push 62
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 63
-  jmp handler_entry
+    push 0
+    push 63
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 64
-  jmp handler_entry
+    push 0
+    push 64
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 65
-  jmp handler_entry
+    push 0
+    push 65
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 66
-  jmp handler_entry
+    push 0
+    push 66
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 67
-  jmp handler_entry
+    push 0
+    push 67
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 68
-  jmp handler_entry
+    push 0
+    push 68
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 69
-  jmp handler_entry
+    push 0
+    push 69
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 70
-  jmp handler_entry
+    push 0
+    push 70
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 71
-  jmp handler_entry
+    push 0
+    push 71
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 72
-  jmp handler_entry
+    push 0
+    push 72
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 73
-  jmp handler_entry
+    push 0
+    push 73
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 74
-  jmp handler_entry
+    push 0
+    push 74
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 75
-  jmp handler_entry
+    push 0
+    push 75
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 76
-  jmp handler_entry
+    push 0
+    push 76
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 77
-  jmp handler_entry
+    push 0
+    push 77
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 78
-  jmp handler_entry
+    push 0
+    push 78
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 79
-  jmp handler_entry
+    push 0
+    push 79
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 80
-  jmp handler_entry
+    push 0
+    push 80
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 81
-  jmp handler_entry
+    push 0
+    push 81
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 82
-  jmp handler_entry
+    push 0
+    push 82
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 83
-  jmp handler_entry
+    push 0
+    push 83
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 84
-  jmp handler_entry
+    push 0
+    push 84
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 85
-  jmp handler_entry
+    push 0
+    push 85
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 86
-  jmp handler_entry
+    push 0
+    push 86
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 87
-  jmp handler_entry
+    push 0
+    push 87
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 88
-  jmp handler_entry
+    push 0
+    push 88
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 89
-  jmp handler_entry
+    push 0
+    push 89
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 90
-  jmp handler_entry
+    push 0
+    push 90
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 91
-  jmp handler_entry
+    push 0
+    push 91
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 92
-  jmp handler_entry
+    push 0
+    push 92
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 93
-  jmp handler_entry
+    push 0
+    push 93
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 94
-  jmp handler_entry
+    push 0
+    push 94
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 95
-  jmp handler_entry
+    push 0
+    push 95
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 96
-  jmp handler_entry
+    push 0
+    push 96
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 97
-  jmp handler_entry
+    push 0
+    push 97
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 98
-  jmp handler_entry
+    push 0
+    push 98
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 99
-  jmp handler_entry
+    push 0
+    push 99
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 100
-  jmp handler_entry
+    push 0
+    push 100
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 101
-  jmp handler_entry
+    push 0
+    push 101
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 102
-  jmp handler_entry
+    push 0
+    push 102
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 103
-  jmp handler_entry
+    push 0
+    push 103
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 104
-  jmp handler_entry
+    push 0
+    push 104
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 105
-  jmp handler_entry
+    push 0
+    push 105
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 106
-  jmp handler_entry
+    push 0
+    push 106
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 107
-  jmp handler_entry
+    push 0
+    push 107
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 108
-  jmp handler_entry
+    push 0
+    push 108
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 109
-  jmp handler_entry
+    push 0
+    push 109
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 110
-  jmp handler_entry
+    push 0
+    push 110
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 111
-  jmp handler_entry
+    push 0
+    push 111
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 112
-  jmp handler_entry
+    push 0
+    push 112
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 113
-  jmp handler_entry
+    push 0
+    push 113
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 114
-  jmp handler_entry
+    push 0
+    push 114
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 115
-  jmp handler_entry
+    push 0
+    push 115
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 116
-  jmp handler_entry
+    push 0
+    push 116
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 117
-  jmp handler_entry
+    push 0
+    push 117
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 118
-  jmp handler_entry
+    push 0
+    push 118
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 119
-  jmp handler_entry
+    push 0
+    push 119
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 120
-  jmp handler_entry
+    push 0
+    push 120
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 121
-  jmp handler_entry
+    push 0
+    push 121
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 122
-  jmp handler_entry
+    push 0
+    push 122
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 123
-  jmp handler_entry
+    push 0
+    push 123
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 124
-  jmp handler_entry
+    push 0
+    push 124
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 125
-  jmp handler_entry
+    push 0
+    push 125
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 126
-  jmp handler_entry
+    push 0
+    push 126
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 127
-  jmp handler_entry
+    push 0
+    push 127
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 128
-  jmp handler_entry
+    push 0
+    push 128
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 129
-  jmp handler_entry
+    push 0
+    push 129
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 130
-  jmp handler_entry
+    push 0
+    push 130
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 131
-  jmp handler_entry
+    push 0
+    push 131
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 132
-  jmp handler_entry
+    push 0
+    push 132
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 133
-  jmp handler_entry
+    push 0
+    push 133
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 134
-  jmp handler_entry
+    push 0
+    push 134
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 135
-  jmp handler_entry
+    push 0
+    push 135
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 136
-  jmp handler_entry
+    push 0
+    push 136
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 137
-  jmp handler_entry
+    push 0
+    push 137
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 138
-  jmp handler_entry
+    push 0
+    push 138
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 139
-  jmp handler_entry
+    push 0
+    push 139
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 140
-  jmp handler_entry
+    push 0
+    push 140
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 141
-  jmp handler_entry
+    push 0
+    push 141
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 142
-  jmp handler_entry
+    push 0
+    push 142
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 143
-  jmp handler_entry
+    push 0
+    push 143
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 144
-  jmp handler_entry
+    push 0
+    push 144
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 145
-  jmp handler_entry
+    push 0
+    push 145
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 146
-  jmp handler_entry
+    push 0
+    push 146
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 147
-  jmp handler_entry
+    push 0
+    push 147
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 148
-  jmp handler_entry
+    push 0
+    push 148
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 149
-  jmp handler_entry
+    push 0
+    push 149
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 150
-  jmp handler_entry
+    push 0
+    push 150
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 151
-  jmp handler_entry
+    push 0
+    push 151
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 152
-  jmp handler_entry
+    push 0
+    push 152
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 153
-  jmp handler_entry
+    push 0
+    push 153
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 154
-  jmp handler_entry
+    push 0
+    push 154
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 155
-  jmp handler_entry
+    push 0
+    push 155
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 156
-  jmp handler_entry
+    push 0
+    push 156
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 157
-  jmp handler_entry
+    push 0
+    push 157
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 158
-  jmp handler_entry
+    push 0
+    push 158
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 159
-  jmp handler_entry
+    push 0
+    push 159
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 160
-  jmp handler_entry
+    push 0
+    push 160
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 161
-  jmp handler_entry
+    push 0
+    push 161
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 162
-  jmp handler_entry
+    push 0
+    push 162
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 163
-  jmp handler_entry
+    push 0
+    push 163
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 164
-  jmp handler_entry
+    push 0
+    push 164
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 165
-  jmp handler_entry
+    push 0
+    push 165
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 166
-  jmp handler_entry
+    push 0
+    push 166
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 167
-  jmp handler_entry
+    push 0
+    push 167
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 168
-  jmp handler_entry
+    push 0
+    push 168
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 169
-  jmp handler_entry
+    push 0
+    push 169
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 170
-  jmp handler_entry
+    push 0
+    push 170
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 171
-  jmp handler_entry
+    push 0
+    push 171
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 172
-  jmp handler_entry
+    push 0
+    push 172
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 173
-  jmp handler_entry
+    push 0
+    push 173
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 174
-  jmp handler_entry
+    push 0
+    push 174
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 175
-  jmp handler_entry
+    push 0
+    push 175
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 176
-  jmp handler_entry
+    push 0
+    push 176
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 177
-  jmp handler_entry
+    push 0
+    push 177
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 178
-  jmp handler_entry
+    push 0
+    push 178
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 179
-  jmp handler_entry
+    push 0
+    push 179
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 180
-  jmp handler_entry
+    push 0
+    push 180
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 181
-  jmp handler_entry
+    push 0
+    push 181
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 182
-  jmp handler_entry
+    push 0
+    push 182
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 183
-  jmp handler_entry
+    push 0
+    push 183
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 184
-  jmp handler_entry
+    push 0
+    push 184
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 185
-  jmp handler_entry
+    push 0
+    push 185
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 186
-  jmp handler_entry
+    push 0
+    push 186
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 187
-  jmp handler_entry
+    push 0
+    push 187
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 188
-  jmp handler_entry
+    push 0
+    push 188
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 189
-  jmp handler_entry
+    push 0
+    push 189
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 190
-  jmp handler_entry
+    push 0
+    push 190
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 191
-  jmp handler_entry
+    push 0
+    push 191
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 192
-  jmp handler_entry
+    push 0
+    push 192
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 193
-  jmp handler_entry
+    push 0
+    push 193
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 194
-  jmp handler_entry
+    push 0
+    push 194
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 195
-  jmp handler_entry
+    push 0
+    push 195
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 196
-  jmp handler_entry
+    push 0
+    push 196
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 197
-  jmp handler_entry
+    push 0
+    push 197
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 198
-  jmp handler_entry
+    push 0
+    push 198
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 199
-  jmp handler_entry
+    push 0
+    push 199
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 200
-  jmp handler_entry
+    push 0
+    push 200
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 201
-  jmp handler_entry
+    push 0
+    push 201
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 202
-  jmp handler_entry
+    push 0
+    push 202
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 203
-  jmp handler_entry
+    push 0
+    push 203
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 204
-  jmp handler_entry
+    push 0
+    push 204
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 205
-  jmp handler_entry
+    push 0
+    push 205
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 206
-  jmp handler_entry
+    push 0
+    push 206
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 207
-  jmp handler_entry
+    push 0
+    push 207
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 208
-  jmp handler_entry
+    push 0
+    push 208
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 209
-  jmp handler_entry
+    push 0
+    push 209
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 210
-  jmp handler_entry
+    push 0
+    push 210
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 211
-  jmp handler_entry
+    push 0
+    push 211
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 212
-  jmp handler_entry
+    push 0
+    push 212
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 213
-  jmp handler_entry
+    push 0
+    push 213
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 214
-  jmp handler_entry
+    push 0
+    push 214
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 215
-  jmp handler_entry
+    push 0
+    push 215
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 216
-  jmp handler_entry
+    push 0
+    push 216
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 217
-  jmp handler_entry
+    push 0
+    push 217
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 218
-  jmp handler_entry
+    push 0
+    push 218
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 219
-  jmp handler_entry
+    push 0
+    push 219
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 220
-  jmp handler_entry
+    push 0
+    push 220
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 221
-  jmp handler_entry
+    push 0
+    push 221
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 222
-  jmp handler_entry
+    push 0
+    push 222
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 223
-  jmp handler_entry
+    push 0
+    push 223
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 224
-  jmp handler_entry
+    push 0
+    push 224
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 225
-  jmp handler_entry
+    push 0
+    push 225
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 226
-  jmp handler_entry
+    push 0
+    push 226
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 227
-  jmp handler_entry
+    push 0
+    push 227
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 228
-  jmp handler_entry
+    push 0
+    push 228
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 229
-  jmp handler_entry
+    push 0
+    push 229
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 230
-  jmp handler_entry
+    push 0
+    push 230
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 231
-  jmp handler_entry
+    push 0
+    push 231
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 232
-  jmp handler_entry
+    push 0
+    push 232
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 233
-  jmp handler_entry
+    push 0
+    push 233
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 234
-  jmp handler_entry
+    push 0
+    push 234
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 235
-  jmp handler_entry
+    push 0
+    push 235
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 236
-  jmp handler_entry
+    push 0
+    push 236
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 237
-  jmp handler_entry
+    push 0
+    push 237
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 238
-  jmp handler_entry
+    push 0
+    push 238
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 239
-  jmp handler_entry
+    push 0
+    push 239
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 240
-  jmp handler_entry
+    push 0
+    push 240
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 241
-  jmp handler_entry
+    push 0
+    push 241
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 242
-  jmp handler_entry
+    push 0
+    push 242
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 243
-  jmp handler_entry
+    push 0
+    push 243
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 244
-  jmp handler_entry
+    push 0
+    push 244
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 245
-  jmp handler_entry
+    push 0
+    push 245
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 246
-  jmp handler_entry
+    push 0
+    push 246
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 247
-  jmp handler_entry
+    push 0
+    push 247
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 248
-  jmp handler_entry
+    push 0
+    push 248
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 249
-  jmp handler_entry
+    push 0
+    push 249
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 250
-  jmp handler_entry
+    push 0
+    push 250
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 251
-  jmp handler_entry
+    push 0
+    push 251
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 252
-  jmp handler_entry
+    push 0
+    push 252
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 253
-  jmp handler_entry
+    push 0
+    push 253
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 254
-  jmp handler_entry
+    push 0
+    push 254
+    jmp handler_entry
 
 .align 16
-  push 0
-  push 255
-  jmp handler_entry
-"
+    push 0
+    push 255
+    jmp handler_entry
+    "
 );

--- a/arch/x86/src/registers/bits32/eflags.rs
+++ b/arch/x86/src/registers/bits32/eflags.rs
@@ -78,7 +78,14 @@ impl EFlags {
 pub unsafe fn read() -> EFlags {
     let r: u32;
     unsafe {
-        asm!("pushfl; popl {0}", out(reg) r, options(att_syntax));
+        asm!(
+            "
+    pushfl
+    popl {0}
+            ",
+            out(reg) r,
+            options(att_syntax)
+        );
     }
     EFlags(LocalRegisterCopy::new(r))
 }
@@ -87,7 +94,14 @@ pub unsafe fn read() -> EFlags {
 #[inline(always)]
 pub unsafe fn set(val: EFlags) {
     unsafe {
-        asm!("pushl {0}; popfl", in(reg) val.0.get(), options(att_syntax));
+        asm!(
+            "
+    pushl {0}
+    popfl
+            ",
+            in(reg) val.0.get(),
+            options(att_syntax)
+        );
     }
 }
 

--- a/arch/x86/src/registers/bits32/mod.rs
+++ b/arch/x86/src/registers/bits32/mod.rs
@@ -18,7 +18,15 @@ use core::arch::asm;
 #[inline(always)]
 pub unsafe fn stack_jmp(stack: *mut (), ip: *const ()) -> ! {
     unsafe {
-        asm!("movl {0}, %esp; jmp {1}", in(reg) stack, in(reg) ip, options(att_syntax));
+        asm!(
+            "
+    movl {0}, %esp
+    jmp {1}
+            ",
+            in(reg) stack,
+            in(reg) ip,
+            options(att_syntax)
+        );
     }
 
     unreachable!()

--- a/arch/x86/src/registers/segmentation.rs
+++ b/arch/x86/src/registers/segmentation.rs
@@ -491,10 +491,16 @@ pub unsafe fn load_gs(sel: SegmentSelector) {
 #[cfg(target_arch = "x86")]
 pub unsafe fn load_cs(sel: SegmentSelector) {
     unsafe {
-        asm!("pushl {0}; \
-            pushl $1f; \
-            lretl; \
-            1:", in(reg) sel.bits() as u32, options(att_syntax));
+        asm!(
+            "
+    pushl {0};
+    pushl $1f;
+    lretl;
+    1:
+            ",
+            in(reg) sel.bits() as u32,
+            options(att_syntax)
+        );
     }
 }
 

--- a/arch/x86/src/registers/segmentation.rs
+++ b/arch/x86/src/registers/segmentation.rs
@@ -493,9 +493,9 @@ pub unsafe fn load_cs(sel: SegmentSelector) {
     unsafe {
         asm!(
             "
-    pushl {0};
-    pushl $1f;
-    lretl;
+    pushl {0}
+    pushl $1f
+    lretl
     1:
             ",
             in(reg) sel.bits() as u32,

--- a/arch/x86/src/start.rs
+++ b/arch/x86/src/start.rs
@@ -46,7 +46,6 @@ pub unsafe extern "C" fn initialize_ram_jump_to_main() {
 3:
     hlt
     jmp     3b
-
-"
+        "
     );
 }


### PR DESCRIPTION
### Pull Request Overview

Do a formatting pass over the x86 crate for my unofficial ASM format.

This does not change one-line, single instruction asm blocks as those really don't benefit from this format any most other files leave those as one line asm blocks.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
