### PR TITLE
chips: rp2xxx, rp2350: share the pad control enums, add the RP2350 pad controls

### DIFF
--- a/chips/rp2040/src/gpio.rs
+++ b/chips/rp2040/src/gpio.rs
@@ -14,6 +14,7 @@ use kernel::utilities::StaticRef;
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{ReadOnly, ReadWrite, register_bitfields, register_structs};
+pub use rp2xxx::pads::{DriveStrength, SlewRate};
 
 use crate::chip::Processor;
 #[repr(C)]
@@ -394,24 +395,6 @@ enum_from_primitive! {
        USB = 9,
        NULL = 0x1f
     }
-}
-
-/// Slew rate of an output
-#[derive(Debug, Eq, PartialEq)]
-pub enum SlewRate {
-    /// Fast slew rate.
-    Fast = 1,
-    /// Slow slew rate.
-    Slow = 0,
-}
-
-/// Drive Strength of a GPIO Pin
-#[derive(Debug, Eq, PartialEq)]
-pub enum DriveStrength {
-    Drive2mA = 0,
-    Drive4ma = 1,
-    Drive8ma = 2,
-    Drive12ma = 3,
 }
 
 pub struct RPGpioPin<'a> {

--- a/chips/rp2350/src/gpio.rs
+++ b/chips/rp2350/src/gpio.rs
@@ -12,6 +12,7 @@ use kernel::utilities::registers::{
     interfaces::{ReadWriteable, Readable, Writeable},
     register_bitfields, register_structs,
 };
+pub use rp2xxx::pads::{DriveStrength, SlewRate};
 
 use crate::chip::Processor;
 #[repr(C)]
@@ -1337,6 +1338,22 @@ impl<'a> RPGpioPin<'a> {
 
     pub fn deactivate_pads(&self) {
         self.gpio_pad_registers.gpio_pad[self.pin].modify(GPIO_PAD::OD::SET + GPIO_PAD::IE::CLEAR);
+    }
+
+    /// Enable or disable the pad's Schmitt trigger on the input path.
+    pub fn set_schmitt(&self, enable: bool) {
+        self.gpio_pad_registers.gpio_pad[self.pin].modify(GPIO_PAD::SCHMITT.val(enable as u32));
+    }
+
+    /// Set how fast the pad drives an edge.
+    pub fn set_slew_rate(&self, slew_rate: SlewRate) {
+        self.gpio_pad_registers.gpio_pad[self.pin].modify(GPIO_PAD::SLEWFAST.val(slew_rate as u32));
+    }
+
+    /// Set how much current the pad can source or sink.
+    pub fn set_drive_strength(&self, drive_strength: DriveStrength) {
+        self.gpio_pad_registers.gpio_pad[self.pin]
+            .modify(GPIO_PAD::DRIVE.val(drive_strength as u32));
     }
 
     pub fn handle_interrupt(&self) {

--- a/chips/rp2xxx/src/lib.rs
+++ b/chips/rp2xxx/src/lib.rs
@@ -11,10 +11,13 @@
 //!
 //! Peripherals that only look alike are *not* here. `clocks`, `gpio` and `uart`
 //! each diverge by hundreds of lines between the two chips and stay in their
-//! own crates.
+//! own crates. `pads` is the exception within GPIO rather than a softening of
+//! that rule: the pad control register really is identical on both chips, so
+//! the two enums describing it are shared while everything around them is not.
 
 #![no_std]
 
+pub mod pads;
 pub mod spi;
 
 /// Access to the peripheral clock, `clk_peri`.

--- a/chips/rp2xxx/src/pads.rs
+++ b/chips/rp2xxx/src/pads.rs
@@ -1,0 +1,29 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+//! Pad configuration shared by the RP2040 and the RP2350.
+//!
+//! The two chips' GPIO blocks diverge and stay in their own crates, but the
+//! pad control register does not: `GPIO_PAD` places `DRIVE` at bits 5:4,
+//! `SCHMITT` at bit 1 and `SLEWFAST` at bit 0 on both, and encodes drive
+//! strength with the same four values. These two enums describe those fields,
+//! so a driver that has to tune a pad can be written once.
+
+/// Slew rate of an output
+#[derive(Debug, Eq, PartialEq)]
+pub enum SlewRate {
+    /// Slow slew rate.
+    Slow = 0,
+    /// Fast slew rate.
+    Fast = 1,
+}
+
+/// Drive Strength of a GPIO Pin
+#[derive(Debug, Eq, PartialEq)]
+pub enum DriveStrength {
+    Drive2mA = 0,
+    Drive4ma = 1,
+    Drive8ma = 2,
+    Drive12ma = 3,
+}


### PR DESCRIPTION
### What this does

Two commits, answering @ppannuto's question on #5126:

> The commit message notes, "The two enums are copied from
> chips/rp2040/src/gpio.rs exactly" -- should these enums just be in the shared
> rp2xxx and re-exported in 2040 and 2350 instead of copied?

They should, so this does that first and then adds the RP2350 methods on top.

**1. Share the pad control enums.** `chips/rp2xxx` gains `src/pads.rs` holding
`SlewRate` and `DriveStrength`, and `rp2040` re-exports them from where it
declared them. Unlike the rest of GPIO this is not a judgement call about two
things staying alike: `GPIO_PAD` places `DRIVE` at bits 5:4, `SCHMITT` at bit 1
and `SLEWFAST` at bit 0 on both chips, and encodes 2, 4, 8 and 12 mA as 0 to 3
on both. The enums describe those fields and nothing else.

The shared copy is the RP2040's with one change: `SlewRate` declared `Fast`
before `Slow`, which reads backwards when the discriminants are 1 and 0. Both
are explicit and used with `as u32`, so ordering them cannot change a caller.

`DriveStrength` keeps the RP2040's inconsistent spelling, `Drive2mA` with a
capital A and `Drive4ma`, `Drive8ma`, `Drive12ma` without. Correcting it would
touch `chips/rp2040/src/pio.rs`, the only caller of either enum, and that is
the file #5126 is moving code out of. Two open PRs should not both edit it.
Worth doing once #5126 lands.

**2. Add the pad controls `chips/rp2350/src/gpio.rs` lacks.** Three methods
whose bodies are the RP2040's character for character, against register fields
already declared at the right bits. Nothing calls them yet; they are what a PIO
gSPI driver needs to bring up a CYW43439 radio, which is how the RP2040 Pico W
board reaches its WiFi chip today.

This does not depend on #5126 and does not touch a file it touches.

### Testing Strategy

All five RP2040 and RP2350 boards are unchanged against master:

    board                  text   data     bss
    raspberry_pi_pico     98348      0   16528
    pico_explorer_base   102444      0   72668
    nano_rp2040_connect   94252      0   14368
    raspberry_pi_pico_w  352300      0   20724
    raspberry_pi_pico_2   69164      0   19100

Checked per section as well as by that summary, which sums `.text` and a
`.storage` region that is empty on these boards and `ALIGN(PAGE_SIZE)` at both
ends, so it pads to the next 4K boundary and can hide a change smaller than a
page. On `raspberry_pi_pico_w`, the only board calling either enum, `.text` is
349532 and `.storage` 2452 before and after.

`cargo clippy -- -D warnings` and `cargo fmt --check` are clean on `rp2040`,
`rp2350` and `rp2xxx`. The first commit was checked on its own as well, so the
split does not produce a broken intermediate.

I do not have an RP2040, and the three RP2350 methods have no callers here, so
none of this has run on hardware. The methods are character for character the
ones on my Pico 2 W branch, where the RP2350 PIO gSPI path calls all three and
reads the radio's MAC over gSPI on silicon. That run does not test this diff,
but the code in it is this code.

### My own review

I read the diff. I did not build it, and nothing here has been on hardware.

### AI disclosure

Per `CONTRIBUTING.md`: written with Claude Code (Claude Opus 5), including the
commit messages and this description. Every number above was measured rather
than recalled, by building each board against master and comparing.


Full context: 
https://via-balaena.github.io/tock-rp2350/
