### PR TITLE
 capsules/aes: slice staged buffers to their real lengths

### DIFF
--- a/capsules/extra/src/symmetric_encryption/aes.rs
+++ b/capsules/extra/src/symmetric_encryption/aes.rs
@@ -13,8 +13,7 @@ use core::marker::PhantomData;
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::hil::symmetric_encryption::{
-    AES, AES_BLOCK_SIZE, AESCBC, AESCCM, AESCtr, AESECB, AESGCM, AESKeySize, CCMClient, Client,
-    GCMClient,
+    AES, AESCBC, AESCCM, AESCtr, AESECB, AESGCM, AESKeySize, CCMClient, Client, GCMClient,
 };
 use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
@@ -299,13 +298,12 @@ impl<
         match op {
             AesOperation::AESCtr(_) | AesOperation::AESCBC(_) | AesOperation::AESECB(_) => {
                 if let Some(dest_buf) = self.dest_buffer.take() {
-                    if let Some((e, source, dest)) = AES::crypt(
-                        self.aes,
-                        self.source_buffer.take(),
-                        dest_buf,
-                        0,
-                        AES_BLOCK_SIZE,
-                    ) {
+                    // The HIL requires source.len() == stop_index - start_index,
+                    // and `crypt_done` copies the whole staged buffer back out.
+                    let staged = self.source_buffer.map_or(0, |buf| buf.len());
+                    if let Some((e, source, dest)) =
+                        AES::crypt(self.aes, self.source_buffer.take(), dest_buf, 0, staged)
+                    {
                         // Error, clear the processid and data
                         self.aes.disable();
                         self.processid.clear();

--- a/capsules/extra/src/symmetric_encryption/aes.rs
+++ b/capsules/extra/src/symmetric_encryption/aes.rs
@@ -125,7 +125,7 @@ impl<
                                             AesOperation::AESCtr(_)
                                             | AesOperation::AESCBC(_)
                                             | AesOperation::AESECB(_) => {
-                                                AES::set_key(self.aes, buf)?;
+                                                AES::set_key(self.aes, &buf[..static_buffer_len])?;
                                                 Ok(())
                                             }
                                             AesOperation::AESCCM(_) => {
@@ -167,7 +167,7 @@ impl<
                                             AesOperation::AESCtr(_)
                                             | AesOperation::AESCBC(_)
                                             | AesOperation::AESECB(_) => {
-                                                AES::set_iv(self.aes, buf)?;
+                                                AES::set_iv(self.aes, &buf[..static_buffer_len])?;
                                                 Ok(())
                                             }
                                             AesOperation::AESCCM(_) => {

--- a/capsules/extra/src/symmetric_encryption/aes.rs
+++ b/capsules/extra/src/symmetric_encryption/aes.rs
@@ -174,7 +174,8 @@ impl<
                                                 Ok(())
                                             }
                                             AesOperation::AESGCM(_) => {
-                                                AESGCM::set_iv(self.aes, &buf[0..13])?;
+                                                // GCM's IV is 96-bit; 13 is the CCM nonce length.
+                                                AESGCM::set_iv(self.aes, &buf[0..12])?;
                                                 Ok(())
                                             }
                                         }


### PR DESCRIPTION
### Pull Request Overview

Three independent length updates in `capsules-extra` `AesDriver`
- `set_key` + `set_iv` got the whole 32-byte staging buffer, not the part filled; HIL requires the slice length to match the key size
* `crypt()` was called with `AES_BLOCK_SIZE` regardless of how much data had actually been staged, leaving the second block stale while still reporting success; the HIL contract requires `source.len() == stop_index - start_index`.
- GCM got `&buf[0..13]`: that's `CCM_NONCE_LENGTH`; GCM's IV is 96-bit, and `capsules/aes_gcm::set_iv` itself does `nonce.len().min(12)`

### Testing Strategy

- `make prepush` passes
- each commit type-checks independently (`cargo check -p capsules-extra` at all three)
- hardware, for commits 1 and 2:

    | stage                  | before      | after 1              | after 1+2 |
    |------------------------|-------------|----------------------|-----------|
    | `libtock_aes_setup()`  | `-7 ESIZE`  | pass                 | pass      |
    | CTR ciphertext         | -           | mismatch at byte 16  | cipher text match|

### Checklist

- [x] Ran `make prepush`.

### PR Contents

#### Documentation

- [x] No documentation updates are required.

#### AI Use

- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md#ai-policy) and have properly disclosed my AI use below.
    - Tool used: Claude Opus 5 via Claude Code
    - What portion: the patch was drafted at my direction
    - Review: The AI-generated code was reviewed by myself