### PR TITLE
HIL: Add `set_client` to `hil::i2c::I2CDevice`

### DIFF
--- a/boards/components/src/apds9960.rs
+++ b/boards/components/src/apds9960.rs
@@ -10,6 +10,7 @@ use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::hil::gpio;
 use kernel::hil::i2c;
+use kernel::hil::i2c::I2CDevice as _;
 
 #[macro_export]
 macro_rules! apds9960_component_static {

--- a/boards/components/src/atecc508a.rs
+++ b/boards/components/src/atecc508a.rs
@@ -16,6 +16,7 @@ use capsules_extra::atecc508a::Atecc508a;
 use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::hil::i2c;
+use kernel::hil::i2c::I2CDevice as _;
 
 // Setup static space for the objects.
 #[macro_export]

--- a/boards/components/src/bme280.rs
+++ b/boards/components/src/bme280.rs
@@ -28,6 +28,7 @@ use capsules_extra::bme280::Bme280;
 use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::hil::i2c;
+use kernel::hil::i2c::I2CDevice as _;
 
 // Setup static space for the objects.
 #[macro_export]

--- a/boards/components/src/bmm150.rs
+++ b/boards/components/src/bmm150.rs
@@ -19,6 +19,7 @@ use capsules_extra::bmm150::BMM150;
 use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::hil::i2c;
+use kernel::hil::i2c::I2CDevice as _;
 
 // Setup static space for the objects.
 #[macro_export]

--- a/boards/components/src/bmp280.rs
+++ b/boards/components/src/bmp280.rs
@@ -33,6 +33,7 @@ use capsules_extra::bmp280::Bmp280;
 use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::hil::i2c;
+use kernel::hil::i2c::I2CDevice as _;
 use kernel::hil::time::Alarm;
 
 #[macro_export]

--- a/boards/components/src/bus.rs
+++ b/boards/components/src/bus.rs
@@ -32,6 +32,7 @@ use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::hil::bus8080;
 use kernel::hil::i2c;
+use kernel::hil::i2c::I2CDevice as _;
 use kernel::hil::spi::{self, ClockPhase, ClockPolarity, SpiMasterDevice};
 
 // Setup static space for the objects.

--- a/boards/components/src/ccs811.rs
+++ b/boards/components/src/ccs811.rs
@@ -28,6 +28,7 @@ use capsules_extra::ccs811::Ccs811;
 use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::hil::i2c;
+use kernel::hil::i2c::I2CDevice as _;
 
 // Setup static space for the objects.
 #[macro_export]

--- a/boards/components/src/chirp_i2c_moisture.rs
+++ b/boards/components/src/chirp_i2c_moisture.rs
@@ -26,6 +26,7 @@ use capsules_extra::chirp_i2c_moisture::{BUFFER_SIZE, ChirpI2cMoisture};
 use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::hil::i2c;
+use kernel::hil::i2c::I2CDevice as _;
 
 // Setup static space for the objects.
 #[macro_export]

--- a/boards/components/src/dfrobot_rainfall_sensor.rs
+++ b/boards/components/src/dfrobot_rainfall_sensor.rs
@@ -22,6 +22,7 @@ use capsules_extra::dfrobot_rainfall_sensor::{BUFFER_SIZE, DFRobotRainFall};
 use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::hil::i2c;
+use kernel::hil::i2c::I2CDevice as _;
 use kernel::hil::time;
 use kernel::hil::time::Alarm;
 

--- a/boards/components/src/ft6x06.rs
+++ b/boards/components/src/ft6x06.rs
@@ -22,6 +22,7 @@ use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::hil::gpio;
 use kernel::hil::i2c;
+use kernel::hil::i2c::I2CDevice as _;
 
 // Setup static space for the objects.
 #[macro_export]

--- a/boards/components/src/fxos8700.rs
+++ b/boards/components/src/fxos8700.rs
@@ -22,6 +22,7 @@
 
 use capsules_core::virtualizers::virtual_i2c::{I2CDevice, MuxI2C};
 use capsules_extra::fxos8700cq::Fxos8700cq;
+use kernel::hil::i2c::I2CDevice as _;
 
 use kernel::component::Component;
 

--- a/boards/components/src/hs3003.rs
+++ b/boards/components/src/hs3003.rs
@@ -18,6 +18,7 @@ use capsules_extra::hs3003::Hs3003;
 use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::hil::i2c;
+use kernel::hil::i2c::I2CDevice as _;
 
 // Setup static space for the objects.
 #[macro_export]

--- a/boards/components/src/hts221.rs
+++ b/boards/components/src/hts221.rs
@@ -18,6 +18,7 @@ use capsules_extra::hts221::Hts221;
 use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::hil::i2c;
+use kernel::hil::i2c::I2CDevice as _;
 
 // Setup static space for the objects.
 #[macro_export]

--- a/boards/components/src/isl29035.rs
+++ b/boards/components/src/isl29035.rs
@@ -35,6 +35,7 @@ use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
 use kernel::hil;
 use kernel::hil::i2c;
+use kernel::hil::i2c::I2CDevice as _;
 use kernel::hil::time::{self, Alarm};
 
 // Setup static space for the objects.

--- a/boards/components/src/lps22hb.rs
+++ b/boards/components/src/lps22hb.rs
@@ -9,6 +9,7 @@ use capsules_extra::lps22hb::Lps22hb;
 use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::hil::i2c;
+use kernel::hil::i2c::I2CDevice as _;
 
 #[macro_export]
 macro_rules! lps22hb_component_static {

--- a/boards/components/src/lps25hb.rs
+++ b/boards/components/src/lps25hb.rs
@@ -11,6 +11,7 @@ use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
 use kernel::hil::gpio;
 use kernel::hil::i2c;
+use kernel::hil::i2c::I2CDevice as _;
 
 #[macro_export]
 macro_rules! lps25hb_component_static {

--- a/boards/components/src/lsm303agr.rs
+++ b/boards/components/src/lsm303agr.rs
@@ -30,6 +30,7 @@ use core::mem::MaybeUninit;
 use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
 use kernel::hil::i2c;
+use kernel::hil::i2c::I2CDevice as _;
 
 // Setup static space for the objects.
 #[macro_export]

--- a/boards/components/src/lsm303dlhc.rs
+++ b/boards/components/src/lsm303dlhc.rs
@@ -29,6 +29,7 @@ use core::mem::MaybeUninit;
 use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
 use kernel::hil::i2c;
+use kernel::hil::i2c::I2CDevice as _;
 
 // Setup static space for the objects.
 #[macro_export]

--- a/boards/components/src/lsm6dsox.rs
+++ b/boards/components/src/lsm6dsox.rs
@@ -34,6 +34,7 @@ use core::mem::MaybeUninit;
 use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
 use kernel::hil::i2c;
+use kernel::hil::i2c::I2CDevice as _;
 
 // Setup static space for the objects.
 #[macro_export]

--- a/boards/components/src/ltc294x.rs
+++ b/boards/components/src/ltc294x.rs
@@ -22,6 +22,7 @@ use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
 use kernel::hil::gpio;
 use kernel::hil::i2c;
+use kernel::hil::i2c::I2CDevice as _;
 
 #[macro_export]
 macro_rules! ltc294x_component_static {

--- a/boards/components/src/mlx90614.rs
+++ b/boards/components/src/mlx90614.rs
@@ -23,6 +23,7 @@ use capsules_extra::mlx90614::Mlx90614SMBus;
 use core::mem::MaybeUninit;
 use kernel::capabilities::MemoryAllocationCapability;
 use kernel::component::Component;
+use kernel::hil::i2c::I2CDevice as _;
 use kernel::hil::i2c::{self, NoSMBus};
 
 // Setup static space for the objects.

--- a/boards/components/src/sh1106.rs
+++ b/boards/components/src/sh1106.rs
@@ -18,6 +18,7 @@
 use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::hil;
+use kernel::hil::i2c::I2CDevice as _;
 
 // Setup static space for the objects.
 #[macro_export]

--- a/boards/components/src/sht3x.rs
+++ b/boards/components/src/sht3x.rs
@@ -22,6 +22,7 @@ use capsules_extra::sht3x::SHT3x;
 use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::hil::i2c;
+use kernel::hil::i2c::I2CDevice as _;
 use kernel::hil::time::Alarm;
 
 // Setup static space for the objects.

--- a/boards/components/src/sht4x.rs
+++ b/boards/components/src/sht4x.rs
@@ -22,6 +22,7 @@ use capsules_extra::sht4x::SHT4x;
 use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::hil::i2c;
+use kernel::hil::i2c::I2CDevice as _;
 use kernel::hil::time::Alarm;
 
 // Setup static space for the objects.

--- a/boards/components/src/si7021.rs
+++ b/boards/components/src/si7021.rs
@@ -24,6 +24,7 @@ use capsules_core::virtualizers::virtual_i2c::{I2CDevice, MuxI2C};
 use capsules_extra::si7021::SI7021;
 use kernel::component::Component;
 use kernel::hil::i2c;
+use kernel::hil::i2c::I2CDevice as _;
 use kernel::hil::time::{self, Alarm};
 
 // Setup static space for the objects.

--- a/boards/components/src/ssd1306.rs
+++ b/boards/components/src/ssd1306.rs
@@ -18,6 +18,7 @@
 use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::hil;
+use kernel::hil::i2c::I2CDevice as _;
 
 // Setup static space for the objects.
 #[macro_export]

--- a/capsules/core/src/virtualizers/virtual_i2c.rs
+++ b/capsules/core/src/virtualizers/virtual_i2c.rs
@@ -243,7 +243,7 @@ impl<'a, I: i2c::I2CMaster<'a>, S: i2c::SMBusMaster<'a>> ListNode<'a, I2CDevice<
     }
 }
 
-impl<'a, I: i2c::I2CMaster<'a>> i2c::I2CDevice for I2CDevice<'a, I> {
+impl<'a, I: i2c::I2CMaster<'a>> i2c::I2CDevice<'a> for I2CDevice<'a, I> {
     fn enable(&self) {
         if !self.enabled.get() {
             self.enabled.set(true);
@@ -332,11 +332,6 @@ impl<'a, I: i2c::I2CMaster<'a>, S: i2c::SMBusMaster<'a>> SMBusDevice<'a, I, S> {
             client: OptionalCell::empty(),
         }
     }
-
-    pub fn set_client(&'a self, client: &'a dyn I2CClient) {
-        self.mux.smbus_devices.push_head(self);
-        self.client.set(client);
-    }
 }
 
 impl<'a, I: i2c::I2CMaster<'a>, S: i2c::SMBusMaster<'a>> I2CClient for SMBusDevice<'a, I, S> {
@@ -355,7 +350,9 @@ impl<'a, I: i2c::I2CMaster<'a>, S: i2c::SMBusMaster<'a>> ListNode<'a, SMBusDevic
     }
 }
 
-impl<'a, I: i2c::I2CMaster<'a>, S: i2c::SMBusMaster<'a>> i2c::I2CDevice for SMBusDevice<'a, I, S> {
+impl<'a, I: i2c::I2CMaster<'a>, S: i2c::SMBusMaster<'a>> i2c::I2CDevice<'a>
+    for SMBusDevice<'a, I, S>
+{
     fn enable(&self) {
         if !self.enabled.get() {
             self.enabled.set(true);
@@ -411,9 +408,14 @@ impl<'a, I: i2c::I2CMaster<'a>, S: i2c::SMBusMaster<'a>> i2c::I2CDevice for SMBu
             Err((Error::ArbitrationLost, buffer))
         }
     }
+
+    fn set_client(&'a self, client: &'a dyn I2CClient) {
+        self.mux.smbus_devices.push_head(self);
+        self.client.set(client);
+    }
 }
 
-impl<'a, I: i2c::I2CMaster<'a>, S: i2c::SMBusMaster<'a>> i2c::SMBusDevice
+impl<'a, I: i2c::I2CMaster<'a>, S: i2c::SMBusMaster<'a>> i2c::SMBusDevice<'a>
     for SMBusDevice<'a, I, S>
 {
     fn smbus_write_read(

--- a/capsules/core/src/virtualizers/virtual_i2c.rs
+++ b/capsules/core/src/virtualizers/virtual_i2c.rs
@@ -225,11 +225,6 @@ impl<'a, I: i2c::I2CMaster<'a>, S: i2c::SMBusMaster<'a>> I2CDevice<'a, I, S> {
             client: OptionalCell::empty(),
         }
     }
-
-    pub fn set_client(&'a self, client: &'a dyn I2CClient) {
-        self.mux.i2c_devices.push_head(self);
-        self.client.set(client);
-    }
 }
 
 impl<'a, I: i2c::I2CMaster<'a>, S: i2c::SMBusMaster<'a>> I2CClient for I2CDevice<'a, I, S> {
@@ -303,6 +298,11 @@ impl<'a, I: i2c::I2CMaster<'a>> i2c::I2CDevice for I2CDevice<'a, I> {
         } else {
             Err((Error::ArbitrationLost, buffer))
         }
+    }
+
+    fn set_client(&'a self, client: &'a dyn I2CClient) {
+        self.mux.i2c_devices.push_head(self);
+        self.client.set(client);
     }
 }
 

--- a/capsules/extra/src/apds9960.rs
+++ b/capsules/extra/src/apds9960.rs
@@ -110,7 +110,7 @@ enum State {
     Done,      // Final state for take_measurement() state sequence
 }
 
-pub struct APDS9960<'a, I: i2c::I2CDevice> {
+pub struct APDS9960<'a, I: i2c::I2CDevice<'a>> {
     i2c: &'a I,
     interrupt_pin: &'a dyn gpio::InterruptPin<'a>,
     prox_callback: OptionalCell<&'a dyn kernel::hil::sensors::ProximityClient>,
@@ -118,7 +118,7 @@ pub struct APDS9960<'a, I: i2c::I2CDevice> {
     buffer: TakeCell<'static, [u8]>,
 }
 
-impl<'a, I: i2c::I2CDevice> APDS9960<'a, I> {
+impl<'a, I: i2c::I2CDevice<'a>> APDS9960<'a, I> {
     pub fn new(
         i2c: &'a I,
         interrupt_pin: &'a dyn gpio::InterruptPin<'a>,
@@ -295,7 +295,7 @@ impl<'a, I: i2c::I2CDevice> APDS9960<'a, I> {
     }
 }
 
-impl<I: i2c::I2CDevice> i2c::I2CClient for APDS9960<'_, I> {
+impl<'a, I: i2c::I2CDevice<'a>> i2c::I2CClient for APDS9960<'a, I> {
     fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), i2c::Error>) {
         match self.state.get() {
             State::ReadId => {
@@ -532,7 +532,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for APDS9960<'_, I> {
 }
 
 /// Interrupt Service Routine
-impl<I: i2c::I2CDevice> gpio::Client for APDS9960<'_, I> {
+impl<'a, I: i2c::I2CDevice<'a>> gpio::Client for APDS9960<'a, I> {
     fn fired(&self) {
         self.buffer.take().map(|buffer| {
             // Read value in PDATA reg
@@ -554,7 +554,7 @@ impl<I: i2c::I2CDevice> gpio::Client for APDS9960<'_, I> {
 }
 
 /// Proximity Driver Trait Implementation
-impl<'a, I: i2c::I2CDevice> kernel::hil::sensors::ProximityDriver<'a> for APDS9960<'a, I> {
+impl<'a, I: i2c::I2CDevice<'a>> kernel::hil::sensors::ProximityDriver<'a> for APDS9960<'a, I> {
     fn read_proximity(&self) -> Result<(), ErrorCode> {
         self.take_measurement()
     }

--- a/capsules/extra/src/at24c_eeprom.rs
+++ b/capsules/extra/src/at24c_eeprom.rs
@@ -74,7 +74,7 @@ enum State {
 }
 
 pub struct AT24C<'a> {
-    i2c: &'a dyn I2CDevice,
+    i2c: &'a dyn I2CDevice<'a>,
     buffer: TakeCell<'static, [u8]>,
     client_page: TakeCell<'a, EEPROMPage>,
     flash_client: OptionalCell<&'a dyn hil::flash::Client<AT24C<'a>>>,
@@ -82,7 +82,7 @@ pub struct AT24C<'a> {
 }
 
 impl<'a> AT24C<'a> {
-    pub fn new(i2c: &'a dyn I2CDevice, buffer: &'static mut [u8]) -> Self {
+    pub fn new(i2c: &'a dyn I2CDevice<'a>, buffer: &'static mut [u8]) -> Self {
         Self {
             i2c,
             buffer: TakeCell::new(buffer),

--- a/capsules/extra/src/atecc508a.rs
+++ b/capsules/extra/src/atecc508a.rs
@@ -183,7 +183,7 @@ enum Operation {
 
 pub struct Atecc508a<'a> {
     buffer: TakeCell<'static, [u8]>,
-    i2c: &'a dyn I2CDevice,
+    i2c: &'a dyn I2CDevice<'a>,
     op: Cell<Operation>,
     op_len: Cell<usize>,
 
@@ -215,7 +215,7 @@ pub struct Atecc508a<'a> {
 
 impl<'a> Atecc508a<'a> {
     pub fn new(
-        i2c: &'a dyn I2CDevice,
+        i2c: &'a dyn I2CDevice<'a>,
         buffer: &'static mut [u8],
         entropy_buffer: &'static mut [u8; 32],
         digest_buffer: &'static mut [u8; 64],

--- a/capsules/extra/src/bme280.rs
+++ b/capsules/extra/src/bme280.rs
@@ -82,7 +82,7 @@ struct CalibrationData {
     hum6: u16,
 }
 
-pub struct Bme280<'a, I: I2CDevice> {
+pub struct Bme280<'a, I: I2CDevice<'a>> {
     buffer: TakeCell<'static, [u8]>,
     i2c: &'a I,
     calibration: Cell<CalibrationData>,
@@ -94,7 +94,7 @@ pub struct Bme280<'a, I: I2CDevice> {
     t_fine: Cell<i32>,
 }
 
-impl<'a, I: I2CDevice> Bme280<'a, I> {
+impl<'a, I: I2CDevice<'a>> Bme280<'a, I> {
     pub fn new(i2c: &'a I, buffer: &'static mut [u8]) -> Self {
         Bme280 {
             buffer: TakeCell::new(buffer),
@@ -120,7 +120,7 @@ impl<'a, I: I2CDevice> Bme280<'a, I> {
     }
 }
 
-impl<'a, I: I2CDevice> TemperatureDriver<'a> for Bme280<'a, I> {
+impl<'a, I: I2CDevice<'a>> TemperatureDriver<'a> for Bme280<'a, I> {
     fn set_client(&self, client: &'a dyn TemperatureClient) {
         self.temperature_client.set(client);
     }
@@ -146,7 +146,7 @@ impl<'a, I: I2CDevice> TemperatureDriver<'a> for Bme280<'a, I> {
     }
 }
 
-impl<'a, I: I2CDevice> HumidityDriver<'a> for Bme280<'a, I> {
+impl<'a, I: I2CDevice<'a>> HumidityDriver<'a> for Bme280<'a, I> {
     fn set_client(&self, client: &'a dyn HumidityClient) {
         self.humidity_client.set(client);
     }
@@ -172,7 +172,7 @@ impl<'a, I: I2CDevice> HumidityDriver<'a> for Bme280<'a, I> {
     }
 }
 
-impl<'a, I: I2CDevice> PressureDriver<'a> for Bme280<'a, I> {
+impl<'a, I: I2CDevice<'a>> PressureDriver<'a> for Bme280<'a, I> {
     fn set_client(&self, client: &'a dyn PressureClient) {
         self.pressure_client.set(client);
     }
@@ -198,7 +198,7 @@ impl<'a, I: I2CDevice> PressureDriver<'a> for Bme280<'a, I> {
     }
 }
 
-impl<I: I2CDevice> I2CClient for Bme280<'_, I> {
+impl<'a, I: I2CDevice<'a>> I2CClient for Bme280<'a, I> {
     fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
         if let Err(i2c_err) = status {
             // We have no way to report an error, so just return a bogus value

--- a/capsules/extra/src/bmm150.rs
+++ b/capsules/extra/src/bmm150.rs
@@ -65,14 +65,14 @@ enum Registers {
     REPZ = 0x52,
 }
 
-pub struct BMM150<'a, I: I2CDevice> {
+pub struct BMM150<'a, I: I2CDevice<'a>> {
     buffer: TakeCell<'static, [u8]>,
     i2c: &'a I,
     ninedof_client: OptionalCell<&'a dyn NineDofClient>,
     state: Cell<State>,
 }
 
-impl<'a, I: I2CDevice> BMM150<'a, I> {
+impl<'a, I: I2CDevice<'a>> BMM150<'a, I> {
     pub fn new(buffer: &'static mut [u8], i2c: &'a I) -> BMM150<'a, I> {
         BMM150 {
             buffer: TakeCell::new(buffer),
@@ -117,7 +117,7 @@ impl<'a, I: I2CDevice> BMM150<'a, I> {
     }
 }
 
-impl<'a, I: i2c::I2CDevice> NineDof<'a> for BMM150<'a, I> {
+impl<'a, I: i2c::I2CDevice<'a>> NineDof<'a> for BMM150<'a, I> {
     fn set_client(&self, client: &'a dyn NineDofClient) {
         self.ninedof_client.set(client);
     }
@@ -137,7 +137,7 @@ enum State {
     Read,
 }
 
-impl<I: I2CDevice> I2CClient for BMM150<'_, I> {
+impl<'a, I: I2CDevice<'a>> I2CClient for BMM150<'a, I> {
     fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
         if let Err(i2c_err) = status {
             self.state.set(State::Sleep);

--- a/capsules/extra/src/bmp280.rs
+++ b/capsules/extra/src/bmp280.rs
@@ -139,11 +139,11 @@ impl State {
 }
 
 /// Complies with the reading and writing protocol used by the sensor.
-struct I2cWrapper<'a, I: i2c::I2CDevice> {
+struct I2cWrapper<'a, I: i2c::I2CDevice<'a>> {
     i2c: &'a I,
 }
 
-impl<I: i2c::I2CDevice> I2cWrapper<'_, I> {
+impl<'a, I: i2c::I2CDevice<'a>> I2cWrapper<'a, I> {
     fn write<const COUNT: usize>(
         &self,
         buffer: &'static mut [u8],
@@ -178,7 +178,7 @@ impl<I: i2c::I2CDevice> I2cWrapper<'_, I> {
     }
 }
 
-pub struct Bmp280<'a, A: Alarm<'a>, I: i2c::I2CDevice> {
+pub struct Bmp280<'a, A: Alarm<'a>, I: i2c::I2CDevice<'a>> {
     i2c: I2cWrapper<'a, I>,
     temperature_client: OptionalCell<&'a dyn hil::sensors::TemperatureClient>,
     // This might be better as a `RefCell`,
@@ -194,7 +194,7 @@ pub struct Bmp280<'a, A: Alarm<'a>, I: i2c::I2CDevice> {
     alarm: &'a A,
 }
 
-impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> Bmp280<'a, A, I> {
+impl<'a, A: Alarm<'a>, I: i2c::I2CDevice<'a>> Bmp280<'a, A, I> {
     pub fn new(i2c: &'a I, buffer: &'static mut [u8], alarm: &'a A) -> Self {
         Self {
             i2c: I2cWrapper { i2c },
@@ -328,7 +328,7 @@ impl I2cOperation {
     }
 }
 
-impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> i2c::I2CClient for Bmp280<'a, A, I> {
+impl<'a, A: Alarm<'a>, I: i2c::I2CDevice<'a>> i2c::I2CClient for Bmp280<'a, A, I> {
     fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
         let mut temp_readout = None;
         let mut i2c_op = I2cOperation::Disable;
@@ -469,7 +469,9 @@ impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> i2c::I2CClient for Bmp280<'a, A, I> {
     }
 }
 
-impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> hil::sensors::TemperatureDriver<'a> for Bmp280<'a, A, I> {
+impl<'a, A: Alarm<'a>, I: i2c::I2CDevice<'a>> hil::sensors::TemperatureDriver<'a>
+    for Bmp280<'a, A, I>
+{
     fn set_client(&self, client: &'a dyn hil::sensors::TemperatureClient) {
         self.temperature_client.set(client)
     }
@@ -479,7 +481,9 @@ impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> hil::sensors::TemperatureDriver<'a> fo
     }
 }
 
-impl<'a, A: hil::time::Alarm<'a>, I: i2c::I2CDevice> hil::time::AlarmClient for Bmp280<'a, A, I> {
+impl<'a, A: hil::time::Alarm<'a>, I: i2c::I2CDevice<'a>> hil::time::AlarmClient
+    for Bmp280<'a, A, I>
+{
     fn alarm(&self) {
         self.handle_alarm()
     }

--- a/capsules/extra/src/bus.rs
+++ b/capsules/extra/src/bus.rs
@@ -418,7 +418,7 @@ impl<'a, S: SpiMasterDevice<'a>> SpiMasterClient for SpiMasterBus<'a, S> {
 
 /*********** I2C ************/
 
-pub struct I2CMasterBus<'a, I: I2CDevice> {
+pub struct I2CMasterBus<'a, I: I2CDevice<'a>> {
     i2c: &'a I,
     len: Cell<usize>,
     client: OptionalCell<&'a dyn Client>,
@@ -426,7 +426,7 @@ pub struct I2CMasterBus<'a, I: I2CDevice> {
     status: Cell<BusStatus>,
 }
 
-impl<'a, I: I2CDevice> I2CMasterBus<'a, I> {
+impl<'a, I: I2CDevice<'a>> I2CMasterBus<'a, I> {
     pub fn new(i2c: &'a I, addr_buffer: &'static mut [u8]) -> I2CMasterBus<'a, I> {
         I2CMasterBus {
             i2c,
@@ -438,7 +438,7 @@ impl<'a, I: I2CDevice> I2CMasterBus<'a, I> {
     }
 }
 
-impl<'a, A: BusAddr, I: I2CDevice> Bus<'a, A> for I2CMasterBus<'a, I> {
+impl<'a, A: BusAddr, I: I2CDevice<'a>> Bus<'a, A> for I2CMasterBus<'a, I> {
     fn set_addr(&self, addr: A) -> Result<(), ErrorCode> {
         self.addr_buffer
             .take()
@@ -509,7 +509,7 @@ impl<'a, A: BusAddr, I: I2CDevice> Bus<'a, A> for I2CMasterBus<'a, I> {
     }
 }
 
-impl<I: I2CDevice> I2CClient for I2CMasterBus<'_, I> {
+impl<'a, I: I2CDevice<'a>> I2CClient for I2CMasterBus<'a, I> {
     fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), Error>) {
         let len = match status {
             Ok(()) => self.len.get(),

--- a/capsules/extra/src/ccs811.rs
+++ b/capsules/extra/src/ccs811.rs
@@ -65,7 +65,7 @@ enum Operation {
 
 pub struct Ccs811<'a> {
     buffer: TakeCell<'static, [u8]>,
-    i2c: &'a dyn I2CDevice,
+    i2c: &'a dyn I2CDevice<'a>,
     client: OptionalCell<&'a dyn AirQualityClient>,
     state: Cell<DeviceState>,
     op: Cell<Operation>,
@@ -76,7 +76,7 @@ pub struct Ccs811<'a> {
 }
 
 impl<'a> Ccs811<'a> {
-    pub fn new(i2c: &'a dyn I2CDevice, buffer: &'static mut [u8]) -> Self {
+    pub fn new(i2c: &'a dyn I2CDevice<'a>, buffer: &'static mut [u8]) -> Self {
         Self {
             buffer: TakeCell::new(buffer),
             i2c,

--- a/capsules/extra/src/chirp_i2c_moisture.rs
+++ b/capsules/extra/src/chirp_i2c_moisture.rs
@@ -50,7 +50,7 @@ enum Operation {
     Moisture,
 }
 
-pub struct ChirpI2cMoisture<'a, I: I2CDevice> {
+pub struct ChirpI2cMoisture<'a, I: I2CDevice<'a>> {
     buffer: TakeCell<'static, [u8]>,
     i2c: &'a I,
     moisture_client: OptionalCell<&'a dyn MoistureClient>,
@@ -58,7 +58,7 @@ pub struct ChirpI2cMoisture<'a, I: I2CDevice> {
     op: Cell<Operation>,
 }
 
-impl<'a, I: I2CDevice> ChirpI2cMoisture<'a, I> {
+impl<'a, I: I2CDevice<'a>> ChirpI2cMoisture<'a, I> {
     pub fn new(i2c: &'a I, buffer: &'static mut [u8]) -> Self {
         ChirpI2cMoisture {
             buffer: TakeCell::new(buffer),
@@ -70,7 +70,7 @@ impl<'a, I: I2CDevice> ChirpI2cMoisture<'a, I> {
     }
 }
 
-impl<'a, I: I2CDevice> MoistureDriver<'a> for ChirpI2cMoisture<'a, I> {
+impl<'a, I: I2CDevice<'a>> MoistureDriver<'a> for ChirpI2cMoisture<'a, I> {
     fn set_client(&self, client: &'a dyn MoistureClient) {
         self.moisture_client.set(client);
     }
@@ -99,7 +99,7 @@ impl<'a, I: I2CDevice> MoistureDriver<'a> for ChirpI2cMoisture<'a, I> {
     }
 }
 
-impl<I: I2CDevice> I2CClient for ChirpI2cMoisture<'_, I> {
+impl<'a, I: I2CDevice<'a>> I2CClient for ChirpI2cMoisture<'a, I> {
     fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
         if let Err(i2c_err) = status {
             self.buffer.replace(buffer);

--- a/capsules/extra/src/dfrobot_rainfall_sensor.rs
+++ b/capsules/extra/src/dfrobot_rainfall_sensor.rs
@@ -37,7 +37,7 @@ enum Operation {
     RainFall,
 }
 
-pub struct DFRobotRainFall<'a, A: Alarm<'a>, I: I2CDevice> {
+pub struct DFRobotRainFall<'a, A: Alarm<'a>, I: I2CDevice<'a>> {
     buffer: TakeCell<'static, [u8]>,
     i2c: &'a I,
     rainfall_client: OptionalCell<&'a dyn RainFallClient>,
@@ -46,7 +46,7 @@ pub struct DFRobotRainFall<'a, A: Alarm<'a>, I: I2CDevice> {
     alarm: &'a A,
 }
 
-impl<'a, A: Alarm<'a>, I: I2CDevice> DFRobotRainFall<'a, A, I> {
+impl<'a, A: Alarm<'a>, I: I2CDevice<'a>> DFRobotRainFall<'a, A, I> {
     pub fn new(i2c: &'a I, buffer: &'static mut [u8], alarm: &'a A) -> Self {
         DFRobotRainFall {
             buffer: TakeCell::new(buffer),
@@ -73,7 +73,7 @@ impl<'a, A: Alarm<'a>, I: I2CDevice> DFRobotRainFall<'a, A, I> {
     }
 }
 
-impl<'a, A: Alarm<'a>, I: I2CDevice> RainFallDriver<'a> for DFRobotRainFall<'a, A, I> {
+impl<'a, A: Alarm<'a>, I: I2CDevice<'a>> RainFallDriver<'a> for DFRobotRainFall<'a, A, I> {
     fn set_client(&self, client: &'a dyn RainFallClient) {
         self.rainfall_client.set(client);
     }
@@ -107,7 +107,7 @@ impl<'a, A: Alarm<'a>, I: I2CDevice> RainFallDriver<'a> for DFRobotRainFall<'a, 
     }
 }
 
-impl<'a, A: Alarm<'a>, I: I2CDevice> I2CClient for DFRobotRainFall<'a, A, I> {
+impl<'a, A: Alarm<'a>, I: I2CDevice<'a>> I2CClient for DFRobotRainFall<'a, A, I> {
     fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
         if let Err(i2c_err) = status {
             self.buffer.replace(buffer);
@@ -186,7 +186,7 @@ impl<'a, A: Alarm<'a>, I: I2CDevice> I2CClient for DFRobotRainFall<'a, A, I> {
     }
 }
 
-impl<'a, A: Alarm<'a>, I: I2CDevice> AlarmClient for DFRobotRainFall<'a, A, I> {
+impl<'a, A: Alarm<'a>, I: I2CDevice<'a>> AlarmClient for DFRobotRainFall<'a, A, I> {
     fn alarm(&self) {
         match self.op.get() {
             Operation::None => (),

--- a/capsules/extra/src/ft6x06.rs
+++ b/capsules/extra/src/ft6x06.rs
@@ -50,7 +50,7 @@ enum_from_primitive! {
     }
 }
 
-pub struct Ft6x06<'a, I: i2c::I2CDevice> {
+pub struct Ft6x06<'a, I: i2c::I2CDevice<'a>> {
     i2c: &'a I,
     interrupt_pin: &'a dyn gpio::InterruptPin<'a>,
     touch_client: OptionalCell<&'a dyn touch::TouchClient>,
@@ -61,7 +61,7 @@ pub struct Ft6x06<'a, I: i2c::I2CDevice> {
     events: TakeCell<'static, [TouchEvent]>,
 }
 
-impl<'a, I: i2c::I2CDevice> Ft6x06<'a, I> {
+impl<'a, I: i2c::I2CDevice<'a>> Ft6x06<'a, I> {
     pub fn new(
         i2c: &'a I,
         interrupt_pin: &'a dyn gpio::InterruptPin<'a>,
@@ -83,7 +83,7 @@ impl<'a, I: i2c::I2CDevice> Ft6x06<'a, I> {
     }
 }
 
-impl<I: i2c::I2CDevice> i2c::I2CClient for Ft6x06<'_, I> {
+impl<'a, I: i2c::I2CDevice<'a>> i2c::I2CClient for Ft6x06<'a, I> {
     fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), i2c::Error>) {
         self.num_touches.set((buffer[1] & 0x0F) as usize);
         self.touch_client.map(|client| {
@@ -168,7 +168,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Ft6x06<'_, I> {
     }
 }
 
-impl<I: i2c::I2CDevice> gpio::Client for Ft6x06<'_, I> {
+impl<'a, I: i2c::I2CDevice<'a>> gpio::Client for Ft6x06<'a, I> {
     fn fired(&self) {
         self.buffer.take().map(|buffer| {
             self.interrupt_pin.disable_interrupts();
@@ -187,7 +187,7 @@ impl<I: i2c::I2CDevice> gpio::Client for Ft6x06<'_, I> {
     }
 }
 
-impl<'a, I: i2c::I2CDevice> touch::Touch<'a> for Ft6x06<'a, I> {
+impl<'a, I: i2c::I2CDevice<'a>> touch::Touch<'a> for Ft6x06<'a, I> {
     fn enable(&self) -> Result<(), ErrorCode> {
         Ok(())
     }
@@ -201,13 +201,13 @@ impl<'a, I: i2c::I2CDevice> touch::Touch<'a> for Ft6x06<'a, I> {
     }
 }
 
-impl<'a, I: i2c::I2CDevice> touch::Gesture<'a> for Ft6x06<'a, I> {
+impl<'a, I: i2c::I2CDevice<'a>> touch::Gesture<'a> for Ft6x06<'a, I> {
     fn set_client(&self, client: &'a dyn touch::GestureClient) {
         self.gesture_client.replace(client);
     }
 }
 
-impl<'a, I: i2c::I2CDevice> touch::MultiTouch<'a> for Ft6x06<'a, I> {
+impl<'a, I: i2c::I2CDevice<'a>> touch::MultiTouch<'a> for Ft6x06<'a, I> {
     fn enable(&self) -> Result<(), ErrorCode> {
         Ok(())
     }

--- a/capsules/extra/src/fxos8700cq.rs
+++ b/capsules/extra/src/fxos8700cq.rs
@@ -182,7 +182,7 @@ enum State {
 }
 
 pub struct Fxos8700cq<'a> {
-    i2c: &'a dyn I2CDevice,
+    i2c: &'a dyn I2CDevice<'a>,
     interrupt_pin1: &'a dyn gpio::InterruptPin<'a>,
     state: Cell<State>,
     buffer: TakeCell<'static, [u8]>,
@@ -191,7 +191,7 @@ pub struct Fxos8700cq<'a> {
 
 impl<'a> Fxos8700cq<'a> {
     pub fn new(
-        i2c: &'a dyn I2CDevice,
+        i2c: &'a dyn I2CDevice<'a>,
         interrupt_pin1: &'a dyn gpio::InterruptPin<'a>,
         buffer: &'static mut [u8],
     ) -> Fxos8700cq<'a> {

--- a/capsules/extra/src/hs3003.rs
+++ b/capsules/extra/src/hs3003.rs
@@ -54,7 +54,7 @@ use kernel::hil::i2c::{self, I2CClient, I2CDevice};
 use kernel::hil::sensors::{HumidityClient, HumidityDriver, TemperatureClient, TemperatureDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 
-pub struct Hs3003<'a, I: I2CDevice> {
+pub struct Hs3003<'a, I: I2CDevice<'a>> {
     buffer: TakeCell<'static, [u8]>,
     i2c: &'a I,
     temperature_client: OptionalCell<&'a dyn TemperatureClient>,
@@ -64,7 +64,7 @@ pub struct Hs3003<'a, I: I2CDevice> {
     pending_humidity: Cell<bool>,
 }
 
-impl<'a, I: I2CDevice> Hs3003<'a, I> {
+impl<'a, I: I2CDevice<'a>> Hs3003<'a, I> {
     pub fn new(i2c: &'a I, buffer: &'static mut [u8]) -> Self {
         Hs3003 {
             buffer: TakeCell::new(buffer),
@@ -95,7 +95,7 @@ impl<'a, I: I2CDevice> Hs3003<'a, I> {
     }
 }
 
-impl<'a, I: I2CDevice> TemperatureDriver<'a> for Hs3003<'a, I> {
+impl<'a, I: I2CDevice<'a>> TemperatureDriver<'a> for Hs3003<'a, I> {
     fn set_client(&self, client: &'a dyn TemperatureClient) {
         self.temperature_client.set(client);
     }
@@ -110,7 +110,7 @@ impl<'a, I: I2CDevice> TemperatureDriver<'a> for Hs3003<'a, I> {
     }
 }
 
-impl<'a, I: I2CDevice> HumidityDriver<'a> for Hs3003<'a, I> {
+impl<'a, I: I2CDevice<'a>> HumidityDriver<'a> for Hs3003<'a, I> {
     fn set_client(&self, client: &'a dyn HumidityClient) {
         self.humidity_client.set(client);
     }
@@ -132,7 +132,7 @@ enum State {
     Read,
 }
 
-impl<I: I2CDevice> I2CClient for Hs3003<'_, I> {
+impl<'a, I: I2CDevice<'a>> I2CClient for Hs3003<'a, I> {
     fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
         if let Err(i2c_err) = status {
             self.state.set(State::Sleep);

--- a/capsules/extra/src/hts221.rs
+++ b/capsules/extra/src/hts221.rs
@@ -88,7 +88,7 @@ struct CalibrationData {
     humidity_intercept: f32,
 }
 
-pub struct Hts221<'a, I: I2CDevice> {
+pub struct Hts221<'a, I: I2CDevice<'a>> {
     buffer: TakeCell<'static, [u8]>,
     i2c: &'a I,
     temperature_client: OptionalCell<&'a dyn TemperatureClient>,
@@ -98,7 +98,7 @@ pub struct Hts221<'a, I: I2CDevice> {
     pending_humidity: Cell<bool>,
 }
 
-impl<'a, I: I2CDevice> Hts221<'a, I> {
+impl<'a, I: I2CDevice<'a>> Hts221<'a, I> {
     pub fn new(i2c: &'a I, buffer: &'static mut [u8]) -> Self {
         Hts221 {
             buffer: TakeCell::new(buffer),
@@ -152,7 +152,7 @@ impl<'a, I: I2CDevice> Hts221<'a, I> {
     }
 }
 
-impl<'a, I: I2CDevice> TemperatureDriver<'a> for Hts221<'a, I> {
+impl<'a, I: I2CDevice<'a>> TemperatureDriver<'a> for Hts221<'a, I> {
     fn set_client(&self, client: &'a dyn TemperatureClient) {
         self.temperature_client.set(client);
     }
@@ -167,7 +167,7 @@ impl<'a, I: I2CDevice> TemperatureDriver<'a> for Hts221<'a, I> {
     }
 }
 
-impl<'a, I: I2CDevice> HumidityDriver<'a> for Hts221<'a, I> {
+impl<'a, I: I2CDevice<'a>> HumidityDriver<'a> for Hts221<'a, I> {
     fn set_client(&self, client: &'a dyn HumidityClient) {
         self.humidity_client.set(client);
     }
@@ -192,7 +192,7 @@ enum State {
     Idle(CalibrationData, i32, usize),
 }
 
-impl<I: I2CDevice> I2CClient for Hts221<'_, I> {
+impl<'a, I: I2CDevice<'a>> I2CClient for Hts221<'a, I> {
     fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
         if let Err(i2c_err) = status {
             self.state.set(State::Idle(

--- a/capsules/extra/src/isl29035.rs
+++ b/capsules/extra/src/isl29035.rs
@@ -54,7 +54,7 @@ enum State {
 }
 
 pub struct Isl29035<'a, A: time::Alarm<'a>> {
-    i2c: &'a dyn I2CDevice,
+    i2c: &'a dyn I2CDevice<'a>,
     alarm: &'a A,
     state: Cell<State>,
     buffer: TakeCell<'static, [u8]>,
@@ -62,7 +62,11 @@ pub struct Isl29035<'a, A: time::Alarm<'a>> {
 }
 
 impl<'a, A: time::Alarm<'a>> Isl29035<'a, A> {
-    pub fn new(i2c: &'a dyn I2CDevice, alarm: &'a A, buffer: &'static mut [u8]) -> Isl29035<'a, A> {
+    pub fn new(
+        i2c: &'a dyn I2CDevice<'a>,
+        alarm: &'a A,
+        buffer: &'static mut [u8],
+    ) -> Isl29035<'a, A> {
         Isl29035 {
             i2c,
             alarm,

--- a/capsules/extra/src/lps22hb.rs
+++ b/capsules/extra/src/lps22hb.rs
@@ -78,7 +78,7 @@ enum Registers {
     LpfpRes = 0x33,
 }
 
-pub struct Lps22hb<'a, I: I2CDevice> {
+pub struct Lps22hb<'a, I: I2CDevice<'a>> {
     buffer: TakeCell<'static, [u8]>,
     i2c_bus: &'a I,
     pressure_client: OptionalCell<&'a dyn PressureClient>,
@@ -86,7 +86,7 @@ pub struct Lps22hb<'a, I: I2CDevice> {
     state: Cell<State>,
 }
 
-impl<'a, I: I2CDevice> Lps22hb<'a, I> {
+impl<'a, I: I2CDevice<'a>> Lps22hb<'a, I> {
     pub fn new(i2c_bus: &'a I, buffer: &'static mut [u8]) -> Lps22hb<'a, I> {
         Lps22hb {
             buffer: TakeCell::new(buffer),
@@ -131,7 +131,7 @@ impl<'a, I: I2CDevice> Lps22hb<'a, I> {
     }
 }
 
-impl<'a, I: I2CDevice> PressureDriver<'a> for Lps22hb<'a, I> {
+impl<'a, I: I2CDevice<'a>> PressureDriver<'a> for Lps22hb<'a, I> {
     fn set_client(&self, client: &'a dyn PressureClient) {
         self.pressure_client.set(client);
     }
@@ -158,7 +158,7 @@ pub enum State {
     GotMeasurement,
 }
 
-impl<I: I2CDevice> I2CClient for Lps22hb<'_, I> {
+impl<'a, I: I2CDevice<'a>> I2CClient for Lps22hb<'a, I> {
     fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
         if let Err(i2c_err) = status {
             self.state.set(State::Idle);

--- a/capsules/extra/src/lps25hb.rs
+++ b/capsules/extra/src/lps25hb.rs
@@ -103,7 +103,7 @@ enum State {
 #[derive(Default)]
 pub struct App {}
 
-pub struct LPS25HB<'a, I: i2c::I2CDevice> {
+pub struct LPS25HB<'a, I: i2c::I2CDevice<'a>> {
     i2c: &'a I,
     interrupt_pin: &'a dyn gpio::InterruptPin<'a>,
     state: Cell<State>,
@@ -112,7 +112,7 @@ pub struct LPS25HB<'a, I: i2c::I2CDevice> {
     owning_process: OptionalCell<ProcessId>,
 }
 
-impl<'a, I: i2c::I2CDevice> LPS25HB<'a, I> {
+impl<'a, I: i2c::I2CDevice<'a>> LPS25HB<'a, I> {
     pub fn new(
         i2c: &'a I,
         interrupt_pin: &'a dyn gpio::InterruptPin<'a>,
@@ -175,7 +175,7 @@ impl<'a, I: i2c::I2CDevice> LPS25HB<'a, I> {
     }
 }
 
-impl<I: i2c::I2CDevice> i2c::I2CClient for LPS25HB<'_, I> {
+impl<'a, I: i2c::I2CDevice<'a>> i2c::I2CClient for LPS25HB<'a, I> {
     fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
         if status != Ok(()) {
             self.state.set(State::Idle);
@@ -302,7 +302,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for LPS25HB<'_, I> {
     }
 }
 
-impl<I: i2c::I2CDevice> gpio::Client for LPS25HB<'_, I> {
+impl<'a, I: i2c::I2CDevice<'a>> gpio::Client for LPS25HB<'a, I> {
     fn fired(&self) {
         self.buffer.take().map(|buf| {
             // turn on i2c to send commands
@@ -321,7 +321,7 @@ impl<I: i2c::I2CDevice> gpio::Client for LPS25HB<'_, I> {
     }
 }
 
-impl<I: i2c::I2CDevice> SyscallDriver for LPS25HB<'_, I> {
+impl<'a, I: i2c::I2CDevice<'a>> SyscallDriver for LPS25HB<'a, I> {
     fn command(
         &self,
         command_num: usize,

--- a/capsules/extra/src/lsm303agr.rs
+++ b/capsules/extra/src/lsm303agr.rs
@@ -144,7 +144,7 @@ enum State {
 #[derive(Default)]
 pub struct App {}
 
-pub struct Lsm303agrI2C<'a, I: i2c::I2CDevice> {
+pub struct Lsm303agrI2C<'a, I: i2c::I2CDevice<'a>> {
     config_in_progress: Cell<bool>,
     i2c_accelerometer: &'a I,
     i2c_magnetometer: &'a I,
@@ -163,7 +163,7 @@ pub struct Lsm303agrI2C<'a, I: i2c::I2CDevice> {
     owning_process: OptionalCell<ProcessId>,
 }
 
-impl<'a, I: i2c::I2CDevice> Lsm303agrI2C<'a, I> {
+impl<'a, I: i2c::I2CDevice<'a>> Lsm303agrI2C<'a, I> {
     pub fn new(
         i2c_accelerometer: &'a I,
         i2c_magnetometer: &'a I,
@@ -405,7 +405,7 @@ impl<'a, I: i2c::I2CDevice> Lsm303agrI2C<'a, I> {
     }
 }
 
-impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303agrI2C<'_, I> {
+impl<'a, I: i2c::I2CDevice<'a>> i2c::I2CClient for Lsm303agrI2C<'a, I> {
     fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
         match self.state.get() {
             State::IsPresent => {
@@ -602,7 +602,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303agrI2C<'_, I> {
     }
 }
 
-impl<I: i2c::I2CDevice> SyscallDriver for Lsm303agrI2C<'_, I> {
+impl<'a, I: i2c::I2CDevice<'a>> SyscallDriver for Lsm303agrI2C<'a, I> {
     fn command(
         &self,
         command_num: usize,
@@ -709,7 +709,7 @@ impl<I: i2c::I2CDevice> SyscallDriver for Lsm303agrI2C<'_, I> {
     }
 }
 
-impl<'a, I: i2c::I2CDevice> sensors::NineDof<'a> for Lsm303agrI2C<'a, I> {
+impl<'a, I: i2c::I2CDevice<'a>> sensors::NineDof<'a> for Lsm303agrI2C<'a, I> {
     fn set_client(&self, nine_dof_client: &'a dyn sensors::NineDofClient) {
         self.nine_dof_client.replace(nine_dof_client);
     }
@@ -723,7 +723,7 @@ impl<'a, I: i2c::I2CDevice> sensors::NineDof<'a> for Lsm303agrI2C<'a, I> {
     }
 }
 
-impl<'a, I: i2c::I2CDevice> sensors::TemperatureDriver<'a> for Lsm303agrI2C<'a, I> {
+impl<'a, I: i2c::I2CDevice<'a>> sensors::TemperatureDriver<'a> for Lsm303agrI2C<'a, I> {
     fn set_client(&self, temperature_client: &'a dyn sensors::TemperatureClient) {
         self.temperature_client.replace(temperature_client);
     }

--- a/capsules/extra/src/lsm303dlhc.rs
+++ b/capsules/extra/src/lsm303dlhc.rs
@@ -138,7 +138,7 @@ enum State {
     ReadMagnetometerXYZ,
 }
 
-pub struct Lsm303dlhcI2C<'a, I: i2c::I2CDevice> {
+pub struct Lsm303dlhcI2C<'a, I: i2c::I2CDevice<'a>> {
     config_in_progress: Cell<bool>,
     i2c_accelerometer: &'a I,
     i2c_magnetometer: &'a I,
@@ -160,7 +160,7 @@ pub struct Lsm303dlhcI2C<'a, I: i2c::I2CDevice> {
 #[derive(Default)]
 pub struct App {}
 
-impl<'a, I: i2c::I2CDevice> Lsm303dlhcI2C<'a, I> {
+impl<'a, I: i2c::I2CDevice<'a>> Lsm303dlhcI2C<'a, I> {
     pub fn new(
         i2c_accelerometer: &'a I,
         i2c_magnetometer: &'a I,
@@ -398,7 +398,7 @@ impl<'a, I: i2c::I2CDevice> Lsm303dlhcI2C<'a, I> {
     }
 }
 
-impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303dlhcI2C<'_, I> {
+impl<'a, I: i2c::I2CDevice<'a>> i2c::I2CClient for Lsm303dlhcI2C<'a, I> {
     fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
         match self.state.get() {
             State::IsPresent => {
@@ -617,7 +617,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm303dlhcI2C<'_, I> {
     }
 }
 
-impl<I: i2c::I2CDevice> SyscallDriver for Lsm303dlhcI2C<'_, I> {
+impl<'a, I: i2c::I2CDevice<'a>> SyscallDriver for Lsm303dlhcI2C<'a, I> {
     fn command(
         &self,
         command_num: usize,
@@ -727,7 +727,7 @@ impl<I: i2c::I2CDevice> SyscallDriver for Lsm303dlhcI2C<'_, I> {
     }
 }
 
-impl<'a, I: i2c::I2CDevice> sensors::NineDof<'a> for Lsm303dlhcI2C<'a, I> {
+impl<'a, I: i2c::I2CDevice<'a>> sensors::NineDof<'a> for Lsm303dlhcI2C<'a, I> {
     fn set_client(&self, nine_dof_client: &'a dyn sensors::NineDofClient) {
         self.nine_dof_client.replace(nine_dof_client);
     }
@@ -741,7 +741,7 @@ impl<'a, I: i2c::I2CDevice> sensors::NineDof<'a> for Lsm303dlhcI2C<'a, I> {
     }
 }
 
-impl<'a, I: i2c::I2CDevice> sensors::TemperatureDriver<'a> for Lsm303dlhcI2C<'a, I> {
+impl<'a, I: i2c::I2CDevice<'a>> sensors::TemperatureDriver<'a> for Lsm303dlhcI2C<'a, I> {
     fn set_client(&self, temperature_client: &'a dyn sensors::TemperatureClient) {
         self.temperature_client.replace(temperature_client);
     }

--- a/capsules/extra/src/lsm6dsoxtr.rs
+++ b/capsules/extra/src/lsm6dsoxtr.rs
@@ -169,7 +169,7 @@ enum State {
 #[derive(Default)]
 pub struct App {}
 
-pub struct Lsm6dsoxtrI2C<'a, I: i2c::I2CDevice> {
+pub struct Lsm6dsoxtrI2C<'a, I: i2c::I2CDevice<'a>> {
     i2c: &'a I,
     state: Cell<State>,
     config_in_progress: Cell<bool>,
@@ -187,7 +187,7 @@ pub struct Lsm6dsoxtrI2C<'a, I: i2c::I2CDevice> {
     syscall_process: OptionalCell<ProcessId>,
 }
 
-impl<'a, I: i2c::I2CDevice> Lsm6dsoxtrI2C<'a, I> {
+impl<'a, I: i2c::I2CDevice<'a>> Lsm6dsoxtrI2C<'a, I> {
     pub fn new(
         i2c: &'a I,
         buffer: &'static mut [u8],
@@ -380,7 +380,7 @@ impl<'a, I: i2c::I2CDevice> Lsm6dsoxtrI2C<'a, I> {
     }
 }
 
-impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm6dsoxtrI2C<'_, I> {
+impl<'a, I: i2c::I2CDevice<'a>> i2c::I2CClient for Lsm6dsoxtrI2C<'a, I> {
     fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
         match self.state.get() {
             State::IsPresent => {
@@ -542,7 +542,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for Lsm6dsoxtrI2C<'_, I> {
     }
 }
 
-impl<I: i2c::I2CDevice> SyscallDriver for Lsm6dsoxtrI2C<'_, I> {
+impl<'a, I: i2c::I2CDevice<'a>> SyscallDriver for Lsm6dsoxtrI2C<'a, I> {
     fn command(
         &self,
         command_num: usize,
@@ -616,7 +616,7 @@ impl<I: i2c::I2CDevice> SyscallDriver for Lsm6dsoxtrI2C<'_, I> {
     }
 }
 
-impl<'a, I: i2c::I2CDevice> NineDof<'a> for Lsm6dsoxtrI2C<'a, I> {
+impl<'a, I: i2c::I2CDevice<'a>> NineDof<'a> for Lsm6dsoxtrI2C<'a, I> {
     fn set_client(&self, nine_dof_client: &'a dyn NineDofClient) {
         self.nine_dof_client.replace(nine_dof_client);
     }
@@ -630,7 +630,7 @@ impl<'a, I: i2c::I2CDevice> NineDof<'a> for Lsm6dsoxtrI2C<'a, I> {
     }
 }
 
-impl<'a, I: i2c::I2CDevice> sensors::TemperatureDriver<'a> for Lsm6dsoxtrI2C<'a, I> {
+impl<'a, I: i2c::I2CDevice<'a>> sensors::TemperatureDriver<'a> for Lsm6dsoxtrI2C<'a, I> {
     fn set_client(&self, temperature_client: &'a dyn sensors::TemperatureClient) {
         self.temperature_client.replace(temperature_client);
     }

--- a/capsules/extra/src/ltc294x.rs
+++ b/capsules/extra/src/ltc294x.rs
@@ -139,7 +139,7 @@ pub trait LTC294XClient {
 }
 
 /// Implementation of a driver for the LTC294X coulomb counters.
-pub struct LTC294X<'a, I: i2c::I2CDevice> {
+pub struct LTC294X<'a, I: i2c::I2CDevice<'a>> {
     i2c: &'a I,
     interrupt_pin: Option<&'a dyn gpio::InterruptPin<'a>>,
     model: Cell<ChipModel>,
@@ -148,7 +148,7 @@ pub struct LTC294X<'a, I: i2c::I2CDevice> {
     client: OptionalCell<&'static dyn LTC294XClient>,
 }
 
-impl<'a, I: i2c::I2CDevice> LTC294X<'a, I> {
+impl<'a, I: i2c::I2CDevice<'a>> LTC294X<'a, I> {
     pub fn new(
         i2c: &'a I,
         interrupt_pin: Option<&'a dyn gpio::InterruptPin<'a>>,
@@ -341,7 +341,7 @@ impl<'a, I: i2c::I2CDevice> LTC294X<'a, I> {
     }
 }
 
-impl<I: i2c::I2CDevice> i2c::I2CClient for LTC294X<'_, I> {
+impl<'a, I: i2c::I2CDevice<'a>> i2c::I2CClient for LTC294X<'a, I> {
     fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), i2c::Error>) {
         match self.state.get() {
             State::ReadStatus => {
@@ -415,7 +415,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for LTC294X<'_, I> {
     }
 }
 
-impl<I: i2c::I2CDevice> gpio::Client for LTC294X<'_, I> {
+impl<'a, I: i2c::I2CDevice<'a>> gpio::Client for LTC294X<'a, I> {
     fn fired(&self) {
         self.client.map(|client| {
             client.interrupt();
@@ -441,13 +441,13 @@ mod upcall {
 
 /// Default implementation of the LTC2941 driver that provides a Driver
 /// interface for providing access to applications.
-pub struct LTC294XDriver<'a, I: i2c::I2CDevice> {
+pub struct LTC294XDriver<'a, I: i2c::I2CDevice<'a>> {
     ltc294x: &'a LTC294X<'a, I>,
     grants: Grant<App, UpcallCount<{ upcall::COUNT }>, AllowRoCount<0>, AllowRwCount<0>>,
     owning_process: OptionalCell<ProcessId>,
 }
 
-impl<'a, I: i2c::I2CDevice> LTC294XDriver<'a, I> {
+impl<'a, I: i2c::I2CDevice<'a>> LTC294XDriver<'a, I> {
     pub fn new(
         ltc: &'a LTC294X<'a, I>,
         grants: Grant<App, UpcallCount<{ upcall::COUNT }>, AllowRoCount<0>, AllowRwCount<0>>,
@@ -460,7 +460,7 @@ impl<'a, I: i2c::I2CDevice> LTC294XDriver<'a, I> {
     }
 }
 
-impl<I: i2c::I2CDevice> LTC294XClient for LTC294XDriver<'_, I> {
+impl<'a, I: i2c::I2CDevice<'a>> LTC294XClient for LTC294XDriver<'a, I> {
     fn interrupt(&self) {
         self.owning_process.map(|pid| {
             let _res = self.grants.enter(pid, |_app, upcalls| {
@@ -525,7 +525,7 @@ impl<I: i2c::I2CDevice> LTC294XClient for LTC294XDriver<'_, I> {
     }
 }
 
-impl<I: i2c::I2CDevice> SyscallDriver for LTC294XDriver<'_, I> {
+impl<'a, I: i2c::I2CDevice<'a>> SyscallDriver for LTC294XDriver<'a, I> {
     /// Request operations for the LTC294X chip.
     ///
     /// ### `command_num`

--- a/capsules/extra/src/max17205.rs
+++ b/capsules/extra/src/max17205.rs
@@ -110,7 +110,7 @@ pub trait MAX17205Client {
     fn romid(&self, rid: u64, error: Result<(), ErrorCode>);
 }
 
-pub struct MAX17205<'a, I: i2c::I2CDevice> {
+pub struct MAX17205<'a, I: i2c::I2CDevice<'a>> {
     i2c_lower: &'a I,
     i2c_upper: &'a I,
     state: Cell<State>,
@@ -121,7 +121,7 @@ pub struct MAX17205<'a, I: i2c::I2CDevice> {
     client: OptionalCell<&'static dyn MAX17205Client>,
 }
 
-impl<'a, I: i2c::I2CDevice> MAX17205<'a, I> {
+impl<'a, I: i2c::I2CDevice<'a>> MAX17205<'a, I> {
     pub fn new(i2c_lower: &'a I, i2c_upper: &'a I, buffer: &'static mut [u8]) -> MAX17205<'a, I> {
         MAX17205 {
             i2c_lower,
@@ -214,7 +214,7 @@ impl<'a, I: i2c::I2CDevice> MAX17205<'a, I> {
     }
 }
 
-impl<I: i2c::I2CDevice> i2c::I2CClient for MAX17205<'_, I> {
+impl<'a, I: i2c::I2CDevice<'a>> i2c::I2CClient for MAX17205<'a, I> {
     fn command_complete(&self, buffer: &'static mut [u8], error: Result<(), i2c::Error>) {
         match self.state.get() {
             State::SetupReadStatus => {
@@ -405,15 +405,15 @@ mod upcall {
 #[derive(Default)]
 pub struct App {}
 
-pub struct MAX17205Driver<'a, I: i2c::I2CDevice> {
+pub struct MAX17205Driver<'a, I: i2c::I2CDevice<'a>> {
     max17205: &'a MAX17205<'a, I>,
     owning_process: OptionalCell<ProcessId>,
     apps: Grant<App, UpcallCount<{ upcall::COUNT }>, AllowRoCount<0>, AllowRwCount<0>>,
 }
 
-impl<'a, I: i2c::I2CDevice> MAX17205Driver<'a, I> {
+impl<'a, I: i2c::I2CDevice<'a>> MAX17205Driver<'a, I> {
     pub fn new(
-        max: &'a MAX17205<I>,
+        max: &'a MAX17205<'a, I>,
         grant: Grant<App, UpcallCount<{ upcall::COUNT }>, AllowRoCount<0>, AllowRwCount<0>>,
     ) -> Self {
         Self {
@@ -424,7 +424,7 @@ impl<'a, I: i2c::I2CDevice> MAX17205Driver<'a, I> {
     }
 }
 
-impl<I: i2c::I2CDevice> MAX17205Client for MAX17205Driver<'_, I> {
+impl<'a, I: i2c::I2CDevice<'a>> MAX17205Client for MAX17205Driver<'a, I> {
     fn status(&self, status: u16, error: Result<(), ErrorCode>) {
         self.owning_process.map(|pid| {
             let _ = self.apps.enter(pid, |_app, upcalls| {
@@ -507,7 +507,7 @@ impl<I: i2c::I2CDevice> MAX17205Client for MAX17205Driver<'_, I> {
     }
 }
 
-impl<I: i2c::I2CDevice> SyscallDriver for MAX17205Driver<'_, I> {
+impl<'a, I: i2c::I2CDevice<'a>> SyscallDriver for MAX17205Driver<'a, I> {
     /// Setup and read the MAX17205.
     ///
     /// ### `command_num`

--- a/capsules/extra/src/mcp230xx.rs
+++ b/capsules/extra/src/mcp230xx.rs
@@ -133,7 +133,7 @@ enum PinState {
     Low = 0x00,
 }
 
-pub struct MCP230xx<'a, I: hil::i2c::I2CDevice> {
+pub struct MCP230xx<'a, I: hil::i2c::I2CDevice<'a>> {
     i2c: &'a I,
     state: Cell<State>,
     bank_size: u8,       // How many GPIO pins per bank (likely 8)
@@ -146,7 +146,7 @@ pub struct MCP230xx<'a, I: hil::i2c::I2CDevice> {
     client: OptionalCell<&'static dyn gpio_async::Client>,
 }
 
-impl<'a, I: hil::i2c::I2CDevice> MCP230xx<'a, I> {
+impl<'a, I: hil::i2c::I2CDevice<'a>> MCP230xx<'a, I> {
     pub fn new(
         i2c: &'a I,
         interrupt_pin_a: Option<&'a dyn gpio::InterruptValuePin<'a>>,
@@ -394,7 +394,7 @@ impl<'a, I: hil::i2c::I2CDevice> MCP230xx<'a, I> {
     }
 }
 
-impl<I: hil::i2c::I2CDevice> hil::i2c::I2CClient for MCP230xx<'_, I> {
+impl<'a, I: hil::i2c::I2CDevice<'a>> hil::i2c::I2CClient for MCP230xx<'a, I> {
     fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), hil::i2c::Error>) {
         match self.state.get() {
             State::SelectIoDir(pin_number, direction) => {
@@ -556,7 +556,7 @@ impl<I: hil::i2c::I2CDevice> hil::i2c::I2CClient for MCP230xx<'_, I> {
     }
 }
 
-impl<I: hil::i2c::I2CDevice> gpio::ClientWithValue for MCP230xx<'_, I> {
+impl<'a, I: hil::i2c::I2CDevice<'a>> gpio::ClientWithValue for MCP230xx<'a, I> {
     fn fired(&self, value: u32) {
         if value < 2 {
             return; // Error, value specifies which pin A=0, B=1
@@ -576,7 +576,7 @@ impl<I: hil::i2c::I2CDevice> gpio::ClientWithValue for MCP230xx<'_, I> {
     }
 }
 
-impl<I: hil::i2c::I2CDevice> gpio_async::Port for MCP230xx<'_, I> {
+impl<'a, I: hil::i2c::I2CDevice<'a>> gpio_async::Port for MCP230xx<'a, I> {
     fn disable(&self, pin: usize) -> Result<(), ErrorCode> {
         // Best we can do is make this an input.
         self.set_direction(pin as u8, Direction::Input)

--- a/capsules/extra/src/mlx90614.rs
+++ b/capsules/extra/src/mlx90614.rs
@@ -68,7 +68,7 @@ enum_from_primitive! {
 #[derive(Default)]
 pub struct App {}
 
-pub struct Mlx90614SMBus<'a, S: i2c::SMBusDevice> {
+pub struct Mlx90614SMBus<'a, S: i2c::SMBusDevice<'a>> {
     smbus_temp: &'a S,
     temperature_client: OptionalCell<&'a dyn sensors::TemperatureClient>,
     buffer: TakeCell<'static, [u8]>,
@@ -77,7 +77,7 @@ pub struct Mlx90614SMBus<'a, S: i2c::SMBusDevice> {
     owning_process: OptionalCell<ProcessId>,
 }
 
-impl<'a, S: i2c::SMBusDevice> Mlx90614SMBus<'a, S> {
+impl<'a, S: i2c::SMBusDevice<'a>> Mlx90614SMBus<'a, S> {
     pub fn new(
         smbus_temp: &'a S,
         buffer: &'static mut [u8],
@@ -119,7 +119,7 @@ impl<'a, S: i2c::SMBusDevice> Mlx90614SMBus<'a, S> {
     }
 }
 
-impl<S: i2c::SMBusDevice> i2c::I2CClient for Mlx90614SMBus<'_, S> {
+impl<'a, S: i2c::SMBusDevice<'a>> i2c::I2CClient for Mlx90614SMBus<'a, S> {
     fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
         match self.state.get() {
             State::Idle => {
@@ -168,7 +168,7 @@ impl<S: i2c::SMBusDevice> i2c::I2CClient for Mlx90614SMBus<'_, S> {
     }
 }
 
-impl<S: i2c::SMBusDevice> SyscallDriver for Mlx90614SMBus<'_, S> {
+impl<'a, S: i2c::SMBusDevice<'a>> SyscallDriver for Mlx90614SMBus<'a, S> {
     fn command(
         &self,
         command_num: usize,
@@ -233,7 +233,7 @@ impl<S: i2c::SMBusDevice> SyscallDriver for Mlx90614SMBus<'_, S> {
     }
 }
 
-impl<'a, S: i2c::SMBusDevice> sensors::TemperatureDriver<'a> for Mlx90614SMBus<'a, S> {
+impl<'a, S: i2c::SMBusDevice<'a>> sensors::TemperatureDriver<'a> for Mlx90614SMBus<'a, S> {
     fn set_client(&self, temperature_client: &'a dyn sensors::TemperatureClient) {
         self.temperature_client.replace(temperature_client);
     }

--- a/capsules/extra/src/pca9544a.rs
+++ b/capsules/extra/src/pca9544a.rs
@@ -76,7 +76,7 @@ mod upcall {
 #[derive(Default)]
 pub struct App {}
 
-pub struct PCA9544A<'a, I: i2c::I2CDevice> {
+pub struct PCA9544A<'a, I: i2c::I2CDevice<'a>> {
     i2c: &'a I,
     state: Cell<State>,
     buffer: TakeCell<'static, [u8]>,
@@ -84,7 +84,7 @@ pub struct PCA9544A<'a, I: i2c::I2CDevice> {
     owning_process: OptionalCell<ProcessId>,
 }
 
-impl<'a, I: i2c::I2CDevice> PCA9544A<'a, I> {
+impl<'a, I: i2c::I2CDevice<'a>> PCA9544A<'a, I> {
     pub fn new(
         i2c: &'a I,
         buffer: &'static mut [u8],
@@ -153,7 +153,7 @@ impl<'a, I: i2c::I2CDevice> PCA9544A<'a, I> {
     }
 }
 
-impl<I: i2c::I2CDevice> i2c::I2CClient for PCA9544A<'_, I> {
+impl<'a, I: i2c::I2CDevice<'a>> i2c::I2CClient for PCA9544A<'a, I> {
     fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), i2c::Error>) {
         match self.state.get() {
             State::ReadControl(field) => {
@@ -191,7 +191,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for PCA9544A<'_, I> {
     }
 }
 
-impl<I: i2c::I2CDevice> SyscallDriver for PCA9544A<'_, I> {
+impl<'a, I: i2c::I2CDevice<'a>> SyscallDriver for PCA9544A<'a, I> {
     /// Control the I2C selector.
     ///
     /// ### `command_num`

--- a/capsules/extra/src/sh1106.rs
+++ b/capsules/extra/src/sh1106.rs
@@ -35,7 +35,7 @@ enum State {
     WritePage(u8),
 }
 
-pub struct Sh1106<'a, I: hil::i2c::I2CDevice> {
+pub struct Sh1106<'a, I: hil::i2c::I2CDevice<'a>> {
     i2c: &'a I,
     state: Cell<State>,
     client: OptionalCell<&'a dyn hil::screen::ScreenClient>,
@@ -50,7 +50,7 @@ pub struct Sh1106<'a, I: hil::i2c::I2CDevice> {
     active_frame_height: Cell<u8>,
 }
 
-impl<'a, I: hil::i2c::I2CDevice> Sh1106<'a, I> {
+impl<'a, I: hil::i2c::I2CDevice<'a>> Sh1106<'a, I> {
     pub fn new(i2c: &'a I, buffer: &'static mut [u8], enable_charge_pump: bool) -> Self {
         Self {
             i2c,
@@ -231,7 +231,7 @@ impl<'a, I: hil::i2c::I2CDevice> Sh1106<'a, I> {
     }
 }
 
-impl<'a, I: hil::i2c::I2CDevice> hil::screen::ScreenSetup<'a> for Sh1106<'a, I> {
+impl<'a, I: hil::i2c::I2CDevice<'a>> hil::screen::ScreenSetup<'a> for Sh1106<'a, I> {
     fn set_client(&self, client: &'a dyn hil::screen::ScreenSetupClient) {
         self.setup_client.set(client);
     }
@@ -271,7 +271,7 @@ impl<'a, I: hil::i2c::I2CDevice> hil::screen::ScreenSetup<'a> for Sh1106<'a, I> 
     }
 }
 
-impl<'a, I: hil::i2c::I2CDevice> hil::screen::Screen<'a> for Sh1106<'a, I> {
+impl<'a, I: hil::i2c::I2CDevice<'a>> hil::screen::Screen<'a> for Sh1106<'a, I> {
     fn set_client(&self, client: &'a dyn hil::screen::ScreenClient) {
         self.client.set(client);
     }
@@ -367,7 +367,7 @@ impl<'a, I: hil::i2c::I2CDevice> hil::screen::Screen<'a> for Sh1106<'a, I> {
     }
 }
 
-impl<I: hil::i2c::I2CDevice> hil::i2c::I2CClient for Sh1106<'_, I> {
+impl<'a, I: hil::i2c::I2CDevice<'a>> hil::i2c::I2CClient for Sh1106<'a, I> {
     fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), hil::i2c::Error>) {
         self.buffer.replace(buffer);
         self.i2c.disable();

--- a/capsules/extra/src/sht3x.rs
+++ b/capsules/extra/src/sht3x.rs
@@ -71,7 +71,7 @@ fn crc8(data: &[u8]) -> u8 {
     crc
 }
 
-pub struct SHT3x<'a, A: Alarm<'a>, I: i2c::I2CDevice> {
+pub struct SHT3x<'a, A: Alarm<'a>, I: i2c::I2CDevice<'a>> {
     i2c: &'a I,
     humidity_client: OptionalCell<&'a dyn kernel::hil::sensors::HumidityClient>,
     temperature_client: OptionalCell<&'a dyn kernel::hil::sensors::TemperatureClient>,
@@ -82,7 +82,7 @@ pub struct SHT3x<'a, A: Alarm<'a>, I: i2c::I2CDevice> {
     alarm: &'a A,
 }
 
-impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> SHT3x<'a, A, I> {
+impl<'a, A: Alarm<'a>, I: i2c::I2CDevice<'a>> SHT3x<'a, A, I> {
     pub fn new(i2c: &'a I, buffer: &'static mut [u8], alarm: &'a A) -> SHT3x<'a, A, I> {
         SHT3x {
             i2c,
@@ -143,7 +143,7 @@ impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> SHT3x<'a, A, I> {
     }
 }
 
-impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> time::AlarmClient for SHT3x<'a, A, I> {
+impl<'a, A: Alarm<'a>, I: i2c::I2CDevice<'a>> time::AlarmClient for SHT3x<'a, A, I> {
     fn alarm(&self) {
         let state = self.state.get();
         match state {
@@ -164,7 +164,7 @@ impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> time::AlarmClient for SHT3x<'a, A, I> 
     }
 }
 
-impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> i2c::I2CClient for SHT3x<'a, A, I> {
+impl<'a, A: Alarm<'a>, I: i2c::I2CDevice<'a>> i2c::I2CClient for SHT3x<'a, A, I> {
     fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
         match status {
             Ok(()) => {
@@ -225,7 +225,7 @@ impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> i2c::I2CClient for SHT3x<'a, A, I> {
     }
 }
 
-impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> kernel::hil::sensors::HumidityDriver<'a>
+impl<'a, A: Alarm<'a>, I: i2c::I2CDevice<'a>> kernel::hil::sensors::HumidityDriver<'a>
     for SHT3x<'a, A, I>
 {
     fn set_client(&self, client: &'a dyn kernel::hil::sensors::HumidityClient) {
@@ -237,7 +237,7 @@ impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> kernel::hil::sensors::HumidityDriver<'
     }
 }
 
-impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> kernel::hil::sensors::TemperatureDriver<'a>
+impl<'a, A: Alarm<'a>, I: i2c::I2CDevice<'a>> kernel::hil::sensors::TemperatureDriver<'a>
     for SHT3x<'a, A, I>
 {
     fn set_client(&self, client: &'a dyn kernel::hil::sensors::TemperatureClient) {

--- a/capsules/extra/src/sht4x.rs
+++ b/capsules/extra/src/sht4x.rs
@@ -66,7 +66,7 @@ fn crc8(data: &[u8]) -> u8 {
     crc
 }
 
-pub struct SHT4x<'a, A: Alarm<'a>, I: i2c::I2CDevice> {
+pub struct SHT4x<'a, A: Alarm<'a>, I: i2c::I2CDevice<'a>> {
     i2c: &'a I,
     humidity_client: OptionalCell<&'a dyn kernel::hil::sensors::HumidityClient>,
     temperature_client: OptionalCell<&'a dyn kernel::hil::sensors::TemperatureClient>,
@@ -77,7 +77,7 @@ pub struct SHT4x<'a, A: Alarm<'a>, I: i2c::I2CDevice> {
     alarm: &'a A,
 }
 
-impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> SHT4x<'a, A, I> {
+impl<'a, A: Alarm<'a>, I: i2c::I2CDevice<'a>> SHT4x<'a, A, I> {
     pub fn new(i2c: &'a I, buffer: &'static mut [u8], alarm: &'a A) -> SHT4x<'a, A, I> {
         SHT4x {
             i2c,
@@ -146,7 +146,7 @@ impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> SHT4x<'a, A, I> {
     }
 }
 
-impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> time::AlarmClient for SHT4x<'a, A, I> {
+impl<'a, A: Alarm<'a>, I: i2c::I2CDevice<'a>> time::AlarmClient for SHT4x<'a, A, I> {
     fn alarm(&self) {
         let state = self.state.get();
         match state {
@@ -164,7 +164,7 @@ impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> time::AlarmClient for SHT4x<'a, A, I> 
     }
 }
 
-impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> i2c::I2CClient for SHT4x<'a, A, I> {
+impl<'a, A: Alarm<'a>, I: i2c::I2CDevice<'a>> i2c::I2CClient for SHT4x<'a, A, I> {
     fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
         match status {
             Ok(()) => {
@@ -239,7 +239,7 @@ impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> i2c::I2CClient for SHT4x<'a, A, I> {
     }
 }
 
-impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> kernel::hil::sensors::HumidityDriver<'a>
+impl<'a, A: Alarm<'a>, I: i2c::I2CDevice<'a>> kernel::hil::sensors::HumidityDriver<'a>
     for SHT4x<'a, A, I>
 {
     fn set_client(&self, client: &'a dyn kernel::hil::sensors::HumidityClient) {
@@ -251,7 +251,7 @@ impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> kernel::hil::sensors::HumidityDriver<'
     }
 }
 
-impl<'a, A: Alarm<'a>, I: i2c::I2CDevice> kernel::hil::sensors::TemperatureDriver<'a>
+impl<'a, A: Alarm<'a>, I: i2c::I2CDevice<'a>> kernel::hil::sensors::TemperatureDriver<'a>
     for SHT4x<'a, A, I>
 {
     fn set_client(&self, client: &'a dyn kernel::hil::sensors::TemperatureClient) {

--- a/capsules/extra/src/si7021.rs
+++ b/capsules/extra/src/si7021.rs
@@ -97,7 +97,7 @@ enum OnDeck {
     Humidity,
 }
 
-pub struct SI7021<'a, A: time::Alarm<'a>, I: i2c::I2CDevice> {
+pub struct SI7021<'a, A: time::Alarm<'a>, I: i2c::I2CDevice<'a>> {
     i2c: &'a I,
     alarm: &'a A,
     temp_callback: OptionalCell<&'a dyn kernel::hil::sensors::TemperatureClient>,
@@ -107,7 +107,7 @@ pub struct SI7021<'a, A: time::Alarm<'a>, I: i2c::I2CDevice> {
     buffer: TakeCell<'static, [u8]>,
 }
 
-impl<'a, A: time::Alarm<'a>, I: i2c::I2CDevice> SI7021<'a, A, I> {
+impl<'a, A: time::Alarm<'a>, I: i2c::I2CDevice<'a>> SI7021<'a, A, I> {
     pub fn new(i2c: &'a I, alarm: &'a A, buffer: &'static mut [u8]) -> SI7021<'a, A, I> {
         // setup and return struct
         SI7021 {
@@ -150,7 +150,7 @@ impl<'a, A: time::Alarm<'a>, I: i2c::I2CDevice> SI7021<'a, A, I> {
     }
 }
 
-impl<'a, A: time::Alarm<'a>, I: i2c::I2CDevice> i2c::I2CClient for SI7021<'a, A, I> {
+impl<'a, A: time::Alarm<'a>, I: i2c::I2CDevice<'a>> i2c::I2CClient for SI7021<'a, A, I> {
     fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), i2c::Error>) {
         match self.state.get() {
             State::SelectElectronicId1 => {
@@ -244,7 +244,7 @@ impl<'a, A: time::Alarm<'a>, I: i2c::I2CDevice> i2c::I2CClient for SI7021<'a, A,
     }
 }
 
-impl<'a, A: time::Alarm<'a>, I: i2c::I2CDevice> kernel::hil::sensors::TemperatureDriver<'a>
+impl<'a, A: time::Alarm<'a>, I: i2c::I2CDevice<'a>> kernel::hil::sensors::TemperatureDriver<'a>
     for SI7021<'a, A, I>
 {
     fn read_temperature(&self) -> Result<(), ErrorCode> {
@@ -279,7 +279,7 @@ impl<'a, A: time::Alarm<'a>, I: i2c::I2CDevice> kernel::hil::sensors::Temperatur
     }
 }
 
-impl<'a, A: time::Alarm<'a>, I: i2c::I2CDevice> kernel::hil::sensors::HumidityDriver<'a>
+impl<'a, A: time::Alarm<'a>, I: i2c::I2CDevice<'a>> kernel::hil::sensors::HumidityDriver<'a>
     for SI7021<'a, A, I>
 {
     fn read_humidity(&self) -> Result<(), ErrorCode> {
@@ -315,7 +315,7 @@ impl<'a, A: time::Alarm<'a>, I: i2c::I2CDevice> kernel::hil::sensors::HumidityDr
     }
 }
 
-impl<'a, A: time::Alarm<'a>, I: i2c::I2CDevice> time::AlarmClient for SI7021<'a, A, I> {
+impl<'a, A: time::Alarm<'a>, I: i2c::I2CDevice<'a>> time::AlarmClient for SI7021<'a, A, I> {
     fn alarm(&self) {
         self.buffer.take().map(|buffer| {
             // turn on i2c to send commands

--- a/capsules/extra/src/ssd1306.rs
+++ b/capsules/extra/src/ssd1306.rs
@@ -281,7 +281,7 @@ enum State {
     Write,
 }
 
-pub struct Ssd1306<'a, I: hil::i2c::I2CDevice> {
+pub struct Ssd1306<'a, I: hil::i2c::I2CDevice<'a>> {
     i2c: &'a I,
     state: Cell<State>,
     client: OptionalCell<&'a dyn hil::screen::ScreenClient>,
@@ -291,7 +291,7 @@ pub struct Ssd1306<'a, I: hil::i2c::I2CDevice> {
     enable_charge_pump: bool,
 }
 
-impl<'a, I: hil::i2c::I2CDevice> Ssd1306<'a, I> {
+impl<'a, I: hil::i2c::I2CDevice<'a>> Ssd1306<'a, I> {
     pub fn new(i2c: &'a I, buffer: &'static mut [u8], enable_charge_pump: bool) -> Ssd1306<'a, I> {
         Ssd1306 {
             i2c,
@@ -383,7 +383,7 @@ impl<'a, I: hil::i2c::I2CDevice> Ssd1306<'a, I> {
     }
 }
 
-impl<'a, I: hil::i2c::I2CDevice> hil::screen::ScreenSetup<'a> for Ssd1306<'a, I> {
+impl<'a, I: hil::i2c::I2CDevice<'a>> hil::screen::ScreenSetup<'a> for Ssd1306<'a, I> {
     fn set_client(&self, client: &'a dyn hil::screen::ScreenSetupClient) {
         self.setup_client.set(client);
     }
@@ -423,7 +423,7 @@ impl<'a, I: hil::i2c::I2CDevice> hil::screen::ScreenSetup<'a> for Ssd1306<'a, I>
     }
 }
 
-impl<'a, I: hil::i2c::I2CDevice> hil::screen::Screen<'a> for Ssd1306<'a, I> {
+impl<'a, I: hil::i2c::I2CDevice<'a>> hil::screen::Screen<'a> for Ssd1306<'a, I> {
     fn set_client(&self, client: &'a dyn hil::screen::ScreenClient) {
         self.client.set(client);
     }
@@ -536,7 +536,7 @@ impl<'a, I: hil::i2c::I2CDevice> hil::screen::Screen<'a> for Ssd1306<'a, I> {
     }
 }
 
-impl<I: hil::i2c::I2CDevice> hil::i2c::I2CClient for Ssd1306<'_, I> {
+impl<'a, I: hil::i2c::I2CDevice<'a>> hil::i2c::I2CClient for Ssd1306<'a, I> {
     fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), hil::i2c::Error>) {
         self.buffer.replace(buffer);
         self.i2c.disable();

--- a/capsules/extra/src/tsl2561.rs
+++ b/capsules/extra/src/tsl2561.rs
@@ -211,7 +211,7 @@ enum State {
 #[derive(Default)]
 pub struct App {}
 
-pub struct TSL2561<'a, I: i2c::I2CDevice> {
+pub struct TSL2561<'a, I: i2c::I2CDevice<'a>> {
     i2c: &'a I,
     interrupt_pin: &'a dyn gpio::InterruptPin<'a>,
     state: Cell<State>,
@@ -220,7 +220,7 @@ pub struct TSL2561<'a, I: i2c::I2CDevice> {
     owning_process: OptionalCell<ProcessId>,
 }
 
-impl<'a, I: i2c::I2CDevice> TSL2561<'a, I> {
+impl<'a, I: i2c::I2CDevice<'a>> TSL2561<'a, I> {
     pub fn new(
         i2c: &'a I,
         interrupt_pin: &'a dyn gpio::InterruptPin<'a>,
@@ -359,7 +359,7 @@ impl<'a, I: i2c::I2CDevice> TSL2561<'a, I> {
     }
 }
 
-impl<I: i2c::I2CDevice> i2c::I2CClient for TSL2561<'_, I> {
+impl<'a, I: i2c::I2CDevice<'a>> i2c::I2CClient for TSL2561<'a, I> {
     fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), i2c::Error>) {
         match self.state.get() {
             State::SelectId => {
@@ -449,7 +449,7 @@ impl<I: i2c::I2CDevice> i2c::I2CClient for TSL2561<'_, I> {
     }
 }
 
-impl<I: i2c::I2CDevice> gpio::Client for TSL2561<'_, I> {
+impl<'a, I: i2c::I2CDevice<'a>> gpio::Client for TSL2561<'a, I> {
     fn fired(&self) {
         self.buffer.take().map(|buffer| {
             // turn on i2c to send commands
@@ -464,7 +464,7 @@ impl<I: i2c::I2CDevice> gpio::Client for TSL2561<'_, I> {
     }
 }
 
-impl<I: i2c::I2CDevice> SyscallDriver for TSL2561<'_, I> {
+impl<'a, I: i2c::I2CDevice<'a>> SyscallDriver for TSL2561<'a, I> {
     fn command(
         &self,
         command_num: usize,

--- a/kernel/src/hil/i2c.rs
+++ b/kernel/src/hil/i2c.rs
@@ -217,7 +217,7 @@ pub trait I2CHwSlaveClient {
 /// Higher-level interface for I2C Master commands that wraps in the I2C
 /// address. It gives an interface for communicating with a specific I2C
 /// device.
-pub trait I2CDevice {
+pub trait I2CDevice<'a> {
     fn enable(&self);
     fn disable(&self);
     fn write_read(
@@ -229,9 +229,12 @@ pub trait I2CDevice {
     fn write(&self, data: &'static mut [u8], len: usize) -> Result<(), (Error, &'static mut [u8])>;
     fn read(&self, buffer: &'static mut [u8], len: usize)
     -> Result<(), (Error, &'static mut [u8])>;
+
+    /// Set the client for the I2CDevice.
+    fn set_client(&self, client: &'a dyn I2CClient);
 }
 
-pub trait SMBusDevice: I2CDevice {
+pub trait SMBusDevice<'a>: I2CDevice<'a> {
     /// Write data then read data to a slave device in an SMBus
     /// compatible way.
     ///

--- a/kernel/src/hil/i2c.rs
+++ b/kernel/src/hil/i2c.rs
@@ -231,7 +231,7 @@ pub trait I2CDevice<'a> {
     -> Result<(), (Error, &'static mut [u8])>;
 
     /// Set the client for the I2CDevice.
-    fn set_client(&self, client: &'a dyn I2CClient);
+    fn set_client(&'a self, client: &'a dyn I2CClient);
 }
 
 pub trait SMBusDevice<'a>: I2CDevice<'a> {


### PR DESCRIPTION
### Pull Request Overview

This PR adds `set_client` to the `I2CDevice` HIL, and updates the code base to match. I'm not really sure why this wasn't already in the HIL. [It is supposed to be.](https://book.tockos.org/trd/trd3-hil-design#rule-12-traits-that-can-trigger-callbacks-should-have-a-set_client-method)

There isn't much that uses this, really just the i2c virtualizer. However, because of the callback lifetime, this ends up touching a bunch of files. Also we need the trait in scope in components to be able to use the API (instead of the pub function of the virtualizer that was there before).


- The `use kernel::hil::i2c::I2CDevice as _;` is needed, as without the `as _` rust complains about the trait not being in scope.
- The `&'a self` in `fn set_client(&'a self, client: &'a dyn I2CClient);` is needed to add the device to the mux list in the virtualizer.

### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

I added the set_client API to the HIL and fixed the virtualizer, but then had claude fix every other issue. It mostly just added lifetimes and the import in components.
