### PR TITLE
CI: move the hifive1 qemu test to new runner

### DIFF
--- a/.github/workflows/qemu_virt.yml
+++ b/.github/workflows/qemu_virt.yml
@@ -78,3 +78,7 @@ jobs:
         # ../../../libtock-c is relative to tools/ci/qemu-virt-ci-runner/,
         # which is the working directory when cargo run executes.
         run: make ci-job-qemu-virt QEMU_VIRT_ARGS="--board qemu_rv64_virt --libtock-c ../../../libtock-c"
+
+      - name: Run hifive1 QEMU CI tests
+        shell: bash
+        run: make ci-job-qemu-virt QEMU_VIRT_ARGS="--board hifive1 --libtock-c ../../../libtock-c"

--- a/boards/hifive1/Makefile
+++ b/boards/hifive1/Makefile
@@ -4,8 +4,6 @@
 
 # Makefile for building the tock kernel for the HiFive1 platform
 
-QEMU ?= qemu-system-riscv32
-
 include ../Makefile.common
 
 # Default target for installing the kernel.
@@ -16,13 +14,6 @@ flash: $(TARGET_PATH)/release/$(PLATFORM).elf
 	openocd \
 		-c "source [find board/sifive-hifive1-revb.cfg]; program $<; resume 0x20000000; exit"
 
-qemu: $(TARGET_PATH)/release/$(PLATFORM).elf
-	$(QEMU) -M sifive_e,revb=true -kernel $^  -nographic
-
-qemu-app: $(TARGET_PATH)/release/$(PLATFORM).elf
-	$(QEMU) -M sifive_e,revb=true -kernel $^ -device loader,file=$(APP),addr=0x20040000 -nographic
-
-
 TOCKLOADER=tockloader
 TOCKLOADER_JTAG_FLAGS = --jlink --board hifive1b
 KERNEL_ADDRESS = 0x20010000
@@ -31,3 +22,26 @@ KERNEL_ADDRESS = 0x20010000
 .PHONY: flash
 flash-jlink: $(TARGET_PATH)/release/$(PLATFORM).bin
 	$(TOCKLOADER) $(TOCKLOADER_GENERAL_FLAGS) flash --address $(KERNEL_ADDRESS) $(TOCKLOADER_JTAG_FLAGS) $<
+
+
+# QEMU version
+
+QEMU_CMD ?= qemu-system-riscv32
+
+QEMU_CMDLINE_EXTRA ?= \
+
+QEMU_CMDLINE := \
+    $(QEMU_CMD) \
+    -M sifive_e,revb=true \
+    -nographic \
+    $(QEMU_CMDLINE_EXTRA)
+
+init:
+	tockloader local-board set hifive1 \
+		--app-address 0x20040000 \
+		--flash-address 0x20040000 \
+		--binary-path hifive1-qemu.bin \
+		--arch rv32imac \
+
+run: $(TARGET_PATH)/release/$(PLATFORM).elf
+	$(QEMU_CMDLINE) -kernel $^ -device loader,file=hifive1-qemu.bin,addr=0x20040000

--- a/boards/hifive1/README.md
+++ b/boards/hifive1/README.md
@@ -28,21 +28,24 @@ QEMU can be started with Tock using the following arguments (in Tock's top-level
 $ qemu-system-riscv32 -M sifive_e,revb=true -kernel $TOCK_ROOT/target/riscv32imac-unknown-none-elf/release/hifive1.elf  -nographic
 ```
 
-Or with the `qemu` make target:
+Or with the `run` make target:
 
 ```bash
-$ make qemu
+$ make run
 ```
 
 QEMU can be started with Tock and a userspace app using the following arguments (in Tock's top-level directory):
 
-```
-qemu-system-riscv32 -M sifive_e,revb=true -kernel $TOCK_ROOT/target/riscv32imac-unknown-none-elf/release/hifive1.elf -device loader,file=./examples/hello.tbf,addr=0x20040000 -nographic
-```
-Or with the `qemu-app` make target:
+First, initialize the local board for installing apps:
 
 ```bash
-$ make APP=/path/to/app.tbf qemu-app
+$ make init
+```
+
+Then run the kernel and app in QEMU:
+
+```bash
+$ make run
 ```
 
 The TBF must be compiled for the HiFive board which is, at the time of writing,
@@ -51,10 +54,10 @@ the Hello World exmple app from the libtock-rs repository by running:
 
 ```
 $ cd [LIBTOCK-RS-DIR]
-$ make EXAMPLE=hello_world flash-hifive1
-$ tar xf target/riscv32imac-unknown-none-elf/tab/hifive1/hello_world.tab
+$ make hifive1 EXAMPLE=console
+$ tockloader install ./target/tbf/hifive1/console.tab
 $ cd [TOCK_ROOT]/boards/hifive
-$ make APP=[LIBTOCK-RS-DIR]/rv32imac.tbf qemu-app
+$ make run
 ```
 
 HiFive1 Revision A

--- a/tools/ci/qemu-runner/src/main.rs
+++ b/tools/ci/qemu-runner/src/main.rs
@@ -16,29 +16,6 @@ fn kill_qemu(p: &mut PtySession) -> Result<(), Error> {
     Ok(())
 }
 
-fn hifive1() -> Result<(), Error> {
-    // First, build the board if needed
-    // n.b. rexpect's `exp_eof` does not actually block main thread, so use
-    // the standard Rust process library mechanism instead.
-    let mut build = Command::new("make")
-        .arg("-C")
-        .arg("../../../boards/hifive1")
-        .spawn()
-        .expect("failed to spawn build");
-    assert!(build.wait().unwrap().success());
-
-    let mut p = spawn("make qemu -C ../../../boards/hifive1", Some(3_000))?;
-
-    p.exp_string("HiFive1 initialization complete.")?;
-    p.exp_string("Entering main loop.")?;
-
-    // Test completed, kill QEMU
-    kill_qemu(&mut p)?;
-
-    p.exp_string("QEMU: Terminated")?;
-    Ok(())
-}
-
 fn earlgrey_cw310() -> Result<(), Error> {
     // First, build the board if needed
     // n.b. rexpect's `exp_eof` does not actually block main thread, so use
@@ -73,10 +50,6 @@ fn earlgrey_cw310() -> Result<(), Error> {
 
 fn main() {
     println!("Tock qemu-runner starting...");
-    println!("");
-    println!("Running hifive1 tests...");
-    hifive1().unwrap_or_else(|e| panic!("hifive1 job failed with {}", e));
-    println!("hifive1 SUCCESS.");
     println!("");
     println!("Running earlgrey_cw310 tests...");
     earlgrey_cw310().unwrap_or_else(|e| panic!("earlgrey_cw310 job failed with {}", e));

--- a/tools/ci/qemu-virt-ci-runner/src/boards/hifive1.rs
+++ b/tools/ci/qemu-virt-ci-runner/src/boards/hifive1.rs
@@ -1,0 +1,40 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+use std::time::Duration;
+
+use crate::{App, TestCase, TestStep};
+
+pub static BOARD: super::Board = super::Board {
+    name: "hifive1",
+    board_dir: "../../../boards/hifive1",
+    tock_targets: "\
+        rv32imac|rv32imac.0x20040080.0x80002800|0x20040080|0x80002800",
+    tests: TESTS,
+};
+
+static TESTS: &[TestCase] = &[
+    TestCase {
+        name: "boot",
+        description: "Boot the board in qemu and verify the kernel starts.",
+        apps: &[],
+        steps: &[TestStep::WaitSerialInOrder {
+            needles: &["HiFive1 initialization complete.", "Entering main loop."],
+            timeout: Duration::from_secs(10),
+        }],
+        screenshot_delay: Duration::from_millis(0),
+        expected_screen_hash: None,
+    },
+    TestCase {
+        name: "c_hello",
+        description: "Run the c_hello app and verify it prints \"Hello World!\" over serial.",
+        apps: &[App::LibtockC("c_hello")],
+        steps: &[TestStep::WaitSerialInOrder {
+            needles: &["Hello World!"],
+            timeout: Duration::from_secs(10),
+        }],
+        screenshot_delay: Duration::from_millis(0),
+        expected_screen_hash: None,
+    },
+];

--- a/tools/ci/qemu-virt-ci-runner/src/boards/mod.rs
+++ b/tools/ci/qemu-virt-ci-runner/src/boards/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2026.
 
+pub mod hifive1;
 pub mod qemu_rv64_virt;
 
 pub struct Board {
@@ -18,4 +19,4 @@ pub struct Board {
     pub tests: &'static [crate::TestCase],
 }
 
-pub static BOARDS: &[&Board] = &[&qemu_rv64_virt::BOARD];
+pub static BOARDS: &[&Board] = &[&qemu_rv64_virt::BOARD, &hifive1::BOARD];


### PR DESCRIPTION
### Pull Request Overview

This standardizes the makefile for the hifive1 board for running the kernel in qemu. Then, it moves the CI runner to the new qemu-virt CI tool which makes it easier to run multiple tests, including one with a userspace application.

I updated the hifive1 readme to match.


### Testing Strategy

Running the CI test locally, and also trying it on this PR.


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [x] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [ ] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md#ai-policy) and have properly disclosed my AI use below. This PR comment, and any subsequent PR interactions must not be generated using AI, except for under a `<details>` drawer.

<!-- Include details of AI use here, if you used any -->
