### PR TITLE
chips: qemu-rv32-virt: add pflash driver

### DIFF
--- a/boards/qemu_rv32_virt/src/lib.rs
+++ b/boards/qemu_rv32_virt/src/lib.rs
@@ -289,6 +289,7 @@ pub unsafe fn start() -> (
         QemuRv32VirtDefaultPeripherals,
         QemuRv32VirtDefaultPeripherals::new(),
     );
+    peripherals.init();
 
     // Create a shared UART channel for the console and for kernel
     // debug over the provided memory-mapped 16550-compatible

--- a/chips/qemu_rv32_virt_chip/src/chip.rs
+++ b/chips/qemu_rv32_virt_chip/src/chip.rs
@@ -40,6 +40,7 @@ pub struct QemuRv32VirtChip<'a, I: InterruptService + 'a> {
 pub struct QemuRv32VirtDefaultPeripherals<'a> {
     pub uart0: qemu_virt_chip::uart::Uart16550<'a>,
     pub virtio_mmio: [VirtIOMMIODevice; 8],
+    pub pflash: crate::pflash::Pflash0<'a>,
 }
 
 impl QemuRv32VirtDefaultPeripherals<'_> {
@@ -56,7 +57,12 @@ impl QemuRv32VirtDefaultPeripherals<'_> {
                 VirtIOMMIODevice::new(crate::virtio_mmio::VIRTIO_MMIO_6_BASE),
                 VirtIOMMIODevice::new(crate::virtio_mmio::VIRTIO_MMIO_7_BASE),
             ],
+            pflash: crate::pflash::Pflash0::new(crate::pflash::PFLASH0_BASE),
         }
+    }
+
+    pub fn init(&'static self) {
+        kernel::deferred_call::DeferredCallClient::register(&self.pflash);
     }
 }
 

--- a/chips/qemu_rv32_virt_chip/src/lib.rs
+++ b/chips/qemu_rv32_virt_chip/src/lib.rs
@@ -13,5 +13,6 @@ pub mod virtio_mmio;
 
 pub mod chip;
 pub mod clint;
+pub mod pflash;
 pub mod plic;
 pub mod uart;

--- a/chips/qemu_rv32_virt_chip/src/pflash.rs
+++ b/chips/qemu_rv32_virt_chip/src/pflash.rs
@@ -1,0 +1,78 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+//! `pflash` (parallel NOR / CFI flash) storage for the qemu-rv32-virt chip.
+//!
+//! QEMU's `virt` machine unconditionally reserves two 32 MiB pflash windows at
+//! `0x2000_0000` and `0x2200_0000`, regardless of whether a `-drive if=pflash`
+//! is actually attached.
+
+use kernel::utilities::StaticRef;
+use kernel::utilities::registers::ReadWrite;
+use qemu_virt_chip::pflash::Pflash;
+
+/// Total size, in bytes, of `pflash` unit 0.
+pub const PFLASH0_SIZE: usize = 32 * 1024 * 1024;
+
+/// `pflash` unit 0 size in 32-bit words.
+pub const PFLASH0_WORDS: usize = PFLASH0_SIZE / 4;
+
+/// Size, in bytes, of a single erase sector.
+pub const PFLASH0_SECTOR_SIZE: usize = 256 * 1024;
+
+/// Sector size in 32-bit words.
+pub const PFLASH0_SECTOR_WORDS: usize = PFLASH0_SECTOR_SIZE / 4;
+
+/// MMIO representation of this chip's `pflash` region.
+///
+/// This is simply a flat array of 32-bit-wide words.
+pub type Pflash0Registers = [ReadWrite<u32>; PFLASH0_WORDS];
+
+/// The [`Pflash`] driver, specialized for the qemu-rv32-virt chip.
+pub type Pflash0<'a> = Pflash<'a, PFLASH0_WORDS, PFLASH0_SECTOR_WORDS, PflashPage>;
+
+pub const PFLASH0_BASE: StaticRef<Pflash0Registers> =
+    unsafe { StaticRef::new(0x2000_0000 as *const Pflash0Registers) };
+
+/// A single erase-sector-sized page of flash.
+///
+/// An example instantiation looks like:
+///
+/// ```rust,ignore
+/// # use kernel::static_init;
+/// # use qemu_rv32_virt_chip::pflash::PflashPage;
+/// let pagebuffer = unsafe { static_init!(PflashPage, PflashPage::default()) };
+/// ```
+pub struct PflashPage(pub [u8; PFLASH0_SECTOR_SIZE]);
+
+impl Default for PflashPage {
+    // A page here is sector-sized (256 KiB) to match this device's erase
+    // granularity, unlike most other `Flash` implementations' much smaller
+    // pages. This is only ever constructed once into `static` storage via
+    // `static_init!`, never actually placed on a live call stack.
+    #[allow(clippy::large_stack_arrays, clippy::large_stack_frames)]
+    fn default() -> Self {
+        Self([0; PFLASH0_SECTOR_SIZE])
+    }
+}
+
+impl core::ops::Index<usize> for PflashPage {
+    type Output = u8;
+
+    fn index(&self, idx: usize) -> &u8 {
+        &self.0[idx]
+    }
+}
+
+impl core::ops::IndexMut<usize> for PflashPage {
+    fn index_mut(&mut self, idx: usize) -> &mut u8 {
+        &mut self.0[idx]
+    }
+}
+
+impl AsMut<[u8]> for PflashPage {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.0
+    }
+}

--- a/chips/qemu_virt_chip/src/lib.rs
+++ b/chips/qemu_virt_chip/src/lib.rs
@@ -7,4 +7,5 @@
 #![forbid(unsafe_code)]
 #![no_std]
 
+pub mod pflash;
 pub mod uart;

--- a/chips/qemu_virt_chip/src/pflash.rs
+++ b/chips/qemu_virt_chip/src/pflash.rs
@@ -134,16 +134,36 @@ impl<const WORDS: usize, const PAGE_WORDS: usize, P: 'static + Default + AsMut<[
             return Err((ErrorCode::INVAL, data));
         }
 
-        if !self.is_page_blank(page_number) {
+        let start = page_number * PAGE_WORDS;
+
+        // First, check if anything we want to write will change non-0xFFFFFFFF
+        // words already in flash. If so, we need to do a erase first (like
+        // normal flash). However, if we are only writing data that is already
+        // erased, don't first do an erase. Writing data on the QEMU pflash is
+        // VERY slow. So avoiding extra writes is very worthwhile.
+        let mut do_erase = false;
+        for (i, word) in data.as_mut().as_chunks::<4>().0.iter().enumerate() {
+            let value = u32::from_le_bytes(*word);
+            let existing_value = self.registers[start + i].get();
+
+            if existing_value != 0xFFFFFFFF && value != existing_value {
+                do_erase = true;
+                break;
+            }
+        }
+
+        if do_erase {
             self.erase_sector(page_number);
         }
 
-        let start = page_number * PAGE_WORDS;
         for (i, word) in data.as_mut().as_chunks::<4>().0.iter().enumerate() {
             let value = u32::from_le_bytes(*word);
-            // Skip writing the default value. This is incredibly slow to write
-            // every word in the sector.
-            if value != 0xFFFFFFFF {
+            let existing_value = self.registers[start + i].get();
+
+            // Skip writing the default value. Also, skip writing values that
+            // are already in flash. It is incredibly slow to write every word
+            // in the sector.
+            if value != 0xFFFFFFFF && value != existing_value {
                 self.program_word(start + i, value);
             }
         }

--- a/chips/qemu_virt_chip/src/pflash.rs
+++ b/chips/qemu_virt_chip/src/pflash.rs
@@ -136,17 +136,17 @@ impl<const WORDS: usize, const PAGE_WORDS: usize, P: 'static + Default + AsMut<[
 
         let start = page_number * PAGE_WORDS;
 
-        // First, check if anything we want to write will change non-0xFFFFFFFF
-        // words already in flash. If so, we need to do a erase first (like
-        // normal flash). However, if we are only writing data that is already
-        // erased, don't first do an erase. Writing data on the QEMU pflash is
-        // VERY slow. So avoiding extra writes is very worthwhile.
+        // First, check if anything we want to write will need to change a 0 bit
+        // to a 1 in flash. If so, we need to do a erase first (like normal
+        // flash). However, if we are only writing data that is already erased,
+        // don't first do an erase. Writing data on the QEMU pflash is VERY
+        // slow. So avoiding extra writes is very worthwhile.
         let mut do_erase = false;
         for (i, word) in data.as_mut().as_chunks::<4>().0.iter().enumerate() {
             let value = u32::from_le_bytes(*word);
             let existing_value = self.registers[start + i].get();
 
-            if existing_value != 0xFFFFFFFF && value != existing_value {
+            if (value & !existing_value) != 0 {
                 do_erase = true;
                 break;
             }

--- a/chips/qemu_virt_chip/src/pflash.rs
+++ b/chips/qemu_virt_chip/src/pflash.rs
@@ -1,0 +1,251 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+//! Driver for QEMU's emulated parallel NOR (CFI) flash, as exposed on the
+//! `pflash` devices.
+//!
+//! QEMU's `pflash-cfi01` model (as used by qemu-rv32-virt) implements the
+//! Intel/Sharp extended command set: commands are single bytes, with no
+//! address-based unlock sequence.
+
+use core::cell::Cell;
+use kernel::ErrorCode;
+use kernel::deferred_call::{DeferredCall, DeferredCallClient};
+use kernel::hil;
+use kernel::utilities::StaticRef;
+use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::utilities::registers::ReadWrite;
+use kernel::utilities::registers::interfaces::{Readable, Writeable};
+
+/// Intel/Sharp command set command values understood by QEMU's `pflash-cfi01`
+/// model.
+mod cmd {
+    pub const PROGRAM: u32 = 0x40;
+    pub const ERASE: u32 = 0x20;
+    pub const READ_ARRAY: u32 = 0xFF;
+}
+
+/// Tracks the current state and command of the flash.
+#[derive(Clone, Copy, PartialEq)]
+enum FlashState {
+    Ready,
+    Read,
+    Write,
+    Erase,
+}
+
+/// Driver for a QEMU `pflash` device.
+///
+/// - `WORDS`: total device size, in 32-bit words.
+/// - `PAGE_WORDS`: erase-sector size, in 32-bit words. Must evenly divide
+///   `WORDS`.
+/// - `P`: the [`hil::flash::Flash::Page`] type used for this device, which must
+///   hold exactly `PAGE_WORDS * 4` bytes.
+pub struct Pflash<'a, const WORDS: usize, const PAGE_WORDS: usize, P: 'static + Default> {
+    registers: StaticRef<[ReadWrite<u32>; WORDS]>,
+    client: OptionalCell<&'a dyn hil::flash::Client<Pflash<'a, WORDS, PAGE_WORDS, P>>>,
+    buffer: TakeCell<'static, P>,
+    state: Cell<FlashState>,
+    deferred_call: DeferredCall,
+}
+
+impl<const WORDS: usize, const PAGE_WORDS: usize, P: 'static + Default + AsMut<[u8]>>
+    Pflash<'_, WORDS, PAGE_WORDS, P>
+{
+    pub fn new(registers: StaticRef<[ReadWrite<u32>; WORDS]>) -> Self {
+        Self {
+            registers,
+            client: OptionalCell::empty(),
+            buffer: TakeCell::empty(),
+            state: Cell::new(FlashState::Ready),
+            deferred_call: DeferredCall::new(),
+        }
+    }
+
+    /// Number of erase sectors on this device.
+    fn num_sectors(&self) -> usize {
+        WORDS / PAGE_WORDS
+    }
+
+    fn command(&self, word_index: usize, value: u32) {
+        self.registers[word_index].set(value);
+    }
+
+    /// Return the device to normal "read array" mode.
+    ///
+    /// Necessary after every program or erase operation: QEMU's model does not
+    /// do this automatically, and reads would otherwise keep returning status
+    /// register contents instead of flash contents.
+    fn read_array_mode(&self) {
+        self.command(0, cmd::READ_ARRAY);
+    }
+
+    fn is_page_blank(&self, page_number: usize) -> bool {
+        let start = page_number * PAGE_WORDS;
+        (start..start + PAGE_WORDS).all(|i| self.registers[i].get() == 0xFFFF_FFFF)
+    }
+
+    fn erase_sector(&self, page_number: usize) {
+        let start = page_number * PAGE_WORDS;
+        self.command(start, cmd::ERASE);
+        self.read_array_mode();
+    }
+
+    fn program_word(&self, word_index: usize, value: u32) {
+        self.command(word_index, cmd::PROGRAM);
+        self.command(word_index, value);
+        self.read_array_mode();
+    }
+
+    fn read_range(
+        &self,
+        page_number: usize,
+        buffer: &'static mut P,
+    ) -> Result<(), (ErrorCode, &'static mut P)> {
+        if page_number >= self.num_sectors() {
+            return Err((ErrorCode::INVAL, buffer));
+        }
+
+        let start = page_number * PAGE_WORDS;
+        for (i, word) in buffer
+            .as_mut()
+            .as_chunks_mut::<4>()
+            .0
+            .iter_mut()
+            .enumerate()
+        {
+            *word = self.registers[start + i].get().to_le_bytes();
+        }
+
+        self.buffer.replace(buffer);
+        self.state.set(FlashState::Read);
+        self.deferred_call.set();
+
+        Ok(())
+    }
+
+    fn write_page_impl(
+        &self,
+        page_number: usize,
+        data: &'static mut P,
+    ) -> Result<(), (ErrorCode, &'static mut P)> {
+        if page_number >= self.num_sectors() {
+            return Err((ErrorCode::INVAL, data));
+        }
+
+        if !self.is_page_blank(page_number) {
+            self.erase_sector(page_number);
+        }
+
+        let start = page_number * PAGE_WORDS;
+        for (i, word) in data.as_mut().as_chunks::<4>().0.iter().enumerate() {
+            let value = u32::from_le_bytes(*word);
+            // Skip writing the default value. This is incredibly slow to write
+            // every word in the sector.
+            if value != 0xFFFFFFFF {
+                self.program_word(start + i, value);
+            }
+        }
+
+        self.buffer.replace(data);
+        self.state.set(FlashState::Write);
+        self.deferred_call.set();
+
+        Ok(())
+    }
+
+    fn erase_page_impl(&self, page_number: usize) -> Result<(), ErrorCode> {
+        if page_number >= self.num_sectors() {
+            return Err(ErrorCode::INVAL);
+        }
+
+        if !self.is_page_blank(page_number) {
+            self.erase_sector(page_number);
+        }
+
+        self.state.set(FlashState::Erase);
+        self.deferred_call.set();
+
+        Ok(())
+    }
+
+    fn handle_interrupt(&self) {
+        let state = self.state.get();
+        self.state.set(FlashState::Ready);
+
+        match state {
+            FlashState::Read => {
+                self.client.map(|client| {
+                    self.buffer.take().map(|buffer| {
+                        client.read_complete(buffer, Ok(()));
+                    });
+                });
+            }
+            FlashState::Write => {
+                self.client.map(|client| {
+                    self.buffer.take().map(|buffer| {
+                        client.write_complete(buffer, Ok(()));
+                    });
+                });
+            }
+            FlashState::Erase => {
+                self.client.map(|client| {
+                    client.erase_complete(Ok(()));
+                });
+            }
+            FlashState::Ready => {}
+        }
+    }
+}
+
+impl<
+    'a,
+    const WORDS: usize,
+    const PAGE_WORDS: usize,
+    P: 'static + Default + AsMut<[u8]>,
+    C: hil::flash::Client<Pflash<'a, WORDS, PAGE_WORDS, P>>,
+> hil::flash::HasClient<'a, C> for Pflash<'a, WORDS, PAGE_WORDS, P>
+{
+    fn set_client(&'a self, client: &'a C) {
+        self.client.set(client);
+    }
+}
+
+impl<const WORDS: usize, const PAGE_WORDS: usize, P: 'static + Default + AsMut<[u8]>>
+    hil::flash::Flash for Pflash<'_, WORDS, PAGE_WORDS, P>
+{
+    type Page = P;
+
+    fn read_page(
+        &self,
+        page_number: usize,
+        buf: &'static mut Self::Page,
+    ) -> Result<(), (ErrorCode, &'static mut Self::Page)> {
+        self.read_range(page_number, buf)
+    }
+
+    fn write_page(
+        &self,
+        page_number: usize,
+        buf: &'static mut Self::Page,
+    ) -> Result<(), (ErrorCode, &'static mut Self::Page)> {
+        self.write_page_impl(page_number, buf)
+    }
+
+    fn erase_page(&self, page_number: usize) -> Result<(), ErrorCode> {
+        self.erase_page_impl(page_number)
+    }
+}
+
+impl<const WORDS: usize, const PAGE_WORDS: usize, P: 'static + Default + AsMut<[u8]>>
+    DeferredCallClient for Pflash<'_, WORDS, PAGE_WORDS, P>
+{
+    fn handle_deferred_call(&self) {
+        self.handle_interrupt();
+    }
+
+    fn register(&'static self) {
+        self.deferred_call.register(self);
+    }
+}

--- a/chips/qemu_virt_chip/src/pflash.rs
+++ b/chips/qemu_virt_chip/src/pflash.rs
@@ -191,10 +191,7 @@ impl<const WORDS: usize, const PAGE_WORDS: usize, P: 'static + Default + AsMut<[
     }
 
     fn handle_interrupt(&self) {
-        let state = self.state.get();
-        self.state.set(FlashState::Ready);
-
-        match state {
+        match self.state.replace(FlashState::Ready) {
             FlashState::Read => {
                 self.client.map(|client| {
                     self.buffer.take().map(|buffer| {


### PR DESCRIPTION


### Pull Request Overview

This adds a flash driver for the [`pflash`](https://www.qemu.org/docs/master/system/riscv/virt.html#using-flash-devices) device in the qemu-rv32-virt board.

I had claude write this. The driver isn't that big, and I went back and forth with it a few times to get the chip vs. rv32-chip split. I've gone through it and it all looks reasonable. 

This allows us to implement nonvolatile storage.


### Testing Strategy

I have created a qemu-rv32-virt test board that includes this and verified it works with the Isolated Nonvolatile Storage Driver.

I found that it is incredibly slow to write the entire sector every time. I added a check that skips writing 0xFF bytes, which makes it run as expected.


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

Claude wrote the original version of the driver. I reviewed the code, and fixed the overly verbose comments.
