### PR TITLE
kernel: debug: inner safety docs match function

### DIFF
--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -484,7 +484,8 @@ pub fn initialize_debug_gpio<P: ThreadIdProvider>() {
 /// Callers of this function must ensure that this function is never called
 /// concurrently with other calls to [`initialize_debug_gpio_unsafe`].
 pub unsafe fn initialize_debug_gpio_unsafe<P: ThreadIdProvider>() {
-    // SAFETY: See the function-level safety comment.
+    // SAFETY: The caller ensures there is no concurrent call to
+    // `DEBUG_GPIOS.bind_to_thread_unsafe()`.
     unsafe {
         DEBUG_GPIOS
             .bind_to_thread_unsafe::<P>(MapCell::empty())
@@ -592,7 +593,9 @@ pub fn initialize_debug_writer_wrapper<P: ThreadIdProvider>() {
 /// Callers of this function must ensure that this function is never called
 /// concurrently with other calls to [`initialize_debug_writer_wrapper_unsafe`].
 pub unsafe fn initialize_debug_writer_wrapper_unsafe<P: ThreadIdProvider>() {
-    // SAFETY: See the function-level safety comment.
+    // SAFETY: The caller ensures there is no concurrent call to
+    // `DEBUG_WRITER.bind_to_thread_unsafe()` and
+    // `DEBUG_WRITER_COUNT.bind_to_thread_unsafe()`.
     unsafe {
         DEBUG_WRITER
             .bind_to_thread_unsafe::<P>(MapCell::empty())

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -484,6 +484,7 @@ pub fn initialize_debug_gpio<P: ThreadIdProvider>() {
 /// Callers of this function must ensure that this function is never called
 /// concurrently with other calls to [`initialize_debug_gpio_unsafe`].
 pub unsafe fn initialize_debug_gpio_unsafe<P: ThreadIdProvider>() {
+    // SAFETY: See the function-level safety comment.
     unsafe {
         DEBUG_GPIOS
             .bind_to_thread_unsafe::<P>(MapCell::empty())
@@ -591,6 +592,7 @@ pub fn initialize_debug_writer_wrapper<P: ThreadIdProvider>() {
 /// Callers of this function must ensure that this function is never called
 /// concurrently with other calls to [`initialize_debug_writer_wrapper_unsafe`].
 pub unsafe fn initialize_debug_writer_wrapper_unsafe<P: ThreadIdProvider>() {
+    // SAFETY: See the function-level safety comment.
     unsafe {
         DEBUG_WRITER
             .bind_to_thread_unsafe::<P>(MapCell::empty())


### PR DESCRIPTION
### Pull Request Overview

Add safety docs to the remaining unsafe uses in kernel/src/debug.

These are just pass through safety comments stemming from single thread value.


### Testing Strategy

`cargo clippy -p kernel -- -A clippy::all -W clippy::undocumented_unsafe_blocks`


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md#ai-policy) and have properly disclosed my AI use below. This PR comment, and any subsequent PR interactions must not be generated using AI, except for under a `<details>` drawer.

<!-- Include details of AI use here, if you used any -->
