### PR TITLE
kernel: Propose `filter_registration()` interface

### DIFF
--- a/boards/components/src/ipc/ipc_registry_package_name.rs
+++ b/boards/components/src/ipc/ipc_registry_package_name.rs
@@ -13,6 +13,7 @@
 //! let ipc_registry_package_name = IpcRegistryPackageNameComponent::new(
 //!     board_kernel,
 //!     capsules_core::ipc::ipc_registry_package_name::DRIVER_NUM,
+//!     &capsules_core::ipc::filters::IpcPackageNameRegistrationFilterNull {},
 //!     PMCapability,
 //!     create_capability!(capabilities::MemoryAllocationCapability)
 //!     )
@@ -23,59 +24,66 @@ use capsules_core::ipc::ipc_registry_package_name::IpcRegistryPackageName;
 use core::mem::MaybeUninit;
 use kernel::capabilities::{MemoryAllocationCapability, ProcessManagementCapability};
 use kernel::component::Component;
+use kernel::platform::registration::RegistrationFilter;
 
 #[macro_export]
 macro_rules! ipc_registry_package_name_component_static {
-    ($C:ty $(,)?) => {{
+    ($RF:ty, $C:ty $(,)?) => {{
         kernel::static_buf!(
-            capsules_core::ipc::ipc_registry_package_name::IpcRegistryPackageName<
-                $C,
-            >
+            capsules_core::ipc::ipc_registry_package_name::IpcRegistryPackageName<'static, $RF, $C>
         )
     }};
 }
 
-pub type IpcRegistryPackageNameComponentType<C> =
-    capsules_core::ipc::ipc_registry_package_name::IpcRegistryPackageName<C>;
+pub type IpcRegistryPackageNameComponentType<RF, C> =
+    capsules_core::ipc::ipc_registry_package_name::IpcRegistryPackageName<'static, RF, C>;
 
 pub struct IpcRegistryPackageNameComponent<
+    RF: RegistrationFilter + 'static,
     C: ProcessManagementCapability,
     CAP: MemoryAllocationCapability,
 > {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
+    registration_filter: &'static RF,
     capability: C,
     mem_cap: CAP,
 }
 
-impl<C: ProcessManagementCapability, CAP: MemoryAllocationCapability>
-    IpcRegistryPackageNameComponent<C, CAP>
+impl<RF: RegistrationFilter, C: ProcessManagementCapability, CAP: MemoryAllocationCapability>
+    IpcRegistryPackageNameComponent<RF, C, CAP>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
+        registration_filter: &'static RF,
         capability: C,
         mem_cap: CAP,
     ) -> Self {
         Self {
             board_kernel,
             driver_num,
+            registration_filter,
             capability,
             mem_cap,
         }
     }
 }
 
-impl<C: ProcessManagementCapability + 'static, CAP: MemoryAllocationCapability> Component
-    for IpcRegistryPackageNameComponent<C, CAP>
+impl<
+    RF: RegistrationFilter<RegistrationIdentifier = &'static str>,
+    C: ProcessManagementCapability + 'static,
+    CAP: MemoryAllocationCapability,
+> Component for IpcRegistryPackageNameComponent<RF, C, CAP>
 {
-    type StaticInput = &'static mut MaybeUninit<IpcRegistryPackageName<C>>;
-    type Output = &'static IpcRegistryPackageName<C>;
+    type StaticInput = &'static mut MaybeUninit<IpcRegistryPackageName<'static, RF, C>>;
+    type Output = &'static IpcRegistryPackageName<'static, RF, C>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
         s.write(IpcRegistryPackageName::new(
             self.board_kernel
                 .create_grant(self.driver_num, &self.mem_cap),
+            self.registration_filter,
             self.board_kernel,
             self.capability,
         ))

--- a/boards/components/src/ipc/ipc_registry_string_name.rs
+++ b/boards/components/src/ipc/ipc_registry_string_name.rs
@@ -10,6 +10,7 @@
 //! let ipc_registry_string_name = IpcRegistryStringNameComponent::new(
 //!     board_kernel,
 //!     capsules_core::ipc::ipc_registry_string_name::DRIVER_NUM,
+//!     &capsules_core::ipc::filters::IpcStringNameRegistrationFilterNull {},
 //!     create_capability!(capabilities::MemoryAllocationCapability)
 //!     )
 //!     .finalize(components::ipc_registry_string_name_component_static!());

--- a/boards/components/src/ipc/ipc_registry_string_name.rs
+++ b/boards/components/src/ipc/ipc_registry_string_name.rs
@@ -19,39 +19,63 @@ use capsules_core::ipc::ipc_registry_string_name::IpcRegistryStringName;
 use core::mem::MaybeUninit;
 use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
+use kernel::platform::registration::RegistrationFilter;
 
 #[macro_export]
 macro_rules! ipc_registry_string_name_component_static {
-    () => {{ kernel::static_buf!(capsules_core::ipc::ipc_registry_string_name::IpcRegistryStringName) }};
+    ($RF:ty $(,)?) => {{
+        kernel::static_buf!(
+            capsules_core::ipc::ipc_registry_string_name::IpcRegistryStringName<'static, $RF>
+        )
+    }};
 }
 
-pub type IpcRegistryStringNameComponentType =
-    capsules_core::ipc::ipc_registry_string_name::IpcRegistryStringName;
+pub type IpcRegistryStringNameComponentType<RF> =
+    capsules_core::ipc::ipc_registry_string_name::IpcRegistryStringName<'static, RF>;
 
-pub struct IpcRegistryStringNameComponent<CAP: MemoryAllocationCapability> {
+pub struct IpcRegistryStringNameComponent<
+    RF: RegistrationFilter + 'static,
+    CAP: MemoryAllocationCapability,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
+    registration_filter: &'static RF,
     mem_cap: CAP,
 }
 
-impl<CAP: MemoryAllocationCapability> IpcRegistryStringNameComponent<CAP> {
-    pub fn new(board_kernel: &'static kernel::Kernel, driver_num: usize, mem_cap: CAP) -> Self {
+impl<RF: RegistrationFilter, CAP: MemoryAllocationCapability>
+    IpcRegistryStringNameComponent<RF, CAP>
+{
+    pub fn new(
+        board_kernel: &'static kernel::Kernel,
+        driver_num: usize,
+        registration_filter: &'static RF,
+        mem_cap: CAP,
+    ) -> Self {
         Self {
             board_kernel,
             driver_num,
+            registration_filter,
             mem_cap,
         }
     }
 }
 
-impl<CAP: MemoryAllocationCapability> Component for IpcRegistryStringNameComponent<CAP> {
-    type StaticInput = &'static mut MaybeUninit<IpcRegistryStringName>;
-    type Output = &'static IpcRegistryStringName;
+impl<
+    RF: RegistrationFilter<
+        RegistrationIdentifier = [u8; capsules_core::ipc::ipc_registry_string_name::MAX_STRING_LEN],
+    >,
+    CAP: MemoryAllocationCapability,
+> Component for IpcRegistryStringNameComponent<RF, CAP>
+{
+    type StaticInput = &'static mut MaybeUninit<IpcRegistryStringName<'static, RF>>;
+    type Output = &'static IpcRegistryStringName<'static, RF>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
         s.write(IpcRegistryStringName::new(
             self.board_kernel
                 .create_grant(self.driver_num, &self.mem_cap),
+            self.registration_filter,
         ))
     }
 }

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -120,8 +120,11 @@ type Lsm303agrDriver = capsules_extra::lsm303agr::Lsm303agrI2C<
     capsules_core::virtualizers::virtual_i2c::I2CDevice<'static, I2cHw>,
 >;
 type BuzzerDriver = components::buzzer::BuzzerComponentType<AlarmHw, PwmHw>;
+type IpcRegistryStringNameFilter = capsules_core::ipc::filters::IpcStringNameRegistrationFilterNull;
 type IpcRegistryStringNameDriver =
-    components::ipc::ipc_registry_string_name::IpcRegistryStringNameComponentType;
+    components::ipc::ipc_registry_string_name::IpcRegistryStringNameComponentType<
+        IpcRegistryStringNameFilter,
+    >;
 type IpcRelayRequestDriver = components::ipc::ipc_relay_request::IpcRelayRequestComponentType;
 
 /// Supported drivers by the platform
@@ -700,9 +703,12 @@ unsafe fn start() -> (
         components::ipc::ipc_registry_string_name::IpcRegistryStringNameComponent::new(
             board_kernel,
             capsules_core::ipc::ipc_registry_string_name::DRIVER_NUM,
+            &capsules_core::ipc::filters::IpcStringNameRegistrationFilterNull {},
             create_capability!(capabilities::MemoryAllocationCapability),
         )
-        .finalize(components::ipc_registry_string_name_component_static!());
+        .finalize(components::ipc_registry_string_name_component_static!(
+            IpcRegistryStringNameFilter
+        ));
 
     let ipc_relay_request = components::ipc::ipc_relay_request::IpcRelayRequestComponent::new(
         board_kernel,

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -193,8 +193,11 @@ type ProcessConsoleDriver =
     components::process_console::ProcessConsoleComponentType<AlarmHw, ProcessConsoleCap>;
 type TemperatureDriver = components::temperature::TemperatureComponentType<TemperatureHw>;
 type IpcDriver = kernel::ipc::IPC<{ NUM_PROCS as u8 }>;
+type IpcRegistryStringNameFilter = capsules_core::ipc::filters::IpcStringNameRegistrationFilterNull;
 type IpcRegistryStringNameDriver =
-    components::ipc::ipc_registry_string_name::IpcRegistryStringNameComponentType;
+    components::ipc::ipc_registry_string_name::IpcRegistryStringNameComponentType<
+        IpcRegistryStringNameFilter,
+    >;
 type IpcRelayRequestDriver = components::ipc::ipc_relay_request::IpcRelayRequestComponentType;
 
 // TicKV
@@ -893,9 +896,12 @@ pub unsafe fn start_no_pconsole() -> (
         components::ipc::ipc_registry_string_name::IpcRegistryStringNameComponent::new(
             board_kernel,
             capsules_core::ipc::ipc_registry_string_name::DRIVER_NUM,
+            &capsules_core::ipc::filters::IpcStringNameRegistrationFilterNull {},
             create_capability!(capabilities::MemoryAllocationCapability),
         )
-        .finalize(components::ipc_registry_string_name_component_static!());
+        .finalize(components::ipc_registry_string_name_component_static!(
+            IpcRegistryStringNameFilter
+        ));
 
     let ipc_relay_request = components::ipc::ipc_relay_request::IpcRelayRequestComponent::new(
         board_kernel,

--- a/capsules/core/README.md
+++ b/capsules/core/README.md
@@ -80,6 +80,7 @@ Interprocess Communication (IPC) mechanisms and related infrastructure.
 - **[IPC Identifier](src/ipc/ipc_identifier.rs)**: IPC Identifier type used in other IPC capsules.
 - **[IPC Registry String Name](src/ipc/ipc_registry_string_name.rs)**: Service registry and discovery based on process-specified string names.
 - **[IPC Registry Package Name](src/ipc/ipc_registry_package_name.rs)**: Service registry and discovery based on process package names.
+- **[IPC Registration Filter](src/ipc/filters.rs)**: Enables filtering of which services are allowed to register.
 - **[IPC Relay Request](src/ipc/ipc_relay_request.rs)**: Single-copy communication via client-to-server requests and server-to-client responses.
 
 Miscellaneous Capsules & Infrastructure

--- a/capsules/core/src/ipc/README.md
+++ b/capsules/core/src/ipc/README.md
@@ -17,6 +17,11 @@ provide different underlying implementations for registration and/or discovery.
 Current capsules allow for registration/discovery using string names or package
 names.
 
+The [Registration Filter](filter.rs) types can be used for filtering of which
+apps are allowed to register as certain service names. See the
+[RegistrationFilter policy trait](../../../../kernel/src/platform/registration.rs)
+for more details.
+
 ## Relay
 
 **Relay** capsules provide a means for single-copy, allow-to-allow

--- a/capsules/core/src/ipc/filters.rs
+++ b/capsules/core/src/ipc/filters.rs
@@ -4,7 +4,7 @@
 
 use kernel::errorcode::ErrorCode;
 use kernel::platform::registration::RegistrationFilter;
-use kernel::process::ShortId;
+use kernel::process::ProcessId;
 
 /// Null filter for [`IpcRegistryStringName`].
 ///
@@ -15,7 +15,7 @@ impl RegistrationFilter for IpcStringNameRegistrationFilterNull {
     type RegistrationIdentifier = [u8; super::ipc_registry_string_name::MAX_STRING_LEN];
     fn filter_registration(
         &self,
-        _appid: ShortId,
+        _processid: ProcessId,
         _registrationid: &Self::RegistrationIdentifier,
     ) -> Result<(), ErrorCode> {
         Ok(())

--- a/capsules/core/src/ipc/filters.rs
+++ b/capsules/core/src/ipc/filters.rs
@@ -1,0 +1,23 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+use kernel::errorcode::ErrorCode;
+use kernel::platform::registration::RegistrationFilter;
+use kernel::process::ShortId;
+
+/// Null filter for [`IpcRegistryStringName`].
+///
+/// This permits all registrations from all processes.
+pub struct IpcStringNameRegistrationFilterNull;
+
+impl RegistrationFilter for IpcStringNameRegistrationFilterNull {
+    type RegistrationIdentifier = [u8; super::ipc_registry_string_name::MAX_STRING_LEN];
+    fn filter_registration(
+        &self,
+        _appid: ShortId,
+        _registrationid: &Self::RegistrationIdentifier,
+    ) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+}

--- a/capsules/core/src/ipc/filters.rs
+++ b/capsules/core/src/ipc/filters.rs
@@ -21,3 +21,19 @@ impl RegistrationFilter for IpcStringNameRegistrationFilterNull {
         Ok(())
     }
 }
+
+/// Null filter for [`IpcRegistryPackageName`].
+///
+/// This permits all registrations from all processes.
+pub struct IpcPackageNameRegistrationFilterNull;
+
+impl RegistrationFilter for IpcPackageNameRegistrationFilterNull {
+    type RegistrationIdentifier = &'static str;
+    fn filter_registration(
+        &self,
+        _processid: ProcessId,
+        _registrationid: &Self::RegistrationIdentifier,
+    ) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+}

--- a/capsules/core/src/ipc/ipc_registry_package_name.rs
+++ b/capsules/core/src/ipc/ipc_registry_package_name.rs
@@ -21,6 +21,7 @@
 //! let ipc_registry_package_name = components::ipc::ipc_registry_package_name::IpcRegistryPackageNameComponent::new(
 //!     board_kernel,
 //!     capsules_core::ipc::ipc_registry_package_name::DRIVER_NUM,
+//!     &capsules_core::ipc::filters::IpcPackageNameRegistrationFilterNull {},
 //!     PMCapability,
 //!     create_capability!(capabilities::MemoryAllocationCapability),
 //! ).finalize(components::ipc_registry_package_name_component_static!(PMCapability));
@@ -29,6 +30,7 @@
 use crate::ipc::ipc_identifier::IpcIdentifier;
 use kernel::capabilities::ProcessManagementCapability;
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
+use kernel::platform::registration::RegistrationFilter;
 use kernel::processbuffer::ReadableProcessBuffer;
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::{ErrorCode, Kernel, ProcessId};
@@ -63,7 +65,7 @@ pub struct App {
 ///
 /// This capsule allows for registration and discovery of IPC processes via the
 /// Package Name field of their TBF header.
-pub struct IpcRegistryPackageName<C: ProcessManagementCapability> {
+pub struct IpcRegistryPackageName<'a, RF: RegistrationFilter, C: ProcessManagementCapability> {
     /// Grant memory
     apps: Grant<
         App,
@@ -71,6 +73,9 @@ pub struct IpcRegistryPackageName<C: ProcessManagementCapability> {
         AllowRoCount<{ ro_allow::COUNT }>,
         AllowRwCount<0>,
     >,
+
+    /// Filter for validating service registrations.
+    registration_filter: &'a RF,
 
     /// Reference to the kernel object so we can access process state.
     kernel: &'static Kernel,
@@ -80,7 +85,12 @@ pub struct IpcRegistryPackageName<C: ProcessManagementCapability> {
     capability: C,
 }
 
-impl<C: ProcessManagementCapability> IpcRegistryPackageName<C> {
+impl<
+    'a,
+    RF: RegistrationFilter<RegistrationIdentifier = &'static str>,
+    C: ProcessManagementCapability,
+> IpcRegistryPackageName<'a, RF, C>
+{
     /// Create a new IpcRegistryPackageName capsule
     pub fn new(
         grant: Grant<
@@ -89,19 +99,35 @@ impl<C: ProcessManagementCapability> IpcRegistryPackageName<C> {
             AllowRoCount<{ ro_allow::COUNT }>,
             AllowRwCount<0>,
         >,
+        registration_filter: &'a RF,
         kernel: &'static Kernel,
         capability: C,
     ) -> Self {
         Self {
             apps: grant,
+            registration_filter,
             kernel,
             capability,
         }
     }
 
     fn register(&self, processid: ProcessId) -> Result<(), ErrorCode> {
-        // If registration validation is desired, that would go here before
-        // saving the name
+        // Check that package name exists, and validate it
+        self.kernel.process_map_or_external(
+            Err(ErrorCode::NOMEM),
+            processid,
+            |process| {
+                if process.get_process_name() == "" {
+                    // Can't register without a package name
+                    Err(ErrorCode::NOMEM)
+                } else {
+                    // Validate this registration attempt
+                    self.registration_filter
+                        .filter_registration(processid, &process.get_process_name())
+                }
+            },
+            &self.capability,
+        )?;
 
         // Ensure that a package name field exists
         if !self.kernel.process_map_or_external(
@@ -202,7 +228,9 @@ impl<C: ProcessManagementCapability> IpcRegistryPackageName<C> {
     }
 }
 
-impl<C: ProcessManagementCapability> SyscallDriver for IpcRegistryPackageName<C> {
+impl<RF: RegistrationFilter<RegistrationIdentifier = &'static str>, C: ProcessManagementCapability>
+    SyscallDriver for IpcRegistryPackageName<'_, RF, C>
+{
     /// Registration and discovery of IPC services
     ///
     /// Matches based on server package name and client allowed buffer.

--- a/capsules/core/src/ipc/ipc_registry_string_name.rs
+++ b/capsules/core/src/ipc/ipc_registry_string_name.rs
@@ -132,7 +132,7 @@ impl<'a, RF: RegistrationFilter<RegistrationIdentifier = [u8; MAX_STRING_LEN]>>
 
         // Validate this registration attempt
         self.registration_filter
-            .filter_registration(processid.short_app_id(), &new_name)?;
+            .filter_registration(processid, &new_name)?;
 
         // Save newly registered name
         self.apps.enter(processid, |app, kerneldata| {

--- a/capsules/core/src/ipc/ipc_registry_string_name.rs
+++ b/capsules/core/src/ipc/ipc_registry_string_name.rs
@@ -15,8 +15,9 @@
 //! let ipc_registry_string_name = components::ipc::ipc_registry_string_name::IpcRegistryStringNameComponent::new(
 //!     board_kernel,
 //!     capsules_core::ipc::ipc_registry_string_name::DRIVER_NUM,
+//!     &capsules_core::ipc::filters::IpcStringNameRegistrationFilterNull {},
 //!     create_capability!(capabilities::MemoryAllocationCapability),
-//! ).finalize(components::ipc_registry_string_name_component_static!());
+//! ).finalize(components::ipc_registry_string_name_component_static!(capsules_core::ipc::filters::IpcStringNameRegistrationFilterNull));
 //! ```
 
 use crate::ipc::ipc_identifier::IpcIdentifier;
@@ -92,9 +93,6 @@ impl<'a, RF: RegistrationFilter<RegistrationIdentifier = [u8; MAX_STRING_LEN]>>
     }
 
     fn register(&self, processid: ProcessId) -> Result<(), ErrorCode> {
-        // If registration validation is desired, that would go here before
-        // comparing or saving the name itself
-
         // Get allowed name to validate and later save
         let mut new_name: [u8; MAX_STRING_LEN] = [0; MAX_STRING_LEN];
         self.apps.enter(processid, |_, kerneldata| {
@@ -132,6 +130,7 @@ impl<'a, RF: RegistrationFilter<RegistrationIdentifier = [u8; MAX_STRING_LEN]>>
             }
         }
 
+        // Validate this registration attempt
         self.registration_filter
             .filter_registration(processid.short_app_id(), &new_name)?;
 
@@ -214,8 +213,8 @@ impl<'a, RF: RegistrationFilter<RegistrationIdentifier = [u8; MAX_STRING_LEN]>>
     }
 }
 
-impl<'a, RF: RegistrationFilter<RegistrationIdentifier = [u8; MAX_STRING_LEN]>> SyscallDriver
-    for IpcRegistryStringName<'a, RF>
+impl<RF: RegistrationFilter<RegistrationIdentifier = [u8; MAX_STRING_LEN]>> SyscallDriver
+    for IpcRegistryStringName<'_, RF>
 {
     /// Registration and discovery of IPC services
     ///

--- a/capsules/core/src/ipc/ipc_registry_string_name.rs
+++ b/capsules/core/src/ipc/ipc_registry_string_name.rs
@@ -21,6 +21,7 @@
 
 use crate::ipc::ipc_identifier::IpcIdentifier;
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
+use kernel::platform::registration::RegistrationFilter;
 use kernel::processbuffer::ReadableProcessBuffer;
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::{ErrorCode, ProcessId};
@@ -46,7 +47,7 @@ mod upcall {
 }
 
 /// Maximum string length, with a value of 20 by default.
-const MAX_STRING_LEN: usize = 20;
+pub const MAX_STRING_LEN: usize = 20;
 
 /// Per-process metadata
 #[derive(Default)]
@@ -59,7 +60,7 @@ pub struct App {
 ///
 /// This capsule allows for registration and discovery of IPC processes via a
 /// string provided by the process.
-pub struct IpcRegistryStringName {
+pub struct IpcRegistryStringName<'a, RF: RegistrationFilter> {
     /// Grant memory
     apps: Grant<
         App,
@@ -67,9 +68,13 @@ pub struct IpcRegistryStringName {
         AllowRoCount<{ ro_allow::COUNT }>,
         AllowRwCount<0>,
     >,
+
+    registration_filter: &'a RF,
 }
 
-impl IpcRegistryStringName {
+impl<'a, RF: RegistrationFilter<RegistrationIdentifier = [u8; MAX_STRING_LEN]>>
+    IpcRegistryStringName<'a, RF>
+{
     // Create a new IPC Registry String Name capsule
     pub fn new(
         grant: Grant<
@@ -78,8 +83,12 @@ impl IpcRegistryStringName {
             AllowRoCount<{ ro_allow::COUNT }>,
             AllowRwCount<0>,
         >,
+        registration_filter: &'a RF,
     ) -> Self {
-        Self { apps: grant }
+        Self {
+            apps: grant,
+            registration_filter,
+        }
     }
 
     fn register(&self, processid: ProcessId) -> Result<(), ErrorCode> {
@@ -122,6 +131,9 @@ impl IpcRegistryStringName {
                 return Err(ErrorCode::ALREADY);
             }
         }
+
+        self.registration_filter
+            .filter_registration(processid.short_app_id(), &new_name)?;
 
         // Save newly registered name
         self.apps.enter(processid, |app, kerneldata| {
@@ -202,7 +214,9 @@ impl IpcRegistryStringName {
     }
 }
 
-impl SyscallDriver for IpcRegistryStringName {
+impl<'a, RF: RegistrationFilter<RegistrationIdentifier = [u8; MAX_STRING_LEN]>> SyscallDriver
+    for IpcRegistryStringName<'a, RF>
+{
     /// Registration and discovery of IPC services
     ///
     /// Matches based on "names": length MAX_STRING_LEN arrays of u8.

--- a/capsules/core/src/ipc/ipc_registry_string_name.rs
+++ b/capsules/core/src/ipc/ipc_registry_string_name.rs
@@ -70,6 +70,7 @@ pub struct IpcRegistryStringName<'a, RF: RegistrationFilter> {
         AllowRwCount<0>,
     >,
 
+    /// Filter for validating service registrations.
     registration_filter: &'a RF,
 }
 

--- a/capsules/core/src/ipc/mod.rs
+++ b/capsules/core/src/ipc/mod.rs
@@ -4,6 +4,7 @@
 
 //! Provides capsules for interprocess communication (IPC)
 
+pub mod filters;
 pub mod ipc_identifier;
 pub mod ipc_registry_package_name;
 pub mod ipc_registry_string_name;

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -9,6 +9,7 @@
 pub mod chip;
 pub mod dma_fence;
 pub mod mpu;
+pub mod registration;
 pub mod scheduler_timer;
 pub mod watchdog;
 

--- a/kernel/src/platform/registration.rs
+++ b/kernel/src/platform/registration.rs
@@ -1,0 +1,59 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+use crate::errorcode::ErrorCode;
+use crate::process::ShortId;
+
+/// Filter policy abstraction for userspace registration interfaces.
+///
+/// This trait enables capsules that permit registrations from userspace
+/// processes to support customized registration filters. Kernels can configure
+/// the registration policy of registration-based capsules by implementing this
+/// trait with the desired registration policy.
+///
+/// # Use Cases
+///
+/// The canonical use case is userspace processes registering some service with
+/// the kernel. For example, a process may provide a service via IPC, and
+/// registers that service with the kernel. This filter allows the kernel to
+/// decide whether to permit that registration.
+///
+pub trait RegistrationFilter {
+    /// The type of registration identifier specific to the registration
+    /// interface.
+    ///
+    /// Different registration interfaces will use different identifiers to
+    /// identify what type of service is being registered. For example, services
+    /// could be identified by a string name (`&str`) or a well-known id
+    /// (`usize`).
+    type RegistrationIdentifier;
+
+    /// Called to determine if a registration request should be permitted.
+    ///
+    /// A registration interface can use this function to determine whether to
+    /// permit a userspace process to proceed with the registration.
+    ///
+    /// # Return
+    ///
+    /// To permit the registration, return `Ok(())`.
+    ///
+    /// To deny the registration, return `Err()` with an [`ErrorCode`]. Using
+    /// [`ErrorCode::FAIL`] is recommended.
+    fn filter_registration(
+        &self,
+        appid: ShortId,
+        registrationid: &Self::RegistrationIdentifier,
+    ) -> Result<(), ErrorCode>;
+}
+
+impl RegistrationFilter for () {
+    type RegistrationIdentifier = ();
+    fn filter_registration(
+        &self,
+        _appid: ShortId,
+        _registrationid: &Self::RegistrationIdentifier,
+    ) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+}

--- a/kernel/src/platform/registration.rs
+++ b/kernel/src/platform/registration.rs
@@ -3,7 +3,7 @@
 // Copyright Tock Contributors 2026.
 
 use crate::errorcode::ErrorCode;
-use crate::process::ShortId;
+use crate::process::ProcessId;
 
 /// Filter policy abstraction for userspace registration interfaces.
 ///
@@ -42,18 +42,7 @@ pub trait RegistrationFilter {
     /// [`ErrorCode::FAIL`] is recommended.
     fn filter_registration(
         &self,
-        appid: ShortId,
+        processid: ProcessId,
         registrationid: &Self::RegistrationIdentifier,
     ) -> Result<(), ErrorCode>;
-}
-
-impl RegistrationFilter for () {
-    type RegistrationIdentifier = ();
-    fn filter_registration(
-        &self,
-        _appid: ShortId,
-        _registrationid: &Self::RegistrationIdentifier,
-    ) -> Result<(), ErrorCode> {
-        Ok(())
-    }
 }


### PR DESCRIPTION
### Pull Request Overview

This trait is a generic interface for filtering registrations. The initial use case is IPC service registration, but it would also apply to userspace service registration.

This parallels the `filter_syscall` interface, and allows the kernel to plug-in a filter for which userspace processes are allowed to register which services.


### Testing Strategy

Tested only by complining.


### TODO or Help Wanted

I don't know how feasible it would be to use a single filter for different types of registrations. But the interface is hopefully generic.


### Checklist

- [ ] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [ ] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
