### PR TITLE
2026-06-17 core WG notes: include more tock-registers migration plan

### DIFF
--- a/doc/wg/core/notes/core-notes-2026-06-17.md
+++ b/doc/wg/core/notes/core-notes-2026-06-17.md
@@ -81,7 +81,7 @@
 * Leon: Something that stuck out to me: understanding how register structs use array suboptimally now. I don't think this is viable for a port, but for just understanding LLMs are good at extracting semantic patterns.
 * Johnathan: I thought about that, but I was worried that it would switch all PRs to "I used LLMs on this" and track that. An LLM would be helpful for understanding though.
 * Leon: Makes sense, I can see the taint issue.
-* Johnathan: So release 0.11 on crates.io. Then add tock-registers-v0 workspace-wide pointing at 0.11. Migrate all crates to that version. Delete the kernel exports. Then add a new dependency that's the new tock registers that points at main on the new tock registers, tagged to a commit.
+* Johnathan: So release 0.11 on crates.io. Then add tock-registers-v0 workspace-wide pointing at 0.11. Migrate all crates to that version. Delete the kernel exports. Remove the old APIs from tock-registers. Then add a new workspace dependency to tock that points at main on the new tock registers, pinned to a commit. Migrate some drivers to the new APIs. Once the new APIs have stabilized, release tock-registers 2.0.
 * Johnathan: Question, do we immediately remove the old APIs from main after releasing 0.11?
 * Brad: Yes
 * Leon: Did we decide on a 0.11 not a 1.0? (general agreement)


### PR DESCRIPTION
### Pull Request Overview

During the 2026-06-17 meeting, the notetaker did not quite keep up when I was reading my proposed plan for migrating Tock to register_map. I had that plan on paper, so I know what I said, but regrettably I did not speak up with the full plan when the notes PR was originally sent.

This completes the plan based on the written notes I had during the meeting.

I'm okay if we ditch this, I recognize that it's pretty late for a notes fix.

### Testing Strategy

Viewed [Rendered](https://github.com/jrvanwhy/tock/blob/registers-migration-notes/doc/wg/core/notes/core-notes-2026-06-17.md) doc.

### TODO or Help Wanted

None

### Checklist

- [X] Ran `make prepush`.


### PR Contents

#### Documentation

- [X] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [ ] No documentation updates are required.

#### AI Use

- [X] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
