### PR TITLE
kernel: process binary: use safe API for slice

### DIFF
--- a/kernel/src/process_binary.rs
+++ b/kernel/src/process_binary.rs
@@ -254,8 +254,6 @@ impl ProcessBinary {
     }
 
     pub(crate) fn get_integrity_region_slice(&self) -> &'static [u8] {
-        unsafe {
-            core::slice::from_raw_parts(self.flash.as_ptr(), self.header.get_binary_end() as usize)
-        }
+        &self.flash[0..self.header.get_binary_end() as usize]
     }
 }


### PR DESCRIPTION
### Pull Request Overview

In the kernel, the process binary API for getting a slice over the integrity region uses an unsafe API. I'm not entirely sure why, but this converts it to use a safe API.


### Testing Strategy

`cargo clippy -p kernel -- -A clippy::all -W clippy::undocumented_unsafe_blocks`


### TODO or Help Wanted

I guess this technically adds a panic possibility, but, that is better than the status quo, and logically this function cannot fail.


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md#ai-policy) and have properly disclosed my AI use below. This PR comment, and any subsequent PR interactions must not be generated using AI, except for under a `<details>` drawer.

I asked claude for ideas on alternative APIs that do not require unsafe code.
