### PR TITLE
tools: add --no-deps to docs build

### DIFF
--- a/tools/build/build_all_docs.sh
+++ b/tools/build/build_all_docs.sh
@@ -26,7 +26,10 @@ fi
 rm -f _COW _COW2
 
 # Make the documentation for all the boards, for the host's native target.
-cargo doc
+#
+# `--no-deps` skips generating docs for third-party dependencies, which takes a
+# long time and we don't link to anyway.
+cargo doc --no-deps
 
 # Replace the default rust logo with our own Tock logo and the favicon with our
 # own favicon. Note, it is also possible to set this using a `#[doc]` attribute

--- a/tools/ci/netlify-build.sh
+++ b/tools/ci/netlify-build.sh
@@ -16,11 +16,17 @@ set -e
 set -u
 set -x
 
-# Install rust stuff that we need
-curl https://sh.rustup.rs -sSf | sh -s -- -y
-
-# And fixup path for the newly installed rust stuff
+# Netlify automatically restores ~/.rustup, ~/.cargo/{registry,bin}, and
+# ./target from the previous build's cache when Cargo.toml/Cargo.lock are
+# present at the repo root (see run-build-functions.sh in
+# netlify/build-image), so put the cache's bin dir on PATH first and only
+# run the installer if that didn't already give us a cargo, instead of
+# unconditionally reinstalling over a cache hit every time.
 export PATH="$PATH:$HOME/.cargo/bin"
+
+if ! command -v cargo > /dev/null 2>&1; then
+    curl https://sh.rustup.rs -sSf | sh -s -- -y
+fi
 
 # Do the actual work
 make ci-runner-netlify


### PR DESCRIPTION
### Pull Request Overview

This disables building documentation for _external_ dependencies in our dependency tree. We never link to them anyway, and some of them take a really long time to build (e.g. quote/syn/proc-macro2).

This fixes the CI issue where our docs builds have slowly ticked longer and longer and just ran into netlify's 20m build limit.

We should've done this a long time ago frankly.

### Testing Strategy

This pull request was tested by — you're looking at it.


### TODO or Help Wanted

N/A


### Checklist

- [ ] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
