### PR TITLE
process_standard: Use map_addr instead of ptr -> usize -> ptr casts

### DIFF
--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -1336,7 +1336,7 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
                                 // Now, to mark that the grant has been entered, we set the lowest
                                 // bit to one and save this as the grant pointer.
                                 grant_entry.grant_ptr =
-                                    (usize::from(grant_ptr_nonnull.addr()) | 0x1) as *mut u8;
+                                    grant_ptr_nonnull.map_addr(|a| a | 0x1).as_ptr();
 
                                 // And we return the grant pointer to the entered grant.
                                 Ok(grant_ptr_nonnull)
@@ -1384,7 +1384,7 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
                 // Now, to mark that the grant has been released, we set the
                 // lowest bit back to zero and save this as the grant
                 // pointer.
-                grant_entry.grant_ptr = (grant_ptr as usize & !0x1) as *mut u8;
+                grant_entry.grant_ptr = grant_ptr.map_addr(|a| a & !0x1);
             }
         });
     }
@@ -2612,7 +2612,7 @@ impl<C: 'static + Chip, D: 'static + ProcessStandardDebug> ProcessStandard<'_, C
             // `!(align - 1)` then returns a mask with leading ones, followed by
             // `a` trailing zeros.
             let alignment_mask = !(align - 1);
-            let new_break = (new_break_unaligned as usize & alignment_mask) as *const u8;
+            let new_break = new_break_unaligned.map_addr(|a| a & alignment_mask);
 
             // Verify there is space for this allocation
             if new_break < self.app_break.get() {


### PR DESCRIPTION
### Pull Request Overview

This replaces ptr <-> usize round-trips with .map_addr in a few places.

### Testing Strategy

Just `make prepush` and "eh looks safe enough".

### TODO or Help Wanted

None

### Checklist

- [X] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [X] No documentation updates are required.

#### AI Use

- [X] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
