### PR TITLE
doc/Maintenance: overhaul release strategy

### DIFF
--- a/doc/Maintenance.md
+++ b/doc/Maintenance.md
@@ -9,10 +9,9 @@ group](wg/core/README.md) maintains the Tock project.
 
 - [Roadmap and Feature Planning](#roadmap-and-feature-planning)
 - [Outreach and Education](#outreach-and-education)
-- [Preparing a Release](#preparing-a-release)
+- [Tock Release Strategy](#tock-release-strategy)
   * [Release Tasks](#release-tasks)
     + [Before the release](#before-the-release)
-    + [Tagging a release candidate](#tagging-a-release-candidate)
     + [Release testing](#release-testing)
     + [Tagging a release](#tagging-a-release)
     + [Starting the next release](#starting-the-next-release)
@@ -39,28 +38,36 @@ academic and professional conferences.
 The project also maintains a [book](https://book.tockos.org) which includes
 self-guided tutorials for various Tock features.
 
-## Preparing a Release
+## Tock Release Strategy
 
 Tock releases are milestone-based, with a rough expectation that a new release
 of Tock would occur every 3-12 months. Before a release, a set of issues are
 tagged with the `release-blocker` tag, and the release will be tested when all
-of the release-blocker issues are closed. One week before the intended release
-date, all new pull requests are put on hold, and everyone uses/tests the
-software using the established testing process. Bug fixes for the release are
-marked as such (in the title) and applied quickly. Once the release is ready,
-the core team makes a branch with the release number and pull request reviews
-restart.
+of the release-blocker issues to be included in the upcoming release are closed
+(release blockers for an upcoming major version do not need to hold up a minor
+release).
 
-Release branches are named `release-[version]`. For example, 'release-1.4.1'.
+Once all such release-blocker issues are closed, a new release branch is
+created. Release branches are named `release/$major.$minor`, for example
+`release/1.4`. This branch is used to perform tests and validation for the
+upcoming release. Once the release branch is deemed read and stable, a release
+is tagged. The branch is not deleted post-release; future fixes will be merged
+into this branch and it will be used to tag new patch releases.
 
-Patches may be made against release branches to fix bugs.
+After testing, a release is tagged. Release tags must be created as *annotated*
+git tags, not lightweight tags as they would be created for GitHub releases.
+These are created using `git tag -a` and are considered release-quality tags by
+Git, e.g. with `git describe`). Tags should contain the same release notes as
+are attached to the corresponding GitHub release. Tags will be named using the
+format `release-$major.$minor.$patch`. The initial release for a given minor
+version carries patch number `0`.
 
 > Note: Previously, Tock operated with a time-based release policy with the goal
-of creating a release every two months. The intent was these periodic stable
-releases would make it easier for users to install and track changes to Tock.
-However, the overhead of keeping to that schedule was too daunting to make the
-releases reliably timed, and it often did not fit well with the inclusion of
-major features which might be in-flight at a release point.
+> of creating a release every two months. The intent was these periodic stable
+> releases would make it easier for users to install and track changes to Tock.
+> However, the overhead of keeping to that schedule was too daunting to make the
+> releases reliably timed, and it often did not fit well with the inclusion of
+> major features which might be in-flight at a release point.
 
 ### Release Tasks
 
@@ -74,30 +81,15 @@ major features which might be in-flight at a release point.
 	- A sign-off checklist for each core working group member.
 - Work through issues and pull requests with the `release-blocker` tag.
 
-#### Tagging a release candidate
-
-- Once most blocking PRs are merged, the core working group will often decide on
-  a "freeze", where any new PRs will not be merged until after a release.
-  Typically, this freeze should only last about a week.
-- Once all issues and pull requests marked `release-blocker` are closed/merged,
-  a release candidate can be tagged by a member of the core working group. The
-  tagging of a release candidate marks the beginning of the release testing
-  phase.
-- Release candidates are named release-<version>-rc-x, where x is the release
-  candidate in question.
-- The version number in `kernel/src/lib.rs` is updated by incrementing
-  `KERNEL_PRERELEASE_VERSION`.
-- The version number in the root `Cargo.toml` file is updated to
-  `<version>-rcx`, where x is the release candidate in question.
-
 #### Release testing
 
 During the release testing period, members of the core working group and
 maintainers of various boards will run release tests, checking off individual
-tests as they are run for each board. Rather than maintain a list of tests in
-the repository, each release involves running all of the tests that were run for
-a board at a previous release, plus any new tests the maintainer of that board
-wants to run. Accordingly, the release testing process is generally as follows:
+tests as they are run for each board. These tests are to be run on the branched
+off release branch. Rather than maintain a list of tests in the repository, each
+release involves running all of the tests that were run for a board at a
+previous release, plus any new tests the maintainer of that board wants to run.
+Accordingly, the release testing process is generally as follows:
 - Select a board to test
 - Copy the release testing checklist for that board from the tracking issue of
   the previous release, but uncheck all the boxes.
@@ -130,11 +122,12 @@ then a release can be tagged.
 
 #### Starting the next release
 
-Immediately after a release, the minor version number is incremented and the
-patch version number is set to 0. This is set in the root `Cargo.toml` file by
-setting the version to `<new version>-dev` and in `kernel/src/lib.rs` by
-updating `KERNEL_MAJOR_VERSION`, `KERNEL_MINOR_VERSION`, and
-`KERNEL_PATCH_VERSION`, and setting `KERNEL_PRERELEASE_VERSION` to 1.
+Immediately after branching off a release, the minor version number on the
+`master` branch is incremented and the patch version number is set to 0. This is
+set in the root `Cargo.toml` file by setting the version to `<new version>-dev`
+and in `kernel/src/lib.rs` by updating `KERNEL_MAJOR_VERSION`,
+`KERNEL_MINOR_VERSION`, and `KERNEL_PATCH_VERSION`, and setting
+`KERNEL_PRERELEASE_VERSION` to 1.
 
 ## Stabilizing a Syscall Driver
 


### PR DESCRIPTION
### Pull Request Overview

We've moved away from release candidate tags for the upcoming release, to a branch based model. Given Tock's increasing surface area and large amounts of contributions this is a more sustainable approach compared to "stopping the world".

Accordingly, we should update or release strategy documentation. In line with this change, I propose we also do the following cleanups.

- We name the release branches and tags using a distinct prefix. Git technically supports branches and tags with the same prefix or the same name as they live under different namespaces, but the tooling doesn't deal with this well.

  Thus, this uses `release/$major.minor` for the working and evolving release branch (with the commonly used `/` namespace separator), vs. `release-$major.$minor.$patch` for actual release tags (using a `-` instead).

- We always name release tags with the patch version included, even if it's `0`. This just makes our naming and any tooling more consistent, and brings us in line with this de-facto standard practice.

  We do use a `0` patch version elsewhere in the repo already, like in the Cargo versions or in the embedded kernel versions.

- We force using annotated release tags. Tagging a release on GitHub creates a lightweight tag, which isn't respected in Git the same way as a "heavy-weight" annotated tag is. Annotated tags are the intended tool for releases and interact better with various Git tooling, so we should use them.

The only thing that these changes loose is that we're no longer necessarily using a single stable target for release testing, but a moving release branch. I deem this acceptable: we'll be careful about what we merge / backport into this branch, and it's unlikely that a fix discovered on one board will silently, and without the contributor knowing, break another board.

### Testing Strategy

N/A


### TODO or Help Wanted

N/A


### Checklist

- [ ] Ran `make prepush`.


### PR Contents

#### Documentation

- [X] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [ ] No documentation updates are required.

#### AI Use

- [X] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md#ai-policy) and have properly disclosed my AI use below. This PR comment, and any subsequent PR interactions must not be generated using AI, except for under a `<details>` drawer.

<!-- Include details of AI use here, if you used any -->
