### PR TITLE
kernel: memop: cap ptr needs to be restricted

### DIFF
--- a/kernel/src/memop.rs
+++ b/kernel/src/memop.rs
@@ -74,7 +74,7 @@ pub(crate) fn memop(process: &dyn Process, op_type: usize, r1: usize) -> Syscall
             CapabilityPtr::new_with_authority(
                 addresses.sram_end as *const _,
                 addresses.sram_start,
-                addresses.sram_end - addresses.sram_start,
+                addresses.sram_app_brk - addresses.sram_start,
                 CapabilityPtrPermissions::ReadWrite,
             )
         }),


### PR DESCRIPTION


### Pull Request Overview

In memop we create capability pointers to respond to memory address inquiries from processes. We need to ensure the authority we are expressing with those pointers matches what the process can actually access.

The process only has authority to read/write SRAM below its brk (from the start of its RAM region). Even though the pointer points beyond that, we must restrict the capability.

Note, this has no effect on our current platforms (the authority range is ignored in capability_ptr.rs). However, to document the unsafe requirements we need this change.

### Testing Strategy

Nothing


### TODO or Help Wanted

The corresponding documentation PR is coming, but I thought this change warrants its own scrutiny.


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [x] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [ ] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md#ai-policy) and have properly disclosed my AI use below. This PR comment, and any subsequent PR interactions must not be generated using AI, except for under a `<details>` drawer.

<!-- Include details of AI use here, if you used any -->
