### PR TITLE
boards: nucleo_u545re_q: config is stable

### DIFF
--- a/boards/nucleo_u545re_q/.cargo/config.toml
+++ b/boards/nucleo_u545re_q/.cargo/config.toml
@@ -9,6 +9,3 @@ include = [
 
 [build]
 target = "thumbv8m.main-none-eabi"
-
-[unstable]
-config-include = true


### PR DESCRIPTION
### Pull Request Overview

This should have been removed before merging the board.


### Testing Strategy

Avoids these warnings:

```
❯ make
warning: unused config key `unstable.config-include` in `/Users/bradjc/git/tock/boards/nucleo_u545re_q/.cargo/config.toml`
warning: unused config key `unstable.config-include` in `/Users/bradjc/git/tock/boards/nucleo_u545re_q/.cargo/config.toml`
warning: unused config key `unstable.config-include` in `/Users/bradjc/git/tock/boards/nucleo_u545re_q/.cargo/config.toml`
    Finished `release` profile [optimized + debuginfo] target(s) in 0.08s
   text	   data	    bss	    dec	    hex	filename
  90156	      0	  16444	 106600	  1a068	/Users/bradjc/git/tock/target/thumbv8m.main-none-eabi/release/nucleo_u545re_q
324f4126a181a3d4baef5878e665252f0fb2854386028fe9f1149065973b29b2  /Users/bradjc/git/tock/target/thumbv8m.main-none-eabi/release/nucleo_u545re_q.bin
```


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
