### PR TITLE
ci: qemu virt: install build-essential not gcc

### DIFF
--- a/.github/workflows/qemu_virt.yml
+++ b/.github/workflows/qemu_virt.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install -y curl git make gcc gcc-riscv64-unknown-elf qemu-system-riscv python3-pip pipx bash wget file unzip xvfb
+          apt-get install -y curl git make build-essential gcc-riscv64-unknown-elf qemu-system-riscv python3-pip pipx bash wget file unzip xvfb
 
       - name: Install Rust
         run: |


### PR DESCRIPTION


### Pull Request Overview

CI suddenly started failing to install elf2tab (no idea why it worked before and not now). I gave the error message to claude and it determined that just installing gcc is not enough to install an elf2tab dependency. It recommended `build-essential` which makes sense.

Here is the error in CI:

```
Run cargo install elf2tab
info: syncing channel updates for nightly-2026-07-21-x86_64-unknown-linux-gnu
info: latest update on 2026-07-21 for version 1.99.0-nightly (87e5904f5 2026-07-20)
info: downloading 17 components
warn: the missing active toolchain `nightly-2026-07-21-x86_64-unknown-linux-gnu` has been auto-installed
warn: this might cause rustup commands to take longer time to finish than expected
info: you may opt out with `RUSTUP_AUTO_INSTALL=0` or `rustup set auto-install disable`
    Updating crates.io index
 Downloading crates ...
  Downloaded elf2tab v0.13.0
  Installing elf2tab v0.13.0
warning: default toolchain implicitly overridden with `nightly-2026-07-21-x86_64-unknown-linux-gnu` by rustup toolchain file
  |
  = help: use `cargo +stable install` if you meant to use the stable toolchain
  = note: rustup selects the toolchain based on the parent environment and not the environment of the package being installed
    Updating crates.io index
     Locking 78 packages to latest compatible versions
      Adding elf v0.7.4 (available: v0.8.0)
      Adding generic-array v0.14.7 (available: v0.14.9)
      Adding ring v0.16.20 (available: v0.17.14)
      Adding sha2 v0.10.9 (available: v0.11.0)
 Downloading crates ...
  Downloaded anstream v1.0.0
  Downloaded anstyle-query v1.1.5
  Downloaded typenum v1.20.1
  Downloaded autocfg v1.5.1
  Downloaded anstyle v1.0.14
  Downloaded anstyle-parse v1.0.0
  Downloaded bitflags v2.13.1
  Downloaded elf v0.7.4
  Downloaded shlex v2.0.1
  Downloaded strsim v0.11.1
  Downloaded block-buffer v0.10.4
  Downloaded unicode-ident v1.0.24
  Downloaded quote v1.0.47
  Downloaded sha2 v0.10.9
  Downloaded untrusted v0.7.1
  Downloaded clap_lex v1.1.0
  Downloaded errno v0.3.14
  Downloaded generic-array v0.14.7
  Downloaded clap_builder v4.6.6
  Downloaded cpufeatures v0.2.17
  Downloaded heck v0.5.0
  Downloaded once_cell v1.21.4
  Downloaded find-msvc-tools v0.1.11
  Downloaded xattr v1.6.1
  Downloaded filetime v0.2.29
  Downloaded terminal_size v0.4.4
  Downloaded cfg-if v1.0.4
  Downloaded clap-num v1.2.0
  Downloaded clap_derive v4.6.4
  Downloaded colorchoice v1.0.5
  Downloaded crypto-common v0.1.7
  Downloaded proc-macro2 v1.0.107
  Downloaded spin v0.5.2
  Downloaded version_check v0.9.5
  Downloaded cc v1.4.4
  Downloaded clap v4.6.6
  Downloaded digest v0.10.7
  Downloaded iana-time-zone v0.1.65
  Downloaded is_terminal_polyfill v1.70.2
  Downloaded utf8parse v0.2.2
  Downloaded chrono v0.4.45
  Downloaded num-traits v0.2.19
  Downloaded tar v0.4.46
  Downloaded syn v3.0.4
  Downloaded rustix v1.1.4
  Downloaded libc v0.2.189
  Downloaded linux-raw-sys v0.12.1
  Downloaded ring v0.16.20
   Compiling rustix v1.1.4
   Compiling version_check v0.9.5
   Compiling bitflags v2.13.1
   Compiling linux-raw-sys v0.12.1
error: linking with `cc` failed: exit status: 1
  |
  = note:  "cc" "-m64" "/tmp/cargo-installQGHY3y/release/build/rustix-04fd4f19d82bfdbf/rustcjD16ZH/symbols.o" "<3 object files omitted>" "-Wl,--as-needed" "-Wl,-Bstatic" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib/{libstd-*,libpanic_unwind-*,libobject-*,libmemchr-*,libaddr2line-*,libgimli-*,libcfg_if-*,librustc_demangle-*,libstd_detect-*,libhashbrown-*,librustc_std_workspace_alloc-*,libminiz_oxide-*,libadler2-*,libunwind-*,liblibc-*,librustc_std_workspace_core-*,liballoc-*,libcore-*,libcompiler_builtins-*}.rlib" "-Wl,-Bdynamic" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-L" "/tmp/cargo-installQGHY3y/release/build/rustix-04fd4f19d82bfdbf/rustcjD16ZH/raw-dylibs" "-B<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/bin/gcc-ld" "-fuse-ld=lld" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-L" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-o" "/tmp/cargo-installQGHY3y/release/build/rustix-04fd4f19d82bfdbf/build_script_build-04fd4f19d82bfdbf" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-Wl,--strip-debug" "-nodefaultlibs"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: rust-lld: error: cannot open Scrt1.o: No such file or directory
          rust-lld: error: cannot open crti.o: No such file or directory
          rust-lld: error: unable to find library -lutil
          rust-lld: error: unable to find library -lrt
          rust-lld: error: unable to find library -lpthread
          rust-lld: error: unable to find library -lm
          rust-lld: error: unable to find library -ldl
          rust-lld: error: unable to find library -lc
          rust-lld: error: cannot open crtn.o: No such file or directory
          collect2: error: ld returned 1 exit status
          

error: could not compile `rustix` (build script) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: failed to compile `elf2tab v0.13.0`, intermediate artifacts can be found at `/tmp/cargo-installQGHY3y`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_BUILD_BUILD_DIR` to that path.
Error: Process completed with exit code 101.
```



### Testing Strategy

waiting for CI to run


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

I asked claude to diagnose the problem. I made the one word change myself, however!
