### PR TITLE
esp32-c3: fix addresses to avoid aliasing

### DIFF
--- a/boards/esp32-c3-devkitM-1/layout.ld
+++ b/boards/esp32-c3-devkitM-1/layout.ld
@@ -2,11 +2,20 @@
 /* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
 /* Copyright Tock Contributors 2023.                                  */
 
+/* The ESP32-C3 has some odd aliasing features in its memory, where
+ * what we think is in flash is actually executing out of the same
+ * address space as physical RAM.
+ *
+ * To convert from a "flash" address to the address it actually uses,
+ * subtract 0x700000. The addresses in comments on the right indicate
+ * the actual physical addresses used at runtime. These must not
+ * overlap.
+ */
 MEMORY
 {
-  rom (rx)  : ORIGIN = 0x40380000, LENGTH = 0x30000
-  ram (rwx) : ORIGIN = 0x3FCA0000, LENGTH = 0x30000
-  prog (rx) : ORIGIN = 0x403B0000, LENGTH = 0x30000
+  rom  (rx)  : ORIGIN = 0x40380000, LENGTH = 0x20000 /* 0x3FC80000 - 0x3FCA0000 */
+  ram  (rwx) : ORIGIN = 0x3FCA0000, LENGTH = 0x18000 /* 0x3FCA0000 - 0x3FCB8000 */
+  prog (rx)  : ORIGIN = 0x403B8000, LENGTH = 0x28000 /* 0x3FCB8000 - 0x3FCE0000 */
 }
 
 INCLUDE tock_kernel_layout.ld


### PR DESCRIPTION


### Pull Request Overview

The ESP32-C3 chip doesn't have XIP flash, and instead runs everything out of RAM, but still uses separate addresses for flash and ram. We were configuring the chip to use the same addresses for RAM as the application flash code.

This lead to an issue where the kernel was configuring the process control block for a process and was actually overwriting the code for another app.

Here is claude's explanation:

<details>
<html><head></head><body><h2>Root cause: <code>ram</code> and <code>prog</code> in <code>layout.ld</code> are the same physical SRAM</h2>
<p>On the ESP32‑C3 there is no XIP for Tock apps — the Makefile builds one <code>kernel + apps</code> blob, <code>esptool elf2image</code>'s it, and the ROM loader drops it into <strong>Internal SRAM1</strong>. SRAM1 is visible on two buses at once:</p>
<pre><code>instruction-bus view : 0x4038_0000 .. 0x403E_0000
data-bus view        : 0x3FC8_0000 .. 0x3FCE_0000
alias delta          : 0x4038_0000 - 0x3FC8_0000 = 0x70_0000
</code></pre>
<p><code>instr_addr == data_addr + 0x70_0000</code> — they are the <em>same bytes</em>.</p>
<p>Your <a href="https://claude.ai/epitaxy/boards/esp32-c3-devkitM-1/layout.ld">layout.ld</a>:</p>

region | given range | physical SRAM1 bytes
-- | -- | --
rom | 0x4038_0000 + 0x30000 | [0x00000, 0x30000)
ram | 0x3FCA_0000 + 0x30000 | [0x20000, 0x50000)
prog | 0x403B_0000 + 0x30000 | [0x30000, 0x60000)


<p><code>ram</code> and <code>prog</code> overlap over <code>[0x30000, 0x50000)</code>. In bus terms: <strong>data <code>0x3FCB_0000</code> is the exact same memory as instruction <code>0x403B_0000</code></strong> — i.e. the app‑RAM pool physically overlaps the app‑code region.</p>
<h2>Why it only breaks with the second app</h2>
<ul>
<li><strong>RNG only:</strong> the app‑RAM allocator hands out low addresses (<code>0x3FCA_2800</code>) and never climbs to <code>0x3FCB_0000</code>, so nothing aliases RNG's code. Works.</li>
<li><strong>RNG + sensors:</strong> the kernel allocates the <em>second</em> process's RAM block at <code>0x3FCB_0000</code> (your dump: sensors RAM base <code>0x3FCB_0000</code>, block <code>0x3FCB_0000‑0x3FCB_1A40</code>). That is bit‑for‑bit the same memory as RNG's code at <code>0x403B_0000‑0x403B_1A40</code>. Loading sensors writes its process struct / grant pointers / upcall table into the top of that block (<code>0x3FCB_15F0+</code>), zeroing RNG's instructions there.</li>
</ul>
<p>Check the numbers against your crash:</p>
<ul>
<li>RNG flash base <code>0x403B_0000</code> ➜ data alias <code>0x3FCB_0000</code> = sensors RAM base. Identical.</li>
<li>Fault PC <code>0x403B_16EC</code> ➜ data alias <code>0x3FCB_16EC</code>, which sits inside sensors' <code>[0x3FCB_0000, 0x3FCB_1A40]</code> control block (right after the <code>0x3FCB_15F0</code> bookkeeping the kernel just wrote).</li>
<li><code>mcause = 2</code> (illegal instruction), <code>mtval = 0</code> → the CPU fetched <code>0x0000</code>. Not a PMP fault (<code>pmpcfg0 = 0x0B000D00</code>, region <code>#00</code> is <code>-r-x</code> over <code>0x403B_0000‑0x403B_424C</code>, so the fetch is <em>permitted</em> — the bytes are just gone).</li>
</ul>
<p>The <code>_malloc_r</code> detail is a red herring: it's simply the first code path RNG reaches that lies in the clobbered <code>0x403B_0000..0x403B_1A40</code> window; the early startup it already ran lives below that. The sensors "Instruction access misaligned @ PC 0" in the dump is just its uninitialised fault fields — it never ran.</p>
<h2>Fix</h2>
<p>Repartition SRAM1 so <code>rom</code> / <code>ram</code> / <code>prog</code> are disjoint <strong>in physical bytes</strong>, remembering the <code>0x70_0000</code> alias. The current split three‑way‑books the RAM; it only ever worked because the kernel is small and there was one small app.</p>
<p>One concrete option (adjust the sizes to your real kernel/app footprints):</p>
<pre><code class="language-ld">MEMORY
{
  /* phys [0x00000, 0x20000) */
  rom  (rx)  : ORIGIN = 0x40380000, LENGTH = 0x20000
  /* phys [0x20000, 0x38000) */
  ram  (rwx) : ORIGIN = 0x3FCA0000, LENGTH = 0x18000
  /* phys [0x38000, 0x60000) */
  prog (rx)  : ORIGIN = 0x403B8000, LENGTH = 0x28000
}
</code></pre>
<p>Then update the app address in <a href="https://claude.ai/epitaxy/boards/esp32-c3-devkitM-1/Makefile">Makefile</a> to match:</p>
<pre><code class="language-bash">tockloader local-board set esp32_c3_devkitm1 --binary-path esp32_c3_devkitm1.bin --arch rv32imc --app-address 0x403B8000 --flash-address 0x40380000
</code></pre>
<p>and rebuild/reflash the combined image. If you don't want to move <code>--app-address</code>, the minimal change is to shrink <code>ram</code> so it can't reach <code>prog</code>'s physical start (<code>LENGTH = 0x10000</code>, ending exactly at data <code>0x3FCB0000</code>) — but that caps kernel + all app RAM at 64 KB, which is probably too tight once you have two apps.</p></body></html>## Root cause: `ram` and `prog` in `layout.ld` are the same physical SRAM

On the ESP32‑C3 there is no XIP for Tock apps — the Makefile builds one `kernel + apps` blob, `esptool elf2image`'s it, and the ROM loader drops it into **Internal SRAM1**. SRAM1 is visible on two buses at once:

```
instruction-bus view : 0x4038_0000 .. 0x403E_0000
data-bus view        : 0x3FC8_0000 .. 0x3FCE_0000
alias delta          : 0x4038_0000 - 0x3FC8_0000 = 0x70_0000
```

`instr_addr == data_addr + 0x70_0000` — they are the *same bytes*.

Your [[layout.ld](https://claude.ai/epitaxy/boards/esp32-c3-devkitM-1/layout.ld)](boards/esp32-c3-devkitM-1/layout.ld):

| region | given range | physical SRAM1 bytes |
|---|---|---|
| `rom`  | `0x4038_0000 + 0x30000` | `[0x00000, 0x30000)` |
| `ram`  | `0x3FCA_0000 + 0x30000` | `[0x20000, 0x50000)` |
| `prog` | `0x403B_0000 + 0x30000` | `[0x30000, 0x60000)` |

`ram` and `prog` overlap over `[0x30000, 0x50000)`. In bus terms: **data `0x3FCB_0000` is the exact same memory as instruction `0x403B_0000`** — i.e. the app‑RAM pool physically overlaps the app‑code region.

## Why it only breaks with the second app

- **RNG only:** the app‑RAM allocator hands out low addresses (`0x3FCA_2800`) and never climbs to `0x3FCB_0000`, so nothing aliases RNG's code. Works.
- **RNG + sensors:** the kernel allocates the *second* process's RAM block at `0x3FCB_0000` (your dump: sensors RAM base `0x3FCB_0000`, block `0x3FCB_0000‑0x3FCB_1A40`). That is bit‑for‑bit the same memory as RNG's code at `0x403B_0000‑0x403B_1A40`. Loading sensors writes its process struct / grant pointers / upcall table into the top of that block (`0x3FCB_15F0+`), zeroing RNG's instructions there.

Check the numbers against your crash:
- RNG flash base `0x403B_0000` ➜ data alias `0x3FCB_0000` = sensors RAM base. Identical.
- Fault PC `0x403B_16EC` ➜ data alias `0x3FCB_16EC`, which sits inside sensors' `[0x3FCB_0000, 0x3FCB_1A40]` control block (right after the `0x3FCB_15F0` bookkeeping the kernel just wrote).
- `mcause = 2` (illegal instruction), `mtval = 0` → the CPU fetched `0x0000`. Not a PMP fault (`pmpcfg0 = 0x0B000D00`, region `#00` is `-r-x` over `0x403B_0000‑0x403B_424C`, so the fetch is *permitted* — the bytes are just gone).

The `_malloc_r` detail is a red herring: it's simply the first code path RNG reaches that lies in the clobbered `0x403B_0000..0x403B_1A40` window; the early startup it already ran lives below that. The sensors "Instruction access misaligned @ PC 0" in the dump is just its uninitialised fault fields — it never ran.

## Fix

Repartition SRAM1 so `rom` / `ram` / `prog` are disjoint **in physical bytes**, remembering the `0x70_0000` alias. The current split three‑way‑books the RAM; it only ever worked because the kernel is small and there was one small app.

One concrete option (adjust the sizes to your real kernel/app footprints):

```ld
MEMORY
{
  /* phys [0x00000, 0x20000) */
  rom  (rx)  : ORIGIN = 0x40380000, LENGTH = 0x20000
  /* phys [0x20000, 0x38000) */
  ram  (rwx) : ORIGIN = 0x3FCA0000, LENGTH = 0x18000
  /* phys [0x38000, 0x60000) */
  prog (rx)  : ORIGIN = 0x403B8000, LENGTH = 0x28000
}
```

Then update the app address in [[Makefile](https://claude.ai/epitaxy/boards/esp32-c3-devkitM-1/Makefile)](boards/esp32-c3-devkitM-1/Makefile) to match:

```bash
tockloader local-board set esp32_c3_devkitm1 --binary-path esp32_c3_devkitm1.bin --arch rv32imc --app-address 0x403B8000 --flash-address 0x40380000
```

and rebuild/reflash the combined image. If you don't want to move `--app-address`, the minimal change is to shrink `ram` so it can't reach `prog`'s physical start (`LENGTH = 0x10000`, ending exactly at data `0x3FCB0000`) — but that caps kernel + all app RAM at 64 KB, which is probably too tight once you have two apps.
</details>

This fixes the addresses to not use overlapping regions in the actual SRAM.


### Testing Strategy

Running three apps at the same time successfully.


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md#ai-policy) and have properly disclosed my AI use below. This PR comment, and any subsequent PR interactions must not be generated using AI, except for under a `<details>` drawer.

I tried hard to debug this. I wasn't making any progress, so I asked claude. It diagnosed this issue and suggested a better memory layout.
