### PR TITLE
build: deny warnings in doc builds too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -671,6 +671,12 @@ ci-job-qemu-virt:
 ci-job-rustdoc:
 	$(call banner,CI-Job: Rustdoc Documentation)
 	@TOCK_CARGO_FLAGS="--config $(DENY_WARNINGS_CARGO_CONFIG)" tools/build/build_all_docs.sh
+	# `build_all_docs.sh` above builds the published doc site, but only for
+	# the host's native target: code gated on a board's real target (e.g.
+	# `#[cfg(target_arch = "arm", target_os = "none")]`) is never compiled,
+	# so rustdoc never checks it. `alldoc` builds each board's docs against
+	# its own real target/config, closing that gap.
+	@TOCK_CARGO_FLAGS="--config $(DENY_WARNINGS_CARGO_CONFIG)" $(MAKE) alldoc
 
 ## End CI rules
 ##

--- a/Makefile
+++ b/Makefile
@@ -670,7 +670,7 @@ ci-job-qemu-virt:
 .PHONY: ci-job-rustdoc
 ci-job-rustdoc:
 	$(call banner,CI-Job: Rustdoc Documentation)
-	@tools/build/build_all_docs.sh
+	@TOCK_CARGO_FLAGS="--config $(DENY_WARNINGS_CARGO_CONFIG)" tools/build/build_all_docs.sh
 
 ## End CI rules
 ##

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -284,7 +284,7 @@ debug-lst:  $(TARGET_PATH)/debug/$(PLATFORM).lst
 
 .PHONY: doc
 doc:
-	$(Q)$(CARGO) --color=always doc $(VERBOSE_FLAGS) --release --package $(PLATFORM)
+	$(Q)$(CARGO) --color=always doc $(VERBOSE_FLAGS) $(TOCK_CARGO_FLAGS) --release --package $(PLATFORM)
 
 
 .PHONY: lst

--- a/boards/cargo/deny_warnings.toml
+++ b/boards/cargo/deny_warnings.toml
@@ -2,13 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2026.
 
-# Deny warnings for board compilation. This is not included by boards'
-# `.cargo/config.toml` directly (which would make warnings fatal even for
-# everyday local development). Instead, CI passes this file via `cargo
-# --config <path>`, which merges its `rustflags` with the ones already
-# configured for the board rather than replacing them, unlike the
-# `RUSTFLAGS` environment variable. See `TOCK_CARGO_FLAGS` in
-# `boards/Makefile.common`.
+# Deny warnings for board compilation and doc builds. This is not included
+# by boards' `.cargo/config.toml` directly (which would make warnings fatal
+# even for everyday local development). Instead, CI passes this file via
+# `cargo --config <path>`, which merges its `rustflags`/`rustdocflags` with
+# whatever is already configured (e.g. a board's linker flags) rather than
+# replacing them, unlike the `RUSTFLAGS`/`RUSTDOCFLAGS` environment
+# variables. See `TOCK_CARGO_FLAGS` in `boards/Makefile.common` and
+# `tools/build/build_all_docs.sh`.
 
 [build]
 rustflags = ["-D", "warnings"]
+rustdocflags = ["-D", "warnings"]

--- a/boards/cargo/tock_flags.toml
+++ b/boards/cargo/tock_flags.toml
@@ -30,8 +30,6 @@ rustflags = [
   "-Z", "emit-stack-sizes",
 ]
 rustdocflags = [
-  # Error if there are warnings. This allows CI to fail on warnings.
-  "-D", "warnings",
   # Document internal code. This is helpful for understanding how the kernel
   # works and developing within crates.
   "--document-private-items"

--- a/tools/build/build_all_docs.sh
+++ b/tools/build/build_all_docs.sh
@@ -100,9 +100,16 @@ mkdir -p "$META/host"
 # RUSTDOCFLAGS makes each crate write its own non-colliding <crate>.json
 # into $META/host. `--no-deps` skips generating docs for third-party
 # dependencies, which takes a long time and we don't link to anyway.
+#
+# TOCK_CARGO_FLAGS is unset for everyday local use, so warnings are
+# non-fatal here, same as a local `cargo build`/`check`. CI (ci-job-rustdoc)
+# sets it to `--config boards/cargo/deny_warnings.toml`, which merges that
+# file's `rustdocflags` with whatever each package already sets, rather
+# than replacing it outright (which `RUSTDOCFLAGS` as an environment
+# variable would do), so doc warnings are treated as build failures there.
 CARGO_TARGET_DIR="$WORK" \
     RUSTDOCFLAGS="${RUSTDOCFLAGS:-} -Z unstable-options --write-doc-meta-dir=$META/host" \
-    cargo doc --no-deps
+    cargo doc --no-deps $TOCK_CARGO_FLAGS
 
 # CRATE_TARGETS crates get pulled into the host pass too, as dependencies
 # of the boards/chips that use them. Prune their host-pass meta so the


### PR DESCRIPTION
### Pull Request Overview

Stacked on #5076.

This extends deny-warnings-in-CI treatment to doc builds. We've always intended to do this, I just keep getting it wrong :( -- hopefully Claude is better than me at finally nailing this down.

If you're interested in the details, here's why doc warnings kept slipping through before:

 - `ci-job-rustdoc` (`tools/build/build_all_docs.sh`) ran a bare `cargo doc` from the repo root. That picks up no `rustdocflags` at all (no root `.cargo/config.toml`), so doc warnings have never actually failed this job.
 - It also only builds for the host's native target, so any code gated on a board's real target/config is never compiled by that pass and rustdoc never checks it.

This PR: (1) extends `boards/cargo/deny_warnings.toml` with `rustdocflags` alongside its existing `rustflags`, wired through the same `TOCK_CARGO_FLAGS` opt-in as compiles, so `-D warnings` is CI-only, not a plain local `make doc`/`cargo doc`; (2) wires the pre-existing but CI-unused `alldoc` target into `ci-job-rustdoc`, which builds each board's docs against its own real target/config, closing the target-gating gap.

That target-gating fix surfaced five pre-existing, doc-only bugs which are all fixed.

<details><summary>Full list of bugfixes</summary>
Nothing had ever built docs against a real riscv64, riscv32, or x86 target before.
- `arch/riscv/src/{pseudo_instructions,syscall}.rs`: a `cfg(any(doc, target_arch = "riscv32"))` / `cfg(target_arch = "riscv64")` pair (4 items) both activate simultaneously under a real riscv64 doc build, causing `E0428: defined multiple times`. Restricted the riscv32 variant's `doc` fallback to exclude riscv64.
- `arch/x86/src/interrupts/poller.rs`: redundant explicit doc link target (`rustdoc::redundant_explicit_links`).
- `chips/pci-x86/src/device.rs`: ambiguous doc link between a private module and a re-exported function of the same name (`rustdoc::broken_intra_doc_links`); disambiguated to the function per the surrounding prose.
- `chips/x86_q35/src/ps2.rs`: two bare URLs in doc comments (`rustdoc::bare_urls`).
</details>

### Testing Strategy

Verified with real injected doc warnings at each step, not just inspection: confirmed the old bare `cargo doc` accepts a broken intra-doc link silently, while `--config deny_warnings.toml` and `make ci-job-rustdoc` both reject it; confirmed the same for target-gated code specifically (a broken link inside `arch/cortex-m7`'s ARM-only branch is invisible to the host-target build but caught once building against a board's real target); confirmed a plain local `make doc` stays lenient while `TOCK_CARGO_FLAGS`-opted-in CI does not. Full real `ci-job-rustdoc` (all 61 boards, both the site build and the target-gated sweep) passes clean. `make prepush` passes.

### TODO or Help Wanted

N/A

### Checklist

- [x] Ran `make prepush`.

### PR Contents

#### Documentation

- [x] No documentation updates are required.

#### AI Use

- [x] AI was used in this PR. I have read Tock's AI policy and have properly
      disclosed my AI use below.

This PR was produced by the same extended Claude Code session as #5076.

<details><summary>Prompts that drove the content of this PR specifically</summary>

1. "The historical intent of NOWARNINGS was to not allow warnings in *any* build configuration, including docs builds—can we add another commit to fix things so that CI correctly denies warnings in docs builds moving forward

   Is this the current behavior for docs builds? If not, fix it and add a new commit"

2. "Add one more commit to enforce doc checks on target-gated code"

3. (In response to Claude finding the riscv32/riscv64 doc-cfg collision and asking how to handle it, presenting several options:) "Fix it now, separate commit"

4. "When doing code builds locally, warnings are allowed but rejected in CI. warnings should not be a hard error unless running in a CI context (note that "in a CI context" should be determined by a Makefile rule here, like how `ci-job-compilation` opts-in to the stricter rules, so that "true CI" can easily be replicated locally).

   Is this the current behavior for docs builds? If not, fix it and add a new commit"

5. "Can we fold commit 62667523a into 58547d2bf? I think it makes sense for that to just be one change"

6. "Squash the last two commits in PR2 together, 7d6b0c54c is small and we don't need to introduce a build-breaking commit in history here."
</details>

I have manually reviewed the diff before opening this PR.
