### PR TITLE
doc: cryptography wg meeting notes august 18 + august 25 2026

### DIFF
--- a/doc/wg/cryptography/notes/cryptography-notes-2026-08-18.md
+++ b/doc/wg/cryptography/notes/cryptography-notes-2026-08-18.md
@@ -1,0 +1,63 @@
+# Tock Cryptography WG Meeting Notes
+
+**Date:** 8-18-26 
+
+**Participants:**
+  - Tyler Potyondy
+  - Amit Levy
+  - Hans Martin
+  - Roy Bachynskyi
+
+## Updates
+- Amit: Moving forward, we should have a call for agenda items prior to the meeting to help structure the meeting.
+- Tyler: This is a good idea and would be useful now that we have a larger group with more discussion items. We can maybe setup a reminder in the matrix channel?
+- Amit: Yes, I can set this up.
+- Hans: Do we want to have a shared doc for agenda items?
+- Amit: In core/network-wg we have had a slack reminder that goes out before the meetings. That's what Tyler was referring to.
+- Hans: I'm in favor of an email thread, this seems easiest and good.
+- Tyler: We previously have used the cryptography working group mailing list email thread, but this didn't have much engagement. Matrix seems to have had more engagement.
+- Hans: I'm good with using the matrix channel as well.
+- Amit: One other idea is to use a hackmd shared file for agenda items. Another thing I've seen for the Rust working groups is using github discussions/issues for agenda items.
+- Tyler: I like the idea of using a github discussion + a reminder in the matrix channel linking to the github discussion. 
+- All: Agree use github discussion + matrix reminder.
+
+## Digest HIL - Adopt AES Data Movement Patterns
+- Roy: Experimenting with the aes HIL data movement patterns, I like the design and it worked well here.
+- Roy: One drawback of the aes hil redesign is this is not compatible with DMA since for DMA we would need to store the buffer.
+- Roy: I added a SubSlice type for when we need to use DMA and dma specific functions/traits.
+- Roy: What I've seen is that the key is usually not sent using DMA and is loaded in one run. The only exception to this was a specific STM chip that requires sending the key as the first block, calculates the hash, then you start sending data. After sending the key again, you then finally get the outputted digest.
+- Roy: For the HSM module we are currently working with, you load the key into registers (don't need dma).
+- Amit: So the `read_key` method here is fine to think of as blocking since often it is a non-dma blocking implementation. In the "weird" case you mentioned above where you need to send the key twice, the low level implementation of the hil should probably just store the key and write/send it twice. So for the user of the hil it seems this method would work.
+- Roy: Yes, this is correct. When implementing this before, we used a mapcell to store this key.
+- Tyler: I'm a bit confused why we are needing a dma specific implementation here for the digest hil. Does the aes hil redesign not support dma hardware? For Bobby's new design, we just pass &mut [u8] via the client methods. Does pluton not use dma hardware for crypto operations and is this something our aes hil redesign is missing?
+- Hans: Generally we've tried to avoid drivers/hils holding stateful operations since this can be a vector of attack. This makes me a little hesitant to introduce this.
+- Hans: Taking a step back here too with the driver mutex, I have some concerns with the mutex design as well that it may be too low level of a primitive to safely use in Tock generally.
+- Hans: We generally try to avoid any stateful operation. 
+- Amit: I think the question more specifically is in aes you pass some big blob and request hardware to go encrypt the blob and that is async.
+- Amit: So for the client when it is time for the client to know that it needs a new key, a callback is issued and passes a slice of u8s that most likely is static but this lifetime is dropped.
+- Tyler: So my question is more so about the feeding data down into the hardware / driver specific implementation. It seems to me like there is some discrepancy here since Roy's implementation is using SubSliceMutImut with a static lifetime instead of just &mut [u8] for the data movement.
+- Tyler: This tells me that either (1) there is something fundamentally different with the digest crypto hardware (like using dma) that is different than the aes hardware or (2) the digest hil design being presented here is inconsistent with the data movement patterns we've been using.   
+- Roy: So the challenge here is that we need to store the buffer since we need a static lifetime for dma operations/store the buffer during the dma operation.
+- Amit: So what do we if we drop the feed dma buffer and dma buffer done from these interfaces?
+- Roy: We would need to add the static lifetime to the read input.
+- Amit: I don't think the interface would need a static lifetime and it could maybe just be stored as a SubSliceMut/Imut.
+- Amit: The implementation of this HIL is going to have some static buffer. When you call read input it's going to essentially subtype this to &mut u8 to the client even though it is a static buffer.
+- Tyler: Right, I want to really drill into why the HIL method though looks very different and is using SubSliceMutImut instead of &mut u8 to feed data to the hardware/driver.
+- Roy: So my understanding is that for AES it is only synchronous 1 shot operations?
+- Amit: I think this would be driver dependent.
+- Amit: Ideally the low level driver doesn't copy, the client copies into the input parameter which can be used for dma since it has a static lifetime under the hood. This however is only one possible pattern. You could also have many static slices under the hood, one long static slice under the hood and you could pass in half of a slice the first time to read input, read input would return and you fire off an async operation. 
+- Amit: You then would call read_input again to pass in more data for perhaps increased throughput for double buffering. 
+- Roy: Okay, I will explore this pattern more with the lifetimes as discussed here.
+- Amit: If it seems you need to use a SubSliceMutImut, my advice would be to have the low level driver hold a SubSliceMutImut and then pass the needed subslice up to the user of the hil.
+- Roy: This sounds good. This will help to cleanup the user of the HIL. The current capsule implementation is a little messy with this HIL proposed today since you from the capsule need to track if you are using dma or non dma hardware (and call separate functions accordingly). This obviously is not great.
+- Tyler: You already mentioned this is suboptimal but just to emphasize this point, we really should avoid hardware specific details leaking across the HIL into the capsule.
+- Hans: So this divergence from dma mode vs cpu mode is indicative of the driver mutex being the right shape or tool but the higher level api/design around it seems to conflate a lot of different issues.
+- Hans: What this indicates is that there is no sole unit of ownership in the driver mutex model that I think should be resolved before we upstream the driver mutex.
+- Hans: The driver mutex is a useful primitive to have for drivers and is more broadly useful outside cryptography operations. Perhaps we can design an interface for using the mutex that would provide some safeguards for locking access. This is an abstract criticism of our current design in pluton and challenges applying it to other interfaces.
+- Amit: Where does the mutex come in/connect to the discussion from the data movement? 
+- Amit: I think this is useful as a reminder that there are two orthogonal things happening here, there is the data movement challenge/solution that avoids each layer owning a static buffer which leads to memory waste and makes it difficult to know how to size things. What Roy was showing here is specifically for data movement. Separately from this, there is also the mutex for allowing multiple clients to use the same hardware without needing to have a handwritten virtualization layer for each piece of hardware.
+- Tyler: Yes, these are orthogonal. 
+- Amit: There is overlap with the digest hil / mutex is multimodal so either you build a specialized virtualizer or you use something like the mutex to expose something that looks like separate pieces of hardware which under the hood mutually exclude each other (how to do this is still unclear).
+- Hans: I was probably over emphasizing the mutex side of things, but I see them as very related to how you would design a compositional model for heterogenous hardware. I suspect the driver mutex design would influence the data movement. 
+- Tyler: For next time I think it would be really useful for you Hans to give us a rundown of these specific concerns with the mutex model and the challenges you see as where potential footguns are. 
+- Hans: Sure, I can do that for next time. The biggest concern for me is the unit of ownership in the driver mutex model. 

--- a/doc/wg/cryptography/notes/cryptography-notes-2026-08-25.md
+++ b/doc/wg/cryptography/notes/cryptography-notes-2026-08-25.md
@@ -1,0 +1,63 @@
+# Tock Cryptography WG Meeting Notes
+
+**Date:** 8-25-26
+
+**Participants:**
+  - Tyler Potyondy
+  - Hans Martin
+  - Roy Bachynskyi
+  - Irina Bradu
+  - Alex
+
+## Updates
+- Hans: One clarification from last week on my end, the driver mutex doesn't define the composition model. Both the higher level API and composition model require careful consideration. 
+
+## Digest HIL - [branch](https://github.com/frihetselsker/tock/tree/digest_hil)
+- Roy: I removed the dma buffer method as we discussed before. Now the HIL looks more abstract. 
+- Roy: Now we allocate a buffer and pass this to the init function for the driver so it is stored in the driver itself if the driver needs DMA. This made the capsule code much more clean.
+- Tyler: What do the client methods for passing data to the driver look like? 
+- Roy: Now we just pass &[u8].
+- Tyler: This looks great and is much closer to the shape of Bobby's design for data movement in the aes hil redesign.
+- Hans: I'm curious what the driver's implementation of this HIL looks like.
+- Roy: This is in the hash capsule. 
+- Tyler: And this uses the driver mutex in the capsule? 
+- Roy: Yes, the biggest difference between this updated capsule and the upstream hash capsule is that we cannot enqueue multiple operations. It will just return BUSY to the app if some operation is already in progress.
+- Roy: This is as opposed to something like the HMAC capsule which enqueues operations. Bobby's aes branch also didn't use enqueuing so I based the work in progress version 
+- Tyler: This may be a side effect of the aes capsule/redesign being a work in progress, simple example to showcase the new HIL. We haven't extensively discussed this, but I imagine we will want to support queuing of operations in the capsule.
+- Roy: Okay I can work on adding this.
+- Tyler: Does Pluton support queuing in crypto capsules?
+- Hans: Generally in Pluton we default to not using queuing work and just return with a BUSY failure to the app.
+- Tyler: That makes sense, I think there are reasons for both. In the case of knowing the specific applications that are running on your kernel, avoiding queuing operations seems reasonable. However, in the more general Tock case where a number of different apps may be run on a kernel image, it seems very useful and important for us to support and allow multiple apps to queue up work and not just bubble up the error to userspace.
+- Tyler: Overall, this is great though!
+- Roy: The only difference in my capsule was how I handle some offsets. I'm not sure if this will cause issues for some users of the interface. Remember, I mentioned for the STM driver that you have to write the key twice (from the capsule). 
+- Roy: There is a potential maybe for a vulnerability here. You can pass from the capsule a buffer of arbitrary size and this seems maybe a way someone could leak key information. This doesn't happen in the current implementation, but seems to maybe be a cause for future issues.
+- Hans: If I understand correctly, the HMAC capsule resets the key offset to zero after each pass. I wonder if it would be a good idea to track what the key phase is.
+- Roy: Maybe we can impose some enum in the capsule to restrict the number of times we could allow a driver to read the key.
+- Hans: This would help prevent an error from silently replaying a key. I can take a look at this.
+- Roy: I'm looking now to what I should do next for upstreaming this.
+- Tyler: One thing that may be awkward with the timing is that this is now ahead of our AES work and would be the first to introduce the driver mutex pattern. This is something we will need to discuss more once Bobby and Amit are back to finish discussing the driver mutex and also getting this upstreamed. 
+- Tyler: In terms of changes, is it just going to be the updated digest HIL and then the driver/capsule updates?
+- Roy: Yes, I think that's everything. I think it might also make sense is to keep the current HIL in Tock and have the new one plus the old one that is marked for deprecation.
+- Tyler: Why would we keep the old one as well? Is the new one not a superset of the functionality of the old HIL?
+- Roy: OpenTitan uses the old HIL and I don't have a way for testing the changes to those drivers.
+- Tyler: There should only be the one HIL and any new HIL should replace the old one for this. In regards to testing on OpenTitan, we can likely ask Kat for some help with this. In general too, I think that implementing the HIL for another set of hardware is a good test of the HILs design and whether it is truly hardware agnostic. 
+- Hans: I concur generally and think we should fully replace the old HIL. 
+
+## State of Public Key Crypto in Tock
+- Alex: We are working on some digital signature infrastructure. I saw there was a capsule made last year by Kat on some of this.
+- Alex: What I've been doing is looking at elliptic curve/modular arithmetic for a HIL. I am hoping to have a capsule/draft of how this would work in an ecdsa capsule signing. 
+- Alex: The idea for modular arithmetic would be having a calculator that is stored in memory and trying to use the data movement pattern the working group has been looking at.
+- Hans: If I understand correctly, this is a general modular arithmetic HIL?
+- Alex: Yes.
+- Hans: Would you consider a more minimal HIL for something like modular exponentiation?
+- Alex: Yes you could, but I was thinking about algorithms that have more complex operations.
+- Tyler: What does existing hardware support for these cryptography modes and operations proposed in the HIL look like in tock? 
+- Alex: Some of the modes ares supported on the STM board I've been working with.
+- Tyler: So this would be a subset of the operations in the enum?
+- Alex: Only division would be missing in this implementation but we could implement division from some of the other modes that are supported.
+- Tyler: One feedback I have on this proposal is that we should encode more of the hardware properties into the type system. We have been discussing this in the working group generally, but this is a great example where you will have many runtime errors of NOSUPPORT.
+- Alex: Using traits would allow for this type enforcement. I can switch to this.
+- Tyler: Other thing I'd like to draw attention to is the need for software-cryptography support here. This is another area we've spent a lot of time discussing and introducing some of these more complicated cryptography algorithms will provide an increased need for having a good story for this.
+- Tyler: We have previously discussed moving all software cryptography from the kernel and into userspace. Something like https://github.com/tock/tock/pull/4869 provides a way to expose userspace services to the kernel.
+- Tyler: All of this is perhaps less relevant for your specific HIL here, but this is something that'd be useful for us to keep thinking more about and that is important as we expand support for more complicated, and potentially less well supported in hardware, cryptography algs.
+- Alex: I'm concerned as well of software implementations of cryptography. Since I found accelerators that work, I think this is a decent place to work on adding hardware support for this in Tock.


### PR DESCRIPTION
### Pull Request Overview

This pull request adds the cryptography wg meeting notes from August 18 & 25, 2026. [rendered (8/18)](https://github.com/tyler-potyondy/tock/blob/31d598ef4497e8cec5b5a58281b21562e69761d9/doc/wg/cryptography/notes/cryptography-notes-2026-08-18.md) [rendered (8/25)](https://github.com/tyler-potyondy/tock/blob/e1785f2093f77f85b58609075cf8159af3493606/doc/wg/cryptography/notes/cryptography-notes-2026-08-25.md)


### Testing Strategy

N/A

### TODO or Help Wanted

N/A

### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [x] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
