### PR TITLE
QEMU virt: pflash: only write changed bytes

### DIFF
--- a/chips/qemu_virt_chip/src/pflash.rs
+++ b/chips/qemu_virt_chip/src/pflash.rs
@@ -134,16 +134,36 @@ impl<const WORDS: usize, const PAGE_WORDS: usize, P: 'static + Default + AsMut<[
             return Err((ErrorCode::INVAL, data));
         }
 
-        if !self.is_page_blank(page_number) {
+        let start = page_number * PAGE_WORDS;
+
+        // First, check if anything we want to write will change non-0xFFFFFFFF
+        // words already in flash. If so, we need to do a erase first (like
+        // normal flash). However, if we are only writing data that is already
+        // erased, don't first do an erase. Writing data on the QEMU pflash is
+        // VERY slow. So avoiding extra writes is very worthwhile.
+        let mut do_erase = false;
+        for (i, word) in data.as_mut().as_chunks::<4>().0.iter().enumerate() {
+            let value = u32::from_le_bytes(*word);
+            let existing_value = self.registers[start + i].get();
+
+            if existing_value != 0xFFFFFFFF && value != existing_value {
+                do_erase = true;
+                break;
+            }
+        }
+
+        if do_erase {
             self.erase_sector(page_number);
         }
 
-        let start = page_number * PAGE_WORDS;
         for (i, word) in data.as_mut().as_chunks::<4>().0.iter().enumerate() {
             let value = u32::from_le_bytes(*word);
-            // Skip writing the default value. This is incredibly slow to write
-            // every word in the sector.
-            if value != 0xFFFFFFFF {
+            let existing_value = self.registers[start + i].get();
+
+            // Skip writing the default value. Also, skip writing values that
+            // are already in flash. It is incredibly slow to write every word
+            // in the sector.
+            if value != 0xFFFFFFFF && value != existing_value {
                 self.program_word(start + i, value);
             }
         }

--- a/chips/qemu_virt_chip/src/pflash.rs
+++ b/chips/qemu_virt_chip/src/pflash.rs
@@ -136,17 +136,17 @@ impl<const WORDS: usize, const PAGE_WORDS: usize, P: 'static + Default + AsMut<[
 
         let start = page_number * PAGE_WORDS;
 
-        // First, check if anything we want to write will change non-0xFFFFFFFF
-        // words already in flash. If so, we need to do a erase first (like
-        // normal flash). However, if we are only writing data that is already
-        // erased, don't first do an erase. Writing data on the QEMU pflash is
-        // VERY slow. So avoiding extra writes is very worthwhile.
+        // First, check if anything we want to write will need to change a 0 bit
+        // to a 1 in flash. If so, we need to do a erase first (like normal
+        // flash). However, if we are only writing data that is already erased,
+        // don't first do an erase. Writing data on the QEMU pflash is VERY
+        // slow. So avoiding extra writes is very worthwhile.
         let mut do_erase = false;
         for (i, word) in data.as_mut().as_chunks::<4>().0.iter().enumerate() {
             let value = u32::from_le_bytes(*word);
             let existing_value = self.registers[start + i].get();
 
-            if existing_value != 0xFFFFFFFF && value != existing_value {
+            if (value & !existing_value) != 0 {
                 do_erase = true;
                 break;
             }


### PR DESCRIPTION
### Pull Request Overview

While porting the app loader to QEMU/riscv, I found that writing even a small app would take a long time (15+ minutes) because I was writing 128 bytes at a time, and the pflash driver was doing a full read-erase-write cycle on a 256 KB flash sector for every 128 bytes. Reading flash is fast, erasing pflash is fast, writing it is SLOW. So, this patch changes the pflash logic to skip erasing pages that don't need to be erased because the region that has changed is already erased.


### Testing Strategy

Writing the blink app with this patch takes a couple seconds, rather than 15+ minutes.


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
