### PR TITLE
rp2: build the flashed image with tockloader instead of splicing an ELF

### DIFF
--- a/boards/nano_rp2040_connect/Makefile
+++ b/boards/nano_rp2040_connect/Makefile
@@ -6,10 +6,13 @@
 
 include ../Makefile.common
 
-KERNEL=$(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/release/$(PLATFORM)-app.elf
-
 BOOTSEL_FOLDER?=/media/$(USER)/RPI-RP2
+
+# From layout.ld: flash begins at `rom`, applications at `prog`.
+FLASH_ADDRESS=0x10000000
+APP_ADDRESS=0x10040000
+
+IMAGE=$(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-image.bin
 
 # Default target for installing the kernel.
 .PHONY: install
@@ -18,17 +21,16 @@ install: flash
 flash-openocd: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	$(OPENOCD) $(OPENOCD_OPTIONS) -c "program $<; verify_image $<;  reset; shutdown;"
 
-.PHONY: flash
-flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	elf2uf2-rs $< $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2
-	@if [ -d $(BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2 "$(BOOTSEL_FOLDER)"; else echo; echo Please edit the BOOTSEL_FOLDER variable to point to you Nano RP2040 Flash Drive Folder; fi
+.PHONY: init
+init:
+	tockloader local-board set $(PLATFORM) --binary-path $(IMAGE) --arch cortex-m0 --app-address $(APP_ADDRESS) --flash-address $(FLASH_ADDRESS)
 
-.PHONY: flash-app
-flash-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
-ifeq ($(APP),)
-	$(error Please define the APP variable with the TBF file to flash an application)
-endif
-	arm-none-eabi-objcopy --set-section-flags .apps=LOAD,ALLOC $(KERNEL) $(KERNEL_WITH_APP)
-	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL_WITH_APP)
-	elf2uf2-rs $(KERNEL_WITH_APP) $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2
-	@if [ -d $(BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2 "$(BOOTSEL_FOLDER)"; else echo; echo Please edit the BOOTSEL_FOLDER variable to point to you Nano RP2040 Flash Drive Folder; fi
+# Write the kernel to the flash file with tockloader
+.PHONY: write-kernel
+write-kernel: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+	tockloader flash --local-board --address $(FLASH_ADDRESS) $<
+
+.PHONY: flash
+flash: write-kernel
+	picotool uf2 convert $(IMAGE) -t bin -o $(FLASH_ADDRESS) --family rp2040 $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2
+	@if [ -d $(BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2 "$(BOOTSEL_FOLDER)"; else echo; echo Please edit the BOOTSEL_FOLDER variable to point to you Nano RP2040 Flash Drive Folder; fi

--- a/boards/nano_rp2040_connect/README.md
+++ b/boards/nano_rp2040_connect/README.md
@@ -10,16 +10,19 @@ board built using the Raspberry Pi Foundation's RP2040 chip.
 
 First, follow the [Tock Getting Started guide](../../doc/Getting_Started.md)
 
-## Installing elf2uf2-rs
+## Installing picotool
 
-The Nano RP2040 uses UF2 files for flashing. Tock compiles to an ELF file.
-The `elf2uf2-rs` utility is needed to transform the Tock ELF file into an UF2 file.
+The RP2040 uses UF2 files for flashing. `tockloader` builds a flash image that
+holds the kernel and any applications, and the `picotool` utility transforms that
+image into a UF2 file.
 
-To install `elf2uf2`, run the commands:
+To install `picotool`, check the instructions from their GitHub [page](https://github.com/raspberrypi/picotool).
 
-```bash
-$ cargo install elf2uf2-rs
-```
+## Installing tockloader
+
+`tockloader` writes the kernel and the applications into the flash image this
+board is programmed from. See the
+[Getting Started guide](../../doc/Getting_Started.md) for how to install it.
 
 ## Flashing the kernel
 
@@ -41,7 +44,8 @@ the device can be [forced into BOOTSEL mode using a jumper wire](https://docs.ar
 4. Wait for the flash drive to mount
 5. Disconnect the board from USB (*very important*)
 
-`cd` into `boards/nano_rp2040_connect` directory and run:
+`cd` into `boards/nano_rp2040_connect` directory and run `make init` once to
+point `tockloader` at this board's flash image, followed by:
 
 ```bash
 $ make flash
@@ -59,9 +63,11 @@ $ make flash-debug
 
 Enter BOOTSEL mode.
 
-Apps are built out-of-tree. Once an app is built, you can add the path to it in the Makefile (APP variable), then run:
+Apps are built out-of-tree. Once an app is built, install it into the flash image
+and write that image to the board:
 ```bash
-$ APP="<path to app's tbf file>" make flash-app
+$ tockloader install --local-board <path to app's .tab file>
+$ make flash
 ```
 
 ## Serial Interface

--- a/boards/pico_explorer_base/Makefile
+++ b/boards/pico_explorer_base/Makefile
@@ -12,29 +12,31 @@ OPENOCD_OPTIONS=-f openocd-$(OPENOCD_INTERFACE).cfg
 
 BOOTSEL_FOLDER?=/media/$(USER)/RPI-RP2
 
-KERNEL=$(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/release/$(PLATFORM)-app.elf
+# From layout.ld: flash begins at `rom`, applications at `prog`.
+FLASH_ADDRESS=0x10000000
+APP_ADDRESS=0x10040000
+
+IMAGE=$(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-image.bin
 
 
 # Default target for installing the kernel.
 .PHONY: install
 install: flash
 
+.PHONY: init
+init:
+	tockloader local-board set $(PLATFORM) --binary-path $(IMAGE) --arch cortex-m0 --app-address $(APP_ADDRESS) --flash-address $(FLASH_ADDRESS)
+
+# Write the kernel to the flash file with tockloader
+.PHONY: write-kernel
+write-kernel: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+	tockloader flash --local-board --address $(FLASH_ADDRESS) $<
+
 .PHONY: flash-openocd
-flash-openocd: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	$(OPENOCD) $(OPENOCD_OPTIONS) -c "program $<; verify_image $<;  reset; shutdown;"
+flash-openocd: write-kernel
+	$(OPENOCD) $(OPENOCD_OPTIONS) -c "program $(IMAGE) $(FLASH_ADDRESS) verify reset; shutdown;"
 
 .PHONY: flash
-flash: $(KERNEL)
-	elf2uf2-rs $< $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2
+flash: write-kernel
+	picotool uf2 convert $(IMAGE) -t bin -o $(FLASH_ADDRESS) --family rp2040 $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2
 	@if [ -d $(BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2 "$(BOOTSEL_FOLDER)"; else echo; echo Please edit the BOOTSEL_FOLDER variable to point to you Raspberry Pi Pico Flash Drive Folder; echo You can download and flash $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2; fi
-
-.PHONY: program
-program: $(KERNEL)
-ifeq ($(APP),)
-	$(error Please define the APP variable with the TBF file to flash an application)
-endif
-	arm-none-eabi-objcopy --set-section-flags .apps=LOAD,ALLOC $(KERNEL) $(KERNEL_WITH_APP)
-	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL_WITH_APP)
-	elf2uf2-rs $(KERNEL_WITH_APP) $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2
-	@if [ -d $(BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2 "$(BOOTSEL_FOLDER)"; else echo; echo Please edit the BOOTSEL_FOLDER variable to point to you Raspberry Pi Pico Flash Drive Folder; echo You can download and flash $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2; fi

--- a/boards/pico_explorer_base/README.md
+++ b/boards/pico_explorer_base/README.md
@@ -11,16 +11,19 @@ board developed by the Raspberry Pi Foundation based on the RP2040 chip.
 
 First, follow the [Tock Getting Started guide](../../doc/Getting_Started.md)
 
-## Installing elf2uf2-rs
+## Installing picotool
 
-The Nano RP2040 uses UF2 files for flashing. Tock compiles to an ELF file.
-The `elf2uf2-rs` utility is needed to transform the Tock ELF file into an UF2 file.
+The RP2040 uses UF2 files for flashing. `tockloader` builds a flash image that
+holds the kernel and any applications, and the `picotool` utility transforms that
+image into a UF2 file.
 
-To install `elf2uf2`, run the commands:
+To install `picotool`, check the instructions from their GitHub [page](https://github.com/raspberrypi/picotool).
 
-```bash
-$ cargo install elf2uf2-rs
-```
+## Installing tockloader
+
+`tockloader` writes the kernel and the applications into the flash image this
+board is programmed from. See the
+[Getting Started guide](../../doc/Getting_Started.md) for how to install it.
 
 ## Flashing the kernel
 
@@ -31,7 +34,8 @@ The Raspberry Pi Pico RP2040 Connect can be programmed using its bootloader, whi
 To flash the Pico RP2040, it needs to be put into BOOTSEL mode. This will mount
 a flash drive that allows one to copy a UF2 file. To enter BOOTSEL mode, press the BOOTSEL button and hold it while you connect the other end of the micro USB cable to your computer.
 
-Then `cd` into `boards/raspberry_pi_pico` directory and run:
+Then `cd` into `boards/pico_explorer_base` directory and run `make init` once to
+point `tockloader` at this board's flash image, followed by:
 
 ```bash
 $ make flash
@@ -49,9 +53,11 @@ $ make flash-debug
 
 Enter BOOTSEL mode.
 
-Apps are built out-of-tree. Once an app is built, you can add the path to it in the Makefile (APP variable), then run:
+Apps are built out-of-tree. Once an app is built, install it into the flash image
+and write that image to the board:
 ```bash
-$ APP="<path to app's tbf file>" make program
+$ tockloader install --local-board <path to app's .tab file>
+$ make flash
 ```
 
 ## Debugging
@@ -152,12 +158,15 @@ $ arm-none-eabi-gdb tock/target/thumbv6m-none-eabi/release/raspberry_pi_pico.elf
 ```
 ## Flashing app
 
-Apps are built out-of-tree. Once an app is built, you can add the path to it in the Makefile (APP variable), then run:
+Apps are built out-of-tree. Once an app is built, install it into the flash image
+and write that image to the board over SWD:
 ```bash
-$ make program
+$ tockloader install --local-board <path to app's .tab file>
+$ make flash-openocd
 ```
 
-This will generate a new ELF file that can be deployed on the Raspberry Pi Pico via gdb and OpenOCD as described in the [section above](#flash-the-tock-kernel).
+The gdb route in the section above loads the kernel ELF, and carries no
+application.
 
 ## Book
 

--- a/boards/raspberry_pi_pico/Makefile
+++ b/boards/raspberry_pi_pico/Makefile
@@ -16,39 +16,36 @@ OPENOCD_OPTIONS=-f $(curr)openocd-$(OPENOCD_INTERFACE).cfg
 
 BOOTSEL_FOLDER?=/media/$(USER)/RPI-RP2
 
-KERNEL=$(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/release/$(PLATFORM)-app.elf
+# From layout.ld: flash begins at `rom`, applications at `prog`. Boards that
+# include this Makefile set APP_ADDRESS themselves if their `prog` differs.
+FLASH_ADDRESS?=0x10000000
+APP_ADDRESS?=0x10040000
+
+IMAGE=$(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-image.bin
 
 # Default target for installing the kernel.
 .PHONY: install
 install: flash
 
+.PHONY: init
+init:
+	tockloader local-board set $(PLATFORM) --binary-path $(IMAGE) --arch cortex-m0 --app-address $(APP_ADDRESS) --flash-address $(FLASH_ADDRESS)
+
+# Write the kernel to the flash file with tockloader
+.PHONY: write-kernel
+write-kernel: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+	tockloader flash --local-board --address $(FLASH_ADDRESS) $<
+
 .PHONY: flash-openocd
-flash-openocd: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	$(OPENOCD) $(OPENOCD_OPTIONS) -c "program $<; verify_image $<;  reset; shutdown;"
+flash-openocd: write-kernel
+	$(OPENOCD) $(OPENOCD_OPTIONS) -c "program $(IMAGE) $(FLASH_ADDRESS) verify reset; shutdown;"
 
 .PHONY: flash-probe
-flash-probe: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	probe-rs run $< --chip rp2040
+flash-probe: write-kernel
+	probe-rs download $(IMAGE) --chip rp2040 --binary-format bin --base-address $(FLASH_ADDRESS)
+	probe-rs reset --chip rp2040
 
 .PHONY: flash
-flash: $(KERNEL)
-	elf2uf2-rs $< $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2
+flash: write-kernel
+	picotool uf2 convert $(IMAGE) -t bin -o $(FLASH_ADDRESS) --family rp2040 $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2
 	@if [ -d $(BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2 "$(BOOTSEL_FOLDER)"; else echo; echo Please edit the BOOTSEL_FOLDER variable to point to you Raspberry Pi Pico Flash Drive Folder; echo You can download and flash $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2; fi
-
-$(KERNEL_WITH_APP): $(KERNEL)
-ifeq ($(APP),)
-	$(error Please define the APP variable with the TBF file to flash an application)
-endif
-	arm-none-eabi-objcopy --set-section-flags .apps=LOAD,ALLOC $(KERNEL) $@
-	arm-none-eabi-objcopy --update-section .apps=$(APP) $@
-
-.PHONY: program
-program: $(KERNEL_WITH_APP)
-	elf2uf2-rs $(KERNEL_WITH_APP) $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2
-	@if [ -d $(BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2 "$(BOOTSEL_FOLDER)"; else echo; echo Please edit the BOOTSEL_FOLDER variable to point to you Raspberry Pi Pico Flash Drive Folder; echo You can download and flash $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2; fi
-
-.PHONY: program-probe
-program-probe: $(KERNEL_WITH_APP)
-	probe-rs run $< --chip rp2040
-

--- a/boards/raspberry_pi_pico/README.md
+++ b/boards/raspberry_pi_pico/README.md
@@ -10,18 +10,19 @@ board developed by the Raspberry Pi Foundation and is based on the RP2040 chip.
 
 First, follow the [Tock Getting Started guide](../../doc/Getting_Started.md)
 
-## Installing elf2uf2-rs
+## Installing picotool
 
-The Nano RP2040 uses UF2 files for flashing. Tock compiles to an ELF file.
-The `elf2uf2-rs` utility is needed to transform the Tock ELF file into an UF2 file.
+The RP2040 uses UF2 files for flashing. `tockloader` builds a flash image that
+holds the kernel and any applications, and the `picotool` utility transforms that
+image into a UF2 file.
 
-To install `elf2uf2`, run the commands:
+To install `picotool`, check the instructions from their GitHub [page](https://github.com/raspberrypi/picotool).
 
-```bash
-$ cargo install elf2uf2-rs
-```
+## Installing tockloader
 
-> Note: Sometimes cargo will not be able to find libudev bindings. Installing the apt package `librust-libudev-dev` might solve this issue.
+`tockloader` writes the kernel and the applications into the flash image this
+board is programmed from. See the
+[Getting Started guide](../../doc/Getting_Started.md) for how to install it.
 
 ## Flashing the kernel
 
@@ -35,7 +36,8 @@ a flash drive that allows one to copy a UF2 file. To enter BOOTSEL mode, press t
 > Note: One problem you can run into is the Pico unmounting as soon as you let go of the BOOTSEL button. 
 > In this case hold the BOOTSEL button for the entire duration of the flashing process.
 
-Then `cd` into `boards/raspberry_pi_pico` directory and run:
+Then `cd` into `boards/raspberry_pi_pico` directory and run `make init` once to
+point `tockloader` at this board's flash image, followed by:
 
 ```bash
 $ make flash
@@ -53,9 +55,11 @@ $ make flash-debug
 
 Enter BOOTSEL mode.
 
-Apps are built out-of-tree. Once an app is built, you can add the path to it in the Makefile (APP variable), then run:
+Apps are built out-of-tree. Once an app is built, install it into the flash image
+and write that image to the board:
 ```bash
-$ APP="<path to app's tbf file>" make program
+$ tockloader install --local-board <path to app's .tab file>
+$ make flash
 ```
 
 ## Debugging
@@ -156,12 +160,15 @@ $ arm-none-eabi-gdb tock/target/thumbv6m-none-eabi/release/raspberry_pi_pico.elf
 ```
 ## Flashing app
 
-Apps are built out-of-tree. Once an app is built, you can add the path to it in the Makefile (APP variable), then run:
+Apps are built out-of-tree. Once an app is built, install it into the flash image
+and write that image to the board over SWD:
 ```bash
-$ make program
+$ tockloader install --local-board <path to app's .tab file>
+$ make flash-openocd
 ```
 
-This will generate a new ELF file that can be deployed on the Raspberry Pi Pico via gdb and OpenOCD as described in the [section above](#flash-the-tock-kernel).
+`make flash-probe` sends the same image with probe-rs instead. The gdb route in
+the section above loads the kernel ELF, and carries no application.
 
 ## Book
 

--- a/boards/raspberry_pi_pico_2/Makefile
+++ b/boards/raspberry_pi_pico_2/Makefile
@@ -12,38 +12,31 @@ OPENOCD_OPTIONS=-f openocd-$(OPENOCD_INTERFACE).cfg
 
 BOOTSEL_FOLDER?=/run/media/$(USER)/RP2350
 
-KERNEL=$(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/release/$(PLATFORM)-app.elf
+# From layout.ld: flash begins at `bootloader`, applications at `prog`.
+FLASH_ADDRESS=0x10000000
+APP_ADDRESS=0x10040000
+
+IMAGE=$(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-image.bin
 
 
 # Default target for installing the kernel.
 .PHONY: install
 install: flash
 
+.PHONY: init
+init:
+	tockloader local-board set $(PLATFORM) --binary-path $(IMAGE) --arch cortex-m33 --app-address $(APP_ADDRESS) --flash-address $(FLASH_ADDRESS)
+
+# Write the kernel to the flash file with tockloader
+.PHONY: write-kernel
+write-kernel: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+	tockloader flash --local-board --address $(FLASH_ADDRESS) $<
+
 .PHONY: flash-openocd
-flash-openocd: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	$(OPENOCD) $(OPENOCD_OPTIONS) -c "adapter speed 5000" -c "program $<; verify_image $<;  reset; shutdown;"
+flash-openocd: write-kernel
+	$(OPENOCD) $(OPENOCD_OPTIONS) -c "adapter speed 5000" -c "program $(IMAGE) $(FLASH_ADDRESS) verify reset; shutdown;"
 
 .PHONY: flash
-flash: $(KERNEL)
-	picotool uf2 convert $< $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2
+flash: write-kernel
+	picotool uf2 convert $(IMAGE) -t bin -o $(FLASH_ADDRESS) $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2
 	@if [ -d $(BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2 "$(BOOTSEL_FOLDER)"; else echo; echo Please edit the BOOTSEL_FOLDER variable to point to you Raspberry Pi Pico 2 Flash Drive Folder; echo You can download and flash $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).uf2; fi
-
-.PHONY: program
-program: $(KERNEL)
-ifeq ($(APP),)
-	$(error Please define the APP variable with the TBF file to flash an application)
-endif
-	arm-none-eabi-objcopy --set-section-flags .apps=LOAD,ALLOC $(KERNEL) $(KERNEL_WITH_APP)
-	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL_WITH_APP)
-	picotool uf2 convert $(KERNEL_WITH_APP) $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2
-	@if [ -d $(BOOTSEL_FOLDER) ]; then cp $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2 "$(BOOTSEL_FOLDER)"; else echo; echo Please edit the BOOTSEL_FOLDER variable to point to you Raspberry Pi Pico 2 Flash Drive Folder; echo You can download and flash $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.uf2; fi
-
-.PHONY: program-openocd
-program-openocd: $(KERNEL)
-ifeq ($(APP),)
-	$(error Please define the APP variable with the TBF file to flash an application)
-endif
-	arm-none-eabi-objcopy --set-section-flags .apps=LOAD,ALLOC $(KERNEL) $(KERNEL_WITH_APP)
-	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL_WITH_APP)
-	$(OPENOCD) $(OPENOCD_OPTIONS) -c "adapter speed 5000" -c "program $(KERNEL_WITH_APP); verify_image $(KERNEL_WITH_APP);  reset; shutdown;"

--- a/boards/raspberry_pi_pico_2/README.md
+++ b/boards/raspberry_pi_pico_2/README.md
@@ -12,10 +12,17 @@ First, follow the [Tock Getting Started guide](../../doc/Getting_Started.md)
 
 ## Installing picotool
 
-The RP2350 uses UF2 files for flashing. Tock compiles to an ELF file.
-The `picotool` utility is needed to transform the Tock ELF file into an UF2 file.
+The RP2350 uses UF2 files for flashing. `tockloader` builds a flash image that
+holds the kernel and any applications, and the `picotool` utility transforms that
+image into a UF2 file.
 
 To install `picotool`, check the instructions from their GitHub [page](https://github.com/raspberrypi/picotool).
+
+## Installing tockloader
+
+`tockloader` writes the kernel and the applications into the flash image this
+board is programmed from. See the
+[Getting Started guide](../../doc/Getting_Started.md) for how to install it.
 
 
 ## Flashing the kernel
@@ -27,7 +34,8 @@ The Raspberry Pi Pico 2 RP2350 Connect can be programmed using its bootloader, w
 To flash the Pico RP2350, it needs to be put into BOOTSEL mode. This will mount
 a flash drive that allows one to copy a UF2 file. To enter BOOTSEL mode, press the BOOTSEL button and hold it while you connect the other end of the micro USB cable to your computer.
 
-Then `cd` into `boards/raspberry_pi_pico_2` directory and run:
+Then `cd` into `boards/raspberry_pi_pico_2` directory and run `make init` once to
+point `tockloader` at this board's flash image, followed by:
 
 ```bash
 $ make flash
@@ -45,9 +53,11 @@ $ make flash-debug
 
 Enter BOOTSEL mode.
 
-Apps are built out-of-tree. Once an app is built, you can add the path to it in the Makefile (APP variable), then run:
+Apps are built out-of-tree. Once an app is built, install it into the flash image
+and write that image to the board:
 ```bash
-$ APP="<path to app's tbf file>" make program
+$ tockloader install --local-board <path to app's .tab file>
+$ make flash
 ```
 
 ## Debugging
@@ -148,9 +158,12 @@ $ arm-none-eabi-gdb tock/target/thumbv8m.main-none-eabi/release/raspberry_pi_pic
 ```
 ## Flashing app
 
-Apps are built out-of-tree. Once an app is built, you can add the path to it in the Makefile (APP variable), then run:
+Apps are built out-of-tree. Once an app is built, install it into the flash image
+and write that image to the board over SWD:
 ```bash
-$ make program
+$ tockloader install --local-board <path to app's .tab file>
+$ make flash-openocd
 ```
 
-This will generate a new ELF file that can be deployed on the Raspberry Pi Pico 2 via gdb and OpenOCD as described in the [section above](#flash-the-tock-kernel).
+The gdb route in the section above loads the kernel ELF, and carries no
+application.

--- a/boards/raspberry_pi_pico_w/Makefile
+++ b/boards/raspberry_pi_pico_w/Makefile
@@ -2,4 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright OxidOS Automotive 2025.
 
+# From layout.ld: this board's kernel region is larger, so `prog` starts higher
+# than it does on the Raspberry Pi Pico.
+APP_ADDRESS=0x10090000
+
 include ../raspberry_pi_pico/Makefile


### PR DESCRIPTION
### Pull Request Overview

Fixes two defects in the current flash route:
- #4770: `objcopy` lays the program headers out again; the (NOLOAD) `.stack` segment claims file content for SRAM.
- Ghost app: the splice writes nothing at the slot after the last app, so an old TBF header survives. This route fixes it because `tockloader` writes a terminator at that slot; the loader's existing behavior (stopping at the first invalid header) then prevents the stale app from running.

This route opens no ELF, so #4770 cannot recur. Tockloader builds a flat flash image; picotool/openocd/probe-rs write it directly.

**User-visible:** Apps are now installed with `tockloader install --local-board <tab>`, then `make flash`. `elf2uf2-rs` leaves the tree; `picotool` is used on all five boards (including `raspberry_pi_pico_w`, whose kernel region is 576 KiB and app prog is at `0x10090000`, not `0x10040000`). No Rust changes; 2 commits, Makefiles and READMEs only (four READMEs changed; `raspberry_pi_pico_w/README.md` points readers to the Pico's guide and needed no edit).

**Capability gain:** `--update-section .apps=<file>` takes one file, so the splice route cannot place two apps at all. This route does: `tockloader install --local-board` is called once with both `.tab` files (the signature is `[tab ...]`), then `make flash`. The image is 274,433 bytes. Tockloader's layout reports `leak_claim` (4,096 bytes) at slot `0x10040000` and `leak_observe` (8,192 bytes) at slot `0x10041000`; the kernel lists both. Verified on silicon over SWD and BOOTSEL.

**Conflicts:** #5156 (all four Makefiles) - merge-tested against current head; #5158 is now merged (this branch is rebased onto it; the two README lines this PR replaces are resolved); #5141 merges clean. 

### Testing Strategy

**On the board (Pico 2 W, Debug Probe):**
- `make flash-openocd` runs; process console lists the app live.
- Kernel-only: application region erased first over SWD (`flash erase_address 0x10040000 0x40000`, so the test measures the boot and not a stale app), then `make init` + `make flash-openocd` with nothing installed. Image exactly 262,144 bytes, `** Verified OK **`. Board boots; `list` returns its header row with nothing under it.
- BOOTSEL: UF2 (549,376 bytes, 1,073 blocks, family `0xe48bff59`) copied onto the RP2350 bootloader volume; board left BOOTSEL on its own and both apps came up.
- probe-rs: `probe-rs download --chip RP235x --binary-format bin --base-address 0x10000000` finished in 17.74s, then `probe-rs reset`; board boots.
- Two apps: kernel lists both; the invocation is described above in Capability gain.
- 8,192-byte app then 1,024-byte app, no erase: only the second loads.
- The one-byte A/B test: without the terminator, the kernel runs an app that is not in the image.
- The terminator byte (`flash fillb 0x10041000 0x00 1`) alone invalidates the version field (02→00) and kills the ghost app on reset; the erase that also occurs in the normal flash path is not required to fix the issue.

**On the machine:**
- Pico 2 (RP2350), single-app build: UF2 1,029 blocks, family `0xe48bff59`, payload byte-identical to the image that booted.
- Raspberry Pi Pico (RP2040), `elf2uf2-rs` vs `picotool` on the same ELF: 400 blocks, same 102,400 addresses, zero disagreements.
- On the RP2040 image, `picotool` writes 159,744 bytes more, all zero, below the app address.
- Kernel-only UF2: Pico 204,800 → 524,288; Pico 2 147,456 → 524,288. Every added block is zero; every shared block is byte-identical.
- `make init` and `make flash` run end-to-end on `raspberry_pi_pico` with tockloader 1.18.1 and picotool. With tockloader absent, `make flash` exits 2 at `write-kernel` with Error 127.

**Limits:**
- No RP2040 booted. `probe-rs` was verified with `--chip RP235x`; `--chip rp2040` was not exercised.
- The probe-rs invocation is manual (there is no `flash-probe` target on the Pico 2) and matches the Makefile's flag form.


### TODO or Help Wanted

- Someone with an RP2040 board to confirm it boots.
- Follow-up: a per-board `flash_file` entry in `tockloader` would remove the machine-wide `local-board` setting entirely.

### Checklist

- [x] Ran `make prepush`.

### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required. (READMEs updated for the four boards needing changes; `/docs` and the Book are unaffected.)

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md#ai-policy) and have properly disclosed my AI use below. This PR comment, and any subsequent PR interactions must not be generated using AI, except for under a `<details>` drawer.

Code written with Claude Opus 5/Claude Code.

All measurements were produced by running commands or observing the board.

<details>
<summary>AI-assisted prose</summary>

https://via-balaena.github.io/tock-rp2350/findings/5160/

</details>