### PR TITLE
kernel/grant: make CustomGrant::enter take &mut self

### DIFF
--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -1540,7 +1540,7 @@ impl<T> CustomGrant<T> {
     /// Because this function requires `&mut self`, it should be impossible to
     /// access the inner data of a given `CustomGrant` reentrantly. Thus the
     /// reentrance detection we use for non-custom grants is not needed here.
-    pub fn enter<F, R>(&self, fun: F) -> Result<R, Error>
+    pub fn enter<F, R>(&mut self, fun: F) -> Result<R, Error>
     where
         F: FnOnce(GrantData<'_, T>) -> R,
     {


### PR DESCRIPTION
### Pull Request Overview

This function was previously requiring a `&mut self` reference to prevent mutable aliasing of the grant's contents through reentrancy. However, this was removed following a clippy lint as part of a Rust update in 287b53cbfb82 ("bump Rust nightly to nightly-2024-05-23").

It does not appear that this Clippy lint is currently active on my system with our configuration, so I'd avoid adding an explicit `#[allow]` to it right now.


### Testing Strategy

N/A


### TODO or Help Wanted

N/A


### Checklist

- [ ] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [X] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [X] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md#ai-policy) and have properly disclosed my AI use below. This PR comment, and any subsequent PR interactions must not be generated using AI, except for under a `<details>` drawer.

This was discovered as part of a soundness review with Claude Opus 5. I verified the finding, gathered additional context, and implemented this (trivial) fix myself.
