### PR TITLE
apploader: add uninstall function

### DIFF
--- a/boards/components/src/app_loader.rs
+++ b/boards/components/src/app_loader.rs
@@ -26,8 +26,10 @@
 //!     dynamic_binary_storage,
 //!     dynamic_binary_storage,
 //!     dynamic_binary_storage,
+//!     dynamic_binary_storage,
 //!     create_capability!(capabilities::MemoryAllocationCapability),
 //!     ).finalize(components::app_loader_component_static!(
+//!     DynamicBinaryStorage<'static>,
 //!     DynamicBinaryStorage<'static>,
 //!     DynamicBinaryStorage<'static>,
 //!     DynamicBinaryStorage<'static>,
@@ -43,8 +45,8 @@ use kernel::dynamic_binary_storage;
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! app_loader_component_static {
-    ($S:ty, $L:ty, $T:ty $(,)?) => {{
-        let al = kernel::static_buf!(capsules_extra::app_loader::AppLoader<$S, $L, $T>);
+    ($S:ty, $L:ty, $T:ty, $U:ty $(,)?) => {{
+        let al = kernel::static_buf!(capsules_extra::app_loader::AppLoader<$S, $L, $T, $U>);
         let buffer = kernel::static_buf!([u8; capsules_extra::app_loader::BUF_LEN]);
 
         (al, buffer)
@@ -55,6 +57,7 @@ pub struct AppLoaderComponent<
     S: dynamic_binary_storage::DynamicBinaryStore + 'static,
     L: dynamic_binary_storage::DynamicProcessLoad + 'static,
     T: dynamic_binary_storage::DynamicProcessUnload + 'static,
+    U: dynamic_binary_storage::DynamicProcessUninstall + 'static,
     CAP: MemoryAllocationCapability + 'static,
 > {
     board_kernel: &'static kernel::Kernel,
@@ -62,6 +65,7 @@ pub struct AppLoaderComponent<
     storage_driver: &'static S,
     load_driver: &'static L,
     unload_driver: &'static T,
+    uninstall_driver: &'static U,
     mem_cap: CAP,
 }
 
@@ -69,8 +73,9 @@ impl<
     S: dynamic_binary_storage::DynamicBinaryStore + 'static,
     L: dynamic_binary_storage::DynamicProcessLoad + 'static,
     T: dynamic_binary_storage::DynamicProcessUnload + 'static,
+    U: dynamic_binary_storage::DynamicProcessUninstall + 'static,
     CAP: MemoryAllocationCapability + 'static,
-> AppLoaderComponent<S, L, T, CAP>
+> AppLoaderComponent<S, L, T, U, CAP>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
@@ -78,6 +83,7 @@ impl<
         storage_driver: &'static S,
         load_driver: &'static L,
         unload_driver: &'static T,
+        uninstall_driver: &'static U,
         mem_cap: CAP,
     ) -> Self {
         Self {
@@ -86,6 +92,7 @@ impl<
             storage_driver,
             load_driver,
             unload_driver,
+            uninstall_driver,
             mem_cap,
         }
     }
@@ -95,14 +102,15 @@ impl<
     S: dynamic_binary_storage::DynamicBinaryStore + 'static,
     L: dynamic_binary_storage::DynamicProcessLoad + 'static,
     T: dynamic_binary_storage::DynamicProcessUnload + 'static,
+    U: dynamic_binary_storage::DynamicProcessUninstall + 'static,
     CAP: MemoryAllocationCapability + 'static,
-> Component for AppLoaderComponent<S, L, T, CAP>
+> Component for AppLoaderComponent<S, L, T, U, CAP>
 {
     type StaticInput = (
-        &'static mut MaybeUninit<AppLoader<S, L, T>>,
+        &'static mut MaybeUninit<AppLoader<S, L, T, U>>,
         &'static mut MaybeUninit<[u8; capsules_extra::app_loader::BUF_LEN]>,
     );
-    type Output = &'static AppLoader<S, L, T>;
+    type Output = &'static AppLoader<S, L, T, U>;
 
     fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let buffer = static_buffer
@@ -115,6 +123,7 @@ impl<
             self.storage_driver,
             self.load_driver,
             self.unload_driver,
+            self.uninstall_driver,
             buffer,
         ));
         dynamic_binary_storage::DynamicBinaryStore::set_storage_client(
@@ -127,6 +136,10 @@ impl<
         );
         dynamic_binary_storage::DynamicProcessUnload::set_unload_client(
             self.unload_driver,
+            dynamic_app_loader,
+        );
+        dynamic_binary_storage::DynamicProcessUninstall::set_uninstall_client(
+            self.uninstall_driver,
             dynamic_app_loader,
         );
         dynamic_app_loader

--- a/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
@@ -156,6 +156,7 @@ pub struct MicroBit {
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
+        DynamicBinaryStorage<'static>,
     >,
 
     scheduler: &'static SchedulerInUse,
@@ -885,9 +886,11 @@ unsafe fn start() -> (
         dynamic_binary_storage,
         dynamic_binary_storage,
         dynamic_binary_storage,
+        dynamic_binary_storage,
         create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::app_loader_component_static!(
+        DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
@@ -100,6 +100,7 @@ pub struct Platform {
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
+        DynamicBinaryStorage<'static>,
     >,
 }
 
@@ -508,9 +509,11 @@ pub unsafe fn main() {
         dynamic_binary_storage,
         dynamic_binary_storage,
         dynamic_binary_storage,
+        dynamic_binary_storage,
         create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::app_loader_component_static!(
+        DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,

--- a/boards/tutorials/nrf52840dk-dynamic-apps-and-policies/src/main.rs
+++ b/boards/tutorials/nrf52840dk-dynamic-apps-and-policies/src/main.rs
@@ -83,6 +83,7 @@ type AppLoaderDriver = capsules_extra::app_loader::AppLoader<
     DynamicBinaryStorage<'static>,
     DynamicBinaryStorage<'static>,
     DynamicBinaryStorage<'static>,
+    DynamicBinaryStorage<'static>,
 >;
 
 type Verifier = ecdsa_sw::p256_verifier::EcdsaP256SignatureVerifier<'static>;
@@ -528,9 +529,11 @@ pub unsafe fn main() {
         dynamic_binary_storage,
         dynamic_binary_storage,
         dynamic_binary_storage,
+        dynamic_binary_storage,
         create_capability!(capabilities::MemoryAllocationCapability),
     )
     .finalize(components::app_loader_component_static!(
+        DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,
         DynamicBinaryStorage<'static>,

--- a/capsules/extra/src/app_loader.rs
+++ b/capsules/extra/src/app_loader.rs
@@ -614,7 +614,7 @@ impl<
                 // (usually defined by the return value of `Unload`, but
                 // can be extensible).
 
-                let result = self.uninstall_driver.uninstall(arg1);
+                let result = self.uninstall_driver.uninstall_with_app_handle(arg1);
                 match result {
                     Ok(()) => CommandReturn::success(),
                     Err(e) => {

--- a/capsules/extra/src/app_loader.rs
+++ b/capsules/extra/src/app_loader.rs
@@ -100,8 +100,10 @@ mod upcall {
     pub const ABORT_DONE: usize = 4;
     /// Unload done callback.
     pub const UNLOAD_DONE: usize = 5;
+    /// Uninstall Done callback.
+    pub const UNINSTALL_DONE: usize = 6;
     /// Number of upcalls.
-    pub const COUNT: u8 = 6;
+    pub const COUNT: u8 = 7;
 }
 
 // Ids for read-only allow buffers
@@ -125,11 +127,13 @@ pub struct AppLoader<
     S: dynamic_binary_storage::DynamicBinaryStore + 'static,
     L: dynamic_binary_storage::DynamicProcessLoad + 'static,
     T: dynamic_binary_storage::DynamicProcessUnload + 'static,
+    U: dynamic_binary_storage::DynamicProcessUninstall + 'static,
 > {
     // The underlying driver for the process flashing and loading.
     storage_driver: &'static S,
     load_driver: &'static L,
     unload_driver: &'static T,
+    uninstall_driver: &'static U,
     // Per-app state.
     apps: Grant<
         App,
@@ -149,7 +153,8 @@ impl<
     S: dynamic_binary_storage::DynamicBinaryStore + 'static,
     L: dynamic_binary_storage::DynamicProcessLoad + 'static,
     T: dynamic_binary_storage::DynamicProcessUnload + 'static,
-> AppLoader<S, L, T>
+    U: dynamic_binary_storage::DynamicProcessUninstall + 'static,
+> AppLoader<S, L, T, U>
 {
     pub fn new(
         grant: Grant<
@@ -161,13 +166,15 @@ impl<
         storage_driver: &'static S,
         load_driver: &'static L,
         unload_driver: &'static T,
+        uninstall_driver: &'static U,
         buffer: &'static mut [u8],
-    ) -> AppLoader<S, L, T> {
+    ) -> AppLoader<S, L, T, U> {
         AppLoader {
             apps: grant,
             storage_driver,
             load_driver,
             unload_driver,
+            uninstall_driver,
             buffer: TakeCell::new(buffer),
             current_process: OptionalCell::empty(),
             new_app_length: Cell::new(0),
@@ -253,7 +260,8 @@ impl<
     S: dynamic_binary_storage::DynamicBinaryStore + 'static,
     L: dynamic_binary_storage::DynamicProcessLoad + 'static,
     T: dynamic_binary_storage::DynamicProcessUnload + 'static,
-> dynamic_binary_storage::DynamicBinaryStoreClient for AppLoader<S, L, T>
+    U: dynamic_binary_storage::DynamicProcessUninstall + 'static,
+> dynamic_binary_storage::DynamicBinaryStoreClient for AppLoader<S, L, T, U>
 {
     /// Let the requesting app know we are done setting up for the new app
     fn setup_done(&self, result: Result<(), ErrorCode>) {
@@ -317,7 +325,8 @@ impl<
     S: dynamic_binary_storage::DynamicBinaryStore + 'static,
     L: dynamic_binary_storage::DynamicProcessLoad + 'static,
     T: dynamic_binary_storage::DynamicProcessUnload + 'static,
-> dynamic_binary_storage::DynamicProcessLoadClient for AppLoader<S, L, T>
+    U: dynamic_binary_storage::DynamicProcessUninstall + 'static,
+> dynamic_binary_storage::DynamicProcessLoadClient for AppLoader<S, L, T, U>
 {
     /// Let the requesting app know we are done loading the new process
     ///
@@ -364,7 +373,8 @@ impl<
     S: dynamic_binary_storage::DynamicBinaryStore + 'static,
     L: dynamic_binary_storage::DynamicProcessLoad + 'static,
     T: dynamic_binary_storage::DynamicProcessUnload + 'static,
-> dynamic_binary_storage::DynamicProcessUnloadClient for AppLoader<S, L, T>
+    U: dynamic_binary_storage::DynamicProcessUninstall + 'static,
+> dynamic_binary_storage::DynamicProcessUnloadClient for AppLoader<S, L, T, U>
 {
     /// Let the app know we have unloaded the target process
     /// and return an opaque identifier for the process binary
@@ -384,12 +394,36 @@ impl<
     }
 }
 
+impl<
+    S: dynamic_binary_storage::DynamicBinaryStore + 'static,
+    L: dynamic_binary_storage::DynamicProcessLoad + 'static,
+    T: dynamic_binary_storage::DynamicProcessUnload + 'static,
+    U: dynamic_binary_storage::DynamicProcessUninstall + 'static,
+> dynamic_binary_storage::DynamicProcessUninstallClient for AppLoader<S, L, T, U>
+{
+    /// Let the app know we have uninstalled the target application
+    /// binary.
+    fn uninstall_done(&self, result: Result<(), ErrorCode>) {
+        self.current_process.map(|processid| {
+            let _ = self.apps.enter(processid, move |app, kernel_data| {
+                // And then signal the app.
+                app.pending_command = false;
+
+                self.current_process.take();
+                let _ = kernel_data
+                    .schedule_upcall(upcall::UNINSTALL_DONE, (into_statuscode(result), 0, 0));
+            });
+        });
+    }
+}
+
 /// Provide an interface for userland.
 impl<
     S: dynamic_binary_storage::DynamicBinaryStore + 'static,
     L: dynamic_binary_storage::DynamicProcessLoad + 'static,
     T: dynamic_binary_storage::DynamicProcessUnload + 'static,
-> SyscallDriver for AppLoader<S, L, T>
+    U: dynamic_binary_storage::DynamicProcessUninstall + 'static,
+> SyscallDriver for AppLoader<S, L, T, U>
 {
     /// Command interface.
     ///
@@ -431,6 +465,9 @@ impl<
     /// - `6`: Request kernel to unload a processs
     ///  - Returns Ok(()) when the application is successfully scheduled for unload
     ///  - Returns ErrorCode::FAIL when the unload fails
+    /// - `7`: Request kernel to uninstall an application binary
+    ///  - Returns Ok(()) when application is scheduled for uninstall
+    ///  - Returns ErrorCode::FAIL when uninstall fails.
     ///
     /// The driver returns ErrorCode::INVAL if any operation is called before the
     /// preceeding operation was invoked. For example, `write()` cannot be called before
@@ -564,6 +601,21 @@ impl<
                 };
                 let res = self.unload_driver.unload(shortid);
                 match res {
+                    Ok(()) => CommandReturn::success(),
+                    Err(e) => {
+                        self.current_process.take();
+                        CommandReturn::failure(e)
+                    }
+                }
+            }
+            7 => {
+                // Request the kernel to uninstall an application binary
+                // by specifying its `app_handle`
+                // (usually defined by the return value of `Unload`, but
+                // can be extensible).
+
+                let result = self.uninstall_driver.uninstall(arg1);
+                match result {
                     Ok(()) => CommandReturn::success(),
                     Err(e) => {
                         self.current_process.take();

--- a/kernel/src/dynamic_binary_storage.rs
+++ b/kernel/src/dynamic_binary_storage.rs
@@ -392,7 +392,7 @@ impl<'a, 'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: Nonvolatil
             buffer[15] = buffer[3] ^ buffer[7] ^ buffer[11];
 
             for i in 16..BUF_LEN {
-                buffer[i] = 0x00_u8;
+                buffer[i] = 0xff_u8;
             }
         });
 
@@ -423,7 +423,7 @@ impl<'a, 'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: Nonvolatil
     fn erase_chunk(&self, offset: usize, chunk_size: usize) -> Result<(), ErrorCode> {
         self.buffer.map(|buffer| {
             for i in 0..chunk_size {
-                buffer[i] = 0x00_u8;
+                buffer[i] = 0xff_u8;
             }
         });
 

--- a/kernel/src/dynamic_binary_storage.rs
+++ b/kernel/src/dynamic_binary_storage.rs
@@ -25,7 +25,7 @@ use crate::utilities::cells::{OptionalCell, TakeCell};
 use crate::utilities::leasable_buffer::SubSliceMut;
 
 /// Expected buffer length for storing application binaries.
-pub const BUF_LEN: usize = 512;
+pub const BUF_LEN: usize = 4096;
 
 /// The number of bytes in the TBF header for a padding app.
 const PADDING_TBF_HEADER_LENGTH: usize = 16;
@@ -52,6 +52,8 @@ struct ProcessLoadMetadata {
     next_app_start_addr: usize,
     padding_requirement: PaddingRequirement,
     setup_padding: bool,
+    erase_chunk_offset: usize,
+    uninstall_app_end_address: usize,
 }
 
 /// This interface supports flashing binaries at runtime.
@@ -387,6 +389,10 @@ impl<'a, 'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: Nonvolatil
             buffer[13] = buffer[1] ^ buffer[5] ^ buffer[9];
             buffer[14] = buffer[2] ^ buffer[6] ^ buffer[10];
             buffer[15] = buffer[3] ^ buffer[7] ^ buffer[11];
+
+            for i in 16..BUF_LEN {
+                buffer[i] = 0x00_u8;
+            }
         });
 
         self.buffer.take().map_or(Err(ErrorCode::BUSY), |buffer| {
@@ -397,9 +403,9 @@ impl<'a, 'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: Nonvolatil
                 true => {
                     // Write the header only if there are more than 16 bytes.
                     // available in the flash.
-                    let mut padding_slice = SubSliceMut::new(buffer);
-                    padding_slice.slice(..PADDING_TBF_HEADER_LENGTH);
-                    // We are only writing the header, so 16 bytes is enough.
+                    let padding_slice = SubSliceMut::new(buffer);
+                    // padding_slice.slice(..PADDING_TBF_HEADER_LENGTH);
+                    // // We are only writing the header, so 16 bytes is enough.
                     self.write_buffer(padding_slice, offset)
                         .map_err(|(e, buf)| {
                             self.buffer.replace(buf.take());
@@ -408,6 +414,31 @@ impl<'a, 'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: Nonvolatil
                 }
                 false => Err(ErrorCode::NOMEM),
             }
+        })
+    }
+
+    /// Function to erase a chunk of non-volatile storage.
+    /// Takes in arguments for the offset and chunk size.
+    fn erase_chunk(&self, offset: usize, chunk_size: usize) -> Result<(), ErrorCode> {
+        self.buffer.map(|buffer| {
+            for i in 0..chunk_size {
+                buffer[i] = 0x00_u8;
+            }
+        });
+
+        // We risk the chance of skipping a page on reset
+        if let Some(mut metadata) = self.process_metadata.get() {
+            metadata.erase_chunk_offset = offset + chunk_size;
+            self.process_metadata.set(metadata);
+        }
+
+        // If power cycle happens here
+        self.buffer.take().map_or(Err(ErrorCode::BUSY), |buffer| {
+            let erase_chunk = SubSliceMut::new(buffer);
+            self.write_buffer(erase_chunk, offset).map_err(|(e, buf)| {
+                self.buffer.replace(buf.take());
+                e
+            })
         })
     }
 }
@@ -519,11 +550,19 @@ impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileSto
             }
             State::Uninstall => {
                 self.buffer.replace(buffer);
-                // Reset metadata and let client know we are done uninstalling the app.
-                self.reset_process_loading_metadata();
-                self.uninstall_client.map(|client| {
-                    client.uninstall_done(Ok(()));
-                });
+                if let Some(metadata) = self.process_metadata.get() {
+                    if metadata.erase_chunk_offset < metadata.uninstall_app_end_address {
+                        // We are still within the bounds of this application, so let
+                        // us erase it.
+                        let _ = self.erase_chunk(metadata.erase_chunk_offset, BUF_LEN);
+                    } else {
+                        // Reset metadata and let client know we are done uninstalling the app.
+                        self.reset_process_loading_metadata();
+                        self.uninstall_client.map(|client| {
+                            client.uninstall_done(Ok(()));
+                        });
+                    }
+                }
             }
             State::Idle => {
                 self.buffer.replace(buffer);
@@ -830,6 +869,7 @@ impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileSto
         match self.state.get() {
             State::Idle => {
                 self.state.set(State::Uninstall);
+                self.process_metadata.set(ProcessLoadMetadata::default());
 
                 // This relation is true for this implementation, however,
                 // app_handle could encompass other identifiers.
@@ -847,7 +887,15 @@ impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileSto
                 let padding_result =
                     self.write_padding_app(application_binary_size, application_binary_address);
                 let _ = match padding_result {
-                    Ok(()) => Ok(()),
+                    Ok(()) => {
+                        if let Some(mut metadata) = self.process_metadata.get() {
+                            metadata.erase_chunk_offset = application_binary_address + BUF_LEN;
+                            metadata.uninstall_app_end_address =
+                                application_binary_address + application_binary_size;
+                            self.process_metadata.set(metadata);
+                        }
+                        Ok(())
+                    }
                     Err(_) => {
                         // This means we were unable to write the
                         // padding app.

--- a/kernel/src/dynamic_binary_storage.rs
+++ b/kernel/src/dynamic_binary_storage.rs
@@ -38,6 +38,7 @@ pub enum State {
     Load,
     Abort,
     Unload(Result<(), ErrorCode>, usize),
+    Uninstall,
     PaddingWrite,
     Fail,
 }
@@ -152,6 +153,24 @@ pub trait DynamicProcessUnloadClient {
     fn unload_done(&self, result: Result<(), ErrorCode>, app_handle: usize);
 }
 
+/// This interface supports uninstalling processes during runtime.
+pub trait DynamicProcessUninstall {
+    /// Call to uninstall an application binary with a specified `app_handle`.
+    fn uninstall(&self, app_handle: usize) -> Result<(), ErrorCode>;
+
+    /// Sets a client for the SequentialDynamicProcessUninstall Object
+    ///
+    /// When the client operation is done, it calls the `uninstall_done()`
+    /// function.
+    fn set_uninstall_client(&self, client: &'static dyn DynamicProcessUninstallClient);
+}
+
+/// The callback for dynamic process unloading.
+pub trait DynamicProcessUninstallClient {
+    /// Removed application binary from storage.
+    fn uninstall_done(&self, result: Result<(), ErrorCode>);
+}
+
 /// Dynamic process loading machine.
 pub struct SequentialDynamicBinaryStorage<
     'a,
@@ -167,6 +186,7 @@ pub struct SequentialDynamicBinaryStorage<
     storage_client: OptionalCell<&'static dyn DynamicBinaryStoreClient>,
     load_client: OptionalCell<&'static dyn DynamicProcessLoadClient>,
     unload_client: OptionalCell<&'static dyn DynamicProcessUnloadClient>,
+    uninstall_client: OptionalCell<&'static dyn DynamicProcessUninstallClient>,
     process_metadata: OptionalCell<ProcessLoadMetadata>,
     state: Cell<State>,
     deferred_call: DeferredCall,
@@ -189,6 +209,7 @@ impl<'a, 'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: Nonvolatil
             storage_client: OptionalCell::empty(),
             load_client: OptionalCell::empty(),
             unload_client: OptionalCell::empty(),
+            uninstall_client: OptionalCell::empty(),
             process_metadata: OptionalCell::empty(),
             state: Cell::new(State::Idle),
             deferred_call: DeferredCall::new(),
@@ -239,7 +260,9 @@ impl<'a, 'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: Nonvolatil
             // If we are going to write the padding header, we already know
             // where to write in flash, so we don't have to add the start
             // address
-            State::Setup | State::Load | State::PaddingWrite | State::Abort => Ok(offset),
+            State::Setup | State::Load | State::PaddingWrite | State::Abort | State::Uninstall => {
+                Ok(offset)
+            }
             // We aren't supposed to be able to write unless we are in one of
             // the first two write states
             _ => Err(ErrorCode::FAIL),
@@ -493,6 +516,14 @@ impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileSto
             }
             State::Unload(_, _) => {
                 self.buffer.replace(buffer);
+            }
+            State::Uninstall => {
+                self.buffer.replace(buffer);
+                // Reset metadata and let client know we are done uninstalling the app.
+                self.reset_process_loading_metadata();
+                self.uninstall_client.map(|client| {
+                    client.uninstall_done(Ok(()));
+                });
             }
             State::Idle => {
                 self.buffer.replace(buffer);
@@ -776,6 +807,55 @@ impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileSto
                 };
 
                 result
+            }
+            _ => {
+                // We are in the wrong mode of operation. Ideally we should never reach
+                // here, but this error exists as a failsafe. The capsule should send
+                // a busy error out to the userland app.
+                Err(ErrorCode::BUSY)
+            }
+        }
+    }
+}
+
+/// Uninstall interface exposed to the app_loader capsule
+impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileStorage<'b>>
+    DynamicProcessUninstall for SequentialDynamicBinaryStorage<'_, 'b, C, D, F>
+{
+    fn set_uninstall_client(&self, client: &'static dyn DynamicProcessUninstallClient) {
+        self.uninstall_client.set(client);
+    }
+
+    fn uninstall(&self, app_handle: usize) -> Result<(), ErrorCode> {
+        match self.state.get() {
+            State::Idle => {
+                self.state.set(State::Uninstall);
+
+                // This relation is true for this implementation, however,
+                // app_handle could encompass other identifiers.
+                let application_binary_address = app_handle;
+
+                let application_binary_size =
+                    match self.loader_driver.fetch_application_binary_size(app_handle) {
+                        Ok(app_size) => app_size as usize,
+                        Err(_) => {
+                            self.reset_process_loading_metadata();
+                            return Err(ErrorCode::FAIL);
+                        }
+                    };
+
+                let padding_result =
+                    self.write_padding_app(application_binary_size, application_binary_address);
+                let _ = match padding_result {
+                    Ok(()) => Ok(()),
+                    Err(_) => {
+                        // This means we were unable to write the
+                        // padding app.
+                        self.reset_process_loading_metadata();
+                        Err(ErrorCode::FAIL)
+                    }
+                };
+                padding_result
             }
             _ => {
                 // We are in the wrong mode of operation. Ideally we should never reach

--- a/kernel/src/dynamic_binary_storage.rs
+++ b/kernel/src/dynamic_binary_storage.rs
@@ -158,6 +158,7 @@ pub trait DynamicProcessUnloadClient {
 /// This interface supports uninstalling processes during runtime.
 pub trait DynamicProcessUninstall {
     /// Call to uninstall an application binary with a specified `app_handle`.
+    /// `app_handle` is defined by the return value of the `Unload()` operation.
     fn uninstall_with_app_handle(&self, app_handle: usize) -> Result<(), ErrorCode>;
 
     /// Sets a client for the SequentialDynamicProcessUninstall Object

--- a/kernel/src/dynamic_binary_storage.rs
+++ b/kernel/src/dynamic_binary_storage.rs
@@ -158,7 +158,7 @@ pub trait DynamicProcessUnloadClient {
 /// This interface supports uninstalling processes during runtime.
 pub trait DynamicProcessUninstall {
     /// Call to uninstall an application binary with a specified `app_handle`.
-    fn uninstall(&self, app_handle: usize) -> Result<(), ErrorCode>;
+    fn uninstall_with_app_handle(&self, app_handle: usize) -> Result<(), ErrorCode>;
 
     /// Sets a client for the SequentialDynamicProcessUninstall Object
     ///
@@ -865,7 +865,7 @@ impl<'b, C: Chip + 'static, D: ProcessStandardDebug + 'static, F: NonvolatileSto
         self.uninstall_client.set(client);
     }
 
-    fn uninstall(&self, app_handle: usize) -> Result<(), ErrorCode> {
+    fn uninstall_with_app_handle(&self, app_handle: usize) -> Result<(), ErrorCode> {
         match self.state.get() {
             State::Idle => {
                 self.state.set(State::Uninstall);

--- a/kernel/src/process_loading.rs
+++ b/kernel/src/process_loading.rs
@@ -1235,6 +1235,37 @@ impl<'a, C: Chip, D: ProcessStandardDebug> SequentialProcessLoaderMachine<'a, C,
             )),
         }
     }
+
+    /// Function to return the size of an application with a specified handle `app_handle`.
+    pub fn fetch_application_binary_size(
+        &self,
+        app_handle: usize,
+    ) -> Result<u32, ProcessBinaryError> {
+        let flash = self.flash_bank.get();
+        let application_binary_address = app_handle - flash.as_ptr() as usize;
+
+        // Might want to verify if the app is valid with check_new_binary_validity() either here, or before returning the size
+        let test_header_slice = flash
+            .get(application_binary_address..application_binary_address + 8)
+            .ok_or(ProcessBinaryError::NotEnoughFlash)?;
+
+        let header = test_header_slice
+            .try_into()
+            .or(Err(ProcessBinaryError::NotEnoughFlash))?;
+
+        let (_version, _header_length, app_length) =
+            match tock_tbf::parse::parse_tbf_header_lengths(header) {
+                Ok((v, hl, el)) => (v, hl, el),
+                Err(tock_tbf::types::InitialTbfParseError::InvalidHeader(_app_length)) => {
+                    return Err(ProcessBinaryError::TbfHeaderNotFound);
+                }
+                Err(tock_tbf::types::InitialTbfParseError::UnableToParse) => {
+                    return Err(ProcessBinaryError::TbfHeaderNotFound);
+                }
+            };
+
+        Ok(app_length)
+    }
 }
 
 impl<'a, C: Chip, D: ProcessStandardDebug> ProcessLoadingAsync<'a>


### PR DESCRIPTION
### Pull Request Overview

This pull request adds the ability to uninstall an application binary.


### Testing Strategy

This pull request was tested by testing against libtock-c applications.

<img width="1502" height="1099" alt="unload_uninstall" src="https://github.com/user-attachments/assets/25974c40-d380-4fe7-8027-b13b4d49ad25" />

### TODO or Help Wanted



N/A


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [ ] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

This PR adds a new `DynamicProcessUninstall` trait that currently exposes one `uninstall(app_handle)` method. The app_handle iss an opaque identifier that comes from the `unload()` function and so You MUST call `unload` before calling `uninstall`. 

This implementation works, however a limitation is that unload only works on active processes, which are only created from the latest version off an application binary. We might be interested in removing older versions once a new version is deemed stable, or if we need to make space for other applications. This would require some sort of an identifier that is persistent and accessible to the requesting application, and a version number. This could be a separate uninstall API within the trait, but I am not entirely sure how that should be implemented for now. 