### PR TITLE
RFC: Revise how we generate docs to eliminate lots (maybe all) `cfg(doc)`

### DIFF
--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -104,7 +104,7 @@ pub trait CortexMVariant {
     unsafe fn print_cortexm_state(writer: &mut dyn Write);
 }
 
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+#[cfg(all(target_arch = "arm", target_os = "none"))]
 pub unsafe extern "C" fn unhandled_interrupt() {
     use core::arch::asm;
     let mut interrupt_number: u32;
@@ -161,7 +161,7 @@ pub unsafe extern "C" fn unhandled_interrupt() {
 /// We use `initialize_ram_jump_to_main` as a symbol in the linker file. This is
 /// the only user of the name `initialize_ram_jump_to_main` and no other symbol
 /// may use the same name.
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+#[cfg(all(target_arch = "arm", target_os = "none"))]
 #[unsafe(naked)]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn initialize_ram_jump_to_main() {
@@ -416,12 +416,12 @@ pub fn print_cortexm_state(writer: &mut dyn Write) {
 // ARM assembly since it will not compile.
 ///////////////////////////////////////////////////////////////////
 
-#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 pub unsafe extern "C" fn unhandled_interrupt() {
     unimplemented!()
 }
 
-#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 pub unsafe extern "C" fn initialize_ram_jump_to_main() {
     unimplemented!()
 }

--- a/arch/cortex-m/src/scb.rs
+++ b/arch/cortex-m/src/scb.rs
@@ -275,7 +275,7 @@ const SCB: StaticRef<ScbRegisters> = unsafe { StaticRef::new(0xE000ED00 as *cons
 /// Allow the core to go into deep sleep on WFI.
 ///
 /// The specific definition of "deep sleep" is chip specific.
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+#[cfg(all(target_arch = "arm", target_os = "none"))]
 pub unsafe fn set_sleepdeep() {
     use core::arch::asm;
 
@@ -307,7 +307,7 @@ pub unsafe fn set_sleepdeep() {
 }
 
 // Mock implementation for tests on Travis-CI.
-#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 pub unsafe fn set_sleepdeep() {
     // Dummy operation to satisfy the `Writable` trait import on
     // non-ARM platforms.
@@ -338,7 +338,7 @@ pub unsafe fn set_vector_table_offset(offset: *const ()) {
 }
 
 /// Disable the FPU
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+#[cfg(all(target_arch = "arm", target_os = "none"))]
 pub unsafe fn disable_fpca() {
     use core::arch::asm;
     SCB.cpacr
@@ -376,7 +376,7 @@ pub unsafe fn disable_fpca() {
 }
 
 // Mock implementation for tests on Travis-CI.
-#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 pub unsafe fn disable_fpca() {
     // Dummy read register, to satisfy the `Readable` trait import on
     // non-ARM platforms.

--- a/arch/cortex-m/src/support.rs
+++ b/arch/cortex-m/src/support.rs
@@ -7,7 +7,7 @@
 use crate::scb;
 
 /// NOP instruction
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+#[cfg(all(target_arch = "arm", target_os = "none"))]
 #[inline(always)]
 pub fn nop() {
     use core::arch::asm;
@@ -32,7 +32,7 @@ pub fn nop() {
 }
 
 /// WFI instruction
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+#[cfg(all(target_arch = "arm", target_os = "none"))]
 #[inline(always)]
 pub unsafe fn wfi() {
     use core::arch::asm;
@@ -57,7 +57,7 @@ pub unsafe fn wfi() {
 }
 
 /// Single-core critical section operation
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+#[cfg(all(target_arch = "arm", target_os = "none"))]
 pub fn with_interrupts_disabled<F, R>(f: F) -> R
 where
     F: FnOnce() -> R,
@@ -109,19 +109,19 @@ where
 
 /// NOP instruction (mock)
 // Mock implementations for tests on Travis-CI.
-#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 pub fn nop() {
     unimplemented!()
 }
 
 /// WFI instruction (mock)
-#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 pub unsafe fn wfi() {
     unimplemented!()
 }
 
 /// Single-core critical section operation (mock)
-#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 pub fn with_interrupts_disabled<F, R>(_f: F) -> R
 where
     F: FnOnce() -> R,
@@ -145,7 +145,7 @@ pub fn reset() -> ! {
 ///
 /// Returns `true` if the CPU is executing in an interrupt handler. Returns
 /// `false` if the chip is executing in thread mode.
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+#[cfg(all(target_arch = "arm", target_os = "none"))]
 pub fn is_interrupt_context() -> bool {
     use core::arch::asm;
     let mut interrupt_number: u32;
@@ -180,7 +180,7 @@ pub fn is_interrupt_context() -> bool {
     (interrupt_number & 0x1FF) != 0
 }
 
-#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 pub fn is_interrupt_context() -> bool {
     unimplemented!()
 }

--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -55,7 +55,7 @@ pub static mut SCB_REGISTERS: UnsafeCell<[u32; 5]> = UnsafeCell::new([0; 5]);
 ///
 /// We need to do this in assembly because we cannot have Rust access
 /// the global variable.
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+#[cfg(all(target_arch = "arm", target_os = "none"))]
 pub fn get_global_app_hard_fault() -> usize {
     let app_fault: usize;
 
@@ -88,7 +88,7 @@ pub fn get_global_app_hard_fault() -> usize {
 ///
 /// We need to do this in assembly because we cannot have Rust access
 /// the global variable.
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+#[cfg(all(target_arch = "arm", target_os = "none"))]
 pub fn get_global_syscall_fired() -> usize {
     let syscall_fired: usize;
 
@@ -122,7 +122,7 @@ pub fn get_global_syscall_fired() -> usize {
 ///
 /// We need to do this in assembly because we cannot have Rust access
 /// the global variable.
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+#[cfg(all(target_arch = "arm", target_os = "none"))]
 pub fn get_global_scb_registers() -> (u32, u32, u32, u32, u32) {
     let _ccr: u32;
     let cfsr: u32;
@@ -165,19 +165,19 @@ pub fn get_global_scb_registers() -> (u32, u32, u32, u32, u32) {
 }
 
 /// Dummy
-#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 pub fn get_global_app_hard_fault() -> usize {
     0
 }
 
 /// Dummy
-#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 pub fn get_global_syscall_fired() -> usize {
     0
 }
 
 /// Dummy
-#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 pub fn get_global_scb_registers() -> (u32, u32, u32, u32, u32) {
     (0, 0, 0, 0, 0)
 }

--- a/arch/cortex-m0/src/lib.rs
+++ b/arch/cortex-m0/src/lib.rs
@@ -16,7 +16,7 @@ pub use cortexm::nvic;
 pub use cortexm::syscall;
 pub use cortexm::thread_id;
 
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+#[cfg(all(target_arch = "arm", target_os = "none"))]
 struct HardFaultStackedRegisters {
     r0: u32,
     r1: u32,
@@ -28,7 +28,7 @@ struct HardFaultStackedRegisters {
     xpsr: u32,
 }
 
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+#[cfg(all(target_arch = "arm", target_os = "none"))]
 /// Handle a hard fault that occurred in the kernel. This function is invoked
 /// by the naked hard_fault_handler function.
 unsafe extern "C" fn hard_fault_handler_kernel(faulting_stack: *mut u32) -> ! {
@@ -72,7 +72,7 @@ unsafe extern "C" fn hard_fault_handler_kernel(faulting_stack: *mut u32) -> ! {
 }
 
 // Mock implementation for tests on Travis-CI.
-#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 unsafe extern "C" fn generic_isr() {
     unimplemented!()
 }
@@ -97,7 +97,7 @@ unsafe extern "C" fn generic_isr() {
 ///   - This writes to `r7`, a callee-saved register, but it is pushed and
 ///     popped to/from the stack to return to its original value.
 /// - This does not fall-through, it branches at the end.
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+#[cfg(all(target_arch = "arm", target_os = "none"))]
 #[unsafe(naked)]
 unsafe extern "C" fn generic_isr() {
     use core::arch::naked_asm;
@@ -194,7 +194,7 @@ unsafe extern "C" fn generic_isr() {
 }
 
 // Mock implementation for tests on Travis-CI.
-#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 unsafe extern "C" fn systick_handler() {
     unimplemented!()
 }
@@ -214,7 +214,7 @@ unsafe extern "C" fn systick_handler() {
 /// - OUTPUTS:
 ///   - This writes to `r0`, a caller-saved register.
 /// - This does not fall-through, it branches at the end.
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+#[cfg(all(target_arch = "arm", target_os = "none"))]
 #[unsafe(naked)]
 unsafe extern "C" fn systick_handler() {
     use core::arch::naked_asm;
@@ -246,7 +246,7 @@ unsafe extern "C" fn systick_handler() {
 }
 
 // Mock implementation for tests on Travis-CI.
-#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 unsafe extern "C" fn svc_handler() {
     unimplemented!()
 }
@@ -259,7 +259,7 @@ unsafe extern "C" fn svc_handler() {
 ///   - This writes to `r0`, a caller-saved register.
 ///   - This writes to `r1`, a caller-saved register.
 /// - This does not fall-through, it branches in both branches.
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+#[cfg(all(target_arch = "arm", target_os = "none"))]
 #[unsafe(naked)]
 unsafe extern "C" fn svc_handler() {
     use core::arch::naked_asm;
@@ -309,7 +309,7 @@ unsafe extern "C" fn svc_handler() {
 }
 
 // Mock implementation for tests on Travis-CI.
-#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 unsafe extern "C" fn hard_fault_handler() {
     unimplemented!()
 }
@@ -324,7 +324,7 @@ unsafe extern "C" fn hard_fault_handler() {
 ///   - This writes to `r2`, a caller-saved register.
 ///   - This writes to `r3`, a caller-saved register.
 /// - This does not fall-through, it branches at the end.
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+#[cfg(all(target_arch = "arm", target_os = "none"))]
 #[unsafe(naked)]
 unsafe extern "C" fn hard_fault_handler() {
     use core::arch::naked_asm;
@@ -432,7 +432,7 @@ impl cortexm::CortexMVariant for CortexM0 {
     const HARD_FAULT_HANDLER: unsafe extern "C" fn() = hard_fault_handler;
 
     // Mock implementation for tests on Travis-CI.
-    #[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+    #[cfg(not(all(target_arch = "arm", target_os = "none")))]
     unsafe fn switch_to_user(
         _user_stack: *const usize,
         _process_regs: &mut [usize; 8],
@@ -440,7 +440,7 @@ impl cortexm::CortexMVariant for CortexM0 {
         unimplemented!()
     }
 
-    #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+    #[cfg(all(target_arch = "arm", target_os = "none"))]
     unsafe fn switch_to_user(
         mut user_stack: *const usize,
         process_regs: &mut [usize; 8],

--- a/arch/cortex-m0p/src/lib.rs
+++ b/arch/cortex-m0p/src/lib.rs
@@ -36,7 +36,7 @@ pub use cortexm::unhandled_interrupt;
 use cortexm0::CortexM0;
 
 // Mock implementation for tests on Travis-CI.
-#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 pub unsafe extern "C" fn svc_handler() {
     unimplemented!()
 }
@@ -49,7 +49,7 @@ pub unsafe extern "C" fn svc_handler() {
 ///   - This writes to `r0`, a caller-saved register.
 ///   - This writes to `r1`, a caller-saved register.
 /// - This does not fall-through, it branches in both branches.
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+#[cfg(all(target_arch = "arm", target_os = "none"))]
 #[unsafe(naked)]
 pub unsafe extern "C" fn svc_handler() {
     use core::arch::naked_asm;
@@ -109,7 +109,7 @@ impl cortexm::CortexMVariant for CortexM0P {
     const SVC_HANDLER: unsafe extern "C" fn() = svc_handler;
     const HARD_FAULT_HANDLER: unsafe extern "C" fn() = CortexM0::HARD_FAULT_HANDLER;
 
-    #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+    #[cfg(all(target_arch = "arm", target_os = "none"))]
     unsafe fn switch_to_user(
         user_stack: *const usize,
         process_regs: &mut [usize; 8],
@@ -117,7 +117,7 @@ impl cortexm::CortexMVariant for CortexM0P {
         unsafe { CortexM0::switch_to_user(user_stack, process_regs) }
     }
 
-    #[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+    #[cfg(not(all(target_arch = "arm", target_os = "none")))]
     unsafe fn switch_to_user(
         _user_stack: *const usize,
         _process_regs: &mut [usize; 8],

--- a/arch/cortex-v7m/src/lib.rs
+++ b/arch/cortex-v7m/src/lib.rs
@@ -18,7 +18,7 @@
 /// - OUTPUTS:
 ///   - This writes to `r0`, a caller-saved register.
 /// - This does not fall-through, it branches at the end.
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+#[cfg(all(target_arch = "arm", target_os = "none"))]
 #[unsafe(naked)]
 pub unsafe extern "C" fn systick_handler_arm_v7m() {
     use core::arch::naked_asm;
@@ -71,7 +71,7 @@ pub unsafe extern "C" fn systick_handler_arm_v7m() {
 ///   - This writes to `r2`, a caller-saved register.
 ///   - This writes to `r3`, a caller-saved register.
 /// - This does not fall-through, it branches in both arms of the branch.
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+#[cfg(all(target_arch = "arm", target_os = "none"))]
 #[unsafe(naked)]
 pub unsafe extern "C" fn svc_handler_arm_v7m() {
     use core::arch::naked_asm;
@@ -170,7 +170,7 @@ pub unsafe extern "C" fn svc_handler_arm_v7m() {
 ///   - This writes to `r2`, a caller-saved register.
 ///   - This writes to `r3`, a caller-saved register.
 /// - This does not fall-through, it branches at the end.
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+#[cfg(all(target_arch = "arm", target_os = "none"))]
 #[unsafe(naked)]
 pub unsafe extern "C" fn generic_isr_arm_v7m() {
     use core::arch::naked_asm;
@@ -255,7 +255,7 @@ pub unsafe extern "C" fn generic_isr_arm_v7m() {
 ///
 /// For documentation of this function, please see
 /// `CortexMVariant::switch_to_user`.
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+#[cfg(all(target_arch = "arm", target_os = "none"))]
 pub unsafe fn switch_to_user_arm_v7m(
     mut user_stack: *const usize,
     process_regs: &mut [usize; 8],
@@ -354,7 +354,7 @@ pub unsafe fn switch_to_user_arm_v7m(
     }
 }
 
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+#[cfg(all(target_arch = "arm", target_os = "none"))]
 /// Continue the hardfault handler for all hard-faults that occurred
 /// during kernel execution. This function must never return.
 unsafe extern "C" fn hard_fault_handler_arm_v7m_kernel(
@@ -567,7 +567,7 @@ unsafe extern "C" fn hard_fault_handler_arm_v7m_kernel(
 ///   - This writes to `r2`, a caller-saved register.
 ///   - This writes to `r3`, a caller-saved register.
 /// - This does not fall-through, it branches at the end.
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+#[cfg(all(target_arch = "arm", target_os = "none"))]
 #[unsafe(naked)]
 pub unsafe extern "C" fn hard_fault_handler_arm_v7m() {
     // These constants are defined in the linker script.
@@ -701,22 +701,22 @@ pub fn ipsr_isr_number_to_str(isr_number: usize) -> &'static str {
 // ARM assembly since it will not compile.
 ///////////////////////////////////////////////////////////////////
 
-#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 pub unsafe extern "C" fn systick_handler_arm_v7m() {
     unimplemented!()
 }
 
-#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 pub unsafe extern "C" fn svc_handler_arm_v7m() {
     unimplemented!()
 }
 
-#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 pub unsafe extern "C" fn generic_isr_arm_v7m() {
     unimplemented!()
 }
 
-#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 pub unsafe extern "C" fn switch_to_user_arm_v7m(
     _user_stack: *const u8,
     _process_regs: &mut [usize; 8],
@@ -724,7 +724,7 @@ pub unsafe extern "C" fn switch_to_user_arm_v7m(
     unimplemented!()
 }
 
-#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 pub unsafe extern "C" fn hard_fault_handler_arm_v7m() {
     unimplemented!()
 }

--- a/arch/riscv/build.rs
+++ b/arch/riscv/build.rs
@@ -13,25 +13,23 @@
 //! that is valid on any RISC-V platform, with or without an OS.
 //!
 //! Commonly, code that is Tock-specific and only makes sense on bare-metal
-//! platforms will be gated by the logical OR of `riscv_bare_metal` and `doc`.
-//! For example:
+//! platforms will be gated by `riscv_bare_metal`. For example:
 //!
 //! ```
-//! #[cfg(any(riscv_bare_metal, doc))]
+//! #[cfg(riscv_bare_metal)]
 //! pub extern "C" fn _start_trap() -> ! {
 //!     // trap handler code...
 //! }
 //! ```
 //!
 //! This ensures that this code is only compiled and tested when the target is
-//! bare metal RISC-V, or when building documentation so that any function
-//! comments will be included in the rustdocs. However, cargo often builds Tock
-//! code targeted for the host machine (which is likely not RISC-V), for example
-//! when running tests. Therefore, we also need to include a mock implementation
-//! so the symbol still exists:
+//! bare metal RISC-V. However, cargo often builds Tock code targeted for the
+//! host machine (which is likely not RISC-V), for example when running
+//! tests. Therefore, we also need to include a mock implementation so the
+//! symbol still exists:
 //!
 //! ```
-//! #[cfg(not(any(riscv_bare_metal, doc)))]
+//! #[cfg(not(riscv_bare_metal))]
 //! pub extern "C" fn _start_trap() -> ! {
 //!     unimplemented!()
 //! }
@@ -44,7 +42,7 @@
 //! example, a simple NOP instruction:
 //!
 //! ```
-//! #[cfg(any(riscv, doc))]
+//! #[cfg(riscv)]
 //! pub fn nop() {
 //!     unsafe { asm!("nop"); }
 //! }
@@ -55,17 +53,17 @@
 //! That can be gated on the specific `target_arch` like this:
 //!
 //! ```
-//! #[cfg(all(target_arch = "riscv32", not(doc)))]
+//! #[cfg(target_arch = "riscv32")]
 //! pub const XLEN: usize = 32;
-//! #[cfg(all(target_arch = "riscv64", not(doc)))]
+//! #[cfg(target_arch = "riscv64")]
 //! pub const XLEN: usize = 64;
 //! ```
 //!
 //! However, to make non-cross-compiled compilations still work (like `cargo
-//! test`), and for documentation, we still need the mock implementation:
+//! test`), we still need the mock implementation:
 //!
 //! ```
-//! #[cfg(any(not(riscv), doc))]
+//! #[cfg(not(riscv))]
 //! pub const XLEN: usize = 32;
 //! ```
 //!

--- a/arch/riscv/src/csr/mod.rs
+++ b/arch/riscv/src/csr/mod.rs
@@ -283,7 +283,11 @@ pub const CSR: &CSR = &CSR {
 };
 
 impl CSR {
-    // resets the cycle counter to 0
+    /// Resets the cycle counter (`mcycle`, and `mcycleh` on RISCV-32) to 0.
+    ///
+    /// On RISCV-32 the 64-bit cycle count is split across two 32-bit CSRs,
+    /// `mcycle` (low) and `mcycleh` (high); both are reset here. On
+    /// RISCV-64, `mcycle` alone holds the full 64-bit count.
     #[cfg(not(target_arch = "riscv64"))]
     pub fn reset_cycle_counter(&self) {
         // Write lower first so that we don't overflow before writing the upper
@@ -291,13 +295,22 @@ impl CSR {
         CSR.mcycleh.write(mcycle::mcycleh::mcycleh.val(0));
     }
 
-    // resets the cycle counter to 0
+    /// Resets the cycle counter (`mcycle`, and `mcycleh` on RISCV-32) to 0.
+    ///
+    /// On RISCV-32 the 64-bit cycle count is split across two 32-bit CSRs,
+    /// `mcycle` (low) and `mcycleh` (high); both are reset here. On
+    /// RISCV-64, `mcycle` alone holds the full 64-bit count.
     #[cfg(target_arch = "riscv64")]
     pub fn reset_cycle_counter(&self) {
         CSR.mcycle.write(mcycle::mcycle::mcycle.val(0));
     }
 
-    // reads the cycle counter
+    /// Reads the 64-bit cycle counter.
+    ///
+    /// On RISCV-32 the count is split across two 32-bit CSRs, `mcycle` (low)
+    /// and `mcycleh` (high); this reads both, retrying if a rollover is
+    /// detected between the two reads. On RISCV-64, `mcycle` alone holds the
+    /// full 64-bit count and is read directly.
     #[cfg(not(target_arch = "riscv64"))]
     pub fn read_cycle_counter(&self) -> u64 {
         let (mut top, mut bot): (usize, usize);
@@ -316,7 +329,12 @@ impl CSR {
         (top as u64).checked_shl(32).unwrap() + bot as u64
     }
 
-    // reads the cycle counter
+    /// Reads the 64-bit cycle counter.
+    ///
+    /// On RISCV-32 the count is split across two 32-bit CSRs, `mcycle` (low)
+    /// and `mcycleh` (high); this reads both, retrying if a rollover is
+    /// detected between the two reads. On RISCV-64, `mcycle` alone holds the
+    /// full 64-bit count and is read directly.
     #[cfg(target_arch = "riscv64")]
     pub fn read_cycle_counter(&self) -> u64 {
         // On RV64 `mcycle` is a single 64-bit CSR; `read` returns `usize`, which

--- a/arch/riscv/src/csr/pmpaddr.rs
+++ b/arch/riscv/src/csr/pmpaddr.rs
@@ -7,6 +7,13 @@ use kernel::utilities::registers::register_bitfields;
 // Default to 32 bit if compiling for debug/testing.
 #[cfg(not(target_arch = "riscv64"))]
 register_bitfields![usize,
+    /// The `pmpaddr` register bitfield.
+    ///
+    /// This is `XLEN` (32) bits wide on RISCV-32, and `XLEN - 10` (54) bits
+    /// wide on RISCV-64: RV64 supports only a 56 bit physical address space,
+    /// and addresses here are left-shifted by 2 bits, so the uppermost 10
+    /// bits of the 64-bit CSR are reserved (WARL-0). See `PMPADDR_MASK` in
+    /// `pmp.rs`.
     pub pmpaddr [
         addr OFFSET(0) NUMBITS(crate::XLEN) []
     ]
@@ -14,6 +21,13 @@ register_bitfields![usize,
 
 #[cfg(target_arch = "riscv64")]
 register_bitfields![usize,
+    /// The `pmpaddr` register bitfield.
+    ///
+    /// This is `XLEN` (32) bits wide on RISCV-32, and `XLEN - 10` (54) bits
+    /// wide on RISCV-64: RV64 supports only a 56 bit physical address space,
+    /// and addresses here are left-shifted by 2 bits, so the uppermost 10
+    /// bits of the 64-bit CSR are reserved (WARL-0). See `PMPADDR_MASK` in
+    /// `pmp.rs`.
     pub pmpaddr [
         addr OFFSET(0) NUMBITS(crate::XLEN - 10) []
     ]

--- a/arch/riscv/src/csr/pmpconfig.rs
+++ b/arch/riscv/src/csr/pmpconfig.rs
@@ -7,6 +7,13 @@ use kernel::utilities::registers::register_bitfields;
 // Default to 32 bit if compiling for debug/testing.
 #[cfg(not(target_arch = "riscv64"))]
 register_bitfields![usize,
+    /// The `pmpcfg` register bitfield.
+    ///
+    /// A `pmpcfgN` register is `XLEN` bits wide and holds one octet of
+    /// configuration per PMP entry. On RISCV-32 this is 4 entries (`r0`
+    /// through `l3`). On RISCV-64 it is 8 entries (`r0` through `l7`), since
+    /// each `pmpcfgN` register is twice as wide and packs twice as many
+    /// entries.
     pub pmpcfg [
         r0 OFFSET(0) NUMBITS(1) [],
         w0 OFFSET(1) NUMBITS(1) [],
@@ -56,6 +63,13 @@ register_bitfields![usize,
 
 #[cfg(target_arch = "riscv64")]
 register_bitfields![usize,
+    /// The `pmpcfg` register bitfield.
+    ///
+    /// A `pmpcfgN` register is `XLEN` bits wide and holds one octet of
+    /// configuration per PMP entry. On RISCV-32 this is 4 entries (`r0`
+    /// through `l3`). On RISCV-64 it is 8 entries (`r0` through `l7`), since
+    /// each `pmpcfgN` register is twice as wide and packs twice as many
+    /// entries.
     pub pmpcfg [
         r0 OFFSET(0) NUMBITS(1) [],
         w0 OFFSET(1) NUMBITS(1) [],

--- a/arch/riscv/src/dma_fence.rs
+++ b/arch/riscv/src/dma_fence.rs
@@ -44,7 +44,7 @@ impl RiscvCoherentDmaFence {
     }
 }
 
-#[cfg(any(riscv, doc))]
+#[cfg(riscv)]
 unsafe impl DmaFence for RiscvCoherentDmaFence {
     /// Expose prior writes to in-memory buffers to subsequent DMA operations.
     ///
@@ -156,7 +156,7 @@ unsafe impl DmaFence for RiscvCoherentDmaFence {
     }
 }
 
-#[cfg(not(any(riscv_bare_metal, doc)))]
+#[cfg(not(riscv_bare_metal))]
 unsafe impl DmaFence for RiscvCoherentDmaFence {
     fn release<T>(self, _slice_ptr: *mut [T]) {
         // When building for another architecture, such as for tests or CI:

--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -24,7 +24,7 @@ pub const XLEN: usize = 1 << XLEN_LOG2;
 
 /// `XLEN_LOG2` is the log base 2 of [`XLEN`].
 ///
-/// Value varies based on RISCV-32 (XLEN_LOG2=5) vs. RISCV-64 (XLEN_LOG2=6).
+/// This is `5` on RISCV-32 (`XLEN` = 32) and `6` on RISCV-64 (`XLEN` = 64).
 pub const XLEN_LOG2: usize = usize::BITS.trailing_zeros() as usize;
 
 extern "C" {
@@ -59,11 +59,11 @@ extern "C" {
 ///    any Rust code runs. See <https://github.com/tock/tock/issues/2222> for more
 ///    information.
 /// 3. Finally it calls `main()`, the main entry point for Tock boards.
-#[cfg(any(riscv_bare_metal, doc))]
+#[cfg(riscv_bare_metal)]
 // Only apply the `link_section` attribute when actually targeting bare-metal
-// RISC-V. Host builds (e.g. `doc`, tests, clippy on macOS, Windows, Linux,
-// ...) use object formats (Mach-O, PE, ...) that reject a bare section name
-// like this, yielding errors such as: `mach-o section specifier requires a
+// RISC-V. Host builds (e.g. tests, clippy on macOS, Windows, Linux, ...) use
+// object formats (Mach-O, PE, ...) that reject a bare section name like
+// this, yielding errors such as: `mach-o section specifier requires a
 // segment and section separated by a comma`.
 #[cfg_attr(riscv_bare_metal, link_section = ".riscv.start")]
 #[unsafe(naked)]
@@ -156,7 +156,7 @@ pub unsafe extern "C" fn initialize_ram_jump_to_main() {
 }
 
 // Mock implementation for tests on Travis-CI.
-#[cfg(not(any(riscv_bare_metal, doc)))]
+#[cfg(not(riscv_bare_metal))]
 pub unsafe extern "C" fn initialize_ram_jump_to_main() {
     unimplemented!()
 }
@@ -291,11 +291,11 @@ pub unsafe fn configure_trap_handler() {
 /// invoked, it may, for instance, choose to ignore a certain trap, access
 /// global state (subject to synchronization), etc. It must still abide to
 /// the contract as stated above.
-#[cfg(any(riscv_bare_metal, doc))]
+#[cfg(riscv_bare_metal)]
 // Only apply the `link_section` attribute when actually targeting bare-metal
-// RISC-V. Host builds (e.g. `doc`, tests, clippy on macOS, Windows, Linux,
-// ...) use object formats (Mach-O, PE, ...) that reject a bare section name
-// like this, yielding errors such as: `mach-o section specifier requires a
+// RISC-V. Host builds (e.g. tests, clippy on macOS, Windows, Linux, ...) use
+// object formats (Mach-O, PE, ...) that reject a bare section name like
+// this, yielding errors such as: `mach-o section specifier requires a
 // segment and section separated by a comma`.
 #[cfg_attr(riscv_bare_metal, link_section = ".riscv.trap")]
 // We need the `_start_trap` function to be 256 byte aligned. The linker script
@@ -450,7 +450,7 @@ pub extern "C" fn _start_trap() -> ! {
 }
 
 // Mock implementation for tests on Travis-CI.
-#[cfg(not(any(riscv_bare_metal, doc)))]
+#[cfg(not(riscv_bare_metal))]
 pub extern "C" fn _start_trap() -> ! {
     unimplemented!()
 }
@@ -466,7 +466,7 @@ pub extern "C" fn _start_trap() -> ! {
 /// <https://elixir.bootlin.com/linux/v5.12.10/source/arch/riscv/include/asm/jump_label.h#L21>
 /// as suggested by the RISC-V developers:
 /// <https://groups.google.com/a/groups.riscv.org/g/isa-dev/c/XKkYacERM04/m/CdpOcqtRAgAJ>
-#[cfg(any(riscv_bare_metal, doc))]
+#[cfg(riscv_bare_metal)]
 pub unsafe fn semihost_command(command: usize, arg0: usize, arg1: usize) -> usize {
     use core::arch::asm;
     let res;
@@ -490,7 +490,7 @@ pub unsafe fn semihost_command(command: usize, arg0: usize, arg1: usize) -> usiz
 }
 
 // Mock implementation for tests on Travis-CI.
-#[cfg(not(any(riscv_bare_metal, doc)))]
+#[cfg(not(riscv_bare_metal))]
 pub unsafe fn semihost_command(_command: usize, _arg0: usize, _arg1: usize) -> usize {
     unimplemented!()
 }

--- a/arch/riscv/src/pseudo_instructions.rs
+++ b/arch/riscv/src/pseudo_instructions.rs
@@ -37,11 +37,7 @@
 ///     "
 /// );
 /// ```
-#[cfg(any(not(riscv), doc))]
-#[macro_export]
-macro_rules! xlen_macros[() => [r""]];
-
-#[cfg(all(target_arch = "riscv32", not(doc)))]
+#[cfg(target_arch = "riscv32")]
 #[macro_export]
 macro_rules! xlen_macros[() => [r"
     .macro sx src, dest
@@ -52,7 +48,31 @@ macro_rules! xlen_macros[() => [r"
     .endm
 "]];
 
-#[cfg(all(target_arch = "riscv64", not(doc)))]
+/// Generate `asm!()` macros to create register-sized load and store
+/// instructions.
+///
+/// On RISCV-32 this creates two psuedoinstructions:
+/// 1. `sx` -> `sw`
+/// 2. `lx` -> `lw`
+///
+/// On RISCV-64 this creates two psuedoinstructions:
+/// 1. `sx` -> `sd`
+/// 2. `lx` -> `ld`
+///
+/// These apply globally, and so only need to be included once in the project.
+/// For example:
+///
+/// ```rust,ignore
+/// use core::arch::naked_asm;
+/// use riscv::xlen_macros;
+/// naked_asm!(
+///     xlen_macros!(),
+///     "
+///     ...asm code here...
+///     "
+/// );
+/// ```
+#[cfg(target_arch = "riscv64")]
 #[macro_export]
 macro_rules! xlen_macros[() => [r"
     .macro sx src, dest

--- a/arch/riscv/src/support.rs
+++ b/arch/riscv/src/support.rs
@@ -6,7 +6,7 @@
 
 use crate::csr::{CSR, mstatus::mstatus};
 
-#[cfg(any(riscv, doc))]
+#[cfg(riscv)]
 #[inline(always)]
 /// NOP instruction
 pub fn nop() {
@@ -16,7 +16,7 @@ pub fn nop() {
     }
 }
 
-#[cfg(any(riscv, doc))]
+#[cfg(riscv)]
 #[inline(always)]
 /// Wait For Interrupt (WFI) instruction.
 pub unsafe fn wfi() {
@@ -51,12 +51,12 @@ where
 }
 
 // Mock implementations for tests on Travis-CI.
-#[cfg(not(any(riscv, doc)))]
+#[cfg(not(riscv))]
 pub fn nop() {
     unimplemented!()
 }
 
-#[cfg(not(any(riscv, doc)))]
+#[cfg(not(riscv))]
 pub unsafe fn wfi() {
     unimplemented!()
 }

--- a/arch/riscv/src/syscall.rs
+++ b/arch/riscv/src/syscall.rs
@@ -355,7 +355,7 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
         Ok(())
     }
 
-    #[cfg(any(riscv_bare_metal, doc))]
+    #[cfg(riscv_bare_metal)]
     unsafe fn switch_to_process(
         &self,
         _accessible_memory_start: *const u8,
@@ -809,7 +809,7 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
     }
 
     // Mock implementation for tests on Travis-CI.
-    #[cfg(not(any(riscv_bare_metal, doc)))]
+    #[cfg(not(riscv_bare_metal))]
     unsafe fn switch_to_process(
         &self,
         _accessible_memory_start: *const u8,

--- a/arch/riscv/src/thread_id.rs
+++ b/arch/riscv/src/thread_id.rs
@@ -18,7 +18,7 @@ pub enum RiscvThreadIdProvider {}
 //
 // The assembly (read `mhartid`, load the `_trap_handler_active` symbol address,
 // read a `usize`) is XLEN-agnostic, so the same code serves both rv32 and rv64.
-#[cfg(any(riscv_bare_metal, doc))]
+#[cfg(riscv_bare_metal)]
 unsafe impl ThreadIdProvider for RiscvThreadIdProvider {
     /// Return the current thread ID, computed using the `mhartid` (hardware thread
     /// ID), and a flag indicating whether the current hart is currently in a trap
@@ -83,7 +83,7 @@ unsafe impl ThreadIdProvider for RiscvThreadIdProvider {
 }
 
 // Mock implementation for non-RISC-V (host) target builds
-#[cfg(not(any(riscv_bare_metal, doc)))]
+#[cfg(not(riscv_bare_metal))]
 unsafe impl ThreadIdProvider for RiscvThreadIdProvider {
     fn running_thread_id() -> usize {
         unimplemented!()

--- a/arch/x86/src/dma_fence.rs
+++ b/arch/x86/src/dma_fence.rs
@@ -40,7 +40,7 @@ impl X86DmaFence {
     }
 }
 
-#[cfg(any(doc, target_arch = "x86"))]
+#[cfg(target_arch = "x86")]
 unsafe impl DmaFence for X86DmaFence {
     /// Expose prior writes to in-memory buffers to subsequent DMA operations.
     ///
@@ -116,7 +116,7 @@ unsafe impl DmaFence for X86DmaFence {
     }
 }
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 unsafe impl DmaFence for X86DmaFence {
     fn release<T>(self, _slice_ptr: *mut [T]) {
         // When building for another architecture, such as for tests or CI:

--- a/arch/x86/src/registers/bits32/eflags.rs
+++ b/arch/x86/src/registers/bits32/eflags.rs
@@ -107,12 +107,12 @@ pub unsafe fn set(val: EFlags) {
 
 //For CI only
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 pub unsafe fn read() -> EFlags {
     unimplemented!()
 }
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 pub unsafe fn set(_val: EFlags) {
     unimplemented!()
 }

--- a/arch/x86/src/registers/bits32/mod.rs
+++ b/arch/x86/src/registers/bits32/mod.rs
@@ -34,7 +34,7 @@ pub unsafe fn stack_jmp(stack: *mut (), ip: *const ()) -> ! {
 
 //For CI only
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 pub unsafe fn stack_jmp(_stack: *mut (), _ip: *const ()) -> ! {
     unimplemented!()
 }

--- a/arch/x86/src/registers/controlregs.rs
+++ b/arch/x86/src/registers/controlregs.rs
@@ -137,32 +137,32 @@ pub unsafe fn cr3_write(val: u64) {
 
 // For CI only
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 pub unsafe fn cr0() -> Cr0 {
     unimplemented!()
 }
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 pub unsafe fn cr0_write(_val: Cr0) {
     unimplemented!()
 }
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 pub unsafe fn cr4() -> Cr4 {
     unimplemented!()
 }
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 pub unsafe fn cr4_write(_val: Cr4) {
     unimplemented!()
 }
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 pub unsafe fn cr3() -> u64 {
     unimplemented!()
 }
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 pub unsafe fn cr3_write(_val: u64) {
     unimplemented!()
 }

--- a/arch/x86/src/registers/dtables.rs
+++ b/arch/x86/src/registers/dtables.rs
@@ -146,32 +146,32 @@ pub unsafe fn sidt<T>(idt: &mut DescriptorTablePointer<T>) {
 
 //For CI only
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 pub unsafe fn lgdt<T>(_gdt: &DescriptorTablePointer<T>) {
     unimplemented!()
 }
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 pub unsafe fn sgdt<T>(_idt: &mut DescriptorTablePointer<T>) {
     unimplemented!()
 }
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 pub unsafe fn load_ldtr(_selector: SegmentSelector) {
     unimplemented!()
 }
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 pub unsafe fn ldtr() -> SegmentSelector {
     unimplemented!()
 }
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 pub unsafe fn lidt<T>(_idt: &DescriptorTablePointer<T>) {
     unimplemented!()
 }
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 pub unsafe fn sidt<T>(_idt: &mut DescriptorTablePointer<T>) {
     unimplemented!()
 }

--- a/arch/x86/src/registers/io.rs
+++ b/arch/x86/src/registers/io.rs
@@ -89,32 +89,32 @@ pub unsafe fn inl(port: u16) -> u32 {
 
 //For CI only
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 pub unsafe fn outb(_port: u16, _val: u8) {
     unimplemented!()
 }
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 pub unsafe fn inb(_port: u16) -> u8 {
     unimplemented!()
 }
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 pub unsafe fn outw(_port: u16, _val: u16) {
     unimplemented!()
 }
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 pub unsafe fn inw(_port: u16) -> u16 {
     unimplemented!()
 }
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 pub unsafe fn outl(_port: u16, _val: u32) {
     unimplemented!()
 }
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 pub unsafe fn inl(_port: u16) -> u32 {
     unimplemented!()
 }

--- a/arch/x86/src/registers/segmentation.rs
+++ b/arch/x86/src/registers/segmentation.rs
@@ -541,32 +541,32 @@ pub enum SystemDescriptorTypes32 {
 
 //For CI only
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 pub unsafe fn load_ss(_sel: SegmentSelector) {
     unimplemented!()
 }
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 pub unsafe fn load_ds(_sel: SegmentSelector) {
     unimplemented!()
 }
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 pub unsafe fn load_es(_sel: SegmentSelector) {
     unimplemented!()
 }
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 pub unsafe fn load_fs(_sel: SegmentSelector) {
     unimplemented!()
 }
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 pub unsafe fn load_gs(_sel: SegmentSelector) {
     unimplemented!()
 }
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 pub unsafe fn load_cs(_sel: SegmentSelector) {
     unimplemented!()
 }

--- a/arch/x86/src/registers/task.rs
+++ b/arch/x86/src/registers/task.rs
@@ -41,12 +41,12 @@ pub unsafe fn load_tr(sel: segmentation::SegmentSelector) {
 
 //For CI only
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 pub unsafe fn tr() -> segmentation::SegmentSelector {
     unimplemented!()
 }
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 pub unsafe fn load_tr(_sel: segmentation::SegmentSelector) {
     unimplemented!()
 }

--- a/arch/x86/src/registers/tlb.rs
+++ b/arch/x86/src/registers/tlb.rs
@@ -32,7 +32,7 @@ pub unsafe fn flush_all() {
 
 // For CI only
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 pub unsafe fn flush(_addr: usize) {
     unimplemented!()
 }

--- a/arch/x86/src/support.rs
+++ b/arch/x86/src/support.rs
@@ -4,7 +4,7 @@
 
 //! Miscellaneous low-level operations
 
-#[cfg(any(doc, target_arch = "x86"))]
+#[cfg(target_arch = "x86")]
 use core::arch::asm;
 
 /// Execute closure without allowing any interrupts on the current core.
@@ -12,7 +12,7 @@ use core::arch::asm;
 /// This function ensures interrupts are disabled before invoking the given
 /// closue `f`. This allows / you to safely perform single-core operations
 /// which would otherwise race against interrupt handlers.
-#[cfg(any(doc, target_arch = "x86"))]
+#[cfg(target_arch = "x86")]
 pub fn with_interrupts_disabled<F, R>(f: F) -> R
 where
     F: FnOnce() -> R,
@@ -41,7 +41,7 @@ where
     }
 }
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 pub fn with_interrupts_disabled<F, R>(_: F) -> R
 where
     F: FnOnce() -> R,
@@ -50,7 +50,7 @@ where
 }
 
 /// Executes a single NOP instruction.
-#[cfg(any(doc, target_arch = "x86"))]
+#[cfg(target_arch = "x86")]
 #[inline(always)]
 pub fn nop() {
     unsafe {
@@ -58,7 +58,7 @@ pub fn nop() {
     }
 }
 
-#[cfg(not(any(doc, target_arch = "x86")))]
+#[cfg(not(target_arch = "x86"))]
 #[inline(always)]
 pub fn nop() {
     unimplemented!()

--- a/boards/lora_e5_mini/src/main.rs
+++ b/boards/lora_e5_mini/src/main.rs
@@ -7,9 +7,7 @@
 //! - <https://wiki.seeedstudio.com/LoRa_E5_mini/>
 
 #![no_std]
-// Disable this attribute when documenting, as a workaround for
-// https://github.com/rust-lang/rust/issues/62184.
-#![cfg_attr(not(doc), no_main)]
+#![no_main]
 #![deny(missing_docs)]
 
 use core::ptr::addr_of_mut;

--- a/boards/qemu_i486_q35/src/main.rs
+++ b/boards/qemu_i486_q35/src/main.rs
@@ -5,9 +5,7 @@
 //! Board file for qemu-system-i486 "q35" machine type
 
 #![no_std]
-// Disable this attribute when documenting, as a workaround for
-// https://github.com/rust-lang/rust/issues/62184.
-#![cfg_attr(not(doc), no_main)]
+#![no_main]
 
 use capsules_core::alarm;
 use capsules_core::console::{self, Console};

--- a/boards/raspberry_pi_pico_2/src/main.rs
+++ b/boards/raspberry_pi_pico_2/src/main.rs
@@ -7,9 +7,7 @@
 //! It is based on RP2350SoC SoC (Cortex M33).
 
 #![no_std]
-// Disable this attribute when documenting, as a workaround for
-// https://github.com/rust-lang/rust/issues/62184.
-#![cfg_attr(not(doc), no_main)]
+#![no_main]
 #![deny(missing_docs)]
 
 use core::ptr::addr_of_mut;

--- a/boards/raspberry_pi_pico_2/src/main.rs
+++ b/boards/raspberry_pi_pico_2/src/main.rs
@@ -158,6 +158,11 @@ extern "C" {
     fn jump_to_bootloader();
 }
 
+// Unlike arch/* and chips/*, board crates aren't cross-compiled against
+// their real target for docs (see CRATE_TARGETS in
+// tools/build/build_all_docs.sh), so `doc` is what makes the host-target
+// doc pass pick this real implementation over having no implementation
+// at all.
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 core::arch::global_asm!(
     "

--- a/chips/apollo3/src/lib.rs
+++ b/chips/apollo3/src/lib.rs
@@ -85,7 +85,7 @@ pub static PATCH: [unsafe extern "C" fn(); 16] = [unhandled_interrupt; 16];
 
 // The SVC call in this function means that we need to ensure it's inlined in
 // `main()` otherwise we end up with a clobbered stack.
-#[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+#[cfg(all(target_arch = "arm", target_os = "none"))]
 #[inline(always)]
 pub unsafe fn actually_disable_fpu() {
     use core::arch::asm;
@@ -95,7 +95,7 @@ pub unsafe fn actually_disable_fpu() {
 }
 
 // Mock implementation for tests
-#[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+#[cfg(not(all(target_arch = "arm", target_os = "none")))]
 pub unsafe fn actually_disable_fpu() {
     // Prevent unused code warning.
     scb::disable_fpca();

--- a/chips/arty_e21_chip/src/chip.rs
+++ b/chips/arty_e21_chip/src/chip.rs
@@ -156,7 +156,7 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for ArtyExx<'a, 
 // This needs to be chip specific because how the CLIC works is configured
 // when the trap handler address is specified in mtvec, and that is only
 // valid for platforms with a CLIC.
-#[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
+#[cfg(all(target_arch = "riscv32", target_os = "none"))]
 pub unsafe fn configure_trap_handler() {
     use core::arch::asm;
     asm!(
@@ -179,7 +179,7 @@ pub unsafe fn configure_trap_handler() {
 }
 
 // Mock implementation for tests on Travis-CI.
-#[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
+#[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
 pub unsafe fn configure_trap_handler() {
     unimplemented!()
 }

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -449,7 +449,7 @@ pub unsafe fn configure_trap_handler() {
 // Mock implementation for crate tests that does not include the section
 // specifier, as the test will not use our linker script, and the host
 // compilation environment may not allow the section name.
-#[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
+#[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
 pub extern "C" fn _earlgrey_start_trap_vectored() -> ! {
     use core::hint::unreachable_unchecked;
     unsafe {
@@ -457,12 +457,12 @@ pub extern "C" fn _earlgrey_start_trap_vectored() -> ! {
     }
 }
 
-#[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
+#[cfg(all(target_arch = "riscv32", target_os = "none"))]
 // Only apply the `link_section` attribute when actually targeting bare-metal
-// RISC-V. Some host builds (e.g. `doc`, tests, clippy on macOS, Windows,
-// ...) use object formats (Mach-O, PE, ...) that reject a bare section name
-// like this, yielding errors such as: `mach-o section specifier requires a
-// segment and section separated by a comma`.
+// RISC-V (`target_os = "none"`). Non-bare-metal object formats (Mach-O, PE,
+// ...) reject a bare section name like this, yielding errors such as:
+// `mach-o section specifier requires a segment and section separated by a
+// comma`.
 #[cfg_attr(
     all(target_arch = "riscv32", target_os = "none"),
     link_section = ".riscv.trap_vectored"

--- a/chips/esp32-c3/src/chip.rs
+++ b/chips/esp32-c3/src/chip.rs
@@ -294,7 +294,7 @@ pub unsafe fn configure_trap_handler() {
 // Mock implementation for crate tests that does not include the section
 // specifier, as the test will not use our linker script, and the host
 // compilation environment may not allow the section name.
-#[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
+#[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
 pub extern "C" fn _start_trap_vectored() -> ! {
     use core::hint::unreachable_unchecked;
     unsafe {
@@ -302,12 +302,12 @@ pub extern "C" fn _start_trap_vectored() -> ! {
     }
 }
 
-#[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
+#[cfg(all(target_arch = "riscv32", target_os = "none"))]
 // Only apply the `link_section` attribute when actually targeting bare-metal
-// RISC-V. Some host builds (e.g. `doc`, tests, clippy on macOS, Windows,
-// ...) use object formats (Mach-O, PE, ...) that reject a bare section name
-// like this, yielding errors such as: `mach-o section specifier requires a
-// segment and section separated by a comma`.
+// RISC-V (`target_os = "none"`). Non-bare-metal object formats (Mach-O, PE,
+// ...) reject a bare section name like this, yielding errors such as:
+// `mach-o section specifier requires a segment and section separated by a
+// comma`.
 #[cfg_attr(
     all(target_arch = "riscv32", target_os = "none"),
     link_section = ".riscv.trap_vectored"

--- a/chips/litex_vexriscv/src/interrupt_controller.rs
+++ b/chips/litex_vexriscv/src/interrupt_controller.rs
@@ -102,12 +102,12 @@ mod vexriscv_irq_raw {
     /// defined in litex/soc/cores/cpu/vexriscv/csr-defs.h
     const CSR_IRQ_PENDING: usize = 0xFC0;
 
-    #[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
+    #[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
     pub unsafe fn irq_getmask() -> usize {
         0
     }
 
-    #[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
+    #[cfg(all(target_arch = "riscv32", target_os = "none"))]
     pub unsafe fn irq_getmask() -> usize {
         let mask: usize;
         use core::arch::asm;
@@ -115,21 +115,21 @@ mod vexriscv_irq_raw {
         mask
     }
 
-    #[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
+    #[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
     pub unsafe fn irq_setmask(_mask: usize) {}
 
-    #[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
+    #[cfg(all(target_arch = "riscv32", target_os = "none"))]
     pub unsafe fn irq_setmask(mask: usize) {
         use core::arch::asm;
         asm!("csrw {csr}, {mask}", csr = const CSR_IRQ_MASK, mask = in(reg) mask);
     }
 
-    #[cfg(not(any(doc, all(target_arch = "riscv32", target_os = "none"))))]
+    #[cfg(not(all(target_arch = "riscv32", target_os = "none")))]
     pub unsafe fn irq_pending() -> usize {
         0
     }
 
-    #[cfg(any(doc, all(target_arch = "riscv32", target_os = "none")))]
+    #[cfg(all(target_arch = "riscv32", target_os = "none"))]
     pub unsafe fn irq_pending() -> usize {
         let pending: usize;
         use core::arch::asm;

--- a/chips/rp2040/src/clocks.rs
+++ b/chips/rp2040/src/clocks.rs
@@ -1042,7 +1042,7 @@ impl Clocks {
         (((source_freq as u64) << 8) / freq as u64) as u32
     }
 
-    #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+    #[cfg(all(target_arch = "arm", target_os = "none"))]
     #[inline]
     fn loop_3_cycles(&self, clock: Clock) {
         if self.get_frequency(clock) > 0 {
@@ -1061,7 +1061,7 @@ impl Clocks {
         }
     }
 
-    #[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+    #[cfg(not(all(target_arch = "arm", target_os = "none")))]
     fn loop_3_cycles(&self, _clock: Clock) {
         unimplemented!()
     }

--- a/chips/rp2350/src/clocks.rs
+++ b/chips/rp2350/src/clocks.rs
@@ -1155,7 +1155,7 @@ impl Clocks {
         (((source_freq as u64) << 16) / freq as u64) as u32
     }
 
-    #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+    #[cfg(all(target_arch = "arm", target_os = "none"))]
     #[inline]
     fn loop_3_cycles(&self, clock: Clock) {
         if self.get_frequency(clock) > 0 {
@@ -1172,7 +1172,7 @@ impl Clocks {
         }
     }
 
-    #[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+    #[cfg(not(all(target_arch = "arm", target_os = "none")))]
     fn loop_3_cycles(&self, _clock: Clock) {
         unimplemented!()
     }

--- a/chips/stm32f4xx/src/fsmc.rs
+++ b/chips/stm32f4xx/src/fsmc.rs
@@ -244,7 +244,7 @@ impl<'a> Fsmc<'a> {
         self.bank[bank as usize].map(|bank| bank.ram.get())
     }
 
-    #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+    #[cfg(all(target_arch = "arm", target_os = "none"))]
     #[inline]
     fn write_reg(&self, bank: FsmcBanks, addr: u16) {
         use kernel::utilities::registers::interfaces::Writeable;
@@ -255,7 +255,7 @@ impl<'a> Fsmc<'a> {
         }
     }
 
-    #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
+    #[cfg(all(target_arch = "arm", target_os = "none"))]
     #[inline]
     fn write_data(&self, bank: FsmcBanks, data: u16) {
         use kernel::utilities::registers::interfaces::Writeable;
@@ -266,12 +266,12 @@ impl<'a> Fsmc<'a> {
         }
     }
 
-    #[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+    #[cfg(not(all(target_arch = "arm", target_os = "none")))]
     fn write_reg(&self, _bank: FsmcBanks, _addr: u16) {
         unimplemented!()
     }
 
-    #[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
+    #[cfg(not(all(target_arch = "arm", target_os = "none")))]
     fn write_data(&self, _bank: FsmcBanks, _data: u16) {
         unimplemented!()
     }

--- a/libraries/riscv-csr/src/csr.rs
+++ b/libraries/riscv-csr/src/csr.rs
@@ -144,12 +144,9 @@ impl<R: RegisterLongName, const V: usize> ReadWriteRiscvCsr<usize, R, V> {
     /// This method corresponds to the RISC-V `CSRRW rd, csr, rs1`
     /// instruction where `rs1 = in(reg) value_to_set` and `rd =
     /// out(reg) <return value>`.
-    #[cfg(any(
-        doc,
-        all(
-            any(target_arch = "riscv32", target_arch = "riscv64"),
-            target_os = "none"
-        )
+    #[cfg(all(
+        any(target_arch = "riscv32", target_arch = "riscv64"),
+        target_os = "none"
     ))]
     #[inline]
     pub fn atomic_replace(&self, val_to_set: usize) -> usize {
@@ -178,12 +175,9 @@ impl<R: RegisterLongName, const V: usize> ReadWriteRiscvCsr<usize, R, V> {
     /// instruction where `rs1 = in(reg) value_to_set` and `rd =
     /// out(reg) <return value>`.
     // Mock implementations for tests on Travis-CI.
-    #[cfg(not(any(
-        doc,
-        all(
-            any(target_arch = "riscv32", target_arch = "riscv64"),
-            target_os = "none"
-        )
+    #[cfg(not(all(
+        any(target_arch = "riscv32", target_arch = "riscv64"),
+        target_os = "none"
     )))]
     pub fn atomic_replace(&self, _value_to_set: usize) -> usize {
         unimplemented!("RISC-V CSR {} Atomic Read/Write", V)
@@ -194,12 +188,9 @@ impl<R: RegisterLongName, const V: usize> ReadWriteRiscvCsr<usize, R, V> {
     /// This method corresponds to the RISC-V `CSRRS rd, csr, rs1`
     /// instruction where `rs1 = in(reg) bitmask` and `rd = out(reg)
     /// <return value>`.
-    #[cfg(any(
-        doc,
-        all(
-            any(target_arch = "riscv32", target_arch = "riscv64"),
-            target_os = "none"
-        )
+    #[cfg(all(
+        any(target_arch = "riscv32", target_arch = "riscv64"),
+        target_os = "none"
     ))]
     #[inline]
     pub fn read_and_set_bits(&self, bitmask: usize) -> usize {
@@ -224,12 +215,9 @@ impl<R: RegisterLongName, const V: usize> ReadWriteRiscvCsr<usize, R, V> {
     /// instruction where `rs1 = in(reg) bitmask` and `rd = out(reg)
     /// <return value>`.
     // Mock implementations for tests on Travis-CI.
-    #[cfg(not(any(
-        doc,
-        all(
-            any(target_arch = "riscv32", target_arch = "riscv64"),
-            target_os = "none"
-        )
+    #[cfg(not(all(
+        any(target_arch = "riscv32", target_arch = "riscv64"),
+        target_os = "none"
     )))]
     pub fn read_and_set_bits(&self, bitmask: usize) -> usize {
         unimplemented!(
@@ -244,12 +232,9 @@ impl<R: RegisterLongName, const V: usize> ReadWriteRiscvCsr<usize, R, V> {
     /// This method corresponds to the RISC-V `CSRRC rd, csr, rs1`
     /// instruction where `rs1 = in(reg) bitmask` and `rd = out(reg)
     /// <return value>`.
-    #[cfg(any(
-        doc,
-        all(
-            any(target_arch = "riscv32", target_arch = "riscv64"),
-            target_os = "none"
-        )
+    #[cfg(all(
+        any(target_arch = "riscv32", target_arch = "riscv64"),
+        target_os = "none"
     ))]
     #[inline]
     pub fn read_and_clear_bits(&self, bitmask: usize) -> usize {
@@ -274,12 +259,9 @@ impl<R: RegisterLongName, const V: usize> ReadWriteRiscvCsr<usize, R, V> {
     /// instruction where `rs1 = in(reg) bitmask` and `rd = out(reg)
     /// <return value>`.
     // Mock implementations for tests on Travis-CI.
-    #[cfg(not(any(
-        doc,
-        all(
-            any(target_arch = "riscv32", target_arch = "riscv64"),
-            target_os = "none"
-        )
+    #[cfg(not(all(
+        any(target_arch = "riscv32", target_arch = "riscv64"),
+        target_os = "none"
     )))]
     pub fn read_and_clear_bits(&self, bitmask: usize) -> usize {
         unimplemented!(
@@ -318,12 +300,9 @@ impl<R: RegisterLongName, const V: usize> Readable for ReadWriteRiscvCsr<usize, 
     type T = usize;
     type R = R;
 
-    #[cfg(any(
-        doc,
-        all(
-            any(target_arch = "riscv32", target_arch = "riscv64"),
-            target_os = "none"
-        )
+    #[cfg(all(
+        any(target_arch = "riscv32", target_arch = "riscv64"),
+        target_os = "none"
     ))]
     #[inline]
     fn get(&self) -> usize {
@@ -336,12 +315,9 @@ impl<R: RegisterLongName, const V: usize> Readable for ReadWriteRiscvCsr<usize, 
     }
 
     // Mock implementations for tests on Travis-CI.
-    #[cfg(not(any(
-        doc,
-        all(
-            any(target_arch = "riscv32", target_arch = "riscv64"),
-            target_os = "none"
-        )
+    #[cfg(not(all(
+        any(target_arch = "riscv32", target_arch = "riscv64"),
+        target_os = "none"
     )))]
     fn get(&self) -> usize {
         unimplemented!("reading RISC-V CSR {}", V)
@@ -352,12 +328,9 @@ impl<R: RegisterLongName, const V: usize> Writeable for ReadWriteRiscvCsr<usize,
     type T = usize;
     type R = R;
 
-    #[cfg(any(
-        doc,
-        all(
-            any(target_arch = "riscv32", target_arch = "riscv64"),
-            target_os = "none"
-        )
+    #[cfg(all(
+        any(target_arch = "riscv32", target_arch = "riscv64"),
+        target_os = "none"
     ))]
     #[inline]
     fn set(&self, val_to_set: usize) {
@@ -367,12 +340,9 @@ impl<R: RegisterLongName, const V: usize> Writeable for ReadWriteRiscvCsr<usize,
         }
     }
 
-    #[cfg(not(any(
-        doc,
-        all(
-            any(target_arch = "riscv32", target_arch = "riscv64"),
-            target_os = "none"
-        )
+    #[cfg(not(all(
+        any(target_arch = "riscv32", target_arch = "riscv64"),
+        target_os = "none"
     )))]
     fn set(&self, _val_to_set: usize) {
         unimplemented!("writing RISC-V CSR {}", V)

--- a/tools/build/build_all_docs.sh
+++ b/tools/build/build_all_docs.sh
@@ -5,6 +5,15 @@
 # Copyright Tock Contributors 2023.
 
 # Builds all of the board documentation into doc/rustdoc.
+#
+# This relies on rustdoc's unstable cross-crate-info merging mechanism
+# (RFC 3662, "Mergeable rustdoc cross-crate info": --write-doc-meta-dir /
+# --read-doc-meta-dir, gated behind -Z unstable-options). The actual merge
+# logic runs inside rustdoc itself -- this script never parses or rewrites
+# rustdoc's own output format -- but the flags it's built on are still
+# actively changing shape, not close to stabilizing as of Aug 2026.
+#   - rust-lang/rust#130676 is the tracking issue.
+#   - rust-lang/rust#152902, the stabilization PR.
 
 set -e
 
@@ -25,27 +34,154 @@ else
 fi
 rm -f _COW _COW2
 
-# Make the documentation for all the boards, for the host's native target.
+# arch/* and select chips/* crates have no host-target implementation (no
+# `doc`-mock cfg branch to fall back to), so they're built here against
+# their real target triple and merged into the unified doc tree via
+# rustdoc's --write-doc-meta-dir/--read-doc-meta-dir.
 #
-# `--no-deps` skips generating docs for third-party dependencies, which takes a
-# long time and we don't link to anyway.
-cargo doc --no-deps
+# Target picked by: which board uses the crate, and what target that
+# board builds for (boards/*/.cargo/config.toml).
+#
+# Maintained by hand: add an entry whenever a new arch or chip crate with
+# no host-target implementation is added.
+#
+# Each entry is "crate:target-triple". A plain indexed array (rather than
+# an associative array, i.e. `declare -A`) is used deliberately: macOS
+# ships bash 3.2, which predates associative arrays entirely.
+CRATE_TARGETS=(
+    "cortexm0:thumbv6m-none-eabi"
+    "cortexm0p:thumbv6m-none-eabi"
+    "apollo3:thumbv7em-none-eabi"
+    "arty_e21_chip:riscv32imac-unknown-none-elf"
+    "earlgrey:riscv32imc-unknown-none-elf"
+    "esp32-c3:riscv32imc-unknown-none-elf"
+    "litex_vexriscv:riscv32imc-unknown-none-elf"
+    "rp2040:thumbv6m-none-eabi"
+    "rp2350:thumbv8m.main-none-eabi"
+    "stm32f4xx:thumbv7em-none-eabi"
+)
 
-# Replace the default rust logo with our own Tock logo and the favicon with our
-# own favicon. Note, it is also possible to set this using a `#[doc]` attribute
+# Crates whose dependent boards/chips actually build for more than one real
+# target -- `riscv` serves both riscv32 and riscv64 boards, `cortexm` (and
+# its cortexv7m companion) serve both thumbv7em and thumbv8m.main boards.
+# Picking a single target here is a deliberate, somewhat arbitrary call,
+# not a fact about the crate the way CRATE_TARGETS' entries are -- called
+# out separately so that's obvious at a glance. Folded into CRATE_TARGETS
+# below; nothing past this point distinguishes the two.
+SHARED_CRATE_TARGETS=(
+    "riscv:riscv32imac-unknown-none-elf"
+    "cortexm:thumbv7em-none-eabi"
+    "cortexv7m:thumbv7em-none-eabi"
+)
+CRATE_TARGETS+=("${SHARED_CRATE_TARGETS[@]}")
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+META="$WORK/meta"
+mkdir -p "$META/host"
+
+# 1. Host pass: every crate not in CRATE_TARGETS, plus dependencies.
+# RUSTDOCFLAGS makes each crate write its own non-colliding <crate>.json
+# into $META/host. `--no-deps` skips generating docs for third-party
+# dependencies, which takes a long time and we don't link to anyway.
+CARGO_TARGET_DIR="$WORK" \
+    RUSTDOCFLAGS="${RUSTDOCFLAGS:-} -Z unstable-options --write-doc-meta-dir=$META/host" \
+    cargo doc --no-deps
+
+# CRATE_TARGETS crates get pulled into the host pass too, as dependencies
+# of the boards/chips that use them. Prune their host-pass meta so the
+# finalize step only sees each crate's dedicated real-target meta.
+for entry in "${CRATE_TARGETS[@]}"; do
+    crate="${entry%%:*}"
+    rm -f "$META/host/${crate//-/_}.json"
+done
+
+# 2. One independent real-target pass per CRATE_TARGETS crate. No
+# --read-doc-meta-dir: only each build's own <crate>/ and src/<crate>/
+# output is used later, the rest is discarded.
+for entry in "${CRATE_TARGETS[@]}"; do
+    crate="${entry%%:*}"
+    target="${entry#*:}"
+    echo "--- documenting $crate for $target ---"
+    CARGO_TARGET_DIR="$WORK" \
+        cargo rustdoc -p "$crate" --target "$target" -- \
+        -Z unstable-options --write-doc-meta-dir="$META/$crate"
+done
+
+# 3. Finalize: a single bare `rustdoc` invocation (no cargo, and no
+# crate source -- finalize mode doesn't take any, see the note up top)
+# reads every meta directory written above and writes the fully-merged
+# crates.js/trait.impl/search.index/src-files.js/static.files to its own
+# --out-dir.
+FINAL_DIR="$WORK/final"
+read_flags=(--read-doc-meta-dir="$META/host")
+for entry in "${CRATE_TARGETS[@]}"; do
+    crate="${entry%%:*}"
+    read_flags+=(--read-doc-meta-dir="$META/$crate")
+done
+echo "--- finalizing merged cross-crate info ---"
+rustdoc -Z unstable-options --out-dir="$FINAL_DIR" "${read_flags[@]}"
+
+# help.html/settings.html are static UI chrome, not derived from any
+# crate's content -- generate them with an ordinary, non-merge-mode
+# rustdoc call on a throwaway empty crate rather than trust the finalize
+# step above for them. On at least one nightly seen in the wild, finalize
+# mode silently didn't write these two files at all (rust-lang/rust#159473
+# fixes this upstream, but not every nightly has that fix yet); a plain
+# rustdoc invocation always writes them correctly and isn't exposed to
+# whatever else changes about finalize mode's behavior in the future.
+echo '//! empty' > "$WORK/empty.rs"
+rustdoc --out-dir="$WORK/chrome" "$WORK/empty.rs"
+
+# 4. Final assembly, three overlaid layers:
+#   a) Host pass output as the base: real per-crate page content for
+#      every host-buildable crate (the finalize step only carries
+#      cross-crate glue, not a crate's own rendered pages).
+#   b) The finalize step's merged glue files, over the host pass's own
+#      (unmerged) versions of the same files.
+#   c) Each CRATE_TARGETS crate's own real-target content, over
+#      whatever the host pass produced for it as a dependency.
+OUT="$WORK/merged"
+cp -r "$WORK/doc" "$OUT"
+for f in crates.js src-files.js; do
+    cp "$FINAL_DIR/$f" "$OUT/$f"
+done
+cp "$WORK/chrome/help.html" "$OUT/help.html"
+cp "$WORK/chrome/settings.html" "$OUT/settings.html"
+rm -rf "$OUT/trait.impl" "$OUT/search.index" "$OUT/static.files"
+cp -r "$FINAL_DIR/trait.impl" "$OUT/trait.impl"
+cp -r "$FINAL_DIR/search.index" "$OUT/search.index"
+cp -r "$FINAL_DIR/static.files" "$OUT/static.files"
+for entry in "${CRATE_TARGETS[@]}"; do
+    crate="${entry%%:*}"
+    target="${entry#*:}"
+    # rustdoc substitutes '-' with '_' in output directory names, since
+    # crate names there are Rust identifiers (e.g. package "esp32-c3" is
+    # documented under a directory named "esp32_c3").
+    docname="${crate//-/_}"
+    rm -rf "$OUT/$docname" "$OUT/src/$docname"
+    cp -r "$WORK/$target/doc/$docname" "$OUT/$docname"
+    if [ -d "$WORK/$target/doc/src/$docname" ]; then
+        cp -r "$WORK/$target/doc/src/$docname" "$OUT/src/$docname"
+    fi
+done
+
+# Replace the default rust logo with our own Tock logo and the favicon with
+# our own favicon. Note, it is also possible to set this using a `#[doc]`
+# attribute
 # (https://doc.rust-lang.org/rustdoc/the-doc-attribute.html#html_logo_url) but
 # doing it this way avoids having to set the attribute for every crate.
-curl https://www.tockos.org/assets/img/tocklogo.png --output target/doc/rust-logo.png
-curl https://www.tockos.org/assets/img/icons/favicon-32x32.png --output target/doc/favicon-32x32.png
-curl https://www.tockos.org/assets/img/icons/favicon-16x16.png --output target/doc/favicon-16x16.png
-curl https://www.tockos.org/assets/img/icons/safari-pinned-tab.svg --output target/doc/favicon.svg
-
-# Move the docs to doc/rustdoc.
-$CP_COW -r target/doc doc/rustdoc
+curl https://www.tockos.org/assets/img/tocklogo.png --output "$OUT/rust-logo.png"
+curl https://www.tockos.org/assets/img/icons/favicon-32x32.png --output "$OUT/favicon-32x32.png"
+curl https://www.tockos.org/assets/img/icons/favicon-16x16.png --output "$OUT/favicon-16x16.png"
+curl https://www.tockos.org/assets/img/icons/safari-pinned-tab.svg --output "$OUT/favicon.svg"
 
 # Temporary redirect rule
 # https://www.netlify.com/docs/redirects/
-cat > doc/rustdoc/_redirects << EOF
+cat > "$OUT/_redirects" << EOF
 # While we don't have a home page :/
 /            /kernel            302
 EOF
+
+# Move the docs to doc/rustdoc.
+$CP_COW -r "$OUT" doc/rustdoc

--- a/tools/build/build_all_docs.sh
+++ b/tools/build/build_all_docs.sh
@@ -48,6 +48,10 @@ rm -f _COW _COW2
 # Each entry is "crate:target-triple". A plain indexed array (rather than
 # an associative array, i.e. `declare -A`) is used deliberately: macOS
 # ships bash 3.2, which predates associative arrays entirely.
+#
+# `x86` is the one entry using a path to a custom JSON target spec instead
+# of a builtin triple (no builtin i486 target exists); see the `.json`
+# branch in the per-crate build loop below for what that requires.
 CRATE_TARGETS=(
     "cortexm0:thumbv6m-none-eabi"
     "cortexm0p:thumbv6m-none-eabi"
@@ -59,6 +63,7 @@ CRATE_TARGETS=(
     "rp2040:thumbv6m-none-eabi"
     "rp2350:thumbv8m.main-none-eabi"
     "stm32f4xx:thumbv7em-none-eabi"
+    "x86:boards/qemu_i486_q35/i486-unknown-none.json"
 )
 
 # Crates whose dependent boards/chips actually build for more than one real
@@ -76,6 +81,15 @@ SHARED_CRATE_TARGETS=(
     "cortexv7m:thumbv7em-none-eabi"
 )
 CRATE_TARGETS+=("${SHARED_CRATE_TARGETS[@]}")
+
+# cargo/rustdoc name a target's output directory after its triple, or (for
+# a `--target path/to/name.json`) after just `name` -- strip any leading
+# path and `.json` suffix to get that directory name from a CRATE_TARGETS
+# target value.
+target_dir_name() {
+    local t="${1##*/}"
+    echo "${t%.json}"
+}
 
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
@@ -105,9 +119,22 @@ for entry in "${CRATE_TARGETS[@]}"; do
     crate="${entry%%:*}"
     target="${entry#*:}"
     echo "--- documenting $crate for $target ---"
-    CARGO_TARGET_DIR="$WORK" \
-        cargo rustdoc -p "$crate" --target "$target" -- \
-        -Z unstable-options --write-doc-meta-dir="$META/$crate"
+    if [ "${target%.json}" != "$target" ]; then
+        # A custom JSON target spec (no builtin triple exists) needs
+        # cargo's own -Z json-target-spec just to accept a `--target
+        # *.json` path, and -Z build-std since custom targets have no
+        # prebuilt std/core component to fall back on. All -Z flags have
+        # to be grouped together before the subcommand for cargo to
+        # accept them.
+        CARGO_TARGET_DIR="$WORK" \
+            cargo -Z json-target-spec -Z build-std=core,compiler_builtins -Z unstable-options \
+            rustdoc -p "$crate" --target "$target" -- \
+            --write-doc-meta-dir="$META/$crate"
+    else
+        CARGO_TARGET_DIR="$WORK" \
+            cargo rustdoc -p "$crate" --target "$target" -- \
+            -Z unstable-options --write-doc-meta-dir="$META/$crate"
+    fi
 done
 
 # 3. Finalize: a single bare `rustdoc` invocation (no cargo, and no
@@ -156,15 +183,15 @@ cp -r "$FINAL_DIR/search.index" "$OUT/search.index"
 cp -r "$FINAL_DIR/static.files" "$OUT/static.files"
 for entry in "${CRATE_TARGETS[@]}"; do
     crate="${entry%%:*}"
-    target="${entry#*:}"
+    target_dir=$(target_dir_name "${entry#*:}")
     # rustdoc substitutes '-' with '_' in output directory names, since
     # crate names there are Rust identifiers (e.g. package "esp32-c3" is
     # documented under a directory named "esp32_c3").
     docname="${crate//-/_}"
     rm -rf "$OUT/$docname" "$OUT/src/$docname"
-    cp -r "$WORK/$target/doc/$docname" "$OUT/$docname"
-    if [ -d "$WORK/$target/doc/src/$docname" ]; then
-        cp -r "$WORK/$target/doc/src/$docname" "$OUT/src/$docname"
+    cp -r "$WORK/$target_dir/doc/$docname" "$OUT/$docname"
+    if [ -d "$WORK/$target_dir/doc/src/$docname" ]; then
+        cp -r "$WORK/$target_dir/doc/src/$docname" "$OUT/src/$docname"
     fi
 done
 

--- a/tools/build/build_all_docs.sh
+++ b/tools/build/build_all_docs.sh
@@ -62,14 +62,16 @@ CRATE_TARGETS=(
 )
 
 # Crates whose dependent boards/chips actually build for more than one real
-# target -- `riscv` serves both riscv32 and riscv64 boards, `cortexm` (and
-# its cortexv7m companion) serve both thumbv7em and thumbv8m.main boards.
-# Picking a single target here is a deliberate, somewhat arbitrary call,
-# not a fact about the crate the way CRATE_TARGETS' entries are -- called
-# out separately so that's obvious at a glance. Folded into CRATE_TARGETS
-# below; nothing past this point distinguishes the two.
+# target -- `riscv` (and its riscv-csr dependency) serve both riscv32 and
+# riscv64 boards; `cortexm` (and its cortexv7m companion) serve both
+# thumbv7em and thumbv8m.main boards. Picking a single target here is a
+# deliberate, somewhat arbitrary call, not a fact about the crate the way
+# CRATE_TARGETS' entries are -- called out separately so that's obvious at
+# a glance. Folded into CRATE_TARGETS below; nothing past this point
+# distinguishes the two.
 SHARED_CRATE_TARGETS=(
     "riscv:riscv32imac-unknown-none-elf"
+    "riscv-csr:riscv32imac-unknown-none-elf"
     "cortexm:thumbv7em-none-eabi"
     "cortexv7m:thumbv7em-none-eabi"
 )


### PR DESCRIPTION
### Pull Request Overview

The PR aims to eliminate most, if not all use of `cfg(doc)` :tada:

There's a fair bit of text here, but I promise I wrote all of it :)

#### Background: Why we have the `cfg(doc)` mess at all and why we can get rid of it now

This investigation was inspired by #5018, which highlighted the frustrating number of `cfg` permutations that we have. I think this is a case where key things have improved upstream such that we can eliminate a lot of `cfg(doc)` stuff.

One thing that we've always valued is a single, unified documentation across the various crates in the tock kernel. Way back in the day, we built docs for every crate and then merged the output ourselves; that was fragile and sucked to do. Nowadays, we do a `cargo doc` on the whole workspace which does the unification for us.

We have `cfg(doc)` so that when building something like arch-specific code with a host target we still choose to document the arch-specific one. We needed this for a few reasons:

  1. Once upon a time, `rustdoc` would _only_ build for the host target, you couldn't specify a non-host target for docs builds
      - That's not true anymore, I don't know when it changed but I think it was a long time ago. You can run `rustdoc` for different targets [n.b., this is what rust-embedded, embassy, and others already do and is _half_ of why they aren't littered with `cfg(doc)` and mocks]
  2. We needed the 'whole workspace cargo doc' to get the unified build (and `host` is the only target that makes sense for the _whole_ workspace, since anything else would filter out arches in a weird way)
      - This isn't true anymore either. [Rustdoc now explicitly supports merging documentation from multiple crates](https://rust-lang.github.io/rfcs/3662-mergeable-rustdoc-cross-crate-info.html) — this is technically an unstable feature of rustdoc, and there's some non-trivial blockers to it being stabilized, but it's also heavily used by projects bigger than Tock so I don't fear that it's going anywhere.

#### The punchline: I believe we can remove "doc" from most cfgs.

By running rustdoc with real targets, we get 'for free' the benefit Brad noted on #5018 `Ideally get the docs from what is likely the most documented function.` since documentation builds will now use the actual real target code.

Now for the bad news: This doesn't actually remove most/any of the mock impls, because they are still used by `cargo test` and `clippy`, which still do host builds*. But it does at least eliminate some complexity from the `cfg` signatures.

#### How it works

We go back to a "merge" instead of a single `cargo doc` for the whole workspace when doing the docs build.

However, this not nearly as fragile and painful as it used to be. We aren't mucking around in the internals of rustdoc output, we're using rustdoc itself and officially supported upstream tools to do the merging.

The only thing that is manual is the selection of _which_ crates need target-specific builds (and which target to use for them), i.e., the `CRATE_TARGETS` array in `build_all_docs` — this only needs to be updated when we add a new architecture or a chip with some assembly in it; I don't expect much churn here.

`*from above`: The mock impls are technically still used here too for the moment. It's more efficient to just do the same host-target workspace doc build we've always been doing (which will document the "wrong" host mock impls) and then do arch-specific doc runs for the cases that need it and overwrite the workspace build (as opposed to building every crate separately and merging them all). Doing this supposedly (trusting 🤖) saves a few minutes on a full docs build.

I had Claude do a lot of the heavy lifting to actually implement things here. 

### Testing Strategy

This pull request was tested by building docs and comparing their output to the previously generated docs.

### TODO or Help Wanted

Do we like this? I hope we like this, I'm pretty excited to see a lot of `cfg` go away...

### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

Claude did the actual implementation work here and authored the commits with some heavy iteration and interaction from me on the details.
