### PR TITLE
kernel: return Err(NODEVICE) on subscribe on bogus driver

### DIFF
--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -918,29 +918,29 @@ impl Kernel {
                         // conversion.
                         let upcall = Upcall::new(process.processid(), upcall_id, appdata, upcall_ptr);
 
-                        // If `ptr` is not null, we must first verify that the
-                        // upcall function pointer is within process accessible
-                        // memory. Per TRD104:
-                        //
-                        // > If the passed upcall is not valid (is outside
-                        // > process executable memory...), the kernel...MUST
-                        // > immediately return a failure with a error code of
-                        // > `INVALID`.
-                        let rval1 = upcall_ptr.map_or(None, |upcall_ptr_nonnull| {
-                            if !process.is_valid_upcall_function_pointer(upcall_ptr_nonnull.as_ptr()) {
-                                Some(ErrorCode::INVAL)
-                            } else {
-                                None
-                            }
-                        });
+                        let rval = match driver {
+                            Some(driver) => {
+                                // If `ptr` is not null, we must first verify that the
+                                // upcall function pointer is within process accessible
+                                // memory. Per TRD104:
+                                //
+                                // > If the passed upcall is not valid (is outside
+                                // > process executable memory...), the kernel...MUST
+                                // > immediately return a failure with a error code of
+                                // > `INVALID`.
+                                let rval1 = upcall_ptr.map_or(None, |upcall_ptr_nonnull| {
+                                    if !process.is_valid_upcall_function_pointer(upcall_ptr_nonnull.as_ptr()) {
+                                        Some(ErrorCode::INVAL)
+                                    } else {
+                                        None
+                                    }
+                                });
 
-                        // If the upcall is either null or valid, then we
-                        // continue handling the upcall.
-                        let rval = match rval1 {
-                            Some(err) => upcall.into_subscribe_failure(err),
-                            None => {
-                                match driver {
-                                    Some(driver) => {
+                                // If the upcall is either null or valid, then we
+                                // continue handling the upcall.
+                                match rval1 {
+                                    Some(err) => upcall.into_subscribe_failure(err),
+                                    None => {
                                         // At this point we must save the new
                                         // upcall and return the old. The
                                         // upcalls are stored by the core kernel
@@ -1019,9 +1019,9 @@ impl Kernel {
                                             }
                                         }
                                     }
-                                    None => upcall.into_subscribe_failure(ErrorCode::NODEVICE),
                                 }
-                            }
+                            },
+                            None => upcall.into_subscribe_failure(ErrorCode::NODEVICE),
                         };
 
                         // Per TRD104, we only clear upcalls if the subscribe


### PR DESCRIPTION





### Pull Request Overview

TRD104 [says](https://book.tockos.org/trd/trd104-syscalls#4-system-call-api):

> If userspace invokes a system call on a peripheral driver that is not installed in the kernel, the kernel MUST return a Failure result with an error of NODEVICE.

The kernel was not doing this if userspace called subscribe with a bogus function pointer (one not in the process's memory region). Instead, it would return `INVAL` because that check was happening first.

This corrects that by making the subscribe implementation more closely match the other syscalls and do the match on `driver` sooner.

Unfortunately, the diff for this is somewhat ugly, even though the change is pretty simple. All I did was move the match on `driver` to be the outer match, rather than inside of the match on `rval1`.

### Testing Strategy

Using the new [syscall-return test](https://github.com/tock/libtock-c/pull/583) on qemu.


### TODO or Help Wanted

Does this violate Tock 2 stability guarantees?


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
