### PR TITLE
Add a test capsule that uses all syscall return variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1307,6 +1307,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "qemu_rv32_virt-syscall-return-test"
+version = "0.2.3-dev"
+dependencies = [
+ "capsules-core",
+ "capsules-extra",
+ "capsules-system",
+ "components",
+ "kernel",
+ "qemu_rv32_virt",
+ "qemu_rv32_virt_chip",
+ "rv32i",
+ "tock-tbf",
+ "tock_build_scripts",
+]
+
+[[package]]
 name = "qemu_rv32_virt-tutorial"
 version = "0.2.3-dev"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ members = [
     "boards/tutorials/nrf52840dk-thread-tutorial",
     "boards/lora_e5_mini",
     "boards/tutorials/qemu_rv32_virt-tutorial",
+    "boards/configurations/qemu_rv32_virt/qemu_rv32_virt-syscall-return-test",
     "capsules/aes_gcm",
     "capsules/ecdsa_sw",
     "capsules/core",

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -102,6 +102,7 @@ pub mod spi;
 pub mod ssd1306;
 pub mod st77xx;
 pub mod storage_permissions;
+pub mod syscall_return_test;
 pub mod temperature;
 pub mod temperature_rp2040;
 pub mod temperature_stm;

--- a/boards/components/src/syscall_return_test.rs
+++ b/boards/components/src/syscall_return_test.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache License, Version 2.0 or the MIT License.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2024.
+// Copyright Tock Contributors 2026.
 
 //! Component for the SyscallReturnTest capsule.
 //!

--- a/boards/components/src/syscall_return_test.rs
+++ b/boards/components/src/syscall_return_test.rs
@@ -1,0 +1,49 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2024.
+
+//! Component for the SyscallReturnTest capsule.
+//!
+//! Capsule: capsules/extra/src/syscall_return_test.rs
+
+use core::mem::MaybeUninit;
+use kernel::capabilities::MemoryAllocationCapability;
+use kernel::component::Component;
+
+#[macro_export]
+macro_rules! syscall_return_test_component_static {
+    () => {{ kernel::static_buf!(capsules_extra::syscall_return_test::SyscallReturnTest) }};
+}
+
+pub type SyscallReturnTestComponentType = capsules_extra::syscall_return_test::SyscallReturnTest;
+
+pub struct SyscallReturnTestComponent<CAP: MemoryAllocationCapability + 'static> {
+    board_kernel: &'static kernel::Kernel,
+    driver_num: usize,
+    mem_cap: CAP,
+}
+
+impl<CAP: MemoryAllocationCapability + 'static> SyscallReturnTestComponent<CAP> {
+    pub fn new(board_kernel: &'static kernel::Kernel, driver_num: usize, mem_cap: CAP) -> Self {
+        Self {
+            board_kernel,
+            driver_num,
+            mem_cap,
+        }
+    }
+}
+
+impl<CAP: MemoryAllocationCapability + 'static> Component for SyscallReturnTestComponent<CAP> {
+    type StaticInput =
+        &'static mut MaybeUninit<capsules_extra::syscall_return_test::SyscallReturnTest>;
+    type Output = &'static capsules_extra::syscall_return_test::SyscallReturnTest;
+
+    fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        let grant = self
+            .board_kernel
+            .create_grant(self.driver_num, &self.mem_cap);
+        s.write(capsules_extra::syscall_return_test::SyscallReturnTest::new(
+            grant,
+        ))
+    }
+}

--- a/boards/configurations/qemu_rv32_virt/qemu_rv32_virt-syscall-return-test/.cargo/config.toml
+++ b/boards/configurations/qemu_rv32_virt/qemu_rv32_virt-syscall-return-test/.cargo/config.toml
@@ -1,0 +1,24 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2026.
+
+include = [
+  "../../../../cargo/tock_flags.toml",
+  "../../../../cargo/unstable_flags.toml",
+  "../../../../cargo/riscv_flags.toml",
+]
+
+[build]
+target = "riscv32imac-unknown-none-elf"
+
+[target.riscv32imac-unknown-none-elf]
+runner = ["qemu-system-riscv32",
+          "-machine", "virt",
+          "-semihosting",
+          "-global", "driver=riscv-cpu,property=smepmp,value=true",
+          "-global", "virtio-mmio.force-legacy=false",
+          "-device", "virtio-rng-device",
+          "-device", "virtio-keyboard-device",
+          "-serial", "stdio",
+          "-bios", "qemu_rv32_virt_test.bin"]
+

--- a/boards/configurations/qemu_rv32_virt/qemu_rv32_virt-syscall-return-test/Cargo.toml
+++ b/boards/configurations/qemu_rv32_virt/qemu_rv32_virt-syscall-return-test/Cargo.toml
@@ -1,0 +1,29 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2026.
+
+[package]
+name = "qemu_rv32_virt-syscall-return-test"
+version.workspace = true
+authors.workspace = true
+build = "../../../build.rs"
+edition.workspace = true
+
+[dependencies]
+kernel = { path = "../../../../kernel" }
+
+components = { path = "../../../components" }
+rv32i = { path = "../../../../arch/rv32i" }
+qemu_rv32_virt = { path = "../../../qemu_rv32_virt" }
+qemu_rv32_virt_chip = { path = "../../../../chips/qemu_rv32_virt_chip" }
+capsules-core = { path = "../../../../capsules/core" }
+capsules-extra = { path = "../../../../capsules/extra" }
+capsules-system = { path = "../../../../capsules/system" }
+
+tock-tbf = { path = "../../../../libraries/tock-tbf" }
+
+[build-dependencies]
+tock_build_scripts = { path = "../../../build_scripts" }
+
+[lints]
+workspace = true

--- a/boards/configurations/qemu_rv32_virt/qemu_rv32_virt-syscall-return-test/Makefile
+++ b/boards/configurations/qemu_rv32_virt/qemu_rv32_virt-syscall-return-test/Makefile
@@ -1,0 +1,38 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2026.
+
+include ../../../Makefile.common
+
+QEMU_CMD := qemu-system-riscv32
+
+QEMU_BASE_CMDLINE := \
+    $(QEMU_CMD) \
+    -machine virt \
+    -semihosting \
+    -global driver=riscv-cpu,property=smepmp,value=true \
+    -global virtio-mmio.force-legacy=false \
+    -device virtio-rng-device \
+    -serial stdio
+
+
+# Set this as the default local board to write apps to with tockloader
+.PHONY: init
+init:
+	tockloader local-board set qemu_rv32_virt --binary-path qemu_rv32_virt_test.bin
+
+# Write the kernel to the flash file with tockloader
+.PHONY: install
+install: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+	tockloader flash --address 0x80000000 $<
+
+qemu_rv32_virt_tutorial.bin: install
+
+# Run the kernel inside a qemu-riscv32-system "virt" machine type simulation
+.PHONY: run
+run: qemu_rv32_virt_test.bin | install
+	@echo
+	@echo -e "Running $$($(QEMU_CMD) --version | head -n1)"
+	@echo "To exit type C-a x"
+	@echo
+	$(QEMU_BASE_CMDLINE) -bios '$<'

--- a/boards/configurations/qemu_rv32_virt/qemu_rv32_virt-syscall-return-test/README.md
+++ b/boards/configurations/qemu_rv32_virt/qemu_rv32_virt-syscall-return-test/README.md
@@ -1,0 +1,5 @@
+QEMU RISC-V 32 bit `virt` Configuration Board for Syscall Return Testing
+========================================================================
+
+This board crate targets the QEMU RISC-V 32 bit `virt` platform. This includes
+the syscall test capsule for trying all syscall return types.

--- a/boards/configurations/qemu_rv32_virt/qemu_rv32_virt-syscall-return-test/layout.ld
+++ b/boards/configurations/qemu_rv32_virt/qemu_rv32_virt-syscall-return-test/layout.ld
@@ -1,0 +1,5 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2026.                                  */
+
+INCLUDE ../../../qemu_rv32_virt/layout.ld

--- a/boards/configurations/qemu_rv32_virt/qemu_rv32_virt-syscall-return-test/src/main.rs
+++ b/boards/configurations/qemu_rv32_virt/qemu_rv32_virt-syscall-return-test/src/main.rs
@@ -1,0 +1,189 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+//! Board file for the qemu_rv32_virt syscall return type test configuration.
+//!
+//! This board includes only the SyscallReturnTest capsule on top of the base
+//! qemu_rv32_virt platform. It is intended to be used with userspace tests
+//! that verify correct encoding and decoding of every syscall return variant.
+
+#![no_std]
+#![no_main]
+
+use kernel::capabilities;
+use kernel::component::Component;
+use kernel::platform::KernelResources;
+use kernel::platform::SyscallDriverLookup;
+use kernel::{create_capability, debug};
+
+//------------------------------------------------------------------------------
+// BOARD CONSTANTS
+//------------------------------------------------------------------------------
+
+pub const NUM_PROCS: usize = 4;
+
+const FAULT_RESPONSE: capsules_system::process_policies::PanicFaultPolicy =
+    capsules_system::process_policies::PanicFaultPolicy {};
+
+//------------------------------------------------------------------------------
+// PLATFORM AND SYSCALL HANDLING
+//------------------------------------------------------------------------------
+
+struct Platform {
+    base: qemu_rv32_virt_lib::QemuRv32VirtPlatform,
+    syscall_return_test: &'static capsules_extra::syscall_return_test::SyscallReturnTest,
+}
+
+impl SyscallDriverLookup for Platform {
+    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    where
+        F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
+    {
+        match driver_num {
+            capsules_extra::syscall_return_test::DRIVER_NUM => f(Some(self.syscall_return_test)),
+            _ => self.base.with_driver(driver_num, f),
+        }
+    }
+}
+
+impl KernelResources<qemu_rv32_virt_lib::ChipHw> for Platform {
+    type SyscallDriverLookup = Self;
+    type SyscallFilter = <qemu_rv32_virt_lib::QemuRv32VirtPlatform as KernelResources<
+        qemu_rv32_virt_lib::ChipHw,
+    >>::SyscallFilter;
+    type ProcessFault = <qemu_rv32_virt_lib::QemuRv32VirtPlatform as KernelResources<
+        qemu_rv32_virt_lib::ChipHw,
+    >>::ProcessFault;
+    type Scheduler = <qemu_rv32_virt_lib::QemuRv32VirtPlatform as KernelResources<
+        qemu_rv32_virt_lib::ChipHw,
+    >>::Scheduler;
+    type SchedulerTimer = <qemu_rv32_virt_lib::QemuRv32VirtPlatform as KernelResources<
+        qemu_rv32_virt_lib::ChipHw,
+    >>::SchedulerTimer;
+    type WatchDog = <qemu_rv32_virt_lib::QemuRv32VirtPlatform as KernelResources<
+        qemu_rv32_virt_lib::ChipHw,
+    >>::WatchDog;
+    type ContextSwitchCallback = <qemu_rv32_virt_lib::QemuRv32VirtPlatform as KernelResources<
+        qemu_rv32_virt_lib::ChipHw,
+    >>::ContextSwitchCallback;
+
+    fn syscall_driver_lookup(&self) -> &Self::SyscallDriverLookup {
+        self
+    }
+    fn syscall_filter(&self) -> &Self::SyscallFilter {
+        self.base.syscall_filter()
+    }
+    fn process_fault(&self) -> &Self::ProcessFault {
+        self.base.process_fault()
+    }
+    fn scheduler(&self) -> &Self::Scheduler {
+        self.base.scheduler()
+    }
+    fn scheduler_timer(&self) -> &Self::SchedulerTimer {
+        self.base.scheduler_timer()
+    }
+    fn watchdog(&self) -> &Self::WatchDog {
+        self.base.watchdog()
+    }
+    fn context_switch_callback(&self) -> &Self::ContextSwitchCallback {
+        self.base.context_switch_callback()
+    }
+}
+
+/// Main function called after RAM initialized.
+#[no_mangle]
+pub unsafe fn main() {
+    let main_loop_capability = create_capability!(capabilities::MainLoopCapability);
+
+    let (board_kernel, base_platform, chip) = qemu_rv32_virt_lib::start();
+
+    //--------------------------------------------------------------------------
+    // SYSCALL RETURN TEST CAPSULE
+    //--------------------------------------------------------------------------
+
+    let syscall_return_test = components::syscall_return_test::SyscallReturnTestComponent::new(
+        board_kernel,
+        capsules_extra::syscall_return_test::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
+    )
+    .finalize(components::syscall_return_test_component_static!());
+
+    let platform = Platform {
+        base: base_platform,
+        syscall_return_test,
+    };
+
+    let _ = platform.base.process_console_start();
+
+    //--------------------------------------------------------------------------
+    // CREDENTIAL CHECKING
+    //--------------------------------------------------------------------------
+
+    let checking_policy = components::appid::checker_null::AppCheckerNullComponent::new()
+        .finalize(components::app_checker_null_component_static!());
+
+    let assigner = components::appid::assigner_name::AppIdAssignerNamesComponent::new()
+        .finalize(components::appid_assigner_names_component_static!());
+
+    let checker = components::appid::checker::ProcessCheckerMachineComponent::new(checking_policy)
+        .finalize(components::process_checker_machine_component_static!());
+
+    //--------------------------------------------------------------------------
+    // STORAGE PERMISSIONS
+    //--------------------------------------------------------------------------
+
+    let storage_permissions_policy =
+        components::storage_permissions::null::StoragePermissionsNullComponent::new().finalize(
+            components::storage_permissions_null_component_static!(
+                qemu_rv32_virt_lib::ChipHw,
+                kernel::process::ProcessStandardDebugFull,
+            ),
+        );
+
+    //--------------------------------------------------------------------------
+    // PROCESS LOADING
+    //--------------------------------------------------------------------------
+
+    extern "C" {
+        static _sapps: u8;
+        static _eapps: u8;
+        static mut _sappmem: u8;
+        static _eappmem: u8;
+    }
+
+    let app_flash = core::slice::from_raw_parts(
+        core::ptr::addr_of!(_sapps),
+        core::ptr::addr_of!(_eapps) as usize - core::ptr::addr_of!(_sapps) as usize,
+    );
+    let app_memory = core::slice::from_raw_parts_mut(
+        core::ptr::addr_of_mut!(_sappmem),
+        core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
+    );
+
+    let _loader = components::loader::sequential::ProcessLoaderSequentialComponent::new(
+        checker,
+        board_kernel,
+        chip,
+        &FAULT_RESPONSE,
+        assigner,
+        storage_permissions_policy,
+        app_flash,
+        app_memory,
+        create_capability!(capabilities::ProcessManagementCapability),
+    )
+    .finalize(components::process_loader_sequential_component_static!(
+        qemu_rv32_virt_lib::ChipHw,
+        kernel::process::ProcessStandardDebugFull,
+        NUM_PROCS
+    ));
+
+    debug!("Starting main kernel loop.");
+
+    board_kernel.kernel_loop(
+        &platform,
+        chip,
+        Some(&platform.base.ipc),
+        &main_loop_capability,
+    );
+}

--- a/boards/configurations/qemu_rv64_virt/qemu_rv64_virt-test-ci/src/main.rs
+++ b/boards/configurations/qemu_rv64_virt/qemu_rv64_virt-test-ci/src/main.rs
@@ -31,11 +31,14 @@ type LedDriver = capsules_core::led::LedDriver<'static, ScreenOnLedSingle, 4>;
 
 type ButtonDriver = capsules_extra::button_keyboard::ButtonKeyboard<'static>;
 
+type SyscallReturnTestDriver = components::syscall_return_test::SyscallReturnTestComponentType;
+
 struct Platform {
     base: qemu_rv64_virt_lib::QemuRv64VirtPlatform,
     screen: Option<&'static ScreenDriver>,
     led: Option<&'static LedDriver>,
     buttons: Option<&'static ButtonDriver>,
+    syscall_return_test: &'static SyscallReturnTestDriver,
 }
 
 impl SyscallDriverLookup for Platform {
@@ -65,6 +68,7 @@ impl SyscallDriverLookup for Platform {
                     f(None)
                 }
             }
+            capsules_extra::syscall_return_test::DRIVER_NUM => f(Some(self.syscall_return_test)),
 
             _ => self.base.with_driver(driver_num, f),
         }
@@ -208,11 +212,27 @@ pub unsafe fn main() {
         .finalize(components::keyboard_button_component_static!())
     });
 
+    //--------------------------------------------------------------------------
+    // SYSCALL RETURN TEST CAPSULE
+    //--------------------------------------------------------------------------
+
+    let syscall_return_test = components::syscall_return_test::SyscallReturnTestComponent::new(
+        board_kernel,
+        capsules_extra::syscall_return_test::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
+    )
+    .finalize(components::syscall_return_test_component_static!());
+
+    //--------------------------------------------------------------------------
+    // PLATFORM
+    //--------------------------------------------------------------------------
+
     let platform = Platform {
         base: base_platform,
         screen,
         led,
         buttons,
+        syscall_return_test,
     };
 
     // Start the process console:

--- a/capsules/core/src/driver.rs
+++ b/capsules/core/src/driver.rs
@@ -102,5 +102,8 @@ pub enum NUM {
     DateTime              = 0x90007,
     CycleCount            = 0x90008,
     Servo                 = 0x90009,
+
+    // Testing
+    SyscallReturnTest     = 0xA0000,
 }
 }

--- a/capsules/core/src/driver.rs
+++ b/capsules/core/src/driver.rs
@@ -104,6 +104,6 @@ pub enum NUM {
     Servo                 = 0x90009,
 
     // Testing
-    SyscallReturnTest     = 0xA0000,
+    SyscallReturnTest     = 0xB0000,
 }
 }

--- a/capsules/extra/README.md
+++ b/capsules/extra/README.md
@@ -210,4 +210,5 @@ various elements of Tock.
   to enter a fault state when a button is pressed.
 - **[Panic Button](src/panic_button.rs)**: Use a button to force a `panic!()`.
 - **[Process Info](src/process_info_driver.rs)**: Inspect and control processes.
+- **[Syscall Return Test](src/syscall_return_test.rs)**: Use all syscall return types.
 

--- a/capsules/extra/src/lib.rs
+++ b/capsules/extra/src/lib.rs
@@ -107,6 +107,7 @@ pub mod sound_pressure;
 pub mod ssd1306;
 pub mod st77xx;
 pub mod symmetric_encryption;
+pub mod syscall_return_test;
 pub mod temperature;
 pub mod temperature_rp2040;
 pub mod temperature_stm;

--- a/capsules/extra/src/syscall_return_test.rs
+++ b/capsules/extra/src/syscall_return_test.rs
@@ -1,0 +1,111 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+//! Capsule for testing syscall return variants from userspace.
+//!
+//! Each command returns a specific [`SyscallReturn`] variant with distinct,
+//! known values so userspace tests can verify correct encoding and decoding
+//! of every return type.
+//!
+//! The capsule also supports subscribe, allow read-only, allow read-write,
+//! and allow userspace-readable syscalls with subscribe_num/allow_num 0. This
+//! lets userspace tests verify that success and failure returns carry back the
+//! expected pointer and length values.
+//!
+//! For allow calls, pass a valid buffer (within app memory) for a success
+//! return and an invalid pointer (e.g. 0x90) for a failure return. For
+//! subscribe, pass a valid function pointer for success and an invalid one
+//! (e.g. 0x90) for failure.
+//!
+//! ## Command numbers
+//!
+//!  - 0:  Success (driver presence check)
+//!  - 1:  Failure(ErrorCode::FAIL)
+//!  - 2:  FailureU32(ErrorCode::BUSY, 0x10000001)
+//!  - 3:  FailureU32U32(ErrorCode::NOMEM, 0x20000001, 0x20000002)
+//!  - 4:  FailureU64(ErrorCode::INVAL, 0x4000000000000001)
+//!  - 5:  Success
+//!  - 6:  SuccessU32(0x60000001)
+//!  - 7:  SuccessU32U32(0x70000001, 0x70000002)
+//!  - 8:  SuccessU32U32U32(0x80000001, 0x80000002, 0x80000003)
+//!  - 9:  SuccessU64(0x9000000000000001)
+//!  - 10: SuccessU32U64(0xA0000001, 0xA000000000000002)
+
+use kernel::grant::{AllowRoCount, AllowRwCount, Grant, GrantKernelData, UpcallCount};
+use kernel::process;
+use kernel::processbuffer::UserspaceReadableProcessBuffer;
+use kernel::syscall::{CommandReturn, SyscallDriver};
+use kernel::{ErrorCode, ProcessId};
+
+pub const DRIVER_NUM: usize = capsules_core::driver::NUM::SyscallReturnTest as usize;
+
+/// Per-process grant data. Holds the userspace-readable buffer swapped in via
+/// `allow_userspace_readable`.
+#[derive(Default)]
+pub struct App {
+    userspace_readable_buf: UserspaceReadableProcessBuffer,
+}
+
+pub struct SyscallReturnTest {
+    apps: Grant<App, UpcallCount<1>, AllowRoCount<1>, AllowRwCount<1>>,
+}
+
+impl SyscallReturnTest {
+    pub fn new(grant: Grant<App, UpcallCount<1>, AllowRoCount<1>, AllowRwCount<1>>) -> Self {
+        SyscallReturnTest { apps: grant }
+    }
+}
+
+impl SyscallDriver for SyscallReturnTest {
+    fn command(
+        &self,
+        command_num: usize,
+        _r2: usize,
+        _r3: usize,
+        _process_id: ProcessId,
+    ) -> CommandReturn {
+        match command_num {
+            0 => CommandReturn::success(),
+            1 => CommandReturn::failure(ErrorCode::FAIL),
+            2 => CommandReturn::failure_u32(ErrorCode::BUSY, 0x1000_0001),
+            3 => CommandReturn::failure_u32_u32(ErrorCode::NOMEM, 0x2000_0001, 0x2000_0002),
+            4 => CommandReturn::failure_u64(ErrorCode::INVAL, 0x4000_0000_0000_0001),
+            5 => CommandReturn::success(),
+            6 => CommandReturn::success_u32(0x6000_0001),
+            7 => CommandReturn::success_u32_u32(0x7000_0001, 0x7000_0002),
+            8 => CommandReturn::success_u32_u32_u32(0x8000_0001, 0x8000_0002, 0x8000_0003),
+            9 => CommandReturn::success_u64(0x9000_0000_0000_0001),
+            10 => CommandReturn::success_u32_u64(0xA000_0001, 0xA000_0000_0000_0002),
+            _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
+        }
+    }
+
+    /// Accept or reject an allow-userspace-readable buffer.
+    ///
+    /// `which` 0: accept — swap the incoming buffer with whatever was stored
+    /// previously (initially empty) and return the old one to userspace.
+    /// Any other `which` value: reject with `NOSUPPORT`.
+    fn allow_userspace_readable(
+        &self,
+        processid: ProcessId,
+        which: usize,
+        mut slice: UserspaceReadableProcessBuffer,
+    ) -> Result<UserspaceReadableProcessBuffer, (UserspaceReadableProcessBuffer, ErrorCode)> {
+        if which == 0 {
+            let res = self.apps.enter(processid, |data, _: &GrantKernelData| {
+                core::mem::swap(&mut data.userspace_readable_buf, &mut slice);
+            });
+            match res {
+                Ok(()) => Ok(slice),
+                Err(e) => Err((slice, e.into())),
+            }
+        } else {
+            Err((slice, ErrorCode::NOSUPPORT))
+        }
+    }
+
+    fn allocate_grant(&self, process_id: ProcessId) -> Result<(), process::Error> {
+        self.apps.enter(process_id, |_, _| {})
+    }
+}

--- a/capsules/extra/src/syscall_return_test.rs
+++ b/capsules/extra/src/syscall_return_test.rs
@@ -22,14 +22,14 @@
 //!
 //!  - 0:  Success (driver presence check)
 //!  - 1:  Failure(ErrorCode::FAIL)
-//!  - 2:  FailureU32(ErrorCode::BUSY, 0x10000001)
-//!  - 3:  FailureU32U32(ErrorCode::NOMEM, 0x20000001, 0x20000002)
+//!  - 2:  FailureU32(ErrorCode::BUSY, 0x20000001)
+//!  - 3:  FailureU32U32(ErrorCode::NOMEM, 0x30000001, 0x30000002)
 //!  - 4:  FailureU64(ErrorCode::INVAL, 0x4000000000000001)
 //!  - 5:  Success
 //!  - 6:  SuccessU32(0x60000001)
 //!  - 7:  SuccessU32U32(0x70000001, 0x70000002)
-//!  - 8:  SuccessU32U32U32(0x80000001, 0x80000002, 0x80000003)
-//!  - 9:  SuccessU64(0x9000000000000001)
+//!  - 8:  SuccessU64(0x8000000000000001)
+//!  - 9:  SuccessU32U32U32(0x90000001, 0x90000002, 0x90000003)
 //!  - 10: SuccessU32U64(0xA0000001, 0xA000000000000002)
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, GrantKernelData, UpcallCount};
@@ -68,14 +68,14 @@ impl SyscallDriver for SyscallReturnTest {
         match command_num {
             0 => CommandReturn::success(),
             1 => CommandReturn::failure(ErrorCode::FAIL),
-            2 => CommandReturn::failure_u32(ErrorCode::BUSY, 0x1000_0001),
-            3 => CommandReturn::failure_u32_u32(ErrorCode::NOMEM, 0x2000_0001, 0x2000_0002),
+            2 => CommandReturn::failure_u32(ErrorCode::BUSY, 0x2000_0001),
+            3 => CommandReturn::failure_u32_u32(ErrorCode::NOMEM, 0x3000_0001, 0x3000_0002),
             4 => CommandReturn::failure_u64(ErrorCode::INVAL, 0x4000_0000_0000_0001),
             5 => CommandReturn::success(),
             6 => CommandReturn::success_u32(0x6000_0001),
             7 => CommandReturn::success_u32_u32(0x7000_0001, 0x7000_0002),
-            8 => CommandReturn::success_u32_u32_u32(0x8000_0001, 0x8000_0002, 0x8000_0003),
-            9 => CommandReturn::success_u64(0x9000_0000_0000_0001),
+            8 => CommandReturn::success_u64(0x8000_0000_0000_0001),
+            9 => CommandReturn::success_u32_u32_u32(0x9000_0001, 0x9000_0002, 0x9000_0003),
             10 => CommandReturn::success_u32_u64(0xA000_0001, 0xA000_0000_0000_0002),
             _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
         }


### PR DESCRIPTION
### Pull Request Overview

To make sure there is at least one use case for every syscall return variant, this adds a test capsule that enables testing them all. It uses a different command number for each return variant, and supports all three allow types.

I had claude generate this. But reviewing it, it's pretty straightforward.

There are 32-bit and 64-bit config test boards that implement this syscall driver for testing.


### Testing Strategy

Running it with the matching libtock-c test code which verifies all return types are as expected.


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

Claude wrote the capsule.
