### PR TITLE
kernel: HIL: NonvolatileStorage: return buffer on read/write errors

### DIFF
--- a/capsules/extra/src/app_flash_driver.rs
+++ b/capsules/extra/src/app_flash_driver.rs
@@ -127,7 +127,12 @@ impl<'a> AppFlash<'a> {
                                             *c = d[i].get();
                                         }
 
-                                        self.driver.write(buffer, flash_address, length)
+                                        self.driver.write(buffer, flash_address, length).map_err(
+                                            |(e, buf)| {
+                                                self.buffer.replace(buf);
+                                                e
+                                            },
+                                        )
                                     })
                             })
                         })
@@ -185,12 +190,12 @@ impl hil::nonvolatile_storage::NonvolatileStorageClient for AppFlash<'_> {
                                             *c = d[i].get();
                                         }
 
-                                        if let Ok(()) =
-                                            self.driver.write(buffer, flash_address, length)
-                                        {
-                                            true
-                                        } else {
-                                            false
+                                        match self.driver.write(buffer, flash_address, length) {
+                                            Ok(()) => true,
+                                            Err((_e, buf)) => {
+                                                self.buffer.replace(buf);
+                                                false
+                                            }
                                         }
                                     }
                                 })

--- a/capsules/extra/src/app_loader.rs
+++ b/capsules/extra/src/app_loader.rs
@@ -238,7 +238,10 @@ impl<
                         let res = self.storage_driver.write(write_buffer, offset);
                         match res {
                             Ok(()) => Ok(()),
-                            Err(e) => Err(e),
+                            Err((e, buffer)) => {
+                                self.buffer.replace(buffer.take());
+                                Err(e)
+                            }
                         }
                     })
             })

--- a/capsules/extra/src/fm25cl.rs
+++ b/capsules/extra/src/fm25cl.rs
@@ -172,38 +172,47 @@ impl<'a, S: hil::spi::SpiMasterDevice<'a>> FM25CL<'a, S> {
         }
     }
 
-    pub fn read(&self, address: u16, buffer: &'static mut [u8], len: u16) -> Result<(), ErrorCode> {
-        self.configure_spi()?;
+    pub fn read(
+        &self,
+        address: u16,
+        buffer: &'static mut [u8],
+        len: u16,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+        if let Err(e) = self.configure_spi() {
+            return Err((e, buffer));
+        }
 
-        self.txbuffer
-            .take()
-            .map_or(Err(ErrorCode::RESERVE), |mut txbuffer| {
-                self.rxbuffer
-                    .take()
-                    .map_or(Err(ErrorCode::RESERVE), move |mut rxbuffer| {
-                        txbuffer[0] = Opcodes::ReadMemory as u8;
-                        txbuffer[1] = ((address >> 8) & 0xFF) as u8;
-                        txbuffer[2] = (address & 0xFF) as u8;
+        let Some(mut txbuffer) = self.txbuffer.take() else {
+            return Err((ErrorCode::RESERVE, buffer));
+        };
 
-                        // Save the user buffer for later
-                        self.client_buffer.replace(buffer);
+        let Some(mut rxbuffer) = self.rxbuffer.take() else {
+            self.txbuffer.replace(txbuffer);
+            return Err((ErrorCode::RESERVE, buffer));
+        };
 
-                        rxbuffer.reset();
-                        let read_len = cmp::min(rxbuffer.len(), 3 + len as usize);
-                        rxbuffer.slice(..read_len);
+        txbuffer[0] = Opcodes::ReadMemory as u8;
+        txbuffer[1] = ((address >> 8) & 0xFF) as u8;
+        txbuffer[2] = (address & 0xFF) as u8;
 
-                        self.state.set(State::ReadMemory);
-                        let res = self.spi.read_write_bytes(txbuffer, Some(rxbuffer));
-                        match res {
-                            Ok(()) => Ok(()),
-                            Err((err, txbuffer, rxbuffer)) => {
-                                self.txbuffer.replace(txbuffer);
-                                self.rxbuffer.replace(rxbuffer.unwrap());
-                                Err(err)
-                            }
-                        }
-                    })
-            })
+        // Save the user buffer for later
+        self.client_buffer.replace(buffer);
+
+        rxbuffer.reset();
+        let read_len = cmp::min(rxbuffer.len(), 3 + len as usize);
+        rxbuffer.slice(..read_len);
+
+        self.state.set(State::ReadMemory);
+        let res = self.spi.read_write_bytes(txbuffer, Some(rxbuffer));
+        match res {
+            Ok(()) => Ok(()),
+            Err((err, txbuffer, rxbuffer)) => {
+                self.txbuffer.replace(txbuffer);
+                self.rxbuffer.replace(rxbuffer.unwrap());
+                // We just stashed the buffer above; reclaim it to return.
+                Err((err, self.client_buffer.take().unwrap()))
+            }
+        }
     }
 }
 
@@ -330,7 +339,7 @@ impl<'a, S: hil::spi::SpiMasterDevice<'a>> hil::nonvolatile_storage::Nonvolatile
         buffer: &'static mut [u8],
         address: usize,
         length: usize,
-    ) -> Result<(), ErrorCode> {
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         self.read(address as u16, buffer, length as u16)
     }
 

--- a/capsules/extra/src/fm25cl.rs
+++ b/capsules/extra/src/fm25cl.rs
@@ -140,33 +140,36 @@ impl<'a, S: hil::spi::SpiMasterDevice<'a>> FM25CL<'a, S> {
         address: u16,
         buffer: &'static mut [u8],
         len: u16,
-    ) -> Result<(), ErrorCode> {
-        self.configure_spi()?;
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+        if let Err(e) = self.configure_spi() {
+            return Err((e, buffer));
+        }
 
-        self.txbuffer
-            .take()
-            .map_or(Err(ErrorCode::RESERVE), move |mut txbuffer| {
-                let write_len = cmp::min(txbuffer.len(), len as usize);
+        let Some(mut txbuffer) = self.txbuffer.take() else {
+            return Err((ErrorCode::RESERVE, buffer));
+        };
 
-                // Need to save the buffer passed to us so we can give it back.
-                self.client_buffer.replace(buffer);
-                // Also save address and len for the actual write.
-                self.client_write_address.set(address);
-                self.client_write_len.set(write_len as u16);
+        let write_len = cmp::min(txbuffer.len(), len as usize);
 
-                self.state.set(State::WriteEnable);
-                txbuffer[0] = Opcodes::WriteEnable as u8;
-                txbuffer.slice(..1);
-                let res = self.spi.read_write_bytes(txbuffer, None);
+        // Need to save the buffer passed to us so we can give it back.
+        self.client_buffer.replace(buffer);
+        // Also save address and len for the actual write.
+        self.client_write_address.set(address);
+        self.client_write_len.set(write_len as u16);
 
-                match res {
-                    Ok(()) => Ok(()),
-                    Err((err, txbuffer, _)) => {
-                        self.txbuffer.replace(txbuffer);
-                        Err(err)
-                    }
-                }
-            })
+        self.state.set(State::WriteEnable);
+        txbuffer[0] = Opcodes::WriteEnable as u8;
+        txbuffer.slice(..1);
+        let res = self.spi.read_write_bytes(txbuffer, None);
+
+        match res {
+            Ok(()) => Ok(()),
+            Err((err, txbuffer, _)) => {
+                self.txbuffer.replace(txbuffer);
+                // We just stashed the buffer above; reclaim it to return.
+                Err((err, self.client_buffer.take().unwrap()))
+            }
+        }
     }
 
     pub fn read(&self, address: u16, buffer: &'static mut [u8], len: u16) -> Result<(), ErrorCode> {
@@ -336,7 +339,7 @@ impl<'a, S: hil::spi::SpiMasterDevice<'a>> hil::nonvolatile_storage::Nonvolatile
         buffer: &'static mut [u8],
         address: usize,
         length: usize,
-    ) -> Result<(), ErrorCode> {
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         self.write(address as u16, buffer, length as u16)
     }
 }

--- a/capsules/extra/src/isolated_nonvolatile_storage_driver.rs
+++ b/capsules/extra/src/isolated_nonvolatile_storage_driver.rs
@@ -536,6 +536,10 @@ impl<'a, const APP_REGION_SIZE: usize> IsolatedNonvolatileStorage<'a, APP_REGION
 
             self.driver
                 .write(buffer, region_header_address, REGION_HEADER_LEN)
+                .map_err(|(e, buf)| {
+                    self.buffer.replace(buf);
+                    e
+                })
         })
     }
 
@@ -566,7 +570,11 @@ impl<'a, const APP_REGION_SIZE: usize> IsolatedNonvolatileStorage<'a, APP_REGION
 
             self.driver
                 .write(buffer, offset, active_len)
-                .and(Ok((next_erase_start, remaining_len)))
+                .map(|()| (next_erase_start, remaining_len))
+                .map_err(|(e, buf)| {
+                    self.buffer.replace(buf);
+                    e
+                })
         })
     }
 
@@ -884,7 +892,10 @@ impl<'a, const APP_REGION_SIZE: usize> IsolatedNonvolatileStorage<'a, APP_REGION
                             NvmCommand::Write { offset: _ } => self
                                 .driver
                                 .write(buffer, physical_address, active_len_buf)
-                                .or(Err(ErrorCode::FAIL)),
+                                .map_err(|(_e, buf)| {
+                                    self.buffer.replace(buf);
+                                    ErrorCode::FAIL
+                                }),
                             NvmCommand::GetSize => Err(ErrorCode::FAIL),
                         }
                     });

--- a/capsules/extra/src/isolated_nonvolatile_storage_driver.rs
+++ b/capsules/extra/src/isolated_nonvolatile_storage_driver.rs
@@ -508,6 +508,10 @@ impl<'a, const APP_REGION_SIZE: usize> IsolatedNonvolatileStorage<'a, APP_REGION
         self.buffer.take().map_or(Err(ErrorCode::NOMEM), |buffer| {
             self.driver
                 .read(buffer, region_header_address, REGION_HEADER_LEN)
+                .map_err(|(e, buf)| {
+                    self.buffer.replace(buf);
+                    e
+                })
         })
     }
 
@@ -888,7 +892,10 @@ impl<'a, const APP_REGION_SIZE: usize> IsolatedNonvolatileStorage<'a, APP_REGION
                             NvmCommand::Read { offset: _ } => self
                                 .driver
                                 .read(buffer, physical_address, active_len_buf)
-                                .or(Err(ErrorCode::FAIL)),
+                                .map_err(|(_e, buf)| {
+                                    self.buffer.replace(buf);
+                                    ErrorCode::FAIL
+                                }),
                             NvmCommand::Write { offset: _ } => self
                                 .driver
                                 .write(buffer, physical_address, active_len_buf)

--- a/capsules/extra/src/nonvolatile_storage_driver.rs
+++ b/capsules/extra/src/nonvolatile_storage_driver.rs
@@ -333,9 +333,13 @@ impl<'a> NonvolatileStorage<'a> {
                                 NonvolatileCommand::KernelRead => {
                                     self.driver.read(kernel_buffer, offset, active_len)
                                 }
-                                NonvolatileCommand::KernelWrite => {
-                                    self.driver.write(kernel_buffer, offset, active_len)
-                                }
+                                NonvolatileCommand::KernelWrite => self
+                                    .driver
+                                    .write(kernel_buffer, offset, active_len)
+                                    .map_err(|(e, buf)| {
+                                        self.kernel_buffer.replace(buf);
+                                        e
+                                    }),
                                 _ => Err(ErrorCode::FAIL),
                             }
                         } else {
@@ -377,9 +381,13 @@ impl<'a> NonvolatileStorage<'a> {
                     NonvolatileCommand::UserspaceRead => {
                         self.driver.read(buffer, physical_address, active_len)
                     }
-                    NonvolatileCommand::UserspaceWrite => {
-                        self.driver.write(buffer, physical_address, active_len)
-                    }
+                    NonvolatileCommand::UserspaceWrite => self
+                        .driver
+                        .write(buffer, physical_address, active_len)
+                        .map_err(|(e, buf)| {
+                            self.buffer.replace(buf);
+                            e
+                        }),
                     _ => Err(ErrorCode::FAIL),
                 }
             })
@@ -398,11 +406,17 @@ impl<'a> NonvolatileStorage<'a> {
                         self.kernel_readwrite_address.get(),
                         self.kernel_readwrite_length.get(),
                     ),
-                    NonvolatileCommand::KernelWrite => self.driver.write(
-                        kernel_buffer,
-                        self.kernel_readwrite_address.get(),
-                        self.kernel_readwrite_length.get(),
-                    ),
+                    NonvolatileCommand::KernelWrite => self
+                        .driver
+                        .write(
+                            kernel_buffer,
+                            self.kernel_readwrite_address.get(),
+                            self.kernel_readwrite_length.get(),
+                        )
+                        .map_err(|(e, buf)| {
+                            self.kernel_buffer.replace(buf);
+                            e
+                        }),
                     _ => Err(ErrorCode::FAIL),
                 }
             });
@@ -519,9 +533,10 @@ impl<'a> hil::nonvolatile_storage::NonvolatileStorage<'a> for NonvolatileStorage
         buffer: &'static mut [u8],
         address: usize,
         length: usize,
-    ) -> Result<(), ErrorCode> {
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         self.kernel_buffer.replace(buffer);
         self.enqueue_command(NonvolatileCommand::KernelWrite, address, length, None)
+            .map_err(|e| (e, self.kernel_buffer.take().unwrap()))
     }
 }
 

--- a/capsules/extra/src/nonvolatile_storage_driver.rs
+++ b/capsules/extra/src/nonvolatile_storage_driver.rs
@@ -330,9 +330,13 @@ impl<'a> NonvolatileStorage<'a> {
                             self.current_user.set(NonvolatileUser::Kernel);
 
                             match command {
-                                NonvolatileCommand::KernelRead => {
-                                    self.driver.read(kernel_buffer, offset, active_len)
-                                }
+                                NonvolatileCommand::KernelRead => self
+                                    .driver
+                                    .read(kernel_buffer, offset, active_len)
+                                    .map_err(|(e, buf)| {
+                                        self.kernel_buffer.replace(buf);
+                                        e
+                                    }),
                                 NonvolatileCommand::KernelWrite => self
                                     .driver
                                     .write(kernel_buffer, offset, active_len)
@@ -378,9 +382,13 @@ impl<'a> NonvolatileStorage<'a> {
 
                 // self.current_app.set(Some(processid));
                 match command {
-                    NonvolatileCommand::UserspaceRead => {
-                        self.driver.read(buffer, physical_address, active_len)
-                    }
+                    NonvolatileCommand::UserspaceRead => self
+                        .driver
+                        .read(buffer, physical_address, active_len)
+                        .map_err(|(e, buf)| {
+                            self.buffer.replace(buf);
+                            e
+                        }),
                     NonvolatileCommand::UserspaceWrite => self
                         .driver
                         .write(buffer, physical_address, active_len)
@@ -401,11 +409,17 @@ impl<'a> NonvolatileStorage<'a> {
                 self.current_user.set(NonvolatileUser::Kernel);
 
                 match self.kernel_command.get() {
-                    NonvolatileCommand::KernelRead => self.driver.read(
-                        kernel_buffer,
-                        self.kernel_readwrite_address.get(),
-                        self.kernel_readwrite_length.get(),
-                    ),
+                    NonvolatileCommand::KernelRead => self
+                        .driver
+                        .read(
+                            kernel_buffer,
+                            self.kernel_readwrite_address.get(),
+                            self.kernel_readwrite_length.get(),
+                        )
+                        .map_err(|(e, buf)| {
+                            self.kernel_buffer.replace(buf);
+                            e
+                        }),
                     NonvolatileCommand::KernelWrite => self
                         .driver
                         .write(
@@ -523,9 +537,10 @@ impl<'a> hil::nonvolatile_storage::NonvolatileStorage<'a> for NonvolatileStorage
         buffer: &'static mut [u8],
         address: usize,
         length: usize,
-    ) -> Result<(), ErrorCode> {
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         self.kernel_buffer.replace(buffer);
         self.enqueue_command(NonvolatileCommand::KernelRead, address, length, None)
+            .map_err(|e| (e, self.kernel_buffer.take().unwrap()))
     }
 
     fn write(

--- a/capsules/extra/src/nonvolatile_to_pages.rs
+++ b/capsules/extra/src/nonvolatile_to_pages.rs
@@ -140,54 +140,56 @@ impl<'a, F: hil::flash::Flash> hil::nonvolatile_storage::NonvolatileStorage<'a>
         buffer: &'static mut [u8],
         address: usize,
         length: usize,
-    ) -> Result<(), ErrorCode> {
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         if self.state.get() != State::Idle {
-            return Err(ErrorCode::BUSY);
+            return Err((ErrorCode::BUSY, buffer));
         }
 
-        self.pagebuffer
-            .take()
-            .map_or(Err(ErrorCode::RESERVE), move |pagebuffer| {
-                let page_size = pagebuffer.as_mut().len();
+        let Some(pagebuffer) = self.pagebuffer.take() else {
+            return Err((ErrorCode::RESERVE, buffer));
+        };
 
-                self.state.set(State::Write);
-                self.length.set(length);
+        let page_size = pagebuffer.as_mut().len();
 
-                if address.is_multiple_of(page_size) && length >= page_size {
-                    // This write is aligned to a page and we are writing an entire
-                    // page or more.
+        self.state.set(State::Write);
+        self.length.set(length);
 
-                    // Copy data into page buffer.
-                    pagebuffer.as_mut()[..page_size].copy_from_slice(&buffer[..page_size]);
+        if address.is_multiple_of(page_size) && length >= page_size {
+            // This write is aligned to a page and we are writing an entire
+            // page or more.
 
-                    self.buffer.replace(buffer);
-                    self.address.set(address + page_size);
-                    self.remaining_length.set(length - page_size);
-                    self.buffer_index.set(page_size);
+            // Copy data into page buffer.
+            pagebuffer.as_mut()[..page_size].copy_from_slice(&buffer[..page_size]);
 
-                    match self.driver.write_page(address / page_size, pagebuffer) {
-                        Ok(()) => Ok(()),
-                        Err((error_code, pagebuffer)) => {
-                            self.pagebuffer.replace(pagebuffer);
-                            Err(error_code)
-                        }
-                    }
-                } else {
-                    // Need to do a read first.
-                    self.buffer.replace(buffer);
-                    self.address.set(address);
-                    self.remaining_length.set(length);
-                    self.buffer_index.set(0);
+            self.buffer.replace(buffer);
+            self.address.set(address + page_size);
+            self.remaining_length.set(length - page_size);
+            self.buffer_index.set(page_size);
 
-                    match self.driver.read_page(address / page_size, pagebuffer) {
-                        Ok(()) => Ok(()),
-                        Err((error_code, pagebuffer)) => {
-                            self.pagebuffer.replace(pagebuffer);
-                            Err(error_code)
-                        }
-                    }
+            match self.driver.write_page(address / page_size, pagebuffer) {
+                Ok(()) => Ok(()),
+                Err((error_code, pagebuffer)) => {
+                    self.pagebuffer.replace(pagebuffer);
+                    // We just stored the buffer above; reclaim it to return.
+                    Err((error_code, self.buffer.take().unwrap()))
                 }
-            })
+            }
+        } else {
+            // Need to do a read first.
+            self.buffer.replace(buffer);
+            self.address.set(address);
+            self.remaining_length.set(length);
+            self.buffer_index.set(0);
+
+            match self.driver.read_page(address / page_size, pagebuffer) {
+                Ok(()) => Ok(()),
+                Err((error_code, pagebuffer)) => {
+                    self.pagebuffer.replace(pagebuffer);
+                    // We just stored the buffer above; reclaim it to return.
+                    Err((error_code, self.buffer.take().unwrap()))
+                }
+            }
+        }
     }
 }
 

--- a/capsules/extra/src/nonvolatile_to_pages.rs
+++ b/capsules/extra/src/nonvolatile_to_pages.rs
@@ -106,33 +106,34 @@ impl<'a, F: hil::flash::Flash> hil::nonvolatile_storage::NonvolatileStorage<'a>
         buffer: &'static mut [u8],
         address: usize,
         length: usize,
-    ) -> Result<(), ErrorCode> {
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         if self.state.get() != State::Idle {
-            return Err(ErrorCode::BUSY);
+            return Err((ErrorCode::BUSY, buffer));
         }
 
-        self.pagebuffer
-            .take()
-            .map_or(Err(ErrorCode::RESERVE), move |pagebuffer| {
-                let page_size = pagebuffer.as_mut().len();
+        let Some(pagebuffer) = self.pagebuffer.take() else {
+            return Err((ErrorCode::RESERVE, buffer));
+        };
 
-                // Just start reading. We'll worry about how much of the page we
-                // want later.
-                self.state.set(State::Read);
-                self.buffer.replace(buffer);
-                self.address.set(address);
-                self.length.set(length);
-                self.remaining_length.set(length);
-                self.buffer_index.set(0);
+        let page_size = pagebuffer.as_mut().len();
 
-                match self.driver.read_page(address / page_size, pagebuffer) {
-                    Ok(()) => Ok(()),
-                    Err((error_code, pagebuffer)) => {
-                        self.pagebuffer.replace(pagebuffer);
-                        Err(error_code)
-                    }
-                }
-            })
+        // Just start reading. We'll worry about how much of the page we
+        // want later.
+        self.state.set(State::Read);
+        self.buffer.replace(buffer);
+        self.address.set(address);
+        self.length.set(length);
+        self.remaining_length.set(length);
+        self.buffer_index.set(0);
+
+        match self.driver.read_page(address / page_size, pagebuffer) {
+            Ok(()) => Ok(()),
+            Err((error_code, pagebuffer)) => {
+                self.pagebuffer.replace(pagebuffer);
+                // We just stored the buffer above; reclaim it to return.
+                Err((error_code, self.buffer.take().unwrap()))
+            }
+        }
     }
 
     fn write(

--- a/kernel/src/dynamic_binary_storage.rs
+++ b/kernel/src/dynamic_binary_storage.rs
@@ -80,7 +80,11 @@ pub trait DynamicBinaryStore {
     ///
     /// Returns an error if the write is outside of the permitted region or is
     /// writing an invalid header.
-    fn write(&self, buffer: SubSliceMut<'static, u8>, offset: usize) -> Result<(), ErrorCode>;
+    fn write(
+        &self,
+        buffer: SubSliceMut<'static, u8>,
+        offset: usize,
+    ) -> Result<(), (ErrorCode, SubSliceMut<'static, u8>)>;
 
     /// Signal to the kernel that the requesting process is done writing the new
     /// binary.
@@ -248,12 +252,13 @@ impl<'a, 'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: Nonvolatil
         &self,
         user_buffer: SubSliceMut<'static, u8>,
         offset: usize,
-    ) -> Result<(), ErrorCode> {
+    ) -> Result<(), (ErrorCode, SubSliceMut<'static, u8>)> {
         let length = user_buffer.len();
-        // Take the buffer to perform tbf header validation and write with.
-        let buffer = user_buffer.take();
 
-        let physical_address = self.compute_address(offset, length)?;
+        let physical_address = match self.compute_address(offset, length) {
+            Ok(addr) => addr,
+            Err(e) => return Err((e, user_buffer)),
+        };
 
         // The kernel needs to check if the app is trying to write/overwrite the
         // header. So the app can only write to the first 8 bytes if the app is
@@ -266,7 +271,7 @@ impl<'a, 'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: Nonvolatil
         // set of 8 bytes which is used to determine if the header is valid. We
         // don't want apps to do this, so we return an error.
         if (offset == 0 && length < 8) || (offset != 0 && offset < 8) {
-            return Err(ErrorCode::INVAL);
+            return Err((ErrorCode::INVAL, user_buffer));
         }
 
         // Check if we are writing the start of the TBF header.
@@ -275,23 +280,37 @@ impl<'a, 'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: Nonvolatil
         // it is trying to write at the very beginning of the promised flash
         // region, we require the app writes the entire 8 bytes of the header.
         // This header is then checked for validity.
+        //
+        // We validate through a borrow of `user_buffer` here (rather than
+        // consuming it via `take()`) so that we still own it and can return
+        // it back to the caller on every error path.
         if offset == 0 {
             // Pass the first eight bytes of the tbf header to parse out the
             // length of the header and app. We then use those values to see if
             // the app is going to be valid.
-            let test_header_slice = buffer.get(0..8).ok_or(ErrorCode::INVAL)?;
-            let header = test_header_slice.try_into().or(Err(ErrorCode::FAIL))?;
+            let test_header_slice = match user_buffer.as_slice().get(0..8) {
+                Some(slice) => slice,
+                None => {
+                    return Err((ErrorCode::INVAL, user_buffer));
+                }
+            };
+            let header = match test_header_slice.try_into() {
+                Ok(header) => header,
+                Err(_) => {
+                    return Err((ErrorCode::FAIL, user_buffer));
+                }
+            };
             let (_version, _header_length, entry_length) =
                 match tock_tbf::parse::parse_tbf_header_lengths(header) {
                     Ok((v, hl, el)) => (v, hl, el),
                     Err(tock_tbf::types::InitialTbfParseError::InvalidHeader(_entry_length)) => {
                         // If we have an invalid header, so we return an error
-                        return Err(ErrorCode::INVAL);
+                        return Err((ErrorCode::INVAL, user_buffer));
                     }
                     Err(tock_tbf::types::InitialTbfParseError::UnableToParse) => {
                         // If we could not parse the header, then that's an
                         // issue. We return an Error.
-                        return Err(ErrorCode::INVAL);
+                        return Err((ErrorCode::INVAL, user_buffer));
                     }
                 };
 
@@ -303,10 +322,15 @@ impl<'a, 'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: Nonvolatil
                 new_app_len = metadata.new_app_length;
             }
             if entry_length as usize != new_app_len {
-                return Err(ErrorCode::INVAL);
+                return Err((ErrorCode::INVAL, user_buffer));
             }
         }
-        self.flash_driver.write(buffer, physical_address, length)
+
+        // Take the buffer to write with.
+        let buffer = user_buffer.take();
+        self.flash_driver
+            .write(buffer, physical_address, length)
+            .map_err(|(e, buf)| (e, SubSliceMut::new(buf)))
     }
 
     /// Function to generate the padding header to append after the new app.
@@ -354,6 +378,10 @@ impl<'a, 'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: Nonvolatil
                     padding_slice.slice(..PADDING_TBF_HEADER_LENGTH);
                     // We are only writing the header, so 16 bytes is enough.
                     self.write_buffer(padding_slice, offset)
+                        .map_err(|(e, buf)| {
+                            self.buffer.replace(buf.take());
+                            e
+                        })
                 }
                 false => Err(ErrorCode::NOMEM),
             }
@@ -576,16 +604,20 @@ impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileSto
         }
     }
 
-    fn write(&self, buffer: SubSliceMut<'static, u8>, offset: usize) -> Result<(), ErrorCode> {
+    fn write(
+        &self,
+        buffer: SubSliceMut<'static, u8>,
+        offset: usize,
+    ) -> Result<(), (ErrorCode, SubSliceMut<'static, u8>)> {
         match self.state.get() {
             State::AppWrite => {
                 let res = self.write_buffer(buffer, offset);
                 match res {
                     Ok(()) => Ok(()),
-                    Err(e) => {
+                    Err((e, buffer)) => {
                         // If we fail here, let us erase the app we just wrote.
                         self.state.set(State::Fail);
-                        Err(e)
+                        Err((e, buffer))
                     }
                 }
             }
@@ -593,7 +625,7 @@ impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileSto
                 // We are in the wrong mode of operation. Ideally we should never reach
                 // here, but this error exists as a failsafe. The capsule should send
                 // a busy error out to the userland app.
-                Err(ErrorCode::INVAL)
+                Err((ErrorCode::INVAL, buffer))
             }
         }
     }

--- a/kernel/src/hil/nonvolatile_storage.rs
+++ b/kernel/src/hil/nonvolatile_storage.rs
@@ -24,12 +24,15 @@ pub trait NonvolatileStorage<'a> {
     /// Write `length` bytes starting at address `address` from the provided
     /// buffer. The buffer must be at least `length` bytes long. This address
     /// must be in the address space of the physical storage.
+    ///
+    /// On error, the buffer is returned alongside the `ErrorCode` so the
+    /// caller does not lose ownership of it.
     fn write(
         &self,
         buffer: &'static mut [u8],
         address: usize,
         length: usize,
-    ) -> Result<(), ErrorCode>;
+    ) -> Result<(), (ErrorCode, &'static mut [u8])>;
 }
 
 /// Client interface for nonvolatile storage.

--- a/kernel/src/hil/nonvolatile_storage.rs
+++ b/kernel/src/hil/nonvolatile_storage.rs
@@ -14,12 +14,15 @@ pub trait NonvolatileStorage<'a> {
     /// Read `length` bytes starting at address `address` in to the provided
     /// buffer. The buffer must be at least `length` bytes long. The address
     /// must be in the address space of the physical storage.
+    ///
+    /// On error, the buffer is returned alongside the `ErrorCode` so the
+    /// caller does not lose ownership of it.
     fn read(
         &self,
         buffer: &'static mut [u8],
         address: usize,
         length: usize,
-    ) -> Result<(), ErrorCode>;
+    ) -> Result<(), (ErrorCode, &'static mut [u8])>;
 
     /// Write `length` bytes starting at address `address` from the provided
     /// buffer. The buffer must be at least `length` bytes long. This address


### PR DESCRIPTION
### Pull Request Overview

This fixes a longstanding issue, where I originally wrote the NonvolatileStorage HIL without returning buffers on errors. This is a bug, and HILs are expected to do this.

This adds the return type in the HIL, and then updates all uses to handle the buffers.


### Testing Strategy

Porting app_loader to rv32i. My original attempt was failing, and then everything else failed because the buffer was lost.


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

This was entirely done by claude. I used the nonvolatile storage stack with the app loader for testing. The changes are pretty straightforward, but a little messy just because there are ownership issues with buffers. Luckily this doesn't touch too many files.
