### PR TITLE
rp2: strip .stack from the ELF that make program flashes

### DIFF
--- a/boards/nano_rp2040_connect/Makefile
+++ b/boards/nano_rp2040_connect/Makefile
@@ -23,6 +23,10 @@ flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	elf2uf2-rs $< $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2
 	@if [ -d $(BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2 "$(BOOTSEL_FOLDER)"; else echo; echo Please edit the BOOTSEL_FOLDER variable to point to you Nano RP2040 Flash Drive Folder; fi
 
+# Giving .apps contents makes objcopy lay the program headers out again, and
+# the (NOLOAD) .stack segment comes back claiming file content for SRAM that
+# has none. UF2 converters reject the result, so drop the section from the
+# image being flashed: it only reserves stack space and carries no bytes.
 .PHONY: flash-app
 flash-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
 ifeq ($(APP),)
@@ -30,5 +34,6 @@ ifeq ($(APP),)
 endif
 	arm-none-eabi-objcopy --set-section-flags .apps=LOAD,ALLOC $(KERNEL) $(KERNEL_WITH_APP)
 	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL_WITH_APP)
+	arm-none-eabi-objcopy -R .stack $(KERNEL_WITH_APP)
 	elf2uf2-rs $(KERNEL_WITH_APP) $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2
 	@if [ -d $(BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2 "$(BOOTSEL_FOLDER)"; else echo; echo Please edit the BOOTSEL_FOLDER variable to point to you Nano RP2040 Flash Drive Folder; fi

--- a/boards/pico_explorer_base/Makefile
+++ b/boards/pico_explorer_base/Makefile
@@ -29,6 +29,10 @@ flash: $(KERNEL)
 	elf2uf2-rs $< $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2
 	@if [ -d $(BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2 "$(BOOTSEL_FOLDER)"; else echo; echo Please edit the BOOTSEL_FOLDER variable to point to you Raspberry Pi Pico Flash Drive Folder; echo You can download and flash $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2; fi
 
+# Giving .apps contents makes objcopy lay the program headers out again, and
+# the (NOLOAD) .stack segment comes back claiming file content for SRAM that
+# has none. UF2 converters reject the result, so drop the section from the
+# image being flashed: it only reserves stack space and carries no bytes.
 .PHONY: program
 program: $(KERNEL)
 ifeq ($(APP),)
@@ -36,5 +40,6 @@ ifeq ($(APP),)
 endif
 	arm-none-eabi-objcopy --set-section-flags .apps=LOAD,ALLOC $(KERNEL) $(KERNEL_WITH_APP)
 	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL_WITH_APP)
+	arm-none-eabi-objcopy -R .stack $(KERNEL_WITH_APP)
 	elf2uf2-rs $(KERNEL_WITH_APP) $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2
 	@if [ -d $(BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2 "$(BOOTSEL_FOLDER)"; else echo; echo Please edit the BOOTSEL_FOLDER variable to point to you Raspberry Pi Pico Flash Drive Folder; echo You can download and flash $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2; fi

--- a/boards/raspberry_pi_pico/Makefile
+++ b/boards/raspberry_pi_pico/Makefile
@@ -36,12 +36,17 @@ flash: $(KERNEL)
 	elf2uf2-rs $< $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2
 	@if [ -d $(BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2 "$(BOOTSEL_FOLDER)"; else echo; echo Please edit the BOOTSEL_FOLDER variable to point to you Raspberry Pi Pico Flash Drive Folder; echo You can download and flash $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2; fi
 
+# Giving .apps contents makes objcopy lay the program headers out again, and
+# the (NOLOAD) .stack segment comes back claiming file content for SRAM that
+# has none. UF2 converters reject the result, so drop the section from the
+# image being flashed: it only reserves stack space and carries no bytes.
 $(KERNEL_WITH_APP): $(KERNEL)
 ifeq ($(APP),)
 	$(error Please define the APP variable with the TBF file to flash an application)
 endif
 	arm-none-eabi-objcopy --set-section-flags .apps=LOAD,ALLOC $(KERNEL) $@
 	arm-none-eabi-objcopy --update-section .apps=$(APP) $@
+	arm-none-eabi-objcopy -R .stack $@
 
 .PHONY: program
 program: $(KERNEL_WITH_APP)

--- a/boards/raspberry_pi_pico_2/Makefile
+++ b/boards/raspberry_pi_pico_2/Makefile
@@ -29,6 +29,10 @@ flash: $(KERNEL)
 	picotool uf2 convert $< $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2
 	@if [ -d $(BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2 "$(BOOTSEL_FOLDER)"; else echo; echo Please edit the BOOTSEL_FOLDER variable to point to you Raspberry Pi Pico 2 Flash Drive Folder; echo You can download and flash $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2; fi
 
+# Giving .apps contents makes objcopy lay the program headers out again, and
+# the (NOLOAD) .stack segment comes back claiming file content for SRAM that
+# has none. UF2 converters reject the result, so drop the section from the
+# image being flashed: it only reserves stack space and carries no bytes.
 .PHONY: program
 program: $(KERNEL)
 ifeq ($(APP),)
@@ -36,6 +40,7 @@ ifeq ($(APP),)
 endif
 	arm-none-eabi-objcopy --set-section-flags .apps=LOAD,ALLOC $(KERNEL) $(KERNEL_WITH_APP)
 	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL_WITH_APP)
+	arm-none-eabi-objcopy -R .stack $(KERNEL_WITH_APP)
 	picotool uf2 convert $(KERNEL_WITH_APP) $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2
 	@if [ -d $(BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2 "$(BOOTSEL_FOLDER)"; else echo; echo Please edit the BOOTSEL_FOLDER variable to point to you Raspberry Pi Pico 2 Flash Drive Folder; echo You can download and flash $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2; fi
 
@@ -46,4 +51,5 @@ ifeq ($(APP),)
 endif
 	arm-none-eabi-objcopy --set-section-flags .apps=LOAD,ALLOC $(KERNEL) $(KERNEL_WITH_APP)
 	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL_WITH_APP)
+	arm-none-eabi-objcopy -R .stack $(KERNEL_WITH_APP)
 	$(OPENOCD) $(OPENOCD_OPTIONS) -c "adapter speed 5000" -c "program $(KERNEL_WITH_APP); verify_image $(KERNEL_WITH_APP);  reset; shutdown;"


### PR DESCRIPTION
### Pull Request Overview

Splicing an app into the kernel breaks the relevant make target on 4 of the 5 RP2 boards: "ELF contains memory contents for uninitialized memory at 20000000". BFD re-lays headers after --set-section-flags .apps=LOAD,ALLOC, and .stack (NOLOAD) ends up claiming file contents for SRAM. Add -R .stack to each objcopy splice rule. Fixes #4770.

<details>
<summary>AI-generated measurement data</summary>

https://via-balaena.github.io/tock-rp2350/findings/4770/

</details>

### Testing Strategy

potto216's RP2040: reporter verified on his machine via program/elf2uf2-rs/BOOTSEL. App ran; console "Hello world!". (https://github.com/tock/tock/issues/4770#issuecomment-5573463328)

program-openocd on RP2350: Pico 2 W over Debug Probe. rc=2 → rc=0. Without fix, openocd verify_image fails at 0x20000000 and aborts before reset, leaving board halted.

File-level: all 4 boards pass (raspberry_pi_pico, raspberry_pi_pico_2, pico_explorer_base, nano_rp2040_connect). pico_explorer_base and nano_rp2040_connect are file-level only. No hardware run yet.

### TODO or Help Wanted

program-probe (probe-rs): not run. Could someone with an RP2040 and probe-rs try it? @potto216 ?

### Checklist

- [x] Ran `make prepush`.

### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md#ai-policy) and have properly disclosed my AI use below. This PR comment, and any subsequent PR interactions must not be generated using AI, except for under a `<details>` drawer.

Code written with Claude Opus 5