### PR TITLE
boards: declare all 520 kB of SRAM on Pico 2

### DIFF
--- a/boards/raspberry_pi_pico_2/layout.ld
+++ b/boards/raspberry_pi_pico_2/layout.ld
@@ -14,7 +14,7 @@ MEMORY
   bootloader (rx) : ORIGIN = 0x10000000, LENGTH = 1024
   rom (rx)  : ORIGIN = 0x10000400, LENGTH = 255K
   prog (rx) : ORIGIN = 0x10040000, LENGTH = 256K
-  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 264K
+  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 520K
 }
 
 PAGE_SIZE = 4K;


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the RAM size in the Raspberry Pi Pico 2 linker script.

`boards/raspberry_pi_pico_2/layout.ld` declares 264 kB of RAM. That is the
RP2040's SRAM size — the line is byte-identical to the one in
`boards/raspberry_pi_pico/layout.ld`, which this board's layout was derived
from. The RP2350 has 520 kB.

RP2350 datasheet §4.2:

> There is a total of 520 kB (520 × 1024 bytes) of on-chip SRAM. For
> performance reasons, this memory is physically partitioned into ten banks,
> but logically it still behaves as a single, flat 520 kB memory.

The region is contiguous and entirely available to the kernel: the address map
runs from `SRAM_BASE` at `0x20000000` to `SRAM_END` at `0x20082000`, which is
520 kB. The bootrom's dedicated 1 kB of Boot RAM is a separate block at
`0x400e0000` and does not overlap it.

#### Is the upper half actually powered?

`0x20040000` is a documented watermark between the SRAM0 and SRAM1 power
domains, so it is worth saying explicitly that everything above it is live
under this port:

- The bootrom powers both domains up unconditionally. RP2350 datasheet §5.2.2,
  in the always-taken branch of the boot sequence: "Power up SRAM0 and SRAM1
  power domains (XIP RAM domain is already powered)."
- `SYSCFG.MEMPOWERDOWN`, which can put individual banks into a
  retain-contents-but-inaccessible state, resets to `0x0` on every bit — and
  `chips/rp2350` has no SYSCFG driver, so Tock never writes it.
- `Chip::sleep()` is a bare `wfi()`. Nothing in the port touches POWMAN.

So SRAM0–SRAM9 are all powered and accessible by the time the kernel runs.

#### Why 520 kB and not 512 kB

The top 8 kB is two non-striped 4 kB banks, SRAM8 and SRAM9 at `0x20080000`
and `0x20081000`, which the datasheet describes as "useful for hoisting
high-bandwidth data structures like the processor stacks". I considered
reserving them and declaring only the 512 kB striped region.

I went with 520 kB because §4.2 is explicit that "RP2350 does not restrict the
data stored in each bank" and that the ten banks are "logically ... a single,
flat 520 kB memory", so there is no correctness reason to hold them back. If
the project would rather keep those two banks in reserve for a future use,
512 kB is a one-character change and I am happy to make it.

Because `tock_kernel_layout.ld` computes `_eappmem = ORIGIN(ram) + LENGTH(ram)`,
the change only affects how much memory is available to processes. It roughly
doubles it:

| | `_sappmem` | `_eappmem` | available to applications |
|---|---|---|---|
| before | `0x20004a48` | `0x20042000` | 251,320 bytes (245 kB) |
| after | `0x20004a48` | `0x20082000` | 513,464 bytes (501 kB) |

`raspberry_pi_pico_2` is the only board in-tree targeting the RP2350, so no
other board is affected. The RP2040 boards keep 264 kB, which is correct for
them.

### Testing Strategy

This pull request was tested by building the board before and after the change
and comparing the resulting binaries and symbols.

- `make -C boards/raspberry_pi_pico_2` succeeds.
- Kernel `text` and `bss` are byte-identical before and after (69164 / 19020),
  confirming the change is confined to the application memory region.
- `llvm-nm` confirms `_eappmem` moves from `0x20042000` to `0x20082000` and
  `_sappmem` is unchanged, i.e. `0x20000000 + 520K` exactly.
- `make prepush` passes.

**Not tested on hardware.** I do not have a non-wireless Pico 2 to flash, and
the change alters the memory a process is given rather than any code path, so
I would appreciate a maintainer with the board confirming that a process which
requests more than 245 kB now loads and runs.

### TODO or Help Wanted

This pull request still needs on-hardware confirmation, per above.

Two adjacent things I did not touch, but noticed, and am happy to fold in or
split out if wanted:

- The commented-out "boot from RAM" block at the top of the same file still
  carries RP2040-derived numbers.
- `raspberry_pi_pico_2` is the RP2350A (QFN-60, 30 GPIO). If an RP2350B board
  is ever added, `chips/rp2350` currently defines `GPIO0`–`GPIO29` only, and
  the `gpio_hi_*` registers are declared but unused.

### Checklist

- [x] Ran `make prepush`.

### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

**Tool:** Claude Opus 5, via Claude Code.

**What the AI did:** The bug was found by the AI while it was cross-checking a
piece of writing about the RP2350 memory map against the datasheet and this
tree — it noticed the linker script disagreed with the datasheet and that the
value matched the RP2040 board exactly. The AI then produced the one-line
change, the commit message, and this description, and ran the verification
described under Testing Strategy.

**What the patch is:** a single literal, `264K` → `520K`, on line 17 of
`boards/raspberry_pi_pico_2/layout.ld`. No generated code.

**How it was reviewed:** every factual claim above was checked against a
primary source rather than taken from the model — the 520 kB figure and the
`SRAM_BASE`/`SRAM_END` bounds against RP2350 datasheet §4.2 and §2.2.3, the
Boot RAM location against §4.3, the RP2040's 264 kB against Raspberry Pi's
published silicon comparison, and the RP2040-provenance claim against
`git log` and a diff of the two `layout.ld` files. The before/after numbers
are read from `llvm-nm` on the actual build outputs, not predicted.

I have read the diff and the reasoning above myself and agree with both. The
change is a single literal; everything supporting it is either quoted from the
datasheet or reproducible from the build outputs described under Testing
Strategy. The one claim I cannot close myself is the on-hardware behaviour,
which is called out under Help Wanted rather than glossed over.
