### PR TITLE
kernel: dma_slice: add missing safety docs

### DIFF
--- a/kernel/src/utilities/dma_slice.rs
+++ b/kernel/src/utilities/dma_slice.rs
@@ -286,6 +286,9 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSliceMut<'a, T
         // made by DMA operations finished _before_ this function ran:
         fence.acquire::<T>(self.slice_ptr.as_ptr());
 
+        // SAFETY: This pointer must be convertible to a reference. We know that
+        // it is because the only constructor for `self.slice_ptr` started with
+        // a valid Rust reference.
         unsafe { self.slice_ptr.as_mut() }
     }
 }
@@ -619,6 +622,10 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMut<'a
         fence.acquire::<T>(ptr::slice_from_raw_parts_mut(self.as_mut_ptr(), self.len()));
 
         // Restore the original `SubSliceMut` configuration:
+        //
+        // SAFETY: The `internal_slice_ptr` pointer must be convertible to a
+        // reference. We know that it is because the only constructor for
+        // `self.internal_slice_ptr` started with a valid Rust reference.
         let mut sub_slice_mut = SubSliceMut::new(unsafe { self.internal_slice_ptr.as_mut() });
         sub_slice_mut.slice(self.active_range);
         sub_slice_mut
@@ -636,6 +643,10 @@ impl<'a, T: immutable_from_into_bytes::ImmutableFromIntoBytes> DmaSubSliceMut<'a
     /// were read-only).
     unsafe fn take_no_acquire(mut self) -> SubSliceMut<'a, T> {
         // Restore the original `SubSliceMut` configuration:
+        //
+        // SAFETY: The `internal_slice_ptr` pointer must be convertible to a
+        // reference. We know that it is because the only constructor for
+        // `self.internal_slice_ptr` started with a valid Rust reference.
         let mut sub_slice_mut = SubSliceMut::new(unsafe { self.internal_slice_ptr.as_mut() });
         sub_slice_mut.slice(self.active_range);
         sub_slice_mut
@@ -786,14 +797,24 @@ pub mod immutable_from_into_bytes {
     pub unsafe trait ImmutableFromIntoBytes: private::Sealed {}
 
     impl private::Sealed for u8 {}
+    // SAFETY: The primitive u8 type is always initialized, does not have
+    // interior mutability, and is always valid for any byte patterns.
     unsafe impl ImmutableFromIntoBytes for u8 {}
     impl private::Sealed for u16 {}
+    // SAFETY: The primitive u16 type is always initialized, does not have
+    // interior mutability, and is always valid for any byte patterns.
     unsafe impl ImmutableFromIntoBytes for u16 {}
     impl private::Sealed for u32 {}
+    // SAFETY: The primitive u32 type is always initialized, does not have
+    // interior mutability, and is always valid for any byte patterns.
     unsafe impl ImmutableFromIntoBytes for u32 {}
     impl private::Sealed for u64 {}
+    // SAFETY: The primitive u64 type is always initialized, does not have
+    // interior mutability, and is always valid for any byte patterns.
     unsafe impl ImmutableFromIntoBytes for u64 {}
     impl private::Sealed for u128 {}
+    // SAFETY: The primitive u128 type is always initialized, does not have
+    // interior mutability, and is always valid for any byte patterns.
     unsafe impl ImmutableFromIntoBytes for u128 {}
 }
 


### PR DESCRIPTION
### Pull Request Overview

There are three missing safety docs in dma_slice where a stored NonNull pointer is converted back to a slice. The safety requirement is [here](https://doc.rust-lang.org/core/ptr/struct.NonNull.html#safety-4), and I think the justification is pretty straightforward.

Also I gave it a shot to document why implementing `ImmutableFromIntoBytes` for primitive types is ok. 


### Testing Strategy

`cargo clippy -p kernel -- -A clippy::all -W clippy::undocumented_unsafe_blocks`


### TODO or Help Wanted

Is this a sufficient argument for why the pointer is convertible to a reference?


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md#ai-policy) and have properly disclosed my AI use below. This PR comment, and any subsequent PR interactions must not be generated using AI, except for under a `<details>` drawer.

<!-- Include details of AI use here, if you used any -->
