### PR TITLE
qemu_i486_q35: use config.toml `json-target-spec` instead of `-Zjson-target-spec`

### DIFF
--- a/boards/qemu_i486_q35/.cargo/config.toml
+++ b/boards/qemu_i486_q35/.cargo/config.toml
@@ -7,13 +7,12 @@ include = [
   "../../cargo/unstable_flags.toml",
 ]
 
-[env]
-# Relative to crate root, not this file
-# TODO: where is the best place to store this config file?
-RUST_TARGET_PATH = "."
-
 [build]
 target = "i486-unknown-none.json"
+
+# Required for .json target
+[unstable]
+json-target-spec = true
 
 [target.i486-unknown-none]
 runner = "qemu-system-i386 -cpu 486 -machine q35 -net none -device isa-debug-exit,iobase=0xf4,iosize=0x04 -device virtio-rng-pci,disable-legacy=on -serial stdio -kernel"

--- a/boards/qemu_i486_q35/Makefile
+++ b/boards/qemu_i486_q35/Makefile
@@ -8,10 +8,6 @@
 # Skip auto-installing targets with rustup, since we are using a custom target
 NO_RUSTUP := 1
 
-# Because we use a custom target with a .json file, we must pass
-# `-Zjson-target-spec` to cargo as of roughly January 2026.
-CARGO = cargo -Zjson-target-spec
-
 include ../Makefile.common
 
 QEMU_CMD             := qemu-system-i386


### PR DESCRIPTION
### Pull Request Overview

This removes another Makefile flag in favor of the cargo-native approach.

Technically it "puts something in .cargo", but in this case I don't really see that as a great crime since there's already a "thing" in `.cargo`, namely the `target` specifier, this is just a flag we have to set to use the `target` specifier that this file happens to choose.

### Testing Strategy

This pull request was tested by compiling.

### TODO or Help Wanted

N/A

### Checklist

- [ ] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [X] No documentation updates are required.

#### AI Use

- [X] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
