### PR TITLE
build: remove dead NOWARNINGS env var, restore deny-warnings for board builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ allboards boards:
 
 .PHONY: allcheck check
 allcheck check:
-	@cargo check
+	@cargo check $(TOCK_CARGO_FLAGS)
 
 .PHONY: alldoc doc
 alldoc doc:
@@ -380,7 +380,7 @@ ci-setup-markdown-toc:
 
 define ci_job_markdown_toc
 	$(call banner,CI-Job: Markdown Table of Contents Validation)
-	@NOWARNINGS=true PATH="node_modules/.bin:${PATH}" tools/ci/toc.sh
+	@PATH="node_modules/.bin:${PATH}" tools/ci/toc.sh
 endef
 
 .PHONY: ci-job-markdown-toc
@@ -420,15 +420,22 @@ ci-job-clippy:
 
 
 ### ci-runner-github-build jobs:
+# Path to a `.cargo/config.toml` fragment that denies warnings. Passed via
+# `cargo --config <path>` (see `TOCK_CARGO_FLAGS` above and in
+# `boards/Makefile.common`) rather than the `RUSTFLAGS` environment
+# variable, since the latter would entirely replace (not merge with) any
+# `rustflags` a crate already sets via its own `.cargo/config.toml`.
+DENY_WARNINGS_CARGO_CONFIG := $(CURDIR)/boards/cargo/deny_warnings.toml
+
 .PHONY: ci-job-syntax
 ci-job-syntax:
 	$(call banner,CI-Job: Syntax)
-	@NOWARNINGS=true $(MAKE) allcheck
+	@TOCK_CARGO_FLAGS="--config $(DENY_WARNINGS_CARGO_CONFIG)" $(MAKE) allcheck
 
 .PHONY: ci-job-compilation
 ci-job-compilation:
 	$(call banner,CI-Job: Compilation)
-	@NOWARNINGS=true $(MAKE) allboards
+	@TOCK_CARGO_FLAGS="--config $(DENY_WARNINGS_CARGO_CONFIG)" $(MAKE) allboards
 
 
 define ci_setup_msrv
@@ -461,9 +468,9 @@ ci-job-debug-support-targets:
 	# work, but don't build them for every board.
 	#
 	# The choice of building for the nrf52dk was chosen by random die roll.
-	@NOWARNINGS=true $(MAKE) -C boards/nordic/nrf52dk lst
-	@NOWARNINGS=true $(MAKE) -C boards/nordic/nrf52dk debug
-	@NOWARNINGS=true $(MAKE) -C boards/nordic/nrf52dk debug-lst
+	@TOCK_CARGO_FLAGS="--config $(DENY_WARNINGS_CARGO_CONFIG)" $(MAKE) -C boards/nordic/nrf52dk lst
+	@TOCK_CARGO_FLAGS="--config $(DENY_WARNINGS_CARGO_CONFIG)" $(MAKE) -C boards/nordic/nrf52dk debug
+	@TOCK_CARGO_FLAGS="--config $(DENY_WARNINGS_CARGO_CONFIG)" $(MAKE) -C boards/nordic/nrf52dk debug-lst
 
 .PHONY: ci-job-collect-artifacts
 ci-job-collect-artifacts: ci-job-compilation
@@ -485,10 +492,10 @@ ci-job-collect-artifacts: ci-job-compilation
 .PHONY: ci-job-libraries
 ci-job-libraries:
 	$(call banner,CI-Job: Libraries)
-	@cd libraries/enum_primitive && NOWARNINGS=true RUSTFLAGS="-D warnings" cargo test
-	@cd libraries/riscv-csr && NOWARNINGS=true RUSTFLAGS="-D warnings" cargo test
-	@cd libraries/tock-cells && NOWARNINGS=true RUSTFLAGS="-D warnings" cargo test
-	@cd libraries/tickv && NOWARNINGS=true RUSTFLAGS="-D warnings" cargo test
+	@cd libraries/enum_primitive && cargo test --config $(DENY_WARNINGS_CARGO_CONFIG)
+	@cd libraries/riscv-csr && cargo test --config $(DENY_WARNINGS_CARGO_CONFIG)
+	@cd libraries/tock-cells && cargo test --config $(DENY_WARNINGS_CARGO_CONFIG)
+	@cd libraries/tickv && cargo test --config $(DENY_WARNINGS_CARGO_CONFIG)
 
 .PHONY: ci-job-archs
 ci-job-archs:
@@ -496,22 +503,22 @@ ci-job-archs:
 	@for arch in `./tools/build/list_archs.sh`;\
 		do echo "$$(tput bold)Test $$arch";\
 		cd arch/$$arch;\
-		NOWARNINGS=true RUSTFLAGS="-D warnings" cargo test || exit 1;\
+		cargo test --config $(DENY_WARNINGS_CARGO_CONFIG) || exit 1;\
 		cd ../..;\
 		done
 
 .PHONY: ci-job-kernel
 ci-job-kernel:
 	$(call banner,CI-Job: Kernel)
-	@cd kernel && NOWARNINGS=true RUSTFLAGS="-D warnings" cargo test
+	@cd kernel && cargo test --config $(DENY_WARNINGS_CARGO_CONFIG)
 
 .PHONY: ci-job-capsules
 ci-job-capsules:
 	$(call banner,CI-Job: Capsules)
 	@# Capsule initialization depends on board/chip specific imports, so ignore doc tests
-	@cd capsules/core && NOWARNINGS=true RUSTFLAGS="-D warnings" cargo test
-	@cd capsules/extra && NOWARNINGS=true RUSTFLAGS="-D warnings" cargo test
-	@cd capsules/system && NOWARNINGS=true RUSTFLAGS="-D warnings" cargo test
+	@cd capsules/core && cargo test --config $(DENY_WARNINGS_CARGO_CONFIG)
+	@cd capsules/extra && cargo test --config $(DENY_WARNINGS_CARGO_CONFIG)
+	@cd capsules/system && cargo test --config $(DENY_WARNINGS_CARGO_CONFIG)
 
 .PHONY: ci-job-chips
 ci-job-chips:
@@ -519,7 +526,7 @@ ci-job-chips:
 	@for chip in `./tools/build/list_chips.sh`;\
 		do echo "$$(tput bold)Test $$chip";\
 		cd chips/$$chip;\
-		NOWARNINGS=true RUSTFLAGS="-D warnings" cargo test || exit 1;\
+		cargo test --config $(DENY_WARNINGS_CARGO_CONFIG) || exit 1;\
 		cd ../..;\
 		done
 
@@ -551,8 +558,8 @@ ci-setup-tools:
 
 define ci_job_tools
 	$(call banner,CI-Job: Tools)
-	@NOWARNINGS=true RUSTFLAGS="-D warnings" \
-		cargo test --all-targets --manifest-path=tools/Cargo.toml --workspace || exit 1
+	@cargo test --config $(DENY_WARNINGS_CARGO_CONFIG) \
+		--all-targets --manifest-path=tools/Cargo.toml --workspace || exit 1
 endef
 
 .PHONY: ci-job-tools
@@ -566,12 +573,12 @@ ci-job-miri:
 	#
 	# Note: This is highly experimental and limited at the moment.
 	#
-	@cd kernel && NOWARNINGS=true cargo miri test
-	@for a in $$(tools/build/list_archs.sh); do cd arch/$$a && NOWARNINGS=true cargo miri test && cd ../..; done
-	@cd capsules/core && NOWARNINGS=true cargo miri test
-	@cd capsules/extra && NOWARNINGS=true cargo miri test
-	@cd capsules/system && NOWARNINGS=true cargo miri test
-	@for c in $$(tools/build/list_chips.sh); do cd chips/$$c && NOWARNINGS=true cargo miri test && cd ../..; done
+	@cd kernel && cargo miri test
+	@for a in $$(tools/build/list_archs.sh); do cd arch/$$a && cargo miri test && cd ../..; done
+	@cd capsules/core && cargo miri test
+	@cd capsules/extra && cargo miri test
+	@cd capsules/system && cargo miri test
+	@for c in $$(tools/build/list_chips.sh); do cd chips/$$c && cargo miri test && cd ../..; done
 
 
 .PHONY: ci-job-cargo-test-build
@@ -638,7 +645,7 @@ define ci_job_qemu
 	$(call banner,CI-Job: QEMU)
 	@cd tools/ci/qemu-runner;\
 		PATH="$(shell pwd)/tools/ci/qemu/build/:${PATH}"\
-		NOWARNINGS=true cargo run
+		cargo run
 	@cd boards/opentitan/earlgrey-cw310;\
 		PATH="$(shell pwd)/tools/ci/qemu/build/:${PATH}"\
 		make test
@@ -654,7 +661,7 @@ ci-job-qemu: ci-setup-qemu
 .PHONY: ci-job-rustdoc
 ci-job-rustdoc:
 	$(call banner,CI-Job: Rustdoc Documentation)
-	@NOWARNINGS=true tools/build/build_all_docs.sh
+	@tools/build/build_all_docs.sh
 
 ## End CI rules
 ##

--- a/arch/cortex-m7/src/lib.rs
+++ b/arch/cortex-m7/src/lib.rs
@@ -46,7 +46,7 @@ impl cortexm::CortexMVariant for CortexM7 {
         user_stack: *const usize,
         process_regs: &mut [usize; 8],
     ) -> *const usize {
-        cortexv7m::switch_to_user_arm_v7m(user_stack, process_regs)
+        unsafe { cortexv7m::switch_to_user_arm_v7m(user_stack, process_regs) }
     }
 
     #[cfg(not(all(target_arch = "arm", target_os = "none")))]

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -186,6 +186,13 @@ OBJDUMP_FLAGS ?= --disassemble-all --source --section-headers --demangle
 # Set default flags for size.
 SIZE_FLAGS ?=
 
+# Additional flags passed to every `cargo` invocation that actually builds or
+# checks code. CI uses this to pass `--config <path>`, which merges (rather
+# than replaces, as the `RUSTFLAGS` environment variable would) with the
+# `rustflags` already set via `.cargo/config.toml`. See
+# `boards/cargo/deny_warnings.toml`.
+TOCK_CARGO_FLAGS ?=
+
 # Additional flags that can be passed to print_tock_memory_usage.py via an
 # environment variable. By default, pass an empty string.
 PTMU_ARGS ?=
@@ -252,7 +259,7 @@ all: release
 # binary. This makes checking for Rust errors much faster.
 .PHONY: check
 check:
-	$(Q)$(CARGO) check $(VERBOSE_FLAGS)
+	$(Q)$(CARGO) check $(VERBOSE_FLAGS) $(TOCK_CARGO_FLAGS)
 
 
 .PHONY: clean
@@ -318,10 +325,10 @@ $(TOCK_ROOT_DIRECTORY)tools/build/sha256sum/target/debug/sha256sum:
 
 .PHONY: $(TARGET_PATH)/release/$(PLATFORM)
 $(TARGET_PATH)/release/$(PLATFORM):
-	$(Q)$(CARGO) rustc $(VERBOSE_FLAGS) --bin $(PLATFORM) --release
+	$(Q)$(CARGO) rustc $(VERBOSE_FLAGS) $(TOCK_CARGO_FLAGS) --bin $(PLATFORM) --release
 	$(Q)$(SIZE) $(SIZE_FLAGS) $@
 
 .PHONY: $(TARGET_PATH)/debug/$(PLATFORM)
 $(TARGET_PATH)/debug/$(PLATFORM):
-	$(Q)$(CARGO) build $(VERBOSE_FLAGS) --bin $(PLATFORM)
+	$(Q)$(CARGO) build $(VERBOSE_FLAGS) $(TOCK_CARGO_FLAGS) --bin $(PLATFORM)
 	$(Q)$(SIZE) $(SIZE_FLAGS) $@

--- a/boards/cargo/deny_warnings.toml
+++ b/boards/cargo/deny_warnings.toml
@@ -1,0 +1,14 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2026.
+
+# Deny warnings for board compilation. This is not included by boards'
+# `.cargo/config.toml` directly (which would make warnings fatal even for
+# everyday local development). Instead, CI passes this file via `cargo
+# --config <path>`, which merges its `rustflags` with the ones already
+# configured for the board rather than replacing them, unlike the
+# `RUSTFLAGS` environment variable. See `TOCK_CARGO_FLAGS` in
+# `boards/Makefile.common`.
+
+[build]
+rustflags = ["-D", "warnings"]

--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -21,22 +21,26 @@ include ../../Makefile.common
 
 # Pass OpenTitan board configuration option in `BOARD_CONFIGURATION` through
 # Cargo `--features`. Please see `Cargo.toml` for available options.
+#
+# Use `+=` rather than `=` so this extends (rather than clobbers) any
+# `TOCK_CARGO_FLAGS` already inherited from the environment, e.g. the
+# `--config` deny-warnings flag CI sets for `allboards`.
 ifneq ($(BOARD_CONFIGURATION),)
-	CARGO_FLAGS = --no-default-features --features=$(BOARD_CONFIGURATION)
+	TOCK_CARGO_FLAGS += --no-default-features --features=$(BOARD_CONFIGURATION)
 endif
 
 .PHONY: check
 check:
-	$(Q)$(CARGO) check $(VERBOSE_FLAGS) $(CARGO_FLAGS)
+	$(Q)$(CARGO) check $(VERBOSE_FLAGS) $(TOCK_CARGO_FLAGS)
 
 .PHONY: $(TARGET_PATH)/release/$(PLATFORM)
 $(TARGET_PATH)/release/$(PLATFORM):
-	$(Q)$(CARGO) build $(VERBOSE_FLAGS) $(CARGO_FLAGS) --release
+	$(Q)$(CARGO) build $(VERBOSE_FLAGS) $(TOCK_CARGO_FLAGS) --release
 	$(Q)$(SIZE) $(SIZE_FLAGS) $@
 
 .PHONY: $(TARGET_PATH)/debug/$(PLATFORM)
 $(TARGET_PATH)/debug/$(PLATFORM):
-	$(Q)$(CARGO) build $(VERBOSE_FLAGS) $(CARGO_FLAGS)
+	$(Q)$(CARGO) build $(VERBOSE_FLAGS) $(TOCK_CARGO_FLAGS)
 	$(Q)$(SIZE) $(SIZE_FLAGS) $@
 
 .PHONY: ot-check
@@ -110,10 +114,10 @@ test:
 ifneq ($(OPENTITAN_TREE),)
 	$(error "Running on QEMU, use test-hardware to run on hardware")
 endif
-	$(Q)TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} QEMU_ENTRY_POINT=${QEMU_ENTRY_POINT} TARGET=${TARGET} LINKER_SCRIPT_OVERRIDE=test_layout.ld $(CARGO) test $(CARGO_FLAGS) $(NO_RUN) --bin $(PLATFORM) --release
+	$(Q)TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} QEMU_ENTRY_POINT=${QEMU_ENTRY_POINT} TARGET=${TARGET} LINKER_SCRIPT_OVERRIDE=test_layout.ld $(CARGO) test $(TOCK_CARGO_FLAGS) $(NO_RUN) --bin $(PLATFORM) --release
 
 test-hardware: ot-check
-	$(Q)OBJCOPY=$(RISC_PREFIX)-objcopy TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} TARGET=${TARGET} LINKER_SCRIPT_OVERRIDE=test_layout.ld $(CARGO) test $(CARGO_FLAGS) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests
+	$(Q)OBJCOPY=$(RISC_PREFIX)-objcopy TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} TARGET=${TARGET} LINKER_SCRIPT_OVERRIDE=test_layout.ld $(CARGO) test $(TOCK_CARGO_FLAGS) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests
 
 test-verilator: ot-check
-	$(Q)VERILATOR="yes" OBJCOPY=$(RISC_PREFIX)-objcopy TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} TARGET=${TARGET} LINKER_SCRIPT_OVERRIDE=test_layout.ld $(CARGO) test $(CARGO_FLAGS) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests,sim_verilator
+	$(Q)VERILATOR="yes" OBJCOPY=$(RISC_PREFIX)-objcopy TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} TARGET=${TARGET} LINKER_SCRIPT_OVERRIDE=test_layout.ld $(CARGO) test $(TOCK_CARGO_FLAGS) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests,sim_verilator


### PR DESCRIPTION
### Pull Request Overview

Our Makefile was full of vestigial references to `NOWARNINGS`, but nothing's actually used that environment variable since 01b36bb0f (in 2024...).

As as consequence, `ci-job-syntax`, `ci-job-compilation`, and `ci-job-debug-support-targets` stopped denying warnings on board builds at all.

This PR removes the dead variable and restores deny-on-warnings for those jobs.

One of the reasons we didn't do this before is that using the `RUSTFLAGS` environment variable _replaces_ other rustflags, and several of our builds rely on `.cargo/config.toml` rustflags for linker flags. It turns out the right way to handle this is just adding a second cargo config since cargo will merge multiple configs.

There was one latent warning that we'd been silently allowing that is also now fixed in this PR (a missing `unsafe` in a newly-2024 edition crate).

### Testing Strategy

Verified with real injected warnings, not just inspection: confirmed `ci-job-syntax`/`ci-job-compilation` fail on a deliberately introduced warning while a plain local `make check`/`release` doesn't (and doesn't lose any board-specific flags); reverted and ran the full real `ci-job-syntax` and `ci-job-compilation` (all 61 boards) clean. `make prepush` passes.

### TODO or Help Wanted

N/A

### Checklist

- [x] Ran `make prepush`.

### PR Contents

#### Documentation

- [x] No documentation updates are required.

#### AI Use

- [x] AI was used in this PR. I have read Tock's AI policy and have properly
      disclosed my AI use below.

This PR was produced by an extended Claude Code session covering investigation, implementation, and verification.

<details>
<summary>Prompts that drove the content of this PR</summary>

1. "investigate NOWARNINGS env variable"

2. "The Makefile sets an environment variable, NOWARNINGS, in lots of places, but it's not obvious if anything actually reads this any more?

   Is this an environment variable that possibly some subtools are sensitive to? Or is it actually not used any more?

   Investigate git history to see how the variable used to be used to inform whether it is still relevant / useful.

   Is this something we should just remove, or should we add back some logic that got lost to do something different based on the environment variable?"

   (I chose the option "Delete NOWARNINGS, restore deny-warnings for board builds" from a set of choices Claude presented.)

3. "is CARGO_FLAGS just an arbitrary name, or a special environment variable that cargo normally pays attention to?"

4. "I see you got the name from history, does anything in-tree use CARGO_FLAGS prior to our work here? Does our use of this variable conflict?"

5. "yes, fix it and fold into the same commit" (in response to Claude finding the `boards/opentitan/earlgrey-cw310/Makefile` clobber bug)

6. "since this environment variable is really more about how Tock wants to drive cargo rather than invoking standard cargo things, would it make sense to rename it to TOCK_CARGO_FLAGS ?"

7. "it seems like we now have two paths that deny warnings—some things that use DENY_WARNINGS_CARGO_CONFIG and some things that manually specify RUSTFLAGS="-D warnings"

   why do we have two different ways to enable warnings?

   do we need both, can we harmonize to one?"

   (I chose "Yes, switch everything to --config" from Claude's presented options.)

8. "Does CI still pass with these changes, or were there latent warnings slipping through that now need to be fixed" (this is what led to finding and fixing the `arch/cortex-m7` bug)

</details>

I have manually reviewed the diff before opening this PR.
