### PR TITLE
Add a PanicContext token (derived from PanicInfo) and use it to safely create PanicWriters (was #5111)

### DIFF
--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -7,6 +7,7 @@
 #![no_std]
 
 use core::fmt::Write;
+use kernel::platform::chip::PanicWriter;
 
 pub mod dcb;
 pub mod dma_fence;
@@ -101,7 +102,7 @@ pub trait CortexMVariant {
     /// Format and display architecture-specific state useful for debugging.
     ///
     /// This is generally used after a `panic!()` to aid debugging.
-    unsafe fn print_cortexm_state(writer: &mut dyn Write);
+    fn print_cortexm_state<W: Write>(writer: &mut PanicWriter<W>);
 }
 
 #[cfg(all(target_arch = "arm", target_os = "none"))]

--- a/arch/cortex-m0/src/lib.rs
+++ b/arch/cortex-m0/src/lib.rs
@@ -7,6 +7,7 @@
 #![no_std]
 
 use core::fmt::Write;
+use kernel::platform::chip::PanicWriter;
 
 // Re-export the base generic cortex-m functions here as they are
 // valid on cortex-m0.
@@ -548,7 +549,7 @@ impl cortexm::CortexMVariant for CortexM0 {
     }
 
     #[inline]
-    unsafe fn print_cortexm_state(writer: &mut dyn Write) {
+    fn print_cortexm_state<W: Write>(writer: &mut PanicWriter<W>) {
         cortexm::print_cortexm_state(writer)
     }
 }

--- a/arch/cortex-m0p/src/lib.rs
+++ b/arch/cortex-m0p/src/lib.rs
@@ -7,6 +7,7 @@
 #![no_std]
 
 use core::fmt::Write;
+use kernel::platform::chip::PanicWriter;
 
 pub mod mpu {
     use kernel::utilities::StaticRef;
@@ -126,7 +127,7 @@ impl cortexm::CortexMVariant for CortexM0P {
     }
 
     #[inline]
-    unsafe fn print_cortexm_state(writer: &mut dyn Write) {
+    fn print_cortexm_state<W: Write>(writer: &mut PanicWriter<W>) {
         cortexm::print_cortexm_state(writer)
     }
 }

--- a/arch/cortex-m3/src/lib.rs
+++ b/arch/cortex-m3/src/lib.rs
@@ -7,6 +7,7 @@
 #![no_std]
 
 use core::fmt::Write;
+use kernel::platform::chip::PanicWriter;
 
 pub mod mpu {
     use kernel::utilities::StaticRef;
@@ -59,7 +60,7 @@ impl cortexm::CortexMVariant for CortexM3 {
     }
 
     #[inline]
-    unsafe fn print_cortexm_state(writer: &mut dyn Write) {
+    fn print_cortexm_state<W: Write>(writer: &mut PanicWriter<W>) {
         cortexm::print_cortexm_state(writer)
     }
 }

--- a/arch/cortex-m33/src/lib.rs
+++ b/arch/cortex-m33/src/lib.rs
@@ -7,6 +7,7 @@
 #![no_std]
 
 use core::fmt::Write;
+use kernel::platform::chip::PanicWriter;
 
 pub mod mpu_v8m;
 
@@ -64,7 +65,7 @@ impl cortexm::CortexMVariant for CortexM33 {
     }
 
     #[inline]
-    unsafe fn print_cortexm_state(writer: &mut dyn Write) {
+    fn print_cortexm_state<W: Write>(writer: &mut PanicWriter<W>) {
         cortexm::print_cortexm_state(writer)
     }
 }

--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -7,6 +7,7 @@
 #![no_std]
 
 use core::fmt::Write;
+use kernel::platform::chip::PanicWriter;
 
 pub mod mpu {
     use kernel::utilities::StaticRef;
@@ -59,7 +60,7 @@ impl cortexm::CortexMVariant for CortexM4 {
     }
 
     #[inline]
-    unsafe fn print_cortexm_state(writer: &mut dyn Write) {
+    fn print_cortexm_state<W: Write>(writer: &mut PanicWriter<W>) {
         cortexm::print_cortexm_state(writer)
     }
 }

--- a/arch/cortex-m4f/src/lib.rs
+++ b/arch/cortex-m4f/src/lib.rs
@@ -7,6 +7,7 @@
 #![no_std]
 
 use core::fmt::Write;
+use kernel::platform::chip::PanicWriter;
 
 pub mod mpu {
     use kernel::utilities::StaticRef;
@@ -60,7 +61,7 @@ impl cortexm::CortexMVariant for CortexM4F {
     }
 
     #[inline]
-    unsafe fn print_cortexm_state(writer: &mut dyn Write) {
+    fn print_cortexm_state<W: Write>(writer: &mut PanicWriter<W>) {
         cortexm::print_cortexm_state(writer)
     }
 }

--- a/arch/cortex-m7/src/lib.rs
+++ b/arch/cortex-m7/src/lib.rs
@@ -7,6 +7,7 @@
 #![no_std]
 
 use core::fmt::Write;
+use kernel::platform::chip::PanicWriter;
 
 pub mod mpu {
     use kernel::utilities::StaticRef;
@@ -58,7 +59,7 @@ impl cortexm::CortexMVariant for CortexM7 {
     }
 
     #[inline]
-    unsafe fn print_cortexm_state(writer: &mut dyn Write) {
+    fn print_cortexm_state<W: Write>(writer: &mut PanicWriter<W>) {
         cortexm::print_cortexm_state(writer)
     }
 }

--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -8,6 +8,7 @@
 
 use core::fmt::Write;
 
+use kernel::platform::chip::PanicWriter;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 
 pub mod clic;
@@ -496,7 +497,7 @@ pub unsafe fn semihost_command(_command: usize, _arg0: usize, _arg1: usize) -> u
 }
 
 /// Print a readable string for an mcause reason.
-pub unsafe fn print_mcause(mcval: csr::mcause::Trap, writer: &mut dyn Write) {
+pub fn print_mcause(mcval: csr::mcause::Trap, writer: &mut dyn Write) {
     let s = match mcval {
         csr::mcause::Trap::Interrupt(interrupt) => match interrupt {
             csr::mcause::Interrupt::UserSoft => "User software interrupt",
@@ -533,7 +534,7 @@ pub unsafe fn print_mcause(mcval: csr::mcause::Trap, writer: &mut dyn Write) {
 
 /// Prints out RISCV machine state, including basic system registers
 /// (mcause, mstatus, mtvec, mepc, mtval, interrupt status).
-pub unsafe fn print_riscv_state(writer: &mut dyn Write) {
+pub fn print_riscv_state<W: Write>(writer: &mut PanicWriter<W>) {
     let mcval: csr::mcause::Trap = core::convert::From::from(csr::CSR.mcause.extract());
     let _ = writer.write_fmt(format_args!("\r\n---| RISC-V Machine State |---\r\n"));
     let _ = writer.write_fmt(format_args!("Last cause (mcause): "));

--- a/chips/apollo3/src/chip.rs
+++ b/chips/apollo3/src/chip.rs
@@ -8,6 +8,7 @@ use core::fmt::Write;
 use cortexm4f::{CortexM4F, CortexMVariant};
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
+use kernel::platform::chip::PanicWriter;
 
 pub struct Apollo3<I: InterruptService + 'static> {
     mpu: cortexm4f::mpu::MPU,
@@ -164,7 +165,7 @@ impl<I: InterruptService + 'static> Chip for Apollo3<I> {
         cortexm4f::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(_this: Option<&Self>, write: &mut dyn Write) {
+    fn print_state<W: Write>(_this: Option<&Self>, write: &mut PanicWriter<W>) {
         CortexM4F::print_cortexm_state(write);
     }
 }

--- a/chips/arty_e21_chip/src/chip.rs
+++ b/chips/arty_e21_chip/src/chip.rs
@@ -6,6 +6,7 @@ use core::fmt::Write;
 use kernel::debug;
 use kernel::hil::time::Freq32KHz;
 use kernel::platform::chip::InterruptService;
+use kernel::platform::chip::PanicWriter;
 use kernel::utilities::registers::interfaces::Readable;
 
 use crate::clint;
@@ -146,7 +147,7 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for ArtyExx<'a, 
         rv32i::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(_this: Option<&Self>, write: &mut dyn Write) {
+    fn print_state<W: Write>(_this: Option<&Self>, write: &mut PanicWriter<W>) {
         rv32i::print_riscv_state(write);
     }
 }

--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -8,6 +8,7 @@ use core::fmt::Write;
 use core::ptr::addr_of;
 use kernel::debug;
 use kernel::platform::chip::Chip;
+use kernel::platform::chip::PanicWriter;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 use rv32i::csr;
 use rv32i::csr::{CSR, mcause, mie::mie, mip::mip};
@@ -177,7 +178,7 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for E310x<'a, I>
         rv32i::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(_this: Option<&Self>, writer: &mut dyn Write) {
+    fn print_state<W: Write>(_this: Option<&Self>, writer: &mut PanicWriter<W>) {
         rv32i::print_riscv_state(writer);
     }
 }

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -4,10 +4,11 @@
 
 //! High-level setup and interrupt mapping for the chip.
 
-use core::fmt::{Display, Write};
+use core::fmt::Display;
+use core::fmt::Write;
 use core::marker::PhantomData;
 use core::ptr::addr_of;
-use kernel::platform::chip::{Chip, InterruptService};
+use kernel::platform::chip::{Chip, InterruptService, PanicWriter};
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use rv32i::csr::{CSR, mcause, mie::mie, mtvec::mtvec};
 use rv32i::pmp::{PMPUserMPU, TORUserPMP};
@@ -314,7 +315,7 @@ impl<
         rv32i::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(this: Option<&Self>, writer: &mut dyn Write) {
+    fn print_state<W: Write>(this: Option<&Self>, writer: &mut PanicWriter<W>) {
         let _ = writer.write_fmt(format_args!(
             "\r\n---| OpenTitan Earlgrey configuration for {} |---",
             CFG::NAME

--- a/chips/esp32-c3/src/chip.rs
+++ b/chips/esp32-c3/src/chip.rs
@@ -7,7 +7,7 @@
 use core::fmt::Write;
 use core::ptr::addr_of;
 
-use kernel::platform::chip::{Chip, InterruptService};
+use kernel::platform::chip::{Chip, InterruptService, PanicWriter};
 use kernel::utilities::StaticRef;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 
@@ -156,7 +156,7 @@ impl<'a, I: InterruptService + 'a> Chip for Esp32C3<'a, I> {
         rv32i::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(_this: Option<&Self>, writer: &mut dyn Write) {
+    fn print_state<W: Write>(_this: Option<&Self>, writer: &mut PanicWriter<W>) {
         let mcval: csr::mcause::Trap = core::convert::From::from(csr::CSR.mcause.extract());
         let _ = writer.write_fmt(format_args!("\r\n---| RISC-V Machine State |---\r\n"));
         let _ = writer.write_fmt(format_args!("Last cause (mcause): "));

--- a/chips/esp32/src/uart.rs
+++ b/chips/esp32/src/uart.rs
@@ -483,7 +483,7 @@ use kernel::utilities::io_write::IoWrite;
 /// operation of the Tock kernel.
 ///
 /// TODO: Validate this [`UartPanicWriter`] is always sound to create.
-struct UartPanicWriter<'a> {
+pub struct UartPanicWriter<'a> {
     uart: Uart<'a>,
 }
 
@@ -510,13 +510,14 @@ pub struct UartPanicWriterConfig {
     pub params: kernel::hil::uart::Parameters,
 }
 
-impl kernel::platform::chip::PanicWriter for Uart<'_> {
+impl<'a> kernel::platform::chip::PanicWriterFactory for Uart<'a> {
     type Config = UartPanicWriterConfig;
+    type Writer = UartPanicWriter<'a>;
 
     fn create_panic_writer(
         config: Self::Config,
-        _panic: &core::panic::PanicInfo,
-    ) -> impl IoWrite + core::fmt::Write {
+        panic_context: &kernel::context_tokens::PanicContext,
+    ) -> kernel::platform::chip::PanicWriter<Self::Writer> {
         use kernel::hil::uart::Configure as _;
 
         let uart = Uart::new(config.registers);
@@ -524,6 +525,6 @@ impl kernel::platform::chip::PanicWriter for Uart<'_> {
         // Configure the UART correctly for panics.
         let _ = uart.configure(config.params);
 
-        UartPanicWriter { uart }
+        kernel::platform::chip::PanicWriter::new(UartPanicWriter { uart }, panic_context)
     }
 }

--- a/chips/imxrt10xx/src/chip.rs
+++ b/chips/imxrt10xx/src/chip.rs
@@ -7,7 +7,7 @@
 use core::fmt::Write;
 use cortexm7::{CortexM7, CortexMVariant};
 use kernel::debug;
-use kernel::platform::chip::{Chip, InterruptService};
+use kernel::platform::chip::{Chip, InterruptService, PanicWriter};
 
 use crate::nvic;
 
@@ -153,7 +153,7 @@ impl<I: InterruptService + 'static> Chip for Imxrt10xx<I> {
         cortexm7::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(_this: Option<&Self>, write: &mut dyn Write) {
+    fn print_state<W: Write>(_this: Option<&Self>, write: &mut PanicWriter<W>) {
         CortexM7::print_cortexm_state(write);
     }
 }

--- a/chips/litex_vexriscv/src/chip.rs
+++ b/chips/litex_vexriscv/src/chip.rs
@@ -8,6 +8,7 @@ use core::fmt::Write;
 use core::ptr::addr_of;
 use kernel::debug;
 use kernel::platform::chip::InterruptService;
+use kernel::platform::chip::PanicWriter;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 use rv32i::csr::{CSR, mcause, mie::mie};
 use rv32i::pmp::{PMPUserMPU, kernel_protection::KernelProtectionPMP};
@@ -104,7 +105,7 @@ impl<I: 'static + InterruptService> kernel::platform::chip::Chip for LiteXVexRis
         rv32i::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(this: Option<&Self>, writer: &mut dyn Write) {
+    fn print_state<W: Write>(this: Option<&Self>, writer: &mut PanicWriter<W>) {
         let _ = writer.write_fmt(format_args!(
             "\r\n---| LiteX configuration for {} |---",
             this.map_or("unknown board (in trap handler thread)", |t| t

--- a/chips/lpc55s6x/src/chip.rs
+++ b/chips/lpc55s6x/src/chip.rs
@@ -3,12 +3,13 @@
 // Copyright Tock Contributors 2025.
 
 //! Chip trait setup.
-use core::fmt::Write;
 use core::panic;
 
+use core::fmt::Write;
 use cortexm33::{CortexM33, CortexMVariant};
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
+use kernel::platform::chip::PanicWriter;
 
 use crate::clocks::Clock;
 use crate::ctimer0::LPCTimer;
@@ -97,7 +98,7 @@ impl<I: InterruptService> Chip for Lpc55s69<'_, I> {
         cortexm33::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(_this: Option<&Self>, writer: &mut dyn Write) {
+    fn print_state<W: Write>(_this: Option<&Self>, writer: &mut PanicWriter<W>) {
         CortexM33::print_cortexm_state(writer);
     }
 }

--- a/chips/msp432/src/chip.rs
+++ b/chips/msp432/src/chip.rs
@@ -5,6 +5,7 @@
 use core::fmt::Write;
 use cortexm4::{CortexM4, CortexMVariant};
 use kernel::platform::chip::Chip;
+use kernel::platform::chip::PanicWriter;
 
 use crate::nvic;
 use crate::wdt;
@@ -152,7 +153,7 @@ impl<'a, I: InterruptService + 'a> Chip for Msp432<'a, I> {
         cortexm4::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(_this: Option<&Self>, write: &mut dyn Write) {
+    fn print_state<W: Write>(_this: Option<&Self>, write: &mut PanicWriter<W>) {
         CortexM4::print_cortexm_state(write);
     }
 }

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -7,6 +7,7 @@
 use core::fmt::Write;
 use cortexm4f::{CortexM4F, CortexMVariant, nvic};
 use kernel::platform::chip::InterruptService;
+use kernel::platform::chip::PanicWriter;
 use kernel::utilities::StaticRef;
 
 //
@@ -207,7 +208,7 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for NRF52<'a, I>
         cortexm4f::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(_this: Option<&Self>, write: &mut dyn Write) {
+    fn print_state<W: Write>(_this: Option<&Self>, write: &mut PanicWriter<W>) {
         CortexM4F::print_cortexm_state(write);
     }
 }

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -808,7 +808,7 @@ impl<'a> uart::Receive<'a> for Uarte<'a> {
 /// operation of the Tock kernel.
 ///
 /// TODO: Validate this [`UartPanicWriter`] is always sound to create.
-struct UartPanicWriter<'a> {
+pub struct UartPanicWriter<'a> {
     inner: Uarte<'a>,
 }
 
@@ -843,13 +843,14 @@ pub struct UartPanicWriterConfig {
     pub rts: Option<Pin>,
 }
 
-impl kernel::platform::chip::PanicWriter for Uarte<'_> {
+impl<'a> kernel::platform::chip::PanicWriterFactory for Uarte<'a> {
     type Config = UartPanicWriterConfig;
+    type Writer = UartPanicWriter<'a>;
 
     fn create_panic_writer(
         config: Self::Config,
-        _panic: &core::panic::PanicInfo,
-    ) -> impl IoWrite + core::fmt::Write {
+        panic_context: &kernel::context_tokens::PanicContext,
+    ) -> kernel::platform::chip::PanicWriter<Self::Writer> {
         use uart::Configure as _;
 
         // SAFETY: This must be unique and the only owner of the UARTE0 register
@@ -868,7 +869,7 @@ impl kernel::platform::chip::PanicWriter for Uarte<'_> {
             config.rts.map(pinmux::Pinmux::new),
         );
         let _ = inner.configure(config.params);
-        UartPanicWriter { inner }
+        kernel::platform::chip::PanicWriter::new(UartPanicWriter { inner }, panic_context)
     }
 }
 

--- a/chips/psc3/src/chip.rs
+++ b/chips/psc3/src/chip.rs
@@ -8,6 +8,7 @@ use core::fmt::Write;
 use kernel::hil::gpio::Configure;
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
+use kernel::platform::chip::PanicWriter;
 
 use crate::cpuss_ppu;
 use crate::flashc;
@@ -154,7 +155,7 @@ impl<I: InterruptService> Chip for Psc3<'_, I> {
         cortexm33::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(_this: Option<&Self>, writer: &mut dyn Write) {
+    fn print_state<W: Write>(_this: Option<&Self>, writer: &mut PanicWriter<W>) {
         CortexM33::print_cortexm_state(writer);
     }
 }

--- a/chips/psc3/src/scb.rs
+++ b/chips/psc3/src/scb.rs
@@ -403,7 +403,7 @@ impl Configure for Scb<'_> {
 ///
 /// This is only to be used by panic messages and is not used within the normal
 /// operation of the Tock kernel.
-struct ScbPanicWriter<'a> {
+pub struct ScbPanicWriter<'a> {
     scb: Scb<'a>,
 }
 
@@ -426,13 +426,14 @@ pub struct ScbPanicWriterConfig {
     pub params: kernel::hil::uart::Parameters,
 }
 
-impl kernel::platform::chip::PanicWriter for Scb<'_> {
+impl<'a> kernel::platform::chip::PanicWriterFactory for Scb<'a> {
     type Config = ScbPanicWriterConfig;
+    type Writer = ScbPanicWriter<'a>;
 
     fn create_panic_writer(
         config: Self::Config,
-        _panic: &core::panic::PanicInfo,
-    ) -> impl IoWrite + core::fmt::Write {
+        panic_context: &kernel::context_tokens::PanicContext,
+    ) -> kernel::platform::chip::PanicWriter<Self::Writer> {
         use kernel::hil::uart::Configure as _;
 
         let scb = Scb::new();
@@ -445,6 +446,6 @@ impl kernel::platform::chip::PanicWriter for Scb<'_> {
 
         scb.enable_scb();
 
-        ScbPanicWriter { scb }
+        kernel::platform::chip::PanicWriter::new(ScbPanicWriter { scb }, panic_context)
     }
 }

--- a/chips/psoc62xa/src/chip.rs
+++ b/chips/psoc62xa/src/chip.rs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright OxidOS Automotive 2025 SRL.
 
+use core::fmt::Write;
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
+use kernel::platform::chip::PanicWriter;
 
 use crate::{cpuss, gpio, hsiom, peri, scb, srss, tcpwm};
 use cortexm0p::{CortexM0P, CortexMVariant};
@@ -51,7 +53,7 @@ impl<I: InterruptService> Chip for Psoc62xa<'_, I> {
         cortexm0p::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(_this: Option<&Self>, writer: &mut dyn core::fmt::Write) {
+    fn print_state<W: Write>(_this: Option<&Self>, writer: &mut PanicWriter<W>) {
         CortexM0P::print_cortexm_state(writer);
     }
 

--- a/chips/qemu_rv32_virt_chip/src/chip.rs
+++ b/chips/qemu_rv32_virt_chip/src/chip.rs
@@ -9,7 +9,7 @@ use core::ptr::addr_of;
 
 use kernel::debug;
 use kernel::hil::time::Freq10MHz;
-use kernel::platform::chip::{Chip, InterruptService};
+use kernel::platform::chip::{Chip, InterruptService, PanicWriter};
 
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 
@@ -176,7 +176,7 @@ impl<'a, I: InterruptService + 'a> Chip for QemuRv32VirtChip<'a, I> {
         rv32i::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(this: Option<&Self>, writer: &mut dyn Write) {
+    fn print_state<W: Write>(this: Option<&Self>, writer: &mut PanicWriter<W>) {
         rv32i::print_riscv_state(writer);
         if let Some(t) = this {
             let _ = writer.write_fmt(format_args!("{}", t.pmp.pmp));

--- a/chips/qemu_rv32_virt_chip/src/uart.rs
+++ b/chips/qemu_rv32_virt_chip/src/uart.rs
@@ -50,17 +50,18 @@ pub struct UartPanicWriterConfig {
     pub params: hil::uart::Parameters,
 }
 
-impl kernel::platform::chip::PanicWriter for UartPanicWriter<'_> {
+impl<'a> kernel::platform::chip::PanicWriterFactory for UartPanicWriter<'a> {
     type Config = UartPanicWriterConfig;
+    type Writer = UartPanicWriter<'a>;
 
     fn create_panic_writer(
         config: Self::Config,
-        _panic: &core::panic::PanicInfo,
-    ) -> impl IoWrite + core::fmt::Write {
+        panic_context: &kernel::context_tokens::PanicContext,
+    ) -> kernel::platform::chip::PanicWriter<Self::Writer> {
         use hil::uart::Configure as _;
 
         let inner = Uart16550::new(UART0_BASE);
         let _ = inner.configure(config.params);
-        UartPanicWriter { inner }
+        kernel::platform::chip::PanicWriter::new(UartPanicWriter { inner }, panic_context)
     }
 }

--- a/chips/qemu_rv64_virt_chip/src/chip.rs
+++ b/chips/qemu_rv64_virt_chip/src/chip.rs
@@ -9,7 +9,7 @@ use core::ptr::addr_of;
 
 use kernel::debug;
 use kernel::hil::time::Freq10MHz;
-use kernel::platform::chip::{Chip, InterruptService};
+use kernel::platform::chip::{Chip, InterruptService, PanicWriter};
 
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 
@@ -173,7 +173,7 @@ impl<'a, I: InterruptService + 'a> Chip for QemuRv64VirtChip<'a, I> {
         rv64i::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(this: Option<&Self>, writer: &mut dyn Write) {
+    fn print_state<W: Write>(this: Option<&Self>, writer: &mut PanicWriter<W>) {
         rv64i::print_riscv_state(writer);
         if let Some(t) = this {
             let _ = writer.write_fmt(format_args!("{}", t.pmp.pmp));

--- a/chips/qemu_rv64_virt_chip/src/uart.rs
+++ b/chips/qemu_rv64_virt_chip/src/uart.rs
@@ -50,17 +50,18 @@ pub struct UartPanicWriterConfig {
     pub params: hil::uart::Parameters,
 }
 
-impl kernel::platform::chip::PanicWriter for UartPanicWriter<'_> {
+impl<'a> kernel::platform::chip::PanicWriterFactory for UartPanicWriter<'a> {
     type Config = UartPanicWriterConfig;
+    type Writer = UartPanicWriter<'a>;
 
     fn create_panic_writer(
         config: Self::Config,
-        _panic: &core::panic::PanicInfo,
-    ) -> impl IoWrite + core::fmt::Write {
+        panic_context: &kernel::context_tokens::PanicContext,
+    ) -> kernel::platform::chip::PanicWriter<Self::Writer> {
         use hil::uart::Configure as _;
 
         let inner = Uart16550::new(UART0_BASE);
         let _ = inner.configure(config.params);
-        UartPanicWriter { inner }
+        kernel::platform::chip::PanicWriter::new(UartPanicWriter { inner }, panic_context)
     }
 }

--- a/chips/rp2040/src/chip.rs
+++ b/chips/rp2040/src/chip.rs
@@ -7,6 +7,7 @@
 use core::fmt::Write;
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
+use kernel::platform::chip::PanicWriter;
 
 use crate::adc;
 use crate::clocks::Clocks;
@@ -125,7 +126,7 @@ impl<I: InterruptService> Chip for Rp2040<'_, I> {
         cortexm0p::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(_this: Option<&Self>, writer: &mut dyn Write) {
+    fn print_state<W: Write>(_this: Option<&Self>, writer: &mut PanicWriter<W>) {
         CortexM0P::print_cortexm_state(writer);
     }
 }

--- a/chips/rp2350/src/chip.rs
+++ b/chips/rp2350/src/chip.rs
@@ -7,6 +7,7 @@
 use core::fmt::Write;
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
+use kernel::platform::chip::PanicWriter;
 
 use crate::clocks::Clocks;
 use crate::gpio::{RPPins, SIO};
@@ -112,7 +113,7 @@ impl<I: InterruptService> Chip for Rp2350<'_, I> {
         cortexm33::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(_this: Option<&Self>, writer: &mut dyn Write) {
+    fn print_state<W: Write>(_this: Option<&Self>, writer: &mut PanicWriter<W>) {
         CortexM33::print_cortexm_state(writer);
     }
 }

--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -8,7 +8,7 @@ use crate::pm;
 
 use core::fmt::Write;
 use cortexm4::{CortexM4, CortexMVariant};
-use kernel::platform::chip::{Chip, InterruptService};
+use kernel::platform::chip::{Chip, InterruptService, PanicWriter};
 
 pub struct Sam4l<I: InterruptService + 'static> {
     mpu: cortexm4::mpu::MPU,
@@ -293,7 +293,7 @@ impl<I: InterruptService + 'static> Chip for Sam4l<I> {
         cortexm4::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(_this: Option<&Self>, writer: &mut dyn Write) {
+    fn print_state<W: Write>(_this: Option<&Self>, writer: &mut PanicWriter<W>) {
         CortexM4::print_cortexm_state(writer);
     }
 }

--- a/chips/segger/src/rtt.rs
+++ b/chips/segger/src/rtt.rs
@@ -383,7 +383,7 @@ impl<'a, A: hil::time::Alarm<'a>> uart::Receive<'a> for SeggerRtt<'a, A> {
 /// operation of the Tock kernel.
 ///
 /// TODO: Validate this [`RttPanicWriter`] is always sound to create.
-struct RttPanicWriter<'a> {
+pub struct RttPanicWriter<'a> {
     inner: &'a SeggerRttMemory<'a>,
 }
 
@@ -401,13 +401,14 @@ impl core::fmt::Write for RttPanicWriter<'_> {
     }
 }
 
-impl<'a> kernel::platform::chip::PanicWriter for SeggerRttMemory<'a> {
+impl<'a> kernel::platform::chip::PanicWriterFactory for SeggerRttMemory<'a> {
     type Config = &'a SeggerRttMemory<'a>;
+    type Writer = RttPanicWriter<'a>;
 
     fn create_panic_writer(
         config: Self::Config,
-        _panic: &core::panic::PanicInfo,
-    ) -> impl IoWrite + core::fmt::Write {
-        RttPanicWriter { inner: config }
+        panic_context: &kernel::context_tokens::PanicContext,
+    ) -> kernel::platform::chip::PanicWriter<Self::Writer> {
+        kernel::platform::chip::PanicWriter::new(RttPanicWriter { inner: config }, panic_context)
     }
 }

--- a/chips/sifive/src/uart.rs
+++ b/chips/sifive/src/uart.rs
@@ -460,7 +460,7 @@ use kernel::utilities::io_write::IoWrite;
 /// operation of the Tock kernel.
 ///
 /// TODO: Validate this [`UartPanicWriter`] is always sound to create.
-struct UartPanicWriter<'a> {
+pub struct UartPanicWriter<'a> {
     uart: Uart<'a>,
 }
 
@@ -488,13 +488,14 @@ pub struct UartPanicWriterConfig {
     pub params: kernel::hil::uart::Parameters,
 }
 
-impl kernel::platform::chip::PanicWriter for Uart<'_> {
+impl<'a> kernel::platform::chip::PanicWriterFactory for Uart<'a> {
     type Config = UartPanicWriterConfig;
+    type Writer = UartPanicWriter<'a>;
 
     fn create_panic_writer(
         config: Self::Config,
-        _panic: &core::panic::PanicInfo,
-    ) -> impl IoWrite + core::fmt::Write {
+        panic_context: &kernel::context_tokens::PanicContext,
+    ) -> kernel::platform::chip::PanicWriter<Self::Writer> {
         use kernel::hil::uart::Configure as _;
 
         let uart = Uart::new(config.registers, config.clock_frequency);
@@ -502,6 +503,6 @@ impl kernel::platform::chip::PanicWriter for Uart<'_> {
         // Configure the UART correctly for panics.
         let _ = uart.configure(config.params);
 
-        UartPanicWriter { uart }
+        kernel::platform::chip::PanicWriter::new(UartPanicWriter { uart }, panic_context)
     }
 }

--- a/chips/stm32f303xc/src/chip.rs
+++ b/chips/stm32f303xc/src/chip.rs
@@ -8,6 +8,7 @@ use core::fmt::Write;
 use cortexm4f::{CortexM4F, CortexMVariant};
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
+use kernel::platform::chip::PanicWriter;
 
 use crate::nvic;
 
@@ -149,7 +150,7 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32f3xx<'a, I> {
         cortexm4f::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(_this: Option<&Self>, write: &mut dyn Write) {
+    fn print_state<W: Write>(_this: Option<&Self>, write: &mut PanicWriter<W>) {
         CortexM4F::print_cortexm_state(write);
     }
 }

--- a/chips/stm32f4xx/src/chip.rs
+++ b/chips/stm32f4xx/src/chip.rs
@@ -8,6 +8,7 @@ use core::fmt::Write;
 use cortexm4f::{CortexM4F, CortexMVariant};
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
+use kernel::platform::chip::PanicWriter;
 
 use crate::dma;
 use crate::nvic;
@@ -211,7 +212,7 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32f4xx<'a, I> {
         cortexm4f::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(_this: Option<&Self>, write: &mut dyn Write) {
+    fn print_state<W: Write>(_this: Option<&Self>, write: &mut PanicWriter<W>) {
         CortexM4F::print_cortexm_state(write);
     }
 }

--- a/chips/stm32u5xx/src/chip.rs
+++ b/chips/stm32u5xx/src/chip.rs
@@ -32,6 +32,7 @@ use kernel::hil::spi::SpiMaster;
 use kernel::hil::symmetric_encryption::AES256;
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
+use kernel::platform::chip::PanicWriter;
 use stm32u5xx_unsafe::aes::AES_BASE;
 
 pub struct Stm32u5xx<'a, I: InterruptService + 'a> {
@@ -439,7 +440,7 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32u5xx<'a, I> {
         cortexm33::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(_this: Option<&Self>, write: &mut dyn Write) {
+    fn print_state<W: Write>(_this: Option<&Self>, write: &mut PanicWriter<W>) {
         let _ = write.write_str("Cortex-M33 state\n");
     }
 }

--- a/chips/stm32u5xx/src/usart.rs
+++ b/chips/stm32u5xx/src/usart.rs
@@ -5,9 +5,11 @@
 use crate::dma::{ChannelId, Dma, DmaPeripheral};
 use core::cell::Cell;
 use cortexm33::dma_fence::CortexMDmaFence;
+use kernel::context_tokens::PanicContext;
 use kernel::deferred_call::{DeferredCall, DeferredCallClient};
 use kernel::hil::uart::{self};
 use kernel::platform::chip::PanicWriter;
+use kernel::platform::chip::PanicWriterFactory;
 use kernel::utilities::StaticRef;
 use kernel::utilities::cells::MapCell;
 use kernel::utilities::cells::OptionalCell;
@@ -490,7 +492,7 @@ impl<'a> uart::Receive<'a> for Usart<'a> {
     }
 }
 
-struct UsartPanicWriter {
+pub struct UsartPanicWriter {
     registers: StaticRef<UsartRegisters>,
 }
 
@@ -517,12 +519,13 @@ pub struct UsartPanicWriterConfig {
     pub base: StaticRef<UsartRegisters>,
 }
 
-impl PanicWriter for Usart<'_> {
+impl PanicWriterFactory for Usart<'_> {
     type Config = UsartPanicWriterConfig;
+    type Writer = UsartPanicWriter;
     fn create_panic_writer(
         config: Self::Config,
-        _panic: &core::panic::PanicInfo,
-    ) -> impl IoWrite + core::fmt::Write {
+        panic_context: &PanicContext,
+    ) -> PanicWriter<Self::Writer> {
         let writer = UsartPanicWriter {
             registers: config.base,
         };
@@ -533,6 +536,6 @@ impl PanicWriter for Usart<'_> {
         regs.brr.write(BRR::BRR.val(35));
         regs.cr1.write(CR1::TE::SET + CR1::RE::SET + CR1::UE::SET);
 
-        writer
+        PanicWriter::new(writer, panic_context)
     }
 }

--- a/chips/stm32wle5xx/src/chip.rs
+++ b/chips/stm32wle5xx/src/chip.rs
@@ -8,6 +8,7 @@ use core::fmt::Write;
 use cortexm4::{CortexM4, CortexMVariant};
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
+use kernel::platform::chip::PanicWriter;
 
 use crate::chip_specific::chip_specs::ChipSpecs as ChipSpecsTrait;
 use crate::nvic;
@@ -184,7 +185,7 @@ impl<'a, I: InterruptService + 'a> Chip for Stm32wle5xx<'a, I> {
         }
     }
 
-    unsafe fn print_state(_this: Option<&Self>, write: &mut dyn Write) {
+    fn print_state<W: Write>(_this: Option<&Self>, write: &mut PanicWriter<W>) {
         CortexM4::print_cortexm_state(write);
     }
 }

--- a/chips/veer_el2/src/chip.rs
+++ b/chips/veer_el2/src/chip.rs
@@ -7,7 +7,7 @@
 
 use crate::machine_timer::Clint;
 use core::fmt::Write;
-use kernel::platform::chip::{Chip, InterruptService};
+use kernel::platform::chip::{Chip, InterruptService, PanicWriter};
 use kernel::utilities::StaticRef;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 use rv32i::csr::{CSR, mcause, mie::mie, mip::mip};
@@ -148,7 +148,7 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for VeeR<'a, I> 
         rv32i::support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(_this: Option<&Self>, writer: &mut dyn Write) {
+    fn print_state<W: Write>(_this: Option<&Self>, writer: &mut PanicWriter<W>) {
         rv32i::print_riscv_state(writer);
     }
 }

--- a/chips/x86_q35/src/chip.rs
+++ b/chips/x86_q35/src/chip.rs
@@ -3,9 +3,8 @@
 // Copyright Tock Contributors 2024.
 
 use core::fmt::Write;
-
 use kernel::component::Component;
-use kernel::platform::chip::{Chip, InterruptService};
+use kernel::platform::chip::{Chip, InterruptService, PanicWriter};
 use x86::mpu::PagingMPU;
 use x86::registers::bits32::paging::{PD, PT};
 use x86::support;
@@ -241,7 +240,7 @@ impl<'a, I1: InterruptService, I2: InterruptService, const PR: u16> Chip for Pc<
         support::with_interrupts_disabled(f)
     }
 
-    unsafe fn print_state(_this: Option<&Self>, writer: &mut dyn Write) {
+    fn print_state<W: Write>(_this: Option<&Self>, writer: &mut PanicWriter<W>) {
         let _ = writeln!(writer);
         let _ = writeln!(writer, "---| PC State |---");
         let _ = writeln!(writer);

--- a/kernel/src/context_tokens.rs
+++ b/kernel/src/context_tokens.rs
@@ -1,0 +1,52 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+//! Typed proofs for the current context code is executing in.
+//!
+//! This module provides zero-sized marker tokens that signify the current
+//! execution context. These are designed to provide compile-time assertions
+//! for code which is sensitive to execution context.
+//!
+//! Enforcing context with comments is fragile and subject to user error. The
+//! `unsafe` keyword is overloaded here, as context-sensitive operations are
+//! not necessarily soundness concerns (though, being able to assert an
+//! execution context is often necessary to justify `unsafe` operations).
+
+use core::marker::PhantomData;
+use core::panic::PanicInfo;
+
+/// Proof that the current code is executing while the kernel is panicking.
+///
+/// `PanicInfo` has no public constructor: the language only ever creates one
+/// to hand to the `#[panic_handler]`. Holding a `&PanicInfo` is therefore
+/// unforgeable proof that a panic is genuinely underway, and this token
+/// exists so that proof can be threaded through ordinary function
+/// signatures instead of re-derived (or merely asserted in a doc comment)
+/// at every layer of the panic-printing path.
+///
+/// This type is neither [`Send`] nor [`Sync`]: it should not be squirreled
+/// away and used to vouch for a panic beyond the dynamic extent in which it
+/// was minted.
+pub struct PanicContext {
+    _not_send_sync: PhantomData<*const ()>,
+}
+
+impl PanicContext {
+    /// Mint a new [`PanicContext`] token.
+    ///
+    /// Prefer [`kernel::mint_panic_context!`](crate::mint_panic_context),
+    /// which wraps this in the required `unsafe` block, over calling this
+    /// directly.
+    ///
+    /// # Safety
+    ///
+    /// The caller must actually hold a `&PanicInfo`, i.e. must be executing
+    /// as part of handling a genuine language panic.
+    #[doc(hidden)]
+    pub unsafe fn new_trusted(_panic_info: &PanicInfo) -> Self {
+        PanicContext {
+            _not_send_sync: PhantomData,
+        }
+    }
+}

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -109,9 +109,11 @@ use core::panic::PanicInfo;
 use core::str;
 
 use crate::capabilities::SetDebugWriterCapability;
+use crate::context_tokens::PanicContext;
 use crate::hil;
 use crate::platform::chip::Chip;
 use crate::platform::chip::PanicWriter;
+use crate::platform::chip::PanicWriterFactory;
 use crate::platform::chip::ThreadIdProvider;
 use crate::process::ProcessPrinter;
 use crate::process::ProcessSlot;
@@ -156,52 +158,38 @@ impl<C: Chip, PP: ProcessPrinter> PanicResources<C, PP> {
 /// Care must be taken on how one interacts with the system once this function
 /// returns.
 ///
-/// Because this requires a [`PanicInfo`] reference, this can only be called
-/// from a panic context.
-pub fn panic_print<PW: PanicWriter, C: Chip, PP: ProcessPrinter>(
+/// **NOTE:** The supplied `writer` must be synchronous.
+pub fn panic_print<PW: PanicWriterFactory, C: Chip, PP: ProcessPrinter>(
     writer_config: PW::Config,
     panic_info: &PanicInfo,
     nop: &dyn Fn(),
     panic_resources: Option<&PanicResources<C, PP>>,
 ) {
+    // We are executing inside the panic handler's call graph, so this proves
+    // everything below is only ever reached while panicking.
+    let panic_context = crate::mint_panic_context!(panic_info);
+
     // Create the synchronous writer we can use to output the panic message.
-    let mut writer = PW::create_panic_writer(writer_config, panic_info);
+    let mut writer = PW::create_panic_writer(writer_config, &panic_context);
 
-    panic_begin(nop);
-
+    panic_begin(nop, &panic_context);
     // Flush debug buffer if needed
     flush(&mut writer);
-
-    // Display general information about the kernel.
     panic_banner(&mut writer, panic_info);
 
     panic_resources.map(|pr| {
         let chip = pr.chip.take();
-
-        // SAFETY: This may only be called during a panic, and we are guaranteed
-        // to be in a panic when running this function.
-        unsafe {
-            panic_cpu_state(chip, &mut writer);
-        }
+        panic_cpu_state(chip, &mut writer);
 
         chip.map(|c| {
-            use crate::platform::mpu::MPU;
             // Some systems may enforce memory protection regions for the kernel,
             // making application memory inaccessible. However, printing process
             // information will attempt to access memory. If we are provided a chip
-            // reference, attempt to disable userspace memory protection first.
-            //
-            // SAFETY: This is safe because we are in a panic handler and we
-            // will never run processes again. We do not guarantee we will
-            // re-enable the MPU, but that is ok because in a panic we do not
-            // run processes.
-            unsafe { c.mpu().disable_app_mpu() }
+            // reference, attempt to disable userspace memory protection first:
+            crate::platform::mpu::mpu_disable_panic(c.mpu(), &panic_context)
         });
         pr.processes.take().map(|p| {
-            // SAFETY: We are guaranteed to be in a panic context.
-            unsafe {
-                panic_process_info(p, pr.printer.take(), &mut writer);
-            }
+            panic_process_info(p, pr.printer.take(), &mut writer);
         });
     });
 }
@@ -212,10 +200,7 @@ pub fn panic_print<PW: PanicWriter, C: Chip, PP: ProcessPrinter>(
 ///
 /// This will print a detailed debugging message and then loop forever while
 /// blinking an LED in a recognizable pattern.
-///
-/// Because this requires a [`PanicInfo`] reference, this can only be called
-/// from a panic context.
-pub fn panic<L: hil::led::Led, PW: PanicWriter, C: Chip, PP: ProcessPrinter>(
+pub fn panic<L: hil::led::Led, PW: PanicWriterFactory, C: Chip, PP: ProcessPrinter>(
     leds: &mut [&L],
     writer_config: PW::Config,
     panic_info: &PanicInfo,
@@ -244,42 +229,41 @@ pub fn panic<L: hil::led::Led, PW: PanicWriter, C: Chip, PP: ProcessPrinter>(
 /// returns.
 ///
 /// **NOTE:** The supplied `writer` must be synchronous.
-///
-/// # Safety
-///
-/// - This must ONLY be called during a panic.
-pub unsafe fn panic_print_old<W: Write + IoWrite, C: Chip, PP: ProcessPrinter>(
+pub fn panic_print_old<W: IoWrite + Write, C: Chip, PP: ProcessPrinter>(
     writer: &mut W,
     panic_info: &PanicInfo,
     nop: &dyn Fn(),
     panic_resources: Option<&PanicResources<C, PP>>,
 ) {
-    // SAFETY: This has the same safety reasoning as `panic_print()`. This
-    // implementation is deprecated. When all callers are updated it will be
-    // removed.
-    unsafe {
-        panic_begin(nop);
-        // Flush debug buffer if needed
-        flush(writer);
-        panic_banner(writer, panic_info);
+    // We are executing inside the panic handler's call graph, so this proves
+    // everything below is only ever reached while panicking. This is what
+    // lets us wrap `writer` (a plain writer the board constructed with no
+    // special marker) in a `PanicWriter`, without every board needing to
+    // construct one itself.
+    let panic_context = crate::mint_panic_context!(panic_info);
+    let mut writer = PanicWriter::new(writer, &panic_context);
+    let writer = &mut writer;
 
-        panic_resources.map(|pr| {
-            let chip = pr.chip.take();
-            panic_cpu_state(chip, writer);
+    panic_begin(nop, &panic_context);
+    // Flush debug buffer if needed
+    flush(writer);
+    panic_banner(writer, panic_info);
 
-            chip.map(|c| {
-                // Some systems may enforce memory protection regions for the kernel,
-                // making application memory inaccessible. However, printing process
-                // information will attempt to access memory. If we are provided a chip
-                // reference, attempt to disable userspace memory protection first:
-                use crate::platform::mpu::MPU;
-                c.mpu().disable_app_mpu()
-            });
-            pr.processes.take().map(|p| {
-                panic_process_info(p, pr.printer.take(), writer);
-            });
+    panic_resources.map(|pr| {
+        let chip = pr.chip.take();
+        panic_cpu_state(chip, writer);
+
+        chip.map(|c| {
+            // Some systems may enforce memory protection regions for the kernel,
+            // making application memory inaccessible. However, printing process
+            // information will attempt to access memory. If we are provided a chip
+            // reference, attempt to disable userspace memory protection first:
+            crate::platform::mpu::mpu_disable_panic(c.mpu(), &panic_context)
         });
-    }
+        pr.processes.take().map(|p| {
+            panic_process_info(p, pr.printer.take(), writer);
+        });
+    });
 }
 
 /// Tock default panic routine.
@@ -288,11 +272,7 @@ pub unsafe fn panic_print_old<W: Write + IoWrite, C: Chip, PP: ProcessPrinter>(
 ///
 /// This will print a detailed debugging message and then loop forever while
 /// blinking an LED in a recognizable pattern.
-///
-/// # Safety
-///
-/// - This must ONLY be called during a panic.
-pub unsafe fn panic_old<L: hil::led::Led, W: Write + IoWrite, C: Chip, PP: ProcessPrinter>(
+pub fn panic_old<L: hil::led::Led, W: IoWrite + Write, C: Chip, PP: ProcessPrinter>(
     leds: &mut [&L],
     writer: &mut W,
     panic_info: &PanicInfo,
@@ -300,12 +280,8 @@ pub unsafe fn panic_old<L: hil::led::Led, W: Write + IoWrite, C: Chip, PP: Proce
     panic_resources: Option<&PanicResources<C, PP>>,
 ) -> ! {
     // Call `panic_print` first which will print out the panic information and
-    // return.
-    //
-    // SAFETY: The requirements match this function.
-    unsafe {
-        panic_print_old(writer, panic_info, nop, panic_resources);
-    }
+    // return
+    panic_print_old(writer, panic_info, nop, panic_resources);
 
     // The system is no longer in a well-defined state, we cannot
     // allow this function to return
@@ -319,7 +295,7 @@ pub unsafe fn panic_old<L: hil::led::Led, W: Write + IoWrite, C: Chip, PP: Proce
 /// This opaque method should always be called at the beginning of a board's
 /// panic method to allow hooks for any core kernel cleanups that may be
 /// appropriate.
-pub fn panic_begin(nop: &dyn Fn()) {
+pub fn panic_begin(nop: &dyn Fn(), _panic_context: &PanicContext) {
     // Let any outstanding uart DMA's finish
     for _ in 0..200000 {
         nop();
@@ -327,12 +303,7 @@ pub fn panic_begin(nop: &dyn Fn()) {
 }
 
 /// Lightweight prints about the current panic and kernel version.
-///
-/// **NOTE:** The supplied `writer` must be synchronous.
-///
-/// Because this requires a [`PanicInfo`] reference, this can only be called
-/// from a panic context.
-pub fn panic_banner<W: Write>(writer: &mut W, panic_info: &PanicInfo) {
+pub fn panic_banner<W: Write>(writer: &mut PanicWriter<W>, panic_info: &PanicInfo) {
     // Expand `PanicInfo` manually rather than using its `Display`
     // implementation. The `Display` implementation inserts bare LFs
     // between the location line and the message body, rather than a
@@ -369,31 +340,15 @@ pub fn panic_banner<W: Write>(writer: &mut W, panic_info: &PanicInfo) {
 }
 
 /// Print current machine (CPU) state.
-///
-/// **NOTE:** The supplied `writer` must be synchronous.
-///
-/// # Safety
-///
-/// This may only be called during a panic.
-pub unsafe fn panic_cpu_state<W: Write, C: Chip>(chip: Option<&'static C>, writer: &mut W) {
-    // SAFETY: The function-level safety doc requires this only be called during
-    // a panic, matching the requirement for `print_state()`.
-    unsafe {
-        C::print_state(chip, writer);
-    }
+pub fn panic_cpu_state<W: Write, C: Chip>(chip: Option<&'static C>, writer: &mut PanicWriter<W>) {
+    C::print_state(chip, writer);
 }
 
 /// More detailed prints about all processes.
-///
-/// **NOTE:** The supplied `writer` must be synchronous.
-///
-/// # Safety
-///
-/// This must only be called from a panic context.
-pub unsafe fn panic_process_info<PP: ProcessPrinter, W: Write>(
+pub fn panic_process_info<PP: ProcessPrinter, W: Write>(
     processes: &'static [ProcessSlot],
     process_printer: Option<&'static PP>,
-    writer: &mut W,
+    writer: &mut PanicWriter<W>,
 ) {
     process_printer.map(|printer| {
         // print data about each process
@@ -782,7 +737,7 @@ macro_rules! debug_expr {
 }
 
 /// Flush any stored messages to the output writer.
-fn flush<W: Write + IoWrite>(writer: &mut W) {
+fn flush<W: IoWrite + Write>(writer: &mut PanicWriter<W>) {
     try_get_debug_writer(|debug_writer|{
         if debug_writer.to_write_len() > 0 {
             let _ = writer.write_str(

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -160,6 +160,7 @@ static TOCK_ATTRIBUTES_KERNEL_VERSION: TockAttributesKernelVersion = TockAttribu
 pub mod capabilities;
 pub mod collections;
 pub mod component;
+pub mod context_tokens;
 pub mod debug;
 pub mod deferred_call;
 pub mod dynamic_binary_storage;

--- a/kernel/src/platform/chip.rs
+++ b/kernel/src/platform/chip.rs
@@ -4,11 +4,11 @@
 
 //! Interfaces for implementing microcontrollers in Tock.
 
+use crate::context_tokens::PanicContext;
 use crate::platform::mpu;
 use crate::syscall;
 use crate::utilities::io_write::IoWrite;
 use core::fmt::Write;
-use core::panic::PanicInfo;
 
 /// Interface for individual MCUs.
 ///
@@ -97,12 +97,11 @@ pub trait Chip {
     /// information if it depends on runtime-accessible state in `Self`, but
     /// that reference is not provided.
     ///
-    /// # Safety
-    ///
-    /// Implementations may need to access low-level chip-specific hardware that
-    /// isn't safe to access during the normal operation of the chip. This
-    /// function may only be called from a panic context.
-    unsafe fn print_state(this: Option<&Self>, writer: &mut dyn Write);
+    /// Implementations may need to access low-level chip-specific hardware
+    /// that isn't safe to access during the normal operation of the chip.
+    /// The `&mut PanicWriter<W>` parameter is proof that this is only ever
+    /// called from a panic context, which is what makes that access sound.
+    fn print_state<W: Write>(this: Option<&Self>, writer: &mut PanicWriter<W>);
 }
 
 /// Interface for retrieving the currently executing thread.
@@ -206,31 +205,71 @@ impl ClockInterface for NoClockControl {
 /// `ClockInterface` objects.
 pub const NO_CLOCK_CONTROL: NoClockControl = NoClockControl {};
 
+/// Wraps a plain writer, given proof (a [`PanicContext`]) that a panic is
+/// genuinely underway.
+///
+/// A writer only becomes a [`PanicWriter`] by being wrapped here, and this is
+/// only constructible by presenting a [`PanicContext`]. Holding a
+/// `&mut PanicWriter<W>` is therefore itself proof that it is sound to
+/// perform synchronous I/O outside of the normal asynchronous kernel flow
+/// (e.g. because the system is already tearing down after a panic):
+/// consumers that accept a `&mut PanicWriter<W>` (rather than a plain
+/// [`IoWrite`] or [`core::fmt::Write`]) can rely on that assertion having
+/// already been made, and do not need to be `unsafe` themselves.
+///
+/// `W` may be an owned writer (e.g. for
+/// [`PanicWriterFactory::create_panic_writer`] implementations, which
+/// construct a fresh writer and return it by value) or a mutable reference
+/// to an existing one (e.g. for boards with a long-lived `static mut`
+/// writer, which only need to prove the *use* of that writer happens during
+/// a panic).
+pub struct PanicWriter<W> {
+    inner: W,
+}
+
+impl<W: Write> PanicWriter<W> {
+    /// Wrap `inner`, proven sound by `_panic_context`.
+    pub fn new(inner: W, _panic_context: &PanicContext) -> Self {
+        PanicWriter { inner }
+    }
+}
+
+impl<W: IoWrite> IoWrite for PanicWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> usize {
+        self.inner.write(buf)
+    }
+}
+
+impl<W: Write> Write for PanicWriter<W> {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.inner.write_str(s)
+    }
+}
+
 /// Interface for chips to create a synchronous writer for panics.
 ///
 /// Any mechanism that can output a panic message during a panic must implement
-/// [`PanicWriter`] to enable the `panic()` functions to write the output. This
-/// requires the mechanism to provide a new constructor for the writer that
-/// creates a synchronous writer that implements [`IoWrite`].
+/// [`PanicWriterFactory`] to enable the `panic()` functions to write the
+/// output. This requires the mechanism to provide a new constructor for the
+/// writer that creates a synchronous [`PanicWriter`].
 ///
 /// This is a dedicated trait because synchronous I/O is only used for panic
 /// handling. This allows chips to clearly separate synchronous implementations
 /// that are a special case only for panics.
-pub trait PanicWriter {
+pub trait PanicWriterFactory {
     /// The configuration data the mechanism needs to configure the writer for
     /// panic output.
     type Config;
 
+    /// The concrete synchronous writer this mechanism constructs.
+    type Writer: IoWrite + Write;
+
     /// Create a new synchronous writer capable of sending panic messages.
     ///
-    /// The writer must implement [`IoWrite`] (which is just `std:io::Write`
-    /// implemented for no_std).
-    ///
-    /// This function requires a [`PanicInfo`] reference, but the implementation
-    /// should not use it. This only enforces that this function is only called
-    /// from a panic context and not during normal operation.
+    /// The `panic_context` proves this is only ever called while panicking,
+    /// which is what makes it sound to return a [`PanicWriter`].
     fn create_panic_writer(
         config: Self::Config,
-        _panic: &PanicInfo,
-    ) -> impl IoWrite + core::fmt::Write;
+        panic_context: &PanicContext,
+    ) -> PanicWriter<Self::Writer>;
 }

--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -4,6 +4,7 @@
 
 //! Interface for configuring the Memory Protection Unit.
 
+use crate::context_tokens::PanicContext;
 use core::fmt::{self, Display};
 
 /// User mode access permissions.
@@ -300,4 +301,15 @@ pub unsafe trait MPU {
     /// transitively write to kernel-private memory (such as MMIO registers of
     /// DMA-capable peripherals).
     unsafe fn configure_mpu(&self, config: &Self::MpuConfig);
+}
+
+/// Disables the app MPU because the kernel is panicking.
+///
+/// [`MPU::disable_app_mpu`] is `unsafe` because the kernel must re-enable it
+/// via [`MPU::enable_app_mpu`] before ever switching back to an application.
+/// A panic never does: the caller is beginning to unwind panic-time
+/// diagnostics, and Tock's panic handlers never resume normal execution.
+pub fn mpu_disable_panic<M: MPU + ?Sized>(mpu: &M, _panic_context: &PanicContext) {
+    // SAFETY: we are panicking and will never switch back to an application.
+    unsafe { mpu.disable_app_mpu() }
 }

--- a/kernel/src/utilities/helpers.rs
+++ b/kernel/src/utilities/helpers.rs
@@ -434,6 +434,49 @@ pub fn usize_as_native_mut(val: &mut usize) -> &mut u64 {
     unsafe { &mut *ptr.cast::<u64>() }
 }
 
+/// Mint a [`PanicContext`](crate::context_tokens::PanicContext) token.
+///
+/// This is the `PanicContext` equivalent of [`create_capability!`]: it hides
+/// the `unsafe` keyword at the call site while still requiring that call
+/// site be in a crate permitted to use `unsafe` at all.
+///
+/// # Usage Example
+///
+/// ```ignore
+/// # use kernel::mint_panic_context;
+/// # use core::panic::PanicInfo;
+/// # fn f(panic_info: &PanicInfo) {
+/// let panic_context = kernel::mint_panic_context!(panic_info);
+/// # }
+/// ```
+///
+/// # Restrictions
+///
+/// This helper macro cannot be called from `#![forbid(unsafe_code)]` crates.
+/// The argument must be an actual `&PanicInfo` obtained from a
+/// `#[panic_handler]` (or a function that was itself handed one); `PanicInfo`
+/// has no public constructor, so this is unforgeable proof that a panic is
+/// genuinely underway.
+///
+/// # Safety
+///
+/// This macro can only be used in a context that is allowed to use `unsafe`.
+/// Specifically, an internal `allow(unsafe_code)` directive will conflict with
+/// any `forbid(unsafe_code)` at the crate or block level.
+#[macro_export]
+macro_rules! mint_panic_context {
+    ($panic_info:expr) => {{
+        let panic_info = $panic_info;
+        // SAFETY: this expansion only compiles in a crate permitted to use
+        // `unsafe` (see macro doc); by invoking this macro here, the caller
+        // asserts `panic_info` is a genuine `&PanicInfo`.
+        #[allow(unsafe_code)]
+        unsafe {
+            $crate::context_tokens::PanicContext::new_trusted(panic_info)
+        }
+    }};
+}
+
 /// Compute a POSIX-style CRC32 checksum of a slice.
 ///
 /// Online calculator: <https://crccalc.com/>

--- a/kernel/src/utilities/io_write.rs
+++ b/kernel/src/utilities/io_write.rs
@@ -33,3 +33,17 @@ pub trait IoWrite {
         total
     }
 }
+
+// This blanket impl (mirroring the one `core::fmt::Write` already has for
+// `&mut W`) only exists so `PanicWriter<W>` (see `kernel::platform::chip`)
+// can wrap a `&mut W` as well as an owned `W`. That's needed for the legacy
+// `panic_old`/`panic_print_old` path, where boards hand in a reference to an
+// existing writer rather than constructing one via
+// `PanicWriterFactory::create_panic_writer`. Once every board is converted
+// to `create_panic_writer`, `panic_old`/`panic_print_old` (and this impl)
+// can be removed.
+impl<T: IoWrite + ?Sized> IoWrite for &mut T {
+    fn write(&mut self, buf: &[u8]) -> usize {
+        (**self).write(buf)
+    }
+}


### PR DESCRIPTION
***Note: This was #5111.*** I accidentally deleted the branch from the fork, which apparently perma-closes PRs. I restored the branch and this is just re-opening the PR.

It incorporates the updates from the first PR, and adds a TODO currently blocked on resolving the naming discussion in #5095. 

### Pull Request Overview

This pull request combines the concepts from #5054, #5063, and our various discussions. It subsumes these and the prior related PRs on `unsafe` in various kernel print interfaces (i.e., #5048, #5049).

It introduces two new concepts:
 - A `PanicContext` token, similar to `InterruptDisabled` (#5095)
     - Here, we don't even need `unsafe` to mint the token; instead we can rely on having a `PanicInfo` as the "safe" mint method — there's one function that is used to create tokens from `PanicInfo`, so if we ever come to distrust that for some reason, it's easy to find all the mint sites that rely on `PanicInfo` as the authority for "is panic'ing"
 - A `PanicWrite` trait, which is just a wrapper trait around standard `IoWrite + Write` interfaces, but expresses the semantic that (a) we are in a panic, and (b) the writer synchronous.

The first two commits are the interesting new things; the last one is the bulk implementation of interface updates. In sum, it removes around 45 `unsafe`s (but we all know how well Claude counts....)

### Testing Strategy

This pull request was tested by compiling.

### TODO or Help Wanted

Do we like the dedicated `PanicWrite` trait (above and beyond just `PanicContext`)? I do, I think it more clearly conveys that this isn't just a normal `Write` happening either.

---

Resolve naming, pending discussion on #5095.

### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

Claude did the mechanical work here. I did the design work.