### PR TITLE
kernel: Reformat safety docs to match clippy's expectations

### DIFF
--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -1453,7 +1453,8 @@ impl<'a, T: Default, Upcalls: UpcallSize, AllowROs: AllowRoSize, AllowRWs: Allow
         };
 
         // Get references to all of the saved upcall data.
-        //
+        let (saved_upcalls_slice, saved_allow_ro_slice, saved_allow_rw_slice) =
+            layout.get_resource_slices();
         // SAFETY:
         // - Pointer is well aligned and initialized with data from Self::new()
         //   call.
@@ -1465,8 +1466,6 @@ impl<'a, T: Default, Upcalls: UpcallSize, AllowROs: AllowRoSize, AllowRWs: Allow
         //   Mutable reference to this memory are only created through the
         //   kernel in the syscall interface which is serialized in time with
         //   this call.
-        let (saved_upcalls_slice, saved_allow_ro_slice, saved_allow_rw_slice) =
-            layout.get_resource_slices();
         let grant_data = unsafe {
             EnteredGrantKernelManagedLayout::offset_of_grant_data_t(
                 grant_ptr,

--- a/kernel/src/utilities/arch_helpers.rs
+++ b/kernel/src/utilities/arch_helpers.rs
@@ -694,9 +694,7 @@ pub unsafe fn encode_upcall_trd64bit_ptr(
     a2: *mut u64,
     a3: *mut u64,
 ) {
-    // # Safety
-    //
-    // All safety invariants must be upheld by the function caller.
+    // SAFETY: All safety invariants must be upheld by the function caller.
     unsafe {
         // The TRD specifies that arguments 0, 1, and 2 are u32s. So, we cast to
         // u32 to ensure we are not using the upper bits, and then cast to u64


### PR DESCRIPTION
### Pull Request Overview

These are two instances in the kernel where we had safety docs but in the wrong place or format to match what clippy expects.


### Testing Strategy

`cargo clippy -p kernel -- -A clippy::all -W clippy::undocumented_unsafe_blocks`


### TODO or Help Wanted
n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md#ai-policy) and have properly disclosed my AI use below. This PR comment, and any subsequent PR interactions must not be generated using AI, except for under a `<details>` drawer.

<!-- Include details of AI use here, if you used any -->
