### PR TITLE
build: cooperate with Netlify's automatic Rust cache

### DIFF
--- a/tools/ci/netlify-build.sh
+++ b/tools/ci/netlify-build.sh
@@ -16,11 +16,17 @@ set -e
 set -u
 set -x
 
-# Install rust stuff that we need
-curl https://sh.rustup.rs -sSf | sh -s -- -y
-
-# And fixup path for the newly installed rust stuff
+# Netlify automatically restores ~/.rustup, ~/.cargo/{registry,bin}, and
+# ./target from the previous build's cache when Cargo.toml/Cargo.lock are
+# present at the repo root (see run-build-functions.sh in
+# netlify/build-image), so put the cache's bin dir on PATH first and only
+# run the installer if that didn't already give us a cargo, instead of
+# unconditionally reinstalling over a cache hit every time.
 export PATH="$PATH:$HOME/.cargo/bin"
+
+if ! command -v cargo > /dev/null 2>&1; then
+    curl https://sh.rustup.rs -sSf | sh -s -- -y
+fi
 
 # Do the actual work
 make ci-runner-netlify


### PR DESCRIPTION
# Human Written Explanation 

Claude has a verbose explanation below, but the tl;dr is that we weren't actually using netlify cache on docs builds and this fixes it. Warm cache builds fall to ~3m versus ~20m before. 

---


### Pull Request Overview

Stacked on #5079. Draft -- opened autonomously, Pat hasn't reviewed the diff yet.

`--no-deps` (#5079) only bought back ~2 minutes; the Netlify docs build was still landing right at the 20 minute ceiling. Netlify already has an automatic cache for exactly this: whenever `Cargo.toml`/`Cargo.lock` exist at the repo root (ours always have), it restores `~/.rustup`, `~/.cargo/registry`, `~/.cargo/bin`, and `./target` from the previous build before running our build command, and saves them again after. `netlify-build.sh` was fighting that by unconditionally re-running the rustup installer on every single build, so we never actually got to reuse any of it -- this fixes that by checking for an already-on-PATH cargo (from the restored cache) before falling back to installing.

This doesn't implement any caching itself -- Netlify's cache is the primitive being used; this just stops discarding it.

### Testing Strategy

Since this is purely about Netlify's own build-time caching behavior, it can't be verified locally -- it needed real Netlify builds. Tested via a throwaway PR (#5081, now closed) with this same commit, opened directly against master to actually trigger Netlify (stacked PRs like this one don't get their own preview build on this project -- confirmed separately by comparing #5077, also stacked, which likewise got zero Netlify checks). Two consecutive pushes to that branch: first build (cold, nothing cached yet for a brand new branch) took 18m30s; second build (pushed immediately after) took 2m45s. That ~6.7x speedup confirms the cache is real and this fix is what unlocks it.

Also profiled a fully cold `cargo doc --no-deps` locally (empty `target/`, empty `CARGO_HOME`): ~14.4 core-minutes of real work across 373 build units, which an 8-thread desktop parallelizes down to ~2 minutes wall-clock but which Netlify's less-parallel build container was apparently turning into ~18-20 minutes every single build, since nothing ever persisted. That matches the 18m30s cold vs 2m45s warm result above.

### TODO or Help Wanted

N/A

### Checklist

- [ ] Ran `make prepush`.

### PR Contents

#### Documentation

- [x] No documentation updates are required.

#### AI Use

- [x] AI was used in this PR. I have read Tock's AI policy and have properly
      disclosed my AI use below.

This PR was produced by the same extended Claude Code session as #5079/#5076/#5077.

<details><summary>Prompts that drove the content of this PR</summary>

1. "Is there a minimally invasive change we could do to bring docs build time down as a short term fix? There's a lot of work around docs in flight elsewhere and I don't want to anything major, but do want to unstick CI"

2. "Look into this more. PR 5079 added no deps, but just failed with the same timeout" (turned out to be inaccurate -- 5079 had actually passed, just barely -- but sent me back into the numbers)

3. "Confirm costs" (in response to a hypothesis about board/chip crate count dominating build time -- led to local `--timings` profiling and the discovery that it's ~14 core-minutes of real work, not something `--no-deps` addresses)

4. "I thought netlify supported caching natively? We should get caching working, but use netlify primitives, don't implement it ourselves" followed by "I understand that we may need to test with repeated pushes to trigger builds, that is fine" -- this is what led to the throwaway #5081 and the fix in this PR

</details>

This diff has not been manually reviewed by Pat before opening -- opened as a draft specifically for that reason, per standing instruction to open autonomous PRs as drafts marked for testing/review rather than assuming review has happened.
