### PR TITLE
[TESTING ONLY, DO NOT REVIEW] build: cooperate with Netlify's automatic Rust cache

### DIFF
--- a/tools/ci/netlify-build.sh
+++ b/tools/ci/netlify-build.sh
@@ -16,11 +16,17 @@ set -e
 set -u
 set -x
 
-# Install rust stuff that we need
-curl https://sh.rustup.rs -sSf | sh -s -- -y
-
-# And fixup path for the newly installed rust stuff
+# Netlify automatically restores ~/.rustup, ~/.cargo/{registry,bin}, and
+# ./target from the previous build's cache when Cargo.toml/Cargo.lock are
+# present at the repo root (see run-build-functions.sh in
+# netlify/build-image), so put the cache's bin dir on PATH first and only
+# run the installer if that didn't already give us a cargo, instead of
+# unconditionally reinstalling over a cache hit every time.
 export PATH="$PATH:$HOME/.cargo/bin"
+
+if ! command -v cargo > /dev/null 2>&1; then
+    curl https://sh.rustup.rs -sSf | sh -s -- -y
+fi
 
 # Do the actual work
 make ci-runner-netlify


### PR DESCRIPTION
**TESTING ONLY -- DO NOT REVIEW.** Opened directly against master (not stacked on #5079) purely to get a real Netlify deploy-preview build, since I've now confirmed stacked PRs (base != master) never trigger one on this project regardless of draft/ready state. Expect follow-up push(es) while I test whether the fix actually speeds up a second build. Once confirmed, the real commit will be re-proposed properly stacked on #5079, and this throwaway PR will be closed.

### Pull Request Overview

Single commit, cherry-picked from #5080 (closed -- wrong base branch, not wrong content): stops `tools/ci/netlify-build.sh` from unconditionally reinstalling the Rust toolchain on every build, so it can actually reuse the `~/.rustup`, `~/.cargo/registry`, `~/.cargo/bin`, and `./target` caches Netlify already restores automatically for repos with a root `Cargo.toml`/`Cargo.lock`.

### Testing Strategy

Needs a real Netlify build to confirm -- that's the entire point of this PR existing. See banner above.

### TODO or Help Wanted

Confirm a build actually triggers here (unlike #5080), then confirm a second push to this branch comes in meaningfully faster than the first.

### Checklist

- [ ] Ran `make prepush`.

### PR Contents

#### Documentation

- [x] No documentation updates are required.

#### AI Use

- [x] AI was used in this PR. I have read Tock's AI policy and have properly
      disclosed my AI use below.

Same session as #5079/#5080; see #5080 (closed) for the prompts that drove this change's content. This PR itself exists only because of the base-branch/Netlify-trigger discovery, not new prompted content.

This diff was not manually reviewed by Pat before opening -- it's a testing PR opened autonomously to exercise real Netlify CI; see the banner at the top.
