### PR TITLE
boards: rp2350: clear stale NVIC pending after the peripheral reset

### DIFF
--- a/boards/raspberry_pi_pico_2/src/main.rs
+++ b/boards/raspberry_pi_pico_2/src/main.rs
@@ -281,6 +281,13 @@ pub unsafe fn main() {
 
     resets.unreset_all_except(&[], true);
 
+    // Clear again now the peripherals have been reset. `Chip::init()` clears
+    // pending interrupts too, but a source still asserting then re-latches at
+    // once, and resetting it afterwards does not take the latched bit back.
+    // The bootrom leaves USB enabled with its interrupt enables set, so a
+    // reset out of a live bootrom session panicked on an unclaimed IRQ 14.
+    cortexm33::nvic::clear_all_pending();
+
     // Set the UART used for panic
     (*addr_of_mut!(io::WRITER)).set_uart(&peripherals.uart0);
 


### PR DESCRIPTION
### Pull Request Overview

1. A Pico 2 can panic at boot with `unhandled interrupt 14`.
2. IRQ 14 is `USBCTRL_IRQ`; the `rp2350` chip crate has no USB driver, so nothing claims it.
3. `Chip::init()` already calls `clear_all_pending()`, but it runs before the peripheral reset, so a still-asserting source re-latches; the reset then silences it without clearing the pending bit. This PR adds a second `clear_all_pending()` after the peripheral reset to clear the re-latched bit.

### Testing Strategy

- Reproduction: Erase the first flash sector so the bootrom falls back to its USB device, then reset from the debugger (OpenOCD) while that session is live.
- Result: Panics every time before this change, never after - 6/0/6 A/B/A.
- Board: Pico 2 W running the upstream `raspberry_pi_pico_2` crate.

### TODO or Help Wanted

None, this is ready for review.

### Checklist

- [x] Ran `make prepush` (green).
- [x] Ran `make clippy` (clean, though not required by template).

### PR Contents
#### Documentation
- [x] No documentation updates are required. This is a board-file fix with no doc impact.

#### AI Use
- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md#ai-policy) and have properly disclosed my AI use below.

Code written with Claude Opus 5/Claude Code.


<details>
<summary>AI-assisted prose</summary>

https://via-balaena.github.io/tock-rp2350/findings/5165/

</details>