### PR TITLE
Add `InterruptsDisabled` token for tracking single-core interrupt state and `InterruptsDisabledCell` for shared state

### DIFF
--- a/arch/cortex-m/src/support.rs
+++ b/arch/cortex-m/src/support.rs
@@ -5,6 +5,7 @@
 //! Helper functions for the Cortex-M architecture.
 
 use crate::scb;
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 
 /// NOP instruction
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
@@ -60,7 +61,7 @@ pub unsafe fn wfi() {
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 pub fn with_interrupts_disabled<F, R>(f: F) -> R
 where
-    F: FnOnce() -> R,
+    F: FnOnce(&InterruptsDisabled) -> R,
 {
     use core::arch::asm;
     // Set PRIMASK to disable interrupts.
@@ -83,7 +84,10 @@ where
         asm!("cpsid i", options(nomem, nostack, preserves_flags));
     }
 
-    let res = f();
+    // Safety: we just disabled interrupts (PRIMASK) above.
+    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
+
+    let res = f(&interrupts_disabled);
 
     // Unset PRIMASK to re-enable interrupts.
     //
@@ -124,7 +128,7 @@ pub unsafe fn wfi() {
 #[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
 pub fn with_interrupts_disabled<F, R>(_f: F) -> R
 where
-    F: FnOnce() -> R,
+    F: FnOnce(&InterruptsDisabled) -> R,
 {
     unimplemented!()
 }

--- a/arch/cortex-m/src/support.rs
+++ b/arch/cortex-m/src/support.rs
@@ -84,8 +84,8 @@ where
         asm!("cpsid i", options(nomem, nostack, preserves_flags));
     }
 
-    // Safety: we just disabled interrupts (PRIMASK) above.
-    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
+    // we just disabled interrupts (PRIMASK) above.
+    let interrupts_disabled = kernel::mint_interrupts_disabled_context!();
 
     let res = f(&interrupts_disabled);
 

--- a/arch/cortex-m/src/support.rs
+++ b/arch/cortex-m/src/support.rs
@@ -5,7 +5,7 @@
 //! Helper functions for the Cortex-M architecture.
 
 use crate::scb;
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
+use kernel::context_tokens::InterruptsDisabledContext;
 
 /// NOP instruction
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
@@ -61,7 +61,7 @@ pub unsafe fn wfi() {
 #[cfg(any(doc, all(target_arch = "arm", target_os = "none")))]
 pub fn with_interrupts_disabled<F, R>(f: F) -> R
 where
-    F: FnOnce(&InterruptsDisabled) -> R,
+    F: FnOnce(&InterruptsDisabledContext) -> R,
 {
     use core::arch::asm;
     // Set PRIMASK to disable interrupts.
@@ -85,7 +85,7 @@ where
     }
 
     // Safety: we just disabled interrupts (PRIMASK) above.
-    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
+    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
 
     let res = f(&interrupts_disabled);
 
@@ -128,7 +128,7 @@ pub unsafe fn wfi() {
 #[cfg(not(any(doc, all(target_arch = "arm", target_os = "none"))))]
 pub fn with_interrupts_disabled<F, R>(_f: F) -> R
 where
-    F: FnOnce(&InterruptsDisabled) -> R,
+    F: FnOnce(&InterruptsDisabledContext) -> R,
 {
     unimplemented!()
 }

--- a/arch/riscv/src/clic.rs
+++ b/arch/riscv/src/clic.rs
@@ -4,7 +4,7 @@
 
 //! Core Local Interrupt Control peripheral driver.
 
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
+use kernel::context_tokens::InterruptsDisabledContext;
 use kernel::utilities::StaticRef;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 use kernel::utilities::registers::{ReadWrite, register_bitfields};
@@ -286,7 +286,7 @@ impl Clic {
 ///
 /// This is outside of the `Clic` struct because it has to be called from the
 /// trap handler which does not have a reference to the CLIC object.
-pub fn disable_interrupt(index: u32, _interrupts_disabled: &InterruptsDisabled) {
+pub fn disable_interrupt(index: u32, _interrupts_disabled: &InterruptsDisabledContext) {
     let regs: &ClicRegisters = &CLIC_BASE;
 
     match index {

--- a/arch/riscv/src/clic.rs
+++ b/arch/riscv/src/clic.rs
@@ -4,6 +4,7 @@
 
 //! Core Local Interrupt Control peripheral driver.
 
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 use kernel::utilities::StaticRef;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 use kernel::utilities::registers::{ReadWrite, register_bitfields};
@@ -285,7 +286,7 @@ impl Clic {
 ///
 /// This is outside of the `Clic` struct because it has to be called from the
 /// trap handler which does not have a reference to the CLIC object.
-pub unsafe fn disable_interrupt(index: u32) {
+pub fn disable_interrupt(index: u32, _interrupts_disabled: &InterruptsDisabled) {
     let regs: &ClicRegisters = &CLIC_BASE;
 
     match index {

--- a/arch/riscv/src/support.rs
+++ b/arch/riscv/src/support.rs
@@ -40,8 +40,8 @@ where
         .read_and_clear_bits(mstatus::mie.mask << mstatus::mie.shift)
         & mstatus::mie.mask << mstatus::mie.shift;
 
-    // Safety: we just disabled machine mode interrupts above.
-    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
+    // we just disabled machine mode interrupts above.
+    let interrupts_disabled = kernel::mint_interrupts_disabled_context!();
 
     // Machine mode interrupts are disabled, execute the (uninterruptible)
     // function

--- a/arch/riscv/src/support.rs
+++ b/arch/riscv/src/support.rs
@@ -5,6 +5,7 @@
 //! Core low-level operations.
 
 use crate::csr::{CSR, mstatus::mstatus};
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 
 #[cfg(any(doc, target_arch = "riscv32", target_arch = "riscv64"))]
 #[inline(always)]
@@ -27,7 +28,7 @@ pub unsafe fn wfi() {
 /// Single-core critical section operation
 pub fn with_interrupts_disabled<F, R>(f: F) -> R
 where
-    F: FnOnce() -> R,
+    F: FnOnce(&InterruptsDisabled) -> R,
 {
     // Read the mstatus MIE field and disable machine mode interrupts
     // atomically
@@ -39,9 +40,12 @@ where
         .read_and_clear_bits(mstatus::mie.mask << mstatus::mie.shift)
         & mstatus::mie.mask << mstatus::mie.shift;
 
+    // Safety: we just disabled machine mode interrupts above.
+    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
+
     // Machine mode interrupts are disabled, execute the (uninterruptible)
     // function
-    let res = f();
+    let res = f(&interrupts_disabled);
 
     // If [`mstatus::mie`] was set before, set it again. Otherwise,
     // this function will be a nop.

--- a/arch/riscv/src/support.rs
+++ b/arch/riscv/src/support.rs
@@ -5,7 +5,7 @@
 //! Core low-level operations.
 
 use crate::csr::{CSR, mstatus::mstatus};
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
+use kernel::context_tokens::InterruptsDisabledContext;
 
 #[cfg(any(doc, target_arch = "riscv32", target_arch = "riscv64"))]
 #[inline(always)]
@@ -28,7 +28,7 @@ pub unsafe fn wfi() {
 /// Single-core critical section operation
 pub fn with_interrupts_disabled<F, R>(f: F) -> R
 where
-    F: FnOnce(&InterruptsDisabled) -> R,
+    F: FnOnce(&InterruptsDisabledContext) -> R,
 {
     // Read the mstatus MIE field and disable machine mode interrupts
     // atomically
@@ -41,7 +41,7 @@ where
         & mstatus::mie.mask << mstatus::mie.shift;
 
     // Safety: we just disabled machine mode interrupts above.
-    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
+    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
 
     // Machine mode interrupts are disabled, execute the (uninterruptible)
     // function

--- a/arch/x86/src/interrupts/poller.rs
+++ b/arch/x86/src/interrupts/poller.rs
@@ -68,7 +68,7 @@ impl InterruptPoller {
     where
         F: FnOnce(&InterruptPoller) -> R,
     {
-        support::with_interrupts_disabled(|| {
+        support::with_interrupts_disabled(|_interrupts_disabled| {
             // Safety: Interrupts are disabled within this closure, so we can safely access the
             //         singleton without racing against interrupt handlers.
             let poller = unsafe { &*ptr::addr_of!(SINGLETON) };

--- a/arch/x86/src/interrupts/poller.rs
+++ b/arch/x86/src/interrupts/poller.rs
@@ -7,6 +7,8 @@ use core::ptr;
 
 use tock_registers::LocalRegisterCopy;
 
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
+
 use crate::support;
 
 use super::NUM_VECTORS;
@@ -63,27 +65,25 @@ impl InterruptPoller {
     ///
     /// The given closure `f` is executed with interrupts disabled (using
     /// [`support::with_interrupts_disabled`](crate::support::with_interrupts_disabled))
-    /// and  passed a reference to the singleton.
+    /// and passed a reference to the singleton, along with the `InterruptsDisabled` token proving
+    /// that interrupts are disabled for the duration of the closure.
     pub fn access<F, R>(f: F) -> R
     where
-        F: FnOnce(&InterruptPoller) -> R,
+        F: FnOnce(&InterruptPoller, &InterruptsDisabled) -> R,
     {
-        support::with_interrupts_disabled(|_interrupts_disabled| {
+        support::with_interrupts_disabled(|interrupts_disabled| {
             // Safety: Interrupts are disabled within this closure, so we can safely access the
             //         singleton without racing against interrupt handlers.
             let poller = unsafe { &*ptr::addr_of!(SINGLETON) };
 
-            f(poller)
+            f(poller, interrupts_disabled)
         })
     }
 
     /// Marks that the specified interrupt as pending.
     ///
-    /// # Safety
-    ///
-    /// Interrupts must be disabled when this function is called. This function is _intended_ to be
-    /// called from within an ISR, so hopefully this is already true.
-    pub unsafe fn set_pending(num: u32) {
+    /// This function is _intended_ to be called from within an ISR.
+    pub fn set_pending(num: u32, _interrupts_disabled: &InterruptsDisabled) {
         // Safety: Caller ensures interrupts are disabled when this function is called, so it
         //         should be safe to access the singleton without racing against any interrupt
         //         handlers.

--- a/arch/x86/src/interrupts/poller.rs
+++ b/arch/x86/src/interrupts/poller.rs
@@ -7,7 +7,7 @@ use core::ptr;
 
 use tock_registers::LocalRegisterCopy;
 
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
+use kernel::context_tokens::InterruptsDisabledContext;
 
 use crate::support;
 
@@ -65,11 +65,11 @@ impl InterruptPoller {
     ///
     /// The given closure `f` is executed with interrupts disabled (using
     /// [`support::with_interrupts_disabled`](crate::support::with_interrupts_disabled))
-    /// and passed a reference to the singleton, along with the `InterruptsDisabled` token proving
+    /// and passed a reference to the singleton, along with the `InterruptsDisabledContext` token proving
     /// that interrupts are disabled for the duration of the closure.
     pub fn access<F, R>(f: F) -> R
     where
-        F: FnOnce(&InterruptPoller, &InterruptsDisabled) -> R,
+        F: FnOnce(&InterruptPoller, &InterruptsDisabledContext) -> R,
     {
         support::with_interrupts_disabled(|interrupts_disabled| {
             // Safety: Interrupts are disabled within this closure, so we can safely access the
@@ -83,7 +83,7 @@ impl InterruptPoller {
     /// Marks that the specified interrupt as pending.
     ///
     /// This function is _intended_ to be called from within an ISR.
-    pub fn set_pending(num: u32, _interrupts_disabled: &InterruptsDisabled) {
+    pub fn set_pending(num: u32, _interrupts_disabled: &InterruptsDisabledContext) {
         // Safety: Caller ensures interrupts are disabled when this function is called, so it
         //         should be safe to access the singleton without racing against any interrupt
         //         handlers.

--- a/arch/x86/src/support.rs
+++ b/arch/x86/src/support.rs
@@ -6,7 +6,7 @@
 
 #[cfg(any(doc, target_arch = "x86"))]
 use core::arch::asm;
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
+use kernel::context_tokens::InterruptsDisabledContext;
 
 /// Execute closure without allowing any interrupts on the current core.
 ///
@@ -16,7 +16,7 @@ use kernel::platform::interrupts_disabled::InterruptsDisabled;
 #[cfg(any(doc, target_arch = "x86"))]
 pub fn with_interrupts_disabled<F, R>(f: F) -> R
 where
-    F: FnOnce(&InterruptsDisabled) -> R,
+    F: FnOnce(&InterruptsDisabledContext) -> R,
 {
     use crate::registers::bits32::eflags::{self, EFLAGS};
     use crate::registers::irq;
@@ -35,7 +35,7 @@ where
         // Safety: interrupts are disabled at this point, either because we
         // just disabled them above, or because they were already disabled
         // when this function was called.
-        let interrupts_disabled = InterruptsDisabled::new_trusted();
+        let interrupts_disabled = InterruptsDisabledContext::new_trusted();
 
         let res = f(&interrupts_disabled);
 
@@ -50,7 +50,7 @@ where
 #[cfg(not(any(doc, target_arch = "x86")))]
 pub fn with_interrupts_disabled<F, R>(_: F) -> R
 where
-    F: FnOnce(&InterruptsDisabled) -> R,
+    F: FnOnce(&InterruptsDisabledContext) -> R,
 {
     unimplemented!()
 }

--- a/arch/x86/src/support.rs
+++ b/arch/x86/src/support.rs
@@ -32,10 +32,10 @@ where
             irq::disable();
         }
 
-        // Safety: interrupts are disabled at this point, either because we
-        // just disabled them above, or because they were already disabled
-        // when this function was called.
-        let interrupts_disabled = InterruptsDisabledContext::new_trusted();
+        // interrupts are disabled at this point, either because we just
+        // disabled them above, or because they were already disabled when
+        // this function was called.
+        let interrupts_disabled = kernel::mint_interrupts_disabled_context!();
 
         let res = f(&interrupts_disabled);
 

--- a/arch/x86/src/support.rs
+++ b/arch/x86/src/support.rs
@@ -6,6 +6,7 @@
 
 #[cfg(any(doc, target_arch = "x86"))]
 use core::arch::asm;
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 
 /// Execute closure without allowing any interrupts on the current core.
 ///
@@ -15,7 +16,7 @@ use core::arch::asm;
 #[cfg(any(doc, target_arch = "x86"))]
 pub fn with_interrupts_disabled<F, R>(f: F) -> R
 where
-    F: FnOnce() -> R,
+    F: FnOnce(&InterruptsDisabled) -> R,
 {
     use crate::registers::bits32::eflags::{self, EFLAGS};
     use crate::registers::irq;
@@ -31,7 +32,12 @@ where
             irq::disable();
         }
 
-        let res = f();
+        // Safety: interrupts are disabled at this point, either because we
+        // just disabled them above, or because they were already disabled
+        // when this function was called.
+        let interrupts_disabled = InterruptsDisabled::new_trusted();
+
+        let res = f(&interrupts_disabled);
 
         if enabled {
             irq::enable();
@@ -44,7 +50,7 @@ where
 #[cfg(not(any(doc, target_arch = "x86")))]
 pub fn with_interrupts_disabled<F, R>(_: F) -> R
 where
-    F: FnOnce() -> R,
+    F: FnOnce(&InterruptsDisabled) -> R,
 {
     unimplemented!()
 }

--- a/chips/apollo3/src/chip.rs
+++ b/chips/apollo3/src/chip.rs
@@ -6,9 +6,9 @@
 
 use core::fmt::Write;
 use cortexm4f::{CortexM4F, CortexMVariant};
+use kernel::context_tokens::InterruptsDisabledContext;
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
 
 pub struct Apollo3<I: InterruptService + 'static> {
     mpu: cortexm4f::mpu::MPU,
@@ -160,7 +160,7 @@ impl<I: InterruptService + 'static> Chip for Apollo3<I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&InterruptsDisabled) -> R,
+        F: FnOnce(&InterruptsDisabledContext) -> R,
     {
         cortexm4f::support::with_interrupts_disabled(f)
     }

--- a/chips/apollo3/src/chip.rs
+++ b/chips/apollo3/src/chip.rs
@@ -8,6 +8,7 @@ use core::fmt::Write;
 use cortexm4f::{CortexM4F, CortexMVariant};
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 
 pub struct Apollo3<I: InterruptService + 'static> {
     mpu: cortexm4f::mpu::MPU,
@@ -159,7 +160,7 @@ impl<I: InterruptService + 'static> Chip for Apollo3<I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce() -> R,
+        F: FnOnce(&InterruptsDisabled) -> R,
     {
         cortexm4f::support::with_interrupts_disabled(f)
     }

--- a/chips/arty_e21_chip/src/chip.rs
+++ b/chips/arty_e21_chip/src/chip.rs
@@ -6,6 +6,7 @@ use core::fmt::Write;
 use kernel::debug;
 use kernel::hil::time::Freq32KHz;
 use kernel::platform::chip::InterruptService;
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 use kernel::utilities::registers::interfaces::Readable;
 
 use crate::clint;
@@ -141,7 +142,7 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for ArtyExx<'a, 
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce() -> R,
+        F: FnOnce(&InterruptsDisabled) -> R,
     {
         rv32i::support::with_interrupts_disabled(f)
     }

--- a/chips/arty_e21_chip/src/chip.rs
+++ b/chips/arty_e21_chip/src/chip.rs
@@ -3,10 +3,10 @@
 // Copyright Tock Contributors 2022.
 
 use core::fmt::Write;
+use kernel::context_tokens::InterruptsDisabledContext;
 use kernel::debug;
 use kernel::hil::time::Freq32KHz;
 use kernel::platform::chip::InterruptService;
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
 use kernel::utilities::registers::interfaces::Readable;
 
 use crate::clint;
@@ -142,7 +142,7 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for ArtyExx<'a, 
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&InterruptsDisabled) -> R,
+        F: FnOnce(&InterruptsDisabledContext) -> R,
     {
         rv32i::support::with_interrupts_disabled(f)
     }
@@ -194,7 +194,7 @@ pub unsafe fn configure_trap_handler() {
 pub extern "C" fn start_trap_rust() {
     // Safety: we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
+    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
     let mcause = rv32i::csr::CSR.mcause.extract();
 
     match rv32i::csr::mcause::Trap::from(mcause) {
@@ -221,7 +221,7 @@ pub extern "C" fn start_trap_rust() {
 pub extern "C" fn disable_interrupt_trap_handler(mcause: u32) {
     // Safety: we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
+    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
     // The interrupt number is then the lowest 8
     // bits.
     let interrupt_index = mcause & 0xFF;

--- a/chips/arty_e21_chip/src/chip.rs
+++ b/chips/arty_e21_chip/src/chip.rs
@@ -192,9 +192,9 @@ pub unsafe fn configure_trap_handler() {
 /// disable it.
 #[export_name = "_start_trap_rust_from_kernel"]
 pub extern "C" fn start_trap_rust() {
-    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
+    let interrupts_disabled = kernel::mint_interrupts_disabled_context!();
     let mcause = rv32i::csr::CSR.mcause.extract();
 
     match rv32i::csr::mcause::Trap::from(mcause) {
@@ -219,9 +219,9 @@ pub extern "C" fn start_trap_rust() {
 /// interrupt that fired so that it does not trigger again.
 #[export_name = "_disable_interrupt_trap_rust_from_app"]
 pub extern "C" fn disable_interrupt_trap_handler(mcause: u32) {
-    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
+    let interrupts_disabled = kernel::mint_interrupts_disabled_context!();
     // The interrupt number is then the lowest 8
     // bits.
     let interrupt_index = mcause & 0xFF;

--- a/chips/arty_e21_chip/src/chip.rs
+++ b/chips/arty_e21_chip/src/chip.rs
@@ -192,6 +192,9 @@ pub unsafe fn configure_trap_handler() {
 /// disable it.
 #[export_name = "_start_trap_rust_from_kernel"]
 pub extern "C" fn start_trap_rust() {
+    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // `mstatus.MIE` on trap entry before any Rust code runs.
+    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
     let mcause = rv32i::csr::CSR.mcause.extract();
 
     match rv32i::csr::mcause::Trap::from(mcause) {
@@ -200,9 +203,7 @@ pub extern "C" fn start_trap_rust() {
             // index in the mcause register. The interrupt number is the lowest
             // 8 bits.
             let interrupt_index = mcause.read(rv32i::csr::mcause::mcause::reason) & 0xFF;
-            unsafe {
-                rv32i::clic::disable_interrupt(interrupt_index as u32);
-            }
+            rv32i::clic::disable_interrupt(interrupt_index as u32, &interrupts_disabled);
         }
 
         rv32i::csr::mcause::Trap::Exception(_exception) => {
@@ -218,12 +219,13 @@ pub extern "C" fn start_trap_rust() {
 /// interrupt that fired so that it does not trigger again.
 #[export_name = "_disable_interrupt_trap_rust_from_app"]
 pub extern "C" fn disable_interrupt_trap_handler(mcause: u32) {
+    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // `mstatus.MIE` on trap entry before any Rust code runs.
+    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
     // The interrupt number is then the lowest 8
     // bits.
     let interrupt_index = mcause & 0xFF;
-    unsafe {
-        rv32i::clic::disable_interrupt(interrupt_index);
-    }
+    rv32i::clic::disable_interrupt(interrupt_index, &interrupts_disabled);
 }
 
 /// Array used to track the "trap handler active" state per hart.

--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -101,13 +101,13 @@ impl<'a, I: InterruptService + 'a> E310x<'a, I> {
             .modify(csr::mstatus::mstatus::mie.val(old_mie));
     }
 
-    unsafe fn handle_plic_interrupts(&self) {
+    fn handle_plic_interrupts(&self) {
         while let Some(interrupt) = self.plic.get_saved_interrupts() {
             if !self.plic_interrupt_service.service_interrupt(interrupt) {
                 debug!("Pidx {}", interrupt);
             }
-            self.with_interrupts_disabled(|_interrupts_disabled| {
-                self.plic.complete(interrupt);
+            self.with_interrupts_disabled(|interrupts_disabled| {
+                self.plic.complete(interrupt, interrupts_disabled);
             });
         }
     }
@@ -136,9 +136,7 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for E310x<'a, I>
                 self.timer.handle_interrupt();
             }
             if self.plic.get_saved_interrupts().is_some() {
-                unsafe {
-                    self.handle_plic_interrupts();
-                }
+                self.handle_plic_interrupts();
             }
 
             if !mip.any_matching_bits_set(mip::mtimer::SET)
@@ -205,7 +203,7 @@ fn handle_exception(exception: mcause::Exception) {
     }
 }
 
-unsafe fn handle_interrupt(intr: mcause::Interrupt) {
+fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDisabled) {
     match intr {
         mcause::Interrupt::UserSoft
         | mcause::Interrupt::UserTimer
@@ -228,16 +226,19 @@ unsafe fn handle_interrupt(intr: mcause::Interrupt) {
             // We received an interrupt, disable interrupts while we handle them
             CSR.mie.modify(mie::mext::CLEAR);
 
+            // Safety: interrupts are disabled (we have an InterruptsDisabled
+            // token), so this cannot race a concurrent access to the PLIC.
+            let plic_ref = unsafe { &*addr_of!(PLIC) };
+
             // Claim the interrupt, unwrap() as we know an interrupt exists
             // Once claimed this interrupt won't fire until it's completed
             // NOTE: The interrupt is no longer pending in the PLIC
             loop {
-                let interrupt = (*addr_of!(PLIC)).next_pending();
+                let interrupt = plic_ref.next_pending();
 
                 match interrupt {
                     Some(irq) => {
-                        // Safe as interrupts are disabled
-                        (*addr_of!(PLIC)).save_interrupt(irq);
+                        plic_ref.save_interrupt(irq, interrupts_disabled);
                     }
                     None => {
                         // Enable generic interrupts
@@ -261,9 +262,12 @@ unsafe fn handle_interrupt(intr: mcause::Interrupt) {
 /// in kernel mode.
 #[export_name = "_start_trap_rust_from_kernel"]
 pub unsafe extern "C" fn start_trap_rust() {
+    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // `mstatus.MIE` on trap entry before any Rust code runs.
+    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
     match mcause::Trap::from(CSR.mcause.extract()) {
         mcause::Trap::Interrupt(interrupt) => {
-            handle_interrupt(interrupt);
+            handle_interrupt(interrupt, &interrupts_disabled);
         }
         mcause::Trap::Exception(exception) => {
             handle_exception(exception);
@@ -277,9 +281,12 @@ pub unsafe extern "C" fn start_trap_rust() {
 /// interrupt that fired so that it does not trigger again.
 #[export_name = "_disable_interrupt_trap_rust_from_app"]
 pub unsafe extern "C" fn disable_interrupt_trap_handler(mcause_val: u32) {
+    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // `mstatus.MIE` on trap entry before any Rust code runs.
+    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
     match mcause::Trap::from(mcause_val as usize) {
         mcause::Trap::Interrupt(interrupt) => {
-            handle_interrupt(interrupt);
+            handle_interrupt(interrupt, &interrupts_disabled);
         }
         _ => {
             panic!("unexpected non-interrupt\n");

--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -14,9 +14,9 @@ use rv32i::csr::{CSR, mcause, mie::mie, mip::mip};
 use rv32i::pmp::{PMPUserMPU, simple::SimplePMP};
 
 use crate::plic::PLIC;
+use kernel::context_tokens::InterruptsDisabledContext;
 use kernel::hil::time::Freq32KHz;
 use kernel::platform::chip::InterruptService;
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
 use sifive::plic::Plic;
 
 pub type E310xClint<'a> = sifive::clint::Clint<'a, Freq32KHz>;
@@ -171,7 +171,7 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for E310x<'a, I>
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&InterruptsDisabled) -> R,
+        F: FnOnce(&InterruptsDisabledContext) -> R,
     {
         rv32i::support::with_interrupts_disabled(f)
     }
@@ -203,7 +203,7 @@ fn handle_exception(exception: mcause::Exception) {
     }
 }
 
-fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDisabled) {
+fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDisabledContext) {
     match intr {
         mcause::Interrupt::UserSoft
         | mcause::Interrupt::UserTimer
@@ -226,7 +226,7 @@ fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDis
             // We received an interrupt, disable interrupts while we handle them
             CSR.mie.modify(mie::mext::CLEAR);
 
-            // Safety: interrupts are disabled (we have an InterruptsDisabled
+            // Safety: interrupts are disabled (we have an InterruptsDisabledContext
             // token), so this cannot race a concurrent access to the PLIC.
             let plic_ref = unsafe { &*addr_of!(PLIC) };
 
@@ -264,7 +264,7 @@ fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDis
 pub unsafe extern "C" fn start_trap_rust() {
     // Safety: we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
+    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
     match mcause::Trap::from(CSR.mcause.extract()) {
         mcause::Trap::Interrupt(interrupt) => {
             handle_interrupt(interrupt, &interrupts_disabled);
@@ -283,7 +283,7 @@ pub unsafe extern "C" fn start_trap_rust() {
 pub unsafe extern "C" fn disable_interrupt_trap_handler(mcause_val: u32) {
     // Safety: we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
+    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
     match mcause::Trap::from(mcause_val as usize) {
         mcause::Trap::Interrupt(interrupt) => {
             handle_interrupt(interrupt, &interrupts_disabled);

--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -262,9 +262,9 @@ fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDis
 /// in kernel mode.
 #[export_name = "_start_trap_rust_from_kernel"]
 pub unsafe extern "C" fn start_trap_rust() {
-    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
+    let interrupts_disabled = kernel::mint_interrupts_disabled_context!();
     match mcause::Trap::from(CSR.mcause.extract()) {
         mcause::Trap::Interrupt(interrupt) => {
             handle_interrupt(interrupt, &interrupts_disabled);
@@ -281,9 +281,9 @@ pub unsafe extern "C" fn start_trap_rust() {
 /// interrupt that fired so that it does not trigger again.
 #[export_name = "_disable_interrupt_trap_rust_from_app"]
 pub unsafe extern "C" fn disable_interrupt_trap_handler(mcause_val: u32) {
-    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
+    let interrupts_disabled = kernel::mint_interrupts_disabled_context!();
     match mcause::Trap::from(mcause_val as usize) {
         mcause::Trap::Interrupt(interrupt) => {
             handle_interrupt(interrupt, &interrupts_disabled);

--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -16,6 +16,7 @@ use rv32i::pmp::{PMPUserMPU, simple::SimplePMP};
 use crate::plic::PLIC;
 use kernel::hil::time::Freq32KHz;
 use kernel::platform::chip::InterruptService;
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 use sifive::plic::Plic;
 
 pub type E310xClint<'a> = sifive::clint::Clint<'a, Freq32KHz>;
@@ -105,7 +106,7 @@ impl<'a, I: InterruptService + 'a> E310x<'a, I> {
             if !self.plic_interrupt_service.service_interrupt(interrupt) {
                 debug!("Pidx {}", interrupt);
             }
-            self.with_interrupts_disabled(|| {
+            self.with_interrupts_disabled(|_interrupts_disabled| {
                 self.plic.complete(interrupt);
             });
         }
@@ -172,7 +173,7 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for E310x<'a, I>
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce() -> R,
+        F: FnOnce(&InterruptsDisabled) -> R,
     {
         rv32i::support::with_interrupts_disabled(f)
     }

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -8,6 +8,7 @@ use core::fmt::{Display, Write};
 use core::marker::PhantomData;
 use core::ptr::addr_of;
 use kernel::platform::chip::{Chip, InterruptService};
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use rv32i::csr::{CSR, mcause, mie::mie, mtvec::mtvec};
 use rv32i::pmp::{PMPUserMPU, TORUserPMP};
@@ -196,7 +197,7 @@ impl<
                         // In order to stop an interrupt loop, we first disable the
                         // interrupt. `service_pending_interrupts()` will re-enable
                         // interrupts once they are all handled.
-                        self.with_interrupts_disabled(|| {
+                        self.with_interrupts_disabled(|_interrupts_disabled| {
                             // Safe as interrupts are disabled
                             self.plic.disable(interrupt);
                             self.plic.complete(interrupt);
@@ -211,7 +212,7 @@ impl<
             match interrupt {
                 interrupts::HMAC_HMACDONE..=interrupts::HMAC_HMACERR => {}
                 _ => {
-                    self.with_interrupts_disabled(|| {
+                    self.with_interrupts_disabled(|_interrupts_disabled| {
                         self.plic.complete(interrupt);
                     });
                 }
@@ -309,7 +310,7 @@ impl<
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce() -> R,
+        F: FnOnce(&InterruptsDisabled) -> R,
     {
         rv32i::support::with_interrupts_disabled(f)
     }

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -408,9 +408,9 @@ fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDis
 /// in kernel mode.
 #[export_name = "_start_trap_rust_from_kernel"]
 pub unsafe extern "C" fn start_trap_rust() {
-    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
+    let interrupts_disabled = kernel::mint_interrupts_disabled_context!();
     match mcause::Trap::from(CSR.mcause.extract()) {
         mcause::Trap::Interrupt(interrupt) => {
             handle_interrupt(interrupt, &interrupts_disabled);
@@ -427,9 +427,9 @@ pub unsafe extern "C" fn start_trap_rust() {
 /// interrupt that fired so that it does not trigger again.
 #[export_name = "_disable_interrupt_trap_rust_from_app"]
 pub unsafe extern "C" fn disable_interrupt_trap_handler(mcause_val: u32) {
-    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
+    let interrupts_disabled = kernel::mint_interrupts_disabled_context!();
     match mcause::Trap::from(mcause_val as usize) {
         mcause::Trap::Interrupt(interrupt) => {
             handle_interrupt(interrupt, &interrupts_disabled);

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -7,8 +7,8 @@
 use core::fmt::{Display, Write};
 use core::marker::PhantomData;
 use core::ptr::addr_of;
+use kernel::context_tokens::InterruptsDisabledContext;
 use kernel::platform::chip::{Chip, InterruptService};
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use rv32i::csr::{CSR, mcause, mie::mie, mtvec::mtvec};
 use rv32i::pmp::{PMPUserMPU, TORUserPMP};
@@ -307,7 +307,7 @@ impl<
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&InterruptsDisabled) -> R,
+        F: FnOnce(&InterruptsDisabledContext) -> R,
     {
         rv32i::support::with_interrupts_disabled(f)
     }
@@ -350,7 +350,7 @@ fn handle_exception(exception: mcause::Exception) {
     }
 }
 
-fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDisabled) {
+fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDisabledContext) {
     match intr {
         mcause::Interrupt::UserSoft
         | mcause::Interrupt::UserTimer
@@ -373,7 +373,7 @@ fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDis
             // We received an interrupt, disable interrupts while we handle them
             CSR.mie.modify(mie::mext::CLEAR);
 
-            // Safety: interrupts are disabled (we have an InterruptsDisabled
+            // Safety: interrupts are disabled (we have an InterruptsDisabledContext
             // token), so this cannot race a concurrent access to the PLIC.
             let plic_ref = unsafe { &*addr_of!(PLIC) };
 
@@ -410,7 +410,7 @@ fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDis
 pub unsafe extern "C" fn start_trap_rust() {
     // Safety: we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
+    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
     match mcause::Trap::from(CSR.mcause.extract()) {
         mcause::Trap::Interrupt(interrupt) => {
             handle_interrupt(interrupt, &interrupts_disabled);
@@ -429,7 +429,7 @@ pub unsafe extern "C" fn start_trap_rust() {
 pub unsafe extern "C" fn disable_interrupt_trap_handler(mcause_val: u32) {
     // Safety: we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
+    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
     match mcause::Trap::from(mcause_val as usize) {
         mcause::Trap::Interrupt(interrupt) => {
             handle_interrupt(interrupt, &interrupts_disabled);

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -169,7 +169,7 @@ impl<
         self.plic.enable_all();
     }
 
-    unsafe fn handle_plic_interrupts(&self) {
+    fn handle_plic_interrupts(&self) {
         while let Some(interrupt) = self.plic.get_saved_interrupts() {
             match interrupt {
                 interrupts::PWRMGRAONWAKEUP => {
@@ -197,10 +197,9 @@ impl<
                         // In order to stop an interrupt loop, we first disable the
                         // interrupt. `service_pending_interrupts()` will re-enable
                         // interrupts once they are all handled.
-                        self.with_interrupts_disabled(|_interrupts_disabled| {
-                            // Safe as interrupts are disabled
+                        self.with_interrupts_disabled(|interrupts_disabled| {
                             self.plic.disable(interrupt);
-                            self.plic.complete(interrupt);
+                            self.plic.complete(interrupt, interrupts_disabled);
                         });
                     }
                     if !self.plic_interrupt_service.service_interrupt(interrupt) {
@@ -212,8 +211,8 @@ impl<
             match interrupt {
                 interrupts::HMAC_HMACDONE..=interrupts::HMAC_HMACERR => {}
                 _ => {
-                    self.with_interrupts_disabled(|_interrupts_disabled| {
-                        self.plic.complete(interrupt);
+                    self.with_interrupts_disabled(|interrupts_disabled| {
+                        self.plic.complete(interrupt, interrupts_disabled);
                     });
                 }
             }
@@ -280,9 +279,7 @@ impl<
     fn service_pending_interrupts(&self) {
         loop {
             if self.plic.get_saved_interrupts().is_some() {
-                unsafe {
-                    self.handle_plic_interrupts();
-                }
+                self.handle_plic_interrupts();
             }
 
             if self.plic.get_saved_interrupts().is_none() {
@@ -353,7 +350,7 @@ fn handle_exception(exception: mcause::Exception) {
     }
 }
 
-unsafe fn handle_interrupt(intr: mcause::Interrupt) {
+fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDisabled) {
     match intr {
         mcause::Interrupt::UserSoft
         | mcause::Interrupt::UserTimer
@@ -376,16 +373,19 @@ unsafe fn handle_interrupt(intr: mcause::Interrupt) {
             // We received an interrupt, disable interrupts while we handle them
             CSR.mie.modify(mie::mext::CLEAR);
 
+            // Safety: interrupts are disabled (we have an InterruptsDisabled
+            // token), so this cannot race a concurrent access to the PLIC.
+            let plic_ref = unsafe { &*addr_of!(PLIC) };
+
             // Claim the interrupt, unwrap() as we know an interrupt exists
             // Once claimed this interrupt won't fire until it's completed
             // NOTE: The interrupt is no longer pending in the PLIC
             loop {
-                let interrupt = (*addr_of!(PLIC)).next_pending();
+                let interrupt = plic_ref.next_pending();
 
                 match interrupt {
                     Some(irq) => {
-                        // Safe as interrupts are disabled
-                        (*addr_of!(PLIC)).save_interrupt(irq);
+                        plic_ref.save_interrupt(irq, interrupts_disabled);
                     }
                     None => {
                         // Enable generic interrupts
@@ -408,9 +408,12 @@ unsafe fn handle_interrupt(intr: mcause::Interrupt) {
 /// in kernel mode.
 #[export_name = "_start_trap_rust_from_kernel"]
 pub unsafe extern "C" fn start_trap_rust() {
+    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // `mstatus.MIE` on trap entry before any Rust code runs.
+    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
     match mcause::Trap::from(CSR.mcause.extract()) {
         mcause::Trap::Interrupt(interrupt) => {
-            handle_interrupt(interrupt);
+            handle_interrupt(interrupt, &interrupts_disabled);
         }
         mcause::Trap::Exception(exception) => {
             handle_exception(exception);
@@ -424,9 +427,12 @@ pub unsafe extern "C" fn start_trap_rust() {
 /// interrupt that fired so that it does not trigger again.
 #[export_name = "_disable_interrupt_trap_rust_from_app"]
 pub unsafe extern "C" fn disable_interrupt_trap_handler(mcause_val: u32) {
+    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // `mstatus.MIE` on trap entry before any Rust code runs.
+    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
     match mcause::Trap::from(mcause_val as usize) {
         mcause::Trap::Interrupt(interrupt) => {
-            handle_interrupt(interrupt);
+            handle_interrupt(interrupt, &interrupts_disabled);
         }
         _ => {
             panic!("unexpected non-interrupt\n");

--- a/chips/earlgrey/src/plic.rs
+++ b/chips/earlgrey/src/plic.rs
@@ -5,7 +5,7 @@
 //! Platform Level Interrupt Control peripheral driver.
 
 use crate::registers::top_earlgrey::RV_PLIC_BASE_ADDR;
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
+use kernel::context_tokens::InterruptsDisabledContext;
 use kernel::utilities::StaticRef;
 use kernel::utilities::interrupts_disabled_cell::InterruptsDisabledCell;
 use kernel::utilities::registers::LocalRegisterCopy;
@@ -121,7 +121,7 @@ impl Plic {
     /// This will save the interrupt at index internally to be handled later.
     /// Saved interrupts can be retrieved by calling `get_saved_interrupts()`.
     /// Saved interrupts are cleared when `'complete()` is called.
-    pub fn save_interrupt(&self, index: u32, interrupts_disabled: &InterruptsDisabled) {
+    pub fn save_interrupt(&self, index: u32, interrupts_disabled: &InterruptsDisabledContext) {
         if index >= PLIC_IRQ_NUM as u32 {
             panic!("Invalid IRQ: {}", index)
         }
@@ -149,7 +149,7 @@ impl Plic {
 
     /// Signal that an interrupt is finished being handled. In Tock, this should be
     /// called from the normal main loop (not the interrupt handler).
-    pub fn complete(&self, index: u32, interrupts_disabled: &InterruptsDisabled) {
+    pub fn complete(&self, index: u32, interrupts_disabled: &InterruptsDisabledContext) {
         self.registers.claim.set(index);
         if index >= PLIC_IRQ_NUM as u32 {
             panic!("Invalid IRQ: {}", index)

--- a/chips/earlgrey/src/plic.rs
+++ b/chips/earlgrey/src/plic.rs
@@ -4,10 +4,10 @@
 
 //! Platform Level Interrupt Control peripheral driver.
 
-use core::cell::Cell;
-
 use crate::registers::top_earlgrey::RV_PLIC_BASE_ADDR;
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 use kernel::utilities::StaticRef;
+use kernel::utilities::interrupts_disabled_cell::InterruptsDisabledCell;
 use kernel::utilities::registers::LocalRegisterCopy;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 use kernel::utilities::registers::{ReadOnly, ReadWrite, register_bitfields, register_structs};
@@ -52,7 +52,7 @@ register_bitfields![u32,
 
 pub struct Plic {
     registers: StaticRef<PlicRegisters>,
-    saved: [Cell<LocalRegisterCopy<u32>>; PLIC_REGS],
+    saved: [InterruptsDisabledCell<LocalRegisterCopy<u32>>; PLIC_REGS],
 }
 
 impl Plic {
@@ -60,12 +60,12 @@ impl Plic {
         Plic {
             registers: base,
             saved: [
-                Cell::new(LocalRegisterCopy::new(0)),
-                Cell::new(LocalRegisterCopy::new(0)),
-                Cell::new(LocalRegisterCopy::new(0)),
-                Cell::new(LocalRegisterCopy::new(0)),
-                Cell::new(LocalRegisterCopy::new(0)),
-                Cell::new(LocalRegisterCopy::new(0)),
+                InterruptsDisabledCell::new(LocalRegisterCopy::new(0)),
+                InterruptsDisabledCell::new(LocalRegisterCopy::new(0)),
+                InterruptsDisabledCell::new(LocalRegisterCopy::new(0)),
+                InterruptsDisabledCell::new(LocalRegisterCopy::new(0)),
+                InterruptsDisabledCell::new(LocalRegisterCopy::new(0)),
+                InterruptsDisabledCell::new(LocalRegisterCopy::new(0)),
             ],
         }
     }
@@ -119,21 +119,19 @@ impl Plic {
 
     /// Save the current interrupt to be handled later
     /// This will save the interrupt at index internally to be handled later.
-    /// Interrupts must be disabled before this is called.
     /// Saved interrupts can be retrieved by calling `get_saved_interrupts()`.
     /// Saved interrupts are cleared when `'complete()` is called.
-    pub unsafe fn save_interrupt(&self, index: u32) {
+    pub fn save_interrupt(&self, index: u32, interrupts_disabled: &InterruptsDisabled) {
         if index >= PLIC_IRQ_NUM as u32 {
             panic!("Invalid IRQ: {}", index)
         }
         let offset = (index / 32) as usize;
         let mask = 1 << (index % 32);
 
-        // OR the current saved state with the new value
-        let new_saved = self.saved[offset].get().get() | mask;
-
-        // Set the new state
-        self.saved[offset].set(LocalRegisterCopy::new(new_saved));
+        self.saved[offset].update(
+            |val| LocalRegisterCopy::new(val.get() | mask),
+            interrupts_disabled,
+        );
     }
 
     /// The `next_pending()` function will only return enabled interrupts.
@@ -151,8 +149,7 @@ impl Plic {
 
     /// Signal that an interrupt is finished being handled. In Tock, this should be
     /// called from the normal main loop (not the interrupt handler).
-    /// Interrupts must be disabled before this is called.
-    pub unsafe fn complete(&self, index: u32) {
+    pub fn complete(&self, index: u32, interrupts_disabled: &InterruptsDisabled) {
         self.registers.claim.set(index);
         if index >= PLIC_IRQ_NUM as u32 {
             panic!("Invalid IRQ: {}", index)
@@ -160,10 +157,9 @@ impl Plic {
         let offset = (index / 32) as usize;
         let mask = !(1 << (index % 32));
 
-        // OR the current saved state with the new value
-        let new_saved = self.saved[offset].get().get() & mask;
-
-        // Set the new state
-        self.saved[offset].set(LocalRegisterCopy::new(new_saved));
+        self.saved[offset].update(
+            |val| LocalRegisterCopy::new(val.get() & mask),
+            interrupts_disabled,
+        );
     }
 }

--- a/chips/esp32-c3/src/chip.rs
+++ b/chips/esp32-c3/src/chip.rs
@@ -257,9 +257,9 @@ fn handle_interrupt(_intr: mcause::Interrupt, interrupts_disabled: &InterruptsDi
 /// in kernel mode.
 #[export_name = "_start_trap_rust_from_kernel"]
 pub unsafe extern "C" fn start_trap_rust() {
-    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
+    let interrupts_disabled = kernel::mint_interrupts_disabled_context!();
     match mcause::Trap::from(CSR.mcause.extract()) {
         mcause::Trap::Interrupt(interrupt) => {
             handle_interrupt(interrupt, &interrupts_disabled);
@@ -276,9 +276,9 @@ pub unsafe extern "C" fn start_trap_rust() {
 /// interrupt that fired so that it does not trigger again.
 #[export_name = "_disable_interrupt_trap_rust_from_app"]
 pub unsafe extern "C" fn disable_interrupt_trap_handler(mcause_val: u32) {
-    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
+    let interrupts_disabled = kernel::mint_interrupts_disabled_context!();
     match mcause::Trap::from(mcause_val as usize) {
         mcause::Trap::Interrupt(interrupt) => {
             handle_interrupt(interrupt, &interrupts_disabled);

--- a/chips/esp32-c3/src/chip.rs
+++ b/chips/esp32-c3/src/chip.rs
@@ -96,14 +96,13 @@ impl<'a, I: InterruptService + 'a> Esp32C3<'a, I> {
         self.intc.enable_all();
     }
 
-    unsafe fn handle_pic_interrupts(&self) {
+    fn handle_pic_interrupts(&self) {
         while let Some(interrupt) = self.intc.get_saved_interrupts() {
             if !self.pic_interrupt_service.service_interrupt(interrupt) {
                 panic!("Unhandled interrupt {}", interrupt);
             }
-            self.with_interrupts_disabled(|_interrupts_disabled| {
-                // Safe as interrupts are disabled
-                self.intc.complete(interrupt);
+            self.with_interrupts_disabled(|interrupts_disabled| {
+                self.intc.complete(interrupt, interrupts_disabled);
             });
         }
     }
@@ -119,9 +118,7 @@ impl<'a, I: InterruptService + 'a> Chip for Esp32C3<'a, I> {
     fn service_pending_interrupts(&self) {
         loop {
             if self.intc.get_saved_interrupts().is_some() {
-                unsafe {
-                    self.handle_pic_interrupts();
-                }
+                self.handle_pic_interrupts();
             }
 
             if self.intc.get_saved_interrupts().is_none() {
@@ -227,20 +224,23 @@ fn handle_exception(exception: mcause::Exception) {
     }
 }
 
-unsafe fn handle_interrupt(_intr: mcause::Interrupt) {
+fn handle_interrupt(_intr: mcause::Interrupt, interrupts_disabled: &InterruptsDisabled) {
     CSR.mstatus.modify(csr::mstatus::mstatus::mie::CLEAR);
+
+    // Safety: interrupts are disabled (we have an InterruptsDisabled
+    // token), so this cannot race a concurrent access to the INTC.
+    let intc_ref = unsafe { &*addr_of!(INTC) };
 
     // Claim the interrupt, unwrap() as we know an interrupt exists
     // Once claimed this interrupt won't fire until it's completed
     // NOTE: The interrupt is no longer pending in the PLIC
     loop {
-        let interrupt = (*addr_of!(INTC)).next_pending();
+        let interrupt = intc_ref.next_pending();
 
         match interrupt {
             Some(irq) => {
-                // Safe as interrupts are disabled
-                (*addr_of!(INTC)).save_interrupt(irq);
-                (*addr_of!(INTC)).disable(irq);
+                intc_ref.save_interrupt(irq, interrupts_disabled);
+                intc_ref.disable(irq);
             }
             None => {
                 // Enable generic interrupts
@@ -257,9 +257,12 @@ unsafe fn handle_interrupt(_intr: mcause::Interrupt) {
 /// in kernel mode.
 #[export_name = "_start_trap_rust_from_kernel"]
 pub unsafe extern "C" fn start_trap_rust() {
+    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // `mstatus.MIE` on trap entry before any Rust code runs.
+    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
     match mcause::Trap::from(CSR.mcause.extract()) {
         mcause::Trap::Interrupt(interrupt) => {
-            handle_interrupt(interrupt);
+            handle_interrupt(interrupt, &interrupts_disabled);
         }
         mcause::Trap::Exception(exception) => {
             handle_exception(exception);
@@ -273,9 +276,12 @@ pub unsafe extern "C" fn start_trap_rust() {
 /// interrupt that fired so that it does not trigger again.
 #[export_name = "_disable_interrupt_trap_rust_from_app"]
 pub unsafe extern "C" fn disable_interrupt_trap_handler(mcause_val: u32) {
+    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // `mstatus.MIE` on trap entry before any Rust code runs.
+    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
     match mcause::Trap::from(mcause_val as usize) {
         mcause::Trap::Interrupt(interrupt) => {
-            handle_interrupt(interrupt);
+            handle_interrupt(interrupt, &interrupts_disabled);
         }
         _ => {
             panic!("unexpected non-interrupt\n");

--- a/chips/esp32-c3/src/chip.rs
+++ b/chips/esp32-c3/src/chip.rs
@@ -8,6 +8,7 @@ use core::fmt::Write;
 use core::ptr::addr_of;
 
 use kernel::platform::chip::{Chip, InterruptService};
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 use kernel::utilities::StaticRef;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 
@@ -100,7 +101,7 @@ impl<'a, I: InterruptService + 'a> Esp32C3<'a, I> {
             if !self.pic_interrupt_service.service_interrupt(interrupt) {
                 panic!("Unhandled interrupt {}", interrupt);
             }
-            self.with_interrupts_disabled(|| {
+            self.with_interrupts_disabled(|_interrupts_disabled| {
                 // Safe as interrupts are disabled
                 self.intc.complete(interrupt);
             });
@@ -151,7 +152,7 @@ impl<'a, I: InterruptService + 'a> Chip for Esp32C3<'a, I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce() -> R,
+        F: FnOnce(&InterruptsDisabled) -> R,
     {
         rv32i::support::with_interrupts_disabled(f)
     }

--- a/chips/esp32-c3/src/chip.rs
+++ b/chips/esp32-c3/src/chip.rs
@@ -7,8 +7,8 @@
 use core::fmt::Write;
 use core::ptr::addr_of;
 
+use kernel::context_tokens::InterruptsDisabledContext;
 use kernel::platform::chip::{Chip, InterruptService};
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
 use kernel::utilities::StaticRef;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 
@@ -149,7 +149,7 @@ impl<'a, I: InterruptService + 'a> Chip for Esp32C3<'a, I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&InterruptsDisabled) -> R,
+        F: FnOnce(&InterruptsDisabledContext) -> R,
     {
         rv32i::support::with_interrupts_disabled(f)
     }
@@ -224,10 +224,10 @@ fn handle_exception(exception: mcause::Exception) {
     }
 }
 
-fn handle_interrupt(_intr: mcause::Interrupt, interrupts_disabled: &InterruptsDisabled) {
+fn handle_interrupt(_intr: mcause::Interrupt, interrupts_disabled: &InterruptsDisabledContext) {
     CSR.mstatus.modify(csr::mstatus::mstatus::mie::CLEAR);
 
-    // Safety: interrupts are disabled (we have an InterruptsDisabled
+    // Safety: interrupts are disabled (we have an InterruptsDisabledContext
     // token), so this cannot race a concurrent access to the INTC.
     let intc_ref = unsafe { &*addr_of!(INTC) };
 
@@ -259,7 +259,7 @@ fn handle_interrupt(_intr: mcause::Interrupt, interrupts_disabled: &InterruptsDi
 pub unsafe extern "C" fn start_trap_rust() {
     // Safety: we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
+    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
     match mcause::Trap::from(CSR.mcause.extract()) {
         mcause::Trap::Interrupt(interrupt) => {
             handle_interrupt(interrupt, &interrupts_disabled);
@@ -278,7 +278,7 @@ pub unsafe extern "C" fn start_trap_rust() {
 pub unsafe extern "C" fn disable_interrupt_trap_handler(mcause_val: u32) {
     // Safety: we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
+    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
     match mcause::Trap::from(mcause_val as usize) {
         mcause::Trap::Interrupt(interrupt) => {
             handle_interrupt(interrupt, &interrupts_disabled);

--- a/chips/esp32-c3/src/intc.rs
+++ b/chips/esp32-c3/src/intc.rs
@@ -5,7 +5,7 @@
 //! Platform Level Interrupt Control peripheral driver.
 
 use crate::interrupts;
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
+use kernel::context_tokens::InterruptsDisabledContext;
 use kernel::utilities::StaticRef;
 use kernel::utilities::interrupts_disabled_cell::InterruptsDisabledCell;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
@@ -133,7 +133,7 @@ impl Intc {
     /// This will save the interrupt at index internally to be handled later.
     /// Saved interrupts can be retrieved by calling `get_saved_interrupts()`.
     /// Saved interrupts are cleared when `'complete()` is called.
-    pub fn save_interrupt(&self, irq: u32, interrupts_disabled: &InterruptsDisabled) {
+    pub fn save_interrupt(&self, irq: u32, interrupts_disabled: &InterruptsDisabledContext) {
         self.saved.update(
             |val| LocalRegisterCopy::new(val.get() | 1 << irq),
             interrupts_disabled,
@@ -154,7 +154,7 @@ impl Intc {
 
     /// Signal that an interrupt is finished being handled. In Tock, this should be
     /// called from the normal main loop (not the interrupt handler).
-    pub fn complete(&self, irq: u32, interrupts_disabled: &InterruptsDisabled) {
+    pub fn complete(&self, irq: u32, interrupts_disabled: &InterruptsDisabledContext) {
         self.saved.update(
             |val| LocalRegisterCopy::new(val.get() & !(1 << irq)),
             interrupts_disabled,

--- a/chips/esp32-c3/src/intc.rs
+++ b/chips/esp32-c3/src/intc.rs
@@ -4,10 +4,10 @@
 
 //! Platform Level Interrupt Control peripheral driver.
 
-use core::cell::Cell;
-
 use crate::interrupts;
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 use kernel::utilities::StaticRef;
+use kernel::utilities::interrupts_disabled_cell::InterruptsDisabledCell;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 use kernel::utilities::registers::{
     LocalRegisterCopy, ReadWrite, register_bitfields, register_structs,
@@ -58,14 +58,14 @@ register_bitfields![u32,
 
 pub struct Intc {
     registers: StaticRef<IntcRegisters>,
-    saved: Cell<LocalRegisterCopy<u32>>,
+    saved: InterruptsDisabledCell<LocalRegisterCopy<u32>>,
 }
 
 impl Intc {
     pub const fn new(base: StaticRef<IntcRegisters>) -> Self {
         Intc {
             registers: base,
-            saved: Cell::new(LocalRegisterCopy::new(0)),
+            saved: InterruptsDisabledCell::new(LocalRegisterCopy::new(0)),
         }
     }
 
@@ -131,15 +131,13 @@ impl Intc {
 
     /// Save the current interrupt to be handled later
     /// This will save the interrupt at index internally to be handled later.
-    /// Interrupts must be disabled before this is called.
     /// Saved interrupts can be retrieved by calling `get_saved_interrupts()`.
     /// Saved interrupts are cleared when `'complete()` is called.
-    pub unsafe fn save_interrupt(&self, irq: u32) {
-        // OR the current saved state with the new value
-        let new_saved = self.saved.get().get() | 1 << irq;
-
-        // Set the new state
-        self.saved.set(LocalRegisterCopy::new(new_saved));
+    pub fn save_interrupt(&self, irq: u32, interrupts_disabled: &InterruptsDisabled) {
+        self.saved.update(
+            |val| LocalRegisterCopy::new(val.get() | 1 << irq),
+            interrupts_disabled,
+        );
     }
 
     /// The `next_pending()` function will only return enabled interrupts.
@@ -156,12 +154,10 @@ impl Intc {
 
     /// Signal that an interrupt is finished being handled. In Tock, this should be
     /// called from the normal main loop (not the interrupt handler).
-    /// Interrupts must be disabled before this is called.
-    pub unsafe fn complete(&self, irq: u32) {
-        // OR the current saved state with the new value
-        let new_saved = self.saved.get().get() & !(1 << irq);
-
-        // Set the new state
-        self.saved.set(LocalRegisterCopy::new(new_saved));
+    pub fn complete(&self, irq: u32, interrupts_disabled: &InterruptsDisabled) {
+        self.saved.update(
+            |val| LocalRegisterCopy::new(val.get() & !(1 << irq)),
+            interrupts_disabled,
+        );
     }
 }

--- a/chips/imxrt10xx/src/chip.rs
+++ b/chips/imxrt10xx/src/chip.rs
@@ -8,6 +8,7 @@ use core::fmt::Write;
 use cortexm7::{CortexM7, CortexMVariant};
 use kernel::debug;
 use kernel::platform::chip::{Chip, InterruptService};
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 
 use crate::nvic;
 
@@ -148,7 +149,7 @@ impl<I: InterruptService + 'static> Chip for Imxrt10xx<I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce() -> R,
+        F: FnOnce(&InterruptsDisabled) -> R,
     {
         cortexm7::support::with_interrupts_disabled(f)
     }

--- a/chips/imxrt10xx/src/chip.rs
+++ b/chips/imxrt10xx/src/chip.rs
@@ -6,9 +6,9 @@
 
 use core::fmt::Write;
 use cortexm7::{CortexM7, CortexMVariant};
+use kernel::context_tokens::InterruptsDisabledContext;
 use kernel::debug;
 use kernel::platform::chip::{Chip, InterruptService};
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
 
 use crate::nvic;
 
@@ -149,7 +149,7 @@ impl<I: InterruptService + 'static> Chip for Imxrt10xx<I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&InterruptsDisabled) -> R,
+        F: FnOnce(&InterruptsDisabledContext) -> R,
     {
         cortexm7::support::with_interrupts_disabled(f)
     }

--- a/chips/imxrt10xx/src/gpio.rs
+++ b/chips/imxrt10xx/src/gpio.rs
@@ -332,7 +332,7 @@ impl<'a, const N: usize> Port<'a, N> {
         // changed due to an external interrupt. `ISR` is a read/clear write
         // 1 register (`rc_w1`). So, we only clear bits whose value has been
         // transferred to `isr`.
-        let isr_val = with_interrupts_disabled(|| {
+        let isr_val = with_interrupts_disabled(|_interrupts_disabled| {
             let isr_val = self.registers.isr.get();
             self.registers.isr.set(isr_val);
             isr_val
@@ -744,7 +744,7 @@ impl hil::gpio::Input for Pin<'_> {
 
 impl<'a> hil::gpio::Interrupt<'a> for Pin<'a> {
     fn enable_interrupts(&self, mode: hil::gpio::InterruptEdge) {
-        with_interrupts_disabled(|| {
+        with_interrupts_disabled(|_interrupts_disabled| {
             // disable the interrupt
             self.mask_interrupt();
             self.clear_pending();
@@ -755,7 +755,7 @@ impl<'a> hil::gpio::Interrupt<'a> for Pin<'a> {
     }
 
     fn disable_interrupts(&self) {
-        with_interrupts_disabled(|| {
+        with_interrupts_disabled(|_interrupts_disabled| {
             self.mask_interrupt();
             self.clear_pending();
         });

--- a/chips/imxrt10xx/src/gpt.rs
+++ b/chips/imxrt10xx/src/gpt.rs
@@ -392,7 +392,7 @@ impl<'a, F: hil::time::Frequency> hil::time::Alarm<'a> for Gpt<'a, F> {
     }
 
     fn disarm(&self) -> Result<(), ErrorCode> {
-        with_interrupts_disabled(|| {
+        with_interrupts_disabled(|_interrupts_disabled| {
             // Disable counter
             self.registers.ir.modify(IR::OF1IE::CLEAR);
             cortexm7::nvic::Nvic::new(self.irqn).clear_pending();

--- a/chips/litex_vexriscv/src/chip.rs
+++ b/chips/litex_vexriscv/src/chip.rs
@@ -7,7 +7,7 @@
 use core::fmt::Write;
 use core::ptr::addr_of;
 use kernel::debug;
-use kernel::platform::chip::InterruptService;
+use kernel::platform::chip::{Chip, InterruptService};
 use kernel::platform::interrupts_disabled::InterruptsDisabled;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 use rv32i::csr::{CSR, mcause, mie::mie};
@@ -50,12 +50,15 @@ impl<I: 'static + InterruptService> LiteXVexRiscv<I> {
         VexRiscvInterruptController::unmask_all_interrupts();
     }
 
-    unsafe fn handle_interrupts(&self) {
+    fn handle_interrupts(&self) {
         while let Some(interrupt) = self.interrupt_controller.next_saved() {
             if !self.interrupt_service.service_interrupt(interrupt as u32) {
                 debug!("Unknown interrupt: {}", interrupt);
             }
-            self.interrupt_controller.complete_saved(interrupt);
+            self.with_interrupts_disabled(|interrupts_disabled| {
+                self.interrupt_controller
+                    .complete_saved(interrupt, interrupts_disabled);
+            });
         }
     }
 }
@@ -77,9 +80,7 @@ impl<I: 'static + InterruptService> kernel::platform::chip::Chip for LiteXVexRis
 
     fn service_pending_interrupts(&self) {
         while self.interrupt_controller.next_saved().is_some() {
-            unsafe {
-                self.handle_interrupts();
-            }
+            self.handle_interrupts();
         }
 
         // Re-enable all MIE interrupts that we care about. Since we
@@ -140,7 +141,7 @@ fn handle_exception(exception: mcause::Exception) {
     }
 }
 
-unsafe fn handle_interrupt(intr: mcause::Interrupt) {
+fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDisabled) {
     match intr {
         mcause::Interrupt::UserSoft
         | mcause::Interrupt::UserTimer
@@ -160,15 +161,22 @@ unsafe fn handle_interrupt(intr: mcause::Interrupt) {
             CSR.mie.modify(mie::mtimer::CLEAR);
         }
         mcause::Interrupt::MachineExternal => {
-            // We received an interrupt, disable interrupts while we handle them
+            // Mask the external interrupt source so this (level-triggered)
+            // interrupt cannot re-trap before the bottom half drains and
+            // completes it.
             CSR.mie.modify(mie::mext::CLEAR);
+
+            // Safety: interrupts are disabled (we have an InterruptsDisabled
+            // token), so this cannot race a concurrent access to the
+            // interrupt controller.
+            let interrupt_controller_ref = unsafe { &*addr_of!(INTERRUPT_CONTROLLER) };
 
             // Save the interrupts and check whether at least one
             // interrupt is to be handled
             //
-            // If no interrupt was saved, reenable interrupts
-            // immediately
-            if !(*addr_of!(INTERRUPT_CONTROLLER)).save_pending() {
+            // If no interrupt was saved, unmask the external interrupt
+            // source immediately
+            if !interrupt_controller_ref.save_pending(interrupts_disabled) {
                 CSR.mie.modify(mie::mext::SET);
             }
         }
@@ -185,9 +193,12 @@ unsafe fn handle_interrupt(intr: mcause::Interrupt) {
 /// kernel mode.
 #[export_name = "_start_trap_rust_from_kernel"]
 pub unsafe extern "C" fn start_trap_rust() {
+    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // `mstatus.MIE` on trap entry before any Rust code runs.
+    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
     match mcause::Trap::from(CSR.mcause.extract()) {
         mcause::Trap::Interrupt(interrupt) => {
-            handle_interrupt(interrupt);
+            handle_interrupt(interrupt, &interrupts_disabled);
         }
         mcause::Trap::Exception(exception) => {
             handle_exception(exception);
@@ -201,9 +212,12 @@ pub unsafe extern "C" fn start_trap_rust() {
 /// interrupt that fired so that it does not trigger again.
 #[export_name = "_disable_interrupt_trap_rust_from_app"]
 pub unsafe extern "C" fn disable_interrupt_trap_handler(mcause_val: u32) {
+    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // `mstatus.MIE` on trap entry before any Rust code runs.
+    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
     match mcause::Trap::from(mcause_val as usize) {
         mcause::Trap::Interrupt(interrupt) => {
-            handle_interrupt(interrupt);
+            handle_interrupt(interrupt, &interrupts_disabled);
         }
         _ => {
             panic!("unexpected non-interrupt\n");

--- a/chips/litex_vexriscv/src/chip.rs
+++ b/chips/litex_vexriscv/src/chip.rs
@@ -193,9 +193,9 @@ fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDis
 /// kernel mode.
 #[export_name = "_start_trap_rust_from_kernel"]
 pub unsafe extern "C" fn start_trap_rust() {
-    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
+    let interrupts_disabled = kernel::mint_interrupts_disabled_context!();
     match mcause::Trap::from(CSR.mcause.extract()) {
         mcause::Trap::Interrupt(interrupt) => {
             handle_interrupt(interrupt, &interrupts_disabled);
@@ -212,9 +212,9 @@ pub unsafe extern "C" fn start_trap_rust() {
 /// interrupt that fired so that it does not trigger again.
 #[export_name = "_disable_interrupt_trap_rust_from_app"]
 pub unsafe extern "C" fn disable_interrupt_trap_handler(mcause_val: u32) {
-    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
+    let interrupts_disabled = kernel::mint_interrupts_disabled_context!();
     match mcause::Trap::from(mcause_val as usize) {
         mcause::Trap::Interrupt(interrupt) => {
             handle_interrupt(interrupt, &interrupts_disabled);

--- a/chips/litex_vexriscv/src/chip.rs
+++ b/chips/litex_vexriscv/src/chip.rs
@@ -8,6 +8,7 @@ use core::fmt::Write;
 use core::ptr::addr_of;
 use kernel::debug;
 use kernel::platform::chip::InterruptService;
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 use rv32i::csr::{CSR, mcause, mie::mie};
 use rv32i::pmp::{PMPUserMPU, kernel_protection::KernelProtectionPMP};
@@ -99,7 +100,7 @@ impl<I: 'static + InterruptService> kernel::platform::chip::Chip for LiteXVexRis
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce() -> R,
+        F: FnOnce(&InterruptsDisabled) -> R,
     {
         rv32i::support::with_interrupts_disabled(f)
     }

--- a/chips/litex_vexriscv/src/chip.rs
+++ b/chips/litex_vexriscv/src/chip.rs
@@ -6,9 +6,9 @@
 
 use core::fmt::Write;
 use core::ptr::addr_of;
+use kernel::context_tokens::InterruptsDisabledContext;
 use kernel::debug;
 use kernel::platform::chip::{Chip, InterruptService};
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 use rv32i::csr::{CSR, mcause, mie::mie};
 use rv32i::pmp::{PMPUserMPU, kernel_protection::KernelProtectionPMP};
@@ -101,7 +101,7 @@ impl<I: 'static + InterruptService> kernel::platform::chip::Chip for LiteXVexRis
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&InterruptsDisabled) -> R,
+        F: FnOnce(&InterruptsDisabledContext) -> R,
     {
         rv32i::support::with_interrupts_disabled(f)
     }
@@ -141,7 +141,7 @@ fn handle_exception(exception: mcause::Exception) {
     }
 }
 
-fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDisabled) {
+fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDisabledContext) {
     match intr {
         mcause::Interrupt::UserSoft
         | mcause::Interrupt::UserTimer
@@ -166,7 +166,7 @@ fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDis
             // completes it.
             CSR.mie.modify(mie::mext::CLEAR);
 
-            // Safety: interrupts are disabled (we have an InterruptsDisabled
+            // Safety: interrupts are disabled (we have an InterruptsDisabledContext
             // token), so this cannot race a concurrent access to the
             // interrupt controller.
             let interrupt_controller_ref = unsafe { &*addr_of!(INTERRUPT_CONTROLLER) };
@@ -195,7 +195,7 @@ fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDis
 pub unsafe extern "C" fn start_trap_rust() {
     // Safety: we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
+    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
     match mcause::Trap::from(CSR.mcause.extract()) {
         mcause::Trap::Interrupt(interrupt) => {
             handle_interrupt(interrupt, &interrupts_disabled);
@@ -214,7 +214,7 @@ pub unsafe extern "C" fn start_trap_rust() {
 pub unsafe extern "C" fn disable_interrupt_trap_handler(mcause_val: u32) {
     // Safety: we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
+    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
     match mcause::Trap::from(mcause_val as usize) {
         mcause::Trap::Interrupt(interrupt) => {
             handle_interrupt(interrupt, &interrupts_disabled);

--- a/chips/litex_vexriscv/src/interrupt_controller.rs
+++ b/chips/litex_vexriscv/src/interrupt_controller.rs
@@ -4,7 +4,8 @@
 
 //! VexRiscv-specific interrupt controller implementation
 
-use core::cell::Cell;
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
+use kernel::utilities::interrupts_disabled_cell::InterruptsDisabledCell;
 
 /// Rust wrapper around the raw CSR-based VexRiscv interrupt
 /// controller
@@ -12,25 +13,25 @@ use core::cell::Cell;
 /// The wrapper supports saving all currently pending interrupts to an
 /// internal state, which can then be used for interrupt processing.
 pub struct VexRiscvInterruptController {
-    saved_interrupts: Cell<usize>,
+    saved_interrupts: InterruptsDisabledCell<usize>,
 }
 
 impl VexRiscvInterruptController {
     /// Construct a new VexRiscvInterruptController instance
     pub const fn new() -> Self {
         VexRiscvInterruptController {
-            saved_interrupts: Cell::new(0),
+            saved_interrupts: InterruptsDisabledCell::new(0),
         }
     }
 
     /// Save the currently pending interrupts in hardware to the
     /// internal state
-    ///
-    /// This should be accessed in an atomic context to ensure a
-    /// consistent view on the pending interrupts is saved.
-    pub unsafe fn save_pending(&self) -> bool {
-        let all_pending = vexriscv_irq_raw::irq_pending();
-        self.saved_interrupts.set(all_pending);
+    pub fn save_pending(&self, interrupts_disabled: &InterruptsDisabled) -> bool {
+        // Safety: irq_pending() is unsafe only because it is an inline-asm
+        // CSR read; a single read cannot race or tear, so no additional
+        // precondition is needed here.
+        let all_pending = unsafe { vexriscv_irq_raw::irq_pending() };
+        self.saved_interrupts.set(all_pending, interrupts_disabled);
 
         // return true if some interrupts were saved
         all_pending != 0
@@ -63,21 +64,31 @@ impl VexRiscvInterruptController {
     ///
     /// If all interrupts are marked as complete, `next_saved` will
     /// return `None`.
-    pub fn complete_saved(&self, idx: usize) {
+    pub fn complete_saved(&self, idx: usize, interrupts_disabled: &InterruptsDisabled) {
         self.saved_interrupts
-            .set(self.saved_interrupts.get() & !(1 << idx));
+            .update(|val| val & !(1 << idx), interrupts_disabled);
     }
 
     /// Suppress (mask) a specific interrupt source in the interrupt
     /// controller
-    pub unsafe fn mask_interrupt(idx: usize) {
-        vexriscv_irq_raw::irq_setmask(vexriscv_irq_raw::irq_getmask() & !(1 << idx));
+    pub fn mask_interrupt(idx: usize, _interrupts_disabled: &InterruptsDisabled) {
+        // Safety: interrupts are disabled (we have an InterruptsDisabled
+        // token), so this read-modify-write of the mask register cannot
+        // race a concurrent access.
+        unsafe {
+            vexriscv_irq_raw::irq_setmask(vexriscv_irq_raw::irq_getmask() & !(1 << idx));
+        }
     }
 
     /// Unsuppress (unmask) a specific interrupt source in the
     /// interrupt controller
-    pub unsafe fn unmask_interrupt(idx: usize) {
-        vexriscv_irq_raw::irq_setmask(vexriscv_irq_raw::irq_getmask() | (1 << idx));
+    pub fn unmask_interrupt(idx: usize, _interrupts_disabled: &InterruptsDisabled) {
+        // Safety: interrupts are disabled (we have an InterruptsDisabled
+        // token), so this read-modify-write of the mask register cannot
+        // race a concurrent access.
+        unsafe {
+            vexriscv_irq_raw::irq_setmask(vexriscv_irq_raw::irq_getmask() | (1 << idx));
+        }
     }
 
     /// Suppress (mask) all interrupts in the interrupt controller

--- a/chips/litex_vexriscv/src/interrupt_controller.rs
+++ b/chips/litex_vexriscv/src/interrupt_controller.rs
@@ -4,7 +4,7 @@
 
 //! VexRiscv-specific interrupt controller implementation
 
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
+use kernel::context_tokens::InterruptsDisabledContext;
 use kernel::utilities::interrupts_disabled_cell::InterruptsDisabledCell;
 
 /// Rust wrapper around the raw CSR-based VexRiscv interrupt
@@ -26,7 +26,7 @@ impl VexRiscvInterruptController {
 
     /// Save the currently pending interrupts in hardware to the
     /// internal state
-    pub fn save_pending(&self, interrupts_disabled: &InterruptsDisabled) -> bool {
+    pub fn save_pending(&self, interrupts_disabled: &InterruptsDisabledContext) -> bool {
         // Safety: irq_pending() is unsafe only because it is an inline-asm
         // CSR read; a single read cannot race or tear, so no additional
         // precondition is needed here.
@@ -64,15 +64,15 @@ impl VexRiscvInterruptController {
     ///
     /// If all interrupts are marked as complete, `next_saved` will
     /// return `None`.
-    pub fn complete_saved(&self, idx: usize, interrupts_disabled: &InterruptsDisabled) {
+    pub fn complete_saved(&self, idx: usize, interrupts_disabled: &InterruptsDisabledContext) {
         self.saved_interrupts
             .update(|val| val & !(1 << idx), interrupts_disabled);
     }
 
     /// Suppress (mask) a specific interrupt source in the interrupt
     /// controller
-    pub fn mask_interrupt(idx: usize, _interrupts_disabled: &InterruptsDisabled) {
-        // Safety: interrupts are disabled (we have an InterruptsDisabled
+    pub fn mask_interrupt(idx: usize, _interrupts_disabled: &InterruptsDisabledContext) {
+        // Safety: interrupts are disabled (we have an InterruptsDisabledContext
         // token), so this read-modify-write of the mask register cannot
         // race a concurrent access.
         unsafe {
@@ -82,8 +82,8 @@ impl VexRiscvInterruptController {
 
     /// Unsuppress (unmask) a specific interrupt source in the
     /// interrupt controller
-    pub fn unmask_interrupt(idx: usize, _interrupts_disabled: &InterruptsDisabled) {
-        // Safety: interrupts are disabled (we have an InterruptsDisabled
+    pub fn unmask_interrupt(idx: usize, _interrupts_disabled: &InterruptsDisabledContext) {
+        // Safety: interrupts are disabled (we have an InterruptsDisabledContext
         // token), so this read-modify-write of the mask register cannot
         // race a concurrent access.
         unsafe {

--- a/chips/lpc55s6x/src/chip.rs
+++ b/chips/lpc55s6x/src/chip.rs
@@ -9,6 +9,7 @@ use core::panic;
 use cortexm33::{CortexM33, CortexMVariant};
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 
 use crate::clocks::Clock;
 use crate::ctimer0::LPCTimer;
@@ -92,7 +93,7 @@ impl<I: InterruptService> Chip for Lpc55s69<'_, I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce() -> R,
+        F: FnOnce(&InterruptsDisabled) -> R,
     {
         cortexm33::support::with_interrupts_disabled(f)
     }

--- a/chips/lpc55s6x/src/chip.rs
+++ b/chips/lpc55s6x/src/chip.rs
@@ -7,9 +7,9 @@ use core::fmt::Write;
 use core::panic;
 
 use cortexm33::{CortexM33, CortexMVariant};
+use kernel::context_tokens::InterruptsDisabledContext;
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
 
 use crate::clocks::Clock;
 use crate::ctimer0::LPCTimer;
@@ -93,7 +93,7 @@ impl<I: InterruptService> Chip for Lpc55s69<'_, I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&InterruptsDisabled) -> R,
+        F: FnOnce(&InterruptsDisabledContext) -> R,
     {
         cortexm33::support::with_interrupts_disabled(f)
     }

--- a/chips/lpc55s6x/src/ctimer0.rs
+++ b/chips/lpc55s6x/src/ctimer0.rs
@@ -388,7 +388,7 @@ impl<'a> LPCTimer<'a> {
     }
 
     fn enable_timer_interrupt(&self) {
-        with_interrupts_disabled(|| {
+        with_interrupts_disabled(|_interrupts_disabled| {
             let n = cortexm33::nvic::Nvic::new(CTIMER0);
             n.enable();
         })
@@ -459,7 +459,7 @@ impl<'a> Alarm<'a> for LPCTimer<'a> {
         self.disable_interrupt();
         self.armed.set(false);
 
-        with_interrupts_disabled(|| {
+        with_interrupts_disabled(|_interrupts_disabled| {
             cortexm33::nvic::Nvic::new(CTIMER0).clear_pending();
         });
 

--- a/chips/msp432/src/chip.rs
+++ b/chips/msp432/src/chip.rs
@@ -9,6 +9,7 @@ use kernel::platform::chip::Chip;
 use crate::nvic;
 use crate::wdt;
 use kernel::platform::chip::InterruptService;
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 
 pub struct Msp432<'a, I: InterruptService + 'a> {
     mpu: cortexm4::mpu::MPU,
@@ -147,7 +148,7 @@ impl<'a, I: InterruptService + 'a> Chip for Msp432<'a, I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce() -> R,
+        F: FnOnce(&InterruptsDisabled) -> R,
     {
         cortexm4::support::with_interrupts_disabled(f)
     }

--- a/chips/msp432/src/chip.rs
+++ b/chips/msp432/src/chip.rs
@@ -8,8 +8,8 @@ use kernel::platform::chip::Chip;
 
 use crate::nvic;
 use crate::wdt;
+use kernel::context_tokens::InterruptsDisabledContext;
 use kernel::platform::chip::InterruptService;
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
 
 pub struct Msp432<'a, I: InterruptService + 'a> {
     mpu: cortexm4::mpu::MPU,
@@ -148,7 +148,7 @@ impl<'a, I: InterruptService + 'a> Chip for Msp432<'a, I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&InterruptsDisabled) -> R,
+        F: FnOnce(&InterruptsDisabledContext) -> R,
     {
         cortexm4::support::with_interrupts_disabled(f)
     }

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -7,6 +7,7 @@
 use core::fmt::Write;
 use cortexm4f::{CortexM4F, CortexMVariant, nvic};
 use kernel::platform::chip::InterruptService;
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 use kernel::utilities::StaticRef;
 
 //
@@ -195,7 +196,7 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for NRF52<'a, I>
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce() -> R,
+        F: FnOnce(&InterruptsDisabled) -> R,
     {
         cortexm4f::support::with_interrupts_disabled(f)
     }

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -6,8 +6,8 @@
 
 use core::fmt::Write;
 use cortexm4f::{CortexM4F, CortexMVariant, nvic};
+use kernel::context_tokens::InterruptsDisabledContext;
 use kernel::platform::chip::InterruptService;
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
 use kernel::utilities::StaticRef;
 
 //
@@ -196,7 +196,7 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for NRF52<'a, I>
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&InterruptsDisabled) -> R,
+        F: FnOnce(&InterruptsDisabledContext) -> R,
     {
         cortexm4f::support::with_interrupts_disabled(f)
     }

--- a/chips/nrf52/src/usbd.rs
+++ b/chips/nrf52/src/usbd.rs
@@ -791,7 +791,7 @@ impl<'a> Usbd<'a> {
     /// USBD might not reach its active state.
     fn apply_errata_171(&self, val: u32) {
         if self.has_errata_171() {
-            with_interrupts_disabled(|| {
+            with_interrupts_disabled(|_interrupts_disabled| {
                 if USBERRATA_BASE.reg_c00.get() == 0 {
                     USBERRATA_BASE.reg_c00.set(0x9375);
                     USBERRATA_BASE.reg_c14.set(val);
@@ -806,7 +806,7 @@ impl<'a> Usbd<'a> {
     /// USB cannot be enabled
     fn apply_errata_187(&self, val: u32) {
         if self.has_errata_187() {
-            with_interrupts_disabled(|| {
+            with_interrupts_disabled(|_interrupts_disabled| {
                 if USBERRATA_BASE.reg_c00.get() == 0 {
                     USBERRATA_BASE.reg_c00.set(0x9375);
                     USBERRATA_BASE.reg_d14.set(val);

--- a/chips/psc3/src/chip.rs
+++ b/chips/psc3/src/chip.rs
@@ -8,6 +8,7 @@ use core::fmt::Write;
 use kernel::hil::gpio::Configure;
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 
 use crate::cpuss_ppu;
 use crate::flashc;
@@ -149,7 +150,7 @@ impl<I: InterruptService> Chip for Psc3<'_, I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce() -> R,
+        F: FnOnce(&InterruptsDisabled) -> R,
     {
         cortexm33::support::with_interrupts_disabled(f)
     }

--- a/chips/psc3/src/chip.rs
+++ b/chips/psc3/src/chip.rs
@@ -5,10 +5,10 @@
 //! Chip trait setup and default peripheral initialization.
 
 use core::fmt::Write;
+use kernel::context_tokens::InterruptsDisabledContext;
 use kernel::hil::gpio::Configure;
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
 
 use crate::cpuss_ppu;
 use crate::flashc;
@@ -150,7 +150,7 @@ impl<I: InterruptService> Chip for Psc3<'_, I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&InterruptsDisabled) -> R,
+        F: FnOnce(&InterruptsDisabledContext) -> R,
     {
         cortexm33::support::with_interrupts_disabled(f)
     }

--- a/chips/psoc62xa/src/chip.rs
+++ b/chips/psoc62xa/src/chip.rs
@@ -4,6 +4,7 @@
 
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 
 use crate::{cpuss, gpio, hsiom, peri, scb, srss, tcpwm};
 use cortexm0p::{CortexM0P, CortexMVariant};
@@ -46,7 +47,7 @@ impl<I: InterruptService> Chip for Psoc62xa<'_, I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce() -> R,
+        F: FnOnce(&InterruptsDisabled) -> R,
     {
         cortexm0p::support::with_interrupts_disabled(f)
     }

--- a/chips/psoc62xa/src/chip.rs
+++ b/chips/psoc62xa/src/chip.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright OxidOS Automotive 2025 SRL.
 
+use kernel::context_tokens::InterruptsDisabledContext;
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
 
 use crate::{cpuss, gpio, hsiom, peri, scb, srss, tcpwm};
 use cortexm0p::{CortexM0P, CortexMVariant};
@@ -47,7 +47,7 @@ impl<I: InterruptService> Chip for Psoc62xa<'_, I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&InterruptsDisabled) -> R,
+        F: FnOnce(&InterruptsDisabledContext) -> R,
     {
         cortexm0p::support::with_interrupts_disabled(f)
     }

--- a/chips/qemu_rv32_virt_chip/src/chip.rs
+++ b/chips/qemu_rv32_virt_chip/src/chip.rs
@@ -264,9 +264,9 @@ fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDis
 /// interrupt occurs while the chip is in kernel mode.
 #[export_name = "_start_trap_rust_from_kernel"]
 pub unsafe extern "C" fn start_trap_rust() {
-    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
+    let interrupts_disabled = kernel::mint_interrupts_disabled_context!();
     match mcause::Trap::from(CSR.mcause.extract()) {
         mcause::Trap::Interrupt(interrupt) => {
             handle_interrupt(interrupt, &interrupts_disabled);
@@ -283,9 +283,9 @@ pub unsafe extern "C" fn start_trap_rust() {
 /// interrupt that fired so that it does not trigger again.
 #[export_name = "_disable_interrupt_trap_rust_from_app"]
 pub unsafe extern "C" fn disable_interrupt_trap_handler(mcause_val: u32) {
-    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
+    let interrupts_disabled = kernel::mint_interrupts_disabled_context!();
     match mcause::Trap::from(mcause_val as usize) {
         mcause::Trap::Interrupt(interrupt) => {
             handle_interrupt(interrupt, &interrupts_disabled);

--- a/chips/qemu_rv32_virt_chip/src/chip.rs
+++ b/chips/qemu_rv32_virt_chip/src/chip.rs
@@ -7,10 +7,10 @@
 use core::fmt::Write;
 use core::ptr::addr_of;
 
+use kernel::context_tokens::InterruptsDisabledContext;
 use kernel::debug;
 use kernel::hil::time::Freq10MHz;
 use kernel::platform::chip::{Chip, InterruptService};
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
 
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 
@@ -170,7 +170,7 @@ impl<'a, I: InterruptService + 'a> Chip for QemuRv32VirtChip<'a, I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&InterruptsDisabled) -> R,
+        F: FnOnce(&InterruptsDisabledContext) -> R,
     {
         rv32i::support::with_interrupts_disabled(f)
     }
@@ -205,7 +205,7 @@ fn handle_exception(exception: mcause::Exception) {
     }
 }
 
-fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDisabled) {
+fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDisabledContext) {
     match intr {
         mcause::Interrupt::UserSoft
         | mcause::Interrupt::UserTimer
@@ -228,7 +228,7 @@ fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDis
             // We received an interrupt, disable interrupts while we handle them
             CSR.mie.modify(mie::mext::CLEAR);
 
-            // Safety: interrupts are disabled (we have an InterruptsDisabled
+            // Safety: interrupts are disabled (we have an InterruptsDisabledContext
             // token), so this cannot race a concurrent access to the PLIC.
             let plic_ref = unsafe { &*addr_of!(PLIC) };
 
@@ -266,7 +266,7 @@ fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDis
 pub unsafe extern "C" fn start_trap_rust() {
     // Safety: we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
+    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
     match mcause::Trap::from(CSR.mcause.extract()) {
         mcause::Trap::Interrupt(interrupt) => {
             handle_interrupt(interrupt, &interrupts_disabled);
@@ -285,7 +285,7 @@ pub unsafe extern "C" fn start_trap_rust() {
 pub unsafe extern "C" fn disable_interrupt_trap_handler(mcause_val: u32) {
     // Safety: we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
+    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
     match mcause::Trap::from(mcause_val as usize) {
         mcause::Trap::Interrupt(interrupt) => {
             handle_interrupt(interrupt, &interrupts_disabled);

--- a/chips/qemu_rv32_virt_chip/src/chip.rs
+++ b/chips/qemu_rv32_virt_chip/src/chip.rs
@@ -100,13 +100,13 @@ impl<'a, I: InterruptService + 'a> QemuRv32VirtChip<'a, I> {
         self.plic.enable_all();
     }
 
-    unsafe fn handle_plic_interrupts(&self) {
+    fn handle_plic_interrupts(&self) {
         while let Some(interrupt) = self.plic.get_saved_interrupts() {
             if !self.plic_interrupt_service.service_interrupt(interrupt) {
                 debug!("Pidx {}", interrupt);
             }
-            self.with_interrupts_disabled(|_interrupts_disabled| {
-                self.plic.complete(interrupt);
+            self.with_interrupts_disabled(|interrupts_disabled| {
+                self.plic.complete(interrupt, interrupts_disabled);
             });
         }
     }
@@ -135,9 +135,7 @@ impl<'a, I: InterruptService + 'a> Chip for QemuRv32VirtChip<'a, I> {
                 self.timer.handle_interrupt();
             }
             if self.plic.get_saved_interrupts().is_some() {
-                unsafe {
-                    self.handle_plic_interrupts();
-                }
+                self.handle_plic_interrupts();
             }
 
             if !mip.any_matching_bits_set(mip::mtimer::SET)
@@ -207,7 +205,7 @@ fn handle_exception(exception: mcause::Exception) {
     }
 }
 
-unsafe fn handle_interrupt(intr: mcause::Interrupt) {
+fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDisabled) {
     match intr {
         mcause::Interrupt::UserSoft
         | mcause::Interrupt::UserTimer
@@ -230,16 +228,19 @@ unsafe fn handle_interrupt(intr: mcause::Interrupt) {
             // We received an interrupt, disable interrupts while we handle them
             CSR.mie.modify(mie::mext::CLEAR);
 
+            // Safety: interrupts are disabled (we have an InterruptsDisabled
+            // token), so this cannot race a concurrent access to the PLIC.
+            let plic_ref = unsafe { &*addr_of!(PLIC) };
+
             // Claim the interrupt, unwrap() as we know an interrupt exists
             // Once claimed this interrupt won't fire until it's completed
             // NOTE: The interrupt is no longer pending in the PLIC
             loop {
-                let interrupt = (*addr_of!(PLIC)).next_pending();
+                let interrupt = plic_ref.next_pending();
 
                 match interrupt {
                     Some(irq) => {
-                        // Safe as interrupts are disabled
-                        (*addr_of!(PLIC)).save_interrupt(irq);
+                        plic_ref.save_interrupt(irq, interrupts_disabled);
                     }
                     None => {
                         // Enable generic interrupts
@@ -263,9 +264,12 @@ unsafe fn handle_interrupt(intr: mcause::Interrupt) {
 /// interrupt occurs while the chip is in kernel mode.
 #[export_name = "_start_trap_rust_from_kernel"]
 pub unsafe extern "C" fn start_trap_rust() {
+    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // `mstatus.MIE` on trap entry before any Rust code runs.
+    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
     match mcause::Trap::from(CSR.mcause.extract()) {
         mcause::Trap::Interrupt(interrupt) => {
-            handle_interrupt(interrupt);
+            handle_interrupt(interrupt, &interrupts_disabled);
         }
         mcause::Trap::Exception(exception) => {
             handle_exception(exception);
@@ -279,9 +283,12 @@ pub unsafe extern "C" fn start_trap_rust() {
 /// interrupt that fired so that it does not trigger again.
 #[export_name = "_disable_interrupt_trap_rust_from_app"]
 pub unsafe extern "C" fn disable_interrupt_trap_handler(mcause_val: u32) {
+    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // `mstatus.MIE` on trap entry before any Rust code runs.
+    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
     match mcause::Trap::from(mcause_val as usize) {
         mcause::Trap::Interrupt(interrupt) => {
-            handle_interrupt(interrupt);
+            handle_interrupt(interrupt, &interrupts_disabled);
         }
         _ => {
             panic!("unexpected non-interrupt\n");

--- a/chips/qemu_rv32_virt_chip/src/chip.rs
+++ b/chips/qemu_rv32_virt_chip/src/chip.rs
@@ -10,6 +10,7 @@ use core::ptr::addr_of;
 use kernel::debug;
 use kernel::hil::time::Freq10MHz;
 use kernel::platform::chip::{Chip, InterruptService};
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 
@@ -104,7 +105,7 @@ impl<'a, I: InterruptService + 'a> QemuRv32VirtChip<'a, I> {
             if !self.plic_interrupt_service.service_interrupt(interrupt) {
                 debug!("Pidx {}", interrupt);
             }
-            self.with_interrupts_disabled(|| {
+            self.with_interrupts_disabled(|_interrupts_disabled| {
                 self.plic.complete(interrupt);
             });
         }
@@ -171,7 +172,7 @@ impl<'a, I: InterruptService + 'a> Chip for QemuRv32VirtChip<'a, I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce() -> R,
+        F: FnOnce(&InterruptsDisabled) -> R,
     {
         rv32i::support::with_interrupts_disabled(f)
     }

--- a/chips/qemu_rv64_virt_chip/src/chip.rs
+++ b/chips/qemu_rv64_virt_chip/src/chip.rs
@@ -261,9 +261,9 @@ fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDis
 /// interrupt occurs while the chip is in kernel mode.
 #[export_name = "_start_trap_rust_from_kernel"]
 pub unsafe extern "C" fn start_trap_rust() {
-    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
+    let interrupts_disabled = kernel::mint_interrupts_disabled_context!();
     match mcause::Trap::from(CSR.mcause.extract()) {
         mcause::Trap::Interrupt(interrupt) => {
             handle_interrupt(interrupt, &interrupts_disabled);
@@ -280,9 +280,9 @@ pub unsafe extern "C" fn start_trap_rust() {
 /// interrupt that fired so that it does not trigger again.
 #[export_name = "_disable_interrupt_trap_rust_from_app"]
 pub unsafe extern "C" fn disable_interrupt_trap_handler(mcause_val: u64) {
-    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
+    let interrupts_disabled = kernel::mint_interrupts_disabled_context!();
     match mcause::Trap::from(mcause_val as usize) {
         mcause::Trap::Interrupt(interrupt) => {
             handle_interrupt(interrupt, &interrupts_disabled);

--- a/chips/qemu_rv64_virt_chip/src/chip.rs
+++ b/chips/qemu_rv64_virt_chip/src/chip.rs
@@ -7,10 +7,10 @@
 use core::fmt::Write;
 use core::ptr::addr_of;
 
+use kernel::context_tokens::InterruptsDisabledContext;
 use kernel::debug;
 use kernel::hil::time::Freq10MHz;
 use kernel::platform::chip::{Chip, InterruptService};
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
 
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 
@@ -167,7 +167,7 @@ impl<'a, I: InterruptService + 'a> Chip for QemuRv64VirtChip<'a, I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&InterruptsDisabled) -> R,
+        F: FnOnce(&InterruptsDisabledContext) -> R,
     {
         rv64i::support::with_interrupts_disabled(f)
     }
@@ -202,7 +202,7 @@ fn handle_exception(exception: mcause::Exception) {
     }
 }
 
-fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDisabled) {
+fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDisabledContext) {
     match intr {
         mcause::Interrupt::UserSoft
         | mcause::Interrupt::UserTimer
@@ -225,7 +225,7 @@ fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDis
             // We received an interrupt, disable interrupts while we handle them
             CSR.mie.modify(mie::mext::CLEAR);
 
-            // Safety: interrupts are disabled (we have an InterruptsDisabled
+            // Safety: interrupts are disabled (we have an InterruptsDisabledContext
             // token), so this cannot race a concurrent access to the PLIC.
             let plic_ref = unsafe { &*addr_of!(PLIC) };
 
@@ -263,7 +263,7 @@ fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDis
 pub unsafe extern "C" fn start_trap_rust() {
     // Safety: we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
+    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
     match mcause::Trap::from(CSR.mcause.extract()) {
         mcause::Trap::Interrupt(interrupt) => {
             handle_interrupt(interrupt, &interrupts_disabled);
@@ -282,7 +282,7 @@ pub unsafe extern "C" fn start_trap_rust() {
 pub unsafe extern "C" fn disable_interrupt_trap_handler(mcause_val: u64) {
     // Safety: we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
+    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
     match mcause::Trap::from(mcause_val as usize) {
         mcause::Trap::Interrupt(interrupt) => {
             handle_interrupt(interrupt, &interrupts_disabled);

--- a/chips/qemu_rv64_virt_chip/src/chip.rs
+++ b/chips/qemu_rv64_virt_chip/src/chip.rs
@@ -10,6 +10,7 @@ use core::ptr::addr_of;
 use kernel::debug;
 use kernel::hil::time::Freq10MHz;
 use kernel::platform::chip::{Chip, InterruptService};
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 
@@ -101,7 +102,7 @@ impl<'a, I: InterruptService + 'a> QemuRv64VirtChip<'a, I> {
             if !self.plic_interrupt_service.service_interrupt(interrupt) {
                 debug!("Pidx {}", interrupt);
             }
-            self.with_interrupts_disabled(|| {
+            self.with_interrupts_disabled(|_interrupts_disabled| {
                 self.plic.complete(interrupt);
             });
         }
@@ -168,7 +169,7 @@ impl<'a, I: InterruptService + 'a> Chip for QemuRv64VirtChip<'a, I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce() -> R,
+        F: FnOnce(&InterruptsDisabled) -> R,
     {
         rv64i::support::with_interrupts_disabled(f)
     }

--- a/chips/qemu_rv64_virt_chip/src/chip.rs
+++ b/chips/qemu_rv64_virt_chip/src/chip.rs
@@ -97,13 +97,13 @@ impl<'a, I: InterruptService + 'a> QemuRv64VirtChip<'a, I> {
         self.plic.enable_all();
     }
 
-    unsafe fn handle_plic_interrupts(&self) {
+    fn handle_plic_interrupts(&self) {
         while let Some(interrupt) = self.plic.get_saved_interrupts() {
             if !self.plic_interrupt_service.service_interrupt(interrupt) {
                 debug!("Pidx {}", interrupt);
             }
-            self.with_interrupts_disabled(|_interrupts_disabled| {
-                self.plic.complete(interrupt);
+            self.with_interrupts_disabled(|interrupts_disabled| {
+                self.plic.complete(interrupt, interrupts_disabled);
             });
         }
     }
@@ -132,9 +132,7 @@ impl<'a, I: InterruptService + 'a> Chip for QemuRv64VirtChip<'a, I> {
                 self.timer.handle_interrupt();
             }
             if self.plic.get_saved_interrupts().is_some() {
-                unsafe {
-                    self.handle_plic_interrupts();
-                }
+                self.handle_plic_interrupts();
             }
 
             if !mip.any_matching_bits_set(mip::mtimer::SET)
@@ -204,7 +202,7 @@ fn handle_exception(exception: mcause::Exception) {
     }
 }
 
-unsafe fn handle_interrupt(intr: mcause::Interrupt) {
+fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDisabled) {
     match intr {
         mcause::Interrupt::UserSoft
         | mcause::Interrupt::UserTimer
@@ -227,16 +225,19 @@ unsafe fn handle_interrupt(intr: mcause::Interrupt) {
             // We received an interrupt, disable interrupts while we handle them
             CSR.mie.modify(mie::mext::CLEAR);
 
+            // Safety: interrupts are disabled (we have an InterruptsDisabled
+            // token), so this cannot race a concurrent access to the PLIC.
+            let plic_ref = unsafe { &*addr_of!(PLIC) };
+
             // Claim the interrupt, unwrap() as we know an interrupt exists
             // Once claimed this interrupt won't fire until it's completed
             // NOTE: The interrupt is no longer pending in the PLIC
             loop {
-                let interrupt = (*addr_of!(PLIC)).next_pending();
+                let interrupt = plic_ref.next_pending();
 
                 match interrupt {
                     Some(irq) => {
-                        // Safe as interrupts are disabled
-                        (*addr_of!(PLIC)).save_interrupt(irq);
+                        plic_ref.save_interrupt(irq, interrupts_disabled);
                     }
                     None => {
                         // Enable generic interrupts
@@ -260,9 +261,12 @@ unsafe fn handle_interrupt(intr: mcause::Interrupt) {
 /// interrupt occurs while the chip is in kernel mode.
 #[export_name = "_start_trap_rust_from_kernel"]
 pub unsafe extern "C" fn start_trap_rust() {
+    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // `mstatus.MIE` on trap entry before any Rust code runs.
+    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
     match mcause::Trap::from(CSR.mcause.extract()) {
         mcause::Trap::Interrupt(interrupt) => {
-            handle_interrupt(interrupt);
+            handle_interrupt(interrupt, &interrupts_disabled);
         }
         mcause::Trap::Exception(exception) => {
             handle_exception(exception);
@@ -276,9 +280,12 @@ pub unsafe extern "C" fn start_trap_rust() {
 /// interrupt that fired so that it does not trigger again.
 #[export_name = "_disable_interrupt_trap_rust_from_app"]
 pub unsafe extern "C" fn disable_interrupt_trap_handler(mcause_val: u64) {
+    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // `mstatus.MIE` on trap entry before any Rust code runs.
+    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
     match mcause::Trap::from(mcause_val as usize) {
         mcause::Trap::Interrupt(interrupt) => {
-            handle_interrupt(interrupt);
+            handle_interrupt(interrupt, &interrupts_disabled);
         }
         _ => {
             panic!("unexpected non-interrupt\n");

--- a/chips/rp2040/src/chip.rs
+++ b/chips/rp2040/src/chip.rs
@@ -5,9 +5,9 @@
 //! Chip trait setup.
 
 use core::fmt::Write;
+use kernel::context_tokens::InterruptsDisabledContext;
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
 
 use crate::adc;
 use crate::clocks::Clocks;
@@ -121,7 +121,7 @@ impl<I: InterruptService> Chip for Rp2040<'_, I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&InterruptsDisabled) -> R,
+        F: FnOnce(&InterruptsDisabledContext) -> R,
     {
         cortexm0p::support::with_interrupts_disabled(f)
     }

--- a/chips/rp2040/src/chip.rs
+++ b/chips/rp2040/src/chip.rs
@@ -7,6 +7,7 @@
 use core::fmt::Write;
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 
 use crate::adc;
 use crate::clocks::Clocks;
@@ -120,7 +121,7 @@ impl<I: InterruptService> Chip for Rp2040<'_, I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce() -> R,
+        F: FnOnce(&InterruptsDisabled) -> R,
     {
         cortexm0p::support::with_interrupts_disabled(f)
     }

--- a/chips/rp2040/src/timer.rs
+++ b/chips/rp2040/src/timer.rs
@@ -199,7 +199,7 @@ impl<'a> RPTimer<'a> {
         // Failing to do so results in the interrupt being set as pending but
         // not fired. This means that the interrupt will be handled whenever the
         // next kernel tasks are processed.
-        with_interrupts_disabled(|| {
+        with_interrupts_disabled(|_interrupts_disabled| {
             let n = cortexm0p::nvic::Nvic::new(TIMER_IRQ_0);
             n.enable();
         })
@@ -254,7 +254,7 @@ impl<'a> Alarm<'a> for RPTimer<'a> {
 
     fn disarm(&self) -> Result<(), ErrorCode> {
         self.registers.armed.set(1);
-        with_interrupts_disabled(|| {
+        with_interrupts_disabled(|_interrupts_disabled| {
             // Clear pending interrupts
             cortexm0p::nvic::Nvic::new(TIMER_IRQ_0).clear_pending();
         });

--- a/chips/rp2350/src/chip.rs
+++ b/chips/rp2350/src/chip.rs
@@ -7,6 +7,7 @@
 use core::fmt::Write;
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 
 use crate::clocks::Clocks;
 use crate::gpio::{RPPins, SIO};
@@ -106,7 +107,7 @@ impl<I: InterruptService> Chip for Rp2350<'_, I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce() -> R,
+        F: FnOnce(&InterruptsDisabled) -> R,
     {
         cortexm33::support::with_interrupts_disabled(f)
     }

--- a/chips/rp2350/src/chip.rs
+++ b/chips/rp2350/src/chip.rs
@@ -5,9 +5,9 @@
 //! Chip trait setup.
 
 use core::fmt::Write;
+use kernel::context_tokens::InterruptsDisabledContext;
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
 
 use crate::clocks::Clocks;
 use crate::gpio::{RPPins, SIO};
@@ -107,7 +107,7 @@ impl<I: InterruptService> Chip for Rp2350<'_, I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&InterruptsDisabled) -> R,
+        F: FnOnce(&InterruptsDisabledContext) -> R,
     {
         cortexm33::support::with_interrupts_disabled(f)
     }

--- a/chips/rp2350/src/timer.rs
+++ b/chips/rp2350/src/timer.rs
@@ -197,7 +197,7 @@ impl<'a> RPTimer<'a> {
         // Failing to do so results in the interrupt being set as pending but
         // not fired. This means that the interrupt will be handled whenever the
         // next kernel tasks are processed.
-        with_interrupts_disabled(|| {
+        with_interrupts_disabled(|_interrupts_disabled| {
             cortexm33::nvic::Nvic::new(TIMER0_IRQ_0).enable();
         })
     }
@@ -251,7 +251,7 @@ impl<'a> Alarm<'a> for RPTimer<'a> {
 
     fn disarm(&self) -> Result<(), ErrorCode> {
         self.registers.armed.set(1);
-        with_interrupts_disabled(|| {
+        with_interrupts_disabled(|_interrupts_disabled| {
             // Clear pending interrupts
             cortexm33::nvic::Nvic::new(TIMER0_IRQ_0).clear_pending();
         });

--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -8,8 +8,8 @@ use crate::pm;
 
 use core::fmt::Write;
 use cortexm4::{CortexM4, CortexMVariant};
+use kernel::context_tokens::InterruptsDisabledContext;
 use kernel::platform::chip::{Chip, InterruptService};
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
 
 pub struct Sam4l<I: InterruptService + 'static> {
     mpu: cortexm4::mpu::MPU,
@@ -289,7 +289,7 @@ impl<I: InterruptService + 'static> Chip for Sam4l<I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&InterruptsDisabled) -> R,
+        F: FnOnce(&InterruptsDisabledContext) -> R,
     {
         cortexm4::support::with_interrupts_disabled(f)
     }

--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -9,6 +9,7 @@ use crate::pm;
 use core::fmt::Write;
 use cortexm4::{CortexM4, CortexMVariant};
 use kernel::platform::chip::{Chip, InterruptService};
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 
 pub struct Sam4l<I: InterruptService + 'static> {
     mpu: cortexm4::mpu::MPU,
@@ -288,7 +289,7 @@ impl<I: InterruptService + 'static> Chip for Sam4l<I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce() -> R,
+        F: FnOnce(&InterruptsDisabled) -> R,
     {
         cortexm4::support::with_interrupts_disabled(f)
     }

--- a/chips/sifive/src/plic.rs
+++ b/chips/sifive/src/plic.rs
@@ -4,9 +4,9 @@
 
 //! Platform Level Interrupt Control peripheral driver.
 
-use core::cell::Cell;
-
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 use kernel::utilities::StaticRef;
+use kernel::utilities::interrupts_disabled_cell::InterruptsDisabledCell;
 use kernel::utilities::registers::LocalRegisterCopy;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 use kernel::utilities::registers::{ReadOnly, ReadWrite, register_bitfields};
@@ -110,7 +110,7 @@ register_bitfields![u32,
 /// platforms implemented without the generic parameter.
 pub struct Plic<const TOTAL_INTS: usize = 51> {
     registers: RegsWrapper,
-    saved: [Cell<LocalRegisterCopy<u32>>; 2],
+    saved: [InterruptsDisabledCell<LocalRegisterCopy<u32>>; 2],
 }
 
 impl<const TOTAL_INTS: usize> Plic<TOTAL_INTS> {
@@ -118,8 +118,8 @@ impl<const TOTAL_INTS: usize> Plic<TOTAL_INTS> {
         Plic {
             registers: RegsWrapper::new(base, TOTAL_INTS),
             saved: [
-                Cell::new(LocalRegisterCopy::new(0)),
-                Cell::new(LocalRegisterCopy::new(0)),
+                InterruptsDisabledCell::new(LocalRegisterCopy::new(0)),
+                InterruptsDisabledCell::new(LocalRegisterCopy::new(0)),
             ],
         }
     }
@@ -211,18 +211,16 @@ impl<const TOTAL_INTS: usize> Plic<TOTAL_INTS> {
 
     /// Save the current interrupt to be handled later
     /// This will save the interrupt at index internally to be handled later.
-    /// Interrupts must be disabled before this is called.
     /// Saved interrupts can be retrieved by calling `get_saved_interrupts()`.
     /// Saved interrupts are cleared when `'complete()` is called.
-    pub unsafe fn save_interrupt(&self, index: u32) {
+    pub fn save_interrupt(&self, index: u32, interrupts_disabled: &InterruptsDisabled) {
         let offset = usize::from(index >= 32);
         let irq = index % 32;
 
-        // OR the current saved state with the new value
-        let new_saved = self.saved[offset].get().get() | 1 << irq;
-
-        // Set the new state
-        self.saved[offset].set(LocalRegisterCopy::new(new_saved));
+        self.saved[offset].update(
+            |val| LocalRegisterCopy::new(val.get() | 1 << irq),
+            interrupts_disabled,
+        );
     }
 
     /// The `next_pending()` function will only return enabled interrupts.
@@ -241,18 +239,16 @@ impl<const TOTAL_INTS: usize> Plic<TOTAL_INTS> {
 
     /// Signal that an interrupt is finished being handled. In Tock, this should be
     /// called from the normal main loop (not the interrupt handler).
-    /// Interrupts must be disabled before this is called.
-    pub unsafe fn complete(&self, index: u32) {
+    pub fn complete(&self, index: u32, interrupts_disabled: &InterruptsDisabled) {
         self.registers.get_claim_reg().set(index);
 
         let offset = usize::from(index >= 32);
         let irq = index % 32;
 
-        // OR the current saved state with the new value
-        let new_saved = self.saved[offset].get().get() & !(1 << irq);
-
-        // Set the new state
-        self.saved[offset].set(LocalRegisterCopy::new(new_saved));
+        self.saved[offset].update(
+            |val| LocalRegisterCopy::new(val.get() & !(1 << irq)),
+            interrupts_disabled,
+        );
     }
 
     /// This is a generic implementation. There may be board specific versions as

--- a/chips/sifive/src/plic.rs
+++ b/chips/sifive/src/plic.rs
@@ -4,7 +4,7 @@
 
 //! Platform Level Interrupt Control peripheral driver.
 
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
+use kernel::context_tokens::InterruptsDisabledContext;
 use kernel::utilities::StaticRef;
 use kernel::utilities::interrupts_disabled_cell::InterruptsDisabledCell;
 use kernel::utilities::registers::LocalRegisterCopy;
@@ -213,7 +213,7 @@ impl<const TOTAL_INTS: usize> Plic<TOTAL_INTS> {
     /// This will save the interrupt at index internally to be handled later.
     /// Saved interrupts can be retrieved by calling `get_saved_interrupts()`.
     /// Saved interrupts are cleared when `'complete()` is called.
-    pub fn save_interrupt(&self, index: u32, interrupts_disabled: &InterruptsDisabled) {
+    pub fn save_interrupt(&self, index: u32, interrupts_disabled: &InterruptsDisabledContext) {
         let offset = usize::from(index >= 32);
         let irq = index % 32;
 
@@ -239,7 +239,7 @@ impl<const TOTAL_INTS: usize> Plic<TOTAL_INTS> {
 
     /// Signal that an interrupt is finished being handled. In Tock, this should be
     /// called from the normal main loop (not the interrupt handler).
-    pub fn complete(&self, index: u32, interrupts_disabled: &InterruptsDisabled) {
+    pub fn complete(&self, index: u32, interrupts_disabled: &InterruptsDisabledContext) {
         self.registers.get_claim_reg().set(index);
 
         let offset = usize::from(index >= 32);

--- a/chips/stm32f303xc/src/chip.rs
+++ b/chips/stm32f303xc/src/chip.rs
@@ -6,9 +6,9 @@
 
 use core::fmt::Write;
 use cortexm4f::{CortexM4F, CortexMVariant};
+use kernel::context_tokens::InterruptsDisabledContext;
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
 
 use crate::nvic;
 
@@ -145,7 +145,7 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32f3xx<'a, I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&InterruptsDisabled) -> R,
+        F: FnOnce(&InterruptsDisabledContext) -> R,
     {
         cortexm4f::support::with_interrupts_disabled(f)
     }

--- a/chips/stm32f303xc/src/chip.rs
+++ b/chips/stm32f303xc/src/chip.rs
@@ -8,6 +8,7 @@ use core::fmt::Write;
 use cortexm4f::{CortexM4F, CortexMVariant};
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 
 use crate::nvic;
 
@@ -144,7 +145,7 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32f3xx<'a, I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce() -> R,
+        F: FnOnce(&InterruptsDisabled) -> R,
     {
         cortexm4f::support::with_interrupts_disabled(f)
     }

--- a/chips/stm32f303xc/src/exti.rs
+++ b/chips/stm32f303xc/src/exti.rs
@@ -701,7 +701,7 @@ impl<'a> Exti<'a> {
         // changed due to an external interrupt. `EXTI_PR` is a read/clear write
         // 1 register (`rc_w1`). So, we only clear bits whose value has been
         // transferred to `exti_pr`.
-        with_interrupts_disabled(|| {
+        with_interrupts_disabled(|_interrupts_disabled| {
             exti_pr = self.registers.pr1.get();
             self.registers.pr1.set(exti_pr);
         });

--- a/chips/stm32f303xc/src/gpio.rs
+++ b/chips/stm32f303xc/src/gpio.rs
@@ -1114,7 +1114,7 @@ impl hil::gpio::Input for Pin<'_> {
 
 impl<'a> hil::gpio::Interrupt<'a> for Pin<'a> {
     fn enable_interrupts(&self, mode: hil::gpio::InterruptEdge) {
-        with_interrupts_disabled(|| {
+        with_interrupts_disabled(|_interrupts_disabled| {
             self.exti_lineid.map(|lineid| {
                 let l = lineid;
 
@@ -1143,7 +1143,7 @@ impl<'a> hil::gpio::Interrupt<'a> for Pin<'a> {
     }
 
     fn disable_interrupts(&self) {
-        with_interrupts_disabled(|| {
+        with_interrupts_disabled(|_interrupts_disabled| {
             self.exti_lineid.map(|lineid| {
                 let l = lineid;
                 self.exti.mask_interrupt(l);

--- a/chips/stm32f303xc/src/tim2.rs
+++ b/chips/stm32f303xc/src/tim2.rs
@@ -423,7 +423,7 @@ impl<'a> Alarm<'a> for Tim2<'a> {
     }
 
     fn disarm(&self) -> Result<(), ErrorCode> {
-        with_interrupts_disabled(|| {
+        with_interrupts_disabled(|_interrupts_disabled| {
             // Disable counter
             self.registers.dier.modify(DIER::CC1IE::CLEAR);
             cortexm4f::nvic::Nvic::new(self.irqn).clear_pending();

--- a/chips/stm32f4xx/src/chip.rs
+++ b/chips/stm32f4xx/src/chip.rs
@@ -6,9 +6,9 @@
 
 use core::fmt::Write;
 use cortexm4f::{CortexM4F, CortexMVariant};
+use kernel::context_tokens::InterruptsDisabledContext;
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
 
 use crate::dma;
 use crate::nvic;
@@ -207,7 +207,7 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32f4xx<'a, I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&InterruptsDisabled) -> R,
+        F: FnOnce(&InterruptsDisabledContext) -> R,
     {
         cortexm4f::support::with_interrupts_disabled(f)
     }

--- a/chips/stm32f4xx/src/chip.rs
+++ b/chips/stm32f4xx/src/chip.rs
@@ -8,6 +8,7 @@ use core::fmt::Write;
 use cortexm4f::{CortexM4F, CortexMVariant};
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 
 use crate::dma;
 use crate::nvic;
@@ -206,7 +207,7 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32f4xx<'a, I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce() -> R,
+        F: FnOnce(&InterruptsDisabled) -> R,
     {
         cortexm4f::support::with_interrupts_disabled(f)
     }

--- a/chips/stm32f4xx/src/exti.rs
+++ b/chips/stm32f4xx/src/exti.rs
@@ -584,7 +584,7 @@ impl<'a> Exti<'a> {
         // changed due to an external interrupt. `EXTI_PR` is a read/clear write
         // 1 register (`rc_w1`). So, we only clear bits whose value has been
         // transferred to `exti_pr`.
-        with_interrupts_disabled(|| {
+        with_interrupts_disabled(|_interrupts_disabled| {
             exti_pr = self.registers.pr.get();
             self.registers.pr.set(exti_pr);
         });

--- a/chips/stm32f4xx/src/gpio.rs
+++ b/chips/stm32f4xx/src/gpio.rs
@@ -1201,7 +1201,7 @@ impl hil::gpio::Input for Pin<'_> {
 
 impl<'a> hil::gpio::Interrupt<'a> for Pin<'a> {
     fn enable_interrupts(&self, mode: hil::gpio::InterruptEdge) {
-        with_interrupts_disabled(|| {
+        with_interrupts_disabled(|_interrupts_disabled| {
             self.exti_lineid.map(|lineid| {
                 let l = lineid;
 
@@ -1230,7 +1230,7 @@ impl<'a> hil::gpio::Interrupt<'a> for Pin<'a> {
     }
 
     fn disable_interrupts(&self) {
-        with_interrupts_disabled(|| {
+        with_interrupts_disabled(|_interrupts_disabled| {
             self.exti_lineid.map(|lineid| {
                 let l = lineid;
                 self.exti.mask_interrupt(l);

--- a/chips/stm32f4xx/src/tim2.rs
+++ b/chips/stm32f4xx/src/tim2.rs
@@ -443,7 +443,7 @@ impl<'a> Alarm<'a> for Tim2<'a> {
     }
 
     fn disarm(&self) -> Result<(), ErrorCode> {
-        with_interrupts_disabled(|| {
+        with_interrupts_disabled(|_interrupts_disabled| {
             // Disable counter
             self.registers.dier.modify(DIER::CC1IE::CLEAR);
             cortexm4f::nvic::Nvic::new(self.irqn).clear_pending();

--- a/chips/stm32u5xx/src/chip.rs
+++ b/chips/stm32u5xx/src/chip.rs
@@ -32,6 +32,7 @@ use kernel::hil::spi::SpiMaster;
 use kernel::hil::symmetric_encryption::AES256;
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 use stm32u5xx_unsafe::aes::AES_BASE;
 
 pub struct Stm32u5xx<'a, I: InterruptService + 'a> {
@@ -434,7 +435,7 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32u5xx<'a, I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce() -> R,
+        F: FnOnce(&InterruptsDisabled) -> R,
     {
         cortexm33::support::with_interrupts_disabled(f)
     }

--- a/chips/stm32u5xx/src/chip.rs
+++ b/chips/stm32u5xx/src/chip.rs
@@ -27,12 +27,12 @@ use crate::usart;
 use crate::{aes, dac, exti, rsa};
 
 use core::fmt::Write;
+use kernel::context_tokens::InterruptsDisabledContext;
 use kernel::deferred_call::DeferredCallClient;
 use kernel::hil::spi::SpiMaster;
 use kernel::hil::symmetric_encryption::AES256;
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
 use stm32u5xx_unsafe::aes::AES_BASE;
 
 pub struct Stm32u5xx<'a, I: InterruptService + 'a> {
@@ -435,7 +435,7 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32u5xx<'a, I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&InterruptsDisabled) -> R,
+        F: FnOnce(&InterruptsDisabledContext) -> R,
     {
         cortexm33::support::with_interrupts_disabled(f)
     }

--- a/chips/stm32wle5xx/src/chip.rs
+++ b/chips/stm32wle5xx/src/chip.rs
@@ -6,9 +6,9 @@
 
 use core::fmt::Write;
 use cortexm4::{CortexM4, CortexMVariant};
+use kernel::context_tokens::InterruptsDisabledContext;
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
 
 use crate::chip_specific::chip_specs::ChipSpecs as ChipSpecsTrait;
 use crate::nvic;
@@ -173,7 +173,7 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32wle5xx<'a, I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&InterruptsDisabled) -> R,
+        F: FnOnce(&InterruptsDisabledContext) -> R,
     {
         cortexm4::support::with_interrupts_disabled(f)
     }

--- a/chips/stm32wle5xx/src/chip.rs
+++ b/chips/stm32wle5xx/src/chip.rs
@@ -8,6 +8,7 @@ use core::fmt::Write;
 use cortexm4::{CortexM4, CortexMVariant};
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 
 use crate::chip_specific::chip_specs::ChipSpecs as ChipSpecsTrait;
 use crate::nvic;
@@ -172,7 +173,7 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32wle5xx<'a, I> {
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce() -> R,
+        F: FnOnce(&InterruptsDisabled) -> R,
     {
         cortexm4::support::with_interrupts_disabled(f)
     }

--- a/chips/stm32wle5xx/src/exti.rs
+++ b/chips/stm32wle5xx/src/exti.rs
@@ -620,7 +620,7 @@ impl<'a> Exti<'a> {
         // changed due to an external interrupt. `EXTI_PR` is a read/clear write
         // 1 register (`rc_w1`). So, we only clear bits whose value has been
         // transferred to `exti_pr`.
-        with_interrupts_disabled(|| {
+        with_interrupts_disabled(|_interrupts_disabled| {
             exti_pr = self.registers.pr1.get();
             self.registers.pr1.set(exti_pr);
         });

--- a/chips/stm32wle5xx/src/gpio.rs
+++ b/chips/stm32wle5xx/src/gpio.rs
@@ -1105,7 +1105,7 @@ impl hil::gpio::Input for Pin<'_> {
 
 impl<'a> hil::gpio::Interrupt<'a> for Pin<'a> {
     fn enable_interrupts(&self, mode: hil::gpio::InterruptEdge) {
-        with_interrupts_disabled(|| {
+        with_interrupts_disabled(|_interrupts_disabled| {
             self.exti_lineid.map(|lineid| {
                 let l = lineid;
 
@@ -1134,7 +1134,7 @@ impl<'a> hil::gpio::Interrupt<'a> for Pin<'a> {
     }
 
     fn disable_interrupts(&self) {
-        with_interrupts_disabled(|| {
+        with_interrupts_disabled(|_interrupts_disabled| {
             self.exti_lineid.map(|lineid| {
                 let l = lineid;
                 self.exti.mask_interrupt(l);

--- a/chips/stm32wle5xx/src/tim2.rs
+++ b/chips/stm32wle5xx/src/tim2.rs
@@ -425,7 +425,7 @@ impl<'a> Alarm<'a> for Tim2<'a> {
     }
 
     fn disarm(&self) -> Result<(), ErrorCode> {
-        with_interrupts_disabled(|| {
+        with_interrupts_disabled(|_interrupts_disabled| {
             // Disable counter
             self.registers.dier.modify(DIER::CC1IE::CLEAR);
             cortexm4::nvic::Nvic::new(self.irqn).clear_pending();

--- a/chips/veer_el2/src/chip.rs
+++ b/chips/veer_el2/src/chip.rs
@@ -73,14 +73,13 @@ impl<'a, I: InterruptService + 'a> VeeR<'a, I> {
         pic.enable_all();
     }
 
-    unsafe fn handle_pic_interrupts(&self, pic: &Pic) {
+    fn handle_pic_interrupts(&self, pic: &Pic) {
         while let Some(interrupt) = pic.get_saved_interrupts() {
             if !self.pic_interrupt_service.service_interrupt(interrupt) {
                 panic!("Unhandled interrupt {}", interrupt);
             }
-            self.with_interrupts_disabled(|_interrupts_disabled| {
-                // Safe as interrupts are disabled
-                pic.complete(interrupt);
+            self.with_interrupts_disabled(|interrupts_disabled| {
+                pic.complete(interrupt, interrupts_disabled);
             });
         }
     }
@@ -113,9 +112,7 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for VeeR<'a, I> 
                 self.mtimer.handle_interrupt();
             }
             if pic.get_saved_interrupts().is_some() {
-                unsafe {
-                    self.handle_pic_interrupts(&pic);
-                }
+                self.handle_pic_interrupts(&pic);
             }
 
             if !mip.any_matching_bits_set(mip::mtimer::SET) && pic.get_saved_interrupts().is_none()
@@ -175,7 +172,7 @@ fn handle_exception(exception: mcause::Exception) {
     }
 }
 
-unsafe fn handle_interrupt(intr: mcause::Interrupt) {
+fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDisabled) {
     match intr {
         mcause::Interrupt::UserSoft
         | mcause::Interrupt::UserTimer
@@ -209,8 +206,7 @@ unsafe fn handle_interrupt(intr: mcause::Interrupt) {
 
                 match interrupt {
                     Some(irq) => {
-                        // Safe as interrupts are disabled
-                        pic.save_interrupt(irq);
+                        pic.save_interrupt(irq, interrupts_disabled);
                     }
                     None => {
                         // Enable generic interrupts
@@ -236,9 +232,12 @@ unsafe fn handle_interrupt(intr: mcause::Interrupt) {
 /// Accesses CSRs.
 #[export_name = "_start_trap_rust_from_kernel"]
 pub unsafe extern "C" fn start_trap_rust() {
+    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // `mstatus.MIE` on trap entry before any Rust code runs.
+    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
     match mcause::Trap::from(CSR.mcause.extract()) {
         mcause::Trap::Interrupt(interrupt) => {
-            handle_interrupt(interrupt);
+            handle_interrupt(interrupt, &interrupts_disabled);
         }
         mcause::Trap::Exception(exception) => {
             handle_exception(exception);
@@ -252,10 +251,13 @@ pub unsafe extern "C" fn start_trap_rust() {
 /// interrupt that fired so that it does not trigger again.
 #[export_name = "_disable_interrupt_trap_rust_from_app"]
 pub unsafe extern "C" fn disable_interrupt_trap_handler(mcause_val: u32) {
+    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // `mstatus.MIE` on trap entry before any Rust code runs.
+    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
     match mcause::Trap::from(mcause_val as usize) {
-        mcause::Trap::Interrupt(interrupt) => unsafe {
-            handle_interrupt(interrupt);
-        },
+        mcause::Trap::Interrupt(interrupt) => {
+            handle_interrupt(interrupt, &interrupts_disabled);
+        }
         _ => {
             panic!("unexpected non-interrupt\n");
         }

--- a/chips/veer_el2/src/chip.rs
+++ b/chips/veer_el2/src/chip.rs
@@ -7,8 +7,8 @@
 
 use crate::machine_timer::Clint;
 use core::fmt::Write;
+use kernel::context_tokens::InterruptsDisabledContext;
 use kernel::platform::chip::{Chip, InterruptService};
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
 use kernel::utilities::StaticRef;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 use rv32i::csr::{CSR, mcause, mie::mie, mip::mip};
@@ -140,7 +140,7 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for VeeR<'a, I> 
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&InterruptsDisabled) -> R,
+        F: FnOnce(&InterruptsDisabledContext) -> R,
     {
         rv32i::support::with_interrupts_disabled(f)
     }
@@ -172,7 +172,7 @@ fn handle_exception(exception: mcause::Exception) {
     }
 }
 
-fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDisabled) {
+fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDisabledContext) {
     match intr {
         mcause::Interrupt::UserSoft
         | mcause::Interrupt::UserTimer
@@ -234,7 +234,7 @@ fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDis
 pub unsafe extern "C" fn start_trap_rust() {
     // Safety: we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
+    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
     match mcause::Trap::from(CSR.mcause.extract()) {
         mcause::Trap::Interrupt(interrupt) => {
             handle_interrupt(interrupt, &interrupts_disabled);
@@ -253,7 +253,7 @@ pub unsafe extern "C" fn start_trap_rust() {
 pub unsafe extern "C" fn disable_interrupt_trap_handler(mcause_val: u32) {
     // Safety: we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
+    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
     match mcause::Trap::from(mcause_val as usize) {
         mcause::Trap::Interrupt(interrupt) => {
             handle_interrupt(interrupt, &interrupts_disabled);

--- a/chips/veer_el2/src/chip.rs
+++ b/chips/veer_el2/src/chip.rs
@@ -8,6 +8,7 @@
 use crate::machine_timer::Clint;
 use core::fmt::Write;
 use kernel::platform::chip::{Chip, InterruptService};
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 use kernel::utilities::StaticRef;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 use rv32i::csr::{CSR, mcause, mie::mie, mip::mip};
@@ -77,8 +78,7 @@ impl<'a, I: InterruptService + 'a> VeeR<'a, I> {
             if !self.pic_interrupt_service.service_interrupt(interrupt) {
                 panic!("Unhandled interrupt {}", interrupt);
             }
-
-            self.with_interrupts_disabled(|| {
+            self.with_interrupts_disabled(|_interrupts_disabled| {
                 // Safe as interrupts are disabled
                 pic.complete(interrupt);
             });
@@ -143,7 +143,7 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for VeeR<'a, I> 
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce() -> R,
+        F: FnOnce(&InterruptsDisabled) -> R,
     {
         rv32i::support::with_interrupts_disabled(f)
     }

--- a/chips/veer_el2/src/chip.rs
+++ b/chips/veer_el2/src/chip.rs
@@ -232,9 +232,9 @@ fn handle_interrupt(intr: mcause::Interrupt, interrupts_disabled: &InterruptsDis
 /// Accesses CSRs.
 #[export_name = "_start_trap_rust_from_kernel"]
 pub unsafe extern "C" fn start_trap_rust() {
-    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
+    let interrupts_disabled = kernel::mint_interrupts_disabled_context!();
     match mcause::Trap::from(CSR.mcause.extract()) {
         mcause::Trap::Interrupt(interrupt) => {
             handle_interrupt(interrupt, &interrupts_disabled);
@@ -251,9 +251,9 @@ pub unsafe extern "C" fn start_trap_rust() {
 /// interrupt that fired so that it does not trigger again.
 #[export_name = "_disable_interrupt_trap_rust_from_app"]
 pub unsafe extern "C" fn disable_interrupt_trap_handler(mcause_val: u32) {
-    // Safety: we were just called via a trap, and RISC-V hardware clears
+    // we were just called via a trap, and RISC-V hardware clears
     // `mstatus.MIE` on trap entry before any Rust code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
+    let interrupts_disabled = kernel::mint_interrupts_disabled_context!();
     match mcause::Trap::from(mcause_val as usize) {
         mcause::Trap::Interrupt(interrupt) => {
             handle_interrupt(interrupt, &interrupts_disabled);

--- a/chips/veer_el2/src/pic.rs
+++ b/chips/veer_el2/src/pic.rs
@@ -7,7 +7,7 @@
 testbench for VeeR EL2, so the Pic is not expected to handle any interrupts. */
 
 use core::sync::atomic::{AtomicU32, Ordering};
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
+use kernel::context_tokens::InterruptsDisabledContext;
 use kernel::utilities::StaticRef;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 use kernel::utilities::registers::{ReadWrite, register_bitfields, register_structs};
@@ -184,7 +184,7 @@ impl Pic {
     /// This will save the interrupt at index internally to be handled later.
     /// Saved interrupts can be retrieved by calling `get_saved_interrupts()`.
     /// Saved interrupts are cleared when `'complete()` is called.
-    pub fn save_interrupt(&self, index: u32, _interrupts_disabled: &InterruptsDisabled) {
+    pub fn save_interrupt(&self, index: u32, _interrupts_disabled: &InterruptsDisabledContext) {
         assert!(index < 96, "Unsupported index {}", index);
         let bitmap = &INTERRUPT_BITMAPS[(index / 32) as usize];
         bitmap.store(
@@ -208,7 +208,7 @@ impl Pic {
 
     /// Signal that an interrupt is finished being handled. In Tock, this should be
     /// called from the normal main loop (not the interrupt handler).
-    pub fn complete(&self, index: u32, _interrupts_disabled: &InterruptsDisabled) {
+    pub fn complete(&self, index: u32, _interrupts_disabled: &InterruptsDisabledContext) {
         // Clear the interrupt
         self.registers.meigwclr[index as usize - 1].set(0);
         // Enable the interrupt

--- a/chips/veer_el2/src/pic.rs
+++ b/chips/veer_el2/src/pic.rs
@@ -7,6 +7,7 @@
 testbench for VeeR EL2, so the Pic is not expected to handle any interrupts. */
 
 use core::sync::atomic::{AtomicU32, Ordering};
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 use kernel::utilities::StaticRef;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 use kernel::utilities::registers::{ReadWrite, register_bitfields, register_structs};
@@ -181,10 +182,9 @@ impl Pic {
 
     /// Save the current interrupt to be handled later
     /// This will save the interrupt at index internally to be handled later.
-    /// Interrupts must be disabled before this is called.
     /// Saved interrupts can be retrieved by calling `get_saved_interrupts()`.
     /// Saved interrupts are cleared when `'complete()` is called.
-    pub fn save_interrupt(&self, index: u32) {
+    pub fn save_interrupt(&self, index: u32, _interrupts_disabled: &InterruptsDisabled) {
         assert!(index < 96, "Unsupported index {}", index);
         let bitmap = &INTERRUPT_BITMAPS[(index / 32) as usize];
         bitmap.store(
@@ -208,12 +208,7 @@ impl Pic {
 
     /// Signal that an interrupt is finished being handled. In Tock, this should be
     /// called from the normal main loop (not the interrupt handler).
-    /// Interrupts must be disabled before this is called.
-    ///
-    /// # Safety
-    ///
-    /// access to memory-mapped registers
-    pub unsafe fn complete(&self, index: u32) {
+    pub fn complete(&self, index: u32, _interrupts_disabled: &InterruptsDisabled) {
         // Clear the interrupt
         self.registers.meigwclr[index as usize - 1].set(0);
         // Enable the interrupt

--- a/chips/x86_q35/src/chip.rs
+++ b/chips/x86_q35/src/chip.rs
@@ -5,8 +5,8 @@
 use core::fmt::Write;
 
 use kernel::component::Component;
+use kernel::context_tokens::InterruptsDisabledContext;
 use kernel::platform::chip::{Chip, InterruptService};
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
 use x86::mpu::PagingMPU;
 use x86::registers::bits32::paging::{PD, PT};
 use x86::support;
@@ -235,7 +235,7 @@ impl<'a, I1: InterruptService, I2: InterruptService, const PR: u16> Chip for Pc<
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&InterruptsDisabled) -> R,
+        F: FnOnce(&InterruptsDisabledContext) -> R,
     {
         support::with_interrupts_disabled(f)
     }

--- a/chips/x86_q35/src/chip.rs
+++ b/chips/x86_q35/src/chip.rs
@@ -6,6 +6,7 @@ use core::fmt::Write;
 
 use kernel::component::Component;
 use kernel::platform::chip::{Chip, InterruptService};
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 use x86::mpu::PagingMPU;
 use x86::registers::bits32::paging::{PD, PT};
 use x86::support;
@@ -236,7 +237,7 @@ impl<'a, I1: InterruptService, I2: InterruptService, const PR: u16> Chip for Pc<
 
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce() -> R,
+        F: FnOnce(&InterruptsDisabled) -> R,
     {
         support::with_interrupts_disabled(f)
     }

--- a/chips/x86_q35/src/chip.rs
+++ b/chips/x86_q35/src/chip.rs
@@ -162,7 +162,7 @@ impl<'a, I1: InterruptService, I2: InterruptService, const PR: u16> Chip for Pc<
     }
 
     fn service_pending_interrupts(&self) {
-        InterruptPoller::access(|poller| {
+        InterruptPoller::access(|poller, interrupts_disabled| {
             while let Some(num) = poller.next_pending() {
                 let mut handled = true;
                 match self.default_peripherals.service_interrupt(num) {
@@ -178,9 +178,7 @@ impl<'a, I1: InterruptService, I2: InterruptService, const PR: u16> Chip for Pc<
 
                 // Unmask the interrupt so it can fire again, but only if we know how to handle it
                 if handled {
-                    unsafe {
-                        crate::pic::unmask(num);
-                    }
+                    crate::pic::unmask(num, interrupts_disabled);
                 } else {
                     kernel::debug!("Unhandled external interrupt {} left masked", num);
                 }
@@ -189,7 +187,7 @@ impl<'a, I1: InterruptService, I2: InterruptService, const PR: u16> Chip for Pc<
     }
 
     fn has_pending_interrupts(&self) -> bool {
-        InterruptPoller::access(|poller| poller.next_pending().is_some())
+        InterruptPoller::access(|poller, _interrupts_disabled| poller.next_pending().is_some())
     }
 
     #[cfg(target_arch = "x86")]

--- a/chips/x86_q35/src/interrupts.rs
+++ b/chips/x86_q35/src/interrupts.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2024.
 
-use kernel::context_tokens::InterruptsDisabledContext;
 use x86::InterruptPoller;
 
 use super::pic;
@@ -24,10 +23,10 @@ use super::pic;
 #[allow(unsupported_calling_conventions)]
 #[no_mangle]
 unsafe extern "cdecl" fn handle_external_interrupt(num: u32) {
-    // Safety: we were just called via the IDT interrupt gate, and x86
-    // hardware clears EFLAGS.IF on entry through an interrupt gate before
-    // any handler code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
+    // we were just called via the IDT interrupt gate, and x86 hardware
+    // clears EFLAGS.IF on entry through an interrupt gate before any handler
+    // code runs.
+    let interrupts_disabled = kernel::mint_interrupts_disabled_context!();
     InterruptPoller::set_pending(num, &interrupts_disabled);
     pic::mask(num, &interrupts_disabled);
     pic::eoi(num, &interrupts_disabled);

--- a/chips/x86_q35/src/interrupts.rs
+++ b/chips/x86_q35/src/interrupts.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2024.
 
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
+use kernel::context_tokens::InterruptsDisabledContext;
 use x86::InterruptPoller;
 
 use super::pic;
@@ -27,7 +27,7 @@ unsafe extern "cdecl" fn handle_external_interrupt(num: u32) {
     // Safety: we were just called via the IDT interrupt gate, and x86
     // hardware clears EFLAGS.IF on entry through an interrupt gate before
     // any handler code runs.
-    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
+    let interrupts_disabled = unsafe { InterruptsDisabledContext::new_trusted() };
     InterruptPoller::set_pending(num, &interrupts_disabled);
     pic::mask(num, &interrupts_disabled);
     pic::eoi(num, &interrupts_disabled);

--- a/chips/x86_q35/src/interrupts.rs
+++ b/chips/x86_q35/src/interrupts.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2024.
 
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 use x86::InterruptPoller;
 
 use super::pic;
@@ -23,9 +24,11 @@ use super::pic;
 #[allow(unsupported_calling_conventions)]
 #[no_mangle]
 unsafe extern "cdecl" fn handle_external_interrupt(num: u32) {
-    unsafe {
-        InterruptPoller::set_pending(num);
-        pic::mask(num);
-        pic::eoi(num);
-    }
+    // Safety: we were just called via the IDT interrupt gate, and x86
+    // hardware clears EFLAGS.IF on entry through an interrupt gate before
+    // any handler code runs.
+    let interrupts_disabled = unsafe { InterruptsDisabled::new_trusted() };
+    InterruptPoller::set_pending(num, &interrupts_disabled);
+    pic::mask(num, &interrupts_disabled);
+    pic::eoi(num, &interrupts_disabled);
 }

--- a/chips/x86_q35/src/pic.rs
+++ b/chips/x86_q35/src/pic.rs
@@ -9,6 +9,7 @@
 //! * <https://wiki.osdev.org/8259_PIC>
 //! * <https://github.com/rust-osdev/pic8259>
 
+use kernel::platform::interrupts_disabled::InterruptsDisabled;
 use x86::IDT_RESERVED_EXCEPTIONS;
 use x86::registers::io;
 
@@ -95,11 +96,11 @@ pub unsafe fn init() {
 ///
 /// If `num` does not correspond to either the primary or secondary PIC, then no action is taken.
 ///
-/// # Safety
-///
-/// This function must _only_ be called from an interrupt servicing routine. Calling this function
-/// from the normal kernel loop could interfere with this crate's interrupt handling logic.
-pub(crate) unsafe fn eoi(num: u32) {
+/// This function must only be called from within the interrupt servicing routine actually
+/// handling `num`. Unlike `mask`/`unmask`, holding `&InterruptsDisabled` alone is not sufficient
+/// here: sending EOI outside of real interrupt-service context -- even with interrupts disabled --
+/// can desynchronize the PIC's internal in-service state and corrupt future interrupt delivery.
+pub(crate) fn eoi(num: u32, _interrupts_disabled: &InterruptsDisabled) {
     let _ = u8::try_from(num).map(|num| unsafe {
         if (PIC1_OFFSET..PIC1_OFFSET + 8).contains(&num) {
             io::outb(PIC1_CMD, PIC_CMD_EOI);
@@ -113,12 +114,7 @@ pub(crate) unsafe fn eoi(num: u32) {
 /// Masks interrupt `num`, disabling its delivery to the CPU.
 ///
 /// If `num` does not correspond to either the primary or secondary PIC, then no action is taken.
-///
-/// # Safety
-///
-/// Must be called with interrupts disabled or from within an interrupt handler to avoid race
-/// conditions updating the IMR.
-pub(crate) unsafe fn mask(num: u32) {
+pub(crate) fn mask(num: u32, _interrupts_disabled: &InterruptsDisabled) {
     let _ = u8::try_from(num).map(|n| unsafe {
         if (PIC1_OFFSET..PIC1_OFFSET + 8).contains(&n) {
             let bit = n - PIC1_OFFSET; // 0-7
@@ -136,14 +132,9 @@ pub(crate) unsafe fn mask(num: u32) {
 ///
 /// If `num` does not correspond to either the primary or secondary PIC, then no action is taken.
 ///
-/// # Safety
-///
-/// Must be called with interrupts disabled or from within an interrupt handler to avoid race
-/// conditions updating the IMR.
-///
 /// There must be an interrupt handler registered to properly handle `num`, as the interrupt may
 /// fire at any time once this function is called.
-pub(crate) unsafe fn unmask(num: u32) {
+pub(crate) fn unmask(num: u32, _interrupts_disabled: &InterruptsDisabled) {
     let _ = u8::try_from(num).map(|n| unsafe {
         if (PIC1_OFFSET..PIC1_OFFSET + 8).contains(&n) {
             let bit = n - PIC1_OFFSET; // 0-7

--- a/chips/x86_q35/src/pic.rs
+++ b/chips/x86_q35/src/pic.rs
@@ -9,7 +9,7 @@
 //! * <https://wiki.osdev.org/8259_PIC>
 //! * <https://github.com/rust-osdev/pic8259>
 
-use kernel::platform::interrupts_disabled::InterruptsDisabled;
+use kernel::context_tokens::InterruptsDisabledContext;
 use x86::IDT_RESERVED_EXCEPTIONS;
 use x86::registers::io;
 
@@ -97,10 +97,10 @@ pub unsafe fn init() {
 /// If `num` does not correspond to either the primary or secondary PIC, then no action is taken.
 ///
 /// This function must only be called from within the interrupt servicing routine actually
-/// handling `num`. Unlike `mask`/`unmask`, holding `&InterruptsDisabled` alone is not sufficient
+/// handling `num`. Unlike `mask`/`unmask`, holding `&InterruptsDisabledContext` alone is not sufficient
 /// here: sending EOI outside of real interrupt-service context -- even with interrupts disabled --
 /// can desynchronize the PIC's internal in-service state and corrupt future interrupt delivery.
-pub(crate) fn eoi(num: u32, _interrupts_disabled: &InterruptsDisabled) {
+pub(crate) fn eoi(num: u32, _interrupts_disabled: &InterruptsDisabledContext) {
     let _ = u8::try_from(num).map(|num| unsafe {
         if (PIC1_OFFSET..PIC1_OFFSET + 8).contains(&num) {
             io::outb(PIC1_CMD, PIC_CMD_EOI);
@@ -114,7 +114,7 @@ pub(crate) fn eoi(num: u32, _interrupts_disabled: &InterruptsDisabled) {
 /// Masks interrupt `num`, disabling its delivery to the CPU.
 ///
 /// If `num` does not correspond to either the primary or secondary PIC, then no action is taken.
-pub(crate) fn mask(num: u32, _interrupts_disabled: &InterruptsDisabled) {
+pub(crate) fn mask(num: u32, _interrupts_disabled: &InterruptsDisabledContext) {
     let _ = u8::try_from(num).map(|n| unsafe {
         if (PIC1_OFFSET..PIC1_OFFSET + 8).contains(&n) {
             let bit = n - PIC1_OFFSET; // 0-7
@@ -134,7 +134,7 @@ pub(crate) fn mask(num: u32, _interrupts_disabled: &InterruptsDisabled) {
 ///
 /// There must be an interrupt handler registered to properly handle `num`, as the interrupt may
 /// fire at any time once this function is called.
-pub(crate) fn unmask(num: u32, _interrupts_disabled: &InterruptsDisabled) {
+pub(crate) fn unmask(num: u32, _interrupts_disabled: &InterruptsDisabledContext) {
     let _ = u8::try_from(num).map(|n| unsafe {
         if (PIC1_OFFSET..PIC1_OFFSET + 8).contains(&n) {
             let bit = n - PIC1_OFFSET; // 0-7

--- a/kernel/src/context_tokens.rs
+++ b/kernel/src/context_tokens.rs
@@ -2,7 +2,24 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2026.
 
-//! A typed proof that interrupts are currently disabled on this core.
+//! Typed proofs for the current context code is executing in.
+//!
+//! This module provides zero-sized marker tokens that signify the current
+//! execution context. These are designed to provide compile-time assertions
+//! for code which is sensitive to execution context. E.g., when manipulating
+//! state that is shared across top-half and bottom-half interrupt handlers, it
+//! is important to ensure that interrupts are disabled.
+//!
+//! Enforcing context with comments is fragile and subject to user error. The
+//! `unsafe` keyword is overloaded here, as context-sensitive operations are
+//! not necessarily soundness concerns (though, being able to assert an
+//! execution context is often necessary to justify `unsafe` operations).
+//!
+//! Contexts are generally orthogonal. A core which is executing an interrupt
+//! service routine (in handler context) may or may not automatically be in an
+//! interrupt-disabled context---the details depend on the architecture. Code
+//! using contexts should be careful to specify exactly which context(s) they
+//! need and why.
 
 use core::marker::PhantomData;
 
@@ -15,12 +32,12 @@ use core::marker::PhantomData;
 ///
 /// This type is neither [`Send`] nor [`Sync`]: a token minted on one core
 /// must not be used to vouch for the interrupt state of another core.
-pub struct InterruptsDisabled {
+pub struct InterruptsDisabledContext {
     _not_send_sync: PhantomData<*const ()>,
 }
 
-impl InterruptsDisabled {
-    /// Mint a new [`InterruptsDisabled`] token.
+impl InterruptsDisabledContext {
+    /// Mint a new [`InterruptsDisabledContext`] token.
     ///
     /// This is only intended to be called from the small set of places that
     /// actually establish that interrupts are disabled on this core: the
@@ -35,7 +52,7 @@ impl InterruptsDisabled {
     /// this core for as long as any reference to the returned token is used.
     #[doc(hidden)]
     pub unsafe fn new_trusted() -> Self {
-        InterruptsDisabled {
+        InterruptsDisabledContext {
             _not_send_sync: PhantomData,
         }
     }

--- a/kernel/src/context_tokens.rs
+++ b/kernel/src/context_tokens.rs
@@ -39,6 +39,10 @@ pub struct InterruptsDisabledContext {
 impl InterruptsDisabledContext {
     /// Mint a new [`InterruptsDisabledContext`] token.
     ///
+    /// Prefer [`kernel::mint_interrupts_disabled_context!`](crate::mint_interrupts_disabled_context),
+    /// which wraps this in the required `unsafe` block, over calling this
+    /// directly.
+    ///
     /// This is only intended to be called from the small set of places that
     /// actually establish that interrupts are disabled on this core: the
     /// architecture-level `with_interrupts_disabled` primitives, and trap or

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -384,7 +384,7 @@ impl Kernel {
                         // the running test does not generate
                         // any interrupts.
                         if !no_sleep {
-                            chip.with_interrupts_disabled(|| {
+                            chip.with_interrupts_disabled(|_interrupts_disabled| {
                                 // Cannot sleep if interrupts are pending,
                                 // as on most platforms unhandled interrupts
                                 // will wake the device. Also, if the only

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -160,6 +160,7 @@ static TOCK_ATTRIBUTES_KERNEL_VERSION: TockAttributesKernelVersion = TockAttribu
 pub mod capabilities;
 pub mod collections;
 pub mod component;
+pub mod context_tokens;
 pub mod debug;
 pub mod deferred_call;
 pub mod dynamic_binary_storage;

--- a/kernel/src/platform/chip.rs
+++ b/kernel/src/platform/chip.rs
@@ -4,6 +4,7 @@
 
 //! Interfaces for implementing microcontrollers in Tock.
 
+use crate::platform::interrupts_disabled::InterruptsDisabled;
 use crate::platform::mpu;
 use crate::syscall;
 use crate::utilities::io_write::IoWrite;
@@ -79,9 +80,13 @@ pub trait Chip {
     /// means that interrupts are disabled so that an interrupt will not fire
     /// during the passed in function's execution, but *does not* make any
     /// guarantees about memory consistency on a multi-core system.
+    ///
+    /// The passed-in function receives a proof that interrupts are disabled,
+    /// which it can pass on to other functions that require it. See
+    /// [`InterruptsDisabled`].
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce() -> R;
+        F: FnOnce(&InterruptsDisabled) -> R;
 
     /// Print out debug information about the current chip state (system
     /// registers, MPU configuration, etc.) to a supplied writer.

--- a/kernel/src/platform/chip.rs
+++ b/kernel/src/platform/chip.rs
@@ -4,7 +4,7 @@
 
 //! Interfaces for implementing microcontrollers in Tock.
 
-use crate::platform::interrupts_disabled::InterruptsDisabled;
+use crate::context_tokens::InterruptsDisabledContext;
 use crate::platform::mpu;
 use crate::syscall;
 use crate::utilities::io_write::IoWrite;
@@ -83,10 +83,10 @@ pub trait Chip {
     ///
     /// The passed-in function receives a proof that interrupts are disabled,
     /// which it can pass on to other functions that require it. See
-    /// [`InterruptsDisabled`].
+    /// [`InterruptsDisabledContext`].
     fn with_interrupts_disabled<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&InterruptsDisabled) -> R;
+        F: FnOnce(&InterruptsDisabledContext) -> R;
 
     /// Print out debug information about the current chip state (system
     /// registers, MPU configuration, etc.) to a supplied writer.

--- a/kernel/src/platform/interrupts_disabled.rs
+++ b/kernel/src/platform/interrupts_disabled.rs
@@ -1,0 +1,42 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+//! A typed proof that interrupts are currently disabled on this core.
+
+use core::marker::PhantomData;
+
+/// Proof that interrupts are currently disabled on the current core.
+///
+/// Like [`Chip::with_interrupts_disabled`](crate::platform::chip::Chip::with_interrupts_disabled),
+/// this type makes no guarantees about memory consistency on a multi-core
+/// system -- it only proves that interrupts are disabled on the current
+/// core.
+///
+/// This type is neither [`Send`] nor [`Sync`]: a token minted on one core
+/// must not be used to vouch for the interrupt state of another core.
+pub struct InterruptsDisabled {
+    _not_send_sync: PhantomData<*const ()>,
+}
+
+impl InterruptsDisabled {
+    /// Mint a new [`InterruptsDisabled`] token.
+    ///
+    /// This is only intended to be called from the small set of places that
+    /// actually establish that interrupts are disabled on this core: the
+    /// architecture-level `with_interrupts_disabled` primitives, and trap or
+    /// interrupt handlers on architectures where hardware disables
+    /// interrupts automatically on entry (e.g. RISC-V clearing
+    /// `mstatus.MIE`, or x86 executing through an IDT interrupt gate).
+    ///
+    /// # Safety
+    ///
+    /// The caller must guarantee that interrupts are actually disabled on
+    /// this core for as long as any reference to the returned token is used.
+    #[doc(hidden)]
+    pub unsafe fn new_trusted() -> Self {
+        InterruptsDisabled {
+            _not_send_sync: PhantomData,
+        }
+    }
+}

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -8,7 +8,6 @@
 
 pub mod chip;
 pub mod dma_fence;
-pub mod interrupts_disabled;
 pub mod mpu;
 pub mod scheduler_timer;
 pub mod watchdog;

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -8,6 +8,7 @@
 
 pub mod chip;
 pub mod dma_fence;
+pub mod interrupts_disabled;
 pub mod mpu;
 pub mod scheduler_timer;
 pub mod watchdog;

--- a/kernel/src/utilities/helpers.rs
+++ b/kernel/src/utilities/helpers.rs
@@ -264,6 +264,48 @@ macro_rules! mint_defined_capability {
     };
 }
 
+/// Mint an [`InterruptsDisabledContext`](crate::context_tokens::InterruptsDisabledContext) token.
+///
+/// This is the `InterruptsDisabledContext` equivalent of [`create_capability!`]:
+/// it hides the `unsafe` keyword at the call site while still requiring that
+/// call site be in a crate permitted to use `unsafe` at all.
+///
+/// # Usage Example
+///
+/// ```ignore
+/// # use kernel::mint_interrupts_disabled_context;
+/// let interrupts_disabled = kernel::mint_interrupts_disabled_context!();
+/// ```
+///
+/// # Restrictions
+///
+/// This helper macro cannot be called from `#![forbid(unsafe_code)]` crates.
+/// It must only be invoked from a source location that has just established
+/// interrupts are genuinely disabled on this core: an architecture-level
+/// `with_interrupts_disabled` primitive, or a trap/interrupt handler on an
+/// architecture where hardware disables interrupts automatically on entry.
+/// Invoking this anywhere else compiles cleanly but produces a token that
+/// doesn't actually correspond to the current interrupt state, defeating its
+/// purpose.
+///
+/// # Safety
+///
+/// This macro can only be used in a context that is allowed to use `unsafe`.
+/// Specifically, an internal `allow(unsafe_code)` directive will conflict with
+/// any `forbid(unsafe_code)` at the crate or block level.
+#[macro_export]
+macro_rules! mint_interrupts_disabled_context {
+    () => {{
+        // SAFETY: this expansion only compiles in a crate permitted to use
+        // `unsafe` (see macro doc); by invoking this macro here, the caller
+        // asserts interrupts are genuinely disabled on this core.
+        #[allow(unsafe_code)]
+        unsafe {
+            $crate::context_tokens::InterruptsDisabledContext::new_trusted()
+        }
+    }};
+}
+
 /// Count the number of passed expressions.
 ///
 /// Useful for constructing variable sized arrays in other macros.

--- a/kernel/src/utilities/interrupts_disabled_cell.rs
+++ b/kernel/src/utilities/interrupts_disabled_cell.rs
@@ -1,0 +1,66 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+//! A `Cell` whose writes require proof that interrupts are disabled.
+
+use core::cell::Cell;
+
+use crate::platform::interrupts_disabled::InterruptsDisabled;
+
+/// A `Cell<T>` that can be freely read, but can only be written while
+/// holding proof that interrupts are disabled on this core.
+///
+/// This is intended for state shared between top half (handler context)
+/// code and normal kernel main loop code, e.g., a software-maintained
+/// "saved interrupts" bitmap.
+///
+/// Reads are unguarded because a stale read here is not a consistency
+/// problem -- interrupts can occur any time generally. However, when
+/// writing, it's important that the writer understand the implications
+/// of writing to state shared between handler and non-handler context.
+///
+/// This type is deliberately not [`Sync`]: `Sync` would promise safe access
+/// from any hart with no further checking, which would not hold on genuine
+/// multi-hart hardware (the same reason [`InterruptsDisabled`] itself is
+/// `!Send + !Sync`). Consequently, a struct embedding this type still needs
+/// to live behind a `static mut` (or equivalent) at the top level, just as
+/// it would with a plain `Cell`.
+pub struct InterruptsDisabledCell<T> {
+    value: Cell<T>,
+}
+
+impl<T> InterruptsDisabledCell<T> {
+    /// Create a new `InterruptsDisabledCell` containing `val`.
+    pub const fn new(val: T) -> Self {
+        Self {
+            value: Cell::new(val),
+        }
+    }
+
+    /// Overwrite the contained value.
+    ///
+    /// Requires proof that interrupts are disabled on this core, so this
+    /// cannot race a concurrent read-modify-write from the other half of a
+    /// top/bottom-half handler pair.
+    pub fn set(&self, val: T, _interrupts_disabled: &InterruptsDisabled) {
+        self.value.set(val);
+    }
+}
+
+impl<T: Copy> InterruptsDisabledCell<T> {
+    /// Read the contained value.
+    ///
+    /// Unguarded: a torn or stale read is not a soundness problem for this
+    /// type's intended use.
+    pub fn get(&self) -> T {
+        self.value.get()
+    }
+
+    /// Read the contained value, apply `f`, and store the result.
+    pub fn update(&self, f: impl FnOnce(T) -> T, interrupts_disabled: &InterruptsDisabled) -> T {
+        let new = f(self.get());
+        self.set(new, interrupts_disabled);
+        new
+    }
+}

--- a/kernel/src/utilities/interrupts_disabled_cell.rs
+++ b/kernel/src/utilities/interrupts_disabled_cell.rs
@@ -6,7 +6,7 @@
 
 use core::cell::Cell;
 
-use crate::platform::interrupts_disabled::InterruptsDisabled;
+use crate::context_tokens::InterruptsDisabledContext;
 
 /// A `Cell<T>` that can be freely read, but can only be written while
 /// holding proof that interrupts are disabled on this core.
@@ -22,7 +22,7 @@ use crate::platform::interrupts_disabled::InterruptsDisabled;
 ///
 /// This type is deliberately not [`Sync`]: `Sync` would promise safe access
 /// from any hart with no further checking, which would not hold on genuine
-/// multi-hart hardware (the same reason [`InterruptsDisabled`] itself is
+/// multi-hart hardware (the same reason [`InterruptsDisabledContext`] itself is
 /// `!Send + !Sync`). Consequently, a struct embedding this type still needs
 /// to live behind a `static mut` (or equivalent) at the top level, just as
 /// it would with a plain `Cell`.
@@ -43,7 +43,7 @@ impl<T> InterruptsDisabledCell<T> {
     /// Requires proof that interrupts are disabled on this core, so this
     /// cannot race a concurrent read-modify-write from the other half of a
     /// top/bottom-half handler pair.
-    pub fn set(&self, val: T, _interrupts_disabled: &InterruptsDisabled) {
+    pub fn set(&self, val: T, _interrupts_disabled: &InterruptsDisabledContext) {
         self.value.set(val);
     }
 }
@@ -58,7 +58,11 @@ impl<T: Copy> InterruptsDisabledCell<T> {
     }
 
     /// Read the contained value, apply `f`, and store the result.
-    pub fn update(&self, f: impl FnOnce(T) -> T, interrupts_disabled: &InterruptsDisabled) -> T {
+    pub fn update(
+        &self,
+        f: impl FnOnce(T) -> T,
+        interrupts_disabled: &InterruptsDisabledContext,
+    ) -> T {
         let new = f(self.get());
         self.set(new, interrupts_disabled);
         new

--- a/kernel/src/utilities/mod.rs
+++ b/kernel/src/utilities/mod.rs
@@ -11,6 +11,7 @@ pub mod copy_range;
 pub mod copy_slice;
 pub mod dma_slice;
 pub mod helpers;
+pub mod interrupts_disabled_cell;
 pub mod io_write;
 pub mod leasable_buffer;
 pub mod machine_register;


### PR DESCRIPTION
### Pull Request Overview

Right now, we signal "caller must have interrupts disabled" inconsistently — sometimes `unsafe fn` + a doc comment, sometimes [not marked at all](https://github.com/tock/tock/pull/4890/#discussion_r3771053992).

This PR adds a typed proof token, `InterruptsDisabled`, minted only where interrupts are genuinely disabled (specifically: RISC-V trap entry, x86 IDT-gate entry, and `Chip::with_interrupts_disabled`).

Methods that need to run with interrupts disabled now require this token as a parameter, so the compiler can enforce the expectation. This also has the added benefit of cleaning up a bunch of unneeded `unsafe`s (though it does add a few `unsafe` blocks at the token mint sites too):

| | added | removed | net |
|---|---|---|---|
| `unsafe fn` | 1 | 29 | −28 |
| `unsafe {}` blocks | 28 | 12 | +16 |
| total `unsafe` | 30 | 41 | −11 |


While I was working on the refactor, I realized that one of the primary use cases for methods was accessing ___and updating___ state between top-half handlers and bottom-half code. While there's no _memory-safety_ issues here because accesses went through `Cell`s, this is a consistency bug waiting to happen (indeed, this fixes one real bug found along the way: `litex_vexriscv::complete_saved` had no `with_interrupts_disabled` wrapper at its call site). So the refactor also adds a new type, `InterruptsDisabledCell<T>`, which is just a `Cell` that can only be written to when interrupts are disabled (enforced by the type system).

### Testing Strategy

Claude did: Real board build + `cargo fmt`/`clippy` per touched crate per commit; full `make allboards` (61/61) after every change. `make prepush` clean.

### TODO or Help Wanted

The first two commits are the most interesting; recommend just scrolling to the bottom to review the `kernel/` changes first.

### Checklist
- [x] Ran `make prepush`.

### PR Contents

#### Documentation
- [x] No documentation updates are required.

#### AI Use
- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read Tock's AI policy and have properly
      disclosed my AI use below.

Developed collaboratively with Claude (Sonnet 5) across scope audit, design, implementation, and review.

<details>
<summary>Prompts given, in order:</summary>

- "Scope the audit; don't rely on unsafe as an indicator of whether a function expects to be in a critical section, it seems inconsistent currently"
- "Let's start a new branch for work on this project; branch off latest upstream master"
- "Get a sense of the full scope of the problem before we propose any designs"
- "Be mindful the Tock has a top half / bottom half interrupt model, with most code in bottom half handlers which do not run in hardware exception context"
- "Let's talk about the design of the token itself — should it be a specific type, some zero sized struct the kernel defines, or a trait that any object could implement?"
- "Should this type be called 'CriticalSection' or 'WithInterruptsDisabled' — I think the latter is true to the actual implementation in most cases, and makes it clearer that this is a construct that primarily protects single core operation / I think that also answers the cortex M question, interrupts as a whole are not disabled when a handler starts so it shouldn't mint the token automatically"
- "Agreed with name InterruptsDisabled"
- "Let's work through all the design questions first so we don't have any surprises later"
- "Nit: 5 uses the variable 'cs' to hold the minted instance. Two problems here: 'cs' is an abbreviation of critical section, and we are NOT doing any assurances around critical sections, and secondly the short variable name violates the Tock style guide, which prefers full nouns over abbreviations / 6: unsure whether this is really necessary, plan to re-evaluate this when we have a concrete implementation"
- "11: Does this ordering match similar constructs in Tock codebase (eg capabilities)? Or should it go last?"
- "Design sounds good. Create a plan for implementation."
- (plan-mode edit) directed pulling PR #4890's commits onto the branch and rebasing until it lands upstream
- "Pause for me to review the PoC"
- "push this branch to origin, don't do anything else"
- "In 55a31305, comments in the kernel directory still use the term \"critical section\". Remove references to critical section and tighten the comments to just say what the types actually do"
- "I pruned the comment further; apply my edits to the first commit in the series and update"
- "the commits we cherry-picked have since been merged / rebase our work on latest upstream master and drop the cherry-picked commits that are already merged"
- "Let's make a plan for Stage 3"
- "The original scope looked over x86 and riscv, but didn't consider arm -- survey the arm-based code and see if there are places where this token should be applied? Summarize the potential scope of work for including arm"
- "From the arm survey, one more thing to check: We added the InterruptsDisabled token to its with_interrupts_disabled closure, but in most places that token is ignored/unused -- are there any places it should be used? E.g., methods from within closure bodies that should be taking the token?"
- "push it"
- "bd2262781 adds `unsafe` around PLIC accesses, but next_pending() isn't unsafe -- are these unsafe block necessary or could they be removed?"
- "Is this the unsafe pattern that SingleThreadValue is intended to remove?"
- "Save that as a memory note"
- "In 45a62bd57, do interrupts actually need to be disabled before the call occurs? It looks like the concern is the read and write of the `self.saved` cell maybe?"
- "this all feels a little fragile, it relies on code knowing that `Intc::saved` can be modified in an interrupt handler -- is there anything Rust can do to help make this more obvious?"
- "yes, sketch it out -- it would probably live in libraries/tock-cells right?"
- "Why the Copy bound on T?"
- "why is update in the Copy impl? Seems like it should not require a copy since we're mutating the actual cell contents. Probably needs to be implemented as a closure taking a reference?"
- "Makes sense. New question: Are we duplicating something that already exists in upstream Rust? Do we need to invent our own type here?"
- "Explain option 1 more"
- "Okay, let's go back to our custom cell design. Describe your implementation plan fully"
- "I've edited chips/e310x/src/chip.rs to have just one unsafe block. Does this change make sense and work as expected?"
- "yes, amend all commits to apply this simplification"
- "In 339c93b, the single-letter variable `v` isn't in line with Tock coding conventions; I think in this case it can probably be `val` as that's an established shorthand in the codebase?"
- "In 2227a18616 handle_interrupt looks weird, line 164 disables interrupts, but they are already disabled by virtue of being in the function? then 177-178 can re-enable interrupts (without destroying the interrupts_disabled token)? / Look more critically at this whole implementation"
- "Update the comment. Don't note the fragility"
- "Don't need the \"This is independent of `mstatus.MIE`...\" part of the comment"
- "In litex, update the comments on line 177-178 similarly to clarify that this is talking about reenabling the external interrupts"
- "Update the branch name to not mention critical sections"
- "Should vexriscv_irq_raw methods take the token we just made rather than being unsafe? Especially irq_pending(), but check all of the methods?"
- "Yes convert those. Does the safety comment before the call to irq_pending make sense with this new information?"
- "irq_pending should probably update to be a safe function that encapsulates the unsafe internally. There's no real preconditions here. That's out of scope for this work save that finding to memory for a future project"
- "The x86 eoi function has a different invariant, it says it has to be called from a handler, not just with interrupts disabled / Restore that part of the comment —or explain why it was wrong"
- "Make a note for a potential future project in memory to explore a token or other indicator of executing in ISR context"
- "Let's start working on a PR; draft one for me to review; don't push anything"
- "Be sure you have updated the relevant unsafe statistics"
- "This is way way way too long ... Keep this focused on what the PR does only; not all the work we did, all the things we ruled out, etc"
- "Remove the list of conversions, people can see the diff / You don't need to clip things inside the details block for the AI interaction; keep all the info there, putting it in a summary element keeps it from being noisy"

</details>
