### PR TITLE
boards: remove dead boot-from-RAM layout

### DIFF
--- a/boards/nano_rp2040_connect/layout.ld
+++ b/boards/nano_rp2040_connect/layout.ld
@@ -4,12 +4,6 @@
 
 MEMORY
 {
-  /* uncomment this to boot from RAM */
-  /* reset (rx)  : ORIGIN = 0x20000000, LENGTH = 16K
-  rom (rx)  : ORIGIN = 0x20000100, LENGTH = 256K
-  prog (rx) : ORIGIN = 0x20040000, LENGTH = 1K
-  ram (rwx) : ORIGIN = 0x20004000, LENGTH = 240K */
-
   /* boot from Flash */
   rom (rx)  : ORIGIN = 0x10000000, LENGTH = 256K
   prog (rx) : ORIGIN = 0x10040000, LENGTH = 512K

--- a/boards/pico_explorer_base/layout.ld
+++ b/boards/pico_explorer_base/layout.ld
@@ -4,12 +4,6 @@
 
 MEMORY
 {
-  /* uncomment this to boot from RAM */
-  /* reset (rx)  : ORIGIN = 0x20000000, LENGTH = 16K
-  rom (rx)  : ORIGIN = 0x20000100, LENGTH = 256K
-  prog (rx) : ORIGIN = 0x20040000, LENGTH = 1K
-  ram (rwx) : ORIGIN = 0x20004000, LENGTH = 240K */
-
   /* boot from Flash */
   rom (rx)  : ORIGIN = 0x10000000, LENGTH = 256K
   prog (rx) : ORIGIN = 0x10040000, LENGTH = 256K

--- a/boards/raspberry_pi_pico/layout.ld
+++ b/boards/raspberry_pi_pico/layout.ld
@@ -4,12 +4,6 @@
 
 MEMORY
 {
-  /* uncomment this to boot from RAM */
-  /* reset (rx)  : ORIGIN = 0x20000000, LENGTH = 16K
-  rom (rx)  : ORIGIN = 0x20000100, LENGTH = 256K
-  prog (rx) : ORIGIN = 0x20040000, LENGTH = 1K
-  ram (rwx) : ORIGIN = 0x20004000, LENGTH = 240K */
-
   /* boot from Flash */
   rom (rx)  : ORIGIN = 0x10000000, LENGTH = 256K
   prog (rx) : ORIGIN = 0x10040000, LENGTH = 256K

--- a/boards/raspberry_pi_pico_2/layout.ld
+++ b/boards/raspberry_pi_pico_2/layout.ld
@@ -4,12 +4,6 @@
 
 MEMORY
 {
-  /* uncomment this to boot from RAM */
-  /* reset (rx)  : ORIGIN = 0x20000000, LENGTH = 16K
-  rom (rx)  : ORIGIN = 0x20000100, LENGTH = 256K
-  prog (rx) : ORIGIN = 0x20040000, LENGTH = 1K
-  ram (rwx) : ORIGIN = 0x20004000, LENGTH = 240K */
-
   /* boot from Flash */
   bootloader (rx) : ORIGIN = 0x10000000, LENGTH = 1024
   rom (rx)  : ORIGIN = 0x10000400, LENGTH = 255K

--- a/boards/raspberry_pi_pico_w/layout.ld
+++ b/boards/raspberry_pi_pico_w/layout.ld
@@ -5,12 +5,6 @@
 
 MEMORY
 {
-  /* uncomment this to boot from RAM */
-  /* reset (rx)  : ORIGIN = 0x20000000, LENGTH = 16K
-  rom (rx)  : ORIGIN = 0x20000100, LENGTH = 256K
-  prog (rx) : ORIGIN = 0x20040000, LENGTH = 1K
-  ram (rwx) : ORIGIN = 0x20004000, LENGTH = 240K */
-
   /* boot from Flash */
   rom (rx)  : ORIGIN = 0x10000000, LENGTH = 576K
   prog (rx) : ORIGIN = 0x10090000, LENGTH = 256K


### PR DESCRIPTION
### Pull Request Overview

Five RP2040/RP2350 boards carry a commented-out "uncomment this to boot from
RAM" `MEMORY` block in `layout.ld`. Following that instruction does not link:

```
raspberry_pi_pico:
rust-lld: error: section .text virtual address range overlaps with .stack
>>> .text  range is [0x20000200, 0x2001769F]
>>> .stack range is [0x20004000, 0x200054FF]

raspberry_pi_pico_2, additionally:
rust-lld: error: memory region 'bootloader' not declared
```

`rom` starts at `0x20000100` with a length of at least 128K, so it always runs
past `ram` at `0x20004000` — the regions overlap by construction, at every
revision since the block was added in 5eed5c3ff, whatever the lengths are
tuned to. On `raspberry_pi_pico_2` the block additionally predates the
`bootloader` region the file's own `SECTIONS` requires. Nothing else in-tree
references booting these boards from RAM, though the block does still get
tuned: 93fb60309 changes nothing but these commented lines.

Removing rather than repairing, since there is no documented layout to repair
it to. Happy to go the other way if anyone wants the path actually supported.

cc @alexandruradovici, who added it in 5eed5c3ff.

### Testing Strategy

Comment-only change. All five boards build, and each kernel `.bin` has the same
SHA-256 before and after.

### TODO or Help Wanted

Nothing.

### Checklist

- [x] Ran `make prepush`.

### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

**Tool:** Claude Opus 5, via Claude Code.

**What the AI did:** found the issue, made the deletion, and wrote this
description. 30 deleted comment lines across five `layout.ld` files; no code.

**How it was checked:** the linker errors above are real output from
uncommenting the block and building, on both an RP2040 board and the RP2350
one — not predicted.

**My own review:** I read the diff and reproduced the overlap error myself.
