### PR TITLE
[TESTING ONLY, DO NOT REVIEW] build: cooperate with Netlify's automatic Rust cache

### DIFF
--- a/tools/ci/netlify-build.sh
+++ b/tools/ci/netlify-build.sh
@@ -16,11 +16,17 @@ set -e
 set -u
 set -x
 
-# Install rust stuff that we need
-curl https://sh.rustup.rs -sSf | sh -s -- -y
-
-# And fixup path for the newly installed rust stuff
+# Netlify automatically restores ~/.rustup, ~/.cargo/{registry,bin}, and
+# ./target from the previous build's cache when Cargo.toml/Cargo.lock are
+# present at the repo root (see run-build-functions.sh in
+# netlify/build-image), so put the cache's bin dir on PATH first and only
+# run the installer if that didn't already give us a cargo, instead of
+# unconditionally reinstalling over a cache hit every time.
 export PATH="$PATH:$HOME/.cargo/bin"
+
+if ! command -v cargo > /dev/null 2>&1; then
+    curl https://sh.rustup.rs -sSf | sh -s -- -y
+fi
 
 # Do the actual work
 make ci-runner-netlify


### PR DESCRIPTION
**TESTING ONLY -- DO NOT REVIEW.** Opened purely to trigger real Netlify preview builds and confirm whether Netlify's cache actually helps here. Temporarily marked ready-for-review (not draft) only because this Netlify project appears to skip builds on pushes to already-draft PRs -- will convert back to draft once the caching fix is confirmed. Expect force-pushes/junk follow-up commits while I test this.

### Pull Request Overview

Stacked on #5079.

`--no-deps` (#5079) only bought back ~2 minutes; the Netlify docs build is still landing right at the 20 minute ceiling. This digs into why and fixes the actual cause.

Netlify already has an automatic cache for exactly this: whenever `Cargo.toml`/`Cargo.lock` exist at the repo root (ours always have), it restores `~/.rustup`, `~/.cargo/registry`, `~/.cargo/bin`, and `./target` from the previous build before running our build command, and saves them again after. `netlify-build.sh` was fighting that by unconditionally re-running the rustup installer on every single build, which meant we never actually got to reuse any of it.

I profiled a fully cold `cargo doc --no-deps` locally (empty `target/`, empty `CARGO_HOME`, so no local cache either): it's genuinely ~14.4 core-minutes of work across 373 build units (chip HAL crates dominate -- stm32 variants, cortex-m3, riscv, lowrisc/earlgrey, lpc55s6x, msp432, sam4l, rp2040/2350, psoc62xa, pci-x86 -- boards themselves are cheap, each chip is just built once regardless of how many boards use it). An 8-thread desktop parallelizes that down to ~2 minutes wall-clock; Netlify apparently can't get nearly that much parallelism, which is consistent with a resource-constrained build container rather than "the docs are inherently this slow." Paying that cost from absolute zero on every build is what's actually pushing us over 20 minutes.

This PR doesn't implement any caching itself -- it just stops discarding the cache Netlify already provides, by putting the cache's `~/.cargo/bin` on `PATH` before checking whether a toolchain is already there, and only invoking the installer on an actual cache miss.

### Testing Strategy

This needs a real Netlify build to confirm (can't be tested locally, since the whole point is Netlify's own cache behavior). Verified the script change is at least correct in isolation (`bash -n`, and confirmed `command -v cargo` now checks after `PATH` is updated, not before). Plan is to watch this PR's own preview build, then push a trivial follow-up commit to the same branch to confirm the *second* build comes in meaningfully faster than the first (which will still be a cold/first-time build for this new branch).

### TODO or Help Wanted

Needs confirmation from a live Netlify build (or two) that the cache is actually being hit and meaningfully cuts wall-clock time, since this is Netlify platform behavior I can't reproduce locally.

### Checklist

- [ ] Ran `make prepush`.

### PR Contents

#### Documentation

- [x] No documentation updates are required.

#### AI Use

- [x] AI was used in this PR. I have read Tock's AI policy and have properly
      disclosed my AI use below.

<details><summary>Prompts that drove the content of this PR</summary>

1. "Is there a minimally invasive change we could do to bring docs build time down as a short term fix? There's a lot of work around docs in flight elsewhere and I don't want to anything major, but do want to unstick CI"

2. "Look into this more. PR 5079 added no deps, but just failed with the same timeout" (this turned out to be inaccurate -- 5079 had actually passed, just barely -- but sent me back into the numbers)

3. "Confirm costs" (in response to my hypothesis about board/chip crate count dominating build time -- this is what led to the local `--timings` profiling and the discovery that it's ~14 core-minutes of real work, not something `--no-deps` addresses)

4. "I thought netlify supported caching natively? We should get caching working, but use netlify primitives, don't implement it ourselves" followed by "I understand that we may need to test with repeated pushes to trigger builds, that is fine"

</details>

This diff was not manually reviewed by Pat before opening -- it's a testing PR opened autonomously to exercise real Netlify CI; see the banner at the top.
