### PR TITLE
arch/riscv: derive XLEN_LOG2 without cfg(target_arch)

### DIFF
--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -24,14 +24,8 @@ pub const XLEN: usize = 1 << XLEN_LOG2;
 
 /// `XLEN_LOG2` is the log base 2 of [`XLEN`].
 ///
-/// Actual value varies based on RISCV-32 vs. RISCV-64.
-// Use << operator to (somewhat) hide value in rustdocs.
-#[cfg(any(not(riscv), doc))]
-pub const XLEN_LOG2: usize = 3 << 1;
-#[cfg(all(target_arch = "riscv32", not(doc)))]
-pub const XLEN_LOG2: usize = 5;
-#[cfg(all(target_arch = "riscv64", not(doc)))]
-pub const XLEN_LOG2: usize = 6;
+/// Value varies based on RISCV-32 (XLEN_LOG2=5) vs. RISCV-64 (XLEN_LOG2=6).
+pub const XLEN_LOG2: usize = usize::BITS.trailing_zeros() as usize;
 
 extern "C" {
     // Where the end of the stack region is (and hence where the stack should


### PR DESCRIPTION
### Pull Request Overview

tl;dr—one less `cfg`

`XLEN_LOG2` was three cfg-gated definitions (riscv32, riscv64, and a host/doc mock) purely to record `log2(usize::BITS)`.

`usize::BITS.trailing_zeros()` gives the identical value on both widths with no `cfg` target_arch gating.

I don't think the `3 << 1` --> `_ (5)` thing in docs is worth the extra lines of code versus just the doc comment here.

### Testing Strategy

This pull request was tested by compiling.

### TODO or Help Wanted

N/A

### Checklist

- [x] Ran `make prepush`.

### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.
