### PR TITLE
kernel: Document IPC safety

### DIFF
--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -65,6 +65,20 @@ impl<const NUM_PROCS: u8> IPC<NUM_PROCS> {
 
     /// Schedule an IPC upcall for a process. This is called by the main
     /// scheduler loop if an IPC task was queued for the process.
+    ///
+    /// # Safety
+    ///
+    /// Scheduling the upcall is what causes a shared buffer to be shared with
+    /// the target (`schedule_on`) process. This causes an MPU region to be
+    /// created for the target process, giving it access to the shared buffer.
+    ///
+    /// The caller must ensure that source (`called_from`) process is not
+    /// deallocated/reclaimed while the buffer is still shared (i.e., the MPU
+    /// region is mapped). Failing to ensure this could potentially give the
+    /// original target process access to memory allocated for a new process.
+    /// More problematically, that memory could be used for the kernel's grant
+    /// region for a new process, and allowing a process to access that memory
+    /// violates memory safety for the kernel.
     pub(crate) unsafe fn schedule_upcall(
         &self,
         schedule_on: ProcessId,

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -661,12 +661,9 @@ impl Kernel {
                                         // Should we communicate the error somehow?
                                         // https://github.com/tock/tock/issues/1993
                                         //
-                                        // SAFETY: This is safe by coincidence: we currently have no code in
-                                        // Tock that _actually_ reclaims any memory given out to processes.
-                                        // So, even though a process can have a MPU region for a buffer
-                                        // owned by a process that no longer exists, the underlying memory
-                                        // for that buffer is guaranteed to not be used by the kernel for
-                                        // anything.
+                                        // SAFETY: This is NOT safe. This is a known issue with this
+                                        // implementation of IPC:
+                                        // <https://github.com/tock/tock/issues/1993>.
                                         unsafe {
                                             let _ = ipc.schedule_upcall(
                                                 process.processid(),

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -660,6 +660,13 @@ impl Kernel {
                                         // TODO(alevy): this could error for a variety of reasons.
                                         // Should we communicate the error somehow?
                                         // https://github.com/tock/tock/issues/1993
+                                        //
+                                        // SAFETY: This is safe by coincidence: we currently have no code in
+                                        // Tock that _actually_ reclaims any memory given out to processes.
+                                        // So, even though a process can have a MPU region for a buffer
+                                        // owned by a process that no longer exists, the underlying memory
+                                        // for that buffer is guaranteed to not be used by the kernel for
+                                        // anything.
                                         unsafe {
                                             let _ = ipc.schedule_upcall(
                                                 process.processid(),


### PR DESCRIPTION
### Pull Request Overview

It is going to take longer to merge #5090 which removes our existing IPC. In the meantime, this adds safety documentation for IPC so we can continue to work towards automatically enforcing safety docs in the kernel code.

For our use of IPC, I just point to the issue and say that this code is in fact not safe.


### Testing Strategy

n/a


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
