### PR TITLE
STM32F4xx CAN Filter Support and HIL Changes

### DIFF
--- a/chips/stm32f4xx/src/can.rs
+++ b/chips/stm32f4xx/src/can.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache License, Version 2.0 or the MIT License.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022
+// Copyright Tock Contributors 2026
 // Copyright OxidOS Automotive SRL 2022
 //
 // Author: Teona Severin <teona.severin@oxidos.io>
@@ -8,15 +8,16 @@
 //! Low-level CAN driver for STM32F4XX chips
 //!
 
-use crate::clocks::{Stm32f4Clocks, phclk};
+use crate::clocks::{phclk, Stm32f4Clocks};
 use core::cell::Cell;
 use kernel::deferred_call::{DeferredCall, DeferredCallClient};
 use kernel::hil::can::{self, StandardBitTiming};
+use kernel::hil::can::{Filters, Mode};
 use kernel::platform::chip::ClockInterface;
-use kernel::utilities::StaticRef;
 use kernel::utilities::cells::{OptionalCell, TakeCell};
-use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
-use kernel::utilities::registers::{ReadWrite, register_bitfields, register_structs};
+use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
+use kernel::utilities::registers::{register_bitfields, register_structs, ReadWrite};
+use kernel::utilities::StaticRef;
 
 pub const BRP_MIN_STM32: u32 = 0;
 pub const BRP_MAX_STM32: u32 = 1023;
@@ -549,14 +550,18 @@ impl<'a> Can<'a> {
         self.registers.can_mcr.modify(CAN_MCR::TXFP::CLEAR);
 
         match self.automatic_retransmission.get() {
+            true => self.registers.can_mcr.modify(CAN_MCR::NART::CLEAR),
+            false => self.registers.can_mcr.modify(CAN_MCR::NART::SET),
+        }
+
+        match self.automatic_wake_up.get() {
             true => self.registers.can_mcr.modify(CAN_MCR::AWUM::SET),
             false => self.registers.can_mcr.modify(CAN_MCR::AWUM::CLEAR),
         }
 
-        match self.automatic_wake_up.get() {
-            true => self.registers.can_mcr.modify(CAN_MCR::NART::CLEAR),
-            false => self.registers.can_mcr.modify(CAN_MCR::NART::SET),
-        }
+        // clear before setting, in case the mode is already set due to a previous configuration with no reset inbetween
+        self.registers.can_btr.modify(CAN_BTR::LBKM::CLEAR);
+        self.registers.can_btr.modify(CAN_BTR::SILM::CLEAR);
 
         if let Some(operating_mode_settings) = self.operating_mode.get() {
             match operating_mode_settings {
@@ -589,47 +594,193 @@ impl<'a> Can<'a> {
         Ok(())
     }
 
+    fn gracefully_exit_filter_cfg(&self, was_filter_on: bool, filter_number: u32) {
+        // to gracefully exit we need to both clear init and make sure the filter is as it was before
+        if was_filter_on {
+            self.registers.can_fa1r.modify(
+                CAN_FA1R::FACT.val(self.registers.can_fa1r.read(CAN_FA1R::FACT) | filter_number),
+            );
+        }
+        self.registers.can_fmr.modify(CAN_FMR::FINIT::CLEAR);
+    }
+
+    // std ids are 11 bits, extended ids are 29 bits but we get u16 and u32. this means if we dont use this function, we will silently accept invalid ids
+    // and that could lead to unexpected behavior
+    fn check_id(id: &can::Id) -> bool {
+        match id {
+            can::Id::Standard(val) if *val > 0x7ff => false,
+            can::Id::Extended(val) if *val > 0x1fff_ffff => false,
+            _ => true,
+        }
+    }
+
     /// Configure a filter to receive messages
-    pub fn config_filter(&self, filter_info: can::FilterParameters, enable: bool) {
+    /// Maps the HIL's filter modes onto bxCAN filter banks (RM0090 §32.7.4).
+    ///
+    /// - `Mode::Mask` → 32-bit mask mode, one bank per filter. IDE and RTR are
+    ///   forced to must-match so a standard filter cannot alias an extended frame
+    ///   whose top 11 bits coincide, and remote frames are never accepted.
+    /// - `Mode::List` → identifier list mode. Mixed IDs use 32-bit scale (so only one or two ids per filter);
+    ///   If we have all-standard IDs we use dual 16-bit scale(up to 4 per filter). Unused
+    ///   slots are padded with the last ID rather than zero, since 0x000 is a valid
+    ///   identifier and could cause issues
+    /// - `Mode::Range` → `NOSUPPORT`; bxCAN has no range filter.
+    ///
+    /// `number` is a filter bank index (0–27).
+    pub fn config_filter(
+        &self,
+        filter_info: &can::FilterParameters,
+        number: usize,
+    ) -> Result<(), kernel::ErrorCode> {
+        if number >= 28 {
+            return Err(kernel::ErrorCode::INVAL);
+        }
+
         // get position of the filter number
-        let filter_number = 1 << filter_info.number;
+        let filter_number = 1 << number;
 
         // start filter configuration
         self.registers.can_fmr.modify(CAN_FMR::FINIT::SET);
+
+        // remember if filter was on for graceful exit
+        let was_filter_on = self.registers.can_fa1r.read(CAN_FA1R::FACT) & filter_number != 0;
 
         // request filter number filter_number
         self.registers.can_fa1r.modify(
             CAN_FA1R::FACT.val(self.registers.can_fa1r.read(CAN_FA1R::FACT) & !filter_number),
         );
 
-        // request filter width to be 32 or 16 bits
-        match filter_info.scale_bits {
-            can::ScaleBits::Bits16 => {
+        // for more info on how these work check rm0090 32.7.4
+        // tldr is we match this bxCAN driver to MCAN functionality as much as possible
+        match filter_info.mode {
+            Mode::List(list) => {
+                for id in list {
+                    if !Self::check_id(id) {
+                        self.gracefully_exit_filter_cfg(was_filter_on, filter_number);
+                        return Err(kernel::ErrorCode::INVAL);
+                    }
+                }
+
+                let has_ext = list.iter().any(|id| matches!(id, can::Id::Extended(_)));
+                if has_ext {
+                    if list.len() > 2 {
+                        self.gracefully_exit_filter_cfg(was_filter_on, filter_number);
+                        return Err(kernel::ErrorCode::INVAL);
+                    }
+
+                    self.registers.can_fs1r.modify(
+                        CAN_FS1R::FSC
+                            .val(self.registers.can_fs1r.read(CAN_FS1R::FSC) | filter_number),
+                    );
+
+                    self.registers.can_fm1r.modify(
+                        CAN_FM1R::FBM
+                            .val(self.registers.can_fm1r.read(CAN_FM1R::FBM) | filter_number),
+                    );
+
+                    let fir1 = match list[0] {
+                        can::Id::Standard(val) => (val as u32) << 21,
+                        can::Id::Extended(val) => val << 3 | (1 << 2),
+                    };
+
+                    let fir2 = if list.len() == 2 {
+                        match list[1] {
+                            can::Id::Standard(val) => (val as u32) << 21,
+                            can::Id::Extended(val) => val << 3 | (1 << 2),
+                        }
+                    } else {
+                        // we pad the second one with the first result if its empty
+                        fir1
+                    };
+
+                    self.registers.can_firx[number * 2].modify(CAN_FiRx::FB.val(fir1));
+                    self.registers.can_firx[number * 2 + 1].modify(CAN_FiRx::FB.val(fir2));
+                } else {
+                    if list.len() > 4 || list.is_empty() {
+                        self.gracefully_exit_filter_cfg(was_filter_on, filter_number);
+                        return Err(kernel::ErrorCode::INVAL);
+                    }
+                    self.registers.can_fs1r.modify(
+                        CAN_FS1R::FSC
+                            .val(self.registers.can_fs1r.read(CAN_FS1R::FSC) & !filter_number),
+                    );
+
+                    self.registers.can_fm1r.modify(
+                        CAN_FM1R::FBM
+                            .val(self.registers.can_fm1r.read(CAN_FM1R::FBM) | filter_number),
+                    );
+
+                    // we iterate over the given ids, as we know by now they are all standard
+                    // we put them into the filter banks and then we pad the leftover unused filter ids with the last id because 0x000 is a valid can id and can potentially cause trouble
+
+                    let fir: u32 = match list[list.len() - 1] {
+                        can::Id::Standard(val) => (val << 5) as u32,
+                        can::Id::Extended(_) => {
+                            self.gracefully_exit_filter_cfg(was_filter_on, filter_number);
+                            return Err(kernel::ErrorCode::INVAL); // this will never be reached, as we dont have any extended IDs on this branch
+                        }
+                    };
+
+                    // we init with the last id for padding purposes, again 0 is a valid id and may mess things up
+                    let mut ids = [fir; 4];
+
+                    // we fill array
+                    for (count, id) in list.iter().enumerate() {
+                        if let can::Id::Standard(val) = id {
+                            ids[count] = (*val << 5) as u32;
+                        }
+                    }
+
+                    // we know we have maximum 4 ids(padded if we received less) so we can use hardcoded indices.
+                    self.registers.can_firx[number * 2]
+                        .modify(CAN_FiRx::FB.val(ids[0] | (ids[1] << 16)));
+                    self.registers.can_firx[number * 2 + 1]
+                        .modify(CAN_FiRx::FB.val(ids[2] | (ids[3] << 16)));
+                }
+            }
+
+            Mode::Mask { value, bitmask } => {
+                if !Self::check_id(&value) || !Self::check_id(&bitmask) {
+                    self.gracefully_exit_filter_cfg(was_filter_on, filter_number);
+                    return Err(kernel::ErrorCode::INVAL);
+                }
+                // we set filter scale to 32 bits as we use 32 bit mode for both ext and std ids
                 self.registers.can_fs1r.modify(
                     CAN_FS1R::FSC.val(self.registers.can_fs1r.read(CAN_FS1R::FSC) | filter_number),
                 );
-            }
-            can::ScaleBits::Bits32 => {
-                self.registers.can_fs1r.modify(
-                    CAN_FS1R::FSC.val(self.registers.can_fs1r.read(CAN_FS1R::FSC) & !filter_number),
-                );
-            }
-        }
 
-        self.registers.can_firx[(filter_info.number as usize) * 2].modify(CAN_FiRx::FB.val(0));
-        self.registers.can_firx[(filter_info.number as usize) * 2 + 1].modify(CAN_FiRx::FB.val(0));
-
-        // request filter mode to be mask or list
-        match filter_info.identifier_mode {
-            can::IdentifierMode::List => {
-                self.registers.can_fm1r.modify(
-                    CAN_FM1R::FBM.val(self.registers.can_fm1r.read(CAN_FM1R::FBM) | filter_number),
-                );
-            }
-            can::IdentifierMode::Mask => {
+                // set mask
                 self.registers.can_fm1r.modify(
                     CAN_FM1R::FBM.val(self.registers.can_fm1r.read(CAN_FM1R::FBM) & !filter_number),
                 );
+
+                // for simplicity, even if we could have 2 masks and 2 ids/filter, we only do 1 as mask mode should be the most widely supported mode
+                match (value, bitmask) {
+                    (can::Id::Standard(v), can::Id::Standard(m)) => {
+                        // set value
+                        self.registers.can_firx[number * 2]
+                            .modify(CAN_FiRx::FB.val((v as u32) << 21));
+                        self.registers.can_firx[number * 2 + 1]
+                            .modify(CAN_FiRx::FB.val(((m as u32) << 21) | (1 << 2) | (1 << 1)));
+                        // the or's are because we need to match the RTR and IDE bits
+                    }
+                    (can::Id::Extended(v), can::Id::Extended(m)) => {
+                        // set value
+                        self.registers.can_firx[number * 2]
+                            .modify(CAN_FiRx::FB.val((v << 3) | (1 << 2))); //we need to set IDE so std ids dont get matched to extended filters
+                        self.registers.can_firx[number * 2 + 1]
+                            .modify(CAN_FiRx::FB.val((m << 3) | (1 << 2) | (1 << 1)));
+                        // the or's are because we need to match the RTR and IDE bits
+                    }
+                    _ => {
+                        self.gracefully_exit_filter_cfg(was_filter_on, filter_number);
+                        return Err(kernel::ErrorCode::INVAL);
+                    }
+                }
+            }
+            Mode::Range(..) => {
+                self.gracefully_exit_filter_cfg(was_filter_on, filter_number);
+                return Err(kernel::ErrorCode::NOSUPPORT);
             }
         }
 
@@ -644,15 +795,13 @@ impl<'a> Can<'a> {
             );
         }
 
-        if enable {
-            self.registers.can_fa1r.modify(
-                CAN_FA1R::FACT.val(self.registers.can_fa1r.read(CAN_FA1R::FACT) | filter_number),
-            );
-        } else {
-            self.registers.can_fa1r.modify(
-                CAN_FA1R::FACT.val(self.registers.can_fa1r.read(CAN_FA1R::FACT) & !filter_number),
-            );
-        }
+        self.registers.can_fa1r.modify(
+            CAN_FA1R::FACT.val(self.registers.can_fa1r.read(CAN_FA1R::FACT) | filter_number),
+        );
+
+        // clear filter init bit
+        self.registers.can_fmr.modify(CAN_FMR::FINIT::CLEAR);
+        Ok(())
     }
 
     pub fn enable_filter_config(&self) {
@@ -701,7 +850,7 @@ impl<'a> Can<'a> {
                             .modify(CAN_TIxR::IDE::CLEAR);
                         self.registers.can_tx_mailbox[tx_mailbox]
                             .can_tir
-                            .modify(CAN_TIxR::STID.val(id as u32 & 0xeff));
+                            .modify(CAN_TIxR::STID.val(id as u32 & 0x7ff));
                         self.registers.can_tx_mailbox[tx_mailbox]
                             .can_tir
                             .modify(CAN_TIxR::EXID.val(0));
@@ -712,7 +861,7 @@ impl<'a> Can<'a> {
                             .modify(CAN_TIxR::IDE::SET);
                         self.registers.can_tx_mailbox[tx_mailbox]
                             .can_tir
-                            .modify(CAN_TIxR::STID.val((id & 0xffc0000) >> 18));
+                            .modify(CAN_TIxR::STID.val((id >> 18) & 0x7ff));
                         self.registers.can_tx_mailbox[tx_mailbox]
                             .can_tir
                             .modify(CAN_TIxR::EXID.val(id & 0x003fffff));
@@ -883,8 +1032,8 @@ impl<'a> Can<'a> {
         let message_length = self.registers.can_rx_mailbox[rx_mailbox]
             .can_rdtr
             .read(CAN_RDTxR::DLC) as usize;
-        let recv: u64 = ((self.registers.can_rx_mailbox[0].can_rdhr.get() as u64) << 32)
-            | (self.registers.can_rx_mailbox[0].can_rdlr.get() as u64);
+        let recv: u64 = ((self.registers.can_rx_mailbox[rx_mailbox].can_rdhr.get() as u64) << 32)
+            | (self.registers.can_rx_mailbox[rx_mailbox].can_rdlr.get() as u64);
         let rx_buf = recv.to_le_bytes();
         self.rx_buffer.map(|rx| {
             rx[..8].copy_from_slice(&rx_buf[..8]);
@@ -902,7 +1051,7 @@ impl<'a> Can<'a> {
             self.registers.can_rf0r.modify(CAN_RF0R::FOVR0::SET);
         }
 
-        if self.registers.can_rf0r.read(CAN_RF0R::FMP0) != 0 {
+        while self.registers.can_rf0r.read(CAN_RF0R::FMP0) != 0 {
             let (message_id, message_length, mut rx_buf) = self.process_received_message(0);
 
             self.receive_client.map(|receive_client| {
@@ -925,7 +1074,7 @@ impl<'a> Can<'a> {
             self.registers.can_rf1r.modify(CAN_RF1R::FOVR1::SET);
         }
 
-        if self.registers.can_rf1r.read(CAN_RF1R::FMP1) != 0 {
+        while self.registers.can_rf1r.read(CAN_RF1R::FMP1) != 0 {
             self.fifo1_interrupt_counter
                 .replace(self.fifo1_interrupt_counter.get() + 1);
             let (message_id, message_length, mut rx_buf) = self.process_received_message(1);
@@ -967,19 +1116,19 @@ impl<'a> Can<'a> {
         }
         // Last Error Code
         match self.registers.can_esr.read(CAN_ESR::LEC) {
-            0x001 => self
+            0b001 => self
                 .can_state
                 .set(CanState::RunningError(can::Error::Stuff)),
-            0x010 => self.can_state.set(CanState::RunningError(can::Error::Form)),
-            0x011 => self.can_state.set(CanState::RunningError(can::Error::Ack)),
-            0x100 => self
+            0b010 => self.can_state.set(CanState::RunningError(can::Error::Form)),
+            0b011 => self.can_state.set(CanState::RunningError(can::Error::Ack)),
+            0b100 => self
                 .can_state
                 .set(CanState::RunningError(can::Error::BitRecessive)),
-            0x101 => self
+            0b101 => self
                 .can_state
                 .set(CanState::RunningError(can::Error::BitDominant)),
-            0x110 => self.can_state.set(CanState::RunningError(can::Error::Crc)),
-            0x111 => self
+            0b110 => self.can_state.set(CanState::RunningError(can::Error::Crc)),
+            0b111 => self
                 .can_state
                 .set(CanState::RunningError(can::Error::SetBySoftware)),
             _ => {}
@@ -987,6 +1136,12 @@ impl<'a> Can<'a> {
 
         self.error_interrupt_counter
             .replace(self.error_interrupt_counter.get() + 1);
+
+        // clear ERRI (rc_w1), use set instead of modify to avoid clear by read
+        self.registers.can_msr.set(CAN_MSR::ERRI::SET.value);
+
+        // clear LEC
+        self.registers.can_esr.modify(CAN_ESR::LEC.val(0b111));
 
         if let CanState::RunningError(err) = self.can_state.get() {
             self.controller_client.map(|controller_client| {
@@ -1078,6 +1233,7 @@ impl DeferredCallClient for Can<'_> {
                             controller_client.state_changed(self.can_state.get().into());
                             controller_client.enabled(Err(enable_err));
                         });
+                        return;
                     }
                     self.controller_client.map(|controller_client| {
                         controller_client.state_changed(can::State::Running);
@@ -1352,24 +1508,27 @@ impl can::Receive<{ can::STANDARD_CAN_PACKET_SIZE }> for Can<'_> {
         match self.can_state.get() {
             CanState::Normal | CanState::RunningError(_) => {
                 self.can_state.set(CanState::Normal);
-                self.config_filter(
-                    can::FilterParameters {
-                        number: 0,
-                        scale_bits: can::ScaleBits::Bits32,
-                        identifier_mode: can::IdentifierMode::Mask,
-                        fifo_number: 0,
-                    },
-                    true,
-                );
-                self.config_filter(
-                    can::FilterParameters {
-                        number: 1,
-                        scale_bits: can::ScaleBits::Bits32,
-                        identifier_mode: can::IdentifierMode::Mask,
-                        fifo_number: 1,
-                    },
-                    true,
-                );
+                if !self.is_enabled(0).unwrap_or(false) {
+                    let _ = self.config_filter(
+                        &can::FilterParameters {
+                            mode: can::Mode::Mask {
+                                value: can::Id::Standard(0),
+                                bitmask: can::Id::Standard(0),
+                            },
+                            fifo_number: 1,
+                        },
+                        0,
+                    );
+                    // we also want extended to pass thru the initial filter
+                    // because the HIL specifies it to have to be ID0, we have to manually override the IDE bit of this filter
+                    // to make it pass through both standard and extended frames, its easier to set it like so
+                    // this also sets RTR to don't care, which setting a filter thru config_filter can't do
+                    self.registers.can_fmr.modify(CAN_FMR::FINIT::SET);
+                    self.registers.can_firx[0].modify(CAN_FiRx::FB.val(0));
+                    self.registers.can_firx[1].modify(CAN_FiRx::FB.val(0));
+                    self.registers.can_fmr.modify(CAN_FMR::FINIT::CLEAR);
+                }
+
                 self.enable_filter_config();
                 self.enable_irq(CanInterruptMode::Fifo0Interrupt);
                 self.enable_irq(CanInterruptMode::Fifo1Interrupt);
@@ -1384,24 +1543,6 @@ impl can::Receive<{ can::STANDARD_CAN_PACKET_SIZE }> for Can<'_> {
         match self.can_state.get() {
             CanState::Normal | CanState::RunningError(_) => {
                 self.can_state.set(CanState::Normal);
-                self.config_filter(
-                    can::FilterParameters {
-                        number: 0,
-                        scale_bits: can::ScaleBits::Bits32,
-                        identifier_mode: can::IdentifierMode::Mask,
-                        fifo_number: 0,
-                    },
-                    false,
-                );
-                self.config_filter(
-                    can::FilterParameters {
-                        number: 1,
-                        scale_bits: can::ScaleBits::Bits32,
-                        identifier_mode: can::IdentifierMode::Mask,
-                        fifo_number: 1,
-                    },
-                    false,
-                );
                 self.enable_filter_config();
                 self.disable_irq(CanInterruptMode::Fifo0Interrupt);
                 self.disable_irq(CanInterruptMode::Fifo1Interrupt);
@@ -1419,6 +1560,55 @@ impl can::Receive<{ can::STANDARD_CAN_PACKET_SIZE }> for Can<'_> {
                 }
             }
             CanState::Sleep | CanState::Initialization => Err(kernel::ErrorCode::OFF),
+        }
+    }
+}
+
+impl can::Filters for Can<'_> {
+    fn enable_filter(
+        &self,
+        number: usize,
+        filter: &can::FilterParameters,
+    ) -> Result<(), kernel::ErrorCode> {
+        self.config_filter(filter, number)
+    }
+
+    fn disable_filter(&self, number: usize) -> Result<(), kernel::ErrorCode> {
+        if number >= 28 {
+            return Err(kernel::ErrorCode::INVAL);
+        }
+        // according to 32.9.4 we can clear this with finit cleared
+        self.registers.can_fa1r.modify(
+            CAN_FA1R::FACT.val(self.registers.can_fa1r.read(CAN_FA1R::FACT) & !(1 << number)),
+        );
+        Ok(())
+    }
+
+    fn is_enabled(&self, number: usize) -> Result<bool, kernel::ErrorCode> {
+        if number >= 28 {
+            return Err(kernel::ErrorCode::INVAL);
+        }
+        Ok(self.registers.can_fa1r.read(CAN_FA1R::FACT) & (1 << number) != 0)
+    }
+
+    // all 3 counts are the same because on bxcan you can have either ext, std or both in the same filter
+    fn filter_count(&self) -> usize {
+        28
+    }
+
+    fn filter_count_std(&self) -> usize {
+        28
+    }
+
+    fn filter_count_ext(&self) -> usize {
+        28
+    }
+
+    fn id_list_max_len(&self, has_extended: bool) -> usize {
+        if has_extended {
+            2
+        } else {
+            4
         }
     }
 }

--- a/kernel/src/hil/can.rs
+++ b/kernel/src/hil/can.rs
@@ -126,45 +126,44 @@ impl From<Error> for ErrorCode {
     }
 }
 
-/// The Scale Bits structure defines the 2 possible widths
-/// of the filter bank
+/// Mode of one of the filter elements.
+///
+/// This most closely resembles Bosch MCAN as it is the most prevalent CAN peripheral
+/// Some drivers of other CAN peripherals(like bxCAN) can return no support on some of these modes
+/// Most, if not all CAN peripherals should support mask mode
 #[derive(Debug, Copy, Clone)]
-pub enum ScaleBits {
-    Bits16,
-    Bits32,
-}
-
-/// The filter can be configured to filter the messages by matching
-/// an identifier or by bitwise matching multiple identifiers.
-#[derive(Debug, Copy, Clone)]
-pub enum IdentifierMode {
-    /// A mask is used to filter the messages
-    List,
-    /// The value of the identifier is used to filter the messages
-    Mask,
+pub enum Mode<'a> {
+    /// A list of allowed IDs composes the element.
+    /// Keep in mind that these may vary. For example, bxCAN can have 4 standard filters/element while MCAN can only have 2
+    /// Trying to create a list filter with more than the max supported amount will return an error
+    List(&'a [Id]),
+    /// An ID and a bitmask compose the filter element.
+    /// The true bits in the bitmask must match in order for the message to be received.
+    /// This mode should be supported on almost all CAN peripherals.
+    /// It goes without saying that you cannot apply an extended ID bitmask to a standard ID or vice versa.
+    Mask { value: Id, bitmask: Id },
+    /// Range mode is composed of two IDs
+    /// The IDs must both be standard or extended
+    /// All IDs in the range will pass through the filter
+    /// May be unsupported on some CAN peripherals, in this case it will return a NOSUPPORT error
+    Range(Id, Id),
 }
 
 /// The identifier can be standard (11 bits) or extended (29 bits)
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
 pub enum Id {
     Standard(u16),
     Extended(u32),
 }
 
 /// This structure defines the parameters to configure a filter bank
+///
+/// This is thought to most closely resemble the Bosch MCAN peripheral found on most modern MCUs
+/// For chips using older or different peripheral some modes may return nosupport or invalid error
 #[derive(Copy, Clone)]
-pub struct FilterParameters {
-    /// The filter Id
-    ///
-    /// This value is dependent on the peripheral used and identifies
-    /// the filter bank that will be used
-    pub number: u32,
-
-    /// The width of the filter bank
-    pub scale_bits: ScaleBits,
-
+pub struct FilterParameters<'a> {
     /// The way in which the message Ids will be filtered.
-    pub identifier_mode: IdentifierMode,
+    pub mode: Mode<'a>,
 
     /// The receive FIFO Id that the filter will be applied to
     pub fifo_number: usize,
@@ -545,11 +544,8 @@ pub trait ConfigureFd: Configure {
     fn get_frame_size() -> usize;
 }
 
-/// The `Filter` trait is used to enable and disable a filter bank.
-///
-/// When the receiving process starts by calling the `start_receiving_process`
-/// in the `Receive` trait, there MUST be no filter enabled.
-pub trait Filter {
+/// The `Filters` trait is used to enable and disable a filter bank.
+pub trait Filters {
     /// Enables a filter for message reception.
     ///
     /// # Arguments:
@@ -557,28 +553,46 @@ pub trait Filter {
     /// * `filter` - A FilterParameters structure to define the filter
     ///   configuration
     ///
+    /// * 'number' = The filter Id to identify the filter bank to enable, will return inval if bigger than `filter_count()`
+    ///
     /// # Return values:
     ///
     /// * `Ok()` - The filter was successfully configured.
     /// * `Err(ErrorCode)` - indicates the error because of which the request
     ///   cannot be completed
-    fn enable_filter(&self, filter: FilterParameters) -> Result<(), ErrorCode>;
+    fn enable_filter(&self, number: usize, filter: &FilterParameters) -> Result<(), ErrorCode>;
 
     /// Disables a filter.
     ///
     /// # Arguments:
     ///
-    /// * `number` - The filter Id to identify the filter bank to disable
+    /// * `number` - The filter Id to identify the filter bank to disable, will return INVAL if bigger than `filter_count()`
     ///
     /// # Return values:
     ///
     /// * `Ok()` - The filter was successfully disabled.
     /// * `Err(ErrorCode)` - indicates the error because of which the request
     ///   cannot be completed
-    fn disable_filter(&self, number: u32) -> Result<(), ErrorCode>;
+    fn disable_filter(&self, number: usize) -> Result<(), ErrorCode>;
+
+    /// Returns whether the filter bank with the provided number is enabled
+    fn is_enabled(&self, number: usize) -> Result<bool, ErrorCode>;
 
     /// Returns the number of filters the peripheral provides
     fn filter_count(&self) -> usize;
+
+    /// Returns the theoretical max number of standard filters, could be smaller if extended filters are also used
+    fn filter_count_std(&self) -> usize;
+
+    /// Returns the theoretical max number of active extended filters, could be smaller if standard filters are also used
+    fn filter_count_ext(&self) -> usize;
+
+    /// Maximum number of identifiers accepted in a single `Mode::List` filter.
+    ///
+    /// `has_extended` must be true if *any* identifier in the intended list is
+    /// extended, since a peripheral may be forced into a wider filter layout by
+    /// a single extended identifier.
+    fn id_list_max_len(&self, has_extended: bool) -> usize;
 }
 
 /// The `Controller` trait is used to enable and disable the CAN peripheral.
@@ -684,9 +698,10 @@ pub trait Receive<const PACKET_SIZE: usize> {
     /// Start receiving messaged on the CAN bus.
     ///
     /// In most cases, this function should be called after the peripheral was
-    /// previously configured. When calling this function, there MUST be
-    /// no filters enabled by the user. The implementation of this function
-    /// MUST permit receiving frames on all available receiving FIFOs.
+    /// previously configured. If the peripheral requires a filter to receive messages and no filter is already set on number 0,
+    /// this function will create a pass all filter on slot 0. The user must disable or overwrite this filter if they
+    /// wish to only allow specific messages to be received.
+    /// The implementation of this function MUST permit receiving frames on all available receiving FIFOs.
     ///
     /// # Arguments:
     ///


### PR DESCRIPTION
### Pull Request Overview

This pull request adds proper filter support for the STM32F4xx bxCAN peripheral. It also fixes various small bugs throughout the driver. 

It also proposes some needed HIL changes such that it matches more CAN peripherals, especially the ones in modern chips, while trying to lose as little functionality as possible. The HIL is made to most closely resemble the Bosch M_CAN FDCAN peripheral that is the most prevalent in modern MCUs. As in the F4 driver, it can be used on other peripherals as well. Unsupported features or attempts to do something that the peripheral doesn't support result in INVAL or NOSUPPORT errors.


### Testing Strategy

This pull request was tested by actually receiving messages on a NUCLEO F429ZI devboard with a CAN transciever. As the capsule doesn't yet seem to implement any filter functionality, they were set upon driver init in the kernel. A small and very rudimentary userspace implementation was used to test actually receiving messages.


### TODO or Help Wanted

This pull request still needs a capsule to actually expose this functionality to userspace.

The point of this was backporting the HIL changes that were made for filter support in the U545 CAN driver that will be PR'd in a very short time to the only existing CAN driver, which is the f4.


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>


Claude was used to help me understand the codebase and also build very rudimentary userspace support for testing.
No AI CLI tools of any sort were used in the development of any of the code in the pull request itself.