### PR TITLE
 clippy: change - to _

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,16 +188,16 @@ nonminimal_bool = "allow"
 # Particularly for setting register values, expressing a zero offset can be
 # semantically meaningful and encourage consistency between several lines of
 # code.
-identity-op = "allow"
+identity_op = "allow"
 # Subjective, and for SyscallDrivers sometimes enumerating the specific command
 # numbers rather than using a range is semantically more clear.
-manual-range-patterns = "allow"
+manual_range_patterns = "allow"
 # Particularly when interactive with hardware, including a leading zero can
 # often be semantically more clear.
 zero_prefixed_literal = "allow"
 
 
-manual-flatten = "allow"
+manual_flatten = "allow"
 
 
 # STYLE
@@ -210,7 +210,7 @@ collapsible_if = "allow"
 # Sometimes if statements are easier to read than match statements.
 comparison_chain = "allow"
 # Sometimes it's more clear to have repetition in enum names.
-enum-variant-names = "allow"
+enum_variant_names = "allow"
 # For buffers, `.get(0)` (using byte index) makes more sense than `.first()`.
 get_first = "allow"
 # There are often good reasons to enumerate different states that have the same
@@ -222,7 +222,7 @@ len_without_is_empty = "allow"
 # Buffer logic often makes more sense with lengths, and not `is_empty()`.
 len_zero = "allow"
 # Sometimes the borrow checker works better with `match` instead of `.map()`.
-manual-map = "allow"
+manual_map = "allow"
 # Syntax like `!(-17..=4).contains(&x)` is just not clear.
 manual_range_contains = "allow"
 # Match statement is clear, using `matches!()` is not an improvement.
@@ -231,18 +231,18 @@ match_like_matches_macro = "allow"
 module_inception = "allow"
 # Maybe someday we want this, but right now `for i in 0..4` is much more clear
 # than using `.iter()` functions like `.skip(n)`.
-needless-range-loop = "allow"
+needless_range_loop = "allow"
 # We don't need unused Default implementations.
 new_without_default = "allow"
 # Using `Result()` is good practice, even if there is no meaning to the error.
 result_unit_err = "allow"
 # For hardware registers it can make sense to group bits semantically and not
 # just in multiples of four.
-unusual-byte-groupings = "allow"
+unusual_byte_groupings = "allow"
 # We widely use upper case acronyms for hardware registers and fields.
 upper_case_acronyms = "allow"
 # Condensing match statements can make code harder to read and inconsistent.
-collapsible-match = "allow"
+collapsible_match = "allow"
 
 missing_safety_doc = "allow"
 
@@ -253,7 +253,7 @@ perf = { level = "deny", priority = -1 }
 # Tock extensively uses enums for state machines, and it often is much clearer
 # to store objects between states in the state enum rather than as "global"
 # variables in the struct itself. Therefore, some enums end up quite large.
-large-enum-variant = "allow"
+large_enum_variant = "allow"
 
 
 # CARGO
@@ -265,7 +265,7 @@ cargo_common_metadata = "allow"
 # We generally avoid all cargo features, and therefore it isn't intuitive that
 # we would expect some features to be enabled by default, so it can make sense
 # to have a feature to disable something.
-negative-feature-names = "allow"
+negative_feature_names = "allow"
 
 
 # NURSERY
@@ -307,7 +307,7 @@ manual_let_else = "allow"
 single_match_else = "allow"
 inline_always = "allow"
 module_name_repetitions = "allow"
-unnested-or-patterns = "allow"
+unnested_or_patterns = "allow"
 redundant_else = "allow"
 return_self_not_must_use = "allow"
 match_same_arms = "allow"
@@ -335,7 +335,7 @@ range_plus_one = "allow"
 missing_panics_doc = "allow"
 match_wildcard_for_single_variants = "allow"
 unused_self = "allow"
-cast-possible-wrap = "allow"
+cast_possible_wrap = "allow"
 uninlined_format_args = "allow"
 unreadable_literal = "allow"
 needless_pass_by_value = "allow"


### PR DESCRIPTION


### Pull Request Overview

clippy is moving to the names with underscores. This gets ahead of what will be a warning in an upcoming nightly.


### Testing Strategy

CI


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
