### PR TITLE
Add custom target specs for riscv boards to silence the `relax` warning on all riscv board builds

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -73,7 +73,8 @@ $(call check_defined, TARGET)
 # Location of target-specific build.
 # Make sure we delete the ".json" extension if we are building a custom TARGET
 # defined in a JSON file as cargo defines the target folder without ".json".
-TARGET_PATH := $(TARGET_DIRECTORY)$(subst .json,,$(TARGET))
+# Also strip any path prefix since cargo uses only the filename stem.
+TARGET_PATH := $(TARGET_DIRECTORY)$(if $(filter %.json,$(TARGET)),$(basename $(notdir $(TARGET))),$(TARGET))
 
 # If environment variable V or VERBOSE is non-empty, be verbose.
 ifneq ($(V),)
@@ -122,6 +123,11 @@ endif
 # Verify that various required Rust components are installed. All of these steps
 # only have to be done once per Rust version, but will take some time when
 # compiling for the first time.
+#
+# Custom target JSON specs (TARGET ending in .json) are not managed by rustup
+# and do not appear in `rustup target list`; they are built from source via
+# -Zbuild-std and need no rustup registration, so skip the check for them.
+ifneq ($(suffix $(TARGET)),.json)
 ifneq ($(shell $(RUSTUP) target list | grep "$(TARGET) (installed)"),$(TARGET) (installed))
   $(info Request to compile for a missing TARGET: $(TARGET))
   $(info )
@@ -134,6 +140,7 @@ ifneq ($(shell $(RUSTUP) target list | grep "$(TARGET) (installed)"),$(TARGET) (
   $(info     $(RUSTUP) target add $(TARGET))
   $(info )
   $(error Missing required target: $(TARGET))
+endif
 endif
 
 # If the board the user is compiling is using the stable toolchain, verify that

--- a/boards/arty_e21/.cargo/config.toml
+++ b/boards/arty_e21/.cargo/config.toml
@@ -9,5 +9,5 @@ include = [
 ]
 
 [build]
-target = "riscv32imac-unknown-none-elf"
+target = "../cargo/riscv32imac-unknown-none-elf.json"
 

--- a/boards/arty_e21/Makefile
+++ b/boards/arty_e21/Makefile
@@ -16,10 +16,10 @@ TOCKLOADER_OPENOCD_FLAGS = --openocd --board arty
 install: flash
 
 .PHONY: flash-tockloader
-flash-tockloader: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+flash-tockloader: $(TARGET_PATH)/release/$(PLATFORM).bin
 	$(TOCKLOADER) $(TOCKLOADER_GENERAL_FLAGS) flash --address $(KERNEL_ADDRESS) $(TOCKLOADER_OPENOCD_FLAGS) $<
 
-flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+flash: $(TARGET_PATH)/release/$(PLATFORM).bin
 	openocd -f openocd/arty-openocd-digilent.cfg \
 		-c "init; jtagspi_init 0 openocd/bscan_spi_xc7a100t.bit; jtagspi_program $< 0x400000; shutdown"
 

--- a/boards/cargo/README.md
+++ b/boards/cargo/README.md
@@ -21,3 +21,38 @@ include = [
   "../../cargo/unstable_flags.toml",
 ]
 ```
+
+
+Custom Target Specifications
+-----------------------------
+
+This folder also contains custom target specification JSON files for RISC-V
+targets (`riscv32imc-unknown-none-elf.json`, `riscv32imac-unknown-none-elf.json`,
+`riscv64imac-unknown-none-elf.json`). These are derived from the built-in rustc
+target specs (obtainable via `rustc -Z unstable-options --print target-spec-json
+--target <triple>`) with two modifications:
+
+- `+relax` is appended to `features` to enable LLVM to emit relaxable
+  relocations, allowing the linker to perform RISC-V linker relaxation
+  (a significant code size optimization).
+- The `metadata` block is stripped as it is informational only and not
+  used by the build.
+
+The reason for using custom specs rather than passing `-Ctarget-feature=+relax`
+is that `+relax` is not yet stabilized in rustc's target feature API, so
+specifying it via `-Ctarget-feature` emits an "unstable feature" warning that
+cannot be suppressed. Embedding it in the base target spec avoids the warning.
+Upstream stabilization is tracked at https://github.com/rust-lang/rust/issues/150257.
+
+When updating the Rust toolchain (`rust-toolchain.toml`), run
+`tools/repo-maintenance/update_rust_version.sh`, which will automatically
+check these files against the new toolchain's target specs and update them
+if needed.
+
+Boards reference these specs by setting `target` to a relative path in their
+`.cargo/config.toml`:
+
+```toml
+[build]
+target = "../../cargo/riscv32imc-unknown-none-elf.json"
+```

--- a/boards/cargo/riscv32imac-unknown-none-elf.json
+++ b/boards/cargo/riscv32imac-unknown-none-elf.json
@@ -1,0 +1,17 @@
+{
+  "arch": "riscv32",
+  "cpu": "generic-rv32",
+  "crt-objects-fallback": "false",
+  "data-layout": "e-m:e-p:32:32-i64:64-n32-S128",
+  "eh-frame-header": false,
+  "emit-debug-gdb-scripts": false,
+  "features": "+m,+a,+c,+relax",
+  "linker": "rust-lld",
+  "linker-flavor": "gnu-lld",
+  "llvm-abiname": "ilp32",
+  "llvm-target": "riscv32",
+  "max-atomic-width": 32,
+  "panic-strategy": "abort",
+  "relocation-model": "static",
+  "target-pointer-width": 32
+}

--- a/boards/cargo/riscv32imc-unknown-none-elf.json
+++ b/boards/cargo/riscv32imc-unknown-none-elf.json
@@ -1,0 +1,18 @@
+{
+  "arch": "riscv32",
+  "atomic-cas": false,
+  "cpu": "generic-rv32",
+  "crt-objects-fallback": "false",
+  "data-layout": "e-m:e-p:32:32-i64:64-n32-S128",
+  "eh-frame-header": false,
+  "emit-debug-gdb-scripts": false,
+  "features": "+m,+c,+forced-atomics,+relax",
+  "linker": "rust-lld",
+  "linker-flavor": "gnu-lld",
+  "llvm-abiname": "ilp32",
+  "llvm-target": "riscv32",
+  "max-atomic-width": 32,
+  "panic-strategy": "abort",
+  "relocation-model": "static",
+  "target-pointer-width": 32
+}

--- a/boards/cargo/riscv64imac-unknown-none-elf.json
+++ b/boards/cargo/riscv64imac-unknown-none-elf.json
@@ -1,0 +1,22 @@
+{
+  "arch": "riscv64",
+  "code-model": "medium",
+  "cpu": "generic-rv64",
+  "crt-objects-fallback": "false",
+  "data-layout": "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128",
+  "eh-frame-header": false,
+  "emit-debug-gdb-scripts": false,
+  "features": "+m,+a,+c,+relax",
+  "linker": "rust-lld",
+  "linker-flavor": "gnu-lld",
+  "llvm-abiname": "lp64",
+  "llvm-target": "riscv64",
+  "max-atomic-width": 64,
+  "panic-strategy": "abort",
+  "relocation-model": "static",
+  "supported-sanitizers": [
+    "shadow-call-stack",
+    "kernel-address"
+  ],
+  "target-pointer-width": 64
+}

--- a/boards/cargo/riscv_flags.toml
+++ b/boards/cargo/riscv_flags.toml
@@ -4,13 +4,13 @@
 
 # RISC-V-specific flags.
 
+[unstable]
+json-target-spec = true
+
 [build]
 rustflags = [
   # NOTE: This flag causes kernel panics on some ARM cores. Since the size
   # benefit is almost exclusively for RISC-V, we only apply it for those
   # targets.
   "-C", "force-frame-pointers=no",
-  # Ensure relocations generated is eligible for linker relaxation.
-  # This provides huge space savings.
-  "-C", "target-feature=+relax",
 ]

--- a/boards/configurations/qemu_rv64_virt/.cargo/config.toml
+++ b/boards/configurations/qemu_rv64_virt/.cargo/config.toml
@@ -9,4 +9,4 @@ include = [
 ]
 
 [build]
-target = "riscv64imac-unknown-none-elf"
+target = "../../cargo/riscv64imac-unknown-none-elf.json"

--- a/boards/configurations/qemu_rv64_virt/qemu_rv64_virt-test-ci/Makefile
+++ b/boards/configurations/qemu_rv64_virt/qemu_rv64_virt-test-ci/Makefile
@@ -32,7 +32,7 @@ init:
 
 # Write the kernel to the flash file with tockloader
 .PHONY: install
-install: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+install: $(TARGET_PATH)/release/$(PLATFORM).bin
 	tockloader flash --address 0x80000000 $<
 
 qemu_rv64_virt_tutorial.bin: install
@@ -42,7 +42,7 @@ qemu_rv64_virt_tutorial.bin: install
 run: qemu_rv64_virt_tutorial.bin | install
 	@echo
 	@echo -e "Running $$($(QEMU_CMD) --version | head -n1) with\n"\
-          " - kernel $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf"
+          " - kernel $(TARGET_PATH)/release/$(PLATFORM).elf"
 	@echo "To exit type C-a x"
 	@echo
 	$(QEMU_CMDLINE) -bios '$<'

--- a/boards/esp32-c3-devkitM-1/.cargo/config.toml
+++ b/boards/esp32-c3-devkitM-1/.cargo/config.toml
@@ -10,7 +10,7 @@ include = [
 ]
 
 [build]
-target = "riscv32imc-unknown-none-elf"
+target = "../cargo/riscv32imc-unknown-none-elf.json"
 
 [target.'cfg(target_arch = "riscv32")']
 runner = "./run.sh"

--- a/boards/esp32-c3-devkitM-1/Makefile
+++ b/boards/esp32-c3-devkitM-1/Makefile
@@ -18,7 +18,7 @@ init:
 
 # Write the kernel to the flash file with tockloader
 .PHONY: write-kernel
-write-kernel: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+write-kernel: $(TARGET_PATH)/release/$(PLATFORM).bin
 	tockloader flash --local-board --address 0x40380000 $<
 
 esp32_c3_devkitm1.bin: write-kernel

--- a/boards/hifive1/.cargo/config.toml
+++ b/boards/hifive1/.cargo/config.toml
@@ -9,5 +9,5 @@ include = [
 ]
 
 [build]
-target = "riscv32imac-unknown-none-elf"
+target = "../cargo/riscv32imac-unknown-none-elf.json"
 

--- a/boards/hifive1/Makefile
+++ b/boards/hifive1/Makefile
@@ -12,14 +12,14 @@ include ../Makefile.common
 .PHONY: install
 install: flash
 
-flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+flash: $(TARGET_PATH)/release/$(PLATFORM).elf
 	openocd \
 		-c "source [find board/sifive-hifive1-revb.cfg]; program $<; resume 0x20000000; exit"
 
-qemu: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+qemu: $(TARGET_PATH)/release/$(PLATFORM).elf
 	$(QEMU) -M sifive_e,revb=true -kernel $^  -nographic
 
-qemu-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+qemu-app: $(TARGET_PATH)/release/$(PLATFORM).elf
 	$(QEMU) -M sifive_e,revb=true -kernel $^ -device loader,file=$(APP),addr=0x20040000 -nographic
 
 
@@ -29,5 +29,5 @@ KERNEL_ADDRESS = 0x20010000
 
 # upload kernel over JTAG
 .PHONY: flash
-flash-jlink: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+flash-jlink: $(TARGET_PATH)/release/$(PLATFORM).bin
 	$(TOCKLOADER) $(TOCKLOADER_GENERAL_FLAGS) flash --address $(KERNEL_ADDRESS) $(TOCKLOADER_JTAG_FLAGS) $<

--- a/boards/hifive_inventor/.cargo/config.toml
+++ b/boards/hifive_inventor/.cargo/config.toml
@@ -9,5 +9,5 @@ include = [
 ]
 
 [build]
-target = "riscv32imac-unknown-none-elf"
+target = "../cargo/riscv32imac-unknown-none-elf.json"
 

--- a/boards/hifive_inventor/Makefile
+++ b/boards/hifive_inventor/Makefile
@@ -18,5 +18,5 @@ KERNEL_ADDRESS = 0x20010000
 
 # upload kernel over JTAG
 .PHONY: flash-jlink
-flash-jlink: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+flash-jlink: $(TARGET_PATH)/release/$(PLATFORM).bin
 	$(TOCKLOADER) $(TOCKLOADER_GENERAL_FLAGS) flash --address $(KERNEL_ADDRESS) $(TOCKLOADER_JTAG_FLAGS) $<

--- a/boards/litex/arty/.cargo/config.toml
+++ b/boards/litex/arty/.cargo/config.toml
@@ -9,5 +9,5 @@ include = [
 ]
 
 [build]
-target = "riscv32imc-unknown-none-elf"
+target = "../../cargo/riscv32imc-unknown-none-elf.json"
 

--- a/boards/litex/sim/.cargo/config.toml
+++ b/boards/litex/sim/.cargo/config.toml
@@ -9,5 +9,5 @@ include = [
 ]
 
 [build]
-target = "riscv32imc-unknown-none-elf"
+target = "../../cargo/riscv32imc-unknown-none-elf.json"
 

--- a/boards/opentitan/earlgrey-cw310/.cargo/config.toml
+++ b/boards/opentitan/earlgrey-cw310/.cargo/config.toml
@@ -12,7 +12,7 @@ include = [
 ]
 
 [build]
-target = "riscv32imc-unknown-none-elf"
+target = "../../cargo/riscv32imc-unknown-none-elf.json"
 
 [target.'cfg(target_arch = "riscv32")']
 runner = "./run.sh"

--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -69,41 +69,41 @@ endif
 .PHONY: install
 install: flash
 
-qemu: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+qemu: $(TARGET_PATH)/release/$(PLATFORM).elf
 	$(QEMU) -M opentitan -kernel $^ -nographic -serial mon:stdio -global driver=riscv.lowrisc.ibex.soc,property=resetvec,value=${QEMU_ENTRY_POINT}
 
-qemu-gdb: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+qemu-gdb: $(TARGET_PATH)/release/$(PLATFORM).elf
 	$(QEMU) -s -S -M opentitan -kernel $^ -nographic -serial mon:stdio -global driver=riscv.lowrisc.ibex.soc,property=resetvec,value=${QEMU_ENTRY_POINT}
 
-qemu-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+qemu-app: $(TARGET_PATH)/release/$(PLATFORM).elf
 	$(QEMU) -M opentitan -kernel $^ -device loader,file=$(APP),addr=0x20030000 -nographic -serial mon:stdio -global driver=riscv.lowrisc.ibex.soc,property=resetvec,value=${QEMU_ENTRY_POINT}
 
-qemu-app-gdb : $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+qemu-app-gdb : $(TARGET_PATH)/release/$(PLATFORM).elf
 	$(QEMU) -s -S -M opentitan -kernel $^ -device loader,file=$(APP),addr=0x20030000 -nographic -serial mon:stdio -global driver=riscv.lowrisc.ibex.soc,property=resetvec,value=${QEMU_ENTRY_POINT}
 
-flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
-	$(OPENTITAN_TREE)/bazel-bin/sw/host/opentitantool/opentitantool.runfiles/lowrisc_opentitan/sw/host/opentitantool/opentitantool --interface=cw310 bootstrap $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+flash: $(TARGET_PATH)/release/$(PLATFORM).bin
+	$(OPENTITAN_TREE)/bazel-bin/sw/host/opentitantool/opentitantool.runfiles/lowrisc_opentitan/sw/host/opentitantool/opentitantool --interface=cw310 bootstrap $(TARGET_PATH)/release/$(PLATFORM).bin
 
-flash-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	$(RISC_PREFIX)-objcopy --set-section-flags .apps=LOAD,ALLOC $^ $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf
-	$(RISC_PREFIX)-objcopy --update-section .apps=$(APP) $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf
-	$(RISC_PREFIX)-objcopy --output-target=binary $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.bin
-	$(OPENTITAN_TREE)/bazel-bin/sw/host/opentitantool/opentitantool.runfiles/lowrisc_opentitan/sw/host/opentitantool/opentitantool --interface=cw310 bootstrap $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.bin
+flash-app: $(TARGET_PATH)/release/$(PLATFORM).elf
+	$(RISC_PREFIX)-objcopy --set-section-flags .apps=LOAD,ALLOC $^ $(TARGET_PATH)/release/$(PLATFORM)-app.elf
+	$(RISC_PREFIX)-objcopy --update-section .apps=$(APP) $(TARGET_PATH)/release/$(PLATFORM)-app.elf
+	$(RISC_PREFIX)-objcopy --output-target=binary $(TARGET_PATH)/release/$(PLATFORM)-app.elf $(TARGET_PATH)/release/$(PLATFORM)-app.bin
+	$(OPENTITAN_TREE)/bazel-bin/sw/host/opentitantool/opentitantool.runfiles/lowrisc_opentitan/sw/host/opentitantool/opentitantool --interface=cw310 bootstrap $(TARGET_PATH)/release/$(PLATFORM)-app.bin
 
-verilator: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+verilator: $(TARGET_PATH)/release/$(PLATFORM).elf
 	$(call check_defined, OPENTITAN_TREE)
 #	Make a copy so we dont modify the original elf when linkng apps
-	$(RISC_PREFIX)-objcopy $^ $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.elf
+	$(RISC_PREFIX)-objcopy $^ $(TARGET_PATH)/release/$(PLATFORM)_verilator.elf
 ifneq ($(APP),)
 		$(info [CW-130: Verilator]: Linking App)
-		$(RISC_PREFIX)-objcopy --set-section-flags .apps=LOAD,ALLOC $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.elf $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.elf
-		$(RISC_PREFIX)-objcopy --update-section .apps=$(APP) $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.elf
+		$(RISC_PREFIX)-objcopy --set-section-flags .apps=LOAD,ALLOC $(TARGET_PATH)/release/$(PLATFORM)_verilator.elf $(TARGET_PATH)/release/$(PLATFORM)_verilator.elf
+		$(RISC_PREFIX)-objcopy --update-section .apps=$(APP) $(TARGET_PATH)/release/$(PLATFORM)_verilator.elf
 endif
 	$(info [CW-130: Verilator]: Starting)
-	$(RISC_PREFIX)-objcopy --output-target=binary $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.elf $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.bin
-	srec_cat $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.bin \
+	$(RISC_PREFIX)-objcopy --output-target=binary $(TARGET_PATH)/release/$(PLATFORM)_verilator.elf $(TARGET_PATH)/release/$(PLATFORM)_verilator.bin
+	srec_cat $(TARGET_PATH)/release/$(PLATFORM)_verilator.bin \
 		--binary --offset 0 --byte-swap 8 --fill 0xff \
-		-within $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.bin\
+		-within $(TARGET_PATH)/release/$(PLATFORM)_verilator.bin\
 		-binary -range-pad 8 --output binary.64.vmem --vmem 64
 	$(OPENTITAN_TREE)/bazel-out/k8-fastbuild/bin/hw/build.verilator_real/sim-verilator/Vchip_sim_tb \
 		--meminit=rom,$(OPENTITAN_TREE)/bazel-out/k8-fastbuild-ST-2cc462681f62/bin/sw/device/lib/testing/test_rom/test_rom_sim_verilator.39.scr.vmem \

--- a/boards/qemu_rv32_virt/.cargo/config.toml
+++ b/boards/qemu_rv32_virt/.cargo/config.toml
@@ -9,5 +9,5 @@ include = [
 ]
 
 [build]
-target = "riscv32imac-unknown-none-elf"
+target = "../cargo/riscv32imac-unknown-none-elf.json"
 

--- a/boards/qemu_rv32_virt/Makefile
+++ b/boards/qemu_rv32_virt/Makefile
@@ -73,11 +73,11 @@ QEMU_BASE_CMDLINE := \
 
 # Run the kernel inside a qemu-riscv32-system "virt" machine type simulation
 .PHONY: run
-run: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+run: $(TARGET_PATH)/release/$(PLATFORM).elf
 	@echo
 	@echo -e "Running $$($(QEMU_CMD) --version | head -n1)"\
 	  "(tested: $(WORKING_QEMU_VERSIONS); known broken: $(BROKEN_QEMU_VERSIONS)) with\n"\
-          " - kernel $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf"
+          " - kernel $(TARGET_PATH)/release/$(PLATFORM).elf"
 	@echo "To exit type C-a x"
 	@echo
 	$(QEMU_BASE_CMDLINE) \
@@ -87,11 +87,11 @@ run: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 # Same as `run`, but with a `virtio-gpu` video device attached, showing the
 # screen output in a QEMU window
 .PHONY: run-gui
-run-gui: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+run-gui: $(TARGET_PATH)/release/$(PLATFORM).elf
 	@echo
 	@echo -e "Running $$($(QEMU_CMD) --version | head -n1)"\
 	  "(tested: $(WORKING_QEMU_VERSIONS); known broken: $(BROKEN_QEMU_VERSIONS)) with\n"\
-          " - kernel $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf"
+          " - kernel $(TARGET_PATH)/release/$(PLATFORM).elf"
 	@echo "To exit type C-a x"
 	@echo
 	$(QEMU_BASE_CMDLINE) \
@@ -102,11 +102,11 @@ run-gui: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 # Same as `run`, but load an application specified by $(APP) into the respective
 # memory location.
 .PHONY: run-app
-run-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+run-app: $(TARGET_PATH)/release/$(PLATFORM).elf
 	@echo
 	@echo -e "Running $$($(QEMU_CMD) --version | head -n1)"\
 	  "(tested: $(WORKING_QEMU_VERSIONS); known broken: $(BROKEN_QEMU_VERSIONS)) with\n"\
-          " - kernel $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf\n"\
+          " - kernel $(TARGET_PATH)/release/$(PLATFORM).elf\n"\
 	  " - app $(APP)"
 	@echo "To exit type C-a x"
 	@echo
@@ -118,11 +118,11 @@ run-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 # Same as `run-app`, but with a `virtio-gpu` video device attached, showing the
 # screen output in a QEMU window
 .PHONY: run-app-gui
-run-app-gui: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+run-app-gui: $(TARGET_PATH)/release/$(PLATFORM).elf
 	@echo
 	@echo -e "Running $$($(QEMU_CMD) --version | head -n1)"\
 	  "(tested: $(WORKING_QEMU_VERSIONS); known broken: $(BROKEN_QEMU_VERSIONS)) with\n"\
-          " - kernel $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf\n"\
+          " - kernel $(TARGET_PATH)/release/$(PLATFORM).elf\n"\
 	  " - app $(APP)"
 	@echo "To exit type C-a x"
 	@echo

--- a/boards/qemu_rv64_virt/.cargo/config.toml
+++ b/boards/qemu_rv64_virt/.cargo/config.toml
@@ -9,4 +9,4 @@ include = [
 ]
 
 [build]
-target = "riscv64imac-unknown-none-elf"
+target = "../cargo/riscv64imac-unknown-none-elf.json"

--- a/boards/qemu_rv64_virt/Makefile
+++ b/boards/qemu_rv64_virt/Makefile
@@ -73,11 +73,11 @@ QEMU_BASE_CMDLINE := \
 
 # Run the kernel inside a qemu-riscv64-system "virt" machine type simulation
 .PHONY: run
-run: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+run: $(TARGET_PATH)/release/$(PLATFORM).elf
 	@echo
 	@echo -e "Running $$($(QEMU_CMD) --version | head -n1)"\
 	  "(tested: $(WORKING_QEMU_VERSIONS); known broken: $(BROKEN_QEMU_VERSIONS)) with\n"\
-          " - kernel $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf"
+          " - kernel $(TARGET_PATH)/release/$(PLATFORM).elf"
 	@echo "To exit type C-a x"
 	@echo
 	$(QEMU_BASE_CMDLINE) \
@@ -87,11 +87,11 @@ run: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 # Same as `run`, but with a `virtio-gpu` video device attached, showing the
 # screen output in a QEMU window
 .PHONY: run-gui
-run-gui: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+run-gui: $(TARGET_PATH)/release/$(PLATFORM).elf
 	@echo
 	@echo -e "Running $$($(QEMU_CMD) --version | head -n1)"\
 	  "(tested: $(WORKING_QEMU_VERSIONS); known broken: $(BROKEN_QEMU_VERSIONS)) with\n"\
-          " - kernel $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf"
+          " - kernel $(TARGET_PATH)/release/$(PLATFORM).elf"
 	@echo "To exit type C-a x"
 	@echo
 	$(QEMU_BASE_CMDLINE) \
@@ -102,11 +102,11 @@ run-gui: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 # Same as `run`, but load an application specified by $(APP) into the respective
 # memory location.
 .PHONY: run-app
-run-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+run-app: $(TARGET_PATH)/release/$(PLATFORM).elf
 	@echo
 	@echo -e "Running $$($(QEMU_CMD) --version | head -n1)"\
 	  "(tested: $(WORKING_QEMU_VERSIONS); known broken: $(BROKEN_QEMU_VERSIONS)) with\n"\
-          " - kernel $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf\n"\
+          " - kernel $(TARGET_PATH)/release/$(PLATFORM).elf\n"\
 	  " - app $(APP)"
 	@echo "To exit type C-a x"
 	@echo
@@ -118,11 +118,11 @@ run-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 # Same as `run-app`, but with a `virtio-gpu` video device attached, showing the
 # screen output in a QEMU window
 .PHONY: run-app-gui
-run-app-gui: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+run-app-gui: $(TARGET_PATH)/release/$(PLATFORM).elf
 	@echo
 	@echo -e "Running $$($(QEMU_CMD) --version | head -n1)"\
 	  "(tested: $(WORKING_QEMU_VERSIONS); known broken: $(BROKEN_QEMU_VERSIONS)) with\n"\
-          " - kernel $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf\n"\
+          " - kernel $(TARGET_PATH)/release/$(PLATFORM).elf\n"\
 	  " - app $(APP)"
 	@echo "To exit type C-a x"
 	@echo

--- a/boards/redboard_redv/.cargo/config.toml
+++ b/boards/redboard_redv/.cargo/config.toml
@@ -9,5 +9,5 @@ include = [
 ]
 
 [build]
-target = "riscv32imac-unknown-none-elf"
+target = "../cargo/riscv32imac-unknown-none-elf.json"
 

--- a/boards/redboard_redv/Makefile
+++ b/boards/redboard_redv/Makefile
@@ -12,14 +12,14 @@ include ../Makefile.common
 .PHONY: install
 install: flash
 
-flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+flash: $(TARGET_PATH)/release/$(PLATFORM).elf
 	openocd \
 		-c "source [find board/sifive-hifive1-revb.cfg]; program $<; resume 0x20000000; exit"
 
-qemu: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+qemu: $(TARGET_PATH)/release/$(PLATFORM).elf
 	$(QEMU) -M sifive_e,revb=true -kernel $^  -nographic
 
-qemu-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+qemu-app: $(TARGET_PATH)/release/$(PLATFORM).elf
 	$(QEMU) -M sifive_e,revb=true -kernel $^ -device loader,file=$(APP),addr=0x20010000 -nographic
 
 
@@ -29,5 +29,5 @@ KERNEL_ADDRESS = 0x20010000
 
 # upload kernel over JTAG
 .PHONY: flash
-flash-jlink: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+flash-jlink: $(TARGET_PATH)/release/$(PLATFORM).bin
 	$(TOCKLOADER) $(TOCKLOADER_GENERAL_FLAGS) flash --address $(KERNEL_ADDRESS) $(TOCKLOADER_JTAG_FLAGS) $<

--- a/boards/tutorials/qemu_rv32_virt-tutorial/.cargo/config.toml
+++ b/boards/tutorials/qemu_rv32_virt-tutorial/.cargo/config.toml
@@ -9,7 +9,7 @@ include = [
 ]
 
 [build]
-target = "riscv32imac-unknown-none-elf"
+target = "../../cargo/riscv32imac-unknown-none-elf.json"
 
 [target.riscv32imac-unknown-none-elf]
 runner = ["qemu-system-riscv32",

--- a/boards/tutorials/qemu_rv32_virt-tutorial/Makefile
+++ b/boards/tutorials/qemu_rv32_virt-tutorial/Makefile
@@ -29,7 +29,7 @@ init:
 
 # Write the kernel to the flash file with tockloader
 .PHONY: install
-install: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+install: $(TARGET_PATH)/release/$(PLATFORM).bin
 	tockloader flash --address 0x80000000 $<
 
 qemu_rv32_virt_tutorial.bin: install
@@ -40,7 +40,7 @@ run: qemu_rv32_virt_tutorial.bin | install
 	@echo
 	@echo -e "Running $$($(QEMU_CMD) --version | head -n1)"\
 	  "(tested: $(WORKING_QEMU_VERSIONS); known broken: $(BROKEN_QEMU_VERSIONS)) with\n"\
-          " - kernel $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf"
+          " - kernel $(TARGET_PATH)/release/$(PLATFORM).elf"
 	@echo "To exit type C-a x"
 	@echo
 	$(QEMU_BASE_CMDLINE) -bios '$<'

--- a/boards/veer_el2_sim/.cargo/config.toml
+++ b/boards/veer_el2_sim/.cargo/config.toml
@@ -9,5 +9,5 @@ include = [
 ]
 
 [build]
-target = "riscv32imc-unknown-none-elf"
+target = "../cargo/riscv32imc-unknown-none-elf.json"
 

--- a/boards/veer_el2_sim/Makefile
+++ b/boards/veer_el2_sim/Makefile
@@ -5,7 +5,6 @@
 
 # Makefile for building the tock kernel for the VeeR EL2 simulation platform
 
-TARGET=riscv32imc-unknown-none-elf
 PLATFORM=veer_el2_sim
 GNU_OBJCOPY ?= riscv64-unknown-elf-objcopy
 

--- a/tools/repo-maintenance/update_rust_version.sh
+++ b/tools/repo-maintenance/update_rust_version.sh
@@ -38,3 +38,56 @@ sed -i._SED_HACK "s/nightly-[0-9]*-[0-9]*-[0-9]*/${NIGHTLY}/g" .vscode/settings.
 sed -i._SED_HACK "s/nightly-[0-9]*-[0-9]*-[0-9]*/${NIGHTLY}/g" doc/Getting_Started.md
 
 find . -name '*._SED_HACK' -delete
+
+# Update custom RISC-V target specs to match the new toolchain.
+#
+# Tock uses custom target JSON specs (boards/cargo/riscv*.json) rather than
+# the built-in RISC-V targets so that the +relax feature (which enables LLVM
+# to emit relaxable relocations for linker relaxation, providing significant
+# code size savings) can be included in the base target definition. Features
+# specified via -Ctarget-feature trigger an "unstable feature" warning for
+# +relax because rustc has not yet stabilized it; features in the target spec
+# itself do not. There is no active upstream stabilization effort as of 2026;
+# track progress at https://github.com/rust-lang/rust/issues/150257.
+#
+# These JSON files are derived from `rustc --print target-spec-json` with
+# +relax appended to features and the metadata block stripped; they must be
+# kept in sync when the toolchain changes.
+echo "Checking RISC-V custom target specs..."
+for TARGET in riscv32imc-unknown-none-elf riscv32imac-unknown-none-elf riscv64imac-unknown-none-elf; do
+    JSON="boards/cargo/${TARGET}.json"
+    [ -f "$JSON" ] || continue
+
+    # rust-toolchain.toml was already updated to $NIGHTLY above, so plain
+    # `rustc` here picks up the new toolchain via rustup's toolchain-file
+    # override, installing it first if needed.
+    UPSTREAM_FILE=$(mktemp)
+    rustc -Z unstable-options --print target-spec-json --target "$TARGET" > "$UPSTREAM_FILE"
+    if [ ! -s "$UPSTREAM_FILE" ]; then
+        echo "  ${TARGET}: rustc produced no target spec, aborting" >&2
+        rm "$UPSTREAM_FILE"
+        exit 1
+    fi
+
+    python3 - "$JSON" "$TARGET" "$UPSTREAM_FILE" <<'PYEOF'
+import json, sys
+
+with open(sys.argv[3]) as f:
+    upstream = json.load(f)
+upstream['features'] = upstream.get('features', '') + ',+relax'
+upstream.pop('metadata', None)
+
+path = sys.argv[1]
+with open(path) as f:
+    current = json.load(f)
+
+if current != upstream:
+    print(f"  {sys.argv[2]}: spec changed, updating")
+    with open(path, 'w') as f:
+        json.dump(upstream, f, indent=2)
+        f.write('\n')
+else:
+    print(f"  {sys.argv[2]}: up to date")
+PYEOF
+    rm "$UPSTREAM_FILE"
+done


### PR DESCRIPTION
### Pull Request Overview

All of our riscv board builds print a multi-line warning right now because we enable `+relax` (for good reason, as it leads to real code size improvements). The warning comes because `relax` isn't stabilized and the path to general stabilization is a bit fuzzy as far as I can tell—but I don't think it's going anywhere, it's just passing through an llvm intrinsic. The stabilization concerns are more around how to handle 'default behavior' when `relax` working requires some platform support (setting `gp` correctly, which Tock does do).

The approach this takes, then, is to create custom targets for riscv boards, because if `relax` is in the target specs definition, then no warning is emitted; the warning only comes when you use Cargo to turn on `relax`. In practice, upstream default target specs rarely change, and I had Claude update the toolchain update script to check / update these as-needed.

A _better_ solution would be to pick back up the thread on #4464, since then we could include `relax` in the upstream specs for the `tock` target — but that's a much bigger project. This is an immediate cleanup of some real noise in our builds.

### Testing Strategy

This pull request was tested by compiling.

### TODO or Help Wanted

I'm unsure whether or not we want this, as it's a bit more 'custom' board machinery. I don't think it's too bad, and it would be nice to eliminate the multi-line warning that prints with every riscv board build.

### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

I asked Claude where the warning was coming from and whether we could silence it. We iterated for a while, and this was the best approach I came to.

<details><summary>Here's a summary of some of the other things I forced Claude to try that didn't work.</summary>
Empirical results, each tested for real:
<ul>
<li> (a) RUSTFLAGS env var: breaks the build — replaces (not merges) the config-file rustflags, dropping Tock's sentinel flag (cfg_tock_buildflagssentinel) that boards/build_scripts checks for; build panics before the warning question is even reachable.</li>
<li> (b) .cargo/config.toml via [build.rustflags]: this is master's current, real setup (boards/cargo/riscv_flags.toml) — confirmed the warning still fires on every crate compiled.</li>
<li> (b-variant) [target.<triple>.rustflags]: also breaks — Cargo's rustflags source selection is winner-take-all across config fragments, not merged, so it silently drops tock_flags.toml's sentinel flag too (same panic as (a)). Not viable regardless of the warning.</li>
<li> (d) -A unstable-features: does not suppress it. --cap-lints allow does suppress it at the raw rustc level — but Cargo only auto-applies --cap-lints to external/registry dependencies, never to local workspace/path crates (our own kernel/board/arch crates), so this can't be leveraged through normal builds.</li>
</ul>

Bottom line: No config-file-based mechanism — including PR #5076's --config merge trick — can suppress this warning for Tock's own crates; it's a hard-coded rustc diagnostic with no lint name, confirming the branch's existing commit message claim. The custom JSON target-spec approach (embedding +relax in the target's features field rather than passing it as a -C target-feature flag) remains the only working path, since it doesn't go through the "unstable -C flag" warning at all. Recommend sticking with the current dev/riscv/custom-target-relax design.
</details>