### PR TITLE
enter_custom_grant: Use strict provenance APIs.

### DIFF
--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -1361,11 +1361,13 @@ impl<C: Chip, D: 'static + ProcessStandardDebug> Process for ProcessStandard<'_,
         }
 
         // Get the address of the custom grant based on the identifier.
-        let custom_grant_address = self.get_custom_grant_address(identifier);
+        let address = self.get_custom_grant_address(identifier);
 
         // We never deallocate custom grants and only we can change the
         // `identifier` so we know this is a valid address for the custom grant.
-        Ok(custom_grant_address as *mut u8)
+        // kernel_memory_break seems like the most reasonable pointer to get the
+        // provenance from.
+        Ok(self.kernel_memory_break().with_addr(address).cast_mut())
     }
 
     unsafe fn leave_grant(&self, grant_num: usize) {


### PR DESCRIPTION
### Pull Request Overview

This changes ProcessStandard::enter_custom_grant to explicitly specify the provenance of the returned pointer.

### Testing Strategy

`make prepush` and "I hope this is correct".

### TODO or Help Wanted

Is `kernel_memory_break` the best place to get the provenance from? From the kernel memory layout, it's the closest pointer to where grants are stored that is *before* the location the grants are stored in. I did look at every use of `kernel_memory_break`, and it appears to always have the provenance we need.

As an alternative, we could store a pointer in ProcessCustomGrantIdentifier rather than an offset. Based on the documentation it seems to me that storing a `usize` is more in line with the design, so I left the inner type alone.

### Checklist

- [X] Ran `make prepush`.

### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [X] No documentation updates are required.

#### AI Use

- [X] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
