### PR TITLE
tools: ci-qemu-virt: Support multiple targets, fix bugs

### DIFF
--- a/.github/workflows/qemu_virt.yml
+++ b/.github/workflows/qemu_virt.yml
@@ -57,24 +57,6 @@ jobs:
           repository: tock/libtock-c
           path: libtock-c
 
-      - name: Build libtock-c apps
-        shell: bash
-        run: |
-          export TOCK_TARGETS="\
-            rv64imac|rv64imac.0x80100080.0x80300000|0x80100080|0x80300000\
-            rv64imac|rv64imac.0x80110080.0x80310000|0x80110080|0x80310000\
-            rv64imac|rv64imac.0x80130080.0x80330000|0x80130080|0x80330000\
-            rv64imac|rv64imac.0x80180080.0x80380000|0x80180080|0x80380000"
-          pushd libtock-c/examples
-          make -C c_hello
-          make -C tests/led/led-odd
-          make -C tests/u8g2-demos/tock-logo
-          make -C tests/button_print
-          make -C tests/console/console
-          make -C blink
-          make -C tests/exit
-          popd
-
       - name: Build the qemu_rv64_virt-test-ci kernel
         shell: bash
         run: |

--- a/.github/workflows/qemu_virt.yml
+++ b/.github/workflows/qemu_virt.yml
@@ -62,12 +62,6 @@ jobs:
         run: |
           pushd boards/configurations/qemu_rv64_virt/qemu_rv64_virt-test-ci
           make
-          popd
-
-      - name: Initialize local board with kernel
-        shell: bash
-        run: |
-          pushd boards/configurations/qemu_rv64_virt/qemu_rv64_virt-test-ci
           make init
           make install
           popd
@@ -77,10 +71,10 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 &
           echo "DISPLAY=:99" >> $GITHUB_ENV
 
-      - name: Run qemu-virt CI tests
+      - name: Run qemu_rv64_virt-test-ci CI tests
         shell: bash
         # libtock-c is checked out inside the tock workspace in CI (GitHub
         # Actions requires checkouts to be under the workspace root).
         # ../../../libtock-c is relative to tools/ci/qemu-virt-ci-runner/,
         # which is the working directory when cargo run executes.
-        run: make ci-job-qemu-virt QEMU_VIRT_ARGS="--libtock-c ../../../libtock-c"
+        run: make ci-job-qemu-virt QEMU_VIRT_ARGS="--board qemu_rv64_virt --libtock-c ../../../libtock-c"

--- a/tools/ci/qemu-virt-ci-runner/README.md
+++ b/tools/ci/qemu-virt-ci-runner/README.md
@@ -16,7 +16,7 @@ A CI test runner for the `qemu_rv64_virt` Tock board.  It installs
   ```sh
   cargo run -- --libtock-c /path/to/libtock-c
   ```
-- The `qemu_rv64_virt-test-ci` board built and initialized:
+- The target board built and initialized.  For `qemu_rv64_virt`:
   ```sh
   cd boards/configurations/qemu_rv64_virt/qemu_rv64_virt-test-ci
   make
@@ -26,22 +26,30 @@ A CI test runner for the `qemu_rv64_virt` Tock board.  It installs
 
 ## Usage
 
+### List all available boards
+
+```sh
+cargo run -- --boards
+```
+
 ### Run all tests
 
 ```sh
-cargo run
+cargo run -- [--board <board-name>]
 ```
+
+If only one board is registered, `--board` can be omitted.
 
 ### Run a single test
 
 ```sh
-cargo run -- --test <test-name>
+cargo run -- [--board <board-name>] --test <test-name>
 ```
 
 ### List all tests with descriptions
 
 ```sh
-cargo run -- --tests
+cargo run -- [--board <board-name>] --tests
 ```
 
 ### Capture a screenshot to establish a baseline hash
@@ -71,18 +79,26 @@ To verify from the command line:
   shasum -a 256 /tmp/led-odd.ppm
 ```
 
-Paste the hash into `expected_screen_hash` in `src/main.rs`:
+Paste the hash into `expected_screen_hash` in the board's test file:
 
 ```rust
 expected_screen_hash: Some("20867e9c50573728461a70c4421b86ea08e09b4693d172c54123937f8a2a455e"),
 ```
 
+## Adding a new board
+
+Create `src/boards/<board_name>.rs` defining a `pub static BOARD: super::Board`
+with the board directory and a `static TESTS: &[TestCase]` slice.  Then add the
+new module to `src/boards/mod.rs` (`pub mod <board_name>;`) and append
+`&<board_name>::BOARD` to the `BOARDS` slice.
+
 ## Adding a new test
 
-Add a `TestCase` entry to the `TESTS` slice in `src/main.rs`.  Each test has a
-name, a human-readable description, a list of apps to install, an ordered
-sequence of steps, an optional settle delay before the screenshot, and an
-optional expected screenshot hash.
+Add a `TestCase` entry to the `TESTS` slice in the appropriate board file
+(e.g. `src/boards/qemu_rv64_virt.rs`).  Each test has a name, a
+human-readable description, a list of apps to install, an ordered sequence of
+steps, an optional settle delay before the screenshot, and an optional expected
+screenshot hash.
 
 ### Test steps
 

--- a/tools/ci/qemu-virt-ci-runner/src/boards/mod.rs
+++ b/tools/ci/qemu-virt-ci-runner/src/boards/mod.rs
@@ -1,0 +1,17 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+pub mod qemu_rv64_virt;
+
+pub struct Board {
+    /// Short identifier used with --board on the command line.
+    pub name: &'static str,
+    /// Path to the board directory (where `make run` is executed), relative to
+    /// the qemu-virt-ci-runner working directory.
+    pub board_dir: &'static str,
+    /// All test cases defined for this board.
+    pub tests: &'static [crate::TestCase],
+}
+
+pub static BOARDS: &[&Board] = &[&qemu_rv64_virt::BOARD];

--- a/tools/ci/qemu-virt-ci-runner/src/boards/mod.rs
+++ b/tools/ci/qemu-virt-ci-runner/src/boards/mod.rs
@@ -10,6 +10,10 @@ pub struct Board {
     /// Path to the board directory (where `make run` is executed), relative to
     /// the qemu-virt-ci-runner working directory.
     pub board_dir: &'static str,
+    /// Space-separated TOCK_TARGETS string passed to libtock-c `make` when
+    /// building apps.  Each entry has the form
+    /// `arch|name|flash_start|ram_start`.
+    pub tock_targets: &'static str,
     /// All test cases defined for this board.
     pub tests: &'static [crate::TestCase],
 }

--- a/tools/ci/qemu-virt-ci-runner/src/boards/qemu_rv64_virt.rs
+++ b/tools/ci/qemu-virt-ci-runner/src/boards/qemu_rv64_virt.rs
@@ -4,7 +4,7 @@
 
 use std::time::Duration;
 
-use crate::{TestCase, TestStep};
+use crate::{App, TestCase, TestStep};
 
 pub static BOARD: super::Board = super::Board {
     name: "qemu_rv64_virt",
@@ -21,7 +21,7 @@ static TESTS: &[TestCase] = &[
     TestCase {
         name: "c_hello",
         description: "Run the c_hello app and verify it prints \"Hello World!\" over serial.",
-        apps: &["c_hello"],
+        apps: &[App::LibtockC("c_hello")],
         steps: &[TestStep::WaitSerialInOrder {
             needles: &["Hello World!"],
             timeout: Duration::from_secs(30),
@@ -32,7 +32,7 @@ static TESTS: &[TestCase] = &[
     TestCase {
         name: "led-odd",
         description: "Run led-odd and verify the screen shows LEDs 1 and 3 on.",
-        apps: &["tests/led/led-odd"],
+        apps: &[App::LibtockC("tests/led/led-odd")],
         steps: &[TestStep::WaitSerialInOrder {
             needles: &["Entering main loop."],
             timeout: Duration::from_secs(30),
@@ -45,7 +45,7 @@ static TESTS: &[TestCase] = &[
     TestCase {
         name: "tock-logo",
         description: "Run the tock-logo u8g2 demo and verify the screen matches the expected logo.",
-        apps: &["tests/u8g2-demos/tock-logo"],
+        apps: &[App::LibtockC("tests/u8g2-demos/tock-logo")],
         steps: &[TestStep::WaitSerialInOrder {
             needles: &["Entering main loop."],
             timeout: Duration::from_secs(30),
@@ -58,7 +58,10 @@ static TESTS: &[TestCase] = &[
     TestCase {
         name: "led-odd-logo",
         description: "Run led-odd and tock-logo together and verify the combined screen output as the LEDs display on the screen.",
-        apps: &["tests/led/led-odd", "tests/u8g2-demos/tock-logo"],
+        apps: &[
+            App::LibtockC("tests/led/led-odd"),
+            App::LibtockC("tests/u8g2-demos/tock-logo"),
+        ],
         steps: &[TestStep::WaitSerialInOrder {
             needles: &["Entering main loop."],
             timeout: Duration::from_secs(30),
@@ -71,7 +74,7 @@ static TESTS: &[TestCase] = &[
     TestCase {
         name: "button_print",
         description: "Use the keyboard to send the character up arrow, and ensure that is translated to button 0 being pressed for userspace.",
-        apps: &["tests/button_print"],
+        apps: &[App::LibtockC("tests/button_print")],
         steps: &[
             TestStep::Sleep(Duration::from_millis(500)),
             TestStep::SendKey("up"),
@@ -86,7 +89,7 @@ static TESTS: &[TestCase] = &[
     TestCase {
         name: "console",
         description: "Send characters over serial and verify the console app echoes them back.",
-        apps: &["tests/console/console"],
+        apps: &[App::LibtockC("tests/console/console")],
         steps: &[
             TestStep::WaitSerialInOrder {
                 needles: &["Entering main loop."],
@@ -111,7 +114,7 @@ static TESTS: &[TestCase] = &[
     TestCase {
         name: "hello-pconsole",
         description: "Run c_hello alongside the process console and verify both the app output and the tock$ prompt appear.",
-        apps: &["c_hello"],
+        apps: &[App::LibtockC("c_hello")],
         steps: &[
             TestStep::Sleep(Duration::from_millis(100)),
             TestStep::SendSerial("\n\r"),
@@ -143,7 +146,7 @@ static TESTS: &[TestCase] = &[
     TestCase {
         name: "pconsole-list",
         description: "Run two apps and verify the process console 'list' command shows both, in any scheduler order.",
-        apps: &["c_hello", "blink"],
+        apps: &[App::LibtockC("c_hello"), App::LibtockC("blink")],
         steps: &[
             TestStep::Sleep(Duration::from_millis(500)),
             TestStep::SendSerial("list\n\r"),
@@ -158,7 +161,7 @@ static TESTS: &[TestCase] = &[
     TestCase {
         name: "exit",
         description: "Run the exit app and confirm it shows as Terminated in the process list.",
-        apps: &["tests/exit"],
+        apps: &[App::LibtockC("tests/exit")],
         steps: &[
             TestStep::WaitSerialInOrder {
                 needles: &["Testing exit.", "Exiting."],
@@ -177,7 +180,7 @@ static TESTS: &[TestCase] = &[
     TestCase {
         name: "unexpected-rx",
         description: "Send a serial byte before the app starts and verify the kernel handles unexpected RX without crashing.",
-        apps: &["c_hello"],
+        apps: &[App::LibtockC("c_hello")],
         steps: &[
             TestStep::SendSerial("a"),
             TestStep::WaitSerialInOrder {

--- a/tools/ci/qemu-virt-ci-runner/src/boards/qemu_rv64_virt.rs
+++ b/tools/ci/qemu-virt-ci-runner/src/boards/qemu_rv64_virt.rs
@@ -1,0 +1,186 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+use std::time::Duration;
+
+use crate::{TestCase, TestStep};
+
+pub static BOARD: super::Board = super::Board {
+    name: "qemu_rv64_virt",
+    board_dir: "../../../boards/configurations/qemu_rv64_virt/qemu_rv64_virt-test-ci",
+    tests: TESTS,
+};
+
+static TESTS: &[TestCase] = &[
+    TestCase {
+        name: "c_hello",
+        description: "Run the c_hello app and verify it prints \"Hello World!\" over serial.",
+        apps: &["c_hello"],
+        steps: &[TestStep::WaitSerialInOrder {
+            needles: &["Hello World!"],
+            timeout: Duration::from_secs(30),
+        }],
+        screenshot_delay: Duration::from_millis(0),
+        expected_screen_hash: None,
+    },
+    TestCase {
+        name: "led-odd",
+        description: "Run led-odd and verify the screen shows LEDs 1 and 3 on.",
+        apps: &["tests/led/led-odd"],
+        steps: &[TestStep::WaitSerialInOrder {
+            needles: &["Entering main loop."],
+            timeout: Duration::from_secs(30),
+        }],
+        screenshot_delay: Duration::from_millis(500),
+        expected_screen_hash: Some(
+            "c4d49a185592f23074ae5b83caa7d506967fbe8f93a547fa60de93bc2ddd282f",
+        ),
+    },
+    TestCase {
+        name: "tock-logo",
+        description: "Run the tock-logo u8g2 demo and verify the screen matches the expected logo.",
+        apps: &["tests/u8g2-demos/tock-logo"],
+        steps: &[TestStep::WaitSerialInOrder {
+            needles: &["Entering main loop."],
+            timeout: Duration::from_secs(30),
+        }],
+        screenshot_delay: Duration::from_millis(500),
+        expected_screen_hash: Some(
+            "4150b38c3cf468a388c0a09eb309ac8c480f692599cc0fc3e2684e0fafb5463d",
+        ),
+    },
+    TestCase {
+        name: "led-odd-logo",
+        description: "Run led-odd and tock-logo together and verify the combined screen output as the LEDs display on the screen.",
+        apps: &["tests/led/led-odd", "tests/u8g2-demos/tock-logo"],
+        steps: &[TestStep::WaitSerialInOrder {
+            needles: &["Entering main loop."],
+            timeout: Duration::from_secs(30),
+        }],
+        screenshot_delay: Duration::from_millis(500),
+        expected_screen_hash: Some(
+            "bfec0b5a3c5b72edb6128c7c9b6690b56d7ac93e1047d9ef45a22be0c9b4d4fa",
+        ),
+    },
+    TestCase {
+        name: "button_print",
+        description: "Use the keyboard to send the character up arrow, and ensure that is translated to button 0 being pressed for userspace.",
+        apps: &["tests/button_print"],
+        steps: &[
+            TestStep::Sleep(Duration::from_millis(500)),
+            TestStep::SendKey("up"),
+            TestStep::WaitSerialInOrder {
+                needles: &["Button Press! Button: 0 Status: 0"],
+                timeout: Duration::from_secs(30),
+            },
+        ],
+        screenshot_delay: Duration::from_millis(0),
+        expected_screen_hash: None,
+    },
+    TestCase {
+        name: "console",
+        description: "Send characters over serial and verify the console app echoes them back.",
+        apps: &["tests/console/console"],
+        steps: &[
+            TestStep::WaitSerialInOrder {
+                needles: &["Entering main loop."],
+                timeout: Duration::from_secs(30),
+            },
+            TestStep::Sleep(Duration::from_millis(30)),
+            TestStep::SendSerial("a"),
+            TestStep::WaitSerialInOrder {
+                needles: &["Got character: 'a'"],
+                timeout: Duration::from_secs(10),
+            },
+            TestStep::Sleep(Duration::from_millis(100)),
+            TestStep::SendSerial("R"),
+            TestStep::WaitSerialInOrder {
+                needles: &["Got character: 'R'"],
+                timeout: Duration::from_secs(10),
+            },
+        ],
+        screenshot_delay: Duration::from_millis(0),
+        expected_screen_hash: None,
+    },
+    TestCase {
+        name: "hello-pconsole",
+        description: "Run c_hello alongside the process console and verify both the app output and the tock$ prompt appear.",
+        apps: &["c_hello"],
+        steps: &[
+            TestStep::Sleep(Duration::from_millis(100)),
+            TestStep::SendSerial("\n\r"),
+            TestStep::WaitSerialAnyOrder {
+                needles: &["Hello World!", "tock$"],
+                timeout: Duration::from_secs(10),
+            },
+        ],
+        screenshot_delay: Duration::from_millis(0),
+        expected_screen_hash: None,
+    },
+    TestCase {
+        name: "pconsole-help",
+        description: "Send the 'help' command to the process console and verify the help output.",
+        apps: &[],
+        steps: &[
+            TestStep::Sleep(Duration::from_millis(500)),
+            TestStep::SendSerial("help\n\r"),
+            TestStep::WaitSerialInOrder {
+                needles: &[
+                    "Valid commands are: help status list stop start fault boot terminate process kernel reset panic console-start console-stop",
+                ],
+                timeout: Duration::from_secs(10),
+            },
+        ],
+        screenshot_delay: Duration::from_millis(0),
+        expected_screen_hash: None,
+    },
+    TestCase {
+        name: "pconsole-list",
+        description: "Run two apps and verify the process console 'list' command shows both, in any scheduler order.",
+        apps: &["c_hello", "blink"],
+        steps: &[
+            TestStep::Sleep(Duration::from_millis(500)),
+            TestStep::SendSerial("list\n\r"),
+            TestStep::WaitSerialAnyOrder {
+                needles: &["blink", "c_hello"],
+                timeout: Duration::from_secs(10),
+            },
+        ],
+        screenshot_delay: Duration::from_millis(0),
+        expected_screen_hash: None,
+    },
+    TestCase {
+        name: "exit",
+        description: "Run the exit app and confirm it shows as Terminated in the process list.",
+        apps: &["tests/exit"],
+        steps: &[
+            TestStep::WaitSerialInOrder {
+                needles: &["Testing exit.", "Exiting."],
+                timeout: Duration::from_secs(10),
+            },
+            TestStep::Sleep(Duration::from_millis(500)),
+            TestStep::SendSerial("list\n\r"),
+            TestStep::WaitSerialInOrder {
+                needles: &["exit", "Terminated"],
+                timeout: Duration::from_secs(10),
+            },
+        ],
+        screenshot_delay: Duration::from_millis(0),
+        expected_screen_hash: None,
+    },
+    TestCase {
+        name: "unexpected-rx",
+        description: "Send a serial byte before the app starts and verify the kernel handles unexpected RX without crashing.",
+        apps: &["c_hello"],
+        steps: &[
+            TestStep::SendSerial("a"),
+            TestStep::WaitSerialInOrder {
+                needles: &["Hello World!"],
+                timeout: Duration::from_secs(5),
+            },
+        ],
+        screenshot_delay: Duration::from_millis(0),
+        expected_screen_hash: None,
+    },
+];

--- a/tools/ci/qemu-virt-ci-runner/src/boards/qemu_rv64_virt.rs
+++ b/tools/ci/qemu-virt-ci-runner/src/boards/qemu_rv64_virt.rs
@@ -9,6 +9,11 @@ use crate::{TestCase, TestStep};
 pub static BOARD: super::Board = super::Board {
     name: "qemu_rv64_virt",
     board_dir: "../../../boards/configurations/qemu_rv64_virt/qemu_rv64_virt-test-ci",
+    tock_targets: "\
+        rv64imac|rv64imac.0x80100080.0x80300000|0x80100080|0x80300000 \
+        rv64imac|rv64imac.0x80110080.0x80310000|0x80110080|0x80310000 \
+        rv64imac|rv64imac.0x80130080.0x80330000|0x80130080|0x80330000 \
+        rv64imac|rv64imac.0x80180080.0x80380000|0x80180080|0x80380000",
     tests: TESTS,
 };
 

--- a/tools/ci/qemu-virt-ci-runner/src/main.rs
+++ b/tools/ci/qemu-virt-ci-runner/src/main.rs
@@ -172,7 +172,7 @@ fn wait_for_tcp(port: u16) -> Result<TcpStream, String> {
 
 /// Install tockloader apps, start QEMU in the background, and run the test closure.
 fn run_with_apps<F>(
-    app_names: &[&str],
+    apps: &[App],
     libtock_c_dir: &Path,
     board_dir: &str,
     test_fn: F,
@@ -190,18 +190,27 @@ where
         return Err(format!("tockloader erase-apps failed"));
     }
 
-    println!("Installing apps: {:?}", app_names);
+    let app_labels: Vec<&str> = apps
+        .iter()
+        .map(|a| match a {
+            App::LibtockC(p) => *p,
+        })
+        .collect();
+    println!("Installing apps: {:?}", app_labels);
 
-    // Install each libtock-c example app with tockloader.
-    for app in app_names {
-        let app_path = libtock_c_dir.join("examples").join(app);
-        let status = Command::new("tockloader")
-            .current_dir(&app_path)
-            .args(["install"])
-            .status()
-            .map_err(|e| format!("tockloader install failed for {}: {}", app, e))?;
-        if !status.success() {
-            return Err(format!("tockloader install failed for {}", app));
+    for app in apps {
+        match app {
+            App::LibtockC(path) => {
+                let app_path = libtock_c_dir.join("examples").join(path);
+                let status = Command::new("tockloader")
+                    .current_dir(&app_path)
+                    .args(["install"])
+                    .status()
+                    .map_err(|e| format!("tockloader install failed for {}: {}", path, e))?;
+                if !status.success() {
+                    return Err(format!("tockloader install failed for {}", path));
+                }
+            }
         }
     }
 
@@ -392,10 +401,17 @@ pub(crate) enum TestStep {
     SendSerial(&'static str),
 }
 
+/// An app to install before running a test.
+#[derive(Clone, Copy)]
+pub(crate) enum App {
+    /// A libtock-c app identified by its path relative to `libtock-c/examples/`.
+    LibtockC(&'static str),
+}
+
 pub(crate) struct TestCase {
     pub name: &'static str,
     pub description: &'static str,
-    pub apps: &'static [&'static str],
+    pub apps: &'static [App],
     /// Ordered sequence of actions to perform after QEMU is running.
     pub steps: &'static [TestStep],
     /// How long to wait after all steps before capturing the screenshot.
@@ -561,23 +577,25 @@ fn cmd_screenshot(
     )
 }
 
-fn build_apps(app_names: &[&str], libtock_c_dir: &Path, tock_targets: &str) -> Result<(), String> {
-    let mut unique: Vec<&str> = app_names.to_vec();
-    unique.sort();
-    unique.dedup();
-    for app in unique {
-        if app.is_empty() {
-            continue;
-        }
-        let app_path = libtock_c_dir.join("examples").join(app);
-        println!("Building app: {}", app);
+fn build_apps(apps: &[App], libtock_c_dir: &Path, tock_targets: &str) -> Result<(), String> {
+    let mut libtock_c_paths: Vec<&str> = apps
+        .iter()
+        .filter_map(|a| match a {
+            App::LibtockC(path) => Some(*path),
+        })
+        .collect();
+    libtock_c_paths.sort();
+    libtock_c_paths.dedup();
+    for path in libtock_c_paths {
+        let app_path = libtock_c_dir.join("examples").join(path);
+        println!("Building libtock-c app: {}", path);
         let status = Command::new("make")
             .current_dir(&app_path)
             .env("TOCK_TARGETS", tock_targets)
             .status()
-            .map_err(|e| format!("`make` failed for {}: {}", app, e))?;
+            .map_err(|e| format!("`make` failed for {}: {}", path, e))?;
         if !status.success() {
-            return Err(format!("`make` failed for {}", app));
+            return Err(format!("`make` failed for {}", path));
         }
     }
     Ok(())
@@ -596,7 +614,7 @@ fn cmd_run_all(board: &boards::Board, libtock_c_dir: &Path) -> Result<(), String
         return Err(format!("`make init` failed in {}", board.board_dir));
     }
 
-    let all_apps: Vec<&str> = board
+    let all_apps: Vec<App> = board
         .tests
         .iter()
         .flat_map(|tc| tc.apps.iter().copied())

--- a/tools/ci/qemu-virt-ci-runner/src/main.rs
+++ b/tools/ci/qemu-virt-ci-runner/src/main.rs
@@ -310,7 +310,8 @@ fn expect_serial_any_order(
 }
 
 /// Wait until each needle appears in the serial output in the given order.
-/// Each needle must appear after all preceding needles have been matched.
+/// Each needle must appear strictly after the end of the previous needle's
+/// match, so a single occurrence in the output cannot satisfy two needles.
 fn expect_serial_in_order(
     serial: &mut BufReader<TcpStream>,
     needles: &[&str],
@@ -321,9 +322,18 @@ fn expect_serial_in_order(
         needles, timeout
     );
     let mut idx = 0;
+    // Byte offset into the accumulated buffer; needle[idx] is only searched
+    // in buf[search_from..] so each match must follow the previous one.
+    let mut search_from = 0usize;
     read_serial_until(serial, timeout, |buf| {
-        while idx < needles.len() && buf.contains(needles[idx]) {
-            idx += 1;
+        while idx < needles.len() {
+            match buf[search_from..].find(needles[idx]) {
+                Some(pos) => {
+                    search_from += pos + needles[idx].len();
+                    idx += 1;
+                }
+                None => break,
+            }
         }
         Ok(idx == needles.len())
     })

--- a/tools/ci/qemu-virt-ci-runner/src/main.rs
+++ b/tools/ci/qemu-virt-ci-runner/src/main.rs
@@ -552,6 +552,16 @@ fn cmd_screenshot(
 fn cmd_run_all(board: &boards::Board, libtock_c_dir: &Path) -> Result<(), String> {
     println!("qemu-virt CI runner starting (board: {})...", board.name);
 
+    println!("Running `make init` in {}...", board.board_dir);
+    let status = Command::new("make")
+        .current_dir(board.board_dir)
+        .arg("init")
+        .status()
+        .map_err(|e| format!("failed to run `make init` in {}: {}", board.board_dir, e))?;
+    if !status.success() {
+        return Err(format!("`make init` failed in {}", board.board_dir));
+    }
+
     for tc in board.tests {
         run_test(tc, libtock_c_dir, board.board_dir)?;
         println!("TEST PASSED: {}", tc.name);

--- a/tools/ci/qemu-virt-ci-runner/src/main.rs
+++ b/tools/ci/qemu-virt-ci-runner/src/main.rs
@@ -14,7 +14,7 @@ use nix::unistd::Pid;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
-const BOARD_DIR: &str = "../../../boards/configurations/qemu_rv64_virt/qemu_rv64_virt-test-ci";
+mod boards;
 
 // Default libtock-c location: a sibling of the Tock repository root.
 // Override with --libtock-c <dir>.
@@ -171,7 +171,12 @@ fn wait_for_tcp(port: u16) -> Result<TcpStream, String> {
 }
 
 /// Install tockloader apps, start QEMU in the background, and run the test closure.
-fn run_with_apps<F>(app_names: &[&str], libtock_c_dir: &Path, test_fn: F) -> Result<(), String>
+fn run_with_apps<F>(
+    app_names: &[&str],
+    libtock_c_dir: &Path,
+    board_dir: &str,
+    test_fn: F,
+) -> Result<(), String>
 where
     F: FnOnce(&mut QmpConnection, &mut BufReader<TcpStream>, &mut TcpStream) -> Result<(), String>,
 {
@@ -192,7 +197,7 @@ where
         let app_path = libtock_c_dir.join("examples").join(app);
         let status = Command::new("tockloader")
             .current_dir(&app_path)
-            .args(["install", "--board", "qemu_rv64_virt"])
+            .args(["install"])
             .status()
             .map_err(|e| format!("tockloader install failed for {}: {}", app, e))?;
         if !status.success() {
@@ -203,7 +208,7 @@ where
     // Spawn `make run` with the extra QEMU flags that expose control sockets.
     println!("Starting QEMU via `make run`...");
     let child = Command::new("make")
-        .current_dir(BOARD_DIR)
+        .current_dir(board_dir)
         .arg("run")
         .env("QEMU_CMDLINE_EXTRA", QEMU_CMDLINE_EXTRA)
         .process_group(0)
@@ -217,7 +222,6 @@ where
     // establish both connections first.
     println!("Waiting for QMP socket on port {}...", QMP_PORT);
     let mut qmp = QmpConnection::connect().map_err(|e| format!("QMP connect failed: {}", e))?;
-    println!("QMP TCP connected.");
 
     println!("Waiting for serial socket on port {}...", SERIAL_PORT);
     let serial_stream =
@@ -226,69 +230,64 @@ where
         .try_clone()
         .map_err(|e| format!("failed to clone serial stream: {}", e))?;
     let mut serial = BufReader::new(serial_stream);
-    println!("Serial TCP connected.");
 
-    // Now that both clients are connected, QEMU will emit the QMP greeting.
+    // Now both TCP connections exist; negotiate the QMP protocol.
     qmp.handshake()
         .map_err(|e| format!("QMP handshake failed: {}", e))?;
-    println!("QMP ready.");
+    println!("QMP handshake complete.");
 
-    // Un-pause QEMU so the board actually starts running.
+    // Resume the CPU (QEMU starts paused with -S).
     qmp.resume()
-        .map_err(|e| format!("QMP cont failed: {}", e))?;
-    println!("QEMU running.");
+        .map_err(|e| format!("QMP resume failed: {}", e))?;
+    println!("QEMU resumed.");
 
     let result = test_fn(&mut qmp, &mut serial, &mut serial_write);
 
+    // Always stop QEMU after the test, whether it passed or failed.
     qemu.kill();
+
     result
 }
 
-/// Read serial lines until the deadline, calling `check` after each line.
-/// `check` receives the full accumulated buffer and returns `true` when done.
+/// Read serial output until `done` returns `true` or `timeout` elapses.
 fn read_serial_until<F>(
     serial: &mut BufReader<TcpStream>,
     timeout: Duration,
-    mut check: F,
+    mut done: F,
 ) -> Result<(), String>
 where
     F: FnMut(&str) -> Result<bool, String>,
 {
-    serial
-        .get_ref()
-        .set_read_timeout(Some(timeout))
-        .map_err(|e| e.to_string())?;
-
     let deadline = Instant::now() + timeout;
     let mut buf = String::new();
-
     loop {
-        if Instant::now() >= deadline {
-            return Err(format!("serial timeout after {:?}", timeout));
-        }
         let mut line = String::new();
         match serial.read_line(&mut line) {
-            Ok(0) => return Err("serial connection closed unexpectedly".into()),
+            Ok(0) => {
+                // EOF; treat as timeout.
+                return Err(format!("serial EOF after {:?}", timeout));
+            }
             Ok(_) => {
                 print!("[serial] {}", line);
                 buf.push_str(&line);
-                if check(&buf)? {
+                if done(&buf)? {
                     return Ok(());
                 }
             }
-            Err(e)
+            Err(ref e)
                 if e.kind() == std::io::ErrorKind::WouldBlock
                     || e.kind() == std::io::ErrorKind::TimedOut =>
             {
-                return Err(format!("serial timeout after {:?}", timeout));
+                if Instant::now() >= deadline {
+                    return Err(format!("timeout after {:?}", timeout));
+                }
             }
-            Err(e) => return Err(format!("serial read error: {}", e)),
+            Err(e) => return Err(e.to_string()),
         }
     }
 }
 
-/// Wait until every needle has appeared somewhere in the serial output,
-/// in any order.
+/// Wait until every needle has appeared in the serial output, in any order.
 fn expect_serial_any_order(
     serial: &mut BufReader<TcpStream>,
     needles: &[&str],
@@ -352,12 +351,12 @@ fn screendump_hash(qmp: &mut QmpConnection) -> Result<String, String> {
 }
 
 // ---------------------------------------------------------------------------
-// Test definitions
+// Shared test types (referenced by board modules via `crate::TestCase`)
 // ---------------------------------------------------------------------------
 
 /// One action in an ordered test sequence.  Steps are executed in order after
 /// QEMU is running; serial waits and key presses may be freely interleaved.
-enum TestStep {
+pub(crate) enum TestStep {
     /// Wait until every needle has appeared in the serial output, in any order.
     /// Use this when the Tock scheduler may interleave output from multiple apps.
     WaitSerialAnyOrder {
@@ -383,191 +382,17 @@ enum TestStep {
     SendSerial(&'static str),
 }
 
-struct TestCase {
-    name: &'static str,
-    description: &'static str,
-    apps: &'static [&'static str],
+pub(crate) struct TestCase {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub apps: &'static [&'static str],
     /// Ordered sequence of actions to perform after QEMU is running.
-    steps: &'static [TestStep],
+    pub steps: &'static [TestStep],
     /// How long to wait after all steps before capturing the screenshot.
-    screenshot_delay: Duration,
+    pub screenshot_delay: Duration,
     /// Optional known-good screendump hash. `None` means skip the check.
-    expected_screen_hash: Option<&'static str>,
+    pub expected_screen_hash: Option<&'static str>,
 }
-
-const TESTS: &[TestCase] = &[
-    TestCase {
-        name: "c_hello",
-        description: "Run the c_hello app and verify it prints \"Hello World!\" over serial.",
-        apps: &["c_hello"],
-        steps: &[TestStep::WaitSerialInOrder {
-            needles: &["Hello World!"],
-            timeout: Duration::from_secs(30),
-        }],
-        screenshot_delay: Duration::from_millis(0),
-        // Set to Some("known_hash_here") once a baseline is established.
-        expected_screen_hash: None,
-    },
-    TestCase {
-        name: "led-odd",
-        description: "Run led-odd and verify the screen shows LEDs 1 and 3 on.",
-        apps: &["tests/led/led-odd"],
-        steps: &[TestStep::WaitSerialInOrder {
-            needles: &["Entering main loop."],
-            timeout: Duration::from_secs(30),
-        }],
-        screenshot_delay: Duration::from_millis(500),
-        expected_screen_hash: Some(
-            "c4d49a185592f23074ae5b83caa7d506967fbe8f93a547fa60de93bc2ddd282f",
-        ),
-    },
-    TestCase {
-        name: "tock-logo",
-        description: "Run the tock-logo u8g2 demo and verify the screen matches the expected logo.",
-        apps: &["tests/u8g2-demos/tock-logo"],
-        steps: &[TestStep::WaitSerialInOrder {
-            needles: &["Entering main loop."],
-            timeout: Duration::from_secs(30),
-        }],
-        screenshot_delay: Duration::from_millis(500),
-        expected_screen_hash: Some(
-            "4150b38c3cf468a388c0a09eb309ac8c480f692599cc0fc3e2684e0fafb5463d",
-        ),
-    },
-    TestCase {
-        name: "led-odd-logo",
-        description: "Run led-odd and tock-logo together and verify the combined screen output as the LEDs display on the screen.",
-        apps: &["tests/led/led-odd", "tests/u8g2-demos/tock-logo"],
-        steps: &[TestStep::WaitSerialInOrder {
-            needles: &["Entering main loop."],
-            timeout: Duration::from_secs(30),
-        }],
-        screenshot_delay: Duration::from_millis(500),
-        expected_screen_hash: Some(
-            "bfec0b5a3c5b72edb6128c7c9b6690b56d7ac93e1047d9ef45a22be0c9b4d4fa",
-        ),
-    },
-    TestCase {
-        name: "button_print",
-        description: "Use the keyboard to send the character up arrow, and ensure that is translated to button 0 being pressed for userspace.",
-        apps: &["tests/button_print"],
-        steps: &[
-            TestStep::Sleep(Duration::from_millis(500)),
-            TestStep::SendKey("up"),
-            TestStep::WaitSerialInOrder {
-                needles: &["Button Press! Button: 0 Status: 0"],
-                timeout: Duration::from_secs(30),
-            },
-        ],
-        screenshot_delay: Duration::from_millis(0),
-        expected_screen_hash: None,
-    },
-    TestCase {
-        name: "console",
-        description: "Send characters over serial and verify the console app echoes them back.",
-        apps: &["tests/console/console"],
-        steps: &[
-            TestStep::WaitSerialInOrder {
-                needles: &["Entering main loop."],
-                timeout: Duration::from_secs(30),
-            },
-            TestStep::Sleep(Duration::from_millis(30)),
-            TestStep::SendSerial("a"),
-            TestStep::WaitSerialInOrder {
-                needles: &["Got character: 'a'"],
-                timeout: Duration::from_secs(10),
-            },
-            TestStep::Sleep(Duration::from_millis(100)),
-            TestStep::SendSerial("R"),
-            TestStep::WaitSerialInOrder {
-                needles: &["Got character: 'R'"],
-                timeout: Duration::from_secs(10),
-            },
-        ],
-        screenshot_delay: Duration::from_millis(0),
-        expected_screen_hash: None,
-    },
-    TestCase {
-        name: "hello-pconsole",
-        description: "Run c_hello alongside the process console and verify both the app output and the tock$ prompt appear.",
-        apps: &["c_hello"],
-        steps: &[
-            TestStep::Sleep(Duration::from_millis(100)),
-            TestStep::SendSerial("\n\r"),
-            TestStep::WaitSerialAnyOrder {
-                needles: &["Hello World!", "tock$"],
-                timeout: Duration::from_secs(10),
-            },
-        ],
-        screenshot_delay: Duration::from_millis(0),
-        expected_screen_hash: None,
-    },
-    TestCase {
-        name: "pconsole-help",
-        description: "Send the 'help' command to the process console and verify the help output.",
-        apps: &[],
-        steps: &[
-            TestStep::Sleep(Duration::from_millis(500)),
-            TestStep::SendSerial("help\n\r"),
-            TestStep::WaitSerialInOrder {
-                needles: &[
-                    "Valid commands are: help status list stop start fault boot terminate process kernel reset panic console-start console-stop",
-                ],
-                timeout: Duration::from_secs(10),
-            },
-        ],
-        screenshot_delay: Duration::from_millis(0),
-        expected_screen_hash: None,
-    },
-    TestCase {
-        name: "pconsole-list",
-        description: "Run two apps and verify the process console 'list' command shows both, in any scheduler order.",
-        apps: &["c_hello", "blink"],
-        steps: &[
-            TestStep::Sleep(Duration::from_millis(500)),
-            TestStep::SendSerial("list\n\r"),
-            TestStep::WaitSerialAnyOrder {
-                needles: &["blink", "c_hello"],
-                timeout: Duration::from_secs(10),
-            },
-        ],
-        screenshot_delay: Duration::from_millis(0),
-        expected_screen_hash: None,
-    },
-    TestCase {
-        name: "exit",
-        description: "Run the exit app and confirm it shows as Terminated in the process list.",
-        apps: &["tests/exit"],
-        steps: &[
-            TestStep::WaitSerialInOrder {
-                needles: &["Testing exit.", "Exiting."],
-                timeout: Duration::from_secs(10),
-            },
-            TestStep::Sleep(Duration::from_millis(500)),
-            TestStep::SendSerial("list\n\r"),
-            TestStep::WaitSerialInOrder {
-                needles: &["exit", "Terminated"],
-                timeout: Duration::from_secs(10),
-            },
-        ],
-        screenshot_delay: Duration::from_millis(0),
-        expected_screen_hash: None,
-    },
-    TestCase {
-        name: "unexpected-rx",
-        description: "Send a serial byte before the app starts and verify the kernel handles unexpected RX without crashing.",
-        apps: &["c_hello"],
-        steps: &[
-            TestStep::SendSerial("a"),
-            TestStep::WaitSerialInOrder {
-                needles: &["Hello World!"],
-                timeout: Duration::from_secs(5),
-            },
-        ],
-        screenshot_delay: Duration::from_millis(0),
-        expected_screen_hash: None,
-    },
-];
 
 // ---------------------------------------------------------------------------
 
@@ -609,55 +434,74 @@ fn run_steps(
     Ok(())
 }
 
-fn run_test(tc: &TestCase, libtock_c_dir: &Path) -> Result<(), String> {
+fn run_test(tc: &TestCase, libtock_c_dir: &Path, board_dir: &str) -> Result<(), String> {
     println!();
     println!("{}", "=".repeat(70));
     println!("TEST: {}", tc.name);
     println!("{}", "=".repeat(70));
 
-    run_with_apps(tc.apps, libtock_c_dir, |qmp, serial, serial_write| {
-        run_steps(tc.steps, qmp, serial, serial_write)?;
+    run_with_apps(
+        tc.apps,
+        libtock_c_dir,
+        board_dir,
+        |qmp, serial, serial_write| {
+            run_steps(tc.steps, qmp, serial, serial_write)?;
 
-        // Wait for the display to settle before capturing.
-        if !tc.screenshot_delay.is_zero() {
-            println!("Waiting {:?} before screenshot...", tc.screenshot_delay);
-            std::thread::sleep(tc.screenshot_delay);
-        }
-
-        // Optionally verify the screen.
-        if let Some(known_hash) = tc.expected_screen_hash {
-            let actual = screendump_hash(qmp)?;
-            if actual != known_hash {
-                return Err(format!(
-                    "screen hash mismatch: expected {} got {}",
-                    known_hash, actual
-                ));
+            // Wait for the display to settle before capturing.
+            if !tc.screenshot_delay.is_zero() {
+                println!("Waiting {:?} before screenshot...", tc.screenshot_delay);
+                std::thread::sleep(tc.screenshot_delay);
             }
-            println!("Screen hash check passed: {}", actual);
-        } else {
-            // Still capture the hash so it can be recorded as a baseline.
-            match screendump_hash(qmp) {
-                Ok(hash) => println!("Screen hash (baseline): {}", hash),
-                Err(e) => println!("Screen hash unavailable: {}", e),
-            }
-        }
 
-        Ok(())
-    })
+            // Optionally verify the screen.
+            if let Some(known_hash) = tc.expected_screen_hash {
+                let actual = screendump_hash(qmp)?;
+                if actual != known_hash {
+                    return Err(format!(
+                        "screen hash mismatch: expected {} got {}",
+                        known_hash, actual
+                    ));
+                }
+                println!("Screen hash check passed: {}", actual);
+            } else {
+                // Still capture the hash so it can be recorded as a baseline.
+                match screendump_hash(qmp) {
+                    Ok(hash) => println!("Screen hash (baseline): {}", hash),
+                    Err(e) => println!("Screen hash unavailable: {}", e),
+                }
+            }
+
+            Ok(())
+        },
+    )
 }
 
 /// Boot a single named test, wait until the board is in a known running state
 /// (by satisfying its serial expectations if any), take a screendump, copy it
 /// to `dest`, and print the SHA-256 hash.  This is intended for establishing
 /// or inspecting the baseline hash that goes into `expected_screen_hash`.
-fn cmd_screenshot(test_name: &str, dest: &Path, libtock_c_dir: &Path) -> Result<(), String> {
-    let tc = TESTS.iter().find(|t| t.name == test_name).ok_or_else(|| {
-        format!(
-            "unknown test {:?}; available tests: {}",
-            test_name,
-            TESTS.iter().map(|t| t.name).collect::<Vec<_>>().join(", ")
-        )
-    })?;
+fn cmd_screenshot(
+    board: &boards::Board,
+    test_name: &str,
+    dest: &Path,
+    libtock_c_dir: &Path,
+) -> Result<(), String> {
+    let tc = board
+        .tests
+        .iter()
+        .find(|t| t.name == test_name)
+        .ok_or_else(|| {
+            format!(
+                "unknown test {:?}; available tests: {}",
+                test_name,
+                board
+                    .tests
+                    .iter()
+                    .map(|t| t.name)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        })?;
 
     println!(
         "Screenshot mode: test={:?} dest={}",
@@ -665,46 +509,51 @@ fn cmd_screenshot(test_name: &str, dest: &Path, libtock_c_dir: &Path) -> Result<
         dest.display()
     );
 
-    run_with_apps(tc.apps, libtock_c_dir, |qmp, serial, serial_write| {
-        // Run all steps (serial waits, key presses, sleeps) so the board
-        // reaches a known state before the screenshot is captured.
-        run_steps(tc.steps, qmp, serial, serial_write)?;
+    run_with_apps(
+        tc.apps,
+        libtock_c_dir,
+        board.board_dir,
+        |qmp, serial, serial_write| {
+            // Run all steps (serial waits, key presses, sleeps) so the board
+            // reaches a known state before the screenshot is captured.
+            run_steps(tc.steps, qmp, serial, serial_write)?;
 
-        // Wait for the display to settle before capturing.
-        if !tc.screenshot_delay.is_zero() {
-            println!("Waiting {:?} before screenshot...", tc.screenshot_delay);
-            std::thread::sleep(tc.screenshot_delay);
-        }
+            // Wait for the display to settle before capturing.
+            if !tc.screenshot_delay.is_zero() {
+                println!("Waiting {:?} before screenshot...", tc.screenshot_delay);
+                std::thread::sleep(tc.screenshot_delay);
+            }
 
-        // Take the screendump into a temp file, then copy to dest.
-        let tmp = tempfile::Builder::new()
-            .suffix(".ppm")
-            .tempfile()
-            .map_err(|e| e.to_string())?;
-        qmp.screendump(tmp.path())?;
-        std::fs::copy(tmp.path(), dest)
-            .map_err(|e| format!("failed to copy screenshot to {}: {}", dest.display(), e))?;
+            // Take the screendump into a temp file, then copy to dest.
+            let tmp = tempfile::Builder::new()
+                .suffix(".ppm")
+                .tempfile()
+                .map_err(|e| e.to_string())?;
+            qmp.screendump(tmp.path())?;
+            std::fs::copy(tmp.path(), dest)
+                .map_err(|e| format!("failed to copy screenshot to {}: {}", dest.display(), e))?;
 
-        // Compute and print the hash so it can be pasted into expected_screen_hash.
-        let bytes = std::fs::read(dest).map_err(|e| e.to_string())?;
-        let hash = format!("{:x}", Sha256::digest(&bytes));
-        println!("Screenshot saved to:  {}", dest.display());
-        println!("SHA-256:              {}", hash);
-        println!();
-        println!(
-            "To verify from the command line:\n  shasum -a 256 {}",
-            dest.display()
-        );
+            // Compute and print the hash so it can be pasted into expected_screen_hash.
+            let bytes = std::fs::read(dest).map_err(|e| e.to_string())?;
+            let hash = format!("{:x}", Sha256::digest(&bytes));
+            println!("Screenshot saved to:  {}", dest.display());
+            println!("SHA-256:              {}", hash);
+            println!();
+            println!(
+                "To verify from the command line:\n  shasum -a 256 {}",
+                dest.display()
+            );
 
-        Ok(())
-    })
+            Ok(())
+        },
+    )
 }
 
-fn cmd_run_all(libtock_c_dir: &Path) -> Result<(), String> {
-    println!("qemu-virt CI runner starting...");
+fn cmd_run_all(board: &boards::Board, libtock_c_dir: &Path) -> Result<(), String> {
+    println!("qemu-virt CI runner starting (board: {})...", board.name);
 
-    for tc in TESTS {
-        run_test(tc, libtock_c_dir)?;
+    for tc in board.tests {
+        run_test(tc, libtock_c_dir, board.board_dir)?;
         println!("TEST PASSED: {}", tc.name);
         println!("{}", "-".repeat(70));
     }
@@ -712,8 +561,10 @@ fn cmd_run_all(libtock_c_dir: &Path) -> Result<(), String> {
     Ok(())
 }
 
-fn cmd_list_tests() {
-    for tc in TESTS {
+fn cmd_list_tests(board: &boards::Board) {
+    println!("Board: {}", board.name);
+    println!();
+    for tc in board.tests {
         println!("{}", tc.name);
         println!("  {}", tc.description);
     }
@@ -722,35 +573,93 @@ fn cmd_list_tests() {
 fn usage(argv0: &str) {
     eprintln!("Usage:");
     eprintln!(
-        "  {} [--libtock-c <dir>]                            Run all tests",
+        "  {} [--board <board>] [--libtock-c <dir>]                            Run all tests",
         argv0
     );
     eprintln!(
-        "  {} [--libtock-c <dir>] --test <test>              Run a single named test",
+        "  {} [--board <board>] [--libtock-c <dir>] --test <test>              Run a single named test",
         argv0
     );
     eprintln!(
-        "  {} --tests                                         List all tests with descriptions",
+        "  {} [--board <board>] --tests                                         List all tests with descriptions",
         argv0
     );
     eprintln!(
-        "  {} [--libtock-c <dir>] --screenshot <test> <file> Boot <test>, save screenshot, print hash",
+        "  {} [--board <board>] [--libtock-c <dir>] --screenshot <test> <file> Boot <test>, save screenshot, print hash",
+        argv0
+    );
+    eprintln!(
+        "  {} --boards                                                           List all available boards",
         argv0
     );
     eprintln!();
     eprintln!("Options:");
+    eprintln!("  --board <name>      Select the target board.");
+    eprintln!(
+        "                      Default: {} (only board available)",
+        boards::BOARDS[0].name
+    );
     eprintln!("  --libtock-c <dir>   Path to the libtock-c repository root.");
     eprintln!("                      Default: {}", LIBTOCK_C_DIR_DEFAULT);
     eprintln!();
-    eprintln!("Available tests:");
-    for tc in TESTS {
-        eprintln!("  {}", tc.name);
+    eprintln!("Available boards:");
+    for b in boards::BOARDS {
+        eprintln!("  {}", b.name);
     }
+}
+
+fn select_board(name: &str) -> Option<&'static boards::Board> {
+    boards::BOARDS.iter().copied().find(|b| b.name == name)
 }
 
 fn main() {
     let mut args: Vec<String> = std::env::args().collect();
     let argv0 = args[0].clone();
+
+    // --boards: list available boards and exit.
+    if args.iter().any(|a| a == "--boards") {
+        for b in boards::BOARDS {
+            println!("{}", b.name);
+        }
+        std::process::exit(0);
+    }
+
+    // Extract --board <name> from args before dispatching.
+    let board: &boards::Board = if let Some(pos) = args.iter().position(|a| a == "--board") {
+        if pos + 1 >= args.len() {
+            eprintln!("error: --board requires a board name argument");
+            std::process::exit(2);
+        }
+        let name = args.remove(pos + 1);
+        args.remove(pos);
+        match select_board(&name) {
+            Some(b) => b,
+            None => {
+                eprintln!(
+                    "error: unknown board {:?}; available boards: {}",
+                    name,
+                    boards::BOARDS
+                        .iter()
+                        .map(|b| b.name)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+                std::process::exit(2);
+            }
+        }
+    } else if boards::BOARDS.len() == 1 {
+        boards::BOARDS[0]
+    } else {
+        eprintln!(
+            "error: multiple boards available; specify one with --board <name>: {}",
+            boards::BOARDS
+                .iter()
+                .map(|b| b.name)
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        std::process::exit(2);
+    };
 
     // Extract --libtock-c <dir> from args before dispatching, since it may
     // appear at any position.
@@ -768,19 +677,19 @@ fn main() {
 
     let result = match args.as_slice() {
         // Normal mode: run all tests.
-        [_] => cmd_run_all(&libtock_c_dir),
+        [_] => cmd_run_all(board, &libtock_c_dir),
 
         // List tests with descriptions (no libtock-c needed).
         [_, flag] if flag == "--tests" => {
-            cmd_list_tests();
+            cmd_list_tests(board);
             std::process::exit(0);
         }
 
         // Single-test mode.
         [_, flag, test_name] if flag == "--test" => {
-            match TESTS.iter().find(|t| t.name == test_name.as_str()) {
+            match board.tests.iter().find(|t| t.name == test_name.as_str()) {
                 Some(tc) => {
-                    let r = run_test(tc, &libtock_c_dir);
+                    let r = run_test(tc, &libtock_c_dir, board.board_dir);
                     if r.is_ok() {
                         println!("TEST PASSED: {}", tc.name);
                     }
@@ -790,7 +699,12 @@ fn main() {
                     eprintln!(
                         "unknown test {:?}; available tests: {}",
                         test_name,
-                        TESTS.iter().map(|t| t.name).collect::<Vec<_>>().join(", ")
+                        board
+                            .tests
+                            .iter()
+                            .map(|t| t.name)
+                            .collect::<Vec<_>>()
+                            .join(", ")
                     );
                     std::process::exit(2);
                 }
@@ -799,7 +713,7 @@ fn main() {
 
         // Screenshot mode: boot one test and save a screendump.
         [_, flag, test_name, dest] if flag == "--screenshot" => {
-            cmd_screenshot(test_name, Path::new(dest), &libtock_c_dir)
+            cmd_screenshot(board, test_name, Path::new(dest), &libtock_c_dir)
         }
 
         _ => {

--- a/tools/ci/qemu-virt-ci-runner/src/main.rs
+++ b/tools/ci/qemu-virt-ci-runner/src/main.rs
@@ -612,6 +612,46 @@ fn cmd_run_all(board: &boards::Board, libtock_c_dir: &Path) -> Result<(), String
     Ok(())
 }
 
+fn cmd_run_one(board: &boards::Board, test_name: &str, libtock_c_dir: &Path) -> Result<(), String> {
+    println!(
+        "qemu-virt CI runner single test (board: {}, test: {})...",
+        board.name, test_name
+    );
+
+    println!("Running `make init` in {}...", board.board_dir);
+    let status = Command::new("make")
+        .current_dir(board.board_dir)
+        .arg("init")
+        .status()
+        .map_err(|e| format!("failed to run `make init` in {}: {}", board.board_dir, e))?;
+    if !status.success() {
+        return Err(format!("`make init` failed in {}", board.board_dir));
+    }
+
+    let tc = board
+        .tests
+        .iter()
+        .find(|t| t.name == test_name)
+        .ok_or_else(|| {
+            format!(
+                "unknown test {:?}; available tests: {}",
+                test_name,
+                board
+                    .tests
+                    .iter()
+                    .map(|t| t.name)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        })?;
+    build_apps(tc.apps, libtock_c_dir, board.tock_targets)?;
+    let r = run_test(tc, libtock_c_dir, board.board_dir);
+    if r.is_ok() {
+        println!("TEST PASSED: {}", tc.name);
+    }
+    r
+}
+
 fn cmd_list_tests(board: &boards::Board) {
     println!("Board: {}", board.name);
     println!();
@@ -737,34 +777,7 @@ fn main() {
         }
 
         // Single-test mode.
-        [_, flag, test_name] if flag == "--test" => {
-            match board.tests.iter().find(|t| t.name == test_name.as_str()) {
-                Some(tc) => {
-                    if let Err(e) = build_apps(tc.apps, &libtock_c_dir, board.tock_targets) {
-                        eprintln!("Error: {}", e);
-                        std::process::exit(1);
-                    }
-                    let r = run_test(tc, &libtock_c_dir, board.board_dir);
-                    if r.is_ok() {
-                        println!("TEST PASSED: {}", tc.name);
-                    }
-                    r
-                }
-                None => {
-                    eprintln!(
-                        "unknown test {:?}; available tests: {}",
-                        test_name,
-                        board
-                            .tests
-                            .iter()
-                            .map(|t| t.name)
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    );
-                    std::process::exit(2);
-                }
-            }
-        }
+        [_, flag, test_name] if flag == "--test" => cmd_run_one(board, test_name, &libtock_c_dir),
 
         // Screenshot mode: boot one test and save a screendump.
         [_, flag, test_name, dest] if flag == "--screenshot" => {

--- a/tools/ci/qemu-virt-ci-runner/src/main.rs
+++ b/tools/ci/qemu-virt-ci-runner/src/main.rs
@@ -519,6 +519,8 @@ fn cmd_screenshot(
         dest.display()
     );
 
+    build_apps(tc.apps, libtock_c_dir, board.tock_targets)?;
+
     run_with_apps(
         tc.apps,
         libtock_c_dir,
@@ -559,6 +561,28 @@ fn cmd_screenshot(
     )
 }
 
+fn build_apps(app_names: &[&str], libtock_c_dir: &Path, tock_targets: &str) -> Result<(), String> {
+    let mut unique: Vec<&str> = app_names.to_vec();
+    unique.sort();
+    unique.dedup();
+    for app in unique {
+        if app.is_empty() {
+            continue;
+        }
+        let app_path = libtock_c_dir.join("examples").join(app);
+        println!("Building app: {}", app);
+        let status = Command::new("make")
+            .current_dir(&app_path)
+            .env("TOCK_TARGETS", tock_targets)
+            .status()
+            .map_err(|e| format!("`make` failed for {}: {}", app, e))?;
+        if !status.success() {
+            return Err(format!("`make` failed for {}", app));
+        }
+    }
+    Ok(())
+}
+
 fn cmd_run_all(board: &boards::Board, libtock_c_dir: &Path) -> Result<(), String> {
     println!("qemu-virt CI runner starting (board: {})...", board.name);
 
@@ -571,6 +595,13 @@ fn cmd_run_all(board: &boards::Board, libtock_c_dir: &Path) -> Result<(), String
     if !status.success() {
         return Err(format!("`make init` failed in {}", board.board_dir));
     }
+
+    let all_apps: Vec<&str> = board
+        .tests
+        .iter()
+        .flat_map(|tc| tc.apps.iter().copied())
+        .collect();
+    build_apps(&all_apps, libtock_c_dir, board.tock_targets)?;
 
     for tc in board.tests {
         run_test(tc, libtock_c_dir, board.board_dir)?;
@@ -709,6 +740,10 @@ fn main() {
         [_, flag, test_name] if flag == "--test" => {
             match board.tests.iter().find(|t| t.name == test_name.as_str()) {
                 Some(tc) => {
+                    if let Err(e) = build_apps(tc.apps, &libtock_c_dir, board.tock_targets) {
+                        eprintln!("Error: {}", e);
+                        std::process::exit(1);
+                    }
                     let r = run_test(tc, &libtock_c_dir, board.board_dir);
                     if r.is_ok() {
                         println!("TEST PASSED: {}", tc.name);


### PR DESCRIPTION
### Pull Request Overview

The main change to the QEMU-virt infrastructure for CI is separating out the tests for boards so that the same tool can support multiple QEMU Tock boards. This moves the test list to its own file. It also builds the apps in the tool so that the build does not need to be specified by the CI workflow.

This also fixes somes bugs I found while adding more tests, including finding multiple needles and running `make init` at the right time.


### Testing Strategy

In CI, and running the runner with the qemu-rv32-virt CI test board I'm working on.


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md#ai-policy) and have properly disclosed my AI use below. This PR comment, and any subsequent PR interactions must not be generated using AI, except for under a `<details>` drawer.

I continue to use claude to write the CI runner tool. All changes to the tool were written by claude in response to my prompts for each commit. I review and commit each commit. This drastically accelerates writing the test runner code.