### PR TITLE
Alternative: IPC Registration Validation

### DIFF
--- a/boards/components/src/ipc/ipc_registry_string_name.rs
+++ b/boards/components/src/ipc/ipc_registry_string_name.rs
@@ -32,14 +32,24 @@ pub struct IpcRegistryStringNameComponent<CAP: MemoryAllocationCapability> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     mem_cap: CAP,
+    validation:
+        Option<capsules_core::ipc::ipc_registration_validation::IpcRegistrationValidationFunction>,
 }
 
 impl<CAP: MemoryAllocationCapability> IpcRegistryStringNameComponent<CAP> {
-    pub fn new(board_kernel: &'static kernel::Kernel, driver_num: usize, mem_cap: CAP) -> Self {
+    pub fn new(
+        board_kernel: &'static kernel::Kernel,
+        driver_num: usize,
+        mem_cap: CAP,
+        validation: Option<
+            capsules_core::ipc::ipc_registration_validation::IpcRegistrationValidationFunction,
+        >,
+    ) -> Self {
         Self {
             board_kernel,
             driver_num,
             mem_cap,
+            validation,
         }
     }
 }
@@ -52,6 +62,7 @@ impl<CAP: MemoryAllocationCapability> Component for IpcRegistryStringNameCompone
         s.write(IpcRegistryStringName::new(
             self.board_kernel
                 .create_grant(self.driver_num, &self.mem_cap),
+            self.validation,
         ))
     }
 }

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -10,13 +10,13 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use kernel::capabilities;
 use kernel::component::Component;
 use kernel::debug::PanicResources;
 use kernel::hil::time::Counter;
 use kernel::platform::chip::Chip;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::utilities::single_thread_value::SingleThreadValue;
+use kernel::{ErrorCode, ProcessId, capabilities};
 
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
@@ -216,6 +216,12 @@ impl KernelResources<nrf52833::chip::NRF52<'static, Nrf52833DefaultPeripherals<'
     fn context_switch_callback(&self) -> &Self::ContextSwitchCallback {
         &()
     }
+}
+
+// Validation example for IPC Registration
+fn validate_ipc_registration(_processid: ProcessId, _name: &[u8]) -> Result<(), ErrorCode> {
+    // Accept all validation requests
+    Ok(())
 }
 
 /// This is in a separate, inline(never) function so that its stack frame is
@@ -701,6 +707,7 @@ unsafe fn start() -> (
             board_kernel,
             capsules_core::ipc::ipc_registry_string_name::DRIVER_NUM,
             create_capability!(capabilities::MemoryAllocationCapability),
+            Some(validate_ipc_registration),
         )
         .finalize(components::ipc_registry_string_name_component_static!());
 

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -890,6 +890,7 @@ pub unsafe fn start_no_pconsole() -> (
             board_kernel,
             capsules_core::ipc::ipc_registry_string_name::DRIVER_NUM,
             create_capability!(capabilities::MemoryAllocationCapability),
+            None,
         )
         .finalize(components::ipc_registry_string_name_component_static!());
 

--- a/capsules/core/README.md
+++ b/capsules/core/README.md
@@ -78,6 +78,7 @@ Interprocess Communication
 Interprocess Communication (IPC) mechanisms and related infrastructure.
 
 - **[IPC Identifier](src/ipc/ipc_identifier.rs)**: IPC Identifier type used in other IPC capsules.
+- **[IPC Registration Validation](src/ipc/ipc_registration_validation.rs)**: Function type for validating registration attempts.
 - **[IPC Registry String Name](src/ipc/ipc_registry_string_name.rs)**: Service registry and discovery based on process-specified string names.
 - **[IPC Registry Package Name](src/ipc/ipc_registry_package_name.rs)**: Service registry and discovery based on process package names.
 - **[IPC Relay Request](src/ipc/ipc_relay_request.rs)**: Single-copy communication via client-to-server requests and server-to-client responses.

--- a/capsules/core/src/ipc/README.md
+++ b/capsules/core/src/ipc/README.md
@@ -17,6 +17,10 @@ provide different underlying implementations for registration and/or discovery.
 Current capsules allow for registration/discovery using string names or package
 names.
 
+Registration of a service can be validated at the board level by implementing
+and providing an
+[`IpcRegistrationValidationFunction`](ipc_registration_validation.rs).
+
 ## Relay
 
 **Relay** capsules provide a means for single-copy, allow-to-allow

--- a/capsules/core/src/ipc/ipc_registration_validation.rs
+++ b/capsules/core/src/ipc/ipc_registration_validation.rs
@@ -1,0 +1,23 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+//! Validation function type for IPC registration validation.
+//!
+//! This function is used to synchronously validate a registration attempt
+//! before allowing it. The implementation can choose to allow or deny
+//! registration based on the process and name provided.
+
+use kernel::{ErrorCode, ProcessId};
+
+/// Validation function signature
+///
+/// Arguments:
+///  * ProcessId to be validated
+///  * Name it is attempting to register with
+///
+/// Return:
+///  * Result. To allow registration, return `Ok(())`. To deny registration
+///    return `Err()` with an [`ErrorCode`]. Using [`ErrorCode::FAIL`] is
+///    recommended.
+pub type IpcRegistrationValidationFunction = fn(ProcessId, &[u8]) -> Result<(), ErrorCode>;

--- a/capsules/core/src/ipc/ipc_registry_string_name.rs
+++ b/capsules/core/src/ipc/ipc_registry_string_name.rs
@@ -16,10 +16,12 @@
 //!     board_kernel,
 //!     capsules_core::ipc::ipc_registry_string_name::DRIVER_NUM,
 //!     create_capability!(capabilities::MemoryAllocationCapability),
+//!     None,
 //! ).finalize(components::ipc_registry_string_name_component_static!());
 //! ```
 
 use crate::ipc::ipc_identifier::IpcIdentifier;
+use crate::ipc::ipc_registration_validation::IpcRegistrationValidationFunction;
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::processbuffer::ReadableProcessBuffer;
 use kernel::syscall::{CommandReturn, SyscallDriver};
@@ -67,6 +69,10 @@ pub struct IpcRegistryStringName {
         AllowRoCount<{ ro_allow::COUNT }>,
         AllowRwCount<0>,
     >,
+
+    /// Optional validation function. If this function is supplied it will be
+    /// called to determine if validation can succeed.
+    validation: Option<IpcRegistrationValidationFunction>,
 }
 
 impl IpcRegistryStringName {
@@ -78,14 +84,15 @@ impl IpcRegistryStringName {
             AllowRoCount<{ ro_allow::COUNT }>,
             AllowRwCount<0>,
         >,
+        validation: Option<IpcRegistrationValidationFunction>,
     ) -> Self {
-        Self { apps: grant }
+        Self {
+            apps: grant,
+            validation,
+        }
     }
 
     fn register(&self, processid: ProcessId) -> Result<(), ErrorCode> {
-        // If registration validation is desired, that would go here before
-        // comparing or saving the name itself
-
         // Get allowed name to validate and later save
         let mut new_name: [u8; MAX_STRING_LEN] = [0; MAX_STRING_LEN];
         self.apps.enter(processid, |_, kerneldata| {
@@ -121,6 +128,11 @@ impl IpcRegistryStringName {
                 // we'll give an error to this second app. First-come-first-served.
                 return Err(ErrorCode::ALREADY);
             }
+        }
+
+        // Validate this registration attempt
+        if let Some(validator) = self.validation {
+            validator(processid, &new_name)?;
         }
 
         // Save newly registered name

--- a/capsules/core/src/ipc/mod.rs
+++ b/capsules/core/src/ipc/mod.rs
@@ -5,6 +5,7 @@
 //! Provides capsules for interprocess communication (IPC)
 
 pub mod ipc_identifier;
+pub mod ipc_registration_validation;
 pub mod ipc_registry_package_name;
 pub mod ipc_registry_string_name;
 pub mod ipc_relay_request;


### PR DESCRIPTION
### Pull Request Overview

This pull request adds an IPC Registration Validation function type. This function can be implemented in a board file to synchronously make a determination on whether to allow an IPC service to register with a given string name.

This is an alternative to #5089 In this PR, validation is added as an IPC-specific function type rather than as a generic filter interface.

### Testing Strategy

Untested


### TODO or Help Wanted

We should make a determination on whether we prefer this or #5089 


### Checklist

- [X] Ran `make prepush`.


### PR Contents

#### Documentation

- [X] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [ ] No documentation updates are required.

#### AI Use

- [X] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
