### PR TITLE
kernel: processbuffer: Attempt to add missing safety docs

### DIFF
--- a/kernel/src/processbuffer.rs
+++ b/kernel/src/processbuffer.rs
@@ -408,6 +408,9 @@ impl ReadOnlyProcessBuffer {
     }
 }
 
+// SAFETY: This implementation must be correct. The implementation of `ptr()`
+// ensures that a null pointer is returned if `len()` is 0, and a pointer to the
+// allowed buffer otherwise.
 unsafe impl ReadableProcessBuffer for ReadOnlyProcessBuffer {
     /// Return the length of the buffer in bytes.
     fn len(&self) -> usize {
@@ -619,6 +622,9 @@ impl ReadWriteProcessBuffer {
     }
 }
 
+// SAFETY: This implementation must be correct. The implementation of `ptr()`
+// ensures that a null pointer is returned if `len()` is 0, and a pointer to the
+// allowed buffer otherwise.
 unsafe impl ReadableProcessBuffer for ReadWriteProcessBuffer {
     /// Return the length of the buffer in bytes.
     fn len(&self) -> usize {
@@ -664,14 +670,17 @@ unsafe impl ReadableProcessBuffer for ReadWriteProcessBuffer {
                     // here. For more information, refer to the
                     // comment and subsequent discussion on tock/tock#2632:
                     // https://github.com/tock/tock/pull/2632#issuecomment-869974365
-                    Ok(fun(unsafe {
-                        raw_processbuf_to_roprocessslice(self.ptr, self.len)
-                    }))
+                    let ro_process_slice =
+                        unsafe { raw_processbuf_to_roprocessslice(self.ptr, self.len) };
+                    Ok(fun(ro_process_slice))
                 }),
         }
     }
 }
 
+// SAFETY: This implementation must be correct. We rely on the default
+// implementation and the correctness of the `ReadableProcessBuffer`
+// implementation.
 unsafe impl WriteableProcessBuffer for ReadWriteProcessBuffer {
     fn mut_enter<F, R>(&self, fun: F) -> Result<R, process::Error>
     where
@@ -698,9 +707,9 @@ unsafe impl WriteableProcessBuffer for ReadWriteProcessBuffer {
                     // here. For more information, refer to the
                     // comment and subsequent discussion on tock/tock#2632:
                     // https://github.com/tock/tock/pull/2632#issuecomment-869974365
-                    Ok(fun(unsafe {
-                        raw_processbuf_to_rwprocessslice(self.ptr, self.len)
-                    }))
+                    let rw_process_slice =
+                        unsafe { raw_processbuf_to_rwprocessslice(self.ptr, self.len) };
+                    Ok(fun(rw_process_slice))
                 }),
         }
     }
@@ -833,7 +842,7 @@ pub struct ReadableProcessSlice {
 }
 
 fn cast_byte_slice_to_process_slice(byte_slice: &[ReadableProcessByte]) -> &ReadableProcessSlice {
-    // As ReadableProcessSlice is a transparent wrapper around its inner type,
+    // SAFETY: As ReadableProcessSlice is a transparent wrapper around its inner type,
     // [ReadableProcessByte], we can safely transmute a reference to the inner
     // type as a reference to the outer type with the same lifetime.
     unsafe { core::mem::transmute::<&[ReadableProcessByte], &ReadableProcessSlice>(byte_slice) }


### PR DESCRIPTION
### Pull Request Overview

There are three unsafe trait implementations in processbuffer.rs in the kernel. I made an attempt to provide a safety doc. However, I admit I do not fully understand the subtleties. @lschuermann any guidance?

There were also a couple cases where the comment just needed to be formatted or moved to be compatible with clippy.


### Testing Strategy

`cargo clippy -p kernel -- -A clippy::all -W clippy::undocumented_unsafe_blocks`


### TODO or Help Wanted

Ideally Leon would review this to perhaps better explain how these implementations match the trait requirements.


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md#ai-policy) and have properly disclosed my AI use below. This PR comment, and any subsequent PR interactions must not be generated using AI, except for under a `<details>` drawer.

<!-- Include details of AI use here, if you used any -->
