### PR TITLE
boards: rpi pico 2: use tockloader local-board

### DIFF
--- a/boards/raspberry_pi_pico_2/Makefile
+++ b/boards/raspberry_pi_pico_2/Makefile
@@ -12,38 +12,26 @@ OPENOCD_OPTIONS=-f openocd-$(OPENOCD_INTERFACE).cfg
 
 BOOTSEL_FOLDER?=/run/media/$(USER)/RP2350
 
-KERNEL=$(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/release/$(PLATFORM)-app.elf
-
-
 # Default target for installing the kernel.
 .PHONY: install
-install: flash
+install: program
 
-.PHONY: flash-openocd
-flash-openocd: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	$(OPENOCD) $(OPENOCD_OPTIONS) -c "adapter speed 5000" -c "program $<; verify_image $<;  reset; shutdown;"
 
 .PHONY: flash
-flash: $(KERNEL)
-	picotool uf2 convert $< $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2
-	@if [ -d $(BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2 "$(BOOTSEL_FOLDER)"; else echo; echo Please edit the BOOTSEL_FOLDER variable to point to you Raspberry Pi Pico 2 Flash Drive Folder; echo You can download and flash $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2; fi
+flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+	tockloader flash --address 0x10000000 --board raspberry_pi_pico_2 $<
+
+
+.PHONY: init
+init:
+	tockloader local-board set raspberry_pi_pico --binary-path rpi2.bin --flash-address 0x10000000 --app-address 0x10040000
+
+rpi2.bin: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+	tockloader flash --address 0x10000000 $<
+
+rpi2.uf2: rpi2.bin
+	picotool uf2 convert $< $@
 
 .PHONY: program
-program: $(KERNEL)
-ifeq ($(APP),)
-	$(error Please define the APP variable with the TBF file to flash an application)
-endif
-	arm-none-eabi-objcopy --set-section-flags .apps=LOAD,ALLOC $(KERNEL) $(KERNEL_WITH_APP)
-	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL_WITH_APP)
-	picotool uf2 convert $(KERNEL_WITH_APP) $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2
-	@if [ -d $(BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2 "$(BOOTSEL_FOLDER)"; else echo; echo Please edit the BOOTSEL_FOLDER variable to point to you Raspberry Pi Pico 2 Flash Drive Folder; echo You can download and flash $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2; fi
-
-.PHONY: program-openocd
-program-openocd: $(KERNEL)
-ifeq ($(APP),)
-	$(error Please define the APP variable with the TBF file to flash an application)
-endif
-	arm-none-eabi-objcopy --set-section-flags .apps=LOAD,ALLOC $(KERNEL) $(KERNEL_WITH_APP)
-	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL_WITH_APP)
-	$(OPENOCD) $(OPENOCD_OPTIONS) -c "adapter speed 5000" -c "program $(KERNEL_WITH_APP); verify_image $(KERNEL_WITH_APP);  reset; shutdown;"
+program: rpi2.uf2
+	cp $< "$(BOOTSEL_FOLDER)"

--- a/boards/raspberry_pi_pico_2/Makefile
+++ b/boards/raspberry_pi_pico_2/Makefile
@@ -16,6 +16,9 @@ BOOTSEL_FOLDER?=/run/media/$(USER)/RP2350
 .PHONY: install
 install: program
 
+.PHONY: flash-openocd
+flash-openocd: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+	$(OPENOCD) $(OPENOCD_OPTIONS) -c "adapter speed 5000" -c "program $<; verify_image $<;  reset; shutdown;"
 
 .PHONY: flash
 flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin

--- a/boards/raspberry_pi_pico_2/README.md
+++ b/boards/raspberry_pi_pico_2/README.md
@@ -12,47 +12,75 @@ First, follow the [Tock Getting Started guide](../../doc/Getting_Started.md)
 
 ## Installing picotool
 
-The RP2350 uses UF2 files for flashing. Tock compiles to an ELF file.
-The `picotool` utility is needed to transform the Tock ELF file into an UF2 file.
+The RP2350 uses UF2 files for flashing. Tock compiles to an ELF file. The
+`picotool` utility is needed to transform the Tock ELF file into an UF2 file.
 
-To install `picotool`, check the instructions from their GitHub [page](https://github.com/raspberrypi/picotool).
+To install `picotool`, check the instructions from their GitHub
+[page](https://github.com/raspberrypi/picotool).
 
 
 ## Flashing the kernel
 
-The Raspberry Pi Pico 2 RP2350 Connect can be programmed using its bootloader, which requires an UF2 file.
+The Raspberry Pi Pico 2 RP2350 Connect can be programmed using its bootloader,
+which requires an UF2 file.
+
+### Configure the local board with Tockloader
+
+The Pico 2 bootloader can only flash a single file at a fixed address. So we
+need to create a combined file that includes the kernel and apps. To configure
+Tockloader to do this, run
+
+```bash
+$ make init
+```
 
 ### Enter BOOTSEL mode
 
 To flash the Pico RP2350, it needs to be put into BOOTSEL mode. This will mount
-a flash drive that allows one to copy a UF2 file. To enter BOOTSEL mode, press the BOOTSEL button and hold it while you connect the other end of the micro USB cable to your computer.
+a flash drive that allows one to copy a UF2 file. To enter BOOTSEL mode, press
+the BOOTSEL button and hold it while you connect the other end of the micro USB
+cable to your computer.
 
 Then `cd` into `boards/raspberry_pi_pico_2` directory and run:
 
 ```bash
-$ make flash
-
-(or)
-
-$ make flash-debug
+$ make program
 ```
 
-> Note: The Makefile provides the BOOTSEL_FOLDER variable that points towards the mount point of
-> the Pico 2 RP2350 flash drive. By default, this is located in `/media/$(USER)/RP2350`. This might
-> be different on several systems, make sure to adjust it.
+> Note: The Makefile provides the BOOTSEL_FOLDER variable that points towards
+> the mount point of the Pico 2 RP2350 flash drive. By default, this is located
+> in `/media/$(USER)/RP2350`. This might be different on several systems, make
+> sure to adjust it.
+>
+> On Mac, this can likely be set with `export BOOTSEL_FOLDER=/Volumes/RP2350`.
 
-## Flashing app
+## Installing apps
 
 Enter BOOTSEL mode.
 
-Apps are built out-of-tree. Once an app is built, you can add the path to it in the Makefile (APP variable), then run:
-```bash
-$ APP="<path to app's tbf file>" make flash-app
+Apps are built out-of-tree. Once an app is built,
+install it with tockloader:
+
+```
+$ tockloader install
+```
+
+Because of the `make init` step above, this will install the app to the local
+file.
+
+To install the kernel and apps to the board:
+
+```
+$ make program
 ```
 
 ## Debugging
 
-The Raspberry Pi Pico can also be programmed via an SWD connection, which requires the Pico to be connected to a regular Raspberry Pi device that exposes the necessary pins OR using another Raspberry Pi Pico set up in “Picoprobe” mode. The kernel is transferred to the Raspberry Pi Pico using a [custom version of OpenOCD](https://github.com/raspberrypi/openocd).
+The Raspberry Pi Pico can also be programmed via an SWD connection, which
+requires the Pico to be connected to a regular Raspberry Pi device that exposes
+the necessary pins OR using another Raspberry Pi Pico set up in “Picoprobe”
+mode. The kernel is transferred to the Raspberry Pi Pico using a [custom version
+of OpenOCD](https://github.com/raspberrypi/openocd).
 
 ### Flashing Setup
 
@@ -70,11 +98,17 @@ $ make -j4
 $ sudo make install
 ```
 
-Enable SSH on the Raspberry Pi by following the [instructions on the Raspberry Pi website](https://www.raspberrypi.org/documentation/remote-access/ssh/).
+Enable SSH on the Raspberry Pi by following the [instructions on the Raspberry
+Pi website](https://www.raspberrypi.org/documentation/remote-access/ssh/).
 
-Next, connect the SWD pins of the Pico 2 (the tree lower wires) to GND, GPIO 24, and GPIO 25 of the Raspberry Pi. You can follow the schematic in the [official documentation](https://datasheets.raspberrypi.org/pico/getting-started-with-pico.pdf#%5B%7B%22num%22%3A22%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C115%2C431.757%2Cnull%5D) and connect the blue, black, and purple wires.
+Next, connect the SWD pins of the Pico 2 (the tree lower wires) to GND, GPIO 24,
+and GPIO 25 of the Raspberry Pi. You can follow the schematic in the
+[official documentation](https://datasheets.raspberrypi.org/pico/getting-started-with-pico.pdf#%5B%7B%22num%22%3A22%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C115%2C431.757%2Cnull%5D)
+and connect the blue, black, and purple wires.
 
-Also connect the other three wires as shown in the schematic, which will connect the Pico UART to the Raspberry Pi. This will enable the serial communication between the two devices.
+Also connect the other three wires as shown in the schematic, which will connect
+the Pico UART to the Raspberry Pi. This will enable the serial communication
+between the two devices.
 
 #### From a Linux Host using a Picoprobe (option 2)
 
@@ -90,22 +124,35 @@ $ make -j4
 $ sudo make install
 ```
 
-Download the Picoprobe UF2 file onto the USB mass storage device presented by the Pico that is going to act as Picoprobe device after plugging it into some USB port: https://datasheets.raspberrypi.com/soft/picoprobe.uf2 (the device should automatically restart after the file has been written).
+Download the Picoprobe UF2 file onto the USB mass storage device presented by
+the Pico that is going to act as Picoprobe device after plugging it into some
+USB port: https://datasheets.raspberrypi.com/soft/picoprobe.uf2 (the device
+should automatically restart after the file has been written).
 
-Next, connect the SWD pins of the Pico 2 target (the tree lower wires, left-to-right) to GP2, GND, and GP3 of the Pico that will act as Picoprobe. You can follow the schematic in the [official documentation](https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf#%5B%7B%22num%22%3A64%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C115%2C696.992%2Cnull%5D) and connect the blue, black, and purple wires.
+Next, connect the SWD pins of the Pico 2 target (the tree lower wires,
+left-to-right) to GP2, GND, and GP3 of the Pico that will act as Picoprobe. You
+can follow the schematic in the
+[official documentation](https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf#%5B%7B%22num%22%3A64%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C115%2C696.992%2Cnull%5D)
+and connect the blue, black, and purple wires.
 
-Also connect the other four wires as shown in the schematic, which will connect the Pico UART and power to the Picoprobe. This will enable the serial communication between the two devices.
+Also connect the other four wires as shown in the schematic, which will connect
+the Pico UART and power to the Picoprobe. This will enable the serial
+communication between the two devices.
 
 ### Flashing the tock kernel
 
 #### Building and Deploying from the same System
+
 `cd` into `boards/raspberry_pi_pico` directory and run:
 
 ```bash
 $ make flash OPENOCD_INTERFACE=[swd|picoprobe]
 ```
 
-The *OPENOCD_INTERFACE* parameter selects which mode to flash the target Pico device in: `swd` flashes directly via SWD over GPIO (default, needs to be run a regular Raspberry Pi), `picoprobe` flashes indirectly via another Raspberry Pi Pico device.
+The *OPENOCD_INTERFACE* parameter selects which mode to flash the target Pico
+device in: `swd` flashes directly via SWD over GPIO (default, needs to be run a
+regular Raspberry Pi), `picoprobe` flashes indirectly via another Raspberry Pi
+Pico device.
 
 You can also open a serial console on to view debug messages:
 ```bash
@@ -119,13 +166,11 @@ $ picocom /dev/ttyACM0 -b 115200 -l
 
 ```bash
 $ make
-
-(or)
-
-$ make debug
 ```
 
-Connect via ssh to the Raspberry Pi and forward port 3333. Then start OpenOCD on the Pi.
+Connect via ssh to the Raspberry Pi and forward port 3333. Then start OpenOCD on
+the Pi.
+
 ```bash
 $ ssh pi@<pi_IP> -L 3333:localhost:3333
 
@@ -133,24 +178,20 @@ $ ssh pi@<pi_IP> -L 3333:localhost:3333
 
 $ openocd -f interface/raspberrypi-swd.cfg -f target/rp2350.cfg
 ```
+
 You can also open a serial console on the Raspberry Pi for debug messages.
+
 ```bash
 $ sudo apt install minicom
 $ minicom -b 115200 -o -D /dev/serial0
 ```
 
-On the local computer use gdb-multiarch on Linux or arm-none-eabi-gdb on MacOS to deploy tock.
+On the local computer use gdb-multiarch on Linux or arm-none-eabi-gdb on MacOS
+to deploy tock.
+
 ```bash
 $ arm-none-eabi-gdb tock/target/thumbv8m.main-none-eabi/release/raspberry_pi_pico_2.elf
 (gdb) target remote :3333
 (gdb) load
 (gdb) continue
 ```
-## Flashing app
-
-Apps are built out-of-tree. Once an app is built, you can add the path to it in the Makefile (APP variable), then run:
-```bash
-$ make program
-```
-
-This will generate a new ELF file that can be deployed on the Raspberry Pi Pico 2 via gdb and OpenOCD as described in the [section above](#flash-the-tock-kernel).

--- a/boards/raspberry_pi_pico_2/README.md
+++ b/boards/raspberry_pi_pico_2/README.md
@@ -146,7 +146,7 @@ communication between the two devices.
 `cd` into `boards/raspberry_pi_pico` directory and run:
 
 ```bash
-$ make flash OPENOCD_INTERFACE=[swd|picoprobe]
+$ make flash-openocd OPENOCD_INTERFACE=[swd|picoprobe]
 ```
 
 The *OPENOCD_INTERFACE* parameter selects which mode to flash the target Pico


### PR DESCRIPTION
### Pull Request Overview

Tockloader's local-board feature makes programming something like the rpi-pico2 where there needs to be one binary image to flash much easier. Rather than manually creating combined binary elf files, this just has tockloader arrange everything in a local binary file. Then that binary is flashed to the board. After running `make init`, all normal tockloader commands work.


### Testing Strategy

I just verified this works on an rpi pico 2 I have, and I was able to get the blink app to blink.


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
