### PR TITLE
arch: arm: don't modify FPU context in CONTROL

### DIFF
--- a/arch/cortex-m0/src/lib.rs
+++ b/arch/cortex-m0/src/lib.rs
@@ -109,6 +109,12 @@ unsafe extern "C" fn generic_isr() {
     bne 100f
 
     // We need to make sure the kernel continues the execution after this ISR
+    //
+    // On v6m:
+    //  - CONTROL[0] is nPriv, which we want to set to 0 here
+    //  - CONTROL[1] is SPSEL, but **ignores writes in handler mode**
+    //  - CONTROL[2:31] are RAZ/WI ; UNK/SBZP (ARM DDI 0419E §B1.4.5)
+    // so it is safe to simply write the register without reading it first.
     movs r0, #0
     msr CONTROL, r0
     // CONTROL writes must be followed by ISB
@@ -215,6 +221,12 @@ unsafe extern "C" fn systick_handler() {
     naked_asm!(
         "
     // Set thread mode to privileged to switch back to kernel mode.
+    //
+    // On v6m:
+    //  - CONTROL[0] is nPriv, which we want to set to 0 here
+    //  - CONTROL[1] is SPSEL, but **ignores writes in handler mode**
+    //  - CONTROL[2:31] are RAZ/WI ; UNK/SBZP (ARM DDI 0419E §B1.4.5)
+    // so it is safe to simply write the register without reading it first.
     movs r0, #0
     msr CONTROL, r0
     // CONTROL writes must be followed by ISB
@@ -256,6 +268,11 @@ unsafe extern "C" fn svc_handler() {
     ldr r0, 200f // EXC_RETURN_MSP
     cmp lr, r0
     bne 100f
+    // On v6m:
+    //  - CONTROL[0] is nPriv, which we want to set to 1 here
+    //  - CONTROL[1] is SPSEL, but **ignores writes in handler mode**
+    //  - CONTROL[2:31] are RAZ/WI ; UNK/SBZP (ARM DDI 0419E §B1.4.5)
+    // so it is safe to simply write the register without reading it first.
     movs r0, #1
     msr CONTROL, r0
     // CONTROL writes must be followed by ISB
@@ -265,6 +282,11 @@ unsafe extern "C" fn svc_handler() {
     bx r1
 
 100: // to_kernel
+    // On v6m:
+    //  - CONTROL[0] is nPriv, which we want to set to 0 here
+    //  - CONTROL[1] is SPSEL, but **ignores writes in handler mode**
+    //  - CONTROL[2:31] are RAZ/WI ; UNK/SBZP (ARM DDI 0419E §B1.4.5)
+    // so it is safe to simply write the register without reading it first.
     movs r0, #0
     msr CONTROL, r0
     // CONTROL writes must be followed by ISB
@@ -371,6 +393,12 @@ unsafe extern "C" fn hard_fault_handler() {
     str r2, [r0, #16]
 
     // Set thread mode to privileged
+    //
+    // On v6m:
+    //  - CONTROL[0] is nPriv, which we want to set to 0 here
+    //  - CONTROL[1] is SPSEL, but **ignores writes in handler mode**
+    //  - CONTROL[2:31] are RAZ/WI ; UNK/SBZP (ARM DDI 0419E §B1.4.5)
+    // so it is safe to simply write the register without reading it first.
     movs r0, #0
     msr CONTROL, r0
     // No ISB required on M0

--- a/arch/cortex-m0p/src/lib.rs
+++ b/arch/cortex-m0p/src/lib.rs
@@ -61,6 +61,12 @@ pub unsafe extern "C" fn svc_handler() {
 
     // If we get here, then this is a context switch from the kernel to the
     // application. Set thread mode to unprivileged to run the application.
+    //
+    // On v6m:
+    //  - CONTROL[0] is nPriv, which we want to set to 1 here
+    //  - CONTROL[1] is SPSEL, but **ignores writes in handler mode**
+    //  - CONTROL[2:31] are RAZ/WI ; UNK/SBZP (ARM DDI 0419E §B1.4.5)
+    // so it is safe to simply write the register without reading it first.
     movs r0, #1
     msr CONTROL, r0
     ldr r1, 200f // EXC_RETURN_PSP
@@ -71,6 +77,12 @@ pub unsafe extern "C" fn svc_handler() {
     movs r1, #1
     str r1, [r0, #0]
     // Set thread mode to privileged as we switch back to the kernel.
+    //
+    // On v6m:
+    //  - CONTROL[0] is nPriv, which we want to set to 0 here
+    //  - CONTROL[1] is SPSEL, but **ignores writes in handler mode**
+    //  - CONTROL[2:31] are RAZ/WI ; UNK/SBZP (ARM DDI 0419E §B1.4.5)
+    // so it is safe to simply write the register without reading it first.
     movs r0, #0
     msr CONTROL, r0
     ldr r1, 100f // EXC_RETURN_MSP

--- a/arch/cortex-v7m/src/lib.rs
+++ b/arch/cortex-v7m/src/lib.rs
@@ -27,14 +27,20 @@ pub unsafe extern "C" fn systick_handler_arm_v7m() {
     // Use the CONTROL register to set the thread mode to privileged to switch
     // back to kernel mode.
     //
-    // CONTROL[1]: Stack status
-    //   0 = Default stack (MSP) is used
-    //   1 = Alternate stack is used
-    // CONTROL[0]: Mode
-    //   0 = Privileged in thread mode
+    // CONTROL[2]: FPCA (Floating-Point Context Active)
+    //   0 = No active floating-point context
+    //   1 = Floating-point context active (FPU registers saved on exception entry)
+    // CONTROL[1]: SPSEL (Stack Pointer Select)
+    //   0 = Main Stack Pointer (MSP) is used
+    //   1 = Process Stack Pointer (PSP) is used
+    // CONTROL[0]: nPriv (Priviledged Mode?)
+    //   0 = Privileged in thread mode <--------- set to this here
     //   1 = User state in thread mode
-    mov r0, #0                        // r0 = 0
-    msr CONTROL, r0                   // CONTROL = 0
+    //
+    // Do not change other CONTROL bits.
+    mrs r0, CONTROL                   // r0 = CONTROL
+    bic r0, r0, #1                    // r0 = r0 & ~0x1
+    msr CONTROL, r0                   // CONTROL.nPriv = 0
     // CONTROL writes must be followed by an Instruction Synchronization Barrier
     // (ISB). https://developer.arm.com/documentation/dai0321/latest
     isb                               // synchronization barrier
@@ -83,14 +89,20 @@ pub unsafe extern "C" fn svc_handler_arm_v7m() {
     // application. Use the CONTROL register to set the thread mode to
     // unprivileged to run the application.
     //
-    // CONTROL[1]: Stack status
-    //   0 = Default stack (MSP) is used
-    //   1 = Alternate stack is used
-    // CONTROL[0]: Mode
+    // CONTROL[2]: FPCA (Floating-Point Context Active)
+    //   0 = No active floating-point context
+    //   1 = Floating-point context active (FPU registers saved on exception entry)
+    // CONTROL[1]: SPSEL (Stack Pointer Select)
+    //   0 = Main Stack Pointer (MSP) is used
+    //   1 = Process Stack Pointer (PSP) is used
+    // CONTROL[0]: nPriv (Priviledged Mode?)
     //   0 = Privileged in thread mode
-    //   1 = User state in thread mode
-    mov r0, #1                        // r0 = 1
-    msr CONTROL, r0                   // CONTROL = 1
+    //   1 = User state in thread mode <--------- set to this here
+    //
+    // Do not change other CONTROL bits.
+    mrs r0, CONTROL                   // r0 = CONTROL
+    orr r0, #1                        // r0 = r0 | 0x1
+    msr CONTROL, r0                   // CONTROL.nPriv = 1
     // CONTROL writes must be followed by an Instruction Synchronization Barrier
     // (ISB). https://developer.arm.com/documentation/dai0321/latest
     isb
@@ -115,14 +127,20 @@ pub unsafe extern "C" fn svc_handler_arm_v7m() {
     // Use the CONTROL register to set the thread mode to privileged to switch
     // back to kernel mode.
     //
-    // CONTROL[1]: Stack status
-    //   0 = Default stack (MSP) is used
-    //   1 = Alternate stack is used
-    // CONTROL[0]: Mode
-    //   0 = Privileged in thread mode
+    // CONTROL[2]: FPCA (Floating-Point Context Active)
+    //   0 = No active floating-point context
+    //   1 = Floating-point context active (FPU registers saved on exception entry)
+    // CONTROL[1]: SPSEL (Stack Pointer Select)
+    //   0 = Main Stack Pointer (MSP) is used
+    //   1 = Process Stack Pointer (PSP) is used
+    // CONTROL[0]: nPriv (Priviledged Mode?)
+    //   0 = Privileged in thread mode <--------- set to this here
     //   1 = User state in thread mode
-    mov r0, #0                        // r0 = 0
-    msr CONTROL, r0                   // CONTROL = 0
+    //
+    // Do not change other CONTROL bits.
+    mrs r0, CONTROL                   // r0 = CONTROL
+    bic r0, r0, #1                    // r0 = r0 & ~0x1
+    msr CONTROL, r0                   // CONTROL.nPriv = 0
     // CONTROL writes must be followed by an Instruction Synchronization Barrier
     // (ISB). https://developer.arm.com/documentation/dai0321/latest
     isb
@@ -162,14 +180,20 @@ pub unsafe extern "C" fn generic_isr_arm_v7m() {
     // we are executing as the kernel. This may be redundant if the interrupt
     // happened while the kernel code was executing.
     //
-    // CONTROL[1]: Stack status
-    //   0 = Default stack (MSP) is used
-    //   1 = Alternate stack is used
-    // CONTROL[0]: Mode
-    //   0 = Privileged in thread mode
+    // CONTROL[2]: FPCA (Floating-Point Context Active)
+    //   0 = No active floating-point context
+    //   1 = Floating-point context active (FPU registers saved on exception entry)
+    // CONTROL[1]: SPSEL (Stack Pointer Select)
+    //   0 = Main Stack Pointer (MSP) is used
+    //   1 = Process Stack Pointer (PSP) is used
+    // CONTROL[0]: nPriv (Priviledged Mode?)
+    //   0 = Privileged in thread mode <--------- set to this here
     //   1 = User state in thread mode
-    mov r0, #0                        // r0 = 0
-    msr CONTROL, r0                   // CONTROL = 0
+    //
+    // Do not change other CONTROL bits.
+    mrs r0, CONTROL                   // r0 = CONTROL
+    bic r0, r0, #1                    // r0 = r0 & ~0x1
+    msr CONTROL, r0                   // CONTROL.nPriv = 0
     // CONTROL writes must be followed by an Instruction Synchronization Barrier
     // (ISB). https://developer.arm.com/documentation/dai0321/latest
     isb
@@ -626,8 +650,9 @@ pub unsafe extern "C" fn hard_fault_handler_arm_v7m() {
     mov r1, #1               // r1 = 1
     str r1, [r0, #0]         // APP_HARD_FAULT = 1
 
-    // Set thread mode to privileged
-    mov r0, #0
+    // Set thread mode to privileged. Do not touch other CONTROL state.
+    mrs r0, CONTROL
+    bic r0, r0, #1
     msr CONTROL, r0
     // CONTROL writes must be followed by ISB
     // http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dai0321a/BIHFJCAC.html


### PR DESCRIPTION
### Pull Request Overview

This is defensive today, we don't have anything that uses hard float upstream, but we shouldn't be blindly modifying other parts of CONTROL. We use LR return mechanisms to control SPSEL, so this doesn't change anything there (SPSEL writes are ignored in handler mode anyway; but FPCA writes are valid, hence the code change here).

### Testing Strategy

This pull request was tested by compiling / reasoning.

### TODO or Help Wanted

Probably should run this on some real hardware (👀 treadmill)

### Checklist

- [ ] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
