### PR TITLE
boards: linker: fix kernel len calculation

### DIFF
--- a/boards/build_scripts/tock_kernel_layout.ld
+++ b/boards/build_scripts/tock_kernel_layout.ld
@@ -395,7 +395,7 @@ SECTIONS
          * the kernel binary.
          */
         LONG(ORIGIN(rom)) /* Address of start of kernel binary. */
-        LONG((LOADADDR(.relocate) + (_erelocate - _srelocate)) - ORIGIN(rom)) /* Length of kernel binary. */
+        LONG((_etext + (_erelocate - _srelocate)) - ORIGIN(rom)) /* Length of kernel binary. */
         SHORT(0x0102) /* Type = Kernel Flash = 0x0102 */
         SHORT(8)      /* Length = 8 bytes */
 


### PR DESCRIPTION


### Pull Request Overview

Using `LOADADDR(.relocate)` gets caught up in the same issues we've seen before, where different passes can end up with different addresses. In particular, somtimes that gets set to the address in RAM.

This uses the location of `_etext` instead, which is more straightforward anyway, and avoids this issue.

Fixes #4959.


### Testing Strategy

Running 
```
$ cd boards/nucleo_u545re_q
$ tockloader local-board set --binary-path board.bin --arch cortex-m4 --app-address 0x0C040000 --flash-address 0x0C000000 nucleo_u545re_q
$ make
$ tockloader flash --address 0x0C000000 /Users/bradjc/git/tock/target/thumbv8m.main-none-eabi/release/nucleo_u545re_q.bin
$ tockloader info
```
and seeing the output

```
❯ tockloader info
[INFO   ] No device name specified. Using default name "tock".
[INFO   ] Using flash-file to communicate with the board.
[INFO   ] Using settings from KNOWN_BOARDS["nucleo_u545re_q"]
[INFO   ] Operating on flash file "/Users/bradjc/git/tock/boards/nucleo_u545re_q/board.bin".
[INFO   ] Limiting flash size to 0x80000000 bytes.
tockloader version: 1.18.0-dev
[STATUS ] Showing all properties of the board...
[INFO   ] Hardcoding command line argument "openocd" to "True" for board nucleo_u545re_q.
[INFO   ] No found apps.
Apps:
Kernel Attributes                               [0x0  ] [0xc040000]
  sentinel            : TOCK                    [-0x4 ] [0xc03fffc]
  version             : 1                       [-0x8 ] [0xc03fff8]
KATLV: App Memory (0x101)                       [-0x14] [0xc03ffec]
  app_memory_start    :  805322808   0x30004038
  app_memory_len      :     147400      0x23fc8
KATLV: Kernel Binary (0x102)                    [-0x20] [0xc03ffe0]
  kernel_binary_start :  201326592    0xc000000
  kernel_binary_len   :      90112      0x16000
KATLV: Kernel Version (0x103)                   [-0x2c] [0xc03ffd4]
  kernel_version      : 2.3.0-dev

[INFO   ] Finished in 0.000 seconds
```

whereas before it was:

```
❯ tockloader info
[INFO   ] No device name specified. Using default name "tock".
[INFO   ] Using flash-file to communicate with the board.
[INFO   ] Using settings from KNOWN_BOARDS["nucleo_u545re_q"]
[INFO   ] Operating on flash file "/Users/bradjc/git/tock/boards/nucleo_u545re_q/board.bin".
[INFO   ] Limiting flash size to 0x80000000 bytes.
tockloader version: 1.18.0-dev
[STATUS ] Showing all properties of the board...
[INFO   ] Hardcoding command line argument "openocd" to "True" for board nucleo_u545re_q.
[INFO   ] No found apps.
Apps:
Kernel Attributes                               [0x0  ] [0xc040000]
  sentinel            : TOCK                    [-0x4 ] [0xc03fffc]
  version             : 1                       [-0x8 ] [0xc03fff8]
KATLV: App Memory (0x101)                       [-0x14] [0xc03ffec]
  app_memory_start    :  805322808   0x30004038
  app_memory_len      :     147400      0x23fc8
KATLV: Kernel Binary (0x102)                    [-0x20] [0xc03ffe0]
  kernel_binary_start :  201326592    0xc000000
  kernel_binary_len   :  603987968   0x24002000
KATLV: Kernel Version (0x103)                   [-0x2c] [0xc03ffd4]
  kernel_version      : 2.3.0-dev

[INFO   ] Finished in 0.000 seconds
```
(note the kernel binary length is way too large.)


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

I asked claude to suggest a fix.
