### PR TITLE
Doc: Misc `cargo doc` and `make doc` fixes 2026-08

### DIFF
--- a/chips/psc3/src/interrupts.rs
+++ b/chips/psc3/src/interrupts.rs
@@ -224,61 +224,61 @@ pub const TCPWM_0_MOTIF_INTERRUPT_65: u32 = 0x6B;
 pub const PASS_INTERRUPT_MCPASS: u32 = 0x6C;
 /// Combined SAR Entry and FIR results interrupt (dec: 109)
 pub const PASS_INTERRUPT_SAR_RESULTS: u32 = 0x6D;
-/// Individual SAR Entry result interrupts [0] (dec: 110)
+/// Individual SAR Entry result interrupts#0 (dec: 110)
 pub const PASS_INTERRUPT_SAR_ENTRY_DONE_0: u32 = 0x6E;
-/// Individual SAR Entry result interrupts [1] (dec: 111)
+/// Individual SAR Entry result interrupts#1 (dec: 111)
 pub const PASS_INTERRUPT_SAR_ENTRY_DONE_1: u32 = 0x6F;
-/// Individual SAR Entry result interrupts [2] (dec: 112)
+/// Individual SAR Entry result interrupts#2 (dec: 112)
 pub const PASS_INTERRUPT_SAR_ENTRY_DONE_2: u32 = 0x70;
-/// Individual SAR Entry result interrupts [3] (dec: 113)
+/// Individual SAR Entry result interrupts#3 (dec: 113)
 pub const PASS_INTERRUPT_SAR_ENTRY_DONE_3: u32 = 0x71;
-/// Individual SAR Entry result interrupts [4] (dec: 114)
+/// Individual SAR Entry result interrupts#4 (dec: 114)
 pub const PASS_INTERRUPT_SAR_ENTRY_DONE_4: u32 = 0x72;
-/// Individual SAR Entry result interrupts [5] (dec: 115)
+/// Individual SAR Entry result interrupts#5 (dec: 115)
 pub const PASS_INTERRUPT_SAR_ENTRY_DONE_5: u32 = 0x73;
-/// Individual SAR Entry result interrupts [6] (dec: 116)
+/// Individual SAR Entry result interrupts#6 (dec: 116)
 pub const PASS_INTERRUPT_SAR_ENTRY_DONE_6: u32 = 0x74;
-/// Individual SAR Entry result interrupts [7] (dec: 117)
+/// Individual SAR Entry result interrupts#7 (dec: 117)
 pub const PASS_INTERRUPT_SAR_ENTRY_DONE_7: u32 = 0x75;
-/// Individual FIR result interrupts[0] (dec: 118)
+/// Individual FIR result interrupts#0 (dec: 118)
 pub const PASS_INTERRUPT_SAR_FIR_DONE_0: u32 = 0x76;
-/// Individual FIR result interrupts[1] (dec: 119)
+/// Individual FIR result interrupts#1 (dec: 119)
 pub const PASS_INTERRUPT_SAR_FIR_DONE_1: u32 = 0x77;
 /// Combined SAR range interrupt (dec: 120)
 pub const PASS_INTERRUPT_SAR_RANGES: u32 = 0x78;
-/// Individual SAR range interrupts[0] (dec: 121)
+/// Individual SAR range interrupts#0 (dec: 121)
 pub const PASS_INTERRUPT_SAR_RANGE_0: u32 = 0x79;
-/// Individual SAR range interrupts[1] (dec: 122)
+/// Individual SAR range interrupts#1 (dec: 122)
 pub const PASS_INTERRUPT_SAR_RANGE_1: u32 = 0x7A;
-/// Individual SAR range interrupts[2] (dec: 123)
+/// Individual SAR range interrupts#2 (dec: 123)
 pub const PASS_INTERRUPT_SAR_RANGE_2: u32 = 0x7B;
-/// Individual SAR range interrupts[3] (dec: 124)
+/// Individual SAR range interrupts#3 (dec: 124)
 pub const PASS_INTERRUPT_SAR_RANGE_3: u32 = 0x7C;
-/// Individual SAR range interrupts[4] (dec: 125)
+/// Individual SAR range interrupts#4 (dec: 125)
 pub const PASS_INTERRUPT_SAR_RANGE_4: u32 = 0x7D;
-/// Individual SAR range interrupts[5] (dec: 126)
+/// Individual SAR range interrupts#5 (dec: 126)
 pub const PASS_INTERRUPT_SAR_RANGE_5: u32 = 0x7E;
-/// Individual SAR range interrupts[6] (dec: 127)
+/// Individual SAR range interrupts#6 (dec: 127)
 pub const PASS_INTERRUPT_SAR_RANGE_6: u32 = 0x7F;
-/// Individual SAR range interrupts[7] (dec: 128)
+/// Individual SAR range interrupts#7 (dec: 128)
 pub const PASS_INTERRUPT_SAR_RANGE_7: u32 = 0x80;
 /// Combined CSG DAC interrupt (dec: 129)
 pub const PASS_INTERRUPT_CSG_DACS: u32 = 0x81;
-/// Individual CSG DAC interrupts ( 5 in PSOC C3 )[0] (dec: 130)
+/// Individual CSG DAC interrupts ( 5 in PSOC C3 )#0 (dec: 130)
 pub const PASS_INTERRUPT_CSG_DAC_0: u32 = 0x82;
-/// Individual CSG DAC interrupts ( 5 in PSOC C3 )[1] (dec: 131)
+/// Individual CSG DAC interrupts ( 5 in PSOC C3 )#1 (dec: 131)
 pub const PASS_INTERRUPT_CSG_DAC_1: u32 = 0x83;
-/// Individual CSG DAC interrupts ( 5 in PSOC C3 )[2] (dec: 132)
+/// Individual CSG DAC interrupts ( 5 in PSOC C3 )#2 (dec: 132)
 pub const PASS_INTERRUPT_CSG_DAC_2: u32 = 0x84;
-/// Individual CSG DAC interrupts ( 5 in PSOC C3 )[3] (dec: 133)
+/// Individual CSG DAC interrupts ( 5 in PSOC C3 )#3 (dec: 133)
 pub const PASS_INTERRUPT_CSG_DAC_3: u32 = 0x85;
-/// Individual CSG DAC interrupts ( 5 in PSOC C3 )[4] (dec: 134)
+/// Individual CSG DAC interrupts ( 5 in PSOC C3 )#4 (dec: 134)
 pub const PASS_INTERRUPT_CSG_DAC_4: u32 = 0x86;
-/// Individual CSG DAC interrupts ( 5 in PSOC C3 )[5] (dec: 135)
+/// Individual CSG DAC interrupts ( 5 in PSOC C3 )#5 (dec: 135)
 pub const PASS_INTERRUPT_CSG_DAC_5: u32 = 0x87;
-/// Individual CSG DAC interrupts ( 5 in PSOC C3 )[6] (dec: 136)
+/// Individual CSG DAC interrupts ( 5 in PSOC C3 )#6 (dec: 136)
 pub const PASS_INTERRUPT_CSG_DAC_6: u32 = 0x88;
-/// Individual CSG DAC interrupts ( 5 in PSOC C3 )[7] (dec: 137)
+/// Individual CSG DAC interrupts ( 5 in PSOC C3 )#7 (dec: 137)
 pub const PASS_INTERRUPT_CSG_DAC_7: u32 = 0x89;
 /// Combined CSG CMP interrupts (dec: 138)
 pub const PASS_INTERRUPT_CSG_CMPS: u32 = 0x8A;

--- a/chips/stm32wle5xx/src/subghz_radio.rs
+++ b/chips/stm32wle5xx/src/subghz_radio.rs
@@ -14,7 +14,7 @@
 //! through the gpio capsule.
 //!
 //! Radiolib takes a similar approach in their stm32wle5xx port:
-//! https://github.com/jgromes/RadioLib/issues/588.
+//! <https://github.com/jgromes/RadioLib/issues/588>.
 
 use core::cell::Cell;
 

--- a/chips/virtio/src/devices/virtio_gpu/deferred_call.rs
+++ b/chips/virtio/src/devices/virtio_gpu/deferred_call.rs
@@ -5,7 +5,7 @@
 use core::cell::Cell;
 
 /// Different deferred calls requested by and delivered to the
-/// [`VirtIOGPU`] driver.
+/// [`VirtIOGPU`](super::VirtIOGPU) driver.
 #[derive(Copy, Clone)]
 #[repr(usize)]
 pub enum PendingDeferredCall {
@@ -13,7 +13,7 @@ pub enum PendingDeferredCall {
 }
 
 /// Manager of the deferred calls requested by and delivered to the
-/// [`VirtIOGPU`] driver.
+/// [`VirtIOGPU`](super::VirtIOGPU) driver.
 pub struct PendingDeferredCallMask(Cell<usize>);
 
 impl PendingDeferredCallMask {

--- a/chips/x86_q35/src/keyboard.rs
+++ b/chips/x86_q35/src/keyboard.rs
@@ -10,9 +10,9 @@
 //! - Keyboard speaks simple command/ACK (0xFA) / RESEND (0xFE) protocol
 //!
 //! References:
-//! - OSDev: i8042 PS/2 Controller — https://wiki.osdev.org/I8042_PS/2_Controller
-//! - OSDev: PS/2 Keyboard — https://wiki.osdev.org/PS/2_Keyboard
-//! - OSDev: Keyboard / Scan Code Set 2 — https://wiki.osdev.org/Keyboard#Scan_Code_Set_2
+//! - OSDev: i8042 PS/2 Controller — <https://wiki.osdev.org/I8042_PS/2_Controller>
+//! - OSDev: PS/2 Keyboard — <https://wiki.osdev.org/PS/2_Keyboard>
+//! - OSDev: Keyboard / Scan Code Set 2 — <https://wiki.osdev.org/Keyboard#Scan_Code_Set_2>
 
 use crate::cmd_fifo::Fifo as CmdFifo;
 use crate::ps2::Ps2Client;

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -1713,7 +1713,7 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
     ///
     /// because of the error:
     ///
-    /// ```ignore
+    /// ```text
     /// error: generic `Self` types are currently not permitted in anonymous constants
     ///     --> kernel/src/process_standard.rs:1712:70
     ///      |

--- a/kernel/src/utilities/dma_slice.rs
+++ b/kernel/src/utilities/dma_slice.rs
@@ -749,7 +749,7 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMutImm
 pub mod immutable_from_into_bytes {
     /// Sealing module for [`ImmutableFromIntoBytes`]
     mod private {
-        /// Sealing trait for [`ImmutableFromIntoBytes`]
+        /// Sealing trait for [`ImmutableFromIntoBytes`](super::ImmutableFromIntoBytes)
         pub trait Sealed {}
     }
 


### PR DESCRIPTION
### Pull Request Overview

Playing with docs turns up a bunch of warnings and errors depending on which `cargo doc` or `make doc` command you run. This fixes a handful.


### Testing Strategy

Running `cargo doc` and `make doc` in different directories.


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
